### PR TITLE
Fix paste simulation for non-QWERTY keyboard layouts

### DIFF
--- a/Sources/MacParakeetCore/Services/ClipboardService.swift
+++ b/Sources/MacParakeetCore/Services/ClipboardService.swift
@@ -31,8 +31,15 @@ public enum ClipboardServiceError: LocalizedError {
 @MainActor
 public final class ClipboardService: ClipboardServiceProtocol {
     private let logger = Logger(subsystem: "com.macparakeet.core", category: "ClipboardService")
+    private let pasteShortcutKeyResolver: PasteShortcutKeyResolver
 
-    public init() {}
+    public init() {
+        pasteShortcutKeyResolver = PasteShortcutKeyResolver()
+    }
+
+    init(pasteShortcutKeyResolver: PasteShortcutKeyResolver) {
+        self.pasteShortcutKeyResolver = pasteShortcutKeyResolver
+    }
 
     /// Paste text into the active app by:
     /// 1. Saving current clipboard
@@ -154,7 +161,7 @@ public final class ClipboardService: ClipboardServiceProtocol {
         // Resolve the shortcut under the same Command-modified layout state that
         // the generated CGEvents will carry. This preserves layouts such as
         // "Dvorak - QWERTY ⌘" that intentionally remap only while Command is held.
-        let vKeyCode = virtualKeyCode(for: "v", modifierKeyState: UInt32(cmdKey >> 8))
+        let vKeyCode = pasteShortcutKeyResolver.virtualKeyCode(for: "v", modifierKeyState: UInt32(cmdKey >> 8))
 
         guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: true),
               let keyUp = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: false) else {
@@ -166,57 +173,5 @@ public final class ClipboardService: ClipboardServiceProtocol {
 
         keyUp.flags = .maskCommand
         keyUp.post(tap: .cghidEventTap)
-    }
-
-    private func virtualKeyCode(for character: Character, modifierKeyState: UInt32 = 0) -> CGKeyCode {
-        let fallbackKeyCode: CGKeyCode = 0x09
-        guard let layoutSourceRef = TISCopyCurrentKeyboardLayoutInputSource() else {
-            logger.error("Failed to get current keyboard input source; falling back to QWERTY keycode 0x09")
-            return fallbackKeyCode
-        }
-        let layoutSource = layoutSourceRef.takeRetainedValue()
-
-        guard let layoutDataRef = TISGetInputSourceProperty(layoutSource, kTISPropertyUnicodeKeyLayoutData) else {
-            logger.error("Failed to resolve keyboard layout data for paste shortcut; falling back to QWERTY keycode 0x09")
-            return fallbackKeyCode
-        }
-
-        let layoutData = Unmanaged<CFData>.fromOpaque(layoutDataRef).takeUnretainedValue()
-        guard let layoutBytes = CFDataGetBytePtr(layoutData) else {
-            logger.error("Failed to access keyboard layout bytes for paste shortcut; falling back to QWERTY keycode 0x09")
-            return fallbackKeyCode
-        }
-        let keyboardLayout = UnsafeRawPointer(layoutBytes).assumingMemoryBound(to: UCKeyboardLayout.self)
-
-        guard let target = String(character).utf16.first else {
-            logger.error("Failed to encode character for paste shortcut lookup; falling back to QWERTY keycode 0x09")
-            return fallbackKeyCode
-        }
-
-        for keyCode: UInt16 in 0..<128 {
-            var deadKeyState: UInt32 = 0
-            var length = 0
-            var chars = [UniChar](repeating: 0, count: 4)
-
-            let status = UCKeyTranslate(
-                keyboardLayout,
-                keyCode,
-                UInt16(kUCKeyActionDown),
-                modifierKeyState,
-                UInt32(LMGetKbdType()),
-                UInt32(kUCKeyTranslateNoDeadKeysMask),
-                &deadKeyState,
-                chars.count,
-                &length,
-                &chars
-            )
-
-            if status == noErr && length > 0 && chars[0] == target {
-                return CGKeyCode(keyCode)
-            }
-        }
-
-        logger.error("Failed to resolve virtual keycode for character '\(String(character), privacy: .public)'; falling back to QWERTY keycode 0x09")
-        return fallbackKeyCode
     }
 }

--- a/Sources/MacParakeetCore/Services/PasteShortcutKeyResolver.swift
+++ b/Sources/MacParakeetCore/Services/PasteShortcutKeyResolver.swift
@@ -1,0 +1,119 @@
+import Carbon
+import Foundation
+import OSLog
+
+enum KeyboardLayoutLookupResult {
+    case data(CFData)
+    case missingInputSource
+    case missingLayoutData
+    case inaccessibleLayoutBytes
+}
+
+struct PasteShortcutKeyResolver {
+    private let logger = Logger(subsystem: "com.macparakeet.core", category: "ClipboardService")
+    private let keyboardLayoutProvider: () -> KeyboardLayoutLookupResult
+    private let keyboardTypeProvider: () -> UInt32
+    private let translatedCharacterProvider: (CFData, UInt16, UInt32, UInt32) -> UniChar?
+
+    init(
+        keyboardLayoutProvider: @escaping () -> KeyboardLayoutLookupResult = Self.liveKeyboardLayout,
+        keyboardTypeProvider: @escaping () -> UInt32 = { UInt32(LMGetKbdType()) },
+        translatedCharacterProvider: @escaping (CFData, UInt16, UInt32, UInt32) -> UniChar? = Self.translatedCharacter
+    ) {
+        self.keyboardLayoutProvider = keyboardLayoutProvider
+        self.keyboardTypeProvider = keyboardTypeProvider
+        self.translatedCharacterProvider = translatedCharacterProvider
+    }
+
+    func virtualKeyCode(for character: Character, modifierKeyState: UInt32 = 0) -> CGKeyCode {
+        let fallbackKeyCode: CGKeyCode = 0x09
+        let layoutLookup = keyboardLayoutProvider()
+
+        let layoutData: CFData
+        switch layoutLookup {
+        case .data(let data):
+            layoutData = data
+        case .missingInputSource:
+            logger.error("Failed to get current keyboard input source; falling back to QWERTY keycode 0x09")
+            return fallbackKeyCode
+        case .missingLayoutData:
+            logger.error("Failed to resolve keyboard layout data for paste shortcut; falling back to QWERTY keycode 0x09")
+            return fallbackKeyCode
+        case .inaccessibleLayoutBytes:
+            logger.error("Failed to access keyboard layout bytes for paste shortcut; falling back to QWERTY keycode 0x09")
+            return fallbackKeyCode
+        }
+
+        guard let target = String(character).utf16.first else {
+            logger.error("Failed to encode character for paste shortcut lookup; falling back to QWERTY keycode 0x09")
+            return fallbackKeyCode
+        }
+
+        let keyboardType = keyboardTypeProvider()
+        for keyCode: UInt16 in 0..<128 {
+            guard let translated = translatedCharacterProvider(layoutData, keyCode, modifierKeyState, keyboardType) else {
+                continue
+            }
+
+            if translated == target {
+                return CGKeyCode(keyCode)
+            }
+        }
+
+        logger.error("Failed to resolve virtual keycode for character '\(String(character), privacy: .public)'; falling back to QWERTY keycode 0x09")
+        return fallbackKeyCode
+    }
+
+    private static func liveKeyboardLayout() -> KeyboardLayoutLookupResult {
+        guard let layoutSourceRef = TISCopyCurrentKeyboardLayoutInputSource() else {
+            return .missingInputSource
+        }
+        let layoutSource = layoutSourceRef.takeRetainedValue()
+
+        guard let layoutDataRef = TISGetInputSourceProperty(layoutSource, kTISPropertyUnicodeKeyLayoutData) else {
+            return .missingLayoutData
+        }
+
+        let layoutData = Unmanaged<CFData>.fromOpaque(layoutDataRef).takeUnretainedValue()
+        guard CFDataGetBytePtr(layoutData) != nil else {
+            return .inaccessibleLayoutBytes
+        }
+
+        return .data(layoutData)
+    }
+
+    private static func translatedCharacter(
+        layoutData: CFData,
+        keyCode: UInt16,
+        modifierKeyState: UInt32,
+        keyboardType: UInt32
+    ) -> UniChar? {
+        guard let layoutBytes = CFDataGetBytePtr(layoutData) else {
+            return nil
+        }
+
+        let keyboardLayout = UnsafeRawPointer(layoutBytes).assumingMemoryBound(to: UCKeyboardLayout.self)
+        var deadKeyState: UInt32 = 0
+        var length = 0
+        var chars = [UniChar](repeating: 0, count: 4)
+
+        let status = UCKeyTranslate(
+            keyboardLayout,
+            keyCode,
+            UInt16(kUCKeyActionDown),
+            modifierKeyState,
+            keyboardType,
+            UInt32(kUCKeyTranslateNoDeadKeysMask),
+            &deadKeyState,
+            chars.count,
+            &length,
+            &chars
+        )
+
+        guard status == noErr, length > 0 else {
+            return nil
+        }
+
+        return chars[0]
+    }
+}

--- a/Tests/MacParakeetTests/Services/PasteShortcutKeyResolverTests.swift
+++ b/Tests/MacParakeetTests/Services/PasteShortcutKeyResolverTests.swift
@@ -1,0 +1,75 @@
+import Carbon
+import XCTest
+@testable import MacParakeetCore
+
+final class PasteShortcutKeyResolverTests: XCTestCase {
+    func testResolvesNonQwertyMapping() {
+        let resolver = PasteShortcutKeyResolver(
+            keyboardLayoutProvider: { .data(Self.dummyLayoutData) },
+            keyboardTypeProvider: { 40 },
+            translatedCharacterProvider: { _, keyCode, modifierKeyState, keyboardType in
+                XCTAssertEqual(modifierKeyState, 0)
+                XCTAssertEqual(keyboardType, 40)
+                return keyCode == 17 ? Self.vCharacter : nil
+            }
+        )
+
+        XCTAssertEqual(resolver.virtualKeyCode(for: "v"), 17)
+    }
+
+    func testUsesCommandModifiedMappingWhenResolvingPasteShortcut() {
+        let commandModifierState = UInt32(cmdKey >> 8)
+        let resolver = PasteShortcutKeyResolver(
+            keyboardLayoutProvider: { .data(Self.dummyLayoutData) },
+            translatedCharacterProvider: { _, keyCode, modifierKeyState, _ in
+                switch (keyCode, modifierKeyState) {
+                case (9, commandModifierState):
+                    return Self.vCharacter
+                case (17, 0):
+                    return Self.vCharacter
+                default:
+                    return nil
+                }
+            }
+        )
+
+        XCTAssertEqual(resolver.virtualKeyCode(for: "v", modifierKeyState: 0), 17)
+        XCTAssertEqual(resolver.virtualKeyCode(for: "v", modifierKeyState: commandModifierState), 9)
+    }
+
+    func testFallsBackToQwertyWhenLayoutSourceIsMissing() {
+        let resolver = PasteShortcutKeyResolver(
+            keyboardLayoutProvider: { .missingInputSource },
+            translatedCharacterProvider: { _, _, _, _ in
+                XCTFail("Translator should not be called when input source is missing")
+                return nil
+            }
+        )
+
+        XCTAssertEqual(resolver.virtualKeyCode(for: "v"), 0x09)
+    }
+
+    func testFallsBackToQwertyWhenLayoutDataIsMissing() {
+        let resolver = PasteShortcutKeyResolver(
+            keyboardLayoutProvider: { .missingLayoutData },
+            translatedCharacterProvider: { _, _, _, _ in
+                XCTFail("Translator should not be called when layout data is missing")
+                return nil
+            }
+        )
+
+        XCTAssertEqual(resolver.virtualKeyCode(for: "v"), 0x09)
+    }
+
+    func testFallsBackToQwertyWhenNoMatchingKeyCodeExists() {
+        let resolver = PasteShortcutKeyResolver(
+            keyboardLayoutProvider: { .data(Self.dummyLayoutData) },
+            translatedCharacterProvider: { _, _, _, _ in nil }
+        )
+
+        XCTAssertEqual(resolver.virtualKeyCode(for: "v"), 0x09)
+    }
+
+    private static let dummyLayoutData = Data([0x00]) as CFData
+    private static let vCharacter = UniChar(("v" as UnicodeScalar).value)
+}


### PR DESCRIPTION
Fixes #54.

## What Changed
- `Sources/MacParakeetCore/Services/ClipboardService.swift`: Added `import Carbon` plus a `virtualKeyCode(for:)` helper that uses `UCKeyTranslate` to resolve the keycode for `v` from the active keyboard layout instead of hardcoding QWERTY keycode `0x09`.
- Updated paste simulation to send `Cmd+V` using the resolved keycode.
- Switched layout lookup to `TISCopyCurrentKeyboardLayoutInputSource()` so IME/input-mode users still resolve against the backing keyboard layout.
- Kept the `0x09` fallback only as a defensive last resort, with explicit logging when layout resolution fails.

## Root Intent
The original paste simulation hardcoded virtual keycode `0x09`, which is the physical `v` position on QWERTY. On Dvorak that position produces `k`, so `Cmd+V` was sent as `Cmd+K`. The same class of bug affects Colemak, AZERTY, and other non-QWERTY layouts.

The first pass of this PR replaced the hardcoded keycode with a dynamic lookup, but it queried `TISCopyCurrentKeyboardInputSource()`. That works when the active input source is itself a keyboard layout, but it is incomplete when the active source is an IME or input mode. In those cases, `kTISPropertyUnicodeKeyLayoutData` can be unavailable on the current input source, causing the helper to fall back to the old QWERTY keycode.

Using `TISCopyCurrentKeyboardLayoutInputSource()` fixes the abstraction mismatch by asking macOS for the backing keyboard layout rather than the current IME wrapper. That makes the shortcut resolution work for both direct non-QWERTY layouts and IME-backed non-QWERTY layouts.

## Validation
- `swift build`
- `swift test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Paste now detects and uses the correct key for the paste shortcut based on your current keyboard layout, improving reliability across varied input sources; includes a safe fallback when layout detection isn't available.
* **Tests**
  * Added tests validating layout-aware shortcut resolution and fallback behavior across scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->