### PR TITLE
fix: eliminate idle CPU/GPU waste from perpetual SwiftUI animations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ All ADRs are in `spec/adr/`. These are locked decisions -- don't second-guess th
 
 ## Current Phase
 
-**v0.6 In Progress** -- ~198 source files, ~101 test files, 1352 tests passing (`swift test` green as of 2026-04-10)
+**v0.6 In Progress** -- ~222 source files, ~110 test files, 1414 tests passing (1401 XCTest + 13 Swift Testing, as of 2026-04-15)
 
 - **v0.1** MVP -- System-wide dictation, file transcription, overlay, history, export, SQLite, CLI, STT engine
 - **v0.2** Clean Pipeline -- Text processing (filler removal, custom words, snippets), Vocabulary UI, feedback form

--- a/Sources/MacParakeet/Views/Components/AIStreamingIndicator.swift
+++ b/Sources/MacParakeet/Views/Components/AIStreamingIndicator.swift
@@ -2,25 +2,32 @@ import SwiftUI
 
 /// A sentient streaming indicator — three orbs that breathe with overlapping
 /// phases, each with a soft glow halo. Slow, organic, alive.
+///
+/// Uses SwiftUI animations instead of a 30fps TimelineView — the 1.3Hz sine
+/// wave only needs ~2 animation interpolations, not 30 redraws per second.
 struct AIStreamingIndicator: View {
-    var body: some View {
-        TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { context in
-            let t = context.date.timeIntervalSinceReferenceDate
-            HStack(spacing: 14) {
-                ForEach(0..<3, id: \.self) { i in
-                    let phase = sin(t * 1.3 + Double(i) * 0.85)
-                    let intensity = 0.3 + 0.7 * ((phase + 1) / 2)
-                    let scale = 0.75 + 0.25 * ((phase + 1) / 2)
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var breathing = false
 
-                    Circle()
-                        .fill(DesignSystem.Colors.accent)
-                        .frame(width: 5, height: 5)
-                        .scaleEffect(scale)
-                        .opacity(intensity)
-                        .shadow(color: DesignSystem.Colors.accent.opacity(intensity * 0.4), radius: 4)
-                }
+    var body: some View {
+        HStack(spacing: 14) {
+            ForEach(0..<3, id: \.self) { i in
+                Circle()
+                    .fill(DesignSystem.Colors.accent)
+                    .frame(width: 5, height: 5)
+                    .scaleEffect(breathing ? 1.0 : 0.75)
+                    .opacity(breathing ? 1.0 : 0.3)
+                    .shadow(color: DesignSystem.Colors.accent.opacity(breathing ? 0.4 : 0.12), radius: 4)
+                    .animation(
+                        reduceMotion ? nil : .easeInOut(duration: 1.0 / 1.3)
+                            .repeatForever(autoreverses: true)
+                            .delay(Double(i) * 0.10),
+                        value: breathing
+                    )
             }
         }
+        .onAppear { breathing = true }
+        .onDisappear { breathing = false }
     }
 }
 

--- a/Sources/MacParakeet/Views/Components/SacredGeometry.swift
+++ b/Sources/MacParakeet/Views/Components/SacredGeometry.swift
@@ -304,6 +304,8 @@ struct MeditativeMerkabaView: View {
     var tintColor: Color? = nil
     var animate: Bool = true
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     @State private var rotationCW: Double = 0
     @State private var rotationCCW: Double = 60
     @State private var centerPulse: Double = 0.15
@@ -311,6 +313,7 @@ struct MeditativeMerkabaView: View {
 
     private var effectiveColor: Color { tintColor ?? .primary }
     private var radius: CGFloat { size * 0.4 }
+    private var shouldAnimate: Bool { animate && !reduceMotion }
 
     var body: some View {
         ZStack {
@@ -334,11 +337,11 @@ struct MeditativeMerkabaView: View {
         .frame(width: size, height: size)
         .drawingGroup()
         .onAppear {
-            if animate {
+            if shouldAnimate {
                 startAnimation()
             }
         }
-        .onChange(of: animate) { _, newValue in
+        .onChange(of: shouldAnimate) { _, newValue in
             if newValue {
                 startAnimation()
             } else {

--- a/Sources/MacParakeet/Views/History/DictationHistoryView.swift
+++ b/Sources/MacParakeet/Views/History/DictationHistoryView.swift
@@ -243,7 +243,7 @@ struct DictationHistoryView: View {
         VStack(spacing: DesignSystem.Spacing.lg) {
             Spacer()
 
-            MeditativeMerkabaView(size: 72, revolutionDuration: 8.0, tintColor: DesignSystem.Colors.accent)
+            MeditativeMerkabaView(size: 72, revolutionDuration: 8.0, tintColor: DesignSystem.Colors.accent, animate: false)
                 .opacity(0.4)
 
             VStack(spacing: DesignSystem.Spacing.sm) {

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelView.swift
@@ -172,7 +172,7 @@ struct BreathingSeedOfLifeView: View {
             Circle()
                 .fill(strokeColor.opacity(glowBreathing ? 0.5 : 0.2))
                 .frame(width: circleRadius * 2, height: circleRadius * 2)
-                .blur(radius: 8)
+                .shadow(color: strokeColor.opacity(glowBreathing ? 0.4 : 0.15), radius: 12)
                 .scaleEffect(glowBreathing ? 1.2 : 0.9)
 
             // Center circle

--- a/Sources/MacParakeet/Views/Transcription/PortalDropZone.swift
+++ b/Sources/MacParakeet/Views/Transcription/PortalDropZone.swift
@@ -40,7 +40,8 @@ struct PortalDropZone: View {
                     MeditativeMerkabaView(
                         size: 80,
                         revolutionDuration: isDragging ? 3.0 : 6.0,
-                        tintColor: DesignSystem.Colors.accent
+                        tintColor: DesignSystem.Colors.accent,
+                        animate: isDragging
                     )
                     .opacity(isDragging ? 0.9 : 0.7)
                     .animation(.easeInOut(duration: 0.3), value: isDragging)

--- a/Sources/MacParakeet/Views/Transcription/PromptLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/PromptLibraryView.swift
@@ -316,7 +316,7 @@ struct PromptLibraryView: View {
 
     private var emptyStateView: some View {
         VStack(spacing: DesignSystem.Spacing.md) {
-            MeditativeMerkabaView(size: 40, revolutionDuration: 12.0, tintColor: DesignSystem.Colors.accent)
+            MeditativeMerkabaView(size: 40, revolutionDuration: 12.0, tintColor: DesignSystem.Colors.accent, animate: false)
             Text("No custom prompts yet")
                 .font(DesignSystem.Typography.bodyLarge.weight(.medium))
                 .foregroundStyle(DesignSystem.Colors.textPrimary)

--- a/docs/blog/using-all-three-chips.md
+++ b/docs/blog/using-all-three-chips.md
@@ -1,6 +1,6 @@
 # Using All Three Chips: How We Rebuilt MacParakeet's Speech Engine for Apple Silicon
 
-> Status: **HISTORICAL** - LLM support removed 2026-02-23. MacParakeet now uses a two-chip architecture (CPU + ANE). GPU/LLM content below is outdated.
+> Status: **HISTORICAL** - The old on-device Qwen3-8B / mlx-swift-lm path was removed 2026-02-23. GPU-local LLM content below is outdated; current LLM features use external providers or local CLI, while core speech remains a two-chip architecture (CPU + ANE).
 
 *MacParakeet Engineering*
 

--- a/docs/planning/2026-02-local-llm-planning-pack.md
+++ b/docs/planning/2026-02-local-llm-planning-pack.md
@@ -1,6 +1,6 @@
 # Local LLM Planning Pack (Qwen3-8B)
 
-> Status: **HISTORICAL** - LLM support (Qwen3-8B / MLX-Swift) removed 2026-02-23.
+> Status: **HISTORICAL** - The on-device Qwen3-8B / MLX-Swift plan documented here was removed 2026-02-23. Current LLM support uses external providers or local CLI instead.
 
 Last updated: 2026-02-13
 Scope: Production planning for local LLM integration in MacParakeet.

--- a/docs/planning/2026-02-qwen-4b-vs-8b-benchmark-report.md
+++ b/docs/planning/2026-02-qwen-4b-vs-8b-benchmark-report.md
@@ -1,6 +1,6 @@
 # Qwen 4B vs 8B Benchmark Report (Local + External Alignment)
 
-> Status: **HISTORICAL** - LLM support (Qwen3-8B / MLX-Swift) removed 2026-02-23.
+> Status: **HISTORICAL** - The on-device Qwen3-8B / MLX-Swift path documented here was removed 2026-02-23. Current LLM support uses external providers or local CLI instead.
 
 Last updated: 2026-02-13
 Owner: Core

--- a/docs/planning/2026-02-qwen3-8b-benchmark-plan.md
+++ b/docs/planning/2026-02-qwen3-8b-benchmark-plan.md
@@ -1,6 +1,6 @@
 # Qwen3-8B Benchmark Plan (macOS Local)
 
-> Status: **HISTORICAL** - LLM support (Qwen3-8B / MLX-Swift) removed 2026-02-23.
+> Status: **HISTORICAL** - The on-device Qwen3-8B / MLX-Swift path documented here was removed 2026-02-23. Current LLM support uses external providers or local CLI instead.
 
 Last updated: 2026-02-13
 Purpose: Establish repeatable, practical measurements for local Qwen3-8B quality and performance in MacParakeet.

--- a/docs/planning/2026-02-transcript-chat-gui-deep-dive.md
+++ b/docs/planning/2026-02-transcript-chat-gui-deep-dive.md
@@ -1,6 +1,6 @@
 # Transcript Chat GUI Deep Dive
 
-> Status: **HISTORICAL** - Transcript Chat and LLM support removed 2026-02-23.
+> Status: **HISTORICAL** - The local transcript-chat/runtime plan in this doc was superseded when the on-device Qwen3-8B / MLX-Swift path was removed 2026-02-23. Transcript chat still exists via the current provider-based LLM architecture.
 
 Status: Draft proposal for implementation  
 Date: 2026-02-14  

--- a/docs/planning/2026-04-08-crash-report-rootcause-installtap.md
+++ b/docs/planning/2026-04-08-crash-report-rootcause-installtap.md
@@ -83,7 +83,7 @@ ORDER BY ts DESC
 | `model_download_failed` | 5 | 2 |
 | `diarization_failed` | 4 | 3 |
 | `llm_prompt_result_failed` | 3 | 2 |
-| `llm_summary_failed` | 2 | 1 |
+| `llm_formatter_failed` | 2 | 1 |
 | `transcription_failed` | 2 | 2 |
 
 All 14 `crash_occurred` records are on `app_ver = 0.5.5` except one stale record

--- a/docs/planning/llm-runtime-risk-register.md
+++ b/docs/planning/llm-runtime-risk-register.md
@@ -1,6 +1,6 @@
 # LLM Runtime Risk Register (Qwen3-8B + MLX-Swift-LM)
 
-> Status: **HISTORICAL** - LLM support (Qwen3-8B / MLX-Swift) removed 2026-02-23.
+> Status: **HISTORICAL** - The on-device Qwen3-8B / MLX-Swift runtime documented here was removed 2026-02-23. Current LLM support uses external providers or local CLI instead.
 
 Last updated: 2026-02-13
 

--- a/docs/research/fluidaudio-stt-migration.md
+++ b/docs/research/fluidaudio-stt-migration.md
@@ -1,6 +1,6 @@
 # FluidAudio CoreML Migration: STT Backend Evaluation
 
-> Status: **HISTORICAL** — Research findings from February 12-13, 2026. FluidAudio migration is complete. LLM/Qwen3-8B GPU references are outdated — LLM support removed 2026-02-23.
+> Status: **HISTORICAL** — Research findings from February 12-13, 2026. FluidAudio migration is complete. The local Qwen3-8B GPU path referenced here is outdated because the on-device mlx-swift-lm runtime was removed 2026-02-23; current LLM support uses external providers or local CLI.
 
 ## Problem Statement
 

--- a/docs/research/open-source-models-landscape-2026.md
+++ b/docs/research/open-source-models-landscape-2026.md
@@ -1,6 +1,6 @@
 # Open Source Models Landscape (February 2026)
 
-> Status: **HISTORICAL** — Research snapshot as of February 12, 2026. LLM support (Qwen3-8B / MLX-Swift) removed from MacParakeet 2026-02-23. Only Parakeet STT via FluidAudio CoreML remains.
+> Status: **HISTORICAL** — Research snapshot as of February 12, 2026. The local Qwen3-8B / MLX-Swift path discussed here was removed from MacParakeet on 2026-02-23. Current LLM support uses external providers or local CLI; Parakeet STT via FluidAudio CoreML remains the speech engine.
 
 Deep dive into the current state of open source models relevant to MacParakeet: STT, small LLMs, and the Apple MLX ecosystem.
 

--- a/docs/research/wisprflow-deep-dive.md
+++ b/docs/research/wisprflow-deep-dive.md
@@ -1,6 +1,6 @@
 # WisprFlow Deep Dive
 
-> Status: **HISTORICAL** - Competitive research from February 2026. LLM/Command Mode comparisons are outdated — MacParakeet removed LLM support 2026-02-23.
+> Status: **HISTORICAL** - Competitive research from February 2026. The local Qwen3-8B / Command Mode comparisons here are outdated because the on-device LLM path was removed 2026-02-23. Current LLM features use provider-based integrations or local CLI instead.
 
 ## What WisprFlow Does
 

--- a/docs/runtime-revalidation-checklist.md
+++ b/docs/runtime-revalidation-checklist.md
@@ -1,6 +1,6 @@
 # Runtime Revalidation Checklist (macOS Local LLM)
 
-> Status: **HISTORICAL** - LLM support (Qwen3-8B / MLX-Swift) removed 2026-02-23.
+> Status: **HISTORICAL** - The on-device Qwen3-8B / MLX-Swift runtime documented here was removed 2026-02-23. Current LLM support uses external providers or local CLI instead.
 
 Last updated: 2026-02-13
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -142,13 +142,15 @@ CREATE INDEX idx_events_session ON events(session);
 | Event | Props | Question It Answers |
 |---|---|---|
 | `export_used` | `format` (txt, md, srt, vtt, docx, pdf, json) | Which export formats matter? |
-| `llm_summary_used` | `provider` (openai, anthropic, ollama, openrouter) | Is LLM worth maintaining? Which providers? |
-| `llm_summary_failed` | `provider`, `error_type` | LLM failure rates per provider |
+| `llm_prompt_result_used` | `provider` | Are prompt-library results and generated summaries being used? Which providers matter? |
+| `llm_prompt_result_failed` | `provider`, `error_type` | Failure rates for prompt-library result generation per provider |
 | `llm_chat_used` | `provider`, `message_count` | Do people chat with transcripts? |
 | `llm_chat_failed` | `provider`, `error_type` | Chat failure rates per provider |
+| `llm_formatter_used` | `provider`, `source`, `duration_seconds`, `input_chars`, `output_chars`, `default_prompt_used`, `input_truncated` | Is transcript/dictation formatting useful, and how expensive is it? |
+| `llm_formatter_failed` | `provider`, `source`, `duration_seconds`, `error_type`, `default_prompt_used`, `input_truncated` | Formatter failure rates and prompt-shape correlations |
 | `history_searched` | — | Is search useful? |
 | `history_replayed` | — | Do people re-listen to audio? |
-| `copy_to_clipboard` | `source` (dictation, transcription, history) | How do people get text out? |
+| `copy_to_clipboard` | `source` (dictation, transcription, history, meeting, discover) | How do people get text out? |
 | `keystroke_snippet_fired` | — | Are keystroke action snippets being used? |
 | `feedback_submitted` | `category` (bug, featureRequest, other) | Feedback volume and sentiment split |
 | `transcription_deleted` | — | Are users cleaning up transcriptions? |
@@ -165,7 +167,7 @@ CREATE INDEX idx_events_session ON events(session);
 | `processing_mode_changed` | `mode` (raw, clean) | Is the clean pipeline valued? |
 | `custom_word_added` | — | Are custom words used? (NOT the word itself) |
 | `snippet_added` | — | Are snippets used? |
-| `setting_changed` | `setting` (save_history, audio_retention, menu_bar_only, hide_pill) | Which settings get toggled? |
+| `setting_changed` | `setting` (save_history, audio_retention, menu_bar_only, hide_pill, save_transcription_audio, speaker_diarization, auto_save, meeting_auto_save, meeting_hotkey, launch_at_login, silence_auto_stop, voice_return) | Which settings get toggled? |
 | `telemetry_opted_out` | — | How many opt out? (send this one last event, then stop) |
 
 ### 6. Licensing — "Is the business working?"
@@ -197,7 +199,7 @@ CREATE INDEX idx_events_session ON events(session);
 
 | Event | Props | Question It Answers |
 |---|---|---|
-| `permission_prompted` | `permission` (microphone, accessibility) | How many prompts are shown? |
+| `permission_prompted` | `permission` (microphone, accessibility, screen_recording) | How many prompts are shown? |
 | `permission_granted` | `permission` | Grant rate |
 | `permission_denied` | `permission` | Denial rate — is something confusing? |
 
@@ -392,7 +394,7 @@ External AI review of the telemetry design. Each point was evaluated and accepte
 | 5 | Missing `dictation_failed` — core feature failures are a blind spot | Added to Dictation events with `error_type` prop. |
 | 6 | Missing `transcription_cancelled` — long jobs get abandoned | Added with `source` and `audio_duration_seconds` props. |
 | 7 | Missing `model_download_cancelled` — onboarding funnel gap | Added to Performance events. |
-| 8 | Missing `llm_summary_failed` / `llm_chat_failed` — need failure rates per provider | Added both with `provider` + `error_type` props. |
+| 8 | Missing LLM failure telemetry — need provider-level failure rates | Added `llm_prompt_result_failed`, `llm_chat_failed`, and formatter failure events with provider + error props. |
 | 9 | Cut `dictation_private` — sensitive signal, user explicitly wanted privacy | Removed. |
 | 10 | Cut `hotkey_changed.key` value — track boolean, not which key | Changed to `hotkey_customized` with no props. |
 | 11 | Cut `pill_hidden` as separate event — redundant with `setting_changed` | Merged into `setting_changed` with `setting: "hide_pill"`. |

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -102,7 +102,6 @@ CREATE INDEX idx_events_session ON events(session);
 |---|---|---|
 | `app_launched` | — | How many active users? DAU/WAU/MAU? |
 | `app_quit` | `session_duration_seconds` | How long are sessions? |
-| `app_updated` | `from_version`, `to_version` | Are users updating? How fast? |
 | `onboarding_completed` | `duration_seconds` | How long does setup take? |
 | `onboarding_step` | `step` (permissions, model_download, etc.) | Where do people get stuck in onboarding? |
 
@@ -172,19 +171,18 @@ CREATE INDEX idx_events_session ON events(session);
 
 ### 6. Licensing — "Is the business working?"
 
-> Note: App is now free/GPL-3.0. Most licensing events are dead code (trial, purchase, restore). Only `license_activated` and `license_activation_failed` are wired — kept for the historical $0 LemonSqueezy product.
+> Note: App is now free/GPL-3.0. The licensing enum cases are kept in `TelemetryEventName` for the historical $0 LemonSqueezy product, but most are dead code — only `license_activated` and `license_activation_failed` are wired today.
 
 | Event | Props | Question It Answers |
 |---|---|---|
-| `trial_started` | — | When do trials begin? |
-| `trial_expired` | — | Are people hitting the trial wall? |
-| `paywall_viewed` | — | Are people seeing the paywall? |
-| `purchase_started` | — | Are people attempting to buy? |
+| `trial_started` | — | When do trials begin? (dead, free app) |
+| `trial_expired` | — | Are people hitting the trial wall? (dead, free app) |
+| `purchase_started` | — | Are people attempting to buy? (dead, free app) |
 | `license_activated` | — | Conversion! |
 | `license_activation_failed` | `error_type` | What blocks purchases? |
-| `restore_attempted` | — | Are people trying to restore? |
-| `restore_succeeded` | — | Restore success rate |
-| `restore_failed` | `error_type` | What blocks restores? |
+| `restore_attempted` | — | Are people trying to restore? (dead, free app) |
+| `restore_succeeded` | — | Restore success rate (dead, free app) |
+| `restore_failed` | `error_type` | What blocks restores? (dead, free app) |
 
 ### 7. Performance — "Is the app fast?"
 

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -795,49 +795,35 @@ CREATE TABLE text_snippets (
 
 ---
 
-### F8: AI Text Refinement — REMOVED
+### F8: AI Formatter
 
-> Status: **REMOVED** (2026-02-23) — LLM support removed. Formal/Email/Code modes and Qwen3-8B dependency eliminated. Only Raw and Clean (deterministic) modes remain.
+> Status: **IMPLEMENTED ON CURRENT BRANCH** — Optional provider-based formatter for dictation and transcription. The old on-device Qwen3-8B mode presets were removed; formatting now runs through the configured LLM provider or local CLI.
 
-**What:** ~~LLM-powered text transformation for cases where deterministic cleanup is not enough. Uses Qwen3-8B via MLX-Swift, running entirely on-device.~~
+**What:** Optional post-processing formatter that runs *after* deterministic cleanup when the user enables it in AI settings. It is intended to polish punctuation, capitalization, paragraphing, and obvious transcript errors without changing the underlying meaning.
 
-**Context modes:**
+**Current behavior:**
 
-| Mode | Pipeline | Behavior |
+| Stage | Pipeline | Behavior |
 |------|----------|----------|
 | Raw | None | Parakeet output, no processing |
 | Clean | Deterministic (F7) | Filler removal + custom words + snippets |
-| Formal | Clean + LLM | Professional tone, grammar fixes, clear structure |
-| Email | Clean + LLM | Format as email with greeting, body, sign-off |
-| Code | Clean + LLM | Technical dictation, preserve syntax, format as code |
+| AI Formatter | Clean + provider-based LLM | Optional transcript cleanup using the configured LLM provider/local CLI |
 
-Modes stack: Formal/Email/Code always run the clean pipeline first, then apply LLM refinement on top.
+Important constraints:
 
-**LLM details:**
-- Model: Qwen3-8B (4-bit quantized, `mlx-community/Qwen3-8B-4bit`)
-- Framework: MLX-Swift (Apple Silicon optimized)
-- Non-thinking mode for all refinement (fast, `temp=0.7, topP=0.8`)
-- System prompts per mode:
-
-| Mode | System Prompt Summary |
-|------|----------------------|
-| Formal | "Rewrite into professional, clear language. Preserve meaning. Fix grammar." |
-| Email | "Format as a professional email. Add appropriate greeting and sign-off." |
-| Code | "This is technical dictation about programming. Preserve code terms, format appropriately." |
-
-**Personal dictionary (auto-learn):**
-- Track words the user corrects via custom words (F9)
-- Over time, build a vocabulary profile
-- Surface suggestions: "You frequently correct 'react' to 'React'. Add as custom word?"
+- formatter is a separate toggle, not a dictation mode
+- formatter uses the shared `LLMService`
+- formatter can run for both dictation and file/meeting transcription
+- formatter falls back to deterministic cleanup if the provider errors or times out
+- formatter prompt is user-editable in AI settings
 
 **Acceptance criteria:**
-- [ ] Formal mode produces professional, grammatically correct output
-- [ ] Email mode formats text as proper email
-- [ ] Code mode preserves technical terms and syntax
-- [ ] LLM modes always apply clean pipeline first
-- [ ] LLM processing completes in <5 seconds for typical dictations
-- [x] Mode is a global default (set in Vocabulary, applies to all dictations)
-- [ ] Graceful fallback to Clean if LLM fails or times out
+- [x] Formatter can be enabled or disabled independently of Raw/Clean mode
+- [x] Formatter runs only after deterministic cleanup
+- [x] Formatter supports dictation and transcription flows
+- [x] Formatter uses the configured provider or local CLI through shared LLM infrastructure
+- [x] Formatter prompt is editable and resettable from settings
+- [x] Graceful fallback to deterministic cleanup if formatting fails
 
 ---
 
@@ -920,7 +906,7 @@ Modes stack: Formal/Email/Code always run the clean pipeline first, then apply L
 
 ### F10: Command Mode (Epic) — REMOVED
 
-> Status: **REMOVED** (2026-02-23) — LLM support removed. Command Mode (F10a/F10b) and Chat with Transcript (F10c) eliminated along with Qwen3-8B dependency.
+> Status: **PARTIALLY REMOVED** — Command Mode (F10a/F10b) was removed with the old local Qwen3-8B path. Transcript Chat (F10c) still exists through the current provider-based LLM architecture.
 
 **What:** ~~Select text in any app, activate command mode, speak a natural language command, and the text is edited in-place by the local LLM.~~
 
@@ -1021,17 +1007,17 @@ Overlay shows selected text preview (truncated) so the user confirms the right t
 
 ---
 
-### F10c: Transcript Chat (GUI MVP) — REMOVED
+### F10c: Transcript Chat (GUI MVP)
 
-> Status: **REMOVED** (2026-02-23) — LLM support removed.
+> Status: **IMPLEMENTED ON CURRENT BRANCH** — Transcript chat is available from the transcript detail screen through the configured LLM provider or local CLI.
 
-**What:** ~~Ask questions about the currently selected transcript from the transcript detail screen using local Qwen3-8B.~~
+**What:** Ask questions about the currently selected transcript from the transcript detail screen using the shared provider-based LLM service.
 
 **Scope (MVP):**
 - Current transcript scope only (no cross-transcript retrieval yet)
-- In-memory thread per transcript for current app session
+- Multiple persisted conversations per transcript
 - Bounded transcript context assembly to avoid prompt overflow
-- Local-only execution (no cloud calls)
+- Uses whichever provider/local CLI the user configured in AI settings
 
 **Flow:**
 
@@ -1046,9 +1032,9 @@ Overlay shows selected text preview (truncated) so the user confirms the right t
 │    - current transcript text                                   │
 │    - truncation marker if needed                               │
 ├─────────────────────────────────────────────────────────────────┤
-│ 4. Qwen3-8B generates response locally                         │
+│ 4. Configured LLM provider generates response                  │
 │    - loading state shown in panel                              │
-│    - no network dependency                                     │
+│    - local CLI / local provider / cloud provider supported     │
 ├─────────────────────────────────────────────────────────────────┤
 │ 5. Response appears in thread                                  │
 │    - retry available for failed generations                    │
@@ -1057,17 +1043,17 @@ Overlay shows selected text preview (truncated) so the user confirms the right t
 ```
 
 **Technical implementation:**
-- Prompt composed via shared `TranscriptChatPromptComposer`
-- Prompt task uses `LLMTask.transcriptChat(question:transcript:)`
-- Context bounded by `TranscriptContextAssembler.assemble(...)`
-- Response generated through `LLMServiceProtocol.generate(...)`
+- Response generated through `LLMServiceProtocol.chatStream(question:transcript:history:)`
+- Context is bounded before prompt submission
+- Conversations are persisted per transcript through `ChatConversationRepository`
+- Model/provider selection comes from the shared LLM settings/config store
 
 **Acceptance criteria:**
 - [x] Transcript detail shows chat panel UI
 - [x] User can send a question and receive a response in-thread
 - [x] Context is bounded for long transcripts
 - [x] Failed responses surface inline error with retry path
-- [x] Local model readiness status is visible in panel
+- [x] Current provider/model readiness is visible in the panel
 
 ---
 

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -797,7 +797,7 @@ CREATE TABLE text_snippets (
 
 ### F8: AI Formatter
 
-> Status: **IMPLEMENTED ON CURRENT BRANCH** — Optional provider-based formatter for dictation and transcription. The old on-device Qwen3-8B mode presets were removed; formatting now runs through the configured LLM provider or local CLI.
+> Status: **IMPLEMENTED** — Optional provider-based formatter for dictation and file/YouTube transcription. The old on-device Qwen3-8B mode presets were removed; formatting now runs through the configured LLM provider or local CLI.
 
 **What:** Optional post-processing formatter that runs *after* deterministic cleanup when the user enables it in AI settings. It is intended to polish punctuation, capitalization, paragraphing, and obvious transcript errors without changing the underlying meaning.
 
@@ -813,14 +813,15 @@ Important constraints:
 
 - formatter is a separate toggle, not a dictation mode
 - formatter uses the shared `LLMService`
-- formatter can run for both dictation and file/meeting transcription
+- formatter runs for dictation and file/YouTube transcription flows; meeting transcripts currently use deterministic cleanup only (see `TelemetryFormatterSource` — `.dictation` and `.transcription` are the only emitter sources wired today)
 - formatter falls back to deterministic cleanup if the provider errors or times out
 - formatter prompt is user-editable in AI settings
 
 **Acceptance criteria:**
 - [x] Formatter can be enabled or disabled independently of Raw/Clean mode
 - [x] Formatter runs only after deterministic cleanup
-- [x] Formatter supports dictation and transcription flows
+- [x] Formatter supports dictation and file/YouTube transcription flows
+- [ ] Formatter supports meeting transcription (not yet wired — meeting path goes through `MeetingTranscriptFinalizer` without invoking `formatTranscript`)
 - [x] Formatter uses the configured provider or local CLI through shared LLM infrastructure
 - [x] Formatter prompt is editable and resettable from settings
 - [x] Graceful fallback to deterministic cleanup if formatting fails

--- a/spec/adr/001-parakeet-stt.md
+++ b/spec/adr/001-parakeet-stt.md
@@ -3,7 +3,7 @@
 > Status: **Accepted**
 > Date: 2026-02-08
 > Runtime Note (2026-02-13): Runtime/mechanism details in this ADR are historical and superseded by ADR-007. ADR-001 remains authoritative for STT model choice.
-> Note: GPU/LLM references (Qwen3-8B, "three-chip") are historical — LLM support removed 2026-02-23. MacParakeet now uses a two-chip architecture (CPU + ANE).
+> Note: GPU/LLM references (Qwen3-8B, "three-chip") are historical — the old on-device mlx-swift-lm path was removed 2026-02-23. Current LLM features use external providers or local CLI, while the speech runtime remains a two-chip architecture (CPU + ANE).
 
 ## Context
 

--- a/spec/adr/003-one-time-purchase.md
+++ b/spec/adr/003-one-time-purchase.md
@@ -3,7 +3,7 @@
 > Status: **HISTORICAL** - Superseded by open-source release (GPL-3.0) in v0.5. MacParakeet is now free.
 > Date: 2026-02-08
 > Amended: 2026-03-24 — MacParakeet went free and open-source (GPL-3.0). LemonSqueezy kept as $0 product for download tracking. The $49 pricing model below is historical context only.
-> Note: References to "command mode" and "LLM modes" in pricing rationale are historical — LLM support removed 2026-02-23.
+> Note: References to the old local "command mode" / Qwen3-8B LLM modes in the pricing rationale are historical — that on-device path was removed 2026-02-23. Current provider-based LLM features are documented separately.
 
 ## Context
 

--- a/spec/adr/007-fluidaudio-coreml-migration.md
+++ b/spec/adr/007-fluidaudio-coreml-migration.md
@@ -2,7 +2,7 @@
 
 > Status: **Accepted**
 > Date: 2026-02-13
-> Note: Core decision (FluidAudio CoreML for STT) is implemented and active. GPU/LLM references (Qwen3-8B, "GPU contention") are historical — LLM support removed 2026-02-23.
+> Note: Core decision (FluidAudio CoreML for STT) is implemented and active. GPU/LLM references (Qwen3-8B, "GPU contention") are historical — the old on-device mlx-swift-lm path was removed 2026-02-23.
 
 ## Context
 

--- a/spec/adr/008-local-llm-runtime-and-model.md
+++ b/spec/adr/008-local-llm-runtime-and-model.md
@@ -1,6 +1,6 @@
 # ADR-008: Local LLM Runtime and Model Baseline (Qwen3-8B)
 
-> Status: **HISTORICAL** - Superseded. LLM support removed 2026-02-23. Qwen3-8B and mlx-swift-lm dependency fully removed from codebase.
+> Status: **HISTORICAL** - Superseded. The on-device Qwen3-8B / mlx-swift-lm runtime was removed 2026-02-23. Current LLM support uses external providers or local CLI instead.
 > Date: 2026-02-13
 
 ## Context


### PR DESCRIPTION
Closes #107

## Summary

MacParakeet was burning **~15-18% CPU and ~10% GPU at idle** because the default Transcribe screen ran four `repeatForever` SwiftUI animations inside `.drawingGroup()` — even when the user wasn't interacting with the app. The process never slept; `top` showed it permanently in `running` state with a continuous `NSDisplayCycleFlush → NSHostingView.layout() → QuartzCore` render loop.

After this fix, idle CPU drops to **0.0%** and the process state becomes `sleeping`.

```
BEFORE (main window open, idle on Transcribe tab):

  ┌─────────────────────────────────────┐
  │  SwiftUI View Body                  │
  │  4x repeatForever animations        │
  │         │                           │
  │         ▼  every frame (~16ms)      │
  ���  NSDisplayCycleFlush                │
  │         │                           │
  │         ▼                           │
  │  NSHostingView.layout()             │
  │         │                           │
  │         ▼                           │
  │  .drawingGroup() → GPU texture      │
  │         │                           │
  │         ▼                           │
  │  QuartzCore composite               │
  │                                     │
  │  CPU: ~15-18%    GPU: ~10%          │
  │  Process state: running (always)    │
  └─────────────────────────────────────┘

AFTER:

  ┌─────────────────────────────────────┐
  │  SwiftUI View Body                  │
  │  Static geometry, no animations     │
  │         │                           │
  │         ▼  once (on appear)         │
  │  .drawingGroup() → cached texture   │
  │                                     │
  │  No render loop. No frame ticks.    │
  │                                     │
  │  CPU: 0.0%       GPU: 0.0%         │
  │  Process state: sleeping            │
  └─────────────────────────────────────┘

ON DRAG (file hover over drop zone):

  ┌─────────────────────────────────────┐
  │  isDragging = true                  │
  │         │                           │
  │         ▼                           │
  │  animate: isDragging → true         │
  │  Merkaba spins, particles appear    │
  │  CA Render Server drives animation  │
  │         │                           │
  │         ▼  on drop / drag exit      │
  │  isDragging = false                 │
  │  stopAnimation() → static again     │
  └─────────────────────────────────────┘
```

## Changes

| Fix | File | What | Impact |
|-----|------|------|--------|
| 1 | `PortalDropZone.swift` | Merkaba animates only during file drag (`animate: isDragging`) | **Primary fix** — eliminates the idle render loop |
| 2 | `SacredGeometry.swift` | `MeditativeMerkabaView` respects `accessibilityReduceMotion` | Accessibility gap closed for all 8 usage sites |
| 3 | `MeetingRecordingPanelView.swift` | `BreathingSeedOfLifeView`: `.blur(radius: 8)` → `.shadow()` | Blur forces per-frame Gaussian; shadow is CA-cacheable |
| 4 | `AIStreamingIndicator.swift` | 30fps `TimelineView` → SwiftUI `.animation()` modifiers | Offloads interpolation to CA Render Server; adds `reduceMotion` + `onDisappear` reset |
| 5 | `DictationHistoryView.swift` | Empty-state merkaba: `animate: false` | Prevents animation when history tab is open and empty |
| 6 | `PromptLibraryView.swift` | Empty-state merkaba: `animate: false` | Prevents animation when prompt library is open and empty |

## Measured Results

```
                        BEFORE          AFTER
CPU (idle, frontmost)   13.8% → 17.7%   0.0%
Process state           running          sleeping
Memory                  198 MB           44 MB
```

Measured with `top -l 3 -s 2` on Apple Silicon, main window open on the default Transcribe tab.

## Review Process

Two rounds of 6-agent review (3x Codex, 3x Gemini):
- **Round 1**: Found and fixed re-appearance animation bug, phase delay calibration, 2 additional always-animating empty states, missing `reduceMotion` on AIStreamingIndicator
- **Round 2**: All 6 agents confirmed ship-ready, clean compile, no regressions
- **Tests**: 4 `swift test` runs passed, `swift build` clean with 0 warnings

## Test plan

- [x] `swift test` passes (4 runs)
- [x] `swift build` clean, 0 warnings  
- [x] Measured 0.0% idle CPU after fix (via `top`)
- [ ] Visual check: portal drop zone looks correct at rest (static merkaba)
- [ ] Visual check: merkaba animates on file drag, stops on drop
- [ ] Visual check: AIStreamingIndicator breathing dots during LLM chat
- [ ] Visual check: BreathingSeedOfLifeView glow during meeting recording
- [ ] Smoke test: toggle macOS Reduce Motion while app is open

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI Formatter: Optional provider-based text refinement after transcription with deterministic fallback.
  * Transcript Chat with persistent conversation history.

* **Improvements**
  * Enhanced accessibility with Reduce Motion support for animations.
  * Updated visual glow effects for improved design consistency.

* **Documentation**
  * Clarified LLM architecture now relies on external providers or local CLI instead of on-device approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->