### PR TITLE
chore: gitignore journal/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Auto-memory
 MEMORY.md
 
+# Private journal (telemetry analyses, postmortems, field notes — agent-only)
+journal/
+
 # Claude Code
 .claude/
 


### PR DESCRIPTION
Adds `journal/` to `.gitignore`. It's a private agent-only notes folder per `MEMORY.md` convention but was never gitignored — kept showing up as `?? journal/` in every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)