### PR TITLE
Extract timestamped transcript content from TranscriptResultView

### DIFF
--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -1723,41 +1723,25 @@ struct TranscriptResultView: View {
     // MARK: - Timestamped View
 
     @ViewBuilder
-    private func timestampedView(words: [WordTimestamp]) -> some View {
-        if cachedHasSpeakers {
-            // Speaker-aware layout: use cached turns
-            ForEach(Array(cachedTurns.enumerated()), id: \.element.segments.first?.startMs) { _, turn in
-                transcriptTurnCard(
-                    speakerLabel: cachedSpeakerLabelMap[turn.speakerId] ?? "Unknown",
-                    speakerColor: cachedSpeakerColorMap[turn.speakerId] ?? DesignSystem.Colors.textTertiary,
-                    segments: turn.segments.map { ($0.startMs, $0.text) }
-                )
-                .id(turn.segments.first?.startMs ?? 0)
-            }
-        } else {
-            // No speakers — use cached segments
-            ForEach(Array(cachedSegments.enumerated()), id: \.element.startMs) { index, segment in
-                let isActive = isSegmentActiveBinarySearch(segmentIndex: index)
-                HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
-                    timestampChip(segment.startMs)
-
-                    Text(segment.text)
-                        .font(DesignSystem.Typography.bodyLarge)
-                        .foregroundStyle(DesignSystem.Colors.textPrimary)
-                        .textSelection(.enabled)
-                        .lineSpacing(5)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+    private func timestampedView(words _: [WordTimestamp]) -> some View {
+        TranscriptTimestampedContentView(
+            hasSpeakers: cachedHasSpeakers,
+            turns: cachedTurns,
+            segments: cachedSegments,
+            speakerColorMap: cachedSpeakerColorMap,
+            speakerLabelForID: { cachedSpeakerLabelMap[$0] ?? "Unknown" },
+            isSegmentActive: isSegmentActiveBinarySearch(segmentIndex:),
+            timestampLabel: { formatTimestamp(ms: $0) },
+            isTimestampSeekable: playerViewModel.playerState == .ready,
+            onTimestampTap: { startMs in
+                playerViewModel.seek(toMs: startMs)
+                if !playerViewModel.isPlaying {
+                    playerViewModel.togglePlayPause()
                 }
-                .padding(DesignSystem.Spacing.md)
-                .background(
-                    RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
-                        .fill(isActive
-                              ? DesignSystem.Colors.accent.opacity(0.12)
-                              : DesignSystem.Colors.surfaceElevated.opacity(0.45))
-                )
-                .id(segment.startMs)
+                autoScrollPaused = false
+                scrollPauseTask?.cancel()
             }
-        }
+        )
     }
 
     // MARK: - Speaker Summary Panel
@@ -1893,88 +1877,6 @@ struct TranscriptResultView: View {
             return "\(minutes)m \(seconds)s"
         }
         return "\(seconds)s"
-    }
-
-    private func transcriptTurnCard(
-        speakerLabel: String,
-        speakerColor: Color,
-        segments: [(startMs: Int, text: String)]
-    ) -> some View {
-        VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
-            HStack(spacing: DesignSystem.Spacing.sm) {
-                Circle()
-                    .fill(speakerColor)
-                    .frame(width: 10, height: 10)
-
-                Text(speakerLabel)
-                    .font(DesignSystem.Typography.body.weight(.semibold))
-                    .foregroundStyle(speakerColor)
-
-                if let firstStart = segments.first?.startMs {
-                    metadataChip(icon: "clock", text: formatTimestamp(ms: firstStart), tint: DesignSystem.Colors.textSecondary)
-                }
-
-                Spacer()
-            }
-
-            VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
-                ForEach(Array(segments.enumerated()), id: \.offset) { _, segment in
-                    HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
-                        timestampChip(segment.startMs)
-
-                        Text(segment.text)
-                            .font(DesignSystem.Typography.bodyLarge)
-                            .foregroundStyle(DesignSystem.Colors.textPrimary)
-                            .textSelection(.enabled)
-                            .lineSpacing(5)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                }
-            }
-        }
-        .padding(DesignSystem.Spacing.md)
-        .background(
-            RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
-                .fill(speakerColor.opacity(0.08))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
-                .strokeBorder(speakerColor.opacity(0.18), lineWidth: 0.75)
-        )
-    }
-
-    private var isPlayerSeekable: Bool {
-        playerViewModel.playerState == .ready
-    }
-
-    @ViewBuilder
-    private func timestampChip(_ startMs: Int) -> some View {
-        Text(formatTimestamp(ms: startMs))
-            .font(DesignSystem.Typography.timestamp)
-            .foregroundStyle(isPlayerSeekable ? DesignSystem.Colors.accent : DesignSystem.Colors.textSecondary)
-            .padding(.vertical, 4)
-            .padding(.horizontal, 8)
-            .background(
-                Capsule()
-                    .fill(DesignSystem.Colors.surface)
-            )
-            .frame(width: 72, alignment: .leading)
-            .contentShape(Capsule())
-            .onTapGesture {
-                if isPlayerSeekable {
-                    playerViewModel.seek(toMs: startMs)
-                    if !playerViewModel.isPlaying {
-                        playerViewModel.togglePlayPause()
-                    }
-                    autoScrollPaused = false
-                    scrollPauseTask?.cancel()
-                }
-            }
-            .onHover { hovering in
-                if isPlayerSeekable {
-                    if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                }
-            }
     }
 
     // MARK: - Segment Cache

--- a/Sources/MacParakeet/Views/Transcription/TranscriptTimestampedContentView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptTimestampedContentView.swift
@@ -1,0 +1,185 @@
+import SwiftUI
+import MacParakeetCore
+
+struct TranscriptTimestampedContentView: View {
+    let hasSpeakers: Bool
+    let turns: [SpeakerTurn]
+    let segments: [TranscriptSegment]
+    let speakerColorMap: [String: Color]
+    let speakerLabelForID: (String) -> String
+    let isSegmentActive: (Int) -> Bool
+    let timestampLabel: (Int) -> String
+    let isTimestampSeekable: Bool
+    let onTimestampTap: (Int) -> Void
+
+    var body: some View {
+        if hasSpeakers {
+            ForEach(turns, id: \.segments.first?.startMs) { turn in
+                TranscriptTurnCardView(
+                    speakerLabel: speakerLabelForID(turn.speakerId),
+                    speakerColor: speakerColorMap[turn.speakerId] ?? DesignSystem.Colors.textTertiary,
+                    segments: turn.segments,
+                    timestampLabel: timestampLabel,
+                    isTimestampSeekable: isTimestampSeekable,
+                    onTimestampTap: onTimestampTap
+                )
+                .id(turn.segments.first?.startMs ?? 0)
+            }
+        } else {
+            ForEach(Array(segments.enumerated()), id: \.element.startMs) { index, segment in
+                let isActive = isSegmentActive(index)
+                HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+                    TranscriptTimestampChip(
+                        startMs: segment.startMs,
+                        label: timestampLabel(segment.startMs),
+                        isSeekable: isTimestampSeekable,
+                        onTap: onTimestampTap
+                    )
+
+                    Text(segment.text)
+                        .font(DesignSystem.Typography.bodyLarge)
+                        .foregroundStyle(DesignSystem.Colors.textPrimary)
+                        .textSelection(.enabled)
+                        .lineSpacing(5)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .padding(DesignSystem.Spacing.md)
+                .background(
+                    RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
+                        .fill(isActive
+                              ? DesignSystem.Colors.accent.opacity(0.12)
+                              : DesignSystem.Colors.surfaceElevated.opacity(0.45))
+                )
+                .id(segment.startMs)
+            }
+        }
+    }
+}
+
+private struct TranscriptTurnCardView: View {
+    let speakerLabel: String
+    let speakerColor: Color
+    let segments: [TranscriptSegment]
+    let timestampLabel: (Int) -> String
+    let isTimestampSeekable: Bool
+    let onTimestampTap: (Int) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+            HStack(spacing: DesignSystem.Spacing.sm) {
+                Circle()
+                    .fill(speakerColor)
+                    .frame(width: 10, height: 10)
+
+                Text(speakerLabel)
+                    .font(DesignSystem.Typography.body.weight(.semibold))
+                    .foregroundStyle(speakerColor)
+
+                if let firstStart = segments.first?.startMs {
+                    transcriptMetadataChip(icon: "clock", text: timestampLabel(firstStart))
+                }
+
+                Spacer()
+            }
+
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+                ForEach(Array(segments.enumerated()), id: \.offset) { _, segment in
+                    HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+                        TranscriptTimestampChip(
+                            startMs: segment.startMs,
+                            label: timestampLabel(segment.startMs),
+                            isSeekable: isTimestampSeekable,
+                            onTap: onTimestampTap
+                        )
+
+                        Text(segment.text)
+                            .font(DesignSystem.Typography.bodyLarge)
+                            .foregroundStyle(DesignSystem.Colors.textPrimary)
+                            .textSelection(.enabled)
+                            .lineSpacing(5)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+            }
+        }
+        .padding(DesignSystem.Spacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
+                .fill(speakerColor.opacity(0.08))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
+                .strokeBorder(speakerColor.opacity(0.18), lineWidth: 0.75)
+        )
+    }
+
+    @ViewBuilder
+    private func transcriptMetadataChip(icon: String, text: String) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.system(size: 10, weight: .semibold))
+            Text(text)
+                .font(DesignSystem.Typography.timestamp)
+        }
+        .foregroundStyle(DesignSystem.Colors.textSecondary)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(
+            Capsule()
+                .fill(DesignSystem.Colors.surfaceElevated)
+        )
+    }
+}
+
+private struct TranscriptTimestampChip: View {
+    let startMs: Int
+    let label: String
+    let isSeekable: Bool
+    let onTap: (Int) -> Void
+    @State private var isHovering = false
+    @State private var didPushCursor = false
+
+    var body: some View {
+        Text(label)
+            .font(DesignSystem.Typography.timestamp)
+            .foregroundStyle(isSeekable ? DesignSystem.Colors.accent : DesignSystem.Colors.textSecondary)
+            .padding(.vertical, 4)
+            .padding(.horizontal, 8)
+            .background(
+                Capsule()
+                    .fill(DesignSystem.Colors.surface)
+            )
+            .frame(width: 72, alignment: .leading)
+            .contentShape(Capsule())
+            .onTapGesture {
+                guard isSeekable else { return }
+                onTap(startMs)
+            }
+            .onHover { hovering in
+                isHovering = hovering
+                updateCursor()
+            }
+            .onChange(of: isSeekable) { _, _ in
+                updateCursor()
+            }
+            .onDisappear {
+                if didPushCursor {
+                    NSCursor.pop()
+                    didPushCursor = false
+                }
+            }
+    }
+
+    private func updateCursor() {
+        let shouldShowPointer = isHovering && isSeekable
+        if shouldShowPointer, !didPushCursor {
+            NSCursor.pointingHand.push()
+            didPushCursor = true
+            return
+        }
+        if !shouldShowPointer, didPushCursor {
+            NSCursor.pop()
+            didPushCursor = false
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract timestamped transcript rendering into 
- move speaker turn card and timestamp chip into focused private subviews in the new file
- keep  responsible for orchestration/state while delegating rendering to the extracted component

## Why
- reduce  size and mixed responsibilities
- improve reviewability and future testability of timestamped transcript UI logic

## Verification
- [1/1] Compiling plugin GenerateManual
[2/2] Compiling plugin GenerateDoccReference
Building for debugging...
[2/27] Write macparakeet-cli-entitlement.plist
[2/27] Write sources
[2/27] Copying menubar-icon@2x.png
[5/27] Write sources
[7/27] Copying discover-fallback.json
[8/27] Copying Info.plist
[9/27] Write sources
[10/27] Copying PrivacyInfo.xcprivacy
[10/27] Write sources
[10/27] Write MacParakeet-entitlement.plist
[10/27] Copying menubar-icon.png
[17/27] Copying Sparkle.framework
[18/27] Write swift-version--58304C5D6DBC2206.txt
[20/186] Emitting module ArgumentParserToolInfo
[21/186] Compiling ArgumentParserToolInfo ToolInfo.swift
[21/235] Compiling MachTaskSelfWrapper MachTaskSelf.c
[22/235] Compiling FastClusterWrapper FastClusterWrapper.cpp
[24/389] Compiling FluidAudio SortformerModelInference.swift
[25/389] Compiling FluidAudio SortformerStateUpdater.swift
[26/389] Compiling FluidAudio SortformerTypes.swift
[27/389] Compiling FluidAudio DownloadUtils.swift
[28/392] Compiling FluidAudio TdtFrameNavigation.swift
[29/392] Compiling FluidAudio TdtHypothesis.swift
[30/392] Compiling FluidAudio TdtJointDecision.swift
[31/392] Compiling FluidAudio TdtJointInputProvider.swift
[32/392] Compiling FluidAudio TdtDecoderV2.swift
[33/392] Compiling FluidAudio TdtDecoderV3.swift
[34/392] Compiling FluidAudio TdtDurationMapping.swift
[35/392] Emitting module ArgumentParser
[36/392] Compiling ArgumentParser ParsableArgumentsValidation.swift
[37/392] Compiling ArgumentParser PositionalArgumentsValidator.swift
[38/392] Compiling ArgumentParser UniqueNamesValidator.swift
[39/392] Compiling FluidAudio AsrModels.swift
[40/392] Compiling FluidAudio AsrTypes.swift
[41/392] Compiling FluidAudio AudioBuffer.swift
[42/392] Compiling FluidAudio KokoroSynthesizer+VoiceEmbeddings.swift
[43/392] Compiling FluidAudio KokoroSynthesizer.swift
[44/392] Compiling FluidAudio TtsCustomLexicon.swift
[45/392] Compiling FluidAudio PocketTtsConstantsLoader.swift
[46/392] Compiling FluidAudio TdtModelInference.swift
[47/392] Compiling FluidAudio TtsTextPreprocessor.swift
[48/392] Compiling FluidAudio KokoroSynthesizer+Memory.swift
[49/392] Compiling FluidAudio KokoroSynthesizer+ModelUtils.swift
[50/392] Compiling FluidAudio BlasIndex.swift
[51/392] Compiling FluidAudio EncoderFrameView.swift
[52/392] Compiling FluidAudio TdtConfig.swift
[53/392] Compiling FluidAudio TdtDecoderState.swift
[54/392] Compiling FluidAudio AudioValidation.swift
[55/392] Compiling FluidAudio SegmentationProcessor.swift
[56/392] Compiling FluidAudio SlidingWindow.swift
[57/392] Compiling FluidAudio SortformerDiarizer.swift
[58/392] Compiling FluidAudio CtcZhCnManager.swift
[59/392] Compiling FluidAudio CtcZhCnModels.swift
[60/392] Compiling FluidAudio VDSPOperations.swift
[61/392] Compiling FluidAudio FluidAudioSwift.swift
[62/392] Compiling FluidAudio TextNormalizer.swift
[63/392] Compiling FluidAudio ModelNames.swift
[64/392] Compiling FluidAudio MLArrayCache.swift
[65/392] Compiling FluidAudio AsrManager+Pipeline.swift
[66/392] Compiling FluidAudio AsrManager+TokenProcessing.swift
[67/392] Compiling FluidAudio AsrManager+Transcription.swift
[68/392] Compiling FluidAudio AsrManager.swift
[69/392] Compiling FluidAudio PocketTtsResourceDownloader.swift
[70/392] Compiling FluidAudio PocketTtsModelStore.swift
[71/392] Compiling FluidAudio PocketTtsSession.swift
[72/392] Compiling FluidAudio PocketTtsSynthesizer+Flow.swift
[73/392] Compiling FluidAudio ChunkProcessor.swift
[74/392] Compiling FluidAudio CtcJaManager.swift
[75/392] Compiling FluidAudio CtcJaModels.swift
[76/392] Compiling FluidAudio SpeakerCountConstraints.swift
[77/392] Compiling FluidAudio VBxClustering.swift
[78/392] Compiling FluidAudio OfflineDiarizerManager.swift
[79/392] Compiling FluidAudio OfflineDiarizerModels.swift
[80/392] Compiling FluidAudio OfflineDiarizerTypes.swift
[81/392] Compiling FluidAudio OfflineEmbeddingExtractor.swift
[82/392] Compiling FluidAudio PLDATransform.swift
[83/392] Compiling FluidAudio WeightInterpolation.swift
[84/392] Compiling FluidAudio OfflineSegmentationProcessor.swift
[85/392] Compiling FluidAudio OfflineReconstruction.swift
[86/392] Compiling FluidAudio SpeakerManager.swift
[87/392] Compiling FluidAudio SpeakerOperations.swift
[88/404] Compiling FluidAudio SpeakerTypes.swift
[89/404] Compiling FluidAudio DiarizerManager.swift
[90/404] Compiling FluidAudio DiarizerModels.swift
[91/404] Compiling FluidAudio DiarizerTypes.swift
[92/404] Compiling FluidAudio DiarizerTimeline.swift
[93/404] Compiling FluidAudio EmbeddingExtractor.swift
[94/404] Compiling FluidAudio LSEENDDatatypes.swift
[95/404] Compiling FluidAudio LSEENDDiarizer.swift
[96/404] Compiling FluidAudio LSEENDModelInference.swift
[97/404] Compiling FluidAudio LSEENDPreprocessor.swift
[98/404] Compiling FluidAudio PocketTtsSynthesizer+KVCache.swift
[99/404] Compiling FluidAudio PocketTtsSynthesizer+Mimi.swift
[100/404] Compiling FluidAudio ANEMemoryOptimizer.swift
[101/404] Compiling FluidAudio ANEMemoryUtils.swift
[102/404] Compiling FluidAudio ASRConstants.swift
[103/404] Compiling FluidAudio AppLogger.swift
[104/404] Compiling FluidAudio AssetDownloader.swift
[105/404] Compiling FluidAudio AudioConverter.swift
[106/404] Compiling FluidAudio AudioMelSpectrogram.swift
[107/404] Compiling FluidAudio AudioSampleSource.swift
[108/404] Compiling FluidAudio AudioSource.swift
[109/404] Compiling FluidAudio AudioSourceFactory.swift
[110/404] Compiling FluidAudio AudioStream.swift
[111/404] Compiling FluidAudio CtcKeywordSpotter+Inference.swift
[112/404] Compiling FluidAudio CtcKeywordSpotter.swift
[113/404] Compiling FluidAudio CtcModels.swift
[114/404] Compiling FluidAudio CtcTokenizer.swift
[115/404] Compiling FluidAudio SlidingWindowAsrManager.swift
[116/404] Compiling FluidAudio SlidingWindowAsrSession.swift
[117/404] Compiling FluidAudio StreamingEouAsrManager.swift
[118/404] Compiling FluidAudio NemotronChunkSize.swift
[119/404] Compiling FluidAudio NemotronStreamingConfig.swift
[120/404] Compiling FluidAudio StreamingNemotronAsrManager+Pipeline.swift
[121/404] Compiling FluidAudio StreamingNemotronAsrManager.swift
[122/404] Compiling FluidAudio ParakeetModelVariant.swift
[123/404] Compiling FluidAudio MultilingualG2PModel.swift
[124/404] Compiling FluidAudio CtcDecoder.swift
[125/404] Compiling FluidAudio BKTree.swift
[126/404] Compiling FluidAudio VocabularyRescorer+CandidateMatching.swift
[127/404] Compiling FluidAudio ContextBiasingConstants.swift
[128/404] Compiling FluidAudio CustomVocabularyContext.swift
[129/404] Compiling FluidAudio VocabularyRescorer+TokenEvaluation.swift
[130/404] Compiling FluidAudio VocabularyRescorer+TokenRescoring.swift
[131/404] Compiling FluidAudio VocabularyRescorer+Utilities.swift
[132/404] Compiling FluidAudio VocabularyRescorer.swift
[133/404] Compiling FluidAudio BpeTokenizer.swift
[134/404] Compiling FluidAudio CtcDPAlgorithm.swift
[135/404] Compiling FluidAudio ModelRegistry.swift
[136/404] Compiling FluidAudio G2PModel.swift
[137/404] Compiling FluidAudio KokoroVocabulary.swift
[138/404] Compiling FluidAudio LexiconAssetManager.swift
[139/404] Compiling FluidAudio TtsResourceDownloader.swift
[140/404] Compiling FluidAudio KokoroTtsManager.swift
[141/404] Compiling FluidAudio KokoroSynthesizer+Types.swift
[142/404] Compiling FluidAudio KokoroChunker.swift
[143/404] Compiling FluidAudio KokoroModelCache.swift
[144/404] Compiling FluidAudio KokoroSynthesizer+LexiconCache.swift
[145/404] Compiling FluidAudio PhonemeMapper.swift
[146/404] Compiling FluidAudio AHCClustering.swift
[147/404] Compiling FluidAudio KMeansClustering.swift
[160/404] Compiling GRDB DatabaseCancellable.swift
[161/404] Compiling GRDB ValueConcurrentObserver.swift
[162/404] Compiling GRDB ValueWriteOnlyObserver.swift
[163/404] Compiling GRDB Fetch.swift
[164/404] Compiling GRDB Map.swift
[165/404] Compiling GRDB RemoveDuplicates.swift
[166/404] Compiling GRDB Trace.swift
[167/404] Compiling GRDB ValueReducer.swift
[168/404] Compiling GRDB SharedValueObservation.swift
[169/404] Compiling GRDB ValueObservation.swift
[170/404] Compiling GRDB ValueObservationScheduler.swift
[171/404] Compiling GRDB resource_bundle_accessor.swift
[172/404] Emitting module GRDB
[185/404] Compiling FluidAudio PocketTtsSynthesizer+Types.swift
[186/404] Compiling FluidAudio PocketTtsSynthesizer.swift
[187/404] Compiling FluidAudio PocketTtsVoiceCloner.swift
[188/404] Compiling FluidAudio PocketTTSError.swift
[189/404] Compiling FluidAudio PocketTtsConstants.swift
[190/404] Compiling FluidAudio PocketTtsManager.swift
[191/404] Compiling FluidAudio SentencePieceProto.swift
[192/404] Compiling FluidAudio SentencePieceTokenizer.swift
[193/404] Compiling FluidAudio SSMLProcessor.swift
[194/404] Compiling GRDB JoinAssociation.swift
[195/404] Compiling GRDB CommonTableExpression.swift
[196/404] Compiling GRDB QueryInterfaceRequest.swift
[197/404] Compiling FluidAudio StreamingAsrManager.swift
[198/404] Compiling FluidAudio Tokenizer.swift
[199/404] Compiling FluidAudio TdtJaManager.swift
[200/404] Compiling FluidAudio TdtJaModels.swift
[201/404] Compiling FluidAudio Qwen3AsrConfig.swift
[202/404] Compiling FluidAudio Qwen3AsrManager.swift
[203/404] Compiling FluidAudio Qwen3AsrModels.swift
[204/404] Compiling FluidAudio Qwen3RoPE.swift
[205/404] Compiling FluidAudio Qwen3StreamingManager.swift
[206/404] Compiling FluidAudio WhisperMelSpectrogram.swift
[207/404] Compiling FluidAudio PunctuationCommitLayer.swift
[208/404] Compiling FluidAudio ARPALanguageModel.swift
[212/404] Compiling FluidAudio ModelWarmup.swift
[213/404] Compiling FluidAudio PerformanceMetrics.swift
[214/404] Compiling FluidAudio ProgressEmitter.swift
[215/404] Compiling FluidAudio StringUtils.swift
[216/404] Compiling FluidAudio SystemInfo.swift
[217/404] Compiling FluidAudio ZeroCopyFeatureProvider.swift
[218/404] Compiling FluidAudio MultilingualG2PError.swift
[219/404] Compiling FluidAudio MultilingualG2PLanguage.swift
[220/404] Compiling FluidAudio RnntDecoder.swift
[257/415] Emitting module FluidAudio
Internal Error: DecodingError.dataCorrupted: Data was corrupted. Debug description: Corrupted JSON. Underlying error: unexpected end of file
Internal Error: DecodingError.dataCorrupted: Data was corrupted. Debug description: Corrupted JSON. Underlying error: unexpected end of file
Internal Error: DecodingError.dataCorrupted: Data was corrupted. Debug description: Corrupted JSON. Underlying error: unexpected end of file
Internal Error: DecodingError.dataCorrupted: Data was corrupted. Debug description: Corrupted JSON. Underlying error: unexpected end of file
Internal Error: DecodingError.dataCorrupted: Data was corrupted. Debug description: Corrupted JSON. Underlying error: unexpected end of file
Internal Error: DecodingError.dataCorrupted: Data was corrupted. Debug description: Corrupted JSON. Underlying error: unexpected end of file
Internal Error: DecodingError.dataCorrupted: Data was corrupted. Debug description: Corrupted JSON. Underlying error: unexpected end of file
Internal Error: DecodingError.dataCorrupted: Data was corrupted. Debug description: Corrupted JSON. Underlying error: unexpected end of file
Internal Error: DecodingError.dataCorrupted: Data was corrupted. Debug description: Corrupted JSON. Underlying error: unexpected end of file
Internal Error: DecodingError.dataCorrupted: Data was corrupted. Debug description: Corrupted JSON. Underlying error: unexpected end of file
Internal Error: DecodingError.dataCorrupted: Data was corrupted. Debug description: Corrupted JSON. Underlying error: unexpected end of file
Internal Error: DecodingError.dataCorrupted: Data was corrupted. Debug description: Corrupted JSON. Underlying error: unexpected end of file
[364/415] Compiling FluidAudio SSMLTagParser.swift
[365/415] Compiling FluidAudio SSMLTypes.swift
[366/415] Compiling FluidAudio SayAsInterpreter.swift
[367/415] Compiling FluidAudio AudioPostProcessor.swift
[368/415] Compiling FluidAudio TtsBackend.swift
[369/415] Compiling FluidAudio TtsConstants.swift
[370/415] Compiling FluidAudio TtsModels.swift
[371/415] Compiling FluidAudio VadManager+SpeechSegmentation.swift
[372/415] Compiling FluidAudio VadManager+Streaming.swift
[373/415] Compiling FluidAudio VadManager.swift
[374/415] Compiling FluidAudio VadTypes.swift
[410/510] Compiling MacParakeetCore KeyAction.swift
[411/510] Compiling MacParakeetCore LLMProvider.swift
[412/510] Compiling MacParakeetCore LLMTypes.swift
[413/510] Compiling MacParakeetCore Prompt.swift
[414/510] Compiling MacParakeetCore PromptResult.swift
[415/510] Compiling MacParakeetCore TextSnippet.swift
[416/510] Compiling MacParakeetCore Transcription.swift
[417/517] Emitting module MacParakeetCore
[418/517] Compiling MacParakeetCore CustomWordRepository.swift
[419/517] Compiling MacParakeetCore DatabaseManager.swift
[420/517] Compiling MacParakeetCore DictationRepository.swift
[421/517] Compiling MacParakeetCore PromptRepository.swift
[422/517] Compiling MacParakeetCore PromptResultRepository.swift
[423/517] Compiling MacParakeetCore TextSnippetRepository.swift
[424/517] Compiling MacParakeetCore TranscriptionRepository.swift
[425/517] Compiling MacParakeetCore DictationFlowStateMachine.swift
[426/517] Compiling MacParakeetCore MeetingRecordingFlowStateMachine.swift
[427/517] Compiling MacParakeetCore AudioSource.swift
[428/517] Compiling MacParakeetCore ChatConversation.swift
[429/517] Compiling MacParakeetCore CustomWord.swift
[430/517] Compiling MacParakeetCore Dictation.swift
[431/517] Compiling MacParakeetCore DictationResult.swift
[432/517] Compiling MacParakeetCore DiscoverContent.swift
[433/517] Compiling MacParakeetCore AppNotifications.swift
[434/517] Compiling MacParakeetCore AppPreferences.swift
[435/517] Compiling MacParakeetCore AppRuntimePreferences.swift
[436/517] Compiling MacParakeetCore AudioChunker.swift
[437/517] Compiling MacParakeetCore AudioDeviceManager.swift
[438/517] Compiling MacParakeetCore AudioFileConverter.swift
[439/517] Compiling MacParakeetCore AudioProcessor.swift
[440/517] Compiling MacParakeetCore AudioProcessorProtocol.swift
[441/517] Compiling MacParakeetCore Int+Duration.swift
[442/517] Compiling MacParakeetCore NumberFormatting.swift
[443/517] Compiling MacParakeetCore Entitlements.swift
[444/517] Compiling MacParakeetCore EntitlementsService.swift
[445/517] Compiling MacParakeetCore KeyValueStore.swift
[446/517] Compiling MacParakeetCore KeychainKeyValueStore.swift
[447/517] Compiling MacParakeetCore LemonSqueezyLicenseAPI.swift
[448/517] Compiling MacParakeetCore LLMError.swift
[449/517] Compiling MacParakeetCore LLMExecutionContext.swift
[450/517] Compiling MacParakeetCore LLMService.swift
[451/517] Compiling MacParakeetCore LaunchAtLoginService.swift
[452/517] Compiling MacParakeetCore LocalCLIExecutor.swift
[453/517] Compiling MacParakeetCore LocalCLILLMClient.swift
[454/517] Compiling MacParakeetCore MeetingChunkResultBuffer.swift
[455/517] Compiling MacParakeetCore YouTubeDownloader.swift
[456/517] Compiling MacParakeetCore TextProcessingPipeline.swift
[457/517] Compiling MacParakeetCore TextProcessingResult.swift
[458/517] Compiling MacParakeetCore TextRefinementService.swift
[459/517] Compiling MacParakeetCore TranscriptSegmenter.swift
[460/517] Compiling MacParakeetCore UnicodeSearch.swift
[461/517] Compiling MacParakeetCore YouTubeURLValidator.swift
[462/517] Compiling MacParakeetCore MeetingRecordingOutput.swift
[463/517] Compiling MacParakeetCore MeetingRecordingService.swift
[464/517] Compiling MacParakeetCore MeetingTranscriptAssembler.swift
[465/517] Compiling MacParakeetCore PasteShortcutKeyResolver.swift
[466/517] Compiling MacParakeetCore PermissionService.swift
[467/517] Compiling MacParakeetCore RoutingLLMClient.swift
[468/517] Compiling MacParakeetCore SpeakerMerger.swift
[469/517] Compiling MacParakeetCore SystemInfo.swift
[470/517] Compiling MacParakeetCore TelemetryErrorClassifier.swift
[471/517] Compiling MacParakeetCore TelemetryEvent.swift
[472/517] Compiling MacParakeetCore TelemetryService.swift
[473/517] Compiling MacParakeetCore ThumbnailCacheService.swift
[474/517] Compiling MacParakeetCore TranscriptionService.swift
[475/517] Compiling MacParakeetCore VideoStreamService.swift
[476/517] Compiling MacParakeetCore TranscriptionProgress.swift
[477/517] Compiling MacParakeetCore FnKeyStateMachine.swift
[478/517] Compiling MacParakeetCore HotkeyGestureController.swift
[479/517] Compiling MacParakeetCore HotkeyTrigger.swift
[480/517] Compiling MacParakeetCore KeyCodeNames.swift
[481/517] Compiling MacParakeetCore OnboardingProgressParser.swift
[482/517] Compiling MacParakeetCore STTClient.swift
[483/517] Compiling MacParakeetCore STTClientProtocol.swift
[484/517] Compiling MacParakeetCore STTResult.swift
[485/517] Compiling MacParakeetCore STTRuntime.swift
[486/517] Compiling MacParakeetCore STTScheduler.swift
[487/517] Compiling MacParakeetCore AccessibilityService.swift
[488/517] Compiling MacParakeetCore AppPaths.swift
[489/517] Compiling MacParakeetCore AutoSaveService.swift
[490/517] Compiling MacParakeetCore AudioRecorder.swift
[491/517] Compiling MacParakeetCore CoreAudioHelpers.swift
[492/517] Compiling MacParakeetCore MeetingAudioCaptureService.swift
[493/517] Compiling MacParakeetCore MeetingAudioError.swift
[494/517] Compiling MacParakeetCore MeetingAudioStorageWriter.swift
[495/517] Compiling MacParakeetCore MicrophoneCapture.swift
[496/517] Compiling MacParakeetCore SystemAudioTap.swift
[497/517] Compiling MacParakeetCore ChatConversationRepository.swift
[498/517] Compiling MacParakeetCore DictationStopDecision.swift
[499/517] Compiling MacParakeetCore DiscoverService.swift
[500/517] Compiling MacParakeetCore DiscoverThoughtsService.swift
[501/517] Compiling MacParakeetCore ExportService.swift
[502/517] Compiling MacParakeetCore FeedbackService.swift
[503/517] Compiling MacParakeetCore LLMClient.swift
[504/517] Compiling MacParakeetCore LLMConfigStore.swift
[505/517] Compiling MacParakeetCore BinaryBootstrap.swift
[506/517] Compiling MacParakeetCore BuildIdentity.swift
[507/517] Compiling MacParakeetCore ClipboardService.swift
[508/517] Compiling MacParakeetCore CrashReporter.swift
[509/517] Compiling MacParakeetCore DiarizationService.swift
[510/517] Compiling MacParakeetCore DictationService.swift
[511/517] Compiling MacParakeetCore DictationServiceSession.swift
[512/556] Compiling CLI StatsCommand.swift
[513/556] Compiling CLI LLMInlineConfig.swift
[514/556] Compiling CLI LLMCommand.swift
[515/556] Compiling CLI LLMTestCommand.swift
[516/556] Compiling MacParakeetViewModels LLMSettingsViewModel.swift
[517/556] Compiling MacParakeetViewModels MediaPlayerViewModel.swift
[518/556] Compiling CLI LLMSummarizeCommand.swift
[519/556] Compiling CLI TranscribeCommand.swift
[520/557] Compiling CLI LLMTransformCommand.swift
[521/557] Compiling CLI ModelsCommand.swift
[522/557] Compiling MacParakeetViewModels IdlePillViewModel.swift
[523/557] Compiling MacParakeetViewModels LLMSettingsDraft.swift
[524/557] Compiling MacParakeetViewModels TranscriptionLibraryViewModel.swift
Internal Error: DecodingError.dataCorrupted: Data was corrupted. Debug description: Corrupted JSON. Underlying error: unexpected end of file
[525/557] Compiling MacParakeetViewModels TextSnippetsViewModel.swift
[526/558] Compiling MacParakeetViewModels MeetingRecordingPreviewLine.swift
[527/558] Compiling MacParakeetViewModels OnboardingViewModel.swift
[528/558] Compiling MacParakeetViewModels CustomWordsViewModel.swift
[529/558] Compiling MacParakeetViewModels DictationHistoryViewModel.swift
[530/558] Emitting module CLI
[531/558] Compiling MacParakeetViewModels DiscoverViewModel.swift
[532/558] Compiling MacParakeetViewModels FeedbackViewModel.swift
[533/558] Compiling CLI MacParakeetCLI.swift
[533/558] Write Objects.LinkFileList
[535/558] Compiling MacParakeetViewModels TranscriptionDeletionCleanup.swift
[536/558] Compiling MacParakeetViewModels TranscriptChatViewModel.swift
Internal Error: DecodingError.dataCorrupted: Data was corrupted. Debug description: Corrupted JSON. Underlying error: unexpected end of file
Internal Error: DecodingError.dataCorrupted: Data was corrupted. Debug description: Corrupted JSON. Underlying error: unexpected end of file
Internal Error: DecodingError.dataCorrupted: Data was corrupted. Debug description: Corrupted JSON. Underlying error: unexpected end of file
[541/558] Compiling MacParakeetViewModels SettingsViewModel.swift
[542/558] Compiling MacParakeetViewModels PromptResultsViewModel.swift
[545/558] Compiling MacParakeetViewModels PromptsViewModel.swift
Internal Error: DecodingError.dataCorrupted: Data was corrupted. Debug description: Corrupted JSON. Underlying error: unexpected end of file
Internal Error: DecodingError.dataCorrupted: Data was corrupted. Debug description: Corrupted JSON. Underlying error: unexpected end of file
[550/558] Compiling MacParakeetViewModels MeetingRecordingPanelViewModel.swift
[551/558] Compiling MacParakeetViewModels MeetingRecordingPillViewModel.swift
[552/558] Emitting module MacParakeetViewModels
[553/558] Compiling MacParakeetViewModels TranscriptionViewModel.swift
[553/619] Linking macparakeet-cli
[554/619] Applying macparakeet-cli
[556/619] Compiling MacParakeet OnboardingWindowController.swift
[557/619] Compiling MacParakeet AIStreamingIndicator.swift
[558/619] Compiling MacParakeet AudioScrubberBar.swift
[559/619] Compiling MacParakeet DesignSystem.swift
[560/619] Compiling MacParakeet FlowLayout.swift
[561/619] Compiling MacParakeet BreathWaveIcon.swift
[562/619] Compiling MacParakeet GlobalShortcutManager.swift
[563/619] Compiling MacParakeet HotkeyManager.swift
[564/619] Compiling MacParakeet MacParakeetApp.swift
[565/619] Compiling MacParakeet MenuBarDropView.swift
[566/623] Compiling MacParakeet MarkdownContentView.swift
[567/623] Compiling MacParakeet ModelSelectorView.swift
[568/623] Compiling MacParakeet ParticleSystem.swift
[569/623] Compiling MacParakeet SacredGeometry.swift
[570/623] Compiling MacParakeet SonicMandalaView.swift
[571/623] Compiling MacParakeet AppEnvironment.swift
[572/623] Compiling MacParakeet AppHotkeyCoordinator.swift
[573/623] Compiling MacParakeet DictationFlowCoordinator.swift
[574/623] Compiling MacParakeet MeetingRecordingFlowCoordinator.swift
[575/623] Compiling MacParakeet AppDelegate.swift
[576/623] Compiling MacParakeet MeetingRowCard.swift
[577/623] Compiling MacParakeet MeetingsView.swift
[578/623] Compiling MacParakeet MerkabaPillIcon.swift
[579/623] Compiling MacParakeet TranscriptTextView.swift
[580/623] Compiling MacParakeet IdlePillView.swift
[581/623] Compiling MacParakeet WaveformView.swift
[582/623] Compiling MacParakeet DiscoverSidebarCard.swift
[583/623] Compiling MacParakeet DiscoverView.swift
[584/623] Compiling MacParakeet SacredGeometryShapes.swift
[585/623] Compiling MacParakeet FeedbackView.swift
[586/623] Compiling MacParakeet DictationHistoryView.swift
[587/623] Compiling MacParakeet MainWindowState.swift
[588/623] Compiling MacParakeet MainWindowView.swift
[589/623] Compiling MacParakeet DualAudioOrbView.swift
[590/623] Emitting module MacParakeet
[591/623] Compiling MacParakeet FlowerCompletionView.swift
[592/623] Compiling MacParakeet MeetingRecordingPanelController.swift
[593/623] Compiling MacParakeet MeetingRecordingPanelView.swift
[594/623] Compiling MacParakeet MeetingRecordingPillController.swift
[595/623] Compiling MacParakeet MeetingRecordingPillView.swift
[596/623] Compiling MacParakeet PortalDropZone.swift
[597/623] Compiling MacParakeet PromptLibraryView.swift
[598/623] Compiling MacParakeet TranscribeView.swift
[599/623] Compiling MacParakeet TranscriptResultActions.swift
[600/623] Compiling MacParakeet CustomWordsView.swift
[601/623] Compiling MacParakeet TextSnippetsView.swift
[602/623] Compiling MacParakeet VocabularyView.swift
[603/623] Compiling MacParakeet resource_bundle_accessor.swift
[604/623] Compiling MacParakeet OnboardingFlowView.swift
[605/623] Compiling MacParakeet HotkeyRecorderView.swift
[606/623] Compiling MacParakeet LLMSettingsView.swift
[607/623] Compiling MacParakeet SettingsView.swift
[608/623] Compiling MacParakeet SoundManager.swift
[609/623] Compiling MacParakeet VideoPlayerView.swift
[610/623] Compiling MacParakeet DictationOverlayController.swift
[611/623] Compiling MacParakeet DictationOverlayView.swift
[612/623] Compiling MacParakeet IdlePillController.swift
[613/623] Compiling MacParakeet TranscriptionVideoPanel.swift
[614/623] Compiling MacParakeet TranscriptionViewHelpers.swift
[615/623] Compiling MacParakeet YouTubeInputPanelController.swift
[616/623] Compiling MacParakeet YouTubeInputPanelView.swift
[617/623] Compiling MacParakeet TranscriptResultView.swift
[618/623] Compiling MacParakeet TranscriptTimestampedContentView.swift
[619/623] Compiling MacParakeet TranscriptionLibraryView.swift
[620/623] Compiling MacParakeet TranscriptionThumbnailCard.swift
[620/623] Write Objects.LinkFileList
[621/623] Linking MacParakeet
[622/623] Applying MacParakeet
Build complete! (55.27s)
- Test Suite 'Selected tests' started at 2026-04-08 00:28:51.933.
Test Suite 'MacParakeetPackageTests.xctest' started at 2026-04-08 00:28:51.934.
Test Suite 'TranscriptionViewModelTests' started at 2026-04-08 00:28:51.934.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testCancelTranscriptionResetsToIdleWithoutError]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testCancelTranscriptionResetsToIdleWithoutError]' passed (0.110 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testConfigureLoadsTranscriptions]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testConfigureLoadsTranscriptions]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testConfigureWithEmptyRepo]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testConfigureWithEmptyRepo]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testDeleteCurrentTranscriptionClearsSelection]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testDeleteCurrentTranscriptionClearsSelection]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testDeleteDoesNotClearUnrelatedCurrentTranscription]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testDeleteDoesNotClearUnrelatedCurrentTranscription]' passed (0.001 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testDeleteFailureKeepsCurrentSelection]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testDeleteFailureKeepsCurrentSelection]' passed (0.002 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testDeleteTranscription]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testDeleteTranscription]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testDeleteYouTubeTranscriptionKeepsStoredAudioWhenRepoDeleteFails]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testDeleteYouTubeTranscriptionKeepsStoredAudioWhenRepoDeleteFails]' passed (0.001 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testDeleteYouTubeTranscriptionRemovesStoredAudioFile]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testDeleteYouTubeTranscriptionRemovesStoredAudioFile]' passed (0.028 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testHandleFileDropReturnsFalseWhenAlreadyTranscribing]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testHandleFileDropReturnsFalseWhenAlreadyTranscribing]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testHandleFileDropSkipsUnsupportedAndUsesSupportedProvider]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testHandleFileDropSkipsUnsupportedAndUsesSupportedProvider]' passed (0.322 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testInitialState]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testInitialState]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testLLMAvailableReflectsConfigState]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testLLMAvailableReflectsConfigState]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testLoadPersistedContentRefreshesCurrentTranscriptionFromDB]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testLoadPersistedContentRefreshesCurrentTranscriptionFromDB]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testLoadTranscriptionsBeforeConfigureIsNoOp]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testLoadTranscriptionsBeforeConfigureIsNoOp]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testLoadTranscriptionsRefreshesFromRepo]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testLoadTranscriptionsRefreshesFromRepo]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRenameCurrentTranscriptionIgnoresEmptyName]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRenameCurrentTranscriptionIgnoresEmptyName]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRenameCurrentTranscriptionTrimsWhitespace]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRenameCurrentTranscriptionTrimsWhitespace]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRenameCurrentTranscriptionUpdatesStateAndRepo]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRenameCurrentTranscriptionUpdatesStateAndRepo]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRenameSpeakerEmptySpeakersArrayIsNoOp]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRenameSpeakerEmptySpeakersArrayIsNoOp]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRenameSpeakerIgnoresEmptyLabel]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRenameSpeakerIgnoresEmptyLabel]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRenameSpeakerIgnoresUnknownId]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRenameSpeakerIgnoresUnknownId]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRenameSpeakerNoOpWithoutCurrentTranscription]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRenameSpeakerNoOpWithoutCurrentTranscription]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRenameSpeakerPersistsToRepo]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRenameSpeakerPersistsToRepo]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRenameSpeakerSameLabelIsNoOp]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRenameSpeakerSameLabelIsNoOp]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRenameSpeakerTrimsWhitespace]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRenameSpeakerTrimsWhitespace]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRenameSpeakerUpdatesInMemoryState]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRenameSpeakerUpdatesInMemoryState]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRetranscribeDoesNothingWhenFileIsMissing]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRetranscribeDoesNothingWhenFileIsMissing]' passed (0.106 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRetranscribeFailureLeavesOriginalIntact]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRetranscribeFailureLeavesOriginalIntact]' passed (0.320 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRetranscribePreservesMeetingSourceType]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRetranscribePreservesMeetingSourceType]' passed (0.322 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRetranscribeUpdatesOriginalRecordInPlace]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testRetranscribeUpdatesOriginalRecordInPlace]' passed (0.320 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testShowTabsFalseWhenNothingAvailable]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testShowTabsFalseWhenNothingAvailable]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testShowTabsTrueWhenHasConversations]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testShowTabsTrueWhenHasConversations]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testShowTabsTrueWhenLLMAvailable]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testShowTabsTrueWhenLLMAvailable]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testShowTabsTrueWhenSavedSummaryExists]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testShowTabsTrueWhenSavedSummaryExists]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testStartingNewTranscriptionCancelsInFlightRequest]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testStartingNewTranscriptionCancelsInFlightRequest]' passed (0.256 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testTranscribeFileBeforeConfigureIsNoOp]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testTranscribeFileBeforeConfigureIsNoOp]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testTranscribeFileClearsErrorMessage]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testTranscribeFileClearsErrorMessage]' passed (0.206 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testTranscribeFileErrorHandling]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testTranscribeFileErrorHandling]' passed (0.211 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testTranscribeFileProgressMessage]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testTranscribeFileProgressMessage]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testTranscribeFileUpdatesState]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testTranscribeFileUpdatesState]' passed (0.208 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testTranscribeURLIgnoresFailedDuplicates]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testTranscribeURLIgnoresFailedDuplicates]' passed (0.203 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testTranscribeURLInvalidInputNoOp]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testTranscribeURLInvalidInputNoOp]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testTranscribeURLMatchesDifferentURLFormats]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testTranscribeURLMatchesDifferentURLFormats]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testTranscribeURLProgressClearsPercentOnNonPercentPhase]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testTranscribeURLProgressClearsPercentOnNonPercentPhase]' passed (0.015 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testTranscribeURLProgressParsesDownloadPercent]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testTranscribeURLProgressParsesDownloadPercent]' passed (0.011 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testTranscribeURLProgressTracksPhaseHeadlineAndSourceKind]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testTranscribeURLProgressTracksPhaseHeadlineAndSourceKind]' passed (0.011 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testTranscribeURLProgressTracksTranscribingPercent]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testTranscribeURLProgressTracksTranscribingPercent]' passed (0.015 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testTranscribeURLShowsExistingWhenAlreadyTranscribed]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testTranscribeURLShowsExistingWhenAlreadyTranscribed]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testTranscribeURLUpdatesState]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testTranscribeURLUpdatesState]' passed (0.210 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testUpdateConversationStatusUpdatesShowTabs]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testUpdateConversationStatusUpdatesShowTabs]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testUpdateLLMAvailability]' started.
Test Case '-[MacParakeetTests.TranscriptionViewModelTests testUpdateLLMAvailability]' passed (0.000 seconds).
Test Suite 'TranscriptionViewModelTests' passed at 2026-04-08 00:28:54.821.
	 Executed 52 tests, with 0 failures (0 unexpected) in 2.883 (2.887) seconds
Test Suite 'MacParakeetPackageTests.xctest' passed at 2026-04-08 00:28:54.821.
	 Executed 52 tests, with 0 failures (0 unexpected) in 2.883 (2.887) seconds
Test Suite 'Selected tests' passed at 2026-04-08 00:28:54.821.
	 Executed 52 tests, with 0 failures (0 unexpected) in 2.883 (2.888) seconds
◇ Test run started.
↳ Testing Library Version: 1400
↳ Target Platform: arm64e-apple-macos14.0
✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized transcript timestamp rendering logic to consolidate duplicate functionality and improve code maintainability. Timestamp seeking and display behavior unified across different transcript view modes, including speaker-aware and non-speaker layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->