### PR TITLE
[codex] Add OpenAI-compatible AI provider option

### DIFF
--- a/Sources/CLI/Commands/LLMInlineConfig.swift
+++ b/Sources/CLI/Commands/LLMInlineConfig.swift
@@ -95,13 +95,12 @@ struct LLMInlineOptions: ParsableArguments {
             guard let key = apiKey else { throw ValidationError("--api-key is required for OpenAI") }
             providerConfig = .openai(apiKey: key, model: model ?? "gpt-4.1", baseURL: overrideURL)
         case .openaiCompatible:
-            guard let key = apiKey else { throw ValidationError("--api-key is required for OpenAI-Compatible") }
             guard let overrideURL else { throw ValidationError("--base-url is required for OpenAI-Compatible") }
             guard let model, !model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
                 throw ValidationError("--model is required for OpenAI-Compatible")
             }
             providerConfig = .openaiCompatible(
-                apiKey: key,
+                apiKey: apiKey?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty,
                 model: model.trimmingCharacters(in: .whitespacesAndNewlines),
                 baseURL: overrideURL
             )
@@ -141,5 +140,11 @@ struct LLMInlineOptions: ParsableArguments {
 
     func buildConfig() throws -> LLMProviderConfig {
         try buildExecutionContext().context.providerConfig
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
     }
 }

--- a/Sources/CLI/Commands/LLMInlineConfig.swift
+++ b/Sources/CLI/Commands/LLMInlineConfig.swift
@@ -36,7 +36,7 @@ func readInput(_ path: String) throws -> String {
 
 /// Shared options for CLI commands that call an LLM provider directly (no Keychain).
 struct LLMInlineOptions: ParsableArguments {
-    @Option(name: .long, help: "Provider: anthropic, openai, gemini, openrouter, ollama, lmstudio, cli.")
+    @Option(name: .long, help: "Provider: anthropic, openai, openaiCompatible, gemini, openrouter, ollama, lmstudio, cli.")
     var provider: String
 
     @Option(name: .long, help: "API key.")
@@ -55,10 +55,20 @@ struct LLMInlineOptions: ParsableArguments {
     var local: Bool = false
 
     private func providerID() throws -> LLMProviderID {
-        // Accept "cli" as a short alias for "localCLI"
-        let normalized = provider == "cli" ? "localCLI" : provider
+        // Accept simple aliases for provider names used in docs and terminals.
+        let normalized: String
+        switch provider.lowercased() {
+        case "cli":
+            normalized = "localCLI"
+        case "openaicompatible", "openai-compatible":
+            normalized = "openaiCompatible"
+        default:
+            normalized = provider
+        }
         guard let providerID = LLMProviderID(rawValue: normalized) else {
-            throw ValidationError("Unknown provider '\(provider)'. Options: anthropic, openai, gemini, openrouter, ollama, lmstudio, cli")
+            throw ValidationError(
+                "Unknown provider '\(provider)'. Options: anthropic, openai, openaiCompatible, gemini, openrouter, ollama, lmstudio, cli"
+            )
         }
         return providerID
     }
@@ -84,6 +94,17 @@ struct LLMInlineOptions: ParsableArguments {
         case .openai:
             guard let key = apiKey else { throw ValidationError("--api-key is required for OpenAI") }
             providerConfig = .openai(apiKey: key, model: model ?? "gpt-4.1", baseURL: overrideURL)
+        case .openaiCompatible:
+            guard let key = apiKey else { throw ValidationError("--api-key is required for OpenAI-Compatible") }
+            guard let overrideURL else { throw ValidationError("--base-url is required for OpenAI-Compatible") }
+            guard let model, !model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw ValidationError("--model is required for OpenAI-Compatible")
+            }
+            providerConfig = .openaiCompatible(
+                apiKey: key,
+                model: model.trimmingCharacters(in: .whitespacesAndNewlines),
+                baseURL: overrideURL
+            )
         case .gemini:
             guard let key = apiKey else { throw ValidationError("--api-key is required for Gemini") }
             providerConfig = .gemini(apiKey: key, model: model ?? "gemini-2.5-flash", baseURL: overrideURL)

--- a/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
@@ -34,12 +34,16 @@ struct LLMSettingsView: View {
                 Divider()
 
                 // API key (hidden for local providers)
-                if viewModel.requiresAPIKey {
+                if viewModel.supportsAPIKey {
                     HStack(alignment: .top) {
                         VStack(alignment: .leading, spacing: 2) {
                             Text("API Key")
                                 .font(DesignSystem.Typography.body)
-                            Text("Your key is stored securely in the macOS Keychain.")
+                            Text(
+                                viewModel.requiresAPIKey
+                                    ? "Your key is stored securely in the macOS Keychain."
+                                    : "Optional. Leave blank for servers that do not require authentication."
+                            )
                                 .font(DesignSystem.Typography.caption)
                                 .foregroundStyle(.secondary)
                         }

--- a/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
@@ -27,7 +27,7 @@ struct LLMSettingsView: View {
                 }
                 .labelsHidden()
                 .pickerStyle(.menu)
-                .frame(width: 160)
+                .frame(width: 190)
             }
 
             if viewModel.selectedProviderID != nil {
@@ -55,6 +55,24 @@ struct LLMSettingsView: View {
                 if viewModel.selectedProviderID == .localCLI {
                     cliSettingsSection
                 } else {
+                    if viewModel.selectedProviderID?.requiresCustomEndpoint == true {
+                        HStack(alignment: .top) {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("Custom Endpoint")
+                                    .font(DesignSystem.Typography.body)
+                                Text("OpenAI-compatible base URL, for example https://api.example.com/v1.")
+                                    .font(DesignSystem.Typography.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer(minLength: DesignSystem.Spacing.md)
+                            TextField("https://api.example.com/v1", text: $viewModel.baseURLOverride)
+                                .textFieldStyle(.roundedBorder)
+                                .frame(width: 220)
+                        }
+
+                        Divider()
+                    }
+
                     // Model name
                     HStack(alignment: .top) {
                         VStack(alignment: .leading, spacing: 2) {
@@ -69,23 +87,25 @@ struct LLMSettingsView: View {
                     }
 
                     // Advanced: Base URL override
-                    DisclosureGroup("Advanced", isExpanded: $showAdvanced) {
-                        HStack(alignment: .top) {
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text("Base URL")
-                                    .font(DesignSystem.Typography.body)
-                                Text("Override the default API endpoint.")
-                                    .font(DesignSystem.Typography.caption)
-                                    .foregroundStyle(.secondary)
+                    if viewModel.selectedProviderID?.requiresCustomEndpoint != true {
+                        DisclosureGroup("Advanced", isExpanded: $showAdvanced) {
+                            HStack(alignment: .top) {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text("Base URL")
+                                        .font(DesignSystem.Typography.body)
+                                    Text("Override the default API endpoint.")
+                                        .font(DesignSystem.Typography.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                                Spacer(minLength: DesignSystem.Spacing.md)
+                                TextField("https://...", text: $viewModel.baseURLOverride)
+                                    .textFieldStyle(.roundedBorder)
+                                    .frame(width: 220)
                             }
-                            Spacer(minLength: DesignSystem.Spacing.md)
-                            TextField("https://...", text: $viewModel.baseURLOverride)
-                                .textFieldStyle(.roundedBorder)
-                                .frame(width: 220)
+                            .padding(.top, DesignSystem.Spacing.sm)
                         }
-                        .padding(.top, DesignSystem.Spacing.sm)
+                        .font(DesignSystem.Typography.caption)
                     }
-                    .font(DesignSystem.Typography.caption)
                 }
 
                 Divider()

--- a/Sources/MacParakeetCore/Models/LLMProvider.swift
+++ b/Sources/MacParakeetCore/Models/LLMProvider.swift
@@ -34,11 +34,19 @@ public enum LLMProviderID: String, Codable, Sendable, CaseIterable {
         }
     }
 
-    /// Whether the provider needs an API key to function.
-    public var requiresAPIKey: Bool {
+    /// Whether the provider supports API-key-based auth.
+    public var supportsAPIKey: Bool {
         switch self {
         case .ollama, .lmstudio, .localCLI: return false
         case .anthropic, .openai, .openaiCompatible, .gemini, .openrouter: return true
+        }
+    }
+
+    /// Whether the provider needs an API key to function.
+    public var requiresAPIKey: Bool {
+        switch self {
+        case .openaiCompatible, .ollama, .lmstudio, .localCLI: return false
+        case .anthropic, .openai, .gemini, .openrouter: return true
         }
     }
 
@@ -106,7 +114,7 @@ public struct LLMProviderConfig: Codable, Sendable, Equatable {
     }
 
     public static func openaiCompatible(
-        apiKey: String,
+        apiKey: String? = nil,
         model: String,
         baseURL: URL
     ) -> LLMProviderConfig {

--- a/Sources/MacParakeetCore/Models/LLMProvider.swift
+++ b/Sources/MacParakeetCore/Models/LLMProvider.swift
@@ -5,6 +5,7 @@ import Foundation
 public enum LLMProviderID: String, Codable, Sendable, CaseIterable {
     case anthropic
     case openai
+    case openaiCompatible
     case gemini
     case openrouter
     case ollama
@@ -15,6 +16,7 @@ public enum LLMProviderID: String, Codable, Sendable, CaseIterable {
         switch self {
         case .anthropic: return "Anthropic"
         case .openai: return "OpenAI"
+        case .openaiCompatible: return "OpenAI-Compatible"
         case .gemini: return "Google Gemini"
         case .openrouter: return "OpenRouter"
         case .ollama: return "Ollama"
@@ -28,7 +30,7 @@ public enum LLMProviderID: String, Codable, Sendable, CaseIterable {
     public var isLocal: Bool {
         switch self {
         case .ollama, .lmstudio: return true
-        case .anthropic, .openai, .gemini, .openrouter, .localCLI: return false
+        case .anthropic, .openai, .openaiCompatible, .gemini, .openrouter, .localCLI: return false
         }
     }
 
@@ -36,7 +38,15 @@ public enum LLMProviderID: String, Codable, Sendable, CaseIterable {
     public var requiresAPIKey: Bool {
         switch self {
         case .ollama, .lmstudio, .localCLI: return false
-        case .anthropic, .openai, .gemini, .openrouter: return true
+        case .anthropic, .openai, .openaiCompatible, .gemini, .openrouter: return true
+        }
+    }
+
+    /// Whether the provider must be configured with a user-supplied endpoint.
+    public var requiresCustomEndpoint: Bool {
+        switch self {
+        case .openaiCompatible: return true
+        case .anthropic, .openai, .gemini, .openrouter, .ollama, .lmstudio, .localCLI: return false
         }
     }
 
@@ -89,6 +99,20 @@ public struct LLMProviderConfig: Codable, Sendable, Equatable {
         LLMProviderConfig(
             id: .openai,
             baseURL: baseURL ?? URL(string: "https://api.openai.com/v1")!,
+            apiKey: apiKey,
+            modelName: model,
+            isLocal: false
+        )
+    }
+
+    public static func openaiCompatible(
+        apiKey: String,
+        model: String,
+        baseURL: URL
+    ) -> LLMProviderConfig {
+        LLMProviderConfig(
+            id: .openaiCompatible,
+            baseURL: baseURL,
             apiKey: apiKey,
             modelName: model,
             isLocal: false

--- a/Sources/MacParakeetViewModels/LLMSettingsDraft.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsDraft.swift
@@ -113,6 +113,9 @@ public struct LLMSettingsDraft: Equatable, Sendable {
                     && suggestedModelName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             return .missingModelSelection
         }
+        if providerID.requiresCustomEndpoint && trimmedBaseURLOverride.isEmpty {
+            return .invalidBaseURL
+        }
         if !trimmedBaseURLOverride.isEmpty {
             guard let overrideURL = URL(string: trimmedBaseURLOverride),
                   Self.isAllowedBaseURLOverride(overrideURL) else {

--- a/Sources/MacParakeetViewModels/LLMSettingsDraft.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsDraft.swift
@@ -69,6 +69,10 @@ public struct LLMSettingsDraft: Equatable, Sendable {
         providerID?.requiresAPIKey ?? false
     }
 
+    public var supportsAPIKey: Bool {
+        providerID?.supportsAPIKey ?? false
+    }
+
     public var trimmedAPIKey: String {
         apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
     }
@@ -177,7 +181,7 @@ public struct LLMSettingsDraft: Equatable, Sendable {
         let selectedCLITemplate = cliConfig.map { LocalCLITemplate.inferredTemplate(for: $0.commandTemplate) } ?? nil
         return LLMSettingsDraft(
             providerID: providerID,
-            apiKeyInput: providerID?.requiresAPIKey == true ? apiKey : "",
+            apiKeyInput: providerID?.supportsAPIKey == true ? apiKey : "",
             suggestedModelName: defaultModelName,
             useCustomModel: false,
             customModelName: "",

--- a/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
@@ -88,6 +88,10 @@ public final class LLMSettingsViewModel {
         draft.requiresAPIKey
     }
 
+    public var supportsAPIKey: Bool {
+        draft.supportsAPIKey
+    }
+
     public var availableModels: [String] {
         guard let providerID = draft.providerID else { return [] }
         if providerID == .lmstudio {
@@ -334,7 +338,7 @@ public final class LLMSettingsViewModel {
         }
         let currentProvider = draft.providerID
         let apiKey: String
-        if let currentProvider, currentProvider.requiresAPIKey {
+        if let currentProvider, currentProvider.supportsAPIKey {
             apiKey = (try? configStore.loadAPIKey(for: currentProvider)) ?? ""
         } else {
             apiKey = ""
@@ -422,7 +426,7 @@ public final class LLMSettingsViewModel {
         if providerID != .lmstudio {
             resetDiscoveredModels()
         }
-        let apiKey = providerID.requiresAPIKey ? ((try? configStore?.loadAPIKey(for: providerID)) ?? "") : ""
+        let apiKey = providerID.supportsAPIKey ? ((try? configStore?.loadAPIKey(for: providerID)) ?? "") : ""
         let cliConfig = providerID == .localCLI ? cliConfigStore?.load() : nil
         var nextDraft = LLMSettingsDraft.defaults(
             for: providerID,

--- a/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
@@ -579,6 +579,7 @@ public final class LLMSettingsViewModel {
             "gpt-4.1",
             "gpt-4.1-mini",
         ]
+        case .openaiCompatible: return []
         case .gemini: return [
             "gemini-3.1-pro-preview",
             "gemini-3-flash-preview",
@@ -625,6 +626,7 @@ public final class LLMSettingsViewModel {
         switch provider {
         case .anthropic: return "https://api.anthropic.com/v1"
         case .openai: return "https://api.openai.com/v1"
+        case .openaiCompatible: return ""
         case .gemini: return "https://generativelanguage.googleapis.com/v1beta/openai"
         case .openrouter: return "https://openrouter.ai/api/v1"
         case .ollama: return "http://localhost:11434/v1"

--- a/Tests/CLITests/LLMConfigCommandTests.swift
+++ b/Tests/CLITests/LLMConfigCommandTests.swift
@@ -44,6 +44,21 @@ final class LLMConfigCommandTests: XCTestCase {
         XCTAssertEqual(config.baseURL.absoluteString, "http://127.0.0.1:11435/v1")
     }
 
+    func testInlineOptionsBuildOpenAICompatibleConfig() throws {
+        let options = try LLMInlineOptions.parse([
+            "--provider", "openai-compatible",
+            "--api-key", "sk-third-party",
+            "--base-url", "https://api.example.com/v1",
+            "--model", "vendor/model"
+        ])
+
+        let config = try options.buildConfig()
+        XCTAssertEqual(config.id, .openaiCompatible)
+        XCTAssertEqual(config.apiKey, "sk-third-party")
+        XCTAssertEqual(config.baseURL.absoluteString, "https://api.example.com/v1")
+        XCTAssertEqual(config.modelName, "vendor/model")
+    }
+
     func testLocalCLIExecutionContextRoutesThroughCLIClient() async throws {
         let options = try LLMInlineOptions.parse([
             "--provider", "cli",

--- a/Tests/CLITests/LLMConfigCommandTests.swift
+++ b/Tests/CLITests/LLMConfigCommandTests.swift
@@ -59,6 +59,18 @@ final class LLMConfigCommandTests: XCTestCase {
         XCTAssertEqual(config.modelName, "vendor/model")
     }
 
+    func testInlineOptionsBuildOpenAICompatibleConfigWithoutAPIKey() throws {
+        let options = try LLMInlineOptions.parse([
+            "--provider", "openai-compatible",
+            "--base-url", "https://api.example.com/v1",
+            "--model", "vendor/model"
+        ])
+
+        let config = try options.buildConfig()
+        XCTAssertEqual(config.id, .openaiCompatible)
+        XCTAssertNil(config.apiKey)
+    }
+
     func testLocalCLIExecutionContextRoutesThroughCLIClient() async throws {
         let options = try LLMInlineOptions.parse([
             "--provider", "cli",

--- a/Tests/MacParakeetTests/Services/LLMClientTests.swift
+++ b/Tests/MacParakeetTests/Services/LLMClientTests.swift
@@ -207,7 +207,7 @@ final class LLMClientTests: XCTestCase {
         }
 
         let config = LLMProviderConfig(
-            id: .openai,
+            id: .openaiCompatible,
             baseURL: URL(string: "http://localhost:8080/v1")!,
             apiKey: nil,
             modelName: "test-model",
@@ -691,6 +691,32 @@ final class LLMClientTests: XCTestCase {
         }
 
         let config = LLMProviderConfig.openai(apiKey: "sk-test", model: "gpt-4o")
+        _ = try await llmClient.chatCompletion(
+            messages: [ChatMessage(role: .user, content: "Hi")],
+            config: config,
+            options: ChatCompletionOptions(temperature: 0.7, maxTokens: 500)
+        )
+
+        XCTAssertEqual(capturedBody?["max_tokens"] as? Int, 500)
+        XCTAssertNil(capturedBody?["max_completion_tokens"])
+        XCTAssertEqual(capturedBody?["temperature"] as? Double, 0.7)
+    }
+
+    func testOpenAICompatibleProviderDoesNotApplyOpenAISpecificTokenParameters() async throws {
+        var capturedBody: [String: Any]?
+
+        MockURLProtocol.handler = { request in
+            if let body = self.extractBody(from: request) {
+                capturedBody = body
+            }
+            return (self.okResponse(for: request), self.validResponseData())
+        }
+
+        let config = LLMProviderConfig.openaiCompatible(
+            apiKey: "sk-test",
+            model: "gpt-5.2",
+            baseURL: URL(string: "https://api.example.com/v1")!
+        )
         _ = try await llmClient.chatCompletion(
             messages: [ChatMessage(role: .user, content: "Hi")],
             config: config,

--- a/Tests/MacParakeetTests/ViewModels/LLMSettingsDraftTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LLMSettingsDraftTests.swift
@@ -64,7 +64,6 @@ final class LLMSettingsDraftTests: XCTestCase {
     func testOpenAICompatibleProviderRequiresCustomEndpoint() {
         let draft = LLMSettingsDraft(
             providerID: .openaiCompatible,
-            apiKeyInput: "test-key",
             useCustomModel: true,
             customModelName: "third-party-model"
         )

--- a/Tests/MacParakeetTests/ViewModels/LLMSettingsDraftTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LLMSettingsDraftTests.swift
@@ -60,4 +60,15 @@ final class LLMSettingsDraftTests: XCTestCase {
         XCTAssertEqual(config?.id, .lmstudio)
         XCTAssertEqual(config?.modelName, "")
     }
+
+    func testOpenAICompatibleProviderRequiresCustomEndpoint() {
+        let draft = LLMSettingsDraft(
+            providerID: .openaiCompatible,
+            apiKeyInput: "test-key",
+            useCustomModel: true,
+            customModelName: "third-party-model"
+        )
+
+        XCTAssertEqual(draft.validationError, .invalidBaseURL)
+    }
 }

--- a/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
@@ -75,6 +75,15 @@ final class LLMSettingsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.requiresAPIKey)
     }
 
+    func testOpenAICompatibleProviderStartsInCustomModelMode() {
+        viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
+        viewModel.selectedProviderID = .openaiCompatible
+
+        XCTAssertTrue(viewModel.requiresAPIKey)
+        XCTAssertTrue(viewModel.useCustomModel)
+        XCTAssertTrue(viewModel.availableModels.isEmpty)
+    }
+
     // MARK: - Save
 
     func testSavePersistsToStore() {
@@ -103,6 +112,20 @@ final class LLMSettingsViewModelTests: XCTestCase {
 
         let saved = mockConfigStore.config
         XCTAssertEqual(saved?.baseURL.absoluteString, "https://my-server.com/v1")
+    }
+
+    func testOpenAICompatibleProviderRequiresEndpointBeforeSave() {
+        viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
+        viewModel.selectedProviderID = .openaiCompatible
+        viewModel.apiKeyInput = "sk-third-party"
+        viewModel.customModelName = "third-party-model"
+
+        XCTAssertFalse(viewModel.canSave)
+        XCTAssertEqual(viewModel.validationMessage, "Enter a valid HTTPS base URL, or use localhost for local servers.")
+
+        viewModel.baseURLOverride = "https://api.example.com/v1"
+
+        XCTAssertTrue(viewModel.canSave)
     }
 
     // MARK: - Load Existing
@@ -742,5 +765,21 @@ final class LLMSettingsViewModelTests: XCTestCase {
         viewModel.selectedProviderID = .openai
         XCTAssertTrue(viewModel.requiresAPIKey)
         XCTAssertFalse(viewModel.availableModels.isEmpty)
+    }
+
+    func testSaveOpenAICompatibleProviderPersistsCustomEndpoint() {
+        viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
+        viewModel.selectedProviderID = .openaiCompatible
+        viewModel.apiKeyInput = "sk-third-party"
+        viewModel.customModelName = "vendor/model"
+        viewModel.baseURLOverride = "https://api.example.com/v1"
+
+        viewModel.saveConfiguration()
+
+        let saved = mockConfigStore.config
+        XCTAssertEqual(saved?.id, .openaiCompatible)
+        XCTAssertEqual(saved?.apiKey, "sk-third-party")
+        XCTAssertEqual(saved?.modelName, "vendor/model")
+        XCTAssertEqual(saved?.baseURL.absoluteString, "https://api.example.com/v1")
     }
 }

--- a/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
@@ -79,7 +79,8 @@ final class LLMSettingsViewModelTests: XCTestCase {
         viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
         viewModel.selectedProviderID = .openaiCompatible
 
-        XCTAssertTrue(viewModel.requiresAPIKey)
+        XCTAssertFalse(viewModel.requiresAPIKey)
+        XCTAssertTrue(viewModel.supportsAPIKey)
         XCTAssertTrue(viewModel.useCustomModel)
         XCTAssertTrue(viewModel.availableModels.isEmpty)
     }
@@ -117,7 +118,6 @@ final class LLMSettingsViewModelTests: XCTestCase {
     func testOpenAICompatibleProviderRequiresEndpointBeforeSave() {
         viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
         viewModel.selectedProviderID = .openaiCompatible
-        viewModel.apiKeyInput = "sk-third-party"
         viewModel.customModelName = "third-party-model"
 
         XCTAssertFalse(viewModel.canSave)
@@ -781,5 +781,18 @@ final class LLMSettingsViewModelTests: XCTestCase {
         XCTAssertEqual(saved?.apiKey, "sk-third-party")
         XCTAssertEqual(saved?.modelName, "vendor/model")
         XCTAssertEqual(saved?.baseURL.absoluteString, "https://api.example.com/v1")
+    }
+
+    func testSaveOpenAICompatibleProviderAllowsEmptyAPIKey() {
+        viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
+        viewModel.selectedProviderID = .openaiCompatible
+        viewModel.customModelName = "vendor/model"
+        viewModel.baseURLOverride = "https://api.example.com/v1"
+
+        viewModel.saveConfiguration()
+
+        let saved = mockConfigStore.config
+        XCTAssertEqual(saved?.id, .openaiCompatible)
+        XCTAssertNil(saved?.apiKey)
     }
 }


### PR DESCRIPTION
## What changed

This adds a dedicated `OpenAI-Compatible` option under AI Provider so users can connect third-party services that expose an OpenAI-like API surface.

The new provider path lets the user configure:

- a custom endpoint
- an optional API key
- a model name

It also keeps this provider separate from the built-in OpenAI option, so we can preserve OpenAI-specific defaults and request quirks for the real OpenAI API without applying them to third-party endpoints.

## Why this changed

Before this change, users could only approximate this setup by reusing another provider path or overriding the OpenAI base URL. That mixed together provider-specific defaults, key storage, model suggestions, and request-shaping behavior.

The main gap was that we did not have a clean bring-your-own OpenAI-compatible provider path for services that follow the same API structure but are not actually OpenAI.

This update also keeps the API key optional for local and self-hosted compatibility layers such as vLLM, LocalAI, and Ollama-compatible servers that do not require authentication by default.

## User impact

Users can now select `OpenAI-Compatible` in Settings and manually provide:

- `Custom Endpoint`
- `API Key` when their server requires it
- `Model`

This makes it possible to use hosted third-party providers and local OpenAI-compatible servers without pretending to be the built-in OpenAI provider.

## Validation

- `swift test --filter LLMSettingsDraftTests`
- `swift test --filter LLMSettingsViewModelTests`
- `swift test --filter LLMClientTests`
- `swift test --filter LLMConfigCommandTests`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OpenAI-compatible provider support to CLI and settings, enabling integration with compatible APIs using custom endpoint configuration
  * Implemented optional API key handling for compatible providers
  * Enhanced settings UI with new custom endpoint input field and improved API key messaging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->