### PR TITLE
Replace 5-language Whisper picker with searchable popover (100 languages)

### DIFF
--- a/Sources/MacParakeet/Views/Settings/LanguagePickerPopover.swift
+++ b/Sources/MacParakeet/Views/Settings/LanguagePickerPopover.swift
@@ -30,6 +30,7 @@ struct LanguagePickerButton: View {
         }
         .buttonStyle(.bordered)
         .disabled(isDisabled)
+        .accessibilityLabel("Whisper language: \(WhisperLanguageCatalog.displayLabel(for: selection))")
         .popover(isPresented: $isShowing, arrowEdge: .bottom) {
             LanguagePickerPopover(selection: $selection) {
                 isShowing = false
@@ -82,7 +83,6 @@ struct LanguagePickerPopover: View {
                 .font(DesignSystem.Typography.bodySmall)
                 .textFieldStyle(.plain)
                 .focused($searchFocused)
-                .onSubmit { commitHighlighted() }
             if !query.isEmpty {
                 Button {
                     query = ""
@@ -116,7 +116,7 @@ struct LanguagePickerPopover: View {
     private var list: some View {
         ScrollViewReader { proxy in
             ScrollView {
-                LazyVStack(alignment: .leading, spacing: 0) {
+                VStack(alignment: .leading, spacing: 0) {
                     let rows = visibleRows
                     if rows.isEmpty {
                         emptyState
@@ -172,6 +172,7 @@ struct LanguagePickerPopover: View {
                     .imageScale(.small)
                     .foregroundStyle(isSelected ? DesignSystem.Colors.accent : .clear)
                     .frame(width: LanguagePickerLayout.checkmarkWidth)
+                    .accessibilityHidden(true)
                 Text(language.englishName)
                     .font(DesignSystem.Typography.bodySmall)
                     .foregroundStyle(DesignSystem.Colors.textPrimary)
@@ -197,6 +198,8 @@ struct LanguagePickerPopover: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel(for: language))
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
         .onHover { hovering in
             if hovering {
                 highlightedCode = language.code
@@ -227,6 +230,13 @@ struct LanguagePickerPopover: View {
     private func commit(_ code: String) {
         selection = code
         onCommit()
+    }
+
+    private func accessibilityLabel(for language: WhisperLanguage) -> String {
+        if language.nativeName.isEmpty || language.nativeName == language.englishName {
+            return language.englishName
+        }
+        return "\(language.englishName), \(language.nativeName)"
     }
 }
 
@@ -270,7 +280,9 @@ private struct KeyEventCatcher: NSViewRepresentable {
         var onDown: (() -> Void)?
         var onReturn: (() -> Void)?
 
-        private var monitor: Any?
+        // `deinit` is nonisolated; the AppKit monitor is installed and removed
+        // on the main thread during the view's lifetime.
+        nonisolated(unsafe) private var monitor: Any?
 
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()

--- a/Sources/MacParakeet/Views/Settings/LanguagePickerPopover.swift
+++ b/Sources/MacParakeet/Views/Settings/LanguagePickerPopover.swift
@@ -295,13 +295,13 @@ private struct KeyEventCatcher: NSViewRepresentable {
                         return event
                     }
                     switch event.keyCode {
-                    case 125: // arrow down
+                    case KeyCode.arrowDown:
                         self.onDown?()
                         return nil
-                    case 126: // arrow up
+                    case KeyCode.arrowUp:
                         self.onUp?()
                         return nil
-                    case 36, 76: // return / numpad enter
+                    case KeyCode.returnKey, KeyCode.keypadEnter:
                         self.onReturn?()
                         return nil
                     default:
@@ -325,6 +325,13 @@ private struct KeyEventCatcher: NSViewRepresentable {
                 return true
             }
             return false
+        }
+
+        private enum KeyCode {
+            static let arrowDown: UInt16 = 125
+            static let arrowUp: UInt16 = 126
+            static let returnKey: UInt16 = 36
+            static let keypadEnter: UInt16 = 76
         }
 
         deinit {

--- a/Sources/MacParakeet/Views/Settings/LanguagePickerPopover.swift
+++ b/Sources/MacParakeet/Views/Settings/LanguagePickerPopover.swift
@@ -1,0 +1,297 @@
+import AppKit
+import MacParakeetCore
+import SwiftUI
+
+/// Trigger button + popover wrapper used inline in settings rows.
+///
+/// The button shows the current selection's English label and a chevron.
+/// Tapping opens the popover; commit dismisses it. Disabled state matches the
+/// segmented engine picker so the row visually mutes when Whisper is inactive.
+struct LanguagePickerButton: View {
+    @Binding var selection: String
+    var isDisabled: Bool
+
+    @State private var isShowing = false
+
+    var body: some View {
+        Button {
+            isShowing = true
+        } label: {
+            HStack(spacing: 6) {
+                Text(WhisperLanguageCatalog.displayLabel(for: selection))
+                    .lineLimit(1)
+                Spacer(minLength: 4)
+                Image(systemName: "chevron.up.chevron.down")
+                    .imageScale(.small)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(width: 160)
+        }
+        .buttonStyle(.bordered)
+        .disabled(isDisabled)
+        .popover(isPresented: $isShowing, arrowEdge: .bottom) {
+            LanguagePickerPopover(selection: $selection) {
+                isShowing = false
+            }
+        }
+    }
+}
+
+/// Searchable popover for the full Whisper language list.
+///
+/// Layout: search field (autofocused) → divider → scrollable list with
+/// "Auto-detect" pinned at top, separated from the alphabetical full list.
+/// Selection commits and dismisses on click or ⏎; Esc dismisses (handled by
+/// the popover itself). Keyboard nav: ↑↓ moves the highlight, hover syncs it
+/// to whichever row the cursor is over so the two input modes don't fight.
+struct LanguagePickerPopover: View {
+    @Binding var selection: String
+    var onCommit: () -> Void
+
+    @State private var query = ""
+    @State private var highlightedCode: String
+    @FocusState private var searchFocused: Bool
+
+    init(selection: Binding<String>, onCommit: @escaping () -> Void) {
+        self._selection = selection
+        self.onCommit = onCommit
+        // Seed highlight with the current selection so opening the popover
+        // immediately points at the active language.
+        self._highlightedCode = State(initialValue: selection.wrappedValue)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            searchField
+            Divider()
+            list
+        }
+        .frame(width: 280)
+        .onAppear { searchFocused = true }
+    }
+
+    // MARK: - Search field
+
+    private var searchField: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .imageScale(.small)
+                .foregroundStyle(.secondary)
+            TextField("Search languages", text: $query)
+                .textFieldStyle(.plain)
+                .focused($searchFocused)
+                .onSubmit { commitHighlighted() }
+            if !query.isEmpty {
+                Button {
+                    query = ""
+                    searchFocused = true
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .imageScale(.small)
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear search")
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+    }
+
+    // MARK: - List
+
+    /// Visible rows after applying `query`. `auto` is included whenever the
+    /// query is empty or the typed text plausibly matches "auto".
+    private var visibleRows: [WhisperLanguage] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let results = WhisperLanguageCatalog.search(query)
+        let includesAuto = trimmed.isEmpty
+            || "auto".contains(trimmed)
+            || "auto-detect".contains(trimmed)
+        return includesAuto ? [WhisperLanguageCatalog.auto] + results : results
+    }
+
+    private var list: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    let rows = visibleRows
+                    if rows.isEmpty {
+                        emptyState
+                    } else {
+                        ForEach(Array(rows.enumerated()), id: \.element.code) { index, language in
+                            row(for: language)
+                                .id(language.code)
+                            if index == 0 && language.code == WhisperLanguageCatalog.autoCode && rows.count > 1 {
+                                Divider().padding(.horizontal, 8)
+                            }
+                        }
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+            .frame(maxHeight: 320)
+            .background(KeyEventCatcher(
+                onUp: { moveHighlight(by: -1, proxy: proxy) },
+                onDown: { moveHighlight(by: 1, proxy: proxy) },
+                onReturn: { commitHighlighted() }
+            ))
+            .onAppear {
+                proxy.scrollTo(highlightedCode, anchor: .center)
+            }
+            .onChange(of: query) { _, _ in
+                if let first = visibleRows.first {
+                    highlightedCode = first.code
+                    proxy.scrollTo(first.code, anchor: .top)
+                }
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        Text("No matches")
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 24)
+    }
+
+    // MARK: - Row
+
+    private func row(for language: WhisperLanguage) -> some View {
+        let isSelected = language.code == selection
+        let isHighlighted = language.code == highlightedCode
+
+        return Button {
+            commit(language.code)
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "checkmark")
+                    .imageScale(.small)
+                    .foregroundStyle(isSelected ? Color.accentColor : .clear)
+                    .frame(width: 12)
+                Text(language.englishName)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                Spacer(minLength: 8)
+                if !language.nativeName.isEmpty
+                    && language.nativeName != language.englishName {
+                    Text(language.nativeName)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(isHighlighted ? Color.accentColor.opacity(0.18) : Color.clear)
+            )
+            .padding(.horizontal, 4)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            if hovering {
+                highlightedCode = language.code
+            }
+        }
+    }
+
+    // MARK: - Keyboard nav
+
+    private func moveHighlight(by delta: Int, proxy: ScrollViewProxy) {
+        let rows = visibleRows
+        guard !rows.isEmpty else { return }
+        let currentIndex = rows.firstIndex(where: { $0.code == highlightedCode }) ?? 0
+        let newIndex = max(0, min(rows.count - 1, currentIndex + delta))
+        let code = rows[newIndex].code
+        highlightedCode = code
+        proxy.scrollTo(code, anchor: nil)
+    }
+
+    private func commitHighlighted() {
+        if visibleRows.contains(where: { $0.code == highlightedCode }) {
+            commit(highlightedCode)
+        } else if let first = visibleRows.first {
+            commit(first.code)
+        }
+    }
+
+    private func commit(_ code: String) {
+        selection = code
+        onCommit()
+    }
+}
+
+// MARK: - Key event catcher
+//
+// `.onKeyPress` only fires on the focused responder, which is the search
+// `TextField`. Plumbing arrow keys through the text field is unreliable —
+// arrows move the caret instead — so we drop a tiny `NSView` that lives
+// alongside the list and intercepts ↑/↓/↩ at the AppKit responder chain. It
+// never takes first responder away from the search field.
+
+private struct KeyEventCatcher: NSViewRepresentable {
+    let onUp: () -> Void
+    let onDown: () -> Void
+    let onReturn: () -> Void
+
+    func makeNSView(context: Context) -> CatcherView {
+        let view = CatcherView()
+        view.onUp = onUp
+        view.onDown = onDown
+        view.onReturn = onReturn
+        return view
+    }
+
+    func updateNSView(_ nsView: CatcherView, context: Context) {
+        nsView.onUp = onUp
+        nsView.onDown = onDown
+        nsView.onReturn = onReturn
+    }
+
+    final class CatcherView: NSView {
+        var onUp: (() -> Void)?
+        var onDown: (() -> Void)?
+        var onReturn: (() -> Void)?
+
+        private var monitor: Any?
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            if window != nil, monitor == nil {
+                monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+                    guard let self, let window = self.window, event.window === window else {
+                        return event
+                    }
+                    switch event.keyCode {
+                    case 125: // arrow down
+                        self.onDown?()
+                        return nil
+                    case 126: // arrow up
+                        self.onUp?()
+                        return nil
+                    case 36, 76: // return / numpad enter
+                        self.onReturn?()
+                        return nil
+                    default:
+                        return event
+                    }
+                }
+            } else if window == nil, let monitor {
+                NSEvent.removeMonitor(monitor)
+                self.monitor = nil
+            }
+        }
+
+        deinit {
+            if let monitor {
+                NSEvent.removeMonitor(monitor)
+            }
+        }
+    }
+}

--- a/Sources/MacParakeet/Views/Settings/LanguagePickerPopover.swift
+++ b/Sources/MacParakeet/Views/Settings/LanguagePickerPopover.swift
@@ -17,15 +17,16 @@ struct LanguagePickerButton: View {
         Button {
             isShowing = true
         } label: {
-            HStack(spacing: 6) {
+            HStack(spacing: DesignSystem.Spacing.xs) {
                 Text(WhisperLanguageCatalog.displayLabel(for: selection))
+                    .font(DesignSystem.Typography.bodySmall)
                     .lineLimit(1)
-                Spacer(minLength: 4)
+                Spacer(minLength: DesignSystem.Spacing.xs)
                 Image(systemName: "chevron.up.chevron.down")
                     .imageScale(.small)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
             }
-            .frame(width: 160)
+            .frame(width: LanguagePickerLayout.buttonWidth)
         }
         .buttonStyle(.bordered)
         .disabled(isDisabled)
@@ -66,18 +67,19 @@ struct LanguagePickerPopover: View {
             Divider()
             list
         }
-        .frame(width: 280)
+        .frame(width: LanguagePickerLayout.popoverWidth)
         .onAppear { searchFocused = true }
     }
 
     // MARK: - Search field
 
     private var searchField: some View {
-        HStack(spacing: 6) {
+        HStack(spacing: DesignSystem.Spacing.xs) {
             Image(systemName: "magnifyingglass")
                 .imageScale(.small)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
             TextField("Search languages", text: $query)
+                .font(DesignSystem.Typography.bodySmall)
                 .textFieldStyle(.plain)
                 .focused($searchFocused)
                 .onSubmit { commitHighlighted() }
@@ -88,14 +90,14 @@ struct LanguagePickerPopover: View {
                 } label: {
                     Image(systemName: "xmark.circle.fill")
                         .imageScale(.small)
-                        .foregroundStyle(.tertiary)
+                        .foregroundStyle(DesignSystem.Colors.textTertiary)
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Clear search")
             }
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
+        .padding(.horizontal, DesignSystem.Spacing.sm)
+        .padding(.vertical, DesignSystem.Spacing.sm)
     }
 
     // MARK: - List
@@ -123,14 +125,14 @@ struct LanguagePickerPopover: View {
                             row(for: language)
                                 .id(language.code)
                             if index == 0 && language.code == WhisperLanguageCatalog.autoCode && rows.count > 1 {
-                                Divider().padding(.horizontal, 8)
+                                Divider().padding(.horizontal, DesignSystem.Spacing.sm)
                             }
                         }
                     }
                 }
-                .padding(.vertical, 4)
+                .padding(.vertical, DesignSystem.Spacing.xs)
             }
-            .frame(maxHeight: 320)
+            .frame(maxHeight: LanguagePickerLayout.listMaxHeight)
             .background(KeyEventCatcher(
                 onUp: { moveHighlight(by: -1, proxy: proxy) },
                 onDown: { moveHighlight(by: 1, proxy: proxy) },
@@ -150,10 +152,10 @@ struct LanguagePickerPopover: View {
 
     private var emptyState: some View {
         Text("No matches")
-            .font(.callout)
-            .foregroundStyle(.secondary)
+            .font(DesignSystem.Typography.bodySmall)
+            .foregroundStyle(DesignSystem.Colors.textSecondary)
             .frame(maxWidth: .infinity)
-            .padding(.vertical, 24)
+            .padding(.vertical, DesignSystem.Spacing.lg)
     }
 
     // MARK: - Row
@@ -165,32 +167,33 @@ struct LanguagePickerPopover: View {
         return Button {
             commit(language.code)
         } label: {
-            HStack(spacing: 8) {
+            HStack(spacing: DesignSystem.Spacing.sm) {
                 Image(systemName: "checkmark")
                     .imageScale(.small)
-                    .foregroundStyle(isSelected ? Color.accentColor : .clear)
-                    .frame(width: 12)
+                    .foregroundStyle(isSelected ? DesignSystem.Colors.accent : .clear)
+                    .frame(width: LanguagePickerLayout.checkmarkWidth)
                 Text(language.englishName)
-                    .foregroundStyle(.primary)
+                    .font(DesignSystem.Typography.bodySmall)
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
                     .lineLimit(1)
-                Spacer(minLength: 8)
+                Spacer(minLength: DesignSystem.Spacing.sm)
                 if !language.nativeName.isEmpty
                     && language.nativeName != language.englishName {
                     Text(language.nativeName)
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
+                        .font(DesignSystem.Typography.bodySmall)
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
                         .lineLimit(1)
                         .truncationMode(.tail)
                 }
             }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 5)
+            .padding(.horizontal, DesignSystem.Spacing.sm)
+            .padding(.vertical, DesignSystem.Spacing.xs)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
-                RoundedRectangle(cornerRadius: 5, style: .continuous)
-                    .fill(isHighlighted ? Color.accentColor.opacity(0.18) : Color.clear)
+                RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius, style: .continuous)
+                    .fill(isHighlighted ? DesignSystem.Colors.accent.opacity(LanguagePickerLayout.highlightOpacity) : Color.clear)
             )
-            .padding(.horizontal, 4)
+            .padding(.horizontal, DesignSystem.Spacing.xs)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -225,6 +228,14 @@ struct LanguagePickerPopover: View {
         selection = code
         onCommit()
     }
+}
+
+private enum LanguagePickerLayout {
+    static let buttonWidth: CGFloat = 160
+    static let popoverWidth: CGFloat = 280
+    static let listMaxHeight: CGFloat = 320
+    static let checkmarkWidth: CGFloat = 12
+    static let highlightOpacity = 0.18
 }
 
 // MARK: - Key event catcher
@@ -268,6 +279,9 @@ private struct KeyEventCatcher: NSViewRepresentable {
                     guard let self, let window = self.window, event.window === window else {
                         return event
                     }
+                    guard !self.shouldPassThrough(event, in: window) else {
+                        return event
+                    }
                     switch event.keyCode {
                     case 125: // arrow down
                         self.onDown?()
@@ -286,6 +300,19 @@ private struct KeyEventCatcher: NSViewRepresentable {
                 NSEvent.removeMonitor(monitor)
                 self.monitor = nil
             }
+        }
+
+        private func shouldPassThrough(_ event: NSEvent, in window: NSWindow) -> Bool {
+            if !event.modifierFlags.intersection([.command, .option, .control, .shift]).isEmpty {
+                return true
+            }
+            if let textView = window.firstResponder as? NSTextView, textView.hasMarkedText() {
+                return true
+            }
+            if let fieldEditor = window.fieldEditor(false, for: nil) as? NSTextView, fieldEditor.hasMarkedText() {
+                return true
+            }
+            return false
         }
 
         deinit {

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -801,16 +801,10 @@ struct SettingsView: View {
                         detail: "Only used when Whisper is active. Auto-detect works for most files."
                     )
                     Spacer(minLength: DesignSystem.Spacing.md)
-                    Picker("Whisper language", selection: $viewModel.whisperDefaultLanguage) {
-                        Text("Auto").tag("auto")
-                        Text("English").tag("en")
-                        Text("Korean").tag("ko")
-                        Text("Japanese").tag("ja")
-                        Text("Mandarin").tag("zh")
-                    }
-                    .labelsHidden()
-                    .frame(width: 160)
-                    .disabled(viewModel.speechEnginePreference != .whisper)
+                    LanguagePickerButton(
+                        selection: $viewModel.whisperDefaultLanguage,
+                        isDisabled: viewModel.speechEnginePreference != .whisper
+                    )
                 }
 
                 Divider()

--- a/Sources/MacParakeetCore/WhisperLanguageCatalog.swift
+++ b/Sources/MacParakeetCore/WhisperLanguageCatalog.swift
@@ -130,6 +130,23 @@ public enum WhisperLanguageCatalog {
         uniqueKeysWithValues: all.map { ($0.code, $0) }
     )
 
+    /// WhisperKit accepts a handful of alternate names for the same language
+    /// token. Keep those searchable so the UI does not hide supported inputs
+    /// behind one preferred English label.
+    private static let aliasesByCode: [String: [String]] = [
+        "ca": ["valencian"],
+        "es": ["castilian"],
+        "ht": ["haitian"],
+        "lb": ["letzeburgesch"],
+        "my": ["myanmar"],
+        "nl": ["flemish"],
+        "pa": ["panjabi"],
+        "ps": ["pushto"],
+        "ro": ["moldavian", "moldovan"],
+        "si": ["sinhalese"],
+        "zh": ["mandarin"],
+    ]
+
     public static func language(forCode code: String) -> WhisperLanguage? {
         byCode[code.lowercased()]
     }
@@ -145,28 +162,36 @@ public enum WhisperLanguageCatalog {
 
     /// Returns languages ranked by relevance to `query`.
     /// Empty query returns the alphabetical list as-is (no Auto row).
-    /// Ranking: code-exact (0) → English-prefix (1) → native-prefix (2) → English-substring (3) → native-substring (4).
+    /// Ranking: code-exact → code-prefix → English-prefix → native-prefix
+    /// → alias-prefix → English-substring → native-substring → alias-substring.
     /// Within a rank, alphabetical by English name.
     public static func search(_ query: String) -> [WhisperLanguage] {
-        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let trimmed = normalizedSearchTerm(query)
         guard !trimmed.isEmpty else { return all }
 
         var results: [(rank: Int, language: WhisperLanguage)] = []
         for language in all {
-            let english = language.englishName.lowercased()
-            let native = language.nativeName.lowercased()
-            let code = language.code.lowercased()
+            let english = normalizedSearchTerm(language.englishName)
+            let native = normalizedSearchTerm(language.nativeName)
+            let code = normalizedSearchTerm(language.code)
+            let aliases = aliasesByCode[language.code, default: []].map(normalizedSearchTerm)
             let rank: Int
             if code == trimmed {
                 rank = 0
-            } else if english.hasPrefix(trimmed) {
+            } else if code.hasPrefix(trimmed) {
                 rank = 1
-            } else if !native.isEmpty && native.hasPrefix(trimmed) {
+            } else if english.hasPrefix(trimmed) {
                 rank = 2
-            } else if english.contains(trimmed) {
+            } else if !native.isEmpty && native.hasPrefix(trimmed) {
                 rank = 3
-            } else if native.contains(trimmed) {
+            } else if aliases.contains(where: { $0.hasPrefix(trimmed) }) {
                 rank = 4
+            } else if english.contains(trimmed) {
+                rank = 5
+            } else if native.contains(trimmed) {
+                rank = 6
+            } else if aliases.contains(where: { $0.contains(trimmed) }) {
+                rank = 7
             } else {
                 continue
             }
@@ -179,5 +204,12 @@ public enum WhisperLanguageCatalog {
                 return lhs.language.englishName < rhs.language.englishName
             }
             .map(\.language)
+    }
+
+    private static func normalizedSearchTerm(_ value: String) -> String {
+        value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: Locale(identifier: "en_US_POSIX"))
+            .lowercased()
     }
 }

--- a/Sources/MacParakeetCore/WhisperLanguageCatalog.swift
+++ b/Sources/MacParakeetCore/WhisperLanguageCatalog.swift
@@ -1,0 +1,183 @@
+import Foundation
+
+public struct WhisperLanguage: Hashable, Sendable, Identifiable {
+    public let code: String
+    public let englishName: String
+    public let nativeName: String
+
+    public init(code: String, englishName: String, nativeName: String) {
+        self.code = code
+        self.englishName = englishName
+        self.nativeName = nativeName
+    }
+
+    public var id: String { code }
+}
+
+public enum WhisperLanguageCatalog {
+    public static let autoCode = "auto"
+
+    public static let auto = WhisperLanguage(
+        code: autoCode,
+        englishName: "Auto-detect",
+        nativeName: ""
+    )
+
+    public static let all: [WhisperLanguage] = [
+        WhisperLanguage(code: "af", englishName: "Afrikaans", nativeName: "Afrikaans"),
+        WhisperLanguage(code: "sq", englishName: "Albanian", nativeName: "Shqip"),
+        WhisperLanguage(code: "am", englishName: "Amharic", nativeName: "አማርኛ"),
+        WhisperLanguage(code: "ar", englishName: "Arabic", nativeName: "العربية"),
+        WhisperLanguage(code: "hy", englishName: "Armenian", nativeName: "Հայերեն"),
+        WhisperLanguage(code: "as", englishName: "Assamese", nativeName: "অসমীয়া"),
+        WhisperLanguage(code: "az", englishName: "Azerbaijani", nativeName: "Azərbaycan"),
+        WhisperLanguage(code: "ba", englishName: "Bashkir", nativeName: "Башҡортса"),
+        WhisperLanguage(code: "eu", englishName: "Basque", nativeName: "Euskara"),
+        WhisperLanguage(code: "be", englishName: "Belarusian", nativeName: "Беларуская"),
+        WhisperLanguage(code: "bn", englishName: "Bengali", nativeName: "বাংলা"),
+        WhisperLanguage(code: "bs", englishName: "Bosnian", nativeName: "Bosanski"),
+        WhisperLanguage(code: "br", englishName: "Breton", nativeName: "Brezhoneg"),
+        WhisperLanguage(code: "bg", englishName: "Bulgarian", nativeName: "Български"),
+        WhisperLanguage(code: "my", englishName: "Burmese", nativeName: "မြန်မာ"),
+        WhisperLanguage(code: "yue", englishName: "Cantonese", nativeName: "粵語"),
+        WhisperLanguage(code: "ca", englishName: "Catalan", nativeName: "Català"),
+        WhisperLanguage(code: "zh", englishName: "Chinese", nativeName: "中文"),
+        WhisperLanguage(code: "hr", englishName: "Croatian", nativeName: "Hrvatski"),
+        WhisperLanguage(code: "cs", englishName: "Czech", nativeName: "Čeština"),
+        WhisperLanguage(code: "da", englishName: "Danish", nativeName: "Dansk"),
+        WhisperLanguage(code: "nl", englishName: "Dutch", nativeName: "Nederlands"),
+        WhisperLanguage(code: "en", englishName: "English", nativeName: "English"),
+        WhisperLanguage(code: "et", englishName: "Estonian", nativeName: "Eesti"),
+        WhisperLanguage(code: "fo", englishName: "Faroese", nativeName: "Føroyskt"),
+        WhisperLanguage(code: "fi", englishName: "Finnish", nativeName: "Suomi"),
+        WhisperLanguage(code: "fr", englishName: "French", nativeName: "Français"),
+        WhisperLanguage(code: "gl", englishName: "Galician", nativeName: "Galego"),
+        WhisperLanguage(code: "ka", englishName: "Georgian", nativeName: "ქართული"),
+        WhisperLanguage(code: "de", englishName: "German", nativeName: "Deutsch"),
+        WhisperLanguage(code: "el", englishName: "Greek", nativeName: "Ελληνικά"),
+        WhisperLanguage(code: "gu", englishName: "Gujarati", nativeName: "ગુજરાતી"),
+        WhisperLanguage(code: "ht", englishName: "Haitian Creole", nativeName: "Kreyòl Ayisyen"),
+        WhisperLanguage(code: "ha", englishName: "Hausa", nativeName: "Hausa"),
+        WhisperLanguage(code: "haw", englishName: "Hawaiian", nativeName: "ʻŌlelo Hawaiʻi"),
+        WhisperLanguage(code: "he", englishName: "Hebrew", nativeName: "עברית"),
+        WhisperLanguage(code: "hi", englishName: "Hindi", nativeName: "हिन्दी"),
+        WhisperLanguage(code: "hu", englishName: "Hungarian", nativeName: "Magyar"),
+        WhisperLanguage(code: "is", englishName: "Icelandic", nativeName: "Íslenska"),
+        WhisperLanguage(code: "id", englishName: "Indonesian", nativeName: "Bahasa Indonesia"),
+        WhisperLanguage(code: "it", englishName: "Italian", nativeName: "Italiano"),
+        WhisperLanguage(code: "ja", englishName: "Japanese", nativeName: "日本語"),
+        WhisperLanguage(code: "jw", englishName: "Javanese", nativeName: "Basa Jawa"),
+        WhisperLanguage(code: "kn", englishName: "Kannada", nativeName: "ಕನ್ನಡ"),
+        WhisperLanguage(code: "kk", englishName: "Kazakh", nativeName: "Қазақша"),
+        WhisperLanguage(code: "km", englishName: "Khmer", nativeName: "ខ្មែរ"),
+        WhisperLanguage(code: "ko", englishName: "Korean", nativeName: "한국어"),
+        WhisperLanguage(code: "lo", englishName: "Lao", nativeName: "ລາວ"),
+        WhisperLanguage(code: "la", englishName: "Latin", nativeName: "Latina"),
+        WhisperLanguage(code: "lv", englishName: "Latvian", nativeName: "Latviešu"),
+        WhisperLanguage(code: "ln", englishName: "Lingala", nativeName: "Lingála"),
+        WhisperLanguage(code: "lt", englishName: "Lithuanian", nativeName: "Lietuvių"),
+        WhisperLanguage(code: "lb", englishName: "Luxembourgish", nativeName: "Lëtzebuergesch"),
+        WhisperLanguage(code: "mk", englishName: "Macedonian", nativeName: "Македонски"),
+        WhisperLanguage(code: "mg", englishName: "Malagasy", nativeName: "Malagasy"),
+        WhisperLanguage(code: "ms", englishName: "Malay", nativeName: "Bahasa Melayu"),
+        WhisperLanguage(code: "ml", englishName: "Malayalam", nativeName: "മലയാളം"),
+        WhisperLanguage(code: "mt", englishName: "Maltese", nativeName: "Malti"),
+        WhisperLanguage(code: "mi", englishName: "Maori", nativeName: "Māori"),
+        WhisperLanguage(code: "mr", englishName: "Marathi", nativeName: "मराठी"),
+        WhisperLanguage(code: "mn", englishName: "Mongolian", nativeName: "Монгол"),
+        WhisperLanguage(code: "ne", englishName: "Nepali", nativeName: "नेपाली"),
+        WhisperLanguage(code: "no", englishName: "Norwegian", nativeName: "Norsk"),
+        WhisperLanguage(code: "nn", englishName: "Norwegian Nynorsk", nativeName: "Nynorsk"),
+        WhisperLanguage(code: "oc", englishName: "Occitan", nativeName: "Occitan"),
+        WhisperLanguage(code: "ps", englishName: "Pashto", nativeName: "پښتو"),
+        WhisperLanguage(code: "fa", englishName: "Persian", nativeName: "فارسی"),
+        WhisperLanguage(code: "pl", englishName: "Polish", nativeName: "Polski"),
+        WhisperLanguage(code: "pt", englishName: "Portuguese", nativeName: "Português"),
+        WhisperLanguage(code: "pa", englishName: "Punjabi", nativeName: "ਪੰਜਾਬੀ"),
+        WhisperLanguage(code: "ro", englishName: "Romanian", nativeName: "Română"),
+        WhisperLanguage(code: "ru", englishName: "Russian", nativeName: "Русский"),
+        WhisperLanguage(code: "sa", englishName: "Sanskrit", nativeName: "संस्कृतम्"),
+        WhisperLanguage(code: "sr", englishName: "Serbian", nativeName: "Српски"),
+        WhisperLanguage(code: "sn", englishName: "Shona", nativeName: "ChiShona"),
+        WhisperLanguage(code: "sd", englishName: "Sindhi", nativeName: "سنڌي"),
+        WhisperLanguage(code: "si", englishName: "Sinhala", nativeName: "සිංහල"),
+        WhisperLanguage(code: "sk", englishName: "Slovak", nativeName: "Slovenčina"),
+        WhisperLanguage(code: "sl", englishName: "Slovenian", nativeName: "Slovenščina"),
+        WhisperLanguage(code: "so", englishName: "Somali", nativeName: "Soomaali"),
+        WhisperLanguage(code: "es", englishName: "Spanish", nativeName: "Español"),
+        WhisperLanguage(code: "su", englishName: "Sundanese", nativeName: "Basa Sunda"),
+        WhisperLanguage(code: "sw", englishName: "Swahili", nativeName: "Kiswahili"),
+        WhisperLanguage(code: "sv", englishName: "Swedish", nativeName: "Svenska"),
+        WhisperLanguage(code: "tl", englishName: "Tagalog", nativeName: "Tagalog"),
+        WhisperLanguage(code: "tg", englishName: "Tajik", nativeName: "Тоҷикӣ"),
+        WhisperLanguage(code: "ta", englishName: "Tamil", nativeName: "தமிழ்"),
+        WhisperLanguage(code: "tt", englishName: "Tatar", nativeName: "Татар"),
+        WhisperLanguage(code: "te", englishName: "Telugu", nativeName: "తెలుగు"),
+        WhisperLanguage(code: "th", englishName: "Thai", nativeName: "ภาษาไทย"),
+        WhisperLanguage(code: "bo", englishName: "Tibetan", nativeName: "བོད་སྐད་"),
+        WhisperLanguage(code: "tr", englishName: "Turkish", nativeName: "Türkçe"),
+        WhisperLanguage(code: "tk", englishName: "Turkmen", nativeName: "Türkmen"),
+        WhisperLanguage(code: "uk", englishName: "Ukrainian", nativeName: "Українська"),
+        WhisperLanguage(code: "ur", englishName: "Urdu", nativeName: "اردو"),
+        WhisperLanguage(code: "uz", englishName: "Uzbek", nativeName: "Oʻzbekcha"),
+        WhisperLanguage(code: "vi", englishName: "Vietnamese", nativeName: "Tiếng Việt"),
+        WhisperLanguage(code: "cy", englishName: "Welsh", nativeName: "Cymraeg"),
+        WhisperLanguage(code: "yi", englishName: "Yiddish", nativeName: "ייִדיש"),
+        WhisperLanguage(code: "yo", englishName: "Yoruba", nativeName: "Yorùbá"),
+    ]
+
+    private static let byCode: [String: WhisperLanguage] = Dictionary(
+        uniqueKeysWithValues: all.map { ($0.code, $0) }
+    )
+
+    public static func language(forCode code: String) -> WhisperLanguage? {
+        byCode[code.lowercased()]
+    }
+
+    /// User-facing label for the picker button. Falls back to upper-cased code
+    /// for unknown values so a stale UserDefaults entry still renders something.
+    public static func displayLabel(for code: String) -> String {
+        if code.isEmpty || code.lowercased() == autoCode {
+            return auto.englishName
+        }
+        return language(forCode: code)?.englishName ?? code.uppercased()
+    }
+
+    /// Returns languages ranked by relevance to `query`.
+    /// Empty query returns the alphabetical list as-is (no Auto row).
+    /// Ranking: code-exact (0) → English-prefix (1) → native-prefix (2) → English-substring (3) → native-substring (4).
+    /// Within a rank, alphabetical by English name.
+    public static func search(_ query: String) -> [WhisperLanguage] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !trimmed.isEmpty else { return all }
+
+        var results: [(rank: Int, language: WhisperLanguage)] = []
+        for language in all {
+            let english = language.englishName.lowercased()
+            let native = language.nativeName.lowercased()
+            let code = language.code.lowercased()
+            let rank: Int
+            if code == trimmed {
+                rank = 0
+            } else if english.hasPrefix(trimmed) {
+                rank = 1
+            } else if !native.isEmpty && native.hasPrefix(trimmed) {
+                rank = 2
+            } else if english.contains(trimmed) {
+                rank = 3
+            } else if native.contains(trimmed) {
+                rank = 4
+            } else {
+                continue
+            }
+            results.append((rank, language))
+        }
+
+        return results
+            .sorted { lhs, rhs in
+                if lhs.rank != rhs.rank { return lhs.rank < rhs.rank }
+                return lhs.language.englishName < rhs.language.englishName
+            }
+            .map(\.language)
+    }
+}

--- a/Tests/MacParakeetTests/STT/WhisperLanguageCatalogTests.swift
+++ b/Tests/MacParakeetTests/STT/WhisperLanguageCatalogTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class WhisperLanguageCatalogTests: XCTestCase {
+
+    func testCatalogContainsExpectedLanguageCount() {
+        // WhisperKit's `Constants.languages` resolves to 100 unique codes
+        // (Cantonese has its own `yue` distinct from Mandarin's `zh`).
+        XCTAssertEqual(WhisperLanguageCatalog.all.count, 100)
+    }
+
+    func testAllCodesAreUnique() {
+        let codes = WhisperLanguageCatalog.all.map(\.code)
+        XCTAssertEqual(Set(codes).count, codes.count, "duplicate language code in catalog")
+    }
+
+    func testCatalogIsSortedAlphabeticallyByEnglishName() {
+        let names = WhisperLanguageCatalog.all.map(\.englishName)
+        XCTAssertEqual(names, names.sorted(), "catalog must be alphabetical")
+    }
+
+    func testCanonicalLanguagesArePresent() {
+        let codes = Set(WhisperLanguageCatalog.all.map(\.code))
+        for code in ["en", "ko", "ja", "zh", "es", "fr", "vi", "hi", "ar", "ru", "yue"] {
+            XCTAssertTrue(codes.contains(code), "missing expected language code \(code)")
+        }
+    }
+
+    func testEveryEntryHasNonEmptyNames() {
+        for language in WhisperLanguageCatalog.all {
+            XCTAssertFalse(language.code.isEmpty)
+            XCTAssertFalse(language.englishName.isEmpty, "missing english name for \(language.code)")
+            XCTAssertFalse(language.nativeName.isEmpty, "missing native name for \(language.code)")
+        }
+    }
+
+    func testLookupByCodeIsCaseInsensitive() {
+        XCTAssertEqual(WhisperLanguageCatalog.language(forCode: "KO")?.englishName, "Korean")
+        XCTAssertEqual(WhisperLanguageCatalog.language(forCode: "ko")?.englishName, "Korean")
+    }
+
+    func testLookupReturnsNilForUnknownCode() {
+        XCTAssertNil(WhisperLanguageCatalog.language(forCode: "xx"))
+    }
+
+    func testDisplayLabelHandlesAutoAndUnknownCodes() {
+        XCTAssertEqual(WhisperLanguageCatalog.displayLabel(for: "auto"), "Auto-detect")
+        XCTAssertEqual(WhisperLanguageCatalog.displayLabel(for: ""), "Auto-detect")
+        XCTAssertEqual(WhisperLanguageCatalog.displayLabel(for: "ko"), "Korean")
+        XCTAssertEqual(WhisperLanguageCatalog.displayLabel(for: "xx"), "XX")
+    }
+
+    func testEmptySearchReturnsFullAlphabeticalList() {
+        let results = WhisperLanguageCatalog.search("")
+        XCTAssertEqual(results.count, WhisperLanguageCatalog.all.count)
+        XCTAssertEqual(results.first?.englishName, WhisperLanguageCatalog.all.first?.englishName)
+    }
+
+    func testCodeExactMatchOutranksPrefixMatch() {
+        // "es" is the Spanish code AND the prefix of "Estonian".
+        // Spanish should come first because code-exact (rank 0) outranks
+        // English-prefix (rank 1).
+        let results = WhisperLanguageCatalog.search("es")
+        XCTAssertEqual(results.first?.code, "es", "code match should rank above prefix match")
+        XCTAssertTrue(results.contains { $0.code == "et" }, "Estonian should still appear")
+    }
+
+    func testEnglishPrefixMatchesAreReturned() {
+        let results = WhisperLanguageCatalog.search("japan")
+        XCTAssertEqual(results.first?.code, "ja")
+    }
+
+    func testNativeScriptSearchFindsKorean() {
+        // Typing the first jamo of 한국어 should find Korean via native-prefix.
+        let results = WhisperLanguageCatalog.search("한")
+        XCTAssertEqual(results.first?.code, "ko")
+    }
+
+    func testNoMatchReturnsEmpty() {
+        XCTAssertTrue(WhisperLanguageCatalog.search("ZZZZZZZ").isEmpty)
+    }
+
+    func testNormalizationRoundTripIsLossless() {
+        // `SpeechEnginePreference.normalizeLanguage` lowercases; ensure every
+        // catalog code survives that pass unchanged so we never silently drop
+        // a saved selection.
+        for language in WhisperLanguageCatalog.all {
+            XCTAssertEqual(
+                SpeechEnginePreference.normalizeLanguage(language.code),
+                language.code,
+                "code \(language.code) should round-trip through normalizeLanguage"
+            )
+        }
+    }
+
+    func testAutoCodeNormalizesToNil() {
+        XCTAssertNil(SpeechEnginePreference.normalizeLanguage(WhisperLanguageCatalog.autoCode))
+    }
+}

--- a/Tests/MacParakeetTests/STT/WhisperLanguageCatalogTests.swift
+++ b/Tests/MacParakeetTests/STT/WhisperLanguageCatalogTests.swift
@@ -58,11 +58,15 @@ final class WhisperLanguageCatalogTests: XCTestCase {
 
     func testCodeExactMatchOutranksPrefixMatch() {
         // "es" is the Spanish code AND the prefix of "Estonian".
-        // Spanish should come first because code-exact (rank 0) outranks
-        // English-prefix (rank 1).
+        // Spanish should come first because code-exact outranks English-prefix.
         let results = WhisperLanguageCatalog.search("es")
         XCTAssertEqual(results.first?.code, "es", "code match should rank above prefix match")
         XCTAssertTrue(results.contains { $0.code == "et" }, "Estonian should still appear")
+    }
+
+    func testCodePrefixMatchesMultiCharacterCodes() {
+        let results = WhisperLanguageCatalog.search("yu")
+        XCTAssertEqual(results.first?.code, "yue")
     }
 
     func testEnglishPrefixMatchesAreReturned() {
@@ -74,6 +78,17 @@ final class WhisperLanguageCatalogTests: XCTestCase {
         // Typing the first jamo of 한국어 should find Korean via native-prefix.
         let results = WhisperLanguageCatalog.search("한")
         XCTAssertEqual(results.first?.code, "ko")
+    }
+
+    func testAliasSearchFindsWhisperKitNames() {
+        XCTAssertEqual(WhisperLanguageCatalog.search("mandarin").first?.code, "zh")
+        XCTAssertEqual(WhisperLanguageCatalog.search("castilian").first?.code, "es")
+        XCTAssertEqual(WhisperLanguageCatalog.search("myanmar").first?.code, "my")
+    }
+
+    func testNativeScriptSearchIsDiacriticInsensitive() {
+        let results = WhisperLanguageCatalog.search("espanol")
+        XCTAssertEqual(results.first?.code, "es")
     }
 
     func testNoMatchReturnsEmpty() {


### PR DESCRIPTION
## Summary

The Whisper language setting used to be a 5-item dropdown — Auto, English, Korean, Japanese, Mandarin. That covered CJK well but excluded the audience that actually *needs* Whisper because Parakeet doesn't speak their language: Vietnamese, Hindi, Arabic, Russian, and ~90 others. This PR ships the full Whisper language list (100 codes) behind a searchable popover that follows the same macOS-native idiom as System Settings → Language & Region.

## Visual change

```
Before                         After
──────                         ─────
[ Korean       ▾ ]             [ Korean       ▾ ]
   Auto                              │
   English                           ▼ popover
   Korean                            ┌──────────────────────────────┐
   Japanese                          │ 🔍 Search                    │
 ✓ Mandarin                          ├──────────────────────────────┤
                                     │ Auto-detect              ✓   │
                                     ├──────────────────────────────┤
                                     │ Afrikaans         Afrikaans  │
                                     │ Albanian              Shqip  │
                                     │ Amharic              አማርኛ   │
                                     │ Arabic              العربية  │
                                     │ … (100 languages, scrollable)│
                                     │ Korean              한국어   │
                                     │ … type to filter             │
                                     └──────────────────────────────┘
                                     ↑↓ highlight · ⏎ commit · ⎋ dismiss
```

## Why this and not other options

| Option | Verdict |
| --- | --- |
| Long native menu w/ 100 items | No — `NSMenu` past ~20 items is unscannable, no search |
| Submenu by region (Asia / Europe / …) | No — adds taxonomy users have to learn before they can find their language |
| Modal sheet | Too heavy for a single-value pick — popover dismisses on outside click |
| **Searchable popover** | **Yes** — same pattern Apple uses for Time Zone, Add Language |

## Design choices

- **Auto pinned + divider, never sorted into the list.** Auto is the default and conceptually different from "pick a specific language" — it must always be visible without scrolling.
- **English name + native script side by side.** Searchable in either: typing `ko`, `한`, or `kor` all surface Korean. Native name renders in secondary color so the English-name column stays the dominant scan target.
- **Ranking: code-exact → code-prefix → English-prefix → native-prefix → alias-prefix → English-substring → native-substring → alias-substring.** `es` returns Spanish first (code match) instead of Estonian (English prefix). `mandarin` (a WhisperKit alias for `zh`) still finds Chinese. Within a rank, alphabetical by English name.
- **Diacritic-insensitive folding.** `espanol` finds Español; `turkce` finds Türkçe. Native scripts (Hangul, Arabic, Hebrew, etc.) survive folding intact.
- **Keyboard nav via `NSEvent.addLocalMonitorForEvents`, not `.onKeyPress`.** Focus lives on the search `TextField`, so SwiftUI's `.onKeyPress` would either compete with caret navigation or never fire. A small AppKit key catcher intercepts ↑/↓/⏎ at the responder chain. It passes events through whenever modifier keys are present or the field editor has marked text (active IME composition) so Korean/Japanese/Chinese users can compose freely without the popover stealing their Return.
- **Hover syncs highlight.** Without this, mouse-hovered row + keyboard highlight diverge and ⏎ commits the wrong thing.

## What was deferred

- **Recents / favorites** — adds persistence + eviction policy. Defer until asked.
- **Region grouping** (Asia / Europe / …) — alphabetical + search beats taxonomy users have to learn before they can find their language.
- **Per-language model-size hints** — interesting but tangential.

## Why now

Follow-up to #167 (multilingual WhisperKit) and #169 (Whisper engine-switch UX fixes). With Whisper now selectable in production, the static 5-item list became the next visible bottleneck — particularly for non-CJK Whisper audiences who literally couldn't pin their language without falling back to Auto.

## Files changed

- `Sources/MacParakeetCore/WhisperLanguageCatalog.swift` (new, 100 entries + ranked search + WhisperKit aliases)
- `Sources/MacParakeet/Views/Settings/LanguagePickerPopover.swift` (new, button + popover + AppKit key catcher with IME pass-through)
- `Sources/MacParakeet/Views/Settings/SettingsView.swift` (replaced inline Picker — 14 lines down to 4)
- `Tests/MacParakeetTests/STT/WhisperLanguageCatalogTests.swift` (new, 18 focused tests)

## Test plan

- [x] `swift test` — 1833 XCTest + 13 Swift Testing pass, including 18 new catalog tests
- [ ] Open Settings → Speech Recognition, switch to Whisper, click the language button — popover opens, search field is autofocused, current selection is centered in view
- [ ] Type `ko` → Korean is first; `한` → Korean is first; `es` → Spanish is first (code match), Estonian below; `mandarin` → Chinese; `espanol` → Español
- [ ] Use ↑/↓ to walk the list, ⏎ to commit, hover a row and ⏎ commits that one
- [ ] Switch to Korean IME, type `한` in the search field — IME composition completes normally, popover does not steal Return
- [ ] Switch to Parakeet — the language button visibly disables, popover does not open

🤖 Generated with [Claude Code](https://claude.com/claude-code)