### PR TITLE
feat(cli): prompts subcommand + structured JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 </p>
 
 <p align="center">
+  <a href="https://deepwiki.com/moona3k/macparakeet"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-GPL--3.0-blue.svg" alt="GPL-3.0 License"></a>
   <img src="https://img.shields.io/badge/macOS-14.2%2B-000000.svg" alt="macOS 14.2+">
   <img src="https://img.shields.io/badge/Swift-6.0-F05138.svg" alt="Swift 6">

--- a/Sources/CLI/Commands/CLIHelpers.swift
+++ b/Sources/CLI/Commands/CLIHelpers.swift
@@ -82,3 +82,52 @@ func findDictation(id: String, repo: DictationRepository) throws -> Dictation {
     }
     return match
 }
+
+// MARK: - Prompt Lookup
+
+/// Resolves a prompt by exact UUID, UUID prefix, or case-insensitive name.
+/// Names are checked only when no UUID-prefix match was found, so an ambiguous
+/// prefix surfaces as such instead of silently falling through to a name match.
+func findPrompt(idOrName: String, repo: PromptRepository) throws -> Prompt {
+    let trimmed = idOrName.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { throw CLILookupError.emptyID }
+
+    if let uuid = UUID(uuidString: trimmed), let prompt = try repo.fetch(id: uuid) {
+        return prompt
+    }
+
+    let all = try repo.fetchAll()
+    let lowered = trimmed.lowercased()
+
+    let prefixMatches = all.filter { $0.id.uuidString.lowercased().hasPrefix(lowered) }
+    if prefixMatches.count == 1 { return prefixMatches[0] }
+    if prefixMatches.count > 1 {
+        throw CLILookupError.ambiguous("Multiple prompts match '\(trimmed)' as ID prefix. Be more specific.")
+    }
+
+    let nameMatches = all.filter { $0.name.lowercased() == lowered }
+    if nameMatches.count == 1 { return nameMatches[0] }
+    if nameMatches.count > 1 {
+        throw CLILookupError.ambiguous("Multiple prompts named '\(trimmed)'. Use ID instead.")
+    }
+
+    throw CLILookupError.notFound("No prompt matching '\(trimmed)'")
+}
+
+// MARK: - JSON Output
+
+/// Single source of truth for CLI JSON output. Matches the convention established
+/// by `calendar upcoming --json`: ISO-8601 dates, sorted keys, pretty-printed.
+let cliJSONEncoder: JSONEncoder = {
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    return encoder
+}()
+
+func printJSON<T: Encodable>(_ value: T) throws {
+    let data = try cliJSONEncoder.encode(value)
+    if let s = String(data: data, encoding: .utf8) {
+        print(s)
+    }
+}

--- a/Sources/CLI/Commands/FlowSnippetsCommand.swift
+++ b/Sources/CLI/Commands/FlowSnippetsCommand.swift
@@ -20,11 +20,22 @@ struct FlowSnippetsCommand: AsyncParsableCommand {
             abstract: "List all text snippets."
         )
 
+        @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+        var json: Bool = false
+
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
         func run() async throws {
             try AppPaths.ensureDirectories()
-            let dbManager = try DatabaseManager(path: AppPaths.databasePath)
+            let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
             let repo = TextSnippetRepository(dbQueue: dbManager.dbQueue)
             let snippets = try repo.fetchAll()
+
+            if json {
+                try printJSON(snippets)
+                return
+            }
 
             if snippets.isEmpty {
                 print("No text snippets configured.")
@@ -56,9 +67,12 @@ struct FlowSnippetsCommand: AsyncParsableCommand {
         @Argument(help: "The expansion text.")
         var expansion: String
 
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
         func run() async throws {
             try AppPaths.ensureDirectories()
-            let dbManager = try DatabaseManager(path: AppPaths.databasePath)
+            let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
             let repo = TextSnippetRepository(dbQueue: dbManager.dbQueue)
 
             let snippet = TextSnippet(trigger: trigger, expansion: expansion)
@@ -77,9 +91,12 @@ struct FlowSnippetsCommand: AsyncParsableCommand {
         @Argument(help: "The UUID (or prefix) of the snippet to delete.")
         var id: String
 
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
         func run() async throws {
             try AppPaths.ensureDirectories()
-            let dbManager = try DatabaseManager(path: AppPaths.databasePath)
+            let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
             let repo = TextSnippetRepository(dbQueue: dbManager.dbQueue)
 
             // Support UUID prefix matching

--- a/Sources/CLI/Commands/FlowWordsCommand.swift
+++ b/Sources/CLI/Commands/FlowWordsCommand.swift
@@ -17,14 +17,38 @@ struct FlowWordsCommand: AsyncParsableCommand {
     struct ListWords: AsyncParsableCommand {
         static let configuration = CommandConfiguration(
             commandName: "list",
-            abstract: "List all custom words."
+            abstract: "List custom words."
         )
+
+        enum SourceFilter: String, ExpressibleByArgument {
+            case all, manual, learned
+        }
+
+        @Option(name: .long, help: "Filter by source: all, manual, learned. Default: all.")
+        var source: SourceFilter = .all
+
+        @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+        var json: Bool = false
+
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
 
         func run() async throws {
             try AppPaths.ensureDirectories()
-            let dbManager = try DatabaseManager(path: AppPaths.databasePath)
+            let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
             let repo = CustomWordRepository(dbQueue: dbManager.dbQueue)
-            let words = try repo.fetchAll()
+            let all = try repo.fetchAll()
+            let words: [CustomWord]
+            switch source {
+            case .all:     words = all
+            case .manual:  words = all.filter { $0.source == .manual }
+            case .learned: words = all.filter { $0.source == .learned }
+            }
+
+            if json {
+                try printJSON(words)
+                return
+            }
 
             if words.isEmpty {
                 print("No custom words configured.")
@@ -34,9 +58,9 @@ struct FlowWordsCommand: AsyncParsableCommand {
             for word in words {
                 let status = word.isEnabled ? "+" : "-"
                 if let replacement = word.replacement {
-                    print("[\(status)] \(word.word) -> \(replacement)  (\(word.id.uuidString.prefix(8)))")
+                    print("[\(status)] \(word.word) -> \(replacement)  [\(word.source.rawValue)]  (\(word.id.uuidString.prefix(8)))")
                 } else {
-                    print("[\(status)] \(word.word) (anchor)  (\(word.id.uuidString.prefix(8)))")
+                    print("[\(status)] \(word.word) (anchor)  [\(word.source.rawValue)]  (\(word.id.uuidString.prefix(8)))")
                 }
             }
             print("\n\(words.count) word(s)")
@@ -55,9 +79,12 @@ struct FlowWordsCommand: AsyncParsableCommand {
         @Argument(help: "The replacement text (omit for vocabulary anchor).")
         var replacement: String?
 
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
         func run() async throws {
             try AppPaths.ensureDirectories()
-            let dbManager = try DatabaseManager(path: AppPaths.databasePath)
+            let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
             let repo = CustomWordRepository(dbQueue: dbManager.dbQueue)
 
             let customWord = CustomWord(word: word, replacement: replacement)
@@ -80,9 +107,12 @@ struct FlowWordsCommand: AsyncParsableCommand {
         @Argument(help: "The UUID (or prefix) of the word to delete.")
         var id: String
 
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
         func run() async throws {
             try AppPaths.ensureDirectories()
-            let dbManager = try DatabaseManager(path: AppPaths.databasePath)
+            let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
             let repo = CustomWordRepository(dbQueue: dbManager.dbQueue)
 
             // Support UUID prefix matching

--- a/Sources/CLI/Commands/HealthCommand.swift
+++ b/Sources/CLI/Commands/HealthCommand.swift
@@ -117,6 +117,10 @@ struct HealthCommand: AsyncParsableCommand {
 
         // 5. Local speech stack
         let sttClient = STTClient()
+        // CLI is about to exit anyway, but `defer` guarantees shutdown runs
+        // even if a future change adds a throw between init and the explicit
+        // shutdown below. Detached because defer can't await.
+        defer { Task { await sttClient.shutdown() } }
         let diarizationService = DiarizationService()
         let status = await loadSpeechStackStatus(
             sttClient: sttClient,
@@ -144,7 +148,6 @@ struct HealthCommand: AsyncParsableCommand {
                 if !json { print("Speech-stack repair failed — \(error.localizedDescription)") }
             }
         }
-        await sttClient.shutdown()
         if !json { print() }
 
         // 6. Bundled FFmpeg

--- a/Sources/CLI/Commands/HealthCommand.swift
+++ b/Sources/CLI/Commands/HealthCommand.swift
@@ -14,6 +14,9 @@ struct HealthCommand: AsyncParsableCommand {
     @Option(name: .long, help: "Maximum repair attempts when --repair-models is set.")
     var repairAttempts: Int = 3
 
+    @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+    var json: Bool = false
+
     func run() async throws {
         let validatedRepairAttempts: Int?
         if repairModels {
@@ -22,126 +25,248 @@ struct HealthCommand: AsyncParsableCommand {
             validatedRepairAttempts = nil
         }
 
-        print("MacParakeet Health Check")
-        print("========================")
-        print()
+        // Operations are run unconditionally; printing is gated on `!json` so the
+        // final JSON dump is the only thing on stdout in --json mode.
+        var report = HealthReport()
+
+        if !json {
+            print("MacParakeet Health Check")
+            print("========================")
+            print()
+        }
 
         // 1. Paths
-        print("Paths:")
-        print("  App Support: \(AppPaths.appSupportDir)")
-        print("  Database:    \(AppPaths.databasePath)")
-        print("  Temp:        \(AppPaths.tempDir)")
-        print("  Bin:         \(AppPaths.binDir)")
-        print("  yt-dlp:      \(AppPaths.ytDlpBinaryPath)")
-        print()
+        report.paths = HealthReport.Paths(
+            appSupport: AppPaths.appSupportDir,
+            database: AppPaths.databasePath,
+            temp: AppPaths.tempDir,
+            bin: AppPaths.binDir,
+            ytDlp: AppPaths.ytDlpBinaryPath
+        )
+        if !json {
+            print("Paths:")
+            print("  App Support: \(report.paths.appSupport)")
+            print("  Database:    \(report.paths.database)")
+            print("  Temp:        \(report.paths.temp)")
+            print("  Bin:         \(report.paths.bin)")
+            print("  yt-dlp:      \(report.paths.ytDlp)")
+            print()
+        }
 
         // 2. Directories
-        print("Directories:")
         do {
             try AppPaths.ensureDirectories()
-            print("  All directories exist or created.")
+            report.directoriesOK = true
         } catch {
-            print("  ERROR: \(error.localizedDescription)")
+            report.directoriesOK = false
+            report.directoriesError = error.localizedDescription
         }
-        print()
+        if !json {
+            print("Directories:")
+            if report.directoriesOK {
+                print("  All directories exist or created.")
+            } else {
+                print("  ERROR: \(report.directoriesError ?? "unknown")")
+            }
+            print()
+        }
 
         // 3. Database
-        print("Database:")
-        let dbExists = FileManager.default.fileExists(atPath: AppPaths.databasePath)
-        if dbExists {
+        let database: HealthReport.Database
+        if FileManager.default.fileExists(atPath: AppPaths.databasePath) {
             do {
                 let dbManager = try DatabaseManager(path: AppPaths.databasePath)
-                let dictationRepo = DictationRepository(dbQueue: dbManager.dbQueue)
-                let transcriptionRepo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
-
-                let dictStats = try dictationRepo.stats()
-                let transcriptions = try transcriptionRepo.fetchAll(limit: nil)
-
-                print("  Status: OK")
-                print("  Dictations: \(dictStats.totalCount)")
-                print("  Transcriptions: \(transcriptions.count)")
+                let dictStats = try DictationRepository(dbQueue: dbManager.dbQueue).stats()
+                let transcriptions = try TranscriptionRepository(dbQueue: dbManager.dbQueue).fetchAll(limit: nil)
+                database = .init(status: "ok", dictations: dictStats.totalCount, transcriptions: transcriptions.count, error: nil)
             } catch {
-                print("  Status: ERROR — \(error.localizedDescription)")
+                database = .init(status: "error", dictations: nil, transcriptions: nil, error: error.localizedDescription)
             }
         } else {
-            print("  Status: Not created yet (will be created on first use)")
+            database = .init(status: "missing", dictations: nil, transcriptions: nil, error: nil)
         }
-        print()
+        report.database = database
+        if !json {
+            print("Database:")
+            switch database.status {
+            case "ok":
+                print("  Status: OK")
+                print("  Dictations: \(database.dictations ?? 0)")
+                print("  Transcriptions: \(database.transcriptions ?? 0)")
+            case "missing":
+                print("  Status: Not created yet (will be created on first use)")
+            default:
+                print("  Status: ERROR — \(database.error ?? "unknown")")
+            }
+            print()
+        }
 
         // 4. Audio input
-        print("Audio Input:")
-        printAudioInputDiagnostics(loadAudioInputDiagnostics())
-        print()
+        let audio = loadAudioInputDiagnostics()
+        report.audioInput = HealthReport.AudioInput(
+            deviceCount: audio.devices.count,
+            selectedUID: audio.storedSelectedUID,
+            defaultDeviceName: audio.defaultDevice?.name,
+            builtInDeviceName: audio.builtInDevice?.name
+        )
+        if !json {
+            print("Audio Input:")
+            printAudioInputDiagnostics(audio)
+            print()
+        }
 
         // 5. Local speech stack
-        print("Local Speech Stack:")
         let sttClient = STTClient()
         let diarizationService = DiarizationService()
         let status = await loadSpeechStackStatus(
             sttClient: sttClient,
             diarizationService: diarizationService
         )
-        printSpeechStackStatus(status, includeHeader: false)
+        report.speechStack = SpeechStackPayload(status: status)
+        if !json {
+            print("Local Speech Stack:")
+            printSpeechStackStatus(status, includeHeader: false)
+        }
 
         if let repairAttempts = validatedRepairAttempts {
-            print()
-            print("Speech-stack repair requested...")
+            if !json { print(); print("Speech-stack repair requested...") }
             do {
                 try await prepareSpeechStack(
                     attempts: repairAttempts,
                     sttClient: sttClient,
                     diarizationService: diarizationService,
-                    log: { message in print("  \(message)") }
+                    log: { message in if !self.json { print("  \(message)") } }
                 )
-                print("Speech-stack repair completed.")
+                report.repair = HealthReport.Repair(attempted: true, completed: true, error: nil)
+                if !json { print("Speech-stack repair completed.") }
             } catch {
-                print("Speech-stack repair failed — \(error.localizedDescription)")
+                report.repair = HealthReport.Repair(attempted: true, completed: false, error: error.localizedDescription)
+                if !json { print("Speech-stack repair failed — \(error.localizedDescription)") }
             }
         }
         await sttClient.shutdown()
-        print()
+        if !json { print() }
 
         // 6. Bundled FFmpeg
-        print("FFmpeg:")
+        let ffmpeg: HealthReport.Binary
         if let ffmpegPath = BinaryBootstrap.resolveRuntimeFFmpegPath() {
-            if ffmpegPath == AppPaths.bundledFFmpegPath() {
-                print("  Status: Found bundled binary at \(ffmpegPath)")
-            } else {
-                print("  Status: Found development fallback at \(ffmpegPath)")
-            }
+            let isBundled = ffmpegPath == AppPaths.bundledFFmpegPath()
+            ffmpeg = .init(status: isBundled ? "bundled" : "fallback", path: ffmpegPath, error: nil)
         } else {
-            print("  Status: Missing (bundle + development fallback)")
+            ffmpeg = .init(status: "missing", path: nil, error: nil)
         }
-        print()
+        report.ffmpeg = ffmpeg
+        if !json {
+            print("FFmpeg:")
+            switch ffmpeg.status {
+            case "bundled": print("  Status: Found bundled binary at \(ffmpeg.path ?? "")")
+            case "fallback": print("  Status: Found development fallback at \(ffmpeg.path ?? "")")
+            default: print("  Status: Missing (bundle + development fallback)")
+            }
+            print()
+        }
 
-        // 7. yt-dlp managed binary
-        print("yt-dlp:")
-        let bootstrap = BinaryBootstrap()
+        // 7. yt-dlp
+        let ytDlp: HealthReport.Binary
         do {
-            let path = try await bootstrap.ensureYtDlpAvailable()
-            print("  Status: Ready at \(path)")
+            let path = try await BinaryBootstrap().ensureYtDlpAvailable()
+            ytDlp = .init(status: "ready", path: path, error: nil)
         } catch {
-            print("  Status: Not available — \(error.localizedDescription)")
+            ytDlp = .init(status: "missing", path: nil, error: error.localizedDescription)
         }
-        print()
+        report.ytDlp = ytDlp
+        if !json {
+            print("yt-dlp:")
+            switch ytDlp.status {
+            case "ready": print("  Status: Ready at \(ytDlp.path ?? "")")
+            default:      print("  Status: Not available — \(ytDlp.error ?? "unknown")")
+            }
+            print()
+        }
 
-        // 8. Calendar (EventKit) — agents can't see TCC dialogs from the
-        // GUI, so the CLI surface lets them check authorization status
-        // headlessly during dev iteration.
-        print("Calendar (EventKit):")
+        // 8. Calendar
+        let permission = CalendarService.shared.permissionStatus
         let calendarStatus: String
-        switch CalendarService.shared.permissionStatus {
-        case .granted: calendarStatus = "Granted"
-        case .denied: calendarStatus = "Denied (open System Settings → Privacy & Security → Calendars)"
-        case .notDetermined: calendarStatus = "Not requested (run the app once and grant access)"
+        switch permission {
+        case .granted: calendarStatus = "granted"
+        case .denied: calendarStatus = "denied"
+        case .notDetermined: calendarStatus = "notDetermined"
         }
-        print("  Status: \(calendarStatus)")
-        if CalendarService.shared.permissionStatus == .granted {
-            let calendars = await CalendarService.shared.availableCalendars()
-            print("  Calendars visible: \(calendars.count)")
+        var calendarsVisible: Int?
+        if permission == .granted {
+            calendarsVisible = await CalendarService.shared.availableCalendars().count
         }
-        print()
+        report.calendar = HealthReport.Calendar(permission: calendarStatus, calendarsVisible: calendarsVisible)
+        if !json {
+            print("Calendar (EventKit):")
+            switch permission {
+            case .granted:
+                print("  Status: Granted")
+                if let n = calendarsVisible { print("  Calendars visible: \(n)") }
+            case .denied:
+                print("  Status: Denied (open System Settings → Privacy & Security → Calendars)")
+            case .notDetermined:
+                print("  Status: Not requested (run the app once and grant access)")
+            }
+            print()
+            print("Done.")
+        } else {
+            try printJSON(report)
+        }
+    }
+}
 
-        print("Done.")
+// Health JSON payload. Local to the CLI so adding diagnostic fields here
+// doesn't require touching the Core layer.
+private struct HealthReport: Encodable {
+    var paths: Paths = .empty
+    var directoriesOK: Bool = false
+    var directoriesError: String?
+    var database: Database?
+    var audioInput: AudioInput?
+    var speechStack: SpeechStackPayload?
+    var repair: Repair?
+    var ffmpeg: Binary?
+    var ytDlp: Binary?
+    var calendar: Calendar?
+
+    struct Paths: Encodable {
+        let appSupport: String
+        let database: String
+        let temp: String
+        let bin: String
+        let ytDlp: String
+        static let empty = Paths(appSupport: "", database: "", temp: "", bin: "", ytDlp: "")
+    }
+
+    struct Database: Encodable {
+        let status: String  // "ok" | "missing" | "error"
+        let dictations: Int?
+        let transcriptions: Int?
+        let error: String?
+    }
+
+    struct AudioInput: Encodable {
+        let deviceCount: Int
+        let selectedUID: String?
+        let defaultDeviceName: String?
+        let builtInDeviceName: String?
+    }
+
+    struct Repair: Encodable {
+        let attempted: Bool
+        let completed: Bool
+        let error: String?
+    }
+
+    struct Binary: Encodable {
+        let status: String
+        let path: String?
+        let error: String?
+    }
+
+    struct Calendar: Encodable {
+        let permission: String  // "granted" | "denied" | "notDetermined"
+        let calendarsVisible: Int?
     }
 }

--- a/Sources/CLI/Commands/HistoryCommand.swift
+++ b/Sources/CLI/Commands/HistoryCommand.swift
@@ -30,6 +30,9 @@ struct DictationsSubcommand: ParsableCommand {
     @Option(name: .shortAndLong, help: "Maximum number of results.")
     var limit: Int = 20
 
+    @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+    var json: Bool = false
+
     @Option(help: "Path to SQLite database file (defaults to the app database).")
     var database: String?
 
@@ -38,6 +41,11 @@ struct DictationsSubcommand: ParsableCommand {
         let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
         let repo = DictationRepository(dbQueue: dbManager.dbQueue)
         let dictations = try repo.fetchAll(limit: limit)
+
+        if json {
+            try printJSON(dictations)
+            return
+        }
 
         if dictations.isEmpty {
             print("No dictations found.")
@@ -71,6 +79,9 @@ struct TranscriptionsSubcommand: ParsableCommand {
     @Option(name: .shortAndLong, help: "Maximum number of results.")
     var limit: Int = 20
 
+    @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+    var json: Bool = false
+
     @Option(help: "Path to SQLite database file (defaults to the app database).")
     var database: String?
 
@@ -79,6 +90,11 @@ struct TranscriptionsSubcommand: ParsableCommand {
         let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
         let repo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
         let transcriptions = try repo.fetchAll(limit: limit)
+
+        if json {
+            try printJSON(transcriptions)
+            return
+        }
 
         if transcriptions.isEmpty {
             print("No transcriptions found.")
@@ -116,6 +132,9 @@ struct SearchSubcommand: ParsableCommand {
     @Option(name: .shortAndLong, help: "Maximum number of results.")
     var limit: Int = 20
 
+    @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+    var json: Bool = false
+
     @Option(help: "Path to SQLite database file (defaults to the app database).")
     var database: String?
 
@@ -124,6 +143,11 @@ struct SearchSubcommand: ParsableCommand {
         let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
         let repo = DictationRepository(dbQueue: dbManager.dbQueue)
         let results = try repo.search(query: query, limit: limit)
+
+        if json {
+            try printJSON(results)
+            return
+        }
 
         if results.isEmpty {
             print("No results for \"\(query)\".")
@@ -158,6 +182,9 @@ struct SearchTranscriptionsSubcommand: ParsableCommand {
     @Option(name: .shortAndLong, help: "Maximum number of results.")
     var limit: Int = 20
 
+    @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+    var json: Bool = false
+
     @Option(help: "Path to SQLite database file (defaults to the app database).")
     var database: String?
 
@@ -166,6 +193,11 @@ struct SearchTranscriptionsSubcommand: ParsableCommand {
         let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
         let repo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
         let results = try repo.search(query: query, limit: limit)
+
+        if json {
+            try printJSON(results)
+            return
+        }
 
         if results.isEmpty {
             print("No transcriptions matching \"\(query)\".")
@@ -247,6 +279,9 @@ struct FavoritesSubcommand: ParsableCommand {
         abstract: "List favorite transcriptions."
     )
 
+    @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+    var json: Bool = false
+
     @Option(help: "Path to SQLite database file (defaults to the app database).")
     var database: String?
 
@@ -255,6 +290,11 @@ struct FavoritesSubcommand: ParsableCommand {
         let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
         let repo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
         let favorites = try repo.fetchFavorites()
+
+        if json {
+            try printJSON(favorites)
+            return
+        }
 
         if favorites.isEmpty {
             print("No favorite transcriptions.")

--- a/Sources/CLI/Commands/ModelsCommand.swift
+++ b/Sources/CLI/Commands/ModelsCommand.swift
@@ -22,6 +22,9 @@ extension ModelsCommand {
             abstract: "Show speech-stack status without forcing downloads."
         )
 
+        @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+        var json: Bool = false
+
         func run() async throws {
             let sttClient = STTClient()
             let diarizationService = DiarizationService()
@@ -29,7 +32,11 @@ extension ModelsCommand {
                 sttClient: sttClient,
                 diarizationService: diarizationService
             )
-            printSpeechStackStatus(status)
+            if json {
+                try printJSON(SpeechStackPayload(status: status))
+            } else {
+                printSpeechStackStatus(status)
+            }
             await sttClient.shutdown()
         }
     }
@@ -92,6 +99,22 @@ extension ModelsCommand {
             DiarizationService.clearModelCache()
             print("Local speech and speaker model caches cleared")
         }
+    }
+}
+
+struct SpeechStackPayload: Encodable {
+    let speechModelCached: Bool
+    let speechRuntimeReady: Bool
+    let speakerModelsCached: Bool
+    let speakerModelsPrepared: Bool
+    let summary: String
+
+    init(status: SpeechStackStatus) {
+        self.speechModelCached = status.speechModelCached
+        self.speechRuntimeReady = status.speechRuntimeReady
+        self.speakerModelsCached = status.speakerModelsCached
+        self.speakerModelsPrepared = status.speakerModelsPrepared
+        self.summary = status.summary
     }
 }
 

--- a/Sources/CLI/Commands/PromptsCommand.swift
+++ b/Sources/CLI/Commands/PromptsCommand.swift
@@ -1,0 +1,410 @@
+import ArgumentParser
+import Foundation
+import MacParakeetCore
+
+/// `macparakeet-cli prompts` — manage the prompt library and run prompts
+/// against saved transcriptions. Built so an agent or CI run can verify
+/// migrations, seed test prompts deterministically, and exercise the
+/// multi-summary write path without launching the GUI.
+struct PromptsCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "prompts",
+        abstract: "Manage the prompt library and run prompts against transcriptions.",
+        subcommands: [
+            ListSubcommand.self,
+            ShowSubcommand.self,
+            AddSubcommand.self,
+            SetSubcommand.self,
+            DeleteSubcommand.self,
+            RestoreDefaultsSubcommand.self,
+            RunSubcommand.self,
+        ],
+        defaultSubcommand: ListSubcommand.self
+    )
+}
+
+// MARK: - List
+
+extension PromptsCommand {
+    struct ListSubcommand: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "list",
+            abstract: "List prompts in the library."
+        )
+
+        enum Filter: String, ExpressibleByArgument {
+            case all, visible, autoRun = "auto-run"
+        }
+
+        @Option(name: .long, help: "Which prompts to list: all, visible, auto-run. Default: all.")
+        var filter: Filter = .all
+
+        @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+        var json: Bool = false
+
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
+        func run() throws {
+            try AppPaths.ensureDirectories()
+            let db = try DatabaseManager(path: resolvedDatabasePath(database))
+            let repo = PromptRepository(dbQueue: db.dbQueue)
+
+            let prompts: [Prompt]
+            switch filter {
+            case .all:     prompts = try repo.fetchAll()
+            case .visible: prompts = try repo.fetchVisible(category: nil)
+            case .autoRun: prompts = try repo.fetchAutoRunPrompts()
+            }
+
+            if json {
+                try printJSON(prompts)
+                return
+            }
+
+            if prompts.isEmpty {
+                print("No prompts found.")
+                return
+            }
+
+            for p in prompts {
+                let badges = renderBadges(p)
+                print("\(p.id.uuidString.prefix(8))  \(p.name)\(badges)")
+            }
+            print()
+            print("\(prompts.count) prompt(s)")
+        }
+    }
+}
+
+// MARK: - Show
+
+extension PromptsCommand {
+    struct ShowSubcommand: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "show",
+            abstract: "Show a prompt's full content."
+        )
+
+        @Argument(help: "Prompt ID, ID prefix, or name.")
+        var idOrName: String
+
+        @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+        var json: Bool = false
+
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
+        func run() throws {
+            try AppPaths.ensureDirectories()
+            let db = try DatabaseManager(path: resolvedDatabasePath(database))
+            let repo = PromptRepository(dbQueue: db.dbQueue)
+            let prompt = try findPrompt(idOrName: idOrName, repo: repo)
+
+            if json {
+                try printJSON(prompt)
+                return
+            }
+
+            print("ID:        \(prompt.id.uuidString)")
+            print("Name:      \(prompt.name)\(renderBadges(prompt))")
+            print("Category:  \(prompt.category.rawValue)")
+            print("Updated:   \(ISO8601DateFormatter().string(from: prompt.updatedAt))")
+            print()
+            print(prompt.content)
+        }
+    }
+}
+
+// MARK: - Add
+
+extension PromptsCommand {
+    struct AddSubcommand: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "add",
+            abstract: "Add a custom prompt."
+        )
+
+        @Option(name: .long, help: "Prompt display name (must be unique).")
+        var name: String
+
+        @Option(name: .long, help: "Prompt body text. Mutually exclusive with --from-file.")
+        var content: String?
+
+        @Option(name: .long, help: "Path to a file containing the prompt body. Use /dev/stdin to pipe.")
+        var fromFile: String?
+
+        @Flag(name: .long, help: "Mark as auto-run (implies visible).")
+        var autoRun: Bool = false
+
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
+        func validate() throws {
+            if (content == nil) == (fromFile == nil) {
+                throw ValidationError("specify exactly one of --content or --from-file")
+            }
+            if name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                throw ValidationError("--name must not be empty")
+            }
+        }
+
+        func run() throws {
+            try AppPaths.ensureDirectories()
+            let db = try DatabaseManager(path: resolvedDatabasePath(database))
+            let repo = PromptRepository(dbQueue: db.dbQueue)
+
+            // validate() guarantees exactly one of content / fromFile is set.
+            let body: String
+            if let content {
+                body = content
+            } else {
+                body = try String(contentsOfFile: fromFile!, encoding: .utf8)
+            }
+
+            let prompt = Prompt(
+                name: name.trimmingCharacters(in: .whitespacesAndNewlines),
+                content: body,
+                isVisible: true,
+                isAutoRun: autoRun
+            )
+            try repo.save(prompt)
+            print("Added prompt '\(prompt.name)' (\(prompt.id.uuidString.prefix(8)))")
+        }
+    }
+}
+
+// MARK: - Set
+
+extension PromptsCommand {
+    struct SetSubcommand: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "set",
+            abstract: "Toggle a prompt's visibility or auto-run state."
+        )
+
+        @Argument(help: "Prompt ID, ID prefix, or name.")
+        var idOrName: String
+
+        @Flag(name: .long, help: "Make the prompt visible in the library.")
+        var visible: Bool = false
+
+        @Flag(name: .long, help: "Hide the prompt from the library.")
+        var hidden: Bool = false
+
+        @Flag(name: .long, help: "Enable auto-run on completed transcriptions.")
+        var autoRun: Bool = false
+
+        @Flag(name: .long, help: "Disable auto-run.")
+        var noAutoRun: Bool = false
+
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
+        func validate() throws {
+            if visible && hidden {
+                throw ValidationError("--visible and --hidden are mutually exclusive")
+            }
+            if autoRun && noAutoRun {
+                throw ValidationError("--auto-run and --no-auto-run are mutually exclusive")
+            }
+            if !(visible || hidden || autoRun || noAutoRun) {
+                throw ValidationError("specify at least one of --visible / --hidden / --auto-run / --no-auto-run")
+            }
+        }
+
+        func run() throws {
+            try AppPaths.ensureDirectories()
+            let db = try DatabaseManager(path: resolvedDatabasePath(database))
+            let repo = PromptRepository(dbQueue: db.dbQueue)
+
+            var prompt = try findPrompt(idOrName: idOrName, repo: repo)
+
+            if visible { prompt.isVisible = true }
+            if hidden  { prompt.isVisible = false; prompt.isAutoRun = false }
+            if autoRun { prompt.isAutoRun = true; prompt.isVisible = true }
+            if noAutoRun { prompt.isAutoRun = false }
+
+            prompt.updatedAt = Date()
+            try repo.save(prompt)
+            print("Updated '\(prompt.name)':\(renderBadges(prompt))")
+        }
+    }
+}
+
+// MARK: - Delete
+
+extension PromptsCommand {
+    struct DeleteSubcommand: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "delete",
+            abstract: "Delete a custom prompt (built-ins cannot be deleted)."
+        )
+
+        @Argument(help: "Prompt ID, ID prefix, or name.")
+        var idOrName: String
+
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
+        func run() throws {
+            try AppPaths.ensureDirectories()
+            let db = try DatabaseManager(path: resolvedDatabasePath(database))
+            let repo = PromptRepository(dbQueue: db.dbQueue)
+
+            let prompt = try findPrompt(idOrName: idOrName, repo: repo)
+            if prompt.isBuiltIn {
+                throw PromptCLIError.cannotDeleteBuiltIn(prompt.name)
+            }
+            let deleted = try repo.delete(id: prompt.id)
+            guard deleted else {
+                throw PromptCLIError.deleteFailed(prompt.name)
+            }
+            print("Deleted prompt '\(prompt.name)'")
+        }
+    }
+}
+
+// MARK: - Restore Defaults
+
+extension PromptsCommand {
+    struct RestoreDefaultsSubcommand: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "restore-defaults",
+            abstract: "Re-show all built-in prompts (does not affect custom prompts)."
+        )
+
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
+        func run() throws {
+            try AppPaths.ensureDirectories()
+            let db = try DatabaseManager(path: resolvedDatabasePath(database))
+            let repo = PromptRepository(dbQueue: db.dbQueue)
+            try repo.restoreDefaults()
+            print("Built-in prompts re-shown.")
+        }
+    }
+}
+
+// MARK: - Run
+
+extension PromptsCommand {
+    struct RunSubcommand: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "run",
+            abstract: "Run a saved prompt against a saved transcription via an LLM provider."
+        )
+
+        @OptionGroup var llm: LLMInlineOptions
+
+        @Argument(help: "Prompt ID, ID prefix, or name.")
+        var promptIdOrName: String
+
+        @Option(name: .long, help: "Transcription ID or prefix to run the prompt against.")
+        var transcription: String
+
+        @Flag(name: .long, help: "Print output only; don't save a PromptResult to the summaries table.")
+        var noStore: Bool = false
+
+        @Flag(name: .long, help: "Stream the response token by token.")
+        var stream: Bool = false
+
+        @Option(name: .long, help: "Extra instructions appended to the prompt for this run.")
+        var extra: String?
+
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
+        func run() async throws {
+            try AppPaths.ensureDirectories()
+            let db = try DatabaseManager(path: resolvedDatabasePath(database))
+            let promptRepo = PromptRepository(dbQueue: db.dbQueue)
+            let transcriptionRepo = TranscriptionRepository(dbQueue: db.dbQueue)
+            let resultRepo = PromptResultRepository(dbQueue: db.dbQueue)
+
+            let prompt = try findPrompt(idOrName: promptIdOrName, repo: promptRepo)
+            let transcript = try findTranscription(id: transcription, repo: transcriptionRepo)
+
+            let transcriptText = transcript.cleanTranscript ?? transcript.rawTranscript ?? ""
+            guard !transcriptText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw PromptCLIError.emptyTranscript(transcript.fileName)
+            }
+
+            let trimmedExtra = extra?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let normalizedExtra = (trimmedExtra?.isEmpty == false) ? trimmedExtra : nil
+            let systemPrompt = assembledSystemPrompt(promptContent: prompt.content, extraInstructions: normalizedExtra)
+
+            let execution = try llm.buildExecutionContext()
+            let service = LLMService(
+                client: execution.client,
+                contextResolver: StaticLLMExecutionContextResolver(context: execution.context)
+            )
+
+            var output = ""
+            if stream {
+                let tokenStream = service.generatePromptResultStream(
+                    transcript: transcriptText,
+                    systemPrompt: systemPrompt
+                )
+                for try await token in tokenStream {
+                    print(token, terminator: "")
+                    output += token
+                }
+                print()
+            } else {
+                output = try await service.generatePromptResult(
+                    transcript: transcriptText,
+                    systemPrompt: systemPrompt
+                )
+                print(output)
+            }
+
+            if !noStore {
+                let result = PromptResult(
+                    transcriptionId: transcript.id,
+                    promptName: prompt.name,
+                    promptContent: prompt.content,
+                    extraInstructions: normalizedExtra,
+                    content: output
+                )
+                try resultRepo.save(result)
+                // Status messages on stderr so stdout stays grep-able as the prompt output.
+                FileHandle.standardError.write(Data("\nSaved PromptResult \(result.id.uuidString.prefix(8))\n".utf8))
+            }
+        }
+
+        // Mirrors PromptResultsViewModel.assembledSystemPrompt so CLI runs match GUI behavior.
+        private func assembledSystemPrompt(promptContent: String, extraInstructions: String?) -> String {
+            guard let extraInstructions, !extraInstructions.isEmpty else { return promptContent }
+            return promptContent + "\n\n" + extraInstructions
+        }
+    }
+}
+
+// MARK: - Helpers
+
+private func renderBadges(_ p: Prompt) -> String {
+    var badges: [String] = []
+    if p.isBuiltIn { badges.append("built-in") }
+    if !p.isVisible { badges.append("hidden") }
+    if p.isAutoRun { badges.append("auto-run") }
+    return badges.isEmpty ? "" : "  [\(badges.joined(separator: ", "))]"
+}
+
+private enum PromptCLIError: Error, LocalizedError {
+    case cannotDeleteBuiltIn(String)
+    case deleteFailed(String)
+    case emptyTranscript(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .cannotDeleteBuiltIn(let name):
+            return "Cannot delete built-in prompt '\(name)'. Use `prompts set <name> --hidden` to hide it instead."
+        case .deleteFailed(let name):
+            return "Delete failed for prompt '\(name)'."
+        case .emptyTranscript(let fileName):
+            return "Transcription '\(fileName)' has no text to run a prompt against."
+        }
+    }
+}

--- a/Sources/CLI/Commands/PromptsCommand.swift
+++ b/Sources/CLI/Commands/PromptsCommand.swift
@@ -131,7 +131,7 @@ extension PromptsCommand {
         @Option(name: .long, help: "Prompt body text. Mutually exclusive with --from-file.")
         var content: String?
 
-        @Option(name: .long, help: "Path to a file containing the prompt body. Use /dev/stdin to pipe.")
+        @Option(name: .long, help: "Path to a file containing the prompt body.")
         var fromFile: String?
 
         @Flag(name: .long, help: "Mark as auto-run (implies visible).")
@@ -141,8 +141,8 @@ extension PromptsCommand {
         var database: String?
 
         func validate() throws {
-            if (content == nil) == (fromFile == nil) {
-                throw ValidationError("specify exactly one of --content or --from-file")
+            if content != nil && fromFile != nil {
+                throw ValidationError("--content and --from-file are mutually exclusive")
             }
             if name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 throw ValidationError("--name must not be empty")
@@ -154,12 +154,18 @@ extension PromptsCommand {
             let db = try DatabaseManager(path: resolvedDatabasePath(database))
             let repo = PromptRepository(dbQueue: db.dbQueue)
 
-            // validate() guarantees exactly one of content / fromFile is set.
+            // Body precedence: --content > --from-file > stdin (for piped workflows
+            // like `cat prompt.md | macparakeet-cli prompts add --name X`).
             let body: String
             if let content {
                 body = content
+            } else if let fromFile {
+                body = try String(contentsOfFile: fromFile, encoding: .utf8)
             } else {
-                body = try String(contentsOfFile: fromFile!, encoding: .utf8)
+                body = readStdinUTF8()
+            }
+            guard !body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw ValidationError("prompt body is empty (provide --content, --from-file, or pipe via stdin)")
             }
 
             let prompt = Prompt(
@@ -170,6 +176,11 @@ extension PromptsCommand {
             )
             try repo.save(prompt)
             print("Added prompt '\(prompt.name)' (\(prompt.id.uuidString.prefix(8)))")
+        }
+
+        private func readStdinUTF8() -> String {
+            let data = FileHandle.standardInput.readDataToEndOfFile()
+            return String(data: data, encoding: .utf8) ?? ""
         }
     }
 }
@@ -207,6 +218,12 @@ extension PromptsCommand {
             }
             if autoRun && noAutoRun {
                 throw ValidationError("--auto-run and --no-auto-run are mutually exclusive")
+            }
+            // Auto-run requires visible (mirrors PromptRepository.toggleAutoRun).
+            // Reject the contradictory combo explicitly so the user doesn't get a
+            // silent precedence surprise where one flag overrides the other.
+            if hidden && autoRun {
+                throw ValidationError("--hidden and --auto-run cannot be combined (auto-run requires visible)")
             }
             if !(visible || hidden || autoRun || noAutoRun) {
                 throw ValidationError("specify at least one of --visible / --hidden / --auto-run / --no-auto-run")

--- a/Sources/CLI/Commands/StatsCommand.swift
+++ b/Sources/CLI/Commands/StatsCommand.swift
@@ -8,6 +8,9 @@ struct StatsCommand: ParsableCommand {
         abstract: "Show voice stats dashboard."
     )
 
+    @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+    var json: Bool = false
+
     @Option(help: "Path to SQLite database file (defaults to the app database).")
     var database: String?
 
@@ -20,6 +23,11 @@ struct StatsCommand: ParsableCommand {
         let stats = try dictationRepo.stats()
         let transcriptionCount = try transcriptionRepo.count()
         let favoriteCount = try transcriptionRepo.fetchFavorites().count
+
+        if json {
+            try printJSON(StatsPayload(stats: stats, transcriptionCount: transcriptionCount, favoriteCount: favoriteCount))
+            return
+        }
 
         if stats.visibleCount == 0 && transcriptionCount == 0 {
             print("No voice activity yet.")
@@ -80,5 +88,48 @@ struct StatsCommand: ParsableCommand {
         if favoriteCount > 0 {
             print("  Favorites:        \(favoriteCount)")
         }
+    }
+}
+
+private struct StatsPayload: Encodable {
+    let dictations: Dictations
+    let transcriptions: Transcriptions
+
+    init(stats: DictationStats, transcriptionCount: Int, favoriteCount: Int) {
+        self.dictations = Dictations(
+            visibleCount: stats.visibleCount,
+            totalCount: stats.totalCount,
+            totalWords: stats.totalWords,
+            totalDurationMs: stats.totalDurationMs,
+            averageDurationMs: stats.averageDurationMs,
+            averageWPM: stats.averageWPM,
+            longestDurationMs: stats.longestDurationMs,
+            weeklyStreak: stats.weeklyStreak,
+            dictationsThisWeek: stats.dictationsThisWeek,
+            timeSavedMs: stats.timeSavedMs,
+            booksEquivalent: stats.booksEquivalent,
+            emailsEquivalent: stats.emailsEquivalent
+        )
+        self.transcriptions = Transcriptions(total: transcriptionCount, favorites: favoriteCount)
+    }
+
+    struct Dictations: Encodable {
+        let visibleCount: Int
+        let totalCount: Int
+        let totalWords: Int
+        let totalDurationMs: Int
+        let averageDurationMs: Int
+        let averageWPM: Double
+        let longestDurationMs: Int
+        let weeklyStreak: Int
+        let dictationsThisWeek: Int
+        let timeSavedMs: Int
+        let booksEquivalent: Double
+        let emailsEquivalent: Double
+    }
+
+    struct Transcriptions: Encodable {
+        let total: Int
+        let favorites: Int
     }
 }

--- a/Sources/CLI/MacParakeetCLI.swift
+++ b/Sources/CLI/MacParakeetCLI.swift
@@ -15,6 +15,7 @@ struct CLI: AsyncParsableCommand {
             ModelsCommand.self,
             FlowCommand.self,
             LLMCommand.self,
+            PromptsCommand.self,
             CalendarCommand.self,
             FeedbackCommand.self,
         ],

--- a/Tests/CLITests/PromptsCommandTests.swift
+++ b/Tests/CLITests/PromptsCommandTests.swift
@@ -156,16 +156,18 @@ final class PromptsCommandTests: XCTestCase {
     // MARK: - JSON encoder
 
     func testCLIJSONEncoderEmitsParseableJSON() throws {
+        // DatabaseManager() seeds 6 built-in prompts during migration, so we
+        // can't assume insertion order — search by name instead of position.
         let db = try DatabaseManager()
         let repo = PromptRepository(dbQueue: db.dbQueue)
-        let p = Prompt(name: "JSON Test", content: "Body")
-        try repo.save(p)
+        try repo.save(Prompt(name: "JSON Test", content: "Body"))
 
         let prompts = try repo.fetchAll()
         let data = try cliJSONEncoder.encode(prompts)
 
         let parsed = try JSONSerialization.jsonObject(with: data) as? [[String: Any]]
         XCTAssertNotNil(parsed)
-        XCTAssertEqual(parsed?.first?["name"] as? String, "JSON Test")
+        let names = parsed?.compactMap { $0["name"] as? String } ?? []
+        XCTAssertTrue(names.contains("JSON Test"), "Expected 'JSON Test' in encoded names; got: \(names)")
     }
 }

--- a/Tests/CLITests/PromptsCommandTests.swift
+++ b/Tests/CLITests/PromptsCommandTests.swift
@@ -102,6 +102,59 @@ final class PromptsCommandTests: XCTestCase {
 
     // MARK: - cliJSONEncoder smoke
 
+    // MARK: - Set validation
+    // .parse() runs validate() automatically, so a failed parse with our error
+    // text proves validate() rejected it.
+
+    func testSetRejectsContradictoryHiddenAndAutoRun() {
+        XCTAssertThrowsError(
+            try PromptsCommand.SetSubcommand.parse(["anything", "--hidden", "--auto-run"])
+        ) { error in
+            XCTAssertTrue(String(describing: error).contains("auto-run requires visible"),
+                          "Expected message about auto-run requiring visible, got: \(error)")
+        }
+    }
+
+    func testSetRejectsMutuallyExclusiveVisibleHidden() {
+        XCTAssertThrowsError(
+            try PromptsCommand.SetSubcommand.parse(["anything", "--visible", "--hidden"])
+        )
+    }
+
+    func testSetRequiresAtLeastOneFlag() {
+        XCTAssertThrowsError(try PromptsCommand.SetSubcommand.parse(["anything"]))
+    }
+
+    func testSetAcceptsHiddenWithNoAutoRun() {
+        XCTAssertNoThrow(
+            try PromptsCommand.SetSubcommand.parse(["anything", "--hidden", "--no-auto-run"])
+        )
+    }
+
+    // MARK: - Add validation
+
+    func testAddRejectsContentAndFromFileTogether() {
+        XCTAssertThrowsError(
+            try PromptsCommand.AddSubcommand.parse([
+                "--name", "X", "--content", "body", "--from-file", "/tmp/file.txt"
+            ])
+        )
+    }
+
+    func testAddAllowsNeitherSet() {
+        // Neither set means "read body from stdin" — parsing must succeed; the
+        // empty-body guard runs in run(), not validate().
+        XCTAssertNoThrow(try PromptsCommand.AddSubcommand.parse(["--name", "X"]))
+    }
+
+    func testAddRejectsEmptyName() {
+        XCTAssertThrowsError(
+            try PromptsCommand.AddSubcommand.parse(["--name", "   ", "--content", "body"])
+        )
+    }
+
+    // MARK: - JSON encoder
+
     func testCLIJSONEncoderEmitsParseableJSON() throws {
         let db = try DatabaseManager()
         let repo = PromptRepository(dbQueue: db.dbQueue)

--- a/Tests/CLITests/PromptsCommandTests.swift
+++ b/Tests/CLITests/PromptsCommandTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import XCTest
+@testable import CLI
+@testable import MacParakeetCore
+
+final class PromptsCommandTests: XCTestCase {
+
+    // MARK: - findPrompt
+
+    func testFindPromptByExactUUID() throws {
+        let db = try DatabaseManager()
+        let repo = PromptRepository(dbQueue: db.dbQueue)
+        let p = Prompt(name: "Custom A", content: "Hello")
+        try repo.save(p)
+
+        let found = try findPrompt(idOrName: p.id.uuidString, repo: repo)
+        XCTAssertEqual(found.id, p.id)
+    }
+
+    func testFindPromptByPrefix() throws {
+        let db = try DatabaseManager()
+        let repo = PromptRepository(dbQueue: db.dbQueue)
+        let p = Prompt(name: "Custom B", content: "Hello")
+        try repo.save(p)
+
+        let prefix = String(p.id.uuidString.prefix(8))
+        let found = try findPrompt(idOrName: prefix, repo: repo)
+        XCTAssertEqual(found.id, p.id)
+    }
+
+    func testFindPromptByNameCaseInsensitive() throws {
+        let db = try DatabaseManager()
+        let repo = PromptRepository(dbQueue: db.dbQueue)
+        let p = Prompt(name: "My Special Prompt", content: "Hello")
+        try repo.save(p)
+
+        let found = try findPrompt(idOrName: "my special prompt", repo: repo)
+        XCTAssertEqual(found.id, p.id)
+    }
+
+    func testFindPromptThrowsNotFoundForBogusInput() throws {
+        let db = try DatabaseManager()
+        let repo = PromptRepository(dbQueue: db.dbQueue)
+
+        XCTAssertThrowsError(try findPrompt(idOrName: "nonexistent-prompt-name", repo: repo)) { error in
+            guard let lookupError = error as? CLILookupError else {
+                return XCTFail("Expected CLILookupError, got \(error)")
+            }
+            if case .notFound = lookupError {} else {
+                XCTFail("Expected .notFound, got \(lookupError)")
+            }
+        }
+    }
+
+    func testFindPromptThrowsEmptyIDForWhitespace() throws {
+        let db = try DatabaseManager()
+        let repo = PromptRepository(dbQueue: db.dbQueue)
+
+        XCTAssertThrowsError(try findPrompt(idOrName: "   ", repo: repo)) { error in
+            guard let lookupError = error as? CLILookupError else {
+                return XCTFail("Expected CLILookupError")
+            }
+            if case .emptyID = lookupError {} else {
+                XCTFail("Expected .emptyID, got \(lookupError)")
+            }
+        }
+    }
+
+    func testFindPromptThrowsAmbiguousForSharedPrefix() throws {
+        let db = try DatabaseManager()
+        let repo = PromptRepository(dbQueue: db.dbQueue)
+
+        let uuid1 = UUID(uuidString: "CCDDEEFF-1111-1111-1111-111111111111")!
+        let uuid2 = UUID(uuidString: "CCDDEEFF-2222-2222-2222-222222222222")!
+        try repo.save(Prompt(id: uuid1, name: "X", content: "x"))
+        try repo.save(Prompt(id: uuid2, name: "Y", content: "y"))
+
+        XCTAssertThrowsError(try findPrompt(idOrName: "CCDDEEFF", repo: repo)) { error in
+            guard let lookupError = error as? CLILookupError else {
+                return XCTFail("Expected CLILookupError")
+            }
+            if case .ambiguous = lookupError {} else {
+                XCTFail("Expected .ambiguous, got \(lookupError)")
+            }
+        }
+    }
+
+    func testFindPromptPrefersIDPrefixOverName() throws {
+        // If a name happens to look like a UUID prefix that also matches a real
+        // prompt's UUID, the ID match wins. This mirrors the precedence in
+        // findTranscription/findDictation.
+        let db = try DatabaseManager()
+        let repo = PromptRepository(dbQueue: db.dbQueue)
+
+        let realID = UUID(uuidString: "DEADBEEF-1111-1111-1111-111111111111")!
+        try repo.save(Prompt(id: realID, name: "Real", content: "real"))
+        try repo.save(Prompt(name: "deadbeef", content: "name-only"))
+
+        let found = try findPrompt(idOrName: "deadbeef", repo: repo)
+        XCTAssertEqual(found.id, realID, "ID prefix match should beat case-insensitive name match")
+    }
+
+    // MARK: - cliJSONEncoder smoke
+
+    func testCLIJSONEncoderEmitsParseableJSON() throws {
+        let db = try DatabaseManager()
+        let repo = PromptRepository(dbQueue: db.dbQueue)
+        let p = Prompt(name: "JSON Test", content: "Body")
+        try repo.save(p)
+
+        let prompts = try repo.fetchAll()
+        let data = try cliJSONEncoder.encode(prompts)
+
+        let parsed = try JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+        XCTAssertNotNil(parsed)
+        XCTAssertEqual(parsed?.first?["name"] as? String, "JSON Test")
+    }
+}

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -26,34 +26,49 @@ This script builds the latest debug binary, stops stale `/Applications`/`dist` a
 macparakeet-cli
 ├── transcribe <input> [options]         Transcribe a file or YouTube URL
 ├── history                              View and manage history
-│   ├── dictations [--limit]             List recent dictations (default)
-│   ├── transcriptions [--limit]         List recent transcriptions
-│   ├── search <query> [--limit]         Search dictation history
-│   ├── search-transcriptions <query> [--limit]  Search transcriptions by keyword
+│   ├── dictations [--limit] [--json]    List recent dictations (default)
+│   ├── transcriptions [--limit] [--json]  List recent transcriptions
+│   ├── search <query> [--limit] [--json]  Search dictation history
+│   ├── search-transcriptions <query> [--limit] [--json]  Search transcriptions
 │   ├── delete-dictation <id>            Delete a dictation by ID
 │   ├── delete-transcription <id>        Delete a transcription by ID
-│   ├── favorites                        List favorite transcriptions
+│   ├── favorites [--json]               List favorite transcriptions
 │   ├── favorite <id>                    Mark a transcription as favorite
 │   └── unfavorite <id>                  Remove from favorites
 ├── export <id> [options]                Export a transcription to file
-├── stats                                Show voice stats dashboard
-├── health [--repair-models]             System health and model status
+├── stats [--json]                       Show voice stats dashboard
+├── health [--repair-models] [--json]    System health and model status
 ├── models                               Speech model lifecycle
-│   ├── status                           Show model status
+│   ├── status [--json]                  Show model status
 │   ├── warm-up [--attempts]             Warm up speech model
 │   ├── repair [--attempts]              Best-effort model repair
 │   └── clear                            Delete cached models
 ├── flow                                 Text processing pipeline
 │   ├── process <text> [--copy]          Run clean text processing
 │   ├── words {list,add,delete}          Manage custom words
+│   │   └── list [--source manual|learned|all] [--json]
 │   └── snippets {list,add,delete}       Manage text snippets
+│       └── list [--json]
 ├── llm                                  LLM provider commands
 │   ├── test-connection                  Test provider connectivity
 │   ├── summarize <input>                Summarize text via LLM
 │   ├── chat <input> --question          Ask about a transcript
 │   └── transform <input> --prompt       Apply custom LLM transform
+├── prompts                              Manage prompt library
+│   ├── list [--filter all|visible|auto-run] [--json]
+│   ├── show <id-or-name> [--json]
+│   ├── add --name X (--content Y | --from-file path) [--auto-run]
+│   ├── set <id-or-name> [--visible|--hidden] [--auto-run|--no-auto-run]
+│   ├── delete <id-or-name>              Delete custom prompt (built-ins protected)
+│   ├── restore-defaults                 Re-show all built-in prompts
+│   └── run <id-or-name> --transcription <id> [--no-store] [--stream] [--extra ...]
 └── feedback <message> [options]         Submit feedback
 ```
+
+> **JSON output convention**: any query command marked `[--json]` emits a single
+> JSON document on stdout (ISO-8601 dates, sorted keys, pretty-printed). Pipe to
+> `jq` or any JSON tool. Side-effect commands (delete, favorite, etc.) print one
+> confirmation line and don't accept `--json`.
 
 ## Core Modes
 
@@ -301,6 +316,78 @@ swift run macparakeet-cli llm summarize transcript.txt --provider cli --command 
 # Custom command
 swift run macparakeet-cli llm chat transcript.txt --provider cli --command "my-tool --stdin" --question "Key points?"
 ```
+
+## Prompt Library
+
+The prompt library powers multi-summary results in the GUI. The CLI lets you
+seed test prompts, audit migration state, and exercise the summary write path
+without launching the app.
+
+### List, show, add
+
+```bash
+# Lists default to "all"; --filter narrows to visible-only or auto-run-only.
+swift run macparakeet-cli prompts list
+swift run macparakeet-cli prompts list --filter auto-run --json | jq '.[].name'
+
+# Show full content. <id-or-name> accepts UUID, UUID prefix, or exact name.
+swift run macparakeet-cli prompts show "Summary"
+swift run macparakeet-cli prompts show A4882688
+
+# Add a custom prompt. Either --content or --from-file is required.
+swift run macparakeet-cli prompts add --name "Daily Notes" \
+  --content "Extract action items grouped by person."
+swift run macparakeet-cli prompts add --name "From File" --from-file ./prompt.md
+echo "Inline body" | swift run macparakeet-cli prompts add --name "Piped" --from-file /dev/stdin
+```
+
+### Visibility / auto-run toggles
+
+`set` accepts mutually exclusive flag pairs. Hidden implies not auto-run; auto-run
+implies visible — these invariants are enforced.
+
+```bash
+swift run macparakeet-cli prompts set "Daily Notes" --auto-run
+swift run macparakeet-cli prompts set "Daily Notes" --hidden
+swift run macparakeet-cli prompts set "Summary" --no-auto-run
+```
+
+### Delete and restore
+
+```bash
+swift run macparakeet-cli prompts delete "Daily Notes"
+swift run macparakeet-cli prompts restore-defaults   # re-shows hidden built-ins
+```
+
+Built-in prompts cannot be deleted; the CLI surfaces a clear error and suggests
+`prompts set <name> --hidden` instead.
+
+### Run a prompt against a transcription
+
+`prompts run` calls the configured LLM provider with the prompt as system message
+and the transcription text as input. By default it persists the result to the
+`summaries` table so the GUI sees it on the next reload.
+
+```bash
+swift run macparakeet-cli prompts run "Summary" \
+  --transcription <transcription-id> \
+  --provider anthropic --api-key sk-ant-...
+
+# Stream output and skip persistence (preview-only)
+swift run macparakeet-cli prompts run "Action Items & Decisions" \
+  --transcription a3f7 \
+  --provider openai --api-key sk-... \
+  --stream --no-store
+
+# Add per-run instructions (mirrors the GUI's regenerate-with-extra flow)
+swift run macparakeet-cli prompts run "Blog Post" \
+  --transcription a3f7 \
+  --provider anthropic --api-key sk-ant-... \
+  --extra "Tone: warm and direct. Audience: engineers."
+```
+
+`prompts run` writes the model output to **stdout** and the "Saved PromptResult X"
+confirmation to **stderr**, so `> result.txt` captures only the prompt output.
 
 ## Feedback
 

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -334,11 +334,13 @@ swift run macparakeet-cli prompts list --filter auto-run --json | jq '.[].name'
 swift run macparakeet-cli prompts show "Summary"
 swift run macparakeet-cli prompts show A4882688
 
-# Add a custom prompt. Either --content or --from-file is required.
+# Add a custom prompt. Body precedence: --content > --from-file > stdin.
 swift run macparakeet-cli prompts add --name "Daily Notes" \
   --content "Extract action items grouped by person."
 swift run macparakeet-cli prompts add --name "From File" --from-file ./prompt.md
-echo "Inline body" | swift run macparakeet-cli prompts add --name "Piped" --from-file /dev/stdin
+
+# Pipe via stdin when both --content and --from-file are omitted.
+cat ./prompt.md | swift run macparakeet-cli prompts add --name "Piped"
 ```
 
 ### Visibility / auto-run toggles

--- a/plans/active/cli-prompts-and-json-output.md
+++ b/plans/active/cli-prompts-and-json-output.md
@@ -28,7 +28,7 @@ parity for parity's sake. Each addition has a concrete dev/CI/agent use case.
 
 ### 1. `prompts` subcommand (new)
 
-```
+```text
 prompts list [--visible | --auto-run | --all] [--json]
 prompts show <id-or-name> [--json]
 prompts add --name "X" [--content "..." | --from-file path]
@@ -82,7 +82,7 @@ confirmation line; JSON would be noise).
 
 ### 3. `--source` filter on `flow words list`
 
-```
+```text
 flow words list [--source manual|learned|all] [--json]
 ```
 
@@ -108,7 +108,7 @@ Default: `all`. Closes a real GUI/CLI gap — the source column exists and is me
 
 | Decision | Choice | Why |
 |---|---|---|
-| Prompt set semantics | `--visible|--hidden` and `--auto-run|--no-auto-run` mutually-exclusive flag pairs | Idempotent; agents want "set to X," not "flip" |
+| Prompt set semantics | `--visible`/`--hidden` and `--auto-run`/`--no-auto-run` mutually-exclusive flag pairs | Idempotent; agents want "set to X," not "flip" |
 | Prompt delete on built-in | Error with clear message | Matches repo behavior; `restore-defaults` handles re-show case |
 | `prompts run` default | `--store true` (use `--no-store` to opt out) | The verb implies the action; opt-out preserves preview workflow |
 | JSON encoder | iso8601 dates, pretty-printed, sorted keys | Matches `CalendarCommand`; single convention is easier to remember |

--- a/plans/active/cli-prompts-and-json-output.md
+++ b/plans/active/cli-prompts-and-json-output.md
@@ -31,8 +31,9 @@ parity for parity's sake. Each addition has a concrete dev/CI/agent use case.
 ```
 prompts list [--visible | --auto-run | --all] [--json]
 prompts show <id-or-name> [--json]
-prompts add --name "X" (--content "..." | --from-file path | (stdin if both omitted))
+prompts add --name "X" [--content "..." | --from-file path]
             [--auto-run]
+            (if both --content and --from-file are omitted, body is read from stdin)
 prompts set <id-or-name> [--visible|--hidden] [--auto-run|--no-auto-run]
 prompts delete <id-or-name>
 prompts restore-defaults

--- a/plans/active/cli-prompts-and-json-output.md
+++ b/plans/active/cli-prompts-and-json-output.md
@@ -1,0 +1,160 @@
+# Plan: CLI prompts subsystem + structured output
+
+> Status: **ACTIVE**
+> Branch: `feat/cli-prompts-and-json`
+> Owner: agent (Claude)
+> Related: `MEMORY.md` decision *"CLI stays as internal dev tool"*
+
+## Why
+
+The CLI was last meaningfully expanded around v0.4. Two GUI table groups added since
+have **no CLI access at all**:
+
+- `prompts` (added v0.5, ADR-013)
+- `summaries` aka `PromptResult` (added v0.5, ADR-013)
+
+That makes those features the *only* parts of the data model an agent or CI run cannot
+touch headlessly. We hit the friction every time we want to verify a prompt-library
+migration, seed test prompts, or smoke-test the multi-summary write path.
+
+Separately, every CLI query command except `transcribe` and `calendar upcoming` emits
+human-formatted text only, so anything an agent or script wants to consume requires
+fragile output-parsing.
+
+This plan addresses both. It is **scoped deliberately small** — we are not pursuing
+parity for parity's sake. Each addition has a concrete dev/CI/agent use case.
+
+## What's in scope
+
+### 1. `prompts` subcommand (new)
+
+```
+prompts list [--visible | --auto-run | --all] [--json]
+prompts show <id-or-name> [--json]
+prompts add --name "X" (--content "..." | --from-file path | (stdin if both omitted))
+            [--auto-run]
+prompts set <id-or-name> [--visible|--hidden] [--auto-run|--no-auto-run]
+prompts delete <id-or-name>
+prompts restore-defaults
+prompts run <id-or-name> --transcription <id> [--no-store] [--stream]
+            [--extra "additional instructions"]
+            (LLM provider options: --provider --api-key --model --base-url --command)
+```
+
+**Lookup**: `<id-or-name>` accepts UUID exact, UUID prefix, or case-insensitive name.
+Mirrors the `findTranscription` / `findDictation` resolve-and-error pattern. Ambiguity
+is surfaced.
+
+**Set semantics**: respects the repo's invariants — hidden implies not auto-run; auto-run
+implies visible. Implemented via fetch + mutate + `repo.save()` (GRDB upsert).
+
+**Delete**: refuses built-ins (matches `PromptRepository.delete` returning `false`).
+CLI surfaces a clear error.
+
+**Run**: defaults to `--store true` because the whole point of this command is to
+exercise the persistence path. `--no-store` opts out (handy for "preview only" runs).
+
+### 2. `--json` sweep on query commands
+
+Add `--json` to:
+
+- `history dictations`
+- `history transcriptions`
+- `history search`
+- `history search-transcriptions`
+- `history favorites`
+- `stats`
+- `flow words list`
+- `flow snippets list`
+- `health`
+- `models status`
+
+Encoder convention: `JSONEncoder` with `.iso8601`, `[.prettyPrinted, .sortedKeys]`,
+matching `CalendarCommand`. Top level is an array for list commands, an object for
+single-record / status commands.
+
+**NOT swept** (intentional): `transcribe` (already has `--format json`), `export`
+(`--format` is the export-format selector, different concept), `flow process`
+(returns processed text — JSON wrapping has no value), every side-effect command
+(`delete-*`, `favorite`, `unfavorite`, `flow words add`, etc. — they print one
+confirmation line; JSON would be noise).
+
+### 3. `--source` filter on `flow words list`
+
+```
+flow words list [--source manual|learned|all] [--json]
+```
+
+Default: `all`. Closes a real GUI/CLI gap — the source column exists and is meaningful
+(manual = user-typed, learned = vocabulary anchor) but invisible to the CLI today.
+
+## What's explicitly out of scope
+
+- **`meetings` subcommand.** Real value, but parking it until we feel the friction
+  (next time we debug a meeting-pipeline regression). Recovery is also nicer to design
+  *after* ADR-019 lands.
+- **`settings get/set`.** Punt until we have a clear use case beyond `defaults write`.
+- **`llm config show` reading from Keychain.** Keychain ACLs depend on code-signing
+  identity; the dev CLI binary signs differently than the bundled app, so this would
+  need careful entitlement + signing work for marginal gain. Current
+  `--provider --api-key` flow is fine.
+- **Chat conversation persistence.** `llm chat` is a one-shot — no need for
+  multi-conversation persistence in the CLI.
+- **Diarization speaker rename.** GUI-only; no agent use case yet.
+- **Hotkey config from CLI.** Format is complex, GUI is fine.
+
+## Design decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| Prompt set semantics | `--visible|--hidden` and `--auto-run|--no-auto-run` mutually-exclusive flag pairs | Idempotent; agents want "set to X," not "flip" |
+| Prompt delete on built-in | Error with clear message | Matches repo behavior; `restore-defaults` handles re-show case |
+| `prompts run` default | `--store true` (use `--no-store` to opt out) | The verb implies the action; opt-out preserves preview workflow |
+| JSON encoder | iso8601 dates, pretty-printed, sorted keys | Matches `CalendarCommand`; single convention is easier to remember |
+| Lookup helper location | `Sources/CLI/Commands/CLIHelpers.swift` | Already houses `findTranscription`/`findDictation` — same shape |
+| Should `prompts run` accept extra instructions? | Yes, via `--extra "..."` | Mirrors GUI's regenerate-with-extra flow; stored on `PromptResult.extraInstructions` |
+
+## Tests
+
+- `Tests/CLITests/PromptsCommandTests.swift`
+  - `findPrompt` resolution: by UUID, by prefix, by name (case-insensitive), not-found, ambiguous.
+  - That's it for now — full integration of `prompts run` requires a live LLM and is exercised manually.
+- One smoke test asserting `history dictations --json` emits parseable JSON for a seeded record.
+
+Aim: ~6-8 new test cases. We have 1521+ tests; we are not trying to add a hundred more.
+
+## Files touched
+
+**New:**
+- `Sources/CLI/Commands/PromptsCommand.swift`
+- `Tests/CLITests/PromptsCommandTests.swift`
+
+**Modified:**
+- `Sources/CLI/MacParakeetCLI.swift` — register PromptsCommand
+- `Sources/CLI/Commands/CLIHelpers.swift` — add `findPrompt`
+- `Sources/CLI/Commands/HistoryCommand.swift` — `--json` x5
+- `Sources/CLI/Commands/StatsCommand.swift` — `--json`
+- `Sources/CLI/Commands/FlowWordsCommand.swift` — `--source`, `--json`
+- `Sources/CLI/Commands/FlowSnippetsCommand.swift` — `--json`
+- `Sources/CLI/Commands/HealthCommand.swift` — `--json`
+- `Sources/CLI/Commands/ModelsCommand.swift` — `--json` (status only)
+- `docs/cli-testing.md` — add prompts section, document `--json`, document `--source`
+
+## Acceptance
+
+- `swift build` passes.
+- `swift test` shows green for new + existing CLI tests.
+- `swift run macparakeet-cli prompts list` emits the 6 built-ins after a fresh DB.
+- `swift run macparakeet-cli history dictations --json | jq .` parses cleanly.
+- `swift run macparakeet-cli prompts add --name "Test" --content "Hi" && \
+  swift run macparakeet-cli prompts list | grep Test` works end-to-end.
+
+## Risks / things to watch
+
+- **GRDB upsert via `save`**: `Prompt` has `id: UUID` as primary key and is
+  `PersistableRecord`. Calling `save` on an existing prompt updates it in place —
+  this is what we want for `set`. Verified by reading repo code.
+- **Built-in deletion**: silently returns `false` from repo. CLI must check the
+  return value and emit a clear error (don't print "Deleted" on a no-op).
+- **Empty `summaries` after `prompts run --no-store`**: confirm we don't accidentally
+  call `repo.save` when storage is opted out.


### PR DESCRIPTION
## Why

The CLI has been the only headless surface for the data model since v0.1, but two GUI-era table groups had **no CLI access at all**:

- `prompts` (added v0.5, ADR-013) — the prompt library
- `summaries` aka `PromptResult` (added v0.5) — the multi-summary store

Anything an agent or CI script wanted to verify in those tables required launching the GUI. Separately, every CLI query command except `transcribe` and `calendar upcoming` emitted human-formatted text only, so structured consumption needed fragile output-parsing.

Per `MEMORY.md`, the CLI is an internal dev/agent tool — not a user-facing surface. This PR closes the two highest-leverage gaps for that role and explicitly defers the rest (meetings, settings, llm config from Keychain, …) until we feel concrete friction. See `plans/active/cli-prompts-and-json-output.md` for the full scope-out and rationale.

## What's new

### `prompts` subcommand

```
macparakeet-cli prompts
├── list [--filter all|visible|auto-run] [--json]
├── show <id-or-name> [--json]
├── add  --name X [--content Y | --from-file path]   # body via stdin if both omitted
├── set  <id-or-name> [--visible|--hidden] [--auto-run|--no-auto-run]
├── delete <id-or-name>
├── restore-defaults
└── run <id-or-name> --transcription <id> [--no-store] [--stream] [--extra ...]
```

`<id-or-name>` accepts UUID, UUID prefix, or case-insensitive name (mirrors `findTranscription` / `findDictation`). `set` enforces the same invariants as the GUI's toggle methods: hidden ⇒ not auto-run; auto-run ⇒ visible. The contradictory `--hidden --auto-run` combination is rejected in `validate()`. Built-in delete is refused with a clear error and points the user to `set --hidden`.

`prompts add` body precedence is `--content > --from-file > stdin`, so `cat prompt.md | macparakeet-cli prompts add --name X` works for piped workflows.

### `--json` sweep on query commands

Added to `history dictations | transcriptions | search | search-transcriptions | favorites`, `stats`, `health`, `models status`, `flow words list`, `flow snippets list`. Side-effect commands (delete, favorite, etc.) intentionally don't take `--json` — they print one confirmation line.

Single shared encoder + helper in `CLIHelpers.swift` matching the existing `CalendarCommand` convention (ISO-8601 dates, sorted keys, pretty-printed):

```swift
let cliJSONEncoder: JSONEncoder = { ... }()
func printJSON<T: Encodable>(_ value: T) throws { ... }
```

### `--source manual|learned|all` filter on `flow words list`

The `source` column has always been meaningful (manual = user-typed; learned = vocabulary anchor) but was invisible to the CLI. Now filterable.

### `--database` parity

`flow words add/delete` and `flow snippets add/delete` now accept `--database`, matching every other DB-touching CLI command. Required for end-to-end test isolation.

## Data flow for `prompts run`

```
                ┌──────────────────────┐
                │  prompts table       │
                │  (Prompt repo)       │
                └──────────┬───────────┘
                           │ findPrompt(idOrName:)
                           ▼
┌────────────────┐   ┌───────────────┐   ┌─────────────────────┐
│ transcriptions │──▶│ assembled     │──▶│ LLMService.         │
│ table (text)   │   │ systemPrompt  │   │ generatePromptResult│
└────────────────┘   │ + transcript  │   │ (or ...Stream)      │
                     └───────────────┘   └──────────┬──────────┘
                                                    │ output
                                          stdout ◀──┤
                                                    ▼ (unless --no-store)
                                          ┌──────────────────────┐
                                          │ summaries table      │
                                          │ (PromptResult)       │
                                          └──────────────────────┘
                                          stderr: "Saved PromptResult …"
```

The `assembledSystemPrompt(promptContent:extraInstructions:)` helper mirrors `PromptResultsViewModel.assembledSystemPrompt` so CLI runs match GUI behavior exactly.

## Tests

15 new tests in `Tests/CLITests/PromptsCommandTests.swift`:
- `findPrompt` resolution (UUID exact, prefix, name, ambiguity, ID-prefix-beats-name precedence, empty input).
- `prompts set` flag validation (mutually-exclusive pairs, contradictory hidden+auto-run, at-least-one required).
- `prompts add` argument validation (mutually-exclusive content+from-file, empty name, neither-set-allowed-for-stdin).
- JSON encoder smoke test.

Full suite: **1587 tests, 0 failures**.

## Test plan

- [x] `swift build --product macparakeet-cli` passes
- [x] `swift test` passes (1587 / 0 failures)
- [x] `prompts list` shows the 6 built-in seeds in a fresh DB
- [x] `prompts add` + `prompts set --hidden` + `prompts list --filter visible` works end-to-end
- [x] `prompts delete <built-in-name>` errors with a helpful message
- [x] `prompts add --hidden --auto-run` is rejected with a clear validation error
- [x] `cat prompt.md | prompts add --name X` reads body from stdin
- [x] `history dictations --json | jq .` parses
- [x] `flow words list --json` includes `source` field; `--source manual` filters correctly
- [x] `health --json` emits a single parseable JSON object on stdout
- [ ] (manual) `prompts run` against a real LLM provider — requires API key, exercised manually

## Review history

Codex + Gemini fresh-eye reviews caught two real issues, fixed in commit `4d1a40a`:
1. Plan/code drift: stdin fallback in `prompts add` was promised but blocked.
2. Silent precedence: `prompts set --hidden --auto-run` let auto-run quietly win.

Both reviewers confirmed:
- HealthCommand `--json` mode emits no stray stdout writes (collect-then-print refactor is airtight).
- No public API leakage from MacParakeetCore.
- No force-unwrap or partial-write hazards.

Pre-existing duplication (UUID-prefix matching in flow commands, FlowError vs CLILookupError) noted but declined as out-of-scope cleanup.

## Out of scope (intentionally)

- **`meetings` subcommand** — recovery just landed on main as ADR-019; we'll add CLI inspection when we next debug a meeting-pipeline regression.
- **`settings get/set`** — `defaults write` is fine for now.
- **`llm config` reading from Keychain** — Keychain ACLs depend on code-signing identity; the dev CLI signs differently than the bundled app, so this needs careful entitlement work for marginal gain. Current `--provider --api-key` flow stays.
- **Diarization speaker rename** — GUI-only; no agent use case yet.
- **Hotkey config** — niche format, GUI is fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
