### PR TITLE
[codex] Fix hotkey tap recovery

### DIFF
--- a/Sources/MacParakeet/Hotkey/GlobalShortcutManager.swift
+++ b/Sources/MacParakeet/Hotkey/GlobalShortcutManager.swift
@@ -70,6 +70,7 @@ public final class GlobalShortcutManager {
         installedRunLoop = runLoop
         CFRunLoopAddSource(runLoop, runLoopSource, .commonModes)
         CGEvent.tapEnable(tap: tap, enable: true)
+        syncModifierPressedState()
         return true
     }
 
@@ -94,6 +95,7 @@ public final class GlobalShortcutManager {
             if let tap = eventTap {
                 CGEvent.tapEnable(tap: tap, enable: true)
             }
+            recoverFromDisabledTap()
             return Unmanaged.passUnretained(event)
         }
 
@@ -114,15 +116,18 @@ public final class GlobalShortcutManager {
             return Unmanaged.passUnretained(event)
         }
 
-        let isPressed = event.flags.contains(mask)
+        handleModifierFlagsChanged(flags: event.flags, mask: mask)
+        return Unmanaged.passUnretained(event)
+    }
+
+    private func handleModifierFlagsChanged(flags: CGEventFlags, mask: CGEventFlags) {
+        let isPressed = flags.contains(mask)
         if isPressed != targetModifierWasPressed {
             targetModifierWasPressed = isPressed
             if isPressed {
                 onTrigger?()
             }
         }
-
-        return Unmanaged.passUnretained(event)
     }
 
     private func handleKeyCodeEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
@@ -160,6 +165,33 @@ public final class GlobalShortcutManager {
             flags: event.flags.rawValue & HotkeyTrigger.relevantModifierBits
         )
         return shouldSwallow ? nil : Unmanaged.passUnretained(event)
+    }
+
+    private func recoverFromDisabledTap(flags: CGEventFlags? = nil) {
+        recoverFromDisabledTap(flags: flags, triggerKeyPressed: currentPhysicalTriggerKeyIsPressed())
+    }
+
+    private func recoverFromDisabledTap(flags: CGEventFlags? = nil, triggerKeyPressed: Bool) {
+        triggerKeyIsPressed = triggerKeyPressed
+        syncModifierPressedState(flags: flags)
+    }
+
+    private func currentPhysicalTriggerKeyIsPressed() -> Bool {
+        guard trigger.kind == .keyCode || trigger.kind == .chord,
+              let keyCode = trigger.keyCode else {
+            return false
+        }
+        return CGEventSource.keyState(.combinedSessionState, key: CGKeyCode(keyCode))
+    }
+
+    private func syncModifierPressedState(flags: CGEventFlags? = nil) {
+        guard trigger.kind == .modifier, let mask = targetMask else {
+            targetModifierWasPressed = false
+            return
+        }
+
+        let currentFlags = flags ?? CGEventSource.flagsState(.combinedSessionState)
+        targetModifierWasPressed = currentFlags.contains(mask)
     }
 
     @discardableResult
@@ -200,6 +232,18 @@ public final class GlobalShortcutManager {
             keyCode: keyCode,
             flags: flags & HotkeyTrigger.relevantModifierBits
         )
+    }
+
+    func modifierFlagsChangedForTesting(flags: CGEventFlags) {
+        guard let mask = targetMask else { return }
+        handleModifierFlagsChanged(flags: flags, mask: mask)
+    }
+
+    func recoverFromDisabledTapForTesting(
+        flags: CGEventFlags? = nil,
+        triggerKeyPressed: Bool = false
+    ) {
+        recoverFromDisabledTap(flags: flags, triggerKeyPressed: triggerKeyPressed)
     }
 
     private static func mask(for trigger: HotkeyTrigger) -> CGEventFlags? {

--- a/Sources/MacParakeet/Hotkey/GlobalShortcutManager.swift
+++ b/Sources/MacParakeet/Hotkey/GlobalShortcutManager.swift
@@ -70,7 +70,7 @@ public final class GlobalShortcutManager {
         installedRunLoop = runLoop
         CFRunLoopAddSource(runLoop, runLoopSource, .commonModes)
         CGEvent.tapEnable(tap: tap, enable: true)
-        syncModifierPressedState()
+        recoverFromDisabledTap()
         return true
     }
 

--- a/Sources/MacParakeet/Hotkey/HotkeyManager.swift
+++ b/Sources/MacParakeet/Hotkey/HotkeyManager.swift
@@ -150,7 +150,7 @@ public final class HotkeyManager {
         installedRunLoop = runLoop
         CFRunLoopAddSource(runLoop, runLoopSource, .commonModes)
         CGEvent.tapEnable(tap: tap, enable: true)
-        syncModifierPressedState()
+        recoverFromDisabledTap()
 
         return true
     }

--- a/Sources/MacParakeet/Hotkey/HotkeyManager.swift
+++ b/Sources/MacParakeet/Hotkey/HotkeyManager.swift
@@ -187,7 +187,7 @@ public final class HotkeyManager {
         // Re-enable it to prevent the hotkey from silently dying.
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
             if let tap = eventTap { CGEvent.tapEnable(tap: tap, enable: true) }
-            syncModifierPressedState()
+            recoverFromDisabledTap()
             return Unmanaged.passUnretained(event)
         }
 
@@ -296,6 +296,7 @@ public final class HotkeyManager {
                 return gestureController.triggerPressed(timestampMs: timestampMs)
             }
 
+            guard targetModifierGestureIsActive else { return [] }
             targetModifierGestureIsActive = false
             let outputs: [HotkeyGestureController.Output]
             if bareTap {
@@ -369,6 +370,13 @@ public final class HotkeyManager {
 
     func syncModifierPressedStateForTesting(flags: CGEventFlags) {
         syncModifierPressedState(flags: flags)
+    }
+
+    func recoverFromDisabledTapForTesting(
+        flags: CGEventFlags? = nil,
+        triggerKeyPressed: Bool = false
+    ) {
+        resetGestureState(flags: flags, triggerKeyPressed: triggerKeyPressed)
     }
 
     // MARK: - KeyCode Trigger Path
@@ -490,14 +498,30 @@ public final class HotkeyManager {
 
     /// Reset state machine to idle (e.g., after cancel countdown expires).
     public func resetToIdle(flags: CGEventFlags? = nil) {
+        resetGestureState(flags: flags, triggerKeyPressed: false)
+    }
+
+    private func recoverFromDisabledTap(flags: CGEventFlags? = nil) {
+        resetGestureState(flags: flags, triggerKeyPressed: currentPhysicalTriggerKeyIsPressed())
+    }
+
+    private func resetGestureState(flags: CGEventFlags? = nil, triggerKeyPressed: Bool) {
         cancelStartupTimer()
         cancelHoldTimer()
-        triggerKeyIsPressed = false
+        triggerKeyIsPressed = triggerKeyPressed
         chordModifierReleased = false
         targetModifierGestureIsActive = false
         bareTap = true
         gestureController.reset()
         syncModifierPressedState(flags: flags)
+    }
+
+    private func currentPhysicalTriggerKeyIsPressed() -> Bool {
+        guard trigger.kind == .keyCode || trigger.kind == .chord,
+              let keyCode = trigger.keyCode else {
+            return false
+        }
+        return CGEventSource.keyState(.combinedSessionState, key: CGKeyCode(keyCode))
     }
 
     private func syncModifierPressedState(flags: CGEventFlags? = nil) {

--- a/Tests/MacParakeetTests/Hotkey/GlobalShortcutManagerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/GlobalShortcutManagerTests.swift
@@ -1,8 +1,97 @@
 import XCTest
+import CoreGraphics
 @testable import MacParakeet
 @testable import MacParakeetCore
 
 final class GlobalShortcutManagerTests: XCTestCase {
+    func testTapRecoveryResyncsModifierAfterMissedRelease() {
+        let manager = GlobalShortcutManager(trigger: .fn)
+        var triggerCount = 0
+        manager.onTrigger = { triggerCount += 1 }
+
+        manager.modifierFlagsChangedForTesting(flags: [.maskSecondaryFn])
+        XCTAssertEqual(triggerCount, 1)
+
+        manager.recoverFromDisabledTapForTesting(flags: [])
+        manager.modifierFlagsChangedForTesting(flags: [.maskSecondaryFn])
+
+        XCTAssertEqual(triggerCount, 2)
+    }
+
+    func testTapRecoveryAllowsChordAfterMissedKeyUp() {
+        let trigger = HotkeyTrigger.chord(modifiers: ["command", "shift"], keyCode: 46)
+        let manager = GlobalShortcutManager(trigger: trigger)
+        var triggerCount = 0
+        manager.onTrigger = { triggerCount += 1 }
+
+        XCTAssertTrue(
+            manager.handleChordEventForTesting(
+                type: .keyDown,
+                keyCode: 46,
+                flags: trigger.chordEventFlags
+            )
+        )
+        XCTAssertTrue(
+            manager.handleChordEventForTesting(
+                type: .keyDown,
+                keyCode: 46,
+                flags: trigger.chordEventFlags
+            )
+        )
+        XCTAssertEqual(triggerCount, 1)
+
+        manager.recoverFromDisabledTapForTesting(triggerKeyPressed: false)
+        XCTAssertTrue(
+            manager.handleChordEventForTesting(
+                type: .keyDown,
+                keyCode: 46,
+                flags: trigger.chordEventFlags
+            )
+        )
+
+        XCTAssertEqual(triggerCount, 2)
+    }
+
+    func testTapRecoveryPreservesHeldChordKeyToAvoidRepeatTrigger() {
+        let trigger = HotkeyTrigger.chord(modifiers: ["command", "shift"], keyCode: 46)
+        let manager = GlobalShortcutManager(trigger: trigger)
+        var triggerCount = 0
+        manager.onTrigger = { triggerCount += 1 }
+
+        XCTAssertTrue(
+            manager.handleChordEventForTesting(
+                type: .keyDown,
+                keyCode: 46,
+                flags: trigger.chordEventFlags
+            )
+        )
+        manager.recoverFromDisabledTapForTesting(triggerKeyPressed: true)
+
+        XCTAssertTrue(
+            manager.handleChordEventForTesting(
+                type: .keyDown,
+                keyCode: 46,
+                flags: trigger.chordEventFlags
+            )
+        )
+        XCTAssertEqual(triggerCount, 1)
+        XCTAssertTrue(
+            manager.handleChordEventForTesting(
+                type: .keyUp,
+                keyCode: 46,
+                flags: trigger.chordEventFlags
+            )
+        )
+        XCTAssertTrue(
+            manager.handleChordEventForTesting(
+                type: .keyDown,
+                keyCode: 46,
+                flags: trigger.chordEventFlags
+            )
+        )
+        XCTAssertEqual(triggerCount, 2)
+    }
+
     func testChordRequiresExactModifierMatch() {
         let trigger = HotkeyTrigger.chord(modifiers: ["command", "shift"], keyCode: 46)
         let manager = GlobalShortcutManager(trigger: trigger)

--- a/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
@@ -12,6 +12,65 @@ final class HotkeyManagerTests: XCTestCase {
         CGEventFlags(rawValue: masks.reduce(0, |))
     }
 
+    func testTapRecoveryResetsPendingModifierGesture() {
+        let manager = HotkeyManager(trigger: .fn)
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_000
+            ),
+            [
+                .scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs),
+                .scheduleHoldWindow(milliseconds: FnKeyStateMachine.defaultTapThresholdMs),
+            ]
+        )
+
+        manager.recoverFromDisabledTapForTesting(flags: [])
+
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [])
+        XCTAssertEqual(manager.holdWindowElapsedForTesting(), [])
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_100
+            ),
+            [
+                .scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs),
+                .scheduleHoldWindow(milliseconds: FnKeyStateMachine.defaultTapThresholdMs),
+            ]
+        )
+    }
+
+    func testTapRecoveryResyncsStillHeldModifierWithoutReleaseOutput() {
+        let manager = HotkeyManager(trigger: .fn)
+
+        _ = manager.modifierFlagsChangedOutputsForTesting(
+            flags: [.maskSecondaryFn],
+            timestampMs: 1_000
+        )
+
+        manager.recoverFromDisabledTapForTesting(flags: [.maskSecondaryFn])
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_050
+            ),
+            []
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_100
+            ),
+            [
+                .scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs),
+                .scheduleHoldWindow(milliseconds: FnKeyStateMachine.defaultTapThresholdMs),
+            ]
+        )
+    }
+
     func testAdditionalModifierInterruptsBareFnBeforeStartup() {
         let manager = HotkeyManager(trigger: .fn)
 
@@ -47,6 +106,28 @@ final class HotkeyManagerTests: XCTestCase {
                 .cancelHoldWindow,
             ]
         )
+    }
+
+    func testRegularKeyInterruptsBareFnAndCancelsPendingTimers() {
+        let manager = HotkeyManager(trigger: .fn)
+
+        _ = manager.modifierFlagsChangedOutputsForTesting(
+            flags: [.maskSecondaryFn],
+            timestampMs: 1_000
+        )
+
+        XCTAssertEqual(
+            manager.modifierKeyDownOutputsForTesting(
+                keyCode: 0,
+                timestampMs: 1_050
+            ),
+            [
+                .cancelStartupDebounce,
+                .cancelHoldWindow,
+            ]
+        )
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [])
+        XCTAssertEqual(manager.holdWindowElapsedForTesting(), [])
     }
 
     func testAdditionalModifierSilentlyDiscardsAfterProvisionalStartup() {

--- a/docs/audits/2026-04-26-codebase-audit.md
+++ b/docs/audits/2026-04-26-codebase-audit.md
@@ -9,9 +9,9 @@
 | | Count |
 |---|---:|
 | Total findings (P0 / P1 / P2) | 70 |
-| FIXED | 28 |
+| FIXED | 30 |
 | REFUTED on verification | 5 |
-| DEFERRED with reason | 37 |
+| DEFERRED with reason | 35 |
 
 ---
 
@@ -135,10 +135,10 @@ Status legend: **FIXED** (commit referenced) · **REFUTED** (with reason) ·
 
 | ID | Title | Status | Note |
 |---|---|---|---|
-| AUDIT-046 | Tap re-enable doesn't reset edge flags | DEFERRED | HIGH regression risk — needs Mac runtime verification before/after with active dictation hotkey. |
+| AUDIT-046 | Tap re-enable doesn't reset edge flags | FIXED | Follow-up PR resets stale gesture state after tap re-enable, cancels pending timers, resyncs modifier edges, and preserves physical key-held state so held repeats are not treated as new triggers. |
 | AUDIT-047 | Tap callback races with MainActor closures | DEFERRED | Same regression-risk class. |
 | AUDIT-048 | Mach time conversion assumes 1:1 timebase | DEFERRED | P2; precision-only. |
-| AUDIT-049 | `bareTap` invalidation doesn't cancel debounce timer | DEFERRED | Same regression-risk class as AUDIT-046. |
+| AUDIT-049 | `bareTap` invalidation doesn't cancel debounce timer | FIXED | Regression tests lock that regular-key bare-tap interruption cancels startup/hold windows; tap-disabled recovery also resets the gesture controller so stale timer callbacks cannot start or stop recording. |
 | AUDIT-050 | Paste pipeline doesn't verify frontmost app | DEFERRED | Focus race window 0–15ms; fix needs careful UX consideration. |
 | AUDIT-051 | `start()` doesn't log `AXIsProcessTrusted` on tap failure | FIXED | `2a0e557b` (#154). Observability-only; one-line OSLog warning on the existing failure branch. Distinguishes Accessibility-permission denial from generic system error in log triage. |
 | AUDIT-052 | `GlobalShortcutManager` swallows unrelated shortcuts | DEFERRED | P2. |
@@ -202,8 +202,9 @@ Status legend: **FIXED** (commit referenced) · **REFUTED** (with reason) ·
 5. **Threading-boundary fragility at C-callback / Swift-Concurrency seams** —
    CGEvent tap → MainActor, URLSession callbacks → actor state, Core Audio IO
    block → @unchecked Sendable. Recurring pattern; partial mitigation via
-   AUDIT-006 watchdog and AUDIT-031 pipe-drain ordering. Hotkey-state-machine
-   race fixes (AUDIT-046 / 047 / 049) deferred pending runtime verification.
+   AUDIT-006 watchdog and AUDIT-031 pipe-drain ordering. Hotkey tap recovery
+   now resets edge state and pending timers (AUDIT-046 / 049); the callback
+   actor-boundary concern remains deferred (AUDIT-047).
 
 6. **External fragility with no fallback** — Single-endpoint network
    preflight (AUDIT-066), single LLM provider with tight timeouts and no
@@ -247,9 +248,9 @@ Status legend: **FIXED** (commit referenced) · **REFUTED** (with reason) ·
 
 The deferred items, in priority order:
 
-1. **Hotkey state-machine fixes** (AUDIT-046 / 047 / 049 / 050). Real bugs;
-   the only blocker is regression risk on a delicate area that needs Mac
-   runtime verification before/after with the dictation hotkey active.
+1. **Hotkey/paste follow-ups** (AUDIT-047 / 050; AUDIT-048 / 052 lower-risk
+   P2). Remaining items need careful runtime verification around active
+   dictation and paste targeting.
 2. **Notes durability — scene-phase persistence + lock-file rotation flush**
    (AUDIT-002 follow-up). The narrowed crash-window concern remains.
 3. **Test-quality cleanup** (AUDIT-059 / 060 / 061 / 062 / 063). 92 hardcoded
@@ -280,3 +281,6 @@ The deferred items, in priority order:
 - **2026-04-26 AUDIT-003 follow-up** — `MeetingAudioStorageWriter` no longer
   declares blanket `@unchecked Sendable`; finalization uses a narrow
   AVFoundation callback bridge while writer access remains actor-owned.
+- **2026-04-26 AUDIT-046/AUDIT-049 follow-up** — hotkey tap-disabled recovery
+  now resets stale gesture state, cancels pending startup/hold timers, and
+  resyncs edge detection without changing normal dictation gestures.


### PR DESCRIPTION
## Summary
- Recover cleanly when macOS temporarily disables and re-enables the hotkey event tap.
- Reset stale dictation gesture state, cancel pending startup/hold timers, and resync modifier/key edges without changing normal hotkey gestures.
- Mark AUDIT-046 and AUDIT-049 fixed; leave the callback-isolation and paste-targeting items deferred.

## Validation
- `swift build -Xswiftc -warn-concurrency`
- `swift build -Xswiftc -swift-version -Xswiftc 6`
- `swift test --filter 'HotkeyManagerTests|GlobalShortcutManagerTests|HotkeyGestureControllerTests|FnKeyStateMachineTests|DictationFlowStateMachineTests'`
- `git diff --check`