### PR TITLE
Fix speech-engine switch lockout and idle-badge UX

### DIFF
--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -1322,7 +1322,11 @@ struct SettingsView: View {
         case .ready:
             ("checkmark.circle.fill", "Ready", DesignSystem.Colors.successGreen)
         case .notLoaded:
-            ("pause.circle.fill", "Not Loaded", .secondary)
+            // The model is on disk and will lazy-load on first use; this is a
+            // healthy idle state, not an error. Earlier copy ("Not Loaded"
+            // with a pause icon) read as broken and prompted users to hit
+            // Repair to "fix" something that wasn't actually broken.
+            ("checkmark.circle.fill", "Downloaded", DesignSystem.Colors.successGreen)
         case .notDownloaded:
             ("arrow.down.circle.fill", "Not Downloaded", DesignSystem.Colors.errorRed)
         case .repairing:

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -846,7 +846,11 @@ struct SettingsView: View {
         case .notDownloaded:
             return "Download"
         case .notLoaded:
-            return "Repair"
+            // The badge already says "Downloaded ✓"; pairing it with "Repair"
+            // implied the model was broken. The button actually re-runs the
+            // download (fast no-op via HuggingFace cache when files are
+            // intact), so name it for what it does.
+            return "Re-download"
         case .failed:
             return "Retry"
         case .ready:

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -837,17 +837,29 @@ public final class SettingsViewModel {
     public func refreshModelStatus() {
         modelStatusRefreshGeneration += 1
         let refreshGeneration = modelStatusRefreshGeneration
+        let whisperModelVariant = SpeechEnginePreference.whisperModelVariant(defaults: defaults)
 
         guard let sttClient else {
             parakeetStatus = .unknown
             parakeetStatusDetail = "Unavailable in this runtime."
-            refreshWhisperModelStatus()
+            whisperModelStatus = .checking
+            whisperModelStatusDetail = "Checking model state..."
+            Task { @MainActor [weak self] in
+                let whisperDownloaded = await Task.detached(priority: .userInitiated) {
+                    WhisperEngine.isModelDownloaded(model: whisperModelVariant)
+                }.value
+                guard let self, self.modelStatusRefreshGeneration == refreshGeneration else {
+                    return
+                }
+                self.applyWhisperDownloadedStatus(whisperDownloaded)
+            }
             return
         }
 
         parakeetStatus = .checking
         parakeetStatusDetail = "Checking model state..."
-        refreshWhisperModelStatus()
+        whisperModelStatus = .checking
+        whisperModelStatusDetail = "Checking model state..."
 
         Task { @MainActor [weak self] in
             guard let self else { return }
@@ -861,7 +873,6 @@ public final class SettingsViewModel {
             // can't pair the new preference with the old engine's readiness.
             let activeEngine = self.speechEnginePreference
             let isSpeechModelCached = self.isSpeechModelCached
-            let whisperModelVariant = SpeechEnginePreference.whisperModelVariant(defaults: self.defaults)
 
             async let activeEngineLoaded = sttClient.isReady()
             async let diskState = Task.detached(priority: .userInitiated) {
@@ -891,18 +902,20 @@ public final class SettingsViewModel {
             if activeEngine == .whisper, activeEngineIsLoaded {
                 self.whisperModelStatus = .ready
                 self.whisperModelStatusDetail = "Loaded in memory and ready."
-            } else if modelDiskState.whisperDownloaded {
-                self.whisperModelStatus = .notLoaded
-                self.whisperModelStatusDetail = "Downloaded. Loads automatically when Whisper is selected."
             } else {
-                self.whisperModelStatus = .notDownloaded
-                self.whisperModelStatusDetail = "Not downloaded yet."
+                self.applyWhisperDownloadedStatus(modelDiskState.whisperDownloaded)
             }
         }
     }
 
     public func refreshWhisperModelStatus() {
-        if WhisperEngine.isModelDownloaded(model: SpeechEnginePreference.whisperModelVariant(defaults: defaults)) {
+        applyWhisperDownloadedStatus(
+            WhisperEngine.isModelDownloaded(model: SpeechEnginePreference.whisperModelVariant(defaults: defaults))
+        )
+    }
+
+    private func applyWhisperDownloadedStatus(_ isDownloaded: Bool) {
+        if isDownloaded {
             // Optimistic file-based check; `refreshModelStatus()` will upgrade
             // to `.ready` after asking the runtime if Whisper is the active
             // engine and currently loaded.

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -391,6 +391,7 @@ public final class SettingsViewModel {
     private let permissionPollingInterval: Duration
     private var isApplyingLaunchAtLoginState = false
     private var isApplyingSpeechEngineState = false
+    private var modelStatusRefreshGeneration = 0
     // `deinit` is nonisolated even though this type is `@MainActor`.
     // These handles are only mutated on the main actor during the view
     // model lifetime; unsafe access lets deinit cancel/unregister.
@@ -834,6 +835,9 @@ public final class SettingsViewModel {
     }
 
     public func refreshModelStatus() {
+        modelStatusRefreshGeneration += 1
+        let refreshGeneration = modelStatusRefreshGeneration
+
         guard let sttClient else {
             parakeetStatus = .unknown
             parakeetStatusDetail = "Unavailable in this runtime."
@@ -856,16 +860,27 @@ public final class SettingsViewModel {
             // Snapshot the engine before the await so a mid-suspension toggle
             // can't pair the new preference with the old engine's readiness.
             let activeEngine = self.speechEnginePreference
-            let activeEngineLoaded = await sttClient.isReady()
-            let parakeetCached = self.isSpeechModelCached()
-            let whisperDownloaded = WhisperEngine.isModelDownloaded(
-                model: SpeechEnginePreference.whisperModelVariant(defaults: self.defaults)
-            )
+            let isSpeechModelCached = self.isSpeechModelCached
+            let whisperModelVariant = SpeechEnginePreference.whisperModelVariant(defaults: self.defaults)
 
-            if activeEngine == .parakeet, activeEngineLoaded {
+            async let activeEngineLoaded = sttClient.isReady()
+            async let diskState = Task.detached(priority: .userInitiated) {
+                (
+                    parakeetCached: isSpeechModelCached(),
+                    whisperDownloaded: WhisperEngine.isModelDownloaded(model: whisperModelVariant)
+                )
+            }.value
+
+            let (activeEngineIsLoaded, modelDiskState) = await (activeEngineLoaded, diskState)
+            guard self.modelStatusRefreshGeneration == refreshGeneration,
+                  self.speechEnginePreference == activeEngine else {
+                return
+            }
+
+            if activeEngine == .parakeet, activeEngineIsLoaded {
                 self.parakeetStatus = .ready
                 self.parakeetStatusDetail = "Loaded in memory and ready."
-            } else if parakeetCached {
+            } else if modelDiskState.parakeetCached {
                 self.parakeetStatus = .notLoaded
                 self.parakeetStatusDetail = "Downloaded. Loads automatically when needed."
             } else {
@@ -873,10 +888,10 @@ public final class SettingsViewModel {
                 self.parakeetStatusDetail = "Not downloaded yet."
             }
 
-            if activeEngine == .whisper, activeEngineLoaded {
+            if activeEngine == .whisper, activeEngineIsLoaded {
                 self.whisperModelStatus = .ready
                 self.whisperModelStatusDetail = "Loaded in memory and ready."
-            } else if whisperDownloaded {
+            } else if modelDiskState.whisperDownloaded {
                 self.whisperModelStatus = .notLoaded
                 self.whisperModelStatusDetail = "Downloaded. Loads automatically when Whisper is selected."
             } else {

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -845,28 +845,49 @@ public final class SettingsViewModel {
         parakeetStatusDetail = "Checking model state..."
         refreshWhisperModelStatus()
 
-        Task {
-            let parakeetReady = await sttClient.isReady()
-            let parakeetCached = isSpeechModelCached()
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            // `sttClient.isReady()` returns the *active* engine's loaded state
+            // (see STTRuntime.isReady), so we apply it to whichever engine is
+            // currently selected and keep the inactive engine on its disk-cache
+            // status. Without this branch, switching to Whisper left the
+            // Whisper badge stuck at "Not Loaded" forever.
+            let activeEngineLoaded = await sttClient.isReady()
+            let parakeetCached = self.isSpeechModelCached()
+            let whisperDownloaded = WhisperEngine.isModelDownloaded(
+                model: SpeechEnginePreference.whisperModelVariant(defaults: self.defaults)
+            )
+            let activeEngine = self.speechEnginePreference
 
-            await MainActor.run {
-                if self.speechEnginePreference == .parakeet, parakeetReady {
-                    self.parakeetStatus = .ready
-                    self.parakeetStatusDetail = "Loaded in memory and ready."
-                } else if parakeetCached {
-                    self.parakeetStatus = .notLoaded
-                    self.parakeetStatusDetail = "Downloaded. Loads automatically when needed."
-                } else {
-                    self.parakeetStatus = .notDownloaded
-                    self.parakeetStatusDetail = "Not downloaded yet."
-                }
+            if activeEngine == .parakeet, activeEngineLoaded {
+                self.parakeetStatus = .ready
+                self.parakeetStatusDetail = "Loaded in memory and ready."
+            } else if parakeetCached {
+                self.parakeetStatus = .notLoaded
+                self.parakeetStatusDetail = "Downloaded. Loads automatically when needed."
+            } else {
+                self.parakeetStatus = .notDownloaded
+                self.parakeetStatusDetail = "Not downloaded yet."
+            }
 
+            if activeEngine == .whisper, activeEngineLoaded {
+                self.whisperModelStatus = .ready
+                self.whisperModelStatusDetail = "Loaded in memory and ready."
+            } else if whisperDownloaded {
+                self.whisperModelStatus = .notLoaded
+                self.whisperModelStatusDetail = "Downloaded. Loads automatically when Whisper is selected."
+            } else {
+                self.whisperModelStatus = .notDownloaded
+                self.whisperModelStatusDetail = "Not downloaded yet."
             }
         }
     }
 
     public func refreshWhisperModelStatus() {
         if WhisperEngine.isModelDownloaded(model: SpeechEnginePreference.whisperModelVariant(defaults: defaults)) {
+            // Optimistic file-based check; `refreshModelStatus()` will upgrade
+            // to `.ready` after asking the runtime if Whisper is the active
+            // engine and currently loaded.
             whisperModelStatus = .notLoaded
             whisperModelStatusDetail = "Downloaded. Loads automatically when Whisper is selected."
         } else {
@@ -922,22 +943,23 @@ public final class SettingsViewModel {
         }
 
         speechEngineSwitching = true
-        Task {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            // `defer` fires even on cancellation or unexpected early exit, so
+            // the segmented Picker can never get pinned in the disabled
+            // "Switching..." state.
+            defer {
+                self.speechEngineSwitching = false
+                self.refreshModelStatus()
+            }
             do {
                 try await speechEngineSwitcher.setSpeechEngine(preference)
-                await MainActor.run {
-                    preference.save(to: self.defaults)
-                    self.speechEngineSwitching = false
-                    self.refreshModelStatus()
-                }
+                preference.save(to: self.defaults)
             } catch {
-                await MainActor.run {
-                    self.speechEngineSwitching = false
-                    self.speechEngineError = error.localizedDescription
-                    self.isApplyingSpeechEngineState = true
-                    self.speechEnginePreference = SpeechEnginePreference.current(defaults: self.defaults)
-                    self.isApplyingSpeechEngineState = false
-                }
+                self.speechEngineError = error.localizedDescription
+                self.isApplyingSpeechEngineState = true
+                self.speechEnginePreference = SpeechEnginePreference.current(defaults: self.defaults)
+                self.isApplyingSpeechEngineState = false
             }
         }
     }

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -852,12 +852,15 @@ public final class SettingsViewModel {
             // currently selected and keep the inactive engine on its disk-cache
             // status. Without this branch, switching to Whisper left the
             // Whisper badge stuck at "Not Loaded" forever.
+            //
+            // Snapshot the engine before the await so a mid-suspension toggle
+            // can't pair the new preference with the old engine's readiness.
+            let activeEngine = self.speechEnginePreference
             let activeEngineLoaded = await sttClient.isReady()
             let parakeetCached = self.isSpeechModelCached()
             let whisperDownloaded = WhisperEngine.isModelDownloaded(
                 model: SpeechEnginePreference.whisperModelVariant(defaults: self.defaults)
             )
-            let activeEngine = self.speechEnginePreference
 
             if activeEngine == .parakeet, activeEngineLoaded {
                 self.parakeetStatus = .ready

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -15,6 +15,24 @@ final class SettingsViewModelTests: XCTestCase {
     var entitlements: EntitlementsService!
     var youtubeDownloadsTestDir: URL!
 
+    private func waitUntil(
+        timeout: Duration = .seconds(1),
+        pollInterval: Duration = .milliseconds(10),
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        _ condition: () -> Bool
+    ) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now + timeout
+        while !condition() {
+            if clock.now >= deadline {
+                XCTFail("Timed out waiting for condition", file: file, line: line)
+                return
+            }
+            try await Task.sleep(for: pollInterval)
+        }
+    }
+
     override func setUp() {
         mockRepo = MockDictationRepository()
         mockTranscriptionRepo = MockTranscriptionRepository()
@@ -672,6 +690,32 @@ final class SettingsViewModelTests: XCTestCase {
 
         try await Task.sleep(for: .milliseconds(120))
         XCTAssertEqual(vm.parakeetStatus, .notDownloaded)
+    }
+
+    func testRefreshModelStatusMarksActiveWhisperReady() async throws {
+        SpeechEnginePreference.whisper.save(to: testDefaults)
+        let vm = SettingsViewModel(
+            defaults: testDefaults,
+            youtubeDownloadsDirPath: { [youtubeDownloadsTestDir] in
+                youtubeDownloadsTestDir?.path ?? AppPaths.youtubeDownloadsDir
+            },
+            isSpeechModelCached: { true }
+        )
+        let stt = MockSTTClient()
+        await stt.setReady(true)
+
+        vm.configure(
+            permissionService: mockPermissions,
+            dictationRepo: mockRepo,
+            entitlementsService: entitlements,
+            checkoutURL: nil,
+            sttClient: stt
+        )
+
+        try await waitUntil { vm.whisperModelStatus == .ready }
+        XCTAssertEqual(vm.whisperModelStatusDetail, "Loaded in memory and ready.")
+        XCTAssertEqual(vm.parakeetStatus, .notLoaded)
+        XCTAssertEqual(vm.parakeetStatusDetail, "Downloaded. Loads automatically when needed.")
     }
 
     func testRepairParakeetModelUsesRetryAndEndsReady() async throws {


### PR DESCRIPTION
## What

Two small fixes to the Speech Recognition card that combined into a "feature looks broken" report:

1. **Engine picker no longer pins on "Switching speech engine…"** when the switch finishes (or fails) in an unexpected way.
2. **Idle badge no longer reads as broken.** "Not Loaded" + pause icon → "Downloaded" + green check, and the active engine actually goes to "Ready" after switching.

## Root cause

### Bug 1 — engine picker pinned in disabled state

`SettingsViewModel.applySpeechEngineChange` flipped `speechEngineSwitching = true`, awaited the switch from inside an unstructured `Task {}`, then tried to clear the flag from a hand-rolled `await MainActor.run { … }` block. The cleanup lived in **two** places (success and catch), and any cancellation / early-exit between `setSpeechEngine` returning and the `MainActor.run` block running left the flag pinned forever. Once that happens, `Picker(selection:)` is `.disabled(true)` and the user can't move off whichever engine they last selected.

The fix is the smaller pattern: `Task { @MainActor [weak self] in … defer { … } }`. One cleanup path, runs on every exit including cancellation. No change to the underlying `STTScheduler` / `STTRuntime` flow.

### Bug 2 — Whisper badge never said "Ready" + "Not Loaded" looked broken

Two things stacked here:

- `refreshWhisperModelStatus` only checked the **disk cache**, never asked whether Whisper was actually loaded into memory. So even after switching to Whisper and the runtime calling `WhisperKit(...)` successfully, the badge stayed at `.notLoaded`.
- The post-switch `refreshModelStatus` Task did query runtime readiness via `sttClient.isReady()`, but only applied the result to `parakeetStatus`. The Whisper branch was missing entirely. `STTRuntime.isReady()` already returns the **active engine's** loaded state — it just wasn't being routed to the right side of the UI.
- The `.notLoaded` badge rendered as `pause.circle.fill` + "Not Loaded" + secondary grey. That visual reads as a problem state. Users (correctly observed in this report) hit "Repair", which re-runs the Hugging Face download (fast no-op via cache), brings the status back to `.notLoaded`, and the user concludes the model is broken.

The fix is to query `sttClient.isReady()` once and apply it symmetrically — whichever engine is active gets `.ready` if loaded; the inactive engine stays on its disk-cache state. And rename the idle-but-downloaded badge to "Downloaded" with a green check, since that's what it actually means.

## Why minimal

Considered (and skipped) for this PR:

- A new `isParakeetLoaded()` / `isWhisperLoaded()` API split on `STTRuntime`. Existing `isReady()` already returns the active engine's state — splitting now would be over-engineering for two engines.
- Piping a progress callback through the engine switch so the user sees CoreML compilation progress. Real concern but separate UX work; this PR keeps to the lockout/UX bug.
- A watchdog timer. The `defer` covers the actual failure mode (cancellation during await). Adding a timer on top would be defensive engineering for an unobserved failure.

## Test plan

- [x] `swift test --filter SettingsViewModelTests` — 54 tests pass, including the existing `testSpeechEngineChangeCallsSwitcherAndPersistsOnSuccess` and `testSpeechEngineChangeRevertsWhenSwitcherFails` (these caught the original contract; `defer` doesn't change it).
- [ ] Local: Parakeet → Whisper → Parakeet round-trip with the picker re-enabling each time.
- [ ] Local: confirm the active engine's badge shows "Ready" after the switch settles, and the inactive engine's badge shows "Downloaded" (not "Not Loaded").

## Files changed

- `Sources/MacParakeetViewModels/SettingsViewModel.swift` — `Task { @MainActor }` + `defer` cleanup; symmetric Parakeet/Whisper readiness branches in `refreshModelStatus`.
- `Sources/MacParakeet/Views/Settings/SettingsView.swift` — `.notLoaded` badge text + icon + color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)