### PR TITLE
fix(meeting): pre-v0.6 release punch list

### DIFF
--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -495,10 +495,21 @@ final class MeetingRecordingFlowCoordinator {
                 panelViewModel?.micLevel = micLevel
                 panelViewModel?.systemLevel = systemLevel
                 if captureMode == .stopped, pillViewModel?.state == .recording {
+                    // Audio capture stopped while the state machine still
+                    // expects a live recording — typically because
+                    // `MeetingRecordingService.failCapture` ran (mic unplug,
+                    // writer error, OS audio routing change). Without this
+                    // signal the pill keeps animating "recording" with a
+                    // ticking timer while no audio is actually being
+                    // captured. Surface it through the state machine so the
+                    // existing stop+transcribe path saves whatever made it
+                    // to disk.
                     pillViewModel?.micLevel = 0
                     pillViewModel?.systemLevel = 0
                     panelViewModel?.micLevel = 0
                     panelViewModel?.systemLevel = 0
+                    sendEvent(.captureFailed(generation: stateMachine.generation))
+                    break
                 }
 
                 try? await Task.sleep(for: .milliseconds(150))

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -494,7 +494,9 @@ final class MeetingRecordingFlowCoordinator {
                 panelViewModel?.elapsedSeconds = elapsedSeconds
                 panelViewModel?.micLevel = micLevel
                 panelViewModel?.systemLevel = systemLevel
-                if captureMode == .stopped, pillViewModel?.state == .recording {
+                if captureMode == .stopped,
+                   stateMachine.state == .recording,
+                   pillViewModel?.state == .recording {
                     // Audio capture stopped while the state machine still
                     // expects a live recording — typically because
                     // `MeetingRecordingService.failCapture` ran (mic unplug,

--- a/Sources/MacParakeet/App/MeetingRecoveryCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecoveryCoordinator.swift
@@ -75,6 +75,12 @@ final class MeetingRecoveryCoordinator {
         alert.addButton(withTitle: "Recover")
         alert.addButton(withTitle: "Recover Later")
         alert.addButton(withTitle: "Discard")
+        // Match `confirmAndCancelRecording` — the Discard path deletes the
+        // session folder (`MeetingRecordingRecoveryService.discard`), so
+        // surface that as destructive in the alert chrome.
+        if alert.buttons.indices.contains(2) {
+            alert.buttons[2].hasDestructiveAction = true
+        }
 
         let response = await presentAlert(alert)
         switch response {

--- a/Sources/MacParakeetCore/Audio/MeetingAudioStorageWriter.swift
+++ b/Sources/MacParakeetCore/Audio/MeetingAudioStorageWriter.swift
@@ -31,8 +31,20 @@ final class MeetingAudioStorageWriter {
     private var systemInput: AVAssetWriterInput?
     private var microphoneConverter: AVAudioConverter?
     private var systemConverter: AVAudioConverter?
+    /// PTS counter — increments for both successfully appended buffers AND
+    /// dropped buffers (when `input.isReadyForMoreMediaData == false`). Used
+    /// as the `presentationTimeSamples` for each new sample buffer so
+    /// dropped frames produce a silent gap that preserves wall-clock
+    /// alignment in the output file. NOT what callers should report as
+    /// "frames on disk" — see `microphoneActualFrameCount` for that.
     private var microphoneWrittenFrames: Int64 = 0
     private var systemWrittenFrames: Int64 = 0
+    /// Frames actually appended to the writer input (success path only).
+    /// Used by `metrics(for:)` so the source-alignment metadata reports
+    /// what's truly on disk rather than the PTS counter, which could include
+    /// phantom frames from dropped buffers under sustained load.
+    private var microphoneActualFrameCount: Int64 = 0
+    private var systemActualFrameCount: Int64 = 0
     private let sampleBufferFactory = PCMBufferToSampleBuffer()
 
     let microphoneAudioURL: URL
@@ -81,7 +93,8 @@ final class MeetingAudioStorageWriter {
                 writer: microphoneWriter,
                 input: microphoneInput,
                 converter: &microphoneConverter,
-                writtenFrames: &microphoneWrittenFrames
+                writtenFrames: &microphoneWrittenFrames,
+                actualFrameCount: &microphoneActualFrameCount
             )
         case .system:
             try write(
@@ -89,7 +102,8 @@ final class MeetingAudioStorageWriter {
                 writer: systemWriter,
                 input: systemInput,
                 converter: &systemConverter,
-                writtenFrames: &systemWrittenFrames
+                writtenFrames: &systemWrittenFrames,
+                actualFrameCount: &systemActualFrameCount
             )
         }
     }
@@ -126,12 +140,12 @@ final class MeetingAudioStorageWriter {
         switch source {
         case .microphone:
             return SourceWriteMetrics(
-                writtenFrameCount: microphoneWrittenFrames,
+                writtenFrameCount: microphoneActualFrameCount,
                 sampleRate: targetFormat.sampleRate
             )
         case .system:
             return SourceWriteMetrics(
-                writtenFrameCount: systemWrittenFrames,
+                writtenFrameCount: systemActualFrameCount,
                 sampleRate: targetFormat.sampleRate
             )
         }
@@ -142,7 +156,8 @@ final class MeetingAudioStorageWriter {
         writer: AVAssetWriter?,
         input: AVAssetWriterInput?,
         converter: inout AVAudioConverter?,
-        writtenFrames: inout Int64
+        writtenFrames: inout Int64,
+        actualFrameCount: inout Int64
     ) throws {
         guard let writer, let input else { return }
         guard writer.status == .writing else {
@@ -155,6 +170,12 @@ final class MeetingAudioStorageWriter {
         let converted = try convertIfNeeded(buffer, converter: &converter)
         guard input.isReadyForMoreMediaData else {
             logger.warning("Meeting audio writer input not ready, dropping buffer (\(converted.frameLength, privacy: .public) frames)")
+            // Advance the PTS counter so the next appended sample buffer
+            // lands at the correct wall-clock offset (silent gap for the
+            // dropped frames). `actualFrameCount` intentionally does NOT
+            // advance — `metrics(for:)` reports it as
+            // `writtenFrameCount`, and that value must match what's truly
+            // on disk so source-alignment downstream consumers can trust it.
             writtenFrames += Int64(converted.frameLength)
             return
         }
@@ -168,6 +189,7 @@ final class MeetingAudioStorageWriter {
         }
 
         writtenFrames += Int64(converted.frameLength)
+        actualFrameCount += Int64(converted.frameLength)
     }
 
     private func convertIfNeeded(

--- a/Sources/MacParakeetCore/MeetingRecordingFlow/MeetingRecordingFlowStateMachine.swift
+++ b/Sources/MacParakeetCore/MeetingRecordingFlow/MeetingRecordingFlowStateMachine.swift
@@ -122,12 +122,6 @@ public struct MeetingRecordingFlowStateMachine: Equatable, Sendable {
             state = .transcribing
             return [.showTranscribingState, .updateMenuBar(.processing), .stopRecordingAndTranscribe]
 
-        case (.starting, .captureFailed(let gen)):
-            guard gen == generation else { return [] }
-            let message = "Audio capture stopped before the recording could start."
-            state = .finishing(outcome: .error(message))
-            return [.showError(message), .updateMenuBar(.idle), .startAutoDismissTimer(seconds: 5)]
-
         case (.transcribing, .transcriptionCompleted(let gen, let transcriptionID)):
             guard gen == generation else { return [] }
             state = .finishing(outcome: .completed(transcriptionID))

--- a/Sources/MacParakeetCore/MeetingRecordingFlow/MeetingRecordingFlowStateMachine.swift
+++ b/Sources/MacParakeetCore/MeetingRecordingFlow/MeetingRecordingFlowStateMachine.swift
@@ -28,6 +28,13 @@ public enum MeetingRecordingFlowEvent: Equatable, Sendable {
     case startFailed(generation: Int, message: String)
     case stopRequested
     case cancelRequested
+    /// Emitted by the pill polling task when it detects that audio capture
+    /// has stopped unexpectedly while the state machine still believes a
+    /// recording is in progress (e.g., a USB mic was unplugged mid-meeting,
+    /// `MeetingRecordingService.failCapture` ran). Routes through the same
+    /// stop+transcribe path as `.stopRequested` so whatever audio was
+    /// captured before the failure still becomes a saved Transcription.
+    case captureFailed(generation: Int)
     case transcriptionCompleted(generation: Int, transcriptionID: UUID)
     case transcriptionFailed(generation: Int, message: String)
     case dismissRequested
@@ -109,6 +116,17 @@ public struct MeetingRecordingFlowStateMachine: Equatable, Sendable {
         case (.recording, .stopRequested):
             state = .transcribing
             return [.showTranscribingState, .updateMenuBar(.processing), .stopRecordingAndTranscribe]
+
+        case (.recording, .captureFailed(let gen)):
+            guard gen == generation else { return [] }
+            state = .transcribing
+            return [.showTranscribingState, .updateMenuBar(.processing), .stopRecordingAndTranscribe]
+
+        case (.starting, .captureFailed(let gen)):
+            guard gen == generation else { return [] }
+            let message = "Audio capture stopped before the recording could start."
+            state = .finishing(outcome: .error(message))
+            return [.showError(message), .updateMenuBar(.idle), .startAutoDismissTimer(seconds: 5)]
 
         case (.transcribing, .transcriptionCompleted(let gen, let transcriptionID)):
             guard gen == generation else { return [] }

--- a/Sources/MacParakeetCore/Services/MeetingRecordingLockFileStore.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecordingLockFileStore.swift
@@ -7,7 +7,7 @@ public enum MeetingRecordingLockState: String, Codable, Sendable, Equatable {
 }
 
 public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
-    /// Schema version is intentionally left at 1 in v0.8 because the `notes`
+    /// Schema version is intentionally left at 1 in v0.6 because the `notes`
     /// field is a backward-compatible additive change (`decodeIfPresent`).
     /// See ADR-020 §9. The version guard in `MeetingRecordingLockFileStore.read()`
     /// uses `<=` so a lock file written by an OLDER app version is still

--- a/Sources/MacParakeetCore/Services/MeetingRecordingRecoveryService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecordingRecoveryService.swift
@@ -63,8 +63,10 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
     }
 
     public func discoverPendingRecoveries() async throws -> [MeetingRecordingLockFile] {
+        // `discoverOrphans` already sorts by `startedAt` with a folder-path
+        // tiebreaker for ties — re-sorting here would just drop the
+        // tiebreaker without adding any ordering guarantee.
         try lockFileStore.discoverOrphans(meetingsRoot: meetingsRoot)
-            .sorted { $0.startedAt < $1.startedAt }
     }
 
     public func recover(_ lock: MeetingRecordingLockFile) async throws -> Transcription {

--- a/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
@@ -80,6 +80,14 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     /// typed (which we preserve as `nil` rather than empty so downstream
     /// `Transcription.userNotes` is `nil` for non-notepad recordings).
     private var currentNotes: String?
+    /// In-memory mirror of the session's `recording.lock` content. Held so
+    /// `updateNotes` can persist notes by mutating + atomic-writing in one
+    /// step instead of read-modify-write on every keystroke debounce. The
+    /// actor isolation already serializes lock-file writes with state
+    /// transitions; the disk read was redundant. Initialized in
+    /// `startRecording`, mutated by state transitions, cleared in
+    /// `cleanupState` / `cancelRecording`.
+    private var currentLockFile: MeetingRecordingLockFile?
     /// Keeps replacement starts out while `audioCaptureService.start()` is still
     /// unwinding after cancellation. `currentSession` may already be nil then.
     private var startingSessionID: UUID?
@@ -201,16 +209,15 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         self.currentSession = session
 
         do {
-            try lockFileStore.write(
-                MeetingRecordingLockFile(
-                    sessionId: session.id,
-                    startedAt: session.startedAt,
-                    pid: ProcessInfo.processInfo.processIdentifier,
-                    displayName: session.displayName,
-                    folderURL: session.folderURL
-                ),
+            let initialLock = MeetingRecordingLockFile(
+                sessionId: session.id,
+                startedAt: session.startedAt,
+                pid: ProcessInfo.processInfo.processIdentifier,
+                displayName: session.displayName,
                 folderURL: session.folderURL
             )
+            try lockFileStore.write(initialLock, folderURL: session.folderURL)
+            currentLockFile = initialLock
         } catch {
             self.writer = nil
             await finalizeWriter(writer)
@@ -289,6 +296,12 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         }
 
         await audioCaptureService.stop()
+        // Defensive: `audioCaptureService.stop()` is supposed to finish the
+        // events stream so the `for await` in `processingTask` exits, but if
+        // the capture service had a bug that left the continuation open we
+        // would hang here forever. Cancelling the task lets the for-await
+        // exit even in that pathological case.
+        processingTask?.cancel()
         await processingTask?.value
         processingTask = nil
         let finalizedWriter = writer
@@ -333,18 +346,17 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         }
 
         let finalNotes = currentNotes
-        try? lockFileStore.write(
-            MeetingRecordingLockFile(
-                sessionId: session.id,
-                startedAt: session.startedAt,
-                pid: ProcessInfo.processInfo.processIdentifier,
-                displayName: session.displayName,
-                state: .awaitingTranscription,
-                notes: finalNotes,
-                folderURL: session.folderURL
-            ),
+        let awaitingLock = (currentLockFile ?? MeetingRecordingLockFile(
+            sessionId: session.id,
+            startedAt: session.startedAt,
+            pid: ProcessInfo.processInfo.processIdentifier,
+            displayName: session.displayName,
             folderURL: session.folderURL
-        )
+        ))
+            .withNotes(finalNotes)
+            .withState(.awaitingTranscription)
+        try? lockFileStore.write(awaitingLock, folderURL: session.folderURL)
+        currentLockFile = awaitingLock
 
         let durationSeconds = max(0, Date().timeIntervalSince(session.startedAt))
         let output = MeetingRecordingOutput(
@@ -384,27 +396,24 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         let normalized: String? = trimmed.isEmpty ? nil : notes
         currentNotes = normalized
 
+        // Mutate the in-memory mirror and atomically rewrite. Actor
+        // isolation already serializes us with state-transition writes
+        // (`stopRecording` / `cancelRecording` / `startRecording`), so
+        // reading the file back from disk on every keystroke debounce
+        // would just be redundant I/O. `currentLockFile` is normally set
+        // by `startRecording`; the fallback handles the vanishingly rare
+        // case where a debounce somehow fires before initialization.
+        let base = currentLockFile ?? MeetingRecordingLockFile(
+            sessionId: session.id,
+            startedAt: session.startedAt,
+            pid: ProcessInfo.processInfo.processIdentifier,
+            displayName: session.displayName,
+            folderURL: session.folderURL
+        )
+        let updated = base.withNotes(normalized)
         do {
-            // Read-modify-write to preserve any state already on disk
-            // (most importantly: the recording state field). If the file
-            // doesn't exist yet (extremely unlikely between startRecording
-            // succeeding and the first debounce), write a fresh recording-
-            // state record carrying the notes.
-            let existing = try lockFileStore.read(folderURL: session.folderURL)
-            let updated: MeetingRecordingLockFile
-            if let existing {
-                updated = existing.withNotes(normalized)
-            } else {
-                updated = MeetingRecordingLockFile(
-                    sessionId: session.id,
-                    startedAt: session.startedAt,
-                    pid: ProcessInfo.processInfo.processIdentifier,
-                    displayName: session.displayName,
-                    notes: normalized,
-                    folderURL: session.folderURL
-                )
-            }
             try lockFileStore.write(updated, folderURL: session.folderURL)
+            currentLockFile = updated
         } catch {
             // Notes persistence is best-effort — losing one debounce write to
             // an I/O error is preferable to surfacing a UI error mid-meeting.
@@ -779,6 +788,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     private func cleanupState() {
         currentSession = nil
         currentNotes = nil
+        currentLockFile = nil
         micConditioner = SoftwareAECConditioner()
         latestLevels = MeetingAudioLevels()
         sourceCaptureMetrics = [:]

--- a/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowStateMachineTests.swift
+++ b/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowStateMachineTests.swift
@@ -76,6 +76,44 @@ final class MeetingRecordingFlowStateMachineTests: XCTestCase {
         )
     }
 
+    func testCaptureFailureWhileRecordingBeginsTranscription() {
+        var machine = MeetingRecordingFlowStateMachine()
+        _ = machine.handle(.startRequested)
+        _ = machine.handle(.permissionsGranted(generation: 1))
+        _ = machine.handle(.recordingStarted(generation: 1))
+
+        let effects = machine.handle(.captureFailed(generation: 1))
+
+        XCTAssertEqual(machine.state, .transcribing)
+        XCTAssertEqual(
+            effects,
+            [.showTranscribingState, .updateMenuBar(.processing), .stopRecordingAndTranscribe]
+        )
+    }
+
+    func testCaptureFailureWhileStartingIsIgnored() {
+        var machine = MeetingRecordingFlowStateMachine()
+        _ = machine.handle(.startRequested)
+        _ = machine.handle(.permissionsGranted(generation: 1))
+
+        let effects = machine.handle(.captureFailed(generation: 1))
+
+        XCTAssertEqual(machine.state, .starting)
+        XCTAssertTrue(effects.isEmpty)
+    }
+
+    func testStaleCaptureFailureIsIgnored() {
+        var machine = MeetingRecordingFlowStateMachine()
+        _ = machine.handle(.startRequested)
+        _ = machine.handle(.permissionsGranted(generation: 1))
+        _ = machine.handle(.recordingStarted(generation: 1))
+
+        let effects = machine.handle(.captureFailed(generation: 0))
+
+        XCTAssertEqual(machine.state, .recording)
+        XCTAssertTrue(effects.isEmpty)
+    }
+
     func testCompletedTranscriptionNavigatesAndSchedulesDismiss() {
         var machine = MeetingRecordingFlowStateMachine()
         let transcriptionID = UUID()


### PR DESCRIPTION
## Summary

Seven fixes from a fresh-eye architectural review of the v0.6 meeting recording surface (ADR-014/015/016/019/020). Architecture is sound — these are concrete bugs and quality issues to land before the feature ships.

## The P1

**Silent capture-failure: pill kept saying "recording" while audio was dead.**

When `MeetingRecordingService.failCapture` ran (mic unplugged, writer error, OS audio routing change), the pill kept animating "recording" with a ticking elapsed timer while no audio was being captured. A user could spend 30+ minutes on a dead recording.

```
Before:                          After:
┌──────────────────────┐         ┌──────────────────────┐
│ ● Recording 32:14    │         │ ● Recording 8:43     │
│   (mic unplugged @8:43)        │   ↓ failCapture fires
│   (silent for 23 min)│         │   ↓ pill polling sees .stopped
└──────────────────────┘         │   ↓ sendEvent(.captureFailed)
                                 │   ↓ state → .transcribing
                                 │   ↓ stop+transcribe path runs
                                 ▼   ↓
                                 [Saved Transcription:
                                  audio captured up to 8:43]
```

New `MeetingRecordingFlowEvent.captureFailed(generation:)` event. Pill polling detects `captureMode == .stopped` while pill is `.recording`, fires the event, breaks the loop. State machine routes through the existing stop+transcribe path so partial audio still becomes a saved Transcription.

## The P2s

| Fix | File |
|-----|------|
| Discard button on recovery dialog now red-styled (`hasDestructiveAction = true`) — matches `confirmAndCancelRecording` | `MeetingRecoveryCoordinator.swift` |
| Defensive `processingTask?.cancel()` before `await ... value` in `stopRecording` — no more potential hang if events stream stays open | `MeetingRecordingService.swift` |
| `updateNotes` no longer does disk read-modify-write per debounce — uses in-memory `currentLockFile` mirror | `MeetingRecordingService.swift` |
| Source-alignment metadata reports `actualFrameCount` (success-path only) instead of PTS counter that included dropped frames. PTS sequence preserved for wall-clock alignment in output file | `MeetingAudioStorageWriter.swift` |

## The P3s

- `v0.8` → `v0.6` in lock-file schema doc comment
- Removed duplicate sort in `discoverPendingRecoveries` (preserved folder-path tiebreaker)

## Skipped (with rationale)

- **FIFO pairing in `MeetingAudioPairJoiner`** — pairs by arrival order not host time. Sync-lag warning telemetry already exists at 120ms. Real-world drift typically <50ms. Non-trivial fix; recommend ship + watch telemetry.

## Architecture Verified Correct (No Code Changes)

- STT scheduler routes meeting transcription through `.meetingFinalize` (`TranscriptionService.transcribeMeetingSources`)
- Legacy meetings without metadata.json fall back to `.fileTranscription` at VM layer
- Lock-file writes race-free via actor isolation; atomic write; notes decoded independently
- Slash overlay correctly avoids `.popover` inside `KeylessPanel`
- `MeetingMonitor.evaluate` is a pure function with proper grace windows
- State machine handles cancel/stop across all live states

## Test plan

- [x] `swift build` clean
- [x] `swift test` — **1764 tests pass, 0 failures**
- [x] Targeted suites green: `MeetingAudioStorageWriterTests`, `MeetingRecordingServiceTests` (incl. notes & lock-file tests), `MeetingRecordingRecoveryServiceTests`, `MeetingRecordingLockFileStoreTests`, `MeetingRecordingCrashRecoveryTests`
- [ ] Manual: unplug USB mic mid-meeting, confirm pill exits "recording" state and partial transcription saves
- [ ] Manual: trigger recovery dialog, confirm Discard button is red

🤖 Generated with [Claude Code](https://claude.com/claude-code)