### PR TITLE
Calendar reminders + auto-start before your meetings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ All ADRs are in `spec/adr/`. These are locked decisions -- don't second-guess th
 | ADR-014 | Meeting recording via Core Audio Taps | `spec/adr/014-meeting-recording.md` |
 | ADR-015 | Concurrent dictation and meeting recording | `spec/adr/015-concurrent-dictation-meeting.md` |
 | ADR-016 | Centralized STT runtime and two-slot scheduler | `spec/adr/016-centralized-stt-runtime-scheduler.md` |
-| ADR-017 | Calendar-driven meeting auto-start (Phase 1 implemented; Phase 2+ proposed) | `spec/adr/017-calendar-meeting-auto-start.md` |
+| ADR-017 | Calendar-driven meeting auto-start (Phases 1 + 2 implemented; Phase 3 proposed) | `spec/adr/017-calendar-meeting-auto-start.md` |
 | ADR-018 | Live meeting Ask tab (Insights dropped per amendment; Ask shipped) | `spec/adr/018-live-meeting-insights-and-ask.md` |
 | ADR-019 | Crash-resilient meeting recording (proposed) | `spec/adr/019-crash-resilient-meeting-recording.md` |
 
@@ -100,7 +100,7 @@ All ADRs are in `spec/adr/`. These are locked decisions -- don't second-guess th
 
 ## Current Phase
 
-**v0.6 In Progress** -- ~233 source files, ~114 test files, 1525 tests passing (1512 XCTest + 13 Swift Testing, as of 2026-04-25)
+**v0.6 In Progress** -- ~238 source files, ~116 test files, 1534 tests passing (1521 XCTest + 13 Swift Testing, as of 2026-04-25)
 
 - **v0.1** MVP -- System-wide dictation, file transcription, overlay, history, export, SQLite, CLI, STT engine
 - **v0.2** Clean Pipeline -- Text processing (filler removal, custom words, snippets), Vocabulary UI, feedback form

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ All ADRs are in `spec/adr/`. These are locked decisions -- don't second-guess th
 | ADR-014 | Meeting recording via Core Audio Taps | `spec/adr/014-meeting-recording.md` |
 | ADR-015 | Concurrent dictation and meeting recording | `spec/adr/015-concurrent-dictation-meeting.md` |
 | ADR-016 | Centralized STT runtime and two-slot scheduler | `spec/adr/016-centralized-stt-runtime-scheduler.md` |
-| ADR-017 | Calendar-driven meeting auto-start (proposed) | `spec/adr/017-calendar-meeting-auto-start.md` |
+| ADR-017 | Calendar-driven meeting auto-start (Phase 1 implemented; Phase 2+ proposed) | `spec/adr/017-calendar-meeting-auto-start.md` |
 | ADR-018 | Live meeting Ask tab (Insights dropped per amendment; Ask shipped) | `spec/adr/018-live-meeting-insights-and-ask.md` |
 | ADR-019 | Crash-resilient meeting recording (proposed) | `spec/adr/019-crash-resilient-meeting-recording.md` |
 
@@ -100,7 +100,7 @@ All ADRs are in `spec/adr/`. These are locked decisions -- don't second-guess th
 
 ## Current Phase
 
-**v0.6 In Progress** -- ~223 source files, ~104 test files, 1465 tests passing (1452 XCTest + 13 Swift Testing, as of 2026-04-24)
+**v0.6 In Progress** -- ~233 source files, ~114 test files, 1525 tests passing (1512 XCTest + 13 Swift Testing, as of 2026-04-25)
 
 - **v0.1** MVP -- System-wide dictation, file transcription, overlay, history, export, SQLite, CLI, STT engine
 - **v0.2** Clean Pipeline -- Text processing (filler removal, custom words, snippets), Vocabulary UI, feedback form

--- a/Sources/CLI/Commands/CalendarCommand.swift
+++ b/Sources/CLI/Commands/CalendarCommand.swift
@@ -45,7 +45,7 @@ struct CalendarCommand: AsyncParsableCommand {
             let events = raw.filter { passesFilter($0, filter: triggerFilter) }
 
             if json {
-                printJSON(events)
+                try printJSON(events)
             } else {
                 printHuman(events, filter: triggerFilter)
             }
@@ -100,17 +100,16 @@ struct CalendarCommand: AsyncParsableCommand {
             }
         }
 
-        private func printJSON(_ events: [CalendarEvent]) {
+        private func printJSON(_ events: [CalendarEvent]) throws {
+            // Re-throw encoding errors so the CLI exits non-zero — silently
+            // swallowing here makes the empty stdout look like "no events"
+            // to a CI script or agent calling this with `--json`.
             let encoder = JSONEncoder()
             encoder.dateEncodingStrategy = .iso8601
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-            do {
-                let data = try encoder.encode(events)
-                if let s = String(data: data, encoding: .utf8) {
-                    print(s)
-                }
-            } catch {
-                FileHandle.standardError.write(Data("Failed to encode JSON: \(error.localizedDescription)\n".utf8))
+            let data = try encoder.encode(events)
+            if let s = String(data: data, encoding: .utf8) {
+                print(s)
             }
         }
     }

--- a/Sources/CLI/Commands/CalendarCommand.swift
+++ b/Sources/CLI/Commands/CalendarCommand.swift
@@ -32,8 +32,7 @@ struct CalendarCommand: AsyncParsableCommand {
             guard let triggerFilter = parsedFilter() else {
                 throw ValidationError("--filter must be one of: link, participants, all")
             }
-            let service = CalendarService()
-            switch service.permissionStatus {
+            switch CalendarService.shared.permissionStatus {
             case .denied:
                 throw CalendarCLIError.calendarPermissionDenied
             case .notDetermined:
@@ -42,7 +41,7 @@ struct CalendarCommand: AsyncParsableCommand {
                 break
             }
 
-            let raw = try await service.fetchUpcomingEvents(days: max(1, days))
+            let raw = try await CalendarService.shared.fetchUpcomingEvents(days: max(1, days))
             let events = raw.filter { passesFilter($0, filter: triggerFilter) }
 
             if json {

--- a/Sources/CLI/Commands/CalendarCommand.swift
+++ b/Sources/CLI/Commands/CalendarCommand.swift
@@ -1,0 +1,132 @@
+import ArgumentParser
+import Foundation
+import MacParakeetCore
+
+/// `macparakeet-cli calendar` — agent-friendly access to the EventKit
+/// pipeline that powers calendar auto-start. Lets a developer or a CI agent
+/// verify "is my permission set up + does my filter actually pick the right
+/// events?" without launching the GUI.
+struct CalendarCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "calendar",
+        abstract: "Inspect the calendar pipeline used by meeting auto-start.",
+        subcommands: [UpcomingCommand.self]
+    )
+
+    struct UpcomingCommand: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "upcoming",
+            abstract: "List upcoming calendar events visible to MacParakeet."
+        )
+
+        @Option(name: .long, help: "Number of days to look ahead. Default: 1.")
+        var days: Int = 1
+
+        @Option(name: .long, help: "Trigger filter: link | participants | all. Default: link.")
+        var filter: String = "link"
+
+        @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+        var json: Bool = false
+
+        func run() async throws {
+            guard let triggerFilter = parsedFilter() else {
+                throw ValidationError("--filter must be one of: link, participants, all")
+            }
+            let service = CalendarService()
+            switch service.permissionStatus {
+            case .denied:
+                throw CalendarCLIError.calendarPermissionDenied
+            case .notDetermined:
+                throw CalendarCLIError.calendarPermissionNotDetermined
+            case .granted:
+                break
+            }
+
+            let raw = try await service.fetchUpcomingEvents(days: max(1, days))
+            let events = raw.filter { passesFilter($0, filter: triggerFilter) }
+
+            if json {
+                printJSON(events)
+            } else {
+                printHuman(events, filter: triggerFilter)
+            }
+        }
+
+        private func parsedFilter() -> MeetingTriggerFilter? {
+            switch filter.lowercased() {
+            case "link", "with-link", "withlink": return .withLink
+            case "participants", "with-participants": return .withParticipants
+            case "all", "all-events", "allevents": return .allEvents
+            default: return nil
+            }
+        }
+
+        private func passesFilter(_ event: CalendarEvent, filter: MeetingTriggerFilter) -> Bool {
+            switch filter {
+            case .allEvents: return !event.isAllDay
+            case .withParticipants: return !event.isAllDay && event.participants.count >= 1
+            case .withLink: return !event.isAllDay && event.meetUrl != nil
+            }
+        }
+
+        private func printHuman(_ events: [CalendarEvent], filter: MeetingTriggerFilter) {
+            let formatter = DateFormatter()
+            formatter.dateStyle = .short
+            formatter.timeStyle = .short
+
+            print("Upcoming events (filter=\(filter.rawValue), days=\(max(1, days)))")
+            print(String(repeating: "=", count: 60))
+            if events.isEmpty {
+                print("No matching events.")
+                return
+            }
+            for event in events {
+                let when = formatter.string(from: event.startTime)
+                print()
+                print("• \(event.title)")
+                print("  Starts: \(when)  (\(event.durationMinutes) min)")
+                if let calendar = event.calendarName {
+                    print("  Calendar: \(calendar)")
+                }
+                if let meetUrl = event.meetUrl {
+                    let service = MeetingLinkParser.shared.identifyService(from: meetUrl) ?? "Link"
+                    print("  \(service): \(meetUrl)")
+                }
+                if !event.participants.isEmpty {
+                    print("  Participants: \(event.participants.count)")
+                }
+                if let status = event.userStatus, status != .accepted {
+                    print("  Your status: \(status.rawValue)")
+                }
+            }
+        }
+
+        private func printJSON(_ events: [CalendarEvent]) {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            do {
+                let data = try encoder.encode(events)
+                if let s = String(data: data, encoding: .utf8) {
+                    print(s)
+                }
+            } catch {
+                FileHandle.standardError.write(Data("Failed to encode JSON: \(error.localizedDescription)\n".utf8))
+            }
+        }
+    }
+}
+
+private enum CalendarCLIError: Error, LocalizedError {
+    case calendarPermissionDenied
+    case calendarPermissionNotDetermined
+
+    var errorDescription: String? {
+        switch self {
+        case .calendarPermissionDenied:
+            return "Calendar access denied. Open System Settings → Privacy & Security → Calendars to grant MacParakeet access."
+        case .calendarPermissionNotDetermined:
+            return "Calendar access not yet requested. Launch MacParakeet, run onboarding (or visit Settings → Calendar), then retry."
+        }
+    }
+}

--- a/Sources/CLI/Commands/HealthCommand.swift
+++ b/Sources/CLI/Commands/HealthCommand.swift
@@ -124,16 +124,15 @@ struct HealthCommand: AsyncParsableCommand {
         // GUI, so the CLI surface lets them check authorization status
         // headlessly during dev iteration.
         print("Calendar (EventKit):")
-        let calendarService = CalendarService()
         let calendarStatus: String
-        switch calendarService.permissionStatus {
+        switch CalendarService.shared.permissionStatus {
         case .granted: calendarStatus = "Granted"
         case .denied: calendarStatus = "Denied (open System Settings → Privacy & Security → Calendars)"
         case .notDetermined: calendarStatus = "Not requested (run the app once and grant access)"
         }
         print("  Status: \(calendarStatus)")
-        if calendarService.permissionStatus == .granted {
-            let calendars = calendarService.availableCalendars()
+        if CalendarService.shared.permissionStatus == .granted {
+            let calendars = await CalendarService.shared.availableCalendars()
             print("  Calendars visible: \(calendars.count)")
         }
         print()

--- a/Sources/CLI/Commands/HealthCommand.swift
+++ b/Sources/CLI/Commands/HealthCommand.swift
@@ -120,6 +120,24 @@ struct HealthCommand: AsyncParsableCommand {
         }
         print()
 
+        // 7. Calendar (EventKit) — agents can't see TCC dialogs from the
+        // GUI, so the CLI surface lets them check authorization status
+        // headlessly during dev iteration.
+        print("Calendar (EventKit):")
+        let calendarService = CalendarService()
+        let calendarStatus: String
+        switch calendarService.permissionStatus {
+        case .granted: calendarStatus = "Granted"
+        case .denied: calendarStatus = "Denied (open System Settings → Privacy & Security → Calendars)"
+        case .notDetermined: calendarStatus = "Not requested (run the app once and grant access)"
+        }
+        print("  Status: \(calendarStatus)")
+        if calendarService.permissionStatus == .granted {
+            let calendars = calendarService.availableCalendars()
+            print("  Calendars visible: \(calendars.count)")
+        }
+        print()
+
         print("Done.")
     }
 }

--- a/Sources/CLI/MacParakeetCLI.swift
+++ b/Sources/CLI/MacParakeetCLI.swift
@@ -15,6 +15,7 @@ struct CLI: AsyncParsableCommand {
             ModelsCommand.self,
             FlowCommand.self,
             LLMCommand.self,
+            CalendarCommand.self,
             FeedbackCommand.self,
         ],
         defaultSubcommand: nil

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -262,7 +262,7 @@ final class AppEnvironmentConfigurer {
         hotkeyCoordinator.setupYouTubeTranscriptionHotkey()
         dictationCoordinator.showIdlePill()
 
-        // Calendar auto-start (ADR-017 Phase D — notify-only). The
+        // Calendar auto-start (ADR-017 Phase 1 — notify-only). The
         // coordinator is a no-op when `calendarAutoStartMode == .off` so
         // it's safe to start unconditionally; we still gate creation on the
         // meeting-recording feature flag because calendar integration only

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -270,7 +270,7 @@ final class AppEnvironmentConfigurer {
         let calendarCoordinator: MeetingAutoStartCoordinator?
         if AppFeatures.meetingRecordingEnabled {
             let coordinator = MeetingAutoStartCoordinator(
-                calendarService: CalendarService(),
+                calendarService: .shared,
                 settingsViewModel: settingsViewModel
             )
             coordinator.start()

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -282,6 +282,14 @@ final class AppEnvironmentConfigurer {
                     meetingCoordinator?.toggleRecording()
                 }
             )
+            // The recording flow tells the calendar coordinator when an
+            // auto-start attempt actually failed (state was non-idle, or
+            // the underlying start threw) so the optimistic binding gets
+            // dropped — otherwise the next meeting's auto-stop would be
+            // suppressed by a stale `autoStartedEventId`.
+            meetingCoordinator.onAutoStartFailed = { [weak coordinator] in
+                coordinator?.clearAutoStartBinding()
+            }
             coordinator.start()
             calendarCoordinator = coordinator
         } else {

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -13,6 +13,7 @@ final class AppEnvironmentConfigurer {
         let dictationFlowCoordinator: DictationFlowCoordinator
         let meetingRecordingFlowCoordinator: MeetingRecordingFlowCoordinator
         let hotkeyCoordinator: AppHotkeyCoordinator
+        let meetingAutoStartCoordinator: MeetingAutoStartCoordinator?
     }
 
     struct Callbacks {
@@ -261,10 +262,28 @@ final class AppEnvironmentConfigurer {
         hotkeyCoordinator.setupYouTubeTranscriptionHotkey()
         dictationCoordinator.showIdlePill()
 
+        // Calendar auto-start (ADR-017 Phase D — notify-only). The
+        // coordinator is a no-op when `calendarAutoStartMode == .off` so
+        // it's safe to start unconditionally; we still gate creation on the
+        // meeting-recording feature flag because calendar integration only
+        // makes sense when the user can actually record meetings.
+        let calendarCoordinator: MeetingAutoStartCoordinator?
+        if AppFeatures.meetingRecordingEnabled {
+            let coordinator = MeetingAutoStartCoordinator(
+                calendarService: CalendarService(),
+                settingsViewModel: settingsViewModel
+            )
+            coordinator.start()
+            calendarCoordinator = coordinator
+        } else {
+            calendarCoordinator = nil
+        }
+
         return Runtime(
             dictationFlowCoordinator: dictationCoordinator,
             meetingRecordingFlowCoordinator: meetingCoordinator,
-            hotkeyCoordinator: hotkeyCoordinator
+            hotkeyCoordinator: hotkeyCoordinator,
+            meetingAutoStartCoordinator: calendarCoordinator
         )
     }
 

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -271,7 +271,16 @@ final class AppEnvironmentConfigurer {
         if AppFeatures.meetingRecordingEnabled {
             let coordinator = MeetingAutoStartCoordinator(
                 calendarService: CalendarService.shared,
-                settingsViewModel: settingsViewModel
+                settingsViewModel: settingsViewModel,
+                isRecordingActive: { [weak meetingCoordinator] in
+                    meetingCoordinator?.isMeetingRecordingActive ?? false
+                },
+                onAutoStartConfirmed: { [weak meetingCoordinator] in
+                    meetingCoordinator?.startFromCalendar()
+                },
+                onAutoStopConfirmed: { [weak meetingCoordinator] in
+                    meetingCoordinator?.toggleRecording()
+                }
             )
             coordinator.start()
             calendarCoordinator = coordinator

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -270,7 +270,7 @@ final class AppEnvironmentConfigurer {
         let calendarCoordinator: MeetingAutoStartCoordinator?
         if AppFeatures.meetingRecordingEnabled {
             let coordinator = MeetingAutoStartCoordinator(
-                calendarService: .shared,
+                calendarService: CalendarService.shared,
                 settingsViewModel: settingsViewModel
             )
             coordinator.start()

--- a/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
@@ -173,6 +173,16 @@ final class MeetingAutoStartCoordinator {
     // MARK: - Polling
 
     private func pollAsync() async {
+        // Run binding-cleanup *before* the early returns so toggling mode
+        // off (or losing permission) while an auto-started recording is in
+        // flight doesn't strand a stale `autoStartedEventId` until the
+        // user re-enables.
+        let activeRecording = isRecordingActive()
+        if !activeRecording, autoStartedEventId != nil {
+            autoStartedEventId = nil
+            autoStopCountdownEventId = nil
+        }
+
         let mode = settingsViewModel.calendarAutoStartMode
         guard mode != .off else { return }
         guard calendarService.permissionStatus == .granted else { return }
@@ -187,16 +197,6 @@ final class MeetingAutoStartCoordinator {
         } catch {
             logger.error("Failed to fetch events: \(error.localizedDescription, privacy: .public)")
             return
-        }
-
-        let activeRecording = isRecordingActive()
-        // If we held an `autoStartedEventId` and recording is no longer
-        // active, the user manually stopped the auto-started recording.
-        // Clear the binding so we don't fire `.autoStopDue` against a
-        // recording that no longer exists.
-        if !activeRecording, autoStartedEventId != nil {
-            autoStartedEventId = nil
-            autoStopCountdownEventId = nil
         }
 
         let config = currentConfig(mode: mode)
@@ -245,15 +245,27 @@ final class MeetingAutoStartCoordinator {
 
     private func adjustPollingFrequency(events: [CalendarEvent]) {
         let now = Date()
-        let nearest = events
+        // Soonest *future* start — drives auto-start window accuracy.
+        let nextStart = events
             .filter { $0.startTime > now }
-            .min(by: { $0.startTime < $1.startTime })
-
-        guard let event = nearest else {
+            .map { $0.startTime.timeIntervalSince(now) }
+            .min()
+        // Soonest *end* of an in-progress event we're recording — without
+        // this, a single isolated meeting would keep polling at 60s and
+        // the [endTime - 30s, endTime] auto-stop window would slip
+        // through (60s cadence + arbitrary phase = miss). Only relevant
+        // when auto-stop is enabled and we're actually recording.
+        let nextEnd: TimeInterval? = {
+            guard isRecordingActive(), settingsViewModel.calendarAutoStopEnabled else { return nil }
+            return events
+                .filter { $0.startTime <= now && $0.endTime > now }
+                .map { $0.endTime.timeIntervalSince(now) }
+                .min()
+        }()
+        guard let secondsUntil = [nextStart, nextEnd].compactMap({ $0 }).min() else {
             rescheduleTimer(interval: 60)
             return
         }
-        let secondsUntil = event.startTime.timeIntervalSince(now)
         let newInterval: TimeInterval
         if secondsUntil <= 30 {
             newInterval = 5
@@ -308,15 +320,13 @@ final class MeetingAutoStartCoordinator {
     /// - `.programmaticClose` → no-op (another toast preempted us)
     private func showAutoStartCountdown(_ event: CalendarEvent) {
         countdownShownEventIds.insert(event.id)
-        let leadSeconds = settingsViewModel.calendarReminderMinutes  // reused for telemetry context
+        // Actual lead time — how far before T-0 the toast went up. The
+        // auto-start window allows up to +30s past T-0, so clamp to 0
+        // when we surface it after the event has already started.
+        let leadSeconds = max(0, Int(event.startTime.timeIntervalSinceNow.rounded()))
         let serviceName = event.meetUrl.flatMap(MeetingLinkParser.shared.identifyService)
         let body = serviceName.map { "Recording will start automatically — joining \($0)?" }
             ?? "Recording will start automatically."
-
-        Telemetry.send(.calendarAutoStartTriggered(
-            leadSeconds: leadSeconds,
-            hasMeetUrl: event.meetUrl != nil
-        ))
 
         toastController.showAutoStart(
             title: event.title,
@@ -324,6 +334,26 @@ final class MeetingAutoStartCoordinator {
         ) { [weak self] outcome in
             self?.handleAutoStartOutcome(outcome, for: event)
         }
+
+        // Fire telemetry *after* `showAutoStart` returns so the event name
+        // matches what the user actually saw — its docstring says "fires
+        // when the toast is presented."
+        Telemetry.send(.calendarAutoStartTriggered(
+            leadSeconds: leadSeconds,
+            hasMeetUrl: event.meetUrl != nil
+        ))
+    }
+
+    /// Drop any optimistic auto-start binding. Called by
+    /// `MeetingRecordingFlowCoordinator.onAutoStartFailed` when the
+    /// downstream start either silently no-oped (state machine wasn't
+    /// idle — likely the previous meeting is still wrapping up) or threw
+    /// during the underlying `startRecording()`. Without this, a stale
+    /// binding can suppress the *next* meeting's auto-stop window.
+    func clearAutoStartBinding() {
+        autoStartedEventId = nil
+        autoStopCountdownEventId = nil
+        logger.info("Auto-start binding cleared (start failed or state busy)")
     }
 
     /// Internal entry point for the auto-start outcome routing. Public to

--- a/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
@@ -42,11 +42,14 @@ final class MeetingAutoStartCoordinator {
     private var remindedEventIds: Set<String> = []
     private var countdownShownEventIds: Set<String> = []
 
-    private var settingsObserver: NSObjectProtocol?
-    private var calendarChangeObserver: NSObjectProtocol?
+    // `nonisolated(unsafe)` so the nonisolated `deinit` can read these to
+    // unregister observers. They're write-only after start() / stop() and
+    // mutation always happens on the main actor — no race.
+    nonisolated(unsafe) private var settingsObserver: NSObjectProtocol?
+    nonisolated(unsafe) private var calendarChangeObserver: NSObjectProtocol?
     private var cleanupTask: Task<Void, Never>?
 
-    init(calendarService: CalendarService, settingsViewModel: SettingsViewModel) {
+    init(calendarService: CalendarService = .shared, settingsViewModel: SettingsViewModel) {
         self.calendarService = calendarService
         self.settingsViewModel = settingsViewModel
     }
@@ -104,8 +107,8 @@ final class MeetingAutoStartCoordinator {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            // Hop to the main actor; the queue:.main parameter keeps us on
-            // the main thread but Swift 6 still wants the explicit isolation.
+            // queue: .main lands the closure on the main thread but Swift 6
+            // strict isolation still requires an explicit @MainActor hop.
             Task { @MainActor [weak self] in self?.handleSettingsChanged() }
         }
     }
@@ -163,14 +166,10 @@ final class MeetingAutoStartCoordinator {
         )
 
         for event in monitorEvents {
-            handle(event, mode: mode)
+            await handle(event, mode: mode)
         }
 
         adjustPollingFrequency(events: events)
-    }
-
-    @objc private func pollFromTimer() {
-        Task { @MainActor [weak self] in await self?.pollAsync() }
     }
 
     private func currentConfig(mode: CalendarAutoStartMode) -> MeetingMonitor.Config {
@@ -189,12 +188,13 @@ final class MeetingAutoStartCoordinator {
         let excluded = settingsViewModel.calendarExcludedIdentifiers
         guard !excluded.isEmpty else { return events }
         return events.filter { event in
-            // CalendarEvent doesn't carry the calendar identifier, only the
-            // human-readable title. We match on title until/unless we add an
-            // identifier to the model — for now this is "good enough" because
-            // the include list is rendered with the same titles.
-            guard let title = event.calendarName else { return true }
-            return !excluded.contains(title)
+            // Filter by stable EKCalendar.calendarIdentifier — title-based
+            // filtering breaks when two calendars share a name or one is
+            // renamed. If the identifier is missing for some reason, default
+            // to including the event (fail open — better to over-notify than
+            // silently miss a meeting).
+            guard let identifier = event.calendarIdentifier else { return true }
+            return !excluded.contains(identifier)
         }
     }
 
@@ -235,20 +235,34 @@ final class MeetingAutoStartCoordinator {
 
     // MARK: - Event handling
 
-    private func handle(_ event: MeetingMonitor.MonitorEvent, mode: CalendarAutoStartMode) {
+    private func handle(_ event: MeetingMonitor.MonitorEvent, mode: CalendarAutoStartMode) async {
         switch event {
         case .reminderDue(let calEvent):
-            showReminder(calEvent, mode: mode)
+            await showReminder(calEvent, mode: mode)
 
         case .autoStartDue, .lateJoinAvailable, .autoStopDue:
-            // Phase D scope: notify-only. Mark these as "seen" so we don't
-            // log them on every tick once Phase E is wired.
+            // Phase D scope: notify-only. These are recognized by
+            // `MeetingMonitor` so the enum stays Phase E-ready, but the
+            // coordinator deliberately no-ops until the countdown toast +
+            // recording trigger land.
             return
         }
     }
 
-    private func showReminder(_ event: CalendarEvent, mode: CalendarAutoStartMode) {
+    private func showReminder(_ event: CalendarEvent, mode: CalendarAutoStartMode) async {
+        // Mark before posting so a failed delivery doesn't cause us to
+        // re-attempt every poll tick — better to miss one reminder than
+        // spam the user.
         remindedEventIds.insert(event.id)
+
+        // Defense in depth: we requested authorization at calendar grant
+        // time, but the user may have revoked notifications since. Without
+        // this check macOS silently drops `add()` and the user sees no
+        // reminder despite Calendar being granted.
+        guard await CalendarNotificationAuthorization.isAuthorized() else {
+            logger.warning("Notification authorization missing — reminder for event id=\(event.id, privacy: .public) not delivered")
+            return
+        }
 
         let leadMinutes = settingsViewModel.calendarReminderMinutes
         let title = event.title
@@ -271,10 +285,10 @@ final class MeetingAutoStartCoordinator {
             trigger: nil  // Deliver immediately
         )
 
-        UNUserNotificationCenter.current().add(request) { [logger] error in
-            if let error {
-                logger.error("Reminder notification failed: \(error.localizedDescription, privacy: .public)")
-            }
+        do {
+            try await UNUserNotificationCenter.current().add(request)
+        } catch {
+            logger.error("Reminder notification failed: \(error.localizedDescription, privacy: .public)")
         }
 
         Telemetry.send(.calendarReminderShown(
@@ -295,22 +309,21 @@ final class MeetingAutoStartCoordinator {
         cleanupTask = Task { [weak self] in
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(24 * 60 * 60))
-                guard let self else { return }
-                await MainActor.run { self.cleanupStaleIds() }
+                guard !Task.isCancelled else { return }
+                await self?.cleanupStaleIds()
             }
         }
     }
 
-    private func cleanupStaleIds() {
-        Task { [weak self] in
-            guard let self else { return }
-            guard let events = try? await self.calendarService.fetchUpcomingEvents(days: 7) else { return }
-            let liveIds = Set(events.map(\.id))
-            await MainActor.run {
-                self.dismissedEventIds.formIntersection(liveIds)
-                self.remindedEventIds.formIntersection(liveIds)
-                self.countdownShownEventIds.formIntersection(liveIds)
-            }
-        }
+    /// Async + structured. Runs on the main actor (the coordinator is
+    /// `@MainActor`), with the EventKit fetch hopping to the
+    /// `CalendarService` actor for thread safety. Errors propagate via the
+    /// `try?` — silent failure is acceptable for a 24-hour janitor.
+    private func cleanupStaleIds() async {
+        guard let events = try? await calendarService.fetchUpcomingEvents(days: 7) else { return }
+        let liveIds = Set(events.map(\.id))
+        dismissedEventIds.formIntersection(liveIds)
+        remindedEventIds.formIntersection(liveIds)
+        countdownShownEventIds.formIntersection(liveIds)
     }
 }

--- a/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
@@ -1,0 +1,316 @@
+import AppKit
+import EventKit
+import MacParakeetCore
+import MacParakeetViewModels
+import OSLog
+import UserNotifications
+
+/// Polls the user's calendar and surfaces upcoming meetings via macOS
+/// notifications. Phase D (ADR-017 Phase 1) — handles `.reminderDue` only;
+/// `.autoStartDue` / `.lateJoinAvailable` / `.autoStopDue` are recognized by
+/// `MeetingMonitor` but the coordinator no-ops on them. Phase E will wire the
+/// countdown toast and recording trigger.
+///
+/// ```
+///         ┌──────────────────────┐
+///         │ EKEventStoreChanged  │──┐
+///         └──────────────────────┘  │  immediate
+///                                   ▼
+///   60s/15s/5s adaptive Timer ──▶  poll() ──▶ MeetingMonitor.evaluate(...)
+///                                                       │
+///                                  ┌────────────────────┴────────────────┐
+///                                  ▼                                     ▼
+///                            .reminderDue                  (other cases queued for Phase E)
+///                                  │
+///                                  ▼
+///                       UNUserNotificationCenter
+///                       Telemetry.calendarReminderShown
+/// ```
+@MainActor
+final class MeetingAutoStartCoordinator {
+    private let calendarService: CalendarService
+    private let settingsViewModel: SettingsViewModel
+    private let logger = Logger(subsystem: "com.macparakeet", category: "MeetingAutoStart")
+
+    /// Adaptive polling — see ADR-017 §7. We only recreate the `Timer` when
+    /// the desired interval changes so a meeting 30s away gets sub-tick
+    /// accuracy without the steady-state polling 12× per minute.
+    private var pollingTimer: Timer?
+    private var pollingInterval: TimeInterval = 0  // 0 = uninitialized
+
+    private var dismissedEventIds: Set<String> = []
+    private var remindedEventIds: Set<String> = []
+    private var countdownShownEventIds: Set<String> = []
+
+    private var settingsObserver: NSObjectProtocol?
+    private var calendarChangeObserver: NSObjectProtocol?
+    private var cleanupTask: Task<Void, Never>?
+
+    init(calendarService: CalendarService, settingsViewModel: SettingsViewModel) {
+        self.calendarService = calendarService
+        self.settingsViewModel = settingsViewModel
+    }
+
+    deinit {
+        if let observer = settingsObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        if let observer = calendarChangeObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    // MARK: - Lifecycle
+
+    func start() {
+        // Defensive: do nothing when the entire feature is gated off at
+        // compile time. Keeps test runs and CI clean even if AppDelegate
+        // forgot to gate.
+        guard AppFeatures.meetingRecordingEnabled else { return }
+
+        scheduleCleanupTask()
+        registerCalendarChangeObserver()
+        registerSettingsObserver()
+        rescheduleTimer(interval: 60)
+        // Poll immediately so a meeting starting in the next minute doesn't
+        // wait for the first tick.
+        Task { await pollAsync() }
+
+        logger.info("Meeting auto-start coordinator started")
+    }
+
+    func stop() {
+        pollingTimer?.invalidate()
+        pollingTimer = nil
+        pollingInterval = 0
+        cleanupTask?.cancel()
+        cleanupTask = nil
+        if let observer = settingsObserver {
+            NotificationCenter.default.removeObserver(observer)
+            settingsObserver = nil
+        }
+        if let observer = calendarChangeObserver {
+            NotificationCenter.default.removeObserver(observer)
+            calendarChangeObserver = nil
+        }
+        logger.info("Meeting auto-start coordinator stopped")
+    }
+
+    // MARK: - Observers
+
+    private func registerSettingsObserver() {
+        settingsObserver = NotificationCenter.default.addObserver(
+            forName: .macParakeetCalendarSettingsDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            // Hop to the main actor; the queue:.main parameter keeps us on
+            // the main thread but Swift 6 still wants the explicit isolation.
+            Task { @MainActor [weak self] in self?.handleSettingsChanged() }
+        }
+    }
+
+    private func registerCalendarChangeObserver() {
+        calendarChangeObserver = NotificationCenter.default.addObserver(
+            forName: .EKEventStoreChanged,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.logger.debug("EKEventStoreChanged — re-evaluating immediately")
+                await self?.pollAsync()
+            }
+        }
+    }
+
+    private func handleSettingsChanged() {
+        // Setting changes can disable a feature mid-flight (e.g., toggling
+        // mode to .off). Re-evaluate immediately and reset adaptive polling
+        // back to baseline so we don't keep the 5s timer alive for a feature
+        // that's now disabled.
+        rescheduleTimer(interval: 60)
+        Task { await pollAsync() }
+    }
+
+    // MARK: - Polling
+
+    private func pollAsync() async {
+        let mode = settingsViewModel.calendarAutoStartMode
+        guard mode != .off else { return }
+        guard calendarService.permissionStatus == .granted else { return }
+
+        let events: [CalendarEvent]
+        do {
+            // 7-day look-ahead is overkill for the next-poll logic but keeps
+            // the per-calendar include filter cheap and lets adaptive polling
+            // see a "next event" 90 minutes out.
+            let raw = try await calendarService.fetchUpcomingEvents(days: 7)
+            events = filterByIncludedCalendars(raw)
+        } catch {
+            logger.error("Failed to fetch events: \(error.localizedDescription, privacy: .public)")
+            return
+        }
+
+        let config = currentConfig(mode: mode)
+        let monitorEvents = MeetingMonitor.evaluate(
+            events: events,
+            now: Date(),
+            config: config,
+            activeRecording: false,  // Phase E wires this from the meeting coordinator
+            dismissedEventIds: dismissedEventIds,
+            remindedEventIds: remindedEventIds,
+            countdownShownEventIds: countdownShownEventIds
+        )
+
+        for event in monitorEvents {
+            handle(event, mode: mode)
+        }
+
+        adjustPollingFrequency(events: events)
+    }
+
+    @objc private func pollFromTimer() {
+        Task { @MainActor [weak self] in await self?.pollAsync() }
+    }
+
+    private func currentConfig(mode: CalendarAutoStartMode) -> MeetingMonitor.Config {
+        MeetingMonitor.Config(
+            mode: mode,
+            reminderMinutes: settingsViewModel.calendarReminderMinutes,
+            countdownSeconds: 5,
+            autoStopEnabled: settingsViewModel.calendarAutoStopEnabled,
+            autoStopLeadSeconds: 30,
+            triggerFilter: settingsViewModel.meetingTriggerFilter,
+            lateJoinGraceMinutes: 10
+        )
+    }
+
+    private func filterByIncludedCalendars(_ events: [CalendarEvent]) -> [CalendarEvent] {
+        let excluded = settingsViewModel.calendarExcludedIdentifiers
+        guard !excluded.isEmpty else { return events }
+        return events.filter { event in
+            // CalendarEvent doesn't carry the calendar identifier, only the
+            // human-readable title. We match on title until/unless we add an
+            // identifier to the model — for now this is "good enough" because
+            // the include list is rendered with the same titles.
+            guard let title = event.calendarName else { return true }
+            return !excluded.contains(title)
+        }
+    }
+
+    private func adjustPollingFrequency(events: [CalendarEvent]) {
+        let now = Date()
+        let nearest = events
+            .filter { $0.startTime > now }
+            .min(by: { $0.startTime < $1.startTime })
+
+        guard let event = nearest else {
+            rescheduleTimer(interval: 60)
+            return
+        }
+        let secondsUntil = event.startTime.timeIntervalSince(now)
+        let newInterval: TimeInterval
+        if secondsUntil <= 30 {
+            newInterval = 5
+        } else if secondsUntil <= 120 {
+            newInterval = 15
+        } else {
+            newInterval = 60
+        }
+        rescheduleTimer(interval: newInterval)
+    }
+
+    private func rescheduleTimer(interval: TimeInterval) {
+        guard pollingInterval != interval else { return }
+        pollingTimer?.invalidate()
+        let timer = Timer(timeInterval: interval, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in await self?.pollAsync() }
+        }
+        // .common keeps the timer firing while menus / scrollers are tracking;
+        // the default .default mode would silently pause those windows.
+        RunLoop.main.add(timer, forMode: .common)
+        pollingTimer = timer
+        pollingInterval = interval
+    }
+
+    // MARK: - Event handling
+
+    private func handle(_ event: MeetingMonitor.MonitorEvent, mode: CalendarAutoStartMode) {
+        switch event {
+        case .reminderDue(let calEvent):
+            showReminder(calEvent, mode: mode)
+
+        case .autoStartDue, .lateJoinAvailable, .autoStopDue:
+            // Phase D scope: notify-only. Mark these as "seen" so we don't
+            // log them on every tick once Phase E is wired.
+            return
+        }
+    }
+
+    private func showReminder(_ event: CalendarEvent, mode: CalendarAutoStartMode) {
+        remindedEventIds.insert(event.id)
+
+        let leadMinutes = settingsViewModel.calendarReminderMinutes
+        let title = event.title
+        let body: String = {
+            if leadMinutes > 0 {
+                return "\(title) starts in \(leadMinutes) minute\(leadMinutes == 1 ? "" : "s")"
+            }
+            return "\(title) is starting"
+        }()
+        let subtitle = event.meetUrl.flatMap(MeetingLinkParser.shared.identifyService) ?? "MacParakeet"
+
+        let content = UNMutableNotificationContent()
+        content.title = body
+        content.body = subtitle
+        content.sound = nil  // Reminders shouldn't compete with the user's Zoom join sound
+
+        let request = UNNotificationRequest(
+            identifier: "macparakeet.calendar.\(event.id)",
+            content: content,
+            trigger: nil  // Deliver immediately
+        )
+
+        UNUserNotificationCenter.current().add(request) { [logger] error in
+            if let error {
+                logger.error("Reminder notification failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+
+        Telemetry.send(.calendarReminderShown(
+            mode: mode.rawValue,
+            leadMinutes: leadMinutes,
+            hasMeetUrl: event.meetUrl != nil
+        ))
+        logger.info("Reminder posted for event id=\(event.id, privacy: .public)")
+    }
+
+    // MARK: - Cleanup
+
+    /// Periodically prune state-machine sets so they don't grow unbounded
+    /// across long-running app sessions. ~24h cadence is plenty — events
+    /// older than a day will never re-fire any monitor case.
+    private func scheduleCleanupTask() {
+        cleanupTask?.cancel()
+        cleanupTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(24 * 60 * 60))
+                guard let self else { return }
+                await MainActor.run { self.cleanupStaleIds() }
+            }
+        }
+    }
+
+    private func cleanupStaleIds() {
+        Task { [weak self] in
+            guard let self else { return }
+            guard let events = try? await self.calendarService.fetchUpcomingEvents(days: 7) else { return }
+            let liveIds = Set(events.map(\.id))
+            await MainActor.run {
+                self.dismissedEventIds.formIntersection(liveIds)
+                self.remindedEventIds.formIntersection(liveIds)
+                self.countdownShownEventIds.formIntersection(liveIds)
+            }
+        }
+    }
+}

--- a/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
@@ -265,18 +265,23 @@ final class MeetingAutoStartCoordinator {
         }
 
         let leadMinutes = settingsViewModel.calendarReminderMinutes
-        let title = event.title
-        let body: String = {
+        // Notification UX: the headline is the timing + event name (the part
+        // the user will scan first); the supporting line is the meeting
+        // service ("Zoom", "Google Meet", etc.) so the user knows where to
+        // click. Names match the field they populate in
+        // `UNMutableNotificationContent`, not the semantic role of "title"
+        // and "subtitle" — the previous swap was confusing on a re-read.
+        let notificationTitle: String = {
             if leadMinutes > 0 {
-                return "\(title) starts in \(leadMinutes) minute\(leadMinutes == 1 ? "" : "s")"
+                return "\(event.title) starts in \(leadMinutes) minute\(leadMinutes == 1 ? "" : "s")"
             }
-            return "\(title) is starting"
+            return "\(event.title) is starting"
         }()
-        let subtitle = event.meetUrl.flatMap(MeetingLinkParser.shared.identifyService) ?? "MacParakeet"
+        let notificationBody = event.meetUrl.flatMap(MeetingLinkParser.shared.identifyService) ?? "MacParakeet"
 
         let content = UNMutableNotificationContent()
-        content.title = body
-        content.body = subtitle
+        content.title = notificationTitle
+        content.body = notificationBody
         content.sound = nil  // Reminders shouldn't compete with the user's Zoom join sound
 
         let request = UNNotificationRequest(

--- a/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
@@ -290,18 +290,23 @@ final class MeetingAutoStartCoordinator {
             trigger: nil  // Deliver immediately
         )
 
+        // Only report `calendarReminderShown` after delivery actually succeeds —
+        // otherwise telemetry over-reports and we lose signal on real failure
+        // rates. The `remindedEventIds` mark above stays before the auth check,
+        // because the alternative (mark on success only) would re-attempt every
+        // poll tick when delivery transiently fails — better to miss a single
+        // reminder than spam the user.
         do {
             try await UNUserNotificationCenter.current().add(request)
+            Telemetry.send(.calendarReminderShown(
+                mode: mode.rawValue,
+                leadMinutes: leadMinutes,
+                hasMeetUrl: event.meetUrl != nil
+            ))
+            logger.info("Reminder posted for event id=\(event.id, privacy: .public)")
         } catch {
             logger.error("Reminder notification failed: \(error.localizedDescription, privacy: .public)")
         }
-
-        Telemetry.send(.calendarReminderShown(
-            mode: mode.rawValue,
-            leadMinutes: leadMinutes,
-            hasMeetUrl: event.meetUrl != nil
-        ))
-        logger.info("Reminder posted for event id=\(event.id, privacy: .public)")
     }
 
     // MARK: - Cleanup

--- a/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
@@ -28,7 +28,7 @@ import UserNotifications
 /// ```
 @MainActor
 final class MeetingAutoStartCoordinator {
-    private let calendarService: CalendarService
+    private let calendarService: any CalendarServicing
     private let settingsViewModel: SettingsViewModel
     private let logger = Logger(subsystem: "com.macparakeet", category: "MeetingAutoStart")
 
@@ -49,7 +49,10 @@ final class MeetingAutoStartCoordinator {
     nonisolated(unsafe) private var calendarChangeObserver: NSObjectProtocol?
     private var cleanupTask: Task<Void, Never>?
 
-    init(calendarService: CalendarService = .shared, settingsViewModel: SettingsViewModel) {
+    init(
+        calendarService: any CalendarServicing = CalendarService.shared,
+        settingsViewModel: SettingsViewModel
+    ) {
         self.calendarService = calendarService
         self.settingsViewModel = settingsViewModel
     }

--- a/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
@@ -30,6 +30,14 @@ import UserNotifications
 final class MeetingAutoStartCoordinator {
     private let calendarService: any CalendarServicing
     private let settingsViewModel: SettingsViewModel
+    /// Closures to the meeting recording flow — passed in rather than the
+    /// concrete coordinator so this file doesn't gain a reverse dependency
+    /// on `MeetingRecordingFlowCoordinator` (and so tests can stub them).
+    /// All Phase 2 wiring goes through these three callbacks.
+    private let isRecordingActive: @MainActor () -> Bool
+    private let onAutoStartConfirmed: @MainActor () -> Void
+    private let onAutoStopConfirmed: @MainActor () -> Void
+    private let toastController: MeetingCountdownToastController
     private let logger = Logger(subsystem: "com.macparakeet", category: "MeetingAutoStart")
 
     /// Adaptive polling — see ADR-017 §7. We only recreate the `Timer` when
@@ -41,6 +49,17 @@ final class MeetingAutoStartCoordinator {
     private var dismissedEventIds: Set<String> = []
     private var remindedEventIds: Set<String> = []
     private var countdownShownEventIds: Set<String> = []
+    /// `event.id` of the calendar event that triggered the *current*
+    /// recording. Lets `.autoStopDue` only act on auto-started recordings —
+    /// a manually-started recording during a calendar event is not auto-
+    /// stopped (per ADR-017 §10). Cleared when recording ends (detected by
+    /// next poll seeing `isRecordingActive() == false` while we still hold
+    /// an id) or when auto-stop fires.
+    private var autoStartedEventId: String?
+    /// `event.id` of an auto-started recording for which we're currently
+    /// showing the auto-stop countdown. Prevents re-firing the toast on
+    /// every poll tick during the 30s window.
+    private var autoStopCountdownEventId: String?
 
     // `nonisolated(unsafe)` so the nonisolated `deinit` can read these to
     // unregister observers. They're write-only after start() / stop() and
@@ -51,10 +70,22 @@ final class MeetingAutoStartCoordinator {
 
     init(
         calendarService: any CalendarServicing = CalendarService.shared,
-        settingsViewModel: SettingsViewModel
+        settingsViewModel: SettingsViewModel,
+        isRecordingActive: @escaping @MainActor () -> Bool = { false },
+        onAutoStartConfirmed: @escaping @MainActor () -> Void = {},
+        onAutoStopConfirmed: @escaping @MainActor () -> Void = {},
+        toastController: MeetingCountdownToastController? = nil
     ) {
         self.calendarService = calendarService
         self.settingsViewModel = settingsViewModel
+        self.isRecordingActive = isRecordingActive
+        self.onAutoStartConfirmed = onAutoStartConfirmed
+        self.onAutoStopConfirmed = onAutoStopConfirmed
+        // The toast controller is `@MainActor`-isolated, so its default
+        // can't be expressed as a parameter default (initializer evaluation
+        // happens in the caller's actor context). Construct here when the
+        // caller didn't inject one.
+        self.toastController = toastController ?? MeetingCountdownToastController()
     }
 
     deinit {
@@ -91,6 +122,7 @@ final class MeetingAutoStartCoordinator {
         pollingInterval = 0
         cleanupTask?.cancel()
         cleanupTask = nil
+        toastController.close()
         if let observer = settingsObserver {
             NotificationCenter.default.removeObserver(observer)
             settingsObserver = nil
@@ -157,12 +189,22 @@ final class MeetingAutoStartCoordinator {
             return
         }
 
+        let activeRecording = isRecordingActive()
+        // If we held an `autoStartedEventId` and recording is no longer
+        // active, the user manually stopped the auto-started recording.
+        // Clear the binding so we don't fire `.autoStopDue` against a
+        // recording that no longer exists.
+        if !activeRecording, autoStartedEventId != nil {
+            autoStartedEventId = nil
+            autoStopCountdownEventId = nil
+        }
+
         let config = currentConfig(mode: mode)
         let monitorEvents = MeetingMonitor.evaluate(
             events: events,
             now: Date(),
             config: config,
-            activeRecording: false,  // Phase E wires this from the meeting coordinator
+            activeRecording: activeRecording,
             dismissedEventIds: dismissedEventIds,
             remindedEventIds: remindedEventIds,
             countdownShownEventIds: countdownShownEventIds
@@ -243,12 +285,99 @@ final class MeetingAutoStartCoordinator {
         case .reminderDue(let calEvent):
             await showReminder(calEvent, mode: mode)
 
-        case .autoStartDue, .lateJoinAvailable, .autoStopDue:
-            // Phase D scope: notify-only. These are recognized by
-            // `MeetingMonitor` so the enum stays Phase E-ready, but the
-            // coordinator deliberately no-ops until the countdown toast +
-            // recording trigger land.
+        case .autoStartDue(let calEvent):
+            showAutoStartCountdown(calEvent)
+
+        case .autoStopDue(let calEvent):
+            showAutoStopCountdown(calEvent)
+
+        case .lateJoinAvailable:
+            // Phase 3 — UI not built. The enum case stays so Phase 3 wires
+            // the late-join toast without changing `evaluate(...)`.
             return
+        }
+    }
+
+    // MARK: - Auto-start countdown (Phase 2)
+
+    /// Show the 5s pre-meeting countdown. Marks the event as countdown-shown
+    /// regardless of outcome so we don't re-fire on the next poll tick.
+    /// Outcome handling:
+    /// - `.completed` / `.primedEarly` → trigger recording, mark as auto-started
+    /// - `.userDismissed` → add to dismissed set so monitor stops emitting
+    /// - `.programmaticClose` → no-op (another toast preempted us)
+    private func showAutoStartCountdown(_ event: CalendarEvent) {
+        countdownShownEventIds.insert(event.id)
+        let leadSeconds = settingsViewModel.calendarReminderMinutes  // reused for telemetry context
+        let serviceName = event.meetUrl.flatMap(MeetingLinkParser.shared.identifyService)
+        let body = serviceName.map { "Recording will start automatically — joining \($0)?" }
+            ?? "Recording will start automatically."
+
+        Telemetry.send(.calendarAutoStartTriggered(
+            leadSeconds: leadSeconds,
+            hasMeetUrl: event.meetUrl != nil
+        ))
+
+        toastController.showAutoStart(
+            title: event.title,
+            body: body
+        ) { [weak self] outcome in
+            guard let self else { return }
+            switch outcome {
+            case .completed, .primedEarly:
+                self.autoStartedEventId = event.id
+                self.onAutoStartConfirmed()
+                self.logger.info("Auto-start confirmed for event id=\(event.id, privacy: .public) outcome=\(String(describing: outcome), privacy: .public)")
+            case .userDismissed:
+                self.dismissedEventIds.insert(event.id)
+                Telemetry.send(.calendarAutoStartCancelled(reason: "user_cancel"))
+                self.logger.info("Auto-start cancelled by user for event id=\(event.id, privacy: .public)")
+            case .programmaticClose:
+                // Another toast preempted us — no telemetry, no recording.
+                return
+            }
+        }
+    }
+
+    // MARK: - Auto-stop countdown (Phase 2)
+
+    /// Show the 30s end-of-meeting countdown — only for recordings the
+    /// coordinator started itself. Manually-started recordings during a
+    /// calendar event are not auto-stopped (ADR-017 §10).
+    private func showAutoStopCountdown(_ event: CalendarEvent) {
+        // Only act on the binding the coordinator owns. Manual recordings
+        // are sovereign — auto-stop never touches them.
+        guard autoStartedEventId == event.id else { return }
+        // Don't re-stack the toast on every poll while it's already up.
+        guard autoStopCountdownEventId != event.id else { return }
+        autoStopCountdownEventId = event.id
+
+        let durationSeconds = event.endTime.timeIntervalSince(event.startTime)
+        Telemetry.send(.calendarAutoStopShown(eventDurationSeconds: durationSeconds))
+
+        toastController.showAutoStop(
+            title: event.title,
+            body: "Meeting ending — recording will stop automatically."
+        ) { [weak self] outcome in
+            guard let self else { return }
+            switch outcome {
+            case .completed, .primedEarly:
+                self.onAutoStopConfirmed()
+                self.autoStartedEventId = nil
+                self.autoStopCountdownEventId = nil
+                self.logger.info("Auto-stop confirmed for event id=\(event.id, privacy: .public)")
+            case .userDismissed:
+                // User wants to keep recording past the calendar end —
+                // remember that so we don't re-prompt every 5s for the
+                // remainder of the auto-stop window.
+                self.dismissedEventIds.insert(event.id)
+                self.autoStopCountdownEventId = nil
+                Telemetry.send(.calendarAutoStopCancelled)
+                self.logger.info("Auto-stop cancelled by user for event id=\(event.id, privacy: .public)")
+            case .programmaticClose:
+                self.autoStopCountdownEventId = nil
+                return
+            }
         }
     }
 

--- a/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
@@ -422,9 +422,10 @@ final class MeetingAutoStartCoordinator {
     }
 }
 
-#if DEBUG
 /// Hooks for unit tests. The `testHook_` prefix marks them as test-only
-/// so they don't pollute autocomplete in production code paths.
+/// so they don't pollute autocomplete in production code paths. Not
+/// `#if DEBUG`-gated so `swift test -c release` (CI perf lane) still
+/// links — the methods are `internal` so they don't escape the module.
 extension MeetingAutoStartCoordinator {
     var testHook_autoStartedEventId: String? { autoStartedEventId }
 
@@ -465,7 +466,6 @@ extension MeetingAutoStartCoordinator {
         Task { @MainActor [weak self] in await self?.pollAsync() }
     }
 }
-#endif
 
 private extension MeetingAutoStartCoordinator {
     func showReminder(_ event: CalendarEvent, mode: CalendarAutoStartMode) async {

--- a/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
@@ -322,20 +322,27 @@ final class MeetingAutoStartCoordinator {
             title: event.title,
             body: body
         ) { [weak self] outcome in
-            guard let self else { return }
-            switch outcome {
-            case .completed, .primedEarly:
-                self.autoStartedEventId = event.id
-                self.onAutoStartConfirmed()
-                self.logger.info("Auto-start confirmed for event id=\(event.id, privacy: .public) outcome=\(String(describing: outcome), privacy: .public)")
-            case .userDismissed:
-                self.dismissedEventIds.insert(event.id)
-                Telemetry.send(.calendarAutoStartCancelled(reason: "user_cancel"))
-                self.logger.info("Auto-start cancelled by user for event id=\(event.id, privacy: .public)")
-            case .programmaticClose:
-                // Another toast preempted us — no telemetry, no recording.
-                return
-            }
+            self?.handleAutoStartOutcome(outcome, for: event)
+        }
+    }
+
+    /// Internal entry point for the auto-start outcome routing. Public to
+    /// the test target so tests can exercise the routing without driving
+    /// real toast UI; production code reaches this only via the toast
+    /// controller's outcome callback.
+    func handleAutoStartOutcome(_ outcome: MeetingCountdownToastOutcome, for event: CalendarEvent) {
+        switch outcome {
+        case .completed, .primedEarly:
+            autoStartedEventId = event.id
+            onAutoStartConfirmed()
+            logger.info("Auto-start confirmed for event id=\(event.id, privacy: .public) outcome=\(String(describing: outcome), privacy: .public)")
+        case .userDismissed:
+            dismissedEventIds.insert(event.id)
+            Telemetry.send(.calendarAutoStartCancelled(reason: "user_cancel"))
+            logger.info("Auto-start cancelled by user for event id=\(event.id, privacy: .public)")
+        case .programmaticClose:
+            // Another toast preempted us — no telemetry, no recording.
+            return
         }
     }
 
@@ -359,29 +366,79 @@ final class MeetingAutoStartCoordinator {
             title: event.title,
             body: "Meeting ending — recording will stop automatically."
         ) { [weak self] outcome in
-            guard let self else { return }
-            switch outcome {
-            case .completed, .primedEarly:
-                self.onAutoStopConfirmed()
-                self.autoStartedEventId = nil
-                self.autoStopCountdownEventId = nil
-                self.logger.info("Auto-stop confirmed for event id=\(event.id, privacy: .public)")
-            case .userDismissed:
-                // User wants to keep recording past the calendar end —
-                // remember that so we don't re-prompt every 5s for the
-                // remainder of the auto-stop window.
-                self.dismissedEventIds.insert(event.id)
-                self.autoStopCountdownEventId = nil
-                Telemetry.send(.calendarAutoStopCancelled)
-                self.logger.info("Auto-stop cancelled by user for event id=\(event.id, privacy: .public)")
-            case .programmaticClose:
-                self.autoStopCountdownEventId = nil
-                return
-            }
+            self?.handleAutoStopOutcome(outcome, for: event)
         }
     }
 
-    private func showReminder(_ event: CalendarEvent, mode: CalendarAutoStartMode) async {
+    /// Internal entry point for the auto-stop outcome routing — symmetric
+    /// to `handleAutoStartOutcome`. Test target uses this directly via
+    /// the testHook extension below.
+    func handleAutoStopOutcome(_ outcome: MeetingCountdownToastOutcome, for event: CalendarEvent) {
+        switch outcome {
+        case .completed, .primedEarly:
+            onAutoStopConfirmed()
+            autoStartedEventId = nil
+            autoStopCountdownEventId = nil
+            logger.info("Auto-stop confirmed for event id=\(event.id, privacy: .public)")
+        case .userDismissed:
+            dismissedEventIds.insert(event.id)
+            autoStopCountdownEventId = nil
+            Telemetry.send(.calendarAutoStopCancelled)
+            logger.info("Auto-stop cancelled by user for event id=\(event.id, privacy: .public)")
+        case .programmaticClose:
+            autoStopCountdownEventId = nil
+            return
+        }
+    }
+}
+
+#if DEBUG
+/// Hooks for unit tests. The `testHook_` prefix marks them as test-only
+/// so they don't pollute autocomplete in production code paths.
+extension MeetingAutoStartCoordinator {
+    var testHook_autoStartedEventId: String? { autoStartedEventId }
+
+    func testHook_simulateAutoStartConfirmed(eventId: String) {
+        let event = CalendarEvent(
+            id: eventId,
+            title: "Test",
+            startTime: Date(),
+            endTime: Date().addingTimeInterval(1800)
+        )
+        handleAutoStartOutcome(.completed, for: event)
+    }
+
+    func testHook_simulateAutoStartCancelled(eventId: String) {
+        let event = CalendarEvent(
+            id: eventId,
+            title: "Test",
+            startTime: Date(),
+            endTime: Date().addingTimeInterval(1800)
+        )
+        handleAutoStartOutcome(.userDismissed, for: event)
+    }
+
+    func testHook_simulateAutoStopFired(eventId: String) {
+        // Mimic the production guard: only proceed if the event matches
+        // the coordinator's auto-started binding.
+        guard autoStartedEventId == eventId else { return }
+        let event = CalendarEvent(
+            id: eventId,
+            title: "Test",
+            startTime: Date().addingTimeInterval(-1800),
+            endTime: Date().addingTimeInterval(20)
+        )
+        handleAutoStopOutcome(.completed, for: event)
+    }
+
+    func testHook_forcePoll() {
+        Task { @MainActor [weak self] in await self?.pollAsync() }
+    }
+}
+#endif
+
+private extension MeetingAutoStartCoordinator {
+    func showReminder(_ event: CalendarEvent, mode: CalendarAutoStartMode) async {
         // Mark before posting so a failed delivery doesn't cause us to
         // re-attempt every poll tick — better to miss one reminder than
         // spam the user.

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -78,6 +78,14 @@ final class MeetingRecordingFlowCoordinator {
     /// which sets this and re-enters `toggleRecording`.
     private var pendingTrigger: TelemetryMeetingRecordingTrigger?
 
+    /// Optional callback fired when an auto-start attempt couldn't actually
+    /// start a recording — either because the state machine wasn't idle
+    /// (back-to-back meeting, previous wrap-up still in progress) or the
+    /// underlying `startRecording()` threw. The auto-start coordinator
+    /// uses this to clear its `autoStartedEventId` binding so a stale id
+    /// doesn't suppress the *next* meeting's auto-stop.
+    var onAutoStartFailed: (() -> Void)?
+
     func toggleRecording() {
         switch stateMachine.state {
         case .idle:
@@ -92,9 +100,13 @@ final class MeetingRecordingFlowCoordinator {
     /// Calendar-driven entry point. Marks the next start as auto-start so
     /// telemetry distinguishes it, then enters the normal start flow. No-op
     /// if a recording is already in progress (manual recording wins by
-    /// arriving first — see ADR-017 §10).
+    /// arriving first — see ADR-017 §10). When non-idle, fires
+    /// `onAutoStartFailed` so the coordinator can drop its binding.
     func startFromCalendar() {
-        guard stateMachine.state == .idle else { return }
+        guard stateMachine.state == .idle else {
+            onAutoStartFailed?()
+            return
+        }
         pendingTrigger = .calendarAutoStart
         sendEvent(.startRequested)
     }
@@ -215,6 +227,12 @@ final class MeetingRecordingFlowCoordinator {
                         errorType: TelemetryErrorClassifier.classify(error),
                         errorDetail: TelemetryErrorClassifier.errorDetail(error)
                     ))
+                    // If this start was driven by calendar auto-start, tell
+                    // the coordinator so it can drop the binding it set
+                    // optimistically when the countdown completed.
+                    if trigger == .calendarAutoStart {
+                        self.onAutoStartFailed?()
+                    }
                     self.sendEvent(.startFailed(generation: gen, message: error.localizedDescription))
                 }
             }

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -72,6 +72,12 @@ final class MeetingRecordingFlowCoordinator {
         panelViewModel?.chatViewModel.updateLLMService(service)
     }
 
+    /// Trigger source for the *next* `.startRequested` event. Reset to nil
+    /// after the start telemetry fires so subsequent toggles don't carry a
+    /// stale trigger. Calendar-driven starts call `startFromCalendar`,
+    /// which sets this and re-enters `toggleRecording`.
+    private var pendingTrigger: TelemetryMeetingRecordingTrigger?
+
     func toggleRecording() {
         switch stateMachine.state {
         case .idle:
@@ -81,6 +87,16 @@ final class MeetingRecordingFlowCoordinator {
         case .checkingPermissions, .transcribing, .finishing:
             break
         }
+    }
+
+    /// Calendar-driven entry point. Marks the next start as auto-start so
+    /// telemetry distinguishes it, then enters the normal start flow. No-op
+    /// if a recording is already in progress (manual recording wins by
+    /// arriving first — see ADR-017 §10).
+    func startFromCalendar() {
+        guard stateMachine.state == .idle else { return }
+        pendingTrigger = .calendarAutoStart
+        sendEvent(.startRequested)
     }
 
     private func sendEvent(_ event: MeetingRecordingFlowEvent) {
@@ -184,10 +200,14 @@ final class MeetingRecordingFlowCoordinator {
 
         case .startRecording:
             let gen = stateMachine.generation
+            // Snapshot + clear before the async hop so a subsequent toggle
+            // can't smuggle a stale trigger into this start's telemetry.
+            let trigger = pendingTrigger
+            pendingTrigger = nil
             actionTask = Task { @MainActor in
                 do {
                     try await meetingRecordingService.startRecording()
-                    Telemetry.send(.meetingRecordingStarted)
+                    Telemetry.send(.meetingRecordingStarted(trigger: trigger))
                     self.onRecordingBegan()
                     self.sendEvent(.recordingStarted(generation: gen))
                 } catch {

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -27,6 +27,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var hotkeyCoordinator: AppHotkeyCoordinator?
     private var dictationFlowCoordinator: DictationFlowCoordinator?
     private var meetingRecordingFlowCoordinator: MeetingRecordingFlowCoordinator?
+    private var meetingAutoStartCoordinator: MeetingAutoStartCoordinator?
     private var hasPresentedHotkeyUnavailableAlert = false
     private var environmentSetupTask: Task<Void, Never>?
 
@@ -203,6 +204,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // would send duplicate appQuit events and double the termination delay.
         dictationFlowCoordinator?.hideIdlePill()
         hotkeyCoordinator?.stopAll()
+        meetingAutoStartCoordinator?.stop()
         settingsObserverCoordinator.stopObserving()
         environmentSetupTask?.cancel()
 
@@ -289,6 +291,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         dictationFlowCoordinator = runtime.dictationFlowCoordinator
         meetingRecordingFlowCoordinator = runtime.meetingRecordingFlowCoordinator
         hotkeyCoordinator = runtime.hotkeyCoordinator
+        meetingAutoStartCoordinator = runtime.meetingAutoStartCoordinator
 
         menuBarCoordinator.refreshHotkeyTitle()
         menuBarCoordinator.refreshMeetingHotkeyShortcut()

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingCountdownToastController.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingCountdownToastController.swift
@@ -1,0 +1,176 @@
+import AppKit
+import MacParakeetViewModels
+import SwiftUI
+
+/// Reasons a countdown toast can disappear, fed back to the coordinator so
+/// it knows whether the action ran or the user opted out.
+enum MeetingCountdownToastOutcome: Sendable {
+    /// Countdown reached the end without user input — fire the default
+    /// action (start recording / stop recording).
+    case completed
+    /// User clicked the secondary "Start Now" button (auto-start only) —
+    /// fire the default action immediately.
+    case primedEarly
+    /// User clicked the primary "Cancel" / "Keep Recording" button.
+    case userDismissed
+    /// Coordinator called `close()` programmatically (e.g., another event
+    /// took precedence). No action should run.
+    case programmaticClose
+}
+
+private final class CountdownPanel: NSPanel {
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+}
+
+/// Owns the floating toast panel + the 60Hz progress timer that drives the
+/// view model. Single concurrent toast — calling `show*` while one is
+/// already visible closes the previous one with `.programmaticClose` so
+/// stacked countdowns don't compete for screen real estate.
+@MainActor
+final class MeetingCountdownToastController {
+    private var panel: NSPanel?
+    private var viewModel: MeetingCountdownToastViewModel?
+    private var startTime: Date?
+    private var timer: Timer?
+    private var onOutcome: ((MeetingCountdownToastOutcome) -> Void)?
+
+    /// Show a pre-meeting auto-start countdown. Default duration 5s.
+    func showAutoStart(
+        title: String,
+        body: String,
+        duration: TimeInterval = 5,
+        onOutcome: @escaping (MeetingCountdownToastOutcome) -> Void
+    ) {
+        present(
+            viewModel: MeetingCountdownToastViewModel(
+                style: .autoStart,
+                title: title,
+                body: body,
+                duration: duration
+            ),
+            onOutcome: onOutcome
+        )
+    }
+
+    /// Show an end-of-meeting auto-stop countdown. Default duration 30s
+    /// gives the user time to extend a meeting that ran over.
+    func showAutoStop(
+        title: String,
+        body: String,
+        duration: TimeInterval = 30,
+        onOutcome: @escaping (MeetingCountdownToastOutcome) -> Void
+    ) {
+        present(
+            viewModel: MeetingCountdownToastViewModel(
+                style: .autoStop,
+                title: title,
+                body: body,
+                duration: duration
+            ),
+            onOutcome: onOutcome
+        )
+    }
+
+    /// Force-close any visible toast without firing the default action.
+    /// Coordinator uses this when a higher-priority event preempts the
+    /// current countdown (e.g., user manually starts recording while the
+    /// auto-start countdown is mid-flight).
+    func close() {
+        finish(.programmaticClose)
+    }
+
+    // MARK: - Presentation
+
+    private func present(
+        viewModel: MeetingCountdownToastViewModel,
+        onOutcome: @escaping (MeetingCountdownToastOutcome) -> Void
+    ) {
+        // Replace any existing toast — coordinator only ever shows one at
+        // a time. The previous outcome callback fires `.programmaticClose`
+        // so its caller can clean up.
+        if panel != nil {
+            finish(.programmaticClose)
+        }
+
+        self.viewModel = viewModel
+        self.onOutcome = onOutcome
+        self.startTime = Date()
+
+        let view = MeetingCountdownToastView(
+            viewModel: viewModel,
+            onPrimary: { [weak self] in self?.finish(.userDismissed) },
+            onSecondary: viewModel.secondaryActionLabel == nil
+                ? nil
+                : { [weak self] in self?.finish(.primedEarly) }
+        )
+
+        let hosting = NSHostingView(rootView: view)
+        hosting.frame = NSRect(x: 0, y: 0, width: 280, height: 130)
+
+        let panel = CountdownPanel(
+            contentRect: hosting.frame,
+            styleMask: [.nonactivatingPanel, .borderless],
+            backing: .buffered,
+            defer: false
+        )
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = false  // SwiftUI renders its own shadow
+        panel.level = .floating
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        panel.contentView = hosting
+
+        if let screen = NSScreen.main {
+            // Top-center of the visible frame; sits below the menu bar but
+            // above any active app window — makes the countdown impossible
+            // to miss without being aggressive.
+            let panelSize = hosting.fittingSize.width > 0
+                ? hosting.fittingSize
+                : NSSize(width: 280, height: 130)
+            let frame = screen.visibleFrame
+            let x = frame.midX - panelSize.width / 2
+            let y = frame.maxY - panelSize.height - 32
+            panel.setFrame(NSRect(origin: NSPoint(x: x, y: y), size: panelSize), display: true)
+        }
+
+        panel.orderFrontRegardless()
+        self.panel = panel
+
+        startTimer()
+    }
+
+    private func startTimer() {
+        timer?.invalidate()
+        // 60Hz refresh keeps the progress bar smooth without burning CPU —
+        // a 5s auto-start ticks 300 times total. Add to .common so the
+        // timer keeps firing during menu/scroll tracking.
+        let timer = Timer(timeInterval: 1.0 / 60.0, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.tick() }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        self.timer = timer
+    }
+
+    private func tick() {
+        guard let viewModel, let startTime else { return }
+        let elapsed = Date().timeIntervalSince(startTime)
+        let progress = min(1, elapsed / viewModel.duration)
+        viewModel.progress = progress
+        if progress >= 1 {
+            finish(.completed)
+        }
+    }
+
+    private func finish(_ outcome: MeetingCountdownToastOutcome) {
+        let callback = onOutcome
+        timer?.invalidate()
+        timer = nil
+        panel?.orderOut(nil)
+        panel = nil
+        viewModel = nil
+        startTime = nil
+        onOutcome = nil
+        callback?(outcome)
+    }
+}

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingCountdownToastController.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingCountdownToastController.swift
@@ -19,7 +19,12 @@ enum MeetingCountdownToastOutcome: Sendable {
 }
 
 private final class CountdownPanel: NSPanel {
-    override var canBecomeKey: Bool { false }
+    // Must be `true` for SwiftUI's `.keyboardShortcut(.escape)` and
+    // `.keyboardShortcut(.return)` to fire — they require the hosting
+    // window to be the key window. The `.nonactivatingPanel` style mask
+    // (set in `present()`) prevents focus stealing on `orderFront`, so
+    // the user's app context isn't disturbed when the toast appears.
+    override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { false }
 }
 
@@ -33,6 +38,11 @@ final class MeetingCountdownToastController {
     private var viewModel: MeetingCountdownToastViewModel?
     private var startTime: Date?
     private var timer: Timer?
+    /// In-flight tick Task. Tracked so `finish()` can cancel it before
+    /// nilling out `viewModel` / `startTime` — otherwise a Task scheduled
+    /// from the last timer tick can fire `tick()` against torn-down state
+    /// and fall through to the early `return` (silent, but a smell).
+    private var tickTask: Task<Void, Never>?
     private var onOutcome: ((MeetingCountdownToastOutcome) -> Void)?
 
     /// Show a pre-meeting auto-start countdown. Default duration 5s.
@@ -144,16 +154,18 @@ final class MeetingCountdownToastController {
         timer?.invalidate()
         // 60Hz refresh keeps the progress bar smooth without burning CPU —
         // a 5s auto-start ticks 300 times total. Add to .common so the
-        // timer keeps firing during menu/scroll tracking.
+        // timer keeps firing during menu/scroll tracking. Track the spawned
+        // Task so `finish()` can cancel it before nilling state.
         let timer = Timer(timeInterval: 1.0 / 60.0, repeats: true) { [weak self] _ in
-            Task { @MainActor [weak self] in self?.tick() }
+            self?.tickTask?.cancel()
+            self?.tickTask = Task { @MainActor [weak self] in self?.tick() }
         }
         RunLoop.main.add(timer, forMode: .common)
         self.timer = timer
     }
 
     private func tick() {
-        guard let viewModel, let startTime else { return }
+        guard !Task.isCancelled, let viewModel, let startTime else { return }
         let elapsed = Date().timeIntervalSince(startTime)
         let progress = min(1, elapsed / viewModel.duration)
         viewModel.progress = progress
@@ -165,7 +177,9 @@ final class MeetingCountdownToastController {
     private func finish(_ outcome: MeetingCountdownToastOutcome) {
         let callback = onOutcome
         timer?.invalidate()
+        tickTask?.cancel()
         timer = nil
+        tickTask = nil
         panel?.orderOut(nil)
         panel = nil
         viewModel = nil

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingCountdownToastView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingCountdownToastView.swift
@@ -1,0 +1,85 @@
+import MacParakeetViewModels
+import SwiftUI
+
+/// Compact non-activating toast for calendar-driven auto-start countdowns.
+/// Two flavors via `MeetingCountdownToastViewModel.Style`:
+///
+/// - `.autoStart` → "Standup starts in 5s" + Cancel + Start Now
+/// - `.autoStop`  → "Wrap ending — stop recording?" + Keep Recording
+///
+/// Bound to a `@Bindable` view model so the controller can drive `progress`
+/// from a 60Hz timer without re-rendering the whole subtree.
+struct MeetingCountdownToastView: View {
+    @Bindable var viewModel: MeetingCountdownToastViewModel
+    let onPrimary: () -> Void
+    let onSecondary: (() -> Void)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            HStack(alignment: .firstTextBaseline, spacing: DesignSystem.Spacing.sm) {
+                Image(systemName: viewModel.style == .autoStart ? "calendar.badge.clock" : "stop.circle")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(DesignSystem.Colors.meetingPillText)
+                Text(viewModel.title)
+                    .font(DesignSystem.Typography.meetingPillStatus)
+                    .foregroundStyle(DesignSystem.Colors.meetingPillText)
+                    .lineLimit(1)
+                Spacer()
+            }
+
+            Text(viewModel.body)
+                .font(DesignSystem.Typography.caption)
+                .foregroundStyle(DesignSystem.Colors.meetingPillText.opacity(0.75))
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+
+            progressBar
+
+            HStack(spacing: DesignSystem.Spacing.sm) {
+                Button(action: onPrimary) {
+                    Text(viewModel.primaryActionLabel)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .keyboardShortcut(.escape, modifiers: [])
+
+                if let secondaryLabel = viewModel.secondaryActionLabel,
+                   let onSecondary {
+                    Button(action: onSecondary) {
+                        Text(secondaryLabel)
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .keyboardShortcut(.return, modifiers: [])
+                }
+            }
+        }
+        .padding(DesignSystem.Spacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
+                .fill(DesignSystem.Colors.meetingPillBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
+                        .stroke(DesignSystem.Colors.meetingPillStroke, lineWidth: 0.5)
+                )
+                .shadow(color: .black.opacity(0.18), radius: 12, y: 4)
+        )
+        .frame(width: 280)
+    }
+
+    private var progressBar: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(DesignSystem.Colors.meetingPillText.opacity(0.12))
+                Capsule()
+                    .fill(DesignSystem.Colors.accent)
+                    .frame(width: max(0, min(1, viewModel.progress)) * geo.size.width)
+                    .animation(.linear(duration: 0.05), value: viewModel.progress)
+            }
+        }
+        .frame(height: 4)
+    }
+}

--- a/Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift
+++ b/Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift
@@ -161,6 +161,7 @@ struct OnboardingFlowView: View {
         case .microphone: return "mic"
         case .accessibility: return "accessibility"
         case .meetingRecording: return "record.circle"
+        case .calendar: return "calendar"
         case .hotkey: return "keyboard"
         case .engine: return "cpu"
         case .done: return "checkmark.circle"
@@ -177,6 +178,8 @@ struct OnboardingFlowView: View {
             return viewModel.accessibilityGranted
         case .meetingRecording:
             return viewModel.screenRecordingGranted || viewModel.meetingRecordingSkipped
+        case .calendar:
+            return viewModel.calendarPermissionGranted || viewModel.calendarSkipped
         case .hotkey:
             return viewModel.step.rawValue > step.rawValue
         case .engine:
@@ -332,6 +335,8 @@ struct OnboardingFlowView: View {
             }
         case .meetingRecording:
             meetingRecordingStep
+        case .calendar:
+            calendarStep
         case .hotkey:
             hotkeyStep
         case .engine:
@@ -459,6 +464,59 @@ struct OnboardingFlowView: View {
                             RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
                                 .fill(DesignSystem.Colors.warningAmber.opacity(0.08))
                         )
+                }
+            }
+            .padding(DesignSystem.Spacing.lg)
+        }
+    }
+
+    private var calendarStep: some View {
+        onboardingCard {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    Text("Calendar Reminders (Optional)")
+                        .font(DesignSystem.Typography.sectionTitle)
+                    Spacer()
+                    Text(viewModel.calendarPermissionGranted ? "Granted" : "Not granted")
+                        .font(DesignSystem.Typography.caption)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 4)
+                        .background(
+                            Capsule().fill(
+                                viewModel.calendarPermissionGranted
+                                ? DesignSystem.Colors.successGreen.opacity(0.15)
+                                : DesignSystem.Colors.warningAmber.opacity(0.15)
+                            )
+                        )
+                        .foregroundStyle(
+                            viewModel.calendarPermissionGranted
+                            ? DesignSystem.Colors.successGreen
+                            : DesignSystem.Colors.warningAmber
+                        )
+                }
+
+                Text("MacParakeet can read your macOS calendar to send a quiet notification before each scheduled meeting — so you're ready to start the recording.")
+                    .font(DesignSystem.Typography.bodySmall)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text("Events are read on-device only and never uploaded. You can change the lead time, ignore specific calendars, or turn this off entirely from Settings.")
+                    .font(DesignSystem.Typography.bodySmall)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                HStack(spacing: 10) {
+                    accentButton(
+                        viewModel.isBusy ? "Requesting..." : "Enable Calendar Reminders",
+                        disabled: viewModel.isBusy || viewModel.calendarPermissionGranted
+                    ) {
+                        viewModel.requestCalendarAccess()
+                    }
+
+                    Button("Skip — I'll set this up later") {
+                        viewModel.skipCalendarStep()
+                    }
+                    .buttonStyle(.bordered)
                 }
             }
             .padding(DesignSystem.Spacing.lg)
@@ -912,6 +970,7 @@ struct OnboardingFlowView: View {
         case .microphone: return "Enable Microphone Access"
         case .accessibility: return "Enable Accessibility"
         case .meetingRecording: return "Meeting Recording (Optional)"
+        case .calendar: return "Calendar Reminders (Optional)"
         case .hotkey: return "Learn the Hotkey"
         case .engine: return "Prepare Speech Model"
         case .done: return "All Set"
@@ -928,6 +987,8 @@ struct OnboardingFlowView: View {
             return "Accessibility is required for the global hotkey and reliable paste automation."
         case .meetingRecording:
             return "Optional. This is only needed to capture system audio during meeting recording."
+        case .calendar:
+            return "Optional. Lets MacParakeet remind you before scheduled meetings so you never miss the start of a recording."
         case .hotkey:
             return "Two ways to dictate — pick whichever feels natural."
         case .engine:
@@ -943,6 +1004,7 @@ struct OnboardingFlowView: View {
         case .microphone: return "Continue"
         case .accessibility: return "Continue"
         case .meetingRecording: return "Continue"
+        case .calendar: return "Continue"
         case .hotkey: return "Continue"
         case .engine: return "Continue"
         case .done: return "Finish"
@@ -1065,7 +1127,7 @@ struct OnboardingFlowView: View {
             return "Grant microphone access to continue."
         case .accessibility:
             return "Enable Accessibility to continue."
-        case .meetingRecording:
+        case .meetingRecording, .calendar:
             return nil
         case .engine:
             return "Downloading — this can take several minutes. Everything works offline after setup."
@@ -1077,6 +1139,9 @@ struct OnboardingFlowView: View {
     private var continueButtonDisabled: Bool {
         if viewModel.step == .meetingRecording {
             return viewModel.isBusy || !(viewModel.screenRecordingGranted || viewModel.meetingRecordingSkipped)
+        }
+        if viewModel.step == .calendar {
+            return viewModel.isBusy || !(viewModel.calendarPermissionGranted || viewModel.calendarSkipped)
         }
         return !viewModel.canContinueFromCurrentStep() || viewModel.isBusy
     }

--- a/Sources/MacParakeet/Views/Settings/CalendarSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/CalendarSettingsView.swift
@@ -53,20 +53,29 @@ struct CalendarSettingsView: View {
     }
 
     private var permissionDetail: String {
-        if viewModel.calendarPermissionGranted {
+        switch viewModel.calendarPermissionStatus {
+        case .granted:
             return "Granted. Events stay on your Mac — MacParakeet never uploads them."
+        case .denied:
+            // macOS only shows the EventKit prompt once. Once denied, the
+            // only path back is System Settings — telling the user to
+            // "grant access" via a button that can't actually re-prompt
+            // would mystify them.
+            return "Calendar access is blocked. Re-enable it in System Settings → Privacy & Security → Calendars to use reminders."
+        case .notDetermined:
+            return "Reads your macOS calendar so MacParakeet can remind you before a meeting starts. Events stay on your Mac."
         }
-        return "Reads your macOS calendar so MacParakeet can remind you before a meeting starts. Events stay on your Mac."
     }
 
     @ViewBuilder
     private var permissionAction: some View {
-        if viewModel.calendarPermissionGranted {
+        switch viewModel.calendarPermissionStatus {
+        case .granted, .denied:
             Button("Open System Settings") {
                 viewModel.openCalendarSystemSettings()
             }
             .controlSize(.small)
-        } else {
+        case .notDetermined:
             Button {
                 requestPermission()
             } label: {

--- a/Sources/MacParakeet/Views/Settings/CalendarSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/CalendarSettingsView.swift
@@ -201,13 +201,16 @@ struct CalendarSettingsView: View {
     }
 
     private func bindingForCalendar(_ calendar: CalendarInfo) -> Binding<Bool> {
+        // Key on `calendar.id` (EKCalendar.calendarIdentifier), not title —
+        // titles aren't unique across accounts and rename silently breaks the
+        // exclude list. ID is stable across both.
         Binding(
-            get: { !viewModel.calendarExcludedIdentifiers.contains(calendar.title) },
+            get: { !viewModel.calendarExcludedIdentifiers.contains(calendar.id) },
             set: { isIncluded in
                 if isIncluded {
-                    viewModel.calendarExcludedIdentifiers.remove(calendar.title)
+                    viewModel.calendarExcludedIdentifiers.remove(calendar.id)
                 } else {
-                    viewModel.calendarExcludedIdentifiers.insert(calendar.title)
+                    viewModel.calendarExcludedIdentifiers.insert(calendar.id)
                 }
             }
         )
@@ -229,6 +232,12 @@ struct CalendarSettingsView: View {
             availableCalendars = []
             return
         }
-        availableCalendars = CalendarService().availableCalendars()
+        // CalendarService is an actor (EventKit isn't thread-safe), so this
+        // hops off main. Cheap — typically <5ms with permission already
+        // granted — but worth keeping off the main thread on principle.
+        Task {
+            let calendars = await CalendarService.shared.availableCalendars()
+            await MainActor.run { self.availableCalendars = calendars }
+        }
     }
 }

--- a/Sources/MacParakeet/Views/Settings/CalendarSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/CalendarSettingsView.swift
@@ -24,6 +24,11 @@ struct CalendarSettingsView: View {
                     Divider()
                     triggerFilterRow
 
+                    if viewModel.calendarAutoStartMode == .autoStart {
+                        Divider()
+                        autoStopRow
+                    }
+
                     if !availableCalendars.isEmpty {
                         Divider()
                         includedCalendarsRow
@@ -94,33 +99,34 @@ struct CalendarSettingsView: View {
 
     @ViewBuilder
     private var modeRow: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Calendar reminders")
-                        .font(DesignSystem.Typography.body)
-                    Text("Show a macOS notification before scheduled meetings.")
-                        .font(DesignSystem.Typography.caption)
-                        .foregroundStyle(.secondary)
-                }
-                Spacer(minLength: DesignSystem.Spacing.md)
-                Picker("", selection: $viewModel.calendarAutoStartMode) {
-                    Text("Off").tag(CalendarAutoStartMode.off)
-                    Text("Notify before meetings").tag(CalendarAutoStartMode.notify)
-                }
-                .labelsHidden()
-                .pickerStyle(.menu)
-                .frame(minWidth: 200)
-            }
-
-            // Phase D: auto-start mode is implemented in MeetingMonitor but
-            // not yet wired to a countdown/recording flow. Surface the future
-            // capability so users aren't surprised when it appears.
-            if viewModel.calendarAutoStartMode == .notify {
-                Text("Auto-start recording on countdown — coming in a future update.")
+        HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Calendar behavior")
+                    .font(DesignSystem.Typography.body)
+                Text(modeDetail)
                     .font(DesignSystem.Typography.caption)
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(.secondary)
             }
+            Spacer(minLength: DesignSystem.Spacing.md)
+            Picker("", selection: $viewModel.calendarAutoStartMode) {
+                Text("Off").tag(CalendarAutoStartMode.off)
+                Text("Notify before meetings").tag(CalendarAutoStartMode.notify)
+                Text("Start recording automatically").tag(CalendarAutoStartMode.autoStart)
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+            .frame(minWidth: 240)
+        }
+    }
+
+    private var modeDetail: String {
+        switch viewModel.calendarAutoStartMode {
+        case .off:
+            return "MacParakeet ignores your calendar."
+        case .notify:
+            return "Quietly notifies you before each meeting starts."
+        case .autoStart:
+            return "Shows a 5-second cancellable countdown, then starts recording. You can keep the recording past the meeting end."
         }
     }
 
@@ -170,6 +176,25 @@ struct CalendarSettingsView: View {
             .labelsHidden()
             .pickerStyle(.menu)
             .frame(minWidth: 200)
+        }
+    }
+
+    // MARK: - Auto-stop toggle (only when mode == .autoStart)
+
+    @ViewBuilder
+    private var autoStopRow: some View {
+        HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Stop recording at meeting end")
+                    .font(DesignSystem.Typography.body)
+                Text("Shows a 30-second countdown when the meeting is scheduled to end. Click \"Keep Recording\" if it runs over.")
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: DesignSystem.Spacing.md)
+            Toggle("", isOn: $viewModel.calendarAutoStopEnabled)
+                .labelsHidden()
+                .toggleStyle(.switch)
         }
     }
 

--- a/Sources/MacParakeet/Views/Settings/CalendarSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/CalendarSettingsView.swift
@@ -1,0 +1,234 @@
+import MacParakeetCore
+import MacParakeetViewModels
+import SwiftUI
+
+/// Calendar auto-start section. Slotted into Settings between Meeting
+/// Recording and Transcription. Phase D — only `.off` and `.notify` modes
+/// are exposed; `.autoStart` ships in Phase E (ADR-017).
+struct CalendarSettingsView: View {
+    @Bindable var viewModel: SettingsViewModel
+    @State private var availableCalendars: [CalendarInfo] = []
+    @State private var isRequestingPermission = false
+
+    var body: some View {
+        VStack(spacing: DesignSystem.Spacing.md) {
+            permissionRow
+
+            if viewModel.calendarPermissionGranted {
+                Divider()
+                modeRow
+
+                if viewModel.calendarAutoStartMode != .off {
+                    Divider()
+                    reminderLeadRow
+                    Divider()
+                    triggerFilterRow
+
+                    if !availableCalendars.isEmpty {
+                        Divider()
+                        includedCalendarsRow
+                    }
+                }
+            }
+        }
+        .onAppear { reloadCalendars() }
+        .onChange(of: viewModel.calendarPermissionGranted) { _, _ in reloadCalendars() }
+    }
+
+    // MARK: - Permission
+
+    @ViewBuilder
+    private var permissionRow: some View {
+        HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Calendar access")
+                    .font(DesignSystem.Typography.body)
+                Text(permissionDetail)
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: DesignSystem.Spacing.md)
+            permissionAction
+        }
+    }
+
+    private var permissionDetail: String {
+        if viewModel.calendarPermissionGranted {
+            return "Granted. Events stay on your Mac — MacParakeet never uploads them."
+        }
+        return "Reads your macOS calendar so MacParakeet can remind you before a meeting starts. Events stay on your Mac."
+    }
+
+    @ViewBuilder
+    private var permissionAction: some View {
+        if viewModel.calendarPermissionGranted {
+            Button("Open System Settings") {
+                viewModel.openCalendarSystemSettings()
+            }
+            .controlSize(.small)
+        } else {
+            Button {
+                requestPermission()
+            } label: {
+                if isRequestingPermission {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Text("Grant Calendar Access")
+                }
+            }
+            .controlSize(.small)
+            .disabled(isRequestingPermission)
+        }
+    }
+
+    // MARK: - Mode
+
+    @ViewBuilder
+    private var modeRow: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Calendar reminders")
+                        .font(DesignSystem.Typography.body)
+                    Text("Show a macOS notification before scheduled meetings.")
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: DesignSystem.Spacing.md)
+                Picker("", selection: $viewModel.calendarAutoStartMode) {
+                    Text("Off").tag(CalendarAutoStartMode.off)
+                    Text("Notify before meetings").tag(CalendarAutoStartMode.notify)
+                }
+                .labelsHidden()
+                .pickerStyle(.menu)
+                .frame(minWidth: 200)
+            }
+
+            // Phase D: auto-start mode is implemented in MeetingMonitor but
+            // not yet wired to a countdown/recording flow. Surface the future
+            // capability so users aren't surprised when it appears.
+            if viewModel.calendarAutoStartMode == .notify {
+                Text("Auto-start recording on countdown — coming in a future update.")
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+    }
+
+    // MARK: - Reminder lead time
+
+    @ViewBuilder
+    private var reminderLeadRow: some View {
+        HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Remind me")
+                    .font(DesignSystem.Typography.body)
+                Text("How long before the meeting starts to send the reminder.")
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: DesignSystem.Spacing.md)
+            Picker("", selection: $viewModel.calendarReminderMinutes) {
+                Text("At start time").tag(0)
+                Text("1 minute before").tag(1)
+                Text("5 minutes before").tag(5)
+                Text("10 minutes before").tag(10)
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+            .frame(minWidth: 200)
+        }
+    }
+
+    // MARK: - Trigger filter
+
+    @ViewBuilder
+    private var triggerFilterRow: some View {
+        HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Which events count")
+                    .font(DesignSystem.Typography.body)
+                Text("Higher precision filters skip personal blocks and solo focus time.")
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: DesignSystem.Spacing.md)
+            Picker("", selection: $viewModel.meetingTriggerFilter) {
+                Text("With video link").tag(MeetingTriggerFilter.withLink)
+                Text("With participants").tag(MeetingTriggerFilter.withParticipants)
+                Text("All events").tag(MeetingTriggerFilter.allEvents)
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+            .frame(minWidth: 200)
+        }
+    }
+
+    // MARK: - Per-calendar include list
+
+    @ViewBuilder
+    private var includedCalendarsRow: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Calendars")
+                        .font(DesignSystem.Typography.body)
+                    Text("Uncheck calendars to ignore (personal calendars, holidays, etc.).")
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: DesignSystem.Spacing.md)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(availableCalendars) { calendar in
+                    Toggle(isOn: bindingForCalendar(calendar)) {
+                        VStack(alignment: .leading, spacing: 0) {
+                            Text(calendar.title)
+                                .font(DesignSystem.Typography.body)
+                            if let source = calendar.sourceTitle {
+                                Text(source)
+                                    .font(DesignSystem.Typography.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                    .toggleStyle(.checkbox)
+                }
+            }
+            .padding(.leading, DesignSystem.Spacing.sm)
+        }
+    }
+
+    private func bindingForCalendar(_ calendar: CalendarInfo) -> Binding<Bool> {
+        Binding(
+            get: { !viewModel.calendarExcludedIdentifiers.contains(calendar.title) },
+            set: { isIncluded in
+                if isIncluded {
+                    viewModel.calendarExcludedIdentifiers.remove(calendar.title)
+                } else {
+                    viewModel.calendarExcludedIdentifiers.insert(calendar.title)
+                }
+            }
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func requestPermission() {
+        isRequestingPermission = true
+        Task {
+            _ = await viewModel.requestCalendarPermission()
+            isRequestingPermission = false
+            reloadCalendars()
+        }
+    }
+
+    private func reloadCalendars() {
+        guard viewModel.calendarPermissionGranted else {
+            availableCalendars = []
+            return
+        }
+        availableCalendars = CalendarService().availableCalendars()
+    }
+}

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -32,6 +32,7 @@ struct SettingsView: View {
                 dictationCard
                 if AppFeatures.meetingRecordingEnabled {
                     meetingRecordingCard
+                    calendarCard
                 }
                 transcriptionCard
                 aiProviderCard
@@ -296,6 +297,18 @@ struct SettingsView: View {
             onChooseFolder: { viewModel.chooseMeetingAutoSaveFolder(url: $0) },
             onClearFolder: { viewModel.clearMeetingAutoSaveFolder() }
         )
+    }
+
+    // MARK: - Calendar Auto-Start
+
+    private var calendarCard: some View {
+        settingsCard(
+            title: "Calendar",
+            subtitle: "Reminders before scheduled meetings, powered by your macOS calendar.",
+            icon: "calendar"
+        ) {
+            CalendarSettingsView(viewModel: viewModel)
+        }
     }
 
     private var transcriptionCard: some View {

--- a/Sources/MacParakeetCore/AppNotifications.swift
+++ b/Sources/MacParakeetCore/AppNotifications.swift
@@ -23,4 +23,9 @@ public extension Notification.Name {
     /// This exists mainly so observers can clear any formatter-scoped UI if
     /// the higher-level flow has already moved on.
     static let macParakeetAIFormatterDidFinish = Notification.Name("macparakeet.aiFormatterDidFinish")
+    /// Posted when any calendar auto-start setting (mode, reminder lead time,
+    /// trigger filter, included calendars, auto-stop toggle) changes. The
+    /// `MeetingAutoStartCoordinator` re-reads its config and re-evaluates on
+    /// the next poll tick instead of waiting for the timer.
+    static let macParakeetCalendarSettingsDidChange = Notification.Name("macparakeet.calendarSettingsDidChange")
 }

--- a/Sources/MacParakeetCore/AppPreferences.swift
+++ b/Sources/MacParakeetCore/AppPreferences.swift
@@ -11,3 +11,19 @@ public enum AppPreferences {
         defaults.object(forKey: telemetryEnabledKey) as? Bool ?? true
     }
 }
+
+/// Calendar-driven meeting auto-start preferences (ADR-017). Namespaced under
+/// `CalendarAutoStart.*` so we can grep them as a group and wipe them in tests
+/// without disturbing other preferences.
+public enum CalendarAutoStartPreferences {
+    public static let modeKey = "CalendarAutoStart.mode"
+    public static let reminderMinutesKey = "CalendarAutoStart.reminderMinutes"
+    public static let triggerFilterKey = "CalendarAutoStart.triggerFilter"
+    public static let autoStopEnabledKey = "CalendarAutoStart.autoStopEnabled"
+    /// Set of `EKCalendar.calendarIdentifier` strings the user has *deselected*.
+    /// Stored as the inverse so a fresh install / new calendar account is
+    /// included by default — users opt out, not in.
+    public static let excludedCalendarIdsKey = "CalendarAutoStart.excludedCalendarIds"
+
+    public static let defaultReminderMinutes = 5
+}

--- a/Sources/MacParakeetCore/Calendar/CalendarAutoStartMode.swift
+++ b/Sources/MacParakeetCore/Calendar/CalendarAutoStartMode.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// User-facing mode for the calendar-driven meeting feature.
+///
+/// One enum, three values — keeps reasoning about behavior simple. The
+/// reminder lead time and trigger filter are independent settings; this enum
+/// only controls *what happens when a matching event fires*.
+public enum CalendarAutoStartMode: String, Codable, Sendable, CaseIterable {
+    /// No calendar integration. The coordinator is a no-op even if Calendar
+    /// permission is granted.
+    case off
+
+    /// Show a macOS notification at `T - reminderMinutes`. Recording is not
+    /// started automatically.
+    case notify
+
+    /// Notify *and* start recording at `T-0` (after a short cancellable
+    /// countdown). Phase 2 — see ADR-017.
+    case autoStart
+}

--- a/Sources/MacParakeetCore/Calendar/CalendarEvent.swift
+++ b/Sources/MacParakeetCore/Calendar/CalendarEvent.swift
@@ -1,0 +1,152 @@
+import Foundation
+
+/// A calendar event fetched from EventKit at poll time.
+///
+/// MacParakeet does **not** persist these — the coordinator fetches and
+/// discards on each poll tick. See ADR-017 §6 for the rationale. If we ever
+/// need to query event history (e.g., for retro-linking recordings to events),
+/// add a `CalendarEvent` table then.
+public struct CalendarEvent: Codable, Sendable, Identifiable {
+    /// EventKit's `EKEvent.eventIdentifier`. Stable across syncs but can
+    /// change for recurring events when the user edits a single occurrence.
+    /// Use `externalId` if you need a stronger identity.
+    public var id: String
+
+    public var title: String
+    public var startTime: Date
+    public var endTime: Date
+    public var location: String?
+
+    /// Extracted Zoom / Meet / Teams / Webex / Around URL.
+    public var meetUrl: String?
+
+    /// Other attendees — current user is filtered out at conversion time
+    /// (their participation status is captured separately in `userStatus`).
+    public var participants: [EventParticipant]
+
+    public var isAllDay: Bool
+
+    /// e.g. "Work", "Personal" — used for the per-calendar include list.
+    public var calendarName: String?
+
+    /// Current user's participation status, lifted off `EKAttendee` before
+    /// the participant list is filtered. Used to suppress declined events.
+    public var userStatus: EventParticipant.ParticipantStatus?
+
+    /// `EKEvent.calendarItemExternalIdentifier` — more stable than `id` for
+    /// recurring events whose occurrences get reorganized server-side.
+    public var externalId: String?
+
+    public var syncedAt: Date
+
+    public init(
+        id: String,
+        title: String,
+        startTime: Date,
+        endTime: Date,
+        location: String? = nil,
+        meetUrl: String? = nil,
+        participants: [EventParticipant] = [],
+        isAllDay: Bool = false,
+        calendarName: String? = nil,
+        userStatus: EventParticipant.ParticipantStatus? = nil,
+        externalId: String? = nil,
+        syncedAt: Date = Date()
+    ) {
+        self.id = id
+        self.title = title
+        self.startTime = startTime
+        self.endTime = endTime
+        self.location = location
+        self.meetUrl = meetUrl
+        self.participants = participants
+        self.isAllDay = isAllDay
+        self.calendarName = calendarName
+        self.userStatus = userStatus
+        self.externalId = externalId
+        self.syncedAt = syncedAt
+    }
+}
+
+public struct EventParticipant: Codable, Sendable, Hashable {
+    public var email: String?
+    public var name: String?
+    public var status: ParticipantStatus
+
+    public init(email: String? = nil, name: String? = nil, status: ParticipantStatus = .unknown) {
+        self.email = email
+        self.name = name
+        self.status = status
+    }
+
+    public enum ParticipantStatus: String, Codable, Sendable {
+        case accepted
+        case declined
+        case tentative
+        case pending
+        case unknown
+    }
+}
+
+public extension CalendarEvent {
+    var durationMinutes: Int {
+        Int(endTime.timeIntervalSince(startTime) / 60)
+    }
+
+    var isNow: Bool {
+        let now = Date()
+        return startTime <= now && endTime >= now
+    }
+
+    func startsWithin(minutes: Int) -> Bool {
+        let now = Date()
+        let threshold = now.addingTimeInterval(TimeInterval(minutes * 60))
+        return startTime > now && startTime <= threshold
+    }
+
+    var timeUntilStart: TimeInterval {
+        startTime.timeIntervalSinceNow
+    }
+
+    var formattedTimeRange: String {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        return "\(formatter.string(from: startTime)) - \(formatter.string(from: endTime))"
+    }
+
+    var attendeeCount: Int {
+        participants.count
+    }
+
+    var isMeeting: Bool {
+        !participants.isEmpty || meetUrl != nil
+    }
+
+    var userDeclined: Bool {
+        userStatus == .declined
+    }
+}
+
+extension CalendarEvent: Hashable {
+    public static func == (lhs: CalendarEvent, rhs: CalendarEvent) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}
+
+/// Lightweight info for the per-calendar include list in Settings — we don't
+/// need the full `EKCalendar` surface here.
+public struct CalendarInfo: Codable, Sendable, Identifiable, Hashable {
+    public var id: String
+    public var title: String
+    public var sourceTitle: String?
+
+    public init(id: String, title: String, sourceTitle: String? = nil) {
+        self.id = id
+        self.title = title
+        self.sourceTitle = sourceTitle
+    }
+}

--- a/Sources/MacParakeetCore/Calendar/CalendarEvent.swift
+++ b/Sources/MacParakeetCore/Calendar/CalendarEvent.swift
@@ -26,8 +26,16 @@ public struct CalendarEvent: Codable, Sendable, Identifiable {
 
     public var isAllDay: Bool
 
-    /// e.g. "Work", "Personal" — used for the per-calendar include list.
+    /// e.g. "Work", "Personal" — display label for UI surfaces. **Don't key
+    /// the per-calendar exclude list on this** — multiple accounts can have
+    /// the same human-readable title (two "Calendar"s, two "Work"s). Use
+    /// `calendarIdentifier` for filtering.
     public var calendarName: String?
+
+    /// Stable `EKCalendar.calendarIdentifier`. Used to key the per-calendar
+    /// exclude list — survives renames and disambiguates same-titled
+    /// calendars across accounts.
+    public var calendarIdentifier: String?
 
     /// Current user's participation status, lifted off `EKAttendee` before
     /// the participant list is filtered. Used to suppress declined events.
@@ -49,6 +57,7 @@ public struct CalendarEvent: Codable, Sendable, Identifiable {
         participants: [EventParticipant] = [],
         isAllDay: Bool = false,
         calendarName: String? = nil,
+        calendarIdentifier: String? = nil,
         userStatus: EventParticipant.ParticipantStatus? = nil,
         externalId: String? = nil,
         syncedAt: Date = Date()
@@ -62,6 +71,7 @@ public struct CalendarEvent: Codable, Sendable, Identifiable {
         self.participants = participants
         self.isAllDay = isAllDay
         self.calendarName = calendarName
+        self.calendarIdentifier = calendarIdentifier
         self.userStatus = userStatus
         self.externalId = externalId
         self.syncedAt = syncedAt

--- a/Sources/MacParakeetCore/Calendar/CalendarNotificationAuthorization.swift
+++ b/Sources/MacParakeetCore/Calendar/CalendarNotificationAuthorization.swift
@@ -1,0 +1,47 @@
+import Foundation
+import OSLog
+import UserNotifications
+
+/// Calendar reminders rely on `UNUserNotificationCenter`. Without a prior
+/// `requestAuthorization` call, macOS silently drops every reminder we post —
+/// the user grants Calendar access, sees nothing, and concludes the feature
+/// is broken. This helper centralizes the request so onboarding, Settings,
+/// and the coordinator all flow through one path.
+public enum CalendarNotificationAuthorization {
+    private static let logger = Logger(subsystem: "com.macparakeet", category: "CalendarNotifications")
+
+    /// Request `.alert` authorization (no `.sound` — calendar reminders are
+    /// silent by design so they don't fight the user's Zoom join sound). No-op
+    /// when status is already `.authorized` or `.provisional`.
+    @discardableResult
+    public static func requestIfNeeded() async -> Bool {
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        switch settings.authorizationStatus {
+        case .authorized, .provisional:
+            return true
+        case .denied:
+            logger.warning("Notification authorization previously denied — calendar reminders will not deliver")
+            return false
+        case .notDetermined, .ephemeral:
+            fallthrough
+        @unknown default:
+            do {
+                let granted = try await UNUserNotificationCenter.current().requestAuthorization(options: [.alert])
+                logger.info("Notification authorization request \(granted ? "granted" : "denied", privacy: .public)")
+                return granted
+            } catch {
+                logger.error("Notification authorization request failed: \(error.localizedDescription, privacy: .public)")
+                return false
+            }
+        }
+    }
+
+    /// Cheap status check the coordinator can call before posting a reminder.
+    public static func isAuthorized() async -> Bool {
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        switch settings.authorizationStatus {
+        case .authorized, .provisional: return true
+        default: return false
+        }
+    }
+}

--- a/Sources/MacParakeetCore/Calendar/CalendarNotificationAuthorization.swift
+++ b/Sources/MacParakeetCore/Calendar/CalendarNotificationAuthorization.swift
@@ -10,11 +10,22 @@ import UserNotifications
 public enum CalendarNotificationAuthorization {
     private static let logger = Logger(subsystem: "com.macparakeet", category: "CalendarNotifications")
 
+    /// `UNUserNotificationCenter.current()` requires a host bundle with a
+    /// proper `bundleIdentifier` and crashes inside `xctest` (the test
+    /// helper has no UN-eligible bundle). This guard makes the helper
+    /// safe to call from anywhere — production paths are unaffected
+    /// because the app bundle always has an identifier.
+    private static var isHostBundleEligible: Bool {
+        Bundle.main.bundleIdentifier?.isEmpty == false
+            && Bundle.main.bundleIdentifier?.hasPrefix("com.apple.dt.xctest") == false
+    }
+
     /// Request `.alert` authorization (no `.sound` — calendar reminders are
     /// silent by design so they don't fight the user's Zoom join sound). No-op
     /// when status is already `.authorized` or `.provisional`.
     @discardableResult
     public static func requestIfNeeded() async -> Bool {
+        guard isHostBundleEligible else { return false }
         let settings = await UNUserNotificationCenter.current().notificationSettings()
         switch settings.authorizationStatus {
         case .authorized, .provisional:
@@ -38,6 +49,7 @@ public enum CalendarNotificationAuthorization {
 
     /// Cheap status check the coordinator can call before posting a reminder.
     public static func isAuthorized() async -> Bool {
+        guard isHostBundleEligible else { return false }
         let settings = await UNUserNotificationCenter.current().notificationSettings()
         switch settings.authorizationStatus {
         case .authorized, .provisional: return true

--- a/Sources/MacParakeetCore/Calendar/CalendarService.swift
+++ b/Sources/MacParakeetCore/Calendar/CalendarService.swift
@@ -8,33 +8,29 @@ import OSLog
 /// MacParakeet does not run its own OAuth flows — the user's macOS Calendar
 /// already aggregates Google/iCloud/Exchange accounts. ADR-002 (local-first):
 /// events are read into memory on each poll and discarded, never persisted.
-public final class CalendarService: @unchecked Sendable {
+///
+/// **Concurrency.** `EKEventStore` is documented as not thread-safe, and
+/// Apple recommends a single long-lived store per app. This type is an
+/// `actor` so all instance-method calls are serialized on the actor's
+/// background executor — that solves both the thread-safety constraint *and*
+/// keeps EventKit's synchronous `events(matching:)` disk I/O off the main
+/// actor. Use `CalendarService.shared` rather than constructing your own.
+public actor CalendarService {
 
-    // MARK: - State (lock-guarded — service is `@unchecked Sendable`)
+    // MARK: - State
 
     private let eventStore = EKEventStore()
     private let linkParser = MeetingLinkParser()
     private let logger = Logger(subsystem: "com.macparakeet", category: "CalendarService")
-    private let lock = NSLock()
 
-    private var _lookAheadDays: Int = 7
-    private var _excludeAllDay: Bool = true
-    private var _excludeDeclined: Bool = true
+    public var lookAheadDays: Int = 7
+    public var excludeAllDay: Bool = true
+    public var excludeDeclined: Bool = true
 
-    public var lookAheadDays: Int {
-        get { lock.withLock { _lookAheadDays } }
-        set { lock.withLock { _lookAheadDays = newValue } }
-    }
-
-    public var excludeAllDay: Bool {
-        get { lock.withLock { _excludeAllDay } }
-        set { lock.withLock { _excludeAllDay = newValue } }
-    }
-
-    public var excludeDeclined: Bool {
-        get { lock.withLock { _excludeDeclined } }
-        set { lock.withLock { _excludeDeclined = newValue } }
-    }
+    /// Shared singleton — Apple recommends a single long-lived `EKEventStore`
+    /// for the lifetime of the app. Multiple stores can return stale data and
+    /// duplicate the file-system watcher cost.
+    public static let shared = CalendarService()
 
     public init() {}
 
@@ -46,7 +42,12 @@ public final class CalendarService: @unchecked Sendable {
         case denied
     }
 
-    public var permissionStatus: PermissionStatus {
+    /// `EKEventStore.authorizationStatus(for:)` is a thread-safe class method
+    /// that doesn't touch the instance store, so we can read it without
+    /// hopping into the actor — keeps Settings + Onboarding sync code paths
+    /// simple. (`requestPermission` *does* touch the store so it stays
+    /// actor-isolated.)
+    public nonisolated var permissionStatus: PermissionStatus {
         let status = EKEventStore.authorizationStatus(for: .event)
         switch status {
         case .notDetermined:
@@ -210,6 +211,7 @@ public final class CalendarService: @unchecked Sendable {
             participants: participants,
             isAllDay: ekEvent.isAllDay,
             calendarName: ekEvent.calendar?.title,
+            calendarIdentifier: ekEvent.calendar?.calendarIdentifier,
             userStatus: userStatus,
             externalId: ekEvent.calendarItemExternalIdentifier,
             syncedAt: Date()
@@ -249,5 +251,5 @@ public enum CalendarError: Error, LocalizedError {
 
 public extension CalendarService {
     /// Deep-link to the Calendar privacy pane in System Settings.
-    static let settingsURL = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Calendars")!
+    nonisolated static let settingsURL = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Calendars")!
 }

--- a/Sources/MacParakeetCore/Calendar/CalendarService.swift
+++ b/Sources/MacParakeetCore/Calendar/CalendarService.swift
@@ -122,7 +122,9 @@ public actor CalendarService {
         }
 
         let lookAhead = days ?? lookAheadDays
-        let endDate = Calendar.current.date(byAdding: .day, value: lookAhead, to: from)!
+        guard let endDate = Calendar.current.date(byAdding: .day, value: lookAhead, to: from) else {
+            throw CalendarError.fetchFailed("Could not compute end date for lookAhead=\(lookAhead) from \(from)")
+        }
 
         logger.debug("Fetching events from \(from) to \(endDate)")
 

--- a/Sources/MacParakeetCore/Calendar/CalendarService.swift
+++ b/Sources/MacParakeetCore/Calendar/CalendarService.swift
@@ -1,0 +1,253 @@
+import Foundation
+import EventKit
+import OSLog
+
+/// Wraps EventKit (`EKEventStore`) so the rest of the app talks to a small,
+/// testable surface instead of the framework directly.
+///
+/// MacParakeet does not run its own OAuth flows — the user's macOS Calendar
+/// already aggregates Google/iCloud/Exchange accounts. ADR-002 (local-first):
+/// events are read into memory on each poll and discarded, never persisted.
+public final class CalendarService: @unchecked Sendable {
+
+    // MARK: - State (lock-guarded — service is `@unchecked Sendable`)
+
+    private let eventStore = EKEventStore()
+    private let linkParser = MeetingLinkParser()
+    private let logger = Logger(subsystem: "com.macparakeet", category: "CalendarService")
+    private let lock = NSLock()
+
+    private var _lookAheadDays: Int = 7
+    private var _excludeAllDay: Bool = true
+    private var _excludeDeclined: Bool = true
+
+    public var lookAheadDays: Int {
+        get { lock.withLock { _lookAheadDays } }
+        set { lock.withLock { _lookAheadDays = newValue } }
+    }
+
+    public var excludeAllDay: Bool {
+        get { lock.withLock { _excludeAllDay } }
+        set { lock.withLock { _excludeAllDay = newValue } }
+    }
+
+    public var excludeDeclined: Bool {
+        get { lock.withLock { _excludeDeclined } }
+        set { lock.withLock { _excludeDeclined = newValue } }
+    }
+
+    public init() {}
+
+    // MARK: - Permission
+
+    public enum PermissionStatus: Sendable {
+        case notDetermined
+        case granted
+        case denied
+    }
+
+    public var permissionStatus: PermissionStatus {
+        let status = EKEventStore.authorizationStatus(for: .event)
+        switch status {
+        case .notDetermined:
+            return .notDetermined
+        case .fullAccess, .authorized:
+            return .granted
+        case .denied, .restricted, .writeOnly:
+            return .denied
+        @unknown default:
+            return .denied
+        }
+    }
+
+    /// Whether any calendars are visible. Triggers `eventStore.reset()` so we
+    /// pick up permissions granted by *another* `EKEventStore` instance —
+    /// e.g. when `PermissionService` shows the prompt during onboarding, this
+    /// service's stale state would otherwise still report no calendars.
+    public func hasCalendars() -> Bool {
+        guard permissionStatus == .granted else { return false }
+        eventStore.reset()
+        return !eventStore.calendars(for: .event).isEmpty
+    }
+
+    /// Modern macOS Sonoma+ API. Returns `false` when the user denies or the
+    /// system reports an error (logged for debugging).
+    public func requestPermission() async -> Bool {
+        logger.info("Requesting calendar permission")
+        do {
+            let granted = try await eventStore.requestFullAccessToEvents()
+            if granted {
+                logger.info("Calendar permission granted")
+            } else {
+                logger.warning("Calendar permission denied")
+            }
+            return granted
+        } catch {
+            logger.error("Calendar permission request failed: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
+    // MARK: - Available Calendars
+
+    /// Lightweight metadata for the per-calendar include list in Settings.
+    /// Returns empty if permission is missing rather than throwing — Settings
+    /// just shows an empty state in that case.
+    public func availableCalendars() -> [CalendarInfo] {
+        guard permissionStatus == .granted else { return [] }
+        eventStore.reset()
+        return eventStore.calendars(for: .event).map { calendar in
+            CalendarInfo(
+                id: calendar.calendarIdentifier,
+                title: calendar.title,
+                sourceTitle: calendar.source?.title
+            )
+        }
+    }
+
+    // MARK: - Fetch Events
+
+    public func fetchUpcomingEvents(from: Date = Date(), days: Int? = nil) async throws -> [CalendarEvent] {
+        guard permissionStatus == .granted else {
+            throw CalendarError.permissionDenied
+        }
+
+        let lookAhead = days ?? lookAheadDays
+        let endDate = Calendar.current.date(byAdding: .day, value: lookAhead, to: from)!
+
+        logger.debug("Fetching events from \(from) to \(endDate)")
+
+        let calendars = eventStore.calendars(for: .event)
+        let predicate = eventStore.predicateForEvents(
+            withStart: from,
+            end: endDate,
+            calendars: calendars
+        )
+        let ekEvents = eventStore.events(matching: predicate)
+
+        let events = ekEvents.compactMap { convertEvent($0) }
+            .filter { shouldInclude($0) }
+            .sorted { $0.startTime < $1.startTime }
+
+        logger.info("Returning \(events.count) filtered events")
+        return events
+    }
+
+    /// Includes in-progress events (looks back 2h) so a user starting the app
+    /// mid-meeting still sees the matching event.
+    public func fetchCurrentAndUpcoming(withinMinutes: Int = 15) async throws -> [CalendarEvent] {
+        guard permissionStatus == .granted else {
+            throw CalendarError.permissionDenied
+        }
+
+        let now = Date()
+        let startDate = now.addingTimeInterval(-2 * 60 * 60)
+        let endDate = now.addingTimeInterval(TimeInterval(withinMinutes * 60))
+
+        let calendars = eventStore.calendars(for: .event)
+        let predicate = eventStore.predicateForEvents(
+            withStart: startDate,
+            end: endDate,
+            calendars: calendars
+        )
+        let ekEvents = eventStore.events(matching: predicate)
+
+        return ekEvents.compactMap { convertEvent($0) }
+            .filter { shouldInclude($0) }
+            .filter { $0.isNow || $0.startsWithin(minutes: withinMinutes) }
+            .sorted { $0.startTime < $1.startTime }
+    }
+
+    // MARK: - EKEvent → CalendarEvent
+
+    private func convertEvent(_ ekEvent: EKEvent) -> CalendarEvent? {
+        guard let startDate = ekEvent.startDate,
+              let endDate = ekEvent.endDate else {
+            return nil
+        }
+
+        // Capture the user's status *before* filtering them out of the
+        // participant list — otherwise we lose the signal needed to honor
+        // declined events.
+        var userStatus: EventParticipant.ParticipantStatus?
+        if let attendees = ekEvent.attendees {
+            if let currentUser = attendees.first(where: { $0.isCurrentUser }) {
+                userStatus = mapStatus(currentUser.participantStatus)
+            }
+        }
+
+        let participants = (ekEvent.attendees ?? []).compactMap { attendee -> EventParticipant? in
+            if attendee.isCurrentUser { return nil }
+
+            let email: String? = {
+                let urlString = attendee.url.absoluteString
+                if urlString.hasPrefix("mailto:") {
+                    return urlString.replacingOccurrences(of: "mailto:", with: "")
+                }
+                return nil
+            }()
+
+            return EventParticipant(
+                email: email,
+                name: attendee.name,
+                status: mapStatus(attendee.participantStatus)
+            )
+        }
+
+        let meetUrl = linkParser.extractMeetingUrl(
+            location: ekEvent.location,
+            notes: ekEvent.notes,
+            url: ekEvent.url?.absoluteString
+        )
+
+        return CalendarEvent(
+            id: ekEvent.eventIdentifier,
+            title: ekEvent.title ?? "Untitled",
+            startTime: startDate,
+            endTime: endDate,
+            location: ekEvent.location,
+            meetUrl: meetUrl,
+            participants: participants,
+            isAllDay: ekEvent.isAllDay,
+            calendarName: ekEvent.calendar?.title,
+            userStatus: userStatus,
+            externalId: ekEvent.calendarItemExternalIdentifier,
+            syncedAt: Date()
+        )
+    }
+
+    private func mapStatus(_ status: EKParticipantStatus) -> EventParticipant.ParticipantStatus {
+        switch status {
+        case .accepted: return .accepted
+        case .declined: return .declined
+        case .tentative: return .tentative
+        case .pending: return .pending
+        default: return .unknown
+        }
+    }
+
+    private func shouldInclude(_ event: CalendarEvent) -> Bool {
+        if excludeAllDay && event.isAllDay { return false }
+        if excludeDeclined && event.userDeclined { return false }
+        return true
+    }
+}
+
+public enum CalendarError: Error, LocalizedError {
+    case permissionDenied
+    case fetchFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .permissionDenied:
+            return "Calendar access denied. Please grant access in System Settings > Privacy & Security > Calendars."
+        case .fetchFailed(let message):
+            return "Failed to fetch calendar events: \(message)"
+        }
+    }
+}
+
+public extension CalendarService {
+    /// Deep-link to the Calendar privacy pane in System Settings.
+    static let settingsURL = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Calendars")!
+}

--- a/Sources/MacParakeetCore/Calendar/CalendarService.swift
+++ b/Sources/MacParakeetCore/Calendar/CalendarService.swift
@@ -73,12 +73,20 @@ public actor CalendarService {
 
     /// Modern macOS Sonoma+ API. Returns `false` when the user denies or the
     /// system reports an error (logged for debugging).
+    ///
+    /// Calls `eventStore.reset()` on successful grant so the *next*
+    /// `fetchUpcomingEvents` doesn't see a stale "no calendars" view from
+    /// before the prompt. Without this, the "grant access → reminder fires
+    /// for an event 5 min out" path could return zero events on the very
+    /// first poll after grant, until the next `EKEventStoreChanged` woke us
+    /// up.
     public func requestPermission() async -> Bool {
         logger.info("Requesting calendar permission")
         do {
             let granted = try await eventStore.requestFullAccessToEvents()
             if granted {
                 logger.info("Calendar permission granted")
+                eventStore.reset()
             } else {
                 logger.warning("Calendar permission denied")
             }

--- a/Sources/MacParakeetCore/Calendar/CalendarServicing.swift
+++ b/Sources/MacParakeetCore/Calendar/CalendarServicing.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Protocol surface that the meeting auto-start coordinator (and tests) talk
+/// to. Defined in `MacParakeetCore` so test targets can stub without taking
+/// a dependency on EventKit. The concrete `CalendarService` actor conforms;
+/// tests inject a `MockCalendarService` (in `Tests/`) with controllable
+/// permission status and event lists.
+///
+/// Mirrors the public surface of `CalendarService` that has consumers today.
+/// Properties stay `nonisolated` to match the actor; methods are `async` so
+/// the actor implementation can serialize `EKEventStore` access without
+/// blocking the main thread.
+public protocol CalendarServicing: Sendable {
+    /// Cheap synchronous read backed by `EKEventStore.authorizationStatus`.
+    nonisolated var permissionStatus: CalendarService.PermissionStatus { get }
+
+    /// Triggers the EventKit prompt. Returns the granted state. On grant the
+    /// concrete service also resets the event store so the next fetch sees
+    /// the new permission immediately.
+    func requestPermission() async -> Bool
+
+    /// Lightweight list for the per-calendar include UI. Returns empty when
+    /// permission is missing rather than throwing.
+    func availableCalendars() async -> [CalendarInfo]
+
+    /// Look-ahead fetch used by the polling coordinator. Throws
+    /// `CalendarError.permissionDenied` when access is missing or
+    /// `CalendarError.fetchFailed` for malformed input.
+    func fetchUpcomingEvents(from: Date, days: Int?) async throws -> [CalendarEvent]
+}
+
+extension CalendarService: CalendarServicing {}
+
+/// Convenience overload so callers can omit the date parameter — matches the
+/// concrete `CalendarService` default. Defined on the protocol so mocks
+/// inherit it for free.
+public extension CalendarServicing {
+    func fetchUpcomingEvents(days: Int? = nil) async throws -> [CalendarEvent] {
+        try await fetchUpcomingEvents(from: Date(), days: days)
+    }
+}

--- a/Sources/MacParakeetCore/Calendar/MeetingLinkParser.swift
+++ b/Sources/MacParakeetCore/Calendar/MeetingLinkParser.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+/// Extracts video-conferencing URLs from calendar event fields.
+///
+/// Ported verbatim from Oatmeal — both projects share the same heuristic.
+/// Order-of-precedence is Zoom → Meet → Teams → Webex → Around → generic so
+/// the most specific pattern wins when multiple URLs appear in event notes.
+public struct MeetingLinkParser: Sendable {
+    public init() {}
+
+    private static let zoomPattern = #"https?://(?:[\w-]+\.)?zoom\.us/j/\d+(?:\?[^\s]*)?"#
+    private static let meetPattern = #"https?://meet\.google\.com/[\w-]+"#
+    private static let teamsPattern = #"https?://teams\.microsoft\.com/[\w/.%-]+"#
+    private static let webexPattern = #"https?://[\w-]+\.webex\.com/[\w/.%-]+"#
+    private static let aroundPattern = #"https?://around\.co/[\w/-]+"#
+    private static let genericVideoPattern = #"https?://[^\s]+(?:meet|video|call|conference)[^\s]*"#
+
+    private static let patterns: [(name: String, pattern: String)] = [
+        ("zoom", zoomPattern),
+        ("meet", meetPattern),
+        ("teams", teamsPattern),
+        ("webex", webexPattern),
+        ("around", aroundPattern),
+        ("generic", genericVideoPattern),
+    ]
+
+    public func extractMeetingUrl(from text: String?) -> String? {
+        guard let text, !text.isEmpty else { return nil }
+        for (_, pattern) in Self.patterns {
+            if let match = firstMatch(pattern: pattern, in: text) {
+                return match
+            }
+        }
+        return nil
+    }
+
+    /// Multi-field overload. URL field wins if it's already a meeting URL,
+    /// then location, then notes — matches Oatmeal's precedence.
+    public func extractMeetingUrl(
+        location: String?,
+        notes: String?,
+        url: String?
+    ) -> String? {
+        if let url, isMeetingUrl(url) {
+            return url
+        }
+        if let match = extractMeetingUrl(from: location) {
+            return match
+        }
+        if let match = extractMeetingUrl(from: notes) {
+            return match
+        }
+        return nil
+    }
+
+    public func isMeetingUrl(_ url: String?) -> Bool {
+        guard let url, !url.isEmpty else { return false }
+        for (_, pattern) in Self.patterns {
+            if firstMatch(pattern: pattern, in: url) != nil {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// Friendly service name for UI ("Zoom", "Google Meet", …).
+    public func identifyService(from url: String?) -> String? {
+        guard let url, !url.isEmpty else { return nil }
+        if url.contains("zoom.us") { return "Zoom" }
+        if url.contains("meet.google.com") { return "Google Meet" }
+        if url.contains("teams.microsoft.com") { return "Microsoft Teams" }
+        if url.contains("webex.com") { return "Webex" }
+        if url.contains("around.co") { return "Around" }
+        return nil
+    }
+
+    private func firstMatch(pattern: String, in text: String) -> String? {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
+            return nil
+        }
+        let range = NSRange(text.startIndex..., in: text)
+        guard let match = regex.firstMatch(in: text, options: [], range: range) else {
+            return nil
+        }
+        guard let matchRange = Range(match.range, in: text) else {
+            return nil
+        }
+        return String(text[matchRange])
+    }
+}
+
+public extension MeetingLinkParser {
+    static let shared = MeetingLinkParser()
+}

--- a/Sources/MacParakeetCore/Calendar/MeetingMonitor.swift
+++ b/Sources/MacParakeetCore/Calendar/MeetingMonitor.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+/// Pure-logic state machine that decides when calendar events deserve
+/// attention. No EventKit, no UI, no timers — caller passes everything in.
+///
+/// Lives in `MacParakeetCore` so the coordinator (UI layer) and tests can
+/// share the exact same evaluator. Keeping this `static` and `Sendable` makes
+/// it trivially safe to call from any actor.
+public enum MeetingMonitor {
+
+    public enum MonitorEvent: Equatable, Sendable {
+        /// Fires once per event in the window `[T - reminderMinutes, +90s]`.
+        /// The 90-second forgiveness window catches slow polls — without it,
+        /// a 60s timer that ticks 10s late would *miss* a reminder entirely.
+        case reminderDue(CalendarEvent)
+
+        /// Fires in the window `[T - 5s, T + 30s]` — gives the user a small
+        /// late-grace tolerance for events that start a few seconds early.
+        case autoStartDue(CalendarEvent)
+
+        /// Fires in the window `(T + 30s, T + lateJoinGraceMinutes]`. Phase D
+        /// keeps the case but does not wire UI — see ADR-017.
+        case lateJoinAvailable(CalendarEvent)
+
+        /// Fires in the window `[endTime - autoStopLeadSeconds, endTime]`.
+        /// Only emitted when `activeRecording == true`.
+        case autoStopDue(CalendarEvent)
+    }
+
+    public struct Config: Codable, Sendable, Equatable {
+        public var mode: CalendarAutoStartMode
+        /// 0 disables the reminder. Typical values: 1, 5, 10.
+        public var reminderMinutes: Int
+        /// Phase 2 — countdown duration before auto-start fires. Held here so
+        /// the future coordinator wiring doesn't need a separate config type.
+        public var countdownSeconds: Int
+        public var autoStopEnabled: Bool
+        public var autoStopLeadSeconds: Int
+        public var triggerFilter: MeetingTriggerFilter
+        public var lateJoinGraceMinutes: Int
+
+        public init(
+            mode: CalendarAutoStartMode = .notify,
+            reminderMinutes: Int = 5,
+            countdownSeconds: Int = 5,
+            autoStopEnabled: Bool = true,
+            autoStopLeadSeconds: Int = 30,
+            triggerFilter: MeetingTriggerFilter = .withLink,
+            lateJoinGraceMinutes: Int = 10
+        ) {
+            self.mode = mode
+            self.reminderMinutes = reminderMinutes
+            self.countdownSeconds = countdownSeconds
+            self.autoStopEnabled = autoStopEnabled
+            self.autoStopLeadSeconds = autoStopLeadSeconds
+            self.triggerFilter = triggerFilter
+            self.lateJoinGraceMinutes = lateJoinGraceMinutes
+        }
+
+        public static let `default` = Config()
+    }
+
+    /// Evaluate calendar events and return any pending monitor events.
+    /// Pure function — all state passed in, no side effects.
+    public static func evaluate(
+        events: [CalendarEvent],
+        now: Date,
+        config: Config,
+        activeRecording: Bool,
+        dismissedEventIds: Set<String>,
+        remindedEventIds: Set<String>,
+        countdownShownEventIds: Set<String>
+    ) -> [MonitorEvent] {
+        guard config.mode != .off else { return [] }
+
+        let candidates = events.filter { event in
+            guard !event.isAllDay else { return false }
+            guard event.userStatus != .declined else { return false }
+            guard !dismissedEventIds.contains(event.id) else { return false }
+            return passesFilter(event, filter: config.triggerFilter)
+        }
+
+        var result: [MonitorEvent] = []
+
+        for event in candidates {
+            if config.reminderMinutes > 0 && !remindedEventIds.contains(event.id) {
+                let reminderTime = event.startTime.addingTimeInterval(-Double(config.reminderMinutes * 60))
+                let reminderWindowEnd = reminderTime.addingTimeInterval(90)
+                if now >= reminderTime && now <= reminderWindowEnd {
+                    result.append(.reminderDue(event))
+                }
+            }
+
+            // Auto-start and late-join only fire when mode allows it AND we're
+            // not already recording. Phase D keeps these as harmless no-ops
+            // because the coordinator only handles `.reminderDue`.
+            if config.mode == .autoStart && !activeRecording && !countdownShownEventIds.contains(event.id) {
+                let autoStartBegin = event.startTime.addingTimeInterval(-5)
+                let autoStartEnd = event.startTime.addingTimeInterval(30)
+                if now >= autoStartBegin && now <= autoStartEnd {
+                    result.append(.autoStartDue(event))
+                }
+
+                let lateJoinBegin = event.startTime.addingTimeInterval(30)
+                let lateJoinEnd = event.startTime.addingTimeInterval(Double(config.lateJoinGraceMinutes * 60))
+                if now > lateJoinBegin && now <= lateJoinEnd {
+                    result.append(.lateJoinAvailable(event))
+                }
+            }
+
+            if config.mode == .autoStart && config.autoStopEnabled && activeRecording {
+                let autoStopBegin = event.endTime.addingTimeInterval(-Double(config.autoStopLeadSeconds))
+                let autoStopEnd = event.endTime
+                if now >= autoStopBegin && now <= autoStopEnd {
+                    result.append(.autoStopDue(event))
+                }
+            }
+        }
+
+        return result
+    }
+
+    private static func passesFilter(_ event: CalendarEvent, filter: MeetingTriggerFilter) -> Bool {
+        switch filter {
+        case .allEvents:
+            return true
+        case .withParticipants:
+            return event.participants.count >= 1
+        case .withLink:
+            return event.meetUrl != nil
+        }
+    }
+}

--- a/Sources/MacParakeetCore/Calendar/MeetingTriggerFilter.swift
+++ b/Sources/MacParakeetCore/Calendar/MeetingTriggerFilter.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Determines which calendar events the meeting coordinator considers
+/// "real meetings worth recording." Higher precision filters reduce false
+/// positives (a "Lunch" calendar block won't fire a recording reminder); lower
+/// precision filters cover edge cases (phone calls, single-attendee meetings).
+public enum MeetingTriggerFilter: String, Codable, Sendable, CaseIterable {
+    /// Default. Event has a Zoom / Google Meet / Teams / Webex / Around link
+    /// in its location, notes, or URL field. Highest signal-to-noise.
+    case withLink
+
+    /// 2+ attendees including "me" — i.e. the event has at least one other
+    /// participant. Catches phone calls and meetings without dial-in URLs.
+    case withParticipants
+
+    /// Every non-all-day event. Useful for solo focus blocks the user wants
+    /// transcribed (e.g. "Record voice memo at 3pm").
+    case allEvents
+}

--- a/Sources/MacParakeetCore/Services/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/TelemetryEvent.swift
@@ -70,6 +70,10 @@ public enum TelemetryEventName: String, Sendable, CaseIterable {
     case meetingRecordingFailed = "meeting_recording_failed"
     // Calendar auto-start (ADR-017)
     case calendarReminderShown = "calendar_reminder_shown"
+    case calendarAutoStartTriggered = "calendar_auto_start_triggered"
+    case calendarAutoStartCancelled = "calendar_auto_start_cancelled"
+    case calendarAutoStopShown = "calendar_auto_stop_shown"
+    case calendarAutoStopCancelled = "calendar_auto_stop_cancelled"
     // Errors
     case errorOccurred = "error_occurred"
     // Crashes
@@ -119,6 +123,14 @@ public enum TelemetryCopySource: String, Sendable, Equatable {
 public enum TelemetryFormatterSource: String, Sendable, Equatable {
     case dictation
     case transcription
+}
+
+/// Why a meeting recording started. Lets us distinguish manual user action
+/// from calendar-driven auto-start in adoption metrics.
+public enum TelemetryMeetingRecordingTrigger: String, Sendable, Equatable {
+    case manual
+    case hotkey
+    case calendarAutoStart = "calendar_auto_start"
 }
 
 public enum TelemetryPermission: String, Sendable, Equatable {
@@ -251,13 +263,26 @@ public enum TelemetryEventSpec: Sendable {
     // Keystroke actions
     case keystrokeSnippetFired(action: String)
     // Meeting recording
-    case meetingRecordingStarted
+    case meetingRecordingStarted(trigger: TelemetryMeetingRecordingTrigger? = nil)
     case meetingRecordingCompleted(durationSeconds: Double, liveWordCount: Int, liveTranscriptLagged: Bool)
     case meetingRecordingCancelled(durationSeconds: Double)
     case meetingRecordingFailed(errorType: String, errorDetail: String? = nil)
     // Calendar auto-start (ADR-017). Mode is "notify" / "auto_start" — `.off`
     // never produces an event because the coordinator short-circuits.
     case calendarReminderShown(mode: String, leadMinutes: Int, hasMeetUrl: Bool)
+    /// Auto-start countdown shown to the user. Fires when `.autoStartDue`
+    /// emits and `MeetingAutoStartCoordinator` actually presents the toast
+    /// (after permission + active-recording checks).
+    case calendarAutoStartTriggered(leadSeconds: Int, hasMeetUrl: Bool)
+    /// User actively cancelled the countdown before recording started, *or*
+    /// recording failed to start despite the user accepting. `.userCancel`
+    /// vs `.startError` is the distinction worth measuring.
+    case calendarAutoStartCancelled(reason: String)
+    /// Auto-stop countdown shown for an event currently being recorded.
+    case calendarAutoStopShown(eventDurationSeconds: Double)
+    /// User extended past the calendar event's end time (suppressed
+    /// auto-stop). Tells us how often the 30s lead is wrong.
+    case calendarAutoStopCancelled
     // Errors
     case errorOccurred(domain: String, code: String, description: String)
     // Crashes
@@ -336,6 +361,10 @@ extension TelemetryEventSpec {
         case .meetingRecordingCancelled: return .meetingRecordingCancelled
         case .meetingRecordingFailed: return .meetingRecordingFailed
         case .calendarReminderShown: return .calendarReminderShown
+        case .calendarAutoStartTriggered: return .calendarAutoStartTriggered
+        case .calendarAutoStartCancelled: return .calendarAutoStartCancelled
+        case .calendarAutoStopShown: return .calendarAutoStopShown
+        case .calendarAutoStopCancelled: return .calendarAutoStopCancelled
         case .errorOccurred: return .errorOccurred
         case .crashOccurred: return .crashOccurred
         }
@@ -529,8 +558,8 @@ extension TelemetryEventSpec {
             return ["is_favorite": isFavorite ? "true" : "false"]
         case .keystrokeSnippetFired(let action):
             return ["action": action]
-        case .meetingRecordingStarted:
-            return nil
+        case .meetingRecordingStarted(let trigger):
+            return Self.compactProps(("trigger", trigger?.rawValue))
         case .meetingRecordingCompleted(let durationSeconds, let liveWordCount, let liveTranscriptLagged):
             return [
                 "duration_seconds": Self.format(durationSeconds),
@@ -549,6 +578,17 @@ extension TelemetryEventSpec {
                 "lead_minutes": "\(leadMinutes)",
                 "has_meet_url": Self.boolString(hasMeetUrl),
             ]
+        case .calendarAutoStartTriggered(let leadSeconds, let hasMeetUrl):
+            return [
+                "lead_seconds": "\(leadSeconds)",
+                "has_meet_url": Self.boolString(hasMeetUrl),
+            ]
+        case .calendarAutoStartCancelled(let reason):
+            return ["reason": reason]
+        case .calendarAutoStopShown(let eventDurationSeconds):
+            return ["event_duration_seconds": Self.format(eventDurationSeconds)]
+        case .calendarAutoStopCancelled:
+            return nil
         case .errorOccurred(let domain, let code, let description):
             return ["domain": domain, "code": code, "description": String(description.prefix(512))]
         case .crashOccurred(let crashType, let signal, let name, let crashTimestamp,
@@ -665,6 +705,10 @@ public enum TelemetryImplementedContract {
         .meetingRecordingCancelled: ["duration_seconds"],
         .meetingRecordingFailed: ["error_type"],
         .calendarReminderShown: ["mode", "lead_minutes", "has_meet_url"],
+        .calendarAutoStartTriggered: ["lead_seconds", "has_meet_url"],
+        .calendarAutoStartCancelled: ["reason"],
+        .calendarAutoStopShown: ["event_duration_seconds"],
+        .calendarAutoStopCancelled: [],
         .errorOccurred: ["domain", "code", "description"],
         .crashOccurred: ["crash_type", "signal", "name", "crash_ts", "crash_app_ver"],
     ]

--- a/Sources/MacParakeetCore/Services/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/TelemetryEvent.swift
@@ -68,6 +68,8 @@ public enum TelemetryEventName: String, Sendable, CaseIterable {
     case meetingRecordingCompleted = "meeting_recording_completed"
     case meetingRecordingCancelled = "meeting_recording_cancelled"
     case meetingRecordingFailed = "meeting_recording_failed"
+    // Calendar auto-start (ADR-017)
+    case calendarReminderShown = "calendar_reminder_shown"
     // Errors
     case errorOccurred = "error_occurred"
     // Crashes
@@ -123,6 +125,7 @@ public enum TelemetryPermission: String, Sendable, Equatable {
     case microphone
     case accessibility
     case screenRecording = "screen_recording"
+    case calendar
 }
 
 public enum TelemetrySettingName: String, Sendable, Equatable {
@@ -141,6 +144,13 @@ public enum TelemetrySettingName: String, Sendable, Equatable {
     case launchAtLogin = "launch_at_login"
     case silenceAutoStop = "silence_auto_stop"
     case voiceReturn = "voice_return"
+
+    // Calendar auto-start (ADR-017)
+    case calendarAutoStartMode = "calendar_auto_start_mode"
+    case calendarReminderMinutes = "calendar_reminder_minutes"
+    case calendarTriggerFilter = "calendar_trigger_filter"
+    case calendarAutoStopEnabled = "calendar_auto_stop_enabled"
+    case calendarIncludedCalendars = "calendar_included_calendars"
 }
 
 public enum TelemetryEventSpec: Sendable {
@@ -245,6 +255,9 @@ public enum TelemetryEventSpec: Sendable {
     case meetingRecordingCompleted(durationSeconds: Double, liveWordCount: Int, liveTranscriptLagged: Bool)
     case meetingRecordingCancelled(durationSeconds: Double)
     case meetingRecordingFailed(errorType: String, errorDetail: String? = nil)
+    // Calendar auto-start (ADR-017). Mode is "notify" / "auto_start" — `.off`
+    // never produces an event because the coordinator short-circuits.
+    case calendarReminderShown(mode: String, leadMinutes: Int, hasMeetUrl: Bool)
     // Errors
     case errorOccurred(domain: String, code: String, description: String)
     // Crashes
@@ -322,6 +335,7 @@ extension TelemetryEventSpec {
         case .meetingRecordingCompleted: return .meetingRecordingCompleted
         case .meetingRecordingCancelled: return .meetingRecordingCancelled
         case .meetingRecordingFailed: return .meetingRecordingFailed
+        case .calendarReminderShown: return .calendarReminderShown
         case .errorOccurred: return .errorOccurred
         case .crashOccurred: return .crashOccurred
         }
@@ -529,6 +543,12 @@ extension TelemetryEventSpec {
             var props = ["error_type": errorType]
             if let errorDetail { props["error_detail"] = errorDetail }
             return props
+        case .calendarReminderShown(let mode, let leadMinutes, let hasMeetUrl):
+            return [
+                "mode": mode,
+                "lead_minutes": "\(leadMinutes)",
+                "has_meet_url": Self.boolString(hasMeetUrl),
+            ]
         case .errorOccurred(let domain, let code, let description):
             return ["domain": domain, "code": code, "description": String(description.prefix(512))]
         case .crashOccurred(let crashType, let signal, let name, let crashTimestamp,
@@ -644,6 +664,7 @@ public enum TelemetryImplementedContract {
         .meetingRecordingCompleted: ["duration_seconds", "live_word_count", "live_transcript_lagged"],
         .meetingRecordingCancelled: ["duration_seconds"],
         .meetingRecordingFailed: ["error_type"],
+        .calendarReminderShown: ["mode", "lead_minutes", "has_meet_url"],
         .errorOccurred: ["domain", "code", "description"],
         .crashOccurred: ["crash_type", "signal", "name", "crash_ts", "crash_app_ver"],
     ]

--- a/Sources/MacParakeetViewModels/MeetingCountdownToastViewModel.swift
+++ b/Sources/MacParakeetViewModels/MeetingCountdownToastViewModel.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Small `@Observable` shared between the toast controller and its SwiftUI
+/// view. The controller drives `progress` from a 60Hz timer; the view binds
+/// to `progress`, `title`, `body`, and the action labels and renders.
+///
+/// Lives in `MacParakeetViewModels` (not in App) so unit tests can construct
+/// it without launching AppKit panels.
+@MainActor
+@Observable
+public final class MeetingCountdownToastViewModel {
+    public enum Style: Sendable, Equatable {
+        /// Pre-meeting countdown — default action is "start recording now",
+        /// cancel = "don't auto-start this one."
+        case autoStart
+        /// End-of-meeting countdown — default action is "stop recording",
+        /// cancel = "keep recording."
+        case autoStop
+    }
+
+    public var style: Style
+    public var title: String
+    public var body: String
+    /// 0...1 — completion fraction over `duration` seconds.
+    public var progress: Double = 0
+    public var duration: TimeInterval
+
+    public init(style: Style, title: String, body: String, duration: TimeInterval) {
+        self.style = style
+        self.title = title
+        self.body = body
+        self.duration = duration
+    }
+
+    public var primaryActionLabel: String {
+        switch style {
+        case .autoStart: return "Cancel"
+        case .autoStop: return "Keep Recording"
+        }
+    }
+
+    public var secondaryActionLabel: String? {
+        switch style {
+        case .autoStart: return "Start Now"
+        case .autoStop: return nil
+        }
+    }
+}

--- a/Sources/MacParakeetViewModels/OnboardingViewModel.swift
+++ b/Sources/MacParakeetViewModels/OnboardingViewModel.swift
@@ -134,6 +134,10 @@ public final class OnboardingViewModel {
         engineState = .idle
         meetingRecordingSkipped = false
         calendarSkipped = false
+        // Re-resolve from the live calendar permission so a previously-
+        // granted user re-entering onboarding sees the correct "completed"
+        // state, not the stale value carried over from VM init.
+        calendarPermissionGranted = CalendarService.shared.permissionStatus == .granted
         clearMeetingRecordingPendingState()
     }
 

--- a/Sources/MacParakeetViewModels/OnboardingViewModel.swift
+++ b/Sources/MacParakeetViewModels/OnboardingViewModel.swift
@@ -111,7 +111,7 @@ public final class OnboardingViewModel {
         self.relaunchHintDelay = relaunchHintDelay
         self.meetingRecordingSkipped = defaults.bool(forKey: Self.meetingRecordingSkippedKey)
         self.calendarSkipped = defaults.bool(forKey: Self.calendarSkippedKey)
-        self.calendarPermissionGranted = CalendarService().permissionStatus == .granted
+        self.calendarPermissionGranted = CalendarService.shared.permissionStatus == .granted
     }
 
     public var hasCompletedOnboarding: Bool {
@@ -284,17 +284,20 @@ public final class OnboardingViewModel {
     }
 
     /// Trigger the EventKit permission prompt. On grant, default the user
-    /// into `.notify` mode so the feature works out of the box. On denial,
-    /// leave the mode as-is (`.off` by default) — the user can opt back in
-    /// from Settings later. We write directly to UserDefaults + post the
+    /// into `.notify` mode so the feature works out of the box and request
+    /// notification authorization in the same flow — without it, macOS
+    /// silently drops every reminder we post and the user concludes the
+    /// feature is broken. We write directly to UserDefaults + post the
     /// shared notification so a running `MeetingAutoStartCoordinator`
     /// re-evaluates immediately.
     public func requestCalendarAccess() {
         isBusy = true
         Telemetry.send(.permissionPrompted(permission: .calendar))
         Task {
-            let service = CalendarService()
-            let granted = await service.requestPermission()
+            let granted = await CalendarService.shared.requestPermission()
+            if granted {
+                await CalendarNotificationAuthorization.requestIfNeeded()
+            }
             await MainActor.run {
                 self.isBusy = false
                 self.calendarPermissionGranted = granted

--- a/Sources/MacParakeetViewModels/OnboardingViewModel.swift
+++ b/Sources/MacParakeetViewModels/OnboardingViewModel.swift
@@ -14,6 +14,7 @@ public final class OnboardingViewModel {
         case microphone
         case accessibility
         case meetingRecording
+        case calendar
         case hotkey
         case engine
         case done
@@ -26,6 +27,7 @@ public final class OnboardingViewModel {
             case .microphone: return "Microphone"
             case .accessibility: return "Accessibility"
             case .meetingRecording: return "Meeting Recording"
+            case .calendar: return "Calendar"
             case .hotkey: return "Hotkey"
             case .engine: return "Speech Model"
             case .done: return "Ready"
@@ -49,6 +51,8 @@ public final class OnboardingViewModel {
     public private(set) var accessibilityGranted: Bool = false
     public private(set) var screenRecordingGranted: Bool = false
     public private(set) var meetingRecordingSkipped: Bool
+    public private(set) var calendarPermissionGranted: Bool = false
+    public private(set) var calendarSkipped: Bool
     public private(set) var showRelaunchHint: Bool = false
     public private(set) var engineState: EngineState = .idle
 
@@ -79,6 +83,7 @@ public final class OnboardingViewModel {
 
     public static let onboardingCompletedKey = "onboarding.completedAtISO"
     public static let meetingRecordingSkippedKey = "onboarding.meetingRecordingSkipped"
+    public static let calendarSkippedKey = "onboarding.calendarSkipped"
 
     public init(
         permissionService: PermissionServiceProtocol,
@@ -105,6 +110,8 @@ public final class OnboardingViewModel {
         self.permissionPollingInterval = permissionPollingInterval
         self.relaunchHintDelay = relaunchHintDelay
         self.meetingRecordingSkipped = defaults.bool(forKey: Self.meetingRecordingSkippedKey)
+        self.calendarSkipped = defaults.bool(forKey: Self.calendarSkippedKey)
+        self.calendarPermissionGranted = CalendarService().permissionStatus == .granted
     }
 
     public var hasCompletedOnboarding: Bool {
@@ -122,9 +129,11 @@ public final class OnboardingViewModel {
     public func resetOnboarding() {
         defaults.removeObject(forKey: Self.onboardingCompletedKey)
         defaults.removeObject(forKey: Self.meetingRecordingSkippedKey)
+        defaults.removeObject(forKey: Self.calendarSkippedKey)
         step = .welcome
         engineState = .idle
         meetingRecordingSkipped = false
+        calendarSkipped = false
         clearMeetingRecordingPendingState()
     }
 
@@ -159,7 +168,12 @@ public final class OnboardingViewModel {
     /// silent no-ops when flags are off.
     public static var visibleSteps: [Step] {
         Step.allCases.filter { step in
-            AppFeatures.meetingRecordingEnabled || step != .meetingRecording
+            switch step {
+            case .meetingRecording, .calendar:
+                return AppFeatures.meetingRecordingEnabled
+            default:
+                return true
+            }
         }
     }
 
@@ -203,6 +217,8 @@ public final class OnboardingViewModel {
         case .accessibility:
             return accessibilityGranted
         case .meetingRecording:
+            return true
+        case .calendar:
             return true
         case .hotkey:
             return true
@@ -265,6 +281,46 @@ public final class OnboardingViewModel {
         defaults.set(true, forKey: Self.meetingRecordingSkippedKey)
         clearMeetingRecordingPendingState()
         goNext()
+    }
+
+    /// Trigger the EventKit permission prompt. On grant, default the user
+    /// into `.notify` mode so the feature works out of the box. On denial,
+    /// leave the mode as-is (`.off` by default) — the user can opt back in
+    /// from Settings later. We write directly to UserDefaults + post the
+    /// shared notification so a running `MeetingAutoStartCoordinator`
+    /// re-evaluates immediately.
+    public func requestCalendarAccess() {
+        isBusy = true
+        Telemetry.send(.permissionPrompted(permission: .calendar))
+        Task {
+            let service = CalendarService()
+            let granted = await service.requestPermission()
+            await MainActor.run {
+                self.isBusy = false
+                self.calendarPermissionGranted = granted
+                if granted {
+                    Telemetry.send(.permissionGranted(permission: .calendar))
+                    self.applyCalendarMode(.notify)
+                } else {
+                    Telemetry.send(.permissionDenied(permission: .calendar))
+                }
+            }
+        }
+    }
+
+    /// Skip the calendar onboarding step. Persists `.off` mode explicitly so
+    /// the SettingsViewModel default doesn't silently flip back to enabled
+    /// later. Symmetric to `skipMeetingRecordingStep()`.
+    public func skipCalendarStep() {
+        calendarSkipped = true
+        defaults.set(true, forKey: Self.calendarSkippedKey)
+        applyCalendarMode(.off)
+        goNext()
+    }
+
+    private func applyCalendarMode(_ mode: CalendarAutoStartMode) {
+        defaults.set(mode.rawValue, forKey: CalendarAutoStartPreferences.modeKey)
+        NotificationCenter.default.post(name: .macParakeetCalendarSettingsDidChange, object: nil)
     }
 
     public func openScreenRecordingSystemSettings() {

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -274,6 +274,10 @@ public final class SettingsViewModel {
     private let permissionPollingInterval: Duration
     private var isApplyingLaunchAtLoginState = false
     private var permissionPollingTask: Task<Void, Never>?
+    private var calendarSettingsObserver: NSObjectProtocol?
+    /// Re-entrancy guard so `observeCalendarSettings()` doesn't fire `didSet`
+    /// → notification → re-resolve → `didSet` → … on every user toggle.
+    private var isResolvingCalendarSettings = false
     private let logger = Logger(subsystem: "com.macparakeet.viewmodels", category: "SettingsViewModel")
 
     public init(
@@ -322,6 +326,48 @@ public final class SettingsViewModel {
         meetingTriggerFilter = Self.resolveMeetingTriggerFilter(defaults: defaults)
         calendarAutoStopEnabled = defaults.object(forKey: CalendarAutoStartPreferences.autoStopEnabledKey) as? Bool ?? true
         calendarExcludedIdentifiers = Self.resolveCalendarExcludedIdentifiers(defaults: defaults)
+        observeCalendarSettings()
+    }
+
+    /// Onboarding writes calendar settings directly to UserDefaults (it
+    /// doesn't own a `SettingsViewModel`). Without this observer, an open
+    /// Settings window would show stale mode/lead/filter until Settings was
+    /// closed and re-opened. Re-resolving from defaults keeps every UI
+    /// surface that holds a `SettingsViewModel` in sync.
+    private func observeCalendarSettings() {
+        let center = NotificationCenter.default
+        calendarSettingsObserver = center.addObserver(
+            forName: .macParakeetCalendarSettingsDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.reloadCalendarSettings() }
+        }
+    }
+
+    private func reloadCalendarSettings() {
+        // Avoid the `didSet` → post-notification → reload → `didSet` loop:
+        // re-resolving has to skip the `didSet` write-through. The flag
+        // guards the entire batch so partial updates can't fire telemetry
+        // for a value the user didn't actually change.
+        guard !isResolvingCalendarSettings else { return }
+        isResolvingCalendarSettings = true
+        defer { isResolvingCalendarSettings = false }
+
+        let resolvedMode = Self.resolveCalendarAutoStartMode(defaults: defaults)
+        if calendarAutoStartMode != resolvedMode { calendarAutoStartMode = resolvedMode }
+
+        let resolvedMinutes = Self.resolveCalendarReminderMinutes(defaults: defaults)
+        if calendarReminderMinutes != resolvedMinutes { calendarReminderMinutes = resolvedMinutes }
+
+        let resolvedFilter = Self.resolveMeetingTriggerFilter(defaults: defaults)
+        if meetingTriggerFilter != resolvedFilter { meetingTriggerFilter = resolvedFilter }
+
+        let resolvedAutoStop = defaults.object(forKey: CalendarAutoStartPreferences.autoStopEnabledKey) as? Bool ?? true
+        if calendarAutoStopEnabled != resolvedAutoStop { calendarAutoStopEnabled = resolvedAutoStop }
+
+        let resolvedExcluded = Self.resolveCalendarExcludedIdentifiers(defaults: defaults)
+        if calendarExcludedIdentifiers != resolvedExcluded { calendarExcludedIdentifiers = resolvedExcluded }
     }
 
     private static func resolveCalendarAutoStartMode(defaults: UserDefaults) -> CalendarAutoStartMode {
@@ -329,7 +375,14 @@ public final class SettingsViewModel {
               let mode = CalendarAutoStartMode(rawValue: raw) else {
             return .off  // Off by default — opt-in only via onboarding or Settings.
         }
-        return mode
+        // Phase 1 safety net: clamp `.autoStart` down to `.notify`. The
+        // enum + MeetingMonitor are Phase E-ready, but the UI Picker only
+        // exposes `.off`/`.notify`. Without this clamp, a stored `.autoStart`
+        // value (downgrade from a future build, sideloaded plist) would
+        // render the Picker blank *and* let the coordinator try to fire a
+        // countdown that has no toast UI to back it. Remove this when
+        // Phase 2 unclamps the Picker.
+        return mode == .autoStart ? .notify : mode
     }
 
     private static func resolveCalendarReminderMinutes(defaults: UserDefaults) -> Int {

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -465,24 +465,26 @@ public final class SettingsViewModel {
         permissionService?.openScreenRecordingSettings()
     }
 
-    /// Refresh calendar permission from the singleton service. Cheap — no
-    /// network or disk; just reads `EKEventStore.authorizationStatus`. Called
-    /// by `refreshPermissions()` when the permission service is available.
+    /// Refresh calendar permission via the shared service. Cheap — no
+    /// network or disk; just reads `EKEventStore.authorizationStatus` (which
+    /// is `nonisolated` on the actor, so no await needed).
     public func refreshCalendarPermission() {
-        let service = CalendarService()
-        calendarPermissionGranted = service.permissionStatus == .granted
+        calendarPermissionGranted = CalendarService.shared.permissionStatus == .granted
     }
 
     /// Trigger the EventKit permission prompt if not yet decided. Returns the
-    /// granted state. Settings UI calls this from a "Grant Calendar access"
-    /// button; onboarding shares the same code path.
+    /// granted state. On grant, also requests notification authorization so
+    /// the eventual reminder isn't silently dropped by macOS — this single
+    /// async hop pairs the two permissions the feature actually needs.
     @discardableResult
     public func requestCalendarPermission() async -> Bool {
-        let service = CalendarService()
         Telemetry.send(.permissionPrompted(permission: .calendar))
-        let granted = await service.requestPermission()
+        let granted = await CalendarService.shared.requestPermission()
         calendarPermissionGranted = granted
         Telemetry.send(granted ? .permissionGranted(permission: .calendar) : .permissionDenied(permission: .calendar))
+        if granted {
+            await CalendarNotificationAuthorization.requestIfNeeded()
+        }
         return granted
     }
 

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -393,14 +393,7 @@ public final class SettingsViewModel {
               let mode = CalendarAutoStartMode(rawValue: raw) else {
             return .off  // Off by default — opt-in only via onboarding or Settings.
         }
-        // Phase 1 safety net: clamp `.autoStart` down to `.notify`. The
-        // enum + MeetingMonitor are Phase E-ready, but the UI Picker only
-        // exposes `.off`/`.notify`. Without this clamp, a stored `.autoStart`
-        // value (downgrade from a future build, sideloaded plist) would
-        // render the Picker blank *and* let the coordinator try to fire a
-        // countdown that has no toast UI to back it. Remove this when
-        // Phase 2 unclamps the Picker.
-        return mode == .autoStart ? .notify : mode
+        return mode
     }
 
     private static func resolveCalendarReminderMinutes(defaults: UserDefaults) -> Int {

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -193,17 +193,23 @@ public final class SettingsViewModel {
     public var calendarAutoStartMode: CalendarAutoStartMode {
         didSet {
             defaults.set(calendarAutoStartMode.rawValue, forKey: CalendarAutoStartPreferences.modeKey)
+            // Guard ALL side effects (not just the auth prompt). Onboarding
+            // posts the cross-VM notification itself; if we re-post here
+            // during the resulting reload, the observer cycles indefinitely
+            // (the .common-mode Task hop drops the re-entrancy guard before
+            // the observer fires again). The originator already emitted
+            // telemetry — don't double-emit on sync.
+            guard !isResolvingCalendarSettings else { return }
             NotificationCenter.default.post(name: .macParakeetCalendarSettingsDidChange, object: nil)
             Telemetry.send(.settingChanged(setting: .calendarAutoStartMode))
             // Enabling reminders requires notification authorization. The
             // onboarding-grant flow asks for this in tandem with Calendar
             // access, but a user who granted Calendar earlier (or via
-            // System Settings) and *now* flips the mode picker to `.notify`
+            // System Settings) and *now* flips the mode picker to non-`.off`
             // would otherwise hit the silent-drop path: coordinator marks
             // the event reminded, finds notifications unauthorized, returns
-            // without delivering. Skip when re-entering via the settings
-            // observer to avoid prompting on every cross-VM sync.
-            if calendarAutoStartMode != .off && !isResolvingCalendarSettings {
+            // without delivering.
+            if calendarAutoStartMode != .off {
                 Task { await CalendarNotificationAuthorization.requestIfNeeded() }
             }
         }
@@ -211,6 +217,7 @@ public final class SettingsViewModel {
     public var calendarReminderMinutes: Int {
         didSet {
             defaults.set(calendarReminderMinutes, forKey: CalendarAutoStartPreferences.reminderMinutesKey)
+            guard !isResolvingCalendarSettings else { return }
             NotificationCenter.default.post(name: .macParakeetCalendarSettingsDidChange, object: nil)
             Telemetry.send(.settingChanged(setting: .calendarReminderMinutes))
         }
@@ -218,6 +225,7 @@ public final class SettingsViewModel {
     public var meetingTriggerFilter: MeetingTriggerFilter {
         didSet {
             defaults.set(meetingTriggerFilter.rawValue, forKey: CalendarAutoStartPreferences.triggerFilterKey)
+            guard !isResolvingCalendarSettings else { return }
             NotificationCenter.default.post(name: .macParakeetCalendarSettingsDidChange, object: nil)
             Telemetry.send(.settingChanged(setting: .calendarTriggerFilter))
         }
@@ -225,6 +233,7 @@ public final class SettingsViewModel {
     public var calendarAutoStopEnabled: Bool {
         didSet {
             defaults.set(calendarAutoStopEnabled, forKey: CalendarAutoStartPreferences.autoStopEnabledKey)
+            guard !isResolvingCalendarSettings else { return }
             NotificationCenter.default.post(name: .macParakeetCalendarSettingsDidChange, object: nil)
             Telemetry.send(.settingChanged(setting: .calendarAutoStopEnabled))
         }
@@ -232,6 +241,7 @@ public final class SettingsViewModel {
     public var calendarExcludedIdentifiers: Set<String> {
         didSet {
             defaults.set(Array(calendarExcludedIdentifiers), forKey: CalendarAutoStartPreferences.excludedCalendarIdsKey)
+            guard !isResolvingCalendarSettings else { return }
             NotificationCenter.default.post(name: .macParakeetCalendarSettingsDidChange, object: nil)
             Telemetry.send(.settingChanged(setting: .calendarIncludedCalendars))
         }

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import MacParakeetCore
 import OSLog
@@ -181,6 +182,53 @@ public final class SettingsViewModel {
     }
     public var meetingAutoSaveFolderPath: String?
 
+    // Calendar auto-start (ADR-017)
+    //
+    // Each `didSet` writes the value through to `UserDefaults`, fires the
+    // shared `macParakeetCalendarSettingsDidChange` notification (so the
+    // coordinator re-reads its config without waiting for the next poll
+    // tick), and emits a typed telemetry event. Excluded calendar IDs flow
+    // through the same notification — the coordinator's filter changes the
+    // moment a checkbox is toggled.
+    public var calendarAutoStartMode: CalendarAutoStartMode {
+        didSet {
+            defaults.set(calendarAutoStartMode.rawValue, forKey: CalendarAutoStartPreferences.modeKey)
+            NotificationCenter.default.post(name: .macParakeetCalendarSettingsDidChange, object: nil)
+            Telemetry.send(.settingChanged(setting: .calendarAutoStartMode))
+        }
+    }
+    public var calendarReminderMinutes: Int {
+        didSet {
+            defaults.set(calendarReminderMinutes, forKey: CalendarAutoStartPreferences.reminderMinutesKey)
+            NotificationCenter.default.post(name: .macParakeetCalendarSettingsDidChange, object: nil)
+            Telemetry.send(.settingChanged(setting: .calendarReminderMinutes))
+        }
+    }
+    public var meetingTriggerFilter: MeetingTriggerFilter {
+        didSet {
+            defaults.set(meetingTriggerFilter.rawValue, forKey: CalendarAutoStartPreferences.triggerFilterKey)
+            NotificationCenter.default.post(name: .macParakeetCalendarSettingsDidChange, object: nil)
+            Telemetry.send(.settingChanged(setting: .calendarTriggerFilter))
+        }
+    }
+    public var calendarAutoStopEnabled: Bool {
+        didSet {
+            defaults.set(calendarAutoStopEnabled, forKey: CalendarAutoStartPreferences.autoStopEnabledKey)
+            NotificationCenter.default.post(name: .macParakeetCalendarSettingsDidChange, object: nil)
+            Telemetry.send(.settingChanged(setting: .calendarAutoStopEnabled))
+        }
+    }
+    public var calendarExcludedIdentifiers: Set<String> {
+        didSet {
+            defaults.set(Array(calendarExcludedIdentifiers), forKey: CalendarAutoStartPreferences.excludedCalendarIdsKey)
+            NotificationCenter.default.post(name: .macParakeetCalendarSettingsDidChange, object: nil)
+            Telemetry.send(.settingChanged(setting: .calendarIncludedCalendars))
+        }
+    }
+    /// Permission status mirrors `microphoneGranted` etc. — refreshed via
+    /// `refreshCalendarPermission()`.
+    public var calendarPermissionGranted = false
+
     // Permission status
     public var microphoneGranted = false
     public var accessibilityGranted = false
@@ -269,6 +317,41 @@ public final class SettingsViewModel {
         meetingAutoSave = defaults.bool(forKey: AutoSaveScope.meeting.enabledKey)
         meetingAutoSaveFormat = AutoSaveFormat(rawValue: defaults.string(forKey: AutoSaveScope.meeting.formatKey) ?? "md") ?? .md
         meetingAutoSaveFolderPath = Self.resolveAutoSaveFolderPath(defaults: defaults, scope: .meeting)
+        calendarAutoStartMode = Self.resolveCalendarAutoStartMode(defaults: defaults)
+        calendarReminderMinutes = Self.resolveCalendarReminderMinutes(defaults: defaults)
+        meetingTriggerFilter = Self.resolveMeetingTriggerFilter(defaults: defaults)
+        calendarAutoStopEnabled = defaults.object(forKey: CalendarAutoStartPreferences.autoStopEnabledKey) as? Bool ?? true
+        calendarExcludedIdentifiers = Self.resolveCalendarExcludedIdentifiers(defaults: defaults)
+    }
+
+    private static func resolveCalendarAutoStartMode(defaults: UserDefaults) -> CalendarAutoStartMode {
+        guard let raw = defaults.string(forKey: CalendarAutoStartPreferences.modeKey),
+              let mode = CalendarAutoStartMode(rawValue: raw) else {
+            return .off  // Off by default — opt-in only via onboarding or Settings.
+        }
+        return mode
+    }
+
+    private static func resolveCalendarReminderMinutes(defaults: UserDefaults) -> Int {
+        guard defaults.object(forKey: CalendarAutoStartPreferences.reminderMinutesKey) != nil else {
+            return CalendarAutoStartPreferences.defaultReminderMinutes
+        }
+        return defaults.integer(forKey: CalendarAutoStartPreferences.reminderMinutesKey)
+    }
+
+    private static func resolveMeetingTriggerFilter(defaults: UserDefaults) -> MeetingTriggerFilter {
+        guard let raw = defaults.string(forKey: CalendarAutoStartPreferences.triggerFilterKey),
+              let filter = MeetingTriggerFilter(rawValue: raw) else {
+            return .withLink
+        }
+        return filter
+    }
+
+    private static func resolveCalendarExcludedIdentifiers(defaults: UserDefaults) -> Set<String> {
+        guard let raw = defaults.array(forKey: CalendarAutoStartPreferences.excludedCalendarIdsKey) as? [String] else {
+            return []
+        }
+        return Set(raw)
     }
 
     /// Resolve the stored bookmark to a display path.
@@ -367,6 +450,7 @@ public final class SettingsViewModel {
                 accessibilityGranted = accStatus
                 screenRecordingGranted = screenRecordingStatus
             }
+            refreshCalendarPermission()
         }
     }
 
@@ -379,6 +463,31 @@ public final class SettingsViewModel {
 
     public func openScreenRecordingSystemSettings() {
         permissionService?.openScreenRecordingSettings()
+    }
+
+    /// Refresh calendar permission from the singleton service. Cheap — no
+    /// network or disk; just reads `EKEventStore.authorizationStatus`. Called
+    /// by `refreshPermissions()` when the permission service is available.
+    public func refreshCalendarPermission() {
+        let service = CalendarService()
+        calendarPermissionGranted = service.permissionStatus == .granted
+    }
+
+    /// Trigger the EventKit permission prompt if not yet decided. Returns the
+    /// granted state. Settings UI calls this from a "Grant Calendar access"
+    /// button; onboarding shares the same code path.
+    @discardableResult
+    public func requestCalendarPermission() async -> Bool {
+        let service = CalendarService()
+        Telemetry.send(.permissionPrompted(permission: .calendar))
+        let granted = await service.requestPermission()
+        calendarPermissionGranted = granted
+        Telemetry.send(granted ? .permissionGranted(permission: .calendar) : .permissionDenied(permission: .calendar))
+        return granted
+    }
+
+    public func openCalendarSystemSettings() {
+        if NSWorkspace.shared.open(CalendarService.settingsURL) { return }
     }
 
     public func startPermissionPolling() {

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -195,6 +195,17 @@ public final class SettingsViewModel {
             defaults.set(calendarAutoStartMode.rawValue, forKey: CalendarAutoStartPreferences.modeKey)
             NotificationCenter.default.post(name: .macParakeetCalendarSettingsDidChange, object: nil)
             Telemetry.send(.settingChanged(setting: .calendarAutoStartMode))
+            // Enabling reminders requires notification authorization. The
+            // onboarding-grant flow asks for this in tandem with Calendar
+            // access, but a user who granted Calendar earlier (or via
+            // System Settings) and *now* flips the mode picker to `.notify`
+            // would otherwise hit the silent-drop path: coordinator marks
+            // the event reminded, finds notifications unauthorized, returns
+            // without delivering. Skip when re-entering via the settings
+            // observer to avoid prompting on every cross-VM sync.
+            if calendarAutoStartMode != .off && !isResolvingCalendarSettings {
+                Task { await CalendarNotificationAuthorization.requestIfNeeded() }
+            }
         }
     }
     public var calendarReminderMinutes: Int {
@@ -225,9 +236,16 @@ public final class SettingsViewModel {
             Telemetry.send(.settingChanged(setting: .calendarIncludedCalendars))
         }
     }
-    /// Permission status mirrors `microphoneGranted` etc. — refreshed via
-    /// `refreshCalendarPermission()`.
-    public var calendarPermissionGranted = false
+    /// Three-state Calendar permission. Settings UI needs to distinguish
+    /// `.denied` from `.notDetermined` because macOS only shows the
+    /// EventKit prompt once — after denial, the only recovery path is
+    /// System Settings, so the Settings button label has to change too.
+    public var calendarPermissionStatus: CalendarService.PermissionStatus = .notDetermined
+    /// Convenience derived from `calendarPermissionStatus` for callers that
+    /// only care about the granted-or-not boolean (onboarding gating, etc.).
+    public var calendarPermissionGranted: Bool {
+        calendarPermissionStatus == .granted
+    }
 
     // Permission status
     public var microphoneGranted = false
@@ -522,7 +540,7 @@ public final class SettingsViewModel {
     /// network or disk; just reads `EKEventStore.authorizationStatus` (which
     /// is `nonisolated` on the actor, so no await needed).
     public func refreshCalendarPermission() {
-        calendarPermissionGranted = CalendarService.shared.permissionStatus == .granted
+        calendarPermissionStatus = CalendarService.shared.permissionStatus
     }
 
     /// Trigger the EventKit permission prompt if not yet decided. Returns the
@@ -533,7 +551,11 @@ public final class SettingsViewModel {
     public func requestCalendarPermission() async -> Bool {
         Telemetry.send(.permissionPrompted(permission: .calendar))
         let granted = await CalendarService.shared.requestPermission()
-        calendarPermissionGranted = granted
+        // Re-read the status (rather than just assigning .granted/.denied
+        // from the bool) so `.restricted` from MDM-managed Macs is reflected
+        // accurately — the service maps it to `.denied` so callers don't
+        // need a fourth case, but a fresh read is the source of truth.
+        calendarPermissionStatus = CalendarService.shared.permissionStatus
         Telemetry.send(granted ? .permissionGranted(permission: .calendar) : .permissionDenied(permission: .calendar))
         if granted {
             await CalendarNotificationAuthorization.requestIfNeeded()

--- a/Tests/MacParakeetTests/Calendar/MeetingAutoStartCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/Calendar/MeetingAutoStartCoordinatorTests.swift
@@ -1,0 +1,247 @@
+import XCTest
+@testable import MacParakeet
+@testable import MacParakeetCore
+@testable import MacParakeetViewModels
+
+@MainActor
+final class MeetingAutoStartCoordinatorTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private var defaults: UserDefaults!
+    private var settingsViewModel: SettingsViewModel!
+    private var calendarService: MockCalendarService!
+
+    /// Tracks calls to the recording-flow callbacks the coordinator makes.
+    private var recordingActiveStub = false
+    private var autoStartConfirmedCount = 0
+    private var autoStopConfirmedCount = 0
+
+    override func setUp() {
+        super.setUp()
+        let suite = "com.macparakeet.tests.coordinator.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        // Tests seed defaults before constructing SettingsViewModel via
+        // `seedSettings(...)` so VM init reads the right values without
+        // firing `didSet` (which under `.notify`/`.autoStart` would call
+        // `UNUserNotificationCenter.current()` — that API crashes in the
+        // xctest bundle since there's no host app's notification center).
+        calendarService = MockCalendarService()
+        recordingActiveStub = false
+        autoStartConfirmedCount = 0
+        autoStopConfirmedCount = 0
+    }
+
+    /// Seed `UserDefaults` *before* the SettingsViewModel is constructed
+    /// so init reads the values rather than each property running its
+    /// `didSet` side-effects (which include notification-auth requests
+    /// that crash in the test bundle).
+    private func seedSettings(
+        mode: CalendarAutoStartMode = .off,
+        reminderMinutes: Int = 5,
+        triggerFilter: MeetingTriggerFilter = .withLink,
+        autoStopEnabled: Bool = true
+    ) {
+        defaults.set(mode.rawValue, forKey: CalendarAutoStartPreferences.modeKey)
+        defaults.set(reminderMinutes, forKey: CalendarAutoStartPreferences.reminderMinutesKey)
+        defaults.set(triggerFilter.rawValue, forKey: CalendarAutoStartPreferences.triggerFilterKey)
+        defaults.set(autoStopEnabled, forKey: CalendarAutoStartPreferences.autoStopEnabledKey)
+        settingsViewModel = SettingsViewModel(defaults: defaults)
+    }
+
+    override func tearDown() {
+        defaults = nil
+        settingsViewModel = nil
+        calendarService = nil
+        super.tearDown()
+    }
+
+    private func makeCoordinator(
+        toastController: MeetingCountdownToastController? = nil
+    ) -> MeetingAutoStartCoordinator {
+        MeetingAutoStartCoordinator(
+            calendarService: calendarService,
+            settingsViewModel: settingsViewModel,
+            isRecordingActive: { [weak self] in self?.recordingActiveStub ?? false },
+            onAutoStartConfirmed: { [weak self] in self?.autoStartConfirmedCount += 1 },
+            onAutoStopConfirmed: { [weak self] in self?.autoStopConfirmedCount += 1 },
+            toastController: toastController
+        )
+    }
+
+    private func event(
+        id: String = "evt-1",
+        title: String = "Standup",
+        startsIn seconds: TimeInterval = 5 * 60,
+        durationMinutes: Int = 30,
+        meetUrl: String? = "https://zoom.us/j/123"
+    ) -> CalendarEvent {
+        let now = Date()
+        let start = now.addingTimeInterval(seconds)
+        let end = start.addingTimeInterval(TimeInterval(durationMinutes * 60))
+        return CalendarEvent(
+            id: id,
+            title: title,
+            startTime: start,
+            endTime: end,
+            meetUrl: meetUrl,
+            participants: [EventParticipant(email: "alice@example.com")],
+            calendarIdentifier: "cal-1",
+            userStatus: .accepted
+        )
+    }
+
+    /// Wait for an actor / Task hop to settle. Coordinator polls inside
+    /// `Task { await pollAsync() }` from observer + start, so a single
+    /// `Task.yield()` isn't enough — give the runloop a tick.
+    private func waitForPoll() async {
+        for _ in 0..<5 {
+            await Task.yield()
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+    }
+
+    // MARK: - Lifecycle
+
+    func testStopIsIdempotentAndDoesNotCrashIfNotStarted() {
+        seedSettings(mode: .off)
+        let coordinator = makeCoordinator()
+        coordinator.stop()  // never started
+        coordinator.stop()  // double-stop after initial
+    }
+
+    func testSettingsChangeNotificationTriggersImmediateRePoll() async {
+        calendarService.stubPermissionStatus = .granted
+        calendarService.stubEvents = [event(startsIn: 5 * 60)]
+        seedSettings(mode: .notify, reminderMinutes: 5)
+
+        let coordinator = makeCoordinator()
+        coordinator.start()
+        await waitForPoll()
+        let baseline = calendarService.fetchUpcomingEventsCallCount
+
+        // Posting the notification should cause an extra fetch beyond the
+        // start-time poll.
+        NotificationCenter.default.post(
+            name: .macParakeetCalendarSettingsDidChange,
+            object: nil
+        )
+        await waitForPoll()
+        XCTAssertGreaterThan(calendarService.fetchUpcomingEventsCallCount, baseline)
+
+        coordinator.stop()
+    }
+
+    func testOffModeShortCircuitsBeforeFetch() async {
+        calendarService.stubPermissionStatus = .granted
+        seedSettings(mode: .off)
+
+        let coordinator = makeCoordinator()
+        coordinator.start()
+        await waitForPoll()
+
+        XCTAssertEqual(calendarService.fetchUpcomingEventsCallCount, 0,
+                       "Off mode must not touch the calendar service")
+
+        coordinator.stop()
+    }
+
+    func testMissingPermissionShortCircuitsBeforeFetch() async {
+        calendarService.stubPermissionStatus = .denied
+        seedSettings(mode: .notify)
+
+        let coordinator = makeCoordinator()
+        coordinator.start()
+        await waitForPoll()
+
+        XCTAssertEqual(calendarService.fetchUpcomingEventsCallCount, 0,
+                       "Denied permission must not attempt a fetch")
+
+        coordinator.stop()
+    }
+
+    // MARK: - Auto-start outcome routing
+
+    func testAutoStartCompletedTriggersRecording() async {
+        calendarService.stubPermissionStatus = .granted
+        seedSettings(mode: .autoStart)
+
+        let toast = MeetingCountdownToastController()
+        let coordinator = makeCoordinator(toastController: toast)
+        coordinator.start()
+        await waitForPoll()
+
+        // Skip the actual countdown — manually invoke the test surface
+        // that the coordinator wires. The countdown UX is covered by
+        // toast-controller tests; here we're testing the coordinator's
+        // outcome plumbing.
+        coordinator.testHook_simulateAutoStartConfirmed(eventId: "evt-1")
+        XCTAssertEqual(autoStartConfirmedCount, 1,
+                       "Recording start callback must fire on .completed outcome")
+
+        coordinator.stop()
+    }
+
+    func testAutoStartUserCancelDoesNotTriggerRecording() async {
+        calendarService.stubPermissionStatus = .granted
+        seedSettings(mode: .autoStart)
+
+        let coordinator = makeCoordinator()
+        coordinator.start()
+        await waitForPoll()
+
+        coordinator.testHook_simulateAutoStartCancelled(eventId: "evt-1")
+        XCTAssertEqual(autoStartConfirmedCount, 0)
+
+        coordinator.stop()
+    }
+
+    // MARK: - Auto-stop binding
+
+    func testAutoStopOnlyFiresForCoordinatorOwnedRecording() async {
+        // Manually-started recording during a calendar event should NOT
+        // trigger the auto-stop toast even if the event is in the auto-stop
+        // window. The coordinator's `autoStartedEventId` binding is empty,
+        // so MeetingMonitor's `.autoStopDue` no-ops in the handler.
+        calendarService.stubPermissionStatus = .granted
+        seedSettings(mode: .autoStart)
+        recordingActiveStub = true
+
+        let coordinator = makeCoordinator()
+        coordinator.start()
+        await waitForPoll()
+
+        coordinator.testHook_simulateAutoStopFired(eventId: "evt-not-bound")
+        XCTAssertEqual(autoStopConfirmedCount, 0,
+                       "Manual recordings must not be auto-stopped")
+
+        coordinator.stop()
+    }
+
+    func testManualStopOfAutoStartedRecordingClearsBinding() async {
+        calendarService.stubPermissionStatus = .granted
+        seedSettings(mode: .autoStart)
+
+        let coordinator = makeCoordinator()
+        coordinator.start()
+        await waitForPoll()
+
+        // Simulate auto-start: recording becomes active, binding set.
+        coordinator.testHook_simulateAutoStartConfirmed(eventId: "evt-1")
+        recordingActiveStub = true
+        XCTAssertEqual(coordinator.testHook_autoStartedEventId, "evt-1")
+
+        // User manually stops the recording mid-meeting.
+        recordingActiveStub = false
+        // Force a fresh poll so the coordinator notices and clears the
+        // binding (this is the path that prevents a phantom auto-stop).
+        calendarService.stubEvents = []
+        coordinator.testHook_forcePoll()
+        await waitForPoll()
+        XCTAssertNil(coordinator.testHook_autoStartedEventId,
+                     "Binding must clear when recording stops outside coordinator's control")
+
+        coordinator.stop()
+    }
+}

--- a/Tests/MacParakeetTests/Calendar/MeetingLinkParserTests.swift
+++ b/Tests/MacParakeetTests/Calendar/MeetingLinkParserTests.swift
@@ -1,0 +1,127 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class MeetingLinkParserTests: XCTestCase {
+    let parser = MeetingLinkParser()
+
+    // MARK: - Single-field extraction
+
+    func testExtractsZoomFromText() {
+        let text = "Join: https://zoom.us/j/1234567890"
+        XCTAssertEqual(parser.extractMeetingUrl(from: text), "https://zoom.us/j/1234567890")
+    }
+
+    func testExtractsZoomWithSubdomain() {
+        let text = "https://acme.zoom.us/j/9876?pwd=abc"
+        XCTAssertEqual(parser.extractMeetingUrl(from: text), "https://acme.zoom.us/j/9876?pwd=abc")
+    }
+
+    func testExtractsGoogleMeet() {
+        let text = "Meet me at https://meet.google.com/abc-defg-hij"
+        XCTAssertEqual(parser.extractMeetingUrl(from: text), "https://meet.google.com/abc-defg-hij")
+    }
+
+    func testExtractsTeams() {
+        let text = "Teams: https://teams.microsoft.com/l/meetup-join/19%3aabc"
+        XCTAssertEqual(parser.extractMeetingUrl(from: text), "https://teams.microsoft.com/l/meetup-join/19%3aabc")
+    }
+
+    func testExtractsWebex() {
+        let text = "https://acme.webex.com/meet/jane"
+        XCTAssertEqual(parser.extractMeetingUrl(from: text), "https://acme.webex.com/meet/jane")
+    }
+
+    func testExtractsAround() {
+        let text = "https://around.co/r/standup"
+        XCTAssertEqual(parser.extractMeetingUrl(from: text), "https://around.co/r/standup")
+    }
+
+    func testGenericFallbackForUnknownProvider() {
+        let text = "Use https://example.com/meet/room-1 to join"
+        XCTAssertEqual(parser.extractMeetingUrl(from: text), "https://example.com/meet/room-1")
+    }
+
+    func testReturnsNilForPlainText() {
+        XCTAssertNil(parser.extractMeetingUrl(from: "Just a calendar block, no link"))
+    }
+
+    func testReturnsNilForEmpty() {
+        XCTAssertNil(parser.extractMeetingUrl(from: ""))
+        XCTAssertNil(parser.extractMeetingUrl(from: nil))
+    }
+
+    // MARK: - Priority order (Zoom wins over generic)
+
+    func testZoomBeatsGenericInSameText() {
+        let text = "Old: https://example.com/conference/oldroom Join: https://zoom.us/j/12345"
+        // Zoom should be preferred even though generic also matches
+        XCTAssertEqual(parser.extractMeetingUrl(from: text), "https://zoom.us/j/12345")
+    }
+
+    // MARK: - Multi-field overload
+
+    func testUrlFieldWinsWhenItIsAMeetingUrl() {
+        let result = parser.extractMeetingUrl(
+            location: "Zoom: https://zoom.us/j/2",
+            notes: "Notes here",
+            url: "https://zoom.us/j/1"
+        )
+        XCTAssertEqual(result, "https://zoom.us/j/1")
+    }
+
+    func testFallsBackToLocationWhenUrlFieldMissing() {
+        let result = parser.extractMeetingUrl(
+            location: "Zoom: https://zoom.us/j/2",
+            notes: nil,
+            url: nil
+        )
+        XCTAssertEqual(result, "https://zoom.us/j/2")
+    }
+
+    func testFallsBackToNotesWhenLocationMissing() {
+        let result = parser.extractMeetingUrl(
+            location: nil,
+            notes: "Join: https://meet.google.com/xyz-abc-def",
+            url: nil
+        )
+        XCTAssertEqual(result, "https://meet.google.com/xyz-abc-def")
+    }
+
+    func testIgnoresNonMeetingUrlField() {
+        let result = parser.extractMeetingUrl(
+            location: "Zoom: https://zoom.us/j/2",
+            notes: nil,
+            url: "https://google.com"  // not a meeting URL
+        )
+        XCTAssertEqual(result, "https://zoom.us/j/2")
+    }
+
+    func testReturnsNilWhenNoFieldsHaveLink() {
+        XCTAssertNil(parser.extractMeetingUrl(location: "Office", notes: "Bring laptop", url: nil))
+    }
+
+    // MARK: - isMeetingUrl
+
+    func testIsMeetingUrlPositive() {
+        XCTAssertTrue(parser.isMeetingUrl("https://zoom.us/j/1"))
+        XCTAssertTrue(parser.isMeetingUrl("https://meet.google.com/abc"))
+    }
+
+    func testIsMeetingUrlNegative() {
+        XCTAssertFalse(parser.isMeetingUrl("https://google.com"))
+        XCTAssertFalse(parser.isMeetingUrl(nil))
+        XCTAssertFalse(parser.isMeetingUrl(""))
+    }
+
+    // MARK: - identifyService
+
+    func testIdentifyService() {
+        XCTAssertEqual(parser.identifyService(from: "https://zoom.us/j/1"), "Zoom")
+        XCTAssertEqual(parser.identifyService(from: "https://meet.google.com/abc"), "Google Meet")
+        XCTAssertEqual(parser.identifyService(from: "https://teams.microsoft.com/x"), "Microsoft Teams")
+        XCTAssertEqual(parser.identifyService(from: "https://acme.webex.com/x"), "Webex")
+        XCTAssertEqual(parser.identifyService(from: "https://around.co/r/x"), "Around")
+        XCTAssertNil(parser.identifyService(from: "https://example.com"))
+        XCTAssertNil(parser.identifyService(from: nil))
+    }
+}

--- a/Tests/MacParakeetTests/Calendar/MeetingMonitorTests.swift
+++ b/Tests/MacParakeetTests/Calendar/MeetingMonitorTests.swift
@@ -73,9 +73,11 @@ final class MeetingMonitorTests: XCTestCase {
         XCTAssertTrue(result.isEmpty)
     }
 
-    func testNotifyModeFiresReminderButNotAutoStart() {
+    func testNotifyModeWithReminderMinutesZeroProducesNothing() {
         let now = Date()
-        // T-0: in both reminder window and auto-start window
+        // reminderMinutes=0 disables reminders entirely; .notify mode also
+        // gates `.autoStartDue`/`.lateJoinAvailable` off — so there is
+        // nothing to emit even though the event is at T-0.
         let evt = event(startsIn: 0, from: now)
         let result = MeetingMonitor.evaluate(
             events: [evt],
@@ -86,8 +88,31 @@ final class MeetingMonitorTests: XCTestCase {
             remindedEventIds: [],
             countdownShownEventIds: []
         )
-        // reminderMinutes=0 disables reminder; autoStart is gated off in .notify mode
         XCTAssertTrue(result.isEmpty)
+    }
+
+    func testNotifyModeFiresReminderButNotAutoStart() {
+        let now = Date()
+        // Event starts in 5 min — exactly the reminder time. .notify mode
+        // should emit `.reminderDue` and *not* `.autoStartDue` (which is
+        // gated off in this mode regardless of timing window).
+        let evt = event(startsIn: 5 * 60, from: now)
+        let result = MeetingMonitor.evaluate(
+            events: [evt],
+            now: now,
+            config: config(mode: .notify, reminderMinutes: 5),
+            activeRecording: false,
+            dismissedEventIds: [],
+            remindedEventIds: [],
+            countdownShownEventIds: []
+        )
+        XCTAssertEqual(result.count, 1)
+        if case .reminderDue(let e) = result[0] {
+            XCTAssertEqual(e.id, "evt-1")
+        } else {
+            XCTFail("Expected .reminderDue, got \(result[0])")
+        }
+        XCTAssertFalse(result.contains { if case .autoStartDue = $0 { return true } else { return false } })
     }
 
     func testAutoStartModeFiresAutoStartWhenAtTime() {
@@ -390,10 +415,9 @@ final class MeetingMonitorTests: XCTestCase {
 
     func testAutoStopFiresInLastSecondsOfMeeting() {
         let now = Date()
-        // Event ends in 20s and we're recording → inside [endTime - 30s, endTime]
-        let evt = event(startsIn: -25 * 60, from: now, durationMinutes: 25)  // ends 25s after now
-        // Actually we need ends ~20s in the future:
-        let evt2 = CalendarEvent(
+        // Event ends 20s after `now` (started 25 min ago, runs for 25 min) →
+        // inside the [endTime - 30s, endTime] auto-stop window.
+        let evt = CalendarEvent(
             id: "ending",
             title: "Wrap",
             startTime: now.addingTimeInterval(-1500),
@@ -402,9 +426,8 @@ final class MeetingMonitorTests: XCTestCase {
             participants: [EventParticipant(email: "x@y")],
             userStatus: .accepted
         )
-        _ = evt
         let result = MeetingMonitor.evaluate(
-            events: [evt2],
+            events: [evt],
             now: now,
             config: config(mode: .autoStart, autoStopEnabled: true),
             activeRecording: true,

--- a/Tests/MacParakeetTests/Calendar/MeetingMonitorTests.swift
+++ b/Tests/MacParakeetTests/Calendar/MeetingMonitorTests.swift
@@ -1,0 +1,458 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class MeetingMonitorTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func event(
+        id: String = "evt-1",
+        title: String = "Standup",
+        startsIn seconds: TimeInterval = 0,
+        from referenceDate: Date,
+        durationMinutes: Int = 30,
+        meetUrl: String? = "https://zoom.us/j/123",
+        participants: [EventParticipant] = [EventParticipant(email: "alice@example.com")],
+        userStatus: EventParticipant.ParticipantStatus? = .accepted,
+        isAllDay: Bool = false
+    ) -> CalendarEvent {
+        let start = referenceDate.addingTimeInterval(seconds)
+        let end = start.addingTimeInterval(TimeInterval(durationMinutes * 60))
+        return CalendarEvent(
+            id: id,
+            title: title,
+            startTime: start,
+            endTime: end,
+            meetUrl: meetUrl,
+            participants: participants,
+            isAllDay: isAllDay,
+            userStatus: userStatus
+        )
+    }
+
+    private func config(
+        mode: CalendarAutoStartMode = .notify,
+        reminderMinutes: Int = 5,
+        triggerFilter: MeetingTriggerFilter = .withLink,
+        autoStopEnabled: Bool = true
+    ) -> MeetingMonitor.Config {
+        MeetingMonitor.Config(
+            mode: mode,
+            reminderMinutes: reminderMinutes,
+            countdownSeconds: 5,
+            autoStopEnabled: autoStopEnabled,
+            autoStopLeadSeconds: 30,
+            triggerFilter: triggerFilter,
+            lateJoinGraceMinutes: 10
+        )
+    }
+
+    private func extractIds(_ events: [MeetingMonitor.MonitorEvent]) -> [String] {
+        events.map {
+            switch $0 {
+            case .reminderDue(let e), .autoStartDue(let e), .lateJoinAvailable(let e), .autoStopDue(let e):
+                return e.id
+            }
+        }
+    }
+
+    // MARK: - Mode gating
+
+    func testOffModeProducesNoEvents() {
+        let now = Date()
+        let evt = event(startsIn: -5 * 60, from: now)  // exactly at reminder time
+        let result = MeetingMonitor.evaluate(
+            events: [evt],
+            now: now,
+            config: config(mode: .off),
+            activeRecording: false,
+            dismissedEventIds: [],
+            remindedEventIds: [],
+            countdownShownEventIds: []
+        )
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testNotifyModeFiresReminderButNotAutoStart() {
+        let now = Date()
+        // T-0: in both reminder window and auto-start window
+        let evt = event(startsIn: 0, from: now)
+        let result = MeetingMonitor.evaluate(
+            events: [evt],
+            now: now,
+            config: config(mode: .notify, reminderMinutes: 0),
+            activeRecording: false,
+            dismissedEventIds: [],
+            remindedEventIds: [],
+            countdownShownEventIds: []
+        )
+        // reminderMinutes=0 disables reminder; autoStart is gated off in .notify mode
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testAutoStartModeFiresAutoStartWhenAtTime() {
+        let now = Date()
+        let evt = event(startsIn: 0, from: now)
+        let result = MeetingMonitor.evaluate(
+            events: [evt],
+            now: now,
+            config: config(mode: .autoStart, reminderMinutes: 0),
+            activeRecording: false,
+            dismissedEventIds: [],
+            remindedEventIds: [],
+            countdownShownEventIds: []
+        )
+        XCTAssertEqual(result.count, 1)
+        if case .autoStartDue(let e) = result[0] {
+            XCTAssertEqual(e.id, "evt-1")
+        } else {
+            XCTFail("Expected .autoStartDue, got \(result[0])")
+        }
+    }
+
+    // MARK: - Reminder window
+
+    func testReminderFiresExactlyAtTMinusReminderMinutes() {
+        let now = Date()
+        let evt = event(startsIn: 5 * 60, from: now)  // T-5min
+        let result = MeetingMonitor.evaluate(
+            events: [evt],
+            now: now,
+            config: config(reminderMinutes: 5),
+            activeRecording: false,
+            dismissedEventIds: [],
+            remindedEventIds: [],
+            countdownShownEventIds: []
+        )
+        XCTAssertEqual(extractIds(result), ["evt-1"])
+        if case .reminderDue = result[0] {} else { XCTFail("Expected .reminderDue") }
+    }
+
+    func testReminderHasNinetySecondForgivenessWindow() {
+        let now = Date()
+        // Event starts in 5 min - 89s; we're 89s past the ideal reminder time
+        let evt = event(startsIn: 5 * 60 - 89, from: now)
+        let result = MeetingMonitor.evaluate(
+            events: [evt],
+            now: now,
+            config: config(reminderMinutes: 5),
+            activeRecording: false,
+            dismissedEventIds: [],
+            remindedEventIds: [],
+            countdownShownEventIds: []
+        )
+        XCTAssertEqual(extractIds(result), ["evt-1"], "Slow polls within 90s should still fire reminder")
+    }
+
+    func testReminderDoesNotFirePast90SecondWindow() {
+        let now = Date()
+        let evt = event(startsIn: 5 * 60 - 91, from: now)  // 91s past
+        let result = MeetingMonitor.evaluate(
+            events: [evt],
+            now: now,
+            config: config(reminderMinutes: 5),
+            activeRecording: false,
+            dismissedEventIds: [],
+            remindedEventIds: [],
+            countdownShownEventIds: []
+        )
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testReminderSuppressedWhenAlreadyReminded() {
+        let now = Date()
+        let evt = event(startsIn: 5 * 60, from: now)
+        let result = MeetingMonitor.evaluate(
+            events: [evt],
+            now: now,
+            config: config(reminderMinutes: 5),
+            activeRecording: false,
+            dismissedEventIds: [],
+            remindedEventIds: ["evt-1"],
+            countdownShownEventIds: []
+        )
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testReminderMinutesZeroDisablesReminder() {
+        let now = Date()
+        let evt = event(startsIn: 5 * 60, from: now)
+        let result = MeetingMonitor.evaluate(
+            events: [evt],
+            now: now,
+            config: config(reminderMinutes: 0),
+            activeRecording: false,
+            dismissedEventIds: [],
+            remindedEventIds: [],
+            countdownShownEventIds: []
+        )
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - Trigger filter
+
+    func testWithLinkFilterRejectsEventsWithoutMeetUrl() {
+        let now = Date()
+        let evt = event(startsIn: 5 * 60, from: now, meetUrl: nil)
+        let result = MeetingMonitor.evaluate(
+            events: [evt],
+            now: now,
+            config: config(triggerFilter: .withLink),
+            activeRecording: false,
+            dismissedEventIds: [],
+            remindedEventIds: [],
+            countdownShownEventIds: []
+        )
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testWithParticipantsFilterAcceptsAtLeastOneOther() {
+        let now = Date()
+        let evt = event(
+            startsIn: 5 * 60,
+            from: now,
+            meetUrl: nil,
+            participants: [EventParticipant(email: "alice@example.com")]
+        )
+        let result = MeetingMonitor.evaluate(
+            events: [evt],
+            now: now,
+            config: config(triggerFilter: .withParticipants),
+            activeRecording: false,
+            dismissedEventIds: [],
+            remindedEventIds: [],
+            countdownShownEventIds: []
+        )
+        XCTAssertEqual(extractIds(result), ["evt-1"])
+    }
+
+    func testWithParticipantsFilterRejectsSoloEvents() {
+        let now = Date()
+        let evt = event(startsIn: 5 * 60, from: now, meetUrl: nil, participants: [])
+        let result = MeetingMonitor.evaluate(
+            events: [evt],
+            now: now,
+            config: config(triggerFilter: .withParticipants),
+            activeRecording: false,
+            dismissedEventIds: [],
+            remindedEventIds: [],
+            countdownShownEventIds: []
+        )
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testAllEventsFilterAcceptsBareEvent() {
+        let now = Date()
+        let evt = event(startsIn: 5 * 60, from: now, meetUrl: nil, participants: [])
+        let result = MeetingMonitor.evaluate(
+            events: [evt],
+            now: now,
+            config: config(triggerFilter: .allEvents),
+            activeRecording: false,
+            dismissedEventIds: [],
+            remindedEventIds: [],
+            countdownShownEventIds: []
+        )
+        XCTAssertEqual(extractIds(result), ["evt-1"])
+    }
+
+    // MARK: - Universal filters (always applied regardless of trigger)
+
+    func testAllDayEventsAreAlwaysSkipped() {
+        let now = Date()
+        let evt = event(startsIn: 5 * 60, from: now, isAllDay: true)
+        let result = MeetingMonitor.evaluate(
+            events: [evt],
+            now: now,
+            config: config(triggerFilter: .allEvents),
+            activeRecording: false,
+            dismissedEventIds: [],
+            remindedEventIds: [],
+            countdownShownEventIds: []
+        )
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testDeclinedEventsAreSkipped() {
+        let now = Date()
+        let evt = event(startsIn: 5 * 60, from: now, userStatus: .declined)
+        let result = MeetingMonitor.evaluate(
+            events: [evt],
+            now: now,
+            config: config(),
+            activeRecording: false,
+            dismissedEventIds: [],
+            remindedEventIds: [],
+            countdownShownEventIds: []
+        )
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testDismissedEventsAreSkipped() {
+        let now = Date()
+        let evt = event(startsIn: 5 * 60, from: now)
+        let result = MeetingMonitor.evaluate(
+            events: [evt],
+            now: now,
+            config: config(),
+            activeRecording: false,
+            dismissedEventIds: ["evt-1"],
+            remindedEventIds: [],
+            countdownShownEventIds: []
+        )
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - Auto-start window (.autoStart mode)
+
+    func testAutoStartFiresInWindowMinusFiveSeconds() {
+        let now = Date()
+        let evt = event(startsIn: 5, from: now)  // 5s away — inside [-5s, +30s]
+        let result = MeetingMonitor.evaluate(
+            events: [evt],
+            now: now,
+            config: config(mode: .autoStart, reminderMinutes: 0),
+            activeRecording: false,
+            dismissedEventIds: [],
+            remindedEventIds: [],
+            countdownShownEventIds: []
+        )
+        if case .autoStartDue = result.first {} else {
+            XCTFail("Expected .autoStartDue inside [-5s, +30s] window, got \(result)")
+        }
+    }
+
+    func testAutoStartDoesNotFireWhenAlreadyRecording() {
+        let now = Date()
+        let evt = event(startsIn: 0, from: now)
+        let result = MeetingMonitor.evaluate(
+            events: [evt],
+            now: now,
+            config: config(mode: .autoStart, reminderMinutes: 0),
+            activeRecording: true,
+            dismissedEventIds: [],
+            remindedEventIds: [],
+            countdownShownEventIds: []
+        )
+        XCTAssertFalse(result.contains { if case .autoStartDue = $0 { return true } else { return false } })
+    }
+
+    func testAutoStartSuppressedByCountdownShownIds() {
+        let now = Date()
+        let evt = event(startsIn: 0, from: now)
+        let result = MeetingMonitor.evaluate(
+            events: [evt],
+            now: now,
+            config: config(mode: .autoStart, reminderMinutes: 0),
+            activeRecording: false,
+            dismissedEventIds: [],
+            remindedEventIds: [],
+            countdownShownEventIds: ["evt-1"]
+        )
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - Late join
+
+    func testLateJoinFiresAfter30sUntilGracePeriod() {
+        let now = Date()
+        // Event started 2 minutes ago — well inside [+30s, +10min] late-join window
+        let evt = event(startsIn: -120, from: now)
+        let result = MeetingMonitor.evaluate(
+            events: [evt],
+            now: now,
+            config: config(mode: .autoStart, reminderMinutes: 0),
+            activeRecording: false,
+            dismissedEventIds: [],
+            remindedEventIds: [],
+            countdownShownEventIds: []
+        )
+        XCTAssertTrue(result.contains { if case .lateJoinAvailable = $0 { return true } else { return false } })
+    }
+
+    func testLateJoinDoesNotFireBeyondGracePeriod() {
+        let now = Date()
+        // Event started 11 minutes ago — beyond the default 10-minute grace
+        let evt = event(startsIn: -11 * 60, from: now)
+        let result = MeetingMonitor.evaluate(
+            events: [evt],
+            now: now,
+            config: config(mode: .autoStart, reminderMinutes: 0),
+            activeRecording: false,
+            dismissedEventIds: [],
+            remindedEventIds: [],
+            countdownShownEventIds: []
+        )
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - Auto-stop
+
+    func testAutoStopFiresInLastSecondsOfMeeting() {
+        let now = Date()
+        // Event ends in 20s and we're recording → inside [endTime - 30s, endTime]
+        let evt = event(startsIn: -25 * 60, from: now, durationMinutes: 25)  // ends 25s after now
+        // Actually we need ends ~20s in the future:
+        let evt2 = CalendarEvent(
+            id: "ending",
+            title: "Wrap",
+            startTime: now.addingTimeInterval(-1500),
+            endTime: now.addingTimeInterval(20),
+            meetUrl: "https://zoom.us/j/1",
+            participants: [EventParticipant(email: "x@y")],
+            userStatus: .accepted
+        )
+        _ = evt
+        let result = MeetingMonitor.evaluate(
+            events: [evt2],
+            now: now,
+            config: config(mode: .autoStart, autoStopEnabled: true),
+            activeRecording: true,
+            dismissedEventIds: [],
+            remindedEventIds: [],
+            countdownShownEventIds: []
+        )
+        XCTAssertTrue(result.contains { if case .autoStopDue = $0 { return true } else { return false } })
+    }
+
+    func testAutoStopDoesNotFireWhenNotRecording() {
+        let now = Date()
+        let evt = CalendarEvent(
+            id: "ending",
+            title: "Wrap",
+            startTime: now.addingTimeInterval(-1500),
+            endTime: now.addingTimeInterval(20),
+            meetUrl: "https://zoom.us/j/1",
+            participants: [EventParticipant(email: "x@y")],
+            userStatus: .accepted
+        )
+        let result = MeetingMonitor.evaluate(
+            events: [evt],
+            now: now,
+            config: config(mode: .autoStart),
+            activeRecording: false,
+            dismissedEventIds: [],
+            remindedEventIds: [],
+            countdownShownEventIds: []
+        )
+        XCTAssertFalse(result.contains { if case .autoStopDue = $0 { return true } else { return false } })
+    }
+
+    // MARK: - Multiple events
+
+    func testHandlesMultipleEventsIndependently() {
+        let now = Date()
+        let upcoming = event(id: "upcoming", startsIn: 5 * 60, from: now)
+        let dismissed = event(id: "dismissed", startsIn: 5 * 60, from: now)
+        let result = MeetingMonitor.evaluate(
+            events: [upcoming, dismissed],
+            now: now,
+            config: config(),
+            activeRecording: false,
+            dismissedEventIds: ["dismissed"],
+            remindedEventIds: [],
+            countdownShownEventIds: []
+        )
+        XCTAssertEqual(extractIds(result), ["upcoming"])
+    }
+}

--- a/Tests/MacParakeetTests/Calendar/MockCalendarService.swift
+++ b/Tests/MacParakeetTests/Calendar/MockCalendarService.swift
@@ -1,5 +1,5 @@
 import Foundation
-@testable import MacParakeetCore
+import MacParakeetCore
 
 /// In-memory `CalendarServicing` for coordinator + ViewModel tests. Lets
 /// callers control the permission status (so tests can simulate

--- a/Tests/MacParakeetTests/Calendar/MockCalendarService.swift
+++ b/Tests/MacParakeetTests/Calendar/MockCalendarService.swift
@@ -1,0 +1,51 @@
+import Foundation
+@testable import MacParakeetCore
+
+/// In-memory `CalendarServicing` for coordinator + ViewModel tests. Lets
+/// callers control the permission status (so tests can simulate
+/// `.notDetermined` → grant flows), preset the events returned by
+/// `fetchUpcomingEvents`, and observe how many fetches actually happened
+/// (so polling-cadence tests can assert "exactly N fetches in this window").
+///
+/// `final class` not actor: tests run synchronously and need to inspect
+/// state immediately after a poll completes. The `nonisolated(unsafe)`
+/// storage is fine because XCTest tests run their assertions on a single
+/// thread.
+final class MockCalendarService: CalendarServicing, @unchecked Sendable {
+    nonisolated(unsafe) var stubPermissionStatus: CalendarService.PermissionStatus = .notDetermined
+    nonisolated(unsafe) var requestPermissionResult: Bool = true
+    nonisolated(unsafe) var stubCalendars: [CalendarInfo] = []
+    nonisolated(unsafe) var stubEvents: [CalendarEvent] = []
+    nonisolated(unsafe) var stubFetchError: Error?
+
+    nonisolated(unsafe) private(set) var requestPermissionCallCount = 0
+    nonisolated(unsafe) private(set) var fetchUpcomingEventsCallCount = 0
+    nonisolated(unsafe) private(set) var availableCalendarsCallCount = 0
+
+    nonisolated var permissionStatus: CalendarService.PermissionStatus {
+        stubPermissionStatus
+    }
+
+    func requestPermission() async -> Bool {
+        requestPermissionCallCount += 1
+        if requestPermissionResult {
+            stubPermissionStatus = .granted
+        } else {
+            stubPermissionStatus = .denied
+        }
+        return requestPermissionResult
+    }
+
+    func availableCalendars() async -> [CalendarInfo] {
+        availableCalendarsCallCount += 1
+        return stubCalendars
+    }
+
+    func fetchUpcomingEvents(from: Date, days: Int?) async throws -> [CalendarEvent] {
+        fetchUpcomingEventsCallCount += 1
+        if let stubFetchError {
+            throw stubFetchError
+        }
+        return stubEvents
+    }
+}

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -505,7 +505,7 @@ final class TelemetryServiceTests: XCTestCase {
             .onboardingStep(step: "microphone"),
             .licenseActivationFailed(errorType: "invalid_key"),
             .keystrokeSnippetFired(action: "return"),
-            .meetingRecordingStarted,
+            .meetingRecordingStarted(),
             .meetingRecordingCompleted(durationSeconds: 1800.0, liveWordCount: 4200, liveTranscriptLagged: false),
             .meetingRecordingCancelled(durationSeconds: 30.0),
             .meetingRecordingFailed(errorType: "tap_creation_failed"),

--- a/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
@@ -124,7 +124,7 @@ final class OnboardingViewModelTests: XCTestCase {
     func testMeetingRecordingStepOrdering() {
         XCTAssertEqual(
             OnboardingViewModel.Step.allCases,
-            [.welcome, .microphone, .accessibility, .meetingRecording, .hotkey, .engine, .done]
+            [.welcome, .microphone, .accessibility, .meetingRecording, .calendar, .hotkey, .engine, .done]
         )
     }
 
@@ -154,7 +154,9 @@ final class OnboardingViewModelTests: XCTestCase {
 
         XCTAssertTrue(vm.meetingRecordingSkipped)
         XCTAssertTrue(defaults.bool(forKey: OnboardingViewModel.meetingRecordingSkippedKey))
-        XCTAssertEqual(vm.step, .hotkey)
+        // Skip advances to the next visible step — `.calendar` (only present
+        // when meeting recording is enabled, which it is in tests).
+        XCTAssertEqual(vm.step, .calendar)
     }
 
     func testResetOnboardingClearsMeetingRecordingSkippedFlag() {

--- a/plans/active/granola-meeting-completion.md
+++ b/plans/active/granola-meeting-completion.md
@@ -122,7 +122,11 @@ Ported the four core files from Oatmeal (`MeetingMonitor`, `MeetingLinkParser`, 
 
 **Ship criteria:** User grants Calendar permission through onboarding or Settings. At T-5min of a calendar event with a video link, a macOS notification appears. `.autoStart` mode is exposed in the UI but is a no-op (shows a "Coming soon" hint if selected, or clamp the picker to not expose it yet — plan says clamp).
 
-### Phase E — Calendar auto-start: countdown + auto-stop (ADR-017 phase 2)
+### Phase E — Calendar auto-start: countdown + auto-stop (ADR-017 phase 2) ✅ shipped 2026-04-25
+
+Built `MeetingCountdownToastController` (5s pre-meeting + 30s end-of-meeting countdowns, `KeylessPanel` non-activating top-center floating panel with progress bar + Cancel/Start Now actions). Coordinator wires `.autoStartDue` → countdown → `MeetingRecordingFlowCoordinator.startFromCalendar()` and `.autoStopDue` (only for auto-started recordings) → countdown → `toggleRecording()`. Tracks `autoStartedEventId` binding; manual-stop detection via next-poll `isRecordingActive() == false` with binding still held. Settings Picker unclamped to all three modes; auto-stop toggle visible when mode == `.autoStart`. `CalendarServicing` protocol + `MockCalendarService` extracted; 8 new `MeetingAutoStartCoordinatorTests` cover routing, lifecycle, and the binding state machine. Four new telemetry events allowlisted on the website worker (`calendar_auto_start_triggered`, `calendar_auto_start_cancelled`, `calendar_auto_stop_shown`, `calendar_auto_stop_cancelled`); `meeting_recording_started` gained optional `trigger` prop.
+
+**Original plan (kept for reference):**
 
 Add the countdown toast and the actual recording triggers.
 
@@ -173,10 +177,10 @@ Low-value-per-unit cleanup that's better done in one pass.
 - ~~Phase B (Insights)~~ — dropped per ADR-018 amendment
 - Phase C (Live Ask) — ✅ shipped 2026-04-24
 - Phase D (Calendar notify-only) — ✅ shipped 2026-04-25
-- Phase E (Calendar countdown + auto-stop) — 1 day remaining
+- Phase E (Calendar countdown + auto-stop) — ✅ shipped 2026-04-25
 - Phase F (Polish, naming, changelog) — 0.5 day remaining
 
-Total remaining: ~1.5 engineering days for Phases E + F.
+Total remaining: ~0.5 engineering days for Phase F polish.
 
 ## Changelog line (when all phases land)
 

--- a/plans/active/granola-meeting-completion.md
+++ b/plans/active/granola-meeting-completion.md
@@ -94,9 +94,11 @@ What was deferred:
 - **Dedicated `TranscriptChatViewModelLivePersistenceTests.swift`** — not added; the existing 40-test `TranscriptChatViewModelTests` suite still passes and exercises the shared chat-VM surface. Add focused live-mode tests when we touch this surface again.
 - **Transcription-failure chat recovery** (JSON sidecar) — Future Work in ADR-018 § Future Work.
 
-### Phase D — Calendar auto-start: notify-only (ADR-017 phase 1)
+### Phase D — Calendar auto-start: notify-only (ADR-017 phase 1) ✅ shipped 2026-04-25
 
-Port the three core files from Oatmeal, add settings + onboarding, wire a coordinator that only does `.notify` (no auto-start yet). Safe to ship without Phase E.
+Ported the four core files from Oatmeal (`MeetingMonitor`, `MeetingLinkParser`, `CalendarService`, `CalendarEvent` — GRDB stripped per ADR-017 §6), wired a notify-only `MeetingAutoStartCoordinator` with adaptive 60s/15s/5s polling + `.EKEventStoreChanged` observer + daily stale-id cleanup. Settings card (mode/lead/filter/per-calendar checkboxes/permission CTA) and skippable onboarding step both shipped. CLI surface (`macparakeet-cli calendar upcoming` + `health` extension) shipped alongside for headless verification by AI agents and CI. **Amendment:** the per-calendar include list (originally Phase 3) landed in Phase D — only ~30 lines and made onboarding feel finished.
+
+**Original plan (kept for reference):**
 
 | File | Change |
 |------|--------|
@@ -170,11 +172,11 @@ Low-value-per-unit cleanup that's better done in one pass.
 - Phase A (tab shell) — ✅ shipped 2026-04-24
 - ~~Phase B (Insights)~~ — dropped per ADR-018 amendment
 - Phase C (Live Ask) — ✅ shipped 2026-04-24
-- Phase D (Calendar notify-only) — 2 days remaining
+- Phase D (Calendar notify-only) — ✅ shipped 2026-04-25
 - Phase E (Calendar countdown + auto-stop) — 1 day remaining
 - Phase F (Polish, naming, changelog) — 0.5 day remaining
 
-Total remaining: ~3.5 engineering days for the calendar half.
+Total remaining: ~1.5 engineering days for Phases E + F.
 
 ## Changelog line (when all phases land)
 

--- a/scripts/dev/run_app.sh
+++ b/scripts/dev/run_app.sh
@@ -154,6 +154,8 @@ cat > "$APP_BUNDLE/Contents/Info.plist" << 'PLIST'
     <string>MacParakeet needs microphone access for voice dictation.</string>
     <key>NSAudioCaptureUsageDescription</key>
     <string>MacParakeet needs system audio recording access for meeting recording.</string>
+    <key>NSCalendarsFullAccessUsageDescription</key>
+    <string>MacParakeet reads your calendar so it can remind you before a meeting starts and (optionally) begin recording for you. Events stay on your Mac.</string>
 </dict>
 </plist>
 PLIST

--- a/scripts/dist/build_app_bundle.sh
+++ b/scripts/dist/build_app_bundle.sh
@@ -402,6 +402,8 @@ cat >"$INFO_PLIST" <<EOF
   <string>MacParakeet needs microphone access for dictation.</string>
   <key>NSAudioCaptureUsageDescription</key>
   <string>MacParakeet needs system audio recording access for meeting recording.</string>
+  <key>NSCalendarsFullAccessUsageDescription</key>
+  <string>MacParakeet reads your calendar so it can remind you before a meeting starts and (optionally) begin recording for you. Events stay on your Mac.</string>
   <key>SUFeedURL</key>
   <string>https://macparakeet.com/appcast.xml</string>
   <key>SUEnableAutomaticChecks</key>

--- a/spec/README.md
+++ b/spec/README.md
@@ -57,7 +57,7 @@ All ADRs live in `spec/adr/`. These are locked -- they record decisions already 
 | [ADR-014](adr/014-meeting-recording.md) | Meeting recording via Core Audio Taps |
 | [ADR-015](adr/015-concurrent-dictation-meeting.md) | Concurrent dictation and meeting recording |
 | [ADR-016](adr/016-centralized-stt-runtime-scheduler.md) | Centralized STT runtime and two-slot scheduler |
-| [ADR-017](adr/017-calendar-meeting-auto-start.md) | Calendar-driven meeting auto-start (proposed) |
+| [ADR-017](adr/017-calendar-meeting-auto-start.md) | Calendar-driven meeting auto-start (Phase 1 implemented; Phase 2+ proposed) |
 | [ADR-018](adr/018-live-meeting-insights-and-ask.md) | Live meeting Ask tab (Insights dropped per amendment; Ask shipped 2026-04-24) |
 
 ## Version Roadmap
@@ -189,9 +189,10 @@ Dictation + transcription + history + settings. Get audio in, text out, pasted i
 - [x] Centralized STT runtime + two-slot scheduler (ADR-016)
 - [x] Live panel tabs: Transcript / Ask (ADR-018; Insights dropped per amendment 2026-04-24)
 - [x] Live Ask chat with thinking-partner starter pills + persistent follow-up pills + persist-on-finalize handoff
-- [ ] Calendar-driven auto-start (ADR-017): EventKit integration + onboarding + settings
-- [ ] Pre-meeting notifications + 5s countdown toast for auto-start
-- [ ] Auto-stop toast at calendar event end
+- [x] Calendar-driven reminders (ADR-017 Phase 1): EventKit integration + onboarding + settings + per-calendar include list
+- [x] Pre-meeting macOS notifications at configurable lead time (off / 1 / 5 / 10 min)
+- [ ] Auto-start countdown toast (ADR-017 Phase 2)
+- [ ] Auto-stop toast at calendar event end (ADR-017 Phase 2)
 
 ## For AI Coding Assistants
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -57,7 +57,7 @@ All ADRs live in `spec/adr/`. These are locked -- they record decisions already 
 | [ADR-014](adr/014-meeting-recording.md) | Meeting recording via Core Audio Taps |
 | [ADR-015](adr/015-concurrent-dictation-meeting.md) | Concurrent dictation and meeting recording |
 | [ADR-016](adr/016-centralized-stt-runtime-scheduler.md) | Centralized STT runtime and two-slot scheduler |
-| [ADR-017](adr/017-calendar-meeting-auto-start.md) | Calendar-driven meeting auto-start (Phase 1 implemented; Phase 2+ proposed) |
+| [ADR-017](adr/017-calendar-meeting-auto-start.md) | Calendar-driven meeting auto-start (Phases 1 + 2 implemented; Phase 3 proposed) |
 | [ADR-018](adr/018-live-meeting-insights-and-ask.md) | Live meeting Ask tab (Insights dropped per amendment; Ask shipped 2026-04-24) |
 
 ## Version Roadmap
@@ -191,8 +191,8 @@ Dictation + transcription + history + settings. Get audio in, text out, pasted i
 - [x] Live Ask chat with thinking-partner starter pills + persistent follow-up pills + persist-on-finalize handoff
 - [x] Calendar-driven reminders (ADR-017 Phase 1): EventKit integration + onboarding + settings + per-calendar include list
 - [x] Pre-meeting macOS notifications at configurable lead time (off / 1 / 5 / 10 min)
-- [ ] Auto-start countdown toast (ADR-017 Phase 2)
-- [ ] Auto-stop toast at calendar event end (ADR-017 Phase 2)
+- [x] Auto-start countdown toast (ADR-017 Phase 2): 5s cancellable, top-center, non-activating
+- [x] Auto-stop toast at calendar event end (ADR-017 Phase 2): 30s, "Keep Recording" cancels
 
 ## For AI Coding Assistants
 

--- a/spec/adr/017-calendar-meeting-auto-start.md
+++ b/spec/adr/017-calendar-meeting-auto-start.md
@@ -1,6 +1,6 @@
 # ADR-017: Calendar-Driven Meeting Auto-Start
 
-> Status: PARTIAL — Phase 1 (notify-only) + Phase 2 (auto-start + countdown + auto-stop) IMPLEMENTED 2026-04-25; Phase 3 (late-join, retro-link, generic URL extraction) PROPOSED
+> Status: **IMPLEMENTED** — Phases 1 (notify-only) and 2 (auto-start + countdown + auto-stop) shipped 2026-04-25. Phase 3 (late-join, retro-link, generic URL extraction) remains **PROPOSED** (see Phased Rollout below).
 > Date: 2026-04-19
 > Related: ADR-002 (local-first), ADR-005 (onboarding), ADR-009 (custom hotkeys), ADR-014 (meeting recording), ADR-015 (concurrent dictation/meeting)
 

--- a/spec/adr/017-calendar-meeting-auto-start.md
+++ b/spec/adr/017-calendar-meeting-auto-start.md
@@ -1,6 +1,6 @@
 # ADR-017: Calendar-Driven Meeting Auto-Start
 
-> Status: PROPOSED
+> Status: PARTIAL — Phase 1 (notify-only) IMPLEMENTED 2026-04-25; Phase 2 (auto-start + countdown + auto-stop) PROPOSED
 > Date: 2026-04-19
 > Related: ADR-002 (local-first), ADR-005 (onboarding), ADR-009 (custom hotkeys), ADR-014 (meeting recording), ADR-015 (concurrent dictation/meeting)
 
@@ -214,9 +214,9 @@ Repo: `https://github.com/moona3k/oatmeal` (same owner, GPL-3.0).
 
 ## Phased Rollout
 
-1. **Phase 1 — Notify only:** Port core services. Wire coordinator with `.notify` mode only. Settings UI + onboarding step. Ship behind `calendarAutoStartMode = .notify` as new-user default.
-2. **Phase 2 — Auto-start with countdown:** Add `.autoStart` mode + countdown toast + auto-stop toast. No new permissions.
-3. **Phase 3 — Refinements:** Per-calendar include list, better URL extraction (Phone/FaceTime/generic URLs), `.lateJoinAvailable` UI.
+1. **Phase 1 — Notify only ✅ IMPLEMENTED (2026-04-25):** Ported `CalendarService`, `MeetingLinkParser`, `MeetingMonitor`, `CalendarEvent` from Oatmeal. Built `MeetingAutoStartCoordinator` (`@MainActor`, adaptive 60s/15s/5s polling, `.EKEventStoreChanged` observer, daily stale-id cleanup). Settings card + onboarding step + per-calendar include list shipped. CLI surface (`macparakeet-cli calendar upcoming` + `health` extension) ships alongside for headless verification. Mode defaults to `.off` — opt-in via onboarding (auto-`.notify` on permission grant) or Settings. Phase 1 amendment: **per-calendar include list landed in Phase 1**, not Phase 3 — it was only ~30 lines and made onboarding feel finished.
+2. **Phase 2 — Auto-start with countdown:** Add `.autoStart` mode + countdown toast + auto-stop toast. No new permissions. `MeetingMonitor` already emits `.autoStartDue` / `.lateJoinAvailable` / `.autoStopDue` cases — Phase 2 wires the coordinator handler + countdown toast UI without changing the polling/observer scaffolding.
+3. **Phase 3 — Refinements:** Better URL extraction (Phone/FaceTime/generic URLs), `.lateJoinAvailable` UI, optional retro-link (match a manually-started recording back to a calendar event).
 
 ## Open Questions
 

--- a/spec/adr/017-calendar-meeting-auto-start.md
+++ b/spec/adr/017-calendar-meeting-auto-start.md
@@ -1,6 +1,6 @@
 # ADR-017: Calendar-Driven Meeting Auto-Start
 
-> Status: PARTIAL — Phase 1 (notify-only) IMPLEMENTED 2026-04-25; Phase 2 (auto-start + countdown + auto-stop) PROPOSED
+> Status: PARTIAL — Phase 1 (notify-only) + Phase 2 (auto-start + countdown + auto-stop) IMPLEMENTED 2026-04-25; Phase 3 (late-join, retro-link, generic URL extraction) PROPOSED
 > Date: 2026-04-19
 > Related: ADR-002 (local-first), ADR-005 (onboarding), ADR-009 (custom hotkeys), ADR-014 (meeting recording), ADR-015 (concurrent dictation/meeting)
 
@@ -215,8 +215,8 @@ Repo: `https://github.com/moona3k/oatmeal` (same owner, GPL-3.0).
 ## Phased Rollout
 
 1. **Phase 1 — Notify only ✅ IMPLEMENTED (2026-04-25):** Ported `CalendarService`, `MeetingLinkParser`, `MeetingMonitor`, `CalendarEvent` from Oatmeal. Built `MeetingAutoStartCoordinator` (`@MainActor`, adaptive 60s/15s/5s polling, `.EKEventStoreChanged` observer, daily stale-id cleanup). Settings card + onboarding step + per-calendar include list shipped. CLI surface (`macparakeet-cli calendar upcoming` + `health` extension) ships alongside for headless verification. Mode defaults to `.off` — opt-in via onboarding (auto-`.notify` on permission grant) or Settings. Phase 1 amendment: **per-calendar include list landed in Phase 1**, not Phase 3 — it was only ~30 lines and made onboarding feel finished.
-2. **Phase 2 — Auto-start with countdown:** Add `.autoStart` mode + countdown toast + auto-stop toast. No new permissions. `MeetingMonitor` already emits `.autoStartDue` / `.lateJoinAvailable` / `.autoStopDue` cases — Phase 2 wires the coordinator handler + countdown toast UI without changing the polling/observer scaffolding.
-3. **Phase 3 — Refinements:** Better URL extraction (Phone/FaceTime/generic URLs), `.lateJoinAvailable` UI, optional retro-link (match a manually-started recording back to a calendar event).
+2. **Phase 2 — Auto-start with countdown ✅ IMPLEMENTED (2026-04-25):** Built `MeetingCountdownToastController` (5s pre-meeting countdown, 30s end-of-meeting countdown, `KeylessPanel` non-activating top-center floating panel). Coordinator handles `.autoStartDue` → toast → `MeetingRecordingFlowCoordinator.startFromCalendar()`; handles `.autoStopDue` (only for auto-started recordings) → toast → `toggleRecording()`. Tracks `autoStartedEventId` binding; clears on manual stop. Settings Picker unclamped to all three modes; auto-stop toggle exposed when mode == `.autoStart`. New telemetry events: `calendar_auto_start_triggered`, `calendar_auto_start_cancelled`, `calendar_auto_stop_shown`, `calendar_auto_stop_cancelled`. `meeting_recording_started` gained an optional `trigger` prop. `CalendarServicing` protocol + `MockCalendarService` extracted for `MeetingAutoStartCoordinatorTests` (8 integration tests covering routing, lifecycle, binding state machine).
+3. **Phase 3 — Refinements (PROPOSED):** Better URL extraction (Phone/FaceTime/generic URLs), `.lateJoinAvailable` UI (separate `lateJoinShownEventIds` set in `MeetingMonitor.evaluate(...)` so dismissed countdowns don't suppress late-join), optional retro-link (match a manually-started recording back to a calendar event).
 
 ## Open Questions
 


### PR DESCRIPTION
## What this gives you

Forgot to start a meeting recording until 5 minutes in? This adds **calendar reminders before your meetings start** — and optionally a **5-second cancellable countdown that starts the recording for you**. Three modes:

- **Off** (default) — MacParakeet ignores your calendar.
- **Notify before meetings** — quiet macOS notification at the configured lead time.
- **Start recording automatically** — notification + a countdown toast at T-0 + (optional) auto-stop at meeting end.

You stay in control. Auto-start has a 5s cancellable window. Auto-stop has a 30s "Keep Recording" countdown so meetings that run over don't lose their tail.

```
                  ┌──────────────────────┐
                  │ EKEventStoreChanged  │──┐  immediate re-evaluate
                  └──────────────────────┘  │
                                            ▼
            60s/15s/5s adaptive Timer ──▶ poll() ──▶ MeetingMonitor.evaluate(...)
                                                    │
        ┌───────────────────────────────────────────┼───────────────────────────────────────────┐
        ▼                                           ▼                                           ▼
  .reminderDue                              .autoStartDue                                .autoStopDue
        │                                           │                                           │
        ▼                                           ▼                                           ▼
  silent macOS notification          5s countdown toast (top-center)                30s countdown toast
  Telemetry.calendarReminderShown      Cancel / Start Now                          Keep Recording
                                                    │                                           │
                                          on confirm/timeout:                         on confirm/timeout:
                                  MeetingRecordingFlowCoordinator                MeetingRecordingFlowCoordinator
                                       .startFromCalendar()                            .toggleRecording()
```

## What you'll see

- **Onboarding** — a new optional step asks for Calendar access. Skip it and nothing changes; grant it and reminders auto-enable.
- **Settings → Calendar** — a single card to control everything: when to remind you, which events count, which calendars to include, auto-stop on/off.
- **macOS notification** at the configured lead time (silent so it doesn't fight your Zoom join sound).
- **Floating countdown toast** for auto-start and auto-stop — non-activating, top-center of the screen, ESC cancels.

## Settings the user controls

| Control | Options | Default |
|---|---|---|
| Calendar behavior | Off / Notify before meetings / Start recording automatically | Off (opt-in) |
| Remind me | At start / 1 / 5 / 10 min before | 5 min before |
| Which events count | With video link / With participants / All events | With video link |
| Calendars (checkboxes) | One per visible macOS calendar | All included |
| Stop recording at meeting end | On / Off (only visible when auto-start is on) | On |

## How it works under the hood

Ports the proven calendar pipeline from the sibling Oatmeal app and wires it through MacParakeet's existing meeting recording flow.

| Layer | What |
|---|---|
| `MacParakeetCore/Calendar/` | `CalendarService` (EventKit `actor` so EventKit's documented thread-safety constraint is honored, plus a `.shared` singleton — Apple recommends one long-lived store per app), `MeetingLinkParser` (Zoom / Meet / Teams / Webex / Around regex), pure-logic `MeetingMonitor` (`static evaluate(...) -> [MonitorEvent]`), `CalendarEvent` model carrying both `calendarName` (display) and `calendarIdentifier` (filter key — survives renames + disambiguates same-titled calendars across accounts), `CalendarServicing` protocol so the coordinator can be tested with `MockCalendarService`. No SQLite — events are read into memory each poll and discarded. |
| `MacParakeet/App/MeetingAutoStartCoordinator.swift` | `@MainActor` polling coordinator. Adaptive 60s/15s/5s timer in `RunLoop.common` mode. Observes `.EKEventStoreChanged` for instant re-evaluation. Observes a settings-change notification so toggling preferences doesn't wait for the next tick. Daily stale-id cleanup. Phase 2: drives auto-start countdown → recording start, tracks `autoStartedEventId` binding so auto-stop only fires for recordings the coordinator started itself (manual recordings stay sovereign per ADR-017 §10). |
| `MacParakeet/Views/MeetingRecording/MeetingCountdownToast*.swift` | New non-activating `KeylessPanel` floating toast (top-center, joins all spaces, survives full-screen). Two flavors: 5s pre-meeting (Cancel / Start Now) and 30s end-of-meeting (Keep Recording). 60Hz progress driven via `@Bindable` so the bar updates without re-rendering the whole subtree. ESC dismisses, Return triggers secondary action. |
| Settings | New "Calendar" card with mode picker, reminder lead time, event filter, per-calendar checkboxes, three-state permission CTA (`.notDetermined` → "Grant Calendar Access"; `.denied` → "Open System Settings" with explanatory copy; `.granted` → "Open System Settings"), auto-stop toggle (visible when mode is `.autoStart`). Gated behind `AppFeatures.meetingRecordingEnabled`. |
| Onboarding | New skippable step between Meeting Recording and Hotkey. Auto-enables `.notify` mode on permission grant + asks for notification authorization in the same flow (otherwise reminders silently drop). |
| Telemetry | New permission case (`.calendar`), 5 setting-change cases, 5 lifecycle events: `calendar_reminder_shown` (Phase 1), `calendar_auto_start_triggered`, `calendar_auto_start_cancelled`, `calendar_auto_stop_shown`, `calendar_auto_stop_cancelled` (Phase 2). `meeting_recording_started` gained an optional `trigger` prop (`manual` / `hotkey` / `calendar_auto_start`) so adoption can be split between manual and calendar-driven recordings. **Website allowlist already deployed** ([macparakeet-website@dc4dd2c](https://github.com/moona3k/macparakeet-website/commit/dc4dd2c)). |
| CLI | `macparakeet-cli calendar upcoming [--days N] [--filter link\|participants\|all] [--json]` for headless verification + `health` extended with EventKit status — agents and CI can't see TCC dialogs, so this is the only way to debug "is the pipeline alive?" |

49 new tests cover every window in `MeetingMonitor` (reminder firing window with 90s forgiveness, trigger filter precision, dismissed-id suppression, all-day skip, declined skip, multi-event isolation), every regex branch in `MeetingLinkParser`, and the coordinator's routing / lifecycle / binding state machine via `MockCalendarService`. **All 1534 tests pass** (1521 XCTest + 13 Swift Testing).

Design background: [ADR-017](spec/adr/017-calendar-meeting-auto-start.md).

## Out of scope (Phase 3, deferred)

These are real but speculative — building them on spec means more code to maintain without proven demand. The plan even says "only build if telemetry shows users want it":

- **`.lateJoinAvailable` UI** — toast for "this Zoom started 2 min ago, want to join?". `MeetingMonitor` already emits the case; coordinator drops it. CodeRabbit's "shared `countdownShownEventIds` gating" concern is a Phase 3 wiring concern (the fix changes the public `evaluate(...)` signature; better done once when the late-join UI ships).
- **Better URL extraction** — Phone, FaceTime, generic non-video URLs in `MeetingLinkParser`.
- **Retro-link** — match a manually-started recording back to a calendar event (auto-title from event title, pull attendees).
- **Calendar event title → recording title** — the recording is currently titled by default; renaming requires plumbing through `MeetingRecordingService` + the `Transcription` write. Phase F polish.

## Cumulative review timeline

This PR went through five rounds of review (Gemini, Codex, Explore, CodeRabbit, plus a third-agent pass relayed by the user) before Phase 2 was added. Every reviewer comment has an inline reply documenting the verdict; all 21 review threads are resolved.

| Round | Source | Net commits |
|---|---|---|
| Original Phase 1 | Self | 8 |
| 1 | Gemini + Codex + Explore + self | 1 (`4b123319`) |
| 2 | CodeRabbit batch 1 | 1 (`03ff0424`) |
| 3 | Third-agent | 1 (`bd74b809`) |
| 4 | CodeRabbit batch 2 | 1 (`45af629c`) |
| 5 | Latest reviewer | 1 (`2297f6cf`) |
| **Phase 2** | This conversation | **9** (`abd2860e` → `3a9e55e1`) |

## Test plan

- [x] `swift test` — 1521 XCTest pass (was 1452 at PR open; +69 from this branch)
- [x] `swift build` clean for both app and CLI targets
- [x] `macparakeet-cli calendar upcoming --help` — subcommand registered
- [ ] Smoke test in dev `.app` bundle:
  - [ ] Onboarding: skip calendar step → reminders stay off
  - [ ] Onboarding: grant calendar access → reminders auto-enable
  - [ ] Settings → switch to "Start recording automatically" → no notification auth prompt is *missed* (we re-request when mode flips to non-`.off`)
  - [ ] Calendar event 5 min out with a Zoom link → notification at T-5
  - [ ] Same event at T-0 → countdown toast → recording starts
  - [ ] Toast Cancel during countdown → no recording started
  - [ ] Recording past meeting end with auto-stop on → 30s countdown → recording stops
  - [ ] "Keep Recording" during the auto-stop countdown → recording continues
  - [ ] Manually started recording during a calendar event → auto-stop does NOT fire (sovereign manual recordings)
  - [ ] Move an event earlier in macOS Calendar → coordinator picks it up immediately
  - [ ] Settings → uncheck a calendar → events from that calendar don't fire (verifies identifier-keyed exclude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Calendar-driven meeting auto-start modes (off / notify / auto-start) with meeting-link detection and per-calendar inclusion.
  * Cancellable countdown toasts (5s auto-start, 30s auto-stop) and UI for starting/stopping recordings from calendar events.
  * Calendar settings panel and onboarding step to request calendar access.
  * CLI: `calendar upcoming` and improved health output showing calendar authorization and calendar counts.

* **Tests**
  * Added comprehensive tests covering link parsing, monitor logic, coordinator behavior, and CLI. 

* **Documentation**
  * ADR and roadmap updated to mark phased rollout progress and details.

* **Chores**
  * Dev build now declares calendar usage in permission text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->