### PR TITLE
Fix edited transcript exports

### DIFF
--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -2210,7 +2210,18 @@ struct TranscriptResultView: View {
         return !words.isEmpty
     }
 
+    private var hasEditedTranscriptForExport: Bool {
+        guard activeTranscription.isTranscriptEdited else { return false }
+        guard let cleanTranscript = activeTranscription.cleanTranscript else { return false }
+        return !cleanTranscript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var hasAlignedTimestampsForExport: Bool {
+        hasTimestamps && !hasEditedTranscriptForExport
+    }
+
     private var hasSpeakerLabelsForExport: Bool {
+        guard !hasEditedTranscriptForExport else { return false }
         guard let speakers = activeTranscription.speakers, !speakers.isEmpty,
               let words = activeTranscription.wordTimestamps else { return false }
         return words.contains { $0.speakerId != nil }
@@ -2218,7 +2229,7 @@ struct TranscriptResultView: View {
 
     private var resolvedTranscriptExportOptions: TranscriptExportOptions {
         var options = transcriptExportOptions
-        if !hasTimestamps {
+        if !hasAlignedTimestampsForExport {
             options.includeTimestamps = false
         }
         if !hasSpeakerLabelsForExport {
@@ -2303,7 +2314,7 @@ struct TranscriptResultView: View {
                     .foregroundStyle(DesignSystem.Colors.textSecondary)
 
                 Toggle("Include timestamps", isOn: $transcriptExportOptions.includeTimestamps)
-                    .disabled(!selectedExportFormat.supportsTranscriptOptions || !hasTimestamps)
+                    .disabled(!selectedExportFormat.supportsTranscriptOptions || !hasAlignedTimestampsForExport)
 
                 Toggle("Include speaker labels", isOn: $transcriptExportOptions.includeSpeakerLabels)
                     .disabled(!selectedExportFormat.supportsTranscriptOptions || !hasSpeakerLabelsForExport)

--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -432,6 +432,13 @@ public final class DatabaseManager: Sendable {
             }
         }
 
+        // v0.7.7 - Distinguish user-edited transcript text from automatic cleanup.
+        migrator.registerMigration("v0.7.7-transcript-edited-flag") { db in
+            try db.alter(table: "transcriptions") { t in
+                t.add(column: "isTranscriptEdited", .boolean).notNull().defaults(to: false)
+            }
+        }
+
         try migrator.migrate(dbQueue)
         try reconcileBuiltInPrompts()
     }

--- a/Sources/MacParakeetCore/Models/Transcription.swift
+++ b/Sources/MacParakeetCore/Models/Transcription.swift
@@ -32,6 +32,7 @@ public struct Transcription: Codable, Identifiable, Sendable {
     public var isFavorite: Bool
     public var sourceType: SourceType
     public var recoveredFromCrash: Bool
+    public var isTranscriptEdited: Bool
     public var updatedAt: Date
 
     public enum TranscriptionStatus: String, Codable, Sendable {
@@ -66,6 +67,7 @@ public struct Transcription: Codable, Identifiable, Sendable {
         isFavorite: Bool = false,
         sourceType: SourceType = .file,
         recoveredFromCrash: Bool = false,
+        isTranscriptEdited: Bool = false,
         updatedAt: Date = Date()
     ) {
         self.id = id
@@ -92,6 +94,7 @@ public struct Transcription: Codable, Identifiable, Sendable {
         self.isFavorite = isFavorite
         self.sourceType = sourceType
         self.recoveredFromCrash = recoveredFromCrash
+        self.isTranscriptEdited = isTranscriptEdited
         self.updatedAt = updatedAt
     }
 }
@@ -142,7 +145,7 @@ extension Transcription: FetchableRecord, PersistableRecord {
         case rawTranscript, cleanTranscript, wordTimestamps, language
         case speakerCount, speakers, diarizationSegments, chatMessages
         case status, errorMessage, exportPath, sourceURL
-        case thumbnailURL, channelName, videoDescription, isFavorite, sourceType, recoveredFromCrash, updatedAt
+        case thumbnailURL, channelName, videoDescription, isFavorite, sourceType, recoveredFromCrash, isTranscriptEdited, updatedAt
     }
 
     /// Backward-compatible decoding: `speakers` column may contain old `[String]` JSON
@@ -190,6 +193,7 @@ extension Transcription: FetchableRecord, PersistableRecord {
             sourceType = .file
         }
         recoveredFromCrash = try container.decodeIfPresent(Bool.self, forKey: .recoveredFromCrash) ?? false
+        isTranscriptEdited = try container.decodeIfPresent(Bool.self, forKey: .isTranscriptEdited) ?? false
         updatedAt = try container.decode(Date.self, forKey: .updatedAt)
     }
 }

--- a/Sources/MacParakeetCore/Services/ExportService.swift
+++ b/Sources/MacParakeetCore/Services/ExportService.swift
@@ -44,6 +44,16 @@ public final class ExportService: ExportServiceProtocol, Sendable {
         transcription.cleanTranscript ?? transcription.rawTranscript ?? ""
     }
 
+    private func editedTranscriptText(transcription: Transcription) -> String? {
+        guard transcription.isTranscriptEdited,
+              let text = transcription.cleanTranscript?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !text.isEmpty
+        else {
+            return nil
+        }
+        return text
+    }
+
     /// Export transcription as plain text file
     public func exportToTxt(transcription: Transcription, url: URL) throws {
         try exportToTxt(transcription: transcription, url: url, options: .default)
@@ -60,6 +70,13 @@ public final class ExportService: ExportServiceProtocol, Sendable {
 
     /// Export transcription as SRT subtitle file
     public func exportToSRT(transcription: Transcription, url: URL) throws {
+        if let text = editedTranscriptText(transcription: transcription) {
+            let duration = transcription.durationMs ?? 0
+            let content = "1\n00:00:00,000 --> \(srtTimestamp(ms: duration))\n\(text)\n"
+            try content.write(to: url, atomically: true, encoding: .utf8)
+            return
+        }
+
         guard let words = transcription.wordTimestamps, !words.isEmpty else {
             // Fall back to full transcript as a single cue
             let text = preferredText(transcription: transcription)
@@ -74,6 +91,13 @@ public final class ExportService: ExportServiceProtocol, Sendable {
 
     /// Export transcription as WebVTT subtitle file
     public func exportToVTT(transcription: Transcription, url: URL) throws {
+        if let text = editedTranscriptText(transcription: transcription) {
+            let duration = transcription.durationMs ?? 0
+            let content = "WEBVTT\n\n\(vttTimestamp(ms: 0)) --> \(vttTimestamp(ms: duration))\n\(text)\n"
+            try content.write(to: url, atomically: true, encoding: .utf8)
+            return
+        }
+
         guard let words = transcription.wordTimestamps, !words.isEmpty else {
             let text = preferredText(transcription: transcription)
             let duration = transcription.durationMs ?? 0
@@ -261,7 +285,10 @@ public final class ExportService: ExportServiceProtocol, Sendable {
             lines.append("")
         }
 
-        if let timestamps = transcription.wordTimestamps, !timestamps.isEmpty {
+        if let text = editedTranscriptText(transcription: transcription) {
+            lines.append(text)
+            lines.append("")
+        } else if let timestamps = transcription.wordTimestamps, !timestamps.isEmpty {
             let cues = buildSubtitleCues(from: timestamps)
             if options.includeTimestamps || options.includeSpeakerLabels {
                 if options.includeTimestamps {
@@ -427,7 +454,9 @@ public final class ExportService: ExportServiceProtocol, Sendable {
             lines.append("")
         }
 
-        if let timestamps = transcription.wordTimestamps, !timestamps.isEmpty {
+        if let text = editedTranscriptText(transcription: transcription) {
+            lines.append(text)
+        } else if let timestamps = transcription.wordTimestamps, !timestamps.isEmpty {
             let cues = buildSubtitleCues(from: timestamps)
             if options.includeTimestamps || options.includeSpeakerLabels {
                 if options.includeTimestamps {
@@ -529,7 +558,9 @@ public final class ExportService: ExportServiceProtocol, Sendable {
         result.append(NSAttributedString(string: "----------------------------------------------------------\n\n", attributes: [.foregroundColor: NSColor.tertiaryLabelColor]))
 
         // Content
-        if let timestamps = transcription.wordTimestamps, !timestamps.isEmpty {
+        if let text = editedTranscriptText(transcription: transcription) {
+            result.append(NSAttributedString(string: text, attributes: [.font: bodyFont]))
+        } else if let timestamps = transcription.wordTimestamps, !timestamps.isEmpty {
             let cues = buildSubtitleCues(from: timestamps)
             var lastSpeakerId: String? = nil
             for cue in cues {

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -575,6 +575,7 @@ public final class TranscriptionViewModel {
         guard trimmed != currentText else { return false }
 
         transcription.cleanTranscript = trimmed == transcription.rawTranscript ? nil : trimmed
+        transcription.isTranscriptEdited = transcription.cleanTranscript != nil
         transcription.updatedAt = Date()
 
         do {
@@ -601,6 +602,7 @@ public final class TranscriptionViewModel {
         }
 
         transcription.cleanTranscript = nil
+        transcription.isTranscriptEdited = false
         transcription.updatedAt = Date()
 
         do {

--- a/Tests/MacParakeetTests/Services/ExportServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/ExportServiceTests.swift
@@ -96,6 +96,34 @@ final class ExportServiceTests: XCTestCase {
         XCTAssertTrue(text.contains("[0:02] Goodbye."))
     }
 
+    func testFormatPlainTextDefaultUsesEditedTranscriptWhenTimestampsExist() {
+        let transcription = makeExportOptionsTranscription(
+            cleanTranscript: "Edited transcript without timing.",
+            isTranscriptEdited: true
+        )
+
+        let text = exportService.formatPlainText(transcription: transcription)
+
+        XCTAssertTrue(text.contains("interview.mp3"))
+        XCTAssertTrue(text.contains("Edited transcript without timing."))
+        XCTAssertFalse(text.contains("[0:00] Hello."))
+        XCTAssertFalse(text.contains("[0:02] Goodbye."))
+        XCTAssertFalse(text.contains("Alice:"))
+        XCTAssertFalse(text.contains("Bob:"))
+    }
+
+    func testFormatPlainTextDefaultKeepsTimestampsForAutomaticCleanTranscript() {
+        let transcription = makeExportOptionsTranscription(cleanTranscript: "Automatically cleaned transcript.")
+
+        let text = exportService.formatPlainText(transcription: transcription)
+
+        XCTAssertTrue(text.contains("[0:00] Hello."))
+        XCTAssertTrue(text.contains("[0:02] Goodbye."))
+        XCTAssertTrue(text.contains("Alice:"))
+        XCTAssertTrue(text.contains("Bob:"))
+        XCTAssertFalse(text.contains("Automatically cleaned transcript."))
+    }
+
     func testFormatPlainTextCanOmitMetadataTimestampsAndSpeakers() {
         let transcription = makeExportOptionsTranscription(cleanTranscript: "Edited transcript without timing.")
         let options = TranscriptExportOptions(
@@ -159,6 +187,22 @@ final class ExportServiceTests: XCTestCase {
         XCTAssertFalse(markdown.contains("**Duration:**"))
         XCTAssertFalse(markdown.contains("**Alice**"))
         XCTAssertFalse(markdown.contains("**[0:00]**"))
+    }
+
+    func testFormatMarkdownDefaultUsesEditedTranscriptWhenTimestampsExist() {
+        let transcription = makeExportOptionsTranscription(
+            cleanTranscript: "Edited transcript without timing.",
+            isTranscriptEdited: true
+        )
+
+        let markdown = exportService.formatMarkdown(transcription: transcription)
+
+        XCTAssertTrue(markdown.contains("# interview.mp3"))
+        XCTAssertTrue(markdown.contains("Edited transcript without timing."))
+        XCTAssertFalse(markdown.contains("**[0:00]** Hello."))
+        XCTAssertFalse(markdown.contains("**[0:02]** Goodbye."))
+        XCTAssertFalse(markdown.contains("**Alice**"))
+        XCTAssertFalse(markdown.contains("**Bob**"))
     }
 
     func testFormatMarkdownWithoutTimestampsJoinsSameSpeakerCues() {
@@ -348,6 +392,43 @@ final class ExportServiceTests: XCTestCase {
         let content = try String(contentsOf: tempURL, encoding: .utf8)
         XCTAssertTrue(content.hasPrefix("WEBVTT\n"))
         XCTAssertTrue(content.contains("00:00:00.000 --> 00:00:01.000\nHello world."))
+
+        try? FileManager.default.removeItem(at: tempURL)
+    }
+
+    func testExportToSRTUsesEditedTranscriptWhenTimestampsExist() throws {
+        let transcription = makeExportOptionsTranscription(
+            cleanTranscript: "Edited transcript without timing.",
+            isTranscriptEdited: true
+        )
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test_export_\(UUID().uuidString).srt")
+
+        try exportService.exportToSRT(transcription: transcription, url: tempURL)
+
+        let content = try String(contentsOf: tempURL, encoding: .utf8)
+        XCTAssertTrue(content.contains("1\n00:00:00,000 --> 00:00:05,000\nEdited transcript without timing."))
+        XCTAssertFalse(content.contains("Hello."))
+        XCTAssertFalse(content.contains("Goodbye."))
+
+        try? FileManager.default.removeItem(at: tempURL)
+    }
+
+    func testExportToVTTUsesEditedTranscriptWhenTimestampsExist() throws {
+        let transcription = makeExportOptionsTranscription(
+            cleanTranscript: "Edited transcript without timing.",
+            isTranscriptEdited: true
+        )
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test_export_\(UUID().uuidString).vtt")
+
+        try exportService.exportToVTT(transcription: transcription, url: tempURL)
+
+        let content = try String(contentsOf: tempURL, encoding: .utf8)
+        XCTAssertTrue(content.hasPrefix("WEBVTT\n"))
+        XCTAssertTrue(content.contains("00:00:00.000 --> 00:00:05.000\nEdited transcript without timing."))
+        XCTAssertFalse(content.contains("Hello."))
+        XCTAssertFalse(content.contains("Goodbye."))
 
         try? FileManager.default.removeItem(at: tempURL)
     }
@@ -753,7 +834,10 @@ final class ExportServiceTests: XCTestCase {
         XCTAssertFalse(content.contains("Speaker"))
     }
 
-    private func makeExportOptionsTranscription(cleanTranscript: String? = nil) -> Transcription {
+    private func makeExportOptionsTranscription(
+        cleanTranscript: String? = nil,
+        isTranscriptEdited: Bool = false
+    ) -> Transcription {
         Transcription(
             fileName: "interview.mp3",
             durationMs: 5000,
@@ -767,7 +851,8 @@ final class ExportServiceTests: XCTestCase {
                 SpeakerInfo(id: "S1", label: "Alice"),
                 SpeakerInfo(id: "S2", label: "Bob"),
             ],
-            status: .completed
+            status: .completed,
+            isTranscriptEdited: isTranscriptEdited
         )
     }
 

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -650,9 +650,11 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertTrue(saved)
         XCTAssertEqual(viewModel.currentTranscription?.rawTranscript, "Original transcript")
         XCTAssertEqual(viewModel.currentTranscription?.cleanTranscript, "Corrected transcript")
+        XCTAssertEqual(viewModel.currentTranscription?.isTranscriptEdited, true)
         let persisted = try XCTUnwrap(mockRepo.fetch(id: t.id))
         XCTAssertEqual(persisted.rawTranscript, "Original transcript")
         XCTAssertEqual(persisted.cleanTranscript, "Corrected transcript")
+        XCTAssertTrue(persisted.isTranscriptEdited)
     }
 
     func testUpdateCurrentTranscriptTextRejectsEmptyText() {
@@ -699,7 +701,8 @@ final class TranscriptionViewModelTests: XCTestCase {
             fileName: "test.mp3",
             rawTranscript: "Original transcript",
             cleanTranscript: "Corrected transcript",
-            status: .completed
+            status: .completed,
+            isTranscriptEdited: true
         )
         mockRepo.transcriptions = [t]
 
@@ -710,8 +713,10 @@ final class TranscriptionViewModelTests: XCTestCase {
 
         XCTAssertTrue(reverted)
         XCTAssertNil(viewModel.currentTranscription?.cleanTranscript)
+        XCTAssertEqual(viewModel.currentTranscription?.isTranscriptEdited, false)
         let persisted = try XCTUnwrap(mockRepo.fetch(id: t.id))
         XCTAssertNil(persisted.cleanTranscript)
+        XCTAssertFalse(persisted.isTranscriptEdited)
     }
 
     func testRevertCurrentTranscriptToOriginalKeepsStateWhenSaveFails() {
@@ -719,7 +724,8 @@ final class TranscriptionViewModelTests: XCTestCase {
             fileName: "test.mp3",
             rawTranscript: "Original transcript",
             cleanTranscript: "Corrected transcript",
-            status: .completed
+            status: .completed,
+            isTranscriptEdited: true
         )
         mockRepo.transcriptions = [t]
         mockRepo.saveError = NSError(domain: "repo", code: 1)
@@ -731,6 +737,7 @@ final class TranscriptionViewModelTests: XCTestCase {
 
         XCTAssertFalse(reverted)
         XCTAssertEqual(viewModel.currentTranscription?.cleanTranscript, "Corrected transcript")
+        XCTAssertEqual(viewModel.currentTranscription?.isTranscriptEdited, true)
     }
 
     func testRevertCurrentTranscriptToOriginalFailsWithoutConfiguredRepository() {
@@ -738,7 +745,8 @@ final class TranscriptionViewModelTests: XCTestCase {
             fileName: "test.mp3",
             rawTranscript: "Original transcript",
             cleanTranscript: "Corrected transcript",
-            status: .completed
+            status: .completed,
+            isTranscriptEdited: true
         )
         viewModel.currentTranscription = t
 
@@ -746,6 +754,7 @@ final class TranscriptionViewModelTests: XCTestCase {
 
         XCTAssertFalse(reverted)
         XCTAssertEqual(viewModel.currentTranscription?.cleanTranscript, "Corrected transcript")
+        XCTAssertEqual(viewModel.currentTranscription?.isTranscriptEdited, true)
     }
 
     // MARK: - Speaker Rename


### PR DESCRIPTION
## Summary
- add an explicit manual transcript edit flag so automatic cleanup remains timestamp-exportable
- export manual edits from edited text instead of stale word timestamps across TXT, Markdown, PDF/DOCX, SRT, and VTT
- disable timestamp/speaker export toggles when a transcript has manual edits

## Verification
- swift test --filter 'ExportServiceTests|TranscriptionViewModelTests|TranscriptionModelTests|DatabaseManagerTests'
- swift test --quiet from clean temporary worktree: 1590 XCTest tests + 13 Swift Testing tests passed
- git diff --check origin/main...HEAD