### PR TITLE
Add Vocabulary and AI Features sections to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,44 @@ swift run macparakeet-cli history
 | YouTube | yt-dlp |
 | Platform | macOS 14.2+, Apple Silicon |
 
+## Vocabulary
+
+The Vocabulary panel controls how dictated text is cleaned up before pasting. No AI involved — it's a fast, deterministic pipeline that runs in under 1ms.
+
+You choose between two **processing modes**:
+
+- **Raw** — Paste exactly what the speech engine produces, no changes
+- **Clean** (default) — Run the text through a multi-step pipeline before pasting
+
+**The Clean pipeline** applies these steps in order:
+
+1. **Filler removal** — Strips "um", "uh", and sentence-start fillers like "so", "well", "like"
+2. **Custom words** — Applies your word replacement rules (e.g., "aye pee eye" becomes "API", or "kubernetes" gets capitalized to "Kubernetes"). Case-insensitive, whole-word matching. Words can be toggled on/off without deleting.
+3. **Voice Return** — If you've defined a trigger phrase (e.g., "press return") and speak it at the end of a dictation, it's stripped from the output and a Return keypress is simulated after paste
+4. **Snippet expansion** — Replaces short trigger phrases with longer text (e.g., "my signature" expands to "Best regards, David"). Triggers are natural language phrases because that's what the speech engine outputs. Matched longest-first to prevent collisions.
+5. **Whitespace cleanup** — Collapses spaces, fixes punctuation spacing, capitalizes the first letter
+
+Every dictation stores both the raw and clean transcript so you can always see what changed.
+
+## AI Features
+
+AI features are entirely **opt-in** and separate from speech recognition — transcription is always local. The LLM only sees transcript text, never audio.
+
+**What it does:**
+
+- **Summarize** — After a transcription or meeting recording finishes, click Summarize and pick a prompt ("Meeting Notes", "Action Items", "Key Quotes", etc.) or write your own. The LLM processes the transcript and streams back a summary. You can generate multiple summaries per transcript, each in its own tab. Prompts marked as auto-run generate summaries automatically for new transcriptions.
+- **Chat** — Ask questions about a transcript in a multi-turn chat interface. The LLM answers based on the transcript content.
+
+**Supported providers:**
+
+| Type | Options |
+|------|---------|
+| Cloud | Anthropic (Claude), OpenAI, Google Gemini, OpenRouter |
+| Local | Ollama, LM Studio |
+| CLI | Claude Code, Codex (runs as subprocess) |
+
+**Setup:** In Settings > Intelligence, pick a provider, enter an API key (cloud) or confirm the local server is running, select a model, and hit Test Connection. Cloud providers store keys in the macOS Keychain. Local providers (Ollama, LM Studio, CLI) keep everything on-device.
+
 ## Privacy
 
 All speech recognition runs on the Neural Engine. Your audio never leaves your Mac.


### PR DESCRIPTION
## Summary
- Adds a **Vocabulary** section explaining the text processing pipeline (processing modes, filler removal, custom words, voice return, snippet expansion, whitespace cleanup)
- Adds an **AI Features** section explaining summarization, chat, supported providers, and setup flow
- Both sections placed above the existing Privacy section for natural reading order

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm no other files were changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added vocabulary documentation detailing paste-processing modes (Raw vs Clean) and the clean pipeline steps
  * Added AI features documentation clarifying that transcription remains local and AI is opt-in, with information on Summarize and Chat capabilities and configuration options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->