### PR TITLE
ADR-016: Centralized two-slot STT control plane

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ MacParakeet has three primary modes that are equal in importance:
 2. **File transcription** -- Drag-drop audio/video files for full transcription (MacWhisper-style)
 3. **Meeting recording** -- Capture system audio + mic simultaneously, transcribe locally (simple Granola-style)
 
-All three modes share the same Parakeet STT backend but have different UI flows, audio sources, and data models. **Dictation and meeting recording run concurrently** (ADR-015) -- a user can dictate freely during a meeting recording. Each flow owns its own AVAudioEngine; macOS HAL handles mic multiplexing. All STT work routes through one process-wide runtime and scheduler (ADR-016), with dictation prioritized over meeting live preview and batch file work.
+All three modes share the same Parakeet STT backend but have different UI flows, audio sources, and data models. **Dictation and meeting recording run concurrently** (ADR-015) -- a user can dictate freely during a meeting recording. Each flow owns its own AVAudioEngine; macOS HAL handles mic multiplexing. All STT work routes through one process-wide runtime and scheduler (ADR-016), with a reserved dictation slot and a shared background slot where meeting work outranks file transcription.
 
 ### STT Integration (Parakeet via FluidAudio)
 
@@ -126,8 +126,9 @@ All three modes share the same Parakeet STT backend but have different UI flows,
 - ~2.5% Word Error Rate
 - ~66 MB working memory during inference (vs ~2 GB+ on GPU/MLX)
 - ~6 GB CoreML model bundle downloaded during onboarding
-- One process-wide STT runtime owns `AsrManager`
-- One scheduler owns priorities, backpressure, and job-scoped progress
+- One process-wide `STTRuntime` owner manages model lifecycle for the app
+- The default STT topology uses 2 execution slots: reserved dictation + shared meeting/batch
+- One `STTScheduler` owns slot assignment, priority, backpressure, cancellation, and job-scoped progress
 
 **Swift API:**
 ```swift

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,9 +118,7 @@ MacParakeet has three primary modes that are equal in importance:
 
 All three modes share the same Parakeet STT backend but have different UI flows, audio sources, and data models. **Dictation and meeting recording run concurrently** (ADR-015) -- a user can dictate freely during a meeting recording. Each flow owns its own AVAudioEngine; macOS HAL handles mic multiplexing.
 
-ADR-016 defines the **approved target architecture** as one process-wide runtime/scheduler path with a reserved dictation slot and a shared background slot where meeting work outranks file transcription.
-
-**Current branch note:** the checked-out v0.6 implementation has already centralized STT ownership in `AppEnvironment`, but it still uses an intermediate internal `dictation` / `meeting` / `batch` lane shape while converging toward the approved two-slot design. Read `spec/03-architecture.md` and `spec/06-stt-engine.md` as the source of truth for target-vs-current distinctions.
+ADR-016 defines the STT architecture as one process-wide runtime/scheduler path with a reserved dictation slot and a shared background slot where meeting work outranks file transcription.
 
 ### STT Integration (Parakeet via FluidAudio)
 
@@ -131,9 +129,8 @@ ADR-016 defines the **approved target architecture** as one process-wide runtime
 - ~66 MB working memory per active Parakeet inference slot (vs ~2 GB+ on GPU/MLX)
 - ~6 GB CoreML speech model bundle downloaded during onboarding
 - ~130 MB diarization asset bundle prepared alongside onboarding/default speaker-detection readiness
-- Approved target: one process-wide `STTRuntime` owner manages model lifecycle for the app
-- Approved target: the default STT topology uses 2 execution slots: reserved dictation + shared meeting/batch
-- Current branch implementation: centralized ownership exists, but execution still routes through internal `dictation` / `meeting` / `batch` lanes while converging to the target shape
+- One process-wide `STTRuntime` owner manages model lifecycle for the app
+- The default STT topology uses 2 execution slots: reserved dictation + shared meeting/batch
 - One `STTScheduler` owns slot assignment, priority, backpressure, cancellation, and job-scoped progress
 
 **Swift API:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,11 @@ MacParakeet has three primary modes that are equal in importance:
 2. **File transcription** -- Drag-drop audio/video files for full transcription (MacWhisper-style)
 3. **Meeting recording** -- Capture system audio + mic simultaneously, transcribe locally (simple Granola-style)
 
-All three modes share the same Parakeet STT backend but have different UI flows, audio sources, and data models. **Dictation and meeting recording run concurrently** (ADR-015) -- a user can dictate freely during a meeting recording. Each flow owns its own AVAudioEngine; macOS HAL handles mic multiplexing. All STT work routes through one process-wide runtime and scheduler (ADR-016), with a reserved dictation slot and a shared background slot where meeting work outranks file transcription.
+All three modes share the same Parakeet STT backend but have different UI flows, audio sources, and data models. **Dictation and meeting recording run concurrently** (ADR-015) -- a user can dictate freely during a meeting recording. Each flow owns its own AVAudioEngine; macOS HAL handles mic multiplexing.
+
+ADR-016 defines the **approved target architecture** as one process-wide runtime/scheduler path with a reserved dictation slot and a shared background slot where meeting work outranks file transcription.
+
+**Current branch note:** the checked-out v0.6 implementation has already centralized STT ownership in `AppEnvironment`, but it still uses an intermediate internal `dictation` / `meeting` / `batch` lane shape while converging toward the approved two-slot design. Read `spec/03-architecture.md` and `spec/06-stt-engine.md` as the source of truth for target-vs-current distinctions.
 
 ### STT Integration (Parakeet via FluidAudio)
 
@@ -124,11 +128,12 @@ All three modes share the same Parakeet STT backend but have different UI flows,
 - Parakeet TDT 0.6B-v3 returns word-level timestamps + confidence scores
 - ~155x realtime on Apple Silicon (60 min audio in ~23 seconds)
 - ~2.5% Word Error Rate
-- ~66 MB working memory during inference (vs ~2 GB+ on GPU/MLX)
+- ~66 MB working memory per active Parakeet inference slot (vs ~2 GB+ on GPU/MLX)
 - ~6 GB CoreML speech model bundle downloaded during onboarding
 - ~130 MB diarization asset bundle prepared alongside onboarding/default speaker-detection readiness
-- One process-wide `STTRuntime` owner manages model lifecycle for the app
-- The default STT topology uses 2 execution slots: reserved dictation + shared meeting/batch
+- Approved target: one process-wide `STTRuntime` owner manages model lifecycle for the app
+- Approved target: the default STT topology uses 2 execution slots: reserved dictation + shared meeting/batch
+- Current branch implementation: centralized ownership exists, but execution still routes through internal `dictation` / `meeting` / `batch` lanes while converging to the target shape
 - One `STTScheduler` owns slot assignment, priority, backpressure, cancellation, and job-scoped progress
 
 **Swift API:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ All ADRs are in `spec/adr/`. These are locked decisions -- don't second-guess th
 | ADR-013 | Prompt Library + multi-summary architecture | `spec/adr/013-prompt-library-multi-summary.md` |
 | ADR-014 | Meeting recording via Core Audio Taps | `spec/adr/014-meeting-recording.md` |
 | ADR-015 | Concurrent dictation and meeting recording | `spec/adr/015-concurrent-dictation-meeting.md` |
-| ADR-016 | Centralized STT runtime and scheduler | `spec/adr/016-centralized-stt-runtime-scheduler.md` |
+| ADR-016 | Centralized STT runtime and two-slot scheduler | `spec/adr/016-centralized-stt-runtime-scheduler.md` |
 
 > Historical ADRs (still in `spec/adr/`, kept for context): ADR-003 (one-time purchase pricing), ADR-006 (trial + license activation), ADR-008 (local LLM runtime). The app is now free/GPL-3.0.
 
@@ -125,7 +125,8 @@ All three modes share the same Parakeet STT backend but have different UI flows,
 - ~155x realtime on Apple Silicon (60 min audio in ~23 seconds)
 - ~2.5% Word Error Rate
 - ~66 MB working memory during inference (vs ~2 GB+ on GPU/MLX)
-- ~6 GB CoreML model bundle downloaded during onboarding
+- ~6 GB CoreML speech model bundle downloaded during onboarding
+- ~130 MB diarization asset bundle prepared alongside onboarding/default speaker-detection readiness
 - One process-wide `STTRuntime` owner manages model lifecycle for the app
 - The default STT topology uses 2 execution slots: reserved dictation + shared meeting/batch
 - One `STTScheduler` owns slot assignment, priority, backpressure, cancellation, and job-scoped progress

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,21 +1,12 @@
 {
   "pins" : [
     {
-      "identity" : "eventsource",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattt/EventSource.git",
-      "state" : {
-        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
-        "version" : "1.4.1"
-      }
-    },
-    {
       "identity" : "fluidaudio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio",
       "state" : {
-        "revision" : "2d2979486bd7125558fe783741ef9a2757b3c1bb",
-        "version" : "0.12.5"
+        "revision" : "57551cd90e0bbec342766244358bcf08afb05290",
+        "version" : "0.13.6"
       }
     },
     {
@@ -43,96 +34,6 @@
       "state" : {
         "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
         "version" : "1.7.1"
-      }
-    },
-    {
-      "identity" : "swift-asn1",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-asn1.git",
-      "state" : {
-        "revision" : "9f542610331815e29cc3821d3b6f488db8715517",
-        "version" : "1.6.0"
-      }
-    },
-    {
-      "identity" : "swift-atomics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-atomics.git",
-      "state" : {
-        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
-        "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "swift-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections.git",
-      "state" : {
-        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
-        "version" : "1.4.1"
-      }
-    },
-    {
-      "identity" : "swift-crypto",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-crypto.git",
-      "state" : {
-        "revision" : "fa308c07a6fa04a727212d793e761460e41049c3",
-        "version" : "4.3.0"
-      }
-    },
-    {
-      "identity" : "swift-huggingface",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-huggingface.git",
-      "state" : {
-        "revision" : "b721959445b617d0bf03910b2b4aced345fd93bf",
-        "version" : "0.9.0"
-      }
-    },
-    {
-      "identity" : "swift-jinja",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-jinja.git",
-      "state" : {
-        "revision" : "f731f03bf746481d4fda07f817c3774390c4d5b9",
-        "version" : "2.3.2"
-      }
-    },
-    {
-      "identity" : "swift-nio",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio.git",
-      "state" : {
-        "revision" : "b31565862a8f39866af50bc6676160d8dda7de35",
-        "version" : "2.96.0"
-      }
-    },
-    {
-      "identity" : "swift-system",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-system.git",
-      "state" : {
-        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
-        "version" : "1.6.4"
-      }
-    },
-    {
-      "identity" : "swift-transformers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-transformers",
-      "state" : {
-        "revision" : "eed7264ac5e4ec5dfa6165c6e5c5577364344fe4",
-        "version" : "1.2.0"
-      }
-    },
-    {
-      "identity" : "yyjson",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ibireme/yyjson.git",
-      "state" : {
-        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
-        "version" : "0.12.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         // GRDB for SQLite (dictation history + transcription records)
         .package(url: "https://github.com/groue/GRDB.swift", from: "7.0.0"),
         // FluidAudio for Parakeet STT on CoreML/ANE
-        .package(url: "https://github.com/FluidInference/FluidAudio", .upToNextMinor(from: "0.12.1")),
+        .package(url: "https://github.com/FluidInference/FluidAudio", .upToNextMinor(from: "0.13.6")),
         // ArgumentParser for CLI
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
         // Sparkle for auto-updates (non-App Store distribution)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ MacParakeet runs NVIDIA's Parakeet TDT on Apple's Neural Engine via [FluidAudio]
 
 - Dictation and meeting recording can run at the same time.
 - Audio capture stays independent per flow.
-- All STT work routes through one shared runtime owner and explicit scheduler with dictation, meeting, and batch lanes, so active meeting work and dictation do not queue behind library/batch transcription.
+- All STT work routes through one shared runtime owner and explicit scheduler with two default slots: a reserved dictation slot and a shared meeting/batch slot, so file transcription can wait behind interactive work.
 
 ### Performance
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ MacParakeet runs NVIDIA's Parakeet TDT on Apple's Neural Engine via [FluidAudio]
 
 - Dictation and meeting recording can run at the same time.
 - Audio capture stays independent per flow.
-- All STT work routes through one shared runtime and scheduler so interactive dictation stays prioritized over background preview and batch transcription work.
+- All STT work routes through one shared runtime owner and explicit scheduler with dictation, meeting, and batch lanes, so active meeting work and dictation do not queue behind library/batch transcription.
 
 ### Performance
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
 ---
 
-MacParakeet runs NVIDIA's Parakeet TDT on Apple's Neural Engine via [FluidAudio](https://github.com/FluidInference/FluidAudio) CoreML. Press a hotkey, speak, text appears. Or drag a file and get a full transcript. All speech recognition happens on your Mac.
+MacParakeet runs NVIDIA's Parakeet TDT on Apple's Neural Engine via [FluidAudio](https://github.com/FluidInference/FluidAudio) CoreML. It has three co-equal modes: system-wide dictation, file/URL transcription, and meeting recording. All speech recognition happens on your Mac.
 
 ## What it does
 
@@ -50,9 +50,17 @@ MacParakeet runs NVIDIA's Parakeet TDT on Apple's Neural Engine via [FluidAudio]
 
 **File transcription** — Drag audio or video files, or paste a YouTube URL. Full transcript with word-level timestamps, speaker labels, and export to 7 formats (TXT, Markdown, SRT, VTT, DOCX, PDF, JSON).
 
+**Meeting recording** — Capture microphone + system audio together, watch a live transcript preview while recording, and save the finished meeting directly into the library with summaries, chat, search, and export support.
+
 **Text cleanup** — Filler word removal, custom word replacements, text snippets with triggers. Deterministic pipeline, no LLM needed.
 
-**AI features** — Optional transcript summaries and chat. The current branch ships a prompt library with 7 built-in summary prompts plus custom prompts, multi-summary tabs, and queued summary generation. Use Claude Code or Codex via Local CLI, or connect OpenAI, Anthropic, Google Gemini, Ollama, or OpenRouter. Entirely opt-in, with a fully local setup available when you stay on local providers/features.
+**AI features** — Optional transcript summaries and chat. Ships with a prompt library, built-in and custom summary prompts, multi-summary tabs, and queued summary generation. Use Claude Code or Codex via Local CLI, or connect OpenAI, Anthropic, Google Gemini, Ollama, or OpenRouter. Entirely opt-in, with a fully local setup available when you stay on local providers/features.
+
+### Concurrent by design
+
+- Dictation and meeting recording can run at the same time.
+- Audio capture stays independent per flow.
+- All STT work routes through one shared runtime and scheduler so interactive dictation stays prioritized over background preview and batch transcription work.
 
 ### Performance
 
@@ -71,7 +79,7 @@ MacParakeet runs NVIDIA's Parakeet TDT on Apple's Neural Engine via [FluidAudio]
 
 **Download:** Grab the [notarized DMG](https://downloads.macparakeet.com/MacParakeet.dmg) or visit [macparakeet.com](https://macparakeet.com). Drag to Applications, done.
 
-First launch downloads the speech model (~6 GB). After that, dictation and transcription work fully offline.
+First launch downloads the speech model (~6 GB). After that, dictation, meeting recording, and transcription work fully offline.
 
 **Build from source:**
 
@@ -97,6 +105,7 @@ swift run macparakeet-cli history
 | Layer | Choice |
 |-------|--------|
 | STT | Parakeet TDT 0.6B-v3 via [FluidAudio](https://github.com/FluidInference/FluidAudio) CoreML (Neural Engine) |
+| STT orchestration | Shared runtime + explicit scheduler across dictation, meeting recording, and transcription |
 | Language | Swift 6.0 + SwiftUI |
 | Database | SQLite via GRDB |
 | Auto-updates | Sparkle 2 |

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ MacParakeet runs NVIDIA's Parakeet TDT on Apple's Neural Engine via [FluidAudio]
 
 - ~155x realtime — 60 min of audio in ~23 seconds
 - ~2.5% word error rate (Parakeet TDT 0.6B-v3)
-- ~66 MB working memory during inference
+- ~66 MB working memory per active Parakeet inference slot
 - 25 European languages with auto-detection
 
 ### Limitations

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ MacParakeet runs NVIDIA's Parakeet TDT on Apple's Neural Engine via [FluidAudio]
 
 **Download:** Grab the [notarized DMG](https://downloads.macparakeet.com/MacParakeet.dmg) or visit [macparakeet.com](https://macparakeet.com). Drag to Applications, done.
 
-First launch downloads the speech model (~6 GB). After that, dictation, meeting recording, and transcription work fully offline.
+First launch downloads the speech model (~6 GB) plus speaker-detection assets (~130 MB) when that default-on feature remains enabled. After that, dictation, meeting recording, and transcription work fully offline.
 
 **Build from source:**
 

--- a/Sources/CLI/Commands/HealthCommand.swift
+++ b/Sources/CLI/Commands/HealthCommand.swift
@@ -5,10 +5,10 @@ import MacParakeetCore
 struct HealthCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "health",
-        abstract: "Check system health: database, local models, and helper binaries."
+        abstract: "Check system health: database, local speech stack, and helper binaries."
     )
 
-    @Flag(name: .long, help: "Attempt to repair/warm the Parakeet speech model.")
+    @Flag(name: .long, help: "Attempt to repair/warm the local speech stack.")
     var repairModels: Bool = false
 
     @Option(name: .long, help: "Maximum repair attempts when --repair-models is set.")
@@ -68,24 +68,29 @@ struct HealthCommand: AsyncParsableCommand {
         }
         print()
 
-        // 4. Local models
-        print("Local Models:")
+        // 4. Local speech stack
+        print("Local Speech Stack:")
         let sttClient = STTClient()
-
-        await printSTTStatus(sttClient: sttClient)
+        let diarizationService = DiarizationService()
+        let status = await loadSpeechStackStatus(
+            sttClient: sttClient,
+            diarizationService: diarizationService
+        )
+        printSpeechStackStatus(status, includeHeader: false)
 
         if let repairAttempts = validatedRepairAttempts {
             print()
-            print("Model repair requested...")
+            print("Speech-stack repair requested...")
             do {
-                try await warmUpModels(
+                try await prepareSpeechStack(
                     attempts: repairAttempts,
                     sttClient: sttClient,
+                    diarizationService: diarizationService,
                     log: { message in print("  \(message)") }
                 )
-                print("Model repair completed.")
+                print("Speech-stack repair completed.")
             } catch {
-                print("Model repair failed — \(error.localizedDescription)")
+                print("Speech-stack repair failed — \(error.localizedDescription)")
             }
         }
         await sttClient.shutdown()

--- a/Sources/CLI/Commands/ModelsCommand.swift
+++ b/Sources/CLI/Commands/ModelsCommand.swift
@@ -5,7 +5,7 @@ import MacParakeetCore
 struct ModelsCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "models",
-        abstract: "Inspect and manage the local Parakeet speech model.",
+        abstract: "Inspect and manage the local speech and speaker models.",
         subcommands: [
             Status.self,
             WarmUp.self,
@@ -19,19 +19,25 @@ extension ModelsCommand {
     struct Status: AsyncParsableCommand {
         static let configuration = CommandConfiguration(
             commandName: "status",
-            abstract: "Show speech model status without forcing downloads."
+            abstract: "Show speech-stack status without forcing downloads."
         )
 
         func run() async throws {
             let sttClient = STTClient()
-            await printSTTStatus(sttClient: sttClient)
+            let diarizationService = DiarizationService()
+            let status = await loadSpeechStackStatus(
+                sttClient: sttClient,
+                diarizationService: diarizationService
+            )
+            printSpeechStackStatus(status)
+            await sttClient.shutdown()
         }
     }
 
     struct WarmUp: AsyncParsableCommand {
         static let configuration = CommandConfiguration(
             commandName: "warm-up",
-            abstract: "Warm up speech model. May download on first run."
+            abstract: "Warm up the local speech stack. May download on first run."
         )
 
         @Option(name: .long, help: "Maximum attempts.")
@@ -40,18 +46,21 @@ extension ModelsCommand {
         func run() async throws {
             let attempts = try validatedAttempts(attempts)
             let sttClient = STTClient()
-            try await warmUpModels(
+            let diarizationService = DiarizationService()
+            try await prepareSpeechStack(
                 attempts: attempts,
                 sttClient: sttClient,
+                diarizationService: diarizationService,
                 log: { print($0) }
             )
+            await sttClient.shutdown()
         }
     }
 
     struct Repair: AsyncParsableCommand {
         static let configuration = CommandConfiguration(
             commandName: "repair",
-            abstract: "Best-effort retry speech model repair."
+            abstract: "Best-effort retry for the local speech stack."
         )
 
         @Option(name: .long, help: "Maximum attempts.")
@@ -60,11 +69,14 @@ extension ModelsCommand {
         func run() async throws {
             let attempts = try validatedAttempts(attempts)
             let sttClient = STTClient()
-            try await warmUpModels(
+            let diarizationService = DiarizationService()
+            try await prepareSpeechStack(
                 attempts: attempts,
                 sttClient: sttClient,
+                diarizationService: diarizationService,
                 log: { print($0) }
             )
+            await sttClient.shutdown()
         }
     }
 
@@ -77,8 +89,32 @@ extension ModelsCommand {
         func run() async throws {
             let sttClient = STTClient()
             await sttClient.clearModelCache()
-            print("Parakeet (STT): model cache cleared")
+            DiarizationService.clearModelCache()
+            print("Local speech and speaker model caches cleared")
         }
+    }
+}
+
+struct SpeechStackStatus: Sendable, Equatable {
+    let speechModelCached: Bool
+    let speechRuntimeReady: Bool
+    let speakerModelsCached: Bool
+    let speakerModelsPrepared: Bool
+
+    var summary: String {
+        if speechRuntimeReady && speakerModelsPrepared {
+            return "Ready"
+        }
+        if speechModelCached && speakerModelsCached {
+            return "Downloaded (loads on demand)"
+        }
+        if speechModelCached {
+            return "Speech model present, speaker models missing"
+        }
+        if speakerModelsCached {
+            return "Speaker models present, speech model missing"
+        }
+        return "Not downloaded"
     }
 }
 
@@ -89,25 +125,38 @@ func validatedAttempts(_ attempts: Int) throws -> Int {
     return attempts
 }
 
-func printSTTStatus(sttClient: STTClientProtocol) async {
-    let cached = STTClient.isModelCached()
-    let ready = await sttClient.isReady()
+func loadSpeechStackStatus(
+    sttClient: STTClientProtocol,
+    diarizationService: DiarizationServiceProtocol,
+    isSpeechModelCached: @escaping @Sendable () -> Bool = { STTClient.isModelCached() }
+) async -> SpeechStackStatus {
+    async let speechRuntimeReady = sttClient.isReady()
+    async let speakerModelsCached = diarizationService.hasCachedModels()
+    async let speakerModelsPrepared = diarizationService.isReady()
 
-    print("Parakeet (STT):")
-    print("  Cached: \(cached ? "Yes" : "No")")
-    print("  Ready:  \(ready ? "Yes" : "No")")
-    if ready {
-        print("  Status: Ready")
-    } else if cached {
-        print("  Status: Downloaded (loads on demand)")
-    } else {
-        print("  Status: Not downloaded")
-    }
+    return await SpeechStackStatus(
+        speechModelCached: isSpeechModelCached(),
+        speechRuntimeReady: speechRuntimeReady,
+        speakerModelsCached: speakerModelsCached,
+        speakerModelsPrepared: speakerModelsPrepared
+    )
 }
 
-func warmUpModels(
+func printSpeechStackStatus(_ status: SpeechStackStatus, includeHeader: Bool = true) {
+    if includeHeader {
+        print("Local speech stack:")
+    }
+    print("  Speech model cached:   \(status.speechModelCached ? "Yes" : "No")")
+    print("  Speech runtime loaded: \(status.speechRuntimeReady ? "Yes" : "No")")
+    print("  Speaker models cached: \(status.speakerModelsCached ? "Yes" : "No")")
+    print("  Speaker models prepared: \(status.speakerModelsPrepared ? "Yes" : "No")")
+    print("  Status: \(status.summary)")
+}
+
+func prepareSpeechStack(
     attempts: Int,
     sttClient: STTClientProtocol,
+    diarizationService: DiarizationServiceProtocol,
     log: @escaping @Sendable (String) -> Void
 ) async throws {
     log("Parakeet (STT): preparing...")
@@ -119,8 +168,18 @@ func warmUpModels(
         }
     }
 
-    let ready = await sttClient.isReady()
-    log("Parakeet (STT): \(ready ? "Ready" : "Not ready")")
+    log("Speaker models: preparing...")
+    try await runWithRetry(attempts: attempts, label: "Speaker models", log: log) { _ in
+        try await diarizationService.prepareModels { message in
+            log("Speaker models: \(message)")
+        }
+    }
+
+    let status = await loadSpeechStackStatus(
+        sttClient: sttClient,
+        diarizationService: diarizationService
+    )
+    log("Speech stack: \(status.summary)")
 }
 
 private func runWithRetry(

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -72,17 +72,18 @@ struct TranscribeCommand: AsyncParsableCommand {
         }
 
         let diarizationService: DiarizationService? = noDiarize ? nil : DiarizationService()
-        let appDefaults = UserDefaults(suiteName: "com.macparakeet") ?? UserDefaults.standard
+        let appDefaultsSuiteName = "com.macparakeet"
 
         let service = TranscriptionService(
             audioProcessor: audioProcessor,
-            sttClient: sttClient,
+            sttTranscriber: sttClient,
             transcriptionRepo: transcriptionRepo,
             entitlements: entitlementsService,
             customWordRepo: customWordRepo,
             snippetRepo: snippetRepo,
             processingMode: {
-                Self.resolveProcessingMode(self.mode, storedMode: appDefaults.string(forKey: "processingMode"))
+                let defaults = UserDefaults(suiteName: appDefaultsSuiteName) ?? UserDefaults.standard
+                return Self.resolveProcessingMode(self.mode, storedMode: defaults.string(forKey: "processingMode"))
             },
             shouldKeepDownloadedAudio: {
                 switch self.downloadedAudio {
@@ -91,7 +92,8 @@ struct TranscribeCommand: AsyncParsableCommand {
                 case .delete:
                     return false
                 case .appDefault:
-                    return appDefaults.object(forKey: "saveTranscriptionAudio") as? Bool ?? true
+                    let defaults = UserDefaults(suiteName: appDefaultsSuiteName) ?? UserDefaults.standard
+                    return defaults.object(forKey: "saveTranscriptionAudio") as? Bool ?? true
                 }
             },
             youtubeDownloader: youtubeDownloader,

--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -12,8 +12,8 @@ final class AppEnvironment {
     let chatConversationRepo: ChatConversationRepository
     let promptRepo: PromptRepository
     let promptResultRepo: PromptResultRepository
-    let sttClient: STTClient
-    let meetingSTTClient: STTClient
+    let sttRuntime: STTRuntime
+    let sttScheduler: STTScheduler
     let audioProcessor: AudioProcessor
     let meetingRecordingService: MeetingRecordingService
     let dictationService: DictationService
@@ -54,10 +54,10 @@ final class AppEnvironment {
         try? dictationRepo.clearMissingAudioPaths()
 
         // Services
-        sttClient = STTClient()
-        meetingSTTClient = STTClient()
+        sttRuntime = STTRuntime()
+        sttScheduler = STTScheduler(runtime: sttRuntime)
         audioProcessor = AudioProcessor()
-        meetingRecordingService = MeetingRecordingService(sttClient: meetingSTTClient)
+        meetingRecordingService = MeetingRecordingService(sttTranscriber: sttScheduler)
         clipboardService = ClipboardService()
         exportService = ExportService()
         permissionService = PermissionService()
@@ -114,7 +114,7 @@ final class AppEnvironment {
 
         dictationService = DictationService(
             audioProcessor: audioProcessor,
-            sttClient: sttClient,
+            sttTranscriber: sttScheduler,
             dictationRepo: dictationRepo,
             shouldSaveAudio: {
                 // Defaults to true if unset (matches Settings UI default).
@@ -147,7 +147,7 @@ final class AppEnvironment {
 
         transcriptionService = TranscriptionService(
             audioProcessor: audioProcessor,
-            sttClient: sttClient,
+            sttTranscriber: sttScheduler,
             transcriptionRepo: transcriptionRepo,
             entitlements: entitlementsService,
             customWordRepo: customWordRepo,

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -120,7 +120,7 @@ final class MeetingRecordingFlowCoordinator {
             panelVM.elapsedSeconds = 0
             panelVM.micLevel = 0
             panelVM.systemLevel = 0
-            panelVM.updatePreviewLines([])
+            panelVM.updatePreviewLines([], isTranscriptionLagging: false)
             panelVM.onStop = { [weak self] in self?.toggleRecording() }
             panelVM.onClose = { [weak self] in self?.hideMeetingPanel() }
             panelViewModel = panelVM
@@ -337,7 +337,10 @@ final class MeetingRecordingFlowCoordinator {
                     Self.makePreviewLines(from: update)
                 }.value
                 guard !Task.isCancelled else { break }
-                panelViewModel?.updatePreviewLines(previewLines)
+                panelViewModel?.updatePreviewLines(
+                    previewLines,
+                    isTranscriptionLagging: update.isTranscriptionLagging
+                )
             }
         }
     }

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -111,10 +111,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // Block briefly for STT cleanup (ANE/CoreML resource release).
         // Must use Task.detached — a plain Task inherits @MainActor context and would
         // deadlock because the main thread is blocked by semaphore.wait below.
-        let sttClient = appEnvironment?.sttClient
+        let sttScheduler = appEnvironment?.sttScheduler
         let semaphore = DispatchSemaphore(value: 0)
         Task.detached {
-            await sttClient?.shutdown()
+            await sttScheduler?.shutdown()
             semaphore.signal()
         }
         _ = semaphore.wait(timeout: .now() + 2.0)
@@ -385,7 +385,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 checkoutURL: env.checkoutURL,
                 customWordRepo: env.customWordRepo,
                 snippetRepo: env.snippetRepo,
-                sttClient: env.sttClient
+                sttClient: env.sttScheduler
             )
             customWordsViewModel.configure(repo: env.customWordRepo)
             textSnippetsViewModel.configure(repo: env.snippetRepo)
@@ -690,7 +690,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         if !completed {
             showOnboarding(
                 permissionService: env.permissionService,
-                sttClient: env.sttClient,
+                sttClient: env.sttScheduler,
                 diarizationService: env.diarizationService
             )
         }
@@ -717,7 +717,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         guard let env = appEnvironment else { return }
         showOnboarding(
             permissionService: env.permissionService,
-            sttClient: env.sttClient,
+            sttClient: env.sttScheduler,
             diarizationService: env.diarizationService
         )
     }

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelView.swift
@@ -42,6 +42,15 @@ struct MeetingRecordingPanelView: View {
                     .foregroundStyle(DesignSystem.Colors.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)
 
+                if viewModel.showsLaggingIndicator {
+                    Label("Transcript preview is catching up", systemImage: "exclamationmark.triangle.fill")
+                        .font(DesignSystem.Typography.caption.weight(.semibold))
+                        .foregroundStyle(DesignSystem.Colors.warningAmber)
+                        .padding(.horizontal, DesignSystem.Spacing.sm)
+                        .padding(.vertical, 6)
+                        .background(Capsule().fill(DesignSystem.Colors.surfaceElevated))
+                }
+
                 if viewModel.showsAudioLevels {
                     DualAudioLevelView(
                         micLevel: viewModel.micLevel,

--- a/Sources/MacParakeetCore/STT/STTClient.swift
+++ b/Sources/MacParakeetCore/STT/STTClient.swift
@@ -1,401 +1,53 @@
 import FluidAudio
 import Foundation
-import os
 
-/// STT client backed by FluidAudio CoreML/ANE runtime.
-public actor STTClient: STTClientProtocol {
-    private var manager: AsrManager?
-    private var models: AsrModels?
-    private var initializationTask: Task<Void, Error>?
-    private var warmUpProgressHandler: (@Sendable (String) -> Void)?
-    private let modelVersion: AsrModelVersion
-
-    // MARK: - Background warm-up (survives ViewModel lifecycle)
-
-    /// Current state of background warm-up, observable from any context.
-    public enum WarmUpState: Sendable, Equatable {
-        case idle
-        case working(message: String, progress: Double?)
-        case ready
-        case failed(message: String)
-    }
-
-    /// The latest warm-up state. Updated during backgroundWarmUp().
-    /// Thread-safe: reads/writes go through the actor.
-    public private(set) var backgroundWarmUpState: WarmUpState = .idle
-
-    /// Active background warm-up task, if any. Lives on the actor — not tied to any ViewModel.
-    private var backgroundWarmUpTask: Task<Void, Never>?
-
-    /// Continuations for anyone observing warm-up progress.
-    private var warmUpObservers: [UUID: AsyncStream<WarmUpState>.Continuation] = [:]
-
-    /// Start warm-up in the background. Safe to call multiple times — joins existing task.
-    /// The download continues even if no one is observing progress.
-    public func backgroundWarmUp() {
-        if case .ready = backgroundWarmUpState { return }
-        if backgroundWarmUpTask != nil { return }
-
-        backgroundWarmUpTask = Task { [weak self] in
-            guard let self else { return }
-            await self.setBackgroundWarmUpState(.working(message: "Checking setup requirements...", progress: nil))
-
-            do {
-                try await self.warmUp { [weak self] progressMessage in
-                    guard let self else { return }
-                    Task {
-                        let message = "Speech model: \(progressMessage)"
-                        let fraction = OnboardingProgressParser.parseProgressFraction(from: message)
-                        await self.setBackgroundWarmUpState(.working(message: message, progress: fraction))
-                    }
-                }
-                await self.setBackgroundWarmUpState(.ready)
-            } catch is CancellationError {
-                // Cancelled — don't update state
-            } catch {
-                await self.setBackgroundWarmUpState(.failed(message: error.localizedDescription))
-            }
-            await self.clearBackgroundWarmUpTask()
-        }
-    }
-
-    /// Observe warm-up state changes. Returns an AsyncStream that yields the current state
-    /// immediately, then all subsequent changes. Closing the stream (by letting it go out of
-    /// scope) does NOT cancel the download.
-    public func observeWarmUpProgress() -> (id: UUID, stream: AsyncStream<WarmUpState>) {
-        let id = UUID()
-        let stream = AsyncStream<WarmUpState> { continuation in
-            continuation.yield(backgroundWarmUpState)
-            warmUpObservers[id] = continuation
-            continuation.onTermination = { @Sendable _ in
-                Task { [weak self] in
-                    await self?.removeWarmUpObserver(id: id)
-                }
-            }
-        }
-        return (id, stream)
-    }
-
-    public func removeWarmUpObserver(id: UUID) {
-        warmUpObservers.removeValue(forKey: id)
-    }
-
-    private func setBackgroundWarmUpState(_ state: WarmUpState) {
-        // Guard: never regress from .ready/.failed to .working — stale progress
-        // callback Tasks can arrive after the download completes, which would
-        // corrupt backgroundWarmUpState and block onboarding reconnection.
-        if case .working = state {
-            switch backgroundWarmUpState {
-            case .ready, .failed: return
-            default: break
-            }
-        }
-        backgroundWarmUpState = state
-        for (_, continuation) in warmUpObservers {
-            continuation.yield(state)
-        }
-    }
-
-    private func clearBackgroundWarmUpTask() {
-        backgroundWarmUpTask = nil
-    }
+/// Backwards-compatible facade for standalone callers that still construct an STT client.
+/// The app now owns `STTRuntime` + `STTScheduler` directly (ADR-016).
+public actor STTClient: STTManaging {
+    private let scheduler: STTScheduler
 
     public init(modelVersion: AsrModelVersion = .v3) {
-        self.modelVersion = modelVersion
+        let runtime = STTRuntime(modelVersion: modelVersion)
+        self.scheduler = STTScheduler(runtime: runtime)
     }
 
-    public func transcribe(audioPath: String, onProgress: (@Sendable (Int, Int) -> Void)? = nil) async throws -> STTResult {
-        try await ensureInitialized()
-
-        guard let manager else {
-            throw STTError.modelNotLoaded
-        }
-
-        let audioURL = URL(fileURLWithPath: audioPath)
-        let transcriptionProgressTask: Task<Void, Never>? = if let onProgress {
-            Task {
-                do {
-                    let progressStream = await manager.transcriptionProgressStream
-                    var lastProgress = -1
-                    for try await value in progressStream {
-                        let percent = min(99, max(0, Int((value * 100).rounded())))
-                        guard percent != lastProgress else { continue }
-                        lastProgress = percent
-                        onProgress(percent, 100)
-                    }
-                } catch {
-                    // Transcription still completes (or fails) independently.
-                }
-            }
-        } else {
-            nil
-        }
-        defer {
-            transcriptionProgressTask?.cancel()
-        }
-
-        onProgress?(0, 100)
-
-        do {
-            try Task.checkCancellation()
-            let result = try await manager.transcribe(audioURL, source: .system)
-            let words = Self.mergeTokenTimingsIntoWords(result.tokenTimings)
-            onProgress?(100, 100)
-            return STTResult(text: result.text, words: words)
-        } catch {
-            throw try Self.mapTranscriptionError(error)
-        }
+    public func transcribe(
+        audioPath: String,
+        job: STTJobKind,
+        onProgress: (@Sendable (Int, Int) -> Void)?
+    ) async throws -> STTResult {
+        try await scheduler.transcribe(audioPath: audioPath, job: job, onProgress: onProgress)
     }
 
     public func warmUp(onProgress: (@Sendable (String) -> Void)?) async throws {
-        warmUpProgressHandler = onProgress
-        defer {
-            warmUpProgressHandler = nil
-        }
+        try await scheduler.warmUp(onProgress: onProgress)
+    }
 
-        onProgress?("Loading model into memory...")
+    public func backgroundWarmUp() async {
+        await scheduler.backgroundWarmUp()
+    }
 
-        let start = ContinuousClock.now
-        do {
-            try await ensureInitialized()
-            let elapsed = start.duration(to: .now)
-            let seconds = Double(elapsed.components.seconds) + Double(elapsed.components.attoseconds) / 1e18
-            Telemetry.send(.modelLoaded(loadTimeSeconds: seconds))
-            onProgress?("Ready")
-        } catch {
-            throw try Self.mapWarmUpError(error)
-        }
+    public func observeWarmUpProgress() async -> (id: UUID, stream: AsyncStream<STTWarmUpState>) {
+        await scheduler.observeWarmUpProgress()
+    }
+
+    public func removeWarmUpObserver(id: UUID) async {
+        await scheduler.removeWarmUpObserver(id: id)
     }
 
     public func isReady() async -> Bool {
-        guard let manager else { return false }
-        return manager.isAvailable
-    }
-
-    public func shutdown() async {
-        initializationTask?.cancel()
-        initializationTask = nil
-        manager?.cleanup()
-        manager = nil
-        models = nil
-        warmUpProgressHandler = nil
+        await scheduler.isReady()
     }
 
     public func clearModelCache() async {
-        await shutdown()
-        DownloadUtils.clearAllModelCaches()
+        await scheduler.clearModelCache()
+    }
+
+    public func shutdown() async {
+        await scheduler.shutdown()
     }
 
     public nonisolated static func isModelCached(version: AsrModelVersion = .v3) -> Bool {
-        let cacheDir = AsrModels.defaultCacheDirectory(for: version)
-        return AsrModels.modelsExist(at: cacheDir, version: version)
-    }
-
-    // MARK: - Private
-
-    private func ensureInitialized() async throws {
-        if let manager, manager.isAvailable {
-            return
-        }
-
-        if let initializationTask {
-            try await initializationTask.value
-            return
-        }
-
-        let version = modelVersion
-        let warmUpProgressHandler = self.warmUpProgressHandler
-        let task = Task {
-            let lastProgressUpdate = OSAllocatedUnfairLock(initialState: Date.distantPast)
-            let lastProgressMessage = OSAllocatedUnfairLock(initialState: "")
-            let progressHandler: DownloadUtils.ProgressHandler?
-            if let warmUpProgressHandler {
-                let progressCallback: @Sendable (String) -> Void = warmUpProgressHandler
-                progressHandler = { progress in
-                    guard let message = Self.warmUpProgressMessage(from: progress) else { return }
-                    let now = Date()
-                    let shouldEmit = lastProgressUpdate.withLock { lastUpdate in
-                        guard now.timeIntervalSince(lastUpdate) >= 0.25 else {
-                            return false
-                        }
-                        lastUpdate = now
-                        return true
-                    }
-                    guard shouldEmit else { return }
-
-                    let isNewMessage = lastProgressMessage.withLock { lastMessage in
-                        guard lastMessage != message else { return false }
-                        lastMessage = message
-                        return true
-                    }
-                    guard isNewMessage else { return }
-
-                    progressCallback(message)
-                }
-            } else {
-                progressHandler = nil
-            }
-
-            let downloadedModels = try await AsrModels.downloadAndLoad(
-                version: version,
-                progressHandler: progressHandler
-            )
-            let asrManager = AsrManager(config: .default)
-            try await asrManager.initialize(models: downloadedModels)
-            completeInitialization(models: downloadedModels, manager: asrManager)
-        }
-
-        initializationTask = task
-
-        do {
-            try await task.value
-        } catch {
-            initializationTask = nil
-            throw error
-        }
-    }
-
-    private func completeInitialization(models: AsrModels, manager: AsrManager) {
-        guard !Task.isCancelled else {
-            manager.cleanup()
-            initializationTask = nil
-            return
-        }
-        self.models = models
-        self.manager = manager
-        self.initializationTask = nil
-    }
-
-    private nonisolated static func mapWarmUpError(_ error: Error) throws -> STTError {
-        if error is CancellationError {
-            throw error
-        }
-        if let mapped = mapCommonError(error) {
-            return mapped
-        }
-        return .engineStartFailed(error.localizedDescription)
-    }
-
-    private nonisolated static func mapTranscriptionError(_ error: Error) throws -> STTError {
-        if error is CancellationError {
-            throw error
-        }
-        if let mapped = mapCommonError(error) {
-            return mapped
-        }
-        return .transcriptionFailed(error.localizedDescription)
-    }
-
-    private nonisolated static func mapCommonError(_ error: Error) -> STTError? {
-        if error is CancellationError {
-            return nil
-        }
-
-        if let sttError = error as? STTError {
-            return sttError
-        }
-
-        if let asrError = error as? ASRError {
-            switch asrError {
-            case .notInitialized:
-                return .modelNotLoaded
-            case .invalidAudioData:
-                return .transcriptionFailed(asrError.localizedDescription)
-            case .modelLoadFailed, .modelCompilationFailed:
-                return .engineStartFailed(asrError.localizedDescription)
-            case .processingFailed(let message):
-                return .transcriptionFailed(message)
-            case .unsupportedPlatform(let message):
-                return .engineStartFailed(message)
-            case .streamingConversionFailed, .fileAccessFailed:
-                return .transcriptionFailed(asrError.localizedDescription)
-            }
-        }
-
-        if let modelError = error as? AsrModelsError {
-            return .engineStartFailed(modelError.localizedDescription)
-        }
-
-        // Network errors during model download (ensureInitialized → downloadAndLoad)
-        // surface as URLError. Map to a clear "model not downloaded" message instead
-        // of the confusing "The Internet connection appears to be offline."
-        if let urlError = error as? URLError {
-            switch urlError.code {
-            case .notConnectedToInternet, .networkConnectionLost, .timedOut,
-                 .cannotFindHost, .cannotConnectToHost, .dnsLookupFailed:
-                return .modelDownloadFailed
-            default:
-                return .engineStartFailed(urlError.localizedDescription)
-            }
-        }
-
-        return nil
-    }
-
-    private nonisolated static func warmUpProgressMessage(from progress: DownloadUtils.DownloadProgress) -> String? {
-        switch progress.phase {
-        case .listing:
-            return "Preparing speech model download..."
-        case .downloading(let completedFiles, let totalFiles):
-            guard totalFiles > 0 else { return nil }
-            let percent = max(0, min(100, Int(progress.fractionCompleted * 100.0)))
-            return "Downloading speech model... \(percent)% (\(completedFiles)/\(totalFiles))"
-        case .compiling:
-            return "Compiling speech model..."
-        }
-    }
-
-    private nonisolated static func mergeTokenTimingsIntoWords(_ tokenTimings: [TokenTiming]?) -> [TimestampedWord] {
-        guard let tokenTimings, !tokenTimings.isEmpty else { return [] }
-
-        var words: [TimestampedWord] = []
-        var currentWord = ""
-        var currentStartTime: TimeInterval?
-        var currentEndTime: TimeInterval = 0
-        var currentConfidences: [Float] = []
-
-        func flushCurrentWord() {
-            guard !currentWord.isEmpty, let startTime = currentStartTime else { return }
-            let averageConfidence = currentConfidences.isEmpty
-                ? 0.0
-                : (currentConfidences.reduce(0, +) / Float(currentConfidences.count))
-
-            words.append(
-                TimestampedWord(
-                    word: currentWord,
-                    startMs: Int((startTime * 1_000).rounded()),
-                    endMs: Int((currentEndTime * 1_000).rounded()),
-                    confidence: Double(averageConfidence)
-                ))
-
-            currentWord = ""
-            currentStartTime = nil
-            currentEndTime = 0
-            currentConfidences.removeAll(keepingCapacity: true)
-        }
-
-        for timing in tokenTimings {
-            let normalizedToken = timing.token.replacingOccurrences(of: "▁", with: " ")
-            let trimmedToken = normalizedToken.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmedToken.isEmpty else { continue }
-
-            if normalizedToken.hasPrefix(" ") || normalizedToken.hasPrefix("\n") || normalizedToken.hasPrefix("\t") {
-                flushCurrentWord()
-                currentWord = trimmedToken
-                currentStartTime = timing.startTime
-                currentEndTime = timing.endTime
-                currentConfidences = [timing.confidence]
-            } else {
-                if currentStartTime == nil {
-                    currentStartTime = timing.startTime
-                }
-                currentWord += trimmedToken
-                currentEndTime = timing.endTime
-                currentConfidences.append(timing.confidence)
-            }
-        }
-
-        flushCurrentWord()
-        return words
+        STTRuntime.isModelCached(version: version)
     }
 }

--- a/Sources/MacParakeetCore/STT/STTClient.swift
+++ b/Sources/MacParakeetCore/STT/STTClient.swift
@@ -1,8 +1,12 @@
 import FluidAudio
 import Foundation
 
-/// Backwards-compatible facade for standalone callers that still construct an STT client.
-/// The app now owns `STTRuntime` + `STTScheduler` directly (ADR-016).
+/// Standalone STT facade for the CLI tool and test helpers.
+///
+/// - Warning: Each ``STTClient`` creates its **own** `STTRuntime` and `STTScheduler`,
+///   bypassing the process-wide singleton that ADR-016 requires.
+///   **App code must never instantiate this type directly.**
+///   Use the shared ``STTScheduler`` from `AppEnvironment` instead.
 public actor STTClient: STTManaging {
     private let scheduler: STTScheduler
 

--- a/Sources/MacParakeetCore/STT/STTClientProtocol.swift
+++ b/Sources/MacParakeetCore/STT/STTClientProtocol.swift
@@ -1,28 +1,47 @@
 import Foundation
 
-public protocol STTClientProtocol: Sendable {
-    /// Transcribe an audio file at the given path
-    func transcribe(audioPath: String, onProgress: (@Sendable (Int, Int) -> Void)?) async throws -> STTResult
+public enum STTJobKind: Sendable, Equatable {
+    case dictation
+    case meetingFinalize
+    case meetingLiveChunk
+    case fileTranscription
+}
 
-    /// Warm up the STT engine (load model into memory) with optional progress callback.
-    /// Progress messages are human-readable strings like "Downloading speech model (571 MB)... 45%".
+public enum STTWarmUpState: Sendable, Equatable {
+    case idle
+    case working(message: String, progress: Double?)
+    case ready
+    case failed(message: String)
+}
+
+public protocol STTTranscribing: Sendable {
+    func transcribe(
+        audioPath: String,
+        job: STTJobKind,
+        onProgress: (@Sendable (Int, Int) -> Void)?
+    ) async throws -> STTResult
+}
+
+public protocol STTRuntimeManaging: Sendable {
     func warmUp(onProgress: (@Sendable (String) -> Void)?) async throws
-
-    /// Check if the STT engine is initialized and ready
+    func backgroundWarmUp() async
+    func observeWarmUpProgress() async -> (id: UUID, stream: AsyncStream<STTWarmUpState>)
+    func removeWarmUpObserver(id: UUID) async
     func isReady() async -> Bool
-
-    /// Clear all cached speech and speaker models.
     func clearModelCache() async
-
-    /// Shut down the STT engine
     func shutdown() async
 }
 
-extension STTClientProtocol {
-    public func transcribe(audioPath: String) async throws -> STTResult {
-        try await transcribe(audioPath: audioPath, onProgress: nil)
-    }
+public typealias STTManaging = STTTranscribing & STTRuntimeManaging
+public typealias STTClientProtocol = STTManaging
 
+extension STTTranscribing {
+    public func transcribe(audioPath: String, job: STTJobKind) async throws -> STTResult {
+        try await transcribe(audioPath: audioPath, job: job, onProgress: nil)
+    }
+}
+
+extension STTRuntimeManaging {
     public func warmUp() async throws {
         try await warmUp(onProgress: nil)
     }

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -24,6 +24,7 @@ public actor STTRuntime: STTRuntimeProtocol {
     private var batchManager: AsrManager?
     private var models: AsrModels?
     private var initializationTask: Task<Void, Error>?
+    private var initializationGeneration: UInt64 = 0
     private var warmUpProgressHandler: (@Sendable (String) -> Void)?
     private let modelVersion: AsrModelVersion
 
@@ -167,21 +168,22 @@ public actor STTRuntime: STTRuntimeProtocol {
 
     public func shutdown() async {
         invalidateBackgroundWarmUp()
-        initializationTask?.cancel()
-        initializationTask = nil
-        if let dictationManager {
-            await dictationManager.cleanup()
-        }
-        if let meetingManager {
-            await meetingManager.cleanup()
-        }
-        if let batchManager {
-            await batchManager.cleanup()
-        }
-        dictationManager = nil
-        meetingManager = nil
-        batchManager = nil
-        models = nil
+        let inFlightInitialization = cancelInitialization()
+        inFlightInitialization?.cancel()
+        _ = try? await inFlightInitialization?.value
+
+        let dictationManager = self.dictationManager
+        let meetingManager = self.meetingManager
+        let batchManager = self.batchManager
+        self.dictationManager = nil
+        self.meetingManager = nil
+        self.batchManager = nil
+        self.models = nil
+        await Self.cleanupManagers(
+            dictationManager: dictationManager,
+            meetingManager: meetingManager,
+            batchManager: batchManager
+        )
         warmUpProgressHandler = nil
         setBackgroundWarmUpState(.idle)
     }
@@ -232,10 +234,7 @@ public actor STTRuntime: STTRuntimeProtocol {
     }
 
     private func ensureInitialized() async throws {
-        if let dictationManager, let meetingManager, let batchManager,
-           await dictationManager.isAvailable,
-           await meetingManager.isAvailable,
-           await batchManager.isAvailable {
+        if dictationManager != nil, meetingManager != nil, batchManager != nil {
             return
         }
 
@@ -244,11 +243,15 @@ public actor STTRuntime: STTRuntimeProtocol {
             return
         }
 
+        let generation = nextInitializationGeneration()
         let version = modelVersion
         let warmUpProgressHandler = self.warmUpProgressHandler
         let task = Task {
             let lastProgressUpdate = OSAllocatedUnfairLock(initialState: Date.distantPast)
             let lastProgressMessage = OSAllocatedUnfairLock(initialState: "")
+            var dictationManager: AsrManager?
+            var meetingManager: AsrManager?
+            var batchManager: AsrManager?
             let progressHandler: DownloadUtils.ProgressHandler?
             if let warmUpProgressHandler {
                 let progressCallback: @Sendable (String) -> Void = warmUpProgressHandler
@@ -281,45 +284,95 @@ public actor STTRuntime: STTRuntimeProtocol {
                 version: version,
                 progressHandler: progressHandler
             )
-            let dictationManager = AsrManager(config: .default)
-            let meetingManager = AsrManager(config: .default)
-            let batchManager = AsrManager(config: .default)
-            try await dictationManager.loadModels(downloadedModels)
-            try await meetingManager.loadModels(downloadedModels)
-            try await batchManager.loadModels(downloadedModels)
-            await self.completeInitialization(
-                models: downloadedModels,
-                dictationManager: dictationManager,
-                meetingManager: meetingManager,
-                batchManager: batchManager
-            )
+            do {
+                let loadedDictationManager = AsrManager(config: .default)
+                let loadedMeetingManager = AsrManager(config: .default)
+                let loadedBatchManager = AsrManager(config: .default)
+                dictationManager = loadedDictationManager
+                meetingManager = loadedMeetingManager
+                batchManager = loadedBatchManager
+                try await loadedDictationManager.loadModels(downloadedModels)
+                try await loadedMeetingManager.loadModels(downloadedModels)
+                try await loadedBatchManager.loadModels(downloadedModels)
+                try Task.checkCancellation()
+                try await self.completeInitialization(
+                    generation: generation,
+                    models: downloadedModels,
+                    dictationManager: loadedDictationManager,
+                    meetingManager: loadedMeetingManager,
+                    batchManager: loadedBatchManager
+                )
+                dictationManager = nil
+                meetingManager = nil
+                batchManager = nil
+            } catch {
+                await Self.cleanupManagers(
+                    dictationManager: dictationManager,
+                    meetingManager: meetingManager,
+                    batchManager: batchManager
+                )
+                throw error
+            }
         }
 
         initializationTask = task
 
         do {
             try await task.value
+            if initializationGeneration == generation {
+                initializationTask = nil
+            }
         } catch {
-            initializationTask = nil
+            if initializationGeneration == generation {
+                initializationTask = nil
+            }
             throw error
         }
     }
 
     private func completeInitialization(
+        generation: UInt64,
         models: AsrModels,
         dictationManager: AsrManager,
         meetingManager: AsrManager,
         batchManager: AsrManager
-    ) async {
-        guard !Task.isCancelled else {
-            initializationTask = nil
-            return
+    ) async throws {
+        guard initializationGeneration == generation else {
+            throw CancellationError()
         }
+        try Task.checkCancellation()
         self.models = models
         self.dictationManager = dictationManager
         self.meetingManager = meetingManager
         self.batchManager = batchManager
-        self.initializationTask = nil
+    }
+
+    private func nextInitializationGeneration() -> UInt64 {
+        initializationGeneration &+= 1
+        return initializationGeneration
+    }
+
+    private func cancelInitialization() -> Task<Void, Error>? {
+        initializationGeneration &+= 1
+        let task = initializationTask
+        initializationTask = nil
+        return task
+    }
+
+    private nonisolated static func cleanupManagers(
+        dictationManager: AsrManager?,
+        meetingManager: AsrManager?,
+        batchManager: AsrManager?
+    ) async {
+        if let dictationManager {
+            await dictationManager.cleanup()
+        }
+        if let meetingManager {
+            await meetingManager.cleanup()
+        }
+        if let batchManager {
+            await batchManager.cleanup()
+        }
     }
 
     private func manager(for lane: STTRuntimeLane) -> AsrManager? {

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -40,15 +40,15 @@ public actor STTRuntime: STTRuntimeProtocol {
         self.modelVersion = modelVersion
     }
 
-    public func transcribe(
+    func transcribe(
         audioPath: String,
         job: STTJobKind,
         onProgress: (@Sendable (Int, Int) -> Void)? = nil
     ) async throws -> STTResult {
         try await ensureInitialized()
 
-        let lane = route(for: job)
-        guard let manager = manager(for: lane) else {
+        let slot = route(for: job)
+        guard let manager = manager(for: slot) else {
             throw STTError.modelNotLoaded
         }
 
@@ -124,7 +124,8 @@ public actor STTRuntime: STTRuntimeProtocol {
             do {
                 try await self.warmUp { [weak self] progressMessage in
                     guard let self else { return }
-                    Task {
+                    Task { [weak self] in
+                        guard let self else { return }
                         let message = "Speech model: \(progressMessage)"
                         let fraction = OnboardingProgressParser.parseProgressFraction(from: message)
                         await self.setBackgroundWarmUpState(

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -114,12 +114,13 @@ public actor STTRuntime: STTRuntimeProtocol {
         if backgroundWarmUpTask != nil { return }
 
         let generation = beginBackgroundWarmUp()
+        prepareBackgroundWarmUpForRetry()
+        setBackgroundWarmUpState(
+            .working(message: "Checking setup requirements...", progress: nil),
+            generation: generation
+        )
         backgroundWarmUpTask = Task { [weak self] in
             guard let self else { return }
-            await self.setBackgroundWarmUpState(
-                .working(message: "Checking setup requirements...", progress: nil),
-                generation: generation
-            )
 
             do {
                 try await self.warmUp { [weak self] progressMessage in
@@ -212,6 +213,12 @@ public actor STTRuntime: STTRuntimeProtocol {
         backgroundWarmUpGeneration &+= 1
         backgroundWarmUpTask?.cancel()
         backgroundWarmUpTask = nil
+    }
+
+    private func prepareBackgroundWarmUpForRetry() {
+        if case .failed = backgroundWarmUpState {
+            backgroundWarmUpState = .idle
+        }
     }
 
     private func setBackgroundWarmUpState(_ state: STTWarmUpState, generation: UInt64) {

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -17,7 +17,11 @@ protocol STTRuntimeProtocol: Sendable {
     func clearModelCache() async
 }
 
-/// Sole owner of the shared Parakeet runtime lifecycle.
+/// Sole owner of the shared Parakeet STT lifecycle.
+///
+/// The runtime stays process-wide and singular at the app boundary, but it keeps
+/// one `AsrManager` per scheduler lane so dictation, meeting, and batch work do
+/// not head-of-line block each other inside app-level scheduling.
 public actor STTRuntime: STTRuntimeProtocol {
     private var dictationManager: AsrManager?
     private var meetingManager: AsrManager?

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -20,12 +20,11 @@ protocol STTRuntimeProtocol: Sendable {
 /// Sole owner of the shared Parakeet STT lifecycle.
 ///
 /// The runtime stays process-wide and singular at the app boundary, but it keeps
-/// one `AsrManager` per scheduler lane so dictation, meeting, and batch work do
-/// not head-of-line block each other inside app-level scheduling.
+/// one `AsrManager` per execution slot so dictation remains isolated from the
+/// shared background workload inside app-level scheduling.
 public actor STTRuntime: STTRuntimeProtocol {
-    private var dictationManager: AsrManager?
-    private var meetingManager: AsrManager?
-    private var batchManager: AsrManager?
+    private var interactiveManager: AsrManager?
+    private var backgroundManager: AsrManager?
     private var models: AsrModels?
     private var initializationTask: Task<Void, Error>?
     private var initializationGeneration: UInt64 = 0
@@ -164,11 +163,10 @@ public actor STTRuntime: STTRuntimeProtocol {
     }
 
     public func isReady() async -> Bool {
-        guard let dictationManager, let meetingManager, let batchManager else { return false }
-        let dictationReady = await dictationManager.isAvailable
-        let meetingReady = await meetingManager.isAvailable
-        let batchReady = await batchManager.isAvailable
-        return dictationReady && meetingReady && batchReady
+        guard let interactiveManager, let backgroundManager else { return false }
+        let interactiveReady = await interactiveManager.isAvailable
+        let backgroundReady = await backgroundManager.isAvailable
+        return interactiveReady && backgroundReady
     }
 
     public func shutdown() async {
@@ -177,17 +175,14 @@ public actor STTRuntime: STTRuntimeProtocol {
         inFlightInitialization?.cancel()
         _ = try? await inFlightInitialization?.value
 
-        let dictationManager = self.dictationManager
-        let meetingManager = self.meetingManager
-        let batchManager = self.batchManager
-        self.dictationManager = nil
-        self.meetingManager = nil
-        self.batchManager = nil
+        let interactiveManager = self.interactiveManager
+        let backgroundManager = self.backgroundManager
+        self.interactiveManager = nil
+        self.backgroundManager = nil
         self.models = nil
         await Self.cleanupManagers(
-            dictationManager: dictationManager,
-            meetingManager: meetingManager,
-            batchManager: batchManager
+            interactiveManager: interactiveManager,
+            backgroundManager: backgroundManager
         )
         warmUpProgressHandler = nil
         setBackgroundWarmUpState(.idle)
@@ -245,7 +240,7 @@ public actor STTRuntime: STTRuntimeProtocol {
     }
 
     private func ensureInitialized() async throws {
-        if dictationManager != nil, meetingManager != nil, batchManager != nil {
+        if interactiveManager != nil, backgroundManager != nil {
             return
         }
 
@@ -260,9 +255,8 @@ public actor STTRuntime: STTRuntimeProtocol {
         let task = Task {
             let lastProgressUpdate = OSAllocatedUnfairLock(initialState: Date.distantPast)
             let lastProgressMessage = OSAllocatedUnfairLock(initialState: "")
-            var dictationManager: AsrManager?
-            var meetingManager: AsrManager?
-            var batchManager: AsrManager?
+            var interactiveManager: AsrManager?
+            var backgroundManager: AsrManager?
             let progressHandler: DownloadUtils.ProgressHandler?
             if let warmUpProgressHandler {
                 let progressCallback: @Sendable (String) -> Void = warmUpProgressHandler
@@ -296,35 +290,27 @@ public actor STTRuntime: STTRuntimeProtocol {
                 progressHandler: progressHandler
             )
             do {
-                // Keep one manager per scheduler lane. FluidAudio exposes progress
-                // as a manager-scoped single session, so separate managers avoid
-                // cross-lane progress/state crosstalk while still sharing one
-                // downloaded read-only model bundle.
-                let loadedDictationManager = AsrManager(config: .default)
-                let loadedMeetingManager = AsrManager(config: .default)
-                let loadedBatchManager = AsrManager(config: .default)
-                dictationManager = loadedDictationManager
-                meetingManager = loadedMeetingManager
-                batchManager = loadedBatchManager
-                try await loadedDictationManager.loadModels(downloadedModels)
-                try await loadedMeetingManager.loadModels(downloadedModels)
-                try await loadedBatchManager.loadModels(downloadedModels)
+                // FluidAudio progress is manager-scoped, so each slot keeps its
+                // own manager while the read-only model bundle stays shared.
+                let loadedInteractiveManager = AsrManager(config: .default)
+                let loadedBackgroundManager = AsrManager(config: .default)
+                interactiveManager = loadedInteractiveManager
+                backgroundManager = loadedBackgroundManager
+                try await loadedInteractiveManager.loadModels(downloadedModels)
+                try await loadedBackgroundManager.loadModels(downloadedModels)
                 try Task.checkCancellation()
                 try await self.completeInitialization(
                     generation: generation,
                     models: downloadedModels,
-                    dictationManager: loadedDictationManager,
-                    meetingManager: loadedMeetingManager,
-                    batchManager: loadedBatchManager
+                    interactiveManager: loadedInteractiveManager,
+                    backgroundManager: loadedBackgroundManager
                 )
-                dictationManager = nil
-                meetingManager = nil
-                batchManager = nil
+                interactiveManager = nil
+                backgroundManager = nil
             } catch {
                 await Self.cleanupManagers(
-                    dictationManager: dictationManager,
-                    meetingManager: meetingManager,
-                    batchManager: batchManager
+                    interactiveManager: interactiveManager,
+                    backgroundManager: backgroundManager
                 )
                 throw error
             }
@@ -348,18 +334,16 @@ public actor STTRuntime: STTRuntimeProtocol {
     private func completeInitialization(
         generation: UInt64,
         models: AsrModels,
-        dictationManager: AsrManager,
-        meetingManager: AsrManager,
-        batchManager: AsrManager
+        interactiveManager: AsrManager,
+        backgroundManager: AsrManager
     ) async throws {
         guard initializationGeneration == generation else {
             throw CancellationError()
         }
         try Task.checkCancellation()
         self.models = models
-        self.dictationManager = dictationManager
-        self.meetingManager = meetingManager
-        self.batchManager = batchManager
+        self.interactiveManager = interactiveManager
+        self.backgroundManager = backgroundManager
     }
 
     private func nextInitializationGeneration() -> UInt64 {
@@ -375,40 +359,32 @@ public actor STTRuntime: STTRuntimeProtocol {
     }
 
     private nonisolated static func cleanupManagers(
-        dictationManager: AsrManager?,
-        meetingManager: AsrManager?,
-        batchManager: AsrManager?
+        interactiveManager: AsrManager?,
+        backgroundManager: AsrManager?
     ) async {
-        if let dictationManager {
-            await dictationManager.cleanup()
+        if let interactiveManager {
+            await interactiveManager.cleanup()
         }
-        if let meetingManager {
-            await meetingManager.cleanup()
-        }
-        if let batchManager {
-            await batchManager.cleanup()
+        if let backgroundManager {
+            await backgroundManager.cleanup()
         }
     }
 
     private func manager(for lane: STTRuntimeLane) -> AsrManager? {
         switch lane {
-        case .dictation:
-            dictationManager
-        case .meeting:
-            meetingManager
-        case .batch:
-            batchManager
+        case .interactive:
+            interactiveManager
+        case .background:
+            backgroundManager
         }
     }
 
     private func route(for job: STTJobKind) -> STTRuntimeLane {
         switch job {
         case .dictation:
-            .dictation
-        case .meetingFinalize, .meetingLiveChunk:
-            .meeting
-        case .fileTranscription:
-            .batch
+            .interactive
+        case .meetingFinalize, .meetingLiveChunk, .fileTranscription:
+            .background
         }
     }
 
@@ -544,7 +520,6 @@ public actor STTRuntime: STTRuntimeProtocol {
 }
 
 private enum STTRuntimeLane: Sendable {
-    case dictation
-    case meeting
-    case batch
+    case interactive
+    case background
 }

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -88,6 +88,11 @@ public actor STTRuntime: STTRuntimeProtocol {
         }
     }
 
+    /// Warms the runtime and reports progress through `onProgress` only.
+    ///
+    /// This method does not update `observeWarmUpProgress()` observers. Call
+    /// `backgroundWarmUp()` when UI state should flow through the shared
+    /// observer stream instead of a one-off callback.
     public func warmUp(onProgress: (@Sendable (String) -> Void)?) async throws {
         warmUpProgressHandler = onProgress
         defer {
@@ -160,7 +165,7 @@ public actor STTRuntime: STTRuntimeProtocol {
     }
 
     public func removeWarmUpObserver(id: UUID) async {
-        warmUpObservers.removeValue(forKey: id)
+        warmUpObservers.removeValue(forKey: id)?.finish()
     }
 
     public func isReady() async -> Bool {

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -117,6 +117,12 @@ public actor STTRuntime: STTRuntimeProtocol {
         if case .ready = backgroundWarmUpState { return }
         if backgroundWarmUpTask != nil { return }
 
+        // Order matters: `beginBackgroundWarmUp()` advances the generation
+        // counter *before* the task is assigned to `backgroundWarmUpTask`.
+        // This is safe because both the generation check and the nil-task
+        // guard at the top run synchronously on this actor — no suspension
+        // point exists between them and the assignment below, so no
+        // concurrent caller can observe the intermediate state.
         let generation = beginBackgroundWarmUp()
         prepareBackgroundWarmUpForRetry()
         setBackgroundWarmUpState(

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -27,6 +27,7 @@ public actor STTRuntime: STTRuntimeProtocol {
     private var backgroundWarmUpState: STTWarmUpState = .idle
     private var backgroundWarmUpTask: Task<Void, Never>?
     private var warmUpObservers: [UUID: AsyncStream<STTWarmUpState>.Continuation] = [:]
+    private var backgroundWarmUpGeneration: UInt64 = 0
 
     public init(modelVersion: AsrModelVersion = .v3) {
         self.modelVersion = modelVersion
@@ -102,9 +103,13 @@ public actor STTRuntime: STTRuntimeProtocol {
         if case .ready = backgroundWarmUpState { return }
         if backgroundWarmUpTask != nil { return }
 
+        let generation = beginBackgroundWarmUp()
         backgroundWarmUpTask = Task { [weak self] in
             guard let self else { return }
-            await self.setBackgroundWarmUpState(.working(message: "Checking setup requirements...", progress: nil))
+            await self.setBackgroundWarmUpState(
+                .working(message: "Checking setup requirements...", progress: nil),
+                generation: generation
+            )
 
             do {
                 try await self.warmUp { [weak self] progressMessage in
@@ -112,16 +117,20 @@ public actor STTRuntime: STTRuntimeProtocol {
                     Task {
                         let message = "Speech model: \(progressMessage)"
                         let fraction = OnboardingProgressParser.parseProgressFraction(from: message)
-                        await self.setBackgroundWarmUpState(.working(message: message, progress: fraction))
+                        await self.setBackgroundWarmUpState(
+                            .working(message: message, progress: fraction),
+                            generation: generation
+                        )
                     }
                 }
-                await self.setBackgroundWarmUpState(.ready)
+                try Task.checkCancellation()
+                await self.setBackgroundWarmUpState(.ready, generation: generation)
             } catch is CancellationError {
                 // Cancelled — don't update state.
             } catch {
-                await self.setBackgroundWarmUpState(.failed(message: error.localizedDescription))
+                await self.setBackgroundWarmUpState(.failed(message: error.localizedDescription), generation: generation)
             }
-            await self.clearBackgroundWarmUpTask()
+            await self.clearBackgroundWarmUpTask(generation: generation)
         }
     }
 
@@ -149,12 +158,14 @@ public actor STTRuntime: STTRuntimeProtocol {
     }
 
     public func shutdown() async {
+        invalidateBackgroundWarmUp()
         initializationTask?.cancel()
         initializationTask = nil
         manager?.cleanup()
         manager = nil
         models = nil
         warmUpProgressHandler = nil
+        setBackgroundWarmUpState(.idle)
     }
 
     public func clearModelCache() async {
@@ -166,6 +177,22 @@ public actor STTRuntime: STTRuntimeProtocol {
     public nonisolated static func isModelCached(version: AsrModelVersion = .v3) -> Bool {
         let cacheDir = AsrModels.defaultCacheDirectory(for: version)
         return AsrModels.modelsExist(at: cacheDir, version: version)
+    }
+
+    private func beginBackgroundWarmUp() -> UInt64 {
+        backgroundWarmUpGeneration &+= 1
+        return backgroundWarmUpGeneration
+    }
+
+    private func invalidateBackgroundWarmUp() {
+        backgroundWarmUpGeneration &+= 1
+        backgroundWarmUpTask?.cancel()
+        backgroundWarmUpTask = nil
+    }
+
+    private func setBackgroundWarmUpState(_ state: STTWarmUpState, generation: UInt64) {
+        guard generation == backgroundWarmUpGeneration else { return }
+        setBackgroundWarmUpState(state)
     }
 
     private func setBackgroundWarmUpState(_ state: STTWarmUpState) {
@@ -181,7 +208,8 @@ public actor STTRuntime: STTRuntimeProtocol {
         }
     }
 
-    private func clearBackgroundWarmUpTask() {
+    private func clearBackgroundWarmUpTask(generation: UInt64) {
+        guard generation == backgroundWarmUpGeneration else { return }
         backgroundWarmUpTask = nil
     }
 

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -1,0 +1,390 @@
+import FluidAudio
+import Foundation
+import os
+
+protocol STTRuntimeProtocol: Sendable {
+    func transcribe(
+        audioPath: String,
+        onProgress: (@Sendable (Int, Int) -> Void)?
+    ) async throws -> STTResult
+    func warmUp(onProgress: (@Sendable (String) -> Void)?) async throws
+    func backgroundWarmUp() async
+    func observeWarmUpProgress() async -> (id: UUID, stream: AsyncStream<STTWarmUpState>)
+    func removeWarmUpObserver(id: UUID) async
+    func isReady() async -> Bool
+    func shutdown() async
+    func clearModelCache() async
+}
+
+/// Sole owner of the shared Parakeet runtime lifecycle.
+public actor STTRuntime: STTRuntimeProtocol {
+    private var manager: AsrManager?
+    private var models: AsrModels?
+    private var initializationTask: Task<Void, Error>?
+    private var warmUpProgressHandler: (@Sendable (String) -> Void)?
+    private let modelVersion: AsrModelVersion
+
+    private var backgroundWarmUpState: STTWarmUpState = .idle
+    private var backgroundWarmUpTask: Task<Void, Never>?
+    private var warmUpObservers: [UUID: AsyncStream<STTWarmUpState>.Continuation] = [:]
+
+    public init(modelVersion: AsrModelVersion = .v3) {
+        self.modelVersion = modelVersion
+    }
+
+    public func transcribe(
+        audioPath: String,
+        onProgress: (@Sendable (Int, Int) -> Void)? = nil
+    ) async throws -> STTResult {
+        try await ensureInitialized()
+
+        guard let manager else {
+            throw STTError.modelNotLoaded
+        }
+
+        let audioURL = URL(fileURLWithPath: audioPath)
+        let transcriptionProgressTask: Task<Void, Never>? = if let onProgress {
+            Task {
+                do {
+                    let progressStream = await manager.transcriptionProgressStream
+                    var lastProgress = -1
+                    for try await value in progressStream {
+                        let percent = min(99, max(0, Int((value * 100).rounded())))
+                        guard percent != lastProgress else { continue }
+                        lastProgress = percent
+                        onProgress(percent, 100)
+                    }
+                } catch {
+                    // The transcription task completes or fails independently.
+                }
+            }
+        } else {
+            nil
+        }
+        defer {
+            transcriptionProgressTask?.cancel()
+        }
+
+        onProgress?(0, 100)
+
+        do {
+            try Task.checkCancellation()
+            let result = try await manager.transcribe(audioURL, source: .system)
+            let words = Self.mergeTokenTimingsIntoWords(result.tokenTimings)
+            onProgress?(100, 100)
+            return STTResult(text: result.text, words: words)
+        } catch {
+            throw try Self.mapTranscriptionError(error)
+        }
+    }
+
+    public func warmUp(onProgress: (@Sendable (String) -> Void)?) async throws {
+        warmUpProgressHandler = onProgress
+        defer {
+            warmUpProgressHandler = nil
+        }
+
+        onProgress?("Loading model into memory...")
+
+        let start = ContinuousClock.now
+        do {
+            try await ensureInitialized()
+            let elapsed = start.duration(to: .now)
+            let seconds = Double(elapsed.components.seconds) + Double(elapsed.components.attoseconds) / 1e18
+            Telemetry.send(.modelLoaded(loadTimeSeconds: seconds))
+            onProgress?("Ready")
+        } catch {
+            throw try Self.mapWarmUpError(error)
+        }
+    }
+
+    public func backgroundWarmUp() async {
+        if case .ready = backgroundWarmUpState { return }
+        if backgroundWarmUpTask != nil { return }
+
+        backgroundWarmUpTask = Task { [weak self] in
+            guard let self else { return }
+            await self.setBackgroundWarmUpState(.working(message: "Checking setup requirements...", progress: nil))
+
+            do {
+                try await self.warmUp { [weak self] progressMessage in
+                    guard let self else { return }
+                    Task {
+                        let message = "Speech model: \(progressMessage)"
+                        let fraction = OnboardingProgressParser.parseProgressFraction(from: message)
+                        await self.setBackgroundWarmUpState(.working(message: message, progress: fraction))
+                    }
+                }
+                await self.setBackgroundWarmUpState(.ready)
+            } catch is CancellationError {
+                // Cancelled — don't update state.
+            } catch {
+                await self.setBackgroundWarmUpState(.failed(message: error.localizedDescription))
+            }
+            await self.clearBackgroundWarmUpTask()
+        }
+    }
+
+    public func observeWarmUpProgress() async -> (id: UUID, stream: AsyncStream<STTWarmUpState>) {
+        let id = UUID()
+        let stream = AsyncStream<STTWarmUpState> { continuation in
+            continuation.yield(backgroundWarmUpState)
+            warmUpObservers[id] = continuation
+            continuation.onTermination = { @Sendable _ in
+                Task { [weak self] in
+                    await self?.removeWarmUpObserver(id: id)
+                }
+            }
+        }
+        return (id, stream)
+    }
+
+    public func removeWarmUpObserver(id: UUID) async {
+        warmUpObservers.removeValue(forKey: id)
+    }
+
+    public func isReady() async -> Bool {
+        guard let manager else { return false }
+        return manager.isAvailable
+    }
+
+    public func shutdown() async {
+        initializationTask?.cancel()
+        initializationTask = nil
+        manager?.cleanup()
+        manager = nil
+        models = nil
+        warmUpProgressHandler = nil
+    }
+
+    public func clearModelCache() async {
+        await shutdown()
+        DownloadUtils.clearAllModelCaches()
+        setBackgroundWarmUpState(.idle)
+    }
+
+    public nonisolated static func isModelCached(version: AsrModelVersion = .v3) -> Bool {
+        let cacheDir = AsrModels.defaultCacheDirectory(for: version)
+        return AsrModels.modelsExist(at: cacheDir, version: version)
+    }
+
+    private func setBackgroundWarmUpState(_ state: STTWarmUpState) {
+        if case .working = state {
+            switch backgroundWarmUpState {
+            case .ready, .failed: return
+            default: break
+            }
+        }
+        backgroundWarmUpState = state
+        for (_, continuation) in warmUpObservers {
+            continuation.yield(state)
+        }
+    }
+
+    private func clearBackgroundWarmUpTask() {
+        backgroundWarmUpTask = nil
+    }
+
+    private func ensureInitialized() async throws {
+        if let manager, manager.isAvailable {
+            return
+        }
+
+        if let initializationTask {
+            try await initializationTask.value
+            return
+        }
+
+        let version = modelVersion
+        let warmUpProgressHandler = self.warmUpProgressHandler
+        let task = Task {
+            let lastProgressUpdate = OSAllocatedUnfairLock(initialState: Date.distantPast)
+            let lastProgressMessage = OSAllocatedUnfairLock(initialState: "")
+            let progressHandler: DownloadUtils.ProgressHandler?
+            if let warmUpProgressHandler {
+                let progressCallback: @Sendable (String) -> Void = warmUpProgressHandler
+                progressHandler = { progress in
+                    guard let message = Self.warmUpProgressMessage(from: progress) else { return }
+                    let now = Date()
+                    let shouldEmit = lastProgressUpdate.withLock { lastUpdate in
+                        guard now.timeIntervalSince(lastUpdate) >= 0.25 else {
+                            return false
+                        }
+                        lastUpdate = now
+                        return true
+                    }
+                    guard shouldEmit else { return }
+
+                    let isNewMessage = lastProgressMessage.withLock { lastMessage in
+                        guard lastMessage != message else { return false }
+                        lastMessage = message
+                        return true
+                    }
+                    guard isNewMessage else { return }
+
+                    progressCallback(message)
+                }
+            } else {
+                progressHandler = nil
+            }
+
+            let downloadedModels = try await AsrModels.downloadAndLoad(
+                version: version,
+                progressHandler: progressHandler
+            )
+            let asrManager = AsrManager(config: .default)
+            try await asrManager.initialize(models: downloadedModels)
+            completeInitialization(models: downloadedModels, manager: asrManager)
+        }
+
+        initializationTask = task
+
+        do {
+            try await task.value
+        } catch {
+            initializationTask = nil
+            throw error
+        }
+    }
+
+    private func completeInitialization(models: AsrModels, manager: AsrManager) {
+        guard !Task.isCancelled else {
+            manager.cleanup()
+            initializationTask = nil
+            return
+        }
+        self.models = models
+        self.manager = manager
+        self.initializationTask = nil
+    }
+
+    private nonisolated static func mapWarmUpError(_ error: Error) throws -> STTError {
+        if error is CancellationError {
+            throw error
+        }
+        if let mapped = mapCommonError(error) {
+            return mapped
+        }
+        return .engineStartFailed(error.localizedDescription)
+    }
+
+    private nonisolated static func mapTranscriptionError(_ error: Error) throws -> STTError {
+        if error is CancellationError {
+            throw error
+        }
+        if let mapped = mapCommonError(error) {
+            return mapped
+        }
+        return .transcriptionFailed(error.localizedDescription)
+    }
+
+    private nonisolated static func mapCommonError(_ error: Error) -> STTError? {
+        if error is CancellationError {
+            return nil
+        }
+
+        if let sttError = error as? STTError {
+            return sttError
+        }
+
+        if let asrError = error as? ASRError {
+            switch asrError {
+            case .notInitialized:
+                return .modelNotLoaded
+            case .invalidAudioData:
+                return .transcriptionFailed(asrError.localizedDescription)
+            case .modelLoadFailed, .modelCompilationFailed:
+                return .engineStartFailed(asrError.localizedDescription)
+            case .processingFailed(let message):
+                return .transcriptionFailed(message)
+            case .unsupportedPlatform(let message):
+                return .engineStartFailed(message)
+            case .streamingConversionFailed, .fileAccessFailed:
+                return .transcriptionFailed(asrError.localizedDescription)
+            }
+        }
+
+        if let modelError = error as? AsrModelsError {
+            return .engineStartFailed(modelError.localizedDescription)
+        }
+
+        if let urlError = error as? URLError {
+            switch urlError.code {
+            case .notConnectedToInternet, .networkConnectionLost, .timedOut,
+                 .cannotFindHost, .cannotConnectToHost, .dnsLookupFailed:
+                return .modelDownloadFailed
+            default:
+                return .engineStartFailed(urlError.localizedDescription)
+            }
+        }
+
+        return nil
+    }
+
+    private nonisolated static func warmUpProgressMessage(from progress: DownloadUtils.DownloadProgress) -> String? {
+        switch progress.phase {
+        case .listing:
+            return "Preparing speech model download..."
+        case .downloading(let completedFiles, let totalFiles):
+            guard totalFiles > 0 else { return nil }
+            let percent = max(0, min(100, Int(progress.fractionCompleted * 100.0)))
+            return "Downloading speech model... \(percent)% (\(completedFiles)/\(totalFiles))"
+        case .compiling:
+            return "Compiling speech model..."
+        }
+    }
+
+    private nonisolated static func mergeTokenTimingsIntoWords(_ tokenTimings: [TokenTiming]?) -> [TimestampedWord] {
+        guard let tokenTimings, !tokenTimings.isEmpty else { return [] }
+
+        var words: [TimestampedWord] = []
+        var currentWord = ""
+        var currentStartTime: TimeInterval?
+        var currentEndTime: TimeInterval = 0
+        var currentConfidences: [Float] = []
+
+        func flushCurrentWord() {
+            guard !currentWord.isEmpty, let startTime = currentStartTime else { return }
+            let averageConfidence = currentConfidences.isEmpty
+                ? 0.0
+                : (currentConfidences.reduce(0, +) / Float(currentConfidences.count))
+
+            words.append(
+                TimestampedWord(
+                    word: currentWord,
+                    startMs: Int((startTime * 1_000).rounded()),
+                    endMs: Int((currentEndTime * 1_000).rounded()),
+                    confidence: Double(averageConfidence)
+                ))
+
+            currentWord = ""
+            currentStartTime = nil
+            currentEndTime = 0
+            currentConfidences.removeAll(keepingCapacity: true)
+        }
+
+        for timing in tokenTimings {
+            let normalizedToken = timing.token.replacingOccurrences(of: "▁", with: " ")
+            let trimmedToken = normalizedToken.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedToken.isEmpty else { continue }
+
+            if normalizedToken.hasPrefix(" ") || normalizedToken.hasPrefix("\n") || normalizedToken.hasPrefix("\t") {
+                flushCurrentWord()
+                currentWord = trimmedToken
+                currentStartTime = timing.startTime
+                currentEndTime = timing.endTime
+                currentConfidences = [timing.confidence]
+            } else {
+                if currentStartTime == nil {
+                    currentStartTime = timing.startTime
+                }
+                currentWord += trimmedToken
+                currentEndTime = timing.endTime
+                currentConfidences.append(timing.confidence)
+            }
+        }
+
+        flushCurrentWord()
+        return words
+    }
+}

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -289,6 +289,10 @@ public actor STTRuntime: STTRuntimeProtocol {
                 progressHandler: progressHandler
             )
             do {
+                // Keep one manager per scheduler lane. FluidAudio exposes progress
+                // as a manager-scoped single session, so separate managers avoid
+                // cross-lane progress/state crosstalk while still sharing one
+                // downloaded read-only model bundle.
                 let loadedDictationManager = AsrManager(config: .default)
                 let loadedMeetingManager = AsrManager(config: .default)
                 let loadedBatchManager = AsrManager(config: .default)

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -5,6 +5,7 @@ import os
 protocol STTRuntimeProtocol: Sendable {
     func transcribe(
         audioPath: String,
+        job: STTJobKind,
         onProgress: (@Sendable (Int, Int) -> Void)?
     ) async throws -> STTResult
     func warmUp(onProgress: (@Sendable (String) -> Void)?) async throws
@@ -18,7 +19,9 @@ protocol STTRuntimeProtocol: Sendable {
 
 /// Sole owner of the shared Parakeet runtime lifecycle.
 public actor STTRuntime: STTRuntimeProtocol {
-    private var manager: AsrManager?
+    private var dictationManager: AsrManager?
+    private var meetingManager: AsrManager?
+    private var batchManager: AsrManager?
     private var models: AsrModels?
     private var initializationTask: Task<Void, Error>?
     private var warmUpProgressHandler: (@Sendable (String) -> Void)?
@@ -35,11 +38,13 @@ public actor STTRuntime: STTRuntimeProtocol {
 
     public func transcribe(
         audioPath: String,
+        job: STTJobKind,
         onProgress: (@Sendable (Int, Int) -> Void)? = nil
     ) async throws -> STTResult {
         try await ensureInitialized()
 
-        guard let manager else {
+        let lane = route(for: job)
+        guard let manager = manager(for: lane) else {
             throw STTError.modelNotLoaded
         }
 
@@ -70,7 +75,7 @@ public actor STTRuntime: STTRuntimeProtocol {
 
         do {
             try Task.checkCancellation()
-            let result = try await manager.transcribe(audioURL, source: .system)
+            let result = try await manager.transcribe(audioURL)
             let words = Self.mergeTokenTimingsIntoWords(result.tokenTimings)
             onProgress?(100, 100)
             return STTResult(text: result.text, words: words)
@@ -153,16 +158,29 @@ public actor STTRuntime: STTRuntimeProtocol {
     }
 
     public func isReady() async -> Bool {
-        guard let manager else { return false }
-        return manager.isAvailable
+        guard let dictationManager, let meetingManager, let batchManager else { return false }
+        let dictationReady = await dictationManager.isAvailable
+        let meetingReady = await meetingManager.isAvailable
+        let batchReady = await batchManager.isAvailable
+        return dictationReady && meetingReady && batchReady
     }
 
     public func shutdown() async {
         invalidateBackgroundWarmUp()
         initializationTask?.cancel()
         initializationTask = nil
-        manager?.cleanup()
-        manager = nil
+        if let dictationManager {
+            await dictationManager.cleanup()
+        }
+        if let meetingManager {
+            await meetingManager.cleanup()
+        }
+        if let batchManager {
+            await batchManager.cleanup()
+        }
+        dictationManager = nil
+        meetingManager = nil
+        batchManager = nil
         models = nil
         warmUpProgressHandler = nil
         setBackgroundWarmUpState(.idle)
@@ -214,7 +232,10 @@ public actor STTRuntime: STTRuntimeProtocol {
     }
 
     private func ensureInitialized() async throws {
-        if let manager, manager.isAvailable {
+        if let dictationManager, let meetingManager, let batchManager,
+           await dictationManager.isAvailable,
+           await meetingManager.isAvailable,
+           await batchManager.isAvailable {
             return
         }
 
@@ -260,9 +281,18 @@ public actor STTRuntime: STTRuntimeProtocol {
                 version: version,
                 progressHandler: progressHandler
             )
-            let asrManager = AsrManager(config: .default)
-            try await asrManager.initialize(models: downloadedModels)
-            completeInitialization(models: downloadedModels, manager: asrManager)
+            let dictationManager = AsrManager(config: .default)
+            let meetingManager = AsrManager(config: .default)
+            let batchManager = AsrManager(config: .default)
+            try await dictationManager.loadModels(downloadedModels)
+            try await meetingManager.loadModels(downloadedModels)
+            try await batchManager.loadModels(downloadedModels)
+            await self.completeInitialization(
+                models: downloadedModels,
+                dictationManager: dictationManager,
+                meetingManager: meetingManager,
+                batchManager: batchManager
+            )
         }
 
         initializationTask = task
@@ -275,15 +305,43 @@ public actor STTRuntime: STTRuntimeProtocol {
         }
     }
 
-    private func completeInitialization(models: AsrModels, manager: AsrManager) {
+    private func completeInitialization(
+        models: AsrModels,
+        dictationManager: AsrManager,
+        meetingManager: AsrManager,
+        batchManager: AsrManager
+    ) async {
         guard !Task.isCancelled else {
-            manager.cleanup()
             initializationTask = nil
             return
         }
         self.models = models
-        self.manager = manager
+        self.dictationManager = dictationManager
+        self.meetingManager = meetingManager
+        self.batchManager = batchManager
         self.initializationTask = nil
+    }
+
+    private func manager(for lane: STTRuntimeLane) -> AsrManager? {
+        switch lane {
+        case .dictation:
+            dictationManager
+        case .meeting:
+            meetingManager
+        case .batch:
+            batchManager
+        }
+    }
+
+    private func route(for job: STTJobKind) -> STTRuntimeLane {
+        switch job {
+        case .dictation:
+            .dictation
+        case .meetingFinalize, .meetingLiveChunk:
+            .meeting
+        case .fileTranscription:
+            .batch
+        }
     }
 
     private nonisolated static func mapWarmUpError(_ error: Error) throws -> STTError {
@@ -415,4 +473,10 @@ public actor STTRuntime: STTRuntimeProtocol {
         flushCurrentWord()
         return words
     }
+}
+
+private enum STTRuntimeLane: Sendable {
+    case dictation
+    case meeting
+    case batch
 }

--- a/Sources/MacParakeetCore/STT/STTScheduler.swift
+++ b/Sources/MacParakeetCore/STT/STTScheduler.swift
@@ -142,11 +142,11 @@ public actor STTScheduler: STTManaging {
         }
 
         continuations[job.id] = continuation
-        var slotState = slotState(for: job.slot)
+        var currentSlotState = slotState(for: job.slot)
 
         if job.job == .meetingLiveChunk,
-           pendingMeetingLiveJobCount(in: slotState) >= meetingLiveChunkBacklogLimit,
-           let droppedJob = dropOldestPendingMeetingLiveJob(in: &slotState) {
+           pendingMeetingLiveJobCount(in: currentSlotState) >= meetingLiveChunkBacklogLimit,
+           let droppedJob = dropOldestPendingMeetingLiveJob(in: &currentSlotState) {
             logger.notice(
                 "stt_backpressure drop_pending_meeting_live_chunk id=\(droppedJob.id.uuidString, privacy: .public)"
             )
@@ -155,13 +155,13 @@ public actor STTScheduler: STTManaging {
             )
         }
 
-        slotState.pendingJobs.append(job)
-        setSlotState(slotState, for: job.slot)
+        currentSlotState.pendingJobs.append(job)
+        setSlotState(currentSlotState, for: job.slot)
         startNextJobIfNeeded(in: job.slot)
     }
 
     private func nextEnqueueOrder() -> UInt64 {
-        defer { enqueueCounter += 1 }
+        defer { enqueueCounter &+= 1 }
         return enqueueCounter
     }
 
@@ -192,21 +192,21 @@ public actor STTScheduler: STTManaging {
     }
 
     private func startNextJobIfNeeded(in slot: SchedulerSlot) {
-        var slotState = slotState(for: slot)
-        guard slotState.currentJob == nil else { return }
-        guard let next = dequeueNextJob(in: &slotState) else {
-            setSlotState(slotState, for: slot)
+        var currentSlotState = slotState(for: slot)
+        guard currentSlotState.currentJob == nil else { return }
+        guard let next = dequeueNextJob(in: &currentSlotState) else {
+            setSlotState(currentSlotState, for: slot)
             return
         }
 
-        slotState.currentJob = next
-        slotState.currentExecutionTask = Task {
+        currentSlotState.currentJob = next
+        currentSlotState.currentExecutionTask = Task {
             try await runtime.transcribe(audioPath: next.audioPath, job: next.job, onProgress: next.onProgress)
         }
-        slotState.currentWaitTask = Task { [weak self] in
+        currentSlotState.currentWaitTask = Task { [weak self] in
             await self?.awaitCurrentJobCompletion(jobID: next.id, in: slot)
         }
-        setSlotState(slotState, for: slot)
+        setSlotState(currentSlotState, for: slot)
     }
 
     private func dequeueNextJob(in slotState: inout SlotState) -> ScheduledJob? {
@@ -260,19 +260,19 @@ public actor STTScheduler: STTManaging {
 
     private func cancel(jobID: UUID) {
         for slot in SchedulerSlot.allCases {
-            var slotState = slotState(for: slot)
-            if let index = slotState.pendingJobs.firstIndex(where: { $0.id == jobID }) {
-                slotState.pendingJobs.remove(at: index)
-                setSlotState(slotState, for: slot)
+            var currentSlotState = slotState(for: slot)
+            if let index = currentSlotState.pendingJobs.firstIndex(where: { $0.id == jobID }) {
+                currentSlotState.pendingJobs.remove(at: index)
+                setSlotState(currentSlotState, for: slot)
                 cancelledJobIDs.remove(jobID)
                 continuations.removeValue(forKey: jobID)?.resume(throwing: CancellationError())
                 return
             }
 
-            if slotState.currentJob?.id == jobID {
-                slotState.currentExecutionTask?.cancel()
+            if currentSlotState.currentJob?.id == jobID {
+                currentSlotState.currentExecutionTask?.cancel()
                 cancelledJobIDs.remove(jobID)
-                setSlotState(slotState, for: slot)
+                setSlotState(currentSlotState, for: slot)
                 return
             }
         }
@@ -283,9 +283,9 @@ public actor STTScheduler: STTManaging {
     private func cancelAllPendingJobs() {
         let pendingIDs = SchedulerSlot.allCases.flatMap { slotState(for: $0).pendingJobs.map(\.id) }
         for slot in SchedulerSlot.allCases {
-            var slotState = slotState(for: slot)
-            slotState.pendingJobs.removeAll()
-            setSlotState(slotState, for: slot)
+            var currentSlotState = slotState(for: slot)
+            currentSlotState.pendingJobs.removeAll()
+            setSlotState(currentSlotState, for: slot)
         }
         for id in pendingIDs {
             continuations.removeValue(forKey: id)?.resume(throwing: CancellationError())
@@ -328,6 +328,8 @@ private enum SchedulerSlot: CaseIterable, Sendable {
 }
 
 private extension STTJobKind {
+    // Priority is compared only within a slot. `dictation` and `meetingFinalize`
+    // both rank highest, but they never contend because they execute on different slots.
     var priorityRank: Int {
         switch self {
         case .dictation:

--- a/Sources/MacParakeetCore/STT/STTScheduler.swift
+++ b/Sources/MacParakeetCore/STT/STTScheduler.swift
@@ -49,6 +49,7 @@ public actor STTScheduler: STTManaging {
     private var laneStates: [SchedulerLane: LaneState] = Dictionary(
         uniqueKeysWithValues: SchedulerLane.allCases.map { ($0, LaneState()) }
     )
+    private var cancelledJobIDs: Set<UUID> = []
     private var acceptsNewJobs = true
 
     /// - Parameter meetingLiveChunkBacklogLimit: Maximum pending live-preview chunks before the
@@ -76,6 +77,7 @@ public actor STTScheduler: STTManaging {
         onProgress: (@Sendable (Int, Int) -> Void)? = nil
     ) async throws -> STTResult {
         let id = UUID()
+        try Task.checkCancellation()
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
                 enqueue(
@@ -117,18 +119,12 @@ public actor STTScheduler: STTManaging {
     }
 
     public func clearModelCache() async {
-        acceptsNewJobs = false
-        defer { acceptsNewJobs = true }
-        cancelAllPendingJobs()
-        await cancelAndDrainRunningJobs()
+        await quiesce(restoreAcceptsNewJobs: true)
         await runtime.clearModelCache()
     }
 
     public func shutdown() async {
-        acceptsNewJobs = false
-        defer { acceptsNewJobs = true }
-        cancelAllPendingJobs()
-        await cancelAndDrainRunningJobs()
+        await quiesce(restoreAcceptsNewJobs: false)
         await runtime.shutdown()
     }
 
@@ -136,6 +132,11 @@ public actor STTScheduler: STTManaging {
         _ job: ScheduledJob,
         continuation: CheckedContinuation<STTResult, Error>
     ) {
+        if Task.isCancelled || cancelledJobIDs.remove(job.id) != nil {
+            continuation.resume(throwing: CancellationError())
+            return
+        }
+
         guard acceptsNewJobs else {
             continuation.resume(throwing: STTSchedulerError.unavailable)
             return
@@ -242,6 +243,7 @@ public actor STTScheduler: STTManaging {
         guard laneState.currentJob?.id == jobID else { return }
 
         let continuation = continuations.removeValue(forKey: jobID)
+        cancelledJobIDs.remove(jobID)
         laneState.currentJob = nil
         laneState.currentExecutionTask = nil
         laneState.currentWaitTask = nil
@@ -263,16 +265,20 @@ public actor STTScheduler: STTManaging {
             if let index = laneState.pendingJobs.firstIndex(where: { $0.id == jobID }) {
                 laneState.pendingJobs.remove(at: index)
                 setLaneState(laneState, for: lane)
+                cancelledJobIDs.remove(jobID)
                 continuations.removeValue(forKey: jobID)?.resume(throwing: CancellationError())
                 return
             }
 
             if laneState.currentJob?.id == jobID {
                 laneState.currentExecutionTask?.cancel()
+                cancelledJobIDs.remove(jobID)
                 setLaneState(laneState, for: lane)
                 return
             }
         }
+
+        cancelledJobIDs.insert(jobID)
     }
 
     private func cancelAllPendingJobs() {
@@ -284,6 +290,15 @@ public actor STTScheduler: STTManaging {
         }
         for id in pendingIDs {
             continuations.removeValue(forKey: id)?.resume(throwing: CancellationError())
+        }
+    }
+
+    private func quiesce(restoreAcceptsNewJobs: Bool) async {
+        acceptsNewJobs = false
+        cancelAllPendingJobs()
+        await cancelAndDrainRunningJobs()
+        if restoreAcceptsNewJobs {
+            acceptsNewJobs = true
         }
     }
 

--- a/Sources/MacParakeetCore/STT/STTScheduler.swift
+++ b/Sources/MacParakeetCore/STT/STTScheduler.swift
@@ -1,0 +1,265 @@
+import Foundation
+import OSLog
+
+public enum STTSchedulerError: Error, LocalizedError, Equatable {
+    case droppedDueToBackpressure(job: STTJobKind)
+    case unavailable
+
+    public var errorDescription: String? {
+        switch self {
+        case .droppedDueToBackpressure(let job):
+            return "Speech job dropped due to backpressure: \(String(describing: job))"
+        case .unavailable:
+            return "Speech scheduler is temporarily unavailable"
+        }
+    }
+}
+
+/// Centralized broker for all STT work in the app process.
+public actor STTScheduler: STTManaging {
+    private struct ScheduledJob: Sendable {
+        let id: UUID
+        let audioPath: String
+        let job: STTJobKind
+        let enqueueOrder: UInt64
+        let onProgress: (@Sendable (Int, Int) -> Void)?
+    }
+
+    private let logger = Logger(subsystem: "com.macparakeet.core", category: "STTScheduler")
+    private let runtime: STTRuntimeProtocol
+    private let meetingLiveChunkBacklogLimit: Int
+
+    private var enqueueCounter: UInt64 = 0
+    private var pendingJobs: [ScheduledJob] = []
+    private var continuations: [UUID: CheckedContinuation<STTResult, Error>] = [:]
+    private var currentJob: ScheduledJob?
+    private var currentExecutionTask: Task<STTResult, Error>?
+    private var currentWaitTask: Task<Void, Never>?
+    private var acceptsNewJobs = true
+
+    public init(
+        runtime: STTRuntime = STTRuntime(),
+        meetingLiveChunkBacklogLimit: Int = 24
+    ) {
+        self.runtime = runtime as STTRuntimeProtocol
+        self.meetingLiveChunkBacklogLimit = meetingLiveChunkBacklogLimit
+    }
+
+    init(
+        runtimeProvider: STTRuntimeProtocol,
+        meetingLiveChunkBacklogLimit: Int = 24
+    ) {
+        self.runtime = runtimeProvider
+        self.meetingLiveChunkBacklogLimit = meetingLiveChunkBacklogLimit
+    }
+
+    public func transcribe(
+        audioPath: String,
+        job: STTJobKind,
+        onProgress: (@Sendable (Int, Int) -> Void)? = nil
+    ) async throws -> STTResult {
+        let id = UUID()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                enqueue(
+                    ScheduledJob(
+                        id: id,
+                        audioPath: audioPath,
+                        job: job,
+                        enqueueOrder: nextEnqueueOrder(),
+                        onProgress: onProgress
+                    ),
+                    continuation: continuation
+                )
+            }
+        } onCancel: {
+            Task { [weak self] in
+                await self?.cancel(jobID: id)
+            }
+        }
+    }
+
+    public func warmUp(onProgress: (@Sendable (String) -> Void)?) async throws {
+        try await runtime.warmUp(onProgress: onProgress)
+    }
+
+    public func backgroundWarmUp() async {
+        await runtime.backgroundWarmUp()
+    }
+
+    public func observeWarmUpProgress() async -> (id: UUID, stream: AsyncStream<STTWarmUpState>) {
+        await runtime.observeWarmUpProgress()
+    }
+
+    public func removeWarmUpObserver(id: UUID) async {
+        await runtime.removeWarmUpObserver(id: id)
+    }
+
+    public func isReady() async -> Bool {
+        await runtime.isReady()
+    }
+
+    public func clearModelCache() async {
+        acceptsNewJobs = false
+        cancelAllPendingJobs()
+        if let currentWaitTask {
+            currentExecutionTask?.cancel()
+            await currentWaitTask.value
+        }
+        await runtime.clearModelCache()
+        acceptsNewJobs = true
+    }
+
+    public func shutdown() async {
+        acceptsNewJobs = false
+        cancelAllPendingJobs()
+        if let currentWaitTask {
+            currentExecutionTask?.cancel()
+            await currentWaitTask.value
+        }
+        await runtime.shutdown()
+        acceptsNewJobs = true
+    }
+
+    private func enqueue(
+        _ job: ScheduledJob,
+        continuation: CheckedContinuation<STTResult, Error>
+    ) {
+        guard acceptsNewJobs else {
+            continuation.resume(throwing: STTSchedulerError.unavailable)
+            return
+        }
+
+        continuations[job.id] = continuation
+
+        if job.job == .meetingLiveChunk,
+           pendingMeetingLiveJobCount >= meetingLiveChunkBacklogLimit,
+           let droppedJob = dropOldestPendingMeetingLiveJob() {
+            logger.notice(
+                "stt_backpressure drop_pending_meeting_live_chunk id=\(droppedJob.id.uuidString, privacy: .public)"
+            )
+            continuations.removeValue(forKey: droppedJob.id)?.resume(
+                throwing: STTSchedulerError.droppedDueToBackpressure(job: .meetingLiveChunk)
+            )
+        }
+
+        pendingJobs.append(job)
+        startNextJobIfNeeded()
+    }
+
+    private func nextEnqueueOrder() -> UInt64 {
+        defer { enqueueCounter += 1 }
+        return enqueueCounter
+    }
+
+    private var pendingMeetingLiveJobCount: Int {
+        pendingJobs.reduce(into: 0) { count, job in
+            if job.job == .meetingLiveChunk {
+                count += 1
+            }
+        }
+    }
+
+    private func dropOldestPendingMeetingLiveJob() -> ScheduledJob? {
+        guard let index = pendingJobs.enumerated()
+            .filter({ $0.element.job == .meetingLiveChunk })
+            .min(by: { $0.element.enqueueOrder < $1.element.enqueueOrder })?
+            .offset else {
+            return nil
+        }
+        return pendingJobs.remove(at: index)
+    }
+
+    private func startNextJobIfNeeded() {
+        guard currentJob == nil else { return }
+        guard let next = dequeueNextJob() else { return }
+
+        currentJob = next
+        currentExecutionTask = Task {
+            try await runtime.transcribe(audioPath: next.audioPath, onProgress: next.onProgress)
+        }
+        currentWaitTask = Task { [weak self] in
+            await self?.awaitCurrentJobCompletion(jobID: next.id)
+        }
+    }
+
+    private func dequeueNextJob() -> ScheduledJob? {
+        guard let index = pendingJobs.indices.min(by: { lhs, rhs in
+            let left = pendingJobs[lhs]
+            let right = pendingJobs[rhs]
+            if left.job.priorityRank != right.job.priorityRank {
+                return left.job.priorityRank < right.job.priorityRank
+            }
+            return left.enqueueOrder < right.enqueueOrder
+        }) else {
+            return nil
+        }
+        return pendingJobs.remove(at: index)
+    }
+
+    private func awaitCurrentJobCompletion(jobID: UUID) async {
+        guard currentJob?.id == jobID, let executionTask = currentExecutionTask else { return }
+
+        let result: Result<STTResult, Error>
+        do {
+            result = .success(try await executionTask.value)
+        } catch {
+            result = .failure(error)
+        }
+
+        finishCurrentJob(jobID: jobID, result: result)
+    }
+
+    private func finishCurrentJob(jobID: UUID, result: Result<STTResult, Error>) {
+        guard currentJob?.id == jobID else { return }
+
+        let continuation = continuations.removeValue(forKey: jobID)
+        currentJob = nil
+        currentExecutionTask = nil
+        currentWaitTask = nil
+
+        switch result {
+        case .success(let value):
+            continuation?.resume(returning: value)
+        case .failure(let error):
+            continuation?.resume(throwing: error)
+        }
+
+        startNextJobIfNeeded()
+    }
+
+    private func cancel(jobID: UUID) {
+        if let index = pendingJobs.firstIndex(where: { $0.id == jobID }) {
+            pendingJobs.remove(at: index)
+            continuations.removeValue(forKey: jobID)?.resume(throwing: CancellationError())
+            return
+        }
+
+        if currentJob?.id == jobID {
+            currentExecutionTask?.cancel()
+        }
+    }
+
+    private func cancelAllPendingJobs() {
+        let pendingIDs = pendingJobs.map(\.id)
+        pendingJobs.removeAll()
+        for id in pendingIDs {
+            continuations.removeValue(forKey: id)?.resume(throwing: CancellationError())
+        }
+    }
+}
+
+private extension STTJobKind {
+    var priorityRank: Int {
+        switch self {
+        case .dictation:
+            0
+        case .meetingFinalize:
+            1
+        case .meetingLiveChunk:
+            2
+        case .fileTranscription:
+            3
+        }
+    }
+}

--- a/Sources/MacParakeetCore/STT/STTScheduler.swift
+++ b/Sources/MacParakeetCore/STT/STTScheduler.swift
@@ -59,7 +59,7 @@ public actor STTScheduler: STTManaging {
         meetingLiveChunkBacklogLimit: Int = 120
     ) {
         self.runtime = runtime as STTRuntimeProtocol
-        self.meetingLiveChunkBacklogLimit = meetingLiveChunkBacklogLimit
+        self.meetingLiveChunkBacklogLimit = max(1, meetingLiveChunkBacklogLimit)
     }
 
     init(
@@ -67,7 +67,7 @@ public actor STTScheduler: STTManaging {
         meetingLiveChunkBacklogLimit: Int = 120
     ) {
         self.runtime = runtimeProvider
-        self.meetingLiveChunkBacklogLimit = meetingLiveChunkBacklogLimit
+        self.meetingLiveChunkBacklogLimit = max(1, meetingLiveChunkBacklogLimit)
     }
 
     public func transcribe(

--- a/Sources/MacParakeetCore/STT/STTScheduler.swift
+++ b/Sources/MacParakeetCore/STT/STTScheduler.swift
@@ -17,9 +17,8 @@ public enum STTSchedulerError: Error, LocalizedError, Equatable {
 
 /// Centralized broker for all STT work in the app process.
 ///
-/// Jobs execute independently per lane so dictation can remain responsive while
-/// meeting transcription is active, and batch/file transcription no longer
-/// stalls meeting stop/finalize.
+/// Jobs execute independently per slot so dictation can remain responsive while
+/// meeting and file work share an explicitly prioritized background path.
 public actor STTScheduler: STTManaging {
     private struct ScheduledJob: Sendable {
         let id: UUID
@@ -28,12 +27,12 @@ public actor STTScheduler: STTManaging {
         let enqueueOrder: UInt64
         let onProgress: (@Sendable (Int, Int) -> Void)?
 
-        var lane: SchedulerLane {
-            SchedulerLane(job: job)
+        var slot: SchedulerSlot {
+            SchedulerSlot(job: job)
         }
     }
 
-    private struct LaneState {
+    private struct SlotState {
         var pendingJobs: [ScheduledJob] = []
         var currentJob: ScheduledJob?
         var currentExecutionTask: Task<STTResult, Error>?
@@ -46,8 +45,8 @@ public actor STTScheduler: STTManaging {
 
     private var enqueueCounter: UInt64 = 0
     private var continuations: [UUID: CheckedContinuation<STTResult, Error>] = [:]
-    private var laneStates: [SchedulerLane: LaneState] = Dictionary(
-        uniqueKeysWithValues: SchedulerLane.allCases.map { ($0, LaneState()) }
+    private var slotStates: [SchedulerSlot: SlotState] = Dictionary(
+        uniqueKeysWithValues: SchedulerSlot.allCases.map { ($0, SlotState()) }
     )
     private var cancelledJobIDs: Set<UUID> = []
     private var acceptsNewJobs = true
@@ -143,11 +142,11 @@ public actor STTScheduler: STTManaging {
         }
 
         continuations[job.id] = continuation
-        var laneState = laneState(for: job.lane)
+        var slotState = slotState(for: job.slot)
 
         if job.job == .meetingLiveChunk,
-           pendingMeetingLiveJobCount(in: laneState) >= meetingLiveChunkBacklogLimit,
-           let droppedJob = dropOldestPendingMeetingLiveJob(in: &laneState) {
+           pendingMeetingLiveJobCount(in: slotState) >= meetingLiveChunkBacklogLimit,
+           let droppedJob = dropOldestPendingMeetingLiveJob(in: &slotState) {
             logger.notice(
                 "stt_backpressure drop_pending_meeting_live_chunk id=\(droppedJob.id.uuidString, privacy: .public)"
             )
@@ -156,9 +155,9 @@ public actor STTScheduler: STTManaging {
             )
         }
 
-        laneState.pendingJobs.append(job)
-        setLaneState(laneState, for: job.lane)
-        startNextJobIfNeeded(in: job.lane)
+        slotState.pendingJobs.append(job)
+        setSlotState(slotState, for: job.slot)
+        startNextJobIfNeeded(in: job.slot)
     }
 
     private func nextEnqueueOrder() -> UInt64 {
@@ -166,54 +165,54 @@ public actor STTScheduler: STTManaging {
         return enqueueCounter
     }
 
-    private func laneState(for lane: SchedulerLane) -> LaneState {
-        laneStates[lane, default: LaneState()]
+    private func slotState(for slot: SchedulerSlot) -> SlotState {
+        slotStates[slot, default: SlotState()]
     }
 
-    private func setLaneState(_ laneState: LaneState, for lane: SchedulerLane) {
-        laneStates[lane] = laneState
+    private func setSlotState(_ slotState: SlotState, for slot: SchedulerSlot) {
+        slotStates[slot] = slotState
     }
 
-    private func pendingMeetingLiveJobCount(in laneState: LaneState) -> Int {
-        laneState.pendingJobs.reduce(into: 0) { count, job in
+    private func pendingMeetingLiveJobCount(in slotState: SlotState) -> Int {
+        slotState.pendingJobs.reduce(into: 0) { count, job in
             if job.job == .meetingLiveChunk {
                 count += 1
             }
         }
     }
 
-    private func dropOldestPendingMeetingLiveJob(in laneState: inout LaneState) -> ScheduledJob? {
-        guard let index = laneState.pendingJobs.enumerated()
+    private func dropOldestPendingMeetingLiveJob(in slotState: inout SlotState) -> ScheduledJob? {
+        guard let index = slotState.pendingJobs.enumerated()
             .filter({ $0.element.job == .meetingLiveChunk })
             .min(by: { $0.element.enqueueOrder < $1.element.enqueueOrder })?
             .offset else {
             return nil
         }
-        return laneState.pendingJobs.remove(at: index)
+        return slotState.pendingJobs.remove(at: index)
     }
 
-    private func startNextJobIfNeeded(in lane: SchedulerLane) {
-        var laneState = laneState(for: lane)
-        guard laneState.currentJob == nil else { return }
-        guard let next = dequeueNextJob(in: &laneState) else {
-            setLaneState(laneState, for: lane)
+    private func startNextJobIfNeeded(in slot: SchedulerSlot) {
+        var slotState = slotState(for: slot)
+        guard slotState.currentJob == nil else { return }
+        guard let next = dequeueNextJob(in: &slotState) else {
+            setSlotState(slotState, for: slot)
             return
         }
 
-        laneState.currentJob = next
-        laneState.currentExecutionTask = Task {
+        slotState.currentJob = next
+        slotState.currentExecutionTask = Task {
             try await runtime.transcribe(audioPath: next.audioPath, job: next.job, onProgress: next.onProgress)
         }
-        laneState.currentWaitTask = Task { [weak self] in
-            await self?.awaitCurrentJobCompletion(jobID: next.id, in: lane)
+        slotState.currentWaitTask = Task { [weak self] in
+            await self?.awaitCurrentJobCompletion(jobID: next.id, in: slot)
         }
-        setLaneState(laneState, for: lane)
+        setSlotState(slotState, for: slot)
     }
 
-    private func dequeueNextJob(in laneState: inout LaneState) -> ScheduledJob? {
-        guard let index = laneState.pendingJobs.indices.min(by: { lhs, rhs in
-            let left = laneState.pendingJobs[lhs]
-            let right = laneState.pendingJobs[rhs]
+    private func dequeueNextJob(in slotState: inout SlotState) -> ScheduledJob? {
+        guard let index = slotState.pendingJobs.indices.min(by: { lhs, rhs in
+            let left = slotState.pendingJobs[lhs]
+            let right = slotState.pendingJobs[rhs]
             if left.job.priorityRank != right.job.priorityRank {
                 return left.job.priorityRank < right.job.priorityRank
             }
@@ -221,12 +220,12 @@ public actor STTScheduler: STTManaging {
         }) else {
             return nil
         }
-        return laneState.pendingJobs.remove(at: index)
+        return slotState.pendingJobs.remove(at: index)
     }
 
-    private func awaitCurrentJobCompletion(jobID: UUID, in lane: SchedulerLane) async {
-        let laneState = laneState(for: lane)
-        guard laneState.currentJob?.id == jobID, let executionTask = laneState.currentExecutionTask else { return }
+    private func awaitCurrentJobCompletion(jobID: UUID, in slot: SchedulerSlot) async {
+        let slotState = slotState(for: slot)
+        guard slotState.currentJob?.id == jobID, let executionTask = slotState.currentExecutionTask else { return }
 
         let result: Result<STTResult, Error>
         do {
@@ -235,19 +234,19 @@ public actor STTScheduler: STTManaging {
             result = .failure(error)
         }
 
-        finishCurrentJob(jobID: jobID, in: lane, result: result)
+        finishCurrentJob(jobID: jobID, in: slot, result: result)
     }
 
-    private func finishCurrentJob(jobID: UUID, in lane: SchedulerLane, result: Result<STTResult, Error>) {
-        var laneState = laneState(for: lane)
-        guard laneState.currentJob?.id == jobID else { return }
+    private func finishCurrentJob(jobID: UUID, in slot: SchedulerSlot, result: Result<STTResult, Error>) {
+        var slotState = slotState(for: slot)
+        guard slotState.currentJob?.id == jobID else { return }
 
         let continuation = continuations.removeValue(forKey: jobID)
         cancelledJobIDs.remove(jobID)
-        laneState.currentJob = nil
-        laneState.currentExecutionTask = nil
-        laneState.currentWaitTask = nil
-        setLaneState(laneState, for: lane)
+        slotState.currentJob = nil
+        slotState.currentExecutionTask = nil
+        slotState.currentWaitTask = nil
+        setSlotState(slotState, for: slot)
 
         switch result {
         case .success(let value):
@@ -256,24 +255,24 @@ public actor STTScheduler: STTManaging {
             continuation?.resume(throwing: error)
         }
 
-        startNextJobIfNeeded(in: lane)
+        startNextJobIfNeeded(in: slot)
     }
 
     private func cancel(jobID: UUID) {
-        for lane in SchedulerLane.allCases {
-            var laneState = laneState(for: lane)
-            if let index = laneState.pendingJobs.firstIndex(where: { $0.id == jobID }) {
-                laneState.pendingJobs.remove(at: index)
-                setLaneState(laneState, for: lane)
+        for slot in SchedulerSlot.allCases {
+            var slotState = slotState(for: slot)
+            if let index = slotState.pendingJobs.firstIndex(where: { $0.id == jobID }) {
+                slotState.pendingJobs.remove(at: index)
+                setSlotState(slotState, for: slot)
                 cancelledJobIDs.remove(jobID)
                 continuations.removeValue(forKey: jobID)?.resume(throwing: CancellationError())
                 return
             }
 
-            if laneState.currentJob?.id == jobID {
-                laneState.currentExecutionTask?.cancel()
+            if slotState.currentJob?.id == jobID {
+                slotState.currentExecutionTask?.cancel()
                 cancelledJobIDs.remove(jobID)
-                setLaneState(laneState, for: lane)
+                setSlotState(slotState, for: slot)
                 return
             }
         }
@@ -282,11 +281,11 @@ public actor STTScheduler: STTManaging {
     }
 
     private func cancelAllPendingJobs() {
-        let pendingIDs = SchedulerLane.allCases.flatMap { laneState(for: $0).pendingJobs.map(\.id) }
-        for lane in SchedulerLane.allCases {
-            var laneState = laneState(for: lane)
-            laneState.pendingJobs.removeAll()
-            setLaneState(laneState, for: lane)
+        let pendingIDs = SchedulerSlot.allCases.flatMap { slotState(for: $0).pendingJobs.map(\.id) }
+        for slot in SchedulerSlot.allCases {
+            var slotState = slotState(for: slot)
+            slotState.pendingJobs.removeAll()
+            setSlotState(slotState, for: slot)
         }
         for id in pendingIDs {
             continuations.removeValue(forKey: id)?.resume(throwing: CancellationError())
@@ -303,10 +302,10 @@ public actor STTScheduler: STTManaging {
     }
 
     private func cancelAndDrainRunningJobs() async {
-        let waitTasks = SchedulerLane.allCases.compactMap { lane -> Task<Void, Never>? in
-            let laneState = laneState(for: lane)
-            laneState.currentExecutionTask?.cancel()
-            return laneState.currentWaitTask
+        let waitTasks = SchedulerSlot.allCases.compactMap { slot -> Task<Void, Never>? in
+            let slotState = slotState(for: slot)
+            slotState.currentExecutionTask?.cancel()
+            return slotState.currentWaitTask
         }
         for task in waitTasks {
             await task.value
@@ -314,19 +313,16 @@ public actor STTScheduler: STTManaging {
     }
 }
 
-private enum SchedulerLane: CaseIterable, Sendable {
-    case dictation
-    case meeting
-    case batch
+private enum SchedulerSlot: CaseIterable, Sendable {
+    case interactive
+    case background
 
     init(job: STTJobKind) {
         switch job {
         case .dictation:
-            self = .dictation
-        case .meetingFinalize, .meetingLiveChunk:
-            self = .meeting
-        case .fileTranscription:
-            self = .batch
+            self = .interactive
+        case .meetingFinalize, .meetingLiveChunk, .fileTranscription:
+            self = .background
         }
     }
 }
@@ -341,7 +337,7 @@ private extension STTJobKind {
         case .meetingLiveChunk:
             1
         case .fileTranscription:
-            0
+            2
         }
     }
 }

--- a/Sources/MacParakeetCore/STT/STTScheduler.swift
+++ b/Sources/MacParakeetCore/STT/STTScheduler.swift
@@ -37,6 +37,9 @@ public actor STTScheduler: STTManaging {
     private var currentWaitTask: Task<Void, Never>?
     private var acceptsNewJobs = true
 
+    /// - Parameter meetingLiveChunkBacklogLimit: Maximum pending live-preview chunks before the
+    ///   oldest is dropped. 24 ≈ 4 minutes of 10-second chunks, enough to absorb a burst of
+    ///   dictation preemptions without losing meaningful meeting context.
     public init(
         runtime: STTRuntime = STTRuntime(),
         meetingLiveChunkBacklogLimit: Int = 24
@@ -101,24 +104,24 @@ public actor STTScheduler: STTManaging {
 
     public func clearModelCache() async {
         acceptsNewJobs = false
+        defer { acceptsNewJobs = true }
         cancelAllPendingJobs()
         if let currentWaitTask {
             currentExecutionTask?.cancel()
             await currentWaitTask.value
         }
         await runtime.clearModelCache()
-        acceptsNewJobs = true
     }
 
     public func shutdown() async {
         acceptsNewJobs = false
+        defer { acceptsNewJobs = true }
         cancelAllPendingJobs()
         if let currentWaitTask {
             currentExecutionTask?.cancel()
             await currentWaitTask.value
         }
         await runtime.shutdown()
-        acceptsNewJobs = true
     }
 
     private func enqueue(

--- a/Sources/MacParakeetCore/STT/STTScheduler.swift
+++ b/Sources/MacParakeetCore/STT/STTScheduler.swift
@@ -16,6 +16,10 @@ public enum STTSchedulerError: Error, LocalizedError, Equatable {
 }
 
 /// Centralized broker for all STT work in the app process.
+///
+/// Jobs execute independently per lane so dictation can remain responsive while
+/// meeting transcription is active, and batch/file transcription no longer
+/// stalls meeting stop/finalize.
 public actor STTScheduler: STTManaging {
     private struct ScheduledJob: Sendable {
         let id: UUID
@@ -23,6 +27,17 @@ public actor STTScheduler: STTManaging {
         let job: STTJobKind
         let enqueueOrder: UInt64
         let onProgress: (@Sendable (Int, Int) -> Void)?
+
+        var lane: SchedulerLane {
+            SchedulerLane(job: job)
+        }
+    }
+
+    private struct LaneState {
+        var pendingJobs: [ScheduledJob] = []
+        var currentJob: ScheduledJob?
+        var currentExecutionTask: Task<STTResult, Error>?
+        var currentWaitTask: Task<Void, Never>?
     }
 
     private let logger = Logger(subsystem: "com.macparakeet.core", category: "STTScheduler")
@@ -30,16 +45,15 @@ public actor STTScheduler: STTManaging {
     private let meetingLiveChunkBacklogLimit: Int
 
     private var enqueueCounter: UInt64 = 0
-    private var pendingJobs: [ScheduledJob] = []
     private var continuations: [UUID: CheckedContinuation<STTResult, Error>] = [:]
-    private var currentJob: ScheduledJob?
-    private var currentExecutionTask: Task<STTResult, Error>?
-    private var currentWaitTask: Task<Void, Never>?
+    private var laneStates: [SchedulerLane: LaneState] = Dictionary(
+        uniqueKeysWithValues: SchedulerLane.allCases.map { ($0, LaneState()) }
+    )
     private var acceptsNewJobs = true
 
     /// - Parameter meetingLiveChunkBacklogLimit: Maximum pending live-preview chunks before the
     ///   oldest is dropped. 24 ≈ 4 minutes of 10-second chunks, enough to absorb a burst of
-    ///   dictation preemptions without losing meaningful meeting context.
+    ///   dictation activity without losing meaningful meeting context.
     public init(
         runtime: STTRuntime = STTRuntime(),
         meetingLiveChunkBacklogLimit: Int = 24
@@ -106,10 +120,7 @@ public actor STTScheduler: STTManaging {
         acceptsNewJobs = false
         defer { acceptsNewJobs = true }
         cancelAllPendingJobs()
-        if let currentWaitTask {
-            currentExecutionTask?.cancel()
-            await currentWaitTask.value
-        }
+        await cancelAndDrainRunningJobs()
         await runtime.clearModelCache()
     }
 
@@ -117,10 +128,7 @@ public actor STTScheduler: STTManaging {
         acceptsNewJobs = false
         defer { acceptsNewJobs = true }
         cancelAllPendingJobs()
-        if let currentWaitTask {
-            currentExecutionTask?.cancel()
-            await currentWaitTask.value
-        }
+        await cancelAndDrainRunningJobs()
         await runtime.shutdown()
     }
 
@@ -134,10 +142,11 @@ public actor STTScheduler: STTManaging {
         }
 
         continuations[job.id] = continuation
+        var laneState = laneState(for: job.lane)
 
         if job.job == .meetingLiveChunk,
-           pendingMeetingLiveJobCount >= meetingLiveChunkBacklogLimit,
-           let droppedJob = dropOldestPendingMeetingLiveJob() {
+           pendingMeetingLiveJobCount(in: laneState) >= meetingLiveChunkBacklogLimit,
+           let droppedJob = dropOldestPendingMeetingLiveJob(in: &laneState) {
             logger.notice(
                 "stt_backpressure drop_pending_meeting_live_chunk id=\(droppedJob.id.uuidString, privacy: .public)"
             )
@@ -146,8 +155,9 @@ public actor STTScheduler: STTManaging {
             )
         }
 
-        pendingJobs.append(job)
-        startNextJobIfNeeded()
+        laneState.pendingJobs.append(job)
+        setLaneState(laneState, for: job.lane)
+        startNextJobIfNeeded(in: job.lane)
     }
 
     private func nextEnqueueOrder() -> UInt64 {
@@ -155,41 +165,54 @@ public actor STTScheduler: STTManaging {
         return enqueueCounter
     }
 
-    private var pendingMeetingLiveJobCount: Int {
-        pendingJobs.reduce(into: 0) { count, job in
+    private func laneState(for lane: SchedulerLane) -> LaneState {
+        laneStates[lane, default: LaneState()]
+    }
+
+    private func setLaneState(_ laneState: LaneState, for lane: SchedulerLane) {
+        laneStates[lane] = laneState
+    }
+
+    private func pendingMeetingLiveJobCount(in laneState: LaneState) -> Int {
+        laneState.pendingJobs.reduce(into: 0) { count, job in
             if job.job == .meetingLiveChunk {
                 count += 1
             }
         }
     }
 
-    private func dropOldestPendingMeetingLiveJob() -> ScheduledJob? {
-        guard let index = pendingJobs.enumerated()
+    private func dropOldestPendingMeetingLiveJob(in laneState: inout LaneState) -> ScheduledJob? {
+        guard let index = laneState.pendingJobs.enumerated()
             .filter({ $0.element.job == .meetingLiveChunk })
             .min(by: { $0.element.enqueueOrder < $1.element.enqueueOrder })?
             .offset else {
             return nil
         }
-        return pendingJobs.remove(at: index)
+        return laneState.pendingJobs.remove(at: index)
     }
 
-    private func startNextJobIfNeeded() {
-        guard currentJob == nil else { return }
-        guard let next = dequeueNextJob() else { return }
+    private func startNextJobIfNeeded(in lane: SchedulerLane) {
+        var laneState = laneState(for: lane)
+        guard laneState.currentJob == nil else { return }
+        guard let next = dequeueNextJob(in: &laneState) else {
+            setLaneState(laneState, for: lane)
+            return
+        }
 
-        currentJob = next
-        currentExecutionTask = Task {
-            try await runtime.transcribe(audioPath: next.audioPath, onProgress: next.onProgress)
+        laneState.currentJob = next
+        laneState.currentExecutionTask = Task {
+            try await runtime.transcribe(audioPath: next.audioPath, job: next.job, onProgress: next.onProgress)
         }
-        currentWaitTask = Task { [weak self] in
-            await self?.awaitCurrentJobCompletion(jobID: next.id)
+        laneState.currentWaitTask = Task { [weak self] in
+            await self?.awaitCurrentJobCompletion(jobID: next.id, in: lane)
         }
+        setLaneState(laneState, for: lane)
     }
 
-    private func dequeueNextJob() -> ScheduledJob? {
-        guard let index = pendingJobs.indices.min(by: { lhs, rhs in
-            let left = pendingJobs[lhs]
-            let right = pendingJobs[rhs]
+    private func dequeueNextJob(in laneState: inout LaneState) -> ScheduledJob? {
+        guard let index = laneState.pendingJobs.indices.min(by: { lhs, rhs in
+            let left = laneState.pendingJobs[lhs]
+            let right = laneState.pendingJobs[rhs]
             if left.job.priorityRank != right.job.priorityRank {
                 return left.job.priorityRank < right.job.priorityRank
             }
@@ -197,11 +220,12 @@ public actor STTScheduler: STTManaging {
         }) else {
             return nil
         }
-        return pendingJobs.remove(at: index)
+        return laneState.pendingJobs.remove(at: index)
     }
 
-    private func awaitCurrentJobCompletion(jobID: UUID) async {
-        guard currentJob?.id == jobID, let executionTask = currentExecutionTask else { return }
+    private func awaitCurrentJobCompletion(jobID: UUID, in lane: SchedulerLane) async {
+        let laneState = laneState(for: lane)
+        guard laneState.currentJob?.id == jobID, let executionTask = laneState.currentExecutionTask else { return }
 
         let result: Result<STTResult, Error>
         do {
@@ -210,16 +234,18 @@ public actor STTScheduler: STTManaging {
             result = .failure(error)
         }
 
-        finishCurrentJob(jobID: jobID, result: result)
+        finishCurrentJob(jobID: jobID, in: lane, result: result)
     }
 
-    private func finishCurrentJob(jobID: UUID, result: Result<STTResult, Error>) {
-        guard currentJob?.id == jobID else { return }
+    private func finishCurrentJob(jobID: UUID, in lane: SchedulerLane, result: Result<STTResult, Error>) {
+        var laneState = laneState(for: lane)
+        guard laneState.currentJob?.id == jobID else { return }
 
         let continuation = continuations.removeValue(forKey: jobID)
-        currentJob = nil
-        currentExecutionTask = nil
-        currentWaitTask = nil
+        laneState.currentJob = nil
+        laneState.currentExecutionTask = nil
+        laneState.currentWaitTask = nil
+        setLaneState(laneState, for: lane)
 
         switch result {
         case .success(let value):
@@ -228,26 +254,64 @@ public actor STTScheduler: STTManaging {
             continuation?.resume(throwing: error)
         }
 
-        startNextJobIfNeeded()
+        startNextJobIfNeeded(in: lane)
     }
 
     private func cancel(jobID: UUID) {
-        if let index = pendingJobs.firstIndex(where: { $0.id == jobID }) {
-            pendingJobs.remove(at: index)
-            continuations.removeValue(forKey: jobID)?.resume(throwing: CancellationError())
-            return
-        }
+        for lane in SchedulerLane.allCases {
+            var laneState = laneState(for: lane)
+            if let index = laneState.pendingJobs.firstIndex(where: { $0.id == jobID }) {
+                laneState.pendingJobs.remove(at: index)
+                setLaneState(laneState, for: lane)
+                continuations.removeValue(forKey: jobID)?.resume(throwing: CancellationError())
+                return
+            }
 
-        if currentJob?.id == jobID {
-            currentExecutionTask?.cancel()
+            if laneState.currentJob?.id == jobID {
+                laneState.currentExecutionTask?.cancel()
+                setLaneState(laneState, for: lane)
+                return
+            }
         }
     }
 
     private func cancelAllPendingJobs() {
-        let pendingIDs = pendingJobs.map(\.id)
-        pendingJobs.removeAll()
+        let pendingIDs = SchedulerLane.allCases.flatMap { laneState(for: $0).pendingJobs.map(\.id) }
+        for lane in SchedulerLane.allCases {
+            var laneState = laneState(for: lane)
+            laneState.pendingJobs.removeAll()
+            setLaneState(laneState, for: lane)
+        }
         for id in pendingIDs {
             continuations.removeValue(forKey: id)?.resume(throwing: CancellationError())
+        }
+    }
+
+    private func cancelAndDrainRunningJobs() async {
+        let waitTasks = SchedulerLane.allCases.compactMap { lane -> Task<Void, Never>? in
+            let laneState = laneState(for: lane)
+            laneState.currentExecutionTask?.cancel()
+            return laneState.currentWaitTask
+        }
+        for task in waitTasks {
+            await task.value
+        }
+    }
+}
+
+private enum SchedulerLane: CaseIterable, Sendable {
+    case dictation
+    case meeting
+    case batch
+
+    init(job: STTJobKind) {
+        switch job {
+        case .dictation:
+            self = .dictation
+        case .meetingFinalize, .meetingLiveChunk:
+            self = .meeting
+        case .fileTranscription:
+            self = .batch
         }
     }
 }
@@ -258,11 +322,11 @@ private extension STTJobKind {
         case .dictation:
             0
         case .meetingFinalize:
-            1
+            0
         case .meetingLiveChunk:
-            2
+            1
         case .fileTranscription:
-            3
+            0
         }
     }
 }

--- a/Sources/MacParakeetCore/STT/STTScheduler.swift
+++ b/Sources/MacParakeetCore/STT/STTScheduler.swift
@@ -52,11 +52,11 @@ public actor STTScheduler: STTManaging {
     private var acceptsNewJobs = true
 
     /// - Parameter meetingLiveChunkBacklogLimit: Maximum pending live-preview chunks before the
-    ///   oldest is dropped. 24 ≈ 4 minutes of 10-second chunks, enough to absorb a burst of
-    ///   dictation activity without losing meaningful meeting context.
+    ///   oldest is dropped. 120 ≈ 4 minutes of dual-source 5-second chunks emitted every ~4
+    ///   seconds, enough to absorb a prolonged dictation burst before preview starts dropping.
     public init(
         runtime: STTRuntime = STTRuntime(),
-        meetingLiveChunkBacklogLimit: Int = 24
+        meetingLiveChunkBacklogLimit: Int = 120
     ) {
         self.runtime = runtime as STTRuntimeProtocol
         self.meetingLiveChunkBacklogLimit = meetingLiveChunkBacklogLimit
@@ -64,7 +64,7 @@ public actor STTScheduler: STTManaging {
 
     init(
         runtimeProvider: STTRuntimeProtocol,
-        meetingLiveChunkBacklogLimit: Int = 24
+        meetingLiveChunkBacklogLimit: Int = 120
     ) {
         self.runtime = runtimeProvider
         self.meetingLiveChunkBacklogLimit = meetingLiveChunkBacklogLimit

--- a/Sources/MacParakeetCore/Services/DiarizationService.swift
+++ b/Sources/MacParakeetCore/Services/DiarizationService.swift
@@ -123,6 +123,10 @@ public actor MockDiarizationService: DiarizationServiceProtocol {
         self.diarizeResult = nil
     }
 
+    public func configurePrepareModels(error: Error?) {
+        self.prepareModelsError = error
+    }
+
     public func diarize(audioURL: URL) async throws -> MacParakeetDiarizationResult {
         diarizeCalled = true
         if let error = diarizeError { throw error }

--- a/Sources/MacParakeetCore/Services/DiarizationService.swift
+++ b/Sources/MacParakeetCore/Services/DiarizationService.swift
@@ -29,20 +29,30 @@ public protocol DiarizationServiceProtocol: Sendable {
     func diarize(audioURL: URL) async throws -> MacParakeetDiarizationResult
     func prepareModels(onProgress: (@Sendable (String) -> Void)?) async throws
     func isReady() async -> Bool
+    func hasCachedModels() async -> Bool
 }
 
 extension DiarizationServiceProtocol {
     public func prepareModels() async throws {
         try await prepareModels(onProgress: nil)
     }
+
+    public func hasCachedModels() async -> Bool {
+        false
+    }
 }
 
 public actor DiarizationService: DiarizationServiceProtocol {
     private let manager: OfflineDiarizerManager
+    private let modelsDirectory: URL
     private var modelsReady = false
 
-    public init(config: OfflineDiarizerConfig = .default) {
+    public init(
+        config: OfflineDiarizerConfig = .default,
+        modelsDirectory: URL? = nil
+    ) {
         self.manager = OfflineDiarizerManager(config: config)
+        self.modelsDirectory = (modelsDirectory ?? OfflineDiarizerModels.defaultModelsDirectory()).standardizedFileURL
     }
 
     public func diarize(audioURL: URL) async throws -> MacParakeetDiarizationResult {
@@ -87,13 +97,39 @@ public actor DiarizationService: DiarizationServiceProtocol {
 
     public func prepareModels(onProgress: (@Sendable (String) -> Void)? = nil) async throws {
         onProgress?("Downloading speaker models...")
-        try await manager.prepareModels()
+        try await manager.prepareModels(directory: modelsDirectory)
         modelsReady = true
         onProgress?("Speaker models ready")
     }
 
     public func isReady() async -> Bool {
         modelsReady
+    }
+
+    public func hasCachedModels() async -> Bool {
+        Self.isModelCached(directory: modelsDirectory)
+    }
+
+    public nonisolated static func isModelCached(directory: URL? = nil) -> Bool {
+        let repoDirectory = modelCacheDirectory(directory: directory)
+        return requiredModelNames().allSatisfy { modelName in
+            FileManager.default.fileExists(
+                atPath: repoDirectory.appendingPathComponent(modelName, isDirectory: false).path
+            )
+        }
+    }
+
+    public nonisolated static func clearModelCache(directory: URL? = nil) {
+        try? FileManager.default.removeItem(at: modelCacheDirectory(directory: directory))
+    }
+
+    nonisolated static func modelCacheDirectory(directory: URL? = nil) -> URL {
+        let baseDirectory = (directory ?? OfflineDiarizerModels.defaultModelsDirectory()).standardizedFileURL
+        return baseDirectory.appendingPathComponent(Repo.diarizer.folderName, isDirectory: true)
+    }
+
+    nonisolated static func requiredModelNames() -> [String] {
+        Array(ModelNames.OfflineDiarizer.requiredModels)
     }
 }
 
@@ -110,6 +146,8 @@ public actor MockDiarizationService: DiarizationServiceProtocol {
     public var diarizeCalled = false
     public var prepareModelsCalled = false
     public var prepareModelsError: Error?
+    public var ready = false
+    public var cachedModels = false
 
     public init() {}
 
@@ -127,6 +165,14 @@ public actor MockDiarizationService: DiarizationServiceProtocol {
         self.prepareModelsError = error
     }
 
+    public func configureReady(_ ready: Bool) {
+        self.ready = ready
+    }
+
+    public func configureCachedModels(_ cachedModels: Bool) {
+        self.cachedModels = cachedModels
+    }
+
     public func diarize(audioURL: URL) async throws -> MacParakeetDiarizationResult {
         diarizeCalled = true
         if let error = diarizeError { throw error }
@@ -136,9 +182,15 @@ public actor MockDiarizationService: DiarizationServiceProtocol {
     public func prepareModels(onProgress: (@Sendable (String) -> Void)?) async throws {
         prepareModelsCalled = true
         if let error = prepareModelsError { throw error }
+        ready = true
+        cachedModels = true
     }
 
     public func isReady() async -> Bool {
-        true
+        ready
+    }
+
+    public func hasCachedModels() async -> Bool {
+        cachedModels
     }
 }

--- a/Sources/MacParakeetCore/Services/DictationService.swift
+++ b/Sources/MacParakeetCore/Services/DictationService.swift
@@ -45,7 +45,7 @@ extension DictationServiceProtocol {
 public actor DictationService: DictationServiceProtocol {
     private let logger = Logger(subsystem: "com.macparakeet.core", category: "DictationService")
     private let audioProcessor: AudioProcessorProtocol
-    private let sttClient: STTClientProtocol
+    private let sttTranscriber: STTTranscribing
     private let dictationRepo: DictationRepositoryProtocol
     private let shouldSaveAudio: (@Sendable () -> Bool)?
     private let shouldSaveDictationHistory: (@Sendable () -> Bool)?
@@ -75,7 +75,7 @@ public actor DictationService: DictationServiceProtocol {
 
     public init(
         audioProcessor: AudioProcessorProtocol,
-        sttClient: STTClientProtocol,
+        sttTranscriber: STTTranscribing,
         dictationRepo: DictationRepositoryProtocol,
         shouldSaveAudio: (@Sendable () -> Bool)? = nil,
         shouldSaveDictationHistory: (@Sendable () -> Bool)? = nil,
@@ -87,7 +87,7 @@ public actor DictationService: DictationServiceProtocol {
         cancelWindow: Duration = .seconds(5)
     ) {
         self.audioProcessor = audioProcessor
-        self.sttClient = sttClient
+        self.sttTranscriber = sttTranscriber
         self.dictationRepo = dictationRepo
         self.shouldSaveAudio = shouldSaveAudio
         self.shouldSaveDictationHistory = shouldSaveDictationHistory
@@ -381,7 +381,7 @@ public actor DictationService: DictationServiceProtocol {
             }
         }
 
-        let result = try await sttClient.transcribe(audioPath: audioURL.path)
+        let result = try await sttTranscriber.transcribe(audioPath: audioURL.path, job: .dictation)
         logger.debug("processCapturedAudio transcription complete chars=\(result.text.count)")
 
         let trimmed = result.text.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/MacParakeetCore/Services/ExportService.swift
+++ b/Sources/MacParakeetCore/Services/ExportService.swift
@@ -1,6 +1,7 @@
 import Foundation
 import AppKit
 
+@MainActor
 public protocol ExportServiceProtocol: Sendable {
     func exportToTxt(transcription: Transcription, url: URL) throws
     func exportToSRT(transcription: Transcription, url: URL) throws

--- a/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
@@ -46,12 +46,10 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         let task: Task<Void, Never>
     }
 
-    private static let maxPendingChunkTasks = 24
-
     private let logger = Logger(subsystem: "com.macparakeet.core", category: "MeetingRecordingService")
     private let audioCaptureService: any MeetingAudioCapturing
     private let audioConverter: any AudioFileConverting
-    private let sttClient: STTClientProtocol
+    private let sttTranscriber: STTTranscribing
     private let fileManager: FileManager
 
     private var currentSession: Session?
@@ -74,12 +72,12 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     public init(
         audioCaptureService: any MeetingAudioCapturing = MeetingAudioCaptureService(),
         audioConverter: any AudioFileConverting = AudioFileConverter(),
-        sttClient: STTClientProtocol = STTClient(),
+        sttTranscriber: STTTranscribing,
         fileManager: FileManager = .default
     ) {
         self.audioCaptureService = audioCaptureService
         self.audioConverter = audioConverter
-        self.sttClient = sttClient
+        self.sttTranscriber = sttTranscriber
         self.fileManager = fileManager
     }
 
@@ -325,12 +323,6 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         source: AudioSource,
         session: Session
     ) {
-        if pendingChunkTasks.count >= Self.maxPendingChunkTasks {
-            chunkTranscriptionFailed = true
-            logger.warning("Dropping live meeting chunk because the backlog exceeded \(Self.maxPendingChunkTasks, privacy: .public) tasks")
-            return
-        }
-
         let sequence = nextChunkSequence[source] ?? 0
         nextChunkSequence[source] = sequence + 1
 
@@ -375,7 +367,11 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             .appendingPathComponent("\(source.rawValue)-\(chunk.startMs)-\(chunk.endMs).wav")
         try writeChunkAudio(samples: chunk.samples, to: chunkURL)
         defer { try? fileManager.removeItem(at: chunkURL) }
-        return try await sttClient.transcribe(audioPath: chunkURL.path, onProgress: nil)
+        return try await sttTranscriber.transcribe(
+            audioPath: chunkURL.path,
+            job: .meetingLiveChunk,
+            onProgress: nil
+        )
     }
 
     private func writeChunkAudio(samples: [Float], to url: URL) throws {
@@ -436,7 +432,11 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         sequence: Int,
         sessionID: UUID
     ) {
-        logger.error("Meeting chunk transcription failed: \(error.localizedDescription, privacy: .public)")
+        if case STTSchedulerError.droppedDueToBackpressure(job: .meetingLiveChunk) = error {
+            logger.notice("Meeting live chunk dropped by scheduler backpressure")
+        } else {
+            logger.error("Meeting chunk transcription failed: \(error.localizedDescription, privacy: .public)")
+        }
         guard currentSession?.id == sessionID else { return }
         chunkTranscriptionFailed = true
         let readyResults = chunkResultBuffer.receiveFailure(sequence: sequence, source: source)

--- a/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
@@ -183,10 +183,11 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         await processingTask?.value
         processingTask = nil
         await flushTranscriptChunkers(for: session)
-        let pendingTasks = pendingChunkTasks.map(\.task)
-        pendingChunkTasks = []
-        for task in pendingTasks {
-            await task.value
+        // Preserve prepared speaker metadata when the preview tail drains quickly,
+        // but stop waiting once live preview falls behind so finalize can take over.
+        let preparedTranscriptReady = await waitForPendingChunkTasksToDrain(timeout: .milliseconds(150))
+        if !preparedTranscriptReady {
+            await cancelPendingChunkTasks(waitForCancellation: false)
         }
         writer?.finalize()
         writer = nil
@@ -213,7 +214,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             microphoneAudioURL: session.microphoneAudioURL,
             systemAudioURL: session.systemAudioURL,
             durationSeconds: durationSeconds,
-            preparedTranscript: chunkTranscriptionFailed
+            preparedTranscript: (chunkTranscriptionFailed || !preparedTranscriptReady)
                 ? nil
                 : transcriptAssembler.finalizedTranscript(durationMs: Int(durationSeconds * 1000))
         )
@@ -230,12 +231,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         processingTask?.cancel()
         await processingTask?.value
         processingTask = nil
-        let pendingTasks = pendingChunkTasks.map(\.task)
-        pendingChunkTasks = []
-        for task in pendingTasks {
-            task.cancel()
-            await task.value
-        }
+        await cancelPendingChunkTasks(waitForCancellation: true)
         writer?.finalize()
         writer = nil
         cleanupState()
@@ -342,7 +338,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
                     sessionID: session.id
                 )
             } catch is CancellationError {
-                return
+                // Cancellation is expected when stopRecording prioritizes finalize.
             } catch {
                 await self.handleChunkTranscriptionFailure(
                     error,
@@ -351,13 +347,11 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
                     sessionID: session.id
                 )
             }
+
+            await self.removePendingChunkTask(id: taskID)
         }
 
         pendingChunkTasks.append(PendingChunkTask(id: taskID, task: task))
-        Task { [weak self] in
-            await task.value
-            await self?.removePendingChunkTask(id: taskID)
-        }
     }
 
     private func transcribeChunk(
@@ -464,6 +458,31 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             let size = try fileManager.attributesOfItem(atPath: url.path)[.size] as? NSNumber
             return (size?.intValue ?? 0) > 0
         }
+    }
+
+    private func cancelPendingChunkTasks(waitForCancellation: Bool) async {
+        let tasks = pendingChunkTasks.map(\.task)
+        pendingChunkTasks = []
+
+        for task in tasks {
+            task.cancel()
+        }
+
+        guard waitForCancellation else { return }
+        for task in tasks {
+            await task.value
+        }
+    }
+
+    private func waitForPendingChunkTasksToDrain(timeout: Duration) async -> Bool {
+        let startedAt = ContinuousClock.now
+        while !pendingChunkTasks.isEmpty {
+            if startedAt.duration(to: .now) > timeout {
+                return false
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return true
     }
 
     private func removePendingChunkTask(id: UUID) {

--- a/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
@@ -428,6 +428,8 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         sequence: Int,
         sessionID: UUID
     ) {
+        guard currentSession?.id == sessionID else { return }
+
         let droppedByBackpressure =
             if case STTSchedulerError.droppedDueToBackpressure(job: .meetingLiveChunk) = error {
                 true
@@ -442,7 +444,6 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             logger.error("Meeting chunk transcription failed: \(error.localizedDescription, privacy: .public)")
             chunkTranscriptionFailed = true
         }
-        guard currentSession?.id == sessionID else { return }
         let readyResults = chunkResultBuffer.receiveFailure(sequence: sequence, source: source)
         for ready in readyResults {
             let update = transcriptAssembler.apply(result: ready.result, chunk: ready.chunk, source: source)

--- a/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
@@ -63,6 +63,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     private var chunkResultBuffer = MeetingChunkResultBuffer()
     private var transcriptAssembler = MeetingTranscriptAssembler()
     private var chunkTranscriptionFailed = false
+    private var isTranscriptionLagging = false
     private var captureFailed = false
     private var latestLevels = MeetingAudioLevels()
 
@@ -149,6 +150,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         chunkResultBuffer.reset()
         transcriptAssembler.reset()
         chunkTranscriptionFailed = false
+        isTranscriptionLagging = false
         captureFailed = false
 
         processingTask = Task { [weak self] in
@@ -413,6 +415,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         sessionID: UUID
     ) {
         guard currentSession?.id == sessionID else { return }
+        isTranscriptionLagging = false
         let readyResults = chunkResultBuffer.receiveSuccess(
             sequence: sequence,
             source: source,
@@ -422,7 +425,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
 
         for ready in readyResults {
             let update = transcriptAssembler.apply(result: ready.result, chunk: ready.chunk, source: source)
-            transcriptContinuation?.yield(update)
+            yieldTranscriptUpdate(update)
         }
     }
 
@@ -434,6 +437,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     ) {
         if case STTSchedulerError.droppedDueToBackpressure(job: .meetingLiveChunk) = error {
             logger.notice("Meeting live chunk dropped by scheduler backpressure")
+            isTranscriptionLagging = true
         } else {
             logger.error("Meeting chunk transcription failed: \(error.localizedDescription, privacy: .public)")
         }
@@ -442,8 +446,15 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         let readyResults = chunkResultBuffer.receiveFailure(sequence: sequence, source: source)
         for ready in readyResults {
             let update = transcriptAssembler.apply(result: ready.result, chunk: ready.chunk, source: source)
-            transcriptContinuation?.yield(update)
+            yieldTranscriptUpdate(update)
         }
+    }
+
+    private func yieldTranscriptUpdate(_ update: MeetingTranscriptUpdate) {
+        let adjusted = isTranscriptionLagging && !update.isTranscriptionLagging
+            ? MeetingTranscriptUpdate(words: update.words, speakers: update.speakers, isTranscriptionLagging: true)
+            : update
+        transcriptContinuation?.yield(adjusted)
     }
 
     private func existingSourceURLs(for session: Session) throws -> [URL] {
@@ -468,6 +479,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         chunkResultBuffer.reset()
         transcriptAssembler.reset()
         chunkTranscriptionFailed = false
+        isTranscriptionLagging = false
         captureFailed = false
         transcriptContinuation?.finish()
         transcriptContinuation = nil

--- a/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
@@ -183,8 +183,8 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         await processingTask?.value
         processingTask = nil
         await flushTranscriptChunkers(for: session)
-        // Preserve prepared speaker metadata when the preview tail drains quickly,
-        // but stop waiting once live preview falls behind so finalize can take over.
+        // Preserve any prepared speaker metadata that is already assembled, but
+        // stop waiting once live preview falls behind so finalize can take over.
         let preparedTranscriptReady = await waitForPendingChunkTasksToDrain(timeout: .milliseconds(150))
         if !preparedTranscriptReady {
             await cancelPendingChunkTasks(waitForCancellation: false)
@@ -214,7 +214,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             microphoneAudioURL: session.microphoneAudioURL,
             systemAudioURL: session.systemAudioURL,
             durationSeconds: durationSeconds,
-            preparedTranscript: (chunkTranscriptionFailed || !preparedTranscriptReady)
+            preparedTranscript: chunkTranscriptionFailed
                 ? nil
                 : transcriptAssembler.finalizedTranscript(durationMs: Int(durationSeconds * 1000))
         )
@@ -409,7 +409,6 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         sessionID: UUID
     ) {
         guard currentSession?.id == sessionID else { return }
-        isTranscriptionLagging = false
         let readyResults = chunkResultBuffer.receiveSuccess(
             sequence: sequence,
             source: source,
@@ -429,14 +428,21 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         sequence: Int,
         sessionID: UUID
     ) {
-        if case STTSchedulerError.droppedDueToBackpressure(job: .meetingLiveChunk) = error {
+        let droppedByBackpressure =
+            if case STTSchedulerError.droppedDueToBackpressure(job: .meetingLiveChunk) = error {
+                true
+            } else {
+                false
+            }
+
+        if droppedByBackpressure {
             logger.notice("Meeting live chunk dropped by scheduler backpressure")
             isTranscriptionLagging = true
         } else {
             logger.error("Meeting chunk transcription failed: \(error.localizedDescription, privacy: .public)")
+            chunkTranscriptionFailed = true
         }
         guard currentSession?.id == sessionID else { return }
-        chunkTranscriptionFailed = true
         let readyResults = chunkResultBuffer.receiveFailure(sequence: sequence, source: source)
         for ready in readyResults {
             let update = transcriptAssembler.apply(result: ready.result, chunk: ready.chunk, source: source)
@@ -445,10 +451,19 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     }
 
     private func yieldTranscriptUpdate(_ update: MeetingTranscriptUpdate) {
-        let adjusted = isTranscriptionLagging && !update.isTranscriptionLagging
-            ? MeetingTranscriptUpdate(words: update.words, speakers: update.speakers, isTranscriptionLagging: true)
-            : update
-        transcriptContinuation?.yield(adjusted)
+        if isTranscriptionLagging && !update.isTranscriptionLagging {
+            transcriptContinuation?.yield(
+                MeetingTranscriptUpdate(
+                    words: update.words,
+                    speakers: update.speakers,
+                    isTranscriptionLagging: true
+                )
+            )
+            isTranscriptionLagging = false
+            return
+        }
+
+        transcriptContinuation?.yield(update)
     }
 
     private func existingSourceURLs(for session: Session) throws -> [URL] {

--- a/Sources/MacParakeetCore/Services/MeetingTranscriptAssembler.swift
+++ b/Sources/MacParakeetCore/Services/MeetingTranscriptAssembler.swift
@@ -3,10 +3,14 @@ import Foundation
 public struct MeetingTranscriptUpdate: Sendable, Equatable {
     public let words: [WordTimestamp]
     public let speakers: [SpeakerInfo]
+    /// `true` when live-preview chunks were recently dropped due to STT backpressure.
+    /// The UI can use this to show a "transcription lagging" indicator.
+    public let isTranscriptionLagging: Bool
 
-    public init(words: [WordTimestamp], speakers: [SpeakerInfo]) {
+    public init(words: [WordTimestamp], speakers: [SpeakerInfo], isTranscriptionLagging: Bool = false) {
         self.words = words
         self.speakers = speakers
+        self.isTranscriptionLagging = isTranscriptionLagging
     }
 }
 

--- a/Sources/MacParakeetCore/Services/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/TelemetryEvent.swift
@@ -85,6 +85,14 @@ public enum TelemetryTranscriptionSource: String, Sendable, Equatable {
     case dragDrop = "drag_drop"
 }
 
+public enum TelemetryTranscriptionStage: String, Sendable, Equatable {
+    case download
+    case audioConversion = "audio_conversion"
+    case stt
+    case diarization
+    case postProcessing = "post_processing"
+}
+
 public enum TelemetryCopySource: String, Sendable, Equatable {
     case dictation
     case transcription
@@ -122,10 +130,23 @@ public enum TelemetryEventSpec: Sendable {
         source: TelemetryTranscriptionSource,
         audioDurationSeconds: Double?,
         processingSeconds: Double?,
-        wordCount: Int
+        wordCount: Int,
+        speakerCount: Int? = nil,
+        diarizationRequested: Bool,
+        diarizationApplied: Bool,
+        meetingPreparedTranscriptUsed: Bool? = nil
     )
-    case transcriptionCancelled(source: TelemetryTranscriptionSource, audioDurationSeconds: Double?)
-    case transcriptionFailed(source: TelemetryTranscriptionSource, errorType: String, errorDetail: String? = nil)
+    case transcriptionCancelled(
+        source: TelemetryTranscriptionSource,
+        audioDurationSeconds: Double?,
+        stage: TelemetryTranscriptionStage
+    )
+    case transcriptionFailed(
+        source: TelemetryTranscriptionSource,
+        stage: TelemetryTranscriptionStage,
+        errorType: String,
+        errorDetail: String? = nil
+    )
     case diarizationStarted(source: TelemetryTranscriptionSource)
     case diarizationCompleted(source: TelemetryTranscriptionSource, speakerCount: Int, durationSeconds: Double)
     case diarizationFailed(source: TelemetryTranscriptionSource, errorType: String, errorDetail: String? = nil)
@@ -293,20 +314,38 @@ extension TelemetryEventSpec {
                 ("source", source.rawValue),
                 ("audio_duration_seconds", audioDurationSeconds.map(Self.format))
             )
-        case .transcriptionCompleted(let source, let audioDurationSeconds, let processingSeconds, let wordCount):
+        case .transcriptionCompleted(
+            let source,
+            let audioDurationSeconds,
+            let processingSeconds,
+            let wordCount,
+            let speakerCount,
+            let diarizationRequested,
+            let diarizationApplied,
+            let meetingPreparedTranscriptUsed
+        ):
             return Self.compactProps(
                 ("source", source.rawValue),
                 ("audio_duration_seconds", audioDurationSeconds.map(Self.format)),
                 ("processing_seconds", processingSeconds.map(Self.format)),
-                ("word_count", "\(wordCount)")
+                ("word_count", "\(wordCount)"),
+                ("speaker_count", speakerCount.map(String.init)),
+                ("diarization_requested", Self.boolString(diarizationRequested)),
+                ("diarization_applied", Self.boolString(diarizationApplied)),
+                ("meeting_prepared_transcript_used", meetingPreparedTranscriptUsed.map(Self.boolString))
             )
-        case .transcriptionCancelled(let source, let audioDurationSeconds):
+        case .transcriptionCancelled(let source, let audioDurationSeconds, let stage):
             return Self.compactProps(
                 ("source", source.rawValue),
-                ("audio_duration_seconds", audioDurationSeconds.map(Self.format))
+                ("audio_duration_seconds", audioDurationSeconds.map(Self.format)),
+                ("stage", stage.rawValue)
             )
-        case .transcriptionFailed(let source, let errorType, let errorDetail):
-            var props = ["source": source.rawValue, "error_type": errorType]
+        case .transcriptionFailed(let source, let stage, let errorType, let errorDetail):
+            var props = [
+                "source": source.rawValue,
+                "stage": stage.rawValue,
+                "error_type": errorType,
+            ]
             if let errorDetail { props["error_detail"] = errorDetail }
             return props
         case .diarizationStarted(let source):
@@ -408,6 +447,10 @@ extension TelemetryEventSpec {
         String(format: "%.1f", value)
     }
 
+    private static func boolString(_ value: Bool) -> String {
+        value ? "true" : "false"
+    }
+
     private static func mergeDevice(_ base: [String: String]?, _ device: RecordingDeviceInfo?) -> [String: String]? {
         guard let device else { return base }
         var merged = base ?? [:]
@@ -431,9 +474,9 @@ public enum TelemetryImplementedContract {
         .dictationEmpty: [],
         .dictationFailed: ["error_type"],
         .transcriptionStarted: ["source"],
-        .transcriptionCompleted: ["source", "word_count"],
-        .transcriptionCancelled: ["source"],
-        .transcriptionFailed: ["source", "error_type"],
+        .transcriptionCompleted: ["source", "word_count", "diarization_requested", "diarization_applied"],
+        .transcriptionCancelled: ["source", "stage"],
+        .transcriptionFailed: ["source", "stage", "error_type"],
         .diarizationStarted: ["source"],
         .diarizationCompleted: ["source", "speaker_count"],
         .diarizationFailed: ["source", "error_type"],

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -183,12 +183,40 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
             try await entitlements.assertCanTranscribe(now: Date())
         }
 
-        onProgress?(.downloading(percent: 0))
-        let downloadResult = try await downloader.download(url: urlString) { percent in
-            onProgress?(.downloading(percent: percent))
+        let downloadResult: YouTubeDownloader.DownloadResult
+        do {
+            onProgress?(.downloading(percent: 0))
+            downloadResult = try await downloader.download(url: urlString) { percent in
+                onProgress?(.downloading(percent: percent))
+            }
+        } catch {
+            if error is CancellationError {
+                Telemetry.send(.transcriptionCancelled(
+                    source: .youtube,
+                    audioDurationSeconds: nil,
+                    stage: .download
+                ))
+            } else {
+                Telemetry.send(.transcriptionFailed(
+                    source: .youtube,
+                    stage: .download,
+                    errorType: Self.errorType(for: error),
+                    errorDetail: TelemetryErrorClassifier.errorDetail(error)
+                ))
+            }
+            throw error
         }
         onProgress?(.downloading(percent: 100))
-        try Task.checkCancellation()
+        do {
+            try Task.checkCancellation()
+        } catch {
+            Telemetry.send(.transcriptionCancelled(
+                source: .youtube,
+                audioDurationSeconds: downloadResult.durationSeconds.map(Double.init),
+                stage: .download
+            ))
+            throw error
+        }
         let keepDownloadedAudio = shouldKeepDownloadedAudio()
 
         var transcription = Transcription(
@@ -202,7 +230,10 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
             sourceType: .youtube
         )
         try transcriptionRepo.save(transcription)
-        Telemetry.send(.transcriptionStarted(source: .youtube, audioDurationSeconds: nil))
+        Telemetry.send(.transcriptionStarted(
+            source: .youtube,
+            audioDurationSeconds: downloadResult.durationSeconds.map(Double.init)
+        ))
 
         // Cache YouTube thumbnail locally (non-blocking)
         if let thumbURL = downloadResult.thumbnailURL {
@@ -243,6 +274,9 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
     ) async throws -> Transcription {
         var wavURL: URL?
         let processingStartedAt = Date()
+        var lifecycleStage: TelemetryTranscriptionStage = .audioConversion
+        let meetingPreparedTranscriptUsed = source == .meeting && meetingSpeakerMetadata != nil
+        let diarizationRequested = meetingPreparedTranscriptUsed || (diarizationService != nil && shouldDiarize())
         do {
             onProgress?(.converting)
             wavURL = try await audioProcessor.convert(fileURL: fileURL)
@@ -252,6 +286,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
             }
 
             onProgress?(.transcribing(percent: 0))
+            lifecycleStage = .stt
             let sttProgress: (@Sendable (Int, Int) -> Void)? = onProgress.map { callback in
                 { @Sendable current, total in
                     let pct = total > 0 ? Int(Double(current) / Double(total) * 100) : 0
@@ -290,6 +325,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
                 transcription.speakers = meetingSpeakerMetadata.speakers
                 transcription.diarizationSegments = Self.buildDiarizationSegments(from: mergedWords)
             } else if let diarizationService, shouldDiarize() {
+                lifecycleStage = .diarization
                 do {
                     onProgress?(.identifyingSpeakers)
                     Telemetry.send(.diarizationStarted(source: source))
@@ -325,11 +361,14 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
                 }
             }
 
+            lifecycleStage = .postProcessing
             let completed = try await completeTranscription(
                 source: source,
                 transcription: &transcription,
                 rawText: result.text,
-                processingStartedAt: processingStartedAt
+                processingStartedAt: processingStartedAt,
+                diarizationRequested: diarizationRequested,
+                meetingPreparedTranscriptUsed: meetingPreparedTranscriptUsed
             )
 
             try? FileManager.default.removeItem(at: wavURL)
@@ -352,11 +391,13 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
             if error is CancellationError {
                 Telemetry.send(.transcriptionCancelled(
                     source: source,
-                    audioDurationSeconds: audioDurationSeconds
+                    audioDurationSeconds: audioDurationSeconds,
+                    stage: lifecycleStage
                 ))
             } else {
                 Telemetry.send(.transcriptionFailed(
                     source: source,
+                    stage: lifecycleStage,
                     errorType: Self.errorType(for: error),
                     errorDetail: TelemetryErrorClassifier.errorDetail(error)
                 ))
@@ -392,7 +433,9 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         source: TelemetryTranscriptionSource,
         transcription: inout Transcription,
         rawText: String,
-        processingStartedAt: Date
+        processingStartedAt: Date,
+        diarizationRequested: Bool,
+        meetingPreparedTranscriptUsed: Bool
     ) async throws -> Transcription {
         let mode = processingMode()
         var customWords: [CustomWord] = []
@@ -423,11 +466,16 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         let wordCount = transcription.rawTranscript?.split(whereSeparator: \.isWhitespace).count ?? 0
         let audioDurationSeconds = transcription.durationMs.map { Double($0) / 1000.0 }
         let processingSeconds = Date().timeIntervalSince(processingStartedAt)
+        let diarizationApplied = !(transcription.diarizationSegments?.isEmpty ?? true)
         Telemetry.send(.transcriptionCompleted(
             source: source,
             audioDurationSeconds: audioDurationSeconds,
             processingSeconds: processingSeconds,
-            wordCount: wordCount
+            wordCount: wordCount,
+            speakerCount: transcription.speakerCount,
+            diarizationRequested: diarizationRequested,
+            diarizationApplied: diarizationApplied,
+            meetingPreparedTranscriptUsed: source == .meeting ? meetingPreparedTranscriptUsed : nil
         ))
 
         return transcription

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -38,7 +38,7 @@ extension TranscriptionServiceProtocol {
 public actor TranscriptionService: TranscriptionServiceProtocol {
     private let logger = Logger(subsystem: "com.macparakeet.core", category: "TranscriptionService")
     private let audioProcessor: AudioProcessorProtocol
-    private let sttClient: STTClientProtocol
+    private let sttTranscriber: STTTranscribing
     private let transcriptionRepo: TranscriptionRepositoryProtocol
     private let entitlements: EntitlementsChecking?
     private let customWordRepo: CustomWordRepositoryProtocol?
@@ -52,7 +52,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
 
     public init(
         audioProcessor: AudioProcessorProtocol,
-        sttClient: STTClientProtocol,
+        sttTranscriber: STTTranscribing,
         transcriptionRepo: TranscriptionRepositoryProtocol,
         entitlements: EntitlementsChecking? = nil,
         customWordRepo: CustomWordRepositoryProtocol? = nil,
@@ -64,7 +64,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         diarizationService: DiarizationServiceProtocol? = nil
     ) {
         self.audioProcessor = audioProcessor
-        self.sttClient = sttClient
+        self.sttTranscriber = sttTranscriber
         self.transcriptionRepo = transcriptionRepo
         self.entitlements = entitlements
         self.customWordRepo = customWordRepo
@@ -249,7 +249,11 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
                     callback(.transcribing(percent: min(pct, 99)))
                 }
             }
-            let result = try await sttClient.transcribe(audioPath: wavURL.path, onProgress: sttProgress)
+            let result = try await sttTranscriber.transcribe(
+                audioPath: wavURL.path,
+                job: source == .meeting ? .meetingFinalize : .fileTranscription,
+                onProgress: sttProgress
+            )
 
             let words = result.words.map { word in
                 WordTimestamp(

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -95,6 +95,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
             storedFileURL: fileURL,
             displayFileName: nil,
             source: source,
+            sttJob: .fileTranscription,
             sourceType: sourceType,
             onProgress: onProgress
         )
@@ -109,6 +110,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
             storedFileURL: recording.mixedAudioURL,
             displayFileName: recording.displayName,
             source: .meeting,
+            sttJob: .meetingFinalize,
             sourceType: .meeting,
             meetingSpeakerMetadata: recording.preparedTranscript,
             onProgress: onProgress
@@ -120,6 +122,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         storedFileURL: URL?,
         displayFileName: String?,
         source: TelemetryTranscriptionSource,
+        sttJob: STTJobKind,
         sourceType: Transcription.SourceType,
         meetingSpeakerMetadata: MeetingRealtimeTranscript? = nil,
         onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
@@ -160,6 +163,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         return try await transcribeAudio(
             fileURL: fileURL,
             source: source,
+            sttJob: sttJob,
             transcription: &transcription,
             tempFiles: [],
             meetingSpeakerMetadata: meetingSpeakerMetadata,
@@ -214,6 +218,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         return try await transcribeAudio(
             fileURL: downloadResult.audioFileURL,
             source: .youtube,
+            sttJob: .fileTranscription,
             transcription: &transcription,
             tempFiles: [downloadResult.audioFileURL],
             cleanUpDownloadedFiles: !keepDownloadedAudio,
@@ -226,6 +231,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
     private func transcribeAudio(
         fileURL: URL,
         source: TelemetryTranscriptionSource,
+        sttJob: STTJobKind,
         transcription: inout Transcription,
         tempFiles: [URL],
         cleanUpDownloadedFiles: Bool = true,
@@ -251,7 +257,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
             }
             let result = try await sttTranscriber.transcribe(
                 audioPath: wavURL.path,
-                job: source == .meeting ? .meetingFinalize : .fileTranscription,
+                job: sttJob,
                 onProgress: sttProgress
             )
 

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -105,6 +105,9 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         recording: MeetingRecordingOutput,
         onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
     ) async throws -> Transcription {
+        // Reserve `.meetingFinalize` for the immediate post-stop meeting path.
+        // Saved meeting retranscribes still go through the batch/file lane even
+        // though their telemetry source remains `.meeting`.
         return try await transcribe(
             fileURL: recording.mixedAudioURL,
             storedFileURL: recording.mixedAudioURL,

--- a/Sources/MacParakeetViewModels/MeetingRecordingPanelViewModel.swift
+++ b/Sources/MacParakeetViewModels/MeetingRecordingPanelViewModel.swift
@@ -15,13 +15,18 @@ public final class MeetingRecordingPanelViewModel {
     public var micLevel: Float = 0
     public var systemLevel: Float = 0
     public var previewLines: [MeetingRecordingPreviewLine] = []
+    public var isTranscriptionLagging: Bool = false
     public var onStop: (() -> Void)?
     public var onClose: (() -> Void)?
 
     public init() {}
 
-    public func updatePreviewLines(_ lines: [MeetingRecordingPreviewLine]) {
+    public func updatePreviewLines(
+        _ lines: [MeetingRecordingPreviewLine],
+        isTranscriptionLagging: Bool = false
+    ) {
         previewLines = lines
+        self.isTranscriptionLagging = isTranscriptionLagging
     }
 
     public func reset() {
@@ -30,6 +35,7 @@ public final class MeetingRecordingPanelViewModel {
         micLevel = 0
         systemLevel = 0
         previewLines = []
+        isTranscriptionLagging = false
     }
 
     public var formattedElapsed: String {
@@ -59,12 +65,22 @@ public final class MeetingRecordingPanelViewModel {
     public var statusMessage: String {
         switch state {
         case .hidden, .recording:
+            if isTranscriptionLagging {
+                return "Live transcript preview is catching up. The final transcript will still include the full meeting."
+            }
             return "Live transcript preview updates while the flower pill stays pinned."
         case .transcribing:
             return "Meeting audio is being transcribed and saved to your library."
         case .error(let message):
             return message
         }
+    }
+
+    public var showsLaggingIndicator: Bool {
+        if case .recording = state {
+            return isTranscriptionLagging
+        }
+        return false
     }
 
     public var showsElapsedTime: Bool {

--- a/Sources/MacParakeetViewModels/OnboardingViewModel.swift
+++ b/Sources/MacParakeetViewModels/OnboardingViewModel.swift
@@ -63,6 +63,7 @@ public final class OnboardingViewModel {
     private var warmUpObserverTask: Task<Void, Never>?
     private var warmUpObserverId: UUID?
     private let requiredFirstSetupDiskBytes: Int64 = 7 * 1_024 * 1_024 * 1_024
+    private let requiredDiarizationSetupDiskBytes: Int64 = 512 * 1_024 * 1_024
 
     public static let onboardingCompletedKey = "onboarding.completedAtISO"
 
@@ -277,6 +278,7 @@ public final class OnboardingViewModel {
 
     private func prepareDiarizationModelsIfNeeded(generation: Int) async throws {
         guard let diarizationService else { return }
+        guard await diarizationService.isReady() == false else { return }
 
         engineState = .working(message: "Speaker models: downloading...", progress: nil)
         do {
@@ -322,24 +324,46 @@ public final class OnboardingViewModel {
             throw STTError.engineStartFailed("Local model runtime requires Apple Silicon with Metal support.")
         }
 
-        // Only gate on network/disk if the model still needs downloading.
-        // If the model is already cached, skip preflight regardless of onboarding state
-        // (e.g. user reset onboarding while offline — no download needed).
-        guard !isSpeechModelCached() else { return }
+        let speechModelCached = isSpeechModelCached()
+        let diarizationAssetsReady = await areDiarizationAssetsReadyForOnboarding()
+
+        guard !speechModelCached || !diarizationAssetsReady else { return }
+
+        let (requiredDiskBytes, setupLabel, networkRequirement) =
+            if speechModelCached {
+                (
+                    requiredDiarizationSetupDiskBytes,
+                    "speaker-model setup",
+                    "Internet connection is required to download speaker models. Check your network and retry."
+                )
+            } else {
+                (
+                    requiredFirstSetupDiskBytes,
+                    "first-time speech model setup",
+                    "Internet connection is required for first-time model download. Check your network and retry."
+                )
+            }
 
         guard let freeBytes = availableDiskBytes() else {
-            throw STTError.engineStartFailed("Unable to determine free disk space. Verify at least \(Self.formatGiB(requiredFirstSetupDiskBytes)) is available, then retry.")
+            throw STTError.engineStartFailed(
+                "Unable to determine free disk space. Verify at least \(Self.formatGiB(requiredDiskBytes)) is available for \(setupLabel), then retry."
+            )
         }
 
-        guard freeBytes >= requiredFirstSetupDiskBytes else {
+        guard freeBytes >= requiredDiskBytes else {
             throw STTError.engineStartFailed(
-                "Not enough free disk space for first-time model setup. Need at least \(Self.formatGiB(requiredFirstSetupDiskBytes)) (available: \(Self.formatGiB(freeBytes)))."
+                "Not enough free disk space for \(setupLabel). Need at least \(Self.formatGiB(requiredDiskBytes)) (available: \(Self.formatGiB(freeBytes)))."
             )
         }
 
         guard await isNetworkReachable() else {
-            throw STTError.engineStartFailed("Internet connection is required for first-time model download. Check your network and retry.")
+            throw STTError.engineStartFailed(networkRequirement)
         }
+    }
+
+    private func areDiarizationAssetsReadyForOnboarding() async -> Bool {
+        guard let diarizationService else { return true }
+        return await diarizationService.hasCachedModels()
     }
 
     private nonisolated static func formatGiB(_ bytes: Int64) -> String {

--- a/Sources/MacParakeetViewModels/OnboardingViewModel.swift
+++ b/Sources/MacParakeetViewModels/OnboardingViewModel.swift
@@ -62,6 +62,7 @@ public final class OnboardingViewModel {
     private var refreshTask: Task<Void, Never>?
     private var warmUpObserverTask: Task<Void, Never>?
     private var warmUpObserverId: UUID?
+    private var warmUpObservationToken: UUID?
     private let requiredFirstSetupDiskBytes: Int64 = 7 * 1_024 * 1_024 * 1_024
     private let requiredDiarizationSetupDiskBytes: Int64 = 512 * 1_024 * 1_024
 
@@ -202,74 +203,81 @@ public final class OnboardingViewModel {
 
         engineGeneration += 1
         let generation = engineGeneration
+        let observationToken = UUID()
         isBusy = true
         engineState = .working(message: "Checking setup requirements...", progress: nil)
+        warmUpObservationToken = observationToken
 
         // Assign the outer Task immediately so re-entrant calls hit the
         // `warmUpObserverTask != nil` guard. Without this, the two `await`
         // actor hops below leave a window where a second call can proceed.
-        let outerTask = Task { [weak self] in
+        let outerTask = Task { @MainActor [weak self] in
             guard let self else { return }
+            let clearObservationIfCurrent = { [weak self] (observerId: UUID?) in
+                guard let self, self.warmUpObservationToken == observationToken else { return }
+                self.warmUpObserverTask = nil
+                self.warmUpObserverId = nil
+                self.warmUpObservationToken = nil
+                if let observerId {
+                    Task { [sttClient] in await sttClient.removeWarmUpObserver(id: observerId) }
+                }
+            }
+
             do {
                 try await runEnginePreflight()
-                guard self.engineGeneration == generation else { return }
+                guard self.engineGeneration == generation, self.warmUpObservationToken == observationToken else { return }
             } catch {
-                await MainActor.run {
-                    guard self.engineGeneration == generation else { return }
-                    self.engineState = .failed(message: error.localizedDescription)
-                    self.isBusy = false
-                }
+                guard self.engineGeneration == generation, self.warmUpObservationToken == observationToken else { return }
+                self.engineState = .failed(message: error.localizedDescription)
+                self.isBusy = false
+                clearObservationIfCurrent(nil)
                 return
             }
 
             let warmUpStartedAt = Date()
             Telemetry.send(.modelDownloadStarted)
-            await self.sttClient.backgroundWarmUp()
+            await sttClient.backgroundWarmUp()
+            guard self.engineGeneration == generation, self.warmUpObservationToken == observationToken else { return }
 
             // Subscribe to progress updates
-            let (observerId, stream) = await self.sttClient.observeWarmUpProgress()
-            await MainActor.run {
-                self.warmUpObserverId = observerId
-                self.warmUpObserverTask = Task { @MainActor [weak self] in
-                    // Ensure warmUpObserverTask is cleared when the loop exits
-                    // for any reason (cancellation, stream end, generation mismatch)
-                    // so the guard at the top of startEngineWarmUp() doesn't block
-                    // future calls with a stale completed Task handle.
-                    defer { self?.warmUpObserverTask = nil }
+            let (observerId, stream) = await sttClient.observeWarmUpProgress()
+            guard self.engineGeneration == generation, self.warmUpObservationToken == observationToken else {
+                await sttClient.removeWarmUpObserver(id: observerId)
+                return
+            }
 
-                    for await state in stream {
-                        guard let self, self.engineGeneration == generation else { break }
-                        switch state {
-                        case .idle:
-                            self.engineState = .working(message: "Preparing...", progress: nil)
-                        case .working(let message, let progress):
-                            self.engineState = .working(message: message, progress: progress)
-                        case .ready:
-                            let durationSeconds = Date().timeIntervalSince(warmUpStartedAt)
-                            Telemetry.send(.modelDownloadCompleted(durationSeconds: durationSeconds))
-                            do {
-                                try await self.prepareDiarizationModelsIfNeeded(generation: generation)
-                            } catch is CancellationError {
-                                self.warmUpObserverTask?.cancel()
-                                break
-                            } catch {
-                                guard self.engineGeneration == generation else { break }
-                                self.engineState = .failed(message: error.localizedDescription)
-                                self.isBusy = false
-                                self.warmUpObserverTask?.cancel()
-                                break
-                            }
-                            guard self.engineGeneration == generation else { break }
-                            self.engineState = .ready
-                            self.isBusy = false
-                            self.warmUpObserverTask?.cancel()
-                        case .failed(let message):
-                            Telemetry.send(.modelDownloadFailed(errorType: "BackgroundWarmUpError", errorDetail: message))
-                            self.engineState = .failed(message: message)
-                            self.isBusy = false
-                            self.warmUpObserverTask?.cancel()
-                        }
+            self.warmUpObserverId = observerId
+            defer { clearObservationIfCurrent(observerId) }
+
+            observationLoop: for await state in stream {
+                guard self.engineGeneration == generation, self.warmUpObservationToken == observationToken else { break }
+                switch state {
+                case .idle:
+                    self.engineState = .working(message: "Preparing...", progress: nil)
+                case .working(let message, let progress):
+                    self.engineState = .working(message: message, progress: progress)
+                case .ready:
+                    let durationSeconds = Date().timeIntervalSince(warmUpStartedAt)
+                    Telemetry.send(.modelDownloadCompleted(durationSeconds: durationSeconds))
+                    do {
+                        try await self.prepareDiarizationModelsIfNeeded(generation: generation)
+                    } catch is CancellationError {
+                        break observationLoop
+                    } catch {
+                        guard self.engineGeneration == generation, self.warmUpObservationToken == observationToken else { break observationLoop }
+                        self.engineState = .failed(message: error.localizedDescription)
+                        self.isBusy = false
+                        break observationLoop
                     }
+                    guard self.engineGeneration == generation, self.warmUpObservationToken == observationToken else { break observationLoop }
+                    self.engineState = .ready
+                    self.isBusy = false
+                    break observationLoop
+                case .failed(let message):
+                    Telemetry.send(.modelDownloadFailed(errorType: "BackgroundWarmUpError", errorDetail: message))
+                    self.engineState = .failed(message: message)
+                    self.isBusy = false
+                    break observationLoop
                 }
             }
         }
@@ -301,9 +309,7 @@ public final class OnboardingViewModel {
 
 
     public func retryEngineWarmUp() {
-        warmUpObserverTask?.cancel()
-        warmUpObserverTask = nil
-        warmUpObserverId = nil
+        cancelWarmUpObservation()
         engineState = .idle
         startEngineWarmUp()
     }
@@ -311,6 +317,11 @@ public final class OnboardingViewModel {
     /// Stop observing warm-up progress (e.g., when the window closes).
     /// Does NOT cancel the shared background download.
     public func stopObservingWarmUp() {
+        cancelWarmUpObservation()
+    }
+
+    private func cancelWarmUpObservation() {
+        warmUpObservationToken = nil
         warmUpObserverTask?.cancel()
         warmUpObserverTask = nil
         if let id = warmUpObserverId {

--- a/Sources/MacParakeetViewModels/OnboardingViewModel.swift
+++ b/Sources/MacParakeetViewModels/OnboardingViewModel.swift
@@ -62,7 +62,6 @@ public final class OnboardingViewModel {
     private var refreshTask: Task<Void, Never>?
     private var warmUpObserverTask: Task<Void, Never>?
     private var warmUpObserverId: UUID?
-    private let engineWarmUpAttempts = 3
     private let requiredFirstSetupDiskBytes: Int64 = 7 * 1_024 * 1_024 * 1_024
 
     public static let onboardingCompletedKey = "onboarding.completedAtISO"
@@ -84,7 +83,7 @@ public final class OnboardingViewModel {
         self.isRuntimeSupported = isRuntimeSupported ?? { Self.defaultRuntimeSupportedCheck() }
         self.availableDiskBytes = availableDiskBytes ?? { Self.defaultAvailableDiskBytes() }
         self.isNetworkReachable = isNetworkReachable ?? { await Self.defaultNetworkReachabilityCheck() }
-        self.isSpeechModelCached = isSpeechModelCached ?? { STTClient.isModelCached() }
+        self.isSpeechModelCached = isSpeechModelCached ?? { STTRuntime.isModelCached() }
         self.defaults = defaults
         self.now = now
     }
@@ -222,19 +221,12 @@ public final class OnboardingViewModel {
                 return
             }
 
-            // Start background download on STTClient (survives ViewModel lifecycle)
-            guard let sttClient = self.sttClient as? STTClient else {
-                // Fallback for mock STTClient in tests — use old direct approach
-                await self.startDirectWarmUp(generation: generation)
-                return
-            }
-
             let warmUpStartedAt = Date()
             Telemetry.send(.modelDownloadStarted)
-            await sttClient.backgroundWarmUp()
+            await self.sttClient.backgroundWarmUp()
 
             // Subscribe to progress updates
-            let (observerId, stream) = await sttClient.observeWarmUpProgress()
+            let (observerId, stream) = await self.sttClient.observeWarmUpProgress()
             await MainActor.run {
                 self.warmUpObserverId = observerId
                 self.warmUpObserverTask = Task { @MainActor [weak self] in
@@ -270,81 +262,6 @@ public final class OnboardingViewModel {
         warmUpObserverTask = outerTask
     }
 
-    /// Direct warm-up for mock STTClient in tests (no backgroundWarmUp support).
-    /// Includes retry logic matching the background path.
-    private func startDirectWarmUp(generation: Int) async {
-        let warmUpStartedAt = Date()
-        do {
-            Telemetry.send(.modelDownloadStarted)
-            await MainActor.run {
-                guard self.engineGeneration == generation else { return }
-                self.engineState = .working(
-                    message: "Downloading speech model (~6 GB). This is a one-time download...",
-                    progress: nil
-                )
-            }
-
-            try await runWithRetry(maxAttempts: engineWarmUpAttempts, onRetry: { [weak self] attempt in
-                guard let self, self.engineGeneration == generation else { return }
-                self.engineState = .working(
-                    message: "Retrying speech model setup (attempt \(attempt)/\(self.engineWarmUpAttempts))...",
-                    progress: nil
-                )
-            }) {
-                guard self.engineGeneration == generation else { throw CancellationError() }
-                try await self.sttClient.warmUp { [weak self] progressMessage in
-                    Task { @MainActor [weak self] in
-                        guard let self, self.engineGeneration == generation else { return }
-                        let message = "Speech model: \(progressMessage)"
-                        let fraction = OnboardingProgressParser.parseProgressFraction(from: message)
-                        self.engineState = .working(message: message, progress: fraction)
-                    }
-                }
-            }
-
-            let loadTimeSeconds = Date().timeIntervalSince(warmUpStartedAt)
-            Telemetry.send(.modelDownloadCompleted(durationSeconds: loadTimeSeconds))
-
-            // Prepare diarization models (non-fatal)
-            if let diarizationService = self.diarizationService {
-                await MainActor.run {
-                    guard self.engineGeneration == generation else { return }
-                    self.engineState = .working(message: "Speaker models: downloading...", progress: nil)
-                }
-                do {
-                    try await diarizationService.prepareModels(onProgress: { [weak self] msg in
-                        Task { @MainActor [weak self] in
-                            guard let self, self.engineGeneration == generation else { return }
-                            self.engineState = .working(message: "Speaker models: \(msg)", progress: nil)
-                        }
-                    })
-                } catch {
-                    logger.error("diarization_model_prep_failed error=\(error.localizedDescription, privacy: .public)")
-                    Telemetry.send(.errorOccurred(
-                        domain: "diarization",
-                        code: "model_prep_failed",
-                        description: TelemetryErrorClassifier.errorDetail(error)
-                    ))
-                }
-            }
-
-            await MainActor.run {
-                guard self.engineGeneration == generation else { return }
-                self.engineState = .ready
-                self.isBusy = false
-            }
-        } catch is CancellationError {
-            // cancelled
-        } catch {
-            Telemetry.send(.modelDownloadFailed(errorType: TelemetryErrorClassifier.classify(error), errorDetail: TelemetryErrorClassifier.errorDetail(error)))
-            await MainActor.run {
-                guard self.engineGeneration == generation else { return }
-                self.engineState = .failed(message: error.localizedDescription)
-                self.isBusy = false
-            }
-        }
-    }
-
 
     public func retryEngineWarmUp() {
         warmUpObserverTask?.cancel()
@@ -355,41 +272,14 @@ public final class OnboardingViewModel {
     }
 
     /// Stop observing warm-up progress (e.g., when the window closes).
-    /// Does NOT cancel the background download on STTClient.
+    /// Does NOT cancel the shared background download.
     public func stopObservingWarmUp() {
         warmUpObserverTask?.cancel()
         warmUpObserverTask = nil
-        if let id = warmUpObserverId, let sttClient = sttClient as? STTClient {
-            Task { await sttClient.removeWarmUpObserver(id: id) }
+        if let id = warmUpObserverId {
+            Task { [sttClient] in await sttClient.removeWarmUpObserver(id: id) }
         }
         warmUpObserverId = nil
-    }
-
-    private func runWithRetry(
-        maxAttempts: Int,
-        onRetry: @escaping (_ attempt: Int) -> Void,
-        operation: @escaping () async throws -> Void
-    ) async throws {
-        precondition(maxAttempts >= 1, "maxAttempts must be >= 1")
-
-        var backoffNs: UInt64 = 250_000_000
-        var lastError: Error?
-
-        for attempt in 1...maxAttempts {
-            do {
-                try await operation()
-                return
-            } catch {
-                lastError = error
-                guard attempt < maxAttempts else { break }
-                let nextAttempt = attempt + 1
-                onRetry(nextAttempt)
-                try await Task.sleep(nanoseconds: backoffNs)
-                backoffNs *= 2
-            }
-        }
-
-        throw lastError ?? STTError.engineStartFailed("Local model warm-up failed.")
     }
 
     private func runEnginePreflight() async throws {

--- a/Sources/MacParakeetViewModels/OnboardingViewModel.swift
+++ b/Sources/MacParakeetViewModels/OnboardingViewModel.swift
@@ -246,7 +246,18 @@ public final class OnboardingViewModel {
                         case .ready:
                             let durationSeconds = Date().timeIntervalSince(warmUpStartedAt)
                             Telemetry.send(.modelDownloadCompleted(durationSeconds: durationSeconds))
-                            await self.prepareDiarizationModelsIfNeeded(generation: generation)
+                            do {
+                                try await self.prepareDiarizationModelsIfNeeded(generation: generation)
+                            } catch is CancellationError {
+                                self.warmUpObserverTask?.cancel()
+                                break
+                            } catch {
+                                guard self.engineGeneration == generation else { break }
+                                self.engineState = .failed(message: error.localizedDescription)
+                                self.isBusy = false
+                                self.warmUpObserverTask?.cancel()
+                                break
+                            }
                             guard self.engineGeneration == generation else { break }
                             self.engineState = .ready
                             self.isBusy = false
@@ -264,7 +275,7 @@ public final class OnboardingViewModel {
         warmUpObserverTask = outerTask
     }
 
-    private func prepareDiarizationModelsIfNeeded(generation: Int) async {
+    private func prepareDiarizationModelsIfNeeded(generation: Int) async throws {
         guard let diarizationService else { return }
 
         engineState = .working(message: "Speaker models: downloading...", progress: nil)
@@ -282,6 +293,7 @@ public final class OnboardingViewModel {
                 code: "model_prep_failed",
                 description: TelemetryErrorClassifier.errorDetail(error)
             ))
+            throw error
         }
     }
 

--- a/Sources/MacParakeetViewModels/OnboardingViewModel.swift
+++ b/Sources/MacParakeetViewModels/OnboardingViewModel.swift
@@ -246,6 +246,8 @@ public final class OnboardingViewModel {
                         case .ready:
                             let durationSeconds = Date().timeIntervalSince(warmUpStartedAt)
                             Telemetry.send(.modelDownloadCompleted(durationSeconds: durationSeconds))
+                            await self.prepareDiarizationModelsIfNeeded(generation: generation)
+                            guard self.engineGeneration == generation else { break }
                             self.engineState = .ready
                             self.isBusy = false
                             self.warmUpObserverTask?.cancel()
@@ -260,6 +262,27 @@ public final class OnboardingViewModel {
             }
         }
         warmUpObserverTask = outerTask
+    }
+
+    private func prepareDiarizationModelsIfNeeded(generation: Int) async {
+        guard let diarizationService else { return }
+
+        engineState = .working(message: "Speaker models: downloading...", progress: nil)
+        do {
+            try await diarizationService.prepareModels(onProgress: { [weak self] message in
+                Task { @MainActor [weak self] in
+                    guard let self, self.engineGeneration == generation else { return }
+                    self.engineState = .working(message: "Speaker models: \(message)", progress: nil)
+                }
+            })
+        } catch {
+            logger.error("diarization_model_prep_failed error=\(error.localizedDescription, privacy: .public)")
+            Telemetry.send(.errorOccurred(
+                domain: "diarization",
+                code: "model_prep_failed",
+                description: TelemetryErrorClassifier.errorDetail(error)
+            ))
+        }
     }
 
 

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -194,7 +194,7 @@ public final class SettingsViewModel {
     public init(
         defaults: UserDefaults = .standard,
         youtubeDownloadsDirPath: @escaping @Sendable () -> String = { AppPaths.youtubeDownloadsDir },
-        isSpeechModelCached: @escaping @Sendable () -> Bool = { STTClient.isModelCached() }
+        isSpeechModelCached: @escaping @Sendable () -> Bool = { STTRuntime.isModelCached() }
     ) {
         self.defaults = defaults
         self.youtubeDownloadsDirPath = youtubeDownloadsDirPath

--- a/Tests/CLITests/ModelLifecycleCommandTests.swift
+++ b/Tests/CLITests/ModelLifecycleCommandTests.swift
@@ -54,7 +54,11 @@ private actor StubSTTClient: STTClientProtocol {
         failuresBeforeSuccess = max(0, count)
     }
 
-    func transcribe(audioPath: String, onProgress: (@Sendable (Int, Int) -> Void)?) async throws -> STTResult {
+    func transcribe(
+        audioPath: String,
+        job: STTJobKind,
+        onProgress: (@Sendable (Int, Int) -> Void)?
+    ) async throws -> STTResult {
         STTResult(text: "", words: [])
     }
 
@@ -69,6 +73,18 @@ private actor StubSTTClient: STTClientProtocol {
         }
         ready = true
     }
+
+    func backgroundWarmUp() async {}
+
+    func observeWarmUpProgress() async -> (id: UUID, stream: AsyncStream<STTWarmUpState>) {
+        let stream = AsyncStream<STTWarmUpState> { continuation in
+            continuation.yield(ready ? .ready : .idle)
+            continuation.finish()
+        }
+        return (UUID(), stream)
+    }
+
+    func removeWarmUpObserver(id: UUID) async {}
 
     func isReady() async -> Bool {
         ready

--- a/Tests/CLITests/ModelLifecycleCommandTests.swift
+++ b/Tests/CLITests/ModelLifecycleCommandTests.swift
@@ -23,12 +23,14 @@ final class ModelLifecycleCommandTests: XCTestCase {
 
     func testWarmUpRetriesConfiguredAttempts() async {
         let stt = StubSTTClient()
+        let diarization = StubDiarizationService()
         await stt.setFailuresBeforeSuccess(2)
 
         do {
-            try await warmUpModels(
+            try await prepareSpeechStack(
                 attempts: 3,
                 sttClient: stt,
+                diarizationService: diarization,
                 log: { _ in }
             )
         } catch {
@@ -37,6 +39,33 @@ final class ModelLifecycleCommandTests: XCTestCase {
 
         let sttCalls = await stt.warmUpCalls
         XCTAssertEqual(sttCalls, 3)
+        let diarizationCalls = await diarization.prepareModelsCalls
+        XCTAssertEqual(diarizationCalls, 1)
+    }
+
+    func testLoadSpeechStackStatusReflectsSpeechAndSpeakerReadinessSeparately() async {
+        let stt = StubSTTClient()
+        let diarization = StubDiarizationService()
+        await stt.setReady(true)
+        await diarization.setCachedModels(false)
+        await diarization.setReady(false)
+
+        let status = await loadSpeechStackStatus(
+            sttClient: stt,
+            diarizationService: diarization,
+            isSpeechModelCached: { true }
+        )
+
+        XCTAssertEqual(
+            status,
+            SpeechStackStatus(
+                speechModelCached: true,
+                speechRuntimeReady: true,
+                speakerModelsCached: false,
+                speakerModelsPrepared: false
+            )
+        )
+        XCTAssertEqual(status.summary, "Speech model present, speaker models missing")
     }
 }
 
@@ -52,6 +81,10 @@ private actor StubSTTClient: STTClientProtocol {
 
     func setFailuresBeforeSuccess(_ count: Int) {
         failuresBeforeSuccess = max(0, count)
+    }
+
+    func setReady(_ value: Bool) {
+        ready = value
     }
 
     func transcribe(
@@ -95,4 +128,37 @@ private actor StubSTTClient: STTClientProtocol {
     }
 
     func shutdown() async {}
+}
+
+private actor StubDiarizationService: DiarizationServiceProtocol {
+    private(set) var prepareModelsCalls = 0
+    private var ready = false
+    private var cachedModels = false
+
+    func setReady(_ value: Bool) {
+        ready = value
+    }
+
+    func setCachedModels(_ value: Bool) {
+        cachedModels = value
+    }
+
+    func diarize(audioURL: URL) async throws -> MacParakeetDiarizationResult {
+        MacParakeetDiarizationResult(segments: [], speakerCount: 0, speakers: [])
+    }
+
+    func prepareModels(onProgress: (@Sendable (String) -> Void)?) async throws {
+        prepareModelsCalls += 1
+        ready = true
+        cachedModels = true
+        onProgress?("Speaker models ready")
+    }
+
+    func isReady() async -> Bool {
+        ready
+    }
+
+    func hasCachedModels() async -> Bool {
+        cachedModels
+    }
 }

--- a/Tests/MacParakeetTests/Integration/CancelFlowTests.swift
+++ b/Tests/MacParakeetTests/Integration/CancelFlowTests.swift
@@ -18,7 +18,7 @@ final class CancelFlowTests: XCTestCase {
 
         dictationService = DictationService(
             audioProcessor: mockAudio,
-            sttClient: mockSTT,
+            sttTranscriber: mockSTT,
             dictationRepo: dictationRepo
         )
     }

--- a/Tests/MacParakeetTests/Integration/DictationFlowTests.swift
+++ b/Tests/MacParakeetTests/Integration/DictationFlowTests.swift
@@ -15,7 +15,7 @@ final class DictationFlowTests: XCTestCase {
 
         dictationService = DictationService(
             audioProcessor: mockAudio,
-            sttClient: mockSTT,
+            sttTranscriber: mockSTT,
             dictationRepo: dictationRepo
         )
     }

--- a/Tests/MacParakeetTests/Integration/TranscriptionFlowTests.swift
+++ b/Tests/MacParakeetTests/Integration/TranscriptionFlowTests.swift
@@ -18,7 +18,7 @@ final class TranscriptionFlowTests: XCTestCase {
 
         transcriptionService = TranscriptionService(
             audioProcessor: mockAudio,
-            sttClient: mockSTT,
+            sttTranscriber: mockSTT,
             transcriptionRepo: transcriptionRepo
         )
     }

--- a/Tests/MacParakeetTests/STT/MockSTTClient.swift
+++ b/Tests/MacParakeetTests/STT/MockSTTClient.swift
@@ -78,42 +78,31 @@ public actor MockSTTClient: STTClientProtocol {
     }
 
     public func backgroundWarmUp() async {
+        if case .ready = warmUpState { return }
         if backgroundWarmUpTask != nil { return }
         prepareWarmUpStateForRetry()
         setWarmUpState(.working(message: "Checking setup requirements...", progress: nil))
 
         backgroundWarmUpTask = Task { [weak self] in
             guard let self else { return }
-            let maxAttempts = 3
-            var attempt = 1
-            while attempt <= maxAttempts {
-                do {
-                    try await self.warmUp { [weak self] progressMessage in
-                        Task {
-                            await self?.setWarmUpState(
-                                .working(
-                                    message: "Speech model: \(progressMessage)",
-                                    progress: OnboardingProgressParser.parseProgressFraction(
-                                        from: "Speech model: \(progressMessage)"
-                                    )
+            do {
+                try await self.warmUp { [weak self] progressMessage in
+                    Task {
+                        await self?.setWarmUpState(
+                            .working(
+                                message: "Speech model: \(progressMessage)",
+                                progress: OnboardingProgressParser.parseProgressFraction(
+                                    from: "Speech model: \(progressMessage)"
                                 )
                             )
-                        }
+                        )
                     }
-                    await self.setWarmUpState(.ready)
-                    await self.clearBackgroundWarmUpTask()
-                    return
-                } catch {
-                    if attempt == maxAttempts {
-                        await self.setWarmUpState(.failed(message: error.localizedDescription))
-                        break
-                    }
-                    attempt += 1
-                    await self.setWarmUpState(
-                        .working(message: "Retrying speech model setup (attempt \(attempt)/\(maxAttempts))...", progress: nil)
-                    )
-                    try? await Task.sleep(for: .milliseconds(250))
                 }
+                await self.setWarmUpState(.ready)
+            } catch is CancellationError {
+                // Match STTRuntime: cancellation does not mutate the shared state machine.
+            } catch {
+                await self.setWarmUpState(.failed(message: error.localizedDescription))
             }
             await self.clearBackgroundWarmUpTask()
         }
@@ -134,7 +123,7 @@ public actor MockSTTClient: STTClientProtocol {
     }
 
     public func removeWarmUpObserver(id: UUID) async {
-        warmUpObservers.removeValue(forKey: id)
+        warmUpObservers.removeValue(forKey: id)?.finish()
     }
 
     public func wasWarmUpCalled() -> Bool {

--- a/Tests/MacParakeetTests/STT/MockSTTClient.swift
+++ b/Tests/MacParakeetTests/STT/MockSTTClient.swift
@@ -79,13 +79,14 @@ public actor MockSTTClient: STTClientProtocol {
 
     public func backgroundWarmUp() async {
         if backgroundWarmUpTask != nil { return }
+        prepareWarmUpStateForRetry()
+        setWarmUpState(.working(message: "Checking setup requirements...", progress: nil))
 
         backgroundWarmUpTask = Task { [weak self] in
             guard let self else { return }
             let maxAttempts = 3
             var attempt = 1
             while attempt <= maxAttempts {
-                await self.setWarmUpState(.working(message: "Checking setup requirements...", progress: nil))
                 do {
                     try await self.warmUp { [weak self] progressMessage in
                         Task {
@@ -158,6 +159,12 @@ public actor MockSTTClient: STTClientProtocol {
 
     public func shutdown() async {
         shutdownCalled = true
+    }
+
+    private func prepareWarmUpStateForRetry() {
+        if case .failed = warmUpState {
+            warmUpState = .idle
+        }
     }
 
     private func setWarmUpState(_ state: STTWarmUpState) {

--- a/Tests/MacParakeetTests/STT/MockSTTClient.swift
+++ b/Tests/MacParakeetTests/STT/MockSTTClient.swift
@@ -6,6 +6,7 @@ public actor MockSTTClient: STTClientProtocol {
     public var transcribeError: Error?
     public var transcribeCallCount = 0
     public var lastAudioPath: String?
+    public var lastJob: STTJobKind?
     public var warmUpCalled = false
     public var warmUpCallCount = 0
     public var warmUpError: Error?
@@ -13,6 +14,9 @@ public actor MockSTTClient: STTClientProtocol {
     public var warmUpProgressPhases: [String]?
     public var clearModelCacheCalled = false
     public var shutdownCalled = false
+    private var warmUpState: STTWarmUpState = .idle
+    private var warmUpObservers: [UUID: AsyncStream<STTWarmUpState>.Continuation] = [:]
+    private var backgroundWarmUpTask: Task<Void, Never>?
 
     public init() {}
 
@@ -35,9 +39,14 @@ public actor MockSTTClient: STTClientProtocol {
         self.warmUpFailuresBeforeSuccess = max(0, count)
     }
 
-    public func transcribe(audioPath: String, onProgress: (@Sendable (Int, Int) -> Void)? = nil) async throws -> STTResult {
+    public func transcribe(
+        audioPath: String,
+        job: STTJobKind,
+        onProgress: (@Sendable (Int, Int) -> Void)? = nil
+    ) async throws -> STTResult {
         transcribeCallCount += 1
         lastAudioPath = audioPath
+        lastJob = job
 
         if let error = transcribeError {
             throw error
@@ -68,6 +77,65 @@ public actor MockSTTClient: STTClientProtocol {
         ready = true
     }
 
+    public func backgroundWarmUp() async {
+        if backgroundWarmUpTask != nil { return }
+
+        backgroundWarmUpTask = Task { [weak self] in
+            guard let self else { return }
+            let maxAttempts = 3
+            var attempt = 1
+            while attempt <= maxAttempts {
+                await self.setWarmUpState(.working(message: "Checking setup requirements...", progress: nil))
+                do {
+                    try await self.warmUp { [weak self] progressMessage in
+                        Task {
+                            await self?.setWarmUpState(
+                                .working(
+                                    message: "Speech model: \(progressMessage)",
+                                    progress: OnboardingProgressParser.parseProgressFraction(
+                                        from: "Speech model: \(progressMessage)"
+                                    )
+                                )
+                            )
+                        }
+                    }
+                    await self.setWarmUpState(.ready)
+                    await self.clearBackgroundWarmUpTask()
+                    return
+                } catch {
+                    if attempt == maxAttempts {
+                        await self.setWarmUpState(.failed(message: error.localizedDescription))
+                        break
+                    }
+                    attempt += 1
+                    await self.setWarmUpState(
+                        .working(message: "Retrying speech model setup (attempt \(attempt)/\(maxAttempts))...", progress: nil)
+                    )
+                    try? await Task.sleep(for: .milliseconds(250))
+                }
+            }
+            await self.clearBackgroundWarmUpTask()
+        }
+    }
+
+    public func observeWarmUpProgress() async -> (id: UUID, stream: AsyncStream<STTWarmUpState>) {
+        let id = UUID()
+        let stream = AsyncStream<STTWarmUpState> { continuation in
+            continuation.yield(warmUpState)
+            warmUpObservers[id] = continuation
+            continuation.onTermination = { @Sendable _ in
+                Task { [weak self] in
+                    await self?.removeWarmUpObserver(id: id)
+                }
+            }
+        }
+        return (id, stream)
+    }
+
+    public func removeWarmUpObserver(id: UUID) async {
+        warmUpObservers.removeValue(forKey: id)
+    }
+
     public func wasWarmUpCalled() -> Bool {
         warmUpCalled
     }
@@ -85,9 +153,29 @@ public actor MockSTTClient: STTClientProtocol {
     public func clearModelCache() async {
         clearModelCacheCalled = true
         ready = false
+        setWarmUpState(.idle)
     }
 
     public func shutdown() async {
         shutdownCalled = true
+    }
+
+    private func setWarmUpState(_ state: STTWarmUpState) {
+        if case .working = state {
+            switch warmUpState {
+            case .ready, .failed:
+                return
+            default:
+                break
+            }
+        }
+        warmUpState = state
+        for (_, observer) in warmUpObservers {
+            observer.yield(state)
+        }
+    }
+
+    private func clearBackgroundWarmUpTask() {
+        backgroundWarmUpTask = nil
     }
 }

--- a/Tests/MacParakeetTests/STT/STTClientTests.swift
+++ b/Tests/MacParakeetTests/STT/STTClientTests.swift
@@ -37,7 +37,7 @@ final class STTClientTests: XCTestCase {
         let expectedResult = STTResult(text: "Hello from mock")
         await mock.configure(result: expectedResult)
 
-        let result = try await mock.transcribe(audioPath: "/tmp/test.wav")
+        let result = try await mock.transcribe(audioPath: "/tmp/test.wav", job: .fileTranscription)
         XCTAssertEqual(result.text, "Hello from mock")
 
         let callCount = await mock.transcribeCallCount
@@ -52,7 +52,7 @@ final class STTClientTests: XCTestCase {
         await mock.configure(error: STTError.transcriptionFailed("test error"))
 
         do {
-            _ = try await mock.transcribe(audioPath: "/tmp/test.wav")
+            _ = try await mock.transcribe(audioPath: "/tmp/test.wav", job: .fileTranscription)
             XCTFail("Should have thrown")
         } catch let error as STTError {
             if case .transcriptionFailed(let reason) = error {

--- a/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
+++ b/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import MacParakeetCore
 
 final class STTSchedulerTests: XCTestCase {
-    func testDictationRunsWhileMeetingLaneIsBusy() async throws {
+    func testDictationRunsWhileBackgroundSlotIsBusy() async throws {
         let runtime = MockSTTRuntime()
         await runtime.block(path: "meeting-live")
         let scheduler = STTScheduler(runtimeProvider: runtime, meetingLiveChunkBacklogLimit: 8)
@@ -25,7 +25,7 @@ final class STTSchedulerTests: XCTestCase {
         _ = try await meetingTask.value
     }
 
-    func testMeetingFinalizeRunsWhileBatchLaneIsBusy() async throws {
+    func testMeetingFinalizeWaitsBehindRunningFileTranscriptionOnSharedBackgroundSlot() async throws {
         let runtime = MockSTTRuntime()
         await runtime.block(path: "file")
         let scheduler = STTScheduler(runtimeProvider: runtime, meetingLiveChunkBacklogLimit: 8)
@@ -38,17 +38,20 @@ final class STTSchedulerTests: XCTestCase {
         let finalizeTask = Task {
             try await scheduler.transcribe(audioPath: "meeting-finalize", job: .meetingFinalize)
         }
-        try await waitForStartedPaths(runtime: runtime, count: 2)
+        try await Task.sleep(for: .milliseconds(100))
 
         let startedWhileFileBlocked = await runtime.startedPaths()
-        XCTAssertEqual(startedWhileFileBlocked, ["file", "meeting-finalize"])
+        XCTAssertEqual(startedWhileFileBlocked, ["file"])
 
-        _ = try await finalizeTask.value
         await runtime.release(path: "file")
         _ = try await fileTask.value
+        _ = try await finalizeTask.value
+
+        let finalStartedPaths = await runtime.startedPaths()
+        XCTAssertEqual(finalStartedPaths, ["file", "meeting-finalize"])
     }
 
-    func testMeetingFinalizeBeatsQueuedMeetingLiveChunkWithinMeetingLane() async throws {
+    func testMeetingFinalizeBeatsQueuedMeetingLiveChunkWithinBackgroundSlot() async throws {
         let runtime = MockSTTRuntime()
         await runtime.block(path: "seed")
         let scheduler = STTScheduler(runtimeProvider: runtime, meetingLiveChunkBacklogLimit: 8)
@@ -75,6 +78,33 @@ final class STTSchedulerTests: XCTestCase {
         XCTAssertEqual(finalStartedPaths, ["seed", "meeting-finalize", "live"])
     }
 
+    func testMeetingFinalizeBeatsQueuedFileTranscriptionWithinBackgroundSlot() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.block(path: "seed")
+        let scheduler = STTScheduler(runtimeProvider: runtime, meetingLiveChunkBacklogLimit: 8)
+
+        let seedTask = Task { try await scheduler.transcribe(audioPath: "seed", job: .meetingLiveChunk) }
+        try await waitForStartedPaths(runtime: runtime, count: 1)
+
+        let fileTask = Task { try await scheduler.transcribe(audioPath: "file", job: .fileTranscription) }
+        let finalizeTask = Task {
+            try await scheduler.transcribe(audioPath: "meeting-finalize", job: .meetingFinalize)
+        }
+
+        try await Task.sleep(for: .milliseconds(100))
+        let startedWhileSeedBlocked = await runtime.startedPaths()
+        XCTAssertEqual(startedWhileSeedBlocked, ["seed"])
+
+        await runtime.release(path: "seed")
+
+        _ = try await seedTask.value
+        _ = try await finalizeTask.value
+        _ = try await fileTask.value
+
+        let finalStartedPaths = await runtime.startedPaths()
+        XCTAssertEqual(finalStartedPaths, ["seed", "meeting-finalize", "file"])
+    }
+
     func testLifecycleOperationsTargetSharedRuntime() async throws {
         let runtime = MockSTTRuntime()
         let scheduler = STTScheduler(runtimeProvider: runtime)
@@ -91,7 +121,7 @@ final class STTSchedulerTests: XCTestCase {
         XCTAssertEqual(counts.shutdown, 1)
     }
 
-    func testProgressIsScopedPerJobAcrossLanes() async throws {
+    func testProgressIsScopedPerJobAcrossSlots() async throws {
         let runtime = MockSTTRuntime()
         await runtime.setProgressScript([10, 50], for: "file")
         await runtime.setProgressScript([20, 80], for: "dictation")
@@ -197,13 +227,13 @@ final class STTSchedulerTests: XCTestCase {
         await runtime.block(path: "active")
         let scheduler = STTScheduler(runtimeProvider: runtime, meetingLiveChunkBacklogLimit: 8)
 
-        // Start an active job in the meeting lane.
+        // Start an active job in the shared background slot.
         let activeTask = Task {
             try await scheduler.transcribe(audioPath: "active", job: .meetingLiveChunk)
         }
         try await waitForStartedPaths(runtime: runtime, count: 1)
 
-        // Queue a pending job behind it in the same lane.
+        // Queue a pending job behind it in the same slot.
         let pendingTask = Task {
             try await scheduler.transcribe(audioPath: "pending", job: .meetingLiveChunk)
         }
@@ -237,13 +267,13 @@ final class STTSchedulerTests: XCTestCase {
         await runtime.block(path: "blocker")
         let scheduler = STTScheduler(runtimeProvider: runtime, meetingLiveChunkBacklogLimit: 8)
 
-        // Block the batch lane with a long-running job.
+        // Block the shared background slot with a long-running file job.
         let blockerTask = Task {
             try await scheduler.transcribe(audioPath: "blocker", job: .fileTranscription)
         }
         try await waitForStartedPaths(runtime: runtime, count: 1)
 
-        // Queue a second job in the same lane — it will be pending.
+        // Queue a second job in the same slot — it will be pending.
         let pendingTask = Task {
             try await scheduler.transcribe(audioPath: "queued", job: .fileTranscription)
         }

--- a/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
+++ b/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
@@ -1,0 +1,258 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class STTSchedulerTests: XCTestCase {
+    func testDictationBeatsQueuedMeetingLiveChunk() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.block(path: "seed")
+        let scheduler = STTScheduler(runtimeProvider: runtime, meetingLiveChunkBacklogLimit: 8)
+
+        let seedTask = Task { try await scheduler.transcribe(audioPath: "seed", job: .fileTranscription) }
+        try await waitForStartedPaths(runtime: runtime, count: 1)
+
+        let liveTask = Task { try await scheduler.transcribe(audioPath: "live", job: .meetingLiveChunk) }
+        let dictationTask = Task { try await scheduler.transcribe(audioPath: "dictation", job: .dictation) }
+
+        try await Task.sleep(for: .milliseconds(100))
+        let startedWhileSeedBlocked = await runtime.startedPaths()
+        XCTAssertEqual(startedWhileSeedBlocked, ["seed"])
+
+        await runtime.release(path: "seed")
+
+        _ = try await seedTask.value
+        _ = try await dictationTask.value
+        _ = try await liveTask.value
+
+        let finalStartedPaths = await runtime.startedPaths()
+        XCTAssertEqual(finalStartedPaths, ["seed", "dictation", "live"])
+    }
+
+    func testMeetingFinalizeBeatsQueuedFileTranscription() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.block(path: "seed")
+        let scheduler = STTScheduler(runtimeProvider: runtime, meetingLiveChunkBacklogLimit: 8)
+
+        let seedTask = Task { try await scheduler.transcribe(audioPath: "seed", job: .dictation) }
+        try await waitForStartedPaths(runtime: runtime, count: 1)
+
+        let fileTask = Task { try await scheduler.transcribe(audioPath: "file", job: .fileTranscription) }
+        let finalizeTask = Task { try await scheduler.transcribe(audioPath: "meeting-finalize", job: .meetingFinalize) }
+
+        try await Task.sleep(for: .milliseconds(100))
+        let startedWhileSeedBlocked = await runtime.startedPaths()
+        XCTAssertEqual(startedWhileSeedBlocked, ["seed"])
+
+        await runtime.release(path: "seed")
+
+        _ = try await seedTask.value
+        _ = try await finalizeTask.value
+        _ = try await fileTask.value
+
+        let finalStartedPaths = await runtime.startedPaths()
+        XCTAssertEqual(finalStartedPaths, ["seed", "meeting-finalize", "file"])
+    }
+
+    func testLifecycleOperationsTargetSharedRuntime() async throws {
+        let runtime = MockSTTRuntime()
+        let scheduler = STTScheduler(runtimeProvider: runtime)
+
+        try await scheduler.warmUp()
+        _ = await scheduler.isReady()
+        await scheduler.clearModelCache()
+        await scheduler.shutdown()
+
+        let counts = await runtime.lifecycleCounts()
+        XCTAssertEqual(counts.warmUp, 1)
+        XCTAssertEqual(counts.isReady, 1)
+        XCTAssertEqual(counts.clearModelCache, 1)
+        XCTAssertEqual(counts.shutdown, 1)
+    }
+
+    func testProgressIsScopedPerJob() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.setProgressScript([10, 50], for: "file")
+        await runtime.setProgressScript([20, 80], for: "dictation")
+        await runtime.block(path: "file")
+
+        let scheduler = STTScheduler(runtimeProvider: runtime, meetingLiveChunkBacklogLimit: 8)
+        let fileProgress = ProgressSink()
+        let dictationProgress = ProgressSink()
+
+        let fileTask = Task {
+            try await scheduler.transcribe(audioPath: "file", job: .fileTranscription) { current, _ in
+                fileProgress.record(current)
+            }
+        }
+
+        try await waitForStartedPaths(runtime: runtime, count: 1)
+
+        let dictationTask = Task {
+            try await scheduler.transcribe(audioPath: "dictation", job: .dictation) { current, _ in
+                dictationProgress.record(current)
+            }
+        }
+
+        try await Task.sleep(for: .milliseconds(100))
+        let fileValuesWhileBlocked = fileProgress.currentValues()
+        let dictationValuesWhileBlocked = dictationProgress.currentValues()
+        XCTAssertEqual(fileValuesWhileBlocked, [10, 50])
+        XCTAssertEqual(dictationValuesWhileBlocked, [])
+
+        await runtime.release(path: "file")
+
+        _ = try await fileTask.value
+        _ = try await dictationTask.value
+
+        let finalFileValues = fileProgress.currentValues()
+        let finalDictationValues = dictationProgress.currentValues()
+        XCTAssertEqual(finalFileValues, [10, 50])
+        XCTAssertEqual(finalDictationValues, [20, 80])
+    }
+
+    func testMeetingLiveChunkBackpressureDropsOldestPendingLiveChunk() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.block(path: "seed")
+        let scheduler = STTScheduler(runtimeProvider: runtime, meetingLiveChunkBacklogLimit: 1)
+
+        let seedTask = Task { try await scheduler.transcribe(audioPath: "seed", job: .fileTranscription) }
+        try await waitForStartedPaths(runtime: runtime, count: 1)
+
+        let droppedTask = Task { try await scheduler.transcribe(audioPath: "live-1", job: .meetingLiveChunk) }
+        let survivingTask = Task { try await scheduler.transcribe(audioPath: "live-2", job: .meetingLiveChunk) }
+
+        do {
+            _ = try await droppedTask.value
+            XCTFail("Expected dropped live chunk to fail")
+        } catch let error as STTSchedulerError {
+            XCTAssertEqual(error, .droppedDueToBackpressure(job: .meetingLiveChunk))
+        }
+
+        await runtime.release(path: "seed")
+
+        _ = try await seedTask.value
+        _ = try await survivingTask.value
+
+        let finalStartedPaths = await runtime.startedPaths()
+        XCTAssertEqual(finalStartedPaths, ["seed", "live-2"])
+    }
+
+    private func waitForStartedPaths(
+        runtime: MockSTTRuntime,
+        count: Int,
+        timeout: Duration = .seconds(2)
+    ) async throws {
+        let start = ContinuousClock.now
+        while await runtime.startedPaths().count < count {
+            if start.duration(to: .now) > timeout {
+                XCTFail("Timed out waiting for \(count) started paths")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+    }
+}
+
+private actor MockSTTRuntime: STTRuntimeProtocol {
+    private var blockedPaths: Set<String> = []
+    private var waitingContinuations: [String: CheckedContinuation<Void, Never>] = [:]
+    private var progressScripts: [String: [Int]] = [:]
+    private var started: [String] = []
+
+    private(set) var warmUpCallCount = 0
+    private(set) var isReadyCallCount = 0
+    private(set) var clearModelCacheCallCount = 0
+    private(set) var shutdownCallCount = 0
+    private var ready = false
+
+    func transcribe(
+        audioPath: String,
+        onProgress: (@Sendable (Int, Int) -> Void)?
+    ) async throws -> STTResult {
+        started.append(audioPath)
+
+        if let script = progressScripts[audioPath] {
+            for progress in script {
+                onProgress?(progress, 100)
+            }
+        }
+
+        if blockedPaths.contains(audioPath) {
+            await withCheckedContinuation { continuation in
+                waitingContinuations[audioPath] = continuation
+            }
+        }
+
+        return STTResult(text: audioPath, words: [])
+    }
+
+    func warmUp(onProgress: (@Sendable (String) -> Void)?) async throws {
+        warmUpCallCount += 1
+        ready = true
+        onProgress?("Ready")
+    }
+
+    func backgroundWarmUp() async {}
+
+    func observeWarmUpProgress() async -> (id: UUID, stream: AsyncStream<STTWarmUpState>) {
+        let stream = AsyncStream<STTWarmUpState> { continuation in
+            continuation.yield(ready ? .ready : .idle)
+            continuation.finish()
+        }
+        return (UUID(), stream)
+    }
+
+    func removeWarmUpObserver(id: UUID) async {}
+
+    func isReady() async -> Bool {
+        isReadyCallCount += 1
+        return ready
+    }
+
+    func shutdown() async {
+        shutdownCallCount += 1
+    }
+
+    func clearModelCache() async {
+        clearModelCacheCallCount += 1
+        ready = false
+    }
+
+    func block(path: String) {
+        blockedPaths.insert(path)
+    }
+
+    func release(path: String) {
+        blockedPaths.remove(path)
+        waitingContinuations.removeValue(forKey: path)?.resume()
+    }
+
+    func setProgressScript(_ values: [Int], for path: String) {
+        progressScripts[path] = values
+    }
+
+    func startedPaths() -> [String] {
+        started
+    }
+
+    func lifecycleCounts() -> (warmUp: Int, isReady: Int, clearModelCache: Int, shutdown: Int) {
+        (warmUpCallCount, isReadyCallCount, clearModelCacheCallCount, shutdownCallCount)
+    }
+}
+
+private final class ProgressSink: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [Int] = []
+
+    func record(_ value: Int) {
+        lock.lock()
+        values.append(value)
+        lock.unlock()
+    }
+
+    func currentValues() -> [Int] {
+        lock.lock()
+        let snapshot = values
+        lock.unlock()
+        return snapshot
+    }
+}

--- a/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
+++ b/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
@@ -183,6 +183,33 @@ final class STTSchedulerTests: XCTestCase {
         XCTAssertEqual(finalStartedPaths, ["seed", "live-2"])
     }
 
+    func testMeetingLiveChunkBacklogLimitClampsToAtLeastOne() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.block(path: "seed")
+        let scheduler = STTScheduler(runtimeProvider: runtime, meetingLiveChunkBacklogLimit: 0)
+
+        let seedTask = Task { try await scheduler.transcribe(audioPath: "seed", job: .meetingLiveChunk) }
+        try await waitForStartedPaths(runtime: runtime, count: 1)
+
+        let droppedTask = Task { try await scheduler.transcribe(audioPath: "live-1", job: .meetingLiveChunk) }
+        let survivingTask = Task { try await scheduler.transcribe(audioPath: "live-2", job: .meetingLiveChunk) }
+
+        do {
+            _ = try await droppedTask.value
+            XCTFail("Expected dropped live chunk to fail")
+        } catch let error as STTSchedulerError {
+            XCTAssertEqual(error, .droppedDueToBackpressure(job: .meetingLiveChunk))
+        }
+
+        await runtime.release(path: "seed")
+
+        _ = try await seedTask.value
+        _ = try await survivingTask.value
+
+        let finalStartedPaths = await runtime.startedPaths()
+        XCTAssertEqual(finalStartedPaths, ["seed", "live-2"])
+    }
+
     func testAlreadyCancelledTaskNeverEnqueuesScheduledJob() async throws {
         let runtime = MockSTTRuntime()
         let scheduler = STTScheduler(runtimeProvider: runtime)

--- a/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
+++ b/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
@@ -153,6 +153,45 @@ final class STTSchedulerTests: XCTestCase {
         XCTAssertEqual(finalStartedPaths, ["seed", "live-2"])
     }
 
+    func testAlreadyCancelledTaskNeverEnqueuesScheduledJob() async throws {
+        let runtime = MockSTTRuntime()
+        let scheduler = STTScheduler(runtimeProvider: runtime)
+
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            return try await scheduler.transcribe(audioPath: "cancelled-before-enqueue", job: .fileTranscription)
+        }
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {
+            // Expected.
+        }
+
+        let startedPaths = await runtime.startedPaths()
+        XCTAssertTrue(startedPaths.isEmpty)
+    }
+
+    func testShutdownKeepsSchedulerClosedToNewJobs() async throws {
+        let runtime = MockSTTRuntime()
+        let scheduler = STTScheduler(runtimeProvider: runtime)
+
+        await scheduler.shutdown()
+
+        do {
+            _ = try await scheduler.transcribe(audioPath: "after-shutdown", job: .dictation)
+            XCTFail("Expected scheduler to reject new work after shutdown")
+        } catch let error as STTSchedulerError {
+            XCTAssertEqual(error, .unavailable)
+        }
+
+        let counts = await runtime.lifecycleCounts()
+        XCTAssertEqual(counts.shutdown, 1)
+        let startedPaths = await runtime.startedPaths()
+        XCTAssertTrue(startedPaths.isEmpty)
+    }
+
     private func waitForStartedPaths(
         runtime: MockSTTRuntime,
         count: Int,

--- a/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
+++ b/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
@@ -183,6 +183,7 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
 
     func transcribe(
         audioPath: String,
+        job: STTJobKind,
         onProgress: (@Sendable (Int, Int) -> Void)?
     ) async throws -> STTResult {
         started.append(audioPath)
@@ -199,7 +200,7 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
             }
         }
 
-        return STTResult(text: audioPath, words: [])
+        return STTResult(text: "\(job):\(audioPath)", words: [])
     }
 
     func warmUp(onProgress: (@Sendable (String) -> Void)?) async throws {

--- a/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
+++ b/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
@@ -192,6 +192,83 @@ final class STTSchedulerTests: XCTestCase {
         XCTAssertTrue(startedPaths.isEmpty)
     }
 
+    func testShutdownCancelsActiveAndPendingJobs() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.block(path: "active")
+        let scheduler = STTScheduler(runtimeProvider: runtime, meetingLiveChunkBacklogLimit: 8)
+
+        // Start an active job in the meeting lane.
+        let activeTask = Task {
+            try await scheduler.transcribe(audioPath: "active", job: .meetingLiveChunk)
+        }
+        try await waitForStartedPaths(runtime: runtime, count: 1)
+
+        // Queue a pending job behind it in the same lane.
+        let pendingTask = Task {
+            try await scheduler.transcribe(audioPath: "pending", job: .meetingLiveChunk)
+        }
+        // Let the enqueue settle.
+        try await Task.sleep(for: .milliseconds(50))
+
+        // Shutdown should cancel both.
+        await scheduler.shutdown()
+
+        do {
+            _ = try await activeTask.value
+            XCTFail("Expected active job to be cancelled by shutdown")
+        } catch is CancellationError {
+            // Expected.
+        }
+
+        do {
+            _ = try await pendingTask.value
+            XCTFail("Expected pending job to be cancelled by shutdown")
+        } catch is CancellationError {
+            // Expected.
+        }
+
+        // Runtime shutdown was called.
+        let counts = await runtime.lifecycleCounts()
+        XCTAssertEqual(counts.shutdown, 1)
+    }
+
+    func testPendingJobCancelledBeforeExecution() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.block(path: "blocker")
+        let scheduler = STTScheduler(runtimeProvider: runtime, meetingLiveChunkBacklogLimit: 8)
+
+        // Block the batch lane with a long-running job.
+        let blockerTask = Task {
+            try await scheduler.transcribe(audioPath: "blocker", job: .fileTranscription)
+        }
+        try await waitForStartedPaths(runtime: runtime, count: 1)
+
+        // Queue a second job in the same lane — it will be pending.
+        let pendingTask = Task {
+            try await scheduler.transcribe(audioPath: "queued", job: .fileTranscription)
+        }
+        // Let the enqueue settle.
+        try await Task.sleep(for: .milliseconds(50))
+
+        // Cancel the pending task from the caller side.
+        pendingTask.cancel()
+
+        do {
+            _ = try await pendingTask.value
+            XCTFail("Expected pending job to throw CancellationError")
+        } catch is CancellationError {
+            // Expected.
+        }
+
+        // The cancelled job should never have reached the runtime.
+        let startedPaths = await runtime.startedPaths()
+        XCTAssertEqual(startedPaths, ["blocker"])
+
+        // Unblock and verify the original job still completes.
+        await runtime.release(path: "blocker")
+        _ = try await blockerTask.value
+    }
+
     private func waitForStartedPaths(
         runtime: MockSTTRuntime,
         count: Int,
@@ -210,7 +287,7 @@ final class STTSchedulerTests: XCTestCase {
 
 private actor MockSTTRuntime: STTRuntimeProtocol {
     private var blockedPaths: Set<String> = []
-    private var waitingContinuations: [String: CheckedContinuation<Void, Never>] = [:]
+    private var waitingContinuations: [String: CheckedContinuation<Void, any Error>] = [:]
     private var progressScripts: [String: [Int]] = [:]
     private var started: [String] = []
 
@@ -234,11 +311,16 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
         }
 
         if blockedPaths.contains(audioPath) {
-            await withCheckedContinuation { continuation in
-                waitingContinuations[audioPath] = continuation
+            try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { continuation in
+                    waitingContinuations[audioPath] = continuation
+                }
+            } onCancel: {
+                Task { await self.cancelBlocked(path: audioPath) }
             }
         }
 
+        try Task.checkCancellation()
         return STTResult(text: "\(job):\(audioPath)", words: [])
     }
 
@@ -280,7 +362,11 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
 
     func release(path: String) {
         blockedPaths.remove(path)
-        waitingContinuations.removeValue(forKey: path)?.resume()
+        waitingContinuations.removeValue(forKey: path)?.resume(returning: ())
+    }
+
+    private func cancelBlocked(path: String) {
+        waitingContinuations.removeValue(forKey: path)?.resume(throwing: CancellationError())
     }
 
     func setProgressScript(_ values: [Int], for path: String) {

--- a/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
+++ b/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
@@ -2,41 +2,64 @@ import XCTest
 @testable import MacParakeetCore
 
 final class STTSchedulerTests: XCTestCase {
-    func testDictationBeatsQueuedMeetingLiveChunk() async throws {
+    func testDictationRunsWhileMeetingLaneIsBusy() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.block(path: "meeting-live")
+        let scheduler = STTScheduler(runtimeProvider: runtime, meetingLiveChunkBacklogLimit: 8)
+
+        let meetingTask = Task {
+            try await scheduler.transcribe(audioPath: "meeting-live", job: .meetingLiveChunk)
+        }
+        try await waitForStartedPaths(runtime: runtime, count: 1)
+
+        let dictationTask = Task {
+            try await scheduler.transcribe(audioPath: "dictation", job: .dictation)
+        }
+        try await waitForStartedPaths(runtime: runtime, count: 2)
+
+        let startedWhileMeetingBlocked = await runtime.startedPaths()
+        XCTAssertEqual(startedWhileMeetingBlocked, ["meeting-live", "dictation"])
+
+        _ = try await dictationTask.value
+        await runtime.release(path: "meeting-live")
+        _ = try await meetingTask.value
+    }
+
+    func testMeetingFinalizeRunsWhileBatchLaneIsBusy() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.block(path: "file")
+        let scheduler = STTScheduler(runtimeProvider: runtime, meetingLiveChunkBacklogLimit: 8)
+
+        let fileTask = Task {
+            try await scheduler.transcribe(audioPath: "file", job: .fileTranscription)
+        }
+        try await waitForStartedPaths(runtime: runtime, count: 1)
+
+        let finalizeTask = Task {
+            try await scheduler.transcribe(audioPath: "meeting-finalize", job: .meetingFinalize)
+        }
+        try await waitForStartedPaths(runtime: runtime, count: 2)
+
+        let startedWhileFileBlocked = await runtime.startedPaths()
+        XCTAssertEqual(startedWhileFileBlocked, ["file", "meeting-finalize"])
+
+        _ = try await finalizeTask.value
+        await runtime.release(path: "file")
+        _ = try await fileTask.value
+    }
+
+    func testMeetingFinalizeBeatsQueuedMeetingLiveChunkWithinMeetingLane() async throws {
         let runtime = MockSTTRuntime()
         await runtime.block(path: "seed")
         let scheduler = STTScheduler(runtimeProvider: runtime, meetingLiveChunkBacklogLimit: 8)
 
-        let seedTask = Task { try await scheduler.transcribe(audioPath: "seed", job: .fileTranscription) }
+        let seedTask = Task { try await scheduler.transcribe(audioPath: "seed", job: .meetingLiveChunk) }
         try await waitForStartedPaths(runtime: runtime, count: 1)
 
         let liveTask = Task { try await scheduler.transcribe(audioPath: "live", job: .meetingLiveChunk) }
-        let dictationTask = Task { try await scheduler.transcribe(audioPath: "dictation", job: .dictation) }
-
-        try await Task.sleep(for: .milliseconds(100))
-        let startedWhileSeedBlocked = await runtime.startedPaths()
-        XCTAssertEqual(startedWhileSeedBlocked, ["seed"])
-
-        await runtime.release(path: "seed")
-
-        _ = try await seedTask.value
-        _ = try await dictationTask.value
-        _ = try await liveTask.value
-
-        let finalStartedPaths = await runtime.startedPaths()
-        XCTAssertEqual(finalStartedPaths, ["seed", "dictation", "live"])
-    }
-
-    func testMeetingFinalizeBeatsQueuedFileTranscription() async throws {
-        let runtime = MockSTTRuntime()
-        await runtime.block(path: "seed")
-        let scheduler = STTScheduler(runtimeProvider: runtime, meetingLiveChunkBacklogLimit: 8)
-
-        let seedTask = Task { try await scheduler.transcribe(audioPath: "seed", job: .dictation) }
-        try await waitForStartedPaths(runtime: runtime, count: 1)
-
-        let fileTask = Task { try await scheduler.transcribe(audioPath: "file", job: .fileTranscription) }
-        let finalizeTask = Task { try await scheduler.transcribe(audioPath: "meeting-finalize", job: .meetingFinalize) }
+        let finalizeTask = Task {
+            try await scheduler.transcribe(audioPath: "meeting-finalize", job: .meetingFinalize)
+        }
 
         try await Task.sleep(for: .milliseconds(100))
         let startedWhileSeedBlocked = await runtime.startedPaths()
@@ -46,10 +69,10 @@ final class STTSchedulerTests: XCTestCase {
 
         _ = try await seedTask.value
         _ = try await finalizeTask.value
-        _ = try await fileTask.value
+        _ = try await liveTask.value
 
         let finalStartedPaths = await runtime.startedPaths()
-        XCTAssertEqual(finalStartedPaths, ["seed", "meeting-finalize", "file"])
+        XCTAssertEqual(finalStartedPaths, ["seed", "meeting-finalize", "live"])
     }
 
     func testLifecycleOperationsTargetSharedRuntime() async throws {
@@ -68,7 +91,7 @@ final class STTSchedulerTests: XCTestCase {
         XCTAssertEqual(counts.shutdown, 1)
     }
 
-    func testProgressIsScopedPerJob() async throws {
+    func testProgressIsScopedPerJobAcrossLanes() async throws {
         let runtime = MockSTTRuntime()
         await runtime.setProgressScript([10, 50], for: "file")
         await runtime.setProgressScript([20, 80], for: "dictation")
@@ -83,7 +106,6 @@ final class STTSchedulerTests: XCTestCase {
                 fileProgress.record(current)
             }
         }
-
         try await waitForStartedPaths(runtime: runtime, count: 1)
 
         let dictationTask = Task {
@@ -91,22 +113,17 @@ final class STTSchedulerTests: XCTestCase {
                 dictationProgress.record(current)
             }
         }
+        try await waitForStartedPaths(runtime: runtime, count: 2)
 
-        try await Task.sleep(for: .milliseconds(100))
+        _ = try await dictationTask.value
+
         let fileValuesWhileBlocked = fileProgress.currentValues()
         let dictationValuesWhileBlocked = dictationProgress.currentValues()
         XCTAssertEqual(fileValuesWhileBlocked, [10, 50])
-        XCTAssertEqual(dictationValuesWhileBlocked, [])
+        XCTAssertEqual(dictationValuesWhileBlocked, [20, 80])
 
         await runtime.release(path: "file")
-
         _ = try await fileTask.value
-        _ = try await dictationTask.value
-
-        let finalFileValues = fileProgress.currentValues()
-        let finalDictationValues = dictationProgress.currentValues()
-        XCTAssertEqual(finalFileValues, [10, 50])
-        XCTAssertEqual(finalDictationValues, [20, 80])
     }
 
     func testMeetingLiveChunkBackpressureDropsOldestPendingLiveChunk() async throws {
@@ -114,7 +131,7 @@ final class STTSchedulerTests: XCTestCase {
         await runtime.block(path: "seed")
         let scheduler = STTScheduler(runtimeProvider: runtime, meetingLiveChunkBacklogLimit: 1)
 
-        let seedTask = Task { try await scheduler.transcribe(audioPath: "seed", job: .fileTranscription) }
+        let seedTask = Task { try await scheduler.transcribe(audioPath: "seed", job: .meetingLiveChunk) }
         try await waitForStartedPaths(runtime: runtime, count: 1)
 
         let droppedTask = Task { try await scheduler.transcribe(audioPath: "live-1", job: .meetingLiveChunk) }

--- a/Tests/MacParakeetTests/Services/DiarizationServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/DiarizationServiceTests.swift
@@ -57,11 +57,37 @@ final class DiarizationServiceTests: XCTestCase {
         try await mock.prepareModels()
         let wasCalled = await mock.prepareModelsCalled
         XCTAssertTrue(wasCalled)
+        let ready = await mock.isReady()
+        XCTAssertTrue(ready)
+        let cached = await mock.hasCachedModels()
+        XCTAssertTrue(cached)
     }
 
     func testIsReady() async {
         let mock = MockDiarizationService()
         let ready = await mock.isReady()
-        XCTAssertTrue(ready)
+        XCTAssertFalse(ready)
+    }
+
+    func testClearModelCacheRemovesCachedSpeakerModels() throws {
+        let tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let repoDirectory = DiarizationService.modelCacheDirectory(directory: tempDirectory)
+        try FileManager.default.createDirectory(at: repoDirectory, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: tempDirectory)
+        }
+
+        for modelName in DiarizationService.requiredModelNames() {
+            let modelURL = repoDirectory.appendingPathComponent(modelName, isDirectory: false)
+            FileManager.default.createFile(atPath: modelURL.path, contents: Data())
+        }
+
+        XCTAssertTrue(DiarizationService.isModelCached(directory: tempDirectory))
+
+        DiarizationService.clearModelCache(directory: tempDirectory)
+
+        XCTAssertFalse(DiarizationService.isModelCached(directory: tempDirectory))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: repoDirectory.path))
     }
 }

--- a/Tests/MacParakeetTests/Services/DictationServiceSessionTests.swift
+++ b/Tests/MacParakeetTests/Services/DictationServiceSessionTests.swift
@@ -17,7 +17,7 @@ final class DictationServiceSessionTests: XCTestCase {
 
         service = DictationService(
             audioProcessor: mockAudio,
-            sttClient: mockSTT,
+            sttTranscriber: mockSTT,
             dictationRepo: dictationRepo
         )
         session = DictationServiceSession(service: service)

--- a/Tests/MacParakeetTests/Services/DictationServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/DictationServiceTests.swift
@@ -15,7 +15,7 @@ final class DictationServiceTests: XCTestCase {
 
         service = DictationService(
             audioProcessor: mockAudio,
-            sttClient: mockSTT,
+            sttTranscriber: mockSTT,
             dictationRepo: dictationRepo
         )
     }

--- a/Tests/MacParakeetTests/Services/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecordingServiceTests.swift
@@ -20,7 +20,7 @@ final class MeetingRecordingServiceTests: XCTestCase {
         let service = MeetingRecordingService(
             audioCaptureService: captureService,
             audioConverter: audioConverter,
-            sttClient: sttClient
+            sttTranscriber: sttClient
         )
 
         try await service.startRecording()
@@ -111,7 +111,11 @@ private actor SequencedMeetingSTTClient: STTClientProtocol {
         self.remainingResults = results
     }
 
-    func transcribe(audioPath: String, onProgress: (@Sendable (Int, Int) -> Void)?) async throws -> STTResult {
+    func transcribe(
+        audioPath: String,
+        job: STTJobKind,
+        onProgress: (@Sendable (Int, Int) -> Void)?
+    ) async throws -> STTResult {
         guard !remainingResults.isEmpty else {
             XCTFail("Unexpected extra meeting STT request")
             return STTResult(text: "", words: [])
@@ -120,6 +124,18 @@ private actor SequencedMeetingSTTClient: STTClientProtocol {
     }
 
     func warmUp(onProgress: (@Sendable (String) -> Void)?) async throws {}
+
+    func backgroundWarmUp() async {}
+
+    func observeWarmUpProgress() async -> (id: UUID, stream: AsyncStream<STTWarmUpState>) {
+        let stream = AsyncStream<STTWarmUpState> { continuation in
+            continuation.yield(.ready)
+            continuation.finish()
+        }
+        return (UUID(), stream)
+    }
+
+    func removeWarmUpObserver(id: UUID) async {}
 
     func isReady() async -> Bool { true }
 

--- a/Tests/MacParakeetTests/Services/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecordingServiceTests.swift
@@ -176,6 +176,50 @@ final class MeetingRecordingServiceTests: XCTestCase {
         XCTAssertNotNil(output.preparedTranscript)
     }
 
+    func testStaleChunkFailureFromPreviousSessionDoesNotPoisonNextSession() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let audioConverter = MockMeetingAudioFileConverter()
+        let sttClient = PathScriptedMeetingSTTClient(responses: [
+            "microphone-100000-105000": .failure(message: "late failure", delay: .milliseconds(300)),
+            "microphone-200000-205000": .result(STTResult(text: "fresh", words: [
+                TimestampedWord(word: "fresh", startMs: 0, endMs: 160, confidence: 0.9),
+            ])),
+        ])
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: audioConverter,
+            sttTranscriber: sttClient
+        )
+
+        try await service.startRecording()
+
+        let firstBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.25))
+        await captureService.yield(.microphoneBuffer(
+            firstBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
+        ))
+
+        let firstOutput = try await service.stopRecording()
+        defer { try? FileManager.default.removeItem(at: firstOutput.folderURL) }
+        XCTAssertNil(firstOutput.preparedTranscript)
+
+        try await service.startRecording()
+
+        let secondBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.5))
+        await captureService.yield(.microphoneBuffer(
+            secondBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 200.0))
+        ))
+        try await Task.sleep(for: .milliseconds(350))
+
+        let secondOutput = try await service.stopRecording()
+        defer { try? FileManager.default.removeItem(at: secondOutput.folderURL) }
+
+        let prepared = try XCTUnwrap(secondOutput.preparedTranscript)
+        XCTAssertEqual(prepared.words.map(\.word), ["fresh"])
+        XCTAssertEqual(prepared.words.map(\.speakerId), ["microphone"])
+    }
+
     private func waitForLiveChunkTranscriptionStart(
         _ client: SleepingMeetingSTTClient,
         timeout: Duration = .seconds(1)
@@ -214,18 +258,28 @@ final class MeetingRecordingServiceTests: XCTestCase {
 
 private actor MockMeetingAudioCaptureService: MeetingAudioCapturing {
     private var continuation: AsyncStream<MeetingAudioCaptureEvent>.Continuation?
-    private lazy var stream: AsyncStream<MeetingAudioCaptureEvent> = AsyncStream(bufferingPolicy: .unbounded) {
-        self.continuation = $0
-    }
+    private var stream: AsyncStream<MeetingAudioCaptureEvent>?
 
     var events: AsyncStream<MeetingAudioCaptureEvent> {
-        stream
+        if let stream {
+            return stream
+        }
+
+        let stream = AsyncStream<MeetingAudioCaptureEvent>(bufferingPolicy: .unbounded) {
+            self.continuation = $0
+        }
+        self.stream = stream
+        return stream
     }
 
-    func start() async throws {}
+    func start() async throws {
+        _ = events
+    }
 
     func stop() async {
         continuation?.finish()
+        continuation = nil
+        stream = nil
     }
 
     func yield(_ event: MeetingAudioCaptureEvent) {
@@ -386,4 +440,64 @@ private actor PrefixScriptedMeetingSTTClient: STTClientProtocol {
     func clearModelCache() async {}
 
     func shutdown() async {}
+}
+
+private actor PathScriptedMeetingSTTClient: STTClientProtocol {
+    enum Response {
+        case result(STTResult, delay: Duration = .zero)
+        case failure(message: String, delay: Duration = .zero)
+    }
+
+    private let responses: [String: Response]
+
+    init(responses: [String: Response]) {
+        self.responses = responses
+    }
+
+    func transcribe(
+        audioPath: String,
+        job: STTJobKind,
+        onProgress: (@Sendable (Int, Int) -> Void)?
+    ) async throws -> STTResult {
+        guard let response = responses.first(where: { audioPath.contains($0.key) })?.value else {
+            return STTResult(text: "", words: [])
+        }
+
+        switch response {
+        case .result(let result, let delay):
+            await waitIgnoringCancellation(for: delay)
+            return result
+        case .failure(let message, let delay):
+            await waitIgnoringCancellation(for: delay)
+            throw STTError.transcriptionFailed(message)
+        }
+    }
+
+    func warmUp(onProgress: (@Sendable (String) -> Void)?) async throws {}
+
+    func backgroundWarmUp() async {}
+
+    func observeWarmUpProgress() async -> (id: UUID, stream: AsyncStream<STTWarmUpState>) {
+        let stream = AsyncStream<STTWarmUpState> { continuation in
+            continuation.yield(.ready)
+            continuation.finish()
+        }
+        return (UUID(), stream)
+    }
+
+    func removeWarmUpObserver(id: UUID) async {}
+
+    func isReady() async -> Bool { true }
+
+    func clearModelCache() async {}
+
+    func shutdown() async {}
+
+    private func waitIgnoringCancellation(for delay: Duration) async {
+        guard delay > .zero else { return }
+        let startedAt = ContinuousClock.now
+        while startedAt.duration(to: .now) < delay {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
 }

--- a/Tests/MacParakeetTests/Services/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecordingServiceTests.swift
@@ -51,6 +51,48 @@ final class MeetingRecordingServiceTests: XCTestCase {
         ])
     }
 
+    func testStopRecordingCancelsPendingLiveChunksInsteadOfWaitingForThem() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let audioConverter = MockMeetingAudioFileConverter()
+        let sttClient = SleepingMeetingSTTClient(liveChunkDelay: .seconds(1))
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: audioConverter,
+            sttTranscriber: sttClient
+        )
+
+        try await service.startRecording()
+
+        let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.25))
+        await captureService.yield(.microphoneBuffer(
+            microphoneBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
+        ))
+        try await waitForLiveChunkTranscriptionStart(sttClient)
+
+        let startedAt = ContinuousClock.now
+        let output = try await service.stopRecording()
+        let elapsed = startedAt.duration(to: .now)
+        defer { try? FileManager.default.removeItem(at: output.folderURL) }
+
+        XCTAssertLessThan(elapsed, .milliseconds(500))
+        XCTAssertNil(output.preparedTranscript)
+    }
+
+    private func waitForLiveChunkTranscriptionStart(
+        _ client: SleepingMeetingSTTClient,
+        timeout: Duration = .seconds(1)
+    ) async throws {
+        let startedAt = ContinuousClock.now
+        while await client.liveChunkCallCount == 0 {
+            if startedAt.duration(to: .now) > timeout {
+                XCTFail("Timed out waiting for live chunk transcription to start")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+    }
+
     private func makeMonoFloatBuffer(frameCount: Int, sampleValue: Float) -> AVAudioPCMBuffer? {
         guard let format = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,
@@ -121,6 +163,47 @@ private actor SequencedMeetingSTTClient: STTClientProtocol {
             return STTResult(text: "", words: [])
         }
         return remainingResults.removeFirst()
+    }
+
+    func warmUp(onProgress: (@Sendable (String) -> Void)?) async throws {}
+
+    func backgroundWarmUp() async {}
+
+    func observeWarmUpProgress() async -> (id: UUID, stream: AsyncStream<STTWarmUpState>) {
+        let stream = AsyncStream<STTWarmUpState> { continuation in
+            continuation.yield(.ready)
+            continuation.finish()
+        }
+        return (UUID(), stream)
+    }
+
+    func removeWarmUpObserver(id: UUID) async {}
+
+    func isReady() async -> Bool { true }
+
+    func clearModelCache() async {}
+
+    func shutdown() async {}
+}
+
+private actor SleepingMeetingSTTClient: STTClientProtocol {
+    private let liveChunkDelay: Duration
+    private(set) var liveChunkCallCount = 0
+
+    init(liveChunkDelay: Duration) {
+        self.liveChunkDelay = liveChunkDelay
+    }
+
+    func transcribe(
+        audioPath: String,
+        job: STTJobKind,
+        onProgress: (@Sendable (Int, Int) -> Void)?
+    ) async throws -> STTResult {
+        if job == .meetingLiveChunk {
+            liveChunkCallCount += 1
+            try await Task.sleep(for: liveChunkDelay)
+        }
+        return STTResult(text: "", words: [])
     }
 
     func warmUp(onProgress: (@Sendable (String) -> Void)?) async throws {}

--- a/Tests/MacParakeetTests/Services/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecordingServiceTests.swift
@@ -79,6 +79,103 @@ final class MeetingRecordingServiceTests: XCTestCase {
         XCTAssertNil(output.preparedTranscript)
     }
 
+    func testStopRecordingPreservesPreparedTranscriptWhenPendingChunksTimeOut() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let audioConverter = MockMeetingAudioFileConverter()
+        let sttClient = PrefixScriptedMeetingSTTClient(
+            microphoneSteps: [
+                .result(
+                    STTResult(text: "mic", words: [
+                        TimestampedWord(word: "mic", startMs: 0, endMs: 120, confidence: 0.9),
+                    ])
+                ),
+            ],
+            systemSteps: [
+                .result(
+                    STTResult(text: "sys", words: [
+                        TimestampedWord(word: "sys", startMs: 0, endMs: 120, confidence: 0.9),
+                    ]),
+                    delay: .seconds(1)
+                ),
+            ]
+        )
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: audioConverter,
+            sttTranscriber: sttClient
+        )
+
+        try await service.startRecording()
+
+        let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.25))
+        let systemBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.5))
+
+        await captureService.yield(.microphoneBuffer(
+            microphoneBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
+        ))
+        await captureService.yield(.systemBuffer(
+            systemBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.150))
+        ))
+
+        let output = try await service.stopRecording()
+        defer { try? FileManager.default.removeItem(at: output.folderURL) }
+
+        let prepared = try XCTUnwrap(output.preparedTranscript)
+        XCTAssertEqual(prepared.words.map(\.word), ["mic"])
+        XCTAssertEqual(prepared.words.map(\.speakerId), ["microphone"])
+    }
+
+    func testBackpressureDropMarksNextTranscriptUpdateAsLagging() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let audioConverter = MockMeetingAudioFileConverter()
+        let sttClient = PrefixScriptedMeetingSTTClient(
+            microphoneSteps: [
+                .result(
+                    STTResult(text: "first", words: [
+                        TimestampedWord(word: "first", startMs: 0, endMs: 120, confidence: 0.9),
+                    ]),
+                    delay: .milliseconds(200)
+                ),
+                .dropBackpressure,
+            ]
+        )
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: audioConverter,
+            sttTranscriber: sttClient
+        )
+
+        let updates = await service.transcriptUpdates
+        let nextUpdate = Task {
+            var iterator = updates.makeAsyncIterator()
+            return await iterator.next()
+        }
+
+        try await service.startRecording()
+
+        let firstBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.25))
+        let secondBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 64_000, sampleValue: 0.25))
+        await captureService.yield(.microphoneBuffer(
+            firstBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
+        ))
+        await captureService.yield(.microphoneBuffer(
+            secondBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 104.0))
+        ))
+
+        let maybeUpdate = await nextUpdate.value
+        let update = try XCTUnwrap(maybeUpdate)
+        XCTAssertTrue(update.isTranscriptionLagging)
+        XCTAssertEqual(update.words.map(\.word), ["first"])
+
+        let output = try await service.stopRecording()
+        defer { try? FileManager.default.removeItem(at: output.folderURL) }
+        XCTAssertNotNil(output.preparedTranscript)
+    }
+
     private func waitForLiveChunkTranscriptionStart(
         _ client: SleepingMeetingSTTClient,
         timeout: Duration = .seconds(1)
@@ -204,6 +301,70 @@ private actor SleepingMeetingSTTClient: STTClientProtocol {
             try await Task.sleep(for: liveChunkDelay)
         }
         return STTResult(text: "", words: [])
+    }
+
+    func warmUp(onProgress: (@Sendable (String) -> Void)?) async throws {}
+
+    func backgroundWarmUp() async {}
+
+    func observeWarmUpProgress() async -> (id: UUID, stream: AsyncStream<STTWarmUpState>) {
+        let stream = AsyncStream<STTWarmUpState> { continuation in
+            continuation.yield(.ready)
+            continuation.finish()
+        }
+        return (UUID(), stream)
+    }
+
+    func removeWarmUpObserver(id: UUID) async {}
+
+    func isReady() async -> Bool { true }
+
+    func clearModelCache() async {}
+
+    func shutdown() async {}
+}
+
+private actor PrefixScriptedMeetingSTTClient: STTClientProtocol {
+    enum Step: Sendable {
+        case result(STTResult, delay: Duration = .zero)
+        case dropBackpressure
+    }
+
+    private var microphoneSteps: [Step]
+    private var systemSteps: [Step]
+
+    init(
+        microphoneSteps: [Step] = [],
+        systemSteps: [Step] = []
+    ) {
+        self.microphoneSteps = microphoneSteps
+        self.systemSteps = systemSteps
+    }
+
+    func transcribe(
+        audioPath: String,
+        job: STTJobKind,
+        onProgress: (@Sendable (Int, Int) -> Void)?
+    ) async throws -> STTResult {
+        let fileName = URL(fileURLWithPath: audioPath).lastPathComponent
+        let step: Step
+        if fileName.hasPrefix("microphone-"), !microphoneSteps.isEmpty {
+            step = microphoneSteps.removeFirst()
+        } else if fileName.hasPrefix("system-"), !systemSteps.isEmpty {
+            step = systemSteps.removeFirst()
+        } else {
+            step = .result(STTResult(text: "", words: []))
+        }
+
+        switch step {
+        case .result(let result, let delay):
+            if delay > .zero {
+                try await Task.sleep(for: delay)
+            }
+            return result
+        case .dropBackpressure:
+            throw STTSchedulerError.droppedDueToBackpressure(job: .meetingLiveChunk)
+        }
     }
 
     func warmUp(onProgress: (@Sendable (String) -> Void)?) async throws {}

--- a/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
@@ -229,7 +229,7 @@ final class TranscriptionServiceTests: XCTestCase {
         XCTAssertTrue(phases.contains { if case .transcribing = $0 { true } else { false } })
     }
 
-    func testTranscribeMeetingUsesBatchSTTAndAppliesPreparedSpeakerMetadata() async throws {
+    func testTranscribeMeetingUsesFinalizeLaneAndAppliesPreparedSpeakerMetadata() async throws {
         let recordingURL = try makeTempDownloadedAudio()
         defer { try? FileManager.default.removeItem(at: recordingURL) }
 
@@ -276,6 +276,7 @@ final class TranscriptionServiceTests: XCTestCase {
 
         let result = try await service.transcribeMeeting(recording: recording)
         let sttCallCount = await mockSTT.transcribeCallCount
+        let lastJob = await mockSTT.lastJob
         let convertCallCount = await mockAudio.convertCallCount
 
         XCTAssertEqual(result.fileName, "Meeting Demo")
@@ -288,7 +289,19 @@ final class TranscriptionServiceTests: XCTestCase {
         ])
         XCTAssertEqual(result.wordTimestamps?.map(\.speakerId), ["microphone", "microphone", "system", "system"])
         XCTAssertEqual(sttCallCount, 1)
+        XCTAssertEqual(lastJob, .meetingFinalize)
         XCTAssertEqual(convertCallCount, 1)
+    }
+
+    func testMeetingSourceRetranscribeUsesBatchLane() async throws {
+        let expectedResult = STTResult(text: "Meeting archive retranscribe")
+        await mockSTT.configure(result: expectedResult)
+
+        let fileURL = URL(fileURLWithPath: "/tmp/meeting-archive.m4a")
+        _ = try await service.transcribe(fileURL: fileURL, source: .meeting)
+
+        let lastJob = await mockSTT.lastJob
+        XCTAssertEqual(lastJob, .fileTranscription)
     }
 
     private func makeTempDownloadedAudio() throws -> URL {

--- a/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
@@ -23,6 +23,39 @@ private actor MockYouTubeDownloader: YouTubeDownloading {
     }
 }
 
+private final class TelemetrySpy: TelemetryServiceProtocol, @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [TelemetryEventSpec] = []
+
+    func send(_ event: TelemetryEventSpec) {
+        lock.lock()
+        events.append(event)
+        lock.unlock()
+    }
+
+    func flush() async {}
+
+    func flushForTermination() {}
+
+    func snapshot() -> [TelemetryEventSpec] {
+        lock.lock()
+        defer { lock.unlock() }
+        return events
+    }
+}
+
+private actor FailingYouTubeDownloader: YouTubeDownloading {
+    private let error: Error
+
+    init(error: Error) {
+        self.error = error
+    }
+
+    func download(url: String, onProgress: (@Sendable (Int) -> Void)?) async throws -> YouTubeDownloader.DownloadResult {
+        throw error
+    }
+}
+
 final class TranscriptionServiceTests: XCTestCase {
     var service: TranscriptionService!
     var mockAudio: MockAudioProcessor!
@@ -34,6 +67,7 @@ final class TranscriptionServiceTests: XCTestCase {
         mockAudio = MockAudioProcessor()
         mockSTT = MockSTTClient()
         transcriptionRepo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
+        Telemetry.configure(NoOpTelemetryService())
 
         service = TranscriptionService(
             audioProcessor: mockAudio,
@@ -230,6 +264,8 @@ final class TranscriptionServiceTests: XCTestCase {
     }
 
     func testTranscribeMeetingUsesFinalizeLaneAndAppliesPreparedSpeakerMetadata() async throws {
+        let telemetry = TelemetrySpy()
+        Telemetry.configure(telemetry)
         let recordingURL = try makeTempDownloadedAudio()
         defer { try? FileManager.default.removeItem(at: recordingURL) }
 
@@ -291,6 +327,25 @@ final class TranscriptionServiceTests: XCTestCase {
         XCTAssertEqual(sttCallCount, 1)
         XCTAssertEqual(lastJob, .meetingFinalize)
         XCTAssertEqual(convertCallCount, 1)
+
+        let events = telemetry.snapshot()
+        guard case .transcriptionCompleted(
+            let source,
+            _,
+            _,
+            _,
+            let speakerCount,
+            let diarizationRequested,
+            let diarizationApplied,
+            let meetingPreparedTranscriptUsed
+        ) = try XCTUnwrap(events.last) else {
+            return XCTFail("Expected transcription_completed telemetry")
+        }
+        XCTAssertEqual(source, .meeting)
+        XCTAssertEqual(speakerCount, 2)
+        XCTAssertTrue(diarizationRequested)
+        XCTAssertTrue(diarizationApplied)
+        XCTAssertEqual(meetingPreparedTranscriptUsed, true)
     }
 
     func testMeetingSourceRetranscribeUsesBatchLane() async throws {
@@ -302,6 +357,38 @@ final class TranscriptionServiceTests: XCTestCase {
 
         let lastJob = await mockSTT.lastJob
         XCTAssertEqual(lastJob, .fileTranscription)
+    }
+
+    func testTranscribeURLDownloadFailureEmitsDownloadStageTelemetry() async throws {
+        let telemetry = TelemetrySpy()
+        Telemetry.configure(telemetry)
+        let downloader = FailingYouTubeDownloader(
+            error: YouTubeDownloadError.downloadFailed("yt-dlp failed")
+        )
+
+        let service = TranscriptionService(
+            audioProcessor: mockAudio,
+            sttTranscriber: mockSTT,
+            transcriptionRepo: transcriptionRepo,
+            youtubeDownloader: downloader
+        )
+
+        do {
+            _ = try await service.transcribeURL(urlString: "https://youtu.be/dQw4w9WgXcQ")
+            XCTFail("Should have thrown")
+        } catch let error as YouTubeDownloadError {
+            guard case .downloadFailed = error else {
+                return XCTFail("Unexpected download error: \(error)")
+            }
+        }
+
+        let events = telemetry.snapshot()
+        guard case .transcriptionFailed(let source, let stage, let errorType, _) = try XCTUnwrap(events.last) else {
+            return XCTFail("Expected transcription_failed telemetry")
+        }
+        XCTAssertEqual(source, .youtube)
+        XCTAssertEqual(stage, .download)
+        XCTAssertEqual(errorType, "YouTubeDownloadError.downloadFailed")
     }
 
     private func makeTempDownloadedAudio() throws -> URL {

--- a/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
@@ -37,7 +37,7 @@ final class TranscriptionServiceTests: XCTestCase {
 
         service = TranscriptionService(
             audioProcessor: mockAudio,
-            sttClient: mockSTT,
+            sttTranscriber: mockSTT,
             transcriptionRepo: transcriptionRepo
         )
     }
@@ -156,7 +156,7 @@ final class TranscriptionServiceTests: XCTestCase {
 
         let service = TranscriptionService(
             audioProcessor: mockAudio,
-            sttClient: mockSTT,
+            sttTranscriber: mockSTT,
             transcriptionRepo: transcriptionRepo,
             youtubeDownloader: downloader
         )
@@ -182,7 +182,7 @@ final class TranscriptionServiceTests: XCTestCase {
 
         let service = TranscriptionService(
             audioProcessor: mockAudio,
-            sttClient: mockSTT,
+            sttTranscriber: mockSTT,
             transcriptionRepo: transcriptionRepo,
             shouldKeepDownloadedAudio: { false },
             youtubeDownloader: downloader
@@ -211,7 +211,7 @@ final class TranscriptionServiceTests: XCTestCase {
 
         let service = TranscriptionService(
             audioProcessor: mockAudio,
-            sttClient: mockSTT,
+            sttTranscriber: mockSTT,
             transcriptionRepo: transcriptionRepo,
             youtubeDownloader: downloader
         )

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -258,6 +258,66 @@ final class TelemetryServiceTests: XCTestCase {
         XCTAssertTrue(json["props"] is NSNull || json["props"] == nil)
     }
 
+    func testTranscriptionCompletedSerializesDiarizationContext() throws {
+        let event = TelemetryEvent(
+            spec: .transcriptionCompleted(
+                source: .meeting,
+                audioDurationSeconds: 90.0,
+                processingSeconds: 12.4,
+                wordCount: 240,
+                speakerCount: 3,
+                diarizationRequested: true,
+                diarizationApplied: true,
+                meetingPreparedTranscriptUsed: true
+            ),
+            appVer: "0.4.2",
+            osVer: "15.3",
+            locale: "en-US",
+            chip: "Apple M1",
+            session: "test-session"
+        )
+
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        let data = try encoder.encode(event)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let props = try XCTUnwrap(json["props"] as? [String: String])
+
+        XCTAssertEqual(props["source"], "meeting")
+        XCTAssertEqual(props["audio_duration_seconds"], "90.0")
+        XCTAssertEqual(props["processing_seconds"], "12.4")
+        XCTAssertEqual(props["word_count"], "240")
+        XCTAssertEqual(props["speaker_count"], "3")
+        XCTAssertEqual(props["diarization_requested"], "true")
+        XCTAssertEqual(props["diarization_applied"], "true")
+        XCTAssertEqual(props["meeting_prepared_transcript_used"], "true")
+    }
+
+    func testTranscriptionFailedSerializesStage() throws {
+        let event = TelemetryEvent(
+            spec: .transcriptionFailed(
+                source: .youtube,
+                stage: .download,
+                errorType: "download_failed"
+            ),
+            appVer: "0.4.2",
+            osVer: "15.3",
+            locale: "en-US",
+            chip: "Apple M1",
+            session: "test-session"
+        )
+
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        let data = try encoder.encode(event)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let props = try XCTUnwrap(json["props"] as? [String: String])
+
+        XCTAssertEqual(props["source"], "youtube")
+        XCTAssertEqual(props["stage"], "download")
+        XCTAssertEqual(props["error_type"], "download_failed")
+    }
+
     func testImplementedContractCoversEveryTypedEventName() {
         XCTAssertEqual(
             Set(TelemetryEventName.allCases),
@@ -371,9 +431,18 @@ final class TelemetryServiceTests: XCTestCase {
             .dictationEmpty(durationSeconds: 1.5),
             .dictationFailed(errorType: "network"),
             .transcriptionStarted(source: .file, audioDurationSeconds: 30.0),
-            .transcriptionCompleted(source: .dragDrop, audioDurationSeconds: 30.0, processingSeconds: 2.4, wordCount: 120),
-            .transcriptionCancelled(source: .youtube, audioDurationSeconds: 45.0),
-            .transcriptionFailed(source: .file, errorType: "transcribe"),
+            .transcriptionCompleted(
+                source: .dragDrop,
+                audioDurationSeconds: 30.0,
+                processingSeconds: 2.4,
+                wordCount: 120,
+                speakerCount: 2,
+                diarizationRequested: true,
+                diarizationApplied: true,
+                meetingPreparedTranscriptUsed: nil
+            ),
+            .transcriptionCancelled(source: .youtube, audioDurationSeconds: 45.0, stage: .stt),
+            .transcriptionFailed(source: .file, stage: .audioConversion, errorType: "transcribe"),
             .exportUsed(format: "txt"),
             .llmPromptResultUsed(provider: "openai"),
             .llmPromptResultFailed(provider: "openai", errorType: "auth"),

--- a/Tests/MacParakeetTests/ViewModels/MeetingRecordingPanelViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/MeetingRecordingPanelViewModelTests.swift
@@ -41,6 +41,7 @@ final class MeetingRecordingPanelViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.showsAudioLevels)
         XCTAssertEqual(viewModel.previewLines, lines)
         XCTAssertEqual(viewModel.statusTitle, "Recording")
+        XCTAssertFalse(viewModel.showsLaggingIndicator)
     }
 
     func testTranscribingAndErrorStatesUpdateStatusSurface() {
@@ -57,19 +58,35 @@ final class MeetingRecordingPanelViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.showsElapsedTime)
     }
 
+    func testLaggingRecordingStateUpdatesStatusSurface() {
+        let viewModel = MeetingRecordingPanelViewModel()
+
+        viewModel.state = .recording
+        viewModel.updatePreviewLines([], isTranscriptionLagging: true)
+
+        XCTAssertTrue(viewModel.showsLaggingIndicator)
+        XCTAssertTrue(viewModel.statusMessage.contains("catching up"))
+
+        viewModel.state = .transcribing
+        XCTAssertFalse(viewModel.showsLaggingIndicator)
+    }
+
     func testResetClearsTranscriptPreview() {
         let viewModel = MeetingRecordingPanelViewModel()
         viewModel.state = .recording
         viewModel.elapsedSeconds = 42
-        viewModel.updatePreviewLines([
-            MeetingRecordingPreviewLine(
-                id: "1",
-                timestamp: "0:42",
-                speakerLabel: "Them",
-                text: "Reset should clear this",
-                source: .system
-            )
-        ])
+        viewModel.updatePreviewLines(
+            [
+                MeetingRecordingPreviewLine(
+                    id: "1",
+                    timestamp: "0:42",
+                    speakerLabel: "Them",
+                    text: "Reset should clear this",
+                    source: .system
+                )
+            ],
+            isTranscriptionLagging: true
+        )
 
         viewModel.reset()
 
@@ -78,5 +95,6 @@ final class MeetingRecordingPanelViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.micLevel, 0)
         XCTAssertEqual(viewModel.systemLevel, 0)
         XCTAssertTrue(viewModel.previewLines.isEmpty)
+        XCTAssertFalse(viewModel.isTranscriptionLagging)
     }
 }

--- a/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
@@ -251,14 +251,18 @@ final class OnboardingViewModelTests: XCTestCase {
         XCTAssertEqual(sttCalls, 0)
     }
 
-    func testEngineWarmUpSkipsPreflightWhenSpeechCachedEvenIfOnboardingIncompleteAndOffline() async throws {
+    func testEngineWarmUpFailsPreflightWhenSpeechCachedButSpeakerModelsMissingAndOffline() async throws {
         let perms = MockPermissionService()
         let stt = MockSTTClient()
+        let diarization = MockDiarizationService()
+        await diarization.configureCachedModels(false)
+        await diarization.configureReady(false)
         let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
 
         let vm = makeViewModel(
             permissionService: perms,
             sttClient: stt,
+            diarizationService: diarization,
             defaults: defaults,
             isNetworkReachable: { false },
             isSpeechModelCached: { true }
@@ -267,10 +271,39 @@ final class OnboardingViewModelTests: XCTestCase {
         vm.startEngineWarmUp()
         try await Task.sleep(for: .milliseconds(120))
 
-        // Model is cached — should skip preflight and proceed to warm-up,
-        // even if onboarding hasn't completed and we're offline.
+        if case .failed(let message) = vm.engineState {
+            XCTAssertTrue(message.lowercased().contains("speaker models"))
+        } else {
+            XCTFail("Expected preflight failure when speaker models are missing")
+        }
+
         let sttCalls = await stt.warmUpCallCount
-        XCTAssertEqual(sttCalls, 1, "Should proceed to STT warm-up when model is cached")
+        XCTAssertEqual(sttCalls, 0, "Should fail before STT warm-up when speaker models are missing")
+    }
+
+    func testEngineWarmUpSkipsPreflightWhenSpeechAndSpeakerModelsAreCachedOffline() async throws {
+        let perms = MockPermissionService()
+        let stt = MockSTTClient()
+        let diarization = MockDiarizationService()
+        await diarization.configureCachedModels(true)
+        await diarization.configureReady(false)
+        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
+
+        let vm = makeViewModel(
+            permissionService: perms,
+            sttClient: stt,
+            diarizationService: diarization,
+            defaults: defaults,
+            isNetworkReachable: { false },
+            isSpeechModelCached: { true }
+        )
+        vm.jump(to: .engine)
+        vm.startEngineWarmUp()
+        try await Task.sleep(for: .milliseconds(150))
+
+        XCTAssertEqual(vm.engineState, .ready)
+        let sttCalls = await stt.warmUpCallCount
+        XCTAssertEqual(sttCalls, 1, "Should proceed to STT warm-up when all required assets are cached")
     }
 
     func testEngineWarmUpFailsPreflightWhenDiskTooLowOnFirstSetup() async throws {

--- a/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
@@ -187,7 +187,7 @@ final class OnboardingViewModelTests: XCTestCase {
         XCTAssertEqual(state, .working(message: "Downloading...", progress: 0.5))
     }
 
-    func testEngineWarmUpRetriesTransientSTTFailure() async throws {
+    func testEngineWarmUpFailsTransientSTTFailureWithoutImplicitRetry() async throws {
         let perms = MockPermissionService()
         let stt = MockSTTClient()
         await stt.configureWarmUpFailuresBeforeSuccess(2)
@@ -197,11 +197,11 @@ final class OnboardingViewModelTests: XCTestCase {
         vm.jump(to: .engine)
 
         vm.startEngineWarmUp()
-        try await Task.sleep(for: .milliseconds(1_100))
+        try await Task.sleep(for: .milliseconds(200))
 
-        XCTAssertEqual(vm.engineState, .ready)
+        XCTAssertEqual(vm.engineState, .failed(message: STTError.engineStartFailed("warm-up failed").localizedDescription))
         let sttCalls = await stt.warmUpCallCount
-        XCTAssertEqual(sttCalls, 3)
+        XCTAssertEqual(sttCalls, 1)
     }
 
     func testRetryEngineWarmUpRecoversAfterFailedBackgroundWarmUp() async throws {

--- a/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
@@ -204,6 +204,27 @@ final class OnboardingViewModelTests: XCTestCase {
         XCTAssertEqual(sttCalls, 3)
     }
 
+    func testRetryEngineWarmUpRecoversAfterFailedBackgroundWarmUp() async throws {
+        let perms = MockPermissionService()
+        let stt = MockSTTClient()
+        await stt.configureWarmUp(error: STTError.modelDownloadFailed)
+        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
+
+        let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
+        vm.jump(to: .engine)
+
+        vm.startEngineWarmUp()
+        try await Task.sleep(for: .milliseconds(900))
+
+        XCTAssertEqual(vm.engineState, .failed(message: STTError.modelDownloadFailed.localizedDescription))
+
+        await stt.configureWarmUp(error: nil)
+        vm.retryEngineWarmUp()
+        try await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertEqual(vm.engineState, .ready)
+    }
+
     func testEngineWarmUpFailsPreflightWhenOfflineOnFirstSetup() async throws {
         let perms = MockPermissionService()
         let stt = MockSTTClient()

--- a/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
@@ -109,6 +109,29 @@ final class OnboardingViewModelTests: XCTestCase {
         XCTAssertTrue(prepared)
     }
 
+    func testEngineWarmUpFailsWhenDiarizationPreparationFails() async throws {
+        let perms = MockPermissionService()
+        let stt = MockSTTClient()
+        let diarization = MockDiarizationService()
+        await diarization.configurePrepareModels(error: STTError.modelDownloadFailed)
+        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
+        defaults.removePersistentDomain(forName: defaults.volatileDomainNames.first ?? "")
+
+        let vm = makeViewModel(
+            permissionService: perms,
+            sttClient: stt,
+            diarizationService: diarization,
+            defaults: defaults
+        )
+        vm.jump(to: .engine)
+
+        vm.startEngineWarmUp()
+        try await Task.sleep(for: .milliseconds(150))
+
+        XCTAssertEqual(vm.engineState, .failed(message: STTError.modelDownloadFailed.localizedDescription))
+        XCTAssertFalse(vm.canContinueFromCurrentStep())
+    }
+
     func testMarkOnboardingCompletedPersistsToDefaults() {
         let perms = MockPermissionService()
         let stt = MockSTTClient()

--- a/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
@@ -7,6 +7,7 @@ final class OnboardingViewModelTests: XCTestCase {
     private func makeViewModel(
         permissionService: PermissionServiceProtocol,
         sttClient: STTClientProtocol,
+        diarizationService: DiarizationServiceProtocol? = nil,
         defaults: UserDefaults,
         isRuntimeSupported: @escaping @Sendable () -> Bool = { true },
         availableDiskBytes: @escaping @Sendable () -> Int64? = { 20 * 1_024 * 1_024 * 1_024 },
@@ -16,6 +17,7 @@ final class OnboardingViewModelTests: XCTestCase {
         OnboardingViewModel(
             permissionService: permissionService,
             sttClient: sttClient,
+            diarizationService: diarizationService,
             isRuntimeSupported: isRuntimeSupported,
             availableDiskBytes: availableDiskBytes,
             isNetworkReachable: isNetworkReachable,
@@ -82,6 +84,29 @@ final class OnboardingViewModelTests: XCTestCase {
         let called = await stt.wasWarmUpCalled()
         XCTAssertTrue(called)
         XCTAssertTrue(vm.canContinueFromCurrentStep())
+    }
+
+    func testEngineWarmUpPreparesDiarizationModelsBeforeReady() async throws {
+        let perms = MockPermissionService()
+        let stt = MockSTTClient()
+        let diarization = MockDiarizationService()
+        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
+        defaults.removePersistentDomain(forName: defaults.volatileDomainNames.first ?? "")
+
+        let vm = makeViewModel(
+            permissionService: perms,
+            sttClient: stt,
+            diarizationService: diarization,
+            defaults: defaults
+        )
+        vm.jump(to: .engine)
+
+        vm.startEngineWarmUp()
+        try await Task.sleep(for: .milliseconds(150))
+
+        XCTAssertEqual(vm.engineState, .ready)
+        let prepared = await diarization.prepareModelsCalled
+        XCTAssertTrue(prepared)
     }
 
     func testMarkOnboardingCompletedPersistsToDefaults() {

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -122,10 +122,12 @@ CREATE INDEX idx_events_session ON events(session);
 
 | Event | Props | Question It Answers |
 |---|---|---|
-| `transcription_started` | `source` (file, youtube, drag_drop), `audio_duration_seconds` | What sources are popular? How big are the files? |
-| `transcription_completed` | `source`, `audio_duration_seconds`, `processing_seconds`, `word_count` | Real-world performance metrics |
-| `transcription_cancelled` | `source`, `audio_duration_seconds` | Are people abandoning long jobs? |
-| `transcription_failed` | `source`, `error_type` | What's breaking? |
+| `transcription_started` | `source` (file, youtube, drag_drop, meeting), `audio_duration_seconds` | What sources are popular? How big are the jobs? |
+| `transcription_completed` | `source`, `audio_duration_seconds`, `processing_seconds`, `word_count`, `speaker_count`, `diarization_requested`, `diarization_applied`, `meeting_prepared_transcript_used?` | Real-world performance, speaker-label coverage, and whether meeting finalization reused live preview metadata |
+| `transcription_cancelled` | `source`, `audio_duration_seconds`, `stage` (download, audio_conversion, stt, diarization, post_processing) | Where do users abandon jobs? |
+| `transcription_failed` | `source`, `stage`, `error_type` | What's breaking, and in which pipeline stage? |
+
+`transcription_completed` is the canonical outcome event for batch/file/YouTube/meeting finalization. The separate `diarization_*` events remain useful for diarization-specific timing and failure analysis, but the completion event now carries enough context to answer product questions without joining multiple event streams first.
 
 ### 3b. Speaker Diarization — "Is speaker detection working?"
 

--- a/plans/active/2026-04-adr016-two-slot-convergence-plan.md
+++ b/plans/active/2026-04-adr016-two-slot-convergence-plan.md
@@ -1,0 +1,294 @@
+# ADR-016 Two-Slot Convergence Plan
+
+> Status: **ACTIVE**
+> Date: 2026-04-06
+> Driving docs: `spec/adr/016-centralized-stt-runtime-scheduler.md`, `spec/03-architecture.md`, `spec/06-stt-engine.md`, `spec/adr/015-concurrent-dictation-meeting.md`
+> GitHub context: issue `#64`, PR `#65`
+
+## Objective
+
+Converge the current centralized STT implementation on `feature/adr-016-stt-runtime-scheduler` from its intermediate three-lane shape to the approved ADR-016 two-slot design:
+
+- one process-wide STT control plane
+- one shared STT runtime owner
+- one reserved interactive slot for `dictation`
+- one shared background slot for `meetingFinalize`, `meetingLiveChunk`, and `fileTranscription`
+- explicit meeting-preview backpressure
+- diarization kept separate from the speech scheduler
+
+This plan is for the **next coding agent**. It assumes the docs are already aligned to the approved target and that the code is the remaining work.
+
+## Current Snapshot
+
+### Already true on this branch
+
+1. App-owned STT wiring is centralized in `AppEnvironment`.
+2. `STTRuntime` and `STTScheduler` exist and are shared by dictation, meeting recording, and transcription.
+3. `STTClient` is no longer app-owned architecture; it is a CLI/test compatibility facade.
+4. Meeting transcript backlog reporting is already wired through the panel UI.
+5. Docs/specs/ADRs now clearly distinguish:
+   - approved target architecture
+   - current branch implementation
+
+### Still not aligned with the approved target
+
+1. `STTRuntime` still owns **three** managers:
+   - `dictationManager`
+   - `meetingManager`
+   - `batchManager`
+2. `STTScheduler` still routes work through **three** internal lanes:
+   - `dictation`
+   - `meeting`
+   - `batch`
+3. That means the current code still protects file transcription from meeting work more strongly than the approved two-slot policy allows.
+4. Onboarding still has a real readiness gap:
+   - `runEnginePreflight()` only checks STT cache/readiness
+   - diarization preparation still happens later
+   - `DiarizationService.isReady()` is process-local, not a persistent cache/readiness check
+
+## Locked Target
+
+These are not open design questions for this pass.
+
+### Job classes
+
+1. `dictation`
+2. `meetingFinalize`
+3. `meetingLiveChunk`
+4. `fileTranscription`
+
+### Slot policy
+
+1. **Interactive slot**
+   - reserved for `dictation`
+2. **Background slot**
+   - shared by `meetingFinalize`, `meetingLiveChunk`, and `fileTranscription`
+
+### Background-slot priority
+
+1. `meetingFinalize`
+2. `meetingLiveChunk`
+3. `fileTranscription`
+
+### Explicit accepted tradeoff
+
+If a long `fileTranscription` job is already running on the background slot, later meeting STT work may wait until that non-preemptive batch job completes or reaches a future yield boundary. That is an accepted v1 tradeoff.
+
+### Out of scope for this pass
+
+1. Chunked/yielding batch transcription
+2. Hardware-adaptive executor counts
+3. A dedicated third batch slot
+4. Folding diarization into the STT scheduler
+5. Large UI redesign
+
+## Current vs Target Shape
+
+### Current branch implementation
+
+```text
+Feature services
+    │
+    ▼
+STTScheduler
+    ├── dictation lane
+    ├── meeting lane
+    └── batch lane
+    │
+    ▼
+STTRuntime
+    ├── dictationManager
+    ├── meetingManager
+    └── batchManager
+```
+
+### Approved target
+
+```text
+Feature services
+    │
+    ▼
+STTScheduler
+    ├── interactive slot
+    │     └── dictation
+    └── background slot
+          ├── meetingFinalize
+          ├── meetingLiveChunk
+          └── fileTranscription
+    │
+    ▼
+STTRuntime
+    ├── interactiveManager
+    └── backgroundManager
+```
+
+## Code Touchpoints
+
+### Must change
+
+1. `Sources/MacParakeetCore/STT/STTRuntime.swift`
+2. `Sources/MacParakeetCore/STT/STTScheduler.swift`
+3. `Sources/MacParakeetViewModels/OnboardingViewModel.swift`
+4. `Sources/MacParakeetCore/Services/DiarizationService.swift`
+5. `Tests/MacParakeetTests/STT/STTSchedulerTests.swift`
+6. `Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift`
+
+### Likely to inspect but not necessarily change much
+
+1. `Sources/MacParakeet/App/AppEnvironment.swift`
+2. `Sources/MacParakeetCore/STT/STTClient.swift`
+3. `Sources/MacParakeetCore/Services/MeetingRecordingService.swift`
+4. `Sources/MacParakeetCore/Services/TranscriptionService.swift`
+5. `Tests/MacParakeetTests/ViewModels/MeetingRecordingPanelViewModelTests.swift`
+
+## Recommended Delivery Order
+
+### Phase 1: Runtime topology convergence
+
+Goal: reduce the runtime from 3 internal managers to 2 without changing the public producer-facing API.
+
+Tasks:
+
+1. Replace the internal runtime lane enum with two cases:
+   - `interactive`
+   - `background`
+2. Replace:
+   - `dictationManager`
+   - `meetingManager`
+   - `batchManager`
+   with:
+   - `interactiveManager`
+   - `backgroundManager`
+3. Route jobs as follows:
+   - `dictation` -> `interactive`
+   - `meetingFinalize`, `meetingLiveChunk`, `fileTranscription` -> `background`
+4. Update initialization, cleanup, `isReady()`, and shutdown paths accordingly.
+
+Exit criteria:
+
+1. No `meetingManager` or `batchManager` remains in `STTRuntime`.
+2. Runtime routing is two-slot only.
+
+### Phase 2: Scheduler policy convergence
+
+Goal: collapse scheduler internals from 3 lanes to the approved 2-slot policy.
+
+Tasks:
+
+1. Replace `SchedulerLane` with:
+   - `interactive`
+   - `background`
+2. Update routing so:
+   - `dictation` always enters `interactive`
+   - `meetingFinalize`, `meetingLiveChunk`, `fileTranscription` enter `background`
+3. Keep priority ordering inside the background slot:
+   - `meetingFinalize`
+   - `meetingLiveChunk`
+   - `fileTranscription`
+4. Preserve current meeting-live backpressure behavior on the background slot.
+5. Preserve cancellation behavior and quiesce/shutdown semantics.
+
+Important:
+
+- Do **not** try to solve batch preemption in this pass.
+- The implementation should intentionally allow a running batch job to occupy the background slot.
+
+Exit criteria:
+
+1. No separate `meeting` or `batch` scheduler lanes remain.
+2. Queueing behavior matches the approved target.
+
+### Phase 3: Onboarding and diarization readiness
+
+Goal: remove the late speaker-model failure path and make onboarding readiness honest.
+
+Tasks:
+
+1. Add a persistent diarization readiness/cache check to `DiarizationService`.
+   Recommendation:
+   - introduce a static/nonisolated cache check or equivalent helper that does not rely on process-local `modelsReady`
+2. Update `OnboardingViewModel.runEnginePreflight()` so it does not return early solely because the STT model is cached when required diarization assets are still missing.
+3. Keep the accepted offline behavior:
+   - if both required assets are already cached, onboarding can proceed offline
+   - if any required default-on asset is missing, preflight must surface the disk/network requirement before warm-up claims success
+4. Keep diarization outside the STT scheduler itself.
+
+Exit criteria:
+
+1. Onboarding cannot report ready while speaker-detection assets are still missing.
+2. Reset-onboarding + offline no longer fails late in diarization preparation.
+
+### Phase 4: Test realignment
+
+Goal: make tests assert the approved two-slot behavior rather than the old three-lane independence behavior.
+
+Tasks:
+
+1. Rewrite `STTSchedulerTests` around:
+   - reserved interactive slot for `dictation`
+   - shared background slot for meeting + file jobs
+   - background priority ordering
+   - meeting-live backpressure
+   - cancellation/quiesce behavior
+2. Add or update tests for the accepted v1 tradeoff:
+   - a running file transcription may delay later meeting STT on the background slot
+3. Add onboarding tests that cover:
+   - STT cached + diarization missing + offline -> preflight failure before false-ready
+   - both cached -> offline success
+4. Keep existing meeting lagging-state UI tests intact; that path is already wired.
+
+Exit criteria:
+
+1. Tests describe the approved target policy, not the superseded three-lane model.
+
+### Phase 5: Final doc/code sync
+
+Goal: make the docs stop needing “current branch implementation note” language once the code actually converges.
+
+Tasks:
+
+1. Remove or simplify the “current branch implementation note” blocks in:
+   - `CLAUDE.md`
+   - `spec/03-architecture.md`
+   - `spec/06-stt-engine.md`
+2. Re-check memory wording against the actual implementation that ships after convergence.
+3. Update PR `#65` description if the implementation catches up to the docs during this pass.
+
+Exit criteria:
+
+1. Docs can describe the checked-out code directly again without caveats.
+
+## Testing / Verification Checklist
+
+### Required automated checks
+
+1. `swift build`
+2. `swift test`
+3. Focused scheduler tests:
+   - `swift test --filter STTSchedulerTests`
+4. Focused onboarding tests:
+   - `swift test --filter OnboardingViewModelTests`
+
+### Recommended manual checks
+
+1. Start file transcription, then start meeting recording:
+   - dictation remains responsive
+   - meeting preview/finalization behavior matches the accepted tradeoff
+2. Meeting live preview under backlog:
+   - lagging indicator appears
+   - final saved meeting remains complete
+3. Reset onboarding while offline with:
+   - STT cached
+   - diarization assets removed or unavailable
+   Verify onboarding fails honestly before ready state
+
+## Notes For The Next Agent
+
+1. Do not re-open the architecture debate in this pass; ADR-016 is already locked to the two-slot target.
+2. Do not spend time re-centralizing app wiring; that part is already done.
+3. The real implementation work is:
+   - topology convergence
+   - onboarding/diarization readiness correctness
+   - test realignment
+4. The meeting lagging-state UI path is already wired end-to-end; do not redo it unless a regression appears.
+5. If you need to preserve historical context, keep it in `plans/completed/2026-04-centralized-stt-runtime-scheduler.md`, not in active specs.

--- a/plans/completed/2026-04-centralized-stt-runtime-scheduler.md
+++ b/plans/completed/2026-04-centralized-stt-runtime-scheduler.md
@@ -1,6 +1,6 @@
 # Centralized STT Runtime + Scheduler Implementation Plan
 
-> Status: **ACTIVE**
+> Status: **IMPLEMENTED**
 > Date: 2026-04-05
 > Driving ADRs: ADR-016 (centralized STT runtime and scheduler), ADR-015 (concurrent dictation and meeting recording), ADR-014 (meeting recording)
 
@@ -14,6 +14,17 @@ This plan assumes the docs-first architecture update has already landed in spec/
 - one scheduler owns admission, priority, backpressure, cancellation, and job-scoped progress
 - dictation, meeting recording, and file/YouTube transcription become producers submitting jobs into the scheduler
 - audio capture remains independent per flow
+
+## Implementation Outcome
+
+The implementation landed with the intended end-state architecture:
+
+- `STTRuntime` is the sole app-owned owner of `AsrManager` lifecycle
+- `STTScheduler` is the sole app-owned owner of STT job admission, priority ordering, and backpressure
+- `AppEnvironment` wires one shared runtime/scheduler path for dictation, meeting recording, and file/YouTube transcription
+- onboarding warm-up, readiness checks, cache clearing, and shutdown all route through that shared path
+- meeting live chunks are dropped under backlog by scheduler policy rather than by service-local guards
+- `STTClient` remains only as a compatibility facade around the shared stack for standalone callers/tests
 
 ## Goals
 
@@ -75,7 +86,7 @@ This plan assumes the docs-first architecture update has already landed in spec/
 
 ### Backpressure Policy
 
-1. Meeting live chunk jobs are droppable/coalescible under backlog.
+1. Meeting live chunk jobs are droppable under backlog.
 2. Dictation must never wait behind queued low-priority work.
 3. Batch file work may wait, pause between work units, or remain non-preemptive in phase 1.
 
@@ -144,7 +155,7 @@ Exit criteria:
 
 1. Move live chunk backlog policy into the scheduler or clearly partitioned scheduling logic.
 2. Preserve current best-effort behavior for live preview.
-3. Make dropped/coalesced work observable in tests and logs.
+3. Make dropped work observable in tests and logs.
 
 Exit criteria:
 - backlog behavior is explicit, not incidental.
@@ -173,7 +184,7 @@ Exit criteria:
 3. Progress isolation:
    - progress for one job does not leak to another
 4. Backpressure:
-   - meeting live chunks drop or coalesce under thresholds
+   - meeting live chunks drop under thresholds
 
 ### Regression Coverage
 
@@ -204,11 +215,11 @@ Tests:
 - `Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift`
 - new scheduler-focused tests
 
-## Open Design Questions
+## Resolved Design Decisions
 
-1. Should `STTClientProtocol` remain the producer-facing interface, with the scheduler hidden behind it, or should producers depend on a new `STTScheduling` protocol?
-2. Should meeting live chunk dropping live inside `MeetingRecordingService` or move fully into the scheduler?
-3. Do we segment file/YouTube transcription now, or explicitly defer that to a follow-up once the centralized scheduler is in place?
+1. Keep `STTClientProtocol` as the producer-facing compatibility boundary for this pass, backed by the shared scheduler/runtime path.
+2. Move meeting live chunk dropping fully into `STTScheduler` so backpressure policy has one owner.
+3. Defer segmented file/YouTube transcription to follow-up work; ADR-016 ships centralized ownership and priority ordering first.
 
 ## Recommended Delivery Shape
 

--- a/plans/completed/2026-04-centralized-stt-runtime-scheduler.md
+++ b/plans/completed/2026-04-centralized-stt-runtime-scheduler.md
@@ -6,11 +6,11 @@
 
 ## Overview
 
-Refactor MacParakeet's STT architecture from per-flow client ownership to one process-wide STT runtime with one explicit scheduler/broker in front of it.
+Refactor MacParakeet's STT architecture from per-flow client ownership to one process-wide STT runtime owner with one explicit scheduler/broker in front of it.
 
 This plan assumes the docs-first architecture update has already landed in spec/ADR form. The code should be brought into alignment with the new decision:
 
-- one STT runtime owns `AsrManager`
+- one STT runtime actor owns the lane-scoped `AsrManager` set
 - one scheduler owns admission, priority, backpressure, cancellation, and job-scoped progress
 - dictation, meeting recording, and file/YouTube transcription become producers submitting jobs into the scheduler
 - audio capture remains independent per flow
@@ -19,11 +19,12 @@ This plan assumes the docs-first architecture update has already landed in spec/
 
 The implementation landed with the intended end-state architecture:
 
-- `STTRuntime` is the sole app-owned owner of `AsrManager` lifecycle
+- `STTRuntime` is the sole app-owned owner of model lifecycle and lane-scoped `AsrManager` instances
 - `STTScheduler` is the sole app-owned owner of STT job admission, priority ordering, and backpressure
 - `AppEnvironment` wires one shared runtime/scheduler path for dictation, meeting recording, and file/YouTube transcription
 - onboarding warm-up, readiness checks, cache clearing, and shutdown all route through that shared path
 - meeting live chunks are dropped under backlog by scheduler policy rather than by service-local guards
+- only the immediate post-stop meeting path uses `meetingFinalize`; archived meeting retranscribes stay on the batch lane
 - `STTClient` remains only as a compatibility facade around the shared stack for standalone callers/tests
 
 ## Goals
@@ -54,7 +55,7 @@ The implementation landed with the intended end-state architecture:
 ### Core Types
 
 1. `STTRuntime`
-   - Sole owner of `AsrManager`
+   - Sole owner of model lifecycle and the lane-scoped `AsrManager` set
    - Handles warm-up, initialization, readiness, shutdown, cache clearing
    - Exposes a minimal runtime API to execute one transcription request
 
@@ -77,17 +78,16 @@ The implementation landed with the intended end-state architecture:
 3. `TranscriptionService`
    - submits `fileTranscription` jobs
 
-### Priority Policy
+### Lane Policy
 
-1. `dictation`
-2. `meetingFinalize`
-3. `meetingLiveChunk`
-4. `fileTranscription`
+1. Dictation lane: `dictation`
+2. Meeting lane: `meetingFinalize` ahead of `meetingLiveChunk`
+3. Batch lane: `fileTranscription`
 
 ### Backpressure Policy
 
 1. Meeting live chunk jobs are droppable under backlog.
-2. Dictation must never wait behind queued low-priority work.
+2. Dictation and active meeting work must never wait behind queued batch/library retranscription work.
 3. Batch file work may wait, pause between work units, or remain non-preemptive in phase 1.
 
 ## Execution Phases
@@ -132,7 +132,7 @@ Exit criteria:
 1. `DictationService` submits dictation jobs to the scheduler.
 2. `MeetingRecordingService` submits live chunk jobs to the scheduler.
 3. `MeetingRecordingService` finalization path submits a higher-priority meeting-finalize job.
-4. `TranscriptionService` submits file/YouTube jobs to the scheduler.
+4. `TranscriptionService` submits file/YouTube jobs plus saved-item retranscribes to the batch lane.
 
 Exit criteria:
 - no feature service owns its own STT runtime/client.
@@ -219,7 +219,8 @@ Tests:
 
 1. Keep `STTClientProtocol` as the producer-facing compatibility boundary for this pass, backed by the shared scheduler/runtime path.
 2. Move meeting live chunk dropping fully into `STTScheduler` so backpressure policy has one owner.
-3. Defer segmented file/YouTube transcription to follow-up work; ADR-016 ships centralized ownership and priority ordering first.
+3. Keep `meetingFinalize` reserved for the immediate post-stop path; saved meeting retranscribes remain batch work.
+4. Defer segmented file/YouTube transcription to follow-up work; ADR-016 ships centralized ownership and lane policy first.
 
 ## Recommended Delivery Shape
 

--- a/plans/completed/2026-04-centralized-stt-runtime-scheduler.md
+++ b/plans/completed/2026-04-centralized-stt-runtime-scheduler.md
@@ -1,240 +1,119 @@
-# Centralized STT Runtime + Scheduler Implementation Plan
+# Centralized STT Runtime + Scheduler Plan
 
-> Status: **IMPLEMENTED**
+> Status: **HISTORICAL** - implementation branch landed an intermediate lane-based design; ADR-016 was refined on 2026-04-06 to a two-slot target architecture
 > Date: 2026-04-05
+> Updated: 2026-04-06
 > Driving ADRs: ADR-016 (centralized STT runtime and scheduler), ADR-015 (concurrent dictation and meeting recording), ADR-014 (meeting recording)
 
 ## Overview
 
-Refactor MacParakeet's STT architecture from per-flow client ownership to one process-wide STT runtime owner with one explicit scheduler/broker in front of it.
+This plan originally drove the refactor from per-flow STT ownership to one process-wide runtime owner with one explicit scheduler in front of it.
 
-This plan assumes the docs-first architecture update has already landed in spec/ADR form. The code should be brought into alignment with the new decision:
+The branch that followed this plan successfully centralized runtime ownership and replaced implicit contention with explicit scheduling, but it implemented that policy as three fixed execution lanes:
 
-- one STT runtime actor owns the lane-scoped `AsrManager` set
-- one scheduler owns admission, priority, backpressure, cancellation, and job-scoped progress
-- dictation, meeting recording, and file/YouTube transcription become producers submitting jobs into the scheduler
-- audio capture remains independent per flow
+- dictation
+- meeting
+- batch
 
-## Implementation Outcome
+After a final product and architecture review on 2026-04-06, MacParakeet's approved target architecture was simplified further. The accepted end state is now:
 
-The implementation landed with the intended end-state architecture:
+- one process-wide STT control plane
+- one shared STT runtime owner
+- four job classes:
+  - `dictation`
+  - `meetingFinalize`
+  - `meetingLiveChunk`
+  - `fileTranscription`
+- two default execution slots:
+  - an interactive slot reserved for `dictation`
+  - a background slot shared by `meetingFinalize`, `meetingLiveChunk`, and `fileTranscription`
+- background-slot priority:
+  1. `meetingFinalize`
+  2. `meetingLiveChunk`
+  3. `fileTranscription`
+- explicit backpressure for droppable meeting live preview
+- diarization kept separate from the speech-slot scheduler
 
-- `STTRuntime` is the sole app-owned owner of model lifecycle and lane-scoped `AsrManager` instances
-- `STTScheduler` is the sole app-owned owner of STT job admission, priority ordering, and backpressure
-- `AppEnvironment` wires one shared runtime/scheduler path for dictation, meeting recording, and file/YouTube transcription
-- onboarding warm-up, readiness checks, cache clearing, and shutdown all route through that shared path
-- meeting live chunks are dropped under backlog by scheduler policy rather than by service-local guards
-- only the immediate post-stop meeting path uses `meetingFinalize`; archived meeting retranscribes stay on the batch lane
-- `STTClient` remains only as a compatibility facade around the shared stack for standalone callers/tests
+This archived plan is kept for historical context because it explains how the branch reached shared STT ownership, but ADR-016 and the active specs now define the canonical target architecture.
 
-## Goals
+## What The Branch Accomplished
 
-1. Make STT ownership explicit and singular.
-2. Protect dictation latency during concurrent meeting recording.
-3. Preserve meeting live preview while making it best-effort under backlog.
-4. Keep file/YouTube transcription architecturally compatible without letting it degrade interactive responsiveness.
-5. Replace incidental concurrency with tested scheduling policy.
+The implementation branch delivered these important architectural steps:
 
-## Non-Goals
+1. One app-owned `STTRuntime` path for model lifecycle, warm-up, readiness, cache clearing, and shutdown.
+2. One app-owned `STTScheduler` path for admission, ordering, progress fan-out, and backpressure.
+3. Shared app wiring through `AppEnvironment` instead of per-feature STT ownership.
+4. Explicit meeting live-preview backlog handling instead of relying on incidental service-local behavior.
 
-1. Rewriting the audio capture architecture.
-2. Reworking dictation or meeting UI state machines beyond integration changes.
-3. Shipping a large product UX change in the same PR.
-4. Solving perfect mid-job preemption for long batch transcription in phase 1.
+Those changes remain directionally correct and are the foundation of the approved design.
 
-## Current Problems To Eliminate
+## Where The Plan Drifted
 
-1. Multiple STT owners in `AppEnvironment`.
-2. Warm-up/onboarding bound to only one STT client.
-3. Shutdown/cleanup bound to only one STT client.
-4. No explicit scheduler policy between dictation, meeting live chunks, and file transcription.
-5. Progress handling coupled too closely to the raw runtime stream.
+This plan assumed the end-state scheduler would keep three fixed execution lanes alive in parallel:
 
-## Target Architecture
+1. Dictation lane
+2. Meeting lane
+3. Batch lane
 
-### Core Types
+That design protects concurrent meeting and dictation work well, but it permanently reserves real inference capacity for file / YouTube transcription. For MacParakeet's product priorities, that turned out to be a stronger commitment than necessary.
 
-1. `STTRuntime`
-   - Sole owner of model lifecycle and the lane-scoped `AsrManager` set
-   - Handles warm-up, initialization, readiness, shutdown, cache clearing
-   - Exposes a minimal runtime API to execute one transcription request
+The approved target architecture therefore does **not** reserve a dedicated third file-transcription slot in v1.
 
-2. `STTScheduler`
-   - Sole owner of queueing, priorities, fairness, cancellation, and backpressure
-   - Executes jobs against `STTRuntime`
-   - Exposes request-scoped progress/results
+## Approved Target Architecture
 
-3. `STTJob`
-   - Encodes request kind and priority
-   - Carries source metadata and cancellation/progress hooks
+### Control Plane
 
-### Producers
+- One process-wide `STTScheduler` owns job admission, queueing, priority, slot assignment, cancellation, backpressure, and job-scoped progress.
+- Producer services submit jobs into the scheduler; they do not own STT topology.
 
-1. `DictationService`
-   - submits `dictation` jobs
-2. `MeetingRecordingService`
-   - submits `meetingLiveChunk` jobs
-   - submits `meetingFinalize` jobs
-3. `TranscriptionService`
-   - submits `fileTranscription` jobs
+### Runtime
 
-### Lane Policy
+- One shared `STTRuntime` owns model lifecycle and the slot-scoped `AsrManager` instances behind the scheduler.
+- Warm-up, readiness, shutdown, and cache clear remain single-path operations.
 
-1. Dictation lane: `dictation`
-2. Meeting lane: `meetingFinalize` ahead of `meetingLiveChunk`
-3. Batch lane: `fileTranscription`
+### Job Classes
+
+1. `dictation`
+2. `meetingFinalize`
+3. `meetingLiveChunk`
+4. `fileTranscription`
+
+### Slot Policy
+
+1. **Interactive slot**
+   - reserved for `dictation`
+2. **Background slot**
+   - shared by `meetingFinalize`, `meetingLiveChunk`, and `fileTranscription`
+
+Priority within the background slot:
+
+1. `meetingFinalize`
+2. `meetingLiveChunk`
+3. `fileTranscription`
 
 ### Backpressure Policy
 
-1. Meeting live chunk jobs are droppable under backlog.
-2. Dictation and active meeting work must never wait behind queued batch/library retranscription work.
-3. Batch file work may wait, pause between work units, or remain non-preemptive in phase 1.
+1. Meeting live preview is best-effort and droppable under backlog.
+2. When a meeting stops, queued live-preview work may be cancelled/dropped so finalization can run next.
+3. File transcription is intentionally queued and single-job in v1.
+4. A running long file transcription may delay meeting STT on the background slot until the batch job finishes or reaches a future yield boundary.
 
-## Execution Phases
+### Diarization Boundary
 
-### Phase 0: Pre-Flight and Design Lock
+Speaker diarization remains a separate service and is not part of the two-slot speech scheduler.
 
-1. Keep ADR-016 and surrounding docs authoritative.
-2. Identify all direct `STTClientProtocol` consumers.
-3. Decide whether phase 1 keeps `STTClientProtocol` as the public producer-facing boundary or introduces a new scheduler protocol immediately.
+## Follow-Up Guidance
 
-Exit criteria:
-- One agreed runtime/scheduler API surface documented in code comments or an implementation sketch.
+Any future implementation work should converge the code on ADR-016's two-slot design rather than extending the historical three-lane branch shape.
 
-### Phase 1: Introduce `STTRuntime`
+If the product later needs stronger simultaneous support for `dictation + meeting + file transcription`, the preferred follow-up order is:
 
-1. Extract the current model lifecycle responsibilities from `STTClient` into a dedicated runtime owner.
-2. Keep behavior identical:
-   - lazy init
-   - warm-up
-   - readiness
-   - shutdown
-   - cache clearing
-3. Ensure there is exactly one runtime instance in `AppEnvironment`.
+1. chunk or otherwise bound file-transcription work so it can yield cleanly
+2. measure whether a third batch slot is justified on baseline Apple Silicon hardware
+3. only then consider enabling an optional third slot
 
-Exit criteria:
-- `AppEnvironment` has one runtime owner.
-- warm-up and shutdown code paths target the shared runtime only.
+## References
 
-### Phase 2: Introduce `STTScheduler`
-
-1. Add an explicit scheduler actor in front of the runtime.
-2. Define job kinds and priority ordering.
-3. Execute one job at a time against the runtime in phase 1.
-4. Expose request-scoped progress and cancellation.
-
-Exit criteria:
-- producers no longer talk to runtime lifecycle directly.
-- scheduler ordering is deterministic and testable.
-
-### Phase 3: Migrate Producers
-
-1. `DictationService` submits dictation jobs to the scheduler.
-2. `MeetingRecordingService` submits live chunk jobs to the scheduler.
-3. `MeetingRecordingService` finalization path submits a higher-priority meeting-finalize job.
-4. `TranscriptionService` submits file/YouTube jobs plus saved-item retranscribes to the batch lane.
-
-Exit criteria:
-- no feature service owns its own STT runtime/client.
-- all transcription requests flow through one scheduler.
-
-### Phase 4: Progress Isolation
-
-1. Ensure progress is job-scoped.
-2. Prevent crosstalk between:
-   - onboarding warm-up
-   - dictation progress
-   - meeting live chunk work
-   - file transcription progress
-3. Update any producer assumptions that progress is globally sourced from the runtime.
-
-Exit criteria:
-- concurrent or interleaved jobs cannot leak progress to the wrong caller.
-
-### Phase 5: Backpressure for Meeting Live Chunks
-
-1. Move live chunk backlog policy into the scheduler or clearly partitioned scheduling logic.
-2. Preserve current best-effort behavior for live preview.
-3. Make dropped work observable in tests and logs.
-
-Exit criteria:
-- backlog behavior is explicit, not incidental.
-- meeting live preview can degrade gracefully without affecting correctness of final saved meeting.
-
-### Phase 6: Batch Work Strategy
-
-1. Decide phase-1 behavior for file/YouTube transcription while interactive work exists:
-   - queue-only, non-preemptive between jobs
-   - or bounded segmentation if feasible now
-2. Document tradeoff in code and tests.
-3. If not segmented in this pass, add a follow-up task for chunked batch STT.
-
-Exit criteria:
-- product behavior is intentional and documented.
-
-## Testing Plan
-
-### New Tests
-
-1. Scheduler priority ordering:
-   - dictation beats queued meeting live chunks
-   - meeting finalization beats queued file transcription
-2. Shared ownership:
-   - warm-up, readiness, shutdown, cache clear target one runtime
-3. Progress isolation:
-   - progress for one job does not leak to another
-4. Backpressure:
-   - meeting live chunks drop under thresholds
-
-### Regression Coverage
-
-1. Existing dictation service tests remain green.
-2. Existing meeting recording tests remain green.
-3. Existing transcription service tests remain green.
-4. Full suite remains green after producer migration.
-
-## Likely File Touchpoints
-
-Core:
-- `Sources/MacParakeetCore/STT/STTClient.swift`
-- `Sources/MacParakeetCore/STT/STTClientProtocol.swift`
-- new runtime/scheduler files under `Sources/MacParakeetCore/STT/`
-
-Services:
-- `Sources/MacParakeetCore/Services/DictationService.swift`
-- `Sources/MacParakeetCore/Services/MeetingRecordingService.swift`
-- `Sources/MacParakeetCore/Services/TranscriptionService.swift`
-
-App wiring:
-- `Sources/MacParakeet/App/AppEnvironment.swift`
-- `Sources/MacParakeet/AppDelegate.swift`
-
-Tests:
-- `Tests/MacParakeetTests/STT/*`
-- `Tests/MacParakeetTests/Services/MeetingRecordingServiceTests.swift`
-- `Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift`
-- new scheduler-focused tests
-
-## Resolved Design Decisions
-
-1. Keep `STTClientProtocol` as the producer-facing compatibility boundary for this pass, backed by the shared scheduler/runtime path.
-2. Move meeting live chunk dropping fully into `STTScheduler` so backpressure policy has one owner.
-3. Keep `meetingFinalize` reserved for the immediate post-stop path; saved meeting retranscribes remain batch work.
-4. Defer segmented file/YouTube transcription to follow-up work; ADR-016 ships centralized ownership and lane policy first.
-
-## Recommended Delivery Shape
-
-1. Runtime extraction + single-owner wiring
-2. Scheduler introduction + dictation migration
-3. Meeting recording migration + backlog policy
-4. File/YouTube migration + progress isolation
-5. Final cleanup, tests, and doc sync
-
-## Definition of Done
-
-1. There is one process-wide STT runtime owner.
-2. There is one explicit scheduler/broker for all STT work.
-3. Dictation and meeting recording coexist without per-flow STT ownership.
-4. Warm-up and shutdown are single-path and deterministic.
-5. Scheduler priority/backpressure behavior is covered by tests.
-6. Docs and code match ADR-016.
+- ADR-016: `spec/adr/016-centralized-stt-runtime-scheduler.md`
+- Architecture spec: `spec/03-architecture.md`
+- STT engine spec: `spec/06-stt-engine.md`

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -341,7 +341,7 @@ User drops file(s) onto window or menu bar icon
          │
          ▼
 ┌──────────────────┐
-│  STT Scheduler   │ ── Submit file transcription job to shared STT stack
+│  STT Scheduler   │ ── Queue low-priority file transcription job in shared STT stack
 └────────┬─────────┘
          │
          ▼

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -341,7 +341,7 @@ User drops file(s) onto window or menu bar icon
          │
          ▼
 ┌──────────────────┐
-│    STTClient     │ ── Send audio to Parakeet via FluidAudio CoreML
+│  STT Scheduler   │ ── Submit file transcription job to shared STT stack
 └────────┬─────────┘
          │
          ▼

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -96,23 +96,23 @@ See [00-vision.md](./00-vision.md) for positioning and market context.
 
 ### F0: First-Run Onboarding
 
-**What:** A premium first-run setup window that guides users through permissions, hotkey basics, and local model setup so core dictation and file transcription are ready immediately.
+**What:** A premium first-run setup window that guides users through permissions, hotkey basics, and local speech-stack setup so core dictation and file transcription are ready immediately.
 
 **Goals:**
 - Reduce first-run friction (no mysterious permission failures).
 - Teach the core interaction model in under 60 seconds.
-- Download and warm up the local speech model (Parakeet STT) on first run.
+- Download and warm up the local speech stack on first run: Parakeet STT plus default-on speaker-detection assets.
 
 **Flow:**
 1. Welcome
 2. Microphone permission
 3. Accessibility permission
 4. Hotkey instructions (configurable trigger + Esc)
-5. Speech model setup (Parakeet, retry required)
+5. Speech stack setup (Parakeet + speaker detection, retry required)
 6. Ready
 
 **Model failure recovery:**
-- Before warm-up, onboarding runs lightweight preflight checks (runtime support + first-setup disk/network readiness).
+- Before warm-up, onboarding runs lightweight preflight checks (runtime support + first-setup disk/network readiness for both STT and any required default-on speaker-detection assets).
 - If local model setup fails, onboarding shows explicit recovery tips based on failure type.
 - Users get direct CTAs: `Retry` and `Open Settings` (to `Settings > Local Models > Repair`).
 

--- a/spec/03-architecture.md
+++ b/spec/03-architecture.md
@@ -110,16 +110,18 @@ Dictation and meeting recording run concurrently as independent audio pipelines,
 
                 │
                 ▼
-      STT Scheduler / Broker (priority + backpressure)
+      STT Scheduler / Control Plane
+      ├── Interactive slot  → dictation
+      └── Background slot   → meeting + file transcription
                 │
                 ▼
-     STT Runtime (lane-scoped AsrManagers on CoreML / ANE)
+     STT Runtime (slot-scoped AsrManagers on CoreML / ANE)
 ```
 
 - **No shared audio engine** — dictation and meeting capture remain independent. macOS HAL multiplexes mic access.
 - **No mutual exclusion** — dictation and meeting recording can both be active.
 - **Centralized STT ownership** — one runtime owns model lifecycle, warm-up, and shutdown.
-- **Explicit scheduling** — dedicated dictation / meeting / batch lanes; within the meeting lane, finalize beats live preview.
+- **Explicit scheduling** — a reserved dictation slot plus a shared background slot; within the background slot, finalize beats live preview, and file transcription waits.
 - **Menu bar icon priority** — meeting > dictation > file-transcription > idle.
 
 ---
@@ -298,7 +300,7 @@ Saved meeting audio file
 AudioProcessor.convert(fileURL:) → 16kHz mono WAV in temp dir
     │
     ▼
-STTScheduler.transcribe(audioPath:, job: .fileTranscription, onProgress:) → batch lane work
+STTScheduler.transcribe(audioPath:, job: .fileTranscription, onProgress:) → queued background-slot work
     │
     ▼
 Updated Transcription persisted with sourceType still = .meeting
@@ -372,7 +374,7 @@ protocol AudioProcessorProtocol: Sendable {
 
 #### 2.5 STT Runtime + Scheduler
 
-**Responsibility:** The shared STT stack owns one process-wide Parakeet runtime actor plus one explicit scheduler. `STTRuntime` owns FluidAudio model lifecycle and the lane-scoped `AsrManager` set used by dictation, meeting, and batch work. `STTScheduler` owns lane admission, in-lane priority, backpressure, cancellation, and request-scoped progress. `STTClient` remains as a compatibility facade, not as an app-owned second runtime.
+**Responsibility:** The shared STT stack owns one process-wide Parakeet runtime actor plus one explicit scheduler. `STTRuntime` owns FluidAudio model lifecycle and the slot-scoped `AsrManager` set used by the interactive and background execution slots. `STTScheduler` owns admission, slot assignment, in-slot priority, backpressure, cancellation, and request-scoped progress. `STTClient` remains as a compatibility facade, not as an app-owned second runtime.
 
 **Key Types/Protocols:**
 ```swift
@@ -450,12 +452,13 @@ Feature services (Dictation / Meeting / File / URL)
     │
     ▼
 STTScheduler
+    ├── interactive slot → dictation
+    └── background slot  → meetingFinalize > meetingLiveChunk > fileTranscription
     │
     ▼
 STTRuntime
-    ├── dictation lane → AsrManager
-    ├── meeting lane   → AsrManager
-    └── batch lane     → AsrManager
+    ├── interactive slot → AsrManager
+    └── background slot  → AsrManager
 ```
 
 **Model Lifecycle:**
@@ -467,14 +470,14 @@ STTRuntime.warmUp() called (lazy, on first use or from onboarding)
     │
     ├── Check: Are CoreML models downloaded?
     │     │
-    │     ├── Yes → initialize lane managers → Runtime ready (~162ms warm load)
+    │     ├── Yes → initialize slot managers → Runtime ready (~162ms warm load)
     │     │
     │     └── No ──► AsrModels.downloadAndLoad() (~6 GB download)
     │                  CoreML compilation (~3.4s first time)
-    │                  initialize lane managers
+    │                  initialize slot managers
     │
     ▼
-Lane managers ready — scheduler admits transcription jobs
+Slot managers ready — scheduler admits transcription jobs
 ```
 
 #### 2.6 ExportService
@@ -1101,7 +1104,7 @@ Subsequent Launches ──> Window shown (fast)
                        Dictation runs immediately
 ```
 
-After initial warm-up, subsequent dictations are near-instant because the shared runtime keeps `AsrManager` initialized and ready between requests.
+After initial warm-up, subsequent dictations are near-instant because the shared runtime keeps its slot managers initialized and ready between requests.
 
 ### Transcription Speed
 
@@ -1116,7 +1119,7 @@ Parakeet TDT 0.6B-v3 throughput varies by device class: approximately 155x realt
 
 ### Memory Management
 
-- **Parakeet model:** One shared runtime keeps `AsrManager` initialized after first use. Uses ~66 MB working RAM on the ANE. Released when the app quits.
+- **Parakeet model:** One shared runtime keeps its slot managers initialized after first use. Uses ~66 MB working RAM per active inference slot on the ANE path and is released when the app quits.
 - **Audio buffers:** Ring buffer during recording, flushed to temp file on stop. No recording duration limit — local processing means no artificial caps.
 - **Database:** GRDB uses WAL mode by default. No connection pooling needed (single-user app).
 
@@ -1129,7 +1132,7 @@ First dictation completes
     │
     ▼
 Schedule background task (low priority):
-    └── If Parakeet model not loaded → initialize AsrManager
+    └── If Parakeet model not loaded → initialize the shared runtime's slot managers
 ```
 
 This ensures subsequent interactions feel instant without bloating initial startup.

--- a/spec/03-architecture.md
+++ b/spec/03-architecture.md
@@ -87,9 +87,9 @@
 
 **Core STT runs on-device.** Optional LLM features use configured providers or Local CLI tools, and telemetry/crash reporting are opt-out. The app supports a fully local setup, but it is not network-free in every configuration.
 
-### Concurrency Model (ADR-015 + ADR-016 Target)
+### Concurrency Model (ADR-015 + ADR-016)
 
-The diagram below shows the **approved ADR-016 target architecture**. Dictation and meeting recording run concurrently as independent audio pipelines, while STT converges on one scheduler and one shared runtime owner:
+The diagram below shows the ADR-016 architecture. Dictation and meeting recording run concurrently as independent audio pipelines, while STT routes through one scheduler and one shared runtime owner:
 
 ```
 ┌─ Dictation Pipeline ──────────────────────┐
@@ -120,11 +120,9 @@ The diagram below shows the **approved ADR-016 target architecture**. Dictation 
 
 - **No shared audio engine** — dictation and meeting capture remain independent. macOS HAL multiplexes mic access.
 - **No mutual exclusion** — dictation and meeting recording can both be active.
-- **Centralized STT ownership** — the approved end state has one runtime owner for lifecycle, warm-up, and shutdown.
-- **Explicit scheduling** — the approved end state uses a reserved dictation slot plus a shared background slot; within the background slot, finalize beats live preview, and file transcription waits.
+- **Centralized STT ownership** — one runtime owner manages lifecycle, warm-up, and shutdown.
+- **Explicit scheduling** — the STT stack uses a reserved dictation slot plus a shared background slot; within the background slot, finalize beats live preview, and file transcription waits.
 - **Menu bar icon priority** — meeting > dictation > file-transcription > idle.
-
-**Current branch implementation note:** this branch has already centralized STT ownership in `AppEnvironment`, but the checked-out code still uses an intermediate internal `dictation` / `meeting` / `batch` lane topology while converging to the target two-slot policy.
 
 ---
 
@@ -376,9 +374,7 @@ protocol AudioProcessorProtocol: Sendable {
 
 #### 2.5 STT Runtime + Scheduler
 
-**Responsibility:** The shared STT stack owns one process-wide Parakeet runtime actor plus one explicit scheduler. In the **approved target architecture**, `STTRuntime` owns FluidAudio model lifecycle and the slot-scoped `AsrManager` set used by the interactive and background execution slots. `STTScheduler` owns admission, slot assignment, in-slot priority, backpressure, cancellation, and request-scoped progress. `STTClient` remains as a compatibility facade, not as an app-owned second runtime.
-
-**Current branch implementation note:** the checked-out v0.6 code already centralizes ownership behind shared `STTRuntime` / `STTScheduler` instances, but it still routes execution through internal `dictation`, `meeting`, and `batch` lanes rather than the final two-slot policy documented here.
+**Responsibility:** The shared STT stack owns one process-wide Parakeet runtime actor plus one explicit scheduler. `STTRuntime` owns FluidAudio model lifecycle and the slot-scoped `AsrManager` set used by the interactive and background execution slots. `STTScheduler` owns admission, slot assignment, in-slot priority, backpressure, cancellation, and request-scoped progress. `STTClient` remains as a compatibility facade, not as an app-owned second runtime.
 
 **Key Types/Protocols:**
 ```swift

--- a/spec/03-architecture.md
+++ b/spec/03-architecture.md
@@ -89,7 +89,7 @@
 
 ### Concurrency Model (ADR-015 + ADR-016)
 
-Dictation and meeting recording run concurrently as independent audio pipelines, but all STT work routes through one scheduler and one runtime:
+Dictation and meeting recording run concurrently as independent audio pipelines, but all STT work routes through one scheduler and one shared runtime owner:
 
 ```
 ┌─ Dictation Pipeline ──────────────────────┐
@@ -113,13 +113,13 @@ Dictation and meeting recording run concurrently as independent audio pipelines,
       STT Scheduler / Broker (priority + backpressure)
                 │
                 ▼
-     STT Runtime (single AsrManager on CoreML / ANE)
+     STT Runtime (lane-scoped AsrManagers on CoreML / ANE)
 ```
 
 - **No shared audio engine** — dictation and meeting capture remain independent. macOS HAL multiplexes mic access.
 - **No mutual exclusion** — dictation and meeting recording can both be active.
 - **Centralized STT ownership** — one runtime owns model lifecycle, warm-up, and shutdown.
-- **Explicit scheduling** — dictation > meeting finalize > meeting live chunks > file transcription.
+- **Explicit scheduling** — dedicated dictation / meeting / batch lanes; within the meeting lane, finalize beats live preview.
 - **Menu bar icon priority** — meeting > dictation > file-transcription > idle.
 
 ---
@@ -262,7 +262,7 @@ DictationResult returned
 
 #### 2.2 TranscriptionService
 
-**Responsibility:** Orchestrates file and URL transcription: download/convert audio, run STT, apply optional deterministic cleanup, persist results, and emit UI progress phases.
+**Responsibility:** Orchestrates file and URL transcription: download/convert audio, run STT, apply optional deterministic cleanup, persist results, emit UI progress phases, and retranscribe saved library items.
 
 **Key Types/Protocols:**
 ```swift
@@ -290,6 +290,18 @@ TranscriptionRepository.save() → persisted to database
     │
     ▼
 Transcription returned to UI
+
+Saved meeting retranscription from the library:
+Saved meeting audio file
+    │
+    ▼
+AudioProcessor.convert(fileURL:) → 16kHz mono WAV in temp dir
+    │
+    ▼
+STTScheduler.transcribe(audioPath:, job: .fileTranscription, onProgress:) → batch lane work
+    │
+    ▼
+Updated Transcription persisted with sourceType still = .meeting
 
 YouTube URL transcription:
 YouTube URL
@@ -360,7 +372,7 @@ protocol AudioProcessorProtocol: Sendable {
 
 #### 2.5 STT Runtime + Scheduler
 
-**Responsibility:** The shared STT stack owns one process-wide Parakeet runtime plus one explicit scheduler. `STTRuntime` owns FluidAudio model lifecycle. `STTScheduler` owns job admission, priority, backpressure, cancellation, and request-scoped progress. `STTClient` remains as a compatibility facade, not as an app-owned second runtime.
+**Responsibility:** The shared STT stack owns one process-wide Parakeet runtime actor plus one explicit scheduler. `STTRuntime` owns FluidAudio model lifecycle and the lane-scoped `AsrManager` set used by dictation, meeting, and batch work. `STTScheduler` owns lane admission, in-lane priority, backpressure, cancellation, and request-scoped progress. `STTClient` remains as a compatibility facade, not as an app-owned second runtime.
 
 **Key Types/Protocols:**
 ```swift
@@ -441,9 +453,9 @@ STTScheduler
     │
     ▼
 STTRuntime
-    │
-    ▼
-AsrManager (single process-wide owner)
+    ├── dictation lane → AsrManager
+    ├── meeting lane   → AsrManager
+    └── batch lane     → AsrManager
 ```
 
 **Model Lifecycle:**
@@ -455,14 +467,14 @@ STTRuntime.warmUp() called (lazy, on first use or from onboarding)
     │
     ├── Check: Are CoreML models downloaded?
     │     │
-    │     ├── Yes → AsrManager.initialize(models:) → Runtime ready (~162ms warm load)
+    │     ├── Yes → initialize lane managers → Runtime ready (~162ms warm load)
     │     │
     │     └── No ──► AsrModels.downloadAndLoad() (~6 GB download)
     │                  CoreML compilation (~3.4s first time)
-    │                  AsrManager.initialize(models:)
+    │                  initialize lane managers
     │
     ▼
-AsrManager ready — scheduler admits transcription jobs
+Lane managers ready — scheduler admits transcription jobs
 ```
 
 #### 2.6 ExportService

--- a/spec/03-architecture.md
+++ b/spec/03-architecture.md
@@ -42,8 +42,8 @@
 │  │  └──────────────────┬──────────────────┘  └────────────┬────────────┘   │  │
 │  │                               │                                           │  │
 │  │                     ┌─────────▼─────────┐  ┌────────────────────────────┐ │  │
-│  │                     │    STTClient      │  │  TextProcessingPipeline   │ │  │
-│  │                     │  (FluidAudio)     │  │  (Deterministic cleanup)  │ │  │
+│  │                     │   STT Scheduler   │  │  TextProcessingPipeline   │ │  │
+│  │                     │   + Runtime       │  │  (Deterministic cleanup)  │ │  │
 │  │                     └─────────┬─────────┘  └────────────────────────────┘ │  │
 │  │                               │                                           │  │
 │  │  ┌──────────────┐  ┌────────▼──────────────────────────────────────────┐ │  │
@@ -233,7 +233,7 @@ enum DictationState: Sendable {
 }
 ```
 
-**Dependencies:** `AudioProcessor`, `STTClient`, `DictationRepository`, `ClipboardService`
+**Dependencies:** `AudioProcessor`, shared `STTManaging` scheduler/runtime path, `DictationRepository`, `ClipboardService`
 
 **Data Flow:**
 ```
@@ -250,7 +250,7 @@ Hotkey released (or toggle stop)
     ▼
 DictationService.stopRecording()
     │ ── Writes buffer to temp WAV (16kHz mono)
-    │ ── Sends to STTClient
+    │ ── Submits a `dictation` job to the shared STT scheduler
     │ ── Receives raw transcript
     │ ── Runs TextProcessingPipeline (if mode == .clean)
     │ ── Saves to DictationRepository
@@ -272,7 +272,7 @@ protocol TranscriptionServiceProtocol: Sendable {
 }
 ```
 
-**Dependencies:** `AudioProcessor`, `STTClient`, `TranscriptionRepository`, `YouTubeDownloader`, storage prefs (`saveTranscriptionAudio`)
+**Dependencies:** `AudioProcessor`, shared `STTManaging` scheduler/runtime path, `TranscriptionRepository`, `YouTubeDownloader`, storage prefs (`saveTranscriptionAudio`)
 
 **Data Flow:**
 ```
@@ -283,7 +283,7 @@ File URL
 AudioProcessor.convert(fileURL:) → 16kHz mono WAV in temp dir
     │
     ▼
-STTClient.transcribe(audioPath:, onProgress:) → raw transcript + word timestamps
+STTScheduler.transcribe(audioPath:, job: .fileTranscription, onProgress:) → raw transcript + word timestamps
     │
     ▼
 TranscriptionRepository.save() → persisted to database
@@ -301,7 +301,7 @@ YouTubeDownloader.download(url:, onProgress:) → emits download %
 AudioProcessor.convert(fileURL:) → 16kHz mono WAV in temp dir
     │
     ▼
-STTClient.transcribe(audioPath:, onProgress:) → emits chunk %
+STTScheduler.transcribe(audioPath:, job: .fileTranscription, onProgress:) → emits chunk %
     │
     ▼
 TranscriptionRepository.save() with sourceURL (+ filePath when retention enabled)
@@ -358,18 +358,46 @@ protocol AudioProcessorProtocol: Sendable {
 - Audio buffer stored in memory during recording, flushed to disk on stop
 - Supports: MP3, WAV, M4A, FLAC, OGG, OPUS, MP4, MOV, MKV, WebM, AVI
 
-#### 2.5 STTClient
+#### 2.5 STT Runtime + Scheduler
 
-**Responsibility:** Native Swift wrapper around FluidAudio CoreML. Manages model lifecycle (download, load, transcribe, shutdown). Runs Parakeet TDT on the Neural Engine (ANE).
+**Responsibility:** The shared STT stack owns one process-wide Parakeet runtime plus one explicit scheduler. `STTRuntime` owns FluidAudio model lifecycle. `STTScheduler` owns job admission, priority, backpressure, cancellation, and request-scoped progress. `STTClient` remains as a compatibility facade, not as an app-owned second runtime.
 
 **Key Types/Protocols:**
 ```swift
-protocol STTClientProtocol: Sendable {
-    func transcribe(audioPath: String, onProgress: (@Sendable (Int, Int) -> Void)?) async throws -> STTResult
-    func isReady() async -> Bool
+public enum STTJobKind: Sendable, Equatable {
+    case dictation
+    case meetingFinalize
+    case meetingLiveChunk
+    case fileTranscription
+}
+
+public enum STTWarmUpState: Sendable, Equatable {
+    case idle
+    case working(message: String, progress: Double?)
+    case ready
+    case failed(message: String)
+}
+
+public protocol STTTranscribing: Sendable {
+    func transcribe(
+        audioPath: String,
+        job: STTJobKind,
+        onProgress: (@Sendable (Int, Int) -> Void)?
+    ) async throws -> STTResult
+}
+
+public protocol STTRuntimeManaging: Sendable {
     func warmUp(onProgress: (@Sendable (String) -> Void)?) async throws
+    func backgroundWarmUp() async
+    func observeWarmUpProgress() async -> (id: UUID, stream: AsyncStream<STTWarmUpState>)
+    func removeWarmUpObserver(id: UUID) async
+    func clearModelCache() async
+    func isReady() async -> Bool
     func shutdown() async
 }
+
+public typealias STTManaging = STTTranscribing & STTRuntimeManaging
+public typealias STTClientProtocol = STTManaging
 
 struct STTResult: Sendable {
     let text: String
@@ -406,13 +434,13 @@ let result = try await manager.transcribe(samples, source: .system)
 
 **Ownership Model:**
 ```
-Feature services (Dictation / Meeting / File)
+Feature services (Dictation / Meeting / File / URL)
     │
     ▼
-STT Scheduler / Broker
+STTScheduler
     │
     ▼
-STT Runtime
+STTRuntime
     │
     ▼
 AsrManager (single process-wide owner)
@@ -423,7 +451,7 @@ AsrManager (single process-wide owner)
 App Launch
     │
     ▼
-STTRuntime.warmUp() called (lazy, on first use)
+STTRuntime.warmUp() called (lazy, on first use or from onboarding)
     │
     ├── Check: Are CoreML models downloaded?
     │     │
@@ -625,20 +653,21 @@ Native Swift, runs in the app process via FluidAudio CoreML on the Neural Engine
      │                     │  stopCapture() → WAV   │
      │                     │ ─────────────────────> │
      │                     │                        │
-     │                     │      ┌─────────┐       │
-     │                     │ ───> │STTClient│       │
-     │                     │      └────┬────┘       │
-     │                     │           │            │
-     │                     │           │  transcribe(wav)
-     │                     │           │ ────────────────────┐
+     │                     │      ┌──────────────┐   │
+     │                     │ ───> │STTScheduler  │   │
+     │                     │      └──────┬───────┘   │
+     │                     │             │           │
+     │                     │             │  transcribe(wav, .dictation)
+     │                     │             │ ────────────────────┐
      │                     │           │                     │
-     │                     │           │    ┌────────────────▼───┐
-     │                     │           │    │  Parakeet (ANE)   │
-     │                     │           │    └────────────────┬───┘
+     │                     │             │    ┌──────────────▼──────┐
+     │                     │             │    │ STTRuntime +        │
+     │                     │             │    │ Parakeet (ANE)      │
+     │                     │             │    └─────────────────────┘
      │                     │           │                     │
-     │                     │           │  raw transcript     │
-     │                     │           │ <───────────────────┘
-     │                     │           │
+     │                     │             │  raw transcript     │
+     │                     │             │ <───────────────────┘
+     │                     │             │
      │                     │  raw text │
      │                     │ <──────── │
      │                     │
@@ -674,9 +703,9 @@ Native Swift, runs in the app process via FluidAudio CoreML on the Neural Engine
        │                       │  16kHz mono WAV        │    input → WAV
        │                       │ <───────────────────── │
        │                       │
-       │                       │     ┌──────────┐
-       │                       │ ──> │STTClient │ ──> Parakeet (ANE)
-       │                       │     └─────┬────┘
+       │                       │     ┌──────────────┐
+       │                       │ ──> │STTScheduler  │ ──> STTRuntime + Parakeet (ANE)
+       │                       │     └─────┬────────┘
        │                       │           │
        │                       │  STTResult (text + timestamps)
        │                       │ <──────── │
@@ -1118,7 +1147,7 @@ MacParakeet has a small surface area compared to Oatmeal. Focus testing on the c
 - **Models** — Codable round-trip, validation, edge cases
 - **Repositories** — CRUD operations, search queries, migration correctness
 - **ExportService** — Format generation (TXT in v0.1; SRT, VTT, JSON in v0.3)
-- **STTClient** — FluidAudio wrapper (mock the STTClientProtocol interface)
+- **STT scheduler/runtime boundary** — mock the `STTClientProtocol` interface (`STTManaging`) rather than real FluidAudio
 - **AudioProcessor** — Format detection, conversion parameter correctness (mock FFmpeg)
 
 ### What We Skip
@@ -1150,12 +1179,25 @@ actor MockSTTClient: STTClientProtocol {
     func configure(result: STTResult) { transcribeResult = result; transcribeError = nil }
     func configure(error: Error) { transcribeError = error; transcribeResult = nil }
 
-    func transcribe(audioPath: String, onProgress: (@Sendable (Int, Int) -> Void)? = nil) async throws -> STTResult {
+    func transcribe(
+        audioPath: String,
+        job: STTJobKind,
+        onProgress: (@Sendable (Int, Int) -> Void)? = nil
+    ) async throws -> STTResult {
         if let error = transcribeError { throw error }
-        guard let result = transcribeResult else { throw STTError.modelNotReady }
+        guard let result = transcribeResult else { throw STTError.modelNotLoaded }
         return result
     }
-    func warmUp() async throws {}
+    func warmUp(onProgress: (@Sendable (String) -> Void)?) async throws {}
+    func backgroundWarmUp() async {}
+    func observeWarmUpProgress() async -> (id: UUID, stream: AsyncStream<STTWarmUpState>) {
+        (UUID(), AsyncStream { continuation in
+            continuation.yield(.idle)
+            continuation.finish()
+        })
+    }
+    func removeWarmUpObserver(id: UUID) async {}
+    func clearModelCache() async {}
     func isReady() async -> Bool { ready }
     func shutdown() async {}
 }

--- a/spec/03-architecture.md
+++ b/spec/03-architecture.md
@@ -80,16 +80,16 @@
 │  │(Mic)     │  │ Hotkey)  │  │ Paste)      │  │ Control)     │  │Taps     ││
 │  └──────────┘  └──────────┘  └─────────────┘  └──────────────┘  └─────────┘│
 │                                                                                  │
-│  Total AI Memory: ~66 MB peak (Parakeet on ANE)                                │
+│  Parakeet working RAM: ~66 MB per active inference slot on ANE                │
 │  Recommended: 8 GB RAM (Apple Silicon only).                                    │
 └──────────────────────────────────────────────────────────────────────────────────┘
 ```
 
 **Core STT runs on-device.** Optional LLM features use configured providers or Local CLI tools, and telemetry/crash reporting are opt-out. The app supports a fully local setup, but it is not network-free in every configuration.
 
-### Concurrency Model (ADR-015 + ADR-016)
+### Concurrency Model (ADR-015 + ADR-016 Target)
 
-Dictation and meeting recording run concurrently as independent audio pipelines, but all STT work routes through one scheduler and one shared runtime owner:
+The diagram below shows the **approved ADR-016 target architecture**. Dictation and meeting recording run concurrently as independent audio pipelines, while STT converges on one scheduler and one shared runtime owner:
 
 ```
 ┌─ Dictation Pipeline ──────────────────────┐
@@ -120,9 +120,11 @@ Dictation and meeting recording run concurrently as independent audio pipelines,
 
 - **No shared audio engine** — dictation and meeting capture remain independent. macOS HAL multiplexes mic access.
 - **No mutual exclusion** — dictation and meeting recording can both be active.
-- **Centralized STT ownership** — one runtime owns model lifecycle, warm-up, and shutdown.
-- **Explicit scheduling** — a reserved dictation slot plus a shared background slot; within the background slot, finalize beats live preview, and file transcription waits.
+- **Centralized STT ownership** — the approved end state has one runtime owner for lifecycle, warm-up, and shutdown.
+- **Explicit scheduling** — the approved end state uses a reserved dictation slot plus a shared background slot; within the background slot, finalize beats live preview, and file transcription waits.
 - **Menu bar icon priority** — meeting > dictation > file-transcription > idle.
+
+**Current branch implementation note:** this branch has already centralized STT ownership in `AppEnvironment`, but the checked-out code still uses an intermediate internal `dictation` / `meeting` / `batch` lane topology while converging to the target two-slot policy.
 
 ---
 
@@ -374,7 +376,9 @@ protocol AudioProcessorProtocol: Sendable {
 
 #### 2.5 STT Runtime + Scheduler
 
-**Responsibility:** The shared STT stack owns one process-wide Parakeet runtime actor plus one explicit scheduler. `STTRuntime` owns FluidAudio model lifecycle and the slot-scoped `AsrManager` set used by the interactive and background execution slots. `STTScheduler` owns admission, slot assignment, in-slot priority, backpressure, cancellation, and request-scoped progress. `STTClient` remains as a compatibility facade, not as an app-owned second runtime.
+**Responsibility:** The shared STT stack owns one process-wide Parakeet runtime actor plus one explicit scheduler. In the **approved target architecture**, `STTRuntime` owns FluidAudio model lifecycle and the slot-scoped `AsrManager` set used by the interactive and background execution slots. `STTScheduler` owns admission, slot assignment, in-slot priority, backpressure, cancellation, and request-scoped progress. `STTClient` remains as a compatibility facade, not as an app-owned second runtime.
+
+**Current branch implementation note:** the checked-out v0.6 code already centralizes ownership behind shared `STTRuntime` / `STTScheduler` instances, but it still routes execution through internal `dictation`, `meeting`, and `batch` lanes rather than the final two-slot policy documented here.
 
 **Key Types/Protocols:**
 ```swift
@@ -446,7 +450,7 @@ let result = try await manager.transcribe(samples, source: .system)
 // result.text, result.tokenTimings (word-level timestamps + confidence)
 ```
 
-**Ownership Model:**
+**Approved Target Ownership Model:**
 ```
 Feature services (Dictation / Meeting / File / URL)
     │
@@ -1118,7 +1122,7 @@ Parakeet TDT 0.6B-v3 throughput varies by device class: approximately 155x realt
 
 ### Memory Management
 
-- **Parakeet model:** One shared runtime keeps its slot managers initialized after first use. Uses ~66 MB working RAM per active inference slot on the ANE path and is released when the app quits.
+- **Parakeet model:** One shared runtime owner keeps its managers initialized after first use. Budget ~66 MB working RAM per active inference slot on the ANE path. Real total memory depends on how many managers are loaded/active in the current implementation, whether the background capacity stays lazy in the final design, and whether diarization models are also resident.
 - **Audio buffers:** Ring buffer during recording, flushed to temp file on stop. No recording duration limit — local processing means no artificial caps.
 - **Database:** GRDB uses WAL mode by default. No connection pooling needed (single-user app).
 

--- a/spec/03-architecture.md
+++ b/spec/03-architecture.md
@@ -480,6 +480,8 @@ STTRuntime.warmUp() called (lazy, on first use or from onboarding)
 Slot managers ready — scheduler admits transcription jobs
 ```
 
+Product-level readiness can coordinate additional services beyond the two STT slots. In particular, speaker diarization remains outside the speech scheduler, but onboarding should still account for its required assets before declaring default-on file-transcription features fully ready.
+
 #### 2.6 ExportService
 
 **Responsibility:** Convert transcription results into various output formats.
@@ -777,7 +779,9 @@ Single SQLite file via GRDB. All data in one place. No external database process
 
 **Location:** `~/Library/Application Support/MacParakeet/macparakeet.db`
 
-### Schema
+### Representative Schema Excerpt
+
+See [01-data-model.md](01-data-model.md) for the full current schema. The excerpt below highlights the core tables and columns most relevant to the architecture discussion.
 
 ```sql
 -- Dictation history (voice-to-text sessions)
@@ -791,18 +795,13 @@ CREATE TABLE dictations (
     audioPath       TEXT,                   -- relative path to saved audio (nullable)
     pastedToApp     TEXT,                   -- bundle ID of target app
     processingMode  TEXT NOT NULL DEFAULT 'raw', -- 'raw' (v0.1) or 'clean' (v0.2 default via UserDefaults)
+    hidden          BOOLEAN NOT NULL DEFAULT 0,  -- private dictation mode (v0.5)
+    wordCount       INTEGER NOT NULL DEFAULT 0,  -- cached for voice stats (v0.5)
     status          TEXT NOT NULL DEFAULT 'completed', -- 'recording' | 'processing' | 'completed' | 'error'
     errorMessage    TEXT,                   -- non-null if status == 'error'
     updatedAt       TEXT NOT NULL
 );
 CREATE INDEX idx_dictations_created_at ON dictations(createdAt);
-
--- FTS5 external content table for full-text search
-CREATE VIRTUAL TABLE dictations_fts USING fts5(
-    rawTranscript, cleanTranscript,
-    content='dictations', content_rowid='rowid'
-);
--- + sync triggers (INSERT, DELETE, UPDATE)
 
 -- File transcription history
 CREATE TABLE transcriptions (
@@ -815,9 +814,11 @@ CREATE TABLE transcriptions (
     rawTranscript   TEXT,                   -- exact STT output
     cleanTranscript TEXT,                   -- after TextProcessingPipeline (v0.2+)
     wordTimestamps  TEXT,                   -- JSON: [{"word":...,"startMs":...,"endMs":...,"confidence":...}]
+    diarizationSegments TEXT,               -- JSON speaker segments (v0.4+)
     language        TEXT DEFAULT 'en',      -- detected language
     speakerCount    INTEGER,               -- number of speakers (v0.4+)
     speakers        TEXT,                   -- JSON: ["Speaker 1", ...] (v0.4+)
+    sourceType      TEXT NOT NULL DEFAULT 'file', -- file | youtube | meeting (v0.6)
     status          TEXT NOT NULL DEFAULT 'processing', -- 'processing' | 'completed' | 'error' | 'cancelled'
     errorMessage    TEXT,                   -- non-null if status == 'error'
     exportPath      TEXT,                   -- path to exported file
@@ -826,11 +827,8 @@ CREATE TABLE transcriptions (
 );
 CREATE INDEX idx_transcriptions_created_at ON transcriptions(createdAt);
 
--- Custom word corrections (v0.2+ — table not yet created)
--- CREATE TABLE custom_words ( ... )
-
--- Text snippet expansion (v0.2+ — table not yet created)
--- CREATE TABLE text_snippets ( ... )
+-- Additional active tables omitted here for brevity:
+-- custom_words, text_snippets, chat_conversations, prompts, summaries
 ```
 
 ### Migrations
@@ -854,7 +852,8 @@ migrator.registerMigration("v0.1-dictations") { db in
         t.column("errorMessage", .text)
         t.column("updatedAt", .text).notNull()
     }
-    // + FTS5 table + sync triggers
+    // Historical note: v0.1 also created an FTS5 table + sync triggers.
+    // Those were removed in v0.5 after the app standardized on LIKE search.
 }
 
 migrator.registerMigration("v0.1-transcriptions") { db in

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -389,6 +389,7 @@ Floating panel opened from the meeting recording pill. Shows live transcript pre
 │                                          │
 │  🎤 ██████████░░░░  Mic                  │
 │  🔊 ████████░░░░░░  System               │
+│  ⚠ Live preview catching up...          │
 │                                          │
 │  Live Preview:                           │
 │  ──────────────────────────────────────  │
@@ -406,6 +407,7 @@ Floating panel opened from the meeting recording pill. Shows live transcript pre
 
 - **Elapsed timer** — updates every second
 - **Dual audio level meters** — mic and system audio levels (visual feedback that both streams are capturing)
+- **Lag notice** — appears when the scheduler has started dropping or delaying live-preview chunks; recording continues and the final saved meeting remains authoritative
 - **Live transcript preview** — scrolling list of transcribed chunks labeled by source ([Me] = mic, [Them] = system audio)
 - **Stop button** — stops recording, triggers batch transcription, navigates to result
 

--- a/spec/05-audio-pipeline.md
+++ b/spec/05-audio-pipeline.md
@@ -200,9 +200,9 @@ macOS Core Audio's HAL natively multiplexes microphone access — multiple engin
 
 All STT work routes through a process-wide scheduler and a single shared Parakeet runtime owner (ADR-016). That keeps:
 
-- dictation on its own interactive lane
-- meeting live preview best-effort under backlog, with immediate post-stop finalization prioritized inside the meeting lane
-- file / YouTube transcription, plus saved-meeting retranscribes, isolated to the batch lane so they cannot occupy the meeting lane used by active recordings
+- dictation on its own reserved interactive slot
+- meeting live preview best-effort under backlog, with immediate post-stop finalization prioritized on the shared background slot
+- file / YouTube transcription, plus saved-meeting retranscribes, queued behind meeting work on that same background slot
 
 The primary concurrency use case remains meeting recording + dictation. File transcription may coexist architecturally, but it should never degrade dictation responsiveness.
 

--- a/spec/05-audio-pipeline.md
+++ b/spec/05-audio-pipeline.md
@@ -198,11 +198,11 @@ Meeting recording and dictation run concurrently as fully independent pipelines.
 
 macOS Core Audio's HAL natively multiplexes microphone access — multiple engines tapping the same physical mic is a supported pattern. There is no shared audio engine or audio broker.
 
-All STT work routes through a process-wide scheduler and a single Parakeet runtime (ADR-016). That keeps:
+All STT work routes through a process-wide scheduler and a single shared Parakeet runtime owner (ADR-016). That keeps:
 
-- dictation latency highest priority
-- meeting live preview best-effort under backlog
-- file / YouTube transcription architecturally compatible, but lower priority than interactive work
+- dictation on its own interactive lane
+- meeting live preview best-effort under backlog, with immediate post-stop finalization prioritized inside the meeting lane
+- file / YouTube transcription, plus saved-meeting retranscribes, isolated to the batch lane so they cannot occupy the meeting lane used by active recordings
 
 The primary concurrency use case remains meeting recording + dictation. File transcription may coexist architecturally, but it should never degrade dictation responsiveness.
 

--- a/spec/06-stt-engine.md
+++ b/spec/06-stt-engine.md
@@ -167,19 +167,22 @@ struct TimestampedWord: Sendable {
 
 ### Runtime and Scheduling
 
-As implemented in ADR-016, MacParakeet's STT architecture is:
+ADR-016 defines MacParakeet's target STT architecture as:
 
 - **One process-wide `STTRuntime` owner** for model lifecycle and warm-up/shutdown
-- **Lane-scoped `AsrManager` instances inside that runtime** for dictation, meeting, and batch work
-- **One STT scheduler / broker** owning lane admission, in-lane priorities, backpressure, cancellation, and job-scoped progress
+- **Two STT execution slots by default**
+  - an **interactive slot** reserved for `dictation`
+  - a **background slot** shared by `meetingFinalize`, `meetingLiveChunk`, and `fileTranscription`
+- **One STT scheduler / control plane** owning admission, slot assignment, priority, backpressure, cancellation, and job-scoped progress
 - **Many producers** (`DictationService`, `MeetingRecordingService`, `TranscriptionService`) submitting jobs into the scheduler
 
 The app does not treat "one service = one STT runtime" as a valid long-term architecture.
+`STTClient` remains only as a standalone compatibility facade for the CLI and tests; app code uses the shared `STTRuntime` + `STTScheduler` from `AppEnvironment`.
 
 ### Lifecycle
 
 - **Lazy init**: The shared runtime is not loaded at app launch; loaded on first STT request or warm-up
-- **Keep loaded**: Once initialized, the runtime keeps its lane managers ready for subsequent requests
+- **Keep loaded**: Once initialized, the runtime keeps its slot managers ready for subsequent requests
 - **Warm-up during onboarding**: Download models (~6 GB) + CoreML compilation (~3.4s first time)
 - **Graceful shutdown**: The shared runtime is released when the app quits
 - **Single owner**: Warm-up, readiness, shutdown, and cache clear happen once at the runtime layer
@@ -189,50 +192,53 @@ The app does not treat "one service = one STT runtime" as a valid long-term arch
 
 The scheduler exists because STT is a scarce interactive resource even when audio capture is concurrent.
 
-Current implementation:
+Default policy:
 
-1. **Dictation lane**: serial lane dedicated to `dictation`
-2. **Meeting lane**: serial lane dedicated to `meetingFinalize` and `meetingLiveChunk`
-3. **Batch lane**: serial lane dedicated to `fileTranscription`
+1. **Interactive slot**: reserved for `dictation`
+2. **Background slot**: shared by `meetingFinalize`, `meetingLiveChunk`, and `fileTranscription`
 
-Within the meeting lane:
+Priority within the background slot:
 
 1. `meetingFinalize`
 2. `meetingLiveChunk`
+3. `fileTranscription`
 
-Backpressure rules:
+Backpressure and queueing rules:
 
 - Meeting live chunks are best-effort and may be dropped under backlog
-- Immediate post-stop meeting finalization uses `meetingFinalize`; archived meeting retranscribes stay on the batch lane as `fileTranscription`
-- Dictation and active meeting work must not be queued behind batch/library retranscription work
-- Long-running batch work should be segmented into bounded work units where practical; until then, the batch lane remains non-preemptive within a single transcription
+- When a meeting stops, queued live-preview work may be cancelled/dropped so `meetingFinalize` runs next
+- Immediate post-stop meeting finalization uses `meetingFinalize`; archived meeting retranscribes remain `fileTranscription`
+- Dictation must not be queued behind meeting or batch work
+- File transcription is intentionally queued and single-job in v1; a running long batch job may delay meeting STT on the background slot
+- Long-running batch work should be segmented into bounded work units in a future iteration if we want it to yield more gracefully
 - Progress reporting must be fanned out per job, not broadcast globally from the raw runtime stream
 - Cancellation is checked before scheduler admission so fast user cancels do not race into successful transcriptions
+- Speaker diarization remains a separate service and is not part of the two-slot speech scheduler
 
 ### Data Flow
 
 ```
 Dictation:
-  AudioRecorder → AVAudioPCMBuffer → AudioConverter.resampleBuffer() → STTScheduler.submit(dictation) → STTRuntime.transcribe() → STTResult
+  AudioRecorder → AVAudioPCMBuffer → AudioConverter.resampleBuffer() → STTScheduler.transcribe(audioPath:, job: .dictation, onProgress:) → STTRuntime.transcribe() → STTResult
 
 File transcription (v0.4+):
-  FFmpeg (video demux) → .wav → AudioConverter.resampleAudioFile() → STTScheduler.submit(fileTranscription) → STTRuntime.transcribe() → STTResult
+  FFmpeg (video demux) → .wav → AudioConverter.resampleAudioFile() → STTScheduler.transcribe(audioPath:, job: .fileTranscription, onProgress:) → queued background-slot STTResult
                                                                                                              → OfflineDiarizerManager.process() → DiarizationResult
                                                                                                              → Merge word timestamps + speaker segments
 
 YouTube (v0.4+):
-  yt-dlp → .m4a → FFmpeg → AudioConverter.resampleAudioFile() → STTScheduler.submit(fileTranscription) → STTRuntime.transcribe() → STTResult
+  yt-dlp → .m4a → FFmpeg → AudioConverter.resampleAudioFile() → STTScheduler.transcribe(audioPath:, job: .fileTranscription, onProgress:) → queued background-slot STTResult
                                                                                                         → OfflineDiarizerManager.process() → DiarizationResult
                                                                                                         → Merge word timestamps + speaker segments
 
 Meeting live preview (v0.6):
-  MicrophoneCapture/SystemAudioTap → AudioChunker → STTScheduler.submit(meetingLiveChunk) → STTRuntime.transcribe() → live transcript update
+  MicrophoneCapture/SystemAudioTap → AudioChunker → STTScheduler.transcribe(audioPath:, job: .meetingLiveChunk, onProgress:) → background-slot STT → live transcript update
 
 Meeting stop / finalization:
-  Final mixed meeting artifact → STTScheduler.submit(meetingFinalize) → STTRuntime.transcribe() → final saved meeting transcript
+  Final mixed meeting artifact → STTScheduler.transcribe(audioPath:, job: .meetingFinalize, onProgress:) → background-slot STT → final saved meeting transcript
 
 Saved meeting retranscription from the library:
-  Existing meeting audio file → AudioConverter.resampleAudioFile() → STTScheduler.submit(fileTranscription) → STTRuntime.transcribe() → updated meeting transcript
+  Existing meeting audio file → AudioConverter.resampleAudioFile() → STTScheduler.transcribe(audioPath:, job: .fileTranscription, onProgress:) → queued background-slot STT → updated meeting transcript
 ```
 
 ---
@@ -332,10 +338,10 @@ Recommended: 8 GB RAM (Apple Silicon)
 
 ### Optimization Notes
 
-- The shared runtime keeps its lane managers initialized after first use — subsequent calls skip model loading
+- The shared runtime keeps its slot managers initialized after first use — subsequent calls skip model loading
 - Apple Silicon's unified memory means no CPU↔ANE transfer overhead
 - For dictation, latency is the primary concern — sub-100ms after warm-up
-- For file transcription, throughput matters more — the batch lane is isolated from dictation and meeting-lane admission, even though a long batch decode is still non-preemptive within that lane
+- For file transcription, throughput matters more — it is intentionally lower-priority than dictation and meeting work in the shared background slot
 - ANE and GPU run simultaneously — STT never competes with LLM for processing cycles
 
 ---

--- a/spec/06-stt-engine.md
+++ b/spec/06-stt-engine.md
@@ -169,8 +169,9 @@ struct TimestampedWord: Sendable {
 
 As implemented in ADR-016, MacParakeet's STT architecture is:
 
-- **One process-wide STT runtime** owning `AsrManager`
-- **One STT scheduler / broker** owning admission control, priorities, backpressure, cancellation, and job-scoped progress
+- **One process-wide `STTRuntime` owner** for model lifecycle and warm-up/shutdown
+- **Lane-scoped `AsrManager` instances inside that runtime** for dictation, meeting, and batch work
+- **One STT scheduler / broker** owning lane admission, in-lane priorities, backpressure, cancellation, and job-scoped progress
 - **Many producers** (`DictationService`, `MeetingRecordingService`, `TranscriptionService`) submitting jobs into the scheduler
 
 The app does not treat "one service = one STT runtime" as a valid long-term architecture.
@@ -178,28 +179,35 @@ The app does not treat "one service = one STT runtime" as a valid long-term arch
 ### Lifecycle
 
 - **Lazy init**: The shared runtime is not loaded at app launch; loaded on first STT request or warm-up
-- **Keep loaded**: Once initialized, the shared `AsrManager` stays ready for subsequent requests
+- **Keep loaded**: Once initialized, the runtime keeps its lane managers ready for subsequent requests
 - **Warm-up during onboarding**: Download models (~6 GB) + CoreML compilation (~3.4s first time)
 - **Graceful shutdown**: The shared runtime is released when the app quits
 - **Single owner**: Warm-up, readiness, shutdown, and cache clear happen once at the runtime layer
+- **Cancellation-safe init**: Shutdown/cache clear cancel in-flight initialization and wait for loaded managers to clean themselves up before returning
 
 ### Scheduling Policy
 
 The scheduler exists because STT is a scarce interactive resource even when audio capture is concurrent.
 
-Priority order:
+Current implementation:
 
-1. `dictation`
-2. `meetingFinalize`
-3. `meetingLiveChunk`
-4. `fileTranscription`
+1. **Dictation lane**: serial lane dedicated to `dictation`
+2. **Meeting lane**: serial lane dedicated to `meetingFinalize` and `meetingLiveChunk`
+3. **Batch lane**: serial lane dedicated to `fileTranscription`
+
+Within the meeting lane:
+
+1. `meetingFinalize`
+2. `meetingLiveChunk`
 
 Backpressure rules:
 
 - Meeting live chunks are best-effort and may be dropped under backlog
-- Dictation must remain responsive even while meetings or batch transcriptions exist
-- Long-running batch work should be segmented into bounded work units where practical
+- Immediate post-stop meeting finalization uses `meetingFinalize`; archived meeting retranscribes stay on the batch lane as `fileTranscription`
+- Dictation and active meeting work must not be queued behind batch/library retranscription work
+- Long-running batch work should be segmented into bounded work units where practical; until then, the batch lane remains non-preemptive within a single transcription
 - Progress reporting must be fanned out per job, not broadcast globally from the raw runtime stream
+- Cancellation is checked before scheduler admission so fast user cancels do not race into successful transcriptions
 
 ### Data Flow
 
@@ -219,6 +227,12 @@ YouTube (v0.4+):
 
 Meeting live preview (v0.6):
   MicrophoneCapture/SystemAudioTap → AudioChunker → STTScheduler.submit(meetingLiveChunk) → STTRuntime.transcribe() → live transcript update
+
+Meeting stop / finalization:
+  Final mixed meeting artifact → STTScheduler.submit(meetingFinalize) → STTRuntime.transcribe() → final saved meeting transcript
+
+Saved meeting retranscription from the library:
+  Existing meeting audio file → AudioConverter.resampleAudioFile() → STTScheduler.submit(fileTranscription) → STTRuntime.transcribe() → updated meeting transcript
 ```
 
 ---
@@ -318,10 +332,10 @@ Recommended: 8 GB RAM (Apple Silicon)
 
 ### Optimization Notes
 
-- The shared `AsrManager` stays initialized after first use — subsequent calls skip model loading
+- The shared runtime keeps its lane managers initialized after first use — subsequent calls skip model loading
 - Apple Silicon's unified memory means no CPU↔ANE transfer overhead
 - For dictation, latency is the primary concern — sub-100ms after warm-up
-- For file transcription, throughput matters more — scheduler policy keeps interactive work responsive
+- For file transcription, throughput matters more — the batch lane is isolated from dictation and meeting-lane admission, even though a long batch decode is still non-preemptive within that lane
 - ANE and GPU run simultaneously — STT never competes with LLM for processing cycles
 
 ---

--- a/spec/06-stt-engine.md
+++ b/spec/06-stt-engine.md
@@ -167,7 +167,7 @@ struct TimestampedWord: Sendable {
 
 ### Runtime and Scheduling
 
-ADR-016 defines MacParakeet's **approved target STT architecture** as:
+ADR-016 defines MacParakeet's STT architecture as:
 
 - **One process-wide `STTRuntime` owner** for model lifecycle and warm-up/shutdown
 - **Two STT execution slots by default**
@@ -178,8 +178,6 @@ ADR-016 defines MacParakeet's **approved target STT architecture** as:
 
 The app does not treat "one service = one STT runtime" as a valid long-term architecture.
 `STTClient` remains only as a standalone compatibility facade for the CLI and tests; app code uses the shared `STTRuntime` + `STTScheduler` from `AppEnvironment`.
-
-**Current branch implementation note:** the checked-out v0.6 branch has already centralized app-owned STT wiring, but it still executes through internal `dictation` / `meeting` / `batch` lanes with one `AsrManager` per lane. Treat the two-slot policy below as the approved destination, not as a statement that the current code has fully converged yet.
 
 ### Lifecycle
 

--- a/spec/06-stt-engine.md
+++ b/spec/06-stt-engine.md
@@ -114,15 +114,43 @@ This runs a secondary CTC encoder (110M params) alongside the primary TDT encode
 
 ### Protocol Layer
 
-The `STTClientProtocol` interface is unchanged from v0.1. The runtime implementation uses FluidAudio/CoreML:
+The producer-facing STT contract was expanded in ADR-016 so callers declare job type explicitly and runtime lifecycle stays on the shared path:
 
 ```swift
-protocol STTClientProtocol: Sendable {
-    func transcribe(audioPath: String, onProgress: (@Sendable (Int, Int) -> Void)?) async throws -> STTResult
+public enum STTJobKind: Sendable, Equatable {
+    case dictation
+    case meetingFinalize
+    case meetingLiveChunk
+    case fileTranscription
+}
+
+public enum STTWarmUpState: Sendable, Equatable {
+    case idle
+    case working(message: String, progress: Double?)
+    case ready
+    case failed(message: String)
+}
+
+public protocol STTTranscribing: Sendable {
+    func transcribe(
+        audioPath: String,
+        job: STTJobKind,
+        onProgress: (@Sendable (Int, Int) -> Void)?
+    ) async throws -> STTResult
+}
+
+public protocol STTRuntimeManaging: Sendable {
     func warmUp(onProgress: (@Sendable (String) -> Void)?) async throws
+    func backgroundWarmUp() async
+    func observeWarmUpProgress() async -> (id: UUID, stream: AsyncStream<STTWarmUpState>)
+    func removeWarmUpObserver(id: UUID) async
     func isReady() async -> Bool
+    func clearModelCache() async
     func shutdown() async
 }
+
+public typealias STTManaging = STTTranscribing & STTRuntimeManaging
+public typealias STTClientProtocol = STTManaging
 
 struct STTResult: Sendable {
     let text: String
@@ -139,7 +167,7 @@ struct TimestampedWord: Sendable {
 
 ### Runtime and Scheduling
 
-As of ADR-016, MacParakeet's intended STT architecture is:
+As implemented in ADR-016, MacParakeet's STT architecture is:
 
 - **One process-wide STT runtime** owning `AsrManager`
 - **One STT scheduler / broker** owning admission control, priorities, backpressure, cancellation, and job-scoped progress
@@ -168,7 +196,7 @@ Priority order:
 
 Backpressure rules:
 
-- Meeting live chunks are best-effort and may be dropped or coalesced under backlog
+- Meeting live chunks are best-effort and may be dropped under backlog
 - Dictation must remain responsive even while meetings or batch transcriptions exist
 - Long-running batch work should be segmented into bounded work units where practical
 - Progress reporting must be fanned out per job, not broadcast globally from the raw runtime stream

--- a/spec/06-stt-engine.md
+++ b/spec/06-stt-engine.md
@@ -271,8 +271,11 @@ The CoreML model for `parakeet-tdt-0.6b-v3-coreml` is **~6 GB** on HuggingFace. 
 During onboarding:
 
 1. Download CoreML models (~6 GB) with progress indication
-2. One-time CoreML compilation (~3.4s)
-3. Short warm-up transcription to verify everything works
+2. If speaker detection is enabled, prepare diarization assets (~130 MB) on the separate diarization service path
+3. One-time CoreML compilation (~3.4s)
+4. Short warm-up transcription to verify everything works
+
+Onboarding should not report the speech stack as ready until the runtime owner is ready **and** any required default-on speaker-detection assets are available.
 
 This replaces the previous Python venv bootstrap (~500 MB deps + ~2.5 GB model).
 

--- a/spec/06-stt-engine.md
+++ b/spec/06-stt-engine.md
@@ -14,7 +14,7 @@ MacParakeet uses Parakeet TDT 0.6B-v3 via FluidAudio CoreML, running on Apple's 
 | Runtime | FluidAudio SDK (CoreML on ANE) |
 | Word Error Rate | ~2.5% (v3 multilingual) / ~2.1% (v2 English-only) |
 | Speed | ~155x realtime on Apple Silicon |
-| Peak working RAM | ~66 MB (~130 MB with custom vocabulary boosting) |
+| Peak working RAM | ~66 MB per active Parakeet inference slot (~130 MB with custom vocabulary boosting) |
 | Model download | ~6 GB CoreML bundle (one-time, during onboarding) |
 | Output | Word-level timestamps with per-word confidence scores |
 | Input format | 16kHz mono Float32 samples (FluidAudio's AudioConverter handles resampling) |
@@ -167,7 +167,7 @@ struct TimestampedWord: Sendable {
 
 ### Runtime and Scheduling
 
-ADR-016 defines MacParakeet's target STT architecture as:
+ADR-016 defines MacParakeet's **approved target STT architecture** as:
 
 - **One process-wide `STTRuntime` owner** for model lifecycle and warm-up/shutdown
 - **Two STT execution slots by default**
@@ -179,10 +179,12 @@ ADR-016 defines MacParakeet's target STT architecture as:
 The app does not treat "one service = one STT runtime" as a valid long-term architecture.
 `STTClient` remains only as a standalone compatibility facade for the CLI and tests; app code uses the shared `STTRuntime` + `STTScheduler` from `AppEnvironment`.
 
+**Current branch implementation note:** the checked-out v0.6 branch has already centralized app-owned STT wiring, but it still executes through internal `dictation` / `meeting` / `batch` lanes with one `AsrManager` per lane. Treat the two-slot policy below as the approved destination, not as a statement that the current code has fully converged yet.
+
 ### Lifecycle
 
-- **Lazy init**: The shared runtime is not loaded at app launch; loaded on first STT request or warm-up
-- **Keep loaded**: Once initialized, the runtime keeps its slot managers ready for subsequent requests
+- **Lazy init**: The shared runtime owner is not loaded at app launch; loaded on first STT request or warm-up
+- **Keep loaded**: Once initialized, the runtime keeps its currently loaded managers ready for subsequent requests
 - **Warm-up during onboarding**: Download models (~6 GB) + CoreML compilation (~3.4s first time)
 - **Graceful shutdown**: The shared runtime is released when the app quits
 - **Single owner**: Warm-up, readiness, shutdown, and cache clear happen once at the runtime layer
@@ -295,7 +297,7 @@ This replaces the previous Python venv bootstrap (~500 MB deps + ~2.5 GB model).
 - CoreML runs in-process (not a separate daemon) — no subprocess crash isolation
 - Wrap transcription calls in error handling
 - On CoreML failure, log the error, report to user, allow retry
-- Memory pressure: CoreML uses ~66 MB working RAM, far less likely to trigger OOM than the previous ~2 GB MLX path
+- Memory pressure: CoreML uses ~66 MB working RAM per active Parakeet inference slot, far less likely to trigger OOM than the previous ~2 GB MLX path
 
 ### Timeout Handling
 
@@ -329,22 +331,20 @@ For dictation (the primary use case), transcription time is imperceptible. For l
 
 ### Memory Budget
 
-```
-Parakeet STT (CoreML/ANE)      ~66 MB working RAM (~130 MB with vocab boosting)
-App process (UI + services)    ~100 MB
-Audio buffers                  ~50 MB
-────────────────────────────────────
-Total peak                     ~300 MB (without vocab boosting)
-
-Recommended: 8 GB RAM (Apple Silicon)
-```
+- Parakeet STT: ~66 MB working RAM per active slot (~130 MB with vocab boosting)
+- App process (UI + services): ~100 MB
+- Audio buffers: ~50 MB
+- Illustrative warm single-slot budget: ~200-250 MB before diarization
+- Real total memory depends on how many STT managers/slots are loaded and active, whether background capacity stays lazy in the final two-slot design, and whether diarization models are also resident
+- Recommended baseline: 8 GB RAM (Apple Silicon)
 
 ### Optimization Notes
 
-- The shared runtime keeps its slot managers initialized after first use — subsequent calls skip model loading
+- The shared runtime owner keeps its managers initialized after first use — subsequent calls skip model loading
 - Apple Silicon's unified memory means no CPU↔ANE transfer overhead
 - For dictation, latency is the primary concern — sub-100ms after warm-up
 - For file transcription, throughput matters more — it is intentionally lower-priority than dictation and meeting work in the shared background slot
+- The approved two-slot design assumes background capacity is a policy choice rather than a guaranteed always-hot third executor; benchmark any stronger concurrency claim before documenting it as fixed
 - ANE and GPU run simultaneously — STT never competes with LLM for processing cycles
 
 ---

--- a/spec/09-testing.md
+++ b/spec/09-testing.md
@@ -103,13 +103,13 @@ The suite includes targeted regressions for progress behavior in URL transcripti
 
 **What:** Shared runtime ownership, request priority, backpressure, and progress isolation across concurrent producers.
 
-**How:** Protocol-based mocks for the STT runtime plus deterministic scheduler tests that assert execution order and dropped/coalesced work under backlog.
+**How:** Protocol-based mocks for the STT runtime plus deterministic scheduler tests that assert execution order and dropped work under backlog.
 
 **Examples:**
 - Dictation preempts pending meeting live chunk work
 - Meeting finalization runs ahead of new batch file transcription
 - File transcription yields to interactive dictation without corrupting progress callbacks
-- Meeting live chunks are dropped or coalesced when queue thresholds are exceeded
+- Meeting live chunks are dropped when queue thresholds are exceeded
 - App warm-up, shutdown, and cache-clearing hit one shared runtime only
 
 ### CLI Tests

--- a/spec/09-testing.md
+++ b/spec/09-testing.md
@@ -101,17 +101,17 @@ The suite includes targeted regressions for progress behavior in URL transcripti
 
 ### STT Scheduler Tests (ADR-016)
 
-**What:** Shared runtime ownership, request priority, backpressure, and progress isolation across concurrent producers.
+**What:** Shared runtime ownership, two-slot scheduling policy, request priority, backpressure, and progress isolation across concurrent producers.
 
 **How:** Protocol-based mocks for the STT runtime plus deterministic scheduler tests that assert execution order and dropped work under backlog.
 
 **Examples:**
-- Dictation preempts pending meeting live chunk work
-- Meeting finalization runs ahead of new batch file transcription
-- File transcription yields to interactive dictation without corrupting progress callbacks
-- Meeting live chunks are dropped when queue thresholds are exceeded
+- Dictation always uses the reserved interactive slot
+- Meeting finalization runs ahead of queued live preview and file transcription on the background slot
+- File transcription waits behind active meeting work without corrupting progress callbacks
+- Meeting live chunks are dropped when queue thresholds are exceeded or when meeting stop promotes finalization
 - Already-cancelled jobs never enter the scheduler
-- Saved meeting retranscribes stay on the batch lane instead of occupying the meeting lane
+- Saved meeting retranscribes stay in the low-priority file-transcription class
 - App warm-up, shutdown, and cache-clearing hit one shared runtime only
 
 ### CLI Tests

--- a/spec/09-testing.md
+++ b/spec/09-testing.md
@@ -110,6 +110,8 @@ The suite includes targeted regressions for progress behavior in URL transcripti
 - Meeting finalization runs ahead of new batch file transcription
 - File transcription yields to interactive dictation without corrupting progress callbacks
 - Meeting live chunks are dropped when queue thresholds are exceeded
+- Already-cancelled jobs never enter the scheduler
+- Saved meeting retranscribes stay on the batch lane instead of occupying the meeting lane
 - App warm-up, shutdown, and cache-clearing hit one shared runtime only
 
 ### CLI Tests

--- a/spec/09-testing.md
+++ b/spec/09-testing.md
@@ -44,7 +44,7 @@ func testDictationCreation() async throws {
 
 **Examples:**
 - Repository CRUD (create, read, update, delete)
-- Search queries (FTS5 full-text search on dictations)
+- Search queries (LIKE-based substring search on dictations)
 - Migration sequences (v1 -> v2 -> v3 apply cleanly)
 
 ### Integration Tests
@@ -113,6 +113,7 @@ The suite includes targeted regressions for progress behavior in URL transcripti
 - Already-cancelled jobs never enter the scheduler
 - Saved meeting retranscribes stay in the low-priority file-transcription class
 - App warm-up, shutdown, and cache-clearing hit one shared runtime only
+- Onboarding readiness does not report success until required default-on speaker-detection assets are also ready
 
 ### CLI Tests
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -179,7 +179,7 @@ Dictation + transcription + history + settings. Get audio in, text out, pasted i
 - [x] Meeting title prefix + rename flow
 - [x] Hotkey conflict prevention (dictation vs meeting)
 - [x] Concurrent dictation during meeting recording (ADR-015)
-- [ ] Centralized STT runtime + scheduler (ADR-016)
+- [x] Centralized STT runtime + scheduler (ADR-016)
 
 ## For AI Coding Assistants
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -56,7 +56,7 @@ All ADRs live in `spec/adr/`. These are locked -- they record decisions already 
 | [ADR-013](adr/013-prompt-library-multi-summary.md) | Prompt Library + multi-summary architecture |
 | [ADR-014](adr/014-meeting-recording.md) | Meeting recording via Core Audio Taps |
 | [ADR-015](adr/015-concurrent-dictation-meeting.md) | Concurrent dictation and meeting recording |
-| [ADR-016](adr/016-centralized-stt-runtime-scheduler.md) | Centralized STT runtime and scheduler |
+| [ADR-016](adr/016-centralized-stt-runtime-scheduler.md) | Centralized STT runtime and two-slot scheduler |
 
 ## Version Roadmap
 
@@ -179,7 +179,7 @@ Dictation + transcription + history + settings. Get audio in, text out, pasted i
 - [x] Meeting title prefix + rename flow
 - [x] Hotkey conflict prevention (dictation vs meeting)
 - [x] Concurrent dictation during meeting recording (ADR-015)
-- [x] Centralized STT runtime + scheduler (ADR-016)
+- [x] Centralized STT runtime + two-slot scheduler (ADR-016)
 
 ## For AI Coding Assistants
 

--- a/spec/adr/005-onboarding-first-run.md
+++ b/spec/adr/005-onboarding-first-run.md
@@ -1,7 +1,7 @@
 # ADR 005: First-Run Onboarding Window
 
 Date: 2026-02-10
-> Note: Core onboarding flow unchanged. Qwen LLM warm-up step referenced below was removed 2026-02-23 — onboarding now prepares only the Parakeet STT model.
+> Note: Core onboarding flow unchanged. Qwen LLM warm-up step referenced below was removed 2026-02-23. As of 2026-04-06, onboarding prepares the local speech stack: Parakeet STT plus any required default-on speaker-detection assets.
 
 ## Context
 
@@ -9,7 +9,7 @@ MacParakeet is a menu bar app with a configurable global hotkey (default: Fn) an
 
 - Explain the core interaction model (hotkey, stop/paste, cancel).
 - Acquire required permissions (Microphone, Accessibility).
-- Prepare the Parakeet STT model so dictation is ready on first use.
+- Prepare the local speech stack so dictation and default-on file-transcription features are ready on first use.
 
 Without onboarding, users encounter failures out of context (missing permissions, slow first warm-up) and the product feels brittle.
 
@@ -23,19 +23,20 @@ The onboarding flow is linear and step-based:
 2. Microphone permission
 3. Accessibility permission
 4. Hotkey instructions
-5. STT model setup (Parakeet, required to continue; retry available)
+5. Speech stack setup (Parakeet + required speaker-detection assets, retry available)
 6. Ready
 
 The onboarding can also be launched manually from Settings.
 
 If onboarding is closed before completion, the app shows an explicit confirmation dialog. If the user exits setup anyway, onboarding is shown again on the next app activation until completion.
-During STT model setup, onboarding runs lightweight preflight checks (disk space + network readiness) before the Parakeet download begins.
+During speech-stack setup, onboarding runs lightweight preflight checks (disk space + network readiness) before downloading required assets.
 
 ## Consequences
 
 - Users get a guided, premium setup that reduces first-run friction.
 - Hotkey manager is restarted after onboarding to reliably start listening once Accessibility is granted.
 - The Parakeet STT model is downloaded/warmed during onboarding to reduce first-use latency for dictation.
+- If speaker detection is enabled by default, its diarization assets are also prepared before onboarding reports file transcription ready.
 - Preflight checks fail fast with actionable guidance, reducing avoidable warm-up failures.
 - Onboarding completion is stored in `UserDefaults` as an ISO8601 timestamp.
 - Incomplete setup is never silently dismissed; users either continue setup or explicitly defer it.

--- a/spec/adr/010-speaker-diarization.md
+++ b/spec/adr/010-speaker-diarization.md
@@ -131,6 +131,8 @@ Skip diarization for: dictation (single speaker by design), or when the Settings
 
 **CLI:** `macparakeet-cli transcribe` runs diarization by default (backward compatibility). Use `--no-diarize` to skip. Text output shows speaker labels at turn changes; JSON output includes all speaker data via Codable.
 
+**Readiness contract:** Diarization remains a separate service from the STT scheduler, but when speaker detection is enabled by default the onboarding/ready-state path must account for diarization-model readiness before claiming file transcription is fully ready.
+
 ## Rationale
 
 ### Why the offline pipeline, not Sortformer

--- a/spec/adr/015-concurrent-dictation-meeting.md
+++ b/spec/adr/015-concurrent-dictation-meeting.md
@@ -38,14 +38,14 @@ A shared engine would mean dictation start/stop could glitch a long-running meet
 
 ### 2. Shared STT runtime with explicit scheduling
 
-Both flows submit STT work to a process-wide STT scheduler backed by one shared `STTRuntime` owner. The runtime may keep separate lane-scoped managers for dictation, meeting, and batch work, but feature services do not own their own runtimes and the app does not rely on implicit CoreML contention as its scheduling policy.
+Both flows submit STT work to a process-wide STT scheduler backed by one shared `STTRuntime` owner. Feature services do not own their own runtimes and the app does not rely on implicit CoreML contention as its scheduling policy.
 
 The scheduler defines:
 
-- a dedicated dictation lane for the highest-priority interactive workload
-- a dedicated meeting lane where meeting finalization beats live preview work
+- a reserved dictation slot for the highest-priority interactive workload
+- a shared background slot where meeting finalization beats live preview work
 - meeting live chunks as best-effort under backlog
-- a dedicated batch lane for file / YouTube transcription and saved-meeting retranscribes
+- file / YouTube transcription and saved-meeting retranscribes as queued batch work behind active meeting STT
 
 See ADR-016 for the full runtime and scheduler design.
 

--- a/spec/adr/015-concurrent-dictation-meeting.md
+++ b/spec/adr/015-concurrent-dictation-meeting.md
@@ -38,14 +38,14 @@ A shared engine would mean dictation start/stop could glitch a long-running meet
 
 ### 2. Shared STT runtime with explicit scheduling
 
-Both flows submit STT work to a process-wide STT scheduler that owns a single Parakeet runtime. CoreML still serializes ANE inference internally, but the app does not rely on implicit contention as its scheduling policy.
+Both flows submit STT work to a process-wide STT scheduler backed by one shared `STTRuntime` owner. The runtime may keep separate lane-scoped managers for dictation, meeting, and batch work, but feature services do not own their own runtimes and the app does not rely on implicit CoreML contention as its scheduling policy.
 
 The scheduler defines:
 
-- dictation as the highest-priority interactive workload
-- meeting finalization above live preview work
+- a dedicated dictation lane for the highest-priority interactive workload
+- a dedicated meeting lane where meeting finalization beats live preview work
 - meeting live chunks as best-effort under backlog
-- file / YouTube transcription as lowest-priority batch work
+- a dedicated batch lane for file / YouTube transcription and saved-meeting retranscribes
 
 See ADR-016 for the full runtime and scheduler design.
 

--- a/spec/adr/016-centralized-stt-runtime-scheduler.md
+++ b/spec/adr/016-centralized-stt-runtime-scheduler.md
@@ -1,7 +1,7 @@
 # ADR-016: Centralized STT Runtime and Scheduler
 
 > Status: ACCEPTED
-> Date: 2026-04-05
+> Date: 2026-04-06
 > Related: ADR-001 (Parakeet STT), ADR-007 (FluidAudio CoreML migration), ADR-014 (meeting recording), ADR-015 (concurrent dictation and meeting recording)
 
 ## Context
@@ -19,41 +19,43 @@ Parakeet via FluidAudio/CoreML is a scarce, process-wide resource in practice:
 - The expensive part is ANE/CoreML inference, not microphone capture
 - Interactive dictation latency matters far more than batch throughput
 - Meeting live preview is useful but can tolerate bounded lag or dropped chunks under pressure
-- File transcription is usually background/batch work and should never degrade dictation responsiveness
+- Meeting finalization after stop is more important than live preview and should complete promptly
+- File transcription is usually background/batch work and can wait behind interactive work
 
 Per-flow STT ownership leads to duplicated runtime lifecycle, unclear shutdown/warm-up behavior, and no explicit admission control. Even if CoreML serializes inference internally, the app should not rely on implicit contention as its scheduling policy.
 
 ## Decision
 
-### 1. One process-wide STT runtime owner
+### 1. One process-wide STT control plane
 
-MacParakeet owns exactly one app-level STT runtime actor for Parakeet inference in the process.
+MacParakeet owns exactly one app-level STT control plane for Parakeet inference in the process.
+
+That control plane is responsible for:
+
+- job admission
+- queueing and priority
+- slot assignment
+- backpressure
+- cancellation
+- job-scoped progress fan-out
+- runtime lifecycle coordination
+
+Feature services submit jobs to the control plane; they do not own their own STT topology.
+
+### 2. One shared STT runtime owner
+
+The control plane coordinates one shared STT runtime owner for Parakeet model lifecycle.
 
 That runtime is the sole owner of:
 
-- lane-scoped `AsrManager` instances
+- slot-scoped `AsrManager` instances
 - model download / initialization / readiness
 - warm-up progress
 - shutdown / cleanup
 - model cache clearing
 
 No feature service (`DictationService`, `MeetingRecordingService`, `TranscriptionService`) owns its own STT runtime.
-The runtime may keep multiple internal managers so the scheduler can isolate dictation, meeting, and batch work without app-level head-of-line blocking, but that multiplicity stays hidden behind one shared runtime owner.
-
-### 2. One explicit STT scheduler / broker
-
-All transcription requests flow through a single scheduler in front of the runtime.
-
-The scheduler is the sole owner of:
-
-- job admission
-- job priority
-- fairness between modes
-- backpressure
-- cancellation
-- job-scoped progress fan-out
-
-Feature services submit jobs to the scheduler; they do not call the runtime directly.
+Multiple internal managers/executors may exist behind the runtime owner, but that multiplicity remains hidden behind one shared lifecycle boundary.
 
 ### 3. Independent audio capture remains unchanged
 
@@ -65,59 +67,94 @@ This ADR does **not** change the audio architecture from ADR-014 / ADR-015:
 
 Concurrency at the audio layer remains independent. This ADR only centralizes ownership of the STT layer.
 
-### 4. Scheduling policy is lane-driven
+### 4. The default architecture has two execution slots
 
-The scheduler partitions work into three explicit lanes:
+The control plane exposes four job classes:
 
-1. **Dictation lane** — serial, interactive, reserved for `dictation`
-2. **Meeting lane** — serial, reserved for `meetingFinalize` and `meetingLiveChunk`
-3. **Batch lane** — serial, reserved for `fileTranscription`
+1. `dictation`
+2. `meetingFinalize`
+3. `meetingLiveChunk`
+4. `fileTranscription`
 
-Within the meeting lane:
+But it only guarantees **two STT execution slots** by default:
 
-1. **Meeting finalization** beats queued live preview work
-2. **Meeting live chunks** remain best-effort
+1. **Interactive slot** — reserved for `dictation`
+2. **Background slot** — shared by `meetingFinalize`, `meetingLiveChunk`, and `fileTranscription`
 
-Batch work includes:
-
-- file transcription
-- YouTube transcription
-- retranscription of already-saved meetings from the library
-
-Only the immediate post-stop meeting path uses `meetingFinalize`.
-Archived meeting retranscribes stay on the batch lane even when their telemetry/source metadata remains `.meeting`.
+This is deliberate. MacParakeet does **not** reserve a permanent third slot for file / YouTube transcription in v1.
 
 Rationale:
 
-- Dictation is interactive and latency-sensitive
-- Stopped meeting recordings should complete promptly once they enter the meeting lane
-- Live meeting preview should degrade before stop/finalize work
-- Saved-library retranscribes should never occupy the meeting lane used by active meetings
+- Dictation needs the strongest latency guarantee
+- Meeting work is more latency-sensitive than file transcription
+- File transcription is important, but it is asynchronous and can wait
+- The product rarely needs three concurrent STT executions, so always reserving capacity for batch work is unnecessary complexity and pressure
 
-### 5. Backpressure is explicit
+### 5. Priority policy is slot-driven
+
+The control plane uses the following policy:
+
+- `dictation` always targets the interactive slot
+- `meetingFinalize`, `meetingLiveChunk`, and `fileTranscription` target the background slot
+- Priority within the background slot is:
+  1. `meetingFinalize`
+  2. `meetingLiveChunk`
+  3. `fileTranscription`
+
+This means:
+
+- dictation stays responsive even during other work
+- meeting finalization beats live preview
+- file transcription yields to meeting work
+- file transcription does not receive dedicated always-on capacity
+
+Only the immediate post-stop meeting path uses `meetingFinalize`.
+Archived meeting retranscribes remain `fileTranscription` even when their telemetry/source metadata remains `.meeting`.
+
+### 6. Backpressure is explicit
 
 Meeting live chunk transcription is best-effort and droppable under backlog.
 
-If the scheduler exceeds configured queue or latency thresholds, it may:
+If the control plane exceeds configured queue or latency thresholds, it may:
 
 - drop pending live meeting chunks
+- cancel queued live preview work when meeting stop is requested
+- attempt to cancel running live preview work when practical
 - continue preserving the final mixed meeting artifact for post-stop transcription
 
 This keeps the app responsive while preserving correctness of the final saved meeting.
 
-### 6. Long-running jobs must be bounded
+### 7. Long-running batch work is queued, not privileged
 
-To support meaningful prioritization, long-running work must be divided into bounded units whenever practical.
+File / YouTube transcription is intentionally single-job and low-priority in v1.
 
-- Meeting live preview already uses chunked work units
-- Dictation is naturally short
-- File / YouTube transcription should evolve toward chunked or segmented STT work if we want finer-grained fairness within the batch lane
+Until batch transcription is segmented or made interruptible, a running long file transcription may occupy the background slot and delay meeting STT work. This tradeoff is acceptable in v1 because:
 
-Until batch transcription is segmented, each lane remains single-slot and non-preemptive: the scheduler may reorder queued work before admission to a lane, but it does not preempt a currently running decode within that lane.
+- the common case is one or two simultaneous STT producers, not all three
+- dictation remains protected by the interactive slot
+- no data is lost; the impact is queueing and latency, not correctness
 
-### 7. Progress must be job-scoped
+Future improvements may add:
 
-Progress reporting is owned by the scheduler and exposed per job/request, not by directly broadcasting raw runtime progress streams to multiple callers.
+- chunked / yielding file transcription
+- pause/cancel policy for running batch work when a meeting begins
+- an optional third batch slot if measurements justify it
+
+### 8. Diarization remains a separate service
+
+Speaker diarization is not part of the speech-slot scheduler.
+
+It remains a separate service because:
+
+- it is a different model path from Parakeet STT
+- it is not latency-critical like dictation
+- it is usually post-STT enrichment rather than interactive inference
+
+The STT control plane may coordinate with diarization for lifecycle/UI/reporting purposes, but diarization capacity policy remains separate.
+
+### 9. Progress must be job-scoped
+
+Progress reporting is owned by the control plane and exposed per job/request, not by directly broadcasting raw runtime progress streams to multiple callers.
 
 This avoids crosstalk between:
 
@@ -130,25 +167,26 @@ This avoids crosstalk between:
 
 ### Positive
 
-- Clear ownership: one runtime, one scheduler, many producers
+- Clear ownership: one control plane, one runtime owner, many producers
 - Warm-up and shutdown become deterministic
-- Dictation latency is protected explicitly instead of by luck
+- Dictation latency is protected explicitly
 - Meeting live preview degrades gracefully under pressure
-- Saved meeting retranscribes cannot block active meeting finalization
-- The architecture naturally extends to future concurrency cases, including file transcription during meetings
+- File transcription is intentionally simple and low-risk in v1
+- The architecture leaves room for chunked batch work or a third slot later without returning to per-feature STT ownership
 
 ### Negative
 
 - Adds a real scheduling abstraction instead of relying on direct service calls
 - Requires explicit queue, priority, and cancellation tests
-- Chunked batch transcription is a larger follow-on change if full fairness is desired
+- A running long file transcription can delay meeting STT on the shared background slot
+- The control plane must clearly document that batch latency can rise during interactive work
 
 ## Implementation Direction
 
 ### Core types
 
-- `STTRuntime` — owns lane-scoped `AsrManager` instances plus model lifecycle
-- `STTScheduler` — owns lane admission, in-lane priority, progress fan-out, and job execution against the runtime
+- `STTRuntime` — owns slot-scoped `AsrManager` instances plus model lifecycle
+- `STTScheduler` — owns admission, slot assignment, in-slot priority, progress fan-out, and job execution against the runtime
 
 ### Service boundaries
 
@@ -162,13 +200,13 @@ This avoids crosstalk between:
 2. Route all existing `STTClient` call sites through the scheduler
 3. Remove per-feature STT client ownership
 4. Make runtime warm-up / shutdown the single app-wide path
-5. Add scheduler priority and backpressure tests
+5. Add scheduler priority, cancellation, and backpressure tests
 
 ## Notes
 
 - The primary product use case remains **meeting recording + dictation**.
-- File transcription concurrency is worth supporting architecturally, even if it remains a lower-priority workflow in the UX and release messaging.
+- File transcription remains a lower-priority workflow in the UX and release messaging.
 - Upstream validation against the checked-out FluidAudio `0.13.6` dependency supports this design:
   - `AsrManager` is documented as thread-safe/concurrent.
-  - `transcriptionProgressStream` is explicitly single-session per manager, which reinforces keeping progress isolated by lane instead of multiplexing unrelated jobs through one manager instance.
+  - `transcriptionProgressStream` is explicitly single-session per manager, which reinforces keeping progress isolated by slot instead of multiplexing unrelated jobs through one manager instance.
   - `OfflineDiarizerManager.prepareModels()` short-circuits once models are prepared, so MacParakeet's single shared diarization wrapper matches the intended lifecycle.

--- a/spec/adr/016-centralized-stt-runtime-scheduler.md
+++ b/spec/adr/016-centralized-stt-runtime-scheduler.md
@@ -25,19 +25,20 @@ Per-flow STT ownership leads to duplicated runtime lifecycle, unclear shutdown/w
 
 ## Decision
 
-### 1. One process-wide STT runtime
+### 1. One process-wide STT runtime owner
 
-MacParakeet owns exactly one STT runtime for Parakeet inference in the app process.
+MacParakeet owns exactly one app-level STT runtime actor for Parakeet inference in the process.
 
 That runtime is the sole owner of:
 
-- `AsrManager`
+- lane-scoped `AsrManager` instances
 - model download / initialization / readiness
 - warm-up progress
 - shutdown / cleanup
 - model cache clearing
 
 No feature service (`DictationService`, `MeetingRecordingService`, `TranscriptionService`) owns its own STT runtime.
+The runtime may keep multiple internal managers so the scheduler can isolate dictation, meeting, and batch work without app-level head-of-line blocking, but that multiplicity stays hidden behind one shared runtime owner.
 
 ### 2. One explicit STT scheduler / broker
 
@@ -64,21 +65,34 @@ This ADR does **not** change the audio architecture from ADR-014 / ADR-015:
 
 Concurrency at the audio layer remains independent. This ADR only centralizes ownership of the STT layer.
 
-### 4. Priority policy is product-driven
+### 4. Scheduling policy is lane-driven
 
-The scheduler uses the following priority order:
+The scheduler partitions work into three explicit lanes:
 
-1. **Dictation** — highest priority
-2. **Meeting finalization** — high priority after recording stops
-3. **Meeting live chunks** — medium priority, best-effort
-4. **File / YouTube transcription** — lowest priority
+1. **Dictation lane** — serial, interactive, reserved for `dictation`
+2. **Meeting lane** — serial, reserved for `meetingFinalize` and `meetingLiveChunk`
+3. **Batch lane** — serial, reserved for `fileTranscription`
+
+Within the meeting lane:
+
+1. **Meeting finalization** beats queued live preview work
+2. **Meeting live chunks** remain best-effort
+
+Batch work includes:
+
+- file transcription
+- YouTube transcription
+- retranscription of already-saved meetings from the library
+
+Only the immediate post-stop meeting path uses `meetingFinalize`.
+Archived meeting retranscribes stay on the batch lane even when their telemetry/source metadata remains `.meeting`.
 
 Rationale:
 
 - Dictation is interactive and latency-sensitive
-- Stopped meeting recordings should complete promptly
-- Live meeting preview should degrade before dictation does
-- Batch file work should yield to interactive work
+- Stopped meeting recordings should complete promptly once they enter the meeting lane
+- Live meeting preview should degrade before stop/finalize work
+- Saved-library retranscribes should never occupy the meeting lane used by active meetings
 
 ### 5. Backpressure is explicit
 
@@ -87,7 +101,6 @@ Meeting live chunk transcription is best-effort and droppable under backlog.
 If the scheduler exceeds configured queue or latency thresholds, it may:
 
 - drop pending live meeting chunks
-- coalesce stale live chunk jobs
 - continue preserving the final mixed meeting artifact for post-stop transcription
 
 This keeps the app responsive while preserving correctness of the final saved meeting.
@@ -98,9 +111,9 @@ To support meaningful prioritization, long-running work must be divided into bou
 
 - Meeting live preview already uses chunked work units
 - Dictation is naturally short
-- File / YouTube transcription should evolve toward chunked or segmented STT work if we want true coexistence with interactive dictation
+- File / YouTube transcription should evolve toward chunked or segmented STT work if we want finer-grained fairness within the batch lane
 
-Until batch transcription is segmented, the scheduler may only reorder jobs **between** transcriptions, not preempt a currently running long decode.
+Until batch transcription is segmented, each lane remains single-slot and non-preemptive: the scheduler may reorder queued work before admission to a lane, but it does not preempt a currently running decode within that lane.
 
 ### 7. Progress must be job-scoped
 
@@ -121,6 +134,7 @@ This avoids crosstalk between:
 - Warm-up and shutdown become deterministic
 - Dictation latency is protected explicitly instead of by luck
 - Meeting live preview degrades gracefully under pressure
+- Saved meeting retranscribes cannot block active meeting finalization
 - The architecture naturally extends to future concurrency cases, including file transcription during meetings
 
 ### Negative
@@ -133,14 +147,14 @@ This avoids crosstalk between:
 
 ### Core types
 
-- `STTRuntime` — owns `AsrManager` and model lifecycle
-- `STTScheduler` — owns queueing, priority, progress fan-out, and job execution against the runtime
+- `STTRuntime` — owns lane-scoped `AsrManager` instances plus model lifecycle
+- `STTScheduler` — owns lane admission, in-lane priority, progress fan-out, and job execution against the runtime
 
 ### Service boundaries
 
 - `DictationService` submits interactive dictation jobs
-- `MeetingRecordingService` submits live chunk and meeting-finalization jobs
-- `TranscriptionService` submits batch file / YouTube jobs
+- `MeetingRecordingService` submits live chunk and immediate post-stop meeting-finalization jobs
+- `TranscriptionService` submits batch file / YouTube jobs plus saved-item retranscribes
 
 ### Migration path
 

--- a/spec/adr/016-centralized-stt-runtime-scheduler.md
+++ b/spec/adr/016-centralized-stt-runtime-scheduler.md
@@ -111,6 +111,26 @@ This means:
 Only the immediate post-stop meeting path uses `meetingFinalize`.
 Archived meeting retranscribes remain `fileTranscription` even when their telemetry/source metadata remains `.meeting`.
 
+Reference shape:
+
+```text
+DictationService -----------┐
+MeetingRecordingService ----┼--> STTScheduler / Control Plane
+TranscriptionService -------┘
+                                  │
+                                  ├── Interactive slot
+                                  │     └── dictation
+                                  │
+                                  └── Background slot
+                                        ├── meetingFinalize
+                                        ├── meetingLiveChunk
+                                        └── fileTranscription
+                                               │
+                                               ▼
+                                        STTRuntime
+                                  (slot-scoped AsrManager instances)
+```
+
 ### 6. Backpressure is explicit
 
 Meeting live chunk transcription is best-effort and droppable under backlog.
@@ -151,6 +171,8 @@ It remains a separate service because:
 - it is usually post-STT enrichment rather than interactive inference
 
 The STT control plane may coordinate with diarization for lifecycle/UI/reporting purposes, but diarization capacity policy remains separate.
+
+Keeping diarization out of the speech-slot scheduler does **not** mean product readiness may ignore it. When speaker detection is enabled by default, onboarding and ready-state UX must account for diarization-model readiness before claiming file transcription is fully prepared.
 
 ### 9. Progress must be job-scoped
 

--- a/spec/adr/016-centralized-stt-runtime-scheduler.md
+++ b/spec/adr/016-centralized-stt-runtime-scheduler.md
@@ -168,3 +168,7 @@ This avoids crosstalk between:
 
 - The primary product use case remains **meeting recording + dictation**.
 - File transcription concurrency is worth supporting architecturally, even if it remains a lower-priority workflow in the UX and release messaging.
+- Upstream validation against the checked-out FluidAudio `0.13.6` dependency supports this design:
+  - `AsrManager` is documented as thread-safe/concurrent.
+  - `transcriptionProgressStream` is explicitly single-session per manager, which reinforces keeping progress isolated by lane instead of multiplexing unrelated jobs through one manager instance.
+  - `OfflineDiarizerManager.prepareModels()` short-circuits once models are prepared, so MacParakeet's single shared diarization wrapper matches the intended lifecycle.

--- a/spec/kernel/traceability.md
+++ b/spec/kernel/traceability.md
@@ -17,7 +17,7 @@ This matrix traces each requirement ID from `requirements.yaml` to its implement
 | REQ-UI-003 | `MacParakeet/Views/MainWindowView.swift` | (ViewModel tests) |
 | REQ-DATA-001 | `MacParakeetCore/Database/DictationRepository.swift` | `DictationRepositoryTests.swift` |
 | REQ-DATA-002 | `MacParakeetCore/Database/DatabaseManager.swift` | `DatabaseManagerTests.swift` |
-| REQ-STT-001 | `MacParakeetCore/STT/STTRuntime.swift`, `MacParakeetCore/STT/STTScheduler.swift`, `MacParakeetCore/STT/STTClient.swift`, `MacParakeetCore/Services/TranscriptionService.swift`, `MacParakeetViewModels/OnboardingViewModel.swift` | `STTSchedulerTests.swift`, `STTClientTests.swift`, `TranscriptionServiceTests.swift`, `OnboardingViewModelTests.swift` |
+| REQ-STT-001 | `MacParakeet/App/AppEnvironment.swift`, `MacParakeetCore/STT/STTRuntime.swift`, `MacParakeetCore/STT/STTScheduler.swift`, `MacParakeetCore/STT/STTClient.swift`, `MacParakeetCore/Services/DictationService.swift`, `MacParakeetCore/Services/MeetingRecordingService.swift`, `MacParakeetCore/Services/TranscriptionService.swift`, `MacParakeetViewModels/OnboardingViewModel.swift` | `STTSchedulerTests.swift`, `STTClientTests.swift`, `DictationServiceTests.swift`, `MeetingRecordingServiceTests.swift`, `TranscriptionServiceTests.swift`, `OnboardingViewModelTests.swift` |
 | REQ-EXP-001 | `MacParakeetCore/Services/ExportService.swift` | `ExportServiceTests.swift` |
 
 ## v0.2 Clean Pipeline

--- a/spec/kernel/traceability.md
+++ b/spec/kernel/traceability.md
@@ -17,7 +17,7 @@ This matrix traces each requirement ID from `requirements.yaml` to its implement
 | REQ-UI-003 | `MacParakeet/Views/MainWindowView.swift` | (ViewModel tests) |
 | REQ-DATA-001 | `MacParakeetCore/Database/DictationRepository.swift` | `DictationRepositoryTests.swift` |
 | REQ-DATA-002 | `MacParakeetCore/Database/DatabaseManager.swift` | `DatabaseManagerTests.swift` |
-| REQ-STT-001 | `MacParakeetCore/STT/STTClient.swift` | `STTClientTests.swift` |
+| REQ-STT-001 | `MacParakeetCore/STT/STTRuntime.swift`, `MacParakeetCore/STT/STTScheduler.swift`, `MacParakeetCore/STT/STTClient.swift` | `STTSchedulerTests.swift`, `STTClientTests.swift` |
 | REQ-EXP-001 | `MacParakeetCore/Services/ExportService.swift` | `ExportServiceTests.swift` |
 
 ## v0.2 Clean Pipeline

--- a/spec/kernel/traceability.md
+++ b/spec/kernel/traceability.md
@@ -17,7 +17,7 @@ This matrix traces each requirement ID from `requirements.yaml` to its implement
 | REQ-UI-003 | `MacParakeet/Views/MainWindowView.swift` | (ViewModel tests) |
 | REQ-DATA-001 | `MacParakeetCore/Database/DictationRepository.swift` | `DictationRepositoryTests.swift` |
 | REQ-DATA-002 | `MacParakeetCore/Database/DatabaseManager.swift` | `DatabaseManagerTests.swift` |
-| REQ-STT-001 | `MacParakeetCore/STT/STTRuntime.swift`, `MacParakeetCore/STT/STTScheduler.swift`, `MacParakeetCore/STT/STTClient.swift` | `STTSchedulerTests.swift`, `STTClientTests.swift` |
+| REQ-STT-001 | `MacParakeetCore/STT/STTRuntime.swift`, `MacParakeetCore/STT/STTScheduler.swift`, `MacParakeetCore/STT/STTClient.swift`, `MacParakeetCore/Services/TranscriptionService.swift`, `MacParakeetViewModels/OnboardingViewModel.swift` | `STTSchedulerTests.swift`, `STTClientTests.swift`, `TranscriptionServiceTests.swift`, `OnboardingViewModelTests.swift` |
 | REQ-EXP-001 | `MacParakeetCore/Services/ExportService.swift` | `ExportServiceTests.swift` |
 
 ## v0.2 Clean Pipeline


### PR DESCRIPTION
## Summary

This PR implements [ADR-016](https://github.com/moona3k/macparakeet/blob/main/spec/adr/016-centralized-stt-runtime-scheduler.md): all speech-to-text work in the app now routes through one process-wide runtime and an explicit two-slot scheduler.

The new control plane provides:

- **`STTRuntime`** — sole owner of the Parakeet model lifecycle, managing two `AsrManager` instances (one per execution slot)
- **`STTScheduler`** — explicit broker for admission, priority, backpressure, cancellation, and job-scoped progress
- **Two execution slots:**
  - `interactive` — reserved for dictation (always responsive)
  - `background` — shared by `meetingFinalize`, `meetingLiveChunk`, and `fileTranscription`
- **Background-slot priority:** `meetingFinalize` > `meetingLiveChunk` > `fileTranscription`
- **Backpressure:** meeting live preview is best-effort and droppable under backlog

Beyond the core architecture, this PR also:
- hardens meeting-stop behavior under lagging live-preview transcription
- fixes onboarding to check speaker-model readiness before reporting "ready"
- updates the CLI to describe the full local speech stack
- upgrades FluidAudio from 0.12.5 to 0.13.6, dropping 11 transitive dependencies (15 → 4 SPM pins)
- aligns all active specs and docs with the implemented design

Closes #64.

## Why This Change

MacParakeet has three speech workflows with materially different latency profiles:

- **`dictation`** must stay responsive — the user is waiting for pasted text
- **`meetingFinalize`** must complete promptly after the user stops recording
- **`meetingLiveChunk`** is useful but best-effort — preview can lag without data loss
- **`fileTranscription`** is asynchronous — users expect it to take time

Before this PR, each feature created its own `STTClient`. Concurrency guarantees were implicit in wiring, not stated in policy. That made it hard to reason about what happens when dictation fires during a long file transcription, or when meeting stop needs the background slot occupied by a queued live chunk.

This PR replaces that with a centralized, policy-first design: one shared runtime, two execution slots, and explicit rules for priority and backpressure. Dictation gets dedicated capacity. Everything else shares a bounded background path with deterministic ordering.

## Architecture

```text
                           MacParakeet Speech Control Plane

    Dictation                  Meeting Recording                  File / YouTube
    ─────────                  ─────────────────                  ──────────────
    DictationService           MeetingRecordingService            TranscriptionService
          \                           |                           /
           \                          |                          /
            +─────────────────────────+─────────────────────────+
                                      │
                                      ▼
                               ┌────────────────┐
                               │  STTScheduler  │
                               │────────────────│
                               │ interactive    │ → dictation only
                               │ background     │ → meetingFinalize
                               └────────────────┘   meetingLiveChunk
                                      │              fileTranscription
                                      ▼
                                ┌───────────────┐
                                │  STTRuntime   │
                                │───────────────│
                                │ shared model  │
                                │ lifecycle     │
                                │ 2 AsrManagers │
                                └───────────────┘
                                      │
                                      ▼
                              FluidAudio / Parakeet

                 Diarization remains a separate service outside the scheduler.
```

STT ownership is singular at the app boundary. Execution capacity is split into two slots so dictation stays isolated while meeting and file work share an explicitly prioritized background path.

## Scheduling Policy

### Slot assignment

- `dictation` always routes to the reserved **interactive** slot
- `meetingFinalize`, `meetingLiveChunk`, and `fileTranscription` always route to the shared **background** slot

### Background-slot priority

1. `meetingFinalize`
2. `meetingLiveChunk`
3. `fileTranscription`

### Accepted v1 tradeoff

A running long file transcription can still delay later meeting STT on the shared background slot. This is intentional in v1: it keeps the architecture simple, resource usage bounded, and still protects the most important user-facing guarantee — dictation responsiveness.

## What Changed

### Core STT architecture

- Converges the runtime from an intermediate 3-manager shape to the approved 2-slot design
- Converges the scheduler from three fixed lanes (`dictation` / `meeting` / `batch`) to two policy-driven slots (`interactive` + `background`)
- Keeps one `AsrManager` per slot, sharing the same Parakeet model bundle and lifecycle owner
- Centralizes progress, cancellation, shutdown, and warm-up under the shared control plane
- Upgrades FluidAudio from 0.12.5 to 0.13.6

### Dependency reduction (FluidAudio 0.12.5 → 0.13.6)

The FluidAudio upgrade drops **11 of 15** resolved SPM pins (73%), leaving only 4 direct dependencies:

| Remaining (4) | Dropped (11) |
|---|---|
| FluidAudio 0.13.6 | EventSource 1.4.1 |
| GRDB.swift | swift-asn1 1.6.0 |
| Sparkle | swift-atomics 1.3.0 |
| swift-argument-parser | swift-collections 1.4.1 |
| | swift-crypto 4.3.0 |
| | swift-huggingface 0.9.0 |
| | swift-jinja 2.3.2 |
| | swift-nio 2.96.0 |
| | swift-system 1.6.4 |
| | swift-transformers 1.2.0 |
| | yyjson 0.12.0 |

These were all transitive dependencies pulled in by FluidAudio's earlier reliance on the Hugging Face Swift stack (`swift-transformers` → `swift-huggingface` → `swift-jinja`, `yyjson`) and its networking/crypto chain (`swift-nio` → `swift-atomics`, `swift-collections`, `swift-system`; `swift-crypto` → `swift-asn1`; `EventSource`). FluidAudio 0.13.x internalized or eliminated these paths.

Impact: faster clean builds, faster SPM resolution, smaller binary contribution from transitive code, and a significantly reduced supply-chain surface.

### Meeting workflow correctness

- Preserves `meetingFinalize` priority over queued live preview and file transcription
- Keeps live preview droppable under backlog
- Calibrates the live-preview backlog limit against the real dual-source chunk cadence instead of the earlier single-stream assumption
- Preserves already-assembled speaker metadata when stop times out waiting for lagging live chunks
- Prevents backpressure drops from poisoning prepared meeting metadata used by finalization
- Surfaces a "transcription lagging" indicator in the meeting UI when backpressure drops occur
- Prevents stale chunk failures from a prior meeting session from mutating the current session

### Onboarding and speaker assets

- Onboarding preflight now checks both speech-model cache and speaker-model cache before reporting readiness
- Speaker models are still prepared before marking the engine ready
- Speech-model cache, speaker-model cache, and in-process preparation are treated as distinct states instead of one ambiguous `ready` flag
- Warm-up observer registration and cleanup are generation-safe — stale attempts cannot register or overwrite the current observer
- Diarization remains a separate service, outside the STT slot scheduler

### CLI, docs, and tests

- `macparakeet-cli models` and `macparakeet-cli health` now describe the full local speech stack (speech model + speaker models), not just Parakeet STT
- CLI output distinguishes cached assets from in-process preparation and runtime readiness
- Active specs and docs describe the implemented two-slot architecture directly
- New targeted test coverage for the scheduler, onboarding, diarization, and meeting-stop regressions

## User Impact

For users, nothing changes in how the app looks or feels. This PR is about preserving the right behavior under concurrent workloads:

- **Dictation stays responsive** during meeting recording and file transcription
- **Meeting recording finalizes promptly** after the user stops — not blocked behind queued preview chunks
- **Live preview degrades gracefully** under backlog instead of blocking correctness, with a visible "catching up" indicator
- **Stopping a lagging meeting** still preserves any speaker metadata that was already assembled
- **Onboarding no longer falsely reports readiness** when required speaker assets are missing
- **File and YouTube transcription** continue to work as before, queued behind interactive work

## Verification

Executed on this branch after the final audit:

```
swift build                                          ✓
swift test                                           ✓
swift test --filter STTSchedulerTests                ✓
swift test --filter MeetingRecordingServiceTests      ✓
swift test --filter OnboardingViewModelTests          ✓
swift test --filter DiarizationServiceTests           ✓
swift test --filter ModelLifecycleCommandTests        ✓
git diff --check                                     ✓
swift run macparakeet-cli help models                 ✓
swift run macparakeet-cli help health                 ✓
```

## Review Guide

Recommended review order:

1. `Sources/MacParakeetCore/STT/STTScheduler.swift` — the scheduling policy
2. `Sources/MacParakeetCore/STT/STTRuntime.swift` — the runtime lifecycle owner
3. `Sources/MacParakeetCore/Services/MeetingRecordingService.swift` — meeting stop + backpressure handling
4. `Sources/MacParakeetViewModels/OnboardingViewModel.swift` — speaker-model readiness gating
5. `Sources/MacParakeetCore/Services/DiarizationService.swift` — cache/readiness API additions
6. `Sources/CLI/Commands/ModelsCommand.swift` — CLI speech-stack reporting
7. `Sources/CLI/Commands/HealthCommand.swift` — CLI health reporting
8. `Tests/MacParakeetTests/STT/STTSchedulerTests.swift` — scheduler guarantees
9. `Tests/MacParakeetTests/Services/MeetingRecordingServiceTests.swift` — meeting regressions
10. `Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift` — onboarding readiness

Questions to ask while reviewing:

- Does the code match the approved 2-slot ADR-016 architecture?
- Are the scheduler guarantees clear and defensible for all four job kinds?
- Does meeting stop preserve correct speaker metadata under backlog and timeout?
- Is onboarding honest about speaker-model readiness?
- Do the CLI and docs describe the speech stack accurately?
