### PR TITLE
Persist lifetime dictation stats through history deletion (#124)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ All ADRs are in `spec/adr/`. These are locked decisions -- don't second-guess th
 
 ## Current Phase
 
-**v0.6 In Progress** -- ~222 source files, ~111 test files, 1445 tests passing (1432 XCTest + 13 Swift Testing, as of 2026-04-22)
+**v0.6 In Progress** -- ~222 source files, ~111 test files, 1450 tests passing (1437 XCTest + 13 Swift Testing, as of 2026-04-23)
 
 - **v0.1** MVP -- System-wide dictation, file transcription, overlay, history, export, SQLite, CLI, STT engine
 - **v0.2** Clean Pipeline -- Text processing (filler removal, custom words, snippets), Vocabulary UI, feedback form

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ All ADRs are in `spec/adr/`. These are locked decisions -- don't second-guess th
 
 ## Current Phase
 
-**v0.6 In Progress** -- ~222 source files, ~110 test files, 1414 tests passing (1401 XCTest + 13 Swift Testing, as of 2026-04-15)
+**v0.6 In Progress** -- ~222 source files, ~111 test files, 1445 tests passing (1432 XCTest + 13 Swift Testing, as of 2026-04-22)
 
 - **v0.1** MVP -- System-wide dictation, file transcription, overlay, history, export, SQLite, CLI, STT engine
 - **v0.2** Clean Pipeline -- Text processing (filler removal, custom words, snippets), Vocabulary UI, feedback form
@@ -157,6 +157,7 @@ ANE:  Parakeet STT (via FluidAudio/CoreML) -- dedicated ML chip
 - `macparakeet.db` (GRDB): Dictation history + transcription records in a single file
 - No vector search or embeddings needed (unlike Oatmeal)
 - One repository per table (GRDB pattern)
+- `lifetime_dictation_stats` (v0.7.4): singleton counter row keeping headline voice stats (total words, total time, total count, longest dictation) alive through history deletion. Incremented in the same transaction as each completed dictation save. See `spec/01-data-model.md` and issue #124.
 
 ### Audio Capture
 

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -109,7 +109,7 @@ final class AppEnvironmentConfigurer {
             llmClient: env.llmClient
         )
 
-        settingsViewModel.onDictationsCleared = { [weak self] in
+        settingsViewModel.onDictationStateChanged = { [weak self] in
             self?.historyViewModel.loadDictations()
         }
 

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -56,13 +56,13 @@ struct SettingsView: View {
         } message: {
             Text("This will permanently delete all \(viewModel.dictationCount) dictation\(viewModel.dictationCount == 1 ? "" : "s") and their audio files. This cannot be undone.")
         }
-        .alert("Reset Private Statistics?", isPresented: $showResetPrivateStatsAlert) {
+        .alert("Delete Private Dictations?", isPresented: $showResetPrivateStatsAlert) {
             Button("Cancel", role: .cancel) {}
-            Button("Reset", role: .destructive) {
-                viewModel.resetPrivateStatistics()
+            Button("Delete", role: .destructive) {
+                viewModel.deletePrivateDictations()
             }
         } message: {
-            Text("This will delete all accumulated statistics from private dictations. This cannot be undone.")
+            Text("This will permanently delete the metric-only entries from dictations made while \"Save dictation history\" was off. Lifetime stats are not affected. This cannot be undone.")
         }
         .alert("Reset Lifetime Stats?", isPresented: $showResetLifetimeStatsAlert) {
             Button("Cancel", role: .cancel) {}
@@ -573,14 +573,18 @@ struct SettingsView: View {
                     )
                 }
 
-                VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
-                    Text("Maintenance")
-                        .font(DesignSystem.Typography.caption)
-                        .foregroundStyle(.secondary)
-
-                    HStack(spacing: DesignSystem.Spacing.sm) {
+                VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+                    maintenanceGroup(
+                        label: "Delete data",
+                        detail: "Removes rows from your library. Lifetime stats are preserved."
+                    ) {
                         Button("Clear All Dictations...", role: .destructive) {
                             showClearAllAlert = true
+                        }
+                        .buttonStyle(.bordered)
+
+                        Button("Delete Private Dictations...", role: .destructive) {
+                            showResetPrivateStatsAlert = true
                         }
                         .buttonStyle(.bordered)
 
@@ -588,12 +592,12 @@ struct SettingsView: View {
                             showClearYouTubeAudioAlert = true
                         }
                         .buttonStyle(.bordered)
+                    }
 
-                        Button("Reset Private Statistics...", role: .destructive) {
-                            showResetPrivateStatsAlert = true
-                        }
-                        .buttonStyle(.bordered)
-
+                    maintenanceGroup(
+                        label: "Reset counters",
+                        detail: "Zeros lifetime stats. Your dictation history is untouched."
+                    ) {
                         Button("Reset Lifetime Stats...", role: .destructive) {
                             showResetLifetimeStatsAlert = true
                         }
@@ -879,6 +883,28 @@ struct SettingsView: View {
             RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
                 .fill(DesignSystem.Colors.surfaceElevated)
         )
+    }
+
+    @ViewBuilder
+    private func maintenanceGroup<Buttons: View>(
+        label: String,
+        detail: String,
+        @ViewBuilder buttons: () -> Buttons
+    ) -> some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
+            HStack(alignment: .firstTextBaseline, spacing: DesignSystem.Spacing.sm) {
+                Text(label)
+                    .font(DesignSystem.Typography.caption.weight(.medium))
+                    .foregroundStyle(.secondary)
+                Text(detail)
+                    .font(DesignSystem.Typography.micro)
+                    .foregroundStyle(.tertiary)
+                Spacer(minLength: 0)
+            }
+            FlowLayout(spacing: DesignSystem.Spacing.sm) {
+                buttons()
+            }
+        }
     }
 
     private func metricTile(title: String, value: String, detail: String) -> some View {

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -15,6 +15,7 @@ struct SettingsView: View {
     @State private var showClearAllAlert = false
     @State private var showClearYouTubeAudioAlert = false
     @State private var showResetPrivateStatsAlert = false
+    @State private var showResetLifetimeStatsAlert = false
     @State private var copiedBuildIdentity = false
 
     init(viewModel: SettingsViewModel, llmSettingsViewModel: LLMSettingsViewModel, updater: SPUUpdater) {
@@ -62,6 +63,14 @@ struct SettingsView: View {
             }
         } message: {
             Text("This will delete all accumulated statistics from private dictations. This cannot be undone.")
+        }
+        .alert("Reset Lifetime Stats?", isPresented: $showResetLifetimeStatsAlert) {
+            Button("Cancel", role: .cancel) {}
+            Button("Reset", role: .destructive) {
+                viewModel.resetLifetimeStats()
+            }
+        } message: {
+            Text("This will zero your total words, total time, total dictation count, and longest dictation. Your dictation history is not affected. This cannot be undone.")
         }
         .alert("Clear Downloaded YouTube Audio?", isPresented: $showClearYouTubeAudioAlert) {
             Button("Cancel", role: .cancel) {}
@@ -582,6 +591,11 @@ struct SettingsView: View {
 
                         Button("Reset Private Statistics...", role: .destructive) {
                             showResetPrivateStatsAlert = true
+                        }
+                        .buttonStyle(.bordered)
+
+                        Button("Reset Lifetime Stats...", role: .destructive) {
+                            showResetLifetimeStatsAlert = true
                         }
                         .buttonStyle(.bordered)
                     }

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -14,7 +14,6 @@ struct SettingsView: View {
     @State private var automaticallyDownloadsUpdates: Bool
     @State private var showClearAllAlert = false
     @State private var showClearYouTubeAudioAlert = false
-    @State private var showResetPrivateStatsAlert = false
     @State private var showResetLifetimeStatsAlert = false
     @State private var copiedBuildIdentity = false
 
@@ -54,15 +53,7 @@ struct SettingsView: View {
                 viewModel.clearAllDictations()
             }
         } message: {
-            Text("This will permanently delete all \(viewModel.dictationCount) dictation\(viewModel.dictationCount == 1 ? "" : "s") and their audio files. This cannot be undone.")
-        }
-        .alert("Delete Private Dictations?", isPresented: $showResetPrivateStatsAlert) {
-            Button("Cancel", role: .cancel) {}
-            Button("Delete", role: .destructive) {
-                viewModel.deletePrivateDictations()
-            }
-        } message: {
-            Text("This will permanently delete the metric-only entries from dictations made while \"Save dictation history\" was off. Lifetime stats are not affected. This cannot be undone.")
+            Text("This will permanently delete all \(viewModel.dictationCount) dictation\(viewModel.dictationCount == 1 ? "" : "s"), their audio files, and any private metric-only entries. Lifetime stats are not affected. This cannot be undone.")
         }
         .alert("Reset Lifetime Stats?", isPresented: $showResetLifetimeStatsAlert) {
             Button("Cancel", role: .cancel) {}
@@ -580,11 +571,6 @@ struct SettingsView: View {
                     ) {
                         Button("Clear All Dictations...", role: .destructive) {
                             showClearAllAlert = true
-                        }
-                        .buttonStyle(.bordered)
-
-                        Button("Delete Private Dictations...", role: .destructive) {
-                            showResetPrivateStatsAlert = true
                         }
                         .buttonStyle(.bordered)
 

--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -401,6 +401,20 @@ public final class DatabaseManager: Sendable {
             try db.execute(sql: "UPDATE prompts SET isVisible = 1 WHERE isAutoRun = 1")
         }
 
+        // v0.7.4 - Lifetime dictation stats survive history deletion (issue #124).
+        // Single-row counter table, backfilled from existing completed dictations.
+        migrator.registerMigration("v0.7.4-lifetime-dictation-stats") { db in
+            try db.create(table: "lifetime_dictation_stats") { t in
+                t.column("id", .integer).primaryKey().check { $0 == 1 }
+                t.column("totalCount", .integer).notNull().defaults(to: 0)
+                t.column("totalDurationMs", .integer).notNull().defaults(to: 0)
+                t.column("totalWords", .integer).notNull().defaults(to: 0)
+                t.column("longestDurationMs", .integer).notNull().defaults(to: 0)
+                t.column("updatedAt", .text).notNull()
+            }
+            try DictationRepository.recomputeLifetimeStats(db: db)
+        }
+
         try migrator.migrate(dbQueue)
         try reconcileBuiltInPrompts()
     }

--- a/Sources/MacParakeetCore/Database/DictationRepository.swift
+++ b/Sources/MacParakeetCore/Database/DictationRepository.swift
@@ -132,11 +132,13 @@ public final class DictationRepository: DictationRepositoryProtocol {
                     wordCount: dictation.wordCount
                 )
             default:
-                // Non-completed terminal states (.recording / .processing / .error)
-                // and a re-save of an already-completed row that transitions to one
-                // of those — both no-op. A completed → error transition (e.g. a
-                // post-processing failure) intentionally keeps the lifetime
-                // increment: "completed dictations ever", not "currently completed."
+                // Target status isn't .completed — no-op. In practice the app
+                // only saves dictations at .completed (DictationService.save),
+                // so this branch is defensive: if a future code path ever writes
+                // a non-completed status it won't perturb lifetime counters.
+                // Note: "lifetime totalCount" is defined as rows that reached
+                // .completed — consistent with `recomputeLifetimeStats`, which
+                // filters on `status = 'completed'`.
                 break
             }
         }
@@ -355,6 +357,11 @@ public final class DictationRepository: DictationRepositoryProtocol {
     /// Recovery / migration path: rebuild the singleton row from current dictations.
     /// Uses INSERT OR REPLACE so it self-heals even if the row was deleted. Caller
     /// must pass an open `Database` handle (already inside a write transaction).
+    ///
+    /// Counts only `status = 'completed'` rows — this matches the write-path
+    /// definition in `save()`, which increments lifetime counters only when the
+    /// row transitions to `.completed`. Keep the two filters in sync if the
+    /// "lifetime" definition ever broadens.
     public static func recomputeLifetimeStats(db: Database, now: Date = Date()) throws {
         try db.execute(
             sql: """

--- a/Sources/MacParakeetCore/Database/DictationRepository.swift
+++ b/Sources/MacParakeetCore/Database/DictationRepository.swift
@@ -132,6 +132,11 @@ public final class DictationRepository: DictationRepositoryProtocol {
                     wordCount: dictation.wordCount
                 )
             default:
+                // Non-completed terminal states (.recording / .processing / .error)
+                // and a re-save of an already-completed row that transitions to one
+                // of those — both no-op. A completed → error transition (e.g. a
+                // post-processing failure) intentionally keeps the lifetime
+                // increment: "completed dictations ever", not "currently completed."
                 break
             }
         }
@@ -225,17 +230,31 @@ public final class DictationRepository: DictationRepositoryProtocol {
     }
 
     public func stats() throws -> DictationStats {
-        try dbQueue.read { db in
-            // Lifetime totals — survive history deletion (issue #124).
-            let lifetime = try Row.fetchOne(db, sql: """
+        // Write transaction (not read) so we can self-heal if the singleton row is
+        // missing. Migration seeds the row and nothing in code deletes it, so the
+        // heal path should never fire — but if it does (manual DB surgery, partial
+        // migration, etc.) we'd rather rebuild from `dictations` than silently show
+        // zeros and mask a broken invariant. See also `incrementLifetimeStats`,
+        // which throws on the write path for the same reason.
+        try dbQueue.write { db in
+            var lifetime = try Row.fetchOne(db, sql: """
                 SELECT totalCount, totalDurationMs, totalWords, longestDurationMs
                 FROM lifetime_dictation_stats WHERE id = 1
                 """)
+            if lifetime == nil {
+                try Self.recomputeLifetimeStats(db: db)
+                lifetime = try Row.fetchOne(db, sql: """
+                    SELECT totalCount, totalDurationMs, totalWords, longestDurationMs
+                    FROM lifetime_dictation_stats WHERE id = 1
+                    """)
+            }
             let totalCount: Int = lifetime?["totalCount"] ?? 0
             let totalDuration: Int = lifetime?["totalDurationMs"] ?? 0
             let totalWords: Int = lifetime?["totalWords"] ?? 0
             let longestDuration: Int = lifetime?["longestDurationMs"] ?? 0
-            let averageDuration = totalCount > 0 ? totalDuration / totalCount : 0
+            let averageDuration = totalCount > 0
+                ? Int((Double(totalDuration) / Double(totalCount)).rounded())
+                : 0
 
             // visibleCount reflects what's currently in the user's history.
             let visibleCount: Int = try Int.fetchOne(

--- a/Sources/MacParakeetCore/Database/DictationRepository.swift
+++ b/Sources/MacParakeetCore/Database/DictationRepository.swift
@@ -12,6 +12,7 @@ public protocol DictationRepositoryProtocol: Sendable {
     func deleteEmpty() throws -> Int
     func deleteHidden() throws
     func stats() throws -> DictationStats
+    func resetLifetimeStats() throws
 }
 
 public struct DictationStats: Sendable, Equatable {
@@ -312,6 +313,22 @@ public final class DictationRepository: DictationRepositoryProtocol {
             arguments: [durationDelta, wordDelta, newDurationMs, now]
         )
         guard db.changesCount == 1 else { throw LifetimeStatsError.singletonMissing }
+    }
+
+    /// User-initiated zeroing of lifetime stats. Independent of dictation deletion —
+    /// the symmetric counterpart to `deleteAll()`: rows preserved, counters reset.
+    /// Uses INSERT OR REPLACE so it self-heals if the singleton row is missing.
+    public func resetLifetimeStats() throws {
+        try dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    INSERT OR REPLACE INTO lifetime_dictation_stats
+                      (id, totalCount, totalDurationMs, totalWords, longestDurationMs, updatedAt)
+                    VALUES (1, 0, 0, 0, 0, ?)
+                    """,
+                arguments: [Date()]
+            )
+        }
     }
 
     /// Recovery / migration path: rebuild the singleton row from current dictations.

--- a/Sources/MacParakeetCore/Database/DictationRepository.swift
+++ b/Sources/MacParakeetCore/Database/DictationRepository.swift
@@ -15,14 +15,23 @@ public protocol DictationRepositoryProtocol: Sendable {
 }
 
 public struct DictationStats: Sendable, Equatable {
+    /// Lifetime count of completed dictations. Survives history deletion (issue #124).
     public let totalCount: Int
-    /// Count of non-hidden (visible) dictations only. Use for UI that operates on visible rows (e.g. "Clear All").
+    /// Currently-visible (non-hidden) completed dictations. Reflects the user's history right now,
+    /// drops to 0 after "Clear All Dictations".
     public let visibleCount: Int
+    /// Lifetime sum of dictation durations (ms). Survives history deletion.
     public let totalDurationMs: Int
+    /// Lifetime sum of dictated words. Survives history deletion.
     public let totalWords: Int
+    /// Lifetime longest single dictation (ms). High-water mark — only ever increases.
     public let longestDurationMs: Int
+    /// Lifetime average duration (ms), derived from totalDurationMs / totalCount.
     public let averageDurationMs: Int
+    /// Current weekly streak. Derived from existing dictation rows; resets when history is cleared
+    /// (intentional — this is "are you on a streak right now?", not a lifetime metric).
     public let weeklyStreak: Int
+    /// Dictations completed this calendar week, derived from existing rows.
     public let dictationsThisWeek: Int
 
     public static let empty = DictationStats(totalCount: 0, visibleCount: 0, totalDurationMs: 0)
@@ -78,6 +87,13 @@ public extension DictationStats {
     }
 }
 
+public enum LifetimeStatsError: Error {
+    /// Raised when the singleton lifetime_dictation_stats row is missing during a hot-path
+    /// UPDATE. The recompute helper is the recovery path; the increment helpers fail loudly
+    /// to surface invariant violations (e.g. someone manually truncated the table in tests).
+    case singletonMissing
+}
+
 public final class DictationRepository: DictationRepositoryProtocol {
     private let dbQueue: DatabaseQueue
 
@@ -87,7 +103,34 @@ public final class DictationRepository: DictationRepositoryProtocol {
 
     public func save(_ dictation: Dictation) throws {
         try dbQueue.write { db in
+            // MUST fetch existing state BEFORE dictation.save(db). The delta path depends on
+            // the pre-write durationMs / wordCount / status. Reordering would silently turn
+            // every delta-path save into a zero-delta no-op.
+            let existing = try Dictation.fetchOne(db, key: dictation.id)
             try dictation.save(db)
+
+            switch (existing?.status, dictation.status) {
+            case (.some(.completed), .completed):
+                // Mutating an already-counted row (e.g. a future "edit transcript" path).
+                // Apply the delta. longestDurationMs is a high-water mark — never decrements.
+                let prior = existing!  // guaranteed by .some(.completed) match
+                try Self.applyLifetimeDelta(
+                    db: db,
+                    durationDelta: dictation.durationMs - prior.durationMs,
+                    wordDelta: dictation.wordCount - prior.wordCount,
+                    newDurationMs: dictation.durationMs
+                )
+            case (_, .completed):
+                // Fresh insert at .completed, or transition (.recording / .processing /
+                // .error → .completed). Increment by the full row.
+                try Self.incrementLifetimeStats(
+                    db: db,
+                    durationMs: dictation.durationMs,
+                    wordCount: dictation.wordCount
+                )
+            default:
+                break
+            }
         }
     }
 
@@ -180,30 +223,29 @@ public final class DictationRepository: DictationRepositoryProtocol {
 
     public func stats() throws -> DictationStats {
         try dbQueue.read { db in
-            // Numeric aggregates in SQL — includes hidden rows for complete stats
-            let row = try Row.fetchOne(db, sql: """
-                SELECT
-                    COUNT(*) AS cnt,
-                    SUM(CASE WHEN hidden = 0 THEN 1 ELSE 0 END) AS visibleCnt,
-                    COALESCE(SUM(durationMs), 0) AS totalDur,
-                    COALESCE(MAX(durationMs), 0) AS maxDur,
-                    CASE WHEN COUNT(*) > 0
-                        THEN COALESCE(SUM(durationMs), 0) / COUNT(*)
-                        ELSE 0
-                    END AS avgDur,
-                    COALESCE(SUM(wordCount), 0) AS totalWords
-                FROM dictations
-                WHERE status = 'completed'
+            // Lifetime totals — survive history deletion (issue #124).
+            let lifetime = try Row.fetchOne(db, sql: """
+                SELECT totalCount, totalDurationMs, totalWords, longestDurationMs
+                FROM lifetime_dictation_stats WHERE id = 1
                 """)
+            let totalCount: Int = lifetime?["totalCount"] ?? 0
+            let totalDuration: Int = lifetime?["totalDurationMs"] ?? 0
+            let totalWords: Int = lifetime?["totalWords"] ?? 0
+            let longestDuration: Int = lifetime?["longestDurationMs"] ?? 0
+            let averageDuration = totalCount > 0 ? totalDuration / totalCount : 0
 
-            let count: Int = row?["cnt"] ?? 0
-            let visibleCount: Int = row?["visibleCnt"] ?? 0
-            let totalDuration: Int = row?["totalDur"] ?? 0
-            let maxDuration: Int = row?["maxDur"] ?? 0
-            let avgDuration: Int = row?["avgDur"] ?? 0
-            let totalWords: Int = row?["totalWords"] ?? 0
+            // visibleCount reflects what's currently in the user's history.
+            let visibleCount: Int = try Int.fetchOne(
+                db,
+                sql: """
+                    SELECT COUNT(*) FROM dictations
+                    WHERE status = 'completed' AND hidden = 0
+                    """
+            ) ?? 0
 
-            // Weekly streak includes all completed rows (hidden contribute to streak)
+            // Weekly streak / this-week derived from current rows (intentionally
+            // resets when the user clears history — it's "are you on a streak right
+            // now?", not a lifetime metric).
             let dates = try Date.fetchAll(
                 db,
                 sql: "SELECT createdAt FROM dictations WHERE status = 'completed' ORDER BY createdAt DESC"
@@ -211,16 +253,86 @@ public final class DictationRepository: DictationRepositoryProtocol {
             let (streak, thisWeek) = Self.computeWeeklyStreak(from: dates)
 
             return DictationStats(
-                totalCount: count,
+                totalCount: totalCount,
                 visibleCount: visibleCount,
                 totalDurationMs: totalDuration,
                 totalWords: totalWords,
-                longestDurationMs: maxDuration,
-                averageDurationMs: avgDuration,
+                longestDurationMs: longestDuration,
+                averageDurationMs: averageDuration,
                 weeklyStreak: streak,
                 dictationsThisWeek: thisWeek
             )
         }
+    }
+
+    // MARK: - Lifetime stats helpers (issue #124)
+
+    /// Hot-path increment for a newly-completed dictation. UPDATE-only — asserts the
+    /// singleton row exists; throws `LifetimeStatsError.singletonMissing` if not.
+    static func incrementLifetimeStats(
+        db: Database,
+        durationMs: Int,
+        wordCount: Int,
+        now: Date = Date()
+    ) throws {
+        try db.execute(
+            sql: """
+                UPDATE lifetime_dictation_stats
+                SET totalCount        = totalCount + 1,
+                    totalDurationMs   = totalDurationMs + ?,
+                    totalWords        = totalWords + ?,
+                    longestDurationMs = MAX(longestDurationMs, ?),
+                    updatedAt         = ?
+                WHERE id = 1
+                """,
+            arguments: [durationMs, wordCount, durationMs, now]
+        )
+        guard db.changesCount == 1 else { throw LifetimeStatsError.singletonMissing }
+    }
+
+    /// Hot-path delta apply for an already-counted row whose duration / wordCount
+    /// changed (e.g. a future "edit transcript" feature). Does not touch totalCount.
+    /// longestDurationMs is a high-water mark and only ever increases.
+    static func applyLifetimeDelta(
+        db: Database,
+        durationDelta: Int,
+        wordDelta: Int,
+        newDurationMs: Int,
+        now: Date = Date()
+    ) throws {
+        try db.execute(
+            sql: """
+                UPDATE lifetime_dictation_stats
+                SET totalDurationMs   = totalDurationMs + ?,
+                    totalWords        = totalWords + ?,
+                    longestDurationMs = MAX(longestDurationMs, ?),
+                    updatedAt         = ?
+                WHERE id = 1
+                """,
+            arguments: [durationDelta, wordDelta, newDurationMs, now]
+        )
+        guard db.changesCount == 1 else { throw LifetimeStatsError.singletonMissing }
+    }
+
+    /// Recovery / migration path: rebuild the singleton row from current dictations.
+    /// Uses INSERT OR REPLACE so it self-heals even if the row was deleted. Caller
+    /// must pass an open `Database` handle (already inside a write transaction).
+    public static func recomputeLifetimeStats(db: Database, now: Date = Date()) throws {
+        try db.execute(
+            sql: """
+                INSERT OR REPLACE INTO lifetime_dictation_stats
+                  (id, totalCount, totalDurationMs, totalWords, longestDurationMs, updatedAt)
+                SELECT 1,
+                       COUNT(*),
+                       COALESCE(SUM(durationMs), 0),
+                       COALESCE(SUM(wordCount), 0),
+                       COALESCE(MAX(durationMs), 0),
+                       ?
+                FROM dictations
+                WHERE status = 'completed'
+                """,
+            arguments: [now]
+        )
     }
 
     /// Counts words by splitting on whitespace runs. Exact for any input.

--- a/Sources/MacParakeetCore/Database/DictationRepository.swift
+++ b/Sources/MacParakeetCore/Database/DictationRepository.swift
@@ -12,6 +12,8 @@ public protocol DictationRepositoryProtocol: Sendable {
     func deleteEmpty() throws -> Int
     func deleteHidden() throws
     func stats() throws -> DictationStats
+    /// Zero the lifetime stats counter row without touching any dictation rows.
+    /// Symmetric counterpart to `deleteAll()` (rows deleted, stats preserved).
     func resetLifetimeStats() throws
 }
 

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -590,6 +590,20 @@ public final class SettingsViewModel {
         onDictationsCleared?()
     }
 
+    /// Zero the lifetime stats counters. Symmetric to `clearAllDictations()` —
+    /// dictation rows are preserved; only the lifetime totals (total words,
+    /// total time, total count, longest dictation) are reset.
+    public func resetLifetimeStats() {
+        guard let repo = dictationRepo else { return }
+        do {
+            try repo.resetLifetimeStats()
+        } catch {
+            logger.error("Failed to reset lifetime stats error=\(error.localizedDescription, privacy: .public)")
+        }
+        refreshStats()
+        onDictationsCleared?()
+    }
+
     public func clearDownloadedYouTubeAudio() {
         let dir = youtubeDownloadsDirPath()
         let fm = FileManager.default

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -565,29 +565,22 @@ public final class SettingsViewModel {
 
     public func clearAllDictations() {
         guard let repo = dictationRepo else { return }
+        // `deleteAll()` only removes visible (hidden = 0) rows; `deleteHidden()`
+        // covers the metric-only entries created when "Save dictation history" was
+        // off. Together they truly clear all dictation rows. Each runs in its own
+        // GRDB write transaction; partial failure is logged but never silently
+        // corrupts state because the row counts are independent.
         do {
             try repo.deleteAll()
+            try repo.deleteHidden()
         } catch {
-            logger.error("Failed to delete all dictations error=\(error.localizedDescription, privacy: .public)")
+            logger.error("Failed to clear dictations error=\(error.localizedDescription, privacy: .public)")
         }
         // Also remove any saved audio files (best effort).
         let dir = AppPaths.dictationsDir
         if FileManager.default.fileExists(atPath: dir) {
             try? FileManager.default.removeItem(atPath: dir)
             try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        }
-        refreshStats()
-        onDictationStateChanged?()
-    }
-
-    /// Delete dictations marked private (`hidden = 1`). These are the metric-only
-    /// rows produced when "Save dictation history" is off.
-    public func deletePrivateDictations() {
-        guard let repo = dictationRepo else { return }
-        do {
-            try repo.deleteHidden()
-        } catch {
-            logger.error("Failed to delete private dictations error=\(error.localizedDescription, privacy: .public)")
         }
         refreshStats()
         onDictationStateChanged?()

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -559,8 +559,9 @@ public final class SettingsViewModel {
         }
     }
 
-    /// Called after dictations are cleared so other VMs (e.g. history) can reload.
-    public var onDictationsCleared: (() -> Void)?
+    /// Fired after a dictation-state change (rows deleted or lifetime counters reset)
+    /// so other VMs (e.g. the history view) can reload their derived data.
+    public var onDictationStateChanged: (() -> Void)?
 
     public func clearAllDictations() {
         guard let repo = dictationRepo else { return }
@@ -576,18 +577,20 @@ public final class SettingsViewModel {
             try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
         }
         refreshStats()
-        onDictationsCleared?()
+        onDictationStateChanged?()
     }
 
-    public func resetPrivateStatistics() {
+    /// Delete dictations marked private (`hidden = 1`). These are the metric-only
+    /// rows produced when "Save dictation history" is off.
+    public func deletePrivateDictations() {
         guard let repo = dictationRepo else { return }
         do {
             try repo.deleteHidden()
         } catch {
-            logger.error("Failed to delete hidden dictations error=\(error.localizedDescription, privacy: .public)")
+            logger.error("Failed to delete private dictations error=\(error.localizedDescription, privacy: .public)")
         }
         refreshStats()
-        onDictationsCleared?()
+        onDictationStateChanged?()
     }
 
     /// Zero the lifetime stats counters. Symmetric to `clearAllDictations()` —
@@ -601,7 +604,7 @@ public final class SettingsViewModel {
             logger.error("Failed to reset lifetime stats error=\(error.localizedDescription, privacy: .public)")
         }
         refreshStats()
-        onDictationsCleared?()
+        onDictationStateChanged?()
     }
 
     public func clearDownloadedYouTubeAudio() {

--- a/Tests/MacParakeetTests/Database/DatabaseManagerTests.swift
+++ b/Tests/MacParakeetTests/Database/DatabaseManagerTests.swift
@@ -133,6 +133,9 @@ final class DatabaseManagerTests: XCTestCase {
                 )
             """)
 
+            // dictations table is required by the v0.7.4 lifetime stats backfill.
+            try Self.createV05DictationsTable(db: db)
+
             try db.execute(sql: """
                 CREATE TABLE text_snippets (
                     id TEXT PRIMARY KEY,
@@ -236,6 +239,9 @@ final class DatabaseManagerTests: XCTestCase {
                 )
             """)
 
+            // dictations table is required by the v0.7.4 lifetime stats backfill.
+            try Self.createV05DictationsTable(db: db)
+
             try db.execute(
                 sql: """
                     INSERT INTO transcriptions (
@@ -293,5 +299,28 @@ final class DatabaseManagerTests: XCTestCase {
 
         // Clean up
         try? FileManager.default.removeItem(atPath: dbPath)
+    }
+
+    /// Recreates the dictations table at its v0.5 shape (after `v0.5-private-dictation`
+    /// added `hidden` and `wordCount`). Used by partial-migration test fixtures so the
+    /// v0.7.4 lifetime-stats backfill has a real table to read from.
+    static func createV05DictationsTable(db: Database) throws {
+        try db.execute(sql: """
+            CREATE TABLE dictations (
+                id TEXT PRIMARY KEY,
+                createdAt TEXT NOT NULL,
+                durationMs INTEGER NOT NULL,
+                rawTranscript TEXT NOT NULL,
+                cleanTranscript TEXT,
+                audioPath TEXT,
+                pastedToApp TEXT,
+                processingMode TEXT NOT NULL DEFAULT 'raw',
+                status TEXT NOT NULL DEFAULT 'completed',
+                errorMessage TEXT,
+                updatedAt TEXT NOT NULL,
+                hidden INTEGER NOT NULL DEFAULT 0,
+                wordCount INTEGER NOT NULL DEFAULT 0
+            )
+        """)
     }
 }

--- a/Tests/MacParakeetTests/Database/LifetimeDictationStatsTests.swift
+++ b/Tests/MacParakeetTests/Database/LifetimeDictationStatsTests.swift
@@ -60,7 +60,7 @@ final class LifetimeDictationStatsTests: XCTestCase {
     // MARK: - Idempotency
 
     func testReSavingCompletedDictationWithSameValuesDoesNotDoubleCount() throws {
-        var d = Dictation(durationMs: 1000, rawTranscript: "hello", wordCount: 1)
+        let d = Dictation(durationMs: 1000, rawTranscript: "hello", wordCount: 1)
         try repo.save(d)
         try repo.save(d)  // identical re-save → zero delta
         try repo.save(d)
@@ -224,6 +224,29 @@ final class LifetimeDictationStatsTests: XCTestCase {
         XCTAssertEqual(stats.totalCount, 2)
         XCTAssertEqual(stats.totalDurationMs, 4000)
         XCTAssertEqual(stats.totalWords, 3)
+    }
+
+    func testStatsSelfHealsIfSingletonRowMissing() throws {
+        // stats() must rebuild from `dictations` rather than silently reporting zeros
+        // when the singleton row is absent — otherwise we'd mask the same invariant
+        // violation the hot write path throws on.
+        try repo.save(Dictation(durationMs: 1500, rawTranscript: "a", wordCount: 1))
+        try repo.save(Dictation(durationMs: 2500, rawTranscript: "b b", wordCount: 2))
+
+        try manager.dbQueue.write { db in
+            try db.execute(sql: "DELETE FROM lifetime_dictation_stats WHERE id = 1")
+        }
+
+        let stats = try repo.stats()
+        XCTAssertEqual(stats.totalCount, 2, "stats() must self-heal from dictations, not return 0")
+        XCTAssertEqual(stats.totalDurationMs, 4000)
+        XCTAssertEqual(stats.totalWords, 3)
+
+        // Row is persisted after the heal — next save's UPDATE hot-path finds it.
+        let countAfter = try manager.dbQueue.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM lifetime_dictation_stats WHERE id = 1") ?? 0
+        }
+        XCTAssertEqual(countAfter, 1)
     }
 
     // MARK: - User-initiated reset

--- a/Tests/MacParakeetTests/Database/LifetimeDictationStatsTests.swift
+++ b/Tests/MacParakeetTests/Database/LifetimeDictationStatsTests.swift
@@ -1,0 +1,228 @@
+import XCTest
+import GRDB
+@testable import MacParakeetCore
+
+/// Tests for the lifetime_dictation_stats table that survives history deletion (issue #124).
+final class LifetimeDictationStatsTests: XCTestCase {
+    var manager: DatabaseManager!
+    var repo: DictationRepository!
+
+    override func setUp() async throws {
+        manager = try DatabaseManager()
+        repo = DictationRepository(dbQueue: manager.dbQueue)
+    }
+
+    // MARK: - Deletion preserves lifetime totals (the #124 bug)
+
+    func testLifetimeStatsPersistAfterDeleteAll() throws {
+        try repo.save(Dictation(durationMs: 1000, rawTranscript: "one", wordCount: 1))
+        try repo.save(Dictation(durationMs: 2000, rawTranscript: "two two", wordCount: 2))
+        try repo.save(Dictation(durationMs: 3000, rawTranscript: "three three three", wordCount: 3))
+
+        try repo.deleteAll()
+
+        let stats = try repo.stats()
+        XCTAssertEqual(stats.totalCount, 3, "lifetime totalCount must survive deleteAll")
+        XCTAssertEqual(stats.totalDurationMs, 6000)
+        XCTAssertEqual(stats.totalWords, 6)
+        XCTAssertEqual(stats.visibleCount, 0, "visibleCount reflects current rows, drops to 0")
+    }
+
+    func testLifetimeStatsPersistAfterDeleteHidden() throws {
+        let visible = Dictation(durationMs: 1000, rawTranscript: "visible", wordCount: 1)
+        var hidden = Dictation(durationMs: 4000, rawTranscript: "hidden", wordCount: 2)
+        hidden.hidden = true
+
+        try repo.save(visible)
+        try repo.save(hidden)
+        try repo.deleteHidden()
+
+        let stats = try repo.stats()
+        XCTAssertEqual(stats.totalCount, 2, "hidden row contributed to lifetime, survives delete")
+        XCTAssertEqual(stats.totalDurationMs, 5000)
+        XCTAssertEqual(stats.totalWords, 3)
+    }
+
+    func testLifetimeStatsPersistAfterSingleDelete() throws {
+        let d1 = Dictation(durationMs: 1000, rawTranscript: "one", wordCount: 1)
+        let d2 = Dictation(durationMs: 2000, rawTranscript: "two", wordCount: 1)
+        try repo.save(d1)
+        try repo.save(d2)
+
+        XCTAssertTrue(try repo.delete(id: d1.id))
+
+        let stats = try repo.stats()
+        XCTAssertEqual(stats.totalCount, 2)
+        XCTAssertEqual(stats.totalDurationMs, 3000)
+        XCTAssertEqual(stats.visibleCount, 1)
+    }
+
+    // MARK: - Idempotency
+
+    func testReSavingCompletedDictationWithSameValuesDoesNotDoubleCount() throws {
+        var d = Dictation(durationMs: 1000, rawTranscript: "hello", wordCount: 1)
+        try repo.save(d)
+        try repo.save(d)  // identical re-save → zero delta
+        try repo.save(d)
+
+        let stats = try repo.stats()
+        XCTAssertEqual(stats.totalCount, 1)
+        XCTAssertEqual(stats.totalDurationMs, 1000)
+        XCTAssertEqual(stats.totalWords, 1)
+    }
+
+    func testReSavingCompletedDictationWithChangedWordCountAppliesDelta() throws {
+        var d = Dictation(durationMs: 2000, rawTranscript: "hello", wordCount: 5)
+        try repo.save(d)
+
+        d.wordCount = 8  // mutate as if a future "edit transcript" feature ran
+        d.durationMs = 3000
+        try repo.save(d)
+
+        let stats = try repo.stats()
+        XCTAssertEqual(stats.totalCount, 1, "totalCount unchanged on delta path")
+        XCTAssertEqual(stats.totalWords, 8, "delta lifted totalWords from 5 to 8 (not 13)")
+        XCTAssertEqual(stats.totalDurationMs, 3000)
+    }
+
+    // MARK: - Status guards
+
+    func testStatusTransitionToCompletedIncrementsExactlyOnce() throws {
+        var d = Dictation(durationMs: 1000, rawTranscript: "hi", status: .recording, wordCount: 1)
+        try repo.save(d)
+
+        XCTAssertEqual(try repo.stats().totalCount, 0, ".recording does not increment")
+
+        d.status = .completed
+        try repo.save(d)
+
+        XCTAssertEqual(try repo.stats().totalCount, 1)
+    }
+
+    func testErrorStatusDoesNotIncrementLifetime() throws {
+        try repo.save(Dictation(durationMs: 5000, rawTranscript: "bad", status: .error, wordCount: 3))
+
+        let stats = try repo.stats()
+        XCTAssertEqual(stats.totalCount, 0)
+        XCTAssertEqual(stats.totalWords, 0)
+        XCTAssertEqual(stats.totalDurationMs, 0)
+    }
+
+    func testRecordingStatusDoesNotIncrementLifetime() throws {
+        try repo.save(Dictation(durationMs: 5000, rawTranscript: "wip", status: .recording, wordCount: 3))
+
+        let stats = try repo.stats()
+        XCTAssertEqual(stats.totalCount, 0)
+        XCTAssertEqual(stats.totalWords, 0)
+    }
+
+    // MARK: - Hidden rows
+
+    func testHiddenDictationsContributeToLifetime() throws {
+        var hidden = Dictation(durationMs: 4000, rawTranscript: "private", wordCount: 5)
+        hidden.hidden = true
+        try repo.save(hidden)
+
+        let stats = try repo.stats()
+        XCTAssertEqual(stats.totalCount, 1, "hidden dictations count toward lifetime")
+        XCTAssertEqual(stats.totalWords, 5)
+        XCTAssertEqual(stats.totalDurationMs, 4000)
+        XCTAssertEqual(stats.visibleCount, 0)
+    }
+
+    // MARK: - longestDurationMs as high-water mark
+
+    func testLongestDurationIsLifetimeMax() throws {
+        let big = Dictation(durationMs: 5000, rawTranscript: "long", wordCount: 1)
+        try repo.save(big)
+        XCTAssertTrue(try repo.delete(id: big.id))
+
+        try repo.save(Dictation(durationMs: 1000, rawTranscript: "short", wordCount: 1))
+
+        XCTAssertEqual(try repo.stats().longestDurationMs, 5000, "high-water mark survives deletion")
+    }
+
+    func testLongestDurationDoesNotDecreaseOnDelta() throws {
+        var d = Dictation(durationMs: 5000, rawTranscript: "long", wordCount: 1)
+        try repo.save(d)
+
+        d.durationMs = 1000  // shrunk via re-save
+        try repo.save(d)
+
+        XCTAssertEqual(try repo.stats().longestDurationMs, 5000, "high-water mark — no decrement on delta")
+    }
+
+    // MARK: - Empty / fresh DB
+
+    func testEmptyDatabaseLifetimeStatsAreZero() throws {
+        let stats = try repo.stats()
+        XCTAssertEqual(stats.totalCount, 0)
+        XCTAssertEqual(stats.totalDurationMs, 0)
+        XCTAssertEqual(stats.totalWords, 0)
+        XCTAssertEqual(stats.longestDurationMs, 0)
+        XCTAssertEqual(stats.averageDurationMs, 0)
+    }
+
+    // MARK: - Cross-check: incremental vs. recompute
+
+    func testRecomputeMatchesIncrementalAccumulation() throws {
+        try repo.save(Dictation(durationMs: 1000, rawTranscript: "a a", wordCount: 2))
+        try repo.save(Dictation(durationMs: 2500, rawTranscript: "b b b", wordCount: 3))
+        try repo.save(Dictation(durationMs: 4000, rawTranscript: "c", wordCount: 1))
+
+        let incremental = try repo.stats()
+
+        // Recompute from current dictations — should produce identical lifetime totals
+        // because no rows have been deleted yet.
+        try manager.dbQueue.write { db in
+            try DictationRepository.recomputeLifetimeStats(db: db)
+        }
+        let recomputed = try repo.stats()
+
+        XCTAssertEqual(incremental.totalCount, recomputed.totalCount)
+        XCTAssertEqual(incremental.totalDurationMs, recomputed.totalDurationMs)
+        XCTAssertEqual(incremental.totalWords, recomputed.totalWords)
+        XCTAssertEqual(incremental.longestDurationMs, recomputed.longestDurationMs)
+    }
+
+    // MARK: - Singleton-missing safety
+
+    func testIncrementThrowsIfSingletonRowMissing() throws {
+        // Manually wipe the singleton row to simulate corruption.
+        try manager.dbQueue.write { db in
+            try db.execute(sql: "DELETE FROM lifetime_dictation_stats WHERE id = 1")
+        }
+
+        XCTAssertThrowsError(
+            try repo.save(Dictation(durationMs: 1000, rawTranscript: "x", wordCount: 1))
+        ) { error in
+            guard case LifetimeStatsError.singletonMissing = error else {
+                return XCTFail("expected singletonMissing, got \(error)")
+            }
+        }
+
+        // Transaction rolled back — the dictation must not have been saved either.
+        let count = try manager.dbQueue.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM dictations") ?? 0
+        }
+        XCTAssertEqual(count, 0, "save() transaction must roll back when increment throws")
+    }
+
+    // MARK: - Recovery via recompute
+
+    func testRecomputeSelfHealsAfterSingletonDeletion() throws {
+        try repo.save(Dictation(durationMs: 1500, rawTranscript: "a", wordCount: 1))
+        try repo.save(Dictation(durationMs: 2500, rawTranscript: "b b", wordCount: 2))
+
+        // Wipe the lifetime row entirely.
+        try manager.dbQueue.write { db in
+            try db.execute(sql: "DELETE FROM lifetime_dictation_stats WHERE id = 1")
+            try DictationRepository.recomputeLifetimeStats(db: db)
+        }
+
+        let stats = try repo.stats()
+        XCTAssertEqual(stats.totalCount, 2)
+        XCTAssertEqual(stats.totalDurationMs, 4000)
+        XCTAssertEqual(stats.totalWords, 3)
+    }
+}

--- a/Tests/MacParakeetTests/Database/LifetimeDictationStatsTests.swift
+++ b/Tests/MacParakeetTests/Database/LifetimeDictationStatsTests.swift
@@ -225,4 +225,48 @@ final class LifetimeDictationStatsTests: XCTestCase {
         XCTAssertEqual(stats.totalDurationMs, 4000)
         XCTAssertEqual(stats.totalWords, 3)
     }
+
+    // MARK: - User-initiated reset
+
+    func testResetLifetimeStatsZeroesCountersWithoutDeletingDictations() throws {
+        try repo.save(Dictation(durationMs: 5000, rawTranscript: "hello world", wordCount: 2))
+        try repo.save(Dictation(durationMs: 3000, rawTranscript: "again", wordCount: 1))
+        XCTAssertEqual(try repo.stats().totalCount, 2)
+
+        try repo.resetLifetimeStats()
+
+        let stats = try repo.stats()
+        XCTAssertEqual(stats.totalCount, 0)
+        XCTAssertEqual(stats.totalDurationMs, 0)
+        XCTAssertEqual(stats.totalWords, 0)
+        XCTAssertEqual(stats.longestDurationMs, 0)
+
+        // Dictation rows are preserved — symmetric counterpart to deleteAll().
+        XCTAssertEqual(try repo.fetchAll(limit: nil).count, 2)
+        XCTAssertEqual(stats.visibleCount, 2)
+    }
+
+    func testResetLifetimeStatsThenSaveContinuesAccumulating() throws {
+        try repo.save(Dictation(durationMs: 5000, rawTranscript: "old", wordCount: 1))
+        try repo.resetLifetimeStats()
+        try repo.save(Dictation(durationMs: 1000, rawTranscript: "fresh start", wordCount: 2))
+
+        let stats = try repo.stats()
+        XCTAssertEqual(stats.totalCount, 1, "only the post-reset save counts")
+        XCTAssertEqual(stats.totalWords, 2)
+        XCTAssertEqual(stats.totalDurationMs, 1000)
+    }
+
+    func testResetLifetimeStatsSelfHealsIfSingletonRowMissing() throws {
+        try repo.save(Dictation(durationMs: 1000, rawTranscript: "x", wordCount: 1))
+        try manager.dbQueue.write { db in
+            try db.execute(sql: "DELETE FROM lifetime_dictation_stats WHERE id = 1")
+        }
+
+        // Reset uses INSERT OR REPLACE — should not throw even with row missing.
+        XCTAssertNoThrow(try repo.resetLifetimeStats())
+
+        let stats = try repo.stats()
+        XCTAssertEqual(stats.totalCount, 0)
+    }
 }

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -441,6 +441,29 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.dictationCount, 0)
     }
 
+    func testClearAllDictationsAlsoDeletesPrivateRows() {
+        // "Clear All" must wipe both visible and hidden (metric-only) rows.
+        var hidden = Dictation(durationMs: 4000, rawTranscript: "")
+        hidden.hidden = true
+        mockRepo.dictations = [
+            Dictation(durationMs: 1000, rawTranscript: "Visible"),
+            hidden,
+        ]
+
+        viewModel.configure(
+            permissionService: mockPermissions,
+            dictationRepo: mockRepo,
+            entitlementsService: entitlements,
+            checkoutURL: nil
+        )
+
+        viewModel.clearAllDictations()
+
+        XCTAssertTrue(mockRepo.deleteAllCalled, "deleteAll() must run")
+        XCTAssertTrue(mockRepo.deleteHiddenCalled, "deleteHidden() must run too — 'All' means all")
+        XCTAssertTrue(mockRepo.dictations.isEmpty, "no dictation rows survive Clear All")
+    }
+
     // MARK: - Reset Lifetime Stats (#124)
 
     func testResetLifetimeStatsCallsRepo() {

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -441,6 +441,27 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.dictationCount, 0)
     }
 
+    // MARK: - Reset Lifetime Stats (#124)
+
+    func testResetLifetimeStatsCallsRepo() {
+        mockRepo.dictations = [
+            Dictation(durationMs: 1000, rawTranscript: "One"),
+        ]
+
+        viewModel.configure(
+            permissionService: mockPermissions,
+            dictationRepo: mockRepo,
+            entitlementsService: entitlements,
+            checkoutURL: nil
+        )
+
+        viewModel.resetLifetimeStats()
+
+        XCTAssertTrue(mockRepo.resetLifetimeStatsCalled)
+        XCTAssertFalse(mockRepo.deleteAllCalled, "Reset should not delete dictation rows")
+        XCTAssertEqual(viewModel.dictationCount, 1, "Dictation count must survive lifetime reset")
+    }
+
     // MARK: - Unconfigured
 
     func testRefreshStatsBeforeConfigureIsNoOp() {
@@ -451,6 +472,12 @@ final class SettingsViewModelTests: XCTestCase {
     func testClearAllBeforeConfigureIsNoOp() {
         // Should not crash
         viewModel.clearAllDictations()
+        XCTAssertEqual(viewModel.dictationCount, 0)
+    }
+
+    func testResetLifetimeStatsBeforeConfigureIsNoOp() {
+        // Should not crash
+        viewModel.resetLifetimeStats()
         XCTAssertEqual(viewModel.dictationCount, 0)
     }
 

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -478,11 +478,18 @@ final class SettingsViewModelTests: XCTestCase {
             checkoutURL: nil
         )
 
+        var stateChangedFireCount = 0
+        viewModel.onDictationStateChanged = { stateChangedFireCount += 1 }
+
         viewModel.resetLifetimeStats()
 
         XCTAssertTrue(mockRepo.resetLifetimeStatsCalled)
         XCTAssertFalse(mockRepo.deleteAllCalled, "Reset should not delete dictation rows")
         XCTAssertEqual(viewModel.dictationCount, 1, "Dictation count must survive lifetime reset")
+        XCTAssertEqual(
+            stateChangedFireCount, 1,
+            "onDictationStateChanged must fire once so dependent views (e.g. history) reload derived stats"
+        )
     }
 
     // MARK: - Unconfigured

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -71,6 +71,11 @@ final class MockDictationRepository: DictationRepositoryProtocol, @unchecked Sen
         dictations.removeAll { $0.hidden }
     }
 
+    var resetLifetimeStatsCalled = false
+    func resetLifetimeStats() throws {
+        resetLifetimeStatsCalled = true
+    }
+
     func stats() throws -> DictationStats {
         statsCallCount += 1
         let completed = dictations.filter { $0.status == .completed }

--- a/plans/completed/2026-04-lifetime-dictation-stats.md
+++ b/plans/completed/2026-04-lifetime-dictation-stats.md
@@ -1,0 +1,221 @@
+# Lifetime Dictation Stats (Issue #124)
+
+## Problem
+
+Reported in [#124](https://github.com/moona3k/macparakeet/issues/124): user cleared their dictation history and watched their voice stats reset from "thousands of words" to "2 minutes spoken." Privacy housekeeping should not double as a stats reset.
+
+Root cause: `DictationRepository.stats()` (`Sources/MacParakeetCore/Database/DictationRepository.swift:181`) is pure SQL aggregation over the `dictations` table — totals are *derived from rows that the user just deleted*. There is no persistent counter.
+
+## Design Goals
+
+1. Headline lifetime numbers — total words, total time, total dictations, longest dictation — survive any deletion path (`deleteAll`, `deleteHidden`, `delete(id:)`, future single-row deletes from history UI).
+2. No new "Total ever" UI affordance. The existing "Your Voice Stats" card and CLI just start meaning "lifetime" instead of "currently in your history."
+3. Do not regress streak / this-week semantics (those are inherently about *recent activity*, not lifetime, so keep them derived from current rows).
+4. Stay invisible at the call-site level. Existing callers of `repo.save(dictation)` keep working unchanged.
+5. Backfill on first launch after upgrade so existing users do not see a one-off reset to zero. (We cannot recover what was already lost in #124, but we can honor what is currently still in the DB.)
+
+## Non-Goals
+
+- No per-event archival log. We do not need to reconstruct a historical timeline.
+- No public/private split for lifetime totals. Hidden dictations *do* count — privacy is "no transcript stored," not "no metric ever derived."
+- No ADR. This is a localized data-model fix, not an architectural inflection.
+- No new telemetry event.
+
+## Schema
+
+New table, populated by migration `v0.7.4-lifetime-dictation-stats`:
+
+```sql
+CREATE TABLE lifetime_dictation_stats (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    totalCount INTEGER NOT NULL DEFAULT 0,
+    totalDurationMs INTEGER NOT NULL DEFAULT 0,
+    totalWords INTEGER NOT NULL DEFAULT 0,
+    longestDurationMs INTEGER NOT NULL DEFAULT 0,
+    updatedAt TEXT NOT NULL
+);
+```
+
+- Single-row pattern enforced by `CHECK (id = 1)`. The migration immediately calls `recomputeLifetimeStats(db:)` (the shared helper, see below), which uses `INSERT OR REPLACE` and seeds the row from existing data. After migration, the row is guaranteed present and every hot-path update is a plain `UPDATE … WHERE id=1`.
+
+## Increment Path
+
+In `DictationRepository.save()`. **Ordering is load-bearing**: fetch existing → write new → conditional counter touch. After `dictation.save(db)`, re-fetching would return the new values and break the delta math, so the existing-state fetch *must* happen first. Comment this in code.
+
+```swift
+public func save(_ dictation: Dictation) throws {
+    try dbQueue.write { db in
+        // MUST fetch existing state BEFORE dictation.save(db); the delta path
+        // depends on the pre-write status / durationMs / wordCount.
+        let existing = try Dictation.fetchOne(db, key: dictation.id)
+        try dictation.save(db)
+
+        switch (existing?.status, dictation.status) {
+        case (.some(.completed), .completed):
+            // Mutating an already-counted row (e.g. future "edit transcript" path).
+            // Apply the delta so totals don't drift. longestDurationMs stays a
+            // high-water mark — never decrements.
+            // existing is guaranteed non-nil on this branch (matched .some(.completed)).
+            let prior = existing!
+            try applyLifetimeDelta(
+                db: db,
+                durationDelta: dictation.durationMs - prior.durationMs,
+                wordDelta: dictation.wordCount - prior.wordCount,
+                newDurationMs: dictation.durationMs
+            )
+        case (_, .completed):
+            // Fresh insert at .completed, or transition from .recording / .processing
+            // / .error → .completed. Increment by full row.
+            try incrementLifetimeStats(
+                db: db,
+                durationMs: dictation.durationMs,
+                wordCount: dictation.wordCount
+            )
+        default:
+            break
+        }
+    }
+}
+```
+
+Both helpers run a single `UPDATE` against the singleton row and assert `db.changesCount == 1` afterwards — a missing or extra row throws `LifetimeStatsError.singletonMissing` instead of silently corrupting totals (real risk in tests where someone manually wipes the table).
+
+`incrementLifetimeStats`:
+```sql
+UPDATE lifetime_dictation_stats
+SET totalCount        = totalCount + 1,
+    totalDurationMs   = totalDurationMs + :durationMs,
+    totalWords        = totalWords + :wordCount,
+    longestDurationMs = MAX(longestDurationMs, :durationMs),
+    updatedAt         = :now
+WHERE id = 1;
+```
+
+`applyLifetimeDelta` (only fires on completed→completed mutation):
+```sql
+UPDATE lifetime_dictation_stats
+SET totalDurationMs   = totalDurationMs + :durationDelta,
+    totalWords        = totalWords + :wordDelta,
+    longestDurationMs = MAX(longestDurationMs, :newDurationMs),
+    updatedAt         = :now
+WHERE id = 1;
+```
+Note: `totalCount` does not change on a delta path (we already counted this dictation). `longestDurationMs` is a high-water mark — even if the row is shrunk, the lifetime max never decreases. This asymmetry is intentional and documented in the code comment.
+
+Properties this gives us:
+- **Atomic.** Fetch + insert/update + counter touch all run inside one GRDB write transaction. Either all commits or all rolls back.
+- **Drift-resistant.** Re-saving a completed row with mutated `wordCount` or `durationMs` updates the lifetime totals by delta, not skipped. (Today's code never does this, but a future "edit transcript" feature won't silently break stats.)
+- **Idempotent on identical re-save.** Saving a completed row with the same values produces zero deltas → no-op.
+- **Forward-compatible.** If we later split save into `recording → completed` transitions, the increment fires exactly once on the transition.
+- **Serialized.** GRDB `DatabaseQueue` enforces single-writer; no concurrency bug surface.
+- **Loud on corruption.** Singleton row missing? Throws, not silently drops increments.
+
+## Read Path
+
+`stats()` becomes a small composition:
+
+1. `SELECT totalCount, totalDurationMs, totalWords, longestDurationMs FROM lifetime_dictation_stats WHERE id = 1` — lifetime totals.
+2. `SELECT SUM(CASE WHEN hidden = 0 THEN 1 ELSE 0 END) FROM dictations WHERE status = 'completed'` — current `visibleCount` (unchanged semantic: "what's actually in your history right now").
+3. Existing date query → `weeklyStreak` and `dictationsThisWeek` (unchanged).
+4. `averageDurationMs` derived from lifetime totals in Swift, with explicit divide-by-zero guard: `totalCount > 0 ? totalDurationMs / totalCount : 0`.
+
+`DictationStats` struct is unchanged. Field semantics shift:
+
+| Field | Before | After |
+|---|---|---|
+| `totalCount` | rows currently in DB | lifetime completed dictations |
+| `totalDurationMs` | sum of current rows | lifetime sum |
+| `totalWords` | sum of current rows | lifetime sum |
+| `longestDurationMs` | max of current rows | lifetime max |
+| `averageDurationMs` | derived from current rows | derived from lifetime totals |
+| `visibleCount` | non-hidden current rows | unchanged |
+| `weeklyStreak` | from current rows | unchanged (derived, not lifetime — "are you on a streak right now?") |
+| `dictationsThisWeek` | from current rows | unchanged |
+
+Computed properties (`averageWPM`, `timeSavedMs`, `booksEquivalent`, `emailsEquivalent`) automatically follow because they read `totalWords` / `totalDurationMs`.
+
+## UI Impact
+
+`Sources/MacParakeet/Views/History/DictationHistoryView.swift:128`:
+```swift
+subtitle: "\(stats.totalCount) dictation\(stats.totalCount == 1 ? "" : "s")"
+```
+This subtitle now reads "lifetime dictations" rather than "rows in your history."
+
+**Conscious tradeoff acknowledged from review:** right after a "Clear All Dictations" action, the stats card will show e.g. "847 dictations · 12 hours" while the history list directly below it is empty. This is intentional and matches the user request in #124 — they explicitly want lifetime numbers preserved through deletion. The mismatch is the *correct* signal ("here's your lifetime voice output; here's your current retained history"). If real users find this confusing post-ship, the cleanest follow-up is to add a parallel `lifetimeXxx` field set on `DictationStats` and split the UI into a lifetime card + a current-history card. Not doing that now — extra surface area for a hypothetical complaint.
+
+`Sources/CLI/Commands/StatsCommand.swift:34` prints `Total: \(stats.visibleCount)` — leave as-is. CLI "Total" stays "currently visible." If we want to also surface lifetime via CLI, that's a follow-up; not required to fix this issue.
+
+## Tests
+
+**Refactor the backfill into a shared helper.** Extract `recomputeLifetimeStats(db: Database, now: Date = Date()) throws` — note the parameter is `GRDB.Database` (mid-transaction handle), **not** `DatabaseQueue`. Callers are responsible for opening the write transaction (the migration is already inside one; tests wrap with `try dbQueue.write { db in … }`). Trying to nest `dbQueue.write` would deadlock GRDB.
+
+The recompute helper uses `INSERT OR REPLACE` (not `UPDATE`) so it is **bulletproof against a missing or corrupted singleton row** — it always lands the row in the correct state regardless of prior state. This is the deliberate counterpart to the increment-path helpers, which `UPDATE` and assert `db.changesCount == 1` to fail loudly on invariant violations:
+
+| Path | SQL pattern | Behavior on missing row |
+|---|---|---|
+| `incrementLifetimeStats` (hot path) | `UPDATE … WHERE id=1` | Throws `singletonMissing` — invariant violated, fail loudly |
+| `applyLifetimeDelta` (hot path) | `UPDATE … WHERE id=1` | Throws `singletonMissing` — invariant violated, fail loudly |
+| `recomputeLifetimeStats` (recovery / migration) | `INSERT OR REPLACE` | Self-heals — restores the row from current `dictations` |
+
+Three callers, one source of truth: (a) migration calls it for backfill, (b) test 13 calls it directly to cross-check incremental accumulation, (c) the documented recovery recipe is "call `recomputeLifetimeStats`."
+
+New file: `Tests/MacParakeetTests/Database/LifetimeDictationStatsTests.swift`
+
+Cases:
+1. **`testLifetimeStatsPersistAfterDeleteAll`** — save 3, deleteAll, expect lifetime totals intact, visibleCount 0.
+2. **`testLifetimeStatsPersistAfterDeleteHidden`** — save 1 visible + 1 hidden, deleteHidden, expect lifetime totals reflect both.
+3. **`testLifetimeStatsPersistAfterSingleDelete`** — save 2, delete one by id, expect lifetime intact.
+4. **`testReSavingCompletedDictationWithSameValuesDoesNotDoubleCount`** — save once with .completed, save again with identical values, expect counts unchanged (delta = 0).
+5. **`testReSavingCompletedDictationWithChangedWordCountAppliesDelta`** — save with wordCount=5, save again with wordCount=8, expect totalCount=1 (unchanged) and totalWords=8 (not 13).
+6. **`testStatusTransitionToCompletedIncrementsExactlyOnce`** — save with `.recording`, save with `.completed`, expect totalCount=1.
+7. **`testErrorStatusDoesNotIncrementLifetime`** — save with `.error`, expect lifetime totals zero.
+8. **`testRecordingStatusDoesNotIncrementLifetime`** — save with `.recording`, expect lifetime totals zero.
+9. **`testHiddenDictationsContributeToLifetime`** — save 1 hidden, expect totalCount=1, totalWords=N.
+10. **`testLongestDurationIsLifetimeMax`** — save 5000ms, delete it, save 1000ms, expect longestDurationMs still 5000.
+11. **`testLongestDurationDoesNotDecreaseOnDelta`** — save 5000ms, mutate to 1000ms via re-save, expect longestDurationMs still 5000 (high-water mark).
+12. **`testEmptyDatabaseLifetimeStatsAreZero`** — fresh DB, expect all zeros.
+13. **`testRecomputeMatchesIncrementalAccumulation`** — save N rows incrementally (driving the increment path), then call `recomputeLifetimeStats()` (driving the recompute SQL), expect identical results. This pins the two paths together — if either drifts, the test fails.
+14. **`testIncrementThrowsIfSingletonRowMissing`** — manually `DELETE FROM lifetime_dictation_stats`, attempt `repo.save(.completed)`, expect `LifetimeStatsError.singletonMissing` thrown (transaction rolls back, dictation is not saved either).
+
+Existing tests stay green:
+- `DictationStatsQueryTests` — saves rows then reads stats; expectations match because lifetime increments mirror what the old SUM produced. Verified case-by-case: `testStatsTotalCount`, `testStatsTotalWords`, `testStatsLongestDuration`, `testStatsAverageDuration`, `testStatsOnlyCountsCompleted` (`.recording` and `.error` rows skipped by guard).
+- `DictationRepositoryTests.testStats` — saves 3 completed rows then asserts totalCount=3, totalDurationMs=6000. Lifetime increments produce same values.
+- `PrivateDictationTests.testStatsIncludeHiddenRows` — both visible and hidden contribute to lifetime; totals match.
+- `RepositoryEdgeCaseTests` — same.
+
+Run focused database tests during implementation, then full `swift test` before commit.
+
+## Files Touched
+
+- `Sources/MacParakeetCore/Database/DatabaseManager.swift` — add `v0.7.4-lifetime-dictation-stats` migration. Migration calls the shared `recomputeLifetimeStats()` helper for backfill (same code path as the rollback recipe).
+- `Sources/MacParakeetCore/Database/DictationRepository.swift` — modify `save()` (transition + delta logic), modify `stats()` (read from new table), add private `incrementLifetimeStats(db:durationMs:wordCount:)` and `applyLifetimeDelta(db:durationDelta:wordDelta:newDurationMs:)` helpers, add internal `recomputeLifetimeStats(in:)` shared with migration, add `LifetimeStatsError` enum (`.singletonMissing`), update `DictationStats` doc comments to clarify lifetime vs. visible semantics.
+- `Tests/MacParakeetTests/Database/LifetimeDictationStatsTests.swift` — new.
+- `spec/01-data-model.md` — document the new table.
+- `CLAUDE.md` — one-line note in Database section.
+
+## Migration Risk
+
+- Backfill runs the shared `recomputeLifetimeStats()` helper inside the migration's transaction. Pure SQL, no Swift loop. Safe on any DB size.
+- Users on the *current* deflated state (e.g. the user from #124) will lock in their depleted totals. No way to recover historical loss; new dictations accrue normally going forward.
+- Rollback / recovery recipe: call `recomputeLifetimeStats(db:)` (single source of truth, also called by the migration backfill). Uses `INSERT OR REPLACE` so it self-heals even if the singleton row was deleted:
+  ```sql
+  INSERT OR REPLACE INTO lifetime_dictation_stats
+    (id, totalCount, totalDurationMs, totalWords, longestDurationMs, updatedAt)
+  SELECT 1,
+         COUNT(*),
+         COALESCE(SUM(durationMs), 0),
+         COALESCE(SUM(wordCount), 0),
+         COALESCE(MAX(durationMs), 0),
+         ?
+  FROM dictations
+  WHERE status = 'completed';
+  ```
+
+## What This Plan Does NOT Do
+
+- Does not retroactively restore user data lost before this fix ships.
+- Does not change the visible UI layout.
+- Does not split lifetime / private counters.
+- Does not change CLI command output (only field semantics, which the CLI labels as "Total: visible count" anyway).
+- Does not introduce a "Reset all stats including lifetime" affordance. If users want true zeroing, they can delete the SQLite file. (We could add an explicit "Reset Lifetime Stats" button in Settings later — punt unless asked.)

--- a/spec/01-data-model.md
+++ b/spec/01-data-model.md
@@ -11,9 +11,10 @@ MacParakeet uses **SQLite via GRDB** for all persistent storage. Single database
 ## Relationship Diagram
 
 ```
-┌──────────────────┐
-│    dictations    │   v0.1 — Voice dictation history
-└──────────────────┘
+┌──────────────────┐       ┌──────────────────────────────┐
+│    dictations    │ ────▶ │ lifetime_dictation_stats     │  v0.7.4 — Singleton counter
+└──────────────────┘       └──────────────────────────────┘    (survives row deletion)
+   v0.1 — Voice dictation history
 
 ┌──────────────────┐       ┌─────────────────────────┐
 │  transcriptions  │◄──FK──│   chat_conversations    │  v0.5 — Multi-conversation chat
@@ -261,6 +262,31 @@ CREATE INDEX idx_summaries_transcription_id ON summaries(transcriptionId);
 - `promptName` and `promptContent` are snapshots, not references to the `prompts` table. Editing or deleting a prompt after generation doesn't change the summary's metadata.
 - Legacy `transcriptions.summary` column is preserved and mirrors the newest completed summary for backward compatibility with existing export paths.
 - Migration from existing data: `transcriptions.summary` values migrate into `summaries` with `General Summary` prompt metadata.
+
+---
+
+### `lifetime_dictation_stats` (v0.7.4)
+
+Single-row counter table. Headline voice stats (total words, total duration, total count, longest dictation) survive deletion of the underlying `dictations` rows. Fixes [#124](https://github.com/moona3k/macparakeet/issues/124) — clearing dictation history used to wipe stats too because they were SQL aggregates.
+
+```sql
+CREATE TABLE lifetime_dictation_stats (
+    id                INTEGER PRIMARY KEY CHECK (id = 1),    -- singleton row
+    totalCount        INTEGER NOT NULL DEFAULT 0,
+    totalDurationMs   INTEGER NOT NULL DEFAULT 0,
+    totalWords        INTEGER NOT NULL DEFAULT 0,
+    longestDurationMs INTEGER NOT NULL DEFAULT 0,            -- high-water mark
+    updatedAt         TEXT NOT NULL
+);
+```
+
+**Notes:**
+- Singleton enforced by `CHECK (id = 1)`. Migration immediately seeds the row from existing `dictations` so subsequent updates are guaranteed plain `UPDATE`s.
+- Hot-path increments live in `DictationRepository.save()` inside the same write transaction as the row insert. Status transition guard ensures only `→ .completed` increments fire.
+- `applyLifetimeDelta` handles the `(.completed, .completed)` re-save case (e.g. a future "edit transcript" feature) without double-counting.
+- `recomputeLifetimeStats(db:)` (recovery / migration helper) uses `INSERT OR REPLACE` so it self-heals if the singleton row is missing. Increment helpers `UPDATE … WHERE id=1` and throw `LifetimeStatsError.singletonMissing` if `db.changesCount != 1`.
+- Hidden (private) dictations contribute to lifetime totals — privacy is "no transcript stored," not "no metric counted."
+- Weekly streak / "this week" intentionally remain derived from current rows, not lifetime.
 
 ---
 

--- a/spec/01-data-model.md
+++ b/spec/01-data-model.md
@@ -12,9 +12,9 @@ MacParakeet uses **SQLite via GRDB** for all persistent storage. Single database
 
 ```
 ┌──────────────────┐       ┌──────────────────────────────┐
-│    dictations    │ ────▶ │ lifetime_dictation_stats     │  v0.7.4 — Singleton counter
+│    dictations    │ ╌╌╌▶  │ lifetime_dictation_stats     │  v0.7.4 — Singleton counter
 └──────────────────┘       └──────────────────────────────┘    (survives row deletion)
-   v0.1 — Voice dictation history
+   v0.1 — Voice dictation history    (logical write-path, no FK)
 
 ┌──────────────────┐       ┌─────────────────────────┐
 │  transcriptions  │◄──FK──│   chat_conversations    │  v0.5 — Multi-conversation chat

--- a/spec/01-data-model.md
+++ b/spec/01-data-model.md
@@ -287,6 +287,7 @@ CREATE TABLE lifetime_dictation_stats (
 - `recomputeLifetimeStats(db:)` (recovery / migration helper) uses `INSERT OR REPLACE` so it self-heals if the singleton row is missing. Increment helpers `UPDATE … WHERE id=1` and throw `LifetimeStatsError.singletonMissing` if `db.changesCount != 1`.
 - Hidden (private) dictations contribute to lifetime totals — privacy is "no transcript stored," not "no metric counted."
 - Weekly streak / "this week" intentionally remain derived from current rows, not lifetime.
+- User-initiated reset: `DictationRepository.resetLifetimeStats()` zeros the singleton row without touching dictation rows. Symmetric counterpart to `deleteAll()` (rows deleted, stats preserved). Exposed as a "Reset Lifetime Stats..." button in Settings → Storage.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #124. Clearing dictation history used to wipe headline voice stats — total words, total time — because they were SQL aggregates over the deleted rows. Now they live in a separate singleton counter table, updated atomically with each completed dictation save and never touched by deletion paths. Plus a symmetric "Reset Lifetime Stats" affordance for the opposite operation.

The user's framing in #124 — *"one is a privacy thing, one is just for interest"* — captures the design. Privacy deletion and stats-keeping are now fully separated.

## Settings → Storage maintenance actions

| Group | Action | Effect on dictation rows | Effect on lifetime stats |
|---|---|---|---|
| Delete data | Clear All Dictations… | all deleted (visible + private) | preserved |
| Delete data | Clear Downloaded YouTube Audio… | (audio files only) | n/a |
| Reset counters | Reset Lifetime Stats… | preserved | zeroed |

## How it works

```
                       ┌─────────────────────────┐
  save(.completed) ──▶ │ same write transaction  │
                       │                         │
                       │   ┌─────────────────┐   │
                       │   │  dictations row │   │  ◄── deleted by Clear All
                       │   └─────────────────┘   │
                       │           │             │
                       │           │ +1, +dur,   │
                       │           ▼ +words,     │
                       │   ┌──────────────────┐  │
                       │   │ lifetime_stats   │  │  ◄── zeroed by Reset Lifetime
                       │   │   (singleton)    │  │      (rows untouched)
                       │   └──────────────────┘  │
                       └─────────────────────────┘
```

**Status guards** in `save()`:
- non-completed → `.completed`: increment by full row
- `.completed` → `.completed`: apply delta only (no double-count, forward-proofs a future "edit transcript" feature)
- `.error` / `.recording`: no-op

**Safety asymmetry**:
| Path | SQL | Behavior on missing singleton row |
|---|---|---|
| Hot path (increment / delta) | `UPDATE … WHERE id=1` | Throws `LifetimeStatsError.singletonMissing`, transaction rolls back |
| Recovery / migration / user reset | `INSERT OR REPLACE` | Self-heals from current `dictations` (or zeros) |

**Read path** composes lifetime totals (from new table) with current-rows derived fields (`visibleCount`, `weeklyStreak`, `dictationsThisWeek`). Streak intentionally still resets on Clear All — it's "are you on a streak right now?", not a lifetime metric.

**Hidden (private) dictations contribute to lifetime totals.** Privacy is "no transcript stored," not "no metric counted."

## Migration

`v0.7.4-lifetime-dictation-stats` creates the table and seeds the singleton row from existing completed dictations via the shared `recomputeLifetimeStats` helper. Upgraded users keep their current totals.

## UI polish

The destructive maintenance buttons live in two semantic clusters via a new `maintenanceGroup` helper that wraps cleanly with `FlowLayout`:
- **Delete data** — Clear All Dictations, Clear Downloaded YouTube Audio
- **Reset counters** — Reset Lifetime Stats

"Clear All Dictations" now genuinely means "all" — visible *and* private metric-only rows. The previous granular split (a separate "Delete Private Dictations" button) made sense when stats were derived from rows; with lifetime stats independent now, the split no longer bought the user anything.

## Process

Plan written, reviewed by Codex + Gemini in parallel until findings converged. Plan archived in `plans/completed/2026-04-lifetime-dictation-stats.md`. Self-review pass after first implementation surfaced naming + layout issues. Final iteration consolidated overlapping buttons after user feedback.

## Commits

- `8ea211d5` — fix: persist lifetime dictation stats through history deletion (core)
- `f8bfb858` — feat: add user-initiated "Reset Lifetime Stats" affordance (symmetric counterpart)
- `d5201c45` — refactor: clarify maintenance UI — rename, regroup, fix callback semantics
- `20def34c` — refactor: collapse "Clear All" + "Delete Private" into one button

## Test plan

- [x] 18 new tests in `LifetimeDictationStatsTests` pass
- [x] 3 new tests in `SettingsViewModelTests` pass
- [x] Full suite passes (1451 tests)
- [x] Two existing migration tests updated to seed `dictations` (the v0.7.4 backfill needs a real table; production paths always have it from v0.1)
- [x] Visual: Settings → Storage card renders the two maintenance groups cleanly (verified 2026-04-23)
- [ ] Manual: dictate a few times, "Clear All Dictations", confirm "Your Voice Stats" card still shows the lifetime numbers
- [ ] Manual: "Reset Lifetime Stats" zeros the counters but leaves dictation rows in History
- [ ] Manual: confirm symmetric behavior holds with private mode toggled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Lifetime dictation statistics now persist independently of deletion operations
  * New "Reset Lifetime Stats" option in settings to reset statistics without deleting dictations
  * Enhanced statistics tracking with total duration, total words, and longest duration metrics

* **Documentation**
  * Updated documentation for lifetime statistics persistence and reset behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->