### PR TITLE
Fix first-dictation crash for people using Krisp, BlackHole, Loopback, or other virtual audio tools

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -46,12 +46,22 @@ let package = Package(
             ],
             path: "Sources/CLI"
         ),
+        // Objective-C shim target for catching NSException in Swift.
+        // Swift's `do/try/catch` cannot catch Objective-C exceptions raised by
+        // AppKit / AVFoundation / Core Audio — we need an @try/@catch trampoline
+        // to convert them into Swift-throwable NSError values. See issue #91.
+        .target(
+            name: "MacParakeetObjCShims",
+            path: "Sources/MacParakeetObjCShims",
+            publicHeadersPath: "include"
+        ),
         // Shared core library (no UI dependencies)
         .target(
             name: "MacParakeetCore",
             dependencies: [
                 .product(name: "GRDB", package: "GRDB.swift"),
-                .product(name: "FluidAudio", package: "FluidAudio")
+                .product(name: "FluidAudio", package: "FluidAudio"),
+                "MacParakeetObjCShims"
             ],
             path: "Sources/MacParakeetCore",
             exclude: ["Resources"]
@@ -65,7 +75,7 @@ let package = Package(
         // Tests
         .testTarget(
             name: "MacParakeetTests",
-            dependencies: ["MacParakeet", "MacParakeetCore", "MacParakeetViewModels"],
+            dependencies: ["MacParakeet", "MacParakeetCore", "MacParakeetViewModels", "MacParakeetObjCShims"],
             path: "Tests/MacParakeetTests"
         ),
         .testTarget(

--- a/Sources/MacParakeetCore/Audio/AudioRecorder.swift
+++ b/Sources/MacParakeetCore/Audio/AudioRecorder.swift
@@ -70,8 +70,18 @@ public actor AudioRecorder {
     public func start() throws {
         guard !recording else { return }
 
+        // Hard-gate on microphone permission. Today AVFAudio will still attempt
+        // to start without authorization and fail deep in the audio stack with
+        // an opaque NSException. The UI layer requests mic access during
+        // onboarding, so anything other than `.authorized` here means either a
+        // first-run race or the user revoked access in System Settings.
         let authStatus = AVCaptureDevice.authorizationStatus(for: .audio)
         logger.debug("mic_permission_status=\(authStatus.rawValue, privacy: .public)")
+        guard authStatus == .authorized else {
+            throw AudioProcessorError.recordingFailed(
+                "Microphone permission not granted (status=\(authStatus.rawValue)). Grant access in System Settings → Privacy & Security → Microphone."
+            )
+        }
 
         logAvailableDevices()
 
@@ -161,7 +171,13 @@ public actor AudioRecorder {
             )
         }
 
-        let inputFormat = inputNode.outputFormat(forBus: 0)
+        // AVFAudio raises an Objective-C NSException on aggregate / virtual
+        // audio devices in bad states (issue #91). Swift can't catch it without
+        // the ObjC trampoline — without the wrap this line will abort the
+        // process on cluster-A/C crash paths.
+        let inputFormat = try catchingObjCException {
+            inputNode.outputFormat(forBus: 0)
+        }
         logger.info(
             "input_format sr=\(inputFormat.sampleRate, privacy: .public) ch=\(inputFormat.channelCount, privacy: .public) common_format=\(inputFormat.commonFormat.rawValue, privacy: .public)"
         )
@@ -208,8 +224,9 @@ public actor AudioRecorder {
         let url = tempDir.appendingPathComponent("\(UUID().uuidString).wav")
         let file = try AVAudioFile(forWriting: url, settings: outputFormat.settings)
 
-        // Install converter + tap
-        guard let converter = AVAudioConverter(from: inputFormat, to: outputFormat) else {
+        // Pre-validate that the format we just read is convertible to our
+        // target. If this fails we want to bail fast before touching the tap.
+        guard AVAudioConverter(from: inputFormat, to: outputFormat) != nil else {
             try? FileManager.default.removeItem(at: url)
             logger.error(
                 "failed_to_create_audio_converter from sr=\(inputFormat.sampleRate) ch=\(inputFormat.channelCount) to 16kHz 1ch"
@@ -224,103 +241,165 @@ public actor AudioRecorder {
         // Capture the current generation so stale callbacks from previous sessions bail out.
         let tapGeneration = self.sessionGeneration.withLock { $0 }
 
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) {
-            [weak self] buffer, _ in
-            guard let self else { return }
+        // Converter cache for the tap block. We pass `format: nil` to
+        // installTap so AVFAudio delivers buffers in whatever format the bus
+        // is currently producing (avoiding the aggregate-device format-drift
+        // NSException that caused issue #91), and build the converter lazily
+        // on the first buffer. Tap callbacks are serialized per bus so a plain
+        // reference-type cache is safe; `@unchecked Sendable` satisfies Swift 6
+        // concurrency checks.
+        let converterCache = TapConverterCache()
 
-            // Bail if stop() was called (generation bumped) or a new session started
-            let currentGen = self.sessionGeneration.withLock { $0 }
-            guard currentGen == tapGeneration else { return }
+        // AVFAudio can raise NSException from installTap itself on aggregate
+        // devices (e.g. "required condition is false:
+        // IsFormatSampleRateAndChannelCountValid(hwFormat)"). Wrap the install
+        // call so the caller sees a Swift error rather than a hard abort.
+        do {
+            try catchingObjCException {
+                inputNode.installTap(onBus: 0, bufferSize: 4096, format: nil) {
+                    [weak self] buffer, _ in
+                    guard let self else { return }
 
-            // Calculate audio level (RMS) — written atomically, no Task allocation needed
-            let channelData = buffer.floatChannelData?[0]
-            let frameCount = Int(buffer.frameLength)
-            if let data = channelData, frameCount > 0 {
-                var rms: Float = 0
-                for i in 0..<frameCount {
-                    rms += data[i] * data[i]
-                }
-                rms = sqrtf(rms / Float(frameCount))
-                let normalized = min(rms * 5.0, 1.0)
-                self.atomicAudioLevel.withLock { level in
-                    level = level * 0.3 + normalized * 0.7
-                }
-            }
+                    // Bail if stop() was called (generation bumped) or a new session started
+                    let currentGen = self.sessionGeneration.withLock { $0 }
+                    guard currentGen == tapGeneration else { return }
 
-            // Convert to output format
-            let outputFrameCapacity = AVAudioFrameCount(
-                ceil(Double(buffer.frameLength) * outputFormat.sampleRate / inputFormat.sampleRate)
-            )
-            guard outputFrameCapacity > 0,
-                let convertedBuffer = AVAudioPCMBuffer(
-                    pcmFormat: outputFormat,
-                    frameCapacity: outputFrameCapacity
-                )
-            else { return }
-
-            // One-shot input block: provide the buffer exactly once per convert() call.
-            // The converter may call the input block multiple times if it needs more data;
-            // returning the same buffer repeatedly would duplicate samples.
-            var inputConsumed = false
-            var error: NSError?
-            let status = converter.convert(to: convertedBuffer, error: &error) { _, outStatus in
-                if inputConsumed {
-                    outStatus.pointee = .noDataNow
-                    return nil
-                }
-                inputConsumed = true
-                outStatus.pointee = .haveData
-                return buffer
-            }
-
-            switch status {
-            case .haveData:
-                // Re-check generation before writing — stop() may have been called
-                // between the guard at the top and here.
-                guard self.sessionGeneration.withLock({ $0 }) == tapGeneration else { return }
-                do {
-                    try file.write(from: convertedBuffer)
-                    self.sampleCounter.withLock { $0 += Int(convertedBuffer.frameLength) }
-                } catch {
-                    // Log but don't crash — we're on the audio thread.
-                    // Throttled: only first error per session is logged.
-                    let alreadyLogged = self.tapErrorLogged.withLock { logged in
-                        let was = logged; logged = true; return was
+                    // Calculate audio level (RMS) — written atomically, no Task allocation needed
+                    let channelData = buffer.floatChannelData?[0]
+                    let frameCount = Int(buffer.frameLength)
+                    if let data = channelData, frameCount > 0 {
+                        var rms: Float = 0
+                        for i in 0..<frameCount {
+                            rms += data[i] * data[i]
+                        }
+                        rms = sqrtf(rms / Float(frameCount))
+                        let normalized = min(rms * 5.0, 1.0)
+                        self.atomicAudioLevel.withLock { level in
+                            level = level * 0.3 + normalized * 0.7
+                        }
                     }
-                    if !alreadyLogged {
-                        let desc = error.localizedDescription
-                        Task { await self.logTapError("audio_write_error: \(desc)") }
+
+                    // Lazily build the converter from the *actual* buffer format.
+                    // With `format: nil` on installTap, AVFAudio delivers whatever
+                    // the bus is currently producing — which may differ from the
+                    // format we snapshotted before installTap. Re-check on each
+                    // buffer and rebuild the converter if the format drifts
+                    // mid-stream (rare, but cheap to handle).
+                    let bufferFormat = buffer.format
+                    if converterCache.sourceFormat == nil
+                        || converterCache.sourceFormat?.sampleRate != bufferFormat.sampleRate
+                        || converterCache.sourceFormat?.channelCount != bufferFormat.channelCount
+                        || converterCache.sourceFormat?.commonFormat != bufferFormat.commonFormat
+                    {
+                        converterCache.converter = AVAudioConverter(from: bufferFormat, to: outputFormat)
+                        converterCache.sourceFormat = bufferFormat
                     }
-                }
-            case .error:
-                // Log converter errors (throttled — only first occurrence per recording)
-                let alreadyLogged = self.tapErrorLogged.withLock { logged in
-                    let was = logged
-                    logged = true
-                    return was
-                }
-                if !alreadyLogged {
-                    let desc = error?.localizedDescription ?? "unknown"
-                    Task {
-                        await self.logTapError(
-                            "converter_error: \(desc)"
+                    guard let converter = converterCache.converter else {
+                        let alreadyLogged = self.tapErrorLogged.withLock { logged in
+                            let was = logged; logged = true; return was
+                        }
+                        if !alreadyLogged {
+                            let sr = bufferFormat.sampleRate
+                            let ch = bufferFormat.channelCount
+                            Task { await self.logTapError("converter_init_failed sr=\(sr) ch=\(ch)") }
+                        }
+                        return
+                    }
+
+                    // Convert to output format
+                    let outputFrameCapacity = AVAudioFrameCount(
+                        ceil(Double(buffer.frameLength) * outputFormat.sampleRate / bufferFormat.sampleRate)
+                    )
+                    guard outputFrameCapacity > 0,
+                        let convertedBuffer = AVAudioPCMBuffer(
+                            pcmFormat: outputFormat,
+                            frameCapacity: outputFrameCapacity
                         )
+                    else { return }
+
+                    // One-shot input block: provide the buffer exactly once per convert() call.
+                    // The converter may call the input block multiple times if it needs more data;
+                    // returning the same buffer repeatedly would duplicate samples.
+                    var inputConsumed = false
+                    var error: NSError?
+                    let status = converter.convert(to: convertedBuffer, error: &error) { _, outStatus in
+                        if inputConsumed {
+                            outStatus.pointee = .noDataNow
+                            return nil
+                        }
+                        inputConsumed = true
+                        outStatus.pointee = .haveData
+                        return buffer
+                    }
+
+                    switch status {
+                    case .haveData:
+                        // Re-check generation before writing — stop() may have been called
+                        // between the guard at the top and here.
+                        guard self.sessionGeneration.withLock({ $0 }) == tapGeneration else { return }
+                        do {
+                            try file.write(from: convertedBuffer)
+                            self.sampleCounter.withLock { $0 += Int(convertedBuffer.frameLength) }
+                        } catch {
+                            // Log but don't crash — we're on the audio thread.
+                            // Throttled: only first error per session is logged.
+                            let alreadyLogged = self.tapErrorLogged.withLock { logged in
+                                let was = logged; logged = true; return was
+                            }
+                            if !alreadyLogged {
+                                let desc = error.localizedDescription
+                                Task { await self.logTapError("audio_write_error: \(desc)") }
+                            }
+                        }
+                    case .error:
+                        // Log converter errors (throttled — only first occurrence per recording)
+                        let alreadyLogged = self.tapErrorLogged.withLock { logged in
+                            let was = logged
+                            logged = true
+                            return was
+                        }
+                        if !alreadyLogged {
+                            let desc = error?.localizedDescription ?? "unknown"
+                            Task {
+                                await self.logTapError(
+                                    "converter_error: \(desc)"
+                                )
+                            }
+                        }
+                    case .endOfStream:
+                        break
+                    case .inputRanDry:
+                        break
+                    @unknown default:
+                        break
                     }
                 }
-            case .endOfStream:
-                break
-            case .inputRanDry:
-                break
-            @unknown default:
-                break
             }
+        } catch {
+            // installTap raised an NSException (issue #91) — cluster A/C crash
+            // path. Clean up and convert to a Swift error so the built-in-mic
+            // fallback in start() gets a chance, and so DictationService's
+            // catch emits a dictation_failed telemetry event with the real
+            // NSException reason in `error_detail`.
+            try? FileManager.default.removeItem(at: url)
+            logger.error(
+                "install_tap_raised error=\(error.localizedDescription, privacy: .public)"
+            )
+            throw AudioProcessorError.recordingFailed(
+                "Audio tap install failed: \(error.localizedDescription)"
+            )
         }
 
         // Reset counter before engine.start() — the tap can fire immediately after start.
         self.sampleCounter.withLock { $0 = 0 }
 
+        // engine.start() is documented to throw Swift errors, but has been
+        // observed to raise NSException in corner cases (stale CoreAudio state,
+        // aggregate device teardown mid-start). Belt-and-braces wrap.
         do {
-            try engine.start()
+            try catchingObjCException {
+                try engine.start()
+            }
         } catch {
             // Clean up before propagating
             inputNode.removeTap(onBus: 0)
@@ -352,4 +431,13 @@ public actor AudioRecorder {
     private func logTapError(_ message: String) {
         logger.warning("audio_tap \(message, privacy: .public)")
     }
+}
+
+/// Mutable cache for the tap block's `AVAudioConverter`. Tap callbacks are
+/// serialized per bus by AVAudioEngine, so no locking is required. Marked
+/// `@unchecked Sendable` to satisfy Swift 6 strict concurrency checks on the
+/// escaping tap closure capture.
+private final class TapConverterCache: @unchecked Sendable {
+    var converter: AVAudioConverter?
+    var sourceFormat: AVAudioFormat?
 }

--- a/Sources/MacParakeetCore/Audio/AudioRecorder.swift
+++ b/Sources/MacParakeetCore/Audio/AudioRecorder.swift
@@ -304,7 +304,10 @@ public actor AudioRecorder {
                     // (including interleaving/layout), not just SR/ch/common.
                     // Aggregate-device transitions can keep SR/ch/common stable
                     // while flipping other format details.
-                    if converterCache.sourceFormat?.isEqual(bufferFormat) != true {
+                    if tapConverterNeedsRebuild(
+                        cachedSourceFormat: converterCache.sourceFormat,
+                        incomingBufferFormat: bufferFormat
+                    ) {
                         converterCache.converter = AVAudioConverter(from: bufferFormat, to: outputFormat)
                         converterCache.sourceFormat = bufferFormat
                     }
@@ -445,6 +448,14 @@ public actor AudioRecorder {
     private func logTapError(_ message: String) {
         logger.warning("audio_tap \(message, privacy: .public)")
     }
+}
+
+@inline(__always)
+func tapConverterNeedsRebuild(
+    cachedSourceFormat: AVAudioFormat?,
+    incomingBufferFormat: AVAudioFormat
+) -> Bool {
+    cachedSourceFormat?.isEqual(incomingBufferFormat) != true
 }
 
 /// Mutable cache for the tap block's `AVAudioConverter`. Tap callbacks are

--- a/Sources/MacParakeetCore/Audio/AudioRecorder.swift
+++ b/Sources/MacParakeetCore/Audio/AudioRecorder.swift
@@ -300,11 +300,11 @@ public actor AudioRecorder {
                     // would crash. Bail out quietly — the next buffer is
                     // usually well-formed.
                     guard bufferFormat.sampleRate > 0, bufferFormat.channelCount > 0 else { return }
-                    if converterCache.sourceFormat == nil
-                        || converterCache.sourceFormat?.sampleRate != bufferFormat.sampleRate
-                        || converterCache.sourceFormat?.channelCount != bufferFormat.channelCount
-                        || converterCache.sourceFormat?.commonFormat != bufferFormat.commonFormat
-                    {
+                    // Rebuild when the *full* AVAudioFormat identity changes
+                    // (including interleaving/layout), not just SR/ch/common.
+                    // Aggregate-device transitions can keep SR/ch/common stable
+                    // while flipping other format details.
+                    if converterCache.sourceFormat?.isEqual(bufferFormat) != true {
                         converterCache.converter = AVAudioConverter(from: bufferFormat, to: outputFormat)
                         converterCache.sourceFormat = bufferFormat
                     }

--- a/Sources/MacParakeetCore/Audio/AudioRecorder.swift
+++ b/Sources/MacParakeetCore/Audio/AudioRecorder.swift
@@ -78,9 +78,10 @@ public actor AudioRecorder {
         let authStatus = AVCaptureDevice.authorizationStatus(for: .audio)
         logger.debug("mic_permission_status=\(authStatus.rawValue, privacy: .public)")
         guard authStatus == .authorized else {
-            throw AudioProcessorError.recordingFailed(
-                "Microphone permission not granted (status=\(authStatus.rawValue)). Grant access in System Settings → Privacy & Security → Microphone."
+            logger.error(
+                "mic_permission_not_granted status=\(authStatus.rawValue, privacy: .public)"
             )
+            throw AudioProcessorError.microphonePermissionDenied
         }
 
         logAvailableDevices()
@@ -226,7 +227,7 @@ public actor AudioRecorder {
 
         // Pre-validate that the format we just read is convertible to our
         // target. If this fails we want to bail fast before touching the tap.
-        guard AVAudioConverter(from: inputFormat, to: outputFormat) != nil else {
+        guard let initialConverter = AVAudioConverter(from: inputFormat, to: outputFormat) else {
             try? FileManager.default.removeItem(at: url)
             logger.error(
                 "failed_to_create_audio_converter from sr=\(inputFormat.sampleRate) ch=\(inputFormat.channelCount) to 16kHz 1ch"
@@ -244,11 +245,17 @@ public actor AudioRecorder {
         // Converter cache for the tap block. We pass `format: nil` to
         // installTap so AVFAudio delivers buffers in whatever format the bus
         // is currently producing (avoiding the aggregate-device format-drift
-        // NSException that caused issue #91), and build the converter lazily
-        // on the first buffer. Tap callbacks are serialized per bus so a plain
-        // reference-type cache is safe; `@unchecked Sendable` satisfies Swift 6
-        // concurrency checks.
+        // NSException that caused issue #91). Seed the cache with the
+        // converter we just created so the common case (bus format unchanged
+        // between `outputFormat(forBus:)` and the first tap callback) avoids
+        // a redundant `AVAudioConverter` allocation on the real-time audio
+        // thread. If the bus format drifts mid-stream the cache rebuilds it.
+        // Tap callbacks are serialized per bus so a plain reference-type
+        // cache is safe; `@unchecked Sendable` satisfies Swift 6 concurrency
+        // checks.
         let converterCache = TapConverterCache()
+        converterCache.converter = initialConverter
+        converterCache.sourceFormat = inputFormat
 
         // AVFAudio can raise NSException from installTap itself on aggregate
         // devices (e.g. "required condition is false:
@@ -286,6 +293,13 @@ public actor AudioRecorder {
                     // buffer and rebuild the converter if the format drifts
                     // mid-stream (rare, but cheap to handle).
                     let bufferFormat = buffer.format
+                    // Aggregate/virtual devices can occasionally deliver a
+                    // buffer whose format has sampleRate=0 or channelCount=0
+                    // during a hardware transition (Bluetooth HFP↔A2DP, USB
+                    // hot-plug, wake-from-sleep). Dividing by sampleRate below
+                    // would crash. Bail out quietly — the next buffer is
+                    // usually well-formed.
+                    guard bufferFormat.sampleRate > 0, bufferFormat.channelCount > 0 else { return }
                     if converterCache.sourceFormat == nil
                         || converterCache.sourceFormat?.sampleRate != bufferFormat.sampleRate
                         || converterCache.sourceFormat?.channelCount != bufferFormat.channelCount

--- a/Sources/MacParakeetCore/Audio/ObjCExceptionBridge.swift
+++ b/Sources/MacParakeetCore/Audio/ObjCExceptionBridge.swift
@@ -1,0 +1,47 @@
+import Foundation
+import MacParakeetObjCShims
+
+/// Runs `block` inside an Objective-C `@try`/`@catch` trampoline. If `block`
+/// raises an `NSException`, the exception is caught and rethrown as a Swift
+/// `NSError` in the `MPKObjCExceptionErrorDomain` domain. This is the only
+/// reliable way to recover from Objective-C exceptions raised by AppKit,
+/// AVFoundation, Core Audio, etc. — Swift's native `do/try/catch` cannot catch
+/// them and the runtime will call `abort()` as soon as one reaches a Swift frame.
+///
+/// Keep the block as small as possible — only the call that may raise should
+/// run inside it.
+@discardableResult
+func catchingObjCException<T>(_ block: () throws -> T) throws -> T {
+    var result: Result<T, Error>?
+    var objcError: NSError?
+    let ok = MPKTryBlock({
+        do {
+            result = .success(try block())
+        } catch {
+            result = .failure(error)
+        }
+    }, &objcError)
+
+    if !ok {
+        throw objcError ?? NSError(
+            domain: MPKObjCExceptionErrorDomain,
+            code: 0,
+            userInfo: [NSLocalizedDescriptionKey: "Unknown Objective-C exception"]
+        )
+    }
+
+    switch result {
+    case .success(let value):
+        return value
+    case .failure(let error):
+        throw error
+    case .none:
+        // MPKTryBlock returned YES without calling our inner assignment — should
+        // be unreachable, but be explicit rather than force-unwrapping.
+        throw NSError(
+            domain: MPKObjCExceptionErrorDomain,
+            code: 0,
+            userInfo: [NSLocalizedDescriptionKey: "catchingObjCException produced no result"]
+        )
+    }
+}

--- a/Sources/MacParakeetObjCShims/MPKObjCExceptionCatcher.m
+++ b/Sources/MacParakeetObjCShims/MPKObjCExceptionCatcher.m
@@ -1,0 +1,39 @@
+#import "MPKObjCExceptionCatcher.h"
+
+NSErrorDomain const MPKObjCExceptionErrorDomain = @"com.macparakeet.objc-exception";
+
+NSString *const MPKObjCExceptionNameKey = @"MPKObjCExceptionName";
+NSString *const MPKObjCExceptionReasonKey = @"MPKObjCExceptionReason";
+NSString *const MPKObjCExceptionUserInfoKey = @"MPKObjCExceptionUserInfo";
+NSString *const MPKObjCExceptionCallStackKey = @"MPKObjCExceptionCallStack";
+
+BOOL MPKTryBlock(NS_NOESCAPE void (^block)(void),
+                 NSError * _Nullable * _Nullable error) {
+    @try {
+        block();
+        return YES;
+    } @catch (NSException *exception) {
+        if (error != NULL) {
+            NSMutableDictionary<NSErrorUserInfoKey, id> *userInfo = [NSMutableDictionary dictionary];
+
+            NSString *name = exception.name ?: @"NSException";
+            NSString *reason = exception.reason ?: @"(no reason)";
+            userInfo[NSLocalizedDescriptionKey] =
+                [NSString stringWithFormat:@"%@: %@", name, reason];
+            userInfo[MPKObjCExceptionNameKey] = name;
+            userInfo[MPKObjCExceptionReasonKey] = reason;
+            if (exception.userInfo != nil) {
+                userInfo[MPKObjCExceptionUserInfoKey] = exception.userInfo;
+            }
+            NSArray<NSString *> *callStack = exception.callStackSymbols;
+            if (callStack != nil) {
+                userInfo[MPKObjCExceptionCallStackKey] = callStack;
+            }
+
+            *error = [NSError errorWithDomain:MPKObjCExceptionErrorDomain
+                                         code:0
+                                     userInfo:userInfo];
+        }
+        return NO;
+    }
+}

--- a/Sources/MacParakeetObjCShims/include/MPKObjCExceptionCatcher.h
+++ b/Sources/MacParakeetObjCShims/include/MPKObjCExceptionCatcher.h
@@ -1,0 +1,30 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Domain used for `NSError` values produced when an Objective-C `NSException`
+/// is caught by `MPKTryBlock`.
+FOUNDATION_EXPORT NSErrorDomain const MPKObjCExceptionErrorDomain;
+
+/// Keys populated on the `NSError.userInfo` dictionary when an exception is caught.
+FOUNDATION_EXPORT NSString *const MPKObjCExceptionNameKey;
+FOUNDATION_EXPORT NSString *const MPKObjCExceptionReasonKey;
+FOUNDATION_EXPORT NSString *const MPKObjCExceptionUserInfoKey;
+FOUNDATION_EXPORT NSString *const MPKObjCExceptionCallStackKey;
+
+/// Executes @c block inside an Objective-C @c \@try / @c \@catch trampoline.
+///
+/// Swift's native @c do / @c try / @c catch cannot catch Objective-C
+/// @c NSException values — the Swift runtime will call @c abort() as soon as
+/// one propagates through a Swift frame. This helper lets Swift callers convert
+/// an @c NSException raised by AppKit / AVFoundation / Core Audio / etc. into a
+/// throwable @c NSError so it can be handled on the Swift side.
+///
+/// @param block The block to execute. May raise an @c NSException.
+/// @param error Out-parameter populated with a non-nil @c NSError if @c block
+///              raised. Unchanged on success.
+/// @return @c YES if @c block returned normally, @c NO if it raised.
+FOUNDATION_EXPORT BOOL MPKTryBlock(NS_NOESCAPE void (^block)(void),
+                                   NSError * _Nullable * _Nullable error);
+
+NS_ASSUME_NONNULL_END

--- a/Tests/MacParakeetTests/Audio/AudioRecorderFormatChangeTests.swift
+++ b/Tests/MacParakeetTests/Audio/AudioRecorderFormatChangeTests.swift
@@ -1,0 +1,52 @@
+import AVFoundation
+import XCTest
+@testable import MacParakeetCore
+
+final class AudioRecorderFormatChangeTests: XCTestCase {
+    func testTapConverterNeedsRebuildWhenNoCachedFormat() throws {
+        let incoming = try makeFormat()
+        XCTAssertTrue(tapConverterNeedsRebuild(cachedSourceFormat: nil, incomingBufferFormat: incoming))
+    }
+
+    func testTapConverterDoesNotNeedRebuildForEquivalentFormat() throws {
+        let cached = try makeFormat()
+        let incoming = try makeFormat()
+        XCTAssertFalse(
+            tapConverterNeedsRebuild(cachedSourceFormat: cached, incomingBufferFormat: incoming)
+        )
+    }
+
+    func testTapConverterNeedsRebuildWhenInterleavingChanges() throws {
+        let nonInterleaved = try makeFormat(interleaved: false)
+        let interleaved = try makeFormat(interleaved: true)
+        XCTAssertTrue(
+            tapConverterNeedsRebuild(
+                cachedSourceFormat: nonInterleaved,
+                incomingBufferFormat: interleaved
+            )
+        )
+    }
+
+    func testTapConverterNeedsRebuildWhenSampleRateChanges() throws {
+        let cached = try makeFormat(sampleRate: 48_000)
+        let incoming = try makeFormat(sampleRate: 44_100)
+        XCTAssertTrue(
+            tapConverterNeedsRebuild(cachedSourceFormat: cached, incomingBufferFormat: incoming)
+        )
+    }
+
+    private func makeFormat(
+        sampleRate: Double = 48_000,
+        channels: AVAudioChannelCount = 2,
+        interleaved: Bool = false
+    ) throws -> AVAudioFormat {
+        try XCTUnwrap(
+            AVAudioFormat(
+                commonFormat: .pcmFormatFloat32,
+                sampleRate: sampleRate,
+                channels: channels,
+                interleaved: interleaved
+            )
+        )
+    }
+}

--- a/Tests/MacParakeetTests/Audio/ObjCExceptionBridgeTests.swift
+++ b/Tests/MacParakeetTests/Audio/ObjCExceptionBridgeTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import XCTest
+@testable import MacParakeetCore
+import MacParakeetObjCShims
+
+/// Tests for the Objective-C exception catcher that protects AVFAudio calls.
+/// See issue #91 — without this trampoline, Swift can't catch `NSException`
+/// raised by `AVAudioEngine.inputNode.installTap(...)` and the process aborts.
+final class ObjCExceptionBridgeTests: XCTestCase {
+
+    // MARK: - MPKTryBlock (the underlying C API)
+
+    func testMPKTryBlockReturnsTrueOnNormalCompletion() {
+        var ran = false
+        var error: NSError?
+        let ok = MPKTryBlock({ ran = true }, &error)
+
+        XCTAssertTrue(ok)
+        XCTAssertTrue(ran)
+        XCTAssertNil(error)
+    }
+
+    func testMPKTryBlockCatchesNSExceptionAndPopulatesError() {
+        var error: NSError?
+        let ok = MPKTryBlock({
+            NSException(
+                name: NSExceptionName("TestExceptionName"),
+                reason: "synthetic reason for unit test",
+                userInfo: ["key": "value"]
+            ).raise()
+        }, &error)
+
+        XCTAssertFalse(ok)
+        XCTAssertNotNil(error)
+        XCTAssertEqual(error?.domain, MPKObjCExceptionErrorDomain)
+        XCTAssertEqual(error?.userInfo[MPKObjCExceptionNameKey] as? String, "TestExceptionName")
+        XCTAssertEqual(
+            error?.userInfo[MPKObjCExceptionReasonKey] as? String,
+            "synthetic reason for unit test"
+        )
+        let desc = error?.userInfo[NSLocalizedDescriptionKey] as? String
+        XCTAssertEqual(desc, "TestExceptionName: synthetic reason for unit test")
+
+        let userInfo = error?.userInfo[MPKObjCExceptionUserInfoKey] as? [String: Any]
+        XCTAssertEqual(userInfo?["key"] as? String, "value")
+    }
+
+    func testMPKTryBlockToleratesNilErrorOutParameter() {
+        // The API contract allows `error == NULL`. The catcher must not crash
+        // when the caller doesn't care about the error value.
+        let ok = MPKTryBlock({
+            NSException(name: .genericException, reason: "ignored", userInfo: nil).raise()
+        }, nil)
+
+        XCTAssertFalse(ok)
+    }
+
+    // MARK: - catchingObjCException (the Swift wrapper)
+
+    func testCatchingObjCExceptionReturnsValueOnSuccess() throws {
+        let value = try catchingObjCException { 42 }
+        XCTAssertEqual(value, 42)
+    }
+
+    func testCatchingObjCExceptionRethrowsAsNSError() {
+        do {
+            try catchingObjCException {
+                NSException(
+                    name: NSExceptionName("AVFoundationErrorDomain"),
+                    reason: "required condition is false: IsFormatSampleRateAndChannelCountValid(hwFormat)",
+                    userInfo: nil
+                ).raise()
+            }
+            XCTFail("expected catchingObjCException to throw")
+        } catch let error as NSError {
+            XCTAssertEqual(error.domain, MPKObjCExceptionErrorDomain)
+            XCTAssertEqual(
+                error.userInfo[MPKObjCExceptionReasonKey] as? String,
+                "required condition is false: IsFormatSampleRateAndChannelCountValid(hwFormat)"
+            )
+        }
+    }
+
+    func testCatchingObjCExceptionPreservesSwiftThrownErrors() {
+        struct SampleError: Error, Equatable { let tag: String }
+
+        do {
+            _ = try catchingObjCException { () throws -> Int in
+                throw SampleError(tag: "swift-path")
+            }
+            XCTFail("expected catchingObjCException to rethrow Swift error")
+        } catch let error as SampleError {
+            XCTAssertEqual(error.tag, "swift-path")
+        } catch {
+            XCTFail("unexpected error type: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
## What this fixes

If you use **Krisp, BlackHole, Loopback, SoundSource, Audio Hijack, a manual Aggregate Device in *Audio MIDI Setup*, or a Bluetooth-bridged input setup** — basically any "virtual" or "aggregate" audio device on your Mac — MacParakeet 0.5.5 could crash silently the moment you pressed the dictation hotkey. No error dialog, the app just vanished. This PR fixes that.

Users on the built-in MacBook microphone with no third-party audio software were unaffected.

Closes #91
**Investigation:** [`docs/planning/2026-04-08-crash-report-rootcause-installtap.md`](https://github.com/moona3k/macparakeet/blob/main/docs/planning/2026-04-08-crash-report-rootcause-installtap.md)
**Impact:** 10 of 14 (71%) production crashes in the last 72 hours of 0.5.5 telemetry.

## The 1-minute version of the bug

MacParakeet asks Core Audio for the current mic format, then a fraction of a second later tells AVAudioEngine "please tap the mic using *this* format". For most people those two reads return identical values every time. But aggregate audio devices (the wrappers macOS builds around virtual-audio drivers) can have their format shift between those two calls — a Bluetooth headset flipping between HFP and A2DP, a sub-device being hot-plugged, wake-from-sleep, or a driver thread restarting.

When that happens, AVFoundation raises an Objective-C `NSException` deep inside `installTap`. Swift's `do/try/catch` can't catch Objective-C exceptions — they're a completely separate unwinding mechanism — so the exception propagates straight through every Swift frame and the runtime calls `abort()`. SIGABRT. App gone.

The fix has three parts:

1. **Introduce an Objective-C trampoline.** New SPM target `MacParakeetObjCShims` ships `MPKTryBlock`, a tiny `@try`/`@catch` helper that converts any caught `NSException` into an `NSError`. There's also a Swift wrapper, `catchingObjCException { ... }`, that preserves Swift thrown errors and supports generic return values.

2. **Wrap every AVFAudio call in `AudioRecorder.configureAndStart` that can raise:**
   - `inputNode.outputFormat(forBus: 0)` — can raise on aggregate devices in bad states.
   - `inputNode.installTap(...)` — **this is the confirmed issue #91 crash site.**
   - `engine.start()` — documented to throw Swift errors, but has been observed to raise `NSException` in corner cases.

3. **Pass `format: nil` to `installTap` and build the converter lazily from `buffer.format` inside the tap block.** This removes the "captured format no longer matches the bus's current format" failure mode entirely — AVFAudio will just deliver whatever the bus is actually producing, and we adapt. If the bus format drifts *mid-stream*, we rebuild the `AVAudioConverter` on the next buffer.

There's also a fourth, smaller improvement: `AudioRecorder.start()` now hard-rejects `AVCaptureDevice.authorizationStatus(.audio) != .authorized` with a Swift error, instead of proceeding and failing opaquely deep inside AVFAudio. The onboarding flow already requests mic access before the first dictation, so in practice this guard is a belt-and-braces check that makes a silent invariant explicit.

## What users will see after 0.5.6 ships

**Best case (most common):** They press the hotkey, the aggregate device is in a bad state, the `NSException` is caught, and `AudioRecorder.start()` falls back to the built-in microphone automatically. Dictation works on the first try. No crash, no user-visible error.

**Worst case:** Both the aggregate device *and* the built-in mic fail. The user sees the existing dictation-failed path in `DictationService`, and we get a real `dictation_failed` telemetry event with the actual AVFAudio reason string in `error_detail` — actionable signal instead of another opaque `crash_occurred` row.

Either way, **the app no longer disappears mid-keypress.**

## Is this a regression we introduced recently?

No. This bug has been latent since **v0.1**. `git log --follow` on `Sources/MacParakeetCore/Audio/AudioRecorder.swift` shows the `installTap(onBus: 0, bufferSize: 4096, format: inputFormat)` pattern has been present since the very first commit of the audio stack, [`92460f8`](https://github.com/moona3k/macparakeet/commit/92460f8). Every release of MacParakeet has shipped with this exact line.

What changed recently is our ability to *see* the crashes. The signal-handler-based crash reporter landed on 2026-03-31 in [`2fd4d74`](https://github.com/moona3k/macparakeet/commit/2fd4d74) — only 8 days before this investigation. Before Mar 31, affected users would silently lose the app and we would never have known. The 10 crashes in the telemetry window are the **first observations** of a long-standing bug, not a freshly introduced one.

That means two things:

1. **This isn't a panic revert.** We're calmly fixing a long-latent bug, not backing out a bad change.
2. **The 72-hour telemetry count is a floor.** The true historical impact is unknown but almost certainly larger than 10 crashes / 2 users. Shipping the crash reporter was worth it — this is a direct vindication of that work.

## Changes

### New files

- [`Sources/MacParakeetObjCShims/include/MPKObjCExceptionCatcher.h`](../blob/fix/audiorecorder-installtap-exception/Sources/MacParakeetObjCShims/include/MPKObjCExceptionCatcher.h) — Public header for `MPKTryBlock`, the user-info keys, and the error domain.
- [`Sources/MacParakeetObjCShims/MPKObjCExceptionCatcher.m`](../blob/fix/audiorecorder-installtap-exception/Sources/MacParakeetObjCShims/MPKObjCExceptionCatcher.m) — The `@try`/`@catch` implementation. 40 lines.
- [`Sources/MacParakeetCore/Audio/ObjCExceptionBridge.swift`](../blob/fix/audiorecorder-installtap-exception/Sources/MacParakeetCore/Audio/ObjCExceptionBridge.swift) — Swift wrapper `catchingObjCException { ... }` with generic return type and Swift-error passthrough.
- [`Tests/MacParakeetTests/Audio/ObjCExceptionBridgeTests.swift`](../blob/fix/audiorecorder-installtap-exception/Tests/MacParakeetTests/Audio/ObjCExceptionBridgeTests.swift) — 6 unit tests.

### Modified files

- [`Package.swift`](../blob/fix/audiorecorder-installtap-exception/Package.swift) — New `MacParakeetObjCShims` target, wired into `MacParakeetCore` and the test target.
- [`Sources/MacParakeetCore/Audio/AudioRecorder.swift`](../blob/fix/audiorecorder-installtap-exception/Sources/MacParakeetCore/Audio/AudioRecorder.swift):
  - `start()` — mic permission hard-gate.
  - `configureAndStart(overrideDeviceID:)`:
    - `outputFormat(forBus:)` wrapped in `catchingObjCException`.
    - `installTap(...)` wrapped in `catchingObjCException`, called with `format: nil`, cleanup and error conversion on failure.
    - Tap block lazily builds/rebuilds the `AVAudioConverter` from `buffer.format` via a private `TapConverterCache` reference type.
    - `engine.start()` wrapped in `catchingObjCException`.

## Tests

- 6 new unit tests covering `MPKTryBlock` (normal return, `NSException` → `NSError` with name/reason/userInfo/localizedDescription, nil error out-parameter) and `catchingObjCException` (return value, `NSException` rethrow, Swift-error passthrough).
- `swift test`: **1326 tests pass** (1320 pre-existing + 6 new), zero failures, zero unexpected. The previous baseline was 1311; the delta is +6 new tests + 9 pre-existing tests that grew independently on `main` since the investigation started.

## Test plan

- [x] `swift test` — all 1326 tests pass locally
- [x] `swift build` — MacParakeet GUI target builds clean
- [x] Unit-level proof that `MPKTryBlock` converts a synthetic `@throw`d `NSException` into a populated `NSError` (see new test file)
- [x] Unit-level proof that `catchingObjCException` propagates Swift errors through unchanged
- [ ] Manual smoke test via `scripts/dev/run_app.sh` with the built-in MacBook mic — happy path dictation should be unchanged
- [ ] **Post-ship verification (0.5.6 + 72h):** re-query `crash_occurred` for the cluster A/C binary offsets (`0x865c70 / 0x80638c / 0x804d70 / 0x8044c8`) — expect them to disappear. Replacement signal should be `dictation_failed` telemetry events with `error_type` referencing `installTap` or the AVFAudio reason string

## Verification caveat

The actual production trigger (aggregate audio device format drift between `outputFormat` and `installTap` under real load) cannot be reproduced reliably in CI or on a typical dev machine — it requires a real aggregate device in a real transition window (Bluetooth flipping modes, a USB device being hot-plugged, etc.). The happy-path wrap and `MPKTryBlock` itself are unit-testable; the end-to-end fix can only be validated by watching post-ship telemetry.

This is normal for environmental crash fixes. The blast radius of a mis-fix is small:

- **If the wrap is wrong:** the worst case is that we're back to where we are today (silent abort). Nothing gets worse.
- **If the wrap is right:** 71% of current production crashes disappear, and we finally learn the real AVFAudio reason string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Objective-C exception-bridging layer so audio errors are converted to recoverable errors instead of crashing.

* **Bug Fixes**
  * Prevented crashes during recording when underlying audio APIs raise exceptions.
  * Improved audio device compatibility and error handling.
  * Enforced microphone permission checks with clearer error reporting.

* **Tests**
  * Added tests covering the exception bridge and related audio error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
