### PR TITLE
Add deterministic meeting CLI primitives

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -77,6 +77,25 @@ ArgumentParser's plain-text stderr path with exit code `2`. Downstream
 agents that branch on `errorType` should also handle the parse-error case
 by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
+## [1.3.0] -- 2026-04-26
+
+### Added
+
+- `meetings` command namespace for deterministic, local meeting objects:
+  `meetings list`, `meetings show`, `meetings transcript`,
+  `meetings notes get|set|append|clear`, and `meetings export`.
+  These commands expose meeting recordings without requiring any LLM provider:
+  metadata, notes, transcript text, timestamp formats, and Markdown/JSON
+  exports are all local database reads/writes.
+
+### Fixed
+
+- `prompts run` now renders `{{userNotes}}` and `{{transcript}}` with the same
+  prompt assembly path used by the GUI, and stores `userNotesSnapshot` on saved
+  prompt results. This restores GUI/CLI parity for notes-steered meeting
+  prompts while keeping LLM invocation explicitly under `prompts`.
+- Meeting retranscription now preserves durable user-authored meeting notes.
+
 ## [1.2.0] -- 2026-04-26
 
 ### Added

--- a/Sources/CLI/Commands/CLIHelpers.swift
+++ b/Sources/CLI/Commands/CLIHelpers.swift
@@ -93,16 +93,15 @@ func findMeeting(idOrName: String, repo: TranscriptionRepository) throws -> Tran
         return transcription
     }
 
-    let meetings = try repo.fetchBySourceType(.meeting)
     let lowered = trimmed.lowercased()
 
-    let prefixMatches = meetings.filter { $0.id.uuidString.lowercased().hasPrefix(lowered) }
+    let prefixMatches = try repo.fetchBySourceType(.meeting, idPrefix: lowered)
     if prefixMatches.count == 1 { return prefixMatches[0] }
     if prefixMatches.count > 1 {
         throw CLILookupError.ambiguous("Multiple meetings match '\(trimmed)'. Be more specific.")
     }
 
-    let nameMatches = meetings.filter { $0.fileName.lowercased() == lowered }
+    let nameMatches = try repo.fetchBySourceType(.meeting, fileName: trimmed)
     if nameMatches.count == 1 { return nameMatches[0] }
     if nameMatches.count > 1 {
         throw CLILookupError.ambiguous("Multiple meetings named '\(trimmed)'. Use ID instead.")

--- a/Sources/CLI/Commands/CLIHelpers.swift
+++ b/Sources/CLI/Commands/CLIHelpers.swift
@@ -54,26 +54,61 @@ enum CLIInputError: Error, LocalizedError {
 // MARK: - Transcription Lookup (shared by export, delete, favorite, unfavorite)
 
 func findTranscription(id: String, repo: TranscriptionRepository) throws -> Transcription {
-    guard !id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+    let trimmed = id.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
         throw CLILookupError.emptyID
     }
 
     // Try exact UUID first
-    if let uuid = UUID(uuidString: id), let t = try repo.fetch(id: uuid) {
+    if let uuid = UUID(uuidString: trimmed), let t = try repo.fetch(id: uuid) {
         return t
     }
 
     // Prefix match
     let all = try repo.fetchAll()
-    let matches = all.filter { $0.id.uuidString.lowercased().hasPrefix(id.lowercased()) }
+    let lowered = trimmed.lowercased()
+    let matches = all.filter { $0.id.uuidString.lowercased().hasPrefix(lowered) }
 
-    guard let match = matches.first else {
-        throw CLILookupError.notFound("No transcription matching '\(id)'")
+    if matches.count == 1 { return matches[0] }
+    if matches.count > 1 {
+        throw CLILookupError.ambiguous("Multiple transcriptions match '\(trimmed)'. Be more specific.")
     }
-    guard matches.count == 1 else {
-        throw CLILookupError.ambiguous("Multiple transcriptions match '\(id)'. Be more specific.")
+
+    let nameMatches = all.filter { $0.fileName.lowercased() == lowered }
+    if nameMatches.count == 1 { return nameMatches[0] }
+    if nameMatches.count > 1 {
+        throw CLILookupError.ambiguous("Multiple transcriptions named '\(trimmed)'. Use ID instead.")
     }
-    return match
+
+    throw CLILookupError.notFound("No transcription matching '\(trimmed)'")
+}
+
+func findMeeting(idOrName: String, repo: TranscriptionRepository) throws -> Transcription {
+    let trimmed = idOrName.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { throw CLILookupError.emptyID }
+
+    if let uuid = UUID(uuidString: trimmed),
+       let transcription = try repo.fetch(id: uuid),
+       transcription.sourceType == .meeting {
+        return transcription
+    }
+
+    let meetings = try repo.fetchBySourceType(.meeting)
+    let lowered = trimmed.lowercased()
+
+    let prefixMatches = meetings.filter { $0.id.uuidString.lowercased().hasPrefix(lowered) }
+    if prefixMatches.count == 1 { return prefixMatches[0] }
+    if prefixMatches.count > 1 {
+        throw CLILookupError.ambiguous("Multiple meetings match '\(trimmed)'. Be more specific.")
+    }
+
+    let nameMatches = meetings.filter { $0.fileName.lowercased() == lowered }
+    if nameMatches.count == 1 { return nameMatches[0] }
+    if nameMatches.count > 1 {
+        throw CLILookupError.ambiguous("Multiple meetings named '\(trimmed)'. Use ID instead.")
+    }
+
+    throw CLILookupError.notFound("No meeting matching '\(trimmed)'")
 }
 
 // MARK: - Dictation Lookup

--- a/Sources/CLI/Commands/ExportCommand.swift
+++ b/Sources/CLI/Commands/ExportCommand.swift
@@ -76,15 +76,9 @@ struct ExportCommand: AsyncParsableCommand {
         case .markdown:
             return await exportService.formatMarkdown(transcription: transcription)
         case .srt:
-            if let words = transcription.wordTimestamps, !words.isEmpty {
-                return await exportService.formatSRT(words: words, speakers: transcription.speakers)
-            }
-            return transcription.cleanTranscript ?? transcription.rawTranscript ?? ""
+            return await exportService.formatSRT(transcription: transcription)
         case .vtt:
-            if let words = transcription.wordTimestamps, !words.isEmpty {
-                return await exportService.formatVTT(words: words, speakers: transcription.speakers)
-            }
-            return transcription.cleanTranscript ?? transcription.rawTranscript ?? ""
+            return await exportService.formatVTT(transcription: transcription)
         case .json:
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]

--- a/Sources/CLI/Commands/MeetingsCommand.swift
+++ b/Sources/CLI/Commands/MeetingsCommand.swift
@@ -572,10 +572,7 @@ private func sanitizedFileName(_ value: String) -> String {
 }
 
 private func formatDate(_ date: Date) -> String {
-    let formatter = DateFormatter()
-    formatter.dateStyle = .short
-    formatter.timeStyle = .short
-    return formatter.string(from: date)
+    date.formatted(date: .numeric, time: .shortened)
 }
 
 private func formatDuration(_ durationMs: Int) -> String {

--- a/Sources/CLI/Commands/MeetingsCommand.swift
+++ b/Sources/CLI/Commands/MeetingsCommand.swift
@@ -117,17 +117,9 @@ struct MeetingsCommand: AsyncParsableCommand {
                 case .json:
                     try printJSON(MeetingTranscriptRecord(transcription))
                 case .srt:
-                    if let words = transcription.wordTimestamps, !words.isEmpty {
-                        print(await exportService.formatSRT(words: words, speakers: transcription.speakers))
-                    } else {
-                        print(preferredTranscriptText(transcription))
-                    }
+                    print(await exportService.formatSRT(transcription: transcription))
                 case .vtt:
-                    if let words = transcription.wordTimestamps, !words.isEmpty {
-                        print(await exportService.formatVTT(words: words, speakers: transcription.speakers))
-                    } else {
-                        print(preferredTranscriptText(transcription))
-                    }
+                    print(await exportService.formatVTT(transcription: transcription))
                 }
             }
         }

--- a/Sources/CLI/Commands/MeetingsCommand.swift
+++ b/Sources/CLI/Commands/MeetingsCommand.swift
@@ -1,0 +1,590 @@
+import ArgumentParser
+import Foundation
+import MacParakeetCore
+
+struct MeetingsCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "meetings",
+        abstract: "Inspect and manage local meeting recordings.",
+        subcommands: [
+            ListSubcommand.self,
+            ShowSubcommand.self,
+            TranscriptSubcommand.self,
+            NotesSubcommand.self,
+            ExportSubcommand.self,
+        ]
+    )
+
+    struct ListSubcommand: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "list",
+            abstract: "List recent meeting recordings."
+        )
+
+        @Option(name: .shortAndLong, help: "Maximum number of meetings.")
+        var limit: Int = 20
+
+        @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+        var json: Bool = false
+
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
+        func validate() throws {
+            guard limit >= 0 else { throw ValidationError("--limit must be >= 0.") }
+        }
+
+        func run() async throws {
+            try await emitJSONOrRethrow(json: json) {
+                let repo = try makeTranscriptionRepository(database: database)
+                let meetings = try repo.fetchBySourceType(.meeting, limit: limit)
+                    .map(MeetingListItem.init)
+
+                if json {
+                    try printJSON(meetings)
+                    return
+                }
+
+                guard !meetings.isEmpty else {
+                    print("No meetings found.")
+                    return
+                }
+
+                for meeting in meetings {
+                    let duration = meeting.durationMs.map(formatDuration) ?? "--"
+                    let notes = meeting.hasNotes ? "notes" : "no notes"
+                    print("[\(formatDate(meeting.createdAt))] \(meeting.title) (\(duration)) [\(meeting.status)] [\(notes)]  (\(meeting.shortID))")
+                }
+            }
+        }
+    }
+
+    struct ShowSubcommand: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "show",
+            abstract: "Show a local meeting object."
+        )
+
+        @Argument(help: "Meeting UUID, UUID prefix, or exact title.")
+        var meeting: String
+
+        @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+        var json: Bool = false
+
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
+        func run() async throws {
+            try await emitJSONOrRethrow(json: json) {
+                let repo = try makeTranscriptionRepository(database: database)
+                let transcription = try findMeeting(idOrName: meeting, repo: repo)
+                let record = MeetingRecord(transcription)
+
+                if json {
+                    try printJSON(record)
+                    return
+                }
+
+                printMeetingRecord(record)
+            }
+        }
+    }
+
+    struct TranscriptSubcommand: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "transcript",
+            abstract: "Print a meeting transcript."
+        )
+
+        @Argument(help: "Meeting UUID, UUID prefix, or exact title.")
+        var meeting: String
+
+        @Option(name: .shortAndLong, help: "Output format: text, json, srt, vtt.")
+        var format: MeetingTranscriptFormat = .text
+
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
+        func run() async throws {
+            try await emitJSONOrRethrow(json: format == .json) {
+                let repo = try makeTranscriptionRepository(database: database)
+                let transcription = try findMeeting(idOrName: meeting, repo: repo)
+                let exportService = await ExportService()
+
+                switch format {
+                case .text:
+                    print(preferredTranscriptText(transcription))
+                case .json:
+                    try printJSON(MeetingTranscriptRecord(transcription))
+                case .srt:
+                    if let words = transcription.wordTimestamps, !words.isEmpty {
+                        print(await exportService.formatSRT(words: words, speakers: transcription.speakers))
+                    } else {
+                        print(preferredTranscriptText(transcription))
+                    }
+                case .vtt:
+                    if let words = transcription.wordTimestamps, !words.isEmpty {
+                        print(await exportService.formatVTT(words: words, speakers: transcription.speakers))
+                    } else {
+                        print(preferredTranscriptText(transcription))
+                    }
+                }
+            }
+        }
+    }
+
+    struct NotesSubcommand: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "notes",
+            abstract: "Read or update local meeting notes.",
+            subcommands: [
+                GetSubcommand.self,
+                SetSubcommand.self,
+                AppendSubcommand.self,
+                ClearSubcommand.self,
+            ]
+        )
+
+        struct GetSubcommand: AsyncParsableCommand {
+            static let configuration = CommandConfiguration(commandName: "get")
+
+            @Argument(help: "Meeting UUID, UUID prefix, or exact title.")
+            var meeting: String
+
+            @Flag(name: .long, help: "Emit JSON instead of plain text.")
+            var json: Bool = false
+
+            @Option(help: "Path to SQLite database file (defaults to the app database).")
+            var database: String?
+
+            func run() async throws {
+                try await emitJSONOrRethrow(json: json) {
+                    let repo = try makeTranscriptionRepository(database: database)
+                    let transcription = try findMeeting(idOrName: meeting, repo: repo)
+                    let envelope = MeetingNotesRecord(transcription)
+
+                    if json {
+                        try printJSON(envelope)
+                    } else {
+                        print(envelope.notes ?? "")
+                    }
+                }
+            }
+        }
+
+        struct SetSubcommand: AsyncParsableCommand {
+            static let configuration = CommandConfiguration(commandName: "set")
+
+            @Argument(help: "Meeting UUID, UUID prefix, or exact title.")
+            var meeting: String
+
+            @Option(name: .long, help: "Notes text to store.")
+            var text: String?
+
+            @Flag(name: .long, help: "Read notes text from stdin.")
+            var stdin: Bool = false
+
+            @Flag(name: .long, help: "Emit the updated notes object as JSON.")
+            var json: Bool = false
+
+            @Option(help: "Path to SQLite database file (defaults to the app database).")
+            var database: String?
+
+            func validate() throws {
+                if text != nil && stdin {
+                    throw ValidationError("Use either --text or --stdin, not both.")
+                }
+                if text == nil && !stdin {
+                    throw ValidationError("Pass --text or --stdin.")
+                }
+            }
+
+            func run() async throws {
+                try await emitJSONOrRethrow(json: json) {
+                    let repo = try makeTranscriptionRepository(database: database)
+                    let transcription = try findMeeting(idOrName: meeting, repo: repo)
+                    let notes = try notesInput(text: text, stdin: stdin)
+                    try repo.updateUserNotes(id: transcription.id, userNotes: normalizedNotes(notes))
+                    let updated = try repo.fetch(id: transcription.id) ?? transcription
+                    try emitNotesUpdate(MeetingNotesRecord(updated), json: json)
+                }
+            }
+        }
+
+        struct AppendSubcommand: AsyncParsableCommand {
+            static let configuration = CommandConfiguration(commandName: "append")
+
+            @Argument(help: "Meeting UUID, UUID prefix, or exact title.")
+            var meeting: String
+
+            @Option(name: .long, help: "Notes text to append.")
+            var text: String?
+
+            @Flag(name: .long, help: "Read notes text from stdin.")
+            var stdin: Bool = false
+
+            @Flag(name: .long, help: "Emit the updated notes object as JSON.")
+            var json: Bool = false
+
+            @Option(help: "Path to SQLite database file (defaults to the app database).")
+            var database: String?
+
+            func validate() throws {
+                if text != nil && stdin {
+                    throw ValidationError("Use either --text or --stdin, not both.")
+                }
+                if text == nil && !stdin {
+                    throw ValidationError("Pass --text or --stdin.")
+                }
+            }
+
+            func run() async throws {
+                try await emitJSONOrRethrow(json: json) {
+                    let repo = try makeTranscriptionRepository(database: database)
+                    let transcription = try findMeeting(idOrName: meeting, repo: repo)
+                    let addition = try notesInput(text: text, stdin: stdin)
+                    let combined = appendedNotes(existing: transcription.userNotes, addition: addition)
+                    try repo.updateUserNotes(id: transcription.id, userNotes: normalizedNotes(combined))
+                    let updated = try repo.fetch(id: transcription.id) ?? transcription
+                    try emitNotesUpdate(MeetingNotesRecord(updated), json: json)
+                }
+            }
+        }
+
+        struct ClearSubcommand: AsyncParsableCommand {
+            static let configuration = CommandConfiguration(commandName: "clear")
+
+            @Argument(help: "Meeting UUID, UUID prefix, or exact title.")
+            var meeting: String
+
+            @Flag(name: .long, help: "Emit the updated notes object as JSON.")
+            var json: Bool = false
+
+            @Option(help: "Path to SQLite database file (defaults to the app database).")
+            var database: String?
+
+            func run() async throws {
+                try await emitJSONOrRethrow(json: json) {
+                    let repo = try makeTranscriptionRepository(database: database)
+                    let transcription = try findMeeting(idOrName: meeting, repo: repo)
+                    try repo.updateUserNotes(id: transcription.id, userNotes: nil)
+                    let updated = try repo.fetch(id: transcription.id) ?? transcription
+                    try emitNotesUpdate(MeetingNotesRecord(updated), json: json)
+                }
+            }
+        }
+    }
+
+    struct ExportSubcommand: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "export",
+            abstract: "Export a deterministic local meeting artifact."
+        )
+
+        @Argument(help: "Meeting UUID, UUID prefix, or exact title.")
+        var meeting: String
+
+        @Option(name: .shortAndLong, help: "Output format: md, json.")
+        var format: MeetingExportFormat = .md
+
+        @Option(name: .shortAndLong, help: "Output file path (defaults to current directory with auto-generated name).")
+        var output: String?
+
+        @Flag(help: "Print to stdout instead of writing a file.")
+        var stdout: Bool = false
+
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
+        func run() async throws {
+            try await emitJSONOrRethrow(json: stdout && format == .json) {
+                let repo = try makeTranscriptionRepository(database: database)
+                let transcription = try findMeeting(idOrName: meeting, repo: repo)
+                let content = try exportContent(for: transcription, format: format)
+
+                if stdout {
+                    print(content)
+                    return
+                }
+
+                let outputURL = resolvedOutputURL(output, transcription: transcription, fileExtension: format.fileExtension)
+                try FileManager.default.createDirectory(
+                    at: outputURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try content.write(to: outputURL, atomically: true, encoding: .utf8)
+                print("Exported to \(outputURL.path)")
+            }
+        }
+    }
+}
+
+enum MeetingTranscriptFormat: String, ExpressibleByArgument {
+    case text
+    case json
+    case srt
+    case vtt
+}
+
+enum MeetingExportFormat: String, ExpressibleByArgument {
+    case md
+    case json
+
+    var fileExtension: String { rawValue }
+}
+
+private struct MeetingListItem: Encodable {
+    let id: UUID
+    let shortID: String
+    let title: String
+    let createdAt: Date
+    let updatedAt: Date
+    let durationMs: Int?
+    let status: Transcription.TranscriptionStatus
+    let isFavorite: Bool
+    let hasNotes: Bool
+    let notesPreview: String?
+    let hasTranscript: Bool
+    let transcriptPreview: String?
+
+    init(_ transcription: Transcription) {
+        id = transcription.id
+        shortID = String(transcription.id.uuidString.prefix(8))
+        title = transcription.fileName
+        createdAt = transcription.createdAt
+        updatedAt = transcription.updatedAt
+        durationMs = transcription.durationMs
+        status = transcription.status
+        isFavorite = transcription.isFavorite
+        hasNotes = normalizedNotes(transcription.userNotes) != nil
+        notesPreview = preview(transcription.userNotes)
+        let transcript = preferredTranscriptText(transcription)
+        hasTranscript = !transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        transcriptPreview = preview(transcript)
+    }
+}
+
+private struct MeetingRecord: Encodable {
+    let id: UUID
+    let shortID: String
+    let title: String
+    let createdAt: Date
+    let updatedAt: Date
+    let durationMs: Int?
+    let status: Transcription.TranscriptionStatus
+    let isFavorite: Bool
+    let filePath: String?
+    let recoveredFromCrash: Bool
+    let isTranscriptEdited: Bool
+    let notes: String?
+    let rawTranscript: String?
+    let cleanTranscript: String?
+    let transcript: String
+    let wordTimestamps: [WordTimestamp]?
+    let speakerCount: Int?
+    let speakers: [SpeakerInfo]?
+    let diarizationSegments: [DiarizationSegmentRecord]?
+
+    init(_ transcription: Transcription) {
+        id = transcription.id
+        shortID = String(transcription.id.uuidString.prefix(8))
+        title = transcription.fileName
+        createdAt = transcription.createdAt
+        updatedAt = transcription.updatedAt
+        durationMs = transcription.durationMs
+        status = transcription.status
+        isFavorite = transcription.isFavorite
+        filePath = transcription.filePath
+        recoveredFromCrash = transcription.recoveredFromCrash
+        isTranscriptEdited = transcription.isTranscriptEdited
+        notes = transcription.userNotes
+        rawTranscript = transcription.rawTranscript
+        cleanTranscript = transcription.cleanTranscript
+        transcript = preferredTranscriptText(transcription)
+        wordTimestamps = transcription.wordTimestamps
+        speakerCount = transcription.speakerCount
+        speakers = transcription.speakers
+        diarizationSegments = transcription.diarizationSegments
+    }
+}
+
+private struct MeetingTranscriptRecord: Encodable {
+    let id: UUID
+    let title: String
+    let rawTranscript: String?
+    let cleanTranscript: String?
+    let transcript: String
+    let wordTimestamps: [WordTimestamp]?
+    let speakers: [SpeakerInfo]?
+
+    init(_ transcription: Transcription) {
+        id = transcription.id
+        title = transcription.fileName
+        rawTranscript = transcription.rawTranscript
+        cleanTranscript = transcription.cleanTranscript
+        transcript = preferredTranscriptText(transcription)
+        wordTimestamps = transcription.wordTimestamps
+        speakers = transcription.speakers
+    }
+}
+
+private struct MeetingNotesRecord: Encodable {
+    let id: UUID
+    let title: String
+    let notes: String?
+    let hasNotes: Bool
+    let updatedAt: Date
+
+    init(_ transcription: Transcription) {
+        id = transcription.id
+        title = transcription.fileName
+        notes = transcription.userNotes
+        hasNotes = normalizedNotes(transcription.userNotes) != nil
+        updatedAt = transcription.updatedAt
+    }
+}
+
+private func makeTranscriptionRepository(database: String?) throws -> TranscriptionRepository {
+    try AppPaths.ensureDirectories()
+    let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
+    return TranscriptionRepository(dbQueue: dbManager.dbQueue)
+}
+
+private func preferredTranscriptText(_ transcription: Transcription) -> String {
+    transcription.cleanTranscript ?? transcription.rawTranscript ?? ""
+}
+
+private func normalizedNotes(_ value: String?) -> String? {
+    guard let value else { return nil }
+    return value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : value
+}
+
+private func preview(_ value: String?, maxLength: Int = 120) -> String? {
+    guard let value = normalizedNotes(value) else { return nil }
+    let compact = value
+        .split(whereSeparator: \.isNewline)
+        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        .filter { !$0.isEmpty }
+        .joined(separator: " ")
+    guard !compact.isEmpty else { return nil }
+    if compact.count <= maxLength { return compact }
+    let end = compact.index(compact.startIndex, offsetBy: maxLength)
+    return String(compact[..<end]) + "..."
+}
+
+private func notesInput(text: String?, stdin: Bool) throws -> String {
+    let value: String
+    if stdin {
+        let data = FileHandle.standardInput.readDataToEndOfFile()
+        guard let decoded = String(data: data, encoding: .utf8) else {
+            throw CLIInputError.empty
+        }
+        value = decoded
+    } else {
+        value = text ?? ""
+    }
+    guard normalizedNotes(value) != nil else { throw CLIInputError.empty }
+    return value
+}
+
+private func appendedNotes(existing: String?, addition: String) -> String {
+    guard let existing = normalizedNotes(existing) else { return addition }
+    return existing + "\n" + addition
+}
+
+private func emitNotesUpdate(_ record: MeetingNotesRecord, json: Bool) throws {
+    if json {
+        try printJSON(record)
+    } else if record.hasNotes {
+        print("Updated notes for \(record.title).")
+    } else {
+        print("Cleared notes for \(record.title).")
+    }
+}
+
+private func exportContent(for transcription: Transcription, format: MeetingExportFormat) throws -> String {
+    switch format {
+    case .md:
+        return markdownExport(for: transcription)
+    case .json:
+        let data = try cliJSONEncoder.encode(MeetingRecord(transcription))
+        return String(data: data, encoding: .utf8) ?? "{}"
+    }
+}
+
+private func markdownExport(for transcription: Transcription) -> String {
+    var sections: [String] = []
+    sections.append("# \(transcription.fileName)")
+    sections.append("""
+    - ID: \(transcription.id.uuidString)
+    - Created: \(ISO8601DateFormatter().string(from: transcription.createdAt))
+    - Duration: \(transcription.durationMs.map(formatDuration) ?? "--")
+    - Status: \(transcription.status.rawValue)
+    """)
+
+    if let notes = normalizedNotes(transcription.userNotes) {
+        sections.append("## Notes\n\n\(notes)")
+    }
+
+    let transcript = preferredTranscriptText(transcription)
+    if !transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        sections.append("## Transcript\n\n\(transcript)")
+    }
+
+    return sections.joined(separator: "\n\n") + "\n"
+}
+
+private func printMeetingRecord(_ record: MeetingRecord) {
+    print(record.title)
+    print("ID: \(record.id.uuidString)")
+    print("Created: \(formatDate(record.createdAt))")
+    print("Duration: \(record.durationMs.map(formatDuration) ?? "--")")
+    print("Status: \(record.status.rawValue)")
+    if let filePath = record.filePath {
+        print("Audio: \(filePath)")
+    }
+
+    if let notes = normalizedNotes(record.notes) {
+        print("\nNotes:\n\(notes)")
+    }
+
+    if !record.transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        print("\nTranscript:\n\(record.transcript)")
+    }
+}
+
+private func resolvedOutputURL(_ output: String?, transcription: Transcription, fileExtension: String) -> URL {
+    if let output {
+        return URL(fileURLWithPath: expandTilde(output))
+    }
+    let baseName = sanitizedFileName(URL(fileURLWithPath: transcription.fileName).deletingPathExtension().lastPathComponent)
+    return URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        .appendingPathComponent("\(baseName).\(fileExtension)")
+}
+
+private func sanitizedFileName(_ value: String) -> String {
+    let invalid = CharacterSet(charactersIn: "/:")
+    let cleaned = value
+        .components(separatedBy: invalid)
+        .joined(separator: "-")
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    return cleaned.isEmpty ? "meeting" : cleaned
+}
+
+private func formatDate(_ date: Date) -> String {
+    let formatter = DateFormatter()
+    formatter.dateStyle = .short
+    formatter.timeStyle = .short
+    return formatter.string(from: date)
+}
+
+private func formatDuration(_ durationMs: Int) -> String {
+    let totalSeconds = max(0, durationMs / 1000)
+    let hours = totalSeconds / 3600
+    let minutes = (totalSeconds % 3600) / 60
+    let seconds = totalSeconds % 60
+    if hours > 0 {
+        return "\(hours)h \(minutes)m \(seconds)s"
+    }
+    return "\(minutes)m \(seconds)s"
+}

--- a/Sources/CLI/Commands/PromptsCommand.swift
+++ b/Sources/CLI/Commands/PromptsCommand.swift
@@ -360,7 +360,12 @@ extension PromptsCommand {
 
                 let trimmedExtra = extra?.trimmingCharacters(in: .whitespacesAndNewlines)
                 let normalizedExtra = (trimmedExtra?.isEmpty == false) ? trimmedExtra : nil
-                let systemPrompt = assembledSystemPrompt(promptContent: prompt.content, extraInstructions: normalizedExtra)
+                let systemPrompt = PromptSystemPromptAssembler.assemble(
+                    promptContent: prompt.content,
+                    extraInstructions: normalizedExtra,
+                    userNotes: transcript.userNotes,
+                    transcript: transcriptText
+                )
 
                 let execution = try llm.buildExecutionContext()
                 let service = LLMService(
@@ -400,19 +405,14 @@ extension PromptsCommand {
                         promptName: prompt.name,
                         promptContent: prompt.content,
                         extraInstructions: normalizedExtra,
-                        content: output
+                        content: output,
+                        userNotesSnapshot: transcript.userNotes
                     )
                     try resultRepo.save(result)
                     // Status messages on stderr so stdout stays grep-able as the prompt output.
                     FileHandle.standardError.write(Data("\nSaved PromptResult \(result.id.uuidString.prefix(8))\n".utf8))
                 }
             }
-        }
-
-        // Mirrors PromptResultsViewModel.assembledSystemPrompt so CLI runs match GUI behavior.
-        private func assembledSystemPrompt(promptContent: String, extraInstructions: String?) -> String {
-            guard let extraInstructions, !extraInstructions.isEmpty else { return promptContent }
-            return promptContent + "\n\n" + extraInstructions
         }
     }
 }

--- a/Sources/CLI/MacParakeetCLI.swift
+++ b/Sources/CLI/MacParakeetCLI.swift
@@ -5,7 +5,7 @@ struct CLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "macparakeet-cli",
         abstract: "Local STT, transcription, and prompt automation for Apple Silicon. Powered by Parakeet TDT on the Neural Engine.",
-        version: "1.2.0",
+        version: "1.3.0",
         subcommands: [
             TranscribeCommand.self,
             HistoryCommand.self,
@@ -16,6 +16,7 @@ struct CLI: AsyncParsableCommand {
             FlowCommand.self,
             LLMCommand.self,
             PromptsCommand.self,
+            MeetingsCommand.self,
             CalendarCommand.self,
             FeedbackCommand.self,
         ],

--- a/Sources/MacParakeetCore/Database/TranscriptionRepository.swift
+++ b/Sources/MacParakeetCore/Database/TranscriptionRepository.swift
@@ -72,6 +72,18 @@ public final class TranscriptionRepository: TranscriptionRepositoryProtocol {
         }
     }
 
+    public func fetchBySourceType(_ sourceType: Transcription.SourceType, limit: Int? = nil) throws -> [Transcription] {
+        try dbQueue.read { db in
+            var request = Transcription
+                .filter(Transcription.Columns.sourceType == sourceType.rawValue)
+                .order(Transcription.Columns.createdAt.desc)
+            if let limit {
+                request = request.limit(limit)
+            }
+            return try request.fetchAll(db)
+        }
+    }
+
     public func fetchByFilePath(
         _ filePath: String,
         sourceType: Transcription.SourceType? = nil
@@ -186,6 +198,15 @@ public final class TranscriptionRepository: TranscriptionRepositoryProtocol {
         try dbQueue.write { db in
             guard var transcription = try Transcription.fetchOne(db, key: id) else { return }
             transcription.speakers = speakers
+            transcription.updatedAt = Date()
+            try transcription.update(db)
+        }
+    }
+
+    public func updateUserNotes(id: UUID, userNotes: String?) throws {
+        try dbQueue.write { db in
+            guard var transcription = try Transcription.fetchOne(db, key: id) else { return }
+            transcription.userNotes = userNotes
             transcription.updatedAt = Date()
             try transcription.update(db)
         }

--- a/Sources/MacParakeetCore/Database/TranscriptionRepository.swift
+++ b/Sources/MacParakeetCore/Database/TranscriptionRepository.swift
@@ -84,6 +84,39 @@ public final class TranscriptionRepository: TranscriptionRepositoryProtocol {
         }
     }
 
+    public func fetchBySourceType(
+        _ sourceType: Transcription.SourceType,
+        idPrefix: String
+    ) throws -> [Transcription] {
+        let trimmed = idPrefix.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+        let textPattern = escapedLikePattern(trimmed.lowercased()) + "%"
+        let compactPattern = escapedLikePattern(trimmed.lowercased().replacingOccurrences(of: "-", with: "")) + "%"
+        return try dbQueue.read { db in
+            try Transcription
+                .filter(
+                    sql: "sourceType = ? AND (lower(id) LIKE ? ESCAPE '\\' OR lower(hex(id)) LIKE ? ESCAPE '\\')",
+                    arguments: [sourceType.rawValue, textPattern, compactPattern]
+                )
+                .order(Transcription.Columns.createdAt.desc)
+                .fetchAll(db)
+        }
+    }
+
+    public func fetchBySourceType(
+        _ sourceType: Transcription.SourceType,
+        fileName: String
+    ) throws -> [Transcription] {
+        let trimmed = fileName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+        return try dbQueue.read { db in
+            try Transcription
+                .filter(sql: "sourceType = ? AND lower(fileName) = lower(?)", arguments: [sourceType.rawValue, trimmed])
+                .order(Transcription.Columns.createdAt.desc)
+                .fetchAll(db)
+        }
+    }
+
     public func fetchByFilePath(
         _ filePath: String,
         sourceType: Transcription.SourceType? = nil
@@ -237,4 +270,11 @@ public final class TranscriptionRepository: TranscriptionRepositoryProtocol {
                 .fetchAll(db)
         }
     }
+}
+
+private func escapedLikePattern(_ value: String) -> String {
+    value
+        .replacingOccurrences(of: "\\", with: "\\\\")
+        .replacingOccurrences(of: "%", with: "\\%")
+        .replacingOccurrences(of: "_", with: "\\_")
 }

--- a/Sources/MacParakeetCore/Models/PromptSystemPromptAssembler.swift
+++ b/Sources/MacParakeetCore/Models/PromptSystemPromptAssembler.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+public enum PromptSystemPromptAssembler {
+    public static let userNotesPromptWordCap = 8_000
+
+    public static func assemble(
+        promptContent: String,
+        extraInstructions: String?,
+        userNotes: String? = nil,
+        transcript: String? = nil
+    ) -> String {
+        let cappedNotes = userNotes.map { truncateNotesForPrompt($0) }
+        let renderedPrompt = PromptTemplateRenderer.render(
+            promptContent,
+            substitutions: [
+                .userNotes: cappedNotes ?? "",
+                .transcript: transcript ?? "",
+            ]
+        )
+
+        let trimmedInstructions = extraInstructions?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let trimmedInstructions, !trimmedInstructions.isEmpty else {
+            return renderedPrompt
+        }
+        return renderedPrompt + "\n\n" + trimmedInstructions
+    }
+
+    /// Truncate meeting notes for prompt assembly without mutating the saved notes.
+    public static func truncateNotesForPrompt(_ notes: String) -> String {
+        let truncationIndex = indexAfterNthWord(in: notes, n: userNotesPromptWordCap)
+        guard let truncationIndex else { return notes }
+        let kept = notes[..<truncationIndex]
+        return String(kept) + "\n\n[Notes truncated to \(userNotesPromptWordCap) words for summary generation; full notes preserved on the recording.]"
+    }
+
+    private static func indexAfterNthWord(in text: String, n: Int) -> String.Index? {
+        guard n > 0 else { return text.startIndex }
+        var wordCount = 0
+        var inWord = false
+        var nthWordEndIndex: String.Index?
+        var index = text.startIndex
+        while index < text.endIndex {
+            let char = text[index]
+            if char.isWhitespace {
+                inWord = false
+            } else {
+                if !inWord {
+                    wordCount += 1
+                    inWord = true
+                    if wordCount == n + 1 {
+                        return nthWordEndIndex
+                    }
+                }
+                if wordCount == n {
+                    nthWordEndIndex = text.index(after: index)
+                }
+            }
+            index = text.index(after: index)
+        }
+        return nil
+    }
+}

--- a/Sources/MacParakeetCore/Services/ExportService.swift
+++ b/Sources/MacParakeetCore/Services/ExportService.swift
@@ -10,6 +10,8 @@ public protocol ExportServiceProtocol: Sendable {
     func exportToJSON(transcription: Transcription, url: URL) throws
     @MainActor func exportToPDF(transcription: Transcription, url: URL) throws
     @MainActor func exportToDocx(transcription: Transcription, url: URL) throws
+    func formatSRT(transcription: Transcription) -> String
+    func formatVTT(transcription: Transcription) -> String
     func formatSRT(words: [WordTimestamp], speakers: [SpeakerInfo]?) -> String
     func formatVTT(words: [WordTimestamp], speakers: [SpeakerInfo]?) -> String
     func formatMarkdown(transcription: Transcription) -> String
@@ -75,43 +77,42 @@ public final class ExportService: ExportServiceProtocol, Sendable {
 
     /// Export transcription as SRT subtitle file
     public func exportToSRT(transcription: Transcription, url: URL) throws {
-        if let text = editedTranscriptText(transcription: transcription) {
-            let duration = transcription.durationMs ?? 0
-            let content = "1\n00:00:00,000 --> \(srtTimestamp(ms: duration))\n\(singleCueSubtitleText(text))\n"
-            try content.write(to: url, atomically: true, encoding: .utf8)
-            return
-        }
-
-        guard let words = transcription.wordTimestamps, !words.isEmpty else {
-            // Fall back to full transcript as a single cue
-            let text = preferredText(transcription: transcription)
-            let duration = transcription.durationMs ?? 0
-            let content = "1\n00:00:00,000 --> \(srtTimestamp(ms: duration))\n\(singleCueSubtitleText(text))\n"
-            try content.write(to: url, atomically: true, encoding: .utf8)
-            return
-        }
-        let content = formatSRT(words: words, speakers: transcription.speakers)
-        try content.write(to: url, atomically: true, encoding: .utf8)
+        try formatSRT(transcription: transcription).write(to: url, atomically: true, encoding: .utf8)
     }
 
     /// Export transcription as WebVTT subtitle file
     public func exportToVTT(transcription: Transcription, url: URL) throws {
+        try formatVTT(transcription: transcription).write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    /// Format a transcription as SRT, falling back to one full-transcript cue.
+    public func formatSRT(transcription: Transcription) -> String {
         if let text = editedTranscriptText(transcription: transcription) {
             let duration = transcription.durationMs ?? 0
-            let content = "WEBVTT\n\n\(vttTimestamp(ms: 0)) --> \(vttTimestamp(ms: duration))\n\(singleCueSubtitleText(text))\n"
-            try content.write(to: url, atomically: true, encoding: .utf8)
-            return
+            return "1\n00:00:00,000 --> \(srtTimestamp(ms: duration))\n\(singleCueSubtitleText(text))\n"
         }
 
         guard let words = transcription.wordTimestamps, !words.isEmpty else {
             let text = preferredText(transcription: transcription)
             let duration = transcription.durationMs ?? 0
-            let content = "WEBVTT\n\n\(vttTimestamp(ms: 0)) --> \(vttTimestamp(ms: duration))\n\(singleCueSubtitleText(text))\n"
-            try content.write(to: url, atomically: true, encoding: .utf8)
-            return
+            return "1\n00:00:00,000 --> \(srtTimestamp(ms: duration))\n\(singleCueSubtitleText(text))\n"
         }
-        let content = formatVTT(words: words, speakers: transcription.speakers)
-        try content.write(to: url, atomically: true, encoding: .utf8)
+        return formatSRT(words: words, speakers: transcription.speakers)
+    }
+
+    /// Format a transcription as WebVTT, falling back to one full-transcript cue.
+    public func formatVTT(transcription: Transcription) -> String {
+        if let text = editedTranscriptText(transcription: transcription) {
+            let duration = transcription.durationMs ?? 0
+            return "WEBVTT\n\n\(vttTimestamp(ms: 0)) --> \(vttTimestamp(ms: duration))\n\(singleCueSubtitleText(text))\n"
+        }
+
+        guard let words = transcription.wordTimestamps, !words.isEmpty else {
+            let text = preferredText(transcription: transcription)
+            let duration = transcription.durationMs ?? 0
+            return "WEBVTT\n\n\(vttTimestamp(ms: 0)) --> \(vttTimestamp(ms: duration))\n\(singleCueSubtitleText(text))\n"
+        }
+        return formatVTT(words: words, speakers: transcription.speakers)
     }
 
     /// Export transcription as JSON file

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -11,6 +11,17 @@ public protocol TranscriptionServiceProtocol: Sendable {
         recording: MeetingRecordingOutput,
         onProgress: (@Sendable (TranscriptionProgress) -> Void)?
     ) async throws -> Transcription
+    func retranscribe(
+        existing transcription: Transcription,
+        fileURL: URL,
+        source: TelemetryTranscriptionSource,
+        onProgress: (@Sendable (TranscriptionProgress) -> Void)?
+    ) async throws -> Transcription
+    func retranscribeMeeting(
+        existing transcription: Transcription,
+        recording: MeetingRecordingOutput,
+        onProgress: (@Sendable (TranscriptionProgress) -> Void)?
+    ) async throws -> Transcription
     func transcribeURL(urlString: String, onProgress: (@Sendable (TranscriptionProgress) -> Void)?) async throws -> Transcription
 }
 
@@ -32,6 +43,23 @@ extension TranscriptionServiceProtocol {
 
     public func transcribeMeeting(recording: MeetingRecordingOutput) async throws -> Transcription {
         try await transcribeMeeting(recording: recording, onProgress: nil)
+    }
+
+    public func retranscribe(
+        existing transcription: Transcription,
+        fileURL: URL,
+        source: TelemetryTranscriptionSource,
+        onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
+    ) async throws -> Transcription {
+        try await transcribe(fileURL: fileURL, source: source, onProgress: onProgress)
+    }
+
+    public func retranscribeMeeting(
+        existing transcription: Transcription,
+        recording: MeetingRecordingOutput,
+        onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
+    ) async throws -> Transcription {
+        try await transcribeMeeting(recording: recording, onProgress: onProgress)
     }
 }
 
@@ -138,6 +166,60 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         return try await transcribeMeetingAudio(
             recording: recording,
             transcription: &transcription,
+            onProgress: onProgress
+        )
+    }
+
+    public func retranscribe(
+        existing original: Transcription,
+        fileURL: URL,
+        source: TelemetryTranscriptionSource,
+        onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
+    ) async throws -> Transcription {
+        if let entitlements {
+            try await entitlements.assertCanTranscribe(now: Date())
+        }
+
+        var transcription = makeRetranscriptionRecord(from: original)
+        transcription.fileSizeBytes = (try? FileManager.default.attributesOfItem(atPath: fileURL.path)[.size] as? Int)
+            .flatMap { $0 } ?? original.fileSizeBytes
+
+        Telemetry.send(.transcriptionStarted(source: source, audioDurationSeconds: nil))
+
+        return try await transcribeAudio(
+            fileURL: fileURL,
+            source: source,
+            sttJob: .fileTranscription,
+            transcription: &transcription,
+            tempFiles: [],
+            persistFailureStatus: false,
+            onProgress: onProgress
+        )
+    }
+
+    public func retranscribeMeeting(
+        existing original: Transcription,
+        recording: MeetingRecordingOutput,
+        onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
+    ) async throws -> Transcription {
+        if let entitlements {
+            try await entitlements.assertCanTranscribe(now: Date())
+        }
+
+        var transcription = makeRetranscriptionRecord(from: original)
+        transcription.fileSizeBytes = (try? FileManager.default.attributesOfItem(atPath: recording.mixedAudioURL.path)[.size] as? Int)
+            .flatMap { $0 } ?? original.fileSizeBytes
+        transcription.userNotes = original.userNotes ?? recording.userNotes
+
+        Telemetry.send(.transcriptionStarted(
+            source: .meeting,
+            audioDurationSeconds: recording.durationSeconds
+        ))
+
+        return try await transcribeMeetingAudio(
+            recording: recording,
+            transcription: &transcription,
+            persistFailureStatus: false,
             onProgress: onProgress
         )
     }
@@ -285,6 +367,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
     private func transcribeMeetingAudio(
         recording: MeetingRecordingOutput,
         transcription: inout Transcription,
+        persistFailureStatus: Bool = true,
         onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
     ) async throws -> Transcription {
         let processingStartedAt = Date()
@@ -358,26 +441,28 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
                 ))
             }
 
-            let txID = transcription.id
-            if error is CancellationError {
-                do {
-                    try transcriptionRepo.updateStatus(
-                        id: txID,
-                        status: .cancelled,
-                        errorMessage: nil
-                    )
-                } catch let dbError {
-                    logger.error("failed_to_update_cancelled_status id=\(txID) dbError=\(dbError.localizedDescription, privacy: .public)")
-                }
-            } else {
-                do {
-                    try transcriptionRepo.updateStatus(
-                        id: txID,
-                        status: .error,
-                        errorMessage: error.localizedDescription
-                    )
-                } catch let dbError {
-                    logger.error("failed_to_update_error_status id=\(txID) dbError=\(dbError.localizedDescription, privacy: .public)")
+            if persistFailureStatus {
+                let txID = transcription.id
+                if error is CancellationError {
+                    do {
+                        try transcriptionRepo.updateStatus(
+                            id: txID,
+                            status: .cancelled,
+                            errorMessage: nil
+                        )
+                    } catch let dbError {
+                        logger.error("failed_to_update_cancelled_status id=\(txID) dbError=\(dbError.localizedDescription, privacy: .public)")
+                    }
+                } else {
+                    do {
+                        try transcriptionRepo.updateStatus(
+                            id: txID,
+                            status: .error,
+                            errorMessage: error.localizedDescription
+                        )
+                    } catch let dbError {
+                        logger.error("failed_to_update_error_status id=\(txID) dbError=\(dbError.localizedDescription, privacy: .public)")
+                    }
                 }
             }
             throw error
@@ -518,6 +603,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         transcription: inout Transcription,
         tempFiles: [URL],
         cleanUpDownloadedFiles: Bool = true,
+        persistFailureStatus: Bool = true,
         onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
     ) async throws -> Transcription {
         var wavURL: URL?
@@ -643,30 +729,49 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
                 ))
             }
 
-            let txID = transcription.id
-            if error is CancellationError {
-                do {
-                    try transcriptionRepo.updateStatus(
-                        id: txID,
-                        status: .cancelled,
-                        errorMessage: nil
-                    )
-                } catch let dbError {
-                    logger.error("failed_to_update_cancelled_status id=\(txID) dbError=\(dbError.localizedDescription, privacy: .public)")
-                }
-            } else {
-                do {
-                    try transcriptionRepo.updateStatus(
-                        id: txID,
-                        status: .error,
-                        errorMessage: error.localizedDescription
-                    )
-                } catch let dbError {
-                    logger.error("failed_to_update_error_status id=\(txID) dbError=\(dbError.localizedDescription, privacy: .public)")
+            if persistFailureStatus {
+                let txID = transcription.id
+                if error is CancellationError {
+                    do {
+                        try transcriptionRepo.updateStatus(
+                            id: txID,
+                            status: .cancelled,
+                            errorMessage: nil
+                        )
+                    } catch let dbError {
+                        logger.error("failed_to_update_cancelled_status id=\(txID) dbError=\(dbError.localizedDescription, privacy: .public)")
+                    }
+                } else {
+                    do {
+                        try transcriptionRepo.updateStatus(
+                            id: txID,
+                            status: .error,
+                            errorMessage: error.localizedDescription
+                        )
+                    } catch let dbError {
+                        logger.error("failed_to_update_error_status id=\(txID) dbError=\(dbError.localizedDescription, privacy: .public)")
+                    }
                 }
             }
             throw error
         }
+    }
+
+    private func makeRetranscriptionRecord(from original: Transcription) -> Transcription {
+        var transcription = original
+        transcription.durationMs = nil
+        transcription.rawTranscript = nil
+        transcription.cleanTranscript = nil
+        transcription.wordTimestamps = nil
+        transcription.speakerCount = nil
+        transcription.speakers = nil
+        transcription.diarizationSegments = nil
+        transcription.status = .processing
+        transcription.errorMessage = nil
+        transcription.exportPath = nil
+        transcription.isTranscriptEdited = false
+        transcription.updatedAt = Date()
+        return transcription
     }
 
     private func completeTranscription(

--- a/Sources/MacParakeetViewModels/PromptResultsViewModel.swift
+++ b/Sources/MacParakeetViewModels/PromptResultsViewModel.swift
@@ -54,7 +54,7 @@ public final class PromptResultsViewModel {
     /// Soft cap on user notes for prompt-assembly only — full notes remain on
     /// the Transcription row. ~11k tokens at typical English word→token ratio,
     /// leaving headroom for transcript + system prompt + response (ADR-020 §3).
-    static let userNotesPromptWordCap = 8_000
+    static let userNotesPromptWordCap = PromptSystemPromptAssembler.userNotesPromptWordCap
 
     public var promptResults: [PromptResult] = []
     public var pendingGenerations: [PendingGeneration] = []
@@ -502,40 +502,12 @@ public final class PromptResultsViewModel {
         userNotes: String? = nil,
         transcript: String? = nil
     ) -> String {
-        // Substitute supported template variables (ADR-020 §4).
-        //
-        // Single-pass matters here specifically: `cappedNotes` is user-typed
-        // text that may contain literal `{{transcript}}` (pasted code, a
-        // quoted prompt, etc.) and the renderer walks the original template
-        // string only — substituted values are appended to a fresh buffer
-        // and never re-scanned. A naïve sequential `replacingOccurrences`
-        // implementation would re-interpret notes-injected `{{...}}` tokens
-        // on the second pass, leaking transcript content into the rendered
-        // prompt anywhere a user's note happens to look like a template
-        // variable. Do not "simplify" this back to sequential substitution.
-        //
-        // For prompts that include `{{transcript}}` in their template, the
-        // transcript is rendered inline in the system prompt AND still sent
-        // as the user message via `LLMService.generatePromptResultStream`.
-        // The duplication is intentional for v0.6: the LLM provider's own
-        // truncation handles the user-message side, and skipping the
-        // user-message when the template references `{{transcript}}` would
-        // require empty-user-message handling that varies per provider.
-        // Suppression-on-template-use is tracked as Future Work in ADR-020.
-        let cappedNotes = userNotes.map { Self.truncateNotesForPrompt($0) }
-        let renderedPrompt = PromptTemplateRenderer.render(
-            promptContent,
-            substitutions: [
-                .userNotes: cappedNotes ?? "",
-                .transcript: transcript ?? "",
-            ]
+        PromptSystemPromptAssembler.assemble(
+            promptContent: promptContent,
+            extraInstructions: extraInstructions,
+            userNotes: userNotes,
+            transcript: transcript
         )
-
-        let trimmedInstructions = extraInstructions?.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let trimmedInstructions, !trimmedInstructions.isEmpty else {
-            return renderedPrompt
-        }
-        return renderedPrompt + "\n\n" + trimmedInstructions
     }
 
     /// Truncate user notes to the prompt-assembly soft cap (8,000 words).
@@ -549,51 +521,7 @@ public final class PromptResultsViewModel {
     /// spaces and strip the structure the user typed to *steer* the
     /// summary in the first place, which defeats the point.
     static func truncateNotesForPrompt(_ notes: String) -> String {
-        let truncationIndex = indexAfterNthWord(in: notes, n: userNotesPromptWordCap)
-        guard let truncationIndex else { return notes }
-        let kept = notes[..<truncationIndex]
-        return String(kept) + "\n\n[Notes truncated to \(userNotesPromptWordCap) words for summary generation; full notes preserved on the recording.]"
-    }
-
-    /// Returns the index in `text` immediately after the `n`-th
-    /// whitespace-delimited word, or `nil` if `text` has `n` or fewer
-    /// words (no truncation needed). The boundary lands on a non-
-    /// whitespace character so the kept slice ends with the last
-    /// retained word's final character — trailing whitespace stays
-    /// behind, which keeps the inserted suffix on a clean line break.
-    ///
-    /// Truncation is only signaled when we observe a transition INTO an
-    /// (n+1)-th word. Earlier versions returned a non-nil index when the
-    /// n-th word was followed by trailing whitespace (e.g. the user typed
-    /// exactly 8,000 words and a final newline), which produced a false
-    /// "[Notes truncated...]" banner even though the entire input was kept.
-    private static func indexAfterNthWord(in text: String, n: Int) -> String.Index? {
-        guard n > 0 else { return text.startIndex }
-        var wordCount = 0
-        var inWord = false
-        var nthWordEndIndex: String.Index?
-        var index = text.startIndex
-        while index < text.endIndex {
-            let char = text[index]
-            if char.isWhitespace {
-                inWord = false
-            } else {
-                if !inWord {
-                    wordCount += 1
-                    inWord = true
-                    if wordCount == n + 1 {
-                        return nthWordEndIndex
-                    }
-                }
-                if wordCount == n {
-                    nthWordEndIndex = text.index(after: index)
-                }
-            }
-            index = text.index(after: index)
-        }
-        // Reached end of text without ever entering an (n+1)-th word —
-        // text contains at most `n` words and needs no truncation.
-        return nil
+        PromptSystemPromptAssembler.truncateNotesForPrompt(notes)
     }
 
     private func fetchUserNotes(for transcriptionId: UUID) -> String? {

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -277,12 +277,14 @@ public final class TranscriptionViewModel {
                 let result: Transcription
                 if original.sourceType == .meeting,
                    let meetingRecording = archivedMeetingRecording(for: original, mixedAudioURL: url) {
-                    result = try await service.transcribeMeeting(
+                    result = try await service.retranscribeMeeting(
+                        existing: original,
                         recording: meetingRecording,
                         onProgress: progressHandler
                     )
                 } else {
-                    result = try await service.transcribe(
+                    result = try await service.retranscribe(
+                        existing: original,
                         fileURL: url,
                         source: retranscriptionSource,
                         onProgress: progressHandler

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -301,6 +301,8 @@ public final class TranscriptionViewModel {
                 updatedResult.channelName = original.channelName
                 updatedResult.videoDescription = original.videoDescription
                 updatedResult.sourceType = original.sourceType
+                updatedResult.recoveredFromCrash = original.recoveredFromCrash
+                updatedResult.userNotes = original.userNotes
                 updatedResult.updatedAt = Date()
                 do {
                     try transcriptionRepo?.save(updatedResult)

--- a/Tests/CLITests/CLIHelpersTests.swift
+++ b/Tests/CLITests/CLIHelpersTests.swift
@@ -27,6 +27,16 @@ final class CLIHelpersTests: XCTestCase {
         XCTAssertEqual(found.id, t.id)
     }
 
+    func testFindTranscriptionByExactName() throws {
+        let db = try DatabaseManager()
+        let repo = TranscriptionRepository(dbQueue: db.dbQueue)
+        let t = Transcription(fileName: "Design Review", rawTranscript: "Hello", status: .completed)
+        try repo.save(t)
+
+        let found = try findTranscription(id: "design review", repo: repo)
+        XCTAssertEqual(found.id, t.id)
+    }
+
     func testFindTranscriptionThrowsNotFoundForBogusID() throws {
         let db = try DatabaseManager()
         let repo = TranscriptionRepository(dbQueue: db.dbQueue)
@@ -155,6 +165,38 @@ final class CLIHelpersTests: XCTestCase {
             }
             if case .ambiguous = lookupError {} else {
                 XCTFail("Expected .ambiguous, got \(lookupError)")
+            }
+        }
+    }
+
+    // MARK: - findMeeting
+
+    func testFindMeetingFiltersToMeetingSourceType() throws {
+        let db = try DatabaseManager()
+        let repo = TranscriptionRepository(dbQueue: db.dbQueue)
+
+        let meeting = Transcription(fileName: "Planning", status: .completed, sourceType: .meeting)
+        let file = Transcription(fileName: "Planning", status: .completed, sourceType: .file)
+        try repo.save(file)
+        try repo.save(meeting)
+
+        let found = try findMeeting(idOrName: "planning", repo: repo)
+        XCTAssertEqual(found.id, meeting.id)
+    }
+
+    func testFindMeetingRejectsNonMeetingExactUUID() throws {
+        let db = try DatabaseManager()
+        let repo = TranscriptionRepository(dbQueue: db.dbQueue)
+
+        let file = Transcription(fileName: "clip.mp3", status: .completed, sourceType: .file)
+        try repo.save(file)
+
+        XCTAssertThrowsError(try findMeeting(idOrName: file.id.uuidString, repo: repo)) { error in
+            guard let lookupError = error as? CLILookupError else {
+                return XCTFail("Expected CLILookupError")
+            }
+            if case .notFound = lookupError {} else {
+                XCTFail("Expected .notFound, got \(lookupError)")
             }
         }
     }

--- a/Tests/CLITests/MeetingsCommandTests.swift
+++ b/Tests/CLITests/MeetingsCommandTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import CLI
+
+final class MeetingsCommandTests: XCTestCase {
+    func testMeetingsCommandIsRegisteredAtTopLevel() {
+        XCTAssertTrue(
+            CLI.configuration.subcommands.contains { $0 == MeetingsCommand.self },
+            "meetings must be available from macparakeet-cli"
+        )
+    }
+
+    func testExecutableSubcommandsParse() throws {
+        XCTAssertNoThrow(try MeetingsCommand.ListSubcommand.parse(["--json"]))
+        XCTAssertNoThrow(try MeetingsCommand.ShowSubcommand.parse(["abcd", "--json"]))
+        XCTAssertNoThrow(try MeetingsCommand.TranscriptSubcommand.parse(["abcd", "--format", "srt"]))
+        XCTAssertNoThrow(try MeetingsCommand.NotesSubcommand.AppendSubcommand.parse(["abcd", "--text", "Decision: ship"]))
+        XCTAssertNoThrow(try MeetingsCommand.NotesSubcommand.ClearSubcommand.parse(["abcd", "--json"]))
+        XCTAssertNoThrow(try MeetingsCommand.ExportSubcommand.parse(["abcd", "--format", "md", "--stdout"]))
+    }
+
+    func testListRejectsNegativeLimit() {
+        XCTAssertThrowsError(try MeetingsCommand.ListSubcommand.parse(["--limit", "-1"]))
+    }
+
+    func testNotesSetRequiresOneInputSource() {
+        XCTAssertThrowsError(try MeetingsCommand.NotesSubcommand.SetSubcommand.parse(["abcd"]))
+        XCTAssertThrowsError(
+            try MeetingsCommand.NotesSubcommand.SetSubcommand.parse(["abcd", "--text", "note", "--stdin"])
+        )
+        XCTAssertNoThrow(try MeetingsCommand.NotesSubcommand.SetSubcommand.parse(["abcd", "--text", "note"]))
+        XCTAssertNoThrow(try MeetingsCommand.NotesSubcommand.SetSubcommand.parse(["abcd", "--stdin"]))
+    }
+
+    func testNotesAppendRequiresOneInputSource() {
+        XCTAssertThrowsError(try MeetingsCommand.NotesSubcommand.AppendSubcommand.parse(["abcd"]))
+        XCTAssertThrowsError(
+            try MeetingsCommand.NotesSubcommand.AppendSubcommand.parse(["abcd", "--text", "note", "--stdin"])
+        )
+        XCTAssertNoThrow(try MeetingsCommand.NotesSubcommand.AppendSubcommand.parse(["abcd", "--text", "note"]))
+        XCTAssertNoThrow(try MeetingsCommand.NotesSubcommand.AppendSubcommand.parse(["abcd", "--stdin"]))
+    }
+
+    func testFormatRawValues() {
+        XCTAssertEqual(MeetingTranscriptFormat(rawValue: "text"), .text)
+        XCTAssertEqual(MeetingTranscriptFormat(rawValue: "json"), .json)
+        XCTAssertEqual(MeetingTranscriptFormat(rawValue: "srt"), .srt)
+        XCTAssertEqual(MeetingTranscriptFormat(rawValue: "vtt"), .vtt)
+        XCTAssertEqual(MeetingExportFormat(rawValue: "md"), .md)
+        XCTAssertEqual(MeetingExportFormat(rawValue: "json"), .json)
+    }
+}

--- a/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
@@ -103,6 +103,47 @@ final class TranscriptionRepositoryTests: XCTestCase {
         XCTAssertEqual(results.map(\.id), [newerMeeting.id, olderMeeting.id])
     }
 
+    func testFetchBySourceTypeFiltersAndOrdersNewestFirst() throws {
+        let olderMeeting = Transcription(
+            createdAt: Date(timeIntervalSinceNow: -100),
+            fileName: "older meeting",
+            sourceType: .meeting,
+            updatedAt: Date(timeIntervalSinceNow: -100)
+        )
+        let newerMeeting = Transcription(
+            createdAt: Date(timeIntervalSinceNow: -10),
+            fileName: "newer meeting",
+            sourceType: .meeting,
+            updatedAt: Date(timeIntervalSinceNow: -10)
+        )
+        let fileTranscription = Transcription(fileName: "regular file", sourceType: .file)
+
+        try repo.save(olderMeeting)
+        try repo.save(newerMeeting)
+        try repo.save(fileTranscription)
+
+        let results = try repo.fetchBySourceType(.meeting)
+
+        XCTAssertEqual(results.map(\.id), [newerMeeting.id, olderMeeting.id])
+    }
+
+    func testUpdateUserNotesPreservesOtherFields() throws {
+        let transcription = Transcription(
+            fileName: "Meeting Apr 5",
+            rawTranscript: "Transcript",
+            status: .completed,
+            sourceType: .meeting
+        )
+        try repo.save(transcription)
+
+        try repo.updateUserNotes(id: transcription.id, userNotes: "Decision: ship it")
+
+        let fetched = try XCTUnwrap(repo.fetch(id: transcription.id))
+        XCTAssertEqual(fetched.userNotes, "Decision: ship it")
+        XCTAssertEqual(fetched.rawTranscript, "Transcript")
+        XCTAssertEqual(fetched.sourceType, .meeting)
+    }
+
     func testDelete() throws {
         let transcription = Transcription(fileName: "delete-me.mp3")
         try repo.save(transcription)

--- a/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
@@ -127,6 +127,37 @@ final class TranscriptionRepositoryTests: XCTestCase {
         XCTAssertEqual(results.map(\.id), [newerMeeting.id, olderMeeting.id])
     }
 
+    func testFetchBySourceTypeAndIDPrefixFiltersInDatabase() throws {
+        let meetingID = UUID(uuidString: "AABBCCDD-1111-1111-1111-111111111111")!
+        let otherMeetingID = UUID(uuidString: "CCDDEEFF-1111-1111-1111-111111111111")!
+        let meeting = Transcription(id: meetingID, fileName: "Planning", sourceType: .meeting)
+        let otherMeeting = Transcription(id: otherMeetingID, fileName: "Other", sourceType: .meeting)
+        let file = Transcription(
+            id: UUID(uuidString: "AABBCCDD-2222-2222-2222-222222222222")!,
+            fileName: "File",
+            sourceType: .file
+        )
+        try repo.save(meeting)
+        try repo.save(otherMeeting)
+        try repo.save(file)
+
+        let results = try repo.fetchBySourceType(.meeting, idPrefix: "aabbccdd")
+
+        XCTAssertEqual(results.map(\.id), [meetingID])
+        XCTAssertEqual(try repo.fetchBySourceType(.meeting, idPrefix: "AABBCCDD-1111").map(\.id), [meetingID])
+    }
+
+    func testFetchBySourceTypeAndFileNameIsCaseInsensitive() throws {
+        let meeting = Transcription(fileName: "Design Review", sourceType: .meeting)
+        let file = Transcription(fileName: "Design Review", sourceType: .file)
+        try repo.save(meeting)
+        try repo.save(file)
+
+        let results = try repo.fetchBySourceType(.meeting, fileName: "design review")
+
+        XCTAssertEqual(results.map(\.id), [meeting.id])
+    }
+
     func testUpdateUserNotesPreservesOtherFields() throws {
         let transcription = Transcription(
             fileName: "Meeting Apr 5",

--- a/Tests/MacParakeetTests/Models/PromptTemplateRendererTests.swift
+++ b/Tests/MacParakeetTests/Models/PromptTemplateRendererTests.swift
@@ -26,6 +26,20 @@ final class PromptTemplateRendererTests: XCTestCase {
         XCTAssertEqual(rendered, "T:hello world")
     }
 
+    func testSystemPromptAssemblerRendersNotesTranscriptAndExtraInstructions() {
+        let assembled = PromptSystemPromptAssembler.assemble(
+            promptContent: "Notes:\n{{userNotes}}\nTranscript:\n{{transcript}}",
+            extraInstructions: "Focus on decisions.",
+            userNotes: "Decision: ship",
+            transcript: "We agreed to ship."
+        )
+
+        XCTAssertEqual(
+            assembled,
+            "Notes:\nDecision: ship\nTranscript:\nWe agreed to ship.\n\nFocus on decisions."
+        )
+    }
+
     func testMissingKeyFallsBackToEmptyString() {
         // Template uses both variables; substitutions only supplies one.
         let rendered = PromptTemplateRenderer.render(

--- a/Tests/MacParakeetTests/Services/ExportServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/ExportServiceTests.swift
@@ -351,6 +351,34 @@ final class ExportServiceTests: XCTestCase {
         XCTAssertTrue(vtt.contains("00:00:02.000 --> 00:00:03.000\nGoodbye world."))
     }
 
+    func testFormatSRTTranscriptionWithoutTimestampsUsesSingleCue() {
+        let transcription = Transcription(
+            fileName: "meeting.m4a",
+            durationMs: 2500,
+            rawTranscript: " Hello\n\nworld. ",
+            status: .completed,
+            sourceType: .meeting
+        )
+
+        let srt = exportService.formatSRT(transcription: transcription)
+
+        XCTAssertEqual(srt, "1\n00:00:00,000 --> 00:00:02,500\nHello world.\n")
+    }
+
+    func testFormatVTTTranscriptionWithoutTimestampsUsesSingleCue() {
+        let transcription = Transcription(
+            fileName: "meeting.m4a",
+            durationMs: 2500,
+            rawTranscript: " Hello\n\nworld. ",
+            status: .completed,
+            sourceType: .meeting
+        )
+
+        let vtt = exportService.formatVTT(transcription: transcription)
+
+        XCTAssertEqual(vtt, "WEBVTT\n\n00:00:00.000 --> 00:00:02.500\nHello world.\n")
+    }
+
     // MARK: - File Export
 
     func testExportToSRT() throws {

--- a/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
@@ -896,6 +896,100 @@ final class TranscriptionServiceTests: XCTestCase {
         XCTAssertEqual(lastJob, .fileTranscription)
     }
 
+    func testRetranscribeExistingFileUpdatesOriginalRowWithoutDuplicate() async throws {
+        let original = Transcription(
+            id: UUID(),
+            createdAt: Date(timeIntervalSince1970: 123),
+            fileName: "lecture.mp3",
+            filePath: "/tmp/lecture.mp3",
+            rawTranscript: "Old transcript",
+            cleanTranscript: "Edited old transcript",
+            wordTimestamps: [
+                WordTimestamp(word: "Old", startMs: 0, endMs: 100, confidence: 0.9, speakerId: "S1")
+            ],
+            speakerCount: 1,
+            speakers: [SpeakerInfo(id: "S1", label: "Speaker 1")],
+            diarizationSegments: [DiarizationSegmentRecord(speakerId: "S1", startMs: 0, endMs: 100)],
+            status: .completed,
+            sourceURL: "https://youtube.com/watch?v=abc123",
+            thumbnailURL: "https://img.youtube.com/vi/abc123/default.jpg",
+            channelName: "Channel",
+            videoDescription: "Description",
+            isFavorite: true,
+            sourceType: .youtube
+        )
+        try transcriptionRepo.save(original)
+        await mockSTT.configure(result: STTResult(
+            text: "New transcript",
+            words: [
+                TimestampedWord(word: "New", startMs: 0, endMs: 120, confidence: 0.98),
+                TimestampedWord(word: "transcript", startMs: 150, endMs: 420, confidence: 0.97),
+            ]
+        ))
+
+        let result = try await service.retranscribe(
+            existing: original,
+            fileURL: URL(fileURLWithPath: "/tmp/lecture.mp3"),
+            source: .youtube,
+            onProgress: nil
+        )
+
+        let all = try transcriptionRepo.fetchAll(limit: nil)
+        XCTAssertEqual(all.count, 1)
+        XCTAssertEqual(result.id, original.id)
+        XCTAssertEqual(all[0].id, original.id)
+        XCTAssertEqual(all[0].rawTranscript, "New transcript")
+        XCTAssertNil(all[0].cleanTranscript)
+        XCTAssertEqual(all[0].wordTimestamps?.map(\.word), ["New", "transcript"])
+        XCTAssertNil(all[0].speakerCount)
+        XCTAssertNil(all[0].speakers)
+        XCTAssertNil(all[0].diarizationSegments)
+        XCTAssertEqual(all[0].createdAt, original.createdAt)
+        XCTAssertEqual(all[0].fileName, original.fileName)
+        XCTAssertEqual(all[0].filePath, original.filePath)
+        XCTAssertEqual(all[0].sourceURL, original.sourceURL)
+        XCTAssertEqual(all[0].thumbnailURL, original.thumbnailURL)
+        XCTAssertEqual(all[0].channelName, original.channelName)
+        XCTAssertEqual(all[0].videoDescription, original.videoDescription)
+        XCTAssertEqual(all[0].isFavorite, true)
+        XCTAssertEqual(all[0].sourceType, .youtube)
+        XCTAssertEqual(all[0].status, .completed)
+    }
+
+    func testRetranscribeExistingFileFailureLeavesOriginalRowIntact() async throws {
+        let original = Transcription(
+            id: UUID(),
+            fileName: "lecture.mp3",
+            filePath: "/tmp/lecture.mp3",
+            rawTranscript: "Old transcript",
+            status: .completed,
+            sourceType: .file
+        )
+        try transcriptionRepo.save(original)
+        await mockSTT.configure(error: STTError.transcriptionFailed("Model error"))
+
+        do {
+            _ = try await service.retranscribe(
+                existing: original,
+                fileURL: URL(fileURLWithPath: "/tmp/lecture.mp3"),
+                source: .file,
+                onProgress: nil
+            )
+            XCTFail("Should have thrown")
+        } catch let error as STTError {
+            guard case .transcriptionFailed = error else {
+                return XCTFail("Unexpected STT error: \(error)")
+            }
+        }
+
+        let all = try transcriptionRepo.fetchAll(limit: nil)
+        XCTAssertEqual(all.count, 1)
+        XCTAssertEqual(all[0].id, original.id)
+        XCTAssertEqual(all[0].rawTranscript, "Old transcript")
+        XCTAssertEqual(all[0].status, .completed)
+        XCTAssertNil(all[0].errorMessage)
+    }
+
     func testTranscribeURLDownloadFailureEmitsDownloadStageTelemetry() async throws {
         let telemetry = TelemetrySpy()
         Telemetry.configure(telemetry)

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -1064,7 +1064,9 @@ final class TranscriptionViewModelTests: XCTestCase {
             durationMs: 2_000,
             rawTranscript: "Old meeting transcript",
             status: .completed,
-            sourceType: .meeting
+            sourceType: .meeting,
+            recoveredFromCrash: true,
+            userNotes: "Original decision notes"
         )
         mockRepo.transcriptions = [original]
 
@@ -1083,6 +1085,8 @@ final class TranscriptionViewModelTests: XCTestCase {
 
         XCTAssertEqual(mockRepo.transcriptions.count, 1)
         XCTAssertEqual(mockRepo.transcriptions.first?.sourceType, .meeting)
+        XCTAssertEqual(mockRepo.transcriptions.first?.userNotes, "Original decision notes")
+        XCTAssertEqual(mockRepo.transcriptions.first?.recoveredFromCrash, true)
 
         let lastSource = await mockService.lastSource
         XCTAssertEqual(lastSource, .meeting)

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -107,6 +107,22 @@ macparakeet-cli prompts run "Action items" \
 case-insensitive name. Ambiguous prefixes return a `.ambiguous` error so the
 agent can re-prompt the user.
 
+### Inspect meeting recordings
+
+Meeting commands are deterministic local database operations. They do not
+require an LLM provider.
+
+```bash
+macparakeet-cli meetings list --json
+macparakeet-cli meetings show <id-or-prefix-or-title> --json
+macparakeet-cli meetings transcript <id> --format text
+macparakeet-cli meetings transcript <id> --format json
+macparakeet-cli meetings notes get <id> --json
+macparakeet-cli meetings notes append <id> --text "Decision: ship the parser"
+macparakeet-cli meetings notes clear <id> --json
+macparakeet-cli meetings export <id> --format md --stdout
+```
+
 Prompt and direct LLM JSON responses use an envelope with `output`, `provider`,
 `model`, optional `usage`, optional `stopReason`, and `latencyMs`.
 

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -149,6 +149,86 @@ mutually-exclusive combos like `--json` with `--stream`) surface through
 ArgumentParser's plain-text stderr path with exit code `2`. Always branch
 on the exit code first.
 
+## Use it as an agent skill
+
+The clean integration shape is a thin skill wrapper around
+`macparakeet-cli`, not a second transcription implementation. The skill's job
+is to teach an agent when to call the CLI, how to parse the JSON envelopes, and
+which operations are deterministic local database reads/writes.
+
+Claude Code-style skills are a good template because they are just a directory
+with a `SKILL.md` file: the frontmatter names when the skill should load, and
+the body gives concise operating instructions. The same pattern ports to Codex,
+OpenClaw, Hermes, or any agent framework that can shell out to local tools.
+
+```text
+macparakeet-stt/
+  SKILL.md
+```
+
+````markdown
+---
+name: macparakeet-stt
+description: Use when the user asks to transcribe audio or video, inspect or manage MacParakeet meeting recordings, search prior dictations/transcripts, or give an AI agent local speech-to-text tools on Apple Silicon.
+---
+
+# MacParakeet STT
+
+Use `macparakeet-cli` for local-first speech-to-text and meeting artifact
+management on macOS Apple Silicon. STT and database access are local. Do not
+send audio or transcripts to an LLM unless the user explicitly asks for an
+LLM-backed prompt/summary and provides or has configured a provider.
+
+## Startup Check
+
+Run this before real work:
+
+```bash
+macparakeet-cli health --json
+```
+
+If it fails, report the `errorType`/message and stop. Do not guess that models,
+FFmpeg, yt-dlp, or the database are ready.
+
+## Core Commands
+
+```bash
+macparakeet-cli transcribe "<path-or-youtube-url>" --format json
+macparakeet-cli history transcriptions --json
+macparakeet-cli history search-transcriptions "<query>" --json
+macparakeet-cli history search "<query>" --json
+macparakeet-cli meetings list --json
+macparakeet-cli meetings show "<id-or-prefix-or-title>" --json
+macparakeet-cli meetings transcript "<id-or-prefix-or-title>" --format json
+macparakeet-cli meetings notes append "<id-or-prefix-or-title>" --text "<note>" --json
+macparakeet-cli meetings export "<id-or-prefix-or-title>" --format md --stdout
+```
+
+Use `meetings` commands for Granola-style deterministic workflows: list
+recordings, read transcripts, update notes, and export artifacts. These do not
+summarize and do not require an LLM provider.
+
+Only use prompt/LLM commands when the user asks for generated output:
+
+```bash
+macparakeet-cli prompts list --json
+macparakeet-cli prompts run "<prompt-name>" \
+  --transcription "<id-or-prefix-or-title>" \
+  --provider "<provider>" --api-key "$PROVIDER_API_KEY" --model "<model>" \
+  --json
+```
+
+## Operating Rules
+
+- Branch on process exit code first.
+- Parse stdout as JSON for `--json` / `--format json` commands.
+- Treat exit code `2` as invocation misuse; fix the command before retrying.
+- Treat lookup ambiguity as normal; ask for or choose a more specific ID.
+- Never delete user database records unless the user explicitly requests it.
+- Prefer meeting ID or UUID prefix over title when mutating notes.
+- Keep API keys in environment variables; do not put literal keys in commands.
+````
+
 ## Conventions
 
 - **Exit codes:** `0` success, `1` runtime failure (work attempted and failed
@@ -184,9 +264,10 @@ on the exit code first.
 
 - **OpenClaw:** [`openclaw/README.md`](./openclaw/README.md)
 - **Hermes Agent:** [`hermes/README.md`](./hermes/README.md)
-- **Codex CLI / Claude Code / generic AGENTS.md consumers:** read
-  [`/AGENTS.md`](../AGENTS.md) at the repo root, plus this file for the CLI
-  vocabulary.
+- **Claude Code / Codex CLI / generic skill consumers:** use the
+  Claude Code-style `SKILL.md` sketch above for external agents that call
+  `macparakeet-cli`. Coding agents working inside this repository should read
+  [`/AGENTS.md`](../AGENTS.md) instead.
 
 ## Reporting issues
 


### PR DESCRIPTION
## Summary

This promotes meetings into a deterministic local CLI surface without adding an LLM-backed `summarize` command.

```
transcriptions(sourceType: meeting)
        |
        v
macparakeet-cli meetings
        |
        +-- list/show             local metadata + transcript object
        +-- transcript            text/json/srt/vtt
        +-- notes                 get/set/append/clear
        +-- export                md/json local artifact
        |
        v
optional LLM work stays under prompts/llm
```

## What changed

- Added `macparakeet-cli meetings` with `list`, `show`, `transcript`, `notes get|set|append|clear`, and `export`.
- Added meeting-only lookup/query/update helpers so agents can address meetings by UUID, UUID prefix, or exact title without loading every meeting transcript.
- Centralized prompt template assembly in Core and reused it from GUI and CLI.
- Fixed `prompts run` parity for `{{userNotes}}` / `{{transcript}}` rendering and saved `userNotesSnapshot`.
- Preserved durable meeting notes and crash-recovery metadata when retranscribing archived meeting recordings.
- Added explicit core retranscription paths that update the existing row on success and leave it intact on failure, avoiding duplicate transcript rows.
- Centralized SRT/VTT full-transcript fallback so CLI stdout and file exports emit valid subtitle output even without word timestamps.
- Documented a Claude Code-style `SKILL.md` wrapper so external agents can install MacParakeet as a reusable local STT/meeting artifact skill.
- Bumped the CLI contract to `1.3.0` and updated integration docs.

## Boundaries

- No LLM dependency is introduced for meeting commands.
- No live recording control from CLI in this PR.
- No schema migration: this uses existing `transcriptions.sourceType == meeting` and `userNotes` data.

## Verification

- `swift test`
- `swift test --filter 'CLIHelpersTests|TranscriptionRepositoryTests|MeetingsCommandTests'`
- `swift test --filter 'TranscriptionServiceTests|TranscriptionViewModelTests|ExportServiceTests|ExportCommandTests|MeetingsCommandTests|MeetingRecordingRecoveryServiceTests'`
- `swift run macparakeet-cli --version`
- `swift run macparakeet-cli meetings --help`
- `swift run macparakeet-cli meetings notes --help`
- `swift run macparakeet-cli meetings list --json --database <fresh-temp-db>`
