### PR TITLE
[codex] Fix NSHostingView overlay containers

### DIFF
--- a/Sources/MacParakeet/Views/Components/OverlayHostingContainerView.swift
+++ b/Sources/MacParakeet/Views/Components/OverlayHostingContainerView.swift
@@ -1,0 +1,29 @@
+import AppKit
+
+/// Hosts SwiftUI content and an AppKit overlay as siblings, which avoids
+/// mutating `NSHostingView`'s internal view hierarchy.
+final class OverlayHostingContainerView: NSView {
+    let hostingView: NSView
+    let overlayView: NSView
+
+    init(frame: NSRect, hostingView: NSView, overlayView: NSView) {
+        self.hostingView = hostingView
+        self.overlayView = overlayView
+        super.init(frame: frame)
+
+        autoresizesSubviews = true
+
+        hostingView.frame = bounds
+        hostingView.autoresizingMask = [.width, .height]
+        addSubview(hostingView)
+
+        overlayView.frame = bounds
+        overlayView.autoresizingMask = [.width, .height]
+        addSubview(overlayView)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Sources/MacParakeet/Views/Dictation/DictationOverlayController.swift
+++ b/Sources/MacParakeet/Views/Dictation/DictationOverlayController.swift
@@ -85,11 +85,9 @@ final class DictationOverlayController {
         panel.hasShadow = false // SwiftUI handles shadows; system shadow creates visible outline
         panel.level = .floating
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
-        panel.contentView = hosting
 
         // Mouse tracking overlay for hover tooltips
         let tracker = MouseTrackingView(frame: hosting.bounds)
-        tracker.autoresizingMask = [.width, .height]
         tracker.onEnter = { [weak self] in self?.overlayViewModel.isHovered = true }
         tracker.onExit = { [weak self] in
             self?.overlayViewModel.isHovered = false
@@ -98,7 +96,12 @@ final class DictationOverlayController {
         tracker.onMoved = { [weak self] point in
             self?.updateHoverTooltip(at: point, in: hosting.bounds)
         }
-        hosting.addSubview(tracker)
+        let contentView = OverlayHostingContainerView(
+            frame: NSRect(x: 0, y: 0, width: panelWidth, height: panelHeight),
+            hostingView: hosting,
+            overlayView: tracker
+        )
+        panel.contentView = contentView
         trackingView = tracker
 
         // Position at bottom-center, just above the Dock

--- a/Sources/MacParakeet/Views/Dictation/IdlePillController.swift
+++ b/Sources/MacParakeet/Views/Dictation/IdlePillController.swift
@@ -112,11 +112,9 @@ final class IdlePillController {
         panel.hasShadow = false
         panel.level = .floating
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
-        panel.contentView = hosting
 
         // Mouse tracking overlay for hover + click
         let tracker = IdlePillTrackingView(frame: hosting.bounds)
-        tracker.autoresizingMask = [.width, .height]
         tracker.onEnter = { [weak self] in
             Task { @MainActor in self?.viewModel.isHovered = true }
         }
@@ -139,7 +137,12 @@ final class IdlePillController {
         let expandedX = (panelWidth - expandedW) / 2
         tracker.expandedPillRect = NSRect(x: expandedX, y: 0, width: expandedW, height: expandedH)
 
-        hosting.addSubview(tracker)
+        let contentView = OverlayHostingContainerView(
+            frame: NSRect(x: 0, y: 0, width: panelWidth, height: panelHeight),
+            hostingView: hosting,
+            overlayView: tracker
+        )
+        panel.contentView = contentView
         trackingView = tracker
 
         // Position at bottom-center, just above the Dock

--- a/Tests/MacParakeetTests/Views/OverlayHostingContainerViewTests.swift
+++ b/Tests/MacParakeetTests/Views/OverlayHostingContainerViewTests.swift
@@ -1,0 +1,37 @@
+import AppKit
+import XCTest
+@testable import MacParakeet
+
+@MainActor
+final class OverlayHostingContainerViewTests: XCTestCase {
+    func testOverlayIsAddedAsSiblingAboveHostingView() {
+        let hostingView = NSView()
+        let overlayView = NSView()
+
+        let container = OverlayHostingContainerView(
+            frame: NSRect(x: 0, y: 0, width: 300, height: 160),
+            hostingView: hostingView,
+            overlayView: overlayView
+        )
+
+        XCTAssertEqual(container.subviews.count, 2)
+        XCTAssertTrue(container.subviews[0] === hostingView)
+        XCTAssertTrue(container.subviews[1] === overlayView)
+    }
+
+    func testHostingAndOverlayFillContainerBounds() {
+        let hostingView = NSView()
+        let overlayView = NSView()
+
+        let container = OverlayHostingContainerView(
+            frame: NSRect(x: 0, y: 0, width: 350, height: 90),
+            hostingView: hostingView,
+            overlayView: overlayView
+        )
+
+        XCTAssertEqual(hostingView.frame, container.bounds)
+        XCTAssertEqual(overlayView.frame, container.bounds)
+        XCTAssertEqual(hostingView.autoresizingMask, [.width, .height])
+        XCTAssertEqual(overlayView.autoresizingMask, [.width, .height])
+    }
+}


### PR DESCRIPTION
## Summary
- add an `OverlayHostingContainerView` so AppKit tracking overlays live beside `NSHostingView` content instead of inside it
- update the dictation overlay and idle pill panels to use the shared container
- add regression coverage for the hosting/overlay hierarchy and sizing contract

## Root Cause
Both `DictationOverlayController` and `IdlePillController` were calling `hosting.addSubview(tracker)` on an `NSHostingView`.

SwiftUI explicitly rejects that pattern at runtime because it mutates the hosting view's internal hierarchy. In practice this produced repeated `broken view hierarchy` faults during dictation and idle-pill presentation, which matches the stuck menu-bar/UI state seen in the field.

## Impact
- removes the unsupported `NSHostingView` mutation
- keeps hover and click tracking behavior intact
- reduces the chance of the menu-bar companion or dictation surfaces getting stuck in a corrupted UI state

## Validation
- `swift test --filter OverlayHostingContainerViewTests`
