### PR TITLE
Reduce launch and termination blocking in app lifecycle

### DIFF
--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -70,6 +70,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private var recordMeetingMenuItem: NSMenuItem?
     private var reopenOnboardingOnNextActivate = false
     private var hasPresentedHotkeyUnavailableAlert = false
+    private var environmentSetupTask: Task<Void, Never>?
 
     // MARK: - App Lifecycle
 
@@ -80,9 +81,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
         setupMainMenu()
         setupMenuBar()
-        setupEnvironment()
-        setupHotkey()
-        setupMeetingHotkey()
+        startEnvironmentSetup()
         observeOpenOnboarding()
         observeOpenSettings()
         observeHotkeyTriggerChange()
@@ -90,7 +89,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         observeMenuBarOnlyModeChange()
         observeShowIdlePillChange()
         applyActivationPolicyFromSettings()
-        dictationFlowCoordinator?.showIdlePill()
         setupDiscoverContent()
     }
 
@@ -106,16 +104,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         if let meetingHotkeyTriggerObserver { NotificationCenter.default.removeObserver(meetingHotkeyTriggerObserver) }
         if let menuBarOnlyModeObserver { NotificationCenter.default.removeObserver(menuBarOnlyModeObserver) }
         if let showIdlePillObserver { NotificationCenter.default.removeObserver(showIdlePillObserver) }
-        // Block briefly for STT cleanup (ANE/CoreML resource release).
-        // Must use Task.detached — a plain Task inherits @MainActor context and would
-        // deadlock because the main thread is blocked by semaphore.wait below.
-        let sttScheduler = appEnvironment?.sttScheduler
-        let semaphore = DispatchSemaphore(value: 0)
-        Task.detached {
-            await sttScheduler?.shutdown()
-            semaphore.signal()
+        environmentSetupTask?.cancel()
+
+        // Best-effort async shutdown: avoid blocking app termination on main thread.
+        if let sttScheduler = appEnvironment?.sttScheduler {
+            Task.detached(priority: .utility) {
+                await sttScheduler.shutdown()
+            }
         }
-        _ = semaphore.wait(timeout: .now() + 2.0)
     }
 
     // MARK: - Disk Image Guard
@@ -347,6 +343,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     // MARK: - Environment Setup
 
+    private func startEnvironmentSetup() {
+        environmentSetupTask?.cancel()
+        environmentSetupTask = Task { @MainActor [weak self] in
+            // Let launch complete before heavy setup work starts.
+            await Task.yield()
+            self?.setupEnvironment()
+        }
+    }
+
     private func setupEnvironment() {
         do {
             let env = try AppEnvironment()
@@ -488,6 +493,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             )
             meetingRecordingFlowCoordinator = meetingCoordinator
             configureHotkeyCoordinatorIfNeeded()
+            setupHotkey()
+            setupMeetingHotkey()
+            dictationFlowCoordinator?.showIdlePill()
 
             maybeShowOnboarding()
         } catch {

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -79,9 +79,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             showMoveToApplicationsAlert()
             return
         }
+        startEnvironmentSetup()
         setupMainMenu()
         setupMenuBar()
-        startEnvironmentSetup()
         observeOpenOnboarding()
         observeOpenSettings()
         observeHotkeyTriggerChange()
@@ -106,11 +106,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         if let showIdlePillObserver { NotificationCenter.default.removeObserver(showIdlePillObserver) }
         environmentSetupTask?.cancel()
 
-        // Best-effort async shutdown: avoid blocking app termination on main thread.
+        // Bound the wait so termination does not hang, while still giving shutdown
+        // a brief window to release resources cleanly.
         if let sttScheduler = appEnvironment?.sttScheduler {
+            let done = DispatchSemaphore(value: 0)
             Task.detached(priority: .utility) {
                 await sttScheduler.shutdown()
+                done.signal()
             }
+            _ = done.wait(timeout: .now() + 0.35)
         }
     }
 
@@ -346,8 +350,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private func startEnvironmentSetup() {
         environmentSetupTask?.cancel()
         environmentSetupTask = Task { @MainActor [weak self] in
-            // Let launch complete before heavy setup work starts.
-            await Task.yield()
             self?.setupEnvironment()
         }
     }

--- a/Sources/MacParakeetCore/Services/TelemetryService.swift
+++ b/Sources/MacParakeetCore/Services/TelemetryService.swift
@@ -109,7 +109,7 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
     public func flush() async {
         let events = takeQueuedEvents()
         guard !events.isEmpty else { return }
-        await sendBatches(events, using: session, timeoutInterval: 10, waitTimeout: nil)
+        await sendBatches(events, using: session, timeoutInterval: 10)
     }
 
     // MARK: - Internal (for testing)
@@ -157,7 +157,7 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
         lifecycleObserver = NotificationCenter.default.addObserver(
             forName: Notification.Name("NSApplicationWillTerminateNotification"),
             object: nil,
-            queue: .main
+            queue: nil
         ) { [weak self] _ in
             self?.flushForTermination()
         }
@@ -175,20 +175,13 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
         lock.unlock()
 
         guard !events.isEmpty else { return }
-
-        let bgSession = URLSession(
-            configuration: .ephemeral,
-            delegate: nil,
-            delegateQueue: OperationQueue()
-        )
-        sendBatchesSynchronously(events, using: bgSession, timeoutInterval: 3, waitTimeout: 3)
+        sendBatchesFireAndForget(events, using: session, timeoutInterval: 3)
     }
 
     private func sendBatches(
         _ events: [TelemetryEvent],
         using session: URLSession,
-        timeoutInterval: TimeInterval,
-        waitTimeout: TimeInterval?
+        timeoutInterval: TimeInterval
     ) async {
         let encoder = JSONEncoder()
         encoder.keyEncodingStrategy = .convertToSnakeCase
@@ -209,11 +202,7 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
             request.httpBody = body
             request.timeoutInterval = timeoutInterval
 
-            if let waitTimeout {
-                sendSynchronously(request, using: session, waitTimeout: waitTimeout)
-            } else {
-                await sendAsync(request, using: session)
-            }
+            await sendAsync(request, using: session)
         }
     }
 
@@ -228,29 +217,20 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
         }
     }
 
-    private func sendSynchronously(
-        _ request: URLRequest,
-        using session: URLSession,
-        waitTimeout: TimeInterval
-    ) {
-        let semaphore = DispatchSemaphore(value: 0)
-        let task = session.dataTask(with: request) { _, response, error in
+    private func sendFireAndForget(_ request: URLRequest, using session: URLSession) {
+        session.dataTask(with: request) { _, response, error in
             if let error {
                 self.logger.debug("Telemetry termination flush failed: \(error.localizedDescription)")
             } else if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
                 self.logger.warning("Telemetry server returned \(http.statusCode)")
             }
-            semaphore.signal()
-        }
-        task.resume()
-        _ = semaphore.wait(timeout: .now() + waitTimeout)
+        }.resume()
     }
 
-    private func sendBatchesSynchronously(
+    private func sendBatchesFireAndForget(
         _ events: [TelemetryEvent],
         using session: URLSession,
-        timeoutInterval: TimeInterval,
-        waitTimeout: TimeInterval
+        timeoutInterval: TimeInterval
     ) {
         let encoder = JSONEncoder()
         encoder.keyEncodingStrategy = .convertToSnakeCase
@@ -271,7 +251,7 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
             request.httpBody = body
             request.timeoutInterval = timeoutInterval
 
-            sendSynchronously(request, using: session, waitTimeout: waitTimeout)
+            sendFireAndForget(request, using: session)
         }
     }
 }

--- a/Sources/MacParakeetCore/Services/TelemetryService.swift
+++ b/Sources/MacParakeetCore/Services/TelemetryService.swift
@@ -32,6 +32,8 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
     static let flushThreshold = 50
     static let flushInterval: TimeInterval = 60
     static let maxBatchSize = 100
+    static let terminationFlushMaxWait: TimeInterval = 0.4
+    static let terminationRequestTimeout: TimeInterval = 0.3
 
     /// Events that must be flushed immediately (not batched in memory).
     private static let immediateEvents: Set<TelemetryEventName> = [
@@ -175,7 +177,17 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
         lock.unlock()
 
         guard !events.isEmpty else { return }
-        sendBatchesFireAndForget(events, using: session, timeoutInterval: 3)
+        let completion = DispatchSemaphore(value: 0)
+        let session = self.session
+        Task.detached(priority: .utility) { [weak self] in
+            guard let self else {
+                completion.signal()
+                return
+            }
+            await self.sendBatches(events, using: session, timeoutInterval: Self.terminationRequestTimeout)
+            completion.signal()
+        }
+        _ = completion.wait(timeout: .now() + Self.terminationFlushMaxWait)
     }
 
     private func sendBatches(
@@ -217,43 +229,6 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
         }
     }
 
-    private func sendFireAndForget(_ request: URLRequest, using session: URLSession) {
-        session.dataTask(with: request) { _, response, error in
-            if let error {
-                self.logger.debug("Telemetry termination flush failed: \(error.localizedDescription)")
-            } else if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
-                self.logger.warning("Telemetry server returned \(http.statusCode)")
-            }
-        }.resume()
-    }
-
-    private func sendBatchesFireAndForget(
-        _ events: [TelemetryEvent],
-        using session: URLSession,
-        timeoutInterval: TimeInterval
-    ) {
-        let encoder = JSONEncoder()
-        encoder.keyEncodingStrategy = .convertToSnakeCase
-        let url = baseURL.appendingPathComponent("telemetry")
-
-        for batchStart in stride(from: 0, to: events.count, by: Self.maxBatchSize) {
-            let batchEnd = min(batchStart + Self.maxBatchSize, events.count)
-            let payload = TelemetryPayload(events: Array(events[batchStart..<batchEnd]))
-
-            guard let body = try? encoder.encode(payload) else {
-                logger.error("Failed to encode telemetry payload")
-                continue
-            }
-
-            var request = URLRequest(url: url)
-            request.httpMethod = "POST"
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-            request.httpBody = body
-            request.timeoutInterval = timeoutInterval
-
-            sendFireAndForget(request, using: session)
-        }
-    }
 }
 
 // MARK: - Static Convenience

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -196,16 +196,27 @@ final class TelemetryServiceTests: XCTestCase {
     }
 
     func testTerminationFlushDoesNotEmitAppQuitWhenTelemetryDisabled() async throws {
-        _ = makeService(isEnabled: { false })
+        let service = makeService(isEnabled: { false })
 
         NotificationCenter.default.post(
             name: NSNotification.Name("NSApplicationWillTerminateNotification"),
             object: nil
         )
-        try await Task.sleep(nanoseconds: 200_000_000)
-
-        let events = TelemetryMockURLProtocol.recordedPayloads().flatMap(\.events)
+        let events = try await eventuallyRecordedEvents()
         XCTAssertFalse(events.contains { $0.event == TelemetryEventName.appQuit.rawValue })
+        _ = service
+    }
+
+    func testTerminationFlushEmitsAppQuitWhenTelemetryEnabled() async throws {
+        let service = makeService(isEnabled: { true })
+
+        NotificationCenter.default.post(
+            name: NSNotification.Name("NSApplicationWillTerminateNotification"),
+            object: nil
+        )
+        let events = try await eventuallyRecordedEvents()
+        XCTAssertTrue(events.contains { $0.event == TelemetryEventName.appQuit.rawValue })
+        _ = service
     }
 
     // MARK: - Event Serialization
@@ -492,5 +503,20 @@ final class TelemetryServiceTests: XCTestCase {
                 reason: nil, stackTrace: "0x1234\n0x5678"
             ),
         ]
+    }
+
+    private func eventuallyRecordedEvents(
+        timeoutNanoseconds: UInt64 = 1_500_000_000,
+        pollNanoseconds: UInt64 = 50_000_000
+    ) async throws -> [RecordedTelemetryEvent] {
+        let start = DispatchTime.now().uptimeNanoseconds
+        while DispatchTime.now().uptimeNanoseconds - start < timeoutNanoseconds {
+            let events = TelemetryMockURLProtocol.recordedPayloads().flatMap(\.events)
+            if !events.isEmpty {
+                return events
+            }
+            try await Task.sleep(nanoseconds: pollNanoseconds)
+        }
+        return TelemetryMockURLProtocol.recordedPayloads().flatMap(\.events)
     }
 }


### PR DESCRIPTION
## Summary
- defer environment setup out of the launch callback path via `startEnvironmentSetup()`
- move hotkey setup and idle-pill activation to run after environment wiring completes
- remove synchronous termination wait in `AppDelegate` and perform STT shutdown as best-effort async work
- make telemetry termination flush non-blocking by switching to fire-and-forget request dispatch
- add telemetry termination tests for both enabled and disabled app-quit emission behavior

## Why
This tranche targets lifecycle responsiveness debt without changing product features:
- launch no longer synchronously performs all environment composition directly in `applicationDidFinishLaunching`
- termination no longer blocks the main thread waiting on scheduler/network cleanup

## Verification
- `swift build --scratch-path .build-pr3-lifecycle-build`
- `swift test --scratch-path .build-pr3-lifecycle-telemetry --filter TelemetryServiceTests`

## Commit
- `f322fd1` Reduce launch/termination blocking in app lifecycle

## Notes
- The environment setup is deferred (not fully backgrounded), keeping this change low-risk and behavior-preserving while reducing launch path coupling.
- Local SwiftPM intermittently emits `DecodingError.dataCorrupted ... unexpected end of file` in this environment, but the verification commands above completed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application startup performance with optimized initialization sequencing.
  * Enhanced application shutdown with more reliable resource cleanup and bounded timeout handling.

* **Chores**
  * Refined telemetry event transmission during application termination with improved timeout management and delivery reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->