### PR TITLE
fix(cli): route transcribe progress to stderr — 1.0.1

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -30,6 +30,32 @@ JSON output schemas are part of the contract: top-level shape (array vs
 object), field names, and field types are stable within a major version. We
 may add new optional fields in a minor release.
 
+## [1.0.1] -- 2026-04-26
+
+End-to-end validation of the brew-installed 1.0.0 binary surfaced a
+single stdout-pollution bug in `transcribe`. Fixed below; no other
+behavior change.
+
+### Fixed
+
+- `transcribe --format json` emitted a `Transcribing <file>...` (or
+  `Converting`/`Downloading`/`Identifying speakers`/`Finalizing` for
+  YouTube URLs) progress line on **stdout** before the JSON payload,
+  which broke `transcribe ... --format json | jq .` for any scripted
+  caller. Progress messages now go to stderr (matching the existing
+  pattern in `prompts run` and the documented "JSON only to stdout"
+  contract from `integrations/README.md`). New `printErr(_:)` helper
+  in `CLIHelpers.swift` codifies the channel.
+
+### Compatibility notes
+
+- The progress messages are still emitted; they just go to stderr now.
+  Human callers using the human-readable `--format txt` (default) are
+  unaffected — stderr still surfaces in the terminal.
+- Scripted callers that were relying on the progress message appearing
+  on stdout (unlikely; it was a polling-style "..." line) need to read
+  stderr instead.
+
 ## [1.0.0] -- 2026-04-25
 
 First release of the CLI as a versioned public surface. The CLI has existed

--- a/Sources/CLI/Commands/CLIHelpers.swift
+++ b/Sources/CLI/Commands/CLIHelpers.swift
@@ -131,3 +131,10 @@ func printJSON<T: Encodable>(_ value: T) throws {
         print(s)
     }
 }
+
+/// Write a status / progress message to stderr so it doesn't pollute stdout
+/// for callers piping `--json` output to `jq`, scripts, or skill manifests.
+/// Append a trailing newline.
+func printErr(_ s: String) {
+    FileHandle.standardError.write(Data((s + "\n").utf8))
+}

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -103,11 +103,11 @@ struct TranscribeCommand: AsyncParsableCommand {
         if YouTubeURLValidator.isYouTubeURL(trimmedInput) {
             result = try await service.transcribeURL(urlString: trimmedInput) { progress in
                 switch progress {
-                case .converting: print("Converting audio...")
-                case .downloading(let pct): print("Downloading audio... \(pct)%")
-                case .transcribing(let pct): print("Transcribing... \(pct)%")
-                case .identifyingSpeakers: print("Identifying speakers...")
-                case .finalizing: print("Finalizing...")
+                case .converting: printErr("Converting audio...")
+                case .downloading(let pct): printErr("Downloading audio... \(pct)%")
+                case .transcribing(let pct): printErr("Transcribing... \(pct)%")
+                case .identifyingSpeakers: printErr("Identifying speakers...")
+                case .finalizing: printErr("Finalizing...")
                 }
             }
         } else {
@@ -122,7 +122,7 @@ struct TranscribeCommand: AsyncParsableCommand {
                 throw CLIError.unsupportedFormat(ext)
             }
 
-            print("Transcribing \(url.lastPathComponent)...")
+            printErr("Transcribing \(url.lastPathComponent)...")
             result = try await service.transcribe(fileURL: url)
         }
 

--- a/Sources/CLI/MacParakeetCLI.swift
+++ b/Sources/CLI/MacParakeetCLI.swift
@@ -5,7 +5,7 @@ struct CLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "macparakeet-cli",
         abstract: "Local STT, transcription, and prompt automation for Apple Silicon. Powered by Parakeet TDT on the Neural Engine.",
-        version: "1.0.0",
+        version: "1.0.1",
         subcommands: [
             TranscribeCommand.self,
             HistoryCommand.self,


### PR DESCRIPTION
## Summary

End-to-end validation of the brew-installed 1.0.0 binary surfaced a single concrete bug:

```bash
$ macparakeet-cli transcribe /tmp/test.wav --format json | jq .
jq: parse error: Invalid numeric literal at line 1, column 13
```

Cause: `transcribe` printed `Transcribing <file>...` (or `Converting`/`Downloading`/`Identifying speakers`/`Finalizing` on the YouTube path) to **stdout** before the JSON payload, breaking any scripted caller piping `--format json` output to `jq`. This contradicted both the documented contract in [`integrations/README.md`](https://github.com/moona3k/macparakeet/blob/main/integrations/README.md) ("JSON only to stdout") and the existing pattern at [`PromptsCommand.swift:389-390`](https://github.com/moona3k/macparakeet/blob/main/Sources/CLI/Commands/PromptsCommand.swift#L389-L390) where status messages already go to stderr.

## What changed

| File | Change |
|---|---|
| `Sources/CLI/Commands/CLIHelpers.swift` | New `printErr(_:)` helper (writes to `FileHandle.standardError` with trailing newline) — codifies the channel pattern. |
| `Sources/CLI/Commands/TranscribeCommand.swift` | Replace 6 `print(...)` calls (5 in YouTube progress switch + 1 file-transcribe line) with `printErr(...)`. The final `printJSON`/`printText` payload paths are unchanged — those correctly go to stdout. |
| `Sources/CLI/MacParakeetCLI.swift` | Bump version `1.0.0` → `1.0.1`. |
| `Sources/CLI/CHANGELOG.md` | Add `[1.0.1]` entry under Compatibility policy / Fixed describing the bug, the fix, the helper, and the small compatibility implication. |

## Verification

```bash
$ swift build --product macparakeet-cli
$ say -o /tmp/test-stt.wav --data-format=LEI16@22050 "Hello, this is a test"
$ .build/debug/macparakeet-cli transcribe /tmp/test-stt.wav --format json 2>/dev/null | jq -r '.rawTranscript'
Hello, this is a test
$ .build/debug/macparakeet-cli transcribe /tmp/test-stt.wav --format json 2>&1 1>/dev/null | head -1
Transcribing test-stt.wav...
```

✅ Stdout pure JSON · ✅ jq parses · ✅ Progress visible on stderr.

## E2E pass also confirmed (other commands clean)

Every other documented `--json` command was already stdout-clean and matches the schemas in `integrations/README.md`:

`history transcriptions` · `history dictations` · `history search` · `prompts list` · `flow words list` · `models status` · `stats` · `health`

All return ISO-8601 datetimes, sorted keys, top-level array for lists, top-level object for single-record / status responses.

## Why 1.0.1 (PATCH)

Per the [compatibility policy](https://github.com/moona3k/macparakeet/blob/main/Sources/CLI/CHANGELOG.md): bug fix that restores documented behavior, no schema or flag change. Anyone scripting against the documented contract was already broken (jq pipeline failed); this fix is what they expected. Anyone reading the progress message off stdout (basically nobody — it was a one-shot status line, not data) needs to read stderr instead.

## Test plan

- [x] `swift build --product macparakeet-cli` clean
- [x] `--version` reports `1.0.1`
- [x] `transcribe --format json | jq .` parses cleanly
- [x] Progress message verified on stderr
- [x] Other `--json` commands re-tested, still clean
- [ ] CI green
- [ ] After merge: cut `cli-v1.0.1` tag + GitHub release + update tap formula sha256 + verify `brew upgrade moona3k/tap/macparakeet-cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)