### PR TITLE
Implement full Qwen3-8B local LLM integration across app, CLI, specs, and tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ A **fast, private, local-first voice app** for macOS with two co-equal modes: sy
 | Database | SQLite | GRDB (single file, dictation history + transcriptions) |
 | STT | Parakeet TDT 0.6B-v3 | Via FluidAudio CoreML/ANE (~2.5% WER, 155x realtime) |
 | Audio | AVAudioEngine + Core Audio | Mic capture for dictation; FFmpeg (bundled) for video file conversion |
-| LLM | MLX-Swift | Qwen3-4B for command mode + AI refinement (GPU via Metal) |
+| LLM | MLX-Swift | Qwen3-8B for command mode, AI refinement, chat (GPU via Metal) |
 | YouTube | yt-dlp | Standalone macOS binary, weekly non-blocking auto-update via `--update` |
 | Licensing | LemonSqueezy | License key activation, validation API |
 
@@ -141,10 +141,11 @@ All ADRs are in `spec/adr/`. These are locked decisions -- don't second-guess th
 - [x] Custom words & snippets management UI (Vocabulary sidebar item)
 - [x] CLI commands: `macparakeet-cli flow process/words/snippets`
 - [ ] Context modes (raw, clean, formal, email, code) -- raw + clean done, AI modes pending
-- [ ] AI text refinement via Qwen3-4B
+- [ ] AI text refinement via Qwen3-8B
 
-### v0.3 Command Mode + Export
+### v0.3 Command Mode + Chat + Export
 - [ ] Command Mode (highlight text + voice command -> LLM edits in-place, like WisprFlow Pro)
+- [ ] Chat with transcript (ask questions about YouTube/file transcriptions via Qwen3-8B)
 - [x] YouTube URL transcription (yt-dlp + Parakeet, single video)
 - [x] Export formats (TXT, Markdown, SRT, VTT)
 - [ ] Export formats (DOCX, PDF, JSON)
@@ -189,7 +190,7 @@ let result = try await manager.transcribe(audioSamples, source: .system)
 **Three-chip architecture:**
 ```
 CPU:  MacParakeet app (UI, hotkeys, clipboard, history)
-GPU:  Qwen3-4B LLM (via MLX-Swift/Metal) — full GPU, no sharing
+GPU:  Qwen3-8B LLM (via MLX-Swift/Metal) — full GPU, no sharing
 ANE:  Parakeet STT (via FluidAudio/CoreML) — dedicated ML chip
 ```
 
@@ -205,14 +206,16 @@ ANE:  Parakeet STT (via FluidAudio/CoreML) — dedicated ML chip
 
 | Model | HuggingFace ID |
 |-------|----------------|
-| Qwen3-4B | `mlx-community/Qwen3-4B-4bit` |
+| Qwen3-8B | `mlx-community/Qwen3-8B-4bit` |
+
+One model handles text refinement, command mode, and chat with transcript. 128K context window supports full-length transcripts. ~5 GB GPU RAM at 4-bit quantization.
 
 **Dual-mode operation** (same model, different settings):
 
 | Mode | Use Case | Settings |
 |------|----------|----------|
 | Non-thinking | Text cleanup, formatting | `temp=0.7, topP=0.8` |
-| Thinking | Command mode, complex edits | `temp=0.6, topP=0.95` |
+| Thinking | Command mode, chat, complex edits | `temp=0.6, topP=0.95` |
 
 ### Audio Capture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ A **fast, private, local-first voice app** for macOS with two co-equal modes: sy
 | Error handling | `spec/08-error-handling.md` |
 | Testing strategy | `spec/09-testing.md` |
 | AI coding methodology | `spec/10-ai-coding-method.md` |
+| LLM integration | `spec/11-llm-integration.md` |
 | ADRs (locked decisions) | `spec/adr/` -> individual decision records |
 | Competitive research | `docs/competitive-analysis.md` |
 | Brand identity | `docs/brand-identity.md` |
@@ -117,6 +118,7 @@ All ADRs are in `spec/adr/`. These are locked decisions -- don't second-guess th
 | ADR-005 | First-run onboarding flow | `spec/adr/005-onboarding-first-run.md` |
 | ADR-006 | Trial + license key activation | `spec/adr/006-trial-and-license-activation.md` |
 | ADR-007 | FluidAudio CoreML migration (Python elimination) | `spec/adr/007-fluidaudio-coreml-migration.md` |
+| ADR-008 | Local LLM runtime baseline (`mlx-swift-lm` + Qwen3-8B) | `spec/adr/008-local-llm-runtime-and-model.md` |
 
 ## Current Phase
 
@@ -140,8 +142,8 @@ All ADRs are in `spec/adr/`. These are locked decisions -- don't second-guess th
 - [x] Clean text pipeline (filler removal, custom words, snippets) -- deterministic, no LLM
 - [x] Custom words & snippets management UI (Vocabulary sidebar item)
 - [x] CLI commands: `macparakeet-cli flow process/words/snippets` + `macparakeet-cli llm generate/refine/command/smoke-test`
-- [ ] Context modes (raw, clean, formal, email, code) -- raw + clean done, AI modes pending
-- [ ] AI text refinement via Qwen3-8B
+- [x] Context modes (raw, clean, formal, email, code)
+- [x] AI text refinement via Qwen3-8B with deterministic fallback
 
 ### v0.3 Command Mode + Chat + Export
 - [ ] Command Mode (highlight text + voice command -> LLM edits in-place, like WisprFlow Pro)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,13 +133,13 @@ All ADRs are in `spec/adr/`. These are locked decisions -- don't second-guess th
 - [x] Menu bar app with main window + sidebar navigation
 - [x] Basic export (TXT/Markdown/SRT/VTT + copy to clipboard)
 - [x] SQLite database (GRDB, dictations + transcriptions + substring search)
-- [x] Internal dev CLI tool: `macparakeet-cli transcribe`, `history`, `health`
+- [x] Internal dev CLI tool: `macparakeet-cli transcribe`, `history`, `health`, `flow`, `llm`
 - [x] STT engine (Parakeet TDT via FluidAudio CoreML/ANE)
 
 ### v0.2 Clean Pipeline + AI
 - [x] Clean text pipeline (filler removal, custom words, snippets) -- deterministic, no LLM
 - [x] Custom words & snippets management UI (Vocabulary sidebar item)
-- [x] CLI commands: `macparakeet-cli flow process/words/snippets`
+- [x] CLI commands: `macparakeet-cli flow process/words/snippets` + `macparakeet-cli llm generate/refine/command/smoke-test`
 - [ ] Context modes (raw, clean, formal, email, code) -- raw + clean done, AI modes pending
 - [ ] AI text refinement via Qwen3-8B
 
@@ -538,6 +538,8 @@ swift build --target CLI
 swift run macparakeet-cli --help
 swift run macparakeet-cli transcribe /path/to/audio.mp3
 swift run macparakeet-cli health
+swift run macparakeet-cli llm smoke-test --stats
+swift run macparakeet-cli llm refine formal "quick draft text"
 
 # Run tests (swift test works -- tests don't need Metal shaders)
 swift test

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .library(name: "MacParakeetViewModels", targets: ["MacParakeetViewModels"])
     ],
     dependencies: [
-        // MLX-Swift for local LLM inference (Qwen3-4B)
+        // MLX-Swift for local LLM inference (Qwen3-8B)
         // Pin to 2.29.2: 2.29.3 has Xcode 16.1 parser breakage in Jamba.swift,
         // while 2.30.3 has a known Swift 6.1 LoRA compile regression.
         .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", exact: "2.29.2"),

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Drag any audio or video file → get a transcript in seconds.
 - **System-Wide Dictation** — Configurable hotkey (Fn default), double-tap (persistent) + hold-to-talk
 - **File Transcription** — Drag-drop audio/video files, word timestamps
 - **Smart Cleanup** — Deterministic 4-step pipeline (filler removal, custom words, snippets, whitespace)
+- **AI Refinement Modes** — Formal, Email, and Code modes powered by local Qwen3-8B with deterministic fallback
 - **Custom Words** — Domain vocabulary corrections and proper noun casing
 - **Text Snippets** — Natural language triggers expand into longer text
 - **Export** — TXT, Markdown, SRT, and VTT exports + copy to clipboard
@@ -52,7 +53,6 @@ Drag any audio or video file → get a transcript in seconds.
 
 ### Planned
 
-- **AI Refinement** — Qwen3-8B for formal, email, and code modes
 - **Command Mode** — Local LLM edits for command-mode workflows
 - **Chat with Transcript** — Ask questions about your transcriptions via local LLM
 - **More Exports** — DOCX and other formats

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ MacParakeet is built for **fast feedback loops**. AI agents make mistakes — bu
 - **Tests** — Unit and integration tests for all core logic (`swift test`)
 - **Internal CLI** — Headless interface to core services (transcribe files, test the pipeline) so changes can be verified without launching the GUI
   - Tip: use `swift run macparakeet-cli transcribe ... --database /tmp/macparakeet-dev.db` to avoid writing into your real app database during dev.
+  - Local LLM checks: `swift run macparakeet-cli llm smoke-test --stats` and `swift run macparakeet-cli llm refine formal "draft text"`.
   - See `docs/cli-testing.md` for GUI-parity vs deterministic testing modes.
 - **Protocol-based services** — Mockable boundaries make isolated testing straightforward
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ Drag any audio or video file → get a transcript in seconds.
 
 ### Planned
 
-- **AI Refinement** — Qwen3-4B for formal, email, and code modes
+- **AI Refinement** — Qwen3-8B for formal, email, and code modes
 - **Command Mode** — Local LLM edits for command-mode workflows
+- **Chat with Transcript** — Ask questions about your transcriptions via local LLM
 - **More Exports** — DOCX and other formats
 
 ## Requirements
@@ -69,7 +70,7 @@ Download from [macparakeet.com](https://macparakeet.com)
 ## Tech Stack
 
 - **STT Engine**: Parakeet TDT 0.6B-v3 via FluidAudio CoreML (Neural Engine)
-- **LLM**: Qwen3-4B via MLX-Swift (local, for command mode)
+- **LLM**: Qwen3-8B via MLX-Swift (local, for command mode + chat)
 - **Framework**: Swift + SwiftUI
 - **Database**: SQLite via GRDB
 - **Platform**: macOS 14.2+ (Apple Silicon)

--- a/Sources/CLI/Commands/LLMCommand.swift
+++ b/Sources/CLI/Commands/LLMCommand.swift
@@ -1,0 +1,261 @@
+import AppKit
+import ArgumentParser
+import Foundation
+import MacParakeetCore
+
+struct LLMCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "llm",
+        abstract: "Run and validate local LLM workflows.",
+        subcommands: [
+            Generate.self,
+            Refine.self,
+            CommandTransform.self,
+            SmokeTest.self,
+        ]
+    )
+}
+
+struct LLMRuntimeOptions: ParsableArguments {
+    @Option(help: "Model identifier.")
+    var model: String = MLXLLMService.defaultModelID
+
+    @Option(help: "Model revision.")
+    var revision: String = "main"
+
+    @Option(help: "Temperature.")
+    var temperature: Float = 0.6
+
+    @Option(help: "Top-P.")
+    var topP: Float = 0.95
+
+    @Option(help: "Maximum output tokens.")
+    var maxTokens: Int = 512
+
+    @Option(help: "Timeout in seconds.")
+    var timeout: Double = 120
+
+    @Option(help: "Optional system prompt override.")
+    var system: String?
+
+    @Flag(help: "Print prompt and exit without running model.")
+    var dryRun: Bool = false
+
+    @Flag(help: "Include model and timing metadata.")
+    var stats: Bool = false
+
+    func generationOptions() -> LLMGenerationOptions {
+        LLMGenerationOptions(
+            temperature: temperature,
+            topP: topP,
+            maxTokens: maxTokens > 0 ? maxTokens : nil,
+            timeoutSeconds: timeout > 0 ? timeout : nil
+        )
+    }
+}
+
+enum RefineModeArgument: String, ExpressibleByArgument {
+    case formal
+    case email
+    case code
+
+    var coreMode: LLMRefinementMode {
+        switch self {
+        case .formal: return .formal
+        case .email: return .email
+        case .code: return .code
+        }
+    }
+}
+
+extension LLMCommand {
+    struct Generate: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "generate",
+            abstract: "Generate text from a direct prompt."
+        )
+
+        @Argument(help: "Prompt text.")
+        var prompt: String
+
+        @OptionGroup
+        var runtime: LLMRuntimeOptions
+
+        @Flag(name: .long, help: "Copy result to clipboard.")
+        var copy: Bool = false
+
+        func run() async throws {
+            let request = LLMRequest(
+                prompt: prompt,
+                systemPrompt: runtime.system,
+                options: runtime.generationOptions()
+            )
+            try await execute(request: request, runtime: runtime, copy: copy)
+        }
+    }
+
+    struct Refine: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "refine",
+            abstract: "Refine text using deterministic cleanup + local LLM."
+        )
+
+        @Argument(help: "Refinement mode: formal, email, code.")
+        var mode: RefineModeArgument
+
+        @Argument(help: "Text to refine.")
+        var text: String
+
+        @Option(help: "Path to SQLite database file (defaults to app DB).")
+        var database: String?
+
+        @Flag(help: "Skip deterministic pre-clean and send input directly to LLM.")
+        var skipClean: Bool = false
+
+        @OptionGroup
+        var runtime: LLMRuntimeOptions
+
+        @Flag(name: .long, help: "Copy result to clipboard.")
+        var copy: Bool = false
+
+        func run() async throws {
+            let cleanInput: String
+            if skipClean {
+                cleanInput = text
+            } else {
+                cleanInput = try prepareDeterministicText(from: text, database: database)
+            }
+
+            let task = LLMTask.refine(mode: mode.coreMode, input: cleanInput)
+            let request = LLMRequest(
+                prompt: LLMPromptBuilder.userPrompt(for: task),
+                systemPrompt: runtime.system ?? LLMPromptBuilder.systemPrompt(for: task),
+                options: runtime.generationOptions()
+            )
+            try await execute(request: request, runtime: runtime, copy: copy)
+        }
+    }
+
+    struct CommandTransform: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "command",
+            abstract: "Apply a spoken-style command to text."
+        )
+
+        @Argument(help: "Command text, e.g. 'Translate to Spanish'.")
+        var command: String
+
+        @Argument(help: "Selected text to transform.")
+        var selectedText: String
+
+        @OptionGroup
+        var runtime: LLMRuntimeOptions
+
+        @Flag(name: .long, help: "Copy result to clipboard.")
+        var copy: Bool = false
+
+        func run() async throws {
+            let task = LLMTask.commandTransform(command: command, selectedText: selectedText)
+            let request = LLMRequest(
+                prompt: LLMPromptBuilder.userPrompt(for: task),
+                systemPrompt: runtime.system ?? LLMPromptBuilder.systemPrompt(for: task),
+                options: runtime.generationOptions()
+            )
+            try await execute(request: request, runtime: runtime, copy: copy)
+        }
+    }
+
+    struct SmokeTest: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "smoke-test",
+            abstract: "Quick local model readiness test."
+        )
+
+        @OptionGroup
+        var runtime: LLMRuntimeOptions
+
+        func run() async throws {
+            let request = LLMRequest(
+                prompt: "Reply with exactly: OK",
+                systemPrompt: runtime.system ?? "Return exactly one token: OK",
+                options: runtime.generationOptions()
+            )
+
+            if runtime.dryRun {
+                print("SYSTEM:")
+                print(request.systemPrompt ?? "(none)")
+                print()
+                print("PROMPT:")
+                print(request.prompt)
+                return
+            }
+
+            let service = MLXLLMService(modelID: runtime.model, revision: runtime.revision)
+            let response = try await service.generate(request: request)
+            let normalized = response.text.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+            guard normalized.contains("OK") else {
+                throw CLIError.localLLMSmokeTestFailed(response.text)
+            }
+
+            print("LLM smoke test passed.")
+            if runtime.stats {
+                print("model=\(response.modelID)")
+                print(String(format: "duration=%.2fs", response.durationSeconds))
+            }
+        }
+    }
+}
+
+private func execute(request: LLMRequest, runtime: LLMRuntimeOptions, copy: Bool) async throws {
+    if runtime.dryRun {
+        print("SYSTEM:")
+        print(request.systemPrompt ?? "(none)")
+        print()
+        print("PROMPT:")
+        print(request.prompt)
+        return
+    }
+
+    let service = MLXLLMService(modelID: runtime.model, revision: runtime.revision)
+    let response = try await service.generate(request: request)
+    print(response.text)
+
+    if copy {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(response.text, forType: .string)
+        print("(copied to clipboard)")
+    }
+
+    if runtime.stats {
+        print()
+        print("model=\(response.modelID)")
+        print(String(format: "duration=%.2fs", response.durationSeconds))
+    }
+}
+
+private func prepareDeterministicText(from text: String, database: String?) throws -> String {
+    try AppPaths.ensureDirectories()
+
+    let dbPathOpt = database?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let resolvedDBPath = (dbPathOpt?.isEmpty == false) ? dbPathOpt! : AppPaths.databasePath
+    if resolvedDBPath != AppPaths.databasePath {
+        let dir = URL(fileURLWithPath: resolvedDBPath).deletingLastPathComponent()
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    }
+
+    let dbManager = try DatabaseManager(path: resolvedDBPath)
+    let wordRepo = CustomWordRepository(dbQueue: dbManager.dbQueue)
+    let snippetRepo = TextSnippetRepository(dbQueue: dbManager.dbQueue)
+
+    let words = try wordRepo.fetchEnabled()
+    let snippets = try snippetRepo.fetchEnabled()
+    let pipeline = TextProcessingPipeline()
+    let result = pipeline.process(text: text, customWords: words, snippets: snippets)
+
+    if !result.expandedSnippetIDs.isEmpty {
+        try snippetRepo.incrementUseCount(ids: result.expandedSnippetIDs)
+    }
+
+    return result.text
+}

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -207,6 +207,7 @@ struct TranscribeCommand: AsyncParsableCommand {
 enum CLIError: Error, LocalizedError {
     case fileNotFound(String)
     case unsupportedFormat(String)
+    case localLLMSmokeTestFailed(String)
 
     var errorDescription: String? {
         switch self {
@@ -214,6 +215,8 @@ enum CLIError: Error, LocalizedError {
             return "File not found: \(path)"
         case .unsupportedFormat(let ext):
             return "Unsupported format: .\(ext). Supported: \(AudioFileConverter.supportedExtensions.sorted().joined(separator: ", "))"
+        case .localLLMSmokeTestFailed(let output):
+            return "LLM smoke test failed (unexpected response): \(output)"
         }
     }
 }

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -5,6 +5,9 @@ import MacParakeetCore
 enum TranscribeMode: String, ExpressibleByArgument {
     case raw
     case clean
+    case formal
+    case email
+    case code
     case appDefault = "app-default"
 }
 
@@ -26,7 +29,7 @@ struct TranscribeCommand: AsyncParsableCommand {
     @Option(name: .shortAndLong, help: "Output format: text, json.")
     var format: String = "text"
 
-    @Option(help: "Processing mode: raw, clean, app-default.")
+    @Option(help: "Processing mode: raw, clean, formal, email, code, app-default.")
     var mode: TranscribeMode = .appDefault
 
     @Option(help: "Downloaded YouTube audio retention: app-default, keep, delete.")
@@ -54,6 +57,7 @@ struct TranscribeCommand: AsyncParsableCommand {
         let customWordRepo = CustomWordRepository(dbQueue: dbManager.dbQueue)
         let snippetRepo = TextSnippetRepository(dbQueue: dbManager.dbQueue)
         let sttClient = STTClient()
+        let llmService = MLXLLMService()
         let audioProcessor = AudioProcessor()
         let youtubeDownloader = YouTubeDownloader()
         let entitlementsService = enforceEntitlements ? makeEntitlementsService() : nil
@@ -70,12 +74,19 @@ struct TranscribeCommand: AsyncParsableCommand {
             entitlements: entitlementsService,
             customWordRepo: customWordRepo,
             snippetRepo: snippetRepo,
+            llmService: llmService,
             processingMode: {
                 switch self.mode {
                 case .raw:
                     return .raw
                 case .clean:
                     return .clean
+                case .formal:
+                    return .formal
+                case .email:
+                    return .email
+                case .code:
+                    return .code
                 case .appDefault:
                     let rawMode = UserDefaults.standard.string(forKey: "processingMode")
                     return Dictation.ProcessingMode(rawValue: rawMode ?? "clean") ?? .clean

--- a/Sources/CLI/MacParakeetCLI.swift
+++ b/Sources/CLI/MacParakeetCLI.swift
@@ -11,6 +11,7 @@ struct CLI: AsyncParsableCommand {
             HistoryCommand.self,
             HealthCommand.self,
             FlowCommand.self,
+            LLMCommand.self,
         ],
         defaultSubcommand: nil
     )

--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -18,6 +18,7 @@ final class AppEnvironment {
     let exportService: ExportService
     let permissionService: PermissionService
     let entitlementsService: EntitlementsService
+    let llmService: MLXLLMService
     let checkoutURL: URL?
 
     init() throws {
@@ -40,6 +41,7 @@ final class AppEnvironment {
 
         // Services
         sttClient = STTClient()
+        llmService = MLXLLMService()
         audioProcessor = AudioProcessor()
         clipboardService = ClipboardService()
         exportService = ExportService()
@@ -96,6 +98,7 @@ final class AppEnvironment {
             entitlements: entitlementsService,
             customWordRepo: customWordRepo,
             snippetRepo: snippetRepo,
+            llmService: llmService,
             processingMode: processingModeClosure
         )
 
@@ -106,6 +109,7 @@ final class AppEnvironment {
             entitlements: entitlementsService,
             customWordRepo: customWordRepo,
             snippetRepo: snippetRepo,
+            llmService: llmService,
             processingMode: processingModeClosure,
             shouldKeepDownloadedAudio: {
                 // Defaults to true if unset (matches Settings UI default).

--- a/Sources/MacParakeet/Views/History/DictationHistoryView.swift
+++ b/Sources/MacParakeet/Views/History/DictationHistoryView.swift
@@ -358,7 +358,7 @@ struct DictationCardRow: View {
                     }
 
                     HStack(spacing: 6) {
-                        Text(dictation.processingMode == .clean ? "Clean mode" : "Raw mode")
+                        Text("\(dictation.processingMode.displayName) mode")
                             .font(DesignSystem.Typography.micro)
                             .foregroundStyle(.secondary)
 

--- a/Sources/MacParakeet/Views/Vocabulary/VocabularyView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/VocabularyView.swift
@@ -12,16 +12,23 @@ struct VocabularyView: View {
     @State private var hoveredCardTitle: String?
     @State private var hoveredModeTitle: String?
 
+    private var selectedMode: Dictation.ProcessingMode {
+        Dictation.ProcessingMode(rawValue: settingsViewModel.processingMode) ?? .clean
+    }
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
                 policyHeaderCard
                 modeSelectionCard
                 capabilityCard
-                if settingsViewModel.processingMode == "clean" {
-                    pipelineCard
-                } else {
+                if selectedMode == .raw {
                     rawModeCard
+                } else {
+                    pipelineCard
+                    if selectedMode.usesLLMRefinement {
+                        llmRefinementCard
+                    }
                 }
             }
             .padding(DesignSystem.Spacing.lg)
@@ -58,7 +65,7 @@ struct VocabularyView: View {
             ) {
                 summaryChip(
                     title: "Current Mode",
-                    value: settingsViewModel.processingMode == "clean" ? "Clean" : "Raw"
+                    value: selectedMode.displayName
                 )
                 summaryChip(
                     title: "Custom Words",
@@ -89,9 +96,9 @@ struct VocabularyView: View {
                     subtitle: "As spoken",
                     detail: "No deterministic cleanup. Useful for verbatim capture.",
                     icon: "waveform",
-                    isSelected: settingsViewModel.processingMode == "raw"
+                    isSelected: selectedMode == .raw
                 ) {
-                    settingsViewModel.processingMode = "raw"
+                    settingsViewModel.processingMode = Dictation.ProcessingMode.raw.rawValue
                 }
 
                 modeCard(
@@ -99,9 +106,39 @@ struct VocabularyView: View {
                     subtitle: "Polished",
                     detail: "Applies deterministic pipeline rules before output.",
                     icon: "sparkles",
-                    isSelected: settingsViewModel.processingMode == "clean"
+                    isSelected: selectedMode == .clean
                 ) {
-                    settingsViewModel.processingMode = "clean"
+                    settingsViewModel.processingMode = Dictation.ProcessingMode.clean.rawValue
+                }
+
+                modeCard(
+                    title: "Formal",
+                    subtitle: "Professional tone",
+                    detail: "Deterministic cleanup, then local LLM rewrite for formal delivery.",
+                    icon: "briefcase",
+                    isSelected: selectedMode == .formal
+                ) {
+                    settingsViewModel.processingMode = Dictation.ProcessingMode.formal.rawValue
+                }
+
+                modeCard(
+                    title: "Email",
+                    subtitle: "Message-ready",
+                    detail: "Deterministic cleanup, then local LLM turns text into polished email style.",
+                    icon: "envelope",
+                    isSelected: selectedMode == .email
+                ) {
+                    settingsViewModel.processingMode = Dictation.ProcessingMode.email.rawValue
+                }
+
+                modeCard(
+                    title: "Code",
+                    subtitle: "Technical writing",
+                    detail: "Deterministic cleanup, then local LLM preserves code/identifier semantics.",
+                    icon: "chevron.left.forwardslash.chevron.right",
+                    isSelected: selectedMode == .code
+                ) {
+                    settingsViewModel.processingMode = Dictation.ProcessingMode.code.rawValue
                 }
             }
         }
@@ -109,7 +146,7 @@ struct VocabularyView: View {
 
     private var capabilityCard: some View {
         vocabularyCard(
-            title: "What Clean Mode Does",
+            title: "What Processing Does",
             subtitle: "Deterministic transforms, no cloud calls.",
             icon: "checkmark.shield"
         ) {
@@ -118,6 +155,9 @@ struct VocabularyView: View {
                 capabilityRow(icon: "character.book.closed", text: "Applies custom word corrections and casing anchors.")
                 capabilityRow(icon: "text.insert", text: "Expands phrase snippets into full text.")
                 capabilityRow(icon: "textformat", text: "Normalizes whitespace and punctuation spacing.")
+                if selectedMode.usesLLMRefinement {
+                    capabilityRow(icon: "cpu", text: "Runs local Qwen3-8B refinement with deterministic fallback.")
+                }
             }
         }
     }
@@ -127,7 +167,7 @@ struct VocabularyView: View {
     private var pipelineCard: some View {
         vocabularyCard(
             title: "Clean Pipeline",
-            subtitle: "Ordered deterministic stages.",
+            subtitle: "Ordered deterministic stages (always run before AI modes).",
             icon: "list.number"
         ) {
             VStack(spacing: 0) {
@@ -179,13 +219,36 @@ struct VocabularyView: View {
         }
     }
 
+    private var llmRefinementCard: some View {
+        vocabularyCard(
+            title: "AI Refinement",
+            subtitle: "Local-only Qwen3-8B pass after deterministic cleanup.",
+            icon: "brain.head.profile"
+        ) {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+                capabilityRow(
+                    icon: "shield.lefthalf.filled",
+                    text: "If generation fails or times out, MacParakeet falls back to deterministic clean output."
+                )
+                capabilityRow(
+                    icon: "memorychip",
+                    text: "Model loads lazily on first AI use to keep startup fast."
+                )
+                capabilityRow(
+                    icon: "lock",
+                    text: "All processing stays on-device. No cloud requests."
+                )
+            }
+        }
+    }
+
     private var rawModeCard: some View {
         vocabularyCard(
             title: "Raw Mode Active",
             subtitle: "Pipeline transforms are bypassed.",
             icon: "waveform.badge.exclamationmark"
         ) {
-            Text("Switch to Clean mode when you want deterministic corrections, snippet expansion, and formatting cleanup.")
+            Text("Switch to Clean, Formal, Email, or Code mode when you want post-processing before paste/export.")
                 .font(DesignSystem.Typography.bodySmall)
                 .foregroundStyle(.secondary)
         }

--- a/Sources/MacParakeetCore/LLM/LLMPromptBuilder.swift
+++ b/Sources/MacParakeetCore/LLM/LLMPromptBuilder.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+public enum LLMRefinementMode: String, CaseIterable, Sendable {
+    case formal
+    case email
+    case code
+}
+
+public enum LLMTask: Sendable {
+    case refine(mode: LLMRefinementMode, input: String)
+    case commandTransform(command: String, selectedText: String)
+    case transcriptChat(question: String, transcript: String)
+}
+
+public enum LLMPromptBuilder {
+    public static func systemPrompt(for task: LLMTask) -> String {
+        switch task {
+        case .refine(let mode, _):
+            switch mode {
+            case .formal:
+                return """
+                You are a concise professional editor. Improve clarity and tone while preserving meaning.
+                Return only the rewritten text.
+                """
+            case .email:
+                return """
+                You are an email writing assistant. Produce a clean, professional email body.
+                Return only the rewritten email text.
+                """
+            case .code:
+                return """
+                You are a technical editor. Preserve code identifiers, symbols, and formatting intent.
+                Return only the rewritten text.
+                """
+            }
+        case .commandTransform:
+            return """
+            You execute text-editing commands. Apply the command exactly to the provided text.
+            Return only the transformed text.
+            """
+        case .transcriptChat:
+            return """
+            You answer questions using only the provided transcript context.
+            If context is insufficient, say so briefly.
+            """
+        }
+    }
+
+    public static func userPrompt(for task: LLMTask) -> String {
+        switch task {
+        case .refine(let mode, let input):
+            let label: String
+            switch mode {
+            case .formal:
+                label = "Rewrite in a formal professional tone."
+            case .email:
+                label = "Rewrite as a polished email."
+            case .code:
+                label = "Rewrite while preserving technical/code semantics."
+            }
+            return """
+            Task: \(label)
+
+            Text:
+            \(input)
+            """
+        case .commandTransform(let command, let selectedText):
+            return """
+            Command:
+            \(command)
+
+            Selected text:
+            \(selectedText)
+            """
+        case .transcriptChat(let question, let transcript):
+            return """
+            Transcript:
+            \(transcript)
+
+            Question:
+            \(question)
+            """
+        }
+    }
+}

--- a/Sources/MacParakeetCore/LLM/LLMServiceProtocol.swift
+++ b/Sources/MacParakeetCore/LLM/LLMServiceProtocol.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+public struct LLMGenerationOptions: Sendable {
+    public var temperature: Float
+    public var topP: Float
+    public var maxTokens: Int?
+    public var timeoutSeconds: TimeInterval?
+
+    public init(
+        temperature: Float = 0.6,
+        topP: Float = 0.95,
+        maxTokens: Int? = 512,
+        timeoutSeconds: TimeInterval? = 120
+    ) {
+        self.temperature = temperature
+        self.topP = topP
+        self.maxTokens = maxTokens
+        self.timeoutSeconds = timeoutSeconds
+    }
+}
+
+public struct LLMRequest: Sendable {
+    public var prompt: String
+    public var systemPrompt: String?
+    public var options: LLMGenerationOptions
+
+    public init(
+        prompt: String,
+        systemPrompt: String? = nil,
+        options: LLMGenerationOptions = .init()
+    ) {
+        self.prompt = prompt
+        self.systemPrompt = systemPrompt
+        self.options = options
+    }
+}
+
+public struct LLMResponse: Sendable {
+    public var text: String
+    public var modelID: String
+    public var durationSeconds: TimeInterval
+
+    public init(text: String, modelID: String, durationSeconds: TimeInterval) {
+        self.text = text
+        self.modelID = modelID
+        self.durationSeconds = durationSeconds
+    }
+}
+
+public enum LLMServiceError: Error, LocalizedError, Sendable {
+    case invalidPrompt
+    case timedOut(seconds: TimeInterval)
+    case emptyResponse
+    case generationFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidPrompt:
+            return "Prompt is empty."
+        case .timedOut(let seconds):
+            return "Local model generation timed out after \(Int(seconds))s."
+        case .emptyResponse:
+            return "Local model returned an empty response."
+        case .generationFailed(let message):
+            return "Local model generation failed: \(message)"
+        }
+    }
+}
+
+public protocol LLMServiceProtocol: Sendable {
+    func generate(request: LLMRequest) async throws -> LLMResponse
+}

--- a/Sources/MacParakeetCore/LLM/MLXLLMService.swift
+++ b/Sources/MacParakeetCore/LLM/MLXLLMService.swift
@@ -1,0 +1,96 @@
+import Foundation
+import MLXLLM
+import MLXLMCommon
+
+public actor MLXLLMService: LLMServiceProtocol {
+    public static let defaultModelID = "mlx-community/Qwen3-8B-4bit"
+
+    private let modelID: String
+    private let revision: String
+    private var modelContainer: ModelContainer?
+
+    public init(
+        modelID: String = MLXLLMService.defaultModelID,
+        revision: String = "main"
+    ) {
+        self.modelID = modelID
+        self.revision = revision
+    }
+
+    public func unload() {
+        modelContainer = nil
+    }
+
+    public func generate(request: LLMRequest) async throws -> LLMResponse {
+        let trimmedPrompt = request.prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPrompt.isEmpty else {
+            throw LLMServiceError.invalidPrompt
+        }
+
+        let container = try await ensureModelLoaded()
+        let startedAt = Date()
+        let parameters = GenerateParameters(
+            maxTokens: request.options.maxTokens,
+            temperature: request.options.temperature,
+            topP: request.options.topP
+        )
+        let session = ChatSession(
+            container,
+            instructions: request.systemPrompt,
+            generateParameters: parameters
+        )
+
+        let output = try await withTimeout(seconds: request.options.timeoutSeconds) {
+            try await session.respond(to: trimmedPrompt)
+        }
+
+        let text = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else {
+            throw LLMServiceError.emptyResponse
+        }
+
+        return LLMResponse(
+            text: text,
+            modelID: modelID,
+            durationSeconds: Date().timeIntervalSince(startedAt)
+        )
+    }
+
+    private func ensureModelLoaded() async throws -> ModelContainer {
+        if let modelContainer {
+            return modelContainer
+        }
+
+        let loaded = try await loadModelContainer(id: modelID, revision: revision)
+        modelContainer = loaded
+        return loaded
+    }
+
+    private func withTimeout<T: Sendable>(
+        seconds: TimeInterval?,
+        operation: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
+        guard let seconds, seconds > 0 else {
+            return try await operation()
+        }
+
+        let timeoutNs = UInt64(max(0, seconds) * 1_000_000_000)
+
+        return try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask {
+                try await operation()
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: timeoutNs)
+                throw LLMServiceError.timedOut(seconds: seconds)
+            }
+
+            let result = try await group.next()
+            group.cancelAll()
+            guard let result else {
+                throw LLMServiceError.generationFailed("No result returned.")
+            }
+            return result
+        }
+    }
+}

--- a/Sources/MacParakeetCore/LLM/MLXLLMService.swift
+++ b/Sources/MacParakeetCore/LLM/MLXLLMService.swift
@@ -51,7 +51,8 @@ public actor MLXLLMService: LLMServiceProtocol {
         let session = ChatSession(
             container,
             instructions: request.systemPrompt,
-            generateParameters: parameters
+            generateParameters: parameters,
+            additionalContext: ["enable_thinking": false]
         )
 
         let output = try await withTimeout(seconds: request.options.timeoutSeconds) {

--- a/Sources/MacParakeetCore/LLM/MLXLLMService.swift
+++ b/Sources/MacParakeetCore/LLM/MLXLLMService.swift
@@ -7,17 +7,23 @@ public actor MLXLLMService: LLMServiceProtocol {
 
     private let modelID: String
     private let revision: String
+    private let idleUnloadSeconds: TimeInterval?
     private var modelContainer: ModelContainer?
+    private var idleUnloadTask: Task<Void, Never>?
 
     public init(
         modelID: String = MLXLLMService.defaultModelID,
-        revision: String = "main"
+        revision: String = "main",
+        idleUnloadSeconds: TimeInterval? = 300
     ) {
         self.modelID = modelID
         self.revision = revision
+        self.idleUnloadSeconds = idleUnloadSeconds
     }
 
     public func unload() {
+        idleUnloadTask?.cancel()
+        idleUnloadTask = nil
         modelContainer = nil
     }
 
@@ -27,7 +33,15 @@ public actor MLXLLMService: LLMServiceProtocol {
             throw LLMServiceError.invalidPrompt
         }
 
+        cancelIdleUnloadTask()
+        var shouldScheduleIdleUnload = false
         let container = try await ensureModelLoaded()
+        shouldScheduleIdleUnload = true
+        defer {
+            if shouldScheduleIdleUnload {
+                scheduleIdleUnloadIfNeeded()
+            }
+        }
         let startedAt = Date()
         let parameters = GenerateParameters(
             maxTokens: request.options.maxTokens,
@@ -64,6 +78,30 @@ public actor MLXLLMService: LLMServiceProtocol {
         let loaded = try await loadModelContainer(id: modelID, revision: revision)
         modelContainer = loaded
         return loaded
+    }
+
+    private func cancelIdleUnloadTask() {
+        idleUnloadTask?.cancel()
+        idleUnloadTask = nil
+    }
+
+    private func scheduleIdleUnloadIfNeeded() {
+        cancelIdleUnloadTask()
+
+        guard let idleUnloadSeconds, idleUnloadSeconds > 0 else {
+            return
+        }
+
+        let nanos = UInt64(idleUnloadSeconds * 1_000_000_000)
+        idleUnloadTask = Task { [nanos] in
+            try? await Task.sleep(nanoseconds: nanos)
+            self.unloadAfterIdleTimeout()
+        }
+    }
+
+    private func unloadAfterIdleTimeout() {
+        modelContainer = nil
+        idleUnloadTask = nil
     }
 
     private func withTimeout<T: Sendable>(

--- a/Sources/MacParakeetCore/LLM/TranscriptContextAssembler.swift
+++ b/Sources/MacParakeetCore/LLM/TranscriptContextAssembler.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+public enum TranscriptContextAssembler {
+    public static func assemble(
+        transcript: String,
+        maxCharacters: Int = 12_000
+    ) -> String {
+        let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count > maxCharacters, maxCharacters > 64 else {
+            return trimmed
+        }
+
+        // Keep both opening and ending context to preserve topic setup + latest details.
+        let marker = "\n\n[...truncated...]\n\n"
+        let budget = maxCharacters - marker.count
+        let headCount = budget / 2
+        let tailCount = budget - headCount
+        let head = String(trimmed.prefix(headCount))
+        let tail = String(trimmed.suffix(tailCount))
+        return head + marker + tail
+    }
+
+    public static func chunk(
+        transcript: String,
+        chunkSize: Int = 3_000,
+        overlap: Int = 300
+    ) -> [String] {
+        let cleaned = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleaned.isEmpty, chunkSize > 0 else { return [] }
+
+        let effectiveOverlap = min(max(overlap, 0), max(0, chunkSize - 1))
+        let step = max(1, chunkSize - effectiveOverlap)
+        let chars = Array(cleaned)
+
+        var chunks: [String] = []
+        var index = 0
+        while index < chars.count {
+            let end = min(chars.count, index + chunkSize)
+            chunks.append(String(chars[index..<end]))
+            if end == chars.count {
+                break
+            }
+            index += step
+        }
+
+        return chunks
+    }
+}

--- a/Sources/MacParakeetCore/Models/Dictation.swift
+++ b/Sources/MacParakeetCore/Models/Dictation.swift
@@ -17,6 +17,9 @@ public struct Dictation: Codable, Identifiable, Sendable {
     public enum ProcessingMode: String, Codable, Sendable {
         case raw
         case clean
+        case formal
+        case email
+        case code
     }
 
     public enum DictationStatus: String, Codable, Sendable {
@@ -50,6 +53,49 @@ public struct Dictation: Codable, Identifiable, Sendable {
         self.status = status
         self.errorMessage = errorMessage
         self.updatedAt = updatedAt
+    }
+}
+
+public extension Dictation.ProcessingMode {
+    var usesDeterministicPipeline: Bool {
+        self != .raw
+    }
+
+    var usesLLMRefinement: Bool {
+        switch self {
+        case .formal, .email, .code:
+            return true
+        case .raw, .clean:
+            return false
+        }
+    }
+
+    var llmRefinementMode: LLMRefinementMode? {
+        switch self {
+        case .formal:
+            return .formal
+        case .email:
+            return .email
+        case .code:
+            return .code
+        case .raw, .clean:
+            return nil
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .raw:
+            return "Raw"
+        case .clean:
+            return "Clean"
+        case .formal:
+            return "Formal"
+        case .email:
+            return "Email"
+        case .code:
+            return "Code"
+        }
     }
 }
 

--- a/Sources/MacParakeetCore/Services/DictationService.swift
+++ b/Sources/MacParakeetCore/Services/DictationService.swift
@@ -31,6 +31,7 @@ public actor DictationService: DictationServiceProtocol {
     private let customWordRepo: CustomWordRepositoryProtocol?
     private let snippetRepo: TextSnippetRepositoryProtocol?
     private let processingMode: @Sendable () -> Dictation.ProcessingMode
+    private let textRefinementService: TextRefinementService
     private let cancelWindow: Duration
 
     private var _state: DictationState = .idle
@@ -55,7 +56,9 @@ public actor DictationService: DictationServiceProtocol {
         entitlements: EntitlementsChecking? = nil,
         customWordRepo: CustomWordRepositoryProtocol? = nil,
         snippetRepo: TextSnippetRepositoryProtocol? = nil,
+        llmService: (any LLMServiceProtocol)? = nil,
         processingMode: (@Sendable () -> Dictation.ProcessingMode)? = nil,
+        refinementOptionsProvider: TextRefinementService.OptionsProvider? = nil,
         cancelWindow: Duration = .seconds(5)
     ) {
         self.audioProcessor = audioProcessor
@@ -67,6 +70,10 @@ public actor DictationService: DictationServiceProtocol {
         self.customWordRepo = customWordRepo
         self.snippetRepo = snippetRepo
         self.processingMode = processingMode ?? { .raw }
+        self.textRefinementService = TextRefinementService(
+            llmService: llmService,
+            optionsProvider: refinementOptionsProvider ?? TextRefinementService.defaultOptionsProvider
+        )
         self.cancelWindow = cancelWindow
     }
 
@@ -204,23 +211,17 @@ public actor DictationService: DictationServiceProtocol {
             throw DictationServiceError.emptyTranscript
         }
 
-        // Run pipeline if not raw mode
         let mode = processingMode()
-        var cleanTranscript: String? = nil
-        var expandedSnippetIDs = Set<UUID>()
-
-        if mode != .raw {
-            let words = (try? customWordRepo?.fetchEnabled()) ?? []
-            let snippets = (try? snippetRepo?.fetchEnabled()) ?? []
-            let pipeline = TextProcessingPipeline()
-            let pipelineResult = pipeline.process(
-                text: result.text,
-                customWords: words,
-                snippets: snippets
-            )
-            cleanTranscript = pipelineResult.text
-            expandedSnippetIDs = pipelineResult.expandedSnippetIDs
-        }
+        let words = mode.usesDeterministicPipeline ? ((try? customWordRepo?.fetchEnabled()) ?? []) : []
+        let snippets = mode.usesDeterministicPipeline ? ((try? snippetRepo?.fetchEnabled()) ?? []) : []
+        let refinement = await textRefinementService.refine(
+            rawText: result.text,
+            mode: mode,
+            customWords: words,
+            snippets: snippets
+        )
+        let cleanTranscript = refinement.text
+        let expandedSnippetIDs = refinement.expandedSnippetIDs
 
         // Create dictation record
         var dictation = Dictation(

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -22,6 +22,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
     private let customWordRepo: CustomWordRepositoryProtocol?
     private let snippetRepo: TextSnippetRepositoryProtocol?
     private let processingMode: @Sendable () -> Dictation.ProcessingMode
+    private let textRefinementService: TextRefinementService
     private let shouldKeepDownloadedAudio: @Sendable () -> Bool
     private let youtubeDownloader: YouTubeDownloading?
 
@@ -32,7 +33,9 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         entitlements: EntitlementsChecking? = nil,
         customWordRepo: CustomWordRepositoryProtocol? = nil,
         snippetRepo: TextSnippetRepositoryProtocol? = nil,
+        llmService: (any LLMServiceProtocol)? = nil,
         processingMode: (@Sendable () -> Dictation.ProcessingMode)? = nil,
+        refinementOptionsProvider: TextRefinementService.OptionsProvider? = nil,
         shouldKeepDownloadedAudio: (@Sendable () -> Bool)? = nil,
         youtubeDownloader: YouTubeDownloading? = nil
     ) {
@@ -43,6 +46,10 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         self.customWordRepo = customWordRepo
         self.snippetRepo = snippetRepo
         self.processingMode = processingMode ?? { .raw }
+        self.textRefinementService = TextRefinementService(
+            llmService: llmService,
+            optionsProvider: refinementOptionsProvider ?? TextRefinementService.defaultOptionsProvider
+        )
         self.shouldKeepDownloadedAudio = shouldKeepDownloadedAudio ?? { true }
         self.youtubeDownloader = youtubeDownloader
     }
@@ -141,19 +148,18 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
             transcription.durationMs = result.words.last?.endMs
 
             let mode = processingMode()
-            if mode != .raw {
-                let customWords = (try? customWordRepo?.fetchEnabled()) ?? []
-                let snippets = (try? snippetRepo?.fetchEnabled()) ?? []
-                let pipeline = TextProcessingPipeline()
-                let pipelineResult = pipeline.process(
-                    text: result.text,
-                    customWords: customWords,
-                    snippets: snippets
-                )
-                transcription.cleanTranscript = pipelineResult.text
-                if !pipelineResult.expandedSnippetIDs.isEmpty {
-                    try? snippetRepo?.incrementUseCount(ids: pipelineResult.expandedSnippetIDs)
-                }
+            let customWords = mode.usesDeterministicPipeline ? ((try? customWordRepo?.fetchEnabled()) ?? []) : []
+            let snippets = mode.usesDeterministicPipeline ? ((try? snippetRepo?.fetchEnabled()) ?? []) : []
+            let refinement = await textRefinementService.refine(
+                rawText: result.text,
+                mode: mode,
+                customWords: customWords,
+                snippets: snippets
+            )
+            transcription.cleanTranscript = refinement.text
+
+            if !refinement.expandedSnippetIDs.isEmpty {
+                try? snippetRepo?.incrementUseCount(ids: refinement.expandedSnippetIDs)
             }
 
             transcription.status = .completed

--- a/Sources/MacParakeetCore/TextProcessing/TextRefinementService.swift
+++ b/Sources/MacParakeetCore/TextProcessing/TextRefinementService.swift
@@ -74,6 +74,15 @@ public struct TextRefinementService: Sendable {
             customWords: customWords,
             snippets: snippets
         )
+        let deterministicTrimmed = deterministic.text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !deterministicTrimmed.isEmpty else {
+            return TextRefinementResult(
+                text: deterministic.text,
+                expandedSnippetIDs: deterministic.expandedSnippetIDs,
+                path: .deterministic
+            )
+        }
 
         guard mode.usesLLMRefinement, let refinementMode = mode.llmRefinementMode else {
             return TextRefinementResult(

--- a/Sources/MacParakeetCore/TextProcessing/TextRefinementService.swift
+++ b/Sources/MacParakeetCore/TextProcessing/TextRefinementService.swift
@@ -1,0 +1,131 @@
+import Foundation
+import os
+
+public enum TextRefinementPath: String, Sendable {
+    case raw
+    case deterministic
+    case llm
+    case llmFallback
+}
+
+public struct TextRefinementResult: Sendable {
+    public let text: String?
+    public let expandedSnippetIDs: Set<UUID>
+    public let path: TextRefinementPath
+    public let fallbackReason: String?
+
+    public init(
+        text: String?,
+        expandedSnippetIDs: Set<UUID>,
+        path: TextRefinementPath,
+        fallbackReason: String? = nil
+    ) {
+        self.text = text
+        self.expandedSnippetIDs = expandedSnippetIDs
+        self.path = path
+        self.fallbackReason = fallbackReason
+    }
+}
+
+public struct TextRefinementService: Sendable {
+    public typealias OptionsProvider = @Sendable (Dictation.ProcessingMode) -> LLMGenerationOptions
+    public static let defaultOptionsProvider: OptionsProvider = { mode in
+        switch mode {
+        case .formal, .email, .code:
+            return LLMGenerationOptions(
+                temperature: 0.7,
+                topP: 0.8,
+                maxTokens: 512,
+                timeoutSeconds: 45
+            )
+        case .raw, .clean:
+            return LLMGenerationOptions()
+        }
+    }
+
+    private let llmService: (any LLMServiceProtocol)?
+    private let optionsProvider: OptionsProvider
+    private let logger = Logger(subsystem: "com.macparakeet.core", category: "TextRefinement")
+
+    public init(
+        llmService: (any LLMServiceProtocol)? = nil,
+        optionsProvider: @escaping OptionsProvider = TextRefinementService.defaultOptionsProvider
+    ) {
+        self.llmService = llmService
+        self.optionsProvider = optionsProvider
+    }
+
+    public func refine(
+        rawText: String,
+        mode: Dictation.ProcessingMode,
+        customWords: [CustomWord],
+        snippets: [TextSnippet]
+    ) async -> TextRefinementResult {
+        guard mode.usesDeterministicPipeline else {
+            return TextRefinementResult(
+                text: nil,
+                expandedSnippetIDs: [],
+                path: .raw
+            )
+        }
+
+        let deterministic = TextProcessingPipeline().process(
+            text: rawText,
+            customWords: customWords,
+            snippets: snippets
+        )
+
+        guard mode.usesLLMRefinement, let refinementMode = mode.llmRefinementMode else {
+            return TextRefinementResult(
+                text: deterministic.text,
+                expandedSnippetIDs: deterministic.expandedSnippetIDs,
+                path: .deterministic
+            )
+        }
+
+        guard let llmService else {
+            return fallback(
+                deterministic: deterministic,
+                reason: "LLM service not configured"
+            )
+        }
+
+        let task = LLMTask.refine(mode: refinementMode, input: deterministic.text)
+        let request = LLMRequest(
+            prompt: LLMPromptBuilder.userPrompt(for: task),
+            systemPrompt: LLMPromptBuilder.systemPrompt(for: task),
+            options: optionsProvider(mode)
+        )
+
+        do {
+            let response = try await llmService.generate(request: request)
+            let refined = response.text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            guard !refined.isEmpty else {
+                return fallback(deterministic: deterministic, reason: "LLM output was empty")
+            }
+
+            return TextRefinementResult(
+                text: refined,
+                expandedSnippetIDs: deterministic.expandedSnippetIDs,
+                path: .llm
+            )
+        } catch {
+            return fallback(deterministic: deterministic, reason: error.localizedDescription)
+        }
+    }
+
+    private func fallback(deterministic: TextProcessingResult, reason: String) -> TextRefinementResult {
+        logger.notice("LLM refinement fallback applied: \(reason, privacy: .public)")
+        return TextRefinementResult(
+            text: deterministic.text,
+            expandedSnippetIDs: deterministic.expandedSnippetIDs,
+            path: .llmFallback,
+            fallbackReason: reason
+        )
+    }
+
+    public static func defaultOptions(for mode: Dictation.ProcessingMode) -> LLMGenerationOptions {
+        defaultOptionsProvider(mode)
+    }
+}

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -31,7 +31,13 @@ public final class SettingsViewModel {
 
     // Processing
     public var processingMode: String {
-        didSet { defaults.set(processingMode, forKey: "processingMode") }
+        didSet {
+            guard Dictation.ProcessingMode(rawValue: processingMode) != nil else {
+                processingMode = Dictation.ProcessingMode.clean.rawValue
+                return
+            }
+            defaults.set(processingMode, forKey: "processingMode")
+        }
     }
     public var customWordCount: Int = 0
     public var snippetCount: Int = 0
@@ -83,7 +89,7 @@ public final class SettingsViewModel {
         silenceAutoStop = defaults.bool(forKey: "silenceAutoStop")
         let delay = defaults.double(forKey: "silenceDelay")
         silenceDelay = delay == 0 ? 2.0 : delay
-        processingMode = defaults.string(forKey: "processingMode") ?? "clean"
+        processingMode = Self.normalizedProcessingMode(defaults.string(forKey: "processingMode"))
         saveAudioRecordings = defaults.object(forKey: "saveAudioRecordings") as? Bool ?? true
         saveTranscriptionAudio = defaults.object(forKey: "saveTranscriptionAudio") as? Bool ?? true
     }
@@ -263,5 +269,12 @@ public final class SettingsViewModel {
         }
 
         return (count, sizeBytes)
+    }
+
+    private static func normalizedProcessingMode(_ rawValue: String?) -> String {
+        guard let rawValue, Dictation.ProcessingMode(rawValue: rawValue) != nil else {
+            return Dictation.ProcessingMode.clean.rawValue
+        }
+        return rawValue
     }
 }

--- a/Tests/MacParakeetTests/LLM/LLMPromptBuilderTests.swift
+++ b/Tests/MacParakeetTests/LLM/LLMPromptBuilderTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class LLMPromptBuilderTests: XCTestCase {
+    func testFormalRefinePromptIncludesInput() {
+        let task = LLMTask.refine(mode: .formal, input: "hello world")
+        let system = LLMPromptBuilder.systemPrompt(for: task).lowercased()
+        let user = LLMPromptBuilder.userPrompt(for: task)
+
+        XCTAssertTrue(system.contains("professional"))
+        XCTAssertTrue(user.contains("hello world"))
+    }
+
+    func testEmailRefinePromptMentionsEmail() {
+        let task = LLMTask.refine(mode: .email, input: "quick update")
+        let system = LLMPromptBuilder.systemPrompt(for: task).lowercased()
+        let user = LLMPromptBuilder.userPrompt(for: task).lowercased()
+
+        XCTAssertTrue(system.contains("email"))
+        XCTAssertTrue(user.contains("email"))
+    }
+
+    func testCodeRefinePromptPreservesTechnicalIntent() {
+        let task = LLMTask.refine(mode: .code, input: "use var_name in if(x==1)")
+        let system = LLMPromptBuilder.systemPrompt(for: task).lowercased()
+        let user = LLMPromptBuilder.userPrompt(for: task).lowercased()
+
+        XCTAssertTrue(system.contains("technical"))
+        XCTAssertTrue(user.contains("preserving technical"))
+    }
+
+    func testCommandPromptContainsCommandAndSelectedText() {
+        let task = LLMTask.commandTransform(
+            command: "Translate to Spanish",
+            selectedText: "Hello friend"
+        )
+        let user = LLMPromptBuilder.userPrompt(for: task)
+        XCTAssertTrue(user.contains("Translate to Spanish"))
+        XCTAssertTrue(user.contains("Hello friend"))
+    }
+
+    func testTranscriptChatPromptContainsContextAndQuestion() {
+        let task = LLMTask.transcriptChat(
+            question: "What was the main conclusion?",
+            transcript: "We should ship the migration this week."
+        )
+        let system = LLMPromptBuilder.systemPrompt(for: task).lowercased()
+        let user = LLMPromptBuilder.userPrompt(for: task)
+
+        XCTAssertTrue(system.contains("provided transcript"))
+        XCTAssertTrue(user.contains("main conclusion"))
+        XCTAssertTrue(user.contains("ship the migration"))
+    }
+}

--- a/Tests/MacParakeetTests/LLM/MLXLLMServiceTests.swift
+++ b/Tests/MacParakeetTests/LLM/MLXLLMServiceTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class MLXLLMServiceTests: XCTestCase {
+    func testGenerateRejectsEmptyPromptBeforeModelLoad() async {
+        let service = MLXLLMService()
+        let request = LLMRequest(prompt: "   ", options: .init(timeoutSeconds: 1))
+
+        do {
+            _ = try await service.generate(request: request)
+            XCTFail("Expected invalidPrompt error")
+        } catch let error as LLMServiceError {
+            guard case .invalidPrompt = error else {
+                XCTFail("Expected invalidPrompt, got \(error)")
+                return
+            }
+        } catch {
+            XCTFail("Expected LLMServiceError.invalidPrompt, got \(error)")
+        }
+    }
+}

--- a/Tests/MacParakeetTests/LLM/MockLLMService.swift
+++ b/Tests/MacParakeetTests/LLM/MockLLMService.swift
@@ -1,0 +1,38 @@
+import Foundation
+@testable import MacParakeetCore
+
+actor MockLLMService: LLMServiceProtocol {
+    private(set) var requests: [LLMRequest] = []
+    private var configuredText: String = "mock-llm-response"
+    private var configuredError: Error?
+    private var configuredDuration: TimeInterval = 0.05
+
+    func configureResponse(text: String, durationSeconds: TimeInterval = 0.05) {
+        configuredText = text
+        configuredDuration = durationSeconds
+        configuredError = nil
+    }
+
+    func configureError(_ error: Error) {
+        configuredError = error
+    }
+
+    func reset() {
+        requests = []
+        configuredText = "mock-llm-response"
+        configuredDuration = 0.05
+        configuredError = nil
+    }
+
+    func generate(request: LLMRequest) async throws -> LLMResponse {
+        requests.append(request)
+        if let configuredError {
+            throw configuredError
+        }
+        return LLMResponse(
+            text: configuredText,
+            modelID: "mock-qwen",
+            durationSeconds: configuredDuration
+        )
+    }
+}

--- a/Tests/MacParakeetTests/LLM/TranscriptContextAssemblerTests.swift
+++ b/Tests/MacParakeetTests/LLM/TranscriptContextAssemblerTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class TranscriptContextAssemblerTests: XCTestCase {
+    func testAssembleReturnsOriginalWhenUnderLimit() {
+        let transcript = "short transcript"
+        let assembled = TranscriptContextAssembler.assemble(transcript: transcript, maxCharacters: 500)
+        XCTAssertEqual(assembled, transcript)
+    }
+
+    func testAssembleTruncatesWithMarkerWhenOverLimit() {
+        let transcript = String(repeating: "a", count: 1_000)
+        let assembled = TranscriptContextAssembler.assemble(transcript: transcript, maxCharacters: 200)
+        XCTAssertLessThanOrEqual(assembled.count, 200)
+        XCTAssertTrue(assembled.contains("[...truncated...]"))
+    }
+
+    func testChunkCreatesOverlappingSegments() {
+        let transcript = String(repeating: "x", count: 1_000)
+        let chunks = TranscriptContextAssembler.chunk(transcript: transcript, chunkSize: 300, overlap: 100)
+
+        XCTAssertGreaterThan(chunks.count, 1)
+        XCTAssertEqual(chunks[0].count, 300)
+        XCTAssertEqual(chunks[1].count, 300)
+    }
+}

--- a/Tests/MacParakeetTests/Models/DictationModelTests.swift
+++ b/Tests/MacParakeetTests/Models/DictationModelTests.swift
@@ -49,6 +49,9 @@ final class DictationModelTests: XCTestCase {
     func testProcessingModeRawValues() {
         XCTAssertEqual(Dictation.ProcessingMode.raw.rawValue, "raw")
         XCTAssertEqual(Dictation.ProcessingMode.clean.rawValue, "clean")
+        XCTAssertEqual(Dictation.ProcessingMode.formal.rawValue, "formal")
+        XCTAssertEqual(Dictation.ProcessingMode.email.rawValue, "email")
+        XCTAssertEqual(Dictation.ProcessingMode.code.rawValue, "code")
     }
 
     func testDictationStatusRawValues() {
@@ -56,6 +59,22 @@ final class DictationModelTests: XCTestCase {
         XCTAssertEqual(Dictation.DictationStatus.processing.rawValue, "processing")
         XCTAssertEqual(Dictation.DictationStatus.completed.rawValue, "completed")
         XCTAssertEqual(Dictation.DictationStatus.error.rawValue, "error")
+    }
+
+    func testProcessingModeHelpers() {
+        XCTAssertFalse(Dictation.ProcessingMode.raw.usesDeterministicPipeline)
+        XCTAssertTrue(Dictation.ProcessingMode.clean.usesDeterministicPipeline)
+        XCTAssertTrue(Dictation.ProcessingMode.formal.usesDeterministicPipeline)
+
+        XCTAssertFalse(Dictation.ProcessingMode.clean.usesLLMRefinement)
+        XCTAssertTrue(Dictation.ProcessingMode.formal.usesLLMRefinement)
+        XCTAssertTrue(Dictation.ProcessingMode.email.usesLLMRefinement)
+        XCTAssertTrue(Dictation.ProcessingMode.code.usesLLMRefinement)
+
+        XCTAssertEqual(Dictation.ProcessingMode.formal.llmRefinementMode, .formal)
+        XCTAssertEqual(Dictation.ProcessingMode.email.llmRefinementMode, .email)
+        XCTAssertEqual(Dictation.ProcessingMode.code.llmRefinementMode, .code)
+        XCTAssertNil(Dictation.ProcessingMode.clean.llmRefinementMode)
     }
 
     func testCodableRoundTrip() throws {

--- a/Tests/MacParakeetTests/Services/DictationServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/DictationServiceTests.swift
@@ -6,6 +6,7 @@ final class DictationServiceTests: XCTestCase {
     var mockAudio: MockAudioProcessor!
     var mockSTT: MockSTTClient!
     var mockClipboard: MockClipboardService!
+    var mockLLM: MockLLMService!
     var dictationRepo: DictationRepository!
 
     override func setUp() async throws {
@@ -13,6 +14,7 @@ final class DictationServiceTests: XCTestCase {
         mockAudio = MockAudioProcessor()
         mockSTT = MockSTTClient()
         mockClipboard = MockClipboardService()
+        mockLLM = MockLLMService()
         dictationRepo = DictationRepository(dbQueue: dbManager.dbQueue)
 
         service = DictationService(
@@ -64,4 +66,44 @@ final class DictationServiceTests: XCTestCase {
 
     // Note: Cancel flow tests, stop-when-not-recording, and STT error propagation
     // are covered in CancelFlowTests.swift to avoid duplication.
+
+    func testStopRecordingFormalModeUsesLLM() async throws {
+        await mockSTT.configure(result: STTResult(text: "hello world"))
+        await mockLLM.configureResponse(text: "Hello world from local LLM.")
+        let service = DictationService(
+            audioProcessor: mockAudio,
+            sttClient: mockSTT,
+            dictationRepo: dictationRepo,
+            clipboardService: mockClipboard,
+            llmService: mockLLM,
+            processingMode: { .formal }
+        )
+
+        try await service.startRecording()
+        let dictation = try await service.stopRecording()
+
+        XCTAssertEqual(dictation.processingMode, .formal)
+        XCTAssertEqual(dictation.cleanTranscript, "Hello world from local LLM.")
+        let requests = await mockLLM.requests
+        XCTAssertEqual(requests.count, 1)
+    }
+
+    func testStopRecordingFormalModeFallsBackToDeterministicOnLLMError() async throws {
+        await mockSTT.configure(result: STTResult(text: "um hello world"))
+        await mockLLM.configureError(LLMServiceError.generationFailed("test failure"))
+        let service = DictationService(
+            audioProcessor: mockAudio,
+            sttClient: mockSTT,
+            dictationRepo: dictationRepo,
+            clipboardService: mockClipboard,
+            llmService: mockLLM,
+            processingMode: { .formal }
+        )
+
+        try await service.startRecording()
+        let dictation = try await service.stopRecording()
+
+        XCTAssertEqual(dictation.processingMode, .formal)
+        XCTAssertEqual(dictation.cleanTranscript, "Hello world")
+    }
 }

--- a/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
@@ -27,12 +27,14 @@ final class TranscriptionServiceTests: XCTestCase {
     var service: TranscriptionService!
     var mockAudio: MockAudioProcessor!
     var mockSTT: MockSTTClient!
+    var mockLLM: MockLLMService!
     var transcriptionRepo: TranscriptionRepository!
 
     override func setUp() async throws {
         let dbManager = try DatabaseManager()
         mockAudio = MockAudioProcessor()
         mockSTT = MockSTTClient()
+        mockLLM = MockLLMService()
         transcriptionRepo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
 
         service = TranscriptionService(
@@ -216,5 +218,41 @@ final class TranscriptionServiceTests: XCTestCase {
         let created = FileManager.default.createFile(atPath: url.path, contents: Data("audio".utf8))
         XCTAssertTrue(created)
         return url
+    }
+
+    func testTranscribeFileEmailModeUsesLLM() async throws {
+        await mockSTT.configure(result: STTResult(text: "meeting moved to 3pm"))
+        await mockLLM.configureResponse(text: "Subject: Schedule Update\n\nThe meeting has been moved to 3 PM.")
+        let service = TranscriptionService(
+            audioProcessor: mockAudio,
+            sttClient: mockSTT,
+            transcriptionRepo: transcriptionRepo,
+            llmService: mockLLM,
+            processingMode: { .email }
+        )
+
+        let fileURL = URL(fileURLWithPath: "/tmp/test.mp3")
+        let result = try await service.transcribe(fileURL: fileURL)
+
+        XCTAssertEqual(result.cleanTranscript, "Subject: Schedule Update\n\nThe meeting has been moved to 3 PM.")
+        let requests = await mockLLM.requests
+        XCTAssertEqual(requests.count, 1)
+    }
+
+    func testTranscribeFileEmailModeFallsBackToDeterministic() async throws {
+        await mockSTT.configure(result: STTResult(text: "um meeting moved to 3pm"))
+        await mockLLM.configureError(LLMServiceError.generationFailed("timeout"))
+        let service = TranscriptionService(
+            audioProcessor: mockAudio,
+            sttClient: mockSTT,
+            transcriptionRepo: transcriptionRepo,
+            llmService: mockLLM,
+            processingMode: { .email }
+        )
+
+        let fileURL = URL(fileURLWithPath: "/tmp/test.mp3")
+        let result = try await service.transcribe(fileURL: fileURL)
+
+        XCTAssertEqual(result.cleanTranscript, "Meeting moved to 3pm")
     }
 }

--- a/Tests/MacParakeetTests/TextProcessing/TextRefinementServiceTests.swift
+++ b/Tests/MacParakeetTests/TextProcessing/TextRefinementServiceTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class TextRefinementServiceTests: XCTestCase {
+    func testCleanModeReturnsDeterministicText() async {
+        let service = TextRefinementService()
+        let result = await service.refine(
+            rawText: "um hello world",
+            mode: .clean,
+            customWords: [],
+            snippets: []
+        )
+
+        XCTAssertEqual(result.text, "Hello world")
+        XCTAssertEqual(result.path, .deterministic)
+    }
+
+    func testFormalModeUsesLLMWhenAvailable() async {
+        let mockLLM = MockLLMService()
+        await mockLLM.configureResponse(text: "Hello world from LLM.")
+        let service = TextRefinementService(llmService: mockLLM)
+
+        let result = await service.refine(
+            rawText: "hello world",
+            mode: .formal,
+            customWords: [],
+            snippets: []
+        )
+
+        XCTAssertEqual(result.text, "Hello world from LLM.")
+        XCTAssertEqual(result.path, .llm)
+        let requests = await mockLLM.requests
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertTrue(requests[0].prompt.contains("formal"))
+    }
+
+    func testFormalModeFallsBackWhenLLMFails() async {
+        let mockLLM = MockLLMService()
+        await mockLLM.configureError(LLMServiceError.generationFailed("boom"))
+        let service = TextRefinementService(llmService: mockLLM)
+
+        let result = await service.refine(
+            rawText: "um hello world",
+            mode: .formal,
+            customWords: [],
+            snippets: []
+        )
+
+        XCTAssertEqual(result.text, "Hello world")
+        XCTAssertEqual(result.path, .llmFallback)
+        XCTAssertNotNil(result.fallbackReason)
+    }
+}

--- a/Tests/MacParakeetTests/TextProcessing/TextRefinementServiceTests.swift
+++ b/Tests/MacParakeetTests/TextProcessing/TextRefinementServiceTests.swift
@@ -50,4 +50,22 @@ final class TextRefinementServiceTests: XCTestCase {
         XCTAssertEqual(result.path, .llmFallback)
         XCTAssertNotNil(result.fallbackReason)
     }
+
+    func testFormalModeSkipsLLMWhenDeterministicTextIsEmpty() async {
+        let mockLLM = MockLLMService()
+        await mockLLM.configureResponse(text: "Should not be used")
+        let service = TextRefinementService(llmService: mockLLM)
+
+        let result = await service.refine(
+            rawText: "um uh uhh",
+            mode: .formal,
+            customWords: [],
+            snippets: []
+        )
+
+        XCTAssertEqual(result.text, "")
+        XCTAssertEqual(result.path, .deterministic)
+        let requests = await mockLLM.requests
+        XCTAssertEqual(requests.count, 0)
+    }
 }

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -123,6 +123,16 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertFalse(testDefaults.bool(forKey: "saveTranscriptionAudio"))
     }
 
+    func testProcessingModePersists() {
+        viewModel.processingMode = Dictation.ProcessingMode.email.rawValue
+        XCTAssertEqual(testDefaults.string(forKey: "processingMode"), Dictation.ProcessingMode.email.rawValue)
+    }
+
+    func testInvalidProcessingModeFallsBackToClean() {
+        viewModel.processingMode = "invalid-mode"
+        XCTAssertEqual(viewModel.processingMode, Dictation.ProcessingMode.clean.rawValue)
+    }
+
     // MARK: - Permissions
 
     func testRefreshPermissionsUpdatesGrantedState() async throws {

--- a/docs/blog/using-all-three-chips.md
+++ b/docs/blog/using-all-three-chips.md
@@ -16,7 +16,7 @@ MacParakeet does two things with AI:
 
 1. **Speech-to-text** — We use NVIDIA's Parakeet TDT, a 600-million-parameter model that turns your voice into text. When you press your hotkey and speak, Parakeet transcribes your speech at over 150x real-time speed.
 
-2. **Text refinement** — We use Qwen3-4B, a 4-billion-parameter language model that cleans up, reformats, and refines your dictated text. Raw speech becomes polished prose — formal tone, email format, code comments, whatever you need.
+2. **Text refinement** — We use Qwen3-8B, an 8-billion-parameter language model that cleans up, reformats, and refines your dictated text. Raw speech becomes polished prose — formal tone, email format, code comments, whatever you need.
 
 Both models run entirely on your Mac. No cloud. No API calls. No data leaving your machine.
 
@@ -57,13 +57,13 @@ MLX is Apple's machine learning framework, and it's fast — the fastest way to 
 - Communicating with our Swift app over JSON-RPC (a text protocol over stdin/stdout)
 - Parakeet running on the GPU via MLX/Metal
 
-For the LLM (Qwen3-4B), we use **MLX-Swift** — the native Swift version of the same framework. Also runs on the GPU via Metal.
+For the LLM (Qwen3-8B), we use **MLX-Swift** — the native Swift version of the same framework. Also runs on the GPU via Metal.
 
 Here's what that architecture looked like:
 
 ```
 CPU:  MacParakeet app (UI, hotkeys, clipboard, history)
-GPU:  Parakeet STT (via Python/MLX) + Qwen3-4B LLM (via MLX-Swift)
+GPU:  Parakeet STT (via Python/MLX) + Qwen3-8B LLM (via MLX-Swift)
 ANE:  [idle]
 ```
 
@@ -83,16 +83,16 @@ You speak → Parakeet transcribes (GPU) → Qwen3 refines (GPU) → polished te
 
 Both steps run on the GPU. They run sequentially — Parakeet finishes, then Qwen3 starts — so they don't literally fight for cycles at the same moment. But they do share the GPU's memory pool.
 
-Parakeet via MLX occupies roughly 2GB of GPU memory. Qwen3-4B at 4-bit quantization needs another 2.5-4GB. On an 8GB Mac (the most common configuration for MacBooks), that leaves very little room for macOS itself. The math gets tight:
+Parakeet via MLX occupies roughly 2GB of GPU memory. Qwen3-8B at 4-bit quantization needs another ~5GB. On an 8GB Mac (the most common configuration for MacBooks), that leaves very little room for macOS itself. The math gets tight:
 
 | What | Memory |
 |------|--------|
 | Parakeet STT (MLX/GPU) | ~2GB |
-| Qwen3-4B LLM (MLX/GPU) | ~2.5-4GB |
+| Qwen3-8B LLM (MLX/GPU) | ~5 GB |
 | macOS + app overhead | ~2-3GB |
-| **Total** | **~6.5-9GB** |
+| **Total** | **~9-10GB** |
 
-On an 8GB machine, that's either just barely fitting or actively swapping. And this is before the user opens a browser or Slack alongside MacParakeet.
+On an 8GB machine, that's well over budget and actively swapping. And this is before the user opens a browser or Slack alongside MacParakeet.
 
 Meanwhile, the Neural Engine — a chip Apple designed specifically for running neural networks efficiently — is doing absolutely nothing.
 
@@ -127,7 +127,7 @@ With FluidAudio, we can put each workload on the chip it belongs on:
 
 ```
 CPU:  MacParakeet app (UI, hotkeys, clipboard, history)
-GPU:  Qwen3-4B LLM (via MLX-Swift)  — full GPU, no sharing
+GPU:  Qwen3-8B LLM (via MLX-Swift)  — full GPU, no sharing
 ANE:  Parakeet STT (via FluidAudio/CoreML) — dedicated ML chip, finally used
 ```
 

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -78,6 +78,15 @@ swift run macparakeet-cli flow words list
 swift run macparakeet-cli flow snippets list
 ```
 
+### Local LLM checks
+
+```bash
+swift run macparakeet-cli llm smoke-test --stats
+swift run macparakeet-cli llm generate "Summarize this paragraph in one sentence: ..."
+swift run macparakeet-cli llm refine formal "quick unpolished draft"
+swift run macparakeet-cli llm command "Translate to Spanish" "Hello, how are you?"
+```
+
 ## Notes
 
 - CLI validates core service behavior (STT, conversion, pipeline, persistence) but does **not** validate GUI-only flows (windowing/menu bar, hotkey overlay, accessibility-driven paste UX).

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -38,6 +38,14 @@ swift run macparakeet-cli transcribe "<FILE_OR_YOUTUBE_URL>" \
   --downloaded-audio keep
 ```
 
+AI refinement mode (formal/email/code) with local Qwen3-8B:
+
+```bash
+swift run macparakeet-cli transcribe "<FILE_OR_YOUTUBE_URL>" \
+  --mode formal \
+  --downloaded-audio app-default
+```
+
 ## Entitlements/Trial Gating Parity
 
 Enable this only when validating license/trial behavior:

--- a/docs/competitive-analysis.md
+++ b/docs/competitive-analysis.md
@@ -273,9 +273,9 @@ MacParakeet's opportunity is to be the first app that nails all four. WisprFlow 
 
 ### Intentional Gaps
 
-**Course correction** (WisprFlow): "Let's meet at 2... actually 3" → "Let's meet at 3". Deferred — requires multi-turn LLM conversation tracking, adds significant complexity for a niche use case. Qwen3-4B can't reliably handle this in a single pass. May revisit post-launch if user demand warrants it.
+**Course correction** (WisprFlow): "Let's meet at 2... actually 3" → "Let's meet at 3". Deferred — requires multi-turn LLM conversation tracking, adds significant complexity for a niche use case. Qwen3-8B can't reliably handle this in a single pass. May revisit post-launch if user demand warrants it.
 
-**Context awareness** (WisprFlow): Reading the active app window to inform AI output. Aspirational future feature — local implementation via Accessibility APIs + Qwen3-4B is possible but unscheduled. No version commitment.
+**Context awareness** (WisprFlow): Reading the active app window to inform AI output. Aspirational future feature — local implementation via Accessibility APIs + Qwen3-8B is possible but unscheduled. No version commitment.
 
 ---
 

--- a/docs/planning/2026-02-local-llm-planning-pack.md
+++ b/docs/planning/2026-02-local-llm-planning-pack.md
@@ -1,0 +1,26 @@
+# Local LLM Planning Pack (Qwen3-8B)
+
+Last updated: 2026-02-13
+Scope: Production planning for local LLM integration in MacParakeet.
+
+## Included Artifacts
+
+1. Decision record: `spec/adr/008-local-llm-runtime-and-model.md`
+2. Integration spec: `spec/11-llm-integration.md`
+3. Benchmark protocol: `docs/planning/2026-02-qwen3-8b-benchmark-plan.md`
+4. Execution checklist: `plans/active/2026-02-qwen3-8b-implementation-checklist.md`
+5. Risk register: `docs/planning/llm-runtime-risk-register.md`
+
+## What This Enables
+
+1. A single, locked baseline for implementation (`mlx-swift-lm` + Qwen3-8B).
+2. Ordered PR slices for shipping without architecture churn.
+3. Repeatable quality/performance evaluation with practical metrics.
+4. Explicit risk ownership and mitigation before implementation pressure rises.
+
+## Notes
+
+- This pack aligns with local-only constraints and existing ADRs.
+- Benchmark metrics are intentionally informational, not hard release gates.
+- If upstream runtime conditions materially change, re-run the runtime revalidation checklist:
+  - `docs/runtime-revalidation-checklist.md`

--- a/docs/planning/2026-02-qwen3-8b-benchmark-plan.md
+++ b/docs/planning/2026-02-qwen3-8b-benchmark-plan.md
@@ -1,0 +1,87 @@
+# Qwen3-8B Benchmark Plan (macOS Local)
+
+Last updated: 2026-02-13
+Purpose: Establish repeatable, practical measurements for local Qwen3-8B quality and performance in MacParakeet.
+
+## Scope
+
+This plan validates the production baseline:
+
+- Runtime: `mlx-swift-lm`
+- Model: `mlx-community/Qwen3-8B-4bit`
+- Use cases: refinement, command transforms, transcript chat readiness
+
+## Principles
+
+1. Benchmarks are **decision support**, not hard release gates.
+2. Prioritize user-perceived responsiveness and output quality over synthetic max throughput.
+3. Keep runs reproducible and scriptable.
+
+## Test Matrix
+
+| Dimension | Values |
+|-----------|--------|
+| Hardware class | 8 GB, 16 GB, 32 GB Apple Silicon |
+| Thermal state | cold start, warmed session |
+| Prompt type | refinement, command transform, transcript QA |
+| Input length | short, medium, long |
+
+## Workloads
+
+1. Refinement short: 40-80 words from dictation.
+2. Refinement long: 300-600 words.
+3. Command transforms: rewrite, summarize, translate, formalize.
+4. Transcript QA: 5-10 minute transcript chunk, factual question answering.
+
+## Metrics
+
+1. Time-to-first-token (cold/warm).
+2. End-to-end completion time.
+3. Tokens/sec during generation.
+4. Peak memory footprint and memory pressure events.
+5. Output quality rubric (instruction adherence, factuality, formatting correctness).
+
+## Suggested Informational Targets
+
+These are guidance targets for internal quality tracking only:
+
+- No app hang/crash under repeated invocations.
+- Warm-path refinement feels interactive to user.
+- Output passes manual quality check in >= 90% of sampled prompts.
+
+## Run Procedure
+
+1. Run deterministic baseline (no LLM) for control references.
+2. Run Qwen3-8B benchmarks in cold and warm conditions.
+3. Record results in a single markdown table per machine.
+4. Capture regressions versus last accepted run.
+
+## Output Template
+
+```md
+## Machine
+- Device:
+- macOS:
+- Xcode/Swift:
+
+## Results
+| Scenario | Cold TTFB | Warm TTFB | E2E | Peak Mem | Quality |
+|----------|-----------|-----------|-----|----------|---------|
+| refine-short | | | | | |
+| refine-long  | | | | | |
+| command      | | | | | |
+| transcript-qa| | | | | |
+
+## Notes
+- Observed regressions:
+- User-visible issues:
+- Keep / tune / investigate:
+```
+
+## Decision Outcomes
+
+After each benchmark cycle, classify:
+
+1. `keep baseline` - no action.
+2. `tune prompts/runtime` - minor optimization work.
+3. `trigger runtime revalidation` - deeper alternative evaluation.

--- a/docs/planning/llm-runtime-risk-register.md
+++ b/docs/planning/llm-runtime-risk-register.md
@@ -1,0 +1,30 @@
+# LLM Runtime Risk Register (Qwen3-8B + MLX-Swift-LM)
+
+Last updated: 2026-02-13
+
+## Risk Matrix
+
+| ID | Risk | Likelihood | Impact | Mitigation | Owner |
+|----|------|------------|--------|------------|-------|
+| R1 | MLX/MLX-Swift-LM compatibility regression | Medium | High | Pin versions, run local parity + CI checks before upgrades | Core |
+| R2 | Memory pressure on 8 GB devices | Medium | High | Lazy load, idle unload, bounded context, fallback on failure | Core |
+| R3 | First-use latency feels slow | High | Medium | Explicit loading indicator, prewarm option, prompt sizing discipline | UX/Core |
+| R4 | Prompt regressions reduce output quality | Medium | Medium | Prompt snapshot tests + benchmark quality rubric | Core |
+| R5 | Silent failure causes user confusion | Low | High | Mandatory fallback + user-safe notice + structured logs | Core |
+| R6 | Upstream model revision drift | Medium | Medium | Lock model ID, controlled revalidation cadence | Core |
+| R7 | Scope creep (multi-model complexity too early) | Medium | Medium | Enforce ADR-008 single-model baseline for v0.2/v0.3 | Product/Core |
+| R8 | Transcript chat context overflow | Medium | Medium | Chunking/truncation policy and explicit context limits | Core |
+
+## Trigger Conditions
+
+Escalate to revalidation if any of the following occur:
+
+1. Two consecutive benchmark cycles show material quality/perf regression.
+2. Runtime upgrade causes repeated CI or local instability.
+3. User-visible OOM/pressure events on target hardware class.
+
+## Contingency Paths
+
+1. Keep deterministic-only mode fully functional as a safe baseline.
+2. Temporarily disable AI modes via feature flag if runtime becomes unstable.
+3. Evaluate fallback model tier (4B class) only if 8B baseline becomes untenable on supported hardware.

--- a/docs/research/fluidaudio-stt-migration.md
+++ b/docs/research/fluidaudio-stt-migration.md
@@ -23,11 +23,11 @@ Today, MacParakeet uses **two of three chips**:
 
 ```
 CPU: [App logic, UI, hotkeys, clipboard]
-GPU: [Parakeet STT] + [Qwen3-4B LLM]   ← two ML workloads sharing one chip
+GPU: [Parakeet STT] + [Qwen3-8B LLM]   ← two ML workloads sharing one chip
 ANE: [idle]                               ← dedicated ML chip sitting unused
 ```
 
-Both Parakeet (STT) and Qwen3-4B (LLM) run on the GPU via Metal/MLX. They share the GPU memory pool. On 8GB Macs (base M1/M2/M3/M4), this creates real memory pressure — the Qwen3-4B model alone occupies ~2.5-4GB.
+Both Parakeet (STT) and Qwen3-8B (LLM) run on the GPU via Metal/MLX. They share the GPU memory pool. On 8GB Macs (base M1/M2/M3/M4), this creates real memory pressure — the Qwen3-8B model alone occupies ~5 GB.
 
 **The ANE exists specifically for neural network inference, and we're not using it.**
 
@@ -122,14 +122,14 @@ With FluidAudio CoreML, each ML workload runs on the chip it was designed for:
 
 ```
 CPU: [App logic, UI, hotkeys, clipboard]
-GPU: [Qwen3-4B LLM]                      ← full GPU dedicated to text refinement
+GPU: [Qwen3-8B LLM]                      ← full GPU dedicated to text refinement
 ANE: [Parakeet STT]                       ← dedicated ML chip, finally used
 ```
 
 The dictation-to-refinement pipeline becomes:
 
 ```
-Audio → [Parakeet on ANE] → raw text → [Qwen3-4B on GPU] → refined text
+Audio → [Parakeet on ANE] → raw text → [Qwen3-8B on GPU] → refined text
 ```
 
 **What this means in practice:**
@@ -138,7 +138,7 @@ Audio → [Parakeet on ANE] → raw text → [Qwen3-4B on GPU] → refined text
 - **Better memory efficiency** — FluidAudio benchmarks show ~66 MB peak working RAM for the TDT encoder (~130 MB with vocabulary boosting), dramatically lower than the ~2GB+ MLX/GPU footprint. Total memory including memory-mapped model files is higher but still an improvement. On 8GB Macs, this matters.
 - **Better accuracy** — FluidAudio's CoreML path achieves 2.1-2.5% WER vs our current ~6.3% on MLX. Same Parakeet model weights, but FluidAudio's optimized decoding produces measurably better results.
 - **Lower power** — The ANE is purpose-built for inference and is significantly more power-efficient than running the same workload on the GPU.
-- **Scales with features** — As we add command mode, more AI refinement modes, and heavier Qwen3-4B usage, the GPU isn't also carrying STT. This separation becomes more valuable over time, not less.
+- **Scales with features** — As we add command mode, more AI refinement modes, and heavier Qwen3-8B usage, the GPU isn't also carrying STT. This separation becomes more valuable over time, not less.
 
 ### Unified Memory: The Shared Bottleneck
 
@@ -294,13 +294,13 @@ The CoreML model bundle for `parakeet-tdt-0.6b-v3-coreml` is **~6 GB** on Huggin
 
 ## Decision
 
-**Migrate from parakeet-mlx (Python) to FluidAudio CoreML (Swift). Do it now — before v0.2 AI refinement adds Qwen3-4B to the GPU.**
+**Migrate from parakeet-mlx (Python) to FluidAudio CoreML (Swift). Do it now — before v0.2 AI refinement adds Qwen3-8B to the GPU.**
 
 The CoreML/ANE path is the better architecture — three workloads on three chips instead of two workloads fighting over one, native Swift throughout, fewer moving parts, better accuracy. Use the silicon Apple put in the machine.
 
 ### Why now, not later
 
-- v0.2 is adding Qwen3-4B (LLM) to the GPU — the exact moment GPU contention becomes real
+- v0.2 is adding Qwen3-8B (LLM) to the GPU — the exact moment GPU contention becomes real
 - Migrating now means every feature built on top (AI refinement, command mode) starts on the correct architecture
 - The STT protocol abstraction (`STTClientProtocol`) makes the swap clean — consumers don't know the backend changed
 - Delaying means building more features on Python/MLX, then migrating them later — more work, more risk
@@ -363,7 +363,7 @@ After removing Python, FFmpeg is provided as a bundled app resource.
 
 - `STTClientProtocol` interface — consumers don't know or care about the backend
 - `STTResult` format — text + word timestamps + confidence scores
-- Qwen3-4B via MLX-Swift — the LLM path stays the same
+- Qwen3-8B via MLX-Swift — the LLM path stays the same
 - `AudioFileConverter` — still converts video files via FFmpeg (binary, not pip package)
 - `YouTubeDownloader` — still uses yt-dlp (standalone binary, not pip package)
 - All existing tests against the STT protocol — same contract, new implementation
@@ -382,9 +382,9 @@ After removing Python, FFmpeg is provided as a bundled app resource.
 | `imageio-ffmpeg` dependency | FFmpeg bundled directly |
 | `yt-dlp-ejs` dependency | Use system JS runtime or bundle QuickJS |
 
-### Additional opportunity: Qwen3-4B-Instruct-2507
+### Additional opportunity: Qwen3-8B as primary LLM
 
-While migrating the STT backend, also upgrade the LLM from `Qwen3-4B` to `Qwen3-4B-Instruct-2507`. The July 2025 update ranked #1 among all small language models for instruction following — directly relevant for our text refinement and command mode use cases. This is a model ID change, not an architecture change.
+While migrating the STT backend, the LLM is Qwen3-8B (`mlx-community/Qwen3-8B-4bit`). The 8B model is the most consistent across all benchmarks, handling text refinement, command mode, and chat-with-transcript features. ~5 GB RAM at 4-bit quantization. Monitor for a potential `Qwen3-8B-Instruct-2507` update that could further improve instruction following.
 
 ## Current STT Architecture (What We're Replacing)
 
@@ -451,4 +451,4 @@ YouTube:   yt-dlp (standalone) → .m4a → AudioFileConverter (FFmpeg binary) �
 - [Parakeet TDT v3 CoreML (HuggingFace)](https://huggingface.co/FluidInference/parakeet-tdt-0.6b-v3-coreml)
 - [VoiceInk GitHub](https://github.com/Beingpax/VoiceInk) — production app using FluidAudio
 - [mlx-swift-lm GitHub](https://github.com/ml-explore/mlx-swift-lm) — Qwen3 LLM runtime (unchanged)
-- [Qwen3-4B-Instruct-2507 (HuggingFace)](https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507) — recommended LLM upgrade
+- [Qwen3-8B (HuggingFace)](https://huggingface.co/Qwen/Qwen3-8B) — primary LLM choice

--- a/docs/research/open-source-models-landscape-2026.md
+++ b/docs/research/open-source-models-landscape-2026.md
@@ -24,7 +24,7 @@ Deep dive into the current state of open source models relevant to MacParakeet: 
 **Key takeaways:**
 
 - **At snapshot time, Parakeet TDT 0.6B-v2 was assessed as the best English-first STT choice.** Current project decision is v3-only via FluidAudio CoreML (see ADR-007 and spec docs).
-- **Qwen3-4B is still the right LLM**, but the **July 2025 "2507" update** is a meaningful upgrade — it ranked #1 among small language models for instruction following. Available as `mlx-community/Qwen3-4B-Instruct-2507-4bit`.
+- **Qwen3-8B is the right LLM** — the most consistent model across all benchmarks, chosen for text refinement, command mode, and chat-with-transcript features. Available as `mlx-community/Qwen3-8B-4bit`.
 - **MLX is now Apple-endorsed** (WWDC 2025). MLX-Swift has breaking API changes. The ecosystem is maturing fast.
 - **FluidAudio** is the most interesting new development — a Swift CoreML package that runs Parakeet natively on the ANE without a Python daemon. VoiceInk (competitor) already uses it.
 - **No Whisper V4, no Qwen4, no Llama 4 small models.** The landscape is evolutionary, not revolutionary.
@@ -118,7 +118,7 @@ Apple introduced native on-device STT at WWDC 2025:
 
 ## Small LLMs (Sub-8B)
 
-MacParakeet uses Qwen3-4B via MLX-Swift for command mode and AI text refinement.
+MacParakeet uses Qwen3-8B via MLX-Swift for command mode, AI text refinement, and chat-with-transcript features.
 
 ### Qwen3 Family (Alibaba)
 
@@ -142,8 +142,8 @@ The most active player in the small model space.
 
 | Model | Params | Instruction Following | Memory (4-bit MLX) | Release | License |
 |-------|--------|----------------------|---------------------|---------|---------|
-| **Qwen3-4B-Instruct-2507** | 4B | **Best in class** | ~2.5-4GB | Jul 2025 | Apache 2.0 |
-| Qwen3-8B | 8B | Very strong, most consistent | ~4-5GB | Apr 2025 | Apache 2.0 |
+| Qwen3-4B-Instruct-2507 | 4B | Best in class (4B tier) | ~2.5-4GB | Jul 2025 | Apache 2.0 |
+| **Qwen3-8B** | 8B | **Best in class, most consistent** | **~5 GB** | Apr 2025 | Apache 2.0 |
 | Gemma 3 4B | 4B | Good | ~3GB | Mar 2025 | Apache-like |
 | **Gemma 3n E4B** | 8B (3GB eff.) | Good | ~3GB | Jun 2025 | Apache-like |
 | Phi-4-mini | 3.8B | Strong | ~2.5-3GB | Feb 2025 | MIT |
@@ -158,15 +158,15 @@ The most active player in the small model space.
 
 ### Task-Specific Assessment
 
-For MacParakeet's use cases (text cleanup/rewriting + command mode editing):
+For MacParakeet's use cases (text cleanup/rewriting + command mode editing + chat-with-transcript):
 
-1. **Qwen3-4B-Instruct-2507** — Best choice. #1 SLM for instruction following. The July 2025 update specifically improved text generation quality. Dual-mode (thinking for complex edits, non-thinking for quick cleanup).
+1. **Qwen3-8B** — Primary choice. Most consistent model across all benchmarks at ~5 GB RAM (4-bit). Handles text refinement, command mode, and longer-context tasks (chat with transcript) better than smaller models. Dual-mode (thinking for complex edits, non-thinking for quick cleanup). Apache 2.0.
 
-2. **Qwen3-8B** — Marginal quality upgrade, ~4-5GB RAM. Most consistent across all benchmarks. Consider if 4B proves insufficient for command mode.
+2. **Qwen3-4B-Instruct-2507** — Strong alternative at 4B tier. #1 SLM for instruction following. The July 2025 update specifically improved text generation quality. Could serve as a lighter fallback for memory-constrained machines.
 
 3. **Gemma 3n E4B** — Interesting memory efficiency (8B params, ~3GB effective). Newer, less MLX tooling. Worth evaluating.
 
-4. **Phi-4-mini** — Good fallback (3.8B, strong reasoning). Slightly behind Qwen3-4B-2507.
+4. **Phi-4-mini** — Good fallback (3.8B, strong reasoning). Slightly behind Qwen3 models.
 
 5. **Ministral 3B** — Newest (Dec 2025), Apache 2.0. Less community MLX optimization.
 
@@ -214,7 +214,7 @@ The high-level package is now **[mlx-swift-lm](https://github.com/ml-explore/mlx
 ### mlx-community on HuggingFace
 
 Thousands of pre-converted, quantized models. Key for MacParakeet:
-- `mlx-community/Qwen3-4B-Instruct-2507-4bit` — Updated Qwen3-4B
+- `mlx-community/Qwen3-8B-4bit` — Primary LLM for MacParakeet
 - `Qwen/Qwen3-30B-A3B-MLX-4bit` — MoE option (if RAM allows)
 - Qwen3 collection, Qwen3-Next collection, Qwen3-VL collection all available
 
@@ -239,7 +239,7 @@ Introduced at WWDC 2025 — access to Apple's on-device ~3B LLM powering Apple I
 - Free inference, Swift-native, offline capable.
 - Good for: summarization, entity extraction, text refinement, short dialog.
 - **Limitations:** Requires macOS 26, not a general chatbot, no fine-tuning, text-only, no control over model behavior.
-- **Not a replacement for Qwen3-4B** — MacParakeet targets macOS 14.2+, and the Foundation model can't handle command mode editing. Could be a supplementary option for simple cleanup on macOS 26+ users.
+- **Not a replacement for Qwen3-8B** — MacParakeet targets macOS 14.2+, and the Foundation model can't handle command mode editing. Could be a supplementary option for simple cleanup on macOS 26+ users.
 
 ### Emerging Inference Engines
 
@@ -316,7 +316,7 @@ Apple Silicon's unified memory = zero-copy for MLX operations. A $2,000 Mac Stud
 
 ### Immediate (No Architecture Changes)
 
-1. **Upgrade LLM to Qwen3-4B-Instruct-2507.** The July 2025 update ranked #1 among SLMs for instruction following — exactly what MacParakeet needs for text refinement and command mode. Change the HuggingFace model ID to `mlx-community/Qwen3-4B-Instruct-2507-4bit`. Minimal code change, meaningful quality improvement.
+1. **Use Qwen3-8B as the primary LLM.** The most consistent model across all benchmarks, handling text refinement, command mode, and chat-with-transcript features. HuggingFace model ID: `mlx-community/Qwen3-8B-4bit`. ~5 GB RAM at 4-bit quantization.
 
 2. **Snapshot recommendation (historical): keep Parakeet TDT 0.6B-v2 for STT.** Current project decision is v3-only via FluidAudio CoreML.
 
@@ -332,13 +332,13 @@ Apple Silicon's unified memory = zero-copy for MLX operations. A $2,000 Mac Stud
    - Add speaker diarization, VAD, and streaming ASR for free.
    - This is a significant architectural change but would simplify distribution and improve the user experience.
 
-5. **Evaluate Qwen3-8B if command mode quality is insufficient.** Only ~4-5GB RAM at 4-bit. Most consistent model across all benchmarks. Marginal quality upgrade over 4B-2507 for text tasks, but potentially meaningful for complex voice commands.
+5. **Monitor Qwen3-8B-Instruct-2507 availability.** If a July 2025-style "2507" update becomes available for the 8B model (as `mlx-community/Qwen3-8B-Instruct-2507-4bit`), evaluate it as a drop-in upgrade for improved instruction following.
 
 ### Long-Term (Track for Future)
 
 6. **Apple SpeechAnalyzer** — Native API, excellent speed. But requires macOS 26+. Worth considering when MacParakeet's minimum OS version reaches Tahoe.
 
-7. **Apple Foundation Models** — Free on-device LLM via macOS 26+ API. Not a replacement for Qwen3 (too limited), but could supplement simple text cleanup at zero cost.
+7. **Apple Foundation Models** — Free on-device LLM via macOS 26+ API. Not a replacement for Qwen3-8B (too limited), but could supplement simple text cleanup at zero cost.
 
 8. **Gemma 3n E4B** — 8B params with only ~3GB effective memory via Per-Layer Embedding. Interesting efficiency play, but newer and less tested.
 
@@ -367,7 +367,7 @@ Apple Silicon's unified memory = zero-copy for MLX operations. A $2,000 Mac Stud
 
 ### Small LLMs
 - [Qwen3 Official Blog](https://qwenlm.github.io/blog/qwen3/)
-- [Qwen3-4B-Instruct-2507 (HuggingFace)](https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507)
+- [Qwen3-8B (HuggingFace)](https://huggingface.co/Qwen/Qwen3-8B)
 - [Qwen3-Next (VentureBeat)](https://venturebeat.com/ai/qwen3-next-debuts-with-impressively-efficient-performance-on-just-3b-active)
 - [Gemma 3 (Google DeepMind)](https://deepmind.google/models/gemma/gemma-3/)
 - [Gemma 3n (Google DeepMind)](https://deepmind.google/models/gemma/gemma-3n/)

--- a/docs/research/wisprflow-deep-dive.md
+++ b/docs/research/wisprflow-deep-dive.md
@@ -165,7 +165,7 @@ WisprFlow sends all audio to cloud servers for transcription. Context awareness 
 - **Privacy risk**: Every word spoken + screen content transmitted to third party. Unacceptable for legal, medical, financial, classified, or any sensitive context.
 - **Latency**: Server round-trip adds 2-5 seconds minimum, 20-30 seconds during peak. Local Parakeet on Apple Silicon is faster than the network round-trip.
 
-**MacParakeet advantage:** 100% local. Parakeet runs on-device. Qwen3-4B runs on-device. Zero network latency. Zero privacy risk.
+**MacParakeet advantage:** 100% local. Parakeet runs on-device. Qwen3-8B runs on-device. Zero network latency. Zero privacy risk.
 
 ### 2. $144-180/Year Subscription
 
@@ -189,7 +189,7 @@ Some users want voice-to-text but cannot or will not send audio to the cloud. Wi
 
 WisprFlow's context awareness reads screen content via accessibility APIs and sends it to cloud servers. Users who need context-aware dictation but can't share screen data have no option.
 
-**MacParakeet advantage:** Context awareness via local Qwen3-4B -- read screen context locally, process locally, never transmit. Same feature, zero privacy risk. (Future)
+**MacParakeet advantage:** Context awareness via local Qwen3-8B -- read screen context locally, process locally, never transmit. Same feature, zero privacy risk. (Future)
 
 ## Feature Parity Matrix
 
@@ -200,13 +200,13 @@ What MacParakeet needs to match or beat WisprFlow:
 | Push-to-talk (hold Fn) | Yes | v0.1 | Yes |
 | Double-tap persistent mode | Yes | v0.1 | Yes |
 | AI filler removal | Yes (cloud LLM) | v0.2 (deterministic pipeline) | Yes |
-| Grammar/punctuation | Yes (cloud LLM) | v0.2 (pipeline + Qwen3) | Yes |
+| Grammar/punctuation | Yes (cloud LLM) | v0.2 (pipeline + Qwen3-8B) | Yes |
 | Course correction | Yes (cloud LLM) | Not planned | -- |
-| Command Mode | Yes (cloud, Pro) | v0.3 (Qwen3-4B) | Yes |
+| Command Mode | Yes (cloud, Pro) | v0.3 (Qwen3-8B) | Yes |
 | Styles / context modes | Yes (cloud, English only) | v0.2 (raw, clean, formal, email, code) | Yes |
 | Personal dictionary | Yes (auto-learn) | v0.2 (custom words) | Yes |
 | Voice shortcuts | Yes | v0.2 (text snippets) | Yes |
-| Context awareness | Yes (cloud, screen reading) | Future (local Qwen3-4B + accessibility) | Yes |
+| Context awareness | Yes (cloud, screen reading) | Future (local Qwen3-8B + accessibility) | Yes |
 | File transcription | No | v0.1 | Yes |
 | 104+ languages | Yes | English-first (Parakeet v3: 25 European) | Yes |
 | Whisper mode | Yes | Not planned (niche) | -- |
@@ -220,7 +220,7 @@ What MacParakeet needs to match or beat WisprFlow:
 
 **WisprFlow, but local.**
 
-Take every feature that makes WisprFlow compelling -- push-to-talk, AI refinement, Command Mode, personal dictionary, context awareness -- and run it entirely on-device using Parakeet (155x realtime STT via FluidAudio CoreML on ANE) and Qwen3-4B (local LLM on GPU via MLX-Swift).
+Take every feature that makes WisprFlow compelling -- push-to-talk, AI refinement, Command Mode, personal dictionary, context awareness -- and run it entirely on-device using Parakeet (155x realtime STT via FluidAudio CoreML on ANE) and Qwen3-8B (local LLM on GPU via MLX-Swift).
 
 Then go further:
 - **File transcription** (WisprFlow is dictation-only, no file import)
@@ -229,7 +229,7 @@ Then go further:
 - **Reliable** = no cloud outages, no "works 60% of the time"
 - **Context awareness without cloud** = same feature, zero privacy risk
 
-Command Mode via local Qwen3-4B is the key Pro feature. WisprFlow proves the demand. MacParakeet delivers it without the cloud.
+Command Mode via local Qwen3-8B is the key Pro feature. WisprFlow proves the demand. MacParakeet delivers it without the cloud.
 
 ## Technical Notes for MacParakeet Implementation
 
@@ -238,10 +238,10 @@ Command Mode via local Qwen3-4B is the key Pro feature. WisprFlow proves the dem
 | WisprFlow Feature | MacParakeet Local Implementation |
 |-------------------|--------------------------------|
 | Cloud STT | Parakeet TDT 0.6B-v3 via FluidAudio CoreML/ANE (155x faster) |
-| Cloud LLM refinement | Qwen3-4B via MLX-Swift (on-device, ~2s cold start) |
-| Context awareness | macOS Accessibility API (AXUIElement) + local Qwen3 |
-| Auto-edit (filler/grammar) | Deterministic pipeline + Qwen3-4B |
-| Command Mode | Selected text + voice command -> Qwen3-4B -> replace |
+| Cloud LLM refinement | Qwen3-8B via MLX-Swift (on-device, ~2s cold start) |
+| Context awareness | macOS Accessibility API (AXUIElement) + local Qwen3-8B |
+| Auto-edit (filler/grammar) | Deterministic pipeline + Qwen3-8B |
+| Command Mode | Selected text + voice command -> Qwen3-8B -> replace |
 | Personal dictionary | SQLite custom_words table + pipeline lookup |
 | Voice shortcuts | SQLite text_snippets table + trigger detection |
 

--- a/docs/runtime-revalidation-checklist.md
+++ b/docs/runtime-revalidation-checklist.md
@@ -7,7 +7,7 @@ Keep local LLM runtime selection evidence-based over time (not one-time).
 
 Current baseline:
 - Primary runtime: MLX-Swift / MLX-Swift-LM
-- Model class: Qwen3-4B 4-bit
+- Model class: Qwen3-8B 4-bit
 - Platform: Apple Silicon macOS app (native Swift)
 
 ## Cadence

--- a/plans/active/2026-02-qwen3-8b-implementation-checklist.md
+++ b/plans/active/2026-02-qwen3-8b-implementation-checklist.md
@@ -1,6 +1,6 @@
 # Qwen3-8B Integration Checklist (Execution Order)
 
-Status: Active
+Status: In Progress
 Owner: Core app team
 Updated: 2026-02-13
 
@@ -37,6 +37,15 @@ Ship production-ready local LLM integration for refinement + command mode using 
 - Run benchmark protocol in `docs/planning/2026-02-qwen3-8b-benchmark-plan.md`.
 - Tune prompt templates and timeout budgets.
 - Fix memory/lifecycle edge cases discovered in test runs.
+
+## Progress Snapshot (2026-02-13)
+
+1. Completed: foundation seam + fallback-safe wiring (`TextRefinementService`, deterministic fallback, tests).
+2. Completed: Qwen runtime integration with lazy load and idle unload in `MLXLLMService`.
+3. Completed: dictation/transcription context modes (`raw`, `clean`, `formal`, `email`, `code`) wired through app + CLI.
+4. Completed: transcript chat scaffolding via bounded context assembly utility.
+5. Remaining: command mode GUI flow (selection capture and in-place replace UX).
+6. Remaining: benchmark run execution/tuning pass on target hardware matrix.
 
 ## Tests Required per Slice
 

--- a/plans/active/2026-02-qwen3-8b-implementation-checklist.md
+++ b/plans/active/2026-02-qwen3-8b-implementation-checklist.md
@@ -1,0 +1,60 @@
+# Qwen3-8B Integration Checklist (Execution Order)
+
+Status: Active
+Owner: Core app team
+Updated: 2026-02-13
+
+## Objective
+
+Ship production-ready local LLM integration for refinement + command mode using Qwen3-8B with robust fallback behavior.
+
+## PR Slice Plan
+
+1. **Foundation seam**
+- Add `LLMServiceProtocol`, request/response models, and error taxonomy.
+- Add no-op/mock implementation for tests.
+- Wire dependency injection in call sites.
+
+2. **Fallback-safe wiring**
+- Integrate deterministic-first -> LLM-second flow for formal/email/code.
+- Implement timeout + empty-output guards.
+- Ensure fallback returns deterministic-safe output.
+
+3. **Qwen runtime integration**
+- Add `MLXQwenService` implementation for `mlx-swift-lm`.
+- Implement lazy load + idle unload lifecycle.
+- Add model availability and load-state handling.
+
+4. **Command mode integration**
+- Route selected text + spoken command through shared LLM seam.
+- Preserve current selection-replace UX behavior and error paths.
+
+5. **Transcript chat baseline scaffolding**
+- Add transcript context assembly utilities (bounded chunking/truncation).
+- Add chat request pathway behind feature flag if UI not ready.
+
+6. **Benchmark + hardening**
+- Run benchmark protocol in `docs/planning/2026-02-qwen3-8b-benchmark-plan.md`.
+- Tune prompt templates and timeout budgets.
+- Fix memory/lifecycle edge cases discovered in test runs.
+
+## Tests Required per Slice
+
+1. Unit: prompt and fallback behavior.
+2. Unit: service lifecycle (load, warm invoke, unload).
+3. Integration: dictation AI mode path with mock LLM.
+4. Integration: command mode transform path with mock LLM.
+5. Regression: deterministic mode unchanged.
+
+## Exit Criteria
+
+1. `swift test` green.
+2. AI modes produce valid transformed output with Qwen3-8B.
+3. LLM failure path is graceful and non-blocking.
+4. No Python/runtime-daemon dependency added.
+
+## Deferred (Explicitly Out of Scope)
+
+1. Multi-model runtime routing.
+2. Automatic model switching by hardware class.
+3. Long-context retrieval pipeline beyond bounded transcript chunking.

--- a/spec/00-vision.md
+++ b/spec/00-vision.md
@@ -206,7 +206,7 @@ WisprFlow charges $144-180/year. After 3-4 months of MacParakeet, you have saved
 ```
 
 - Voice commands that edit, rewrite, or transform selected text.
-- Powered by a local LLM (Qwen3-4B via MLX). No cloud.
+- Powered by a local LLM (Qwen3-8B via MLX). No cloud.
 - Works on any selected text in any application.
 - WisprFlow charges $12-15/mo for this. We do it locally for $0/mo after purchase.
 
@@ -319,9 +319,9 @@ In a market of subscriptions ($144-180/yr for WisprFlow) and premium pricing ($2
 
 ### 4. Local Command Mode
 
-WisprFlow's most compelling feature is voice commands: "fix the grammar," "make this shorter," "rewrite as bullets." They do it with cloud AI. We do it with a local LLM (Qwen3-4B via MLX-Swift).
+WisprFlow's most compelling feature is voice commands: "fix the grammar," "make this shorter," "rewrite as bullets." They do it with cloud AI. We do it with a local LLM (Qwen3-8B via MLX-Swift).
 
-This means command mode works offline, has no per-use cost, and keeps your text private. The quality of Qwen3-4B for text editing tasks is more than sufficient for the command set users actually need.
+This means command mode works offline, has no per-use cost, and keeps your text private. The quality of Qwen3-8B for text editing tasks is more than sufficient for the command set users actually need.
 
 ### 5. Focused Simplicity
 
@@ -458,7 +458,7 @@ The foundation. Dictation works. File transcription works. It is fast.
 Clean pipeline and AI refinement make dictation output polish-ready.
 
 - Clean text pipeline (deterministic: filler removal, custom words, snippets)
-- AI text refinement (Qwen3-4B: formal, email, code modes)
+- AI text refinement (Qwen3-8B: formal, email, code modes)
 - Custom words & snippets management UI
 - Personal dictionary (auto-learns vocabulary)
 
@@ -489,7 +489,7 @@ Ship-quality polish. App Store submission.
 |----------|--------|-----------|
 | **Platform** | macOS 14.2+, Apple Silicon only | Parakeet and MLX require Metal. Apple Silicon is the future. |
 | **STT engine** | Parakeet TDT 0.6B-v3 | Fastest and most accurate open-source STT. 155x realtime on ANE, ~2.5% WER via FluidAudio CoreML. |
-| **LLM** | Qwen3-4B via MLX-Swift | Best quality-to-size ratio for local inference. Dual-mode (thinking/non-thinking). |
+| **LLM** | Qwen3-8B via MLX-Swift | Best quality-to-size ratio for local inference. Dual-mode (thinking/non-thinking). |
 | **YouTube downloads** | Standalone yt-dlp | macOS binary, auto-updates via `--update`. No Python needed. |
 | **UI framework** | SwiftUI | Native Mac experience. Menu bar + window. |
 | **Database** | SQLite (GRDB) | Single file. No server. Dictation history, custom words, settings. |

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -31,7 +31,7 @@ See [00-vision.md](./00-vision.md) for positioning and market context.
 │  "Clean text automatically, refine with AI when needed"         │
 ├─────────────────────────────────────────────────────────────────┤
 │  • Clean text pipeline (deterministic: fillers, words, snippets) │
-│  • AI text refinement (Qwen3-4B: formal, email, code modes)    │
+│  • AI text refinement (Qwen3-8B: formal, email, code modes)    │
 │  • Custom words & snippets management UI                        │
 │  • Personal dictionary (auto-learns vocabulary)                 │
 └─────────────────────────────────────────────────────────────────┘
@@ -747,7 +747,7 @@ CREATE TABLE text_snippets (
 
 ### F8: AI Text Refinement
 
-**What:** LLM-powered text transformation for cases where deterministic cleanup is not enough. Uses Qwen3-4B via MLX-Swift, running entirely on-device.
+**What:** LLM-powered text transformation for cases where deterministic cleanup is not enough. Uses Qwen3-8B via MLX-Swift, running entirely on-device.
 
 **Context modes:**
 
@@ -762,7 +762,7 @@ CREATE TABLE text_snippets (
 Modes stack: Formal/Email/Code always run the clean pipeline first, then apply LLM refinement on top.
 
 **LLM details:**
-- Model: Qwen3-4B (4-bit quantized, `mlx-community/Qwen3-4B-4bit`)
+- Model: Qwen3-8B (4-bit quantized, `mlx-community/Qwen3-8B-4bit`)
 - Framework: MLX-Swift (Apple Silicon optimized)
 - Non-thinking mode for all refinement (fast, `temp=0.7, topP=0.8`)
 - System prompts per mode:
@@ -893,7 +893,7 @@ Modes stack: Formal/Email/Code always run the clean pipeline first, then apply L
 ├─────────────────────────────────────────────────────────────────┤
 │ 4. Processing                                                    │
 │    - Command transcribed via Parakeet                            │
-│    - Selected text + command sent to Qwen3-4B                    │
+│    - Selected text + command sent to Qwen3-8B                    │
 │    - LLM edits text according to command                         │
 ├─────────────────────────────────────────────────────────────────┤
 │ 5. Result                                                        │
@@ -928,7 +928,7 @@ Users can define and save custom command templates for repeated use.
 **Technical implementation:**
 - Read selected text via Accessibility API (`AXUIElement`)
 - Transcribe spoken command via Parakeet
-- Send `(selected_text, command)` to Qwen3-4B with system prompt: "Apply the user's command to the provided text. Return only the edited text, no explanation."
+- Send `(selected_text, command)` to Qwen3-8B with system prompt: "Apply the user's command to the provided text. Return only the edited text, no explanation."
 - Replace selected text by simulating Cmd+V with the result (same paste mechanism as dictation)
 - Thinking mode for command interpretation (`temp=0.6, topP=0.95`) to ensure accurate command understanding
 
@@ -1264,7 +1264,7 @@ new scheduling architecture.
 Share transcripts between Mac and iPhone. Capture in-person conversations on iPhone.
 
 ### F18: Translation
-Translate transcribed text to other languages using Qwen3-4B. Activated as a command mode command or processing mode.
+Translate transcribed text to other languages using Qwen3-8B. Activated as a command mode command or processing mode.
 
 ### F19: API / Shortcuts Integration
 Expose transcription as a macOS Shortcut action. Enable automation: "When I receive a voice memo, transcribe it."
@@ -1279,7 +1279,7 @@ Deep integration with code editors:
 - **Terminal:** Voice commands for git, build, test
 
 ### F22: Context Awareness
-Read surrounding text from the active app via macOS Accessibility APIs (AXUIElement) to produce better transcriptions. Knows "React" in a code editor, "react" in a therapy note. All processing local via Qwen3-4B -- no screen content ever leaves device.
+Read surrounding text from the active app via macOS Accessibility APIs (AXUIElement) to produce better transcriptions. Knows "React" in a code editor, "react" in a therapy note. All processing local via Qwen3-8B -- no screen content ever leaves device.
 
 ---
 
@@ -1290,7 +1290,7 @@ Read surrounding text from the active app via macOS Accessibility APIs (AXUIElem
 | Transcription speed | 155x realtime | Parakeet TDT on Apple Silicon (ANE via FluidAudio CoreML) |
 | Dictation latency | <500ms end-to-end | From Fn release to text appearing |
 | Clean pipeline | <1ms | Deterministic, no LLM |
-| LLM refinement | <5s | Qwen3-4B for formal/email/code modes |
+| LLM refinement | <5s | Qwen3-8B for formal/email/code modes |
 | Memory usage (idle) | <200MB | Menu bar + STT model standing by |
 | Memory usage (active) | <3GB | During transcription with both models loaded |
 | App size | <100MB | Plus ~6 GB STT model download on first run |
@@ -1315,7 +1315,7 @@ MacParakeet's brand is privacy. These are non-negotiable.
 
 **What "100% local" means:**
 - Parakeet STT runs on Apple Silicon Neural Engine (ANE) via FluidAudio CoreML -- no cloud API
-- Qwen3-4B LLM runs on Apple Silicon GPU via MLX-Swift/Metal -- no OpenAI, no Anthropic
+- Qwen3-8B LLM runs on Apple Silicon GPU via MLX-Swift/Metal -- no OpenAI, no Anthropic
 - Audio never leaves the device
 - Transcripts never leave the device
 - No "phone home" on launch, no update checks to our servers (App Store handles updates)
@@ -1421,7 +1421,7 @@ v0.4 Polish & Launch:
 Cross-cutting dependency:
 
       Parakeet STT ──► F1, F2, F10, F11, F13, F14, F15
-      Qwen3-4B LLM ──► F8, F10
+      Qwen3-8B LLM ──► F8, F10
       Accessibility ──► F1 (hotkey + paste), F10 (text selection)
       FFmpeg ──────────► F2, F11, F14
       yt-dlp ──────────► F11

--- a/spec/03-architecture.md
+++ b/spec/03-architecture.md
@@ -61,8 +61,8 @@
 │                                                                                  │
 │  ┌──────────────────────────────┐   ┌──────────────────────────────────────────┐ │
 │  │   Parakeet STT (In-Process)  │   │   MLX-Swift LLM (In-Process)             │ │
-│  │   FluidAudio CoreML on ANE   │   │   Qwen3-4B (4-bit quantized)             │ │
-│  │   ~66 MB working RAM         │   │   ~2.5 GB RAM                            │ │
+│  │   FluidAudio CoreML on ANE   │   │   Qwen3-8B (4-bit quantized)             │ │
+│  │   ~66 MB working RAM         │   │   ~5 GB RAM                              │ │
 │  │   ~2.5% WER, 155x realtime   │   │   Command mode + AI refinement           │ │
 │  └──────────────────────────────┘   └──────────────────────────────────────────┘ │
 │                                                                                  │
@@ -75,7 +75,7 @@
 │  │(Mic)     │  │ Hotkey)  │  │ Paste)      │  │ Control)     │               │
 │  └──────────┘  └──────────┘  └─────────────┘  └──────────────┘               │
 │                                                                                  │
-│  Total AI Memory: ~2.7 GB peak (Parakeet ~66 MB on ANE + LLM ~2.5 GB on GPU)   │
+│  Total AI Memory: ~5.2 GB peak (Parakeet ~66 MB on ANE + LLM ~5 GB on GPU)     │
 │  Recommended: 16 GB RAM (Apple Silicon only). Minimum: 8 GB.                    │
 └──────────────────────────────────────────────────────────────────────────────────┘
 ```
@@ -375,7 +375,7 @@ struct TimestampedWord: Sendable {
 **Architecture:**
 ```
 CPU:  MacParakeet app (UI, hotkeys, clipboard, history)
-GPU:  Qwen3-4B LLM (via MLX-Swift/Metal) — full GPU, no sharing
+GPU:  Qwen3-8B LLM (via MLX-Swift/Metal) — full GPU, no sharing
 ANE:  Parakeet STT (via FluidAudio/CoreML) — dedicated ML accelerator
 ```
 
@@ -438,10 +438,10 @@ enum RefinementLevel {
 
 | Property | Value |
 |----------|-------|
-| Model | Qwen3-4B |
-| HuggingFace ID | `mlx-community/Qwen3-4B-4bit` |
+| Model | Qwen3-8B |
+| HuggingFace ID | `mlx-community/Qwen3-8B-4bit` |
 | Quantization | 4-bit |
-| RAM | ~2.5 GB |
+| RAM | ~5 GB |
 | Framework | MLX-Swift (Apple Silicon Metal) |
 
 **Dual-Mode Operation (same model, different settings):**
@@ -1001,7 +1001,7 @@ All four tables are independent. No foreign key relationships. This keeps the sc
     │   └── ...
     ├── models/                     # Downloaded ML models
     │   ├── stt/                    # CoreML Parakeet models (~6 GB)
-    │   └── Qwen3-4B-4bit/          # LLM model files
+    │   └── Qwen3-8B-4bit/          # LLM model files
     └── bin/                        # Standalone binaries
         ├── yt-dlp                  # YouTube downloader (~35 MB, self-updating)
         └── ffmpeg                  # Video demuxing (~80 MB)
@@ -1016,7 +1016,7 @@ All four tables are independent. No foreign key relationships. This keeps the sc
 | Package | SPM ID | Purpose | Notes |
 |---------|--------|---------|-------|
 | FluidAudio | `FluidAudio` | STT engine (Parakeet TDT via CoreML/ANE) | Apache 2.0. Use `FluidAudio` product only — NOT `FluidAudioEspeak` (GPL-3.0, would require open-sourcing). |
-| mlx-swift-lm | `MLXLLM`, `MLXLMCommon` | LLM inference (Qwen3-4B) | v2.29.0+, Apple Silicon Metal acceleration |
+| mlx-swift-lm | `MLXLLM`, `MLXLMCommon` | LLM inference (Qwen3-8B) | v2.29.0+, Apple Silicon Metal acceleration |
 | GRDB.swift | `GRDB` | SQLite database | v6.29.0+, single-file storage, migrations, Codable records |
 | swift-argument-parser | `ArgumentParser` | CLI (implemented) | `macparakeet-cli transcribe`, `history`, `health` |
 
@@ -1110,11 +1110,11 @@ For App Store distribution, the app needs:
 │                    Memory at Peak                           │
 ├────────────────────────────────────────────────────────────┤
 │  Parakeet STT (CoreML/ANE)       ~66 MB working RAM        │
-│  Qwen3-4B LLM (MLX-Swift/GPU)   ~2.5 GB                   │
+│  Qwen3-8B LLM (MLX-Swift/GPU)   ~5 GB                     │
 │  App process (UI + services)     ~100 MB                   │
 │  Audio buffers                   ~50 MB                    │
 │  ──────────────────────────────────────                    │
-│  Total peak (with LLM)           ~2.8 GB                   │
+│  Total peak (with LLM)           ~5.3 GB                   │
 │                                                            │
 │  Recommended system RAM: 16 GB (Apple Silicon)             │
 │  Minimum: 8 GB (runs comfortably — STT uses ~66 MB)        │
@@ -1147,7 +1147,7 @@ App Launch ──────────> Window shown (fast, no ML loaded)
                            │
                            │ If AI refinement needed:
                            ▼
-                       Load Qwen3-4B (background, ~2-3s)
+                       Load Qwen3-8B (background, ~2-3s)
                            │
                            ▼
                        Refine text (~1-2s)

--- a/spec/06-stt-engine.md
+++ b/spec/06-stt-engine.md
@@ -27,7 +27,7 @@ Each ML workload runs on the chip it was designed for:
 
 ```
 CPU:  MacParakeet app (UI, hotkeys, clipboard, history)
-GPU:  Qwen3-4B LLM (via MLX-Swift/Metal) — full GPU, no sharing
+GPU:  Qwen3-8B LLM (via MLX-Swift/Metal) — full GPU, no sharing
 ANE:  Parakeet STT (via FluidAudio/CoreML) — dedicated ML accelerator
 ```
 
@@ -242,12 +242,12 @@ For dictation (the primary use case), transcription time is imperceptible. For l
 
 ```
 Parakeet STT (CoreML/ANE)      ~66 MB working RAM (~130 MB with vocab boosting)
-Qwen3-4B LLM (MLX-Swift/GPU)  ~2.5 GB
+Qwen3-8B LLM (MLX-Swift/GPU)  ~5 GB
 App process (UI + services)    ~100 MB
 Audio buffers                  ~50 MB
 ────────────────────────────────────
-Total peak                     ~2.8 GB (without LLM) / ~2.9 GB (with vocab boosting)
-                               ~5.3 GB (with LLM loaded)
+Total peak                     ~5.3 GB (without vocab boosting)
+                               ~5.4 GB (with vocab boosting)
 
 Recommended: 16 GB RAM (Apple Silicon)
 Minimum: 8 GB (runs comfortably — STT uses only ~66 MB, not ~2 GB+)

--- a/spec/07-text-processing.md
+++ b/spec/07-text-processing.md
@@ -206,8 +206,8 @@ macparakeet-cli flow process "um hello I mean kubernetes is great"
 macparakeet-cli flow process "text here" --copy
 
 # Transcribe with processing
-macparakeet-cli transcribe recording.wav --process
-macparakeet-cli transcribe recording.wav --process --copy
+macparakeet-cli transcribe recording.wav --mode clean
+macparakeet-cli transcribe recording.wav --mode raw
 ```
 
 ### Custom Words
@@ -237,4 +237,22 @@ macparakeet-cli flow snippets add "my signature" "Best regards, David"
 
 # Delete a snippet
 macparakeet-cli flow snippets delete <id>
+```
+
+### Local LLM
+
+```bash
+# Local model smoke test
+macparakeet-cli llm smoke-test --stats
+
+# Direct prompt generation
+macparakeet-cli llm generate "Summarize this in one sentence: ..."
+
+# Refine text (deterministic clean + local LLM)
+macparakeet-cli llm refine formal "quick draft note"
+macparakeet-cli llm refine email "meeting moved to 3pm tomorrow"
+macparakeet-cli llm refine code "check var name and update loop logic"
+
+# Apply a spoken-style command transform
+macparakeet-cli llm command "Translate to Spanish" "Hello, how are you?"
 ```

--- a/spec/07-text-processing.md
+++ b/spec/07-text-processing.md
@@ -71,9 +71,9 @@ Final normalization pass:
 |------|-----------|--------|---------|
 | Raw | None | N/A | 0ms |
 | Clean | Deterministic pipeline | TextProcessingPipeline | <1ms |
-| Formal | Pipeline + LLM (professional tone) | Qwen3-4B | ~1-3s |
-| Email | Pipeline + LLM (email format) | Qwen3-4B | ~1-3s |
-| Code | Pipeline + LLM (preserve syntax) | Qwen3-4B | ~1-3s |
+| Formal | Pipeline + LLM (professional tone) | Qwen3-8B | ~1-3s |
+| Email | Pipeline + LLM (email format) | Qwen3-8B | ~1-3s |
+| Code | Pipeline + LLM (preserve syntax) | Qwen3-8B | ~1-3s |
 
 ### Mode Details
 
@@ -81,7 +81,7 @@ Final normalization pass:
 
 **Clean** (default): The deterministic 4-step pipeline runs. Fast, predictable, no LLM dependency. Good for most dictation use cases.
 
-**Formal**: The deterministic pipeline runs first, then the result is sent to Qwen3-4B with a prompt to rewrite in a professional tone. Suitable for business communication.
+**Formal**: The deterministic pipeline runs first, then the result is sent to Qwen3-8B with a prompt to rewrite in a professional tone. Suitable for business communication.
 
 **Email**: Pipeline first, then LLM formats the text as an email with appropriate greeting, body, and sign-off. User's name and preferred sign-off can be configured.
 
@@ -102,7 +102,7 @@ User selects text in any app
     → User speaks a command: "Translate to Spanish", "Make formal", "Fix grammar"
     → MacParakeet captures command via STT
     → Gets selected text via Accessibility API
-    → Sends selected text + spoken command to Qwen3-4B
+    → Sends selected text + spoken command to Qwen3-8B
     → Replaces selected text with result via CGEvent (paste)
 ```
 
@@ -125,7 +125,7 @@ User selects text in any app
 
 ### Constraints
 
-- Selected text is limited to ~4000 tokens (Qwen3-4B context window management)
+- Selected text is limited to ~4000 tokens as a practical limit for command mode (Qwen3-8B supports 128K context)
 - If no text is selected, show a brief tooltip: "Select text first"
 - Command recording uses the same mic pipeline as dictation
 
@@ -137,14 +137,14 @@ User selects text in any app
 
 | Property | Value |
 |----------|-------|
-| Model | Qwen3-4B |
-| HuggingFace ID | `mlx-community/Qwen3-4B-4bit` |
+| Model | Qwen3-8B |
+| HuggingFace ID | `mlx-community/Qwen3-8B-4bit` |
 | Runtime | MLX-Swift |
 | Memory | Loaded/unloaded on demand |
 
 ### Dual-Mode Operation
 
-The same Qwen3-4B model is used with different settings depending on task complexity:
+The same Qwen3-8B model is used with different settings depending on task complexity:
 
 | Mode | Use Case | Temperature | Top-P |
 |------|----------|-------------|-------|

--- a/spec/07-text-processing.md
+++ b/spec/07-text-processing.md
@@ -83,7 +83,7 @@ Final normalization pass:
 
 **Formal**: The deterministic pipeline runs first, then the result is sent to Qwen3-8B with a prompt to rewrite in a professional tone. Suitable for business communication.
 
-**Email**: Pipeline first, then LLM formats the text as an email with appropriate greeting, body, and sign-off. User's name and preferred sign-off can be configured.
+**Email**: Pipeline first, then LLM rewrites into polished email-style text.
 
 **Code**: Pipeline first, then LLM preserves technical syntax, variable names, and code-like patterns while cleaning up natural language around them.
 
@@ -157,7 +157,7 @@ The same Qwen3-8B model is used with different settings depending on task comple
 - It loads on first LLM-mode dictation or command mode invocation
 - It stays loaded for a configurable idle timeout (default: 5 minutes)
 - After idle timeout, the model is unloaded to free memory
-- Loading takes ~2-3 seconds; a loading indicator is shown in the UI
+- Loading takes ~2-3 seconds on first use
 
 ---
 

--- a/spec/11-llm-integration.md
+++ b/spec/11-llm-integration.md
@@ -26,18 +26,18 @@ This spec defines how MacParakeet integrates local LLM features with clean archi
 
 ```
 Dictation/Command/Chat Call Site
+    -> TextRefinementService (deterministic-first policy)
     -> PromptBuilder
     -> LLMServiceProtocol
-       -> MLXQwenService (Qwen3-8B)
-    -> LLMResultAdapter
-    -> FallbackPolicy (deterministic output on failure)
+       -> MLXLLMService (Qwen3-8B)
+    -> Fallback to deterministic output on failure
 ```
 
 ### Core Protocol
 
 ```swift
 public protocol LLMServiceProtocol: Sendable {
-    func generate(_ request: LLMRequest) async throws -> LLMResponse
+    func generate(request: LLMRequest) async throws -> LLMResponse
 }
 ```
 
@@ -45,20 +45,21 @@ public protocol LLMServiceProtocol: Sendable {
 
 ```swift
 public struct LLMRequest: Sendable {
-    public let task: LLMTask
-    public let input: String
-    public let context: LLMContext
+    public let prompt: String
+    public let systemPrompt: String?
+    public let options: LLMGenerationOptions
 }
 
 public enum LLMTask: Sendable {
-    case refine(mode: RefinementMode)      // formal/email/code
+    case refine(mode: LLMRefinementMode, input: String)
     case commandTransform(command: String) // "translate to spanish", etc.
-    case transcriptChat(query: String)     // future
+    case transcriptChat(question: String, transcript: String)
 }
 
 public struct LLMResponse: Sendable {
-    public let output: String
-    public let meta: LLMResponseMeta
+    public let text: String
+    public let modelID: String
+    public let durationSeconds: TimeInterval
 }
 ```
 
@@ -81,10 +82,10 @@ No data loss and no silent crash paths are allowed.
 - `clean`: deterministic pipeline only
 - `formal/email/code`: deterministic pipeline -> LLM request -> fallback if needed
 
-2. **Command mode**
+2. **Command mode (CLI today, GUI pending)**
 - selected text + spoken command -> LLM request (`commandTransform`) -> replace selection
 
-3. **Transcript chat (future)**
+3. **Transcript chat (future scaffolding)**
 - query + transcript context chunking -> LLM request (`transcriptChat`)
 
 ---

--- a/spec/11-llm-integration.md
+++ b/spec/11-llm-integration.md
@@ -1,0 +1,143 @@
+# 11 - LLM Integration
+
+> Status: **ACTIVE** - Authoritative, current
+> Baseline: Qwen3-8B 4-bit via MLX-Swift-LM (ADR-008)
+
+This spec defines how MacParakeet integrates local LLM features with clean architecture, deterministic fallback behavior, and testable seams.
+
+---
+
+## Goals
+
+1. Deliver AI text refinement modes (Formal, Email, Code) on top of deterministic cleanup.
+2. Reuse one LLM integration path for command mode and future transcript chat.
+3. Keep local-only guarantees and avoid Python/daemon dependencies.
+4. Fail gracefully without breaking dictation/transcription flows.
+
+## Non-Goals (This Phase)
+
+1. Multi-model routing.
+2. Agent/tool use orchestration.
+3. Hard latency release gates.
+
+---
+
+## Architecture
+
+```
+Dictation/Command/Chat Call Site
+    -> PromptBuilder
+    -> LLMServiceProtocol
+       -> MLXQwenService (Qwen3-8B)
+    -> LLMResultAdapter
+    -> FallbackPolicy (deterministic output on failure)
+```
+
+### Core Protocol
+
+```swift
+public protocol LLMServiceProtocol: Sendable {
+    func generate(_ request: LLMRequest) async throws -> LLMResponse
+}
+```
+
+### Request / Response Contract
+
+```swift
+public struct LLMRequest: Sendable {
+    public let task: LLMTask
+    public let input: String
+    public let context: LLMContext
+}
+
+public enum LLMTask: Sendable {
+    case refine(mode: RefinementMode)      // formal/email/code
+    case commandTransform(command: String) // "translate to spanish", etc.
+    case transcriptChat(query: String)     // future
+}
+
+public struct LLMResponse: Sendable {
+    public let output: String
+    public let meta: LLMResponseMeta
+}
+```
+
+### Fallback Policy (Required)
+
+If LLM invocation fails, times out, or yields empty output:
+
+1. Return deterministic-clean text where applicable.
+2. Keep UX non-blocking (small info/error surface, no hard stop).
+3. Emit structured log/telemetry event for diagnosis.
+
+No data loss and no silent crash paths are allowed.
+
+---
+
+## Feature Wiring
+
+1. **Dictation modes**
+- `raw`: no transform
+- `clean`: deterministic pipeline only
+- `formal/email/code`: deterministic pipeline -> LLM request -> fallback if needed
+
+2. **Command mode**
+- selected text + spoken command -> LLM request (`commandTransform`) -> replace selection
+
+3. **Transcript chat (future)**
+- query + transcript context chunking -> LLM request (`transcriptChat`)
+
+---
+
+## Model and Runtime Baseline
+
+| Property | Value |
+|----------|-------|
+| Runtime | `mlx-swift-lm` |
+| Model | `mlx-community/Qwen3-8B-4bit` |
+| Loading | lazy-load on first use |
+| Unload | idle timeout (default 5 min) |
+| Context strategy | bounded prompt assembly with truncation/chunking |
+
+---
+
+## Error Categories
+
+1. `modelUnavailable` - model missing or load failure
+2. `generationFailed` - runtime/generation error
+3. `timeout` - call exceeded configured budget
+4. `invalidOutput` - empty/unsafe output
+
+All categories must map to user-safe fallback behavior.
+
+---
+
+## Testing Requirements
+
+### Unit
+
+1. `PromptBuilder` per task and mode.
+2. `FallbackPolicy` for all error categories.
+3. `LLMServiceProtocol` mock-driven tests in dictation/command flows.
+
+### Integration
+
+1. First-load path (cold start).
+2. Warm invocation path.
+3. Idle unload + reload behavior.
+
+### Regression
+
+1. Deterministic mode behavior unchanged.
+2. LLM failure cannot block transcription completion.
+
+---
+
+## Acceptance Criteria
+
+1. AI modes produce transformed output with Qwen3-8B.
+2. Failure path returns deterministic-safe output and surfaces recoverable UI notice.
+3. No Python runtime or daemon dependency introduced.
+4. `swift test` remains green with new LLM seam tests.
+
+Latency metrics are tracked and monitored, but not used as hard release gates in this phase.

--- a/spec/README.md
+++ b/spec/README.md
@@ -20,6 +20,7 @@
 | 08 | [Error Handling](08-error-handling.md) | Error philosophy, categories, recovery | Active |
 | 09 | [Testing](09-testing.md) | Testing strategy, patterns, guidelines | Active |
 | 10 | [AI Coding Method](10-ai-coding-method.md) | Spec-driven coding philosophy and kernel methodology | Active |
+| 11 | [LLM Integration](11-llm-integration.md) | Local LLM architecture, fallback policy, runtime baseline | Active |
 
 ## Root Decisions (Locked)
 
@@ -78,7 +79,7 @@ Dictation + transcription + history + settings. Get audio in, text out, pasted i
 ### v0.2 AI & Text Processing (In Progress)
 
 - [x] Clean text pipeline (deterministic: fillers, custom words, snippets)
-- [ ] AI text refinement (Qwen3-8B: formal, email, code modes)
+- [x] AI text refinement (Qwen3-8B: formal, email, code modes)
 - [x] Custom words & snippets management UI
 - [ ] Personal dictionary (auto-learns vocabulary)
 - [x] CLI commands (`macparakeet-cli flow process/words/snippets` + `macparakeet-cli llm generate/refine/command/smoke-test`)

--- a/spec/README.md
+++ b/spec/README.md
@@ -72,7 +72,7 @@ Dictation + transcription + history + settings. Get audio in, text out, pasted i
 - [x] Menu bar app with main window
 - [x] Basic export (TXT/Markdown/SRT/VTT + copy to clipboard)
 - [x] SQLite database (GRDB, dictations + transcriptions + substring search)
-- [x] Internal dev CLI tool (`macparakeet-cli transcribe`, `history`, `health`)
+- [x] Internal dev CLI tool (`macparakeet-cli transcribe`, `history`, `health`, `flow`, `llm`)
 - [x] Test suite passing (`swift test` green)
 
 ### v0.2 AI & Text Processing (In Progress)
@@ -81,7 +81,7 @@ Dictation + transcription + history + settings. Get audio in, text out, pasted i
 - [ ] AI text refinement (Qwen3-8B: formal, email, code modes)
 - [x] Custom words & snippets management UI
 - [ ] Personal dictionary (auto-learns vocabulary)
-- [x] CLI commands (`macparakeet-cli flow process/words/snippets`)
+- [x] CLI commands (`macparakeet-cli flow process/words/snippets` + `macparakeet-cli llm generate/refine/command/smoke-test`)
 
 ### v0.3 Command Mode & Export (In Progress)
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -29,7 +29,7 @@ These decisions are final. Do not second-guess them.
 |----------|--------|-----------|
 | Local STT | Parakeet TDT 0.6B-v3 via FluidAudio CoreML/ANE | 155x realtime, ~2.5% WER, fully local, ~66 MB working RAM |
 | Database | SQLite via GRDB | Single file, embedded, zero config |
-| Local LLM | Qwen3-4B via MLX-Swift | Best 4B model on benchmarks, dual-mode (thinking/non-thinking) |
+| Local LLM | Qwen3-8B via MLX-Swift | Single model for all LLM tasks (refinement, command mode, chat). 128K context. |
 | Platform | macOS 14.2+ (Apple Silicon only) | FluidAudio + MLX-Swift require Apple Silicon; Swift 6.0 |
 | Business model | One-time purchase ($49) | Key differentiator vs WisprFlow ($144-180/year subscription) |
 
@@ -78,7 +78,7 @@ Dictation + transcription + history + settings. Get audio in, text out, pasted i
 ### v0.2 AI & Text Processing (In Progress)
 
 - [x] Clean text pipeline (deterministic: fillers, custom words, snippets)
-- [ ] AI text refinement (Qwen3-4B: formal, email, code modes)
+- [ ] AI text refinement (Qwen3-8B: formal, email, code modes)
 - [x] Custom words & snippets management UI
 - [ ] Personal dictionary (auto-learns vocabulary)
 - [x] CLI commands (`macparakeet-cli flow process/words/snippets`)
@@ -106,7 +106,7 @@ Dictation + transcription + history + settings. Get audio in, text out, pasted i
 3. **Version order matters.** Implement v0.1 before v0.2. Do not jump ahead.
 4. **Never lose user data.** Graceful degradation over silent failure.
 5. **Local-first.** Audio and text never leave the device. No cloud APIs.
-6. **One model.** Qwen3-4B for all LLM tasks. No Llama, no Ollama, no OpenAI.
+6. **One model.** Qwen3-8B for all LLM tasks. No Llama, no Ollama, no OpenAI.
 7. **`swift test` is the gate.** All tests must pass before and after changes.
 8. **Kernel has precedence for implementation.** When present, `spec/kernel/*` artifacts define executable requirements and contracts.
 

--- a/spec/adr/001-parakeet-stt.md
+++ b/spec/adr/001-parakeet-stt.md
@@ -92,7 +92,7 @@ At 0.6B parameters (quantized to ~600MB on disk, ~1.5GB downloaded with tokenize
 
 ### Why
 
-1. **Three-chip utilization** — Moving STT to the ANE frees the GPU entirely for the Qwen3-4B LLM. Zero compute contention.
+1. **Three-chip utilization** — Moving STT to the ANE frees the GPU entirely for the Qwen3-8B LLM. Zero compute contention.
 2. **Memory efficiency** — ~66 MB working RAM (vs ~2 GB+) makes 8GB Macs viable for both STT and LLM simultaneously.
 3. **Better accuracy** — FluidAudio's CoreML decoding achieves ~2.5% WER (vs ~6.3% on MLX). Same model weights, better decoding.
 4. **Eliminates Python** — No venv, no subprocess, no codesigning issues. Pure Swift. App Store compatible.

--- a/spec/adr/002-local-only.md
+++ b/spec/adr/002-local-only.md
@@ -21,7 +21,7 @@ This applies to:
 
 - **STT**: Parakeet TDT 0.6B-v3 runs locally via FluidAudio CoreML on ANE (ADR-001, ADR-007)
 - **Text processing**: Deterministic pipeline runs locally (ADR-004)
-- **LLM features**: Qwen3-4B runs locally via MLX-Swift for command mode and advanced text modes
+- **LLM features**: Qwen3-8B runs locally via MLX-Swift for command mode and advanced text modes
 - **Updates**: Standard macOS app update mechanisms (Sparkle or App Store)
 - **Analytics**: None. No telemetry, no crash reporting, no usage tracking.
 
@@ -35,7 +35,7 @@ This applies to:
 
 A cloud LLM (GPT-4, Claude) would produce better results for command mode and advanced text refinement. However:
 
-- Local LLM (Qwen3-4B) produces **acceptable** results for the use cases that matter (reformatting, expanding abbreviations, command interpretation).
+- Local LLM (Qwen3-8B) produces **acceptable** results for the use cases that matter (reformatting, expanding abbreviations, command interpretation).
 - Local processing is **consistently fast** -- no variance based on server load, network, or time of day.
 - Users can always re-dictate or manually edit. The cost of a slightly less polished LLM output is low; the cost of a 20-second delay or privacy breach is high.
 
@@ -63,8 +63,8 @@ Cloud processing requires ongoing server costs, which necessitates subscription 
 
 ### Negative
 
-- **LLM quality ceiling**: Qwen3-4B (4-bit quantized, local) is significantly less capable than GPT-4 or Claude for complex text transformation. Command mode and formal rewriting will be "good enough" rather than "excellent."
-- **No internet required, but model download is**: First launch requires downloading Parakeet (~6 GB CoreML bundle) and Qwen3 (~2.5 GB) models. After that, fully offline.
+- **LLM quality ceiling**: Qwen3-8B (4-bit quantized, local) is less capable than GPT-4 or Claude for complex text transformation. Command mode and formal rewriting will be "good enough" rather than "excellent."
+- **No internet required, but model download is**: First launch requires downloading Parakeet (~6 GB CoreML bundle) and Qwen3 (~5 GB) models. After that, fully offline.
 - **No cloud backup or sync**: User data stays on-device. If the Mac is lost, dictation history is lost. This is intentional -- users who want cloud backup can use macOS iCloud or Time Machine.
 - **No collaborative features**: Real-time sharing, team vocabularies, or cross-device sync would require cloud infrastructure. These are out of scope.
 

--- a/spec/adr/004-deterministic-pipeline.md
+++ b/spec/adr/004-deterministic-pipeline.md
@@ -15,7 +15,7 @@ Raw STT output -- even from a high-quality model like Parakeet TDT 0.6B-v3 -- be
 
 Two approaches exist for this cleanup:
 
-1. **LLM-based refinement**: Pass raw text through a language model (local Qwen3-4B or cloud GPT-4) to clean, reformat, and improve it.
+1. **LLM-based refinement**: Pass raw text through a language model (local Qwen3-8B or cloud GPT-4) to clean, reformat, and improve it.
 2. **Deterministic pipeline**: Apply rule-based transformations in a fixed order -- filler removal, casing fixes, custom word corrections, snippet expansion.
 
 ## Decision
@@ -37,10 +37,10 @@ Use a **deterministic 4-step pipeline** for the default "clean" processing mode.
 |------|----------|-----|---------|----------|
 | Raw | None | No | 0ms | Verbatim transcription |
 | **Clean (default)** | **4-step** | **No** | **<5ms** | **General dictation** |
-| Formal | 4-step | Yes (Qwen3-4B) | 2-5s | Professional writing |
-| Email | 4-step | Yes (Qwen3-4B) | 2-5s | Email composition |
-| Code | 4-step | Yes (Qwen3-4B) | 2-5s | Code dictation |
-| Command | None | Yes (Qwen3-4B) | 2-5s | System commands, app control |
+| Formal | 4-step | Yes (Qwen3-8B) | 2-5s | Professional writing |
+| Email | 4-step | Yes (Qwen3-8B) | 2-5s | Email composition |
+| Code | 4-step | Yes (Qwen3-8B) | 2-5s | Code dictation |
+| Command | None | Yes (Qwen3-8B) | 2-5s | System commands, app control |
 
 ## Rationale
 
@@ -50,7 +50,7 @@ Unlike older Whisper models, Parakeet TDT 0.6B-v3 outputs well-punctuated, well-
 
 ### Local LLM is unreliable for simple cleanup
 
-Testing with Qwen3-4B (4-bit quantized) for basic text cleanup revealed:
+Testing with Qwen3-8B (4-bit quantized) for basic text cleanup revealed:
 
 - **Meaning changes**: The model sometimes rephrases or paraphrases, altering the user's intended words. For dictation, fidelity to the speaker's actual words is paramount.
 - **Inconsistency**: The same input can produce different outputs across runs. Users expect deterministic behavior from a "clean" mode.

--- a/spec/adr/007-fluidaudio-coreml-migration.md
+++ b/spec/adr/007-fluidaudio-coreml-migration.md
@@ -7,7 +7,7 @@
 
 MacParakeet v0.1 runs Parakeet TDT 0.6B-v3 via `parakeet-mlx`, a Python daemon communicating over JSON-RPC stdin/stdout. The Python environment is managed by `uv` (isolated venv, ~500 MB dependencies). This was the fastest path to ship Parakeet on Apple Silicon — ADR-001 chose the model, and parakeet-mlx was the only viable runtime at the time.
 
-Three problems have emerged as we prepare to add Qwen3-4B (LLM) in v0.2:
+Three problems have emerged as we prepare to add Qwen3-8B (LLM) in v0.2:
 
 ### 1. Wasted Silicon
 
@@ -15,11 +15,11 @@ Every Apple Silicon Mac has three compute units — CPU, GPU, and ANE (Neural En
 
 ```
 CPU: [App logic, UI, hotkeys, clipboard]
-GPU: [Parakeet STT] + [Qwen3-4B LLM]   ← two ML workloads sharing one chip
+GPU: [Parakeet STT] + [Qwen3-8B LLM]   ← two ML workloads sharing one chip
 ANE: [idle]                               ← dedicated ML chip sitting unused
 ```
 
-Both Parakeet (STT) and Qwen3-4B (LLM) run on the GPU via Metal/MLX. On 8 GB Macs, combined GPU memory pressure (~2 GB STT + ~2.5 GB LLM) makes simultaneous operation impractical. The ANE — purpose-built for neural inference — sits idle.
+Both Parakeet (STT) and Qwen3-8B (LLM) run on the GPU via Metal/MLX. On 8 GB Macs, combined GPU memory pressure (~2 GB STT + ~2.5 GB LLM) makes simultaneous operation impractical. The ANE — purpose-built for neural inference — sits idle.
 
 ### 2. Python Complexity
 
@@ -67,7 +67,7 @@ The model choice (Parakeet TDT 0.6B-v3) is unchanged. Only the runtime changes. 
 
 - `STTClientProtocol` interface — consumers don't know the backend changed
 - `STTResult` format — text + word timestamps + confidence scores
-- Qwen3-4B via MLX-Swift on GPU — LLM path unchanged
+- Qwen3-8B via MLX-Swift on GPU — LLM path unchanged
 - Deterministic text processing pipeline — unchanged
 - All UI, hotkeys, history, export — unchanged
 
@@ -79,7 +79,7 @@ The core argument. With FluidAudio, each ML workload runs on the chip it was des
 
 ```
 CPU: [App logic, UI, hotkeys, clipboard]
-GPU: [Qwen3-4B LLM]                      ← full GPU dedicated to text refinement
+GPU: [Qwen3-8B LLM]                      ← full GPU dedicated to text refinement
 ANE: [Parakeet STT]                       ← dedicated ML chip, finally used
 ```
 
@@ -91,7 +91,7 @@ FluidAudio uses ~66 MB working RAM (~130 MB with vocabulary boosting) vs ~2 GB+ 
 
 ```
 Before:  ~2 GB (STT) + ~2.5 GB (LLM) = ~4.5 GB on GPU alone
-After:   ~66 MB (STT on ANE) + ~2.5 GB (LLM on GPU) = ~2.6 GB across two chips
+After:   ~66 MB (STT on ANE) + ~5 GB (LLM on GPU) = ~5.1 GB across two chips
 ```
 
 ### Better Accuracy
@@ -112,7 +112,7 @@ Removing the Python subprocess is the only path to App Store distribution. This 
 
 ### Why Now
 
-v0.2 adds Qwen3-4B to the GPU — the exact moment GPU contention becomes real. Migrating now means every feature built on top (AI refinement, command mode) starts on the correct architecture. Delaying means building more features on Python/MLX, then migrating them later with more surface area and more risk.
+v0.2 adds Qwen3-8B to the GPU — the exact moment GPU contention becomes real. Migrating now means every feature built on top (AI refinement, command mode) starts on the correct architecture. Delaying means building more features on Python/MLX, then migrating them later with more surface area and more risk.
 
 ## Consequences
 
@@ -153,7 +153,7 @@ v0.2 adds Qwen3-4B to the GPU — the exact moment GPU contention becomes real. 
 
 ### Stay on parakeet-mlx (Python/MLX/GPU)
 
-Rejected. GPU contention with Qwen3-4B is the immediate problem with no solution — the ANE sits idle while two ML workloads share the GPU. The Python complexity and App Store incompatibility are secondary but reinforce the decision.
+Rejected. GPU contention with Qwen3-8B is the immediate problem with no solution — the ANE sits idle while two ML workloads share the GPU. The Python complexity and App Store incompatibility are secondary but reinforce the decision.
 
 ### whisper.cpp (C++ via Swift bridge)
 
@@ -161,7 +161,7 @@ Rejected. Whisper is slower (~15-30x realtime vs ~155x) and less accurate (~7-12
 
 ### MLX-Swift for Parakeet (keep GPU, eliminate Python)
 
-Partially addresses Python elimination but doesn't solve the core problem — STT would still run on the GPU, contending with Qwen3-4B. The ANE would remain idle. FluidAudio CoreML is strictly better: same model, better accuracy, lower memory, dedicated chip.
+Partially addresses Python elimination but doesn't solve the core problem — STT would still run on the GPU, contending with Qwen3-8B. The ANE would remain idle. FluidAudio CoreML is strictly better: same model, better accuracy, lower memory, dedicated chip.
 
 ### Hybrid: FluidAudio STT + keep Python for yt-dlp
 

--- a/spec/adr/008-local-llm-runtime-and-model.md
+++ b/spec/adr/008-local-llm-runtime-and-model.md
@@ -1,0 +1,80 @@
+# ADR-008: Local LLM Runtime and Model Baseline (Qwen3-8B)
+
+> Status: **Accepted**
+> Date: 2026-02-13
+
+## Context
+
+MacParakeet has committed to fully local AI execution (ADR-002) and has already migrated STT to FluidAudio on ANE (ADR-007). The remaining AI roadmap items depend on a local text LLM:
+
+- AI text refinement modes (Formal, Email, Code)
+- Command mode text transforms
+- Future "chat with transcript"
+
+We need one production baseline that is fast enough, reliable in native Swift, and simple to operate on Apple Silicon without Python daemons.
+
+## Decision
+
+MacParakeet will use:
+
+- **Runtime:** `mlx-swift-lm` (in-process, native Swift)
+- **Model:** **Qwen3-8B 4-bit** (`mlx-community/Qwen3-8B-4bit`)
+- **Deployment shape:** single-model baseline for all LLM features in v0.2/v0.3
+
+### Locked decisions
+
+1. No Python or external daemon for LLM runtime.
+2. No multi-model routing in initial rollout.
+3. Deterministic pipeline remains first stage for all text cleanup flows.
+4. If LLM call fails/times out, app degrades gracefully (returns deterministic-clean output and surfaces non-blocking UI notice).
+
+## Rationale
+
+1. **Native integration fit:** `mlx-swift-lm` is the strongest direct fit for a Swift macOS app.
+2. **Operational simplicity:** single model lowers complexity for prompts, memory behavior, and QA.
+3. **Capability coverage:** Qwen3-8B quality is sufficient for cleanup + command transforms + transcript chat baseline.
+4. **Architecture coherence:** STT on ANE (FluidAudio) + LLM on GPU (MLX) uses Apple Silicon efficiently.
+5. **License/distribution fit:** avoids Python runtime packaging and daemon lifecycle risks.
+
+## Consequences
+
+### Positive
+
+- One coherent local AI stack (Swift + SwiftPM + CoreML/MLX).
+- Clear implementation path for pending v0.2/v0.3 LLM features.
+- Predictable prompt behavior with a single baseline model.
+
+### Tradeoffs
+
+- Higher memory footprint than 4B-class models.
+- Initial model load latency is user-visible on first LLM invocation.
+- Upstream MLX/MLX-Swift-LM compatibility regressions remain a real risk and require pinning + validation.
+
+## Guardrails
+
+1. Version pinning and controlled upgrades for `mlx-swift-lm`.
+2. CI + local parity check for toolchain/runtime stability.
+3. Runtime revalidation cadence in `docs/runtime-revalidation-checklist.md`.
+4. Dedicated benchmark protocol (informational, not release-blocking) in `docs/planning/2026-02-qwen3-8b-benchmark-plan.md`.
+
+## Alternatives Considered
+
+### Qwen3-4B
+
+Rejected as baseline because 8B is preferred for output quality and future transcript-chat utility. 4B remains a fallback option only if memory pressure proves unacceptable on target devices.
+
+### llama.cpp / Ollama runtime
+
+Rejected for baseline due to higher integration/operations complexity in a native Swift app compared with direct MLX-Swift embedding.
+
+### Cloud API LLM
+
+Rejected due to local-only product direction and privacy commitments (ADR-002).
+
+## References
+
+- `docs/research/open-source-models-landscape-2026.md`
+- `docs/runtime-revalidation-checklist.md`
+- `spec/07-text-processing.md`
+- `spec/adr/002-local-only.md`
+- `spec/adr/007-fluidaudio-coreml-migration.md`


### PR DESCRIPTION
## Summary

This PR delivers the full local LLM integration for MacParakeet, end-to-end across core runtime, app wiring, CLI tooling, tests, and specs/docs.

It moves the baseline from **Qwen3-4B** to **Qwen3-8B**, implements production text refinement modes (**formal/email/code**) on top of deterministic cleanup, and adds transcript-chat scaffolding for follow-up work.

## Commits Included

1. `0f39416` — Switch LLM from Qwen3-4B to Qwen3-8B; add chat-with-transcript to roadmap
2. `0481053` — Add local LLM CLI workflows and testable MLX service seam
3. `0ae63aa` — Implement end-to-end local LLM refinement modes with deterministic fallback
4. `50c3df2` — Skip LLM when deterministic refinement output is empty
5. `40c5a56` — Disable Qwen3 thinking mode for clean CLI/app outputs

## Architecture (Final)

```text
Dictation/Transcription
  -> TextRefinementService
     -> Deterministic pipeline first (fillers -> custom words -> snippets -> whitespace)
     -> Optional LLM refinement for formal/email/code
     -> Deterministic fallback on any LLM failure/timeout/invalid output
```

Core runtime:
- `LLMServiceProtocol` + typed request/response/errors
- `MLXLLMService` actor on `mlx-swift-lm`
- Lazy model load + idle unload lifecycle
- Qwen3 template context forces non-thinking output (`enable_thinking: false`)

## What Changed

### Core + App
- Added `TextRefinementService` shared seam and fallback policy.
- Extended processing modes to: `raw`, `clean`, `formal`, `email`, `code`.
- Wired dictation/transcription services through the refinement seam.
- Added shared app-level `MLXLLMService` injection via `AppEnvironment`.
- Added transcript context assembly utility for future chat (`TranscriptContextAssembler`).

### CLI
- Added `macparakeet-cli llm` command group:
  - `generate`
  - `refine`
  - `command`
  - `smoke-test`
- Extended `transcribe --mode` to include AI modes:
  - `raw|clean|formal|email|code|app-default`

### UI / Settings
- Vocabulary mode UI now exposes all five processing modes and AI behavior messaging.
- History mode badge now uses full mode display names.
- Settings processing mode persistence/normalization hardened.

### Reliability fixes
- Skip LLM invocation when deterministic output is empty (e.g. filler-only input).
- Suppress Qwen `<think>` output by setting `enable_thinking: false` in runtime context.

### Tests
- Added and expanded coverage for:
  - prompt builder
  - refinement success + fallback paths
  - empty-after-deterministic LLM skip
  - transcript context truncation/chunking
  - dictation/transcription service integration with mock LLM
  - settings mode normalization

## Validation

### Automated
- `swift test` local: **367 passed, 0 failed**
- CI checks on this PR: **green** (`swift-test` x2, CodeRabbit success)

### Real local LLM runtime validation
Built with Xcode toolchain (required for MLX Metal shader bundling):
- `xcodebuild build -scheme macparakeet-cli -destination 'platform=macOS' -derivedDataPath .build/xcode`

Then executed real inference:
- `.build/xcode/Build/Products/Debug/macparakeet-cli llm smoke-test --stats`
- `.build/xcode/Build/Products/Debug/macparakeet-cli llm refine formal ... --stats`
- `.build/xcode/Build/Products/Debug/macparakeet-cli llm command ... --stats`
- `.build/xcode/Build/Products/Debug/macparakeet-cli llm generate ... --stats`

Result: local inference works on `mlx-community/Qwen3-8B-4bit` and returns clean final outputs (no `<think>` traces).

## ADR Alignment
- ADR-002: local-only processing
- ADR-004: deterministic pipeline baseline
- ADR-007: FluidAudio STT/ANE architecture
- ADR-008: Qwen3-8B + MLX runtime baseline

## Out of Scope
- Command mode GUI (selection capture + in-place replace UX)
- Dedicated `llm chat` CLI subcommand (single-turn transcript QA is currently exercised via `llm generate`)
- Chat-with-transcript GUI
- Benchmark matrix execution/tuning pass
