### PR TITLE
Add crash reporting via signal handlers + disk persistence

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -116,6 +116,7 @@ final class AppEnvironment {
         telemetryService = TelemetryService()
         Telemetry.configure(telemetryService)
         Telemetry.send(.appLaunched)
+        CrashReporter.sendPendingReport(via: telemetryService)
 
         llmClient = LLMClient()
         llmConfigStore = LLMConfigStore()

--- a/Sources/MacParakeet/MacParakeetApp.swift
+++ b/Sources/MacParakeet/MacParakeetApp.swift
@@ -9,6 +9,8 @@ import MacParakeetCore
 @main
 struct MacParakeetApp {
     static func main() {
+        CrashReporter.install()
+
         let app = NSApplication.shared
 
         // Enforce the documented minimum OS version (macOS 14.2+).

--- a/Sources/MacParakeetCore/Services/CrashReporter.swift
+++ b/Sources/MacParakeetCore/Services/CrashReporter.swift
@@ -1,0 +1,419 @@
+import Foundation
+import Darwin
+import MachO
+
+/// Lightweight crash reporter that persists crash data to disk via async-signal-safe
+/// POSIX I/O, then sends it as a telemetry event on next launch.
+///
+/// Architecture (same as Sentry/PLCrashReporter core):
+///   1. `install()` — registers signal handlers + ObjC exception handler at app startup
+///   2. Signal handler — writes crash report to disk using pre-allocated buffers
+///   3. `sendPendingReport(via:)` — reads crash file on next launch, sends telemetry event
+///
+/// Known limitations:
+/// - `backtrace()` is not strictly async-signal-safe (can deadlock on dyld lock).
+///   Accepted: same tradeoff all major crash reporters make. Worst case: one report lost.
+/// - `SIGKILL` (OOM kills) cannot be caught — fundamental OS limitation.
+/// - Swift async backtraces not captured — only physical thread stack.
+/// - Framework crash addresses need their own image slide for full symbolication.
+public final class CrashReporter {
+
+    // MARK: - Pre-Allocated Static Buffers (signal-safe)
+
+    /// 4 KB buffer for formatting crash report in the signal handler.
+    private static var buffer = [CChar](repeating: 0, count: 4096)
+
+    /// Pre-resolved crash file path as a C string.
+    private static var crashFilePath = [CChar](repeating: 0, count: 512)
+
+    /// Pre-snapshotted metadata (set once at install, read in signal handler).
+    private static var appVersion = [CChar](repeating: 0, count: 64)
+    private static var osVersion = [CChar](repeating: 0, count: 32)
+    private static var machOUUID = [CChar](repeating: 0, count: 48)
+    private static var aslrSlide = [CChar](repeating: 0, count: 24)
+
+    /// Alternate signal stack for handling stack overflow crashes.
+    private static var altStack = [UInt8](repeating: 0, count: Int(SIGSTKSZ))
+
+    /// Flag to prevent concurrent signal handler entry from multiple threads.
+    /// Volatile int32 — set via OSAtomicTestAndSet which is async-signal-safe.
+    private static var handlerEntered: Int32 = 0
+
+    /// Previous ObjC exception handler (for chaining).
+    private static var previousExceptionHandler: (@convention(c) (NSException) -> Void)?
+
+    /// Signals to catch.
+    private static let signals: [Int32] = [SIGSEGV, SIGABRT, SIGBUS, SIGILL, SIGTRAP, SIGFPE]
+
+    /// Signal name lookup (async-signal-safe — no allocation).
+    private static func signalName(_ sig: Int32) -> StaticString {
+        switch sig {
+        case SIGSEGV: return "SIGSEGV"
+        case SIGABRT: return "SIGABRT"
+        case SIGBUS:  return "SIGBUS"
+        case SIGILL:  return "SIGILL"
+        case SIGTRAP: return "SIGTRAP"
+        case SIGFPE:  return "SIGFPE"
+        default:      return "UNKNOWN"
+        }
+    }
+
+    // MARK: - Install (call once, before NSApplication.run())
+
+    /// Install crash handlers. Call as the very first line of `main()`.
+    /// This method has no dependencies on any services or protocols.
+    public static func install() {
+        // 1. Ensure the crash directory exists
+        let dir = AppPaths.appSupportDir
+        var isDir: ObjCBool = false
+        if !FileManager.default.fileExists(atPath: dir, isDirectory: &isDir) {
+            try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        }
+
+        // 2. Pre-resolve crash file path to C string
+        let path = crashReportPath
+        path.withCString { ptr in
+            strncpy(&crashFilePath, ptr, crashFilePath.count - 1)
+        }
+
+        // 3. Snapshot version strings into static buffers
+        let info = SystemInfo.current
+        info.appVersion.withCString { ptr in
+            strncpy(&appVersion, ptr, appVersion.count - 1)
+        }
+        info.macOSVersion.withCString { ptr in
+            strncpy(&osVersion, ptr, osVersion.count - 1)
+        }
+
+        // 4. Capture Mach-O UUID from main executable load commands
+        snapshotMachOUUID()
+
+        // 5. Capture ASLR slide
+        let slide = _dyld_get_image_vmaddr_slide(0)
+        let slideStr = String(format: "0x%lx", UInt(bitPattern: slide))
+        slideStr.withCString { ptr in
+            strncpy(&aslrSlide, ptr, aslrSlide.count - 1)
+        }
+
+        // 6. Set up alternate signal stack (handles stack overflow crashes)
+        altStack.withUnsafeMutableBufferPointer { buf in
+            var ss = stack_t()
+            ss.ss_sp = UnsafeMutableRawPointer(buf.baseAddress!)
+            ss.ss_size = buf.count
+            ss.ss_flags = 0
+            sigaltstack(&ss, nil)
+        }
+
+        // 7. Register signal handlers via sigaction with SA_ONSTACK
+        for sig in signals {
+            var action = sigaction()
+            action.__sigaction_u = unsafeBitCast(
+                signalHandler as @convention(c) (Int32) -> Void,
+                to: __sigaction_u.self
+            )
+            action.sa_flags = Int32(SA_ONSTACK)
+            sigaction(sig, &action, nil)
+        }
+
+        // 8. Register ObjC uncaught exception handler
+        previousExceptionHandler = NSGetUncaughtExceptionHandler()
+        NSSetUncaughtExceptionHandler(objcExceptionHandler)
+    }
+
+    // MARK: - Signal Handler (@convention(c), async-signal-safe)
+
+    private static let signalHandler: @convention(c) (Int32) -> Void = { sig in
+        // Guard: only first thread proceeds (OSAtomicTestAndSet is async-signal-safe)
+        guard OSAtomicTestAndSet(0, &handlerEntered) == false else { return }
+
+        // Format crash report into pre-allocated buffer using only
+        // async-signal-safe-on-Darwin functions (snprintf, open, write, close).
+        var offset = 0
+        let bufSize = buffer.count
+
+        func appendBytes(_ s: UnsafePointer<CChar>) {
+            let len = Int(strlen(s))
+            guard offset + len < bufSize else { return }
+            buffer.withUnsafeMutableBufferPointer { buf in
+                memcpy(buf.baseAddress! + offset, s, len)
+            }
+            offset += len
+        }
+
+        func appendLine(_ key: UnsafePointer<CChar>, _ value: UnsafePointer<CChar>) {
+            appendBytes(key)
+            appendBytes(value)
+            buffer[offset] = 0x0A // '\n'
+            offset += 1
+        }
+
+        // Manual decimal formatting (async-signal-safe, no snprintf)
+        func appendInt(_ key: UnsafePointer<CChar>, _ value: Int) {
+            appendBytes(key)
+            var digits: (CChar, CChar, CChar, CChar, CChar, CChar, CChar, CChar,
+                         CChar, CChar, CChar, CChar, CChar, CChar, CChar, CChar,
+                         CChar, CChar, CChar, CChar, CChar) =
+                (0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0)
+            var n = value < 0 ? -value : value
+            var pos = 19
+            withUnsafeMutablePointer(to: &digits) { ptr in
+                let base = UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: CChar.self)
+                repeat {
+                    base[pos] = CChar(0x30 + (n % 10)) // '0' = 0x30
+                    n /= 10
+                    pos -= 1
+                } while n > 0
+                if value < 0 { base[pos] = 0x2D; pos -= 1 } // '-'
+                base[20] = 0
+                appendBytes(base + pos + 1)
+            }
+            buffer[offset] = 0x0A
+            offset += 1
+        }
+
+        // Manual hex formatting (async-signal-safe, no snprintf)
+        func appendHex(_ value: UInt) {
+            let hexChars: StaticString = "0123456789abcdef"
+            var hexBuf: (CChar, CChar, CChar, CChar, CChar, CChar, CChar, CChar,
+                         CChar, CChar, CChar, CChar, CChar, CChar, CChar, CChar,
+                         CChar, CChar, CChar) =
+                (0x30, 0x78, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0) // "0x"
+            var n = value
+            var pos = 17
+            withUnsafeMutablePointer(to: &hexBuf) { ptr in
+                let base = UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: CChar.self)
+                hexChars.withUTF8Buffer { chars in
+                    repeat {
+                        base[pos] = CChar(bitPattern: chars[Int(n & 0xF)])
+                        n >>= 4
+                        pos -= 1
+                    } while n > 0
+                }
+                // Shift "0x" prefix to just before the digits
+                base[pos - 1] = 0x78 // 'x'
+                base[pos - 2] = 0x30 // '0'
+                base[18] = 0x0A // '\n'
+                let start = pos - 2
+                let len = 19 - start
+                guard offset + len < bufSize else { return }
+                buffer.withUnsafeMutableBufferPointer { buf in
+                    memcpy(buf.baseAddress! + offset, base + start, len)
+                }
+                offset += len
+            }
+        }
+
+        appendLine("crash_type: ", "signal")
+        appendInt("signal: ", Int(sig))
+
+        // Signal name
+        switch sig {
+        case SIGSEGV: appendLine("name: ", "SIGSEGV")
+        case SIGABRT: appendLine("name: ", "SIGABRT")
+        case SIGBUS:  appendLine("name: ", "SIGBUS")
+        case SIGILL:  appendLine("name: ", "SIGILL")
+        case SIGTRAP: appendLine("name: ", "SIGTRAP")
+        case SIGFPE:  appendLine("name: ", "SIGFPE")
+        default:      appendLine("name: ", "UNKNOWN")
+        }
+
+        appendInt("timestamp: ", time(nil))
+        appendLine("app_ver: ", &appVersion)
+        appendLine("os_ver: ", &osVersion)
+        appendLine("uuid: ", &machOUUID)
+        appendLine("slide: ", &aslrSlide)
+        appendBytes("--- stack ---\n")
+
+        // Stack trace via backtrace() — not strictly async-signal-safe but
+        // pragmatically used by all major crash reporters (Sentry, PLCrashReporter).
+        var frames = [UnsafeMutableRawPointer?](repeating: nil, count: 64)
+        let frameCount = backtrace(&frames, Int32(frames.count))
+        for i in 0..<Int(frameCount) {
+            guard offset + 24 < bufSize else { break }
+            if let addr = frames[i] {
+                appendHex(UInt(bitPattern: addr))
+            }
+        }
+
+        // Write to disk via POSIX I/O
+        let fd = Darwin.open(&crashFilePath, O_WRONLY | O_CREAT | O_TRUNC, 0o644)
+        if fd >= 0 {
+            buffer.withUnsafeBufferPointer { buf in
+                _ = Darwin.write(fd, buf.baseAddress!, offset)
+            }
+            Darwin.close(fd)
+        }
+
+        // Restore default handler and re-raise so macOS gets the crash
+        Darwin.signal(sig, SIG_DFL)
+        Darwin.raise(sig)
+    }
+
+    // MARK: - ObjC Exception Handler (normal Swift context, NOT signal handler)
+
+    private static let objcExceptionHandler: @convention(c) (NSException) -> Void = { exception in
+        let name = exception.name.rawValue
+        let reason = TelemetryErrorClassifier.errorDetail(
+            NSError(domain: name, code: 0, userInfo: [NSLocalizedDescriptionKey: exception.reason ?? ""])
+        )
+
+        // Build crash report as a Swift string (safe here — not in signal handler)
+        var lines = [String]()
+        lines.append("crash_type: exception")
+        lines.append("signal: exception")
+        lines.append("name: \(name)")
+        lines.append("timestamp: \(Int(Date().timeIntervalSince1970))")
+        lines.append("app_ver: \(String(cString: &appVersion))")
+        lines.append("os_ver: \(String(cString: &osVersion))")
+        lines.append("uuid: \(String(cString: &machOUUID))")
+        lines.append("slide: \(String(cString: &aslrSlide))")
+        lines.append("reason: \(reason)")
+        lines.append("--- stack ---")
+
+        for address in exception.callStackReturnAddresses {
+            lines.append(String(format: "0x%lx", address.uintValue))
+        }
+
+        let content = lines.joined(separator: "\n") + "\n"
+        try? content.write(toFile: crashReportPath, atomically: true, encoding: .utf8)
+
+        // Chain to previous handler
+        previousExceptionHandler?(exception)
+    }
+
+    // MARK: - Mach-O UUID Extraction
+
+    private static func snapshotMachOUUID() {
+        guard let header = _dyld_get_image_header(0) else {
+            strncpy(&machOUUID, "unknown", machOUUID.count - 1)
+            return
+        }
+
+        var cursor = UnsafeRawPointer(header).advanced(by: MemoryLayout<mach_header_64>.size)
+        for _ in 0..<header.pointee.ncmds {
+            let cmd = cursor.assumingMemoryBound(to: load_command.self).pointee
+            if cmd.cmd == LC_UUID {
+                // uuid_command: load_command (8 bytes) + uuid (16 bytes)
+                let uuidPtr = cursor.advanced(by: 8).assumingMemoryBound(to: UInt8.self)
+                let bytes = (0..<16).map { uuidPtr[$0] }
+                let formatted = String(format:
+                    "%02X%02X%02X%02X-%02X%02X-%02X%02X-%02X%02X-%02X%02X%02X%02X%02X%02X",
+                    bytes[0], bytes[1], bytes[2], bytes[3],
+                    bytes[4], bytes[5], bytes[6], bytes[7],
+                    bytes[8], bytes[9], bytes[10], bytes[11],
+                    bytes[12], bytes[13], bytes[14], bytes[15])
+                formatted.withCString { ptr in
+                    strncpy(&machOUUID, ptr, machOUUID.count - 1)
+                }
+                return
+            }
+            cursor = cursor.advanced(by: Int(cmd.cmdsize))
+        }
+        strncpy(&machOUUID, "unknown", machOUUID.count - 1)
+    }
+
+    // MARK: - Crash Report Recovery (normal Swift, called on next launch)
+
+    /// Parsed crash report from a previous session.
+    public struct CrashReport {
+        public let crashType: String    // "signal" or "exception"
+        public let signal: String       // e.g. "11" or "exception"
+        public let name: String         // e.g. "SIGSEGV" or "NSInvalidArgumentException"
+        public let timestamp: String    // Unix timestamp
+        public let appVersion: String
+        public let osVersion: String
+        public let uuid: String
+        public let slide: String
+        public let reason: String?      // Only for exceptions
+        public let stackTrace: [String] // Hex addresses
+    }
+
+    /// Path to the crash report file.
+    public static var crashReportPath: String {
+        AppPaths.appSupportDir + "/crash_report.txt"
+    }
+
+    /// Load a pending crash report from disk, if one exists.
+    public static func loadPendingReport(from path: String? = nil) -> CrashReport? {
+        let filePath = path ?? crashReportPath
+        guard let content = try? String(contentsOfFile: filePath, encoding: .utf8),
+              !content.isEmpty else {
+            return nil
+        }
+
+        let lines = content.components(separatedBy: "\n")
+        var fields = [String: String]()
+        var stackTrace = [String]()
+        var inStack = false
+
+        for line in lines {
+            if line == "--- stack ---" {
+                inStack = true
+                continue
+            }
+            if inStack {
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                if trimmed.hasPrefix("0x") {
+                    stackTrace.append(trimmed)
+                }
+            } else if let colonIndex = line.firstIndex(of: ":") {
+                let key = String(line[line.startIndex..<colonIndex]).trimmingCharacters(in: .whitespaces)
+                let value = String(line[line.index(after: colonIndex)...]).trimmingCharacters(in: .whitespaces)
+                fields[key] = value
+            }
+        }
+
+        guard let crashType = fields["crash_type"],
+              let signal = fields["signal"],
+              let name = fields["name"],
+              let timestamp = fields["timestamp"],
+              let appVer = fields["app_ver"] else {
+            return nil
+        }
+
+        return CrashReport(
+            crashType: crashType,
+            signal: signal,
+            name: name,
+            timestamp: timestamp,
+            appVersion: appVer,
+            osVersion: fields["os_ver"] ?? "",
+            uuid: fields["uuid"] ?? "",
+            slide: fields["slide"] ?? "",
+            reason: fields["reason"],
+            stackTrace: stackTrace
+        )
+    }
+
+    /// Send any pending crash report as a telemetry event, then delete the file.
+    /// Call after TelemetryService is initialized.
+    public static func sendPendingReport(via telemetry: TelemetryServiceProtocol) {
+        sendPendingReport(via: telemetry, from: crashReportPath)
+    }
+
+    /// Internal variant with injectable path for testing.
+    static func sendPendingReport(via telemetry: TelemetryServiceProtocol, from path: String) {
+        guard let report = loadPendingReport(from: path) else { return }
+
+        let stackTraceString = report.stackTrace.joined(separator: "\n")
+
+        telemetry.send(.crashOccurred(
+            crashType: report.crashType,
+            signal: report.signal,
+            name: report.name,
+            crashTimestamp: report.timestamp,
+            crashAppVer: report.appVersion,
+            crashOsVer: report.osVersion,
+            uuid: report.uuid,
+            slide: report.slide,
+            stackTrace: stackTraceString
+        ))
+
+        // Always delete — even if telemetry is disabled (send() handles opt-out)
+        deleteCrashFile(at: path)
+    }
+
+    private static func deleteCrashFile(at path: String? = nil) {
+        try? FileManager.default.removeItem(atPath: path ?? crashReportPath)
+    }
+}

--- a/Sources/MacParakeetCore/Services/CrashReporter.swift
+++ b/Sources/MacParakeetCore/Services/CrashReporter.swift
@@ -109,15 +109,17 @@ public final class CrashReporter {
             sigaltstack(&ss, nil)
         }
 
-        // 7. Register signal handlers via sigaction with SA_ONSTACK | SA_RESETHAND
-        // SA_RESETHAND: if the handler itself crashes, fall through to default handler
+        // 7. Register signal handlers via sigaction
+        // SA_ONSTACK:   use alternate stack (handles stack overflow)
+        // SA_RESETHAND: reset to SIG_DFL on entry (handler crash → default termination)
+        // SA_NODEFER:   don't block the signal during handler (belt-and-suspenders with SA_RESETHAND)
         for sig in signals {
             var action = sigaction()
             action.__sigaction_u = unsafeBitCast(
                 signalHandler as @convention(c) (Int32) -> Void,
                 to: __sigaction_u.self
             )
-            action.sa_flags = Int32(SA_ONSTACK) | Int32(SA_RESETHAND)
+            action.sa_flags = Int32(SA_ONSTACK) | Int32(SA_RESETHAND) | Int32(SA_NODEFER)
             sigaction(sig, &action, nil)
         }
 
@@ -133,7 +135,12 @@ public final class CrashReporter {
 
     private static let signalHandler: @convention(c) (Int32) -> Void = { sig in
         // Guard: only first thread proceeds
-        guard OSAtomicCompareAndSwap32Barrier(0, 1, &handlerEntered) else { return }
+        guard OSAtomicCompareAndSwap32Barrier(0, 1, &handlerEntered) else {
+            // Second concurrent thread: re-raise so it terminates via SIG_DFL
+            // rather than resuming from the crash site.
+            Darwin.raise(sig)
+            return
+        }
 
         // snprintf is async-signal-safe on Darwin (per man sigaction).
         // Use it for all formatting — much safer than manual int/hex formatters.

--- a/Sources/MacParakeetCore/Services/CrashReporter.swift
+++ b/Sources/MacParakeetCore/Services/CrashReporter.swift
@@ -19,50 +19,50 @@ import MachO
 public final class CrashReporter {
 
     // MARK: - Pre-Allocated Static Buffers (signal-safe)
+    //
+    // All mutable statics are written once in install() (main thread, before run loop)
+    // and read in the signal handler (crash context). This is safe because install()
+    // completes before any signal can fire, and the signal handler is guarded by an
+    // atomic compare-and-swap to ensure single entry.
 
     /// 4 KB buffer for formatting crash report in the signal handler.
-    private static var buffer = [CChar](repeating: 0, count: 4096)
+    nonisolated(unsafe) private static var buffer = [CChar](repeating: 0, count: 4096)
 
     /// Pre-resolved crash file path as a C string.
-    private static var crashFilePath = [CChar](repeating: 0, count: 512)
+    nonisolated(unsafe) private static var crashFilePath = [CChar](repeating: 0, count: 512)
 
     /// Pre-snapshotted metadata (set once at install, read in signal handler).
-    private static var appVersion = [CChar](repeating: 0, count: 64)
-    private static var osVersion = [CChar](repeating: 0, count: 32)
-    private static var machOUUID = [CChar](repeating: 0, count: 48)
-    private static var aslrSlide = [CChar](repeating: 0, count: 24)
+    nonisolated(unsafe) private static var appVersion = [CChar](repeating: 0, count: 64)
+    nonisolated(unsafe) private static var osVersion = [CChar](repeating: 0, count: 32)
+    nonisolated(unsafe) private static var machOUUID = [CChar](repeating: 0, count: 48)
+    nonisolated(unsafe) private static var aslrSlide = [CChar](repeating: 0, count: 24)
 
     /// Alternate signal stack for handling stack overflow crashes.
-    private static var altStack = [UInt8](repeating: 0, count: Int(SIGSTKSZ))
+    nonisolated(unsafe) private static var altStack = [UInt8](repeating: 0, count: Int(SIGSTKSZ))
 
-    /// Flag to prevent concurrent signal handler entry from multiple threads.
-    /// Volatile int32 — set via OSAtomicTestAndSet which is async-signal-safe.
-    private static var handlerEntered: Int32 = 0
+    /// Pre-allocated frame buffer for backtrace() — avoids heap allocation in signal handler.
+    nonisolated(unsafe) private static var framesBuffer = [UnsafeMutableRawPointer?](repeating: nil, count: 64)
+
+    /// Atomic flag to prevent concurrent signal handler entry from multiple threads.
+    nonisolated(unsafe) private static var handlerEntered: Int32 = 0
 
     /// Previous ObjC exception handler (for chaining).
-    private static var previousExceptionHandler: (@convention(c) (NSException) -> Void)?
+    nonisolated(unsafe) private static var previousExceptionHandler: (@convention(c) (NSException) -> Void)?
+
+    /// Whether install() has been called (prevents double-install).
+    nonisolated(unsafe) private static var installed = false
 
     /// Signals to catch.
     private static let signals: [Int32] = [SIGSEGV, SIGABRT, SIGBUS, SIGILL, SIGTRAP, SIGFPE]
-
-    /// Signal name lookup (async-signal-safe — no allocation).
-    private static func signalName(_ sig: Int32) -> StaticString {
-        switch sig {
-        case SIGSEGV: return "SIGSEGV"
-        case SIGABRT: return "SIGABRT"
-        case SIGBUS:  return "SIGBUS"
-        case SIGILL:  return "SIGILL"
-        case SIGTRAP: return "SIGTRAP"
-        case SIGFPE:  return "SIGFPE"
-        default:      return "UNKNOWN"
-        }
-    }
 
     // MARK: - Install (call once, before NSApplication.run())
 
     /// Install crash handlers. Call as the very first line of `main()`.
     /// This method has no dependencies on any services or protocols.
     public static func install() {
+        guard !installed else { return }
+        installed = true
+
         // 1. Ensure the crash directory exists
         let dir = AppPaths.appSupportDir
         var isDir: ObjCBool = false
@@ -75,15 +75,19 @@ public final class CrashReporter {
         path.withCString { ptr in
             strncpy(&crashFilePath, ptr, crashFilePath.count - 1)
         }
+        crashFilePath[crashFilePath.count - 1] = 0
 
         // 3. Snapshot version strings into static buffers
         let info = SystemInfo.current
         info.appVersion.withCString { ptr in
             strncpy(&appVersion, ptr, appVersion.count - 1)
         }
+        appVersion[appVersion.count - 1] = 0
+
         info.macOSVersion.withCString { ptr in
             strncpy(&osVersion, ptr, osVersion.count - 1)
         }
+        osVersion[osVersion.count - 1] = 0
 
         // 4. Capture Mach-O UUID from main executable load commands
         snapshotMachOUUID()
@@ -94,6 +98,7 @@ public final class CrashReporter {
         slideStr.withCString { ptr in
             strncpy(&aslrSlide, ptr, aslrSlide.count - 1)
         }
+        aslrSlide[aslrSlide.count - 1] = 0
 
         // 6. Set up alternate signal stack (handles stack overflow crashes)
         altStack.withUnsafeMutableBufferPointer { buf in
@@ -104,14 +109,15 @@ public final class CrashReporter {
             sigaltstack(&ss, nil)
         }
 
-        // 7. Register signal handlers via sigaction with SA_ONSTACK
+        // 7. Register signal handlers via sigaction with SA_ONSTACK | SA_RESETHAND
+        // SA_RESETHAND: if the handler itself crashes, fall through to default handler
         for sig in signals {
             var action = sigaction()
             action.__sigaction_u = unsafeBitCast(
                 signalHandler as @convention(c) (Int32) -> Void,
                 to: __sigaction_u.self
             )
-            action.sa_flags = Int32(SA_ONSTACK)
+            action.sa_flags = Int32(SA_ONSTACK) | Int32(SA_RESETHAND)
             sigaction(sig, &action, nil)
         }
 
@@ -121,17 +127,21 @@ public final class CrashReporter {
     }
 
     // MARK: - Signal Handler (@convention(c), async-signal-safe)
+    //
+    // Uses only async-signal-safe functions per Darwin's man sigaction:
+    // snprintf, open, write, close, backtrace, raise, sigaction, time.
 
     private static let signalHandler: @convention(c) (Int32) -> Void = { sig in
-        // Guard: only first thread proceeds (OSAtomicTestAndSet is async-signal-safe)
-        guard OSAtomicTestAndSet(0, &handlerEntered) == false else { return }
+        // Guard: only first thread proceeds
+        guard OSAtomicCompareAndSwap32Barrier(0, 1, &handlerEntered) else { return }
 
-        // Format crash report into pre-allocated buffer using only
-        // async-signal-safe-on-Darwin functions (snprintf, open, write, close).
+        // snprintf is async-signal-safe on Darwin (per man sigaction).
+        // Use it for all formatting — much safer than manual int/hex formatters.
         var offset = 0
         let bufSize = buffer.count
 
-        func appendBytes(_ s: UnsafePointer<CChar>) {
+        // Helper: append formatted string to buffer via snprintf
+        func append(_ s: UnsafePointer<CChar>) {
             let len = Int(strlen(s))
             guard offset + len < bufSize else { return }
             buffer.withUnsafeMutableBufferPointer { buf in
@@ -140,98 +150,53 @@ public final class CrashReporter {
             offset += len
         }
 
-        func appendLine(_ key: UnsafePointer<CChar>, _ value: UnsafePointer<CChar>) {
-            appendBytes(key)
-            appendBytes(value)
-            buffer[offset] = 0x0A // '\n'
-            offset += 1
-        }
-
-        // Manual decimal formatting (async-signal-safe, no snprintf)
-        func appendInt(_ key: UnsafePointer<CChar>, _ value: Int) {
-            appendBytes(key)
-            var digits: (CChar, CChar, CChar, CChar, CChar, CChar, CChar, CChar,
-                         CChar, CChar, CChar, CChar, CChar, CChar, CChar, CChar,
-                         CChar, CChar, CChar, CChar, CChar) =
-                (0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0)
-            var n = value < 0 ? -value : value
-            var pos = 19
-            withUnsafeMutablePointer(to: &digits) { ptr in
-                let base = UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: CChar.self)
-                repeat {
-                    base[pos] = CChar(0x30 + (n % 10)) // '0' = 0x30
-                    n /= 10
-                    pos -= 1
-                } while n > 0
-                if value < 0 { base[pos] = 0x2D; pos -= 1 } // '-'
-                base[20] = 0
-                appendBytes(base + pos + 1)
-            }
-            buffer[offset] = 0x0A
-            offset += 1
-        }
-
-        // Manual hex formatting (async-signal-safe, no snprintf)
-        func appendHex(_ value: UInt) {
-            let hexChars: StaticString = "0123456789abcdef"
-            var hexBuf: (CChar, CChar, CChar, CChar, CChar, CChar, CChar, CChar,
-                         CChar, CChar, CChar, CChar, CChar, CChar, CChar, CChar,
-                         CChar, CChar, CChar) =
-                (0x30, 0x78, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0) // "0x"
-            var n = value
-            var pos = 17
-            withUnsafeMutablePointer(to: &hexBuf) { ptr in
-                let base = UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: CChar.self)
-                hexChars.withUTF8Buffer { chars in
-                    repeat {
-                        base[pos] = CChar(bitPattern: chars[Int(n & 0xF)])
-                        n >>= 4
-                        pos -= 1
-                    } while n > 0
-                }
-                // Shift "0x" prefix to just before the digits
-                base[pos - 1] = 0x78 // 'x'
-                base[pos - 2] = 0x30 // '0'
-                base[18] = 0x0A // '\n'
-                let start = pos - 2
-                let len = 19 - start
-                guard offset + len < bufSize else { return }
+        // Helper: vsnprintf into buffer at current offset.
+        // snprintf is async-signal-safe on Darwin per man sigaction, but Swift marks
+        // C variadic functions as unavailable. Use vsnprintf via withVaList instead.
+        func snprintfInto(_ format: UnsafePointer<CChar>, _ args: CVarArg...) {
+            let remaining = bufSize - offset
+            guard remaining > 0 else { return }
+            let written = withVaList(args) { vaList in
                 buffer.withUnsafeMutableBufferPointer { buf in
-                    memcpy(buf.baseAddress! + offset, base + start, len)
+                    Int(vsnprintf(buf.baseAddress! + offset, remaining, format, vaList))
                 }
-                offset += len
             }
+            if written > 0 { offset += min(written, remaining - 1) }
         }
 
-        appendLine("crash_type: ", "signal")
-        appendInt("signal: ", Int(sig))
+        append("crash_type: signal\n")
+        snprintfInto("signal: %d\n", sig)
 
         // Signal name
+        append("name: ")
         switch sig {
-        case SIGSEGV: appendLine("name: ", "SIGSEGV")
-        case SIGABRT: appendLine("name: ", "SIGABRT")
-        case SIGBUS:  appendLine("name: ", "SIGBUS")
-        case SIGILL:  appendLine("name: ", "SIGILL")
-        case SIGTRAP: appendLine("name: ", "SIGTRAP")
-        case SIGFPE:  appendLine("name: ", "SIGFPE")
-        default:      appendLine("name: ", "UNKNOWN")
+        case SIGSEGV: append("SIGSEGV")
+        case SIGABRT: append("SIGABRT")
+        case SIGBUS:  append("SIGBUS")
+        case SIGILL:  append("SIGILL")
+        case SIGTRAP: append("SIGTRAP")
+        case SIGFPE:  append("SIGFPE")
+        default:      append("UNKNOWN")
         }
+        append("\n")
 
-        appendInt("timestamp: ", time(nil))
-        appendLine("app_ver: ", &appVersion)
-        appendLine("os_ver: ", &osVersion)
-        appendLine("uuid: ", &machOUUID)
-        appendLine("slide: ", &aslrSlide)
-        appendBytes("--- stack ---\n")
+        snprintfInto("timestamp: %ld\n", time(nil))
+
+        // Append pre-snapshotted C strings
+        append("app_ver: "); append(&appVersion); append("\n")
+        append("os_ver: "); append(&osVersion); append("\n")
+        append("uuid: "); append(&machOUUID); append("\n")
+        append("slide: "); append(&aslrSlide); append("\n")
+        append("--- stack ---\n")
 
         // Stack trace via backtrace() — not strictly async-signal-safe but
         // pragmatically used by all major crash reporters (Sentry, PLCrashReporter).
-        var frames = [UnsafeMutableRawPointer?](repeating: nil, count: 64)
-        let frameCount = backtrace(&frames, Int32(frames.count))
+        // Uses pre-allocated framesBuffer to avoid heap allocation.
+        let frameCount = backtrace(&framesBuffer, Int32(framesBuffer.count))
         for i in 0..<Int(frameCount) {
-            guard offset + 24 < bufSize else { break }
-            if let addr = frames[i] {
-                appendHex(UInt(bitPattern: addr))
+            guard bufSize - offset > 20 else { break }
+            if let addr = framesBuffer[i] {
+                snprintfInto("0x%lx\n", UInt(bitPattern: addr))
             }
         }
 
@@ -244,8 +209,8 @@ public final class CrashReporter {
             Darwin.close(fd)
         }
 
-        // Restore default handler and re-raise so macOS gets the crash
-        Darwin.signal(sig, SIG_DFL)
+        // SA_RESETHAND already restored SIG_DFL before entering this handler.
+        // Just re-raise to let the OS default handler produce the crash report.
         Darwin.raise(sig)
     }
 
@@ -289,10 +254,16 @@ public final class CrashReporter {
             return
         }
 
+        guard header.pointee.magic == MH_MAGIC_64 else {
+            strncpy(&machOUUID, "unknown", machOUUID.count - 1)
+            return
+        }
+
         var cursor = UnsafeRawPointer(header).advanced(by: MemoryLayout<mach_header_64>.size)
         for _ in 0..<header.pointee.ncmds {
             let cmd = cursor.assumingMemoryBound(to: load_command.self).pointee
-            if cmd.cmd == LC_UUID {
+            guard cmd.cmdsize >= UInt32(MemoryLayout<load_command>.size) else { break }
+            if cmd.cmd == LC_UUID, cmd.cmdsize >= 24 {
                 // uuid_command: load_command (8 bytes) + uuid (16 bytes)
                 let uuidPtr = cursor.advanced(by: 8).assumingMemoryBound(to: UInt8.self)
                 let bytes = (0..<16).map { uuidPtr[$0] }
@@ -347,13 +318,13 @@ public final class CrashReporter {
         var inStack = false
 
         for line in lines {
-            if line == "--- stack ---" {
+            if line.trimmingCharacters(in: .whitespaces) == "--- stack ---" {
                 inStack = true
                 continue
             }
             if inStack {
                 let trimmed = line.trimmingCharacters(in: .whitespaces)
-                if trimmed.hasPrefix("0x") {
+                if trimmed.hasPrefix("0x"), stackTrace.count < 256 {
                     stackTrace.append(trimmed)
                 }
             } else if let colonIndex = line.firstIndex(of: ":") {

--- a/Sources/MacParakeetCore/Services/CrashReporter.swift
+++ b/Sources/MacParakeetCore/Services/CrashReporter.swift
@@ -232,7 +232,9 @@ public final class CrashReporter {
         lines.append("os_ver: \(String(cString: &osVersion))")
         lines.append("uuid: \(String(cString: &machOUUID))")
         lines.append("slide: \(String(cString: &aslrSlide))")
-        lines.append("reason: \(reason)")
+        let safeReason = reason.replacingOccurrences(of: "\n", with: "\\n")
+                               .replacingOccurrences(of: "\r", with: "\\r")
+        lines.append("reason: \(safeReason)")
         lines.append("--- stack ---")
 
         for address in exception.callStackReturnAddresses {
@@ -318,18 +320,18 @@ public final class CrashReporter {
         var inStack = false
 
         for line in lines {
-            if line.trimmingCharacters(in: .whitespaces) == "--- stack ---" {
+            if line.trimmingCharacters(in: .whitespacesAndNewlines) == "--- stack ---" {
                 inStack = true
                 continue
             }
             if inStack {
-                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
                 if trimmed.hasPrefix("0x"), stackTrace.count < 256 {
                     stackTrace.append(trimmed)
                 }
             } else if let colonIndex = line.firstIndex(of: ":") {
-                let key = String(line[line.startIndex..<colonIndex]).trimmingCharacters(in: .whitespaces)
-                let value = String(line[line.index(after: colonIndex)...]).trimmingCharacters(in: .whitespaces)
+                let key = String(line[line.startIndex..<colonIndex]).trimmingCharacters(in: .whitespacesAndNewlines)
+                let value = String(line[line.index(after: colonIndex)...]).trimmingCharacters(in: .whitespacesAndNewlines)
                 fields[key] = value
             }
         }
@@ -351,7 +353,9 @@ public final class CrashReporter {
             osVersion: fields["os_ver"] ?? "",
             uuid: fields["uuid"] ?? "",
             slide: fields["slide"] ?? "",
-            reason: fields["reason"],
+            reason: fields["reason"]?
+                .replacingOccurrences(of: "\\n", with: "\n")
+                .replacingOccurrences(of: "\\r", with: "\r"),
             stackTrace: stackTrace
         )
     }
@@ -377,6 +381,7 @@ public final class CrashReporter {
             crashOsVer: report.osVersion,
             uuid: report.uuid,
             slide: report.slide,
+            reason: report.reason,
             stackTrace: stackTraceString
         ))
 

--- a/Sources/MacParakeetCore/Services/CrashReporter.swift
+++ b/Sources/MacParakeetCore/Services/CrashReporter.swift
@@ -309,10 +309,13 @@ public final class CrashReporter {
     /// Load a pending crash report from disk, if one exists.
     public static func loadPendingReport(from path: String? = nil) -> CrashReport? {
         let filePath = path ?? crashReportPath
-        guard let content = try? String(contentsOfFile: filePath, encoding: .utf8),
-              !content.isEmpty else {
+        // Use tolerant UTF-8 decoding: a crash mid-write could truncate a
+        // multi-byte character, and strict .utf8 would discard the entire report.
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: filePath)),
+              !data.isEmpty else {
             return nil
         }
+        let content = String(decoding: data, as: UTF8.self)
 
         let lines = content.components(separatedBy: "\n")
         var fields = [String: String]()

--- a/Sources/MacParakeetCore/Services/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/TelemetryEvent.swift
@@ -47,6 +47,8 @@ public enum TelemetryEventName: String, Sendable, CaseIterable {
     case modelDownloadFailed = "model_download_failed"
     // Errors
     case errorOccurred = "error_occurred"
+    // Crashes
+    case crashOccurred = "crash_occurred"
 }
 
 public enum TelemetryDictationTrigger: String, Sendable, Equatable {
@@ -143,6 +145,13 @@ public enum TelemetryEventSpec: Sendable {
     case modelDownloadFailed(errorType: String, errorDetail: String? = nil)
     // Errors
     case errorOccurred(domain: String, code: String, description: String)
+    // Crashes
+    case crashOccurred(
+        crashType: String, signal: String, name: String,
+        crashTimestamp: String, crashAppVer: String,
+        crashOsVer: String, uuid: String,
+        slide: String, stackTrace: String
+    )
 }
 
 extension TelemetryEventSpec {
@@ -191,6 +200,7 @@ extension TelemetryEventSpec {
         case .modelDownloadCompleted: return .modelDownloadCompleted
         case .modelDownloadFailed: return .modelDownloadFailed
         case .errorOccurred: return .errorOccurred
+        case .crashOccurred: return .crashOccurred
         }
     }
 
@@ -307,6 +317,19 @@ extension TelemetryEventSpec {
             return props
         case .errorOccurred(let domain, let code, let description):
             return ["domain": domain, "code": code, "description": String(description.prefix(512))]
+        case .crashOccurred(let crashType, let signal, let name, let crashTimestamp,
+                            let crashAppVer, let crashOsVer, let uuid, let slide, let stackTrace):
+            return Self.compactProps(
+                ("crash_type", crashType),
+                ("signal", signal),
+                ("name", name),
+                ("crash_ts", crashTimestamp),
+                ("crash_app_ver", crashAppVer),
+                ("crash_os_ver", crashOsVer),
+                ("uuid", uuid),
+                ("slide", slide),
+                ("stack_trace", String(stackTrace.prefix(1024)))
+            )
         }
     }
 
@@ -380,6 +403,7 @@ public enum TelemetryImplementedContract {
         .modelDownloadCompleted: ["duration_seconds"],
         .modelDownloadFailed: ["error_type"],
         .errorOccurred: ["domain", "code", "description"],
+        .crashOccurred: ["crash_type", "signal", "name", "crash_ts", "crash_app_ver"],
     ]
 
     public static var implementedEventNames: Set<TelemetryEventName> {

--- a/Sources/MacParakeetCore/Services/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/TelemetryEvent.swift
@@ -150,7 +150,7 @@ public enum TelemetryEventSpec: Sendable {
         crashType: String, signal: String, name: String,
         crashTimestamp: String, crashAppVer: String,
         crashOsVer: String, uuid: String,
-        slide: String, stackTrace: String
+        slide: String, reason: String?, stackTrace: String
     )
 }
 
@@ -318,7 +318,8 @@ extension TelemetryEventSpec {
         case .errorOccurred(let domain, let code, let description):
             return ["domain": domain, "code": code, "description": String(description.prefix(512))]
         case .crashOccurred(let crashType, let signal, let name, let crashTimestamp,
-                            let crashAppVer, let crashOsVer, let uuid, let slide, let stackTrace):
+                            let crashAppVer, let crashOsVer, let uuid, let slide,
+                            let reason, let stackTrace):
             return Self.compactProps(
                 ("crash_type", crashType),
                 ("signal", signal),
@@ -328,7 +329,8 @@ extension TelemetryEventSpec {
                 ("crash_os_ver", crashOsVer),
                 ("uuid", uuid),
                 ("slide", slide),
-                ("stack_trace", String(stackTrace.prefix(1024)))
+                ("reason", reason.map { String($0.prefix(512)) }),
+                ("stack_trace", String(stackTrace.prefix(2048)))
             )
         }
     }

--- a/Sources/MacParakeetCore/Services/TelemetryService.swift
+++ b/Sources/MacParakeetCore/Services/TelemetryService.swift
@@ -46,6 +46,7 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
         .restoreSucceeded,
         .restoreFailed,
         .appQuit,
+        .crashOccurred,
     ]
 
     public init(

--- a/Tests/MacParakeetTests/Services/CrashReporterTests.swift
+++ b/Tests/MacParakeetTests/Services/CrashReporterTests.swift
@@ -1,0 +1,190 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class CrashReporterTests: XCTestCase {
+
+    private var testDir: String!
+
+    override func setUp() {
+        super.setUp()
+        testDir = NSTemporaryDirectory() + "CrashReporterTests-\(UUID().uuidString)"
+        try! FileManager.default.createDirectory(atPath: testDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(atPath: testDir)
+        super.tearDown()
+    }
+
+    private var testCrashPath: String { testDir + "/crash_report.txt" }
+
+    // MARK: - Signal Crash Parsing
+
+    func testLoadPendingReportParsesValidSignalCrash() {
+        let content = """
+        crash_type: signal
+        signal: 11
+        name: SIGSEGV
+        timestamp: 1711900000
+        app_ver: 0.5.1
+        os_ver: 15.3.1
+        uuid: A1B2C3D4-E5F6-7890-ABCD-EF1234567890
+        slide: 0x100000
+        --- stack ---
+        0x00000001a2f3b4c0
+        0x00000001a2f3b4d8
+        0x00000001a2f3b500
+        """
+        try! content.write(toFile: testCrashPath, atomically: true, encoding: .utf8)
+
+        let report = CrashReporter.loadPendingReport(from: testCrashPath)
+        XCTAssertNotNil(report)
+        XCTAssertEqual(report?.crashType, "signal")
+        XCTAssertEqual(report?.signal, "11")
+        XCTAssertEqual(report?.name, "SIGSEGV")
+        XCTAssertEqual(report?.timestamp, "1711900000")
+        XCTAssertEqual(report?.appVersion, "0.5.1")
+        XCTAssertEqual(report?.osVersion, "15.3.1")
+        XCTAssertEqual(report?.uuid, "A1B2C3D4-E5F6-7890-ABCD-EF1234567890")
+        XCTAssertEqual(report?.slide, "0x100000")
+        XCTAssertNil(report?.reason)
+        XCTAssertEqual(report?.stackTrace.count, 3)
+        XCTAssertEqual(report?.stackTrace.first, "0x00000001a2f3b4c0")
+    }
+
+    // MARK: - Exception Crash Parsing
+
+    func testLoadPendingReportParsesExceptionCrash() {
+        let content = """
+        crash_type: exception
+        signal: exception
+        name: NSInvalidArgumentException
+        timestamp: 1711900000
+        app_ver: 0.5.1
+        os_ver: 15.3.1
+        uuid: A1B2C3D4-E5F6-7890-ABCD-EF1234567890
+        slide: 0x0
+        reason: unrecognized selector sent to instance
+        --- stack ---
+        0x00000001a2f3b4c0
+        0x00000001a2f3b4d8
+        """
+        try! content.write(toFile: testCrashPath, atomically: true, encoding: .utf8)
+
+        let report = CrashReporter.loadPendingReport(from: testCrashPath)
+        XCTAssertNotNil(report)
+        XCTAssertEqual(report?.crashType, "exception")
+        XCTAssertEqual(report?.name, "NSInvalidArgumentException")
+        XCTAssertEqual(report?.reason, "unrecognized selector sent to instance")
+        XCTAssertEqual(report?.stackTrace.count, 2)
+    }
+
+    // MARK: - Edge Cases
+
+    func testLoadPendingReportReturnsNilForMissingFile() {
+        let report = CrashReporter.loadPendingReport(from: testDir + "/nonexistent.txt")
+        XCTAssertNil(report)
+    }
+
+    func testLoadPendingReportReturnsNilForEmptyFile() {
+        try! "".write(toFile: testCrashPath, atomically: true, encoding: .utf8)
+        let report = CrashReporter.loadPendingReport(from: testCrashPath)
+        XCTAssertNil(report)
+    }
+
+    func testLoadPendingReportHandlesMalformedFile() {
+        try! "garbage data\nno structure here".write(toFile: testCrashPath, atomically: true, encoding: .utf8)
+        let report = CrashReporter.loadPendingReport(from: testCrashPath)
+        XCTAssertNil(report) // Missing required fields
+    }
+
+    func testLoadPendingReportHandlesPartialFile() {
+        // Only some fields — simulates interrupted write
+        let content = """
+        crash_type: signal
+        signal: 6
+        name: SIGABRT
+        timestamp: 1711900000
+        app_ver: 0.5.1
+        """
+        try! content.write(toFile: testCrashPath, atomically: true, encoding: .utf8)
+
+        let report = CrashReporter.loadPendingReport(from: testCrashPath)
+        XCTAssertNotNil(report) // Has required fields
+        XCTAssertEqual(report?.signal, "6")
+        XCTAssertEqual(report?.name, "SIGABRT")
+        XCTAssertTrue(report?.stackTrace.isEmpty ?? false)
+    }
+
+    // MARK: - Telemetry Integration
+
+    func testSendPendingReportSendsEventAndDeletesFile() {
+        let content = """
+        crash_type: signal
+        signal: 11
+        name: SIGSEGV
+        timestamp: 1711900000
+        app_ver: 0.5.1
+        os_ver: 15.3.1
+        uuid: TESTID
+        slide: 0x100000
+        --- stack ---
+        0x1234
+        0x5678
+        """
+        try! content.write(toFile: testCrashPath, atomically: true, encoding: .utf8)
+
+        let mock = MockTelemetryService()
+        CrashReporter.sendPendingReport(via: mock, from: testCrashPath)
+
+        // Verify event was sent
+        XCTAssertEqual(mock.sentEvents.count, 1)
+        if case .crashOccurred(let crashType, let signal, let name, _, _, _, _, _, _) = mock.sentEvents.first {
+            XCTAssertEqual(crashType, "signal")
+            XCTAssertEqual(signal, "11")
+            XCTAssertEqual(name, "SIGSEGV")
+        } else {
+            XCTFail("Expected crashOccurred event")
+        }
+
+        // Verify file was deleted
+        XCTAssertFalse(FileManager.default.fileExists(atPath: testCrashPath))
+    }
+
+    func testSendPendingReportDeletesFileEvenWhenTelemetryDisabled() {
+        let content = "crash_type: signal\nsignal: 6\nname: SIGABRT\ntimestamp: 0\napp_ver: 0.1\n"
+        try! content.write(toFile: testCrashPath, atomically: true, encoding: .utf8)
+
+        // NoOp service simulates disabled telemetry
+        let noop = NoOpTelemetryService()
+        CrashReporter.sendPendingReport(via: noop, from: testCrashPath)
+
+        // File should still be deleted
+        XCTAssertFalse(FileManager.default.fileExists(atPath: testCrashPath))
+    }
+
+    func testSendPendingReportNoOpWithoutCrashFile() {
+        let mock = MockTelemetryService()
+        CrashReporter.sendPendingReport(via: mock, from: testDir + "/nonexistent.txt")
+        XCTAssertTrue(mock.sentEvents.isEmpty)
+    }
+}
+
+// MARK: - Mock Telemetry Service
+
+private final class MockTelemetryService: TelemetryServiceProtocol, @unchecked Sendable {
+    var sentEvents = [TelemetryEventSpec]()
+
+    func send(_ event: TelemetryEventSpec) {
+        sentEvents.append(event)
+    }
+
+    func flush() async {}
+    func flushForTermination() {}
+}
+
+private final class NoOpTelemetryService: TelemetryServiceProtocol, @unchecked Sendable {
+    func send(_ event: TelemetryEventSpec) {}
+    func flush() async {}
+    func flushForTermination() {}
+}

--- a/Tests/MacParakeetTests/Services/CrashReporterTests.swift
+++ b/Tests/MacParakeetTests/Services/CrashReporterTests.swift
@@ -326,8 +326,4 @@ private final class MockTelemetryService: TelemetryServiceProtocol, @unchecked S
     func flushForTermination() {}
 }
 
-private final class NoOpTelemetryService: TelemetryServiceProtocol, @unchecked Sendable {
-    func send(_ event: TelemetryEventSpec) {}
-    func flush() async {}
-    func flushForTermination() {}
-}
+// NoOpTelemetryService is imported from MacParakeetCore via @testable import

--- a/Tests/MacParakeetTests/Services/CrashReporterTests.swift
+++ b/Tests/MacParakeetTests/Services/CrashReporterTests.swift
@@ -168,6 +168,123 @@ final class CrashReporterTests: XCTestCase {
         CrashReporter.sendPendingReport(via: mock, from: testDir + "/nonexistent.txt")
         XCTAssertTrue(mock.sentEvents.isEmpty)
     }
+
+    // MARK: - Reviewer-Flagged Edge Cases
+
+    func testReasonFieldWithColonsPreservesFullValue() {
+        let content = """
+        crash_type: exception
+        signal: exception
+        name: NSInvalidArgumentException
+        timestamp: 1711900000
+        app_ver: 0.5.1
+        reason: Cannot decode: key "url": no such key
+        --- stack ---
+        0x1234
+        """
+        try! content.write(toFile: testCrashPath, atomically: true, encoding: .utf8)
+
+        let report = CrashReporter.loadPendingReport(from: testCrashPath)
+        XCTAssertEqual(report?.reason, "Cannot decode: key \"url\": no such key")
+    }
+
+    func testNoStackSectionReturnsEmptyStackTrace() {
+        let content = """
+        crash_type: signal
+        signal: 11
+        name: SIGSEGV
+        timestamp: 1711900000
+        app_ver: 0.5.1
+        """
+        try! content.write(toFile: testCrashPath, atomically: true, encoding: .utf8)
+
+        let report = CrashReporter.loadPendingReport(from: testCrashPath)
+        XCTAssertNotNil(report)
+        XCTAssertTrue(report?.stackTrace.isEmpty ?? false)
+    }
+
+    func testNonHexLinesInStackSectionAreSkipped() {
+        let content = """
+        crash_type: signal
+        signal: 11
+        name: SIGSEGV
+        timestamp: 1711900000
+        app_ver: 0.5.1
+        --- stack ---
+        0x1234
+        garbage line
+        not a hex address
+        0x5678
+        """
+        try! content.write(toFile: testCrashPath, atomically: true, encoding: .utf8)
+
+        let report = CrashReporter.loadPendingReport(from: testCrashPath)
+        XCTAssertEqual(report?.stackTrace, ["0x1234", "0x5678"])
+    }
+
+    func testStackTraceCappedAt256Frames() {
+        var lines = [
+            "crash_type: signal", "signal: 11", "name: SIGSEGV",
+            "timestamp: 1711900000", "app_ver: 0.5.1", "--- stack ---"
+        ]
+        for i in 0..<300 {
+            lines.append("0x\(String(i, radix: 16))")
+        }
+        let content = lines.joined(separator: "\n")
+        try! content.write(toFile: testCrashPath, atomically: true, encoding: .utf8)
+
+        let report = CrashReporter.loadPendingReport(from: testCrashPath)
+        XCTAssertEqual(report?.stackTrace.count, 256)
+    }
+
+    func testMissingOptionalFieldsDefaultToEmptyString() {
+        let content = "crash_type: signal\nsignal: 11\nname: SIGSEGV\ntimestamp: 0\napp_ver: 0.1\n"
+        try! content.write(toFile: testCrashPath, atomically: true, encoding: .utf8)
+
+        let report = CrashReporter.loadPendingReport(from: testCrashPath)
+        XCTAssertNotNil(report)
+        XCTAssertEqual(report?.osVersion, "")
+        XCTAssertEqual(report?.uuid, "")
+        XCTAssertEqual(report?.slide, "")
+        XCTAssertNil(report?.reason)
+    }
+
+    func testStackTraceMarkerWithTrailingWhitespace() {
+        let content = "crash_type: signal\nsignal: 11\nname: SIGSEGV\ntimestamp: 0\napp_ver: 0.1\n--- stack ---  \n0xABCD\n"
+        try! content.write(toFile: testCrashPath, atomically: true, encoding: .utf8)
+
+        let report = CrashReporter.loadPendingReport(from: testCrashPath)
+        XCTAssertEqual(report?.stackTrace, ["0xABCD"])
+    }
+
+    func testSendPendingReportIncludesStackTraceInProps() {
+        let content = """
+        crash_type: signal
+        signal: 11
+        name: SIGSEGV
+        timestamp: 1711900000
+        app_ver: 0.5.1
+        os_ver: 15.3
+        uuid: TEST-UUID
+        slide: 0x100000
+        --- stack ---
+        0xAAAA
+        0xBBBB
+        0xCCCC
+        """
+        try! content.write(toFile: testCrashPath, atomically: true, encoding: .utf8)
+
+        let mock = MockTelemetryService()
+        CrashReporter.sendPendingReport(via: mock, from: testCrashPath)
+
+        if case .crashOccurred(_, _, _, _, _, _, let uuid, let slide, let stackTrace) = mock.sentEvents.first {
+            XCTAssertEqual(uuid, "TEST-UUID")
+            XCTAssertEqual(slide, "0x100000")
+            XCTAssertEqual(stackTrace, "0xAAAA\n0xBBBB\n0xCCCC")
+        } else {
+            XCTFail("Expected crashOccurred event")
+        }
+    }
 }
 
 // MARK: - Mock Telemetry Service

--- a/Tests/MacParakeetTests/Services/CrashReporterTests.swift
+++ b/Tests/MacParakeetTests/Services/CrashReporterTests.swift
@@ -139,7 +139,7 @@ final class CrashReporterTests: XCTestCase {
 
         // Verify event was sent
         XCTAssertEqual(mock.sentEvents.count, 1)
-        if case .crashOccurred(let crashType, let signal, let name, _, _, _, _, _, _) = mock.sentEvents.first {
+        if case .crashOccurred(let crashType, let signal, let name, _, _, _, _, _, _, _) = mock.sentEvents.first {
             XCTAssertEqual(crashType, "signal")
             XCTAssertEqual(signal, "11")
             XCTAssertEqual(name, "SIGSEGV")
@@ -277,12 +277,38 @@ final class CrashReporterTests: XCTestCase {
         let mock = MockTelemetryService()
         CrashReporter.sendPendingReport(via: mock, from: testCrashPath)
 
-        if case .crashOccurred(_, _, _, _, _, _, let uuid, let slide, let stackTrace) = mock.sentEvents.first {
+        if case .crashOccurred(_, _, _, _, let appVer, let osVer, let uuid, let slide, let reason, let stackTrace) = mock.sentEvents.first {
+            XCTAssertEqual(appVer, "0.5.1")
+            XCTAssertEqual(osVer, "15.3")
             XCTAssertEqual(uuid, "TEST-UUID")
             XCTAssertEqual(slide, "0x100000")
+            XCTAssertNil(reason)
             XCTAssertEqual(stackTrace, "0xAAAA\n0xBBBB\n0xCCCC")
         } else {
             XCTFail("Expected crashOccurred event")
+        }
+    }
+
+    func testExceptionReasonWithNewlinesIsPreserved() {
+        let content = """
+        crash_type: exception
+        signal: exception
+        name: NSRangeException
+        timestamp: 1711900000
+        app_ver: 0.5.1
+        reason: index 5 beyond bounds [0..3]\\nmore context here
+        --- stack ---
+        0x1234
+        """
+        try! content.write(toFile: testCrashPath, atomically: true, encoding: .utf8)
+
+        let mock = MockTelemetryService()
+        CrashReporter.sendPendingReport(via: mock, from: testCrashPath)
+
+        if case .crashOccurred(_, _, _, _, _, _, _, _, let reason, _) = mock.sentEvents.first {
+            XCTAssertEqual(reason, "index 5 beyond bounds [0..3]\nmore context here")
+        } else {
+            XCTFail("Expected crashOccurred event with reason")
         }
     }
 }

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -396,6 +396,22 @@ final class TelemetryServiceTests: XCTestCase {
             .restoreAttempted,
             .restoreSucceeded,
             .restoreFailed(errorType: "storekit"),
+            .permissionPrompted(permission: .microphone),
+            .permissionGranted(permission: .microphone),
+            .permissionDenied(permission: .accessibility),
+            .modelLoaded(loadTimeSeconds: 2.5),
+            .modelDownloadStarted,
+            .modelDownloadCompleted(durationSeconds: 30.0),
+            .modelDownloadFailed(errorType: "network"),
+            .onboardingStep(step: "microphone"),
+            .licenseActivationFailed(errorType: "invalid_key"),
+            .errorOccurred(domain: "STTError", code: "engineFailed", description: "test"),
+            .crashOccurred(
+                crashType: "signal", signal: "11", name: "SIGSEGV",
+                crashTimestamp: "1711900000", crashAppVer: "0.5.1",
+                crashOsVer: "15.3.1", uuid: "A1B2C3D4", slide: "0x100000",
+                stackTrace: "0x1234\n0x5678"
+            ),
         ]
     }
 }

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -410,7 +410,7 @@ final class TelemetryServiceTests: XCTestCase {
                 crashType: "signal", signal: "11", name: "SIGSEGV",
                 crashTimestamp: "1711900000", crashAppVer: "0.5.1",
                 crashOsVer: "15.3.1", uuid: "A1B2C3D4", slide: "0x100000",
-                stackTrace: "0x1234\n0x5678"
+                reason: nil, stackTrace: "0x1234\n0x5678"
             ),
         ]
     }

--- a/plans/active/crash-reporting.md
+++ b/plans/active/crash-reporting.md
@@ -1,0 +1,163 @@
+# Crash Reporting Implementation Plan
+
+> Status: **ACTIVE**
+
+## Context
+
+MacParakeet had a v0.4.22 incident where users crashed on the onboarding screen but we had **zero visibility** — the crash kills the telemetry service before it can report anything. We need a lightweight crash reporter that persists crash data to disk before the process dies, then sends it as a telemetry event on next launch.
+
+**Design philosophy:** This is Sentry's core architecture distilled to its minimum for a small indie macOS app. No over-engineering — just signal handlers, a file on disk, and a telemetry event.
+
+**Reviewed by:** Gemini + Codex. Findings incorporated below.
+
+## How It Works
+
+```
+1. App starts → CrashReporter.install()   (before anything else)
+     - Ensures crash directory exists
+     - Snapshots version strings + Mach-O UUID into static C buffers
+     - Allocates alternate signal stack (sigaltstack) for stack overflow handling
+     - Registers signal handlers (SIGSEGV, SIGABRT, SIGBUS, SIGILL, SIGTRAP, SIGFPE)
+     - Registers NSSetUncaughtExceptionHandler for ObjC exceptions
+
+2. App crashes → Signal handler fires
+     - atomic_flag guards against concurrent entry from multiple threads
+     - Formats crash info into pre-allocated buffer using snprintf
+     - Captures stack trace via backtrace() (up to 64 frames)
+     - Writes to ~/Library/Application Support/MacParakeet/crash_report.txt
+     - Uses POSIX functions (open/write/close) + snprintf (safe on Darwin)
+     - Restores SIG_DFL then re-raises signal so macOS gets the crash too
+
+3. Next launch → CrashReporter.sendPendingReport(via: telemetryService)
+     - Reads crash_report.txt if it exists
+     - Sends crash_occurred telemetry event (respects opt-out)
+     - Deletes the file unconditionally
+```
+
+## Known Limitations (Documented, Accepted)
+
+- **`backtrace()` is not strictly async-signal-safe** — can deadlock if dyld lock is held at crash time. Accepted: pragmatic choice, same tradeoff Crashlytics/PLCrashReporter make. Worst case: one crash report lost.
+- **`SIGKILL` (OOM kills) cannot be caught** — fundamental OS limitation.
+- **Swift async backtraces not captured** — only physical thread stack, not logical async call chain. No async-signal-safe way to get these.
+- **Framework crash addresses** need their own image slide for symbolication. We capture main executable slide + UUID, which covers most crashes. Framework crashes show raw addresses only.
+
+## Implementation Steps
+
+### Step 1: Add `crashOccurred` event type
+
+**File:** `Sources/MacParakeetCore/Services/TelemetryEvent.swift`
+
+- Add `case crashOccurred = "crash_occurred"` to `TelemetryEventName`
+- Add to `TelemetryEventSpec`:
+  ```swift
+  case crashOccurred(crashType: String, signal: String, name: String,
+                     crashTimestamp: String, crashAppVer: String,
+                     crashOsVer: String, uuid: String,
+                     slide: String, stackTrace: String)
+  ```
+- Add `name` mapping, `props` computation (stack_trace truncated to 1024 chars)
+- Add to `TelemetryImplementedContract.requiredProps`
+
+### Step 2: Add `crashOccurred` to immediate flush events
+
+**File:** `Sources/MacParakeetCore/Services/TelemetryService.swift`
+
+- Add `.crashOccurred` to the `immediateEvents` set (line 37-49)
+
+### Step 3: Create CrashReporter
+
+**File:** `Sources/MacParakeetCore/Services/CrashReporter.swift` (NEW)
+
+Single class with two sections:
+
+**Static install section** (C-level, async-signal-safe):
+- Pre-allocated 4 KB `[CChar]` buffer for formatting
+- Pre-snapshotted C strings: crash file path, app version, OS version, Mach-O UUID (from `SystemInfo.current` + dyld image header)
+- `install()`:
+  1. Ensures `AppPaths.appSupportDir` exists (mkdir if needed)
+  2. Pre-resolves crash file path to C string buffer
+  3. Allocates alternate signal stack via `sigaltstack()` (handles stack overflow crashes)
+  4. Registers signal handlers for `SIGSEGV, SIGABRT, SIGBUS, SIGILL, SIGTRAP, SIGFPE` using `sigaction` with `SA_ONSTACK`
+  5. Registers `NSSetUncaughtExceptionHandler`
+- `signalHandler` — `@convention(c)` function that:
+  1. `atomic_flag_test_and_set` — only first thread proceeds, others skip
+  2. Formats crash_type, signal number, name (static lookup), `time(NULL)` timestamp, pre-snapshotted version/uuid/slide
+  3. Calls `backtrace()` for up to 64 frames, formats each as `0x%lx`
+  4. Writes to crash file via POSIX `open(..., O_WRONLY | O_CREAT | O_TRUNC)`/`write`/`close`
+  5. Restores `SIG_DFL` via `signal(sig, SIG_DFL)` then `raise(sig)` (avoids infinite loop)
+- ObjC exception handler — can use normal Swift (not in signal context), captures exception name + sanitized reason + `callStackReturnAddresses`
+
+**Report recovery section** (normal Swift):
+- `CrashReport` struct with parsed fields
+- `loadPendingReport(from:)` — reads file, parses `key: value` lines + stack trace
+- `sendPendingReport(via:)` — loads report → sends `TelemetryEventSpec.crashOccurred` → deletes file
+- `crashReportPath` — `AppPaths.appSupportDir + "/crash_report.txt"`
+
+**Key design decisions:**
+- **No protocol** — signal handlers are process-global singletons by nature. Testable parts (parsing, telemetry integration) use a `from:` path parameter.
+- **Single crash file, not timestamped** — only one crash per launch. New crash overwrites old. No stale file accumulation.
+- **File deleted unconditionally** — even if telemetry is disabled. `TelemetryService.send()` handles opt-out internally.
+- **Plain text, line-oriented format** — not JSON (too risky to build balanced braces in a signal handler):
+  ```
+  crash_type: signal
+  signal: 11
+  name: SIGSEGV
+  timestamp: 1711900000
+  app_ver: 0.5.1
+  os_ver: 15.3.1
+  uuid: A1B2C3D4-E5F6-7890-ABCD-EF1234567890
+  slide: 0x100000
+  --- stack ---
+  0x00000001a2f3b4c0
+  0x00000001a2f3b4d8
+  ```
+- **`crash_type` discriminator** — `signal` vs `exception` at top of file, cleaner parsing
+
+### Step 4: Wire into app lifecycle
+
+**File:** `Sources/MacParakeet/MacParakeetApp.swift`
+- Add `CrashReporter.install()` as first line of `static func main()`, before everything
+
+**File:** `Sources/MacParakeet/App/AppEnvironment.swift`
+- Add `CrashReporter.sendPendingReport(via: telemetryService)` after line 118 (`Telemetry.send(.appLaunched)`)
+
+### Step 5: Add backend support
+
+**File:** `~/code/macparakeet-website/functions/api/telemetry.ts`
+- Add `"crash_occurred"` to the `ALLOWED_EVENTS` set (line 78)
+- No schema changes — crash data fits in the existing `props` JSON column
+
+### Step 6: Tests
+
+**File:** `Tests/MacParakeetTests/Services/CrashReporterTests.swift` (NEW)
+
+Tests use a temp directory (no real app paths):
+- `testLoadPendingReportParsesValidSignalCrash` — write synthetic crash file, verify all fields parsed
+- `testLoadPendingReportParsesExceptionCrash` — write ObjC exception variant with reason field
+- `testLoadPendingReportReturnsNilForMissingFile`
+- `testLoadPendingReportReturnsNilForEmptyFile`
+- `testLoadPendingReportHandlesMalformedFile` — partial/corrupt data doesn't crash
+- `testSendPendingReportSendsEventAndDeletesFile` — mock telemetry, verify event props + file deleted
+- `testSendPendingReportDeletesFileEvenWhenNoService` — no stale crash files
+- `testSendPendingReportNoOpWithoutCrashFile`
+
+**NOT tested:** Signal handler installation or actual signal delivery (kills the test process).
+
+## Files Changed
+
+| File | Action | Notes |
+|------|--------|-------|
+| `Sources/MacParakeetCore/Services/CrashReporter.swift` | NEW | Core crash reporter |
+| `Sources/MacParakeetCore/Services/TelemetryEvent.swift` | MODIFY | Add crashOccurred event |
+| `Sources/MacParakeetCore/Services/TelemetryService.swift` | MODIFY | Add to immediateEvents |
+| `Sources/MacParakeet/MacParakeetApp.swift` | MODIFY | Install crash reporter |
+| `Sources/MacParakeet/App/AppEnvironment.swift` | MODIFY | Send pending report |
+| `functions/api/telemetry.ts` (website) | MODIFY | Add to allowlist |
+| `Tests/MacParakeetTests/Services/CrashReporterTests.swift` | NEW | Test suite |
+
+## Verification
+
+1. `swift test` — all existing tests pass + new crash reporter tests pass
+2. Build app via `scripts/dev/run_app.sh`
+3. Manually verify: write a synthetic crash file to `~/Library/Application Support/MacParakeet/crash_report.txt`, launch app, check telemetry D1 for `crash_occurred` event
+4. Deploy website worker with updated allowlist


### PR DESCRIPTION
## Context

The v0.4.22 onboarding incident stranded ~23 new users on the setup screen for ~24 hours — a broken Continue button meant they couldn't complete onboarding. While investigating via telemetry, we noticed some sessions showed zero activity after onboarding, raising the question: did they crash? We had no way to tell. The app had zero crash visibility — if the process dies, the telemetry service dies with it.

This PR closes that blind spot.

## Architecture

Same 3-step pattern used by Sentry, PLCrashReporter, and KSCrash — distilled to its minimum for a small indie macOS app:

```
1. install()        → Register signal handlers + ObjC exception handler (before NSApplication.run())
2. Signal fires     → Write crash report to disk via POSIX I/O (pre-allocated buffers, no heap)
3. Next launch      → Read crash file → send crash_occurred telemetry event → delete file
```

**Signals caught:** SIGSEGV, SIGABRT, SIGBUS, SIGILL, SIGTRAP, SIGFPE, plus ObjC uncaught exceptions.

**Crash report format** (plain text, line-oriented — not JSON, because balanced braces are risky in a signal handler):
```
crash_type: signal
signal: 11
name: SIGSEGV
timestamp: 1711900000
app_ver: 0.5.1
os_ver: 15.3.1
uuid: A1B2C3D4-E5F6-7890-ABCD-EF1234567890
slide: 0x100000
--- stack ---
0x00000001a2f3b4c0
0x00000001a2f3b4d8
```

**Symbolication:** Captures Mach-O UUID + ASLR slide, enabling offline symbolication via `atos -o MacParakeet -arch arm64 -l <slide> <addresses>`.

## Signal handler safety

The signal handler uses only async-signal-safe POSIX functions (`open`, `write`, `close`, `vsnprintf`, `backtrace`, `raise`, `time`). Pre-allocated static buffers avoid heap allocation. `OSAtomicCompareAndSwap32Barrier` prevents concurrent handler entry. `SA_RESETHAND | SA_NODEFER` ensures the handler falls through to the default if it itself crashes. `sigaltstack` provides an alternate stack for stack overflow crashes.

**Known tradeoff:** Writing signal handlers in Swift (rather than C) means some Swift runtime calls (`withUnsafeMutableBufferPointer`, `CVarArg` variadics) are not strictly async-signal-safe. In practice, the risk is limited to heap corruption crashes where `malloc` could deadlock — a minority of crash types, and those are also caught by Apple's out-of-process `ReportCrash`. See [review discussion](https://github.com/moona3k/macparakeet/pull/38#discussion_r3019549223) for the full analysis.

## Known limitations (documented, accepted)

- **`backtrace()` not strictly async-signal-safe** — can deadlock on dyld lock. Same tradeoff all major crash reporters make. Worst case: one report lost.
- **`SIGKILL` (OOM kills) cannot be caught** — fundamental OS limitation.
- **Swift async backtraces not captured** — only physical thread stack.
- **Single crash file** — if the app crashes twice before a successful launch, only the second crash is reported.

## Files changed

| File | Change |
|------|--------|
| `CrashReporter.swift` | New — signal handlers, ObjC exception handler, Mach-O UUID extraction, file parser, telemetry sender |
| `TelemetryEvent.swift` | Add `crashOccurred` event with crash metadata props |
| `TelemetryService.swift` | Add `crashOccurred` to immediate flush events |
| `MacParakeetApp.swift` | `CrashReporter.install()` as first line of `main()` |
| `AppEnvironment.swift` | `sendPendingReport(via:)` after telemetry is configured |
| `CrashReporterTests.swift` | 17 tests covering parsing, edge cases, telemetry integration |
| `TelemetryServiceTests.swift` | Add crash event to contract coverage |

## Test plan

- [x] 996 tests passing (983 XCTest + 13 Swift Testing), 0 failures
- [x] 17 CrashReporter tests: signal/exception parsing, missing/empty/malformed files, colons in values, non-hex stack lines, 256-frame cap, trailing whitespace, escaped newlines round-trip, telemetry integration (event sent + file deleted), disabled telemetry, no crash file
- [x] Plan reviewed by Gemini + Codex before implementation
- [x] Implementation reviewed by 13+ independent AI agents; all findings addressed
- [x] Backend `crash_occurred` event added to Cloudflare Worker allowlist and deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)