### PR TITLE
feat(cli): 1.0.0 + AGENTS.md + integrations/ scaffolding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,107 @@
+# AGENTS.md -- MacParakeet
+
+> Read by coding agents (Claude Code, Codex CLI, Hermes, OpenClaw, etc.) working
+> *in this repo*. Deeper project context lives in [`CLAUDE.md`](./CLAUDE.md).
+> If your agent runs *outside* this repo and wants to *call* `macparakeet-cli`,
+> see [`integrations/README.md`](./integrations/README.md) instead.
+
+## What this project is
+
+MacParakeet is a fast, private, local-first voice app for macOS with three
+co-equal modes: system-wide dictation, file transcription, and meeting
+recording. Powered by NVIDIA Parakeet TDT 0.6B v3 via FluidAudio CoreML on
+the Apple Neural Engine.
+
+Free and open-source (GPL-3.0). Apple Silicon only. Requires macOS 14.2+.
+
+The repo ships two products:
+
+- **`macparakeet-cli`** -- versioned public surface
+  ([`Sources/CLI/`](./Sources/CLI/), semver tracked in
+  [`Sources/CLI/CHANGELOG.md`](./Sources/CLI/CHANGELOG.md)).
+- **`MacParakeet.app`** -- SwiftUI macOS app, one consumer of the CLI's
+  underlying core library.
+
+## Build & test
+
+```bash
+# Build everything (app + CLI + core + viewmodels + tests)
+swift build
+
+# Run the test suite (Swift 6 language mode)
+swift test
+
+# Build, codesign, and launch the dev app
+scripts/dev/run_app.sh
+
+# Run the CLI against your local DB
+swift run macparakeet-cli --help
+swift run macparakeet-cli health
+```
+
+The full test suite runs in well under a minute. Run `swift test` before
+declaring code-change work complete; failures are deterministic.
+
+## Code style
+
+- Swift 6.0 with SwiftUI for UI and GRDB for SQLite.
+- One repository per database table (see
+  [`Sources/MacParakeetCore/Database/`](./Sources/MacParakeetCore/Database/)).
+- Comments explain *why*, not *what* -- well-named identifiers carry the what.
+  Default to writing none.
+- `MacParakeetCore` has no UI dependencies (Foundation + GRDB + FluidAudio
+  only). One exception: `ExportService` imports AppKit for PDF/DOCX. No new
+  AppKit imports in Core.
+- ViewModels live in their own SPM target (`Sources/MacParakeetViewModels/`)
+  so they can be tested without the GUI.
+- Async/await for all I/O. No completion handlers, no Combine in new code.
+
+## Architecture orientation
+
+```
+Sources/
+  MacParakeetCore/        -- Pure Swift library: STT, DB, prompts, LLM, audio
+  MacParakeetViewModels/  -- @Observable view models, no UI
+  MacParakeet/            -- SwiftUI app target
+  CLI/                    -- macparakeet-cli; ArgumentParser commands
+Tests/
+  MacParakeetTests/       -- Unit, database, integration tests
+  CLITests/               -- CLI argument-parsing + helper tests
+```
+
+Full spec is in [`spec/`](./spec/). Architectural decisions (locked) are in
+[`spec/adr/`](./spec/adr/). Don't second-guess ADRs.
+
+## Security & privacy
+
+- **Local-first by default.** STT runs on the Apple Neural Engine. No audio
+  ever leaves the device unless the user explicitly enables a cloud LLM
+  provider, telemetry, or YouTube downloads.
+- **No accounts, no logins.** No identifying data is sent anywhere.
+- **The user database lives at**
+  `~/Library/Application Support/MacParakeet/macparakeet.db`. Treat it as user
+  data: never delete without explicit user confirmation; write migrations
+  rather than dropping tables.
+
+## Important runtime locations
+
+| Item | Path |
+|------|------|
+| App bundle | `/Applications/MacParakeet.app` |
+| Database | `~/Library/Application Support/MacParakeet/macparakeet.db` |
+| CoreML STT models (~6 GB) | `~/Library/Application Support/MacParakeet/models/stt/` |
+| Settings | `~/Library/Preferences/com.macparakeet.plist` |
+| Logs | `~/Library/Logs/MacParakeet/` |
+
+## Where to look next
+
+- **Coding-agent context for this repo:** [`CLAUDE.md`](./CLAUDE.md) for deep
+  project context; [`spec/10-ai-coding-method.md`](./spec/10-ai-coding-method.md)
+  for the kernel workflow; ADRs in [`spec/adr/`](./spec/adr/) for locked
+  decisions.
+- **Calling macparakeet-cli from another agent (OpenClaw / Hermes / etc.):**
+  [`integrations/README.md`](./integrations/README.md) and the CLI changelog
+  at [`Sources/CLI/CHANGELOG.md`](./Sources/CLI/CHANGELOG.md).
+- **Commit format:** rich-format messages per
+  [`docs/commit-guidelines.md`](./docs/commit-guidelines.md) for significant
+  changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ The repo ships two products:
 - **`MacParakeet.app`** -- SwiftUI macOS app, one consumer of the CLI's
   underlying core library.
 
-## Build & test
+## Build & Test
 
 ```bash
 # Build everything (app + CLI + core + viewmodels + tests)
@@ -42,7 +42,7 @@ swift run macparakeet-cli health
 The full test suite runs in well under a minute. Run `swift test` before
 declaring code-change work complete; failures are deterministic.
 
-## Code style
+## Code Style
 
 - Swift 6.0 with SwiftUI for UI and GRDB for SQLite.
 - One repository per database table (see
@@ -56,7 +56,7 @@ declaring code-change work complete; failures are deterministic.
   so they can be tested without the GUI.
 - Async/await for all I/O. No completion handlers, no Combine in new code.
 
-## Architecture orientation
+## Architecture Orientation
 
 ```
 Sources/
@@ -72,7 +72,7 @@ Tests/
 Full spec is in [`spec/`](./spec/). Architectural decisions (locked) are in
 [`spec/adr/`](./spec/adr/). Don't second-guess ADRs.
 
-## Security & privacy
+## Security & Privacy
 
 - **Local-first by default.** STT runs on the Apple Neural Engine. No audio
   ever leaves the device unless the user explicitly enables a cloud LLM
@@ -83,7 +83,7 @@ Full spec is in [`spec/`](./spec/). Architectural decisions (locked) are in
   data: never delete without explicit user confirmation; write migrations
   rather than dropping tables.
 
-## Important runtime locations
+## Important Runtime Locations
 
 | Item | Path |
 |------|------|
@@ -93,7 +93,7 @@ Full spec is in [`spec/`](./spec/). Architectural decisions (locked) are in
 | Settings | `~/Library/Preferences/com.macparakeet.plist` |
 | Logs | `~/Library/Logs/MacParakeet/` |
 
-## Where to look next
+## Where to Look Next
 
 - **Coding-agent context for this repo:** [`CLAUDE.md`](./CLAUDE.md) for deep
   project context; [`spec/10-ai-coding-method.md`](./spec/10-ai-coding-method.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,9 @@ A **fast, private, local-first voice app** for macOS with three co-equal modes: 
 | Telemetry system | `docs/telemetry.md` |
 | Commit message format | `docs/commit-guidelines.md` |
 | Implementation plans | `plans/` -> active and completed plans |
+| Cross-agent coding-agent guide | `AGENTS.md` -> slim, convention-following |
+| Downstream agent integration (calling the CLI) | `integrations/README.md` |
+| CLI semver + compatibility policy | `Sources/CLI/CHANGELOG.md` |
 
 ## Tech Stack (Locked Decisions)
 
@@ -243,6 +246,7 @@ View files organized by feature in `Sources/MacParakeet/Views/`:
 ```
 macparakeet/
 ├── CLAUDE.md           # This file (AI assistant context)
+├── AGENTS.md           # Cross-agent guide for coding agents working in this repo
 ├── README.md           # Public-facing readme
 ├── Package.swift       # Swift package manifest
 ├── spec/               # THE SPEC (authoritative, prescriptive)
@@ -260,9 +264,14 @@ macparakeet/
 ├── plans/              # Implementation plans (version controlled)
 │   ├── active/         # Currently being implemented
 │   └── completed/      # Done plans (archived, not deleted)
+├── integrations/       # Downstream agent integration docs (OpenClaw, Hermes, ...)
+│   ├── README.md       # Canonical CLI vocabulary + install for agents calling the CLI
+│   ├── openclaw/SOUL.md
+│   └── hermes/README.md
 ├── Sources/
 │   ├── MacParakeet/            # GUI app (SwiftUI, imports MacParakeetCore + ViewModels)
-│   ├── CLI/                    # CLI tool (ArgumentParser, imports MacParakeetCore)
+│   ├── CLI/                    # macparakeet-cli (ArgumentParser, imports MacParakeetCore)
+│   │   └── CHANGELOG.md        # CLI semver + compatibility policy (public contract)
 │   ├── MacParakeetCore/        # Shared library (no UI deps)
 │   └── MacParakeetViewModels/  # ViewModels (testable, depends on Core)
 ├── Tests/
@@ -399,9 +408,11 @@ scripts/dev/run_app.sh
 # Optional: force a specific signing identity for the dev .app bundle
 MACPARAKEET_CODESIGN_IDENTITY="Apple Development: Your Name (TEAMID)" scripts/dev/run_app.sh
 
-# Build and run CLI
+# Build and run CLI -- public surface, semver tracked in Sources/CLI/CHANGELOG.md.
+# See AGENTS.md (this repo) and integrations/README.md (downstream agents) for context.
 swift build --target CLI
 swift run macparakeet-cli --help
+swift run macparakeet-cli --version    # 1.0.0+
 swift run macparakeet-cli transcribe /path/to/audio.mp3
 swift run macparakeet-cli health
 

--- a/Package.swift
+++ b/Package.swift
@@ -37,14 +37,17 @@ let package = Package(
             path: "Sources/MacParakeet",
             resources: [.process("Resources")]
         ),
-        // CLI tool for headless testing and scripting
+        // macparakeet-cli — versioned public surface (semver, Sources/CLI/CHANGELOG.md).
+        // Consumed by the macOS app, scripted callers, and downstream agent skills
+        // (see /AGENTS.md and integrations/README.md).
         .executableTarget(
             name: "CLI",
             dependencies: [
                 "MacParakeetCore",
                 .product(name: "ArgumentParser", package: "swift-argument-parser")
             ],
-            path: "Sources/CLI"
+            path: "Sources/CLI",
+            exclude: ["CHANGELOG.md"]
         ),
         // Objective-C shim target for catching NSException in Swift.
         // Swift's `do/try/catch` cannot catch Objective-C exceptions raised by

--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -1,0 +1,76 @@
+# Changelog -- macparakeet-cli
+
+All notable changes to the **`macparakeet-cli` surface** are documented here.
+
+This file tracks the CLI specifically -- the commands, flags, output schemas,
+and exit codes that scripted callers (shell scripts, CI pipelines, AI agents)
+depend on. App-level changes ship through Sparkle and are documented in the
+appcast at <https://macparakeet.com/appcast.xml>.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com), and the
+CLI adheres to [Semantic Versioning](https://semver.org).
+
+## Compatibility policy
+
+The CLI surface is a public contract. We follow semver:
+
+- **MAJOR** -- any change that breaks scripted callers: removed commands,
+  renamed flags, removed JSON fields, changed exit-code meanings, changed
+  default behavior of an existing flag.
+- **MINOR** -- additive changes: new commands, new flags, new optional JSON
+  fields, new exit codes for new error classes.
+- **PATCH** -- bug fixes, output formatting tweaks that preserve schema,
+  documentation, performance work.
+
+When we deprecate a command or flag, the old name keeps working for **at least
+one minor release** with a clear `--help` notice and a CHANGELOG callout. New
+names are added first; old names are removed only at a MAJOR boundary.
+
+JSON output schemas are part of the contract: top-level shape (array vs
+object), field names, and field types are stable within a major version. We
+may add new optional fields in a minor release.
+
+## [1.0.0] -- 2026-04-25
+
+First release of the CLI as a versioned public surface. The CLI has existed
+since v0.1 of the MacParakeet app and powered AI-assisted testing through
+v0.4--v0.6. With the prompts subcommand and JSON sweep landing in
+[PR #138](https://github.com/moona3k/macparakeet/pull/138), the surface is
+complete enough to commit to. This release marks that commitment.
+
+### Added
+
+- `prompts` subcommand: `list` / `show` / `add` / `set` / `delete` /
+  `restore-defaults` / `run`. UUID-or-name lookup with prefix matching, error
+  surfacing for ambiguous prefixes, refusal to delete built-ins. `prompts run`
+  invokes any LLM provider configured via `--provider --api-key --model`.
+  ([PR #138](https://github.com/moona3k/macparakeet/pull/138))
+- `--json` flag on read-only commands: `history dictations`,
+  `history transcriptions`, `history search`, `history search-transcriptions`,
+  `history favorites`, `stats`, `flow words list`, `flow snippets list`,
+  `health`, `models status`. Convention: ISO-8601 datetimes, pretty-printed
+  output, sorted keys, top-level array for list commands and object for
+  single-record / status commands. Matches the existing `calendar upcoming
+  --json` shape.
+  ([PR #138](https://github.com/moona3k/macparakeet/pull/138))
+- `flow words list --source manual|learned|all` filter. Default `all`.
+  Surfaces the source distinction (user-typed vs vocabulary-learned) that the
+  schema has carried for two releases but the CLI hadn't exposed.
+  ([PR #138](https://github.com/moona3k/macparakeet/pull/138))
+
+### Changed
+
+- Command abstract reframed from "internal developer CLI" to a public surface.
+  The CLI is now positioned as the canonical Swift-native interface to
+  Parakeet TDT on Apple Silicon, with the macOS app as one consumer of it.
+  Strategic context: `plans/active/cli-as-canonical-parakeet-surface.md`.
+
+### Compatibility notes
+
+- Pre-1.0 callers are unaffected. Every existing command and flag retains its
+  prior behavior; the version bump signals "stability commitment going
+  forward," not a breaking-change cliff.
+- The CLI ships inside the `MacParakeet.app` bundle today
+  (`MacParakeet.app/Contents/MacOS/macparakeet-cli`). Standalone install via
+  Homebrew tap is on the roadmap (see plan above) and will not change command
+  semantics.

--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -74,3 +74,10 @@ complete enough to commit to. This release marks that commitment.
   (`MacParakeet.app/Contents/MacOS/macparakeet-cli`). Standalone install via
   Homebrew tap is on the roadmap (see plan above) and will not change command
   semantics.
+- **`--format json` (transcribe, export) vs `--json` (read-only queries)**
+  is deliberate, not a bug. `transcribe` and `export` carry a `--format`
+  selector because they emit one of several formats (txt / srt / vtt / json /
+  docx / pdf); `--json` on read-only query commands is a binary flag because
+  their output shape is conceptually fixed -- it's either JSON or human.
+  Unifying this would be a major-version breaking change; we are not doing
+  that in 1.0.

--- a/Sources/CLI/MacParakeetCLI.swift
+++ b/Sources/CLI/MacParakeetCLI.swift
@@ -4,8 +4,8 @@ import ArgumentParser
 struct CLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "macparakeet-cli",
-        abstract: "MacParakeet developer CLI (internal; used for AI-assisted development and testing).",
-        version: "0.1.0",
+        abstract: "Local STT, transcription, and prompt automation for Apple Silicon. Powered by Parakeet TDT on the Neural Engine.",
+        version: "1.0.0",
         subcommands: [
             TranscribeCommand.self,
             HistoryCommand.self,

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -110,6 +110,11 @@ agent can re-prompt the user.
 
 - **Exit codes:** `0` on success; non-zero on failure with a one-line stderr
   message. JSON output never goes to stderr.
+- **JSON flag shape:** read-only query commands take `--json` (a binary flag);
+  `transcribe` and `export` take `--format json` because they emit one of
+  several formats (txt / srt / vtt / json / docx / pdf). Both produce stable
+  JSON schemas. The split is deliberate -- see
+  `Sources/CLI/CHANGELOG.md` for the compatibility note.
 - **Lookups:** records that take an `<id-or-name>` argument accept full UUID,
   UUID prefix (>= 4 chars), or case-insensitive name. Ambiguous prefixes
   produce a `.ambiguous` error; missing records produce `.notFound`.

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -1,0 +1,137 @@
+# Integrations -- using `macparakeet-cli` from your agent
+
+> If you are a *coding agent working in this repo*, read
+> [`/AGENTS.md`](../AGENTS.md) instead. This directory is for agents (and the
+> people running them) that want to *call* `macparakeet-cli` to add local STT
+> to their stack.
+
+## What `macparakeet-cli` gives your agent
+
+- **Local Parakeet TDT speech-to-text** at ~155x realtime on Apple Silicon
+  with ~2.5% WER, running on the Neural Engine. No cloud, no API keys, no
+  per-minute charges.
+- **Audio + video file transcription** -- accepts MP3 / WAV / MP4 / MOV /
+  WebM / etc. via the bundled FFmpeg.
+- **YouTube transcription** via bundled yt-dlp.
+- **Persistent SQLite memory layer** -- everything transcribed is queryable
+  later: dictation history, transcriptions, prompt outputs.
+- **Prompt library + LLM-backed summarization** -- bring your own provider
+  (OpenAI, Anthropic, Ollama, LM Studio, OpenAI-compatible local), or skip
+  the LLM entirely and consume raw transcripts.
+- **JSON output everywhere** -- every read-only command supports `--json`
+  with a stable schema (see
+  [`../Sources/CLI/CHANGELOG.md`](../Sources/CLI/CHANGELOG.md) for the
+  contract).
+
+## Install
+
+**Today:** the CLI ships inside the macOS app bundle. After installing
+[MacParakeet](https://macparakeet.com), the binary is at:
+
+```bash
+/Applications/MacParakeet.app/Contents/MacOS/macparakeet-cli --help
+```
+
+For convenience, symlink it onto your `$PATH`:
+
+```bash
+ln -s /Applications/MacParakeet.app/Contents/MacOS/macparakeet-cli \
+      /usr/local/bin/macparakeet-cli
+```
+
+**On the roadmap:** `brew install moona3k/tap/macparakeet-cli` for a
+standalone install with no `.app` required. See
+[`../plans/active/cli-as-canonical-parakeet-surface.md`](../plans/active/cli-as-canonical-parakeet-surface.md).
+
+## Why Apple Silicon specifically
+
+Parakeet TDT runs on the Apple Neural Engine via CoreML. That is the entire
+performance story: 155x realtime, ~66 MB working memory per inference slot.
+On VPS hosts without Apple Silicon (typical for cloud-deployed agent
+daemons), Parakeet falls back to CPU and Whisper.cpp is competitive. **The
+compelling deployment target is a Mac mini (M1+) running headless** as a
+personal AI compute box -- unified memory, ANE, ~8W idle, silent.
+
+## Common commands (the agent vocabulary)
+
+Every command below produces JSON when `--json` is passed. Schemas are stable
+per [`../Sources/CLI/CHANGELOG.md`](../Sources/CLI/CHANGELOG.md).
+
+### Health probe (run at agent init)
+
+```bash
+macparakeet-cli health --json
+```
+
+Reports model readiness, database accessibility, and binary deps (FFmpeg,
+yt-dlp). Use this before issuing real work.
+
+### Transcribe a file
+
+```bash
+macparakeet-cli transcribe /path/to/audio.mp3 --format json
+```
+
+### Transcribe a YouTube video
+
+```bash
+macparakeet-cli transcribe "https://www.youtube.com/watch?v=..." --format json
+```
+
+### Look up past transcriptions
+
+```bash
+macparakeet-cli history transcriptions --json
+macparakeet-cli history search "design review" --json
+```
+
+### Search past dictations
+
+```bash
+macparakeet-cli history dictations --json
+macparakeet-cli history search-transcriptions "what did I say about" --json
+```
+
+### List or run a prompt against a transcription
+
+```bash
+macparakeet-cli prompts list --json
+macparakeet-cli prompts run "Action items" \
+  --transcription <id-or-prefix> \
+  --provider anthropic --api-key "$ANTHROPIC_API_KEY" \
+  --model claude-sonnet-4-6
+```
+
+`<id-or-prefix>` accepts a full UUID, a UUID prefix (>= 4 chars), or the
+case-insensitive name. Ambiguous prefixes return a `.ambiguous` error so the
+agent can re-prompt the user.
+
+## Conventions
+
+- **Exit codes:** `0` on success; non-zero on failure with a one-line stderr
+  message. JSON output never goes to stderr.
+- **Lookups:** records that take an `<id-or-name>` argument accept full UUID,
+  UUID prefix (>= 4 chars), or case-insensitive name. Ambiguous prefixes
+  produce a `.ambiguous` error; missing records produce `.notFound`.
+- **Privacy:** STT and database access never touch the network. The only
+  network egress paths are: YouTube downloads (yt-dlp), optional cloud LLM
+  provider calls (only when `prompts run --provider <cloud>`), and Sparkle
+  update checks (app, not CLI).
+- **Concurrency:** the STT scheduler reserves one slot for dictation and
+  shares a second slot for meeting / batch work (ADR-016). Multiple
+  concurrent CLI calls share the background slot; expect serial transcription
+  of multi-file batches.
+
+## Per-ecosystem entry points
+
+- **OpenClaw:** [`openclaw/SOUL.md`](./openclaw/SOUL.md)
+- **Hermes Agent:** [`hermes/README.md`](./hermes/README.md)
+- **Codex CLI / Claude Code / generic AGENTS.md consumers:** read
+  [`/AGENTS.md`](../AGENTS.md) at the repo root, plus this file for the CLI
+  vocabulary.
+
+## Reporting issues
+
+Open an issue at <https://github.com/moona3k/macparakeet/issues> with the
+`integration` label. Include the agent platform, the CLI version
+(`macparakeet-cli --version`), and a minimal repro.

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -82,14 +82,14 @@ macparakeet-cli transcribe "https://www.youtube.com/watch?v=..." --format json
 
 ```bash
 macparakeet-cli history transcriptions --json
-macparakeet-cli history search "design review" --json
+macparakeet-cli history search-transcriptions "design review" --json
 ```
 
 ### Search past dictations
 
 ```bash
 macparakeet-cli history dictations --json
-macparakeet-cli history search-transcriptions "what did I say about" --json
+macparakeet-cli history search "what did I say about" --json
 ```
 
 ### List or run a prompt against a transcription

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -1,0 +1,70 @@
+# MacParakeet skill for Hermes Agent
+
+> Thin Hermes-flavored entry point. The canonical integration story lives in
+> [`../README.md`](../README.md). The CLI semver contract is at
+> [`../../Sources/CLI/CHANGELOG.md`](../../Sources/CLI/CHANGELOG.md). The
+> repo-root coding-agent guide is at [`/AGENTS.md`](../../AGENTS.md).
+>
+> The exact skill manifest format used by `awesome-hermes-agent` may evolve.
+> Treat the YAML sketch below as illustrative and adapt to the published spec
+> at registration time.
+
+## What this skill provides
+
+Local speech-to-text, transcription, and prompt automation for a Hermes Agent
+running on Apple Silicon. Wraps `macparakeet-cli` so a Hermes skill can call
+the local Parakeet TDT pipeline without any cloud STT dependency.
+
+## Install (manual, today)
+
+```bash
+# 1. Install MacParakeet from https://macparakeet.com
+# 2. Make the CLI available on $PATH
+ln -s /Applications/MacParakeet.app/Contents/MacOS/macparakeet-cli \
+      /usr/local/bin/macparakeet-cli
+# 3. Verify
+macparakeet-cli --version   # 1.0.0+
+macparakeet-cli health --json
+```
+
+`brew install moona3k/tap/macparakeet-cli` is on the roadmap.
+
+## Suggested skill bindings (sketch)
+
+```yaml
+# Illustrative -- adapt to your Hermes skill manifest format.
+name: macparakeet
+description: Local speech-to-text, transcription, and prompt automation
+             on Apple Silicon. Powered by Parakeet TDT on the Neural Engine.
+when_to_use:
+  - User wants to transcribe a local audio/video file.
+  - User wants to transcribe a YouTube URL.
+  - User asks "what was said in <past meeting / dictation>?"
+  - User asks for action items / summary from a recorded transcript.
+commands:
+  transcribe_file: macparakeet-cli transcribe "{path}" --format json
+  transcribe_youtube: macparakeet-cli transcribe "{url}" --format json
+  list_transcriptions: macparakeet-cli history transcriptions --json
+  search: macparakeet-cli history search "{query}" --json
+  search_dictations: macparakeet-cli history search-transcriptions "{query}" --json
+  run_prompt: |
+    macparakeet-cli prompts run "{prompt_id_or_name}" \
+      --transcription {transcription_id} \
+      --provider {provider} --api-key "{api_key}" --model "{model}"
+  health: macparakeet-cli health --json
+```
+
+## Conventions
+
+JSON to stdout when `--json` is set; human-readable errors to stderr;
+non-zero exit on failure. JSON schemas are stable within a major CLI version
+(semver, see [`CHANGELOG.md`](../../Sources/CLI/CHANGELOG.md)). Lookup args
+accept full UUID, UUID prefix (>= 4 chars), or case-insensitive name.
+
+For the full vocabulary, schema details, and privacy posture, see
+[`../README.md`](../README.md).
+
+## Status
+
+Submitted to `awesome-hermes-agent`: tracking via
+<https://github.com/moona3k/macparakeet/issues> with the `integration` label.

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -45,8 +45,8 @@ commands:
   transcribe_file: macparakeet-cli transcribe "{path}" --format json
   transcribe_youtube: macparakeet-cli transcribe "{url}" --format json
   list_transcriptions: macparakeet-cli history transcriptions --json
-  search: macparakeet-cli history search "{query}" --json
-  search_dictations: macparakeet-cli history search-transcriptions "{query}" --json
+  search_transcriptions: macparakeet-cli history search-transcriptions "{query}" --json
+  search_dictations: macparakeet-cli history search "{query}" --json
   run_prompt: |
     macparakeet-cli prompts run "{prompt_id_or_name}" \
       --transcription {transcription_id} \

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -23,7 +23,7 @@ the local Parakeet TDT pipeline without any cloud STT dependency.
 ln -s /Applications/MacParakeet.app/Contents/MacOS/macparakeet-cli \
       /usr/local/bin/macparakeet-cli
 # 3. Verify
-macparakeet-cli --version   # 1.0.0+
+macparakeet-cli --version   # 1.0.0
 macparakeet-cli health --json
 ```
 

--- a/integrations/openclaw/SOUL.md
+++ b/integrations/openclaw/SOUL.md
@@ -1,0 +1,63 @@
+# MacParakeet skill for OpenClaw
+
+> Thin OpenClaw-flavored entry point. The canonical integration story
+> (vocabulary, JSON schemas, privacy posture, conventions) lives in
+> [`../README.md`](../README.md). The CLI semver contract is at
+> [`../../Sources/CLI/CHANGELOG.md`](../../Sources/CLI/CHANGELOG.md).
+>
+> The exact `SOUL.md` schema used by ClawHub may evolve. Treat the structure
+> below as illustrative and adapt to the published spec at registration time.
+
+## What this skill provides
+
+Local speech-to-text and transcription for an OpenClaw agent running on Apple
+Silicon. Wraps `macparakeet-cli` so an OpenClaw skill can:
+
+- Transcribe a local audio/video file.
+- Transcribe a YouTube URL.
+- Search the user's prior dictation/transcription history.
+- Run a prompt against a transcription (action items, summary, etc.).
+
+All execution is local on the Apple Neural Engine. No cloud STT.
+
+## Install (manual, today)
+
+```bash
+# 1. Install MacParakeet from https://macparakeet.com
+# 2. Make the CLI available on $PATH
+ln -s /Applications/MacParakeet.app/Contents/MacOS/macparakeet-cli \
+      /usr/local/bin/macparakeet-cli
+# 3. Verify
+macparakeet-cli --version   # 1.0.0+
+macparakeet-cli health --json
+```
+
+`brew install moona3k/tap/macparakeet-cli` is on the roadmap; the manual
+symlink path will be deprecated once the tap ships.
+
+## Capabilities (suggested SOUL bindings)
+
+| Capability | Command |
+|---|---|
+| Transcribe a file | `macparakeet-cli transcribe <path> --format json` |
+| Transcribe a YouTube URL | `macparakeet-cli transcribe <url> --format json` |
+| List recent transcriptions | `macparakeet-cli history transcriptions --json` |
+| Search transcriptions | `macparakeet-cli history search "<query>" --json` |
+| Search dictations | `macparakeet-cli history search-transcriptions "<query>" --json` |
+| Run a prompt on a transcription | `macparakeet-cli prompts run <prompt-name> --transcription <id> --provider <p> --api-key "$KEY" --model <m>` |
+| Health probe (use in skill init) | `macparakeet-cli health --json` |
+
+## Conventions
+
+JSON to stdout when `--json` is set; human-readable errors to stderr;
+non-zero exit on failure. JSON schemas are stable within a major CLI version
+(semver, see [`CHANGELOG.md`](../../Sources/CLI/CHANGELOG.md)). Lookup args
+accept full UUID, UUID prefix (>= 4 chars), or case-insensitive name.
+
+For the full vocabulary, schema details, and privacy posture, see
+[`../README.md`](../README.md).
+
+## Status
+
+Submitted to ClawHub: tracking via
+<https://github.com/moona3k/macparakeet/issues> with the `integration` label.

--- a/integrations/openclaw/SOUL.md
+++ b/integrations/openclaw/SOUL.md
@@ -28,7 +28,7 @@ All execution is local on the Apple Neural Engine. No cloud STT.
 ln -s /Applications/MacParakeet.app/Contents/MacOS/macparakeet-cli \
       /usr/local/bin/macparakeet-cli
 # 3. Verify
-macparakeet-cli --version   # 1.0.0+
+macparakeet-cli --version   # 1.0.0
 macparakeet-cli health --json
 ```
 

--- a/integrations/openclaw/SOUL.md
+++ b/integrations/openclaw/SOUL.md
@@ -42,8 +42,8 @@ symlink path will be deprecated once the tap ships.
 | Transcribe a file | `macparakeet-cli transcribe <path> --format json` |
 | Transcribe a YouTube URL | `macparakeet-cli transcribe <url> --format json` |
 | List recent transcriptions | `macparakeet-cli history transcriptions --json` |
-| Search transcriptions | `macparakeet-cli history search "<query>" --json` |
-| Search dictations | `macparakeet-cli history search-transcriptions "<query>" --json` |
+| Search transcriptions | `macparakeet-cli history search-transcriptions "<query>" --json` |
+| Search dictations | `macparakeet-cli history search "<query>" --json` |
 | Run a prompt on a transcription | `macparakeet-cli prompts run <prompt-name> --transcription <id> --provider <p> --api-key "$KEY" --model <m>` |
 | Health probe (use in skill init) | `macparakeet-cli health --json` |
 

--- a/plans/active/cli-as-canonical-parakeet-surface.md
+++ b/plans/active/cli-as-canonical-parakeet-surface.md
@@ -1,0 +1,276 @@
+# Plan: MacParakeet CLI as the canonical Parakeet-on-Apple-Silicon surface
+
+> Status: **ACTIVE** — strategic plan, post-PR-#138, pre-v0.6.0
+> Author: agent (Claude) + Daniel
+> Date: 2026-04-25
+> Related: PR #138 (CLI prompts + JSON sweep, merged), PR #141 (gitignore journal/, merged), `MEMORY.md`
+
+---
+
+## TL;DR
+
+**The reframe:** MacParakeet is the canonical Swift-native CLI for Parakeet TDT on Apple Silicon, with a beautiful Mac GUI on top. The CLI is the foundation; the GUI is one (excellent) consumer of it. Apple Silicon AI-agent operators are a real, growing audience that needs exactly this.
+
+**Why now:** OpenClaw (acquired by OpenAI Feb 2026, 350K GitHub stars, 500K running instances) and Hermes Agent (Nous Research, 95K stars in 7 weeks) are exploding. Both deploy as daemons on user-controlled compute (Mac mini, VPS). Both shell out to local CLIs via `AGENTS.md`/`SOUL.md` skill specs. **Voice/STT is the documented gap** in their stacks today — Whisper.cpp is too slow without ANE; OpenAI Whisper API breaks privacy + costs money.
+
+**The slot is open and winnable.** Nobody is currently sitting in the chair labeled *"canonical Swift-native Parakeet CLI for Apple Silicon, batteries included."* parakeet-mlx (Python) is closest in spirit but structurally weaker (Python deps, no SQLite memory layer, no prompts/diarization). MacParakeet — after the PR #138 CLI work — is structurally there. The remaining gap is **claiming the position deliberately.**
+
+---
+
+## Market context (as of April 2026)
+
+### OpenClaw
+
+- **350K+ GitHub stars · 70K forks · 1.6K contributors** (from 245K in early March → +100K in ~5 weeks)
+- **38M monthly visitors · 3.2M active users · 500K running instances**
+- **44,000+ ClawHub skills** in the registry
+- **180 startups** building on top, generating $320K+/month
+- **Acquired by OpenAI in February 2026**
+- **NVIDIA built an enterprise stack on it**
+- Gartner: OpenClaw will be the default OSS choice for the 40% of enterprises deploying autonomous agents by EOY 2026
+
+### Hermes Agent (Nous Research)
+
+- Released **Feb 25, 2026** — **95,600 stars in 7 weeks**
+- "Matched the combined historical growth curves of LangChain and AutoGen"
+- v0.10.0 (Apr 16): 118 skills, three-layer memory, 6 messaging platforms (Telegram/Discord/Slack/WhatsApp/Signal/Email)
+- v0.8.0 (Apr 8): React/Ink CLI rewrite, pluggable transport, AWS Bedrock support
+- macOS install: literal one-liner. Hermes-on-Mac-mini is a documented happy path.
+- Uses **`AGENTS.md` convention** at repo root — becoming the de facto cross-agent integration spec
+- `awesome-hermes-agent` registry exists
+
+### Why Apple Silicon specifically
+
+- M4 Pro Mac mini at $1,399, unified memory, idles at ~8W, silent. The de facto "always-on personal AI compute box."
+- ANE (Apple Neural Engine) gives Parakeet TDT 155× realtime + 2.5% WER + ~66 MB working memory
+- VPS deployments of Hermes/OpenClaw can't access ANE → that's our defensible niche
+- The audience is "Apple Silicon agent operators" (Mac mini dominant, MacBook Pro + Mac Studio also valid)
+
+---
+
+## Architecture (after this reframe)
+
+```
+NVIDIA Parakeet TDT 0.6B v3 (public weights, NeMo)
+                │
+                ▼
+FluidAudio (CoreML/ANE Swift wrapper, public)
+                │
+                ▼
+   ┌────────────────────────────────────┐
+   │   MacParakeetCore (Swift library)  │
+   │   STT + DB + Prompts + LLM         │
+   └─────────────┬──────────────────────┘
+                 │
+        ┌────────┴────────┐
+        ▼                 ▼
+  macparakeet-cli    MacParakeet.app
+  (foundation)       (GUI consumer)
+        │
+        ├──► AGENTS.md (Hermes / Codex CLI / generic)
+        ├──► SOUL.md (OpenClaw)
+        ├──► brew install (headless install)
+        └──► [future] MCP server, more clients
+```
+
+The CLI is the load-bearing surface. The GUI is one well-crafted client of it. Agents are other clients. MCP, when/if shipped, is a future protocol-layer client. All read from the same SQLite + STT pipeline.
+
+---
+
+## Competitive positioning
+
+| Tool | Stack | Strengths | Gaps for agent use |
+|---|---|---|---|
+| **parakeet-mlx** (Python) | Python + MLX | Works, simple syntax, growing | Python deps, no memory layer, no prompts/history, no built-in diarization, not Swift-native |
+| **whisper.cpp** | C++ | Mature, ubiquitous | Different (worse) model, no ANE, slower, no diarization |
+| **FluidAudio CLI demos** | Swift | Same backend we use | Not productized — toys |
+| **VoiceInk** | Swift, GPL, FluidAudio | GUI app | No CLI focus |
+| **MacWhisper / Superwhisper / WisprFlow** | Various | Polished GUI consumer apps | Closed-source, no CLI |
+| **MacParakeet (post-#138)** | Swift native, FluidAudio, SQLite | **Best model + best runtime + memory layer + JSON CLI + GPL** | **Currently lacks the *positioning* + *distribution* to be discovered as canonical** |
+
+---
+
+## Action plan (six items, ordered by leverage)
+
+### 1. Promote `macparakeet-cli` to a versioned public surface
+
+**Why:** The CLI was framed as "internal dev tool" in `MEMORY.md`. Once OpenClaw/Hermes users build skills against `macparakeet-cli flow words add`, that's a public contract. Breaking changes need migration paths.
+
+**What:**
+- Adopt **semver** for the CLI surface. Stamp `1.0.0` on it (it's mature enough — the PR #138 work landed CRUD, JSON, validation, tests).
+- Create `CHANGELOG.md` scoped to CLI changes. Existing app changelog is for the app; the CLI deserves its own.
+- Add a **deprecation policy** doc: "CLI surface is semver. Breaking changes require N versions of `--legacy-X` shim and a release-note callout."
+- Update `MEMORY.md` to flip the "internal dev tool only" line — the CLI is now a public surface.
+- Bump `macparakeet-cli --version` from `0.1.0` to `1.0.0` in `Sources/CLI/MacParakeetCLI.swift`.
+
+**Effort:** 0.5 day.
+
+### 2. Ship `brew install moona3k/tap/macparakeet-cli`
+
+**Why:** Apple Silicon agent operators want CLI without dragging a `.app` into `/Applications`. Headless installs (Mac mini via SSH, launchd contexts) need a clean `brew install`.
+
+**What:**
+- Create a Homebrew tap repo: `moona3k/homebrew-tap`
+- Formula `macparakeet-cli.rb` that:
+  - Downloads the standalone CLI binary (or builds from source)
+  - Installs bundled FFmpeg + yt-dlp dependencies
+  - Sets up `~/Library/Application Support/MacParakeet/` paths
+  - Pins to a tagged release matching the CLI semver
+- Document install path in README + `/agents` website page
+- Optional: `curl -sSL macparakeet.com/install-cli.sh | bash` as an alternative one-liner
+
+**Effort:** 1 day.
+
+**Dependency:** Need a way to ship the CLI binary standalone (not bundled in `.app`). Options:
+- Build from source via `swift build --product macparakeet-cli` in the formula (slow but simple)
+- Pre-built signed binary attached to GitHub releases (faster install, more release work)
+
+Recommend pre-built binary path for distribution speed.
+
+### 3. Write `AGENTS.md` at repo root
+
+**Why:** `AGENTS.md` is becoming the cross-agent convention (Hermes uses it, Codex CLI reads it, Claude Code respects it). Single canonical spec serves all agent integrations.
+
+**What:**
+- File at `/AGENTS.md` (repo root)
+- Documents:
+  - When an agent should use MacParakeet (transcription, prompt-running, history search, vocab management)
+  - Every CLI command with example inputs + expected JSON output shape
+  - Privacy notes (all local, no network unless YouTube/LLM)
+  - Error-handling conventions (exit codes, stderr vs stdout)
+- Per-agent thin wrappers in `integrations/`:
+  - `integrations/openclaw/SOUL.md` — points to root AGENTS.md, adds OpenClaw-specific install
+  - `integrations/hermes/README.md` — Hermes skill registration
+  - `integrations/README.md` — landing page for the integration story
+
+**Effort:** 1 day.
+
+### 4. `/agents` page on macparakeet.com
+
+**Why:** Position page targeting the "Apple Silicon agent operator" persona explicitly. Acquisition surface for the agent audience.
+
+**What:**
+- New page on the marketing site: `macparakeet.com/agents`
+- Headline: *"The local STT layer for your Apple Silicon AI agent."*
+- Sections:
+  - Why MacParakeet for agents (ANE-accelerated, GPL, JSON CLI, no cloud)
+  - Quickstart: brew install + Hermes/OpenClaw skill registration
+  - Example: "Hey OpenClaw, what was my last meeting?" → real CLI output
+  - Privacy stance (everything local except optional YouTube/LLM provider)
+  - Link to AGENTS.md + integrations/
+- Mention in main homepage: small "For AI agents →" link in nav or footer
+
+**Effort:** 0.5 day.
+
+### 5. Submit to ClawHub + awesome-hermes-agent
+
+**Why:** Distribution. The skill registries are how agent users discover integrations.
+
+**What:**
+- PR to `awesome-openclaw-skills` registry — submission with link back to canonical SOUL.md / AGENTS.md
+- PR to `awesome-hermes-agent` registry — same
+- Cross-post to:
+  - r/LocalLLaMA: "Local Whisper alternative for Mac mini AI agents"
+  - Hacker News: "MacParakeet — canonical Parakeet CLI for Apple Silicon agent operators"
+  - Nous Research Discord
+  - OpenClaw Discord
+- Time these to land alongside v0.6.0 release for compounding momentum
+
+**Effort:** 0.5 day for the PRs + community posts (excluding response/moderation time)
+
+### 6. Blog post pinned to v0.6.0
+
+**Why:** Headline narrative for the reframe. Makes the strategic positioning shippable as content.
+
+**What:**
+- Title: *"MacParakeet, reframed: the canonical Parakeet CLI for Apple Silicon"* (or similar)
+- Story arc:
+  - The agent moment is here (OpenClaw + Hermes data)
+  - Voice/STT is the gap in the local agent stack
+  - MacParakeet was built for individual macOS users — but the architecture happens to be exactly what agents need
+  - Today: macparakeet-cli 1.0, AGENTS.md, brew install path, registry submissions
+  - Future: same direction, more depth (MCP later, more agent integrations as ecosystem matures)
+- Link to: AGENTS.md, integrations folder, `/agents` page, Hermes/OpenClaw quickstarts
+- Submit to HN, post to relevant communities
+
+**Effort:** 0.5 day.
+
+---
+
+## Total estimated effort: ~3-4 focused days
+
+Items 1-3 are deep work. Items 4-6 are mostly content + light coding. All can be done in parallel with v0.6.0 release prep.
+
+---
+
+## What's explicitly out of scope (for now)
+
+- **MCP server.** Different niche (Claude Desktop / Cursor users), more effort, no validated demand. Defer until OpenClaw/Hermes integration shows real adoption signal.
+- **Bundle agent integration into v0.6.0 release notes.** v0.6.0 should headline meeting-notepad for current users. Agent integration is a parallel narrative.
+- **Pivot away from GUI users.** They remain the largest and most loved audience. The reframe is *additive*, not subtractive.
+- **Renaming.** "MacParakeet" stays. CLI stays as `macparakeet-cli`. Brand is good.
+- **Whisper.cpp integration.** Stick with FluidAudio + Parakeet TDT. That's the moat.
+- **Cross-platform CLI (Linux/Windows).** Apple Silicon is the entire premise; non-Apple-Silicon defeats the ANE advantage.
+
+---
+
+## Risks / things to watch
+
+1. **Audience size unknown.** OpenClaw/Hermes star counts are aspirational signals, not paying users. Apple-Silicon-agent-operator subset is even smaller. Mitigation: cheap experiment, observe traction.
+2. **Skill registry formats may shift** post-OpenAI's OpenClaw acquisition. Keep specs lightweight and centralized so re-emitting in a new format is mechanical.
+3. **Maintenance burden of versioned CLI surface.** Once committed to semver, breaking changes have a cost. Already low-risk because the CLI is small + well-shaped.
+4. **Positioning confusion** between individual-user audience and agent-operator audience. Mitigation: separate pages on the website, single brand, both legitimate.
+5. **Competitor catches up.** parakeet-mlx could grow a memory layer + diarization. First-mover positioning wins by being there first AND having a structurally better (Swift native, better packaging) base.
+6. **OpenAI may push proprietary alternatives** post-OpenClaw acquisition. Risk if they ship a first-party Whisper-on-Apple-Silicon solution as part of OpenClaw. Mitigation: GPL + local + Parakeet (not Whisper) gives differentiation regardless.
+
+---
+
+## Sequencing relative to v0.6.0
+
+| Phase | When | What |
+|---|---|---|
+| v0.6.0 prep + release | Imminent (separate track) | Meeting-notepad headliner; cut release with usual flow |
+| Item 1 (semver + CHANGELOG) | Can ship before or with v0.6.0 | Doesn't touch app code |
+| Item 2 (brew tap) | Can ship before or with v0.6.0 | Separate repo |
+| Item 3 (AGENTS.md + integrations/) | Can ship before or with v0.6.0 | Pure docs |
+| Item 4 (/agents page) | Pair with v0.6.0 marketing | Website work |
+| Item 5 (registry submissions) | Land alongside v0.6.0 release | Maximize momentum |
+| Item 6 (blog post) | Day-of v0.6.0 release | Single headline narrative |
+
+**The agent integration work is decoupled from v0.6.0 code-wise but coupled in marketing timing.** Done right, both ship the same week with reinforcing narratives.
+
+---
+
+## Open decisions
+
+1. **Bump CLI version to `1.0.0` or `0.6.0`?** Semver suggests 1.0 (it's mature, public). Coupling to app version suggests 0.6.0. **Recommend 1.0.0** — the CLI is its own contract.
+2. **Brew tap repo name?** `moona3k/homebrew-tap` (general) or `moona3k/homebrew-macparakeet` (specific)? **Recommend general tap** so future tools can live alongside.
+3. **`/agents` page or `/cli` page?** Audience-framed (`/agents`) vs surface-framed (`/cli`). **Recommend `/agents`** — leads with persona.
+4. **Standalone binary distribution path?** Build-from-source in formula (simple, slow) vs pre-built signed binary (fast, more release work). **Recommend pre-built** for installation UX.
+5. **Update `CLAUDE.md`** to reflect the reframe (CLI as canonical surface, agent operators as second audience)? **Recommend yes** — keep the codebase context current.
+
+---
+
+## Success signals to watch (4-8 weeks post-launch)
+
+- ClawHub and awesome-hermes-agent listings get accepted + PRs merged
+- GitHub stars trajectory on macparakeet repo
+- Brew tap install count (if telemetry exists, or via Homebrew analytics)
+- `/agents` page traffic
+- Mentions in OpenClaw/Hermes Discord / r/LocalLLaMA
+- New GitHub issues from agent operators (different shape than current GUI-user issues)
+- Pull requests from non-MacParakeet users adding integration improvements
+
+If any of these light up meaningfully → double down (MCP server, more agent integrations, deeper docs).
+If all stay flat → the thesis didn't validate; cost was small (3-4 days), no regret, GUI work continues unaffected.
+
+---
+
+## References
+
+- PR #138: CLI prompts subcommand + structured JSON output (merged 2026-04-25)
+- PR #140: Retire legacy `Transcription.summary` mirror (merged 2026-04-25)
+- PR #141: Gitignore `journal/` directory (merged 2026-04-25)
+- `plans/active/cli-prompts-and-json-output.md` — the immediate predecessor plan
+- `MEMORY.md` — agent context, market positioning notes
+- ADR-013: Prompt Library + Multi-Summary Architecture

--- a/plans/active/cli-as-canonical-parakeet-surface.md
+++ b/plans/active/cli-as-canonical-parakeet-surface.md
@@ -3,7 +3,7 @@
 > Status: **ACTIVE** — strategic plan, post-PR-#138, pre-v0.6.0
 > Author: agent (Claude) + Daniel
 > Date: 2026-04-25
-> Related: PR #138 (CLI prompts + JSON sweep, merged), PR #141 (gitignore journal/, merged), `MEMORY.md`
+> Related: PR #138 (CLI prompts + JSON sweep, merged), PR #141 (gitignore journal/, merged)
 
 ---
 
@@ -94,13 +94,12 @@ The CLI is the load-bearing surface. The GUI is one well-crafted client of it. A
 
 ### 1. Promote `macparakeet-cli` to a versioned public surface
 
-**Why:** The CLI was framed as "internal dev tool" in `MEMORY.md`. Once OpenClaw/Hermes users build skills against `macparakeet-cli flow words add`, that's a public contract. Breaking changes need migration paths.
+**Why:** The CLI was previously framed as `"MacParakeet developer CLI (internal; used for AI-assisted development and testing)"` in its own `--help` abstract. Once OpenClaw/Hermes users build skills against `macparakeet-cli flow words add`, that's a public contract. Breaking changes need migration paths.
 
 **What:**
 - Adopt **semver** for the CLI surface. Stamp `1.0.0` on it (it's mature enough — the PR #138 work landed CRUD, JSON, validation, tests).
 - Create `CHANGELOG.md` scoped to CLI changes. Existing app changelog is for the app; the CLI deserves its own.
 - Add a **deprecation policy** doc: "CLI surface is semver. Breaking changes require N versions of `--legacy-X` shim and a release-note callout."
-- Update `MEMORY.md` to flip the "internal dev tool only" line — the CLI is now a public surface.
 - Bump `macparakeet-cli --version` from `0.1.0` to `1.0.0` in `Sources/CLI/MacParakeetCLI.swift`.
 
 **Effort:** 0.5 day.
@@ -272,5 +271,4 @@ If all stay flat → the thesis didn't validate; cost was small (3-4 days), no r
 - PR #140: Retire legacy `Transcription.summary` mirror (merged 2026-04-25)
 - PR #141: Gitignore `journal/` directory (merged 2026-04-25)
 - `plans/active/cli-prompts-and-json-output.md` — the immediate predecessor plan
-- `MEMORY.md` — agent context, market positioning notes
 - ADR-013: Prompt Library + Multi-Summary Architecture


### PR DESCRIPTION
## Update — strategic + execution record now lives in [#145](https://github.com/moona3k/macparakeet/pull/145)

This PR was the *code-change* PR (CLI version bump, AGENTS.md, integrations/ scaffolding). The full *strategic + execution record* of the agent rollout — including the brew tap publication, registry submission strategy, multi-LLM review findings, the SKILL.md / SOUL.md correction, future ideas — is captured in companion PR **[#145](https://github.com/moona3k/macparakeet/pull/145)** as the canonical historical record.

Live artifacts shipped alongside this PR:
- GitHub release: [`cli-v1.0.0`](https://github.com/moona3k/macparakeet/releases/tag/cli-v1.0.0) (signed + notarized tarball)
- Homebrew tap: [moona3k/homebrew-tap](https://github.com/moona3k/homebrew-tap) (formula + cask, both audit-clean)
- Persona-framed landing: <https://macparakeet.com/agents>
- Launch blog post: <https://macparakeet.com/blog/macparakeet-cli-1-0/>

---


## Summary

- Promotes `macparakeet-cli` to a **versioned public surface** (semver 1.0.0) with a written compatibility policy.
- Adds `AGENTS.md` at repo root and an `integrations/` tree with thin per-ecosystem entry points (OpenClaw, Hermes).
- Lands the strategic reframe planned in [`plans/active/cli-as-canonical-parakeet-surface.md`](plans/active/cli-as-canonical-parakeet-surface.md). **No behavior change** -- every existing command and flag retains its prior semantics.

## Why

After [#138](https://github.com/moona3k/macparakeet/pull/138) landed CRUD-complete prompts coverage and `--json` across every read-only command, the CLI surface is mature enough to commit to. Scripted callers -- shell scripts, CI pipelines, AI agent skill files -- need stable command names, flag shapes, and JSON schemas they can rely on.

This PR is the smallest concrete piece of that reframe: the version bump, the written-down compatibility policy, and the agent-facing docs that point at it.

## Architecture after this PR

```
              Parakeet TDT 0.6B v3   (NeMo, public weights)
                       │
              FluidAudio             (CoreML / Apple Neural Engine)
                       │
              ┌────────┴────────┐
              │ MacParakeetCore │   Swift library, no UI deps
              │ STT · DB · LLM  │
              └────────┬────────┘
                       │
            ┌──────────┴──────────┐
            ▼                     ▼
    macparakeet-cli         MacParakeet.app
    (semver 1.0.0)          (SwiftUI, GUI consumer)
            │
   ┌────────┼────────────────────────┐
   ▼        ▼                        ▼
AGENTS.md  integrations/         brew install
(coding    (OpenClaw SOUL.md,    moona3k/tap/...
 agents in  Hermes README)        (roadmap)
 this repo)
```

The CLI is the load-bearing surface. The GUI is one well-crafted client of it. Downstream agents (OpenClaw skills, Hermes skills, generic shell automation) are other clients, all reading from the same SQLite + STT pipeline.

## What's in this PR

| Commit | What |
|---|---|
| `d86b1c76` | `docs(plan):` strategic plan doc |
| `fc3da120` | `feat(cli):` bump to 1.0.0 + `Sources/CLI/CHANGELOG.md` (semver policy) |
| `ad162fb3` | `docs(agents):` AGENTS.md + integrations/{README, openclaw/SOUL, hermes/README}.md |
| `76e0a9d1` | `fix(cli):` exclude CHANGELOG.md from CLI SPM target |
| `4dd18d76` | `docs(claude):` CLAUDE.md sync (Quick Navigation, Folder Structure, build snippet) |

## What's NOT in this PR (parallel work, separate surfaces)

- **#2** `brew install moona3k/tap/macparakeet-cli` -- needs new tap repo
- **#4** `/agents` page on macparakeet.com -- lives in `macparakeet-website`
- **#5** ClawHub + awesome-hermes-agent registry submissions
- **#6** v0.6.0 blog post: *"MacParakeet, reframed"*

See [`plans/active/cli-as-canonical-parakeet-surface.md`](plans/active/cli-as-canonical-parakeet-surface.md) for the full six-item plan.

## Reviewer hints

- **AGENTS.md scope:** intentionally slim. It serves coding agents working *in* this repo (Claude Code, Codex CLI, Cursor). The "agents *calling* the CLI from outside" story lives in `integrations/README.md`. The plan and the original handoff conflated these; this PR splits them per the actual cross-agent convention.
- **Per-ecosystem files (`SOUL.md`, hermes README):** thin and self-marked as "illustrative -- adapt at registration time." Did not fabricate ClawHub / awesome-hermes-agent manifest schemas that couldn't be verified at write time.
- **CLI version 1.0.0:** decoupled from the app's 0.6.x line. Recommended by the plan; the CLI is its own contract.
- **Package.swift `exclude: ["CHANGELOG.md"]`:** required because the new file lives inside the CLI target's path; otherwise SPM emits an unhandled-file warning. Verified clean build after the fix.

## Test plan

- [x] `swift build --product macparakeet-cli` -- clean, no SPM warnings
- [x] `macparakeet-cli --version` reports `1.0.0`
- [x] `macparakeet-cli --help` reflects the new public abstract
- [ ] `swift test` (full suite) green
- [ ] AGENTS.md, integrations/README.md, openclaw/SOUL.md, hermes/README.md render correctly on GitHub
- [ ] CLAUDE.md table + folder tree edits look right in rendered Markdown
- [ ] `Sources/CLI/CHANGELOG.md` Compatibility policy reads accurately

🤖 Generated with [Claude Code](https://claude.com/claude-code)
