### PR TITLE
Fix active dictation state during hotkey tap recovery

### DIFF
--- a/Sources/MacParakeet/Hotkey/HotkeyManager.swift
+++ b/Sources/MacParakeet/Hotkey/HotkeyManager.swift
@@ -43,6 +43,7 @@ public final class HotkeyManager {
     /// For chord triggers: true after a required modifier was released while the key was still held.
     /// Prevents double fnUp when the key is subsequently released.
     private var chordModifierReleased = false
+    private var activeRecordingMode: FnKeyStateMachine.RecordingMode?
 
     /// Bare-tap filtering: true until a non-Escape key is pressed while modifier is held.
     private var bareTap = true
@@ -176,6 +177,7 @@ public final class HotkeyManager {
         targetModifierGestureIsActive = false
         triggerKeyIsPressed = false
         chordModifierReleased = false
+        activeRecordingMode = nil
         bareTap = true
         gestureController.reset()
     }
@@ -187,7 +189,7 @@ public final class HotkeyManager {
         // Re-enable it to prevent the hotkey from silently dying.
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
             if let tap = eventTap { CGEvent.tapEnable(tap: tap, enable: true) }
-            recoverFromDisabledTap()
+            recoverFromDisabledTap(timestampMs: UInt64(event.timestamp / 1_000_000))
             return Unmanaged.passUnretained(event)
         }
 
@@ -349,6 +351,7 @@ public final class HotkeyManager {
         timestampMs: UInt64
     ) -> [HotkeyGestureController.Output] {
         let outputs = modifierFlagsChangedOutputs(flags: flags, timestampMs: timestampMs)
+        rememberRecordingState(for: outputs)
         previousModifierFlags = flags
         return outputs
     }
@@ -357,26 +360,38 @@ public final class HotkeyManager {
         keyCode: Int64,
         timestampMs: UInt64
     ) -> [HotkeyGestureController.Output] {
-        modifierKeyDownOutputs(keyCode: keyCode, timestampMs: timestampMs)
+        let outputs = modifierKeyDownOutputs(keyCode: keyCode, timestampMs: timestampMs)
+        rememberRecordingState(for: outputs)
+        return outputs
     }
 
     func startupDebounceElapsedForTesting() -> [HotkeyGestureController.Output] {
-        gestureController.startupDebounceElapsed()
+        let outputs = gestureController.startupDebounceElapsed()
+        rememberRecordingState(for: outputs)
+        return outputs
     }
 
     func holdWindowElapsedForTesting() -> [HotkeyGestureController.Output] {
-        gestureController.holdWindowElapsed()
+        let outputs = gestureController.holdWindowElapsed()
+        rememberRecordingState(for: outputs)
+        return outputs
     }
 
     func syncModifierPressedStateForTesting(flags: CGEventFlags) {
         syncModifierPressedState(flags: flags)
     }
 
+    @discardableResult
     func recoverFromDisabledTapForTesting(
         flags: CGEventFlags? = nil,
-        triggerKeyPressed: Bool = false
-    ) {
-        resetGestureState(flags: flags, triggerKeyPressed: triggerKeyPressed)
+        triggerKeyPressed: Bool = false,
+        timestampMs: UInt64 = HotkeyManager.currentTimestampMs()
+    ) -> [HotkeyGestureController.Output] {
+        recoverFromDisabledTap(
+            flags: flags,
+            triggerKeyPressed: triggerKeyPressed,
+            timestampMs: timestampMs
+        )
     }
 
     // MARK: - KeyCode Trigger Path
@@ -489,11 +504,13 @@ public final class HotkeyManager {
     /// Blocks hotkey during the cancel countdown window.
     public func notifyCancelledByUI() {
         gestureController.notifyCancelledByUI()
+        activeRecordingMode = nil
     }
 
     /// Resume recording mode after undo, so hotkey stops the recording correctly.
     public func resumeRecording(mode: FnKeyStateMachine.RecordingMode) {
         gestureController.resumeRecording(mode: mode)
+        activeRecordingMode = mode
     }
 
     /// Reset state machine to idle (e.g., after cancel countdown expires).
@@ -501,8 +518,67 @@ public final class HotkeyManager {
         resetGestureState(flags: flags, triggerKeyPressed: false)
     }
 
-    private func recoverFromDisabledTap(flags: CGEventFlags? = nil) {
-        resetGestureState(flags: flags, triggerKeyPressed: currentPhysicalTriggerKeyIsPressed())
+    @discardableResult
+    private func recoverFromDisabledTap(
+        flags: CGEventFlags? = nil,
+        timestampMs: UInt64 = HotkeyManager.currentTimestampMs()
+    ) -> [HotkeyGestureController.Output] {
+        recoverFromDisabledTap(
+            flags: flags,
+            triggerKeyPressed: currentPhysicalTriggerKeyIsPressed(),
+            timestampMs: timestampMs
+        )
+    }
+
+    @discardableResult
+    private func recoverFromDisabledTap(
+        flags: CGEventFlags? = nil,
+        triggerKeyPressed: Bool,
+        timestampMs: UInt64
+    ) -> [HotkeyGestureController.Output] {
+        let triggerPressed = currentPhysicalTriggerIsPressed(
+            flags: flags,
+            triggerKeyPressed: triggerKeyPressed
+        )
+
+        switch activeRecordingMode {
+        case .holdToTalk:
+            cancelStartupTimer()
+            syncRecoveredTriggerState(
+                flags: flags,
+                triggerKeyPressed: triggerKeyPressed,
+                triggerPressed: triggerPressed
+            )
+            guard !triggerPressed else { return [] }
+
+            let outputs = gestureController.triggerReleased(timestampMs: timestampMs)
+            if trigger.kind == .chord, triggerKeyPressed {
+                chordModifierReleased = true
+            }
+            if trigger.kind == .modifier {
+                targetModifierGestureIsActive = false
+                bareTap = true
+            }
+            handleOutputs(outputs)
+            return outputs
+
+        case .persistent:
+            cancelStartupTimer()
+            cancelHoldTimer()
+            syncRecoveredTriggerState(
+                flags: flags,
+                triggerKeyPressed: triggerKeyPressed,
+                triggerPressed: triggerPressed
+            )
+            if trigger.kind == .chord, triggerKeyPressed, !triggerPressed {
+                chordModifierReleased = true
+            }
+            return []
+
+        case nil:
+            resetGestureState(flags: flags, triggerKeyPressed: triggerKeyPressed)
+            return []
+        }
     }
 
     private func resetGestureState(flags: CGEventFlags? = nil, triggerKeyPressed: Bool) {
@@ -511,9 +587,62 @@ public final class HotkeyManager {
         triggerKeyIsPressed = triggerKeyPressed
         chordModifierReleased = false
         targetModifierGestureIsActive = false
+        activeRecordingMode = nil
         bareTap = true
         gestureController.reset()
         syncModifierPressedState(flags: flags)
+    }
+
+    private static func currentTimestampMs() -> UInt64 {
+        DispatchTime.now().uptimeNanoseconds / 1_000_000
+    }
+
+    private func currentPhysicalTriggerIsPressed(
+        flags: CGEventFlags? = nil,
+        triggerKeyPressed: Bool
+    ) -> Bool {
+        switch trigger.kind {
+        case .modifier:
+            let currentFlags = flags ?? CGEventSource.flagsState(.combinedSessionState)
+            if let targetKeyCode = trigger.modifierKeyCode {
+                return Self.sideSpecificModifierIsPressed(flags: currentFlags, keyCode: targetKeyCode)
+            }
+            if let mask = targetMask {
+                return currentFlags.contains(mask)
+            }
+            return false
+        case .keyCode:
+            return triggerKeyPressed
+        case .chord:
+            guard triggerKeyPressed else { return false }
+            let currentFlags = flags ?? CGEventSource.flagsState(.combinedSessionState)
+            return currentFlags.rawValue & requiredChordFlags == requiredChordFlags
+        case .disabled:
+            return false
+        }
+    }
+
+    private func syncRecoveredTriggerState(
+        flags: CGEventFlags? = nil,
+        triggerKeyPressed: Bool,
+        triggerPressed: Bool
+    ) {
+        triggerKeyIsPressed = triggerKeyPressed
+        syncModifierPressedState(flags: flags)
+
+        switch trigger.kind {
+        case .modifier:
+            targetModifierGestureIsActive = triggerPressed
+            if !triggerPressed {
+                bareTap = true
+            }
+        case .chord:
+            if triggerPressed {
+                chordModifierReleased = false
+            }
+        default:
+            break
+        }
     }
 
     private func currentPhysicalTriggerKeyIsPressed() -> Bool {
@@ -575,6 +704,8 @@ public final class HotkeyManager {
     }
 
     private func handleOutputs(_ outputs: [HotkeyGestureController.Output]) {
+        rememberRecordingState(for: outputs)
+
         for output in outputs {
             switch output {
             case .startRecording(let mode):
@@ -597,6 +728,19 @@ public final class HotkeyManager {
                 cancelStartupTimer()
             case .cancelHoldWindow:
                 cancelHoldTimer()
+            }
+        }
+    }
+
+    private func rememberRecordingState(for outputs: [HotkeyGestureController.Output]) {
+        for output in outputs {
+            switch output {
+            case .startRecording(let mode):
+                activeRecordingMode = mode
+            case .stopRecording, .cancelRecording, .discardRecording:
+                activeRecordingMode = nil
+            default:
+                break
             }
         }
     }

--- a/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
@@ -71,6 +71,108 @@ final class HotkeyManagerTests: XCTestCase {
         )
     }
 
+    func testTapRecoveryDuringActiveHoldToTalkStopsOnRelease() {
+        let manager = HotkeyManager(trigger: .fn)
+
+        _ = manager.modifierFlagsChangedOutputsForTesting(
+            flags: [.maskSecondaryFn],
+            timestampMs: 1_000
+        )
+        XCTAssertEqual(
+            manager.startupDebounceElapsedForTesting(),
+            [.startRecording(mode: .holdToTalk)]
+        )
+
+        XCTAssertEqual(
+            manager.recoverFromDisabledTapForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_150
+            ),
+            []
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_500
+            ),
+            [
+                .cancelStartupDebounce,
+                .cancelHoldWindow,
+                .stopRecording,
+            ]
+        )
+    }
+
+    func testTapRecoveryDuringActiveHoldToTalkStopsIfReleaseWasMissed() {
+        let manager = HotkeyManager(trigger: .fn)
+
+        _ = manager.modifierFlagsChangedOutputsForTesting(
+            flags: [.maskSecondaryFn],
+            timestampMs: 1_000
+        )
+        XCTAssertEqual(
+            manager.startupDebounceElapsedForTesting(),
+            [.startRecording(mode: .holdToTalk)]
+        )
+
+        XCTAssertEqual(
+            manager.recoverFromDisabledTapForTesting(
+                flags: [],
+                timestampMs: 1_500
+            ),
+            [
+                .cancelStartupDebounce,
+                .cancelHoldWindow,
+                .stopRecording,
+            ]
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_600
+            ),
+            [
+                .scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs),
+                .scheduleHoldWindow(milliseconds: FnKeyStateMachine.defaultTapThresholdMs),
+            ]
+        )
+    }
+
+    func testTapRecoveryDuringPersistentRecordingPreservesStopGesture() {
+        let manager = HotkeyManager(trigger: .fn)
+
+        _ = manager.modifierFlagsChangedOutputsForTesting(
+            flags: [.maskSecondaryFn],
+            timestampMs: 1_000
+        )
+        _ = manager.modifierFlagsChangedOutputsForTesting(
+            flags: [],
+            timestampMs: 1_050
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_100
+            ),
+            [.startRecording(mode: .persistent)]
+        )
+
+        XCTAssertEqual(
+            manager.recoverFromDisabledTapForTesting(
+                flags: [],
+                timestampMs: 1_150
+            ),
+            []
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_200
+            ),
+            [.stopRecording]
+        )
+    }
+
     func testAdditionalModifierInterruptsBareFnBeforeStartup() {
         let manager = HotkeyManager(trigger: .fn)
 


### PR DESCRIPTION
## Summary
- Keeps hotkey tap recovery from resetting dictation while recording is already active.
- Hold-to-talk now still stops on release after recovery, including a missed-release recovery case.
- Persistent dictation keeps the next hotkey press as the stop action.

## Validation
- swift test --filter 'HotkeyManagerTests|GlobalShortcutManagerTests|HotkeyGestureControllerTests|FnKeyStateMachineTests|DictationFlowStateMachineTests'
- swift build -Xswiftc -warn-concurrency
- swift build -Xswiftc -swift-version -Xswiftc 6
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missed or unregistered hotkey taps with enhanced recovery logic that adapts based on the current recording mode.

* **Tests**
  * Added comprehensive test coverage for gesture recovery behavior across different recording modes, including hold-to-talk and persistent modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->