### PR TITLE
Harden Whisper release branch, helper packaging, and CLI contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,18 +43,16 @@
 
 ---
 
-MacParakeet runs NVIDIA's Parakeet TDT on Apple's Neural Engine via [FluidAudio](https://github.com/FluidInference/FluidAudio) CoreML. The stable DMG handles system-wide dictation and file/URL transcription. Labs features on `main` add meeting recording and optional local WhisperKit recognition for languages Parakeet does not cover. All speech recognition happens on your Mac.
+MacParakeet runs NVIDIA's Parakeet TDT on Apple's Neural Engine via [FluidAudio](https://github.com/FluidInference/FluidAudio) CoreML. The current release handles system-wide dictation, file/URL transcription, meeting recording, and optional local WhisperKit recognition for languages Parakeet does not cover. All speech recognition happens on your Mac.
 
 ## Release status
 
-The [notarized DMG](https://downloads.macparakeet.com/MacParakeet.dmg) is the stable release channel. It intentionally lags `main` while larger features are tested.
+The [notarized DMG](https://downloads.macparakeet.com/MacParakeet.dmg) is the stable release channel.
 
 | Channel | Status | Includes |
 |---------|--------|----------|
-| Stable DMG | Recommended for normal use | Dictation, file/video/YouTube transcription, exports, vocabulary, AI features |
-| Labs on `main` | Beta, under active testing | Meeting recording, live meeting notes/Ask, crash recovery, optional WhisperKit multilingual STT |
-
-Meeting recording and WhisperKit are **Labs/Beta** features right now. They are implemented on `main`, but they are not in the current public DMG release yet.
+| Stable DMG | Recommended for normal use | Dictation, file/video/YouTube transcription, meeting recording, local WhisperKit fallback, exports, vocabulary, AI features |
+| `main` branch | Development | Next fixes and features before they ship to the stable DMG |
 
 ## What it does
 
@@ -62,7 +60,7 @@ Meeting recording and WhisperKit are **Labs/Beta** features right now. They are 
 
 **File transcription** — Drag audio or video files, or paste a YouTube URL. Full transcript with word-level timestamps, speaker labels, and export to 7 formats (TXT, Markdown, SRT, VTT, DOCX, PDF, JSON). Assign global hotkeys to trigger File or YouTube transcription from anywhere.
 
-**Meeting recording (Labs/Beta, `main` only)** — Record system audio and microphone together, see a live local transcript preview, take notes during the call, then save the finalized transcript to the library with export, prompts, and chat. This is under testing and not included in the current DMG release.
+**Meeting recording** — Record system audio and microphone together, see a live local transcript preview, take notes during the call, then save the finalized transcript to the library with export, prompts, and chat.
 
 **Text cleanup** — Filler word removal, custom word replacements, text snippets with triggers. Deterministic pipeline, no LLM needed.
 
@@ -74,13 +72,13 @@ Meeting recording and WhisperKit are **Labs/Beta** features right now. They are 
 - ~2.5% word error rate (Parakeet TDT 0.6B-v3)
 - ~66 MB working memory per active Parakeet inference slot
 - 25 European languages with Parakeet auto-detection
-- Optional local WhisperKit engine for Korean, Japanese, Chinese, and many other languages (Labs/Beta on `main`; not in the current DMG)
+- Optional local WhisperKit engine for Korean, Japanese, Chinese, and many other languages
 
 ### Limitations
 
 - Apple Silicon only (M1/M2/M3/M4)
 - Parakeet is best for English and supported European languages
-- WhisperKit multilingual support is currently a Labs/Beta feature on `main` and requires a separate local model download before first use
+- WhisperKit multilingual support requires a separate local model download before first use
 
 ## Get it
 
@@ -88,7 +86,7 @@ Meeting recording and WhisperKit are **Labs/Beta** features right now. They are 
 
 First launch downloads the speech model (~6 GB) plus speaker-detection assets (~130 MB). Everything works fully offline after that.
 
-The DMG is the stable release. Labs features such as meeting recording and WhisperKit multilingual STT are currently available only by building from `main`.
+The DMG is the stable release.
 
 **Build from source:**
 
@@ -111,14 +109,14 @@ swift run macparakeet-cli models status
 swift run macparakeet-cli history
 ```
 
-The Whisper CLI commands above require a `main` build with the Labs WhisperKit engine.
+The Whisper CLI commands above require a downloaded local WhisperKit model.
 
 ## Tech stack
 
 | Layer | Choice |
 |-------|--------|
-| STT | Parakeet TDT 0.6B-v3 via [FluidAudio](https://github.com/FluidInference/FluidAudio) CoreML (stable default) + optional WhisperKit Labs engine on `main` |
-| STT orchestration | Shared runtime + explicit scheduler with a reserved dictation slot and a shared meeting/file slot on `main`; speech-engine routing and meeting-session pinning for Labs features |
+| STT | Parakeet TDT 0.6B-v3 via [FluidAudio](https://github.com/FluidInference/FluidAudio) CoreML (default) + optional local WhisperKit engine |
+| STT orchestration | Shared runtime + explicit scheduler with a reserved dictation slot and a shared meeting/file slot; speech-engine routing and meeting-session pinning |
 | Language | Swift 6.0 + SwiftUI |
 | Database | SQLite via GRDB |
 | Auto-updates | Sparkle 2 |
@@ -161,20 +159,20 @@ AI features are entirely **opt-in** and separate from speech recognition — tra
 | Cloud | Anthropic (Claude), OpenAI, Google Gemini, OpenRouter |
 | Local | Ollama, LM Studio |
 | Custom | OpenAI-Compatible (any API-shaped endpoint — vLLM, LocalAI, LiteLLM, llama.cpp server, third-party hosts) |
-| CLI | Claude Code, Codex (runs as subprocess) |
+| CLI subprocess | Claude Code, Codex, or another configured command |
 
-**Setup:** In Settings → AI Provider, pick a provider, enter an API key (cloud) or confirm the local server is running, select a model, and hit Test Connection. Cloud providers store keys in the macOS Keychain. Local providers (Ollama, LM Studio, CLI) keep everything on-device.
+**Setup:** In Settings → AI Provider, pick a provider, enter an API key (cloud) or confirm the local server/CLI command is available, select a model, and hit Test Connection. Cloud providers store keys in the macOS Keychain. Ollama and LM Studio can keep LLM inference on-device. CLI subprocess providers run the configured command locally, but that command may contact its own cloud service.
 
 ## Privacy
 
-All speech recognition runs locally. Parakeet uses the Neural Engine; the Labs WhisperKit engine also runs on-device. Your audio never leaves your Mac.
+All speech recognition runs locally. Parakeet uses the Neural Engine; the optional WhisperKit engine also runs on-device. Your audio never leaves your Mac.
 
 - **No cloud STT.** The model runs on-device. No audio is transmitted.
 - **No accounts.** No login, no email, no registration.
 - **Opt-out telemetry.** Non-identifying usage analytics and crash reporting go to a self-hosted endpoint only when telemetry is enabled. No persistent IDs, no IP storage, and no transcript/audio content is transmitted. [Source code is right here](Sources/MacParakeetCore/Services/TelemetryService.swift) — verify it yourself.
 - **Temp files cleaned up.** Audio deleted after transcription unless you save it.
 
-**What does use the network:** AI summaries and chat connect to configured LLM providers or CLI tools when you choose them. Sparkle checks for app updates. YouTube transcription downloads video via yt-dlp. Telemetry and crash reports go to our self-hosted server unless you opt out. Core dictation and transcription stay fully offline.
+**What does use the network:** AI summaries and chat connect to configured LLM providers, or to whatever service a configured CLI tool chooses to use, when you choose them. Sparkle checks for app updates. YouTube transcription downloads video via yt-dlp. Telemetry and crash reports go to our self-hosted server unless you opt out. Core dictation and transcription stay fully offline.
 
 **Note:** Builds from source also send telemetry by default. Opt out in Settings or set `MACPARAKEET_TELEMETRY_URL` to override.
 

--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -262,8 +262,8 @@ complete enough to commit to. This release marks that commitment.
   semantics.
 - **`--format json` (transcribe, export) vs `--json` (read-only queries)**
   is deliberate, not a bug. `transcribe` and `export` carry a `--format`
-  selector because they emit one of several formats (txt / srt / vtt / json /
-  docx / pdf); `--json` on read-only query commands is a binary flag because
+  selector because they emit one of several formats (`transcribe`: text / json;
+  `export`: txt / markdown / srt / vtt / json); `--json` on read-only query commands is a binary flag because
   their output shape is conceptually fixed -- it's either JSON or human.
   Unifying this would be a major-version breaking change; we are not doing
   that in 1.0.

--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -79,6 +79,10 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ## [Unreleased]
 
+No changes yet.
+
+## [1.4.0] -- 2026-04-28
+
 ### Added
 
 - LLM-backed commands now accept `--api-key-env NAME`; hosted providers also
@@ -104,7 +108,9 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 - `prompts run --json` now emits a single JSON object even when saving the
   generated `PromptResult` fails.
 - CLI deletion now removes app-owned dictation audio, YouTube audio, and
-  meeting recording folders after deleting their database rows.
+  meeting recording folders before deleting their database rows. If managed
+  audio cleanup fails, deletion fails visibly instead of leaving app-owned
+  audio behind silently.
 - Local transcription and export output paths now expand `~`; export also
   creates parent directories and sanitizes default file names.
 - App-bundled CLI installs now include a signed `yt-dlp` helper seed. YouTube

--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -109,6 +109,11 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
   prompt results. This restores GUI/CLI parity for notes-steered meeting
   prompts while keeping LLM invocation explicitly under `prompts`.
 - Meeting retranscription now preserves durable user-authored meeting notes.
+- `health --json` is now a non-mutating readiness probe for helper binaries:
+  it reports whether `yt-dlp` is installed without downloading or updating it.
+  Use `health --repair-binaries` to explicitly install/update helper binaries.
+- UUID prefix lookup now enforces the documented minimum prefix length of
+  four characters before matching database records by ID prefix.
 
 ## [1.2.0] -- 2026-04-26
 

--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -107,6 +107,10 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
   meeting recording folders after deleting their database rows.
 - Local transcription and export output paths now expand `~`; export also
   creates parent directories and sanitizes default file names.
+- App-bundled CLI installs now include a signed `yt-dlp` helper seed. YouTube
+  transcription seeds the managed App Support helper from the bundle before
+  falling back to network install, while `health --json` remains non-mutating
+  and `health --repair-binaries` explicitly fetches the latest helper.
 
 ## [1.3.0] -- 2026-04-26
 

--- a/Sources/CLI/Commands/CLIHelpers.swift
+++ b/Sources/CLI/Commands/CLIHelpers.swift
@@ -31,12 +31,15 @@ enum CLILookupError: Error, LocalizedError {
     case notFound(String)
     case ambiguous(String)
     case emptyID
+    case shortUUIDPrefix(minimumLength: Int)
 
     var errorDescription: String? {
         switch self {
         case .notFound(let msg): return msg
         case .ambiguous(let msg): return msg
         case .emptyID: return "ID must not be empty."
+        case .shortUUIDPrefix(let minimumLength):
+            return "UUID prefixes must be at least \(minimumLength) characters."
         }
     }
 }
@@ -49,6 +52,31 @@ enum CLIInputError: Error, LocalizedError {
         case .empty: return "Input is empty."
         }
     }
+}
+
+private let minimumUUIDPrefixLength = 4
+
+private func isUUIDPrefixCandidate(_ value: String) -> Bool {
+    value.allSatisfy { char in
+        char == "-" || char.isHexDigit
+    }
+}
+
+private func uuidPrefixSearchKey(_ value: String) -> String? {
+    let lowered = value.lowercased()
+    guard lowered.count >= minimumUUIDPrefixLength else { return nil }
+    return lowered
+}
+
+private func shortUUIDPrefixErrorIfApplicable(_ value: String) -> CLILookupError? {
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty,
+          trimmed.count < minimumUUIDPrefixLength,
+          isUUIDPrefixCandidate(trimmed)
+    else {
+        return nil
+    }
+    return .shortUUIDPrefix(minimumLength: minimumUUIDPrefixLength)
 }
 
 // MARK: - Transcription Lookup (shared by export, delete, favorite, unfavorite)
@@ -67,11 +95,13 @@ func findTranscription(id: String, repo: TranscriptionRepository) throws -> Tran
     // Prefix match
     let all = try repo.fetchAll()
     let lowered = trimmed.lowercased()
-    let matches = all.filter { $0.id.uuidString.lowercased().hasPrefix(lowered) }
+    if let prefix = uuidPrefixSearchKey(trimmed) {
+        let matches = all.filter { $0.id.uuidString.lowercased().hasPrefix(prefix) }
 
-    if matches.count == 1 { return matches[0] }
-    if matches.count > 1 {
-        throw CLILookupError.ambiguous("Multiple transcriptions match '\(trimmed)'. Be more specific.")
+        if matches.count == 1 { return matches[0] }
+        if matches.count > 1 {
+            throw CLILookupError.ambiguous("Multiple transcriptions match '\(trimmed)'. Be more specific.")
+        }
     }
 
     let nameMatches = all.filter { $0.fileName.lowercased() == lowered }
@@ -79,6 +109,7 @@ func findTranscription(id: String, repo: TranscriptionRepository) throws -> Tran
     if nameMatches.count > 1 {
         throw CLILookupError.ambiguous("Multiple transcriptions named '\(trimmed)'. Use ID instead.")
     }
+    if let error = shortUUIDPrefixErrorIfApplicable(trimmed) { throw error }
 
     throw CLILookupError.notFound("No transcription matching '\(trimmed)'")
 }
@@ -93,12 +124,12 @@ func findMeeting(idOrName: String, repo: TranscriptionRepository) throws -> Tran
         return transcription
     }
 
-    let lowered = trimmed.lowercased()
-
-    let prefixMatches = try repo.fetchBySourceType(.meeting, idPrefix: lowered)
-    if prefixMatches.count == 1 { return prefixMatches[0] }
-    if prefixMatches.count > 1 {
-        throw CLILookupError.ambiguous("Multiple meetings match '\(trimmed)'. Be more specific.")
+    if let prefix = uuidPrefixSearchKey(trimmed) {
+        let prefixMatches = try repo.fetchBySourceType(.meeting, idPrefix: prefix)
+        if prefixMatches.count == 1 { return prefixMatches[0] }
+        if prefixMatches.count > 1 {
+            throw CLILookupError.ambiguous("Multiple meetings match '\(trimmed)'. Be more specific.")
+        }
     }
 
     let nameMatches = try repo.fetchBySourceType(.meeting, fileName: trimmed)
@@ -106,6 +137,7 @@ func findMeeting(idOrName: String, repo: TranscriptionRepository) throws -> Tran
     if nameMatches.count > 1 {
         throw CLILookupError.ambiguous("Multiple meetings named '\(trimmed)'. Use ID instead.")
     }
+    if let error = shortUUIDPrefixErrorIfApplicable(trimmed) { throw error }
 
     throw CLILookupError.notFound("No meeting matching '\(trimmed)'")
 }
@@ -113,22 +145,27 @@ func findMeeting(idOrName: String, repo: TranscriptionRepository) throws -> Tran
 // MARK: - Dictation Lookup
 
 func findDictation(id: String, repo: DictationRepository) throws -> Dictation {
-    guard !id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+    let trimmed = id.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
         throw CLILookupError.emptyID
     }
 
-    if let uuid = UUID(uuidString: id), let d = try repo.fetch(id: uuid) {
+    if let uuid = UUID(uuidString: trimmed), let d = try repo.fetch(id: uuid) {
         return d
     }
 
+    guard let prefix = uuidPrefixSearchKey(trimmed) else {
+        throw shortUUIDPrefixErrorIfApplicable(trimmed) ?? CLILookupError.notFound("No dictation matching '\(trimmed)'")
+    }
+
     let all = try repo.fetchAll()
-    let matches = all.filter { $0.id.uuidString.lowercased().hasPrefix(id.lowercased()) }
+    let matches = all.filter { $0.id.uuidString.lowercased().hasPrefix(prefix) }
 
     guard let match = matches.first else {
-        throw CLILookupError.notFound("No dictation matching '\(id)'")
+        throw CLILookupError.notFound("No dictation matching '\(trimmed)'")
     }
     guard matches.count == 1 else {
-        throw CLILookupError.ambiguous("Multiple dictations match '\(id)'. Be more specific.")
+        throw CLILookupError.ambiguous("Multiple dictations match '\(trimmed)'. Be more specific.")
     }
     return match
 }
@@ -149,10 +186,12 @@ func findPrompt(idOrName: String, repo: PromptRepository) throws -> Prompt {
     let all = try repo.fetchAll()
     let lowered = trimmed.lowercased()
 
-    let prefixMatches = all.filter { $0.id.uuidString.lowercased().hasPrefix(lowered) }
-    if prefixMatches.count == 1 { return prefixMatches[0] }
-    if prefixMatches.count > 1 {
-        throw CLILookupError.ambiguous("Multiple prompts match '\(trimmed)' as ID prefix. Be more specific.")
+    if let prefix = uuidPrefixSearchKey(trimmed) {
+        let prefixMatches = all.filter { $0.id.uuidString.lowercased().hasPrefix(prefix) }
+        if prefixMatches.count == 1 { return prefixMatches[0] }
+        if prefixMatches.count > 1 {
+            throw CLILookupError.ambiguous("Multiple prompts match '\(trimmed)' as ID prefix. Be more specific.")
+        }
     }
 
     let nameMatches = all.filter { $0.name.lowercased() == lowered }
@@ -160,6 +199,7 @@ func findPrompt(idOrName: String, repo: PromptRepository) throws -> Prompt {
     if nameMatches.count > 1 {
         throw CLILookupError.ambiguous("Multiple prompts named '\(trimmed)'. Use ID instead.")
     }
+    if let error = shortUUIDPrefixErrorIfApplicable(trimmed) { throw error }
 
     throw CLILookupError.notFound("No prompt matching '\(trimmed)'")
 }

--- a/Sources/CLI/Commands/CLIHelpers.swift
+++ b/Sources/CLI/Commands/CLIHelpers.swift
@@ -65,7 +65,11 @@ private func isUUIDPrefixCandidate(_ value: String) -> Bool {
 
 private func uuidPrefixSearchKey(_ value: String) -> String? {
     let lowered = value.lowercased()
-    guard lowered.count >= minimumUUIDPrefixLength else { return nil }
+    guard lowered.count >= minimumUUIDPrefixLength,
+          isUUIDPrefixCandidate(lowered)
+    else {
+        return nil
+    }
     return lowered
 }
 

--- a/Sources/CLI/Commands/CLIHelpers.swift
+++ b/Sources/CLI/Commands/CLIHelpers.swift
@@ -93,11 +93,9 @@ func findTranscription(id: String, repo: TranscriptionRepository) throws -> Tran
         return t
     }
 
-    // Prefix match
-    let all = try repo.fetchAll()
     let lowered = trimmed.lowercased()
     if let prefix = uuidPrefixSearchKey(trimmed) {
-        let matches = all.filter { $0.id.uuidString.lowercased().hasPrefix(prefix) }
+        let matches = try repo.fetchByIDPrefix(prefix)
 
         if matches.count == 1 { return matches[0] }
         if matches.count > 1 {
@@ -105,7 +103,7 @@ func findTranscription(id: String, repo: TranscriptionRepository) throws -> Tran
         }
     }
 
-    let nameMatches = all.filter { $0.fileName.lowercased() == lowered }
+    let nameMatches = try repo.fetchByFileName(lowered)
     if nameMatches.count == 1 { return nameMatches[0] }
     if nameMatches.count > 1 {
         throw CLILookupError.ambiguous("Multiple transcriptions named '\(trimmed)'. Use ID instead.")

--- a/Sources/CLI/Commands/HealthCommand.swift
+++ b/Sources/CLI/Commands/HealthCommand.swift
@@ -186,7 +186,7 @@ struct HealthCommand: AsyncParsableCommand {
         let ytDlp: HealthReport.Binary
         if repairBinaries {
             do {
-                let path = try await BinaryBootstrap().ensureYtDlpAvailable()
+                let path = try await BinaryBootstrap().ensureYtDlpAvailable(allowNetworkUpdate: true)
                 ytDlp = .init(status: "ready", path: path, error: nil)
             } catch {
                 ytDlp = .init(status: "missing", path: nil, error: error.localizedDescription)

--- a/Sources/CLI/Commands/HealthCommand.swift
+++ b/Sources/CLI/Commands/HealthCommand.swift
@@ -14,6 +14,9 @@ struct HealthCommand: AsyncParsableCommand {
     @Option(name: .long, help: "Maximum repair attempts when --repair-models is set.")
     var repairAttempts: Int = 3
 
+    @Flag(name: .long, help: "Install or update helper binaries such as yt-dlp.")
+    var repairBinaries: Bool = false
+
     @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
     var json: Bool = false
 
@@ -171,18 +174,29 @@ struct HealthCommand: AsyncParsableCommand {
 
         // 7. yt-dlp
         let ytDlp: HealthReport.Binary
-        do {
-            let path = try await BinaryBootstrap().ensureYtDlpAvailable()
+        if repairBinaries {
+            do {
+                let path = try await BinaryBootstrap().ensureYtDlpAvailable()
+                ytDlp = .init(status: "ready", path: path, error: nil)
+            } catch {
+                ytDlp = .init(status: "missing", path: nil, error: error.localizedDescription)
+            }
+        } else if let path = BinaryBootstrap.resolveYtDlpPath() {
             ytDlp = .init(status: "ready", path: path, error: nil)
-        } catch {
-            ytDlp = .init(status: "missing", path: nil, error: error.localizedDescription)
+        } else {
+            ytDlp = .init(
+                status: "missing",
+                path: nil,
+                error: "Run `macparakeet-cli health --repair-binaries` or transcribe a YouTube URL to install yt-dlp."
+            )
         }
         report.ytDlp = ytDlp
         if !json {
             print("yt-dlp:")
             switch ytDlp.status {
             case "ready": print("  Status: Ready at \(ytDlp.path ?? "")")
-            default:      print("  Status: Not available — \(ytDlp.error ?? "unknown")")
+            default:
+                print("  Status: Not available — \(ytDlp.error ?? "unknown")")
             }
             print()
         }

--- a/Sources/CLI/Commands/HistoryCommand.swift
+++ b/Sources/CLI/Commands/HistoryCommand.swift
@@ -300,11 +300,11 @@ struct DeleteTranscriptionSubcommand: ParsableCommand {
         let repo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
 
         let transcription = try findTranscription(id: id, repo: repo)
+        try TranscriptionAssetCleanup.removeOwnedAssets(for: transcription)
         let deleted = try repo.delete(id: transcription.id)
         guard deleted else {
             throw CLILookupError.notFound("No transcription matching '\(id)'")
         }
-        TranscriptionAssetCleanup.removeOwnedAssets(for: transcription)
         print("Deleted transcription: \"\(transcription.fileName)\"")
     }
 }

--- a/Sources/CLI/Commands/HistoryCommand.swift
+++ b/Sources/CLI/Commands/HistoryCommand.swift
@@ -252,25 +252,24 @@ struct DeleteDictationSubcommand: ParsableCommand {
         let repo = DictationRepository(dbQueue: dbManager.dbQueue)
 
         let dictation = try findDictation(id: id, repo: repo)
+        if let path = dictation.audioPath {
+            try removeOwnedDictationAudio(at: path)
+        }
         let deleted = try repo.delete(id: dictation.id)
         guard deleted else {
             throw CLILookupError.notFound("No dictation matching '\(id)'")
-        }
-        if let path = dictation.audioPath {
-            removeOwnedDictationAudio(at: path)
         }
         let preview = String(dictation.rawTranscript.prefix(60))
         print("Deleted dictation: \"\(preview)\"")
     }
 }
 
-private func removeOwnedDictationAudio(at path: String, fileManager: FileManager = .default) {
+private func removeOwnedDictationAudio(at path: String, fileManager: FileManager = .default) throws {
     let rootURL = URL(fileURLWithPath: AppPaths.dictationsDir, isDirectory: true)
         .standardizedFileURL
     let targetURL = URL(fileURLWithPath: path).standardizedFileURL
 
     guard targetURL.path.hasPrefix(rootURL.path + "/") else {
-        printErr("Refusing to remove dictation audio outside app-owned dictations directory: \(targetURL.path)")
         return
     }
 
@@ -278,7 +277,10 @@ private func removeOwnedDictationAudio(at path: String, fileManager: FileManager
     do {
         try fileManager.removeItem(at: targetURL)
     } catch {
-        printErr("Failed to remove dictation audio at \(targetURL.path): \(error.localizedDescription)")
+        throw TranscriptionAssetCleanupError.removalFailed(
+            path: targetURL.path,
+            reason: error.localizedDescription
+        )
     }
 }
 

--- a/Sources/CLI/Commands/ModelsCommand.swift
+++ b/Sources/CLI/Commands/ModelsCommand.swift
@@ -173,6 +173,8 @@ struct SpeechStackPayload: Encodable {
     let speechRuntimeReady: Bool
     let speakerModelsCached: Bool
     let speakerModelsPrepared: Bool
+    let whisperModelVariant: String
+    let whisperModelDownloaded: Bool
     let summary: String
 
     init(status: SpeechStackStatus) {
@@ -180,6 +182,8 @@ struct SpeechStackPayload: Encodable {
         self.speechRuntimeReady = status.speechRuntimeReady
         self.speakerModelsCached = status.speakerModelsCached
         self.speakerModelsPrepared = status.speakerModelsPrepared
+        self.whisperModelVariant = status.whisperModelVariant
+        self.whisperModelDownloaded = status.whisperModelDownloaded
         self.summary = status.summary
     }
 }
@@ -189,6 +193,8 @@ struct SpeechStackStatus: Sendable, Equatable {
     let speechRuntimeReady: Bool
     let speakerModelsCached: Bool
     let speakerModelsPrepared: Bool
+    let whisperModelVariant: String
+    let whisperModelDownloaded: Bool
 
     var summary: String {
         if speechRuntimeReady && speakerModelsPrepared {
@@ -217,7 +223,9 @@ func validatedAttempts(_ attempts: Int) throws -> Int {
 func loadSpeechStackStatus(
     sttClient: STTClientProtocol,
     diarizationService: DiarizationServiceProtocol,
-    isSpeechModelCached: @escaping @Sendable () -> Bool = { STTClient.isModelCached() }
+    isSpeechModelCached: @escaping @Sendable () -> Bool = { STTClient.isModelCached() },
+    whisperModelVariant: String = SpeechEnginePreference.whisperModelVariant(defaults: macParakeetAppDefaults()),
+    isWhisperModelDownloaded: @escaping @Sendable (String) -> Bool = { WhisperEngine.isModelDownloaded(model: $0) }
 ) async -> SpeechStackStatus {
     async let speechRuntimeReady = sttClient.isReady()
     async let speakerModelsCached = diarizationService.hasCachedModels()
@@ -227,7 +235,9 @@ func loadSpeechStackStatus(
         speechModelCached: isSpeechModelCached(),
         speechRuntimeReady: speechRuntimeReady,
         speakerModelsCached: speakerModelsCached,
-        speakerModelsPrepared: speakerModelsPrepared
+        speakerModelsPrepared: speakerModelsPrepared,
+        whisperModelVariant: whisperModelVariant,
+        whisperModelDownloaded: isWhisperModelDownloaded(whisperModelVariant)
     )
 }
 
@@ -239,6 +249,8 @@ func printSpeechStackStatus(_ status: SpeechStackStatus, includeHeader: Bool = t
     print("  Speech runtime loaded: \(status.speechRuntimeReady ? "Yes" : "No")")
     print("  Speaker models cached: \(status.speakerModelsCached ? "Yes" : "No")")
     print("  Speaker models prepared: \(status.speakerModelsPrepared ? "Yes" : "No")")
+    print("  Whisper model variant: \(status.whisperModelVariant)")
+    print("  Whisper model downloaded: \(status.whisperModelDownloaded ? "Yes" : "No")")
     print("  Status: \(status.summary)")
 }
 

--- a/Sources/CLI/MacParakeetCLI.swift
+++ b/Sources/CLI/MacParakeetCLI.swift
@@ -6,7 +6,7 @@ struct CLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "macparakeet-cli",
         abstract: "Local STT, transcription, and prompt automation for Apple Silicon. Powered by Parakeet TDT, with optional Whisper multilingual recognition.",
-        version: "1.3.0",
+        version: "1.4.0",
         subcommands: [
             TranscribeCommand.self,
             HistoryCommand.self,

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -493,8 +493,11 @@ final class MeetingRecordingFlowCoordinator {
         case .showError(let message):
             stopPillPolling()
             stopTranscriptObservation()
-            pillViewModel?.state = .error(message)
             panelViewModel?.state = .error(message)
+            pillViewModel?.state = .error(
+                panelViewModel?.compactErrorRecoveryMessage
+                    ?? "Meeting interrupted. Open Library to retry transcription or export captured audio."
+            )
             hideMeetingPanel()
 
         case .hidePill:

--- a/Sources/MacParakeet/Views/Dictation/IdlePillController.swift
+++ b/Sources/MacParakeet/Views/Dictation/IdlePillController.swift
@@ -64,14 +64,16 @@ private final class IdlePillTrackingView: NSView {
 
     override func mouseDown(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
-        if expandedPillRect.contains(point) {
+        let activeRect = isExpanded ? expandedPillRect : collapsedPillRect
+        if activeRect.contains(point) {
             onClicked?()
         }
     }
 
-    // Only intercept clicks in the expanded pill region; pass through everywhere else
+    // Only intercept clicks in the visible pill region; pass through everywhere else.
     override func hitTest(_ point: NSPoint) -> NSView? {
-        expandedPillRect.contains(point) ? self : nil
+        let activeRect = isExpanded ? expandedPillRect : collapsedPillRect
+        return activeRect.contains(point) ? self : nil
     }
 }
 

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPillController.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPillController.swift
@@ -15,7 +15,23 @@ private class PillContentView: NSView {
 
     override func draw(_ dirtyRect: NSRect) {}
 
+    private var activePillRect: NSRect {
+        let height = min(bounds.height, 86)
+        return NSRect(
+            x: bounds.minX,
+            y: bounds.midY - height / 2,
+            width: bounds.width,
+            height: height
+        )
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        activePillRect.contains(point) ? super.hitTest(point) : nil
+    }
+
     override func rightMouseDown(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+        guard activePillRect.contains(point) else { return }
         onRightClick?(event)
     }
 }

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPillView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPillView.swift
@@ -217,6 +217,12 @@ struct MeetingRecordingPillView: View {
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Recording meeting, \(viewModel.formattedElapsed) elapsed")
+        .accessibilityAction {
+            onTap?()
+        }
+        .accessibilityAction(named: Text("End and transcribe")) {
+            viewModel.onStop?()
+        }
     }
 
     private var pillBackground: some View {

--- a/Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift
+++ b/Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift
@@ -1137,12 +1137,6 @@ struct OnboardingFlowView: View {
     }
 
     private var continueButtonDisabled: Bool {
-        if viewModel.step == .meetingRecording {
-            return viewModel.isBusy || !(viewModel.screenRecordingGranted || viewModel.meetingRecordingSkipped)
-        }
-        if viewModel.step == .calendar {
-            return viewModel.isBusy || !(viewModel.calendarPermissionGranted || viewModel.calendarSkipped)
-        }
         return !viewModel.canContinueFromCurrentStep() || viewModel.isBusy
     }
 }

--- a/Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift
+++ b/Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift
@@ -387,7 +387,7 @@ struct OnboardingFlowView: View {
                 featureRow(
                     icon: "lock.shield.fill",
                     title: "100% local",
-                    detail: "Audio never leaves your Mac. No cloud. No accounts. No tracking."
+                    detail: "Audio never leaves your Mac. No cloud STT. No accounts. Non-identifying diagnostics only."
                 )
             }
         }

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -69,6 +69,14 @@ struct TranscriptionLibraryView: View {
                 .padding(.bottom, DesignSystem.Spacing.sm)
             }
 
+            if let errorMessage = viewModel.errorMessage {
+                Text(errorMessage)
+                    .font(DesignSystem.Typography.bodySmall)
+                    .foregroundStyle(DesignSystem.Colors.errorRed)
+                    .padding(.horizontal, DesignSystem.Spacing.lg)
+                    .padding(.bottom, DesignSystem.Spacing.sm)
+            }
+
             // Grid
             if viewModel.filteredTranscriptions.isEmpty {
                 emptyState

--- a/Sources/MacParakeetCore/Audio/MeetingAudioCaptureService.swift
+++ b/Sources/MacParakeetCore/Audio/MeetingAudioCaptureService.swift
@@ -16,9 +16,11 @@ public protocol MeetingAudioCapturing: Sendable {
 
 protocol MeetingMicrophoneCapturing: Sendable {
     typealias AudioBufferHandler = @Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void
+    typealias StallObserver = @Sendable (MeetingAudioError) -> Void
     func start(
         processingMode: MeetingMicProcessingMode,
-        handler: @escaping AudioBufferHandler
+        handler: @escaping AudioBufferHandler,
+        onStall: StallObserver?
     ) throws -> MeetingMicrophoneCaptureStartReport
     func stop()
 }
@@ -44,12 +46,6 @@ extension SystemAudioTap: MeetingSystemAudioTapping {}
 public actor MeetingAudioCaptureService {
     public typealias EventHandler = @Sendable (MeetingAudioCaptureEvent) -> Void
     typealias MeetingMicrophoneCaptureFactory = @Sendable () -> any MeetingMicrophoneCapturing
-
-    // A 48kHz system tap can deliver ~500 callbacks over 5 seconds if Core Audio
-    // uses 480-frame buffers. The live transcription chunker needs that full span
-    // to accumulate its first 80k resampled samples, so the capture queue must be
-    // able to absorb at least one burst-sized chunk across both sources.
-    private static let captureEventBufferCapacity = 2048
 
     private let logger = Logger(subsystem: "com.macparakeet.core", category: "MeetingAudioCaptureService")
     private let microphoneCapture: any MeetingMicrophoneCapturing
@@ -105,9 +101,7 @@ public actor MeetingAudioCaptureService {
         }
 
         var continuation: AsyncStream<MeetingAudioCaptureEvent>.Continuation?
-        let stream = AsyncStream<MeetingAudioCaptureEvent>(
-            bufferingPolicy: .bufferingNewest(Self.captureEventBufferCapacity)
-        ) {
+        let stream = AsyncStream<MeetingAudioCaptureEvent>(bufferingPolicy: .unbounded) {
             continuation = $0
         }
         eventContinuation = continuation
@@ -133,21 +127,27 @@ public actor MeetingAudioCaptureService {
         let microphoneStartReport: MeetingMicrophoneCaptureStartReport
 
         do {
-            microphoneStartReport = try microphoneCapture.start(processingMode: micProcessingMode) { [weak self] buffer, time in
-                guard let copy = Self.deepCopyBuffer(buffer) else {
-                    Logger(subsystem: "com.macparakeet.core", category: "MeetingAudioCaptureService")
-                        .warning("deepCopyBuffer nil for microphone capture: format=\(buffer.format.commonFormat.rawValue) rate=\(buffer.format.sampleRate) ch=\(buffer.format.channelCount) interleaved=\(buffer.format.isInterleaved) frames=\(buffer.frameLength)")
-                    self?.eventSink.emit(
-                        .error(
-                            .captureRuntimeFailure(
-                                "microphone buffer copy failed (format=\(buffer.format.commonFormat.rawValue) rate=\(buffer.format.sampleRate) channels=\(buffer.format.channelCount))"
+            microphoneStartReport = try microphoneCapture.start(
+                processingMode: micProcessingMode,
+                handler: { [weak self] buffer, time in
+                    guard let copy = Self.deepCopyBuffer(buffer) else {
+                        Logger(subsystem: "com.macparakeet.core", category: "MeetingAudioCaptureService")
+                            .warning("deepCopyBuffer nil for microphone capture: format=\(buffer.format.commonFormat.rawValue) rate=\(buffer.format.sampleRate) ch=\(buffer.format.channelCount) interleaved=\(buffer.format.isInterleaved) frames=\(buffer.frameLength)")
+                        self?.eventSink.emit(
+                            .error(
+                                .captureRuntimeFailure(
+                                    "microphone buffer copy failed (format=\(buffer.format.commonFormat.rawValue) rate=\(buffer.format.sampleRate) channels=\(buffer.format.channelCount))"
+                                )
                             )
                         )
-                    )
-                    return
+                        return
+                    }
+                    self?.eventSink.emit(.microphoneBuffer(copy, time))
+                },
+                onStall: { [weak self] error in
+                    self?.eventSink.emit(.error(error))
                 }
-                self?.eventSink.emit(.microphoneBuffer(copy, time))
-            }
+            )
 
             try tap.start(
                 handler: { [weak self] buffer, time in

--- a/Sources/MacParakeetCore/Audio/MeetingAudioStorageWriter.swift
+++ b/Sources/MacParakeetCore/Audio/MeetingAudioStorageWriter.swift
@@ -31,18 +31,12 @@ final class MeetingAudioStorageWriter {
     private var systemInput: AVAssetWriterInput?
     private var microphoneConverter: AVAudioConverter?
     private var systemConverter: AVAudioConverter?
-    /// PTS counter — increments for both successfully appended buffers AND
-    /// dropped buffers (when `input.isReadyForMoreMediaData == false`). Used
-    /// as the `presentationTimeSamples` for each new sample buffer so
-    /// dropped frames produce a silent gap that preserves wall-clock
-    /// alignment in the output file. NOT what callers should report as
-    /// "frames on disk" — see `microphoneActualFrameCount` for that.
+    /// PTS counter for successfully appended buffers.
     private var microphoneWrittenFrames: Int64 = 0
     private var systemWrittenFrames: Int64 = 0
     /// Frames actually appended to the writer input (success path only).
     /// Used by `metrics(for:)` so the source-alignment metadata reports
-    /// what's truly on disk rather than the PTS counter, which could include
-    /// phantom frames from dropped buffers under sustained load.
+    /// what's truly on disk.
     private var microphoneActualFrameCount: Int64 = 0
     private var systemActualFrameCount: Int64 = 0
     private let sampleBufferFactory = PCMBufferToSampleBuffer()
@@ -169,15 +163,8 @@ final class MeetingAudioStorageWriter {
 
         let converted = try convertIfNeeded(buffer, converter: &converter)
         guard input.isReadyForMoreMediaData else {
-            logger.warning("Meeting audio writer input not ready, dropping buffer (\(converted.frameLength, privacy: .public) frames)")
-            // Advance the PTS counter so the next appended sample buffer
-            // lands at the correct wall-clock offset (silent gap for the
-            // dropped frames). `actualFrameCount` intentionally does NOT
-            // advance — `metrics(for:)` reports it as
-            // `writtenFrameCount`, and that value must match what's truly
-            // on disk so source-alignment downstream consumers can trust it.
-            writtenFrames += Int64(converted.frameLength)
-            return
+            logger.error("Meeting audio writer input not ready, failing capture before dropping \(converted.frameLength, privacy: .public) frames")
+            throw MeetingAudioError.storageFailed("audio writer backpressure")
         }
 
         let sampleBuffer = try sampleBufferFactory.makeSampleBuffer(

--- a/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
+++ b/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
@@ -52,6 +52,7 @@ func meetingInputDeviceAttempts(
 
 public final class MicrophoneCapture: @unchecked Sendable {
     public typealias AudioBufferHandler = @Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void
+    public typealias StallObserver = @Sendable (MeetingAudioError) -> Void
     private enum LifecycleState {
         case idle
         case starting
@@ -70,6 +71,7 @@ public final class MicrophoneCapture: @unchecked Sendable {
 
     private var state: LifecycleState = .idle
     private var bufferHandler: AudioBufferHandler?
+    private var stallObserver: StallObserver?
     private var firstBufferReceived = false
     private var watchdogWorkItem: DispatchWorkItem?
 
@@ -101,7 +103,8 @@ public final class MicrophoneCapture: @unchecked Sendable {
 
     public func start(
         processingMode: MeetingMicProcessingMode = .raw,
-        handler: @escaping AudioBufferHandler
+        handler: @escaping AudioBufferHandler,
+        onStall: StallObserver? = nil
     ) throws -> MeetingMicrophoneCaptureStartReport {
         var startError: Error?
         var didStart = false
@@ -124,7 +127,10 @@ public final class MicrophoneCapture: @unchecked Sendable {
             let inputNode = audioEngine.inputNode
             let inputDeviceAttempts = makeInputDeviceAttempts()
             state = .starting
-            handlerLock.withLock { bufferHandler = handler }
+            handlerLock.withLock {
+                bufferHandler = handler
+                stallObserver = onStall
+            }
             do {
                 startReport = try installTapAndStartEngineWithFallback(
                     inputNode: inputNode,
@@ -134,7 +140,10 @@ public final class MicrophoneCapture: @unchecked Sendable {
                 state = .running
                 didStart = true
             } catch {
-                handlerLock.withLock { bufferHandler = nil }
+                handlerLock.withLock {
+                    bufferHandler = nil
+                    stallObserver = nil
+                }
                 state = .idle
                 if let meetingError = error as? MeetingAudioError {
                     startError = meetingError
@@ -169,6 +178,7 @@ public final class MicrophoneCapture: @unchecked Sendable {
             audioEngine.stop()
             handlerLock.withLock {
                 bufferHandler = nil
+                stallObserver = nil
             }
             resetDiagnosticsState()
             state = .idle
@@ -409,7 +419,11 @@ public final class MicrophoneCapture: @unchecked Sendable {
                 guard let self else { return }
                 let shouldLog = self.watchdogLock.withLock { !self.firstBufferReceived }
                 guard shouldLog else { return }
+                let error = MeetingAudioError.captureRuntimeFailure(
+                    "microphone capture started but delivered no buffers within 2 seconds"
+                )
                 self.logger.warning("microphone_capture_no_buffers_within_timeout")
+                self.handlerLock.withLock { self.stallObserver }?(error)
             }
             watchdogWorkItem = item
             return item

--- a/Sources/MacParakeetCore/Database/TranscriptionRepository.swift
+++ b/Sources/MacParakeetCore/Database/TranscriptionRepository.swift
@@ -84,34 +84,65 @@ public final class TranscriptionRepository: TranscriptionRepositoryProtocol {
         }
     }
 
+    public func fetchByIDPrefix(_ idPrefix: String) throws -> [Transcription] {
+        try fetchByIDPrefix(idPrefix, sourceType: nil)
+    }
+
     public func fetchBySourceType(
         _ sourceType: Transcription.SourceType,
         idPrefix: String
+    ) throws -> [Transcription] {
+        try fetchByIDPrefix(idPrefix, sourceType: sourceType)
+    }
+
+    private func fetchByIDPrefix(
+        _ idPrefix: String,
+        sourceType: Transcription.SourceType?
     ) throws -> [Transcription] {
         let trimmed = idPrefix.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return [] }
         let textPattern = escapedLikePattern(trimmed.lowercased()) + "%"
         let compactPattern = escapedLikePattern(trimmed.lowercased().replacingOccurrences(of: "-", with: "")) + "%"
+        var sql = "(lower(id) LIKE ? ESCAPE '\\' OR lower(hex(id)) LIKE ? ESCAPE '\\')"
+        var arguments: [String] = [textPattern, compactPattern]
+        if let sourceType {
+            sql = "sourceType = ? AND \(sql)"
+            arguments.insert(sourceType.rawValue, at: 0)
+        }
         return try dbQueue.read { db in
             try Transcription
-                .filter(
-                    sql: "sourceType = ? AND (lower(id) LIKE ? ESCAPE '\\' OR lower(hex(id)) LIKE ? ESCAPE '\\')",
-                    arguments: [sourceType.rawValue, textPattern, compactPattern]
-                )
+                .filter(sql: sql, arguments: StatementArguments(arguments))
                 .order(Transcription.Columns.createdAt.desc)
                 .fetchAll(db)
         }
+    }
+
+    public func fetchByFileName(_ fileName: String) throws -> [Transcription] {
+        try fetchByFileName(fileName, sourceType: nil)
     }
 
     public func fetchBySourceType(
         _ sourceType: Transcription.SourceType,
         fileName: String
     ) throws -> [Transcription] {
+        try fetchByFileName(fileName, sourceType: sourceType)
+    }
+
+    private func fetchByFileName(
+        _ fileName: String,
+        sourceType: Transcription.SourceType?
+    ) throws -> [Transcription] {
         let trimmed = fileName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return [] }
+        var sql = "lower(fileName) = lower(?)"
+        var arguments: [String] = [trimmed]
+        if let sourceType {
+            sql = "sourceType = ? AND \(sql)"
+            arguments.insert(sourceType.rawValue, at: 0)
+        }
         return try dbQueue.read { db in
             try Transcription
-                .filter(sql: "sourceType = ? AND lower(fileName) = lower(?)", arguments: [sourceType.rawValue, trimmed])
+                .filter(sql: sql, arguments: StatementArguments(arguments))
                 .order(Transcription.Columns.createdAt.desc)
                 .fetchAll(db)
         }

--- a/Sources/MacParakeetCore/STT/WhisperEngine.swift
+++ b/Sources/MacParakeetCore/STT/WhisperEngine.swift
@@ -4,12 +4,49 @@ import Foundation
 import WhisperKit
 #endif
 
+private final class AsyncPermit: @unchecked Sendable {
+    private let lock = NSLock()
+    private var permits: Int
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    init(value: Int = 1) {
+        permits = max(0, value)
+    }
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if permits > 0 {
+                permits -= 1
+                lock.unlock()
+                continuation.resume()
+            } else {
+                waiters.append(continuation)
+                lock.unlock()
+            }
+        }
+    }
+
+    func signal() {
+        lock.lock()
+        if waiters.isEmpty {
+            permits += 1
+            lock.unlock()
+        } else {
+            let continuation = waiters.removeFirst()
+            lock.unlock()
+            continuation.resume()
+        }
+    }
+}
+
 public actor WhisperEngine: STTTranscribing {
     public static let defaultModelVariant = SpeechEnginePreference.defaultWhisperModelVariant
 
     private let modelVariant: String
     private let defaultLanguage: String?
     private let downloadBase: URL
+    private let transcriptionPermit = AsyncPermit()
 
     #if canImport(WhisperKit)
     private var whisperKit: WhisperKit?
@@ -110,9 +147,24 @@ public actor WhisperEngine: STTTranscribing {
         language: String?,
         onProgress: (@Sendable (Int, Int) -> Void)? = nil
     ) async throws -> STTResult {
+        await transcriptionPermit.wait()
+        defer { transcriptionPermit.signal() }
+        try Task.checkCancellation()
+        return try await transcribeLocked(
+            audioURL: audioURL,
+            language: language,
+            onProgress: onProgress
+        )
+    }
+
+    private func transcribeLocked(
+        audioURL: URL,
+        language: String?,
+        onProgress: (@Sendable (Int, Int) -> Void)? = nil
+    ) async throws -> STTResult {
         #if canImport(WhisperKit)
         do {
-            try await prepare(onProgress: nil)
+            try await prepareLocked(onProgress: nil)
             guard let whisperKit else {
                 throw STTError.modelNotLoaded
             }
@@ -151,6 +203,13 @@ public actor WhisperEngine: STTTranscribing {
     }
 
     public func prepare(onProgress: (@Sendable (String) -> Void)? = nil) async throws {
+        await transcriptionPermit.wait()
+        defer { transcriptionPermit.signal() }
+        try Task.checkCancellation()
+        try await prepareLocked(onProgress: onProgress)
+    }
+
+    private func prepareLocked(onProgress: (@Sendable (String) -> Void)? = nil) async throws {
         #if canImport(WhisperKit)
         if isLoaded, whisperKit != nil { return }
         guard let modelFolder = Self.localModelFolder(model: modelVariant, downloadBase: downloadBase) else {
@@ -183,6 +242,9 @@ public actor WhisperEngine: STTTranscribing {
     }
 
     public func unload() async {
+        await transcriptionPermit.wait()
+        defer { transcriptionPermit.signal() }
+
         #if canImport(WhisperKit)
         await whisperKit?.unloadModels()
         whisperKit = nil

--- a/Sources/MacParakeetCore/STT/WhisperEngine.swift
+++ b/Sources/MacParakeetCore/STT/WhisperEngine.swift
@@ -4,39 +4,102 @@ import Foundation
 import WhisperKit
 #endif
 
-private final class AsyncPermit: @unchecked Sendable {
+final class AsyncPermit: @unchecked Sendable {
+    private final class WaitState: @unchecked Sendable {
+        var cancelled = false
+        var completed = false
+    }
+
+    private struct Waiter {
+        let state: WaitState
+        let continuation: CheckedContinuation<Void, Error>
+    }
+
     private let lock = NSLock()
     private var permits: Int
-    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var waiterOrder: [UUID] = []
+    private var waiterHeadIndex = 0
+    private var waiters: [UUID: Waiter] = [:]
 
     init(value: Int = 1) {
         permits = max(0, value)
     }
 
-    func wait() async {
-        await withCheckedContinuation { continuation in
-            lock.lock()
-            if permits > 0 {
-                permits -= 1
-                lock.unlock()
-                continuation.resume()
-            } else {
-                waiters.append(continuation)
-                lock.unlock()
+    func wait() async throws {
+        let id = UUID()
+        let state = WaitState()
+        try await withTaskCancellationHandler {
+            let _: Void = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                lock.lock()
+                if state.cancelled {
+                    state.completed = true
+                    lock.unlock()
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                if permits > 0 {
+                    permits -= 1
+                    state.completed = true
+                    lock.unlock()
+                    continuation.resume()
+                } else {
+                    waiterOrder.append(id)
+                    waiters[id] = Waiter(state: state, continuation: continuation)
+                    lock.unlock()
+                }
             }
+        } onCancel: {
+            cancelWaiter(id: id, state: state)
         }
+    }
+
+    private func cancelWaiter(id: UUID, state: WaitState) {
+        lock.lock()
+        if state.completed {
+            lock.unlock()
+            return
+        }
+        guard let waiter = waiters.removeValue(forKey: id) else {
+            state.cancelled = true
+            lock.unlock()
+            return
+        }
+        state.completed = true
+        lock.unlock()
+        waiter.continuation.resume(throwing: CancellationError())
     }
 
     func signal() {
         lock.lock()
-        if waiters.isEmpty {
-            permits += 1
+        while waiterHeadIndex < waiterOrder.count {
+            let id = waiterOrder[waiterHeadIndex]
+            waiterHeadIndex += 1
+            guard let waiter = waiters.removeValue(forKey: id) else {
+                continue
+            }
+            waiter.state.completed = true
+            compactWaiterOrderIfNeeded()
             lock.unlock()
-        } else {
-            let continuation = waiters.removeFirst()
-            lock.unlock()
-            continuation.resume()
+            waiter.continuation.resume()
+            return
         }
+        permits += 1
+        compactWaiterOrderIfNeeded()
+        lock.unlock()
+    }
+
+    func pendingWaiterCount() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return waiters.count
+    }
+
+    private func compactWaiterOrderIfNeeded() {
+        guard waiterHeadIndex > 64, waiterHeadIndex * 2 > waiterOrder.count else {
+            return
+        }
+        waiterOrder = Array(waiterOrder.dropFirst(waiterHeadIndex))
+        waiterHeadIndex = 0
     }
 }
 
@@ -147,7 +210,7 @@ public actor WhisperEngine: STTTranscribing {
         language: String?,
         onProgress: (@Sendable (Int, Int) -> Void)? = nil
     ) async throws -> STTResult {
-        await transcriptionPermit.wait()
+        try await transcriptionPermit.wait()
         defer { transcriptionPermit.signal() }
         try Task.checkCancellation()
         return try await transcribeLocked(
@@ -194,7 +257,7 @@ public actor WhisperEngine: STTTranscribing {
     }
 
     public func prepare(onProgress: (@Sendable (String) -> Void)? = nil) async throws {
-        await transcriptionPermit.wait()
+        try await transcriptionPermit.wait()
         defer { transcriptionPermit.signal() }
         try Task.checkCancellation()
         try await prepareLocked(onProgress: onProgress)
@@ -233,8 +296,13 @@ public actor WhisperEngine: STTTranscribing {
     }
 
     public func unload() async {
-        await transcriptionPermit.wait()
+        do {
+            try await transcriptionPermit.wait()
+        } catch {
+            return
+        }
         defer { transcriptionPermit.signal() }
+        guard !Task.isCancelled else { return }
 
         #if canImport(WhisperKit)
         await whisperKit?.unloadModels()

--- a/Sources/MacParakeetCore/Services/AppPaths.swift
+++ b/Sources/MacParakeetCore/Services/AppPaths.swift
@@ -47,6 +47,14 @@ public enum AppPaths {
         "\(binDir)/yt-dlp"
     }
 
+    /// Resolve bundled yt-dlp seed binary from app resources.
+    /// Returns nil when running outside an app bundle or when yt-dlp is not present.
+    public static func bundledYtDlpPath() -> String? {
+        guard let resourcePath = Bundle.main.resourcePath else { return nil }
+        let ytDlpPath = (resourcePath as NSString).appendingPathComponent("yt-dlp")
+        return FileManager.default.isExecutableFile(atPath: ytDlpPath) ? ytDlpPath : nil
+    }
+
     /// Cached discover feed
     public static var discoverCachePath: String {
         "\(appSupportDir)/discover-cache.json"

--- a/Sources/MacParakeetCore/Services/BinaryBootstrap.swift
+++ b/Sources/MacParakeetCore/Services/BinaryBootstrap.swift
@@ -43,6 +43,7 @@ public actor BinaryBootstrap {
     private let fileManager: FileManager
     private let ensureDirectories: @Sendable () throws -> Void
     private let ytDlpBinaryPath: @Sendable () -> String
+    private let bundledYtDlpPath: @Sendable () -> String?
     private let tempDirPath: @Sendable () -> String
 
     public init(
@@ -52,6 +53,7 @@ public actor BinaryBootstrap {
         fileManager: FileManager = .default,
         ensureDirectories: @escaping @Sendable () throws -> Void = { try AppPaths.ensureDirectories() },
         ytDlpBinaryPath: @escaping @Sendable () -> String = { AppPaths.ytDlpBinaryPath },
+        bundledYtDlpPath: @escaping @Sendable () -> String? = { AppPaths.bundledYtDlpPath() },
         tempDirPath: @escaping @Sendable () -> String = { AppPaths.tempDir }
     ) {
         self.session = session
@@ -60,15 +62,28 @@ public actor BinaryBootstrap {
         self.fileManager = fileManager
         self.ensureDirectories = ensureDirectories
         self.ytDlpBinaryPath = ytDlpBinaryPath
+        self.bundledYtDlpPath = bundledYtDlpPath
         self.tempDirPath = tempDirPath
     }
 
-    public func ensureYtDlpAvailable() async throws -> String {
+    public func ensureYtDlpAvailable(allowNetworkUpdate: Bool = false) async throws -> String {
         try ensureDirectories()
 
         let targetPath = ytDlpBinaryPath()
+        if allowNetworkUpdate {
+            try await installYtDlp(at: targetPath)
+            defaults.set(now(), forKey: Self.ytDlpLastUpdateCheckKey)
+            return targetPath
+        }
+
         if fileManager.isExecutableFile(atPath: targetPath) {
-            await autoUpdateYtDlpIfNeeded()
+            return targetPath
+        }
+
+        if let bundledPath = bundledYtDlpPath(),
+           fileManager.isExecutableFile(atPath: bundledPath)
+        {
+            try installExecutable(from: URL(fileURLWithPath: bundledPath), toPath: targetPath)
             return targetPath
         }
 
@@ -78,9 +93,16 @@ public actor BinaryBootstrap {
 
     public nonisolated static func resolveYtDlpPath(
         fileManager: FileManager = .default,
-        path: String = AppPaths.ytDlpBinaryPath
+        managedPath: String = AppPaths.ytDlpBinaryPath,
+        bundledPath: String? = AppPaths.bundledYtDlpPath()
     ) -> String? {
-        fileManager.isExecutableFile(atPath: path) ? path : nil
+        if fileManager.isExecutableFile(atPath: managedPath) {
+            return managedPath
+        }
+        if let bundledPath, fileManager.isExecutableFile(atPath: bundledPath) {
+            return bundledPath
+        }
+        return nil
     }
 
     /// Weekly non-blocking update. Failures are intentionally ignored.

--- a/Sources/MacParakeetCore/Services/BinaryBootstrap.swift
+++ b/Sources/MacParakeetCore/Services/BinaryBootstrap.swift
@@ -76,6 +76,13 @@ public actor BinaryBootstrap {
         return targetPath
     }
 
+    public nonisolated static func resolveYtDlpPath(
+        fileManager: FileManager = .default,
+        path: String = AppPaths.ytDlpBinaryPath
+    ) -> String? {
+        fileManager.isExecutableFile(atPath: path) ? path : nil
+    }
+
     /// Weekly non-blocking update. Failures are intentionally ignored.
     public func autoUpdateYtDlpIfNeeded() async {
         guard shouldRunYtDlpUpdateCheck() else { return }

--- a/Sources/MacParakeetCore/Services/MeetingRecordingRecoveryService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecordingRecoveryService.swift
@@ -92,11 +92,9 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
                 if try canOfferRecovery(for: lock) {
                     viable.append(lock)
                 } else {
-                    // Auto-clean instead of skipping silently: the folder + lock
-                    // are otherwise immortal, accumulating across every crash
-                    // until the user manually deletes them. Logged for forensic
-                    // reference if a user reports missing recordings.
-                    purgeEmptySession(lock)
+                    logger.info(
+                        "meeting_recovery_skipped_empty_session session=\(lock.sessionId.uuidString, privacy: .public)"
+                    )
                 }
             } catch {
                 logger.error(
@@ -122,21 +120,6 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
         let micSize = fileSize(at: folderURL.appendingPathComponent("microphone.m4a"))
         let sysSize = fileSize(at: folderURL.appendingPathComponent("system.m4a"))
         return max(micSize, sysSize) >= Self.minViableAudioBytes
-    }
-
-    private func purgeEmptySession(_ lock: MeetingRecordingLockFile) {
-        guard let folderURL = lock.folderURL else { return }
-        guard fileManager.fileExists(atPath: folderURL.path) else { return }
-        do {
-            try fileManager.removeItem(at: folderURL)
-            logger.info(
-                "meeting_recovery_purged_empty_session session=\(lock.sessionId.uuidString, privacy: .public)"
-            )
-        } catch {
-            logger.error(
-                "meeting_recovery_purge_failed session=\(lock.sessionId.uuidString, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
-            )
-        }
     }
 
     public func recover(_ lock: MeetingRecordingLockFile) async throws -> Transcription {

--- a/Sources/MacParakeetCore/Services/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/TelemetryEvent.swift
@@ -581,7 +581,7 @@ extension TelemetryEventSpec {
             ), device)
         case .dictationFailed(let errorType, let errorDetail, let device):
             var props = ["error_type": errorType]
-            if let errorDetail { props["error_detail"] = errorDetail }
+            if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
             return Self.mergeDevice(props, device)
         case .dictationOperation(
             let operationID,
@@ -640,7 +640,7 @@ extension TelemetryEventSpec {
                 "stage": stage.rawValue,
                 "error_type": errorType,
             ]
-            if let errorDetail { props["error_detail"] = errorDetail }
+            if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
             return props
         case .transcriptionOperation(
             let operationID,
@@ -689,7 +689,7 @@ extension TelemetryEventSpec {
             ]
         case .diarizationFailed(let source, let errorType, let errorDetail):
             var props = ["source": source.rawValue, "error_type": errorType]
-            if let errorDetail { props["error_detail"] = errorDetail }
+            if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
             return props
         case .exportUsed(let format):
             return ["format": format]
@@ -697,19 +697,19 @@ extension TelemetryEventSpec {
             return ["provider": provider]
         case .llmPromptResultFailed(let provider, let errorType, let errorDetail):
             var props = ["provider": provider, "error_type": errorType]
-            if let errorDetail { props["error_detail"] = errorDetail }
+            if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
             return props
         case .llmChatUsed(let provider, let messageCount):
             return ["provider": provider, "message_count": "\(messageCount)"]
         case .llmChatFailed(let provider, let errorType, let errorDetail):
             var props = ["provider": provider, "error_type": errorType]
-            if let errorDetail { props["error_detail"] = errorDetail }
+            if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
             return props
         case .llmTransformUsed(let provider):
             return ["provider": provider]
         case .llmTransformFailed(let provider, let errorType, let errorDetail):
             var props = ["provider": provider, "error_type": errorType]
-            if let errorDetail { props["error_detail"] = errorDetail }
+            if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
             return props
         case .llmFormatterUsed(
             let provider,
@@ -790,10 +790,10 @@ extension TelemetryEventSpec {
             return ["step": step]
         case .licenseActivationFailed(let errorType, let errorDetail):
             var props = ["error_type": errorType]
-            if let errorDetail { props["error_detail"] = errorDetail }
+            if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
             return props
         case .restoreFailed(let errorType, let errorDetail):
-            return Self.compactProps(("error_type", errorType), ("error_detail", errorDetail))
+            return Self.compactProps(("error_type", errorType), ("error_detail", Self.sanitizedErrorDetail(errorDetail)))
         case .permissionPrompted(let permission):
             return ["permission": permission.rawValue]
         case .permissionGranted(let permission):
@@ -808,7 +808,7 @@ extension TelemetryEventSpec {
             return ["duration_seconds": Self.format(durationSeconds)]
         case .modelDownloadFailed(let errorType, let errorDetail):
             var props = ["error_type": errorType]
-            if let errorDetail { props["error_detail"] = errorDetail }
+            if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
             return props
         case .feedbackSubmitted(let category):
             return ["category": category]
@@ -849,7 +849,7 @@ extension TelemetryEventSpec {
             return ["duration_seconds": Self.format(durationSeconds)]
         case .meetingRecordingFailed(let errorType, let errorDetail):
             var props = ["error_type": errorType]
-            if let errorDetail { props["error_detail"] = errorDetail }
+            if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
             return props
         case .meetingOperation(
             let operationID,
@@ -909,7 +909,7 @@ extension TelemetryEventSpec {
                 "source": source.rawValue,
                 "error_type": errorType,
             ]
-            if let errorDetail { props["error_detail"] = errorDetail }
+            if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
             return props
         case .calendarReminderShown(let mode, let leadMinutes, let hasMeetUrl):
             return [
@@ -1012,6 +1012,11 @@ extension TelemetryEventSpec {
 
     private static func boolString(_ value: Bool) -> String {
         value ? "true" : "false"
+    }
+
+    private static func sanitizedErrorDetail(_ detail: String?) -> String? {
+        guard let detail, !detail.isEmpty else { return nil }
+        return String(TelemetryErrorClassifier.sanitize(detail).prefix(512))
     }
 
     private static func mergeDevice(_ base: [String: String]?, _ device: RecordingDeviceInfo?) -> [String: String]? {

--- a/Sources/MacParakeetCore/Services/VideoStreamService.swift
+++ b/Sources/MacParakeetCore/Services/VideoStreamService.swift
@@ -195,10 +195,10 @@ public final class VideoStreamService: Sendable {
 
     private func resolveYtDlpPath() throws -> String {
         let candidates = [
-            AppPaths.ytDlpBinaryPath,
+            BinaryBootstrap.resolveYtDlpPath(),
             "/opt/homebrew/bin/yt-dlp",
             "/usr/local/bin/yt-dlp",
-        ]
+        ].compactMap { $0 }
         for path in candidates {
             if FileManager.default.isExecutableFile(atPath: path) {
                 return path

--- a/Sources/MacParakeetCore/Services/VideoStreamService.swift
+++ b/Sources/MacParakeetCore/Services/VideoStreamService.swift
@@ -28,17 +28,17 @@ public final class VideoStreamService: Sendable {
         // Check cache
         if let cached = Self.cache.withLock({ $0[videoID] }),
            cached.expiresAt > Date() {
-            logger.notice("🎯 Cache HIT for \(videoID) (expires in \(Int(cached.expiresAt.timeIntervalSinceNow))s)")
+            logger.notice("video_stream_cache_hit video_id=\(videoID, privacy: .private) expires_in_seconds=\(Int(cached.expiresAt.timeIntervalSinceNow), privacy: .public)")
             return cached.url
         }
-        logger.notice("❌ Cache MISS for \(videoID), extracting via yt-dlp")
+        logger.notice("video_stream_cache_miss video_id=\(videoID, privacy: .private)")
 
         let url = try await extractStreamURL(youtubeURL: youtubeURL)
 
         Self.cache.withLock {
             $0[videoID] = CachedURL(url: url, expiresAt: Date().addingTimeInterval(Self.cacheTTL))
         }
-        logger.notice("✅ Cached stream URL for \(videoID) (TTL: \(Int(Self.cacheTTL))s)")
+        logger.notice("video_stream_cached video_id=\(videoID, privacy: .private) ttl_seconds=\(Int(Self.cacheTTL), privacy: .public)")
 
         return url
     }
@@ -47,15 +47,16 @@ public final class VideoStreamService: Sendable {
     public func invalidateCache(for youtubeURL: String) {
         let videoID = YouTubeURLValidator.extractVideoID(youtubeURL) ?? youtubeURL
         _ = Self.cache.withLock { $0.removeValue(forKey: videoID) }
-        logger.notice("🗑 Invalidated cache for \(videoID)")
+        logger.notice("video_stream_cache_invalidated video_id=\(videoID, privacy: .private)")
     }
 
     // MARK: - Private
 
     private func extractStreamURL(youtubeURL: String) async throws -> URL {
         let ytDlpPath = try resolveYtDlpPath()
-        logger.notice("▶️ Starting yt-dlp extraction for \(youtubeURL)")
-        logger.notice("  yt-dlp path: \(ytDlpPath)")
+        let videoID = YouTubeURLValidator.extractVideoID(youtubeURL) ?? "unknown"
+        logger.notice("video_stream_extraction_started video_id=\(videoID, privacy: .private)")
+        logger.notice("video_stream_yt_dlp_path path=\(ytDlpPath, privacy: .private)")
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: ytDlpPath)
@@ -82,7 +83,7 @@ public final class VideoStreamService: Sendable {
         let startTime = ContinuousClock.now
 
         try process.run()
-        logger.notice("  yt-dlp process launched (PID: \(process.processIdentifier))")
+        logger.notice("video_stream_yt_dlp_launched pid=\(process.processIdentifier, privacy: .public)")
 
         // Wrap EVERYTHING in a single timeout — process termination + pipe drain.
         // The pipes are read AFTER the process terminates (or is killed) rather
@@ -140,29 +141,34 @@ public final class VideoStreamService: Sendable {
         }
 
         let elapsed = ContinuousClock.now - startTime
-        logger.notice("  yt-dlp finished in \(elapsed) (exit: \(process.terminationStatus))")
+        logger.notice("video_stream_yt_dlp_finished elapsed=\(String(describing: elapsed), privacy: .public) exit=\(process.terminationStatus, privacy: .public)")
 
         let stdout = String(data: result.stdout, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let stderr = String(data: result.stderr, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
         if !stderr.isEmpty {
-            logger.notice("  yt-dlp stderr: \(stderr)")
+            logger.notice("video_stream_yt_dlp_stderr detail=\(Self.sanitizedYtDlpMessage(stderr), privacy: .private)")
         }
 
         guard process.terminationStatus == 0, !stdout.isEmpty else {
-            logger.error("❌ yt-dlp extraction failed: \(stderr)")
-            throw VideoStreamError.extractionFailed(stderr.isEmpty ? "No output from yt-dlp" : stderr)
+            let reason = stderr.isEmpty ? "No output from yt-dlp" : Self.sanitizedYtDlpMessage(stderr)
+            logger.error("video_stream_extraction_failed reason=\(reason, privacy: .private)")
+            throw VideoStreamError.extractionFailed(reason)
         }
 
         // yt-dlp may return multiple URLs (video + audio); take the first
         let urlString = stdout.components(separatedBy: .newlines).first ?? stdout
         guard let url = URL(string: urlString) else {
-            logger.error("❌ Invalid stream URL: \(urlString.prefix(100))")
+            logger.error("video_stream_invalid_url")
             throw VideoStreamError.invalidStreamURL
         }
 
-        logger.notice("✅ Extracted stream URL for \(youtubeURL) in \(elapsed)")
+        logger.notice("video_stream_extraction_succeeded video_id=\(videoID, privacy: .private) elapsed=\(String(describing: elapsed), privacy: .public)")
         return url
+    }
+
+    private static func sanitizedYtDlpMessage(_ raw: String) -> String {
+        String(TelemetryErrorClassifier.sanitize(raw).prefix(512))
     }
 
     private enum ProcessOutcome: Sendable {

--- a/Sources/MacParakeetCore/Services/YouTubeDownloader.swift
+++ b/Sources/MacParakeetCore/Services/YouTubeDownloader.swift
@@ -450,15 +450,19 @@ public actor YouTubeDownloader {
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
 
+        func sanitized(_ value: String) -> String {
+            String(TelemetryErrorClassifier.sanitize(value).prefix(512))
+        }
+
         if let errorLine = lines.first(where: { $0.localizedCaseInsensitiveContains("error:") }) {
-            return errorLine
+            return sanitized(errorLine)
         }
 
         if let nonWarningLine = lines.first(where: { !$0.localizedCaseInsensitiveContains("warning:") }) {
-            return nonWarningLine
+            return sanitized(nonWarningLine)
         }
 
-        return lines.first ?? trimmed
+        return sanitized(lines.first ?? trimmed)
     }
 
     private func runYtDlp(

--- a/Sources/MacParakeetCore/Utilities/TranscriptionAssetCleanup.swift
+++ b/Sources/MacParakeetCore/Utilities/TranscriptionAssetCleanup.swift
@@ -1,6 +1,17 @@
 import Foundation
 import os
 
+public enum TranscriptionAssetCleanupError: Error, LocalizedError {
+    case removalFailed(path: String, reason: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .removalFailed(_, let reason):
+            return "Could not remove app-owned audio: \(reason)"
+        }
+    }
+}
+
 public enum TranscriptionAssetCleanup {
     private static let logger = Logger(
         subsystem: "com.macparakeet.core",
@@ -10,20 +21,20 @@ public enum TranscriptionAssetCleanup {
     public static func removeOwnedAssets(
         for transcription: Transcription,
         fileManager: FileManager = .default
-    ) {
+    ) throws {
         guard let filePath = transcription.filePath, !filePath.isEmpty else { return }
 
         switch transcription.sourceType {
         case .youtube:
-            removeYouTubeFile(at: URL(fileURLWithPath: filePath), fileManager: fileManager)
+            try removeYouTubeFile(at: URL(fileURLWithPath: filePath), fileManager: fileManager)
         case .meeting:
-            removeMeetingFolder(containing: URL(fileURLWithPath: filePath), fileManager: fileManager)
+            try removeMeetingFolder(containing: URL(fileURLWithPath: filePath), fileManager: fileManager)
         case .file:
             return
         }
     }
 
-    private static func removeYouTubeFile(at fileURL: URL, fileManager: FileManager) {
+    private static func removeYouTubeFile(at fileURL: URL, fileManager: FileManager) throws {
         let downloadsRootURL = URL(fileURLWithPath: AppPaths.youtubeDownloadsDir, isDirectory: true)
             .standardizedFileURL
         let targetURL = fileURL.standardizedFileURL
@@ -35,10 +46,10 @@ public enum TranscriptionAssetCleanup {
             return
         }
 
-        removeItem(at: targetURL, fileManager: fileManager)
+        try removeItem(at: targetURL, fileManager: fileManager)
     }
 
-    private static func removeMeetingFolder(containing fileURL: URL, fileManager: FileManager) {
+    private static func removeMeetingFolder(containing fileURL: URL, fileManager: FileManager) throws {
         let meetingRootURL = URL(fileURLWithPath: AppPaths.meetingRecordingsDir, isDirectory: true)
             .standardizedFileURL
         let folderURL = fileURL.deletingLastPathComponent().standardizedFileURL
@@ -49,16 +60,20 @@ public enum TranscriptionAssetCleanup {
             )
             return
         }
-        removeItem(at: folderURL, fileManager: fileManager)
+        try removeItem(at: folderURL, fileManager: fileManager)
     }
 
-    private static func removeItem(at url: URL, fileManager: FileManager) {
+    private static func removeItem(at url: URL, fileManager: FileManager) throws {
         guard fileManager.fileExists(atPath: url.path) else { return }
         do {
             try fileManager.removeItem(at: url)
         } catch {
             logger.warning(
                 "Failed to remove transcription asset at \(url.path, privacy: .private): \(String(describing: error), privacy: .private)"
+            )
+            throw TranscriptionAssetCleanupError.removalFailed(
+                path: url.path,
+                reason: error.localizedDescription
             )
         }
     }

--- a/Sources/MacParakeetViewModels/MediaPlayerViewModel.swift
+++ b/Sources/MacParakeetViewModels/MediaPlayerViewModel.swift
@@ -116,7 +116,7 @@ public final class MediaPlayerViewModel {
         playerState = .loading
         loadingElapsed = 0
         startLoadingTimer()
-        logger.info("Loading media: mode=\(String(describing: mode)), source=\(transcription.sourceURL ?? transcription.filePath ?? "none")")
+        logger.info("Loading media: mode=\(String(describing: mode), privacy: .public), source=\(transcription.sourceURL ?? transcription.filePath ?? "none", privacy: .private)")
 
         let task = Task { @MainActor [weak self] in
             guard let self else { return }
@@ -209,7 +209,7 @@ public final class MediaPlayerViewModel {
 
         let start = ContinuousClock.now
         do {
-            logger.info("Extracting stream URL via yt-dlp for \(sourceURL)")
+            logger.info("Extracting stream URL via yt-dlp for source=\(sourceURL, privacy: .private)")
             let streamURL = try await videoStreamService.streamURL(for: sourceURL)
             let extractionTime = ContinuousClock.now - start
             logger.info("Stream URL extracted in \(extractionTime)")
@@ -228,8 +228,9 @@ public final class MediaPlayerViewModel {
             logger.info("YouTube video player ready")
         } catch {
             guard !Task.isCancelled else { return }
-            logger.error("YouTube stream load failed after \(ContinuousClock.now - start): \(error.localizedDescription)")
-            playerState = .error(error.localizedDescription)
+            let detail = TelemetryErrorClassifier.errorDetail(error)
+            logger.error("YouTube stream load failed after \(String(describing: ContinuousClock.now - start), privacy: .public): \(detail, privacy: .private)")
+            playerState = .error(detail)
         }
     }
 

--- a/Sources/MacParakeetViewModels/MeetingRecordingPanelViewModel.swift
+++ b/Sources/MacParakeetViewModels/MeetingRecordingPanelViewModel.swift
@@ -162,6 +162,11 @@ public final class MeetingRecordingPanelViewModel {
         }
     }
 
+    public var compactErrorRecoveryMessage: String? {
+        guard case .error = state else { return nil }
+        return "Meeting interrupted. Open Library to retry transcription or export captured audio."
+    }
+
     public var showsLaggingIndicator: Bool {
         if case .recording = state {
             return isTranscriptionLagging

--- a/Sources/MacParakeetViewModels/TranscriptionDeletionCleanup.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionDeletionCleanup.swift
@@ -2,9 +2,7 @@ import Foundation
 import MacParakeetCore
 
 enum TranscriptionDeletionCleanup {
-    static func removeOwnedAssets(for transcription: Transcription) {
-        Task.detached(priority: .utility) {
-            TranscriptionAssetCleanup.removeOwnedAssets(for: transcription)
-        }
+    static func removeOwnedAssets(for transcription: Transcription) throws {
+        try TranscriptionAssetCleanup.removeOwnedAssets(for: transcription)
     }
 }

--- a/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
@@ -29,6 +29,7 @@ public final class TranscriptionLibraryViewModel {
     public var searchText: String = "" { didSet { recomputeFiltered() } }
     public var sortOrder: LibrarySortOrder = .dateDescending { didSet { recomputeFiltered() } }
     public private(set) var filteredTranscriptions: [Transcription] = []
+    public var errorMessage: String?
 
     private var transcriptionRepo: TranscriptionRepositoryProtocol?
     public let scope: TranscriptionLibraryScope
@@ -93,25 +94,29 @@ public final class TranscriptionLibraryViewModel {
     public func toggleFavorite(_ transcription: Transcription) {
         let newValue = !transcription.isFavorite
         do {
+            errorMessage = nil
             try transcriptionRepo?.updateFavorite(id: transcription.id, isFavorite: newValue)
             if let idx = transcriptions.firstIndex(where: { $0.id == transcription.id }) {
                 transcriptions[idx].isFavorite = newValue
             }
             Telemetry.send(.transcriptionFavorited(isFavorite: newValue))
         } catch {
-            // DB failed — don't update UI state
+            logger.error("Failed to update transcription favorite: \(error.localizedDescription, privacy: .private)")
+            errorMessage = "Failed to update favorite: \(error.localizedDescription)"
         }
     }
 
     public func deleteTranscription(_ transcription: Transcription) {
         do {
+            errorMessage = nil
+            try TranscriptionDeletionCleanup.removeOwnedAssets(for: transcription)
             let deleted = try transcriptionRepo?.delete(id: transcription.id) ?? false
             guard deleted else { return }
-            TranscriptionDeletionCleanup.removeOwnedAssets(for: transcription)
             transcriptions.removeAll { $0.id == transcription.id }
             Telemetry.send(.transcriptionDeleted)
         } catch {
-            // DB failed — don't remove from UI
+            logger.error("Failed to delete transcription: \(error.localizedDescription, privacy: .private)")
+            errorMessage = "Failed to delete transcription: \(error.localizedDescription)"
         }
     }
 }

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -434,16 +434,17 @@ public final class TranscriptionViewModel {
         }
 
         do {
+            try TranscriptionDeletionCleanup.removeOwnedAssets(for: transcription)
             let deleted = try repo.delete(id: transcription.id)
             guard deleted else { return }
-            TranscriptionDeletionCleanup.removeOwnedAssets(for: transcription)
             Telemetry.send(.transcriptionDeleted)
             if currentTranscription?.id == transcription.id {
                 currentTranscription = nil
             }
             loadTranscriptions()
         } catch {
-            logger.error("Failed to delete transcription: \(error.localizedDescription, privacy: .public)")
+            logger.error("Failed to delete transcription: \(error.localizedDescription, privacy: .private)")
+            errorMessage = "Failed to delete transcription: \(error.localizedDescription)"
         }
     }
 

--- a/Tests/CLITests/CLIHelpersTests.swift
+++ b/Tests/CLITests/CLIHelpersTests.swift
@@ -27,6 +27,28 @@ final class CLIHelpersTests: XCTestCase {
         XCTAssertEqual(found.id, t.id)
     }
 
+    func testFindTranscriptionRejectsShortUUIDPrefixUnlessItIsName() throws {
+        let db = try DatabaseManager()
+        let repo = TranscriptionRepository(dbQueue: db.dbQueue)
+        let uuid = UUID(uuidString: "AABBCCDD-1111-1111-1111-111111111111")!
+        let t = Transcription(id: uuid, fileName: "ab", rawTranscript: "Hello", status: .completed)
+        try repo.save(t)
+
+        XCTAssertThrowsError(try findTranscription(id: "aab", repo: repo)) { error in
+            guard let lookupError = error as? CLILookupError else {
+                return XCTFail("Expected CLILookupError, got \(error)")
+            }
+            if case .shortUUIDPrefix(let minimumLength) = lookupError {
+                XCTAssertEqual(minimumLength, 4)
+            } else {
+                XCTFail("Expected .shortUUIDPrefix, got \(lookupError)")
+            }
+        }
+
+        let foundByName = try findTranscription(id: "ab", repo: repo)
+        XCTAssertEqual(foundByName.id, t.id)
+    }
+
     func testFindTranscriptionByExactName() throws {
         let db = try DatabaseManager()
         let repo = TranscriptionRepository(dbQueue: db.dbQueue)
@@ -100,6 +122,24 @@ final class CLIHelpersTests: XCTestCase {
         let prefix = String(d.id.uuidString.prefix(8))
         let found = try findDictation(id: prefix, repo: repo)
         XCTAssertEqual(found.id, d.id)
+    }
+
+    func testFindDictationRejectsShortUUIDPrefix() throws {
+        let db = try DatabaseManager()
+        let repo = DictationRepository(dbQueue: db.dbQueue)
+        let uuid = UUID(uuidString: "BBCCDDEE-1111-1111-1111-111111111111")!
+        try repo.save(Dictation(id: uuid, durationMs: 1000, rawTranscript: "Test dictation"))
+
+        XCTAssertThrowsError(try findDictation(id: "bbc", repo: repo)) { error in
+            guard let lookupError = error as? CLILookupError else {
+                return XCTFail("Expected CLILookupError, got \(error)")
+            }
+            if case .shortUUIDPrefix(let minimumLength) = lookupError {
+                XCTAssertEqual(minimumLength, 4)
+            } else {
+                XCTFail("Expected .shortUUIDPrefix, got \(lookupError)")
+            }
+        }
     }
 
     func testFindDictationThrowsNotFoundForBogusID() throws {
@@ -199,6 +239,29 @@ final class CLIHelpersTests: XCTestCase {
                 XCTFail("Expected .notFound, got \(lookupError)")
             }
         }
+    }
+
+    func testFindMeetingRejectsShortUUIDPrefixUnlessItIsName() throws {
+        let db = try DatabaseManager()
+        let repo = TranscriptionRepository(dbQueue: db.dbQueue)
+
+        let uuid = UUID(uuidString: "CCDDEEFF-1111-1111-1111-111111111111")!
+        let meeting = Transcription(id: uuid, fileName: "cc", status: .completed, sourceType: .meeting)
+        try repo.save(meeting)
+
+        XCTAssertThrowsError(try findMeeting(idOrName: "ccd", repo: repo)) { error in
+            guard let lookupError = error as? CLILookupError else {
+                return XCTFail("Expected CLILookupError")
+            }
+            if case .shortUUIDPrefix(let minimumLength) = lookupError {
+                XCTAssertEqual(minimumLength, 4)
+            } else {
+                XCTFail("Expected .shortUUIDPrefix, got \(lookupError)")
+            }
+        }
+
+        let foundByName = try findMeeting(idOrName: "cc", repo: repo)
+        XCTAssertEqual(foundByName.id, meeting.id)
     }
 
     func testFindDictationThrowsAmbiguousForSharedPrefix() throws {

--- a/Tests/CLITests/ModelLifecycleCommandTests.swift
+++ b/Tests/CLITests/ModelLifecycleCommandTests.swift
@@ -17,9 +17,10 @@ final class ModelLifecycleCommandTests: XCTestCase {
     }
 
     func testHealthParsesRepairFlags() throws {
-        let command = try HealthCommand.parse(["--repair-models", "--repair-attempts", "6"])
+        let command = try HealthCommand.parse(["--repair-models", "--repair-attempts", "6", "--repair-binaries"])
         XCTAssertTrue(command.repairModels)
         XCTAssertEqual(command.repairAttempts, 6)
+        XCTAssertTrue(command.repairBinaries)
     }
 
     func testResolveWhisperDownloadModelRequiresWhisperPrefix() throws {

--- a/Tests/CLITests/ModelLifecycleCommandTests.swift
+++ b/Tests/CLITests/ModelLifecycleCommandTests.swift
@@ -66,7 +66,9 @@ final class ModelLifecycleCommandTests: XCTestCase {
         let status = await loadSpeechStackStatus(
             sttClient: stt,
             diarizationService: diarization,
-            isSpeechModelCached: { true }
+            isSpeechModelCached: { true },
+            whisperModelVariant: "large-v3-v20240930_turbo_632MB",
+            isWhisperModelDownloaded: { $0 == "large-v3-v20240930_turbo_632MB" }
         )
 
         XCTAssertEqual(
@@ -75,7 +77,9 @@ final class ModelLifecycleCommandTests: XCTestCase {
                 speechModelCached: true,
                 speechRuntimeReady: true,
                 speakerModelsCached: false,
-                speakerModelsPrepared: false
+                speakerModelsPrepared: false,
+                whisperModelVariant: "large-v3-v20240930_turbo_632MB",
+                whisperModelDownloaded: true
             )
         )
         XCTAssertEqual(status.summary, "Speech model present, speaker models missing")

--- a/Tests/CLITests/PromptsCommandTests.swift
+++ b/Tests/CLITests/PromptsCommandTests.swift
@@ -28,6 +28,30 @@ final class PromptsCommandTests: XCTestCase {
         XCTAssertEqual(found.id, p.id)
     }
 
+    func testFindPromptRejectsShortUUIDPrefixUnlessItIsName() throws {
+        let db = try DatabaseManager()
+        let repo = PromptRepository(dbQueue: db.dbQueue)
+        let uuid = UUID(uuidString: "DDBBCCAA-1111-1111-1111-111111111111")!
+        let p = Prompt(id: uuid, name: "Custom", content: "Hello")
+        try repo.save(p)
+
+        XCTAssertThrowsError(try findPrompt(idOrName: "ddb", repo: repo)) { error in
+            guard let lookupError = error as? CLILookupError else {
+                return XCTFail("Expected CLILookupError, got \(error)")
+            }
+            if case .shortUUIDPrefix(let minimumLength) = lookupError {
+                XCTAssertEqual(minimumLength, 4)
+            } else {
+                XCTFail("Expected .shortUUIDPrefix, got \(lookupError)")
+            }
+        }
+
+        let nameOnly = Prompt(name: "dd", content: "Name")
+        try repo.save(nameOnly)
+        let foundByName = try findPrompt(idOrName: "dd", repo: repo)
+        XCTAssertEqual(foundByName.id, nameOnly.id)
+    }
+
     func testFindPromptByNameCaseInsensitive() throws {
         let db = try DatabaseManager()
         let repo = PromptRepository(dbQueue: db.dbQueue)

--- a/Tests/MacParakeetTests/Audio/MeetingAudioCaptureServiceTests.swift
+++ b/Tests/MacParakeetTests/Audio/MeetingAudioCaptureServiceTests.swift
@@ -80,7 +80,7 @@ final class MeetingAudioCaptureServiceTests: XCTestCase {
         XCTAssertGreaterThan(buffer.rmsLevel, 0)
     }
 
-    func testEventsStreamRetainsFiveSecondsOfBurstSystemAudioBuffers() async throws {
+    func testEventsStreamRetainsBurstSystemAudioBuffersWithoutDropping() async throws {
         let microphone = MockMeetingMicrophoneCapture()
         let systemTap = MockMeetingSystemAudioTap()
         let service = MeetingAudioCaptureService(
@@ -91,15 +91,12 @@ final class MeetingAudioCaptureServiceTests: XCTestCase {
         let events = await service.events
         _ = try await service.start()
 
-        // 500 callbacks * 480 frames @ 48kHz = 5 seconds of source audio.
-        // After 48kHz -> 16kHz resampling, that is exactly 80,000 samples,
-        // enough for the first live-transcription chunk if no events are dropped.
         let burstBuffer = try XCTUnwrap(makeInterleavedFloatStereoBuffer(
             sampleRate: 48_000,
-            samples: [Float](repeating: 0.25, count: 960)
+            samples: [Float](repeating: 0.25, count: 96)
         ))
 
-        for _ in 0..<500 {
+        for _ in 0..<2_100 {
             systemTap.emit(buffer: burstBuffer, time: AVAudioTime(hostTime: 1))
         }
 
@@ -113,7 +110,33 @@ final class MeetingAudioCaptureServiceTests: XCTestCase {
             }
         }
 
-        XCTAssertEqual(systemBufferCount, 500)
+        XCTAssertEqual(systemBufferCount, 2_100)
+    }
+
+    func testEmitsRuntimeErrorEventWhenMicrophoneStalls() async throws {
+        let microphone = MockMeetingMicrophoneCapture()
+        let service = MeetingAudioCaptureService(
+            microphoneCapture: microphone,
+            systemAudioTapFactory: { MockMeetingSystemAudioTap() }
+        )
+
+        let events = await service.events
+        _ = try await service.start()
+        defer { Task { await service.stop() } }
+
+        microphone.emitStall(.captureRuntimeFailure("microphone capture started but delivered no buffers within 2 seconds"))
+
+        var iterator = events.makeAsyncIterator()
+        let emitted = await iterator.next()
+        guard case let .error(error)? = emitted else {
+            XCTFail("Expected .error event, got \(String(describing: emitted))")
+            return
+        }
+        guard case .captureRuntimeFailure(let message) = error else {
+            XCTFail("Expected captureRuntimeFailure, got \(error)")
+            return
+        }
+        XCTAssertTrue(message.contains("microphone capture started"))
     }
 
     func testStartReturnsVPIOSuccessReportWhenAvailable() async throws {
@@ -301,6 +324,7 @@ final class MeetingAudioCaptureServiceTests: XCTestCase {
 
 private final class MockMeetingMicrophoneCapture: MeetingMicrophoneCapturing, @unchecked Sendable {
     private var handler: AudioBufferHandler?
+    private var stallObserver: StallObserver?
     private let startHandler: (MeetingMicProcessingMode) throws -> MeetingMicrophoneCaptureStartReport
     private(set) var requestedModes: [MeetingMicProcessingMode] = []
 
@@ -317,19 +341,26 @@ private final class MockMeetingMicrophoneCapture: MeetingMicrophoneCapturing, @u
 
     func start(
         processingMode: MeetingMicProcessingMode,
-        handler: @escaping AudioBufferHandler
+        handler: @escaping AudioBufferHandler,
+        onStall: StallObserver?
     ) throws -> MeetingMicrophoneCaptureStartReport {
         self.handler = handler
+        self.stallObserver = onStall
         requestedModes.append(processingMode)
         return try startHandler(processingMode)
     }
 
     func stop() {
         handler = nil
+        stallObserver = nil
     }
 
     func emit(buffer: AVAudioPCMBuffer, time: AVAudioTime) {
         handler?(buffer, time)
+    }
+
+    func emitStall(_ error: MeetingAudioError) {
+        stallObserver?(error)
     }
 }
 

--- a/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
@@ -169,6 +169,35 @@ final class TranscriptionRepositoryTests: XCTestCase {
         XCTAssertEqual(try repo.fetchBySourceType(.meeting, idPrefix: "AABBCCDD-1111").map(\.id), [meetingID])
     }
 
+    func testFetchByIDPrefixFiltersInDatabaseAcrossSourceTypes() throws {
+        let olderID = UUID(uuidString: "AABBCCDD-1111-1111-1111-111111111111")!
+        let newerID = UUID(uuidString: "AABBCCDD-2222-2222-2222-222222222222")!
+        let otherID = UUID(uuidString: "CCDDEEFF-1111-1111-1111-111111111111")!
+        let older = Transcription(
+            id: olderID,
+            createdAt: Date(timeIntervalSinceNow: -100),
+            fileName: "Older",
+            sourceType: .file,
+            updatedAt: Date(timeIntervalSinceNow: -100)
+        )
+        let newer = Transcription(
+            id: newerID,
+            createdAt: Date(timeIntervalSinceNow: -10),
+            fileName: "Newer",
+            sourceType: .meeting,
+            updatedAt: Date(timeIntervalSinceNow: -10)
+        )
+        let other = Transcription(id: otherID, fileName: "Other", sourceType: .file)
+        try repo.save(older)
+        try repo.save(newer)
+        try repo.save(other)
+
+        let results = try repo.fetchByIDPrefix("aabbccdd")
+
+        XCTAssertEqual(results.map(\.id), [newerID, olderID])
+        XCTAssertEqual(try repo.fetchByIDPrefix("AABBCCDD-1111").map(\.id), [olderID])
+    }
+
     func testFetchBySourceTypeAndFileNameIsCaseInsensitive() throws {
         let meeting = Transcription(fileName: "Design Review", sourceType: .meeting)
         let file = Transcription(fileName: "Design Review", sourceType: .file)

--- a/Tests/MacParakeetTests/STT/AsyncPermitTests.swift
+++ b/Tests/MacParakeetTests/STT/AsyncPermitTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class AsyncPermitTests: XCTestCase {
+    func testCancelledWaiterDoesNotConsumeNextSignal() async throws {
+        let permit = AsyncPermit()
+        try await permit.wait()
+
+        let cancelledTask = Task {
+            try await permit.wait()
+        }
+        try await waitForPendingWaiters(1, permit: permit)
+
+        cancelledTask.cancel()
+        do {
+            try await value(cancelledTask)
+            XCTFail("Expected queued waiter to throw CancellationError")
+        } catch is CancellationError {
+            // Expected.
+        }
+        XCTAssertEqual(permit.pendingWaiterCount(), 0)
+
+        let nextTask = Task {
+            try await permit.wait()
+        }
+        try await waitForPendingWaiters(1, permit: permit)
+
+        permit.signal()
+        try await value(nextTask)
+        permit.signal()
+    }
+
+    func testWaitersResumeInFIFOOrder() async throws {
+        let permit = AsyncPermit()
+        try await permit.wait()
+
+        let firstTask = Task {
+            try await permit.wait()
+            return 1
+        }
+        try await waitForPendingWaiters(1, permit: permit)
+
+        let secondTask = Task {
+            try await permit.wait()
+            return 2
+        }
+        try await waitForPendingWaiters(2, permit: permit)
+
+        permit.signal()
+        let firstValue = try await value(firstTask)
+        XCTAssertEqual(firstValue, 1)
+        permit.signal()
+        let secondValue = try await value(secondTask)
+        XCTAssertEqual(secondValue, 2)
+        permit.signal()
+    }
+
+    private func waitForPendingWaiters(
+        _ count: Int,
+        permit: AsyncPermit,
+        timeout: Duration = .seconds(1)
+    ) async throws {
+        let start = ContinuousClock.now
+        while permit.pendingWaiterCount() != count {
+            if start.duration(to: .now) > timeout {
+                XCTFail("Timed out waiting for \(count) pending waiters")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
+    private func value<T>(
+        _ task: Task<T, any Error>,
+        timeout: Duration = .seconds(1)
+    ) async throws -> T {
+        try await withThrowingTaskGroup(of: T.self) { group in
+            defer { group.cancelAll() }
+            group.addTask {
+                try await task.value
+            }
+            group.addTask {
+                try await Task.sleep(for: timeout)
+                throw AsyncPermitTestError.timeout
+            }
+            let result = try await group.next()!
+            return result
+        }
+    }
+}
+
+private enum AsyncPermitTestError: Error {
+    case timeout
+}

--- a/Tests/MacParakeetTests/Services/BinaryBootstrapTests.swift
+++ b/Tests/MacParakeetTests/Services/BinaryBootstrapTests.swift
@@ -92,6 +92,63 @@ final class BinaryBootstrapTests: XCTestCase {
         XCTAssertEqual(tempBinaryArtifactCount(), 0)
     }
 
+    func testEnsureYtDlpAvailableSeedsManagedCopyFromBundledBinaryWithoutNetwork() async throws {
+        let bundledPath = rootDir
+            .appendingPathComponent("bundle", isDirectory: true)
+            .appendingPathComponent("yt-dlp")
+        try FileManager.default.createDirectory(at: bundledPath.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let bundledData = Data("bundled-yt-dlp".utf8)
+        try bundledData.write(to: bundledPath)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: bundledPath.path)
+
+        let bootstrap = makeBootstrap(
+            bundledYtDlpPath: { bundledPath.path },
+            handler: { _ in
+                XCTFail("Bundled yt-dlp seed should avoid network install")
+                throw BinaryBootstrapError.downloadFailed("unexpected request")
+            }
+        )
+
+        let installedPath = try await bootstrap.ensureYtDlpAvailable()
+        XCTAssertEqual(installedPath, ytDlpPath.path)
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: installedPath))
+        XCTAssertEqual(try Data(contentsOf: ytDlpPath), bundledData)
+        XCTAssertEqual(tempBinaryArtifactCount(), 0)
+    }
+
+    func testEnsureYtDlpAvailableExplicitNetworkUpdateReplacesExistingManagedCopy() async throws {
+        try FileManager.default.createDirectory(at: binDir, withIntermediateDirectories: true)
+        try Data("old-yt-dlp".utf8).write(to: ytDlpPath)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: ytDlpPath.path)
+
+        let binaryData = Data("new-yt-dlp".utf8)
+        let checksum = sha256Hex(binaryData)
+        let bootstrap = makeBootstrap { request in
+            guard let url = request.url else {
+                throw BinaryBootstrapError.downloadFailed("Missing URL")
+            }
+
+            switch url.lastPathComponent {
+            case "yt-dlp_macos":
+                return (Self.httpResponse(url: url, statusCode: 200), binaryData)
+            case "SHA2-256SUMS":
+                return (Self.httpResponse(url: url, statusCode: 200), Data("\(checksum) yt-dlp_macos\n".utf8))
+            default:
+                return (Self.httpResponse(url: url, statusCode: 404), Data())
+            }
+        }
+
+        let installedPath = try await bootstrap.ensureYtDlpAvailable(allowNetworkUpdate: true)
+        XCTAssertEqual(installedPath, ytDlpPath.path)
+        XCTAssertEqual(try Data(contentsOf: ytDlpPath), binaryData)
+
+        let defaults = UserDefaults(suiteName: suiteName)!
+        XCTAssertEqual(
+            defaults.object(forKey: "ytDlp.lastUpdateCheckAt") as? Date,
+            Date(timeIntervalSince1970: 1_700_000_000)
+        )
+    }
+
     func testEnsureYtDlpAvailableChecksumMismatchRemovesTempBinary() async throws {
         let binaryData = Data("yt-dlp-test-binary".utf8)
 
@@ -252,6 +309,38 @@ final class BinaryBootstrapTests: XCTestCase {
         XCTAssertNil(resolved)
     }
 
+    func testResolveYtDlpPathPrefersManagedCopyOverBundledSeed() throws {
+        let bundledPath = rootDir
+            .appendingPathComponent("bundle", isDirectory: true)
+            .appendingPathComponent("yt-dlp")
+        try FileManager.default.createDirectory(at: bundledPath.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try createExecutable(at: bundledPath)
+        try FileManager.default.createDirectory(at: binDir, withIntermediateDirectories: true)
+        try createExecutable(at: ytDlpPath)
+
+        let resolved = BinaryBootstrap.resolveYtDlpPath(
+            managedPath: ytDlpPath.path,
+            bundledPath: bundledPath.path
+        )
+
+        XCTAssertEqual(resolved, ytDlpPath.path)
+    }
+
+    func testResolveYtDlpPathFallsBackToBundledSeed() throws {
+        let bundledPath = rootDir
+            .appendingPathComponent("bundle", isDirectory: true)
+            .appendingPathComponent("yt-dlp")
+        try FileManager.default.createDirectory(at: bundledPath.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try createExecutable(at: bundledPath)
+
+        let resolved = BinaryBootstrap.resolveYtDlpPath(
+            managedPath: ytDlpPath.path,
+            bundledPath: bundledPath.path
+        )
+
+        XCTAssertEqual(resolved, bundledPath.path)
+    }
+
     // MARK: - Helpers
 
     private var binDir: URL {
@@ -267,6 +356,7 @@ final class BinaryBootstrapTests: XCTestCase {
     }
 
     private func makeBootstrap(
+        bundledYtDlpPath: @escaping @Sendable () -> String? = { nil },
         handler: @escaping (URLRequest) throws -> (HTTPURLResponse, Data)
     ) -> BinaryBootstrap {
         let configuration = URLSessionConfiguration.ephemeral
@@ -290,6 +380,7 @@ final class BinaryBootstrapTests: XCTestCase {
                 try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
             },
             ytDlpBinaryPath: { ytDlpPath.path },
+            bundledYtDlpPath: bundledYtDlpPath,
             tempDirPath: { tempDir.path }
         )
     }
@@ -308,7 +399,7 @@ final class BinaryBootstrapTests: XCTestCase {
     }
 
     private func createExecutable(at url: URL) throws {
-        try Data("fake-ffmpeg".utf8).write(to: url)
+        try Data("fake-executable".utf8).write(to: url)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
     }
 

--- a/Tests/MacParakeetTests/Services/MeetingRecordingRecoveryServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecordingRecoveryServiceTests.swift
@@ -235,16 +235,17 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
 
     // MARK: - discoverPendingRecoveries - empty-session filter
 
-    func testDiscoverFiltersStubSessionAndPurgesFolder() async throws {
+    func testDiscoverFiltersStubSessionWithoutDeletingFolder() async throws {
         let stub = try makeEmptyStubSession()
 
         let pending = try await recoveryService.discoverPendingRecoveries()
 
         XCTAssertTrue(pending.isEmpty, "stub session with init-only audio should be filtered")
-        XCTAssertFalse(
+        XCTAssertTrue(
             FileManager.default.fileExists(atPath: stub.folderURL.path),
-            "stub session folder should be auto-purged so it doesn't accumulate"
+            "discovery must not delete recording folders before explicit recover/discard"
         )
+        XCTAssertNotNil(try lockStore.read(folderURL: stub.folderURL))
     }
 
     func testDiscoverFiltersSessionWithNoAudioFiles() async throws {
@@ -262,7 +263,8 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
         let pending = try await recoveryService.discoverPendingRecoveries()
 
         XCTAssertTrue(pending.isEmpty, "session with no audio files should be filtered")
-        XCTAssertFalse(FileManager.default.fileExists(atPath: folderURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: folderURL.path))
+        XCTAssertNotNil(try lockStore.read(folderURL: folderURL))
     }
 
     func testDiscoverKeepsSessionWithViableAudio() async throws {
@@ -283,7 +285,8 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
 
         XCTAssertEqual(pending.map(\.sessionId), [viable.lock.sessionId])
         XCTAssertTrue(FileManager.default.fileExists(atPath: viable.folderURL.path))
-        XCTAssertFalse(FileManager.default.fileExists(atPath: stub.folderURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: stub.folderURL.path))
+        XCTAssertNotNil(try lockStore.read(folderURL: stub.folderURL))
     }
 
     func testDiscoverKeepsSessionWhenOnlyOneChannelHasViableAudio() async throws {

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -318,6 +318,49 @@ final class TelemetryServiceTests: XCTestCase {
         XCTAssertLessThanOrEqual(description.count, 512)
     }
 
+    func testErrorDetailPropsAreSanitizedAtSerializationBoundary() throws {
+        let rawDetail = "Failed /Users/alice/private-meeting.m4a via https://example.com/token?secret=abc"
+        let specs: [TelemetryEventSpec] = [
+            .dictationFailed(errorType: "runtime", errorDetail: rawDetail),
+            .transcriptionFailed(source: .file, stage: .stt, errorType: "runtime", errorDetail: rawDetail),
+            .diarizationFailed(source: .meeting, errorType: "runtime", errorDetail: rawDetail),
+            .llmPromptResultFailed(provider: "openai", errorType: "provider", errorDetail: rawDetail),
+            .llmChatFailed(provider: "openai", errorType: "provider", errorDetail: rawDetail),
+            .llmTransformFailed(provider: "openai", errorType: "provider", errorDetail: rawDetail),
+            .licenseActivationFailed(errorType: "network", errorDetail: rawDetail),
+            .restoreFailed(errorType: "network", errorDetail: rawDetail),
+            .modelDownloadFailed(errorType: "network", errorDetail: rawDetail),
+            .meetingRecordingFailed(errorType: "runtime", errorDetail: rawDetail),
+            .meetingRecoveryFailed(count: 1, source: .settings, errorType: "runtime", errorDetail: rawDetail),
+        ]
+
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+
+        for spec in specs {
+            let event = TelemetryEvent(
+                spec: spec,
+                appVer: "0.4.2",
+                osVer: "15.3",
+                locale: "en-US",
+                chip: "Apple M1",
+                session: "test-session"
+            )
+            let data = try encoder.encode(event)
+            let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let props = try XCTUnwrap(json["props"] as? [String: String])
+            let eventName = spec.name.rawValue
+            let detail = try XCTUnwrap(props["error_detail"], "Missing error_detail for \(eventName)")
+
+            XCTAssertFalse(detail.contains("/Users/alice"), eventName)
+            XCTAssertFalse(detail.contains("private-meeting"), eventName)
+            XCTAssertFalse(detail.contains("example.com"), eventName)
+            XCTAssertTrue(detail.contains("<path>"), eventName)
+            XCTAssertTrue(detail.contains("<url>"), eventName)
+            XCTAssertLessThanOrEqual(detail.count, 512, eventName)
+        }
+    }
+
     func testTranscriptionCompletedSerializesDiarizationContext() throws {
         let event = TelemetryEvent(
             spec: .transcriptionCompleted(

--- a/Tests/MacParakeetTests/ViewModels/MeetingRecordingPanelViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/MeetingRecordingPanelViewModelTests.swift
@@ -92,6 +92,10 @@ final class MeetingRecordingPanelViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.statusTitle, "Meeting interrupted", "Phase 4 copy refinement: 'Recording Error' → 'Meeting interrupted'")
         XCTAssertTrue(viewModel.statusMessage.hasPrefix("Boom"), "Detail leads")
         XCTAssertTrue(viewModel.statusMessage.contains("Library"), "Wrapper points the user at the Library for recovery")
+        XCTAssertEqual(
+            viewModel.compactErrorRecoveryMessage,
+            "Meeting interrupted. Open Library to retry transcription or export captured audio."
+        )
         XCTAssertFalse(viewModel.showsElapsedTime)
     }
 

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionDeletionCleanupTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionDeletionCleanupTests.swift
@@ -7,7 +7,7 @@ final class TranscriptionDeletionCleanupTests: XCTestCase {
         try AppPaths.ensureDirectories()
     }
 
-    func testMeetingDeletionRemovesSessionFolder() async throws {
+    func testMeetingDeletionRemovesSessionFolder() throws {
         let folderURL = URL(fileURLWithPath: AppPaths.meetingRecordingsDir, isDirectory: true)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
@@ -24,13 +24,12 @@ final class TranscriptionDeletionCleanupTests: XCTestCase {
             sourceType: .meeting
         )
 
-        TranscriptionDeletionCleanup.removeOwnedAssets(for: transcription)
+        try TranscriptionDeletionCleanup.removeOwnedAssets(for: transcription)
 
-        try await waitForFileAbsence(at: folderURL)
         XCTAssertFalse(FileManager.default.fileExists(atPath: folderURL.path))
     }
 
-    func testMeetingDeletionOutsideAppSupportIsIgnored() async throws {
+    func testMeetingDeletionOutsideAppSupportIsIgnored() throws {
         let folderURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
@@ -45,9 +44,8 @@ final class TranscriptionDeletionCleanupTests: XCTestCase {
             sourceType: .meeting
         )
 
-        TranscriptionDeletionCleanup.removeOwnedAssets(for: transcription)
+        try TranscriptionDeletionCleanup.removeOwnedAssets(for: transcription)
 
-        try await Task.sleep(for: .milliseconds(100))
         XCTAssertTrue(FileManager.default.fileExists(atPath: folderURL.path))
         try? FileManager.default.removeItem(at: folderURL)
     }
@@ -64,7 +62,7 @@ final class TranscriptionDeletionCleanupTests: XCTestCase {
             sourceType: .youtube
         )
 
-        TranscriptionAssetCleanup.removeOwnedAssets(for: transcription)
+        try TranscriptionAssetCleanup.removeOwnedAssets(for: transcription)
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
     }
@@ -82,7 +80,7 @@ final class TranscriptionDeletionCleanupTests: XCTestCase {
             sourceType: .youtube
         )
 
-        TranscriptionAssetCleanup.removeOwnedAssets(for: transcription)
+        try TranscriptionAssetCleanup.removeOwnedAssets(for: transcription)
 
         XCTAssertTrue(FileManager.default.fileExists(atPath: fileURL.path))
     }
@@ -97,19 +95,9 @@ final class TranscriptionDeletionCleanupTests: XCTestCase {
             sourceType: .youtube
         )
 
-        TranscriptionAssetCleanup.removeOwnedAssets(for: transcription)
+        try TranscriptionAssetCleanup.removeOwnedAssets(for: transcription)
 
         XCTAssertTrue(FileManager.default.fileExists(atPath: currentDirectory.path))
     }
 
-    private func waitForFileAbsence(at url: URL, timeout: Duration = .seconds(1)) async throws {
-        let deadline = ContinuousClock.now + timeout
-        while FileManager.default.fileExists(atPath: url.path) {
-            guard ContinuousClock.now < deadline else {
-                XCTFail("Timed out waiting for file removal at \(url.path)")
-                return
-            }
-            try await Task.sleep(for: .milliseconds(20))
-        }
-    }
 }

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -430,7 +430,7 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertTrue(mockRepo.deleteCalledWith.contains(t.id))
     }
 
-    func testDeleteYouTubeTranscriptionRemovesStoredAudioFile() async throws {
+    func testDeleteYouTubeTranscriptionRemovesStoredAudioFile() throws {
         try AppPaths.ensureDirectories()
         let audioURL = URL(fileURLWithPath: AppPaths.youtubeDownloadsDir, isDirectory: true)
             .appendingPathComponent("yt-audio-\(UUID().uuidString).m4a")
@@ -451,11 +451,10 @@ final class TranscriptionViewModelTests: XCTestCase {
         viewModel.configure(transcriptionService: mockService, transcriptionRepo: mockRepo)
         viewModel.deleteTranscription(t)
 
-        try await waitForFileAbsence(at: audioURL)
         XCTAssertFalse(FileManager.default.fileExists(atPath: audioURL.path))
     }
 
-    func testDeleteYouTubeTranscriptionKeepsStoredAudioWhenRepoDeleteFails() throws {
+    func testDeleteYouTubeTranscriptionRemovesStoredAudioBeforeRepoDelete() throws {
         try AppPaths.ensureDirectories()
         let audioURL = URL(fileURLWithPath: AppPaths.youtubeDownloadsDir, isDirectory: true)
             .appendingPathComponent("yt-audio-\(UUID().uuidString).m4a")
@@ -477,8 +476,9 @@ final class TranscriptionViewModelTests: XCTestCase {
         viewModel.configure(transcriptionService: mockService, transcriptionRepo: mockRepo)
         viewModel.deleteTranscription(t)
 
-        XCTAssertTrue(FileManager.default.fileExists(atPath: audioURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: audioURL.path))
         XCTAssertEqual(viewModel.transcriptions.count, 1)
+        XCTAssertNotNil(viewModel.errorMessage)
     }
 
     func testDeleteFailureKeepsCurrentSelection() {
@@ -493,17 +493,6 @@ final class TranscriptionViewModelTests: XCTestCase {
 
         XCTAssertEqual(viewModel.currentTranscription?.id, t.id)
         XCTAssertEqual(viewModel.transcriptions.count, 1)
-    }
-
-    private func waitForFileAbsence(at url: URL, timeout: Duration = .seconds(1)) async throws {
-        let deadline = ContinuousClock.now + timeout
-        while FileManager.default.fileExists(atPath: url.path) {
-            guard ContinuousClock.now < deadline else {
-                XCTFail("Timed out waiting for file removal at \(url.path)")
-                return
-            }
-            try await Task.sleep(for: .milliseconds(20))
-        }
     }
 
     func testDeleteCurrentTranscriptionClearsSelection() {

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -37,7 +37,8 @@ macparakeet-cli
 │   └── unfavorite <id>                  Remove from favorites
 ├── export <id> [options]                Export a transcription to file
 ├── stats [--json]                       Show voice stats dashboard
-├── health [--repair-models] [--json]    System health and model status
+├── health [--repair-models] [--repair-binaries] [--json]
+│                                         System health and model/helper status
 ├── models                               Speech model lifecycle
 │   ├── status [--json]                  Show model status
 │   ├── warm-up [--attempts]             Warm up speech model
@@ -137,7 +138,7 @@ On the current branch, the app is effectively unlocked, so `--enforce-entitlemen
 
 ## Export
 
-Export a transcription by its UUID (or UUID prefix). Supported formats: txt, markdown, srt, vtt, json.
+Export a transcription by its UUID or UUID prefix of at least 4 characters. Supported formats: txt, markdown, srt, vtt, json.
 
 ```bash
 # List transcriptions to find the ID
@@ -184,7 +185,7 @@ swift run macparakeet-cli history delete-dictation <ID>
 swift run macparakeet-cli history delete-transcription <ID>
 ```
 
-IDs support UUID prefix matching (e.g., `3a7b` matches `3a7b1234-...`).
+IDs support UUID prefix matching with at least 4 characters (e.g., `3a7b` matches `3a7b1234-...`).
 
 ### Favorites
 
@@ -199,6 +200,7 @@ swift run macparakeet-cli history unfavorite <ID>
 ```bash
 swift run macparakeet-cli health
 swift run macparakeet-cli health --repair-models --repair-attempts 3
+swift run macparakeet-cli health --repair-binaries
 ```
 
 ## Speech Model Lifecycle
@@ -336,7 +338,7 @@ without launching the app.
 swift run macparakeet-cli prompts list
 swift run macparakeet-cli prompts list --filter auto-run --json | jq '.[].name'
 
-# Show full content. <id-or-name> accepts UUID, UUID prefix, or exact name.
+# Show full content. <id-or-name> accepts UUID, UUID prefix of at least 4 characters, or exact name.
 swift run macparakeet-cli prompts show "Summary"
 swift run macparakeet-cli prompts show A4882688
 

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -230,6 +230,12 @@ swift run macparakeet-cli health --repair-models --repair-attempts 3
 swift run macparakeet-cli health --repair-binaries
 ```
 
+`health --json` is a non-mutating readiness probe: it can report an existing
+managed or app-bundled `yt-dlp`, but it does not install or update helper
+binaries. `health --repair-binaries` explicitly fetches the latest managed
+`yt-dlp` copy. App-bundled CLI installs include a signed `yt-dlp` seed so
+YouTube URL transcription works without a first-use helper download.
+
 ## Meetings
 
 Meeting commands operate on `sourceType = meeting` transcriptions. `<meeting>` accepts a UUID, UUID prefix, or exact title.

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -14,8 +14,9 @@ scripts/dist/build_app_bundle.sh
 
 This creates `dist/MacParakeet.app` and bundles:
 - `Assets/AppIcon.icns` into `Contents/Resources/AppIcon.icns` (app icon for Dock, Finder, DMG)
+- `macparakeet-cli` into `Contents/MacOS/macparakeet-cli`
 - SwiftPM resource bundles into `Contents/Resources/`
-- Standalone helper binaries (yt-dlp and FFmpeg) into `Contents/Resources/` when configured by the build scripts
+- Standalone helper binaries (FFmpeg and optional Node runtime) into `Contents/Resources/` when configured by the build scripts
 - No Python runtime or `uv` bootstrap is bundled (FluidAudio/CoreML STT is native Swift)
 
 `build_app_bundle.sh` automatically downloads a **statically-linked FFmpeg** from [ffmpeg.martin-riedl.de](https://ffmpeg.martin-riedl.de/) (macOS arm64, SHA256-verified). No Homebrew dependency. To use a custom binary instead, set `FFMPEG_PATH`:

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -16,7 +16,7 @@ This creates `dist/MacParakeet.app` and bundles:
 - `Assets/AppIcon.icns` into `Contents/Resources/AppIcon.icns` (app icon for Dock, Finder, DMG)
 - `macparakeet-cli` into `Contents/MacOS/macparakeet-cli`
 - SwiftPM resource bundles into `Contents/Resources/`
-- Standalone helper binaries (FFmpeg and optional Node runtime) into `Contents/Resources/` when configured by the build scripts
+- Standalone helper binaries (FFmpeg, yt-dlp helper seed, and optional Node runtime) into `Contents/Resources/` when configured by the build scripts
 - No Python runtime or `uv` bootstrap is bundled (FluidAudio/CoreML STT is native Swift)
 
 `build_app_bundle.sh` automatically downloads a **statically-linked FFmpeg** from [ffmpeg.martin-riedl.de](https://ffmpeg.martin-riedl.de/) (macOS arm64, SHA256-verified). No Homebrew dependency. To use a custom binary instead, set `FFMPEG_PATH`:
@@ -26,6 +26,12 @@ FFMPEG_PATH=/absolute/path/to/static-ffmpeg scripts/dist/build_app_bundle.sh
 ```
 
 The script verifies the bundled binary has no non-system dylib dependencies (portability check via `otool -L`).
+
+`yt-dlp` is bundled as a signed helper seed. At runtime, the app/CLI copies it
+to `~/Library/Application Support/MacParakeet/bin/yt-dlp` before first YouTube
+transcription so future helper updates never mutate the signed app bundle. To
+use a pre-fetched helper in release builds, set `YTDLP_PATH`; set
+`BUNDLE_YTDLP=0` only for diagnostic builds.
 
 Retained purchase activation config (normally unset in current free builds):
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -139,13 +139,16 @@ The build script accepts `VERSION` and `BUILD_NUMBER` env vars:
 
 ```bash
 VERSION=0.1.1 scripts/dist/build_app_bundle.sh   # set version explicitly
-scripts/dist/build_app_bundle.sh                   # defaults: VERSION=0.1.0, BUILD_NUMBER=UTC timestamp
+scripts/dist/build_app_bundle.sh                   # local/dev only: VERSION defaults to 0.0.0
 ```
 
 - **Patch bump** (0.1.x): Bug fixes, UX improvements to existing features
 - **Minor bump** (0.x.0): New user-facing features (e.g., speaker diarization GUI, batch processing)
 - **Build number**: Auto-generated UTC timestamp — always increases, which is what Sparkle uses to detect updates
 - Both new downloads (R2 DMG) and existing users (Sparkle appcast) get the same DMG
+- **Release builds must set `VERSION=X.Y.Z` explicitly.** The script's default
+  `0.0.0` is intentionally non-release metadata so local bundles cannot be
+  mistaken for a production Sparkle update.
 
 ### Step 1: Build
 

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -65,8 +65,10 @@ macparakeet-cli health --json
 
 Reports model readiness, database accessibility, and binary deps (FFmpeg,
 yt-dlp). This is a non-mutating probe; it reports missing helper binaries but
-does not install or update them. Use `macparakeet-cli health --repair-binaries`
-when you explicitly want to repair helper binaries.
+does not install or update them. App-bundled CLI installs include a signed
+yt-dlp helper seed for YouTube transcription; use
+`macparakeet-cli health --repair-binaries` when you explicitly want to fetch
+the latest managed helper binary.
 
 ### Transcribe a file
 
@@ -204,9 +206,10 @@ macparakeet-cli health --json
 ```
 
 If it fails, report the `errorType`/message and stop. Do not guess that models,
-FFmpeg, yt-dlp, or the database are ready. If `yt-dlp` is missing and the user
-wants YouTube transcription, run `macparakeet-cli health --repair-binaries`
-before retrying.
+FFmpeg, yt-dlp, or the database are ready. App-bundled CLI installs should
+already have a signed yt-dlp helper seed; if `yt-dlp` is still missing and the
+user wants YouTube transcription, run
+`macparakeet-cli health --repair-binaries` before retrying.
 
 ## Core Commands
 

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -284,7 +284,7 @@ macparakeet-cli prompts run "<prompt-name>" \
   ships only allowlisted invocation metadata (`operation_id`, `workflow_id`,
   `parent_operation_id`, `command`, `subcommand`, `outcome`,
   `duration_seconds`, `input_kind`, `output_format`, `json`, `exit_code`,
-  `error_type`) -- never the file path, URL, transcript, language value, or any
+  `error_type`) — never the file path, URL, transcript, language value, or any
   user content (random per-process session UUID, no persistent identifier).
   Disable it any of four ways:
     - `MACPARAKEET_TELEMETRY=0` (per process)

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -17,8 +17,9 @@
 - **Persistent SQLite memory layer** -- everything transcribed is queryable
   later: dictation history, transcriptions, prompt outputs.
 - **Prompt library + LLM-backed summarization** -- bring your own provider
-  (OpenAI, Anthropic, Ollama, LM Studio, OpenAI-compatible local), or skip
-  the LLM entirely and consume raw transcripts.
+  (OpenAI, Anthropic, Ollama, LM Studio, OpenAI-compatible local, or a
+  configured CLI subprocess), or skip the LLM entirely and consume raw
+  transcripts.
 - **JSON output everywhere** -- every read-only command supports `--json`
   with a stable schema (see
   [`../Sources/CLI/CHANGELOG.md`](../Sources/CLI/CHANGELOG.md) for the
@@ -276,9 +277,10 @@ macparakeet-cli prompts run "<prompt-name>" \
   produce a `.ambiguous` error; missing records produce `.notFound`.
 - **Privacy:** STT and database access never touch the network. Network
   egress paths are: explicit helper repair (`health --repair-binaries`),
-  YouTube downloads (yt-dlp), optional cloud LLM provider calls (only when
-  `prompts run --provider <cloud>` or `llm` against a hosted provider),
-  Sparkle update checks (app, not CLI), and a single privacy-safe
+  YouTube downloads (yt-dlp), optional LLM provider calls (only when
+  `prompts run` or `llm` targets a hosted provider, or when a configured
+  Local CLI command contacts its own service), Sparkle update checks (app,
+  not CLI), and a single privacy-safe
   `cli_operation` event per `transcribe` invocation, posted to the self-hosted
   endpoint at `https://macparakeet.com/api/telemetry`. The telemetry event
   ships only allowlisted invocation metadata (`operation_id`, `workflow_id`,

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -64,7 +64,9 @@ macparakeet-cli health --json
 ```
 
 Reports model readiness, database accessibility, and binary deps (FFmpeg,
-yt-dlp). Use this before issuing real work.
+yt-dlp). This is a non-mutating probe; it reports missing helper binaries but
+does not install or update them. Use `macparakeet-cli health --repair-binaries`
+when you explicitly want to repair helper binaries.
 
 ### Transcribe a file
 
@@ -201,7 +203,9 @@ macparakeet-cli health --json
 ```
 
 If it fails, report the `errorType`/message and stop. Do not guess that models,
-FFmpeg, yt-dlp, or the database are ready.
+FFmpeg, yt-dlp, or the database are ready. If `yt-dlp` is missing and the user
+wants YouTube transcription, run `macparakeet-cli health --repair-binaries`
+before retrying.
 
 ## Core Commands
 
@@ -267,9 +271,9 @@ macparakeet-cli prompts run "<prompt-name>" \
   UUID prefix (>= 4 chars), or case-insensitive name. Ambiguous prefixes
   produce a `.ambiguous` error; missing records produce `.notFound`.
 - **Privacy:** STT and database access never touch the network. The only
-  network egress paths are: YouTube downloads (yt-dlp), optional cloud LLM
-  provider calls (only when `prompts run --provider <cloud>`), and Sparkle
-  update checks (app, not CLI).
+  network egress paths are: explicit helper repair (`health --repair-binaries`),
+  YouTube downloads (yt-dlp), optional cloud LLM provider calls (only when
+  `prompts run --provider <cloud>`), and Sparkle update checks (app, not CLI).
 - **Concurrency:** the STT scheduler reserves one slot for dictation and
   shares a second slot for meeting / batch work (ADR-016). Multiple
   concurrent CLI calls share the background slot; expect serial transcription

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -12,7 +12,8 @@
   per-minute charges.
 - **Audio + video file transcription** -- accepts MP3 / WAV / MP4 / MOV /
   WebM / etc. via the bundled FFmpeg.
-- **YouTube transcription** via bundled yt-dlp.
+- **YouTube transcription** via yt-dlp. The app bundle seeds a signed helper
+  into MacParakeet's Application Support folder before first YouTube use.
 - **Persistent SQLite memory layer** -- everything transcribed is queryable
   later: dictation history, transcriptions, prompt outputs.
 - **Prompt library + LLM-backed summarization** -- bring your own provider

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -23,7 +23,7 @@ the local Parakeet TDT pipeline without any cloud STT dependency.
 ln -s /Applications/MacParakeet.app/Contents/MacOS/macparakeet-cli \
       /usr/local/bin/macparakeet-cli
 # 3. Verify
-macparakeet-cli --version   # 1.0.0
+macparakeet-cli --version   # 1.3.0
 macparakeet-cli health --json
 ```
 

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -23,7 +23,7 @@ the local Parakeet TDT pipeline without any cloud STT dependency.
 ln -s /Applications/MacParakeet.app/Contents/MacOS/macparakeet-cli \
       /usr/local/bin/macparakeet-cli
 # 3. Verify
-macparakeet-cli --version   # 1.3.0
+macparakeet-cli --version   # 1.4.0
 macparakeet-cli health --json
 ```
 

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -75,7 +75,7 @@ fields and validation rules may have evolved.
 ````markdown
 ---
 name: macparakeet-stt
-version: 1.0.0
+version: 1.3.0
 author: <your-username>
 description: Local Parakeet TDT speech-to-text on Apple Silicon. Wraps macparakeet-cli (GPL-3.0-or-later).
 tags: [stt, transcription, voice, apple-silicon, local, parakeet]

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -31,7 +31,7 @@ All execution is local on the Apple Neural Engine. No cloud STT.
 ln -s /Applications/MacParakeet.app/Contents/MacOS/macparakeet-cli \
       /usr/local/bin/macparakeet-cli
 # 3. Verify
-macparakeet-cli --version   # 1.3.0
+macparakeet-cli --version   # 1.4.0
 macparakeet-cli health --json
 ```
 
@@ -75,7 +75,7 @@ fields and validation rules may have evolved.
 ````markdown
 ---
 name: macparakeet-stt
-version: 1.3.0
+version: 1.4.0
 author: <your-username>
 description: Local Parakeet TDT speech-to-text on Apple Silicon. Wraps macparakeet-cli (GPL-3.0-or-later).
 tags: [stt, transcription, voice, apple-silicon, local, parakeet]

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -35,11 +35,11 @@ macparakeet-cli --version   # 1.3.0
 macparakeet-cli health --json
 ```
 
-Requires macOS 14.2+ on Apple Silicon. The app bundle includes FFmpeg and
-the CLI. First `transcribe` call downloads ~6 GB of CoreML models to
-`~/Library/Application Support/MacParakeet/models/`. YouTube transcription
-installs `yt-dlp` on demand; `macparakeet-cli health --repair-binaries`
-can prepare it explicitly.
+Requires macOS 14.2+ on Apple Silicon. The app bundle includes FFmpeg,
+yt-dlp, and the CLI. First `transcribe` call downloads ~6 GB of CoreML models
+to `~/Library/Application Support/MacParakeet/models/`. YouTube transcription
+seeds the managed `yt-dlp` helper from the app bundle; `macparakeet-cli health
+--repair-binaries` explicitly fetches the latest helper.
 
 ## Capabilities (CLI vocabulary)
 

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -26,14 +26,20 @@ All execution is local on the Apple Neural Engine. No cloud STT.
 ## Install
 
 ```bash
-brew install moona3k/tap/macparakeet-cli
-macparakeet-cli --version   # 1.0.0
+# 1. Install MacParakeet from https://macparakeet.com
+# 2. Make the bundled CLI available on $PATH
+ln -s /Applications/MacParakeet.app/Contents/MacOS/macparakeet-cli \
+      /usr/local/bin/macparakeet-cli
+# 3. Verify
+macparakeet-cli --version   # 1.3.0
 macparakeet-cli health --json
 ```
 
-Requires macOS 14.2+ on Apple Silicon. The brew formula installs
-ffmpeg + yt-dlp as runtime deps. First `transcribe` call downloads
-~6 GB of CoreML models to `~/Library/Application Support/MacParakeet/models/`.
+Requires macOS 14.2+ on Apple Silicon. The app bundle includes FFmpeg and
+the CLI. First `transcribe` call downloads ~6 GB of CoreML models to
+`~/Library/Application Support/MacParakeet/models/`. YouTube transcription
+installs `yt-dlp` on demand; `macparakeet-cli health --repair-binaries`
+can prepare it explicitly.
 
 ## Capabilities (CLI vocabulary)
 

--- a/scripts/dist/build_app_bundle.sh
+++ b/scripts/dist/build_app_bundle.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # This script:
 # - builds the `MacParakeet` app and `macparakeet-cli` products in Release
 # - assembles a minimal .app bundle (Info.plist + executables + bundled helper binaries)
-# - bundles FFmpeg into Resources and optionally bundles `node` for yt-dlp JS runtime support
+# - bundles FFmpeg and yt-dlp into Resources and optionally bundles `node` for yt-dlp JS runtime support
 #
 # Outputs:
 #   dist/MacParakeet.app
@@ -27,6 +27,8 @@ set -euo pipefail
 #   FFMPEG_PATH         (default: auto-download static build) source ffmpeg binary to bundle
 #   FFMPEG_VERSION      (default: release) 'release' or 'snapshot' from ffmpeg.martin-riedl.de
 #   ALLOW_NON_PORTABLE_FFMPEG (default: 0) allow bundling ffmpeg with non-system dylib deps
+#   BUNDLE_YTDLP       (default: 1) bundle yt-dlp helper seed
+#   YTDLP_PATH         (default: auto-download latest) source yt-dlp binary to bundle
 #   BUNDLE_NODE        (default: 1) bundle Node runtime for yt-dlp
 #   NODE_VERSION       (default: 24.13.1) Node version used when downloading
 
@@ -277,6 +279,59 @@ if [[ "$ALLOW_NON_PORTABLE_FFMPEG" != "1" ]] && command -v otool >/dev/null 2>&1
   fi
 fi
 
+# Bundle yt-dlp as a helper seed. The app/CLI copies this signed bundle copy
+# into Application Support before use, so future updates never mutate the
+# signed app bundle.
+BUNDLE_YTDLP="${BUNDLE_YTDLP:-1}"
+YTDLP_ASSET="yt-dlp_macos"
+YTDLP_LATEST_BASE_URL="https://github.com/yt-dlp/yt-dlp/releases/latest/download"
+
+download_ytdlp() {
+  local out="$1"
+  local tmp_dir
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "$tmp_dir"' EXIT
+  local binary_path="$tmp_dir/$YTDLP_ASSET"
+  local checksums_path="$tmp_dir/SHA2-256SUMS"
+
+  echo "Downloading yt-dlp helper from GitHub releases…"
+  curl -LsSf "$YTDLP_LATEST_BASE_URL/$YTDLP_ASSET" -o "$binary_path"
+  curl -LsSf "$YTDLP_LATEST_BASE_URL/SHA2-256SUMS" -o "$checksums_path"
+
+  local expected_sha
+  expected_sha="$(awk -v target="$YTDLP_ASSET" '$2 == target {print $1}' "$checksums_path" | head -n 1)"
+  local actual_sha
+  actual_sha="$(shasum -a 256 "$binary_path" | awk '{print $1}')"
+
+  if [[ -z "$expected_sha" || "$expected_sha" != "$actual_sha" ]]; then
+    echo "Error: yt-dlp SHA256 verification failed." >&2
+    echo "  Expected: $expected_sha" >&2
+    echo "  Actual:   $actual_sha" >&2
+    exit 1
+  fi
+  echo "SHA256 verified: $actual_sha"
+
+  install -m 0755 "$binary_path" "$out"
+  rm -rf "$tmp_dir"
+  trap - EXIT
+}
+
+if [[ "$BUNDLE_YTDLP" == "1" ]]; then
+  if [[ -n "${YTDLP_PATH:-}" ]]; then
+    if [[ ! -x "$YTDLP_PATH" ]]; then
+      echo "Error: YTDLP_PATH not executable: $YTDLP_PATH" >&2
+      exit 1
+    fi
+    cp "$YTDLP_PATH" "$RESOURCES_DIR/yt-dlp"
+    chmod +x "$RESOURCES_DIR/yt-dlp"
+    echo "Bundled yt-dlp from: $YTDLP_PATH"
+  else
+    download_ytdlp "$RESOURCES_DIR/yt-dlp"
+    echo "Bundled yt-dlp helper seed"
+  fi
+else
+  echo "Skipping yt-dlp bundling (BUNDLE_YTDLP=0)"
+fi
 
 # Optionally bundle `node` for yt-dlp JavaScript runtime support.
 #

--- a/scripts/dist/build_app_bundle.sh
+++ b/scripts/dist/build_app_bundle.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 # Environment variables:
 #   APP_NAME            (default: MacParakeet)
 #   BUNDLE_ID           (default: com.macparakeet.MacParakeet)
-#   VERSION             (default: 0.1.0)
+#   VERSION             (default: 0.0.0; release builds must set this explicitly)
 #   BUILD_NUMBER        (default: UTC timestamp, e.g. 20260213220512)
 #   BUILD_GIT_COMMIT    (default: current git short SHA)
 #   BUILD_DATE_UTC      (default: current UTC ISO-8601 timestamp)
@@ -37,7 +37,7 @@ DIST_DIR="$ROOT_DIR/dist"
 
 APP_NAME="${APP_NAME:-MacParakeet}"
 BUNDLE_ID="${BUNDLE_ID:-com.macparakeet.MacParakeet}"
-VERSION="${VERSION:-0.1.0}"
+VERSION="${VERSION:-0.0.0}"
 BUILD_NUMBER="${BUILD_NUMBER:-$(date -u +%Y%m%d%H%M%S)}"
 BUILD_GIT_COMMIT="${BUILD_GIT_COMMIT:-$(git -C "$ROOT_DIR" rev-parse --short=12 HEAD 2>/dev/null || echo unknown)}"
 BUILD_DATE_UTC="${BUILD_DATE_UTC:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
@@ -53,9 +53,15 @@ CONTENTS_DIR="$APP_DIR/Contents"
 MACOS_DIR="$CONTENTS_DIR/MacOS"
 RESOURCES_DIR="$CONTENTS_DIR/Resources"
 FRAMEWORKS_DIR="$CONTENTS_DIR/Frameworks"
+LEGAL_DIR="$RESOURCES_DIR/Legal"
 
 rm -rf "$APP_DIR"
-mkdir -p "$MACOS_DIR" "$RESOURCES_DIR" "$FRAMEWORKS_DIR"
+mkdir -p "$MACOS_DIR" "$RESOURCES_DIR" "$FRAMEWORKS_DIR" "$LEGAL_DIR"
+
+if [[ "$VERSION" == "0.0.0" ]]; then
+  echo "Warning: VERSION not set; building a local/dev bundle with CFBundleShortVersionString=0.0.0." >&2
+  echo "Set VERSION=X.Y.Z for release builds so Sparkle and release metadata are correct." >&2
+fi
 
 build_swiftpm() {
   if [[ "$SKIP_BUILD" == "1" ]]; then
@@ -446,6 +452,16 @@ else
   echo "Error: Assets/AppIcon.icns not found. Cannot build production app without icon." >&2
   exit 1
 fi
+
+# Ship license/notice material with the app bundle so downloaded artifacts carry
+# the GPL and third-party notices for bundled/downloaded helper binaries.
+if [[ -f "$ROOT_DIR/LICENSE" ]]; then
+  cp "$ROOT_DIR/LICENSE" "$LEGAL_DIR/LICENSE"
+fi
+if [[ -f "$ROOT_DIR/THIRD_PARTY_LICENSES.md" ]]; then
+  cp "$ROOT_DIR/THIRD_PARTY_LICENSES.md" "$LEGAL_DIR/THIRD_PARTY_LICENSES.md"
+fi
+echo "Bundled legal notices: $LEGAL_DIR"
 
 echo "[3/4] Writing Info.plist…"
 INFO_PLIST="$CONTENTS_DIR/Info.plist"

--- a/scripts/dist/build_app_bundle.sh
+++ b/scripts/dist/build_app_bundle.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Build a distributable MacParakeet.app bundle from the SwiftPM executable.
+# Build a distributable MacParakeet.app bundle from release executables.
 #
 # This script:
-# - builds the `MacParakeet` SwiftPM product in Release
-# - assembles a minimal .app bundle (Info.plist + executable + bundled helper binaries)
+# - builds the `MacParakeet` app and `macparakeet-cli` products in Release
+# - assembles a minimal .app bundle (Info.plist + executables + bundled helper binaries)
 # - bundles FFmpeg into Resources and optionally bundles `node` for yt-dlp JS runtime support
 #
 # Outputs:
@@ -70,8 +70,24 @@ build_swiftpm() {
   pushd "$ROOT_DIR" >/dev/null
   if [[ "$UNIVERSAL" == "1" ]]; then
     swift build -c release --arch arm64 --arch x86_64 --product MacParakeet
+    swift build -c release --arch arm64 --arch x86_64 --product macparakeet-cli
   else
     swift build -c release --product MacParakeet
+    swift build -c release --product macparakeet-cli
+  fi
+  popd >/dev/null
+}
+
+build_cli_swiftpm() {
+  if [[ "$SKIP_BUILD" == "1" ]]; then
+    return 0
+  fi
+
+  pushd "$ROOT_DIR" >/dev/null
+  if [[ "$UNIVERSAL" == "1" ]]; then
+    swift build -c release --arch arm64 --arch x86_64 --product macparakeet-cli
+  else
+    swift build -c release --product macparakeet-cli
   fi
   popd >/dev/null
 }
@@ -140,12 +156,36 @@ copy_resource_bundles() {
   fi
 }
 
+swiftpm_release_bin_dir() {
+  pushd "$ROOT_DIR" >/dev/null
+  if [[ "$UNIVERSAL" == "1" ]]; then
+    swift build -c release --arch arm64 --arch x86_64 --product "$1" --show-bin-path
+  else
+    swift build -c release --product "$1" --show-bin-path
+  fi
+  popd >/dev/null
+}
+
+copy_cli_binary() {
+  build_cli_swiftpm
+
+  local cli_bin_dir
+  cli_bin_dir="$(swiftpm_release_bin_dir macparakeet-cli)"
+  local cli_bin_path="$cli_bin_dir/macparakeet-cli"
+  if [[ ! -f "$cli_bin_path" ]]; then
+    echo "Failed to locate CLI Release binary at: $cli_bin_path" >&2
+    exit 1
+  fi
+
+  cp "$cli_bin_path" "$MACOS_DIR/macparakeet-cli"
+  chmod +x "$MACOS_DIR/macparakeet-cli"
+  echo "Bundled CLI: $MACOS_DIR/macparakeet-cli"
+}
+
 if [[ "$BUILD_SYSTEM" == "swiftpm" ]]; then
   build_swiftpm
   # Locate the release binary produced by SwiftPM.
-  pushd "$ROOT_DIR" >/dev/null
-  BIN_DIR="$(swift build -c release --product MacParakeet --show-bin-path)"
-  popd >/dev/null
+  BIN_DIR="$(swiftpm_release_bin_dir MacParakeet)"
   BIN_PATH="$BIN_DIR/MacParakeet"
   if [[ ! -f "$BIN_PATH" ]]; then
     echo "Failed to locate Release binary at: $BIN_PATH" >&2
@@ -159,6 +199,8 @@ else
   build_xcodebuild
   echo "[2/4] Assembling app bundle…"
 fi
+
+copy_cli_binary
 
 # Bundle FFmpeg (required at runtime for media demux/conversion).
 #

--- a/scripts/dist/homebrew-tap-scaffold/HOWTO.md
+++ b/scripts/dist/homebrew-tap-scaffold/HOWTO.md
@@ -34,8 +34,8 @@ In the macparakeet repo, on a tagged commit:
 
 ```bash
 swift build -c release --product macparakeet-cli
-mkdir -p dist/macparakeet-cli-1.0.0-darwin-arm64
-cp .build/release/macparakeet-cli dist/macparakeet-cli-1.0.0-darwin-arm64/
+mkdir -p dist/macparakeet-cli-1.3.0-darwin-arm64
+cp .build/release/macparakeet-cli dist/macparakeet-cli-1.3.0-darwin-arm64/
 ```
 
 ### 3. Sign + notarize the binary
@@ -47,46 +47,39 @@ exact identity is in `scripts/dist/sign_notarize.sh`.
 codesign --sign "Developer ID Application: <YOUR NAME> (<TEAMID>)" \
          --options runtime \
          --timestamp \
-         dist/macparakeet-cli-1.0.0-darwin-arm64/macparakeet-cli
+         dist/macparakeet-cli-1.3.0-darwin-arm64/macparakeet-cli
 
 # Pack for notarization
-ditto -c -k --keepParent dist/macparakeet-cli-1.0.0-darwin-arm64 \
-      dist/macparakeet-cli-1.0.0-darwin-arm64.zip
+ditto -c -k --keepParent dist/macparakeet-cli-1.3.0-darwin-arm64 \
+      dist/macparakeet-cli-1.3.0-darwin-arm64.zip
 
 # Submit. The notarytool keychain profile name is whatever was set up
 # previously (search scripts/dist/ for the actual name).
-xcrun notarytool submit dist/macparakeet-cli-1.0.0-darwin-arm64.zip \
-      --keychain-profile <profile-name> --wait
+xcrun notarytool submit dist/macparakeet-cli-1.3.0-darwin-arm64.zip \
+      --keychain-profile <profile-name>
 ```
 
-> **Heads up:** `notarytool submit --wait` intermittently SIGBUS-crashes
-> (exit 138) on macOS 15+ even after a successful upload. The upload
-> usually succeeds despite the crash. If `--wait` exits non-zero:
->
-> 1. Run `xcrun notarytool history --keychain-profile <profile>` to find
->    the most recent submission ID.
-> 2. Poll its status with `xcrun notarytool info <id> --keychain-profile <profile>`
->    until it reads `Accepted`.
-> 3. If the upload itself failed, resubmit cleanly without `--wait`.
->
-> Resubmitting after a SIGBUS usually works on the next try.
+Poll the returned submission ID with
+`xcrun notarytool info <id> --keychain-profile <profile>` until it reads
+`Accepted`. Do not use `notarytool submit --wait`; the app release pipeline
+avoids it because it can SIGBUS-crash on some macOS/Xcode combinations.
 
 ### 4. Tar + checksum
 
 ```bash
 cd dist
-tar -czf macparakeet-cli-1.0.0-darwin-arm64.tar.gz \
-        macparakeet-cli-1.0.0-darwin-arm64
-shasum -a 256 macparakeet-cli-1.0.0-darwin-arm64.tar.gz
+tar -czf macparakeet-cli-1.3.0-darwin-arm64.tar.gz \
+        macparakeet-cli-1.3.0-darwin-arm64
+shasum -a 256 macparakeet-cli-1.3.0-darwin-arm64.tar.gz
 # Copy the SHA256 hex into the formula's `sha256` field.
 ```
 
 ### 5. Publish the GitHub release
 
 ```bash
-gh release create cli-v1.0.0 \
-  dist/macparakeet-cli-1.0.0-darwin-arm64.tar.gz \
-  --title "macparakeet-cli 1.0.0" \
+gh release create cli-v1.3.0 \
+  dist/macparakeet-cli-1.3.0-darwin-arm64.tar.gz \
+  --title "macparakeet-cli 1.3.0" \
   --notes-file Sources/CLI/CHANGELOG.md
 ```
 
@@ -98,7 +91,7 @@ from the app's release tags.
 ```bash
 cd ~/code/homebrew-tap
 # Update Formula/macparakeet-cli.rb's `sha256` line with the value from step 4.
-git add . && git commit -m "Add macparakeet-cli 1.0.0" && git push
+git add . && git commit -m "Add macparakeet-cli 1.3.0" && git push
 ```
 
 ### 7. Verify end-to-end
@@ -108,11 +101,11 @@ brew untap moona3k/tap 2>/dev/null   # if previously tapped
 brew tap moona3k/tap
 brew install macparakeet-cli
 
-macparakeet-cli --version    # 1.0.0
+macparakeet-cli --version    # 1.3.0
 macparakeet-cli health --json
 ```
 
-## After 1.0.0
+## After the first release
 
 For each subsequent CLI release:
 

--- a/scripts/dist/homebrew-tap-scaffold/HOWTO.md
+++ b/scripts/dist/homebrew-tap-scaffold/HOWTO.md
@@ -34,8 +34,8 @@ In the macparakeet repo, on a tagged commit:
 
 ```bash
 swift build -c release --product macparakeet-cli
-mkdir -p dist/macparakeet-cli-1.3.0-darwin-arm64
-cp .build/release/macparakeet-cli dist/macparakeet-cli-1.3.0-darwin-arm64/
+mkdir -p dist/macparakeet-cli-1.4.0-darwin-arm64
+cp .build/release/macparakeet-cli dist/macparakeet-cli-1.4.0-darwin-arm64/
 ```
 
 ### 3. Sign + notarize the binary
@@ -47,15 +47,15 @@ exact identity is in `scripts/dist/sign_notarize.sh`.
 codesign --sign "Developer ID Application: <YOUR NAME> (<TEAMID>)" \
          --options runtime \
          --timestamp \
-         dist/macparakeet-cli-1.3.0-darwin-arm64/macparakeet-cli
+         dist/macparakeet-cli-1.4.0-darwin-arm64/macparakeet-cli
 
 # Pack for notarization
-ditto -c -k --keepParent dist/macparakeet-cli-1.3.0-darwin-arm64 \
-      dist/macparakeet-cli-1.3.0-darwin-arm64.zip
+ditto -c -k --keepParent dist/macparakeet-cli-1.4.0-darwin-arm64 \
+      dist/macparakeet-cli-1.4.0-darwin-arm64.zip
 
 # Submit. The notarytool keychain profile name is whatever was set up
 # previously (search scripts/dist/ for the actual name).
-xcrun notarytool submit dist/macparakeet-cli-1.3.0-darwin-arm64.zip \
+xcrun notarytool submit dist/macparakeet-cli-1.4.0-darwin-arm64.zip \
       --keychain-profile <profile-name>
 ```
 
@@ -68,18 +68,18 @@ avoids it because it can SIGBUS-crash on some macOS/Xcode combinations.
 
 ```bash
 cd dist
-tar -czf macparakeet-cli-1.3.0-darwin-arm64.tar.gz \
-        macparakeet-cli-1.3.0-darwin-arm64
-shasum -a 256 macparakeet-cli-1.3.0-darwin-arm64.tar.gz
+tar -czf macparakeet-cli-1.4.0-darwin-arm64.tar.gz \
+        macparakeet-cli-1.4.0-darwin-arm64
+shasum -a 256 macparakeet-cli-1.4.0-darwin-arm64.tar.gz
 # Copy the SHA256 hex into the formula's `sha256` field.
 ```
 
 ### 5. Publish the GitHub release
 
 ```bash
-gh release create cli-v1.3.0 \
-  dist/macparakeet-cli-1.3.0-darwin-arm64.tar.gz \
-  --title "macparakeet-cli 1.3.0" \
+gh release create cli-v1.4.0 \
+  dist/macparakeet-cli-1.4.0-darwin-arm64.tar.gz \
+  --title "macparakeet-cli 1.4.0" \
   --notes-file Sources/CLI/CHANGELOG.md
 ```
 
@@ -91,7 +91,7 @@ from the app's release tags.
 ```bash
 cd ~/code/homebrew-tap
 # Update Formula/macparakeet-cli.rb's `sha256` line with the value from step 4.
-git add . && git commit -m "Add macparakeet-cli 1.3.0" && git push
+git add . && git commit -m "Add macparakeet-cli 1.4.0" && git push
 ```
 
 ### 7. Verify end-to-end
@@ -101,7 +101,7 @@ brew untap moona3k/tap 2>/dev/null   # if previously tapped
 brew tap moona3k/tap
 brew install macparakeet-cli
 
-macparakeet-cli --version    # 1.3.0
+macparakeet-cli --version    # 1.4.0
 macparakeet-cli health --json
 ```
 

--- a/scripts/dist/homebrew-tap-scaffold/macparakeet-cli.rb
+++ b/scripts/dist/homebrew-tap-scaffold/macparakeet-cli.rb
@@ -14,10 +14,10 @@
 class MacparakeetCli < Formula
   desc "Local STT, transcription, and prompt automation for Apple Silicon"
   homepage "https://macparakeet.com"
-  url "https://github.com/moona3k/macparakeet/releases/download/cli-v1.0.0/macparakeet-cli-1.0.0-darwin-arm64.tar.gz"
+  url "https://github.com/moona3k/macparakeet/releases/download/cli-v1.3.0/macparakeet-cli-1.3.0-darwin-arm64.tar.gz"
   sha256 "REPLACE_WITH_TARBALL_SHA256_AT_RELEASE_TIME"
   license "GPL-3.0-or-later"
-  version "1.0.0"
+  version "1.3.0"
 
   # macOS 14.2+ (Sonoma) — required by FluidAudio + Swift 6 runtime.
   # Homebrew's `depends_on macos:` only accepts major-version symbols, so

--- a/scripts/dist/homebrew-tap-scaffold/macparakeet-cli.rb
+++ b/scripts/dist/homebrew-tap-scaffold/macparakeet-cli.rb
@@ -14,10 +14,10 @@
 class MacparakeetCli < Formula
   desc "Local STT, transcription, and prompt automation for Apple Silicon"
   homepage "https://macparakeet.com"
-  url "https://github.com/moona3k/macparakeet/releases/download/cli-v1.3.0/macparakeet-cli-1.3.0-darwin-arm64.tar.gz"
+  url "https://github.com/moona3k/macparakeet/releases/download/cli-v1.4.0/macparakeet-cli-1.4.0-darwin-arm64.tar.gz"
   sha256 "REPLACE_WITH_TARBALL_SHA256_AT_RELEASE_TIME"
   license "GPL-3.0-or-later"
-  version "1.3.0"
+  version "1.4.0"
 
   # macOS 14.2+ (Sonoma) — required by FluidAudio + Swift 6 runtime.
   # Homebrew's `depends_on macos:` only accepts major-version symbols, so

--- a/scripts/dist/sign_notarize.sh
+++ b/scripts/dist/sign_notarize.sh
@@ -140,7 +140,7 @@ xcrun stapler staple "$APP_PATH"
 xcrun stapler validate "$APP_PATH"
 
 echo "[8/8] Gatekeeper assess…"
-spctl --assess --type execute --verbose=4 "$APP_PATH" || true
+spctl --assess --type execute --verbose=4 "$APP_PATH"
 
 if [[ "$CREATE_DMG" == "1" ]]; then
   DMG_PATH="$DIST_DIR/${APP_NAME}.dmg"

--- a/scripts/dist/sign_notarize.sh
+++ b/scripts/dist/sign_notarize.sh
@@ -78,7 +78,7 @@ while IFS= read -r -d '' bin; do
   fi
 done < <(
   find "$APP_PATH/Contents/Resources" -maxdepth 1 -type f -perm -111 \
-    \( -name "ffmpeg" -o -name "node" -o -name "node-arm64" -o -name "node-x86_64" \) -print0 2>/dev/null || true
+    \( -name "ffmpeg" -o -name "yt-dlp" -o -name "node" -o -name "node-arm64" -o -name "node-x86_64" \) -print0 2>/dev/null || true
 )
 
 while IFS= read -r -d '' bin; do

--- a/scripts/dist/sign_notarize.sh
+++ b/scripts/dist/sign_notarize.sh
@@ -81,6 +81,17 @@ done < <(
     \( -name "ffmpeg" -o -name "node" -o -name "node-arm64" -o -name "node-x86_64" \) -print0 2>/dev/null || true
 )
 
+while IFS= read -r -d '' bin; do
+  base="$(basename "$bin")"
+  if [[ "$base" == "$APP_NAME" ]]; then
+    continue
+  fi
+  echo "Signing bundled executable: $bin"
+  codesign --force --sign "$SIGN_IDENTITY" --options runtime --timestamp "$bin"
+done < <(
+  find "$APP_PATH/Contents/MacOS" -maxdepth 1 -type f -perm -111 -print0 2>/dev/null || true
+)
+
 ENTITLEMENTS="$ROOT_DIR/scripts/dist/MacParakeet.entitlements"
 
 echo "[3/8] Codesigning app (hardened runtime + entitlements)…"


### PR DESCRIPTION
## Summary

This PR prepares the Whisper language-picker branch for release review. It now covers the app-facing Whisper fallback work plus the surrounding release contracts: bundled helpers, CLI versioning/docs, privacy-sensitive logging, destructive cleanup behavior, meeting capture reliability, and distribution scripts.

## User-Facing Changes

- Whisper remains a local fallback STT engine for languages Parakeet does not cover, with runtime serialization so overlapping jobs cannot drive the same WhisperKit engine concurrently.
- The stable release copy now matches the branch: dictation, file/video/YouTube transcription, meeting recording, and local WhisperKit fallback are documented as part of the release channel.
- The app-bundled CLI contract is preserved: the bundle build script builds/copies `macparakeet-cli`, signing covers `Contents/MacOS` executables, and integration docs point at the bundled binary.
- The public CLI surface is cut as `1.4.0`, with changelog, integration examples, and Homebrew scaffold examples updated.
- `yt-dlp` can be seeded from the signed app bundle into MacParakeet's Application Support folder before falling back to explicit repair/download flows.
- `health --json` stays read-only; helper repair is explicit through `health --repair-binaries`.
- Local CLI provider copy is clearer: the configured command runs locally, but that command may contact its own cloud service.

## Safety And Privacy Hardening

- CLI transcription lookup rejects unsafe short UUID prefixes, treats only UUID-shaped values as prefix candidates, and uses SQL-backed lookup instead of full-table filtering.
- Destructive deletes remove app-owned YouTube, meeting, and dictation audio before deleting database rows; cleanup failures are visible instead of silently leaving managed assets behind.
- Meeting recovery discovery is non-destructive: empty/stub recovery folders are skipped and logged rather than silently purged.
- Meeting capture no longer silently drops event bursts through a bounded stream, surfaces microphone no-buffer stalls as capture errors, and fails visibly on writer backpressure.
- Idle and meeting floating pills now restrict hit testing to the visible/active pill area, reducing transparent click interception over other apps.
- YouTube playback and `yt-dlp` logging now use private/sanitized details instead of raw URLs, stream URLs, paths, or stderr text.
- Telemetry `error_detail` values are sanitized at serialization time and remain covered by tests.

## Distribution Hardening

- App bundle builds include GPL/third-party notices and bundled helper seed resources.
- Gatekeeper assessment now fails release signing when assessment fails.
- Distribution defaults use `0.0.0` for local bundles unless release builds set `VERSION=X.Y.Z` explicitly.
- Homebrew scaffold, CLI changelog, release docs, and integration docs now match the current 1.4.0/bundled-helper release story.

## Reviewer Notes

Primary areas worth reviewing:

- `WhisperEngine` permit cancellation/FIFO behavior.
- `BinaryBootstrap` managed-versus-bundled `yt-dlp` resolution.
- CLI `health`, `models speech-stack`, transcription lookup, and destructive delete contracts.
- Meeting capture error propagation and recovery behavior.
- Floating pill hit testing in dictation and meeting modes.
- Release script behavior for CLI/helper bundling, legal notices, signing, notarization, and Gatekeeper assessment.
- Privacy-sensitive telemetry, logging, and error surfaces.

## Validation

Validated locally on latest PR head `e8f0fea3`:

- `swift test` passed: 1,939 XCTest tests + 16 Swift Testing tests.
- Focused final-audit suite passed: `MeetingAudioCaptureServiceTests`, `MeetingAudioStorageWriterTests`, `MeetingRecordingServiceTests`, `VideoStreamServiceTests`, `YouTubeDownloaderTests`, `MediaPlayerViewModelTests`, `CLIHelpersTests`, and `HistoryCommandTests`.
- Earlier focused PR-comment tests passed: `CLIHelpersTests` and `PromptsCommandTests`.
- Earlier release-audit slices passed: `ModelLifecycleCommandTests`, `MeetingRecordingRecoveryServiceTests`, `TelemetryServiceTests`, `TranscriptionDeletionCleanupTests`, `TranscriptionViewModelTests`, `TranscriptionLibraryViewModelTests`, `MeetingRecordingPanelViewModelTests`, `AsyncPermitTests`, `TranscriptionRepositoryTests`, and `CLIHelpersTests`.
- `git diff --check` passed.
- `bash -n scripts/dist/build_app_bundle.sh` passed.
- `bash -n scripts/dist/sign_notarize.sh` passed.
- `.build/debug/macparakeet-cli --version` prints `1.4.0`.

Earlier validation on `6e34ffbf` also smoke-tested release bundle construction with placeholder helper binaries and confirmed the bundled CLI, `yt-dlp`, and `ffmpeg` resources were present.

## Status

Ready for review. Latest pushed head is `e8f0fea3`; GitHub CI should be evaluated against that commit.
