### PR TITLE
Fix AUDIT-003 meeting audio writer sendability

### DIFF
--- a/Sources/MacParakeetCore/Audio/MeetingAudioStorageWriter.swift
+++ b/Sources/MacParakeetCore/Audio/MeetingAudioStorageWriter.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import Foundation
+import os
 import OSLog
 
 /// AVAssetWriter's finish callback is @Sendable, but the object itself is
@@ -272,7 +273,7 @@ final class MeetingAudioStorageWriter {
 
         input?.markAsFinished()
         let finalizedWriter = FinalizedAVAssetWriter(writer)
-        writer.finishWriting {
+        finalizedWriter.writer.finishWriting {
             if let error = finalizedWriter.writer.error {
                 logger.error("meeting_audio_writer_finalize_failed error=\(error.localizedDescription, privacy: .public)")
             }

--- a/Sources/MacParakeetCore/Audio/MeetingAudioStorageWriter.swift
+++ b/Sources/MacParakeetCore/Audio/MeetingAudioStorageWriter.swift
@@ -2,9 +2,20 @@ import AVFoundation
 import Foundation
 import OSLog
 
-/// Owned and serialized by MeetingRecordingService. The AVFoundation writer
-/// objects it wraps are reference types that are not annotated Sendable.
-final class MeetingAudioStorageWriter: @unchecked Sendable {
+/// AVAssetWriter's finish callback is @Sendable, but the object itself is
+/// non-Sendable. This wrapper is limited to reading the writer's final error
+/// from AVFoundation's own completion callback after writes have stopped.
+private final class FinalizedAVAssetWriter: @unchecked Sendable {
+    let writer: AVAssetWriter
+
+    init(_ writer: AVAssetWriter) {
+        self.writer = writer
+    }
+}
+
+/// Non-Sendable audio sink owned and serialized by MeetingRecordingService.
+/// Its AVFoundation writer/converter objects are mutable reference types.
+final class MeetingAudioStorageWriter {
     struct SourceWriteMetrics: Sendable, Equatable {
         let writtenFrameCount: Int64
         let sampleRate: Double
@@ -82,16 +93,32 @@ final class MeetingAudioStorageWriter: @unchecked Sendable {
         }
     }
 
-    func finalize() async {
-        await finish(writer: microphoneWriter, input: microphoneInput)
-        await finish(writer: systemWriter, input: systemInput)
+    func finalize(completion: @escaping @Sendable () -> Void) {
+        let microphoneWriter = self.microphoneWriter
+        let microphoneInput = self.microphoneInput
+        let systemWriter = self.systemWriter
+        let systemInput = self.systemInput
+        let logger = self.logger
 
-        microphoneWriter = nil
-        microphoneInput = nil
-        systemWriter = nil
-        systemInput = nil
-        microphoneConverter = nil
-        systemConverter = nil
+        self.microphoneWriter = nil
+        self.microphoneInput = nil
+        self.systemWriter = nil
+        self.systemInput = nil
+        self.microphoneConverter = nil
+        self.systemConverter = nil
+
+        let remainingFinishes = OSAllocatedUnfairLock(initialState: 2)
+        let completeOne: @Sendable () -> Void = {
+            let shouldComplete = remainingFinishes.withLock { remaining in
+                remaining -= 1
+                return remaining == 0
+            }
+            if shouldComplete {
+                completion()
+            }
+        }
+        Self.finish(writer: microphoneWriter, input: microphoneInput, logger: logger, completion: completeOne)
+        Self.finish(writer: systemWriter, input: systemInput, logger: logger, completion: completeOne)
     }
 
     func metrics(for source: AudioSource) -> SourceWriteMetrics {
@@ -228,19 +255,28 @@ final class MeetingAudioStorageWriter: @unchecked Sendable {
         return (writer, input)
     }
 
-    private func finish(writer: AVAssetWriter?, input: AVAssetWriterInput?) async {
-        guard let writer else { return }
-        guard writer.status == .writing else { return }
-
-        input?.markAsFinished()
-        await withCheckedContinuation { continuation in
-            writer.finishWriting {
-                continuation.resume()
-            }
+    private static func finish(
+        writer: AVAssetWriter?,
+        input: AVAssetWriterInput?,
+        logger: Logger,
+        completion: @escaping @Sendable () -> Void
+    ) {
+        guard let writer else {
+            completion()
+            return
+        }
+        guard writer.status == .writing else {
+            completion()
+            return
         }
 
-        if let error = writer.error {
-            logger.error("meeting_audio_writer_finalize_failed error=\(error.localizedDescription, privacy: .public)")
+        input?.markAsFinished()
+        let finalizedWriter = FinalizedAVAssetWriter(writer)
+        writer.finishWriting {
+            if let error = finalizedWriter.writer.error {
+                logger.error("meeting_audio_writer_finalize_failed error=\(error.localizedDescription, privacy: .public)")
+            }
+            completion()
         }
     }
 }

--- a/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
@@ -213,7 +213,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             )
         } catch {
             self.writer = nil
-            await writer.finalize()
+            await finalizeWriter(writer)
             cleanupState()
             try? fileManager.removeItem(at: folderURL)
             throw error
@@ -261,7 +261,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             await liveChunkTranscriber.finishSession()
             let writer = self.writer
             self.writer = nil
-            await writer?.finalize()
+            await finalizeWriter(writer)
             cleanupState()
             try? lockFileStore.delete(folderURL: folderURL)
             try? fileManager.removeItem(at: folderURL)
@@ -293,7 +293,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         processingTask = nil
         let finalizedWriter = writer
         writer = nil
-        await finalizedWriter?.finalize()
+        await finalizeWriter(finalizedWriter)
         let writerMetrics = [
             AudioSource.microphone: finalizedWriter?.metrics(for: .microphone),
             AudioSource.system: finalizedWriter?.metrics(for: .system),
@@ -423,11 +423,20 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         await liveChunkTranscriber.finishSession()
         let finalizedWriter = writer
         writer = nil
-        await finalizedWriter?.finalize()
+        await finalizeWriter(finalizedWriter)
         try? lockFileStore.delete(folderURL: session.folderURL)
         cleanupState()
         try? fileManager.removeItem(at: session.folderURL)
         logger.info("Meeting recording cancelled: \(session.id.uuidString, privacy: .public)")
+    }
+
+    private func finalizeWriter(_ writer: MeetingAudioStorageWriter?) async {
+        guard let writer else { return }
+        await withCheckedContinuation { continuation in
+            writer.finalize {
+                continuation.resume()
+            }
+        }
     }
 
     private func handleCaptureEvent(_ event: MeetingAudioCaptureEvent) async {

--- a/Tests/MacParakeetTests/Audio/MeetingAudioStorageWriterTests.swift
+++ b/Tests/MacParakeetTests/Audio/MeetingAudioStorageWriterTests.swift
@@ -19,7 +19,7 @@ final class MeetingAudioStorageWriterTests: XCTestCase {
         let writer = try MeetingAudioStorageWriter(folderURL: tempFolder)
         try writeSeconds(5, source: .microphone, writer: writer)
 
-        await writer.finalize()
+        await finalize(writer)
 
         let duration = try await audioDuration(writer.microphoneAudioURL)
         XCTAssertEqual(duration, 5.0, accuracy: 0.35)
@@ -30,7 +30,7 @@ final class MeetingAudioStorageWriterTests: XCTestCase {
         try writeSeconds(2, source: .microphone, writer: writer)
         try writeSeconds(2, source: .system, writer: writer)
 
-        await writer.finalize()
+        await finalize(writer)
 
         XCTAssertGreaterThan(try fileSize(writer.microphoneAudioURL), 0)
         XCTAssertGreaterThan(try fileSize(writer.systemAudioURL), 0)
@@ -44,7 +44,7 @@ final class MeetingAudioStorageWriterTests: XCTestCase {
         let writer = try MeetingAudioStorageWriter(folderURL: tempFolder)
         try writeSeconds(10, source: .microphone, writer: writer)
 
-        await writer.finalize()
+        await finalize(writer)
 
         let fragments = try fragmentBoundaryOffsets(in: writer.microphoneAudioURL)
         XCTAssertGreaterThanOrEqual(fragments.count, 1)
@@ -68,6 +68,14 @@ final class MeetingAudioStorageWriterTests: XCTestCase {
                 frequency: 220 + Double(chunkIndex * 10)
             )
             try writer.write(buffer, source: source)
+        }
+    }
+
+    private func finalize(_ writer: MeetingAudioStorageWriter) async {
+        await withCheckedContinuation { continuation in
+            writer.finalize {
+                continuation.resume()
+            }
         }
     }
 

--- a/Tests/MacParakeetTests/Services/MeetingRecordingCrashRecoveryTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecordingCrashRecoveryTests.swift
@@ -46,7 +46,15 @@ final class MeetingRecordingCrashRecoveryTests: XCTestCase {
             try writer.write(buffer, source: .microphone)
             try await Task.sleep(for: .seconds(1))
         }
-        await writer.finalize()
+        await finalize(writer)
+    }
+
+    private func finalize(_ writer: MeetingAudioStorageWriter) async {
+        await withCheckedContinuation { continuation in
+            writer.finalize {
+                continuation.resume()
+            }
+        }
     }
 
     private func waitForFileToGrow(_ url: URL) async throws {

--- a/docs/audits/2026-04-26-codebase-audit.md
+++ b/docs/audits/2026-04-26-codebase-audit.md
@@ -9,9 +9,9 @@
 | | Count |
 |---|---:|
 | Total findings (P0 / P1 / P2) | 70 |
-| FIXED | 27 |
+| FIXED | 28 |
 | REFUTED on verification | 5 |
-| DEFERRED with reason | 38 |
+| DEFERRED with reason | 37 |
 
 ---
 
@@ -62,7 +62,7 @@ Status legend: **FIXED** (commit referenced) · **REFUTED** (with reason) ·
 | ID | Title | Status | Note |
 |---|---|---|---|
 | AUDIT-001 | STTScheduler continuation lifecycle | DEFERRED | Pass 2 narrowed: `STTScheduler` is `actor`; sub-claims (a) and (b) prevented by isolation. Only `cancelAndDrainRunningJobs` race remains, severity P2. Watch production telemetry. |
-| AUDIT-003 | `@unchecked Sendable` on Core Audio paths | DEFERRED | VERIFIED but big sendability refactor of `MeetingAudioStorageWriter` deserves its own PR + risk window. |
+| AUDIT-003 | `@unchecked Sendable` on Core Audio paths | FIXED | Follow-up PR removes the blanket `@unchecked Sendable` from `MeetingAudioStorageWriter`. The writer is non-Sendable and remains serialized by `MeetingRecordingService`; only the AVFoundation finish callback boundary keeps a narrow unchecked wrapper. |
 | AUDIT-005 | FFmpeg conversion + mix temp files leak on timeout / cancel | FIXED | `28ceba2c` (#149). SIGTERM-zombie sub-claim refuted (FFmpeg cleans on SIGTERM); `outputURL` leak on Swift-timeout path was the real concern. |
 | AUDIT-006 | `SystemAudioTap` watchdog only logs on silent buffer timeout | FIXED | `a13717cb` + review polish in `43e97090`. Adds 2s first-buffer budget + 1s repeating heartbeat (5s mid-session stall threshold) wired through the existing `MeetingAudioCaptureEvent.error` channel. |
 | AUDIT-014 | `ObjCExceptionBridge` "wired nowhere" | REFUTED | Pass-1 grep was too narrow. `catchingObjCException` is actually used 11 times across `AudioRecorder.swift` + `MicrophoneCapture.swift`. |
@@ -250,19 +250,17 @@ The deferred items, in priority order:
 1. **Hotkey state-machine fixes** (AUDIT-046 / 047 / 049 / 050). Real bugs;
    the only blocker is regression risk on a delicate area that needs Mac
    runtime verification before/after with the dictation hotkey active.
-2. **`MeetingAudioStorageWriter` actor refactor** (AUDIT-003). Big
-   sendability change; deserves its own PR + risk window.
-3. **Notes durability — scene-phase persistence + lock-file rotation flush**
+2. **Notes durability — scene-phase persistence + lock-file rotation flush**
    (AUDIT-002 follow-up). The narrowed crash-window concern remains.
-4. **Test-quality cleanup** (AUDIT-059 / 060 / 061 / 062 / 063). 92 hardcoded
+3. **Test-quality cleanup** (AUDIT-059 / 060 / 061 / 062 / 063). 92 hardcoded
    sleeps, missing VM tests, hardcoded `/tmp` paths, wall-clock polling.
-5. **Dist-script hardening** (AUDIT-055 / 056 / 058 / 070). Appcast cache-
+4. **Dist-script hardening** (AUDIT-055 / 056 / 058 / 070). Appcast cache-
    bust validation, notarytool SIGBUS retry, SIGN_IDENTITY env-var,
    SHASUMS pinning.
-6. **View / VM decomposition** (AUDIT-016 / 017). `TranscriptResultView`
+5. **View / VM decomposition** (AUDIT-016 / 017). `TranscriptResultView`
    2,475 lines and `SettingsViewModel` 1,108 lines — refactor sprint.
-7. **Accessibility + i18n** (AUDIT-067 / 068). Multi-day work.
-8. **Telemetry bucketing** (AUDIT-022). Reduces fingerprintability on small
+6. **Accessibility + i18n** (AUDIT-067 / 068). Multi-day work.
+7. **Telemetry bucketing** (AUDIT-022). Reduces fingerprintability on small
    cohorts.
 
 ---
@@ -279,3 +277,6 @@ The deferred items, in priority order:
 - **2026-04-26 Sprint 2** — 13 fixes shipped via PR #154.
 - **2026-04-26 AUDIT-069 follow-up** — CI hygiene: SwiftPM cache,
   per-step timeouts, and uploaded CI logs.
+- **2026-04-26 AUDIT-003 follow-up** — `MeetingAudioStorageWriter` no longer
+  declares blanket `@unchecked Sendable`; finalization uses a narrow
+  AVFoundation callback bridge while writer access remains actor-owned.


### PR DESCRIPTION
## What changed

- Removed the blanket `@unchecked Sendable` conformance from `MeetingAudioStorageWriter`.
- Kept writer access serialized by `MeetingRecordingService`, avoiding a new writer actor and per-buffer actor hops.
- Reworked finalization so the non-Sendable writer no longer crosses actor isolation through an async instance method.
- Updated focused writer/recording tests and marked AUDIT-003 fixed in the audit doc.

## Validation

- `swift build -Xswiftc -warn-concurrency`
- `swift build -Xswiftc -swift-version -Xswiftc 6`
- `swift test --filter 'MeetingAudioStorageWriterTests|MeetingRecordingServiceTests|MeetingRecordingCrashRecoveryTests'`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of audio finalization during meeting recordings by enhancing microphone and system audio capture completion handling and error tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->