### PR TITLE
Refactor app-shell hotkeys and transcript result side effects

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -31,6 +31,7 @@ final class AppEnvironment {
     let llmClient: RoutingLLMClient
     let llmConfigStore: LLMConfigStore
     let llmService: LLMService
+    let runtimePreferences: AppRuntimePreferencesProtocol
 
     init() throws {
         // Ensure required runtime directories exist (db, dictations, temp).
@@ -63,6 +64,8 @@ final class AppEnvironment {
         permissionService = PermissionService()
         accessibilityService = AccessibilityService()
         launchAtLoginService = LaunchAtLoginService()
+        let runtimePreferences = UserDefaultsAppRuntimePreferences()
+        self.runtimePreferences = runtimePreferences
 
         // Licensing / entitlements (basic guards: 7-day trial + license unlock).
         //
@@ -96,33 +99,23 @@ final class AppEnvironment {
             api: LemonSqueezyLicenseAPI()
         )
 
-        let processingModeClosure: @Sendable () -> Dictation.ProcessingMode = {
-            let raw = UserDefaults.standard.string(forKey: "processingMode")
-            return Dictation.ProcessingMode(rawValue: raw ?? Dictation.ProcessingMode.raw.rawValue) ?? .raw
+        let processingModeClosure: @Sendable () -> Dictation.ProcessingMode = { [runtimePreferences] in
+            runtimePreferences.processingMode
         }
 
         youtubeDownloader = YouTubeDownloader()
         diarizationService = DiarizationService()
 
-        let voiceReturnTriggerClosure: @Sendable () -> String? = {
-            let defaults = UserDefaults.standard
-            guard defaults.bool(forKey: "voiceReturnEnabled") else { return nil }
-            let trigger = (defaults.string(forKey: "voiceReturnTrigger") ?? "press return")
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            return trigger.isEmpty ? nil : trigger
+        let voiceReturnTriggerClosure: @Sendable () -> String? = { [runtimePreferences] in
+            runtimePreferences.voiceReturnTrigger
         }
 
         dictationService = DictationService(
             audioProcessor: audioProcessor,
             sttTranscriber: sttScheduler,
             dictationRepo: dictationRepo,
-            shouldSaveAudio: {
-                // Defaults to true if unset (matches Settings UI default).
-                UserDefaults.standard.object(forKey: "saveAudioRecordings") as? Bool ?? true
-            },
-            shouldSaveDictationHistory: {
-                UserDefaults.standard.object(forKey: "saveDictationHistory") as? Bool ?? true
-            },
+            shouldSaveAudio: { [runtimePreferences] in runtimePreferences.shouldSaveAudioRecordings },
+            shouldSaveDictationHistory: { [runtimePreferences] in runtimePreferences.shouldSaveDictationHistory },
             entitlements: entitlementsService,
             customWordRepo: customWordRepo,
             snippetRepo: snippetRepo,
@@ -153,13 +146,8 @@ final class AppEnvironment {
             customWordRepo: customWordRepo,
             snippetRepo: snippetRepo,
             processingMode: processingModeClosure,
-            shouldKeepDownloadedAudio: {
-                // Defaults to true if unset (matches Settings UI default).
-                UserDefaults.standard.object(forKey: "saveTranscriptionAudio") as? Bool ?? true
-            },
-            shouldDiarize: {
-                UserDefaults.standard.object(forKey: "speakerDiarization") as? Bool ?? true
-            },
+            shouldKeepDownloadedAudio: { [runtimePreferences] in runtimePreferences.shouldSaveTranscriptionAudio },
+            shouldDiarize: { [runtimePreferences] in runtimePreferences.shouldDiarize },
             youtubeDownloader: youtubeDownloader,
             diarizationService: diarizationService
         )

--- a/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
+++ b/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
@@ -46,7 +46,10 @@ final class AppHotkeyCoordinator {
     }
 
     var hotkeyMenuTitle: String {
-        let trigger = HotkeyTrigger.current
+        Self.menuTitle(for: HotkeyTrigger.current)
+    }
+
+    static func menuTitle(for trigger: HotkeyTrigger) -> String {
         if trigger.isDisabled {
             return "Hotkey: Disabled"
         }

--- a/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
+++ b/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
@@ -1,0 +1,167 @@
+import AppKit
+import MacParakeetCore
+import MacParakeetViewModels
+
+@MainActor
+final class AppHotkeyCoordinator {
+    private let settingsViewModel: SettingsViewModel
+    private let onStartDictation: (FnKeyStateMachine.RecordingMode) -> Void
+    private let onStopDictation: () -> Void
+    private let onCancelDictation: () -> Void
+    private let onDiscardRecording: (Bool) -> Void
+    private let onReadyForSecondTap: () -> Void
+    private let onEscapeWhileIdle: () -> Void
+    private let onToggleMeetingRecording: () -> Void
+    private let onPrimaryHotkeyManagerChanged: (HotkeyManager?) -> Void
+    private let onAnyHotkeyEnabled: () -> Void
+    private let onHotkeyUnavailable: () -> Void
+
+    private var hotkeyManager: HotkeyManager?
+    private var meetingHotkeyManager: GlobalShortcutManager?
+
+    init(
+        settingsViewModel: SettingsViewModel,
+        onStartDictation: @escaping (FnKeyStateMachine.RecordingMode) -> Void,
+        onStopDictation: @escaping () -> Void,
+        onCancelDictation: @escaping () -> Void,
+        onDiscardRecording: @escaping (Bool) -> Void,
+        onReadyForSecondTap: @escaping () -> Void,
+        onEscapeWhileIdle: @escaping () -> Void,
+        onToggleMeetingRecording: @escaping () -> Void,
+        onPrimaryHotkeyManagerChanged: @escaping (HotkeyManager?) -> Void,
+        onAnyHotkeyEnabled: @escaping () -> Void,
+        onHotkeyUnavailable: @escaping () -> Void
+    ) {
+        self.settingsViewModel = settingsViewModel
+        self.onStartDictation = onStartDictation
+        self.onStopDictation = onStopDictation
+        self.onCancelDictation = onCancelDictation
+        self.onDiscardRecording = onDiscardRecording
+        self.onReadyForSecondTap = onReadyForSecondTap
+        self.onEscapeWhileIdle = onEscapeWhileIdle
+        self.onToggleMeetingRecording = onToggleMeetingRecording
+        self.onPrimaryHotkeyManagerChanged = onPrimaryHotkeyManagerChanged
+        self.onAnyHotkeyEnabled = onAnyHotkeyEnabled
+        self.onHotkeyUnavailable = onHotkeyUnavailable
+    }
+
+    var hotkeyMenuTitle: String {
+        let trigger = HotkeyTrigger.current
+        if trigger.isDisabled {
+            return "Hotkey: Disabled"
+        }
+        return "Hotkey: \(trigger.displayName) (double-tap / hold)"
+    }
+
+    func setupPrimaryHotkey() {
+        let trigger = HotkeyTrigger.current
+        guard !trigger.isDisabled else {
+            hotkeyManager = nil
+            onPrimaryHotkeyManagerChanged(nil)
+            return
+        }
+
+        let manager = HotkeyManager(trigger: trigger)
+        manager.onStartRecording = { [weak self] mode in
+            self?.onStartDictation(mode)
+        }
+        manager.onStopRecording = { [weak self] in
+            self?.onStopDictation()
+        }
+        manager.onCancelRecording = { [weak self] in
+            self?.onCancelDictation()
+        }
+        manager.onDiscardRecording = { [weak self] showReadyPill in
+            self?.onDiscardRecording(showReadyPill)
+        }
+        manager.onReadyForSecondTap = { [weak self] in
+            self?.onReadyForSecondTap()
+        }
+        manager.onEscapeWhileIdle = { [weak self] in
+            self?.onEscapeWhileIdle()
+        }
+
+        if manager.start() {
+            hotkeyManager = manager
+            onPrimaryHotkeyManagerChanged(manager)
+            onAnyHotkeyEnabled()
+        } else {
+            hotkeyManager = nil
+            onPrimaryHotkeyManagerChanged(nil)
+            onHotkeyUnavailable()
+        }
+    }
+
+    func setupMeetingHotkey() {
+        let trigger = settingsViewModel.meetingHotkeyTrigger
+        guard !trigger.isDisabled else {
+            meetingHotkeyManager = nil
+            return
+        }
+        guard trigger != settingsViewModel.hotkeyTrigger else {
+            meetingHotkeyManager = nil
+            return
+        }
+
+        let manager = GlobalShortcutManager(trigger: trigger)
+        manager.onTrigger = { [weak self] in
+            Task { @MainActor in
+                self?.onToggleMeetingRecording()
+            }
+        }
+
+        if manager.start() {
+            meetingHotkeyManager = manager
+            onAnyHotkeyEnabled()
+        } else {
+            meetingHotkeyManager = nil
+            onHotkeyUnavailable()
+        }
+    }
+
+    func refreshAllHotkeys() {
+        hotkeyManager?.stop()
+        meetingHotkeyManager?.stop()
+        hotkeyManager = nil
+        meetingHotkeyManager = nil
+        onPrimaryHotkeyManagerChanged(nil)
+        setupPrimaryHotkey()
+        setupMeetingHotkey()
+    }
+
+    func refreshMeetingHotkey() {
+        meetingHotkeyManager?.stop()
+        meetingHotkeyManager = nil
+        setupMeetingHotkey()
+    }
+
+    func applyMeetingHotkey(to item: NSMenuItem) {
+        let trigger = settingsViewModel.meetingHotkeyTrigger
+        guard trigger.kind == .chord, let code = trigger.keyCode else {
+            item.keyEquivalent = ""
+            item.keyEquivalentModifierMask = []
+            return
+        }
+        let keyName = KeyCodeNames.name(for: code).shortSymbol
+        item.keyEquivalent = keyName.lowercased()
+        var mask: NSEvent.ModifierFlags = []
+        for modifier in trigger.chordModifiers ?? [] {
+            switch modifier {
+            case "command": mask.insert(.command)
+            case "shift": mask.insert(.shift)
+            case "control": mask.insert(.control)
+            case "option": mask.insert(.option)
+            default: break
+            }
+        }
+        item.keyEquivalentModifierMask = mask
+    }
+
+    func stopAll() {
+        hotkeyManager?.stop()
+        meetingHotkeyManager?.stop()
+        hotkeyManager = nil
+        meetingHotkeyManager = nil
+        onPrimaryHotkeyManagerChanged(nil)
+    }
+}

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -657,13 +657,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     }
 
     private var hotkeyMenuTitle: String {
-        hotkeyCoordinator?.hotkeyMenuTitle ?? {
-            let trigger = HotkeyTrigger.current
-            if trigger.isDisabled {
-                return "Hotkey: Disabled"
-            }
-            return "Hotkey: \(trigger.displayName) (double-tap / hold)"
-        }()
+        hotkeyCoordinator?.hotkeyMenuTitle
+            ?? AppHotkeyCoordinator.menuTitle(for: HotkeyTrigger.current)
     }
 
     /// Configures an NSMenuItem with the meeting hotkey shortcut.

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -370,7 +370,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 transcriptionService: env.transcriptionService,
                 transcriptionRepo: env.transcriptionRepo,
                 llmService: hasLLMConfig ? env.llmService : nil,
-                configStore: env.llmConfigStore,
                 promptResultRepo: env.promptResultRepo,
                 promptResultsViewModel: promptResultsViewModel
             )

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -34,8 +34,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     // MARK: - Services
 
     private var appEnvironment: AppEnvironment?
-    private var hotkeyManager: HotkeyManager?
-    private var meetingHotkeyManager: GlobalShortcutManager?
+    private var hotkeyCoordinator: AppHotkeyCoordinator?
     private var dictationFlowCoordinator: DictationFlowCoordinator?
     private var meetingRecordingFlowCoordinator: MeetingRecordingFlowCoordinator?
 
@@ -100,8 +99,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // NSApplicationWillTerminateNotification observer — calling it here too
         // would send duplicate appQuit events and double the termination delay.
         dictationFlowCoordinator?.hideIdlePill()
-        hotkeyManager?.stop()
-        meetingHotkeyManager?.stop()
+        hotkeyCoordinator?.stopAll()
         if let onboardingObserver { NotificationCenter.default.removeObserver(onboardingObserver) }
         if let settingsObserver { NotificationCenter.default.removeObserver(settingsObserver) }
         if let hotkeyTriggerObserver { NotificationCenter.default.removeObserver(hotkeyTriggerObserver) }
@@ -489,6 +487,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 }
             )
             meetingRecordingFlowCoordinator = meetingCoordinator
+            configureHotkeyCoordinatorIfNeeded()
 
             maybeShowOnboarding()
         } catch {
@@ -523,87 +522,55 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         promptResultsViewModel.updateLLMService(service)
     }
 
+    private func configureHotkeyCoordinatorIfNeeded() {
+        guard hotkeyCoordinator == nil else { return }
+        hotkeyCoordinator = AppHotkeyCoordinator(
+            settingsViewModel: settingsViewModel,
+            onStartDictation: { [weak self] mode in
+                self?.dictationFlowCoordinator?.startDictation(mode: mode, trigger: .hotkey)
+            },
+            onStopDictation: { [weak self] in
+                self?.dictationFlowCoordinator?.stopDictation()
+            },
+            onCancelDictation: { [weak self] in
+                self?.dictationFlowCoordinator?.cancelDictation(reason: .escape)
+            },
+            onDiscardRecording: { [weak self] showReadyPill in
+                self?.dictationFlowCoordinator?.discardProvisionalRecording(showReadyPill: showReadyPill)
+            },
+            onReadyForSecondTap: { [weak self] in
+                self?.dictationFlowCoordinator?.showReadyPill()
+            },
+            onEscapeWhileIdle: { [weak self] in
+                self?.dictationFlowCoordinator?.dismissOverlayIfError()
+            },
+            onToggleMeetingRecording: { [weak self] in
+                self?.toggleMeetingRecording(originatesFromWindow: false)
+            },
+            onPrimaryHotkeyManagerChanged: { [weak self] manager in
+                self?.dictationFlowCoordinator?.hotkeyManager = manager
+            },
+            onAnyHotkeyEnabled: { [weak self] in
+                self?.hasPresentedHotkeyUnavailableAlert = false
+            },
+            onHotkeyUnavailable: { [weak self] in
+                self?.presentHotkeyUnavailableAlertIfNeeded()
+            }
+        )
+    }
+
     // MARK: - Hotkey
 
     private func setupHotkey() {
-        let trigger = HotkeyTrigger.current
-        guard !trigger.isDisabled else {
-            hotkeyManager = nil
-            dictationFlowCoordinator?.hotkeyManager = nil
-            return
-        }
-
-        let manager = HotkeyManager(trigger: trigger)
-
-        manager.onStartRecording = { [weak self] mode in
-            self?.dictationFlowCoordinator?.startDictation(mode: mode, trigger: .hotkey)
-        }
-
-        manager.onStopRecording = { [weak self] in
-            self?.dictationFlowCoordinator?.stopDictation()
-        }
-
-        manager.onCancelRecording = { [weak self] in
-            self?.dictationFlowCoordinator?.cancelDictation(reason: .escape)
-        }
-
-        manager.onDiscardRecording = { [weak self] showReadyPill in
-            self?.dictationFlowCoordinator?.discardProvisionalRecording(showReadyPill: showReadyPill)
-        }
-
-        manager.onReadyForSecondTap = { [weak self] in
-            self?.dictationFlowCoordinator?.showReadyPill()
-        }
-
-        manager.onEscapeWhileIdle = { [weak self] in
-            self?.dictationFlowCoordinator?.dismissOverlayIfError()
-        }
-
-        if manager.start() {
-            hotkeyManager = manager
-            dictationFlowCoordinator?.hotkeyManager = manager
-            hasPresentedHotkeyUnavailableAlert = false
-        } else {
-            hotkeyManager = nil
-            dictationFlowCoordinator?.hotkeyManager = nil
-            presentHotkeyUnavailableAlertIfNeeded()
-        }
+        hotkeyCoordinator?.setupPrimaryHotkey()
     }
 
     private func setupMeetingHotkey() {
-        let trigger = settingsViewModel.meetingHotkeyTrigger
-        guard !trigger.isDisabled else {
-            meetingHotkeyManager = nil
-            return
-        }
-        guard trigger != settingsViewModel.hotkeyTrigger else {
-            meetingHotkeyManager = nil
-            return
-        }
-
-        let manager = GlobalShortcutManager(trigger: trigger)
-        manager.onTrigger = { [weak self] in
-            Task { @MainActor in
-                self?.toggleMeetingRecording(originatesFromWindow: false)
-            }
-        }
-
-        if manager.start() {
-            meetingHotkeyManager = manager
-            hasPresentedHotkeyUnavailableAlert = false
-        } else {
-            meetingHotkeyManager = nil
-            presentHotkeyUnavailableAlertIfNeeded()
-        }
+        hotkeyCoordinator?.setupMeetingHotkey()
     }
 
     private func refreshHotkeyAfterPermissions() {
-        hotkeyManager?.stop()
-        meetingHotkeyManager?.stop()
-        hotkeyManager = nil
-        meetingHotkeyManager = nil
-        setupHotkey()
-        setupMeetingHotkey()
+        hotkeyCoordinator?.refreshAllHotkeys()
     }
 
     private func observeOpenOnboarding() {
@@ -625,12 +592,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor in
-                self?.hotkeyManager?.stop()
-                self?.hotkeyManager = nil
-                self?.meetingHotkeyManager?.stop()
-                self?.meetingHotkeyManager = nil
-                self?.setupHotkey()
-                self?.setupMeetingHotkey()
+                self?.hotkeyCoordinator?.refreshAllHotkeys()
                 self?.hotkeyMenuItem?.title = self?.hotkeyMenuTitle ?? ""
             }
         }
@@ -643,9 +605,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor in
-                self?.meetingHotkeyManager?.stop()
-                self?.meetingHotkeyManager = nil
-                self?.setupMeetingHotkey()
+                self?.hotkeyCoordinator?.refreshMeetingHotkey()
                 if let item = self?.recordMeetingMenuItem {
                     self?.applyMeetingHotkeyToMenuItem(item)
                 }
@@ -697,17 +657,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     }
 
     private var hotkeyMenuTitle: String {
-        let trigger = HotkeyTrigger.current
-        if trigger.isDisabled {
-            return "Hotkey: Disabled"
-        }
-        return "Hotkey: \(trigger.displayName) (double-tap / hold)"
+        hotkeyCoordinator?.hotkeyMenuTitle ?? {
+            let trigger = HotkeyTrigger.current
+            if trigger.isDisabled {
+                return "Hotkey: Disabled"
+            }
+            return "Hotkey: \(trigger.displayName) (double-tap / hold)"
+        }()
     }
 
     /// Configures an NSMenuItem with the meeting hotkey shortcut.
     /// Chord triggers (e.g. ⌘⇧M) render as native macOS shortcut hints.
     /// Non-chord triggers cannot be represented natively and are left without a shortcut indicator.
     private func applyMeetingHotkeyToMenuItem(_ item: NSMenuItem) {
+        if let hotkeyCoordinator {
+            hotkeyCoordinator.applyMeetingHotkey(to: item)
+            return
+        }
         let trigger = settingsViewModel.meetingHotkeyTrigger
         guard trigger.kind == .chord, let code = trigger.keyCode else {
             item.keyEquivalent = ""

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
@@ -1,0 +1,82 @@
+import AppKit
+import Foundation
+import MacParakeetCore
+
+enum TranscriptExportFormat: String {
+    case txt, md, srt, vtt, docx, pdf, json
+}
+
+@MainActor
+enum TranscriptResultActions {
+    static func copyText(_ text: String, source: TelemetryCopySource = .transcription) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+        Telemetry.send(.copyToClipboard(source: source))
+    }
+
+    static func exportPromptResultToDownloads(
+        promptResult: PromptResult,
+        source: Transcription,
+        format: TranscriptExportFormat
+    ) throws -> URL {
+        let baseStem = TranscriptSegmenter.sanitizedExportStem(from: source.fileName)
+        let promptNameSafe = promptResult.promptName
+            .lowercased()
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+            .joined(separator: "-")
+        let promptComponent = promptNameSafe.isEmpty ? "result" : promptNameSafe
+        let stem = "\(baseStem)-\(promptComponent)"
+
+        let downloadsURL = try downloadsDirectory()
+        let fileURL = nextAvailableURL(in: downloadsURL, stem: stem, format: format)
+
+        try promptResult.content.write(to: fileURL, atomically: true, encoding: .utf8)
+        Telemetry.send(.exportUsed(format: format.rawValue))
+        return fileURL
+    }
+
+    static func exportTranscriptToDownloads(
+        transcription: Transcription,
+        format: TranscriptExportFormat
+    ) throws -> URL {
+        let stem = TranscriptSegmenter.sanitizedExportStem(from: transcription.fileName)
+        let downloadsURL = try downloadsDirectory()
+        let fileURL = nextAvailableURL(in: downloadsURL, stem: stem, format: format)
+        let exportService = ExportService()
+
+        switch format {
+        case .txt: try exportService.exportToTxt(transcription: transcription, url: fileURL)
+        case .md: try exportService.exportToMarkdown(transcription: transcription, url: fileURL)
+        case .srt: try exportService.exportToSRT(transcription: transcription, url: fileURL)
+        case .vtt: try exportService.exportToVTT(transcription: transcription, url: fileURL)
+        case .docx: try exportService.exportToDocx(transcription: transcription, url: fileURL)
+        case .pdf: try exportService.exportToPDF(transcription: transcription, url: fileURL)
+        case .json: try exportService.exportToJSON(transcription: transcription, url: fileURL)
+        }
+
+        Telemetry.send(.exportUsed(format: format.rawValue))
+        return fileURL
+    }
+
+    private static func downloadsDirectory() throws -> URL {
+        guard let url = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first else {
+            throw CocoaError(.fileNoSuchFile)
+        }
+        return url
+    }
+
+    private static func nextAvailableURL(
+        in directory: URL,
+        stem: String,
+        format: TranscriptExportFormat
+    ) -> URL {
+        var url = directory.appendingPathComponent("\(stem).\(format.rawValue)")
+        var counter = 1
+        while FileManager.default.fileExists(atPath: url.path) {
+            url = directory.appendingPathComponent("\(stem) (\(counter)).\(format.rawValue)")
+            counter += 1
+        }
+        return url
+    }
+}

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -50,6 +50,7 @@ struct TranscriptResultView: View {
     @State private var cachedTurns: [SpeakerTurn] = []
     @State private var cachedHasSpeakers: Bool = false
     @State private var cachedSpeakerColorMap: [String: Color] = [:]
+    @State private var cachedSpeakerLabelMap: [String: String] = [:]
     @State private var cachedSegmentStartMs: [Int] = []  // sorted, for binary search
     @State private var autoScrollPaused = false
     @State private var scrollPauseTask: Task<Void, Never>?
@@ -1727,7 +1728,7 @@ struct TranscriptResultView: View {
             // Speaker-aware layout: use cached turns
             ForEach(Array(cachedTurns.enumerated()), id: \.element.segments.first?.startMs) { _, turn in
                 transcriptTurnCard(
-                    speakerLabel: speakerLabel(for: turn.speakerId),
+                    speakerLabel: cachedSpeakerLabelMap[turn.speakerId] ?? "Unknown",
                     speakerColor: cachedSpeakerColorMap[turn.speakerId] ?? DesignSystem.Colors.textTertiary,
                     segments: turn.segments.map { ($0.startMs, $0.text) }
                 )
@@ -1985,6 +1986,7 @@ struct TranscriptResultView: View {
             cachedTurns = []
             cachedHasSpeakers = false
             cachedSpeakerColorMap = [:]
+            cachedSpeakerLabelMap = [:]
             cachedSegmentStartMs = []
             return
         }
@@ -1995,10 +1997,17 @@ struct TranscriptResultView: View {
         cachedSegments = segments
         cachedHasSpeakers = hasSpeakers
         cachedSpeakerColorMap = buildSpeakerColorMap()
+        cachedSpeakerLabelMap = buildSpeakerLabelMap()
         cachedSegmentStartMs = segments.map(\.startMs)
 
         if hasSpeakers {
-            cachedTurns = TranscriptSegmenter.groupIntoSpeakerTurns(segments: segments, speakerLabelProvider: speakerLabel(for:))
+            cachedTurns = TranscriptSegmenter.groupIntoSpeakerTurns(
+                segments: segments,
+                speakerLabelProvider: { speakerID in
+                    guard let speakerID else { return "Unknown" }
+                    return cachedSpeakerLabelMap[speakerID] ?? "Unknown"
+                }
+            )
         } else {
             cachedTurns = []
         }
@@ -2065,13 +2074,13 @@ struct TranscriptResultView: View {
         return map
     }
 
-    private func speakerLabel(for speakerId: String?) -> String {
-        guard let id = speakerId,
-              let speakers = transcription.speakers,
-              let info = speakers.first(where: { $0.id == id }) else {
-            return "Unknown"
+    private func buildSpeakerLabelMap() -> [String: String] {
+        guard let speakers = transcription.speakers else { return [:] }
+        var map: [String: String] = [:]
+        for speaker in speakers {
+            map[speaker.id] = speaker.label
         }
-        return info.label
+        return map
     }
 
 

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -400,7 +400,7 @@ struct TranscriptResultView: View {
                         onRetranscribe(transcription)
                     }
                 } message: {
-                    Text("All custom tabs, results, and chats generated from the current transcript will be removed and cannot be recovered.")
+                    Text("This replaces the transcript text in place. Existing prompt results and chats are preserved, but may no longer match the updated transcript.")
                 }
             }
 
@@ -901,9 +901,7 @@ struct TranscriptResultView: View {
             if case .result(let id) = tab,
                let promptResult = promptResultsViewModel.promptResults.first(where: { $0.id == id }) {
                 Button("Copy Result") {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(promptResult.content, forType: .string)
-                    Telemetry.send(.copyToClipboard(source: .transcription))
+                    TranscriptResultActions.copyText(promptResult.content)
                     copiedResultID = id
                     resultCopiedResetTask?.cancel()
                     resultCopiedResetTask = Task {
@@ -911,12 +909,12 @@ struct TranscriptResultView: View {
                         copiedResultID = nil
                     }
                 }
-                
+
                 Menu("Export Document") {
                     Button("Markdown (.md)") { exportGenerationToDownloads(promptResult: promptResult, format: .md) }
                     Button("Plain Text (.txt)") { exportGenerationToDownloads(promptResult: promptResult, format: .txt) }
                 }
-                
+
                 Button("Delete Result", role: .destructive) {
                     promptResultsViewModel.pendingDeletePromptResult = promptResult
                 }
@@ -1027,9 +1025,7 @@ struct TranscriptResultView: View {
 
                         let isCopied = copiedButtonResultID == promptResultID
                         Button {
-                            NSPasteboard.general.clearContents()
-                            NSPasteboard.general.setString(promptResult.content, forType: .string)
-                            Telemetry.send(.copyToClipboard(source: .transcription))
+                            TranscriptResultActions.copyText(promptResult.content)
                             copiedButtonResultID = promptResultID
                             resultButtonCopiedResetTask?.cancel()
                             resultButtonCopiedResetTask = Task {
@@ -1589,8 +1585,7 @@ struct TranscriptResultView: View {
                         if !isUser && !message.isStreaming && !message.content.isEmpty {
                             if hoveredMessageId == message.id || copiedMessageId == message.id {
                                 Button {
-                                    NSPasteboard.general.clearContents()
-                                    NSPasteboard.general.setString(message.content, forType: .string)
+                                    TranscriptResultActions.copyText(message.content)
                                     copiedMessageId = message.id
                                     copiedResetTask?.cancel()
                                     copiedResetTask = Task {
@@ -1732,7 +1727,7 @@ struct TranscriptResultView: View {
             // Speaker-aware layout: use cached turns
             ForEach(Array(cachedTurns.enumerated()), id: \.element.segments.first?.startMs) { _, turn in
                 transcriptTurnCard(
-                    speakerLabel: turn.speakerLabel,
+                    speakerLabel: speakerLabel(for: turn.speakerId),
                     speakerColor: cachedSpeakerColorMap[turn.speakerId] ?? DesignSystem.Colors.textTertiary,
                     segments: turn.segments.map { ($0.startMs, $0.text) }
                 )
@@ -2084,9 +2079,7 @@ struct TranscriptResultView: View {
 
     private func copyToClipboard() {
         let text = transcription.cleanTranscript ?? transcription.rawTranscript ?? ""
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(text, forType: .string)
-        Telemetry.send(.copyToClipboard(source: .transcription))
+        TranscriptResultActions.copyText(text)
         copiedResetTask?.cancel()
         withAnimation(DesignSystem.Animation.hoverTransition) { copied = true }
         copiedResetTask = Task { @MainActor in
@@ -2099,10 +2092,6 @@ struct TranscriptResultView: View {
     private var hasTimestamps: Bool {
         guard let words = transcription.wordTimestamps else { return false }
         return !words.isEmpty
-    }
-
-    private enum ExportFormat: String {
-        case txt, md, srt, vtt, docx, pdf, json
     }
 
     // MARK: - Export Confirmation Popover
@@ -2155,106 +2144,55 @@ struct TranscriptResultView: View {
         .frame(minWidth: 220)
     }
 
-    private func exportGenerationToDownloads(promptResult: PromptResult, format: ExportFormat) {
+    private func exportGenerationToDownloads(promptResult: PromptResult, format: TranscriptExportFormat) {
         let source = viewModel.currentTranscription ?? transcription
-        let baseStem = TranscriptSegmenter.sanitizedExportStem(from: source.fileName)
-        
-        let promptNameSafe = promptResult.promptName
-            .lowercased()
-            .components(separatedBy: CharacterSet.alphanumerics.inverted)
-            .filter { !$0.isEmpty }
-            .joined(separator: "-")
-            
-        let stem = "\(baseStem)-\(promptNameSafe)"
-        
-        guard let downloadsURL = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first else {
+        do {
+            let fileURL = try TranscriptResultActions.exportPromptResultToDownloads(
+                promptResult: promptResult,
+                source: source,
+                format: format
+            )
+            exportErrorMessage = nil
+            SoundManager.shared.play(.transcriptionComplete)
+            dismissTask?.cancel()
+            exportConfirmation = ExportConfirmation(url: fileURL, format: format.rawValue)
+            dismissTask = Task { @MainActor in
+                try? await Task.sleep(for: .seconds(5.0))
+                guard !Task.isCancelled else { return }
+                exportConfirmation = nil
+            }
+        } catch let cocoaError as CocoaError where cocoaError.code == .fileNoSuchFile {
             exportErrorMessage = "Your Downloads folder could not be found."
             SoundManager.shared.play(.errorSoft)
-            return
-        }
-        
-        var fileURL = downloadsURL.appendingPathComponent("\(stem).\(format.rawValue)")
-
-        // Avoid overwriting
-        var counter = 1
-        while FileManager.default.fileExists(atPath: fileURL.path) {
-            fileURL = downloadsURL.appendingPathComponent("\(stem) (\(counter)).\(format.rawValue)")
-            counter += 1
-        }
-
-        do {
-            try promptResult.content.write(to: fileURL, atomically: true, encoding: .utf8)
-            Telemetry.send(.exportUsed(format: format.rawValue))
         } catch {
             exportErrorMessage = error.localizedDescription
             SoundManager.shared.play(.errorSoft)
-            return
-        }
-
-        exportErrorMessage = nil
-        SoundManager.shared.play(.transcriptionComplete)
-
-        dismissTask?.cancel()
-        exportConfirmation = ExportConfirmation(url: fileURL, format: format.rawValue)
-
-        dismissTask = Task { @MainActor in
-            try? await Task.sleep(for: .seconds(5.0))
-            guard !Task.isCancelled else { return }
-            exportConfirmation = nil
         }
     }
 
-    private func exportToDownloads(format: ExportFormat) {
+    private func exportToDownloads(format: TranscriptExportFormat) {
         // Use the ViewModel's copy which reflects any in-flight renames
         let source = viewModel.currentTranscription ?? transcription
-        let stem = TranscriptSegmenter.sanitizedExportStem(from: source.fileName)
-        guard let downloadsURL = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first else {
+        do {
+            let fileURL = try TranscriptResultActions.exportTranscriptToDownloads(
+                transcription: source,
+                format: format
+            )
+            exportErrorMessage = nil
+            SoundManager.shared.play(.transcriptionComplete)
+            dismissTask?.cancel()
+            exportConfirmation = ExportConfirmation(url: fileURL, format: format.rawValue)
+            dismissTask = Task { @MainActor in
+                try? await Task.sleep(for: .seconds(5.0))
+                guard !Task.isCancelled else { return }
+                exportConfirmation = nil
+            }
+        } catch let cocoaError as CocoaError where cocoaError.code == .fileNoSuchFile {
             exportErrorMessage = "Your Downloads folder could not be found."
             SoundManager.shared.play(.errorSoft)
-            return
-        }
-        var fileURL = downloadsURL.appendingPathComponent("\(stem).\(format.rawValue)")
-
-        // Avoid overwriting — append (1), (2), etc.
-        var counter = 1
-        while FileManager.default.fileExists(atPath: fileURL.path) {
-            fileURL = downloadsURL.appendingPathComponent("\(stem) (\(counter)).\(format.rawValue)")
-            counter += 1
-        }
-
-        let exportService = ExportService()
-        do {
-            switch format {
-            case .txt: try exportService.exportToTxt(transcription: source, url: fileURL)
-            case .md: try exportService.exportToMarkdown(transcription: source, url: fileURL)
-            case .srt: try exportService.exportToSRT(transcription: source, url: fileURL)
-            case .vtt: try exportService.exportToVTT(transcription: source, url: fileURL)
-            case .docx: try exportService.exportToDocx(transcription: source, url: fileURL)
-            case .pdf: try exportService.exportToPDF(transcription: source, url: fileURL)
-            case .json: try exportService.exportToJSON(transcription: source, url: fileURL)
-            }
-            Telemetry.send(.exportUsed(format: format.rawValue))
         } catch {
             exportErrorMessage = error.localizedDescription
             SoundManager.shared.play(.errorSoft)
-            return
-        }
-
-        exportErrorMessage = nil
-        SoundManager.shared.play(.transcriptionComplete)
-
-        // Cancel any pending auto-dismiss from a previous export
-        dismissTask?.cancel()
-
-        // Single atomic state drives the popover via .popover(item:),
-        // so presentation and data are never out of sync.
-        exportConfirmation = ExportConfirmation(url: fileURL, format: format.rawValue)
-
-        // Auto-dismiss after 5 seconds
-        dismissTask = Task { @MainActor in
-            try? await Task.sleep(for: .seconds(5.0))
-            guard !Task.isCancelled else { return }
-            exportConfirmation = nil
         }
     }
 

--- a/Sources/MacParakeetCore/AppNotifications.swift
+++ b/Sources/MacParakeetCore/AppNotifications.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-extension Notification.Name {
+public extension Notification.Name {
     static let macParakeetOpenOnboarding = Notification.Name("macparakeet.openOnboarding")
     static let macParakeetOpenSettings = Notification.Name("macparakeet.openSettings")
     static let macParakeetHotkeyTriggerDidChange = Notification.Name("macparakeet.hotkeyTriggerDidChange")

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+public protocol AppRuntimePreferencesProtocol: Sendable {
+    var processingMode: Dictation.ProcessingMode { get }
+    var voiceReturnTrigger: String? { get }
+    var shouldSaveAudioRecordings: Bool { get }
+    var shouldSaveDictationHistory: Bool { get }
+    var shouldSaveTranscriptionAudio: Bool { get }
+    var shouldDiarize: Bool { get }
+}
+
+public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProtocol, @unchecked Sendable {
+    public static let showIdlePillKey = "showIdlePill"
+    public static let silenceAutoStopKey = "silenceAutoStop"
+    public static let silenceDelayKey = "silenceDelay"
+    public static let voiceReturnEnabledKey = "voiceReturnEnabled"
+    public static let voiceReturnTriggerKey = "voiceReturnTrigger"
+    public static let processingModeKey = "processingMode"
+    public static let saveDictationHistoryKey = "saveDictationHistory"
+    public static let saveAudioRecordingsKey = "saveAudioRecordings"
+    public static let saveTranscriptionAudioKey = "saveTranscriptionAudio"
+    public static let speakerDiarizationKey = "speakerDiarization"
+
+    private let defaults: UserDefaults
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    public var processingMode: Dictation.ProcessingMode {
+        let raw = defaults.string(forKey: Self.processingModeKey)
+        return Dictation.ProcessingMode(rawValue: raw ?? Dictation.ProcessingMode.raw.rawValue) ?? .raw
+    }
+
+    public var voiceReturnTrigger: String? {
+        guard defaults.bool(forKey: Self.voiceReturnEnabledKey) else { return nil }
+        let trigger = (defaults.string(forKey: Self.voiceReturnTriggerKey) ?? "press return")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return trigger.isEmpty ? nil : trigger
+    }
+
+    public var shouldSaveAudioRecordings: Bool {
+        defaults.object(forKey: Self.saveAudioRecordingsKey) as? Bool ?? true
+    }
+
+    public var shouldSaveDictationHistory: Bool {
+        defaults.object(forKey: Self.saveDictationHistoryKey) as? Bool ?? true
+    }
+
+    public var shouldSaveTranscriptionAudio: Bool {
+        defaults.object(forKey: Self.saveTranscriptionAudioKey) as? Bool ?? true
+    }
+
+    public var shouldDiarize: Bool {
+        defaults.object(forKey: Self.speakerDiarizationKey) as? Bool ?? true
+    }
+}

--- a/Sources/MacParakeetCore/Database/ChatConversationRepository.swift
+++ b/Sources/MacParakeetCore/Database/ChatConversationRepository.swift
@@ -48,7 +48,7 @@ public final class ChatConversationRepository: ChatConversationRepositoryProtoco
     }
 
     public func deleteAll(transcriptionId: UUID) throws {
-        try dbQueue.write { db in
+        _ = try dbQueue.write { db in
             try ChatConversation
                 .filter(ChatConversation.Columns.transcriptionId == transcriptionId)
                 .deleteAll(db)
@@ -56,7 +56,7 @@ public final class ChatConversationRepository: ChatConversationRepositoryProtoco
     }
 
     public func deleteEmpty(transcriptionId: UUID) throws {
-        try dbQueue.write { db in
+        _ = try dbQueue.write { db in
             try ChatConversation
                 .filter(ChatConversation.Columns.transcriptionId == transcriptionId)
                 .filter(ChatConversation.Columns.messages == nil)

--- a/Sources/MacParakeetCore/Services/CrashReporter.swift
+++ b/Sources/MacParakeetCore/Services/CrashReporter.swift
@@ -72,19 +72,19 @@ public final class CrashReporter {
 
         // 2. Pre-resolve crash file path to C string
         let path = crashReportPath
-        path.withCString { ptr in
+        _ = path.withCString { ptr in
             strncpy(&crashFilePath, ptr, crashFilePath.count - 1)
         }
         crashFilePath[crashFilePath.count - 1] = 0
 
         // 3. Snapshot version strings into static buffers
         let info = SystemInfo.current
-        info.appVersion.withCString { ptr in
+        _ = info.appVersion.withCString { ptr in
             strncpy(&appVersion, ptr, appVersion.count - 1)
         }
         appVersion[appVersion.count - 1] = 0
 
-        info.macOSVersion.withCString { ptr in
+        _ = info.macOSVersion.withCString { ptr in
             strncpy(&osVersion, ptr, osVersion.count - 1)
         }
         osVersion[osVersion.count - 1] = 0
@@ -95,7 +95,7 @@ public final class CrashReporter {
         // 5. Capture ASLR slide
         let slide = _dyld_get_image_vmaddr_slide(0)
         let slideStr = String(format: "0x%lx", UInt(bitPattern: slide))
-        slideStr.withCString { ptr in
+        _ = slideStr.withCString { ptr in
             strncpy(&aslrSlide, ptr, aslrSlide.count - 1)
         }
         aslrSlide[aslrSlide.count - 1] = 0
@@ -151,7 +151,7 @@ public final class CrashReporter {
         func append(_ s: UnsafePointer<CChar>) {
             let len = Int(strlen(s))
             guard offset + len < bufSize else { return }
-            buffer.withUnsafeMutableBufferPointer { buf in
+            _ = buffer.withUnsafeMutableBufferPointer { buf in
                 memcpy(buf.baseAddress! + offset, s, len)
             }
             offset += len
@@ -286,7 +286,7 @@ public final class CrashReporter {
                     bytes[4], bytes[5], bytes[6], bytes[7],
                     bytes[8], bytes[9], bytes[10], bytes[11],
                     bytes[12], bytes[13], bytes[14], bytes[15])
-                formatted.withCString { ptr in
+                _ = formatted.withCString { ptr in
                     strncpy(&machOUUID, ptr, machOUUID.count - 1)
                 }
                 return

--- a/Sources/MacParakeetCore/Services/VideoStreamService.swift
+++ b/Sources/MacParakeetCore/Services/VideoStreamService.swift
@@ -45,7 +45,7 @@ public final class VideoStreamService: Sendable {
     /// Invalidate cached URL for a video (e.g., after playback error).
     public func invalidateCache(for youtubeURL: String) {
         let videoID = YouTubeURLValidator.extractVideoID(youtubeURL) ?? youtubeURL
-        Self.cache.withLock { $0.removeValue(forKey: videoID) }
+        _ = Self.cache.withLock { $0.removeValue(forKey: videoID) }
         logger.notice("🗑 Invalidated cache for \(videoID)")
     }
 

--- a/Sources/MacParakeetViewModels/LLMSettingsDraft.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsDraft.swift
@@ -15,7 +15,7 @@ public struct LLMSettingsDraft: Equatable, Sendable {
             case .missingCustomModel:
                 return "Enter a custom model ID."
             case .invalidBaseURL:
-                return "Enter a valid base URL."
+                return "Enter a valid HTTPS base URL, or use localhost for local servers."
             case .missingCommandTemplate:
                 return "Enter a CLI command."
             }
@@ -91,8 +91,11 @@ public struct LLMSettingsDraft: Equatable, Sendable {
         if useCustomModel && trimmedCustomModelName.isEmpty {
             return .missingCustomModel
         }
-        if !trimmedBaseURLOverride.isEmpty && URL(string: trimmedBaseURLOverride) == nil {
-            return .invalidBaseURL
+        if !trimmedBaseURLOverride.isEmpty {
+            guard let overrideURL = URL(string: trimmedBaseURLOverride),
+                  Self.isAllowedBaseURLOverride(overrideURL) else {
+                return .invalidBaseURL
+            }
         }
         return nil
     }
@@ -114,6 +117,9 @@ public struct LLMSettingsDraft: Equatable, Sendable {
         let baseURL: URL
         if !trimmedBaseURLOverride.isEmpty {
             guard let override = URL(string: trimmedBaseURLOverride) else {
+                throw ValidationError.invalidBaseURL
+            }
+            guard Self.isAllowedBaseURLOverride(override) else {
                 throw ValidationError.invalidBaseURL
             }
             baseURL = override
@@ -172,5 +178,19 @@ public struct LLMSettingsDraft: Equatable, Sendable {
             selectedCLITemplate: selectedCLITemplate,
             cliTimeoutSeconds: cliConfig?.timeoutSeconds ?? LocalCLIConfig.defaultTimeout
         )
+    }
+
+    private static func isAllowedBaseURLOverride(_ url: URL) -> Bool {
+        guard let scheme = url.scheme?.lowercased(),
+              let host = url.host?.lowercased() else {
+            return false
+        }
+        if scheme == "https" {
+            return true
+        }
+        guard scheme == "http" else {
+            return false
+        }
+        return host == "localhost" || host == "127.0.0.1" || host == "::1"
     }
 }

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -27,14 +27,14 @@ public final class SettingsViewModel {
     public var menuBarOnlyMode: Bool {
         didSet {
             defaults.set(menuBarOnlyMode, forKey: AppPreferences.menuBarOnlyModeKey)
-            NotificationCenter.default.post(name: Notification.Name("macparakeet.menuBarOnlyModeDidChange"), object: nil)
+            NotificationCenter.default.post(name: .macParakeetMenuBarOnlyModeDidChange, object: nil)
             Telemetry.send(.settingChanged(setting: .menuBarOnly))
         }
     }
     public var showIdlePill: Bool {
         didSet {
-            defaults.set(showIdlePill, forKey: "showIdlePill")
-            NotificationCenter.default.post(name: Notification.Name("macparakeet.showIdlePillDidChange"), object: nil)
+            defaults.set(showIdlePill, forKey: UserDefaultsAppRuntimePreferences.showIdlePillKey)
+            NotificationCenter.default.post(name: .macParakeetShowIdlePillDidChange, object: nil)
             Telemetry.send(.settingChanged(setting: .hidePill))
         }
     }
@@ -52,7 +52,7 @@ public final class SettingsViewModel {
     public var hotkeyTrigger: HotkeyTrigger {
         didSet {
             hotkeyTrigger.save(to: defaults)
-            NotificationCenter.default.post(name: Notification.Name("macparakeet.hotkeyTriggerDidChange"), object: nil)
+            NotificationCenter.default.post(name: .macParakeetHotkeyTriggerDidChange, object: nil)
             Telemetry.send(.hotkeyCustomized)
         }
     }
@@ -60,7 +60,7 @@ public final class SettingsViewModel {
         didSet {
             meetingHotkeyTrigger.save(to: defaults, defaultsKey: HotkeyTrigger.meetingDefaultsKey)
             NotificationCenter.default.post(
-                name: Notification.Name("macparakeet.meetingHotkeyTriggerDidChange"),
+                name: .macParakeetMeetingHotkeyTriggerDidChange,
                 object: nil
             )
             Telemetry.send(.settingChanged(setting: .meetingHotkey))
@@ -68,23 +68,23 @@ public final class SettingsViewModel {
     }
     public var silenceAutoStop: Bool {
         didSet {
-            defaults.set(silenceAutoStop, forKey: "silenceAutoStop")
+            defaults.set(silenceAutoStop, forKey: UserDefaultsAppRuntimePreferences.silenceAutoStopKey)
             Telemetry.send(.settingChanged(setting: .silenceAutoStop))
         }
     }
     public var silenceDelay: Double {
-        didSet { defaults.set(silenceDelay, forKey: "silenceDelay") }
+        didSet { defaults.set(silenceDelay, forKey: UserDefaultsAppRuntimePreferences.silenceDelayKey) }
     }
 
     // Voice Return
     public var voiceReturnEnabled: Bool {
         didSet {
-            defaults.set(voiceReturnEnabled, forKey: "voiceReturnEnabled")
+            defaults.set(voiceReturnEnabled, forKey: UserDefaultsAppRuntimePreferences.voiceReturnEnabledKey)
             Telemetry.send(.settingChanged(setting: .voiceReturn))
         }
     }
     public var voiceReturnTrigger: String {
-        didSet { defaults.set(voiceReturnTrigger, forKey: "voiceReturnTrigger") }
+        didSet { defaults.set(voiceReturnTrigger, forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggerKey) }
     }
 
     // Processing
@@ -95,10 +95,10 @@ public final class SettingsViewModel {
                 // so execute side effects explicitly for the fallback.
                 let fallback = Dictation.ProcessingMode.raw.rawValue
                 processingMode = fallback
-                defaults.set(fallback, forKey: "processingMode")
+                defaults.set(fallback, forKey: UserDefaultsAppRuntimePreferences.processingModeKey)
                 return
             }
-            defaults.set(processingMode, forKey: "processingMode")
+            defaults.set(processingMode, forKey: UserDefaultsAppRuntimePreferences.processingModeKey)
             Telemetry.send(.processingModeChanged(mode: processingMode))
         }
     }
@@ -108,19 +108,19 @@ public final class SettingsViewModel {
     // Storage
     public var saveDictationHistory: Bool {
         didSet {
-            defaults.set(saveDictationHistory, forKey: "saveDictationHistory")
+            defaults.set(saveDictationHistory, forKey: UserDefaultsAppRuntimePreferences.saveDictationHistoryKey)
             Telemetry.send(.settingChanged(setting: .saveHistory))
         }
     }
     public var saveAudioRecordings: Bool {
         didSet {
-            defaults.set(saveAudioRecordings, forKey: "saveAudioRecordings")
+            defaults.set(saveAudioRecordings, forKey: UserDefaultsAppRuntimePreferences.saveAudioRecordingsKey)
             Telemetry.send(.settingChanged(setting: .audioRetention))
         }
     }
     public var saveTranscriptionAudio: Bool {
         didSet {
-            defaults.set(saveTranscriptionAudio, forKey: "saveTranscriptionAudio")
+            defaults.set(saveTranscriptionAudio, forKey: UserDefaultsAppRuntimePreferences.saveTranscriptionAudioKey)
             Telemetry.send(.settingChanged(setting: .saveTranscriptionAudio))
         }
     }
@@ -128,7 +128,7 @@ public final class SettingsViewModel {
     // Transcription
     public var speakerDiarization: Bool {
         didSet {
-            defaults.set(speakerDiarization, forKey: "speakerDiarization")
+            defaults.set(speakerDiarization, forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey)
             Telemetry.send(.settingChanged(setting: .speakerDiarization))
         }
     }
@@ -216,20 +216,20 @@ public final class SettingsViewModel {
         self.isSpeechModelCached = isSpeechModelCached
         launchAtLogin = defaults.bool(forKey: "launchAtLogin")
         menuBarOnlyMode = AppPreferences.isMenuBarOnlyModeEnabled(defaults: defaults)
-        showIdlePill = defaults.object(forKey: "showIdlePill") as? Bool ?? true
+        showIdlePill = defaults.object(forKey: UserDefaultsAppRuntimePreferences.showIdlePillKey) as? Bool ?? true
         telemetryEnabled = AppPreferences.isTelemetryEnabled(defaults: defaults)
         hotkeyTrigger = HotkeyTrigger.current(defaults: defaults)
         meetingHotkeyTrigger = Self.resolveMeetingHotkeyTrigger(defaults: defaults)
-        silenceAutoStop = defaults.bool(forKey: "silenceAutoStop")
-        let delay = defaults.double(forKey: "silenceDelay")
+        silenceAutoStop = defaults.bool(forKey: UserDefaultsAppRuntimePreferences.silenceAutoStopKey)
+        let delay = defaults.double(forKey: UserDefaultsAppRuntimePreferences.silenceDelayKey)
         silenceDelay = delay == 0 ? 2.0 : delay
-        voiceReturnEnabled = defaults.bool(forKey: "voiceReturnEnabled")
-        voiceReturnTrigger = defaults.string(forKey: "voiceReturnTrigger") ?? "press return"
-        processingMode = Self.normalizedProcessingMode(defaults.string(forKey: "processingMode"))
-        saveDictationHistory = defaults.object(forKey: "saveDictationHistory") as? Bool ?? true
-        saveAudioRecordings = defaults.object(forKey: "saveAudioRecordings") as? Bool ?? true
-        saveTranscriptionAudio = defaults.object(forKey: "saveTranscriptionAudio") as? Bool ?? true
-        speakerDiarization = defaults.object(forKey: "speakerDiarization") as? Bool ?? true
+        voiceReturnEnabled = defaults.bool(forKey: UserDefaultsAppRuntimePreferences.voiceReturnEnabledKey)
+        voiceReturnTrigger = defaults.string(forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggerKey) ?? "press return"
+        processingMode = Self.normalizedProcessingMode(defaults.string(forKey: UserDefaultsAppRuntimePreferences.processingModeKey))
+        saveDictationHistory = defaults.object(forKey: UserDefaultsAppRuntimePreferences.saveDictationHistoryKey) as? Bool ?? true
+        saveAudioRecordings = defaults.object(forKey: UserDefaultsAppRuntimePreferences.saveAudioRecordingsKey) as? Bool ?? true
+        saveTranscriptionAudio = defaults.object(forKey: UserDefaultsAppRuntimePreferences.saveTranscriptionAudioKey) as? Bool ?? true
+        speakerDiarization = defaults.object(forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey) as? Bool ?? true
         autoSaveTranscripts = defaults.bool(forKey: AutoSaveService.enabledKey)
         autoSaveFormat = AutoSaveFormat(rawValue: defaults.string(forKey: AutoSaveService.formatKey) ?? "md") ?? .md
         autoSaveFolderPath = Self.resolveAutoSaveFolderPath(defaults: defaults, scope: .transcription)

--- a/Sources/MacParakeetViewModels/TranscriptChatViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptChatViewModel.swift
@@ -136,7 +136,7 @@ public final class TranscriptChatViewModel {
         if currentConversation == nil {
             guard let transcriptionId else { return }
             let title = String(text.prefix(50))
-            var conversation = ChatConversation(transcriptionId: transcriptionId, title: title)
+            let conversation = ChatConversation(transcriptionId: transcriptionId, title: title)
             do {
                 try conversationRepo?.save(conversation)
                 currentConversation = conversation

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -102,10 +102,8 @@ public final class TranscriptionViewModel {
         transcriptionService: TranscriptionServiceProtocol,
         transcriptionRepo: TranscriptionRepositoryProtocol,
         llmService: LLMServiceProtocol? = nil,
-        configStore: LLMConfigStoreProtocol? = nil,
         promptResultRepo: PromptResultRepositoryProtocol? = nil,
-        promptResultsViewModel: PromptResultsViewModel? = nil,
-        cliConfigStore: LocalCLIConfigStore = LocalCLIConfigStore()
+        promptResultsViewModel: PromptResultsViewModel? = nil
     ) {
         self.transcriptionService = transcriptionService
         self.transcriptionRepo = transcriptionRepo
@@ -241,7 +239,6 @@ public final class TranscriptionViewModel {
               FileManager.default.fileExists(atPath: filePath) else { return }
 
         let url = URL(fileURLWithPath: filePath)
-        let originalID = original.id
         let taskID = beginNewTranscription(source: .localFile, fileName: original.fileName, clearCurrent: true)
         let retranscriptionSource: TelemetryTranscriptionSource = switch original.sourceType {
         case .file:
@@ -260,17 +257,21 @@ public final class TranscriptionViewModel {
                         self?.updateProgress(with: phase, taskID: taskID)
                     }
                 }
-                // Preserve original metadata
+                // Preserve row identity and user-owned metadata so retranscription updates
+                // the existing record instead of deleting and recreating it.
+                result.id = original.id
+                result.createdAt = original.createdAt
+                result.isFavorite = original.isFavorite
                 result.fileName = original.fileName
+                result.filePath = original.filePath
                 result.sourceURL = original.sourceURL
                 result.thumbnailURL = original.thumbnailURL
                 result.channelName = original.channelName
                 result.videoDescription = original.videoDescription
                 result.sourceType = original.sourceType
+                result.updatedAt = Date()
                 do {
                     try transcriptionRepo?.save(result)
-                    // Delete the original to avoid duplicates
-                    _ = try? transcriptionRepo?.delete(id: originalID)
                     completeSuccessfulTranscription(taskID: taskID, result: result)
                 } catch {
                     logger.error("Failed to save transcription result error=\(error.localizedDescription, privacy: .public)")

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowStateMachineTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowStateMachineTests.swift
@@ -929,7 +929,7 @@ final class DictationFlowStateMachineTests: XCTestCase {
     func testRapidRestartFromRecordingThenEntitlementsDeniedResetsMenuBar() {
         var m = machineInRecording()
         // Menu bar was set to .recording when entering recording state
-        let newGen = m.generation
+        _ = m.generation
 
         // Rapid restart → checkingEntitlements
         _ = m.handle(.startRequested(mode: .persistent))

--- a/Tests/MacParakeetTests/ViewModels/LLMSettingsDraftTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LLMSettingsDraftTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import MacParakeetViewModels
+@testable import MacParakeetCore
+
+final class LLMSettingsDraftTests: XCTestCase {
+    func testHTTPRemoteBaseURLIsRejected() {
+        let draft = LLMSettingsDraft(
+            providerID: .openai,
+            apiKeyInput: "test-key",
+            suggestedModelName: "gpt-4.1",
+            baseURLOverride: "http://example.com/v1"
+        )
+
+        XCTAssertEqual(draft.validationError, .invalidBaseURL)
+    }
+
+    func testHTTPLocalhostBaseURLIsAllowed() {
+        let draft = LLMSettingsDraft(
+            providerID: .ollama,
+            suggestedModelName: "qwen3.5:4b",
+            baseURLOverride: "http://localhost:11434/v1"
+        )
+
+        XCTAssertNil(draft.validationError)
+    }
+
+    func testHTTPSRemoteBaseURLIsAllowed() {
+        let draft = LLMSettingsDraft(
+            providerID: .openai,
+            apiKeyInput: "test-key",
+            suggestedModelName: "gpt-4.1",
+            baseURLOverride: "https://example.com/v1"
+        )
+
+        XCTAssertNil(draft.validationError)
+    }
+}

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -860,13 +860,15 @@ final class TranscriptionViewModelTests: XCTestCase {
 
     // MARK: - Retranscribe
 
-    func testRetranscribeDeletesOriginalAndCreatesNewRecord() async throws {
+    func testRetranscribeUpdatesOriginalRecordInPlace() async throws {
         let tmpFile = FileManager.default.temporaryDirectory.appendingPathComponent("retranscribe-test.mp3")
         FileManager.default.createFile(atPath: tmpFile.path, contents: Data([0]))
         defer { try? FileManager.default.removeItem(at: tmpFile) }
 
+        let createdAt = Date(timeIntervalSince1970: 1234)
         let original = Transcription(
             id: UUID(),
+            createdAt: createdAt,
             fileName: "lecture.mp3",
             filePath: tmpFile.path,
             rawTranscript: "Old transcript",
@@ -875,6 +877,7 @@ final class TranscriptionViewModelTests: XCTestCase {
             thumbnailURL: "https://img.youtube.com/vi/abc123/default.jpg",
             channelName: "Channel",
             videoDescription: "Description",
+            isFavorite: true,
             sourceType: .youtube
         )
         mockRepo.transcriptions = [original]
@@ -892,14 +895,16 @@ final class TranscriptionViewModelTests: XCTestCase {
 
         try await Task.sleep(for: .milliseconds(300))
 
-        // Original should be deleted
-        XCTAssertTrue(mockRepo.deleteCalledWith.contains(original.id),
-                       "Original transcription should be deleted after retranscribe")
+        XCTAssertTrue(mockRepo.deleteCalledWith.isEmpty,
+                      "Retranscribe should update the existing transcription instead of deleting it")
 
-        // New record should be saved (the one from the service, with metadata preserved)
+        // Existing record should be updated in place with the new transcript payload.
         let saved = mockRepo.transcriptions
-        XCTAssertEqual(saved.count, 1, "Should have exactly one record (old deleted, new saved)")
-        XCTAssertNotEqual(saved.first?.id, original.id, "New record should have a different ID")
+        XCTAssertEqual(saved.count, 1, "Should still have exactly one record after retranscribe")
+        XCTAssertEqual(saved.first?.id, original.id, "Retranscribe should preserve transcription identity")
+        XCTAssertEqual(saved.first?.createdAt, createdAt, "Should preserve original creation date")
+        XCTAssertEqual(saved.first?.isFavorite, true, "Should preserve favorite state")
+        XCTAssertEqual(saved.first?.rawTranscript, "New transcript", "Should replace transcript content")
         XCTAssertEqual(saved.first?.fileName, "lecture.mp3", "Should preserve original fileName")
         XCTAssertEqual(saved.first?.sourceURL, "https://youtube.com/watch?v=abc123",
                        "Should preserve original sourceURL")


### PR DESCRIPTION
## Summary
- extract hotkey orchestration from `AppDelegate` into `AppHotkeyCoordinator`
- centralize transcript clipboard/export side effects in `TranscriptResultActions`
- simplify `TranscriptResultView` by replacing repeated side-effect blocks with helper calls
- fix speaker label refresh to use live lookup by `speakerId`
- align retranscribe warning copy with current in-place update behavior

## Why
This tranche targets the architecture/UI debt called out in review synthesis:
- reduce app-shell concentration in `AppDelegate`
- keep SwiftUI view code thinner by moving operational side effects out of a large feature view
- improve maintainability and reviewability without changing core product behavior

## Verification
- `swift build --scratch-path .build-review-pr2-step2b`
- `swift test --scratch-path .build-review-pr2-chat --filter TranscriptChatViewModelTests`
- `swift test --scratch-path .build-review-pr2-transcription --filter TranscriptionViewModelTests`

## Commits
- `25fc6c7` Extract app hotkey orchestration from AppDelegate
- `483d996` Extract transcript result side effects into helper

## Note
The local environment intermittently emitted SwiftPM `DecodingError.dataCorrupted ... unexpected end of file` noise during builds, but the verification commands above completed successfully and tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added transcript export with support for multiple formats (TXT, Markdown, SRT, VTT, DOCX, PDF, JSON).
  * Enhanced transcript display with speaker label identification.

* **Bug Fixes**
  * Retranscriptions now preserve original metadata (creation date, favorite status, file details) while updating content.
  * Strengthened LLM configuration validation for base URL settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->