### PR TITLE
Add CLI audio input diagnostics

### DIFF
--- a/Sources/CLI/Commands/AudioInputDiagnostics.swift
+++ b/Sources/CLI/Commands/AudioInputDiagnostics.swift
@@ -1,0 +1,137 @@
+import CoreAudio
+import Foundation
+import MacParakeetCore
+
+struct AudioInputDiagnostics {
+    let devices: [AudioDeviceManager.InputDevice]
+    let defaultDevice: AudioDeviceManager.InputDevice?
+    let storedSelectedUID: String?
+
+    var selectedDevice: AudioDeviceManager.InputDevice? {
+        guard let storedSelectedUID else { return nil }
+        return devices.first { $0.uid == storedSelectedUID }
+    }
+
+    var builtInDevice: AudioDeviceManager.InputDevice? {
+        devices.first(where: \.isBuiltIn)
+    }
+
+    var fallbackOrder: [AudioDeviceManager.InputDevice] {
+        var result: [AudioDeviceManager.InputDevice] = []
+        var seenIDs = Set<AudioDeviceID>()
+
+        func append(_ device: AudioDeviceManager.InputDevice?) {
+            guard let device, seenIDs.insert(device.id).inserted else { return }
+            result.append(device)
+        }
+
+        append(selectedDevice)
+        append(defaultDevice)
+        append(builtInDevice)
+        return result
+    }
+}
+
+func loadAudioInputDiagnostics(
+    defaults: UserDefaults = UserDefaults(suiteName: "com.macparakeet") ?? .standard,
+    inputDevices: () -> [AudioDeviceManager.InputDevice] = { AudioDeviceManager.inputDevices() },
+    defaultInputDeviceInfo: () -> AudioDeviceManager.InputDevice? = {
+        AudioDeviceManager.defaultInputDeviceInfo()
+    }
+) -> AudioInputDiagnostics {
+    let preferences = UserDefaultsAppRuntimePreferences(defaults: defaults)
+    return AudioInputDiagnostics(
+        devices: inputDevices(),
+        defaultDevice: defaultInputDeviceInfo(),
+        storedSelectedUID: preferences.selectedMicrophoneDeviceUID
+    )
+}
+
+func printAudioInputDiagnostics(_ diagnostics: AudioInputDiagnostics) {
+    for line in audioInputDiagnosticsLines(diagnostics) {
+        print(line)
+    }
+}
+
+func audioInputDiagnosticsLines(_ diagnostics: AudioInputDiagnostics) -> [String] {
+    var lines = [String]()
+
+    lines.append("  System default: \(formatOptionalDevice(diagnostics.defaultDevice))")
+
+    if diagnostics.storedSelectedUID != nil {
+        if let selectedDevice = diagnostics.selectedDevice {
+            lines.append(
+                "  Stored selection: \(formatDevice(selectedDevice, markers: ["selected", "available"]))"
+            )
+        } else {
+            lines.append("  Stored selection: Unavailable (stored device is not currently connected)")
+        }
+    } else {
+        lines.append("  Stored selection: System Default")
+    }
+
+    if diagnostics.fallbackOrder.isEmpty {
+        lines.append("  Effective fallback order: None")
+    } else {
+        lines.append("  Effective fallback order:")
+        for (index, device) in diagnostics.fallbackOrder.enumerated() {
+            let markers = fallbackMarkers(for: device, diagnostics: diagnostics)
+            lines.append("    \(index + 1). \(formatDevice(device, markers: markers))")
+        }
+    }
+
+    if diagnostics.devices.isEmpty {
+        lines.append("  Devices: None reported by CoreAudio")
+    } else {
+        lines.append("  Devices:")
+        for device in diagnostics.devices {
+            let markers = deviceMarkers(for: device, diagnostics: diagnostics)
+            lines.append("    - \(formatDevice(device, markers: markers))")
+        }
+    }
+
+    return lines
+}
+
+private func fallbackMarkers(
+    for device: AudioDeviceManager.InputDevice,
+    diagnostics: AudioInputDiagnostics
+) -> [String] {
+    if diagnostics.selectedDevice?.id == device.id {
+        return ["selected"]
+    }
+    if diagnostics.defaultDevice?.id == device.id {
+        return ["system default"]
+    }
+    if diagnostics.builtInDevice?.id == device.id {
+        return ["built-in fallback"]
+    }
+    return []
+}
+
+private func deviceMarkers(
+    for device: AudioDeviceManager.InputDevice,
+    diagnostics: AudioInputDiagnostics
+) -> [String] {
+    var markers = [String]()
+    if diagnostics.defaultDevice?.id == device.id {
+        markers.append("default")
+    }
+    if diagnostics.selectedDevice?.id == device.id {
+        markers.append("selected")
+    }
+    return markers
+}
+
+private func formatOptionalDevice(_ device: AudioDeviceManager.InputDevice?) -> String {
+    guard let device else { return "Unavailable" }
+    return formatDevice(device)
+}
+
+private func formatDevice(
+    _ device: AudioDeviceManager.InputDevice,
+    markers: [String] = []
+) -> String {
+    let tags = ([device.transportLabel] + markers).joined(separator: ", ")
+    return "\(device.name) [\(tags)]"
+}

--- a/Sources/CLI/Commands/AudioInputDiagnostics.swift
+++ b/Sources/CLI/Commands/AudioInputDiagnostics.swift
@@ -33,7 +33,7 @@ struct AudioInputDiagnostics {
 }
 
 func loadAudioInputDiagnostics(
-    defaults: UserDefaults = UserDefaults(suiteName: "com.macparakeet") ?? .standard,
+    defaults: UserDefaults = UserDefaults(suiteName: "com.macparakeet.MacParakeet") ?? .standard,
     inputDevices: () -> [AudioDeviceManager.InputDevice] = { AudioDeviceManager.inputDevices() },
     defaultInputDeviceInfo: () -> AudioDeviceManager.InputDevice? = {
         AudioDeviceManager.defaultInputDeviceInfo()
@@ -97,16 +97,17 @@ private func fallbackMarkers(
     for device: AudioDeviceManager.InputDevice,
     diagnostics: AudioInputDiagnostics
 ) -> [String] {
+    var markers = [String]()
     if diagnostics.selectedDevice?.id == device.id {
-        return ["selected"]
+        markers.append("selected")
     }
     if diagnostics.defaultDevice?.id == device.id {
-        return ["system default"]
+        markers.append("system default")
     }
     if diagnostics.builtInDevice?.id == device.id {
-        return ["built-in fallback"]
+        markers.append("built-in fallback")
     }
-    return []
+    return markers
 }
 
 private func deviceMarkers(

--- a/Sources/CLI/Commands/AudioInputDiagnostics.swift
+++ b/Sources/CLI/Commands/AudioInputDiagnostics.swift
@@ -33,7 +33,7 @@ struct AudioInputDiagnostics {
 }
 
 func loadAudioInputDiagnostics(
-    defaults: UserDefaults = UserDefaults(suiteName: "com.macparakeet.MacParakeet") ?? .standard,
+    defaults: UserDefaults = macParakeetAppDefaults(),
     inputDevices: () -> [AudioDeviceManager.InputDevice] = { AudioDeviceManager.inputDevices() },
     defaultInputDeviceInfo: () -> AudioDeviceManager.InputDevice? = {
         AudioDeviceManager.defaultInputDeviceInfo()
@@ -116,7 +116,7 @@ private func deviceMarkers(
 ) -> [String] {
     var markers = [String]()
     if diagnostics.defaultDevice?.id == device.id {
-        markers.append("default")
+        markers.append("system default")
     }
     if diagnostics.selectedDevice?.id == device.id {
         markers.append("selected")

--- a/Sources/CLI/Commands/CLIHelpers.swift
+++ b/Sources/CLI/Commands/CLIHelpers.swift
@@ -1,6 +1,12 @@
 import Foundation
 import MacParakeetCore
 
+let macParakeetAppDefaultsSuiteName = "com.macparakeet.MacParakeet"
+
+func macParakeetAppDefaults() -> UserDefaults {
+    UserDefaults(suiteName: macParakeetAppDefaultsSuiteName) ?? .standard
+}
+
 // MARK: - Database Path Resolution
 
 func resolvedDatabasePath(_ database: String?) -> String {

--- a/Sources/CLI/Commands/HealthCommand.swift
+++ b/Sources/CLI/Commands/HealthCommand.swift
@@ -68,7 +68,12 @@ struct HealthCommand: AsyncParsableCommand {
         }
         print()
 
-        // 4. Local speech stack
+        // 4. Audio input
+        print("Audio Input:")
+        printAudioInputDiagnostics(loadAudioInputDiagnostics())
+        print()
+
+        // 5. Local speech stack
         print("Local Speech Stack:")
         let sttClient = STTClient()
         let diarizationService = DiarizationService()
@@ -96,7 +101,7 @@ struct HealthCommand: AsyncParsableCommand {
         await sttClient.shutdown()
         print()
 
-        // 5. Bundled FFmpeg
+        // 6. Bundled FFmpeg
         print("FFmpeg:")
         if let ffmpegPath = BinaryBootstrap.resolveRuntimeFFmpegPath() {
             if ffmpegPath == AppPaths.bundledFFmpegPath() {
@@ -109,7 +114,7 @@ struct HealthCommand: AsyncParsableCommand {
         }
         print()
 
-        // 6. yt-dlp managed binary
+        // 7. yt-dlp managed binary
         print("yt-dlp:")
         let bootstrap = BinaryBootstrap()
         do {
@@ -120,7 +125,7 @@ struct HealthCommand: AsyncParsableCommand {
         }
         print()
 
-        // 7. Calendar (EventKit) — agents can't see TCC dialogs from the
+        // 8. Calendar (EventKit) — agents can't see TCC dialogs from the
         // GUI, so the CLI surface lets them check authorization status
         // headlessly during dev iteration.
         print("Calendar (EventKit):")

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -72,8 +72,6 @@ struct TranscribeCommand: AsyncParsableCommand {
         }
 
         let diarizationService: DiarizationService? = noDiarize ? nil : DiarizationService()
-        let appDefaultsSuiteName = "com.macparakeet"
-
         let service = TranscriptionService(
             audioProcessor: audioProcessor,
             sttTranscriber: sttClient,
@@ -82,7 +80,7 @@ struct TranscribeCommand: AsyncParsableCommand {
             customWordRepo: customWordRepo,
             snippetRepo: snippetRepo,
             processingMode: {
-                let defaults = UserDefaults(suiteName: appDefaultsSuiteName) ?? UserDefaults.standard
+                let defaults = macParakeetAppDefaults()
                 return Self.resolveProcessingMode(self.mode, storedMode: defaults.string(forKey: "processingMode"))
             },
             shouldKeepDownloadedAudio: {
@@ -92,7 +90,7 @@ struct TranscribeCommand: AsyncParsableCommand {
                 case .delete:
                     return false
                 case .appDefault:
-                    let defaults = UserDefaults(suiteName: appDefaultsSuiteName) ?? UserDefaults.standard
+                    let defaults = macParakeetAppDefaults()
                     return defaults.object(forKey: "saveTranscriptionAudio") as? Bool ?? true
                 }
             },

--- a/Tests/CLITests/ModelLifecycleCommandTests.swift
+++ b/Tests/CLITests/ModelLifecycleCommandTests.swift
@@ -130,7 +130,7 @@ final class ModelLifecycleCommandTests: XCTestCase {
         XCTAssertFalse(lines.joined(separator: "\n").contains("missing-secret-uid"))
         XCTAssertEqual(
             lines.filter { $0.trimmingCharacters(in: .whitespaces).hasPrefix("1.") },
-            ["    1. MacBook Pro Microphone [built-in, system default]"]
+            ["    1. MacBook Pro Microphone [built-in, system default, built-in fallback]"]
         )
     }
 
@@ -153,11 +153,89 @@ final class ModelLifecycleCommandTests: XCTestCase {
                 "  System default: MacBook Pro Microphone [built-in]",
                 "  Stored selection: System Default",
                 "  Effective fallback order:",
-                "    1. MacBook Pro Microphone [built-in, system default]",
+                "    1. MacBook Pro Microphone [built-in, system default, built-in fallback]",
                 "  Devices:",
                 "    - MacBook Pro Microphone [built-in, default]",
             ]
         )
+    }
+
+    func testAudioInputDiagnosticsMarksSelectedDeviceThatIsAlsoSystemDefault() {
+        let selectedDefault = inputDevice(
+            id: 10,
+            uid: "usb-mic",
+            name: "Desk USB Mic",
+            transport: kAudioDeviceTransportTypeUSB
+        )
+        let builtIn = inputDevice(
+            id: 30,
+            uid: "builtin-mic",
+            name: "MacBook Pro Microphone",
+            transport: kAudioDeviceTransportTypeBuiltIn
+        )
+        let diagnostics = AudioInputDiagnostics(
+            devices: [selectedDefault, builtIn],
+            defaultDevice: selectedDefault,
+            storedSelectedUID: "usb-mic"
+        )
+
+        XCTAssertEqual(
+            audioInputDiagnosticsLines(diagnostics),
+            [
+                "  System default: Desk USB Mic [usb]",
+                "  Stored selection: Desk USB Mic [usb, selected, available]",
+                "  Effective fallback order:",
+                "    1. Desk USB Mic [usb, selected, system default]",
+                "    2. MacBook Pro Microphone [built-in, built-in fallback]",
+                "  Devices:",
+                "    - Desk USB Mic [usb, default, selected]",
+                "    - MacBook Pro Microphone [built-in]",
+            ]
+        )
+    }
+
+    func testLoadAudioInputDiagnosticsUsesInjectedDefaultsAndProviders() {
+        let suiteName = "com.macparakeet.tests.cli.audio.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set("usb-mic", forKey: UserDefaultsAppRuntimePreferences.selectedMicrophoneDeviceUIDKey)
+
+        let selected = inputDevice(
+            id: 10,
+            uid: "usb-mic",
+            name: "Desk USB Mic",
+            transport: kAudioDeviceTransportTypeUSB
+        )
+        let defaultDevice = inputDevice(
+            id: 20,
+            uid: "conference-mic",
+            name: "Conference Mic",
+            transport: kAudioDeviceTransportTypeBluetooth
+        )
+        var inputDevicesCalls = 0
+        var defaultInputDeviceInfoCalls = 0
+
+        let diagnostics = loadAudioInputDiagnostics(
+            defaults: defaults,
+            inputDevices: {
+                inputDevicesCalls += 1
+                return [selected, defaultDevice]
+            },
+            defaultInputDeviceInfo: {
+                defaultInputDeviceInfoCalls += 1
+                return defaultDevice
+            }
+        )
+
+        XCTAssertEqual(inputDevicesCalls, 1)
+        XCTAssertEqual(defaultInputDeviceInfoCalls, 1)
+        XCTAssertEqual(diagnostics.devices.map(\.uid), ["usb-mic", "conference-mic"])
+        XCTAssertEqual(diagnostics.defaultDevice?.uid, "conference-mic")
+        XCTAssertEqual(diagnostics.storedSelectedUID, "usb-mic")
+        XCTAssertEqual(diagnostics.selectedDevice?.uid, "usb-mic")
+        XCTAssertEqual(diagnostics.fallbackOrder.map(\.uid), ["usb-mic", "conference-mic"])
     }
 }
 

--- a/Tests/CLITests/ModelLifecycleCommandTests.swift
+++ b/Tests/CLITests/ModelLifecycleCommandTests.swift
@@ -105,7 +105,7 @@ final class ModelLifecycleCommandTests: XCTestCase {
                 "    3. MacBook Pro Microphone [built-in, built-in fallback]",
                 "  Devices:",
                 "    - Desk USB Mic [usb, selected]",
-                "    - Conference Mic [bluetooth, default]",
+                "    - Conference Mic [bluetooth, system default]",
                 "    - MacBook Pro Microphone [built-in]",
             ]
         )
@@ -155,7 +155,7 @@ final class ModelLifecycleCommandTests: XCTestCase {
                 "  Effective fallback order:",
                 "    1. MacBook Pro Microphone [built-in, system default, built-in fallback]",
                 "  Devices:",
-                "    - MacBook Pro Microphone [built-in, default]",
+                "    - MacBook Pro Microphone [built-in, system default]",
             ]
         )
     }
@@ -188,7 +188,7 @@ final class ModelLifecycleCommandTests: XCTestCase {
                 "    1. Desk USB Mic [usb, selected, system default]",
                 "    2. MacBook Pro Microphone [built-in, built-in fallback]",
                 "  Devices:",
-                "    - Desk USB Mic [usb, default, selected]",
+                "    - Desk USB Mic [usb, system default, selected]",
                 "    - MacBook Pro Microphone [built-in]",
             ]
         )

--- a/Tests/CLITests/ModelLifecycleCommandTests.swift
+++ b/Tests/CLITests/ModelLifecycleCommandTests.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import CoreAudio
 import XCTest
 @testable import MacParakeetCore
 @testable import CLI
@@ -67,6 +68,111 @@ final class ModelLifecycleCommandTests: XCTestCase {
         )
         XCTAssertEqual(status.summary, "Speech model present, speaker models missing")
     }
+
+    func testAudioInputDiagnosticsShowsSelectedDefaultAndFallbackOrder() {
+        let selected = inputDevice(
+            id: 10,
+            uid: "usb-mic",
+            name: "Desk USB Mic",
+            transport: kAudioDeviceTransportTypeUSB
+        )
+        let defaultDevice = inputDevice(
+            id: 20,
+            uid: "conference-mic",
+            name: "Conference Mic",
+            transport: kAudioDeviceTransportTypeBluetooth
+        )
+        let builtIn = inputDevice(
+            id: 30,
+            uid: "builtin-mic",
+            name: "MacBook Pro Microphone",
+            transport: kAudioDeviceTransportTypeBuiltIn
+        )
+        let diagnostics = AudioInputDiagnostics(
+            devices: [selected, defaultDevice, builtIn],
+            defaultDevice: defaultDevice,
+            storedSelectedUID: "usb-mic"
+        )
+
+        XCTAssertEqual(
+            audioInputDiagnosticsLines(diagnostics),
+            [
+                "  System default: Conference Mic [bluetooth]",
+                "  Stored selection: Desk USB Mic [usb, selected, available]",
+                "  Effective fallback order:",
+                "    1. Desk USB Mic [usb, selected]",
+                "    2. Conference Mic [bluetooth, system default]",
+                "    3. MacBook Pro Microphone [built-in, built-in fallback]",
+                "  Devices:",
+                "    - Desk USB Mic [usb, selected]",
+                "    - Conference Mic [bluetooth, default]",
+                "    - MacBook Pro Microphone [built-in]",
+            ]
+        )
+    }
+
+    func testAudioInputDiagnosticsReportsUnavailableStoredSelectionWithoutUID() {
+        let defaultDevice = inputDevice(
+            id: 20,
+            uid: "builtin-mic",
+            name: "MacBook Pro Microphone",
+            transport: kAudioDeviceTransportTypeBuiltIn
+        )
+        let diagnostics = AudioInputDiagnostics(
+            devices: [defaultDevice],
+            defaultDevice: defaultDevice,
+            storedSelectedUID: "missing-secret-uid"
+        )
+
+        let lines = audioInputDiagnosticsLines(diagnostics)
+
+        XCTAssertTrue(lines.contains("  Stored selection: Unavailable (stored device is not currently connected)"))
+        XCTAssertFalse(lines.joined(separator: "\n").contains("missing-secret-uid"))
+        XCTAssertEqual(
+            lines.filter { $0.trimmingCharacters(in: .whitespaces).hasPrefix("1.") },
+            ["    1. MacBook Pro Microphone [built-in, system default]"]
+        )
+    }
+
+    func testAudioInputDiagnosticsDeduplicatesDefaultBuiltInFallback() {
+        let builtInDefault = inputDevice(
+            id: 30,
+            uid: "builtin-mic",
+            name: "MacBook Pro Microphone",
+            transport: kAudioDeviceTransportTypeBuiltIn
+        )
+        let diagnostics = AudioInputDiagnostics(
+            devices: [builtInDefault],
+            defaultDevice: builtInDefault,
+            storedSelectedUID: nil
+        )
+
+        XCTAssertEqual(
+            audioInputDiagnosticsLines(diagnostics),
+            [
+                "  System default: MacBook Pro Microphone [built-in]",
+                "  Stored selection: System Default",
+                "  Effective fallback order:",
+                "    1. MacBook Pro Microphone [built-in, system default]",
+                "  Devices:",
+                "    - MacBook Pro Microphone [built-in, default]",
+            ]
+        )
+    }
+}
+
+private func inputDevice(
+    id: AudioDeviceID,
+    uid: String,
+    name: String,
+    transport: UInt32
+) -> AudioDeviceManager.InputDevice {
+    AudioDeviceManager.InputDevice(
+        id: id,
+        uid: uid,
+        name: name,
+        transportType: transport
+    )
 }
 
 private actor StubSTTClient: STTClientProtocol {


### PR DESCRIPTION
## Summary

Adds read-only audio input diagnostics to `macparakeet-cli health` so support/debug sessions can see the active microphone state without asking users to inspect Settings manually.

The new health section reports:

- current system default input device
- stored microphone selection and whether it is available
- effective fallback order used by capture startup (`selected -> system default -> built-in`)
- visible CoreAudio input devices with transport/default/selected markers

No CLI setting or microphone test command is added. This keeps the surface diagnostic-only and avoids TCC/audio-behavior confusion between the app bundle and the CLI binary.

```text
macparakeet-cli health
        |
        v
UserDefaults(com.macparakeet) ---- selected UID?
        |
        v
AudioDeviceManager.inputDevices() ---- default/built-in lookup
        |
        v
Audio Input health section
        |
        +-- System default
        +-- Stored selection availability
        +-- Effective fallback order
        +-- Device list
```

## Test Plan

- `swift build --target CLI`
- `swift test --filter ModelLifecycleCommandTests`
- `swift test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The health command now includes audio input diagnostics, displaying your system's default microphone, currently selected audio device, connection status, and available fallback options to assist with audio troubleshooting and configuration verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->