### PR TITLE
Fix community GitHub link in Feedback panel

### DIFF
--- a/Sources/MacParakeet/Views/Feedback/FeedbackView.swift
+++ b/Sources/MacParakeet/Views/Feedback/FeedbackView.swift
@@ -348,7 +348,7 @@ struct FeedbackView: View {
             icon: "person.2"
         ) {
             Button {
-                if let url = URL(string: "https://github.com/moona3k/macparakeet-community") {
+                if let url = URL(string: "https://github.com/moona3k/macparakeet/issues") {
                     NSWorkspace.shared.open(url)
                 }
             } label: {


### PR DESCRIPTION
## Summary
- The "Open on GitHub" button in the Feedback community section was still pointing to the archived `macparakeet-community` repo
- Updated the link to `moona3k/macparakeet/issues` where all issues now live

Related: #69 (will close after next release)

## Test plan
- [ ] Open Feedback panel → Community section → click "Open on GitHub" → should open `github.com/moona3k/macparakeet/issues`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Community card link to direct users to the GitHub issues page instead of the community repository page, streamlining the path for users to report bugs and provide feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->