### PR TITLE
Harden CLI telemetry for agent-CLI audience

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -130,8 +130,7 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 - `transcribe` now initializes the shared telemetry client and emits a
   privacy-safe `cli_operation` product-health event after execution. This does
   not change stdout, stderr, JSON schemas, or exit codes; it follows the GUI
-  telemetry preference and can be disabled per process with
-  `MACPARAKEET_TELEMETRY=0`.
+  telemetry preference and the CLI opt-out controls documented above.
 
 ### Fixed
 

--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -84,6 +84,17 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 - LLM-backed commands now accept `--api-key-env NAME`; hosted providers also
   read `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, and
   `OPENROUTER_API_KEY` directly.
+- `config` command namespace for users who only install the CLI (no GUI):
+  `macparakeet-cli config get telemetry`, `config set telemetry on|off`, and
+  `config list`. Values persist in the same UserDefaults suite the GUI reads
+  (`com.macparakeet.MacParakeet`), so a later GUI install picks them up.
+- `transcribe` now honors `DO_NOT_TRACK=1` (industry-standard, also honored
+  by Homebrew, GitLab, VS Code) and auto-disables telemetry in CI environments
+  (`CI`, `GITHUB_ACTIONS`, `GITLAB_CI`, `BUILDKITE`, `CIRCLECI`, `TRAVIS`,
+  `JENKINS_URL`, `TF_BUILD`, `TEAMCITY_VERSION` set to a truthy value). The
+  CI auto-disable can be overridden with `MACPARAKEET_TELEMETRY=1` for
+  developers smoke-testing telemetry from a CI shell. `MACPARAKEET_TELEMETRY=0`
+  remains the explicit per-process kill switch.
 
 ### Fixed
 

--- a/Sources/CLI/Commands/CLIHelpers.swift
+++ b/Sources/CLI/Commands/CLIHelpers.swift
@@ -3,6 +3,7 @@ import Foundation
 import MacParakeetCore
 
 let macParakeetAppDefaultsSuiteName = "com.macparakeet.MacParakeet"
+let cliValidationMisuseExitCode = ExitCode(2)
 
 func macParakeetAppDefaults() -> UserDefaults {
     UserDefaults(suiteName: macParakeetAppDefaultsSuiteName) ?? .standard
@@ -311,7 +312,7 @@ private func rethrowWithOptionalJSONEnvelope(_ error: Error, json: Bool) throws 
     let envelope = CLIErrorEnvelope(error: error)
     try? printJSON(envelope)
     if error is ValidationError || error is CLIInputError {
-        throw ExitCode.validationFailure
+        throw cliValidationMisuseExitCode
     }
     throw ExitCode.failure
 }

--- a/Sources/CLI/Commands/CLITelemetry.swift
+++ b/Sources/CLI/Commands/CLITelemetry.swift
@@ -57,22 +57,25 @@ enum CLITelemetry {
         return .none
     }
 
+    /// Variables that conventionally mark a CI/automation context.
+    /// Hoisted out of `isCIEnvironment` so it isn't reallocated per call.
+    private static let ciEnvVars: [String] = [
+        "CI",
+        "GITHUB_ACTIONS",
+        "GITLAB_CI",
+        "BUILDKITE",
+        "CIRCLECI",
+        "TRAVIS",
+        "JENKINS_URL",
+        "TF_BUILD",
+        "TEAMCITY_VERSION"
+    ]
+
     /// Detects common CI/automation contexts. Conservative: only treats a variable as
     /// CI-positive when it's set to a truthy value, so `CI=false` (yes, some setups
     /// pass that) does not trigger auto-disable.
     static func isCIEnvironment(env: [String: String]) -> Bool {
-        let ciVars = [
-            "CI",
-            "GITHUB_ACTIONS",
-            "GITLAB_CI",
-            "BUILDKITE",
-            "CIRCLECI",
-            "TRAVIS",
-            "JENKINS_URL",
-            "TF_BUILD",
-            "TEAMCITY_VERSION"
-        ]
-        for name in ciVars {
+        for name in ciEnvVars {
             guard let raw = env[name]?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
                 continue
             }

--- a/Sources/CLI/Commands/CLITelemetry.swift
+++ b/Sources/CLI/Commands/CLITelemetry.swift
@@ -2,20 +2,87 @@ import Foundation
 import MacParakeetCore
 
 enum CLITelemetry {
-    static func configureIfNeeded() {
-        let environment = ProcessInfo.processInfo.environment
-        if let override = environment["MACPARAKEET_TELEMETRY"]?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
-           ["0", "false", "no", "off"].contains(override) {
+    /// Outcome of evaluating env-var overrides for CLI telemetry. Resolved before
+    /// the user's persisted UserDefaults preference is consulted.
+    enum EnvOverride: Equatable {
+        /// `MACPARAKEET_TELEMETRY=1/true/yes/on` — explicit force-on, defeats CI auto-disable.
+        case forceOn
+        /// `MACPARAKEET_TELEMETRY=0/false/no/off` or `DO_NOT_TRACK=1` — explicit force-off.
+        case forceOff
+        /// Headless CI context (`CI=true`, `GITHUB_ACTIONS=true`, etc.) with no explicit override.
+        case ciAutoDisable
+        /// No override; honor the persisted UserDefaults `telemetryEnabled` preference.
+        case none
+    }
+
+    static func configureIfNeeded(env: [String: String] = ProcessInfo.processInfo.environment) {
+        switch decideOverride(env: env) {
+        case .forceOff, .ciAutoDisable:
             Telemetry.configure(NoOpTelemetryService())
-            return
+        case .forceOn:
+            Telemetry.configure(TelemetryService(
+                requestTimeoutInterval: 1.0,
+                isEnabled: { true }
+            ))
+        case .none:
+            Telemetry.configure(TelemetryService(
+                requestTimeoutInterval: 1.0,
+                isEnabled: {
+                    AppPreferences.isTelemetryEnabled(defaults: macParakeetAppDefaults())
+                }
+            ))
+        }
+    }
+
+    /// Pure decision function — testable without ProcessInfo or UserDefaults state.
+    /// `MACPARAKEET_TELEMETRY` wins outright. Then `DO_NOT_TRACK=1` (industry-standard,
+    /// honored by Homebrew, GitLab, VS Code, etc.). Then CI auto-disable so a 1000-job
+    /// agent run in GitHub Actions doesn't silently flood the endpoint with `cli_operation`
+    /// events.
+    static func decideOverride(env: [String: String]) -> EnvOverride {
+        if let raw = env["MACPARAKEET_TELEMETRY"]?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+           !raw.isEmpty {
+            if ["0", "false", "no", "off"].contains(raw) { return .forceOff }
+            if ["1", "true", "yes", "on"].contains(raw) { return .forceOn }
         }
 
-        Telemetry.configure(TelemetryService(
-            requestTimeoutInterval: 1.0,
-            isEnabled: {
-                AppPreferences.isTelemetryEnabled(defaults: macParakeetAppDefaults())
+        if let dnt = env["DO_NOT_TRACK"]?.trimmingCharacters(in: .whitespacesAndNewlines), dnt == "1" {
+            return .forceOff
+        }
+
+        if isCIEnvironment(env: env) {
+            return .ciAutoDisable
+        }
+
+        return .none
+    }
+
+    /// Detects common CI/automation contexts. Conservative: only treats a variable as
+    /// CI-positive when it's set to a truthy value, so `CI=false` (yes, some setups
+    /// pass that) does not trigger auto-disable.
+    static func isCIEnvironment(env: [String: String]) -> Bool {
+        let ciVars = [
+            "CI",
+            "GITHUB_ACTIONS",
+            "GITLAB_CI",
+            "BUILDKITE",
+            "CIRCLECI",
+            "TRAVIS",
+            "JENKINS_URL",
+            "TF_BUILD",
+            "TEAMCITY_VERSION"
+        ]
+        for name in ciVars {
+            guard let raw = env[name]?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
+                continue
             }
-        ))
+            let lower = raw.lowercased()
+            if lower == "false" || lower == "0" || lower == "no" || lower == "off" {
+                continue
+            }
+            return true
+        }
+        return false
     }
 
     static func sendOperationAndFlush(

--- a/Sources/CLI/Commands/ConfigCommand.swift
+++ b/Sources/CLI/Commands/ConfigCommand.swift
@@ -9,7 +9,7 @@ import MacParakeetCore
 /// (no GUI) persist preferences like opting out of telemetry — and a later GUI
 /// install picks the same values up automatically. Without this, CLI-only
 /// users would have no way to opt out of telemetry except per-process env vars.
-struct ConfigCommand: AsyncParsableCommand {
+struct ConfigCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "config",
         abstract: "Read or write CLI/app configuration values.",
@@ -20,8 +20,10 @@ struct ConfigCommand: AsyncParsableCommand {
 
         Supported keys:
           telemetry   on|off   Anonymous, non-identifying usage analytics
-                               (default: on). See docs/telemetry.md for the
-                               full event catalog.
+                               (default: on)
+
+        Full event catalog:
+          https://github.com/moona3k/macparakeet/blob/main/docs/telemetry.md
 
         Per-process overrides (env vars, do not require `config set`):
           MACPARAKEET_TELEMETRY=0   Force-off for one invocation
@@ -37,7 +39,7 @@ struct ConfigCommand: AsyncParsableCommand {
 
     // MARK: - Subcommands
 
-    struct GetCommand: AsyncParsableCommand {
+    struct GetCommand: ParsableCommand {
         static let configuration = CommandConfiguration(
             commandName: "get",
             abstract: "Print the current value of a configuration key."
@@ -49,15 +51,15 @@ struct ConfigCommand: AsyncParsableCommand {
         @Flag(name: .long, help: "Emit JSON instead of plain text.")
         var json: Bool = false
 
-        func run() async throws {
-            try await emitJSONOrRethrow(json: json) {
+        func run() throws {
+            try emitJSONOrRethrow(json: json) {
                 let value = try ConfigCommand.read(key: key)
                 try printResult(key: key, value: value, json: json)
             }
         }
     }
 
-    struct SetCommand: AsyncParsableCommand {
+    struct SetCommand: ParsableCommand {
         static let configuration = CommandConfiguration(
             commandName: "set",
             abstract: "Write a configuration value."
@@ -72,15 +74,15 @@ struct ConfigCommand: AsyncParsableCommand {
         @Flag(name: .long, help: "Emit JSON instead of plain text.")
         var json: Bool = false
 
-        func run() async throws {
-            try await emitJSONOrRethrow(json: json) {
+        func run() throws {
+            try emitJSONOrRethrow(json: json) {
                 let written = try ConfigCommand.write(key: key, value: value)
                 try printResult(key: key, value: written, json: json)
             }
         }
     }
 
-    struct ListCommand: AsyncParsableCommand {
+    struct ListCommand: ParsableCommand {
         static let configuration = CommandConfiguration(
             commandName: "list",
             abstract: "Print all configurable keys and their current values."
@@ -89,8 +91,8 @@ struct ConfigCommand: AsyncParsableCommand {
         @Flag(name: .long, help: "Emit JSON instead of plain text.")
         var json: Bool = false
 
-        func run() async throws {
-            try await emitJSONOrRethrow(json: json) {
+        func run() throws {
+            try emitJSONOrRethrow(json: json) {
                 var entries: [(String, String)] = []
                 for key in ConfigCommand.supportedKeys {
                     entries.append((key, try ConfigCommand.read(key: key)))
@@ -141,7 +143,7 @@ struct ConfigCommand: AsyncParsableCommand {
     }
 
     static func parseBool(_ value: String, key: String) throws -> Bool {
-        let v = value.trimmingCharacters(in: .whitespaces).lowercased()
+        let v = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         switch v {
         case "on", "true", "yes", "1", "enable", "enabled":
             return true

--- a/Sources/CLI/Commands/ConfigCommand.swift
+++ b/Sources/CLI/Commands/ConfigCommand.swift
@@ -1,0 +1,171 @@
+import ArgumentParser
+import Foundation
+import MacParakeetCore
+
+/// `macparakeet-cli config` — read or write app preferences from the CLI.
+///
+/// Stores values in the same UserDefaults suite the GUI reads
+/// (`com.macparakeet.MacParakeet`). This lets users who only install the CLI
+/// (no GUI) persist preferences like opting out of telemetry — and a later GUI
+/// install picks the same values up automatically. Without this, CLI-only
+/// users would have no way to opt out of telemetry except per-process env vars.
+struct ConfigCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "config",
+        abstract: "Read or write CLI/app configuration values.",
+        discussion: """
+        Configuration is stored in the shared MacParakeet UserDefaults suite \
+        (com.macparakeet.MacParakeet). The GUI reads the same suite, so values \
+        set here apply to both surfaces.
+
+        Supported keys:
+          telemetry   on|off   Anonymous, non-identifying usage analytics
+                               (default: on). See docs/telemetry.md for the
+                               full event catalog.
+
+        Per-process overrides (env vars, do not require `config set`):
+          MACPARAKEET_TELEMETRY=0   Force-off for one invocation
+          MACPARAKEET_TELEMETRY=1   Force-on for one invocation
+          DO_NOT_TRACK=1            Force-off (industry-standard signal)
+          CI=true                   Auto-disabled in CI environments
+        """,
+        subcommands: [GetCommand.self, SetCommand.self, ListCommand.self]
+    )
+
+    /// Keys recognized by `get`/`set`/`list`.
+    static let supportedKeys: [String] = ["telemetry"]
+
+    // MARK: - Subcommands
+
+    struct GetCommand: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "get",
+            abstract: "Print the current value of a configuration key."
+        )
+
+        @Argument(help: "Configuration key. Supported: \(ConfigCommand.supportedKeys.joined(separator: ", ")).")
+        var key: String
+
+        @Flag(name: .long, help: "Emit JSON instead of plain text.")
+        var json: Bool = false
+
+        func run() async throws {
+            let value = try ConfigCommand.read(key: key)
+            try printResult(key: key, value: value, json: json)
+        }
+    }
+
+    struct SetCommand: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "set",
+            abstract: "Write a configuration value."
+        )
+
+        @Argument(help: "Configuration key. Supported: \(ConfigCommand.supportedKeys.joined(separator: ", ")).")
+        var key: String
+
+        @Argument(help: "Value (e.g. on/off, true/false, 1/0).")
+        var value: String
+
+        @Flag(name: .long, help: "Emit JSON instead of plain text.")
+        var json: Bool = false
+
+        func run() async throws {
+            let written = try ConfigCommand.write(key: key, value: value)
+            try printResult(key: key, value: written, json: json)
+        }
+    }
+
+    struct ListCommand: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "list",
+            abstract: "Print all configurable keys and their current values."
+        )
+
+        @Flag(name: .long, help: "Emit JSON instead of plain text.")
+        var json: Bool = false
+
+        func run() async throws {
+            var entries: [(String, String)] = []
+            for key in ConfigCommand.supportedKeys {
+                let value = (try? ConfigCommand.read(key: key)) ?? "(error)"
+                entries.append((key, value))
+            }
+            if json {
+                let dict = Dictionary(uniqueKeysWithValues: entries)
+                try printJSON(dict)
+            } else {
+                for (key, value) in entries {
+                    print("\(key) = \(value)")
+                }
+            }
+        }
+    }
+
+    // MARK: - Read / Write
+
+    static func read(key: String, defaults: UserDefaults? = nil) throws -> String {
+        let store = defaults ?? macParakeetAppDefaults()
+        switch key {
+        case "telemetry":
+            let on = AppPreferences.isTelemetryEnabled(defaults: store)
+            return on ? "on" : "off"
+        default:
+            throw ConfigError.unknownKey(key)
+        }
+    }
+
+    /// Writes the value and returns the canonical normalized form actually persisted
+    /// (e.g. "on"/"off" for booleans).
+    @discardableResult
+    static func write(key: String, value: String, defaults: UserDefaults? = nil) throws -> String {
+        let store = defaults ?? macParakeetAppDefaults()
+        switch key {
+        case "telemetry":
+            let parsed = try parseBool(value, key: key)
+            store.set(parsed, forKey: AppPreferences.telemetryEnabledKey)
+            return parsed ? "on" : "off"
+        default:
+            throw ConfigError.unknownKey(key)
+        }
+    }
+
+    static func parseBool(_ value: String, key: String) throws -> Bool {
+        let v = value.trimmingCharacters(in: .whitespaces).lowercased()
+        switch v {
+        case "on", "true", "yes", "1", "enable", "enabled":
+            return true
+        case "off", "false", "no", "0", "disable", "disabled":
+            return false
+        default:
+            throw ConfigError.invalidValue(key: key, value: value)
+        }
+    }
+}
+
+private struct ConfigKeyValue: Encodable {
+    let key: String
+    let value: String
+}
+
+private func printResult(key: String, value: String, json: Bool) throws {
+    if json {
+        try printJSON(ConfigKeyValue(key: key, value: value))
+    } else {
+        print(value)
+    }
+}
+
+enum ConfigError: Error, LocalizedError, Equatable {
+    case unknownKey(String)
+    case invalidValue(key: String, value: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unknownKey(let key):
+            return "Unknown config key: \(key). Supported: \(ConfigCommand.supportedKeys.joined(separator: ", "))."
+        case .invalidValue(let key, let value):
+            return "Invalid value for \(key): '\(value)'. Use on/off (or true/false, yes/no, 1/0)."
+        }
+    }
+}

--- a/Sources/CLI/Commands/ConfigCommand.swift
+++ b/Sources/CLI/Commands/ConfigCommand.swift
@@ -50,8 +50,10 @@ struct ConfigCommand: AsyncParsableCommand {
         var json: Bool = false
 
         func run() async throws {
-            let value = try ConfigCommand.read(key: key)
-            try printResult(key: key, value: value, json: json)
+            try await emitJSONOrRethrow(json: json) {
+                let value = try ConfigCommand.read(key: key)
+                try printResult(key: key, value: value, json: json)
+            }
         }
     }
 
@@ -71,8 +73,10 @@ struct ConfigCommand: AsyncParsableCommand {
         var json: Bool = false
 
         func run() async throws {
-            let written = try ConfigCommand.write(key: key, value: value)
-            try printResult(key: key, value: written, json: json)
+            try await emitJSONOrRethrow(json: json) {
+                let written = try ConfigCommand.write(key: key, value: value)
+                try printResult(key: key, value: written, json: json)
+            }
         }
     }
 
@@ -86,23 +90,29 @@ struct ConfigCommand: AsyncParsableCommand {
         var json: Bool = false
 
         func run() async throws {
-            var entries: [(String, String)] = []
-            for key in ConfigCommand.supportedKeys {
-                let value = (try? ConfigCommand.read(key: key)) ?? "(error)"
-                entries.append((key, value))
-            }
-            if json {
-                let dict = Dictionary(uniqueKeysWithValues: entries)
-                try printJSON(dict)
-            } else {
-                for (key, value) in entries {
-                    print("\(key) = \(value)")
+            try await emitJSONOrRethrow(json: json) {
+                var entries: [(String, String)] = []
+                for key in ConfigCommand.supportedKeys {
+                    entries.append((key, try ConfigCommand.read(key: key)))
+                }
+                if json {
+                    let dict = Dictionary(uniqueKeysWithValues: entries)
+                    try printJSON(dict)
+                } else {
+                    for (key, value) in entries {
+                        print("\(key) = \(value)")
+                    }
                 }
             }
         }
     }
 
     // MARK: - Read / Write
+    //
+    // Both throw `ValidationError` for unsupported keys / invalid values so the
+    // CLI's `--json` failure envelope contract picks them up with
+    // `errorType: "validation"` and exit code 2 (misuse). See
+    // `Sources/CLI/CHANGELOG.md` "Exit codes" / "--json failure envelope".
 
     static func read(key: String, defaults: UserDefaults? = nil) throws -> String {
         let store = defaults ?? macParakeetAppDefaults()
@@ -111,7 +121,7 @@ struct ConfigCommand: AsyncParsableCommand {
             let on = AppPreferences.isTelemetryEnabled(defaults: store)
             return on ? "on" : "off"
         default:
-            throw ConfigError.unknownKey(key)
+            throw unknownKeyError(key)
         }
     }
 
@@ -126,7 +136,7 @@ struct ConfigCommand: AsyncParsableCommand {
             store.set(parsed, forKey: AppPreferences.telemetryEnabledKey)
             return parsed ? "on" : "off"
         default:
-            throw ConfigError.unknownKey(key)
+            throw unknownKeyError(key)
         }
     }
 
@@ -138,8 +148,12 @@ struct ConfigCommand: AsyncParsableCommand {
         case "off", "false", "no", "0", "disable", "disabled":
             return false
         default:
-            throw ConfigError.invalidValue(key: key, value: value)
+            throw ValidationError("Invalid value for \(key): '\(value)'. Use on/off (or true/false, yes/no, 1/0).")
         }
+    }
+
+    private static func unknownKeyError(_ key: String) -> ValidationError {
+        ValidationError("Unknown config key: '\(key)'. Supported: \(ConfigCommand.supportedKeys.joined(separator: ", ")).")
     }
 }
 
@@ -153,19 +167,5 @@ private func printResult(key: String, value: String, json: Bool) throws {
         try printJSON(ConfigKeyValue(key: key, value: value))
     } else {
         print(value)
-    }
-}
-
-enum ConfigError: Error, LocalizedError, Equatable {
-    case unknownKey(String)
-    case invalidValue(key: String, value: String)
-
-    var errorDescription: String? {
-        switch self {
-        case .unknownKey(let key):
-            return "Unknown config key: \(key). Supported: \(ConfigCommand.supportedKeys.joined(separator: ", "))."
-        case .invalidValue(let key, let value):
-            return "Invalid value for \(key): '\(value)'. Use on/off (or true/false, yes/no, 1/0)."
-        }
     }
 }

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -30,11 +30,14 @@ struct TranscribeCommand: AsyncParsableCommand {
         commandName: "transcribe",
         abstract: "Transcribe an audio/video file or YouTube URL.",
         discussion: """
-        Telemetry: emits one privacy-safe `cli_operation` event per invocation \
-        (command/outcome/duration/input_kind — never the path, URL, or transcript). \
-        Disable with `MACPARAKEET_TELEMETRY=0`, `DO_NOT_TRACK=1`, the persistent \
+        Telemetry: emits one privacy-safe `cli_operation` event per invocation with \
+        allowlisted invocation metadata (command, outcome, duration, input_kind, \
+        output_format, json, exit_code, error_type). It never includes the path, \
+        URL, transcript, language value, or user content. Disable with \
+        `MACPARAKEET_TELEMETRY=0`, `DO_NOT_TRACK=1`, the persistent \
         `macparakeet-cli config set telemetry off`, or the GUI Settings toggle. \
-        Auto-disabled in CI (CI/GITHUB_ACTIONS/etc.). See docs/telemetry.md.
+        Auto-disabled in CI (CI/GITHUB_ACTIONS/etc.). See \
+        https://github.com/moona3k/macparakeet/blob/main/docs/telemetry.md.
         """
     )
 

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -28,7 +28,14 @@ enum TranscribeSpeechEngine: String, ExpressibleByArgument, CaseIterable, Sendab
 struct TranscribeCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "transcribe",
-        abstract: "Transcribe an audio/video file or YouTube URL."
+        abstract: "Transcribe an audio/video file or YouTube URL.",
+        discussion: """
+        Telemetry: emits one privacy-safe `cli_operation` event per invocation \
+        (command/outcome/duration/input_kind — never the path, URL, or transcript). \
+        Disable with `MACPARAKEET_TELEMETRY=0`, `DO_NOT_TRACK=1`, the persistent \
+        `macparakeet-cli config set telemetry off`, or the GUI Settings toggle. \
+        Auto-disabled in CI (CI/GITHUB_ACTIONS/etc.). See docs/telemetry.md.
+        """
     )
 
     @Argument(help: "Path to audio/video file or YouTube URL to transcribe.")

--- a/Sources/CLI/MacParakeetCLI.swift
+++ b/Sources/CLI/MacParakeetCLI.swift
@@ -12,6 +12,7 @@ struct CLI: AsyncParsableCommand {
             ExportCommand.self,
             StatsCommand.self,
             HealthCommand.self,
+            ConfigCommand.self,
             ModelsCommand.self,
             FlowCommand.self,
             LLMCommand.self,

--- a/Sources/CLI/MacParakeetCLI.swift
+++ b/Sources/CLI/MacParakeetCLI.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import Darwin
 
 @main
 struct CLI: AsyncParsableCommand {
@@ -23,4 +24,45 @@ struct CLI: AsyncParsableCommand {
         ],
         defaultSubcommand: nil
     )
+
+    static func main() async {
+        await main(nil)
+    }
+
+    static func main(_ arguments: [String]?) async {
+        do {
+            var command = try parseAsRoot(arguments)
+            if var asyncCommand = command as? AsyncParsableCommand {
+                try await asyncCommand.run()
+            } else {
+                try command.run()
+            }
+        } catch {
+            exitWithNormalizedError(error)
+        }
+    }
+
+    static func normalizedExitCode(for error: Error) -> ExitCode {
+        if let exitCode = error as? ExitCode {
+            return normalizedExitCode(for: exitCode)
+        }
+        return normalizedExitCode(for: exitCode(for: error))
+    }
+
+    static func normalizedExitCode(for exitCode: ExitCode) -> ExitCode {
+        exitCode == .validationFailure ? cliValidationMisuseExitCode : exitCode
+    }
+
+    private static func exitWithNormalizedError(_ error: Error) -> Never {
+        let exitCode = normalizedExitCode(for: error)
+        let message = fullMessage(for: error)
+        if !message.isEmpty {
+            if exitCode.isSuccess {
+                print(message)
+            } else {
+                printErr(message)
+            }
+        }
+        Darwin.exit(exitCode.rawValue)
+    }
 }

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -943,11 +943,27 @@ struct SettingsView: View {
             subtitle: "Your audio and transcriptions never leave your device.",
             icon: "hand.raised"
         ) {
-            settingsToggleRow(
-                title: "Help improve MacParakeet",
-                detail: "Send non-identifying usage statistics like feature popularity and performance metrics. No personal data is collected.",
-                isOn: $viewModel.telemetryEnabled
-            )
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+                settingsToggleRow(
+                    title: "Help improve MacParakeet",
+                    detail: "Send non-identifying usage statistics like feature popularity and performance metrics. No personal data is collected.",
+                    isOn: $viewModel.telemetryEnabled
+                )
+                Button {
+                    if let url = URL(string: "https://github.com/moona3k/macparakeet/blob/main/docs/telemetry.md") {
+                        NSWorkspace.shared.open(url)
+                    }
+                } label: {
+                    HStack(spacing: 4) {
+                        Text("See the full event catalog")
+                        Image(systemName: "arrow.up.right.square")
+                            .font(.caption)
+                    }
+                }
+                .buttonStyle(.link)
+                .font(DesignSystem.Typography.caption)
+                .accessibilityHint("Opens the telemetry documentation on GitHub in your browser.")
+            }
         }
     }
 

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -958,6 +958,7 @@ struct SettingsView: View {
                         Text("See the full event catalog")
                         Image(systemName: "arrow.up.right.square")
                             .font(.caption)
+                            .accessibilityHidden(true)
                     }
                 }
                 .buttonStyle(.link)

--- a/Tests/CLITests/CLITelemetryTests.swift
+++ b/Tests/CLITests/CLITelemetryTests.swift
@@ -1,0 +1,159 @@
+import XCTest
+@testable import CLI
+@testable import MacParakeetCore
+
+final class CLITelemetryTests: XCTestCase {
+
+    // MARK: - decideOverride: explicit MACPARAKEET_TELEMETRY
+
+    func testDecideOverrideExplicitForceOffAccepts0FalseNoOff() {
+        for raw in ["0", "false", "no", "off", "FALSE", "Off", " no "] {
+            XCTAssertEqual(
+                CLITelemetry.decideOverride(env: ["MACPARAKEET_TELEMETRY": raw]),
+                .forceOff,
+                "Expected forceOff for MACPARAKEET_TELEMETRY=\(raw)"
+            )
+        }
+    }
+
+    func testDecideOverrideExplicitForceOnAccepts1TrueYesOn() {
+        for raw in ["1", "true", "yes", "on", "TRUE", "On", " yes "] {
+            XCTAssertEqual(
+                CLITelemetry.decideOverride(env: ["MACPARAKEET_TELEMETRY": raw]),
+                .forceOn,
+                "Expected forceOn for MACPARAKEET_TELEMETRY=\(raw)"
+            )
+        }
+    }
+
+    func testDecideOverrideEmptyMacparakeetVarFallsThrough() {
+        // An empty MACPARAKEET_TELEMETRY shouldn't trigger forceOff/forceOn — fall through.
+        XCTAssertEqual(
+            CLITelemetry.decideOverride(env: ["MACPARAKEET_TELEMETRY": ""]),
+            .none
+        )
+        XCTAssertEqual(
+            CLITelemetry.decideOverride(env: ["MACPARAKEET_TELEMETRY": "   "]),
+            .none
+        )
+    }
+
+    func testDecideOverrideUnknownMacparakeetValueFallsThrough() {
+        // Unknown values like "maybe" shouldn't accidentally enable or disable.
+        XCTAssertEqual(
+            CLITelemetry.decideOverride(env: ["MACPARAKEET_TELEMETRY": "maybe"]),
+            .none
+        )
+    }
+
+    // MARK: - decideOverride: DO_NOT_TRACK
+
+    func testDecideOverrideHonorsDoNotTrack() {
+        XCTAssertEqual(
+            CLITelemetry.decideOverride(env: ["DO_NOT_TRACK": "1"]),
+            .forceOff
+        )
+    }
+
+    func testDecideOverrideDoNotTrack0DoesNotForceOff() {
+        // DO_NOT_TRACK=0 means "tracking is fine," not "force off."
+        XCTAssertEqual(
+            CLITelemetry.decideOverride(env: ["DO_NOT_TRACK": "0"]),
+            .none
+        )
+    }
+
+    func testDecideOverrideMacparakeetForceOnBeatsDoNotTrack() {
+        // Explicit MACPARAKEET_TELEMETRY=1 wins over DO_NOT_TRACK so a developer
+        // can smoke-test telemetry from a shell that has DO_NOT_TRACK set globally.
+        XCTAssertEqual(
+            CLITelemetry.decideOverride(env: [
+                "MACPARAKEET_TELEMETRY": "1",
+                "DO_NOT_TRACK": "1"
+            ]),
+            .forceOn
+        )
+    }
+
+    // MARK: - decideOverride: CI auto-disable
+
+    func testDecideOverrideAutoDisablesInCI() {
+        for ciVar in ["CI", "GITHUB_ACTIONS", "GITLAB_CI", "BUILDKITE", "CIRCLECI",
+                      "TRAVIS", "JENKINS_URL", "TF_BUILD", "TEAMCITY_VERSION"] {
+            XCTAssertEqual(
+                CLITelemetry.decideOverride(env: [ciVar: "true"]),
+                .ciAutoDisable,
+                "Expected ciAutoDisable for \(ciVar)=true"
+            )
+        }
+    }
+
+    func testDecideOverrideCIFalseDoesNotTriggerAutoDisable() {
+        // Some setups pass CI=false. Don't auto-disable on that.
+        XCTAssertEqual(
+            CLITelemetry.decideOverride(env: ["CI": "false"]),
+            .none
+        )
+        XCTAssertEqual(
+            CLITelemetry.decideOverride(env: ["CI": "0"]),
+            .none
+        )
+        XCTAssertEqual(
+            CLITelemetry.decideOverride(env: ["CI": ""]),
+            .none
+        )
+    }
+
+    func testDecideOverrideMacparakeetForceOnBeatsCIAutoDisable() {
+        // Developer in a CI shell smoke-testing telemetry should be able to override.
+        XCTAssertEqual(
+            CLITelemetry.decideOverride(env: [
+                "CI": "true",
+                "MACPARAKEET_TELEMETRY": "1"
+            ]),
+            .forceOn
+        )
+    }
+
+    func testDecideOverrideMacparakeetForceOffStillForceOffInCI() {
+        XCTAssertEqual(
+            CLITelemetry.decideOverride(env: [
+                "CI": "true",
+                "MACPARAKEET_TELEMETRY": "0"
+            ]),
+            .forceOff
+        )
+    }
+
+    func testDecideOverrideNoEnvVarsReturnsNone() {
+        XCTAssertEqual(CLITelemetry.decideOverride(env: [:]), .none)
+    }
+
+    // MARK: - isCIEnvironment
+
+    func testIsCIEnvironmentTruthyValues() {
+        for value in ["true", "1", "yes", "on", "TRUE", " true "] {
+            XCTAssertTrue(
+                CLITelemetry.isCIEnvironment(env: ["GITHUB_ACTIONS": value]),
+                "Expected truthy detection for GITHUB_ACTIONS=\(value)"
+            )
+        }
+    }
+
+    func testIsCIEnvironmentFalsyValues() {
+        for value in ["false", "0", "no", "off", "", "  "] {
+            XCTAssertFalse(
+                CLITelemetry.isCIEnvironment(env: ["GITHUB_ACTIONS": value]),
+                "Expected falsy detection for GITHUB_ACTIONS=\(value)"
+            )
+        }
+    }
+
+    func testIsCIEnvironmentJenkinsURL() {
+        // JENKINS_URL is conventionally a URL string (not "true"/"false"); treat any
+        // non-falsy value as CI-positive.
+        XCTAssertTrue(
+            CLITelemetry.isCIEnvironment(env: ["JENKINS_URL": "https://ci.example.com/"])
+        )
+    }
+}

--- a/Tests/CLITests/CLITelemetryTests.swift
+++ b/Tests/CLITests/CLITelemetryTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 @testable import CLI
-@testable import MacParakeetCore
 
 final class CLITelemetryTests: XCTestCase {
 

--- a/Tests/CLITests/ConfigCommandTests.swift
+++ b/Tests/CLITests/ConfigCommandTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+@testable import CLI
+@testable import MacParakeetCore
+
+final class ConfigCommandTests: XCTestCase {
+
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        // Isolate each test in a unique UserDefaults suite so we never touch
+        // the user's real `com.macparakeet.MacParakeet` plist.
+        suiteName = "macparakeet.test.config.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    // MARK: - read
+
+    func testReadTelemetryDefaultsToOn() throws {
+        // Mirror AppPreferences.isTelemetryEnabled: missing key → on.
+        let value = try ConfigCommand.read(key: "telemetry", defaults: defaults)
+        XCTAssertEqual(value, "on")
+    }
+
+    func testReadTelemetryReflectsExplicitFalse() throws {
+        defaults.set(false, forKey: AppPreferences.telemetryEnabledKey)
+        XCTAssertEqual(try ConfigCommand.read(key: "telemetry", defaults: defaults), "off")
+    }
+
+    func testReadTelemetryReflectsExplicitTrue() throws {
+        defaults.set(true, forKey: AppPreferences.telemetryEnabledKey)
+        XCTAssertEqual(try ConfigCommand.read(key: "telemetry", defaults: defaults), "on")
+    }
+
+    func testReadUnknownKeyThrows() {
+        XCTAssertThrowsError(try ConfigCommand.read(key: "bogus", defaults: defaults)) { error in
+            guard case ConfigError.unknownKey(let key)? = error as? ConfigError else {
+                return XCTFail("Expected ConfigError.unknownKey, got \(error)")
+            }
+            XCTAssertEqual(key, "bogus")
+        }
+    }
+
+    // MARK: - write
+
+    func testWriteTelemetryOffPersists() throws {
+        let canonical = try ConfigCommand.write(key: "telemetry", value: "off", defaults: defaults)
+        XCTAssertEqual(canonical, "off")
+        XCTAssertEqual(defaults.object(forKey: AppPreferences.telemetryEnabledKey) as? Bool, false)
+    }
+
+    func testWriteTelemetryOnPersists() throws {
+        defaults.set(false, forKey: AppPreferences.telemetryEnabledKey)
+        let canonical = try ConfigCommand.write(key: "telemetry", value: "on", defaults: defaults)
+        XCTAssertEqual(canonical, "on")
+        XCTAssertEqual(defaults.object(forKey: AppPreferences.telemetryEnabledKey) as? Bool, true)
+    }
+
+    func testWriteAcceptsAllBoolSynonyms() throws {
+        for (synonym, expectedBool) in [
+            ("on", true), ("ON", true), ("true", true), ("yes", true),
+            ("1", true), ("enable", true), ("enabled", true),
+            ("off", false), ("OFF", false), ("false", false), ("no", false),
+            ("0", false), ("disable", false), ("disabled", false)
+        ] {
+            let canonical = try ConfigCommand.write(key: "telemetry", value: synonym, defaults: defaults)
+            XCTAssertEqual(canonical, expectedBool ? "on" : "off",
+                           "Synonym '\(synonym)' should canonicalize to \(expectedBool ? "on" : "off")")
+            XCTAssertEqual(defaults.object(forKey: AppPreferences.telemetryEnabledKey) as? Bool, expectedBool)
+        }
+    }
+
+    func testWriteRejectsInvalidValue() {
+        XCTAssertThrowsError(try ConfigCommand.write(key: "telemetry", value: "maybe", defaults: defaults)) { error in
+            guard case ConfigError.invalidValue(let key, let value)? = error as? ConfigError else {
+                return XCTFail("Expected ConfigError.invalidValue, got \(error)")
+            }
+            XCTAssertEqual(key, "telemetry")
+            XCTAssertEqual(value, "maybe")
+        }
+        // Defaults must not have been mutated.
+        XCTAssertNil(defaults.object(forKey: AppPreferences.telemetryEnabledKey))
+    }
+
+    func testWriteUnknownKeyThrows() {
+        XCTAssertThrowsError(try ConfigCommand.write(key: "bogus", value: "on", defaults: defaults)) { error in
+            guard case ConfigError.unknownKey? = error as? ConfigError else {
+                return XCTFail("Expected ConfigError.unknownKey, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - parseBool
+
+    func testParseBoolRejectsEmpty() {
+        XCTAssertThrowsError(try ConfigCommand.parseBool("", key: "telemetry"))
+    }
+}

--- a/Tests/CLITests/ConfigCommandTests.swift
+++ b/Tests/CLITests/ConfigCommandTests.swift
@@ -1,3 +1,4 @@
+import ArgumentParser
 import XCTest
 @testable import CLI
 @testable import MacParakeetCore
@@ -40,12 +41,11 @@ final class ConfigCommandTests: XCTestCase {
         XCTAssertEqual(try ConfigCommand.read(key: "telemetry", defaults: defaults), "on")
     }
 
-    func testReadUnknownKeyThrows() {
+    func testReadUnknownKeyThrowsValidationError() {
+        // Maps to errorType="validation" / exit code 2 in --json failure envelope.
         XCTAssertThrowsError(try ConfigCommand.read(key: "bogus", defaults: defaults)) { error in
-            guard case ConfigError.unknownKey(let key)? = error as? ConfigError else {
-                return XCTFail("Expected ConfigError.unknownKey, got \(error)")
-            }
-            XCTAssertEqual(key, "bogus")
+            XCTAssertTrue(error is ValidationError, "Expected ValidationError, got \(type(of: error))")
+            XCTAssertTrue("\(error)".contains("bogus"))
         }
     }
 
@@ -78,29 +78,32 @@ final class ConfigCommandTests: XCTestCase {
         }
     }
 
-    func testWriteRejectsInvalidValue() {
+    func testWriteRejectsInvalidValueAsValidationError() {
         XCTAssertThrowsError(try ConfigCommand.write(key: "telemetry", value: "maybe", defaults: defaults)) { error in
-            guard case ConfigError.invalidValue(let key, let value)? = error as? ConfigError else {
-                return XCTFail("Expected ConfigError.invalidValue, got \(error)")
-            }
-            XCTAssertEqual(key, "telemetry")
-            XCTAssertEqual(value, "maybe")
+            XCTAssertTrue(error is ValidationError, "Expected ValidationError, got \(type(of: error))")
+            XCTAssertTrue("\(error)".contains("maybe"))
         }
         // Defaults must not have been mutated.
         XCTAssertNil(defaults.object(forKey: AppPreferences.telemetryEnabledKey))
     }
 
-    func testWriteUnknownKeyThrows() {
+    func testWriteUnknownKeyThrowsValidationError() {
         XCTAssertThrowsError(try ConfigCommand.write(key: "bogus", value: "on", defaults: defaults)) { error in
-            guard case ConfigError.unknownKey? = error as? ConfigError else {
-                return XCTFail("Expected ConfigError.unknownKey, got \(error)")
-            }
+            XCTAssertTrue(error is ValidationError, "Expected ValidationError, got \(type(of: error))")
         }
     }
 
     // MARK: - parseBool
 
     func testParseBoolRejectsEmpty() {
-        XCTAssertThrowsError(try ConfigCommand.parseBool("", key: "telemetry"))
+        XCTAssertThrowsError(try ConfigCommand.parseBool("", key: "telemetry")) { error in
+            XCTAssertTrue(error is ValidationError)
+        }
+    }
+
+    func testParseBoolRejectsWhitespaceOnly() {
+        XCTAssertThrowsError(try ConfigCommand.parseBool("   ", key: "telemetry")) { error in
+            XCTAssertTrue(error is ValidationError)
+        }
     }
 }

--- a/Tests/CLITests/ConfigCommandTests.swift
+++ b/Tests/CLITests/ConfigCommandTests.swift
@@ -106,4 +106,9 @@ final class ConfigCommandTests: XCTestCase {
             XCTAssertTrue(error is ValidationError)
         }
     }
+
+    func testParseBoolTrimsNewlines() throws {
+        XCTAssertTrue(try ConfigCommand.parseBool("\n on \n", key: "telemetry"))
+        XCTAssertFalse(try ConfigCommand.parseBool("\n off \n", key: "telemetry"))
+    }
 }

--- a/Tests/CLITests/LLMJSONOutputTests.swift
+++ b/Tests/CLITests/LLMJSONOutputTests.swift
@@ -187,6 +187,34 @@ final class LLMJSONOutputTests: XCTestCase {
         XCTAssertTrue((object["error"] as? String)?.contains("No transcription") == true)
     }
 
+    func testJSONWrapperUsesDocumentedValidationMisuseExitCode() throws {
+        var thrownError: Error?
+        let output = try captureStandardOutput {
+            do {
+                try emitJSONOrRethrow(json: true) {
+                    throw ValidationError("bad combo")
+                }
+            } catch {
+                thrownError = error
+            }
+        }
+
+        let exit = try XCTUnwrap(thrownError as? ExitCode)
+        XCTAssertEqual(exit.rawValue, 2)
+
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any]
+        )
+        XCTAssertEqual(object["ok"] as? Bool, false)
+        XCTAssertEqual(object["errorType"] as? String, "validation")
+    }
+
+    func testCLINormalizesArgumentParserValidationExitCodeToPublicContract() {
+        XCTAssertEqual(CLI.normalizedExitCode(for: ExitCode.validationFailure).rawValue, 2)
+        XCTAssertEqual(CLI.normalizedExitCode(for: ValidationError("bad combo")).rawValue, 2)
+        XCTAssertEqual(CLI.normalizedExitCode(for: ExitCode.failure), .failure)
+    }
+
     // MARK: - Helpers
 
     private func assertParseRejects<C: ParsableCommand>(

--- a/Tests/MacParakeetTests/Services/CLIOperationPrivacyTests.swift
+++ b/Tests/MacParakeetTests/Services/CLIOperationPrivacyTests.swift
@@ -75,11 +75,11 @@ struct CLIOperationPrivacyTests {
         #expect(unexpected.isEmpty, "cli_operation introduced new prop key(s) \(unexpected) — review for privacy and update docs/telemetry.md + integrations/README.md before merging.")
     }
 
-    @Test("input_kind is the enum case name, not user-supplied content")
+    @Test("input_kind serializes to the enum case name; no path/URL substrings leak into any prop value")
     func inputKindIsEnumOnly() {
-        // Even when the file is a malicious filename like
-        // `..//Users/secret/sensitive_recording.m4a`, the only thing that ends
-        // up in props is the ObservabilityInputKind enum case.
+        // Defense in depth: if a future refactor of `compactProps` started
+        // splatting the original input string into a prop value, the contains()
+        // assertions below would catch it.
         let event = TelemetryEventSpec.cliOperation(
             operationID: "op-1",
             operationContext: nil,

--- a/Tests/MacParakeetTests/Services/CLIOperationPrivacyTests.swift
+++ b/Tests/MacParakeetTests/Services/CLIOperationPrivacyTests.swift
@@ -73,6 +73,16 @@ struct CLIOperationPrivacyTests {
         let actual = Set((event.props ?? [:]).keys)
         let unexpected = actual.subtracting(allowed)
         #expect(unexpected.isEmpty, "cli_operation introduced new prop key(s) \(unexpected) — review for privacy and update docs/telemetry.md + integrations/README.md before merging.")
+
+        let requiredForTranscribeFailure: Set<String> = [
+            "operation_id", "workflow_id",
+            "command",
+            "outcome", "duration_seconds",
+            "input_kind", "output_format", "json",
+            "exit_code", "error_type"
+        ]
+        let missing = requiredForTranscribeFailure.subtracting(actual)
+        #expect(missing.isEmpty, "cli_operation dropped required transcribe failure prop key(s) \(missing) — this is a schema regression.")
     }
 
     @Test("input_kind serializes to the enum case name; no path/URL substrings leak into any prop value")

--- a/Tests/MacParakeetTests/Services/CLIOperationPrivacyTests.swift
+++ b/Tests/MacParakeetTests/Services/CLIOperationPrivacyTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+import Testing
+@testable import MacParakeetCore
+
+/// Pins the `cli_operation` event's prop schema. The point of these tests is
+/// not to catch a typo — `compactProps` already does that — but to make any
+/// future addition of a path-shaped, URL-shaped, or content-shaped prop fail
+/// loudly at PR review time. If you're adding `file_path`, `youtube_url`,
+/// `transcript_excerpt`, etc., these tests are doing their job.
+@Suite("cli_operation privacy schema")
+struct CLIOperationPrivacyTests {
+
+    @Test("cli_operation never emits forbidden keys, even with a YouTube input_kind")
+    func cliOperationNeverShipsForbiddenKeys() {
+        let context = ObservabilityOperationContext(
+            operationID: "op-1",
+            workflowID: "wf-1",
+            parentOperationID: nil
+        )
+        let event = TelemetryEventSpec.cliOperation(
+            operationID: "op-1",
+            operationContext: context,
+            command: "transcribe",
+            subcommand: nil,
+            outcome: .success,
+            durationSeconds: 12.5,
+            inputKind: .youtube,
+            outputFormat: "json",
+            json: true,
+            exitCode: 0,
+            errorType: nil
+        )
+
+        let props = event.props ?? [:]
+
+        let forbidden: Set<String> = [
+            "file_path", "path", "filename", "input_path",
+            "url", "youtube_url", "video_url", "video_id",
+            "transcript", "transcript_excerpt", "raw_transcript", "clean_transcript",
+            "language", "host", "hostname",
+            "device_name", "device_uid", "microphone", "microphone_name",
+            "user_email", "email"
+        ]
+        for key in forbidden {
+            #expect(props[key] == nil, "cli_operation must not include \(key); got \(props[key] ?? "<nil>")")
+        }
+    }
+
+    @Test("cli_operation prop keys stay within the documented allowlist")
+    func cliOperationAllowlistStable() {
+        let event = TelemetryEventSpec.cliOperation(
+            operationID: "op-1",
+            operationContext: ObservabilityOperationContext(operationID: "op-1"),
+            command: "transcribe",
+            subcommand: "sub",
+            outcome: .failure,
+            durationSeconds: 1.2,
+            inputKind: .audio,
+            outputFormat: "text",
+            json: false,
+            exitCode: 1,
+            errorType: "URLError.timedOut"
+        )
+
+        let allowed: Set<String> = [
+            "operation_id", "workflow_id", "parent_operation_id",
+            "command", "subcommand",
+            "outcome", "duration_seconds",
+            "input_kind", "output_format", "json",
+            "exit_code", "error_type"
+        ]
+
+        let actual = Set((event.props ?? [:]).keys)
+        let unexpected = actual.subtracting(allowed)
+        #expect(unexpected.isEmpty, "cli_operation introduced new prop key(s) \(unexpected) — review for privacy and update docs/telemetry.md + integrations/README.md before merging.")
+    }
+
+    @Test("input_kind is the enum case name, not user-supplied content")
+    func inputKindIsEnumOnly() {
+        // Even when the file is a malicious filename like
+        // `..//Users/secret/sensitive_recording.m4a`, the only thing that ends
+        // up in props is the ObservabilityInputKind enum case.
+        let event = TelemetryEventSpec.cliOperation(
+            operationID: "op-1",
+            operationContext: nil,
+            command: "transcribe",
+            subcommand: nil,
+            outcome: .success,
+            durationSeconds: 1.0,
+            inputKind: .audio,
+            outputFormat: nil,
+            json: nil,
+            exitCode: nil,
+            errorType: nil
+        )
+        let props = event.props ?? [:]
+        #expect(props["input_kind"] == "audio")
+        // Also make sure no other prop accidentally captured a path-shaped string.
+        for (_, value) in props {
+            #expect(!value.contains("/Users/"), "Found `/Users/` in cli_operation prop value: \(value)")
+            #expect(!value.contains("file://"), "Found `file://` in cli_operation prop value: \(value)")
+            #expect(!value.lowercased().contains("youtube.com"), "Found `youtube.com` in cli_operation prop value: \(value)")
+        }
+    }
+}

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -73,8 +73,9 @@ macparakeet-cli
 > **Telemetry convention**: CLI telemetry uses the same opt-out preference as
 > the GUI and does not change stdout/stderr contracts. `transcribe` emits a
 > privacy-safe `cli_operation` event with command, outcome, duration, output
-> format, and coarse input kind. Set `MACPARAKEET_TELEMETRY=0` to disable CLI
-> telemetry for a process.
+> format, coarse input kind, exit code, and low-cardinality error type. Disable
+> with `MACPARAKEET_TELEMETRY=0`, `DO_NOT_TRACK=1`, or
+> `macparakeet-cli config set telemetry off`.
 
 ## Core Modes
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -274,8 +274,27 @@ events remain useful for diarization-specific timing and failure analysis.
 | `cli_operation` | `operation_id`, `workflow_id`, `parent_operation_id`, `command`, `subcommand`, `outcome`, `duration_seconds`, `input_kind`, `output_format`, `json`, `exit_code`, `error_type` | Which CLI workflows are used by scripts/agents, and where they fail |
 
 CLI telemetry is initialized by `macparakeet-cli transcribe` and uses the same
-app preference as the GUI. Users and automation can also set
-`MACPARAKEET_TELEMETRY=0` to force-disable CLI telemetry for a process.
+app preference as the GUI. Override resolution order (first match wins):
+
+1. `MACPARAKEET_TELEMETRY=0/false/no/off` → force-off for this process
+2. `MACPARAKEET_TELEMETRY=1/true/yes/on` → force-on for this process
+3. `DO_NOT_TRACK=1` → force-off (industry-standard signal, also honored by
+   Homebrew, GitLab, VS Code)
+4. CI auto-disable: any of `CI`, `GITHUB_ACTIONS`, `GITLAB_CI`, `BUILDKITE`,
+   `CIRCLECI`, `TRAVIS`, `JENKINS_URL`, `TF_BUILD`, `TEAMCITY_VERSION` set to
+   a truthy value (avoids 1000-job agent runs flooding the endpoint)
+5. Persisted UserDefaults `telemetryEnabled` (default: true)
+
+CLI-only users (no GUI) can persist their preference via:
+
+```bash
+macparakeet-cli config set telemetry off   # also accepts on, true/false, 1/0
+macparakeet-cli config get telemetry
+macparakeet-cli config list
+```
+
+The CLI writes to the shared UserDefaults suite (`com.macparakeet.MacParakeet`),
+so a later GUI install picks the same preference up automatically.
 
 > **Important:** `error_occurred` includes a `description` field for full error visibility. The **Cloudflare Worker redacts PII server-side** before storage:
 > - File paths (`/Users/...`, `~/...`) → `[PATH]`

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -266,10 +266,26 @@ macparakeet-cli prompts run "<prompt-name>" \
 - **Lookups:** records that take an `<id-or-name>` argument accept full UUID,
   UUID prefix (>= 4 chars), or case-insensitive name. Ambiguous prefixes
   produce a `.ambiguous` error; missing records produce `.notFound`.
-- **Privacy:** STT and database access never touch the network. The only
-  network egress paths are: YouTube downloads (yt-dlp), optional cloud LLM
-  provider calls (only when `prompts run --provider <cloud>`), and Sparkle
-  update checks (app, not CLI).
+- **Privacy:** STT and database access never touch the network. Network
+  egress paths are: YouTube downloads (yt-dlp); optional cloud LLM provider
+  calls (only when `prompts run --provider <cloud>` or `llm` against a hosted
+  provider); Sparkle update checks (app, not CLI); and a single privacy-safe
+  `cli_operation` event per `transcribe` invocation, posted to the
+  self-hosted endpoint at `https://macparakeet.com/api/telemetry`. The
+  telemetry event ships outcome / duration / `input_kind` only — never the
+  file path, URL, transcript, or any user content (random per-process
+  session UUID, no persistent identifier). Disable it any of four ways:
+    - `MACPARAKEET_TELEMETRY=0` (per process)
+    - `DO_NOT_TRACK=1` (industry-standard signal, also honored)
+    - `macparakeet-cli config set telemetry off` (persists in the shared
+      UserDefaults suite the GUI reads)
+    - "Help improve MacParakeet" toggle in the GUI Settings → Privacy card
+
+  Auto-disabled in CI environments (`CI`, `GITHUB_ACTIONS`, `GITLAB_CI`,
+  `BUILDKITE`, `CIRCLECI`, `TRAVIS`, `JENKINS_URL`, `TF_BUILD`,
+  `TEAMCITY_VERSION` — any one set to a truthy value). Override CI auto-
+  disable with `MACPARAKEET_TELEMETRY=1`. See `docs/telemetry.md` for the
+  full event catalog and the Worker-side PII redaction policy.
 - **Concurrency:** the STT scheduler reserves one slot for dictation and
   shares a second slot for meeting / batch work (ADR-016). Multiple
   concurrent CLI calls share the background slot; expect serial transcription

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -272,9 +272,12 @@ macparakeet-cli prompts run "<prompt-name>" \
   provider); Sparkle update checks (app, not CLI); and a single privacy-safe
   `cli_operation` event per `transcribe` invocation, posted to the
   self-hosted endpoint at `https://macparakeet.com/api/telemetry`. The
-  telemetry event ships outcome / duration / `input_kind` only — never the
-  file path, URL, transcript, or any user content (random per-process
-  session UUID, no persistent identifier). Disable it any of four ways:
+  telemetry event ships only allowlisted invocation metadata (`operation_id`,
+  `workflow_id`, `parent_operation_id`, `command`, `subcommand`, `outcome`,
+  `duration_seconds`, `input_kind`, `output_format`, `json`, `exit_code`,
+  `error_type`) — never the file path, URL, transcript, language value, or any
+  user content (random per-process session UUID, no persistent identifier).
+  Disable it any of four ways:
     - `MACPARAKEET_TELEMETRY=0` (per process)
     - `DO_NOT_TRACK=1` (industry-standard signal, also honored)
     - `macparakeet-cli config set telemetry off` (persists in the shared

--- a/spec/kernel/requirements.yaml
+++ b/spec/kernel/requirements.yaml
@@ -16,6 +16,7 @@
 #   PLAY  - Video/audio playback
 #   LIB   - Transcription library
 #   MEET  - Meeting recording
+#   CLI   - Public command-line surface
 
 # --- v0.1 Core MVP ---
 
@@ -226,4 +227,11 @@ REQ-TRANS-002:
 REQ-MEET-007:
   description: Meeting recordings capture the active speech engine and Whisper language at recording start for live preview, metadata, crash recovery, and final transcription
   version: v0.7
+  status: implemented
+
+# --- CLI Public Surface ---
+
+REQ-CLI-001:
+  description: CLI transcription telemetry emits a privacy-safe cli_operation event, honors explicit env/CI/UserDefaults opt-out controls, and exposes config get/set/list for the persisted telemetry preference
+  version: cli-1.3.0
   status: implemented

--- a/spec/kernel/traceability.md
+++ b/spec/kernel/traceability.md
@@ -82,3 +82,9 @@ This matrix traces each requirement ID from `requirements.yaml` to its implement
 | REQ-STT-003 | `MacParakeetCore/STT/STTScheduler.swift`, `MacParakeetCore/STT/STTClient.swift`, `MacParakeetViewModels/SettingsViewModel.swift`, `MacParakeet/Views/Settings/SettingsView.swift`, `MacParakeet/App/AppEnvironment.swift`, `MacParakeet/App/AppEnvironmentConfigurer.swift` | `STTSchedulerTests.swift`, `SettingsViewModelTests.swift` |
 | REQ-TRANS-002 | `CLI/Commands/TranscribeCommand.swift`, `CLI/Commands/ModelsCommand.swift`, `MacParakeetCore/STT/STTResult.swift`, `MacParakeetCore/Services/TranscriptionService.swift`, `MacParakeetCore/Services/AppPaths.swift` | `TranscribeCommandTests.swift`, `ModelLifecycleCommandTests.swift`, `TranscriptionServiceTests.swift` |
 | REQ-MEET-007 | `MacParakeetCore/Services/MeetingRecordingService.swift`, `MacParakeetCore/Services/MeetingRecordingMetadata.swift`, `MacParakeetCore/Services/MeetingRecordingOutput.swift`, `MacParakeetCore/Services/MeetingRecordingLockFileStore.swift`, `MacParakeetCore/Services/MeetingRecordingRecoveryService.swift`, `MacParakeetCore/Services/TranscriptionService.swift` | `MeetingRecordingServiceTests.swift`, `MeetingRecordingLockFileStoreTests.swift`, `MeetingRecordingRecoveryServiceTests.swift`, `TranscriptionServiceTests.swift`, `STTSchedulerTests.swift` |
+
+## CLI Public Surface
+
+| Requirement | Source Files | Test Files |
+|------------|-------------|------------|
+| REQ-CLI-001 | `CLI/MacParakeetCLI.swift`, `CLI/Commands/CLIHelpers.swift`, `CLI/Commands/CLITelemetry.swift`, `CLI/Commands/ConfigCommand.swift`, `CLI/Commands/TranscribeCommand.swift`, `MacParakeetCore/Services/TelemetryEvent.swift`, `MacParakeet/Views/Settings/SettingsView.swift` | `LLMJSONOutputTests.swift`, `CLITelemetryTests.swift`, `ConfigCommandTests.swift`, `CLIOperationPrivacyTests.swift` |


### PR DESCRIPTION
## Why

The CLI is being repositioned as the canonical Parakeet-on-Apple-Silicon surface for agent operators (OpenClaw / Hermes / scripted callers). For that audience the telemetry bar shifts: GUI norms (default-on, Settings toggle) aren't enough. Peer CLIs in this space honor `DO_NOT_TRACK`, auto-disable in CI, and document every byte of egress in the integration guide.

Collection itself was already minimal — random per-process session UUID, no paths / URLs / transcript content, server-side PII redaction. This PR closes the **disclosure-and-defaults gap** without changing payload, schema, exit codes, or stdout.

## What actually goes over the wire (unchanged — confirmed by audit)

```
   ┌─────────────────────────────────────────────────────────────────┐
   │  macparakeet-cli transcribe ~/Recordings/Standup-2026-04-28.m4a │
   └─────────────────────────────────────────────────────────────────┘
                                  │
                                  ▼
   ┌─────────────────────────────────────────────────────────────────┐
   │  STRIPPED at the typed event boundary (cannot reach the wire):  │
   │    • file path           (~/Recordings/Standup-2026-04-28.m4a)  │
   │    • filename            (Standup-2026-04-28.m4a)               │
   │    • YouTube URL / video ID                                     │
   │    • transcript text     (raw + clean)                          │
   │    • word count          (not in cli_operation, only GUI events)│
   │    • language flag value                                        │
   │    • custom database path                                       │
   │    • microphone name / device UID / hardware serial             │
   │    • LLM prompts and responses                                  │
   └─────────────────────────────────────────────────────────────────┘
                                  │
                                  ▼
   ┌─────────────────────────────────────────────────────────────────┐
   │  cli_operation event (one POST per invocation, batched/flushed) │
   │  ─────────────────────────────────────────────────────────────  │
   │    operation_id          random UUID, per-process               │
   │    workflow_id           random UUID, per-process               │
   │    parent_operation_id   nil for CLI                            │
   │    command               "transcribe"                           │
   │    subcommand            nil                                    │
   │    outcome               success | failure | cancelled | empty  │
   │    duration_seconds      12.5                                   │
   │    input_kind            audio | video | youtube | meeting      │
   │    output_format         "text" | "json"                        │
   │    json                  true | false                           │
   │    exit_code             0 | 1                                  │
   │    error_type            "URLError.timedOut" (classifier output)│
   │  + envelope                                                     │
   │    session               random UUID, per-process               │
   │    app_ver, os_ver, locale, chip                                │
   │    ts                    ISO 8601                               │
   │    event_id              UUID, idempotency key                  │
   └─────────────────────────────────────────────────────────────────┘
                                  │ HTTPS, 1s timeout
                                  ▼
   ┌─────────────────────────────────────────────────────────────────┐
   │  https://macparakeet.com/api/telemetry  (self-hosted CF Worker) │
   │    • allowlist validates event name (rejects unknown)           │
   │    • rate-limited 10 req/min/IP (IP not stored)                 │
   │    • country added from CF-IPCountry header                     │
   │    • PII redaction (paths, URLs, emails, API-key shapes)        │
   │    • inserted into D1 (SQLite), 90-day retention                │
   └─────────────────────────────────────────────────────────────────┘
```

The `cli_operation` payload is pinned by the new `CLIOperationPrivacyTests` — any future addition of a path-shaped, URL-shaped, or content-shaped prop fails CI at PR review time.

## New opt-out matrix

```
   Resolution order — first match wins, no fall-through:

   ┌─────────────────────────────────────────────┬─────────────────────┐
   │ MACPARAKEET_TELEMETRY=0/false/no/off        │ → force off         │
   │ MACPARAKEET_TELEMETRY=1/true/yes/on         │ → force on          │   ← NEW: defeats DNT/CI
   │ DO_NOT_TRACK=1                              │ → force off         │   ← NEW
   │ CI=true / GITHUB_ACTIONS=true / GITLAB_CI / │ → auto-disable      │   ← NEW
   │   BUILDKITE / CIRCLECI / TRAVIS /           │                     │
   │   JENKINS_URL / TF_BUILD / TEAMCITY_VERSION │                     │
   │ macparakeet-cli config set telemetry off    │ → persist off       │   ← NEW
   │ GUI Settings → Privacy → "Help improve…"    │ → persist off       │
   │ (default)                                   │ → on, honored       │
   └─────────────────────────────────────────────┴─────────────────────┘
```

`MACPARAKEET_TELEMETRY=1` is preserved as the explicit override for developers smoke-testing telemetry from a CI shell that has `DO_NOT_TRACK` or `CI` set globally.

## Changes

| Change | File | Why |
|---|---|---|
| Honor `DO_NOT_TRACK=1` | `CLITelemetry.swift` | Industry standard (Homebrew, GitLab, VS Code). Cheapest possible way to look like a peer to other agent CLIs. |
| Auto-disable in CI | `CLITelemetry.swift` | Prevents 1000-job agent runs flooding the endpoint with `cli_operation` events. Conservative — `CI=false` does not trigger. |
| `macparakeet-cli config get/set/list` | `Commands/ConfigCommand.swift` (new) | CLI-only users (brew install, no GUI) had no way to persist opt-out. Writes to the shared UserDefaults suite the GUI reads. |
| Surface telemetry in `transcribe --help` | `Commands/TranscribeCommand.swift` | Disclosure at the moment of consent. |
| "See the full event catalog" link | `Views/Settings/SettingsView.swift` | Lets users audit before deciding. Deep-links to `docs/telemetry.md` on GitHub. |
| Privacy bullet enumerates telemetry egress | `integrations/README.md` | Previously listed YouTube/LLM/Sparkle and silently omitted the `cli_operation` POST — the most agent-facing doc was misleading. |
| Env-var precedence ladder doc | `docs/telemetry.md` | Single source of truth for resolution order. |
| `Unreleased` changelog entry | `Sources/CLI/CHANGELOG.md` | Public CLI surface contract. |
| Env-var precedence tests | `Tests/CLITests/CLITelemetryTests.swift` (new) | 13 cases: every truthy/falsy synonym, CI detection edge cases, override-beats-DNT, override-beats-CI, force-off-still-force-off-in-CI. |
| Config persistence tests | `Tests/CLITests/ConfigCommandTests.swift` (new) | 11 cases against an isolated UserDefaults suite — never touches the real plist. |
| `cli_operation` prop allowlist | `Tests/MacParakeetTests/Services/CLIOperationPrivacyTests.swift` (new) | Pins schema; future attempts to add `file_path`, `youtube_url`, `transcript_excerpt`, etc. fail at PR review. |

## Behavior verification

`macparakeet-cli config --help`:
```
OVERVIEW: Read or write CLI/app configuration values.

Configuration is stored in the shared MacParakeet UserDefaults suite
(com.macparakeet.MacParakeet). The GUI reads the same suite, so values set here
apply to both surfaces.

Supported keys:
  telemetry   on|off   Anonymous, non-identifying usage analytics
                       (default: on). See docs/telemetry.md for the
                       full event catalog.

Per-process overrides (env vars, do not require `config set`):
  MACPARAKEET_TELEMETRY=0   Force-off for one invocation
  MACPARAKEET_TELEMETRY=1   Force-on for one invocation
  DO_NOT_TRACK=1            Force-off (industry-standard signal)
  CI=true                   Auto-disabled in CI environments
```

`macparakeet-cli transcribe --help` now opens with:
```
Telemetry: emits one privacy-safe `cli_operation` event per invocation
(command/outcome/duration/input_kind — never the path, URL, or transcript).
Disable with `MACPARAKEET_TELEMETRY=0`, `DO_NOT_TRACK=1`, the persistent
`macparakeet-cli config set telemetry off`, or the GUI Settings toggle.
Auto-disabled in CI (CI/GITHUB_ACTIONS/etc.). See docs/telemetry.md.
```

## What is intentionally NOT in this PR

- **No payload changes.** `cli_operation` schema is frozen by `CLIOperationPrivacyTests`; the PR was scoped to gating + disclosure.
- **No GUI behavior change** beyond the "Learn more" link. The Settings toggle text is unchanged.
- **No worker-side changes.** Allowlist, redaction, rate limiting, retention are unchanged.
- **No `telemetry_opted_out` event from CLI `config set`** — deferred. The GUI still emits it; CLI flips persist silently. Can revisit if we want exit-survey signal.
- **Crash reporter `reason` field hardening** — false positive in initial audit; `CrashReporter.objcExceptionHandler` already passes `reason` through `TelemetryErrorClassifier.errorDetail` which calls `sanitize()`. Verified at `Sources/MacParakeetCore/Services/CrashReporter.swift:227-229`.

## Test plan

- [x] `swift build --target CLI` — clean
- [x] `swift build --target MacParakeet` — clean
- [x] `swift test` — 1886 XCTest + 16 Swift Testing pass; no new failures
- [x] `swift run macparakeet-cli config --help` — help text renders correctly
- [x] `swift run macparakeet-cli transcribe --help` — telemetry note surfaces in help
- [ ] Smoke-test on macOS with GUI installed: GUI Settings "Learn more" link opens GitHub
- [ ] Smoke-test `macparakeet-cli config set telemetry off` then `config get telemetry` round-trip
- [ ] Smoke-test `MACPARAKEET_TELEMETRY=0 DO_NOT_TRACK=1 CI=true macparakeet-cli transcribe sample.wav` — confirm no telemetry POST (via `tcpdump` or proxy)

## ADRs

- **ADR-002** (local-first, opt-out telemetry, no audio/transcript content) — extended to the CLI/agent audience without amendment.
- **ADR-012** (self-hosted telemetry via Cloudflare Worker + D1) — payload and endpoint unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI config command (get/set/list) to persist telemetry preference across CLI and GUI installs; accepts common boolean synonyms.
  * Telemetry now honors DO_NOT_TRACK and auto-disables in CI; explicit env override to force on/off is supported.
  * Settings UI adds a link to telemetry documentation.

* **Documentation**
  * Updated telemetry docs with full override hierarchy, emitted event allowlist, and opt-out options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->