### PR TITLE
Allow http base URLs for local providers (fixes #118)

### DIFF
--- a/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
@@ -69,7 +69,7 @@ struct LLMSettingsView: View {
                                     .foregroundStyle(.secondary)
                             }
                             Spacer(minLength: DesignSystem.Spacing.md)
-                            TextField("https://api.example.com/v1", text: $viewModel.baseURLOverride)
+                            TextField(viewModel.baseURLPlaceholder, text: $viewModel.baseURLOverride)
                                 .textFieldStyle(.roundedBorder)
                                 .frame(width: 220)
                         }
@@ -102,7 +102,7 @@ struct LLMSettingsView: View {
                                         .foregroundStyle(.secondary)
                                 }
                                 Spacer(minLength: DesignSystem.Spacing.md)
-                                TextField("https://...", text: $viewModel.baseURLOverride)
+                                TextField(viewModel.baseURLPlaceholder, text: $viewModel.baseURLOverride)
                                     .textFieldStyle(.roundedBorder)
                                     .frame(width: 220)
                             }

--- a/Sources/MacParakeetViewModels/LLMSettingsDraft.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsDraft.swift
@@ -18,7 +18,7 @@ public struct LLMSettingsDraft: Equatable, Sendable {
             case .missingCustomModel:
                 return "Enter a custom model ID."
             case .invalidBaseURL:
-                return "Enter a valid HTTPS base URL, or use localhost for local servers."
+                return "Enter a valid base URL. Remote endpoints must use https."
             case .missingCommandTemplate:
                 return "Enter a CLI command."
             }

--- a/Sources/MacParakeetViewModels/LLMSettingsDraft.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsDraft.swift
@@ -122,7 +122,7 @@ public struct LLMSettingsDraft: Equatable, Sendable {
         }
         if !trimmedBaseURLOverride.isEmpty {
             guard let overrideURL = URL(string: trimmedBaseURLOverride),
-                  Self.isAllowedBaseURLOverride(overrideURL) else {
+                  Self.isAllowedBaseURLOverride(overrideURL, providerID: providerID) else {
                 return .invalidBaseURL
             }
         }
@@ -160,7 +160,7 @@ public struct LLMSettingsDraft: Equatable, Sendable {
             guard let override = URL(string: trimmedBaseURLOverride) else {
                 throw ValidationError.invalidBaseURL
             }
-            guard Self.isAllowedBaseURLOverride(override) else {
+            guard Self.isAllowedBaseURLOverride(override, providerID: providerID) else {
                 throw ValidationError.invalidBaseURL
             }
             baseURL = override
@@ -237,7 +237,7 @@ public struct LLMSettingsDraft: Equatable, Sendable {
         )
     }
 
-    private static func isAllowedBaseURLOverride(_ url: URL) -> Bool {
+    private static func isAllowedBaseURLOverride(_ url: URL, providerID: LLMProviderID) -> Bool {
         guard let scheme = url.scheme?.lowercased(),
               url.host != nil else {
             return false
@@ -247,6 +247,11 @@ public struct LLMSettingsDraft: Equatable, Sendable {
         }
         guard scheme == "http" else {
             return false
+        }
+        // Local providers (Ollama, LM Studio) may be reachable over any host the
+        // user configures — LAN IP, mDNS hostname, Tailscale, 0.0.0.0 bind, etc.
+        if providerID.isLocal {
+            return true
         }
         return LLMProviderConfig.isLoopbackEndpoint(url)
     }

--- a/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
@@ -62,6 +62,13 @@ public final class LLMSettingsViewModel {
         }
     }
 
+    public var baseURLPlaceholder: String {
+        guard let providerID = draft.providerID else { return "https://..." }
+        let fallback = providerID == .openaiCompatible ? "https://api.example.com/v1" : "https://..."
+        let defaultURL = Self.defaultBaseURL(for: providerID)
+        return defaultURL.isEmpty ? fallback : defaultURL
+    }
+
     public var useCustomModel: Bool {
         get { draft.useCustomModel }
         set {

--- a/Tests/MacParakeetTests/ViewModels/LLMSettingsDraftTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LLMSettingsDraftTests.swift
@@ -64,6 +64,41 @@ final class LLMSettingsDraftTests: XCTestCase {
         XCTAssertEqual(draft.validationError, .invalidBaseURL)
     }
 
+    // Regression: #118 — 0.0.0.0 bind addresses (common Ollama config) must be accepted.
+    func testOllamaWildcardBindBaseURLIsAllowed() {
+        let draft = LLMSettingsDraft(
+            providerID: .ollama,
+            suggestedModelName: "qwen3.5:4b",
+            baseURLOverride: "http://0.0.0.0:11434/v1"
+        )
+
+        XCTAssertNil(draft.validationError)
+    }
+
+    // IPv6 loopback must be treated as loopback for remote providers too. Pins
+    // the behavior of LLMProviderConfig.isLoopbackEndpoint + URL.host for `[::1]`.
+    func testIPv6LoopbackAllowedForRemoteProvider() {
+        let draft = LLMSettingsDraft(
+            providerID: .openaiCompatible,
+            useCustomModel: true,
+            customModelName: "third-party-model",
+            baseURLOverride: "http://[::1]:8080/v1"
+        )
+
+        XCTAssertNil(draft.validationError)
+    }
+
+    // Non-web schemes are rejected for every provider, including local ones.
+    func testNonHTTPSchemeRejectedForLocalProvider() {
+        let draft = LLMSettingsDraft(
+            providerID: .ollama,
+            suggestedModelName: "qwen3.5:4b",
+            baseURLOverride: "ftp://localhost:11434/v1"
+        )
+
+        XCTAssertEqual(draft.validationError, .invalidBaseURL)
+    }
+
     func testHTTPSRemoteBaseURLIsAllowed() {
         let draft = LLMSettingsDraft(
             providerID: .openai,

--- a/Tests/MacParakeetTests/ViewModels/LLMSettingsDraftTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LLMSettingsDraftTests.swift
@@ -24,6 +24,46 @@ final class LLMSettingsDraftTests: XCTestCase {
         XCTAssertNil(draft.validationError)
     }
 
+    // Regression: #118 — Ollama running on a LAN host must not require HTTPS.
+    func testOllamaLANBaseURLIsAllowed() throws {
+        let draft = LLMSettingsDraft(
+            providerID: .ollama,
+            suggestedModelName: "qwen3.5:4b",
+            baseURLOverride: "http://192.168.1.5:11434/v1"
+        )
+
+        XCTAssertNil(draft.validationError)
+
+        let config = try draft.buildConfig(defaultBaseURL: "http://localhost:11434/v1")
+        XCTAssertEqual(config?.id, .ollama)
+        XCTAssertEqual(config?.baseURL.absoluteString, "http://192.168.1.5:11434/v1")
+        XCTAssertEqual(config?.isLocal, true)
+    }
+
+    // Regression: #118 — mDNS / Tailscale / 0.0.0.0 bindings must also be accepted for local providers.
+    func testLMStudioMDNSBaseURLIsAllowed() {
+        let draft = LLMSettingsDraft(
+            providerID: .lmstudio,
+            suggestedModelName: "local-model",
+            baseURLOverride: "http://studio.local:1234/v1"
+        )
+
+        XCTAssertNil(draft.validationError)
+    }
+
+    // Preserves PR #109's tightening: remote providers (including OpenAI-compatible
+    // shims) must use HTTPS unless the user is pointing at loopback.
+    func testOpenAICompatibleRejectsHTTPOnLANHost() {
+        let draft = LLMSettingsDraft(
+            providerID: .openaiCompatible,
+            useCustomModel: true,
+            customModelName: "third-party-model",
+            baseURLOverride: "http://192.168.1.5:8000/v1"
+        )
+
+        XCTAssertEqual(draft.validationError, .invalidBaseURL)
+    }
+
     func testHTTPSRemoteBaseURLIsAllowed() {
         let draft = LLMSettingsDraft(
             providerID: .openai,

--- a/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
@@ -121,7 +121,7 @@ final class LLMSettingsViewModelTests: XCTestCase {
         viewModel.customModelName = "third-party-model"
 
         XCTAssertFalse(viewModel.canSave)
-        XCTAssertEqual(viewModel.validationMessage, "Enter a valid HTTPS base URL, or use localhost for local servers.")
+        XCTAssertEqual(viewModel.validationMessage, "Enter a valid base URL. Remote endpoints must use https.")
 
         viewModel.baseURLOverride = "https://api.example.com/v1"
 


### PR DESCRIPTION
## Summary

- v0.5.6 regressed Ollama/LM Studio users whose base URL isn't `localhost` / `127.*` / `::1` — Save stayed disabled with an HTTPS-required error.
- Gate `isAllowedBaseURLOverride` on `providerID.isLocal`: local providers accept http on any host (LAN, mDNS, Tailscale, `0.0.0.0`). Remote providers (OpenAI, OpenAI-compatible, Anthropic, Gemini, OpenRouter) still require HTTPS or loopback, preserving #109's tightening.
- 3 regression tests added. Full suite: 1427 XCTest + 13 Swift Testing, 0 failures.

## Root cause

Introduced in `0cec87e3` (PR #109) and kept in `b2315947`. The validator was written provider-agnostically:

```swift
// before
if scheme == "http" { return isLoopbackEndpoint(url) }
```

That check treated every `http://` URL the same regardless of provider, so anyone running Ollama on `http://192.168.x.x:11434/v1`, `http://ollama.local:11434/v1`, a Tailscale IP, or `http://0.0.0.0:11434/v1` couldn't save on 0.5.6. v0.5.5 accepted any parseable URL.

## Fix

```swift
// after
if providerID.isLocal { return true }       // Ollama, LM Studio
return isLoopbackEndpoint(url)              // remote providers: https-or-loopback
```

Two-line call-site updates in `validationError` and `buildConfig` pass the already-unwrapped `providerID` through.

## Tests

- `testOllamaLANBaseURLIsAllowed` — `http://192.168.1.5:11434/v1` + Ollama → valid, `buildConfig` returns `isLocal: true`.
- `testLMStudioMDNSBaseURLIsAllowed` — `http://studio.local:1234/v1` + LM Studio → valid.
- `testOpenAICompatibleRejectsHTTPOnLANHost` — `http://192.168.1.5:8000/v1` + OpenAI-Compatible → still `.invalidBaseURL` (preserves #109).
- Existing coverage for loopback, HTTPS, and missing fields all green.

## Test plan

- [x] `swift test --filter LLMSettingsDraftTests` — 11/11 pass
- [x] `swift test` — 1440 tests, 0 failures
- [x] `swift build --target MacParakeet` — clean
- [ ] Smoke test: dev build → Settings → AI Providers → Ollama → set base URL to a LAN IP → Save enabled → text is processed

## Scope

Validator-only fix. No changes to `LLMProviderConfig`, no migration required (Codable enum is `String` raw-valued and stable). Existing users with broken configs will see Save become available as soon as they reopen Settings.

Fixes #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved base URL validation for local LLM providers. HTTP URLs are now supported for local providers without loopback restriction, while remote providers maintain secure HTTPS requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->