### PR TITLE
Add explicit microphone selection and input test

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -46,17 +46,28 @@ final class AppEnvironment {
         promptResultRepo = PromptResultRepository(dbQueue: databaseManager.dbQueue)
 
         // Services
+        let runtimePreferences = UserDefaultsAppRuntimePreferences()
+        self.runtimePreferences = runtimePreferences
+        let selectedInputDeviceUIDProvider: @Sendable () -> String? = { [runtimePreferences] in
+            runtimePreferences.selectedMicrophoneDeviceUID
+        }
+
         sttRuntime = STTRuntime()
         sttScheduler = STTScheduler(runtime: sttRuntime)
-        audioProcessor = AudioProcessor()
-        meetingRecordingService = MeetingRecordingService(sttTranscriber: sttScheduler)
+        audioProcessor = AudioProcessor(
+            selectedInputDeviceUIDProvider: selectedInputDeviceUIDProvider
+        )
+        meetingRecordingService = MeetingRecordingService(
+            audioCaptureService: MeetingAudioCaptureService(
+                selectedInputDeviceUIDProvider: selectedInputDeviceUIDProvider
+            ),
+            sttTranscriber: sttScheduler
+        )
         clipboardService = ClipboardService()
         exportService = ExportService()
         permissionService = PermissionService()
         accessibilityService = AccessibilityService()
         launchAtLoginService = LaunchAtLoginService()
-        let runtimePreferences = UserDefaultsAppRuntimePreferences()
-        self.runtimePreferences = runtimePreferences
 
         // Licensing / entitlements (basic guards: 7-day trial + license unlock).
         //

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -158,6 +158,7 @@ struct SettingsView: View {
                         }
                         .buttonStyle(.bordered)
                         .help("Refresh microphones")
+                        .accessibilityLabel("Refresh microphones")
                     }
                 }
 

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -145,10 +145,11 @@ struct SettingsView: View {
                             Text("System Default").tag(SettingsViewModel.systemDefaultMicrophoneSelection)
                             ForEach(viewModel.microphoneDeviceOptions) { device in
                                 Text(device.displayName).tag(device.uid)
+                                    .disabled(!device.isAvailable)
                             }
                         }
                         .labelsHidden()
-                        .frame(width: 260)
+                        .frame(minWidth: 220, idealWidth: 260, maxWidth: 320)
 
                         Button {
                             viewModel.refreshMicrophoneDevices()

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -29,6 +29,7 @@ struct SettingsView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
                 headerCard
+                audioInputCard
                 dictationCard
                 if AppFeatures.meetingRecordingEnabled {
                     meetingRecordingCard
@@ -122,6 +123,133 @@ struct SettingsView: View {
                 )
             }
         }
+    }
+
+    // MARK: - Audio Input
+
+    private var audioInputCard: some View {
+        settingsCard(
+            title: "Audio Input",
+            subtitle: "Choose the microphone used for dictation and meetings.",
+            icon: "mic"
+        ) {
+            VStack(spacing: DesignSystem.Spacing.md) {
+                HStack(alignment: .center) {
+                    rowText(
+                        title: "Microphone",
+                        detail: viewModel.selectedMicrophoneStatusText
+                    )
+                    Spacer(minLength: DesignSystem.Spacing.md)
+                    HStack(spacing: DesignSystem.Spacing.sm) {
+                        Picker("Microphone", selection: $viewModel.selectedMicrophoneDeviceUID) {
+                            Text("System Default").tag(SettingsViewModel.systemDefaultMicrophoneSelection)
+                            ForEach(viewModel.microphoneDeviceOptions) { device in
+                                Text(device.displayName).tag(device.uid)
+                            }
+                        }
+                        .labelsHidden()
+                        .frame(width: 260)
+
+                        Button {
+                            viewModel.refreshMicrophoneDevices()
+                        } label: {
+                            Image(systemName: "arrow.clockwise")
+                        }
+                        .buttonStyle(.bordered)
+                        .help("Refresh microphones")
+                    }
+                }
+
+                Divider()
+
+                HStack(alignment: .center, spacing: DesignSystem.Spacing.md) {
+                    microphoneTestStatus
+                    Spacer(minLength: DesignSystem.Spacing.md)
+                    Button {
+                        switch viewModel.microphoneTestState {
+                        case .testing:
+                            viewModel.cancelMicrophoneTest()
+                        default:
+                            viewModel.testSelectedMicrophone()
+                        }
+                    } label: {
+                        Label(
+                            viewModel.microphoneTestState == .testing ? "Stop Test" : "Test Input",
+                            systemImage: viewModel.microphoneTestState == .testing ? "stop.fill" : "waveform"
+                        )
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(DesignSystem.Colors.accent)
+                    .disabled(!viewModel.microphoneGranted && viewModel.microphoneTestState != .testing)
+                }
+            }
+        }
+    }
+
+    private var microphoneTestStatus: some View {
+        HStack(spacing: DesignSystem.Spacing.sm) {
+            microphoneLevelMeter(level: viewModel.microphoneTestLevel)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(microphoneTestTitle)
+                    .font(DesignSystem.Typography.body)
+                Text(microphoneTestDetail)
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(microphoneTestDetailColor)
+                    .lineLimit(2)
+            }
+        }
+    }
+
+    private var microphoneTestTitle: String {
+        switch viewModel.microphoneTestState {
+        case .idle:
+            return "Input test"
+        case .testing:
+            return "Listening..."
+        case .succeeded:
+            return "Input detected"
+        case .failed:
+            return "Input test failed"
+        }
+    }
+
+    private var microphoneTestDetail: String {
+        switch viewModel.microphoneTestState {
+        case .idle:
+            return viewModel.microphoneGranted ? "Run a short level check before recording." : "Grant microphone permission before testing."
+        case .testing:
+            return "Speak into the selected microphone."
+        case .succeeded:
+            return "This microphone is producing audio."
+        case .failed(let message):
+            return message
+        }
+    }
+
+    private var microphoneTestDetailColor: Color {
+        switch viewModel.microphoneTestState {
+        case .failed:
+            return DesignSystem.Colors.errorRed
+        default:
+            return .secondary
+        }
+    }
+
+    private func microphoneLevelMeter(level: Float) -> some View {
+        GeometryReader { proxy in
+            let clamped = CGFloat(max(0, min(1, level)))
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(DesignSystem.Colors.surfaceElevated)
+                Capsule()
+                    .fill(DesignSystem.Colors.accent)
+                    .frame(width: max(6, proxy.size.width * clamped))
+                    .animation(.easeOut(duration: 0.12), value: clamped)
+            }
+        }
+        .frame(width: 96, height: 8)
+        .accessibilityLabel("Microphone input level")
+        .accessibilityValue("\(Int(max(0, min(1, level)) * 100)) percent")
     }
 
     // MARK: - General

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -71,8 +71,6 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
     }
 
     public var selectedMicrophoneDeviceUID: String? {
-        let value = defaults.string(forKey: Self.selectedMicrophoneDeviceUIDKey)?
-            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return value.isEmpty ? nil : value
+        AudioDeviceManager.normalizedUID(defaults.string(forKey: Self.selectedMicrophoneDeviceUIDKey))
     }
 }

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -9,6 +9,7 @@ public protocol AppRuntimePreferencesProtocol: Sendable {
     var shouldDiarize: Bool { get }
     var aiFormatterEnabled: Bool { get }
     var aiFormatterPrompt: String { get }
+    var selectedMicrophoneDeviceUID: String? { get }
 }
 
 public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProtocol, @unchecked Sendable {
@@ -24,6 +25,7 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
     public static let speakerDiarizationKey = "speakerDiarization"
     public static let aiFormatterEnabledKey = "aiFormatterEnabled"
     public static let aiFormatterPromptKey = "aiFormatterPrompt"
+    public static let selectedMicrophoneDeviceUIDKey = "selectedMicrophoneDeviceUID"
 
     private let defaults: UserDefaults
 
@@ -66,5 +68,11 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
     public var aiFormatterPrompt: String {
         let prompt = defaults.string(forKey: Self.aiFormatterPromptKey) ?? ""
         return AIFormatter.normalizedPromptTemplate(prompt)
+    }
+
+    public var selectedMicrophoneDeviceUID: String? {
+        let value = defaults.string(forKey: Self.selectedMicrophoneDeviceUIDKey)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return value.isEmpty ? nil : value
     }
 }

--- a/Sources/MacParakeetCore/Audio/AudioDeviceManager.swift
+++ b/Sources/MacParakeetCore/Audio/AudioDeviceManager.swift
@@ -89,11 +89,22 @@ public enum AudioDeviceManager {
 
         return deviceIDs.compactMap { id in
             guard hasInputChannels(id) else { return nil }
-            guard let uid = deviceUID(id) else { return nil }
             let name = deviceName(id) ?? "Unknown Device"
+            guard let uid = deviceUID(id) else {
+                logger.debug(
+                    "skipping_input_device_without_uid id=\(id, privacy: .public) name=\(name, privacy: .public)"
+                )
+                return nil
+            }
             let transport = transportType(id)
             return InputDevice(id: id, uid: uid, name: name, transportType: transport)
         }
+    }
+
+    /// Normalizes persisted CoreAudio device UIDs, treating nil and whitespace as absent.
+    public static func normalizedUID(_ uid: String?) -> String? {
+        let trimmed = uid?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     /// Returns the AudioDeviceID of the built-in microphone, if available.

--- a/Sources/MacParakeetCore/Audio/AudioDeviceManager.swift
+++ b/Sources/MacParakeetCore/Audio/AudioDeviceManager.swift
@@ -16,8 +16,21 @@ public enum AudioDeviceManager {
     /// Describes an available audio input device.
     public struct InputDevice: Sendable, CustomStringConvertible {
         public let id: AudioDeviceID
+        public let uid: String
         public let name: String
         public let transportType: UInt32
+
+        public init(
+            id: AudioDeviceID,
+            uid: String,
+            name: String,
+            transportType: UInt32
+        ) {
+            self.id = id
+            self.uid = uid
+            self.name = name
+            self.transportType = transportType
+        }
 
         public var isBuiltIn: Bool {
             transportType == kAudioDeviceTransportTypeBuiltIn
@@ -33,7 +46,7 @@ public enum AudioDeviceManager {
         }
 
         public var description: String {
-            "\(name) (id=\(id), transport=\(transportLabel))"
+            "\(name) (id=\(id), uid=\(uid), transport=\(transportLabel))"
         }
 
         static func label(for transport: UInt32) -> String {
@@ -76,9 +89,10 @@ public enum AudioDeviceManager {
 
         return deviceIDs.compactMap { id in
             guard hasInputChannels(id) else { return nil }
+            guard let uid = deviceUID(id) else { return nil }
             let name = deviceName(id) ?? "Unknown Device"
             let transport = transportType(id)
-            return InputDevice(id: id, name: name, transportType: transport)
+            return InputDevice(id: id, uid: uid, name: name, transportType: transport)
         }
     }
 
@@ -102,6 +116,20 @@ public enum AudioDeviceManager {
         )
         guard status == noErr, deviceID != kAudioObjectUnknown else { return nil }
         return deviceID
+    }
+
+    /// Returns the current system default input device, if it can be resolved
+    /// to a valid input device descriptor.
+    public static func defaultInputDeviceInfo() -> InputDevice? {
+        guard let id = defaultInputDevice() else { return nil }
+        return deviceInfo(id)
+    }
+
+    /// Resolves a persistent CoreAudio device UID to the current process-local
+    /// `AudioDeviceID`. Device IDs are not stable across boots or hardware
+    /// topology changes, so app preferences should store UIDs and resolve late.
+    public static func inputDeviceID(forUID uid: String) -> AudioDeviceID? {
+        inputDevices().first { $0.uid == uid }?.id
     }
 
     // MARK: - Device Control
@@ -168,6 +196,20 @@ public enum AudioDeviceManager {
         return validName.takeRetainedValue() as String
     }
 
+    /// Returns the persistent CoreAudio UID for a device.
+    public static func deviceUID(_ deviceID: AudioDeviceID) -> String? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyDeviceUID,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var uid: Unmanaged<CFString>?
+        var size = UInt32(MemoryLayout<Unmanaged<CFString>?>.size)
+        let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &uid)
+        guard status == noErr, let validUID = uid else { return nil }
+        return validUID.takeRetainedValue() as String
+    }
+
     /// Returns the transport type of a device (built-in, bluetooth, USB, etc.).
     public static func transportType(_ deviceID: AudioDeviceID) -> UInt32 {
         var address = AudioObjectPropertyAddress(
@@ -185,9 +227,10 @@ public enum AudioDeviceManager {
     /// Returns an InputDevice descriptor for a given device ID, or nil if not a valid input device.
     public static func deviceInfo(_ deviceID: AudioDeviceID) -> InputDevice? {
         guard hasInputChannels(deviceID) else { return nil }
+        guard let uid = deviceUID(deviceID) else { return nil }
         let name = deviceName(deviceID) ?? "Unknown Device"
         let transport = transportType(deviceID)
-        return InputDevice(id: deviceID, name: name, transportType: transport)
+        return InputDevice(id: deviceID, uid: uid, name: name, transportType: transport)
     }
 
     /// For aggregate devices, resolves the transport type of the first active sub-device.

--- a/Sources/MacParakeetCore/Audio/AudioProcessor.swift
+++ b/Sources/MacParakeetCore/Audio/AudioProcessor.swift
@@ -5,8 +5,12 @@ public actor AudioProcessor: AudioProcessorProtocol {
     private let recorder: AudioRecorder
     private let converter: AudioFileConverter
 
-    public init() {
-        self.recorder = AudioRecorder()
+    public init(
+        selectedInputDeviceUIDProvider: @escaping @Sendable () -> String? = { nil }
+    ) {
+        self.recorder = AudioRecorder(
+            selectedInputDeviceUIDProvider: selectedInputDeviceUIDProvider
+        )
         self.converter = AudioFileConverter()
     }
 

--- a/Sources/MacParakeetCore/Audio/AudioRecorder.swift
+++ b/Sources/MacParakeetCore/Audio/AudioRecorder.swift
@@ -93,7 +93,7 @@ public actor AudioRecorder {
 
         logAvailableDevices()
 
-        let selectedDeviceUID = normalizedDeviceUID(selectedInputDeviceUIDProvider())
+        let selectedDeviceUID = AudioDeviceManager.normalizedUID(selectedInputDeviceUIDProvider())
         if let selectedDeviceUID {
             if let selectedDeviceID = AudioDeviceManager.inputDeviceID(forUID: selectedDeviceUID) {
                 do {
@@ -119,7 +119,7 @@ public actor AudioRecorder {
         do {
             try configureAndStart(
                 overrideDeviceID: nil,
-                fallbackUsed: false,
+                fallbackUsed: selectedDeviceUID != nil,
                 requestedDeviceUID: selectedDeviceUID
             )
         } catch {
@@ -488,11 +488,6 @@ public actor AudioRecorder {
                 "  device id=\(device.id, privacy: .public) uid=\(device.uid, privacy: .private) name=\(device.name, privacy: .public) transport=\(device.transportLabel, privacy: .public)\(isDefault, privacy: .public)"
             )
         }
-    }
-
-    private func normalizedDeviceUID(_ uid: String?) -> String? {
-        let trimmed = uid?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return trimmed.isEmpty ? nil : trimmed
     }
 
     private func logTapError(_ message: String) {

--- a/Sources/MacParakeetCore/Audio/AudioRecorder.swift
+++ b/Sources/MacParakeetCore/Audio/AudioRecorder.swift
@@ -13,6 +13,8 @@ public struct RecordingDeviceInfo: Sendable, Equatable {
     public let sampleRate: Double
     public let channels: UInt32
     public let fallbackUsed: Bool
+    public let deviceUID: String?
+    public let requestedDeviceUID: String?
 }
 
 /// Manages microphone recording via AVAudioEngine.
@@ -22,6 +24,7 @@ public struct RecordingDeviceInfo: Sendable, Equatable {
 /// in HFP mode reporting 0 Hz sample rate), automatically falls back to the built-in microphone.
 public actor AudioRecorder {
     private let logger = Logger(subsystem: "com.macparakeet.core", category: "AudioRecorder")
+    private let selectedInputDeviceUIDProvider: @Sendable () -> String?
     private var audioEngine: AVAudioEngine?
     private var audioFile: AVAudioFile?
     /// Thread-safe sample counter updated synchronously from the audio tap callback.
@@ -46,7 +49,11 @@ public actor AudioRecorder {
     /// FluidAudio requires at least 1 second of 16kHz audio (16,000 samples).
     private static let minimumSamples = 16_000
 
-    public init() {}
+    public init(
+        selectedInputDeviceUIDProvider: @escaping @Sendable () -> String? = { nil }
+    ) {
+        self.selectedInputDeviceUIDProvider = selectedInputDeviceUIDProvider
+    }
 
     public var audioLevel: Float {
         // Read the latest value written by the audio tap thread
@@ -86,9 +93,35 @@ public actor AudioRecorder {
 
         logAvailableDevices()
 
-        // Try with the system default device first
+        let selectedDeviceUID = normalizedDeviceUID(selectedInputDeviceUIDProvider())
+        if let selectedDeviceUID {
+            if let selectedDeviceID = AudioDeviceManager.inputDeviceID(forUID: selectedDeviceUID) {
+                do {
+                    try configureAndStart(
+                        overrideDeviceID: selectedDeviceID,
+                        fallbackUsed: false,
+                        requestedDeviceUID: selectedDeviceUID
+                    )
+                    return
+                } catch {
+                    logger.warning(
+                        "selected_input_device_failed uid=\(selectedDeviceUID, privacy: .private) error=\(error.localizedDescription, privacy: .public) — retrying with system default"
+                    )
+                }
+            } else {
+                logger.warning(
+                    "selected_input_device_missing uid=\(selectedDeviceUID, privacy: .private) — retrying with system default"
+                )
+            }
+        }
+
+        // Try with the system default device next.
         do {
-            try configureAndStart(overrideDeviceID: nil)
+            try configureAndStart(
+                overrideDeviceID: nil,
+                fallbackUsed: false,
+                requestedDeviceUID: selectedDeviceUID
+            )
         } catch {
             logger.warning(
                 "default_device_failed error=\(error.localizedDescription, privacy: .public) — retrying with built-in mic"
@@ -103,7 +136,11 @@ public actor AudioRecorder {
             logger.info(
                 "retrying_with_built_in_mic id=\(builtInID, privacy: .public) name=\(name, privacy: .public)"
             )
-            try configureAndStart(overrideDeviceID: builtInID)
+            try configureAndStart(
+                overrideDeviceID: builtInID,
+                fallbackUsed: true,
+                requestedDeviceUID: selectedDeviceUID
+            )
         }
     }
 
@@ -149,7 +186,11 @@ public actor AudioRecorder {
     ///
     /// If `overrideDeviceID` is provided, explicitly sets that device on the engine's
     /// input audio unit before reading the format. Otherwise uses the system default.
-    private func configureAndStart(overrideDeviceID: AudioDeviceID?) throws {
+    private func configureAndStart(
+        overrideDeviceID: AudioDeviceID?,
+        fallbackUsed: Bool,
+        requestedDeviceUID: String?
+    ) throws {
         let engine = AVAudioEngine()
         let inputNode = engine.inputNode
 
@@ -165,10 +206,11 @@ public actor AudioRecorder {
         // Log the resolved device
         if let resolvedID = AudioDeviceManager.currentInputDevice(of: engine) {
             let name = AudioDeviceManager.deviceName(resolvedID) ?? "unknown"
+            let uid = AudioDeviceManager.deviceUID(resolvedID) ?? "unknown"
             let transport = AudioDeviceManager.transportType(resolvedID)
             let transportLabel = AudioDeviceManager.InputDevice.label(for: transport)
             logger.info(
-                "input_device id=\(resolvedID, privacy: .public) name=\(name, privacy: .public) transport=\(transportLabel, privacy: .public)"
+                "input_device id=\(resolvedID, privacy: .public) uid=\(uid, privacy: .private) name=\(name, privacy: .public) transport=\(transportLabel, privacy: .public) requested_uid=\(requestedDeviceUID ?? "system-default", privacy: .private)"
             )
         }
 
@@ -186,6 +228,7 @@ public actor AudioRecorder {
         // Capture device info for telemetry (before validation — we want info even on failure)
         if let resolvedID = AudioDeviceManager.currentInputDevice(of: engine) {
             let name = AudioDeviceManager.deviceName(resolvedID) ?? "unknown"
+            let uid = AudioDeviceManager.deviceUID(resolvedID)
             let transport = AudioDeviceManager.transportType(resolvedID)
             let subTransport = AudioDeviceManager.subDeviceTransport(resolvedID)
             _deviceInfo = RecordingDeviceInfo(
@@ -194,7 +237,9 @@ public actor AudioRecorder {
                 subTransport: subTransport.map { AudioDeviceManager.InputDevice.label(for: $0) },
                 sampleRate: inputFormat.sampleRate,
                 channels: inputFormat.channelCount,
-                fallbackUsed: overrideDeviceID != nil
+                fallbackUsed: fallbackUsed,
+                deviceUID: uid,
+                requestedDeviceUID: requestedDeviceUID
             )
         }
 
@@ -440,9 +485,14 @@ public actor AudioRecorder {
         for device in devices {
             let isDefault = device.id == defaultID ? " [DEFAULT]" : ""
             logger.info(
-                "  device id=\(device.id, privacy: .public) name=\(device.name, privacy: .public) transport=\(device.transportLabel, privacy: .public)\(isDefault, privacy: .public)"
+                "  device id=\(device.id, privacy: .public) uid=\(device.uid, privacy: .private) name=\(device.name, privacy: .public) transport=\(device.transportLabel, privacy: .public)\(isDefault, privacy: .public)"
             )
         }
+    }
+
+    private func normalizedDeviceUID(_ uid: String?) -> String? {
+        let trimmed = uid?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     private func logTapError(_ message: String) {

--- a/Sources/MacParakeetCore/Audio/MeetingAudioCaptureService.swift
+++ b/Sources/MacParakeetCore/Audio/MeetingAudioCaptureService.swift
@@ -56,8 +56,13 @@ public actor MeetingAudioCaptureService {
     private var eventContinuation: AsyncStream<MeetingAudioCaptureEvent>.Continuation?
     private var cachedEvents: AsyncStream<MeetingAudioCaptureEvent>?
 
-    public init(micProcessingMode: MeetingMicProcessingMode = .raw) {
-        self.microphoneCapture = MicrophoneCapture()
+    public init(
+        micProcessingMode: MeetingMicProcessingMode = .raw,
+        selectedInputDeviceUIDProvider: @escaping @Sendable () -> String? = { nil }
+    ) {
+        self.microphoneCapture = MicrophoneCapture(
+            selectedInputDeviceUIDProvider: selectedInputDeviceUIDProvider
+        )
         self.micProcessingMode = micProcessingMode
         self.systemAudioTapFactory = {
             guard #available(macOS 14.2, *) else {

--- a/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
+++ b/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
@@ -245,7 +245,23 @@ public final class MicrophoneCapture: @unchecked Sendable {
     }
 
     private func applySelectedInputDeviceIfAvailable(on engine: AVAudioEngine) {
-        guard let uid = normalizedDeviceUID(selectedInputDeviceUIDProvider()) else { return }
+        guard let uid = AudioDeviceManager.normalizedUID(selectedInputDeviceUIDProvider()) else {
+            guard let defaultID = AudioDeviceManager.defaultInputDevice() else {
+                logger.warning("meeting_default_input_device_missing")
+                return
+            }
+            guard AudioDeviceManager.setInputDevice(defaultID, on: engine) else {
+                logger.warning(
+                    "meeting_default_input_device_set_failed id=\(defaultID, privacy: .public)"
+                )
+                return
+            }
+            let name = AudioDeviceManager.deviceName(defaultID) ?? "unknown"
+            logger.info(
+                "meeting_default_input_device_applied id=\(defaultID, privacy: .public) name=\(name, privacy: .public)"
+            )
+            return
+        }
         guard let deviceID = AudioDeviceManager.inputDeviceID(forUID: uid) else {
             logger.warning("meeting_selected_input_device_missing uid=\(uid, privacy: .private)")
             return
@@ -260,11 +276,6 @@ public final class MicrophoneCapture: @unchecked Sendable {
         logger.info(
             "meeting_selected_input_device_applied uid=\(uid, privacy: .private) id=\(deviceID, privacy: .public) name=\(name, privacy: .public)"
         )
-    }
-
-    private func normalizedDeviceUID(_ uid: String?) -> String? {
-        let trimmed = uid?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return trimmed.isEmpty ? nil : trimmed
     }
 
     private func scheduleSilentBufferWatchdog() {

--- a/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
+++ b/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
@@ -15,6 +15,7 @@ public final class MicrophoneCapture: @unchecked Sendable {
     private let lifecycleQueue = DispatchQueue(label: "com.macparakeet.microphonecapture")
     private let watchdogQueue = DispatchQueue(label: "com.macparakeet.microphonecapture.watchdog", qos: .utility)
     private let handlerLock = NSLock()
+    private let selectedInputDeviceUIDProvider: @Sendable () -> String?
     private let audioEngine = AVAudioEngine()
     private let bufferSize: AVAudioFrameCount = 4096
     private let watchdogLock = NSLock()
@@ -24,7 +25,11 @@ public final class MicrophoneCapture: @unchecked Sendable {
     private var firstBufferReceived = false
     private var watchdogWorkItem: DispatchWorkItem?
 
-    public init() {}
+    public init(
+        selectedInputDeviceUIDProvider: @escaping @Sendable () -> String? = { nil }
+    ) {
+        self.selectedInputDeviceUIDProvider = selectedInputDeviceUIDProvider
+    }
 
     deinit {
         stop()
@@ -69,6 +74,7 @@ public final class MicrophoneCapture: @unchecked Sendable {
             }
 
             let inputNode = audioEngine.inputNode
+            applySelectedInputDeviceIfAvailable(on: audioEngine)
             state = .starting
             handlerLock.withLock { bufferHandler = handler }
             do {
@@ -236,6 +242,29 @@ public final class MicrophoneCapture: @unchecked Sendable {
         try catchingObjCException {
             try inputNode.setVoiceProcessingEnabled(enabled)
         }
+    }
+
+    private func applySelectedInputDeviceIfAvailable(on engine: AVAudioEngine) {
+        guard let uid = normalizedDeviceUID(selectedInputDeviceUIDProvider()) else { return }
+        guard let deviceID = AudioDeviceManager.inputDeviceID(forUID: uid) else {
+            logger.warning("meeting_selected_input_device_missing uid=\(uid, privacy: .private)")
+            return
+        }
+        guard AudioDeviceManager.setInputDevice(deviceID, on: engine) else {
+            logger.warning(
+                "meeting_selected_input_device_set_failed uid=\(uid, privacy: .private) id=\(deviceID, privacy: .public)"
+            )
+            return
+        }
+        let name = AudioDeviceManager.deviceName(deviceID) ?? "unknown"
+        logger.info(
+            "meeting_selected_input_device_applied uid=\(uid, privacy: .private) id=\(deviceID, privacy: .public) name=\(name, privacy: .public)"
+        )
+    }
+
+    private func normalizedDeviceUID(_ uid: String?) -> String? {
+        let trimmed = uid?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     private func scheduleSilentBufferWatchdog() {

--- a/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
+++ b/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
@@ -2,6 +2,54 @@ import Foundation
 import OSLog
 @preconcurrency import AVFoundation
 
+struct MeetingInputDeviceAttempt: Equatable, Sendable {
+    enum Source: Equatable, Sendable {
+        case selected(uid: String)
+        case systemDefault
+        case builtIn
+    }
+
+    let source: Source
+    let deviceID: AudioDeviceID
+}
+
+extension MeetingInputDeviceAttempt.Source {
+    var logValue: String {
+        switch self {
+        case .selected:
+            return "selected"
+        case .systemDefault:
+            return "system_default"
+        case .builtIn:
+            return "built_in"
+        }
+    }
+}
+
+func meetingInputDeviceAttempts(
+    selectedUID: String?,
+    selectedInputDeviceID: (String) -> AudioDeviceID?,
+    defaultInputDevice: () -> AudioDeviceID?,
+    builtInMicrophone: () -> AudioDeviceID?
+) -> [MeetingInputDeviceAttempt] {
+    var attempts: [MeetingInputDeviceAttempt] = []
+    var seenDeviceIDs = Set<AudioDeviceID>()
+
+    func append(_ source: MeetingInputDeviceAttempt.Source, deviceID: AudioDeviceID?) {
+        guard let deviceID, seenDeviceIDs.insert(deviceID).inserted else { return }
+        attempts.append(MeetingInputDeviceAttempt(source: source, deviceID: deviceID))
+    }
+
+    if let selectedUID {
+        append(.selected(uid: selectedUID), deviceID: selectedInputDeviceID(selectedUID))
+    }
+
+    append(.systemDefault, deviceID: defaultInputDevice())
+    append(.builtIn, deviceID: builtInMicrophone())
+
+    return attempts
+}
+
 public final class MicrophoneCapture: @unchecked Sendable {
     public typealias AudioBufferHandler = @Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void
     private enum LifecycleState {
@@ -74,13 +122,14 @@ public final class MicrophoneCapture: @unchecked Sendable {
             }
 
             let inputNode = audioEngine.inputNode
-            applySelectedInputDeviceIfAvailable(on: audioEngine)
+            let inputDeviceAttempts = makeInputDeviceAttempts()
             state = .starting
             handlerLock.withLock { bufferHandler = handler }
             do {
-                startReport = try installTapAndStartEngine(
+                startReport = try installTapAndStartEngineWithFallback(
                     inputNode: inputNode,
-                    processingMode: processingMode
+                    processingMode: processingMode,
+                    inputDeviceAttempts: inputDeviceAttempts
                 )
                 state = .running
                 didStart = true
@@ -244,38 +293,112 @@ public final class MicrophoneCapture: @unchecked Sendable {
         }
     }
 
-    private func applySelectedInputDeviceIfAvailable(on engine: AVAudioEngine) {
-        guard let uid = AudioDeviceManager.normalizedUID(selectedInputDeviceUIDProvider()) else {
-            guard let defaultID = AudioDeviceManager.defaultInputDevice() else {
-                logger.warning("meeting_default_input_device_missing")
-                return
+    private func installTapAndStartEngineWithFallback(
+        inputNode: AVAudioInputNode,
+        processingMode: MeetingMicProcessingMode,
+        inputDeviceAttempts: [MeetingInputDeviceAttempt]
+    ) throws -> MeetingMicrophoneCaptureStartReport {
+        guard !inputDeviceAttempts.isEmpty else {
+            throw MeetingAudioError.noMicrophoneAvailable
+        }
+
+        var lastError: Error?
+        for attempt in inputDeviceAttempts {
+            guard applyInputDeviceAttempt(attempt, on: audioEngine) else {
+                if lastError == nil {
+                    lastError = MeetingAudioError.noMicrophoneAvailable
+                }
+                resetAfterFailedStart(inputNode: inputNode)
+                continue
             }
-            guard AudioDeviceManager.setInputDevice(defaultID, on: engine) else {
-                logger.warning(
-                    "meeting_default_input_device_set_failed id=\(defaultID, privacy: .public)"
+
+            do {
+                let report = try installTapAndStartEngine(
+                    inputNode: inputNode,
+                    processingMode: processingMode
                 )
-                return
+                logInputDeviceAttemptSucceeded(attempt)
+                return report
+            } catch {
+                lastError = error
+                logger.warning(
+                    "meeting_input_device_start_failed source=\(attempt.source.logValue, privacy: .public) id=\(attempt.deviceID, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
+                )
+                resetAfterFailedStart(inputNode: inputNode)
             }
-            let name = AudioDeviceManager.deviceName(defaultID) ?? "unknown"
-            logger.info(
-                "meeting_default_input_device_applied id=\(defaultID, privacy: .public) name=\(name, privacy: .public)"
-            )
-            return
         }
-        guard let deviceID = AudioDeviceManager.inputDeviceID(forUID: uid) else {
-            logger.warning("meeting_selected_input_device_missing uid=\(uid, privacy: .private)")
-            return
+
+        if let meetingError = lastError as? MeetingAudioError {
+            throw meetingError
         }
-        guard AudioDeviceManager.setInputDevice(deviceID, on: engine) else {
-            logger.warning(
-                "meeting_selected_input_device_set_failed uid=\(uid, privacy: .private) id=\(deviceID, privacy: .public)"
-            )
-            return
+        if let lastError {
+            throw MeetingAudioError.audioEngineStartFailed(lastError.localizedDescription)
         }
-        let name = AudioDeviceManager.deviceName(deviceID) ?? "unknown"
-        logger.info(
-            "meeting_selected_input_device_applied uid=\(uid, privacy: .private) id=\(deviceID, privacy: .public) name=\(name, privacy: .public)"
+        throw MeetingAudioError.noMicrophoneAvailable
+    }
+
+    private func makeInputDeviceAttempts() -> [MeetingInputDeviceAttempt] {
+        let selectedUID = AudioDeviceManager.normalizedUID(selectedInputDeviceUIDProvider())
+        let selectedDeviceID: AudioDeviceID?
+        if let selectedUID {
+            selectedDeviceID = AudioDeviceManager.inputDeviceID(forUID: selectedUID)
+            if selectedDeviceID == nil {
+                logger.warning("meeting_selected_input_device_missing uid=\(selectedUID, privacy: .private)")
+            }
+        } else {
+            selectedDeviceID = nil
+        }
+
+        let defaultDeviceID = AudioDeviceManager.defaultInputDevice()
+        if defaultDeviceID == nil {
+            logger.warning("meeting_default_input_device_missing")
+        }
+
+        let builtInDeviceID = AudioDeviceManager.builtInMicrophone()
+        if builtInDeviceID == nil {
+            logger.debug("meeting_built_in_input_device_missing")
+        }
+
+        return meetingInputDeviceAttempts(
+            selectedUID: selectedUID,
+            selectedInputDeviceID: { _ in selectedDeviceID },
+            defaultInputDevice: { defaultDeviceID },
+            builtInMicrophone: { builtInDeviceID }
         )
+    }
+
+    private func applyInputDeviceAttempt(
+        _ attempt: MeetingInputDeviceAttempt,
+        on engine: AVAudioEngine
+    ) -> Bool {
+        guard AudioDeviceManager.setInputDevice(attempt.deviceID, on: engine) else {
+            logger.warning(
+                "meeting_input_device_set_failed source=\(attempt.source.logValue, privacy: .public) id=\(attempt.deviceID, privacy: .public)"
+            )
+            return false
+        }
+
+        let name = AudioDeviceManager.deviceName(attempt.deviceID) ?? "unknown"
+        logger.info(
+            "meeting_input_device_applied source=\(attempt.source.logValue, privacy: .public) id=\(attempt.deviceID, privacy: .public) name=\(name, privacy: .public)"
+        )
+        return true
+    }
+
+    private func logInputDeviceAttemptSucceeded(_ attempt: MeetingInputDeviceAttempt) {
+        let name = AudioDeviceManager.deviceName(attempt.deviceID) ?? "unknown"
+        logger.info(
+            "meeting_input_device_started source=\(attempt.source.logValue, privacy: .public) id=\(attempt.deviceID, privacy: .public) name=\(name, privacy: .public)"
+        )
+    }
+
+    private func resetAfterFailedStart(inputNode: AVAudioInputNode) {
+        try? catchingObjCException {
+            inputNode.removeTap(onBus: 0)
+        }
+        audioEngine.stop()
+        audioEngine.reset()
+        resetDiagnosticsState()
     }
 
     private func scheduleSilentBufferWatchdog() {

--- a/Sources/MacParakeetCore/Services/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/TelemetryEvent.swift
@@ -152,6 +152,7 @@ public enum TelemetrySettingName: String, Sendable, Equatable {
     case meetingHotkey = "meeting_hotkey"
     case fileTranscriptionHotkey = "file_transcription_hotkey"
     case youtubeTranscriptionHotkey = "youtube_transcription_hotkey"
+    case microphoneSelection = "microphone_selection"
 
     case launchAtLogin = "launch_at_login"
     case silenceAutoStop = "silence_auto_stop"

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -42,6 +42,7 @@ public final class SettingsViewModel {
     }
 
     public static let systemDefaultMicrophoneSelection = "__system_default__"
+    private static let microphoneTestSilenceThreshold: Float = 0.01
 
     // General
     public var launchAtLogin: Bool {
@@ -128,7 +129,6 @@ public final class SettingsViewModel {
             let normalized = Self.normalizedMicrophoneSelection(selectedMicrophoneDeviceUID)
             if selectedMicrophoneDeviceUID != normalized {
                 selectedMicrophoneDeviceUID = normalized
-                return
             }
             if normalized == Self.systemDefaultMicrophoneSelection {
                 defaults.removeObject(forKey: UserDefaultsAppRuntimePreferences.selectedMicrophoneDeviceUIDKey)
@@ -519,8 +519,7 @@ public final class SettingsViewModel {
     }
 
     private static func normalizedMicrophoneSelection(_ uid: String?) -> String {
-        let trimmed = uid?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return trimmed.isEmpty ? systemDefaultMicrophoneSelection : trimmed
+        AudioDeviceManager.normalizedUID(uid) ?? systemDefaultMicrophoneSelection
     }
 
     /// Resolve the stored bookmark to a display path.
@@ -678,7 +677,7 @@ public final class SettingsViewModel {
                 }
                 capture.stop()
                 guard !Task.isCancelled else { return }
-                microphoneTestState = levelBox.maxLevel > 0.01
+                microphoneTestState = levelBox.maxLevel > Self.microphoneTestSilenceThreshold
                     ? .succeeded
                     : .failed("No input detected. Check the selected microphone and try again.")
             } catch {

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -29,13 +29,15 @@ public final class SettingsViewModel {
         public let name: String
         public let transportLabel: String
         public let isDefault: Bool
+        public let isAvailable: Bool
 
         public var displayName: String {
-            isDefault ? "\(name) (System Default)" : name
+            if !isAvailable { return "\(name) (unavailable)" }
+            return isDefault ? "\(name) (System Default)" : name
         }
 
         public var detail: String {
-            transportLabel
+            isAvailable ? transportLabel : "Reconnect this microphone or choose another input."
         }
     }
 
@@ -133,6 +135,8 @@ public final class SettingsViewModel {
             } else {
                 defaults.set(normalized, forKey: UserDefaultsAppRuntimePreferences.selectedMicrophoneDeviceUIDKey)
             }
+            microphoneTestTask?.cancel()
+            microphoneTestTask = nil
             microphoneTestState = .idle
             microphoneTestLevel = 0
             Telemetry.send(.settingChanged(setting: .microphoneSelection))
@@ -149,6 +153,9 @@ public final class SettingsViewModel {
             return "Using macOS System Default."
         }
         guard let selected = microphoneDeviceOptions.first(where: { $0.uid == selectedMicrophoneDeviceUID }) else {
+            return "Selected microphone is unavailable. MacParakeet will use System Default until it returns."
+        }
+        guard selected.isAvailable else {
             return "Selected microphone is unavailable. MacParakeet will use System Default until it returns."
         }
         return "Using \(selected.name) for dictation and meeting microphone capture."
@@ -625,12 +632,26 @@ public final class SettingsViewModel {
                 uid: device.uid,
                 name: device.name,
                 transportLabel: device.transportLabel,
-                isDefault: device.uid == defaultUID
+                isDefault: device.uid == defaultUID,
+                isAvailable: true
             )
         }
         .sorted { lhs, rhs in
             if lhs.isDefault != rhs.isDefault { return lhs.isDefault && !rhs.isDefault }
             return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+        }
+        if selectedMicrophoneDeviceUID != Self.systemDefaultMicrophoneSelection,
+           !microphoneDeviceOptions.contains(where: { $0.uid == selectedMicrophoneDeviceUID }) {
+            microphoneDeviceOptions.append(
+                MicrophoneDeviceOption(
+                    id: selectedMicrophoneDeviceUID,
+                    uid: selectedMicrophoneDeviceUID,
+                    name: "Selected microphone",
+                    transportLabel: "unavailable",
+                    isDefault: false,
+                    isAvailable: false
+                )
+            )
         }
     }
 
@@ -653,7 +674,7 @@ public final class SettingsViewModel {
                 }
                 for _ in 0..<40 {
                     try await Task.sleep(for: .milliseconds(50))
-                    microphoneTestLevel = levelBox.maxLevel
+                    microphoneTestLevel = levelBox.latestLevel
                 }
                 capture.stop()
                 guard !Task.isCancelled else { return }
@@ -1041,15 +1062,21 @@ public final class SettingsViewModel {
 
 private final class MicrophoneLevelBox: @unchecked Sendable {
     private let lock = NSLock()
-    private var value: Float = 0
+    private var latestValue: Float = 0
+    private var peakValue: Float = 0
+
+    var latestLevel: Float {
+        lock.withLock { latestValue }
+    }
 
     var maxLevel: Float {
-        lock.withLock { value }
+        lock.withLock { peakValue }
     }
 
     func record(_ level: Float) {
         lock.withLock {
-            value = max(value, level)
+            latestValue = level
+            peakValue = max(peakValue, level)
         }
     }
 }

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -648,14 +648,13 @@ public final class SettingsViewModel {
             guard let self else { return }
             let capture = MicrophoneCapture(selectedInputDeviceUIDProvider: { selectedUID })
             do {
-                _ = try capture.start(processingMode: .raw) { [weak self] buffer, _ in
-                    let level = buffer.rmsLevel
-                    levelBox.record(level)
-                    Task { @MainActor [weak self] in
-                        self?.microphoneTestLevel = max(self?.microphoneTestLevel ?? 0, level)
-                    }
+                _ = try capture.start(processingMode: .raw) { buffer, _ in
+                    levelBox.record(buffer.rmsLevel)
                 }
-                try await Task.sleep(for: .seconds(2))
+                for _ in 0..<40 {
+                    try await Task.sleep(for: .milliseconds(50))
+                    microphoneTestLevel = levelBox.maxLevel
+                }
                 capture.stop()
                 guard !Task.isCancelled else { return }
                 microphoneTestState = levelBox.maxLevel > 0.01

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -16,6 +16,31 @@ public final class SettingsViewModel {
         case failed
     }
 
+    public enum MicrophoneTestState: Equatable {
+        case idle
+        case testing
+        case succeeded
+        case failed(String)
+    }
+
+    public struct MicrophoneDeviceOption: Identifiable, Equatable, Sendable {
+        public let id: String
+        public let uid: String
+        public let name: String
+        public let transportLabel: String
+        public let isDefault: Bool
+
+        public var displayName: String {
+            isDefault ? "\(name) (System Default)" : name
+        }
+
+        public var detail: String {
+            transportLabel
+        }
+    }
+
+    public static let systemDefaultMicrophoneSelection = "__system_default__"
+
     // General
     public var launchAtLogin: Bool {
         didSet {
@@ -95,6 +120,38 @@ public final class SettingsViewModel {
     }
     public var silenceDelay: Double {
         didSet { defaults.set(silenceDelay, forKey: UserDefaultsAppRuntimePreferences.silenceDelayKey) }
+    }
+    public var selectedMicrophoneDeviceUID: String {
+        didSet {
+            let normalized = Self.normalizedMicrophoneSelection(selectedMicrophoneDeviceUID)
+            if selectedMicrophoneDeviceUID != normalized {
+                selectedMicrophoneDeviceUID = normalized
+                return
+            }
+            if normalized == Self.systemDefaultMicrophoneSelection {
+                defaults.removeObject(forKey: UserDefaultsAppRuntimePreferences.selectedMicrophoneDeviceUIDKey)
+            } else {
+                defaults.set(normalized, forKey: UserDefaultsAppRuntimePreferences.selectedMicrophoneDeviceUIDKey)
+            }
+            microphoneTestState = .idle
+            microphoneTestLevel = 0
+            Telemetry.send(.settingChanged(setting: .microphoneSelection))
+        }
+    }
+    public var microphoneDeviceOptions: [MicrophoneDeviceOption] = []
+    public var microphoneTestState: MicrophoneTestState = .idle
+    public var microphoneTestLevel: Float = 0
+    public var selectedMicrophoneStatusText: String {
+        if selectedMicrophoneDeviceUID == Self.systemDefaultMicrophoneSelection {
+            if let currentDefault = microphoneDeviceOptions.first(where: \.isDefault) {
+                return "Using macOS System Default: \(currentDefault.name)."
+            }
+            return "Using macOS System Default."
+        }
+        guard let selected = microphoneDeviceOptions.first(where: { $0.uid == selectedMicrophoneDeviceUID }) else {
+            return "Selected microphone is unavailable. MacParakeet will use System Default until it returns."
+        }
+        return "Using \(selected.name) for dictation and meeting microphone capture."
     }
 
     // Voice Return
@@ -299,10 +356,16 @@ public final class SettingsViewModel {
     private let defaults: UserDefaults
     private let youtubeDownloadsDirPath: @Sendable () -> String
     private let isSpeechModelCached: @Sendable () -> Bool
+    private let inputDevicesProvider: @Sendable () -> [AudioDeviceManager.InputDevice]
+    private let defaultInputDeviceUIDProvider: @Sendable () -> String?
     private let permissionPollingInterval: Duration
     private var isApplyingLaunchAtLoginState = false
-    private var permissionPollingTask: Task<Void, Never>?
-    private var calendarSettingsObserver: NSObjectProtocol?
+    // `deinit` is nonisolated even though this type is `@MainActor`.
+    // These handles are only mutated on the main actor during the view
+    // model lifetime; unsafe access lets deinit cancel/unregister.
+    @ObservationIgnored nonisolated(unsafe) private var permissionPollingTask: Task<Void, Never>?
+    @ObservationIgnored nonisolated(unsafe) private var microphoneTestTask: Task<Void, Never>?
+    @ObservationIgnored nonisolated(unsafe) private var calendarSettingsObserver: NSObjectProtocol?
     /// Re-entrancy guard so `observeCalendarSettings()` doesn't fire `didSet`
     /// → notification → re-resolve → `didSet` → … on every user toggle.
     private var isResolvingCalendarSettings = false
@@ -312,12 +375,20 @@ public final class SettingsViewModel {
         defaults: UserDefaults = .standard,
         youtubeDownloadsDirPath: @escaping @Sendable () -> String = { AppPaths.youtubeDownloadsDir },
         isSpeechModelCached: @escaping @Sendable () -> Bool = { STTRuntime.isModelCached() },
+        inputDevicesProvider: @escaping @Sendable () -> [AudioDeviceManager.InputDevice] = {
+            AudioDeviceManager.inputDevices()
+        },
+        defaultInputDeviceUIDProvider: @escaping @Sendable () -> String? = {
+            AudioDeviceManager.defaultInputDeviceInfo()?.uid
+        },
         permissionPollingInterval: Duration = .seconds(2)
     ) {
         AutoSaveService.migrateLegacyMeetingSettingsIfNeeded(defaults: defaults)
         self.defaults = defaults
         self.youtubeDownloadsDirPath = youtubeDownloadsDirPath
         self.isSpeechModelCached = isSpeechModelCached
+        self.inputDevicesProvider = inputDevicesProvider
+        self.defaultInputDeviceUIDProvider = defaultInputDeviceUIDProvider
         self.permissionPollingInterval = permissionPollingInterval
         launchAtLogin = defaults.bool(forKey: "launchAtLogin")
         menuBarOnlyMode = AppPreferences.isMenuBarOnlyModeEnabled(defaults: defaults)
@@ -336,6 +407,9 @@ public final class SettingsViewModel {
         silenceAutoStop = defaults.bool(forKey: UserDefaultsAppRuntimePreferences.silenceAutoStopKey)
         let delay = defaults.double(forKey: UserDefaultsAppRuntimePreferences.silenceDelayKey)
         silenceDelay = delay == 0 ? 2.0 : delay
+        selectedMicrophoneDeviceUID = Self.normalizedMicrophoneSelection(
+            defaults.string(forKey: UserDefaultsAppRuntimePreferences.selectedMicrophoneDeviceUIDKey)
+        )
         voiceReturnEnabled = defaults.bool(forKey: UserDefaultsAppRuntimePreferences.voiceReturnEnabledKey)
         voiceReturnTrigger = defaults.string(forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggerKey) ?? "press return"
         processingMode = Self.normalizedProcessingMode(defaults.string(forKey: UserDefaultsAppRuntimePreferences.processingModeKey))
@@ -354,7 +428,16 @@ public final class SettingsViewModel {
         meetingTriggerFilter = Self.resolveMeetingTriggerFilter(defaults: defaults)
         calendarAutoStopEnabled = defaults.object(forKey: CalendarAutoStartPreferences.autoStopEnabledKey) as? Bool ?? true
         calendarExcludedIdentifiers = Self.resolveCalendarExcludedIdentifiers(defaults: defaults)
+        refreshMicrophoneDevices()
         observeCalendarSettings()
+    }
+
+    deinit {
+        permissionPollingTask?.cancel()
+        microphoneTestTask?.cancel()
+        if let calendarSettingsObserver {
+            NotificationCenter.default.removeObserver(calendarSettingsObserver)
+        }
     }
 
     /// Onboarding writes calendar settings directly to UserDefaults (it
@@ -426,6 +509,11 @@ public final class SettingsViewModel {
             return []
         }
         return Set(raw)
+    }
+
+    private static func normalizedMicrophoneSelection(_ uid: String?) -> String {
+        let trimmed = uid?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? systemDefaultMicrophoneSelection : trimmed
     }
 
     /// Resolve the stored bookmark to a display path.
@@ -515,6 +603,7 @@ public final class SettingsViewModel {
     }
 
     public func refreshPermissions() {
+        refreshMicrophoneDevices()
         Task {
             if let service = permissionService {
                 let micStatus = await service.checkMicrophonePermission()
@@ -526,6 +615,66 @@ public final class SettingsViewModel {
             }
             refreshCalendarPermission()
         }
+    }
+
+    public func refreshMicrophoneDevices() {
+        let defaultUID = defaultInputDeviceUIDProvider()
+        microphoneDeviceOptions = inputDevicesProvider().map { device in
+            MicrophoneDeviceOption(
+                id: device.uid,
+                uid: device.uid,
+                name: device.name,
+                transportLabel: device.transportLabel,
+                isDefault: device.uid == defaultUID
+            )
+        }
+        .sorted { lhs, rhs in
+            if lhs.isDefault != rhs.isDefault { return lhs.isDefault && !rhs.isDefault }
+            return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+        }
+    }
+
+    public func testSelectedMicrophone() {
+        microphoneTestTask?.cancel()
+        microphoneTestLevel = 0
+        microphoneTestState = .testing
+
+        let selectedUID = selectedMicrophoneDeviceUID == Self.systemDefaultMicrophoneSelection
+            ? nil
+            : selectedMicrophoneDeviceUID
+        let levelBox = MicrophoneLevelBox()
+
+        microphoneTestTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            let capture = MicrophoneCapture(selectedInputDeviceUIDProvider: { selectedUID })
+            do {
+                _ = try capture.start(processingMode: .raw) { [weak self] buffer, _ in
+                    let level = buffer.rmsLevel
+                    levelBox.record(level)
+                    Task { @MainActor [weak self] in
+                        self?.microphoneTestLevel = max(self?.microphoneTestLevel ?? 0, level)
+                    }
+                }
+                try await Task.sleep(for: .seconds(2))
+                capture.stop()
+                guard !Task.isCancelled else { return }
+                microphoneTestState = levelBox.maxLevel > 0.01
+                    ? .succeeded
+                    : .failed("No input detected. Check the selected microphone and try again.")
+            } catch {
+                capture.stop()
+                guard !Task.isCancelled else { return }
+                microphoneTestState = .failed(error.localizedDescription)
+            }
+            microphoneTestTask = nil
+        }
+    }
+
+    public func cancelMicrophoneTest() {
+        microphoneTestTask?.cancel()
+        microphoneTestTask = nil
+        microphoneTestLevel = 0
+        microphoneTestState = .idle
     }
 
     public func requestScreenRecordingAccess() {
@@ -888,5 +1037,20 @@ public final class SettingsViewModel {
         }
 
         throw lastError ?? STTError.engineStartFailed("Model setup failed.")
+    }
+}
+
+private final class MicrophoneLevelBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Float = 0
+
+    var maxLevel: Float {
+        lock.withLock { value }
+    }
+
+    func record(_ level: Float) {
+        lock.withLock {
+            value = max(value, level)
+        }
     }
 }

--- a/Tests/MacParakeetTests/Audio/MicrophoneCaptureTests.swift
+++ b/Tests/MacParakeetTests/Audio/MicrophoneCaptureTests.swift
@@ -1,9 +1,77 @@
 import XCTest
+import CoreAudio
 @testable import MacParakeetCore
 
 final class MicrophoneCaptureTests: XCTestCase {
     func testInitCreatesCaptureInstance() {
         let capture = MicrophoneCapture()
         XCTAssertNotNil(capture)
+    }
+
+    func testInputDeviceAttemptsPreferSelectedThenDefaultThenBuiltIn() {
+        let attempts = meetingInputDeviceAttempts(
+            selectedUID: "usb-mic",
+            selectedInputDeviceID: { uid in uid == "usb-mic" ? AudioDeviceID(10) : nil },
+            defaultInputDevice: { AudioDeviceID(20) },
+            builtInMicrophone: { AudioDeviceID(30) }
+        )
+
+        XCTAssertEqual(
+            attempts,
+            [
+                MeetingInputDeviceAttempt(source: .selected(uid: "usb-mic"), deviceID: 10),
+                MeetingInputDeviceAttempt(source: .systemDefault, deviceID: 20),
+                MeetingInputDeviceAttempt(source: .builtIn, deviceID: 30),
+            ]
+        )
+    }
+
+    func testInputDeviceAttemptsSkipMissingSelectedDevice() {
+        let attempts = meetingInputDeviceAttempts(
+            selectedUID: "missing-mic",
+            selectedInputDeviceID: { _ in nil },
+            defaultInputDevice: { AudioDeviceID(20) },
+            builtInMicrophone: { AudioDeviceID(30) }
+        )
+
+        XCTAssertEqual(
+            attempts,
+            [
+                MeetingInputDeviceAttempt(source: .systemDefault, deviceID: 20),
+                MeetingInputDeviceAttempt(source: .builtIn, deviceID: 30),
+            ]
+        )
+    }
+
+    func testInputDeviceAttemptsDeduplicateDefaultAndBuiltIn() {
+        let attempts = meetingInputDeviceAttempts(
+            selectedUID: nil,
+            selectedInputDeviceID: { _ in nil },
+            defaultInputDevice: { AudioDeviceID(30) },
+            builtInMicrophone: { AudioDeviceID(30) }
+        )
+
+        XCTAssertEqual(
+            attempts,
+            [
+                MeetingInputDeviceAttempt(source: .systemDefault, deviceID: 30),
+            ]
+        )
+    }
+
+    func testInputDeviceAttemptsCanUseBuiltInWhenDefaultMissing() {
+        let attempts = meetingInputDeviceAttempts(
+            selectedUID: nil,
+            selectedInputDeviceID: { _ in nil },
+            defaultInputDevice: { nil },
+            builtInMicrophone: { AudioDeviceID(30) }
+        )
+
+        XCTAssertEqual(
+            attempts,
+            [
+                MeetingInputDeviceAttempt(source: .builtIn, deviceID: 30),
+            ]
+        )
     }
 }

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -110,6 +110,12 @@ final class SettingsViewModelTests: XCTestCase {
     }
 
     func testSelectedMicrophoneNormalizesBlankSelectionToSystemDefault() {
+        viewModel.selectedMicrophoneDeviceUID = "usb-mic-uid"
+        XCTAssertEqual(
+            testDefaults.string(forKey: UserDefaultsAppRuntimePreferences.selectedMicrophoneDeviceUIDKey),
+            "usb-mic-uid"
+        )
+
         viewModel.selectedMicrophoneDeviceUID = "   "
 
         XCTAssertEqual(viewModel.selectedMicrophoneDeviceUID, SettingsViewModel.systemDefaultMicrophoneSelection)
@@ -140,6 +146,7 @@ final class SettingsViewModelTests: XCTestCase {
 
         XCTAssertEqual(vm.microphoneDeviceOptions.map(\.uid), ["builtin-zed", "usb-alpha"])
         XCTAssertEqual(vm.microphoneDeviceOptions.first?.displayName, "Zed Built-In Mic (System Default)")
+        XCTAssertEqual(vm.microphoneDeviceOptions.last?.displayName, "Alpha USB Mic")
         XCTAssertEqual(vm.microphoneDeviceOptions.last?.detail, "usb")
     }
 

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -143,6 +143,33 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(vm.microphoneDeviceOptions.last?.detail, "usb")
     }
 
+    func testRefreshMicrophoneDevicesPreservesUnavailableStoredSelection() {
+        testDefaults.set("missing-usb-mic", forKey: UserDefaultsAppRuntimePreferences.selectedMicrophoneDeviceUIDKey)
+
+        let vm = SettingsViewModel(
+            defaults: testDefaults,
+            inputDevicesProvider: {
+                [
+                    AudioDeviceManager.InputDevice(
+                        id: 10,
+                        uid: "builtin-zed",
+                        name: "Zed Built-In Mic",
+                        transportType: kAudioDeviceTransportTypeBuiltIn
+                    )
+                ]
+            },
+            defaultInputDeviceUIDProvider: { "builtin-zed" }
+        )
+
+        XCTAssertEqual(vm.selectedMicrophoneDeviceUID, "missing-usb-mic")
+        XCTAssertEqual(vm.microphoneDeviceOptions.map(\.uid), ["builtin-zed", "missing-usb-mic"])
+        XCTAssertEqual(vm.microphoneDeviceOptions.last?.displayName, "Selected microphone (unavailable)")
+        XCTAssertEqual(
+            vm.selectedMicrophoneStatusText,
+            "Selected microphone is unavailable. MacParakeet will use System Default until it returns."
+        )
+    }
+
     func testMeetingAutoSaveMigratesLegacyTranscriptionSettings() {
         testDefaults.set(true, forKey: AutoSaveService.enabledKey)
         testDefaults.set(AutoSaveFormat.json.rawValue, forKey: AutoSaveService.formatKey)

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import CoreAudio
 @testable import MacParakeetCore
 @testable import MacParakeetViewModels
 
@@ -62,6 +63,11 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.saveAudioRecordings, "saveAudioRecordings should default to true")
         XCTAssertTrue(viewModel.saveTranscriptionAudio, "saveTranscriptionAudio should default to true")
         XCTAssertEqual(viewModel.meetingHotkeyTrigger, .chord(modifiers: ["command", "shift"], keyCode: 46))
+        XCTAssertEqual(
+            viewModel.selectedMicrophoneDeviceUID,
+            SettingsViewModel.systemDefaultMicrophoneSelection,
+            "microphone selection should default to macOS System Default"
+        )
     }
 
     func testInitLoadsFromUserDefaults() {
@@ -73,6 +79,7 @@ final class SettingsViewModelTests: XCTestCase {
         testDefaults.set(3.0, forKey: "silenceDelay")
         testDefaults.set(false, forKey: "saveAudioRecordings")
         testDefaults.set(false, forKey: "saveTranscriptionAudio")
+        testDefaults.set("usb-mic-uid", forKey: UserDefaultsAppRuntimePreferences.selectedMicrophoneDeviceUIDKey)
         HotkeyTrigger.chord(modifiers: ["control", "option"], keyCode: 46)
             .save(to: testDefaults, defaultsKey: HotkeyTrigger.meetingDefaultsKey)
 
@@ -85,7 +92,55 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(vm.silenceDelay, 3.0)
         XCTAssertFalse(vm.saveAudioRecordings)
         XCTAssertFalse(vm.saveTranscriptionAudio)
+        XCTAssertEqual(vm.selectedMicrophoneDeviceUID, "usb-mic-uid")
         XCTAssertEqual(vm.meetingHotkeyTrigger, .chord(modifiers: ["control", "option"], keyCode: 46))
+    }
+
+    func testSelectedMicrophonePersistsUIDAndClearsForSystemDefault() {
+        viewModel.selectedMicrophoneDeviceUID = "usb-mic-uid"
+
+        XCTAssertEqual(
+            testDefaults.string(forKey: UserDefaultsAppRuntimePreferences.selectedMicrophoneDeviceUIDKey),
+            "usb-mic-uid"
+        )
+
+        viewModel.selectedMicrophoneDeviceUID = SettingsViewModel.systemDefaultMicrophoneSelection
+
+        XCTAssertNil(testDefaults.string(forKey: UserDefaultsAppRuntimePreferences.selectedMicrophoneDeviceUIDKey))
+    }
+
+    func testSelectedMicrophoneNormalizesBlankSelectionToSystemDefault() {
+        viewModel.selectedMicrophoneDeviceUID = "   "
+
+        XCTAssertEqual(viewModel.selectedMicrophoneDeviceUID, SettingsViewModel.systemDefaultMicrophoneSelection)
+        XCTAssertNil(testDefaults.string(forKey: UserDefaultsAppRuntimePreferences.selectedMicrophoneDeviceUIDKey))
+    }
+
+    func testRefreshMicrophoneDevicesUsesInjectedDevicesAndMarksDefaultFirst() {
+        let vm = SettingsViewModel(
+            defaults: testDefaults,
+            inputDevicesProvider: {
+                [
+                    AudioDeviceManager.InputDevice(
+                        id: 20,
+                        uid: "usb-alpha",
+                        name: "Alpha USB Mic",
+                        transportType: kAudioDeviceTransportTypeUSB
+                    ),
+                    AudioDeviceManager.InputDevice(
+                        id: 10,
+                        uid: "builtin-zed",
+                        name: "Zed Built-In Mic",
+                        transportType: kAudioDeviceTransportTypeBuiltIn
+                    )
+                ]
+            },
+            defaultInputDeviceUIDProvider: { "builtin-zed" }
+        )
+
+        XCTAssertEqual(vm.microphoneDeviceOptions.map(\.uid), ["builtin-zed", "usb-alpha"])
+        XCTAssertEqual(vm.microphoneDeviceOptions.first?.displayName, "Zed Built-In Mic (System Default)")
+        XCTAssertEqual(vm.microphoneDeviceOptions.last?.detail, "usb")
     }
 
     func testMeetingAutoSaveMigratesLegacyTranscriptionSettings() {

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -166,7 +166,7 @@ CREATE INDEX idx_events_session ON events(session);
 | `processing_mode_changed` | `mode` (raw, clean) | Is the clean pipeline valued? |
 | `custom_word_added` | — | Are custom words used? (NOT the word itself) |
 | `snippet_added` | — | Are snippets used? |
-| `setting_changed` | `setting` (save_history, audio_retention, menu_bar_only, hide_pill, save_transcription_audio, speaker_diarization, auto_save, meeting_auto_save, meeting_hotkey, launch_at_login, silence_auto_stop, voice_return) | Which settings get toggled? |
+| `setting_changed` | `setting` (save_history, audio_retention, menu_bar_only, hide_pill, save_transcription_audio, speaker_diarization, auto_save, meeting_auto_save, meeting_hotkey, file_transcription_hotkey, youtube_transcription_hotkey, microphone_selection, launch_at_login, silence_auto_stop, voice_return) | Which settings get toggled? |
 | `telemetry_opted_out` | — | How many opt out? (send this one last event, then stop) |
 
 ### 6. Licensing — "Is the business working?"


### PR DESCRIPTION
## Summary

Closes #116.

This adds an **Audio Input** section in Settings so users can choose either macOS System Default or a specific microphone for both dictation and meeting microphone capture. It also adds a short input test with a live level meter, so users can verify the selected microphone before recording.

Under the hood, MacParakeet now stores the persistent CoreAudio device UID and resolves it to the current `AudioDeviceID` only when capture starts. That matches Apple's documented model: `kAudioDevicePropertyDeviceUID` is the persistent device identifier, while HAL input units are switched by setting `kAudioOutputUnitProperty_CurrentDevice` before reading the input format / installing taps.

Apple refs:
- https://developer.apple.com/documentation/CoreAudio/kAudioDevicePropertyDeviceUID
- https://developer.apple.com/library/archive/technotes/tn2091/_index.html

## Flow

```text
Settings UI
  |
  v
UserDefaults: selectedMicrophoneDeviceUID
  |
  +--> Dictation
  |     AudioProcessor -> AudioRecorder
  |       |
  |       v
  |     UID -> current AudioDeviceID -> AVAudioEngine input unit
  |       |
  |       v
  |     selected mic -> system default -> built-in mic
  |
  +--> Meetings
        MeetingAudioCaptureService -> MicrophoneCapture
          |
          v
        UID -> current AudioDeviceID -> AVAudioEngine input unit
          |
          v
        selected mic, or continue on system default if unavailable
```

## What changed

- Added microphone picker, refresh button, status copy, and input test to Settings.
- Persisted selected microphones by CoreAudio UID instead of unstable `AudioDeviceID` values.
- Threaded the selected-device provider into dictation and meeting microphone capture.
- Preserved existing fallback behavior:
  - Dictation: selected mic -> system default -> built-in mic.
  - Meetings: tries the selected mic and falls back to the normal system-default path if missing or rejected.
- Kept telemetry privacy tight: no microphone UID is sent in telemetry. UIDs are also redacted in OSLog; telemetry records only that the microphone selection setting changed.
- Added focused SettingsViewModel coverage for default selection, persistence, blank normalization, and deterministic device-list/default ordering.

## Test Plan

- `swift build --target MacParakeet`
- `swift test --filter SettingsViewModelTests`
- `swift test --filter AudioRecorderFormatChangeTests`
- `swift test --filter MeetingAudioCaptureServiceTests`
- `swift test --filter MicrophoneCaptureTests`
- `swift test`

Full suite result: 1,524 XCTest tests + 13 Swift Testing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added microphone selection in settings to choose preferred audio input device
  * Added ability to refresh available microphones
  * Added microphone testing feature with real-time input level visualization

* **Documentation**
  * Updated telemetry documentation for setting changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->