### PR TITLE
Harden Whisper language and meeting startup routing

### DIFF
--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -53,7 +53,7 @@ struct TranscribeCommand: AsyncParsableCommand {
     @Option(help: "Speech engine: parakeet, whisper.")
     var engine: TranscribeSpeechEngine = .parakeet
 
-    @Option(help: "Language hint for Whisper, as a BCP-47/language code such as ko or en. Parakeet ignores this flag.")
+    @Option(help: "Language hint for Whisper, as a Whisper code such as ko or en. Parakeet ignores this flag.")
     var language: String?
 
     @Option(help: "Downloaded YouTube audio retention: app-default, keep, delete.")

--- a/Sources/MacParakeetCore/STT/WhisperEngine.swift
+++ b/Sources/MacParakeetCore/STT/WhisperEngine.swift
@@ -117,33 +117,34 @@ public actor WhisperEngine: STTTranscribing {
                 throw STTError.modelNotLoaded
             }
 
-            let decodeOptions = Self.makeDecodingOptions(language: language)
+            let requestedLanguage = SpeechEnginePreference.normalizeLanguage(language)
+            let decodeOptions = Self.makeDecodingOptions(language: requestedLanguage)
 
             onProgress?(0, 100)
             let callback: TranscriptionCallback = { _ in
                 onProgress?(50, 100)
                 return true
             }
-            let results = await whisperKit.transcribeWithResults(
+            let result = try await Self.transcribeWithWhisperKit(
+                whisperKit,
                 audioPaths: [audioURL.path],
                 decodeOptions: decodeOptions,
                 callback: callback
             )
 
-            guard let first = results.first else {
-                throw STTError.invalidResponse
+            if requestedLanguage != nil, Self.shouldRetryWithoutForcedLanguage(result) {
+                let fallback = try await Self.transcribeWithWhisperKit(
+                    whisperKit,
+                    audioPaths: [audioURL.path],
+                    decodeOptions: Self.makeDecodingOptions(language: nil),
+                    callback: callback
+                )
+                onProgress?(100, 100)
+                return Self.makeResult(from: fallback, modelVariant: modelVariant)
             }
 
-            let partialResults = try first.get()
-            let merged = TranscriptionUtilities.mergeTranscriptionResults(partialResults)
             onProgress?(100, 100)
-            return STTResult(
-                text: merged.text,
-                words: Self.mapWordTimings(merged.allWords),
-                language: merged.language,
-                engine: .whisper,
-                engineVariant: modelVariant
-            )
+            return Self.makeResult(from: result, modelVariant: modelVariant)
         } catch {
             throw try Self.mapTranscriptionError(error)
         }
@@ -242,12 +243,44 @@ public actor WhisperEngine: STTTranscribing {
         let resolvedLanguage = SpeechEnginePreference.normalizeLanguage(language)
         return DecodingOptions(
             language: resolvedLanguage,
-            // WhisperKit v0.18.0 can silently return empty text for explicit
-            // language hints when prefill prompt is enabled.
-            usePrefillPrompt: false,
+            usePrefillPrompt: resolvedLanguage != nil,
             detectLanguage: resolvedLanguage == nil,
             wordTimestamps: true
         )
+    }
+
+    private static func transcribeWithWhisperKit(
+        _ whisperKit: WhisperKit,
+        audioPaths: [String],
+        decodeOptions: DecodingOptions,
+        callback: TranscriptionCallback
+    ) async throws -> TranscriptionResult {
+        let results = await whisperKit.transcribeWithResults(
+            audioPaths: audioPaths,
+            decodeOptions: decodeOptions,
+            callback: callback
+        )
+
+        guard let first = results.first else {
+            throw STTError.invalidResponse
+        }
+
+        let partialResults = try first.get()
+        return TranscriptionUtilities.mergeTranscriptionResults(partialResults)
+    }
+
+    private static func makeResult(from merged: TranscriptionResult, modelVariant: String) -> STTResult {
+        STTResult(
+            text: merged.text,
+            words: Self.mapWordTimings(merged.allWords),
+            language: merged.language,
+            engine: .whisper,
+            engineVariant: modelVariant
+        )
+    }
+
+    static func shouldRetryWithoutForcedLanguage(_ result: TranscriptionResult) -> Bool {
+        result.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && result.allWords.isEmpty
     }
 
     static func mapWordTimings(_ words: [WordTiming]) -> [TimestampedWord] {

--- a/Sources/MacParakeetCore/STT/WhisperEngine.swift
+++ b/Sources/MacParakeetCore/STT/WhisperEngine.swift
@@ -118,30 +118,18 @@ public actor WhisperEngine: STTTranscribing {
             }
 
             let requestedLanguage = SpeechEnginePreference.normalizeLanguage(language)
-            let decodeOptions = Self.makeDecodingOptions(language: requestedLanguage)
 
             onProgress?(0, 100)
             let callback: TranscriptionCallback = { _ in
                 onProgress?(50, 100)
                 return true
             }
-            let result = try await Self.transcribeWithWhisperKit(
+            let result = try await Self.transcribeWithLanguageFallback(
                 whisperKit,
-                audioPaths: [audioURL.path],
-                decodeOptions: decodeOptions,
+                audioPath: audioURL.path,
+                requestedLanguage: requestedLanguage,
                 callback: callback
             )
-
-            if requestedLanguage != nil, Self.shouldRetryWithoutForcedLanguage(result) {
-                let fallback = try await Self.transcribeWithWhisperKit(
-                    whisperKit,
-                    audioPaths: [audioURL.path],
-                    decodeOptions: Self.makeDecodingOptions(language: nil),
-                    callback: callback
-                )
-                onProgress?(100, 100)
-                return Self.makeResult(from: fallback, modelVariant: modelVariant)
-            }
 
             onProgress?(100, 100)
             return Self.makeResult(from: result, modelVariant: modelVariant)
@@ -246,6 +234,31 @@ public actor WhisperEngine: STTTranscribing {
             usePrefillPrompt: resolvedLanguage != nil,
             detectLanguage: resolvedLanguage == nil,
             wordTimestamps: true
+        )
+    }
+
+    private static func transcribeWithLanguageFallback(
+        _ whisperKit: WhisperKit,
+        audioPath: String,
+        requestedLanguage: String?,
+        callback: TranscriptionCallback
+    ) async throws -> TranscriptionResult {
+        let result = try await transcribeWithWhisperKit(
+            whisperKit,
+            audioPaths: [audioPath],
+            decodeOptions: makeDecodingOptions(language: requestedLanguage),
+            callback: callback
+        )
+
+        guard requestedLanguage != nil, shouldRetryWithoutForcedLanguage(result) else {
+            return result
+        }
+
+        return try await transcribeWithWhisperKit(
+            whisperKit,
+            audioPaths: [audioPath],
+            decodeOptions: makeDecodingOptions(language: nil),
+            callback: callback
         )
     }
 

--- a/Sources/MacParakeetCore/Services/LiveChunkTranscriber.swift
+++ b/Sources/MacParakeetCore/Services/LiveChunkTranscriber.swift
@@ -6,6 +6,7 @@ actor LiveChunkTranscriber {
     struct SessionContext: Sendable {
         let id: UUID
         let chunkFolderURL: URL
+        let speechEngine: SpeechEngineSelection
     }
 
     struct OrderedResult: Sendable {
@@ -133,6 +134,21 @@ actor LiveChunkTranscriber {
             .appendingPathComponent("\(source.rawValue)-\(chunk.startMs)-\(chunk.endMs).wav")
         try writeChunkAudio(samples: chunk.samples, to: chunkURL)
         defer { try? FileManager.default.removeItem(at: chunkURL) }
+        if let routedTranscriber = sttTranscriber as? any SpeechEngineRoutedTranscribing {
+            return try await routedTranscriber.transcribe(
+                audioPath: chunkURL.path,
+                job: .meetingLiveChunk,
+                speechEngine: context.speechEngine,
+                onProgress: nil
+            )
+        }
+
+        guard context.speechEngine == SpeechEngineSelection(engine: .parakeet) else {
+            throw STTError.engineStartFailed(
+                "Pinned \(context.speechEngine.engine.rawValue) speech engine cannot be honored by this transcriber."
+            )
+        }
+
         return try await sttTranscriber.transcribe(
             audioPath: chunkURL.path,
             job: .meetingLiveChunk,

--- a/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
@@ -283,8 +283,32 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         await finalizeWriter(writer)
         await releaseSpeechEngineLease()
         cleanupState()
-        try? lockFileStore.delete(folderURL: folderURL)
-        try? fileManager.removeItem(at: folderURL)
+
+        do {
+            try lockFileStore.delete(folderURL: folderURL)
+        } catch {
+            logFailedStartCleanupError(operation: "delete lock", error: error)
+        }
+
+        do {
+            try fileManager.removeItem(at: folderURL)
+        } catch {
+            if !isMissingFileError(error) {
+                logFailedStartCleanupError(operation: "remove folder", error: error)
+            }
+        }
+    }
+
+    private func logFailedStartCleanupError(operation: String, error: Error) {
+        let nsError = error as NSError
+        logger.warning(
+            "Meeting failed-start cleanup \(operation, privacy: .public) failed: \(nsError.domain, privacy: .public)#\(nsError.code, privacy: .public)"
+        )
+    }
+
+    private func isMissingFileError(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        return nsError.domain == NSCocoaErrorDomain && nsError.code == NSFileNoSuchFileError
     }
 
     private func validateStartStillCurrent(_ session: Session) async throws {

--- a/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
@@ -202,7 +202,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         let now = Date()
         let speechEngineLease = await speechEngineSessionManager?.beginSpeechEngineSession()
         currentSpeechEngineLease = speechEngineLease
-        let speechEngine = speechEngineLease?.selection ?? SpeechEngineSelection.current()
+        let speechEngine = speechEngineLease?.selection ?? SpeechEngineSelection(engine: .parakeet)
         let session = Session(
             id: sessionID,
             displayName: Self.resolveDisplayName(title: title, fallbackDate: now),
@@ -228,41 +228,36 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             )
             try lockFileStore.write(initialLock, folderURL: session.folderURL)
             currentLockFile = initialLock
-        } catch {
-            self.writer = nil
-            await finalizeWriter(writer)
-            await releaseSpeechEngineLease()
-            cleanupState()
-            try? fileManager.removeItem(at: folderURL)
-            throw error
-        }
 
-        let events = await audioCaptureService.events
-        try await validateStartStillCurrent(session)
-        self.latestLevels = MeetingAudioLevels()
-        await captureOrchestrator.reset()
-        try await validateStartStillCurrent(session)
-        micConditioner = SoftwareAECConditioner()
-        transcriptAssembler.reset()
-        isTranscriptionLagging = false
-        captureFailed = false
-        sourceCaptureMetrics = [:]
-        recentSystemRms = 0
-        recentProcessedMicRms = 0
-        latestSystemSignalAt = nil
-        syncLagEmaMs = nil
-        syncLagWarningActive = false
-        lastLoggedSyncLagBucketMs = nil
+            let events = await audioCaptureService.events
+            try await validateStartStillCurrent(session)
+            self.latestLevels = MeetingAudioLevels()
+            await captureOrchestrator.reset()
+            try await validateStartStillCurrent(session)
+            micConditioner = SoftwareAECConditioner()
+            transcriptAssembler.reset()
+            isTranscriptionLagging = false
+            captureFailed = false
+            sourceCaptureMetrics = [:]
+            recentSystemRms = 0
+            recentProcessedMicRms = 0
+            latestSystemSignalAt = nil
+            syncLagEmaMs = nil
+            syncLagWarningActive = false
+            lastLoggedSyncLagBucketMs = nil
 
-        await liveChunkTranscriber.startSession(
-            .init(id: session.id, chunkFolderURL: session.chunkFolderURL),
-            onEvent: { [weak self] event in
-                await self?.handleLiveChunkTranscriberEvent(event, sessionID: session.id)
-            }
-        )
-        try await validateStartStillCurrent(session)
+            await liveChunkTranscriber.startSession(
+                .init(
+                    id: session.id,
+                    chunkFolderURL: session.chunkFolderURL,
+                    speechEngine: session.speechEngine
+                ),
+                onEvent: { [weak self] event in
+                    await self?.handleLiveChunkTranscriberEvent(event, sessionID: session.id)
+                }
+            )
+            try await validateStartStillCurrent(session)
 
-        do {
             let captureStartReport = try await audioCaptureService.start()
             try await validateStartStillCurrent(session)
             configureMicConditioner(from: captureStartReport.microphone)
@@ -274,18 +269,22 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             }
             logger.info("Meeting recording started: \(sessionID.uuidString, privacy: .public)")
         } catch {
-            processingTask?.cancel()
-            processingTask = nil
-            await liveChunkTranscriber.finishSession()
-            let writer = self.writer
-            self.writer = nil
-            await finalizeWriter(writer)
-            await releaseSpeechEngineLease()
-            cleanupState()
-            try? lockFileStore.delete(folderURL: folderURL)
-            try? fileManager.removeItem(at: folderURL)
+            await cleanupFailedStart(folderURL: folderURL)
             throw error
         }
+    }
+
+    private func cleanupFailedStart(folderURL: URL) async {
+        processingTask?.cancel()
+        processingTask = nil
+        await liveChunkTranscriber.finishSession()
+        let writer = self.writer
+        self.writer = nil
+        await finalizeWriter(writer)
+        await releaseSpeechEngineLease()
+        cleanupState()
+        try? lockFileStore.delete(folderURL: folderURL)
+        try? fileManager.removeItem(at: folderURL)
     }
 
     private func validateStartStillCurrent(_ session: Session) async throws {

--- a/Sources/MacParakeetCore/SpeechEnginePreference.swift
+++ b/Sources/MacParakeetCore/SpeechEnginePreference.swift
@@ -66,11 +66,7 @@ public enum SpeechEnginePreference: String, CaseIterable, Codable, Sendable {
     }
 
     public static func normalizeLanguage(_ language: String?) -> String? {
-        guard let language else { return nil }
-        let trimmed = language.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
-        let lowercased = trimmed.replacingOccurrences(of: "_", with: "-").lowercased()
-        return lowercased == "auto" || lowercased == "auto-detect" ? nil : lowercased
+        WhisperLanguageCatalog.canonicalCode(for: language)
     }
 
     public static func normalizeModelVariant(_ variant: String?) -> String? {

--- a/Sources/MacParakeetCore/WhisperLanguageCatalog.swift
+++ b/Sources/MacParakeetCore/WhisperLanguageCatalog.swift
@@ -147,8 +147,30 @@ public enum WhisperLanguageCatalog {
         "zh": ["mandarin"],
     ]
 
+    public static func canonicalCode(for rawCode: String?) -> String? {
+        guard let rawCode else { return nil }
+        let normalized = rawCode
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "_", with: "-")
+            .lowercased()
+        guard !normalized.isEmpty else { return nil }
+        guard normalized != autoCode, normalized != "auto-detect" else { return nil }
+
+        if byCode[normalized] != nil {
+            return normalized
+        }
+
+        if let primarySubtag = normalized.split(separator: "-", maxSplits: 1).first.map(String.init),
+           byCode[primarySubtag] != nil {
+            return primarySubtag
+        }
+
+        return normalized
+    }
+
     public static func language(forCode code: String) -> WhisperLanguage? {
-        byCode[code.lowercased()]
+        guard let canonical = canonicalCode(for: code) else { return nil }
+        return byCode[canonical]
     }
 
     /// User-facing label for the picker button. Falls back to upper-cased code

--- a/Tests/MacParakeetTests/STT/STTClientTests.swift
+++ b/Tests/MacParakeetTests/STT/STTClientTests.swift
@@ -50,7 +50,7 @@ final class STTClientTests: XCTestCase {
         SpeechEnginePreference.saveWhisperDefaultLanguage("KO_kr", defaults: defaults)
 
         XCTAssertEqual(SpeechEnginePreference.current(defaults: defaults), .whisper)
-        XCTAssertEqual(SpeechEnginePreference.whisperDefaultLanguage(defaults: defaults), "ko-kr")
+        XCTAssertEqual(SpeechEnginePreference.whisperDefaultLanguage(defaults: defaults), "ko")
 
         SpeechEnginePreference.saveWhisperDefaultLanguage("auto", defaults: defaults)
         XCTAssertNil(SpeechEnginePreference.whisperDefaultLanguage(defaults: defaults))
@@ -82,14 +82,48 @@ final class STTClientTests: XCTestCase {
         XCTAssertEqual(word.endMs, 2920)
     }
 
-    func testWhisperDecodeOptionsForForcedLanguageDisablePrefillPromptRegression() {
+    func testWhisperDecodeOptionsForForcedLanguageUsesPrefillPrompt() {
         #if canImport(WhisperKit)
         let options = WhisperEngine.makeDecodingOptions(language: "KO_kr")
 
-        XCTAssertEqual(options.language, "ko-kr")
-        XCTAssertFalse(options.usePrefillPrompt)
+        XCTAssertEqual(options.language, "ko")
+        XCTAssertTrue(options.usePrefillPrompt)
         XCTAssertFalse(options.detectLanguage)
         XCTAssertTrue(options.wordTimestamps)
+        #endif
+    }
+
+    func testWhisperDecodeOptionsForAutoLanguageDetectsWithoutPrefillPrompt() {
+        #if canImport(WhisperKit)
+        let options = WhisperEngine.makeDecodingOptions(language: "auto")
+
+        XCTAssertNil(options.language)
+        XCTAssertFalse(options.usePrefillPrompt)
+        XCTAssertTrue(options.detectLanguage)
+        XCTAssertTrue(options.wordTimestamps)
+        #endif
+    }
+
+    func testWhisperForcedLanguageFallbackOnlyRetriesEmptyResults() {
+        #if canImport(WhisperKit)
+        let empty = TranscriptionResult(text: "  \n", segments: [], language: "ko", timings: TranscriptionTimings())
+        XCTAssertTrue(WhisperEngine.shouldRetryWithoutForcedLanguage(empty))
+
+        let textOnly = TranscriptionResult(text: "hello", segments: [], language: "en", timings: TranscriptionTimings())
+        XCTAssertFalse(WhisperEngine.shouldRetryWithoutForcedLanguage(textOnly))
+
+        let withWords = TranscriptionResult(
+            text: "",
+            segments: [
+                TranscriptionSegment(
+                    text: "",
+                    words: [WordTiming(word: "hello", tokens: [], start: 0, end: 0.5, probability: 0.9)]
+                ),
+            ],
+            language: "en",
+            timings: TranscriptionTimings()
+        )
+        XCTAssertFalse(WhisperEngine.shouldRetryWithoutForcedLanguage(withWords))
         #endif
     }
 

--- a/Tests/MacParakeetTests/STT/WhisperLanguageCatalogTests.swift
+++ b/Tests/MacParakeetTests/STT/WhisperLanguageCatalogTests.swift
@@ -39,6 +39,12 @@ final class WhisperLanguageCatalogTests: XCTestCase {
         XCTAssertEqual(WhisperLanguageCatalog.language(forCode: "ko")?.englishName, "Korean")
     }
 
+    func testLookupCanonicalizesLegacyRegionTags() {
+        XCTAssertEqual(WhisperLanguageCatalog.canonicalCode(for: "KO_kr"), "ko")
+        XCTAssertEqual(WhisperLanguageCatalog.language(forCode: "ko-kr")?.englishName, "Korean")
+        XCTAssertEqual(WhisperLanguageCatalog.displayLabel(for: "ko-kr"), "Korean")
+    }
+
     func testLookupReturnsNilForUnknownCode() {
         XCTAssertNil(WhisperLanguageCatalog.language(forCode: "xx"))
     }

--- a/Tests/MacParakeetTests/Services/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecordingServiceTests.swift
@@ -167,6 +167,43 @@ final class MeetingRecordingServiceTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(lockStore.deletes.count, 1)
     }
 
+    func testTaskCancellationDuringAsyncEventsSetupReleasesLeaseAndState() async throws {
+        let captureService = BlockingEventsMeetingAudioCaptureService()
+        let lockStore = RecordingLockFileStore()
+        let sttClient = LeasingMeetingSTTClient(
+            selection: SpeechEngineSelection(engine: .whisper, language: "KO")
+        )
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: MockMeetingAudioFileConverter(),
+            sttTranscriber: sttClient,
+            lockFileStore: lockStore
+        )
+
+        let startTask = Task {
+            try await service.startRecording()
+        }
+        await captureService.waitForEventsCall()
+
+        startTask.cancel()
+        await captureService.releaseEvents()
+
+        do {
+            try await startTask.value
+            XCTFail("startRecording() must not report success after task cancellation")
+        } catch is CancellationError {
+            // Expected.
+        }
+
+        let isRecordingAfterCancellation = await service.isRecording
+        let activeLeaseCount = await sttClient.activeLeaseCount
+        let startCallCount = await captureService.startCallCount
+        XCTAssertFalse(isRecordingAfterCancellation)
+        XCTAssertEqual(activeLeaseCount, 0)
+        XCTAssertEqual(startCallCount, 0)
+        XCTAssertGreaterThanOrEqual(lockStore.deletes.count, 1)
+    }
+
     func testStopRecordingKeepsLockUntilTranscriptionCompletes() async throws {
         let captureService = MockMeetingAudioCaptureService()
         let lockStore = RecordingLockFileStore()
@@ -226,6 +263,32 @@ final class MeetingRecordingServiceTests: XCTestCase {
         XCTAssertEqual(lockStore.writes.last?.file.speechEngine, SpeechEngineSelection(engine: .whisper, language: "ko"))
         let activeLeaseCountAfterStop = await sttClient.activeLeaseCount
         XCTAssertEqual(activeLeaseCountAfterStop, 0)
+    }
+
+    func testLivePreviewUsesCapturedSpeechEngineSelection() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let speechEngine = SpeechEngineSelection(engine: .whisper, language: "KO")
+        let sttClient = LeasingMeetingSTTClient(selection: speechEngine)
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: MockMeetingAudioFileConverter(),
+            sttTranscriber: sttClient
+        )
+
+        try await service.startRecording()
+
+        let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.25))
+        await captureService.yield(.microphoneBuffer(
+            microphoneBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
+        ))
+        try await waitForRoutedLiveChunkSelection(sttClient)
+
+        let routedSelections = await sttClient.routedSelections
+        XCTAssertEqual(routedSelections, [SpeechEngineSelection(engine: .whisper, language: "ko")])
+
+        let output = try await service.stopRecording()
+        try? FileManager.default.removeItem(at: output.folderURL)
     }
 
     func testStopRecordingKeepsLockWhenMixFails() async throws {
@@ -757,6 +820,20 @@ final class MeetingRecordingServiceTests: XCTestCase {
         while await client.liveChunkCallCount == 0 {
             if startedAt.duration(to: .now) > timeout {
                 XCTFail("Timed out waiting for live chunk transcription to start")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+    }
+
+    private func waitForRoutedLiveChunkSelection(
+        _ client: LeasingMeetingSTTClient,
+        timeout: Duration = .seconds(1)
+    ) async throws {
+        let startedAt = ContinuousClock.now
+        while await client.routedSelections.isEmpty {
+            if startedAt.duration(to: .now) > timeout {
+                XCTFail("Timed out waiting for routed live chunk transcription")
                 return
             }
             try await Task.sleep(for: .milliseconds(20))
@@ -1372,9 +1449,10 @@ private actor CountingMeetingSTTClient: STTClientProtocol {
     func shutdown() async {}
 }
 
-private actor LeasingMeetingSTTClient: STTClientProtocol, SpeechEngineSessionManaging {
+private actor LeasingMeetingSTTClient: STTClientProtocol, SpeechEngineRoutedTranscribing, SpeechEngineSessionManaging {
     private let selection: SpeechEngineSelection
     private var activeLeases: Set<UUID> = []
+    private(set) var routedSelections: [SpeechEngineSelection] = []
 
     init(selection: SpeechEngineSelection) {
         self.selection = selection
@@ -1400,6 +1478,18 @@ private actor LeasingMeetingSTTClient: STTClientProtocol, SpeechEngineSessionMan
         onProgress: (@Sendable (Int, Int) -> Void)?
     ) async throws -> STTResult {
         STTResult(text: "", words: [])
+    }
+
+    func transcribe(
+        audioPath: String,
+        job: STTJobKind,
+        speechEngine: SpeechEngineSelection,
+        onProgress: (@Sendable (Int, Int) -> Void)?
+    ) async throws -> STTResult {
+        if job == .meetingLiveChunk {
+            routedSelections.append(speechEngine)
+        }
+        return STTResult(text: "", words: [])
     }
 
     func warmUp(onProgress: (@Sendable (String) -> Void)?) async throws {}

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -749,7 +749,7 @@ final class SettingsViewModelTests: XCTestCase {
 
     func testWhisperDefaultLanguagePersistsNormalizedValue() {
         viewModel.whisperDefaultLanguage = "KO_kr"
-        XCTAssertEqual(SpeechEnginePreference.whisperDefaultLanguage(defaults: testDefaults), "ko-kr")
+        XCTAssertEqual(SpeechEnginePreference.whisperDefaultLanguage(defaults: testDefaults), "ko")
 
         viewModel.whisperDefaultLanguage = "auto"
         XCTAssertNil(SpeechEnginePreference.whisperDefaultLanguage(defaults: testDefaults))

--- a/scripts/dev/verify_whisper_language_smoke.sh
+++ b/scripts/dev/verify_whisper_language_smoke.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SMOKE_DIR="${TMPDIR:-/tmp}/macparakeet-whisper-language-smoke"
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require_voice() {
+  local voice="$1"
+  if ! say -v '?' | grep -q "^${voice}[[:space:]]"; then
+    echo "Missing required macOS voice: ${voice}" >&2
+    exit 1
+  fi
+}
+
+make_clip() {
+  local language="$1"
+  local voice="$2"
+  local text="$3"
+  say -v "$voice" -o "${SMOKE_DIR}/${language}.aiff" "$text"
+  afconvert -f WAVE -d LEI16@16000 "${SMOKE_DIR}/${language}.aiff" "${SMOKE_DIR}/${language}.wav"
+}
+
+run_clip() {
+  local language="$1"
+  local output="${SMOKE_DIR}/${language}.json"
+  local log="${SMOKE_DIR}/${language}.log"
+
+  MACPARAKEET_TELEMETRY=0 swift run --package-path "$ROOT_DIR" macparakeet-cli \
+    transcribe "${SMOKE_DIR}/${language}.wav" \
+    --engine whisper \
+    --language "$language" \
+    --format json \
+    --database "${SMOKE_DIR}/smoke.db" \
+    --no-diarize \
+    >"$output" 2>"$log"
+
+  python3 - "$output" "$language" <<'PY'
+import json
+import sys
+
+path, expected_language = sys.argv[1], sys.argv[2]
+raw = open(path, encoding="utf-8").read()
+start = raw.find("{")
+end = raw.rfind("}")
+if start == -1 or end == -1 or end < start:
+    raise SystemExit(f"{expected_language}: no JSON object in CLI output")
+
+payload = json.loads(raw[start:end + 1])
+language = payload.get("language")
+transcript = (payload.get("rawTranscript") or "").strip()
+if language != expected_language:
+    raise SystemExit(f"{expected_language}: expected language {expected_language!r}, got {language!r}")
+if not transcript:
+    raise SystemExit(f"{expected_language}: empty transcript")
+
+print(f"{expected_language}: {transcript}")
+PY
+}
+
+require_command say
+require_command afconvert
+require_command swift
+require_command python3
+require_voice Samantha
+require_voice Kyoko
+require_voice Yuna
+
+rm -rf "$SMOKE_DIR"
+mkdir -p "$SMOKE_DIR"
+
+make_clip en Samantha "This is an English Whisper language smoke test."
+make_clip ja Kyoko "これは日本語のテストです。"
+make_clip ko Yuna "이것은 한국어 테스트입니다."
+
+run_clip en
+run_clip ja
+run_clip ko
+
+echo "Whisper language smoke clips and logs: ${SMOKE_DIR}"

--- a/scripts/dev/verify_whisper_language_smoke.sh
+++ b/scripts/dev/verify_whisper_language_smoke.sh
@@ -46,7 +46,8 @@ import json
 import sys
 
 path, expected_language = sys.argv[1], sys.argv[2]
-raw = open(path, encoding="utf-8").read()
+with open(path, encoding="utf-8") as f:
+    raw = f.read()
 start = raw.find("{")
 end = raw.rfind("}")
 if start == -1 or end == -1 or end < start:

--- a/spec/adr/021-whisperkit-multilingual-stt.md
+++ b/spec/adr/021-whisperkit-multilingual-stt.md
@@ -46,7 +46,7 @@ public struct SpeechEngineSelection: Codable, Equatable, Sendable {
 }
 ```
 
-Language hints are normalized to lowercase BCP-47-ish tokens with `_` converted to `-`. `"auto"` and `"auto-detect"` are stored as `nil`, which tells WhisperKit to detect language.
+Language hints are normalized to canonical Whisper language codes. Region-style aliases such as `ko-KR`/`KO_kr` collapse to the primary Whisper code (`ko`). `"auto"` and `"auto-detect"` are stored as `nil`, which tells WhisperKit to detect language.
 
 ### 3. Add `WhisperEngine`
 


### PR DESCRIPTION
## Summary

Hardens the Whisper release path around the three release-blocking review findings:

- explicit Whisper language hints now use WhisperKit's forced-language prefill path, with canonical Whisper-code normalization and a one-shot auto-detect fallback for empty forced-language output
- meeting live preview now uses the speech engine/language captured at meeting start instead of rereading mutable defaults per live chunk
- meeting startup now has one post-lease cleanup path so cancellation or throws release the speech-engine lease and clear recording state/artifacts; cleanup failures are logged by operation/domain/code without logging user paths

Also adds a repeatable manual release smoke, `scripts/dev/verify_whisper_language_smoke.sh`, that generates real English/Japanese/Korean macOS `say` clips and runs the Whisper CLI path with explicit `--language` hints.

## Flow

```text
CLI / Settings language input
        |
        v
WhisperLanguageCatalog.canonicalCode
        |     KO_kr, ko-KR -> ko
        v
SpeechEngineSelection(engine: .whisper, language: ko)
        |
        +---------------------------+
        |                           |
        v                           v
File/CLI transcription       Meeting start
        |                    capture lease + selection
        v                           |
WhisperEngine.makeOptions           v
 language != nil              Session.speechEngine
 usePrefillPrompt = true            |
 detectLanguage = false             v
        |                    LiveChunkTranscriber.SessionContext
        v                           |
WhisperKit forced prefill           v
        |                    SpeechEngineRoutedTranscribing
        |                           |
        v                           v
 non-empty result             live preview uses pinned engine/language
        |
        +-- empty text/no words --> retry once with auto-detect
```

Startup cleanup now wraps the post-lease section:

```text
begin lease -> install session -> write lock -> events/reset/live session/start capture
      |                                                            |
      +---------------- any throw/cancellation --------------------+
                                                                   v
                     finish live session -> finalize writer -> release lease
                        -> cleanup state -> delete lock/folder
                                      |           |
                                      v           v
                              log cleanup errors by operation/domain/code
```

## Review Follow-Up

Addressed all actionable Gemini review comments in `956f4745`:

- extracted forced-language retry handling into `transcribeWithLanguageFallback(...)`
- added explicit failed-start cleanup error logging while preserving path privacy
- changed the smoke script JSON read to use `with open(...)`

CodeRabbit's PR comment was a rate-limit notice only, with no actionable code feedback.

## Verification

- `swift test` passed: 1,923 XCTest tests, 0 failures; Swift Testing telemetry/privacy suite also passed (16 tests)
- Focused review-response suite passed: `STTClientTests` plus affected `MeetingRecordingServiceTests` (24 tests)
- Earlier focused post-rebase suite passed: `STTClientTests`, `WhisperLanguageCatalogTests`, affected `MeetingRecordingServiceTests`, and Whisper language settings test (44 tests)
- `scripts/dev/verify_whisper_language_smoke.sh` passed locally:
  - `en`: `This is an English whisper language smoke test.`
  - `ja`: `これは日本語のテストです。`
  - `ko`: `이것은 한국어 테스트입니다.`
- `bash -n scripts/dev/verify_whisper_language_smoke.sh` passed
- `git diff --check` passed

## Notes

The smoke script generates clips at runtime instead of committing binary audio fixtures. That keeps the repo lean while preserving a repeatable release check on machines with the standard Samantha, Kyoko, and Yuna macOS voices plus the downloaded Whisper model.
