### PR TITLE
Add canonical observability operation events

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -87,6 +87,11 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
   These commands expose meeting recordings without requiring any LLM provider:
   metadata, notes, transcript text, timestamp formats, and Markdown/JSON
   exports are all local database reads/writes.
+- `transcribe` now initializes the shared telemetry client and emits a
+  privacy-safe `cli_operation` product-health event after execution. This does
+  not change stdout, stderr, JSON schemas, or exit codes; it follows the GUI
+  telemetry preference and can be disabled per process with
+  `MACPARAKEET_TELEMETRY=0`.
 
 ### Fixed
 

--- a/Sources/CLI/Commands/CLITelemetry.swift
+++ b/Sources/CLI/Commands/CLITelemetry.swift
@@ -1,0 +1,47 @@
+import Foundation
+import MacParakeetCore
+
+enum CLITelemetry {
+    static func configureIfNeeded() {
+        let environment = ProcessInfo.processInfo.environment
+        if let override = environment["MACPARAKEET_TELEMETRY"]?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+           ["0", "false", "no", "off"].contains(override) {
+            Telemetry.configure(NoOpTelemetryService())
+            return
+        }
+
+        Telemetry.configure(TelemetryService(
+            requestTimeoutInterval: 1.0,
+            isEnabled: {
+                AppPreferences.isTelemetryEnabled(defaults: macParakeetAppDefaults())
+            }
+        ))
+    }
+
+    static func sendOperationAndFlush(
+        operationID: String,
+        command: String,
+        subcommand: String? = nil,
+        outcome: ObservabilityOutcome,
+        startedAt: Date,
+        inputKind: ObservabilityInputKind? = nil,
+        outputFormat: String? = nil,
+        json: Bool? = nil,
+        exitCode: Int? = nil,
+        errorType: String? = nil
+    ) async {
+        Telemetry.send(.cliOperation(
+            operationID: operationID,
+            command: command,
+            subcommand: subcommand,
+            outcome: outcome,
+            durationSeconds: Observability.durationSeconds(since: startedAt),
+            inputKind: inputKind,
+            outputFormat: outputFormat,
+            json: json,
+            exitCode: exitCode,
+            errorType: errorType
+        ))
+        await Telemetry.flush()
+    }
+}

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -58,17 +58,24 @@ struct TranscribeCommand: AsyncParsableCommand {
     }
 
     func run() async throws {
+        CLITelemetry.configureIfNeeded()
+        let cliOperationID = Observability.operationID()
+        let cliStartedAt = Date()
         let trimmedInput = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        let inputKind: ObservabilityInputKind = YouTubeURLValidator.isYouTubeURL(trimmedInput)
+            ? .youtube
+            : (Observability.inputKind(for: URL(fileURLWithPath: trimmedInput)) ?? .unknown)
 
-        // Set up services
-        try AppPaths.ensureDirectories()
-        let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
-        let transcriptionRepo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
-        let customWordRepo = CustomWordRepository(dbQueue: dbManager.dbQueue)
-        let snippetRepo = TextSnippetRepository(dbQueue: dbManager.dbQueue)
-        let sttClient = STTClient()
+        var sttClient: STTClient?
         let runResult: Result<Void, Error>
         do {
+            try AppPaths.ensureDirectories()
+            let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
+            let transcriptionRepo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
+            let customWordRepo = CustomWordRepository(dbQueue: dbManager.dbQueue)
+            let snippetRepo = TextSnippetRepository(dbQueue: dbManager.dbQueue)
+            let createdSTTClient = STTClient()
+            sttClient = createdSTTClient
             let audioProcessor = AudioProcessor()
             let youtubeDownloader = YouTubeDownloader()
             let entitlementsService = enforceEntitlements ? makeEntitlementsService() : nil
@@ -81,7 +88,7 @@ struct TranscribeCommand: AsyncParsableCommand {
             let diarizationService: DiarizationService? = noDiarize ? nil : DiarizationService()
             let service = TranscriptionService(
                 audioProcessor: audioProcessor,
-                sttTranscriber: sttClient,
+                sttTranscriber: createdSTTClient,
                 transcriptionRepo: transcriptionRepo,
                 entitlements: entitlementsService,
                 customWordRepo: customWordRepo,
@@ -144,7 +151,31 @@ struct TranscribeCommand: AsyncParsableCommand {
             runResult = .failure(error)
         }
 
-        await sttClient.shutdown()
+        await sttClient?.shutdown()
+        let cliOutcome: ObservabilityOutcome
+        let exitCode: Int
+        let errorType: String?
+        switch runResult {
+        case .success:
+            cliOutcome = .success
+            exitCode = 0
+            errorType = nil
+        case .failure(let error):
+            cliOutcome = .failure
+            exitCode = 1
+            errorType = Observability.errorType(for: error)
+        }
+        await CLITelemetry.sendOperationAndFlush(
+            operationID: cliOperationID,
+            command: "transcribe",
+            outcome: cliOutcome,
+            startedAt: cliStartedAt,
+            inputKind: inputKind,
+            outputFormat: format.rawValue,
+            json: format == .json,
+            exitCode: exitCode,
+            errorType: errorType
+        )
         try runResult.get()
     }
 

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -36,6 +36,8 @@ final class MeetingRecordingFlowCoordinator {
     private var pillPollingTask: Task<Void, Never>?
     private var transcriptObservationTask: Task<Void, Never>?
     private var completedTranscription: Transcription?
+    private var currentMeetingOperationID: String?
+    private var currentMeetingTrigger: TelemetryMeetingRecordingTrigger?
 
     init(
         meetingRecordingService: MeetingRecordingServiceProtocol,
@@ -260,6 +262,9 @@ final class MeetingRecordingFlowCoordinator {
             let title = pendingTitle
             pendingTrigger = nil
             pendingTitle = nil
+            let operationID = Observability.operationID()
+            currentMeetingOperationID = operationID
+            currentMeetingTrigger = trigger
             actionTask = Task { @MainActor in
                 do {
                     try await meetingRecordingService.startRecording(title: title)
@@ -281,6 +286,13 @@ final class MeetingRecordingFlowCoordinator {
                         Telemetry.send(.calendarAutoStartFailed(reason: "service_threw"))
                         self.onAutoStartFailed?()
                     }
+                    self.sendMeetingOperation(
+                        outcome: .failure,
+                        trigger: trigger,
+                        errorType: TelemetryErrorClassifier.classify(error)
+                    )
+                    self.currentMeetingOperationID = nil
+                    self.currentMeetingTrigger = nil
                     self.sendEvent(.startFailed(generation: gen, message: error.localizedDescription))
                 }
             }
@@ -319,12 +331,14 @@ final class MeetingRecordingFlowCoordinator {
             let liveTranscriptLagged = panelViewModel?.isTranscriptionLagging ?? false
             let notesVM = panelViewModel?.notesViewModel
             actionTask = Task { @MainActor in
+                var stoppedOutput: MeetingRecordingOutput?
                 do {
                     // Flush any keystrokes typed in the last < 250 ms so
                     // they make it onto the lock file and into the saved
                     // Transcription.userNotes (ADR-020 §8).
                     await notesVM?.commit()
                     let output = try await meetingRecordingService.stopRecording()
+                    stoppedOutput = output
                     Telemetry.send(.meetingRecordingCompleted(
                         durationSeconds: output.durationSeconds,
                         liveWordCount: liveWordCount,
@@ -332,6 +346,14 @@ final class MeetingRecordingFlowCoordinator {
                     ))
                     let transcription = try await transcriptionService.transcribeMeeting(recording: output, onProgress: nil)
                     await meetingRecordingService.completeTranscription(for: output)
+                    self.sendMeetingOperation(
+                        outcome: .success,
+                        output: output,
+                        liveWordCount: liveWordCount,
+                        liveTranscriptLagged: liveTranscriptLagged
+                    )
+                    self.currentMeetingOperationID = nil
+                    self.currentMeetingTrigger = nil
                     self.completedTranscription = transcription
                     self.sendEvent(.transcriptionCompleted(generation: gen, transcriptionID: transcription.id))
                 } catch {
@@ -339,6 +361,15 @@ final class MeetingRecordingFlowCoordinator {
                         errorType: TelemetryErrorClassifier.classify(error),
                         errorDetail: TelemetryErrorClassifier.errorDetail(error)
                     ))
+                    self.sendMeetingOperation(
+                        outcome: .failure,
+                        output: stoppedOutput,
+                        liveWordCount: liveWordCount,
+                        liveTranscriptLagged: liveTranscriptLagged,
+                        errorType: TelemetryErrorClassifier.classify(error)
+                    )
+                    self.currentMeetingOperationID = nil
+                    self.currentMeetingTrigger = nil
                     self.sendEvent(.transcriptionFailed(generation: gen, message: error.localizedDescription))
                 }
             }
@@ -366,6 +397,12 @@ final class MeetingRecordingFlowCoordinator {
                 await notesVM?.commit()
                 await meetingRecordingService.cancelRecording()
                 Telemetry.send(.meetingRecordingCancelled(durationSeconds: durationSeconds))
+                self.sendMeetingOperation(
+                    outcome: .cancelled,
+                    durationSeconds: durationSeconds
+                )
+                self.currentMeetingOperationID = nil
+                self.currentMeetingTrigger = nil
             }
 
         case .showError(let message):
@@ -578,5 +615,31 @@ final class MeetingRecordingFlowCoordinator {
 
     private func hideMeetingPanel() {
         panelController?.hide()
+    }
+
+    private func sendMeetingOperation(
+        outcome: ObservabilityOutcome,
+        trigger: TelemetryMeetingRecordingTrigger? = nil,
+        output: MeetingRecordingOutput? = nil,
+        durationSeconds: Double? = nil,
+        liveWordCount: Int? = nil,
+        liveTranscriptLagged: Bool? = nil,
+        errorType: String? = nil
+    ) {
+        guard let operationID = currentMeetingOperationID else { return }
+        let notes = output?.userNotes?.trimmingCharacters(in: .whitespacesAndNewlines)
+        Telemetry.send(.meetingOperation(
+            operationID: operationID,
+            outcome: outcome,
+            trigger: trigger ?? currentMeetingTrigger,
+            durationSeconds: output?.durationSeconds ?? durationSeconds,
+            liveWordCount: liveWordCount,
+            liveTranscriptLagged: liveTranscriptLagged,
+            microphoneTrackPresent: output.map { $0.sourceAlignment.microphone != nil },
+            systemTrackPresent: output.map { $0.sourceAlignment.system != nil },
+            notesUsed: notes.map { !$0.isEmpty },
+            notesLengthBucket: output.map { Observability.textLengthBucket($0.userNotes) },
+            errorType: errorType
+        ))
     }
 }

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -83,8 +83,8 @@ final class MeetingRecordingFlowCoordinator {
     /// Pre-set title for the *next* `.startRecording` effect. Paired with
     /// `pendingTrigger`: `startFromCalendar(title:)` sets both, the
     /// `.startRecording` handler snapshots and clears both before the async
-    /// hop. Manual / hotkey starts leave it nil and the service falls back
-    /// to its date-based default.
+    /// hop. Manual / hotkey starts set only the trigger, so the service falls
+    /// back to its date-based default title.
     private var pendingTitle: String?
 
     /// Optional callback fired when an auto-start attempt couldn't actually
@@ -95,9 +95,10 @@ final class MeetingRecordingFlowCoordinator {
     /// doesn't suppress the *next* meeting's auto-stop.
     var onAutoStartFailed: (() -> Void)?
 
-    func toggleRecording() {
+    func toggleRecording(trigger: TelemetryMeetingRecordingTrigger = .manual) {
         switch stateMachine.state {
         case .idle:
+            pendingTrigger = pendingTrigger ?? trigger
             sendEvent(.startRequested)
         case .recording, .starting, .stopping:
             sendEvent(.stopRequested)

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -296,7 +296,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     self?.windowCoordinator.openMainWindow()
                 },
                 onToggleMeetingRecordingFromHotkey: { [weak self] in
-                    self?.toggleMeetingRecording(originatesFromWindow: false)
+                    self?.toggleMeetingRecording(originatesFromWindow: false, trigger: .hotkey)
                 },
                 onTriggerFileTranscriptionFromHotkey: { [weak self] in
                     self?.triggerFileTranscriptionFromHotkey()
@@ -461,7 +461,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Meeting Recording
 
-    private func toggleMeetingRecording(originatesFromWindow: Bool) {
+    private func toggleMeetingRecording(
+        originatesFromWindow: Bool,
+        trigger: TelemetryMeetingRecordingTrigger = .manual
+    ) {
         guard appEnvironment != nil else { return }
 
         if meetingRecordingFlowCoordinator?.isMeetingRecordingActive == true {
@@ -474,7 +477,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             windowCoordinator.openMainWindow()
         }
 
-        meetingRecordingFlowCoordinator?.toggleRecording()
+        meetingRecordingFlowCoordinator?.toggleRecording(trigger: trigger)
     }
 
     // MARK: - Alerts

--- a/Sources/MacParakeetCore/Services/AutoSaveService.swift
+++ b/Sources/MacParakeetCore/Services/AutoSaveService.swift
@@ -83,6 +83,8 @@ public final class AutoSaveService {
 
         let format = AutoSaveFormat(rawValue: defaults.string(forKey: scope.formatKey) ?? "md") ?? .md
         let fileURL = buildFileURL(for: transcription, format: format, in: folderURL)
+        let operationID = Observability.operationID()
+        let startedAt = Date()
 
         do {
             // Ensure the folder still exists
@@ -97,8 +99,24 @@ public final class AutoSaveService {
             }
 
             logger.info("Auto-saved \(scope.rawValue) transcript to \(fileURL.lastPathComponent)")
+            Telemetry.send(.autoSaveOperation(
+                operationID: operationID,
+                scope: scope,
+                format: format,
+                outcome: .success,
+                durationSeconds: Observability.durationSeconds(since: startedAt),
+                errorType: nil
+            ))
         } catch {
             logger.error("Auto-save failed for \(scope.rawValue): \(error.localizedDescription)")
+            Telemetry.send(.autoSaveOperation(
+                operationID: operationID,
+                scope: scope,
+                format: format,
+                outcome: .failure,
+                durationSeconds: Observability.durationSeconds(since: startedAt),
+                errorType: Observability.errorType(for: error)
+            ))
         }
     }
 

--- a/Sources/MacParakeetCore/Services/DictationService.swift
+++ b/Sources/MacParakeetCore/Services/DictationService.swift
@@ -66,6 +66,7 @@ public actor DictationService: DictationServiceProtocol {
     private var pendingCancelledAudioURL: URL?
     private var currentTelemetryContext = DictationTelemetryContext()
     private var recordingStartedAt: Date?
+    private var currentOperationID: String?
     private var activeSessionID: Int = 0
 
     public var state: DictationState {
@@ -153,6 +154,7 @@ public actor DictationService: DictationServiceProtocol {
 
         let requestedSessionID = sessionID ?? activeSessionID + 1
         activeSessionID = requestedSessionID
+        currentOperationID = Observability.operationID()
         _state = .recording
         do {
             try await audioProcessor.startCapture()
@@ -163,6 +165,7 @@ public actor DictationService: DictationServiceProtocol {
                     try? FileManager.default.removeItem(at: audioURL)
                 }
                 recordingStartedAt = nil
+                currentOperationID = nil
                 logger.notice(
                     "startRecording aborted session=\(requestedSessionID) state=\(self.debugStateLabel(self._state), privacy: .public)"
                 )
@@ -175,7 +178,15 @@ public actor DictationService: DictationServiceProtocol {
         } catch {
             let device = await audioProcessor.recordingDeviceInfo
             _state = .idle
+            let operationID = currentOperationID
             recordingStartedAt = nil
+            sendDictationOperation(
+                operationID: operationID,
+                outcome: .failure,
+                errorType: Self.errorType(for: error),
+                device: device
+            )
+            currentOperationID = nil
             Telemetry.send(.dictationFailed(errorType: Self.errorType(for: error), errorDetail: TelemetryErrorClassifier.errorDetail(error), device: device))
             logger.error(
                 "startRecording failed session=\(requestedSessionID) error=\(error.localizedDescription, privacy: .public)"
@@ -222,6 +233,12 @@ public actor DictationService: DictationServiceProtocol {
                 return result
             }
             _state = .success(result.dictation)
+            sendDictationOperation(
+                outcome: .success,
+                durationSeconds: Double(result.dictation.durationMs) / 1000.0,
+                wordCount: result.dictation.wordCount,
+                device: device
+            )
             Telemetry.send(.dictationCompleted(
                 durationSeconds: Double(result.dictation.durationMs) / 1000.0,
                 wordCount: result.dictation.wordCount,
@@ -235,6 +252,7 @@ public actor DictationService: DictationServiceProtocol {
             guard activeSessionID == currentSession else { return result }
             _state = .idle
             recordingStartedAt = nil
+            currentOperationID = nil
             return result
         } catch {
             // Snapshot device before setting state to .idle — prevents reentrancy
@@ -248,11 +266,24 @@ public actor DictationService: DictationServiceProtocol {
             }
             _state = .idle
             if Self.isNoSpeechError(error) {
+                sendDictationOperation(
+                    outcome: .empty,
+                    durationSeconds: currentRecordingDurationSeconds(),
+                    errorType: Self.errorType(for: error),
+                    device: device
+                )
                 Telemetry.send(.dictationEmpty(durationSeconds: currentRecordingDurationSeconds(), device: device))
             } else {
+                sendDictationOperation(
+                    outcome: .failure,
+                    durationSeconds: currentRecordingDurationSeconds(),
+                    errorType: Self.errorType(for: error),
+                    device: device
+                )
                 Telemetry.send(.dictationFailed(errorType: Self.errorType(for: error), errorDetail: TelemetryErrorClassifier.errorDetail(error), device: device))
             }
             recordingStartedAt = nil
+            currentOperationID = nil
             logger.error(
                 "stopRecording failed session=\(currentSession) error=\(error.localizedDescription, privacy: .public)"
             )
@@ -318,7 +349,14 @@ public actor DictationService: DictationServiceProtocol {
             }
         }
 
+        let device = await audioProcessor.recordingDeviceInfo
+        sendDictationOperation(
+            outcome: .cancelled,
+            durationSeconds: currentRecordingDurationSeconds(),
+            device: device
+        )
         recordingStartedAt = nil
+        currentOperationID = nil
         _state = .idle
     }
 
@@ -341,6 +379,12 @@ public actor DictationService: DictationServiceProtocol {
             let result = try await processCapturedAudio(audioURL: audioURL)
             let device = await audioProcessor.recordingDeviceInfo
             _state = .success(result.dictation)
+            sendDictationOperation(
+                outcome: .success,
+                durationSeconds: Double(result.dictation.durationMs) / 1000.0,
+                wordCount: result.dictation.wordCount,
+                device: device
+            )
             Telemetry.send(.dictationCompleted(
                 durationSeconds: Double(result.dictation.durationMs) / 1000.0,
                 wordCount: result.dictation.wordCount,
@@ -350,16 +394,30 @@ public actor DictationService: DictationServiceProtocol {
             try? await Task.sleep(for: .milliseconds(500))
             _state = .idle
             recordingStartedAt = nil
+            currentOperationID = nil
             return result
         } catch {
             let device = await audioProcessor.recordingDeviceInfo
             _state = .idle
             if Self.isNoSpeechError(error) {
+                sendDictationOperation(
+                    outcome: .empty,
+                    durationSeconds: currentRecordingDurationSeconds(),
+                    errorType: Self.errorType(for: error),
+                    device: device
+                )
                 Telemetry.send(.dictationEmpty(durationSeconds: currentRecordingDurationSeconds(), device: device))
             } else {
+                sendDictationOperation(
+                    outcome: .failure,
+                    durationSeconds: currentRecordingDurationSeconds(),
+                    errorType: Self.errorType(for: error),
+                    device: device
+                )
                 Telemetry.send(.dictationFailed(errorType: Self.errorType(for: error), errorDetail: TelemetryErrorClassifier.errorDetail(error), device: device))
             }
             recordingStartedAt = nil
+            currentOperationID = nil
             throw error
         }
     }
@@ -541,8 +599,13 @@ public actor DictationService: DictationServiceProtocol {
     private func resetAfterCancelIfStillCurrent(generation: Int) {
         guard generation == cancelGeneration else { return }
         if case .cancelled = _state {
+            sendDictationOperation(
+                outcome: .cancelled,
+                durationSeconds: currentRecordingDurationSeconds()
+            )
             discardPendingCancelledAudio()
             recordingStartedAt = nil
+            currentOperationID = nil
             _state = .idle
         }
         cancelResetTask = nil
@@ -572,6 +635,27 @@ public actor DictationService: DictationServiceProtocol {
 
     private static func errorType(for error: Error) -> String {
         TelemetryErrorClassifier.classify(error)
+    }
+
+    private func sendDictationOperation(
+        operationID: String? = nil,
+        outcome: ObservabilityOutcome,
+        durationSeconds: Double? = nil,
+        wordCount: Int? = nil,
+        errorType: String? = nil,
+        device: RecordingDeviceInfo? = nil
+    ) {
+        guard let id = operationID ?? currentOperationID else { return }
+        Telemetry.send(.dictationOperation(
+            operationID: id,
+            outcome: outcome,
+            trigger: currentTelemetryContext.trigger,
+            mode: currentTelemetryContext.mode,
+            durationSeconds: durationSeconds,
+            wordCount: wordCount,
+            errorType: errorType,
+            device: device
+        ))
     }
 }
 

--- a/Sources/MacParakeetCore/Services/DictationService.swift
+++ b/Sources/MacParakeetCore/Services/DictationService.swift
@@ -67,6 +67,7 @@ public actor DictationService: DictationServiceProtocol {
     private var currentTelemetryContext = DictationTelemetryContext()
     private var recordingStartedAt: Date?
     private var currentOperationID: String?
+    private var currentOperationContext = DictationTelemetryContext()
     private var activeSessionID: Int = 0
 
     public var state: DictationState {
@@ -155,6 +156,7 @@ public actor DictationService: DictationServiceProtocol {
         let requestedSessionID = sessionID ?? activeSessionID + 1
         activeSessionID = requestedSessionID
         currentOperationID = Observability.operationID()
+        currentOperationContext = context
         _state = .recording
         do {
             try await audioProcessor.startCapture()
@@ -165,7 +167,6 @@ public actor DictationService: DictationServiceProtocol {
                     try? FileManager.default.removeItem(at: audioURL)
                 }
                 recordingStartedAt = nil
-                currentOperationID = nil
                 logger.notice(
                     "startRecording aborted session=\(requestedSessionID) state=\(self.debugStateLabel(self._state), privacy: .public)"
                 )
@@ -176,17 +177,19 @@ public actor DictationService: DictationServiceProtocol {
             Telemetry.send(.dictationStarted(trigger: context.trigger, mode: context.mode))
             logger.debug("startRecording capture started session=\(requestedSessionID)")
         } catch {
+            let operationID = currentOperationID
+            let operationContext = currentOperationContext
             let device = await audioProcessor.recordingDeviceInfo
             _state = .idle
-            let operationID = currentOperationID
             recordingStartedAt = nil
             sendDictationOperation(
                 operationID: operationID,
+                telemetryContext: operationContext,
                 outcome: .failure,
                 errorType: Self.errorType(for: error),
                 device: device
             )
-            currentOperationID = nil
+            clearCurrentOperation()
             Telemetry.send(.dictationFailed(errorType: Self.errorType(for: error), errorDetail: TelemetryErrorClassifier.errorDetail(error), device: device))
             logger.error(
                 "startRecording failed session=\(requestedSessionID) error=\(error.localizedDescription, privacy: .public)"
@@ -252,7 +255,7 @@ public actor DictationService: DictationServiceProtocol {
             guard activeSessionID == currentSession else { return result }
             _state = .idle
             recordingStartedAt = nil
-            currentOperationID = nil
+            clearCurrentOperation()
             return result
         } catch {
             // Snapshot device before setting state to .idle — prevents reentrancy
@@ -283,7 +286,7 @@ public actor DictationService: DictationServiceProtocol {
                 Telemetry.send(.dictationFailed(errorType: Self.errorType(for: error), errorDetail: TelemetryErrorClassifier.errorDetail(error), device: device))
             }
             recordingStartedAt = nil
-            currentOperationID = nil
+            clearCurrentOperation()
             logger.error(
                 "stopRecording failed session=\(currentSession) error=\(error.localizedDescription, privacy: .public)"
             )
@@ -356,7 +359,7 @@ public actor DictationService: DictationServiceProtocol {
             device: device
         )
         recordingStartedAt = nil
-        currentOperationID = nil
+        clearCurrentOperation()
         _state = .idle
     }
 
@@ -394,7 +397,7 @@ public actor DictationService: DictationServiceProtocol {
             try? await Task.sleep(for: .milliseconds(500))
             _state = .idle
             recordingStartedAt = nil
-            currentOperationID = nil
+            clearCurrentOperation()
             return result
         } catch {
             let device = await audioProcessor.recordingDeviceInfo
@@ -417,7 +420,7 @@ public actor DictationService: DictationServiceProtocol {
                 Telemetry.send(.dictationFailed(errorType: Self.errorType(for: error), errorDetail: TelemetryErrorClassifier.errorDetail(error), device: device))
             }
             recordingStartedAt = nil
-            currentOperationID = nil
+            clearCurrentOperation()
             throw error
         }
     }
@@ -605,7 +608,7 @@ public actor DictationService: DictationServiceProtocol {
             )
             discardPendingCancelledAudio()
             recordingStartedAt = nil
-            currentOperationID = nil
+            clearCurrentOperation()
             _state = .idle
         }
         cancelResetTask = nil
@@ -637,8 +640,14 @@ public actor DictationService: DictationServiceProtocol {
         TelemetryErrorClassifier.classify(error)
     }
 
+    private func clearCurrentOperation() {
+        currentOperationID = nil
+        currentOperationContext = DictationTelemetryContext()
+    }
+
     private func sendDictationOperation(
         operationID: String? = nil,
+        telemetryContext: DictationTelemetryContext? = nil,
         outcome: ObservabilityOutcome,
         durationSeconds: Double? = nil,
         wordCount: Int? = nil,
@@ -646,11 +655,12 @@ public actor DictationService: DictationServiceProtocol {
         device: RecordingDeviceInfo? = nil
     ) {
         guard let id = operationID ?? currentOperationID else { return }
+        let context = telemetryContext ?? currentOperationContext
         Telemetry.send(.dictationOperation(
             operationID: id,
             outcome: outcome,
-            trigger: currentTelemetryContext.trigger,
-            mode: currentTelemetryContext.mode,
+            trigger: context.trigger,
+            mode: context.mode,
             durationSeconds: durationSeconds,
             wordCount: wordCount,
             errorType: errorType,

--- a/Sources/MacParakeetCore/Services/LLMService.swift
+++ b/Sources/MacParakeetCore/Services/LLMService.swift
@@ -497,7 +497,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                             inputChars: transcript.count,
                             promptDefaultUsed: promptDefaultUsed,
                             messageCount: 2,
-                            errorType: Self.errorType(for: error)
+                            errorType: Self.operationErrorType(for: error)
                         )
                         throw error
                     }
@@ -538,7 +538,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                             errorType: Self.errorType(for: error)
                         ))
                     }
-                    if provider != "unknown" || error is CancellationError {
+                    if provider != "unknown" {
                         self.sendLLMOperation(
                             operationID: operationID,
                             feature: "prompt_result",
@@ -584,7 +584,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                             startedAt: startedAt,
                             inputChars: question.count + transcript.count,
                             messageCount: messageCount,
-                            errorType: Self.errorType(for: error)
+                            errorType: Self.operationErrorType(for: error)
                         )
                         throw error
                     }
@@ -619,7 +619,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                             errorType: Self.errorType(for: error)
                         ))
                     }
-                    if provider != "unknown" || error is CancellationError {
+                    if provider != "unknown" {
                         self.sendLLMOperation(
                             operationID: operationID,
                             feature: "chat",
@@ -663,7 +663,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                             startedAt: startedAt,
                             inputChars: text.count + prompt.count,
                             messageCount: 2,
-                            errorType: Self.errorType(for: error)
+                            errorType: Self.operationErrorType(for: error)
                         )
                         throw error
                     }
@@ -703,7 +703,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                             errorType: Self.errorType(for: error)
                         ))
                     }
-                    if provider != "unknown" || error is CancellationError {
+                    if provider != "unknown" {
                         self.sendLLMOperation(
                             operationID: operationID,
                             feature: "transform",
@@ -756,7 +756,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                 inputChars: inputChars,
                 promptDefaultUsed: promptDefaultUsed,
                 messageCount: messageCount,
-                errorType: Self.errorType(for: error)
+                errorType: Self.operationErrorType(for: error)
             )
             throw error
         }
@@ -799,7 +799,14 @@ public final class LLMService: LLMServiceProtocol, Sendable {
         TelemetryErrorClassifier.classify(error)
     }
 
+    private static func operationErrorType(for error: Error) -> String? {
+        error is CancellationError ? nil : errorType(for: error)
+    }
+
     private static func outcomeForLLMSetupError(_ error: Error) -> ObservabilityOutcome {
+        if error is CancellationError {
+            return .cancelled
+        }
         if let llmError = error as? LLMError, case .notConfigured = llmError {
             return .unavailable
         }

--- a/Sources/MacParakeetCore/Services/LLMService.swift
+++ b/Sources/MacParakeetCore/Services/LLMService.swift
@@ -129,65 +129,205 @@ public final class LLMService: LLMServiceProtocol, Sendable {
     // MARK: - Envelope (Detailed) Variants
 
     public func generatePromptResultDetailed(transcript: String, systemPrompt: String?) async throws -> LLMResult {
-        let context = try loadContext()
+        let operationID = Observability.operationID()
+        let startedAt = Date()
+        let promptDefaultUsed = systemPrompt?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true
+        let context = try loadContextForLLMOperation(
+            operationID: operationID,
+            feature: "prompt_result",
+            streaming: false,
+            startedAt: startedAt,
+            inputChars: transcript.count,
+            promptDefaultUsed: promptDefaultUsed,
+            messageCount: 2
+        )
         let config = context.providerConfig
-        let truncated = Self.truncateMiddle(transcript, limit: contextBudget(for: config))
+        let budget = contextBudget(for: config)
+        let truncated = Self.truncateMiddle(transcript, limit: budget)
         let messages = [
             ChatMessage(role: .system, content: resolveSummaryPrompt(systemPrompt)),
             ChatMessage(role: .user, content: truncated),
         ]
-        let startedAt = Date()
         do {
             let response = try await client.chatCompletion(messages: messages, context: context, options: .default)
             let latencyMs = Self.latencyMs(since: startedAt)
             Telemetry.send(.llmPromptResultUsed(provider: config.id.rawValue))
+            sendLLMOperation(
+                operationID: operationID,
+                feature: "prompt_result",
+                provider: config.id.rawValue,
+                streaming: false,
+                outcome: .success,
+                startedAt: startedAt,
+                inputChars: transcript.count,
+                outputChars: response.content.count,
+                inputTruncated: transcript.count > budget,
+                promptDefaultUsed: promptDefaultUsed,
+                messageCount: messages.count
+            )
             return LLMResult(response: response, provider: config.id, latencyMs: latencyMs)
         } catch {
-            if !(error is CancellationError) {
+            if error is CancellationError {
+                sendLLMOperation(
+                    operationID: operationID,
+                    feature: "prompt_result",
+                    provider: config.id.rawValue,
+                    streaming: false,
+                    outcome: .cancelled,
+                    startedAt: startedAt,
+                    inputChars: transcript.count,
+                    inputTruncated: transcript.count > budget,
+                    promptDefaultUsed: promptDefaultUsed,
+                    messageCount: messages.count
+                )
+            } else {
                 // No errorDetail for LLM errors — API responses may echo user transcript/prompt content
                 Telemetry.send(.llmPromptResultFailed(provider: config.id.rawValue, errorType: Self.errorType(for: error)))
+                sendLLMOperation(
+                    operationID: operationID,
+                    feature: "prompt_result",
+                    provider: config.id.rawValue,
+                    streaming: false,
+                    outcome: .failure,
+                    startedAt: startedAt,
+                    inputChars: transcript.count,
+                    inputTruncated: transcript.count > budget,
+                    promptDefaultUsed: promptDefaultUsed,
+                    messageCount: messages.count,
+                    errorType: Self.errorType(for: error)
+                )
             }
             throw error
         }
     }
 
     public func chatDetailed(question: String, transcript: String, history: [ChatMessage]) async throws -> LLMResult {
-        let context = try loadContext()
+        let operationID = Observability.operationID()
+        let startedAt = Date()
+        let context = try loadContextForLLMOperation(
+            operationID: operationID,
+            feature: "chat",
+            streaming: false,
+            startedAt: startedAt,
+            inputChars: question.count + transcript.count,
+            messageCount: history.count + 1
+        )
         let config = context.providerConfig
         let messages = buildChatMessages(question: question, transcript: transcript, history: history, config: config)
-        let startedAt = Date()
+        let budget = contextBudget(for: config)
         do {
             let response = try await client.chatCompletion(messages: messages, context: context, options: .default)
             let latencyMs = Self.latencyMs(since: startedAt)
             Telemetry.send(.llmChatUsed(provider: config.id.rawValue, messageCount: history.count + 1))
+            sendLLMOperation(
+                operationID: operationID,
+                feature: "chat",
+                provider: config.id.rawValue,
+                streaming: false,
+                outcome: .success,
+                startedAt: startedAt,
+                inputChars: question.count + transcript.count,
+                outputChars: response.content.count,
+                inputTruncated: transcript.count > budget,
+                messageCount: history.count + 1
+            )
             return LLMResult(response: response, provider: config.id, latencyMs: latencyMs)
         } catch {
-            if !(error is CancellationError) {
+            if error is CancellationError {
+                sendLLMOperation(
+                    operationID: operationID,
+                    feature: "chat",
+                    provider: config.id.rawValue,
+                    streaming: false,
+                    outcome: .cancelled,
+                    startedAt: startedAt,
+                    inputChars: question.count + transcript.count,
+                    inputTruncated: transcript.count > budget,
+                    messageCount: history.count + 1
+                )
+            } else {
                 // No errorDetail for LLM errors — API responses may echo user transcript/prompt content
                 Telemetry.send(.llmChatFailed(provider: config.id.rawValue, errorType: Self.errorType(for: error)))
+                sendLLMOperation(
+                    operationID: operationID,
+                    feature: "chat",
+                    provider: config.id.rawValue,
+                    streaming: false,
+                    outcome: .failure,
+                    startedAt: startedAt,
+                    inputChars: question.count + transcript.count,
+                    inputTruncated: transcript.count > budget,
+                    messageCount: history.count + 1,
+                    errorType: Self.errorType(for: error)
+                )
             }
             throw error
         }
     }
 
     public func transformDetailed(text: String, prompt: String) async throws -> LLMResult {
-        let context = try loadContext()
+        let operationID = Observability.operationID()
+        let startedAt = Date()
+        let context = try loadContextForLLMOperation(
+            operationID: operationID,
+            feature: "transform",
+            streaming: false,
+            startedAt: startedAt,
+            inputChars: text.count + prompt.count,
+            messageCount: 2
+        )
         let config = context.providerConfig
-        let truncated = Self.truncateMiddle(text, limit: contextBudget(for: config))
+        let budget = contextBudget(for: config)
+        let truncated = Self.truncateMiddle(text, limit: budget)
         let messages = [
             ChatMessage(role: .system, content: Prompts.transform),
             ChatMessage(role: .user, content: "Transform the following text according to this instruction: \(prompt)\n\n---\n\n\(truncated)"),
         ]
-        let startedAt = Date()
         do {
             let response = try await client.chatCompletion(messages: messages, context: context, options: .default)
             let latencyMs = Self.latencyMs(since: startedAt)
             Telemetry.send(.llmTransformUsed(provider: config.id.rawValue))
+            sendLLMOperation(
+                operationID: operationID,
+                feature: "transform",
+                provider: config.id.rawValue,
+                streaming: false,
+                outcome: .success,
+                startedAt: startedAt,
+                inputChars: text.count + prompt.count,
+                outputChars: response.content.count,
+                inputTruncated: text.count > budget,
+                messageCount: messages.count
+            )
             return LLMResult(response: response, provider: config.id, latencyMs: latencyMs)
         } catch {
-            if !(error is CancellationError) {
+            if error is CancellationError {
+                sendLLMOperation(
+                    operationID: operationID,
+                    feature: "transform",
+                    provider: config.id.rawValue,
+                    streaming: false,
+                    outcome: .cancelled,
+                    startedAt: startedAt,
+                    inputChars: text.count + prompt.count,
+                    inputTruncated: text.count > budget,
+                    messageCount: messages.count
+                )
+            } else {
                 // No errorDetail for LLM errors — API responses may echo user transcript/prompt content
                 Telemetry.send(.llmTransformFailed(provider: config.id.rawValue, errorType: Self.errorType(for: error)))
+                sendLLMOperation(
+                    operationID: operationID,
+                    feature: "transform",
+                    provider: config.id.rawValue,
+                    streaming: false,
+                    outcome: .failure,
+                    startedAt: startedAt,
+                    inputChars: text.count + prompt.count,
+                    inputTruncated: text.count > budget,
+                    messageCount: messages.count,
+                    errorType: Self.errorType(for: error)
+                )
             }
             throw error
         }
@@ -203,7 +343,18 @@ public final class LLMService: LLMServiceProtocol, Sendable {
         source: TelemetryFormatterSource,
         defaultPromptUsed: Bool
     ) async throws -> String {
-        let context = try loadContext()
+        let operationID = Observability.operationID()
+        let startedAt = Date()
+        let inputChars = transcript.count
+        let context = try loadContextForLLMOperation(
+            operationID: operationID,
+            feature: "formatter_\(source.rawValue)",
+            streaming: false,
+            startedAt: startedAt,
+            inputChars: inputChars,
+            promptDefaultUsed: defaultPromptUsed,
+            messageCount: 2
+        )
         let config = context.providerConfig
         let budget = contextBudget(for: config)
         // Compare original transcript length against budget rather than the
@@ -213,8 +364,6 @@ public final class LLMService: LLMServiceProtocol, Sendable {
         // we have to drop content to fit," which this expresses directly.
         let inputTruncated = transcript.count > budget
         let truncated = Self.truncateMiddle(transcript, limit: budget)
-        let inputChars = transcript.count
-        let startedAt = Date()
 
         do {
             let renderedPrompt = AIFormatter.renderPrompt(template: promptTemplate, transcript: truncated)
@@ -266,9 +415,35 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                 defaultPromptUsed: defaultPromptUsed,
                 inputTruncated: inputTruncated
             ))
+            sendLLMOperation(
+                operationID: operationID,
+                feature: "formatter_\(source.rawValue)",
+                provider: config.id.rawValue,
+                streaming: false,
+                outcome: .success,
+                startedAt: startedAt,
+                inputChars: inputChars,
+                outputChars: output.count,
+                inputTruncated: inputTruncated,
+                promptDefaultUsed: defaultPromptUsed,
+                messageCount: 2
+            )
             return output
         } catch {
-            if !(error is CancellationError) {
+            if error is CancellationError {
+                sendLLMOperation(
+                    operationID: operationID,
+                    feature: "formatter_\(source.rawValue)",
+                    provider: config.id.rawValue,
+                    streaming: false,
+                    outcome: .cancelled,
+                    startedAt: startedAt,
+                    inputChars: inputChars,
+                    inputTruncated: inputTruncated,
+                    promptDefaultUsed: defaultPromptUsed,
+                    messageCount: 2
+                )
+            } else {
                 // No errorDetail for LLM errors — API responses may echo user transcript/prompt content
                 Telemetry.send(.llmFormatterFailed(
                     provider: config.id.rawValue,
@@ -278,6 +453,19 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                     defaultPromptUsed: defaultPromptUsed,
                     inputTruncated: inputTruncated
                 ))
+                sendLLMOperation(
+                    operationID: operationID,
+                    feature: "formatter_\(source.rawValue)",
+                    provider: config.id.rawValue,
+                    streaming: false,
+                    outcome: .failure,
+                    startedAt: startedAt,
+                    inputChars: inputChars,
+                    inputTruncated: inputTruncated,
+                    promptDefaultUsed: defaultPromptUsed,
+                    messageCount: 2,
+                    errorType: Self.errorType(for: error)
+                )
             }
             throw error
         }
@@ -287,22 +475,60 @@ public final class LLMService: LLMServiceProtocol, Sendable {
 
     public func generatePromptResultStream(transcript: String, systemPrompt: String?) -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { continuation in
+            let operationID = Observability.operationID()
+            let startedAt = Date()
+            let promptDefaultUsed = systemPrompt?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true
             let task = Task {
                 var provider = "unknown"
+                var outputChars = 0
+                var inputTruncated: Bool?
                 do {
-                    let context = try self.loadContext()
+                    let context: LLMExecutionContext
+                    do {
+                        context = try self.loadContext()
+                    } catch {
+                        self.sendLLMOperation(
+                            operationID: operationID,
+                            feature: "prompt_result",
+                            provider: provider,
+                            streaming: true,
+                            outcome: Self.outcomeForLLMSetupError(error),
+                            startedAt: startedAt,
+                            inputChars: transcript.count,
+                            promptDefaultUsed: promptDefaultUsed,
+                            messageCount: 2,
+                            errorType: Self.errorType(for: error)
+                        )
+                        throw error
+                    }
                     let config = context.providerConfig
                     provider = config.id.rawValue
-                    let truncated = Self.truncateMiddle(transcript, limit: self.contextBudget(for: config))
+                    let budget = self.contextBudget(for: config)
+                    inputTruncated = transcript.count > budget
+                    let truncated = Self.truncateMiddle(transcript, limit: budget)
                     let messages = [
                         ChatMessage(role: .system, content: self.resolveSummaryPrompt(systemPrompt)),
                         ChatMessage(role: .user, content: truncated),
                     ]
                     let stream = self.client.chatCompletionStream(messages: messages, context: context, options: .default)
                     for try await token in stream {
+                        outputChars += token.count
                         continuation.yield(token)
                     }
                     Telemetry.send(.llmPromptResultUsed(provider: config.id.rawValue))
+                    self.sendLLMOperation(
+                        operationID: operationID,
+                        feature: "prompt_result",
+                        provider: provider,
+                        streaming: true,
+                        outcome: .success,
+                        startedAt: startedAt,
+                        inputChars: transcript.count,
+                        outputChars: outputChars,
+                        inputTruncated: inputTruncated,
+                        promptDefaultUsed: promptDefaultUsed,
+                        messageCount: messages.count
+                    )
                     continuation.finish()
                 } catch {
                     if !(error is CancellationError) {
@@ -311,6 +537,22 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                             provider: provider,
                             errorType: Self.errorType(for: error)
                         ))
+                    }
+                    if provider != "unknown" || error is CancellationError {
+                        self.sendLLMOperation(
+                            operationID: operationID,
+                            feature: "prompt_result",
+                            provider: provider,
+                            streaming: true,
+                            outcome: error is CancellationError ? .cancelled : .failure,
+                            startedAt: startedAt,
+                            inputChars: transcript.count,
+                            outputChars: outputChars,
+                            inputTruncated: inputTruncated,
+                            promptDefaultUsed: promptDefaultUsed,
+                            messageCount: 2,
+                            errorType: error is CancellationError ? nil : Self.errorType(for: error)
+                        )
                     }
                     continuation.finish(throwing: error)
                 }
@@ -321,18 +563,53 @@ public final class LLMService: LLMServiceProtocol, Sendable {
 
     public func chatStream(question: String, transcript: String, history: [ChatMessage]) -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { continuation in
+            let operationID = Observability.operationID()
+            let startedAt = Date()
+            let messageCount = history.count + 1
             let task = Task {
                 var provider = "unknown"
+                var outputChars = 0
+                var inputTruncated: Bool?
                 do {
-                    let context = try self.loadContext()
+                    let context: LLMExecutionContext
+                    do {
+                        context = try self.loadContext()
+                    } catch {
+                        self.sendLLMOperation(
+                            operationID: operationID,
+                            feature: "chat",
+                            provider: provider,
+                            streaming: true,
+                            outcome: Self.outcomeForLLMSetupError(error),
+                            startedAt: startedAt,
+                            inputChars: question.count + transcript.count,
+                            messageCount: messageCount,
+                            errorType: Self.errorType(for: error)
+                        )
+                        throw error
+                    }
                     let config = context.providerConfig
                     provider = config.id.rawValue
+                    inputTruncated = transcript.count > self.contextBudget(for: config)
                     let messages = self.buildChatMessages(question: question, transcript: transcript, history: history, config: config)
                     let stream = self.client.chatCompletionStream(messages: messages, context: context, options: .default)
                     for try await token in stream {
+                        outputChars += token.count
                         continuation.yield(token)
                     }
                     Telemetry.send(.llmChatUsed(provider: config.id.rawValue, messageCount: history.count + 1))
+                    self.sendLLMOperation(
+                        operationID: operationID,
+                        feature: "chat",
+                        provider: provider,
+                        streaming: true,
+                        outcome: .success,
+                        startedAt: startedAt,
+                        inputChars: question.count + transcript.count,
+                        outputChars: outputChars,
+                        inputTruncated: inputTruncated,
+                        messageCount: messageCount
+                    )
                     continuation.finish()
                 } catch {
                     if !(error is CancellationError) {
@@ -341,6 +618,21 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                             provider: provider,
                             errorType: Self.errorType(for: error)
                         ))
+                    }
+                    if provider != "unknown" || error is CancellationError {
+                        self.sendLLMOperation(
+                            operationID: operationID,
+                            feature: "chat",
+                            provider: provider,
+                            streaming: true,
+                            outcome: error is CancellationError ? .cancelled : .failure,
+                            startedAt: startedAt,
+                            inputChars: question.count + transcript.count,
+                            outputChars: outputChars,
+                            inputTruncated: inputTruncated,
+                            messageCount: messageCount,
+                            errorType: error is CancellationError ? nil : Self.errorType(for: error)
+                        )
                     }
                     continuation.finish(throwing: error)
                 }
@@ -351,21 +643,81 @@ public final class LLMService: LLMServiceProtocol, Sendable {
 
     public func transformStream(text: String, prompt: String) -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { continuation in
+            let operationID = Observability.operationID()
+            let startedAt = Date()
             let task = Task {
+                var provider = "unknown"
+                var outputChars = 0
+                var inputTruncated: Bool?
                 do {
-                    let context = try self.loadContext()
+                    let context: LLMExecutionContext
+                    do {
+                        context = try self.loadContext()
+                    } catch {
+                        self.sendLLMOperation(
+                            operationID: operationID,
+                            feature: "transform",
+                            provider: provider,
+                            streaming: true,
+                            outcome: Self.outcomeForLLMSetupError(error),
+                            startedAt: startedAt,
+                            inputChars: text.count + prompt.count,
+                            messageCount: 2,
+                            errorType: Self.errorType(for: error)
+                        )
+                        throw error
+                    }
                     let config = context.providerConfig
-                    let truncated = Self.truncateMiddle(text, limit: self.contextBudget(for: config))
+                    provider = config.id.rawValue
+                    let budget = self.contextBudget(for: config)
+                    inputTruncated = text.count > budget
+                    let truncated = Self.truncateMiddle(text, limit: budget)
                     let messages = [
                         ChatMessage(role: .system, content: Prompts.transform),
                         ChatMessage(role: .user, content: "Transform the following text according to this instruction: \(prompt)\n\n---\n\n\(truncated)"),
                     ]
                     let stream = self.client.chatCompletionStream(messages: messages, context: context, options: .default)
                     for try await token in stream {
+                        outputChars += token.count
                         continuation.yield(token)
                     }
+                    Telemetry.send(.llmTransformUsed(provider: config.id.rawValue))
+                    self.sendLLMOperation(
+                        operationID: operationID,
+                        feature: "transform",
+                        provider: provider,
+                        streaming: true,
+                        outcome: .success,
+                        startedAt: startedAt,
+                        inputChars: text.count + prompt.count,
+                        outputChars: outputChars,
+                        inputTruncated: inputTruncated,
+                        messageCount: messages.count
+                    )
                     continuation.finish()
                 } catch {
+                    if !(error is CancellationError) {
+                        // No errorDetail for LLM errors — API responses may echo user transcript/prompt content
+                        Telemetry.send(.llmTransformFailed(
+                            provider: provider,
+                            errorType: Self.errorType(for: error)
+                        ))
+                    }
+                    if provider != "unknown" || error is CancellationError {
+                        self.sendLLMOperation(
+                            operationID: operationID,
+                            feature: "transform",
+                            provider: provider,
+                            streaming: true,
+                            outcome: error is CancellationError ? .cancelled : .failure,
+                            startedAt: startedAt,
+                            inputChars: text.count + prompt.count,
+                            outputChars: outputChars,
+                            inputTruncated: inputTruncated,
+                            messageCount: 2,
+                            errorType: error is CancellationError ? nil : Self.errorType(for: error)
+                        )
+                    }
                     continuation.finish(throwing: error)
                 }
             }
@@ -380,6 +732,34 @@ public final class LLMService: LLMServiceProtocol, Sendable {
             throw LLMError.notConfigured
         }
         return context
+    }
+
+    private func loadContextForLLMOperation(
+        operationID: String,
+        feature: String,
+        streaming: Bool,
+        startedAt: Date,
+        inputChars: Int?,
+        promptDefaultUsed: Bool? = nil,
+        messageCount: Int? = nil
+    ) throws -> LLMExecutionContext {
+        do {
+            return try loadContext()
+        } catch {
+            sendLLMOperation(
+                operationID: operationID,
+                feature: feature,
+                provider: "unknown",
+                streaming: streaming,
+                outcome: Self.outcomeForLLMSetupError(error),
+                startedAt: startedAt,
+                inputChars: inputChars,
+                promptDefaultUsed: promptDefaultUsed,
+                messageCount: messageCount,
+                errorType: Self.errorType(for: error)
+            )
+            throw error
+        }
     }
 
     private func contextBudget(for config: LLMProviderConfig) -> Int {
@@ -417,6 +797,43 @@ public final class LLMService: LLMServiceProtocol, Sendable {
 
     private static func errorType(for error: Error) -> String {
         TelemetryErrorClassifier.classify(error)
+    }
+
+    private static func outcomeForLLMSetupError(_ error: Error) -> ObservabilityOutcome {
+        if let llmError = error as? LLMError, case .notConfigured = llmError {
+            return .unavailable
+        }
+        return .failure
+    }
+
+    private func sendLLMOperation(
+        operationID: String,
+        feature: String,
+        provider: String,
+        streaming: Bool,
+        outcome: ObservabilityOutcome,
+        startedAt: Date,
+        inputChars: Int?,
+        outputChars: Int? = nil,
+        inputTruncated: Bool? = nil,
+        promptDefaultUsed: Bool? = nil,
+        messageCount: Int? = nil,
+        errorType: String? = nil
+    ) {
+        Telemetry.send(.llmOperation(
+            operationID: operationID,
+            feature: feature,
+            provider: provider,
+            streaming: streaming,
+            outcome: outcome,
+            durationSeconds: Observability.durationSeconds(since: startedAt),
+            inputChars: inputChars,
+            outputChars: outputChars,
+            inputTruncated: inputTruncated,
+            promptDefaultUsed: promptDefaultUsed,
+            messageCount: messageCount,
+            errorType: errorType
+        ))
     }
 
     private func buildChatMessages(

--- a/Sources/MacParakeetCore/Services/Observability.swift
+++ b/Sources/MacParakeetCore/Services/Observability.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+public enum ObservabilityOutcome: String, Sendable {
+    case success
+    case failure
+    case cancelled
+    case empty
+    case unavailable
+}
+
+public enum ObservabilityInputKind: String, Sendable {
+    case audio
+    case video
+    case youtube
+    case meeting
+    case unknown
+}
+
+public enum Observability {
+    public static func operationID() -> String {
+        UUID().uuidString
+    }
+
+    public static func durationSeconds(since startedAt: Date) -> Double {
+        max(0, Date().timeIntervalSince(startedAt))
+    }
+
+    public static func boolString(_ value: Bool) -> String {
+        value ? "true" : "false"
+    }
+
+    public static func errorType(for error: Error) -> String {
+        TelemetryErrorClassifier.classify(error)
+    }
+
+    public static func mediaExtension(for url: URL?) -> String? {
+        guard let ext = url?.pathExtension.lowercased(), !ext.isEmpty else {
+            return nil
+        }
+        return ext
+    }
+
+    public static func inputKind(for url: URL?) -> ObservabilityInputKind? {
+        guard let ext = mediaExtension(for: url) else { return nil }
+        if videoExtensions.contains(ext) { return .video }
+        if audioExtensions.contains(ext) { return .audio }
+        return .unknown
+    }
+
+    public static func fileSizeBucket(bytes: Int?) -> String? {
+        guard let bytes, bytes >= 0 else { return nil }
+        switch bytes {
+        case 0..<1_000_000:
+            return "lt_1mb"
+        case 1_000_000..<10_000_000:
+            return "1_10mb"
+        case 10_000_000..<100_000_000:
+            return "10_100mb"
+        case 100_000_000..<1_000_000_000:
+            return "100mb_1gb"
+        default:
+            return "gte_1gb"
+        }
+    }
+
+    public static func textLengthBucket(_ text: String?) -> String {
+        let count = text?.trimmingCharacters(in: .whitespacesAndNewlines).count ?? 0
+        switch count {
+        case 0:
+            return "none"
+        case 1...200:
+            return "1_200"
+        case 201...1_000:
+            return "201_1000"
+        case 1_001...5_000:
+            return "1001_5000"
+        default:
+            return "gt_5000"
+        }
+    }
+
+    public static func wordCount(_ text: String) -> Int {
+        text.split(whereSeparator: \.isWhitespace).count
+    }
+
+    private static let audioExtensions: Set<String> = [
+        "aac", "aif", "aiff", "caf", "flac", "m4a", "mp3", "ogg", "opus", "wav", "wma"
+    ]
+
+    private static let videoExtensions: Set<String> = [
+        "avi", "flv", "m4v", "mkv", "mov", "mp4", "mpeg", "mpg", "webm", "wmv"
+    ]
+}

--- a/Sources/MacParakeetCore/Services/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/TelemetryEvent.swift
@@ -8,10 +8,12 @@ public enum TelemetryEventName: String, Sendable, CaseIterable {
     case dictationCancelled = "dictation_cancelled"
     case dictationEmpty = "dictation_empty"
     case dictationFailed = "dictation_failed"
+    case dictationOperation = "dictation_operation"
     case transcriptionStarted = "transcription_started"
     case transcriptionCompleted = "transcription_completed"
     case transcriptionCancelled = "transcription_cancelled"
     case transcriptionFailed = "transcription_failed"
+    case transcriptionOperation = "transcription_operation"
     case diarizationStarted = "diarization_started"
     case diarizationCompleted = "diarization_completed"
     case diarizationFailed = "diarization_failed"
@@ -24,6 +26,7 @@ public enum TelemetryEventName: String, Sendable, CaseIterable {
     case llmTransformFailed = "llm_transform_failed"
     case llmFormatterUsed = "llm_formatter_used"
     case llmFormatterFailed = "llm_formatter_failed"
+    case llmOperation = "llm_operation"
     case historySearched = "history_searched"
     case historyReplayed = "history_replayed"
     case copyToClipboard = "copy_to_clipboard"
@@ -35,6 +38,7 @@ public enum TelemetryEventName: String, Sendable, CaseIterable {
     case snippetDeleted = "snippet_deleted"
     case keystrokeSnippetFired = "keystroke_snippet_fired"
     case feedbackSubmitted = "feedback_submitted"
+    case feedbackOperation = "feedback_operation"
     case transcriptionDeleted = "transcription_deleted"
     case dictationDeleted = "dictation_deleted"
     case transcriptionFavorited = "transcription_favorited"
@@ -70,6 +74,7 @@ public enum TelemetryEventName: String, Sendable, CaseIterable {
     case meetingRecordingCompleted = "meeting_recording_completed"
     case meetingRecordingCancelled = "meeting_recording_cancelled"
     case meetingRecordingFailed = "meeting_recording_failed"
+    case meetingOperation = "meeting_operation"
     case meetingRecoveryDiscovered = "meeting_recovery_discovered"
     case meetingRecoveryStarted = "meeting_recovery_started"
     case meetingRecoveryCompleted = "meeting_recovery_completed"
@@ -86,6 +91,10 @@ public enum TelemetryEventName: String, Sendable, CaseIterable {
     case errorOccurred = "error_occurred"
     // Crashes
     case crashOccurred = "crash_occurred"
+    // CLI
+    case cliOperation = "cli_operation"
+    // Local file automation
+    case autoSaveOperation = "auto_save_operation"
 }
 
 public enum TelemetryDictationTrigger: String, Sendable, Equatable {
@@ -187,6 +196,16 @@ public enum TelemetryEventSpec: Sendable {
     case dictationCancelled(durationSeconds: Double?, reason: TelemetryDictationCancelReason?, device: RecordingDeviceInfo? = nil)
     case dictationEmpty(durationSeconds: Double?, device: RecordingDeviceInfo? = nil)
     case dictationFailed(errorType: String, errorDetail: String? = nil, device: RecordingDeviceInfo? = nil)
+    case dictationOperation(
+        operationID: String,
+        outcome: ObservabilityOutcome,
+        trigger: TelemetryDictationTrigger?,
+        mode: TelemetryDictationMode?,
+        durationSeconds: Double?,
+        wordCount: Int?,
+        errorType: String?,
+        device: RecordingDeviceInfo? = nil
+    )
     case transcriptionStarted(source: TelemetryTranscriptionSource, audioDurationSeconds: Double?)
     case transcriptionCompleted(
         source: TelemetryTranscriptionSource,
@@ -207,6 +226,23 @@ public enum TelemetryEventSpec: Sendable {
         stage: TelemetryTranscriptionStage,
         errorType: String,
         errorDetail: String? = nil
+    )
+    case transcriptionOperation(
+        operationID: String,
+        outcome: ObservabilityOutcome,
+        source: TelemetryTranscriptionSource,
+        stage: TelemetryTranscriptionStage?,
+        durationSeconds: Double,
+        audioDurationSeconds: Double?,
+        processingSeconds: Double?,
+        wordCount: Int?,
+        speakerCount: Int?,
+        diarizationRequested: Bool,
+        diarizationApplied: Bool,
+        inputKind: ObservabilityInputKind?,
+        mediaExtension: String?,
+        fileSizeBucket: String?,
+        errorType: String?
     )
     case diarizationStarted(source: TelemetryTranscriptionSource)
     case diarizationCompleted(source: TelemetryTranscriptionSource, speakerCount: Int, durationSeconds: Double)
@@ -234,6 +270,20 @@ public enum TelemetryEventSpec: Sendable {
         errorType: String,
         defaultPromptUsed: Bool,
         inputTruncated: Bool
+    )
+    case llmOperation(
+        operationID: String,
+        feature: String,
+        provider: String,
+        streaming: Bool,
+        outcome: ObservabilityOutcome,
+        durationSeconds: Double,
+        inputChars: Int?,
+        outputChars: Int?,
+        inputTruncated: Bool?,
+        promptDefaultUsed: Bool?,
+        messageCount: Int?,
+        errorType: String?
     )
     case historySearched
     case historyReplayed
@@ -267,6 +317,15 @@ public enum TelemetryEventSpec: Sendable {
     case modelDownloadFailed(errorType: String, errorDetail: String? = nil)
     // Lifecycle actions
     case feedbackSubmitted(category: String)
+    case feedbackOperation(
+        operationID: String,
+        category: String,
+        outcome: ObservabilityOutcome,
+        durationSeconds: Double,
+        screenshotAttached: Bool,
+        systemInfoIncluded: Bool,
+        errorType: String?
+    )
     case transcriptionDeleted
     case dictationDeleted
     case transcriptionFavorited(isFavorite: Bool)
@@ -283,6 +342,19 @@ public enum TelemetryEventSpec: Sendable {
     case meetingRecordingCompleted(durationSeconds: Double, liveWordCount: Int, liveTranscriptLagged: Bool)
     case meetingRecordingCancelled(durationSeconds: Double)
     case meetingRecordingFailed(errorType: String, errorDetail: String? = nil)
+    case meetingOperation(
+        operationID: String,
+        outcome: ObservabilityOutcome,
+        trigger: TelemetryMeetingRecordingTrigger?,
+        durationSeconds: Double?,
+        liveWordCount: Int?,
+        liveTranscriptLagged: Bool?,
+        microphoneTrackPresent: Bool?,
+        systemTrackPresent: Bool?,
+        notesUsed: Bool?,
+        notesLengthBucket: String?,
+        errorType: String?
+    )
     case meetingRecoveryDiscovered(count: Int, source: TelemetryMeetingRecoverySource)
     case meetingRecoveryStarted(count: Int, source: TelemetryMeetingRecoverySource)
     case meetingRecoveryCompleted(count: Int, durationSeconds: Double, source: TelemetryMeetingRecoverySource)
@@ -327,6 +399,26 @@ public enum TelemetryEventSpec: Sendable {
         crashOsVer: String, uuid: String,
         slide: String, reason: String?, stackTrace: String
     )
+    case cliOperation(
+        operationID: String,
+        command: String,
+        subcommand: String?,
+        outcome: ObservabilityOutcome,
+        durationSeconds: Double,
+        inputKind: ObservabilityInputKind?,
+        outputFormat: String?,
+        json: Bool?,
+        exitCode: Int?,
+        errorType: String?
+    )
+    case autoSaveOperation(
+        operationID: String,
+        scope: AutoSaveScope,
+        format: AutoSaveFormat,
+        outcome: ObservabilityOutcome,
+        durationSeconds: Double,
+        errorType: String?
+    )
 }
 
 extension TelemetryEventSpec {
@@ -339,10 +431,12 @@ extension TelemetryEventSpec {
         case .dictationCancelled: return .dictationCancelled
         case .dictationEmpty: return .dictationEmpty
         case .dictationFailed: return .dictationFailed
+        case .dictationOperation: return .dictationOperation
         case .transcriptionStarted: return .transcriptionStarted
         case .transcriptionCompleted: return .transcriptionCompleted
         case .transcriptionCancelled: return .transcriptionCancelled
         case .transcriptionFailed: return .transcriptionFailed
+        case .transcriptionOperation: return .transcriptionOperation
         case .diarizationStarted: return .diarizationStarted
         case .diarizationCompleted: return .diarizationCompleted
         case .diarizationFailed: return .diarizationFailed
@@ -355,6 +449,7 @@ extension TelemetryEventSpec {
         case .llmTransformFailed: return .llmTransformFailed
         case .llmFormatterUsed: return .llmFormatterUsed
         case .llmFormatterFailed: return .llmFormatterFailed
+        case .llmOperation: return .llmOperation
         case .historySearched: return .historySearched
         case .historyReplayed: return .historyReplayed
         case .copyToClipboard: return .copyToClipboard
@@ -384,6 +479,7 @@ extension TelemetryEventSpec {
         case .modelDownloadCompleted: return .modelDownloadCompleted
         case .modelDownloadFailed: return .modelDownloadFailed
         case .feedbackSubmitted: return .feedbackSubmitted
+        case .feedbackOperation: return .feedbackOperation
         case .transcriptionDeleted: return .transcriptionDeleted
         case .dictationDeleted: return .dictationDeleted
         case .transcriptionFavorited: return .transcriptionFavorited
@@ -397,6 +493,7 @@ extension TelemetryEventSpec {
         case .meetingRecordingCompleted: return .meetingRecordingCompleted
         case .meetingRecordingCancelled: return .meetingRecordingCancelled
         case .meetingRecordingFailed: return .meetingRecordingFailed
+        case .meetingOperation: return .meetingOperation
         case .meetingRecoveryDiscovered: return .meetingRecoveryDiscovered
         case .meetingRecoveryStarted: return .meetingRecoveryStarted
         case .meetingRecoveryCompleted: return .meetingRecoveryCompleted
@@ -410,6 +507,8 @@ extension TelemetryEventSpec {
         case .calendarAutoStopCancelled: return .calendarAutoStopCancelled
         case .errorOccurred: return .errorOccurred
         case .crashOccurred: return .crashOccurred
+        case .cliOperation: return .cliOperation
+        case .autoSaveOperation: return .autoSaveOperation
         }
     }
 
@@ -464,6 +563,25 @@ extension TelemetryEventSpec {
             var props = ["error_type": errorType]
             if let errorDetail { props["error_detail"] = errorDetail }
             return Self.mergeDevice(props, device)
+        case .dictationOperation(
+            let operationID,
+            let outcome,
+            let trigger,
+            let mode,
+            let durationSeconds,
+            let wordCount,
+            let errorType,
+            let device
+        ):
+            return Self.mergeDevice(Self.compactProps(
+                ("operation_id", operationID),
+                ("outcome", outcome.rawValue),
+                ("trigger", trigger?.rawValue),
+                ("mode", mode?.rawValue),
+                ("duration_seconds", durationSeconds.map(Self.format)),
+                ("word_count", wordCount.map(String.init)),
+                ("error_type", errorType)
+            ), device)
         case .transcriptionStarted(let source, let audioDurationSeconds):
             return Self.compactProps(
                 ("source", source.rawValue),
@@ -501,6 +619,40 @@ extension TelemetryEventSpec {
             ]
             if let errorDetail { props["error_detail"] = errorDetail }
             return props
+        case .transcriptionOperation(
+            let operationID,
+            let outcome,
+            let source,
+            let stage,
+            let durationSeconds,
+            let audioDurationSeconds,
+            let processingSeconds,
+            let wordCount,
+            let speakerCount,
+            let diarizationRequested,
+            let diarizationApplied,
+            let inputKind,
+            let mediaExtension,
+            let fileSizeBucket,
+            let errorType
+        ):
+            return Self.compactProps(
+                ("operation_id", operationID),
+                ("outcome", outcome.rawValue),
+                ("source", source.rawValue),
+                ("stage", stage?.rawValue),
+                ("duration_seconds", Self.format(durationSeconds)),
+                ("audio_duration_seconds", audioDurationSeconds.map(Self.format)),
+                ("processing_seconds", processingSeconds.map(Self.format)),
+                ("word_count", wordCount.map(String.init)),
+                ("speaker_count", speakerCount.map(String.init)),
+                ("diarization_requested", Self.boolString(diarizationRequested)),
+                ("diarization_applied", Self.boolString(diarizationApplied)),
+                ("input_kind", inputKind?.rawValue),
+                ("media_extension", mediaExtension),
+                ("file_size_bucket", fileSizeBucket),
+                ("error_type", errorType)
+            )
         case .diarizationStarted(let source):
             return ["source": source.rawValue]
         case .diarizationCompleted(let source, let speakerCount, let durationSeconds):
@@ -567,6 +719,34 @@ extension TelemetryEventSpec {
                 "default_prompt_used": Self.boolString(defaultPromptUsed),
                 "input_truncated": Self.boolString(inputTruncated),
             ]
+        case .llmOperation(
+            let operationID,
+            let feature,
+            let provider,
+            let streaming,
+            let outcome,
+            let durationSeconds,
+            let inputChars,
+            let outputChars,
+            let inputTruncated,
+            let promptDefaultUsed,
+            let messageCount,
+            let errorType
+        ):
+            return Self.compactProps(
+                ("operation_id", operationID),
+                ("feature", feature),
+                ("provider", provider),
+                ("streaming", Self.boolString(streaming)),
+                ("outcome", outcome.rawValue),
+                ("duration_seconds", Self.format(durationSeconds)),
+                ("input_chars", inputChars.map(String.init)),
+                ("output_chars", outputChars.map(String.init)),
+                ("input_truncated", inputTruncated.map(Self.boolString)),
+                ("prompt_default_used", promptDefaultUsed.map(Self.boolString)),
+                ("message_count", messageCount.map(String.init)),
+                ("error_type", errorType)
+            )
         case .copyToClipboard(let source):
             return ["source": source.rawValue]
         case .processingModeChanged(let mode):
@@ -603,6 +783,24 @@ extension TelemetryEventSpec {
             return props
         case .feedbackSubmitted(let category):
             return ["category": category]
+        case .feedbackOperation(
+            let operationID,
+            let category,
+            let outcome,
+            let durationSeconds,
+            let screenshotAttached,
+            let systemInfoIncluded,
+            let errorType
+        ):
+            return Self.compactProps(
+                ("operation_id", operationID),
+                ("category", category),
+                ("outcome", outcome.rawValue),
+                ("duration_seconds", Self.format(durationSeconds)),
+                ("screenshot_attached", Self.boolString(screenshotAttached)),
+                ("system_info_included", Self.boolString(systemInfoIncluded)),
+                ("error_type", errorType)
+            )
         case .transcriptionFavorited(let isFavorite):
             return ["is_favorite": isFavorite ? "true" : "false"]
         case .keystrokeSnippetFired(let action):
@@ -621,6 +819,32 @@ extension TelemetryEventSpec {
             var props = ["error_type": errorType]
             if let errorDetail { props["error_detail"] = errorDetail }
             return props
+        case .meetingOperation(
+            let operationID,
+            let outcome,
+            let trigger,
+            let durationSeconds,
+            let liveWordCount,
+            let liveTranscriptLagged,
+            let microphoneTrackPresent,
+            let systemTrackPresent,
+            let notesUsed,
+            let notesLengthBucket,
+            let errorType
+        ):
+            return Self.compactProps(
+                ("operation_id", operationID),
+                ("outcome", outcome.rawValue),
+                ("trigger", trigger?.rawValue),
+                ("duration_seconds", durationSeconds.map(Self.format)),
+                ("live_word_count", liveWordCount.map(String.init)),
+                ("live_transcript_lagged", liveTranscriptLagged.map(Self.boolString)),
+                ("microphone_track_present", microphoneTrackPresent.map(Self.boolString)),
+                ("system_track_present", systemTrackPresent.map(Self.boolString)),
+                ("notes_used", notesUsed.map(Self.boolString)),
+                ("notes_length_bucket", notesLengthBucket),
+                ("error_type", errorType)
+            )
         case .meetingRecoveryDiscovered(let count, let source):
             return [
                 "count": "\(count)",
@@ -695,6 +919,39 @@ extension TelemetryEventSpec {
                 ("reason", reason.map { String($0.prefix(512)) }),
                 ("stack_trace", String(stackTrace.prefix(2048)))
             )
+        case .cliOperation(
+            let operationID,
+            let command,
+            let subcommand,
+            let outcome,
+            let durationSeconds,
+            let inputKind,
+            let outputFormat,
+            let json,
+            let exitCode,
+            let errorType
+        ):
+            return Self.compactProps(
+                ("operation_id", operationID),
+                ("command", command),
+                ("subcommand", subcommand),
+                ("outcome", outcome.rawValue),
+                ("duration_seconds", Self.format(durationSeconds)),
+                ("input_kind", inputKind?.rawValue),
+                ("output_format", outputFormat),
+                ("json", json.map(Self.boolString)),
+                ("exit_code", exitCode.map(String.init)),
+                ("error_type", errorType)
+            )
+        case .autoSaveOperation(let operationID, let scope, let format, let outcome, let durationSeconds, let errorType):
+            return Self.compactProps(
+                ("operation_id", operationID),
+                ("scope", scope.rawValue),
+                ("format", format.rawValue),
+                ("outcome", outcome.rawValue),
+                ("duration_seconds", Self.format(durationSeconds)),
+                ("error_type", errorType)
+            )
         }
     }
 
@@ -718,12 +975,12 @@ extension TelemetryEventSpec {
     private static func mergeDevice(_ base: [String: String]?, _ device: RecordingDeviceInfo?) -> [String: String]? {
         guard let device else { return base }
         var merged = base ?? [:]
-        merged["device_name"] = device.deviceName
         merged["device_transport"] = device.transport
         if let sub = device.subTransport { merged["device_sub_transport"] = sub }
         merged["device_sample_rate"] = "\(Int(device.sampleRate))"
         merged["device_channels"] = "\(device.channels)"
         if device.fallbackUsed { merged["device_fallback"] = "true" }
+        if device.requestedDeviceUID != nil { merged["device_selected"] = "true" }
         return merged
     }
 }
@@ -737,10 +994,12 @@ public enum TelemetryImplementedContract {
         .dictationCancelled: [],
         .dictationEmpty: [],
         .dictationFailed: ["error_type"],
+        .dictationOperation: ["operation_id", "outcome"],
         .transcriptionStarted: ["source"],
         .transcriptionCompleted: ["source", "word_count", "diarization_requested", "diarization_applied"],
         .transcriptionCancelled: ["source", "stage"],
         .transcriptionFailed: ["source", "stage", "error_type"],
+        .transcriptionOperation: ["operation_id", "outcome", "source", "duration_seconds", "diarization_requested", "diarization_applied"],
         .diarizationStarted: ["source"],
         .diarizationCompleted: ["source", "speaker_count"],
         .diarizationFailed: ["source", "error_type"],
@@ -753,6 +1012,7 @@ public enum TelemetryImplementedContract {
         .llmTransformFailed: ["provider", "error_type"],
         .llmFormatterUsed: ["provider", "source", "duration_seconds", "input_chars", "output_chars", "default_prompt_used", "input_truncated"],
         .llmFormatterFailed: ["provider", "source", "duration_seconds", "error_type", "default_prompt_used", "input_truncated"],
+        .llmOperation: ["operation_id", "feature", "provider", "streaming", "outcome", "duration_seconds"],
         .historySearched: [],
         .historyReplayed: [],
         .copyToClipboard: ["source"],
@@ -782,6 +1042,7 @@ public enum TelemetryImplementedContract {
         .modelDownloadCompleted: ["duration_seconds"],
         .modelDownloadFailed: ["error_type"],
         .feedbackSubmitted: ["category"],
+        .feedbackOperation: ["operation_id", "category", "outcome", "duration_seconds", "screenshot_attached", "system_info_included"],
         .transcriptionDeleted: [],
         .dictationDeleted: [],
         .transcriptionFavorited: ["is_favorite"],
@@ -795,6 +1056,7 @@ public enum TelemetryImplementedContract {
         .meetingRecordingCompleted: ["duration_seconds", "live_word_count", "live_transcript_lagged"],
         .meetingRecordingCancelled: ["duration_seconds"],
         .meetingRecordingFailed: ["error_type"],
+        .meetingOperation: ["operation_id", "outcome"],
         .meetingRecoveryDiscovered: ["count", "source"],
         .meetingRecoveryStarted: ["count", "source"],
         .meetingRecoveryCompleted: ["count", "duration_seconds", "source"],
@@ -808,6 +1070,8 @@ public enum TelemetryImplementedContract {
         .calendarAutoStopCancelled: [],
         .errorOccurred: ["domain", "code", "description"],
         .crashOccurred: ["crash_type", "signal", "name", "crash_ts", "crash_app_ver"],
+        .cliOperation: ["operation_id", "command", "outcome", "duration_seconds"],
+        .autoSaveOperation: ["operation_id", "scope", "format", "outcome", "duration_seconds"],
     ]
 
     public static var implementedEventNames: Set<TelemetryEventName> {

--- a/Sources/MacParakeetCore/Services/TelemetryService.swift
+++ b/Sources/MacParakeetCore/Services/TelemetryService.swift
@@ -57,10 +57,12 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
     private let locale: String?
     private let chip: String
     private let isEnabled: () -> Bool
+    private let requestTimeoutInterval: TimeInterval
 
     static let maxQueueSize = 200
     static let flushThreshold = 50
     static let flushInterval: TimeInterval = 60
+    static let requestTimeout: TimeInterval = 10
     static let maxBatchSize = 100
     static let terminationFlushMaxWait: TimeInterval = 0.4
     static let terminationRequestTimeout: TimeInterval = 0.3
@@ -92,6 +94,7 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
     public init(
         baseURL: URL? = nil,
         session: URLSession = .shared,
+        requestTimeoutInterval: TimeInterval = 10,
         isEnabled: @escaping () -> Bool = {
             UserDefaults.standard.object(forKey: "telemetryEnabled") as? Bool ?? true
         }
@@ -106,6 +109,7 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
         }
         self.session = session
         self.isEnabled = isEnabled
+        self.requestTimeoutInterval = requestTimeoutInterval
         self.sessionId = UUID().uuidString
         self.sessionStartedAt = Date()
 
@@ -169,7 +173,7 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
     private func flushQueuedEvents() async -> Set<String> {
         let events = takeQueuedEvents()
         guard !events.isEmpty else { return [] }
-        let failedEvents = await sendBatches(events, using: session, timeoutInterval: 10)
+        let failedEvents = await sendBatches(events, using: session, timeoutInterval: requestTimeoutInterval)
         requeueFailedEvents(failedEvents)
         return Set(failedEvents.map(\.eventId))
     }

--- a/Sources/MacParakeetCore/Services/TelemetryService.swift
+++ b/Sources/MacParakeetCore/Services/TelemetryService.swift
@@ -62,7 +62,6 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
     static let maxQueueSize = 200
     static let flushThreshold = 50
     static let flushInterval: TimeInterval = 60
-    static let requestTimeout: TimeInterval = 10
     static let maxBatchSize = 100
     static let terminationFlushMaxWait: TimeInterval = 0.4
     static let terminationRequestTimeout: TimeInterval = 0.3

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -63,6 +63,30 @@ extension TranscriptionServiceProtocol {
     }
 }
 
+private struct TranscriptionOperationContext: Sendable {
+    let operationID: String
+    let source: TelemetryTranscriptionSource
+    let inputKind: ObservabilityInputKind?
+    let mediaExtension: String?
+    let fileSizeBucket: String?
+    let startedAt: Date
+
+    init(
+        source: TelemetryTranscriptionSource,
+        inputKind: ObservabilityInputKind?,
+        mediaExtension: String?,
+        fileSizeBucket: String?,
+        startedAt: Date = Date()
+    ) {
+        self.operationID = Observability.operationID()
+        self.source = source
+        self.inputKind = inputKind
+        self.mediaExtension = mediaExtension
+        self.fileSizeBucket = fileSizeBucket
+        self.startedAt = startedAt
+    }
+}
+
 public actor TranscriptionService: TranscriptionServiceProtocol {
     private let logger = Logger(subsystem: "com.macparakeet.core", category: "TranscriptionService")
     private let audioProcessor: AudioProcessorProtocol
@@ -148,6 +172,12 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
 
         let fileSize = (try? FileManager.default.attributesOfItem(atPath: recording.mixedAudioURL.path)[.size] as? Int)
             .flatMap { $0 }
+        let operation = TranscriptionOperationContext(
+            source: .meeting,
+            inputKind: .meeting,
+            mediaExtension: Observability.mediaExtension(for: recording.mixedAudioURL),
+            fileSizeBucket: Observability.fileSizeBucket(bytes: fileSize)
+        )
 
         var transcription = Transcription(
             fileName: recording.displayName,
@@ -166,6 +196,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         return try await transcribeMeetingAudio(
             recording: recording,
             transcription: &transcription,
+            operation: operation,
             onProgress: onProgress
         )
     }
@@ -183,6 +214,12 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         var transcription = makeRetranscriptionRecord(from: original)
         transcription.fileSizeBytes = (try? FileManager.default.attributesOfItem(atPath: fileURL.path)[.size] as? Int)
             .flatMap { $0 } ?? original.fileSizeBytes
+        let operation = TranscriptionOperationContext(
+            source: source,
+            inputKind: Observability.inputKind(for: fileURL),
+            mediaExtension: Observability.mediaExtension(for: fileURL),
+            fileSizeBucket: Observability.fileSizeBucket(bytes: transcription.fileSizeBytes)
+        )
 
         Telemetry.send(.transcriptionStarted(source: source, audioDurationSeconds: nil))
 
@@ -191,6 +228,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
             source: source,
             sttJob: .fileTranscription,
             transcription: &transcription,
+            operation: operation,
             tempFiles: [],
             persistFailureStatus: false,
             onProgress: onProgress
@@ -210,6 +248,12 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         transcription.fileSizeBytes = (try? FileManager.default.attributesOfItem(atPath: recording.mixedAudioURL.path)[.size] as? Int)
             .flatMap { $0 } ?? original.fileSizeBytes
         transcription.userNotes = original.userNotes ?? recording.userNotes
+        let operation = TranscriptionOperationContext(
+            source: .meeting,
+            inputKind: .meeting,
+            mediaExtension: Observability.mediaExtension(for: recording.mixedAudioURL),
+            fileSizeBucket: Observability.fileSizeBucket(bytes: transcription.fileSizeBytes)
+        )
 
         Telemetry.send(.transcriptionStarted(
             source: .meeting,
@@ -219,6 +263,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         return try await transcribeMeetingAudio(
             recording: recording,
             transcription: &transcription,
+            operation: operation,
             persistFailureStatus: false,
             onProgress: onProgress
         )
@@ -241,6 +286,12 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         let fileSize = storedFileURL.flatMap {
             (try? FileManager.default.attributesOfItem(atPath: $0.path)[.size] as? Int).flatMap { $0 }
         }
+        let operation = TranscriptionOperationContext(
+            source: source,
+            inputKind: source == .youtube ? .youtube : Observability.inputKind(for: fileURL),
+            mediaExtension: Observability.mediaExtension(for: fileURL),
+            fileSizeBucket: Observability.fileSizeBucket(bytes: fileSize)
+        )
 
         var transcription = Transcription(
             fileName: fileName,
@@ -271,13 +322,27 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
             source: source,
             sttJob: sttJob,
             transcription: &transcription,
+            operation: operation,
             tempFiles: [],
             onProgress: onProgress
         )
     }
 
     public func transcribeURL(urlString: String, onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil) async throws -> Transcription {
+        let operation = TranscriptionOperationContext(
+            source: .youtube,
+            inputKind: .youtube,
+            mediaExtension: nil,
+            fileSizeBucket: nil
+        )
+
         guard let downloader = youtubeDownloader else {
+            sendTranscriptionOperation(
+                operation,
+                outcome: .unavailable,
+                stage: .download,
+                errorType: Self.errorType(for: YouTubeDownloadError.ytDlpNotFound)
+            )
             throw YouTubeDownloadError.ytDlpNotFound
         }
 
@@ -298,6 +363,11 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
                     audioDurationSeconds: nil,
                     stage: .download
                 ))
+                sendTranscriptionOperation(
+                    operation,
+                    outcome: .cancelled,
+                    stage: .download
+                )
             } else {
                 Telemetry.send(.transcriptionFailed(
                     source: .youtube,
@@ -305,6 +375,12 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
                     errorType: Self.errorType(for: error),
                     errorDetail: TelemetryErrorClassifier.errorDetail(error)
                 ))
+                sendTranscriptionOperation(
+                    operation,
+                    outcome: .failure,
+                    stage: .download,
+                    errorType: Self.errorType(for: error)
+                )
             }
             throw error
         }
@@ -317,6 +393,12 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
                 audioDurationSeconds: downloadResult.durationSeconds.map(Double.init),
                 stage: .download
             ))
+            sendTranscriptionOperation(
+                operation,
+                outcome: .cancelled,
+                stage: .download,
+                audioDurationSeconds: downloadResult.durationSeconds.map(Double.init)
+            )
             throw error
         }
         let keepDownloadedAudio = shouldKeepDownloadedAudio()
@@ -356,6 +438,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
             source: .youtube,
             sttJob: .fileTranscription,
             transcription: &transcription,
+            operation: operation,
             tempFiles: [downloadResult.audioFileURL],
             cleanUpDownloadedFiles: !keepDownloadedAudio,
             onProgress: onProgress
@@ -367,6 +450,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
     private func transcribeMeetingAudio(
         recording: MeetingRecordingOutput,
         transcription: inout Transcription,
+        operation: TranscriptionOperationContext,
         persistFailureStatus: Bool = true,
         onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
     ) async throws -> Transcription {
@@ -417,6 +501,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
             let completed = try await completeTranscription(
                 source: .meeting,
                 transcription: &transcription,
+                operation: operation,
                 rawText: finalized.rawTranscript,
                 processingStartedAt: processingStartedAt,
                 diarizationRequested: diarizationRequested,
@@ -432,6 +517,13 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
                     audioDurationSeconds: audioDurationSeconds,
                     stage: lifecycleStage
                 ))
+                sendTranscriptionOperation(
+                    operation,
+                    outcome: .cancelled,
+                    stage: lifecycleStage,
+                    audioDurationSeconds: audioDurationSeconds,
+                    diarizationRequested: diarizationRequested
+                )
             } else {
                 Telemetry.send(.transcriptionFailed(
                     source: .meeting,
@@ -439,6 +531,14 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
                     errorType: Self.errorType(for: error),
                     errorDetail: TelemetryErrorClassifier.errorDetail(error)
                 ))
+                sendTranscriptionOperation(
+                    operation,
+                    outcome: .failure,
+                    stage: lifecycleStage,
+                    audioDurationSeconds: audioDurationSeconds,
+                    diarizationRequested: diarizationRequested,
+                    errorType: Self.errorType(for: error)
+                )
             }
 
             if persistFailureStatus {
@@ -601,6 +701,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         source: TelemetryTranscriptionSource,
         sttJob: STTJobKind,
         transcription: inout Transcription,
+        operation: TranscriptionOperationContext,
         tempFiles: [URL],
         cleanUpDownloadedFiles: Bool = true,
         persistFailureStatus: Bool = true,
@@ -691,6 +792,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
             let completed = try await completeTranscription(
                 source: source,
                 transcription: &transcription,
+                operation: operation,
                 rawText: result.text,
                 processingStartedAt: processingStartedAt,
                 diarizationRequested: diarizationRequested,
@@ -720,6 +822,13 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
                     audioDurationSeconds: audioDurationSeconds,
                     stage: lifecycleStage
                 ))
+                sendTranscriptionOperation(
+                    operation,
+                    outcome: .cancelled,
+                    stage: lifecycleStage,
+                    audioDurationSeconds: audioDurationSeconds,
+                    diarizationRequested: diarizationRequested
+                )
             } else {
                 Telemetry.send(.transcriptionFailed(
                     source: source,
@@ -727,6 +836,14 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
                     errorType: Self.errorType(for: error),
                     errorDetail: TelemetryErrorClassifier.errorDetail(error)
                 ))
+                sendTranscriptionOperation(
+                    operation,
+                    outcome: .failure,
+                    stage: lifecycleStage,
+                    audioDurationSeconds: audioDurationSeconds,
+                    diarizationRequested: diarizationRequested,
+                    errorType: Self.errorType(for: error)
+                )
             }
 
             if persistFailureStatus {
@@ -777,6 +894,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
     private func completeTranscription(
         source: TelemetryTranscriptionSource,
         transcription: inout Transcription,
+        operation: TranscriptionOperationContext,
         rawText: String,
         processingStartedAt: Date,
         diarizationRequested: Bool,
@@ -823,6 +941,17 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
             diarizationRequested: diarizationRequested,
             diarizationApplied: diarizationApplied
         ))
+        sendTranscriptionOperation(
+            operation,
+            outcome: .success,
+            stage: .postProcessing,
+            audioDurationSeconds: audioDurationSeconds,
+            processingSeconds: processingSeconds,
+            wordCount: wordCount,
+            speakerCount: transcription.speakerCount,
+            diarizationRequested: diarizationRequested,
+            diarizationApplied: diarizationApplied
+        )
 
         return transcription
     }
@@ -869,6 +998,37 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
 
     private static func errorType(for error: Error) -> String {
         TelemetryErrorClassifier.classify(error)
+    }
+
+    private func sendTranscriptionOperation(
+        _ operation: TranscriptionOperationContext,
+        outcome: ObservabilityOutcome,
+        stage: TelemetryTranscriptionStage?,
+        audioDurationSeconds: Double? = nil,
+        processingSeconds: Double? = nil,
+        wordCount: Int? = nil,
+        speakerCount: Int? = nil,
+        diarizationRequested: Bool = false,
+        diarizationApplied: Bool = false,
+        errorType: String? = nil
+    ) {
+        Telemetry.send(.transcriptionOperation(
+            operationID: operation.operationID,
+            outcome: outcome,
+            source: operation.source,
+            stage: stage,
+            durationSeconds: Observability.durationSeconds(since: operation.startedAt),
+            audioDurationSeconds: audioDurationSeconds,
+            processingSeconds: processingSeconds ?? Observability.durationSeconds(since: operation.startedAt),
+            wordCount: wordCount,
+            speakerCount: speakerCount,
+            diarizationRequested: diarizationRequested,
+            diarizationApplied: diarizationApplied,
+            inputKind: operation.inputKind,
+            mediaExtension: operation.mediaExtension,
+            fileSizeBucket: operation.fileSizeBucket,
+            errorType: errorType
+        ))
     }
 
     private static let videoExtensions: Set<String> = ["mp4", "mov", "mkv", "avi", "webm", "m4v", "flv", "wmv"]

--- a/Sources/MacParakeetViewModels/FeedbackViewModel.swift
+++ b/Sources/MacParakeetViewModels/FeedbackViewModel.swift
@@ -115,6 +115,8 @@ public final class FeedbackViewModel {
         submissionState = .submitting
         let trimmedMessage = message.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
+        let operationID = Observability.operationID()
+        let startedAt = Date()
 
         let payload = FeedbackPayload(
             category: category,
@@ -134,6 +136,15 @@ public final class FeedbackViewModel {
                 guard !Task.isCancelled else { return }
 
                 Telemetry.send(.feedbackSubmitted(category: payload.category.rawValue))
+                Telemetry.send(.feedbackOperation(
+                    operationID: operationID,
+                    category: payload.category.rawValue,
+                    outcome: .success,
+                    durationSeconds: Observability.durationSeconds(since: startedAt),
+                    screenshotAttached: payload.screenshotBase64 != nil,
+                    systemInfoIncluded: true,
+                    errorType: nil
+                ))
                 submissionState = .success
                 // Auto-reset after 3 seconds
                 try await Task.sleep(for: .seconds(3))
@@ -146,6 +157,15 @@ public final class FeedbackViewModel {
                 return
             } catch {
                 guard !Task.isCancelled else { return }
+                Telemetry.send(.feedbackOperation(
+                    operationID: operationID,
+                    category: payload.category.rawValue,
+                    outcome: .failure,
+                    durationSeconds: Observability.durationSeconds(since: startedAt),
+                    screenshotAttached: payload.screenshotBase64 != nil,
+                    systemInfoIncluded: true,
+                    errorType: Observability.errorType(for: error)
+                ))
                 submissionState = .error(error.localizedDescription)
             }
         }

--- a/Tests/MacParakeetTests/Services/DictationServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/DictationServiceTests.swift
@@ -1,6 +1,31 @@
 import XCTest
 @testable import MacParakeetCore
 
+private final class DictationTelemetrySpy: TelemetryServiceProtocol, @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [TelemetryEventSpec] = []
+
+    func send(_ event: TelemetryEventSpec) {
+        lock.lock()
+        events.append(event)
+        lock.unlock()
+    }
+
+    func sendAndFlush(_ event: TelemetryEventSpec) async -> Bool {
+        send(event)
+        return true
+    }
+
+    func flush() async {}
+    func flushForTermination() {}
+
+    func snapshot() -> [TelemetryEventSpec] {
+        lock.lock()
+        defer { lock.unlock() }
+        return events
+    }
+}
+
 final class DictationServiceTests: XCTestCase {
     var service: DictationService!
     var mockAudio: MockAudioProcessor!
@@ -20,6 +45,15 @@ final class DictationServiceTests: XCTestCase {
         )
     }
 
+    override func tearDown() {
+        Telemetry.configure(NoOpTelemetryService())
+        service = nil
+        mockAudio = nil
+        mockSTT = nil
+        dictationRepo = nil
+        super.tearDown()
+    }
+
     func testInitialStateIsIdle() async {
         let state = await service.state
         if case .idle = state {} else {
@@ -33,6 +67,53 @@ final class DictationServiceTests: XCTestCase {
         if case .recording = state {} else {
             XCTFail("Expected recording state, got \(state)")
         }
+    }
+
+    func testStartFailureUsesRequestedTelemetryContextForOperation() async throws {
+        let telemetry = DictationTelemetrySpy()
+        Telemetry.configure(telemetry)
+
+        try await service.startRecording(context: DictationTelemetryContext(trigger: .menuBar, mode: .persistent))
+        await service.confirmCancel()
+
+        await mockAudio.configureCaptureError(AudioProcessorError.microphoneNotAvailable)
+        do {
+            try await service.startRecording(context: DictationTelemetryContext(trigger: .hotkey, mode: .hold))
+            XCTFail("Expected startRecording to throw")
+        } catch let error as AudioProcessorError {
+            if case .microphoneNotAvailable = error {} else {
+                XCTFail("Expected microphoneNotAvailable, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        let operation = try XCTUnwrap(dictationOperationProps(in: telemetry.snapshot()).last)
+        XCTAssertEqual(operation["outcome"], "failure")
+        XCTAssertEqual(operation["trigger"], "hotkey")
+        XCTAssertEqual(operation["mode"], "hold")
+    }
+
+    func testCancelDuringStartCaptureStillEmitsCancelledOperation() async throws {
+        let telemetry = DictationTelemetrySpy()
+        Telemetry.configure(telemetry)
+        await mockAudio.configureStartCaptureDelay(milliseconds: 100)
+
+        let startTask = Task {
+            try await self.service.startRecording(context: DictationTelemetryContext(trigger: .hotkey, mode: .hold))
+        }
+
+        try await Task.sleep(for: .milliseconds(20))
+        await service.cancelRecording(reason: .hotkey)
+        try await startTask.value
+        await service.confirmCancel()
+
+        let operations = dictationOperationProps(in: telemetry.snapshot())
+        XCTAssertTrue(operations.contains { operation in
+            operation["outcome"] == "cancelled"
+                && operation["trigger"] == "hotkey"
+                && operation["mode"] == "hold"
+        })
     }
 
     func testStopRecordingTranscribesAndSaves() async throws {
@@ -158,4 +239,11 @@ final class DictationServiceTests: XCTestCase {
 
     // Note: Cancel flow tests, stop-when-not-recording, and STT error propagation
     // are covered in CancelFlowTests.swift to avoid duplication.
+
+    private func dictationOperationProps(in events: [TelemetryEventSpec]) -> [[String: String]] {
+        events.compactMap { event in
+            guard case .dictationOperation = event else { return nil }
+            return event.props ?? [:]
+        }
+    }
 }

--- a/Tests/MacParakeetTests/Services/LLMServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/LLMServiceTests.swift
@@ -71,6 +71,7 @@ final class MockLLMClient: LLMClientProtocol, @unchecked Sendable {
 final class MockLLMExecutionContextResolver: LLMExecutionContextResolving, @unchecked Sendable {
     let configStore: MockLLMConfigStore
     var localCLIConfig: LocalCLIConfig?
+    var resolveError: Error?
 
     init(configStore: MockLLMConfigStore, localCLIConfig: LocalCLIConfig? = nil) {
         self.configStore = configStore
@@ -78,6 +79,9 @@ final class MockLLMExecutionContextResolver: LLMExecutionContextResolving, @unch
     }
 
     func resolveContext() throws -> LLMExecutionContext? {
+        if let resolveError {
+            throw resolveError
+        }
         guard let config = try configStore.loadConfig() else { return nil }
         let resolvedLocalCLIConfig = config.id == .localCLI ? localCLIConfig : nil
         return LLMExecutionContext(
@@ -140,6 +144,31 @@ final class MockLLMConfigStore: LLMConfigStoreProtocol, @unchecked Sendable {
     }
 }
 
+private final class LLMTelemetrySpy: TelemetryServiceProtocol, @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [TelemetryEventSpec] = []
+
+    func send(_ event: TelemetryEventSpec) {
+        lock.lock()
+        events.append(event)
+        lock.unlock()
+    }
+
+    func sendAndFlush(_ event: TelemetryEventSpec) async -> Bool {
+        send(event)
+        return true
+    }
+
+    func flush() async {}
+    func flushForTermination() {}
+
+    func snapshot() -> [TelemetryEventSpec] {
+        lock.lock()
+        defer { lock.unlock() }
+        return events
+    }
+}
+
 final class LLMServiceTests: XCTestCase {
     var mockClient: MockLLMClient!
     var mockConfigStore: MockLLMConfigStore!
@@ -152,6 +181,15 @@ final class LLMServiceTests: XCTestCase {
         mockConfigStore.config = .openai(apiKey: "sk-test")
         mockContextResolver = MockLLMExecutionContextResolver(configStore: mockConfigStore)
         service = LLMService(client: mockClient, contextResolver: mockContextResolver)
+    }
+
+    override func tearDown() {
+        Telemetry.configure(NoOpTelemetryService())
+        service = nil
+        mockContextResolver = nil
+        mockConfigStore = nil
+        mockClient = nil
+        super.tearDown()
     }
 
     // MARK: - Not Configured
@@ -219,6 +257,28 @@ final class LLMServiceTests: XCTestCase {
         } catch {
             XCTFail("Unexpected error: \(error)")
         }
+    }
+
+    func testSetupCancellationEmitsCancelledLLMOperationWithoutErrorType() async {
+        let telemetry = LLMTelemetrySpy()
+        Telemetry.configure(telemetry)
+        mockContextResolver.resolveError = CancellationError()
+
+        do {
+            _ = try await service.summarize(transcript: "Test")
+            XCTFail("Expected CancellationError")
+        } catch is CancellationError {
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        let operations = llmOperationProps(in: telemetry.snapshot())
+        XCTAssertEqual(operations.count, 1)
+        XCTAssertEqual(operations.first?["feature"], "prompt_result")
+        XCTAssertEqual(operations.first?["provider"], "unknown")
+        XCTAssertEqual(operations.first?["streaming"], "false")
+        XCTAssertEqual(operations.first?["outcome"], "cancelled")
+        XCTAssertNil(operations.first?["error_type"])
     }
 
     // MARK: - Summarize
@@ -693,6 +753,36 @@ final class LLMServiceTests: XCTestCase {
         }
     }
 
+    func testSummarizeStreamSetupCancellationEmitsOneCancelledLLMOperationWithoutErrorType() async {
+        let telemetry = LLMTelemetrySpy()
+        Telemetry.configure(telemetry)
+        mockContextResolver.resolveError = CancellationError()
+        let stream = service.summarizeStream(transcript: "Test")
+
+        do {
+            for try await _ in stream {
+                XCTFail("Expected stream to throw")
+            }
+            XCTFail("Expected CancellationError")
+        } catch is CancellationError {
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        let events = telemetry.snapshot()
+        let operations = llmOperationProps(in: events)
+        XCTAssertEqual(operations.count, 1)
+        XCTAssertEqual(operations.first?["feature"], "prompt_result")
+        XCTAssertEqual(operations.first?["provider"], "unknown")
+        XCTAssertEqual(operations.first?["streaming"], "true")
+        XCTAssertEqual(operations.first?["outcome"], "cancelled")
+        XCTAssertNil(operations.first?["error_type"])
+        XCTAssertFalse(events.contains { event in
+            if case .llmPromptResultFailed = event { return true }
+            return false
+        })
+    }
+
     func testChatStreamThrowsWhenNotConfigured() async {
         mockConfigStore.config = nil
         let stream = service.chatStream(question: "Q", transcript: "T", history: [])
@@ -747,5 +837,12 @@ final class LLMServiceTests: XCTestCase {
         mockConfigStore.config = nil
         try mockConfigStore.updateModelName("gpt-5-mini")
         XCTAssertNil(try mockConfigStore.loadConfig())
+    }
+
+    private func llmOperationProps(in events: [TelemetryEventSpec]) -> [[String: String]] {
+        events.compactMap { event in
+            guard case .llmOperation = event else { return nil }
+            return event.props ?? [:]
+        }
     }
 }

--- a/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
@@ -432,6 +432,10 @@ final class TranscriptionServiceTests: XCTestCase {
         XCTAssertEqual(convertURLs, [microphoneURL, systemURL])
 
         let events = telemetry.snapshot()
+        let completedEvent = events.reversed().first {
+            if case .transcriptionCompleted = $0 { return true }
+            return false
+        }
         guard case .transcriptionCompleted(
             let source,
             _,
@@ -440,7 +444,7 @@ final class TranscriptionServiceTests: XCTestCase {
             let speakerCount,
             let diarizationRequested,
             let diarizationApplied
-        ) = try XCTUnwrap(events.last) else {
+        ) = try XCTUnwrap(completedEvent) else {
             return XCTFail("Expected transcription_completed telemetry")
         }
         XCTAssertEqual(source, .meeting)
@@ -877,7 +881,11 @@ final class TranscriptionServiceTests: XCTestCase {
         }
 
         let events = telemetry.snapshot()
-        guard case .transcriptionFailed(let source, let stage, let errorType, _) = try XCTUnwrap(events.last) else {
+        let failedEvent = events.reversed().first {
+            if case .transcriptionFailed = $0 { return true }
+            return false
+        }
+        guard case .transcriptionFailed(let source, let stage, let errorType, _) = try XCTUnwrap(failedEvent) else {
             return XCTFail("Expected transcription_failed telemetry")
         }
         XCTAssertEqual(source, .meeting)
@@ -1014,7 +1022,11 @@ final class TranscriptionServiceTests: XCTestCase {
         }
 
         let events = telemetry.snapshot()
-        guard case .transcriptionFailed(let source, let stage, let errorType, _) = try XCTUnwrap(events.last) else {
+        let failedEvent = events.reversed().first {
+            if case .transcriptionFailed = $0 { return true }
+            return false
+        }
+        guard case .transcriptionFailed(let source, let stage, let errorType, _) = try XCTUnwrap(failedEvent) else {
             return XCTFail("Expected transcription_failed telemetry")
         }
         XCTAssertEqual(source, .youtube)

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -400,6 +400,93 @@ final class TelemetryServiceTests: XCTestCase {
         XCTAssertNil(props["file_path"])
     }
 
+    func testCanonicalOperationSerializesSafeDimensionsOnly() throws {
+        let event = TelemetryEvent(
+            spec: .transcriptionOperation(
+                operationID: "op-123",
+                outcome: .success,
+                source: .file,
+                stage: .postProcessing,
+                durationSeconds: 15.8,
+                audioDurationSeconds: 90,
+                processingSeconds: 12.4,
+                wordCount: 240,
+                speakerCount: 2,
+                diarizationRequested: true,
+                diarizationApplied: true,
+                inputKind: .audio,
+                mediaExtension: "m4a",
+                fileSizeBucket: "10_100mb",
+                errorType: nil
+            ),
+            appVer: "0.4.2",
+            osVer: "15.3",
+            locale: "en-US",
+            chip: "Apple M1",
+            session: "test-session"
+        )
+
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        let data = try encoder.encode(event)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let props = try XCTUnwrap(json["props"] as? [String: String])
+
+        XCTAssertEqual(json["event"] as? String, "transcription_operation")
+        XCTAssertEqual(props["operation_id"], "op-123")
+        XCTAssertEqual(props["outcome"], "success")
+        XCTAssertEqual(props["source"], "file")
+        XCTAssertEqual(props["duration_seconds"], "15.8")
+        XCTAssertEqual(props["input_kind"], "audio")
+        XCTAssertEqual(props["media_extension"], "m4a")
+        XCTAssertEqual(props["file_size_bucket"], "10_100mb")
+        XCTAssertNil(props["file_path"])
+        XCTAssertNil(props["file_name"])
+        XCTAssertNil(props["source_url"])
+    }
+
+    func testDictationOperationDoesNotSerializeDeviceNameOrUID() throws {
+        let device = RecordingDeviceInfo(
+            deviceName: "Alice's Custom Microphone",
+            transport: "bluetooth",
+            subTransport: nil,
+            sampleRate: 48_000,
+            channels: 1,
+            fallbackUsed: false,
+            deviceUID: "secret-device-uid",
+            requestedDeviceUID: "secret-requested-uid"
+        )
+        let event = TelemetryEvent(
+            spec: .dictationOperation(
+                operationID: "op-dict",
+                outcome: .success,
+                trigger: .hotkey,
+                mode: .persistent,
+                durationSeconds: 2.4,
+                wordCount: 10,
+                errorType: nil,
+                device: device
+            ),
+            appVer: "0.4.2",
+            osVer: "15.3",
+            locale: "en-US",
+            chip: "Apple M1",
+            session: "test-session"
+        )
+
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        let data = try encoder.encode(event)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let props = try XCTUnwrap(json["props"] as? [String: String])
+
+        XCTAssertEqual(props["device_transport"], "bluetooth")
+        XCTAssertEqual(props["device_selected"], "true")
+        XCTAssertNil(props["device_name"])
+        XCTAssertNil(props["device_uid"])
+        XCTAssertNil(props["requested_device_uid"])
+    }
+
     func testImplementedContractCoversEveryTypedEventName() {
         XCTAssertEqual(
             Set(TelemetryEventName.allCases),
@@ -514,6 +601,15 @@ final class TelemetryServiceTests: XCTestCase {
             .dictationCancelled(durationSeconds: 1.5, reason: .escape),
             .dictationEmpty(durationSeconds: 1.5),
             .dictationFailed(errorType: "network"),
+            .dictationOperation(
+                operationID: "op-dict",
+                outcome: .success,
+                trigger: .hotkey,
+                mode: .persistent,
+                durationSeconds: 12.5,
+                wordCount: 84,
+                errorType: nil
+            ),
             .transcriptionStarted(source: .file, audioDurationSeconds: 30.0),
             .transcriptionCompleted(
                 source: .dragDrop,
@@ -526,6 +622,23 @@ final class TelemetryServiceTests: XCTestCase {
             ),
             .transcriptionCancelled(source: .youtube, audioDurationSeconds: 45.0, stage: .stt),
             .transcriptionFailed(source: .file, stage: .audioConversion, errorType: "transcribe"),
+            .transcriptionOperation(
+                operationID: "op-transcription",
+                outcome: .success,
+                source: .dragDrop,
+                stage: .postProcessing,
+                durationSeconds: 2.9,
+                audioDurationSeconds: 30.0,
+                processingSeconds: 2.4,
+                wordCount: 120,
+                speakerCount: 2,
+                diarizationRequested: true,
+                diarizationApplied: true,
+                inputKind: .audio,
+                mediaExtension: "mp3",
+                fileSizeBucket: "1_10mb",
+                errorType: nil
+            ),
             .exportUsed(format: "txt"),
             .llmPromptResultUsed(provider: "openai"),
             .llmPromptResultFailed(provider: "openai", errorType: "auth"),
@@ -549,6 +662,20 @@ final class TelemetryServiceTests: XCTestCase {
                 errorType: "network",
                 defaultPromptUsed: false,
                 inputTruncated: true
+            ),
+            .llmOperation(
+                operationID: "op-llm",
+                feature: "chat",
+                provider: "openai",
+                streaming: false,
+                outcome: .success,
+                durationSeconds: 1.2,
+                inputChars: 480,
+                outputChars: 512,
+                inputTruncated: false,
+                promptDefaultUsed: nil,
+                messageCount: 3,
+                errorType: nil
             ),
             .historySearched,
             .historyReplayed,
@@ -579,6 +706,15 @@ final class TelemetryServiceTests: XCTestCase {
             .modelDownloadStarted,
             .modelDownloadCompleted(durationSeconds: 30.0),
             .modelDownloadFailed(errorType: "network"),
+            .feedbackOperation(
+                operationID: "op-feedback",
+                category: "bug",
+                outcome: .success,
+                durationSeconds: 0.6,
+                screenshotAttached: false,
+                systemInfoIncluded: true,
+                errorType: nil
+            ),
             .onboardingStep(step: "microphone"),
             .licenseActivationFailed(errorType: "invalid_key"),
             .keystrokeSnippetFired(action: "return"),
@@ -586,6 +722,19 @@ final class TelemetryServiceTests: XCTestCase {
             .meetingRecordingCompleted(durationSeconds: 1800.0, liveWordCount: 4200, liveTranscriptLagged: false),
             .meetingRecordingCancelled(durationSeconds: 30.0),
             .meetingRecordingFailed(errorType: "tap_creation_failed"),
+            .meetingOperation(
+                operationID: "op-meeting",
+                outcome: .success,
+                trigger: .manual,
+                durationSeconds: 1800.0,
+                liveWordCount: 4200,
+                liveTranscriptLagged: false,
+                microphoneTrackPresent: true,
+                systemTrackPresent: true,
+                notesUsed: true,
+                notesLengthBucket: "1_200",
+                errorType: nil
+            ),
             .meetingRecoveryDiscovered(count: 1, source: .launch),
             .meetingRecoveryStarted(count: 1, source: .launch),
             .meetingRecoveryCompleted(count: 1, durationSeconds: 4.2, source: .launch),
@@ -597,6 +746,26 @@ final class TelemetryServiceTests: XCTestCase {
                 crashTimestamp: "1711900000", crashAppVer: "0.5.1",
                 crashOsVer: "15.3.1", uuid: "A1B2C3D4", slide: "0x100000",
                 reason: nil, stackTrace: "0x1234\n0x5678"
+            ),
+            .cliOperation(
+                operationID: "op-cli",
+                command: "transcribe",
+                subcommand: nil,
+                outcome: .success,
+                durationSeconds: 4.2,
+                inputKind: .audio,
+                outputFormat: "json",
+                json: true,
+                exitCode: 0,
+                errorType: nil
+            ),
+            .autoSaveOperation(
+                operationID: "op-auto-save",
+                scope: .transcription,
+                format: .md,
+                outcome: .success,
+                durationSeconds: 0.2,
+                errorType: nil
             ),
         ]
     }

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -70,6 +70,12 @@ macparakeet-cli
 > `jq` or any JSON tool. Side-effect commands (delete, favorite, etc.) print one
 > confirmation line and don't accept `--json`.
 
+> **Telemetry convention**: CLI telemetry uses the same opt-out preference as
+> the GUI and does not change stdout/stderr contracts. `transcribe` emits a
+> privacy-safe `cli_operation` event with command, outcome, duration, output
+> format, and coarse input kind. Set `MACPARAKEET_TELEMETRY=0` to disable CLI
+> telemetry for a process.
+
 ## Core Modes
 
 ### 1) GUI-Parity Mode (recommended for behavior checks)

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -2,6 +2,7 @@
 
 > Status: **ACTIVE** — Design document for MacParakeet's privacy-first analytics system.
 > Reviewed by: Codex (2026-03-13). See [Codex Review](#codex-review-2026-03-13) for accepted/rejected feedback.
+> Observability update: Codex (2026-04-26). Added canonical operation events for product health and CLI/agent usage while preserving the existing opt-out and privacy model.
 
 ## Philosophy
 
@@ -21,7 +22,11 @@
 ## Architecture
 
 ```
-MacParakeet.app (Swift client)
+MacParakeet.app / macparakeet-cli (Swift clients)
+    │
+    │  Typed TelemetryEventSpec events
+    │  - breadcrumb events for funnels
+    │  - canonical *_operation outcome events for product health
     │
     │  POST /api/telemetry  (batch of events, every 60s / app quit / 50 events)
     │
@@ -87,7 +92,7 @@ CREATE INDEX idx_events_session ON events(session);
 - YouTube URLs
 - LLM prompts or responses
 - IP addresses
-- Device serial numbers or hardware IDs
+- Microphone names, device UIDs, serial numbers, or hardware IDs
 - Persistent user identifiers across sessions
 - Unredacted error descriptions (server-side PII redaction strips paths, URLs, keys before storage)
 - Any data that could identify the user
@@ -95,6 +100,23 @@ CREATE INDEX idx_events_session ON events(session);
 ---
 
 ## Event Catalog
+
+### Canonical Operation Events
+
+MacParakeet uses two event shapes together:
+
+- **Breadcrumb events** such as `dictation_started`, `transcription_failed`, and
+  `llm_formatter_used` preserve existing funnel and feature-adoption analysis.
+- **Operation events** such as `dictation_operation`,
+  `transcription_operation`, `meeting_operation`, `llm_operation`,
+  `feedback_operation`, `auto_save_operation`, and `cli_operation` are wide,
+  outcome-focused events emitted once per operation completion. They carry a
+  short-lived `operation_id`, `outcome`, duration, safe dimensions, and
+  `error_type` when relevant.
+
+Operation IDs are random UUIDs and are not persisted across app launches. They
+exist to correlate the start/end/failure breadcrumbs for one local operation
+inside one telemetry session, not to identify a user.
 
 ### 1. App Lifecycle — "Who's using this?"
 
@@ -114,8 +136,9 @@ CREATE INDEX idx_events_session ON events(session);
 | `dictation_cancelled` | `duration_seconds`, `reason` (escape, hotkey, silence), `device_*` | Are people cancelling often? Why? |
 | `dictation_empty` | `duration_seconds`, `device_*` | Are people getting empty results? (quality signal) |
 | `dictation_failed` | `error_type`, `device_*` | Core feature failures — blind spot without this |
+| `dictation_operation` | `operation_id`, `outcome`, `trigger`, `mode`, `duration_seconds`, `word_count`, `error_type`, `device_*` | One wide outcome event per dictation attempt |
 
-> **Device props** (optional, included when available): `device_name`, `device_transport`, `device_sub_transport`, `device_sample_rate`, `device_channels`, `device_fallback`. These help diagnose audio quality issues tied to specific microphone configurations without identifying the user.
+> **Device props** (optional, included when available): `device_transport`, `device_sub_transport`, `device_sample_rate`, `device_channels`, `device_fallback`, `device_selected`. Raw device names and UIDs are intentionally not serialized.
 
 ### 3. Transcription — "Is file transcription valuable?"
 
@@ -125,8 +148,9 @@ CREATE INDEX idx_events_session ON events(session);
 | `transcription_completed` | `source`, `audio_duration_seconds`, `processing_seconds`, `word_count`, `speaker_count`, `diarization_requested`, `diarization_applied` | Real-world performance and speaker-label coverage across file, YouTube, and meeting pipelines |
 | `transcription_cancelled` | `source`, `audio_duration_seconds`, `stage` (download, audio_conversion, stt, diarization, post_processing) | Where do users abandon jobs? |
 | `transcription_failed` | `source`, `stage`, `error_type` | What's breaking, and in which pipeline stage? |
+| `transcription_operation` | `operation_id`, `outcome`, `source`, `stage`, `duration_seconds`, `audio_duration_seconds`, `processing_seconds`, `word_count`, `speaker_count`, `diarization_requested`, `diarization_applied`, `input_kind`, `media_extension`, `file_size_bucket`, `error_type` | One wide outcome event per file, YouTube, or meeting transcription |
 
-`transcription_completed` is the canonical outcome event for batch/file/YouTube/meeting transcription. For meetings, the app now always treats the final transcript as fresh batch STT over the recorded source artifacts, not reused live-preview metadata. The separate `diarization_*` events remain useful for diarization-specific timing and failure analysis, but the completion event now carries enough context to answer product questions without joining multiple event streams first.
+`transcription_operation` is the broad product-health outcome event. `transcription_completed` remains the stable success breadcrumb/performance event. For meetings, the app always treats the final transcript as fresh batch STT over the recorded source artifacts, not reused live-preview metadata. The separate `diarization_*` events remain useful for diarization-specific timing and failure analysis.
 
 ### 3b. Speaker Diarization — "Is speaker detection working?"
 
@@ -147,11 +171,14 @@ CREATE INDEX idx_events_session ON events(session);
 | `llm_chat_failed` | `provider`, `error_type` | Chat failure rates per provider |
 | `llm_formatter_used` | `provider`, `source`, `duration_seconds`, `input_chars`, `output_chars`, `default_prompt_used`, `input_truncated` | Is transcript/dictation formatting useful, and how expensive is it? |
 | `llm_formatter_failed` | `provider`, `source`, `duration_seconds`, `error_type`, `default_prompt_used`, `input_truncated` | Formatter failure rates and prompt-shape correlations |
+| `llm_operation` | `operation_id`, `feature`, `provider`, `streaming`, `outcome`, `duration_seconds`, `input_chars`, `output_chars`, `input_truncated`, `prompt_default_used`, `message_count`, `error_type` | One safe outcome event per LLM call, without prompts, responses, or provider error bodies |
 | `history_searched` | — | Is search useful? |
 | `history_replayed` | — | Do people re-listen to audio? |
 | `copy_to_clipboard` | `source` (dictation, transcription, history, meeting, discover) | How do people get text out? |
 | `keystroke_snippet_fired` | — | Are keystroke action snippets being used? |
 | `feedback_submitted` | `category` (bug, featureRequest, other) | Feedback volume and sentiment split |
+| `feedback_operation` | `operation_id`, `category`, `outcome`, `duration_seconds`, `screenshot_attached`, `system_info_included`, `error_type` | Feedback delivery health without storing message text or email |
+| `auto_save_operation` | `operation_id`, `scope`, `format`, `outcome`, `duration_seconds`, `error_type` | Whether transcript/meeting auto-save succeeds for configured users |
 | `transcription_deleted` | — | Are users cleaning up transcriptions? |
 | `dictation_deleted` | — | History hygiene patterns |
 | `transcription_favorited` | `is_favorite` (true/false) | Which content types get saved? |
@@ -167,6 +194,16 @@ CREATE INDEX idx_events_session ON events(session);
 | `meeting_recovery_completed` | `count`, `duration_seconds`, `source` | Recovery success rate and latency |
 | `meeting_recovery_discarded` | `count`, `source` | How often users intentionally discard interrupted recordings |
 | `meeting_recovery_failed` | `count`, `source`, `error_type`, `error_detail` | What blocks recovery in the field |
+
+### 4c. Meeting Recording — "Is meeting capture healthy?"
+
+| Event | Props | Question It Answers |
+|---|---|---|
+| `meeting_recording_started` | `trigger` (manual, hotkey, calendar_auto_start) | How meetings start |
+| `meeting_recording_completed` | `duration_seconds`, `live_word_count`, `live_transcript_lagged` | Recording duration and live-preview quality |
+| `meeting_recording_cancelled` | `duration_seconds` | How often recordings are intentionally discarded |
+| `meeting_recording_failed` | `error_type` | What blocks recording/finalization |
+| `meeting_operation` | `operation_id`, `outcome`, `trigger`, `duration_seconds`, `live_word_count`, `live_transcript_lagged`, `microphone_track_present`, `system_track_present`, `notes_used`, `notes_length_bucket`, `error_type` | One wide outcome event for the full meeting capture + transcription flow |
 
 ### 5. Settings & Customization — "How do people configure the app?"
 
@@ -218,6 +255,16 @@ CREATE INDEX idx_events_session ON events(session);
 | `error_occurred` | `domain`, `code`, `description` | What errors are users hitting? |
 | `crash_occurred` | `crash_type`, `signal`, `reason`, `stack_trace`, `crash_app_ver`, `crash_os_ver` | What crashes are happening? |
 
+### 10. CLI — "Are agents and scripts succeeding?"
+
+| Event | Props | Question It Answers |
+|---|---|---|
+| `cli_operation` | `operation_id`, `command`, `subcommand`, `outcome`, `duration_seconds`, `input_kind`, `output_format`, `json`, `exit_code`, `error_type` | Which CLI workflows are used by scripts/agents, and where they fail |
+
+CLI telemetry is initialized by `macparakeet-cli transcribe` and uses the same
+app preference as the GUI. Users and automation can also set
+`MACPARAKEET_TELEMETRY=0` to force-disable CLI telemetry for a process.
+
 > **Important:** `error_occurred` includes a `description` field for full error visibility. The **Cloudflare Worker redacts PII server-side** before storage:
 > - File paths (`/Users/...`, `~/...`) → `[PATH]`
 > - URLs → `[URL]`
@@ -234,22 +281,38 @@ CREATE INDEX idx_events_session ON events(session);
 ### Core API
 
 ```swift
-// Simple fire-and-forget API
-Telemetry.send("dictation_completed", [
-    "duration_seconds": "12.5",
-    "word_count": "84",
-    "mode": "hold"
-])
+// Simple fire-and-forget API. Event names and props are typed in
+// TelemetryEventSpec so schema drift is caught by tests.
+Telemetry.send(.dictationCompleted(
+    durationSeconds: 12.5,
+    wordCount: 84,
+    mode: .hold
+))
 
-// No props needed
-Telemetry.send("app_launched")
+Telemetry.send(.transcriptionOperation(
+    operationID: Observability.operationID(),
+    outcome: .success,
+    source: .file,
+    stage: .postProcessing,
+    durationSeconds: 2.9,
+    audioDurationSeconds: 30,
+    processingSeconds: 2.4,
+    wordCount: 120,
+    speakerCount: nil,
+    diarizationRequested: false,
+    diarizationApplied: false,
+    inputKind: .audio,
+    mediaExtension: "m4a",
+    fileSizeBucket: "1_10mb",
+    errorType: nil
+))
 ```
 
 ### Implementation
 
 ```swift
 public protocol TelemetryServiceProtocol: Sendable {
-    func send(_ event: String, props: [String: String]?)
+    func send(_ event: TelemetryEventSpec)
     func flush() async
 }
 
@@ -273,7 +336,7 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
   - When queue hits **50 events**
   - **Immediately** for critical events: `telemetry_opted_out`, `onboarding_completed`, `license_activated`, and all licensing events
 - On flush: POST batch as JSON array to `/api/telemetry`
-- On network failure: events are **dropped** (not persisted to disk — simplicity over completeness)
+- On network failure: failed events are requeued in memory and retried until queue pressure trims them. Events are still not persisted to disk.
 - Max queue size: **200 events** (prevent memory issues if network is down for extended period)
 
 > **Note:** Metrics are best-effort and biased against short sessions and sessions that end in crashes. This is acceptable for product analytics at this scale.


### PR DESCRIPTION
## Summary

Adds a privacy-safe observability layer on top of MacParakeet's existing typed telemetry system. The existing breadcrumb events stay in place for funnels and adoption analysis. This PR adds one wide terminal event for each important operation so product health can be queried without collecting user content.

```
User action / agent command
        |
        v
GUI coordinator or macparakeet-cli
        |
        |  root operation context
        |  operation_id = workflow_id
        v
Core service operation
        |
        |  child operation context
        |  workflow_id = root workflow
        |  parent_operation_id = caller operation
        |
        +--> Existing breadcrumb events
        |    started / completed / failed / cancelled
        |
        v
Canonical *_operation wide event
        operation_id + workflow_id + parent_operation_id
        outcome + stage + duration + safe dimensions
        |
        v
TelemetryService in-memory queue
        |
        v
POST /api/telemetry
        |
        v
Cloudflare Worker + D1
        |
        v
Live stats dashboard operation-health queries
```

## What Changed

- Added `Observability` helpers for operation contexts, operation IDs, workflow IDs, parent operation IDs, durations, error classification, media extension/kind, file-size buckets, text-length buckets, and word counts.
- Added typed `TelemetryEventSpec` cases for these canonical operation events:
  - `dictation_operation`
  - `transcription_operation`
  - `meeting_operation`
  - `llm_operation`
  - `feedback_operation`
  - `auto_save_operation`
  - `cli_operation`
- Instrumented dictation, file transcription, YouTube transcription, meeting finalization, meeting recording, LLM calls including streaming calls, feedback submission, auto-save, and `macparakeet-cli transcribe`.
- Added preflight terminal coverage for failures that happen before a legacy started/completed breadcrumb can fire, including transcription entitlement failures and missing auto-save folders.
- Added meeting-operation stages for permission checks, start recording, stop recording, transcription, completion, and cancellation.
- Added cross-operation correlation so workflows such as CLI -> transcription, meeting -> transcription, and transcription -> formatter can be joined by `workflow_id` and `parent_operation_id`.
- Added CLI telemetry bootstrap that follows the GUI telemetry preference and supports process-level opt-out with `MACPARAKEET_TELEMETRY=0`.
- Made telemetry request timeout configurable so CLI flushes can use a short timeout without changing GUI behavior.
- Removed raw microphone device names and device UIDs from telemetry serialization. Device telemetry now keeps only coarse dimensions such as transport, sample rate, channels, fallback, and selected/not-selected.
- Added dashboard/API rollups for operation outcomes, success rates by operation/source/stage/provider, top `error_type`, meeting track presence, CLI outcomes, and auto-save failures.
- Updated telemetry docs, CLI testing docs, CLI changelog, the public stats dashboard, and serialization/service tests.

## Event Shape

Operation events are intentionally wide and terminal. They answer questions that are hard to answer from breadcrumb events alone.

```
operation_id          random UUID, scoped to one local operation
workflow_id           stable join key for the user-visible workflow
parent_operation_id   immediate caller operation, when nested
outcome               success | failure | cancelled | empty | unavailable
stage                 preflight / download / stt / permissions / etc.
duration_seconds      wall-clock operation duration
safe dimensions       source, provider, streaming, input kind, buckets, track presence
error_type            classifier string only; no raw response bodies
```

Examples of questions this unlocks:

- Which dictation paths fail or return empty output most often?
- Where do transcription jobs fail: preflight, download, conversion, STT, diarization, persistence, or post-processing?
- Are meeting recordings missing mic or system tracks?
- Are meeting failures concentrated in permissions, start, stop, transcription, or completion?
- Are LLM failures provider, configuration, streaming, or output-shape related?
- Are CLI transcribe calls succeeding for scripts and agents?
- Is feedback delivery or auto-save failing in the field?
- Which operation failures need product work first?

## Privacy Boundaries

This PR intentionally does not collect:

- transcript text
- dictation text
- LLM prompts or responses
- provider error response bodies
- file paths or file names
- YouTube URLs
- raw microphone names
- device UIDs or requested device UIDs
- persistent user identifiers

Operation IDs are random UUIDs for local operations. They are correlation keys for one workflow, not user identifiers, and are not persisted as identity.

## Architecture Notes

The implementation extends `TelemetryEventSpec` and `TelemetryService` instead of introducing a second observability stack. That keeps the architecture simple: typed event definitions remain the single client-side contract, and the transport still handles queueing, batching, retry, opt-out, and app-termination flush.

Breadcrumb events still answer funnel questions. Operation events answer product-health and debugging questions. The new `TaskLocal` operation context is correlation-only; it does not control behavior.

## Backend Contract Note

The ingestion Worker must allow these event names before production clients rely on them. If the Worker allowlist is stale, any batch containing a new `*_operation` event will be rejected as an unknown event and requeued by the client.

Required Worker allowlist additions:

```
dictation_operation
transcription_operation
meeting_operation
llm_operation
feedback_operation
auto_save_operation
cli_operation
```

New optional props the backend should preserve:

```
workflow_id
parent_operation_id
stage
```

## Tests

- `swift test --filter TelemetryServiceTests`
- `swift test --filter LLMServiceTests`
- `swift test --filter TranscriptionServiceTests`
- `swift test --filter AutoSaveServiceTests`
- `swift test --filter DictationServiceTests`
- `swift test --filter TranscribeCommandTests`
- `swift test`
- `pnpm build` in `macparakeet-website`

Latest full-suite run in the working tree passed: 1783 XCTest tests plus 13 Swift Testing tests.
