### PR TITLE
Add option to disable dictation and meeting hotkeys

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ All ADRs are in `spec/adr/`. These are locked decisions -- don't second-guess th
 
 ## Current Phase
 
-**v0.6 In Progress** -- ~166 source files, ~87 test files, 1268 tests passing (`swift test` green)
+**v0.6 In Progress** -- ~198 source files, ~101 test files, 1311 tests passing (`swift test` green)
 
 - **v0.1** MVP -- System-wide dictation, file transcription, overlay, history, export, SQLite, CLI, STT engine
 - **v0.2** Clean Pipeline -- Text processing (filler removal, custom words, snippets), Vocabulary UI, feedback form

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -527,7 +527,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     // MARK: - Hotkey
 
     private func setupHotkey() {
-        let manager = HotkeyManager(trigger: HotkeyTrigger.current)
+        let trigger = HotkeyTrigger.current
+        guard !trigger.isDisabled else {
+            hotkeyManager = nil
+            dictationFlowCoordinator?.hotkeyManager = nil
+            return
+        }
+
+        let manager = HotkeyManager(trigger: trigger)
 
         manager.onStartRecording = { [weak self] mode in
             self?.dictationFlowCoordinator?.startDictation(mode: mode, trigger: .hotkey)
@@ -686,7 +693,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     }
 
     private var hotkeyMenuTitle: String {
-        "Hotkey: \(HotkeyTrigger.current.displayName) (double-tap / hold)"
+        let trigger = HotkeyTrigger.current
+        if trigger.isDisabled {
+            return "Hotkey: Disabled"
+        }
+        return "Hotkey: \(trigger.displayName) (double-tap / hold)"
     }
 
     /// Configures an NSMenuItem with the meeting hotkey shortcut.

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -572,12 +572,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     }
 
     private func setupMeetingHotkey() {
-        guard settingsViewModel.meetingHotkeyTrigger != settingsViewModel.hotkeyTrigger else {
+        let trigger = settingsViewModel.meetingHotkeyTrigger
+        guard !trigger.isDisabled else {
+            meetingHotkeyManager = nil
+            return
+        }
+        guard trigger != settingsViewModel.hotkeyTrigger else {
             meetingHotkeyManager = nil
             return
         }
 
-        let manager = GlobalShortcutManager(trigger: settingsViewModel.meetingHotkeyTrigger)
+        let manager = GlobalShortcutManager(trigger: trigger)
         manager.onTrigger = { [weak self] in
             Task { @MainActor in
                 self?.toggleMeetingRecording(originatesFromWindow: false)

--- a/Sources/MacParakeet/Hotkey/GlobalShortcutManager.swift
+++ b/Sources/MacParakeet/Hotkey/GlobalShortcutManager.swift
@@ -98,6 +98,8 @@ public final class GlobalShortcutManager {
         }
 
         switch trigger.kind {
+        case .disabled:
+            return Unmanaged.passUnretained(event)
         case .modifier:
             return handleModifierEvent(type: type, event: event)
         case .keyCode:

--- a/Sources/MacParakeet/Hotkey/HotkeyManager.swift
+++ b/Sources/MacParakeet/Hotkey/HotkeyManager.swift
@@ -181,6 +181,8 @@ public final class HotkeyManager {
         }
 
         switch trigger.kind {
+        case .disabled:
+            return Unmanaged.passUnretained(event)
         case .modifier:
             return handleModifierEvent(type: type, event: event)
         case .keyCode:

--- a/Sources/MacParakeet/Views/Dictation/DictationOverlayController.swift
+++ b/Sources/MacParakeet/Views/Dictation/DictationOverlayController.swift
@@ -148,7 +148,10 @@ final class DictationOverlayController {
             if overlayViewModel.sessionKind == .command {
                 overlayViewModel.hoverTooltip = "Stop & apply (Fn+Control)"
             } else {
-                overlayViewModel.hoverTooltip = "Stop & paste (\(HotkeyTrigger.current.displayName))"
+                let trigger = HotkeyTrigger.current
+                overlayViewModel.hoverTooltip = trigger.isDisabled
+                    ? "Stop & paste"
+                    : "Stop & paste (\(trigger.displayName))"
             }
         } else {
             overlayViewModel.hoverTooltip = nil

--- a/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
+++ b/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
@@ -450,7 +450,11 @@ struct DictationOverlayView: View {
             return ("Permission Required", "Grant access in System Settings > Privacy & Security.")
         }
         if lower.contains("not recording") {
-            return ("Not Recording", "Press \(HotkeyTrigger.current.displayName) to start recording first.")
+            let trigger = HotkeyTrigger.current
+            let hint = trigger.isDisabled
+                ? "Click the dictation pill to start recording."
+                : "Press \(trigger.displayName) to start recording first."
+            return ("Not Recording", hint)
         }
         if lower.contains("timeout") || lower.contains("timed out") {
             return ("Transcription Timed Out", "Try a shorter recording or restart the app.")

--- a/Sources/MacParakeet/Views/Dictation/IdlePillView.swift
+++ b/Sources/MacParakeet/Views/Dictation/IdlePillView.swift
@@ -62,16 +62,24 @@ struct IdlePillView: View {
     // MARK: - Tooltip
 
     private var tooltip: some View {
-        HStack(spacing: 0) {
-            Text("Click or hold ")
-                .font(.system(size: 14, weight: .medium))
-                .foregroundStyle(.white.opacity(0.9))
-            Text(HotkeyTrigger.current.shortSymbol)
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundStyle(Color(nsColor: NSColor(red: 0.85, green: 0.55, blue: 0.75, alpha: 1.0)))
-            Text(" to start dictating")
-                .font(.system(size: 14, weight: .medium))
-                .foregroundStyle(.white.opacity(0.9))
+        Group {
+            if HotkeyTrigger.current.isDisabled {
+                Text("Click to start dictating")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.9))
+            } else {
+                HStack(spacing: 0) {
+                    Text("Click or hold ")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(.white.opacity(0.9))
+                    Text(HotkeyTrigger.current.shortSymbol)
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(Color(nsColor: NSColor(red: 0.85, green: 0.55, blue: 0.75, alpha: 1.0)))
+                    Text(" to start dictating")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(.white.opacity(0.9))
+                }
+            }
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 10)

--- a/Sources/MacParakeet/Views/History/DictationHistoryView.swift
+++ b/Sources/MacParakeet/Views/History/DictationHistoryView.swift
@@ -254,7 +254,9 @@ struct DictationHistoryView: View {
                     .foregroundStyle(.primary)
 
                 Text(viewModel.searchText.isEmpty
-                     ? "Double-tap \(HotkeyTrigger.current.displayName) to start dictating from any app."
+                     ? (HotkeyTrigger.current.isDisabled
+                        ? "Click the dictation pill or set a hotkey in Settings to start dictating."
+                        : "Double-tap \(HotkeyTrigger.current.displayName) to start dictating from any app.")
                      : "Try different words or clear your search.")
                     .font(DesignSystem.Typography.bodySmall)
                     .foregroundStyle(.secondary)

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
@@ -1,0 +1,253 @@
+import MacParakeetCore
+import SwiftUI
+
+/// Row-based card for displaying a meeting recording in a list layout.
+/// Shows duration, title, metadata (speakers, word count), transcript snippet,
+/// and relative time — optimized for scanning a timeline of meetings.
+struct MeetingRowCard<MenuContent: View>: View {
+    let transcription: Transcription
+    var searchText: String = ""
+    var onTap: () -> Void
+    @ViewBuilder var menuContent: () -> MenuContent
+
+    @State private var hovered = false
+    @State private var moreHovered = false
+
+    private var transcript: String? {
+        transcription.cleanTranscript ?? transcription.rawTranscript
+    }
+
+    private var wordCount: Int {
+        guard let text = transcript, !text.isEmpty else { return 0 }
+        return text.split(separator: " ").count
+    }
+
+    private var speakerCount: Int {
+        transcription.speakerCount ?? transcription.speakers?.count ?? 0
+    }
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 0) {
+                durationColumn
+                Divider()
+                    .frame(height: 48)
+                    .opacity(0.4)
+                contentColumn
+            }
+            .padding(.vertical, 12)
+            .padding(.horizontal, DesignSystem.Spacing.md)
+            .background(
+                RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
+                    .fill(hovered
+                          ? DesignSystem.Colors.rowHoverBackground
+                          : .clear)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
+                    .strokeBorder(
+                        hovered
+                            ? DesignSystem.Colors.border.opacity(0.6)
+                            : DesignSystem.Colors.border.opacity(0.25),
+                        lineWidth: 0.5
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .contentShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius))
+        .overlay(alignment: .topTrailing) {
+            moreButton
+                .padding(8)
+                .opacity(hovered ? 1 : 0)
+                .allowsHitTesting(hovered)
+        }
+        .onHover { hovered = $0 }
+        .animation(DesignSystem.Animation.hoverTransition, value: hovered)
+        .contextMenu { menuContent() }
+    }
+
+    // MARK: - Duration Column
+
+    private var durationColumn: some View {
+        VStack(spacing: 2) {
+            if let durationMs = transcription.durationMs {
+                Text(durationMs.formattedDurationCompact)
+                    .font(.system(size: 15, weight: .semibold, design: .rounded).monospacedDigit())
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+            } else {
+                Text("--:--")
+                    .font(.system(size: 15, weight: .semibold, design: .rounded).monospacedDigit())
+                    .foregroundStyle(DesignSystem.Colors.textTertiary)
+            }
+        }
+        .frame(width: 64)
+    }
+
+    // MARK: - Content Column
+
+    private var contentColumn: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            // Row 1: Title + relative time
+            HStack(alignment: .firstTextBaseline) {
+                Text(highlightedText(transcription.fileName))
+                    .font(DesignSystem.Typography.bodySmall.weight(.medium))
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                Spacer(minLength: DesignSystem.Spacing.sm)
+
+                Text(transcription.createdAt.relativeFormatted)
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textTertiary)
+                    .layoutPriority(1)
+            }
+
+            // Row 2: Metadata chips
+            HStack(spacing: DesignSystem.Spacing.sm) {
+                if speakerCount > 0 {
+                    metadataLabel(
+                        icon: "person.2",
+                        text: speakerCount == 1 ? "1 speaker" : "\(speakerCount) speakers"
+                    )
+                }
+
+                if wordCount > 0 {
+                    metadataLabel(
+                        icon: "text.word.spacing",
+                        text: wordCount.formatted() + " words"
+                    )
+                }
+
+                statusIndicator
+            }
+
+            // Row 3: Transcript snippet
+            if let snippet = transcriptSnippet {
+                Text(highlightedText(snippet))
+                    .font(.system(size: 12, weight: .regular))
+                    .foregroundStyle(DesignSystem.Colors.textTertiary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        }
+        .padding(.leading, 12)
+    }
+
+    // MARK: - Metadata Label
+
+    private func metadataLabel(icon: String, text: String) -> some View {
+        HStack(spacing: 3) {
+            Image(systemName: icon)
+                .font(.system(size: 9, weight: .medium))
+            Text(text)
+                .font(DesignSystem.Typography.caption)
+        }
+        .foregroundStyle(DesignSystem.Colors.textTertiary)
+    }
+
+    // MARK: - Status Indicator
+
+    @ViewBuilder
+    private var statusIndicator: some View {
+        switch transcription.status {
+        case .processing:
+            HStack(spacing: 3) {
+                ProgressView()
+                    .controlSize(.mini)
+                Text("Transcribing")
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.accent)
+            }
+        case .error:
+            HStack(spacing: 3) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 9))
+                Text("Error")
+                    .font(DesignSystem.Typography.caption)
+            }
+            .foregroundStyle(DesignSystem.Colors.errorRed)
+        case .completed, .cancelled:
+            EmptyView()
+        }
+    }
+
+    // MARK: - Transcript Snippet
+
+    private var transcriptSnippet: String? {
+        guard let text = transcript else { return nil }
+        let cleaned = text
+            .replacingOccurrences(of: "\n", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleaned.isEmpty else { return nil }
+        return String(cleaned.prefix(120))
+    }
+
+    // MARK: - More Button
+
+    private var moreButton: some View {
+        Menu {
+            menuContent()
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: 11, weight: .bold))
+                .foregroundStyle(DesignSystem.Colors.textTertiary)
+                .frame(width: 24, height: 24)
+                .background(
+                    Circle()
+                        .fill(DesignSystem.Colors.surfaceElevated.opacity(moreHovered ? 1 : 0.8))
+                )
+                .contentShape(Circle())
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .background(
+            Color.clear
+                .contentShape(Rectangle())
+                .onHover { moreHovered = $0 }
+        )
+    }
+
+    // MARK: - Search Highlighting
+
+    private func highlightedText(_ text: String) -> AttributedString {
+        var attributed = AttributedString(text)
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return attributed }
+
+        var searchStart = attributed.startIndex
+        while searchStart < attributed.endIndex {
+            guard let range = attributed[searchStart...].range(
+                of: query,
+                options: .caseInsensitive
+            ) else { break }
+            attributed[range].backgroundColor = DesignSystem.Colors.accent.opacity(0.2)
+            searchStart = range.upperBound
+        }
+        return attributed
+    }
+}
+
+// MARK: - Compact Duration Formatter
+
+extension Int {
+    /// Formats milliseconds as compact duration: "3s", "47s", "15m", "1h 2m".
+    /// Optimized for meeting list scanning — shorter than `formattedDuration`.
+    var formattedDurationCompact: String {
+        let totalSeconds = self / 1000
+        guard totalSeconds > 0 else { return "0s" }
+
+        let hours = totalSeconds / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        let seconds = totalSeconds % 60
+
+        if hours > 0 {
+            return minutes > 0 ? "\(hours)h \(minutes)m" : "\(hours)h"
+        } else if minutes > 0 {
+            return "\(minutes)m"
+        } else {
+            return "\(seconds)s"
+        }
+    }
+}

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingsView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingsView.swift
@@ -7,17 +7,158 @@ struct MeetingsView: View {
     let onStartMeeting: () -> Void
     let onSelectTranscription: (Transcription) -> Void
 
+    @State private var pendingDelete: Transcription?
+
     var body: some View {
-        TranscriptionLibraryView(
-            viewModel: viewModel,
-            title: "Meetings",
-            showsFilterBar: false,
-            primaryActionTitle: "Record Meeting",
-            onPrimaryAction: onStartMeeting,
-            emptyTitle: "No meetings recorded yet",
-            emptyMessage: "Record a meeting to save it here with the rest of your transcript tools."
-        ) { transcription in
-            onSelectTranscription(transcription)
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            meetingList
         }
+        .searchable(text: $viewModel.searchText, prompt: "Search meetings")
+        .onAppear { viewModel.loadTranscriptions() }
+        .alert(
+            "Delete Meeting?",
+            isPresented: Binding(
+                get: { pendingDelete != nil },
+                set: { if !$0 { pendingDelete = nil } }
+            )
+        ) {
+            Button("Cancel", role: .cancel) { pendingDelete = nil }
+            Button("Delete", role: .destructive) {
+                if let transcription = pendingDelete {
+                    viewModel.deleteTranscription(transcription)
+                    pendingDelete = nil
+                }
+            }
+        } message: {
+            if let pending = pendingDelete {
+                Text("\"\(pending.fileName)\" will be permanently deleted.")
+            }
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(alignment: .center) {
+            Text("Meetings")
+                .font(DesignSystem.Typography.pageTitle)
+                .foregroundStyle(DesignSystem.Colors.textPrimary)
+
+            Spacer()
+
+            recordMeetingButton
+        }
+        .padding(.horizontal, DesignSystem.Spacing.lg)
+        .padding(.top, DesignSystem.Spacing.lg)
+        .padding(.bottom, DesignSystem.Spacing.sm)
+    }
+
+    // MARK: - Record Meeting Button
+
+    private var recordMeetingButton: some View {
+        Button(action: onStartMeeting) {
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(DesignSystem.Colors.errorRed)
+                    .frame(width: 8, height: 8)
+
+                Text("Record Meeting")
+                    .font(.system(size: 13, weight: .semibold))
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 7)
+            .background(
+                Capsule()
+                    .fill(DesignSystem.Colors.errorRed.opacity(0.12))
+                    .overlay(
+                        Capsule()
+                            .strokeBorder(DesignSystem.Colors.errorRed.opacity(0.25), lineWidth: 0.5)
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(DesignSystem.Colors.errorRed)
+    }
+
+    // MARK: - Meeting List
+
+    @ViewBuilder
+    private var meetingList: some View {
+        if viewModel.filteredTranscriptions.isEmpty {
+            emptyState
+        } else {
+            ScrollView {
+                LazyVStack(spacing: 2) {
+                    ForEach(viewModel.filteredTranscriptions) { transcription in
+                        MeetingRowCard(
+                            transcription: transcription,
+                            searchText: viewModel.searchText,
+                            onTap: { onSelectTranscription(transcription) },
+                            menuContent: { menuItems(for: transcription) }
+                        )
+                    }
+                }
+                .padding(.horizontal, DesignSystem.Spacing.md)
+                .padding(.bottom, DesignSystem.Spacing.lg)
+            }
+        }
+    }
+
+    // MARK: - Context Menu
+
+    @ViewBuilder
+    private func menuItems(for transcription: Transcription) -> some View {
+        Button {
+            onSelectTranscription(transcription)
+        } label: {
+            Label("Open", systemImage: "doc.text")
+        }
+
+        Button {
+            viewModel.toggleFavorite(transcription)
+        } label: {
+            Label(
+                transcription.isFavorite ? "Remove from Favorites" : "Add to Favorites",
+                systemImage: transcription.isFavorite ? "star.slash" : "star"
+            )
+        }
+
+        Divider()
+
+        Button(role: .destructive) {
+            pendingDelete = transcription
+        } label: {
+            Label("Delete", systemImage: "trash")
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: DesignSystem.Spacing.lg) {
+            Spacer()
+
+            Image(systemName: viewModel.searchText.isEmpty ? "waveform.badge.mic" : "magnifyingglass")
+                .font(.system(size: 40, weight: .light))
+                .foregroundStyle(DesignSystem.Colors.textTertiary)
+
+            Text(viewModel.searchText.isEmpty
+                 ? "No meetings recorded yet"
+                 : "No matching meetings")
+                .font(DesignSystem.Typography.body)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+
+            Text(viewModel.searchText.isEmpty
+                 ? "Press Record Meeting to capture system audio and transcribe locally."
+                 : "Try different words or clear your search.")
+                .font(DesignSystem.Typography.bodySmall)
+                .foregroundStyle(DesignSystem.Colors.textTertiary)
+                .multilineTextAlignment(.center)
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.horizontal, DesignSystem.Spacing.xl)
     }
 }

--- a/Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift
+++ b/Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift
@@ -8,6 +8,13 @@ struct OnboardingFlowView: View {
     let onOpenMainApp: () -> Void
     let onOpenSettings: () -> Void
 
+    /// Trigger shown in onboarding copy — falls back to the default (.fn) when
+    /// the user has disabled their hotkey, so instructional text stays readable.
+    private var displayTrigger: HotkeyTrigger {
+        let current = HotkeyTrigger.current
+        return current.isDisabled ? .fn : current
+    }
+
     private let windowWidth: CGFloat = 740
     private let windowHeight: CGFloat = 500
 
@@ -352,7 +359,7 @@ struct OnboardingFlowView: View {
                 featureRow(
                     icon: "mic.fill",
                     title: "Dictate anywhere",
-                    detail: "Double-tap \(HotkeyTrigger.current.displayName) for persistent dictation, or hold-to-talk and release to stop. Text appears where your cursor is."
+                    detail: "Double-tap \(displayTrigger.displayName) for persistent dictation, or hold-to-talk and release to stop. Text appears where your cursor is."
                 )
                 featureRow(
                     icon: "bolt.fill",
@@ -376,6 +383,21 @@ struct OnboardingFlowView: View {
 
     private var hotkeyStep: some View {
         VStack(alignment: .leading, spacing: 14) {
+            if HotkeyTrigger.current.isDisabled {
+                HStack(spacing: 8) {
+                    Image(systemName: "info.circle.fill")
+                        .foregroundStyle(DesignSystem.Colors.accent)
+                    Text("Your dictation hotkey is currently disabled. The examples below show the default key (\(displayTrigger.shortSymbol)). You can set a hotkey anytime in Settings.")
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(DesignSystem.Spacing.md)
+                .background(
+                    RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
+                        .fill(DesignSystem.Colors.accent.opacity(0.08))
+                )
+            }
+
             // Persistent Mode card
             onboardingCard {
                 HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
@@ -390,10 +412,10 @@ struct OnboardingFlowView: View {
                             .padding(.vertical, 3)
                             .background(Capsule().fill(DesignSystem.Colors.accent.opacity(0.12)))
 
-                        Text("Double-tap \(HotkeyTrigger.current.shortSymbol)")
+                        Text("Double-tap \(displayTrigger.shortSymbol)")
                             .font(DesignSystem.Typography.sectionTitle)
 
-                        Text("Starts persistent recording.\nTap \(HotkeyTrigger.current.shortSymbol) again to stop and paste.")
+                        Text("Starts persistent recording.\nTap \(displayTrigger.shortSymbol) again to stop and paste.")
                             .font(DesignSystem.Typography.bodySmall)
                             .foregroundStyle(.secondary)
                             .fixedSize(horizontal: false, vertical: true)
@@ -416,7 +438,7 @@ struct OnboardingFlowView: View {
                             .padding(.vertical, 3)
                             .background(Capsule().fill(DesignSystem.Colors.accent.opacity(0.12)))
 
-                        Text("Hold \(HotkeyTrigger.current.shortSymbol)")
+                        Text("Hold \(displayTrigger.shortSymbol)")
                             .font(DesignSystem.Typography.sectionTitle)
 
                         Text("Records while you hold the key.\nRelease to stop and paste.")
@@ -441,7 +463,7 @@ struct OnboardingFlowView: View {
                     .foregroundStyle(.tertiary)
             }
 
-            Text("Tip: If your keyboard doesn't send \(HotkeyTrigger.current.displayName) events, you can still use file transcription from the main app window.")
+            Text("Tip: If your keyboard doesn't send \(displayTrigger.displayName) events, you can still use file transcription from the main app window.")
                 .font(DesignSystem.Typography.caption)
                 .foregroundStyle(.secondary)
         }
@@ -455,13 +477,13 @@ struct OnboardingFlowView: View {
 
     private var doubleTapIllustration: some View {
         HStack(spacing: 4) {
-            keyCap(HotkeyTrigger.current.shortSymbol)
+            keyCap(displayTrigger.shortSymbol)
                 .scaleEffect(doubleTapPhase == 1 ? 0.9 : 1.0)
                 .opacity(reduceMotion || doubleTapPhase == 1 ? 1.0 : 0.5)
             Text("·")
                 .font(.system(size: 14, weight: .bold))
                 .foregroundStyle(.tertiary)
-            keyCap(HotkeyTrigger.current.shortSymbol)
+            keyCap(displayTrigger.shortSymbol)
                 .scaleEffect(doubleTapPhase == 2 ? 0.9 : 1.0)
                 .opacity(reduceMotion || doubleTapPhase == 2 ? 1.0 : 0.5)
         }
@@ -470,7 +492,7 @@ struct OnboardingFlowView: View {
 
     private var holdIllustration: some View {
         VStack(spacing: 6) {
-            keyCap(HotkeyTrigger.current.shortSymbol)
+            keyCap(displayTrigger.shortSymbol)
                 .scaleEffect(holdPhase > 0 ? 0.93 : 1.0)
                 .opacity(reduceMotion || holdPhase > 0 ? 1.0 : 0.5)
                 .animation(.easeInOut(duration: 0.15), value: holdPhase > 0)
@@ -650,7 +672,9 @@ struct OnboardingFlowView: View {
 
             onboardingCard {
                 VStack(alignment: .leading, spacing: 14) {
-                    quickTip(icon: "mic.fill", text: "Double-tap \(HotkeyTrigger.current.displayName) to start dictating anywhere")
+                    quickTip(icon: "mic.fill", text: HotkeyTrigger.current.isDisabled
+                        ? "Click the dictation pill or set a hotkey in Settings to start dictating"
+                        : "Double-tap \(displayTrigger.displayName) to start dictating anywhere")
                     quickTip(icon: "doc.fill", text: "Drop an audio file onto the main window to transcribe")
                     quickTip(icon: "gearshape", text: "Visit Settings to customize your experience")
                 }

--- a/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
+++ b/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
@@ -66,23 +66,7 @@ struct HotkeyRecorderView: View {
             .buttonStyle(.bordered)
 
             Menu {
-                if trigger.isDisabled {
-                    Button("Reset to Default (\(defaultTrigger.shortSymbol))") {
-                        switch combinedValidation(for: defaultTrigger) {
-                        case .blocked(let msg):
-                            validationMessage = msg
-                            validationIsBlocked = true
-                        case .warned(let msg):
-                            trigger = defaultTrigger
-                            validationMessage = msg
-                            validationIsBlocked = false
-                        case .allowed:
-                            trigger = defaultTrigger
-                            validationMessage = nil
-                            validationIsBlocked = false
-                        }
-                    }
-                } else {
+                if !trigger.isDisabled {
                     Button("Disable Hotkey") {
                         trigger = .disabled
                         validationMessage = nil
@@ -90,24 +74,14 @@ struct HotkeyRecorderView: View {
                     }
 
                     Divider()
+                }
 
-                    Button("Reset to Default (\(defaultTrigger.shortSymbol))") {
-                        switch combinedValidation(for: defaultTrigger) {
-                        case .blocked(let msg):
-                            validationMessage = msg
-                            validationIsBlocked = true
-                        case .warned(let msg):
-                            trigger = defaultTrigger
-                            validationMessage = msg
-                            validationIsBlocked = false
-                        case .allowed:
-                            trigger = defaultTrigger
-                            validationMessage = nil
-                            validationIsBlocked = false
-                        }
-                    }
-                    .disabled(trigger == defaultTrigger)
+                Button("Reset to Default (\(defaultTrigger.shortSymbol))") {
+                    resetToDefault()
+                }
+                .disabled(trigger == defaultTrigger)
 
+                if !trigger.isDisabled {
                     Divider()
 
                     Button("Record Specific Modifier Side") {
@@ -315,6 +289,22 @@ struct HotkeyRecorderView: View {
         if let monitor = eventMonitor {
             NSEvent.removeMonitor(monitor)
             eventMonitor = nil
+        }
+    }
+
+    private func resetToDefault() {
+        switch combinedValidation(for: defaultTrigger) {
+        case .blocked(let msg):
+            validationMessage = msg
+            validationIsBlocked = true
+        case .warned(let msg):
+            trigger = defaultTrigger
+            validationMessage = msg
+            validationIsBlocked = false
+        case .allowed:
+            trigger = defaultTrigger
+            validationMessage = nil
+            validationIsBlocked = false
         }
     }
 

--- a/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
+++ b/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
@@ -50,44 +50,78 @@ struct HotkeyRecorderView: View {
 
     private var normalView: some View {
         HStack(spacing: 8) {
-            Text("\(trigger.shortSymbol) \(trigger.displayName)")
-                .font(DesignSystem.Typography.body)
-                .foregroundStyle(.primary)
+            if trigger.isDisabled {
+                Text("Disabled")
+                    .font(DesignSystem.Typography.body)
+                    .foregroundStyle(.secondary)
+            } else {
+                Text("\(trigger.shortSymbol) \(trigger.displayName)")
+                    .font(DesignSystem.Typography.body)
+                    .foregroundStyle(.primary)
+            }
 
-            Button("Change...") {
+            Button(trigger.isDisabled ? "Set Hotkey..." : "Change...") {
                 startRecording(modifierCaptureMode: .generic)
             }
             .buttonStyle(.bordered)
 
             Menu {
-                Button("Reset to Default (\(defaultTrigger.shortSymbol))") {
-                    switch combinedValidation(for: defaultTrigger) {
-                    case .blocked(let msg):
-                        validationMessage = msg
-                        validationIsBlocked = true
-                    case .warned(let msg):
-                        trigger = defaultTrigger
-                        validationMessage = msg
-                        validationIsBlocked = false
-                    case .allowed:
-                        trigger = defaultTrigger
+                if trigger.isDisabled {
+                    Button("Reset to Default (\(defaultTrigger.shortSymbol))") {
+                        switch combinedValidation(for: defaultTrigger) {
+                        case .blocked(let msg):
+                            validationMessage = msg
+                            validationIsBlocked = true
+                        case .warned(let msg):
+                            trigger = defaultTrigger
+                            validationMessage = msg
+                            validationIsBlocked = false
+                        case .allowed:
+                            trigger = defaultTrigger
+                            validationMessage = nil
+                            validationIsBlocked = false
+                        }
+                    }
+                } else {
+                    Button("Disable Hotkey") {
+                        trigger = .disabled
                         validationMessage = nil
                         validationIsBlocked = false
                     }
-                }
-                .disabled(trigger == defaultTrigger)
 
-                Divider()
+                    Divider()
 
-                Button("Record Specific Modifier Side") {
-                    startRecording(modifierCaptureMode: .sideSpecific)
+                    Button("Reset to Default (\(defaultTrigger.shortSymbol))") {
+                        switch combinedValidation(for: defaultTrigger) {
+                        case .blocked(let msg):
+                            validationMessage = msg
+                            validationIsBlocked = true
+                        case .warned(let msg):
+                            trigger = defaultTrigger
+                            validationMessage = msg
+                            validationIsBlocked = false
+                        case .allowed:
+                            trigger = defaultTrigger
+                            validationMessage = nil
+                            validationIsBlocked = false
+                        }
+                    }
+                    .disabled(trigger == defaultTrigger)
+
+                    Divider()
+
+                    Button("Record Specific Modifier Side") {
+                        startRecording(modifierCaptureMode: .sideSpecific)
+                    }
                 }
             } label: {
                 Image(systemName: "ellipsis.circle")
                     .font(.system(size: 14))
             }
             .menuStyle(.borderlessButton)
-            .help("Advanced hotkey options, including resetting to default or recording a specific modifier key.")
+            .help(trigger.isDisabled
+                ? "Hotkey options, including restoring the default shortcut."
+                : "Advanced hotkey options, including resetting to default or recording a specific modifier key.")
         }
     }
 

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -255,7 +255,7 @@ struct SettingsView: View {
                             return .blocked("Already used by dictation.")
                         }
 
-                        if !viewModel.hotkeyTrigger.isDisabled, viewModel.hotkeyTrigger == viewModel.meetingHotkeyTrigger {
+                        if !viewModel.meetingHotkeyTrigger.isDisabled, viewModel.hotkeyTrigger == viewModel.meetingHotkeyTrigger {
                             hotkeyConflictText
                         }
                     }

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -183,11 +183,11 @@ struct SettingsView: View {
                     Spacer(minLength: DesignSystem.Spacing.md)
                     VStack(alignment: .trailing, spacing: 4) {
                         HotkeyRecorderView(trigger: $viewModel.hotkeyTrigger) { candidate in
-                            guard candidate == viewModel.meetingHotkeyTrigger else { return .allowed }
+                            guard !candidate.isDisabled, candidate == viewModel.meetingHotkeyTrigger else { return .allowed }
                             return .blocked("Already used by meeting recording.")
                         }
 
-                        if viewModel.hotkeyTrigger == viewModel.meetingHotkeyTrigger {
+                        if !viewModel.hotkeyTrigger.isDisabled, viewModel.hotkeyTrigger == viewModel.meetingHotkeyTrigger {
                             hotkeyConflictText
                         }
                     }
@@ -251,11 +251,11 @@ struct SettingsView: View {
                             trigger: $viewModel.meetingHotkeyTrigger,
                             defaultTrigger: .defaultMeetingRecording
                         ) { candidate in
-                            guard candidate == viewModel.hotkeyTrigger else { return .allowed }
+                            guard !candidate.isDisabled, candidate == viewModel.hotkeyTrigger else { return .allowed }
                             return .blocked("Already used by dictation.")
                         }
 
-                        if viewModel.hotkeyTrigger == viewModel.meetingHotkeyTrigger {
+                        if !viewModel.hotkeyTrigger.isDisabled, viewModel.hotkeyTrigger == viewModel.meetingHotkeyTrigger {
                             hotkeyConflictText
                         }
                     }

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -193,9 +193,11 @@ struct SettingsView: View {
                     }
                 }
 
-                Divider()
+                if !viewModel.hotkeyTrigger.isDisabled {
+                    Divider()
 
-                dictationModeGuide
+                    dictationModeGuide
+                }
 
                 Divider()
 

--- a/Sources/MacParakeetCore/STT/HotkeyTrigger.swift
+++ b/Sources/MacParakeetCore/STT/HotkeyTrigger.swift
@@ -10,6 +10,7 @@ public struct HotkeyTrigger: Sendable {
     // MARK: - Kind
 
     public enum Kind: String, Codable, Sendable {
+        case disabled
         case modifier
         case keyCode
         case chord
@@ -38,9 +39,14 @@ public struct HotkeyTrigger: Sendable {
 
     // MARK: - Computed Properties (derived at runtime)
 
+    /// Whether this trigger is disabled (no hotkey assigned).
+    public var isDisabled: Bool { kind == .disabled }
+
     /// Human-readable name for UI display (e.g., "Fn", "End", "F13", "Command+9", "Right Option").
     public var displayName: String {
         switch kind {
+        case .disabled:
+            return "Disabled"
         case .modifier:
             if let mkc = modifierKeyCode, let info = Self.modifierKeyCodeInfo[mkc],
                let base = Self.modifierDisplayNames[info.modifier] {
@@ -62,6 +68,8 @@ public struct HotkeyTrigger: Sendable {
     /// Short symbol for compact display (e.g., "fn", "⌃", "End", "F13", "⌘9", "R⌥").
     public var shortSymbol: String {
         switch kind {
+        case .disabled:
+            return "—"
         case .modifier:
             if let mkc = modifierKeyCode, let info = Self.modifierKeyCodeInfo[mkc],
                let base = Self.modifierDisplayNames[info.modifier] {
@@ -155,6 +163,10 @@ public struct HotkeyTrigger: Sendable {
         self.modifierKeyCode = modifierKeyCode
     }
 
+    // MARK: - Disabled Preset
+
+    public static let disabled = HotkeyTrigger(kind: .disabled, modifierName: nil, keyCode: nil)
+
     // MARK: - Modifier Presets
 
     public static let fn = HotkeyTrigger(kind: .modifier, modifierName: "fn", keyCode: nil)
@@ -189,6 +201,8 @@ public struct HotkeyTrigger: Sendable {
 
     public var validation: ValidationResult {
         switch kind {
+        case .disabled:
+            return .allowed
         case .modifier:
             return .allowed
         case .keyCode:

--- a/Tests/MacParakeetTests/Hotkey/HotkeyTriggerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyTriggerTests.swift
@@ -20,6 +20,52 @@ final class HotkeyTriggerTests: XCTestCase {
         super.tearDown()
     }
 
+    // MARK: - Disabled
+
+    func testDisabledKind() {
+        let trigger = HotkeyTrigger.disabled
+        XCTAssertEqual(trigger.kind, .disabled)
+        XCTAssertTrue(trigger.isDisabled)
+        XCTAssertNil(trigger.modifierName)
+        XCTAssertNil(trigger.keyCode)
+    }
+
+    func testDisabledDisplayName() {
+        XCTAssertEqual(HotkeyTrigger.disabled.displayName, "Disabled")
+    }
+
+    func testDisabledShortSymbol() {
+        XCTAssertEqual(HotkeyTrigger.disabled.shortSymbol, "—")
+    }
+
+    func testDisabledValidationIsAllowed() {
+        XCTAssertEqual(HotkeyTrigger.disabled.validation, .allowed)
+    }
+
+    func testDisabledIsNotEqualToFn() {
+        XCTAssertNotEqual(HotkeyTrigger.disabled, HotkeyTrigger.fn)
+    }
+
+    func testDisabledCodableRoundtrip() throws {
+        let data = try JSONEncoder().encode(HotkeyTrigger.disabled)
+        let decoded = try JSONDecoder().decode(HotkeyTrigger.self, from: data)
+        XCTAssertEqual(decoded, .disabled)
+        XCTAssertTrue(decoded.isDisabled)
+    }
+
+    func testDisabledPersistence() {
+        HotkeyTrigger.disabled.save(to: testDefaults)
+        let loaded = HotkeyTrigger.current(defaults: testDefaults)
+        XCTAssertEqual(loaded, .disabled)
+        XCTAssertTrue(loaded.isDisabled)
+    }
+
+    func testNonDisabledTriggersAreNotDisabled() {
+        XCTAssertFalse(HotkeyTrigger.fn.isDisabled)
+        XCTAssertFalse(HotkeyTrigger.fromKeyCode(105).isDisabled)
+        XCTAssertFalse(HotkeyTrigger.chord(modifiers: ["command"], keyCode: 25).isDisabled)
+    }
+
     // MARK: - Modifier Presets
 
     func testModifierPresetsHaveCorrectKind() {


### PR DESCRIPTION
Closes #77

## Summary

Adds the ability to **fully disable** the dictation and meeting recording hotkeys from Settings, so users who only use MacParakeet for file transcription can prevent accidental dictation activation.

This was requested by [@rmaicon](https://github.com/rmaicon), who uses MacParakeet purely for file upload + transcription and found the always-active dictation hotkey "in the way."

## How it works

A new `disabled` case is added to `HotkeyTrigger.Kind`. When a hotkey is set to disabled:

- **No CGEvent tap is created** — zero system resources consumed, zero chance of accidental dictation activation
- **The idle pill adapts** — tooltip says "Click to start dictating" (no key reference)
- **Settings adapts** — mode guide hides, recorder shows "Disabled" state with "Set Hotkey..." button
- **All UI text adapts** — overlay hints, menu bar title, history empty state, onboarding

```
┌─────────────────────────────────────────────────────────┐
│  Settings > Dictation                                   │
│                                                         │
│  Hotkey                          Disabled  Set Hotkey… ⋯│
│                                            ┌──────────┐ │
│  (mode guide hidden)                       │ Disable  │ │
│                                            │ Reset ⌫  │ │
│  Auto-stop after silence              [ON] │ Side…    │ │
│                                            └──────────┘ │
│                                  (gear menu, enabled ↑) │
└─────────────────────────────────────────────────────────┘
```

### State flow

```
                    ┌──────────┐
          Set key   │          │  "Disable Hotkey"
       ┌───────────▶│  Active  │───────────────┐
       │            │          │               │
       │            └──────────┘               ▼
       │                                ┌──────────┐
       │    "Set Hotkey..." or          │          │
       └────"Reset to Default"──────────│ Disabled │
                                        │          │
                                        └──────────┘
```

### Conflict resolution

Two disabled hotkeys don't conflict — they're both inactive:

| Dictation | Meeting | Conflict? |
|-----------|---------|-----------|
| `fn`      | `⌘⇧M`  | No        |
| `fn`      | `fn`    | **Yes** — blocked |
| Disabled  | `⌘⇧M`  | No        |
| Disabled  | Disabled| **No** — both inactive |

## Changes

### Data model (`HotkeyTrigger.swift`)
- Added `case disabled` to `Kind` enum
- Added `.disabled` static preset and `isDisabled` computed property
- `displayName` → `"Disabled"`, `shortSymbol` → `"—"`, `validation` → `.allowed`
- Codable/persistence roundtrips correctly; old versions fall back to `.fn` on unknown kind

### Settings UI (`HotkeyRecorderView.swift`, `SettingsView.swift`)
- Gear menu shows "Disable Hotkey" when active, hides it when already disabled
- Disabled state: shows greyed "Disabled" label + "Set Hotkey..." button
- "Reset to Default" always available for quick re-enable
- Extracted `resetToDefault()` helper to eliminate duplicated validation logic
- Dictation mode guide (double-tap / hold) hides when hotkey is disabled
- Conflict validation skips disabled hotkeys (both directions)
- Meeting section conflict text now checks the meeting trigger (not dictation) for semantic clarity

### App lifecycle (`AppDelegate.swift`)
- `setupHotkey()` — early return when disabled, no CGEvent tap created
- `setupMeetingHotkey()` — same guard, checked before conflict check
- Menu bar title shows "Hotkey: Disabled" instead of key name

### Event handling (`HotkeyManager.swift`, `GlobalShortcutManager.swift`)
- Exhaustive switch handles `.disabled` by passing events through (defensive — these managers are never created when disabled, but the compiler requires exhaustive matching)

### UI surfaces
- **Idle pill** (`IdlePillView.swift`) — tooltip: "Click to start dictating" (no key reference)
- **Overlay** (`DictationOverlayView.swift`) — "Not Recording" error: "Click the dictation pill to start recording"
- **Overlay controller** (`DictationOverlayController.swift`) — stop tooltip drops key hint
- **History** (`DictationHistoryView.swift`) — empty state: "Click the dictation pill or set a hotkey in Settings"
- **Onboarding** (`OnboardingFlowView.swift`) — all hotkey references fall back to default Fn symbol when disabled; hotkey step shows info banner explaining the state; done step switches to pill-based guidance

### Tests (`HotkeyTriggerTests.swift`)
8 new tests covering: kind, display name, short symbol, validation, equality, Codable roundtrip, persistence, and non-disabled verification.

## Test plan

- [x] `swift test` — 1319 tests pass (1306 XCTest + 13 Swift Testing), 0 failures
- [ ] Manual: Settings > Dictation > gear menu > "Disable Hotkey" — verify mode guide hides, label shows "Disabled"
- [ ] Manual: With hotkey disabled, verify dictation does not activate on any key press
- [ ] Manual: "Set Hotkey..." or "Reset to Default" re-enables — verify mode guide reappears
- [ ] Manual: Disable both dictation and meeting hotkeys — verify no conflict error shown
- [ ] Manual: Idle pill tooltip shows "Click to start dictating" when hotkey disabled
- [ ] Manual: History empty state shows pill-based hint when hotkey disabled
- [ ] Manual: Menu bar shows "Hotkey: Disabled"
- [ ] Manual: Re-open onboarding with disabled hotkey — verify info banner and Fn fallback text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now disable hotkeys in Settings as an alternative to deletion
  * Redesigned meetings view with search functionality, delete confirmation, and context menu actions for each recording
  
* **Documentation**
  * Updated repository metrics reflecting expanded codebase and test coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->