### PR TITLE
Add "Reset to Default" option to hotkey recorder

### DIFF
--- a/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
+++ b/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
@@ -60,10 +60,20 @@ struct HotkeyRecorderView: View {
             .buttonStyle(.bordered)
 
             Menu {
-                Button("Reset to Default (\(defaultTrigger.shortSymbol) \(defaultTrigger.displayName))") {
-                    trigger = defaultTrigger
-                    validationMessage = nil
-                    validationIsBlocked = false
+                Button("Reset to Default (\(defaultTrigger.shortSymbol))") {
+                    switch combinedValidation(for: defaultTrigger) {
+                    case .blocked(let msg):
+                        validationMessage = msg
+                        validationIsBlocked = true
+                    case .warned(let msg):
+                        trigger = defaultTrigger
+                        validationMessage = msg
+                        validationIsBlocked = false
+                    case .allowed:
+                        trigger = defaultTrigger
+                        validationMessage = nil
+                        validationIsBlocked = false
+                    }
                 }
                 .disabled(trigger == defaultTrigger)
 

--- a/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
+++ b/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
@@ -13,6 +13,7 @@ struct HotkeyRecorderView: View {
     }
 
     @Binding var trigger: HotkeyTrigger
+    var defaultTrigger: HotkeyTrigger = .fn
     var additionalValidation: ((HotkeyTrigger) -> HotkeyTrigger.ValidationResult)? = nil
     @State private var isRecording = false
     @State private var validationMessage: String?
@@ -59,6 +60,15 @@ struct HotkeyRecorderView: View {
             .buttonStyle(.bordered)
 
             Menu {
+                Button("Reset to Default (\(defaultTrigger.shortSymbol) \(defaultTrigger.displayName))") {
+                    trigger = defaultTrigger
+                    validationMessage = nil
+                    validationIsBlocked = false
+                }
+                .disabled(trigger == defaultTrigger)
+
+                Divider()
+
                 Button("Record Specific Modifier Side") {
                     startRecording(modifierCaptureMode: .sideSpecific)
                 }
@@ -67,7 +77,7 @@ struct HotkeyRecorderView: View {
                     .font(.system(size: 14))
             }
             .menuStyle(.borderlessButton)
-            .help("Advanced hotkey options, including recording a specific left or right modifier key.")
+            .help("Advanced hotkey options, including resetting to default or recording a specific modifier key.")
         }
     }
 

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -248,7 +248,7 @@ struct SettingsView: View {
                     VStack(alignment: .trailing, spacing: 4) {
                         HotkeyRecorderView(
                             trigger: $viewModel.meetingHotkeyTrigger,
-                            defaultTrigger: .chord(modifiers: ["command", "shift"], keyCode: 46)
+                            defaultTrigger: HotkeyTrigger.chord(modifiers: ["command", "shift"], keyCode: 46)
                         ) { candidate in
                             guard candidate == viewModel.hotkeyTrigger else { return .allowed }
                             return .blocked("Already used by dictation.")

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -248,7 +248,7 @@ struct SettingsView: View {
                     VStack(alignment: .trailing, spacing: 4) {
                         HotkeyRecorderView(
                             trigger: $viewModel.meetingHotkeyTrigger,
-                            defaultTrigger: HotkeyTrigger.chord(modifiers: ["command", "shift"], keyCode: 46)
+                            defaultTrigger: .defaultMeetingRecording
                         ) { candidate in
                             guard candidate == viewModel.hotkeyTrigger else { return .allowed }
                             return .blocked("Already used by dictation.")

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -246,7 +246,10 @@ struct SettingsView: View {
                     )
                     Spacer(minLength: DesignSystem.Spacing.md)
                     VStack(alignment: .trailing, spacing: 4) {
-                        HotkeyRecorderView(trigger: $viewModel.meetingHotkeyTrigger) { candidate in
+                        HotkeyRecorderView(
+                            trigger: $viewModel.meetingHotkeyTrigger,
+                            defaultTrigger: .chord(modifiers: ["command", "shift"], keyCode: 46)
+                        ) { candidate in
                             guard candidate == viewModel.hotkeyTrigger else { return .allowed }
                             return .blocked("Already used by dictation.")
                         }

--- a/Sources/MacParakeetCore/STT/HotkeyTrigger.swift
+++ b/Sources/MacParakeetCore/STT/HotkeyTrigger.swift
@@ -166,6 +166,11 @@ public struct HotkeyTrigger: Sendable {
     /// All modifier presets for UI iteration.
     public static let modifierPresets: [HotkeyTrigger] = [.fn, .control, .option, .shift, .command]
 
+    // MARK: - Default Triggers
+
+    public static let defaultDictation: HotkeyTrigger = .fn
+    public static let defaultMeetingRecording: HotkeyTrigger = .chord(modifiers: ["command", "shift"], keyCode: 46)
+
     // MARK: - Factory
 
     /// Create a trigger from a CGKeyCode.


### PR DESCRIPTION
## Summary

Adds a **Reset to Default** menu item to the hotkey recorder's `⋯` menu in Settings. Each hotkey shows its own default in the label — dictation shows "Reset to Default (🌐 Fn)", meeting recording shows "Reset to Default (⇧⌘M)". The button is disabled when the hotkey is already at its default value.

The reset runs through the same validation pipeline as manual recording, so conflicts are caught before the change applies.

Default triggers are now named constants (`HotkeyTrigger.defaultDictation`, `.defaultMeetingRecording`) instead of inline literals.

Closes #70.

## Test plan

- [ ] Change dictation hotkey → verify "Reset to Default (🌐 Fn)" appears enabled in `⋯` menu → click → confirm reset to Fn
- [ ] Verify the reset item is disabled when already at default
- [ ] Change meeting hotkey → verify "Reset to Default (⇧⌘M)" appears → click → confirm reset
- [ ] Confirm "Change..." + press Fn still works (no regression)