### PR TITLE
Correlate operation telemetry

### DIFF
--- a/Sources/CLI/Commands/CLITelemetry.swift
+++ b/Sources/CLI/Commands/CLITelemetry.swift
@@ -20,6 +20,7 @@ enum CLITelemetry {
 
     static func sendOperationAndFlush(
         operationID: String,
+        operationContext: ObservabilityOperationContext? = nil,
         command: String,
         subcommand: String? = nil,
         outcome: ObservabilityOutcome,
@@ -32,6 +33,7 @@ enum CLITelemetry {
     ) async {
         Telemetry.send(.cliOperation(
             operationID: operationID,
+            operationContext: operationContext,
             command: command,
             subcommand: subcommand,
             outcome: outcome,

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -59,8 +59,9 @@ struct TranscribeCommand: AsyncParsableCommand {
 
     func run() async throws {
         CLITelemetry.configureIfNeeded()
-        let cliOperationID = Observability.operationID()
-        let cliStartedAt = Date()
+        let cliOperationContext = ObservabilityOperationContext()
+        let cliOperationID = cliOperationContext.operationID
+        let cliStartedAt = cliOperationContext.startedAt
         let trimmedInput = input.trimmingCharacters(in: .whitespacesAndNewlines)
         let inputKind: ObservabilityInputKind = YouTubeURLValidator.isYouTubeURL(trimmedInput)
             ? .youtube
@@ -69,82 +70,84 @@ struct TranscribeCommand: AsyncParsableCommand {
         var sttClient: STTClient?
         let runResult: Result<Void, Error>
         do {
-            try AppPaths.ensureDirectories()
-            let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
-            let transcriptionRepo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
-            let customWordRepo = CustomWordRepository(dbQueue: dbManager.dbQueue)
-            let snippetRepo = TextSnippetRepository(dbQueue: dbManager.dbQueue)
-            let createdSTTClient = STTClient()
-            sttClient = createdSTTClient
-            let audioProcessor = AudioProcessor()
-            let youtubeDownloader = YouTubeDownloader()
-            let entitlementsService = enforceEntitlements ? makeEntitlementsService() : nil
+            try await Observability.withOperationContext(cliOperationContext) {
+                try AppPaths.ensureDirectories()
+                let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
+                let transcriptionRepo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
+                let customWordRepo = CustomWordRepository(dbQueue: dbManager.dbQueue)
+                let snippetRepo = TextSnippetRepository(dbQueue: dbManager.dbQueue)
+                let createdSTTClient = STTClient()
+                sttClient = createdSTTClient
+                let audioProcessor = AudioProcessor()
+                let youtubeDownloader = YouTubeDownloader()
+                let entitlementsService = enforceEntitlements ? makeEntitlementsService() : nil
 
-            if let entitlementsService {
-                await entitlementsService.bootstrapTrialIfNeeded()
-                await entitlementsService.refreshValidationIfNeeded()
-            }
+                if let entitlementsService {
+                    await entitlementsService.bootstrapTrialIfNeeded()
+                    await entitlementsService.refreshValidationIfNeeded()
+                }
 
-            let diarizationService: DiarizationService? = noDiarize ? nil : DiarizationService()
-            let service = TranscriptionService(
-                audioProcessor: audioProcessor,
-                sttTranscriber: createdSTTClient,
-                transcriptionRepo: transcriptionRepo,
-                entitlements: entitlementsService,
-                customWordRepo: customWordRepo,
-                snippetRepo: snippetRepo,
-                processingMode: {
-                    let defaults = macParakeetAppDefaults()
-                    return Self.resolveProcessingMode(self.mode, storedMode: defaults.string(forKey: "processingMode"))
-                },
-                shouldKeepDownloadedAudio: {
-                    switch self.downloadedAudio {
-                    case .keep:
-                        return true
-                    case .delete:
-                        return false
-                    case .appDefault:
+                let diarizationService: DiarizationService? = noDiarize ? nil : DiarizationService()
+                let service = TranscriptionService(
+                    audioProcessor: audioProcessor,
+                    sttTranscriber: createdSTTClient,
+                    transcriptionRepo: transcriptionRepo,
+                    entitlements: entitlementsService,
+                    customWordRepo: customWordRepo,
+                    snippetRepo: snippetRepo,
+                    processingMode: {
                         let defaults = macParakeetAppDefaults()
-                        return defaults.object(forKey: "saveTranscriptionAudio") as? Bool ?? true
+                        return Self.resolveProcessingMode(self.mode, storedMode: defaults.string(forKey: "processingMode"))
+                    },
+                    shouldKeepDownloadedAudio: {
+                        switch self.downloadedAudio {
+                        case .keep:
+                            return true
+                        case .delete:
+                            return false
+                        case .appDefault:
+                            let defaults = macParakeetAppDefaults()
+                            return defaults.object(forKey: "saveTranscriptionAudio") as? Bool ?? true
+                        }
+                    },
+                    youtubeDownloader: youtubeDownloader,
+                    diarizationService: diarizationService
+                )
+
+                let result: Transcription
+
+                if YouTubeURLValidator.isYouTubeURL(trimmedInput) {
+                    result = try await service.transcribeURL(urlString: trimmedInput) { progress in
+                        switch progress {
+                        case .converting: printErr("Converting audio...")
+                        case .downloading(let pct): printErr("Downloading audio... \(pct)%")
+                        case .transcribing(let pct): printErr("Transcribing... \(pct)%")
+                        case .identifyingSpeakers: printErr("Identifying speakers...")
+                        case .finalizing: printErr("Finalizing...")
+                        }
                     }
-                },
-                youtubeDownloader: youtubeDownloader,
-                diarizationService: diarizationService
-            )
+                } else {
+                    let url = URL(fileURLWithPath: trimmedInput)
 
-            let result: Transcription
-
-            if YouTubeURLValidator.isYouTubeURL(trimmedInput) {
-                result = try await service.transcribeURL(urlString: trimmedInput) { progress in
-                    switch progress {
-                    case .converting: printErr("Converting audio...")
-                    case .downloading(let pct): printErr("Downloading audio... \(pct)%")
-                    case .transcribing(let pct): printErr("Transcribing... \(pct)%")
-                    case .identifyingSpeakers: printErr("Identifying speakers...")
-                    case .finalizing: printErr("Finalizing...")
+                    guard FileManager.default.fileExists(atPath: trimmedInput) else {
+                        throw CLIError.fileNotFound(trimmedInput)
                     }
-                }
-            } else {
-                let url = URL(fileURLWithPath: trimmedInput)
 
-                guard FileManager.default.fileExists(atPath: trimmedInput) else {
-                    throw CLIError.fileNotFound(trimmedInput)
-                }
+                    let ext = url.pathExtension.lowercased()
+                    guard AudioFileConverter.supportedExtensions.contains(ext) else {
+                        throw CLIError.unsupportedFormat(ext)
+                    }
 
-                let ext = url.pathExtension.lowercased()
-                guard AudioFileConverter.supportedExtensions.contains(ext) else {
-                    throw CLIError.unsupportedFormat(ext)
+                    printErr("Transcribing \(url.lastPathComponent)...")
+                    result = try await service.transcribe(fileURL: url)
                 }
 
-                printErr("Transcribing \(url.lastPathComponent)...")
-                result = try await service.transcribe(fileURL: url)
-            }
-
-            switch format {
-            case .json:
-                try printJSON(result)
-            case .text:
-                printText(result)
+                switch format {
+                case .json:
+                    try printJSON(result)
+                case .text:
+                    printText(result)
+                }
             }
             runResult = .success(())
         } catch {
@@ -167,6 +170,7 @@ struct TranscribeCommand: AsyncParsableCommand {
         }
         await CLITelemetry.sendOperationAndFlush(
             operationID: cliOperationID,
+            operationContext: cliOperationContext,
             command: "transcribe",
             outcome: cliOutcome,
             startedAt: cliStartedAt,

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -36,7 +36,7 @@ final class MeetingRecordingFlowCoordinator {
     private var pillPollingTask: Task<Void, Never>?
     private var transcriptObservationTask: Task<Void, Never>?
     private var completedTranscription: Transcription?
-    private var currentMeetingOperationID: String?
+    private var currentMeetingOperationContext: ObservabilityOperationContext?
     private var currentMeetingTrigger: TelemetryMeetingRecordingTrigger?
 
     init(
@@ -99,6 +99,7 @@ final class MeetingRecordingFlowCoordinator {
         switch stateMachine.state {
         case .idle:
             pendingTrigger = pendingTrigger ?? trigger
+            currentMeetingOperationContext = currentMeetingOperationContext ?? ObservabilityOperationContext()
             sendEvent(.startRequested)
         case .recording, .starting, .stopping:
             sendEvent(.stopRequested)
@@ -123,6 +124,7 @@ final class MeetingRecordingFlowCoordinator {
         }
         pendingTrigger = .calendarAutoStart
         pendingTitle = title
+        currentMeetingOperationContext = ObservabilityOperationContext()
         sendEvent(.startRequested)
     }
 
@@ -138,8 +140,16 @@ final class MeetingRecordingFlowCoordinator {
     /// keeps the two coordinators in lockstep).
     private func clearPendingStartContext(failureReason: String) {
         let wasCalendarTriggered = pendingTrigger == .calendarAutoStart
+        sendMeetingOperation(
+            outcome: .unavailable,
+            trigger: pendingTrigger,
+            stage: .permissions,
+            errorType: failureReason
+        )
         pendingTrigger = nil
         pendingTitle = nil
+        currentMeetingOperationContext = nil
+        currentMeetingTrigger = nil
         if wasCalendarTriggered {
             Telemetry.send(.calendarAutoStartFailed(reason: failureReason))
             onAutoStartFailed?()
@@ -263,8 +273,8 @@ final class MeetingRecordingFlowCoordinator {
             let title = pendingTitle
             pendingTrigger = nil
             pendingTitle = nil
-            let operationID = Observability.operationID()
-            currentMeetingOperationID = operationID
+            let operationContext = currentMeetingOperationContext ?? ObservabilityOperationContext()
+            currentMeetingOperationContext = operationContext
             currentMeetingTrigger = trigger
             actionTask = Task { @MainActor in
                 do {
@@ -290,9 +300,10 @@ final class MeetingRecordingFlowCoordinator {
                     self.sendMeetingOperation(
                         outcome: .failure,
                         trigger: trigger,
+                        stage: .startRecording,
                         errorType: TelemetryErrorClassifier.classify(error)
                     )
-                    self.currentMeetingOperationID = nil
+                    self.currentMeetingOperationContext = nil
                     self.currentMeetingTrigger = nil
                     self.sendEvent(.startFailed(generation: gen, message: error.localizedDescription))
                 }
@@ -331,29 +342,51 @@ final class MeetingRecordingFlowCoordinator {
             let liveWordCount = panelViewModel?.wordCount ?? 0
             let liveTranscriptLagged = panelViewModel?.isTranscriptionLagging ?? false
             let notesVM = panelViewModel?.notesViewModel
+            let operationContext = currentMeetingOperationContext
             actionTask = Task { @MainActor in
                 var stoppedOutput: MeetingRecordingOutput?
+                var transcriptionFinished = false
                 do {
-                    // Flush any keystrokes typed in the last < 250 ms so
-                    // they make it onto the lock file and into the saved
-                    // Transcription.userNotes (ADR-020 §8).
-                    await notesVM?.commit()
-                    let output = try await meetingRecordingService.stopRecording()
-                    stoppedOutput = output
-                    Telemetry.send(.meetingRecordingCompleted(
-                        durationSeconds: output.durationSeconds,
-                        liveWordCount: liveWordCount,
-                        liveTranscriptLagged: liveTranscriptLagged
-                    ))
-                    let transcription = try await transcriptionService.transcribeMeeting(recording: output, onProgress: nil)
-                    await meetingRecordingService.completeTranscription(for: output)
+                    let transcription: Transcription
+                    if let operationContext {
+                        transcription = try await Observability.withOperationContext(operationContext) {
+                            // Flush any keystrokes typed in the last < 250 ms so
+                            // they make it onto the lock file and into the saved
+                            // Transcription.userNotes (ADR-020 §8).
+                            await notesVM?.commit()
+                            let output = try await meetingRecordingService.stopRecording()
+                            stoppedOutput = output
+                            Telemetry.send(.meetingRecordingCompleted(
+                                durationSeconds: output.durationSeconds,
+                                liveWordCount: liveWordCount,
+                                liveTranscriptLagged: liveTranscriptLagged
+                            ))
+                            let transcription = try await transcriptionService.transcribeMeeting(recording: output, onProgress: nil)
+                            transcriptionFinished = true
+                            await meetingRecordingService.completeTranscription(for: output)
+                            return transcription
+                        }
+                    } else {
+                        await notesVM?.commit()
+                        let output = try await meetingRecordingService.stopRecording()
+                        stoppedOutput = output
+                        Telemetry.send(.meetingRecordingCompleted(
+                            durationSeconds: output.durationSeconds,
+                            liveWordCount: liveWordCount,
+                            liveTranscriptLagged: liveTranscriptLagged
+                        ))
+                        transcription = try await transcriptionService.transcribeMeeting(recording: output, onProgress: nil)
+                        transcriptionFinished = true
+                        await meetingRecordingService.completeTranscription(for: output)
+                    }
                     self.sendMeetingOperation(
                         outcome: .success,
-                        output: output,
+                        output: stoppedOutput,
+                        stage: .completeTranscription,
                         liveWordCount: liveWordCount,
                         liveTranscriptLagged: liveTranscriptLagged
                     )
-                    self.currentMeetingOperationID = nil
+                    self.currentMeetingOperationContext = nil
                     self.currentMeetingTrigger = nil
                     self.completedTranscription = transcription
                     self.sendEvent(.transcriptionCompleted(generation: gen, transcriptionID: transcription.id))
@@ -365,11 +398,12 @@ final class MeetingRecordingFlowCoordinator {
                     self.sendMeetingOperation(
                         outcome: .failure,
                         output: stoppedOutput,
+                        stage: stoppedOutput == nil ? .stopRecording : (transcriptionFinished ? .completeTranscription : .transcription),
                         liveWordCount: liveWordCount,
                         liveTranscriptLagged: liveTranscriptLagged,
                         errorType: TelemetryErrorClassifier.classify(error)
                     )
-                    self.currentMeetingOperationID = nil
+                    self.currentMeetingOperationContext = nil
                     self.currentMeetingTrigger = nil
                     self.sendEvent(.transcriptionFailed(generation: gen, message: error.localizedDescription))
                 }
@@ -400,9 +434,10 @@ final class MeetingRecordingFlowCoordinator {
                 Telemetry.send(.meetingRecordingCancelled(durationSeconds: durationSeconds))
                 self.sendMeetingOperation(
                     outcome: .cancelled,
+                    stage: .cancel,
                     durationSeconds: durationSeconds
                 )
-                self.currentMeetingOperationID = nil
+                self.currentMeetingOperationContext = nil
                 self.currentMeetingTrigger = nil
             }
 
@@ -635,17 +670,20 @@ final class MeetingRecordingFlowCoordinator {
         outcome: ObservabilityOutcome,
         trigger: TelemetryMeetingRecordingTrigger? = nil,
         output: MeetingRecordingOutput? = nil,
+        stage: TelemetryMeetingOperationStage? = nil,
         durationSeconds: Double? = nil,
         liveWordCount: Int? = nil,
         liveTranscriptLagged: Bool? = nil,
         errorType: String? = nil
     ) {
-        guard let operationID = currentMeetingOperationID else { return }
+        guard let operationContext = currentMeetingOperationContext else { return }
         let notes = output?.userNotes?.trimmingCharacters(in: .whitespacesAndNewlines)
         Telemetry.send(.meetingOperation(
-            operationID: operationID,
+            operationID: operationContext.operationID,
+            operationContext: operationContext,
             outcome: outcome,
             trigger: trigger ?? currentMeetingTrigger,
+            stage: stage,
             durationSeconds: output?.durationSeconds ?? durationSeconds,
             liveWordCount: liveWordCount,
             liveTranscriptLagged: liveTranscriptLagged,

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -99,7 +99,7 @@ final class MeetingRecordingFlowCoordinator {
         switch stateMachine.state {
         case .idle:
             pendingTrigger = pendingTrigger ?? trigger
-            currentMeetingOperationContext = currentMeetingOperationContext ?? ObservabilityOperationContext()
+            currentMeetingOperationContext = ObservabilityOperationContext()
             sendEvent(.startRequested)
         case .recording, .starting, .stopping:
             sendEvent(.stopRequested)
@@ -342,31 +342,16 @@ final class MeetingRecordingFlowCoordinator {
             let liveWordCount = panelViewModel?.wordCount ?? 0
             let liveTranscriptLagged = panelViewModel?.isTranscriptionLagging ?? false
             let notesVM = panelViewModel?.notesViewModel
-            let operationContext = currentMeetingOperationContext
+            let operationContext = currentMeetingOperationContext ?? ObservabilityOperationContext()
+            currentMeetingOperationContext = operationContext
             actionTask = Task { @MainActor in
                 var stoppedOutput: MeetingRecordingOutput?
                 var transcriptionFinished = false
                 do {
-                    let transcription: Transcription
-                    if let operationContext {
-                        transcription = try await Observability.withOperationContext(operationContext) {
-                            // Flush any keystrokes typed in the last < 250 ms so
-                            // they make it onto the lock file and into the saved
-                            // Transcription.userNotes (ADR-020 §8).
-                            await notesVM?.commit()
-                            let output = try await meetingRecordingService.stopRecording()
-                            stoppedOutput = output
-                            Telemetry.send(.meetingRecordingCompleted(
-                                durationSeconds: output.durationSeconds,
-                                liveWordCount: liveWordCount,
-                                liveTranscriptLagged: liveTranscriptLagged
-                            ))
-                            let transcription = try await transcriptionService.transcribeMeeting(recording: output, onProgress: nil)
-                            transcriptionFinished = true
-                            await meetingRecordingService.completeTranscription(for: output)
-                            return transcription
-                        }
-                    } else {
+                    let transcription = try await Observability.withOperationContext(operationContext) {
+                        // Flush any keystrokes typed in the last < 250 ms so
+                        // they make it onto the lock file and into the saved
+                        // Transcription.userNotes (ADR-020 §8).
                         await notesVM?.commit()
                         let output = try await meetingRecordingService.stopRecording()
                         stoppedOutput = output
@@ -375,9 +360,10 @@ final class MeetingRecordingFlowCoordinator {
                             liveWordCount: liveWordCount,
                             liveTranscriptLagged: liveTranscriptLagged
                         ))
-                        transcription = try await transcriptionService.transcribeMeeting(recording: output, onProgress: nil)
+                        let transcription = try await transcriptionService.transcribeMeeting(recording: output, onProgress: nil)
                         transcriptionFinished = true
                         await meetingRecordingService.completeTranscription(for: output)
+                        return transcription
                     }
                     self.sendMeetingOperation(
                         outcome: .success,

--- a/Sources/MacParakeetCore/Services/AutoSaveService.swift
+++ b/Sources/MacParakeetCore/Services/AutoSaveService.swift
@@ -76,15 +76,23 @@ public final class AutoSaveService {
     /// Failures are logged but never surfaced to the user.
     public func saveIfEnabled(_ transcription: Transcription, scope: AutoSaveScope = .transcription) {
         guard defaults.bool(forKey: scope.enabledKey) else { return }
+        let format = AutoSaveFormat(rawValue: defaults.string(forKey: scope.formatKey) ?? "md") ?? .md
+        let operationContext = Observability.childOperationContext()
         guard let folderURL = resolveFolder(scope: scope) else {
             logger.warning("Auto-save enabled but no valid folder configured for \(scope.rawValue).")
+            Telemetry.send(.autoSaveOperation(
+                operationID: operationContext.operationID,
+                operationContext: operationContext,
+                scope: scope,
+                format: format,
+                outcome: .unavailable,
+                durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
+                errorType: "folder_unavailable"
+            ))
             return
         }
 
-        let format = AutoSaveFormat(rawValue: defaults.string(forKey: scope.formatKey) ?? "md") ?? .md
         let fileURL = buildFileURL(for: transcription, format: format, in: folderURL)
-        let operationID = Observability.operationID()
-        let startedAt = Date()
 
         do {
             // Ensure the folder still exists
@@ -100,21 +108,23 @@ public final class AutoSaveService {
 
             logger.info("Auto-saved \(scope.rawValue) transcript to \(fileURL.lastPathComponent)")
             Telemetry.send(.autoSaveOperation(
-                operationID: operationID,
+                operationID: operationContext.operationID,
+                operationContext: operationContext,
                 scope: scope,
                 format: format,
                 outcome: .success,
-                durationSeconds: Observability.durationSeconds(since: startedAt),
+                durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
                 errorType: nil
             ))
         } catch {
             logger.error("Auto-save failed for \(scope.rawValue): \(error.localizedDescription)")
             Telemetry.send(.autoSaveOperation(
-                operationID: operationID,
+                operationID: operationContext.operationID,
+                operationContext: operationContext,
                 scope: scope,
                 format: format,
                 outcome: .failure,
-                durationSeconds: Observability.durationSeconds(since: startedAt),
+                durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
                 errorType: Observability.errorType(for: error)
             ))
         }

--- a/Sources/MacParakeetCore/Services/AutoSaveService.swift
+++ b/Sources/MacParakeetCore/Services/AutoSaveService.swift
@@ -80,15 +80,13 @@ public final class AutoSaveService {
         let operationContext = Observability.childOperationContext()
         guard let folderURL = resolveFolder(scope: scope) else {
             logger.warning("Auto-save enabled but no valid folder configured for \(scope.rawValue).")
-            Telemetry.send(.autoSaveOperation(
-                operationID: operationContext.operationID,
+            sendAutoSaveOperation(
                 operationContext: operationContext,
                 scope: scope,
                 format: format,
                 outcome: .unavailable,
-                durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
                 errorType: "folder_unavailable"
-            ))
+            )
             return
         }
 
@@ -107,26 +105,21 @@ public final class AutoSaveService {
             }
 
             logger.info("Auto-saved \(scope.rawValue) transcript to \(fileURL.lastPathComponent)")
-            Telemetry.send(.autoSaveOperation(
-                operationID: operationContext.operationID,
+            sendAutoSaveOperation(
                 operationContext: operationContext,
                 scope: scope,
                 format: format,
-                outcome: .success,
-                durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
-                errorType: nil
-            ))
+                outcome: .success
+            )
         } catch {
             logger.error("Auto-save failed for \(scope.rawValue): \(error.localizedDescription)")
-            Telemetry.send(.autoSaveOperation(
-                operationID: operationContext.operationID,
+            sendAutoSaveOperation(
                 operationContext: operationContext,
                 scope: scope,
                 format: format,
                 outcome: .failure,
-                durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
                 errorType: Observability.errorType(for: error)
-            ))
+            )
         }
     }
 
@@ -164,6 +157,24 @@ public final class AutoSaveService {
               let value = defaults.object(forKey: sourceKey)
         else { return }
         defaults.set(value, forKey: destinationKey)
+    }
+
+    private func sendAutoSaveOperation(
+        operationContext: ObservabilityOperationContext,
+        scope: AutoSaveScope,
+        format: AutoSaveFormat,
+        outcome: ObservabilityOutcome,
+        errorType: String? = nil
+    ) {
+        Telemetry.send(.autoSaveOperation(
+            operationID: operationContext.operationID,
+            operationContext: operationContext,
+            scope: scope,
+            format: format,
+            outcome: outcome,
+            durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
+            errorType: errorType
+        ))
     }
 
     /// Store a folder URL as bookmark data. Returns the display path on success.

--- a/Sources/MacParakeetCore/Services/DictationService.swift
+++ b/Sources/MacParakeetCore/Services/DictationService.swift
@@ -67,7 +67,8 @@ public actor DictationService: DictationServiceProtocol {
     private var currentTelemetryContext = DictationTelemetryContext()
     private var recordingStartedAt: Date?
     private var currentOperationID: String?
-    private var currentOperationContext = DictationTelemetryContext()
+    private var currentOperationTelemetryContext = DictationTelemetryContext()
+    private var currentObservabilityOperationContext: ObservabilityOperationContext?
     private var activeSessionID: Int = 0
 
     public var state: DictationState {
@@ -120,8 +121,22 @@ public actor DictationService: DictationServiceProtocol {
         sessionID: Int?
     ) async throws {
         logger.debug("startRecording requested state=\(self.debugStateLabel(self._state), privacy: .public)")
+        let operationContext = ObservabilityOperationContext()
         if let entitlements {
-            try await entitlements.assertCanTranscribe(now: Date())
+            do {
+                try await entitlements.assertCanTranscribe(now: Date())
+            } catch {
+                let device = await audioProcessor.recordingDeviceInfo
+                sendDictationOperation(
+                    operationID: operationContext.operationID,
+                    operationContext: operationContext,
+                    telemetryContext: context,
+                    outcome: .unavailable,
+                    errorType: Self.errorType(for: error),
+                    device: device
+                )
+                throw error
+            }
         }
 
         switch _state {
@@ -155,8 +170,9 @@ public actor DictationService: DictationServiceProtocol {
 
         let requestedSessionID = sessionID ?? activeSessionID + 1
         activeSessionID = requestedSessionID
-        currentOperationID = Observability.operationID()
-        currentOperationContext = context
+        currentOperationID = operationContext.operationID
+        currentOperationTelemetryContext = context
+        currentObservabilityOperationContext = operationContext
         _state = .recording
         do {
             try await audioProcessor.startCapture()
@@ -178,13 +194,15 @@ public actor DictationService: DictationServiceProtocol {
             logger.debug("startRecording capture started session=\(requestedSessionID)")
         } catch {
             let operationID = currentOperationID
-            let operationContext = currentOperationContext
+            let telemetryContext = currentOperationTelemetryContext
+            let observabilityOperationContext = currentObservabilityOperationContext
             let device = await audioProcessor.recordingDeviceInfo
             _state = .idle
             recordingStartedAt = nil
             sendDictationOperation(
                 operationID: operationID,
-                telemetryContext: operationContext,
+                operationContext: observabilityOperationContext,
+                telemetryContext: telemetryContext,
                 outcome: .failure,
                 errorType: Self.errorType(for: error),
                 device: device
@@ -226,7 +244,14 @@ public actor DictationService: DictationServiceProtocol {
             logger.debug(
                 "stopRecording capture stopped session=\(currentSession) url=\(audioURL.path, privacy: .public)"
             )
-            let result = try await processCapturedAudio(audioURL: audioURL)
+            let result: DictationResult
+            if let operationContext = currentObservabilityOperationContext {
+                result = try await Observability.withOperationContext(operationContext) {
+                    try await processCapturedAudio(audioURL: audioURL)
+                }
+            } else {
+                result = try await processCapturedAudio(audioURL: audioURL)
+            }
             // Guard against reentrancy: a new session may have started during
             // transcription, replacing this session. Don't overwrite its state.
             guard activeSessionID == currentSession else {
@@ -379,7 +404,14 @@ public actor DictationService: DictationServiceProtocol {
 
         _state = .processing
         do {
-            let result = try await processCapturedAudio(audioURL: audioURL)
+            let result: DictationResult
+            if let operationContext = currentObservabilityOperationContext {
+                result = try await Observability.withOperationContext(operationContext) {
+                    try await processCapturedAudio(audioURL: audioURL)
+                }
+            } else {
+                result = try await processCapturedAudio(audioURL: audioURL)
+            }
             let device = await audioProcessor.recordingDeviceInfo
             _state = .success(result.dictation)
             sendDictationOperation(
@@ -642,11 +674,13 @@ public actor DictationService: DictationServiceProtocol {
 
     private func clearCurrentOperation() {
         currentOperationID = nil
-        currentOperationContext = DictationTelemetryContext()
+        currentOperationTelemetryContext = DictationTelemetryContext()
+        currentObservabilityOperationContext = nil
     }
 
     private func sendDictationOperation(
         operationID: String? = nil,
+        operationContext: ObservabilityOperationContext? = nil,
         telemetryContext: DictationTelemetryContext? = nil,
         outcome: ObservabilityOutcome,
         durationSeconds: Double? = nil,
@@ -655,9 +689,11 @@ public actor DictationService: DictationServiceProtocol {
         device: RecordingDeviceInfo? = nil
     ) {
         guard let id = operationID ?? currentOperationID else { return }
-        let context = telemetryContext ?? currentOperationContext
+        let context = telemetryContext ?? currentOperationTelemetryContext
+        let observabilityContext = operationContext ?? currentObservabilityOperationContext
         Telemetry.send(.dictationOperation(
             operationID: id,
+            operationContext: observabilityContext,
             outcome: outcome,
             trigger: context.trigger,
             mode: context.mode,

--- a/Sources/MacParakeetCore/Services/DictationService.swift
+++ b/Sources/MacParakeetCore/Services/DictationService.swift
@@ -463,7 +463,7 @@ public actor DictationService: DictationServiceProtocol {
         pendingCancelledAudioURL = nil
     }
 
-    private func withCurrentObservabilityContextIfAny<T>(
+    private func withCurrentObservabilityContextIfAny<T: Sendable>(
         _ operation: () async throws -> T
     ) async rethrows -> T {
         guard let operationContext = currentObservabilityOperationContext else {

--- a/Sources/MacParakeetCore/Services/DictationService.swift
+++ b/Sources/MacParakeetCore/Services/DictationService.swift
@@ -244,13 +244,8 @@ public actor DictationService: DictationServiceProtocol {
             logger.debug(
                 "stopRecording capture stopped session=\(currentSession) url=\(audioURL.path, privacy: .public)"
             )
-            let result: DictationResult
-            if let operationContext = currentObservabilityOperationContext {
-                result = try await Observability.withOperationContext(operationContext) {
-                    try await processCapturedAudio(audioURL: audioURL)
-                }
-            } else {
-                result = try await processCapturedAudio(audioURL: audioURL)
+            let result = try await withCurrentObservabilityContextIfAny {
+                try await processCapturedAudio(audioURL: audioURL)
             }
             // Guard against reentrancy: a new session may have started during
             // transcription, replacing this session. Don't overwrite its state.
@@ -404,13 +399,8 @@ public actor DictationService: DictationServiceProtocol {
 
         _state = .processing
         do {
-            let result: DictationResult
-            if let operationContext = currentObservabilityOperationContext {
-                result = try await Observability.withOperationContext(operationContext) {
-                    try await processCapturedAudio(audioURL: audioURL)
-                }
-            } else {
-                result = try await processCapturedAudio(audioURL: audioURL)
+            let result = try await withCurrentObservabilityContextIfAny {
+                try await processCapturedAudio(audioURL: audioURL)
             }
             let device = await audioProcessor.recordingDeviceInfo
             _state = .success(result.dictation)
@@ -471,6 +461,17 @@ public actor DictationService: DictationServiceProtocol {
             try? FileManager.default.removeItem(at: url)
         }
         pendingCancelledAudioURL = nil
+    }
+
+    private func withCurrentObservabilityContextIfAny<T>(
+        _ operation: () async throws -> T
+    ) async rethrows -> T {
+        guard let operationContext = currentObservabilityOperationContext else {
+            return try await operation()
+        }
+        return try await Observability.withOperationContext(operationContext) {
+            try await operation()
+        }
     }
 
     private func processCapturedAudio(audioURL: URL) async throws -> DictationResult {

--- a/Sources/MacParakeetCore/Services/LLMService.swift
+++ b/Sources/MacParakeetCore/Services/LLMService.swift
@@ -827,8 +827,10 @@ public final class LLMService: LLMServiceProtocol, Sendable {
         messageCount: Int? = nil,
         errorType: String? = nil
     ) {
+        let operationContext = Observability.operationContext(operationID: operationID, startedAt: startedAt)
         Telemetry.send(.llmOperation(
             operationID: operationID,
+            operationContext: operationContext,
             feature: feature,
             provider: provider,
             streaming: streaming,

--- a/Sources/MacParakeetCore/Services/Observability.swift
+++ b/Sources/MacParakeetCore/Services/Observability.swift
@@ -48,9 +48,10 @@ public enum Observability {
 
     public static func withOperationContext<T>(
         _ context: ObservabilityOperationContext,
+        isolation: isolated (any Actor)? = #isolation,
         operation: () async throws -> T
     ) async rethrows -> T {
-        try await $currentOperationContext.withValue(context, operation: operation)
+        try await $currentOperationContext.withValue(context, operation: operation, isolation: isolation)
     }
 
     public static func childOperationContext(startedAt: Date = Date()) -> ObservabilityOperationContext {

--- a/Sources/MacParakeetCore/Services/Observability.swift
+++ b/Sources/MacParakeetCore/Services/Observability.swift
@@ -16,7 +16,65 @@ public enum ObservabilityInputKind: String, Sendable {
     case unknown
 }
 
+public struct ObservabilityOperationContext: Sendable, Equatable {
+    public let operationID: String
+    public let workflowID: String
+    public let parentOperationID: String?
+    public let startedAt: Date
+
+    public init(
+        operationID: String = Observability.operationID(),
+        workflowID: String? = nil,
+        parentOperationID: String? = nil,
+        startedAt: Date = Date()
+    ) {
+        self.operationID = operationID
+        self.workflowID = workflowID ?? operationID
+        self.parentOperationID = parentOperationID
+        self.startedAt = startedAt
+    }
+
+    public func child(startedAt: Date = Date()) -> ObservabilityOperationContext {
+        ObservabilityOperationContext(
+            workflowID: workflowID,
+            parentOperationID: operationID,
+            startedAt: startedAt
+        )
+    }
+}
+
 public enum Observability {
+    @TaskLocal public static var currentOperationContext: ObservabilityOperationContext?
+
+    public static func withOperationContext<T>(
+        _ context: ObservabilityOperationContext,
+        operation: () async throws -> T
+    ) async rethrows -> T {
+        try await $currentOperationContext.withValue(context, operation: operation)
+    }
+
+    public static func childOperationContext(startedAt: Date = Date()) -> ObservabilityOperationContext {
+        if let currentOperationContext {
+            return currentOperationContext.child(startedAt: startedAt)
+        }
+        return ObservabilityOperationContext(startedAt: startedAt)
+    }
+
+    public static func operationContext(operationID: String, startedAt: Date) -> ObservabilityOperationContext {
+        if let currentOperationContext {
+            if currentOperationContext.operationID == operationID {
+                return currentOperationContext
+            }
+            return ObservabilityOperationContext(
+                operationID: operationID,
+                workflowID: currentOperationContext.workflowID,
+                parentOperationID: currentOperationContext.operationID,
+                startedAt: startedAt
+            )
+        }
+        return ObservabilityOperationContext(operationID: operationID, startedAt: startedAt)
+    }
+
     public static func operationID() -> String {
         UUID().uuidString
     }

--- a/Sources/MacParakeetCore/Services/Observability.swift
+++ b/Sources/MacParakeetCore/Services/Observability.swift
@@ -63,13 +63,12 @@ public enum Observability {
 
     public static func operationContext(operationID: String, startedAt: Date) -> ObservabilityOperationContext {
         if let currentOperationContext {
-            if currentOperationContext.operationID == operationID {
-                return currentOperationContext
-            }
             return ObservabilityOperationContext(
                 operationID: operationID,
                 workflowID: currentOperationContext.workflowID,
-                parentOperationID: currentOperationContext.operationID,
+                parentOperationID: currentOperationContext.operationID == operationID
+                    ? currentOperationContext.parentOperationID
+                    : currentOperationContext.operationID,
                 startedAt: startedAt
             )
         }

--- a/Sources/MacParakeetCore/Services/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/TelemetryEvent.swift
@@ -122,11 +122,13 @@ public enum TelemetryTranscriptionSource: String, Sendable, Equatable {
 }
 
 public enum TelemetryTranscriptionStage: String, Sendable, Equatable {
+    case preflight
     case download
     case audioConversion = "audio_conversion"
     case stt
     case diarization
     case postProcessing = "post_processing"
+    case persistence
 }
 
 public enum TelemetryCopySource: String, Sendable, Equatable {
@@ -148,6 +150,16 @@ public enum TelemetryMeetingRecordingTrigger: String, Sendable, Equatable {
     case manual
     case hotkey
     case calendarAutoStart = "calendar_auto_start"
+}
+
+public enum TelemetryMeetingOperationStage: String, Sendable, Equatable {
+    case permissions
+    case startRecording = "start_recording"
+    case recording
+    case stopRecording = "stop_recording"
+    case transcription
+    case completeTranscription = "complete_transcription"
+    case cancel
 }
 
 public enum TelemetryMeetingRecoverySource: String, Sendable, Equatable {
@@ -198,6 +210,7 @@ public enum TelemetryEventSpec: Sendable {
     case dictationFailed(errorType: String, errorDetail: String? = nil, device: RecordingDeviceInfo? = nil)
     case dictationOperation(
         operationID: String,
+        operationContext: ObservabilityOperationContext? = nil,
         outcome: ObservabilityOutcome,
         trigger: TelemetryDictationTrigger?,
         mode: TelemetryDictationMode?,
@@ -229,6 +242,7 @@ public enum TelemetryEventSpec: Sendable {
     )
     case transcriptionOperation(
         operationID: String,
+        operationContext: ObservabilityOperationContext? = nil,
         outcome: ObservabilityOutcome,
         source: TelemetryTranscriptionSource,
         stage: TelemetryTranscriptionStage?,
@@ -273,6 +287,7 @@ public enum TelemetryEventSpec: Sendable {
     )
     case llmOperation(
         operationID: String,
+        operationContext: ObservabilityOperationContext? = nil,
         feature: String,
         provider: String,
         streaming: Bool,
@@ -319,6 +334,7 @@ public enum TelemetryEventSpec: Sendable {
     case feedbackSubmitted(category: String)
     case feedbackOperation(
         operationID: String,
+        operationContext: ObservabilityOperationContext? = nil,
         category: String,
         outcome: ObservabilityOutcome,
         durationSeconds: Double,
@@ -344,8 +360,10 @@ public enum TelemetryEventSpec: Sendable {
     case meetingRecordingFailed(errorType: String, errorDetail: String? = nil)
     case meetingOperation(
         operationID: String,
+        operationContext: ObservabilityOperationContext? = nil,
         outcome: ObservabilityOutcome,
         trigger: TelemetryMeetingRecordingTrigger?,
+        stage: TelemetryMeetingOperationStage? = nil,
         durationSeconds: Double?,
         liveWordCount: Int?,
         liveTranscriptLagged: Bool?,
@@ -401,6 +419,7 @@ public enum TelemetryEventSpec: Sendable {
     )
     case cliOperation(
         operationID: String,
+        operationContext: ObservabilityOperationContext? = nil,
         command: String,
         subcommand: String?,
         outcome: ObservabilityOutcome,
@@ -413,6 +432,7 @@ public enum TelemetryEventSpec: Sendable {
     )
     case autoSaveOperation(
         operationID: String,
+        operationContext: ObservabilityOperationContext? = nil,
         scope: AutoSaveScope,
         format: AutoSaveFormat,
         outcome: ObservabilityOutcome,
@@ -565,6 +585,7 @@ extension TelemetryEventSpec {
             return Self.mergeDevice(props, device)
         case .dictationOperation(
             let operationID,
+            let operationContext,
             let outcome,
             let trigger,
             let mode,
@@ -575,6 +596,8 @@ extension TelemetryEventSpec {
         ):
             return Self.mergeDevice(Self.compactProps(
                 ("operation_id", operationID),
+                ("workflow_id", operationContext?.workflowID),
+                ("parent_operation_id", operationContext?.parentOperationID),
                 ("outcome", outcome.rawValue),
                 ("trigger", trigger?.rawValue),
                 ("mode", mode?.rawValue),
@@ -621,6 +644,7 @@ extension TelemetryEventSpec {
             return props
         case .transcriptionOperation(
             let operationID,
+            let operationContext,
             let outcome,
             let source,
             let stage,
@@ -638,6 +662,8 @@ extension TelemetryEventSpec {
         ):
             return Self.compactProps(
                 ("operation_id", operationID),
+                ("workflow_id", operationContext?.workflowID),
+                ("parent_operation_id", operationContext?.parentOperationID),
                 ("outcome", outcome.rawValue),
                 ("source", source.rawValue),
                 ("stage", stage?.rawValue),
@@ -721,6 +747,7 @@ extension TelemetryEventSpec {
             ]
         case .llmOperation(
             let operationID,
+            let operationContext,
             let feature,
             let provider,
             let streaming,
@@ -735,6 +762,8 @@ extension TelemetryEventSpec {
         ):
             return Self.compactProps(
                 ("operation_id", operationID),
+                ("workflow_id", operationContext?.workflowID),
+                ("parent_operation_id", operationContext?.parentOperationID),
                 ("feature", feature),
                 ("provider", provider),
                 ("streaming", Self.boolString(streaming)),
@@ -785,6 +814,7 @@ extension TelemetryEventSpec {
             return ["category": category]
         case .feedbackOperation(
             let operationID,
+            let operationContext,
             let category,
             let outcome,
             let durationSeconds,
@@ -794,6 +824,8 @@ extension TelemetryEventSpec {
         ):
             return Self.compactProps(
                 ("operation_id", operationID),
+                ("workflow_id", operationContext?.workflowID),
+                ("parent_operation_id", operationContext?.parentOperationID),
                 ("category", category),
                 ("outcome", outcome.rawValue),
                 ("duration_seconds", Self.format(durationSeconds)),
@@ -821,8 +853,10 @@ extension TelemetryEventSpec {
             return props
         case .meetingOperation(
             let operationID,
+            let operationContext,
             let outcome,
             let trigger,
+            let stage,
             let durationSeconds,
             let liveWordCount,
             let liveTranscriptLagged,
@@ -834,8 +868,11 @@ extension TelemetryEventSpec {
         ):
             return Self.compactProps(
                 ("operation_id", operationID),
+                ("workflow_id", operationContext?.workflowID),
+                ("parent_operation_id", operationContext?.parentOperationID),
                 ("outcome", outcome.rawValue),
                 ("trigger", trigger?.rawValue),
+                ("stage", stage?.rawValue),
                 ("duration_seconds", durationSeconds.map(Self.format)),
                 ("live_word_count", liveWordCount.map(String.init)),
                 ("live_transcript_lagged", liveTranscriptLagged.map(Self.boolString)),
@@ -921,6 +958,7 @@ extension TelemetryEventSpec {
             )
         case .cliOperation(
             let operationID,
+            let operationContext,
             let command,
             let subcommand,
             let outcome,
@@ -933,6 +971,8 @@ extension TelemetryEventSpec {
         ):
             return Self.compactProps(
                 ("operation_id", operationID),
+                ("workflow_id", operationContext?.workflowID),
+                ("parent_operation_id", operationContext?.parentOperationID),
                 ("command", command),
                 ("subcommand", subcommand),
                 ("outcome", outcome.rawValue),
@@ -943,9 +983,11 @@ extension TelemetryEventSpec {
                 ("exit_code", exitCode.map(String.init)),
                 ("error_type", errorType)
             )
-        case .autoSaveOperation(let operationID, let scope, let format, let outcome, let durationSeconds, let errorType):
+        case .autoSaveOperation(let operationID, let operationContext, let scope, let format, let outcome, let durationSeconds, let errorType):
             return Self.compactProps(
                 ("operation_id", operationID),
+                ("workflow_id", operationContext?.workflowID),
+                ("parent_operation_id", operationContext?.parentOperationID),
                 ("scope", scope.rawValue),
                 ("format", format.rawValue),
                 ("outcome", outcome.rawValue),

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -174,20 +174,10 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         )
 
         return try await Observability.withOperationContext(operation.operationContext) {
-            do {
-                if let entitlements {
-                    try await entitlements.assertCanTranscribe(now: Date())
-                }
-            } catch {
-                sendTranscriptionOperation(
-                    operation,
-                    outcome: .unavailable,
-                    stage: .preflight,
-                    audioDurationSeconds: recording.durationSeconds,
-                    errorType: Self.errorType(for: error)
-                )
-                throw error
-            }
+            try await assertCanTranscribeOrEmitPreflight(
+                operation,
+                audioDurationSeconds: recording.durationSeconds
+            )
 
             var transcription = Transcription(
                 fileName: recording.displayName,
@@ -240,19 +230,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         )
 
         return try await Observability.withOperationContext(operation.operationContext) {
-            do {
-                if let entitlements {
-                    try await entitlements.assertCanTranscribe(now: Date())
-                }
-            } catch {
-                sendTranscriptionOperation(
-                    operation,
-                    outcome: .unavailable,
-                    stage: .preflight,
-                    errorType: Self.errorType(for: error)
-                )
-                throw error
-            }
+            try await assertCanTranscribeOrEmitPreflight(operation)
 
             Telemetry.send(.transcriptionStarted(source: source, audioDurationSeconds: nil))
 
@@ -286,20 +264,10 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         )
 
         return try await Observability.withOperationContext(operation.operationContext) {
-            do {
-                if let entitlements {
-                    try await entitlements.assertCanTranscribe(now: Date())
-                }
-            } catch {
-                sendTranscriptionOperation(
-                    operation,
-                    outcome: .unavailable,
-                    stage: .preflight,
-                    audioDurationSeconds: recording.durationSeconds,
-                    errorType: Self.errorType(for: error)
-                )
-                throw error
-            }
+            try await assertCanTranscribeOrEmitPreflight(
+                operation,
+                audioDurationSeconds: recording.durationSeconds
+            )
 
             Telemetry.send(.transcriptionStarted(
                 source: .meeting,
@@ -337,19 +305,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         )
 
         return try await Observability.withOperationContext(operation.operationContext) {
-            do {
-                if let entitlements {
-                    try await entitlements.assertCanTranscribe(now: Date())
-                }
-            } catch {
-                sendTranscriptionOperation(
-                    operation,
-                    outcome: .unavailable,
-                    stage: .preflight,
-                    errorType: Self.errorType(for: error)
-                )
-                throw error
-            }
+            try await assertCanTranscribeOrEmitPreflight(operation)
 
             var transcription = Transcription(
                 fileName: fileName,
@@ -416,19 +372,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
                 throw YouTubeDownloadError.ytDlpNotFound
             }
 
-            do {
-                if let entitlements {
-                    try await entitlements.assertCanTranscribe(now: Date())
-                }
-            } catch {
-                sendTranscriptionOperation(
-                    operation,
-                    outcome: .unavailable,
-                    stage: .preflight,
-                    errorType: Self.errorType(for: error)
-                )
-                throw error
-            }
+            try await assertCanTranscribeOrEmitPreflight(operation)
 
             let downloadResult: YouTubeDownloader.DownloadResult
             do {
@@ -1092,6 +1036,26 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         TelemetryErrorClassifier.classify(error)
     }
 
+    private func assertCanTranscribeOrEmitPreflight(
+        _ operation: TranscriptionOperationContext,
+        audioDurationSeconds: Double? = nil
+    ) async throws {
+        do {
+            if let entitlements {
+                try await entitlements.assertCanTranscribe(now: Date())
+            }
+        } catch {
+            sendTranscriptionOperation(
+                operation,
+                outcome: .unavailable,
+                stage: .preflight,
+                audioDurationSeconds: audioDurationSeconds,
+                errorType: Self.errorType(for: error)
+            )
+            throw error
+        }
+    }
+
     private func sendTranscriptionOperation(
         _ operation: TranscriptionOperationContext,
         outcome: ObservabilityOutcome,
@@ -1112,7 +1076,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
             stage: stage,
             durationSeconds: Observability.durationSeconds(since: operation.operationContext.startedAt),
             audioDurationSeconds: audioDurationSeconds,
-            processingSeconds: processingSeconds ?? Observability.durationSeconds(since: operation.operationContext.startedAt),
+            processingSeconds: processingSeconds,
             wordCount: wordCount,
             speakerCount: speakerCount,
             diarizationRequested: diarizationRequested,

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -64,26 +64,24 @@ extension TranscriptionServiceProtocol {
 }
 
 private struct TranscriptionOperationContext: Sendable {
-    let operationID: String
+    let operationContext: ObservabilityOperationContext
     let source: TelemetryTranscriptionSource
     let inputKind: ObservabilityInputKind?
     let mediaExtension: String?
     let fileSizeBucket: String?
-    let startedAt: Date
 
     init(
         source: TelemetryTranscriptionSource,
         inputKind: ObservabilityInputKind?,
         mediaExtension: String?,
         fileSizeBucket: String?,
-        startedAt: Date = Date()
+        operationContext: ObservabilityOperationContext = Observability.childOperationContext()
     ) {
-        self.operationID = Observability.operationID()
+        self.operationContext = operationContext
         self.source = source
         self.inputKind = inputKind
         self.mediaExtension = mediaExtension
         self.fileSizeBucket = fileSizeBucket
-        self.startedAt = startedAt
     }
 }
 
@@ -166,10 +164,6 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         recording: MeetingRecordingOutput,
         onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
     ) async throws -> Transcription {
-        if let entitlements {
-            try await entitlements.assertCanTranscribe(now: Date())
-        }
-
         let fileSize = (try? FileManager.default.attributesOfItem(atPath: recording.mixedAudioURL.path)[.size] as? Int)
             .flatMap { $0 }
         let operation = TranscriptionOperationContext(
@@ -179,26 +173,54 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
             fileSizeBucket: Observability.fileSizeBucket(bytes: fileSize)
         )
 
-        var transcription = Transcription(
-            fileName: recording.displayName,
-            filePath: recording.mixedAudioURL.path,
-            fileSizeBytes: fileSize,
-            status: .processing,
-            sourceType: .meeting,
-            userNotes: recording.userNotes
-        )
-        try transcriptionRepo.save(transcription)
-        Telemetry.send(.transcriptionStarted(
-            source: .meeting,
-            audioDurationSeconds: recording.durationSeconds
-        ))
+        return try await Observability.withOperationContext(operation.operationContext) {
+            do {
+                if let entitlements {
+                    try await entitlements.assertCanTranscribe(now: Date())
+                }
+            } catch {
+                sendTranscriptionOperation(
+                    operation,
+                    outcome: .unavailable,
+                    stage: .preflight,
+                    audioDurationSeconds: recording.durationSeconds,
+                    errorType: Self.errorType(for: error)
+                )
+                throw error
+            }
 
-        return try await transcribeMeetingAudio(
-            recording: recording,
-            transcription: &transcription,
-            operation: operation,
-            onProgress: onProgress
-        )
+            var transcription = Transcription(
+                fileName: recording.displayName,
+                filePath: recording.mixedAudioURL.path,
+                fileSizeBytes: fileSize,
+                status: .processing,
+                sourceType: .meeting,
+                userNotes: recording.userNotes
+            )
+            do {
+                try transcriptionRepo.save(transcription)
+            } catch {
+                sendTranscriptionOperation(
+                    operation,
+                    outcome: .failure,
+                    stage: .persistence,
+                    audioDurationSeconds: recording.durationSeconds,
+                    errorType: Self.errorType(for: error)
+                )
+                throw error
+            }
+            Telemetry.send(.transcriptionStarted(
+                source: .meeting,
+                audioDurationSeconds: recording.durationSeconds
+            ))
+
+            return try await transcribeMeetingAudio(
+                recording: recording,
+                transcription: &transcription,
+                operation: operation,
+                onProgress: onProgress
+            )
+        }
     }
 
     public func retranscribe(
@@ -207,10 +229,6 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         source: TelemetryTranscriptionSource,
         onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
     ) async throws -> Transcription {
-        if let entitlements {
-            try await entitlements.assertCanTranscribe(now: Date())
-        }
-
         var transcription = makeRetranscriptionRecord(from: original)
         transcription.fileSizeBytes = (try? FileManager.default.attributesOfItem(atPath: fileURL.path)[.size] as? Int)
             .flatMap { $0 } ?? original.fileSizeBytes
@@ -221,18 +239,34 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
             fileSizeBucket: Observability.fileSizeBucket(bytes: transcription.fileSizeBytes)
         )
 
-        Telemetry.send(.transcriptionStarted(source: source, audioDurationSeconds: nil))
+        return try await Observability.withOperationContext(operation.operationContext) {
+            do {
+                if let entitlements {
+                    try await entitlements.assertCanTranscribe(now: Date())
+                }
+            } catch {
+                sendTranscriptionOperation(
+                    operation,
+                    outcome: .unavailable,
+                    stage: .preflight,
+                    errorType: Self.errorType(for: error)
+                )
+                throw error
+            }
 
-        return try await transcribeAudio(
-            fileURL: fileURL,
-            source: source,
-            sttJob: .fileTranscription,
-            transcription: &transcription,
-            operation: operation,
-            tempFiles: [],
-            persistFailureStatus: false,
-            onProgress: onProgress
-        )
+            Telemetry.send(.transcriptionStarted(source: source, audioDurationSeconds: nil))
+
+            return try await transcribeAudio(
+                fileURL: fileURL,
+                source: source,
+                sttJob: .fileTranscription,
+                transcription: &transcription,
+                operation: operation,
+                tempFiles: [],
+                persistFailureStatus: false,
+                onProgress: onProgress
+            )
+        }
     }
 
     public func retranscribeMeeting(
@@ -240,10 +274,6 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         recording: MeetingRecordingOutput,
         onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
     ) async throws -> Transcription {
-        if let entitlements {
-            try await entitlements.assertCanTranscribe(now: Date())
-        }
-
         var transcription = makeRetranscriptionRecord(from: original)
         transcription.fileSizeBytes = (try? FileManager.default.attributesOfItem(atPath: recording.mixedAudioURL.path)[.size] as? Int)
             .flatMap { $0 } ?? original.fileSizeBytes
@@ -255,18 +285,35 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
             fileSizeBucket: Observability.fileSizeBucket(bytes: transcription.fileSizeBytes)
         )
 
-        Telemetry.send(.transcriptionStarted(
-            source: .meeting,
-            audioDurationSeconds: recording.durationSeconds
-        ))
+        return try await Observability.withOperationContext(operation.operationContext) {
+            do {
+                if let entitlements {
+                    try await entitlements.assertCanTranscribe(now: Date())
+                }
+            } catch {
+                sendTranscriptionOperation(
+                    operation,
+                    outcome: .unavailable,
+                    stage: .preflight,
+                    audioDurationSeconds: recording.durationSeconds,
+                    errorType: Self.errorType(for: error)
+                )
+                throw error
+            }
 
-        return try await transcribeMeetingAudio(
-            recording: recording,
-            transcription: &transcription,
-            operation: operation,
-            persistFailureStatus: false,
-            onProgress: onProgress
-        )
+            Telemetry.send(.transcriptionStarted(
+                source: .meeting,
+                audioDurationSeconds: recording.durationSeconds
+            ))
+
+            return try await transcribeMeetingAudio(
+                recording: recording,
+                transcription: &transcription,
+                operation: operation,
+                persistFailureStatus: false,
+                onProgress: onProgress
+            )
+        }
     }
 
     private func transcribe(
@@ -278,10 +325,6 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         sourceType: Transcription.SourceType,
         onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
     ) async throws -> Transcription {
-        if let entitlements {
-            try await entitlements.assertCanTranscribe(now: Date())
-        }
-
         let fileName = displayFileName ?? storedFileURL?.lastPathComponent ?? fileURL.lastPathComponent
         let fileSize = storedFileURL.flatMap {
             (try? FileManager.default.attributesOfItem(atPath: $0.path)[.size] as? Int).flatMap { $0 }
@@ -293,39 +336,65 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
             fileSizeBucket: Observability.fileSizeBucket(bytes: fileSize)
         )
 
-        var transcription = Transcription(
-            fileName: fileName,
-            filePath: storedFileURL?.path,
-            fileSizeBytes: fileSize,
-            status: .processing,
-            sourceType: sourceType
-        )
-        try transcriptionRepo.save(transcription)
-        Telemetry.send(.transcriptionStarted(source: source, audioDurationSeconds: nil))
+        return try await Observability.withOperationContext(operation.operationContext) {
+            do {
+                if let entitlements {
+                    try await entitlements.assertCanTranscribe(now: Date())
+                }
+            } catch {
+                sendTranscriptionOperation(
+                    operation,
+                    outcome: .unavailable,
+                    stage: .preflight,
+                    errorType: Self.errorType(for: error)
+                )
+                throw error
+            }
 
-        // Extract thumbnail from video files (non-blocking)
-        if Self.isVideoFile(fileURL) {
-            let transcriptionId = transcription.id
-            let path = fileURL.path
-            let logger = self.logger
-            Task.detached(priority: .utility) {
-                do {
-                    _ = try await ThumbnailCacheService.shared.extractVideoFrame(from: path, for: transcriptionId)
-                } catch {
-                    logger.error("Thumbnail extraction failed for \(transcriptionId): \(error.localizedDescription, privacy: .public)")
+            var transcription = Transcription(
+                fileName: fileName,
+                filePath: storedFileURL?.path,
+                fileSizeBytes: fileSize,
+                status: .processing,
+                sourceType: sourceType
+            )
+            do {
+                try transcriptionRepo.save(transcription)
+            } catch {
+                sendTranscriptionOperation(
+                    operation,
+                    outcome: .failure,
+                    stage: .persistence,
+                    errorType: Self.errorType(for: error)
+                )
+                throw error
+            }
+            Telemetry.send(.transcriptionStarted(source: source, audioDurationSeconds: nil))
+
+            // Extract thumbnail from video files (non-blocking)
+            if Self.isVideoFile(fileURL) {
+                let transcriptionId = transcription.id
+                let path = fileURL.path
+                let logger = self.logger
+                Task.detached(priority: .utility) {
+                    do {
+                        _ = try await ThumbnailCacheService.shared.extractVideoFrame(from: path, for: transcriptionId)
+                    } catch {
+                        logger.error("Thumbnail extraction failed for \(transcriptionId): \(error.localizedDescription, privacy: .public)")
+                    }
                 }
             }
-        }
 
-        return try await transcribeAudio(
-            fileURL: fileURL,
-            source: source,
-            sttJob: sttJob,
-            transcription: &transcription,
-            operation: operation,
-            tempFiles: [],
-            onProgress: onProgress
-        )
+            return try await transcribeAudio(
+                fileURL: fileURL,
+                source: source,
+                sttJob: sttJob,
+                transcription: &transcription,
+                operation: operation,
+                tempFiles: [],
+                onProgress: onProgress
+            )
+        }
     }
 
     public func transcribeURL(urlString: String, onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil) async throws -> Transcription {
@@ -336,113 +405,136 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
             fileSizeBucket: nil
         )
 
-        guard let downloader = youtubeDownloader else {
-            sendTranscriptionOperation(
-                operation,
-                outcome: .unavailable,
-                stage: .download,
-                errorType: Self.errorType(for: YouTubeDownloadError.ytDlpNotFound)
-            )
-            throw YouTubeDownloadError.ytDlpNotFound
-        }
-
-        if let entitlements {
-            try await entitlements.assertCanTranscribe(now: Date())
-        }
-
-        let downloadResult: YouTubeDownloader.DownloadResult
-        do {
-            onProgress?(.downloading(percent: 0))
-            downloadResult = try await downloader.download(url: urlString) { percent in
-                onProgress?(.downloading(percent: percent))
+        return try await Observability.withOperationContext(operation.operationContext) {
+            guard let downloader = youtubeDownloader else {
+                sendTranscriptionOperation(
+                    operation,
+                    outcome: .unavailable,
+                    stage: .download,
+                    errorType: Self.errorType(for: YouTubeDownloadError.ytDlpNotFound)
+                )
+                throw YouTubeDownloadError.ytDlpNotFound
             }
-        } catch {
-            if error is CancellationError {
+
+            do {
+                if let entitlements {
+                    try await entitlements.assertCanTranscribe(now: Date())
+                }
+            } catch {
+                sendTranscriptionOperation(
+                    operation,
+                    outcome: .unavailable,
+                    stage: .preflight,
+                    errorType: Self.errorType(for: error)
+                )
+                throw error
+            }
+
+            let downloadResult: YouTubeDownloader.DownloadResult
+            do {
+                onProgress?(.downloading(percent: 0))
+                downloadResult = try await downloader.download(url: urlString) { percent in
+                    onProgress?(.downloading(percent: percent))
+                }
+            } catch {
+                if error is CancellationError {
+                    Telemetry.send(.transcriptionCancelled(
+                        source: .youtube,
+                        audioDurationSeconds: nil,
+                        stage: .download
+                    ))
+                    sendTranscriptionOperation(
+                        operation,
+                        outcome: .cancelled,
+                        stage: .download
+                    )
+                } else {
+                    Telemetry.send(.transcriptionFailed(
+                        source: .youtube,
+                        stage: .download,
+                        errorType: Self.errorType(for: error),
+                        errorDetail: TelemetryErrorClassifier.errorDetail(error)
+                    ))
+                    sendTranscriptionOperation(
+                        operation,
+                        outcome: .failure,
+                        stage: .download,
+                        errorType: Self.errorType(for: error)
+                    )
+                }
+                throw error
+            }
+            onProgress?(.downloading(percent: 100))
+            do {
+                try Task.checkCancellation()
+            } catch {
                 Telemetry.send(.transcriptionCancelled(
                     source: .youtube,
-                    audioDurationSeconds: nil,
+                    audioDurationSeconds: downloadResult.durationSeconds.map(Double.init),
                     stage: .download
                 ))
                 sendTranscriptionOperation(
                     operation,
                     outcome: .cancelled,
-                    stage: .download
-                )
-            } else {
-                Telemetry.send(.transcriptionFailed(
-                    source: .youtube,
                     stage: .download,
-                    errorType: Self.errorType(for: error),
-                    errorDetail: TelemetryErrorClassifier.errorDetail(error)
-                ))
+                    audioDurationSeconds: downloadResult.durationSeconds.map(Double.init)
+                )
+                throw error
+            }
+            let keepDownloadedAudio = shouldKeepDownloadedAudio()
+
+            var transcription = Transcription(
+                fileName: downloadResult.title,
+                filePath: keepDownloadedAudio ? downloadResult.audioFileURL.path : nil,
+                status: .processing,
+                sourceURL: urlString,
+                thumbnailURL: downloadResult.thumbnailURL,
+                channelName: downloadResult.channelName,
+                videoDescription: downloadResult.videoDescription,
+                sourceType: .youtube
+            )
+            do {
+                try transcriptionRepo.save(transcription)
+            } catch {
                 sendTranscriptionOperation(
                     operation,
                     outcome: .failure,
-                    stage: .download,
+                    stage: .persistence,
+                    audioDurationSeconds: downloadResult.durationSeconds.map(Double.init),
                     errorType: Self.errorType(for: error)
                 )
+                throw error
             }
-            throw error
-        }
-        onProgress?(.downloading(percent: 100))
-        do {
-            try Task.checkCancellation()
-        } catch {
-            Telemetry.send(.transcriptionCancelled(
+            Telemetry.send(.transcriptionStarted(
                 source: .youtube,
-                audioDurationSeconds: downloadResult.durationSeconds.map(Double.init),
-                stage: .download
-            ))
-            sendTranscriptionOperation(
-                operation,
-                outcome: .cancelled,
-                stage: .download,
                 audioDurationSeconds: downloadResult.durationSeconds.map(Double.init)
-            )
-            throw error
-        }
-        let keepDownloadedAudio = shouldKeepDownloadedAudio()
+            ))
 
-        var transcription = Transcription(
-            fileName: downloadResult.title,
-            filePath: keepDownloadedAudio ? downloadResult.audioFileURL.path : nil,
-            status: .processing,
-            sourceURL: urlString,
-            thumbnailURL: downloadResult.thumbnailURL,
-            channelName: downloadResult.channelName,
-            videoDescription: downloadResult.videoDescription,
-            sourceType: .youtube
-        )
-        try transcriptionRepo.save(transcription)
-        Telemetry.send(.transcriptionStarted(
-            source: .youtube,
-            audioDurationSeconds: downloadResult.durationSeconds.map(Double.init)
-        ))
-
-        // Cache YouTube thumbnail locally (non-blocking)
-        if let thumbURL = downloadResult.thumbnailURL {
-            let transcriptionId = transcription.id
-            let logger = self.logger
-            Task.detached(priority: .utility) {
-                do {
-                    _ = try await ThumbnailCacheService.shared.downloadThumbnail(from: thumbURL, for: transcriptionId)
-                } catch {
-                    logger.error("Thumbnail download failed for \(transcriptionId): \(error.localizedDescription, privacy: .public)")
+            // Cache YouTube thumbnail locally (non-blocking)
+            if let thumbURL = downloadResult.thumbnailURL {
+                let transcriptionId = transcription.id
+                let logger = self.logger
+                Task.detached(priority: .utility) {
+                    do {
+                        _ = try await ThumbnailCacheService.shared.downloadThumbnail(from: thumbURL, for: transcriptionId)
+                    } catch {
+                        logger.error("Thumbnail download failed for \(transcriptionId): \(error.localizedDescription, privacy: .public)")
+                    }
                 }
             }
-        }
 
-        onProgress?(.transcribing(percent: 0))
-        return try await transcribeAudio(
-            fileURL: downloadResult.audioFileURL,
-            source: .youtube,
-            sttJob: .fileTranscription,
-            transcription: &transcription,
-            operation: operation,
-            tempFiles: [downloadResult.audioFileURL],
-            cleanUpDownloadedFiles: !keepDownloadedAudio,
-            onProgress: onProgress
-        )
+            onProgress?(.transcribing(percent: 0))
+            return try await transcribeAudio(
+                fileURL: downloadResult.audioFileURL,
+                source: .youtube,
+                sttJob: .fileTranscription,
+                transcription: &transcription,
+                operation: operation,
+                tempFiles: [downloadResult.audioFileURL],
+                cleanUpDownloadedFiles: !keepDownloadedAudio,
+                onProgress: onProgress
+            )
+        }
     }
 
     // MARK: - Private
@@ -1013,13 +1105,14 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         errorType: String? = nil
     ) {
         Telemetry.send(.transcriptionOperation(
-            operationID: operation.operationID,
+            operationID: operation.operationContext.operationID,
+            operationContext: operation.operationContext,
             outcome: outcome,
             source: operation.source,
             stage: stage,
-            durationSeconds: Observability.durationSeconds(since: operation.startedAt),
+            durationSeconds: Observability.durationSeconds(since: operation.operationContext.startedAt),
             audioDurationSeconds: audioDurationSeconds,
-            processingSeconds: processingSeconds ?? Observability.durationSeconds(since: operation.startedAt),
+            processingSeconds: processingSeconds ?? Observability.durationSeconds(since: operation.operationContext.startedAt),
             wordCount: wordCount,
             speakerCount: speakerCount,
             diarizationRequested: diarizationRequested,

--- a/Sources/MacParakeetViewModels/FeedbackViewModel.swift
+++ b/Sources/MacParakeetViewModels/FeedbackViewModel.swift
@@ -115,8 +115,7 @@ public final class FeedbackViewModel {
         submissionState = .submitting
         let trimmedMessage = message.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
-        let operationID = Observability.operationID()
-        let startedAt = Date()
+        let operationContext = Observability.childOperationContext()
 
         let payload = FeedbackPayload(
             category: category,
@@ -137,10 +136,11 @@ public final class FeedbackViewModel {
 
                 Telemetry.send(.feedbackSubmitted(category: payload.category.rawValue))
                 Telemetry.send(.feedbackOperation(
-                    operationID: operationID,
+                    operationID: operationContext.operationID,
+                    operationContext: operationContext,
                     category: payload.category.rawValue,
                     outcome: .success,
-                    durationSeconds: Observability.durationSeconds(since: startedAt),
+                    durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
                     screenshotAttached: payload.screenshotBase64 != nil,
                     systemInfoIncluded: true,
                     errorType: nil
@@ -158,10 +158,11 @@ public final class FeedbackViewModel {
             } catch {
                 guard !Task.isCancelled else { return }
                 Telemetry.send(.feedbackOperation(
-                    operationID: operationID,
+                    operationID: operationContext.operationID,
+                    operationContext: operationContext,
                     category: payload.category.rawValue,
                     outcome: .failure,
-                    durationSeconds: Observability.durationSeconds(since: startedAt),
+                    durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
                     screenshotAttached: payload.screenshotBase64 != nil,
                     systemInfoIncluded: true,
                     errorType: Observability.errorType(for: error)

--- a/Tests/MacParakeetTests/Services/AutoSaveServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/AutoSaveServiceTests.swift
@@ -1,6 +1,31 @@
 import XCTest
 @testable import MacParakeetCore
 
+private final class AutoSaveTelemetrySpy: TelemetryServiceProtocol, @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [TelemetryEventSpec] = []
+
+    func send(_ event: TelemetryEventSpec) {
+        lock.lock()
+        events.append(event)
+        lock.unlock()
+    }
+
+    func sendAndFlush(_ event: TelemetryEventSpec) async -> Bool {
+        send(event)
+        return true
+    }
+
+    func flush() async {}
+    func flushForTermination() {}
+
+    func snapshot() -> [TelemetryEventSpec] {
+        lock.lock()
+        defer { lock.unlock() }
+        return events
+    }
+}
+
 @MainActor
 final class AutoSaveServiceTests: XCTestCase {
 
@@ -17,6 +42,7 @@ final class AutoSaveServiceTests: XCTestCase {
     }
 
     override func tearDown() {
+        Telemetry.configure(NoOpTelemetryService())
         try? FileManager.default.removeItem(at: tempDir)
         if let name = defaults.volatileDomainNames.first {
             defaults.removeVolatileDomain(forName: name)
@@ -250,6 +276,29 @@ final class AutoSaveServiceTests: XCTestCase {
         let service = makeService()
         // Should not crash; auto-save silently skips when folder is gone
         service.saveIfEnabled(makeTranscription())
+    }
+
+    func testDeletedFolderEmitsUnavailableOperation() {
+        let telemetry = AutoSaveTelemetrySpy()
+        Telemetry.configure(telemetry)
+        configureAutoSave(enabled: true, format: .txt)
+        try! FileManager.default.removeItem(at: tempDir)
+
+        let service = makeService()
+        service.saveIfEnabled(makeTranscription())
+
+        let operation = telemetry.snapshot().reversed().first {
+            if case .autoSaveOperation = $0 { return true }
+            return false
+        }
+        guard let operation,
+              case .autoSaveOperation(_, _, let scope, let format, let outcome, _, let errorType) = operation else {
+            return XCTFail("Expected auto_save_operation telemetry")
+        }
+        XCTAssertEqual(scope, .transcription)
+        XCTAssertEqual(format, .txt)
+        XCTAssertEqual(outcome, .unavailable)
+        XCTAssertEqual(errorType, "folder_unavailable")
     }
 
     func testFallsBackToMarkdownForInvalidStoredFormat() {

--- a/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
@@ -61,6 +61,18 @@ private actor FailingYouTubeDownloader: YouTubeDownloading {
     }
 }
 
+private struct FailingEntitlements: EntitlementsChecking {
+    let error: Error
+
+    func assertCanTranscribe(now: Date) async throws {
+        throw error
+    }
+
+    func currentState(now: Date) async -> EntitlementsState {
+        EntitlementsState(access: .trialExpired(endedAt: now), licenseKeyMasked: nil, lastValidatedAt: nil)
+    }
+}
+
 final class TranscriptionServiceTests: XCTestCase {
     var service: TranscriptionService!
     var mockAudio: MockAudioProcessor!
@@ -130,6 +142,55 @@ final class TranscriptionServiceTests: XCTestCase {
         let all = try transcriptionRepo.fetchAll(limit: nil)
         XCTAssertEqual(all.count, 1)
         XCTAssertEqual(all[0].status, .error)
+    }
+
+    func testTranscribeFileEntitlementFailureEmitsPreflightOperation() async throws {
+        let telemetry = TelemetrySpy()
+        Telemetry.configure(telemetry)
+        let service = TranscriptionService(
+            audioProcessor: mockAudio,
+            sttTranscriber: mockSTT,
+            transcriptionRepo: transcriptionRepo,
+            entitlements: FailingEntitlements(error: EntitlementsError.trialExpired)
+        )
+
+        do {
+            _ = try await service.transcribe(fileURL: URL(fileURLWithPath: "/tmp/test.mp3"))
+            XCTFail("Should have thrown")
+        } catch EntitlementsError.trialExpired {
+            // Expected
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+
+        let operation = telemetry.snapshot().reversed().first {
+            if case .transcriptionOperation = $0 { return true }
+            return false
+        }
+        guard case .transcriptionOperation(
+            _,
+            _,
+            let outcome,
+            let source,
+            let stage,
+            _,
+            _,
+            _,
+            _,
+            _,
+            _,
+            _,
+            _,
+            _,
+            _,
+            let errorType
+        ) = try XCTUnwrap(operation) else {
+            return XCTFail("Expected transcription_operation telemetry")
+        }
+        XCTAssertEqual(outcome, .unavailable)
+        XCTAssertEqual(source, .file)
+        XCTAssertEqual(stage, .preflight)
+        XCTAssertEqual(errorType, "EntitlementsError.trialExpired")
     }
 
     func testTranscribeFileCancellationMarksRecordCancelled() async throws {

--- a/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
@@ -63,13 +63,28 @@ private actor FailingYouTubeDownloader: YouTubeDownloading {
 
 private struct FailingEntitlements: EntitlementsChecking {
     let error: Error
+    let state: EntitlementsState?
+
+    init(error: Error, state: EntitlementsState? = nil) {
+        self.error = error
+        self.state = state
+    }
 
     func assertCanTranscribe(now: Date) async throws {
         throw error
     }
 
     func currentState(now: Date) async -> EntitlementsState {
-        EntitlementsState(access: .trialExpired(endedAt: now), licenseKeyMasked: nil, lastValidatedAt: nil)
+        state ?? Self.state(for: error, now: now)
+    }
+
+    private static func state(for error: Error, now: Date) -> EntitlementsState {
+        switch error {
+        case EntitlementsError.trialExpired:
+            return EntitlementsState(access: .trialExpired(endedAt: now), licenseKeyMasked: nil, lastValidatedAt: nil)
+        default:
+            return EntitlementsState(access: .trialExpired(endedAt: now), licenseKeyMasked: nil, lastValidatedAt: nil)
+        }
     }
 }
 
@@ -147,6 +162,7 @@ final class TranscriptionServiceTests: XCTestCase {
     func testTranscribeFileEntitlementFailureEmitsPreflightOperation() async throws {
         let telemetry = TelemetrySpy()
         Telemetry.configure(telemetry)
+        defer { Telemetry.configure(NoOpTelemetryService()) }
         let service = TranscriptionService(
             audioProcessor: mockAudio,
             sttTranscriber: mockSTT,
@@ -167,30 +183,26 @@ final class TranscriptionServiceTests: XCTestCase {
             if case .transcriptionOperation = $0 { return true }
             return false
         }
-        guard case .transcriptionOperation(
-            _,
-            _,
-            let outcome,
-            let source,
-            let stage,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            let errorType
-        ) = try XCTUnwrap(operation) else {
-            return XCTFail("Expected transcription_operation telemetry")
-        }
-        XCTAssertEqual(outcome, .unavailable)
-        XCTAssertEqual(source, .file)
-        XCTAssertEqual(stage, .preflight)
-        XCTAssertEqual(errorType, "EntitlementsError.trialExpired")
+        let event = TelemetryEvent(
+            spec: try XCTUnwrap(operation),
+            appVer: "test",
+            osVer: "test",
+            locale: "en-US",
+            chip: "test",
+            session: "test"
+        )
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        let data = try encoder.encode(event)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let props = try XCTUnwrap(json["props"] as? [String: String])
+
+        XCTAssertEqual(json["event"] as? String, "transcription_operation")
+        XCTAssertEqual(props["outcome"], "unavailable")
+        XCTAssertEqual(props["source"], "file")
+        XCTAssertEqual(props["stage"], "preflight")
+        XCTAssertEqual(props["error_type"], "EntitlementsError.trialExpired")
+        XCTAssertNil(props["processing_seconds"])
     }
 
     func testTranscribeFileCancellationMarksRecordCancelled() async throws {
@@ -423,6 +435,7 @@ final class TranscriptionServiceTests: XCTestCase {
     func testTranscribeMeetingUsesFinalizeLaneAndMergesFreshSourceTranscriptsByAlignment() async throws {
         let telemetry = TelemetrySpy()
         Telemetry.configure(telemetry)
+        defer { Telemetry.configure(NoOpTelemetryService()) }
         let recordingFolder = URL(fileURLWithPath: AppPaths.tempDir)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: recordingFolder, withIntermediateDirectories: true)
@@ -904,6 +917,7 @@ final class TranscriptionServiceTests: XCTestCase {
     func testTranscribeMeetingSttFailureEmitsSttStageTelemetry() async throws {
         let telemetry = TelemetrySpy()
         Telemetry.configure(telemetry)
+        defer { Telemetry.configure(NoOpTelemetryService()) }
 
         let recordingFolder = URL(fileURLWithPath: AppPaths.tempDir)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -1062,6 +1076,7 @@ final class TranscriptionServiceTests: XCTestCase {
     func testTranscribeURLDownloadFailureEmitsDownloadStageTelemetry() async throws {
         let telemetry = TelemetrySpy()
         Telemetry.configure(telemetry)
+        defer { Telemetry.configure(NoOpTelemetryService()) }
         let downloader = FailingYouTubeDownloader(
             error: YouTubeDownloadError.downloadFailed("yt-dlp failed")
         )

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -445,6 +445,50 @@ final class TelemetryServiceTests: XCTestCase {
         XCTAssertNil(props["source_url"])
     }
 
+    func testOperationContextSerializesWorkflowParentAndStage() throws {
+        let context = ObservabilityOperationContext(
+            operationID: "op-meeting",
+            workflowID: "workflow-123",
+            parentOperationID: "op-cli",
+            startedAt: Date(timeIntervalSince1970: 0)
+        )
+        let event = TelemetryEvent(
+            spec: .meetingOperation(
+                operationID: context.operationID,
+                operationContext: context,
+                outcome: .failure,
+                trigger: .calendarAutoStart,
+                stage: .permissions,
+                durationSeconds: nil,
+                liveWordCount: nil,
+                liveTranscriptLagged: nil,
+                microphoneTrackPresent: nil,
+                systemTrackPresent: nil,
+                notesUsed: nil,
+                notesLengthBucket: nil,
+                errorType: "permission_denied"
+            ),
+            appVer: "0.4.2",
+            osVer: "15.3",
+            locale: "en-US",
+            chip: "Apple M1",
+            session: "test-session"
+        )
+
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        let data = try encoder.encode(event)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let props = try XCTUnwrap(json["props"] as? [String: String])
+
+        XCTAssertEqual(json["event"] as? String, "meeting_operation")
+        XCTAssertEqual(props["operation_id"], "op-meeting")
+        XCTAssertEqual(props["workflow_id"], "workflow-123")
+        XCTAssertEqual(props["parent_operation_id"], "op-cli")
+        XCTAssertEqual(props["stage"], "permissions")
+        XCTAssertEqual(props["error_type"], "permission_denied")
+    }
+
     func testDictationOperationDoesNotSerializeDeviceNameOrUID() throws {
         let device = RecordingDeviceInfo(
             deviceName: "Alice's Custom Microphone",

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -111,12 +111,15 @@ MacParakeet uses two event shapes together:
   `transcription_operation`, `meeting_operation`, `llm_operation`,
   `feedback_operation`, `auto_save_operation`, and `cli_operation` are wide,
   outcome-focused events emitted once per operation completion. They carry a
-  short-lived `operation_id`, `outcome`, duration, safe dimensions, and
-  `error_type` when relevant.
+  short-lived `operation_id`, `workflow_id`, optional `parent_operation_id`,
+  `outcome`, duration, safe dimensions, and `error_type` when relevant.
 
-Operation IDs are random UUIDs and are not persisted across app launches. They
-exist to correlate the start/end/failure breadcrumbs for one local operation
-inside one telemetry session, not to identify a user.
+Operation IDs and workflow IDs are random UUIDs and are not persisted across app
+launches. `workflow_id` lets child work, such as a transcription or LLM call,
+join back to its root operation without string matching. `parent_operation_id`
+links one child operation to the operation that started it. These IDs exist to
+correlate local operation breadcrumbs inside one telemetry session, not to
+identify a user.
 
 ### 1. App Lifecycle — "Who's using this?"
 
@@ -136,7 +139,7 @@ inside one telemetry session, not to identify a user.
 | `dictation_cancelled` | `duration_seconds`, `reason` (escape, hotkey, silence), `device_*` | Are people cancelling often? Why? |
 | `dictation_empty` | `duration_seconds`, `device_*` | Are people getting empty results? (quality signal) |
 | `dictation_failed` | `error_type`, `device_*` | Core feature failures — blind spot without this |
-| `dictation_operation` | `operation_id`, `outcome`, `trigger`, `mode`, `duration_seconds`, `word_count`, `error_type`, `device_*` | One wide outcome event per dictation attempt |
+| `dictation_operation` | `operation_id`, `workflow_id`, `parent_operation_id`, `outcome`, `trigger`, `mode`, `duration_seconds`, `word_count`, `error_type`, `device_*` | One wide outcome event per dictation attempt |
 
 > **Device props** (optional, included when available): `device_transport`, `device_sub_transport`, `device_sample_rate`, `device_channels`, `device_fallback`, `device_selected`. Raw device names and UIDs are intentionally not serialized.
 
@@ -148,9 +151,15 @@ inside one telemetry session, not to identify a user.
 | `transcription_completed` | `source`, `audio_duration_seconds`, `processing_seconds`, `word_count`, `speaker_count`, `diarization_requested`, `diarization_applied` | Real-world performance and speaker-label coverage across file, YouTube, and meeting pipelines |
 | `transcription_cancelled` | `source`, `audio_duration_seconds`, `stage` (download, audio_conversion, stt, diarization, post_processing) | Where do users abandon jobs? |
 | `transcription_failed` | `source`, `stage`, `error_type` | What's breaking, and in which pipeline stage? |
-| `transcription_operation` | `operation_id`, `outcome`, `source`, `stage`, `duration_seconds`, `audio_duration_seconds`, `processing_seconds`, `word_count`, `speaker_count`, `diarization_requested`, `diarization_applied`, `input_kind`, `media_extension`, `file_size_bucket`, `error_type` | One wide outcome event per file, YouTube, or meeting transcription |
+| `transcription_operation` | `operation_id`, `workflow_id`, `parent_operation_id`, `outcome`, `source`, `stage`, `duration_seconds`, `audio_duration_seconds`, `processing_seconds`, `word_count`, `speaker_count`, `diarization_requested`, `diarization_applied`, `input_kind`, `media_extension`, `file_size_bucket`, `error_type` | One wide outcome event per file, YouTube, or meeting transcription |
 
-`transcription_operation` is the broad product-health outcome event. `transcription_completed` remains the stable success breadcrumb/performance event. For meetings, the app always treats the final transcript as fresh batch STT over the recorded source artifacts, not reused live-preview metadata. The separate `diarization_*` events remain useful for diarization-specific timing and failure analysis.
+`transcription_operation` is the broad product-health outcome event. Its
+`stage` values are `preflight`, `download`, `audio_conversion`, `stt`,
+`diarization`, `post_processing`, and `persistence`. `transcription_completed`
+remains the stable success breadcrumb/performance event. For meetings, the app
+always treats the final transcript as fresh batch STT over the recorded source
+artifacts, not reused live-preview metadata. The separate `diarization_*`
+events remain useful for diarization-specific timing and failure analysis.
 
 ### 3b. Speaker Diarization — "Is speaker detection working?"
 
@@ -171,14 +180,14 @@ inside one telemetry session, not to identify a user.
 | `llm_chat_failed` | `provider`, `error_type` | Chat failure rates per provider |
 | `llm_formatter_used` | `provider`, `source`, `duration_seconds`, `input_chars`, `output_chars`, `default_prompt_used`, `input_truncated` | Is transcript/dictation formatting useful, and how expensive is it? |
 | `llm_formatter_failed` | `provider`, `source`, `duration_seconds`, `error_type`, `default_prompt_used`, `input_truncated` | Formatter failure rates and prompt-shape correlations |
-| `llm_operation` | `operation_id`, `feature`, `provider`, `streaming`, `outcome`, `duration_seconds`, `input_chars`, `output_chars`, `input_truncated`, `prompt_default_used`, `message_count`, `error_type` | One safe outcome event per LLM call, without prompts, responses, or provider error bodies |
+| `llm_operation` | `operation_id`, `workflow_id`, `parent_operation_id`, `feature`, `provider`, `streaming`, `outcome`, `duration_seconds`, `input_chars`, `output_chars`, `input_truncated`, `prompt_default_used`, `message_count`, `error_type` | One safe outcome event per LLM call, without prompts, responses, or provider error bodies |
 | `history_searched` | — | Is search useful? |
 | `history_replayed` | — | Do people re-listen to audio? |
 | `copy_to_clipboard` | `source` (dictation, transcription, history, meeting, discover) | How do people get text out? |
 | `keystroke_snippet_fired` | — | Are keystroke action snippets being used? |
 | `feedback_submitted` | `category` (bug, featureRequest, other) | Feedback volume and sentiment split |
-| `feedback_operation` | `operation_id`, `category`, `outcome`, `duration_seconds`, `screenshot_attached`, `system_info_included`, `error_type` | Feedback delivery health without storing message text or email |
-| `auto_save_operation` | `operation_id`, `scope`, `format`, `outcome`, `duration_seconds`, `error_type` | Whether transcript/meeting auto-save succeeds for configured users |
+| `feedback_operation` | `operation_id`, `workflow_id`, `parent_operation_id`, `category`, `outcome`, `duration_seconds`, `screenshot_attached`, `system_info_included`, `error_type` | Feedback delivery health without storing message text or email |
+| `auto_save_operation` | `operation_id`, `workflow_id`, `parent_operation_id`, `scope`, `format`, `outcome`, `duration_seconds`, `error_type` | Whether transcript/meeting auto-save succeeds for configured users |
 | `transcription_deleted` | — | Are users cleaning up transcriptions? |
 | `dictation_deleted` | — | History hygiene patterns |
 | `transcription_favorited` | `is_favorite` (true/false) | Which content types get saved? |
@@ -203,7 +212,10 @@ inside one telemetry session, not to identify a user.
 | `meeting_recording_completed` | `duration_seconds`, `live_word_count`, `live_transcript_lagged` | Recording duration and live-preview quality |
 | `meeting_recording_cancelled` | `duration_seconds` | How often recordings are intentionally discarded |
 | `meeting_recording_failed` | `error_type` | What blocks recording/finalization |
-| `meeting_operation` | `operation_id`, `outcome`, `trigger`, `duration_seconds`, `live_word_count`, `live_transcript_lagged`, `microphone_track_present`, `system_track_present`, `notes_used`, `notes_length_bucket`, `error_type` | One wide outcome event for the full meeting capture + transcription flow |
+| `meeting_operation` | `operation_id`, `workflow_id`, `parent_operation_id`, `outcome`, `trigger`, `stage`, `duration_seconds`, `live_word_count`, `live_transcript_lagged`, `microphone_track_present`, `system_track_present`, `notes_used`, `notes_length_bucket`, `error_type` | One wide outcome event for the full meeting capture + transcription flow |
+
+`meeting_operation.stage` values are `permissions`, `start_recording`,
+`stop_recording`, `transcription`, `complete_transcription`, and `cancel`.
 
 ### 5. Settings & Customization — "How do people configure the app?"
 
@@ -259,7 +271,7 @@ inside one telemetry session, not to identify a user.
 
 | Event | Props | Question It Answers |
 |---|---|---|
-| `cli_operation` | `operation_id`, `command`, `subcommand`, `outcome`, `duration_seconds`, `input_kind`, `output_format`, `json`, `exit_code`, `error_type` | Which CLI workflows are used by scripts/agents, and where they fail |
+| `cli_operation` | `operation_id`, `workflow_id`, `parent_operation_id`, `command`, `subcommand`, `outcome`, `duration_seconds`, `input_kind`, `output_format`, `json`, `exit_code`, `error_type` | Which CLI workflows are used by scripts/agents, and where they fail |
 
 CLI telemetry is initialized by `macparakeet-cli transcribe` and uses the same
 app preference as the GUI. Users and automation can also set
@@ -289,8 +301,10 @@ Telemetry.send(.dictationCompleted(
     mode: .hold
 ))
 
+let operationContext = Observability.childOperationContext()
 Telemetry.send(.transcriptionOperation(
-    operationID: Observability.operationID(),
+    operationID: operationContext.operationID,
+    operationContext: operationContext,
     outcome: .success,
     source: .file,
     stage: .postProcessing,


### PR DESCRIPTION
## Summary

This is the follow-up from the telemetry/observability review of PR #161. It turns operation telemetry into a cleaner wide-event contract: every attempted operation should have a terminal outcome, and related operations can be joined without string matching.

- Add `ObservabilityOperationContext` with `operation_id`, `workflow_id`, and optional `parent_operation_id`.
- Serialize correlation IDs on canonical operation events: CLI, transcription, meeting, dictation, LLM, feedback, and auto-save.
- Emit terminal operation events for failures that happen before normal work starts: transcription entitlement/DB preflight, meeting permissions/start failures, dictation entitlement failure, YouTube downloader unavailable, and auto-save missing folder.
- Add low-cardinality stages for meeting and transcription outcomes so dashboards can ask useful health questions by source/stage/provider.
- Add focused tests for event serialization and the new preflight/folder-failure terminal events.

## Event Model

```text
workflow_id: wf-123

cli_operation              operation_id=cli-1      parent=nil
  |
  +-- transcription_operation operation_id=tx-1    parent=cli-1

meeting_operation          operation_id=mtg-1      parent=nil
  |
  +-- transcription_operation operation_id=tx-2    parent=mtg-1

 dictation_operation       operation_id=dict-1     parent=nil
  |
  +-- llm_operation        operation_id=llm-1      parent=dict-1

 feedback_operation        operation_id=fb-1       parent=<current op when present>
 auto_save_operation       operation_id=save-1     parent=<current op when present>
```

This keeps operation health queryable at two levels:

- Per-operation health: success rate by `event_type`, `operation`, `source`, `stage`, and `provider`.
- Workflow health: join child work back to its root through `workflow_id` and `parent_operation_id`.

## Dashboard Queries This Enables

- Success/failure/unavailable counts by operation type.
- Transcription failure rate by `source` and `stage` (`preflight`, `download`, `transcription`, `persistence`, etc.).
- Meeting failure rate by `stage` (`permissions`, `start_recording`, `stop_recording`, `transcription`, `complete_transcription`).
- Top `error_type` by operation and stage.
- CLI outcomes joined to child transcription outcomes.
- Auto-save unavailable events caused by a missing configured folder.

## Notes

The companion stats/dashboard API work lives in the website repo, outside this app/core/CLI PR. This PR focuses on the emitted event contract and client-side operation coverage.

## Tests

- `swift test`
- `git diff --check --cached`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  - Enhanced observability tracking with workflow context and operation stages to better diagnose issues across meeting recordings, transcriptions, and auto-save operations.
  - Improved error diagnostics with detailed operation stages (preflight, persistence, recording, transcription) for better troubleshooting.

* **Bug Fixes**
  - Auto-save operations now properly report unavailable status when the configured folder is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->