### PR TITLE
feat(calendar): pre-name auto-started recordings + fix toast on multi-monitor

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -262,11 +262,12 @@ final class AppEnvironmentConfigurer {
         hotkeyCoordinator.setupYouTubeTranscriptionHotkey()
         dictationCoordinator.showIdlePill()
 
-        // Calendar auto-start (ADR-017 Phase 1 — notify-only). The
-        // coordinator is a no-op when `calendarAutoStartMode == .off` so
-        // it's safe to start unconditionally; we still gate creation on the
-        // meeting-recording feature flag because calendar integration only
-        // makes sense when the user can actually record meetings.
+        // Calendar auto-start (ADR-017 Phases 1 + 2 — reminders +
+        // countdown toast + auto-stop). The coordinator is a no-op when
+        // `calendarAutoStartMode == .off` so it's safe to start
+        // unconditionally; we still gate creation on the meeting-recording
+        // feature flag because calendar integration only makes sense when
+        // the user can actually record meetings.
         let calendarCoordinator: MeetingAutoStartCoordinator?
         if AppFeatures.meetingRecordingEnabled {
             let coordinator = MeetingAutoStartCoordinator(

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -275,8 +275,8 @@ final class AppEnvironmentConfigurer {
                 isRecordingActive: { [weak meetingCoordinator] in
                     meetingCoordinator?.isMeetingRecordingActive ?? false
                 },
-                onAutoStartConfirmed: { [weak meetingCoordinator] in
-                    meetingCoordinator?.startFromCalendar()
+                onAutoStartConfirmed: { [weak meetingCoordinator] title in
+                    meetingCoordinator?.startFromCalendar(title: title)
                 },
                 onAutoStopConfirmed: { [weak meetingCoordinator] in
                     meetingCoordinator?.toggleRecording()

--- a/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
@@ -5,26 +5,27 @@ import MacParakeetViewModels
 import OSLog
 import UserNotifications
 
-/// Polls the user's calendar and surfaces upcoming meetings via macOS
-/// notifications. Phase D (ADR-017 Phase 1) — handles `.reminderDue` only;
-/// `.autoStartDue` / `.lateJoinAvailable` / `.autoStopDue` are recognized by
-/// `MeetingMonitor` but the coordinator no-ops on them. Phase E will wire the
-/// countdown toast and recording trigger.
+/// Polls the user's calendar and routes upcoming meetings to the right
+/// surface (notification / countdown toast / recording flow).
+/// ADR-017 Phases 1 + 2 are wired here; `.lateJoinAvailable` is the only
+/// `MeetingMonitor` event the coordinator still no-ops on (Phase 3
+/// territory — the enum case stays so Phase 3 can wire the late-join
+/// toast without changing `evaluate(...)`).
 ///
 /// ```
-///         ┌──────────────────────┐
-///         │ EKEventStoreChanged  │──┐
-///         └──────────────────────┘  │  immediate
-///                                   ▼
-///   60s/15s/5s adaptive Timer ──▶  poll() ──▶ MeetingMonitor.evaluate(...)
-///                                                       │
-///                                  ┌────────────────────┴────────────────┐
-///                                  ▼                                     ▼
-///                            .reminderDue                  (other cases queued for Phase E)
-///                                  │
-///                                  ▼
-///                       UNUserNotificationCenter
-///                       Telemetry.calendarReminderShown
+///   ┌──────────────────────┐
+///   │ EKEventStoreChanged  │──┐
+///   └──────────────────────┘  │  immediate
+///                             ▼
+///   60s/15s/5s adaptive Timer ──▶ poll() ──▶ MeetingMonitor.evaluate(...)
+///                                                  │
+///                ┌─────────────┬───────────────────┼──────────────────┐
+///                ▼             ▼                   ▼                  ▼
+///         .reminderDue   .autoStartDue       .autoStopDue    .lateJoinAvailable
+///                │             │                   │                  │
+///                ▼             ▼                   ▼              (no-op,
+///   UNUserNotificationCenter   5s countdown   30s countdown      Phase 3)
+///                              toast → start  toast → stop
 /// ```
 @MainActor
 final class MeetingAutoStartCoordinator {

--- a/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
@@ -35,7 +35,11 @@ final class MeetingAutoStartCoordinator {
     /// on `MeetingRecordingFlowCoordinator` (and so tests can stub them).
     /// All Phase 2 wiring goes through these three callbacks.
     private let isRecordingActive: @MainActor () -> Bool
-    private let onAutoStartConfirmed: @MainActor () -> Void
+    /// Called when the user (or countdown completion) commits to starting
+    /// an auto-start recording. The event title is forwarded so the
+    /// recording flow can pre-name the saved transcription with the
+    /// calendar event name instead of the date-based default.
+    private let onAutoStartConfirmed: @MainActor (_ title: String) -> Void
     private let onAutoStopConfirmed: @MainActor () -> Void
     private let toastController: MeetingCountdownToastController
     private let logger = Logger(subsystem: "com.macparakeet", category: "MeetingAutoStart")
@@ -72,7 +76,7 @@ final class MeetingAutoStartCoordinator {
         calendarService: any CalendarServicing = CalendarService.shared,
         settingsViewModel: SettingsViewModel,
         isRecordingActive: @escaping @MainActor () -> Bool = { false },
-        onAutoStartConfirmed: @escaping @MainActor () -> Void = {},
+        onAutoStartConfirmed: @escaping @MainActor (_ title: String) -> Void = { _ in },
         onAutoStopConfirmed: @escaping @MainActor () -> Void = {},
         toastController: MeetingCountdownToastController? = nil
     ) {
@@ -364,7 +368,7 @@ final class MeetingAutoStartCoordinator {
         switch outcome {
         case .completed, .primedEarly:
             autoStartedEventId = event.id
-            onAutoStartConfirmed()
+            onAutoStartConfirmed(event.title)
             logger.info("Auto-start confirmed for event id=\(event.id, privacy: .public) outcome=\(String(describing: outcome), privacy: .public)")
         case .userDismissed:
             dismissedEventIds.insert(event.id)

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -120,6 +120,24 @@ final class MeetingRecordingFlowCoordinator {
         sendEvent(.startRequested)
     }
 
+    /// Discard the pending start context (trigger + title) when the start
+    /// sequence exits without ever reaching the `.startRecording` effect —
+    /// today, only the permissions-denied path. The `.startRecording`
+    /// effect handler clears these inline because it needs to snapshot
+    /// them first to fire telemetry; this helper is for the paths that
+    /// bail out earlier. If the bailing-out start was calendar-driven,
+    /// notifies the calendar coordinator so its `autoStartedEventId`
+    /// binding doesn't strand (it self-heals on the next poll, but
+    /// notifying immediately keeps the two coordinators in lockstep).
+    private func clearPendingStartContext() {
+        let wasCalendarTriggered = pendingTrigger == .calendarAutoStart
+        pendingTrigger = nil
+        pendingTitle = nil
+        if wasCalendarTriggered {
+            onAutoStartFailed?()
+        }
+    }
+
     private func sendEvent(_ event: MeetingRecordingFlowEvent) {
         let effects = stateMachine.handle(event)
         executeEffects(effects)
@@ -150,6 +168,7 @@ final class MeetingRecordingFlowCoordinator {
 
                 if !microphoneGranted {
                     Telemetry.send(.permissionDenied(permission: .microphone))
+                    self.clearPendingStartContext()
                     self.sendEvent(.permissionsDenied(generation: gen, reason: .microphone))
                     return
                 }
@@ -162,6 +181,7 @@ final class MeetingRecordingFlowCoordinator {
                 let screenGranted = existingScreenGrant || permissionService.requestScreenRecordingPermission()
                 if !screenGranted {
                     Telemetry.send(.permissionDenied(permission: .screenRecording))
+                    self.clearPendingStartContext()
                     self.sendEvent(.permissionsDenied(generation: gen, reason: .screenRecording))
                     return
                 }

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -109,9 +109,12 @@ final class MeetingRecordingFlowCoordinator {
     /// event title, then enters the normal start flow. No-op if a recording
     /// is already in progress (manual recording wins by arriving first —
     /// see ADR-017 §10). When non-idle, fires `onAutoStartFailed` so the
-    /// coordinator can drop its binding.
+    /// calendar coordinator can drop its binding, and emits
+    /// `calendar_auto_start_failed{reason=state_busy}` so we can see how
+    /// often back-to-back meetings actually collide in the wild.
     func startFromCalendar(title: String? = nil) {
         guard stateMachine.state == .idle else {
+            Telemetry.send(.calendarAutoStartFailed(reason: "state_busy"))
             onAutoStartFailed?()
             return
         }
@@ -126,14 +129,16 @@ final class MeetingRecordingFlowCoordinator {
     /// effect handler clears these inline because it needs to snapshot
     /// them first to fire telemetry; this helper is for the paths that
     /// bail out earlier. If the bailing-out start was calendar-driven,
-    /// notifies the calendar coordinator so its `autoStartedEventId`
-    /// binding doesn't strand (it self-heals on the next poll, but
-    /// notifying immediately keeps the two coordinators in lockstep).
-    private func clearPendingStartContext() {
+    /// emits `calendar_auto_start_failed{reason}` and notifies the
+    /// calendar coordinator so its `autoStartedEventId` binding doesn't
+    /// strand (it self-heals on the next poll, but notifying immediately
+    /// keeps the two coordinators in lockstep).
+    private func clearPendingStartContext(failureReason: String) {
         let wasCalendarTriggered = pendingTrigger == .calendarAutoStart
         pendingTrigger = nil
         pendingTitle = nil
         if wasCalendarTriggered {
+            Telemetry.send(.calendarAutoStartFailed(reason: failureReason))
             onAutoStartFailed?()
         }
     }
@@ -168,7 +173,7 @@ final class MeetingRecordingFlowCoordinator {
 
                 if !microphoneGranted {
                     Telemetry.send(.permissionDenied(permission: .microphone))
-                    self.clearPendingStartContext()
+                    self.clearPendingStartContext(failureReason: "permission_denied")
                     self.sendEvent(.permissionsDenied(generation: gen, reason: .microphone))
                     return
                 }
@@ -181,7 +186,7 @@ final class MeetingRecordingFlowCoordinator {
                 let screenGranted = existingScreenGrant || permissionService.requestScreenRecordingPermission()
                 if !screenGranted {
                     Telemetry.send(.permissionDenied(permission: .screenRecording))
-                    self.clearPendingStartContext()
+                    self.clearPendingStartContext(failureReason: "permission_denied")
                     self.sendEvent(.permissionsDenied(generation: gen, reason: .screenRecording))
                     return
                 }
@@ -260,8 +265,12 @@ final class MeetingRecordingFlowCoordinator {
                     ))
                     // If this start was driven by calendar auto-start, tell
                     // the coordinator so it can drop the binding it set
-                    // optimistically when the countdown completed.
+                    // optimistically when the countdown completed, and emit
+                    // the dedicated failure event so analysts can see *why*
+                    // (vs just inferring "silent failure" by subtraction
+                    // from `.calendarAutoStartTriggered`).
                     if trigger == .calendarAutoStart {
+                        Telemetry.send(.calendarAutoStartFailed(reason: "service_threw"))
                         self.onAutoStartFailed?()
                     }
                     self.sendEvent(.startFailed(generation: gen, message: error.localizedDescription))

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -78,6 +78,13 @@ final class MeetingRecordingFlowCoordinator {
     /// which sets this and re-enters `toggleRecording`.
     private var pendingTrigger: TelemetryMeetingRecordingTrigger?
 
+    /// Pre-set title for the *next* `.startRecording` effect. Paired with
+    /// `pendingTrigger`: `startFromCalendar(title:)` sets both, the
+    /// `.startRecording` handler snapshots and clears both before the async
+    /// hop. Manual / hotkey starts leave it nil and the service falls back
+    /// to its date-based default.
+    private var pendingTitle: String?
+
     /// Optional callback fired when an auto-start attempt couldn't actually
     /// start a recording — either because the state machine wasn't idle
     /// (back-to-back meeting, previous wrap-up still in progress) or the
@@ -98,16 +105,18 @@ final class MeetingRecordingFlowCoordinator {
     }
 
     /// Calendar-driven entry point. Marks the next start as auto-start so
-    /// telemetry distinguishes it, then enters the normal start flow. No-op
-    /// if a recording is already in progress (manual recording wins by
-    /// arriving first — see ADR-017 §10). When non-idle, fires
-    /// `onAutoStartFailed` so the coordinator can drop its binding.
-    func startFromCalendar() {
+    /// telemetry distinguishes it and pre-names the recording with the
+    /// event title, then enters the normal start flow. No-op if a recording
+    /// is already in progress (manual recording wins by arriving first —
+    /// see ADR-017 §10). When non-idle, fires `onAutoStartFailed` so the
+    /// coordinator can drop its binding.
+    func startFromCalendar(title: String? = nil) {
         guard stateMachine.state == .idle else {
             onAutoStartFailed?()
             return
         }
         pendingTrigger = .calendarAutoStart
+        pendingTitle = title
         sendEvent(.startRequested)
     }
 
@@ -213,12 +222,14 @@ final class MeetingRecordingFlowCoordinator {
         case .startRecording:
             let gen = stateMachine.generation
             // Snapshot + clear before the async hop so a subsequent toggle
-            // can't smuggle a stale trigger into this start's telemetry.
+            // can't smuggle a stale trigger / title into this start.
             let trigger = pendingTrigger
+            let title = pendingTitle
             pendingTrigger = nil
+            pendingTitle = nil
             actionTask = Task { @MainActor in
                 do {
-                    try await meetingRecordingService.startRecording()
+                    try await meetingRecordingService.startRecording(title: title)
                     Telemetry.send(.meetingRecordingStarted(trigger: trigger))
                     self.onRecordingBegan()
                     self.sendEvent(.recordingStarted(generation: gen))

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingCountdownToastController.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingCountdownToastController.swift
@@ -131,7 +131,7 @@ final class MeetingCountdownToastController {
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         panel.contentView = hosting
 
-        if let screen = NSScreen.main {
+        if let screen = Self.screenForToast() {
             // Top-center of the visible frame; sits below the menu bar but
             // above any active app window — makes the countdown impossible
             // to miss without being aggressive.
@@ -172,6 +172,23 @@ final class MeetingCountdownToastController {
         if progress >= 1 {
             finish(.completed)
         }
+    }
+
+    /// Pick the screen the toast should land on, in priority order:
+    ///   1. Screen containing the mouse cursor (where the user is looking
+    ///      *now*, regardless of which app's window has focus).
+    ///   2. `NSScreen.main` (screen with the key window — usually correct
+    ///      but can drift to MacParakeet's own settings panel when it's the
+    ///      active app).
+    ///   3. First connected screen as a last-resort fallback.
+    /// Returning `nil` is theoretically impossible on a launched macOS app
+    /// but the optional keeps the call site defensive.
+    private static func screenForToast() -> NSScreen? {
+        let mouseLocation = NSEvent.mouseLocation
+        if let screen = NSScreen.screens.first(where: { NSMouseInRect(mouseLocation, $0.frame, false) }) {
+            return screen
+        }
+        return NSScreen.main ?? NSScreen.screens.first
     }
 
     private func finish(_ outcome: MeetingCountdownToastOutcome) {

--- a/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
@@ -160,10 +160,15 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         let writer = try MeetingAudioStorageWriter(folderURL: folderURL)
         let chunkFolderURL = folderURL.appendingPathComponent("chunks", isDirectory: true)
         try fileManager.createDirectory(at: chunkFolderURL, withIntermediateDirectories: true)
+        // Single timestamp shared between displayName fallback and
+        // startedAt — back-to-back `Date()` calls would only diverge if
+        // the clock ticked over a minute boundary between them, which is
+        // vanishingly rare but trivially avoidable.
+        let now = Date()
         let session = Session(
             id: sessionID,
-            displayName: Self.resolveDisplayName(title: title, fallbackDate: Date()),
-            startedAt: Date(),
+            displayName: Self.resolveDisplayName(title: title, fallbackDate: now),
+            startedAt: now,
             folderURL: folderURL,
             chunkFolderURL: chunkFolderURL,
             microphoneAudioURL: writer.microphoneAudioURL,

--- a/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
@@ -18,7 +18,10 @@ public enum CaptureMode: Sendable, Equatable {
 }
 
 public protocol MeetingRecordingServiceProtocol: Sendable {
-    func startRecording() async throws
+    /// `title` lets callers (e.g., the calendar auto-start path) pre-name
+    /// the recording. `nil` or whitespace-only falls back to the default
+    /// "Meeting <date>" label.
+    func startRecording(title: String?) async throws
     func stopRecording() async throws -> MeetingRecordingOutput
     func cancelRecording() async
     var isRecording: Bool { get async }
@@ -27,6 +30,14 @@ public protocol MeetingRecordingServiceProtocol: Sendable {
     var elapsedSeconds: Int { get async }
     var captureMode: CaptureMode { get async }
     var transcriptUpdates: AsyncStream<MeetingTranscriptUpdate> { get async }
+}
+
+public extension MeetingRecordingServiceProtocol {
+    /// Existing manual / hotkey callers use the no-arg form — the calendar
+    /// path is the only caller that has a meaningful title to pass.
+    func startRecording() async throws {
+        try await startRecording(title: nil)
+    }
 }
 
 public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
@@ -138,7 +149,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         return stream
     }
 
-    public func startRecording() async throws {
+    public func startRecording(title: String? = nil) async throws {
         guard currentSession == nil else {
             throw MeetingAudioError.alreadyRunning
         }
@@ -151,7 +162,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         try fileManager.createDirectory(at: chunkFolderURL, withIntermediateDirectories: true)
         let session = Session(
             id: sessionID,
-            displayName: Self.makeDisplayName(for: Date()),
+            displayName: Self.resolveDisplayName(title: title, fallbackDate: Date()),
             startedAt: Date(),
             folderURL: folderURL,
             chunkFolderURL: chunkFolderURL,
@@ -636,6 +647,13 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         transcriptContinuation?.finish()
         transcriptContinuation = nil
         cachedTranscriptUpdates = nil
+    }
+
+    private static func resolveDisplayName(title: String?, fallbackDate: Date) -> String {
+        if let trimmed = title?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty {
+            return trimmed
+        }
+        return makeDisplayName(for: fallbackDate)
     }
 
     private static func makeDisplayName(for date: Date) -> String {

--- a/Sources/MacParakeetCore/Services/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/TelemetryEvent.swift
@@ -72,6 +72,7 @@ public enum TelemetryEventName: String, Sendable, CaseIterable {
     case calendarReminderShown = "calendar_reminder_shown"
     case calendarAutoStartTriggered = "calendar_auto_start_triggered"
     case calendarAutoStartCancelled = "calendar_auto_start_cancelled"
+    case calendarAutoStartFailed = "calendar_auto_start_failed"
     case calendarAutoStopShown = "calendar_auto_stop_shown"
     case calendarAutoStopCancelled = "calendar_auto_stop_cancelled"
     // Errors
@@ -274,10 +275,19 @@ public enum TelemetryEventSpec: Sendable {
     /// emits and `MeetingAutoStartCoordinator` actually presents the toast
     /// (after permission + active-recording checks).
     case calendarAutoStartTriggered(leadSeconds: Int, hasMeetUrl: Bool)
-    /// User actively cancelled the countdown before recording started, *or*
-    /// recording failed to start despite the user accepting. `.userCancel`
-    /// vs `.startError` is the distinction worth measuring.
+    /// User actively cancelled the countdown before recording started.
+    /// Currently only fires `reason: "user_cancel"`. System-side
+    /// failures (permission denial, service throw, state-busy) go
+    /// through `calendarAutoStartFailed` instead so the analyst can
+    /// tell "user said no" from "system couldn't" cleanly.
     case calendarAutoStartCancelled(reason: String)
+    /// Auto-start countdown completed but the recording flow couldn't
+    /// actually start. Distinguishes user opt-out from system failure
+    /// — see ADR-017 §10. Reasons:
+    /// - `permission_denied` — user denied mic/screen during the prompt
+    /// - `state_busy` — recording flow was non-idle (back-to-back meeting)
+    /// - `service_threw` — `MeetingRecordingService.startRecording` errored
+    case calendarAutoStartFailed(reason: String)
     /// Auto-stop countdown shown for an event currently being recorded.
     case calendarAutoStopShown(eventDurationSeconds: Double)
     /// User extended past the calendar event's end time (suppressed
@@ -363,6 +373,7 @@ extension TelemetryEventSpec {
         case .calendarReminderShown: return .calendarReminderShown
         case .calendarAutoStartTriggered: return .calendarAutoStartTriggered
         case .calendarAutoStartCancelled: return .calendarAutoStartCancelled
+        case .calendarAutoStartFailed: return .calendarAutoStartFailed
         case .calendarAutoStopShown: return .calendarAutoStopShown
         case .calendarAutoStopCancelled: return .calendarAutoStopCancelled
         case .errorOccurred: return .errorOccurred
@@ -585,6 +596,8 @@ extension TelemetryEventSpec {
             ]
         case .calendarAutoStartCancelled(let reason):
             return ["reason": reason]
+        case .calendarAutoStartFailed(let reason):
+            return ["reason": reason]
         case .calendarAutoStopShown(let eventDurationSeconds):
             return ["event_duration_seconds": Self.format(eventDurationSeconds)]
         case .calendarAutoStopCancelled:
@@ -707,6 +720,7 @@ public enum TelemetryImplementedContract {
         .calendarReminderShown: ["mode", "lead_minutes", "has_meet_url"],
         .calendarAutoStartTriggered: ["lead_seconds", "has_meet_url"],
         .calendarAutoStartCancelled: ["reason"],
+        .calendarAutoStartFailed: ["reason"],
         .calendarAutoStopShown: ["event_duration_seconds"],
         .calendarAutoStopCancelled: [],
         .errorOccurred: ["domain", "code", "description"],

--- a/Tests/MacParakeetTests/Calendar/MeetingAutoStartCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/Calendar/MeetingAutoStartCoordinatorTests.swift
@@ -177,16 +177,26 @@ final class MeetingAutoStartCoordinatorTests: XCTestCase {
         coordinator.start()
         await waitForPoll()
 
-        // Skip the actual countdown — manually invoke the test surface
-        // that the coordinator wires. The countdown UX is covered by
-        // toast-controller tests; here we're testing the coordinator's
-        // outcome plumbing.
-        coordinator.testHook_simulateAutoStartConfirmed(eventId: "evt-1")
+        // Skip the actual countdown — drive the outcome handler directly
+        // with a unique per-run title. The shared `testHook_` helper
+        // hardcodes "Test", which would let the title assertion pass
+        // even if the implementation hardcoded the title instead of
+        // forwarding `event.title`. The countdown UX itself is covered
+        // by toast-controller tests; here we're testing the coordinator's
+        // outcome plumbing only.
+        let uniqueTitle = "Roadmap Sync \(UUID().uuidString.prefix(8))"
+        let event = CalendarEvent(
+            id: "evt-1",
+            title: uniqueTitle,
+            startTime: Date(),
+            endTime: Date().addingTimeInterval(1800)
+        )
+        coordinator.handleAutoStartOutcome(.completed, for: event)
         XCTAssertEqual(autoStartConfirmedCount, 1,
                        "Recording start callback must fire on .completed outcome")
         // Title forwarding: the calendar event name is what the saved
         // recording will be titled, not the date-based default.
-        XCTAssertEqual(autoStartConfirmedTitles, ["Test"],
+        XCTAssertEqual(autoStartConfirmedTitles, [uniqueTitle],
                        "Auto-start must forward the event title so the saved recording is named after the meeting")
 
         coordinator.stop()

--- a/Tests/MacParakeetTests/Calendar/MeetingAutoStartCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/Calendar/MeetingAutoStartCoordinatorTests.swift
@@ -15,6 +15,7 @@ final class MeetingAutoStartCoordinatorTests: XCTestCase {
     /// Tracks calls to the recording-flow callbacks the coordinator makes.
     private var recordingActiveStub = false
     private var autoStartConfirmedCount = 0
+    private var autoStartConfirmedTitles: [String] = []
     private var autoStopConfirmedCount = 0
 
     override func setUp() {
@@ -30,6 +31,7 @@ final class MeetingAutoStartCoordinatorTests: XCTestCase {
         calendarService = MockCalendarService()
         recordingActiveStub = false
         autoStartConfirmedCount = 0
+        autoStartConfirmedTitles = []
         autoStopConfirmedCount = 0
     }
 
@@ -64,7 +66,10 @@ final class MeetingAutoStartCoordinatorTests: XCTestCase {
             calendarService: calendarService,
             settingsViewModel: settingsViewModel,
             isRecordingActive: { [weak self] in self?.recordingActiveStub ?? false },
-            onAutoStartConfirmed: { [weak self] in self?.autoStartConfirmedCount += 1 },
+            onAutoStartConfirmed: { [weak self] title in
+                self?.autoStartConfirmedCount += 1
+                self?.autoStartConfirmedTitles.append(title)
+            },
             onAutoStopConfirmed: { [weak self] in self?.autoStopConfirmedCount += 1 },
             toastController: toastController
         )
@@ -179,6 +184,10 @@ final class MeetingAutoStartCoordinatorTests: XCTestCase {
         coordinator.testHook_simulateAutoStartConfirmed(eventId: "evt-1")
         XCTAssertEqual(autoStartConfirmedCount, 1,
                        "Recording start callback must fire on .completed outcome")
+        // Title forwarding: the calendar event name is what the saved
+        // recording will be titled, not the date-based default.
+        XCTAssertEqual(autoStartConfirmedTitles, ["Test"],
+                       "Auto-start must forward the event title so the saved recording is named after the meeting")
 
         coordinator.stop()
     }

--- a/Tests/MacParakeetTests/Services/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecordingServiceTests.swift
@@ -423,6 +423,57 @@ final class MeetingRecordingServiceTests: XCTestCase {
         XCTAssertLessThanOrEqual(abs(microphoneSpanMs - systemSpanMs), 1_000)
     }
 
+    func testStartRecordingUsesProvidedTitleAsDisplayName() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let audioConverter = MockMeetingAudioFileConverter()
+        let sttClient = CountingMeetingSTTClient()
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: audioConverter,
+            sttTranscriber: sttClient
+        )
+
+        try await service.startRecording(title: "  Q1 Roadmap Standup  ")
+        let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.25))
+        await captureService.yield(.microphoneBuffer(
+            microphoneBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
+        ))
+
+        let output = try await service.stopRecording()
+        defer { try? FileManager.default.removeItem(at: output.folderURL) }
+
+        // Trim is intentional — calendar event titles often have stray
+        // whitespace and the user shouldn't see it surface in their library.
+        XCTAssertEqual(output.displayName, "Q1 Roadmap Standup")
+    }
+
+    func testStartRecordingFallsBackToDateBasedDisplayNameWhenTitleIsBlank() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let audioConverter = MockMeetingAudioFileConverter()
+        let sttClient = CountingMeetingSTTClient()
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: audioConverter,
+            sttTranscriber: sttClient
+        )
+
+        // Whitespace-only title should not pollute the recording name —
+        // we want the same default a manual recording gets.
+        try await service.startRecording(title: "   \n  ")
+        let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.25))
+        await captureService.yield(.microphoneBuffer(
+            microphoneBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
+        ))
+
+        let output = try await service.stopRecording()
+        defer { try? FileManager.default.removeItem(at: output.folderURL) }
+
+        XCTAssertTrue(output.displayName.hasPrefix("Meeting "),
+                      "Expected date-based fallback, got \(output.displayName)")
+    }
+
     private func waitForLiveChunkTranscriptionStart(
         _ client: SleepingMeetingSTTClient,
         timeout: Duration = .seconds(1)

--- a/spec/README.md
+++ b/spec/README.md
@@ -193,6 +193,7 @@ Dictation + transcription + history + settings. Get audio in, text out, pasted i
 - [x] Pre-meeting macOS notifications at configurable lead time (off / 1 / 5 / 10 min)
 - [x] Auto-start countdown toast (ADR-017 Phase 2): 5s cancellable, top-center, non-activating
 - [x] Auto-stop toast at calendar event end (ADR-017 Phase 2): 30s, "Keep Recording" cancels
+- [x] Calendar event title applied to auto-started recordings (instead of date-based default)
 
 ## For AI Coding Assistants
 


### PR DESCRIPTION
## What you'll see

- **Recordings get the meeting's name.** When MacParakeet auto-starts for "Roadmap Sync" on your calendar, the saved recording is titled "Roadmap Sync" — not "Meeting Apr 25, 2026 at 3:45 PM". Manual recordings are unchanged. Whitespace-only titles fall back to the date label.
- **Countdown toast follows the cursor.** The 5s start / 30s end toast lands on the screen with your mouse — not on `NSScreen.main`. Single-monitor: no change. Multi-monitor: no more toast marooned on the wrong display.
- **(Internal) Failure-mode visibility for auto-start.** New `calendar_auto_start_failed{reason}` event tells us *why* a countdown completed without a recording starting (permission denied / state busy / service threw) — no more inferring "silent failures" by event subtraction.

After this lands, the calendar feature is functionally complete. Further iteration is gated on telemetry, not speculation.

## How the title flows

```
 Calendar event "Roadmap Sync"
       │
       │ EventKit poll → 5s countdown toast → completes
       ▼
 onAutoStartConfirmed(title: event.title)
       │
       ▼
 startFromCalendar(title:)            ← MeetingRecordingFlowCoordinator
       │   pendingTitle = "Roadmap Sync"   (paired with pendingTrigger)
       ▼
 .startRecording effect               ← snapshot + clear pending fields
       │
       ▼
 service.startRecording(title:)       ← MeetingRecordingService
       │   resolveDisplayName: trim → use it
       │                       else → "Meeting <date>"
       ▼
 Transcription.fileName = "Roadmap Sync"
       │
       ▼
 Library card · Detail view · Export filename
```

## How the toast picks a screen

```
 NSEvent.mouseLocation
       │
       ├─► screens.first(where: contains cursor)   ← usually wins
       │
       ├─► NSScreen.main                            ← fallback
       │
       └─► NSScreen.screens.first                   ← last resort
```

## How auto-start outcomes route to telemetry

```
 calendar_auto_start_triggered  (toast presented)
                │
        ┌───────┴────────────────────────────────────────┐
        │                                                │
   user lets it complete                          user clicks Cancel
        │                                                │
        ▼                                                ▼
   start sequence runs                       calendar_auto_start_cancelled
        │                                       (reason: user_cancel)
   ┌────┴──────────────────────────────────┐
   │              │             │          │
   ▼              ▼             ▼          ▼
 happy path  permission     state busy  service throws
 succeeds    denied         (back-to-   (rare)
   │             │           back)         │
   │             ▼             ▼           ▼
   │   calendar_auto_start_failed{reason=…}
   ▼
 meeting_recording_started{trigger=calendar_auto_start}
```

## Code surface (6 commits)

1. **`feat(calendar): pre-name auto-started recordings with the event title`** — `MeetingRecordingServiceProtocol.startRecording(title:)` is the new requirement; a protocol extension preserves the no-arg `startRecording()` for manual / hotkey paths so existing callers don't change. Coordinator plumbs title via `pendingTitle` (parallel to `pendingTrigger`). `MeetingAutoStartCoordinator.onAutoStartConfirmed` callback gains `_ title: String` and forwards `event.title`.
2. **`fix(calendar): place countdown toast on the screen with the cursor`** — single `screenForToast()` helper added to `MeetingCountdownToastController`.
3. **`fix(calendar): clear pending start context when permissions are denied`** — Codex review caught a leak: when calendar auto-start triggers a permission prompt and the user denies, `pendingTitle` and `pendingTrigger` were never cleared. The next manual start would inherit the stale title AND be tagged with the wrong telemetry trigger. Pre-existing for `pendingTrigger` since #132; the title work widened it. Now cleared on both denial branches via a new `clearPendingStartContext()` helper that also notifies `onAutoStartFailed` for calendar-driven attempts. Test sharpened to use a UUID-suffixed title.
4. **`feat(telemetry): add calendar_auto_start_failed for failure-mode visibility`** — new event with `reason ∈ {permission_denied, state_busy, service_threw}` so we can act on what we see instead of subtracting events to guess at silent failure rates.
5. **`fix(meeting): share a single Date() between displayName and startedAt`** — Gemini nit: avoid back-to-back `Date()` calls that could (vanishingly rarely) diverge across a minute boundary.
6. **`docs(calendar): refresh stale Phase 1 / Phase D comments`** — Codex nit: file headers in `MeetingAutoStartCoordinator` and `AppEnvironmentConfigurer` still described notify-only Phase 1 behavior. Refreshed to reflect that Phase 2 is wired.

## ⚠️ Deploy ordering (two-repo)

The new `calendar_auto_start_failed` event needs the matching allowlist entry in the Cloudflare Worker, otherwise:

1. The Worker rejects the *entire batch* (not just the new event) with HTTP 400.
2. The client treats the batch as failed and retries in memory only.
3. On app termination, the unsent batch is **dropped permanently** — no on-disk durability for telemetry.

So merging this Swift PR before the website worker is updated risks silently losing other valid telemetry events that happen to be co-batched with the new one.

- ✅ Website allowlist already pushed: [moona3k/macparakeet-website@7df8949](https://github.com/moona3k/macparakeet-website/commit/7df8949)
- 🚦 **Deploy that website commit BEFORE merging this PR.**
  ```sh
  cd ~/code/macparakeet-website && \
    npx astro build && \
    npx wrangler pages deploy dist --project-name macparakeet-website --branch main
  ```
- 🔍 **Verify** allowlist after deploy:
  ```sh
  curl -X POST https://macparakeet.com/api/telemetry \
    -H 'Content-Type: application/json' \
    -d '{"events":[{"event_id":"smoke","event":"calendar_auto_start_failed","props":{"reason":"smoke_test"},"app_ver":"0","os_ver":"0","session":"smoke","ts":"2026-04-25T00:00:00Z"}]}'
  # Expect: HTTP 200; HTTP 400 "Unknown event" means the deploy didn't take.
  ```

## Test plan

- [x] `swift test --parallel` — 1523 tests, exit 0
- [x] Service: title-with-whitespace lands trimmed; whitespace-only falls back to the date default
- [x] Coordinator: `event.title` forwarded through callback (UUID-suffixed assertion)
- [x] Telemetry contract: required-props validator passes for `calendar_auto_start_failed`
- [x] Two parallel fresh-eye reviews (Codex, Gemini) — both LGTM, all findings addressed (this PR description sharpened per Codex; stale comments refreshed in commit 6)
- [ ] **Manual multi-monitor smoke** — 2-display setup; verify toast lands under cursor
- [ ] **End-to-end** — schedule a meeting "Roadmap Sync" 2 min out with auto-start enabled; confirm library card shows that name (not the date default), and the 30s auto-stop toast fires correctly
- [ ] **Permission-denied telemetry** — manual: revoke mic permission, trigger auto-start, verify `calendar_auto_start_failed{reason=permission_denied}` appears in the next batch (after worker is deployed)

## Out of scope (deferred per planning)

`.lateJoinAvailable` UI · `.transcribing` back-to-back race · auto-stop stuck-toast safety valve · retro-link (manual → calendar) · Phone / FaceTime URL extraction. Each cut for a reason; revival is telemetry-driven (now actually possible thanks to commit 4). ADR-017 Phase 3 stays PROPOSED — not changing the ADR.

## Followup noted

`AutoSaveService` still uses a hardcoded `"Meeting"` filename stem. Calendar-titled recordings could ride that through too — separate PR if it matters.

## Telemetry to watch

- `calendar_auto_start_failed{reason}` — direct failure-mode signal; replaces "subtract for silent failure rate"
- `calendar_auto_start_cancelled{reason=user_cancel}` — is the 5s countdown too short?
- `mode=autoStart` vs `mode=notify` adoption — do users opt up from notify?

🤖 Generated with [Claude Code](https://claude.com/claude-code)