### PR TITLE
Add speaker detection toggle in Settings

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -143,6 +143,9 @@ final class AppEnvironment {
                 // Defaults to true if unset (matches Settings UI default).
                 UserDefaults.standard.object(forKey: "saveTranscriptionAudio") as? Bool ?? true
             },
+            shouldDiarize: {
+                UserDefaults.standard.object(forKey: "speakerDiarization") as? Bool ?? false
+            },
             youtubeDownloader: youtubeDownloader,
             diarizationService: diarizationService
         )

--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -144,7 +144,7 @@ final class AppEnvironment {
                 UserDefaults.standard.object(forKey: "saveTranscriptionAudio") as? Bool ?? true
             },
             shouldDiarize: {
-                UserDefaults.standard.object(forKey: "speakerDiarization") as? Bool ?? false
+                UserDefaults.standard.object(forKey: "speakerDiarization") as? Bool ?? true
             },
             youtubeDownloader: youtubeDownloader,
             diarizationService: diarizationService

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -30,6 +30,7 @@ struct SettingsView: View {
             VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
                 headerCard
                 dictationCard
+                transcriptionCard
                 aiProviderCard
                 storageCard
                 generalCard
@@ -215,6 +216,22 @@ struct SettingsView: View {
                     }
                 }
             }
+        }
+    }
+
+    // MARK: - Transcription
+
+    private var transcriptionCard: some View {
+        settingsCard(
+            title: "Transcription",
+            subtitle: "Options for file and YouTube transcription.",
+            icon: "doc.text"
+        ) {
+            settingsToggleRow(
+                title: "Speaker detection",
+                detail: "Identify who said what. Adds a few seconds of processing time.",
+                isOn: $viewModel.speakerDiarization
+            )
         }
     }
 

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -229,7 +229,7 @@ struct SettingsView: View {
         ) {
             settingsToggleRow(
                 title: "Speaker detection",
-                detail: "Identify who said what. Adds a few seconds of processing time.",
+                detail: "Identify who said what using Pyannote community-1. Typically ~85% accurate — best with clear audio and distinct voices. Adds a few seconds of processing time.",
                 isOn: $viewModel.speakerDiarization
             )
         }

--- a/Sources/MacParakeetCore/Services/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/TelemetryEvent.swift
@@ -95,6 +95,7 @@ public enum TelemetrySettingName: String, Sendable, Equatable {
     case menuBarOnly = "menu_bar_only"
     case hidePill = "hide_pill"
     case saveTranscriptionAudio = "save_transcription_audio"
+    case speakerDiarization = "speaker_diarization"
 }
 
 public enum TelemetryEventSpec: Sendable {

--- a/Sources/MacParakeetCore/Services/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/TelemetryEvent.swift
@@ -12,6 +12,9 @@ public enum TelemetryEventName: String, Sendable, CaseIterable {
     case transcriptionCompleted = "transcription_completed"
     case transcriptionCancelled = "transcription_cancelled"
     case transcriptionFailed = "transcription_failed"
+    case diarizationStarted = "diarization_started"
+    case diarizationCompleted = "diarization_completed"
+    case diarizationFailed = "diarization_failed"
     case exportUsed = "export_used"
     case llmSummaryUsed = "llm_summary_used"
     case llmSummaryFailed = "llm_summary_failed"
@@ -111,6 +114,9 @@ public enum TelemetryEventSpec: Sendable {
     )
     case transcriptionCancelled(source: TelemetryTranscriptionSource, audioDurationSeconds: Double?)
     case transcriptionFailed(source: TelemetryTranscriptionSource, errorType: String, errorDetail: String? = nil)
+    case diarizationStarted(source: TelemetryTranscriptionSource)
+    case diarizationCompleted(source: TelemetryTranscriptionSource, speakerCount: Int, durationSeconds: Double)
+    case diarizationFailed(source: TelemetryTranscriptionSource, errorType: String, errorDetail: String? = nil)
     case exportUsed(format: String)
     case llmSummaryUsed(provider: String)
     case llmSummaryFailed(provider: String, errorType: String, errorDetail: String? = nil)
@@ -171,6 +177,9 @@ extension TelemetryEventSpec {
         case .transcriptionCompleted: return .transcriptionCompleted
         case .transcriptionCancelled: return .transcriptionCancelled
         case .transcriptionFailed: return .transcriptionFailed
+        case .diarizationStarted: return .diarizationStarted
+        case .diarizationCompleted: return .diarizationCompleted
+        case .diarizationFailed: return .diarizationFailed
         case .exportUsed: return .exportUsed
         case .llmSummaryUsed: return .llmSummaryUsed
         case .llmSummaryFailed: return .llmSummaryFailed
@@ -268,6 +277,18 @@ extension TelemetryEventSpec {
                 ("audio_duration_seconds", audioDurationSeconds.map(Self.format))
             )
         case .transcriptionFailed(let source, let errorType, let errorDetail):
+            var props = ["source": source.rawValue, "error_type": errorType]
+            if let errorDetail { props["error_detail"] = errorDetail }
+            return props
+        case .diarizationStarted(let source):
+            return ["source": source.rawValue]
+        case .diarizationCompleted(let source, let speakerCount, let durationSeconds):
+            return [
+                "source": source.rawValue,
+                "speaker_count": "\(speakerCount)",
+                "duration_seconds": Self.format(durationSeconds)
+            ]
+        case .diarizationFailed(let source, let errorType, let errorDetail):
             var props = ["source": source.rawValue, "error_type": errorType]
             if let errorDetail { props["error_detail"] = errorDetail }
             return props
@@ -380,6 +401,9 @@ public enum TelemetryImplementedContract {
         .transcriptionCompleted: ["source", "word_count"],
         .transcriptionCancelled: ["source"],
         .transcriptionFailed: ["source", "error_type"],
+        .diarizationStarted: ["source"],
+        .diarizationCompleted: ["source", "speaker_count"],
+        .diarizationFailed: ["source", "error_type"],
         .exportUsed: ["format"],
         .llmSummaryUsed: ["provider"],
         .llmSummaryFailed: ["provider", "error_type"],

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -38,6 +38,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
     private let processingMode: @Sendable () -> Dictation.ProcessingMode
     private let textRefinementService: TextRefinementService
     private let shouldKeepDownloadedAudio: @Sendable () -> Bool
+    private let shouldDiarize: @Sendable () -> Bool
     private let youtubeDownloader: YouTubeDownloading?
     private let diarizationService: DiarizationServiceProtocol?
 
@@ -50,6 +51,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         snippetRepo: TextSnippetRepositoryProtocol? = nil,
         processingMode: (@Sendable () -> Dictation.ProcessingMode)? = nil,
         shouldKeepDownloadedAudio: (@Sendable () -> Bool)? = nil,
+        shouldDiarize: (@Sendable () -> Bool)? = nil,
         youtubeDownloader: YouTubeDownloading? = nil,
         diarizationService: DiarizationServiceProtocol? = nil
     ) {
@@ -62,6 +64,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         self.processingMode = processingMode ?? { .raw }
         self.textRefinementService = TextRefinementService()
         self.shouldKeepDownloadedAudio = shouldKeepDownloadedAudio ?? { true }
+        self.shouldDiarize = shouldDiarize ?? { true }
         self.youtubeDownloader = youtubeDownloader
         self.diarizationService = diarizationService
     }
@@ -205,7 +208,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
             transcription.wordTimestamps = words
             transcription.durationMs = result.words.last?.endMs
 
-            if let diarizationService {
+            if let diarizationService, shouldDiarize() {
                 do {
                     onProgress?(.identifyingSpeakers)
                     Telemetry.send(.diarizationStarted(source: source))

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -208,7 +208,10 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
             if let diarizationService {
                 do {
                     onProgress?(.identifyingSpeakers)
+                    Telemetry.send(.diarizationStarted(source: source))
+                    let diarStartedAt = Date()
                     let diarResult = try await diarizationService.diarize(audioURL: wavURL)
+                    let diarDuration = Date().timeIntervalSince(diarStartedAt)
                     if !diarResult.segments.isEmpty {
                         let mergedWords = SpeakerMerger.mergeWordTimestampsWithSpeakers(
                             words: words,
@@ -221,14 +224,19 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
                             DiarizationSegmentRecord(speakerId: $0.speakerId, startMs: $0.startMs, endMs: $0.endMs)
                         }
                     }
+                    Telemetry.send(.diarizationCompleted(
+                        source: source,
+                        speakerCount: diarResult.speakerCount,
+                        durationSeconds: diarDuration
+                    ))
                 } catch is CancellationError {
                     throw CancellationError()
                 } catch {
                     logger.error("diarization_failed error=\(error.localizedDescription, privacy: .public)")
-                    Telemetry.send(.errorOccurred(
-                        domain: "diarization",
-                        code: "transcription_diarization_failed",
-                        description: TelemetryErrorClassifier.errorDetail(error)
+                    Telemetry.send(.diarizationFailed(
+                        source: source,
+                        errorType: String(describing: type(of: error)),
+                        errorDetail: TelemetryErrorClassifier.errorDetail(error)
                     ))
                 }
             }

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -109,6 +109,14 @@ public final class SettingsViewModel {
         }
     }
 
+    // Transcription
+    public var speakerDiarization: Bool {
+        didSet {
+            defaults.set(speakerDiarization, forKey: "speakerDiarization")
+            Telemetry.send(.settingChanged(setting: .speakerDiarization))
+        }
+    }
+
     // Permission status
     public var microphoneGranted = false
     public var accessibilityGranted = false
@@ -175,6 +183,7 @@ public final class SettingsViewModel {
         saveDictationHistory = defaults.object(forKey: "saveDictationHistory") as? Bool ?? true
         saveAudioRecordings = defaults.object(forKey: "saveAudioRecordings") as? Bool ?? true
         saveTranscriptionAudio = defaults.object(forKey: "saveTranscriptionAudio") as? Bool ?? true
+        speakerDiarization = defaults.object(forKey: "speakerDiarization") as? Bool ?? false
     }
 
     public func configure(

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -183,7 +183,7 @@ public final class SettingsViewModel {
         saveDictationHistory = defaults.object(forKey: "saveDictationHistory") as? Bool ?? true
         saveAudioRecordings = defaults.object(forKey: "saveAudioRecordings") as? Bool ?? true
         saveTranscriptionAudio = defaults.object(forKey: "saveTranscriptionAudio") as? Bool ?? true
-        speakerDiarization = defaults.object(forKey: "speakerDiarization") as? Bool ?? false
+        speakerDiarization = defaults.object(forKey: "speakerDiarization") as? Bool ?? true
     }
 
     public func configure(

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -1270,7 +1270,7 @@ new scheduling architecture.
 - [x] Single-speaker files handled gracefully (one speaker label)
 - [x] Diarization failure is non-fatal (ASR result preserved)
 - [x] Progress shows "Identifying speakers..." headline
-- [x] Settings toggle for speaker detection (off by default, replaces planned Option-key alternate)
+- [x] Settings toggle for speaker detection (on by default, replaces planned Option-key alternate)
 - [x] CLI: `macparakeet-cli transcribe` runs diarization by default, `--no-diarize` to skip
 
 ---

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -1270,7 +1270,7 @@ new scheduling architecture.
 - [x] Single-speaker files handled gracefully (one speaker label)
 - [x] Diarization failure is non-fatal (ASR result preserved)
 - [x] Progress shows "Identifying speakers..." headline
-- [ ] Option-key (⌥) alternate skips diarization for per-run fast transcription (Step 8 — UI PR)
+- [x] Settings toggle for speaker detection (off by default, replaces planned Option-key alternate)
 - [x] CLI: `macparakeet-cli transcribe` runs diarization by default, `--no-diarize` to skip
 
 ---

--- a/spec/adr/010-speaker-diarization.md
+++ b/spec/adr/010-speaker-diarization.md
@@ -113,11 +113,11 @@ If diarization fails (e.g. `noSpeechDetected`, model error, timeout), the ASR re
 - Per-speaker analytics (speaking time, word count)
 - All export formats include speaker labels when available
 - Progress: "Identifying speakers..." sublabel with time estimate during diarization phase
-- Settings toggle to enable/disable diarization (off by default)
+- Settings toggle to enable/disable diarization (on by default)
 
 ### Always-on vs opt-in
 
-> **Amendment (2026-04-02):** The original decision was "always-on, no global toggle." This has been revised to **opt-in via a Settings toggle (off by default)**. See rationale below.
+> **Amendment (2026-04-02):** The original decision was "always-on, no global toggle." This has been revised to **a Settings toggle (on by default)**. See rationale below.
 
 ~~For file transcription, always run it — users transcribing files almost always want to know who said what.~~ **Revised:** Diarization is controlled by a "Speaker detection" toggle in Settings (on by default). Users who don't need speaker attribution can disable it for faster transcriptions.
 

--- a/spec/adr/010-speaker-diarization.md
+++ b/spec/adr/010-speaker-diarization.md
@@ -119,9 +119,9 @@ If diarization fails (e.g. `noSpeechDetected`, model error, timeout), the ASR re
 
 > **Amendment (2026-04-02):** The original decision was "always-on, no global toggle." This has been revised to **opt-in via a Settings toggle (off by default)**. See rationale below.
 
-~~For file transcription, always run it — users transcribing files almost always want to know who said what.~~ **Revised:** Diarization is opt-in via a "Speaker detection" toggle in Settings (off by default). Users who want speaker attribution enable it once; it stays on for all subsequent transcriptions.
+~~For file transcription, always run it — users transcribing files almost always want to know who said what.~~ **Revised:** Diarization is controlled by a "Speaker detection" toggle in Settings (on by default). Users who don't need speaker attribution can disable it for faster transcriptions.
 
-**Why the change:** The original reasoning assumed ~15% DER would be good enough to justify always-on. In practice, diarization accuracy isn't strong enough to warrant the extra processing time for every transcription by default. Defaulting to off avoids surprising users with slower transcriptions and imperfect speaker labels. Users who need speaker attribution can easily enable it.
+**Why the change:** The original decision was "always-on, no toggle." A Settings toggle gives users explicit control over the accuracy/speed tradeoff. The toggle detail text sets realistic expectations: "~85% accurate — best with clear audio and distinct voices."
 
 **Progress UX:** When enabled, show "Transcribing..." during ASR, then "Identifying speakers..." during diarization. When disabled, the diarization step is skipped entirely (no progress indicator for it).
 

--- a/spec/adr/010-speaker-diarization.md
+++ b/spec/adr/010-speaker-diarization.md
@@ -113,21 +113,23 @@ If diarization fails (e.g. `noSpeechDetected`, model error, timeout), the ASR re
 - Per-speaker analytics (speaking time, word count)
 - All export formats include speaker labels when available
 - Progress: "Identifying speakers..." sublabel with time estimate during diarization phase
-- Option-key alternate to skip diarization for power users (per-run, not a global toggle)
+- Settings toggle to enable/disable diarization (off by default)
 
 ### Always-on vs opt-in
 
-Diarization adds ~30-56 seconds of processing per hour of audio (at 64-122x RTF) on top of ASR's ~23 seconds per hour. Total file transcription time for 1 hour of audio: ~53-79 seconds (ASR + diarization). This is still very fast and the additional time is worth it for speaker attribution. Model download is ~130 MB (one-time).
+> **Amendment (2026-04-02):** The original decision was "always-on, no global toggle." This has been revised to **opt-in via a Settings toggle (off by default)**. See rationale below.
 
-For file transcription, always run it — users transcribing files almost always want to know who said what. If a file has only one speaker, diarization correctly returns a single speaker label with no user-visible overhead.
+~~For file transcription, always run it — users transcribing files almost always want to know who said what.~~ **Revised:** Diarization is opt-in via a "Speaker detection" toggle in Settings (off by default). Users who want speaker attribution enable it once; it stays on for all subsequent transcriptions.
 
-**Progress UX:** Show "Transcribing..." during ASR, then "Identifying speakers..." with sublabel *"Adds ~30-60s per hour of audio"* during diarization. No tooltip or info icon needed — the sublabel sets expectations.
+**Why the change:** The original reasoning assumed ~15% DER would be good enough to justify always-on. In practice, diarization accuracy isn't strong enough to warrant the extra processing time for every transcription by default. Defaulting to off avoids surprising users with slower transcriptions and imperfect speaker labels. Users who need speaker attribution can easily enable it.
 
-**No global toggle.** Adding a settings toggle introduces UI complexity, conditional logic, and "why don't I see speakers?" confusion. Instead, provide a **per-run Option-key alternate** — hold ⌥ when dropping a file to skip diarization ("Transcribe (Fast, No Speakers)"). This follows macOS convention for alternate actions and keeps the default UX clean.
+**Progress UX:** When enabled, show "Transcribing..." during ASR, then "Identifying speakers..." during diarization. When disabled, the diarization step is skipped entirely (no progress indicator for it).
 
-Skip diarization only for: dictation (single speaker by design) or explicit user opt-out via Option-key.
+~~**No global toggle.**~~ **Global toggle added.** A "Speaker detection" toggle in Settings → Transcription controls whether diarization runs. The original concern about "why don't I see speakers?" confusion is addressed by the toggle being clearly labeled and discoverable.
 
-**CLI:** `macparakeet-cli transcribe` runs diarization by default (matching GUI). Use `--no-diarize` to skip. Text output shows speaker labels at turn changes; JSON output includes all speaker data via Codable.
+Skip diarization for: dictation (single speaker by design), or when the Settings toggle is off.
+
+**CLI:** `macparakeet-cli transcribe` runs diarization by default (backward compatibility). Use `--no-diarize` to skip. Text output shows speaker labels at turn changes; JSON output includes all speaker data via Codable.
 
 ## Rationale
 


### PR DESCRIPTION
## Summary
Adds a "Speaker detection" toggle in Settings so users can control whether speaker diarization runs during transcription. On by default. Detail text sets realistic expectations about accuracy (~85%, Pyannote community-1).

Related to #43 — gives users control over speaker detection.

## Test plan
- [x] Toggle ON: diarization runs, speakers identified
- [x] Toggle OFF: diarization skipped, no "Identifying speakers" step
- [x] Retranscribe respects toggle in both directions
- [x] All tests pass

<img width="1548" height="1021" alt="Screenshot 2026-04-02 at 5 13 51 PM" src="https://github.com/user-attachments/assets/a4357a16-dba7-487a-a575-95afdf1c11d5" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)