### PR TITLE
Add one-off engine retry for meeting retranscription

### DIFF
--- a/Sources/MacParakeet/Views/Transcription/TranscribeView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscribeView.swift
@@ -63,8 +63,8 @@ struct TranscribeView: View {
                         onStartNew: {
                             viewModel.showInputPortal()
                         },
-                        onRetranscribe: { original in
-                            viewModel.retranscribe(original)
+                        onRetranscribe: { original, speechEngineOverride in
+                            viewModel.retranscribe(original, speechEngineOverride: speechEngineOverride)
                         }
                     )
                 } else if viewModel.isTranscribing {

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -13,6 +13,34 @@ private struct ExportConfirmation: Identifiable {
     let format: String
 }
 
+private struct RetranscriptionConfirmation: Identifiable {
+    let id = UUID()
+    let speechEngineOverride: SpeechEngineSelection?
+
+    var title: String {
+        if let speechEngineOverride {
+            "Try with \(speechEngineOverride.engine.displayName)?"
+        } else {
+            "Retranscribe this file?"
+        }
+    }
+
+    var confirmLabel: String {
+        if let speechEngineOverride {
+            "Try with \(speechEngineOverride.engine.displayName)"
+        } else {
+            "Retranscribe"
+        }
+    }
+
+    var message: String {
+        if let speechEngineOverride {
+            return "This reruns the saved audio with \(speechEngineOverride.engine.displayName) for this attempt only. Meeting metadata and Settings stay unchanged. Existing prompt results and chats are preserved, but may no longer match the updated transcript."
+        }
+        return "This replaces the transcript text in place. Existing prompt results and chats are preserved, but may no longer match the updated transcript."
+    }
+}
+
 private enum TranscriptDisplayMode: String, CaseIterable, Hashable {
     case text = "Text"
     case timed = "Timed"
@@ -26,7 +54,7 @@ struct TranscriptResultView: View {
     @Bindable var promptsViewModel: PromptsViewModel
     var onBack: (() -> Void)?
     var onStartNew: (() -> Void)?
-    var onRetranscribe: ((Transcription) -> Void)?
+    var onRetranscribe: ((Transcription, SpeechEngineSelection?) -> Void)?
 
     @State private var backHovered = false
     @State private var headerExpanded = false
@@ -71,7 +99,8 @@ struct TranscriptResultView: View {
     @State private var scrollMonitor: Any?
     @State private var showPromptLibrary = false
     @State private var showGeneratePopover = false
-    @State private var showingRetranscribeAlert = false
+    @State private var retranscriptionConfirmation: RetranscriptionConfirmation?
+    @State private var showingEngineComparisonPopover = false
     @State private var showingCancelGenerationAlert: UUID?
     @FocusState private var chatInputFocused: Bool
     @FocusState private var meetingTitleFocused: Bool
@@ -387,21 +416,32 @@ struct TranscriptResultView: View {
                 exportOptionsPopover
             }
 
-            if let onRetranscribe, let filePath = transcription.filePath,
+            if onRetranscribe != nil, let filePath = transcription.filePath,
                FileManager.default.fileExists(atPath: filePath) {
                 Button {
-                    showingRetranscribeAlert = true
+                    retranscriptionConfirmation = RetranscriptionConfirmation(speechEngineOverride: nil)
                 } label: {
                     Label("Retranscribe", systemImage: "arrow.trianglehead.2.clockwise")
                 }
                 .buttonStyle(.bordered)
-                .alert("Retranscribe this file?", isPresented: $showingRetranscribeAlert) {
-                    Button("Cancel", role: .cancel) { }
-                    Button("Retranscribe", role: .destructive) {
-                        onRetranscribe(transcription)
+
+                if let option = viewModel.retranscriptionEngineOption(for: transcription) {
+                    Button {
+                        retranscriptionConfirmation = RetranscriptionConfirmation(
+                            speechEngineOverride: option.alternativeEngine
+                        )
+                    } label: {
+                        Label(option.title, systemImage: "arrow.triangle.2.circlepath")
                     }
-                } message: {
-                    Text("This replaces the transcript text in place. Existing prompt results and chats are preserved, but may no longer match the updated transcript.")
+                    .buttonStyle(.bordered)
+                    .disabled(!option.isAlternativeAvailable)
+                    .help(engineComparisonHelp(for: option))
+                    .onHover { hovering in
+                        showingEngineComparisonPopover = hovering && option.isAlternativeAvailable
+                    }
+                    .popover(isPresented: $showingEngineComparisonPopover, arrowEdge: .top) {
+                        engineComparisonPopover
+                    }
                 }
             }
 
@@ -418,9 +458,74 @@ struct TranscriptResultView: View {
             Spacer()
         }
         .padding(DesignSystem.Spacing.md)
+        .alert(item: $retranscriptionConfirmation) { confirmation in
+            Alert(
+                title: Text(confirmation.title),
+                message: Text(confirmation.message),
+                primaryButton: .destructive(Text(confirmation.confirmLabel)) {
+                    onRetranscribe?(transcription, confirmation.speechEngineOverride)
+                },
+                secondaryButton: .cancel()
+            )
+        }
         .popover(item: $exportConfirmation, arrowEdge: .top) { confirmation in
             exportConfirmationPopover(confirmation)
         }
+    }
+
+    private var engineComparisonPopover: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            Text("Engine tradeoffs")
+                .font(DesignSystem.Typography.caption.weight(.semibold))
+
+            Grid(alignment: .leading, horizontalSpacing: DesignSystem.Spacing.md, verticalSpacing: 6) {
+                GridRow {
+                    engineComparisonHeader("Engine")
+                    engineComparisonHeader("Best for")
+                    engineComparisonHeader("Language coverage")
+                }
+                GridRow {
+                    engineComparisonCell("Parakeet")
+                    engineComparisonCell("Fast reruns")
+                    engineComparisonCell("25 European languages, including English")
+                }
+                GridRow {
+                    engineComparisonCell("Whisper")
+                    engineComparisonCell("Broader language retry")
+                    engineComparisonCell("Korean, Chinese, Japanese, and more")
+                }
+            }
+
+            Text("Trying another engine affects only this rerun.")
+                .font(DesignSystem.Typography.caption)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+        }
+        .padding(DesignSystem.Spacing.md)
+        .frame(width: 430)
+    }
+
+    private func engineComparisonHeader(_ text: String) -> some View {
+        Text(text)
+            .font(DesignSystem.Typography.caption.weight(.semibold))
+            .foregroundStyle(DesignSystem.Colors.textSecondary)
+    }
+
+    private func engineComparisonCell(_ text: String) -> some View {
+        Text(text)
+            .font(DesignSystem.Typography.caption)
+            .foregroundStyle(DesignSystem.Colors.textPrimary)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private func engineComparisonHelp(
+        for option: TranscriptionViewModel.RetranscriptionEngineOption
+    ) -> String {
+        let unavailable = option.unavailableReason.map { "\n\n\($0)" } ?? ""
+        return """
+        Parakeet: faster local reruns; 25 European languages, including English.
+        Whisper: slower, broader multilingual coverage for Korean, Chinese, Japanese, and more.
+        This changes only this rerun.\(unavailable)
+        """
     }
 
     private var activeTranscription: Transcription {

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -35,7 +35,13 @@ private struct RetranscriptionConfirmation: Identifiable {
 
     var message: String {
         if let speechEngineOverride {
-            return "This reruns the saved audio with \(speechEngineOverride.engine.displayName) for this attempt only. Meeting metadata and Settings stay unchanged. Existing prompt results and chats are preserved, but may no longer match the updated transcript."
+            let languageSuffix: String
+            if speechEngineOverride.engine == .whisper {
+                languageSuffix = " Whisper language: \(speechEngineOverride.language ?? "auto-detect")."
+            } else {
+                languageSuffix = ""
+            }
+            return "This reruns the saved audio with \(speechEngineOverride.engine.displayName) for this attempt only.\(languageSuffix) Meeting metadata and Settings stay unchanged. Existing prompt results and chats are preserved, but may no longer match the updated transcript."
         }
         return "This replaces the transcript text in place. Existing prompt results and chats are preserved, but may no longer match the updated transcript."
     }
@@ -426,21 +432,30 @@ struct TranscriptResultView: View {
                 .buttonStyle(.bordered)
 
                 if let option = viewModel.retranscriptionEngineOption(for: transcription) {
-                    Button {
-                        retranscriptionConfirmation = RetranscriptionConfirmation(
-                            speechEngineOverride: option.alternativeEngine
-                        )
-                    } label: {
-                        Label(option.title, systemImage: "arrow.triangle.2.circlepath")
-                    }
-                    .buttonStyle(.bordered)
-                    .disabled(!option.isAlternativeAvailable)
-                    .help(engineComparisonHelp(for: option))
-                    .onHover { hovering in
-                        showingEngineComparisonPopover = hovering && option.isAlternativeAvailable
-                    }
-                    .popover(isPresented: $showingEngineComparisonPopover, arrowEdge: .top) {
-                        engineComparisonPopover
+                    HStack(spacing: 4) {
+                        Button {
+                            retranscriptionConfirmation = RetranscriptionConfirmation(
+                                speechEngineOverride: option.alternativeEngine
+                            )
+                        } label: {
+                            Label(option.title, systemImage: "arrow.triangle.2.circlepath")
+                        }
+                        .buttonStyle(.bordered)
+                        .disabled(!option.isAlternativeAvailable)
+                        .help(engineComparisonHelp(for: option))
+
+                        Button {
+                            showingEngineComparisonPopover.toggle()
+                        } label: {
+                            Image(systemName: "info.circle")
+                                .accessibilityLabel("Compare speech engines")
+                        }
+                        .buttonStyle(.borderless)
+                        .frame(width: 28, height: 28)
+                        .help("Compare Parakeet and Whisper")
+                        .popover(isPresented: $showingEngineComparisonPopover, arrowEdge: .top) {
+                            engineComparisonPopover(for: option)
+                        }
                     }
                 }
             }
@@ -458,22 +473,37 @@ struct TranscriptResultView: View {
             Spacer()
         }
         .padding(DesignSystem.Spacing.md)
-        .alert(item: $retranscriptionConfirmation) { confirmation in
-            Alert(
-                title: Text(confirmation.title),
-                message: Text(confirmation.message),
-                primaryButton: .destructive(Text(confirmation.confirmLabel)) {
-                    onRetranscribe?(transcription, confirmation.speechEngineOverride)
-                },
-                secondaryButton: .cancel()
-            )
+        .alert(
+            retranscriptionConfirmation?.title ?? "Retranscribe this file?",
+            isPresented: isRetranscriptionConfirmationPresented,
+            presenting: retranscriptionConfirmation
+        ) { confirmation in
+            Button(confirmation.confirmLabel, role: .destructive) {
+                onRetranscribe?(transcription, confirmation.speechEngineOverride)
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: { confirmation in
+            Text(confirmation.message)
         }
         .popover(item: $exportConfirmation, arrowEdge: .top) { confirmation in
             exportConfirmationPopover(confirmation)
         }
     }
 
-    private var engineComparisonPopover: some View {
+    private var isRetranscriptionConfirmationPresented: Binding<Bool> {
+        Binding(
+            get: { retranscriptionConfirmation != nil },
+            set: { isPresented in
+                if !isPresented {
+                    retranscriptionConfirmation = nil
+                }
+            }
+        )
+    }
+
+    private func engineComparisonPopover(
+        for option: TranscriptionViewModel.RetranscriptionEngineOption
+    ) -> some View {
         VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
             Text("Engine tradeoffs")
                 .font(DesignSystem.Typography.caption.weight(.semibold))
@@ -499,6 +529,18 @@ struct TranscriptResultView: View {
             Text("Trying another engine affects only this rerun.")
                 .font(DesignSystem.Typography.caption)
                 .foregroundStyle(DesignSystem.Colors.textSecondary)
+
+            if option.alternativeEngine.engine == .whisper {
+                Text("Whisper language: \(option.alternativeEngine.language ?? "auto-detect").")
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+            }
+
+            if let unavailableReason = option.unavailableReason {
+                Text(unavailableReason)
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+            }
         }
         .padding(DesignSystem.Spacing.md)
         .frame(width: 430)

--- a/Sources/MacParakeetCore/Services/MeetingRecordingMetadata.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecordingMetadata.swift
@@ -53,6 +53,7 @@ public struct MeetingRecordingMetadata: Sendable, Codable, Equatable {
 
     public let sourceAlignment: MeetingSourceAlignment
     public let speechEngine: SpeechEngineSelection
+    public let speechEngineWasCaptured: Bool
 
     public init(
         sourceAlignment: MeetingSourceAlignment,
@@ -60,6 +61,7 @@ public struct MeetingRecordingMetadata: Sendable, Codable, Equatable {
     ) {
         self.sourceAlignment = sourceAlignment
         self.speechEngine = speechEngine
+        self.speechEngineWasCaptured = true
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -70,8 +72,9 @@ public struct MeetingRecordingMetadata: Sendable, Codable, Equatable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         sourceAlignment = try container.decode(MeetingSourceAlignment.self, forKey: .sourceAlignment)
-        speechEngine = try container.decodeIfPresent(SpeechEngineSelection.self, forKey: .speechEngine)
-            ?? SpeechEngineSelection(engine: .parakeet)
+        let decodedSpeechEngine = try container.decodeIfPresent(SpeechEngineSelection.self, forKey: .speechEngine)
+        speechEngine = decodedSpeechEngine ?? SpeechEngineSelection(engine: .parakeet)
+        speechEngineWasCaptured = decodedSpeechEngine != nil
     }
 }
 

--- a/Sources/MacParakeetCore/Services/MeetingRecordingOutput.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecordingOutput.swift
@@ -10,6 +10,7 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
     public let durationSeconds: TimeInterval
     public let sourceAlignment: MeetingSourceAlignment
     public let speechEngine: SpeechEngineSelection
+    public let speechEngineWasCaptured: Bool
     /// Free-form notes the user typed during the meeting, captured at finalize
     /// time. Threaded through to `Transcription.userNotes` by the caller so
     /// post-meeting summary generation can steer on what the user emphasized
@@ -26,6 +27,7 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
         durationSeconds: TimeInterval,
         sourceAlignment: MeetingSourceAlignment,
         speechEngine: SpeechEngineSelection = SpeechEngineSelection(engine: .parakeet),
+        speechEngineWasCaptured: Bool = true,
         userNotes: String? = nil
     ) {
         self.sessionID = sessionID
@@ -37,6 +39,7 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
         self.durationSeconds = durationSeconds
         self.sourceAlignment = sourceAlignment
         self.speechEngine = speechEngine
+        self.speechEngineWasCaptured = speechEngineWasCaptured
         self.userNotes = userNotes
     }
 
@@ -69,7 +72,8 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
             systemAudioURL: systemAudioURL,
             durationSeconds: durationSeconds,
             sourceAlignment: metadata.sourceAlignment,
-            speechEngine: metadata.speechEngine
+            speechEngine: metadata.speechEngine,
+            speechEngineWasCaptured: metadata.speechEngineWasCaptured
         )
     }
 }

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -25,6 +25,22 @@ public protocol TranscriptionServiceProtocol: Sendable {
     func transcribeURL(urlString: String, onProgress: (@Sendable (TranscriptionProgress) -> Void)?) async throws -> Transcription
 }
 
+public protocol SpeechEngineOverrideTranscriptionService: TranscriptionServiceProtocol {
+    func retranscribe(
+        existing transcription: Transcription,
+        fileURL: URL,
+        source: TelemetryTranscriptionSource,
+        speechEngineOverride: SpeechEngineSelection?,
+        onProgress: (@Sendable (TranscriptionProgress) -> Void)?
+    ) async throws -> Transcription
+    func retranscribeMeeting(
+        existing transcription: Transcription,
+        recording: MeetingRecordingOutput,
+        speechEngineOverride: SpeechEngineSelection?,
+        onProgress: (@Sendable (TranscriptionProgress) -> Void)?
+    ) async throws -> Transcription
+}
+
 extension TranscriptionServiceProtocol {
     public func transcribe(fileURL: URL) async throws -> Transcription {
         try await transcribe(fileURL: fileURL, source: .file, onProgress: nil)
@@ -61,6 +77,61 @@ extension TranscriptionServiceProtocol {
     ) async throws -> Transcription {
         try await transcribeMeeting(recording: recording, onProgress: onProgress)
     }
+
+    public func retranscribe(
+        existing transcription: Transcription,
+        fileURL: URL,
+        source: TelemetryTranscriptionSource,
+        speechEngineOverride: SpeechEngineSelection?,
+        onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
+    ) async throws -> Transcription {
+        guard let speechEngineOverride else {
+            return try await retranscribe(
+                existing: transcription,
+                fileURL: fileURL,
+                source: source,
+                onProgress: onProgress
+            )
+        }
+        guard let routedService = self as? any SpeechEngineOverrideTranscriptionService else {
+            throw STTError.engineStartFailed(
+                "Pinned \(speechEngineOverride.engine.rawValue) speech engine cannot be honored by this transcription service."
+            )
+        }
+        return try await routedService.retranscribe(
+            existing: transcription,
+            fileURL: fileURL,
+            source: source,
+            speechEngineOverride: speechEngineOverride,
+            onProgress: onProgress
+        )
+    }
+
+    public func retranscribeMeeting(
+        existing transcription: Transcription,
+        recording: MeetingRecordingOutput,
+        speechEngineOverride: SpeechEngineSelection?,
+        onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
+    ) async throws -> Transcription {
+        guard let speechEngineOverride else {
+            return try await retranscribeMeeting(
+                existing: transcription,
+                recording: recording,
+                onProgress: onProgress
+            )
+        }
+        guard let routedService = self as? any SpeechEngineOverrideTranscriptionService else {
+            throw STTError.engineStartFailed(
+                "Pinned \(speechEngineOverride.engine.rawValue) speech engine cannot be honored by this transcription service."
+            )
+        }
+        return try await routedService.retranscribeMeeting(
+            existing: transcription,
+            recording: recording,
+            speechEngineOverride: speechEngineOverride,
+            onProgress: onProgress
+        )
+    }
 }
 
 private struct TranscriptionOperationContext: Sendable {
@@ -85,7 +156,7 @@ private struct TranscriptionOperationContext: Sendable {
     }
 }
 
-public actor TranscriptionService: TranscriptionServiceProtocol {
+public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
     private let logger = Logger(subsystem: "com.macparakeet.core", category: "TranscriptionService")
     private let audioProcessor: AudioProcessorProtocol
     private let sttTranscriber: STTTranscribing
@@ -219,6 +290,22 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         source: TelemetryTranscriptionSource,
         onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
     ) async throws -> Transcription {
+        try await retranscribe(
+            existing: original,
+            fileURL: fileURL,
+            source: source,
+            speechEngineOverride: nil,
+            onProgress: onProgress
+        )
+    }
+
+    public func retranscribe(
+        existing original: Transcription,
+        fileURL: URL,
+        source: TelemetryTranscriptionSource,
+        speechEngineOverride: SpeechEngineSelection? = nil,
+        onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
+    ) async throws -> Transcription {
         var transcription = makeRetranscriptionRecord(from: original)
         transcription.fileSizeBytes = (try? FileManager.default.attributesOfItem(atPath: fileURL.path)[.size] as? Int)
             .flatMap { $0 } ?? original.fileSizeBytes
@@ -242,6 +329,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
                 operation: operation,
                 tempFiles: [],
                 persistFailureStatus: false,
+                speechEngine: speechEngineOverride,
                 onProgress: onProgress
             )
         }
@@ -250,6 +338,20 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
     public func retranscribeMeeting(
         existing original: Transcription,
         recording: MeetingRecordingOutput,
+        onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
+    ) async throws -> Transcription {
+        try await retranscribeMeeting(
+            existing: original,
+            recording: recording,
+            speechEngineOverride: nil,
+            onProgress: onProgress
+        )
+    }
+
+    public func retranscribeMeeting(
+        existing original: Transcription,
+        recording: MeetingRecordingOutput,
+        speechEngineOverride: SpeechEngineSelection? = nil,
         onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
     ) async throws -> Transcription {
         var transcription = makeRetranscriptionRecord(from: original)
@@ -279,6 +381,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
                 transcription: &transcription,
                 operation: operation,
                 persistFailureStatus: false,
+                speechEngineOverride: speechEngineOverride,
                 onProgress: onProgress
             )
         }
@@ -488,6 +591,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         transcription: inout Transcription,
         operation: TranscriptionOperationContext,
         persistFailureStatus: Bool = true,
+        speechEngineOverride: SpeechEngineSelection? = nil,
         onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
     ) async throws -> Transcription {
         let processingStartedAt = Date()
@@ -507,6 +611,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
                 lifecycleStage: &lifecycleStage,
                 temporaryWavURLs: &temporaryWavURLs,
                 sourceWavURLs: &sourceWavURLs,
+                speechEngineOverride: speechEngineOverride,
                 onProgress: onProgress
             )
 
@@ -611,10 +716,12 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         lifecycleStage: inout TelemetryTranscriptionStage,
         temporaryWavURLs: inout [URL],
         sourceWavURLs: inout [AudioSource: URL],
+        speechEngineOverride: SpeechEngineSelection?,
         onProgress: (@Sendable (TranscriptionProgress) -> Void)?
     ) async throws -> [MeetingTranscriptFinalizer.SourceTranscript] {
         var outputs: [MeetingTranscriptFinalizer.SourceTranscript] = []
         let activeSources = [AudioSource.microphone, .system].filter { recording.sourceAlignment.track(for: $0) != nil }
+        let speechEngine = speechEngineOverride ?? (recording.speechEngineWasCaptured ? recording.speechEngine : nil)
 
         for (index, source) in activeSources.enumerated() {
             let fileURL = meetingAudioURL(for: source, recording: recording)
@@ -629,7 +736,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
             let result = try await transcribeSpeech(
                 audioPath: wavURL.path,
                 job: .meetingFinalize,
-                speechEngine: recording.speechEngine,
+                speechEngine: speechEngine,
                 onProgress: meetingSourceProgressMapper(
                     sourceIndex: index,
                     sourceCount: activeSources.count,
@@ -770,6 +877,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
         tempFiles: [URL],
         cleanUpDownloadedFiles: Bool = true,
         persistFailureStatus: Bool = true,
+        speechEngine: SpeechEngineSelection? = nil,
         onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
     ) async throws -> Transcription {
         var wavURL: URL?
@@ -795,7 +903,7 @@ public actor TranscriptionService: TranscriptionServiceProtocol {
             let result = try await transcribeSpeech(
                 audioPath: wavURL.path,
                 job: sttJob,
-                speechEngine: nil,
+                speechEngine: speechEngine,
                 onProgress: sttProgress
             )
 

--- a/Sources/MacParakeetCore/SpeechEnginePreference.swift
+++ b/Sources/MacParakeetCore/SpeechEnginePreference.swift
@@ -10,6 +10,24 @@ public enum SpeechEnginePreference: String, CaseIterable, Codable, Sendable {
 
     public static let defaultWhisperModelVariant = "large-v3-v20240930_turbo_632MB"
 
+    public var displayName: String {
+        switch self {
+        case .parakeet:
+            "Parakeet"
+        case .whisper:
+            "Whisper"
+        }
+    }
+
+    public var alternative: SpeechEnginePreference {
+        switch self {
+        case .parakeet:
+            .whisper
+        case .whisper:
+            .parakeet
+        }
+    }
+
     public static func current(defaults: UserDefaults = .standard) -> SpeechEnginePreference {
         guard let rawValue = defaults.string(forKey: defaultsKey),
               let preference = SpeechEnginePreference(rawValue: rawValue) else {

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -108,17 +108,19 @@ public final class TranscriptionViewModel {
     private static let configurationError = "Transcription services are unavailable. Please try again."
     private let logger = Logger(subsystem: "com.macparakeet.viewmodels", category: "TranscriptionViewModel")
     private let defaults: UserDefaults
-    private let isWhisperModelDownloaded: @Sendable () -> Bool
+    private let isWhisperModelDownloaded: () -> Bool
     public var promptResultsViewModel: PromptResultsViewModel?
 
     public init(
         defaults: UserDefaults = .standard,
-        isWhisperModelDownloaded: @escaping @Sendable () -> Bool = {
-            WhisperEngine.isModelDownloaded(model: SpeechEnginePreference.whisperModelVariant())
-        }
+        isWhisperModelDownloaded: (() -> Bool)? = nil
     ) {
         self.defaults = defaults
-        self.isWhisperModelDownloaded = isWhisperModelDownloaded
+        self.isWhisperModelDownloaded = isWhisperModelDownloaded ?? {
+            WhisperEngine.isModelDownloaded(
+                model: SpeechEnginePreference.whisperModelVariant(defaults: defaults)
+            )
+        }
     }
 
     public func configure(

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -6,6 +6,17 @@ import SwiftUI
 @MainActor
 @Observable
 public final class TranscriptionViewModel {
+    public struct RetranscriptionEngineOption: Equatable, Sendable {
+        public let primaryEngine: SpeechEngineSelection
+        public let alternativeEngine: SpeechEngineSelection
+        public let isAlternativeAvailable: Bool
+        public let unavailableReason: String?
+
+        public var title: String {
+            "Try with \(alternativeEngine.engine.displayName)"
+        }
+    }
+
     public enum SourceKind: Sendable {
         case localFile
         case youtubeURL
@@ -96,9 +107,19 @@ public final class TranscriptionViewModel {
     private var dropAccepted = false
     private static let configurationError = "Transcription services are unavailable. Please try again."
     private let logger = Logger(subsystem: "com.macparakeet.viewmodels", category: "TranscriptionViewModel")
+    private let defaults: UserDefaults
+    private let isWhisperModelDownloaded: @Sendable () -> Bool
     public var promptResultsViewModel: PromptResultsViewModel?
 
-    public init() {}
+    public init(
+        defaults: UserDefaults = .standard,
+        isWhisperModelDownloaded: @escaping @Sendable () -> Bool = {
+            WhisperEngine.isModelDownloaded(model: SpeechEnginePreference.whisperModelVariant())
+        }
+    ) {
+        self.defaults = defaults
+        self.isWhisperModelDownloaded = isWhisperModelDownloaded
+    }
 
     public func configure(
         transcriptionService: TranscriptionServiceProtocol,
@@ -247,7 +268,49 @@ public final class TranscriptionViewModel {
         return "Unsupported file type. Supported formats: \(formats)."
     }
 
-    public func retranscribe(_ original: Transcription) {
+    public func retranscriptionEngineOption(for original: Transcription) -> RetranscriptionEngineOption? {
+        guard original.sourceType == .meeting,
+              let filePath = original.filePath,
+              FileManager.default.fileExists(atPath: filePath) else {
+            return nil
+        }
+
+        let mixedAudioURL = URL(fileURLWithPath: filePath)
+        let primaryEngine: SpeechEngineSelection
+        if let archivedRecording = archivedMeetingRecording(
+            for: original,
+            mixedAudioURL: mixedAudioURL,
+            logFailure: false
+        ),
+           archivedRecording.speechEngineWasCaptured {
+            primaryEngine = archivedRecording.speechEngine
+        } else {
+            primaryEngine = SpeechEngineSelection.current(defaults: defaults)
+        }
+
+        let alternativePreference = primaryEngine.engine.alternative
+        let alternativeEngine = SpeechEngineSelection(
+            engine: alternativePreference,
+            language: alternativePreference == .whisper
+                ? SpeechEnginePreference.whisperDefaultLanguage(defaults: defaults)
+                : nil
+        )
+        let unavailableReason: String?
+        if alternativePreference == .whisper && !isWhisperModelDownloaded() {
+            unavailableReason = "Download the Whisper model in Settings before trying Whisper."
+        } else {
+            unavailableReason = nil
+        }
+
+        return RetranscriptionEngineOption(
+            primaryEngine: primaryEngine,
+            alternativeEngine: alternativeEngine,
+            isAlternativeAvailable: unavailableReason == nil,
+            unavailableReason: unavailableReason
+        )
+    }
+
+    public func retranscribe(_ original: Transcription, speechEngineOverride: SpeechEngineSelection? = nil) {
         guard let service = transcriptionService else {
             reportMissingConfiguration("transcriptionService", action: "retranscribe")
             return
@@ -280,6 +343,7 @@ public final class TranscriptionViewModel {
                     result = try await service.retranscribeMeeting(
                         existing: original,
                         recording: meetingRecording,
+                        speechEngineOverride: speechEngineOverride,
                         onProgress: progressHandler
                     )
                 } else {
@@ -287,6 +351,7 @@ public final class TranscriptionViewModel {
                         existing: original,
                         fileURL: url,
                         source: retranscriptionSource,
+                        speechEngineOverride: speechEngineOverride,
                         onProgress: progressHandler
                     )
                 }
@@ -323,7 +388,8 @@ public final class TranscriptionViewModel {
 
     private func archivedMeetingRecording(
         for original: Transcription,
-        mixedAudioURL: URL
+        mixedAudioURL: URL,
+        logFailure: Bool = true
     ) -> MeetingRecordingOutput? {
         let durationSeconds = Double(original.durationMs ?? 0) / 1000.0
         do {
@@ -333,9 +399,11 @@ public final class TranscriptionViewModel {
                 durationSeconds: durationSeconds
             )
         } catch {
-            logger.notice(
-                "Meeting retranscribe falling back to mixed audio path file=\(original.fileName, privacy: .private) error=\(error.localizedDescription, privacy: .private)"
-            )
+            if logFailure {
+                logger.notice(
+                    "Meeting retranscribe falling back to mixed audio path file=\(original.fileName, privacy: .private) error=\(error.localizedDescription, privacy: .private)"
+                )
+            }
             return nil
         }
     }

--- a/Tests/MacParakeetTests/Services/MeetingRecordingRecoveryServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecordingRecoveryServiceTests.swift
@@ -522,6 +522,25 @@ private final class RecoveryMockTranscriptionService: TranscriptionServiceProtoc
         )
     }
 
+    func retranscribe(
+        existing transcription: Transcription,
+        fileURL: URL,
+        source: TelemetryTranscriptionSource,
+        speechEngineOverride: SpeechEngineSelection?,
+        onProgress: (@Sendable (TranscriptionProgress) -> Void)?
+    ) async throws -> Transcription {
+        fatalError("Not used")
+    }
+
+    func retranscribeMeeting(
+        existing transcription: Transcription,
+        recording: MeetingRecordingOutput,
+        speechEngineOverride: SpeechEngineSelection?,
+        onProgress: (@Sendable (TranscriptionProgress) -> Void)?
+    ) async throws -> Transcription {
+        fatalError("Not used")
+    }
+
     func transcribeURL(
         urlString: String,
         onProgress: (@Sendable (TranscriptionProgress) -> Void)?

--- a/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
@@ -602,6 +602,105 @@ final class TranscriptionServiceTests: XCTestCase {
         XCTAssertEqual(selections, [SpeechEngineSelection(engine: .whisper, language: "ko")])
     }
 
+    func testRetranscribeMeetingCanOverrideCapturedSpeechEngineForOneRun() async throws {
+        let recordingFolder = URL(fileURLWithPath: AppPaths.tempDir)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: recordingFolder, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: recordingFolder) }
+
+        let mixedURL = recordingFolder.appendingPathComponent("meeting.m4a")
+        let microphoneURL = recordingFolder.appendingPathComponent("microphone.m4a")
+        XCTAssertTrue(FileManager.default.createFile(atPath: mixedURL.path, contents: Data("mixed".utf8)))
+        XCTAssertTrue(FileManager.default.createFile(atPath: microphoneURL.path, contents: Data("microphone".utf8)))
+
+        await mockSTT.configure(result: STTResult(
+            text: "Retried with Parakeet",
+            words: [
+                TimestampedWord(word: "Retried", startMs: 0, endMs: 400, confidence: 0.9),
+            ],
+            language: "en"
+        ))
+
+        let recording = MeetingRecordingOutput(
+            sessionID: UUID(),
+            displayName: "Korean Meeting",
+            folderURL: recordingFolder,
+            mixedAudioURL: mixedURL,
+            microphoneAudioURL: microphoneURL,
+            systemAudioURL: recordingFolder.appendingPathComponent("system.m4a"),
+            durationSeconds: 1.0,
+            sourceAlignment: MeetingSourceAlignment(
+                meetingOriginHostTime: nil,
+                microphone: .init(firstHostTime: nil, lastHostTime: nil, startOffsetMs: 0, writtenFrameCount: 24_000, sampleRate: 48_000),
+                system: nil
+            ),
+            speechEngine: SpeechEngineSelection(engine: .whisper, language: "ko")
+        )
+        let original = Transcription(
+            fileName: "Korean Meeting",
+            filePath: mixedURL.path,
+            status: .completed,
+            sourceType: .meeting
+        )
+
+        _ = try await service.retranscribeMeeting(
+            existing: original,
+            recording: recording,
+            speechEngineOverride: SpeechEngineSelection(engine: .parakeet)
+        )
+
+        let selections = await mockSTT.speechEngineSelections
+        XCTAssertEqual(selections, [SpeechEngineSelection(engine: .parakeet)])
+        XCTAssertEqual(recording.speechEngine, SpeechEngineSelection(engine: .whisper, language: "ko"))
+    }
+
+    func testRetranscribeMeetingWithoutCapturedSpeechEngineUsesCurrentRouting() async throws {
+        let recordingFolder = URL(fileURLWithPath: AppPaths.tempDir)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: recordingFolder, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: recordingFolder) }
+
+        let mixedURL = recordingFolder.appendingPathComponent("meeting.m4a")
+        let microphoneURL = recordingFolder.appendingPathComponent("microphone.m4a")
+        XCTAssertTrue(FileManager.default.createFile(atPath: mixedURL.path, contents: Data("mixed".utf8)))
+        XCTAssertTrue(FileManager.default.createFile(atPath: microphoneURL.path, contents: Data("microphone".utf8)))
+
+        await mockSTT.configure(result: STTResult(
+            text: "Legacy rerun",
+            words: [
+                TimestampedWord(word: "Legacy", startMs: 0, endMs: 400, confidence: 0.9),
+            ]
+        ))
+
+        let recording = MeetingRecordingOutput(
+            sessionID: UUID(),
+            displayName: "Legacy Meeting",
+            folderURL: recordingFolder,
+            mixedAudioURL: mixedURL,
+            microphoneAudioURL: microphoneURL,
+            systemAudioURL: recordingFolder.appendingPathComponent("system.m4a"),
+            durationSeconds: 1.0,
+            sourceAlignment: MeetingSourceAlignment(
+                meetingOriginHostTime: nil,
+                microphone: .init(firstHostTime: nil, lastHostTime: nil, startOffsetMs: 0, writtenFrameCount: 24_000, sampleRate: 48_000),
+                system: nil
+            ),
+            speechEngine: SpeechEngineSelection(engine: .parakeet),
+            speechEngineWasCaptured: false
+        )
+        let original = Transcription(
+            fileName: "Legacy Meeting",
+            filePath: mixedURL.path,
+            status: .completed,
+            sourceType: .meeting
+        )
+
+        _ = try await service.retranscribeMeeting(existing: original, recording: recording)
+
+        let selections = await mockSTT.speechEngineSelections
+        XCTAssertEqual(selections, [])
+    }
+
     func testTranscribeMeetingFailsWhenCapturedSpeechEngineCannotBeRouted() async throws {
         let recordingFolder = URL(fileURLWithPath: AppPaths.tempDir)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -1099,6 +1099,122 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertNil(lastFileURL, "Meeting retranscribe should use transcribeMeeting, not generic file transcription")
     }
 
+    func testRetranscribeMeetingPassesSpeechEngineOverride() async throws {
+        let archivedMeeting = try makeArchivedMeetingRecording(
+            speechEngine: SpeechEngineSelection(engine: .whisper, language: "ko")
+        )
+        defer { try? FileManager.default.removeItem(at: archivedMeeting.folderURL) }
+
+        let original = Transcription(
+            id: UUID(),
+            fileName: "Meeting Apr 5",
+            filePath: archivedMeeting.mixedURL.path,
+            durationMs: 2_000,
+            rawTranscript: "Old meeting transcript",
+            status: .completed,
+            sourceType: .meeting
+        )
+        mockRepo.transcriptions = [original]
+
+        let newResult = Transcription(
+            fileName: archivedMeeting.mixedURL.lastPathComponent,
+            rawTranscript: "Updated meeting transcript",
+            status: .completed
+        )
+        await mockService.configure(result: newResult)
+
+        viewModel.configure(transcriptionService: mockService, transcriptionRepo: mockRepo)
+
+        viewModel.retranscribe(
+            original,
+            speechEngineOverride: SpeechEngineSelection(engine: .parakeet)
+        )
+
+        try await Task.sleep(for: .milliseconds(300))
+
+        let override = await mockService.lastSpeechEngineOverride
+        XCTAssertEqual(override, SpeechEngineSelection(engine: .parakeet))
+        let lastMeetingRecording = await mockService.lastMeetingRecording
+        XCTAssertEqual(lastMeetingRecording?.speechEngine, SpeechEngineSelection(engine: .whisper, language: "ko"))
+    }
+
+    func testRetranscriptionEngineOptionUsesCapturedMeetingEngine() throws {
+        let archivedMeeting = try makeArchivedMeetingRecording(
+            speechEngine: SpeechEngineSelection(engine: .whisper, language: "KO")
+        )
+        defer { try? FileManager.default.removeItem(at: archivedMeeting.folderURL) }
+
+        viewModel = TranscriptionViewModel(isWhisperModelDownloaded: { true })
+        let original = Transcription(
+            id: UUID(),
+            fileName: "Korean Meeting",
+            filePath: archivedMeeting.mixedURL.path,
+            durationMs: 2_000,
+            rawTranscript: "Old meeting transcript",
+            status: .completed,
+            sourceType: .meeting
+        )
+
+        let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
+
+        XCTAssertEqual(option.primaryEngine, SpeechEngineSelection(engine: .whisper, language: "ko"))
+        XCTAssertEqual(option.alternativeEngine, SpeechEngineSelection(engine: .parakeet))
+        XCTAssertTrue(option.isAlternativeAvailable)
+        XCTAssertNil(option.unavailableReason)
+        XCTAssertEqual(option.title, "Try with Parakeet")
+    }
+
+    func testRetranscriptionEngineOptionUsesCurrentSettingsForLegacyMeetingMetadata() throws {
+        let suiteName = "TranscriptionViewModelTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        SpeechEnginePreference.whisper.save(to: defaults)
+        SpeechEnginePreference.saveWhisperDefaultLanguage("ja", defaults: defaults)
+        viewModel = TranscriptionViewModel(defaults: defaults, isWhisperModelDownloaded: { true })
+
+        let archivedMeeting = try makeArchivedMeetingRecording(speechEngine: nil)
+        defer { try? FileManager.default.removeItem(at: archivedMeeting.folderURL) }
+
+        let original = Transcription(
+            id: UUID(),
+            fileName: "Legacy Meeting",
+            filePath: archivedMeeting.mixedURL.path,
+            durationMs: 2_000,
+            rawTranscript: "Old meeting transcript",
+            status: .completed,
+            sourceType: .meeting
+        )
+
+        let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
+
+        XCTAssertEqual(option.primaryEngine, SpeechEngineSelection(engine: .whisper, language: "ja"))
+        XCTAssertEqual(option.alternativeEngine, SpeechEngineSelection(engine: .parakeet))
+    }
+
+    func testRetranscriptionEngineOptionDisablesMissingWhisperModel() throws {
+        let archivedMeeting = try makeArchivedMeetingRecording(
+            speechEngine: SpeechEngineSelection(engine: .parakeet)
+        )
+        defer { try? FileManager.default.removeItem(at: archivedMeeting.folderURL) }
+
+        viewModel = TranscriptionViewModel(isWhisperModelDownloaded: { false })
+        let original = Transcription(
+            id: UUID(),
+            fileName: "English Meeting",
+            filePath: archivedMeeting.mixedURL.path,
+            durationMs: 2_000,
+            rawTranscript: "Old meeting transcript",
+            status: .completed,
+            sourceType: .meeting
+        )
+
+        let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
+
+        XCTAssertEqual(option.alternativeEngine, SpeechEngineSelection(engine: .whisper))
+        XCTAssertFalse(option.isAlternativeAvailable)
+        XCTAssertEqual(option.unavailableReason, "Download the Whisper model in Settings before trying Whisper.")
+    }
+
     func testRetranscribeMeetingFallsBackToMixedAudioWhenArchivedMetadataIsMissing() async throws {
         let tmpDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("retranscribe-meeting-fallback-\(UUID().uuidString)", isDirectory: true)
@@ -1252,7 +1368,9 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertEqual(mockRepo.transcriptions.first?.id, original.id)
     }
 
-    private func makeArchivedMeetingRecording() throws -> (folderURL: URL, mixedURL: URL) {
+    private func makeArchivedMeetingRecording(
+        speechEngine: SpeechEngineSelection? = SpeechEngineSelection(engine: .parakeet)
+    ) throws -> (folderURL: URL, mixedURL: URL) {
         let folderURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("meeting-archive-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
@@ -1264,26 +1382,37 @@ final class TranscriptionViewModelTests: XCTestCase {
         FileManager.default.createFile(atPath: microphoneURL.path, contents: Data([1]))
         FileManager.default.createFile(atPath: systemURL.path, contents: Data([2]))
 
-        let metadata = MeetingRecordingMetadata(
-            sourceAlignment: MeetingSourceAlignment(
-                meetingOriginHostTime: nil,
-                microphone: .init(
-                    firstHostTime: nil,
-                    lastHostTime: nil,
-                    startOffsetMs: 0,
-                    writtenFrameCount: 24_000,
-                    sampleRate: 48_000
-                ),
-                system: .init(
-                    firstHostTime: nil,
-                    lastHostTime: nil,
-                    startOffsetMs: 150,
-                    writtenFrameCount: 24_000,
-                    sampleRate: 48_000
-                )
+        let sourceAlignment = MeetingSourceAlignment(
+            meetingOriginHostTime: nil,
+            microphone: .init(
+                firstHostTime: nil,
+                lastHostTime: nil,
+                startOffsetMs: 0,
+                writtenFrameCount: 24_000,
+                sampleRate: 48_000
+            ),
+            system: .init(
+                firstHostTime: nil,
+                lastHostTime: nil,
+                startOffsetMs: 150,
+                writtenFrameCount: 24_000,
+                sampleRate: 48_000
             )
         )
-        try MeetingRecordingMetadataStore.save(metadata, folderURL: folderURL)
+
+        if let speechEngine {
+            let metadata = MeetingRecordingMetadata(
+                sourceAlignment: sourceAlignment,
+                speechEngine: speechEngine
+            )
+            try MeetingRecordingMetadataStore.save(metadata, folderURL: folderURL)
+        } else {
+            let legacyMetadata = try JSONEncoder().encode(["sourceAlignment": sourceAlignment])
+            try legacyMetadata.write(
+                to: folderURL.appendingPathComponent(MeetingRecordingMetadata.fileName),
+                options: .atomic
+            )
+        }
 
         return (folderURL: folderURL, mixedURL: mixedURL)
     }

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -1130,7 +1130,7 @@ final class TranscriptionViewModelTests: XCTestCase {
             speechEngineOverride: SpeechEngineSelection(engine: .parakeet)
         )
 
-        try await Task.sleep(for: .milliseconds(300))
+        try await waitUntil { !self.viewModel.isTranscribing }
 
         let override = await mockService.lastSpeechEngineOverride
         XCTAssertEqual(override, SpeechEngineSelection(engine: .parakeet))

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -238,13 +238,14 @@ final class MockLaunchAtLoginService: LaunchAtLoginControlling {
 
 // MARK: - MockTranscriptionService
 
-actor MockTranscriptionService: TranscriptionServiceProtocol {
+actor MockTranscriptionService: SpeechEngineOverrideTranscriptionService {
     var transcribeResult: Transcription?
     var transcribeError: Error?
     var transcribeCallCount = 0
     var lastFileURL: URL?
     var lastSource: TelemetryTranscriptionSource?
     var lastMeetingRecording: MeetingRecordingOutput?
+    var lastSpeechEngineOverride: SpeechEngineSelection?
     var transcribeProgressPhases: [TranscriptionProgress] = []
     var transcribeDelayMs: UInt64 = 0
     var transcribeURLCallCount = 0
@@ -333,6 +334,27 @@ actor MockTranscriptionService: TranscriptionServiceProtocol {
             status: .completed,
             sourceType: .meeting
         )
+    }
+
+    func retranscribe(
+        existing transcription: Transcription,
+        fileURL: URL,
+        source: TelemetryTranscriptionSource,
+        speechEngineOverride: SpeechEngineSelection?,
+        onProgress: (@Sendable (TranscriptionProgress) -> Void)?
+    ) async throws -> Transcription {
+        lastSpeechEngineOverride = speechEngineOverride
+        return try await transcribe(fileURL: fileURL, source: source, onProgress: onProgress)
+    }
+
+    func retranscribeMeeting(
+        existing transcription: Transcription,
+        recording: MeetingRecordingOutput,
+        speechEngineOverride: SpeechEngineSelection?,
+        onProgress: (@Sendable (TranscriptionProgress) -> Void)?
+    ) async throws -> Transcription {
+        lastSpeechEngineOverride = speechEngineOverride
+        return try await transcribeMeeting(recording: recording, onProgress: onProgress)
     }
 
     func transcribeURL(urlString: String, onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil) async throws -> Transcription {


### PR DESCRIPTION
## Summary

Adds a secondary one-off engine retry for meeting retranscription:

- Keeps primary `Retranscribe` metadata-driven when a meeting captured its engine.
- Adds `Try with Whisper` / `Try with Parakeet` beside the primary action for meeting transcripts with saved audio.
- Routes the secondary action through an explicit one-run `SpeechEngineSelection` override.
- Does not mutate meeting metadata or global Settings.
- Treats legacy meeting metadata without a captured engine as legacy: primary retranscribe follows current Settings, and the secondary button shows the other engine.
- Disables `Try with Whisper` when the Whisper model is not downloaded, with a Settings download hint.
- Adds hover/help comparison copy so users can understand the tradeoff before retrying.

## UX

```
Meeting transcript action bar
+----------------+--------------------+
| Retranscribe   | Try with Whisper   |
+----------------+--------------------+
        |                  |
        |                  +-- one-run alternate engine override
        |
        +-- default path:
            captured metadata engine when present
            current Settings for legacy metadata
```

```
Retry routing

+-----------------------+
| User clicks action    |
+-----------+-----------+
            |
            v
+-----------------------+
| Primary Retranscribe? |
+-----------+-----------+
    yes     |     no
            |
            v
+-----------------------+        +--------------------------+
| captured engine?      |        | alternate engine override|
+-----------+-----------+        +------------+-------------+
    yes     |     no                          |
     |            |                           |
     v            v                           v
metadata     current Settings            Try with X once
engine              |                           |
     +--------------+-------------+-------------+
                                  v
                         retranscribe saved audio
                                  |
                                  v
                         replace transcript in place
```

## Behavior Matrix

| Meeting state | Primary `Retranscribe` | Secondary action |
| --- | --- | --- |
| Captured with Whisper | Whisper, including saved language hint | `Try with Parakeet` |
| Captured with Parakeet | Parakeet | `Try with Whisper` |
| Legacy metadata without engine | Current Settings | Other engine from current Settings |
| Whisper model deleted/missing | Existing behavior for primary | Disabled, prompts Settings download |

## Docs / Research Check

The UI copy is intentionally conservative:

- NVIDIA's Parakeet TDT 0.6B v3 model card describes a high-throughput ASR model with support for 25 European languages and automatic language detection: https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3
- FluidAudio's official docs list Parakeet transcription at 210x RTFx on M4 Pro benchmarks and 25 European languages: https://docs.fluidinference.com/introduction
- OpenAI's Whisper README describes Whisper as multilingual speech recognition / translation / language identification, and documents explicit non-English language usage: https://github.com/openai/whisper
- Argmax's WhisperKit docs/README describe on-device Whisper speech-to-text and language detection/manual specification support: https://github.com/argmaxinc/WhisperKit

That is why the hover/help text says Parakeet is faster for 25 European languages including English, while Whisper is slower but broader for Korean, Chinese, Japanese, and more.

## Implementation Notes

- `MeetingRecordingMetadata` now records whether `speechEngine` was actually present in archived metadata via `speechEngineWasCaptured`.
- `MeetingRecordingOutput` carries that flag through archive loading.
- `TranscriptionServiceProtocol` remains source-compatible. A refinement protocol, `SpeechEngineOverrideTranscriptionService`, handles explicit override-capable services.
- `TranscriptionService` routes `speechEngineOverride` into both generic file retranscription and per-source meeting retranscription.
- `TranscriptionViewModel` computes the alternate engine option and checks whether Whisper is downloaded before exposing an enabled action.
- `TranscriptResultView` presents the secondary action, confirmation copy, and engine comparison hover/help text.

## Validation

- `swift test`
  - 1817 XCTest tests passed
  - 13 Swift Testing tests passed
- `git diff --check`
  - passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to retranscribe meetings with alternative speech engines through new UI prompts.
  * Engine selection interface now displays comparison details and engine tradeoff information during retranscription.
  * Improved tracking of speech engine metadata in archived meeting recordings.

* **Tests**
  * Expanded test coverage for engine override and retranscription workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->