### PR TITLE
[codex] Extract meeting recovery coordinator

### DIFF
--- a/Sources/MacParakeet/App/MeetingRecoveryCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecoveryCoordinator.swift
@@ -1,0 +1,212 @@
+import AppKit
+import Foundation
+import MacParakeetCore
+import MacParakeetViewModels
+
+@MainActor
+final class MeetingRecoveryCoordinator {
+    private let environmentProvider: () -> AppEnvironment?
+    private let settingsViewModel: SettingsViewModel
+    private let libraryViewModel: TranscriptionLibraryViewModel
+    private let meetingsViewModel: TranscriptionLibraryViewModel
+    private let onPresentRecoveredTranscription: (Transcription) -> Void
+
+    init(
+        environmentProvider: @escaping () -> AppEnvironment?,
+        settingsViewModel: SettingsViewModel,
+        libraryViewModel: TranscriptionLibraryViewModel,
+        meetingsViewModel: TranscriptionLibraryViewModel,
+        onPresentRecoveredTranscription: @escaping (Transcription) -> Void
+    ) {
+        self.environmentProvider = environmentProvider
+        self.settingsViewModel = settingsViewModel
+        self.libraryViewModel = libraryViewModel
+        self.meetingsViewModel = meetingsViewModel
+        self.onPresentRecoveredTranscription = onPresentRecoveredTranscription
+    }
+
+    func scheduleLaunchRecoveryScanIfReady(environment env: AppEnvironment) {
+        let onboardingDone = UserDefaults.standard.string(forKey: OnboardingViewModel.onboardingCompletedKey) != nil
+        guard onboardingDone else { return }
+
+        Task { [weak self] in
+            await self?.discoverAndPresentRecoveries(
+                recoveryService: env.meetingRecordingRecoveryService,
+                source: .launch
+            )
+        }
+    }
+
+    func presentPendingMeetingRecoveryDialog() {
+        guard let env = environmentProvider() else { return }
+
+        Task { [weak self] in
+            await self?.discoverAndPresentRecoveries(
+                recoveryService: env.meetingRecordingRecoveryService,
+                source: .settings
+            )
+        }
+    }
+
+    private func discoverAndPresentRecoveries(
+        recoveryService: MeetingRecordingRecoveryServicing,
+        source: TelemetryMeetingRecoverySource
+    ) async {
+        do {
+            let recoveries = try await recoveryService.discoverPendingRecoveries()
+            settingsViewModel.refreshPendingMeetingRecoveries()
+            guard !recoveries.isEmpty else { return }
+            Telemetry.send(.meetingRecoveryDiscovered(count: recoveries.count, source: source))
+            await presentMeetingRecoveryDialog(recoveries, recoveryService: recoveryService, source: source)
+        } catch {
+            await presentMeetingRecoveryError(error)
+        }
+    }
+
+    private func presentMeetingRecoveryDialog(
+        _ recoveries: [MeetingRecordingLockFile],
+        recoveryService: MeetingRecordingRecoveryServicing,
+        source: TelemetryMeetingRecoverySource
+    ) async {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "We found \(recoveries.count) interrupted recording\(recoveries.count == 1 ? "" : "s")"
+        alert.informativeText = recoveryDialogMessage(for: recoveries)
+        alert.addButton(withTitle: "Recover")
+        alert.addButton(withTitle: "Recover Later")
+        alert.addButton(withTitle: "Discard")
+
+        let response = await presentAlert(alert)
+        switch response {
+        case .alertFirstButtonReturn:
+            await recoverMeetingRecordings(
+                recoveries,
+                recoveryService: recoveryService,
+                source: source
+            )
+        case .alertThirdButtonReturn:
+            await discardMeetingRecoveries(
+                recoveries,
+                recoveryService: recoveryService,
+                source: source
+            )
+        default:
+            settingsViewModel.refreshPendingMeetingRecoveries()
+        }
+    }
+
+    private func recoveryDialogMessage(for recoveries: [MeetingRecordingLockFile]) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = .autoupdatingCurrent
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+
+        let sessionLines = recoveries.prefix(5).map { recovery in
+            "\(formatter.string(from: recovery.startedAt)) - \(recovery.displayName)"
+        }
+        let extraCount = max(0, recoveries.count - sessionLines.count)
+        let extraLine = extraCount > 0 ? ["and \(extraCount) more"] : []
+        return (sessionLines + extraLine).joined(separator: "\n")
+            + "\n\nRecovery transcribes the saved audio again and marks the result as recovered."
+    }
+
+    private func recoverMeetingRecordings(
+        _ recoveries: [MeetingRecordingLockFile],
+        recoveryService: MeetingRecordingRecoveryServicing,
+        source: TelemetryMeetingRecoverySource
+    ) async {
+        let startedAt = Date()
+        Telemetry.send(.meetingRecoveryStarted(count: recoveries.count, source: source))
+        var lastRecoveredIndex = -1
+        do {
+            var recovered: [Transcription] = []
+            for (index, recovery) in recoveries.enumerated() {
+                recovered.append(try await recoveryService.recover(recovery))
+                lastRecoveredIndex = index
+            }
+            Telemetry.send(.meetingRecoveryCompleted(
+                count: recovered.count,
+                durationSeconds: Date().timeIntervalSince(startedAt),
+                source: source
+            ))
+            libraryViewModel.loadTranscriptions()
+            meetingsViewModel.loadTranscriptions()
+            settingsViewModel.refreshPendingMeetingRecoveries()
+            if let first = recovered.first {
+                onPresentRecoveredTranscription(first)
+            }
+        } catch {
+            let pendingRecoveries = Array(recoveries.dropFirst(lastRecoveredIndex + 1))
+            Telemetry.send(.meetingRecoveryFailed(
+                count: pendingRecoveries.count,
+                source: source,
+                errorType: TelemetryErrorClassifier.classify(error),
+                errorDetail: TelemetryErrorClassifier.errorDetail(error)
+            ))
+            settingsViewModel.refreshPendingMeetingRecoveries()
+            await presentMeetingRecoveryError(
+                error,
+                recoveries: pendingRecoveries,
+                recoveryService: recoveryService,
+                source: source
+            )
+        }
+    }
+
+    private func discardMeetingRecoveries(
+        _ recoveries: [MeetingRecordingLockFile],
+        recoveryService: MeetingRecordingRecoveryServicing,
+        source: TelemetryMeetingRecoverySource
+    ) async {
+        do {
+            for recovery in recoveries {
+                try await recoveryService.discard(recovery)
+            }
+            Telemetry.send(.meetingRecoveryDiscarded(count: recoveries.count, source: source))
+            settingsViewModel.refreshPendingMeetingRecoveries()
+        } catch {
+            Telemetry.send(.meetingRecoveryFailed(
+                count: recoveries.count,
+                source: source,
+                errorType: TelemetryErrorClassifier.classify(error),
+                errorDetail: TelemetryErrorClassifier.errorDetail(error)
+            ))
+            settingsViewModel.refreshPendingMeetingRecoveries()
+            await presentMeetingRecoveryError(error)
+        }
+    }
+
+    private func presentMeetingRecoveryError(
+        _ error: Error,
+        recoveries: [MeetingRecordingLockFile] = [],
+        recoveryService: MeetingRecordingRecoveryServicing? = nil,
+        source: TelemetryMeetingRecoverySource = .launch
+    ) async {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Meeting Recovery Failed"
+        alert.informativeText = error.localizedDescription
+        alert.addButton(withTitle: "OK")
+        if !recoveries.isEmpty, recoveryService != nil {
+            alert.addButton(withTitle: "Discard Pending")
+        }
+        let response = await presentAlert(alert)
+        guard response == .alertSecondButtonReturn, let recoveryService else { return }
+        await discardMeetingRecoveries(recoveries, recoveryService: recoveryService, source: source)
+    }
+
+    private func presentAlert(_ alert: NSAlert) async -> NSApplication.ModalResponse {
+        NSApp.activate(ignoringOtherApps: true)
+
+        if let window = [NSApp.keyWindow, NSApp.mainWindow].compactMap({ $0 }).first(where: \.isVisible) {
+            return await withCheckedContinuation { continuation in
+                alert.beginSheetModal(for: window) { response in
+                    continuation.resume(returning: response)
+                }
+            }
+        }
+
+        // Launch recovery can happen before there is a window to host a sheet.
+        return alert.runModal()
+    }
+}

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -88,6 +88,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     )
 
+    private lazy var meetingRecoveryCoordinator = MeetingRecoveryCoordinator(
+        environmentProvider: { [weak self] in
+            self?.appEnvironment
+        },
+        settingsViewModel: settingsViewModel,
+        libraryViewModel: libraryViewModel,
+        meetingsViewModel: meetingsViewModel,
+        onPresentRecoveredTranscription: { [weak self] transcription in
+            guard let self else { return }
+            self.transcriptionViewModel.presentCompletedTranscription(transcription, autoSave: true)
+            self.mainWindowState.navigateToTranscription(from: .meetings)
+            self.windowCoordinator.openMainWindow()
+        }
+    )
+
     private lazy var windowCoordinator = AppWindowCoordinator(
         mainWindowState: mainWindowState,
         transcriptionViewModel: transcriptionViewModel,
@@ -286,7 +301,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     self?.presentHotkeyUnavailableAlertIfNeeded()
                 },
                 onRecoverPendingMeetingRecordings: { [weak self] in
-                    self?.presentPendingMeetingRecoveryDialog()
+                    self?.meetingRecoveryCoordinator.presentPendingMeetingRecoveryDialog()
                 }
             )
         )
@@ -300,7 +315,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         menuBarCoordinator.refreshMeetingHotkeyShortcut()
         menuBarCoordinator.refreshTranscriptionHotkeyShortcuts()
         onboardingCoordinator.maybeShow(environment: env)
-        scheduleLaunchRecoveryScanIfReady(environment: env)
+        meetingRecoveryCoordinator.scheduleLaunchRecoveryScanIfReady(environment: env)
     }
 
     private func presentEnvironmentSetupError(_ error: Error) {
@@ -452,178 +467,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         meetingRecordingFlowCoordinator?.toggleRecording()
     }
 
-    private func scheduleLaunchRecoveryScanIfReady(environment env: AppEnvironment) {
-        let onboardingDone = UserDefaults.standard.string(forKey: OnboardingViewModel.onboardingCompletedKey) != nil
-        guard onboardingDone else { return }
-
-        Task { [weak self] in
-            guard let self else { return }
-            do {
-                let recoveries = try await env.meetingRecordingRecoveryService.discoverPendingRecoveries()
-                self.settingsViewModel.refreshPendingMeetingRecoveries()
-                guard !recoveries.isEmpty else { return }
-                Telemetry.send(.meetingRecoveryDiscovered(count: recoveries.count, source: .launch))
-                self.presentMeetingRecoveryDialog(recoveries, source: .launch)
-            } catch {
-                self.presentMeetingRecoveryError(error)
-            }
-        }
-    }
-
-    private func presentPendingMeetingRecoveryDialog() {
-        guard let env = appEnvironment else { return }
-        Task { [weak self] in
-            guard let self else { return }
-            do {
-                let recoveries = try await env.meetingRecordingRecoveryService.discoverPendingRecoveries()
-                self.settingsViewModel.refreshPendingMeetingRecoveries()
-                guard !recoveries.isEmpty else { return }
-                Telemetry.send(.meetingRecoveryDiscovered(count: recoveries.count, source: .settings))
-                self.presentMeetingRecoveryDialog(recoveries, source: .settings)
-            } catch {
-                self.presentMeetingRecoveryError(error)
-            }
-        }
-    }
-
-    private func presentMeetingRecoveryDialog(
-        _ recoveries: [MeetingRecordingLockFile],
-        source: TelemetryMeetingRecoverySource
-    ) {
-        guard let env = appEnvironment else { return }
-
-        NSApp.activate(ignoringOtherApps: true)
-
-        let alert = NSAlert()
-        alert.alertStyle = .warning
-        alert.messageText = "We found \(recoveries.count) interrupted recording\(recoveries.count == 1 ? "" : "s")"
-        alert.informativeText = recoveryDialogMessage(for: recoveries)
-        alert.addButton(withTitle: "Recover")
-        alert.addButton(withTitle: "Recover Later")
-        alert.addButton(withTitle: "Discard")
-
-        let response = alert.runModal()
-        switch response {
-        case .alertFirstButtonReturn:
-            Task { [weak self] in
-                guard let self else { return }
-                await self.recoverMeetingRecordings(recoveries, environment: env, source: source)
-            }
-        case .alertThirdButtonReturn:
-            Task { [weak self] in
-                guard let self else { return }
-                await self.discardMeetingRecoveries(recoveries, environment: env, source: source)
-            }
-        default:
-            settingsViewModel.refreshPendingMeetingRecoveries()
-        }
-    }
-
-    private func recoveryDialogMessage(for recoveries: [MeetingRecordingLockFile]) -> String {
-        let formatter = DateFormatter()
-        formatter.locale = .autoupdatingCurrent
-        formatter.dateStyle = .medium
-        formatter.timeStyle = .short
-
-        let sessionLines = recoveries.prefix(5).map { recovery in
-            "\(formatter.string(from: recovery.startedAt)) - \(recovery.displayName)"
-        }
-        let extraCount = max(0, recoveries.count - sessionLines.count)
-        let extraLine = extraCount > 0 ? ["and \(extraCount) more"] : []
-        return (sessionLines + extraLine).joined(separator: "\n")
-            + "\n\nRecovery transcribes the saved audio again and marks the result as recovered."
-    }
-
-    private func recoverMeetingRecordings(
-        _ recoveries: [MeetingRecordingLockFile],
-        environment env: AppEnvironment,
-        source: TelemetryMeetingRecoverySource
-    ) async {
-        let startedAt = Date()
-        Telemetry.send(.meetingRecoveryStarted(count: recoveries.count, source: source))
-        var pendingRecoveries = recoveries
-        do {
-            var recovered: [Transcription] = []
-            for recovery in recoveries {
-                recovered.append(try await env.meetingRecordingRecoveryService.recover(recovery))
-                pendingRecoveries.removeAll { pending in
-                    pending.sessionId == recovery.sessionId
-                        && pending.folderURL?.path == recovery.folderURL?.path
-                }
-            }
-            Telemetry.send(.meetingRecoveryCompleted(
-                count: recovered.count,
-                durationSeconds: Date().timeIntervalSince(startedAt),
-                source: source
-            ))
-            libraryViewModel.loadTranscriptions()
-            meetingsViewModel.loadTranscriptions()
-            settingsViewModel.refreshPendingMeetingRecoveries()
-            if let first = recovered.first {
-                transcriptionViewModel.presentCompletedTranscription(first, autoSave: true)
-                mainWindowState.navigateToTranscription(from: .meetings)
-                windowCoordinator.openMainWindow()
-            }
-        } catch {
-            Telemetry.send(.meetingRecoveryFailed(
-                count: pendingRecoveries.count,
-                source: source,
-                errorType: TelemetryErrorClassifier.classify(error),
-                errorDetail: TelemetryErrorClassifier.errorDetail(error)
-            ))
-            settingsViewModel.refreshPendingMeetingRecoveries()
-            presentMeetingRecoveryError(error, recoveries: pendingRecoveries, environment: env, source: source)
-        }
-    }
-
-    private func discardMeetingRecoveries(
-        _ recoveries: [MeetingRecordingLockFile],
-        environment env: AppEnvironment,
-        source: TelemetryMeetingRecoverySource
-    ) async {
-        do {
-            for recovery in recoveries {
-                try await env.meetingRecordingRecoveryService.discard(recovery)
-            }
-            Telemetry.send(.meetingRecoveryDiscarded(count: recoveries.count, source: source))
-            settingsViewModel.refreshPendingMeetingRecoveries()
-        } catch {
-            Telemetry.send(.meetingRecoveryFailed(
-                count: recoveries.count,
-                source: source,
-                errorType: TelemetryErrorClassifier.classify(error),
-                errorDetail: TelemetryErrorClassifier.errorDetail(error)
-            ))
-            settingsViewModel.refreshPendingMeetingRecoveries()
-            presentMeetingRecoveryError(error)
-        }
-    }
-
     // MARK: - Alerts
-
-    private func presentMeetingRecoveryError(
-        _ error: Error,
-        recoveries: [MeetingRecordingLockFile] = [],
-        environment env: AppEnvironment? = nil,
-        source: TelemetryMeetingRecoverySource = .launch
-    ) {
-        NSApp.activate(ignoringOtherApps: true)
-
-        let alert = NSAlert()
-        alert.alertStyle = .warning
-        alert.messageText = "Meeting Recovery Failed"
-        alert.informativeText = error.localizedDescription
-        alert.addButton(withTitle: "OK")
-        if !recoveries.isEmpty, env != nil {
-            alert.addButton(withTitle: "Discard Pending")
-        }
-        let response = alert.runModal()
-        guard response == .alertSecondButtonReturn, let env else { return }
-        Task { [weak self] in
-            guard let self else { return }
-            await self.discardMeetingRecoveries(recoveries, environment: env, source: source)
-        }
-    }
 
     private func presentEntitlementsAlert(_ error: Error) {
         NSApp.activate(ignoringOtherApps: true)


### PR DESCRIPTION
## Summary

Extracts the meeting recording recovery modal workflow out of `AppDelegate` into a focused `MeetingRecoveryCoordinator`. The user-facing recovery flow and its telemetry are preserved; `AppDelegate` shrinks to wiring app state, window navigation, and callbacks.

One intentional UX change — recovery alerts now present as sheets when a host window is visible. See **Behavior Changes**.

## Responsibility Shape

```text
Before

AppDelegate
  |-- startup and environment setup
  |-- menu/window wiring
  |-- recording toggles
  `-- recovery discovery, alert flow, telemetry, refreshes

After

AppDelegate
  |-- startup and environment setup
  |-- menu/window wiring
  |-- recording toggles
  `-- MeetingRecoveryCoordinator
        |-- discover pending recoveries
        |-- present recover/recover-later/discard alert
        |-- run recover and discard actions
        |-- send recovery telemetry
        `-- refresh settings, library, and meetings views
```

## What Changed

- Added `Sources/MacParakeet/App/MeetingRecoveryCoordinator.swift`.
- Moved launch and Settings-triggered recovery discovery, alerts, recover/discard actions, telemetry, and view-model refreshes into the coordinator.
- `AppDelegate` retains app-level wiring and the final window navigation when a recovered transcription should be shown.
- Failed-recovery tracking now uses the last completed index instead of mutating the recoveries array inside the loop (O(N²) → O(N)).
- Stabilized two existing STTScheduler live-chunk backpressure tests after validation surfaced an enqueue-order race in the tests.

## Behavior Changes

- **Recovery alerts present as sheets when a host window is visible.** Previously every recovery alert used `alert.runModal()`, which is app-modal and blocks every window in the app. The coordinator now attaches the alert as a sheet to the key or main visible window, falling back to `runModal()` only when no window is visible — typically launch recovery before the first window exists. A Settings-triggered recovery alert no longer freezes the rest of the app while the user decides.

No persistence, recovery service, or recovery-state-machine behavior changed.

## Why This Is Worth Doing

The meeting recording resilience work pushed too much modal-workflow code into `AppDelegate`. Pulling it into a coordinator separates it from startup and window orchestration so future recovery changes are easier to review.

Deliberately conservative:

- No new persistence behavior.
- No new recovery service behavior.
- No new recovery state machine.
- No broad protocol layer just for tests.

## Reviewer Notes

1. `AppDelegate` should only wire `MeetingRecoveryCoordinator` in two places.
2. `MeetingRecoveryCoordinator` is mostly the previous `AppDelegate` recovery workflow moved into one file.
3. Alert presentation still works without a main window at launch (falls back to `runModal()`) and uses sheets when a visible host window exists.
4. The coordinator still refreshes settings/library/meetings views and still opens the first recovered transcription after a successful recovery.
5. The STTScheduler test-only delay just makes the existing backpressure tests deterministic; it does not change scheduler behavior.

## Validation

- `swift build`
- `swift build -c release`
- `swift build -Xswiftc -warn-concurrency`
- `swift test --filter STTSchedulerTests/testMeetingLiveChunkBackpressureDropsOldestPendingLiveChunk`
- `swift test --filter STTSchedulerTests/testMeetingLiveChunkBacklogLimitClampsToAtLeastOne`
- `swift test --parallel`
- `git diff --check`

Full local test result: 1585 XCTest tests passed, plus the Swift Testing suite passed.
