### PR TITLE
Harden meeting recording release paths

### DIFF
--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -2,6 +2,12 @@ import AppKit
 import MacParakeetCore
 import MacParakeetViewModels
 
+enum MeetingRecordingQuitState {
+    case starting
+    case recording
+    case finishing
+}
+
 @MainActor
 final class MeetingRecordingFlowCoordinator {
     var isMeetingRecordingActive: Bool {
@@ -10,6 +16,19 @@ final class MeetingRecordingFlowCoordinator {
             return false
         case .checkingPermissions, .starting, .recording, .stopping, .transcribing:
             return true
+        }
+    }
+
+    var quitState: MeetingRecordingQuitState? {
+        switch stateMachine.state {
+        case .idle, .finishing:
+            return nil
+        case .checkingPermissions, .starting:
+            return .starting
+        case .recording:
+            return .recording
+        case .stopping, .transcribing:
+            return .finishing
         }
     }
 
@@ -35,6 +54,7 @@ final class MeetingRecordingFlowCoordinator {
     private var autoDismissTask: Task<Void, Never>?
     private var pillPollingTask: Task<Void, Never>?
     private var transcriptObservationTask: Task<Void, Never>?
+    private var activeFlowSettlementWaiters: [CheckedContinuation<Void, Never>] = []
     private var completedTranscription: Transcription?
     private var currentMeetingOperationContext: ObservabilityOperationContext?
     private var currentMeetingTrigger: TelemetryMeetingRecordingTrigger?
@@ -108,6 +128,27 @@ final class MeetingRecordingFlowCoordinator {
         }
     }
 
+    func stopRecordingAndWaitForCompletion() async {
+        switch stateMachine.state {
+        case .checkingPermissions, .starting:
+            sendEvent(.cancelRequested)
+        default:
+            sendEvent(.stopRequested)
+        }
+        await waitForActiveFlowToSettle()
+        if let actionTask {
+            await actionTask.value
+        }
+    }
+
+    func discardRecordingAndWaitForCompletion() async {
+        sendEvent(.cancelRequested)
+        await waitForActiveFlowToSettle()
+        if let actionTask {
+            await actionTask.value
+        }
+    }
+
     /// Calendar-driven entry point. Marks the next start as auto-start so
     /// telemetry distinguishes it and pre-names the recording with the
     /// event title, then enters the normal start flow. No-op if a recording
@@ -156,9 +197,27 @@ final class MeetingRecordingFlowCoordinator {
         }
     }
 
+    private func waitForActiveFlowToSettle() async {
+        while isMeetingRecordingActive {
+            await withCheckedContinuation { continuation in
+                activeFlowSettlementWaiters.append(continuation)
+            }
+        }
+    }
+
     private func sendEvent(_ event: MeetingRecordingFlowEvent) {
         let effects = stateMachine.handle(event)
         executeEffects(effects)
+        resumeActiveFlowSettlementWaitersIfNeeded()
+    }
+
+    private func resumeActiveFlowSettlementWaitersIfNeeded() {
+        guard !isMeetingRecordingActive, !activeFlowSettlementWaiters.isEmpty else { return }
+        let waiters = activeFlowSettlementWaiters
+        activeFlowSettlementWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
     }
 
     private func executeEffects(_ effects: [MeetingRecordingFlowEffect]) {
@@ -408,6 +467,9 @@ final class MeetingRecordingFlowCoordinator {
         case .cancelRecording:
             let durationSeconds = Double(panelViewModel?.elapsedSeconds ?? 0)
             let notesVM = panelViewModel?.notesViewModel
+            let cancelledTrigger = currentMeetingTrigger ?? pendingTrigger
+            pendingTrigger = nil
+            pendingTitle = nil
             actionTask?.cancel()
             actionTask = Task { @MainActor in
                 // Stop the in-flight debounce so it can't fire against a
@@ -420,6 +482,7 @@ final class MeetingRecordingFlowCoordinator {
                 Telemetry.send(.meetingRecordingCancelled(durationSeconds: durationSeconds))
                 self.sendMeetingOperation(
                     outcome: .cancelled,
+                    trigger: cancelledTrigger,
                     stage: .cancel,
                     durationSeconds: durationSeconds
                 )

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -40,6 +40,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var meetingAutoStartCoordinator: MeetingAutoStartCoordinator?
     private var hasPresentedHotkeyUnavailableAlert = false
     private var environmentSetupTask: Task<Void, Never>?
+    private var meetingQuitTask: Task<Void, Never>?
 
     // MARK: - View Models
 
@@ -248,6 +249,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         // Don't quit when window closes — dictation/menu bar features stay available.
         false
+    }
+
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        guard meetingRecordingFlowCoordinator?.quitState != nil else {
+            return .terminateNow
+        }
+
+        guard meetingQuitTask == nil else {
+            return .terminateCancel
+        }
+
+        return presentActiveMeetingQuitAlert()
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows _: Bool) -> Bool {
@@ -478,6 +491,76 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         meetingRecordingFlowCoordinator?.toggleRecording(trigger: trigger)
+    }
+
+    private func presentActiveMeetingQuitAlert() -> NSApplication.TerminateReply {
+        guard let quitState = meetingRecordingFlowCoordinator?.quitState else {
+            return .terminateNow
+        }
+
+        NSApp.activate(ignoringOtherApps: true)
+
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+
+        switch quitState {
+        case .starting:
+            alert.messageText = "Meeting Recording Is Starting"
+            alert.informativeText = "Cancel the pending recording before quitting, or keep MacParakeet open."
+            alert.addButton(withTitle: "Cancel Recording & Quit")
+            alert.addButton(withTitle: "Cancel Quit")
+            if alert.buttons.indices.contains(0) {
+                alert.buttons[0].hasDestructiveAction = true
+            }
+            if alert.runModal() == .alertFirstButtonReturn {
+                finishMeetingThenQuit(discard: true)
+            }
+
+        case .recording:
+            alert.messageText = "Meeting Recording in Progress"
+            alert.informativeText = "End and transcribe the meeting before quitting, discard the recording, or keep MacParakeet open."
+            alert.addButton(withTitle: "End & Transcribe")
+            alert.addButton(withTitle: "Discard Recording")
+            alert.addButton(withTitle: "Cancel Quit")
+            if alert.buttons.indices.contains(1) {
+                alert.buttons[1].hasDestructiveAction = true
+            }
+            switch alert.runModal() {
+            case .alertFirstButtonReturn:
+                finishMeetingThenQuit(discard: false)
+            case .alertSecondButtonReturn:
+                finishMeetingThenQuit(discard: true)
+            default:
+                break
+            }
+
+        case .finishing:
+            alert.messageText = "Meeting Transcription in Progress"
+            alert.informativeText = "MacParakeet is saving the meeting. Finish transcription before quitting, or keep the app open."
+            alert.addButton(withTitle: "Finish & Quit")
+            alert.addButton(withTitle: "Cancel Quit")
+            if alert.runModal() == .alertFirstButtonReturn {
+                finishMeetingThenQuit(discard: false)
+            }
+        }
+
+        return .terminateCancel
+    }
+
+    private func finishMeetingThenQuit(discard: Bool) {
+        guard let coordinator = meetingRecordingFlowCoordinator else { return }
+
+        meetingQuitTask?.cancel()
+        meetingQuitTask = Task { @MainActor [weak self, coordinator] in
+            if discard {
+                await coordinator.discardRecordingAndWaitForCompletion()
+            } else {
+                await coordinator.stopRecordingAndWaitForCompletion()
+            }
+            guard !Task.isCancelled else { return }
+            self?.meetingQuitTask = nil
+            NSApp.terminate(nil)
+        }
     }
 
     // MARK: - Alerts

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelView.swift
@@ -16,9 +16,8 @@ struct MeetingRecordingPanelView: View {
             paneContent
             // Notes and Ask own their own bottom UI (Notes shows a soft-cap
             // footer when relevant; Ask owns its composer + follow-up pills).
-            // The Stop control lives on the floating recording pill, so the
-            // panel footer is reserved for transcript-specific controls
-            // (Copy, auto-scroll toggle).
+            // The footer stays transcript-specific (Copy, auto-scroll toggle);
+            // the stop control is in the always-visible header.
             if viewModel.selectedTab == .transcript {
                 Divider()
                 footer
@@ -154,6 +153,12 @@ struct MeetingRecordingPanelView: View {
                     Text("\(viewModel.wordCount) words")
                         .font(.system(size: 10, weight: .regular).monospacedDigit())
                         .foregroundStyle(DesignSystem.Colors.textTertiary.opacity(0.8))
+                }
+
+                if viewModel.canStop {
+                    StopRecordingButton {
+                        viewModel.onStop?()
+                    }
                 }
             }
 
@@ -311,98 +316,6 @@ struct BreathingSeedOfLifeView: View {
     }
 }
 
-/// Stop button with inline "End?" confirmation.
-/// First click shows "End?" label. Second click within 3s confirms.
-/// Auto-reverts to icon if not confirmed.
-private struct StopRecordingButton: View {
-    var onStop: () -> Void
-
-    @State private var isHovered = false
-    @State private var confirming = false
-    @State private var countdownProgress: CGFloat = 1.0
-    @State private var revertTask: Task<Void, Never>?
-
-    var body: some View {
-        Group {
-            if confirming {
-                // Confirmation state — "End?" text button
-                Button {
-                    revertTask?.cancel()
-                    confirming = false
-                    onStop()
-                } label: {
-                    Text("Click to end")
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(DesignSystem.Colors.errorRed)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 5)
-                        .background(
-                            Capsule()
-                                .fill(DesignSystem.Colors.surfaceElevated)
-                                .overlay(
-                                    GeometryReader { geo in
-                                        Capsule()
-                                            .fill(DesignSystem.Colors.errorRed.opacity(0.2))
-                                            .frame(width: geo.size.width * countdownProgress)
-                                    }
-                                    .clipShape(Capsule())
-                                )
-                                .overlay(
-                                    Capsule()
-                                        .stroke(DesignSystem.Colors.errorRed.opacity(0.3), lineWidth: 0.5)
-                                )
-                        )
-                }
-                .buttonStyle(.plain)
-                .transition(.scale(scale: 0.8).combined(with: .opacity))
-            } else {
-                // Default state — stop square icon
-                RoundedRectangle(cornerRadius: 4)
-                    .fill(isHovered ? DesignSystem.Colors.errorRed : DesignSystem.Colors.textTertiary.opacity(0.6))
-                    .frame(width: 13, height: 13)
-                    .padding(9)
-                    .background(
-                        Circle()
-                            .fill(isHovered
-                                ? DesignSystem.Colors.errorRed.opacity(0.15)
-                                : DesignSystem.Colors.surfaceElevated
-                            )
-                            .overlay(
-                                Circle()
-                                    .stroke(isHovered ? DesignSystem.Colors.errorRed.opacity(0.3) : .clear, lineWidth: 0.5)
-                            )
-                    )
-                    .shadow(color: isHovered ? DesignSystem.Colors.errorRed.opacity(0.25) : .clear, radius: 6)
-                    .scaleEffect(isHovered ? 1.08 : 1.0)
-                    .animation(.easeOut(duration: 0.15), value: isHovered)
-                    .onHover { hovering in
-                        isHovered = hovering
-                    }
-                    .onTapGesture {
-                        countdownProgress = 1.0
-                        withAnimation(.spring(response: 0.25, dampingFraction: 0.8)) {
-                            confirming = true
-                        }
-                        withAnimation(.linear(duration: 3)) {
-                            countdownProgress = 0
-                        }
-                        revertTask?.cancel()
-                        revertTask = Task { @MainActor in
-                            try? await Task.sleep(for: .seconds(3))
-                            guard !Task.isCancelled else { return }
-                            withAnimation(.easeOut(duration: 0.2)) {
-                                confirming = false
-                            }
-                        }
-                    }
-                    .transition(.scale(scale: 0.8).combined(with: .opacity))
-            }
-        }
-        .help(confirming ? "Click to confirm" : "End recording")
-        .onDisappear { revertTask?.cancel() }
-    }
-}
-
 /// Polished footer button with hover background and press feedback.
 private struct FooterButton: View {
     let label: String
@@ -499,4 +412,3 @@ private struct FooterIconButton: View {
         }
     }
 }
-

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPillView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPillView.swift
@@ -149,13 +149,24 @@ struct MeetingRecordingPillView: View {
     }
 
     private var sacredRecordingPill: some View {
-        VStack(spacing: 0) {
-            MerkabaPillIcon(
-                isAnimating: true,
-                audioLevel: max(viewModel.micLevel, viewModel.systemLevel)
-            )
+        HStack(spacing: 8) {
+            Button {
+                onTap?()
+            } label: {
+                MerkabaPillIcon(
+                    isAnimating: true,
+                    audioLevel: max(viewModel.micLevel, viewModel.systemLevel)
+                )
+            }
+            .buttonStyle(.plain)
+            .help("Open meeting panel")
+
+            StopRecordingButton {
+                viewModel.onStop?()
+            }
         }
-        .padding(.horizontal, 10)
+        .padding(.leading, 10)
+        .padding(.trailing, 6)
         .padding(.vertical, 6)
         .background(
             Capsule()
@@ -172,9 +183,6 @@ struct MeetingRecordingPillView: View {
         .contentShape(Capsule())
         .onHover { hovering in
             isHovered = hovering
-        }
-        .onTapGesture {
-            onTap?()
         }
         .scaleEffect(isHovered ? 1.05 : 1.0)
         .animation(DesignSystem.Animation.meetingPillHover, value: isHovered)

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingStopButton.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingStopButton.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+
+/// Stop button with inline confirmation.
+/// First click asks for confirmation; second click within 3 seconds stops.
+struct StopRecordingButton: View {
+    var onStop: () -> Void
+
+    @State private var isHovered = false
+    @State private var confirming = false
+    @State private var countdownProgress: CGFloat = 1.0
+    @State private var revertTask: Task<Void, Never>?
+
+    var body: some View {
+        Group {
+            if confirming {
+                Button {
+                    revertTask?.cancel()
+                    confirming = false
+                    onStop()
+                } label: {
+                    Text("Click to end")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(DesignSystem.Colors.errorRed)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .background(
+                            Capsule()
+                                .fill(DesignSystem.Colors.surfaceElevated)
+                                .overlay(
+                                    GeometryReader { geo in
+                                        Capsule()
+                                            .fill(DesignSystem.Colors.errorRed.opacity(0.2))
+                                            .frame(width: geo.size.width * countdownProgress)
+                                    }
+                                    .clipShape(Capsule())
+                                )
+                                .overlay(
+                                    Capsule()
+                                        .stroke(DesignSystem.Colors.errorRed.opacity(0.3), lineWidth: 0.5)
+                                )
+                        )
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Confirm ending recording")
+                .transition(.scale(scale: 0.8).combined(with: .opacity))
+            } else {
+                Button {
+                    beginConfirmation()
+                } label: {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(isHovered ? DesignSystem.Colors.errorRed : DesignSystem.Colors.textTertiary.opacity(0.6))
+                        .frame(width: 13, height: 13)
+                        .padding(9)
+                        .background(
+                            Circle()
+                                .fill(isHovered
+                                    ? DesignSystem.Colors.errorRed.opacity(0.15)
+                                    : DesignSystem.Colors.surfaceElevated
+                                )
+                                .overlay(
+                                    Circle()
+                                        .stroke(
+                                            isHovered ? DesignSystem.Colors.errorRed.opacity(0.3) : .clear,
+                                            lineWidth: 0.5
+                                        )
+                                )
+                        )
+                        .shadow(color: isHovered ? DesignSystem.Colors.errorRed.opacity(0.25) : .clear, radius: 6)
+                        .scaleEffect(isHovered ? 1.08 : 1.0)
+                        .animation(.easeOut(duration: 0.15), value: isHovered)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("End recording")
+                .onHover { hovering in
+                    isHovered = hovering
+                }
+                .transition(.scale(scale: 0.8).combined(with: .opacity))
+            }
+        }
+        .help(confirming ? "Click to confirm" : "End recording")
+        .onDisappear { revertTask?.cancel() }
+    }
+
+    private func beginConfirmation() {
+        countdownProgress = 1.0
+        withAnimation(.spring(response: 0.25, dampingFraction: 0.8)) {
+            confirming = true
+        }
+        withAnimation(.linear(duration: 3)) {
+            countdownProgress = 0
+        }
+        revertTask?.cancel()
+        revertTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(3))
+            guard !Task.isCancelled else { return }
+            withAnimation(.easeOut(duration: 0.2)) {
+                confirming = false
+            }
+        }
+    }
+}

--- a/Sources/MacParakeetCore/Audio/AudioFileConverter.swift
+++ b/Sources/MacParakeetCore/Audio/AudioFileConverter.swift
@@ -3,7 +3,17 @@ import os
 
 public protocol AudioFileConverting: Sendable {
     func convert(fileURL: URL) async throws -> URL
-    func mixToM4A(inputURLs: [URL], outputURL: URL) async throws
+    func mixToM4A(
+        inputURLs: [URL],
+        outputURL: URL,
+        sourceAlignment: MeetingSourceAlignment?
+    ) async throws
+}
+
+public extension AudioFileConverting {
+    func mixToM4A(inputURLs: [URL], outputURL: URL) async throws {
+        try await mixToM4A(inputURLs: inputURLs, outputURL: outputURL, sourceAlignment: nil)
+    }
 }
 
 /// Converts audio/video files to 16kHz mono WAV using FFmpeg subprocess.
@@ -64,7 +74,11 @@ public final class AudioFileConverter: AudioFileConverting, Sendable {
     /// For mic+system dual input, preserve channel separation as stereo:
     /// channel 1 = microphone, channel 2 = system.
     /// For single-input sessions, output a mono AAC file.
-    public func mixToM4A(inputURLs: [URL], outputURL: URL) async throws {
+    public func mixToM4A(
+        inputURLs: [URL],
+        outputURL: URL,
+        sourceAlignment: MeetingSourceAlignment? = nil
+    ) async throws {
         guard !inputURLs.isEmpty else {
             throw AudioProcessorError.conversionFailed("No audio files to mix")
         }
@@ -75,7 +89,8 @@ public final class AudioFileConverter: AudioFileConverting, Sendable {
             try await runFFmpegMix(
                 ffmpegPath: primaryPath,
                 inputURLs: inputURLs,
-                outputURL: outputURL
+                outputURL: outputURL,
+                sourceAlignment: sourceAlignment
             )
         } catch let error as AudioProcessorError {
             guard case .conversionFailed(let reason) = error,
@@ -87,7 +102,8 @@ public final class AudioFileConverter: AudioFileConverting, Sendable {
             try await runFFmpegMix(
                 ffmpegPath: fallbackPath,
                 inputURLs: inputURLs,
-                outputURL: outputURL
+                outputURL: outputURL,
+                sourceAlignment: sourceAlignment
             )
         }
     }
@@ -106,7 +122,11 @@ public final class AudioFileConverter: AudioFileConverting, Sendable {
         ]
     }
 
-    public func ffmpegMixArguments(inputPaths: [String], outputPath: String) -> [String] {
+    public func ffmpegMixArguments(
+        inputPaths: [String],
+        outputPath: String,
+        sourceAlignment: MeetingSourceAlignment? = nil
+    ) -> [String] {
         var args = ["-nostdin"]
         for inputPath in inputPaths {
             args.append(contentsOf: ["-i", inputPath])
@@ -114,9 +134,14 @@ public final class AudioFileConverter: AudioFileConverting, Sendable {
 
         let outputArgs: [String]
         if inputPaths.count == 2 {
+            let microphoneDelayMs = max(0, sourceAlignment?.microphone?.startOffsetMs ?? 0)
+            let systemDelayMs = max(0, sourceAlignment?.system?.startOffsetMs ?? 0)
             args.append(contentsOf: [
                 "-filter_complex",
-                "[0:a]pan=stereo|c0=c0|c1=0*c0[a0];[1:a]pan=stereo|c0=0*c0|c1=c0[a1];[a0][a1]amix=inputs=2:duration=longest:normalize=0[a]",
+                dualSourceMixFilter(
+                    microphoneDelayMs: microphoneDelayMs,
+                    systemDelayMs: systemDelayMs
+                ),
                 "-map", "[a]"
             ])
             outputArgs = [
@@ -150,6 +175,19 @@ public final class AudioFileConverter: AudioFileConverting, Sendable {
             "-y", outputPath,
         ])
         return args
+    }
+
+    private func dualSourceMixFilter(microphoneDelayMs: Int, systemDelayMs: Int) -> String {
+        [
+            "[0:a]pan=stereo|c0=c0|c1=0*c0,adelay=\(stereoDelay(microphoneDelayMs))[a0]",
+            "[1:a]pan=stereo|c0=0*c0|c1=c0,adelay=\(stereoDelay(systemDelayMs))[a1]",
+            "[a0][a1]amix=inputs=2:duration=longest:normalize=0[a]",
+        ]
+        .joined(separator: ";")
+    }
+
+    private func stereoDelay(_ delayMs: Int) -> String {
+        "\(delayMs)|\(delayMs)"
     }
 
     // MARK: - Private
@@ -211,7 +249,8 @@ public final class AudioFileConverter: AudioFileConverting, Sendable {
     private func runFFmpegMix(
         ffmpegPath: String,
         inputURLs: [URL],
-        outputURL: URL
+        outputURL: URL,
+        sourceAlignment: MeetingSourceAlignment?
     ) async throws {
         // The mix output URL is supplied by the caller, but the contract on
         // failure is "no partial output left behind" -- callers can re-run
@@ -229,7 +268,8 @@ public final class AudioFileConverter: AudioFileConverting, Sendable {
         process.executableURL = URL(fileURLWithPath: ffmpegPath)
         process.arguments = ffmpegMixArguments(
             inputPaths: inputURLs.map(\.path),
-            outputPath: outputURL.path
+            outputPath: outputURL.path,
+            sourceAlignment: sourceAlignment
         )
 
         let tempDir = try ensureTempDir()

--- a/Sources/MacParakeetCore/MeetingRecordingFlow/MeetingRecordingFlowStateMachine.swift
+++ b/Sources/MacParakeetCore/MeetingRecordingFlow/MeetingRecordingFlowStateMachine.swift
@@ -81,6 +81,10 @@ public struct MeetingRecordingFlowStateMachine: Equatable, Sendable {
             state = .idle
             return [.updateMenuBar(.idle), .presentPermissionAlert(reason)]
 
+        case (.checkingPermissions, .cancelRequested):
+            state = .idle
+            return [.cancelRecording, .hidePill, .updateMenuBar(.idle)]
+
         case (.starting, .recordingStarted(let gen)):
             guard gen == generation else { return [] }
             state = .recording

--- a/Sources/MacParakeetCore/Services/MeetingRecordingRecoveryService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecordingRecoveryService.swift
@@ -190,11 +190,11 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
         do {
             try await audioConverter.mixToM4A(
                 inputURLs: recoveredSources.map(\.url),
-                outputURL: mixedURL
+                outputURL: mixedURL,
+                sourceAlignment: sourceAlignment
             )
         } catch {
-            logger.error("meeting_recovery_mix_failed session=\(lock.sessionId.uuidString, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
-            throw MeetingRecordingRecoveryError.mixFailed(error.localizedDescription)
+            logger.error("meeting_recovery_mix_failed_nonfatal session=\(lock.sessionId.uuidString, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
         }
 
         // Clamp the wall-clock fallback to non-negative. If the user's clock

--- a/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
@@ -378,12 +378,15 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         }
 
         do {
-            try await audioConverter.mixToM4A(inputURLs: inputURLs, outputURL: session.mixedAudioURL)
+            try await audioConverter.mixToM4A(
+                inputURLs: inputURLs,
+                outputURL: session.mixedAudioURL,
+                sourceAlignment: sourceAlignment
+            )
         } catch {
-            await liveChunkTranscriber.finishSession()
-            await releaseSpeechEngineLease()
-            cleanupState()
-            throw MeetingAudioError.mixFailed(error.localizedDescription)
+            logger.error(
+                "meeting_mix_failed_nonfatal session=\(session.id.uuidString, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
+            )
         }
 
         let finalNotes = currentNotes

--- a/Tests/MacParakeetTests/Audio/AudioFileConverterTests.swift
+++ b/Tests/MacParakeetTests/Audio/AudioFileConverterTests.swift
@@ -60,12 +60,44 @@ final class AudioFileConverterTests: XCTestCase {
 
         XCTAssertTrue(args.contains("-filter_complex"))
         XCTAssertTrue(args.contains(
-            "[0:a]pan=stereo|c0=c0|c1=0*c0[a0];[1:a]pan=stereo|c0=0*c0|c1=c0[a1];[a0][a1]amix=inputs=2:duration=longest:normalize=0[a]"
+            "[0:a]pan=stereo|c0=c0|c1=0*c0,adelay=0|0[a0];[1:a]pan=stereo|c0=0*c0|c1=c0,adelay=0|0[a1];[a0][a1]amix=inputs=2:duration=longest:normalize=0[a]"
         ))
         XCTAssertTrue(args.contains("-map"))
         XCTAssertTrue(args.contains("[a]"))
         XCTAssertTrue(args.contains("-ac"))
         XCTAssertTrue(args.contains("2"))
+    }
+
+    func testFFmpegMixArgumentsApplySourceAlignmentDelays() {
+        let converter = AudioFileConverter()
+        let alignment = MeetingSourceAlignment(
+            meetingOriginHostTime: nil,
+            microphone: .init(
+                firstHostTime: nil,
+                lastHostTime: nil,
+                startOffsetMs: 0,
+                writtenFrameCount: 48_000,
+                sampleRate: 48_000
+            ),
+            system: .init(
+                firstHostTime: nil,
+                lastHostTime: nil,
+                startOffsetMs: 150,
+                writtenFrameCount: 48_000,
+                sampleRate: 48_000
+            )
+        )
+
+        let args = converter.ffmpegMixArguments(
+            inputPaths: ["/tmp/mic.m4a", "/tmp/system.m4a"],
+            outputPath: "/tmp/meeting.m4a",
+            sourceAlignment: alignment
+        )
+
+        XCTAssertTrue(args.contains("-filter_complex"))
+        XCTAssertTrue(args.contains(
+            "[0:a]pan=stereo|c0=c0|c1=0*c0,adelay=0|0[a0];[1:a]pan=stereo|c0=0*c0|c1=c0,adelay=150|150[a1];[a0][a1]amix=inputs=2:duration=longest:normalize=0[a]"
+        ))
     }
 
     func testFFmpegMixArgumentsKeepLongestDualSourceDuration() {

--- a/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowStateMachineTests.swift
+++ b/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowStateMachineTests.swift
@@ -190,6 +190,16 @@ final class MeetingRecordingFlowStateMachineTests: XCTestCase {
         XCTAssertEqual(effects, [.cancelRecording, .hidePill, .updateMenuBar(.idle)])
     }
 
+    func testCancelFromCheckingPermissionsDiscardsPendingStart() {
+        var machine = MeetingRecordingFlowStateMachine()
+        _ = machine.handle(.startRequested)
+
+        let effects = machine.handle(.cancelRequested)
+
+        XCTAssertEqual(machine.state, .idle)
+        XCTAssertEqual(effects, [.cancelRecording, .hidePill, .updateMenuBar(.idle)])
+    }
+
     func testCancelFromTranscribingIsIgnored() {
         var machine = MeetingRecordingFlowStateMachine()
         _ = machine.handle(.startRequested)

--- a/Tests/MacParakeetTests/Services/MeetingRecordingRecoveryServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecordingRecoveryServiceTests.swift
@@ -71,6 +71,23 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
         }
     }
 
+    func testRecoverContinuesWhenMixFails() async throws {
+        let fixture = try makeRecoverableSession()
+        audioConverter.errorToThrow = RecoveryTestError.mixFailed
+
+        let recovered = try await recoveryService.recover(fixture.lock)
+
+        XCTAssertTrue(recovered.recoveredFromCrash)
+        XCTAssertNil(try lockStore.read(folderURL: fixture.folderURL))
+        XCTAssertEqual(transcriptionService.recordings.count, 1)
+        XCTAssertEqual(audioConverter.mixes.count, 1)
+        XCTAssertEqual(audioConverter.mixes.first?.output, fixture.folderURL.appendingPathComponent("meeting.m4a"))
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: fixture.folderURL.appendingPathComponent("meeting.m4a").path),
+            "failed playback mix should not block source-based transcription"
+        )
+    }
+
     func testRecoverRetryReusesSavedTranscriptWhenLockDeletePreviouslyFailed() async throws {
         let fixture = try makeRecoverableSession()
         lockStore.deleteErrorsRemaining = 1
@@ -484,11 +501,15 @@ private final class RecoveryMockAudioConverter: AudioFileConverting, @unchecked 
 
     func convert(fileURL: URL) async throws -> URL { fileURL }
 
-    func mixToM4A(inputURLs: [URL], outputURL: URL) async throws {
-        if let errorToThrow { throw errorToThrow }
+    func mixToM4A(
+        inputURLs: [URL],
+        outputURL: URL,
+        sourceAlignment: MeetingSourceAlignment?
+    ) async throws {
         lock.withLock {
             mixes.append((inputURLs, outputURL))
         }
+        if let errorToThrow { throw errorToThrow }
         FileManager.default.createFile(atPath: outputURL.path, contents: Data("mixed".utf8))
     }
 }

--- a/Tests/MacParakeetTests/Services/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecordingServiceTests.swift
@@ -291,7 +291,7 @@ final class MeetingRecordingServiceTests: XCTestCase {
         try? FileManager.default.removeItem(at: output.folderURL)
     }
 
-    func testStopRecordingKeepsLockWhenMixFails() async throws {
+    func testStopRecordingReturnsOutputAndKeepsLockWhenMixFails() async throws {
         let captureService = MockMeetingAudioCaptureService()
         let lockStore = RecordingLockFileStore()
         let service = MeetingRecordingService(
@@ -309,13 +309,14 @@ final class MeetingRecordingServiceTests: XCTestCase {
             AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
         ))
 
-        do {
-            _ = try await service.stopRecording()
-            XCTFail("Expected mix failure")
-        } catch {
-            XCTAssertTrue(lockStore.deletes.isEmpty)
-            try? FileManager.default.removeItem(at: writtenFolder)
-        }
+        let output = try await service.stopRecording()
+        defer { try? FileManager.default.removeItem(at: writtenFolder) }
+
+        XCTAssertEqual(output.folderURL, writtenFolder)
+        XCTAssertNotNil(output.sourceAlignment.microphone)
+        XCTAssertNil(output.sourceAlignment.system)
+        XCTAssertTrue(lockStore.deletes.isEmpty)
+        XCTAssertEqual(lockStore.writes.last?.file.state, .awaitingTranscription)
     }
 
     func testCancelRecordingDeletesLockAndSessionFolder() async throws {
@@ -719,6 +720,7 @@ final class MeetingRecordingServiceTests: XCTestCase {
             audioConverter.capturedMixedInputs(),
             [output.microphoneAudioURL, output.systemAudioURL]
         )
+        XCTAssertEqual(audioConverter.capturedSourceAlignment(), output.sourceAlignment)
     }
 
     func testAsymmetricSourceCadenceDoesNotInflateSystemChunkTimeline() async throws {
@@ -1171,7 +1173,11 @@ private final class MockMeetingAudioFileConverter: AudioFileConverting, @uncheck
         fileURL
     }
 
-    func mixToM4A(inputURLs: [URL], outputURL: URL) async throws {
+    func mixToM4A(
+        inputURLs: [URL],
+        outputURL: URL,
+        sourceAlignment: MeetingSourceAlignment?
+    ) async throws {
         FileManager.default.createFile(atPath: outputURL.path, contents: Data("mixed".utf8))
     }
 }
@@ -1181,7 +1187,11 @@ private final class ThrowingMeetingAudioFileConverter: AudioFileConverting, @unc
         fileURL
     }
 
-    func mixToM4A(inputURLs: [URL], outputURL: URL) async throws {
+    func mixToM4A(
+        inputURLs: [URL],
+        outputURL: URL,
+        sourceAlignment: MeetingSourceAlignment?
+    ) async throws {
         throw MeetingAudioError.mixFailed("simulated")
     }
 }
@@ -1189,20 +1199,30 @@ private final class ThrowingMeetingAudioFileConverter: AudioFileConverting, @unc
 private final class RecordingMeetingAudioFileConverter: AudioFileConverting, @unchecked Sendable {
     private let lock = NSLock()
     private var mixedInputs: [URL] = []
+    private var mixedSourceAlignment: MeetingSourceAlignment?
 
     func convert(fileURL: URL) async throws -> URL {
         fileURL
     }
 
-    func mixToM4A(inputURLs: [URL], outputURL: URL) async throws {
+    func mixToM4A(
+        inputURLs: [URL],
+        outputURL: URL,
+        sourceAlignment: MeetingSourceAlignment?
+    ) async throws {
         lock.withLock {
             mixedInputs = inputURLs
+            mixedSourceAlignment = sourceAlignment
         }
         FileManager.default.createFile(atPath: outputURL.path, contents: Data("mixed".utf8))
     }
 
     func capturedMixedInputs() -> [URL] {
         lock.withLock { mixedInputs }
+    }
+
+    func capturedSourceAlignment() -> MeetingSourceAlignment? {
+        lock.withLock { mixedSourceAlignment }
     }
 }
 


### PR DESCRIPTION
## Summary
- Makes `meeting.m4a` creation best-effort during normal stop and crash recovery, so valid `microphone.m4a` / `system.m4a` sources still proceed to final meeting transcription.
- Applies microphone/system source alignment to FFmpeg dual-channel mixing with `adelay`, preserving playback/export timing parity with transcript timestamps.
- Adds graceful Quit handling for active meeting startup, recording, and transcription states.
- Surfaces the shared two-click stop control in the panel header and recording pill; the idle stop affordance is now a semantic `Button`.

## Flow
```
mic.m4a      ----\
system.m4a   -----> best-effort meeting.m4a
   \--------------> source-based final STT
```

## Review Status
- Addressed valid reviewer comments for the state-settlement wait, FFmpeg filter readability, stop-button accessibility, and recovery mix-failure test coverage.
- Reviewed the NSTrackingArea tooltip suggestions and intentionally did not add custom tooltip plumbing in this release PR; the tooltip is advisory, while the visible semantic stop control is the release-critical fix.
- Final fresh-eye review found no blocking issues.

## Tests
- `swift test --filter 'MeetingRecordingFlowStateMachineTests|AudioFileConverterTests|MeetingRecordingServiceTests|MeetingRecordingRecoveryServiceTests'` passed: 76 tests.
- `swift test` passed locally: 1926 XCTest tests + 16 Swift Testing tests.
- `git diff --check origin/main...HEAD` passed.

## Notes
- The mixed playback/export artifact may be absent if FFmpeg fails, but transcription now proceeds from source audio as intended.
- Quit no longer relies on crash recovery for the normal active-recording path.
