### PR TITLE
Fix system audio tap not capturing on macOS 15

### DIFF
--- a/Sources/MacParakeetCore/Audio/SystemAudioTap.swift
+++ b/Sources/MacParakeetCore/Audio/SystemAudioTap.swift
@@ -103,7 +103,7 @@ public final class SystemAudioTap: @unchecked Sendable {
     }
 
     private func createProcessTap() throws {
-        let tapDescription = CATapDescription(stereoMixdownOfProcesses: [])
+        let tapDescription = CATapDescription(stereoGlobalTapButExcludeProcesses: [])
         let tapUUID = UUID()
         tapDescription.uuid = tapUUID
         tapDescription.muteBehavior = .unmuted

--- a/scripts/dev/run_app.sh
+++ b/scripts/dev/run_app.sh
@@ -87,6 +87,8 @@ cat > "$APP_BUNDLE/Contents/Info.plist" << 'PLIST'
     <string>0.0.0</string>
     <key>NSMicrophoneUsageDescription</key>
     <string>MacParakeet needs microphone access for voice dictation.</string>
+    <key>NSAudioCaptureUsageDescription</key>
+    <string>MacParakeet needs system audio recording access for meeting recording.</string>
 </dict>
 </plist>
 PLIST

--- a/scripts/dist/build_app_bundle.sh
+++ b/scripts/dist/build_app_bundle.sh
@@ -400,6 +400,8 @@ cat >"$INFO_PLIST" <<EOF
   <true/>
   <key>NSMicrophoneUsageDescription</key>
   <string>MacParakeet needs microphone access for dictation.</string>
+  <key>NSAudioCaptureUsageDescription</key>
+  <string>MacParakeet needs system audio recording access for meeting recording.</string>
   <key>SUFeedURL</key>
   <string>https://macparakeet.com/appcast.xml</string>
   <key>SUEnableAutomaticChecks</key>


### PR DESCRIPTION
## Summary
- **One-line fix**: Changed `CATapDescription(stereoMixdownOfProcesses: [])` to `CATapDescription(stereoGlobalTapButExcludeProcesses: [])` in `SystemAudioTap.swift`

## Root Cause
`stereoMixdownOfProcesses: []` means "mix down audio from these specific processes" — an empty array means no processes, so nothing is captured. This likely worked on macOS 14.x (empty = wildcard) but macOS 15 interprets it literally (empty = nothing).

`stereoGlobalTapButExcludeProcesses: []` means "capture all system audio, exclude nothing" — the correct semantic for meeting recording.

## Result
- System audio chunks now flow (`source=system` in logs)
- "Them" speaker labels appear in the live transcript preview
- Both mic and system audio meters show activity
- Dual-stream transcription works end-to-end

Fixes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)