### PR TITLE
docs(agents): rollout artifacts + registry drafts (post-#144 launch record)

### DIFF
--- a/plans/active/community-posts/README.md
+++ b/plans/active/community-posts/README.md
@@ -1,0 +1,63 @@
+# Community post drafts
+
+Drafts for cross-posting the macparakeet-cli 1.0 launch to the
+relevant communities. **None of these have been posted.** Each
+needs the maintainer's account on the target platform; the agent
+running this rollout doesn't have those credentials.
+
+## Targets and timing
+
+| # | Platform | Audience | Account needed | Draft |
+|---|---|---|---|---|
+| 1 | r/LocalLLaMA | Local-first LLM/AI hobbyists, Mac Studio / Mac mini agent operators | Reddit | [`reddit-localllama.md`](./reddit-localllama.md) |
+| 2 | Hacker News (Show HN) | Broad dev / startup audience | HN account | [`hn-show.md`](./hn-show.md) |
+| 3 | OpenClaw Discord — `#showcase` (or equivalent) | OpenClaw skill authors and operators | Discord with OpenClaw server membership | [`discord-openclaw.md`](./discord-openclaw.md) |
+| 4 | Nous Research Discord — `#hermes-agent` (or equivalent) | Hermes Agent users + Nous community | Discord with Nous server membership | [`discord-nous.md`](./discord-nous.md) |
+
+## Posting order + timing
+
+The right time is **alongside v0.6.0** (the meeting-recording release)
+for compounding momentum — meeting recording is the headline for
+existing users, and the agent reframe is the headline for the new
+audience. Both are interesting in their own right; together they tell
+a fuller story about where MacParakeet is going.
+
+If posting before v0.6.0, lead with the CLI / agent angle and link to
+the `/agents` page + the launch blog post. Avoid pre-announcing
+v0.6.0.
+
+Suggested cadence:
+
+1. **Day 0 (release day)**: Post to r/LocalLLaMA. Tends to be
+   welcoming for local-first AI tools; good first signal.
+2. **Day 0 or Day +1**: Post to Hacker News as a Show HN. Pick a
+   weekday morning Pacific time. **Don't** ask people to upvote;
+   that's a fast-track to flagging.
+3. **Day 0–+2**: Drop the Discord posts in OpenClaw and Nous
+   community spaces. Be respectful of channel norms — if their
+   `#showcase` channel exists, use it.
+4. **Track responses** in this directory; capture any high-quality
+   feedback / bug reports as GitHub issues on macparakeet.
+
+## Voice + posture
+
+- **First-person honest, not promotional.** Match the tone of the
+  open-source-announcement blog post and the macparakeet-cli 1.0
+  launch post.
+- **Lead with the gap** (voice/STT slot for Apple Silicon agents),
+  not with feature lists.
+- **Disclose maintainer status.** Skip salesy adjectives ("fastest,"
+  "best," "amazing"). Let the spec numbers speak.
+- **No AI-attribution boilerplate** in any of these. They're personal
+  posts from the maintainer, not auto-generated content.
+
+## What NOT to do
+
+- **Don't ask for upvotes.** HN auto-flags. Reddit downvotes.
+- **Don't multi-post the same comment.** Tailor each platform.
+- **Don't subtweet competitors.** Whisper.cpp, parakeet-mlx, the
+  OpenAI Whisper API are mentioned only as factual contrast, never
+  as targets.
+- **Don't post before the brew tap, /agents page, and blog post
+  are all live.** All three landed on 2026-04-25, so this gate is
+  green.

--- a/plans/active/community-posts/discord-nous.md
+++ b/plans/active/community-posts/discord-nous.md
@@ -1,0 +1,98 @@
+# Nous Research Discord — `#hermes-agent` (or equivalent)
+
+> **Status:** drafted, not posted. Needs Discord with Nous Research server membership.
+
+## Find the right channel
+
+Nous Research's Discord is the canonical home for Hermes Agent
+discussion. Look for:
+
+1. `#hermes-agent` (most likely)
+2. `#hermes` or `#agents`
+3. `#community-tools` / `#showcase`
+4. `#hermes-skills` if a skills-specific channel exists
+
+If unclear, ask in `#general` ("which channel for new tools that
+Hermes skills can call?") — that's lower-effort than guessing wrong.
+
+## Tone
+
+Nous community values rigor and specificity. They'll ask about model
+internals, evaluation methodology, and reproducibility. Be ready
+with the FluidAudio + Parakeet TDT details and the WER claim's
+provenance (it's NVIDIA's published number for the model).
+
+## Post text
+
+```
+hey nous community 👋
+
+just tagged macparakeet-cli 1.0 — a swift-native CLI for NVIDIA's Parakeet TDT 0.6B v3 running on the Apple Neural Engine via FluidAudio. ~155x realtime, ~2.5% WER, ~66 MB per inference slot. GPL-3.0.
+
+posting because: voice / STT is the documented gap in the Hermes-on-Mac-mini stack, and i think this is the right shape to fill it. concretely, what a Hermes skill author gets:
+
+• local STT (no cloud, ANE-accelerated)
+• file + youtube transcription
+• persistent SQLite memory layer at ~/Library/Application Support/MacParakeet/macparakeet.db (skill can recall prior runs across sessions)
+• prompt library with BYO LLM provider
+• stable JSON on every read-only command (semver, written compatibility policy)
+• exit codes / stderr / lookup conventions documented for skill use
+
+install on macOS 14.2+ Apple Silicon:
+
+```
+brew install moona3k/tap/macparakeet-cli
+macparakeet-cli health --json
+```
+
+hermes-flavored scaffold (illustrative skill manifest sketch + capability table): https://github.com/moona3k/macparakeet/tree/main/integrations/hermes
+
+agent-facing landing: https://macparakeet.com/agents
+launch post (with full architecture story): https://macparakeet.com/blog/macparakeet-cli-1-0/
+
+awesome-hermes-agent issue: https://github.com/0xNyk/awesome-hermes-agent/issues/49
+
+i'm the maintainer (@moona3k on github), happy to answer Qs about wiring it into a skill. open to feedback on the integrations/hermes/ scaffold from people who've actually built Hermes skills.
+```
+
+## Anticipated questions
+
+- **"Is this a Hermes skill?"** — No, it's a CLI that a Hermes skill calls.
+  The scaffold at integrations/hermes/ shows how to wire one up.
+- **"How does the WER compare to Whisper-large-v3?"** — Parakeet TDT
+  0.6B benchmarks at ~2.5% WER on standard English; Whisper-large-v3
+  is similar. The performance edge here is throughput on the ANE,
+  not WER.
+- **"Why not parakeet-mlx?"** — parakeet-mlx is great for the
+  Python ecosystem; macparakeet-cli is Swift-native + has the
+  persistence/prompts layer for skill use.
+- **"Does it support diarization?"** — Yes, via FluidAudio's offline
+  pipeline. Available on file transcription.
+- **"Memory footprint when idle?"** — ~0 MB. Models load on demand
+  per inference slot.
+
+## Things to avoid
+
+- No `@everyone`, `@here`, or `@<role>` pings.
+- Don't post the same text in #hermes-agent and another Nous channel.
+- Don't compare unfavorably to Hermes itself or to other Nous
+  projects — that's poor form in their server.
+- Don't pitch your other tools (the Mac app, the CLI) separately.
+  The post is about the CLI.
+
+## Engagement
+
+- Answer questions the first day actively; less so after.
+- If someone wants to ship a real Hermes skill that wraps this, offer
+  to review their skill manifest or pair on the wiring.
+- Negative or skeptical comments → respond once with a technical
+  answer; don't escalate.
+
+## Track
+
+After posting, capture:
+- Discord channel name + message permalink (if accessible)
+- Date/time of post
+- Notable responses (filed as GH issues if actionable)
+
+Cross-link into PR #145's tracking section.

--- a/plans/active/community-posts/discord-openclaw.md
+++ b/plans/active/community-posts/discord-openclaw.md
@@ -1,0 +1,76 @@
+# OpenClaw Discord — `#showcase` (or equivalent)
+
+> **Status:** drafted, not posted. Needs Discord with OpenClaw server membership.
+
+## Find the right channel
+
+OpenClaw's official server has a `#showcase` channel (or
+similar — verify on join). Drop the post there, NOT in `#general`.
+If `#showcase` doesn't exist, alternatives in priority order:
+
+1. `#community-projects`
+2. `#integrations`
+3. `#tools`
+4. `#general` (last resort, with a tag like `[showcase]` in the message)
+
+## Tone
+
+OpenClaw community is technical + project-focused. They appreciate
+specifics (commands, JSON examples) over marketing copy. Keep it
+short, embed the install command, and let them ask follow-ups.
+
+## Post text
+
+```
+hey openclaw folks 👋
+
+just shipped macparakeet-cli 1.0 — a swift-native CLI that runs Parakeet TDT 0.6B v3 on the Apple Neural Engine. ~155x realtime, ~2.5% WER, ~66 MB per inference slot. free + open-source (GPL-3.0).
+
+what it gives an OpenClaw skill author:
+• local STT (no cloud, no API keys, no per-minute charges)
+• transcribe local audio/video files OR youtube urls
+• search past dictations / transcriptions across sessions (persistent SQLite memory)
+• run prompts against transcriptions (BYO LLM — OpenAI / Anthropic / Ollama / LM Studio / openai-compatible)
+• stable JSON output on every read-only command, semver compatibility policy
+
+requires macOS 14.2+ on Apple Silicon (M1/M2/M3/M4). install:
+
+```
+brew install moona3k/tap/macparakeet-cli
+macparakeet-cli health --json
+```
+
+OpenClaw scaffold (capability table + install + conventions): https://github.com/moona3k/macparakeet/tree/main/integrations/openclaw
+
+agent-facing landing: https://macparakeet.com/agents
+launch blog: https://macparakeet.com/blog/macparakeet-cli-1-0/
+
+i'm the maintainer (@moona3k on github), happy to answer Qs or take feature requests. ClawHub publication is on the roadmap — open to guidance from anyone who's been through it.
+```
+
+## What to avoid
+
+- No `@everyone` or `@here` pings. Ever.
+- Don't repost in multiple channels.
+- Don't paste the same post in any other Discord server within the
+  same week — community moderators talk to each other.
+- Don't follow up "any thoughts?" 24h later. The post is the post.
+  If it landed it landed; if not, learn and try a different angle next time.
+
+## Engaging in the thread
+
+- Answer questions promptly the first day; less aggressively after.
+- If someone wants help wiring it into a specific OpenClaw skill,
+  offer to look at their code or help via DM.
+- If someone reports a bug, ask them to file it on GitHub with
+  `from-discord` label and link the thread.
+
+## Track in the rollout
+
+After posting, capture:
+- Discord channel name + message permalink (if accessible)
+- Date/time of post
+- Substantive responses (filed as GH issues if actionable)
+
+Add the message permalink (or "posted in #showcase on YYYY-MM-DD")
+to PR #145's tracking section.

--- a/plans/active/community-posts/hn-show.md
+++ b/plans/active/community-posts/hn-show.md
@@ -1,0 +1,100 @@
+# Hacker News — Show HN
+
+> **Status:** drafted, not posted. Needs an HN account.
+
+## Why HN
+
+Broad reach into the dev / startup / infra audience. People who run
+homelabs, build agent stacks, run their own Mac mini for compute,
+and care about local-first tooling. HN can be hostile to perceived
+self-promotion, so the framing matters more than the content.
+
+## Best practices (from the HN guidelines + observed patterns)
+
+- **Do** lead with what it is in one sentence. No teaser titles.
+- **Do** use the `Show HN:` prefix — required for project shares and
+  invites a different reader posture.
+- **Do** post on a weekday US morning (Pacific time roughly 8–11 a.m.)
+  for best initial visibility.
+- **Don't** ask for upvotes anywhere (in the post, in followups, in
+  Twitter, in Discord). HN auto-flags this hard.
+- **Don't** post the same blurb to multiple sites the same hour.
+- **Don't** title with hype words. Avoid "fastest," "best,"
+  "revolutionary."
+- **Be present** in the comment thread for the first few hours. Top
+  of the thread is the maintainer's engagement, not just the post.
+
+## Title
+
+```
+Show HN: macparakeet-cli – local Parakeet STT on Apple Silicon for AI agents
+```
+
+(80 chars; HN soft-limit is 80 in the title field.)
+
+## URL field
+
+```
+https://github.com/moona3k/macparakeet
+```
+
+(Linking to the repo, not the website. HN audience prefers the repo.)
+
+## First comment to post immediately after
+
+The first-comment-by-the-author pattern works well on HN — it's a
+chance to add context without making the title too dense. Post this
+**immediately** after submitting:
+
+```markdown
+Hi HN — Daniel, maintainer of MacParakeet here.
+
+Quick context: this repo has had a macOS app (system-wide dictation, file transcription) since the start. The CLI was internal-feeling until today. With v1.0 of the CLI I'm committing to it as a versioned public surface — semver, written compatibility policy, stable JSON output on every read-only command, brew install path.
+
+The reason I'm doing the reframe is that Apple Silicon Mac minis are increasingly the home for personal AI agent daemons (OpenClaw, Hermes, custom shell loops). Voice / STT is the documented gap in that stack: Whisper.cpp doesn't use the Neural Engine, the OpenAI Whisper API breaks local-first, parakeet-mlx (Python) doesn't have a memory layer or prompts. `macparakeet-cli` is exactly the slot between those.
+
+Architecture summary:
+
+```
+              Parakeet TDT 0.6B v3   (NeMo, public weights)
+                       │
+              FluidAudio             (CoreML on the Apple Neural Engine)
+                       │
+              ┌────────┴────────┐
+              │ MacParakeetCore │   Swift library, no UI deps
+              │ STT · DB · LLM  │
+              └────────┬────────┘
+                       │
+            ┌──────────┴──────────┐
+            ▼                     ▼
+    macparakeet-cli         MacParakeet.app
+    (semver 1.0.0)          (SwiftUI, GUI consumer)
+```
+
+The CLI is the load-bearing surface. The macOS app is one well-crafted client of it. Agent skills (OpenClaw, Hermes, generic shell automation) are other clients.
+
+Everything is GPL-3.0. No accounts, no telemetry by default (opt-in, content-free, see <https://github.com/moona3k/macparakeet/blob/main/docs/telemetry.md>). The launch post with the full story is at <https://macparakeet.com/blog/macparakeet-cli-1-0/>; the agent-facing landing is at <https://macparakeet.com/agents>.
+
+Happy to answer anything. Bug reports / feature requests filed on GitHub get a real human response.
+```
+
+## Things to expect in the thread
+
+- **Comparisons to Whisper.cpp / WhisperKit** — be factual: WhisperKit is fine on the ANE; Parakeet TDT happens to be faster + lower-WER for English at the 0.6B size, plus FluidAudio runs both. Both are good.
+- **"Why GPL not MIT?"** — link to <https://macparakeet.com/blog/macparakeet-open-source/> which addresses this directly. The short answer is: end-user app, want improvements to flow back. FluidAudio (Apache 2.0) is the embeddable layer.
+- **Privacy questions** — answer factually: STT runs on-device ANE, DB local, no audio ever leaves device, optional cloud LLM only when explicitly configured.
+- **"Will this work on Linux / x86 Mac?"** — no. Apple Silicon ANE is the entire premise. (For non-Apple-Silicon, parakeet-mlx + Python or Whisper.cpp are appropriate.)
+- **Feature requests** — note in the answer if it's roadmap, not-roadmap, or unsure. "Simplicity is the product" is a real constraint.
+
+## Things NOT to do in comments
+
+- Don't pitch competing tools negatively.
+- Don't post the same content again in replies.
+- Don't paste the launch blog post body into comments — link.
+- Don't engage with bait. The "this should be a Rust CLI" type comments are best replied to once with the technical reason and then ignored.
+
+## After the post
+
+- Keep an eye on the thread for ~2-3 hours after posting (peak engagement window).
+- File any actionable feedback as GitHub issues with `from-hn` label.
+- The HN URL becomes a permanent link to the conversation; it's worth referencing in future blog posts.

--- a/plans/active/community-posts/reddit-localllama.md
+++ b/plans/active/community-posts/reddit-localllama.md
@@ -1,0 +1,93 @@
+# Reddit — r/LocalLLaMA
+
+> **Status:** drafted, not posted. Needs Reddit account + flair selection.
+
+## Why r/LocalLLaMA
+
+The audience overlaps heavily with our target persona: local-first
+AI/ML tinkerers, Mac Studio + Mac mini agent operators, people who
+care about owning their compute and not paying for cloud STT.
+
+## Subreddit conventions to honor
+
+- Posts are usually descriptive titles (no clickbait).
+- Self-posts (text posts) tend to do better than bare links.
+- Code blocks render. Markdown is supported.
+- Cross-posts welcomed if useful, but better to write a fresh post.
+
+## Suggested flair
+
+Likely options: `Resources`, `Tutorial`, `Discussion`, `New Model`.
+**`Resources`** fits best (we're sharing a tool, not a model).
+
+## Title (pick one)
+
+Primary:
+```
+macparakeet-cli 1.0 — local Parakeet TDT speech-to-text on Apple Silicon, for AI agents (GPL-3.0)
+```
+
+Alternatives if 100-char limit is tight:
+- `macparakeet-cli 1.0 — local Parakeet STT on Apple Silicon ANE, for agent use (GPL-3.0)`
+- `Local Parakeet TDT CLI for Apple Silicon agents — macparakeet-cli 1.0 (GPL-3.0)`
+
+## Post body
+
+```markdown
+TL;DR: I just tagged `macparakeet-cli 1.0`, a Swift-native CLI that runs NVIDIA's Parakeet TDT 0.6B v3 on the Apple Neural Engine via FluidAudio. ~155x realtime, ~2.5% WER, ~66 MB memory per inference slot. Free + open-source (GPL-3.0). `brew install moona3k/tap/macparakeet-cli`.
+
+## Why I'm posting it here
+
+Voice/STT is the documented gap in the local-agent stack on Mac:
+
+- Whisper.cpp doesn't use the Neural Engine, so it's measurably slower on Apple Silicon than what the hardware can do.
+- The OpenAI Whisper API is fast but cloud-only, paid, and breaks the local-first posture this subreddit is built around.
+- `parakeet-mlx` (Python) is the closest thing in spirit, but doesn't carry persistence, prompts, or speaker diarization.
+
+`macparakeet-cli` is the slot between those: Apple Silicon native, ANE-accelerated, persistent SQLite memory, prompt library, semver-stable JSON output. The CLI has existed since v0.1 of the MacParakeet macOS app and powered AI-assisted testing through v0.4–v0.6 — the 1.0.0 tag is the commitment to a stable public surface, not a feature release.
+
+## What you can do with it
+
+```bash
+brew install moona3k/tap/macparakeet-cli
+
+macparakeet-cli health --json
+macparakeet-cli transcribe ~/Downloads/podcast.mp3 --format json
+macparakeet-cli transcribe "https://www.youtube.com/watch?v=..." --format json
+macparakeet-cli history search-transcriptions "design review" --json
+macparakeet-cli prompts run "Action items" --transcription <id> \
+  --provider anthropic --api-key "$KEY" --model claude-sonnet-4-6
+```
+
+JSON output everywhere with stable schemas (semver, [CHANGELOG](https://github.com/moona3k/macparakeet/blob/main/Sources/CLI/CHANGELOG.md)). UUID-or-name lookups with `.notFound`/`.ambiguous` error classes. All STT runs on the Neural Engine; no audio leaves the device. Optional cloud LLM provider only if you explicitly pass one.
+
+## Why Apple Silicon specifically
+
+Parakeet TDT runs on the ANE via CoreML. That's the entire performance story. On VPS deployments without Apple Silicon, fallback to CPU is competitive with Whisper.cpp and you might as well use that. **The compelling deployment is a Mac mini (M1+) running headless** — unified memory, ANE, ~8 W idle, silent.
+
+## Pointers
+
+- Repo + docs: <https://github.com/moona3k/macparakeet>
+- For agent operators (OpenClaw, Hermes, Codex, Claude Code): <https://macparakeet.com/agents>
+- Launch post with the architecture story: <https://macparakeet.com/blog/macparakeet-cli-1-0/>
+- Compatibility policy: <https://github.com/moona3k/macparakeet/blob/main/Sources/CLI/CHANGELOG.md>
+
+I'm the maintainer (Daniel, [@moona3k](https://github.com/moona3k)) — happy to answer questions and take feature requests. Issues filed on the repo get a real human response.
+```
+
+## Self-comment to add (optional, after a few hours)
+
+If discussion picks up, drop a follow-up comment with a recipe people often ask about, e.g.:
+
+```
+For anyone wiring this into an agent (OpenClaw / Hermes / a custom shell loop), the integration vocabulary lives at <https://github.com/moona3k/macparakeet/tree/main/integrations>. The thin per-ecosystem scaffolds are at integrations/openclaw/ and integrations/hermes/.
+
+If you want to set up a Mac mini as a personal STT box and call it from another machine, the CLI is fine over SSH (just JSON over stdout). The DB lives at `~/Library/Application Support/MacParakeet/macparakeet.db` so you can rsync that for backups.
+```
+
+## Things to monitor after posting
+
+- Genuine bug reports → file as macparakeet GitHub issues with `bug` label.
+- Feature requests → assess against the "simplicity is the product" north star; not all asks should ship.
+- Questions about FluidAudio / Parakeet TDT internals → defer to FluidAudio docs.
+- Negative comments about closed competitors → don't engage; let the spec numbers speak.

--- a/plans/active/registry-submissions/README.md
+++ b/plans/active/registry-submissions/README.md
@@ -1,0 +1,50 @@
+# Registry submission drafts
+
+Drafts of the content + PR bodies for submitting `macparakeet-cli` to
+the relevant agent skill registries. **None of these have been
+submitted.** Each requires user confirmation before opening an external
+PR (per the standing "ask before visible-to-others actions" rule).
+
+## Targets
+
+| Registry | Repo | Type | Status |
+|---|---|---|---|
+| OpenClaw skill registry | [`openclaw/clawhub`](https://github.com/openclaw/clawhub) | Official skill registry (SOUL.md / package upload) | **Draft only** — verify exact submission schema before PR |
+| Awesome OpenClaw | [`vincentkoc/awesome-openclaw`](https://github.com/vincentkoc/awesome-openclaw) | Curated awesome list (Markdown PR) | **Draft only** — verify category structure |
+| Awesome OpenClaw Skills | [`VoltAgent/awesome-openclaw-skills`](https://github.com/VoltAgent/awesome-openclaw-skills) | Curated skill index (large, automated) | **Draft only** — likely auto-pulls from clawhub |
+| Awesome Hermes Agent | [`0xNyk/awesome-hermes-agent`](https://github.com/0xNyk/awesome-hermes-agent) | Curated awesome list (Markdown PR) | **Draft only** — verify category structure |
+
+## Submission order
+
+Do NOT submit any of these before the brew tap is live, because each
+submission's install path will read `brew install moona3k/tap/macparakeet-cli`.
+Submitting earlier means people land on broken instructions.
+
+Recommended sequence:
+
+1. Cut the brew tap (see `scripts/dist/homebrew-tap-scaffold/HOWTO.md`).
+2. Verify `brew install moona3k/tap/macparakeet-cli` works end-to-end.
+3. Submit `awesome-hermes-agent` PR (lowest-friction, awesome-style).
+4. Submit `awesome-openclaw` PR (same shape).
+5. Submit to `openclaw/clawhub` (official registry — needs schema verification).
+6. `VoltAgent/awesome-openclaw-skills` likely auto-syncs from clawhub —
+   probably no separate submission needed; verify after step 5.
+
+## Per-target drafts
+
+- [`awesome-hermes-agent.md`](./awesome-hermes-agent.md)
+- [`awesome-openclaw.md`](./awesome-openclaw.md)
+- [`clawhub.md`](./clawhub.md)
+
+## Cross-posting (after registry submissions)
+
+Once the registry PRs are in flight, cross-post to:
+
+- **r/LocalLLaMA** — title: *"Local Whisper alternative for Mac mini AI agents (Parakeet on the Neural Engine)"*
+- **Hacker News** — title: *"Show HN: macparakeet-cli — canonical Parakeet CLI for Apple Silicon agents"*
+- **OpenClaw Discord** — `#showcase` or equivalent
+- **Nous Research Discord** — `#hermes-agent` or equivalent
+
+Time these to land alongside v0.6.0 release for compounding momentum
+(item #6 of the canonical plan). Don't fire community posts before the
+brew tap is live.

--- a/plans/active/registry-submissions/README.md
+++ b/plans/active/registry-submissions/README.md
@@ -1,50 +1,65 @@
 # Registry submission drafts
 
-Drafts of the content + PR bodies for submitting `macparakeet-cli` to
-the relevant agent skill registries. **None of these have been
-submitted.** Each requires user confirmation before opening an external
-PR (per the standing "ask before visible-to-others actions" rule).
+Drafts of the content + submission bodies for placing `macparakeet-cli`
+in the relevant agent skill registries. **None of these have been
+submitted.** Each requires explicit user confirmation before opening
+an external action (per the standing "ask before visible-to-others
+actions" rule).
 
-## Targets
+## Status snapshot (post-2026-04-25 reconnaissance)
 
-| Registry | Repo | Type | Status |
-|---|---|---|---|
-| OpenClaw skill registry | [`openclaw/clawhub`](https://github.com/openclaw/clawhub) | Official skill registry (SOUL.md / package upload) | **Draft only** — verify exact submission schema before PR |
-| Awesome OpenClaw | [`vincentkoc/awesome-openclaw`](https://github.com/vincentkoc/awesome-openclaw) | Curated awesome list (Markdown PR) | **Draft only** — verify category structure |
-| Awesome OpenClaw Skills | [`VoltAgent/awesome-openclaw-skills`](https://github.com/VoltAgent/awesome-openclaw-skills) | Curated skill index (large, automated) | **Draft only** — likely auto-pulls from clawhub |
-| Awesome Hermes Agent | [`0xNyk/awesome-hermes-agent`](https://github.com/0xNyk/awesome-hermes-agent) | Curated awesome list (Markdown PR) | **Draft only** — verify category structure |
+The brew tap is live as of 2026-04-25, so install instructions
+(`brew install moona3k/tap/macparakeet-cli`) are now valid in any
+submission. Reconnaissance against each target's `CONTRIBUTING.md`
+sharpened the picture significantly — see per-target notes below.
 
-## Submission order
+| # | Registry | Repo | Submission flow | Recommended action |
+|---|---|---|---|---|
+| 1 | Awesome Hermes Agent | [`0xNyk/awesome-hermes-agent`](https://github.com/0xNyk/awesome-hermes-agent) | **Issue first** — direct PRs explicitly forbidden by CONTRIBUTING.md | Open issue with required fields |
+| 2 | Awesome OpenClaw | [`vincentkoc/awesome-openclaw`](https://github.com/vincentkoc/awesome-openclaw) | **Issue first** via `Add Resource Request` template, PR after maintainer approval | Open issue via template |
+| 3 | OpenClaw skill registry | [`openclaw/clawhub`](https://github.com/openclaw/clawhub) | **CLI-based** (`clawhub skill publish <path>`); uses `SKILL.md` (NOT `SOUL.md`) | **Defer** — needs OpenClaw CLI installed locally + SKILL.md schema verification |
+| 4 | Awesome OpenClaw Skills | [`VoltAgent/awesome-openclaw-skills`](https://github.com/VoltAgent/awesome-openclaw-skills) | Manual PR — but **only accepts skills already published in `github.com/openclaw/skills`** | **Defer** — depends on (3) succeeding first |
 
-Do NOT submit any of these before the brew tap is live, because each
-submission's install path will read `brew install moona3k/tap/macparakeet-cli`.
-Submitting earlier means people land on broken instructions.
+## Critical schema correction
 
-Recommended sequence:
+The `SOUL.md` filename in `integrations/openclaw/` was based on a
+mistaken belief that ClawHub uses SOUL.md. **It does not.** ClawHub
+uses `SKILL.md` with frontmatter metadata. `SOUL.md` is the format
+used by a different agent registry (onlycrabs.ai). See `clawhub.md`
+for details. A follow-up PR to `macparakeet` should rename or
+reframe `integrations/openclaw/SOUL.md` so it accurately reflects
+the SKILL.md target.
 
-1. Cut the brew tap (see `scripts/dist/homebrew-tap-scaffold/HOWTO.md`).
-2. Verify `brew install moona3k/tap/macparakeet-cli` works end-to-end.
-3. Submit `awesome-hermes-agent` PR (lowest-friction, awesome-style).
-4. Submit `awesome-openclaw` PR (same shape).
-5. Submit to `openclaw/clawhub` (official registry — needs schema verification).
-6. `VoltAgent/awesome-openclaw-skills` likely auto-syncs from clawhub —
-   probably no separate submission needed; verify after step 5.
+## Submission order (revised)
+
+The previous "submit all four" plan was incorrect. Updated:
+
+1. **Now** (with explicit user OK): Open issues on `awesome-hermes-agent`
+   and `awesome-openclaw`. Both maintainers vet additions; issues are
+   the prescribed entry point.
+2. **Later** (separate, more involved): If pursuing ClawHub publication,
+   install the OpenClaw CLI, verify SKILL.md frontmatter spec via
+   `docs.openclaw.ai/tools/clawhub`, prepare a real SKILL.md package,
+   and run `clawhub skill publish`.
+3. **Even later**: After (2) succeeds, the `VoltAgent/awesome-openclaw-skills`
+   list may auto-sync, or may accept a manual PR linking to the
+   newly-published clawhub entry.
 
 ## Per-target drafts
 
-- [`awesome-hermes-agent.md`](./awesome-hermes-agent.md)
-- [`awesome-openclaw.md`](./awesome-openclaw.md)
-- [`clawhub.md`](./clawhub.md)
+- [`awesome-hermes-agent.md`](./awesome-hermes-agent.md) — issue body draft
+- [`awesome-openclaw.md`](./awesome-openclaw.md) — issue template responses
+- [`clawhub.md`](./clawhub.md) — deferred submission notes + schema findings
 
-## Cross-posting (after registry submissions)
+## Cross-posting (after registry placements take)
 
-Once the registry PRs are in flight, cross-post to:
+Once the registry placements have landed, cross-post to:
 
-- **r/LocalLLaMA** — title: *"Local Whisper alternative for Mac mini AI agents (Parakeet on the Neural Engine)"*
-- **Hacker News** — title: *"Show HN: macparakeet-cli — canonical Parakeet CLI for Apple Silicon agents"*
+- **r/LocalLLaMA** — *"Local Whisper alternative for Mac mini AI agents (Parakeet on the Neural Engine)"*
+- **Hacker News** — *"Show HN: macparakeet-cli — canonical Parakeet CLI for Apple Silicon agents"*
 - **OpenClaw Discord** — `#showcase` or equivalent
 - **Nous Research Discord** — `#hermes-agent` or equivalent
 
 Time these to land alongside v0.6.0 release for compounding momentum
-(item #6 of the canonical plan). Don't fire community posts before the
-brew tap is live.
+(item #6 of the canonical plan). Don't fire community posts before
+the brew tap is live AND the registry placements have been accepted.

--- a/plans/active/registry-submissions/README.md
+++ b/plans/active/registry-submissions/README.md
@@ -13,12 +13,12 @@ The brew tap is live as of 2026-04-25, so install instructions
 submission. Reconnaissance against each target's `CONTRIBUTING.md`
 sharpened the picture significantly — see per-target notes below.
 
-| # | Registry | Repo | Submission flow | Recommended action |
+| # | Registry | Repo | Submission flow | Status (2026-04-25) |
 |---|---|---|---|---|
-| 1 | Awesome Hermes Agent | [`0xNyk/awesome-hermes-agent`](https://github.com/0xNyk/awesome-hermes-agent) | **Issue first** — direct PRs explicitly forbidden by CONTRIBUTING.md | Open issue with required fields |
-| 2 | Awesome OpenClaw | [`vincentkoc/awesome-openclaw`](https://github.com/vincentkoc/awesome-openclaw) | **Issue first** via `Add Resource Request` template, PR after maintainer approval | Open issue via template |
-| 3 | OpenClaw skill registry | [`openclaw/clawhub`](https://github.com/openclaw/clawhub) | **CLI-based** (`clawhub skill publish <path>`); uses `SKILL.md` (NOT `SOUL.md`) | **Defer** — needs OpenClaw CLI installed locally + SKILL.md schema verification |
-| 4 | Awesome OpenClaw Skills | [`VoltAgent/awesome-openclaw-skills`](https://github.com/VoltAgent/awesome-openclaw-skills) | Manual PR — but **only accepts skills already published in `github.com/openclaw/skills`** | **Defer** — depends on (3) succeeding first |
+| 1 | Awesome Hermes Agent | [`0xNyk/awesome-hermes-agent`](https://github.com/0xNyk/awesome-hermes-agent) | **Issue first** — direct PRs explicitly forbidden by CONTRIBUTING.md | ✅ **Submitted:** [issue #49](https://github.com/0xNyk/awesome-hermes-agent/issues/49) |
+| 2 | Awesome OpenClaw | [`vincentkoc/awesome-openclaw`](https://github.com/vincentkoc/awesome-openclaw) | **Issue first** via `Add Resource Request` template, PR after maintainer approval | ✅ **Submitted:** [issue #71](https://github.com/vincentkoc/awesome-openclaw/issues/71) |
+| 3 | OpenClaw skill registry | [`openclaw/clawhub`](https://github.com/openclaw/clawhub) | **CLI-based** (`openclaw clawhub skill publish <path>`); uses `SKILL.md` (NOT `SOUL.md`) | **Deferred** — npm `openclaw@2026.4.24` is the full OpenClaw runtime (36 deps); installing globally to publish a single skill is overkill. Defer until either an isolated install path is set up OR there's a lighter-weight publish flow. |
+| 4 | Awesome OpenClaw Skills | [`VoltAgent/awesome-openclaw-skills`](https://github.com/VoltAgent/awesome-openclaw-skills) | Manual PR — but **only accepts skills already published in `github.com/openclaw/skills`** | **Deferred** — depends on (3) succeeding first |
 
 ## Critical schema correction
 

--- a/plans/active/registry-submissions/awesome-hermes-agent.md
+++ b/plans/active/registry-submissions/awesome-hermes-agent.md
@@ -1,82 +1,130 @@
 # Submission draft — `0xNyk/awesome-hermes-agent`
 
-> **Status:** draft. Do not submit until the brew tap is live and the
-> author confirms.
+> **Status:** issue body drafted. **Not yet submitted.** Awaiting
+> explicit user OK.
 
-## Verify before submitting
+## Submission flow (per their CONTRIBUTING.md)
 
-1. Read the current `README.md` at <https://github.com/0xNyk/awesome-hermes-agent>
-   to find:
-   - Existing top-level categories (Voice / Speech / STT / Mac / etc.)
-   - Required entry shape (title, link, description, badge?)
-   - Contribution-policy section if any
-2. Match the existing entry voice. Awesome lists are conventionally
-   one-line entries: `- [name](url) — short description.`
+> *"Please do not open a PR directly to add a resource. All additions
+> are reviewed and added by maintainers to ensure consistent quality
+> and editorial voice."*
 
-## Probable category
+So: **open an issue**, not a PR. No issue template is published; the
+CONTRIBUTING.md spells out the required fields.
 
-Look for one of: **"Voice & Speech"**, **"Audio"**, **"Local"**,
-**"Mac / macOS"**, **"Transcription"**. If none of those exists,
-propose adding "Voice & Speech" with this entry as the first item.
+## Required fields (from CONTRIBUTING.md)
 
-## Entry to add
+- Resource name and URL
+- Author (GitHub username)
+- Brief description
+- Category it fits into
+- Why it's awesome
+
+## Section to target
+
+**`Tools & Utilities`** — the section description reads *"Applications,
+CLIs, and utilities built on top of or alongside Hermes Agent."* That
+fits `macparakeet-cli` exactly: it's a CLI that Hermes skills shell
+out to. (Not a Hermes skill itself; the scaffold for that lives at
+`integrations/hermes/README.md`.)
+
+## Maturity tag
+
+**`stable`** — `macparakeet-cli 1.0.0` ships with a written semver
+compatibility policy, brew distribution, signed + notarized binary,
+and is the maintainer's daily driver.
+
+## Proposed entry (matching their format precisely)
+
+The list's entry format, observed verbatim:
+
+```
+*   **[stable]** [macparakeet-cli](https://github.com/moona3k/macparakeet) by [moona3k](https://github.com/moona3k) - Local Parakeet TDT speech-to-text on the Apple Neural Engine — ~155x realtime, ~2.5% WER, ~66 MB per inference slot. Swift-native CLI for Hermes skills to shell out to: persistent SQLite memory, prompt library, stable JSON output (`--json` everywhere). macOS 14.2+ Apple Silicon, GPL-3.0. Install: `brew install moona3k/tap/macparakeet-cli`. Hermes scaffold at [`integrations/hermes/`](https://github.com/moona3k/macparakeet/tree/main/integrations/hermes).
+```
+
+## Issue title
+
+```
+Suggest: macparakeet-cli — local Parakeet STT on Apple Silicon (Tools & Utilities)
+```
+
+## Issue body
 
 ```markdown
-- [macparakeet-cli](https://github.com/moona3k/macparakeet) — Local Parakeet TDT speech-to-text on the Apple Neural Engine. Swift-native CLI with persistent SQLite memory layer, prompt library, and stable JSON output. macOS 14.2+ Apple Silicon, GPL-3.0. `brew install moona3k/tap/macparakeet-cli`.
+**Resource name:** `macparakeet-cli`
+**URL:** <https://github.com/moona3k/macparakeet>
+**Author:** [@moona3k](https://github.com/moona3k) (Daniel Moon — maintainer)
+**Suggested category:** Tools & Utilities
+**Suggested maturity tag:** `stable`
+
+## Brief description
+
+Local Parakeet TDT speech-to-text running on the Apple Neural Engine
+via FluidAudio. Swift-native CLI for Hermes skills to shell out to,
+with a persistent SQLite memory layer, a prompt library, and stable
+JSON output on every read-only command.
+
+## Why it's awesome
+
+Voice/STT is the documented gap in the Hermes-on-Mac-mini stack
+today: Whisper.cpp doesn't use the Neural Engine and is measurably
+slower; the OpenAI Whisper API breaks the local-first posture and
+costs per minute; `parakeet-mlx` (Python) doesn't carry a memory
+layer or prompt library. `macparakeet-cli` fills that slot.
+
+For a Hermes skill author specifically:
+- Stable JSON output (`--json` on every read-only command) with
+  ISO-8601 datetimes, sorted keys, top-level array for lists.
+- UUID-or-name lookup with `.notFound` / `.ambiguous` error classes.
+- Exit codes: 0 success, non-zero failure, errors to stderr only.
+- Persistent SQLite at `~/Library/Application Support/MacParakeet/macparakeet.db`
+  — a Hermes skill can recall prior dictations / transcriptions /
+  prompt outputs across sessions.
+- All execution local on the ANE. Optional cloud LLM provider only
+  when the agent passes `--provider <cloud>`.
+
+## Why now
+
+- **Versioning event today**: `macparakeet-cli 1.0.0` ships with a
+  written compatibility policy ([`Sources/CLI/CHANGELOG.md`](https://github.com/moona3k/macparakeet/blob/main/Sources/CLI/CHANGELOG.md))
+  and stable JSON schemas. Skill authors can finally rely on the
+  surface.
+- **Brew tap live**: `brew install moona3k/tap/macparakeet-cli`.
+- **Hermes scaffold**: [`integrations/hermes/`](https://github.com/moona3k/macparakeet/tree/main/integrations/hermes)
+  has an illustrative skill-manifest sketch with `when_to_use`
+  triggers and command bindings.
+- **Persona-framed landing**: <https://macparakeet.com/agents>.
+
+## Quality checklist (per CONTRIBUTING.md)
+
+- **Relevant** — directly addresses the Hermes-on-Mac-mini voice gap.
+- **Documented** — full README, AGENTS.md, integrations docs,
+  semver-tracked CHANGELOG.
+- **Functional** — daily-driven by maintainer; signed + notarized;
+  brew install verified end-to-end.
+- **Not a duplicate** — no other local-Parakeet-CLI entries on the list.
+- **Open source** — GPL-3.0, full source at the linked repo.
+- **Maintained** — active development, multiple shipped releases.
+- **Why now** — see "Why now" section above.
+
+## Suggested entry (in your format, for editorial reference)
+
+```
+*   **[stable]** [macparakeet-cli](https://github.com/moona3k/macparakeet) by [moona3k](https://github.com/moona3k) - Local Parakeet TDT speech-to-text on the Apple Neural Engine — ~155x realtime, ~2.5% WER, ~66 MB per inference slot. Swift-native CLI for Hermes skills to shell out to: persistent SQLite memory, prompt library, stable JSON output (`--json` everywhere). macOS 14.2+ Apple Silicon, GPL-3.0. Install: `brew install moona3k/tap/macparakeet-cli`. Hermes scaffold at [`integrations/hermes/`](https://github.com/moona3k/macparakeet/tree/main/integrations/hermes).
 ```
 
-## PR title
+## Maintainer disclosure
 
-```
-Add macparakeet-cli — local Parakeet STT for Apple Silicon
-```
-
-## PR body
-
-```markdown
-## What
-
-Adds [`macparakeet-cli`](https://github.com/moona3k/macparakeet) to
-the awesome-hermes-agent list under **<category>**.
-
-## Why it fits
-
-`macparakeet-cli` is the canonical Swift-native CLI for Parakeet TDT
-0.6B v3 on the Apple Neural Engine. It fills a documented gap in the
-Hermes-on-Mac-mini stack:
-
-- Whisper.cpp doesn't use the Neural Engine, so it's slow on Mac.
-- The OpenAI Whisper API is fast but cloud-only and breaks the
-  local-first posture Hermes encourages.
-- `parakeet-mlx` (Python) doesn't carry persistence, prompts, or
-  speaker diarization.
-
-`macparakeet-cli` is:
-
-- ~155× realtime, ~2.5% WER, ~66 MB memory per inference slot.
-- Free + open-source (GPL-3.0).
-- Stable: semver 1.0.0+ with a written compatibility policy.
-- Skill-friendly: `--json` on every read-only command, stable schemas,
-  exit codes, UUID-or-name lookup, errors to stderr.
-
-## Hermes-flavored entry point
-
-A thin Hermes README with an illustrative skill-manifest sketch lives
-at [`integrations/hermes/README.md`](https://github.com/moona3k/macparakeet/blob/main/integrations/hermes/README.md).
-Repo-root [`AGENTS.md`](https://github.com/moona3k/macparakeet/blob/main/AGENTS.md)
-covers cross-agent coding-agent context.
-
-## Author
-
-Daniel Moon (@moona3k), maintainer of MacParakeet. Daily-driver user.
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
+I am the maintainer of MacParakeet (Daniel Moon, @moona3k).
 ```
 
 ## Submission checklist
 
-- [ ] Brew tap live and `brew install moona3k/tap/macparakeet-cli` verified
-- [ ] Target category in `awesome-hermes-agent` README confirmed
-- [ ] Entry shape matches existing entries (one-line, `— em-dash`, period)
-- [ ] PR opened against `0xNyk/awesome-hermes-agent:main`
-- [ ] Linked from internal tracking issue (if any)
+- [x] Brew tap live and `brew install moona3k/tap/macparakeet-cli` verified
+- [x] Target section identified (Tools & Utilities)
+- [x] Entry shape matches existing entries
+- [x] Quality criteria addressed (per CONTRIBUTING)
+- [x] Maintainer affiliation disclosed
+- [ ] User has confirmed go-ahead
+- [ ] Issue opened against `0xNyk/awesome-hermes-agent`
+- [ ] Issue URL captured in this file

--- a/plans/active/registry-submissions/awesome-hermes-agent.md
+++ b/plans/active/registry-submissions/awesome-hermes-agent.md
@@ -1,0 +1,82 @@
+# Submission draft — `0xNyk/awesome-hermes-agent`
+
+> **Status:** draft. Do not submit until the brew tap is live and the
+> author confirms.
+
+## Verify before submitting
+
+1. Read the current `README.md` at <https://github.com/0xNyk/awesome-hermes-agent>
+   to find:
+   - Existing top-level categories (Voice / Speech / STT / Mac / etc.)
+   - Required entry shape (title, link, description, badge?)
+   - Contribution-policy section if any
+2. Match the existing entry voice. Awesome lists are conventionally
+   one-line entries: `- [name](url) — short description.`
+
+## Probable category
+
+Look for one of: **"Voice & Speech"**, **"Audio"**, **"Local"**,
+**"Mac / macOS"**, **"Transcription"**. If none of those exists,
+propose adding "Voice & Speech" with this entry as the first item.
+
+## Entry to add
+
+```markdown
+- [macparakeet-cli](https://github.com/moona3k/macparakeet) — Local Parakeet TDT speech-to-text on the Apple Neural Engine. Swift-native CLI with persistent SQLite memory layer, prompt library, and stable JSON output. macOS 14.2+ Apple Silicon, GPL-3.0. `brew install moona3k/tap/macparakeet-cli`.
+```
+
+## PR title
+
+```
+Add macparakeet-cli — local Parakeet STT for Apple Silicon
+```
+
+## PR body
+
+```markdown
+## What
+
+Adds [`macparakeet-cli`](https://github.com/moona3k/macparakeet) to
+the awesome-hermes-agent list under **<category>**.
+
+## Why it fits
+
+`macparakeet-cli` is the canonical Swift-native CLI for Parakeet TDT
+0.6B v3 on the Apple Neural Engine. It fills a documented gap in the
+Hermes-on-Mac-mini stack:
+
+- Whisper.cpp doesn't use the Neural Engine, so it's slow on Mac.
+- The OpenAI Whisper API is fast but cloud-only and breaks the
+  local-first posture Hermes encourages.
+- `parakeet-mlx` (Python) doesn't carry persistence, prompts, or
+  speaker diarization.
+
+`macparakeet-cli` is:
+
+- ~155× realtime, ~2.5% WER, ~66 MB memory per inference slot.
+- Free + open-source (GPL-3.0).
+- Stable: semver 1.0.0+ with a written compatibility policy.
+- Skill-friendly: `--json` on every read-only command, stable schemas,
+  exit codes, UUID-or-name lookup, errors to stderr.
+
+## Hermes-flavored entry point
+
+A thin Hermes README with an illustrative skill-manifest sketch lives
+at [`integrations/hermes/README.md`](https://github.com/moona3k/macparakeet/blob/main/integrations/hermes/README.md).
+Repo-root [`AGENTS.md`](https://github.com/moona3k/macparakeet/blob/main/AGENTS.md)
+covers cross-agent coding-agent context.
+
+## Author
+
+Daniel Moon (@moona3k), maintainer of MacParakeet. Daily-driver user.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+## Submission checklist
+
+- [ ] Brew tap live and `brew install moona3k/tap/macparakeet-cli` verified
+- [ ] Target category in `awesome-hermes-agent` README confirmed
+- [ ] Entry shape matches existing entries (one-line, `— em-dash`, period)
+- [ ] PR opened against `0xNyk/awesome-hermes-agent:main`
+- [ ] Linked from internal tracking issue (if any)

--- a/plans/active/registry-submissions/awesome-hermes-agent.md
+++ b/plans/active/registry-submissions/awesome-hermes-agent.md
@@ -1,7 +1,6 @@
 # Submission draft — `0xNyk/awesome-hermes-agent`
 
-> **Status:** issue body drafted. **Not yet submitted.** Awaiting
-> explicit user OK.
+> **Status:** ✅ submitted as issue [#49](https://github.com/0xNyk/awesome-hermes-agent/issues/49) on 2026-04-25. Awaiting maintainer review.
 
 ## Submission flow (per their CONTRIBUTING.md)
 

--- a/plans/active/registry-submissions/awesome-openclaw.md
+++ b/plans/active/registry-submissions/awesome-openclaw.md
@@ -1,83 +1,144 @@
 # Submission draft — `vincentkoc/awesome-openclaw`
 
-> **Status:** draft. Do not submit until the brew tap is live and the
-> author confirms.
+> **Status:** issue template responses drafted. **Not yet submitted.**
+> Awaiting explicit user OK.
 
-## Verify before submitting
+## Submission flow (per their CONTRIBUTING.md)
 
-1. Read the current `README.md` at <https://github.com/vincentkoc/awesome-openclaw>
-   to find:
-   - Top-level categories (Voice / Speech / Plugins / Skills / Tools / etc.)
-   - Entry shape conventions
-   - Contribution policy
-2. Note: this list is broader than skills only (covers frameworks,
-   tooling, deployments). Pick the category that fits "an external CLI
-   tool an OpenClaw skill can shell out to."
+> *"Open an issue with the `Add Resource Request` template before
+> opening a PR. Wait for maintainer approval. Unapproved drive-by PRs
+> may be closed."*
 
-## Probable category
+So: **open issue first** via the GitHub Issues UI using the
+[`Add Resource Request`](https://github.com/vincentkoc/awesome-openclaw/issues/new?template=add-resource-request.yml)
+template. PR comes only after maintainer approval and a triage
+discussion.
 
-Best fits: **"Voice & Speech"** / **"Audio"** / **"Tools" / "Integrations"**
-or **"Skills"** if there's a skills subsection. If a Voice category
-doesn't exist, propose adding one with this entry as the first item.
+## Issue template fields (from `.github/ISSUE_TEMPLATE/add-resource-request.yml`)
 
-## Entry to add
+The template enforces the following inputs (all required unless noted):
 
+- **Resource name**
+- **Resource URL**
+- **Suggested section** (dropdown, fixed options)
+- **Why it should be included** (rationale + signal)
+- **Your relationship to this resource** (dropdown, fixed options)
+- **Public signal** (concrete usage / publicity / traction evidence)
+- **Checklist** (4 items, all required)
+
+## Pre-filled responses
+
+### Resource name
+```
+moona3k/macparakeet
+```
+
+### Resource URL
+```
+https://github.com/moona3k/macparakeet
+```
+
+### Suggested section (dropdown)
+**`Plugins and Integrations`** — the section description allows
+community-maintained tools, and our value to OpenClaw is precisely
+as an integration target (an OpenClaw skill shells out to
+`macparakeet-cli` for local Parakeet STT on Apple Silicon).
+
+### Why it should be included (rationale)
 ```markdown
-- [macparakeet-cli](https://github.com/moona3k/macparakeet) — Local Parakeet TDT speech-to-text on the Apple Neural Engine. Swift-native CLI for an OpenClaw skill to shell out to: persistent SQLite memory, prompt library, JSON output. OpenClaw entry point at [`integrations/openclaw/SOUL.md`](https://github.com/moona3k/macparakeet/blob/main/integrations/openclaw/SOUL.md). macOS 14.2+ Apple Silicon, GPL-3.0. `brew install moona3k/tap/macparakeet-cli`.
-```
+Voice / local speech-to-text is currently unrepresented in
+awesome-openclaw, and it's a documented gap in the OpenClaw-on-Mac-mini
+stack: Whisper.cpp doesn't use the Apple Neural Engine; the OpenAI
+Whisper API breaks the local-first posture; `parakeet-mlx` is
+Python-only and has no persistence/prompts.
 
-## PR title
+`macparakeet-cli 1.0.0` is the canonical Swift-native CLI for
+Parakeet TDT on the Apple Neural Engine — ~155x realtime, ~2.5% WER,
+GPL-3.0, semver-stable with a written compatibility policy. For an
+OpenClaw skill author specifically:
 
-```
-Add macparakeet-cli — local Parakeet STT for OpenClaw on Apple Silicon
-```
-
-## PR body
-
-```markdown
-## What
-
-Adds [`macparakeet-cli`](https://github.com/moona3k/macparakeet) to
-awesome-openclaw under **<category>**.
-
-## Why it fits
-
-OpenClaw is increasingly deployed as a daemon on Apple Silicon Mac
-minis. The voice/STT slot in that stack is currently underserved:
-Whisper.cpp doesn't use the Neural Engine; the OpenAI Whisper API
-breaks local-first; `parakeet-mlx` is Python-only and lacks the
-persistence/prompts an OpenClaw skill wants.
-
-`macparakeet-cli` is the canonical Swift-native CLI for Parakeet TDT
-on the Apple Neural Engine — ~155× realtime, ~2.5% WER, ~66 MB memory.
-Free, GPL-3.0, semver-stable (1.0.0+) with a written compatibility
-policy.
-
-For OpenClaw skill authors:
-
-- Stable JSON output (`--json` on every read-only command, ISO-8601
-  datetimes, sorted keys).
-- UUID-or-name lookup with `.notFound`/`.ambiguous` error classes.
+- Stable JSON output (`--json` on every read-only command) with
+  ISO-8601 datetimes and sorted keys.
+- UUID-or-name lookup with `.notFound` / `.ambiguous` error classes.
 - Exit codes: 0 success, non-zero failure, errors to stderr only.
-- Persistent SQLite at `~/Library/Application Support/MacParakeet/macparakeet.db`
-  — lets a skill recall prior dictations/transcriptions across runs.
+- Persistent SQLite memory layer at
+  `~/Library/Application Support/MacParakeet/macparakeet.db` — the
+  skill can recall prior dictations / transcriptions / prompt outputs
+  across sessions without re-transcribing anything.
+- All execution local on the ANE; optional cloud LLM provider only
+  when the agent passes `--provider <cloud>`.
 
-## OpenClaw entry point
+OpenClaw entry point lives at
+[`integrations/openclaw/`](https://github.com/moona3k/macparakeet/tree/main/integrations/openclaw)
+in the macparakeet repo. The full integration vocabulary
+(install, JSON conventions, command list) is at
+[`integrations/README.md`](https://github.com/moona3k/macparakeet/blob/main/integrations/README.md).
+The persona-framed landing page lives at
+<https://macparakeet.com/agents>.
 
-[`integrations/openclaw/SOUL.md`](https://github.com/moona3k/macparakeet/blob/main/integrations/openclaw/SOUL.md)
-— install, capabilities table, conventions. Adapt at clawhub
-registration.
-
-## Author
-
-Daniel Moon (@moona3k), maintainer of MacParakeet.
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
+Install:
+`brew tap moona3k/tap && brew install macparakeet-cli`
+(macOS 14.2+ Apple Silicon).
 ```
+
+### Your relationship (dropdown)
+**`I am the maintainer, founder, or builder`** — disclosing affiliation
+per CONTRIBUTING quality standards.
+
+### Public signal
+```markdown
+- **Public site + brand**: <https://macparakeet.com> (live, Cloudflare
+  Pages), with a dedicated `/agents` landing page at
+  <https://macparakeet.com/agents> shipped alongside this submission.
+- **Open source for ~1 month**: GPL-3.0 since 2026-03-25
+  ([open-source announcement](https://macparakeet.com/blog/macparakeet-open-source/)).
+- **Daily-driven by maintainer**: feature-complete for dictation,
+  file transcription, and (in v0.6 in progress) meeting recording.
+- **Multiple shipped releases**: Sparkle auto-updates from v0.1
+  through current v0.5.7. Public appcast at
+  <https://macparakeet.com/appcast.xml>.
+- **Comprehensive documentation**: spec kernel in `spec/`, ADRs for
+  locked architectural decisions, AGENTS.md at repo root, a
+  semver-tracked CLI changelog at `Sources/CLI/CHANGELOG.md`.
+- **Today**: cut `macparakeet-cli 1.0.0` (first versioned public
+  surface), shipped a Homebrew tap with both formula and cask, and
+  published [a launch blog post](https://macparakeet.com/blog/macparakeet-cli-1-0/)
+  framing the CLI as the canonical Swift-native Parakeet wrapper for
+  Apple Silicon AI agents.
+
+The OpenClaw integration story (`integrations/openclaw/` scaffold) is
+brand new — shipped in [PR #144](https://github.com/moona3k/macparakeet/pull/144)
+on 2026-04-25 — so OpenClaw-specific outside usage is not yet
+established. The underlying tool (`macparakeet-cli`) and the broader
+project are the established surface this submission is asking you to
+list.
+```
+
+### Checklist
+- [x] I checked that this resource is not already listed.
+- [x] I reviewed CONTRIBUTING.md formatting and A-Z ordering rules.
+- [x] The resource is public and can be evaluated from the provided link.
+- [x] If I am affiliated with the resource, I disclosed that above.
+
+## Proposed entry (for editorial reference, in your format)
+
+```
+- [moona3k/macparakeet](https://github.com/moona3k/macparakeet) - Local Parakeet TDT speech-to-text on the Apple Neural Engine. Swift-native CLI for OpenClaw skills to shell out to: persistent SQLite memory, prompt library, stable JSON output. ~155x realtime, ~2.5% WER, ~66 MB per inference slot. macOS 14.2+ Apple Silicon, GPL-3.0. `brew install moona3k/tap/macparakeet-cli`. OpenClaw scaffold at [integrations/openclaw/](https://github.com/moona3k/macparakeet/tree/main/integrations/openclaw).
+```
+
+A-Z ordering note: in `## Plugins and Integrations`, entries are
+alphabetical by repo path. `moona3k/macparakeet` would slot between
+`m1heng/clawdbot-feishu` and `marshallrichards/ClawPhone`.
 
 ## Submission checklist
 
-- [ ] Brew tap live and `brew install moona3k/tap/macparakeet-cli` verified
-- [ ] Target category in `awesome-openclaw` README confirmed
-- [ ] Entry shape matches existing entries
-- [ ] PR opened against `vincentkoc/awesome-openclaw:main`
+- [x] Brew tap live and `brew install moona3k/tap/macparakeet-cli` verified
+- [x] Target section identified (Plugins and Integrations)
+- [x] Issue template fields pre-filled
+- [x] A-Z ordering location identified
+- [x] Maintainer affiliation disclosure prepared
+- [ ] User has confirmed go-ahead
+- [ ] Issue opened via `Add Resource Request` template
+- [ ] Issue URL captured in this file
+- [ ] (After approval) PR opened with the exact entry text
+- [ ] PR URL captured in this file

--- a/plans/active/registry-submissions/awesome-openclaw.md
+++ b/plans/active/registry-submissions/awesome-openclaw.md
@@ -1,7 +1,6 @@
 # Submission draft — `vincentkoc/awesome-openclaw`
 
-> **Status:** issue template responses drafted. **Not yet submitted.**
-> Awaiting explicit user OK.
+> **Status:** ✅ submitted as issue [#71](https://github.com/vincentkoc/awesome-openclaw/issues/71) on 2026-04-25. Awaiting maintainer triage.
 
 ## Submission flow (per their CONTRIBUTING.md)
 

--- a/plans/active/registry-submissions/awesome-openclaw.md
+++ b/plans/active/registry-submissions/awesome-openclaw.md
@@ -1,0 +1,83 @@
+# Submission draft — `vincentkoc/awesome-openclaw`
+
+> **Status:** draft. Do not submit until the brew tap is live and the
+> author confirms.
+
+## Verify before submitting
+
+1. Read the current `README.md` at <https://github.com/vincentkoc/awesome-openclaw>
+   to find:
+   - Top-level categories (Voice / Speech / Plugins / Skills / Tools / etc.)
+   - Entry shape conventions
+   - Contribution policy
+2. Note: this list is broader than skills only (covers frameworks,
+   tooling, deployments). Pick the category that fits "an external CLI
+   tool an OpenClaw skill can shell out to."
+
+## Probable category
+
+Best fits: **"Voice & Speech"** / **"Audio"** / **"Tools" / "Integrations"**
+or **"Skills"** if there's a skills subsection. If a Voice category
+doesn't exist, propose adding one with this entry as the first item.
+
+## Entry to add
+
+```markdown
+- [macparakeet-cli](https://github.com/moona3k/macparakeet) — Local Parakeet TDT speech-to-text on the Apple Neural Engine. Swift-native CLI for an OpenClaw skill to shell out to: persistent SQLite memory, prompt library, JSON output. OpenClaw entry point at [`integrations/openclaw/SOUL.md`](https://github.com/moona3k/macparakeet/blob/main/integrations/openclaw/SOUL.md). macOS 14.2+ Apple Silicon, GPL-3.0. `brew install moona3k/tap/macparakeet-cli`.
+```
+
+## PR title
+
+```
+Add macparakeet-cli — local Parakeet STT for OpenClaw on Apple Silicon
+```
+
+## PR body
+
+```markdown
+## What
+
+Adds [`macparakeet-cli`](https://github.com/moona3k/macparakeet) to
+awesome-openclaw under **<category>**.
+
+## Why it fits
+
+OpenClaw is increasingly deployed as a daemon on Apple Silicon Mac
+minis. The voice/STT slot in that stack is currently underserved:
+Whisper.cpp doesn't use the Neural Engine; the OpenAI Whisper API
+breaks local-first; `parakeet-mlx` is Python-only and lacks the
+persistence/prompts an OpenClaw skill wants.
+
+`macparakeet-cli` is the canonical Swift-native CLI for Parakeet TDT
+on the Apple Neural Engine — ~155× realtime, ~2.5% WER, ~66 MB memory.
+Free, GPL-3.0, semver-stable (1.0.0+) with a written compatibility
+policy.
+
+For OpenClaw skill authors:
+
+- Stable JSON output (`--json` on every read-only command, ISO-8601
+  datetimes, sorted keys).
+- UUID-or-name lookup with `.notFound`/`.ambiguous` error classes.
+- Exit codes: 0 success, non-zero failure, errors to stderr only.
+- Persistent SQLite at `~/Library/Application Support/MacParakeet/macparakeet.db`
+  — lets a skill recall prior dictations/transcriptions across runs.
+
+## OpenClaw entry point
+
+[`integrations/openclaw/SOUL.md`](https://github.com/moona3k/macparakeet/blob/main/integrations/openclaw/SOUL.md)
+— install, capabilities table, conventions. Adapt at clawhub
+registration.
+
+## Author
+
+Daniel Moon (@moona3k), maintainer of MacParakeet.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+## Submission checklist
+
+- [ ] Brew tap live and `brew install moona3k/tap/macparakeet-cli` verified
+- [ ] Target category in `awesome-openclaw` README confirmed
+- [ ] Entry shape matches existing entries
+- [ ] PR opened against `vincentkoc/awesome-openclaw:main`

--- a/plans/active/registry-submissions/clawhub.md
+++ b/plans/active/registry-submissions/clawhub.md
@@ -1,99 +1,141 @@
-# Submission draft — `openclaw/clawhub` (the official OpenClaw skill registry)
+# Submission notes — `openclaw/clawhub` (deferred)
 
-> **Status:** draft, schema-uncertain. Do not submit until the brew tap
-> is live AND the actual ClawHub skill manifest schema is verified.
+> **Status:** **deferred.** ClawHub submission requires the OpenClaw
+> CLI installed locally and a SKILL.md package; the submission flow
+> is non-trivial and needs verification of the current SKILL.md
+> frontmatter schema before attempting.
 
-## What's uncertain
+## What ClawHub actually is (corrected)
 
-ClawHub appears to be the **official skill registry** for OpenClaw —
-not just a curated awesome list. Skills there are typically packaged as
-SOUL.md plus supporting files, with a documented submission flow
-(possibly via the OpenClaw CLI: `openclaw skill publish` or similar) or
-via PR to `openclaw/clawhub`.
+ClawHub is the **official skill registry for OpenClaw** at
+<https://clawhub.ai>. Skills are submitted via the OpenClaw CLI:
 
-Before submitting, verify:
-
-1. Read <https://docs.openclaw.ai/tools/clawhub> for the canonical
-   submission flow.
-2. Inspect <https://github.com/openclaw/clawhub> for repo structure.
-   Are skills bundled per-directory? Is there a manifest schema?
-3. Check whether submission is via CLI tooling, PR, or web upload at
-   <https://clawhub.ai>.
-4. Check whether submission requires native installation of the
-   OpenClaw CLI to package + sign the skill.
-
-The thin scaffold at [`integrations/openclaw/SOUL.md`](https://github.com/moona3k/macparakeet/blob/main/integrations/openclaw/SOUL.md)
-self-marks as "illustrative — adapt at registration time" precisely
-because the schema may have evolved post-OpenAI acquisition.
-
-## Likely submission shape
-
-If ClawHub follows the typical skill-manifest pattern, the skill would be:
-
-```
-macparakeet-stt/
-├── SOUL.md                # Skill manifest (description, capabilities, usage)
-├── install.sh             # Installs the macparakeet-cli host binary
-├── README.md              # Human-facing intro
-└── examples/              # Example invocations
-    ├── transcribe.md
-    ├── search-history.md
-    └── run-prompt.md
+```bash
+clawhub skill publish <path-to-skill-dir>
 ```
 
-`SOUL.md` content would mirror our `integrations/openclaw/SOUL.md`
-but adapted to whatever frontmatter fields ClawHub requires
-(e.g., `name:`, `version:`, `author:`, `tags:`, `requires:`).
+Skills are packaged as a directory containing a `SKILL.md` file with
+frontmatter metadata, plus supporting files. ClawHub renders the
+SKILL.md content and indexes it for search.
 
-## Probable PR title (if PR-based submission)
+## Critical correction: SKILL.md, not SOUL.md
 
-```
-Add macparakeet-stt — local Parakeet STT skill (Apple Silicon)
-```
+When this work began, the handoff document conflated `SOUL.md` with
+the OpenClaw skill format. **It is not.** Reconnaissance against the
+ClawHub README confirms:
 
-## Probable PR body skeleton
+- **ClawHub uses `SKILL.md`** (with frontmatter metadata)
+- **`SOUL.md` belongs to a different agent registry** (onlycrabs.ai)
+
+The `integrations/openclaw/SOUL.md` file in the macparakeet repo is
+therefore misnamed. A follow-up to PR #144 should either rename it to
+`integrations/openclaw/SKILL.md` (or to `integrations/openclaw/README.md`
+for consistency with the Hermes-flavored entry point) and update the
+content to reference the SKILL.md format.
+
+## What's needed to actually submit
+
+1. **Install OpenClaw CLI** locally (`npm install -g openclaw` or per
+   their canonical install path).
+2. **Verify SKILL.md frontmatter spec** at <https://docs.openclaw.ai/tools/clawhub>
+   — what fields are required (`name`, `version`, `author`, `tags`,
+   `requires`, etc.) and what they validate against.
+3. **Create a properly-formed skill package** — directory with
+   `SKILL.md` (frontmatter + body), `install.sh` (installs the
+   `macparakeet-cli` host binary), and possibly `examples/` with
+   illustrative invocations.
+4. **Run `clawhub skill publish <path>`** and capture the resulting
+   ClawHub URL.
+
+## Likely SKILL.md skeleton
 
 ```markdown
-## Skill: macparakeet-stt
+---
+name: macparakeet-stt
+version: 1.0.0
+author: moona3k
+description: Local Parakeet TDT speech-to-text for Apple Silicon. Wraps macparakeet-cli (GPL-3.0).
+tags: [stt, transcription, voice, apple-silicon, local, parakeet]
+requires:
+  - platform: darwin
+  - arch: arm64
+  - macos: ">=14.2"
+license: GPL-3.0-or-later
+---
 
-Local Parakeet TDT speech-to-text for OpenClaw on Apple Silicon.
-Wraps [macparakeet-cli](https://github.com/moona3k/macparakeet)
-(GPL-3.0, semver 1.0+).
+# macparakeet-stt
+
+Local speech-to-text and transcription for an OpenClaw agent running
+on Apple Silicon. Wraps `macparakeet-cli` so an OpenClaw skill can
+transcribe local audio/video files, transcribe YouTube URLs, search
+the user's prior dictation/transcription history, and run a prompt
+against a transcription. All execution is local on the Apple Neural
+Engine; no cloud STT.
+
+## Install
+
+```bash
+brew install moona3k/tap/macparakeet-cli
+```
 
 ## Capabilities
 
-- Transcribe local audio/video files (MP3 / WAV / MP4 / MOV / WebM / ...)
-- Transcribe YouTube URLs
-- Search the user's prior dictation/transcription history
-- Run a prompt against a transcription (action items, summaries, ...)
-
-## Requires
-
-- macOS 14.2+ on Apple Silicon (M1, M2, M3, M4)
-- `brew install moona3k/tap/macparakeet-cli` (the host binary)
+(table of capabilities → CLI invocations — see
+`integrations/openclaw/` in the macparakeet repo for the canonical
+list)
 
 ## Privacy
 
-All execution local. STT runs on the Apple Neural Engine. No audio
-or transcript content is sent over the network unless the user
-explicitly invokes the prompt-runner with a cloud LLM provider.
-
-## Source
-
-- Skill scaffold: <https://github.com/moona3k/macparakeet/blob/main/integrations/openclaw/SOUL.md>
-- Host binary: <https://github.com/moona3k/macparakeet>
-- Compatibility policy: <https://github.com/moona3k/macparakeet/blob/main/Sources/CLI/CHANGELOG.md>
-- Author: @moona3k
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
+All STT runs on the ANE. No audio leaves the device. Optional cloud
+LLM provider only when the user explicitly passes `--provider <cloud>`.
 ```
 
-## Submission checklist
+**This skeleton is illustrative.** The actual SKILL.md frontmatter
+fields must be verified against the current OpenClaw documentation
+before publishing.
 
-- [ ] Brew tap live and `brew install moona3k/tap/macparakeet-cli` verified
-- [ ] ClawHub submission flow confirmed (CLI / PR / web)
-- [ ] SOUL.md schema fields confirmed against current spec
-- [ ] If CLI-based: OpenClaw CLI installed locally and skill packaged
-- [ ] PR / submission opened
-- [ ] `VoltAgent/awesome-openclaw-skills` checked — likely auto-syncs
-      from clawhub; only submit there if it doesn't
+## Why we're deferring
+
+- **Untrusted schema**: SKILL.md frontmatter validation rules aren't
+  fully documented here. Submitting an invalid manifest could be
+  rejected — or worse, accepted in a degraded form that misrepresents
+  the skill.
+- **Untested install path**: The skill's `install.sh` wrapper around
+  `brew install moona3k/tap/macparakeet-cli` needs to be tested in
+  ClawHub's runtime environment.
+- **Post-acquisition uncertainty**: OpenClaw was acquired by OpenAI
+  in February 2026; the registry tooling and submission flow may
+  evolve. Better to consult current docs immediately before
+  publishing rather than relying on possibly-stale information.
+
+## Recommended next action
+
+When ready to pursue:
+
+1. Read <https://docs.openclaw.ai/tools/clawhub> end-to-end.
+2. Read `openclaw/clawhub`'s CONTRIBUTING.md.
+3. Read `docs/quickstart.md` and `docs/cli.md` referenced in the
+   ClawHub README.
+4. Pick or build a sandbox environment to test `clawhub skill publish`
+   before publishing to the live registry.
+5. (Optional) Rename `integrations/openclaw/SOUL.md` →
+   `integrations/openclaw/SKILL.md` (or `README.md`) in a small
+   macparakeet PR to reflect the corrected understanding.
+
+## Downstream dependency
+
+`VoltAgent/awesome-openclaw-skills` only accepts entries for skills
+already published in `github.com/openclaw/skills` (the ClawHub mirror
+repo). So any submission to `awesome-openclaw-skills` depends on
+this ClawHub publication succeeding first.
+
+## Submission checklist (for the future)
+
+- [x] Brew tap live and `brew install moona3k/tap/macparakeet-cli` verified
+- [ ] OpenClaw CLI installed locally
+- [ ] SKILL.md frontmatter schema verified against current docs
+- [ ] Sandbox test of `clawhub skill publish` succeeded
+- [ ] `integrations/openclaw/SOUL.md` renamed to SKILL.md (or otherwise corrected)
+- [ ] User has confirmed go-ahead
+- [ ] `clawhub skill publish` run for live registry
+- [ ] ClawHub URL captured in this file

--- a/plans/active/registry-submissions/clawhub.md
+++ b/plans/active/registry-submissions/clawhub.md
@@ -1,0 +1,99 @@
+# Submission draft — `openclaw/clawhub` (the official OpenClaw skill registry)
+
+> **Status:** draft, schema-uncertain. Do not submit until the brew tap
+> is live AND the actual ClawHub skill manifest schema is verified.
+
+## What's uncertain
+
+ClawHub appears to be the **official skill registry** for OpenClaw —
+not just a curated awesome list. Skills there are typically packaged as
+SOUL.md plus supporting files, with a documented submission flow
+(possibly via the OpenClaw CLI: `openclaw skill publish` or similar) or
+via PR to `openclaw/clawhub`.
+
+Before submitting, verify:
+
+1. Read <https://docs.openclaw.ai/tools/clawhub> for the canonical
+   submission flow.
+2. Inspect <https://github.com/openclaw/clawhub> for repo structure.
+   Are skills bundled per-directory? Is there a manifest schema?
+3. Check whether submission is via CLI tooling, PR, or web upload at
+   <https://clawhub.ai>.
+4. Check whether submission requires native installation of the
+   OpenClaw CLI to package + sign the skill.
+
+The thin scaffold at [`integrations/openclaw/SOUL.md`](https://github.com/moona3k/macparakeet/blob/main/integrations/openclaw/SOUL.md)
+self-marks as "illustrative — adapt at registration time" precisely
+because the schema may have evolved post-OpenAI acquisition.
+
+## Likely submission shape
+
+If ClawHub follows the typical skill-manifest pattern, the skill would be:
+
+```
+macparakeet-stt/
+├── SOUL.md                # Skill manifest (description, capabilities, usage)
+├── install.sh             # Installs the macparakeet-cli host binary
+├── README.md              # Human-facing intro
+└── examples/              # Example invocations
+    ├── transcribe.md
+    ├── search-history.md
+    └── run-prompt.md
+```
+
+`SOUL.md` content would mirror our `integrations/openclaw/SOUL.md`
+but adapted to whatever frontmatter fields ClawHub requires
+(e.g., `name:`, `version:`, `author:`, `tags:`, `requires:`).
+
+## Probable PR title (if PR-based submission)
+
+```
+Add macparakeet-stt — local Parakeet STT skill (Apple Silicon)
+```
+
+## Probable PR body skeleton
+
+```markdown
+## Skill: macparakeet-stt
+
+Local Parakeet TDT speech-to-text for OpenClaw on Apple Silicon.
+Wraps [macparakeet-cli](https://github.com/moona3k/macparakeet)
+(GPL-3.0, semver 1.0+).
+
+## Capabilities
+
+- Transcribe local audio/video files (MP3 / WAV / MP4 / MOV / WebM / ...)
+- Transcribe YouTube URLs
+- Search the user's prior dictation/transcription history
+- Run a prompt against a transcription (action items, summaries, ...)
+
+## Requires
+
+- macOS 14.2+ on Apple Silicon (M1, M2, M3, M4)
+- `brew install moona3k/tap/macparakeet-cli` (the host binary)
+
+## Privacy
+
+All execution local. STT runs on the Apple Neural Engine. No audio
+or transcript content is sent over the network unless the user
+explicitly invokes the prompt-runner with a cloud LLM provider.
+
+## Source
+
+- Skill scaffold: <https://github.com/moona3k/macparakeet/blob/main/integrations/openclaw/SOUL.md>
+- Host binary: <https://github.com/moona3k/macparakeet>
+- Compatibility policy: <https://github.com/moona3k/macparakeet/blob/main/Sources/CLI/CHANGELOG.md>
+- Author: @moona3k
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+## Submission checklist
+
+- [ ] Brew tap live and `brew install moona3k/tap/macparakeet-cli` verified
+- [ ] ClawHub submission flow confirmed (CLI / PR / web)
+- [ ] SOUL.md schema fields confirmed against current spec
+- [ ] If CLI-based: OpenClaw CLI installed locally and skill packaged
+- [ ] PR / submission opened
+- [ ] `VoltAgent/awesome-openclaw-skills` checked — likely auto-syncs
+      from clawhub; only submit there if it doesn't

--- a/plans/active/registry-submissions/clawhub.md
+++ b/plans/active/registry-submissions/clawhub.md
@@ -27,10 +27,10 @@ ClawHub README confirms:
 - **ClawHub uses `SKILL.md`** (with frontmatter metadata)
 - **`SOUL.md` belongs to a different agent registry** (onlycrabs.ai)
 
-The `integrations/openclaw/SOUL.md` file in the macparakeet repo is
-therefore misnamed. A follow-up to PR #144 should either rename it to
-`integrations/openclaw/SKILL.md` (or to `integrations/openclaw/README.md`
-for consistency with the Hermes-flavored entry point) and update the
+The `integrations/openclaw/SOUL.md` file in the macparakeet repo was
+therefore misnamed. **Resolved** in [PR #146](https://github.com/moona3k/macparakeet/pull/146)
+(merged 2026-04-25): renamed to `integrations/openclaw/README.md`
+for consistency with the Hermes-flavored entry point, and updated the
 content to reference the SKILL.md format.
 
 ## What's needed to actually submit

--- a/scripts/dist/homebrew-tap-scaffold/HOWTO.md
+++ b/scripts/dist/homebrew-tap-scaffold/HOWTO.md
@@ -60,9 +60,16 @@ xcrun notarytool submit dist/macparakeet-cli-1.0.0-darwin-arm64.zip \
 ```
 
 > **Heads up:** `notarytool submit --wait` intermittently SIGBUS-crashes
-> on macOS 15+ even after a successful upload. If that happens, drop
-> `--wait`, then poll with `notarytool history` + `notarytool info`.
-> See `memory/feedback_notarytool_wait_bug.md` for the recipe.
+> (exit 138) on macOS 15+ even after a successful upload. The upload
+> usually succeeds despite the crash. If `--wait` exits non-zero:
+>
+> 1. Run `xcrun notarytool history --keychain-profile <profile>` to find
+>    the most recent submission ID.
+> 2. Poll its status with `xcrun notarytool info <id> --keychain-profile <profile>`
+>    until it reads `Accepted`.
+> 3. If the upload itself failed, resubmit cleanly without `--wait`.
+>
+> Resubmitting after a SIGBUS usually works on the next try.
 
 ### 4. Tar + checksum
 

--- a/scripts/dist/homebrew-tap-scaffold/HOWTO.md
+++ b/scripts/dist/homebrew-tap-scaffold/HOWTO.md
@@ -1,0 +1,131 @@
+# How to create the tap repo and ship the first release
+
+This file lives in the macparakeet repo for reference. The tap repo
+itself is a separate GitHub repository.
+
+## One-time tap setup
+
+### 1. Create the tap repo on GitHub
+
+```bash
+gh repo create moona3k/homebrew-tap --public \
+  --description "Homebrew tap for moona3k packages (macparakeet-cli, ...)"
+```
+
+Local clone + initial commit:
+
+```bash
+git clone https://github.com/moona3k/homebrew-tap ~/code/homebrew-tap
+cd ~/code/homebrew-tap
+mkdir -p Formula
+cp ~/code/macparakeet/scripts/dist/homebrew-tap-scaffold/README.md .
+cp ~/code/macparakeet/scripts/dist/homebrew-tap-scaffold/macparakeet-cli.rb Formula/
+# Edit README.md — strip the leading "scaffold" preamble.
+```
+
+Don't push the tap yet — the formula's `sha256` field is a placeholder
+until the release tarball exists (next steps).
+
+## Cutting the first CLI release
+
+### 2. Build the standalone CLI binary
+
+In the macparakeet repo, on a tagged commit:
+
+```bash
+swift build -c release --product macparakeet-cli
+mkdir -p dist/macparakeet-cli-1.0.0-darwin-arm64
+cp .build/release/macparakeet-cli dist/macparakeet-cli-1.0.0-darwin-arm64/
+```
+
+### 3. Sign + notarize the binary
+
+Use the same Developer ID identity already set up for the `.app`. The
+exact identity is in `scripts/dist/sign_notarize.sh`.
+
+```bash
+codesign --sign "Developer ID Application: <YOUR NAME> (<TEAMID>)" \
+         --options runtime \
+         --timestamp \
+         dist/macparakeet-cli-1.0.0-darwin-arm64/macparakeet-cli
+
+# Pack for notarization
+ditto -c -k --keepParent dist/macparakeet-cli-1.0.0-darwin-arm64 \
+      dist/macparakeet-cli-1.0.0-darwin-arm64.zip
+
+# Submit. The notarytool keychain profile name is whatever was set up
+# previously (search scripts/dist/ for the actual name).
+xcrun notarytool submit dist/macparakeet-cli-1.0.0-darwin-arm64.zip \
+      --keychain-profile <profile-name> --wait
+```
+
+> **Heads up:** `notarytool submit --wait` intermittently SIGBUS-crashes
+> on macOS 15+ even after a successful upload. If that happens, drop
+> `--wait`, then poll with `notarytool history` + `notarytool info`.
+> See `memory/feedback_notarytool_wait_bug.md` for the recipe.
+
+### 4. Tar + checksum
+
+```bash
+cd dist
+tar -czf macparakeet-cli-1.0.0-darwin-arm64.tar.gz \
+        macparakeet-cli-1.0.0-darwin-arm64
+shasum -a 256 macparakeet-cli-1.0.0-darwin-arm64.tar.gz
+# Copy the SHA256 hex into the formula's `sha256` field.
+```
+
+### 5. Publish the GitHub release
+
+```bash
+gh release create cli-v1.0.0 \
+  dist/macparakeet-cli-1.0.0-darwin-arm64.tar.gz \
+  --title "macparakeet-cli 1.0.0" \
+  --notes-file Sources/CLI/CHANGELOG.md
+```
+
+Tag pattern: `cli-v<major>.<minor>.<patch>` — keeps CLI tags distinct
+from the app's release tags.
+
+### 6. Push the tap
+
+```bash
+cd ~/code/homebrew-tap
+# Update Formula/macparakeet-cli.rb's `sha256` line with the value from step 4.
+git add . && git commit -m "Add macparakeet-cli 1.0.0" && git push
+```
+
+### 7. Verify end-to-end
+
+```bash
+brew untap moona3k/tap 2>/dev/null   # if previously tapped
+brew tap moona3k/tap
+brew install macparakeet-cli
+
+macparakeet-cli --version    # 1.0.0
+macparakeet-cli health --json
+```
+
+## After 1.0.0
+
+For each subsequent CLI release:
+
+1. Bump `version` in `Sources/CLI/MacParakeetCLI.swift`.
+2. Add an entry to `Sources/CLI/CHANGELOG.md` per semver discipline.
+3. Repeat steps 2–6 above with the new version number.
+
+Bottle support (faster install via pre-built `.bottle.tar.gz` per macOS
+version) is a later phase. Homebrew CI can build bottles automatically;
+see `brew tap-new --pull-label` and the Homebrew bottles docs.
+
+## Why this approach
+
+- **Pre-built signed binary** rather than `swift build` in the formula:
+  faster install (no ~30s SwiftPM compile), no need for users to have
+  Xcode CLT, simpler caveats. Recommended in the canonical plan at
+  `plans/active/cli-as-canonical-parakeet-surface.md`.
+- **Tap separate from main repo:** keeps Homebrew's expected layout
+  (`Formula/<name>.rb`), allows future formulae (`macparakeet-cli`,
+  potentially other tools) to share infrastructure.
+- **Keeping FFmpeg + yt-dlp as `depends_on`** rather than bundling:
+  smaller release tarball, lets users keep one canonical FFmpeg, lets
+  brew handle dep upgrades.

--- a/scripts/dist/homebrew-tap-scaffold/README.md
+++ b/scripts/dist/homebrew-tap-scaffold/README.md
@@ -1,0 +1,47 @@
+# `moona3k/homebrew-tap` README scaffold
+
+This is the README that will live in the **`moona3k/homebrew-tap`** repo
+(to be created). It's drafted here in the macparakeet repo so it stays
+under version control and can be reviewed before the tap repo exists.
+
+When the tap repo is cut (see `HOWTO.md`), copy this file there as the
+top-level `README.md`.
+
+---
+
+# moona3k/homebrew-tap
+
+Homebrew tap for [moona3k](https://github.com/moona3k) packages.
+
+## Available formulae
+
+### `macparakeet-cli`
+
+Local Parakeet TDT speech-to-text + transcription tooling for Apple
+Silicon. ~155&times; realtime on the Apple Neural Engine, ~2.5% WER,
+GPL-3.0.
+
+```bash
+brew tap moona3k/tap
+brew install macparakeet-cli
+
+macparakeet-cli --version
+macparakeet-cli health --json
+macparakeet-cli transcribe ~/Downloads/audio.mp3 --format json
+```
+
+**Requirements:** macOS 14.2+ (Sonoma) on Apple Silicon (M1, M2, M3, M4).
+
+**First run downloads ~6&nbsp;GB of CoreML speech models** to
+`~/Library/Application Support/MacParakeet/models/`. Subsequent runs are
+fully offline.
+
+**Source code:** <https://github.com/moona3k/macparakeet>
+**Compatibility policy (semver):** [`Sources/CLI/CHANGELOG.md`](https://github.com/moona3k/macparakeet/blob/main/Sources/CLI/CHANGELOG.md)
+**For AI-agent integration:** [`integrations/README.md`](https://github.com/moona3k/macparakeet/tree/main/integrations)
+**Standalone-install positioning:** <https://macparakeet.com/agents>
+
+## License
+
+The formulae in this tap are MIT-licensed. The packages they install
+have their own licenses (`macparakeet-cli` is GPL-3.0, see source).

--- a/scripts/dist/homebrew-tap-scaffold/macparakeet-cli.rb
+++ b/scripts/dist/homebrew-tap-scaffold/macparakeet-cli.rb
@@ -1,0 +1,58 @@
+# Homebrew formula for macparakeet-cli.
+#
+# This file is a SCAFFOLD living in the macparakeet repo for review and
+# version control. The actual tap publishes it from a separate repo:
+#
+#   https://github.com/moona3k/homebrew-tap   (to be created)
+#
+# Once the tap repo exists, copy this file to:
+#
+#   <tap-repo>/Formula/macparakeet-cli.rb
+#
+# See ../HOWTO.md for first-release instructions.
+
+class MacparakeetCli < Formula
+  desc "Local STT, transcription, and prompt automation for Apple Silicon"
+  homepage "https://macparakeet.com"
+  url "https://github.com/moona3k/macparakeet/releases/download/cli-v1.0.0/macparakeet-cli-1.0.0-darwin-arm64.tar.gz"
+  sha256 "REPLACE_WITH_TARBALL_SHA256_AT_RELEASE_TIME"
+  license "GPL-3.0-or-later"
+  version "1.0.0"
+
+  # macOS 14.2+ (Sonoma) — required by FluidAudio + Swift 6 runtime
+  depends_on macos: :sonoma
+  # Apple Silicon only — the Neural Engine is the entire performance story
+  depends_on arch: :arm64
+
+  # Runtime media deps (bundled inside MacParakeet.app, but the standalone
+  # CLI install needs them on PATH). Both are stable Homebrew formulae.
+  depends_on "ffmpeg"
+  depends_on "yt-dlp"
+
+  def install
+    bin.install "macparakeet-cli"
+  end
+
+  def caveats
+    <<~EOS
+      First run downloads the Parakeet TDT speech model (~6 GB) to:
+        ~/Library/Application Support/MacParakeet/models/
+
+      The CLI shares its database with the macOS app at:
+        ~/Library/Application Support/MacParakeet/macparakeet.db
+
+      Verify with:
+        macparakeet-cli health --json
+
+      Compatibility policy (semver):
+        https://github.com/moona3k/macparakeet/blob/main/Sources/CLI/CHANGELOG.md
+
+      Agent integration docs (OpenClaw, Hermes, generic):
+        https://github.com/moona3k/macparakeet/tree/main/integrations
+    EOS
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/macparakeet-cli --version")
+  end
+end

--- a/scripts/dist/homebrew-tap-scaffold/macparakeet-cli.rb
+++ b/scripts/dist/homebrew-tap-scaffold/macparakeet-cli.rb
@@ -19,7 +19,10 @@ class MacparakeetCli < Formula
   license "GPL-3.0-or-later"
   version "1.0.0"
 
-  # macOS 14.2+ (Sonoma) — required by FluidAudio + Swift 6 runtime
+  # macOS 14.2+ (Sonoma) — required by FluidAudio + Swift 6 runtime.
+  # Homebrew's `depends_on macos:` only accepts major-version symbols, so
+  # `:sonoma` covers 14.0+; the patch-level floor (14.2) is enforced at
+  # install time via the `odie` check below.
   depends_on macos: :sonoma
   # Apple Silicon only — the Neural Engine is the entire performance story
   depends_on arch: :arm64
@@ -30,6 +33,7 @@ class MacparakeetCli < Formula
   depends_on "yt-dlp"
 
   def install
+    odie "macparakeet-cli requires macOS 14.2 or later" if MacOS.version < "14.2"
     bin.install "macparakeet-cli"
   end
 


### PR DESCRIPTION
## TL;DR

Companion to **[#144](https://github.com/moona3k/macparakeet/pull/144)** (merged: CLI 1.0 + AGENTS.md + integrations/) and **[#146](https://github.com/moona3k/macparakeet/pull/146)** (merged: SOUL.md → README.md correction). This PR is the *strategic record + execution artifacts* for the agent rollout — brew tap scaffolding, registry submission drafts, community post drafts, multi-LLM review findings, all decisions made along the way.

**Intentionally docs-only.** No code changes; no CI gate.

---

## State of the world right now

### Live in production

- **PR #144 merged** at `cd0879b1` — CLI 1.0 + AGENTS.md + integrations/.
- **PR #146 merged** — `integrations/openclaw/SOUL.md` → `README.md` (ClawHub uses `SKILL.md`, not SOUL.md; SOUL.md belongs to a different registry, onlycrabs.ai).
- **`cli-v1.0.0` GitHub release** at https://github.com/moona3k/macparakeet/releases/tag/cli-v1.0.0 — signed + notarized tarball attached.
- **[`moona3k/homebrew-tap`](https://github.com/moona3k/homebrew-tap)** — formula + cask, both `brew audit --strict --new` clean.
  - `brew install moona3k/tap/macparakeet-cli` works end-to-end (verified: on PATH, signed by Developer ID Application: Daniel Moon FYAF2ZD7RM, hardened runtime, `--version` → `1.0.0`).
  - `brew install --cask moona3k/tap/macparakeet` available (cask uses `:no_check` + Sparkle livecheck since the DMG URL is unversioned).
- **macparakeet.com/blog/macparakeet-cli-1-0/** — launch blog post live.
- **macparakeet.com/agents** — page reachable by direct URL (so external references don't 404), but **deliberately not linked from nav** (see "walked back" below).

### Walked back (cautious posture, awaiting e2e validation)

- **`/agents` nav link removed.** Page itself still exists; just not surfaced from header.
- **Registry issues opened then closed.**
  - [`0xNyk/awesome-hermes-agent#49`](https://github.com/0xNyk/awesome-hermes-agent/issues/49) — opened, then closed pre-emptively pending end-to-end validation.
  - [`vincentkoc/awesome-openclaw#71`](https://github.com/vincentkoc/awesome-openclaw/issues/71) — same.

  Both maintainers had not yet engaged at the time of close; the close note explains we're still validating end-to-end before re-filing. Cleaner than leaving open issues we'd have to walk back later.

### Drafted but not fired

- **Community posts** — `plans/active/community-posts/` has 4 ready drafts (r/LocalLLaMA, HN Show HN, OpenClaw Discord, Nous Research Discord). Held because they need the maintainer's accounts on each platform.
- **ClawHub publication** — deferred. The `openclaw` npm package (`openclaw@2026.4.24`) is the *full* OpenClaw runtime + daemon (36 deps, Android build scripts), not a lightweight publish CLI. Installing globally to publish one skill is overkill; defer until either an isolated install or a lighter publish flow exists.
- **`VoltAgent/awesome-openclaw-skills`** — deferred (depends on ClawHub publication first).

---

## What's in this branch

### `scripts/dist/homebrew-tap-scaffold/`

- **`macparakeet-cli.rb`** — source-of-truth scaffold for the formula now published at [moona3k/homebrew-tap](https://github.com/moona3k/homebrew-tap). Pre-built signed binary distribution, `depends_on` ffmpeg + yt-dlp + arch + macos `:sonoma` (with an `odie` runtime check enforcing the actual 14.2 patch-level floor — Homebrew's formula DSL only accepts Symbol versions, not strings).
- **`README.md`** — what the tap repo's README looks like (clearly marked as scaffold).
- **`HOWTO.md`** — full first-release runbook: gh repo create, swift build release, codesign + notarize (with the inlined `notarytool --wait` SIGBUS workaround), tar + shasum, gh release create, push tap, end-to-end verify. Will be the runbook for every subsequent CLI release.

### `plans/active/registry-submissions/`

- **`README.md`** — index of registry targets + submission ordering + critical schema correction (SKILL.md vs SOUL.md).
- **`awesome-hermes-agent.md`** — issue body draft + status (issue #49: opened, then closed pending e2e).
- **`awesome-openclaw.md`** — pre-filled responses for their `Add Resource Request` template + status (issue #71: same).
- **`clawhub.md`** — submission notes + critical SKILL.md finding + reasoning for deferral.

### `plans/active/community-posts/`

- **`README.md`** — index, posting order, voice/posture rules.
- **`reddit-localllama.md`** — title options, body, self-comment, what to monitor.
- **`hn-show.md`** — title, URL field, first-comment-by-author, anticipated thread, what to avoid.
- **`discord-openclaw.md`** — channel selection, post text, engagement guidance.
- **`discord-nous.md`** — same shape for Nous Research server.

---

## The strategic reframe (one paragraph)

MacParakeet has both a polished macOS app and a Swift-native CLI. Until 2026-04-25 the CLI was framed as an internal dev tool. The reframe: **`macparakeet-cli` is the canonical Swift-native CLI for Parakeet TDT on the Apple Neural Engine, and the Mac app is one (excellent) consumer of that CLI.** Both individual GUI users and AI-agent operators on Apple Silicon Mac minis are first-class audiences. Full plan with reasoning: [`plans/active/cli-as-canonical-parakeet-surface.md`](https://github.com/moona3k/macparakeet/blob/main/plans/active/cli-as-canonical-parakeet-surface.md) (in main, from #144).

---

## Architecture (after this rollout)

```
              Parakeet TDT 0.6B v3   (NeMo, public weights)
                       │
              FluidAudio             (CoreML on the Apple Neural Engine)
                       │
              ┌────────┴────────┐
              │ MacParakeetCore │   Swift library, no UI deps
              │ STT · DB · LLM  │
              └────────┬────────┘
                       │
            ┌──────────┴──────────┐
            ▼                     ▼
    macparakeet-cli         MacParakeet.app
    (semver 1.0.0)          (SwiftUI, GUI consumer)
            │
   ┌────────┼─────────────────────────┐
   ▼        ▼                         ▼
AGENTS.md  integrations/          brew install
(coding    (OpenClaw + Hermes     (live)
 agents)    scaffolds)
```

The CLI is the load-bearing surface. The Mac app is one well-crafted client of it. Agent skills (OpenClaw, Hermes, generic shell automation) are other clients, all reading from the same SQLite + STT pipeline.

---

## Two audiences (additive, not subtractive)

| Audience | What they want | How macparakeet serves them |
|---|---|---|
| **Individual macOS users** | Press a hotkey, dictate, get text. Drag a file in, get a transcript. Stays the largest + most loved audience. | The .app — dictation overlay, file transcription UI, meeting recording (v0.6 in progress). Unchanged by this rollout. |
| **Apple Silicon agent operators** | A reliable CLI to call from their OpenClaw/Hermes/Codex skill. Stable JSON, persistent memory, no cloud. | `macparakeet-cli` 1.0.0 with semver compatibility policy + `AGENTS.md` + `integrations/` scaffolds + brew tap. |

The reframe is *additive*. Nothing about the GUI experience changes.

---

## Why we're holding before public launch

The day shipped the *packaging* well: PR #144, signed/notarized binary, audit-clean tap, deployed website pages, two issues filed. But it skipped the **end-to-end story**:

- `brew install moona3k/tap/macparakeet-cli` — verified ✅
- `macparakeet-cli --version` from the brew-installed binary — verified ✅
- `macparakeet-cli health --json` from the brew-installed binary — **not verified**
- `macparakeet-cli transcribe <real-file> --format json` from the brew-installed binary — **not verified**
- JSON output schemas match what `integrations/README.md` documents — **not verified end-to-end**
- A Hermes-style or OpenClaw-style wrapper actually calling the CLI — **not verified**

If a Hermes maintainer follows our submission and the *first transcription* throws, we burn the slot for the next try. Pre-emptive close + nav hide buys us time to do honest validation; re-filing later with "tested end-to-end on macOS X.Y" is materially more credible.

---

## Multi-LLM review findings (PR #144 + this PR)

| Reviewer | Finding | Severity | Resolution |
|---|---|---|---|
| **Codex** (PR #144) | `history search` and `history search-transcriptions` LABELS swapped in 3 integration files + the website /agents page | **Critical** — would send agent operators to wrong command | Fixed in commit `b0b4491e` (PR #144) and `a88b15e` (website). Verified against actual CLI `--help`. |
| **Gemini agent** (PR #144) | Phantom `MEMORY.md` references in committed strategic plan (gitignored, dead links for external readers) | Critical | Removed all 4 references; replaced rationale-by-reference with the actual pre-change abstract text. |
| **Gemini agent** (PR #144) | AGENTS.md heading casing (sentence vs title case) | Nit | Normalized 6 H2s to title case. |
| **Gemini agent** (PR #144) | `1.0.0+` notation in install snippets | Nit | Changed to `1.0.0` (binary reports exactly 1.0.0 on day one). |
| **gemini-code-assist bot** (PR #144) | `transcribe --format json` vs `--json` on read-only commands looks inconsistent | Question | Documented as deliberate in `Sources/CLI/CHANGELOG.md` (transcribe + export emit one of six formats; query commands are JSON-or-human). Not a bug. |
| **brew audit** (3 cycles) | Stanza order; alphabetical `depends_on`; cask `:no_check` + `&:short_version` livecheck | Style/correctness | All fixed; both formula and cask `--strict --new` clean. |
| **gemini-code-assist bot** (this PR) | Formula's `depends_on macos: :sonoma` allows 14.0/14.1; should require ≥14.2 | Polish (the demographic is vanishingly small at this point) | Kept `:sonoma` (Homebrew DSL rejects strings: `Expected type Symbol, got type String with value ">= 14.2"`) + added `odie "macparakeet-cli requires macOS 14.2 or later" if MacOS.version < "14.2"` in `def install`. Audit-clean. |
| **gemini-code-assist bot** (this PR) | Dead link in `HOWTO.md` to gitignored `memory/feedback_notarytool_wait_bug.md` | Doc hygiene | Inlined the 3-step SIGBUS workaround into HOWTO.md; runbook is now self-contained. |
| **Recon (post-#144)** | Original handoff said OpenClaw uses SOUL.md — wrong; ClawHub uses SKILL.md | Critical for accuracy | PR #146 renamed `integrations/openclaw/SOUL.md` → `README.md` + added a post-launch correction preamble to the strategic plan. |
| **Recon (CONTRIBUTING.md reads)** | Both awesome lists explicitly forbid drive-by PRs (issue-first only) | Process | Pivoted from PR submissions to issue submissions. Two silent forks (`moona3k/awesome-hermes-agent`, `moona3k/awesome-openclaw`) were created earlier in the day before reading CONTRIBUTING; never received a commit, never opened a PR, safe to delete. |

---

## Open follow-ups (when ready to launch)

| # | Item | Gate / blocker |
|---|---|---|
| 1 | End-to-end validation: `health --json`, real transcribe, exercise `history`/`prompts list`/`flow words list`, confirm JSON shapes match `integrations/README.md` | Just needs ~30 min of focused testing |
| 2 | Re-file `awesome-hermes-agent` issue with "validated end-to-end on macOS X.Y" line | After (1) |
| 3 | Re-file `awesome-openclaw` issue with same line | After (1) |
| 4 | Re-add "For Agents" link to website nav | After (1) |
| 5 | Fire community posts (HN, r/LocalLLaMA, OpenClaw Discord, Nous Discord) | After (1), pair with v0.6.0 release for compounding momentum |
| 6 | Pursue ClawHub publication — needs OpenClaw CLI installed (in isolated env) + SKILL.md schema verified at `docs.openclaw.ai` | Independent decision |
| 7 | Submit to `VoltAgent/awesome-openclaw-skills` after ClawHub | Depends on (6) |
| 8 | Decide whether to merge this branch to main or close as planning artifact | After full launch — the HOWTO.md is genuinely useful for future releases |
| 9 | Delete the two silent forks under `moona3k/*` if not keeping them | Trivial cleanup |

---

## How to read this PR

| If you want to… | Read |
|---|---|
| Understand the strategy | [`plans/active/cli-as-canonical-parakeet-surface.md`](https://github.com/moona3k/macparakeet/blob/main/plans/active/cli-as-canonical-parakeet-surface.md) (in main, from #144) + this description |
| Cut the next CLI release | [`scripts/dist/homebrew-tap-scaffold/HOWTO.md`](../blob/chore/agent-rollout-drafts/scripts/dist/homebrew-tap-scaffold/HOWTO.md) in this branch |
| Submit to a registry | [`plans/active/registry-submissions/README.md`](../blob/chore/agent-rollout-drafts/plans/active/registry-submissions/README.md) for the index + ordering |
| Fire a community post | [`plans/active/community-posts/README.md`](../blob/chore/agent-rollout-drafts/plans/active/community-posts/README.md) for posting order + posture rules |
| Call the CLI from your agent | [`AGENTS.md`](https://github.com/moona3k/macparakeet/blob/main/AGENTS.md) + [`integrations/README.md`](https://github.com/moona3k/macparakeet/blob/main/integrations/README.md) (in main) |

---

## Test plan

Docs-only branch. No code touched.

- [x] Brew tap end-to-end install verified (`brew install moona3k/tap/macparakeet-cli`)
- [x] Brew formula audit clean (`brew audit --strict --new`)
- [x] Brew cask audit clean (`brew audit --strict --new --cask`)
- [x] cli-v1.0.0 GitHub release reachable + tarball sha256 matches formula
- [x] macparakeet.com/agents and /blog/macparakeet-cli-1-0/ both live
- [x] "For Agents" nav link verified absent from production after walk-back
- [x] Both registry issues confirmed CLOSED
- [x] Gemini-code-assist findings on this PR addressed + replied to
- [x] No external-repo PRs submitted (issue-first per both lists' CONTRIBUTING)
- [ ] User has reviewed this description for completeness + accuracy
- [ ] (When ready) End-to-end validation completed → re-file registry issues, restore nav, fire community posts
