### PR TITLE
Add llm chat CLI baseline with transcript grounding, tests, and spec alignment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ All ADRs are in `spec/adr/`. These are locked decisions -- don't second-guess th
 ### v0.2 Clean Pipeline + AI
 - [x] Clean text pipeline (filler removal, custom words, snippets) -- deterministic, no LLM
 - [x] Custom words & snippets management UI (Vocabulary sidebar item)
-- [x] CLI commands: `macparakeet-cli flow process/words/snippets` + `macparakeet-cli llm generate/refine/command/smoke-test`
+- [x] CLI commands: `macparakeet-cli flow process/words/snippets` + `macparakeet-cli llm generate/refine/command/chat/smoke-test`
 - [x] Context modes (raw, clean, formal, email, code)
 - [x] AI text refinement via Qwen3-8B with deterministic fallback
 
@@ -542,6 +542,7 @@ swift run macparakeet-cli transcribe /path/to/audio.mp3
 swift run macparakeet-cli health
 swift run macparakeet-cli llm smoke-test --stats
 swift run macparakeet-cli llm refine formal "quick draft text"
+swift run macparakeet-cli llm chat "What changed?" --transcript-file /path/to/transcript.txt
 
 # Run tests (swift test works -- tests don't need Metal shaders)
 swift test

--- a/Package.swift
+++ b/Package.swift
@@ -66,6 +66,11 @@ let package = Package(
             name: "MacParakeetTests",
             dependencies: ["MacParakeetCore", "MacParakeetViewModels"],
             path: "Tests/MacParakeetTests"
+        ),
+        .testTarget(
+            name: "CLITests",
+            dependencies: ["CLI", "MacParakeetCore"],
+            path: "Tests/CLITests"
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Drag any audio or video file → get a transcript in seconds.
 ### Planned
 
 - **Command Mode** — Local LLM edits for command-mode workflows
-- **Chat with Transcript** — Ask questions about your transcriptions via local LLM
+- **Chat with Transcript (GUI)** — Ask questions about your transcriptions via local LLM
 - **More Exports** — DOCX and other formats
 
 ## Requirements
@@ -97,7 +97,7 @@ MacParakeet is built for **fast feedback loops**. AI agents make mistakes — bu
 - **Tests** — Unit and integration tests for all core logic (`swift test`)
 - **Internal CLI** — Headless interface to core services (transcribe files, test the pipeline) so changes can be verified without launching the GUI
   - Tip: use `swift run macparakeet-cli transcribe ... --database /tmp/macparakeet-dev.db` to avoid writing into your real app database during dev.
-  - Local LLM checks: `swift run macparakeet-cli llm smoke-test --stats` and `swift run macparakeet-cli llm refine formal "draft text"`.
+  - Local LLM checks: `swift run macparakeet-cli llm smoke-test --stats`, `swift run macparakeet-cli llm refine formal "draft text"`, and `swift run macparakeet-cli llm chat "question" --transcript-file /path/to/transcript.txt`.
   - See `docs/cli-testing.md` for GUI-parity vs deterministic testing modes.
 - **Protocol-based services** — Mockable boundaries make isolated testing straightforward
 

--- a/Sources/CLI/Commands/LLMCommand.swift
+++ b/Sources/CLI/Commands/LLMCommand.swift
@@ -11,6 +11,7 @@ struct LLMCommand: AsyncParsableCommand {
             Generate.self,
             Refine.self,
             CommandTransform.self,
+            Chat.self,
             SmokeTest.self,
         ]
     )
@@ -165,6 +166,48 @@ extension LLMCommand {
         }
     }
 
+    struct Chat: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "chat",
+            abstract: "Single-turn local chat (optionally grounded by transcript context)."
+        )
+
+        @Argument(help: "Question to ask the local model.")
+        var question: String
+
+        @Option(name: .long, help: "Optional transcript text file to append as context.")
+        var transcriptFile: String?
+
+        @OptionGroup
+        var runtime: LLMRuntimeOptions
+
+        @Flag(name: .long, help: "Copy result to clipboard.")
+        var copy: Bool = false
+
+        func run() async throws {
+            let question = question.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !question.isEmpty else {
+                throw CLIError.invalidQuestion
+            }
+
+            let transcriptContext = try LLMChatPromptComposer.loadTranscriptContext(
+                from: transcriptFile
+            )
+            let payload = LLMChatPromptComposer.compose(
+                question: question,
+                transcriptContext: transcriptContext
+            )
+
+            let request = LLMRequest(
+                prompt: payload.prompt,
+                systemPrompt: runtime.system ?? payload.defaultSystemPrompt,
+                options: runtime.generationOptions()
+            )
+
+            try await execute(request: request, runtime: runtime, copy: copy)
+        }
+    }
+
     struct SmokeTest: AsyncParsableCommand {
         static let configuration = CommandConfiguration(
             commandName: "smoke-test",
@@ -202,6 +245,58 @@ extension LLMCommand {
                 print("model=\(response.modelID)")
                 print(String(format: "duration=%.2fs", response.durationSeconds))
             }
+        }
+    }
+}
+
+struct LLMChatPromptPayload: Sendable {
+    let prompt: String
+    let defaultSystemPrompt: String
+}
+
+enum LLMChatPromptComposer {
+    static let defaultSystemPrompt = """
+    You are a concise assistant.
+    Answer directly and avoid unnecessary verbosity.
+    """
+
+    static func compose(question: String, transcriptContext: String?) -> LLMChatPromptPayload {
+        let trimmedQuestion = question.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let transcriptContext,
+           !transcriptContext.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            let task = LLMTask.transcriptChat(question: trimmedQuestion, transcript: transcriptContext)
+            return LLMChatPromptPayload(
+                prompt: LLMPromptBuilder.userPrompt(for: task),
+                defaultSystemPrompt: LLMPromptBuilder.systemPrompt(for: task)
+            )
+        }
+
+        return LLMChatPromptPayload(
+            prompt: trimmedQuestion,
+            defaultSystemPrompt: defaultSystemPrompt
+        )
+    }
+
+    static func loadTranscriptContext(from path: String?) throws -> String? {
+        guard let rawPath = path?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !rawPath.isEmpty
+        else {
+            return nil
+        }
+
+        let fileURL = URL(fileURLWithPath: rawPath)
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            throw CLIError.transcriptFileNotFound(rawPath)
+        }
+
+        do {
+            let transcript = try String(contentsOf: fileURL, encoding: .utf8)
+            let assembled = TranscriptContextAssembler.assemble(transcript: transcript)
+            let trimmed = assembled.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        } catch {
+            throw CLIError.transcriptFileReadFailed(rawPath, underlying: error)
         }
     }
 }

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -219,6 +219,9 @@ enum CLIError: Error, LocalizedError {
     case fileNotFound(String)
     case unsupportedFormat(String)
     case localLLMSmokeTestFailed(String)
+    case invalidQuestion
+    case transcriptFileNotFound(String)
+    case transcriptFileReadFailed(String, underlying: Error)
 
     var errorDescription: String? {
         switch self {
@@ -228,6 +231,12 @@ enum CLIError: Error, LocalizedError {
             return "Unsupported format: .\(ext). Supported: \(AudioFileConverter.supportedExtensions.sorted().joined(separator: ", "))"
         case .localLLMSmokeTestFailed(let output):
             return "LLM smoke test failed (unexpected response): \(output)"
+        case .invalidQuestion:
+            return "Question cannot be empty."
+        case .transcriptFileNotFound(let path):
+            return "Transcript file not found: \(path)"
+        case .transcriptFileReadFailed(let path, let underlying):
+            return "Failed to read transcript file at \(path): \(underlying.localizedDescription)"
         }
     }
 }

--- a/Tests/CLITests/LLMChatCommandTests.swift
+++ b/Tests/CLITests/LLMChatCommandTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import CLI
+
+final class LLMChatCommandTests: XCTestCase {
+    func testComposeWithoutTranscriptUsesDirectQuestion() {
+        let payload = LLMChatPromptComposer.compose(
+            question: "What are the key points?",
+            transcriptContext: nil
+        )
+
+        XCTAssertEqual(payload.prompt, "What are the key points?")
+        XCTAssertEqual(payload.defaultSystemPrompt, LLMChatPromptComposer.defaultSystemPrompt)
+    }
+
+    func testLoadTranscriptContextAndComposeUsesTranscriptPrompt() throws {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("llm-chat-context-\(UUID().uuidString).txt")
+        let transcript = String(repeating: "a", count: 13_000)
+        try transcript.write(to: tempURL, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        let context = try LLMChatPromptComposer.loadTranscriptContext(from: tempURL.path)
+        let payload = LLMChatPromptComposer.compose(
+            question: "Summarize this transcript",
+            transcriptContext: context
+        )
+
+        XCTAssertNotNil(context)
+        XCTAssertTrue(context?.contains("[...truncated...]") == true)
+        XCTAssertTrue(payload.prompt.contains("Transcript:"))
+        XCTAssertTrue(payload.prompt.contains("Question:"))
+    }
+
+    func testChatArgumentParsingReadsTranscriptSystemAndStatsFlags() throws {
+        let command = try LLMCommand.Chat.parse(
+            [
+                "What changed?",
+                "--transcript-file", "/tmp/transcript.txt",
+                "--system", "Be concise",
+                "--stats",
+            ]
+        )
+
+        XCTAssertEqual(command.question, "What changed?")
+        XCTAssertEqual(command.transcriptFile, "/tmp/transcript.txt")
+        XCTAssertEqual(command.runtime.system, "Be concise")
+        XCTAssertTrue(command.runtime.stats)
+    }
+}

--- a/Tests/CLITests/LLMChatCommandTests.swift
+++ b/Tests/CLITests/LLMChatCommandTests.swift
@@ -31,6 +31,31 @@ final class LLMChatCommandTests: XCTestCase {
         XCTAssertTrue(payload.prompt.contains("Question:"))
     }
 
+    func testLoadTranscriptContextThrowsWhenFileDoesNotExist() {
+        let missingPath = "/tmp/macparakeet-missing-\(UUID().uuidString).txt"
+
+        XCTAssertThrowsError(try LLMChatPromptComposer.loadTranscriptContext(from: missingPath)) { error in
+            guard case CLIError.transcriptFileNotFound(let path) = error else {
+                return XCTFail("Expected transcriptFileNotFound, got: \(error)")
+            }
+            XCTAssertEqual(path, missingPath)
+        }
+    }
+
+    func testLoadTranscriptContextThrowsWhenPathIsUnreadable() throws {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("llm-chat-dir-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        XCTAssertThrowsError(try LLMChatPromptComposer.loadTranscriptContext(from: directoryURL.path)) { error in
+            guard case CLIError.transcriptFileReadFailed(let path, _) = error else {
+                return XCTFail("Expected transcriptFileReadFailed, got: \(error)")
+            }
+            XCTAssertEqual(path, directoryURL.path)
+        }
+    }
+
     func testChatArgumentParsingReadsTranscriptSystemAndStatsFlags() throws {
         let command = try LLMCommand.Chat.parse(
             [

--- a/Tests/CLITests/LLMChatCommandTests.swift
+++ b/Tests/CLITests/LLMChatCommandTests.swift
@@ -26,6 +26,7 @@ final class LLMChatCommandTests: XCTestCase {
         )
 
         XCTAssertNotNil(context)
+        XCTAssertLessThanOrEqual(context?.count ?? .max, 12_000)
         XCTAssertTrue(context?.contains("[...truncated...]") == true)
         XCTAssertTrue(payload.prompt.contains("Transcript:"))
         XCTAssertTrue(payload.prompt.contains("Question:"))

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -93,6 +93,10 @@ swift run macparakeet-cli llm smoke-test --stats
 swift run macparakeet-cli llm generate "Summarize this paragraph in one sentence: ..."
 swift run macparakeet-cli llm refine formal "quick unpolished draft"
 swift run macparakeet-cli llm command "Translate to Spanish" "Hello, how are you?"
+swift run macparakeet-cli llm chat "What are the main decisions?"
+swift run macparakeet-cli llm chat "What blockers were mentioned?" \
+  --transcript-file /path/to/transcript.txt \
+  --stats
 ```
 
 ## Notes

--- a/plans/active/2026-02-qwen3-8b-implementation-checklist.md
+++ b/plans/active/2026-02-qwen3-8b-implementation-checklist.md
@@ -29,9 +29,9 @@ Ship production-ready local LLM integration for refinement + command mode using 
 - Route selected text + spoken command through shared LLM seam.
 - Preserve current selection-replace UX behavior and error paths.
 
-5. **Transcript chat baseline scaffolding**
+5. **Transcript chat baseline**
 - Add transcript context assembly utilities (bounded chunking/truncation).
-- Add chat request pathway behind feature flag if UI not ready.
+- Ship CLI chat request pathway (`macparakeet-cli llm chat`) while GUI remains pending.
 
 6. **Benchmark + hardening**
 - Run benchmark protocol in `docs/planning/2026-02-qwen3-8b-benchmark-plan.md`.
@@ -43,7 +43,7 @@ Ship production-ready local LLM integration for refinement + command mode using 
 1. Completed: foundation seam + fallback-safe wiring (`TextRefinementService`, deterministic fallback, tests).
 2. Completed: Qwen runtime integration with lazy load and idle unload in `MLXLLMService`.
 3. Completed: dictation/transcription context modes (`raw`, `clean`, `formal`, `email`, `code`) wired through app + CLI.
-4. Completed: transcript chat scaffolding via bounded context assembly utility.
+4. Completed: transcript chat CLI baseline via `macparakeet-cli llm chat` with bounded context assembly utility.
 5. Remaining: command mode GUI flow (selection capture and in-place replace UX).
 6. Remaining: benchmark run execution/tuning pass on target hardware matrix.
 

--- a/spec/07-text-processing.md
+++ b/spec/07-text-processing.md
@@ -255,4 +255,8 @@ macparakeet-cli llm refine code "check var name and update loop logic"
 
 # Apply a spoken-style command transform
 macparakeet-cli llm command "Translate to Spanish" "Hello, how are you?"
+
+# Single-turn chat (optional transcript grounding)
+macparakeet-cli llm chat "What were the key action items?"
+macparakeet-cli llm chat "What blockers were discussed?" --transcript-file /path/to/transcript.txt
 ```

--- a/spec/09-testing.md
+++ b/spec/09-testing.md
@@ -84,17 +84,16 @@ The suite includes targeted regressions for progress behavior in URL transcripti
 
 ### CLI Tests
 
-**What:** End-to-end flows through the CLI interface.
+**What:** Command parsing and prompt construction behavior for CLI surfaces.
 
-**How:** Real CLI binary + test database. Verify JSON output structure and content.
+**How:** XCTest against the `CLI` module (`CLITests` target), plus manual/automation smoke runs for full binary execution.
 
 **Examples:**
-- `transcribe <file>` returns valid JSON with transcript and timestamps
-- `flow process "text"` applies clean pipeline correctly
-- `flow words list` returns valid JSON array of custom words
-- `flow snippets add "my signature" "Best regards, David"` creates a snippet
+- `llm chat` prompt composition with and without transcript context
+- `llm chat` argument parsing (`--transcript-file`, `--system`, `--stats`)
+- transcript-file loader behavior (missing file, bounded context assembly)
 
-**Tip:** Use a throwaway database path in CLI tests (e.g. `--database /tmp/macparakeet-cli-test.db`) to avoid polluting the real app database.
+**Tip:** For runtime smoke runs, use a throwaway database path (e.g. `--database /tmp/macparakeet-cli-test.db`) to avoid polluting the real app database.
 
 ## What We Skip
 
@@ -215,13 +214,13 @@ Audio and transcript fixtures live in `Tests/Fixtures/`:
 
 ```
 Tests/
-  MacParakeetCoreTests/
-    Models/              # Model encoding, validation
-    Database/            # Repository tests, migration tests
-    Services/            # Integration tests with mocks
-    Pipeline/            # Text processing pipeline tests
-    CLI/                 # CLI end-to-end tests
-  Fixtures/              # Shared test data
+  MacParakeetTests/      # Core + ViewModel tests
+    Models/
+    Database/
+    Services/
+    TextProcessing/
+    LLM/
+  CLITests/              # CLI parsing/prompt tests
 ```
 
 ## Manual QA Checklist — Dictation Overlay

--- a/spec/11-llm-integration.md
+++ b/spec/11-llm-integration.md
@@ -10,7 +10,7 @@ This spec defines how MacParakeet integrates local LLM features with clean archi
 ## Goals
 
 1. Deliver AI text refinement modes (Formal, Email, Code) on top of deterministic cleanup.
-2. Reuse one LLM integration path for command mode and future transcript chat.
+2. Reuse one LLM integration path for command mode and transcript chat.
 3. Keep local-only guarantees and avoid Python/daemon dependencies.
 4. Fail gracefully without breaking dictation/transcription flows.
 
@@ -85,8 +85,9 @@ No data loss and no silent crash paths are allowed.
 2. **Command mode (CLI today, GUI pending)**
 - selected text + spoken command -> LLM request (`commandTransform`) -> replace selection
 
-3. **Transcript chat (future scaffolding)**
-- query + transcript context chunking -> LLM request (`transcriptChat`)
+3. **Transcript chat (CLI baseline, GUI pending)**
+- query + optional transcript context chunking -> LLM request (`transcriptChat`)
+- available in CLI via `macparakeet-cli llm chat ... --transcript-file <path>`
 
 ---
 
@@ -120,6 +121,7 @@ All categories must map to user-safe fallback behavior.
 1. `PromptBuilder` per task and mode.
 2. `FallbackPolicy` for all error categories.
 3. `LLMServiceProtocol` mock-driven tests in dictation/command flows.
+4. CLI chat prompt + argument parsing tests (`llm chat` with transcript context).
 
 ### Integration
 
@@ -140,5 +142,6 @@ All categories must map to user-safe fallback behavior.
 2. Failure path returns deterministic-safe output and surfaces recoverable UI notice.
 3. No Python runtime or daemon dependency introduced.
 4. `swift test` remains green with new LLM seam tests.
+5. CLI single-turn chat supports optional transcript file context with bounded assembly.
 
 Latency metrics are tracked and monitored, but not used as hard release gates in this phase.

--- a/spec/README.md
+++ b/spec/README.md
@@ -82,7 +82,7 @@ Dictation + transcription + history + settings. Get audio in, text out, pasted i
 - [x] AI text refinement (Qwen3-8B: formal, email, code modes)
 - [x] Custom words & snippets management UI
 - [ ] Personal dictionary (auto-learns vocabulary)
-- [x] CLI commands (`macparakeet-cli flow process/words/snippets` + `macparakeet-cli llm generate/refine/command/smoke-test`)
+- [x] CLI commands (`macparakeet-cli flow process/words/snippets` + `macparakeet-cli llm generate/refine/command/chat/smoke-test`)
 
 ### v0.3 Command Mode & Export (In Progress)
 


### PR DESCRIPTION
## Why this PR
This PR ships the first production-usable transcript-chat baseline for local LLM workflows in the CLI so we can validate quality and runtime behavior before GUI command/chat UX lands.

It intentionally keeps scope tight: single-turn chat, optional transcript grounding, and full docs/spec alignment.

## What changed
### 1) New CLI capability
- Added `macparakeet-cli llm chat "<question>"`
- Added optional `--transcript-file <path>` for transcript-grounded Q&A
- Reused shared runtime options (`--model`, `--revision`, `--temperature`, `--top-p`, `--max-tokens`, `--timeout`, `--system`, `--stats`, `--dry-run`, `--copy`)

### 2) Prompt and context composition
- Added `LLMChatPromptComposer` that:
  - uses direct-question prompt when no transcript context is provided
  - uses `LLMTask.transcriptChat` prompt/system templates when transcript context is provided
  - bounds transcript size via `TranscriptContextAssembler.assemble(...)`

### 3) Error handling
- Added explicit CLI errors for:
  - empty/invalid question
  - transcript file not found
  - transcript file read failure

### 4) Test coverage
- Added dedicated `CLITests` SwiftPM target
- Added `LLMChatCommandTests` covering:
  - direct prompt composition (no transcript)
  - transcript context load + bounded prompt shaping
  - argument parsing for `--transcript-file`, `--system`, `--stats`
  - missing transcript file (`transcriptFileNotFound`)
  - unreadable transcript path (`transcriptFileReadFailed`)

### 5) Docs/spec alignment
Updated command matrices, test strategy text, and implementation status in:
- `README.md`
- `docs/cli-testing.md`
- `spec/07-text-processing.md`
- `spec/09-testing.md`
- `spec/11-llm-integration.md`
- `spec/README.md`
- `CLAUDE.md`
- `plans/active/2026-02-qwen3-8b-implementation-checklist.md`

## Behavior details
- `llm chat` validates question input before model invocation.
- If transcript file is present and valid, the prompt becomes transcript-grounded Q&A.
- If transcript content is oversized, it is bounded with existing truncation strategy before request creation.
- `--system` remains an explicit override for advanced debugging/tuning.

## Validation performed
- `swift test` locally (372/372 passing)
- `swift run macparakeet-cli llm --help`
- `swift run macparakeet-cli help llm chat`
- dry-run prompt verification for transcript-grounded chat path
- failure-path check for missing transcript file

## Out of scope (intentional)
- GUI transcript chat UX
- multi-turn chat state/memory
- retrieval/indexing beyond bounded transcript context
- model/runtime changes beyond existing Qwen3-8B + MLX stack

## ADR alignment
- ADR-004: deterministic-first/fallback-safe processing philosophy
- ADR-008: single local LLM runtime/model baseline


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added llm chat command for single-turn conversations with optional transcript-file context and configurable system prompt.

* **Documentation**
  * Updated CLI examples, specs, and guides to document the new chat workflow and GUI naming note.

* **Tests**
  * Added CLI-focused tests covering chat prompt composition, argument parsing, transcript loading, and related behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->