### PR TITLE
Update FluidAudio to 0.14.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio",
       "state" : {
-        "revision" : "57551cd90e0bbec342766244358bcf08afb05290",
-        "version" : "0.13.6"
+        "revision" : "d302273d49ef4d8914b27f20d342be482e8810f1",
+        "version" : "0.14.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         // GRDB for SQLite (dictation history + transcription records)
         .package(url: "https://github.com/groue/GRDB.swift", from: "7.0.0"),
         // FluidAudio for Parakeet STT on CoreML/ANE
-        .package(url: "https://github.com/FluidInference/FluidAudio", .upToNextMinor(from: "0.13.6")),
+        .package(url: "https://github.com/FluidInference/FluidAudio", .upToNextMinor(from: "0.14.1")),
         // ArgumentParser for CLI
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
         // Sparkle for auto-updates (non-App Store distribution)

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -79,7 +79,9 @@ public actor STTRuntime: STTRuntimeProtocol {
 
         do {
             try Task.checkCancellation()
-            let result = try await manager.transcribe(audioURL)
+            let decoderLayers = await manager.decoderLayerCount
+            var decoderState = TdtDecoderState.make(decoderLayers: decoderLayers)
+            let result = try await manager.transcribe(audioURL, decoderState: &decoderState)
             let words = Self.mergeTokenTimingsIntoWords(result.tokenTimings)
             onProgress?(100, 100)
             return STTResult(text: result.text, words: words)

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -26,6 +26,7 @@ public actor STTRuntime: STTRuntimeProtocol {
     private var interactiveManager: AsrManager?
     private var backgroundManager: AsrManager?
     private var models: AsrModels?
+    private var decoderLayerCount: Int?
     private var initializationTask: Task<Void, Error>?
     private var initializationGeneration: UInt64 = 0
     private var warmUpProgressHandler: (@Sendable (String) -> Void)?
@@ -49,6 +50,9 @@ public actor STTRuntime: STTRuntimeProtocol {
 
         let slot = route(for: job)
         guard let manager = manager(for: slot) else {
+            throw STTError.modelNotLoaded
+        }
+        guard let decoderLayers = decoderLayerCount else {
             throw STTError.modelNotLoaded
         }
 
@@ -79,8 +83,8 @@ public actor STTRuntime: STTRuntimeProtocol {
 
         do {
             try Task.checkCancellation()
-            let decoderLayers = await manager.decoderLayerCount
             var decoderState = TdtDecoderState.make(decoderLayers: decoderLayers)
+            try Task.checkCancellation()
             let result = try await manager.transcribe(audioURL, decoderState: &decoderState)
             let words = Self.mergeTokenTimingsIntoWords(result.tokenTimings)
             onProgress?(100, 100)
@@ -194,6 +198,7 @@ public actor STTRuntime: STTRuntimeProtocol {
         self.interactiveManager = nil
         self.backgroundManager = nil
         self.models = nil
+        self.decoderLayerCount = nil
         await Self.cleanupManagers(
             interactiveManager: interactiveManager,
             backgroundManager: backgroundManager
@@ -313,10 +318,12 @@ public actor STTRuntime: STTRuntimeProtocol {
                 backgroundManager = loadedBackgroundManager
                 try await loadedInteractiveManager.loadModels(downloadedModels)
                 try await loadedBackgroundManager.loadModels(downloadedModels)
+                let loadedDecoderLayerCount = await loadedInteractiveManager.decoderLayerCount
                 try Task.checkCancellation()
                 try await self.completeInitialization(
                     generation: generation,
                     models: downloadedModels,
+                    decoderLayerCount: loadedDecoderLayerCount,
                     interactiveManager: loadedInteractiveManager,
                     backgroundManager: loadedBackgroundManager
                 )
@@ -349,6 +356,7 @@ public actor STTRuntime: STTRuntimeProtocol {
     private func completeInitialization(
         generation: UInt64,
         models: AsrModels,
+        decoderLayerCount: Int,
         interactiveManager: AsrManager,
         backgroundManager: AsrManager
     ) async throws {
@@ -357,6 +365,7 @@ public actor STTRuntime: STTRuntimeProtocol {
         }
         try Task.checkCancellation()
         self.models = models
+        self.decoderLayerCount = decoderLayerCount
         self.interactiveManager = interactiveManager
         self.backgroundManager = backgroundManager
     }


### PR DESCRIPTION
## Summary

Updates MacParakeet's FluidAudio dependency from `0.13.6` to the current stable `0.14.1` release.

This keeps the app current with upstream FluidAudio while preserving the existing MacParakeet STT architecture: one shared runtime, scheduled execution lanes, and FluidAudio's built-in offline diarization pipeline.

## What Changed

- Bumped the SwiftPM FluidAudio constraint to `0.14.1`.
- Resolved `Package.resolved` to FluidAudio `0.14.1` at `d302273d49ef4d8914b27f20d342be482e8810f1`.
- Updated `STTRuntime` for FluidAudio's newer ASR API, which now requires an explicit `TdtDecoderState` when transcribing file URLs.

## Compatibility Notes

FluidAudio now exposes decoder state as caller-owned API surface. MacParakeet creates a fresh decoder state per transcription job and sizes it from the loaded `AsrManager.decoderLayerCount`, so the call remains compatible with v2/v3 and other supported Parakeet model variants.

No app data, model cache paths, database schema, diarization merge behavior, or public CLI arguments are changed by this PR.

## Why This Matters

The repo was pinned to `0.13.6`, missing later stable FluidAudio fixes including the post-0.13.6 offline diarization improvements. This PR moves MacParakeet back onto the latest stable upstream line without broadening the blast radius beyond the dependency/API adaptation.

## Verification

- `swift build`
- `swift test`
  - 1,783 XCTest tests passed
  - 13 Swift Testing tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated audio library dependency to version 0.14.1

* **Improvements**
  * Enhanced speech transcription processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->