### PR TITLE
Refactor AppDelegate into a thin lifecycle shell with focused coordinators and regression hardening

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -33,13 +33,8 @@ final class AppEnvironment {
     let llmService: LLMService
     let runtimePreferences: AppRuntimePreferencesProtocol
 
-    init() throws {
-        // Ensure required runtime directories exist (db, dictations, temp).
-        try AppPaths.ensureDirectories()
-
-        // Database
-        let dbPath = AppPaths.databasePath
-        databaseManager = try DatabaseManager(path: dbPath)
+    init(databaseManager: DatabaseManager) throws {
+        self.databaseManager = databaseManager
 
         // Repositories
         dictationRepo = DictationRepository(dbQueue: databaseManager.dbQueue)
@@ -49,10 +44,6 @@ final class AppEnvironment {
         chatConversationRepo = ChatConversationRepository(dbQueue: databaseManager.dbQueue)
         promptRepo = PromptRepository(dbQueue: databaseManager.dbQueue)
         promptResultRepo = PromptResultRepository(dbQueue: databaseManager.dbQueue)
-
-        // One-time cleanup on launch
-        _ = try? dictationRepo.deleteEmpty()
-        try? dictationRepo.clearMissingAudioPaths()
 
         // Services
         sttRuntime = STTRuntime()

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -4,6 +4,11 @@ import MacParakeetViewModels
 
 @MainActor
 final class AppEnvironmentConfigurer {
+    private final class CoordinatorRefs {
+        weak var dictation: DictationFlowCoordinator?
+        weak var meeting: MeetingRecordingFlowCoordinator?
+    }
+
     struct Runtime {
         let dictationFlowCoordinator: DictationFlowCoordinator
         let meetingRecordingFlowCoordinator: MeetingRecordingFlowCoordinator
@@ -171,8 +176,7 @@ final class AppEnvironmentConfigurer {
             callbacks.onMenuBarIconUpdate()
         }
 
-        var dictationCoordinatorRef: DictationFlowCoordinator?
-        var meetingCoordinatorRef: MeetingRecordingFlowCoordinator?
+        let coordinatorRefs = CoordinatorRefs()
 
         let dictationCoordinator = DictationFlowCoordinator(
             dictationService: env.dictationService,
@@ -181,13 +185,13 @@ final class AppEnvironmentConfigurer {
             dictationRepo: env.dictationRepo,
             settingsViewModel: settingsViewModel,
             shouldSuppressIdlePill: {
-                meetingCoordinatorRef?.isMeetingRecordingActive == true
+                coordinatorRefs.meeting?.isMeetingRecordingActive == true
             },
             onMenuBarIconUpdate: { _ in callbacks.onMenuBarIconUpdate() },
             onHistoryReload: { [weak self] in self?.historyViewModel.loadDictations() },
             onPresentEntitlementsAlert: callbacks.onPresentEntitlementsAlert
         )
-        dictationCoordinatorRef = dictationCoordinator
+        coordinatorRefs.dictation = dictationCoordinator
 
         let meetingCoordinator = MeetingRecordingFlowCoordinator(
             meetingRecordingService: env.meetingRecordingService,
@@ -203,39 +207,39 @@ final class AppEnvironmentConfigurer {
                 callbacks.onOpenMainWindow()
             },
             onRecordingBegan: {
-                dictationCoordinatorRef?.hideIdlePill()
+                coordinatorRefs.dictation?.hideIdlePill()
             },
             onFlowReturnedToIdle: {
                 callbacks.onMenuBarIconUpdate()
-                guard dictationCoordinatorRef?.isDictationActive != true else { return }
-                dictationCoordinatorRef?.showIdlePill()
+                guard coordinatorRefs.dictation?.isDictationActive != true else { return }
+                coordinatorRefs.dictation?.showIdlePill()
             }
         )
-        meetingCoordinatorRef = meetingCoordinator
+        coordinatorRefs.meeting = meetingCoordinator
 
         let hotkeyCoordinator = AppHotkeyCoordinator(
             settingsViewModel: settingsViewModel,
             onStartDictation: { mode in
-                dictationCoordinatorRef?.startDictation(mode: mode, trigger: .hotkey)
+                coordinatorRefs.dictation?.startDictation(mode: mode, trigger: .hotkey)
             },
             onStopDictation: {
-                dictationCoordinatorRef?.stopDictation()
+                coordinatorRefs.dictation?.stopDictation()
             },
             onCancelDictation: {
-                dictationCoordinatorRef?.cancelDictation(reason: .escape)
+                coordinatorRefs.dictation?.cancelDictation(reason: .escape)
             },
             onDiscardRecording: { showReadyPill in
-                dictationCoordinatorRef?.discardProvisionalRecording(showReadyPill: showReadyPill)
+                coordinatorRefs.dictation?.discardProvisionalRecording(showReadyPill: showReadyPill)
             },
             onReadyForSecondTap: {
-                dictationCoordinatorRef?.showReadyPill()
+                coordinatorRefs.dictation?.showReadyPill()
             },
             onEscapeWhileIdle: {
-                dictationCoordinatorRef?.dismissOverlayIfError()
+                coordinatorRefs.dictation?.dismissOverlayIfError()
             },
             onToggleMeetingRecording: callbacks.onToggleMeetingRecordingFromHotkey,
             onPrimaryHotkeyManagerChanged: { manager in
-                dictationCoordinatorRef?.hotkeyManager = manager
+                coordinatorRefs.dictation?.hotkeyManager = manager
             },
             onAnyHotkeyEnabled: callbacks.onHotkeyBecameAvailable,
             onHotkeyUnavailable: callbacks.onHotkeyUnavailable

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -1,0 +1,262 @@
+import Foundation
+import MacParakeetCore
+import MacParakeetViewModels
+
+@MainActor
+final class AppEnvironmentConfigurer {
+    struct Runtime {
+        let dictationFlowCoordinator: DictationFlowCoordinator
+        let meetingRecordingFlowCoordinator: MeetingRecordingFlowCoordinator
+        let hotkeyCoordinator: AppHotkeyCoordinator
+    }
+
+    struct Callbacks {
+        let onMenuBarIconUpdate: () -> Void
+        let onPresentEntitlementsAlert: (Error) -> Void
+        let onOpenMainWindow: () -> Void
+        let onToggleMeetingRecordingFromHotkey: () -> Void
+        let onHotkeyBecameAvailable: () -> Void
+        let onHotkeyUnavailable: () -> Void
+    }
+
+    private let transcriptionViewModel: TranscriptionViewModel
+    private let historyViewModel: DictationHistoryViewModel
+    private let settingsViewModel: SettingsViewModel
+    private let customWordsViewModel: CustomWordsViewModel
+    private let textSnippetsViewModel: TextSnippetsViewModel
+    private let libraryViewModel: TranscriptionLibraryViewModel
+    private let meetingsViewModel: TranscriptionLibraryViewModel
+    private let llmSettingsViewModel: LLMSettingsViewModel
+    private let chatViewModel: TranscriptChatViewModel
+    private let promptResultsViewModel: PromptResultsViewModel
+    private let promptsViewModel: PromptsViewModel
+    private let mainWindowState: MainWindowState
+
+    init(
+        transcriptionViewModel: TranscriptionViewModel,
+        historyViewModel: DictationHistoryViewModel,
+        settingsViewModel: SettingsViewModel,
+        customWordsViewModel: CustomWordsViewModel,
+        textSnippetsViewModel: TextSnippetsViewModel,
+        libraryViewModel: TranscriptionLibraryViewModel,
+        meetingsViewModel: TranscriptionLibraryViewModel,
+        llmSettingsViewModel: LLMSettingsViewModel,
+        chatViewModel: TranscriptChatViewModel,
+        promptResultsViewModel: PromptResultsViewModel,
+        promptsViewModel: PromptsViewModel,
+        mainWindowState: MainWindowState
+    ) {
+        self.transcriptionViewModel = transcriptionViewModel
+        self.historyViewModel = historyViewModel
+        self.settingsViewModel = settingsViewModel
+        self.customWordsViewModel = customWordsViewModel
+        self.textSnippetsViewModel = textSnippetsViewModel
+        self.libraryViewModel = libraryViewModel
+        self.meetingsViewModel = meetingsViewModel
+        self.llmSettingsViewModel = llmSettingsViewModel
+        self.chatViewModel = chatViewModel
+        self.promptResultsViewModel = promptResultsViewModel
+        self.promptsViewModel = promptsViewModel
+        self.mainWindowState = mainWindowState
+    }
+
+    func configure(environment env: AppEnvironment, callbacks: Callbacks) -> Runtime {
+        Task {
+            // Only bootstrap trial if onboarding is already completed (returning user).
+            // For new users, trial starts at onboarding completion, not during setup.
+            let onboardingDone = UserDefaults.standard.string(forKey: OnboardingViewModel.onboardingCompletedKey) != nil
+            if onboardingDone {
+                await env.entitlementsService.bootstrapTrialIfNeeded()
+            }
+            await env.entitlementsService.refreshValidationIfNeeded()
+        }
+
+        let hasLLMConfig = (try? env.llmConfigStore.loadConfig()) != nil
+
+        transcriptionViewModel.configure(
+            transcriptionService: env.transcriptionService,
+            transcriptionRepo: env.transcriptionRepo,
+            llmService: hasLLMConfig ? env.llmService : nil,
+            promptResultRepo: env.promptResultRepo,
+            promptResultsViewModel: promptResultsViewModel
+        )
+        historyViewModel.configure(dictationRepo: env.dictationRepo)
+        libraryViewModel.configure(transcriptionRepo: env.transcriptionRepo)
+        meetingsViewModel.configure(transcriptionRepo: env.transcriptionRepo)
+        settingsViewModel.configure(
+            permissionService: env.permissionService,
+            dictationRepo: env.dictationRepo,
+            transcriptionRepo: env.transcriptionRepo,
+            entitlementsService: env.entitlementsService,
+            launchAtLoginService: env.launchAtLoginService,
+            checkoutURL: env.checkoutURL,
+            customWordRepo: env.customWordRepo,
+            snippetRepo: env.snippetRepo,
+            sttClient: env.sttScheduler
+        )
+        customWordsViewModel.configure(repo: env.customWordRepo)
+        textSnippetsViewModel.configure(repo: env.snippetRepo)
+        promptsViewModel.configure(repo: env.promptRepo)
+        llmSettingsViewModel.configure(
+            configStore: env.llmConfigStore,
+            llmClient: env.llmClient
+        )
+
+        settingsViewModel.onDictationsCleared = { [weak self] in
+            self?.historyViewModel.loadDictations()
+        }
+
+        llmSettingsViewModel.onConfigurationChanged = { [weak self] in
+            self?.refreshLLMAvailability(in: env)
+        }
+
+        chatViewModel.configure(
+            llmService: hasLLMConfig ? env.llmService : nil,
+            transcriptText: "",
+            transcriptionRepo: env.transcriptionRepo,
+            configStore: env.llmConfigStore,
+            conversationRepo: env.chatConversationRepo
+        )
+
+        promptResultsViewModel.configure(
+            llmService: hasLLMConfig ? env.llmService : nil,
+            promptRepo: env.promptRepo,
+            promptResultRepo: env.promptResultRepo,
+            transcriptionRepo: env.transcriptionRepo,
+            configStore: env.llmConfigStore
+        )
+
+        chatViewModel.onConversationsChanged = { [weak self] transcriptionID, hasConversations in
+            self?.transcriptionViewModel.updateConversationStatus(
+                id: transcriptionID,
+                hasConversations: hasConversations
+            )
+        }
+
+        chatViewModel.onModelChanged = { [weak self] in
+            self?.promptResultsViewModel.refreshModelInfo()
+        }
+
+        promptResultsViewModel.onModelChanged = { [weak self] in
+            self?.chatViewModel.refreshModelInfo()
+        }
+
+        promptResultsViewModel.onPromptResultsChanged = { [weak self] transcriptionID, hasPromptResults in
+            guard self?.transcriptionViewModel.currentTranscription?.id == transcriptionID else { return }
+            self?.transcriptionViewModel.hasPromptResultTabs = hasPromptResults
+        }
+
+        promptResultsViewModel.onLegacySummaryChanged = { [weak self] transcriptionID, summary in
+            self?.transcriptionViewModel.updateLegacySummary(id: transcriptionID, summary: summary)
+        }
+
+        promptResultsViewModel.onGenerationCompleted = { [weak self] generationID, promptResultID in
+            self?.transcriptionViewModel.handleGenerationCompleted(generationID, promptResultID: promptResultID)
+        }
+
+        promptResultsViewModel.onDeletedPromptResult = { [weak self] promptResultID in
+            self?.transcriptionViewModel.handlePromptResultDeleted(promptResultID)
+        }
+
+        promptResultsViewModel.shouldMarkPromptResultUnread = { [weak self] promptResultID in
+            guard let self else { return true }
+            if case .result(let id) = self.transcriptionViewModel.selectedTab,
+               id == promptResultID {
+                return false
+            }
+            return true
+        }
+
+        transcriptionViewModel.onTranscribingChanged = { _ in
+            callbacks.onMenuBarIconUpdate()
+        }
+
+        var dictationCoordinatorRef: DictationFlowCoordinator?
+        var meetingCoordinatorRef: MeetingRecordingFlowCoordinator?
+
+        let dictationCoordinator = DictationFlowCoordinator(
+            dictationService: env.dictationService,
+            clipboardService: env.clipboardService,
+            entitlementsService: env.entitlementsService,
+            dictationRepo: env.dictationRepo,
+            settingsViewModel: settingsViewModel,
+            shouldSuppressIdlePill: {
+                meetingCoordinatorRef?.isMeetingRecordingActive == true
+            },
+            onMenuBarIconUpdate: { _ in callbacks.onMenuBarIconUpdate() },
+            onHistoryReload: { [weak self] in self?.historyViewModel.loadDictations() },
+            onPresentEntitlementsAlert: callbacks.onPresentEntitlementsAlert
+        )
+        dictationCoordinatorRef = dictationCoordinator
+
+        let meetingCoordinator = MeetingRecordingFlowCoordinator(
+            meetingRecordingService: env.meetingRecordingService,
+            transcriptionService: env.transcriptionService,
+            permissionService: env.permissionService,
+            onMenuBarIconUpdate: { _ in callbacks.onMenuBarIconUpdate() },
+            onTranscriptionReady: { [weak self] transcription in
+                guard let self else { return }
+                self.transcriptionViewModel.presentCompletedTranscription(transcription, autoSave: true)
+                self.libraryViewModel.loadTranscriptions()
+                self.meetingsViewModel.loadTranscriptions()
+                self.mainWindowState.navigateToTranscription(from: .meetings)
+                callbacks.onOpenMainWindow()
+            },
+            onRecordingBegan: {
+                dictationCoordinatorRef?.hideIdlePill()
+            },
+            onFlowReturnedToIdle: {
+                callbacks.onMenuBarIconUpdate()
+                guard dictationCoordinatorRef?.isDictationActive != true else { return }
+                dictationCoordinatorRef?.showIdlePill()
+            }
+        )
+        meetingCoordinatorRef = meetingCoordinator
+
+        let hotkeyCoordinator = AppHotkeyCoordinator(
+            settingsViewModel: settingsViewModel,
+            onStartDictation: { mode in
+                dictationCoordinatorRef?.startDictation(mode: mode, trigger: .hotkey)
+            },
+            onStopDictation: {
+                dictationCoordinatorRef?.stopDictation()
+            },
+            onCancelDictation: {
+                dictationCoordinatorRef?.cancelDictation(reason: .escape)
+            },
+            onDiscardRecording: { showReadyPill in
+                dictationCoordinatorRef?.discardProvisionalRecording(showReadyPill: showReadyPill)
+            },
+            onReadyForSecondTap: {
+                dictationCoordinatorRef?.showReadyPill()
+            },
+            onEscapeWhileIdle: {
+                dictationCoordinatorRef?.dismissOverlayIfError()
+            },
+            onToggleMeetingRecording: callbacks.onToggleMeetingRecordingFromHotkey,
+            onPrimaryHotkeyManagerChanged: { manager in
+                dictationCoordinatorRef?.hotkeyManager = manager
+            },
+            onAnyHotkeyEnabled: callbacks.onHotkeyBecameAvailable,
+            onHotkeyUnavailable: callbacks.onHotkeyUnavailable
+        )
+
+        hotkeyCoordinator.setupPrimaryHotkey()
+        hotkeyCoordinator.setupMeetingHotkey()
+        dictationCoordinator.showIdlePill()
+
+        return Runtime(
+            dictationFlowCoordinator: dictationCoordinator,
+            meetingRecordingFlowCoordinator: meetingCoordinator,
+            hotkeyCoordinator: hotkeyCoordinator
+        )
+    }
+
+    func refreshLLMAvailability(in env: AppEnvironment) {
+        let hasConfig = (try? env.llmConfigStore.loadConfig()) != nil
+        let service: LLMService? = hasConfig ? env.llmService : nil
+        transcriptionViewModel.updateLLMAvailability(hasConfig, llmService: service)
+        chatViewModel.updateLLMService(service)
+        promptResultsViewModel.updateLLMService(service)
+    }
+}

--- a/Sources/MacParakeet/App/AppSettingsObserverCoordinator.swift
+++ b/Sources/MacParakeet/App/AppSettingsObserverCoordinator.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+@MainActor
+final class AppSettingsObserverCoordinator {
+    private let notificationCenter: NotificationCenter
+    private let onOpenOnboarding: () -> Void
+    private let onOpenSettings: () -> Void
+    private let onHotkeyTriggerChanged: () -> Void
+    private let onMeetingHotkeyTriggerChanged: () -> Void
+    private let onMenuBarOnlyModeChanged: () -> Void
+    private let onShowIdlePillChanged: () -> Void
+
+    private var onboardingObserver: Any?
+    private var settingsObserver: Any?
+    private var hotkeyTriggerObserver: Any?
+    private var meetingHotkeyTriggerObserver: Any?
+    private var menuBarOnlyModeObserver: Any?
+    private var showIdlePillObserver: Any?
+
+    init(
+        notificationCenter: NotificationCenter = .default,
+        onOpenOnboarding: @escaping () -> Void,
+        onOpenSettings: @escaping () -> Void,
+        onHotkeyTriggerChanged: @escaping () -> Void,
+        onMeetingHotkeyTriggerChanged: @escaping () -> Void,
+        onMenuBarOnlyModeChanged: @escaping () -> Void,
+        onShowIdlePillChanged: @escaping () -> Void
+    ) {
+        self.notificationCenter = notificationCenter
+        self.onOpenOnboarding = onOpenOnboarding
+        self.onOpenSettings = onOpenSettings
+        self.onHotkeyTriggerChanged = onHotkeyTriggerChanged
+        self.onMeetingHotkeyTriggerChanged = onMeetingHotkeyTriggerChanged
+        self.onMenuBarOnlyModeChanged = onMenuBarOnlyModeChanged
+        self.onShowIdlePillChanged = onShowIdlePillChanged
+    }
+
+    func startObserving() {
+        stopObserving()
+
+        onboardingObserver = notificationCenter.addObserver(
+            forName: .macParakeetOpenOnboarding,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.onOpenOnboarding()
+            }
+        }
+
+        settingsObserver = notificationCenter.addObserver(
+            forName: .macParakeetOpenSettings,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.onOpenSettings()
+            }
+        }
+
+        hotkeyTriggerObserver = notificationCenter.addObserver(
+            forName: .macParakeetHotkeyTriggerDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.onHotkeyTriggerChanged()
+            }
+        }
+
+        meetingHotkeyTriggerObserver = notificationCenter.addObserver(
+            forName: .macParakeetMeetingHotkeyTriggerDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.onMeetingHotkeyTriggerChanged()
+            }
+        }
+
+        menuBarOnlyModeObserver = notificationCenter.addObserver(
+            forName: .macParakeetMenuBarOnlyModeDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.onMenuBarOnlyModeChanged()
+            }
+        }
+
+        showIdlePillObserver = notificationCenter.addObserver(
+            forName: .macParakeetShowIdlePillDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.onShowIdlePillChanged()
+            }
+        }
+    }
+
+    func stopObserving() {
+        if let onboardingObserver {
+            notificationCenter.removeObserver(onboardingObserver)
+            self.onboardingObserver = nil
+        }
+        if let settingsObserver {
+            notificationCenter.removeObserver(settingsObserver)
+            self.settingsObserver = nil
+        }
+        if let hotkeyTriggerObserver {
+            notificationCenter.removeObserver(hotkeyTriggerObserver)
+            self.hotkeyTriggerObserver = nil
+        }
+        if let meetingHotkeyTriggerObserver {
+            notificationCenter.removeObserver(meetingHotkeyTriggerObserver)
+            self.meetingHotkeyTriggerObserver = nil
+        }
+        if let menuBarOnlyModeObserver {
+            notificationCenter.removeObserver(menuBarOnlyModeObserver)
+            self.menuBarOnlyModeObserver = nil
+        }
+        if let showIdlePillObserver {
+            notificationCenter.removeObserver(showIdlePillObserver)
+            self.showIdlePillObserver = nil
+        }
+    }
+}

--- a/Sources/MacParakeet/App/AppStartupBootstrapper.swift
+++ b/Sources/MacParakeet/App/AppStartupBootstrapper.swift
@@ -1,0 +1,21 @@
+import Foundation
+import MacParakeetCore
+
+@MainActor
+final class AppStartupBootstrapper {
+    func bootstrapEnvironment() async throws -> AppEnvironment {
+        let databaseManager = try await Task.detached(priority: .userInitiated) {
+            try AppPaths.ensureDirectories()
+            let manager = try DatabaseManager(path: AppPaths.databasePath)
+
+            // Keep one-time launch cleanup off the main actor.
+            let dictationRepo = DictationRepository(dbQueue: manager.dbQueue)
+            _ = try? dictationRepo.deleteEmpty()
+            try? dictationRepo.clearMissingAudioPaths()
+
+            return manager
+        }.value
+
+        return try AppEnvironment(databaseManager: databaseManager)
+    }
+}

--- a/Sources/MacParakeet/App/AppStartupBootstrapper.swift
+++ b/Sources/MacParakeet/App/AppStartupBootstrapper.swift
@@ -4,18 +4,30 @@ import MacParakeetCore
 @MainActor
 final class AppStartupBootstrapper {
     func bootstrapEnvironment() async throws -> AppEnvironment {
-        let databaseManager = try await Task.detached(priority: .userInitiated) {
+        let bootstrapTask = Task.detached(priority: .userInitiated) {
+            try Task.checkCancellation()
             try AppPaths.ensureDirectories()
+            try Task.checkCancellation()
+
             let manager = try DatabaseManager(path: AppPaths.databasePath)
+            try Task.checkCancellation()
 
             // Keep one-time launch cleanup off the main actor.
             let dictationRepo = DictationRepository(dbQueue: manager.dbQueue)
             _ = try? dictationRepo.deleteEmpty()
             try? dictationRepo.clearMissingAudioPaths()
 
+            try Task.checkCancellation()
             return manager
-        }.value
+        }
 
+        let databaseManager = try await withTaskCancellationHandler {
+            try await bootstrapTask.value
+        } onCancel: {
+            bootstrapTask.cancel()
+        }
+
+        try Task.checkCancellation()
         return try AppEnvironment(databaseManager: databaseManager)
     }
 }

--- a/Sources/MacParakeet/App/AppWindowCoordinator.swift
+++ b/Sources/MacParakeet/App/AppWindowCoordinator.swift
@@ -1,0 +1,224 @@
+import AppKit
+import Sparkle
+import SwiftUI
+import MacParakeetCore
+import MacParakeetViewModels
+
+@MainActor
+final class AppWindowCoordinator: NSObject, NSWindowDelegate {
+    private let mainWindowState: MainWindowState
+    private let transcriptionViewModel: TranscriptionViewModel
+    private let historyViewModel: DictationHistoryViewModel
+    private let settingsViewModel: SettingsViewModel
+    private let llmSettingsViewModel: LLMSettingsViewModel
+    private let chatViewModel: TranscriptChatViewModel
+    private let promptResultsViewModel: PromptResultsViewModel
+    private let promptsViewModel: PromptsViewModel
+    private let customWordsViewModel: CustomWordsViewModel
+    private let textSnippetsViewModel: TextSnippetsViewModel
+    private let feedbackViewModel: FeedbackViewModel
+    private let discoverViewModel: DiscoverViewModel
+    private let libraryViewModel: TranscriptionLibraryViewModel
+    private let meetingsViewModel: TranscriptionLibraryViewModel
+    private let updaterController: SPUStandardUpdaterController
+    private let onRecordMeeting: () -> Void
+    private let onQuit: () -> Void
+    private let isOnboardingVisible: () -> Bool
+
+    private var mainWindow: NSWindow?
+
+    init(
+        mainWindowState: MainWindowState,
+        transcriptionViewModel: TranscriptionViewModel,
+        historyViewModel: DictationHistoryViewModel,
+        settingsViewModel: SettingsViewModel,
+        llmSettingsViewModel: LLMSettingsViewModel,
+        chatViewModel: TranscriptChatViewModel,
+        promptResultsViewModel: PromptResultsViewModel,
+        promptsViewModel: PromptsViewModel,
+        customWordsViewModel: CustomWordsViewModel,
+        textSnippetsViewModel: TextSnippetsViewModel,
+        feedbackViewModel: FeedbackViewModel,
+        discoverViewModel: DiscoverViewModel,
+        libraryViewModel: TranscriptionLibraryViewModel,
+        meetingsViewModel: TranscriptionLibraryViewModel,
+        updaterController: SPUStandardUpdaterController,
+        onRecordMeeting: @escaping () -> Void,
+        onQuit: @escaping () -> Void,
+        isOnboardingVisible: @escaping () -> Bool
+    ) {
+        self.mainWindowState = mainWindowState
+        self.transcriptionViewModel = transcriptionViewModel
+        self.historyViewModel = historyViewModel
+        self.settingsViewModel = settingsViewModel
+        self.llmSettingsViewModel = llmSettingsViewModel
+        self.chatViewModel = chatViewModel
+        self.promptResultsViewModel = promptResultsViewModel
+        self.promptsViewModel = promptsViewModel
+        self.customWordsViewModel = customWordsViewModel
+        self.textSnippetsViewModel = textSnippetsViewModel
+        self.feedbackViewModel = feedbackViewModel
+        self.discoverViewModel = discoverViewModel
+        self.libraryViewModel = libraryViewModel
+        self.meetingsViewModel = meetingsViewModel
+        self.updaterController = updaterController
+        self.onRecordMeeting = onRecordMeeting
+        self.onQuit = onQuit
+        self.isOnboardingVisible = isOnboardingVisible
+    }
+
+    var hasVisiblePrimaryWindow: Bool {
+        (mainWindow?.isVisible ?? false) || isOnboardingVisible()
+    }
+
+    func openMainWindow() {
+        if mainWindow == nil {
+            createMainWindow()
+        }
+        mainWindow?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func openMainWindowToSettings() {
+        mainWindowState.selectedItem = .settings
+        openMainWindow()
+    }
+
+    func handleAppReopen() -> Bool {
+        if hasVisiblePrimaryWindow {
+            NSApp.activate(ignoringOtherApps: true)
+        } else {
+            openMainWindow()
+        }
+        return true
+    }
+
+    func applyActivationPolicyFromSettings() {
+        let menuBarOnly = settingsViewModel.menuBarOnlyMode
+        let wasMainWindowVisible = mainWindow?.isVisible ?? false
+        let mode: NSApplication.ActivationPolicy = menuBarOnly ? .accessory : .regular
+        NSApp.setActivationPolicy(mode)
+
+        // macOS hides all windows when switching to .accessory policy.
+        // Re-show the main window so the user isn't surprised by it disappearing.
+        if menuBarOnly && wasMainWindowVisible {
+            mainWindow?.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+        }
+    }
+
+    func makeDockMenu() -> NSMenu {
+        let menu = NSMenu()
+
+        let openItem = NSMenuItem(
+            title: "Open MacParakeet",
+            action: #selector(dockOpenMainWindow),
+            keyEquivalent: ""
+        )
+        openItem.target = self
+        menu.addItem(openItem)
+
+        let settingsItem = NSMenuItem(
+            title: "Settings...",
+            action: #selector(dockOpenSettings),
+            keyEquivalent: ""
+        )
+        settingsItem.target = self
+        menu.addItem(settingsItem)
+
+        menu.addItem(NSMenuItem.separator())
+
+        let quitItem = NSMenuItem(
+            title: "Quit MacParakeet",
+            action: #selector(dockQuit),
+            keyEquivalent: ""
+        )
+        quitItem.target = self
+        menu.addItem(quitItem)
+
+        return menu
+    }
+
+    @objc private func dockOpenMainWindow() {
+        openMainWindow()
+    }
+
+    @objc private func dockOpenSettings() {
+        openMainWindowToSettings()
+    }
+
+    @objc private func dockQuit() {
+        onQuit()
+    }
+
+    private func createMainWindow() {
+        let contentView = MainWindowView(
+            state: mainWindowState,
+            transcriptionViewModel: transcriptionViewModel,
+            historyViewModel: historyViewModel,
+            settingsViewModel: settingsViewModel,
+            llmSettingsViewModel: llmSettingsViewModel,
+            chatViewModel: chatViewModel,
+            promptResultsViewModel: promptResultsViewModel,
+            promptsViewModel: promptsViewModel,
+            customWordsViewModel: customWordsViewModel,
+            textSnippetsViewModel: textSnippetsViewModel,
+            feedbackViewModel: feedbackViewModel,
+            discoverViewModel: discoverViewModel,
+            libraryViewModel: libraryViewModel,
+            meetingsViewModel: meetingsViewModel,
+            updater: updaterController.updater,
+            onRecordMeeting: onRecordMeeting
+        )
+
+        let window = NSWindow(
+            contentRect: NSRect(
+                x: 0,
+                y: 0,
+                width: DesignSystem.Layout.sidebarMinWidth + DesignSystem.Layout.contentMinWidth,
+                height: DesignSystem.Layout.windowMinHeight
+            ),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "MacParakeet"
+        window.center()
+        window.setFrameAutosaveName("MainWindow")
+        window.minSize = NSSize(
+            width: DesignSystem.Layout.sidebarMinWidth + DesignSystem.Layout.contentMinWidth,
+            height: DesignSystem.Layout.windowMinHeight
+        )
+        window.titlebarAppearsTransparent = true
+        window.contentView = NSHostingView(rootView: contentView)
+        window.delegate = self
+        window.isReleasedWhenClosed = false
+
+        mainWindow = window
+    }
+
+    func windowDidBecomeMain(_ notification: Notification) {
+        guard let window = notification.object as? NSWindow, window === mainWindow else { return }
+        showDockIconIfNeeded()
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        guard let window = notification.object as? NSWindow, window === mainWindow else { return }
+        // Delay slightly so macOS finishes closing the window before we check visibility.
+        DispatchQueue.main.async { [weak self] in
+            self?.hideDockIconIfNeeded()
+        }
+    }
+
+    private func showDockIconIfNeeded() {
+        guard settingsViewModel.menuBarOnlyMode else { return }
+        NSApp.setActivationPolicy(.regular)
+    }
+
+    private func hideDockIconIfNeeded() {
+        guard settingsViewModel.menuBarOnlyMode else { return }
+        // Only hide if no primary windows are visible.
+        guard !hasVisiblePrimaryWindow else { return }
+        NSApp.setActivationPolicy(.accessory)
+    }
+}

--- a/Sources/MacParakeet/App/AppWindowCoordinator.swift
+++ b/Sources/MacParakeet/App/AppWindowCoordinator.swift
@@ -205,7 +205,7 @@ final class AppWindowCoordinator: NSObject, NSWindowDelegate {
     func windowWillClose(_ notification: Notification) {
         guard let window = notification.object as? NSWindow, window === mainWindow else { return }
         // Delay slightly so macOS finishes closing the window before we check visibility.
-        DispatchQueue.main.async { [weak self] in
+        Task { @MainActor [weak self] in
             self?.hideDockIconIfNeeded()
         }
     }

--- a/Sources/MacParakeet/App/MenuBarCoordinator.swift
+++ b/Sources/MacParakeet/App/MenuBarCoordinator.swift
@@ -1,0 +1,376 @@
+import AppKit
+import Sparkle
+import UniformTypeIdentifiers
+import MacParakeetCore
+import MacParakeetViewModels
+
+@MainActor
+final class MenuBarCoordinator: NSObject, NSMenuDelegate {
+    private let updaterController: SPUStandardUpdaterController
+    private let transcriptionViewModel: TranscriptionViewModel
+    private let youtubeInputController: YouTubeInputPanelController
+    private let environmentProvider: () -> AppEnvironment?
+    private let hotkeyMenuTitleProvider: () -> String
+    private let meetingHotkeyTriggerProvider: () -> HotkeyTrigger
+    private let meetingRecordingActiveProvider: () -> Bool
+    private let onOpenMainWindow: () -> Void
+    private let onOpenSettings: () -> Void
+    private let onToggleMeetingRecording: () -> Void
+    private let onQuit: () -> Void
+    private let onShowAboutPanel: () -> Void
+
+    private var statusItem: NSStatusItem?
+    private var pasteLastMenuItem: NSMenuItem?
+    private var recentDictationsMenuItem: NSMenuItem?
+    private var recordMeetingMenuItem: NSMenuItem?
+    private var hotkeyMenuItem: NSMenuItem?
+
+    init(
+        updaterController: SPUStandardUpdaterController,
+        transcriptionViewModel: TranscriptionViewModel,
+        youtubeInputController: YouTubeInputPanelController,
+        environmentProvider: @escaping () -> AppEnvironment?,
+        hotkeyMenuTitleProvider: @escaping () -> String,
+        meetingHotkeyTriggerProvider: @escaping () -> HotkeyTrigger,
+        meetingRecordingActiveProvider: @escaping () -> Bool,
+        onOpenMainWindow: @escaping () -> Void,
+        onOpenSettings: @escaping () -> Void,
+        onToggleMeetingRecording: @escaping () -> Void,
+        onQuit: @escaping () -> Void,
+        onShowAboutPanel: @escaping () -> Void
+    ) {
+        self.updaterController = updaterController
+        self.transcriptionViewModel = transcriptionViewModel
+        self.youtubeInputController = youtubeInputController
+        self.environmentProvider = environmentProvider
+        self.hotkeyMenuTitleProvider = hotkeyMenuTitleProvider
+        self.meetingHotkeyTriggerProvider = meetingHotkeyTriggerProvider
+        self.meetingRecordingActiveProvider = meetingRecordingActiveProvider
+        self.onOpenMainWindow = onOpenMainWindow
+        self.onOpenSettings = onOpenSettings
+        self.onToggleMeetingRecording = onToggleMeetingRecording
+        self.onQuit = onQuit
+        self.onShowAboutPanel = onShowAboutPanel
+    }
+
+    func setupMainMenu() {
+        let mainMenu = NSMenu()
+
+        let appMenuItem = NSMenuItem()
+        let appMenu = NSMenu()
+
+        let aboutItem = NSMenuItem(
+            title: "About MacParakeet",
+            action: #selector(showAboutPanel),
+            keyEquivalent: ""
+        )
+        aboutItem.target = self
+        appMenu.addItem(aboutItem)
+        appMenu.addItem(NSMenuItem.separator())
+
+        let checkForUpdatesItem = NSMenuItem(
+            title: "Check for Updates...",
+            action: #selector(SPUStandardUpdaterController.checkForUpdates(_:)),
+            keyEquivalent: ""
+        )
+        checkForUpdatesItem.target = updaterController
+        appMenu.addItem(checkForUpdatesItem)
+        appMenu.addItem(NSMenuItem.separator())
+
+        let quitItem = NSMenuItem(
+            title: "Quit MacParakeet",
+            action: #selector(quitApp),
+            keyEquivalent: "q"
+        )
+        quitItem.target = self
+        appMenu.addItem(quitItem)
+
+        appMenuItem.submenu = appMenu
+        mainMenu.addItem(appMenuItem)
+
+        let editMenuItem = NSMenuItem()
+        let editMenu = NSMenu(title: "Edit")
+        editMenu.addItem(NSMenuItem(title: "Undo", action: Selector(("undo:")), keyEquivalent: "z"))
+        editMenu.addItem(NSMenuItem(title: "Redo", action: Selector(("redo:")), keyEquivalent: "Z"))
+        editMenu.addItem(NSMenuItem.separator())
+        editMenu.addItem(NSMenuItem(title: "Cut", action: #selector(NSText.cut(_:)), keyEquivalent: "x"))
+        editMenu.addItem(NSMenuItem(title: "Copy", action: #selector(NSText.copy(_:)), keyEquivalent: "c"))
+        editMenu.addItem(NSMenuItem(title: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v"))
+        editMenu.addItem(NSMenuItem(title: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a"))
+        editMenuItem.submenu = editMenu
+        mainMenu.addItem(editMenuItem)
+
+        NSApp.mainMenu = mainMenu
+    }
+
+    func setupMenuBar() {
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+
+        guard let statusItem,
+              let button = statusItem.button else { return }
+
+        button.image = BreathWaveIcon.menuBarIcon(pointSize: 18)
+
+        let dropView = MenuBarDropView(frame: button.bounds)
+        dropView.onDrop = { [weak self] url in
+            Task { @MainActor in
+                self?.handleDroppedFile(url)
+            }
+        }
+        button.addSubview(dropView)
+
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+        menu.delegate = self
+
+        let openItem = NSMenuItem(
+            title: "Open MacParakeet",
+            action: #selector(openMainWindow),
+            keyEquivalent: "o"
+        )
+        openItem.target = self
+        menu.addItem(openItem)
+
+        menu.addItem(NSMenuItem.separator())
+
+        let pasteItem = NSMenuItem(
+            title: "Paste Last Dictation",
+            action: #selector(pasteLastDictation),
+            keyEquivalent: ""
+        )
+        pasteItem.isEnabled = false
+        pasteItem.target = self
+        menu.addItem(pasteItem)
+        pasteLastMenuItem = pasteItem
+
+        let recentItem = NSMenuItem(
+            title: "Recent Dictations",
+            action: nil,
+            keyEquivalent: ""
+        )
+        recentItem.submenu = NSMenu()
+        recentItem.isHidden = true
+        menu.addItem(recentItem)
+        recentDictationsMenuItem = recentItem
+
+        menu.addItem(NSMenuItem.separator())
+
+        let transcribeFileItem = NSMenuItem(
+            title: "Transcribe File...",
+            action: #selector(transcribeFileFromMenu),
+            keyEquivalent: ""
+        )
+        transcribeFileItem.target = self
+        menu.addItem(transcribeFileItem)
+
+        let transcribeYouTubeItem = NSMenuItem(
+            title: "Transcribe from YouTube...",
+            action: #selector(transcribeFromYouTubeMenu),
+            keyEquivalent: ""
+        )
+        transcribeYouTubeItem.target = self
+        menu.addItem(transcribeYouTubeItem)
+
+        let recordMeetingItem = NSMenuItem(
+            title: "Record Meeting",
+            action: #selector(toggleMeetingRecordingFromMenu),
+            keyEquivalent: ""
+        )
+        recordMeetingItem.target = self
+        applyMeetingHotkeyToMenuItem(recordMeetingItem)
+        menu.addItem(recordMeetingItem)
+        recordMeetingMenuItem = recordMeetingItem
+
+        menu.addItem(NSMenuItem.separator())
+
+        let hotkeyItem = NSMenuItem(
+            title: hotkeyMenuTitleProvider(),
+            action: nil,
+            keyEquivalent: ""
+        )
+        hotkeyItem.isEnabled = false
+        menu.addItem(hotkeyItem)
+        hotkeyMenuItem = hotkeyItem
+
+        let settingsItem = NSMenuItem(
+            title: "Settings...",
+            action: #selector(openSettings),
+            keyEquivalent: ","
+        )
+        settingsItem.target = self
+        menu.addItem(settingsItem)
+
+        let checkForUpdatesItem = NSMenuItem(
+            title: "Check for Updates...",
+            action: #selector(SPUStandardUpdaterController.checkForUpdates(_:)),
+            keyEquivalent: ""
+        )
+        checkForUpdatesItem.target = updaterController
+        menu.addItem(checkForUpdatesItem)
+
+        menu.addItem(NSMenuItem.separator())
+
+        let quitItem = NSMenuItem(
+            title: "Quit MacParakeet",
+            action: #selector(quitApp),
+            keyEquivalent: "q"
+        )
+        quitItem.target = self
+        menu.addItem(quitItem)
+
+        statusItem.menu = menu
+    }
+
+    func refreshHotkeyTitle() {
+        hotkeyMenuItem?.title = hotkeyMenuTitleProvider()
+    }
+
+    func refreshMeetingHotkeyShortcut() {
+        guard let recordMeetingMenuItem else { return }
+        applyMeetingHotkeyToMenuItem(recordMeetingMenuItem)
+    }
+
+    func updateIcon(state: BreathWaveIcon.MenuBarState) {
+        statusItem?.button?.image = BreathWaveIcon.menuBarIcon(pointSize: 18, state: state)
+    }
+
+    @objc private func showAboutPanel() {
+        onShowAboutPanel()
+    }
+
+    @objc private func openMainWindow() {
+        onOpenMainWindow()
+    }
+
+    @objc private func openSettings() {
+        onOpenSettings()
+    }
+
+    @objc private func quitApp() {
+        onQuit()
+    }
+
+    @objc private func pasteLastDictation() {
+        guard let env = environmentProvider() else { return }
+        Task {
+            guard let dictation = (try? env.dictationRepo.fetchAll(limit: 1))?.first else { return }
+            let text = dictation.cleanTranscript ?? dictation.rawTranscript
+            await pasteFromMenu(text: text, clipboardService: env.clipboardService)
+        }
+    }
+
+    @objc private func pasteRecentDictation(_ sender: NSMenuItem) {
+        guard let env = environmentProvider(),
+              let id = sender.representedObject as? UUID else { return }
+        Task {
+            guard let dictation = try? env.dictationRepo.fetch(id: id) else { return }
+            let text = dictation.cleanTranscript ?? dictation.rawTranscript
+            await pasteFromMenu(text: text, clipboardService: env.clipboardService)
+        }
+    }
+
+    @objc private func transcribeFileFromMenu() {
+        guard environmentProvider() != nil else { return }
+
+        NSApp.activate(ignoringOtherApps: true)
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.allowedContentTypes = AudioFileConverter.supportedExtensions.compactMap {
+            UTType(filenameExtension: $0)
+        }
+
+        if panel.runModal() == .OK, let url = panel.url {
+            onOpenMainWindow()
+            transcriptionViewModel.transcribeFile(url: url)
+            SoundManager.shared.play(.fileDropped)
+        }
+    }
+
+    @objc private func transcribeFromYouTubeMenu() {
+        guard environmentProvider() != nil else { return }
+        youtubeInputController.show()
+    }
+
+    @objc private func toggleMeetingRecordingFromMenu() {
+        onToggleMeetingRecording()
+    }
+
+    func menuNeedsUpdate(_ menu: NSMenu) {
+        guard let env = environmentProvider() else {
+            pasteLastMenuItem?.isEnabled = false
+            recentDictationsMenuItem?.isHidden = true
+            return
+        }
+
+        let dictations = (try? env.dictationRepo.fetchAll(limit: 5)) ?? []
+        pasteLastMenuItem?.isEnabled = !dictations.isEmpty
+        rebuildRecentDictationsSubmenu(with: dictations)
+
+        recordMeetingMenuItem?.title = meetingRecordingActiveProvider()
+            ? "Stop Meeting Recording"
+            : "Record Meeting"
+    }
+
+    private func handleDroppedFile(_ url: URL) {
+        onOpenMainWindow()
+        transcriptionViewModel.transcribeFile(url: url)
+        SoundManager.shared.play(.fileDropped)
+    }
+
+    /// Resign menu-bar focus, wait for the target app to regain focus, then paste.
+    private func pasteFromMenu(text: String, clipboardService: ClipboardServiceProtocol) async {
+        NSApp.deactivate()
+        try? await Task.sleep(for: .milliseconds(200))
+        do {
+            try await clipboardService.pasteText(text)
+        } catch {
+            await clipboardService.copyToClipboard(text)
+        }
+    }
+
+    private func rebuildRecentDictationsSubmenu(with dictations: [Dictation]) {
+        guard let recentItem = recentDictationsMenuItem else { return }
+        recentItem.isHidden = dictations.isEmpty
+
+        let submenu = NSMenu()
+        for dictation in dictations {
+            let text = (dictation.cleanTranscript ?? dictation.rawTranscript)
+                .replacingOccurrences(of: "\n", with: " ")
+            let truncated = text.count > 40 ? String(text.prefix(40)) + "…" : text
+            let item = NSMenuItem(
+                title: truncated,
+                action: #selector(pasteRecentDictation(_:)),
+                keyEquivalent: ""
+            )
+            item.target = self
+            item.representedObject = dictation.id
+            submenu.addItem(item)
+        }
+        recentItem.submenu = submenu
+    }
+
+    private func applyMeetingHotkeyToMenuItem(_ item: NSMenuItem) {
+        let trigger = meetingHotkeyTriggerProvider()
+        guard trigger.kind == .chord, let code = trigger.keyCode else {
+            item.keyEquivalent = ""
+            item.keyEquivalentModifierMask = []
+            return
+        }
+
+        let keyName = KeyCodeNames.name(for: code).shortSymbol
+        item.keyEquivalent = keyName.lowercased()
+
+        var mask: NSEvent.ModifierFlags = []
+        for modifier in trigger.chordModifiers ?? [] {
+            switch modifier {
+            case "command": mask.insert(.command)
+            case "shift": mask.insert(.shift)
+            case "control": mask.insert(.control)
+            case "option": mask.insert(.option)
+            default: break
+            }
+        }
+        item.keyEquivalentModifierMask = mask
+    }
+}

--- a/Sources/MacParakeet/App/OnboardingCoordinator.swift
+++ b/Sources/MacParakeet/App/OnboardingCoordinator.swift
@@ -1,0 +1,86 @@
+import Foundation
+import MacParakeetCore
+import MacParakeetViewModels
+
+@MainActor
+final class OnboardingCoordinator {
+    private let onboardingWindowController: OnboardingWindowController
+    private let onRefreshHotkeys: () -> Void
+    private let onOpenMainWindow: () -> Void
+    private let onOpenSettings: () -> Void
+
+    private var reopenOnNextActivate = false
+
+    init(
+        onboardingWindowController: OnboardingWindowController,
+        onRefreshHotkeys: @escaping () -> Void,
+        onOpenMainWindow: @escaping () -> Void,
+        onOpenSettings: @escaping () -> Void
+    ) {
+        self.onboardingWindowController = onboardingWindowController
+        self.onRefreshHotkeys = onRefreshHotkeys
+        self.onOpenMainWindow = onOpenMainWindow
+        self.onOpenSettings = onOpenSettings
+    }
+
+    var isVisible: Bool {
+        onboardingWindowController.isVisible
+    }
+
+    func maybeShow(environment: AppEnvironment?) {
+        guard let environment else { return }
+        let completed = UserDefaults.standard.string(forKey: OnboardingViewModel.onboardingCompletedKey) != nil
+        if !completed {
+            show(
+                permissionService: environment.permissionService,
+                sttClient: environment.sttScheduler,
+                diarizationService: environment.diarizationService,
+                entitlementsService: environment.entitlementsService
+            )
+        }
+    }
+
+    func show(environment: AppEnvironment?) {
+        guard let environment else { return }
+        show(
+            permissionService: environment.permissionService,
+            sttClient: environment.sttScheduler,
+            diarizationService: environment.diarizationService,
+            entitlementsService: environment.entitlementsService
+        )
+    }
+
+    func handleApplicationDidBecomeActive(environment: AppEnvironment?) {
+        guard reopenOnNextActivate else { return }
+        maybeShow(environment: environment)
+    }
+
+    private func show(
+        permissionService: PermissionServiceProtocol,
+        sttClient: STTClientProtocol,
+        diarizationService: DiarizationServiceProtocol?,
+        entitlementsService: EntitlementsService
+    ) {
+        onboardingWindowController.show(
+            permissionService: permissionService,
+            sttClient: sttClient,
+            diarizationService: diarizationService,
+            onFinish: { [weak self] in
+                self?.reopenOnNextActivate = false
+                self?.onRefreshHotkeys()
+                Task {
+                    await entitlementsService.bootstrapTrialIfNeeded()
+                }
+            },
+            onOpenMainApp: { [weak self] in
+                self?.onOpenMainWindow()
+            },
+            onOpenSettings: { [weak self] in
+                self?.onOpenSettings()
+            },
+            onIncompleteDismiss: { [weak self] in
+                self?.reopenOnNextActivate = true
+            }
+        )
+    }
+}

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -424,6 +424,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func showAboutPanel() {
         let repoLink = "https://github.com/moona3k/macparakeet"
+        guard let repoURL = URL(string: repoLink) else { return }
         let credits = NSMutableAttributedString()
 
         let style = NSMutableParagraphStyle()
@@ -435,7 +436,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         ]
         let linkAttributes: [NSAttributedString.Key: Any] = [
             .font: NSFont.systemFont(ofSize: 11),
-            .link: URL(string: repoLink)!,
+            .link: repoURL,
             .paragraphStyle: style,
         ]
 

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -373,8 +373,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         if originatesFromWindow {
-            windowCoordinator.openMainWindow()
             mainWindowState.selectedItem = .meetings
+            windowCoordinator.openMainWindow()
         }
 
         meetingRecordingFlowCoordinator?.toggleRecording()

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -1,16 +1,10 @@
 import AppKit
 import Sparkle
-import SwiftUI
-import UniformTypeIdentifiers
 import MacParakeetCore
 import MacParakeetViewModels
 
 @MainActor
-final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
-    // MARK: - Menu Bar
-
-    private var statusItem: NSStatusItem?
-
+final class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Auto-Update
 
     #if DEBUG
@@ -27,18 +21,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     )
     #endif
 
-    // MARK: - Windows
-
-    private var mainWindow: NSWindow?
-
-    // MARK: - Services
+    // MARK: - Runtime Services
 
     private var appEnvironment: AppEnvironment?
     private var hotkeyCoordinator: AppHotkeyCoordinator?
     private var dictationFlowCoordinator: DictationFlowCoordinator?
     private var meetingRecordingFlowCoordinator: MeetingRecordingFlowCoordinator?
+    private var hasPresentedHotkeyUnavailableAlert = false
+    private var environmentSetupTask: Task<Void, Never>?
 
-    // MARK: - ViewModels
+    // MARK: - View Models
 
     private let transcriptionViewModel = TranscriptionViewModel()
     private let historyViewModel = DictationHistoryViewModel()
@@ -55,22 +47,126 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private let promptsViewModel = PromptsViewModel()
     private let mainWindowState = MainWindowState()
     private let onboardingWindowController = OnboardingWindowController()
-    private var onboardingObserver: Any?
-    private var settingsObserver: Any?
-    private var hotkeyTriggerObserver: Any?
-    private var meetingHotkeyTriggerObserver: Any?
-    private var menuBarOnlyModeObserver: Any?
-    private var showIdlePillObserver: Any?
-    private var hotkeyMenuItem: NSMenuItem?
+
     private lazy var youtubeInputController = YouTubeInputPanelController(
         transcriptionViewModel: transcriptionViewModel
     )
-    private var pasteLastMenuItem: NSMenuItem?
-    private var recentDictationsMenuItem: NSMenuItem?
-    private var recordMeetingMenuItem: NSMenuItem?
-    private var reopenOnboardingOnNextActivate = false
-    private var hasPresentedHotkeyUnavailableAlert = false
-    private var environmentSetupTask: Task<Void, Never>?
+
+    // MARK: - Coordinators
+
+    private let startupBootstrapper = AppStartupBootstrapper()
+
+    private lazy var environmentConfigurer = AppEnvironmentConfigurer(
+        transcriptionViewModel: transcriptionViewModel,
+        historyViewModel: historyViewModel,
+        settingsViewModel: settingsViewModel,
+        customWordsViewModel: customWordsViewModel,
+        textSnippetsViewModel: textSnippetsViewModel,
+        libraryViewModel: libraryViewModel,
+        meetingsViewModel: meetingsViewModel,
+        llmSettingsViewModel: llmSettingsViewModel,
+        chatViewModel: chatViewModel,
+        promptResultsViewModel: promptResultsViewModel,
+        promptsViewModel: promptsViewModel,
+        mainWindowState: mainWindowState
+    )
+
+    private lazy var onboardingCoordinator = OnboardingCoordinator(
+        onboardingWindowController: onboardingWindowController,
+        onRefreshHotkeys: { [weak self] in
+            self?.hotkeyCoordinator?.refreshAllHotkeys()
+            self?.menuBarCoordinator.refreshHotkeyTitle()
+            self?.menuBarCoordinator.refreshMeetingHotkeyShortcut()
+        },
+        onOpenMainWindow: { [weak self] in
+            self?.windowCoordinator.openMainWindow()
+        },
+        onOpenSettings: { [weak self] in
+            self?.windowCoordinator.openMainWindowToSettings()
+        }
+    )
+
+    private lazy var windowCoordinator = AppWindowCoordinator(
+        mainWindowState: mainWindowState,
+        transcriptionViewModel: transcriptionViewModel,
+        historyViewModel: historyViewModel,
+        settingsViewModel: settingsViewModel,
+        llmSettingsViewModel: llmSettingsViewModel,
+        chatViewModel: chatViewModel,
+        promptResultsViewModel: promptResultsViewModel,
+        promptsViewModel: promptsViewModel,
+        customWordsViewModel: customWordsViewModel,
+        textSnippetsViewModel: textSnippetsViewModel,
+        feedbackViewModel: feedbackViewModel,
+        discoverViewModel: discoverViewModel,
+        libraryViewModel: libraryViewModel,
+        meetingsViewModel: meetingsViewModel,
+        updaterController: updaterController,
+        onRecordMeeting: { [weak self] in
+            self?.toggleMeetingRecording(originatesFromWindow: true)
+        },
+        onQuit: { [weak self] in
+            self?.quitApp()
+        },
+        isOnboardingVisible: { [weak self] in
+            self?.onboardingWindowController.isVisible ?? false
+        }
+    )
+
+    private lazy var menuBarCoordinator = MenuBarCoordinator(
+        updaterController: updaterController,
+        transcriptionViewModel: transcriptionViewModel,
+        youtubeInputController: youtubeInputController,
+        environmentProvider: { [weak self] in
+            self?.appEnvironment
+        },
+        hotkeyMenuTitleProvider: { [weak self] in
+            self?.hotkeyMenuTitle ?? AppHotkeyCoordinator.menuTitle(for: HotkeyTrigger.current)
+        },
+        meetingHotkeyTriggerProvider: { [weak self] in
+            self?.settingsViewModel.meetingHotkeyTrigger ?? .defaultMeetingRecording
+        },
+        meetingRecordingActiveProvider: { [weak self] in
+            self?.meetingRecordingFlowCoordinator?.isMeetingRecordingActive == true
+        },
+        onOpenMainWindow: { [weak self] in
+            self?.windowCoordinator.openMainWindow()
+        },
+        onOpenSettings: { [weak self] in
+            self?.windowCoordinator.openMainWindowToSettings()
+        },
+        onToggleMeetingRecording: { [weak self] in
+            self?.toggleMeetingRecording(originatesFromWindow: false)
+        },
+        onQuit: { [weak self] in
+            self?.quitApp()
+        },
+        onShowAboutPanel: { [weak self] in
+            self?.showAboutPanel()
+        }
+    )
+
+    private lazy var settingsObserverCoordinator = AppSettingsObserverCoordinator(
+        onOpenOnboarding: { [weak self] in
+            guard let self else { return }
+            self.onboardingCoordinator.show(environment: self.appEnvironment)
+        },
+        onOpenSettings: { [weak self] in
+            self?.windowCoordinator.openMainWindowToSettings()
+        },
+        onHotkeyTriggerChanged: { [weak self] in
+            self?.handleHotkeyTriggerChange()
+        },
+        onMeetingHotkeyTriggerChanged: { [weak self] in
+            self?.handleMeetingHotkeyTriggerChange()
+        },
+        onMenuBarOnlyModeChanged: { [weak self] in
+            self?.windowCoordinator.applyActivationPolicyFromSettings()
+        },
+        onShowIdlePillChanged: { [weak self] in
+            self?.handleShowIdlePillChange()
+        }
+    )
 
     // MARK: - App Lifecycle
 
@@ -79,16 +175,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             showMoveToApplicationsAlert()
             return
         }
+
         startEnvironmentSetup()
-        setupMainMenu()
-        setupMenuBar()
-        observeOpenOnboarding()
-        observeOpenSettings()
-        observeHotkeyTriggerChange()
-        observeMeetingHotkeyTriggerChange()
-        observeMenuBarOnlyModeChange()
-        observeShowIdlePillChange()
-        applyActivationPolicyFromSettings()
+        menuBarCoordinator.setupMainMenu()
+        menuBarCoordinator.setupMenuBar()
+        settingsObserverCoordinator.startObserving()
+        windowCoordinator.applyActivationPolicyFromSettings()
         setupDiscoverContent()
     }
 
@@ -98,12 +190,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // would send duplicate appQuit events and double the termination delay.
         dictationFlowCoordinator?.hideIdlePill()
         hotkeyCoordinator?.stopAll()
-        if let onboardingObserver { NotificationCenter.default.removeObserver(onboardingObserver) }
-        if let settingsObserver { NotificationCenter.default.removeObserver(settingsObserver) }
-        if let hotkeyTriggerObserver { NotificationCenter.default.removeObserver(hotkeyTriggerObserver) }
-        if let meetingHotkeyTriggerObserver { NotificationCenter.default.removeObserver(meetingHotkeyTriggerObserver) }
-        if let menuBarOnlyModeObserver { NotificationCenter.default.removeObserver(menuBarOnlyModeObserver) }
-        if let showIdlePillObserver { NotificationCenter.default.removeObserver(showIdlePillObserver) }
+        settingsObserverCoordinator.stopObserving()
         environmentSetupTask?.cancel()
 
         // Bound the wait so termination does not hang, while still giving shutdown
@@ -116,6 +203,102 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             }
             _ = done.wait(timeout: .now() + 0.35)
         }
+    }
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        // Don't quit when window closes — dictation/menu bar features stay available.
+        false
+    }
+
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows _: Bool) -> Bool {
+        windowCoordinator.handleAppReopen()
+    }
+
+    func applicationDockMenu(_ sender: NSApplication) -> NSMenu? {
+        windowCoordinator.makeDockMenu()
+    }
+
+    func applicationDidBecomeActive(_ notification: Notification) {
+        onboardingCoordinator.handleApplicationDidBecomeActive(environment: appEnvironment)
+    }
+
+    // MARK: - Startup
+
+    private func startEnvironmentSetup() {
+        environmentSetupTask?.cancel()
+        environmentSetupTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                let env = try await startupBootstrapper.bootstrapEnvironment()
+                guard !Task.isCancelled else { return }
+                setupEnvironment(env)
+            } catch is CancellationError {
+                return
+            } catch {
+                presentEnvironmentSetupError(error)
+            }
+        }
+    }
+
+    private func setupEnvironment(_ env: AppEnvironment) {
+        appEnvironment = env
+
+        let runtime = environmentConfigurer.configure(
+            environment: env,
+            callbacks: .init(
+                onMenuBarIconUpdate: { [weak self] in
+                    self?.resolveAndUpdateMenuBarIcon()
+                },
+                onPresentEntitlementsAlert: { [weak self] error in
+                    self?.presentEntitlementsAlert(error)
+                },
+                onOpenMainWindow: { [weak self] in
+                    self?.windowCoordinator.openMainWindow()
+                },
+                onToggleMeetingRecordingFromHotkey: { [weak self] in
+                    self?.toggleMeetingRecording(originatesFromWindow: false)
+                },
+                onHotkeyBecameAvailable: { [weak self] in
+                    self?.hasPresentedHotkeyUnavailableAlert = false
+                },
+                onHotkeyUnavailable: { [weak self] in
+                    self?.presentHotkeyUnavailableAlertIfNeeded()
+                }
+            )
+        )
+
+        dictationFlowCoordinator = runtime.dictationFlowCoordinator
+        meetingRecordingFlowCoordinator = runtime.meetingRecordingFlowCoordinator
+        hotkeyCoordinator = runtime.hotkeyCoordinator
+
+        menuBarCoordinator.refreshHotkeyTitle()
+        menuBarCoordinator.refreshMeetingHotkeyShortcut()
+        onboardingCoordinator.maybeShow(environment: env)
+    }
+
+    private func presentEnvironmentSetupError(_ error: Error) {
+        // Don't silently fail. Without a valid environment, the app can't function.
+        NSApp.setActivationPolicy(.regular)
+        NSApp.activate(ignoringOtherApps: true)
+
+        let alert = NSAlert()
+        alert.alertStyle = .critical
+        alert.messageText = "MacParakeet Failed to Start"
+        alert.informativeText = error.localizedDescription
+        alert.addButton(withTitle: "Quit")
+        _ = alert.runModal()
+
+        NSApp.terminate(nil)
+    }
+
+    private func setupDiscoverContent() {
+        guard let fallbackURL = Bundle.module.url(forResource: "discover-fallback", withExtension: "json"),
+              let data = try? Data(contentsOf: fallbackURL) else { return }
+
+        let service = DiscoverService(fallbackData: data)
+        discoverViewModel.configure(service: service)
+        discoverViewModel.loadCached()
+        discoverViewModel.refreshInBackground()
     }
 
     // MARK: - Disk Image Guard
@@ -133,536 +316,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         alert.alertStyle = .warning
         alert.addButton(withTitle: "Quit")
         alert.runModal()
+
         NSApp.terminate(nil)
     }
 
-    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
-        // Don't quit when window closes — dictation/menu bar features stay available
-        return false
-    }
+    // MARK: - Event Handlers
 
-    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows _: Bool) -> Bool {
-        // Overlay panels (idle/recording pills) are NSWindows and make the `hasVisibleWindows`
-        // flag unreliable for Dock reopen. Only treat primary app windows as visible here.
-        if hasVisiblePrimaryWindow {
-            NSApp.activate(ignoringOtherApps: true)
-        } else {
-            openMainWindow()
-        }
-        return true
-    }
-
-    func applicationDockMenu(_ sender: NSApplication) -> NSMenu? {
-        let menu = NSMenu()
-
-        let openItem = NSMenuItem(
-            title: "Open MacParakeet",
-            action: #selector(openMainWindow),
-            keyEquivalent: ""
-        )
-        openItem.target = self
-        menu.addItem(openItem)
-
-        let settingsItem = NSMenuItem(
-            title: "Settings...",
-            action: #selector(openMainWindowToSettings),
-            keyEquivalent: ""
-        )
-        settingsItem.target = self
-        menu.addItem(settingsItem)
-
-        menu.addItem(NSMenuItem.separator())
-
-        let quitItem = NSMenuItem(
-            title: "Quit MacParakeet",
-            action: #selector(quitApp),
-            keyEquivalent: ""
-        )
-        quitItem.target = self
-        menu.addItem(quitItem)
-
-        return menu
-    }
-
-    // MARK: - Main Menu (enables Cmd+A/C/V/X in text fields)
-
-    private func setupMainMenu() {
-        let mainMenu = NSMenu()
-
-        // App menu
-        let appMenuItem = NSMenuItem()
-        let appMenu = NSMenu()
-
-        let aboutItem = NSMenuItem(
-            title: "About MacParakeet",
-            action: #selector(showAboutPanel),
-            keyEquivalent: ""
-        )
-        aboutItem.target = self
-        appMenu.addItem(aboutItem)
-        appMenu.addItem(NSMenuItem.separator())
-
-        let checkForUpdatesItem = NSMenuItem(
-            title: "Check for Updates...",
-            action: #selector(SPUStandardUpdaterController.checkForUpdates(_:)),
-            keyEquivalent: ""
-        )
-        checkForUpdatesItem.target = updaterController
-        appMenu.addItem(checkForUpdatesItem)
-        appMenu.addItem(NSMenuItem.separator())
-
-        appMenu.addItem(NSMenuItem(title: "Quit MacParakeet", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q"))
-        appMenuItem.submenu = appMenu
-        mainMenu.addItem(appMenuItem)
-
-        // Edit menu — required for text field keyboard shortcuts
-        let editMenuItem = NSMenuItem()
-        let editMenu = NSMenu(title: "Edit")
-        editMenu.addItem(NSMenuItem(title: "Undo", action: Selector(("undo:")), keyEquivalent: "z"))
-        editMenu.addItem(NSMenuItem(title: "Redo", action: Selector(("redo:")), keyEquivalent: "Z"))
-        editMenu.addItem(NSMenuItem.separator())
-        editMenu.addItem(NSMenuItem(title: "Cut", action: #selector(NSText.cut(_:)), keyEquivalent: "x"))
-        editMenu.addItem(NSMenuItem(title: "Copy", action: #selector(NSText.copy(_:)), keyEquivalent: "c"))
-        editMenu.addItem(NSMenuItem(title: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v"))
-        editMenu.addItem(NSMenuItem(title: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a"))
-        editMenuItem.submenu = editMenu
-        mainMenu.addItem(editMenuItem)
-
-        NSApp.mainMenu = mainMenu
-    }
-
-    // MARK: - Menu Bar Setup
-
-    private func setupMenuBar() {
-        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
-
-        guard let statusItem = statusItem,
-              let button = statusItem.button else { return }
-
-        button.image = BreathWaveIcon.menuBarIcon(pointSize: 18)
-
-        let dropView = MenuBarDropView(frame: button.bounds)
-        dropView.onDrop = { [weak self] url in
-            Task { @MainActor in
-                self?.openMainWindow()
-                self?.transcriptionViewModel.transcribeFile(url: url)
-                SoundManager.shared.play(.fileDropped)
-            }
-        }
-        button.addSubview(dropView)
-
-        let menu = NSMenu()
-        menu.autoenablesItems = false
-        menu.delegate = self
-
-        menu.addItem(NSMenuItem(
-            title: "Open MacParakeet",
-            action: #selector(openMainWindow),
-            keyEquivalent: "o"
-        ))
-
-        menu.addItem(NSMenuItem.separator())
-
-        // Paste Last Dictation
-        let pasteItem = NSMenuItem(
-            title: "Paste Last Dictation",
-            action: #selector(pasteLastDictation),
-            keyEquivalent: ""
-        )
-        pasteItem.isEnabled = false
-        menu.addItem(pasteItem)
-        pasteLastMenuItem = pasteItem
-
-        // Recent Dictations submenu
-        let recentItem = NSMenuItem(
-            title: "Recent Dictations",
-            action: nil,
-            keyEquivalent: ""
-        )
-        recentItem.submenu = NSMenu()
-        recentItem.isHidden = true
-        menu.addItem(recentItem)
-        recentDictationsMenuItem = recentItem
-
-        menu.addItem(NSMenuItem.separator())
-
-        // Transcribe actions
-        menu.addItem(NSMenuItem(
-            title: "Transcribe File...",
-            action: #selector(transcribeFileFromMenu),
-            keyEquivalent: ""
-        ))
-
-        menu.addItem(NSMenuItem(
-            title: "Transcribe from YouTube...",
-            action: #selector(transcribeFromYouTubeMenu),
-            keyEquivalent: ""
-        ))
-
-        let recordMeetingItem = NSMenuItem(
-            title: "Record Meeting",
-            action: #selector(toggleMeetingRecordingFromMenu),
-            keyEquivalent: ""
-        )
-        recordMeetingItem.target = self
-        applyMeetingHotkeyToMenuItem(recordMeetingItem)
-        menu.addItem(recordMeetingItem)
-        recordMeetingMenuItem = recordMeetingItem
-
-        menu.addItem(NSMenuItem.separator())
-
-        let hotkeyItem = NSMenuItem(
-            title: hotkeyMenuTitle,
-            action: nil,
-            keyEquivalent: ""
-        )
-        hotkeyItem.isEnabled = false
-        menu.addItem(hotkeyItem)
-        hotkeyMenuItem = hotkeyItem
-
-        menu.addItem(NSMenuItem(
-            title: "Settings...",
-            action: #selector(openMainWindowToSettings),
-            keyEquivalent: ","
-        ))
-
-        let checkForUpdatesItem = NSMenuItem(
-            title: "Check for Updates...",
-            action: #selector(SPUStandardUpdaterController.checkForUpdates(_:)),
-            keyEquivalent: ""
-        )
-        checkForUpdatesItem.target = updaterController
-        menu.addItem(checkForUpdatesItem)
-
-        menu.addItem(NSMenuItem.separator())
-
-        menu.addItem(NSMenuItem(
-            title: "Quit MacParakeet",
-            action: #selector(quitApp),
-            keyEquivalent: "q"
-        ))
-
-        statusItem.menu = menu
-    }
-
-    // MARK: - Environment Setup
-
-    private func startEnvironmentSetup() {
-        environmentSetupTask?.cancel()
-        environmentSetupTask = Task { @MainActor [weak self] in
-            self?.setupEnvironment()
-        }
-    }
-
-    private func setupEnvironment() {
-        do {
-            let env = try AppEnvironment()
-            appEnvironment = env
-
-            Task {
-                // Only bootstrap trial if onboarding is already completed (returning user).
-                // For new users, trial starts at onboarding completion — not during setup.
-                let onboardingDone = UserDefaults.standard.string(forKey: OnboardingViewModel.onboardingCompletedKey) != nil
-                if onboardingDone {
-                    await env.entitlementsService.bootstrapTrialIfNeeded()
-                }
-                await env.entitlementsService.refreshValidationIfNeeded()
-            }
-
-            // Configure view models
-            let hasLLMConfig = (try? env.llmConfigStore.loadConfig()) != nil
-            transcriptionViewModel.configure(
-                transcriptionService: env.transcriptionService,
-                transcriptionRepo: env.transcriptionRepo,
-                llmService: hasLLMConfig ? env.llmService : nil,
-                promptResultRepo: env.promptResultRepo,
-                promptResultsViewModel: promptResultsViewModel
-            )
-            historyViewModel.configure(dictationRepo: env.dictationRepo)
-            libraryViewModel.configure(transcriptionRepo: env.transcriptionRepo)
-            meetingsViewModel.configure(transcriptionRepo: env.transcriptionRepo)
-            settingsViewModel.configure(
-                permissionService: env.permissionService,
-                dictationRepo: env.dictationRepo,
-                transcriptionRepo: env.transcriptionRepo,
-                entitlementsService: env.entitlementsService,
-                launchAtLoginService: env.launchAtLoginService,
-                checkoutURL: env.checkoutURL,
-                customWordRepo: env.customWordRepo,
-                snippetRepo: env.snippetRepo,
-                sttClient: env.sttScheduler
-            )
-            customWordsViewModel.configure(repo: env.customWordRepo)
-            textSnippetsViewModel.configure(repo: env.snippetRepo)
-            promptsViewModel.configure(repo: env.promptRepo)
-            llmSettingsViewModel.configure(
-                configStore: env.llmConfigStore,
-                llmClient: env.llmClient
-            )
-            settingsViewModel.onDictationsCleared = { [weak self] in
-                self?.historyViewModel.loadDictations()
-            }
-            llmSettingsViewModel.onConfigurationChanged = { [weak self] in
-                self?.refreshLLMAvailability()
-            }
-            chatViewModel.configure(
-                llmService: hasLLMConfig ? env.llmService : nil,
-                transcriptText: "",
-                transcriptionRepo: env.transcriptionRepo,
-                configStore: env.llmConfigStore,
-                conversationRepo: env.chatConversationRepo
-            )
-            promptResultsViewModel.configure(
-                llmService: hasLLMConfig ? env.llmService : nil,
-                promptRepo: env.promptRepo,
-                promptResultRepo: env.promptResultRepo,
-                transcriptionRepo: env.transcriptionRepo,
-                configStore: env.llmConfigStore
-            )
-            chatViewModel.onConversationsChanged = { [weak self] transcriptionID, hasConversations in
-                self?.transcriptionViewModel.updateConversationStatus(
-                    id: transcriptionID,
-                    hasConversations: hasConversations
-                )
-            }
-            chatViewModel.onModelChanged = { [weak self] in
-                self?.promptResultsViewModel.refreshModelInfo()
-            }
-            promptResultsViewModel.onModelChanged = { [weak self] in
-                self?.chatViewModel.refreshModelInfo()
-            }
-            promptResultsViewModel.onPromptResultsChanged = { [weak self] transcriptionID, hasPromptResults in
-                guard self?.transcriptionViewModel.currentTranscription?.id == transcriptionID else { return }
-                self?.transcriptionViewModel.hasPromptResultTabs = hasPromptResults
-            }
-            promptResultsViewModel.onLegacySummaryChanged = { [weak self] transcriptionID, summary in
-                self?.transcriptionViewModel.updateLegacySummary(id: transcriptionID, summary: summary)
-            }
-            promptResultsViewModel.onGenerationCompleted = { [weak self] generationID, promptResultID in
-                self?.transcriptionViewModel.handleGenerationCompleted(generationID, promptResultID: promptResultID)
-            }
-            promptResultsViewModel.onDeletedPromptResult = { [weak self] promptResultID in
-                self?.transcriptionViewModel.handlePromptResultDeleted(promptResultID)
-            }
-            promptResultsViewModel.shouldMarkPromptResultUnread = { [weak self] promptResultID in
-                guard let self else { return true }
-                if case .result(let id) = self.transcriptionViewModel.selectedTab,
-                   id == promptResultID {
-                    return false
-                }
-                return true
-            }
-            transcriptionViewModel.onTranscribingChanged = { [weak self] _ in
-                self?.resolveAndUpdateMenuBarIcon()
-            }
-
-            let coordinator = DictationFlowCoordinator(
-                dictationService: env.dictationService,
-                clipboardService: env.clipboardService,
-                entitlementsService: env.entitlementsService,
-                dictationRepo: env.dictationRepo,
-                settingsViewModel: settingsViewModel,
-                shouldSuppressIdlePill: { [weak self] in
-                    self?.meetingRecordingFlowCoordinator?.isMeetingRecordingActive == true
-                },
-                onMenuBarIconUpdate: { [weak self] _ in self?.resolveAndUpdateMenuBarIcon() },
-                onHistoryReload: { [weak self] in self?.historyViewModel.loadDictations() },
-                onPresentEntitlementsAlert: { [weak self] error in self?.presentEntitlementsAlert(error) }
-            )
-            dictationFlowCoordinator = coordinator
-
-            let meetingCoordinator = MeetingRecordingFlowCoordinator(
-                meetingRecordingService: env.meetingRecordingService,
-                transcriptionService: env.transcriptionService,
-                permissionService: env.permissionService,
-                onMenuBarIconUpdate: { [weak self] _ in self?.resolveAndUpdateMenuBarIcon() },
-                onTranscriptionReady: { [weak self] transcription in
-                    guard let self else { return }
-                    self.transcriptionViewModel.presentCompletedTranscription(transcription, autoSave: true)
-                    self.libraryViewModel.loadTranscriptions()
-                    self.meetingsViewModel.loadTranscriptions()
-                    self.mainWindowState.navigateToTranscription(from: .meetings)
-                    self.openMainWindow()
-                },
-                onRecordingBegan: { [weak self] in
-                    self?.dictationFlowCoordinator?.hideIdlePill()
-                },
-                onFlowReturnedToIdle: { [weak self] in
-                    self?.resolveAndUpdateMenuBarIcon()
-                    guard self?.dictationFlowCoordinator?.isDictationActive != true else { return }
-                    self?.dictationFlowCoordinator?.showIdlePill()
-                }
-            )
-            meetingRecordingFlowCoordinator = meetingCoordinator
-            configureHotkeyCoordinatorIfNeeded()
-            setupHotkey()
-            setupMeetingHotkey()
-            dictationFlowCoordinator?.showIdlePill()
-
-            maybeShowOnboarding()
-        } catch {
-            // Don't silently fail. Without a valid environment, the app can't function.
-            NSApp.setActivationPolicy(.regular)
-            NSApp.activate(ignoringOtherApps: true)
-            let alert = NSAlert()
-            alert.alertStyle = .critical
-            alert.messageText = "MacParakeet Failed to Start"
-            alert.informativeText = error.localizedDescription
-            alert.addButton(withTitle: "Quit")
-            _ = alert.runModal()
-            NSApp.terminate(nil)
-        }
-    }
-
-    private func setupDiscoverContent() {
-        guard let fallbackURL = Bundle.module.url(forResource: "discover-fallback", withExtension: "json"),
-              let data = try? Data(contentsOf: fallbackURL) else { return }
-        let service = DiscoverService(fallbackData: data)
-        discoverViewModel.configure(service: service)
-        discoverViewModel.loadCached()
-        discoverViewModel.refreshInBackground()
-    }
-
-    private func refreshLLMAvailability() {
-        guard let env = appEnvironment else { return }
-        let hasConfig = (try? env.llmConfigStore.loadConfig()) != nil
-        let service: LLMService? = hasConfig ? env.llmService : nil
-        transcriptionViewModel.updateLLMAvailability(hasConfig, llmService: service)
-        chatViewModel.updateLLMService(service)
-        promptResultsViewModel.updateLLMService(service)
-    }
-
-    private func configureHotkeyCoordinatorIfNeeded() {
-        guard hotkeyCoordinator == nil else { return }
-        hotkeyCoordinator = AppHotkeyCoordinator(
-            settingsViewModel: settingsViewModel,
-            onStartDictation: { [weak self] mode in
-                self?.dictationFlowCoordinator?.startDictation(mode: mode, trigger: .hotkey)
-            },
-            onStopDictation: { [weak self] in
-                self?.dictationFlowCoordinator?.stopDictation()
-            },
-            onCancelDictation: { [weak self] in
-                self?.dictationFlowCoordinator?.cancelDictation(reason: .escape)
-            },
-            onDiscardRecording: { [weak self] showReadyPill in
-                self?.dictationFlowCoordinator?.discardProvisionalRecording(showReadyPill: showReadyPill)
-            },
-            onReadyForSecondTap: { [weak self] in
-                self?.dictationFlowCoordinator?.showReadyPill()
-            },
-            onEscapeWhileIdle: { [weak self] in
-                self?.dictationFlowCoordinator?.dismissOverlayIfError()
-            },
-            onToggleMeetingRecording: { [weak self] in
-                self?.toggleMeetingRecording(originatesFromWindow: false)
-            },
-            onPrimaryHotkeyManagerChanged: { [weak self] manager in
-                self?.dictationFlowCoordinator?.hotkeyManager = manager
-            },
-            onAnyHotkeyEnabled: { [weak self] in
-                self?.hasPresentedHotkeyUnavailableAlert = false
-            },
-            onHotkeyUnavailable: { [weak self] in
-                self?.presentHotkeyUnavailableAlertIfNeeded()
-            }
-        )
-    }
-
-    // MARK: - Hotkey
-
-    private func setupHotkey() {
-        hotkeyCoordinator?.setupPrimaryHotkey()
-    }
-
-    private func setupMeetingHotkey() {
-        hotkeyCoordinator?.setupMeetingHotkey()
-    }
-
-    private func refreshHotkeyAfterPermissions() {
+    private func handleHotkeyTriggerChange() {
         hotkeyCoordinator?.refreshAllHotkeys()
+        menuBarCoordinator.refreshHotkeyTitle()
+        menuBarCoordinator.refreshMeetingHotkeyShortcut()
     }
 
-    private func observeOpenOnboarding() {
-        onboardingObserver = NotificationCenter.default.addObserver(
-            forName: .macParakeetOpenOnboarding,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor in
-                self?.showOnboarding()
-            }
-        }
+    private func handleMeetingHotkeyTriggerChange() {
+        hotkeyCoordinator?.refreshMeetingHotkey()
+        menuBarCoordinator.refreshMeetingHotkeyShortcut()
     }
 
-    private func observeHotkeyTriggerChange() {
-        hotkeyTriggerObserver = NotificationCenter.default.addObserver(
-            forName: .macParakeetHotkeyTriggerDidChange,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor in
-                self?.hotkeyCoordinator?.refreshAllHotkeys()
-                self?.hotkeyMenuItem?.title = self?.hotkeyMenuTitle ?? ""
-            }
-        }
-    }
-
-    private func observeMeetingHotkeyTriggerChange() {
-        meetingHotkeyTriggerObserver = NotificationCenter.default.addObserver(
-            forName: .macParakeetMeetingHotkeyTriggerDidChange,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor in
-                self?.hotkeyCoordinator?.refreshMeetingHotkey()
-                if let item = self?.recordMeetingMenuItem {
-                    self?.applyMeetingHotkeyToMenuItem(item)
-                }
-            }
-        }
-    }
-
-    private func observeMenuBarOnlyModeChange() {
-        menuBarOnlyModeObserver = NotificationCenter.default.addObserver(
-            forName: .macParakeetMenuBarOnlyModeDidChange,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor in
-                self?.applyActivationPolicyFromSettings()
-            }
-        }
-    }
-
-    private func observeShowIdlePillChange() {
-        showIdlePillObserver = NotificationCenter.default.addObserver(
-            forName: .macParakeetShowIdlePillDidChange,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor in
-                guard let self else { return }
-                if self.settingsViewModel.showIdlePill {
-                    self.dictationFlowCoordinator?.showIdlePill()
-                } else {
-                    self.dictationFlowCoordinator?.hideIdlePill()
-                }
-            }
-        }
-    }
-
-    private func applyActivationPolicyFromSettings() {
-        let menuBarOnly = settingsViewModel.menuBarOnlyMode
-        let wasMainWindowVisible = mainWindow?.isVisible ?? false
-        let mode: NSApplication.ActivationPolicy = menuBarOnly ? .accessory : .regular
-        NSApp.setActivationPolicy(mode)
-
-        // macOS hides all windows when switching to .accessory policy.
-        // Re-show the main window so the user isn't surprised by it disappearing.
-        if menuBarOnly && wasMainWindowVisible {
-            mainWindow?.makeKeyAndOrderFront(nil)
-            NSApp.activate(ignoringOtherApps: true)
+    private func handleShowIdlePillChange() {
+        if settingsViewModel.showIdlePill {
+            dictationFlowCoordinator?.showIdlePill()
+        } else {
+            dictationFlowCoordinator?.hideIdlePill()
         }
     }
 
@@ -671,338 +346,38 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             ?? AppHotkeyCoordinator.menuTitle(for: HotkeyTrigger.current)
     }
 
-    /// Configures an NSMenuItem with the meeting hotkey shortcut.
-    /// Chord triggers (e.g. ⌘⇧M) render as native macOS shortcut hints.
-    /// Non-chord triggers cannot be represented natively and are left without a shortcut indicator.
-    private func applyMeetingHotkeyToMenuItem(_ item: NSMenuItem) {
-        if let hotkeyCoordinator {
-            hotkeyCoordinator.applyMeetingHotkey(to: item)
-            return
-        }
-        let trigger = settingsViewModel.meetingHotkeyTrigger
-        guard trigger.kind == .chord, let code = trigger.keyCode else {
-            item.keyEquivalent = ""
-            item.keyEquivalentModifierMask = []
-            return
-        }
-        let keyName = KeyCodeNames.name(for: code).shortSymbol
-        item.keyEquivalent = keyName.lowercased()
-        var mask: NSEvent.ModifierFlags = []
-        for modifier in trigger.chordModifiers ?? [] {
-            switch modifier {
-            case "command": mask.insert(.command)
-            case "shift": mask.insert(.shift)
-            case "control": mask.insert(.control)
-            case "option": mask.insert(.option)
-            default: break
-            }
-        }
-        item.keyEquivalentModifierMask = mask
-    }
-
-    private func maybeShowOnboarding() {
-        guard let env = appEnvironment else { return }
-        let completed = UserDefaults.standard.string(forKey: OnboardingViewModel.onboardingCompletedKey) != nil
-        if !completed {
-            showOnboarding(
-                permissionService: env.permissionService,
-                sttClient: env.sttScheduler,
-                diarizationService: env.diarizationService
-            )
-        }
-    }
-
-    private func observeOpenSettings() {
-        settingsObserver = NotificationCenter.default.addObserver(
-            forName: .macParakeetOpenSettings,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor in
-                self?.openMainWindowToSettings()
-            }
-        }
-    }
-
-    func applicationDidBecomeActive(_ notification: Notification) {
-        guard reopenOnboardingOnNextActivate else { return }
-        maybeShowOnboarding()
-    }
-
-    private func showOnboarding() {
-        guard let env = appEnvironment else { return }
-        showOnboarding(
-            permissionService: env.permissionService,
-            sttClient: env.sttScheduler,
-            diarizationService: env.diarizationService
-        )
-    }
-
-    private func showOnboarding(
-        permissionService: PermissionServiceProtocol,
-        sttClient: STTClientProtocol,
-        diarizationService: DiarizationServiceProtocol? = nil
-    ) {
-        onboardingWindowController.show(
-            permissionService: permissionService,
-            sttClient: sttClient,
-            diarizationService: diarizationService,
-            onFinish: { [weak self] in
-                self?.reopenOnboardingOnNextActivate = false
-                self?.refreshHotkeyAfterPermissions()
-                // Start the 7-day trial now that onboarding is complete —
-                // user doesn't lose trial days to permission setup.
-                if let env = self?.appEnvironment {
-                    Task { await env.entitlementsService.bootstrapTrialIfNeeded() }
-                }
-            },
-            onOpenMainApp: { [weak self] in
-                self?.openMainWindow()
-            },
-            onOpenSettings: {
-                NotificationCenter.default.post(name: .macParakeetOpenSettings, object: nil)
-            },
-            onIncompleteDismiss: { [weak self] in
-                self?.reopenOnboardingOnNextActivate = true
-            }
-        )
-    }
-
     // MARK: - Menu Bar Icon State
 
     /// Priority-based menu bar icon resolver (ADR-015).
     /// Recording (meeting or dictation) > file transcription > idle.
     private func resolveAndUpdateMenuBarIcon() {
         if meetingRecordingFlowCoordinator?.isMeetingRecordingActive == true {
-            updateMenuBarIcon(state: .recording)
+            menuBarCoordinator.updateIcon(state: .recording)
         } else if dictationFlowCoordinator?.isDictationActive == true {
-            updateMenuBarIcon(state: .recording)
+            menuBarCoordinator.updateIcon(state: .recording)
         } else if transcriptionViewModel.isTranscribing {
-            updateMenuBarIcon(state: .processing)
+            menuBarCoordinator.updateIcon(state: .processing)
         } else {
-            updateMenuBarIcon(state: .idle)
+            menuBarCoordinator.updateIcon(state: .idle)
         }
     }
 
-    private func updateMenuBarIcon(state: BreathWaveIcon.MenuBarState) {
-        statusItem?.button?.image = BreathWaveIcon.menuBarIcon(pointSize: 18, state: state)
-    }
-
-    // MARK: - Dynamic Dock Icon (Menu Bar Only Mode)
-
-    /// Show dock icon temporarily when the main window is open in menu-bar-only mode.
-    private func showDockIconIfNeeded() {
-        guard settingsViewModel.menuBarOnlyMode else { return }
-        NSApp.setActivationPolicy(.regular)
-    }
-
-    /// Hide dock icon when the main window closes in menu-bar-only mode.
-    private func hideDockIconIfNeeded() {
-        guard settingsViewModel.menuBarOnlyMode else { return }
-        // Only hide if no primary windows are visible
-        guard !hasVisiblePrimaryWindow else { return }
-        NSApp.setActivationPolicy(.accessory)
-    }
-
-    private var hasVisiblePrimaryWindow: Bool {
-        (mainWindow?.isVisible ?? false) || onboardingWindowController.isVisible
-    }
-
-    // MARK: - Window Management
-
-    @objc private func openMainWindow() {
-        if mainWindow == nil {
-            createMainWindow()
-        }
-        mainWindow?.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
-    }
-
-    @objc private func openMainWindowToSettings() {
-        mainWindowState.selectedItem = .settings
-        openMainWindow()
-    }
-
-    @objc private func pasteLastDictation() {
-        guard let env = appEnvironment else { return }
-        Task {
-            guard let dictation = (try? env.dictationRepo.fetchAll(limit: 1))?.first else { return }
-            let text = dictation.cleanTranscript ?? dictation.rawTranscript
-            await pasteFromMenu(text: text, clipboardService: env.clipboardService)
-        }
-    }
-
-    @objc private func pasteRecentDictation(_ sender: NSMenuItem) {
-        guard let env = appEnvironment,
-              let id = sender.representedObject as? UUID else { return }
-        Task {
-            guard let dictation = try? env.dictationRepo.fetch(id: id) else { return }
-            let text = dictation.cleanTranscript ?? dictation.rawTranscript
-            await pasteFromMenu(text: text, clipboardService: env.clipboardService)
-        }
-    }
-
-    /// Resign menu-bar focus, wait for the target app to regain focus, then paste.
-    private func pasteFromMenu(text: String, clipboardService: ClipboardServiceProtocol) async {
-        NSApp.deactivate()
-        try? await Task.sleep(for: .milliseconds(200))
-        do {
-            try await clipboardService.pasteText(text)
-        } catch {
-            await clipboardService.copyToClipboard(text)
-        }
-    }
-
-    @objc private func transcribeFileFromMenu() {
-        guard appEnvironment != nil else { return }
-        NSApp.activate(ignoringOtherApps: true)
-        let panel = NSOpenPanel()
-        panel.allowsMultipleSelection = false
-        panel.canChooseDirectories = false
-        panel.allowedContentTypes = AudioFileConverter.supportedExtensions.compactMap {
-            UTType(filenameExtension: $0)
-        }
-
-        if panel.runModal() == .OK, let url = panel.url {
-            openMainWindow()
-            transcriptionViewModel.transcribeFile(url: url)
-            SoundManager.shared.play(.fileDropped)
-        }
-    }
-
-    @objc private func transcribeFromYouTubeMenu() {
-        guard appEnvironment != nil else { return }
-        youtubeInputController.show()
-    }
-
-    @objc private func toggleMeetingRecordingFromMenu() {
-        toggleMeetingRecording(originatesFromWindow: false)
-    }
+    // MARK: - Meeting Recording
 
     private func toggleMeetingRecording(originatesFromWindow: Bool) {
         guard appEnvironment != nil else { return }
+
         if meetingRecordingFlowCoordinator?.isMeetingRecordingActive == true {
             meetingRecordingFlowCoordinator?.toggleRecording()
             return
         }
 
         if originatesFromWindow {
-            openMainWindow()
+            windowCoordinator.openMainWindow()
             mainWindowState.selectedItem = .meetings
         }
+
         meetingRecordingFlowCoordinator?.toggleRecording()
-    }
-
-    private func rebuildRecentDictationsSubmenu(with dictations: [Dictation]) {
-        guard let recentItem = recentDictationsMenuItem else { return }
-        recentItem.isHidden = dictations.isEmpty
-
-        let submenu = NSMenu()
-        for dictation in dictations {
-            let text = (dictation.cleanTranscript ?? dictation.rawTranscript)
-                .replacingOccurrences(of: "\n", with: " ")
-            let truncated = text.count > 40 ? String(text.prefix(40)) + "…" : text
-            let item = NSMenuItem(
-                title: truncated,
-                action: #selector(pasteRecentDictation(_:)),
-                keyEquivalent: ""
-            )
-            item.representedObject = dictation.id
-            submenu.addItem(item)
-        }
-        recentItem.submenu = submenu
-    }
-
-    private func createMainWindow() {
-        let contentView = MainWindowView(
-            state: mainWindowState,
-            transcriptionViewModel: transcriptionViewModel,
-            historyViewModel: historyViewModel,
-            settingsViewModel: settingsViewModel,
-            llmSettingsViewModel: llmSettingsViewModel,
-            chatViewModel: chatViewModel,
-            promptResultsViewModel: promptResultsViewModel,
-            promptsViewModel: promptsViewModel,
-            customWordsViewModel: customWordsViewModel,
-            textSnippetsViewModel: textSnippetsViewModel,
-            feedbackViewModel: feedbackViewModel,
-            discoverViewModel: discoverViewModel,
-            libraryViewModel: libraryViewModel,
-            meetingsViewModel: meetingsViewModel,
-            updater: updaterController.updater,
-            onRecordMeeting: { [weak self] in
-                self?.toggleMeetingRecording(originatesFromWindow: true)
-            }
-        )
-
-        let window = NSWindow(
-            contentRect: NSRect(
-                x: 0, y: 0,
-                width: DesignSystem.Layout.sidebarMinWidth + DesignSystem.Layout.contentMinWidth,
-                height: DesignSystem.Layout.windowMinHeight
-            ),
-            styleMask: [.titled, .closable, .miniaturizable, .resizable],
-            backing: .buffered,
-            defer: false
-        )
-        window.title = "MacParakeet"
-        window.center()
-        window.setFrameAutosaveName("MainWindow")
-        window.minSize = NSSize(
-            width: DesignSystem.Layout.sidebarMinWidth + DesignSystem.Layout.contentMinWidth,
-            height: DesignSystem.Layout.windowMinHeight
-        )
-        window.titlebarAppearsTransparent = true
-        window.contentView = NSHostingView(rootView: contentView)
-        window.delegate = self
-        window.isReleasedWhenClosed = false
-
-        mainWindow = window
-    }
-
-    @objc private func showAboutPanel() {
-        let repoLink = "https://github.com/moona3k/macparakeet"
-        let credits = NSMutableAttributedString()
-
-        let style = NSMutableParagraphStyle()
-        style.alignment = .center
-
-        let normalAttrs: [NSAttributedString.Key: Any] = [
-            .font: NSFont.systemFont(ofSize: 11),
-            .paragraphStyle: style,
-        ]
-        let linkAttrs: [NSAttributedString.Key: Any] = [
-            .font: NSFont.systemFont(ofSize: 11),
-            .link: URL(string: repoLink)!,
-            .paragraphStyle: style,
-        ]
-
-        credits.append(NSAttributedString(string: "Free and open source (GPL-3.0)\n", attributes: normalAttrs))
-        credits.append(NSAttributedString(string: repoLink, attributes: linkAttrs))
-
-        NSApp.activate(ignoringOtherApps: true)
-        NSApp.orderFrontStandardAboutPanel(options: [
-            .credits: credits,
-        ])
-    }
-
-    @objc private func quitApp() {
-        NSApp.terminate(nil)
-    }
-
-    // MARK: - NSWindowDelegate
-
-    func windowDidBecomeMain(_ notification: Notification) {
-        guard let window = notification.object as? NSWindow, window === mainWindow else { return }
-        showDockIconIfNeeded()
-    }
-
-    func windowWillClose(_ notification: Notification) {
-        guard let window = notification.object as? NSWindow, window === mainWindow else { return }
-        // Delay slightly so macOS finishes closing the window before we check visibility
-        DispatchQueue.main.async { [weak self] in
-            self?.hideDockIconIfNeeded()
-        }
     }
 
     // MARK: - Alerts
@@ -1017,9 +392,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         alert.addButton(withTitle: "Open Settings")
         alert.addButton(withTitle: "Not Now")
 
-        let resp = alert.runModal()
-        if resp == .alertFirstButtonReturn {
-            openMainWindowToSettings()
+        let response = alert.runModal()
+        if response == .alertFirstButtonReturn {
+            windowCoordinator.openMainWindowToSettings()
         }
     }
 
@@ -1042,27 +417,36 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
         let response = alert.runModal()
         if response == .alertFirstButtonReturn {
-            openMainWindowToSettings()
+            windowCoordinator.openMainWindowToSettings()
         }
         #endif
     }
 
-}
+    private func showAboutPanel() {
+        let repoLink = "https://github.com/moona3k/macparakeet"
+        let credits = NSMutableAttributedString()
 
-// MARK: - NSMenuDelegate
+        let style = NSMutableParagraphStyle()
+        style.alignment = .center
 
-extension AppDelegate: NSMenuDelegate {
-    func menuNeedsUpdate(_ menu: NSMenu) {
-        guard let env = appEnvironment else {
-            pasteLastMenuItem?.isEnabled = false
-            recentDictationsMenuItem?.isHidden = true
-            return
-        }
-        let dictations = (try? env.dictationRepo.fetchAll(limit: 5)) ?? []
-        pasteLastMenuItem?.isEnabled = !dictations.isEmpty
-        rebuildRecentDictationsSubmenu(with: dictations)
-        recordMeetingMenuItem?.title = meetingRecordingFlowCoordinator?.isMeetingRecordingActive == true
-            ? "Stop Meeting Recording"
-            : "Record Meeting"
+        let normalAttributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 11),
+            .paragraphStyle: style,
+        ]
+        let linkAttributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 11),
+            .link: URL(string: repoLink)!,
+            .paragraphStyle: style,
+        ]
+
+        credits.append(NSAttributedString(string: "Free and open source (GPL-3.0)\n", attributes: normalAttributes))
+        credits.append(NSAttributedString(string: repoLink, attributes: linkAttributes))
+
+        NSApp.activate(ignoringOtherApps: true)
+        NSApp.orderFrontStandardAboutPanel(options: [.credits: credits])
+    }
+
+    private func quitApp() {
+        NSApp.terminate(nil)
     }
 }

--- a/Tests/MacParakeetTests/App/AppSettingsObserverCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/App/AppSettingsObserverCoordinatorTests.swift
@@ -19,30 +19,44 @@ final class AppSettingsObserverCoordinatorTests: XCTestCase {
         var meetingHotkeyTriggerCount = 0
         var menuBarOnlyCount = 0
         var showIdlePillCount = 0
+        var onCallback: (() -> Void)?
 
         lazy var coordinator: AppSettingsObserverCoordinator = AppSettingsObserverCoordinator(
             notificationCenter: center,
-            onOpenOnboarding: { [unowned self] in self.onboardingCount += 1 },
-            onOpenSettings: { [unowned self] in self.settingsCount += 1 },
-            onHotkeyTriggerChanged: { [unowned self] in self.hotkeyTriggerCount += 1 },
-            onMeetingHotkeyTriggerChanged: { [unowned self] in self.meetingHotkeyTriggerCount += 1 },
-            onMenuBarOnlyModeChanged: { [unowned self] in self.menuBarOnlyCount += 1 },
-            onShowIdlePillChanged: { [unowned self] in self.showIdlePillCount += 1 }
+            onOpenOnboarding: { [unowned self] in
+                self.onboardingCount += 1
+                self.onCallback?()
+            },
+            onOpenSettings: { [unowned self] in
+                self.settingsCount += 1
+                self.onCallback?()
+            },
+            onHotkeyTriggerChanged: { [unowned self] in
+                self.hotkeyTriggerCount += 1
+                self.onCallback?()
+            },
+            onMeetingHotkeyTriggerChanged: { [unowned self] in
+                self.meetingHotkeyTriggerCount += 1
+                self.onCallback?()
+            },
+            onMenuBarOnlyModeChanged: { [unowned self] in
+                self.menuBarOnlyCount += 1
+                self.onCallback?()
+            },
+            onShowIdlePillChanged: { [unowned self] in
+                self.showIdlePillCount += 1
+                self.onCallback?()
+            }
         )
-    }
-
-    /// Observer handlers dispatch via `Task { @MainActor in ... }`, so tests
-    /// must yield to let the main actor drain pending work before asserting.
-    private func drainMainActor() async {
-        for _ in 0..<5 {
-            await Task.yield()
-        }
     }
 
     // MARK: - Tests
 
     func test_startObserving_routesEachNotificationToItsCallback() async {
         let fx = Fixture()
+        let callbacks = expectation(description: "all callbacks fire")
+        callbacks.expectedFulfillmentCount = 6
+        fx.onCallback = { callbacks.fulfill() }
         fx.coordinator.startObserving()
 
         fx.center.post(name: .macParakeetOpenOnboarding, object: nil)
@@ -52,7 +66,7 @@ final class AppSettingsObserverCoordinatorTests: XCTestCase {
         fx.center.post(name: .macParakeetMenuBarOnlyModeDidChange, object: nil)
         fx.center.post(name: .macParakeetShowIdlePillDidChange, object: nil)
 
-        await drainMainActor()
+        await fulfillment(of: [callbacks], timeout: 1.0)
 
         XCTAssertEqual(fx.onboardingCount, 1)
         XCTAssertEqual(fx.settingsCount, 1)
@@ -64,6 +78,9 @@ final class AppSettingsObserverCoordinatorTests: XCTestCase {
 
     func test_stopObserving_removesAllObservers() async {
         let fx = Fixture()
+        let noCallbacks = expectation(description: "no callbacks after stopObserving")
+        noCallbacks.isInverted = true
+        fx.onCallback = { noCallbacks.fulfill() }
         fx.coordinator.startObserving()
         fx.coordinator.stopObserving()
 
@@ -74,7 +91,7 @@ final class AppSettingsObserverCoordinatorTests: XCTestCase {
         fx.center.post(name: .macParakeetMenuBarOnlyModeDidChange, object: nil)
         fx.center.post(name: .macParakeetShowIdlePillDidChange, object: nil)
 
-        await drainMainActor()
+        await fulfillment(of: [noCallbacks], timeout: 0.2)
 
         XCTAssertEqual(fx.onboardingCount, 0)
         XCTAssertEqual(fx.settingsCount, 0)
@@ -88,11 +105,13 @@ final class AppSettingsObserverCoordinatorTests: XCTestCase {
         // startObserving() defensively calls stopObserving() first. Calling it
         // twice must not leave two observers on the same notification.
         let fx = Fixture()
+        let callbacks = expectation(description: "single callback fired")
+        fx.onCallback = { callbacks.fulfill() }
         fx.coordinator.startObserving()
         fx.coordinator.startObserving()
 
         fx.center.post(name: .macParakeetHotkeyTriggerDidChange, object: nil)
-        await drainMainActor()
+        await fulfillment(of: [callbacks], timeout: 1.0)
 
         XCTAssertEqual(fx.hotkeyTriggerCount, 1)
     }
@@ -106,13 +125,16 @@ final class AppSettingsObserverCoordinatorTests: XCTestCase {
 
     func test_restart_afterStop_reattachesAllObservers() async {
         let fx = Fixture()
+        let callbacks = expectation(description: "callbacks fire after restart")
+        callbacks.expectedFulfillmentCount = 2
+        fx.onCallback = { callbacks.fulfill() }
         fx.coordinator.startObserving()
         fx.coordinator.stopObserving()
         fx.coordinator.startObserving()
 
         fx.center.post(name: .macParakeetShowIdlePillDidChange, object: nil)
         fx.center.post(name: .macParakeetMenuBarOnlyModeDidChange, object: nil)
-        await drainMainActor()
+        await fulfillment(of: [callbacks], timeout: 1.0)
 
         XCTAssertEqual(fx.showIdlePillCount, 1)
         XCTAssertEqual(fx.menuBarOnlyCount, 1)
@@ -121,10 +143,12 @@ final class AppSettingsObserverCoordinatorTests: XCTestCase {
     func test_callbacksAreIsolated_perNotificationName() async {
         // Posting one notification must not fire unrelated callbacks.
         let fx = Fixture()
+        let callbacks = expectation(description: "single callback for onboarding")
+        fx.onCallback = { callbacks.fulfill() }
         fx.coordinator.startObserving()
 
         fx.center.post(name: .macParakeetOpenOnboarding, object: nil)
-        await drainMainActor()
+        await fulfillment(of: [callbacks], timeout: 1.0)
 
         XCTAssertEqual(fx.onboardingCount, 1)
         XCTAssertEqual(fx.settingsCount, 0)

--- a/Tests/MacParakeetTests/App/AppSettingsObserverCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/App/AppSettingsObserverCoordinatorTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+import MacParakeetCore
+@testable import MacParakeet
+
+@MainActor
+final class AppSettingsObserverCoordinatorTests: XCTestCase {
+
+    // MARK: - Fixture
+
+    /// Bundles a coordinator with an isolated NotificationCenter and counters
+    /// for each callback, so tests don't bleed into `.default` and can assert
+    /// per-notification routing without timing races on shared state.
+    @MainActor
+    private final class Fixture {
+        let center = NotificationCenter()
+        var onboardingCount = 0
+        var settingsCount = 0
+        var hotkeyTriggerCount = 0
+        var meetingHotkeyTriggerCount = 0
+        var menuBarOnlyCount = 0
+        var showIdlePillCount = 0
+
+        lazy var coordinator: AppSettingsObserverCoordinator = AppSettingsObserverCoordinator(
+            notificationCenter: center,
+            onOpenOnboarding: { [unowned self] in self.onboardingCount += 1 },
+            onOpenSettings: { [unowned self] in self.settingsCount += 1 },
+            onHotkeyTriggerChanged: { [unowned self] in self.hotkeyTriggerCount += 1 },
+            onMeetingHotkeyTriggerChanged: { [unowned self] in self.meetingHotkeyTriggerCount += 1 },
+            onMenuBarOnlyModeChanged: { [unowned self] in self.menuBarOnlyCount += 1 },
+            onShowIdlePillChanged: { [unowned self] in self.showIdlePillCount += 1 }
+        )
+    }
+
+    /// Observer handlers dispatch via `Task { @MainActor in ... }`, so tests
+    /// must yield to let the main actor drain pending work before asserting.
+    private func drainMainActor() async {
+        for _ in 0..<5 {
+            await Task.yield()
+        }
+    }
+
+    // MARK: - Tests
+
+    func test_startObserving_routesEachNotificationToItsCallback() async {
+        let fx = Fixture()
+        fx.coordinator.startObserving()
+
+        fx.center.post(name: .macParakeetOpenOnboarding, object: nil)
+        fx.center.post(name: .macParakeetOpenSettings, object: nil)
+        fx.center.post(name: .macParakeetHotkeyTriggerDidChange, object: nil)
+        fx.center.post(name: .macParakeetMeetingHotkeyTriggerDidChange, object: nil)
+        fx.center.post(name: .macParakeetMenuBarOnlyModeDidChange, object: nil)
+        fx.center.post(name: .macParakeetShowIdlePillDidChange, object: nil)
+
+        await drainMainActor()
+
+        XCTAssertEqual(fx.onboardingCount, 1)
+        XCTAssertEqual(fx.settingsCount, 1)
+        XCTAssertEqual(fx.hotkeyTriggerCount, 1)
+        XCTAssertEqual(fx.meetingHotkeyTriggerCount, 1)
+        XCTAssertEqual(fx.menuBarOnlyCount, 1)
+        XCTAssertEqual(fx.showIdlePillCount, 1)
+    }
+
+    func test_stopObserving_removesAllObservers() async {
+        let fx = Fixture()
+        fx.coordinator.startObserving()
+        fx.coordinator.stopObserving()
+
+        fx.center.post(name: .macParakeetOpenOnboarding, object: nil)
+        fx.center.post(name: .macParakeetOpenSettings, object: nil)
+        fx.center.post(name: .macParakeetHotkeyTriggerDidChange, object: nil)
+        fx.center.post(name: .macParakeetMeetingHotkeyTriggerDidChange, object: nil)
+        fx.center.post(name: .macParakeetMenuBarOnlyModeDidChange, object: nil)
+        fx.center.post(name: .macParakeetShowIdlePillDidChange, object: nil)
+
+        await drainMainActor()
+
+        XCTAssertEqual(fx.onboardingCount, 0)
+        XCTAssertEqual(fx.settingsCount, 0)
+        XCTAssertEqual(fx.hotkeyTriggerCount, 0)
+        XCTAssertEqual(fx.meetingHotkeyTriggerCount, 0)
+        XCTAssertEqual(fx.menuBarOnlyCount, 0)
+        XCTAssertEqual(fx.showIdlePillCount, 0)
+    }
+
+    func test_startObserving_isIdempotent_doesNotDoubleFire() async {
+        // startObserving() defensively calls stopObserving() first. Calling it
+        // twice must not leave two observers on the same notification.
+        let fx = Fixture()
+        fx.coordinator.startObserving()
+        fx.coordinator.startObserving()
+
+        fx.center.post(name: .macParakeetHotkeyTriggerDidChange, object: nil)
+        await drainMainActor()
+
+        XCTAssertEqual(fx.hotkeyTriggerCount, 1)
+    }
+
+    func test_stopObserving_isIdempotent_whenNeverStarted() {
+        let fx = Fixture()
+        // Calling stop on a fresh coordinator must not crash or throw.
+        fx.coordinator.stopObserving()
+        fx.coordinator.stopObserving()
+    }
+
+    func test_restart_afterStop_reattachesAllObservers() async {
+        let fx = Fixture()
+        fx.coordinator.startObserving()
+        fx.coordinator.stopObserving()
+        fx.coordinator.startObserving()
+
+        fx.center.post(name: .macParakeetShowIdlePillDidChange, object: nil)
+        fx.center.post(name: .macParakeetMenuBarOnlyModeDidChange, object: nil)
+        await drainMainActor()
+
+        XCTAssertEqual(fx.showIdlePillCount, 1)
+        XCTAssertEqual(fx.menuBarOnlyCount, 1)
+    }
+
+    func test_callbacksAreIsolated_perNotificationName() async {
+        // Posting one notification must not fire unrelated callbacks.
+        let fx = Fixture()
+        fx.coordinator.startObserving()
+
+        fx.center.post(name: .macParakeetOpenOnboarding, object: nil)
+        await drainMainActor()
+
+        XCTAssertEqual(fx.onboardingCount, 1)
+        XCTAssertEqual(fx.settingsCount, 0)
+        XCTAssertEqual(fx.hotkeyTriggerCount, 0)
+        XCTAssertEqual(fx.meetingHotkeyTriggerCount, 0)
+        XCTAssertEqual(fx.menuBarOnlyCount, 0)
+        XCTAssertEqual(fx.showIdlePillCount, 0)
+    }
+}


### PR DESCRIPTION
Closes #89

## Summary
This PR refactors `AppDelegate` into a thin lifecycle/orchestration shell and extracts focused coordinators for startup, environment wiring, menu, windowing, onboarding, and settings observers.

Goal: preserve behavior while reducing coupling and lowering regression risk.

## Why
`AppDelegate` previously mixed too many responsibilities:
- startup/bootstrap and fatal startup handling
- app menu + status menu wiring
- NotificationCenter observer lifecycle
- window lifecycle / Dock policy / reopen routing
- onboarding policy and completion flow
- command dispatch and alert orchestration

This made review, testing, and iteration riskier than necessary.

## Architecture
### Before
```text
AppDelegate
 ├─ lifecycle
 ├─ startup/bootstrap
 ├─ env + VM wiring
 ├─ menu/status menu
 ├─ observers
 ├─ window + dock policy
 ├─ onboarding
 └─ command handlers / alerts
```

### After
```text
AppDelegate (thin shell)
 ├─ lifecycle callbacks
 ├─ startup task orchestration
 ├─ high-level alert presentation
 └─ menu icon-state resolution

AppStartupBootstrapper
AppEnvironmentConfigurer
MenuBarCoordinator
AppSettingsObserverCoordinator
AppWindowCoordinator
OnboardingCoordinator
```

## What Changed
1. Startup boundary
- Added `AppStartupBootstrapper`.
- Moved directory/database bootstrap and one-time launch cleanup off main actor.

2. Composition boundary
- Added `AppEnvironmentConfigurer`.
- Moved environment, view-model, and coordinator composition out of `AppDelegate`.
- Centralized cross-VM callback wiring.

3. Menu boundary
- Added `MenuBarCoordinator`.
- Moved app-menu/status-menu construction, actions, and dynamic menu refresh (`NSMenuDelegate`).

4. Observer boundary
- Added `AppSettingsObserverCoordinator`.
- Moved NotificationCenter registration/teardown and callback routing.

5. Window boundary
- Added `AppWindowCoordinator`.
- Moved main-window creation/routing, Dock menu behavior, reopen behavior, and activation policy handling.

6. Onboarding boundary
- Added `OnboardingCoordinator`.
- Moved onboarding presentation/reopen policy and completion hooks.

7. Environment constructor cleanup
- `AppEnvironment` now uses injected DB manager: `init(databaseManager:)`.

## Follow-up Fixes From Review Feedback
- Fixed cross-coordinator retain-cycle risk by switching to weak cross-references in `AppEnvironmentConfigurer` (`cb70b18`).
- Fixed startup cancellation propagation (`Task.detached` cancellation handling) in `AppStartupBootstrapper` (`cb70b18`).
- Replaced force-unwrap for About panel repo URL with safe optional binding (`cb70b18`).
- Fixed meeting-tab selection order to avoid stale-tab flash (`90ce910`).
- Made `AppSettingsObserverCoordinator` tests deterministic (removed `Task.yield()`-based draining) (`90ce910`).

## Scope / Non-goals
- No intentional feature changes.
- No intentional UX redesign.
- No new global singletons.

## Behavior Parity
- Launch and fatal startup alert flow preserved.
- Menu actions and recent-dictations submenu behavior preserved.
- Hotkey and meeting-hotkey refresh behavior preserved.
- Onboarding open/reopen behavior preserved.
- Menu-bar-only Dock policy behavior preserved.

## Validation
- Automated:
  - `swift test --scratch-path .build-pr-appdelegate`
  - `swift test --scratch-path .build-pr90-review-5 --parallel --num-workers 1`
  - Result: **1320/1320 tests passing**.

- Manual smoke checklist:
  1. Launch path
  2. Startup-failure alert path
  3. Status menu interactions
  4. Paste last/recent dictation
  5. File/YouTube transcription entry points
  6. Meeting toggle (menu/window/hotkey)
  7. Onboarding open/reopen flow
  8. Menu-bar-only Dock behavior
  9. Termination path

## Impact
- `AppDelegate.swift` reduced from ~1085 LOC to ~452 LOC.
- Responsibilities are explicit and locally testable.
- Future lifecycle/menu/window changes have lower blast radius.
