### PR TITLE
Add rigorous Qwen 4B vs 8B benchmark report and eval harnesses

### DIFF
--- a/docs/planning/2026-02-local-llm-planning-pack.md
+++ b/docs/planning/2026-02-local-llm-planning-pack.md
@@ -10,6 +10,7 @@ Scope: Production planning for local LLM integration in MacParakeet.
 3. Benchmark protocol: `docs/planning/2026-02-qwen3-8b-benchmark-plan.md`
 4. Execution checklist: `plans/active/2026-02-qwen3-8b-implementation-checklist.md`
 5. Risk register: `docs/planning/llm-runtime-risk-register.md`
+6. 4B vs 8B benchmark report: `docs/planning/2026-02-qwen-4b-vs-8b-benchmark-report.md`
 
 ## What This Enables
 

--- a/docs/planning/2026-02-qwen-4b-vs-8b-benchmark-report.md
+++ b/docs/planning/2026-02-qwen-4b-vs-8b-benchmark-report.md
@@ -1,0 +1,161 @@
+# Qwen 4B vs 8B Benchmark Report (Local + External Alignment)
+
+Last updated: 2026-02-13
+Owner: Core
+
+## Scope
+
+- Local models tested:
+  - `mlx-community/Qwen3-4B-4bit`
+  - `mlx-community/Qwen3-8B-4bit`
+- Runtime: release `macparakeet-cli` via MLX-Swift-LM
+- Machine:
+  - Apple M4 Pro
+  - 48 GB RAM
+  - macOS 26.2 (25C56)
+- Test goals:
+  - Measure practical latency and memory in app-relevant workloads.
+  - Score strict quality behavior (format/factual/constraint compliance).
+  - Compare with official/public benchmarks.
+
+## Reproducibility
+
+- Perf harness: `scripts/dev/benchmark_qwen_models.sh`
+- Quality harness: `scripts/dev/quality_eval_qwen.sh`
+- Main perf raw file:
+  - `output/benchmarks/qwen-model-benchmark-20260213-232540.tsv`
+- Main perf summary:
+  - `output/benchmarks/qwen-model-benchmark-20260213-232540-summary.tsv`
+- Main quality file:
+  - `output/benchmarks/qwen-quality-eval-20260213-233719.tsv`
+
+## Local Perf Results
+
+### Aggregate (40 runs total, 20/model)
+
+| Model | Avg CLI gen time | Avg wall time | Avg peak memory |
+|---|---:|---:|---:|
+| Qwen3-4B-4bit | 2.932s | 5.995s | 2.90 GB |
+| Qwen3-8B-4bit | 5.207s | 8.405s | 5.03 GB |
+
+### By scenario (avg CLI generation time)
+
+| Scenario | 4B | 8B | 8B slowdown |
+|---|---:|---:|---:|
+| refine-short | 1.078s | 2.168s | 2.01x |
+| refine-long | 3.358s | 6.324s | 1.88x |
+| command | 4.576s | 7.204s | 1.57x |
+| transcript-qa | 2.718s | 5.130s | 1.89x |
+
+### Cold vs warm note
+
+- In this CLI harness, each invocation is a separate process, so "warm" here is mostly OS/cache warmth, not true in-process warm state.
+- Observed cold vs warm differences were small in this setup.
+
+## Strict Quality Results
+
+Quality suite used 8 deterministic checks per model:
+- factual extraction (decision triples)
+- hallucination resistance (exact unknown-date response)
+- wrapper/chatter suppression in formal refine
+- strict JSON compliance
+- hard word-count constraint
+- structured bullet/owner output
+- terse response constraint
+- fact preservation in transform
+
+### Pass rates
+
+| Model | Passed | Total | Pass rate |
+|---|---:|---:|---:|
+| Qwen3-4B-4bit | 5 | 8 | 62.5% |
+| Qwen3-8B-4bit | 6 | 8 | 75.0% |
+
+### Notable failures
+
+- 4B hallucination on unknown-date test:
+  - Returned "Thursday end of day" as if calendar date.
+- 4B and 8B failed exact 12-word constraint (both produced 9-word output).
+- 4B and 8B injected wrapper formatting in formal-refine (`Subject:`, salutations, or similar).
+
+Implication:
+- 8B is materially better on strict factual compliance.
+- Both models need prompt/runtime guardrails for exact formatting constraints.
+
+## External Benchmark Alignment
+
+### Official Qwen3 technical report (base models)
+
+Source: Qwen3 technical report table snapshots (`Qwen3-4B` vs `Qwen3-8B` base).
+
+- MMLU-Pro:
+  - 4B: 50.58
+  - 8B: 56.73
+- SuperGPQA:
+  - 4B: 28.43
+  - 8B: 31.64
+- GPQA:
+  - 4B: 36.87
+  - 8B: 44.44
+
+Interpretation:
+- Official benchmarks show 8B > 4B on reasoning/knowledge-heavy tasks.
+- This matches local quality results (8B higher strict pass rate) at the expected latency/memory cost.
+
+### Official Qwen3-4B-Instruct-2507 update
+
+Source: `Qwen/Qwen3-4B-Instruct-2507` model card benchmark table.
+
+Examples (4B non-thinking -> 4B-Instruct-2507):
+- MMLU-Pro: 58.0 -> 69.6
+- GPQA: 41.7 -> 62.0
+- AIME25: 19.1 -> 47.4
+- LiveBench: 48.4 -> 63.0
+- Arena-Hard v2: 9.5 -> 43.4
+
+Interpretation:
+- Official numbers suggest major upside from newer `-2507` variants.
+- Current local benchmark tested older `mlx-community/*-4bit` baselines, so next pass should include `-2507` model IDs for an apples-to-apples update decision.
+
+## Benchmark Methodology Upgrades (Paper-Informed)
+
+The following are directly motivated by published eval work:
+
+1. Multi-metric evaluation over single-score ranking.
+   - Inspired by HELM: evaluate accuracy + robustness + efficiency + safety dimensions.
+2. Human-calibrated open-ended quality checks.
+   - Inspired by MT-Bench/Chatbot Arena: automated judging is useful but should be calibrated to human preference.
+3. Length/style bias controls in auto-eval.
+   - Inspired by Length-Controlled AlpacaEval.
+4. Anti-gaming tests.
+   - Inspired by "Cheating Automatic LLM Benchmarks": include null/adversarial probes to detect benchmark overfitting.
+5. Reproducibility hygiene.
+   - Inspired by "Lessons from the Trenches": fixed prompts, fixed seeds where possible, pinned runtime/model versions, and tracked raw artifacts.
+
+## Honest Assessment
+
+- If priority is responsiveness and memory headroom: 4B remains attractive.
+- If priority is instruction reliability/factual control in transforms and transcript QA: 8B is clearly safer.
+- Current prompts are not hardened enough for strict formatting and "no-wrapper" behavior in either model.
+- Biggest near-term opportunity is not just 4B vs 8B; it is evaluating newer `-2507` variants under the same harness.
+
+## Final Recommendations
+
+1. Keep 8B as quality-first default for command mode and transcript QA.
+2. Keep 4B as a fallback/low-memory profile for fast refinement.
+3. Run the exact same harness on `Qwen3-4B-Instruct-2507` and `Qwen3-8B-Instruct-2507` (MLX variants) before locking long-term defaults.
+4. Add a hardening pass to prompts/post-processing:
+   - enforce no-wrapper output mode
+   - enforce exact format outputs (JSON/word-count) with validator + retry
+   - add hallucination guard prompts for "unknown/not present" extraction
+
+## Sources
+
+- Qwen3 technical report (arXiv): https://arxiv.org/abs/2505.09388
+- Qwen3 technical report (HTML mirror with tables): https://ar5iv.org/html/2505.09388
+- Qwen3-4B-Instruct-2507 model card: https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507
+- HELM paper: https://arxiv.org/abs/2211.09110
+- MT-Bench / Chatbot Arena paper: https://arxiv.org/abs/2306.05685
+- Length-Controlled AlpacaEval: https://arxiv.org/abs/2404.04475
+- Cheating Automatic LLM Benchmarks: https://arxiv.org/abs/2410.07137
+- Lessons from the Trenches on reproducible evaluation: https://arxiv.org/abs/2405.14782

--- a/scripts/dev/benchmark_qwen_models.sh
+++ b/scripts/dev/benchmark_qwen_models.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BIN_DEFAULT="$ROOT_DIR/.build/arm64-apple-macosx/release/macparakeet-cli"
+BIN="${BIN:-$BIN_DEFAULT}"
+OUT_DIR="${OUT_DIR:-$ROOT_DIR/output/benchmarks}"
+REPS="${REPS:-5}"
+STAMP="${STAMP:-$(date +%Y%m%d-%H%M%S)}"
+
+if [[ ! -x "$BIN" ]]; then
+  echo "error: binary not found or not executable: $BIN" >&2
+  echo "hint: swift build -c release --product macparakeet-cli" >&2
+  exit 1
+fi
+
+if ! [[ "$REPS" =~ ^[0-9]+$ ]] || [[ "$REPS" -lt 1 ]]; then
+  echo "error: REPS must be a positive integer (got: $REPS)" >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+RESULTS_TSV="$OUT_DIR/qwen-model-benchmark-$STAMP.tsv"
+SUMMARY_TSV="$OUT_DIR/qwen-model-benchmark-$STAMP-summary.tsv"
+
+SHORT_TEXT="hey team quick update i shipped the fix for the menu bar crash this morning and i still need to add the regression test and post release notes can you review after lunch"
+LONG_TEXT="yesterday we wrapped the first pass of the onboarding rewrite and the core flow works, but the copy still feels uneven and the handoff between setup screens is abrupt. several users said they understood the value only after the third screen, which means we are front loading details instead of outcomes. i want this rewritten in a clearer, calmer tone that still sounds like us. keep the meaning, but tighten the language, remove repetition, and keep specific commitments. we will keep the launch date for march, but only if we close three risks this week: analytics parity, keyboard shortcut conflicts, and one accessibility bug in the dictation overlay. engineering owns analytics parity and shortcut conflict checks. design owns content polish and visual hierarchy updates. i own final review and launch go no go decision. if any risk slips, we cut non critical polish and preserve reliability first."
+
+TRANSCRIPT_FILE="$OUT_DIR/transcript-sample-$STAMP.txt"
+cat > "$TRANSCRIPT_FILE" <<'TXT'
+[00:00] Maya: Thanks everyone. Quick planning sync for the transcription app release.
+[00:15] Ethan: Current build is stable on M-series laptops, but we still see occasional UI lag when users trigger command mode repeatedly.
+[00:33] Priya: For scope, we agreed to ship with three AI refinement presets only: formal, email, and code. We are deferring custom presets.
+[00:58] Maya: Right. Decision one: keep preset list fixed for this release. Owner Priya to update docs by Tuesday.
+[01:19] Ethan: Decision two: command mode stays text-only in v1. No rich-text formatting transforms.
+[01:33] Maya: Owner Ethan for that implementation and tests by Wednesday.
+[01:50] Noah: Analytics status: event schema is ready, but dashboard filters are incomplete.
+[02:05] Maya: Decision three: launch requires analytics dashboard parity with baseline metrics. Owner Noah, target Thursday end of day.
+[02:28] Priya: Customer interview notes also show confusion around the phrase "auto-polish." We should rename that label.
+[02:46] Maya: Good catch. Not a release blocker, but we should update copy before final RC.
+[03:04] Ethan: Risk list recap: command mode latency spikes, dashboard parity gap, and one accessibility issue with voiceover focus in settings.
+[03:23] Maya: Accessibility bug is a blocker. Owner Maya with support from Ethan. Patch by Wednesday morning.
+[03:42] Noah: If one blocker slips, do we move date?
+[03:50] Maya: Yes, reliability beats schedule. We slip if blockers are unresolved.
+[04:02] Priya: Action recap: Priya docs Tuesday, Ethan command-mode tests Wednesday, Noah analytics parity Thursday, Maya accessibility patch Wednesday.
+TXT
+
+echo -e "model\tscenario\trun_index\tphase\tcli_duration_s\treal_s\tuser_s\tsys_s\tmax_rss_kb\tpeak_mem_bytes\texit_code\toutput_file\ttime_file" > "$RESULTS_TSV"
+
+run_case() {
+  local model="$1"
+  local scenario="$2"
+  local run_index="$3"
+  shift 3
+
+  local phase="warm"
+  if [[ "$run_index" -eq 1 ]]; then
+    phase="cold"
+  fi
+
+  local safe_model="${model//\//_}"
+  local out_file="$OUT_DIR/${STAMP}-${safe_model}-${scenario}-${run_index}.out.txt"
+  local time_file="$OUT_DIR/${STAMP}-${safe_model}-${scenario}-${run_index}.time.txt"
+
+  set +e
+  /usr/bin/time -lp "$@" >"$out_file" 2>"$time_file"
+  local ec=$?
+  set -e
+
+  local cli_duration
+  cli_duration=$( (rg -o "duration=[0-9]+(\\.[0-9]+)?s" "$out_file" || true) | head -n1 | sed 's/duration=//;s/s//')
+  local real_s
+  real_s=$( (rg '^real ' "$time_file" || true) | awk '{print $2}' | head -n1)
+  local user_s
+  user_s=$( (rg '^user ' "$time_file" || true) | awk '{print $2}' | head -n1)
+  local sys_s
+  sys_s=$( (rg '^sys ' "$time_file" || true) | awk '{print $2}' | head -n1)
+  local max_rss_kb
+  max_rss_kb=$( (rg 'maximum resident set size' "$time_file" || true) | awk '{print $1}' | head -n1)
+  local peak_mem_bytes
+  peak_mem_bytes=$( (rg 'peak memory footprint' "$time_file" || true) | awk '{print $1}' | head -n1)
+
+  [[ -n "$cli_duration" ]] || cli_duration="NA"
+  [[ -n "$real_s" ]] || real_s="NA"
+  [[ -n "$user_s" ]] || user_s="NA"
+  [[ -n "$sys_s" ]] || sys_s="NA"
+  [[ -n "$max_rss_kb" ]] || max_rss_kb="NA"
+  [[ -n "$peak_mem_bytes" ]] || peak_mem_bytes="NA"
+
+  echo -e "$model\t$scenario\t$run_index\t$phase\t$cli_duration\t$real_s\t$user_s\t$sys_s\t$max_rss_kb\t$peak_mem_bytes\t$ec\t$out_file\t$time_file" >> "$RESULTS_TSV"
+}
+
+run_suite_for_model() {
+  local model="$1"
+  for run_index in $(seq 1 "$REPS"); do
+    run_case "$model" "refine-short" "$run_index" \
+      "$BIN" llm refine formal "$SHORT_TEXT" \
+      --model "$model" --stats --temperature 0.2 --max-tokens 180
+
+    run_case "$model" "refine-long" "$run_index" \
+      "$BIN" llm refine formal "$LONG_TEXT" \
+      --model "$model" --stats --temperature 0.2 --max-tokens 280
+
+    run_case "$model" "command" "$run_index" \
+      "$BIN" llm command "Rewrite this as release notes with concise bullet points and explicit owners." "$LONG_TEXT" \
+      --model "$model" --stats --temperature 0.2 --max-tokens 260
+
+    run_case "$model" "transcript-qa" "$run_index" \
+      "$BIN" llm chat "What are the three release decisions, their owners, and due dates?" \
+      --transcript-file "$TRANSCRIPT_FILE" \
+      --model "$model" --stats --temperature 0.2 --max-tokens 240
+  done
+}
+
+run_suite_for_model "mlx-community/Qwen3-4B-4bit"
+run_suite_for_model "mlx-community/Qwen3-8B-4bit"
+
+awk -F '\t' '
+  NR == 1 { next }
+  $11 != 0 { next }
+  {
+    key = $1 FS $2 FS $4
+    n[key]++
+    sum_cli[key] += $5
+    sum_cli_sq[key] += ($5 * $5)
+    sum_real[key] += $6
+    sum_real_sq[key] += ($6 * $6)
+    sum_rss[key] += $9
+    sum_peak[key] += $10
+    if (!(key in min_cli) || $5 < min_cli[key]) min_cli[key] = $5
+    if (!(key in max_cli) || $5 > max_cli[key]) max_cli[key] = $5
+    if (!(key in min_real) || $6 < min_real[key]) min_real[key] = $6
+    if (!(key in max_real) || $6 > max_real[key]) max_real[key] = $6
+    if (!(key in min_peak) || $10 < min_peak[key]) min_peak[key] = $10
+    if (!(key in max_peak) || $10 > max_peak[key]) max_peak[key] = $10
+    if (!(key in min_rss) || $9 < min_rss[key]) min_rss[key] = $9
+    if (!(key in max_rss) || $9 > max_rss[key]) max_rss[key] = $9
+  }
+END {
+  print "model\tscenario\tphase\tn\tavg_cli_s\tstd_cli_s\tmin_cli_s\tmax_cli_s\tavg_real_s\tstd_real_s\tmin_real_s\tmax_real_s\tavg_rss_gb\tavg_peak_mem_gb\tmin_peak_mem_gb\tmax_peak_mem_gb"
+  for (k in n) {
+    avg_cli = sum_cli[k] / n[k]
+    var_cli = (sum_cli_sq[k] / n[k]) - (avg_cli * avg_cli)
+    if (var_cli < 0) var_cli = 0
+    std_cli = sqrt(var_cli)
+    avg_real = sum_real[k] / n[k]
+    var_real = (sum_real_sq[k] / n[k]) - (avg_real * avg_real)
+    if (var_real < 0) var_real = 0
+    std_real = sqrt(var_real)
+    avg_rss_gb = (sum_rss[k] / n[k]) / 1024 / 1024 / 1024
+    avg_peak_gb = (sum_peak[k] / n[k]) / 1024 / 1024 / 1024
+    min_peak_gb = min_peak[k] / 1024 / 1024 / 1024
+    max_peak_gb = max_peak[k] / 1024 / 1024 / 1024
+    split(k, p, FS)
+    printf "%s\t%s\t%s\t%d\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.3f\t%.2f\t%.2f\t%.2f\t%.2f\n",
+      p[1], p[2], p[3], n[k], avg_cli, std_cli, min_cli[k], max_cli[k], avg_real, std_real, min_real[k], max_real[k], avg_rss_gb, avg_peak_gb, min_peak_gb, max_peak_gb
+  }
+}' "$RESULTS_TSV" | sort > "$SUMMARY_TSV"
+
+echo "RESULTS_TSV=$RESULTS_TSV"
+echo "SUMMARY_TSV=$SUMMARY_TSV"
+echo "TRANSCRIPT_FILE=$TRANSCRIPT_FILE"

--- a/scripts/dev/quality_eval_qwen.sh
+++ b/scripts/dev/quality_eval_qwen.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BIN_DEFAULT="$ROOT_DIR/.build/arm64-apple-macosx/release/macparakeet-cli"
+BIN="${BIN:-$BIN_DEFAULT}"
+OUT_DIR="${OUT_DIR:-$ROOT_DIR/output/benchmarks}"
+STAMP="${STAMP:-$(date +%Y%m%d-%H%M%S)}"
+
+if [[ ! -x "$BIN" ]]; then
+  echo "error: binary not found or not executable: $BIN" >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+RESULTS_TSV="$OUT_DIR/qwen-quality-eval-$STAMP.tsv"
+
+TRANSCRIPT_FILE="$OUT_DIR/quality-transcript-$STAMP.txt"
+cat > "$TRANSCRIPT_FILE" <<'TXT'
+[00:00] Maya: Thanks everyone. Quick planning sync for the transcription app release.
+[00:58] Maya: Decision one: keep preset list fixed for this release. Owner Priya to update docs by Tuesday.
+[01:19] Ethan: Decision two: command mode stays text-only in v1. No rich-text formatting transforms.
+[01:33] Maya: Owner Ethan for that implementation and tests by Wednesday.
+[02:05] Maya: Decision three: launch requires analytics dashboard parity with baseline metrics. Owner Noah, target Thursday end of day.
+[03:50] Maya: Reliability beats schedule. We slip if blockers are unresolved.
+TXT
+
+echo -e "model\tcase_id\tpass\tdetail\toutput_file" > "$RESULTS_TSV"
+
+trim_output() {
+  local file="$1"
+  sed '/^model=/d;/^duration=/d' "$file"
+}
+
+run_case() {
+  local model="$1"
+  local case_id="$2"
+  shift 2
+  local out_file="$OUT_DIR/${STAMP}-${model//\//_}-${case_id}.out.txt"
+
+  set +e
+  "$@" >"$out_file" 2>&1
+  local ec=$?
+  set -e
+
+  if [[ "$ec" -ne 0 ]]; then
+    echo -e "$model\t$case_id\t0\tcommand_failed:$ec\t$out_file" >> "$RESULTS_TSV"
+    return
+  fi
+
+  local cleaned
+  cleaned="$(trim_output "$out_file")"
+  local pass="0"
+  local detail=""
+
+  case "$case_id" in
+    qa_decisions)
+      if grep -qi 'Priya' <<<"$cleaned" && grep -qi 'Tuesday' <<<"$cleaned" && \
+         grep -qi 'Ethan' <<<"$cleaned" && grep -qi 'Wednesday' <<<"$cleaned" && \
+         grep -qi 'Noah' <<<"$cleaned" && grep -qi 'Thursday' <<<"$cleaned"; then
+        pass="1"; detail="all_decision_triples_present"
+      else
+        detail="missing_decision_triples"
+      fi
+      ;;
+    qa_unknown_date)
+      local normalized
+      normalized="$(echo "$cleaned" | tr '\n' ' ' | sed 's/[[:space:]]\\+/ /g;s/^ //;s/ $//')"
+      if [[ "$normalized" == "NOT SPECIFIED" ]]; then
+        pass="1"; detail="exact_not_specified"
+      else
+        detail="possible_hallucination"
+      fi
+      ;;
+    refine_no_chatter)
+      if grep -Eqi 'Certainly|Here.s|Let me know|---|As requested|Subject:|Dear Team|Best regards' <<<"$cleaned"; then
+        detail="has_wrapper_chatter"
+      else
+        pass="1"; detail="clean_output_no_wrapper"
+      fi
+      ;;
+    strict_json)
+      if command -v jq >/dev/null 2>&1 && jq -e . >/dev/null 2>&1 <<<"$cleaned"; then
+        if jq -e 'has("action") and has("owner") and has("deadline")' >/dev/null 2>&1 <<<"$cleaned"; then
+          pass="1"; detail="valid_json_required_keys"
+        else
+          detail="json_missing_required_keys"
+        fi
+      else
+        detail="invalid_json_or_extra_text"
+      fi
+      ;;
+    exact_12_words)
+      local wc_count
+      wc_count="$(tr '\n' ' ' <<<"$cleaned" | sed 's/[[:space:]]\+/ /g;s/^ //;s/ $//' | wc -w | tr -d ' ')"
+      if [[ "$wc_count" == "12" ]]; then
+        pass="1"; detail="word_count_12"
+      else
+        detail="word_count_${wc_count}"
+      fi
+      ;;
+    bullet_owners)
+      local bullet_count
+      bullet_count="$(grep -Ec '^[[:space:]]*[-*]' <<<"$cleaned" || true)"
+      if [[ "$bullet_count" -ge 3 ]] && grep -qi 'Engineering' <<<"$cleaned" && grep -qi 'Design' <<<"$cleaned"; then
+        pass="1"; detail="bullets_and_owners_present"
+      else
+        detail="missing_bullets_or_owners"
+      fi
+      ;;
+    terse_answer)
+      if grep -Eq '^.{1,80}$' <<<"$(echo "$cleaned" | tr -d '\n')" && ! grep -Eqi 'because|however|additionally' <<<"$cleaned"; then
+        pass="1"; detail="terse_response_ok"
+      else
+        detail="too_verbose"
+      fi
+      ;;
+    command_preserve_facts)
+      if grep -qi 'March' <<<"$cleaned" && grep -qi 'analytics parity' <<<"$cleaned" && grep -qi 'accessibility' <<<"$cleaned"; then
+        pass="1"; detail="core_facts_preserved"
+      else
+        detail="facts_missing"
+      fi
+      ;;
+    *)
+      detail="unknown_case"
+      ;;
+  esac
+
+  echo -e "$model\t$case_id\t$pass\t$detail\t$out_file" >> "$RESULTS_TSV"
+}
+
+SHORT_TEXT="hey team quick update i shipped the fix for the menu bar crash this morning and i still need to add the regression test and post release notes can you review after lunch"
+LONG_TEXT="yesterday we wrapped the first pass of the onboarding rewrite and the core flow works, but the copy still feels uneven and the handoff between setup screens is abrupt. several users said they understood the value only after the third screen, which means we are front loading details instead of outcomes. we will keep the launch date for march, but only if we close three risks this week: analytics parity, keyboard shortcut conflicts, and one accessibility bug in the dictation overlay. engineering owns analytics parity and shortcut conflict checks. design owns content polish and visual hierarchy updates. i own final review and launch go no go decision."
+
+for model in "mlx-community/Qwen3-4B-4bit" "mlx-community/Qwen3-8B-4bit"; do
+  run_case "$model" "qa_decisions" \
+    "$BIN" llm chat "List the three release decisions with owner and due date." \
+      --transcript-file "$TRANSCRIPT_FILE" --model "$model" --stats --temperature 0.2 --max-tokens 220
+
+  run_case "$model" "qa_unknown_date" \
+    "$BIN" llm chat "What calendar launch date is confirmed in the transcript? If no date is present, reply with exactly: NOT SPECIFIED" \
+      --transcript-file "$TRANSCRIPT_FILE" --model "$model" --stats --temperature 0.0 --max-tokens 80
+
+  run_case "$model" "refine_no_chatter" \
+    "$BIN" llm refine formal "$SHORT_TEXT" --model "$model" --stats --temperature 0.2 --max-tokens 140
+
+  run_case "$model" "strict_json" \
+    "$BIN" llm generate "Output ONLY valid JSON with keys action, owner, deadline extracted from: 'Priya updates docs by Tuesday'. No markdown." \
+      --model "$model" --stats --temperature 0.0 --max-tokens 80
+
+  run_case "$model" "exact_12_words" \
+    "$BIN" llm generate "Rewrite this in exactly 12 words and output only that sentence: reliability beats schedule so we slip if blockers remain" \
+      --model "$model" --stats --temperature 0.0 --max-tokens 40
+
+  run_case "$model" "bullet_owners" \
+    "$BIN" llm command "Convert to bullet release notes with explicit owners." "$LONG_TEXT" \
+      --model "$model" --stats --temperature 0.2 --max-tokens 260
+
+  run_case "$model" "terse_answer" \
+    "$BIN" llm chat "In at most 12 words: what is the launch gating principle?" \
+      --transcript-file "$TRANSCRIPT_FILE" --model "$model" --stats --temperature 0.0 --max-tokens 24
+
+  run_case "$model" "command_preserve_facts" \
+    "$BIN" llm command "Rewrite as an executive update paragraph." "$LONG_TEXT" \
+      --model "$model" --stats --temperature 0.2 --max-tokens 220
+done
+
+echo "RESULTS_TSV=$RESULTS_TSV"


### PR DESCRIPTION
## Summary
This PR adds a rigorous, reproducible benchmark package for **Qwen 4B vs 8B** in MacParakeet:

1. Production-focused latency/memory harness.
2. Strict quality-eval harness for factual/format constraints.
3. Comprehensive benchmark report with external-source alignment and recommendations.

## What Changed
- Added perf harness: `scripts/dev/benchmark_qwen_models.sh`
- Added strict quality harness: `scripts/dev/quality_eval_qwen.sh`
- Added report: `docs/planning/2026-02-qwen-4b-vs-8b-benchmark-report.md`
- Linked planning pack entry: `docs/planning/2026-02-local-llm-planning-pack.md`

## Local Benchmark Results (Apple M4 Pro, 48GB, macOS 26.2)
Dataset: 40 perf runs total (20/model).

### Aggregate
| Model | Avg generation (CLI) | Avg wall time | Avg peak memory |
|---|---:|---:|---:|
| Qwen3-4B-4bit | 2.932s | 5.995s | 2.90 GB |
| Qwen3-8B-4bit | 5.207s | 8.405s | 5.03 GB |

### Per-scenario generation time
| Scenario | 4B | 8B | 8B slowdown |
|---|---:|---:|---:|
| refine-short | 1.078s | 2.168s | 2.01x |
| refine-long | 3.358s | 6.324s | 1.88x |
| command | 4.576s | 7.204s | 1.57x |
| transcript-qa | 2.718s | 5.130s | 1.89x |

### Cold vs warm (CLI process model)
| Model | Cold avg generation | Warm avg generation | Cold avg wall | Warm avg wall |
|---|---:|---:|---:|---:|
| Qwen3-4B-4bit | 2.942s | 2.930s | 6.060s | 5.979s |
| Qwen3-8B-4bit | 5.135s | 5.224s | 8.343s | 8.420s |

Note: each run is a fresh CLI process, so “warm” here reflects cache/OS effects, not in-process session warmth.

## Strict Quality Eval Results
8 deterministic checks per model (factual extraction, hallucination resistance, wrapper suppression, strict JSON, hard word-count, structured owners, terseness, fact preservation).

### Scorecard
| Model | Passed | Total | Pass rate |
|---|---:|---:|---:|
| Qwen3-4B-4bit | 5 | 8 | 62.5% |
| Qwen3-8B-4bit | 6 | 8 | 75.0% |

### Failing cases
| Model | Case | Failure detail |
|---|---|---|
| Qwen3-4B-4bit | `qa_unknown_date` | hallucinated “Thursday end of day” instead of exact `NOT SPECIFIED` |
| Qwen3-4B-4bit | `refine_no_chatter` | wrapper chatter (`Certainly…`, subject/salutation patterns) |
| Qwen3-4B-4bit | `exact_12_words` | returned 9 words |
| Qwen3-8B-4bit | `refine_no_chatter` | wrapper formatting (`Subject:`, salutation) |
| Qwen3-8B-4bit | `exact_12_words` | returned 9 words |

## External Benchmark Alignment
### Qwen3 technical report (base models)
| Benchmark | Qwen3-4B | Qwen3-8B |
|---|---:|---:|
| MMLU-Pro | 50.58 | 56.73 |
| SuperGPQA | 28.43 | 31.64 |
| GPQA | 36.87 | 44.44 |

Interpretation: official public benchmarks show 8B > 4B on reasoning-heavy tasks, matching local strict-quality direction.

### Qwen3-4B-Instruct-2507 uplift (model card)
| Benchmark | Qwen3-4B non-thinking | Qwen3-4B-Instruct-2507 |
|---|---:|---:|
| MMLU-Pro | 58.0 | 69.6 |
| GPQA | 41.7 | 62.0 |
| AIME25 | 19.1 | 47.4 |
| LiveBench 20241125 | 48.4 | 63.0 |
| Arena-Hard v2 | 9.5 | 43.4 |

Interpretation: likely large headroom from evaluating `-2507` model variants in the same local harness.

## Assessment
- If optimizing for latency/memory headroom: **4B is stronger**.
- If optimizing for reliability on factual/strict tasks: **8B is safer**.
- Both models still need hardening for exact formatting/no-wrapper behavior.

## Recommendations
1. Keep **8B default** for quality-critical paths (command mode + transcript QA).
2. Keep **4B fallback** for low-memory/low-latency profile.
3. Run same harness next on **`Qwen3-4B-Instruct-2507`** and **`Qwen3-8B-Instruct-2507`**.
4. Add output validators + retry policy for strict format tasks.

## Validation Performed
- `bash -n scripts/dev/benchmark_qwen_models.sh`
- `bash -n scripts/dev/quality_eval_qwen.sh`
- Full perf run (`scripts/dev/benchmark_qwen_models.sh`, 40 runs)
- Full strict quality run (`scripts/dev/quality_eval_qwen.sh`)
- Smoke rerun (`REPS=1`) to verify summary path

## Sources
- Qwen3 technical report (arXiv): https://arxiv.org/abs/2505.09388
- Qwen3 report HTML tables: https://ar5iv.org/html/2505.09388
- Qwen3-4B-Instruct-2507 model card: https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507
- HELM: https://arxiv.org/abs/2211.09110
- MT-Bench / Chatbot Arena: https://arxiv.org/abs/2306.05685
- Length-Controlled AlpacaEval: https://arxiv.org/abs/2404.04475
- Cheating Automatic LLM Benchmarks: https://arxiv.org/abs/2410.07137
- Lessons from the Trenches: https://arxiv.org/abs/2405.14782
