### PR TITLE
Redesign no-speech state with Merkaba leaf animation + menu bar fix

### DIFF
--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -21,32 +21,28 @@ final class DictationFlowCoordinator {
     /// True only while audio is actively being captured or in-flight transcription
     /// is running. Used by `AppDelegate.resolveAndUpdateMenuBarIcon()` so the red
     /// recording dot does NOT linger through terminal display states (success
-    /// checkmark / no-speech leaf animation / error card).
+    /// checkmark / no-speech leaf animation / error card) or through the cancel
+    /// countdown undo window.
     ///
-    /// Returns false for `.idle`, `.ready`, `.checkingEntitlements` (no overlay or
-    /// audio yet) and for `.finishing(...)` (audio already stopped).
+    /// Returns false for:
+    ///   - `.idle`, `.ready`, `.checkingEntitlements` — no overlay or audio yet
+    ///   - `.cancelCountdown` — capture already stopped via `.cancelRecording(reason:)`;
+    ///     state machine explicitly emits `.updateMenuBar(.idle)` at this transition
+    ///     (see `DictationFlowStateMachine.swift:299`)
+    ///   - `.finishing(...)` — terminal display states, audio already stopped
     ///
     /// ---
-    /// KNOWN LIMITATIONS — tracked, not yet fixed:
+    /// KNOWN LIMITATION — not fixable with a boolean:
     ///
-    /// 1. `.cancelCountdown` currently returns `true`, which forces the menu bar
-    ///    red dot to stay on during the 5s undo window. This contradicts the state
-    ///    machine's explicit `.updateMenuBar(.idle)` intent at the recording →
-    ///    cancelCountdown transition (see `DictationFlowStateMachine.swift:299`).
-    ///    Audio capture IS stopped when entering cancelCountdown (via
-    ///    `.cancelRecording(reason:)` effect), so semantically this property
-    ///    should return `false` here. Preserved for now to match pre-existing
-    ///    behavior; flip to `false` when ready.
+    /// `.processing` returns `true` → the resolver shows the RED "recording"
+    /// dot, but the state machine emits `.updateMenuBar(.processing)` (orange)
+    /// on entry (see `DictationFlowStateMachine.swift:279, 333`). The resolver
+    /// has no way to express "orange for dictation processing" because it uses
+    /// boolean flags (`isCapturingAudio`, `isTranscribing`) instead of a
+    /// preference enum. This is a pre-existing inconsistency, not introduced
+    /// by this property.
     ///
-    /// 2. `.processing` returns `true` → the resolver shows the RED "recording"
-    ///    dot, but the state machine emits `.updateMenuBar(.processing)` (orange)
-    ///    on entry (see `DictationFlowStateMachine.swift:279, 333`). The resolver
-    ///    has no way to express "orange for dictation processing" because it uses
-    ///    boolean flags (`isCapturingAudio`, `isTranscribing`) instead of a
-    ///    preference enum. This is a pre-existing inconsistency, not introduced
-    ///    by this property.
-    ///
-    /// The cleaner architectural fix for both is to replace the boolean with a
+    /// The cleaner architectural fix is to replace the boolean with a
     /// `MenuBarState?` preference getter on each flow coordinator, and have
     /// `resolveAndUpdateMenuBarIcon()` pick the highest-priority preference:
     ///
@@ -71,9 +67,9 @@ final class DictationFlowCoordinator {
     /// the dual-purpose `isDictationActive` / `isCapturingAudio` split above.
     var isCapturingAudio: Bool {
         switch stateMachine.state {
-        case .startingService, .recording, .pendingStop, .processing, .cancelCountdown:
+        case .startingService, .recording, .pendingStop, .processing:
             return true
-        case .idle, .ready, .checkingEntitlements, .finishing:
+        case .idle, .ready, .checkingEntitlements, .cancelCountdown, .finishing:
             return false
         }
     }

--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -66,7 +66,11 @@ final class DictationFlowCoordinator {
     /// This would respect each flow's state-machine intent exactly and eliminate
     /// the dual-purpose `isDictationActive` / `isCapturingAudio` split above.
     var isCapturingAudio: Bool {
-        switch stateMachine.state {
+        Self.isCapturingAudio(for: stateMachine.state)
+    }
+
+    static func isCapturingAudio(for state: DictationFlowState) -> Bool {
+        switch state {
         case .startingService, .recording, .pendingStop, .processing:
             return true
         case .idle, .ready, .checkingEntitlements, .cancelCountdown, .finishing:

--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -25,6 +25,50 @@ final class DictationFlowCoordinator {
     ///
     /// Returns false for `.idle`, `.ready`, `.checkingEntitlements` (no overlay or
     /// audio yet) and for `.finishing(...)` (audio already stopped).
+    ///
+    /// ---
+    /// KNOWN LIMITATIONS — tracked, not yet fixed:
+    ///
+    /// 1. `.cancelCountdown` currently returns `true`, which forces the menu bar
+    ///    red dot to stay on during the 5s undo window. This contradicts the state
+    ///    machine's explicit `.updateMenuBar(.idle)` intent at the recording →
+    ///    cancelCountdown transition (see `DictationFlowStateMachine.swift:299`).
+    ///    Audio capture IS stopped when entering cancelCountdown (via
+    ///    `.cancelRecording(reason:)` effect), so semantically this property
+    ///    should return `false` here. Preserved for now to match pre-existing
+    ///    behavior; flip to `false` when ready.
+    ///
+    /// 2. `.processing` returns `true` → the resolver shows the RED "recording"
+    ///    dot, but the state machine emits `.updateMenuBar(.processing)` (orange)
+    ///    on entry (see `DictationFlowStateMachine.swift:279, 333`). The resolver
+    ///    has no way to express "orange for dictation processing" because it uses
+    ///    boolean flags (`isCapturingAudio`, `isTranscribing`) instead of a
+    ///    preference enum. This is a pre-existing inconsistency, not introduced
+    ///    by this property.
+    ///
+    /// The cleaner architectural fix for both is to replace the boolean with a
+    /// `MenuBarState?` preference getter on each flow coordinator, and have
+    /// `resolveAndUpdateMenuBarIcon()` pick the highest-priority preference:
+    ///
+    /// ```swift
+    /// // On DictationFlowCoordinator:
+    /// var menuBarPreference: BreathWaveIcon.MenuBarState? {
+    ///     switch stateMachine.state {
+    ///     case .startingService, .recording, .pendingStop: return .recording
+    ///     case .processing: return .processing
+    ///     default: return nil   // no preference — fall through
+    ///     }
+    /// }
+    ///
+    /// // In AppDelegate.resolveAndUpdateMenuBarIcon:
+    /// if meetingCoordinator?.isMeetingRecordingActive == true { ... }
+    /// else if let pref = dictationCoordinator?.menuBarPreference { ... }
+    /// else if transcriptionViewModel.isTranscribing { ... }
+    /// else { .idle }
+    /// ```
+    ///
+    /// This would respect each flow's state-machine intent exactly and eliminate
+    /// the dual-purpose `isDictationActive` / `isCapturingAudio` split above.
     var isCapturingAudio: Bool {
         switch stateMachine.state {
         case .startingService, .recording, .pendingStop, .processing, .cancelCountdown:

--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -235,10 +235,7 @@ final class DictationFlowCoordinator {
             overlayViewModel?.state = .success
 
         case .showNoSpeech:
-            if let vm = overlayViewModel {
-                vm.noSpeechProgress = 1.0
-                vm.state = .noSpeech
-            }
+            overlayViewModel?.state = .noSpeech
 
         case .showError(let message):
             overlayViewModel?.state = .error(message)

--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -9,10 +9,30 @@ final class DictationFlowCoordinator {
 
     // MARK: - Public Interface
 
-    /// Read by AppDelegate for menu bar icon guard.
-    /// Uses overlayController (not state machine) to match old behavior —
-    /// checkingEntitlements has no overlay yet, so isDictationActive should be false.
+    /// True whenever the dictation overlay is showing. Used by presentation-conflict
+    /// guards (e.g. the idle-pill suppressor when a meeting recording ends) to prevent
+    /// surfaces from colliding with the overlay.
+    ///
+    /// NOTE: this returns true during terminal display states (success checkmark,
+    /// no-speech leaf, error card). For the menu bar icon, use `isCapturingAudio`
+    /// instead — see the note on that property.
     var isDictationActive: Bool { overlayController != nil }
+
+    /// True only while audio is actively being captured or in-flight transcription
+    /// is running. Used by `AppDelegate.resolveAndUpdateMenuBarIcon()` so the red
+    /// recording dot does NOT linger through terminal display states (success
+    /// checkmark / no-speech leaf animation / error card).
+    ///
+    /// Returns false for `.idle`, `.ready`, `.checkingEntitlements` (no overlay or
+    /// audio yet) and for `.finishing(...)` (audio already stopped).
+    var isCapturingAudio: Bool {
+        switch stateMachine.state {
+        case .startingService, .recording, .pendingStop, .processing, .cancelCountdown:
+            return true
+        case .idle, .ready, .checkingEntitlements, .finishing:
+            return false
+        }
+    }
 
     /// Set after init; updated when hotkey manager is recreated
     var hotkeyManager: HotkeyManager?

--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -18,11 +18,15 @@ final class DictationFlowCoordinator {
     /// instead — see the note on that property.
     var isDictationActive: Bool { overlayController != nil }
 
+    /// Preferred menu bar icon state for dictation, derived from flow state.
+    /// Returns nil when dictation has no visual preference and global resolver
+    /// should fall through to other subsystems (e.g. file transcription).
+    var menuBarPreference: BreathWaveIcon.MenuBarState? {
+        Self.menuBarPreference(for: stateMachine.state)
+    }
+
     /// True only while audio is actively being captured or in-flight transcription
-    /// is running. Used by `AppDelegate.resolveAndUpdateMenuBarIcon()` so the red
-    /// recording dot does NOT linger through terminal display states (success
-    /// checkmark / no-speech leaf animation / error card) or through the cancel
-    /// countdown undo window.
+    /// is running.
     ///
     /// Returns false for:
     ///   - `.idle`, `.ready`, `.checkingEntitlements` — no overlay or audio yet
@@ -31,42 +35,19 @@ final class DictationFlowCoordinator {
     ///     (see `DictationFlowStateMachine.swift:299`)
     ///   - `.finishing(...)` — terminal display states, audio already stopped
     ///
-    /// ---
-    /// KNOWN LIMITATION — not fixable with a boolean:
-    ///
-    /// `.processing` returns `true` → the resolver shows the RED "recording"
-    /// dot, but the state machine emits `.updateMenuBar(.processing)` (orange)
-    /// on entry (see `DictationFlowStateMachine.swift:279, 333`). The resolver
-    /// has no way to express "orange for dictation processing" because it uses
-    /// boolean flags (`isCapturingAudio`, `isTranscribing`) instead of a
-    /// preference enum. This is a pre-existing inconsistency, not introduced
-    /// by this property.
-    ///
-    /// The cleaner architectural fix is to replace the boolean with a
-    /// `MenuBarState?` preference getter on each flow coordinator, and have
-    /// `resolveAndUpdateMenuBarIcon()` pick the highest-priority preference:
-    ///
-    /// ```swift
-    /// // On DictationFlowCoordinator:
-    /// var menuBarPreference: BreathWaveIcon.MenuBarState? {
-    ///     switch stateMachine.state {
-    ///     case .startingService, .recording, .pendingStop: return .recording
-    ///     case .processing: return .processing
-    ///     default: return nil   // no preference — fall through
-    ///     }
-    /// }
-    ///
-    /// // In AppDelegate.resolveAndUpdateMenuBarIcon:
-    /// if meetingCoordinator?.isMeetingRecordingActive == true { ... }
-    /// else if let pref = dictationCoordinator?.menuBarPreference { ... }
-    /// else if transcriptionViewModel.isTranscribing { ... }
-    /// else { .idle }
-    /// ```
-    ///
-    /// This would respect each flow's state-machine intent exactly and eliminate
-    /// the dual-purpose `isDictationActive` / `isCapturingAudio` split above.
     var isCapturingAudio: Bool {
         Self.isCapturingAudio(for: stateMachine.state)
+    }
+
+    static func menuBarPreference(for state: DictationFlowState) -> BreathWaveIcon.MenuBarState? {
+        switch state {
+        case .startingService, .recording, .pendingStop:
+            return .recording
+        case .processing:
+            return .processing
+        case .idle, .ready, .checkingEntitlements, .cancelCountdown, .finishing:
+            return nil
+        }
     }
 
     static func isCapturingAudio(for state: DictationFlowState) -> Bool {

--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -14,8 +14,9 @@ final class DictationFlowCoordinator {
     /// surfaces from colliding with the overlay.
     ///
     /// NOTE: this returns true during terminal display states (success checkmark,
-    /// no-speech leaf, error card). For the menu bar icon, use `isCapturingAudio`
-    /// instead — see the note on that property.
+    /// no-speech leaf, error card). For menu bar icon decisions, use
+    /// `menuBarPreference` (or `isCapturingAudio` for capture-only semantics)
+    /// instead.
     var isDictationActive: Bool { overlayController != nil }
 
     /// Preferred menu bar icon state for dictation, derived from flow state.

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -349,7 +349,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Menu Bar Icon State
 
     /// Priority-based menu bar icon resolver (ADR-015).
-    /// Recording (meeting or dictation) > file transcription > idle.
+    /// Meeting recording > dictation menu-bar preference > file transcription > idle.
     ///
     /// Uses `menuBarPreference` from the dictation flow (state-machine-aware) so
     /// `.processing` can render correctly and terminal states do not linger red.

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -351,13 +351,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Priority-based menu bar icon resolver (ADR-015).
     /// Recording (meeting or dictation) > file transcription > idle.
     ///
-    /// Uses `isCapturingAudio` (state-machine-aware) instead of `isDictationActive`
-    /// (overlay-presence) so the red dot does not linger through terminal display
-    /// states — success checkmark, no-speech leaf animation, error card.
+    /// Uses `menuBarPreference` from the dictation flow (state-machine-aware) so
+    /// `.processing` can render correctly and terminal states do not linger red.
     private func resolveAndUpdateMenuBarIcon() {
         let state = Self.resolveMenuBarState(
             isMeetingRecordingActive: meetingRecordingFlowCoordinator?.isMeetingRecordingActive == true,
-            isDictationCapturingAudio: dictationFlowCoordinator?.isCapturingAudio == true,
+            dictationMenuBarPreference: dictationFlowCoordinator?.menuBarPreference,
             isTranscribing: transcriptionViewModel.isTranscribing
         )
         menuBarCoordinator.updateIcon(state: state)
@@ -365,14 +364,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     static func resolveMenuBarState(
         isMeetingRecordingActive: Bool,
-        isDictationCapturingAudio: Bool,
+        dictationMenuBarPreference: BreathWaveIcon.MenuBarState?,
         isTranscribing: Bool
     ) -> BreathWaveIcon.MenuBarState {
         if isMeetingRecordingActive {
             return .recording
         }
-        if isDictationCapturingAudio {
-            return .recording
+        if let dictationMenuBarPreference, dictationMenuBarPreference != .idle {
+            return dictationMenuBarPreference
         }
         if isTranscribing {
             return .processing

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -350,10 +350,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     /// Priority-based menu bar icon resolver (ADR-015).
     /// Recording (meeting or dictation) > file transcription > idle.
+    ///
+    /// Uses `isCapturingAudio` (state-machine-aware) instead of `isDictationActive`
+    /// (overlay-presence) so the red dot does not linger through terminal display
+    /// states — success checkmark, no-speech leaf animation, error card.
     private func resolveAndUpdateMenuBarIcon() {
         if meetingRecordingFlowCoordinator?.isMeetingRecordingActive == true {
             menuBarCoordinator.updateIcon(state: .recording)
-        } else if dictationFlowCoordinator?.isDictationActive == true {
+        } else if dictationFlowCoordinator?.isCapturingAudio == true {
             menuBarCoordinator.updateIcon(state: .recording)
         } else if transcriptionViewModel.isTranscribing {
             menuBarCoordinator.updateIcon(state: .processing)

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -355,15 +355,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// (overlay-presence) so the red dot does not linger through terminal display
     /// states — success checkmark, no-speech leaf animation, error card.
     private func resolveAndUpdateMenuBarIcon() {
-        if meetingRecordingFlowCoordinator?.isMeetingRecordingActive == true {
-            menuBarCoordinator.updateIcon(state: .recording)
-        } else if dictationFlowCoordinator?.isCapturingAudio == true {
-            menuBarCoordinator.updateIcon(state: .recording)
-        } else if transcriptionViewModel.isTranscribing {
-            menuBarCoordinator.updateIcon(state: .processing)
-        } else {
-            menuBarCoordinator.updateIcon(state: .idle)
+        let state = Self.resolveMenuBarState(
+            isMeetingRecordingActive: meetingRecordingFlowCoordinator?.isMeetingRecordingActive == true,
+            isDictationCapturingAudio: dictationFlowCoordinator?.isCapturingAudio == true,
+            isTranscribing: transcriptionViewModel.isTranscribing
+        )
+        menuBarCoordinator.updateIcon(state: state)
+    }
+
+    static func resolveMenuBarState(
+        isMeetingRecordingActive: Bool,
+        isDictationCapturingAudio: Bool,
+        isTranscribing: Bool
+    ) -> BreathWaveIcon.MenuBarState {
+        if isMeetingRecordingActive {
+            return .recording
         }
+        if isDictationCapturingAudio {
+            return .recording
+        }
+        if isTranscribing {
+            return .processing
+        }
+        return .idle
     }
 
     // MARK: - Meeting Recording

--- a/Sources/MacParakeet/Views/Components/DesignSystem.swift
+++ b/Sources/MacParakeet/Views/Components/DesignSystem.swift
@@ -135,6 +135,14 @@ enum DesignSystem {
         static let meetingPillBadge = Font.system(size: 10, weight: .medium, design: .monospaced)
         static let meetingPillCheckmark = Font.system(size: 24, weight: .semibold)
 
+        /// Elegant serif italic label used inside the dictation overlay's no-speech
+        /// terminal pill. Intentionally smaller than `micro` (11pt) and uses `.serif`
+        /// instead of the default `.rounded` / system family so the label reads as a
+        /// quiet, subtle annotation inside the 26×26 Merkaba + leaf composition. It
+        /// overflows the inner content frame via `.fixedSize()` into the capsule's
+        /// padding area, so the pill background stays a perfect 46×46 circle.
+        static let dictationOverlayTerminalLabel = Font.system(size: 8.5, weight: .regular, design: .serif).italic()
+
         // Legacy aliases (kept for existing references)
         static let headline = Font.system(size: 17, weight: .semibold, design: .rounded)
         static let title = Font.system(size: 22, weight: .semibold, design: .rounded)

--- a/Sources/MacParakeet/Views/Components/DesignSystem.swift
+++ b/Sources/MacParakeet/Views/Components/DesignSystem.swift
@@ -79,7 +79,7 @@ enum DesignSystem {
         static let youtubeRed = Color.red
 
         // Pill / overlay
-        static let pillBackground = Color.black.opacity(0.9)
+        static let pillBackground = Color.black.opacity(0.7)
         static let pillBorder = Color.white.opacity(0.15)
         static let recordingRed = Color.red
         static let sacredGlow = Color(light: .init(red: 0.40, green: 0.85, blue: 0.40),
@@ -135,13 +135,13 @@ enum DesignSystem {
         static let meetingPillBadge = Font.system(size: 10, weight: .medium, design: .monospaced)
         static let meetingPillCheckmark = Font.system(size: 24, weight: .semibold)
 
-        /// Elegant serif italic label used inside the dictation overlay's no-speech
-        /// terminal pill. Intentionally smaller than `micro` (11pt) and uses `.serif`
-        /// instead of the default `.rounded` / system family so the label reads as a
-        /// quiet, subtle annotation inside the 26×26 Merkaba + leaf composition. It
-        /// overflows the inner content frame via `.fixedSize()` into the capsule's
-        /// padding area, so the pill background stays a perfect 46×46 circle.
-        static let dictationOverlayTerminalLabel = Font.system(size: 8.5, weight: .regular, design: .serif).italic()
+        /// Soft rounded label used inside the dictation overlay's no-speech terminal
+        /// pill (e.g. "More audio pls"). Uses `.rounded` to match the organic curves
+        /// of the falling leaf + Merkaba dissolve animation, and the same family as
+        /// the app's headline typography (`heroTitle`, `pageTitle`). Sized to sit
+        /// naturally beside the 26pt Merkaba glyph inside a low-profile horizontal
+        /// oval pill.
+        static let dictationOverlayTerminalLabel = Font.system(size: 9.5, weight: .medium, design: .rounded)
 
         // Legacy aliases (kept for existing references)
         static let headline = Font.system(size: 17, weight: .semibold, design: .rounded)

--- a/Sources/MacParakeet/Views/Components/NoSpeechAnimationTiming.swift
+++ b/Sources/MacParakeet/Views/Components/NoSpeechAnimationTiming.swift
@@ -1,0 +1,46 @@
+import Foundation
+import MacParakeetCore
+
+/// Centralized no-speech animation timings.
+/// Anchored to the shared no-speech dismiss window from Core to prevent drift.
+enum NoSpeechAnimationTiming {
+    static let dismissSeconds = DictationFlowTiming.noSpeechDismissSeconds
+
+    // MerkabaDissipateView phases
+    static let merkabaSettleDuration = 0.45
+    static let merkabaDissolveDuration = 0.4
+    static let merkabaDissolveDelay = 0.3
+    static let merkabaExhaleDuration = 0.35
+    static let merkabaExhaleDelay = 0.55
+
+    // NoSpeechContentView phases
+    static let leafFadeInDuration = 0.5
+    static let leafFadeInDelay = 0.35
+    static let leafDriftDuration = 1.6
+    static let leafDriftDelay = 0.35
+    static let textFadeInDuration = 0.4
+    static let textFadeInDelay = 0.75
+    static let leafRecedeDuration = 0.55
+    static let leafRecedeDelay = 1.5
+
+    static let completionBufferSeconds = 0.2
+
+    static let estimatedAnimationCompletionSeconds = max(
+        max(merkabaSettleDuration, merkabaDissolveDelay + merkabaDissolveDuration),
+        max(
+            merkabaExhaleDelay + merkabaExhaleDuration,
+            max(
+                leafFadeInDelay + leafFadeInDuration,
+                max(
+                    leafDriftDelay + leafDriftDuration,
+                    max(textFadeInDelay + textFadeInDuration, leafRecedeDelay + leafRecedeDuration)
+                )
+            )
+        )
+    )
+
+#if DEBUG
+    static let isDismissWindowSufficient =
+        estimatedAnimationCompletionSeconds + completionBufferSeconds <= dismissSeconds
+#endif
+}

--- a/Sources/MacParakeet/Views/Components/SacredGeometry.swift
+++ b/Sources/MacParakeet/Views/Components/SacredGeometry.swift
@@ -154,6 +154,11 @@ struct MerkabaDissipateView: View {
         .scaleEffect(settled ? 0.85 : 1.0)
         .drawingGroup()
         .onAppear {
+            // Reset to baseline so repeated presentations replay deterministically.
+            settled = false
+            dissolved = false
+            exhaled = false
+
             // Phase 1: settle into Star of David alignment
             withAnimation(.easeOut(duration: 0.45)) {
                 settled = true

--- a/Sources/MacParakeet/Views/Components/SacredGeometry.swift
+++ b/Sources/MacParakeet/Views/Components/SacredGeometry.swift
@@ -160,15 +160,21 @@ struct MerkabaDissipateView: View {
             exhaled = false
 
             // Phase 1: settle into Star of David alignment
-            withAnimation(.easeOut(duration: 0.45)) {
+            withAnimation(.easeOut(duration: NoSpeechAnimationTiming.merkabaSettleDuration)) {
                 settled = true
             }
             // Phase 2: dissolve triangles and vertices
-            withAnimation(.easeOut(duration: 0.4).delay(0.3)) {
+            withAnimation(
+                .easeOut(duration: NoSpeechAnimationTiming.merkabaDissolveDuration)
+                    .delay(NoSpeechAnimationTiming.merkabaDissolveDelay)
+            ) {
                 dissolved = true
             }
             // Phase 3: center nexus exhales
-            withAnimation(.easeOut(duration: 0.35).delay(0.55)) {
+            withAnimation(
+                .easeOut(duration: NoSpeechAnimationTiming.merkabaExhaleDuration)
+                    .delay(NoSpeechAnimationTiming.merkabaExhaleDelay)
+            ) {
                 exhaled = true
             }
         }

--- a/Sources/MacParakeet/Views/Components/SacredGeometry.swift
+++ b/Sources/MacParakeet/Views/Components/SacredGeometry.swift
@@ -99,6 +99,98 @@ struct SpinnerRingView: View {
     }
 }
 
+// MARK: - Merkaba Dissipate (No-Speech Terminal)
+
+/// Merkaba wind-down for the "no speech detected" terminal state.
+/// The sacred geometry settles, dissolves, and fades — leaving space for
+/// an external text label to materialize over the top.
+///
+/// Sequence:
+///   Phase 1 — triangles slow and align into Star of David (stillness)
+///   Phase 2 — strokes and vertices dissolve
+///   Phase 3 — center nexus exhales and fades last
+struct MerkabaDissipateView: View {
+    var size: CGFloat = 26
+    var tintColor: Color = .white
+
+    /// Phase 1: triangles slow-rotate and align to Star of David
+    @State private var settled = false
+    /// Phase 2: strokes and vertex glow dissolve
+    @State private var dissolved = false
+    /// Phase 3: center nexus contracts and fades
+    @State private var exhaled = false
+
+    private var radius: CGFloat { size * 0.423 }
+
+    var body: some View {
+        ZStack {
+            // Outer guide ring
+            Circle()
+                .stroke(tintColor.opacity(dissolved ? 0 : 0.05), lineWidth: 0.5)
+                .frame(width: size, height: size)
+
+            // Triangle 1 — settles to 0° (upward-pointing)
+            triangleLayer(
+                rotation: settled ? 0 : 20,
+                strokeOpacity: dissolved ? 0 : 0.35,
+                vertexOpacity: dissolved ? 0 : 0.6
+            )
+
+            // Triangle 2 — settles to 60° (downward, forming Star of David)
+            triangleLayer(
+                rotation: settled ? 60 : 40,
+                strokeOpacity: dissolved ? 0 : 0.2,
+                vertexOpacity: dissolved ? 0 : 0.42
+            )
+
+            // Center nexus — last point of light before text takes over
+            Circle()
+                .fill(tintColor.opacity(exhaled ? 0 : 0.6))
+                .frame(width: size * 0.115, height: size * 0.115)
+                .shadow(color: tintColor.opacity(exhaled ? 0 : 0.3), radius: size * 0.154)
+                .scaleEffect(exhaled ? 0.3 : 1.0)
+        }
+        .frame(width: size, height: size)
+        .scaleEffect(settled ? 0.85 : 1.0)
+        .drawingGroup()
+        .onAppear {
+            // Phase 1: settle into Star of David alignment
+            withAnimation(.easeOut(duration: 0.45)) {
+                settled = true
+            }
+            // Phase 2: dissolve triangles and vertices
+            withAnimation(.easeOut(duration: 0.4).delay(0.3)) {
+                dissolved = true
+            }
+            // Phase 3: center nexus exhales
+            withAnimation(.easeOut(duration: 0.35).delay(0.55)) {
+                exhaled = true
+            }
+        }
+    }
+
+    private func triangleLayer(rotation: Double, strokeOpacity: Double, vertexOpacity: Double) -> some View {
+        ZStack {
+            TriangleShape()
+                .stroke(tintColor.opacity(strokeOpacity), lineWidth: 0.8)
+                .frame(width: radius * 2, height: radius * 2)
+
+            ForEach(0..<3, id: \.self) { i in
+                let angle = (Double(i) * 120.0 - 90.0) * .pi / 180.0
+                let x = Foundation.cos(angle) * radius
+                let y = Foundation.sin(angle) * radius
+
+                Circle()
+                    .fill(tintColor.opacity(vertexOpacity))
+                    .frame(width: size * 0.096, height: size * 0.096)
+                    .shadow(color: tintColor.opacity(vertexOpacity * 0.4), radius: size * 0.115)
+                    .offset(x: x, y: y)
+            }
+        }
+        .rotationEffect(.degrees(rotation))
+    }
+}
+
 // MARK: - Meditative Merkaba (Large, Slow)
 
 /// Larger, slower merkaba for empty states and idle backgrounds.

--- a/Sources/MacParakeet/Views/Components/SacredGeometry.swift
+++ b/Sources/MacParakeet/Views/Components/SacredGeometry.swift
@@ -232,7 +232,8 @@ struct MerkabaDissipateView: View {
 /// ## Accessibility
 /// Honors `Reduce Motion` by presenting the peak state statically (no
 /// inhale animation, just the fully-bloomed ring + nexus). Exposed to
-/// VoiceOver as "Listening".
+/// VoiceOver as "Ready to record" — `.ready` is a poised pause, not an
+/// engaged mic, so we deliberately avoid "Listening".
 struct BreathingRingView: View {
     var size: CGFloat = 18
     var ringColor: Color = .white

--- a/Sources/MacParakeet/Views/Components/SacredGeometry.swift
+++ b/Sources/MacParakeet/Views/Components/SacredGeometry.swift
@@ -202,6 +202,57 @@ struct MerkabaDissipateView: View {
     }
 }
 
+// MARK: - Breathing Ring (Ready / Waiting)
+
+/// Gentle breathing indicator for the dictation overlay's ephemeral `.ready`
+/// state — shown briefly (~800ms) between the first Fn tap and the double-tap
+/// window closing. A soft ring inhales around a pulsing center nexus: the
+/// smallest, lightest member of the sacred-geometry family, signalling
+/// "listening, poised, waiting" without competing with the active Merkaba
+/// (processing) or the dissolving Merkaba (no speech).
+///
+/// Because the pill is typically visible for less than one full breath cycle,
+/// the animation starts cleanly at rest on each appearance so the user always
+/// sees a full inhale — an elegant rise that resolves into either recording
+/// (double-tap landed) or idle (window elapsed).
+struct BreathingRingView: View {
+    var size: CGFloat = 18
+    var tintColor: Color = .white
+
+    /// 0 = rest (exhale), 1 = peak (inhale). A single Double drives ring scale,
+    /// stroke opacity, glow radius, and nexus brightness so every element
+    /// breathes in perfect sync.
+    @State private var breath: CGFloat = 0
+
+    var body: some View {
+        ZStack {
+            // Outer breathing ring — scales and brightens on inhale.
+            Circle()
+                .stroke(tintColor.opacity(0.35 + 0.30 * Double(breath)), lineWidth: 0.9)
+                .frame(width: size, height: size)
+                .scaleEffect(0.90 + 0.14 * breath)
+                .shadow(color: tintColor.opacity(0.20 * Double(breath)), radius: size * 0.09)
+
+            // Center nexus — heart in sync with the ring.
+            Circle()
+                .fill(tintColor.opacity(0.65 + 0.30 * Double(breath)))
+                .frame(width: size * 0.17, height: size * 0.17)
+                .shadow(color: tintColor.opacity(0.35 * Double(breath)), radius: size * 0.14)
+                .scaleEffect(0.85 + 0.20 * breath)
+        }
+        .frame(width: size, height: size)
+        .drawingGroup()
+        .onAppear {
+            // Reset so every presentation begins at rest and inhales cleanly,
+            // regardless of how often the user button-mashes the hotkey.
+            breath = 0
+            withAnimation(.easeInOut(duration: 0.95).repeatForever(autoreverses: true)) {
+                breath = 1
+            }
+        }
+    }
+}
+
 // MARK: - Meditative Merkaba (Large, Slow)
 
 /// Larger, slower merkaba for empty states and idle backgrounds.

--- a/Sources/MacParakeet/Views/Components/SacredGeometry.swift
+++ b/Sources/MacParakeet/Views/Components/SacredGeometry.swift
@@ -204,49 +204,84 @@ struct MerkabaDissipateView: View {
 
 // MARK: - Breathing Ring (Ready / Waiting)
 
-/// Gentle breathing indicator for the dictation overlay's ephemeral `.ready`
+/// Gentle breath indicator for the dictation overlay's ephemeral `.ready`
 /// state — shown briefly (~800ms) between the first Fn tap and the double-tap
-/// window closing. A soft ring inhales around a pulsing center nexus: the
+/// window closing. A soft white ring inhales around a warm coral nexus: the
 /// smallest, lightest member of the sacred-geometry family, signalling
 /// "listening, poised, waiting" without competing with the active Merkaba
 /// (processing) or the dissolving Merkaba (no speech).
 ///
-/// Because the pill is typically visible for less than one full breath cycle,
-/// the animation starts cleanly at rest on each appearance so the user always
-/// sees a full inhale — an elegant rise that resolves into either recording
-/// (double-tap landed) or idle (window elapsed).
+/// ## Motion
+/// A single intentional inhale — **not** a perpetual loop. The pill is
+/// typically visible for ~800ms, which is shorter than any natural breath
+/// cycle; a `repeatForever` animation would be cut off mid-rise and read as
+/// clipped rather than alive. Instead, ring and nexus bloom from rest to
+/// peak via a soft, critically-damped spring (~700ms) and then hold at peak
+/// until the pill dismisses. The entire visible duration reads as one
+/// elegant rise — drawing breath in and holding — with no risk of clipping.
+///
+/// ## Color hierarchy
+/// The ring is white (belongs to the Merkaba family), but the nexus uses
+/// `DesignSystem.Colors.accent` (coral-orange — MacParakeet's brand
+/// attention color). The coral glow bleeds out past the ring into the dark
+/// pill background, creating luminous depth. This is the only dictation
+/// overlay state that uses the brand accent: **`.ready` is "MacParakeet
+/// listening for you."**
+///
+/// ## Accessibility
+/// Honors `Reduce Motion` by presenting the peak state statically (no
+/// inhale animation, just the fully-bloomed ring + nexus). Exposed to
+/// VoiceOver as "Listening".
 struct BreathingRingView: View {
     var size: CGFloat = 18
-    var tintColor: Color = .white
+    var ringColor: Color = .white
+    var nexusColor: Color = DesignSystem.Colors.accent
 
-    /// 0 = rest (exhale), 1 = peak (inhale). A single Double drives ring scale,
-    /// stroke opacity, glow radius, and nexus brightness so every element
-    /// breathes in perfect sync.
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// 0 = rest, 1 = peak. One-shot: animates from 0 → 1 on appear via a
+    /// soft spring and then holds at 1 until the view disappears. Never
+    /// loops — the pill's brief visibility window is too short for a full
+    /// cycle to read cleanly, so a single intentional bloom is more honest.
     @State private var breath: CGFloat = 0
 
     var body: some View {
         ZStack {
-            // Outer breathing ring — scales and brightens on inhale.
+            // White breathing ring — the halo of attention, sibling to the
+            // Merkaba family. Stroke opacity carries the primary breath
+            // signal; a subtle scale adds organic lift without visibly
+            // changing stroke weight.
             Circle()
-                .stroke(tintColor.opacity(0.35 + 0.30 * Double(breath)), lineWidth: 0.9)
+                .stroke(ringColor.opacity(0.30 + 0.40 * Double(breath)), lineWidth: 0.9)
                 .frame(width: size, height: size)
-                .scaleEffect(0.90 + 0.14 * breath)
-                .shadow(color: tintColor.opacity(0.20 * Double(breath)), radius: size * 0.09)
+                .scaleEffect(0.88 + 0.14 * breath)
 
-            // Center nexus — heart in sync with the ring.
+            // Warm coral nexus — the heart of attention. Scales, brightens,
+            // and emits a coral glow that bleeds out past the ring to give
+            // the pill luminous depth on its dark background.
             Circle()
-                .fill(tintColor.opacity(0.65 + 0.30 * Double(breath)))
-                .frame(width: size * 0.17, height: size * 0.17)
-                .shadow(color: tintColor.opacity(0.35 * Double(breath)), radius: size * 0.14)
-                .scaleEffect(0.85 + 0.20 * breath)
+                .fill(nexusColor.opacity(0.55 + 0.40 * Double(breath)))
+                .frame(width: size * 0.18, height: size * 0.18)
+                .scaleEffect(0.80 + 0.25 * breath)
+                .shadow(color: nexusColor.opacity(0.50 * Double(breath)), radius: size * 0.22)
         }
         .frame(width: size, height: size)
-        .drawingGroup()
+        .accessibilityElement()
+        .accessibilityLabel("Listening")
         .onAppear {
-            // Reset so every presentation begins at rest and inhales cleanly,
-            // regardless of how often the user button-mashes the hotkey.
-            breath = 0
-            withAnimation(.easeInOut(duration: 0.95).repeatForever(autoreverses: true)) {
+            // Reduce Motion: skip the inhale, present at peak statically.
+            // The user still sees the fully-bloomed state — they just don't
+            // see it move.
+            guard !reduceMotion else {
+                breath = 1
+                return
+            }
+
+            // One-shot inhale. Critically-damped spring (dampingFraction
+            // 0.95) for a soft, organic arrival — a whisper of warmth
+            // without overshoot. Response 0.70 gives ~700ms bloom, leaving
+            // ~100ms of hold at peak before the pill typically dismisses.
+            withAnimation(.spring(response: 0.70, dampingFraction: 0.95)) {
                 breath = 1
             }
         }

--- a/Sources/MacParakeet/Views/Components/SacredGeometry.swift
+++ b/Sources/MacParakeet/Views/Components/SacredGeometry.swift
@@ -216,9 +216,10 @@ struct MerkabaDissipateView: View {
 /// typically visible for ~800ms, which is shorter than any natural breath
 /// cycle; a `repeatForever` animation would be cut off mid-rise and read as
 /// clipped rather than alive. Instead, ring and nexus bloom from rest to
-/// peak via a soft, critically-damped spring (~700ms) and then hold at peak
-/// until the pill dismisses. The entire visible duration reads as one
-/// elegant rise — drawing breath in and holding — with no risk of clipping.
+/// peak via a soft, near-critically-damped spring (~700ms) and then hold
+/// at peak until the pill dismisses. The entire visible duration reads as
+/// one elegant rise — drawing breath in and holding — with no risk of
+/// clipping.
 ///
 /// ## Color hierarchy
 /// The ring is white (belongs to the Merkaba family), but the nexus uses
@@ -267,7 +268,7 @@ struct BreathingRingView: View {
         }
         .frame(width: size, height: size)
         .accessibilityElement()
-        .accessibilityLabel("Listening")
+        .accessibilityLabel("Ready to record")
         .onAppear {
             // Reduce Motion: skip the inhale, present at peak statically.
             // The user still sees the fully-bloomed state — they just don't
@@ -277,10 +278,11 @@ struct BreathingRingView: View {
                 return
             }
 
-            // One-shot inhale. Critically-damped spring (dampingFraction
-            // 0.95) for a soft, organic arrival — a whisper of warmth
-            // without overshoot. Response 0.70 gives ~700ms bloom, leaving
-            // ~100ms of hold at peak before the pill typically dismisses.
+            // One-shot inhale. Near-critically-damped spring
+            // (dampingFraction 0.95) for a soft, organic arrival — a
+            // whisper of warmth with a sub-perceptible overshoot. Response
+            // 0.70 gives ~700ms bloom, leaving ~100ms of hold at peak
+            // before the pill typically dismisses.
             withAnimation(.spring(response: 0.70, dampingFraction: 0.95)) {
                 breath = 1
             }

--- a/Sources/MacParakeet/Views/Dictation/DictationOverlayController.swift
+++ b/Sources/MacParakeet/Views/Dictation/DictationOverlayController.swift
@@ -204,9 +204,6 @@ final class DictationOverlayViewModel {
     /// Cancel countdown value (separate from state enum to avoid view reconstruction jank).
     var cancelTimeRemaining: Double = 5.0
 
-    /// No-speech progress bar: starts at 1.0, animates to 0.0 over 3 seconds.
-    var noSpeechProgress: CGFloat = 1.0
-
     private var timerTask: Task<Void, Never>?
 
     func startTimer() {

--- a/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
+++ b/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
@@ -57,11 +57,13 @@ private struct CheckmarkShape: Shape {
 
 // MARK: - No Speech Content
 
-/// No-speech terminal animation: Merkaba dissolves → falling leaf + serif label.
-/// Self-contained @State so nothing leaks across dictation sessions.
-/// Sized to 26×26 to match the success/processing circular pill.
+/// No-speech terminal animation: Merkaba dissolves inside a 46×46 circle, then
+/// the pill expands horizontally as the falling leaf + serif label bloom in.
+/// The `expanded` prop is driven by the parent so the pill's padding (circle ↔
+/// oval) stays in sync with this view's internal leaf/text animations.
 private struct NoSpeechContentView: View {
     let isCommand: Bool
+    let expanded: Bool
 
     @State private var leafVisible: Double = 0
     @State private var leafDrift: CGFloat = -4
@@ -69,62 +71,73 @@ private struct NoSpeechContentView: View {
     @State private var textOpacity: Double = 0
 
     private var label: String {
-        isCommand ? "no command" : "no audio"
+        isCommand ? "no command" : "more audio pls"
     }
 
     var body: some View {
-        ZStack {
-            // Sacred geometry dissolves (matches SpinnerRingView default size: 26)
-            MerkabaDissipateView(size: 26)
+        HStack(spacing: expanded ? 4 : 0) {
+            // Sacred geometry + falling leaf — dissolving Merkaba inside a fixed 26×26 box.
+            ZStack {
+                MerkabaDissipateView(size: 26)
 
-            // Leaf drifts in as geometry fades — warm coral-orange (parakeet plumage)
-            Image(systemName: "leaf.fill")
-                .font(.system(size: 18, weight: .light))
-                .foregroundStyle(DesignSystem.Colors.accent.opacity(leafVisible))
-                .rotationEffect(.degrees(leafRotation))
-                .offset(x: leafDrift * 0.5, y: leafDrift)
+                // Leaf drifts in as geometry fades — warm coral-orange (parakeet plumage).
+                // Hidden in phase 0 (circular) and blooms in phase 1 (expanded oval).
+                Image(systemName: "leaf.fill")
+                    .font(.system(size: 14, weight: .light))
+                    .foregroundStyle(DesignSystem.Colors.accent.opacity(leafVisible))
+                    .rotationEffect(.degrees(leafRotation))
+                    .offset(x: leafDrift * 0.5, y: leafDrift)
+            }
+            .frame(width: 26, height: 26)
 
-            // Elegant serif italic label — overflows the 26×26 frame into pill padding,
-            // so the pill background (46×46) can accommodate the text without resizing.
-            // For command mode ("no command"), the pill is allowed to grow into an oval
-            // via isIconOnly=false so the longer label is not clipped (see overlayContent).
-            Text(label)
-                .font(DesignSystem.Typography.dictationOverlayTerminalLabel)
-                .foregroundStyle(.white.opacity(textOpacity))
-                .fixedSize()
+            // Elegant serif italic label — only present in the HStack once expanded,
+            // using `.fixedSize()` for its natural intrinsic width. The parent's
+            // `withAnimation` around the `noSpeechExpanded` flip smoothly animates
+            // the HStack's size change as the text view appears.
+            //
+            // IMPORTANT: do not use `.frame(maxWidth: .infinity)` here — it propagates
+            // up through the HStack → pill → overlay window and balloons the capsule
+            // to full window width. `fixedSize()` alone gives the correct tight width.
+            if expanded {
+                Text(label)
+                    .font(DesignSystem.Typography.dictationOverlayTerminalLabel)
+                    .foregroundStyle(.white.opacity(textOpacity))
+                    .fixedSize()
+                    .transition(.opacity)
+            }
         }
-        .frame(width: 26, height: 26)
-        .onAppear {
-            // Reset to baseline so repeated presentations replay deterministically.
-            leafVisible = 0
-            leafDrift = -4
-            leafRotation = -18
-            textOpacity = 0
+        .onChange(of: expanded) { _, isExpanded in
+            guard isExpanded else { return }
+            runBloomAnimations()
+        }
+    }
 
-#if DEBUG
-            assert(
-                NoSpeechAnimationTiming.isDismissWindowSufficient,
-                "No-speech animation (\(NoSpeechAnimationTiming.estimatedAnimationCompletionSeconds)s) must complete before dismiss (\(NoSpeechAnimationTiming.dismissSeconds)s)."
-            )
-#endif
+    /// Resets animation state and runs the leaf + text bloom sequence. Called when
+    /// `expanded` flips to true (~0.4s after `.noSpeech` is entered, giving the
+    /// circular Merkaba time to settle / dissolve first).
+    private func runBloomAnimations() {
+        // Reset to baseline so repeated presentations replay deterministically.
+        leafVisible = 0
+        leafDrift = -4
+        leafRotation = -18
+        textOpacity = 0
 
-            // Leaf fades in as Merkaba dissolves
-            withAnimation(.easeIn(duration: NoSpeechAnimationTiming.leafFadeInDuration).delay(NoSpeechAnimationTiming.leafFadeInDelay)) {
-                leafVisible = 0.7
-            }
-            // Leaf gently drifts down + rotates (falling)
-            withAnimation(.easeInOut(duration: NoSpeechAnimationTiming.leafDriftDuration).delay(NoSpeechAnimationTiming.leafDriftDelay)) {
-                leafDrift = 6
-                leafRotation = 18
-            }
-            // Text fades in, anchored at center over the leaf
-            withAnimation(.easeIn(duration: NoSpeechAnimationTiming.textFadeInDuration).delay(NoSpeechAnimationTiming.textFadeInDelay)) {
-                textOpacity = 0.95
-            }
-            // Leaf softly recedes so text reads clean
-            withAnimation(.easeOut(duration: NoSpeechAnimationTiming.leafRecedeDuration).delay(NoSpeechAnimationTiming.leafRecedeDelay)) {
-                leafVisible = 0.3
-            }
+        // Leaf fades in as Merkaba finishes dissolving
+        withAnimation(.easeIn(duration: NoSpeechAnimationTiming.leafFadeInDuration)) {
+            leafVisible = 0.7
+        }
+        // Leaf gently drifts down + rotates (falling)
+        withAnimation(.easeInOut(duration: NoSpeechAnimationTiming.leafDriftDuration)) {
+            leafDrift = 6
+            leafRotation = 18
+        }
+        // Text fades in alongside the expansion
+        withAnimation(.easeIn(duration: NoSpeechAnimationTiming.textFadeInDuration).delay(0.15)) {
+            textOpacity = 0.95
+        }
+        // Leaf softly recedes so text reads clean
+        withAnimation(.easeOut(duration: NoSpeechAnimationTiming.leafRecedeDuration).delay(NoSpeechAnimationTiming.leafRecedeDelay - NoSpeechAnimationTiming.leafFadeInDelay)) {
+            leafVisible = 0.3
         }
     }
 }
@@ -132,6 +145,12 @@ private struct NoSpeechContentView: View {
 /// The dictation overlay — compact dark capsule during dictation, wider card for errors.
 struct DictationOverlayView: View {
     @Bindable var viewModel: DictationOverlayViewModel
+
+    /// Drives the no-speech pill's circle → oval width expansion. Starts `false`
+    /// so the pill begins at 46×46 (matching the processing spinner), then flips
+    /// to `true` after a short delay so the pill blooms horizontally as the leaf
+    /// + "more audio pls" label fade in. Reset whenever the pill state changes.
+    @State private var noSpeechExpanded: Bool = false
 
     /// Align tooltip above the hovered button: leading for cancel, trailing for stop.
     private var tooltipAlignment: Alignment {
@@ -156,6 +175,27 @@ struct DictationOverlayView: View {
         }
         .padding(.bottom, 8)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+        .onChange(of: viewModel.pillStateKey) { _, newKey in
+            handlePillStateChange(to: newKey)
+        }
+    }
+
+    /// When entering any noSpeech state, start as a 46×46 circle and schedule the
+    /// oval expansion after a short delay so the Merkaba can begin dissolving in
+    /// its circular form before the pill blooms horizontally.
+    private func handlePillStateChange(to key: String) {
+        guard key.contains("noSpeech") else {
+            noSpeechExpanded = false
+            return
+        }
+        noSpeechExpanded = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+            // Guard against stale transitions: only expand if we are still in noSpeech.
+            guard viewModel.pillStateKey.contains("noSpeech") else { return }
+            withAnimation(.easeOut(duration: 0.45)) {
+                noSpeechExpanded = true
+            }
+        }
     }
 
     @ViewBuilder
@@ -166,22 +206,40 @@ struct DictationOverlayView: View {
 
         default:
             let isReady = if case .ready = viewModel.state { true } else { false }
-            // Processing (non-command), success, and noSpeech (non-command) show a single
-            // icon — use equal padding so the Capsule background renders as a perfect
-            // circle, not an oval. In command mode, the no-speech label is "no command"
-            // (10 chars) which overflows the 46×46 circular pill via fixedSize; fall back
-            // to the oval layout so the label reads cleanly.
+            // Processing (non-command) and success show a single icon — use equal
+            // padding so the Capsule background renders as a perfect circle, not
+            // an oval. noSpeech starts as a circle (matching processing) and then
+            // blooms into an oval once `noSpeechExpanded` flips — so its label
+            // reads cleanly on a full dark background after the expansion.
             let isIconOnly: Bool = {
                 switch viewModel.state {
                 case .processing: return viewModel.sessionKind != .command
                 case .success: return true
-                case .noSpeech: return viewModel.sessionKind != .command
+                case .noSpeech: return !noSpeechExpanded
                 default: return false
                 }
             }()
+            // noSpeech (expanded) uses tighter horizontal padding and smaller vertical
+            // padding than the circular phase, so the bloom animation stretches the
+            // 46×46 circle horizontally while also slimming down vertically into a
+            // low-profile terminal pill.
+            let isNoSpeechState = { if case .noSpeech = viewModel.state { return true } else { return false } }()
+            let isNoSpeechExpanded = isNoSpeechState && noSpeechExpanded
+            let horizontalPadding: CGFloat = {
+                if isReady { return 6 }
+                if isIconOnly { return 10 }
+                if isNoSpeechExpanded { return 10 }
+                return 16
+            }()
+            let verticalPadding: CGFloat = {
+                if isReady { return 4 }
+                if isIconOnly { return 10 }
+                if isNoSpeechExpanded { return 5 }
+                return 7
+            }()
             pillContent
-                .padding(.horizontal, isReady ? 6 : (isIconOnly ? 10 : 16))
-                .padding(.vertical, isReady ? 4 : (isIconOnly ? 10 : 7))
+                .padding(.horizontal, horizontalPadding)
+                .padding(.vertical, verticalPadding)
                 .background(
                     Capsule()
                         .fill(DesignSystem.Colors.pillBackground)
@@ -192,6 +250,7 @@ struct DictationOverlayView: View {
                         .shadow(color: .black.opacity(0.3), radius: 8, y: 4)
                 )
                 .animation(.easeInOut(duration: 0.25), value: viewModel.pillStateKey)
+                .animation(.easeOut(duration: 0.45), value: noSpeechExpanded)
         }
     }
 
@@ -413,7 +472,10 @@ struct DictationOverlayView: View {
     // MARK: - No Speech State
 
     private var noSpeechContent: some View {
-        NoSpeechContentView(isCommand: viewModel.sessionKind == .command)
+        NoSpeechContentView(
+            isCommand: viewModel.sessionKind == .command,
+            expanded: noSpeechExpanded
+        )
     }
 
     // MARK: - Error Card

--- a/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
+++ b/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
@@ -116,6 +116,18 @@ private struct NoSpeechContentView: View {
     /// `expanded` flips to true (~0.4s after `.noSpeech` is entered, giving the
     /// circular Merkaba time to settle / dissolve first).
     private func runBloomAnimations() {
+        #if DEBUG
+        // Fail loudly in debug builds if someone shrinks the dismiss window below
+        // what the animation phases need to complete. This is the actual guard
+        // behind `NoSpeechAnimationTiming.isDismissWindowSufficient`.
+        assert(
+            NoSpeechAnimationTiming.isDismissWindowSufficient,
+            "No-speech dismiss window (\(NoSpeechAnimationTiming.dismissSeconds)s) is too short for " +
+            "estimated animation completion (\(NoSpeechAnimationTiming.estimatedAnimationCompletionSeconds)s) " +
+            "+ buffer (\(NoSpeechAnimationTiming.completionBufferSeconds)s)."
+        )
+        #endif
+
         // Reset to baseline so repeated presentations replay deterministically.
         leafVisible = 0
         leafDrift = -4

--- a/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
+++ b/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
@@ -68,11 +68,6 @@ private struct NoSpeechContentView: View {
     @State private var leafRotation: Double = -18
     @State private var textOpacity: Double = 0
 
-    /// Warm coral/orange accent for the falling leaf.
-    private var leafTint: Color {
-        Color(red: 0.96, green: 0.58, blue: 0.33)
-    }
-
     private var label: String {
         isCommand ? "no command" : "no audio"
     }
@@ -82,18 +77,19 @@ private struct NoSpeechContentView: View {
             // Sacred geometry dissolves (matches SpinnerRingView default size: 26)
             MerkabaDissipateView(size: 26)
 
-            // Leaf drifts in as geometry fades — warm orange nature moment
+            // Leaf drifts in as geometry fades — warm coral-orange (parakeet plumage)
             Image(systemName: "leaf.fill")
                 .font(.system(size: 18, weight: .light))
-                .foregroundStyle(leafTint.opacity(leafVisible))
+                .foregroundStyle(DesignSystem.Colors.accent.opacity(leafVisible))
                 .rotationEffect(.degrees(leafRotation))
                 .offset(x: leafDrift * 0.5, y: leafDrift)
 
             // Elegant serif italic label — overflows the 26×26 frame into pill padding,
             // so the pill background (46×46) can accommodate the text without resizing.
+            // For command mode ("no command"), the pill is allowed to grow into an oval
+            // via isIconOnly=false so the longer label is not clipped (see overlayContent).
             Text(label)
-                .font(.system(size: 8.5, weight: .regular, design: .serif))
-                .italic()
+                .font(DesignSystem.Typography.dictationOverlayTerminalLabel)
                 .foregroundStyle(.white.opacity(textOpacity))
                 .fixedSize()
         }
@@ -157,12 +153,16 @@ struct DictationOverlayView: View {
 
         default:
             let isReady = if case .ready = viewModel.state { true } else { false }
-            // Processing (non-command), success, and noSpeech show a single icon — use equal
-            // padding so the Capsule background renders as a perfect circle, not an oval.
+            // Processing (non-command), success, and noSpeech (non-command) show a single
+            // icon — use equal padding so the Capsule background renders as a perfect
+            // circle, not an oval. In command mode, the no-speech label is "no command"
+            // (10 chars) which overflows the 46×46 circular pill via fixedSize; fall back
+            // to the oval layout so the label reads cleanly.
             let isIconOnly: Bool = {
                 switch viewModel.state {
                 case .processing: return viewModel.sessionKind != .command
-                case .success, .noSpeech: return true
+                case .success: return true
+                case .noSpeech: return viewModel.sessionKind != .command
                 default: return false
                 }
             }()

--- a/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
+++ b/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
@@ -55,6 +55,71 @@ private struct CheckmarkShape: Shape {
     }
 }
 
+// MARK: - No Speech Content
+
+/// No-speech terminal animation: Merkaba dissolves → falling leaf + serif label.
+/// Self-contained @State so nothing leaks across dictation sessions.
+/// Sized to 26×26 to match the success/processing circular pill.
+private struct NoSpeechContentView: View {
+    let isCommand: Bool
+
+    @State private var leafVisible: Double = 0
+    @State private var leafDrift: CGFloat = -4
+    @State private var leafRotation: Double = -18
+    @State private var textOpacity: Double = 0
+
+    /// Warm coral/orange accent for the falling leaf.
+    private var leafTint: Color {
+        Color(red: 0.96, green: 0.58, blue: 0.33)
+    }
+
+    private var label: String {
+        isCommand ? "no command" : "no audio"
+    }
+
+    var body: some View {
+        ZStack {
+            // Sacred geometry dissolves (matches SpinnerRingView default size: 26)
+            MerkabaDissipateView(size: 26)
+
+            // Leaf drifts in as geometry fades — warm orange nature moment
+            Image(systemName: "leaf.fill")
+                .font(.system(size: 18, weight: .light))
+                .foregroundStyle(leafTint.opacity(leafVisible))
+                .rotationEffect(.degrees(leafRotation))
+                .offset(x: leafDrift * 0.5, y: leafDrift)
+
+            // Elegant serif italic label — overflows the 26×26 frame into pill padding,
+            // so the pill background (46×46) can accommodate the text without resizing.
+            Text(label)
+                .font(.system(size: 8.5, weight: .regular, design: .serif))
+                .italic()
+                .foregroundStyle(.white.opacity(textOpacity))
+                .fixedSize()
+        }
+        .frame(width: 26, height: 26)
+        .onAppear {
+            // Leaf fades in as Merkaba dissolves
+            withAnimation(.easeIn(duration: 0.5).delay(0.35)) {
+                leafVisible = 0.7
+            }
+            // Leaf gently drifts down + rotates (falling)
+            withAnimation(.easeInOut(duration: 1.6).delay(0.35)) {
+                leafDrift = 6
+                leafRotation = 18
+            }
+            // Text fades in, anchored at center over the leaf
+            withAnimation(.easeIn(duration: 0.4).delay(0.75)) {
+                textOpacity = 0.95
+            }
+            // Leaf softly recedes so text reads clean
+            withAnimation(.easeOut(duration: 0.55).delay(1.5)) {
+                leafVisible = 0.3
+            }
+        }
+    }
+}
+
 /// The dictation overlay — compact dark capsule during dictation, wider card for errors.
 struct DictationOverlayView: View {
     @Bindable var viewModel: DictationOverlayViewModel
@@ -92,12 +157,12 @@ struct DictationOverlayView: View {
 
         default:
             let isReady = if case .ready = viewModel.state { true } else { false }
-            // Processing (non-command) and success show a single 26×26 icon — use equal
+            // Processing (non-command), success, and noSpeech show a single icon — use equal
             // padding so the Capsule background renders as a perfect circle, not an oval.
             let isIconOnly: Bool = {
                 switch viewModel.state {
                 case .processing: return viewModel.sessionKind != .command
-                case .success: return true
+                case .success, .noSpeech: return true
                 default: return false
                 }
             }()
@@ -335,34 +400,7 @@ struct DictationOverlayView: View {
     // MARK: - No Speech State
 
     private var noSpeechContent: some View {
-        VStack(spacing: 8) {
-            HStack(spacing: 7) {
-                Image(systemName: "waveform.slash")
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.5))
-
-                Text(viewModel.sessionKind == .command ? "No command detected" : "No speech detected")
-                    .font(.system(size: 14, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.7))
-            }
-
-            // Thin progress bar — track + fill, shrinks over 3s
-            ZStack(alignment: .leading) {
-                Capsule()
-                    .fill(Color.white.opacity(0.12))
-                Capsule()
-                    .fill(Color.white.opacity(0.4))
-                    .scaleEffect(x: viewModel.noSpeechProgress, anchor: .trailing)
-                    .animation(.linear(duration: 3.0), value: viewModel.noSpeechProgress)
-            }
-            .frame(height: 2.5)
-            .onAppear {
-                // Trigger after the view renders so SwiftUI has a "from" value to animate
-                viewModel.noSpeechProgress = 0.0
-            }
-        }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 2)
+        NoSpeechContentView(isCommand: viewModel.sessionKind == .command)
     }
 
     // MARK: - Error Card
@@ -545,7 +583,6 @@ struct DictationOverlayView: View {
         DictationOverlayView(viewModel: {
             let vm = DictationOverlayViewModel()
             vm.state = .noSpeech
-            vm.noSpeechProgress = 0.6
             return vm
         }())
 

--- a/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
+++ b/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
@@ -95,6 +95,12 @@ private struct NoSpeechContentView: View {
         }
         .frame(width: 26, height: 26)
         .onAppear {
+            // Reset to baseline so repeated presentations replay deterministically.
+            leafVisible = 0
+            leafDrift = -4
+            leafRotation = -18
+            textOpacity = 0
+
             // Leaf fades in as Merkaba dissolves
             withAnimation(.easeIn(duration: 0.5).delay(0.35)) {
                 leafVisible = 0.7

--- a/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
+++ b/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
@@ -225,14 +225,19 @@ struct DictationOverlayView: View {
             // low-profile terminal pill.
             let isNoSpeechState = { if case .noSpeech = viewModel.state { return true } else { return false } }()
             let isNoSpeechExpanded = isNoSpeechState && noSpeechExpanded
+            // Ready uses equal horizontal/vertical padding so the breathing
+            // ring sits inside a tight ~32×32 circular pill — distinctly
+            // smaller and lighter than the 46×46 processing / noSpeech
+            // circles, reinforcing that `.ready` is a brief, poised pause
+            // rather than active work.
             let horizontalPadding: CGFloat = {
-                if isReady { return 6 }
+                if isReady { return 7 }
                 if isIconOnly { return 10 }
                 if isNoSpeechExpanded { return 10 }
                 return 16
             }()
             let verticalPadding: CGFloat = {
-                if isReady { return 4 }
+                if isReady { return 7 }
                 if isIconOnly { return 10 }
                 if isNoSpeechExpanded { return 5 }
                 return 7
@@ -299,9 +304,15 @@ struct DictationOverlayView: View {
 
     // MARK: - Ready State
 
+    /// Ready pill — a gentle breathing ring that appears briefly after the
+    /// first Fn tap while the state machine waits to see if a second tap lands
+    /// (double-tap = persistent recording) or the window elapses (back to
+    /// idle). The breath ring belongs to the same sacred-geometry family as
+    /// `SpinnerRingView` (processing) and `MerkabaDissipateView` (no speech),
+    /// but is the smallest and lightest member — a poised inhale rather than
+    /// active work or a terminal dissolve.
     private var readyContent: some View {
-        WaveformView(audioLevel: 0.15, barCount: 8)
-            .frame(width: 44, height: 14)
+        BreathingRingView(size: 18)
     }
 
     // MARK: - Hold-to-Talk State

--- a/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
+++ b/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
@@ -101,21 +101,28 @@ private struct NoSpeechContentView: View {
             leafRotation = -18
             textOpacity = 0
 
+#if DEBUG
+            assert(
+                NoSpeechAnimationTiming.isDismissWindowSufficient,
+                "No-speech animation (\(NoSpeechAnimationTiming.estimatedAnimationCompletionSeconds)s) must complete before dismiss (\(NoSpeechAnimationTiming.dismissSeconds)s)."
+            )
+#endif
+
             // Leaf fades in as Merkaba dissolves
-            withAnimation(.easeIn(duration: 0.5).delay(0.35)) {
+            withAnimation(.easeIn(duration: NoSpeechAnimationTiming.leafFadeInDuration).delay(NoSpeechAnimationTiming.leafFadeInDelay)) {
                 leafVisible = 0.7
             }
             // Leaf gently drifts down + rotates (falling)
-            withAnimation(.easeInOut(duration: 1.6).delay(0.35)) {
+            withAnimation(.easeInOut(duration: NoSpeechAnimationTiming.leafDriftDuration).delay(NoSpeechAnimationTiming.leafDriftDelay)) {
                 leafDrift = 6
                 leafRotation = 18
             }
             // Text fades in, anchored at center over the leaf
-            withAnimation(.easeIn(duration: 0.4).delay(0.75)) {
+            withAnimation(.easeIn(duration: NoSpeechAnimationTiming.textFadeInDuration).delay(NoSpeechAnimationTiming.textFadeInDelay)) {
                 textOpacity = 0.95
             }
             // Leaf softly recedes so text reads clean
-            withAnimation(.easeOut(duration: 0.55).delay(1.5)) {
+            withAnimation(.easeOut(duration: NoSpeechAnimationTiming.leafRecedeDuration).delay(NoSpeechAnimationTiming.leafRecedeDelay)) {
                 leafVisible = 0.3
             }
         }

--- a/Sources/MacParakeetCore/DictationFlow/DictationFlowStateMachine.swift
+++ b/Sources/MacParakeetCore/DictationFlow/DictationFlowStateMachine.swift
@@ -371,7 +371,7 @@ public struct DictationFlowStateMachine: Sendable, Equatable {
         case (.processing, .transcriptionFailedNoSpeech(let gen)):
             guard gen == generation else { return [] }
             state = .finishing(outcome: .noSpeech)
-            return [.showNoSpeech, .updateMenuBar(.idle), .startDisplayDismissTimer(seconds: 2.5)]
+            return [.showNoSpeech, .updateMenuBar(.idle), .startDisplayDismissTimer(seconds: DictationFlowTiming.noSpeechDismissSeconds)]
 
         case (.processing, .transcriptionFailed(let gen, let message)):
             guard gen == generation else { return [] }

--- a/Sources/MacParakeetCore/DictationFlow/DictationFlowStateMachine.swift
+++ b/Sources/MacParakeetCore/DictationFlow/DictationFlowStateMachine.swift
@@ -371,7 +371,7 @@ public struct DictationFlowStateMachine: Sendable, Equatable {
         case (.processing, .transcriptionFailedNoSpeech(let gen)):
             guard gen == generation else { return [] }
             state = .finishing(outcome: .noSpeech)
-            return [.showNoSpeech, .updateMenuBar(.idle), .startDisplayDismissTimer(seconds: 3)]
+            return [.showNoSpeech, .updateMenuBar(.idle), .startDisplayDismissTimer(seconds: 2.5)]
 
         case (.processing, .transcriptionFailed(let gen, let message)):
             guard gen == generation else { return [] }

--- a/Sources/MacParakeetCore/DictationFlow/DictationFlowTiming.swift
+++ b/Sources/MacParakeetCore/DictationFlow/DictationFlowTiming.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Shared timing values used across the dictation flow.
+/// Keeping these in Core gives state/effects and UI a single source of truth.
+public enum DictationFlowTiming {
+    /// How long the no-speech terminal state should remain visible before dismiss.
+    public static let noSpeechDismissSeconds: Double = 2.5
+}

--- a/Tests/MacParakeetTests/App/AppDelegateMenuBarResolverTests.swift
+++ b/Tests/MacParakeetTests/App/AppDelegateMenuBarResolverTests.swift
@@ -6,7 +6,7 @@ final class AppDelegateMenuBarResolverTests: XCTestCase {
     func testResolveMenuBarStatePrioritizesMeetingRecording() {
         let state = AppDelegate.resolveMenuBarState(
             isMeetingRecordingActive: true,
-            isDictationCapturingAudio: false,
+            dictationMenuBarPreference: .processing,
             isTranscribing: true
         )
         XCTAssertEqual(state, .recording)
@@ -15,16 +15,25 @@ final class AppDelegateMenuBarResolverTests: XCTestCase {
     func testResolveMenuBarStatePrioritizesDictationRecordingOverTranscribing() {
         let state = AppDelegate.resolveMenuBarState(
             isMeetingRecordingActive: false,
-            isDictationCapturingAudio: true,
+            dictationMenuBarPreference: .recording,
             isTranscribing: true
         )
         XCTAssertEqual(state, .recording)
     }
 
+    func testResolveMenuBarStateUsesDictationProcessingWhenPreferred() {
+        let state = AppDelegate.resolveMenuBarState(
+            isMeetingRecordingActive: false,
+            dictationMenuBarPreference: .processing,
+            isTranscribing: false
+        )
+        XCTAssertEqual(state, .processing)
+    }
+
     func testResolveMenuBarStateUsesProcessingWhenOnlyTranscribing() {
         let state = AppDelegate.resolveMenuBarState(
             isMeetingRecordingActive: false,
-            isDictationCapturingAudio: false,
+            dictationMenuBarPreference: nil,
             isTranscribing: true
         )
         XCTAssertEqual(state, .processing)
@@ -33,7 +42,7 @@ final class AppDelegateMenuBarResolverTests: XCTestCase {
     func testResolveMenuBarStateFallsBackToIdle() {
         let state = AppDelegate.resolveMenuBarState(
             isMeetingRecordingActive: false,
-            isDictationCapturingAudio: false,
+            dictationMenuBarPreference: nil,
             isTranscribing: false
         )
         XCTAssertEqual(state, .idle)

--- a/Tests/MacParakeetTests/App/AppDelegateMenuBarResolverTests.swift
+++ b/Tests/MacParakeetTests/App/AppDelegateMenuBarResolverTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import MacParakeet
+
+@MainActor
+final class AppDelegateMenuBarResolverTests: XCTestCase {
+    func testResolveMenuBarStatePrioritizesMeetingRecording() {
+        let state = AppDelegate.resolveMenuBarState(
+            isMeetingRecordingActive: true,
+            isDictationCapturingAudio: false,
+            isTranscribing: true
+        )
+        XCTAssertEqual(state, .recording)
+    }
+
+    func testResolveMenuBarStatePrioritizesDictationRecordingOverTranscribing() {
+        let state = AppDelegate.resolveMenuBarState(
+            isMeetingRecordingActive: false,
+            isDictationCapturingAudio: true,
+            isTranscribing: true
+        )
+        XCTAssertEqual(state, .recording)
+    }
+
+    func testResolveMenuBarStateUsesProcessingWhenOnlyTranscribing() {
+        let state = AppDelegate.resolveMenuBarState(
+            isMeetingRecordingActive: false,
+            isDictationCapturingAudio: false,
+            isTranscribing: true
+        )
+        XCTAssertEqual(state, .processing)
+    }
+
+    func testResolveMenuBarStateFallsBackToIdle() {
+        let state = AppDelegate.resolveMenuBarState(
+            isMeetingRecordingActive: false,
+            isDictationCapturingAudio: false,
+            isTranscribing: false
+        )
+        XCTAssertEqual(state, .idle)
+    }
+}

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorTests.swift
@@ -4,6 +4,30 @@ import XCTest
 
 @MainActor
 final class DictationFlowCoordinatorTests: XCTestCase {
+    func testMenuBarPreferenceMatchesStateMachineIntent() {
+        XCTAssertEqual(DictationFlowCoordinator.menuBarPreference(for: .startingService(mode: .persistent)), .recording)
+        XCTAssertEqual(DictationFlowCoordinator.menuBarPreference(for: .recording(mode: .holdToTalk)), .recording)
+        XCTAssertEqual(DictationFlowCoordinator.menuBarPreference(for: .pendingStop(mode: .persistent)), .recording)
+        XCTAssertEqual(DictationFlowCoordinator.menuBarPreference(for: .processing), .processing)
+    }
+
+    func testMenuBarPreferenceIsNilOutsideActiveStates() {
+        let states: [DictationFlowState] = [
+            .idle,
+            .ready,
+            .checkingEntitlements(mode: .persistent),
+            .cancelCountdown,
+            .finishing(outcome: .success),
+            .finishing(outcome: .noSpeech),
+            .finishing(outcome: .error("boom")),
+            .finishing(outcome: .pasteFailedCopied("Copied to clipboard. Press Cmd+V.")),
+        ]
+
+        for state in states {
+            XCTAssertNil(DictationFlowCoordinator.menuBarPreference(for: state), "Expected nil for \(state)")
+        }
+    }
+
     func testIsCapturingAudioTrueForCaptureAndProcessingStates() {
         XCTAssertTrue(DictationFlowCoordinator.isCapturingAudio(for: .startingService(mode: .persistent)))
         XCTAssertTrue(DictationFlowCoordinator.isCapturingAudio(for: .recording(mode: .holdToTalk)))

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import MacParakeet
+@testable import MacParakeetCore
+
+@MainActor
+final class DictationFlowCoordinatorTests: XCTestCase {
+    func testIsCapturingAudioTrueForCaptureAndProcessingStates() {
+        XCTAssertTrue(DictationFlowCoordinator.isCapturingAudio(for: .startingService(mode: .persistent)))
+        XCTAssertTrue(DictationFlowCoordinator.isCapturingAudio(for: .recording(mode: .holdToTalk)))
+        XCTAssertTrue(DictationFlowCoordinator.isCapturingAudio(for: .pendingStop(mode: .persistent)))
+        XCTAssertTrue(DictationFlowCoordinator.isCapturingAudio(for: .processing))
+    }
+
+    func testIsCapturingAudioFalseForNonCaptureStatesIncludingFinishing() {
+        let states: [DictationFlowState] = [
+            .idle,
+            .ready,
+            .checkingEntitlements(mode: .persistent),
+            .cancelCountdown,
+            .finishing(outcome: .success),
+            .finishing(outcome: .noSpeech),
+            .finishing(outcome: .error("boom")),
+            .finishing(outcome: .pasteFailedCopied("Copied to clipboard. Press Cmd+V.")),
+        ]
+
+        for state in states {
+            XCTAssertFalse(DictationFlowCoordinator.isCapturingAudio(for: state), "Expected false for \(state)")
+        }
+    }
+}

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowStateMachineTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowStateMachineTests.swift
@@ -515,7 +515,7 @@ final class DictationFlowStateMachineTests: XCTestCase {
         XCTAssertEqual(m.state, .finishing(outcome: .noSpeech))
         XCTAssertTrue(effects.contains(.showNoSpeech))
         XCTAssertTrue(effects.contains(.updateMenuBar(.idle)))
-        XCTAssertTrue(effects.contains(.startDisplayDismissTimer(seconds: 3)))
+        XCTAssertTrue(effects.contains(.startDisplayDismissTimer(seconds: 2.5)))
     }
 
     func testProcessingTranscriptionFailed() {

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowStateMachineTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowStateMachineTests.swift
@@ -780,6 +780,7 @@ final class DictationFlowStateMachineTests: XCTestCase {
         let effects = m.handle(.startRequested(mode: .holdToTalk))
         XCTAssertEqual(m.state, .checkingEntitlements(mode: .holdToTalk))
         XCTAssertEqual(m.generation, oldGen + 1)
+        XCTAssertTrue(effects.contains(.cancelAllTimers))
         XCTAssertTrue(effects.contains(.hideOverlay))
         XCTAssertTrue(effects.contains(.checkEntitlements))
         XCTAssertTrue(effects.contains(.reloadHistory))

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowStateMachineTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowStateMachineTests.swift
@@ -515,7 +515,7 @@ final class DictationFlowStateMachineTests: XCTestCase {
         XCTAssertEqual(m.state, .finishing(outcome: .noSpeech))
         XCTAssertTrue(effects.contains(.showNoSpeech))
         XCTAssertTrue(effects.contains(.updateMenuBar(.idle)))
-        XCTAssertTrue(effects.contains(.startDisplayDismissTimer(seconds: 2.5)))
+        XCTAssertTrue(effects.contains(.startDisplayDismissTimer(seconds: DictationFlowTiming.noSpeechDismissSeconds)))
     }
 
     func testProcessingTranscriptionFailed() {


### PR DESCRIPTION
## Summary

This PR refines dictation terminal states and menu bar behavior with a tighter architecture and deterministic animation behavior.

1. **No-speech terminal redesign**
- Replaces the old large no-speech bubble (`waveform.slash` + label + shrinking progress bar) with a compact terminal animation:
  - `SpinnerRingView` continuity into `MerkabaDissipateView`
  - drifting warm leaf + serif italic label (`no audio` / `no command`)
- Keeps non-command terminal pill visually circular and compact.
- Ensures deterministic replays by resetting local animation state on `onAppear`.

2. **Shared no-speech timing source of truth**
- Introduces `DictationFlowTiming.noSpeechDismissSeconds` in Core.
- State machine and UI timings now reference shared constants to avoid drift.
- Adds debug assertion guard for animation-vs-dismiss-window consistency.

3. **Menu bar resolver refactor**
- Moves from boolean-based dictation participation to explicit state preference:
  - `DictationFlowCoordinator.menuBarPreference: BreathWaveIcon.MenuBarState?`
  - mapping:
    - `.startingService`, `.recording`, `.pendingStop` -> `.recording`
    - `.processing` -> `.processing`
    - terminal/idle/checking/cancelCountdown -> `nil`
- `AppDelegate.resolveMenuBarState(...)` now resolves by priority:
  1. meeting recording
  2. dictation menu-bar preference
  3. file transcription processing
  4. idle
- This fixes lingering red dots during terminal dictation states and correctly shows orange during dictation processing.

4. **Focused tests added/updated**
- `AppDelegateMenuBarResolverTests`
- `DictationFlowCoordinatorTests`
- `DictationFlowStateMachineTests` updated for shared no-speech timing constant

## Key Files

- `Sources/MacParakeet/App/DictationFlowCoordinator.swift`
- `Sources/MacParakeet/AppDelegate.swift`
- `Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift`
- `Sources/MacParakeet/Views/Components/SacredGeometry.swift`
- `Sources/MacParakeet/Views/Components/NoSpeechAnimationTiming.swift`
- `Sources/MacParakeetCore/DictationFlow/DictationFlowTiming.swift`
- `Sources/MacParakeetCore/DictationFlow/DictationFlowStateMachine.swift`
- `Tests/MacParakeetTests/App/AppDelegateMenuBarResolverTests.swift`
- `Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorTests.swift`
- `Tests/MacParakeetTests/DictationFlow/DictationFlowStateMachineTests.swift`

## Validation

- `swift test --filter 'AppDelegateMenuBarResolverTests|DictationFlowCoordinatorTests|DictationFlowStateMachineTests'`
- `swift test`

Closes #88
