### PR TITLE
fix: address merged PR review follow-ups

### DIFF
--- a/Sources/CLI/Commands/CLIHelpers.swift
+++ b/Sources/CLI/Commands/CLIHelpers.swift
@@ -7,14 +7,19 @@ func macParakeetAppDefaults() -> UserDefaults {
     UserDefaults(suiteName: macParakeetAppDefaultsSuiteName) ?? .standard
 }
 
+func expandTilde(_ path: String) -> String {
+    (path as NSString).expandingTildeInPath
+}
+
 // MARK: - Database Path Resolution
 
 func resolvedDatabasePath(_ database: String?) -> String {
     let opt = database?.trimmingCharacters(in: .whitespacesAndNewlines)
     if let opt, !opt.isEmpty {
-        let dir = URL(fileURLWithPath: opt).deletingLastPathComponent()
+        let resolved = expandTilde(opt)
+        let dir = URL(fileURLWithPath: resolved).deletingLastPathComponent()
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        return opt
+        return resolved
     }
     return AppPaths.databasePath
 }
@@ -136,5 +141,5 @@ func printJSON<T: Encodable>(_ value: T) throws {
 /// for callers piping `--json` output to `jq`, scripts, or skill manifests.
 /// Append a trailing newline.
 func printErr(_ s: String) {
-    FileHandle.standardError.write(Data((s + "\n").utf8))
+    try? FileHandle.standardError.write(contentsOf: Data((s + "\n").utf8))
 }

--- a/Sources/CLI/Commands/LLMInlineConfig.swift
+++ b/Sources/CLI/Commands/LLMInlineConfig.swift
@@ -27,7 +27,7 @@ func readInput(_ path: String) throws -> String {
         }
         return lines.joined()
     } else {
-        let url = URL(fileURLWithPath: path)
+        let url = URL(fileURLWithPath: expandTilde(path))
         return try String(contentsOf: url, encoding: .utf8)
     }
 }

--- a/Sources/CLI/Commands/LLMTestCommand.swift
+++ b/Sources/CLI/Commands/LLMTestCommand.swift
@@ -38,6 +38,9 @@ struct LLMTestCommand: AsyncParsableCommand {
         } catch let error as LLMError {
             printErr("Connection failed: \(error.errorDescription ?? String(describing: error))")
             throw ExitCode.failure
+        } catch {
+            printErr("Connection failed: \(error.localizedDescription)")
+            throw ExitCode.failure
         }
     }
 }

--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -147,10 +147,13 @@ final class AppEnvironment {
             aiFormatterPromptTemplate: aiFormatterPromptClosure
         )
 
-        telemetryService = TelemetryService()
-        Telemetry.configure(telemetryService)
+        let telemetry = TelemetryService()
+        telemetryService = telemetry
+        Telemetry.configure(telemetry)
         Telemetry.send(.appLaunched)
-        CrashReporter.sendPendingReport(via: telemetryService)
+        Task {
+            await CrashReporter.sendPendingReport(via: telemetry)
+        }
 
         transcriptionService = TranscriptionService(
             audioProcessor: audioProcessor,

--- a/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
+++ b/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
@@ -76,7 +76,7 @@ struct HotkeyRecorderView: View {
                     Divider()
                 }
 
-                Button("Reset to Default (\(defaultTrigger.shortSymbol))") {
+                Button("Reset to Default (\(Self.resetLabel(for: defaultTrigger)))") {
                     resetToDefault()
                 }
                 .disabled(trigger == defaultTrigger)
@@ -280,6 +280,12 @@ struct HotkeyRecorderView: View {
         case .sideSpecific:
             return HotkeyTrigger(kind: .modifier, modifierName: name, keyCode: nil, modifierKeyCode: keyCode)
         }
+    }
+
+    static func resetLabel(for trigger: HotkeyTrigger) -> String {
+        if trigger == .fn { return "🌐 Fn" }
+        if trigger.kind == .modifier { return trigger.displayName }
+        return trigger.shortSymbol
     }
 
     private func stopRecording() {

--- a/Sources/MacParakeetCore/STT/HotkeyTrigger.swift
+++ b/Sources/MacParakeetCore/STT/HotkeyTrigger.swift
@@ -276,6 +276,11 @@ public struct HotkeyTrigger: Sendable {
             46,  // M
         ]
         if hasCommand && destructiveCmdKeys.contains(code) {
+            // Only bare Cmd+M maps to the system Minimize command; multi-modifier
+            // variants such as Cmd+Shift+M remain valid app-owned defaults.
+            if code == 46 && Set(modifiers ?? []) != ["command"] {
+                return .allowed
+            }
             return .warned("Conflicts with a common system shortcut.")
         }
 

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -265,7 +265,8 @@ public actor STTRuntime: STTRuntimeProtocol {
         let version = modelVersion
         let warmUpProgressHandler = self.warmUpProgressHandler
         let task = Task {
-            let lastProgressUpdate = OSAllocatedUnfairLock(initialState: Date.distantPast)
+            let clock = ContinuousClock()
+            let lastProgressUpdate = OSAllocatedUnfairLock(initialState: clock.now - .seconds(1))
             let lastProgressMessage = OSAllocatedUnfairLock(initialState: "")
             var interactiveManager: AsrManager?
             var backgroundManager: AsrManager?
@@ -274,9 +275,9 @@ public actor STTRuntime: STTRuntimeProtocol {
                 let progressCallback: @Sendable (String) -> Void = warmUpProgressHandler
                 progressHandler = { progress in
                     guard let message = Self.warmUpProgressMessage(from: progress) else { return }
-                    let now = Date()
+                    let now = clock.now
                     let shouldEmit = lastProgressUpdate.withLock { lastUpdate in
-                        guard now.timeIntervalSince(lastUpdate) >= 0.25 else {
+                        guard lastUpdate.duration(to: now) >= .milliseconds(250) else {
                             return false
                         }
                         lastUpdate = now

--- a/Sources/MacParakeetCore/Services/CrashReporter.swift
+++ b/Sources/MacParakeetCore/Services/CrashReporter.swift
@@ -64,10 +64,9 @@ public final class CrashReporter {
         installed = true
 
         // 1. Ensure the crash directory exists
-        let dir = AppPaths.appSupportDir
-        var isDir: ObjCBool = false
-        if !FileManager.default.fileExists(atPath: dir, isDirectory: &isDir) {
-            try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        guard prepareCrashDirectory(at: AppPaths.appSupportDir) else {
+            installed = false
+            return
         }
 
         // 2. Pre-resolve crash file path to C string
@@ -259,6 +258,24 @@ public final class CrashReporter {
         previousExceptionHandler?(exception)
     }
 
+    private static func prepareCrashDirectory(at dir: String) -> Bool {
+        var isDir: ObjCBool = false
+        do {
+            if FileManager.default.fileExists(atPath: dir, isDirectory: &isDir) {
+                if !isDir.boolValue {
+                    try FileManager.default.removeItem(atPath: dir)
+                    try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+                }
+            } else {
+                try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+            }
+            return true
+        } catch {
+            fputs("MacParakeet CrashReporter: failed to prepare crash directory at \(dir): \(error)\n", stderr)
+            return false
+        }
+    }
+
     // MARK: - Mach-O UUID Extraction
 
     private static func snapshotMachOUUID() {
@@ -374,19 +391,20 @@ public final class CrashReporter {
         )
     }
 
-    /// Send any pending crash report as a telemetry event, then delete the file.
+    /// Send any pending crash report as a telemetry event. Delete the file only
+    /// when telemetry reports that the event was delivered or intentionally dropped.
     /// Call after TelemetryService is initialized.
-    public static func sendPendingReport(via telemetry: TelemetryServiceProtocol) {
-        sendPendingReport(via: telemetry, from: crashReportPath)
+    public static func sendPendingReport(via telemetry: TelemetryServiceProtocol) async {
+        await sendPendingReport(via: telemetry, from: crashReportPath)
     }
 
     /// Internal variant with injectable path for testing.
-    static func sendPendingReport(via telemetry: TelemetryServiceProtocol, from path: String) {
+    static func sendPendingReport(via telemetry: TelemetryServiceProtocol, from path: String) async {
         guard let report = loadPendingReport(from: path) else { return }
 
         let stackTraceString = report.stackTrace.joined(separator: "\n")
 
-        telemetry.send(.crashOccurred(
+        let delivered = await telemetry.sendAndFlush(.crashOccurred(
             crashType: report.crashType,
             signal: report.signal,
             name: report.name,
@@ -399,8 +417,10 @@ public final class CrashReporter {
             stackTrace: stackTraceString
         ))
 
-        // Always delete — even if telemetry is disabled (send() handles opt-out)
-        deleteCrashFile(at: path)
+        if delivered {
+            // Delete only after telemetry has either been flushed or intentionally dropped by opt-out.
+            deleteCrashFile(at: path)
+        }
     }
 
     private static func deleteCrashFile(at path: String? = nil) {

--- a/Sources/MacParakeetCore/Services/LLMService.swift
+++ b/Sources/MacParakeetCore/Services/LLMService.swift
@@ -86,7 +86,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
     internal static let localContextBudget = 24_000
 
     public init(
-        client: LLMClientProtocol = LLMClient(),
+        client: LLMClientProtocol = RoutingLLMClient(),
         contextResolver: any LLMExecutionContextResolving = StoredLLMExecutionContextResolver()
     ) {
         self.client = client
@@ -94,7 +94,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
     }
 
     public convenience init(
-        client: LLMClientProtocol = LLMClient(),
+        client: LLMClientProtocol = RoutingLLMClient(),
         configStore: LLMConfigStoreProtocol = LLMConfigStore(),
         cliConfigStore: LocalCLIConfigStore = LocalCLIConfigStore()
     ) {

--- a/Sources/MacParakeetCore/Services/LocalCLIExecutor.swift
+++ b/Sources/MacParakeetCore/Services/LocalCLIExecutor.swift
@@ -71,7 +71,7 @@ public enum LocalCLIError: Error, LocalizedError, Sendable {
     public var errorDescription: String? {
         switch self {
         case .commandNotConfigured:
-            return "Local CLI command is not configured. Choose a template or enter a command in Settings."
+            return "Local CLI command is not configured. Choose a template or pass a command."
         case .commandNotFound(let details):
             return "CLI command not found. Ensure it is installed and on your PATH. Details: \(details)"
         case .timeout(let seconds):

--- a/Sources/MacParakeetCore/Services/LocalCLILLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LocalCLILLMClient.swift
@@ -27,6 +27,8 @@ public final class LocalCLILLMClient: LLMClientProtocol, Sendable {
             return ChatCompletionResponse(content: output, model: "cli")
         } catch let error as LLMError {
             throw error
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
             throw LLMError.cliError(error.localizedDescription)
         }
@@ -58,6 +60,8 @@ public final class LocalCLILLMClient: LLMClientProtocol, Sendable {
             try await executor.testConnection(config: try localCLIConfig(from: context))
         } catch let error as LLMError {
             throw error
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
             throw LLMError.cliError(error.localizedDescription)
         }

--- a/Sources/MacParakeetCore/Services/TelemetryService.swift
+++ b/Sources/MacParakeetCore/Services/TelemetryService.swift
@@ -8,8 +8,34 @@ import AppKit
 
 public protocol TelemetryServiceProtocol: Sendable {
     func send(_ event: TelemetryEventSpec)
+    @discardableResult
+    func sendAndFlush(_ event: TelemetryEventSpec) async -> Bool
     func flush() async
     func flushForTermination()
+}
+
+private actor TelemetryFlushGate {
+    private var isLocked = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func enter() async {
+        if !isLocked {
+            isLocked = true
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func leave() {
+        if waiters.isEmpty {
+            isLocked = false
+        } else {
+            waiters.removeFirst().resume()
+        }
+    }
 }
 
 // MARK: - Implementation
@@ -17,6 +43,7 @@ public protocol TelemetryServiceProtocol: Sendable {
 public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendable {
     private let logger = Logger(subsystem: "com.macparakeet.core", category: "Telemetry")
     private let lock = NSLock()
+    private let flushGate = TelemetryFlushGate()
     private var queue: [TelemetryEvent] = []
     private var flushTimer: Timer?
     private var lifecycleObserver: NSObjectProtocol?
@@ -119,11 +146,32 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
         }
     }
 
+    @discardableResult
+    public func sendAndFlush(_ event: TelemetryEventSpec) async -> Bool {
+        guard isEnabled() || event.name == .telemetryOptedOut else { return true }
+
+        let telemetryEvent = makeTelemetryEvent(from: event)
+
+        await flushGate.enter()
+        enqueue(telemetryEvent)
+        let failedEventIds = await flushQueuedEvents()
+        await flushGate.leave()
+
+        return !failedEventIds.contains(telemetryEvent.eventId)
+    }
+
     public func flush() async {
+        await flushGate.enter()
+        _ = await flushQueuedEvents()
+        await flushGate.leave()
+    }
+
+    private func flushQueuedEvents() async -> Set<String> {
         let events = takeQueuedEvents()
-        guard !events.isEmpty else { return }
+        guard !events.isEmpty else { return [] }
         let failedEvents = await sendBatches(events, using: session, timeoutInterval: 10)
         requeueFailedEvents(failedEvents)
+        return Set(failedEvents.map(\.eventId))
     }
 
     // MARK: - Internal (for testing)
@@ -135,6 +183,15 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
     }
 
     // MARK: - Private
+
+    private func enqueue(_ event: TelemetryEvent) {
+        lock.lock()
+        queue.append(event)
+        if queue.count > Self.maxQueueSize {
+            queue.removeFirst(queue.count - Self.maxQueueSize)
+        }
+        lock.unlock()
+    }
 
     private func takeQueuedEvents() -> [TelemetryEvent] {
         lock.lock()
@@ -319,6 +376,7 @@ public enum Telemetry {
 public final class NoOpTelemetryService: TelemetryServiceProtocol {
     public init() {}
     public func send(_ event: TelemetryEventSpec) {}
+    public func sendAndFlush(_ event: TelemetryEventSpec) async -> Bool { true }
     public func flush() async {}
     public func flushForTermination() {}
 }

--- a/Sources/MacParakeetViewModels/MeetingNotesViewModel.swift
+++ b/Sources/MacParakeetViewModels/MeetingNotesViewModel.swift
@@ -1,5 +1,4 @@
 import Foundation
-import OSLog
 import SwiftUI
 
 /// View model for the live meeting notepad pane (ADR-020 §1, §8, §11).
@@ -84,7 +83,6 @@ public final class MeetingNotesViewModel {
 
     private var persist: ((String) async -> Void)?
     private var debounceTask: Task<Void, Never>?
-    private let logger = Logger(subsystem: "com.macparakeet.viewmodels", category: "MeetingNotesViewModel")
 
     public init() {}
 

--- a/Sources/MacParakeetViewModels/TranscriptChatViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptChatViewModel.swift
@@ -423,6 +423,8 @@ public final class TranscriptChatViewModel {
                 chatHistory.removeAll()
                 currentConversation = nil
             }
+            errorMessage = nil
+            inputText = ""
         }
 
         notifyConversationsChanged()

--- a/Tests/CLITests/CLIHelpersTests.swift
+++ b/Tests/CLITests/CLIHelpersTests.swift
@@ -203,4 +203,10 @@ final class CLIHelpersTests: XCTestCase {
         let path = resolvedDatabasePath(custom)
         XCTAssertEqual(path, custom)
     }
+
+    func testResolvedDatabasePathExpandsTilde() {
+        let path = resolvedDatabasePath("~/macparakeet-test.db")
+        XCTAssertFalse(path.hasPrefix("~"))
+        XCTAssertTrue(path.hasSuffix("/macparakeet-test.db"))
+    }
 }

--- a/Tests/MacParakeetTests/Hotkey/HotkeyTriggerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyTriggerTests.swift
@@ -475,6 +475,10 @@ final class HotkeyTriggerTests: XCTestCase {
         }
     }
 
+    func testDefaultMeetingChordIsAllowed() {
+        XCTAssertEqual(HotkeyTrigger.defaultMeetingRecording.validation, .allowed)
+    }
+
     func testChordCmdQWithoutCommandIsAllowed() {
         // Q with Shift only (no Cmd) — should not trigger the Cmd+Q warning
         let trigger = HotkeyTrigger.chord(modifiers: ["shift"], keyCode: 12)

--- a/Tests/MacParakeetTests/Services/CrashReporterTests.swift
+++ b/Tests/MacParakeetTests/Services/CrashReporterTests.swift
@@ -118,7 +118,7 @@ final class CrashReporterTests: XCTestCase {
 
     // MARK: - Telemetry Integration
 
-    func testSendPendingReportSendsEventAndDeletesFile() {
+    func testSendPendingReportSendsEventAndDeletesFile() async {
         let content = """
         crash_type: signal
         signal: 11
@@ -135,7 +135,7 @@ final class CrashReporterTests: XCTestCase {
         try! content.write(toFile: testCrashPath, atomically: true, encoding: .utf8)
 
         let mock = MockTelemetryService()
-        CrashReporter.sendPendingReport(via: mock, from: testCrashPath)
+        await CrashReporter.sendPendingReport(via: mock, from: testCrashPath)
 
         // Verify event was sent
         XCTAssertEqual(mock.sentEvents.count, 1)
@@ -151,22 +151,35 @@ final class CrashReporterTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: testCrashPath))
     }
 
-    func testSendPendingReportDeletesFileEvenWhenTelemetryDisabled() {
+    func testSendPendingReportDeletesFileEvenWhenTelemetryDisabled() async {
         let content = "crash_type: signal\nsignal: 6\nname: SIGABRT\ntimestamp: 0\napp_ver: 0.1\n"
         try! content.write(toFile: testCrashPath, atomically: true, encoding: .utf8)
 
-        // NoOp service simulates disabled telemetry
+        // NoOp explicitly reports the event as handled so disabled telemetry drops do not retry forever.
         let noop = NoOpTelemetryService()
-        CrashReporter.sendPendingReport(via: noop, from: testCrashPath)
+        await CrashReporter.sendPendingReport(via: noop, from: testCrashPath)
 
         // File should still be deleted
         XCTAssertFalse(FileManager.default.fileExists(atPath: testCrashPath))
     }
 
-    func testSendPendingReportNoOpWithoutCrashFile() {
+    func testSendPendingReportNoOpWithoutCrashFile() async {
         let mock = MockTelemetryService()
-        CrashReporter.sendPendingReport(via: mock, from: testDir + "/nonexistent.txt")
+        await CrashReporter.sendPendingReport(via: mock, from: testDir + "/nonexistent.txt")
         XCTAssertTrue(mock.sentEvents.isEmpty)
+    }
+
+    func testSendPendingReportKeepsFileWhenTelemetryFlushFails() async {
+        let content = "crash_type: signal\nsignal: 6\nname: SIGABRT\ntimestamp: 0\napp_ver: 0.1\n"
+        try! content.write(toFile: testCrashPath, atomically: true, encoding: .utf8)
+
+        let mock = MockTelemetryService()
+        mock.sendAndFlushResult = false
+
+        await CrashReporter.sendPendingReport(via: mock, from: testCrashPath)
+
+        XCTAssertEqual(mock.sentEvents.count, 1)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: testCrashPath))
     }
 
     // MARK: - Reviewer-Flagged Edge Cases
@@ -257,7 +270,7 @@ final class CrashReporterTests: XCTestCase {
         XCTAssertEqual(report?.stackTrace, ["0xABCD"])
     }
 
-    func testSendPendingReportIncludesStackTraceInProps() {
+    func testSendPendingReportIncludesStackTraceInProps() async {
         let content = """
         crash_type: signal
         signal: 11
@@ -275,7 +288,7 @@ final class CrashReporterTests: XCTestCase {
         try! content.write(toFile: testCrashPath, atomically: true, encoding: .utf8)
 
         let mock = MockTelemetryService()
-        CrashReporter.sendPendingReport(via: mock, from: testCrashPath)
+        await CrashReporter.sendPendingReport(via: mock, from: testCrashPath)
 
         if case .crashOccurred(_, _, _, _, let appVer, let osVer, let uuid, let slide, let reason, let stackTrace) = mock.sentEvents.first {
             XCTAssertEqual(appVer, "0.5.1")
@@ -289,7 +302,7 @@ final class CrashReporterTests: XCTestCase {
         }
     }
 
-    func testExceptionReasonWithNewlinesIsPreserved() {
+    func testExceptionReasonWithNewlinesIsPreserved() async {
         let content = """
         crash_type: exception
         signal: exception
@@ -303,7 +316,7 @@ final class CrashReporterTests: XCTestCase {
         try! content.write(toFile: testCrashPath, atomically: true, encoding: .utf8)
 
         let mock = MockTelemetryService()
-        CrashReporter.sendPendingReport(via: mock, from: testCrashPath)
+        await CrashReporter.sendPendingReport(via: mock, from: testCrashPath)
 
         if case .crashOccurred(_, _, _, _, _, _, _, _, let reason, _) = mock.sentEvents.first {
             XCTAssertEqual(reason, "index 5 beyond bounds [0..3]\nmore context here")
@@ -317,9 +330,15 @@ final class CrashReporterTests: XCTestCase {
 
 private final class MockTelemetryService: TelemetryServiceProtocol, @unchecked Sendable {
     var sentEvents = [TelemetryEventSpec]()
+    var sendAndFlushResult = true
 
     func send(_ event: TelemetryEventSpec) {
         sentEvents.append(event)
+    }
+
+    func sendAndFlush(_ event: TelemetryEventSpec) async -> Bool {
+        send(event)
+        return sendAndFlushResult
     }
 
     func flush() async {}

--- a/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
@@ -33,6 +33,11 @@ private final class TelemetrySpy: TelemetryServiceProtocol, @unchecked Sendable 
         lock.unlock()
     }
 
+    func sendAndFlush(_ event: TelemetryEventSpec) async -> Bool {
+        send(event)
+        return true
+    }
+
     func flush() async {}
 
     func flushForTermination() {}

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -172,6 +172,25 @@ final class TelemetryServiceTests: XCTestCase {
         XCTAssertEqual(service.pendingEventCount, 0)
     }
 
+    func testSendAndFlushReturnsTrueWhenDeliverySucceeds() async {
+        let service = makeService()
+
+        let delivered = await service.sendAndFlush(.appLaunched)
+
+        XCTAssertTrue(delivered)
+        XCTAssertEqual(service.pendingEventCount, 0)
+    }
+
+    func testSendAndFlushReturnsFalseAndRequeuesWhenDeliveryFails() async {
+        TelemetryMockURLProtocol.statusCode = 500
+        let service = makeService()
+
+        let delivered = await service.sendAndFlush(.appLaunched)
+
+        XCTAssertFalse(delivered)
+        XCTAssertEqual(service.pendingEventCount, 1)
+    }
+
     func testFlushSplitsRequestsIntoBatchesOf100() async throws {
         let eventCount = 150
         let service = makeService()
@@ -454,6 +473,8 @@ final class TelemetryServiceTests: XCTestCase {
         let service = NoOpTelemetryService()
         service.send(.appLaunched)
         service.send(.dictationStarted(trigger: .hotkey, mode: .hold))
+        let handled = await service.sendAndFlush(.appLaunched)
+        XCTAssertTrue(handled)
         await service.flush()
     }
 

--- a/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
@@ -12,6 +12,11 @@ private final class OnboardingTelemetrySpy: TelemetryServiceProtocol, @unchecked
         lock.unlock()
     }
 
+    func sendAndFlush(_ event: TelemetryEventSpec) async -> Bool {
+        send(event)
+        return true
+    }
+
     func flush() async {}
 
     func flushForTermination() {}

--- a/Tests/MacParakeetTests/ViewModels/TranscriptChatViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptChatViewModelTests.swift
@@ -575,15 +575,19 @@ final class TranscriptChatViewModelTests: XCTestCase {
         let conv1 = ChatConversation(
             transcriptionId: transcriptionId,
             title: "Keep",
-            messages: [ChatMessage(role: .user, content: "Q1")]
+            messages: [ChatMessage(role: .user, content: "Q1")],
+            updatedAt: Date(timeIntervalSinceReferenceDate: 2)
         )
         let conv2 = ChatConversation(
             transcriptionId: transcriptionId,
             title: "Delete",
-            messages: [ChatMessage(role: .user, content: "Q2")]
+            messages: [ChatMessage(role: .user, content: "Q2")],
+            updatedAt: Date(timeIntervalSinceReferenceDate: 1)
         )
         mockConversationRepo.conversations = [conv1, conv2]
         viewModel.loadTranscript("Transcript", transcriptionId: transcriptionId)
+        viewModel.inputText = "draft from deleted chat"
+        viewModel.errorMessage = "stale error"
 
         // Delete conv1 (current)
         viewModel.deleteConversation(conv1)
@@ -592,6 +596,8 @@ final class TranscriptChatViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.conversations[0].id, conv2.id)
         // Should switch to remaining conversation
         XCTAssertEqual(viewModel.currentConversation?.id, conv2.id)
+        XCTAssertEqual(viewModel.inputText, "")
+        XCTAssertNil(viewModel.errorMessage)
         XCTAssertTrue(mockConversationRepo.deleteCalls.contains(conv1.id))
     }
 

--- a/Tests/MacParakeetTests/Views/Settings/HotkeyRecorderViewTests.swift
+++ b/Tests/MacParakeetTests/Views/Settings/HotkeyRecorderViewTests.swift
@@ -26,4 +26,19 @@ final class HotkeyRecorderViewTests: XCTestCase {
             HotkeyTrigger(kind: .modifier, modifierName: "option", keyCode: nil, modifierKeyCode: 61)
         )
     }
+
+    func testResetLabelUsesReadableFnName() {
+        XCTAssertEqual(HotkeyRecorderView.resetLabel(for: .fn), "🌐 Fn")
+    }
+
+    func testResetLabelUsesReadableModifierName() {
+        XCTAssertEqual(HotkeyRecorderView.resetLabel(for: .control), "Control")
+    }
+
+    func testResetLabelUsesChordSymbol() {
+        XCTAssertEqual(
+            HotkeyRecorderView.resetLabel(for: .defaultMeetingRecording),
+            "⇧⌘M"
+        )
+    }
 }

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -46,7 +46,7 @@ ffmpeg + yt-dlp as runtime deps. First `transcribe` call downloads
 | Search transcriptions | `macparakeet-cli history search-transcriptions "<query>" --json` |
 | Search dictations | `macparakeet-cli history search "<query>" --json` |
 | List prompts | `macparakeet-cli prompts list --json` |
-| Run a prompt on a transcription | `macparakeet-cli prompts run <prompt-name> --transcription <id> --provider <p> --api-key "$KEY" --model <m>` |
+| Run a prompt on a transcription | `macparakeet-cli prompts run <prompt-name> --transcription <id-or-name> --provider <p> --api-key "$KEY" --model <m>` |
 
 ## Conventions
 
@@ -71,7 +71,7 @@ fields and validation rules may have evolved.
 name: macparakeet-stt
 version: 1.0.0
 author: <your-username>
-description: Local Parakeet TDT speech-to-text on Apple Silicon. Wraps macparakeet-cli (GPL-3.0).
+description: Local Parakeet TDT speech-to-text on Apple Silicon. Wraps macparakeet-cli (GPL-3.0-or-later).
 tags: [stt, transcription, voice, apple-silicon, local, parakeet]
 requires:
   - platform: darwin

--- a/plans/active/cli-llm-json-output.md
+++ b/plans/active/cli-llm-json-output.md
@@ -40,14 +40,15 @@ This is mostly a **MacParakeetCore refactor**: today `LLMService.summarize/chat/
 
 ### Streaming (`--stream --json`) — deferred NDJSON follow-up
 
-```
+```ndjson
 {"type":"delta","output":"Hello"}
 {"type":"delta","output":" world"}
-{"type":"final","provider":"anthropic","model":"claude-sonnet-4-6","usage":{...},"latencyMs":2345,"stopReason":"end_turn"}
+{"type":"final","output":"","provider":"anthropic","model":"claude-sonnet-4-6","usage":{...},"latencyMs":2345,"stopReason":"end_turn"}
 ```
 
 - One JSON object per line, terminated with `\n`.
 - Always ends with exactly one `final` line. Usage-less providers omit `usage`, matching the one-shot envelope.
+- Streaming deltas carry content as it arrives; the final `output` is empty unless a future implementation explicitly chooses to repeat the concatenated text.
 - Lets agents share a parser between streaming and one-shot paths.
 - In PR #149, `--json --stream` is rejected during argument validation with a clear error.
 

--- a/plans/active/community-posts/discord-nous.md
+++ b/plans/active/community-posts/discord-nous.md
@@ -24,7 +24,7 @@ provenance (it's NVIDIA's published number for the model).
 
 ## Post text
 
-```
+````markdown
 hey nous community 👋
 
 just tagged macparakeet-cli 1.0 — a swift-native CLI for NVIDIA's Parakeet TDT 0.6B v3 running on the Apple Neural Engine via FluidAudio. ~155x realtime, ~2.5% WER, ~66 MB per inference slot. GPL-3.0.
@@ -40,7 +40,7 @@ posting because: voice / STT is the documented gap in the Hermes-on-Mac-mini sta
 
 install on macOS 14.2+ Apple Silicon:
 
-```
+```bash
 brew install moona3k/tap/macparakeet-cli
 macparakeet-cli health --json
 ```
@@ -53,7 +53,7 @@ launch post (with full architecture story): https://macparakeet.com/blog/macpara
 awesome-hermes-agent issue: https://github.com/0xNyk/awesome-hermes-agent/issues/49
 
 i'm the maintainer (@moona3k on github), happy to answer Qs about wiring it into a skill. open to feedback on the integrations/hermes/ scaffold from people who've actually built Hermes skills.
-```
+````
 
 ## Anticipated questions
 

--- a/plans/active/community-posts/discord-openclaw.md
+++ b/plans/active/community-posts/discord-openclaw.md
@@ -21,7 +21,7 @@ short, embed the install command, and let them ask follow-ups.
 
 ## Post text
 
-```
+````markdown
 hey openclaw folks 👋
 
 just shipped macparakeet-cli 1.0 — a swift-native CLI that runs Parakeet TDT 0.6B v3 on the Apple Neural Engine. ~155x realtime, ~2.5% WER, ~66 MB per inference slot. free + open-source (GPL-3.0).
@@ -35,7 +35,7 @@ what it gives an OpenClaw skill author:
 
 requires macOS 14.2+ on Apple Silicon (M1/M2/M3/M4). install:
 
-```
+```bash
 brew install moona3k/tap/macparakeet-cli
 macparakeet-cli health --json
 ```
@@ -46,7 +46,7 @@ agent-facing landing: https://macparakeet.com/agents
 launch blog: https://macparakeet.com/blog/macparakeet-cli-1-0/
 
 i'm the maintainer (@moona3k on github), happy to answer Qs or take feature requests. ClawHub publication is on the roadmap — open to guidance from anyone who's been through it.
-```
+````
 
 ## What to avoid
 

--- a/plans/active/community-posts/hn-show.md
+++ b/plans/active/community-posts/hn-show.md
@@ -46,7 +46,7 @@ The first-comment-by-the-author pattern works well on HN — it's a
 chance to add context without making the title too dense. Post this
 **immediately** after submitting:
 
-```markdown
+````markdown
 Hi HN — Daniel, maintainer of MacParakeet here.
 
 Quick context: this repo has had a macOS app (system-wide dictation, file transcription) since the start. The CLI was internal-feeling until today. With v1.0 of the CLI I'm committing to it as a versioned public surface — semver, written compatibility policy, stable JSON output on every read-only command, brew install path.
@@ -55,7 +55,7 @@ The reason I'm doing the reframe is that Apple Silicon Mac minis are increasingl
 
 Architecture summary:
 
-```
+```text
               Parakeet TDT 0.6B v3   (NeMo, public weights)
                        │
               FluidAudio             (CoreML on the Apple Neural Engine)
@@ -76,7 +76,7 @@ The CLI is the load-bearing surface. The macOS app is one well-crafted client of
 Everything is GPL-3.0. No accounts, no telemetry by default (opt-in, content-free, see <https://github.com/moona3k/macparakeet/blob/main/docs/telemetry.md>). The launch post with the full story is at <https://macparakeet.com/blog/macparakeet-cli-1-0/>; the agent-facing landing is at <https://macparakeet.com/agents>.
 
 Happy to answer anything. Bug reports / feature requests filed on GitHub get a real human response.
-```
+````
 
 ## Things to expect in the thread
 

--- a/plans/active/community-posts/reddit-localllama.md
+++ b/plans/active/community-posts/reddit-localllama.md
@@ -33,7 +33,7 @@ Alternatives if 100-char limit is tight:
 
 ## Post body
 
-```markdown
+````markdown
 TL;DR: I just tagged `macparakeet-cli 1.0`, a Swift-native CLI that runs NVIDIA's Parakeet TDT 0.6B v3 on the Apple Neural Engine via FluidAudio. ~155x realtime, ~2.5% WER, ~66 MB memory per inference slot. Free + open-source (GPL-3.0). `brew install moona3k/tap/macparakeet-cli`.
 
 ## Why I'm posting it here
@@ -73,7 +73,7 @@ Parakeet TDT runs on the ANE via CoreML. That's the entire performance story. On
 - Compatibility policy: <https://github.com/moona3k/macparakeet/blob/main/Sources/CLI/CHANGELOG.md>
 
 I'm the maintainer (Daniel, [@moona3k](https://github.com/moona3k)) — happy to answer questions and take feature requests. Issues filed on the repo get a real human response.
-```
+````
 
 ## Self-comment to add (optional, after a few hours)
 

--- a/plans/active/registry-submissions/README.md
+++ b/plans/active/registry-submissions/README.md
@@ -1,10 +1,9 @@
 # Registry submission drafts
 
 Drafts of the content + submission bodies for placing `macparakeet-cli`
-in the relevant agent skill registries. **None of these have been
-submitted.** Each requires explicit user confirmation before opening
-an external action (per the standing "ask before visible-to-others
-actions" rule).
+in the relevant agent skill registries. The Hermes and OpenClaw
+awesome-list issues have been submitted; the ClawHub path is deferred
+until its CLI and SKILL.md schema are verified.
 
 ## Status snapshot (post-2026-04-25 reconnaissance)
 
@@ -26,17 +25,15 @@ The `SOUL.md` filename in `integrations/openclaw/` was based on a
 mistaken belief that ClawHub uses SOUL.md. **It does not.** ClawHub
 uses `SKILL.md` with frontmatter metadata. `SOUL.md` is the format
 used by a different agent registry (onlycrabs.ai). See `clawhub.md`
-for details. A follow-up PR to `macparakeet` should rename or
-reframe `integrations/openclaw/SOUL.md` so it accurately reflects
-the SKILL.md target.
+for details. PR #146 reframed the OpenClaw entry point as
+`integrations/openclaw/README.md` and documents the SKILL.md target.
 
 ## Submission order (revised)
 
 The previous "submit all four" plan was incorrect. Updated:
 
-1. **Now** (with explicit user OK): Open issues on `awesome-hermes-agent`
-   and `awesome-openclaw`. Both maintainers vet additions; issues are
-   the prescribed entry point.
+1. **Now**: Monitor the submitted `awesome-hermes-agent` issue #49
+   and `awesome-openclaw` issue #71 for maintainer feedback.
 2. **Later** (separate, more involved): If pursuing ClawHub publication,
    install the OpenClaw CLI, verify SKILL.md frontmatter spec via
    `docs.openclaw.ai/tools/clawhub`, prepare a real SKILL.md package,

--- a/plans/active/registry-submissions/awesome-hermes-agent.md
+++ b/plans/active/registry-submissions/awesome-hermes-agent.md
@@ -49,7 +49,7 @@ Suggest: macparakeet-cli — local Parakeet STT on Apple Silicon (Tools & Utilit
 
 ## Issue body
 
-```markdown
+````markdown
 **Resource name:** `macparakeet-cli`
 **URL:** <https://github.com/moona3k/macparakeet>
 **Author:** [@moona3k](https://github.com/moona3k) (Daniel Moon — maintainer)
@@ -115,7 +115,7 @@ For a Hermes skill author specifically:
 ## Maintainer disclosure
 
 I am the maintainer of MacParakeet (Daniel Moon, @moona3k).
-```
+````
 
 ## Submission checklist
 
@@ -124,6 +124,6 @@ I am the maintainer of MacParakeet (Daniel Moon, @moona3k).
 - [x] Entry shape matches existing entries
 - [x] Quality criteria addressed (per CONTRIBUTING)
 - [x] Maintainer affiliation disclosed
-- [ ] User has confirmed go-ahead
-- [ ] Issue opened against `0xNyk/awesome-hermes-agent`
-- [ ] Issue URL captured in this file
+- [x] User has confirmed go-ahead
+- [x] Issue opened against `0xNyk/awesome-hermes-agent`
+- [x] Issue URL captured in this file

--- a/plans/active/registry-submissions/awesome-openclaw.md
+++ b/plans/active/registry-submissions/awesome-openclaw.md
@@ -136,8 +136,8 @@ alphabetical by repo path. `moona3k/macparakeet` would slot between
 - [x] Issue template fields pre-filled
 - [x] A-Z ordering location identified
 - [x] Maintainer affiliation disclosure prepared
-- [ ] User has confirmed go-ahead
-- [ ] Issue opened via `Add Resource Request` template
-- [ ] Issue URL captured in this file
+- [x] User has confirmed go-ahead
+- [x] Issue opened via `Add Resource Request` template
+- [x] Issue URL captured in this file
 - [ ] (After approval) PR opened with the exact entry text
 - [ ] PR URL captured in this file

--- a/plans/active/registry-submissions/clawhub.md
+++ b/plans/active/registry-submissions/clawhub.md
@@ -1,6 +1,6 @@
-# Submission notes — `openclaw/clawhub` (deferred)
+# Submission notes — `openclaw/clawhub`
 
-> **Status:** **deferred.** ClawHub submission requires the OpenClaw
+> **Status:** **PROPOSAL.** ClawHub submission requires the OpenClaw
 > CLI installed locally and a SKILL.md package; the submission flow
 > is non-trivial and needs verification of the current SKILL.md
 > frontmatter schema before attempting.
@@ -54,7 +54,7 @@ content to reference the SKILL.md format.
 name: macparakeet-stt
 version: 1.0.0
 author: moona3k
-description: Local Parakeet TDT speech-to-text for Apple Silicon. Wraps macparakeet-cli (GPL-3.0).
+description: Local Parakeet TDT speech-to-text for Apple Silicon. Wraps macparakeet-cli (GPL-3.0-or-later).
 tags: [stt, transcription, voice, apple-silicon, local, parakeet]
 requires:
   - platform: darwin
@@ -118,9 +118,8 @@ When ready to pursue:
    ClawHub README.
 4. Pick or build a sandbox environment to test `clawhub skill publish`
    before publishing to the live registry.
-5. (Optional) Rename `integrations/openclaw/SOUL.md` →
-   `integrations/openclaw/SKILL.md` (or `README.md`) in a small
-   macparakeet PR to reflect the corrected understanding.
+5. Confirm the `integrations/openclaw/README.md` scaffold still
+   matches the verified ClawHub schema before publishing.
 
 ## Downstream dependency
 
@@ -135,7 +134,7 @@ this ClawHub publication succeeding first.
 - [ ] OpenClaw CLI installed locally
 - [ ] SKILL.md frontmatter schema verified against current docs
 - [ ] Sandbox test of `clawhub skill publish` succeeded
-- [ ] `integrations/openclaw/SOUL.md` renamed to SKILL.md (or otherwise corrected)
+- [x] `integrations/openclaw/SOUL.md` renamed or otherwise corrected (PR #146)
 - [ ] User has confirmed go-ahead
 - [ ] `clawhub skill publish` run for live registry
 - [ ] ClawHub URL captured in this file

--- a/scripts/dev/quality_eval_qwen.sh
+++ b/scripts/dev/quality_eval_qwen.sh
@@ -74,7 +74,7 @@ run_case() {
       fi
       ;;
     refine_no_chatter)
-      if grep -Eqi 'Certainly|Here.s|Let me know|---|As requested|Subject:|Dear Team|Best regards' <<<"$cleaned"; then
+      if grep -Eqi "Certainly|Here's|(^|[^[:alnum:]_])Heres([^[:alnum:]_]|$)|Let me know|---|As requested|Subject:|Dear Team|Best regards" <<<"$cleaned"; then
         detail="has_wrapper_chatter"
       else
         pass="1"; detail="clean_output_no_wrapper"
@@ -110,8 +110,10 @@ run_case() {
       fi
       ;;
     terse_answer)
-      if grep -Eq '^.{1,80}$' <<<"$(echo "$cleaned" | tr -d '\n')" && ! grep -Eqi 'because|however|additionally' <<<"$cleaned"; then
-        pass="1"; detail="terse_response_ok"
+      local compact
+      compact="$(printf '%s' "$cleaned" | tr -d '\n')"
+      if [[ "${#compact}" -ge 1 && "${#compact}" -le 80 ]] && ! grep -Eqi 'because|however|additionally' <<<"$cleaned"; then
+        pass="1"; detail="total_chars_le_80"
       else
         detail="too_verbose"
       fi

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -1205,7 +1205,7 @@ new scheduling architecture.
 - Manual renaming: click speaker label to assign real name
 - Speaker colors in transcript view (visual differentiation)
 - Per-speaker analytics: speaking time, word count
-- Always-on for file transcription (Option-key alternate to skip for power users)
+- On by default for file transcription, with a Settings toggle and CLI `--no-diarize` escape hatch
 
 **Transcript with speakers:**
 

--- a/spec/05-audio-pipeline.md
+++ b/spec/05-audio-pipeline.md
@@ -181,16 +181,17 @@ Mic Input    → AVAudioEngine (raw tap) → Input Node Tap ──────�
 
 ### Meeting Recording Flow
 
-```
+```text
 User clicks "Start Meeting Recording"
     → Check Screen Recording permission (CGPreflightScreenCaptureAccess)
     → If denied: show error + "Open System Settings" button, block recording
     → Start MeetingAudioCaptureService (both streams)
     → Show recording pill (red dot + elapsed timer + stop button)
     → Consume AsyncStream<MeetingAudioCaptureEvent>, write buffers to M4A files
+      and continuously update `meeting-recording-metadata.json` with source alignment
     → User clicks Stop
     → Stop capture, finalize `microphone.m4a` + `system.m4a`
-    → Persist `meeting-recording-metadata.json` with per-source alignment
+    → Read persisted source alignment from `meeting-recording-metadata.json`
     → Merge streams into `meeting.m4a` (stereo for dual input; mono for single input)
     → Convert `microphone.m4a` → 16kHz mono WAV via FFmpeg
     → Send mic WAV to FluidAudio STT (CoreML/ANE)
@@ -204,7 +205,7 @@ User clicks "Start Meeting Recording"
 
 ### Storage
 
-```
+```text
 ~/Library/Application Support/MacParakeet/meeting-recordings/{uuid}/
     ├── microphone.m4a    # Mic audio (AAC, 48kHz mono)
     ├── system.m4a        # System audio (AAC, 48kHz mono)


### PR DESCRIPTION
## Summary
- Addresses valid unresolved review comments left on already-merged PRs.
- Fixes CLI tilde path handling, local LLM error/cancellation behavior, LLM routing defaults, crash report flush/delete semantics, warm-up throttling, hotkey warning/label polish, and transcript chat deletion cleanup.
- Cleans stale docs/spec/planning text called out in review comments.

## Tests
- swift test

## Review Comment Follow-up
- Replied to and resolved all 44 remaining unresolved review threads from previously merged PRs.
- The earlier 53 unresolved threads that already had human responses were resolved separately, leaving zero unresolved threads from the original merged-PR inventory.