### PR TITLE
Remove legacy transcription summary mirror

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -134,7 +134,6 @@ final class AppEnvironmentConfigurer {
             llmService: hasLLMConfig ? env.llmService : nil,
             promptRepo: env.promptRepo,
             promptResultRepo: env.promptResultRepo,
-            transcriptionRepo: env.transcriptionRepo,
             configStore: env.llmConfigStore
         )
 
@@ -156,10 +155,6 @@ final class AppEnvironmentConfigurer {
         promptResultsViewModel.onPromptResultsChanged = { [weak self] transcriptionID, hasPromptResults in
             guard self?.transcriptionViewModel.currentTranscription?.id == transcriptionID else { return }
             self?.transcriptionViewModel.hasPromptResultTabs = hasPromptResults
-        }
-
-        promptResultsViewModel.onLegacySummaryChanged = { [weak self] transcriptionID, summary in
-            self?.transcriptionViewModel.updateLegacySummary(id: transcriptionID, summary: summary)
         }
 
         promptResultsViewModel.onGenerationCompleted = { [weak self] generationID, promptResultID in

--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -422,6 +422,16 @@ public final class DatabaseManager: Sendable {
             }
         }
 
+        // v0.7.6 - Drop legacy one-summary column after v0.7 migrates content to summaries.
+        migrator.registerMigration("v0.7.6-drop-legacy-transcription-summary") { db in
+            let columns = try db.columns(in: "transcriptions")
+            if columns.contains(where: { $0.name == "summary" }) {
+                try db.alter(table: "transcriptions") { t in
+                    t.drop(column: "summary")
+                }
+            }
+        }
+
         try migrator.migrate(dbQueue)
         try reconcileBuiltInPrompts()
     }

--- a/Sources/MacParakeetCore/Database/TranscriptionRepository.swift
+++ b/Sources/MacParakeetCore/Database/TranscriptionRepository.swift
@@ -13,7 +13,6 @@ public protocol TranscriptionRepositoryProtocol: Sendable {
     func deleteAll() throws
     func updateStatus(id: UUID, status: Transcription.TranscriptionStatus, errorMessage: String?) throws
     func updateFileName(id: UUID, fileName: String) throws
-    func updateSummary(id: UUID, summary: String?) throws
     func updateChatMessages(id: UUID, chatMessages: [ChatMessage]?) throws
     func updateSpeakers(id: UUID, speakers: [SpeakerInfo]?) throws
     func clearStoredAudioPathsForURLTranscriptions() throws
@@ -37,7 +36,6 @@ extension TranscriptionRepositoryProtocol {
     public func search(query: String, limit: Int?) throws -> [Transcription] { [] }
     public func clearStoredAudioPathsForURLTranscriptions() throws {}
     public func updateFileName(id: UUID, fileName: String) throws {}
-    public func updateSummary(id: UUID, summary: String?) throws {}
     public func updateChatMessages(id: UUID, chatMessages: [ChatMessage]?) throws {}
     public func updateSpeakers(id: UUID, speakers: [SpeakerInfo]?) throws {}
     public func updateFavorite(id: UUID, isFavorite: Bool) throws {}
@@ -170,15 +168,6 @@ public final class TranscriptionRepository: TranscriptionRepositoryProtocol {
         try dbQueue.write { db in
             guard var transcription = try Transcription.fetchOne(db, key: id) else { return }
             transcription.fileName = fileName
-            transcription.updatedAt = Date()
-            try transcription.update(db)
-        }
-    }
-
-    public func updateSummary(id: UUID, summary: String?) throws {
-        try dbQueue.write { db in
-            guard var transcription = try Transcription.fetchOne(db, key: id) else { return }
-            transcription.summary = summary
             transcription.updatedAt = Date()
             try transcription.update(db)
         }

--- a/Sources/MacParakeetCore/Models/Transcription.swift
+++ b/Sources/MacParakeetCore/Models/Transcription.swift
@@ -21,7 +21,6 @@ public struct Transcription: Codable, Identifiable, Sendable {
     public var speakerCount: Int?
     public var speakers: [SpeakerInfo]?
     public var diarizationSegments: [DiarizationSegmentRecord]?
-    public var summary: String?
     public var chatMessages: [ChatMessage]?
     public var status: TranscriptionStatus
     public var errorMessage: String?
@@ -56,7 +55,6 @@ public struct Transcription: Codable, Identifiable, Sendable {
         speakerCount: Int? = nil,
         speakers: [SpeakerInfo]? = nil,
         diarizationSegments: [DiarizationSegmentRecord]? = nil,
-        summary: String? = nil,
         chatMessages: [ChatMessage]? = nil,
         status: TranscriptionStatus = .processing,
         errorMessage: String? = nil,
@@ -83,7 +81,6 @@ public struct Transcription: Codable, Identifiable, Sendable {
         self.speakerCount = speakerCount
         self.speakers = speakers
         self.diarizationSegments = diarizationSegments
-        self.summary = summary
         self.chatMessages = chatMessages
         self.status = status
         self.errorMessage = errorMessage
@@ -143,7 +140,7 @@ extension Transcription: FetchableRecord, PersistableRecord {
     public enum Columns: String, ColumnExpression {
         case id, createdAt, fileName, filePath, fileSizeBytes, durationMs
         case rawTranscript, cleanTranscript, wordTimestamps, language
-        case speakerCount, speakers, diarizationSegments, summary, chatMessages
+        case speakerCount, speakers, diarizationSegments, chatMessages
         case status, errorMessage, exportPath, sourceURL
         case thumbnailURL, channelName, videoDescription, isFavorite, sourceType, recoveredFromCrash, updatedAt
     }
@@ -176,7 +173,6 @@ extension Transcription: FetchableRecord, PersistableRecord {
         }
 
         diarizationSegments = try container.decodeIfPresent([DiarizationSegmentRecord].self, forKey: .diarizationSegments)
-        summary = try container.decodeIfPresent(String.self, forKey: .summary)
         chatMessages = try container.decodeIfPresent([ChatMessage].self, forKey: .chatMessages)
         status = try container.decode(TranscriptionStatus.self, forKey: .status)
         errorMessage = try container.decodeIfPresent(String.self, forKey: .errorMessage)

--- a/Sources/MacParakeetViewModels/PromptResultsViewModel.swift
+++ b/Sources/MacParakeetViewModels/PromptResultsViewModel.swift
@@ -59,7 +59,6 @@ public final class PromptResultsViewModel {
     public var unreadPromptResultIDs: Set<UUID> = []
     public var onModelChanged: (() -> Void)?
     public var onPromptResultsChanged: ((UUID, Bool) -> Void)?
-    public var onLegacySummaryChanged: ((UUID, String?) -> Void)?
     public var onGenerationCompleted: ((UUID, UUID) -> Void)?
     public var onDeletedPromptResult: ((UUID) -> Void)?
     public var shouldMarkPromptResultUnread: ((UUID) -> Bool)?
@@ -67,7 +66,6 @@ public final class PromptResultsViewModel {
     private var llmService: LLMServiceProtocol?
     private var promptRepo: PromptRepositoryProtocol?
     private var promptResultRepo: PromptResultRepositoryProtocol?
-    private var transcriptionRepo: TranscriptionRepositoryProtocol?
     private var configStore: LLMConfigStoreProtocol?
     private var cliConfigStore: LocalCLIConfigStore?
     private var currentTranscriptionID: UUID?
@@ -128,14 +126,12 @@ public final class PromptResultsViewModel {
         llmService: LLMServiceProtocol?,
         promptRepo: PromptRepositoryProtocol?,
         promptResultRepo: PromptResultRepositoryProtocol?,
-        transcriptionRepo: TranscriptionRepositoryProtocol? = nil,
         configStore: LLMConfigStoreProtocol? = nil,
         cliConfigStore: LocalCLIConfigStore = LocalCLIConfigStore()
     ) {
         self.llmService = llmService
         self.promptRepo = promptRepo
         self.promptResultRepo = promptResultRepo
-        self.transcriptionRepo = transcriptionRepo
         self.configStore = configStore
         self.cliConfigStore = cliConfigStore
         loadVisiblePrompts()
@@ -255,11 +251,6 @@ public final class PromptResultsViewModel {
             _ = try promptResultRepo.delete(id: promptResult.id)
             promptResults.removeAll { $0.id == promptResult.id }
             unreadPromptResultIDs.remove(promptResult.id)
-            do {
-                try syncLegacySummary(for: promptResult.transcriptionId)
-            } catch {
-                logger.warning("Legacy summary sync failed after delete: \(error.localizedDescription, privacy: .public)")
-            }
             if let transcriptionID = currentTranscriptionID {
                 onPromptResultsChanged?(transcriptionID, !promptResults.isEmpty)
             }
@@ -433,12 +424,6 @@ public final class PromptResultsViewModel {
         } else {
             try promptResultRepo?.save(promptResult)
         }
-        do {
-            try transcriptionRepo?.updateSummary(id: generation.transcriptionId, summary: promptResult.content)
-            onLegacySummaryChanged?(generation.transcriptionId, promptResult.content)
-        } catch {
-            logger.warning("Legacy summary sync failed, prompt result saved successfully: \(error.localizedDescription, privacy: .public)")
-        }
 
         pendingGenerations.remove(at: index)
         streamingTask = nil
@@ -492,11 +477,5 @@ public final class PromptResultsViewModel {
     private func normalizedExtraInstructions(_ value: String) -> String? {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
-    }
-
-    private func syncLegacySummary(for transcriptionId: UUID) throws {
-        let latestPromptResult = try promptResultRepo?.fetchAll(transcriptionId: transcriptionId).first
-        try transcriptionRepo?.updateSummary(id: transcriptionId, summary: latestPromptResult?.content)
-        onLegacySummaryChanged?(transcriptionId, latestPromptResult?.content)
     }
 }

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -555,11 +555,6 @@ public final class TranscriptionViewModel {
         self.hasConversations = hasConversations
     }
 
-    public func updateLegacySummary(id: UUID, summary: String?) {
-        guard currentTranscription?.id == id else { return }
-        currentTranscription?.summary = summary
-    }
-
     public func updateLLMAvailability(_ available: Bool, llmService: LLMServiceProtocol? = nil) {
         self.llmAvailable = available
     }

--- a/Tests/MacParakeetTests/Database/DatabaseManagerTests.swift
+++ b/Tests/MacParakeetTests/Database/DatabaseManagerTests.swift
@@ -176,7 +176,7 @@ final class DatabaseManagerTests: XCTestCase {
         }
     }
 
-    func testPromptSummaryMigrationPreservesLegacySummaryColumn() throws {
+    func testPromptSummaryMigrationMovesLegacySummaryAndDropsColumn() throws {
         let tempDir = FileManager.default.temporaryDirectory
         let dbPath = tempDir.appendingPathComponent("prompt_summary_migration_\(UUID().uuidString).db").path
         let transcriptionID = UUID()
@@ -265,15 +265,11 @@ final class DatabaseManagerTests: XCTestCase {
                 sql: "SELECT content FROM summaries WHERE transcriptionId = ?",
                 arguments: [transcriptionID]
             )
-            let preservedLegacySummary = try String.fetchOne(
-                db,
-                sql: "SELECT summary FROM transcriptions WHERE id = ?",
-                arguments: [transcriptionID]
-            )
+            let transcriptionColumns = try db.columns(in: "transcriptions").map(\.name)
 
             XCTAssertEqual(migratedSummaryCount, 1)
             XCTAssertEqual(migratedSummaryContent, legacySummary)
-            XCTAssertEqual(preservedLegacySummary, legacySummary)
+            XCTAssertFalse(transcriptionColumns.contains("summary"))
         }
 
         try? FileManager.default.removeItem(atPath: dbPath)

--- a/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
@@ -178,26 +178,6 @@ final class TranscriptionRepositoryTests: XCTestCase {
         XCTAssertEqual(try repo.fetch(id: transcription.id)?.status, .cancelled)
     }
 
-    // MARK: - Summary Persistence
-
-    func testUpdateSummary() throws {
-        let transcription = Transcription(fileName: "test.mp3", status: .completed)
-        try repo.save(transcription)
-
-        try repo.updateSummary(id: transcription.id, summary: "This is a summary.")
-        let fetched = try repo.fetch(id: transcription.id)
-        XCTAssertEqual(fetched?.summary, "This is a summary.")
-    }
-
-    func testUpdateSummaryToNil() throws {
-        let transcription = Transcription(fileName: "test.mp3", summary: "Old summary", status: .completed)
-        try repo.save(transcription)
-
-        try repo.updateSummary(id: transcription.id, summary: nil)
-        let fetched = try repo.fetch(id: transcription.id)
-        XCTAssertNil(fetched?.summary)
-    }
-
     func testUpdateFileName() throws {
         let transcription = Transcription(fileName: "Meeting Apr 5", status: .completed)
         try repo.save(transcription)

--- a/Tests/MacParakeetTests/Services/MeetingRecordingRecoveryServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecordingRecoveryServiceTests.swift
@@ -392,7 +392,6 @@ private final class RecordingTranscriptionRepository: TranscriptionRepositoryPro
     func deleteAll() throws {}
     func updateStatus(id: UUID, status: Transcription.TranscriptionStatus, errorMessage: String?) throws {}
     func updateFileName(id: UUID, fileName: String) throws {}
-    func updateSummary(id: UUID, summary: String?) throws {}
     func updateChatMessages(id: UUID, chatMessages: [ChatMessage]?) throws {}
     func updateSpeakers(id: UUID, speakers: [SpeakerInfo]?) throws {}
     func clearStoredAudioPathsForURLTranscriptions() throws {}

--- a/Tests/MacParakeetTests/ViewModels/PromptResultsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/PromptResultsViewModelTests.swift
@@ -8,14 +8,12 @@ final class PromptResultsViewModelTests: XCTestCase {
     var llm: MockLLMService!
     var promptRepo: MockPromptRepository!
     var promptResultRepo: MockPromptResultRepository!
-    var transcriptionRepo: MockTranscriptionRepository!
 
     override func setUp() {
         viewModel = PromptResultsViewModel()
         llm = MockLLMService()
         promptRepo = MockPromptRepository()
         promptResultRepo = MockPromptResultRepository()
-        transcriptionRepo = MockTranscriptionRepository()
         promptRepo.prompts = Prompt.builtInPrompts()
     }
 
@@ -23,8 +21,7 @@ final class PromptResultsViewModelTests: XCTestCase {
         viewModel.configure(
             llmService: llm,
             promptRepo: promptRepo,
-            promptResultRepo: promptResultRepo,
-            transcriptionRepo: transcriptionRepo
+            promptResultRepo: promptResultRepo
         )
 
         XCTAssertEqual(viewModel.visiblePrompts.count, 6)
@@ -33,9 +30,8 @@ final class PromptResultsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.canGenerateManualPromptResult)
     }
 
-    func testGeneratePromptResultPersistsCustomPromptAndLegacySummary() async throws {
+    func testGeneratePromptResultPersistsCustomPromptResult() async throws {
         let transcriptionID = UUID()
-        var mirroredLegacySummary: String?
         let prompt = Prompt(
             name: "Action Items",
             content: "Extract action items only.",
@@ -48,12 +44,8 @@ final class PromptResultsViewModelTests: XCTestCase {
         viewModel.configure(
             llmService: llm,
             promptRepo: promptRepo,
-            promptResultRepo: promptResultRepo,
-            transcriptionRepo: transcriptionRepo
+            promptResultRepo: promptResultRepo
         )
-        viewModel.onLegacySummaryChanged = { _, summary in
-            mirroredLegacySummary = summary
-        }
         viewModel.selectedPrompt = prompt
         viewModel.extraInstructions = "Return terse bullet points."
         llm.streamTokens = ["Task ", "one"]
@@ -70,8 +62,6 @@ final class PromptResultsViewModelTests: XCTestCase {
         XCTAssertEqual(promptResultRepo.saveCalls[0].promptName, "Action Items")
         XCTAssertEqual(promptResultRepo.saveCalls[0].extraInstructions, "Return terse bullet points.")
         XCTAssertEqual(promptResultRepo.saveCalls[0].content, "Task one")
-        XCTAssertEqual(transcriptionRepo.updateSummaryCalls.last?.summary, "Task one")
-        XCTAssertEqual(mirroredLegacySummary, "Task one")
         XCTAssertEqual(
             llm.lastSummarySystemPrompt,
             "Extract action items only.\n\nReturn terse bullet points."
@@ -93,8 +83,7 @@ final class PromptResultsViewModelTests: XCTestCase {
         viewModel.configure(
             llmService: llm,
             promptRepo: promptRepo,
-            promptResultRepo: promptResultRepo,
-            transcriptionRepo: transcriptionRepo
+            promptResultRepo: promptResultRepo
         )
         viewModel.shouldMarkPromptResultUnread = { _ in true }
         llm.streamTokens = ["Done"]
@@ -124,8 +113,7 @@ final class PromptResultsViewModelTests: XCTestCase {
         viewModel.configure(
             llmService: llm,
             promptRepo: promptRepo,
-            promptResultRepo: promptResultRepo,
-            transcriptionRepo: transcriptionRepo
+            promptResultRepo: promptResultRepo
         )
 
         XCTAssertTrue(viewModel.canGeneratePromptResult)
@@ -149,8 +137,7 @@ final class PromptResultsViewModelTests: XCTestCase {
         viewModel.configure(
             llmService: llm,
             promptRepo: promptRepo,
-            promptResultRepo: promptResultRepo,
-            transcriptionRepo: transcriptionRepo
+            promptResultRepo: promptResultRepo
         )
         viewModel.loadPromptResults(transcriptionId: transcriptionID)
         llm.streamTokens = ["New ", "summary"]
@@ -167,7 +154,7 @@ final class PromptResultsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.promptResults.first?.id, generationID)
     }
 
-    func testDeletePromptResultUpdatesLegacySummaryFromLatestRemainingResult() throws {
+    func testDeletePromptResultRemovesResultAndKeepsRemainingPromptResults() throws {
         let transcriptionID = UUID()
         let older = PromptResult(
             transcriptionId: transcriptionID,
@@ -190,8 +177,7 @@ final class PromptResultsViewModelTests: XCTestCase {
         viewModel.configure(
             llmService: llm,
             promptRepo: promptRepo,
-            promptResultRepo: promptResultRepo,
-            transcriptionRepo: transcriptionRepo
+            promptResultRepo: promptResultRepo
         )
         viewModel.loadPromptResults(transcriptionId: transcriptionID)
 
@@ -199,15 +185,13 @@ final class PromptResultsViewModelTests: XCTestCase {
 
         XCTAssertEqual(promptResultRepo.deleteCalls, [newer.id])
         XCTAssertEqual(viewModel.promptResults.map(\.content), ["Older"])
-        XCTAssertEqual(transcriptionRepo.updateSummaryCalls.last?.summary, "Older")
     }
 
     func testAutoGeneratePromptResultsSkipsShortTranscript() {
         viewModel.configure(
             llmService: llm,
             promptRepo: promptRepo,
-            promptResultRepo: promptResultRepo,
-            transcriptionRepo: transcriptionRepo
+            promptResultRepo: promptResultRepo
         )
 
         let queuedIDs = viewModel.autoGeneratePromptResults(
@@ -227,8 +211,7 @@ final class PromptResultsViewModelTests: XCTestCase {
         viewModel.configure(
             llmService: llm,
             promptRepo: promptRepo,
-            promptResultRepo: promptResultRepo,
-            transcriptionRepo: transcriptionRepo
+            promptResultRepo: promptResultRepo
         )
 
         let transcript = String(repeating: "Long transcript ", count: 50)
@@ -254,8 +237,7 @@ final class PromptResultsViewModelTests: XCTestCase {
         viewModel.configure(
             llmService: llm,
             promptRepo: promptRepo,
-            promptResultRepo: promptResultRepo,
-            transcriptionRepo: transcriptionRepo
+            promptResultRepo: promptResultRepo
         )
 
         let queuedIDs = viewModel.autoGeneratePromptResults(

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -971,7 +971,6 @@ final class TranscriptionViewModelTests: XCTestCase {
         )
         viewModel.currentTranscription = t
 
-        mockRepo.transcriptions[0].summary = "DB summary"
         mockPromptResultRepo.promptResults = [
             PromptResult(
                 transcriptionId: t.id,
@@ -983,7 +982,6 @@ final class TranscriptionViewModelTests: XCTestCase {
 
         viewModel.loadPersistedContent()
 
-        XCTAssertEqual(viewModel.currentTranscription?.summary, "DB summary")
         XCTAssertTrue(viewModel.hasPromptResultTabs)
     }
 

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -110,7 +110,6 @@ final class MockTranscriptionRepository: TranscriptionRepositoryProtocol, @unche
     var deleteResult = true
     var deleteError: Error?
     var updateFileNameCalls: [(id: UUID, fileName: String)] = []
-    var updateSummaryCalls: [(id: UUID, summary: String?)] = []
     var updateChatMessagesCalls: [(id: UUID, chatMessages: [ChatMessage]?)] = []
     var updateSpeakersCalls: [(id: UUID, speakers: [SpeakerInfo]?)] = []
     var saveError: Error?
@@ -171,14 +170,6 @@ final class MockTranscriptionRepository: TranscriptionRepositoryProtocol, @unche
         updateFileNameCalls.append((id: id, fileName: fileName))
         if let idx = transcriptions.firstIndex(where: { $0.id == id }) {
             transcriptions[idx].fileName = fileName
-            transcriptions[idx].updatedAt = Date()
-        }
-    }
-
-    func updateSummary(id: UUID, summary: String?) throws {
-        updateSummaryCalls.append((id: id, summary: summary))
-        if let idx = transcriptions.firstIndex(where: { $0.id == id }) {
-            transcriptions[idx].summary = summary
             transcriptions[idx].updatedAt = Date()
         }
     }


### PR DESCRIPTION
## Summary
- remove the deprecated `Transcription.summary` runtime field and repository update API
- stop mirroring prompt results back into transcriptions; `summaries` / `PromptResult` remains the canonical store
- add a migration that drops the old `transcriptions.summary` column after existing values are migrated into `summaries`

## Tests
- `swift test --filter DatabaseManagerTests --filter PromptResultsViewModelTests --filter TranscriptionViewModelTests --filter TranscriptionModelTests --filter TranscriptionRepositoryTests`
- `git diff --check`