### PR TITLE
Add configurable transcript export options

### DIFF
--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
@@ -2,8 +2,10 @@ import AppKit
 import Foundation
 import MacParakeetCore
 
-enum TranscriptExportFormat: String {
+enum TranscriptExportFormat: String, CaseIterable, Identifiable {
     case txt, md, srt, vtt, docx, pdf, json
+
+    var id: String { rawValue }
 
     var displayName: String {
         switch self {
@@ -15,6 +17,34 @@ enum TranscriptExportFormat: String {
         case .pdf: "PDF"
         case .json: "JSON"
         }
+    }
+
+    var shortName: String {
+        switch self {
+        case .txt: "Text"
+        case .md: "Markdown"
+        case .srt: "SRT"
+        case .vtt: "VTT"
+        case .docx: "DOCX"
+        case .pdf: "PDF"
+        case .json: "JSON"
+        }
+    }
+
+    var iconName: String {
+        switch self {
+        case .txt: "doc.text"
+        case .md: "text.document"
+        case .srt: "captions.bubble"
+        case .vtt: "captions.bubble.fill"
+        case .docx: "doc.richtext"
+        case .pdf: "doc.viewfinder"
+        case .json: "curlybraces"
+        }
+    }
+
+    var supportsTranscriptOptions: Bool {
+        self == .txt || self == .md
     }
 }
 
@@ -50,7 +80,8 @@ enum TranscriptResultActions {
 
     static func exportTranscriptToDownloads(
         transcription: Transcription,
-        format: TranscriptExportFormat
+        format: TranscriptExportFormat,
+        options: TranscriptExportOptions = .default
     ) throws -> URL {
         let stem = TranscriptSegmenter.sanitizedExportStem(from: transcription.fileName)
         let downloadsURL = try downloadsDirectory()
@@ -58,8 +89,8 @@ enum TranscriptResultActions {
         let exportService = ExportService()
 
         switch format {
-        case .txt: try exportService.exportToTxt(transcription: transcription, url: fileURL)
-        case .md: try exportService.exportToMarkdown(transcription: transcription, url: fileURL)
+        case .txt: try exportService.exportToTxt(transcription: transcription, url: fileURL, options: options)
+        case .md: try exportService.exportToMarkdown(transcription: transcription, url: fileURL, options: options)
         case .srt: try exportService.exportToSRT(transcription: transcription, url: fileURL)
         case .vtt: try exportService.exportToVTT(transcription: transcription, url: fileURL)
         case .docx: try exportService.exportToDocx(transcription: transcription, url: fileURL)

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -38,6 +38,9 @@ struct TranscriptResultView: View {
     @State private var hoveredMessageId: UUID?
     @State private var exportConfirmation: ExportConfirmation?
     @State private var exportErrorMessage: String?
+    @State private var showingExportOptions = false
+    @State private var selectedExportFormat: TranscriptExportFormat = .txt
+    @State private var transcriptExportOptions = TranscriptExportOptions.default
     @State private var copiedResetTask: Task<Void, Never>?
     @State private var resultCopiedResetTask: Task<Void, Never>?
     @State private var resultButtonCopiedResetTask: Task<Void, Never>?
@@ -374,44 +377,14 @@ struct TranscriptResultView: View {
             }
             .buttonStyle(.bordered)
 
-            Menu {
-                Section("Document") {
-                    Button { exportToDownloads(format: .txt) } label: {
-                        Label("Plain Text (.txt)", systemImage: "doc.text")
-                    }
-                    Button { exportToDownloads(format: .md) } label: {
-                        Label("Markdown (.md)", systemImage: "text.document")
-                    }
-                    Button { exportToDownloads(format: .docx) } label: {
-                        Label("Word Document (.docx)", systemImage: "doc.richtext")
-                    }
-                    Button { exportToDownloads(format: .pdf) } label: {
-                        Label("PDF Document (.pdf)", systemImage: "doc.viewfinder")
-                    }
-                }
-
-                Section("Data") {
-                    Button { exportToDownloads(format: .json) } label: {
-                        Label("Raw Data (.json)", systemImage: "curlybraces")
-                    }
-                }
-
-                if hasTimestamps {
-                    Section("Subtitles") {
-                        Button { exportToDownloads(format: .srt) } label: {
-                            Label("SRT (.srt)", systemImage: "captions.bubble")
-                        }
-                        Button { exportToDownloads(format: .vtt) } label: {
-                            Label("WebVTT (.vtt)", systemImage: "captions.bubble.fill")
-                        }
-                    }
-                }
+            Button {
+                showingExportOptions.toggle()
             } label: {
                 Label("Export", systemImage: "arrow.down.doc")
             }
-            .menuStyle(.borderedButton)
-            .popover(item: $exportConfirmation, arrowEdge: .top) { confirmation in
-                exportConfirmationPopover(confirmation)
+            .buttonStyle(.bordered)
+            .popover(isPresented: $showingExportOptions, arrowEdge: .top) {
+                exportOptionsPopover
             }
 
             if let onRetranscribe, let filePath = transcription.filePath,
@@ -445,6 +418,9 @@ struct TranscriptResultView: View {
             Spacer()
         }
         .padding(DesignSystem.Spacing.md)
+        .popover(item: $exportConfirmation, arrowEdge: .top) { confirmation in
+            exportConfirmationPopover(confirmation)
+        }
     }
 
     private var activeTranscription: Transcription {
@@ -2226,6 +2202,126 @@ struct TranscriptResultView: View {
         return !words.isEmpty
     }
 
+    private var hasSpeakerLabelsForExport: Bool {
+        guard let speakers = activeTranscription.speakers, !speakers.isEmpty,
+              let words = activeTranscription.wordTimestamps else { return false }
+        return words.contains { $0.speakerId != nil }
+    }
+
+    private var resolvedTranscriptExportOptions: TranscriptExportOptions {
+        var options = transcriptExportOptions
+        if !hasTimestamps {
+            options.includeTimestamps = false
+        }
+        if !hasSpeakerLabelsForExport {
+            options.includeSpeakerLabels = false
+        }
+        return options
+    }
+
+    private var exportFormatOrder: [TranscriptExportFormat] {
+        [.txt, .md, .srt, .vtt, .json, .pdf, .docx]
+    }
+
+    private var exportOptionsPopover: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+            HStack(spacing: DesignSystem.Spacing.sm) {
+                Label("Export Transcript", systemImage: "arrow.down.doc")
+                    .font(DesignSystem.Typography.body.bold())
+
+                Spacer()
+
+                Button {
+                    showingExportOptions = false
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Close export options")
+            }
+
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
+                Text("Format")
+                    .font(DesignSystem.Typography.caption.weight(.medium))
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+
+                LazyVGrid(
+                    columns: [GridItem(.adaptive(minimum: 104), spacing: 8)],
+                    alignment: .leading,
+                    spacing: 8
+                ) {
+                    ForEach(exportFormatOrder) { format in
+                        Button {
+                            selectedExportFormat = format
+                        } label: {
+                            HStack(spacing: 6) {
+                                Image(systemName: format.iconName)
+                                    .frame(width: 16)
+                                Text(format.shortName)
+                                    .lineLimit(1)
+                                    .minimumScaleFactor(0.85)
+                                Spacer(minLength: 0)
+                            }
+                            .font(DesignSystem.Typography.caption)
+                            .padding(.horizontal, 9)
+                            .padding(.vertical, 7)
+                            .frame(maxWidth: .infinity)
+                            .background(
+                                RoundedRectangle(cornerRadius: 6)
+                                    .fill(selectedExportFormat == format
+                                          ? DesignSystem.Colors.accent.opacity(0.14)
+                                          : DesignSystem.Colors.surface)
+                            )
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 6)
+                                    .strokeBorder(
+                                        selectedExportFormat == format
+                                        ? DesignSystem.Colors.accent.opacity(0.7)
+                                        : DesignSystem.Colors.border.opacity(0.7),
+                                        lineWidth: 1
+                                    )
+                            )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
+                Text("Options")
+                    .font(DesignSystem.Typography.caption.weight(.medium))
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+
+                Toggle("Include timestamps", isOn: $transcriptExportOptions.includeTimestamps)
+                    .disabled(!selectedExportFormat.supportsTranscriptOptions || !hasTimestamps)
+
+                Toggle("Include speaker labels", isOn: $transcriptExportOptions.includeSpeakerLabels)
+                    .disabled(!selectedExportFormat.supportsTranscriptOptions || !hasSpeakerLabelsForExport)
+
+                Toggle("Include metadata", isOn: $transcriptExportOptions.includeMetadata)
+                    .disabled(!selectedExportFormat.supportsTranscriptOptions)
+            }
+
+            Divider()
+
+            HStack {
+                Spacer()
+                Button {
+                    showingExportOptions = false
+                    exportToDownloads(format: selectedExportFormat)
+                } label: {
+                    Label("Export", systemImage: "arrow.down.doc")
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(DesignSystem.Spacing.md)
+        .frame(width: 380)
+    }
+
     // MARK: - Export Confirmation Popover
 
     @ViewBuilder
@@ -2308,7 +2404,8 @@ struct TranscriptResultView: View {
         do {
             let fileURL = try TranscriptResultActions.exportTranscriptToDownloads(
                 transcription: source,
-                format: format
+                format: format,
+                options: format.supportsTranscriptOptions ? resolvedTranscriptExportOptions : .default
             )
             exportErrorMessage = nil
             SoundManager.shared.play(.transcriptionComplete)

--- a/Sources/MacParakeetCore/Services/ExportService.swift
+++ b/Sources/MacParakeetCore/Services/ExportService.swift
@@ -264,23 +264,30 @@ public final class ExportService: ExportServiceProtocol, Sendable {
         if let timestamps = transcription.wordTimestamps, !timestamps.isEmpty {
             let cues = buildSubtitleCues(from: timestamps)
             if options.includeTimestamps || options.includeSpeakerLabels {
-                var lastSpeakerId: String? = nil
-                for cue in cues {
-                    if options.includeSpeakerLabels,
-                       let label = speakerLabel(for: cue.speakerId, in: transcription.speakers),
-                       cue.speakerId != lastSpeakerId {
-                        lines.append("**\(label)**")
-                        lines.append("")
-                    }
-                    lastSpeakerId = cue.speakerId
+                if options.includeTimestamps {
+                    var lastSpeakerId: String? = nil
+                    for cue in cues {
+                        if options.includeSpeakerLabels,
+                           let label = speakerLabel(for: cue.speakerId, in: transcription.speakers),
+                           cue.speakerId != lastSpeakerId {
+                            lines.append("**\(label)**")
+                            lines.append("")
+                        }
+                        lastSpeakerId = cue.speakerId
 
-                    if options.includeTimestamps {
                         let ts = formatReadableTimestamp(ms: cue.startMs)
                         lines.append("**[\(ts)]** \(cue.text)")
-                    } else {
-                        lines.append(cue.text)
+                        lines.append("")
                     }
-                    lines.append("")
+                } else {
+                    for paragraph in speakerParagraphs(from: cues, speakers: transcription.speakers) {
+                        if let label = paragraph.label {
+                            lines.append("**\(label)**")
+                            lines.append("")
+                        }
+                        lines.append(paragraph.text)
+                        lines.append("")
+                    }
                 }
             } else {
                 let text = preferredText(transcription: transcription)
@@ -423,22 +430,30 @@ public final class ExportService: ExportServiceProtocol, Sendable {
         if let timestamps = transcription.wordTimestamps, !timestamps.isEmpty {
             let cues = buildSubtitleCues(from: timestamps)
             if options.includeTimestamps || options.includeSpeakerLabels {
-                var lastSpeakerId: String? = nil
-                for cue in cues {
-                    if options.includeSpeakerLabels,
-                       let label = speakerLabel(for: cue.speakerId, in: transcription.speakers),
-                       cue.speakerId != lastSpeakerId {
-                        if !lines.isEmpty, lines.last != "" {
-                            lines.append("")
+                if options.includeTimestamps {
+                    var lastSpeakerId: String? = nil
+                    for cue in cues {
+                        if options.includeSpeakerLabels,
+                           let label = speakerLabel(for: cue.speakerId, in: transcription.speakers),
+                           cue.speakerId != lastSpeakerId {
+                            if !lines.isEmpty, lines.last != "" {
+                                lines.append("")
+                            }
+                            lines.append("\(label):")
                         }
-                        lines.append("\(label):")
-                    }
-                    lastSpeakerId = cue.speakerId
+                        lastSpeakerId = cue.speakerId
 
-                    if options.includeTimestamps {
                         lines.append("[\(formatReadableTimestamp(ms: cue.startMs))] \(cue.text)")
-                    } else {
-                        lines.append(cue.text)
+                    }
+                } else {
+                    for paragraph in speakerParagraphs(from: cues, speakers: transcription.speakers) {
+                        if let label = paragraph.label {
+                            if !lines.isEmpty, lines.last != "" {
+                                lines.append("")
+                            }
+                            lines.append("\(label):")
+                        }
+                        lines.append(paragraph.text)
                     }
                 }
             } else {
@@ -453,6 +468,30 @@ public final class ExportService: ExportServiceProtocol, Sendable {
         }
 
         return lines.joined(separator: "\n")
+    }
+
+    private struct SpeakerParagraph {
+        var speakerId: String?
+        var label: String?
+        var text: String
+    }
+
+    private func speakerParagraphs(from cues: [SubtitleCue], speakers: [SpeakerInfo]?) -> [SpeakerParagraph] {
+        var paragraphs: [SpeakerParagraph] = []
+        for cue in cues {
+            let label = speakerLabel(for: cue.speakerId, in: speakers)
+            if let last = paragraphs.indices.last,
+               paragraphs[last].speakerId == cue.speakerId {
+                paragraphs[last].text += " \(cue.text)"
+            } else {
+                paragraphs.append(SpeakerParagraph(
+                    speakerId: cue.speakerId,
+                    label: label,
+                    text: cue.text
+                ))
+            }
+        }
+        return paragraphs
     }
 
     // MARK: - Rich Text (AppKit)

--- a/Sources/MacParakeetCore/Services/ExportService.swift
+++ b/Sources/MacParakeetCore/Services/ExportService.swift
@@ -16,6 +16,24 @@ public protocol ExportServiceProtocol: Sendable {
     func formatForClipboard(transcription: Transcription) -> String
 }
 
+public struct TranscriptExportOptions: Sendable, Equatable {
+    public var includeTimestamps: Bool
+    public var includeSpeakerLabels: Bool
+    public var includeMetadata: Bool
+
+    public init(
+        includeTimestamps: Bool = true,
+        includeSpeakerLabels: Bool = true,
+        includeMetadata: Bool = true
+    ) {
+        self.includeTimestamps = includeTimestamps
+        self.includeSpeakerLabels = includeSpeakerLabels
+        self.includeMetadata = includeMetadata
+    }
+
+    public static let `default` = TranscriptExportOptions()
+}
+
 /// Handles exporting transcriptions to files and clipboard.
 /// @MainActor because PDF/DOCX paths use NSTextStorage/NSLayoutManager (AppKit, not thread-safe).
 @MainActor
@@ -28,7 +46,15 @@ public final class ExportService: ExportServiceProtocol, Sendable {
 
     /// Export transcription as plain text file
     public func exportToTxt(transcription: Transcription, url: URL) throws {
-        let content = formatPlainText(transcription: transcription)
+        try exportToTxt(transcription: transcription, url: url, options: .default)
+    }
+
+    public func exportToTxt(
+        transcription: Transcription,
+        url: URL,
+        options: TranscriptExportOptions
+    ) throws {
+        let content = formatPlainText(transcription: transcription, options: options)
         try content.write(to: url, atomically: true, encoding: .utf8)
     }
 
@@ -187,55 +213,78 @@ public final class ExportService: ExportServiceProtocol, Sendable {
 
     /// Export transcription as Markdown file
     public func exportToMarkdown(transcription: Transcription, url: URL) throws {
-        let content = formatMarkdown(transcription: transcription)
+        try exportToMarkdown(transcription: transcription, url: url, options: .default)
+    }
+
+    public func exportToMarkdown(
+        transcription: Transcription,
+        url: URL,
+        options: TranscriptExportOptions
+    ) throws {
+        let content = formatMarkdown(transcription: transcription, options: options)
         try content.write(to: url, atomically: true, encoding: .utf8)
     }
 
     /// Format transcription as Markdown string
     public func formatMarkdown(transcription: Transcription) -> String {
+        formatMarkdown(transcription: transcription, options: .default)
+    }
+
+    public func formatMarkdown(transcription: Transcription, options: TranscriptExportOptions) -> String {
         var lines: [String] = []
 
-        // Title
-        lines.append("# \(transcription.fileName)")
-        lines.append("")
+        if options.includeMetadata {
+            lines.append("# \(transcription.fileName)")
+            lines.append("")
 
-        // Metadata table
-        var meta: [String] = []
-        if let durationMs = transcription.durationMs {
-            meta.append("**Duration:** \(durationMs.formattedDuration)")
-        }
-        if let sourceURL = transcription.sourceURL {
-            meta.append("**Source:** [\(sourceURL)](\(sourceURL))")
-        }
-        let formatter = DateFormatter()
-        formatter.dateStyle = .medium
-        formatter.timeStyle = .short
-        meta.append("**Transcribed:** \(formatter.string(from: transcription.createdAt))")
-        if let language = transcription.language {
-            meta.append("**Language:** \(language)")
-        }
+            var meta: [String] = []
+            if let durationMs = transcription.durationMs {
+                meta.append("**Duration:** \(durationMs.formattedDuration)")
+            }
+            if let sourceURL = transcription.sourceURL {
+                meta.append("**Source:** [\(sourceURL)](\(sourceURL))")
+            }
+            let formatter = DateFormatter()
+            formatter.dateStyle = .medium
+            formatter.timeStyle = .short
+            meta.append("**Transcribed:** \(formatter.string(from: transcription.createdAt))")
+            if let language = transcription.language {
+                meta.append("**Language:** \(language)")
+            }
 
-        if !meta.isEmpty {
-            lines.append(contentsOf: meta)
+            if !meta.isEmpty {
+                lines.append(contentsOf: meta)
+                lines.append("")
+            }
+
+            lines.append("---")
             lines.append("")
         }
 
-        lines.append("---")
-        lines.append("")
-
-        // Transcript body
         if let timestamps = transcription.wordTimestamps, !timestamps.isEmpty {
             let cues = buildSubtitleCues(from: timestamps)
-            var lastSpeakerId: String? = nil
-            for cue in cues {
-                let ts = formatReadableTimestamp(ms: cue.startMs)
-                if let label = speakerLabel(for: cue.speakerId, in: transcription.speakers),
-                   cue.speakerId != lastSpeakerId {
-                    lines.append("**\(label)**")
+            if options.includeTimestamps || options.includeSpeakerLabels {
+                var lastSpeakerId: String? = nil
+                for cue in cues {
+                    if options.includeSpeakerLabels,
+                       let label = speakerLabel(for: cue.speakerId, in: transcription.speakers),
+                       cue.speakerId != lastSpeakerId {
+                        lines.append("**\(label)**")
+                        lines.append("")
+                    }
+                    lastSpeakerId = cue.speakerId
+
+                    if options.includeTimestamps {
+                        let ts = formatReadableTimestamp(ms: cue.startMs)
+                        lines.append("**[\(ts)]** \(cue.text)")
+                    } else {
+                        lines.append(cue.text)
+                    }
                     lines.append("")
                 }
-                lastSpeakerId = cue.speakerId
-                lines.append("**[\(ts)]** \(cue.text)")
+            } else {
+                let text = preferredText(transcription: transcription)
+                lines.append(text.isEmpty ? cues.map(\.text).joined(separator: " ") : text)
                 lines.append("")
             }
         } else {
@@ -360,28 +409,41 @@ public final class ExportService: ExportServiceProtocol, Sendable {
 
     // MARK: - Plain Text
 
-    private func formatPlainText(transcription: Transcription) -> String {
+    public func formatPlainText(transcription: Transcription, options: TranscriptExportOptions = .default) -> String {
         var lines: [String] = []
 
-        // Header
-        lines.append(transcription.fileName)
-        if let durationMs = transcription.durationMs {
-            lines.append("Duration: \(durationMs.formattedDuration)")
+        if options.includeMetadata {
+            lines.append(transcription.fileName)
+            if let durationMs = transcription.durationMs {
+                lines.append("Duration: \(durationMs.formattedDuration)")
+            }
+            lines.append("")
         }
-        lines.append("")
 
-        // Transcript with timestamps and speaker labels at turn changes
         if let timestamps = transcription.wordTimestamps, !timestamps.isEmpty {
             let cues = buildSubtitleCues(from: timestamps)
-            var lastSpeakerId: String? = nil
-            for cue in cues {
-                if let label = speakerLabel(for: cue.speakerId, in: transcription.speakers),
-                   cue.speakerId != lastSpeakerId {
-                    lines.append("")
-                    lines.append("\(label):")
+            if options.includeTimestamps || options.includeSpeakerLabels {
+                var lastSpeakerId: String? = nil
+                for cue in cues {
+                    if options.includeSpeakerLabels,
+                       let label = speakerLabel(for: cue.speakerId, in: transcription.speakers),
+                       cue.speakerId != lastSpeakerId {
+                        if !lines.isEmpty, lines.last != "" {
+                            lines.append("")
+                        }
+                        lines.append("\(label):")
+                    }
+                    lastSpeakerId = cue.speakerId
+
+                    if options.includeTimestamps {
+                        lines.append("[\(formatReadableTimestamp(ms: cue.startMs))] \(cue.text)")
+                    } else {
+                        lines.append(cue.text)
+                    }
                 }
-                lastSpeakerId = cue.speakerId
-                lines.append(cue.text)
+            } else {
+                let text = preferredText(transcription: transcription)
+                lines.append(text.isEmpty ? cues.map(\.text).joined(separator: " ") : text)
             }
         } else {
             let text = preferredText(transcription: transcription)

--- a/Tests/MacParakeetTests/Services/ExportServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/ExportServiceTests.swift
@@ -83,6 +83,87 @@ final class ExportServiceTests: XCTestCase {
         try? FileManager.default.removeItem(at: tempURL)
     }
 
+    func testFormatPlainTextDefaultIncludesMetadataTimestampsAndSpeakers() {
+        let transcription = makeExportOptionsTranscription()
+
+        let text = exportService.formatPlainText(transcription: transcription)
+
+        XCTAssertTrue(text.contains("interview.mp3"))
+        XCTAssertTrue(text.contains("Duration: 0:05"))
+        XCTAssertTrue(text.contains("Alice:"))
+        XCTAssertTrue(text.contains("Bob:"))
+        XCTAssertTrue(text.contains("[0:00] Hello."))
+        XCTAssertTrue(text.contains("[0:02] Goodbye."))
+    }
+
+    func testFormatPlainTextCanOmitMetadataTimestampsAndSpeakers() {
+        let transcription = makeExportOptionsTranscription(cleanTranscript: "Edited transcript without timing.")
+        let options = TranscriptExportOptions(
+            includeTimestamps: false,
+            includeSpeakerLabels: false,
+            includeMetadata: false
+        )
+
+        let text = exportService.formatPlainText(transcription: transcription, options: options)
+
+        XCTAssertEqual(text, "Edited transcript without timing.")
+        XCTAssertFalse(text.contains("interview.mp3"))
+        XCTAssertFalse(text.contains("Duration:"))
+        XCTAssertFalse(text.contains("Alice:"))
+        XCTAssertFalse(text.contains("[0:00]"))
+    }
+
+    func testFormatPlainTextCanKeepSpeakersWithoutTimestamps() {
+        let transcription = makeExportOptionsTranscription()
+        let options = TranscriptExportOptions(
+            includeTimestamps: false,
+            includeSpeakerLabels: true,
+            includeMetadata: false
+        )
+
+        let text = exportService.formatPlainText(transcription: transcription, options: options)
+
+        XCTAssertTrue(text.contains("Alice:"))
+        XCTAssertTrue(text.contains("Bob:"))
+        XCTAssertTrue(text.contains("Hello."))
+        XCTAssertFalse(text.contains("[0:00]"))
+    }
+
+    func testFormatMarkdownCanOmitMetadataTimestampsAndSpeakers() {
+        let transcription = makeExportOptionsTranscription(cleanTranscript: "Edited transcript without timing.")
+        let options = TranscriptExportOptions(
+            includeTimestamps: false,
+            includeSpeakerLabels: false,
+            includeMetadata: false
+        )
+
+        let markdown = exportService.formatMarkdown(transcription: transcription, options: options)
+
+        XCTAssertEqual(markdown.trimmingCharacters(in: .whitespacesAndNewlines), "Edited transcript without timing.")
+        XCTAssertFalse(markdown.contains("# interview.mp3"))
+        XCTAssertFalse(markdown.contains("**Duration:**"))
+        XCTAssertFalse(markdown.contains("**Alice**"))
+        XCTAssertFalse(markdown.contains("**[0:00]**"))
+    }
+
+    func testExportToMarkdownUsesOptions() throws {
+        let transcription = makeExportOptionsTranscription(cleanTranscript: "Edited transcript without timing.")
+        let options = TranscriptExportOptions(
+            includeTimestamps: false,
+            includeSpeakerLabels: false,
+            includeMetadata: false
+        )
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test_export_options_\(UUID().uuidString).md")
+
+        try exportService.exportToMarkdown(transcription: transcription, url: tempURL, options: options)
+        let content = try String(contentsOf: tempURL, encoding: .utf8)
+
+        XCTAssertEqual(content.trimmingCharacters(in: .whitespacesAndNewlines), "Edited transcript without timing.")
+
+        try? FileManager.default.removeItem(at: tempURL)
+    }
+
     // MARK: - SRT Timestamp Formatting
 
     func testSRTTimestampFormatting() {
@@ -640,5 +721,23 @@ final class ExportServiceTests: XCTestCase {
         // Should still use word timestamps path (no speaker labels)
         XCTAssertTrue(content.contains("Hello world."))
         XCTAssertFalse(content.contains("Speaker"))
+    }
+
+    private func makeExportOptionsTranscription(cleanTranscript: String? = nil) -> Transcription {
+        Transcription(
+            fileName: "interview.mp3",
+            durationMs: 5000,
+            rawTranscript: "Hello. Goodbye.",
+            cleanTranscript: cleanTranscript,
+            wordTimestamps: [
+                WordTimestamp(word: "Hello.", startMs: 0, endMs: 500, confidence: 0.99, speakerId: "S1"),
+                WordTimestamp(word: "Goodbye.", startMs: 2000, endMs: 2500, confidence: 0.97, speakerId: "S2"),
+            ],
+            speakers: [
+                SpeakerInfo(id: "S1", label: "Alice"),
+                SpeakerInfo(id: "S2", label: "Bob"),
+            ],
+            status: .completed
+        )
     }
 }

--- a/Tests/MacParakeetTests/Services/ExportServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/ExportServiceTests.swift
@@ -129,6 +129,21 @@ final class ExportServiceTests: XCTestCase {
         XCTAssertFalse(text.contains("[0:00]"))
     }
 
+    func testFormatPlainTextWithoutTimestampsJoinsSameSpeakerCues() {
+        let transcription = makeMultiCueSpeakerTranscription()
+        let options = TranscriptExportOptions(
+            includeTimestamps: false,
+            includeSpeakerLabels: true,
+            includeMetadata: false
+        )
+
+        let text = exportService.formatPlainText(transcription: transcription, options: options)
+
+        XCTAssertTrue(text.contains("Alice:\nFirst cue. Second cue."))
+        XCTAssertFalse(text.contains("First cue.\nSecond cue."))
+        XCTAssertFalse(text.contains("[0:00]"))
+    }
+
     func testFormatMarkdownCanOmitMetadataTimestampsAndSpeakers() {
         let transcription = makeExportOptionsTranscription(cleanTranscript: "Edited transcript without timing.")
         let options = TranscriptExportOptions(
@@ -143,6 +158,21 @@ final class ExportServiceTests: XCTestCase {
         XCTAssertFalse(markdown.contains("# interview.mp3"))
         XCTAssertFalse(markdown.contains("**Duration:**"))
         XCTAssertFalse(markdown.contains("**Alice**"))
+        XCTAssertFalse(markdown.contains("**[0:00]**"))
+    }
+
+    func testFormatMarkdownWithoutTimestampsJoinsSameSpeakerCues() {
+        let transcription = makeMultiCueSpeakerTranscription()
+        let options = TranscriptExportOptions(
+            includeTimestamps: false,
+            includeSpeakerLabels: true,
+            includeMetadata: false
+        )
+
+        let markdown = exportService.formatMarkdown(transcription: transcription, options: options)
+
+        XCTAssertTrue(markdown.contains("**Alice**\n\nFirst cue. Second cue."))
+        XCTAssertFalse(markdown.contains("First cue.\n\nSecond cue."))
         XCTAssertFalse(markdown.contains("**[0:00]**"))
     }
 
@@ -732,6 +762,27 @@ final class ExportServiceTests: XCTestCase {
             wordTimestamps: [
                 WordTimestamp(word: "Hello.", startMs: 0, endMs: 500, confidence: 0.99, speakerId: "S1"),
                 WordTimestamp(word: "Goodbye.", startMs: 2000, endMs: 2500, confidence: 0.97, speakerId: "S2"),
+            ],
+            speakers: [
+                SpeakerInfo(id: "S1", label: "Alice"),
+                SpeakerInfo(id: "S2", label: "Bob"),
+            ],
+            status: .completed
+        )
+    }
+
+    private func makeMultiCueSpeakerTranscription() -> Transcription {
+        Transcription(
+            fileName: "interview.mp3",
+            durationMs: 8000,
+            rawTranscript: "First cue. Second cue. Bob answers.",
+            wordTimestamps: [
+                WordTimestamp(word: "First", startMs: 0, endMs: 300, confidence: 0.99, speakerId: "S1"),
+                WordTimestamp(word: "cue.", startMs: 350, endMs: 700, confidence: 0.99, speakerId: "S1"),
+                WordTimestamp(word: "Second", startMs: 3000, endMs: 3300, confidence: 0.99, speakerId: "S1"),
+                WordTimestamp(word: "cue.", startMs: 3350, endMs: 3700, confidence: 0.99, speakerId: "S1"),
+                WordTimestamp(word: "Bob", startMs: 6000, endMs: 6300, confidence: 0.99, speakerId: "S2"),
+                WordTimestamp(word: "answers.", startMs: 6350, endMs: 6800, confidence: 0.99, speakerId: "S2"),
             ],
             speakers: [
                 SpeakerInfo(id: "S1", label: "Alice"),


### PR DESCRIPTION
## Summary

Add a focused export-options popover for completed transcripts. Users choose the export format first, then adjust only the options that make sense for Text and Markdown, without introducing another ambiguous export preset.

```text
Completed transcript
       |
       v
Export popover
   |
   +-- Format: Text / Markdown / SRT / VTT / JSON / PDF / DOCX
   |
   +-- Text + Markdown options
   |      [x] Include timestamps
   |      [x] Include speaker labels
   |      [x] Include metadata
   |
   +-- Other formats
          use existing format-specific behavior
```

Closes #130.

## What Changed

- Replaced the transcript export menu with a compact format-and-options popover.
- Added Text/Markdown toggles for timestamps, speaker labels, and metadata.
- Defaulted the toggles on so exported transcripts remain readable unless a user chooses otherwise.
- Used edited transcript text for Text/Markdown exports when users remove both timestamps and speaker labels.
- Joined timestamp-free speaker output into natural speaker-turn paragraphs instead of short cue lines.
- Kept SRT, VTT, JSON, PDF, and DOCX on their existing format-specific export paths.
- Added export-service coverage for defaults, option combinations, edited transcript fallback, and speaker paragraph flow.

## Validation

- `git diff --check`
- `swift build`
- `swift test --filter ExportServiceTests`
  - 42 XCTest tests passed
- `swift test`
  - 1466 XCTest tests passed
  - 13 Swift Testing tests passed
