### PR TITLE
Add meeting audio source mode

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -52,6 +52,9 @@ final class AppEnvironment {
         let selectedInputDeviceUIDProvider: @Sendable () -> String? = { [runtimePreferences] in
             runtimePreferences.selectedMicrophoneDeviceUID
         }
+        let meetingAudioSourceModeProvider: @Sendable () -> MeetingAudioSourceMode = { [runtimePreferences] in
+            runtimePreferences.meetingAudioSourceMode
+        }
 
         sttRuntime = STTRuntime(
             speechEngine: SpeechEnginePreference.current(),
@@ -63,7 +66,8 @@ final class AppEnvironment {
         )
         meetingRecordingService = MeetingRecordingService(
             audioCaptureService: MeetingAudioCaptureService(
-                selectedInputDeviceUIDProvider: selectedInputDeviceUIDProvider
+                selectedInputDeviceUIDProvider: selectedInputDeviceUIDProvider,
+                sourceModeProvider: meetingAudioSourceModeProvider
             ),
             sttTranscriber: sttScheduler
         )

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -207,6 +207,7 @@ final class AppEnvironmentConfigurer {
             transcriptionRepo: env.transcriptionRepo,
             conversationRepo: env.chatConversationRepo,
             configStore: env.llmConfigStore,
+            meetingAudioSourceModeProvider: { env.runtimePreferences.meetingAudioSourceMode },
             llmService: hasLLMConfig ? env.llmService : nil,
             onMenuBarIconUpdate: { _ in callbacks.onMenuBarIconUpdate() },
             onTranscriptionReady: { [weak self] transcription in

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -59,6 +59,7 @@ final class MeetingRecordingFlowCoordinator {
     private var completedTranscription: Transcription?
     private var currentMeetingOperationContext: ObservabilityOperationContext?
     private var currentMeetingTrigger: TelemetryMeetingRecordingTrigger?
+    private var pendingAudioSourceMode: MeetingAudioSourceMode?
 
     init(
         meetingRecordingService: MeetingRecordingServiceProtocol,
@@ -192,6 +193,7 @@ final class MeetingRecordingFlowCoordinator {
         )
         pendingTrigger = nil
         pendingTitle = nil
+        pendingAudioSourceMode = nil
         currentMeetingOperationContext = nil
         currentMeetingTrigger = nil
         if wasCalendarTriggered {
@@ -235,6 +237,7 @@ final class MeetingRecordingFlowCoordinator {
             let gen = stateMachine.generation
             actionTask = Task { @MainActor in
                 let sourceMode = meetingAudioSourceModeProvider()
+                self.pendingAudioSourceMode = sourceMode
                 let microphoneGranted: Bool
                 if sourceMode.capturesMicrophone {
                     let microphoneStatus = await permissionService.checkMicrophonePermission()
@@ -340,14 +343,16 @@ final class MeetingRecordingFlowCoordinator {
             // can't smuggle a stale trigger / title into this start.
             let trigger = pendingTrigger
             let title = pendingTitle
+            let sourceMode = pendingAudioSourceMode ?? meetingAudioSourceModeProvider()
             pendingTrigger = nil
             pendingTitle = nil
+            pendingAudioSourceMode = nil
             let operationContext = currentMeetingOperationContext ?? ObservabilityOperationContext()
             currentMeetingOperationContext = operationContext
             currentMeetingTrigger = trigger
             actionTask = Task { @MainActor in
                 do {
-                    try await meetingRecordingService.startRecording(title: title)
+                    try await meetingRecordingService.startRecording(title: title, sourceMode: sourceMode)
                     Telemetry.send(.meetingRecordingStarted(trigger: trigger))
                     self.onRecordingBegan()
                     self.sendEvent(.recordingStarted(generation: gen))
@@ -480,6 +485,7 @@ final class MeetingRecordingFlowCoordinator {
             let cancelledTrigger = currentMeetingTrigger ?? pendingTrigger
             pendingTrigger = nil
             pendingTitle = nil
+            pendingAudioSourceMode = nil
             actionTask?.cancel()
             actionTask = Task { @MainActor in
                 // Stop the in-flight debounce so it can't fire against a

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -39,6 +39,7 @@ final class MeetingRecordingFlowCoordinator {
     private let conversationRepo: ChatConversationRepositoryProtocol
     private let configStore: LLMConfigStoreProtocol
     private let cliConfigStore: LocalCLIConfigStore
+    private let meetingAudioSourceModeProvider: @MainActor @Sendable () -> MeetingAudioSourceMode
     private var llmService: LLMServiceProtocol?
     private let onMenuBarIconUpdate: (BreathWaveIcon.MenuBarState) -> Void
     private let onTranscriptionReady: (Transcription) -> Void
@@ -67,6 +68,7 @@ final class MeetingRecordingFlowCoordinator {
         conversationRepo: ChatConversationRepositoryProtocol,
         configStore: LLMConfigStoreProtocol,
         cliConfigStore: LocalCLIConfigStore = LocalCLIConfigStore(),
+        meetingAudioSourceModeProvider: @escaping @MainActor @Sendable () -> MeetingAudioSourceMode = { .microphoneAndSystem },
         llmService: LLMServiceProtocol?,
         onMenuBarIconUpdate: @escaping (BreathWaveIcon.MenuBarState) -> Void,
         onTranscriptionReady: @escaping (Transcription) -> Void,
@@ -80,6 +82,7 @@ final class MeetingRecordingFlowCoordinator {
         self.conversationRepo = conversationRepo
         self.configStore = configStore
         self.cliConfigStore = cliConfigStore
+        self.meetingAudioSourceModeProvider = meetingAudioSourceModeProvider
         self.llmService = llmService
         self.onMenuBarIconUpdate = onMenuBarIconUpdate
         self.onTranscriptionReady = onTranscriptionReady
@@ -231,16 +234,21 @@ final class MeetingRecordingFlowCoordinator {
         case .checkPermissions:
             let gen = stateMachine.generation
             actionTask = Task { @MainActor in
-                let microphoneStatus = await permissionService.checkMicrophonePermission()
+                let sourceMode = meetingAudioSourceModeProvider()
                 let microphoneGranted: Bool
-                switch microphoneStatus {
-                case .granted:
+                if sourceMode.capturesMicrophone {
+                    let microphoneStatus = await permissionService.checkMicrophonePermission()
+                    switch microphoneStatus {
+                    case .granted:
+                        microphoneGranted = true
+                    case .denied:
+                        microphoneGranted = false
+                    case .notDetermined:
+                        Telemetry.send(.permissionPrompted(permission: .microphone))
+                        microphoneGranted = await permissionService.requestMicrophonePermission()
+                    }
+                } else {
                     microphoneGranted = true
-                case .denied:
-                    microphoneGranted = false
-                case .notDetermined:
-                    Telemetry.send(.permissionPrompted(permission: .microphone))
-                    microphoneGranted = await permissionService.requestMicrophonePermission()
                 }
 
                 if !microphoneGranted {
@@ -249,7 +257,9 @@ final class MeetingRecordingFlowCoordinator {
                     self.sendEvent(.permissionsDenied(generation: gen, reason: .microphone))
                     return
                 }
-                Telemetry.send(.permissionGranted(permission: .microphone))
+                if sourceMode.capturesMicrophone {
+                    Telemetry.send(.permissionGranted(permission: .microphone))
+                }
 
                 let existingScreenGrant = permissionService.checkScreenRecordingPermission()
                 if !existingScreenGrant {

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -585,7 +585,7 @@ struct SettingsView: View {
     private var meetingRecordingCard: some View {
         SettingsCard(
             title: "Meeting Recording",
-            subtitle: "System-audio + mic capture, with optional calendar auto-start.",
+            subtitle: "Dedicated controls for meeting audio capture.",
             icon: "record.circle",
             status: meetingRecordingCardStatus
         ) {
@@ -609,6 +609,24 @@ struct SettingsView: View {
                             hotkeyConflictText
                         }
                     }
+                }
+
+                Divider()
+
+                HStack(alignment: .center) {
+                    rowText(
+                        title: "Audio sources",
+                        detail: viewModel.meetingAudioSourceMode.detail
+                    )
+                    Spacer(minLength: DesignSystem.Spacing.md)
+                    Picker("Audio sources", selection: $viewModel.meetingAudioSourceMode) {
+                        ForEach(MeetingAudioSourceMode.allCases, id: \.self) { mode in
+                            Text(mode.displayTitle).tag(mode)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .frame(minWidth: 220, idealWidth: 260, maxWidth: 320)
                 }
 
                 if viewModel.pendingMeetingRecoveryCount > 0 {

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -10,6 +10,42 @@ public protocol AppRuntimePreferencesProtocol: Sendable {
     var aiFormatterEnabled: Bool { get }
     var aiFormatterPrompt: String { get }
     var selectedMicrophoneDeviceUID: String? { get }
+    var meetingAudioSourceMode: MeetingAudioSourceMode { get }
+}
+
+public enum MeetingAudioSourceMode: String, CaseIterable, Hashable, Sendable, Equatable {
+    case microphoneAndSystem = "microphone_and_system"
+    case systemOnly = "system_only"
+
+    public var capturesMicrophone: Bool {
+        self == .microphoneAndSystem
+    }
+
+    public var displayTitle: String {
+        switch self {
+        case .microphoneAndSystem:
+            return "Microphone + System Audio"
+        case .systemOnly:
+            return "System Audio Only"
+        }
+    }
+
+    public var detail: String {
+        switch self {
+        case .microphoneAndSystem:
+            return "Capture your microphone and computer audio. Weak mic bleed is suppressed live."
+        case .systemOnly:
+            return "Capture computer audio only. Use for browser video, podcasts, lectures, and webinars."
+        }
+    }
+
+    public static func current(defaults: UserDefaults = .standard) -> MeetingAudioSourceMode {
+        guard let raw = defaults.string(forKey: UserDefaultsAppRuntimePreferences.meetingAudioSourceModeKey),
+              let mode = MeetingAudioSourceMode(rawValue: raw) else {
+            return .microphoneAndSystem
+        }
+        return mode
+    }
 }
 
 public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProtocol, @unchecked Sendable {
@@ -26,6 +62,7 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
     public static let aiFormatterEnabledKey = "aiFormatterEnabled"
     public static let aiFormatterPromptKey = "aiFormatterPrompt"
     public static let selectedMicrophoneDeviceUIDKey = "selectedMicrophoneDeviceUID"
+    public static let meetingAudioSourceModeKey = "meetingAudioSourceMode"
 
     private let defaults: UserDefaults
 
@@ -72,5 +109,9 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
 
     public var selectedMicrophoneDeviceUID: String? {
         AudioDeviceManager.normalizedUID(defaults.string(forKey: Self.selectedMicrophoneDeviceUIDKey))
+    }
+
+    public var meetingAudioSourceMode: MeetingAudioSourceMode {
+        MeetingAudioSourceMode.current(defaults: defaults)
     }
 }

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -35,7 +35,7 @@ public enum MeetingAudioSourceMode: String, CaseIterable, Hashable, Sendable, Eq
         case .microphoneAndSystem:
             return "Capture your microphone and computer audio. Weak mic bleed is suppressed live."
         case .systemOnly:
-            return "Capture computer audio only. Use for browser video, podcasts, lectures, and webinars."
+            return "Capture computer audio for meetings. Your microphone is still used for dictation."
         }
     }
 

--- a/Sources/MacParakeetCore/Audio/MeetingAudioCaptureService.swift
+++ b/Sources/MacParakeetCore/Audio/MeetingAudioCaptureService.swift
@@ -10,8 +10,14 @@ public enum MeetingAudioCaptureEvent: Sendable {
 
 public protocol MeetingAudioCapturing: Sendable {
     var events: AsyncStream<MeetingAudioCaptureEvent> { get async }
-    func start() async throws -> MeetingAudioCaptureStartReport
+    func start(sourceMode: MeetingAudioSourceMode?) async throws -> MeetingAudioCaptureStartReport
     func stop() async
+}
+
+public extension MeetingAudioCapturing {
+    func start() async throws -> MeetingAudioCaptureStartReport {
+        try await start(sourceMode: nil)
+    }
 }
 
 protocol MeetingMicrophoneCapturing: Sendable {
@@ -116,26 +122,31 @@ public actor MeetingAudioCaptureService {
         return stream
     }
 
-    public func start() async throws -> MeetingAudioCaptureStartReport {
+    public func start(sourceMode sourceModeOverride: MeetingAudioSourceMode? = nil) async throws -> MeetingAudioCaptureStartReport {
         _ = events
         let continuation = eventContinuation
-        return try await start { event in
+        return try await start(sourceMode: sourceModeOverride) { event in
             continuation?.yield(event)
         }
     }
 
-    public func start(handler: @escaping EventHandler) async throws -> MeetingAudioCaptureStartReport {
+    public func start(
+        sourceMode sourceModeOverride: MeetingAudioSourceMode? = nil,
+        handler: @escaping EventHandler
+    ) async throws -> MeetingAudioCaptureStartReport {
         guard !isCapturing else {
             throw MeetingAudioError.alreadyRunning
         }
 
         let tap = try systemAudioTapFactory()
-        let sourceMode = sourceModeProvider()
+        let sourceMode = sourceModeOverride ?? sourceModeProvider()
         eventSink.setHandler(handler)
         var microphoneStartReport: MeetingMicrophoneCaptureStartReport?
+        var attemptedMicrophoneStart = false
 
         do {
             if sourceMode.capturesMicrophone {
+                attemptedMicrophoneStart = true
                 microphoneStartReport = try microphoneCapture.start(
                     processingMode: micProcessingMode,
                     handler: { [weak self] buffer, time in
@@ -180,7 +191,7 @@ public actor MeetingAudioCaptureService {
                 }
             )
         } catch {
-            if microphoneStartReport != nil {
+            if attemptedMicrophoneStart {
                 microphoneCapture.stop()
             }
             tap.stop()

--- a/Sources/MacParakeetCore/Audio/MeetingAudioCaptureService.swift
+++ b/Sources/MacParakeetCore/Audio/MeetingAudioCaptureService.swift
@@ -51,6 +51,7 @@ public actor MeetingAudioCaptureService {
     private let microphoneCapture: any MeetingMicrophoneCapturing
     private let systemAudioTapFactory: @Sendable () throws -> any MeetingSystemAudioTapping
     private let micProcessingMode: MeetingMicProcessingMode
+    private let sourceModeProvider: @Sendable () -> MeetingAudioSourceMode
     private let eventSink = EventSink()
 
     private var systemAudioTap: (any MeetingSystemAudioTapping)?
@@ -61,12 +62,14 @@ public actor MeetingAudioCaptureService {
 
     public init(
         micProcessingMode: MeetingMicProcessingMode = .raw,
-        selectedInputDeviceUIDProvider: @escaping @Sendable () -> String? = { nil }
+        selectedInputDeviceUIDProvider: @escaping @Sendable () -> String? = { nil },
+        sourceModeProvider: @escaping @Sendable () -> MeetingAudioSourceMode = { .microphoneAndSystem }
     ) {
         self.microphoneCapture = MicrophoneCapture(
             selectedInputDeviceUIDProvider: selectedInputDeviceUIDProvider
         )
         self.micProcessingMode = micProcessingMode
+        self.sourceModeProvider = sourceModeProvider
         self.systemAudioTapFactory = {
             guard #available(macOS 14.2, *) else {
                 throw MeetingAudioError.unsupportedPlatform
@@ -78,21 +81,25 @@ public actor MeetingAudioCaptureService {
     init(
         microphoneCaptureFactory: @escaping MeetingMicrophoneCaptureFactory,
         systemAudioTapFactory: @escaping @Sendable () throws -> any MeetingSystemAudioTapping,
-        micProcessingMode: MeetingMicProcessingMode = .raw
+        micProcessingMode: MeetingMicProcessingMode = .raw,
+        sourceModeProvider: @escaping @Sendable () -> MeetingAudioSourceMode = { .microphoneAndSystem }
     ) {
         self.microphoneCapture = microphoneCaptureFactory()
         self.systemAudioTapFactory = systemAudioTapFactory
         self.micProcessingMode = micProcessingMode
+        self.sourceModeProvider = sourceModeProvider
     }
 
     init(
         microphoneCapture: any MeetingMicrophoneCapturing,
         systemAudioTapFactory: @escaping @Sendable () throws -> any MeetingSystemAudioTapping,
-        micProcessingMode: MeetingMicProcessingMode = .raw
+        micProcessingMode: MeetingMicProcessingMode = .raw,
+        sourceModeProvider: @escaping @Sendable () -> MeetingAudioSourceMode = { .microphoneAndSystem }
     ) {
         self.microphoneCapture = microphoneCapture
         self.systemAudioTapFactory = systemAudioTapFactory
         self.micProcessingMode = micProcessingMode
+        self.sourceModeProvider = sourceModeProvider
     }
 
     public var events: AsyncStream<MeetingAudioCaptureEvent> {
@@ -123,31 +130,34 @@ public actor MeetingAudioCaptureService {
         }
 
         let tap = try systemAudioTapFactory()
+        let sourceMode = sourceModeProvider()
         eventSink.setHandler(handler)
-        let microphoneStartReport: MeetingMicrophoneCaptureStartReport
+        var microphoneStartReport: MeetingMicrophoneCaptureStartReport?
 
         do {
-            microphoneStartReport = try microphoneCapture.start(
-                processingMode: micProcessingMode,
-                handler: { [weak self] buffer, time in
-                    guard let copy = Self.deepCopyBuffer(buffer) else {
-                        Logger(subsystem: "com.macparakeet.core", category: "MeetingAudioCaptureService")
-                            .warning("deepCopyBuffer nil for microphone capture: format=\(buffer.format.commonFormat.rawValue) rate=\(buffer.format.sampleRate) ch=\(buffer.format.channelCount) interleaved=\(buffer.format.isInterleaved) frames=\(buffer.frameLength)")
-                        self?.eventSink.emit(
-                            .error(
-                                .captureRuntimeFailure(
-                                    "microphone buffer copy failed (format=\(buffer.format.commonFormat.rawValue) rate=\(buffer.format.sampleRate) channels=\(buffer.format.channelCount))"
+            if sourceMode.capturesMicrophone {
+                microphoneStartReport = try microphoneCapture.start(
+                    processingMode: micProcessingMode,
+                    handler: { [weak self] buffer, time in
+                        guard let copy = Self.deepCopyBuffer(buffer) else {
+                            Logger(subsystem: "com.macparakeet.core", category: "MeetingAudioCaptureService")
+                                .warning("deepCopyBuffer nil for microphone capture: format=\(buffer.format.commonFormat.rawValue) rate=\(buffer.format.sampleRate) ch=\(buffer.format.channelCount) interleaved=\(buffer.format.isInterleaved) frames=\(buffer.frameLength)")
+                            self?.eventSink.emit(
+                                .error(
+                                    .captureRuntimeFailure(
+                                        "microphone buffer copy failed (format=\(buffer.format.commonFormat.rawValue) rate=\(buffer.format.sampleRate) channels=\(buffer.format.channelCount))"
+                                    )
                                 )
                             )
-                        )
-                        return
+                            return
+                        }
+                        self?.eventSink.emit(.microphoneBuffer(copy, time))
+                    },
+                    onStall: { [weak self] error in
+                        self?.eventSink.emit(.error(error))
                     }
-                    self?.eventSink.emit(.microphoneBuffer(copy, time))
-                },
-                onStall: { [weak self] error in
-                    self?.eventSink.emit(.error(error))
-                }
-            )
+                )
+            }
 
             try tap.start(
                 handler: { [weak self] buffer, time in
@@ -170,7 +180,9 @@ public actor MeetingAudioCaptureService {
                 }
             )
         } catch {
-            microphoneCapture.stop()
+            if microphoneStartReport != nil {
+                microphoneCapture.stop()
+            }
             tap.stop()
             finishEventStream()
             eventSink.setHandler(nil)
@@ -180,9 +192,12 @@ public actor MeetingAudioCaptureService {
         systemAudioTap = tap
         isCapturing = true
         logger.info(
-            "Meeting audio capture started requested_mic_mode=\(String(describing: microphoneStartReport.requestedMode), privacy: .public) effective_mic_mode=\(microphoneStartReport.effectiveMode.rawValue, privacy: .public)"
+            "Meeting audio capture started source_mode=\(sourceMode.rawValue, privacy: .public) microphone_started=\(microphoneStartReport != nil, privacy: .public) requested_mic_mode=\(String(describing: microphoneStartReport?.requestedMode), privacy: .public) effective_mic_mode=\(microphoneStartReport?.effectiveMode.rawValue ?? "none", privacy: .public)"
         )
-        return MeetingAudioCaptureStartReport(microphone: microphoneStartReport)
+        return MeetingAudioCaptureStartReport(
+            sourceMode: sourceMode,
+            microphone: microphoneStartReport
+        )
     }
 
     public func stop() {

--- a/Sources/MacParakeetCore/Audio/MeetingMicProcessingMode.swift
+++ b/Sources/MacParakeetCore/Audio/MeetingMicProcessingMode.swift
@@ -29,9 +29,25 @@ public struct MeetingMicrophoneCaptureStartReport: Sendable, Equatable {
 }
 
 public struct MeetingAudioCaptureStartReport: Sendable, Equatable {
+    public let sourceMode: MeetingAudioSourceMode
     public let microphone: MeetingMicrophoneCaptureStartReport
+    public let microphoneStarted: Bool
 
     public init(microphone: MeetingMicrophoneCaptureStartReport) {
+        self.sourceMode = .microphoneAndSystem
         self.microphone = microphone
+        self.microphoneStarted = true
+    }
+
+    public init(
+        sourceMode: MeetingAudioSourceMode,
+        microphone: MeetingMicrophoneCaptureStartReport? = nil
+    ) {
+        self.sourceMode = sourceMode
+        self.microphone = microphone ?? MeetingMicrophoneCaptureStartReport(
+            requestedMode: .raw,
+            effectiveMode: .raw
+        )
+        self.microphoneStarted = microphone != nil
     }
 }

--- a/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
@@ -260,7 +260,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
 
             let captureStartReport = try await audioCaptureService.start()
             try await validateStartStillCurrent(session)
-            configureMicConditioner(from: captureStartReport.microphone)
+            configureMicConditioner(from: captureStartReport)
             processingTask = Task { [weak self] in
                 guard let self else { return }
                 for await event in events {
@@ -630,21 +630,30 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         }
     }
 
-    private func configureMicConditioner(from report: MeetingMicrophoneCaptureStartReport) {
-        switch report.effectiveMode {
+    private func configureMicConditioner(from report: MeetingAudioCaptureStartReport) {
+        guard report.microphoneStarted else {
+            micConditioner = SoftwareAECConditioner()
+            logger.info(
+                "meeting_mic_conditioner_skipped source_mode=\(report.sourceMode.rawValue, privacy: .public)"
+            )
+            return
+        }
+
+        let microphone = report.microphone
+        switch microphone.effectiveMode {
         case .vpio:
             micConditioner = VPIOConditioner()
         case .raw:
             micConditioner = SoftwareAECConditioner()
         }
 
-        if report.fellBackToRaw {
+        if microphone.fellBackToRaw {
             logger.notice(
-                "meeting_mic_conditioner_fallback requested=\(String(describing: report.requestedMode), privacy: .public) effective=raw requested_policy=\(String(describing: self.requestedMicProcessingMode), privacy: .public)"
+                "meeting_mic_conditioner_fallback requested=\(String(describing: microphone.requestedMode), privacy: .public) effective=raw requested_policy=\(String(describing: self.requestedMicProcessingMode), privacy: .public)"
             )
         } else {
             logger.info(
-                "meeting_mic_conditioner_selected requested=\(String(describing: report.requestedMode), privacy: .public) effective=\(report.effectiveMode.rawValue, privacy: .public)"
+                "meeting_mic_conditioner_selected requested=\(String(describing: microphone.requestedMode), privacy: .public) effective=\(microphone.effectiveMode.rawValue, privacy: .public)"
             )
         }
     }

--- a/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
@@ -21,7 +21,7 @@ public protocol MeetingRecordingServiceProtocol: Sendable {
     /// `title` lets callers (e.g., the calendar auto-start path) pre-name
     /// the recording. `nil` or whitespace-only falls back to the default
     /// "Meeting <date>" label.
-    func startRecording(title: String?) async throws
+    func startRecording(title: String?, sourceMode: MeetingAudioSourceMode?) async throws
     func stopRecording() async throws -> MeetingRecordingOutput
     func completeTranscription(for recording: MeetingRecordingOutput) async
     func cancelRecording() async
@@ -42,8 +42,12 @@ public protocol MeetingRecordingServiceProtocol: Sendable {
 public extension MeetingRecordingServiceProtocol {
     /// Existing manual / hotkey callers use the no-arg form — the calendar
     /// path is the only caller that has a meaningful title to pass.
+    func startRecording(title: String?) async throws {
+        try await startRecording(title: title, sourceMode: nil)
+    }
+
     func startRecording() async throws {
-        try await startRecording(title: nil)
+        try await startRecording(title: nil, sourceMode: nil)
     }
 }
 
@@ -177,7 +181,10 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         return stream
     }
 
-    public func startRecording(title: String? = nil) async throws {
+    public func startRecording(
+        title: String? = nil,
+        sourceMode: MeetingAudioSourceMode? = nil
+    ) async throws {
         guard currentSession == nil, startingSessionID == nil else {
             throw MeetingAudioError.alreadyRunning
         }
@@ -258,7 +265,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             )
             try await validateStartStillCurrent(session)
 
-            let captureStartReport = try await audioCaptureService.start()
+            let captureStartReport = try await audioCaptureService.start(sourceMode: sourceMode)
             try await validateStartStillCurrent(session)
             configureMicConditioner(from: captureStartReport)
             processingTask = Task { [weak self] in

--- a/Sources/MacParakeetCore/Services/MeetingTranscriptFinalizer.swift
+++ b/Sources/MacParakeetCore/Services/MeetingTranscriptFinalizer.swift
@@ -43,7 +43,11 @@ struct MeetingTranscriptFinalizer {
         })
 
         let systemWords = shiftedWordsBySource[.system] ?? []
-        let microphoneWords = shiftedWordsBySource[.microphone] ?? []
+        let microphoneCleanup = MeetingTranscriptNoiseFilter.cleanFinalMicrophoneWords(
+            microphoneWords: shiftedWordsBySource[.microphone] ?? [],
+            systemWords: systemWords
+        )
+        let microphoneWords = microphoneCleanup.microphoneWords
         let finalizedSystemWords: [WordTimestamp]
         if let systemDiarization {
             finalizedSystemWords = SpeakerMerger.mergeWordTimestampsWithSpeakers(
@@ -65,7 +69,11 @@ struct MeetingTranscriptFinalizer {
 
         let speakers = activeSpeakers(from: mergedWords, systemDiarization: systemDiarization)
         let diarizationSegments = buildDiarizationSegments(from: mergedWords)
-        let rawTranscript = finalTranscriptText(from: normalized, mergedWords: mergedWords)
+        let rawTranscript = finalTranscriptText(
+            from: normalized,
+            mergedWords: mergedWords,
+            forceMergedWordText: microphoneCleanup.removedMicrophoneWordCount > 0
+        )
 
         return FinalizedTranscript(
             rawTranscript: rawTranscript,
@@ -153,8 +161,13 @@ struct MeetingTranscriptFinalizer {
 
     private static func finalTranscriptText(
         from sourceTranscripts: [SourceTranscript],
-        mergedWords: [WordTimestamp]
+        mergedWords: [WordTimestamp],
+        forceMergedWordText: Bool = false
     ) -> String {
+        if forceMergedWordText {
+            return transcriptText(from: mergedWords)
+        }
+
         let textualSourceTranscripts = sourceTranscripts.compactMap { sourceTranscript -> (source: AudioSource, text: String, hasWords: Bool)? in
             let text = sourceTranscript.result.text.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !text.isEmpty else { return nil }

--- a/Sources/MacParakeetCore/Services/MeetingTranscriptNoiseFilter.swift
+++ b/Sources/MacParakeetCore/Services/MeetingTranscriptNoiseFilter.swift
@@ -39,6 +39,7 @@ struct MeetingTranscriptNoiseFilter {
             return CleanupResult(microphoneWords: [], removedMicrophoneWordCount: 0)
         }
 
+        let systemTokenWords = normalizedSystemTokenWords(from: systemWords)
         var indexesToDrop = Set<Int>()
         for run in contiguousRuns(in: microphoneWords) {
             if isFillerOnly(run.words) {
@@ -46,7 +47,7 @@ struct MeetingTranscriptNoiseFilter {
                 continue
             }
 
-            if isObviousSystemDuplicate(microphoneRun: run.words, systemWords: systemWords) {
+            if isObviousSystemDuplicate(microphoneRun: run.words, systemTokenWords: systemTokenWords) {
                 indexesToDrop.formUnion(run.indexes)
             }
         }
@@ -95,12 +96,12 @@ struct MeetingTranscriptNoiseFilter {
 
     private static func isObviousSystemDuplicate(
         microphoneRun: [WordTimestamp],
-        systemWords: [WordTimestamp]
+        systemTokenWords: [(token: String, word: WordTimestamp)]
     ) -> Bool {
         let micTokens = normalizedTokens(microphoneRun)
         guard !micTokens.isEmpty,
               micTokens.count <= duplicateMaxWords,
-              systemWords.count >= micTokens.count else {
+              systemTokenWords.count >= micTokens.count else {
             return false
         }
 
@@ -108,12 +109,6 @@ struct MeetingTranscriptNoiseFilter {
         let confidenceAllowsDrop = averageConfidence <= duplicateLowConfidenceThreshold
             || (micTokens.count <= 2 && averageConfidence <= duplicateShortConfidenceThreshold)
         guard confidenceAllowsDrop else { return false }
-
-        let systemTokenWords = systemWords.compactMap { word -> (token: String, word: WordTimestamp)? in
-            guard let token = normalizedToken(word.word) else { return nil }
-            return (token, word)
-        }
-        guard systemTokenWords.count >= micTokens.count else { return false }
 
         for startIndex in 0...(systemTokenWords.count - micTokens.count) {
             let candidate = systemTokenWords[startIndex..<(startIndex + micTokens.count)].map(\.token)
@@ -145,6 +140,13 @@ struct MeetingTranscriptNoiseFilter {
 
     private static func normalizedTokens(_ words: [WordTimestamp]) -> [String] {
         words.compactMap { normalizedToken($0.word) }
+    }
+
+    private static func normalizedSystemTokenWords(from words: [WordTimestamp]) -> [(token: String, word: WordTimestamp)] {
+        words.compactMap { word -> (token: String, word: WordTimestamp)? in
+            guard let token = normalizedToken(word.word) else { return nil }
+            return (token, word)
+        }
     }
 
     private static func normalizedToken(_ token: String) -> String? {

--- a/Sources/MacParakeetCore/Services/MeetingTranscriptNoiseFilter.swift
+++ b/Sources/MacParakeetCore/Services/MeetingTranscriptNoiseFilter.swift
@@ -1,0 +1,155 @@
+import Foundation
+
+struct MeetingTranscriptNoiseFilter {
+    struct CleanupResult: Sendable, Equatable {
+        let microphoneWords: [WordTimestamp]
+        let removedMicrophoneWordCount: Int
+    }
+
+    private struct IndexedRun {
+        let indexes: [Int]
+        let words: [WordTimestamp]
+    }
+
+    private static let fillerTokens: Set<String> = [
+        "ah",
+        "eh",
+        "er",
+        "hm",
+        "hmm",
+        "mm",
+        "mhm",
+        "mmhmm",
+        "uh",
+        "uhh",
+        "um",
+        "umm",
+    ]
+    private static let runGapMs = 1_200
+    private static let duplicateTimingToleranceMs = 600
+    private static let duplicateMaxWords = 10
+    private static let duplicateLowConfidenceThreshold = 0.65
+    private static let duplicateShortConfidenceThreshold = 0.80
+
+    static func cleanFinalMicrophoneWords(
+        microphoneWords: [WordTimestamp],
+        systemWords: [WordTimestamp]
+    ) -> CleanupResult {
+        guard !microphoneWords.isEmpty else {
+            return CleanupResult(microphoneWords: [], removedMicrophoneWordCount: 0)
+        }
+
+        var indexesToDrop = Set<Int>()
+        for run in contiguousRuns(in: microphoneWords) {
+            if isFillerOnly(run.words) {
+                indexesToDrop.formUnion(run.indexes)
+                continue
+            }
+
+            if isObviousSystemDuplicate(microphoneRun: run.words, systemWords: systemWords) {
+                indexesToDrop.formUnion(run.indexes)
+            }
+        }
+
+        guard !indexesToDrop.isEmpty else {
+            return CleanupResult(microphoneWords: microphoneWords, removedMicrophoneWordCount: 0)
+        }
+
+        let cleaned = microphoneWords.enumerated().compactMap { index, word in
+            indexesToDrop.contains(index) ? nil : word
+        }
+        return CleanupResult(
+            microphoneWords: cleaned,
+            removedMicrophoneWordCount: indexesToDrop.count
+        )
+    }
+
+    private static func contiguousRuns(in words: [WordTimestamp]) -> [IndexedRun] {
+        guard let first = words.first else { return [] }
+
+        var runs: [IndexedRun] = []
+        var currentIndexes = [0]
+        var currentWords = [first]
+        var lastEndMs = first.endMs
+
+        for (index, word) in words.enumerated().dropFirst() {
+            if word.startMs - lastEndMs > runGapMs {
+                runs.append(IndexedRun(indexes: currentIndexes, words: currentWords))
+                currentIndexes = [index]
+                currentWords = [word]
+            } else {
+                currentIndexes.append(index)
+                currentWords.append(word)
+            }
+            lastEndMs = word.endMs
+        }
+
+        runs.append(IndexedRun(indexes: currentIndexes, words: currentWords))
+        return runs
+    }
+
+    private static func isFillerOnly(_ words: [WordTimestamp]) -> Bool {
+        let tokens = normalizedTokens(words)
+        return !tokens.isEmpty && tokens.allSatisfy { fillerTokens.contains($0) }
+    }
+
+    private static func isObviousSystemDuplicate(
+        microphoneRun: [WordTimestamp],
+        systemWords: [WordTimestamp]
+    ) -> Bool {
+        let micTokens = normalizedTokens(microphoneRun)
+        guard !micTokens.isEmpty,
+              micTokens.count <= duplicateMaxWords,
+              systemWords.count >= micTokens.count else {
+            return false
+        }
+
+        let averageConfidence = microphoneRun.reduce(0.0) { $0 + $1.confidence } / Double(microphoneRun.count)
+        let confidenceAllowsDrop = averageConfidence <= duplicateLowConfidenceThreshold
+            || (micTokens.count <= 2 && averageConfidence <= duplicateShortConfidenceThreshold)
+        guard confidenceAllowsDrop else { return false }
+
+        let systemTokenWords = systemWords.compactMap { word -> (token: String, word: WordTimestamp)? in
+            guard let token = normalizedToken(word.word) else { return nil }
+            return (token, word)
+        }
+        guard systemTokenWords.count >= micTokens.count else { return false }
+
+        for startIndex in 0...(systemTokenWords.count - micTokens.count) {
+            let candidate = systemTokenWords[startIndex..<(startIndex + micTokens.count)].map(\.token)
+            guard candidate == micTokens else { continue }
+
+            let systemWindow = systemTokenWords[startIndex..<(startIndex + micTokens.count)].map(\.word)
+            if rangesOverlapWithTolerance(lhs: microphoneRun, rhs: systemWindow) {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    private static func rangesOverlapWithTolerance(
+        lhs: [WordTimestamp],
+        rhs: [WordTimestamp]
+    ) -> Bool {
+        guard let lhsStart = lhs.first?.startMs,
+              let lhsEnd = lhs.last?.endMs,
+              let rhsStart = rhs.first?.startMs,
+              let rhsEnd = rhs.last?.endMs else {
+            return false
+        }
+
+        return lhsStart <= rhsEnd + duplicateTimingToleranceMs
+            && rhsStart <= lhsEnd + duplicateTimingToleranceMs
+    }
+
+    private static func normalizedTokens(_ words: [WordTimestamp]) -> [String] {
+        words.compactMap { normalizedToken($0.word) }
+    }
+
+    private static func normalizedToken(_ token: String) -> String? {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "'"))
+        let normalized = String(token.lowercased().unicodeScalars.filter { allowed.contains($0) })
+        return normalized.isEmpty ? nil : normalized
+    }
+}

--- a/Sources/MacParakeetCore/Services/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/TelemetryEvent.swift
@@ -187,6 +187,7 @@ public enum TelemetrySettingName: String, Sendable, Equatable {
     case fileTranscriptionHotkey = "file_transcription_hotkey"
     case youtubeTranscriptionHotkey = "youtube_transcription_hotkey"
     case microphoneSelection = "microphone_selection"
+    case meetingAudioSourceMode = "meeting_audio_source_mode"
 
     case launchAtLogin = "launch_at_login"
     case silenceAutoStop = "silence_auto_stop"

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -142,11 +142,26 @@ public final class SettingsViewModel {
             Telemetry.send(.settingChanged(setting: .microphoneSelection))
         }
     }
+    public var meetingAudioSourceMode: MeetingAudioSourceMode {
+        didSet {
+            defaults.set(
+                meetingAudioSourceMode.rawValue,
+                forKey: UserDefaultsAppRuntimePreferences.meetingAudioSourceModeKey
+            )
+            Telemetry.send(.settingChanged(setting: .meetingAudioSourceMode))
+        }
+    }
     public var microphoneDeviceOptions: [MicrophoneDeviceOption] = []
     public var microphoneTestState: MicrophoneTestState = .idle
     public var microphoneTestLevel: Float = 0
     public var selectedMicrophoneStatusText: String {
         if selectedMicrophoneDeviceUID == Self.systemDefaultMicrophoneSelection {
+            if meetingAudioSourceMode == .systemOnly {
+                if let currentDefault = microphoneDeviceOptions.first(where: \.isDefault) {
+                    return "Using macOS System Default for dictation: \(currentDefault.name). Meeting recording is set to System Audio Only."
+                }
+                return "Using macOS System Default for dictation. Meeting recording is set to System Audio Only."
+            }
             if let currentDefault = microphoneDeviceOptions.first(where: \.isDefault) {
                 return "Using macOS System Default: \(currentDefault.name)."
             }
@@ -157,6 +172,9 @@ public final class SettingsViewModel {
         }
         guard selected.isAvailable else {
             return "Selected microphone is unavailable. MacParakeet will use System Default until it returns."
+        }
+        if meetingAudioSourceMode == .systemOnly {
+            return "Using \(selected.name) for dictation. Meeting recording is set to System Audio Only."
         }
         return "Using \(selected.name) for dictation and meeting microphone capture."
     }
@@ -442,6 +460,7 @@ public final class SettingsViewModel {
         selectedMicrophoneDeviceUID = Self.normalizedMicrophoneSelection(
             defaults.string(forKey: UserDefaultsAppRuntimePreferences.selectedMicrophoneDeviceUIDKey)
         )
+        meetingAudioSourceMode = MeetingAudioSourceMode.current(defaults: defaults)
         voiceReturnEnabled = defaults.bool(forKey: UserDefaultsAppRuntimePreferences.voiceReturnEnabledKey)
         voiceReturnTrigger = defaults.string(forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggerKey) ?? "press return"
         processingMode = Self.normalizedProcessingMode(defaults.string(forKey: UserDefaultsAppRuntimePreferences.processingModeKey))

--- a/Tests/MacParakeetTests/Audio/MeetingAudioCaptureServiceTests.swift
+++ b/Tests/MacParakeetTests/Audio/MeetingAudioCaptureServiceTests.swift
@@ -113,6 +113,41 @@ final class MeetingAudioCaptureServiceTests: XCTestCase {
         XCTAssertEqual(systemBufferCount, 2_100)
     }
 
+    func testSystemOnlyModeStartsSystemTapWithoutMicrophone() async throws {
+        let microphone = MockMeetingMicrophoneCapture()
+        let systemTap = MockMeetingSystemAudioTap()
+        let service = MeetingAudioCaptureService(
+            microphoneCapture: microphone,
+            systemAudioTapFactory: { systemTap },
+            sourceModeProvider: { .systemOnly }
+        )
+
+        let capturedEvents = CapturedMeetingCaptureEvents()
+        let report = try await service.start { event in
+            Task {
+                await capturedEvents.append(event)
+            }
+        }
+        defer { Task { await service.stop() } }
+
+        XCTAssertEqual(report.sourceMode, .systemOnly)
+        XCTAssertFalse(report.microphoneStarted)
+        XCTAssertTrue(microphone.requestedModes.isEmpty)
+        XCTAssertEqual(systemTap.startCallCount, 1)
+
+        let buffer = try XCTUnwrap(makeInterleavedFloatStereoBuffer(
+            sampleRate: 48_000,
+            samples: [0.25, 0.25, 0.25, 0.25]
+        ))
+        microphone.emit(buffer: buffer, time: AVAudioTime(hostTime: 1))
+        systemTap.emit(buffer: buffer, time: AVAudioTime(hostTime: 1))
+
+        try await Task.sleep(for: .milliseconds(50))
+        let events = await capturedEvents.values()
+        XCTAssertEqual(events.systemBufferCount, 1)
+        XCTAssertEqual(events.microphoneBufferCount, 0)
+    }
+
     func testEmitsRuntimeErrorEventWhenMicrophoneStalls() async throws {
         let microphone = MockMeetingMicrophoneCapture()
         let service = MeetingAudioCaptureService(
@@ -367,8 +402,10 @@ private final class MockMeetingMicrophoneCapture: MeetingMicrophoneCapturing, @u
 private final class MockMeetingSystemAudioTap: MeetingSystemAudioTapping, @unchecked Sendable {
     private var handler: AudioBufferHandler?
     private var stallObserver: StallObserver?
+    private(set) var startCallCount = 0
 
     func start(handler: @escaping AudioBufferHandler, onStall: StallObserver?) throws {
+        startCallCount += 1
         self.handler = handler
         self.stallObserver = onStall
     }
@@ -396,5 +433,25 @@ private actor CapturedPCMBuffer {
 
     func value() -> AVAudioPCMBuffer? {
         buffer
+    }
+}
+
+private actor CapturedMeetingCaptureEvents {
+    private var microphoneBufferCount = 0
+    private var systemBufferCount = 0
+
+    func append(_ event: MeetingAudioCaptureEvent) {
+        switch event {
+        case .microphoneBuffer:
+            microphoneBufferCount += 1
+        case .systemBuffer:
+            systemBufferCount += 1
+        case .error:
+            break
+        }
+    }
+
+    func values() -> (microphoneBufferCount: Int, systemBufferCount: Int) {
+        (microphoneBufferCount, systemBufferCount)
     }
 }

--- a/Tests/MacParakeetTests/Audio/MeetingAudioCaptureServiceTests.swift
+++ b/Tests/MacParakeetTests/Audio/MeetingAudioCaptureServiceTests.swift
@@ -142,10 +142,15 @@ final class MeetingAudioCaptureServiceTests: XCTestCase {
         microphone.emit(buffer: buffer, time: AVAudioTime(hostTime: 1))
         systemTap.emit(buffer: buffer, time: AVAudioTime(hostTime: 1))
 
-        try await Task.sleep(for: .milliseconds(50))
-        let events = await capturedEvents.values()
-        XCTAssertEqual(events.systemBufferCount, 1)
-        XCTAssertEqual(events.microphoneBufferCount, 0)
+        for _ in 0..<20 {
+            let events = await capturedEvents.values()
+            if events.systemBufferCount == 1 {
+                XCTAssertEqual(events.microphoneBufferCount, 0)
+                return
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTFail("Timed out waiting for system-only capture events")
     }
 
     func testEmitsRuntimeErrorEventWhenMicrophoneStalls() async throws {

--- a/Tests/MacParakeetTests/Services/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecordingServiceTests.swift
@@ -701,7 +701,7 @@ final class MeetingRecordingServiceTests: XCTestCase {
             sttTranscriber: sttClient
         )
 
-        try await service.startRecording()
+        try await service.startRecording(sourceMode: .systemOnly)
 
         let systemBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.5))
         await captureService.yield(.systemBuffer(
@@ -717,6 +717,8 @@ final class MeetingRecordingServiceTests: XCTestCase {
         XCTAssertNotNil(output.sourceAlignment.system)
         XCTAssertEqual(audioConverter.capturedMixedInputs(), [output.systemAudioURL])
 
+        let requestedSourceModes = await captureService.requestedSourceModes
+        XCTAssertEqual(requestedSourceModes, [.systemOnly])
         let counts = await sttClient.callCounts
         XCTAssertEqual(counts.microphone, 0)
         XCTAssertGreaterThanOrEqual(counts.system, 1)
@@ -1039,7 +1041,7 @@ private actor BlockingEventsMeetingAudioCaptureService: MeetingAudioCapturing {
         }
     }
 
-    func start() async throws -> MeetingAudioCaptureStartReport {
+    func start(sourceMode: MeetingAudioSourceMode?) async throws -> MeetingAudioCaptureStartReport {
         startCallCount += 1
         return MeetingAudioCaptureStartReport(
             microphone: MeetingMicrophoneCaptureStartReport(
@@ -1074,6 +1076,7 @@ private actor MockMeetingAudioCaptureService: MeetingAudioCapturing {
     private var stream: AsyncStream<MeetingAudioCaptureEvent>?
     private let startReport: MeetingAudioCaptureStartReport
     private(set) var startCallCount = 0
+    private(set) var requestedSourceModes: [MeetingAudioSourceMode?] = []
 
     init(
         startReport: MeetingAudioCaptureStartReport = MeetingAudioCaptureStartReport(
@@ -1098,8 +1101,9 @@ private actor MockMeetingAudioCaptureService: MeetingAudioCapturing {
         return stream
     }
 
-    func start() async throws -> MeetingAudioCaptureStartReport {
+    func start(sourceMode: MeetingAudioSourceMode?) async throws -> MeetingAudioCaptureStartReport {
         startCallCount += 1
+        requestedSourceModes.append(sourceMode)
         _ = events
         return startReport
     }
@@ -1135,7 +1139,7 @@ private actor BlockingStartMeetingAudioCaptureService: MeetingAudioCapturing {
         return stream
     }
 
-    func start() async throws -> MeetingAudioCaptureStartReport {
+    func start(sourceMode: MeetingAudioSourceMode?) async throws -> MeetingAudioCaptureStartReport {
         startCallCount += 1
         resumeSatisfiedStartWaiters()
 

--- a/Tests/MacParakeetTests/Services/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecordingServiceTests.swift
@@ -689,6 +689,39 @@ final class MeetingRecordingServiceTests: XCTestCase {
         XCTAssertEqual(counts.system, 0)
     }
 
+    func testSystemOnlyCaptureProducesSystemSourceOnly() async throws {
+        let captureService = MockMeetingAudioCaptureService(
+            startReport: MeetingAudioCaptureStartReport(sourceMode: .systemOnly)
+        )
+        let audioConverter = RecordingMeetingAudioFileConverter()
+        let sttClient = CountingMeetingSTTClient()
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: audioConverter,
+            sttTranscriber: sttClient
+        )
+
+        try await service.startRecording()
+
+        let systemBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.5))
+        await captureService.yield(.systemBuffer(
+            systemBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
+        ))
+        try await waitForMeetingSTTCall(sttClient) { $0.system >= 1 }
+
+        let output = try await service.stopRecording()
+        defer { try? FileManager.default.removeItem(at: output.folderURL) }
+
+        XCTAssertNil(output.sourceAlignment.microphone)
+        XCTAssertNotNil(output.sourceAlignment.system)
+        XCTAssertEqual(audioConverter.capturedMixedInputs(), [output.systemAudioURL])
+
+        let counts = await sttClient.callCounts
+        XCTAssertEqual(counts.microphone, 0)
+        XCTAssertGreaterThanOrEqual(counts.system, 1)
+    }
+
     func testStopRecordingMixesDualSourcesInMicrophoneThenSystemOrder() async throws {
         let captureService = MockMeetingAudioCaptureService()
         let audioConverter = RecordingMeetingAudioFileConverter()
@@ -836,6 +869,21 @@ final class MeetingRecordingServiceTests: XCTestCase {
         while await client.routedSelections.isEmpty {
             if startedAt.duration(to: .now) > timeout {
                 XCTFail("Timed out waiting for routed live chunk transcription")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+    }
+
+    private func waitForMeetingSTTCall(
+        _ client: CountingMeetingSTTClient,
+        timeout: Duration = .seconds(1),
+        _ predicate: @escaping ((microphone: Int, system: Int)) -> Bool
+    ) async throws {
+        let startedAt = ContinuousClock.now
+        while !predicate(await client.callCounts) {
+            if startedAt.duration(to: .now) > timeout {
+                XCTFail("Timed out waiting for meeting STT call")
                 return
             }
             try await Task.sleep(for: .milliseconds(20))
@@ -1024,7 +1072,19 @@ private actor BlockingEventsMeetingAudioCaptureService: MeetingAudioCapturing {
 private actor MockMeetingAudioCaptureService: MeetingAudioCapturing {
     private var continuation: AsyncStream<MeetingAudioCaptureEvent>.Continuation?
     private var stream: AsyncStream<MeetingAudioCaptureEvent>?
+    private let startReport: MeetingAudioCaptureStartReport
     private(set) var startCallCount = 0
+
+    init(
+        startReport: MeetingAudioCaptureStartReport = MeetingAudioCaptureStartReport(
+            microphone: MeetingMicrophoneCaptureStartReport(
+                requestedMode: .vpioPreferred,
+                effectiveMode: .vpio
+            )
+        )
+    ) {
+        self.startReport = startReport
+    }
 
     var events: AsyncStream<MeetingAudioCaptureEvent> {
         if let stream {
@@ -1041,12 +1101,7 @@ private actor MockMeetingAudioCaptureService: MeetingAudioCapturing {
     func start() async throws -> MeetingAudioCaptureStartReport {
         startCallCount += 1
         _ = events
-        return MeetingAudioCaptureStartReport(
-            microphone: MeetingMicrophoneCaptureStartReport(
-                requestedMode: .vpioPreferred,
-                effectiveMode: .vpio
-            )
-        )
+        return startReport
     }
 
     func stop() async {

--- a/Tests/MacParakeetTests/Services/MeetingTranscriptNoiseFilterTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingTranscriptNoiseFilterTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class MeetingTranscriptNoiseFilterTests: XCTestCase {
+    func testFinalizeDropsFillerOnlyMicrophoneRuns() {
+        let finalized = MeetingTranscriptFinalizer.finalize(sourceTranscripts: [
+            .init(
+                source: .microphone,
+                result: STTResult(
+                    text: "Uh uh",
+                    words: [
+                        TimestampedWord(word: "Uh", startMs: 0, endMs: 120, confidence: 0.92),
+                        TimestampedWord(word: "uh", startMs: 180, endMs: 300, confidence: 0.90),
+                    ]
+                ),
+                startOffsetMs: 0
+            ),
+            .init(
+                source: .system,
+                result: STTResult(
+                    text: "lecture content",
+                    words: [
+                        TimestampedWord(word: "lecture", startMs: 0, endMs: 240, confidence: 0.95),
+                        TimestampedWord(word: "content", startMs: 280, endMs: 560, confidence: 0.95),
+                    ]
+                ),
+                startOffsetMs: 0
+            ),
+        ])
+
+        XCTAssertEqual(finalized.words.map(\.word), ["lecture", "content"])
+        XCTAssertEqual(finalized.words.map(\.speakerId), ["system", "system"])
+        XCTAssertEqual(finalized.speakers, [
+            SpeakerInfo(id: "system", label: "Others"),
+        ])
+        XCTAssertEqual(finalized.rawTranscript, "lecture content")
+    }
+
+    func testFinalizeDropsLowConfidenceMicDuplicateOfSystemRun() {
+        let finalized = MeetingTranscriptFinalizer.finalize(sourceTranscripts: [
+            .init(
+                source: .microphone,
+                result: STTResult(
+                    text: "account information",
+                    words: [
+                        TimestampedWord(word: "account", startMs: 80, endMs: 220, confidence: 0.48),
+                        TimestampedWord(word: "information", startMs: 240, endMs: 480, confidence: 0.50),
+                    ]
+                ),
+                startOffsetMs: 0
+            ),
+            .init(
+                source: .system,
+                result: STTResult(
+                    text: "account information",
+                    words: [
+                        TimestampedWord(word: "account", startMs: 0, endMs: 140, confidence: 0.93),
+                        TimestampedWord(word: "information", startMs: 160, endMs: 400, confidence: 0.93),
+                    ]
+                ),
+                startOffsetMs: 0
+            ),
+        ])
+
+        XCTAssertEqual(finalized.words.map(\.speakerId), ["system", "system"])
+        XCTAssertEqual(finalized.rawTranscript, "account information")
+    }
+
+    func testFinalizePreservesHighConfidenceOverlappingMicSpeech() {
+        let finalized = MeetingTranscriptFinalizer.finalize(sourceTranscripts: [
+            .init(
+                source: .microphone,
+                result: STTResult(
+                    text: "Can you hear me",
+                    words: [
+                        TimestampedWord(word: "Can", startMs: 120, endMs: 220, confidence: 0.90),
+                        TimestampedWord(word: "you", startMs: 240, endMs: 320, confidence: 0.90),
+                        TimestampedWord(word: "hear", startMs: 340, endMs: 450, confidence: 0.90),
+                        TimestampedWord(word: "me", startMs: 470, endMs: 540, confidence: 0.90),
+                    ]
+                ),
+                startOffsetMs: 0
+            ),
+            .init(
+                source: .system,
+                result: STTResult(
+                    text: "Can you hear me",
+                    words: [
+                        TimestampedWord(word: "Can", startMs: 0, endMs: 100, confidence: 0.90),
+                        TimestampedWord(word: "you", startMs: 120, endMs: 200, confidence: 0.90),
+                        TimestampedWord(word: "hear", startMs: 220, endMs: 330, confidence: 0.90),
+                        TimestampedWord(word: "me", startMs: 350, endMs: 420, confidence: 0.90),
+                    ]
+                ),
+                startOffsetMs: 0
+            ),
+        ])
+
+        XCTAssertEqual(
+            finalized.words.map(\.speakerId),
+            ["system", "microphone", "system", "system", "microphone", "microphone", "system", "microphone"]
+        )
+    }
+}

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -83,6 +83,7 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.saveAudioRecordings, "saveAudioRecordings should default to true")
         XCTAssertTrue(viewModel.saveTranscriptionAudio, "saveTranscriptionAudio should default to true")
         XCTAssertEqual(viewModel.meetingHotkeyTrigger, .chord(modifiers: ["command", "shift"], keyCode: 46))
+        XCTAssertEqual(viewModel.meetingAudioSourceMode, .microphoneAndSystem)
         XCTAssertEqual(
             viewModel.selectedMicrophoneDeviceUID,
             SettingsViewModel.systemDefaultMicrophoneSelection,
@@ -100,6 +101,10 @@ final class SettingsViewModelTests: XCTestCase {
         testDefaults.set(false, forKey: "saveAudioRecordings")
         testDefaults.set(false, forKey: "saveTranscriptionAudio")
         testDefaults.set("usb-mic-uid", forKey: UserDefaultsAppRuntimePreferences.selectedMicrophoneDeviceUIDKey)
+        testDefaults.set(
+            MeetingAudioSourceMode.systemOnly.rawValue,
+            forKey: UserDefaultsAppRuntimePreferences.meetingAudioSourceModeKey
+        )
         HotkeyTrigger.chord(modifiers: ["control", "option"], keyCode: 46)
             .save(to: testDefaults, defaultsKey: HotkeyTrigger.meetingDefaultsKey)
 
@@ -113,6 +118,7 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertFalse(vm.saveAudioRecordings)
         XCTAssertFalse(vm.saveTranscriptionAudio)
         XCTAssertEqual(vm.selectedMicrophoneDeviceUID, "usb-mic-uid")
+        XCTAssertEqual(vm.meetingAudioSourceMode, .systemOnly)
         XCTAssertEqual(vm.meetingHotkeyTrigger, .chord(modifiers: ["control", "option"], keyCode: 46))
     }
 
@@ -316,6 +322,15 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(
             HotkeyTrigger.current(defaults: testDefaults, defaultsKey: HotkeyTrigger.meetingDefaultsKey),
             trigger
+        )
+    }
+
+    func testMeetingAudioSourceModePersists() {
+        viewModel.meetingAudioSourceMode = .systemOnly
+
+        XCTAssertEqual(
+            testDefaults.string(forKey: UserDefaultsAppRuntimePreferences.meetingAudioSourceModeKey),
+            MeetingAudioSourceMode.systemOnly.rawValue
         )
     }
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -226,7 +226,7 @@ events remain useful for diarization-specific timing and failure analysis.
 | `processing_mode_changed` | `mode` (raw, clean) | Is the clean pipeline valued? |
 | `custom_word_added` | — | Are custom words used? (NOT the word itself) |
 | `snippet_added` | — | Are snippets used? |
-| `setting_changed` | `setting` (save_history, audio_retention, menu_bar_only, hide_pill, save_transcription_audio, speaker_diarization, auto_save, meeting_auto_save, meeting_hotkey, file_transcription_hotkey, youtube_transcription_hotkey, microphone_selection, launch_at_login, silence_auto_stop, voice_return, calendar_auto_start_mode, calendar_reminder_minutes, calendar_trigger_filter, calendar_auto_stop_enabled, calendar_included_calendars) | Which settings get toggled? |
+| `setting_changed` | `setting` (save_history, audio_retention, menu_bar_only, hide_pill, save_transcription_audio, speaker_diarization, auto_save, meeting_auto_save, meeting_hotkey, file_transcription_hotkey, youtube_transcription_hotkey, microphone_selection, meeting_audio_source_mode, launch_at_login, silence_auto_stop, voice_return, calendar_auto_start_mode, calendar_reminder_minutes, calendar_trigger_filter, calendar_auto_stop_enabled, calendar_included_calendars) | Which settings get toggled? |
 | `telemetry_opted_out` | — | How many opt out? (send this one last event, then stop) |
 
 ### 6. Licensing — "Is the business working?"


### PR DESCRIPTION
## Summary

This adds an explicit meeting recording audio source setting so media playback can be recorded cleanly without microphone bleed.

The default remains **Microphone + System Audio** for normal meetings. A new **System Audio Only** mode is available for YouTube, browser videos, lectures, webinars, podcasts, and other playback-only workflows.

## Why

When the user is only playing media in the browser, the transcript should come from system audio. The old path could still capture low-level speaker bleed through the microphone and surface it as fake `Me` transcript segments, such as repeated `Uh` entries.

## What Changed

- Added persisted `MeetingAudioSourceMode` preferences:
  - `Microphone + System Audio`
  - `System Audio Only`
- Added the new audio source picker in Meeting Recording settings.
- Snapshot the selected source mode at recording start so permission checks and capture startup use the same value.
- In **System Audio Only** mode:
  - skip microphone permission for the meeting flow
  - do not start microphone capture
  - only system audio enters live meeting transcription
- Kept the default meeting path as mic + system audio, with the existing live mic bleed suppression behavior.
- Kept raw mic/system recording paths separate for normal meetings.
- Added a narrow final cleanup backup that removes filler-only mic runs and obvious low-confidence mic duplicates of system audio.

## Behavior

```text
Default meeting mode

  Microphone --------------> live STT as Me
       |                         |
       |                         +-- weak bleed suppression remains in the live path
       v
  raw mic file

  System audio -----------> live STT as Others
       |
       v
  raw system file

  final transcript cleanup removes only conservative mic artifacts
```

```text
System Audio Only mode

  Microphone --------------> not requested, not started

  System audio -----------> live STT as Others
       |
       v
  raw system file
```

## Scope

This is intentionally not a new source separation system, diarization rewrite, audio router, or custom noise model. The main fix is configuration: when the workflow is playback-only, keep the microphone out of the capture path entirely.

The final cleanup is only a safety net. It is intentionally conservative and should not be the primary mechanism for fixing live transcript source labels.

## Tests

- `swift test`
- `swift test --filter MeetingAudioCaptureServiceTests/testSystemOnlyModeStartsSystemTapWithoutMicrophone`
- `swift test --filter MeetingRecordingServiceTests/testSystemOnlyCaptureProducesSystemSourceOnly`
- `swift test --filter MeetingTranscriptNoiseFilterTests`
- `swift test --filter SettingsViewModelTests/testMeetingAudioSourceModePersists`
- `git diff --check HEAD`

GitHub CI passed on PR #178 before merge.
