### PR TITLE
Harden CLI JSON and cleanup contracts

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -77,6 +77,26 @@ ArgumentParser's plain-text stderr path with exit code `2`. Downstream
 agents that branch on `errorType` should also handle the parse-error case
 by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
+## [Unreleased]
+
+### Added
+
+- LLM-backed commands now accept `--api-key-env NAME`; hosted providers also
+  read `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, and
+  `OPENROUTER_API_KEY` directly.
+
+### Fixed
+
+- Applied the `--json` failure-envelope contract consistently across read-only
+  CLI surfaces such as history, stats, prompts, calendar, flow vocabulary, and
+  model status.
+- `prompts run --json` now emits a single JSON object even when saving the
+  generated `PromptResult` fails.
+- CLI deletion now removes app-owned dictation audio, YouTube audio, and
+  meeting recording folders after deleting their database rows.
+- Local transcription and export output paths now expand `~`; export also
+  creates parent directories and sanitizes default file names.
+
 ## [1.3.0] -- 2026-04-26
 
 ### Added

--- a/Sources/CLI/Commands/CLIHelpers.swift
+++ b/Sources/CLI/Commands/CLIHelpers.swift
@@ -282,6 +282,18 @@ extension CLIErrorEnvelope {
 /// surface through ArgumentParser's plain-text stderr path; the JSON
 /// envelope contract applies only to errors emitted after argument parsing
 /// succeeds.
+func emitJSONOrRethrow(json: Bool, _ body: () throws -> Void) throws {
+    do {
+        try body()
+    } catch let exit as ExitCode {
+        throw exit
+    } catch let cleanExit as CleanExit {
+        throw cleanExit
+    } catch {
+        try rethrowWithOptionalJSONEnvelope(error, json: json)
+    }
+}
+
 func emitJSONOrRethrow(json: Bool, _ body: () async throws -> Void) async throws {
     do {
         try await body()
@@ -290,12 +302,16 @@ func emitJSONOrRethrow(json: Bool, _ body: () async throws -> Void) async throws
     } catch let cleanExit as CleanExit {
         throw cleanExit
     } catch {
-        guard json else { throw error }
-        let envelope = CLIErrorEnvelope(error: error)
-        try? printJSON(envelope)
-        if error is ValidationError || error is CLIInputError {
-            throw ExitCode.validationFailure
-        }
-        throw ExitCode.failure
+        try rethrowWithOptionalJSONEnvelope(error, json: json)
     }
+}
+
+private func rethrowWithOptionalJSONEnvelope(_ error: Error, json: Bool) throws {
+    guard json else { throw error }
+    let envelope = CLIErrorEnvelope(error: error)
+    try? printJSON(envelope)
+    if error is ValidationError || error is CLIInputError {
+        throw ExitCode.validationFailure
+    }
+    throw ExitCode.failure
 }

--- a/Sources/CLI/Commands/CalendarCommand.swift
+++ b/Sources/CLI/Commands/CalendarCommand.swift
@@ -29,25 +29,27 @@ struct CalendarCommand: AsyncParsableCommand {
         var json: Bool = false
 
         func run() async throws {
-            guard let triggerFilter = parsedFilter() else {
-                throw ValidationError("--filter must be one of: link, participants, all")
-            }
-            switch CalendarService.shared.permissionStatus {
-            case .denied:
-                throw CalendarCLIError.calendarPermissionDenied
-            case .notDetermined:
-                throw CalendarCLIError.calendarPermissionNotDetermined
-            case .granted:
-                break
-            }
+            try await emitJSONOrRethrow(json: json) {
+                guard let triggerFilter = parsedFilter() else {
+                    throw ValidationError("--filter must be one of: link, participants, all")
+                }
+                switch CalendarService.shared.permissionStatus {
+                case .denied:
+                    throw CalendarCLIError.calendarPermissionDenied
+                case .notDetermined:
+                    throw CalendarCLIError.calendarPermissionNotDetermined
+                case .granted:
+                    break
+                }
 
-            let raw = try await CalendarService.shared.fetchUpcomingEvents(days: max(1, days))
-            let events = raw.filter { passesFilter($0, filter: triggerFilter) }
+                let raw = try await CalendarService.shared.fetchUpcomingEvents(days: max(1, days))
+                let events = raw.filter { passesFilter($0, filter: triggerFilter) }
 
-            if json {
-                try printJSON(events)
-            } else {
-                printHuman(events, filter: triggerFilter)
+                if json {
+                    try printJSON(events)
+                } else {
+                    printHuman(events, filter: triggerFilter)
+                }
             }
         }
 

--- a/Sources/CLI/Commands/ExportCommand.swift
+++ b/Sources/CLI/Commands/ExportCommand.swift
@@ -55,16 +55,20 @@ struct ExportCommand: AsyncParsableCommand {
             print(content)
         } else {
             let outputURL = resolveOutputURL(transcription: transcription)
+            try FileManager.default.createDirectory(
+                at: outputURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
             try await writeExport(transcription: transcription, exportService: exportService, url: outputURL)
             print("Exported to \(outputURL.path)")
         }
     }
 
-    private func resolveOutputURL(transcription: Transcription) -> URL {
+    func resolveOutputURL(transcription: Transcription) -> URL {
         if let output {
-            return URL(fileURLWithPath: output)
+            return URL(fileURLWithPath: expandTilde(output))
         }
-        let baseName = URL(fileURLWithPath: transcription.fileName).deletingPathExtension().lastPathComponent
+        let baseName = TranscriptSegmenter.sanitizedExportStem(from: transcription.fileName)
         let fileName = "\(baseName).\(format.fileExtension)"
         return URL(fileURLWithPath: FileManager.default.currentDirectoryPath).appendingPathComponent(fileName)
     }

--- a/Sources/CLI/Commands/FlowSnippetsCommand.swift
+++ b/Sources/CLI/Commands/FlowSnippetsCommand.swift
@@ -27,31 +27,33 @@ struct FlowSnippetsCommand: AsyncParsableCommand {
         var database: String?
 
         func run() async throws {
-            try AppPaths.ensureDirectories()
-            let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
-            let repo = TextSnippetRepository(dbQueue: dbManager.dbQueue)
-            let snippets = try repo.fetchAll()
+            try emitJSONOrRethrow(json: json) {
+                try AppPaths.ensureDirectories()
+                let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
+                let repo = TextSnippetRepository(dbQueue: dbManager.dbQueue)
+                let snippets = try repo.fetchAll()
 
-            if json {
-                try printJSON(snippets)
-                return
-            }
-
-            if snippets.isEmpty {
-                print("No text snippets configured.")
-                return
-            }
-
-            for snippet in snippets {
-                let status = snippet.isEnabled ? "+" : "-"
-                var line = "[\(status)] Say: \"\(snippet.trigger)\" -> \(snippet.expansion)"
-                if snippet.useCount > 0 {
-                    line += "  (used \(snippet.useCount)x)"
+                if json {
+                    try printJSON(snippets)
+                    return
                 }
-                line += "  (\(snippet.id.uuidString.prefix(8)))"
-                print(line)
+
+                if snippets.isEmpty {
+                    print("No text snippets configured.")
+                    return
+                }
+
+                for snippet in snippets {
+                    let status = snippet.isEnabled ? "+" : "-"
+                    var line = "[\(status)] Say: \"\(snippet.trigger)\" -> \(snippet.expansion)"
+                    if snippet.useCount > 0 {
+                        line += "  (used \(snippet.useCount)x)"
+                    }
+                    line += "  (\(snippet.id.uuidString.prefix(8)))"
+                    print(line)
+                }
+                print("\n\(snippets.count) snippet(s)")
             }
-            print("\n\(snippets.count) snippet(s)")
         }
     }
 

--- a/Sources/CLI/Commands/FlowWordsCommand.swift
+++ b/Sources/CLI/Commands/FlowWordsCommand.swift
@@ -34,36 +34,38 @@ struct FlowWordsCommand: AsyncParsableCommand {
         var database: String?
 
         func run() async throws {
-            try AppPaths.ensureDirectories()
-            let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
-            let repo = CustomWordRepository(dbQueue: dbManager.dbQueue)
-            let all = try repo.fetchAll()
-            let words: [CustomWord]
-            switch source {
-            case .all:     words = all
-            case .manual:  words = all.filter { $0.source == .manual }
-            case .learned: words = all.filter { $0.source == .learned }
-            }
-
-            if json {
-                try printJSON(words)
-                return
-            }
-
-            if words.isEmpty {
-                print("No custom words configured.")
-                return
-            }
-
-            for word in words {
-                let status = word.isEnabled ? "+" : "-"
-                if let replacement = word.replacement {
-                    print("[\(status)] \(word.word) -> \(replacement)  [\(word.source.rawValue)]  (\(word.id.uuidString.prefix(8)))")
-                } else {
-                    print("[\(status)] \(word.word) (anchor)  [\(word.source.rawValue)]  (\(word.id.uuidString.prefix(8)))")
+            try emitJSONOrRethrow(json: json) {
+                try AppPaths.ensureDirectories()
+                let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
+                let repo = CustomWordRepository(dbQueue: dbManager.dbQueue)
+                let all = try repo.fetchAll()
+                let words: [CustomWord]
+                switch source {
+                case .all:     words = all
+                case .manual:  words = all.filter { $0.source == .manual }
+                case .learned: words = all.filter { $0.source == .learned }
                 }
+
+                if json {
+                    try printJSON(words)
+                    return
+                }
+
+                if words.isEmpty {
+                    print("No custom words configured.")
+                    return
+                }
+
+                for word in words {
+                    let status = word.isEnabled ? "+" : "-"
+                    if let replacement = word.replacement {
+                        print("[\(status)] \(word.word) -> \(replacement)  [\(word.source.rawValue)]  (\(word.id.uuidString.prefix(8)))")
+                    } else {
+                        print("[\(status)] \(word.word) (anchor)  [\(word.source.rawValue)]  (\(word.id.uuidString.prefix(8)))")
+                    }
+                }
+                print("\n\(words.count) word(s)")
             }
-            print("\n\(words.count) word(s)")
         }
     }
 

--- a/Sources/CLI/Commands/HealthCommand.swift
+++ b/Sources/CLI/Commands/HealthCommand.swift
@@ -18,6 +18,12 @@ struct HealthCommand: AsyncParsableCommand {
     var json: Bool = false
 
     func run() async throws {
+        try await emitJSONOrRethrow(json: json) {
+            try await runHealthCheck()
+        }
+    }
+
+    private func runHealthCheck() async throws {
         let validatedRepairAttempts: Int?
         if repairModels {
             validatedRepairAttempts = try validatedAttempts(repairAttempts)
@@ -117,10 +123,6 @@ struct HealthCommand: AsyncParsableCommand {
 
         // 5. Local speech stack
         let sttClient = STTClient()
-        // CLI is about to exit anyway, but `defer` guarantees shutdown runs
-        // even if a future change adds a throw between init and the explicit
-        // shutdown below. Detached because defer can't await.
-        defer { Task { await sttClient.shutdown() } }
         let diarizationService = DiarizationService()
         let status = await loadSpeechStackStatus(
             sttClient: sttClient,
@@ -149,6 +151,7 @@ struct HealthCommand: AsyncParsableCommand {
             }
         }
         if !json { print() }
+        await sttClient.shutdown()
 
         // 6. Bundled FFmpeg
         let ffmpeg: HealthReport.Binary

--- a/Sources/CLI/Commands/HealthCommand.swift
+++ b/Sources/CLI/Commands/HealthCommand.swift
@@ -123,6 +123,12 @@ struct HealthCommand: AsyncParsableCommand {
 
         // 5. Local speech stack
         let sttClient = STTClient()
+        var sttClientNeedsShutdown = true
+        defer {
+            if sttClientNeedsShutdown {
+                Task { await sttClient.shutdown() }
+            }
+        }
         let diarizationService = DiarizationService()
         let status = await loadSpeechStackStatus(
             sttClient: sttClient,
@@ -152,6 +158,7 @@ struct HealthCommand: AsyncParsableCommand {
         }
         if !json { print() }
         await sttClient.shutdown()
+        sttClientNeedsShutdown = false
 
         // 6. Bundled FFmpeg
         let ffmpeg: HealthReport.Binary

--- a/Sources/CLI/Commands/HistoryCommand.swift
+++ b/Sources/CLI/Commands/HistoryCommand.swift
@@ -257,10 +257,28 @@ struct DeleteDictationSubcommand: ParsableCommand {
             throw CLILookupError.notFound("No dictation matching '\(id)'")
         }
         if let path = dictation.audioPath {
-            try? FileManager.default.removeItem(atPath: path)
+            removeOwnedDictationAudio(at: path)
         }
         let preview = String(dictation.rawTranscript.prefix(60))
         print("Deleted dictation: \"\(preview)\"")
+    }
+}
+
+private func removeOwnedDictationAudio(at path: String, fileManager: FileManager = .default) {
+    let rootURL = URL(fileURLWithPath: AppPaths.dictationsDir, isDirectory: true)
+        .standardizedFileURL
+    let targetURL = URL(fileURLWithPath: path).standardizedFileURL
+
+    guard targetURL.path.hasPrefix(rootURL.path + "/") else {
+        printErr("Refusing to remove dictation audio outside app-owned dictations directory: \(targetURL.path)")
+        return
+    }
+
+    guard fileManager.fileExists(atPath: targetURL.path) else { return }
+    do {
+        try fileManager.removeItem(at: targetURL)
+    } catch {
+        printErr("Failed to remove dictation audio at \(targetURL.path): \(error.localizedDescription)")
     }
 }
 

--- a/Sources/CLI/Commands/HistoryCommand.swift
+++ b/Sources/CLI/Commands/HistoryCommand.swift
@@ -252,7 +252,10 @@ struct DeleteDictationSubcommand: ParsableCommand {
         let repo = DictationRepository(dbQueue: dbManager.dbQueue)
 
         let dictation = try findDictation(id: id, repo: repo)
-        _ = try repo.delete(id: dictation.id)
+        let deleted = try repo.delete(id: dictation.id)
+        guard deleted else {
+            throw CLILookupError.notFound("No dictation matching '\(id)'")
+        }
         if let path = dictation.audioPath {
             try? FileManager.default.removeItem(atPath: path)
         }
@@ -279,7 +282,10 @@ struct DeleteTranscriptionSubcommand: ParsableCommand {
         let repo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
 
         let transcription = try findTranscription(id: id, repo: repo)
-        _ = try repo.delete(id: transcription.id)
+        let deleted = try repo.delete(id: transcription.id)
+        guard deleted else {
+            throw CLILookupError.notFound("No transcription matching '\(id)'")
+        }
         TranscriptionAssetCleanup.removeOwnedAssets(for: transcription)
         print("Deleted transcription: \"\(transcription.fileName)\"")
     }

--- a/Sources/CLI/Commands/HistoryCommand.swift
+++ b/Sources/CLI/Commands/HistoryCommand.swift
@@ -37,36 +37,38 @@ struct DictationsSubcommand: ParsableCommand {
     var database: String?
 
     func run() throws {
-        try AppPaths.ensureDirectories()
-        let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
-        let repo = DictationRepository(dbQueue: dbManager.dbQueue)
-        let dictations = try repo.fetchAll(limit: limit)
+        try emitJSONOrRethrow(json: json) {
+            try AppPaths.ensureDirectories()
+            let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
+            let repo = DictationRepository(dbQueue: dbManager.dbQueue)
+            let dictations = try repo.fetchAll(limit: limit)
 
-        if json {
-            try printJSON(dictations)
-            return
+            if json {
+                try printJSON(dictations)
+                return
+            }
+
+            if dictations.isEmpty {
+                print("No dictations found.")
+                return
+            }
+
+            let formatter = DateFormatter()
+            formatter.dateStyle = .short
+            formatter.timeStyle = .short
+
+            for d in dictations {
+                let date = formatter.string(from: d.createdAt)
+                let seconds = d.durationMs / 1000
+                let text = d.cleanTranscript ?? d.rawTranscript
+                let preview = text.count > 80 ? String(text.prefix(80)) + "..." : text
+                print("[\(date)] (\(seconds)s) \(preview)  (\(d.id.uuidString.prefix(8)))")
+            }
+
+            let stats = try repo.stats()
+            print()
+            print("Total: \(stats.visibleCount) dictations")
         }
-
-        if dictations.isEmpty {
-            print("No dictations found.")
-            return
-        }
-
-        let formatter = DateFormatter()
-        formatter.dateStyle = .short
-        formatter.timeStyle = .short
-
-        for d in dictations {
-            let date = formatter.string(from: d.createdAt)
-            let seconds = d.durationMs / 1000
-            let text = d.cleanTranscript ?? d.rawTranscript
-            let preview = text.count > 80 ? String(text.prefix(80)) + "..." : text
-            print("[\(date)] (\(seconds)s) \(preview)  (\(d.id.uuidString.prefix(8)))")
-        }
-
-        let stats = try repo.stats()
-        print()
-        print("Total: \(stats.visibleCount) dictations")
     }
 }
 
@@ -86,36 +88,38 @@ struct TranscriptionsSubcommand: ParsableCommand {
     var database: String?
 
     func run() throws {
-        try AppPaths.ensureDirectories()
-        let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
-        let repo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
-        let transcriptions = try repo.fetchAll(limit: limit)
+        try emitJSONOrRethrow(json: json) {
+            try AppPaths.ensureDirectories()
+            let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
+            let repo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
+            let transcriptions = try repo.fetchAll(limit: limit)
 
-        if json {
-            try printJSON(transcriptions)
-            return
-        }
-
-        if transcriptions.isEmpty {
-            print("No transcriptions found.")
-            return
-        }
-
-        let formatter = DateFormatter()
-        formatter.dateStyle = .short
-        formatter.timeStyle = .short
-
-        for t in transcriptions {
-            let date = formatter.string(from: t.createdAt)
-            let status = "\(t.status)"
-            let duration: String
-            if let ms = t.durationMs {
-                let s = ms / 1000
-                duration = "\(s / 60)m \(s % 60)s"
-            } else {
-                duration = "—"
+            if json {
+                try printJSON(transcriptions)
+                return
             }
-            print("[\(date)] \(t.fileName) (\(duration)) [\(status)]  (\(t.id.uuidString.prefix(8)))")
+
+            if transcriptions.isEmpty {
+                print("No transcriptions found.")
+                return
+            }
+
+            let formatter = DateFormatter()
+            formatter.dateStyle = .short
+            formatter.timeStyle = .short
+
+            for t in transcriptions {
+                let date = formatter.string(from: t.createdAt)
+                let status = "\(t.status)"
+                let duration: String
+                if let ms = t.durationMs {
+                    let s = ms / 1000
+                    duration = "\(s / 60)m \(s % 60)s"
+                } else {
+                    duration = "—"
+                }
+                print("[\(date)] \(t.fileName) (\(duration)) [\(status)]  (\(t.id.uuidString.prefix(8)))")
+            }
         }
     }
 }
@@ -139,34 +143,36 @@ struct SearchSubcommand: ParsableCommand {
     var database: String?
 
     func run() throws {
-        try AppPaths.ensureDirectories()
-        let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
-        let repo = DictationRepository(dbQueue: dbManager.dbQueue)
-        let results = try repo.search(query: query, limit: limit)
+        try emitJSONOrRethrow(json: json) {
+            try AppPaths.ensureDirectories()
+            let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
+            let repo = DictationRepository(dbQueue: dbManager.dbQueue)
+            let results = try repo.search(query: query, limit: limit)
 
-        if json {
-            try printJSON(results)
-            return
+            if json {
+                try printJSON(results)
+                return
+            }
+
+            if results.isEmpty {
+                print("No results for \"\(query)\".")
+                return
+            }
+
+            let formatter = DateFormatter()
+            formatter.dateStyle = .short
+            formatter.timeStyle = .short
+
+            for d in results {
+                let date = formatter.string(from: d.createdAt)
+                let text = d.cleanTranscript ?? d.rawTranscript
+                let preview = text.count > 80 ? String(text.prefix(80)) + "..." : text
+                print("[\(date)] \(preview)")
+            }
+
+            print()
+            print("\(results.count) result(s)")
         }
-
-        if results.isEmpty {
-            print("No results for \"\(query)\".")
-            return
-        }
-
-        let formatter = DateFormatter()
-        formatter.dateStyle = .short
-        formatter.timeStyle = .short
-
-        for d in results {
-            let date = formatter.string(from: d.createdAt)
-            let text = d.cleanTranscript ?? d.rawTranscript
-            let preview = text.count > 80 ? String(text.prefix(80)) + "..." : text
-            print("[\(date)] \(preview)")
-        }
-
-        print()
-        print("\(results.count) result(s)")
     }
 }
 
@@ -189,40 +195,42 @@ struct SearchTranscriptionsSubcommand: ParsableCommand {
     var database: String?
 
     func run() throws {
-        try AppPaths.ensureDirectories()
-        let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
-        let repo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
-        let results = try repo.search(query: query, limit: limit)
+        try emitJSONOrRethrow(json: json) {
+            try AppPaths.ensureDirectories()
+            let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
+            let repo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
+            let results = try repo.search(query: query, limit: limit)
 
-        if json {
-            try printJSON(results)
-            return
-        }
-
-        if results.isEmpty {
-            print("No transcriptions matching \"\(query)\".")
-            return
-        }
-
-        let formatter = DateFormatter()
-        formatter.dateStyle = .short
-        formatter.timeStyle = .short
-
-        for t in results {
-            let date = formatter.string(from: t.createdAt)
-            let fav = t.isFavorite ? " *" : ""
-            let duration: String
-            if let ms = t.durationMs {
-                let s = ms / 1000
-                duration = "\(s / 60)m \(s % 60)s"
-            } else {
-                duration = "—"
+            if json {
+                try printJSON(results)
+                return
             }
-            print("[\(date)] \(t.fileName) (\(duration)) [\(t.status)]\(fav)  (\(t.id.uuidString.prefix(8)))")
-        }
 
-        print()
-        print("\(results.count) result(s)")
+            if results.isEmpty {
+                print("No transcriptions matching \"\(query)\".")
+                return
+            }
+
+            let formatter = DateFormatter()
+            formatter.dateStyle = .short
+            formatter.timeStyle = .short
+
+            for t in results {
+                let date = formatter.string(from: t.createdAt)
+                let fav = t.isFavorite ? " *" : ""
+                let duration: String
+                if let ms = t.durationMs {
+                    let s = ms / 1000
+                    duration = "\(s / 60)m \(s % 60)s"
+                } else {
+                    duration = "—"
+                }
+                print("[\(date)] \(t.fileName) (\(duration)) [\(t.status)]\(fav)  (\(t.id.uuidString.prefix(8)))")
+            }
+
+            print()
+            print("\(results.count) result(s)")
+        }
     }
 }
 
@@ -245,6 +253,9 @@ struct DeleteDictationSubcommand: ParsableCommand {
 
         let dictation = try findDictation(id: id, repo: repo)
         _ = try repo.delete(id: dictation.id)
+        if let path = dictation.audioPath {
+            try? FileManager.default.removeItem(atPath: path)
+        }
         let preview = String(dictation.rawTranscript.prefix(60))
         print("Deleted dictation: \"\(preview)\"")
     }
@@ -269,6 +280,7 @@ struct DeleteTranscriptionSubcommand: ParsableCommand {
 
         let transcription = try findTranscription(id: id, repo: repo)
         _ = try repo.delete(id: transcription.id)
+        TranscriptionAssetCleanup.removeOwnedAssets(for: transcription)
         print("Deleted transcription: \"\(transcription.fileName)\"")
     }
 }
@@ -286,39 +298,41 @@ struct FavoritesSubcommand: ParsableCommand {
     var database: String?
 
     func run() throws {
-        try AppPaths.ensureDirectories()
-        let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
-        let repo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
-        let favorites = try repo.fetchFavorites()
+        try emitJSONOrRethrow(json: json) {
+            try AppPaths.ensureDirectories()
+            let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
+            let repo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
+            let favorites = try repo.fetchFavorites()
 
-        if json {
-            try printJSON(favorites)
-            return
-        }
-
-        if favorites.isEmpty {
-            print("No favorite transcriptions.")
-            return
-        }
-
-        let formatter = DateFormatter()
-        formatter.dateStyle = .short
-        formatter.timeStyle = .short
-
-        for t in favorites {
-            let date = formatter.string(from: t.createdAt)
-            let duration: String
-            if let ms = t.durationMs {
-                let s = ms / 1000
-                duration = "\(s / 60)m \(s % 60)s"
-            } else {
-                duration = "—"
+            if json {
+                try printJSON(favorites)
+                return
             }
-            print("* [\(date)] \(t.fileName) (\(duration)) [\(t.status)]  (\(t.id.uuidString.prefix(8)))")
-        }
 
-        print()
-        print("\(favorites.count) favorite(s)")
+            if favorites.isEmpty {
+                print("No favorite transcriptions.")
+                return
+            }
+
+            let formatter = DateFormatter()
+            formatter.dateStyle = .short
+            formatter.timeStyle = .short
+
+            for t in favorites {
+                let date = formatter.string(from: t.createdAt)
+                let duration: String
+                if let ms = t.durationMs {
+                    let s = ms / 1000
+                    duration = "\(s / 60)m \(s % 60)s"
+                } else {
+                    duration = "—"
+                }
+                print("* [\(date)] \(t.fileName) (\(duration)) [\(t.status)]  (\(t.id.uuidString.prefix(8)))")
+            }
+
+            print()
+            print("\(favorites.count) favorite(s)")
+        }
     }
 }
 

--- a/Sources/CLI/Commands/LLMInlineConfig.swift
+++ b/Sources/CLI/Commands/LLMInlineConfig.swift
@@ -39,8 +39,11 @@ struct LLMInlineOptions: ParsableArguments {
     @Option(name: .long, help: "Provider: anthropic, openai, openaiCompatible, gemini, openrouter, ollama, lmstudio, cli.")
     var provider: String
 
-    @Option(name: .long, help: "API key. Pass via shell expansion (e.g. --api-key \"$ANTHROPIC_API_KEY\") so the literal key doesn't land in shell history or ps output.")
+    @Option(name: .long, help: "API key literal. Prefer --api-key-env or provider env vars to avoid exposing secrets in process arguments.")
     var apiKey: String?
+
+    @Option(name: .long, help: "Environment variable name containing the API key.")
+    var apiKeyEnv: String?
 
     @Option(name: .long, help: "Model name (e.g. gpt-4o, claude-sonnet-4-20250514, gemini-2.0-flash).")
     var model: String?
@@ -73,7 +76,9 @@ struct LLMInlineOptions: ParsableArguments {
         return providerID
     }
 
-    func buildExecutionContext() throws -> InlineLLMExecutionContext {
+    func buildExecutionContext(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws -> InlineLLMExecutionContext {
         let providerID = try providerID()
 
         let overrideURL: URL? = if let urlStr = baseURL {
@@ -89,10 +94,18 @@ struct LLMInlineOptions: ParsableArguments {
 
         switch providerID {
         case .anthropic:
-            guard let key = apiKey else { throw ValidationError("--api-key is required for Anthropic") }
+            let key = try requiredAPIKey(
+                providerName: "Anthropic",
+                defaultEnvNames: ["ANTHROPIC_API_KEY"],
+                environment: environment
+            )
             providerConfig = .anthropic(apiKey: key, model: model ?? "claude-sonnet-4-6", baseURL: overrideURL)
         case .openai:
-            guard let key = apiKey else { throw ValidationError("--api-key is required for OpenAI") }
+            let key = try requiredAPIKey(
+                providerName: "OpenAI",
+                defaultEnvNames: ["OPENAI_API_KEY"],
+                environment: environment
+            )
             providerConfig = .openai(apiKey: key, model: model ?? "gpt-4.1", baseURL: overrideURL)
         case .openaiCompatible:
             guard let overrideURL else { throw ValidationError("--base-url is required for OpenAI-Compatible") }
@@ -100,15 +113,23 @@ struct LLMInlineOptions: ParsableArguments {
                 throw ValidationError("--model is required for OpenAI-Compatible")
             }
             providerConfig = .openaiCompatible(
-                apiKey: apiKey?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty,
+                apiKey: try optionalAPIKey(defaultEnvNames: [], environment: environment),
                 model: model.trimmingCharacters(in: .whitespacesAndNewlines),
                 baseURL: overrideURL
             )
         case .gemini:
-            guard let key = apiKey else { throw ValidationError("--api-key is required for Gemini") }
+            let key = try requiredAPIKey(
+                providerName: "Gemini",
+                defaultEnvNames: ["GEMINI_API_KEY"],
+                environment: environment
+            )
             providerConfig = .gemini(apiKey: key, model: model ?? "gemini-2.5-flash", baseURL: overrideURL)
         case .openrouter:
-            guard let key = apiKey else { throw ValidationError("--api-key is required for OpenRouter") }
+            let key = try requiredAPIKey(
+                providerName: "OpenRouter",
+                defaultEnvNames: ["OPENROUTER_API_KEY"],
+                environment: environment
+            )
             providerConfig = .openrouter(apiKey: key, model: model ?? "anthropic/claude-sonnet-4", baseURL: overrideURL)
         case .ollama:
             providerConfig = .ollama(model: model ?? "qwen3.5:4b", baseURL: overrideURL)
@@ -148,8 +169,45 @@ struct LLMInlineOptions: ParsableArguments {
         )
     }
 
-    func buildConfig() throws -> LLMProviderConfig {
-        try buildExecutionContext().context.providerConfig
+    private func requiredAPIKey(
+        providerName: String,
+        defaultEnvNames: [String],
+        environment: [String: String]
+    ) throws -> String {
+        if let key = try optionalAPIKey(defaultEnvNames: defaultEnvNames, environment: environment) {
+            return key
+        }
+        let envHint = defaultEnvNames.isEmpty ? "" : ", --api-key-env, or \(defaultEnvNames.joined(separator: "/"))"
+        throw ValidationError("--api-key\(envHint) is required for \(providerName)")
+    }
+
+    private func optionalAPIKey(defaultEnvNames: [String], environment: [String: String]) throws -> String? {
+        if let key = apiKey?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty {
+            return key
+        }
+
+        if let apiKeyEnv {
+            let envName = apiKeyEnv.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !envName.isEmpty else {
+                throw ValidationError("--api-key-env must not be empty")
+            }
+            guard let key = environment[envName]?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty else {
+                throw ValidationError("Environment variable \(envName) is not set or is empty")
+            }
+            return key
+        }
+
+        for envName in defaultEnvNames {
+            if let key = environment[envName]?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty {
+                return key
+            }
+        }
+
+        return nil
+    }
+
+    func buildConfig(environment: [String: String] = ProcessInfo.processInfo.environment) throws -> LLMProviderConfig {
+        try buildExecutionContext(environment: environment).context.providerConfig
     }
 }
 

--- a/Sources/CLI/Commands/LLMInlineConfig.swift
+++ b/Sources/CLI/Commands/LLMInlineConfig.swift
@@ -182,7 +182,11 @@ struct LLMInlineOptions: ParsableArguments {
     }
 
     private func optionalAPIKey(defaultEnvNames: [String], environment: [String: String]) throws -> String? {
-        if let key = apiKey?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty {
+        if let apiKey {
+            let key = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !key.isEmpty else {
+                throw ValidationError("--api-key must not be empty")
+            }
             return key
         }
 

--- a/Sources/CLI/Commands/MeetingsCommand.swift
+++ b/Sources/CLI/Commands/MeetingsCommand.swift
@@ -35,7 +35,7 @@ struct MeetingsCommand: AsyncParsableCommand {
         }
 
         func run() async throws {
-            try await emitJSONOrRethrow(json: json) {
+            try emitJSONOrRethrow(json: json) {
                 let repo = try makeTranscriptionRepository(database: database)
                 let meetings = try repo.fetchBySourceType(.meeting, limit: limit)
                     .map(MeetingListItem.init)
@@ -75,7 +75,7 @@ struct MeetingsCommand: AsyncParsableCommand {
         var database: String?
 
         func run() async throws {
-            try await emitJSONOrRethrow(json: json) {
+            try emitJSONOrRethrow(json: json) {
                 let repo = try makeTranscriptionRepository(database: database)
                 let transcription = try findMeeting(idOrName: meeting, repo: repo)
                 let record = MeetingRecord(transcription)
@@ -150,7 +150,7 @@ struct MeetingsCommand: AsyncParsableCommand {
             var database: String?
 
             func run() async throws {
-                try await emitJSONOrRethrow(json: json) {
+                try emitJSONOrRethrow(json: json) {
                     let repo = try makeTranscriptionRepository(database: database)
                     let transcription = try findMeeting(idOrName: meeting, repo: repo)
                     let envelope = MeetingNotesRecord(transcription)
@@ -192,7 +192,7 @@ struct MeetingsCommand: AsyncParsableCommand {
             }
 
             func run() async throws {
-                try await emitJSONOrRethrow(json: json) {
+                try emitJSONOrRethrow(json: json) {
                     let repo = try makeTranscriptionRepository(database: database)
                     let transcription = try findMeeting(idOrName: meeting, repo: repo)
                     let notes = try notesInput(text: text, stdin: stdin)
@@ -231,7 +231,7 @@ struct MeetingsCommand: AsyncParsableCommand {
             }
 
             func run() async throws {
-                try await emitJSONOrRethrow(json: json) {
+                try emitJSONOrRethrow(json: json) {
                     let repo = try makeTranscriptionRepository(database: database)
                     let transcription = try findMeeting(idOrName: meeting, repo: repo)
                     let addition = try notesInput(text: text, stdin: stdin)
@@ -256,7 +256,7 @@ struct MeetingsCommand: AsyncParsableCommand {
             var database: String?
 
             func run() async throws {
-                try await emitJSONOrRethrow(json: json) {
+                try emitJSONOrRethrow(json: json) {
                     let repo = try makeTranscriptionRepository(database: database)
                     let transcription = try findMeeting(idOrName: meeting, repo: repo)
                     try repo.updateUserNotes(id: transcription.id, userNotes: nil)
@@ -289,7 +289,7 @@ struct MeetingsCommand: AsyncParsableCommand {
         var database: String?
 
         func run() async throws {
-            try await emitJSONOrRethrow(json: stdout && format == .json) {
+            try emitJSONOrRethrow(json: stdout && format == .json) {
                 let repo = try makeTranscriptionRepository(database: database)
                 let transcription = try findMeeting(idOrName: meeting, repo: repo)
                 let content = try exportContent(for: transcription, format: format)

--- a/Sources/CLI/Commands/ModelsCommand.swift
+++ b/Sources/CLI/Commands/ModelsCommand.swift
@@ -28,18 +28,20 @@ extension ModelsCommand {
         var json: Bool = false
 
         func run() async throws {
-            let sttClient = STTClient()
-            let diarizationService = DiarizationService()
-            let status = await loadSpeechStackStatus(
-                sttClient: sttClient,
-                diarizationService: diarizationService
-            )
-            if json {
-                try printJSON(SpeechStackPayload(status: status))
-            } else {
-                printSpeechStackStatus(status)
+            try await emitJSONOrRethrow(json: json) {
+                let sttClient = STTClient()
+                let diarizationService = DiarizationService()
+                let status = await loadSpeechStackStatus(
+                    sttClient: sttClient,
+                    diarizationService: diarizationService
+                )
+                await sttClient.shutdown()
+                if json {
+                    try printJSON(SpeechStackPayload(status: status))
+                } else {
+                    printSpeechStackStatus(status)
+                }
             }
-            await sttClient.shutdown()
         }
     }
 

--- a/Sources/CLI/Commands/ModelsCommand.swift
+++ b/Sources/CLI/Commands/ModelsCommand.swift
@@ -30,12 +30,19 @@ extension ModelsCommand {
         func run() async throws {
             try await emitJSONOrRethrow(json: json) {
                 let sttClient = STTClient()
+                var sttClientNeedsShutdown = true
+                defer {
+                    if sttClientNeedsShutdown {
+                        Task { await sttClient.shutdown() }
+                    }
+                }
                 let diarizationService = DiarizationService()
                 let status = await loadSpeechStackStatus(
                     sttClient: sttClient,
                     diarizationService: diarizationService
                 )
                 await sttClient.shutdown()
+                sttClientNeedsShutdown = false
                 if json {
                     try printJSON(SpeechStackPayload(status: status))
                 } else {
@@ -86,6 +93,12 @@ extension ModelsCommand {
         func run() async throws {
             let attempts = try validatedAttempts(attempts)
             let sttClient = STTClient()
+            var sttClientNeedsShutdown = true
+            defer {
+                if sttClientNeedsShutdown {
+                    Task { await sttClient.shutdown() }
+                }
+            }
             let diarizationService = DiarizationService()
             try await prepareSpeechStack(
                 attempts: attempts,
@@ -94,6 +107,7 @@ extension ModelsCommand {
                 log: { print($0) }
             )
             await sttClient.shutdown()
+            sttClientNeedsShutdown = false
         }
     }
 
@@ -109,6 +123,12 @@ extension ModelsCommand {
         func run() async throws {
             let attempts = try validatedAttempts(attempts)
             let sttClient = STTClient()
+            var sttClientNeedsShutdown = true
+            defer {
+                if sttClientNeedsShutdown {
+                    Task { await sttClient.shutdown() }
+                }
+            }
             let diarizationService = DiarizationService()
             try await prepareSpeechStack(
                 attempts: attempts,
@@ -117,6 +137,7 @@ extension ModelsCommand {
                 log: { print($0) }
             )
             await sttClient.shutdown()
+            sttClientNeedsShutdown = false
         }
     }
 

--- a/Sources/CLI/Commands/PromptsCommand.swift
+++ b/Sources/CLI/Commands/PromptsCommand.swift
@@ -46,33 +46,35 @@ extension PromptsCommand {
         var database: String?
 
         func run() throws {
-            try AppPaths.ensureDirectories()
-            let db = try DatabaseManager(path: resolvedDatabasePath(database))
-            let repo = PromptRepository(dbQueue: db.dbQueue)
+            try emitJSONOrRethrow(json: json) {
+                try AppPaths.ensureDirectories()
+                let db = try DatabaseManager(path: resolvedDatabasePath(database))
+                let repo = PromptRepository(dbQueue: db.dbQueue)
 
-            let prompts: [Prompt]
-            switch filter {
-            case .all:     prompts = try repo.fetchAll()
-            case .visible: prompts = try repo.fetchVisible(category: nil)
-            case .autoRun: prompts = try repo.fetchAutoRunPrompts()
-            }
+                let prompts: [Prompt]
+                switch filter {
+                case .all:     prompts = try repo.fetchAll()
+                case .visible: prompts = try repo.fetchVisible(category: nil)
+                case .autoRun: prompts = try repo.fetchAutoRunPrompts()
+                }
 
-            if json {
-                try printJSON(prompts)
-                return
-            }
+                if json {
+                    try printJSON(prompts)
+                    return
+                }
 
-            if prompts.isEmpty {
-                print("No prompts found.")
-                return
-            }
+                if prompts.isEmpty {
+                    print("No prompts found.")
+                    return
+                }
 
-            for p in prompts {
-                let badges = renderBadges(p)
-                print("\(p.id.uuidString.prefix(8))  \(p.name)\(badges)")
+                for p in prompts {
+                    let badges = renderBadges(p)
+                    print("\(p.id.uuidString.prefix(8))  \(p.name)\(badges)")
+                }
+                print()
+                print("\(prompts.count) prompt(s)")
             }
-            print()
-            print("\(prompts.count) prompt(s)")
         }
     }
 }
@@ -96,22 +98,24 @@ extension PromptsCommand {
         var database: String?
 
         func run() throws {
-            try AppPaths.ensureDirectories()
-            let db = try DatabaseManager(path: resolvedDatabasePath(database))
-            let repo = PromptRepository(dbQueue: db.dbQueue)
-            let prompt = try findPrompt(idOrName: idOrName, repo: repo)
+            try emitJSONOrRethrow(json: json) {
+                try AppPaths.ensureDirectories()
+                let db = try DatabaseManager(path: resolvedDatabasePath(database))
+                let repo = PromptRepository(dbQueue: db.dbQueue)
+                let prompt = try findPrompt(idOrName: idOrName, repo: repo)
 
-            if json {
-                try printJSON(prompt)
-                return
+                if json {
+                    try printJSON(prompt)
+                    return
+                }
+
+                print("ID:        \(prompt.id.uuidString)")
+                print("Name:      \(prompt.name)\(renderBadges(prompt))")
+                print("Category:  \(prompt.category.rawValue)")
+                print("Updated:   \(ISO8601DateFormatter().string(from: prompt.updatedAt))")
+                print()
+                print(prompt.content)
             }
-
-            print("ID:        \(prompt.id.uuidString)")
-            print("Name:      \(prompt.name)\(renderBadges(prompt))")
-            print("Category:  \(prompt.category.rawValue)")
-            print("Updated:   \(ISO8601DateFormatter().string(from: prompt.updatedAt))")
-            print()
-            print(prompt.content)
         }
     }
 }
@@ -374,13 +378,14 @@ extension PromptsCommand {
                 )
 
                 var output = ""
+                var jsonResult: LLMResult?
                 if json {
                     let result = try await service.generatePromptResultDetailed(
                         transcript: transcriptText,
                         systemPrompt: systemPrompt
                     )
                     output = result.output
-                    try printJSON(result)
+                    jsonResult = result
                 } else if stream {
                     let tokenStream = service.generatePromptResultStream(
                         transcript: transcriptText,
@@ -411,6 +416,10 @@ extension PromptsCommand {
                     try resultRepo.save(result)
                     // Status messages on stderr so stdout stays grep-able as the prompt output.
                     FileHandle.standardError.write(Data("\nSaved PromptResult \(result.id.uuidString.prefix(8))\n".utf8))
+                }
+
+                if let jsonResult {
+                    try printJSON(jsonResult)
                 }
             }
         }

--- a/Sources/CLI/Commands/StatsCommand.swift
+++ b/Sources/CLI/Commands/StatsCommand.swift
@@ -15,78 +15,80 @@ struct StatsCommand: ParsableCommand {
     var database: String?
 
     func run() throws {
-        try AppPaths.ensureDirectories()
-        let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
-        let dictationRepo = DictationRepository(dbQueue: dbManager.dbQueue)
-        let transcriptionRepo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
+        try emitJSONOrRethrow(json: json) {
+            try AppPaths.ensureDirectories()
+            let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
+            let dictationRepo = DictationRepository(dbQueue: dbManager.dbQueue)
+            let transcriptionRepo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
 
-        let stats = try dictationRepo.stats()
-        let transcriptionCount = try transcriptionRepo.count()
-        let favoriteCount = try transcriptionRepo.fetchFavorites().count
+            let stats = try dictationRepo.stats()
+            let transcriptionCount = try transcriptionRepo.count()
+            let favoriteCount = try transcriptionRepo.fetchFavorites().count
 
-        if json {
-            try printJSON(StatsPayload(stats: stats, transcriptionCount: transcriptionCount, favoriteCount: favoriteCount))
-            return
-        }
-
-        if stats.visibleCount == 0 && transcriptionCount == 0 {
-            print("No voice activity yet.")
-            return
-        }
-
-        print("=== Voice Stats ===")
-        print()
-
-        // Dictation stats
-        print("Dictations")
-        print("  Total:            \(stats.visibleCount)")
-        print("  Total words:      \(stats.totalWords)")
-        if stats.totalDurationMs > 0 {
-            let totalSec = stats.totalDurationMs / 1000
-            let min = totalSec / 60
-            let sec = totalSec % 60
-            print("  Total duration:   \(min)m \(sec)s")
-        }
-        if stats.averageDurationMs > 0 {
-            let avgSec = stats.averageDurationMs / 1000
-            print("  Avg duration:     \(avgSec)s")
-        }
-        if stats.averageWPM > 0 {
-            print("  Avg WPM:          \(Int(stats.averageWPM))")
-        }
-        if stats.longestDurationMs > 0 {
-            let longestSec = stats.longestDurationMs / 1000
-            let min = longestSec / 60
-            let sec = longestSec % 60
-            print("  Longest:          \(min)m \(sec)s")
-        }
-        if stats.weeklyStreak > 0 {
-            print("  Weekly streak:    \(stats.weeklyStreak) week(s)")
-        }
-        if stats.dictationsThisWeek > 0 {
-            print("  This week:        \(stats.dictationsThisWeek)")
-        }
-
-        // Equivalents
-        if stats.totalWords > 0 {
-            let timeSavedMin = stats.timeSavedMs / 60_000
-            if timeSavedMin > 0 {
-                print("  Time saved:       ~\(timeSavedMin) min (vs typing)")
+            if json {
+                try printJSON(StatsPayload(stats: stats, transcriptionCount: transcriptionCount, favoriteCount: favoriteCount))
+                return
             }
-            if stats.booksEquivalent >= 0.1 {
-                print("  Books equivalent: \(String(format: "%.1f", stats.booksEquivalent))")
-            }
-            if stats.emailsEquivalent >= 1.0 {
-                print("  Emails equivalent: \(Int(stats.emailsEquivalent))")
-            }
-        }
 
-        // Transcription stats
-        print()
-        print("Transcriptions")
-        print("  Total:            \(transcriptionCount)")
-        if favoriteCount > 0 {
-            print("  Favorites:        \(favoriteCount)")
+            if stats.visibleCount == 0 && transcriptionCount == 0 {
+                print("No voice activity yet.")
+                return
+            }
+
+            print("=== Voice Stats ===")
+            print()
+
+            // Dictation stats
+            print("Dictations")
+            print("  Total:            \(stats.visibleCount)")
+            print("  Total words:      \(stats.totalWords)")
+            if stats.totalDurationMs > 0 {
+                let totalSec = stats.totalDurationMs / 1000
+                let min = totalSec / 60
+                let sec = totalSec % 60
+                print("  Total duration:   \(min)m \(sec)s")
+            }
+            if stats.averageDurationMs > 0 {
+                let avgSec = stats.averageDurationMs / 1000
+                print("  Avg duration:     \(avgSec)s")
+            }
+            if stats.averageWPM > 0 {
+                print("  Avg WPM:          \(Int(stats.averageWPM))")
+            }
+            if stats.longestDurationMs > 0 {
+                let longestSec = stats.longestDurationMs / 1000
+                let min = longestSec / 60
+                let sec = longestSec % 60
+                print("  Longest:          \(min)m \(sec)s")
+            }
+            if stats.weeklyStreak > 0 {
+                print("  Weekly streak:    \(stats.weeklyStreak) week(s)")
+            }
+            if stats.dictationsThisWeek > 0 {
+                print("  This week:        \(stats.dictationsThisWeek)")
+            }
+
+            // Equivalents
+            if stats.totalWords > 0 {
+                let timeSavedMin = stats.timeSavedMs / 60_000
+                if timeSavedMin > 0 {
+                    print("  Time saved:       ~\(timeSavedMin) min (vs typing)")
+                }
+                if stats.booksEquivalent >= 0.1 {
+                    print("  Books equivalent: \(String(format: "%.1f", stats.booksEquivalent))")
+                }
+                if stats.emailsEquivalent >= 1.0 {
+                    print("  Emails equivalent: \(Int(stats.emailsEquivalent))")
+                }
+            }
+
+            // Transcription stats
+            print()
+            print("Transcriptions")
+            print("  Total:            \(transcriptionCount)")
+            if favoriteCount > 0 {
+                print("  Favorites:        \(favoriteCount)")
+            }
         }
     }
 }

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -69,6 +69,10 @@ struct TranscribeCommand: AsyncParsableCommand {
         }
     }
 
+    static func localFileURL(for input: String) -> URL {
+        URL(fileURLWithPath: expandTilde(input))
+    }
+
     func run() async throws {
         CLITelemetry.configureIfNeeded()
         let cliOperationContext = ObservabilityOperationContext()
@@ -77,7 +81,7 @@ struct TranscribeCommand: AsyncParsableCommand {
         let trimmedInput = input.trimmingCharacters(in: .whitespacesAndNewlines)
         let inputKind: ObservabilityInputKind = YouTubeURLValidator.isYouTubeURL(trimmedInput)
             ? .youtube
-            : (Observability.inputKind(for: URL(fileURLWithPath: trimmedInput)) ?? .unknown)
+            : (Observability.inputKind(for: Self.localFileURL(for: trimmedInput)) ?? .unknown)
 
         var sttClient: STTClient?
         var whisperEngine: WhisperEngine?
@@ -161,10 +165,10 @@ struct TranscribeCommand: AsyncParsableCommand {
                         }
                     }
                 } else {
-                    let url = URL(fileURLWithPath: trimmedInput)
+                    let url = Self.localFileURL(for: trimmedInput)
 
-                    guard FileManager.default.fileExists(atPath: trimmedInput) else {
-                        throw CLIError.fileNotFound(trimmedInput)
+                    guard FileManager.default.fileExists(atPath: url.path) else {
+                        throw CLIError.fileNotFound(url.path)
                     }
 
                     let ext = url.pathExtension.lowercased()

--- a/Sources/MacParakeetCore/Utilities/TranscriptionAssetCleanup.swift
+++ b/Sources/MacParakeetCore/Utilities/TranscriptionAssetCleanup.swift
@@ -1,0 +1,50 @@
+import Foundation
+import os
+
+public enum TranscriptionAssetCleanup {
+    private static let logger = Logger(
+        subsystem: "com.macparakeet.core",
+        category: "TranscriptionAssetCleanup"
+    )
+
+    public static func removeOwnedAssets(
+        for transcription: Transcription,
+        fileManager: FileManager = .default
+    ) {
+        guard let filePath = transcription.filePath else { return }
+
+        switch transcription.sourceType {
+        case .youtube:
+            removeItem(at: URL(fileURLWithPath: filePath), fileManager: fileManager)
+        case .meeting:
+            removeMeetingFolder(containing: URL(fileURLWithPath: filePath), fileManager: fileManager)
+        case .file:
+            return
+        }
+    }
+
+    private static func removeMeetingFolder(containing fileURL: URL, fileManager: FileManager) {
+        let meetingRootURL = URL(fileURLWithPath: AppPaths.meetingRecordingsDir, isDirectory: true)
+            .standardizedFileURL
+        let folderURL = fileURL.deletingLastPathComponent().standardizedFileURL
+
+        guard folderURL.path.hasPrefix(meetingRootURL.path + "/") else {
+            logger.warning(
+                "Refusing to remove meeting folder outside app support: \(folderURL.path, privacy: .private)"
+            )
+            return
+        }
+        removeItem(at: folderURL, fileManager: fileManager)
+    }
+
+    private static func removeItem(at url: URL, fileManager: FileManager) {
+        guard fileManager.fileExists(atPath: url.path) else { return }
+        do {
+            try fileManager.removeItem(at: url)
+        } catch {
+            logger.warning(
+                "Failed to remove transcription asset at \(url.path, privacy: .private): \(String(describing: error), privacy: .private)"
+            )
+        }
+    }
+}

--- a/Sources/MacParakeetCore/Utilities/TranscriptionAssetCleanup.swift
+++ b/Sources/MacParakeetCore/Utilities/TranscriptionAssetCleanup.swift
@@ -11,16 +11,31 @@ public enum TranscriptionAssetCleanup {
         for transcription: Transcription,
         fileManager: FileManager = .default
     ) {
-        guard let filePath = transcription.filePath else { return }
+        guard let filePath = transcription.filePath, !filePath.isEmpty else { return }
 
         switch transcription.sourceType {
         case .youtube:
-            removeItem(at: URL(fileURLWithPath: filePath), fileManager: fileManager)
+            removeYouTubeFile(at: URL(fileURLWithPath: filePath), fileManager: fileManager)
         case .meeting:
             removeMeetingFolder(containing: URL(fileURLWithPath: filePath), fileManager: fileManager)
         case .file:
             return
         }
+    }
+
+    private static func removeYouTubeFile(at fileURL: URL, fileManager: FileManager) {
+        let downloadsRootURL = URL(fileURLWithPath: AppPaths.youtubeDownloadsDir, isDirectory: true)
+            .standardizedFileURL
+        let targetURL = fileURL.standardizedFileURL
+
+        guard targetURL.path.hasPrefix(downloadsRootURL.path + "/") else {
+            logger.warning(
+                "Refusing to remove YouTube asset outside app support: \(targetURL.path, privacy: .private)"
+            )
+            return
+        }
+
+        removeItem(at: targetURL, fileManager: fileManager)
     }
 
     private static func removeMeetingFolder(containing fileURL: URL, fileManager: FileManager) {

--- a/Sources/MacParakeetViewModels/PromptResultsViewModel.swift
+++ b/Sources/MacParakeetViewModels/PromptResultsViewModel.swift
@@ -316,7 +316,13 @@ public final class PromptResultsViewModel {
     public func autoGeneratePromptResults(transcript: String, transcriptionId: UUID) -> [UUID] {
         guard transcript.count > Self.autoGenerationTranscriptLengthThreshold else { return [] }
 
-        let autoPrompts = (try? promptRepo?.fetchAutoRunPrompts()) ?? [Prompt.defaultPrompt]
+        let autoPrompts: [Prompt]
+        do {
+            autoPrompts = try promptRepo?.fetchAutoRunPrompts() ?? []
+        } catch {
+            logger.warning("Skipping auto-run prompts because preferences could not be loaded: \(error.localizedDescription, privacy: .public)")
+            return []
+        }
         guard !autoPrompts.isEmpty else { return [] }
 
         let userNotes = fetchUserNotes(for: transcriptionId)

--- a/Sources/MacParakeetViewModels/PromptResultsViewModel.swift
+++ b/Sources/MacParakeetViewModels/PromptResultsViewModel.swift
@@ -320,7 +320,7 @@ public final class PromptResultsViewModel {
         do {
             autoPrompts = try promptRepo?.fetchAutoRunPrompts() ?? []
         } catch {
-            logger.warning("Skipping auto-run prompts because preferences could not be loaded: \(error.localizedDescription, privacy: .public)")
+            logger.warning("Skipping auto-run prompts because preferences could not be loaded: \(error.localizedDescription, privacy: .private)")
             return []
         }
         guard !autoPrompts.isEmpty else { return [] }

--- a/Sources/MacParakeetViewModels/TranscriptionDeletionCleanup.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionDeletionCleanup.swift
@@ -1,52 +1,10 @@
 import Foundation
 import MacParakeetCore
-import os
 
 enum TranscriptionDeletionCleanup {
-    private static let logger = Logger(
-        subsystem: "com.macparakeet.viewmodels",
-        category: "TranscriptionDeletionCleanup"
-    )
-
     static func removeOwnedAssets(for transcription: Transcription) {
         Task.detached(priority: .utility) {
-            guard let filePath = transcription.filePath else { return }
-
-            switch transcription.sourceType {
-            case .youtube:
-                removeItem(at: URL(fileURLWithPath: filePath))
-            case .meeting:
-                removeMeetingFolder(containing: URL(fileURLWithPath: filePath))
-            case .file:
-                return
-            }
-        }
-    }
-
-    private static func removeMeetingFolder(containing fileURL: URL) {
-        let meetingRootURL = URL(fileURLWithPath: AppPaths.meetingRecordingsDir, isDirectory: true)
-            .standardizedFileURL
-        let folderURL = fileURL.deletingLastPathComponent().standardizedFileURL
-
-        guard folderURL.path.hasPrefix(meetingRootURL.path + "/") else {
-            logger.warning(
-                "Refusing to remove meeting folder outside app support: \(folderURL.path, privacy: .private)"
-            )
-            return
-        }
-
-        removeItem(at: folderURL)
-    }
-
-    private static func removeItem(at url: URL) {
-        do {
-            if FileManager.default.fileExists(atPath: url.path) {
-                try FileManager.default.removeItem(at: url)
-            }
-        } catch {
-            logger.warning(
-                "Failed to remove transcription asset at \(url.path, privacy: .private): \(String(describing: error), privacy: .private)"
-            )
+            TranscriptionAssetCleanup.removeOwnedAssets(for: transcription)
         }
     }
 }

--- a/Tests/CLITests/ExportCommandTests.swift
+++ b/Tests/CLITests/ExportCommandTests.swift
@@ -23,6 +23,35 @@ final class ExportCommandTests: XCTestCase {
         XCTAssertNil(ExportFormat(rawValue: "docx"))
     }
 
+    func testResolveOutputURLExpandsTilde() throws {
+        let command = try ExportCommand.parse([
+            "abcd",
+            "--output", "~/Desktop/transcript.txt",
+        ])
+        let transcription = Transcription(fileName: "source.mp3", status: .completed)
+
+        let url = command.resolveOutputURL(transcription: transcription)
+
+        XCTAssertEqual(
+            url.path,
+            FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent("Desktop/transcript.txt")
+                .path
+        )
+    }
+
+    func testDefaultOutputURLSanitizesFileName() throws {
+        let command = try ExportCommand.parse([
+            "abcd",
+            "--format", "markdown",
+        ])
+        let transcription = Transcription(fileName: "folder:Meeting/notes.mp3", status: .completed)
+
+        let url = command.resolveOutputURL(transcription: transcription)
+
+        XCTAssertEqual(url.lastPathComponent, "folder Meeting notes.md")
+    }
+
     @MainActor func testExportToTxtWritesFile() throws {
         let t = Transcription(
             fileName: "export-test.mp3",

--- a/Tests/CLITests/HistoryCommandTests.swift
+++ b/Tests/CLITests/HistoryCommandTests.swift
@@ -61,7 +61,9 @@ final class HistoryCommandTests: XCTestCase {
         let db = try DatabaseManager(path: dbURL.path)
         let repo = TranscriptionRepository(dbQueue: db.dbQueue)
 
-        let audioURL = temporaryAssetURL(pathExtension: "m4a")
+        try AppPaths.ensureDirectories()
+        let audioURL = URL(fileURLWithPath: AppPaths.youtubeDownloadsDir, isDirectory: true)
+            .appendingPathComponent("macparakeet-cli-asset-\(UUID().uuidString).m4a")
         defer { try? FileManager.default.removeItem(at: audioURL) }
         _ = FileManager.default.createFile(atPath: audioURL.path, contents: Data("audio".utf8))
 

--- a/Tests/CLITests/HistoryCommandTests.swift
+++ b/Tests/CLITests/HistoryCommandTests.swift
@@ -17,6 +17,31 @@ final class HistoryCommandTests: XCTestCase {
         XCTAssertNil(try repo.fetch(id: d.id))
     }
 
+    func testDeleteDictationCommandRemovesAudioFile() throws {
+        let dbURL = temporaryDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: dbURL) }
+        let db = try DatabaseManager(path: dbURL.path)
+        let repo = DictationRepository(dbQueue: db.dbQueue)
+
+        let audioURL = temporaryAssetURL(pathExtension: "m4a")
+        defer { try? FileManager.default.removeItem(at: audioURL) }
+        _ = FileManager.default.createFile(atPath: audioURL.path, contents: Data("audio".utf8))
+
+        let dictation = Dictation(durationMs: 2000, rawTranscript: "Delete me", audioPath: audioURL.path)
+        try repo.save(dictation)
+
+        let command = try DeleteDictationSubcommand.parse([
+            dictation.id.uuidString,
+            "--database", dbURL.path,
+        ])
+        _ = try captureStandardOutput {
+            try command.run()
+        }
+
+        XCTAssertNil(try repo.fetch(id: dictation.id))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: audioURL.path))
+    }
+
     // MARK: - Delete Transcription
 
     func testDeleteTranscriptionRemovesRecord() throws {
@@ -28,6 +53,37 @@ final class HistoryCommandTests: XCTestCase {
         XCTAssertNotNil(try repo.fetch(id: t.id))
         _ = try repo.delete(id: t.id)
         XCTAssertNil(try repo.fetch(id: t.id))
+    }
+
+    func testDeleteTranscriptionCommandRemovesOwnedYouTubeAudio() throws {
+        let dbURL = temporaryDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: dbURL) }
+        let db = try DatabaseManager(path: dbURL.path)
+        let repo = TranscriptionRepository(dbQueue: db.dbQueue)
+
+        let audioURL = temporaryAssetURL(pathExtension: "m4a")
+        defer { try? FileManager.default.removeItem(at: audioURL) }
+        _ = FileManager.default.createFile(atPath: audioURL.path, contents: Data("audio".utf8))
+
+        let transcription = Transcription(
+            fileName: "delete-me.m4a",
+            filePath: audioURL.path,
+            rawTranscript: "Goodbye",
+            status: .completed,
+            sourceType: .youtube
+        )
+        try repo.save(transcription)
+
+        let command = try DeleteTranscriptionSubcommand.parse([
+            transcription.id.uuidString,
+            "--database", dbURL.path,
+        ])
+        _ = try captureStandardOutput {
+            try command.run()
+        }
+
+        XCTAssertNil(try repo.fetch(id: transcription.id))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: audioURL.path))
     }
 
     // MARK: - Favorites
@@ -118,4 +174,15 @@ final class HistoryCommandTests: XCTestCase {
         let results = try repo.search(query: "common", limit: 3)
         XCTAssertEqual(results.count, 3)
     }
+
+    private func temporaryDatabaseURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("macparakeet-cli-\(UUID().uuidString).db")
+    }
+
+    private func temporaryAssetURL(pathExtension: String) -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("macparakeet-cli-asset-\(UUID().uuidString).\(pathExtension)")
+    }
+
 }

--- a/Tests/CLITests/HistoryCommandTests.swift
+++ b/Tests/CLITests/HistoryCommandTests.swift
@@ -23,7 +23,9 @@ final class HistoryCommandTests: XCTestCase {
         let db = try DatabaseManager(path: dbURL.path)
         let repo = DictationRepository(dbQueue: db.dbQueue)
 
-        let audioURL = temporaryAssetURL(pathExtension: "m4a")
+        try AppPaths.ensureDirectories()
+        let audioURL = URL(fileURLWithPath: AppPaths.dictationsDir, isDirectory: true)
+            .appendingPathComponent("macparakeet-cli-dictation-\(UUID().uuidString).m4a")
         defer { try? FileManager.default.removeItem(at: audioURL) }
         _ = FileManager.default.createFile(atPath: audioURL.path, contents: Data("audio".utf8))
 
@@ -40,6 +42,31 @@ final class HistoryCommandTests: XCTestCase {
 
         XCTAssertNil(try repo.fetch(id: dictation.id))
         XCTAssertFalse(FileManager.default.fileExists(atPath: audioURL.path))
+    }
+
+    func testDeleteDictationCommandLeavesExternalAudioFile() throws {
+        let dbURL = temporaryDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: dbURL) }
+        let db = try DatabaseManager(path: dbURL.path)
+        let repo = DictationRepository(dbQueue: db.dbQueue)
+
+        let audioURL = temporaryAssetURL(pathExtension: "m4a")
+        defer { try? FileManager.default.removeItem(at: audioURL) }
+        _ = FileManager.default.createFile(atPath: audioURL.path, contents: Data("audio".utf8))
+
+        let dictation = Dictation(durationMs: 2000, rawTranscript: "Delete me", audioPath: audioURL.path)
+        try repo.save(dictation)
+
+        let command = try DeleteDictationSubcommand.parse([
+            dictation.id.uuidString,
+            "--database", dbURL.path,
+        ])
+        _ = try captureStandardOutput {
+            try command.run()
+        }
+
+        XCTAssertNil(try repo.fetch(id: dictation.id))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: audioURL.path))
     }
 
     // MARK: - Delete Transcription

--- a/Tests/CLITests/LLMConfigCommandTests.swift
+++ b/Tests/CLITests/LLMConfigCommandTests.swift
@@ -71,6 +71,43 @@ final class LLMConfigCommandTests: XCTestCase {
         XCTAssertNil(config.apiKey)
     }
 
+    func testInlineOptionsReadStandardProviderEnvironment() throws {
+        let options = try LLMInlineOptions.parse([
+            "--provider", "anthropic",
+            "--model", "claude-sonnet-4-6",
+        ])
+
+        let config = try options.buildConfig(environment: ["ANTHROPIC_API_KEY": "sk-env"])
+        XCTAssertEqual(config.id, .anthropic)
+        XCTAssertEqual(config.apiKey, "sk-env")
+    }
+
+    func testInlineOptionsReadExplicitAPIKeyEnvironment() throws {
+        let options = try LLMInlineOptions.parse([
+            "--provider", "openai-compatible",
+            "--api-key-env", "VENDOR_API_KEY",
+            "--base-url", "https://api.example.com/v1",
+            "--model", "vendor/model",
+        ])
+
+        let config = try options.buildConfig(environment: ["VENDOR_API_KEY": "sk-vendor"])
+        XCTAssertEqual(config.id, .openaiCompatible)
+        XCTAssertEqual(config.apiKey, "sk-vendor")
+    }
+
+    func testInlineOptionsRejectMissingExplicitAPIKeyEnvironment() throws {
+        let options = try LLMInlineOptions.parse([
+            "--provider", "openai",
+            "--api-key-env", "MISSING_API_KEY",
+            "--model", "gpt-4.1",
+        ])
+
+        XCTAssertThrowsError(try options.buildConfig(environment: [:])) { error in
+            XCTAssertTrue(error is ValidationError)
+            XCTAssertTrue(String(describing: error).contains("MISSING_API_KEY"))
+        }
+    }
+
     func testInlineOptionsBuildOpenAICompatibleLocalConfig() throws {
         let options = try LLMInlineOptions.parse([
             "--provider", "openai-compatible",

--- a/Tests/CLITests/LLMConfigCommandTests.swift
+++ b/Tests/CLITests/LLMConfigCommandTests.swift
@@ -108,6 +108,19 @@ final class LLMConfigCommandTests: XCTestCase {
         }
     }
 
+    func testInlineOptionsRejectWhitespaceOnlyAPIKey() throws {
+        let options = try LLMInlineOptions.parse([
+            "--provider", "openai",
+            "--api-key", "   \n  ",
+            "--model", "gpt-4.1",
+        ])
+
+        XCTAssertThrowsError(try options.buildConfig(environment: ["OPENAI_API_KEY": "sk-env"])) { error in
+            XCTAssertTrue(error is ValidationError)
+            XCTAssertTrue(String(describing: error).contains("--api-key must not be empty"))
+        }
+    }
+
     func testInlineOptionsBuildOpenAICompatibleLocalConfig() throws {
         let options = try LLMInlineOptions.parse([
             "--provider", "openai-compatible",

--- a/Tests/CLITests/LLMJSONOutputTests.swift
+++ b/Tests/CLITests/LLMJSONOutputTests.swift
@@ -164,6 +164,29 @@ final class LLMJSONOutputTests: XCTestCase {
         XCTAssertEqual(CLIErrorType.key(for: UnknownError()), "runtime")
     }
 
+    func testSyncJSONWrapperEmitsEnvelopeForPostParseFailure() throws {
+        var thrownError: Error?
+        let output = try captureStandardOutput {
+            do {
+                try emitJSONOrRethrow(json: true) {
+                    throw CLILookupError.notFound("No transcription matching 'missing'")
+                }
+            } catch {
+                thrownError = error
+            }
+        }
+
+        let exit = try XCTUnwrap(thrownError as? ExitCode)
+        XCTAssertEqual(exit, .failure)
+
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any]
+        )
+        XCTAssertEqual(object["ok"] as? Bool, false)
+        XCTAssertEqual(object["errorType"] as? String, "lookup")
+        XCTAssertTrue((object["error"] as? String)?.contains("No transcription") == true)
+    }
+
     // MARK: - Helpers
 
     private func assertParseRejects<C: ParsableCommand>(

--- a/Tests/CLITests/StandardOutputCapture.swift
+++ b/Tests/CLITests/StandardOutputCapture.swift
@@ -1,6 +1,8 @@
 import Darwin
 import Foundation
 
+/// Captures the small stdout payloads emitted by focused CLI unit tests.
+/// Do not use this for commands that can stream or print large output.
 func captureStandardOutput(_ body: () throws -> Void) throws -> String {
     let pipe = Pipe()
     let originalStdout = dup(STDOUT_FILENO)
@@ -22,7 +24,11 @@ func captureStandardOutput(_ body: () throws -> Void) throws -> String {
     }
 
     fflush(stdout)
-    dup2(originalStdout, STDOUT_FILENO)
+    guard dup2(originalStdout, STDOUT_FILENO) >= 0 else {
+        let restoreErrno = errno
+        close(originalStdout)
+        throw NSError(domain: NSPOSIXErrorDomain, code: Int(restoreErrno))
+    }
     close(originalStdout)
     pipe.fileHandleForWriting.closeFile()
 

--- a/Tests/CLITests/StandardOutputCapture.swift
+++ b/Tests/CLITests/StandardOutputCapture.swift
@@ -1,0 +1,34 @@
+import Darwin
+import Foundation
+
+func captureStandardOutput(_ body: () throws -> Void) throws -> String {
+    let pipe = Pipe()
+    let originalStdout = dup(STDOUT_FILENO)
+    guard originalStdout >= 0 else {
+        throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+    }
+
+    fflush(stdout)
+    guard dup2(pipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO) >= 0 else {
+        close(originalStdout)
+        throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+    }
+
+    var bodyError: Error?
+    do {
+        try body()
+    } catch {
+        bodyError = error
+    }
+
+    fflush(stdout)
+    dup2(originalStdout, STDOUT_FILENO)
+    close(originalStdout)
+    pipe.fileHandleForWriting.closeFile()
+
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    if let bodyError {
+        throw bodyError
+    }
+    return String(decoding: data, as: UTF8.self)
+}

--- a/Tests/CLITests/TranscribeCommandTests.swift
+++ b/Tests/CLITests/TranscribeCommandTests.swift
@@ -39,4 +39,12 @@ final class TranscribeCommandTests: XCTestCase {
         XCTAssertEqual(command.engine, .parakeet)
         XCTAssertNil(command.language)
     }
+
+    func testLocalFileURLExpandsTilde() {
+        let url = TranscribeCommand.localFileURL(for: "~/sample.wav")
+        XCTAssertEqual(
+            url.path,
+            FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("sample.wav").path
+        )
+    }
 }

--- a/Tests/MacParakeetTests/ViewModels/PromptResultsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/PromptResultsViewModelTests.swift
@@ -255,6 +255,24 @@ final class PromptResultsViewModelTests: XCTestCase {
         XCTAssertEqual(llm.summarizeCallCount, 0)
     }
 
+    func testAutoGeneratePromptResultsSkipsWhenAutoRunPromptFetchFails() {
+        promptRepo.fetchAutoRunPromptsError = PromptAutoRunFetchError()
+        viewModel.configure(
+            llmService: llm,
+            promptRepo: promptRepo,
+            promptResultRepo: promptResultRepo
+        )
+
+        let queuedIDs = viewModel.autoGeneratePromptResults(
+            transcript: String(repeating: "Long transcript ", count: 50),
+            transcriptionId: UUID()
+        )
+
+        XCTAssertTrue(queuedIDs.isEmpty)
+        XCTAssertTrue(viewModel.pendingGenerations.isEmpty)
+        XCTAssertEqual(llm.summarizeCallCount, 0)
+    }
+
     // MARK: - ADR-020 §4–§6 — userNotes plumbing
 
     func testGeneratePromptResultSubstitutesUserNotesIntoSystemPrompt() async throws {
@@ -521,3 +539,5 @@ final class PromptResultsViewModelTests: XCTestCase {
         XCTAssertEqual(resultUnder, underCap)
     }
 }
+
+private struct PromptAutoRunFetchError: Error {}

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionDeletionCleanupTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionDeletionCleanupTests.swift
@@ -52,6 +52,56 @@ final class TranscriptionDeletionCleanupTests: XCTestCase {
         try? FileManager.default.removeItem(at: folderURL)
     }
 
+    func testYouTubeDeletionRemovesDownloadedFileInsideAppSupport() throws {
+        let fileURL = URL(fileURLWithPath: AppPaths.youtubeDownloadsDir, isDirectory: true)
+            .appendingPathComponent("\(UUID().uuidString).m4a")
+        FileManager.default.createFile(atPath: fileURL.path, contents: Data("audio".utf8))
+
+        let transcription = Transcription(
+            fileName: "YouTube.m4a",
+            filePath: fileURL.path,
+            status: .completed,
+            sourceType: .youtube
+        )
+
+        TranscriptionAssetCleanup.removeOwnedAssets(for: transcription)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
+    }
+
+    func testYouTubeDeletionOutsideAppSupportIsIgnored() throws {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString).m4a")
+        FileManager.default.createFile(atPath: fileURL.path, contents: Data("audio".utf8))
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let transcription = Transcription(
+            fileName: "YouTube.m4a",
+            filePath: fileURL.path,
+            status: .completed,
+            sourceType: .youtube
+        )
+
+        TranscriptionAssetCleanup.removeOwnedAssets(for: transcription)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fileURL.path))
+    }
+
+    func testEmptyFilePathIsIgnored() throws {
+        let currentDirectory = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
+
+        let transcription = Transcription(
+            fileName: "Empty.m4a",
+            filePath: "",
+            status: .completed,
+            sourceType: .youtube
+        )
+
+        TranscriptionAssetCleanup.removeOwnedAssets(for: transcription)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: currentDirectory.path))
+    }
+
     private func waitForFileAbsence(at url: URL, timeout: Duration = .seconds(1)) async throws {
         let deadline = ContinuousClock.now + timeout
         while FileManager.default.fileExists(atPath: url.path) {

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -431,7 +431,8 @@ final class TranscriptionViewModelTests: XCTestCase {
     }
 
     func testDeleteYouTubeTranscriptionRemovesStoredAudioFile() async throws {
-        let audioURL = URL(fileURLWithPath: NSTemporaryDirectory())
+        try AppPaths.ensureDirectories()
+        let audioURL = URL(fileURLWithPath: AppPaths.youtubeDownloadsDir, isDirectory: true)
             .appendingPathComponent("yt-audio-\(UUID().uuidString).m4a")
         let created = FileManager.default.createFile(atPath: audioURL.path, contents: Data("audio".utf8))
         XCTAssertTrue(created)
@@ -455,7 +456,8 @@ final class TranscriptionViewModelTests: XCTestCase {
     }
 
     func testDeleteYouTubeTranscriptionKeepsStoredAudioWhenRepoDeleteFails() throws {
-        let audioURL = URL(fileURLWithPath: NSTemporaryDirectory())
+        try AppPaths.ensureDirectories()
+        let audioURL = URL(fileURLWithPath: AppPaths.youtubeDownloadsDir, isDirectory: true)
             .appendingPathComponent("yt-audio-\(UUID().uuidString).m4a")
         let created = FileManager.default.createFile(atPath: audioURL.path, contents: Data("audio".utf8))
         XCTAssertTrue(created)

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -640,7 +640,7 @@ final class MockPromptRepository: PromptRepositoryProtocol, @unchecked Sendable 
         if let fetchAutoRunPromptsError {
             throw fetchAutoRunPromptsError
         }
-        return prompts.filter(\.isAutoRun)
+        return try fetchAll().filter(\.isAutoRun)
     }
 
     func delete(id: UUID) throws -> Bool {

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -607,6 +607,7 @@ final class MockLLMService: LLMServiceProtocol, @unchecked Sendable {
 
 final class MockPromptRepository: PromptRepositoryProtocol, @unchecked Sendable {
     var prompts: [Prompt] = []
+    var fetchAutoRunPromptsError: Error?
 
     func save(_ prompt: Prompt) throws {
         if let index = prompts.firstIndex(where: { $0.id == prompt.id }) {
@@ -636,7 +637,10 @@ final class MockPromptRepository: PromptRepositoryProtocol, @unchecked Sendable 
     }
 
     func fetchAutoRunPrompts() throws -> [Prompt] {
-        prompts.filter(\.isAutoRun)
+        if let fetchAutoRunPromptsError {
+            throw fetchAutoRunPromptsError
+        }
+        return prompts.filter(\.isAutoRun)
     }
 
     func delete(id: UUID) throws -> Bool {

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -112,6 +112,7 @@ macparakeet-cli prompts list --json
 macparakeet-cli prompts run "Action items" \
   --transcription <id-or-prefix> \
   --provider anthropic \
+  --api-key-env ANTHROPIC_API_KEY \
   --model claude-sonnet-4-6 \
   --json
 ```

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -111,7 +111,7 @@ macparakeet-cli history search "what did I say about" --json
 macparakeet-cli prompts list --json
 macparakeet-cli prompts run "Action items" \
   --transcription <id-or-prefix> \
-  --provider anthropic --api-key "$ANTHROPIC_API_KEY" \
+  --provider anthropic \
   --model claude-sonnet-4-6 \
   --json
 ```
@@ -229,7 +229,7 @@ Only use prompt/LLM commands when the user asks for generated output:
 macparakeet-cli prompts list --json
 macparakeet-cli prompts run "<prompt-name>" \
   --transcription "<id-or-prefix-or-title>" \
-  --provider "<provider>" --api-key "$PROVIDER_API_KEY" --model "<model>" \
+  --provider "<provider>" --api-key-env "PROVIDER_API_KEY" --model "<model>" \
   --json
 ```
 
@@ -253,11 +253,10 @@ macparakeet-cli prompts run "<prompt-name>" \
   never goes to stderr regardless of code; parse-time failures still use
   ArgumentParser's plain-text stderr path. Full table in
   `Sources/CLI/CHANGELOG.md` "Exit codes" section.
-- **API keys:** pass via `"$VAR"` shell expansion (e.g.
-  `--api-key "$ANTHROPIC_API_KEY"`), not literally. CLI does not read
-  `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` directly -- but a literal
-  `--api-key sk-...` lands in shell history and `ps`. Env-var expansion
-  avoids both.
+- **API keys:** prefer provider env vars or `--api-key-env NAME`. Hosted
+  providers read `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, and
+  `OPENROUTER_API_KEY` directly. Avoid `--api-key sk-...`; command-line
+  arguments can appear in shell history and process listings.
 - **JSON flag shape:** read-only query commands take `--json` (a binary flag);
   `transcribe` and `export` take `--format json` because they emit one of
   several formats (txt / srt / vtt / json / docx / pdf). Both produce stable

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -50,7 +50,7 @@ commands:
   run_prompt: |
     macparakeet-cli prompts run "{prompt_id_or_name}" \
       --transcription {transcription_id} \
-      --provider {provider} --api-key "{api_key}" --model "{model}"
+      --provider {provider} --api-key-env "{api_key_env}" --model "{model}"
   health: macparakeet-cli health --json
 ```
 

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -46,7 +46,7 @@ ffmpeg + yt-dlp as runtime deps. First `transcribe` call downloads
 | Search transcriptions | `macparakeet-cli history search-transcriptions "<query>" --json` |
 | Search dictations | `macparakeet-cli history search "<query>" --json` |
 | List prompts | `macparakeet-cli prompts list --json` |
-| Run a prompt on a transcription | `macparakeet-cli prompts run <prompt-name> --transcription <id-or-name> --provider <p> --api-key "$KEY" --model <m>` |
+| Run a prompt on a transcription | `macparakeet-cli prompts run <prompt-name> --transcription <id-or-name> --provider <p> --api-key-env KEY_ENV --model <m>` |
 
 ## Conventions
 


### PR DESCRIPTION
## Summary

This PR tightens the public `macparakeet-cli` contract and shares the asset cleanup rules that belong in Core.

- Applies the documented post-parse `--json` failure envelope across read-only CLI surfaces that already expose `--json`.
- Ensures `prompts run --json` emits exactly one JSON object by delaying the success envelope until optional result persistence succeeds.
- Moves transcription asset cleanup into `MacParakeetCore` and uses it from both the CLI and GUI.
- Refuses blank or external transcription media paths before cleanup, including YouTube cache entries outside `AppPaths.youtubeDownloadsDir`.
- Removes app-owned CLI dictation audio only after successful row deletion; paths outside `AppPaths.dictationsDir` are refused.
- Expands `~` for local transcribe/export paths, creates export parent directories, and sanitizes default export filenames.
- Makes GUI prompt auto-run fail closed if prompt preferences cannot be fetched.
- Adds `--api-key-env` and standard hosted-provider environment variable lookup for inline LLM CLI options.
- Updates integration docs and the CLI changelog.

## Cleanup Flow

```text
Transcription deletion

  CLI ----+
          +--> TranscriptionAssetCleanup
  GUI ----+        |
                  +--> YouTube file under AppPaths.youtubeDownloadsDir
                  +--> meeting folder under AppPaths.meetingRecordingsDir
                  +--> blank or external path: refuse/no-op

CLI dictation deletion

  delete DB row -> audioPath under AppPaths.dictationsDir: remove file
                -> external audioPath: refuse/no-op
```

## Reviewer Notes

- JSON success schemas are unchanged. The behavior change is for post-parse failures on commands that already accept `--json`.
- Parse-time ArgumentParser failures still use the existing plain-text stderr path and exit code `2`.
- CLI dictation cleanup intentionally runs after successful row deletion so a database delete failure cannot remove audio first.
- Cleanup failures do not roll back successful database deletion.
- `FlowWordsCommand.swift` and `FlowSnippetsCommand.swift` were CRLF-only upstream. Because this PR touches their `--json` wrappers, they were normalized to LF so whitespace checks stay clean.

## Testing

- `swift test --filter 'CLITests|PromptResultsViewModelTests|TranscriptionDeletionCleanupTests'`
- `swift test --filter 'HistoryCommandTests|LLMConfigCommandTests|LLMJSONOutputTests|PromptResultsViewModelTests|TranscriptionDeletionCleanupTests|TranscriptionViewModelTests/testDeleteYouTubeTranscription'`
- `swift test` passed: 1,861 XCTest cases, 0 failures; 13 Swift Testing checks, 0 failures.
- `git diff --check`