### PR TITLE
Surface missing view-model dependencies explicitly

### DIFF
--- a/Sources/MacParakeetViewModels/TranscriptChatViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptChatViewModel.swift
@@ -134,11 +134,19 @@ public final class TranscriptChatViewModel {
 
         // Lazy conversation creation on first message
         if currentConversation == nil {
-            guard let transcriptionId else { return }
+            guard let transcriptionId else {
+                errorMessage = "Chat is unavailable until a transcript is loaded."
+                return
+            }
+            guard let conversationRepo else {
+                logger.error("Missing conversationRepo in sendMessage")
+                errorMessage = "Chat storage is unavailable. Please relaunch."
+                return
+            }
             let title = String(text.prefix(50))
             let conversation = ChatConversation(transcriptionId: transcriptionId, title: title)
             do {
-                try conversationRepo?.save(conversation)
+                try conversationRepo.save(conversation)
                 currentConversation = conversation
                 conversations.insert(conversation, at: 0)
             } catch {
@@ -265,10 +273,21 @@ public final class TranscriptChatViewModel {
             return
         }
 
+        guard let conversationRepo else {
+            logger.error("Missing conversationRepo in loadTranscript")
+            messages.removeAll()
+            chatHistory.removeAll()
+            conversations.removeAll()
+            currentConversation = nil
+            errorMessage = "Chat storage is unavailable. Please relaunch."
+            inputText = ""
+            return
+        }
+
         // Load conversations from repo
         do {
-            try conversationRepo?.deleteEmpty(transcriptionId: transcriptionId)
-            conversations = try conversationRepo?.fetchAll(transcriptionId: transcriptionId) ?? []
+            try conversationRepo.deleteEmpty(transcriptionId: transcriptionId)
+            conversations = try conversationRepo.fetchAll(transcriptionId: transcriptionId)
         } catch {
             logger.error("Failed to load conversations error=\(error.localizedDescription, privacy: .public)")
             conversations = []
@@ -318,7 +337,9 @@ public final class TranscriptChatViewModel {
             cancelStreaming()
         }
 
-        _ = try? conversationRepo?.delete(id: conversation.id)
+        if let conversationRepo {
+            _ = try? conversationRepo.delete(id: conversation.id)
+        }
         conversations.removeAll { $0.id == conversation.id }
 
         if currentConversation?.id == conversation.id {
@@ -344,7 +365,9 @@ public final class TranscriptChatViewModel {
 
         // Delete all conversations for this transcript
         if let transcriptionId {
-            try? conversationRepo?.deleteAll(transcriptionId: transcriptionId)
+            if let conversationRepo {
+                try? conversationRepo.deleteAll(transcriptionId: transcriptionId)
+            }
             conversations.removeAll()
         }
         currentConversation = nil
@@ -378,15 +401,21 @@ public final class TranscriptChatViewModel {
     private func discardEmptyCurrentConversation() {
         guard let current = currentConversation,
               current.messages == nil || current.messages?.isEmpty == true else { return }
-        _ = try? conversationRepo?.delete(id: current.id)
+        if let conversationRepo {
+            _ = try? conversationRepo.delete(id: current.id)
+        }
         conversations.removeAll { $0.id == current.id }
     }
 
     private func persistChatMessages() {
         guard let currentConversation else { return }
+        guard let conversationRepo else {
+            logger.error("Missing conversationRepo in persistChatMessages")
+            return
+        }
         let toSave = chatHistory.isEmpty ? nil : chatHistory
         do {
-            try conversationRepo?.updateMessages(id: currentConversation.id, messages: toSave)
+            try conversationRepo.updateMessages(id: currentConversation.id, messages: toSave)
             // Update the local copy
             self.currentConversation?.messages = toSave
             if let idx = conversations.firstIndex(where: { $0.id == currentConversation.id }) {

--- a/Sources/MacParakeetViewModels/TranscriptChatViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptChatViewModel.swift
@@ -19,6 +19,8 @@ public struct ChatDisplayMessage: Identifiable, Equatable {
 @MainActor
 @Observable
 public final class TranscriptChatViewModel {
+    private static let storageUnavailableMessage = "Chat storage is unavailable. Please relaunch."
+
     public var messages: [ChatDisplayMessage] = []
     public var inputText: String = ""
     public var isStreaming: Bool = false
@@ -140,7 +142,7 @@ public final class TranscriptChatViewModel {
             }
             guard let conversationRepo else {
                 logger.error("Missing conversationRepo in sendMessage")
-                errorMessage = "Chat storage is unavailable. Please relaunch."
+                errorMessage = Self.storageUnavailableMessage
                 return
             }
             let title = String(text.prefix(50))
@@ -279,7 +281,7 @@ public final class TranscriptChatViewModel {
             chatHistory.removeAll()
             conversations.removeAll()
             currentConversation = nil
-            errorMessage = "Chat storage is unavailable. Please relaunch."
+            errorMessage = Self.storageUnavailableMessage
             inputText = ""
             return
         }
@@ -337,9 +339,20 @@ public final class TranscriptChatViewModel {
             cancelStreaming()
         }
 
-        if let conversationRepo {
-            _ = try? conversationRepo.delete(id: conversation.id)
+        guard let conversationRepo else {
+            logger.error("Missing conversationRepo in deleteConversation")
+            errorMessage = Self.storageUnavailableMessage
+            return
         }
+
+        do {
+            _ = try conversationRepo.delete(id: conversation.id)
+        } catch {
+            logger.error("Failed to delete conversation error=\(error.localizedDescription, privacy: .public)")
+            errorMessage = "Failed to delete conversation."
+            return
+        }
+
         conversations.removeAll { $0.id == conversation.id }
 
         if currentConversation?.id == conversation.id {
@@ -358,18 +371,30 @@ public final class TranscriptChatViewModel {
     /// Clears all conversations for the current transcript (used when retranscribing).
     public func clearHistory() {
         cancelStreaming()
+
+        // Delete all conversations for this transcript
+        if let transcriptionId {
+            guard let conversationRepo else {
+                logger.error("Missing conversationRepo in clearHistory")
+                errorMessage = Self.storageUnavailableMessage
+                return
+            }
+
+            do {
+                try conversationRepo.deleteAll(transcriptionId: transcriptionId)
+            } catch {
+                logger.error("Failed to clear conversations error=\(error.localizedDescription, privacy: .public)")
+                errorMessage = "Failed to clear chat history."
+                return
+            }
+
+            conversations.removeAll()
+        }
+
         messages.removeAll()
         chatHistory.removeAll()
         errorMessage = nil
         inputText = ""
-
-        // Delete all conversations for this transcript
-        if let transcriptionId {
-            if let conversationRepo {
-                try? conversationRepo.deleteAll(transcriptionId: transcriptionId)
-            }
-            conversations.removeAll()
-        }
         currentConversation = nil
 
         notifyConversationsChanged()
@@ -401,9 +426,20 @@ public final class TranscriptChatViewModel {
     private func discardEmptyCurrentConversation() {
         guard let current = currentConversation,
               current.messages == nil || current.messages?.isEmpty == true else { return }
-        if let conversationRepo {
-            _ = try? conversationRepo.delete(id: current.id)
+
+        guard let conversationRepo else {
+            logger.error("Missing conversationRepo in discardEmptyCurrentConversation")
+            errorMessage = Self.storageUnavailableMessage
+            return
         }
+
+        do {
+            _ = try conversationRepo.delete(id: current.id)
+        } catch {
+            logger.error("Failed to discard empty conversation error=\(error.localizedDescription, privacy: .public)")
+            return
+        }
+
         conversations.removeAll { $0.id == current.id }
     }
 

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -74,6 +74,7 @@ public final class TranscriptionViewModel {
             || hasPromptResultTabs
             || hasConversations
     }
+    public private(set) var isConfigured = false
 
     public func handlePromptResultDeleted(_ deletedID: UUID) {
         guard case .result(let selectedID) = selectedTab, selectedID == deletedID else { return }
@@ -93,6 +94,7 @@ public final class TranscriptionViewModel {
     private var activeDropRequestID: UUID?
     private var dropPendingCount = 0
     private var dropAccepted = false
+    private static let configurationError = "Transcription is still initializing. Please try again."
     private let logger = Logger(subsystem: "com.macparakeet.viewmodels", category: "TranscriptionViewModel")
     public var promptResultsViewModel: PromptResultsViewModel?
 
@@ -110,11 +112,17 @@ public final class TranscriptionViewModel {
         self.llmAvailable = llmService != nil
         self.promptResultRepo = promptResultRepo
         self.promptResultsViewModel = promptResultsViewModel
+        isConfigured = true
+        errorMessage = nil
         loadTranscriptions()
     }
 
     public func loadTranscriptions() {
-        guard let repo = transcriptionRepo else { return }
+        guard let repo = transcriptionRepo else {
+            reportMissingConfiguration("transcriptionRepo", action: "loadTranscriptions")
+            transcriptions = []
+            return
+        }
         do {
             transcriptions = try repo.fetchAll(limit: 50)
         } catch {
@@ -124,7 +132,10 @@ public final class TranscriptionViewModel {
     }
 
     public func transcribeFile(url: URL, source: TelemetryTranscriptionSource = .file) {
-        guard let service = transcriptionService else { return }
+        guard let service = transcriptionService else {
+            reportMissingConfiguration("transcriptionService", action: "transcribeFile")
+            return
+        }
         let taskID = beginNewTranscription(source: .localFile, fileName: url.lastPathComponent)
 
         transcriptionTask = Task { @MainActor [weak self] in
@@ -145,7 +156,10 @@ public final class TranscriptionViewModel {
     }
 
     public func transcribeURL() {
-        guard let service = transcriptionService else { return }
+        guard let service = transcriptionService else {
+            reportMissingConfiguration("transcriptionService", action: "transcribeURL")
+            return
+        }
         let url = urlInput.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let videoID = YouTubeURLValidator.extractVideoID(url) else { return }
 
@@ -234,8 +248,11 @@ public final class TranscriptionViewModel {
     }
 
     public func retranscribe(_ original: Transcription) {
-        guard let service = transcriptionService,
-              let filePath = original.filePath,
+        guard let service = transcriptionService else {
+            reportMissingConfiguration("transcriptionService", action: "retranscribe")
+            return
+        }
+        guard let filePath = original.filePath,
               FileManager.default.fileExists(atPath: filePath) else { return }
 
         let url = URL(fileURLWithPath: filePath)
@@ -296,7 +313,10 @@ public final class TranscriptionViewModel {
     }
 
     public func deleteTranscription(_ transcription: Transcription) {
-        guard let repo = transcriptionRepo else { return }
+        guard let repo = transcriptionRepo else {
+            reportMissingConfiguration("transcriptionRepo", action: "deleteTranscription")
+            return
+        }
 
         do {
             let deleted = try repo.delete(id: transcription.id)
@@ -331,6 +351,15 @@ public final class TranscriptionViewModel {
         }
 
         return taskID
+    }
+
+    private func reportMissingConfiguration(_ dependency: String, action: String) {
+        logger.error(
+            "Missing dependency action=\(action, privacy: .public) dependency=\(dependency, privacy: .public)"
+        )
+        if errorMessage == nil {
+            errorMessage = Self.configurationError
+        }
     }
 
     private func completeSuccessfulTranscription(taskID: UUID, result: Transcription) {

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -94,7 +94,7 @@ public final class TranscriptionViewModel {
     private var activeDropRequestID: UUID?
     private var dropPendingCount = 0
     private var dropAccepted = false
-    private static let configurationError = "Transcription is still initializing. Please try again."
+    private static let configurationError = "Transcription services are unavailable. Please try again."
     private let logger = Logger(subsystem: "com.macparakeet.viewmodels", category: "TranscriptionViewModel")
     public var promptResultsViewModel: PromptResultsViewModel?
 

--- a/Tests/MacParakeetTests/ViewModels/TranscriptChatViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptChatViewModelTests.swift
@@ -67,6 +67,14 @@ final class TranscriptChatViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.messages.isEmpty)
     }
 
+    func testSendMessageWithoutLoadedTranscriptShowsConfigurationError() {
+        viewModel.inputText = "Question"
+        viewModel.sendMessage()
+
+        XCTAssertTrue(viewModel.messages.isEmpty)
+        XCTAssertEqual(viewModel.errorMessage, "Chat is unavailable until a transcript is loaded.")
+    }
+
     func testSendMessageWhileStreamingDoesNotSend() async throws {
         let transcriptionId = UUID()
         viewModel.loadTranscript("Transcript", transcriptionId: transcriptionId)

--- a/Tests/MacParakeetTests/ViewModels/TranscriptChatViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptChatViewModelTests.swift
@@ -353,6 +353,46 @@ final class TranscriptChatViewModelTests: XCTestCase {
         XCTAssertTrue(mockConversationRepo.conversations.isEmpty)
     }
 
+    func testDeleteConversationKeepsLocalStateWhenRepoDeleteFails() {
+        enum DeleteFailure: Error { case failed }
+
+        let transcriptionId = UUID()
+        let conv = ChatConversation(
+            transcriptionId: transcriptionId,
+            title: "Chat",
+            messages: [ChatMessage(role: .user, content: "Hi")]
+        )
+        mockConversationRepo.conversations = [conv]
+        viewModel.loadTranscript("Transcript", transcriptionId: transcriptionId)
+        mockConversationRepo.deleteError = DeleteFailure.failed
+
+        viewModel.deleteConversation(conv)
+
+        XCTAssertTrue(viewModel.conversations.contains(where: { $0.id == conv.id }))
+        XCTAssertEqual(viewModel.currentConversation?.id, conv.id)
+        XCTAssertEqual(viewModel.errorMessage, "Failed to delete conversation.")
+    }
+
+    func testClearHistoryKeepsLocalStateWhenRepoDeleteAllFails() {
+        enum DeleteFailure: Error { case failed }
+
+        let transcriptionId = UUID()
+        let conv = ChatConversation(
+            transcriptionId: transcriptionId,
+            title: "Chat",
+            messages: [ChatMessage(role: .user, content: "Hi")]
+        )
+        mockConversationRepo.conversations = [conv]
+        viewModel.loadTranscript("Transcript", transcriptionId: transcriptionId)
+        mockConversationRepo.deleteAllError = DeleteFailure.failed
+
+        viewModel.clearHistory()
+
+        XCTAssertFalse(viewModel.conversations.isEmpty)
+        XCTAssertNotNil(viewModel.currentConversation)
+        XCTAssertEqual(viewModel.errorMessage, "Failed to clear chat history.")
+    }
+
     func testCanSendMessageFalseWhenNoService() {
         viewModel.updateLLMService(nil)
         XCTAssertFalse(viewModel.canSendMessage)

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -579,13 +579,15 @@ final class TranscriptionViewModelTests: XCTestCase {
         let url = URL(fileURLWithPath: "/tmp/audio.mp3")
         viewModel.transcribeFile(url: url)
 
-        // Should not crash and state should remain unchanged
+        // Should not crash and should surface missing configuration
         XCTAssertFalse(viewModel.isTranscribing)
+        XCTAssertEqual(viewModel.errorMessage, "Transcription is still initializing. Please try again.")
     }
 
     func testLoadTranscriptionsBeforeConfigureIsNoOp() {
         viewModel.loadTranscriptions()
         XCTAssertTrue(viewModel.transcriptions.isEmpty)
+        XCTAssertEqual(viewModel.errorMessage, "Transcription is still initializing. Please try again.")
     }
 
     // MARK: - Initial State

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -581,13 +581,13 @@ final class TranscriptionViewModelTests: XCTestCase {
 
         // Should not crash and should surface missing configuration
         XCTAssertFalse(viewModel.isTranscribing)
-        XCTAssertEqual(viewModel.errorMessage, "Transcription is still initializing. Please try again.")
+        XCTAssertEqual(viewModel.errorMessage, "Transcription services are unavailable. Please try again.")
     }
 
     func testLoadTranscriptionsBeforeConfigureIsNoOp() {
         viewModel.loadTranscriptions()
         XCTAssertTrue(viewModel.transcriptions.isEmpty)
-        XCTAssertEqual(viewModel.errorMessage, "Transcription is still initializing. Please try again.")
+        XCTAssertEqual(viewModel.errorMessage, "Transcription services are unavailable. Please try again.")
     }
 
     // MARK: - Initial State

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -669,6 +669,8 @@ final class MockChatConversationRepository: ChatConversationRepositoryProtocol, 
     var deleteEmptyCalls: [UUID] = []
     var updateMessagesCalls: [(id: UUID, messages: [ChatMessage]?)] = []
     var updateTitleCalls: [(id: UUID, title: String)] = []
+    var deleteError: Error?
+    var deleteAllError: Error?
 
     func save(_ conversation: ChatConversation) throws {
         saveCalls.append(conversation)
@@ -690,6 +692,7 @@ final class MockChatConversationRepository: ChatConversationRepositoryProtocol, 
     }
 
     func delete(id: UUID) throws -> Bool {
+        if let deleteError { throw deleteError }
         deleteCalls.append(id)
         let before = conversations.count
         conversations.removeAll { $0.id == id }
@@ -697,6 +700,7 @@ final class MockChatConversationRepository: ChatConversationRepositoryProtocol, 
     }
 
     func deleteAll(transcriptionId: UUID) throws {
+        if let deleteAllError { throw deleteAllError }
         conversations.removeAll { $0.transcriptionId == transcriptionId }
     }
 


### PR DESCRIPTION
## Summary
- add explicit missing-dependency reporting in `TranscriptionViewModel` instead of silent returns
- track `TranscriptionViewModel.isConfigured` and clear stale configuration errors on `configure(...)`
- tighten `TranscriptChatViewModel` conversation-repo/transcript-context handling with clear user-facing errors
- require concrete `conversationRepo` calls in load/persist/create paths rather than optional no-op chaining
- add/adjust tests to verify unconfigured VM behavior now surfaces clear errors

## Why
This tranche addresses the highest-friction part of the VM invariant debt:
- invalid or partially wired states no longer silently no-op in key transcription/chat operations
- wiring mistakes become diagnosable quickly (logs + deterministic UI errors)

## Verification
- `swift test --scratch-path .build-pr4-vm-transcription --filter TranscriptionViewModelTests`
- `swift test --scratch-path .build-pr4-vm-chat --filter TranscriptChatViewModelTests`

## Commit
- `792b437` Surface missing view-model dependencies explicitly

## Scope Note
This is an incremental invariant hardening pass focused on top user paths. A full constructor-injection migration can build on this with lower risk in a follow-up slice.