### PR TITLE
fix(meeting): skip empty orphan sessions in recovery discovery

### DIFF
--- a/Sources/MacParakeetCore/Services/MeetingRecordingRecoveryService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecordingRecoveryService.swift
@@ -70,7 +70,7 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
     ///
     /// Sessions whose audio is at or below this floor were almost always
     /// killed within a second of `MeetingRecordingService.startRecording`
-    /// writing the lock file but before any real audio frames were captured —
+    /// writing the lock file but before any real audio frames were captured -
     /// e.g., a force-quit, hard crash, or rapid dev-cycle restart. Surfacing
     /// these as "interrupted recordings" alarms the user over data that
     /// never existed and where `recover()` would error with
@@ -88,14 +88,21 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
         var viable: [MeetingRecordingLockFile] = []
         viable.reserveCapacity(candidates.count)
         for lock in candidates {
-            if try canOfferRecovery(for: lock) {
+            do {
+                if try canOfferRecovery(for: lock) {
+                    viable.append(lock)
+                } else {
+                    // Auto-clean instead of skipping silently: the folder + lock
+                    // are otherwise immortal, accumulating across every crash
+                    // until the user manually deletes them. Logged for forensic
+                    // reference if a user reports missing recordings.
+                    purgeEmptySession(lock)
+                }
+            } catch {
+                logger.error(
+                    "meeting_recovery_viability_check_failed session=\(lock.sessionId.uuidString, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
+                )
                 viable.append(lock)
-            } else {
-                // Auto-clean instead of skipping silently: the folder + lock
-                // are otherwise immortal, accumulating across every crash
-                // until the user manually deletes them. Logged for forensic
-                // reference if a user reports missing recordings.
-                purgeEmptySession(lock)
             }
         }
         return viable
@@ -119,6 +126,7 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
 
     private func purgeEmptySession(_ lock: MeetingRecordingLockFile) {
         guard let folderURL = lock.folderURL else { return }
+        guard fileManager.fileExists(atPath: folderURL.path) else { return }
         do {
             try fileManager.removeItem(at: folderURL)
             logger.info(

--- a/Sources/MacParakeetCore/Services/MeetingRecordingRecoveryService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecordingRecoveryService.swift
@@ -256,7 +256,31 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
     }
 
     private func existingTranscriptions(for mixedURL: URL) throws -> [Transcription] {
-        try transcriptionRepo.fetchByFilePath(mixedURL.path, sourceType: .meeting)
+        var seenIDs = Set<UUID>()
+        var transcriptions: [Transcription] = []
+        for path in filePathAliases(for: mixedURL) {
+            for transcription in try transcriptionRepo.fetchByFilePath(path, sourceType: .meeting) {
+                guard seenIDs.insert(transcription.id).inserted else { continue }
+                transcriptions.append(transcription)
+            }
+        }
+        return transcriptions
+    }
+
+    private func filePathAliases(for url: URL) -> Set<String> {
+        var paths = Set([
+            url.path,
+            url.standardizedFileURL.path,
+            url.resolvingSymlinksInPath().path,
+        ])
+        for path in Array(paths) {
+            if path.hasPrefix("/private/var/") {
+                paths.insert(String(path.dropFirst("/private".count)))
+            } else if path.hasPrefix("/var/") {
+                paths.insert("/private" + path)
+            }
+        }
+        return paths
     }
 
     private func deleteIncompleteTranscriptions(for mixedURL: URL) throws {

--- a/Sources/MacParakeetCore/Services/MeetingRecordingRecoveryService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecordingRecoveryService.swift
@@ -62,11 +62,73 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
         self.fileManager = fileManager
     }
 
+    /// Minimum size (bytes) for either `microphone.m4a` or `system.m4a` to
+    /// be considered worth offering recovery on. AAC fragmented-MP4 init
+    /// headers (no audio frames) are ~557 bytes; even a fraction of a second
+    /// of compressed audio is several KB. The threshold is comfortably above
+    /// the empty-header floor and well below any meaningful recording.
+    ///
+    /// Sessions whose audio is at or below this floor were almost always
+    /// killed within a second of `MeetingRecordingService.startRecording`
+    /// writing the lock file but before any real audio frames were captured —
+    /// e.g., a force-quit, hard crash, or rapid dev-cycle restart. Surfacing
+    /// these as "interrupted recordings" alarms the user over data that
+    /// never existed and where `recover()` would error with
+    /// `noRecoverableAudio` regardless. Filtering at discovery is cheaper
+    /// (size stat, no AVFoundation load) and preserves the existing public
+    /// contract: every entry returned here is something `recover()` has a
+    /// chance of producing a transcription from.
+    public static let minViableAudioBytes: Int = 4 * 1024
+
     public func discoverPendingRecoveries() async throws -> [MeetingRecordingLockFile] {
         // `discoverOrphans` already sorts by `startedAt` with a folder-path
         // tiebreaker for ties — re-sorting here would just drop the
         // tiebreaker without adding any ordering guarantee.
-        try lockFileStore.discoverOrphans(meetingsRoot: meetingsRoot)
+        let candidates = try lockFileStore.discoverOrphans(meetingsRoot: meetingsRoot)
+        var viable: [MeetingRecordingLockFile] = []
+        viable.reserveCapacity(candidates.count)
+        for lock in candidates {
+            if try canOfferRecovery(for: lock) {
+                viable.append(lock)
+            } else {
+                // Auto-clean instead of skipping silently: the folder + lock
+                // are otherwise immortal, accumulating across every crash
+                // until the user manually deletes them. Logged for forensic
+                // reference if a user reports missing recordings.
+                purgeEmptySession(lock)
+            }
+        }
+        return viable
+    }
+
+    private func canOfferRecovery(for lock: MeetingRecordingLockFile) throws -> Bool {
+        guard let folderURL = lock.folderURL else { return false }
+        let mixedURL = folderURL.appendingPathComponent("meeting.m4a")
+        if try existingCompletedTranscription(for: mixedURL) != nil {
+            return true
+        }
+        return hasViableAudio(in: lock)
+    }
+
+    private func hasViableAudio(in lock: MeetingRecordingLockFile) -> Bool {
+        guard let folderURL = lock.folderURL else { return false }
+        let micSize = fileSize(at: folderURL.appendingPathComponent("microphone.m4a"))
+        let sysSize = fileSize(at: folderURL.appendingPathComponent("system.m4a"))
+        return max(micSize, sysSize) >= Self.minViableAudioBytes
+    }
+
+    private func purgeEmptySession(_ lock: MeetingRecordingLockFile) {
+        guard let folderURL = lock.folderURL else { return }
+        do {
+            try fileManager.removeItem(at: folderURL)
+            logger.info(
+                "meeting_recovery_purged_empty_session session=\(lock.sessionId.uuidString, privacy: .public)"
+            )
+        } catch {
+            logger.error(
+                "meeting_recovery_purge_failed session=\(lock.sessionId.uuidString, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
+            )
+        }
     }
 
     public func recover(_ lock: MeetingRecordingLockFile) async throws -> Transcription {

--- a/Tests/MacParakeetTests/Services/MeetingRecordingRecoveryServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecordingRecoveryServiceTests.swift
@@ -216,7 +216,7 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
         XCTAssertNil(transcription.userNotes, "lock with no notes leaves userNotes nil")
     }
 
-    // MARK: - discoverPendingRecoveries — empty-session filter
+    // MARK: - discoverPendingRecoveries - empty-session filter
 
     func testDiscoverFiltersStubSessionAndPurgesFolder() async throws {
         let stub = try makeEmptyStubSession()
@@ -322,8 +322,21 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
         )
     }
 
+    func testDiscoverKeepsCandidateWhenViabilityCheckFails() async throws {
+        let stub = try makeEmptyStubSession()
+        transcriptionRepo.fetchAllError = RecoveryTestError.transcriptionFailed
+
+        let pending = try await recoveryService.discoverPendingRecoveries()
+
+        XCTAssertEqual(pending.map(\.sessionId), [stub.lock.sessionId])
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: stub.folderURL.path),
+            "a viability-check failure should not purge user data"
+        )
+    }
+
     /// Writes a session folder containing only init-header-sized audio
-    /// stubs — the exact pattern produced by a recording that was killed
+    /// stubs - the exact pattern produced by a recording that was killed
     /// before any audio frames were captured. Real-world stub size is
     /// ~557 bytes; we go with a known-small fixed payload so the test is
     /// deterministic and obviously below `minViableAudioBytes`.
@@ -346,7 +359,7 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
     }
 
     private func writeStubAudio(to url: URL) throws {
-        // 600 bytes — comfortably above an empty file but well under
+        // 600 bytes - comfortably above an empty file but well under
         // `minViableAudioBytes`. The exact byte content is irrelevant; we
         // only care that the file size is below the recovery threshold.
         try Data(count: 600).write(to: url)
@@ -520,6 +533,7 @@ private final class RecoveryMockTranscriptionService: TranscriptionServiceProtoc
 private final class RecordingTranscriptionRepository: TranscriptionRepositoryProtocol, @unchecked Sendable {
     private let lock = NSLock()
     private(set) var saved: [Transcription] = []
+    var fetchAllError: Error?
 
     func save(_ transcription: Transcription) throws {
         lock.withLock {
@@ -533,7 +547,8 @@ private final class RecordingTranscriptionRepository: TranscriptionRepositoryPro
     }
 
     func fetchAll(limit: Int?) throws -> [Transcription] {
-        lock.withLock { saved }
+        if let fetchAllError { throw fetchAllError }
+        return lock.withLock { saved }
     }
 
     func fetchCompletedByVideoID(_ videoID: String) throws -> Transcription? { nil }

--- a/Tests/MacParakeetTests/Services/MeetingRecordingRecoveryServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecordingRecoveryServiceTests.swift
@@ -216,6 +216,142 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
         XCTAssertNil(transcription.userNotes, "lock with no notes leaves userNotes nil")
     }
 
+    // MARK: - discoverPendingRecoveries — empty-session filter
+
+    func testDiscoverFiltersStubSessionAndPurgesFolder() async throws {
+        let stub = try makeEmptyStubSession()
+
+        let pending = try await recoveryService.discoverPendingRecoveries()
+
+        XCTAssertTrue(pending.isEmpty, "stub session with init-only audio should be filtered")
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: stub.folderURL.path),
+            "stub session folder should be auto-purged so it doesn't accumulate"
+        )
+    }
+
+    func testDiscoverFiltersSessionWithNoAudioFiles() async throws {
+        let folderURL = tempRoot.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        let lock = MeetingRecordingLockFile(
+            sessionId: UUID(),
+            startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            pid: 42,
+            displayName: "Empty Session",
+            folderURL: folderURL
+        )
+        try lockStore.write(lock, folderURL: folderURL)
+
+        let pending = try await recoveryService.discoverPendingRecoveries()
+
+        XCTAssertTrue(pending.isEmpty, "session with no audio files should be filtered")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: folderURL.path))
+    }
+
+    func testDiscoverKeepsSessionWithViableAudio() async throws {
+        let viable = try makeRecoverableSession()
+
+        let pending = try await recoveryService.discoverPendingRecoveries()
+
+        XCTAssertEqual(pending.count, 1)
+        XCTAssertEqual(pending.first?.sessionId, viable.lock.sessionId)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: viable.folderURL.path))
+    }
+
+    func testDiscoverFiltersOnlyEmptySessionsInMixedBatch() async throws {
+        let viable = try makeRecoverableSession()
+        let stub = try makeEmptyStubSession()
+
+        let pending = try await recoveryService.discoverPendingRecoveries()
+
+        XCTAssertEqual(pending.map(\.sessionId), [viable.lock.sessionId])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: viable.folderURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: stub.folderURL.path))
+    }
+
+    func testDiscoverKeepsSessionWhenOnlyOneChannelHasViableAudio() async throws {
+        // Recovery already supports single-channel sessions (mic only / system
+        // only), so discovery shouldn't filter them either. Build a mic-only
+        // session: real audio on the mic, init-stub system file.
+        let folderURL = tempRoot.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        try writeM4A(to: folderURL.appendingPathComponent("microphone.m4a"))
+        try writeStubAudio(to: folderURL.appendingPathComponent("system.m4a"))
+        let lock = MeetingRecordingLockFile(
+            sessionId: UUID(),
+            startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            pid: 42,
+            displayName: "Mic-only session",
+            folderURL: folderURL
+        )
+        try lockStore.write(lock, folderURL: folderURL)
+
+        let pending = try await recoveryService.discoverPendingRecoveries()
+
+        XCTAssertEqual(pending.map(\.sessionId), [lock.sessionId])
+    }
+
+    func testDiscoverKeepsCompletedMeetingWhenSourceAudioIsMissing() async throws {
+        let folderURL = tempRoot.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        let mixedURL = folderURL.appendingPathComponent("meeting.m4a")
+        FileManager.default.createFile(atPath: mixedURL.path, contents: Data("mixed".utf8))
+        let existing = Transcription(
+            fileName: "Recovered Team Sync",
+            filePath: mixedURL.path,
+            status: .completed,
+            sourceType: .meeting
+        )
+        try transcriptionRepo.save(existing)
+        let lock = MeetingRecordingLockFile(
+            sessionId: UUID(),
+            startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            pid: 42,
+            displayName: "Recovered Team Sync",
+            state: .awaitingTranscription,
+            folderURL: folderURL
+        )
+        try lockStore.write(lock, folderURL: folderURL)
+
+        let pending = try await recoveryService.discoverPendingRecoveries()
+
+        XCTAssertEqual(pending.map(\.sessionId), [lock.sessionId])
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: folderURL.path),
+            "completed meeting audio must not be purged by the empty-session filter"
+        )
+    }
+
+    /// Writes a session folder containing only init-header-sized audio
+    /// stubs — the exact pattern produced by a recording that was killed
+    /// before any audio frames were captured. Real-world stub size is
+    /// ~557 bytes; we go with a known-small fixed payload so the test is
+    /// deterministic and obviously below `minViableAudioBytes`.
+    private func makeEmptyStubSession() throws -> (folderURL: URL, lock: MeetingRecordingLockFile) {
+        let sessionID = UUID()
+        let folderURL = tempRoot.appendingPathComponent(sessionID.uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        try writeStubAudio(to: folderURL.appendingPathComponent("microphone.m4a"))
+        try writeStubAudio(to: folderURL.appendingPathComponent("system.m4a"))
+
+        let lock = MeetingRecordingLockFile(
+            sessionId: sessionID,
+            startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            pid: 42,
+            displayName: "Stub session",
+            folderURL: folderURL
+        )
+        try lockStore.write(lock, folderURL: folderURL)
+        return (folderURL, lock)
+    }
+
+    private func writeStubAudio(to url: URL) throws {
+        // 600 bytes — comfortably above an empty file but well under
+        // `minViableAudioBytes`. The exact byte content is irrelevant; we
+        // only care that the file size is below the recovery threshold.
+        try Data(count: 600).write(to: url)
+    }
+
     private func makeRecoverableSession(
         microphoneSampleRate: Double = 48_000,
         systemAudio: SourceFixture = .valid,


### PR DESCRIPTION
## Summary

Fixes a noisy and misleading meeting-recovery path: launch recovery could show "interrupted recordings" for folders that only contain AAC init headers and no captured audio. Those sessions cannot be recovered, so discovery now removes obvious empty stubs before prompting the user.

The review pass also keeps completed meeting sessions safe when paths differ by macOS' `/var` and `/private/var` aliases. A stale lock should never cause a valid completed `meeting.m4a` folder to be purged.

## Recovery Flow

```text
orphan recording.lock
        |
        v
discoverPendingRecoveries()
        |
        +-- completed meeting row? -----> keep
        |                                 recover/discard cleans stale lock
        |
        +-- mic/system audio >= 4 KB? --> keep
        |                                 recovery can transcribe real audio
        |
        `-- empty stub ----------------> purge folder + lock
                                          no user-facing recovery dialog
```

## What Changed

- Filters orphaned sessions whose mic/system files are below the viable-audio floor.
- Auto-purges only those empty stub folders so they do not accumulate forever.
- Preserves mic-only/system-only recoveries when either channel has real audio.
- Preserves already-completed meeting sessions, including `/var` vs `/private/var` path aliases.
- Fails open on unexpected viability-check errors so discovery does not hide or purge user data.
- Adds focused recovery tests for empty stubs, mixed batches, single-channel recovery, completed-session preservation, and fail-open behavior.

## Test Plan

- [x] `swift test --filter MeetingRecordingRecoveryServiceTests`
- [x] `swift test`
- [x] GitHub CI `swift-test` on push and pull_request
