### PR TITLE
Engine attribution polish: live UI + persisted attribution

### DIFF
--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -602,6 +602,23 @@ struct TranscriptResultView: View {
         activeTranscription.speakers?.count ?? activeTranscription.speakerCount ?? 0
     }
 
+    /// User-facing engine attribution string for the metadata chip, or `nil`
+    /// for legacy rows saved before the v0.8 engine-attribution migration —
+    /// in that case we omit the chip rather than mislabel.
+    private var engineAttributionLabel: String? {
+        guard let engineRaw = activeTranscription.engine,
+              let preference = SpeechEnginePreference(rawValue: engineRaw) else {
+            return nil
+        }
+        switch preference {
+        case .parakeet:
+            return "Parakeet TDT"
+        case .whisper:
+            let variant = activeTranscription.engineVariant ?? SpeechEnginePreference.defaultWhisperModelVariant
+            return "Whisper \(SpeechEnginePreference.friendlyVariantName(variant))"
+        }
+    }
+
     private var resultHeaderCard: some View {
         VStack(alignment: .leading, spacing: 0) {
             // Always-visible compact row: back button + title + metadata + mandala + expand toggle
@@ -690,6 +707,10 @@ struct TranscriptResultView: View {
 
                         if speakerCountValue > 0 {
                             metadataChip(icon: "person.2.fill", text: "\(speakerCountValue) speaker\(speakerCountValue == 1 ? "" : "s")", tint: DesignSystem.Colors.textSecondary)
+                        }
+
+                        if let engineAttributionLabel {
+                            metadataChip(icon: "cpu", text: engineAttributionLabel, tint: DesignSystem.Colors.textSecondary)
                         }
                     }
 

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -614,7 +614,9 @@ struct TranscriptResultView: View {
         case .parakeet:
             return "Parakeet TDT"
         case .whisper:
-            let variant = activeTranscription.engineVariant ?? SpeechEnginePreference.defaultWhisperModelVariant
+            guard let variant = activeTranscription.engineVariant else {
+                return "Whisper"
+            }
             return "Whisper \(SpeechEnginePreference.friendlyVariantName(variant))"
         }
     }

--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -526,13 +526,23 @@ public final class DatabaseManager: Sendable {
         // pre-Whisper data is unambiguously Parakeet but post-Whisper-merge
         // rows of unknown engine should not be silently labeled.
         migrator.registerMigration("v0.8-engine-attribution") { db in
+            let transcriptionColumns = try db.columns(in: "transcriptions").map(\.name)
             try db.alter(table: "transcriptions") { t in
-                t.add(column: "engine", .text)
-                t.add(column: "engineVariant", .text)
+                if !transcriptionColumns.contains("engine") {
+                    t.add(column: "engine", .text)
+                }
+                if !transcriptionColumns.contains("engineVariant") {
+                    t.add(column: "engineVariant", .text)
+                }
             }
+            let dictationColumns = try db.columns(in: "dictations").map(\.name)
             try db.alter(table: "dictations") { t in
-                t.add(column: "engine", .text)
-                t.add(column: "engineVariant", .text)
+                if !dictationColumns.contains("engine") {
+                    t.add(column: "engine", .text)
+                }
+                if !dictationColumns.contains("engineVariant") {
+                    t.add(column: "engineVariant", .text)
+                }
             }
         }
 

--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -521,6 +521,21 @@ public final class DatabaseManager: Sendable {
             }
         }
 
+        // v0.8 - Engine attribution: capture which STT engine + variant produced
+        // each transcript/dictation. NULL for legacy rows is intentional —
+        // pre-Whisper data is unambiguously Parakeet but post-Whisper-merge
+        // rows of unknown engine should not be silently labeled.
+        migrator.registerMigration("v0.8-engine-attribution") { db in
+            try db.alter(table: "transcriptions") { t in
+                t.add(column: "engine", .text)
+                t.add(column: "engineVariant", .text)
+            }
+            try db.alter(table: "dictations") { t in
+                t.add(column: "engine", .text)
+                t.add(column: "engineVariant", .text)
+            }
+        }
+
         try migrator.migrate(dbQueue)
         try reconcileBuiltInPrompts()
     }

--- a/Sources/MacParakeetCore/Models/Dictation.swift
+++ b/Sources/MacParakeetCore/Models/Dictation.swift
@@ -15,6 +15,12 @@ public struct Dictation: Codable, Identifiable, Sendable {
     public var updatedAt: Date
     public var hidden: Bool
     public var wordCount: Int
+    /// STT engine that produced this dictation (`"parakeet"` / `"whisper"`).
+    /// `nil` for rows created before the v0.8 engine-attribution migration.
+    public var engine: String?
+    /// Engine-specific model variant id (e.g. the Whisper model id).
+    /// `nil` for engines without variants and for legacy rows.
+    public var engineVariant: String?
 
     public enum ProcessingMode: String, Codable, Sendable {
         case raw
@@ -57,7 +63,9 @@ public struct Dictation: Codable, Identifiable, Sendable {
         errorMessage: String? = nil,
         updatedAt: Date = Date(),
         hidden: Bool = false,
-        wordCount: Int = 0
+        wordCount: Int = 0,
+        engine: String? = nil,
+        engineVariant: String? = nil
     ) {
         self.id = id
         self.createdAt = createdAt
@@ -72,6 +80,8 @@ public struct Dictation: Codable, Identifiable, Sendable {
         self.updatedAt = updatedAt
         self.hidden = hidden
         self.wordCount = wordCount
+        self.engine = engine
+        self.engineVariant = engineVariant
     }
 }
 
@@ -97,6 +107,6 @@ extension Dictation: FetchableRecord, PersistableRecord {
     public enum Columns: String, ColumnExpression {
         case id, createdAt, durationMs, rawTranscript, cleanTranscript
         case audioPath, pastedToApp, processingMode, status, errorMessage, updatedAt
-        case hidden, wordCount
+        case hidden, wordCount, engine, engineVariant
     }
 }

--- a/Sources/MacParakeetCore/Models/Transcription.swift
+++ b/Sources/MacParakeetCore/Models/Transcription.swift
@@ -44,6 +44,12 @@ public struct Transcription: Codable, Identifiable, Sendable {
     /// summary generation (ADR-020 §3). `nil` for non-meeting transcripts
     /// and for meetings where the user took no notes.
     public var userNotes: String?
+    /// STT engine that produced this transcript (`"parakeet"` / `"whisper"`).
+    /// `nil` for rows created before the v0.8 engine-attribution migration.
+    public var engine: String?
+    /// Engine-specific model variant id (e.g. the Whisper model id).
+    /// `nil` for engines without variants and for legacy rows.
+    public var engineVariant: String?
     public var updatedAt: Date
 
     public enum TranscriptionStatus: String, Codable, Sendable {
@@ -80,6 +86,8 @@ public struct Transcription: Codable, Identifiable, Sendable {
         recoveredFromCrash: Bool = false,
         isTranscriptEdited: Bool = false,
         userNotes: String? = nil,
+        engine: String? = nil,
+        engineVariant: String? = nil,
         updatedAt: Date = Date()
     ) {
         self.id = id
@@ -108,6 +116,8 @@ public struct Transcription: Codable, Identifiable, Sendable {
         self.recoveredFromCrash = recoveredFromCrash
         self.isTranscriptEdited = isTranscriptEdited
         self.userNotes = userNotes
+        self.engine = engine
+        self.engineVariant = engineVariant
         self.updatedAt = updatedAt
     }
 }
@@ -158,7 +168,7 @@ extension Transcription: FetchableRecord, PersistableRecord {
         case rawTranscript, cleanTranscript, wordTimestamps, language
         case speakerCount, speakers, diarizationSegments, chatMessages
         case status, errorMessage, exportPath, sourceURL
-        case thumbnailURL, channelName, videoDescription, isFavorite, sourceType, recoveredFromCrash, isTranscriptEdited, userNotes, updatedAt
+        case thumbnailURL, channelName, videoDescription, isFavorite, sourceType, recoveredFromCrash, isTranscriptEdited, userNotes, engine, engineVariant, updatedAt
     }
 
     /// Backward-compatible decoding: `speakers` column may contain old `[String]` JSON
@@ -219,6 +229,8 @@ extension Transcription: FetchableRecord, PersistableRecord {
         recoveredFromCrash = try container.decodeIfPresent(Bool.self, forKey: .recoveredFromCrash) ?? false
         isTranscriptEdited = try container.decodeIfPresent(Bool.self, forKey: .isTranscriptEdited) ?? false
         userNotes = try container.decodeIfPresent(String.self, forKey: .userNotes)
+        engine = try container.decodeIfPresent(String.self, forKey: .engine)
+        engineVariant = try container.decodeIfPresent(String.self, forKey: .engineVariant)
         updatedAt = try container.decode(Date.self, forKey: .updatedAt)
     }
 }

--- a/Sources/MacParakeetCore/STT/STTResult.swift
+++ b/Sources/MacParakeetCore/STT/STTResult.swift
@@ -4,11 +4,26 @@ public struct STTResult: Sendable {
     public let text: String
     public let words: [TimestampedWord]
     public let language: String?
+    /// The engine that produced this result. Authoritative — set by the
+    /// engine implementation rather than read from settings, so a mid-job
+    /// preference toggle cannot mislabel an in-flight transcription.
+    public let engine: SpeechEnginePreference
+    /// Engine-specific model variant (e.g. the Whisper model id). `nil`
+    /// for engines without a meaningful variant choice (Parakeet).
+    public let engineVariant: String?
 
-    public init(text: String, words: [TimestampedWord] = [], language: String? = nil) {
+    public init(
+        text: String,
+        words: [TimestampedWord] = [],
+        language: String? = nil,
+        engine: SpeechEnginePreference = .parakeet,
+        engineVariant: String? = nil
+    ) {
         self.text = text
         self.words = words
         self.language = language
+        self.engine = engine
+        self.engineVariant = engineVariant
     }
 }
 

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -153,7 +153,7 @@ public actor STTRuntime: STTRuntimeProtocol {
             let result = try await manager.transcribe(audioURL, decoderState: &decoderState)
             let words = Self.mergeTokenTimingsIntoWords(result.tokenTimings)
             onProgress?(100, 100)
-            return STTResult(text: result.text, words: words)
+            return STTResult(text: result.text, words: words, engine: .parakeet, engineVariant: nil)
         } catch {
             throw try Self.mapTranscriptionError(error)
         }

--- a/Sources/MacParakeetCore/STT/WhisperEngine.swift
+++ b/Sources/MacParakeetCore/STT/WhisperEngine.swift
@@ -140,7 +140,9 @@ public actor WhisperEngine: STTTranscribing {
             return STTResult(
                 text: merged.text,
                 words: Self.mapWordTimings(merged.allWords),
-                language: merged.language
+                language: merged.language,
+                engine: .whisper,
+                engineVariant: modelVariant
             )
         } catch {
             throw try Self.mapTranscriptionError(error)

--- a/Sources/MacParakeetCore/Services/DictationService.swift
+++ b/Sources/MacParakeetCore/Services/DictationService.swift
@@ -534,7 +534,9 @@ public actor DictationService: DictationServiceProtocol {
             processingMode: mode,
             status: .completed,
             hidden: !saveHistory,
-            wordCount: wc
+            wordCount: wc,
+            engine: result.engine.rawValue,
+            engineVariant: result.engineVariant
         )
 
         if saveHistory, shouldSaveAudio?() ?? false {

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -1071,6 +1071,8 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
         transcription.status = .processing
         transcription.errorMessage = nil
         transcription.exportPath = nil
+        transcription.engine = nil
+        transcription.engineVariant = nil
         transcription.isTranscriptEdited = false
         transcription.updatedAt = Date()
         return transcription

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -631,6 +631,13 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
             transcription.rawTranscript = finalized.rawTranscript
             transcription.wordTimestamps = finalized.words
             transcription.language = Self.commonDetectedLanguage(from: sourceResults) ?? transcription.language
+            // Both meeting source transcripts (mic + system) run through the
+            // same `SpeechEngineSelection`, so taking the first source's
+            // engine attribution is authoritative for the merged transcript.
+            if let engineSource = sourceResults.first {
+                transcription.engine = engineSource.result.engine.rawValue
+                transcription.engineVariant = engineSource.result.engineVariant
+            }
             transcription.durationMs = max(
                 Int((recording.durationSeconds * 1000).rounded()),
                 finalized.durationMs ?? 0
@@ -919,6 +926,8 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
             transcription.rawTranscript = result.text
             transcription.wordTimestamps = words
             transcription.language = result.language ?? transcription.language
+            transcription.engine = result.engine.rawValue
+            transcription.engineVariant = result.engineVariant
             transcription.durationMs = words.map(\.endMs).max()
 
             let diarizationApplied: Bool

--- a/Sources/MacParakeetCore/SpeechEnginePreference.swift
+++ b/Sources/MacParakeetCore/SpeechEnginePreference.swift
@@ -79,6 +79,36 @@ public enum SpeechEnginePreference: String, CaseIterable, Codable, Sendable {
         guard !trimmed.isEmpty else { return nil }
         return trimmed.hasPrefix("whisper-") ? String(trimmed.dropFirst("whisper-".count)) : trimmed
     }
+
+    /// Maps an internal Whisper variant id to a short, user-friendly label.
+    /// Falls back to the raw variant if the shape is unrecognized so unknown
+    /// future variants degrade to something readable rather than empty.
+    public static func friendlyVariantName(_ rawVariant: String) -> String {
+        let normalized = normalizeModelVariant(rawVariant) ?? rawVariant
+        let lowered = normalized.lowercased()
+
+        let sizeOrder: [(token: String, label: String)] = [
+            ("large-v3", "Large v3"),
+            ("large-v2", "Large v2"),
+            ("large", "Large"),
+            ("medium", "Medium"),
+            ("small", "Small"),
+            ("base", "Base"),
+            ("tiny", "Tiny")
+        ]
+        var size: String?
+        for entry in sizeOrder where lowered.hasPrefix(entry.token) {
+            size = entry.label
+            break
+        }
+
+        let isTurbo = lowered.contains("turbo")
+
+        if let size {
+            return isTurbo ? "\(size) Turbo" : size
+        }
+        return rawVariant
+    }
 }
 
 public struct SpeechEngineSelection: Codable, Equatable, Sendable {

--- a/Sources/MacParakeetCore/SpeechEnginePreference.swift
+++ b/Sources/MacParakeetCore/SpeechEnginePreference.swift
@@ -96,11 +96,7 @@ public enum SpeechEnginePreference: String, CaseIterable, Codable, Sendable {
             ("base", "Base"),
             ("tiny", "Tiny")
         ]
-        var size: String?
-        for entry in sizeOrder where lowered.hasPrefix(entry.token) {
-            size = entry.label
-            break
-        }
+        let size = sizeOrder.first { lowered.hasPrefix($0.token) }?.label
 
         let isTurbo = lowered.contains("turbo")
 

--- a/Sources/MacParakeetCore/SpeechEnginePreference.swift
+++ b/Sources/MacParakeetCore/SpeechEnginePreference.swift
@@ -96,7 +96,7 @@ public enum SpeechEnginePreference: String, CaseIterable, Codable, Sendable {
             ("base", "Base"),
             ("tiny", "Tiny")
         ]
-        let size = sizeOrder.first { lowered.hasPrefix($0.token) }?.label
+        let size = sizeOrder.first { variantPrefixMatches(lowered, token: $0.token) }?.label
 
         let isTurbo = lowered.contains("turbo")
 
@@ -104,6 +104,23 @@ public enum SpeechEnginePreference: String, CaseIterable, Codable, Sendable {
             return isTurbo ? "\(size) Turbo" : size
         }
         return rawVariant
+    }
+
+    private static func variantPrefixMatches(_ normalized: String, token: String) -> Bool {
+        guard normalized.hasPrefix(token) else { return false }
+        let remainder = normalized.dropFirst(token.count)
+        guard let separator = remainder.first else { return true }
+        guard separator == "-" || separator == "_" || separator == "." else { return false }
+
+        if !token.contains("-v"), separator == "-" {
+            let suffix = remainder.dropFirst()
+            if suffix.first == "v",
+               suffix.dropFirst().first?.isNumber == true {
+                return false
+            }
+        }
+
+        return true
     }
 }
 

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -901,7 +901,7 @@ public final class SettingsViewModel {
 
             if activeEngine == .whisper, activeEngineIsLoaded {
                 self.whisperModelStatus = .ready
-                self.whisperModelStatusDetail = "Loaded in memory and ready."
+                self.whisperModelStatusDetail = "Whisper \(self.whisperVariantFriendlyName) · Loaded in memory and ready."
             } else {
                 self.applyWhisperDownloadedStatus(modelDiskState.whisperDownloaded)
             }
@@ -915,23 +915,31 @@ public final class SettingsViewModel {
     }
 
     private func applyWhisperDownloadedStatus(_ isDownloaded: Bool) {
+        let friendly = whisperVariantFriendlyName
         if isDownloaded {
             // Optimistic file-based check; `refreshModelStatus()` will upgrade
             // to `.ready` after asking the runtime if Whisper is the active
             // engine and currently loaded.
             whisperModelStatus = .notLoaded
-            whisperModelStatusDetail = "Downloaded. Loads automatically when Whisper is selected."
+            whisperModelStatusDetail = "Whisper \(friendly) · Downloaded. Loads automatically when selected."
         } else {
             whisperModelStatus = .notDownloaded
-            whisperModelStatusDetail = "Not downloaded yet."
+            whisperModelStatusDetail = "Whisper \(friendly) · Not downloaded yet."
         }
+    }
+
+    private var whisperVariantFriendlyName: String {
+        SpeechEnginePreference.friendlyVariantName(
+            SpeechEnginePreference.whisperModelVariant(defaults: defaults)
+        )
     }
 
     public func downloadWhisperModel() {
         guard !whisperDownloading else { return }
         whisperDownloading = true
         whisperModelStatus = .repairing
-        whisperModelStatusDetail = "Downloading Whisper model..."
+        let friendly = whisperVariantFriendlyName
+        whisperModelStatusDetail = "Downloading Whisper \(friendly)..."
 
         Task {
             do {
@@ -940,7 +948,8 @@ public final class SettingsViewModel {
                 ) { completed, total in
                     let percent = total > 0 ? Int((Double(completed) / Double(total) * 100).rounded()) : 0
                     Task { @MainActor [weak self] in
-                        self?.whisperModelStatusDetail = "Downloading Whisper model... \(min(max(percent, 0), 100))%"
+                        guard let self else { return }
+                        self.whisperModelStatusDetail = "Downloading Whisper \(self.whisperVariantFriendlyName)... \(min(max(percent, 0), 100))%"
                     }
                 }
                 await MainActor.run {

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -949,7 +949,7 @@ public final class SettingsViewModel {
                     let percent = total > 0 ? Int((Double(completed) / Double(total) * 100).rounded()) : 0
                     Task { @MainActor [weak self] in
                         guard let self else { return }
-                        self.whisperModelStatusDetail = "Downloading Whisper \(self.whisperVariantFriendlyName)... \(min(max(percent, 0), 100))%"
+                        self.whisperModelStatusDetail = "Downloading Whisper \(friendly)... \(min(max(percent, 0), 100))%"
                     }
                 }
                 await MainActor.run {

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -938,13 +938,14 @@ public final class SettingsViewModel {
         guard !whisperDownloading else { return }
         whisperDownloading = true
         whisperModelStatus = .repairing
-        let friendly = whisperVariantFriendlyName
+        let modelVariant = SpeechEnginePreference.whisperModelVariant(defaults: defaults)
+        let friendly = SpeechEnginePreference.friendlyVariantName(modelVariant)
         whisperModelStatusDetail = "Downloading Whisper \(friendly)..."
 
         Task {
             do {
                 _ = try await WhisperEngine.downloadModel(
-                    model: SpeechEnginePreference.whisperModelVariant(defaults: defaults)
+                    model: modelVariant
                 ) { completed, total in
                     let percent = total > 0 ? Int((Double(completed) / Double(total) * 100).rounded()) : 0
                     Task { @MainActor [weak self] in

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -556,7 +556,14 @@ public final class TranscriptionViewModel {
         self.transcriptionProgress = progress.fraction
         self.progressPhase = phase
         self.progressHeadline = Self.headline(for: phase)
-        self.progressSubline = Self.subline(for: phase, sourceKind: sourceKind)
+        let engine = SpeechEnginePreference.current(defaults: defaults)
+        let whisperVariant = SpeechEnginePreference.whisperModelVariant(defaults: defaults)
+        self.progressSubline = Self.subline(
+            for: phase,
+            sourceKind: sourceKind,
+            engine: engine,
+            whisperVariant: whisperVariant
+        )
     }
 
     private static func mapPhase(from progress: TranscriptionProgress) -> ProgressPhase {
@@ -601,14 +608,25 @@ public final class TranscriptionViewModel {
         }
     }
 
-    private static func subline(for phase: ProgressPhase, sourceKind: SourceKind) -> String? {
+    private static func subline(
+        for phase: ProgressPhase,
+        sourceKind: SourceKind,
+        engine: SpeechEnginePreference,
+        whisperVariant: String
+    ) -> String? {
         switch phase {
         case .downloading:
             return sourceKind == .youtubeURL
                 ? "Longer videos take more time to fetch"
                 : nil
         case .transcribing:
-            return "Runs entirely on-device using the Neural Engine"
+            switch engine {
+            case .parakeet:
+                return "Parakeet TDT \u{00B7} Neural Engine"
+            case .whisper:
+                let friendly = SpeechEnginePreference.friendlyVariantName(whisperVariant)
+                return "Whisper \(friendly) \u{00B7} Apple Silicon"
+            }
         case .identifyingSpeakers:
             return "May take several minutes per hour of audio. Speaker labels are approximate \u{2014} click to rename."
         default:

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -103,6 +103,7 @@ public final class TranscriptionViewModel {
     private var transcriptionTask: Task<Void, Never>?
     private var activeTranscriptionTaskID: UUID?
     private var activeProgressSpeechEngine: SpeechEngineSelection?
+    private var activeProgressWhisperVariant: String?
     private var activeDropRequestID: UUID?
     private var dropPendingCount = 0
     private var dropAccepted = false
@@ -458,7 +459,11 @@ public final class TranscriptionViewModel {
 
         let taskID = UUID()
         activeTranscriptionTaskID = taskID
-        activeProgressSpeechEngine = speechEngine ?? SpeechEngineSelection.current(defaults: defaults)
+        let progressSpeechEngine = speechEngine ?? SpeechEngineSelection.current(defaults: defaults)
+        activeProgressSpeechEngine = progressSpeechEngine
+        activeProgressWhisperVariant = progressSpeechEngine.engine == .whisper
+            ? SpeechEnginePreference.whisperModelVariant(defaults: defaults)
+            : nil
         transcribingFileName = fileName
         beginTranscription(source: source)
 
@@ -551,6 +556,7 @@ public final class TranscriptionViewModel {
         transcriptionProgress = nil
         transcribingFileName = ""
         activeProgressSpeechEngine = nil
+        activeProgressWhisperVariant = nil
         progressPhase = .preparing
         progressHeadline = Self.headline(for: .preparing)
         progressSubline = nil
@@ -566,7 +572,8 @@ public final class TranscriptionViewModel {
         self.progressPhase = phase
         self.progressHeadline = Self.headline(for: phase)
         let speechEngine = activeProgressSpeechEngine ?? SpeechEngineSelection.current(defaults: defaults)
-        let whisperVariant = SpeechEnginePreference.whisperModelVariant(defaults: defaults)
+        let whisperVariant = activeProgressWhisperVariant
+            ?? SpeechEnginePreference.whisperModelVariant(defaults: defaults)
         self.progressSubline = Self.subline(
             for: phase,
             sourceKind: sourceKind,

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -634,7 +634,7 @@ public final class TranscriptionViewModel {
                 return "Parakeet TDT \u{00B7} Neural Engine"
             case .whisper:
                 let friendly = SpeechEnginePreference.friendlyVariantName(whisperVariant)
-                return "Whisper \(friendly) \u{00B7} Apple Silicon"
+                return "Whisper \(friendly) \u{00B7} Neural Engine"
             }
         case .identifyingSpeakers:
             return "May take several minutes per hour of audio. Speaker labels are approximate \u{2014} click to rename."

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -102,6 +102,7 @@ public final class TranscriptionViewModel {
     private var promptResultRepo: PromptResultRepositoryProtocol?
     private var transcriptionTask: Task<Void, Never>?
     private var activeTranscriptionTaskID: UUID?
+    private var activeProgressSpeechEngine: SpeechEngineSelection?
     private var activeDropRequestID: UUID?
     private var dropPendingCount = 0
     private var dropAccepted = false
@@ -321,7 +322,12 @@ public final class TranscriptionViewModel {
               FileManager.default.fileExists(atPath: filePath) else { return }
 
         let url = URL(fileURLWithPath: filePath)
-        let taskID = beginNewTranscription(source: .localFile, fileName: original.fileName, clearCurrent: true)
+        let taskID = beginNewTranscription(
+            source: .localFile,
+            fileName: original.fileName,
+            clearCurrent: true,
+            speechEngine: speechEngineOverride
+        )
         let retranscriptionSource: TelemetryTranscriptionSource = switch original.sourceType {
         case .file:
             .file
@@ -445,12 +451,14 @@ public final class TranscriptionViewModel {
     private func beginNewTranscription(
         source: SourceKind,
         fileName: String,
-        clearCurrent: Bool = false
+        clearCurrent: Bool = false,
+        speechEngine: SpeechEngineSelection? = nil
     ) -> UUID {
         transcriptionTask?.cancel()
 
         let taskID = UUID()
         activeTranscriptionTaskID = taskID
+        activeProgressSpeechEngine = speechEngine ?? SpeechEngineSelection.current(defaults: defaults)
         transcribingFileName = fileName
         beginTranscription(source: source)
 
@@ -542,6 +550,7 @@ public final class TranscriptionViewModel {
         progress = ""
         transcriptionProgress = nil
         transcribingFileName = ""
+        activeProgressSpeechEngine = nil
         progressPhase = .preparing
         progressHeadline = Self.headline(for: .preparing)
         progressSubline = nil
@@ -556,12 +565,12 @@ public final class TranscriptionViewModel {
         self.transcriptionProgress = progress.fraction
         self.progressPhase = phase
         self.progressHeadline = Self.headline(for: phase)
-        let engine = SpeechEnginePreference.current(defaults: defaults)
+        let speechEngine = activeProgressSpeechEngine ?? SpeechEngineSelection.current(defaults: defaults)
         let whisperVariant = SpeechEnginePreference.whisperModelVariant(defaults: defaults)
         self.progressSubline = Self.subline(
             for: phase,
             sourceKind: sourceKind,
-            engine: engine,
+            engine: speechEngine.engine,
             whisperVariant: whisperVariant
         )
     }

--- a/Tests/MacParakeetTests/Database/DatabaseManagerTests.swift
+++ b/Tests/MacParakeetTests/Database/DatabaseManagerTests.swift
@@ -650,6 +650,37 @@ final class DatabaseManagerTests: XCTestCase {
         try? FileManager.default.removeItem(atPath: dbPath)
     }
 
+    func testEngineAttributionMigrationToleratesExistingColumnsWhenMigrationMarkerIsMissing() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+        let dbPath = tempDir.appendingPathComponent("engine_attribution_rerun_\(UUID().uuidString).db").path
+        defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+        let manager1 = try DatabaseManager(path: dbPath)
+        try manager1.dbQueue.write { db in
+            try db.execute(
+                sql: "DELETE FROM grdb_migrations WHERE identifier = ?",
+                arguments: ["v0.8-engine-attribution"]
+            )
+        }
+
+        let manager2 = try DatabaseManager(path: dbPath)
+        try manager2.dbQueue.read { db in
+            let transcriptionColumns = try db.columns(in: "transcriptions").map(\.name)
+            let dictationColumns = try db.columns(in: "dictations").map(\.name)
+            XCTAssertTrue(transcriptionColumns.contains("engine"))
+            XCTAssertTrue(transcriptionColumns.contains("engineVariant"))
+            XCTAssertTrue(dictationColumns.contains("engine"))
+            XCTAssertTrue(dictationColumns.contains("engineVariant"))
+
+            let migrationRecorded = try Bool.fetchOne(
+                db,
+                sql: "SELECT EXISTS(SELECT 1 FROM grdb_migrations WHERE identifier = ?)",
+                arguments: ["v0.8-engine-attribution"]
+            ) ?? false
+            XCTAssertTrue(migrationRecorded)
+        }
+    }
+
     /// Recreates the dictations table at its v0.5 shape (after `v0.5-private-dictation`
     /// added `hidden` and `wordCount`). Used by partial-migration test fixtures so the
     /// v0.7.4 lifetime-stats backfill has a real table to read from.

--- a/Tests/MacParakeetTests/Database/DictationRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/DictationRepositoryTests.swift
@@ -32,6 +32,32 @@ final class DictationRepositoryTests: XCTestCase {
         XCTAssertNil(fetched)
     }
 
+    func testEngineAttributionRoundTrips() throws {
+        let dictation = Dictation(
+            durationMs: 1000,
+            rawTranscript: "engine test",
+            engine: SpeechEnginePreference.whisper.rawValue,
+            engineVariant: SpeechEnginePreference.defaultWhisperModelVariant
+        )
+        try repo.save(dictation)
+
+        let fetched = try repo.fetch(id: dictation.id)
+        XCTAssertEqual(fetched?.engine, "whisper")
+        XCTAssertEqual(fetched?.engineVariant, SpeechEnginePreference.defaultWhisperModelVariant)
+    }
+
+    func testLegacyDictationDecodesWithNilEngineFields() throws {
+        let dictation = Dictation(
+            durationMs: 1000,
+            rawTranscript: "no engine"
+        )
+        try repo.save(dictation)
+
+        let fetched = try repo.fetch(id: dictation.id)
+        XCTAssertNil(fetched?.engine)
+        XCTAssertNil(fetched?.engineVariant)
+    }
+
     func testFetchAll() throws {
         let d1 = Dictation(
             createdAt: Date(timeIntervalSinceNow: -100),

--- a/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
@@ -32,6 +32,28 @@ final class TranscriptionRepositoryTests: XCTestCase {
         XCTAssertNil(fetched)
     }
 
+    func testEngineAttributionRoundTrips() throws {
+        let transcription = Transcription(
+            fileName: "engine.mp3",
+            engine: SpeechEnginePreference.whisper.rawValue,
+            engineVariant: SpeechEnginePreference.defaultWhisperModelVariant
+        )
+        try repo.save(transcription)
+
+        let fetched = try repo.fetch(id: transcription.id)
+        XCTAssertEqual(fetched?.engine, "whisper")
+        XCTAssertEqual(fetched?.engineVariant, SpeechEnginePreference.defaultWhisperModelVariant)
+    }
+
+    func testLegacyTranscriptionDecodesWithNilEngineFields() throws {
+        let transcription = Transcription(fileName: "legacy.mp3")
+        try repo.save(transcription)
+
+        let fetched = try repo.fetch(id: transcription.id)
+        XCTAssertNil(fetched?.engine)
+        XCTAssertNil(fetched?.engineVariant)
+    }
+
     func testFetchAll() throws {
         let t1 = Transcription(
             createdAt: Date(timeIntervalSinceNow: -100),

--- a/Tests/MacParakeetTests/STT/SpeechEnginePreferenceTests.swift
+++ b/Tests/MacParakeetTests/STT/SpeechEnginePreferenceTests.swift
@@ -9,8 +9,8 @@ final class SpeechEnginePreferenceTests: XCTestCase {
 
     func testFriendlyVariantNameFallsBackToRawForUnknownShape() {
         XCTAssertEqual(
-            SpeechEnginePreference.friendlyVariantName("xyzzy-experimental-build"),
-            "xyzzy-experimental-build"
+            SpeechEnginePreference.friendlyVariantName("large-v30-experimental-build"),
+            "large-v30-experimental-build"
         )
     }
 }

--- a/Tests/MacParakeetTests/STT/SpeechEnginePreferenceTests.swift
+++ b/Tests/MacParakeetTests/STT/SpeechEnginePreferenceTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class SpeechEnginePreferenceTests: XCTestCase {
+    func testFriendlyVariantNameMapsDefaultWhisperVariant() {
+        let raw = SpeechEnginePreference.defaultWhisperModelVariant
+        XCTAssertEqual(SpeechEnginePreference.friendlyVariantName(raw), "Large v3 Turbo")
+    }
+
+    func testFriendlyVariantNameDropsWhisperPrefix() {
+        XCTAssertEqual(
+            SpeechEnginePreference.friendlyVariantName("whisper-large-v3-v20240930_turbo_632MB"),
+            "Large v3 Turbo"
+        )
+    }
+
+    func testFriendlyVariantNameMapsLargeWithoutTurbo() {
+        XCTAssertEqual(SpeechEnginePreference.friendlyVariantName("large-v3"), "Large v3")
+    }
+
+    func testFriendlyVariantNameMapsSmallerSizes() {
+        XCTAssertEqual(SpeechEnginePreference.friendlyVariantName("small"), "Small")
+        XCTAssertEqual(SpeechEnginePreference.friendlyVariantName("base"), "Base")
+        XCTAssertEqual(SpeechEnginePreference.friendlyVariantName("tiny"), "Tiny")
+        XCTAssertEqual(SpeechEnginePreference.friendlyVariantName("medium-turbo"), "Medium Turbo")
+    }
+
+    func testFriendlyVariantNameFallsBackToRawForUnknownShape() {
+        XCTAssertEqual(
+            SpeechEnginePreference.friendlyVariantName("xyzzy-experimental-build"),
+            "xyzzy-experimental-build"
+        )
+    }
+}

--- a/Tests/MacParakeetTests/STT/SpeechEnginePreferenceTests.swift
+++ b/Tests/MacParakeetTests/STT/SpeechEnginePreferenceTests.swift
@@ -7,24 +7,6 @@ final class SpeechEnginePreferenceTests: XCTestCase {
         XCTAssertEqual(SpeechEnginePreference.friendlyVariantName(raw), "Large v3 Turbo")
     }
 
-    func testFriendlyVariantNameDropsWhisperPrefix() {
-        XCTAssertEqual(
-            SpeechEnginePreference.friendlyVariantName("whisper-large-v3-v20240930_turbo_632MB"),
-            "Large v3 Turbo"
-        )
-    }
-
-    func testFriendlyVariantNameMapsLargeWithoutTurbo() {
-        XCTAssertEqual(SpeechEnginePreference.friendlyVariantName("large-v3"), "Large v3")
-    }
-
-    func testFriendlyVariantNameMapsSmallerSizes() {
-        XCTAssertEqual(SpeechEnginePreference.friendlyVariantName("small"), "Small")
-        XCTAssertEqual(SpeechEnginePreference.friendlyVariantName("base"), "Base")
-        XCTAssertEqual(SpeechEnginePreference.friendlyVariantName("tiny"), "Tiny")
-        XCTAssertEqual(SpeechEnginePreference.friendlyVariantName("medium-turbo"), "Medium Turbo")
-    }
-
     func testFriendlyVariantNameFallsBackToRawForUnknownShape() {
         XCTAssertEqual(
             SpeechEnginePreference.friendlyVariantName("xyzzy-experimental-build"),

--- a/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
@@ -154,6 +154,22 @@ final class TranscriptionServiceTests: XCTestCase {
         XCTAssertEqual(try transcriptionRepo.fetch(id: result.id)?.language, "ko")
     }
 
+    func testTranscribeFilePersistsEngineAttributionFromSTTResult() async throws {
+        await mockSTT.configure(result: STTResult(
+            text: "hello world",
+            engine: .whisper,
+            engineVariant: SpeechEnginePreference.defaultWhisperModelVariant
+        ))
+
+        let result = try await service.transcribe(fileURL: URL(fileURLWithPath: "/tmp/whisper.mp3"))
+
+        XCTAssertEqual(result.engine, "whisper")
+        XCTAssertEqual(result.engineVariant, SpeechEnginePreference.defaultWhisperModelVariant)
+        let fetched = try transcriptionRepo.fetch(id: result.id)
+        XCTAssertEqual(fetched?.engine, "whisper")
+        XCTAssertEqual(fetched?.engineVariant, SpeechEnginePreference.defaultWhisperModelVariant)
+    }
+
     func testTranscribeFileDurationUsesMaximumWordEnd() async throws {
         await mockSTT.configure(result: STTResult(
             text: "out of order",

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -713,7 +713,7 @@ final class SettingsViewModelTests: XCTestCase {
         )
 
         try await waitUntil { vm.whisperModelStatus == .ready }
-        XCTAssertEqual(vm.whisperModelStatusDetail, "Loaded in memory and ready.")
+        XCTAssertEqual(vm.whisperModelStatusDetail, "Whisper Large v3 Turbo · Loaded in memory and ready.")
         XCTAssertEqual(vm.parakeetStatus, .notLoaded)
         XCTAssertEqual(vm.parakeetStatusDetail, "Downloaded. Loads automatically when needed.")
     }

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -117,7 +117,9 @@ final class TranscriptionViewModelTests: XCTestCase {
         let defaults = UserDefaults(suiteName: suiteName)!
         defer { defaults.removePersistentDomain(forName: suiteName) }
         SpeechEnginePreference.whisper.save(to: defaults)
+        SpeechEnginePreference.saveWhisperModelVariant(SpeechEnginePreference.defaultWhisperModelVariant, defaults: defaults)
         viewModel = TranscriptionViewModel(defaults: defaults)
+        let expectedSubline = "Whisper \(SpeechEnginePreference.friendlyVariantName(SpeechEnginePreference.defaultWhisperModelVariant)) · Neural Engine"
         await mockService.configureProgress(phases: [.transcribing(percent: 42)])
         await mockService.configureDelay(milliseconds: 250)
         viewModel.configure(transcriptionService: mockService, transcriptionRepo: mockRepo)
@@ -125,7 +127,7 @@ final class TranscriptionViewModelTests: XCTestCase {
         viewModel.transcribeFile(url: URL(fileURLWithPath: "/tmp/myfile.wav"))
 
         try await waitUntil {
-            self.viewModel.progressSubline == "Whisper Large v3 Turbo · Neural Engine"
+            self.viewModel.progressSubline == expectedSubline
         }
         XCTAssertEqual(viewModel.progressHeadline, "Running speech recognition")
 
@@ -1164,7 +1166,9 @@ final class TranscriptionViewModelTests: XCTestCase {
         let defaults = UserDefaults(suiteName: suiteName)!
         defer { defaults.removePersistentDomain(forName: suiteName) }
         SpeechEnginePreference.parakeet.save(to: defaults)
+        SpeechEnginePreference.saveWhisperModelVariant(SpeechEnginePreference.defaultWhisperModelVariant, defaults: defaults)
         viewModel = TranscriptionViewModel(defaults: defaults)
+        let expectedSubline = "Whisper \(SpeechEnginePreference.friendlyVariantName(SpeechEnginePreference.defaultWhisperModelVariant)) · Neural Engine"
 
         let tmpFile = FileManager.default.temporaryDirectory.appendingPathComponent("retranscribe-progress-\(UUID().uuidString).mp3")
         FileManager.default.createFile(atPath: tmpFile.path, contents: Data([0]))
@@ -1186,7 +1190,7 @@ final class TranscriptionViewModelTests: XCTestCase {
         )
 
         try await waitUntil {
-            self.viewModel.progressSubline == "Whisper Large v3 Turbo · Neural Engine"
+            self.viewModel.progressSubline == expectedSubline
         }
         let override = await mockService.lastSpeechEngineOverride
         XCTAssertEqual(override, SpeechEngineSelection(engine: .whisper, language: "ko"))

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -125,7 +125,7 @@ final class TranscriptionViewModelTests: XCTestCase {
         viewModel.transcribeFile(url: URL(fileURLWithPath: "/tmp/myfile.wav"))
 
         try await waitUntil {
-            self.viewModel.progressSubline == "Whisper Large v3 Turbo · Apple Silicon"
+            self.viewModel.progressSubline == "Whisper Large v3 Turbo · Neural Engine"
         }
         XCTAssertEqual(viewModel.progressHeadline, "Running speech recognition")
 
@@ -1186,7 +1186,7 @@ final class TranscriptionViewModelTests: XCTestCase {
         )
 
         try await waitUntil {
-            self.viewModel.progressSubline == "Whisper Large v3 Turbo · Apple Silicon"
+            self.viewModel.progressSubline == "Whisper Large v3 Turbo · Neural Engine"
         }
         let override = await mockService.lastSpeechEngineOverride
         XCTAssertEqual(override, SpeechEngineSelection(engine: .whisper, language: "ko"))

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -112,6 +112,27 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.progress, "Preparing...", "Initial progress should be 'Preparing...'")
     }
 
+    func testTranscribeFileProgressSublineUsesSelectedEngineSnapshot() async throws {
+        let suiteName = "TranscriptionViewModelTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        SpeechEnginePreference.whisper.save(to: defaults)
+        viewModel = TranscriptionViewModel(defaults: defaults)
+        await mockService.configureProgress(phases: [.transcribing(percent: 42)])
+        await mockService.configureDelay(milliseconds: 250)
+        viewModel.configure(transcriptionService: mockService, transcriptionRepo: mockRepo)
+
+        viewModel.transcribeFile(url: URL(fileURLWithPath: "/tmp/myfile.wav"))
+
+        try await waitUntil {
+            self.viewModel.progressSubline == "Whisper Large v3 Turbo · Apple Silicon"
+        }
+        XCTAssertEqual(viewModel.progressHeadline, "Running speech recognition")
+
+        viewModel.cancelTranscription()
+        try await waitUntil { !self.viewModel.isTranscribing }
+    }
+
     func testTranscribeFileClearsErrorMessage() async throws {
         await mockService.configure(error: NSError(domain: "test", code: 1, userInfo: [
             NSLocalizedDescriptionKey: "First error"
@@ -1136,6 +1157,42 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertEqual(override, SpeechEngineSelection(engine: .parakeet))
         let lastMeetingRecording = await mockService.lastMeetingRecording
         XCTAssertEqual(lastMeetingRecording?.speechEngine, SpeechEngineSelection(engine: .whisper, language: "ko"))
+    }
+
+    func testRetranscribeProgressSublineUsesSpeechEngineOverride() async throws {
+        let suiteName = "TranscriptionViewModelTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        SpeechEnginePreference.parakeet.save(to: defaults)
+        viewModel = TranscriptionViewModel(defaults: defaults)
+
+        let tmpFile = FileManager.default.temporaryDirectory.appendingPathComponent("retranscribe-progress-\(UUID().uuidString).mp3")
+        FileManager.default.createFile(atPath: tmpFile.path, contents: Data([0]))
+        defer { try? FileManager.default.removeItem(at: tmpFile) }
+
+        let original = Transcription(
+            fileName: "lecture.mp3",
+            filePath: tmpFile.path,
+            rawTranscript: "Old transcript",
+            status: .completed
+        )
+        await mockService.configureProgress(phases: [.transcribing(percent: 25)])
+        await mockService.configureDelay(milliseconds: 250)
+        viewModel.configure(transcriptionService: mockService, transcriptionRepo: mockRepo)
+
+        viewModel.retranscribe(
+            original,
+            speechEngineOverride: SpeechEngineSelection(engine: .whisper, language: "ko")
+        )
+
+        try await waitUntil {
+            self.viewModel.progressSubline == "Whisper Large v3 Turbo · Apple Silicon"
+        }
+        let override = await mockService.lastSpeechEngineOverride
+        XCTAssertEqual(override, SpeechEngineSelection(engine: .whisper, language: "ko"))
+
+        viewModel.cancelTranscription()
+        try await waitUntil { !self.viewModel.isTranscribing }
     }
 
     func testRetranscriptionEngineOptionUsesCapturedMeetingEngine() throws {

--- a/plans/active/engine-attribution-polish.md
+++ b/plans/active/engine-attribution-polish.md
@@ -1,0 +1,130 @@
+# Engine Attribution Polish
+
+> Status: **ACTIVE** — single-PR scope, Tier 1 (live) + Tier 2 (persisted) combined.
+> Branch: `feat/engine-attribution-polish` (separate worktree).
+
+## Problem
+
+After PR #167 (Whisper) shipped, MacParakeet has two STT engines but no surfaces tell users *which engine produced what*. Three concrete gaps:
+
+1. **Live progress card** (`TranscriptionViewModel.subline`): hardcoded `"Runs entirely on-device using the Neural Engine"` — Parakeet-flavored copy that's shown for Whisper too.
+2. **Settings → Whisper status detail**: never names the variant (`large-v3-v20240930_turbo_632MB`). Users see no friendly model name anywhere.
+3. **Persisted records** (`Transcription`, `Dictation`): no engine/variant column. Past transcripts are forever ambiguous about what produced them.
+
+PR #167's body explicitly captures engine + language in meeting *metadata/lock* files at recording start — but that information never lands on the final `Transcription` row, so the closing half of the loop is missing.
+
+Whisper merged 2026-04-28 (~36 hours ago). Backfill is trivial *now* (essentially zero historical Whisper rows in the wild). Cost grows daily.
+
+## Goal
+
+One cohesive engine-attribution polish: live UI honest about which engine is running, persisted records carry engine + variant, surfaces that should display attribution do.
+
+## Out of scope
+
+- Cold-start `.loadingModel` overlay state for Whisper first-dictation-after-switch (PR #167's own deferred follow-up — separate UX thread).
+- Per-meeting language picker (PR #167 deferred).
+- Engine attribution on dictation history list rows / library grid rows (low value-per-row; can add later if asked).
+- Telemetry events for engine usage (separate concern; out of scope for this polish).
+
+## Tier 1 — Live UI (zero schema risk)
+
+### Surfaces
+
+| Surface | File | Change |
+|---|---|---|
+| Progress card subline | `Sources/MacParakeetViewModels/TranscriptionViewModel.swift` | Replace hardcoded subline with engine-aware copy read from `STTRuntime.currentSpeechEngineSelection()` |
+| Settings Whisper status detail | `Sources/MacParakeetViewModels/SettingsViewModel.swift` | Prefix friendly variant name onto status detail strings |
+
+### Friendly-name helper
+
+Add to `SpeechEnginePreference` (single source for engine display naming):
+
+```swift
+public static func friendlyVariantName(_ rawVariant: String) -> String
+// "large-v3-v20240930_turbo_632MB" → "Large v3 Turbo"
+// Unknown variant → variant string verbatim (graceful fallback)
+```
+
+### Subline copy
+
+| Engine | Subline |
+|---|---|
+| Parakeet | `"Parakeet TDT · Neural Engine"` |
+| Whisper | `"Whisper {friendlyVariant} · Apple Silicon"` |
+
+(Use middle-dot `·` not bullet — tighter visual.)
+
+## Tier 2 — Persisted Attribution (schema migration)
+
+### Schema migration
+
+`Sources/MacParakeetCore/Database/DatabaseManager.swift`, new migration `v0.7.7-engine-attribution`:
+
+```sql
+ALTER TABLE transcriptions ADD COLUMN engine TEXT;
+ALTER TABLE transcriptions ADD COLUMN engineVariant TEXT;
+ALTER TABLE dictations    ADD COLUMN engine TEXT;
+ALTER TABLE dictations    ADD COLUMN engineVariant TEXT;
+```
+
+- **No backfill.** Pre-migration rows = NULL. Display layer omits the attribution line for NULL rather than mislabeling.
+- Stored values are canonical (`"parakeet"` / `"whisper"`), not display strings — decouple persistence from copy.
+
+### Model updates
+
+- `Sources/MacParakeetCore/Models/Transcription.swift`: add `engine: String?`, `engineVariant: String?`. Update `init(from:)` with `decodeIfPresent`. Extend `Columns`.
+- `Sources/MacParakeetCore/Models/Dictation.swift`: same.
+
+### STTResult carries authoritative engine
+
+`Sources/MacParakeetCore/STT/STTResult.swift`:
+```swift
+public struct STTResult: Sendable {
+    public let text: String
+    public let words: [TimestampedWord]
+    public let language: String?
+    public let engine: SpeechEnginePreference   // NEW
+    public let engineVariant: String?           // NEW (whisper variant; nil for parakeet)
+}
+```
+
+The engine that ran is the authoritative source — not `STTRuntime.currentSpeechEngineSelection()` at save time, which can race a switch. `WhisperEngine` and `ParakeetEngine` populate at result construction.
+
+### Save sites
+
+Populate engine fields from `STTResult`:
+
+| File | Lines | Change |
+|---|---|---|
+| `Sources/MacParakeetCore/Services/DictationService.swift` | ~530 | `Dictation(...)` init gets `engine: result.engine.rawValue, engineVariant: result.engineVariant` |
+| `Sources/MacParakeetCore/Services/TranscriptionService.swift` | 4 save sites (262, 421, 544, 1114) | Same — populate when building/updating `Transcription` |
+| `Sources/MacParakeetCore/Services/MeetingRecordingRecoveryService.swift` | 336 | Recovered meetings inherit engine from lock metadata if present |
+
+### Display surfaces
+
+| Surface | File | Copy |
+|---|---|---|
+| Transcription detail metadata footer | `Sources/MacParakeet/Views/Transcription/...` (find concrete view) | `"Transcribed with Parakeet TDT"` / `"Transcribed with Whisper Large v3 Turbo"` — only when non-nil |
+| CLI JSON output | `Sources/CLI/...` | Add `engine`, `engineVariant` fields to JSON shape |
+
+## Validation
+
+- `swift build` clean.
+- `swift test` — all pre-existing tests pass.
+- New unit tests:
+  - `friendlyVariantName` for known + unknown variants.
+  - Settings status string includes friendly name when Whisper is selected.
+  - Migration: existing rows decode with nil engine.
+  - Save path: `STTResult.engine` round-trips to persisted `Transcription.engine`.
+  - CLI JSON: `engine` field present in output.
+- Manual smoke: dev app, swap to Whisper, transcribe short file, confirm progress card shows `"Whisper Large v3 Turbo · Apple Silicon"`, detail view shows attribution line, JSON CLI output contains engine fields.
+
+## Risks
+
+- **Migration backfill question** — chose `NULL` over `'parakeet'` default. Honest but means display omits line for legacy rows. Acceptable; alternative (default to `parakeet`) is wrong because mid-Whisper-rollout window has ambiguous rows.
+- **STTResult breaking change** — adding required fields to a public struct breaks call sites in tests/mocks. Mitigated by giving default values in init (`engine: SpeechEnginePreference = .parakeet`, `engineVariant: String? = nil`) so test fixtures still compile.
+- **Conflicts with `feat/whisper-language-picker`** (other agent's branch) — both touch `SettingsViewModel.swift` Whisper status. Worktree isolates implementation; merge order will need attention. Will note in PR description.
+
+## PR shape
+
+Single PR titled "Engine attribution polish" (or similar). Sections in PR body: Live UI, Persisted attribution, Migration, Display surfaces, Tests, Manual smoke.

--- a/plans/active/engine-attribution-polish.md
+++ b/plans/active/engine-attribution-polish.md
@@ -50,7 +50,7 @@ public static func friendlyVariantName(_ rawVariant: String) -> String
 | Engine | Subline |
 |---|---|
 | Parakeet | `"Parakeet TDT · Neural Engine"` |
-| Whisper | `"Whisper {friendlyVariant} · Apple Silicon"` |
+| Whisper | `"Whisper {friendlyVariant} · Neural Engine"` |
 
 (Use middle-dot `·` not bullet — tighter visual.)
 
@@ -58,7 +58,7 @@ public static func friendlyVariantName(_ rawVariant: String) -> String
 
 ### Schema migration
 
-`Sources/MacParakeetCore/Database/DatabaseManager.swift`, new migration `v0.7.7-engine-attribution`:
+`Sources/MacParakeetCore/Database/DatabaseManager.swift`, new migration `v0.8-engine-attribution`:
 
 ```sql
 ALTER TABLE transcriptions ADD COLUMN engine TEXT;
@@ -117,7 +117,7 @@ Populate engine fields from `STTResult`:
   - Migration: existing rows decode with nil engine.
   - Save path: `STTResult.engine` round-trips to persisted `Transcription.engine`.
   - CLI JSON: `engine` field present in output.
-- Manual smoke: dev app, swap to Whisper, transcribe short file, confirm progress card shows `"Whisper Large v3 Turbo · Apple Silicon"`, detail view shows attribution line, JSON CLI output contains engine fields.
+- Manual smoke: dev app, swap to Whisper, transcribe short file, confirm progress card shows `"Whisper Large v3 Turbo · Neural Engine"`, detail view shows attribution line, JSON CLI output contains engine fields.
 
 ## Risks
 


### PR DESCRIPTION
## What this does

Before this PR, MacParakeet's UI didn't honestly name which STT engine produced what. After Whisper shipped (#167), the live progress card still said `"Runs entirely on-device using the Neural Engine"` for both engines — Parakeet-flavored copy bleeding onto Whisper jobs. The Settings Whisper status never named the model file. Saved transcripts had no record of the engine, so a Whisper transcript looked identical to a Parakeet one in the database, forever.

This PR makes engine attribution visible everywhere it matters, and persists it so future-you can answer "what produced this transcript?" months from now.

## What you'll see

**Live progress card** while transcribing:

| Engine | Subline |
|---|---|
| Parakeet | `Parakeet TDT · Neural Engine` |
| Whisper | `Whisper Large v3 Turbo · Neural Engine` |

Snapshotted at task start, so the subline reflects the engine that's actually running — even when a single retranscription overrides the global engine selection.

**Settings → Whisper Model** row leads with the friendly variant name:

```
Whisper Large v3 Turbo · Loaded in memory and ready.
Whisper Large v3 Turbo · Downloaded. Loads automatically when selected.
Whisper Large v3 Turbo · Not downloaded yet.
```

**Transcript detail header** (expanded) gains an engine chip — `Parakeet TDT` or `Whisper Large v3 Turbo`. Omitted for transcripts saved before this PR (NULL → no chip, no mislabel).

**CLI** — `transcribe --format json` includes `engine` and `engineVariant` in output automatically.

## How it flows

```
        ┌─────────────────────────┐
        │  STT Engine             │
        │  (ParakeetEngine /      │
        │   WhisperEngine)        │
        └────────────┬────────────┘
                     │ produces
                     v
        ┌─────────────────────────┐
        │  STTResult              │
        │    text                 │
        │    words                │
        │    language?            │
        │    engine               │  ← authoritative
        │    engineVariant?       │
        └────────────┬────────────┘
                     │
       ┌─────────────┴───────────────────┐
       │                                 │
       v                                 v
 ┌──────────────────────┐    ┌──────────────────────────┐
 │  Persisted row       │    │  Live UI (job-start      │
 │   engine TEXT        │    │   snapshot of selection)  │
 │   engineVariant TEXT │    │   • Progress subline      │
 └──────────┬───────────┘    │   • Settings status row   │
            │ rendered as    └──────────────────────────┘
            v
 ┌──────────────────────┐
 │  • Detail header chip│
 │  • CLI JSON output   │
 └──────────────────────┘
```

The engine recorded on the row is set by the engine implementation itself (in `STTResult`) — not read from Settings at save time, which would race a mid-job toggle. The live UI takes a separate snapshot at task start so its display tracks the running job, including for retranscribe-with-override.

## Schema

Migration `v0.8-engine-attribution` adds two nullable columns to each STT-producing table:

```sql
ALTER TABLE transcriptions ADD COLUMN engine TEXT;
ALTER TABLE transcriptions ADD COLUMN engineVariant TEXT;
ALTER TABLE dictations    ADD COLUMN engine TEXT;
ALTER TABLE dictations    ADD COLUMN engineVariant TEXT;
```

Stored values are canonical (`"parakeet"`, `"whisper"`), not display strings. Pre-migration rows decode as `nil`. Migration is idempotent — guards against pre-existing columns from partially-restored databases.

## Design choices

- **NULL over backfill.** Pre-Whisper rows are unambiguously Parakeet, but post-Whisper-merge rows of unknown engine should not be silently mislabeled. Display layer omits the chip rather than printing a guess.
- **Authoritative on `STTResult`.** Engine is set by the engine implementation, not read from Settings at save time. A mid-job preference toggle cannot mislabel an in-flight transcription.
- **Friendly variant naming.** `large-v3-v20240930_turbo_632MB` becomes `Large v3 Turbo`. One variant ships today; the helper handles future variants gracefully — fallback to raw id for unknown shapes, token-boundary check so e.g. a future `large-v30` won't collide with `large-v3`.
- **Retranscribe clears engine fields** in `makeRetranscriptionRecord` for symmetry with the other STT-derived fields it clears (text, words, speakers, language…).

## Validation

- `swift build` clean.
- `swift test` — all tests pass.
- New tests cover: friendly-name happy path + unknown fallback; schema migration round-trip and idempotent rerun; engine-aware progress subline at job start including retranscribe override; end-to-end engine propagation from `STTResult` through to persisted column; repository round-trip + nil-engine decode for legacy rows.

## Test plan (manual)

- [ ] Build + launch dev app.
- [ ] Settings → switch Engine to Whisper. Confirm status row reads `Whisper Large v3 Turbo · …` in all states.
- [ ] Drop a short audio file. Confirm progress card shows `Whisper Large v3 Turbo · Neural Engine` during transcription.
- [ ] Open the resulting transcript, expand the header. Confirm the engine chip shows `Whisper Large v3 Turbo`.
- [ ] Switch back to Parakeet, transcribe again. Confirm subline reads `Parakeet TDT · Neural Engine` and chip reads `Parakeet TDT`.
- [ ] Open a transcript saved before this branch. Confirm the engine chip is omitted (no placeholder).
- [ ] CLI: `swift run macparakeet-cli transcribe sample.mp3 --format json | jq '{engine, engineVariant}'` returns the populated fields.

## Commits

1. `caa2d6cd` Live UI surfaces — progress card subline, Settings status, friendly-name helper.
2. `2e702514` Persisted attribution — schema, model fields, save plumbing, detail chip, CLI JSON.
3. `fa168f5c` Round-1 review feedback — mid-job snapshot, idiom cleanup, migration idempotency guard.
4. `82411da8` Round-2 — Whisper nil-variant fallback honest, retranscribe clears engine fields, end-to-end propagation test, copy correction.
5. `1ee9e88c` Round-3 — variant-prefix token-boundary check, Whisper variant snapshotted alongside engine, plan-doc + test alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
