### PR TITLE
Fix transcribe screen getting stuck on completed transcript

### DIFF
--- a/Sources/MacParakeet/Views/MainWindowView.swift
+++ b/Sources/MacParakeet/Views/MainWindowView.swift
@@ -103,7 +103,7 @@ struct MainWindowView: View {
                             primaryActionTitle: "New Transcription",
                             onPrimaryAction: {
                                 transcriptionViewModel.showInputPortal()
-                                state.selectedItem = .transcribe
+                                state.navigateToTranscription(from: .library)
                             }
                         ) { transcription in
                             transcriptionViewModel.currentTranscription = transcription

--- a/Sources/MacParakeet/Views/MainWindowView.swift
+++ b/Sources/MacParakeet/Views/MainWindowView.swift
@@ -98,7 +98,14 @@ struct MainWindowView: View {
                             onNavigateBack: { state.navigateBack() }
                         )
                     case .library:
-                        TranscriptionLibraryView(viewModel: libraryViewModel) { transcription in
+                        TranscriptionLibraryView(
+                            viewModel: libraryViewModel,
+                            primaryActionTitle: "New Transcription",
+                            onPrimaryAction: {
+                                transcriptionViewModel.showInputPortal()
+                                state.selectedItem = .transcribe
+                            }
+                        ) { transcription in
                             transcriptionViewModel.currentTranscription = transcription
                             state.navigateToTranscription(from: .library)
                         }

--- a/Sources/MacParakeet/Views/Transcription/TranscribeView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscribeView.swift
@@ -56,8 +56,11 @@ struct TranscribeView: View {
                         promptResultsViewModel: promptResultsViewModel,
                         promptsViewModel: promptsViewModel,
                         onBack: {
-                            viewModel.currentTranscription = nil
+                            viewModel.showInputPortal()
                             onNavigateBack?()
+                        },
+                        onStartNew: {
+                            viewModel.showInputPortal()
                         },
                         onRetranscribe: { original in
                             viewModel.retranscribe(original)

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -20,6 +20,7 @@ struct TranscriptResultView: View {
     @Bindable var promptResultsViewModel: PromptResultsViewModel
     @Bindable var promptsViewModel: PromptsViewModel
     var onBack: (() -> Void)?
+    var onStartNew: (() -> Void)?
     var onRetranscribe: ((Transcription) -> Void)?
 
     @State private var backHovered = false
@@ -409,6 +410,16 @@ struct TranscriptResultView: View {
                 } message: {
                     Text("This replaces the transcript text in place. Existing prompt results and chats are preserved, but may no longer match the updated transcript.")
                 }
+            }
+
+            if let onStartNew {
+                Button {
+                    onStartNew()
+                } label: {
+                    Label("New Transcription", systemImage: "plus")
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(DesignSystem.Colors.accent)
             }
 
             Spacer()

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -418,7 +418,7 @@ struct TranscriptResultView: View {
                 } label: {
                     Label("New Transcription", systemImage: "plus")
                 }
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(.bordered)
                 .tint(DesignSystem.Colors.accent)
             }
 

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -394,6 +394,7 @@ public final class TranscriptionViewModel {
     public func showInputPortal() {
         currentTranscription = nil
         selectedTab = .transcript
+        errorMessage = nil
     }
 
     private func completeFailedTranscription(taskID: UUID, error: Error) {

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -391,6 +391,11 @@ public final class TranscriptionViewModel {
         promptResultsViewModel?.autoGeneratePromptResults(transcript: text, transcriptionId: transcription.id)
     }
 
+    public func showInputPortal() {
+        currentTranscription = nil
+        selectedTab = .transcript
+    }
+
     private func completeFailedTranscription(taskID: UUID, error: Error) {
         guard activeTranscriptionTaskID == taskID else { return }
         transcriptionTask = nil

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -507,6 +507,19 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.currentTranscription?.id, t1.id)
     }
 
+    func testShowInputPortalClearsCurrentTranscriptionAndResetsSelection() {
+        let t = Transcription(fileName: "test.mp3", rawTranscript: "Hello", status: .completed)
+        viewModel.currentTranscription = t
+        viewModel.selectedTab = .chat
+        viewModel.hasConversations = true
+
+        viewModel.showInputPortal()
+
+        XCTAssertNil(viewModel.currentTranscription)
+        XCTAssertEqual(viewModel.selectedTab, .transcript)
+        XCTAssertFalse(viewModel.hasConversations)
+    }
+
     // MARK: - File Drop
 
     func testHandleFileDropReturnsFalseWhenAlreadyTranscribing() {

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -512,12 +512,14 @@ final class TranscriptionViewModelTests: XCTestCase {
         viewModel.currentTranscription = t
         viewModel.selectedTab = .chat
         viewModel.hasConversations = true
+        viewModel.errorMessage = "Stale error"
 
         viewModel.showInputPortal()
 
         XCTAssertNil(viewModel.currentTranscription)
         XCTAssertEqual(viewModel.selectedTab, .transcript)
         XCTAssertFalse(viewModel.hasConversations)
+        XCTAssertNil(viewModel.errorMessage)
     }
 
     // MARK: - File Drop


### PR DESCRIPTION
## What changed
- added a shared `showInputPortal()` reset path in the transcription view model
- added a visible `New Transcription` action in the transcript result view
- added the same `New Transcription` entry point from the Library header
- updated the existing transcription view flow to use the shared reset path instead of relying on inline state clearing
- added a regression test that verifies returning to the input portal clears the current selection and resets the active tab

## Why
After the first successful transcription, the Transcribe tab kept rendering the last-opened transcript whenever `currentTranscription` was still set. In practice that made the feature feel stuck on history unless the user noticed the small back chevron in the result header.

## Impact
Users now have an explicit way to start another transcription from both the transcript result screen and the Library screen, so the upload portal remains discoverable after the first completed transcript.

## Validation
- `swift test --filter TranscriptionViewModelTests`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "New Transcription" action added to the library for quick session start.
  * "Start New" button added to transcription results to begin a fresh transcription.
  * Unified navigation flow so starting a new transcription presents the input portal from multiple entry points.

* **Tests**
  * Added test ensuring starting a new transcription clears current state and resets the transcript view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->