### PR TITLE
Add transcript editing

### DIFF
--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
@@ -3,7 +3,21 @@ import Foundation
 import MacParakeetCore
 
 enum TranscriptExportFormat: String {
-    case txt, md, srt, vtt, docx, pdf, json
+    case txt, md, srt, vtt, docx, pdf, json, aiText = "ai-text"
+
+    var fileExtension: String {
+        switch self {
+        case .aiText: return "md"
+        default: return rawValue
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .aiText: return "AI Text"
+        default: return rawValue.uppercased()
+        }
+    }
 }
 
 @MainActor
@@ -48,6 +62,7 @@ enum TranscriptResultActions {
         switch format {
         case .txt: try exportService.exportToTxt(transcription: transcription, url: fileURL)
         case .md: try exportService.exportToMarkdown(transcription: transcription, url: fileURL)
+        case .aiText: try exportService.exportToAIText(transcription: transcription, url: fileURL)
         case .srt: try exportService.exportToSRT(transcription: transcription, url: fileURL)
         case .vtt: try exportService.exportToVTT(transcription: transcription, url: fileURL)
         case .docx: try exportService.exportToDocx(transcription: transcription, url: fileURL)
@@ -71,10 +86,10 @@ enum TranscriptResultActions {
         stem: String,
         format: TranscriptExportFormat
     ) -> URL {
-        var url = directory.appendingPathComponent("\(stem).\(format.rawValue)")
+        var url = directory.appendingPathComponent("\(stem).\(format.fileExtension)")
         var counter = 1
         while FileManager.default.fileExists(atPath: url.path) {
-            url = directory.appendingPathComponent("\(stem) (\(counter)).\(format.rawValue)")
+            url = directory.appendingPathComponent("\(stem) (\(counter)).\(format.fileExtension)")
             counter += 1
         }
         return url

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
@@ -3,19 +3,17 @@ import Foundation
 import MacParakeetCore
 
 enum TranscriptExportFormat: String {
-    case txt, md, srt, vtt, docx, pdf, json, aiText = "ai-text"
-
-    var fileExtension: String {
-        switch self {
-        case .aiText: return "md"
-        default: return rawValue
-        }
-    }
+    case txt, md, srt, vtt, docx, pdf, json
 
     var displayName: String {
         switch self {
-        case .aiText: return "AI Text"
-        default: return rawValue.uppercased()
+        case .txt: "Text"
+        case .md: "Markdown"
+        case .srt: "SRT"
+        case .vtt: "VTT"
+        case .docx: "Word Document"
+        case .pdf: "PDF"
+        case .json: "JSON"
         }
     }
 }
@@ -62,7 +60,6 @@ enum TranscriptResultActions {
         switch format {
         case .txt: try exportService.exportToTxt(transcription: transcription, url: fileURL)
         case .md: try exportService.exportToMarkdown(transcription: transcription, url: fileURL)
-        case .aiText: try exportService.exportToAIText(transcription: transcription, url: fileURL)
         case .srt: try exportService.exportToSRT(transcription: transcription, url: fileURL)
         case .vtt: try exportService.exportToVTT(transcription: transcription, url: fileURL)
         case .docx: try exportService.exportToDocx(transcription: transcription, url: fileURL)
@@ -86,10 +83,10 @@ enum TranscriptResultActions {
         stem: String,
         format: TranscriptExportFormat
     ) -> URL {
-        var url = directory.appendingPathComponent("\(stem).\(format.fileExtension)")
+        var url = directory.appendingPathComponent("\(stem).\(format.rawValue)")
         var counter = 1
         while FileManager.default.fileExists(atPath: url.path) {
-            url = directory.appendingPathComponent("\(stem) (\(counter)).\(format.fileExtension)")
+            url = directory.appendingPathComponent("\(stem) (\(counter)).\(format.rawValue)")
             counter += 1
         }
         return url

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -32,7 +32,6 @@ struct TranscriptResultView: View {
     @State private var headerExpanded = false
     @State private var speakerOverviewExpanded = false
     @State private var copied = false
-    @State private var copiedAIText = false
     @State private var copiedResultID: UUID?
     @State private var copiedButtonResultID: UUID?
     @State private var copiedMessageId: UUID?
@@ -40,7 +39,6 @@ struct TranscriptResultView: View {
     @State private var exportConfirmation: ExportConfirmation?
     @State private var exportErrorMessage: String?
     @State private var copiedResetTask: Task<Void, Never>?
-    @State private var copiedAITextResetTask: Task<Void, Never>?
     @State private var resultCopiedResetTask: Task<Void, Never>?
     @State private var resultButtonCopiedResetTask: Task<Void, Never>?
     @State private var dismissTask: Task<Void, Never>?
@@ -50,6 +48,7 @@ struct TranscriptResultView: View {
     @State private var transcriptDraft = ""
     @State private var transcriptEditError: String?
     @State private var transcriptDisplayMode: TranscriptDisplayMode = .text
+    @State private var transcriptDisplayModeBeforeEdit: TranscriptDisplayMode?
     @State private var editingSpeakerId: String?
     @State private var editingSpeakerLabel: String = ""
     @State private var showConversationPopover = false
@@ -123,6 +122,7 @@ struct TranscriptResultView: View {
             editingTranscript = false
             transcriptDraft = ""
             transcriptEditError = nil
+            transcriptDisplayModeBeforeEdit = nil
             editingSpeakerId = nil
             editingSpeakerLabel = ""
             showConversationPopover = false
@@ -138,10 +138,13 @@ struct TranscriptResultView: View {
             let text = viewModel.currentTranscription?.cleanTranscript ?? viewModel.currentTranscription?.rawTranscript ?? ""
             chatViewModel.loadTranscript(text, transcriptionId: viewModel.currentTranscription?.id)
         }
-        .onChange(of: transcription.speakers) {
+        .onChange(of: activeTranscription.speakers) {
             rebuildSegmentCache()
         }
-        .onChange(of: transcription.wordTimestamps) {
+        .onChange(of: activeTranscription.wordTimestamps) {
+            rebuildSegmentCache()
+        }
+        .onChange(of: activeTranscription.diarizationSegments) {
             rebuildSegmentCache()
         }
         .onChange(of: viewModel.selectedTab) {
@@ -275,8 +278,6 @@ struct TranscriptResultView: View {
         .onDisappear {
             copiedResetTask?.cancel()
             copiedResetTask = nil
-            copiedAITextResetTask?.cancel()
-            copiedAITextResetTask = nil
             resultCopiedResetTask?.cancel()
             resultCopiedResetTask = nil
             resultButtonCopiedResetTask?.cancel()
@@ -373,17 +374,6 @@ struct TranscriptResultView: View {
             }
             .buttonStyle(.bordered)
 
-            Button {
-                copyAITextToClipboard()
-            } label: {
-                Label(
-                    copiedAIText ? "Copied!" : "Copy AI Text",
-                    systemImage: copiedAIText ? "checkmark" : "text.quote"
-                )
-                .foregroundStyle(copiedAIText ? DesignSystem.Colors.successGreen : .primary)
-            }
-            .buttonStyle(.bordered)
-
             Menu {
                 Section("Document") {
                     Button { exportToDownloads(format: .txt) } label: {
@@ -391,9 +381,6 @@ struct TranscriptResultView: View {
                     }
                     Button { exportToDownloads(format: .md) } label: {
                         Label("Markdown (.md)", systemImage: "text.document")
-                    }
-                    Button { exportToDownloads(format: .aiText) } label: {
-                        Label("AI Text (.md)", systemImage: "text.quote")
                     }
                     Button { exportToDownloads(format: .docx) } label: {
                         Label("Word Document (.docx)", systemImage: "doc.richtext")
@@ -482,14 +469,14 @@ struct TranscriptResultView: View {
 
     private var transcriptWordCount: Int {
         if transcriptDisplayMode == .timed,
-           let wordTimestamps = transcription.wordTimestamps, !wordTimestamps.isEmpty {
+           let wordTimestamps = activeTranscription.wordTimestamps, !wordTimestamps.isEmpty {
             return wordTimestamps.count
         }
         return transcriptText.split(whereSeparator: \.isWhitespace).count
     }
 
     private var speakerCountValue: Int {
-        transcription.speakers?.count ?? transcription.speakerCount ?? 0
+        activeTranscription.speakers?.count ?? activeTranscription.speakerCount ?? 0
     }
 
     private var resultHeaderCard: some View {
@@ -808,16 +795,12 @@ struct TranscriptResultView: View {
 
                     if editingTranscript {
                         transcriptEditor
-                    } else if let speakers = activeTranscription.speakers, !speakers.isEmpty,
-                              transcriptDisplayMode == .timed {
-                        speakerSummaryPanel(speakers: speakers)
-
-                        if let timestamps = transcription.wordTimestamps, !timestamps.isEmpty {
-                            timestampedView(words: timestamps)
-                        }
                     } else if transcriptDisplayMode == .timed,
-                              let timestamps = transcription.wordTimestamps,
+                              let timestamps = activeTranscription.wordTimestamps,
                               !timestamps.isEmpty {
+                        if let speakers = activeTranscription.speakers, !speakers.isEmpty {
+                            speakerSummaryPanel(speakers: speakers)
+                        }
                         timestampedView(words: timestamps)
                     } else if !transcriptText.isEmpty {
                         transcriptTextBlock(transcriptText)
@@ -1883,11 +1866,13 @@ struct TranscriptResultView: View {
     // MARK: - Mandala Data
 
     private var mandalaData: MandalaData {
-        if let timestamps = transcription.wordTimestamps, !timestamps.isEmpty {
+        if let timestamps = activeTranscription.wordTimestamps, !timestamps.isEmpty {
             return .from(wordTimestamps: timestamps)
         }
-        return .from(text: transcription.cleanTranscript ?? transcription.rawTranscript ?? transcription.fileName,
-                     durationMs: transcription.durationMs ?? 1000)
+        return .from(
+            text: activeTranscription.cleanTranscript ?? activeTranscription.rawTranscript ?? activeTranscription.fileName,
+            durationMs: activeTranscription.durationMs ?? 1000
+        )
     }
 
     // MARK: - Timestamped View
@@ -1920,8 +1905,8 @@ struct TranscriptResultView: View {
     private func speakerSummaryPanel(speakers: [SpeakerInfo]) -> some View {
         let colorMap = buildSpeakerColorMap()
         let speakerStats = TranscriptSegmenter.computeSpeakerStats(
-            diarizationSegments: transcription.diarizationSegments,
-            wordTimestamps: transcription.wordTimestamps
+            diarizationSegments: activeTranscription.diarizationSegments,
+            wordTimestamps: activeTranscription.wordTimestamps
         )
 
         VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
@@ -2035,6 +2020,7 @@ struct TranscriptResultView: View {
     private func commitSpeakerRename() {
         guard let speakerId = editingSpeakerId else { return }
         viewModel.renameSpeaker(id: speakerId, to: editingSpeakerLabel)
+        rebuildSegmentCache()
         editingSpeakerId = nil
     }
 
@@ -2053,7 +2039,7 @@ struct TranscriptResultView: View {
 
     /// Rebuild cached segment data. Called once on appear and when transcription.id changes.
     private func rebuildSegmentCache() {
-        guard let words = transcription.wordTimestamps, !words.isEmpty else {
+        guard let words = activeTranscription.wordTimestamps, !words.isEmpty else {
             cachedSegments = []
             cachedTurns = []
             cachedHasSpeakers = false
@@ -2138,7 +2124,7 @@ struct TranscriptResultView: View {
     // MARK: - Speaker Helpers
 
     private func buildSpeakerColorMap() -> [String: Color] {
-        guard let speakers = transcription.speakers else { return [:] }
+        guard let speakers = activeTranscription.speakers else { return [:] }
         var map: [String: Color] = [:]
         for (i, speaker) in speakers.enumerated() {
             map[speaker.id] = DesignSystem.Colors.speakerColor(for: i)
@@ -2147,7 +2133,7 @@ struct TranscriptResultView: View {
     }
 
     private func buildSpeakerLabelMap() -> [String: String] {
-        guard let speakers = transcription.speakers else { return [:] }
+        guard let speakers = activeTranscription.speakers else { return [:] }
         var map: [String: String] = [:]
         for speaker in speakers {
             map[speaker.id] = speaker.label
@@ -2162,6 +2148,7 @@ struct TranscriptResultView: View {
     private func beginTranscriptEdit() {
         transcriptDraft = transcriptText
         transcriptEditError = nil
+        transcriptDisplayModeBeforeEdit = transcriptDisplayMode
         editingTranscript = true
         transcriptDisplayMode = .text
         Task { @MainActor in
@@ -2173,6 +2160,8 @@ struct TranscriptResultView: View {
         transcriptDraft = ""
         transcriptEditError = nil
         editingTranscript = false
+        transcriptDisplayMode = transcriptDisplayModeBeforeEdit ?? transcriptDisplayMode
+        transcriptDisplayModeBeforeEdit = nil
     }
 
     private func commitTranscriptEdit() {
@@ -2202,6 +2191,7 @@ struct TranscriptResultView: View {
         transcriptEditError = nil
         editingTranscript = false
         transcriptDisplayMode = .text
+        transcriptDisplayModeBeforeEdit = nil
         SoundManager.shared.play(.transcriptionComplete)
     }
 
@@ -2213,6 +2203,7 @@ struct TranscriptResultView: View {
         transcriptEditError = nil
         editingTranscript = false
         transcriptDisplayMode = hasTimestamps ? .timed : .text
+        transcriptDisplayModeBeforeEdit = nil
         SoundManager.shared.play(.transcriptionComplete)
     }
 
@@ -2230,20 +2221,8 @@ struct TranscriptResultView: View {
         }
     }
 
-    private func copyAITextToClipboard() {
-        let text = ExportService().formatAIText(transcription: activeTranscription)
-        TranscriptResultActions.copyText(text)
-        copiedAITextResetTask?.cancel()
-        withAnimation(DesignSystem.Animation.hoverTransition) { copiedAIText = true }
-        copiedAITextResetTask = Task { @MainActor in
-            try? await Task.sleep(for: .seconds(1.5))
-            guard !Task.isCancelled else { return }
-            withAnimation(DesignSystem.Animation.hoverTransition) { copiedAIText = false }
-        }
-    }
-
     private var hasTimestamps: Bool {
-        guard let words = transcription.wordTimestamps else { return false }
+        guard let words = activeTranscription.wordTimestamps else { return false }
         return !words.isEmpty
     }
 

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -13,6 +13,11 @@ private struct ExportConfirmation: Identifiable {
     let format: String
 }
 
+private enum TranscriptDisplayMode: String, CaseIterable, Hashable {
+    case text = "Text"
+    case timed = "Timed"
+}
+
 struct TranscriptResultView: View {
     let transcription: Transcription
     @Bindable var viewModel: TranscriptionViewModel
@@ -27,6 +32,7 @@ struct TranscriptResultView: View {
     @State private var headerExpanded = false
     @State private var speakerOverviewExpanded = false
     @State private var copied = false
+    @State private var copiedAIText = false
     @State private var copiedResultID: UUID?
     @State private var copiedButtonResultID: UUID?
     @State private var copiedMessageId: UUID?
@@ -34,11 +40,16 @@ struct TranscriptResultView: View {
     @State private var exportConfirmation: ExportConfirmation?
     @State private var exportErrorMessage: String?
     @State private var copiedResetTask: Task<Void, Never>?
+    @State private var copiedAITextResetTask: Task<Void, Never>?
     @State private var resultCopiedResetTask: Task<Void, Never>?
     @State private var resultButtonCopiedResetTask: Task<Void, Never>?
     @State private var dismissTask: Task<Void, Never>?
     @State private var editingMeetingTitle = false
     @State private var meetingTitleDraft = ""
+    @State private var editingTranscript = false
+    @State private var transcriptDraft = ""
+    @State private var transcriptEditError: String?
+    @State private var transcriptDisplayMode: TranscriptDisplayMode = .text
     @State private var editingSpeakerId: String?
     @State private var editingSpeakerLabel: String = ""
     @State private var showConversationPopover = false
@@ -62,6 +73,7 @@ struct TranscriptResultView: View {
     @State private var showingCancelGenerationAlert: UUID?
     @FocusState private var chatInputFocused: Bool
     @FocusState private var meetingTitleFocused: Bool
+    @FocusState private var transcriptEditorFocused: Bool
     @FocusState private var speakerRenameFocused: Bool
 
     private let suggestedPrompts = [
@@ -85,6 +97,7 @@ struct TranscriptResultView: View {
             }
             rebuildSegmentCache()
             viewModel.loadPersistedContent()
+            syncTranscriptDisplayMode()
             promptResultsViewModel.loadVisiblePrompts()
             promptResultsViewModel.loadPromptResults(transcriptionId: transcription.id)
             let text = viewModel.currentTranscription?.cleanTranscript ?? viewModel.currentTranscription?.rawTranscript ?? ""
@@ -107,6 +120,9 @@ struct TranscriptResultView: View {
             speakerOverviewExpanded = false
             editingMeetingTitle = false
             meetingTitleDraft = ""
+            editingTranscript = false
+            transcriptDraft = ""
+            transcriptEditError = nil
             editingSpeakerId = nil
             editingSpeakerLabel = ""
             showConversationPopover = false
@@ -117,6 +133,7 @@ struct TranscriptResultView: View {
             viewModel.hasConversations = false
             viewModel.selectedTab = .transcript
             viewModel.loadPersistedContent()
+            syncTranscriptDisplayMode()
             promptResultsViewModel.loadPromptResults(transcriptionId: transcription.id)
             let text = viewModel.currentTranscription?.cleanTranscript ?? viewModel.currentTranscription?.rawTranscript ?? ""
             chatViewModel.loadTranscript(text, transcriptionId: viewModel.currentTranscription?.id)
@@ -258,6 +275,8 @@ struct TranscriptResultView: View {
         .onDisappear {
             copiedResetTask?.cancel()
             copiedResetTask = nil
+            copiedAITextResetTask?.cancel()
+            copiedAITextResetTask = nil
             resultCopiedResetTask?.cancel()
             resultCopiedResetTask = nil
             resultButtonCopiedResetTask?.cancel()
@@ -354,6 +373,17 @@ struct TranscriptResultView: View {
             }
             .buttonStyle(.bordered)
 
+            Button {
+                copyAITextToClipboard()
+            } label: {
+                Label(
+                    copiedAIText ? "Copied!" : "Copy AI Text",
+                    systemImage: copiedAIText ? "checkmark" : "text.quote"
+                )
+                .foregroundStyle(copiedAIText ? DesignSystem.Colors.successGreen : .primary)
+            }
+            .buttonStyle(.bordered)
+
             Menu {
                 Section("Document") {
                     Button { exportToDownloads(format: .txt) } label: {
@@ -361,6 +391,9 @@ struct TranscriptResultView: View {
                     }
                     Button { exportToDownloads(format: .md) } label: {
                         Label("Markdown (.md)", systemImage: "text.document")
+                    }
+                    Button { exportToDownloads(format: .aiText) } label: {
+                        Label("AI Text (.md)", systemImage: "text.quote")
                     }
                     Button { exportToDownloads(format: .docx) } label: {
                         Label("Word Document (.docx)", systemImage: "doc.richtext")
@@ -427,12 +460,29 @@ struct TranscriptResultView: View {
         .padding(DesignSystem.Spacing.md)
     }
 
+    private var activeTranscription: Transcription {
+        guard let current = viewModel.currentTranscription, current.id == transcription.id else {
+            return transcription
+        }
+        return current
+    }
+
     private var transcriptText: String {
-        transcription.cleanTranscript ?? transcription.rawTranscript ?? ""
+        activeTranscription.cleanTranscript ?? activeTranscription.rawTranscript ?? ""
+    }
+
+    private var rawTranscriptText: String {
+        activeTranscription.rawTranscript ?? ""
+    }
+
+    private var hasEditedTranscript: Bool {
+        guard let clean = activeTranscription.cleanTranscript else { return false }
+        return !clean.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     private var transcriptWordCount: Int {
-        if let wordTimestamps = transcription.wordTimestamps, !wordTimestamps.isEmpty {
+        if transcriptDisplayMode == .timed,
+           let wordTimestamps = transcription.wordTimestamps, !wordTimestamps.isEmpty {
             return wordTimestamps.count
         }
         return transcriptText.split(whereSeparator: \.isWhitespace).count
@@ -748,24 +798,29 @@ struct TranscriptResultView: View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
-                    if let speakers = transcription.speakers, !speakers.isEmpty {
-                        speakerSummaryPanel(speakers: speakers)
+                    transcriptPaneHeader
+
+                    if let error = transcriptEditError {
+                        Label(error, systemImage: "exclamationmark.triangle.fill")
+                            .font(DesignSystem.Typography.caption)
+                            .foregroundStyle(DesignSystem.Colors.errorRed)
                     }
 
-                    if let timestamps = transcription.wordTimestamps, !timestamps.isEmpty {
+                    if editingTranscript {
+                        transcriptEditor
+                    } else if let speakers = activeTranscription.speakers, !speakers.isEmpty,
+                              transcriptDisplayMode == .timed {
+                        speakerSummaryPanel(speakers: speakers)
+
+                        if let timestamps = transcription.wordTimestamps, !timestamps.isEmpty {
+                            timestampedView(words: timestamps)
+                        }
+                    } else if transcriptDisplayMode == .timed,
+                              let timestamps = transcription.wordTimestamps,
+                              !timestamps.isEmpty {
                         timestampedView(words: timestamps)
                     } else if !transcriptText.isEmpty {
-                        Text(transcriptText)
-                            .font(DesignSystem.Typography.bodyLarge)
-                            .foregroundStyle(DesignSystem.Colors.textPrimary)
-                            .textSelection(.enabled)
-                            .lineSpacing(6)
-                            .padding(DesignSystem.Spacing.lg)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .background(
-                                RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
-                                    .fill(DesignSystem.Colors.surfaceElevated.opacity(0.6))
-                            )
+                        transcriptTextBlock(transcriptText)
                     } else {
                         Text("No transcript available")
                             .foregroundStyle(DesignSystem.Colors.textSecondary)
@@ -829,6 +884,105 @@ struct TranscriptResultView: View {
             scrollPauseTask?.cancel()
             autoScrollPaused = false
         }
+    }
+
+    private var transcriptPaneHeader: some View {
+        HStack(spacing: DesignSystem.Spacing.sm) {
+            Label("Transcript", systemImage: "text.alignleft")
+                .font(DesignSystem.Typography.sectionTitle)
+                .foregroundStyle(DesignSystem.Colors.textPrimary)
+
+            if hasEditedTranscript {
+                Label("Edited", systemImage: "checkmark.circle.fill")
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.successGreen)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(
+                        Capsule().fill(DesignSystem.Colors.successGreen.opacity(0.10))
+                    )
+            }
+
+            Spacer()
+
+            if !editingTranscript, hasEditedTranscript, hasTimestamps {
+                Picker("Transcript view", selection: $transcriptDisplayMode) {
+                    ForEach(TranscriptDisplayMode.allCases, id: \.self) { mode in
+                        Text(mode.rawValue).tag(mode)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .frame(width: 150)
+            }
+
+            if editingTranscript {
+                if hasEditedTranscript {
+                    Button {
+                        revertTranscriptEdit()
+                    } label: {
+                        Label("Revert", systemImage: "arrow.uturn.backward")
+                    }
+                    .buttonStyle(.bordered)
+                }
+
+                Button {
+                    cancelTranscriptEdit()
+                } label: {
+                    Label("Cancel", systemImage: "xmark")
+                }
+                .buttonStyle(.bordered)
+
+                Button {
+                    commitTranscriptEdit()
+                } label: {
+                    Label("Save", systemImage: "checkmark")
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(DesignSystem.Colors.accent)
+                .disabled(transcriptDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            } else {
+                Button {
+                    beginTranscriptEdit()
+                } label: {
+                    Label("Edit", systemImage: "pencil")
+                }
+                .buttonStyle(.bordered)
+            }
+        }
+    }
+
+    private var transcriptEditor: some View {
+        TextEditor(text: $transcriptDraft)
+            .font(DesignSystem.Typography.bodyLarge)
+            .foregroundStyle(DesignSystem.Colors.textPrimary)
+            .lineSpacing(6)
+            .scrollContentBackground(.hidden)
+            .focused($transcriptEditorFocused)
+            .padding(DesignSystem.Spacing.md)
+            .frame(minHeight: 320)
+            .background(
+                RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
+                    .fill(DesignSystem.Colors.surfaceElevated.opacity(0.75))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
+                    .strokeBorder(DesignSystem.Colors.accent.opacity(0.30), lineWidth: 1)
+            )
+    }
+
+    private func transcriptTextBlock(_ text: String) -> some View {
+        Text(text)
+            .font(DesignSystem.Typography.bodyLarge)
+            .foregroundStyle(DesignSystem.Colors.textPrimary)
+            .textSelection(.enabled)
+            .lineSpacing(6)
+            .padding(DesignSystem.Spacing.lg)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
+                    .fill(DesignSystem.Colors.surfaceElevated.opacity(0.6))
+            )
     }
 
     // MARK: - Tab Bar
@@ -2001,11 +2155,71 @@ struct TranscriptResultView: View {
         return map
     }
 
+    private func syncTranscriptDisplayMode() {
+        transcriptDisplayMode = hasEditedTranscript ? .text : .timed
+    }
+
+    private func beginTranscriptEdit() {
+        transcriptDraft = transcriptText
+        transcriptEditError = nil
+        editingTranscript = true
+        transcriptDisplayMode = .text
+        Task { @MainActor in
+            transcriptEditorFocused = true
+        }
+    }
+
+    private func cancelTranscriptEdit() {
+        transcriptDraft = ""
+        transcriptEditError = nil
+        editingTranscript = false
+    }
+
+    private func commitTranscriptEdit() {
+        let trimmed = transcriptDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            transcriptEditError = "Transcript text cannot be empty."
+            SoundManager.shared.play(.errorSoft)
+            return
+        }
+
+        if trimmed == transcriptText {
+            cancelTranscriptEdit()
+            return
+        }
+
+        guard viewModel.updateCurrentTranscriptText(to: transcriptDraft) else {
+            transcriptEditError = "Could not save transcript edits."
+            SoundManager.shared.play(.errorSoft)
+            return
+        }
+
+        let updatedText = viewModel.currentTranscription?.cleanTranscript
+            ?? viewModel.currentTranscription?.rawTranscript
+            ?? trimmed
+        chatViewModel.loadTranscript(updatedText, transcriptionId: viewModel.currentTranscription?.id)
+        transcriptDraft = ""
+        transcriptEditError = nil
+        editingTranscript = false
+        transcriptDisplayMode = .text
+        SoundManager.shared.play(.transcriptionComplete)
+    }
+
+    private func revertTranscriptEdit() {
+        guard viewModel.revertCurrentTranscriptToOriginal() else { return }
+        let originalText = viewModel.currentTranscription?.rawTranscript ?? rawTranscriptText
+        chatViewModel.loadTranscript(originalText, transcriptionId: viewModel.currentTranscription?.id)
+        transcriptDraft = ""
+        transcriptEditError = nil
+        editingTranscript = false
+        transcriptDisplayMode = hasTimestamps ? .timed : .text
+        SoundManager.shared.play(.transcriptionComplete)
+    }
 
     // MARK: - Actions
 
     private func copyToClipboard() {
-        let text = transcription.cleanTranscript ?? transcription.rawTranscript ?? ""
+        let text = transcriptText
         TranscriptResultActions.copyText(text)
         copiedResetTask?.cancel()
         withAnimation(DesignSystem.Animation.hoverTransition) { copied = true }
@@ -2013,6 +2227,18 @@ struct TranscriptResultView: View {
             try? await Task.sleep(for: .seconds(1.5))
             guard !Task.isCancelled else { return }
             withAnimation(DesignSystem.Animation.hoverTransition) { copied = false }
+        }
+    }
+
+    private func copyAITextToClipboard() {
+        let text = ExportService().formatAIText(transcription: activeTranscription)
+        TranscriptResultActions.copyText(text)
+        copiedAITextResetTask?.cancel()
+        withAnimation(DesignSystem.Animation.hoverTransition) { copiedAIText = true }
+        copiedAITextResetTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(1.5))
+            guard !Task.isCancelled else { return }
+            withAnimation(DesignSystem.Animation.hoverTransition) { copiedAIText = false }
         }
     }
 
@@ -2032,7 +2258,7 @@ struct TranscriptResultView: View {
                     .foregroundStyle(DesignSystem.Colors.successGreen)
 
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("Exported \(confirmation.format.uppercased())")
+                    Text("Exported \(confirmation.format)")
                         .font(DesignSystem.Typography.body.bold())
                     Text(confirmation.url.lastPathComponent)
                         .font(DesignSystem.Typography.caption)
@@ -2072,7 +2298,7 @@ struct TranscriptResultView: View {
     }
 
     private func exportGenerationToDownloads(promptResult: PromptResult, format: TranscriptExportFormat) {
-        let source = viewModel.currentTranscription ?? transcription
+        let source = activeTranscription
         do {
             let fileURL = try TranscriptResultActions.exportPromptResultToDownloads(
                 promptResult: promptResult,
@@ -2082,7 +2308,7 @@ struct TranscriptResultView: View {
             exportErrorMessage = nil
             SoundManager.shared.play(.transcriptionComplete)
             dismissTask?.cancel()
-            exportConfirmation = ExportConfirmation(url: fileURL, format: format.rawValue)
+            exportConfirmation = ExportConfirmation(url: fileURL, format: format.displayName)
             dismissTask = Task { @MainActor in
                 try? await Task.sleep(for: .seconds(5.0))
                 guard !Task.isCancelled else { return }
@@ -2099,7 +2325,7 @@ struct TranscriptResultView: View {
 
     private func exportToDownloads(format: TranscriptExportFormat) {
         // Use the ViewModel's copy which reflects any in-flight renames
-        let source = viewModel.currentTranscription ?? transcription
+        let source = activeTranscription
         do {
             let fileURL = try TranscriptResultActions.exportTranscriptToDownloads(
                 transcription: source,
@@ -2108,7 +2334,7 @@ struct TranscriptResultView: View {
             exportErrorMessage = nil
             SoundManager.shared.play(.transcriptionComplete)
             dismissTask?.cancel()
-            exportConfirmation = ExportConfirmation(url: fileURL, format: format.rawValue)
+            exportConfirmation = ExportConfirmation(url: fileURL, format: format.displayName)
             dismissTask = Task { @MainActor in
                 try? await Task.sleep(for: .seconds(5.0))
                 guard !Task.isCancelled else { return }

--- a/Sources/MacParakeetCore/Services/ExportService.swift
+++ b/Sources/MacParakeetCore/Services/ExportService.swift
@@ -7,14 +7,12 @@ public protocol ExportServiceProtocol: Sendable {
     func exportToSRT(transcription: Transcription, url: URL) throws
     func exportToVTT(transcription: Transcription, url: URL) throws
     func exportToMarkdown(transcription: Transcription, url: URL) throws
-    func exportToAIText(transcription: Transcription, url: URL) throws
     func exportToJSON(transcription: Transcription, url: URL) throws
     @MainActor func exportToPDF(transcription: Transcription, url: URL) throws
     @MainActor func exportToDocx(transcription: Transcription, url: URL) throws
     func formatSRT(words: [WordTimestamp], speakers: [SpeakerInfo]?) -> String
     func formatVTT(words: [WordTimestamp], speakers: [SpeakerInfo]?) -> String
     func formatMarkdown(transcription: Transcription) -> String
-    func formatAIText(transcription: Transcription) -> String
     func formatForClipboard(transcription: Transcription) -> String
 }
 
@@ -193,12 +191,6 @@ public final class ExportService: ExportServiceProtocol, Sendable {
         try content.write(to: url, atomically: true, encoding: .utf8)
     }
 
-    /// Export transcription as timestamp-free text optimized for AI tools.
-    public func exportToAIText(transcription: Transcription, url: URL) throws {
-        let content = formatAIText(transcription: transcription)
-        try content.write(to: url, atomically: true, encoding: .utf8)
-    }
-
     /// Format transcription as Markdown string
     public func formatMarkdown(transcription: Transcription) -> String {
         var lines: [String] = []
@@ -257,113 +249,9 @@ public final class ExportService: ExportServiceProtocol, Sendable {
         return lines.joined(separator: "\n")
     }
 
-    /// Format a transcript without timestamps or metadata. This keeps user-edited
-    /// text authoritative, and otherwise derives readable paragraphs from timing
-    /// data when that is the best available structure.
-    public func formatAIText(transcription: Transcription) -> String {
-        if let edited = transcription.cleanTranscript?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !edited.isEmpty {
-            return normalizeParagraphText(edited)
-        }
-
-        if let timestamps = transcription.wordTimestamps, !timestamps.isEmpty {
-            let cues = buildSubtitleCues(from: timestamps)
-            if let speakers = transcription.speakers, !speakers.isEmpty {
-                return formatSpeakerParagraphs(cues: cues, speakers: speakers)
-            }
-
-            if let raw = transcription.rawTranscript?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !raw.isEmpty {
-                return normalizeParagraphText(raw)
-            }
-
-            return formatPlainParagraphs(cues: cues)
-        }
-
-        return normalizeParagraphText(preferredText(transcription: transcription))
-    }
-
     /// Format transcription text for clipboard copy
     public func formatForClipboard(transcription: Transcription) -> String {
         preferredText(transcription: transcription)
-    }
-
-    private func normalizeParagraphText(_ text: String) -> String {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return "" }
-
-        let normalizedNewlines = trimmed.replacingOccurrences(of: "\r\n", with: "\n")
-            .replacingOccurrences(of: "\r", with: "\n")
-        let rawParagraphs = normalizedNewlines.components(separatedBy: "\n\n")
-        let paragraphs = rawParagraphs
-            .map { paragraph in
-                paragraph
-                    .components(separatedBy: .newlines)
-                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-                    .filter { !$0.isEmpty }
-                    .joined(separator: " ")
-            }
-            .filter { !$0.isEmpty }
-
-        return paragraphs.joined(separator: "\n\n")
-    }
-
-    private func formatPlainParagraphs(cues: [SubtitleCue]) -> String {
-        var paragraphs: [String] = []
-        var current: [String] = []
-        var wordCount = 0
-
-        for cue in cues {
-            let text = cue.text.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !text.isEmpty else { continue }
-
-            current.append(text)
-            wordCount += text.split(whereSeparator: \.isWhitespace).count
-            let endsSentence = text.last.map { ".!?".contains($0) } ?? false
-            if endsSentence && wordCount >= 55 || wordCount >= 90 {
-                paragraphs.append(current.joined(separator: " "))
-                current = []
-                wordCount = 0
-            }
-        }
-
-        if !current.isEmpty {
-            paragraphs.append(current.joined(separator: " "))
-        }
-
-        return paragraphs.joined(separator: "\n\n")
-    }
-
-    private func formatSpeakerParagraphs(cues: [SubtitleCue], speakers: [SpeakerInfo]) -> String {
-        var lines: [String] = []
-        var currentSpeakerId: String?
-        var currentText: [String] = []
-
-        func flush() {
-            guard !currentText.isEmpty else { return }
-            if let speaker = speakerLabel(for: currentSpeakerId, in: speakers) {
-                lines.append("\(speaker):")
-            }
-            lines.append(currentText.joined(separator: " "))
-            lines.append("")
-            currentText = []
-        }
-
-        for cue in cues {
-            let text = cue.text.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !text.isEmpty else { continue }
-            if cue.speakerId != currentSpeakerId {
-                flush()
-                currentSpeakerId = cue.speakerId
-            }
-            currentText.append(text)
-        }
-
-        flush()
-        while lines.last == "" {
-            lines.removeLast()
-        }
-        return lines.joined(separator: "\n")
     }
 
     // MARK: - Subtitle Cue Building

--- a/Sources/MacParakeetCore/Services/ExportService.swift
+++ b/Sources/MacParakeetCore/Services/ExportService.swift
@@ -7,12 +7,14 @@ public protocol ExportServiceProtocol: Sendable {
     func exportToSRT(transcription: Transcription, url: URL) throws
     func exportToVTT(transcription: Transcription, url: URL) throws
     func exportToMarkdown(transcription: Transcription, url: URL) throws
+    func exportToAIText(transcription: Transcription, url: URL) throws
     func exportToJSON(transcription: Transcription, url: URL) throws
     @MainActor func exportToPDF(transcription: Transcription, url: URL) throws
     @MainActor func exportToDocx(transcription: Transcription, url: URL) throws
     func formatSRT(words: [WordTimestamp], speakers: [SpeakerInfo]?) -> String
     func formatVTT(words: [WordTimestamp], speakers: [SpeakerInfo]?) -> String
     func formatMarkdown(transcription: Transcription) -> String
+    func formatAIText(transcription: Transcription) -> String
     func formatForClipboard(transcription: Transcription) -> String
 }
 
@@ -191,6 +193,12 @@ public final class ExportService: ExportServiceProtocol, Sendable {
         try content.write(to: url, atomically: true, encoding: .utf8)
     }
 
+    /// Export transcription as timestamp-free text optimized for AI tools.
+    public func exportToAIText(transcription: Transcription, url: URL) throws {
+        let content = formatAIText(transcription: transcription)
+        try content.write(to: url, atomically: true, encoding: .utf8)
+    }
+
     /// Format transcription as Markdown string
     public func formatMarkdown(transcription: Transcription) -> String {
         var lines: [String] = []
@@ -249,9 +257,113 @@ public final class ExportService: ExportServiceProtocol, Sendable {
         return lines.joined(separator: "\n")
     }
 
+    /// Format a transcript without timestamps or metadata. This keeps user-edited
+    /// text authoritative, and otherwise derives readable paragraphs from timing
+    /// data when that is the best available structure.
+    public func formatAIText(transcription: Transcription) -> String {
+        if let edited = transcription.cleanTranscript?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !edited.isEmpty {
+            return normalizeParagraphText(edited)
+        }
+
+        if let timestamps = transcription.wordTimestamps, !timestamps.isEmpty {
+            let cues = buildSubtitleCues(from: timestamps)
+            if let speakers = transcription.speakers, !speakers.isEmpty {
+                return formatSpeakerParagraphs(cues: cues, speakers: speakers)
+            }
+
+            if let raw = transcription.rawTranscript?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !raw.isEmpty {
+                return normalizeParagraphText(raw)
+            }
+
+            return formatPlainParagraphs(cues: cues)
+        }
+
+        return normalizeParagraphText(preferredText(transcription: transcription))
+    }
+
     /// Format transcription text for clipboard copy
     public func formatForClipboard(transcription: Transcription) -> String {
         preferredText(transcription: transcription)
+    }
+
+    private func normalizeParagraphText(_ text: String) -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "" }
+
+        let normalizedNewlines = trimmed.replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        let rawParagraphs = normalizedNewlines.components(separatedBy: "\n\n")
+        let paragraphs = rawParagraphs
+            .map { paragraph in
+                paragraph
+                    .components(separatedBy: .newlines)
+                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                    .filter { !$0.isEmpty }
+                    .joined(separator: " ")
+            }
+            .filter { !$0.isEmpty }
+
+        return paragraphs.joined(separator: "\n\n")
+    }
+
+    private func formatPlainParagraphs(cues: [SubtitleCue]) -> String {
+        var paragraphs: [String] = []
+        var current: [String] = []
+        var wordCount = 0
+
+        for cue in cues {
+            let text = cue.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else { continue }
+
+            current.append(text)
+            wordCount += text.split(whereSeparator: \.isWhitespace).count
+            let endsSentence = text.last.map { ".!?".contains($0) } ?? false
+            if endsSentence && wordCount >= 55 || wordCount >= 90 {
+                paragraphs.append(current.joined(separator: " "))
+                current = []
+                wordCount = 0
+            }
+        }
+
+        if !current.isEmpty {
+            paragraphs.append(current.joined(separator: " "))
+        }
+
+        return paragraphs.joined(separator: "\n\n")
+    }
+
+    private func formatSpeakerParagraphs(cues: [SubtitleCue], speakers: [SpeakerInfo]) -> String {
+        var lines: [String] = []
+        var currentSpeakerId: String?
+        var currentText: [String] = []
+
+        func flush() {
+            guard !currentText.isEmpty else { return }
+            if let speaker = speakerLabel(for: currentSpeakerId, in: speakers) {
+                lines.append("\(speaker):")
+            }
+            lines.append(currentText.joined(separator: " "))
+            lines.append("")
+            currentText = []
+        }
+
+        for cue in cues {
+            let text = cue.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else { continue }
+            if cue.speakerId != currentSpeakerId {
+                flush()
+                currentSpeakerId = cue.speakerId
+            }
+            currentText.append(text)
+        }
+
+        flush()
+        while lines.last == "" {
+            lines.removeLast()
+        }
+        return lines.joined(separator: "\n")
     }
 
     // MARK: - Subtitle Cue Building

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -569,6 +569,10 @@ public final class TranscriptionViewModel {
     @discardableResult
     public func updateCurrentTranscriptText(to newText: String) -> Bool {
         guard var transcription = currentTranscription else { return false }
+        guard let repo = transcriptionRepo else {
+            reportMissingConfiguration("transcriptionRepo", action: "updateCurrentTranscriptText")
+            return false
+        }
         let trimmed = newText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return false }
 
@@ -579,7 +583,7 @@ public final class TranscriptionViewModel {
         transcription.updatedAt = Date()
 
         do {
-            try transcriptionRepo?.save(transcription)
+            try repo.save(transcription)
             currentTranscription = transcription
             if let index = transcriptions.firstIndex(where: { $0.id == transcription.id }) {
                 transcriptions[index] = transcription
@@ -596,12 +600,16 @@ public final class TranscriptionViewModel {
         guard var transcription = currentTranscription,
               transcription.cleanTranscript != nil
         else { return false }
+        guard let repo = transcriptionRepo else {
+            reportMissingConfiguration("transcriptionRepo", action: "revertCurrentTranscriptToOriginal")
+            return false
+        }
 
         transcription.cleanTranscript = nil
         transcription.updatedAt = Date()
 
         do {
-            try transcriptionRepo?.save(transcription)
+            try repo.save(transcription)
             currentTranscription = transcription
             if let index = transcriptions.firstIndex(where: { $0.id == transcription.id }) {
                 transcriptions[index] = transcription

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -564,6 +564,55 @@ public final class TranscriptionViewModel {
         self.llmAvailable = available
     }
 
+    // MARK: - Transcript Editing
+
+    @discardableResult
+    public func updateCurrentTranscriptText(to newText: String) -> Bool {
+        guard var transcription = currentTranscription else { return false }
+        let trimmed = newText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+
+        let currentText = transcription.cleanTranscript ?? transcription.rawTranscript ?? ""
+        guard trimmed != currentText else { return false }
+
+        transcription.cleanTranscript = trimmed == transcription.rawTranscript ? nil : trimmed
+        transcription.updatedAt = Date()
+
+        do {
+            try transcriptionRepo?.save(transcription)
+            currentTranscription = transcription
+            if let index = transcriptions.firstIndex(where: { $0.id == transcription.id }) {
+                transcriptions[index] = transcription
+            }
+            return true
+        } catch {
+            logger.error("Failed to persist transcript edit error=\(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
+    @discardableResult
+    public func revertCurrentTranscriptToOriginal() -> Bool {
+        guard var transcription = currentTranscription,
+              transcription.cleanTranscript != nil
+        else { return false }
+
+        transcription.cleanTranscript = nil
+        transcription.updatedAt = Date()
+
+        do {
+            try transcriptionRepo?.save(transcription)
+            currentTranscription = transcription
+            if let index = transcriptions.firstIndex(where: { $0.id == transcription.id }) {
+                transcriptions[index] = transcription
+            }
+            return true
+        } catch {
+            logger.error("Failed to persist transcript revert error=\(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
     // MARK: - Speaker Rename
 
     public func renameSpeaker(id speakerId: String, to newLabel: String) {

--- a/Tests/MacParakeetTests/Services/ExportServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/ExportServiceTests.swift
@@ -314,6 +314,65 @@ final class ExportServiceTests: XCTestCase {
         try? FileManager.default.removeItem(at: tempURL)
     }
 
+    func testFormatAITextPrefersEditedCleanTranscriptAndRemovesMetadata() {
+        let transcription = Transcription(
+            fileName: "video.mp4",
+            durationMs: 5000,
+            rawTranscript: "Original transcript.",
+            cleanTranscript: " Edited transcript.\nwith wrapped line. ",
+            wordTimestamps: [
+                WordTimestamp(word: "Original", startMs: 0, endMs: 500, confidence: 0.99),
+                WordTimestamp(word: "transcript.", startMs: 600, endMs: 1000, confidence: 0.98),
+            ],
+            status: .completed
+        )
+
+        let text = exportService.formatAIText(transcription: transcription)
+
+        XCTAssertEqual(text, "Edited transcript. with wrapped line.")
+        XCTAssertFalse(text.contains("video.mp4"))
+        XCTAssertFalse(text.contains("[0:"))
+    }
+
+    func testFormatAITextUsesSpeakerLabelsWithoutTimestamps() {
+        let transcription = Transcription(
+            fileName: "meeting.m4a",
+            wordTimestamps: [
+                WordTimestamp(word: "Hello.", startMs: 0, endMs: 500, confidence: 0.99, speakerId: "S1"),
+                WordTimestamp(word: "Hi.", startMs: 600, endMs: 1000, confidence: 0.98, speakerId: "S2"),
+            ],
+            speakers: [
+                SpeakerInfo(id: "S1", label: "Alice"),
+                SpeakerInfo(id: "S2", label: "Bob"),
+            ],
+            status: .completed
+        )
+
+        let text = exportService.formatAIText(transcription: transcription)
+
+        XCTAssertTrue(text.contains("Alice:\nHello."))
+        XCTAssertTrue(text.contains("Bob:\nHi."))
+        XCTAssertFalse(text.contains("[0:"))
+    }
+
+    func testExportToAIText() throws {
+        let transcription = Transcription(
+            fileName: "test.mp3",
+            rawTranscript: "Hello world",
+            status: .completed
+        )
+
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test_export_\(UUID().uuidString).md")
+
+        try exportService.exportToAIText(transcription: transcription, url: tempURL)
+
+        let content = try String(contentsOf: tempURL, encoding: .utf8)
+        XCTAssertEqual(content, "Hello world")
+
+        try? FileManager.default.removeItem(at: tempURL)
+    }
+
     // MARK: - New Export Formats
 
     func testExportToJSON() throws {

--- a/Tests/MacParakeetTests/Services/ExportServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/ExportServiceTests.swift
@@ -314,65 +314,6 @@ final class ExportServiceTests: XCTestCase {
         try? FileManager.default.removeItem(at: tempURL)
     }
 
-    func testFormatAITextPrefersEditedCleanTranscriptAndRemovesMetadata() {
-        let transcription = Transcription(
-            fileName: "video.mp4",
-            durationMs: 5000,
-            rawTranscript: "Original transcript.",
-            cleanTranscript: " Edited transcript.\nwith wrapped line. ",
-            wordTimestamps: [
-                WordTimestamp(word: "Original", startMs: 0, endMs: 500, confidence: 0.99),
-                WordTimestamp(word: "transcript.", startMs: 600, endMs: 1000, confidence: 0.98),
-            ],
-            status: .completed
-        )
-
-        let text = exportService.formatAIText(transcription: transcription)
-
-        XCTAssertEqual(text, "Edited transcript. with wrapped line.")
-        XCTAssertFalse(text.contains("video.mp4"))
-        XCTAssertFalse(text.contains("[0:"))
-    }
-
-    func testFormatAITextUsesSpeakerLabelsWithoutTimestamps() {
-        let transcription = Transcription(
-            fileName: "meeting.m4a",
-            wordTimestamps: [
-                WordTimestamp(word: "Hello.", startMs: 0, endMs: 500, confidence: 0.99, speakerId: "S1"),
-                WordTimestamp(word: "Hi.", startMs: 600, endMs: 1000, confidence: 0.98, speakerId: "S2"),
-            ],
-            speakers: [
-                SpeakerInfo(id: "S1", label: "Alice"),
-                SpeakerInfo(id: "S2", label: "Bob"),
-            ],
-            status: .completed
-        )
-
-        let text = exportService.formatAIText(transcription: transcription)
-
-        XCTAssertTrue(text.contains("Alice:\nHello."))
-        XCTAssertTrue(text.contains("Bob:\nHi."))
-        XCTAssertFalse(text.contains("[0:"))
-    }
-
-    func testExportToAIText() throws {
-        let transcription = Transcription(
-            fileName: "test.mp3",
-            rawTranscript: "Hello world",
-            status: .completed
-        )
-
-        let tempURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("test_export_\(UUID().uuidString).md")
-
-        try exportService.exportToAIText(transcription: transcription, url: tempURL)
-
-        let content = try String(contentsOf: tempURL, encoding: .utf8)
-        XCTAssertEqual(content, "Hello world")
-
-        try? FileManager.default.removeItem(at: tempURL)
-    }
-
     // MARK: - New Export Formats
 
     func testExportToJSON() throws {

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -636,6 +636,92 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.llmAvailable)
     }
 
+    // MARK: - Transcript Editing
+
+    func testUpdateCurrentTranscriptTextStoresEditedTextAsCleanTranscript() throws {
+        let t = Transcription(fileName: "test.mp3", rawTranscript: "Original transcript", status: .completed)
+        mockRepo.transcriptions = [t]
+
+        viewModel.configure(transcriptionService: mockService, transcriptionRepo: mockRepo)
+        viewModel.currentTranscription = t
+
+        let saved = viewModel.updateCurrentTranscriptText(to: " Corrected transcript ")
+
+        XCTAssertTrue(saved)
+        XCTAssertEqual(viewModel.currentTranscription?.rawTranscript, "Original transcript")
+        XCTAssertEqual(viewModel.currentTranscription?.cleanTranscript, "Corrected transcript")
+        let persisted = try XCTUnwrap(mockRepo.fetch(id: t.id))
+        XCTAssertEqual(persisted.rawTranscript, "Original transcript")
+        XCTAssertEqual(persisted.cleanTranscript, "Corrected transcript")
+    }
+
+    func testUpdateCurrentTranscriptTextRejectsEmptyText() {
+        let t = Transcription(fileName: "test.mp3", rawTranscript: "Original transcript", status: .completed)
+        mockRepo.transcriptions = [t]
+
+        viewModel.configure(transcriptionService: mockService, transcriptionRepo: mockRepo)
+        viewModel.currentTranscription = t
+
+        let saved = viewModel.updateCurrentTranscriptText(to: "   ")
+
+        XCTAssertFalse(saved)
+        XCTAssertNil(viewModel.currentTranscription?.cleanTranscript)
+    }
+
+    func testUpdateCurrentTranscriptTextKeepsStateWhenSaveFails() {
+        let t = Transcription(fileName: "test.mp3", rawTranscript: "Original transcript", status: .completed)
+        mockRepo.transcriptions = [t]
+        mockRepo.saveError = NSError(domain: "repo", code: 1)
+
+        viewModel.configure(transcriptionService: mockService, transcriptionRepo: mockRepo)
+        viewModel.currentTranscription = t
+
+        let saved = viewModel.updateCurrentTranscriptText(to: "Corrected transcript")
+
+        XCTAssertFalse(saved)
+        XCTAssertEqual(viewModel.currentTranscription?.rawTranscript, "Original transcript")
+        XCTAssertNil(viewModel.currentTranscription?.cleanTranscript)
+    }
+
+    func testRevertCurrentTranscriptToOriginalClearsCleanTranscript() throws {
+        let t = Transcription(
+            fileName: "test.mp3",
+            rawTranscript: "Original transcript",
+            cleanTranscript: "Corrected transcript",
+            status: .completed
+        )
+        mockRepo.transcriptions = [t]
+
+        viewModel.configure(transcriptionService: mockService, transcriptionRepo: mockRepo)
+        viewModel.currentTranscription = t
+
+        let reverted = viewModel.revertCurrentTranscriptToOriginal()
+
+        XCTAssertTrue(reverted)
+        XCTAssertNil(viewModel.currentTranscription?.cleanTranscript)
+        let persisted = try XCTUnwrap(mockRepo.fetch(id: t.id))
+        XCTAssertNil(persisted.cleanTranscript)
+    }
+
+    func testRevertCurrentTranscriptToOriginalKeepsStateWhenSaveFails() {
+        let t = Transcription(
+            fileName: "test.mp3",
+            rawTranscript: "Original transcript",
+            cleanTranscript: "Corrected transcript",
+            status: .completed
+        )
+        mockRepo.transcriptions = [t]
+        mockRepo.saveError = NSError(domain: "repo", code: 1)
+
+        viewModel.configure(transcriptionService: mockService, transcriptionRepo: mockRepo)
+        viewModel.currentTranscription = t
+
+        let reverted = viewModel.revertCurrentTranscriptToOriginal()
+
+        XCTAssertFalse(reverted)
+        XCTAssertEqual(viewModel.currentTranscription?.cleanTranscript, "Corrected transcript")
+    }
+
     // MARK: - Speaker Rename
 
     func testRenameSpeakerUpdatesInMemoryState() {

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -683,6 +683,17 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.currentTranscription?.cleanTranscript)
     }
 
+    func testUpdateCurrentTranscriptTextFailsWithoutConfiguredRepository() {
+        let t = Transcription(fileName: "test.mp3", rawTranscript: "Original transcript", status: .completed)
+        viewModel.currentTranscription = t
+
+        let saved = viewModel.updateCurrentTranscriptText(to: "Corrected transcript")
+
+        XCTAssertFalse(saved)
+        XCTAssertEqual(viewModel.currentTranscription?.rawTranscript, "Original transcript")
+        XCTAssertNil(viewModel.currentTranscription?.cleanTranscript)
+    }
+
     func testRevertCurrentTranscriptToOriginalClearsCleanTranscript() throws {
         let t = Transcription(
             fileName: "test.mp3",
@@ -714,6 +725,21 @@ final class TranscriptionViewModelTests: XCTestCase {
         mockRepo.saveError = NSError(domain: "repo", code: 1)
 
         viewModel.configure(transcriptionService: mockService, transcriptionRepo: mockRepo)
+        viewModel.currentTranscription = t
+
+        let reverted = viewModel.revertCurrentTranscriptToOriginal()
+
+        XCTAssertFalse(reverted)
+        XCTAssertEqual(viewModel.currentTranscription?.cleanTranscript, "Corrected transcript")
+    }
+
+    func testRevertCurrentTranscriptToOriginalFailsWithoutConfiguredRepository() {
+        let t = Transcription(
+            fileName: "test.mp3",
+            rawTranscript: "Original transcript",
+            cleanTranscript: "Corrected transcript",
+            status: .completed
+        )
         viewModel.currentTranscription = t
 
         let reverted = viewModel.revertCurrentTranscriptToOriginal()

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -113,8 +113,12 @@ final class MockTranscriptionRepository: TranscriptionRepositoryProtocol, @unche
     var updateSummaryCalls: [(id: UUID, summary: String?)] = []
     var updateChatMessagesCalls: [(id: UUID, chatMessages: [ChatMessage]?)] = []
     var updateSpeakersCalls: [(id: UUID, speakers: [SpeakerInfo]?)] = []
+    var saveError: Error?
 
     func save(_ transcription: Transcription) throws {
+        if let saveError {
+            throw saveError
+        }
         if let idx = transcriptions.firstIndex(where: { $0.id == transcription.id }) {
             transcriptions[idx] = transcription
         } else {


### PR DESCRIPTION
## Summary

Add inline editing for completed transcripts while preserving the original transcript, timestamps, and speaker data.

```text
rawTranscript + word timestamps + speakers
                 |
                 | user edits transcript text
                 v
cleanTranscript (edited text)
                 |
                 +--> Text view / Copy / Chat context
                 +--> Revert clears cleanTranscript
                 +--> Timed view keeps timestamped playback data
```

Closes #128.

## What changed

- Added an inline transcript editor with Edit, Save, Cancel, Revert, and an Edited state indicator.
- Persist user edits in `cleanTranscript` while preserving `rawTranscript`, speakers, and word timestamps.
- Added Text/Timed switching when edited text and timestamp data both exist.
- Refresh chat context after transcript save/revert so follow-up questions use the visible transcript text.
- Require repository persistence before edit/revert mutates in-memory state.
- Keep timed transcript caches, speaker labels, speaker overview, export, copy, and mandala data aligned with the active transcription.
- Removed the experimental AI Text export/copy surface from this PR.

## Review Status

- Fresh pass over final diff against `origin/main`: no additional code changes needed.
- Previous bot feedback is addressed in code:
  - transcript pane only shows speaker overview with a valid timed view
  - edit/revert no longer optional-chain repository saves
  - cancel restores the previous transcript display mode
  - timed transcript caches use `activeTranscription`
  - AI Text ExportService feedback is obsolete because that scope was removed
- PR is mergeable and GitHub CI is green.

## Validation

- `git diff --check`
- `swift build`
- `swift test --filter TranscriptionViewModelTests`
- `swift test`
  - 1459 XCTest tests passed
  - 13 Swift Testing tests passed


