### PR TITLE
Polish Reset & Cleanup card

### DIFF
--- a/Sources/MacParakeet/Views/Settings/Components/SettingsCard.swift
+++ b/Sources/MacParakeet/Views/Settings/Components/SettingsCard.swift
@@ -16,6 +16,7 @@ struct SettingsCard<Content: View>: View {
     let title: String
     let subtitle: String
     let icon: String
+    let iconTint: Color?
     let statusChip: SettingsCardStatus?
     @ViewBuilder let content: () -> Content
 
@@ -25,26 +26,29 @@ struct SettingsCard<Content: View>: View {
         title: String,
         subtitle: String,
         icon: String,
+        iconTint: Color? = nil,
         status: SettingsCardStatus? = nil,
         @ViewBuilder content: @escaping () -> Content
     ) {
         self.title = title
         self.subtitle = subtitle
         self.icon = icon
+        self.iconTint = iconTint
         self.statusChip = status
         self.content = content
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+        let resolvedIconTint = iconTint ?? DesignSystem.Colors.accent
+        return VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
             HStack(alignment: .top, spacing: DesignSystem.Spacing.sm) {
                 Image(systemName: icon)
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(DesignSystem.Colors.accent)
+                    .foregroundStyle(resolvedIconTint)
                     .frame(width: 30, height: 30)
                     .background(
                         RoundedRectangle(cornerRadius: 8)
-                            .fill(DesignSystem.Colors.accent.opacity(0.12))
+                            .fill(resolvedIconTint.opacity(0.12))
                     )
                     .accessibilityHidden(true)
 

--- a/Sources/MacParakeet/Views/Settings/Components/SettingsDestructiveButton.swift
+++ b/Sources/MacParakeet/Views/Settings/Components/SettingsDestructiveButton.swift
@@ -7,8 +7,16 @@ import SwiftUI
 /// destructive actions without each one re-implementing the confirmation
 /// dance. Uses the native `.alert` modifier — a custom modal would buy a
 /// different look but no actual behavior the platform doesn't already give us.
+///
+/// `accessibilityLabel` overrides the visible button text for VoiceOver. This
+/// matters in the Reset & Cleanup card where each row's title carries the
+/// "what" ("Dictation history") and the visible button is just the verb
+/// ("Clear…") — VoiceOver users hear the row title via the surrounding
+/// `rowText`, but their cursor still lands on the button alone, so the button
+/// needs to read as a complete instruction in isolation.
 struct SettingsDestructiveButton: View {
     let title: String
+    let accessibilityLabelOverride: String?
     let confirmationTitle: String
     let confirmationMessage: String
     let confirmButtonLabel: String
@@ -18,12 +26,14 @@ struct SettingsDestructiveButton: View {
 
     init(
         title: String,
+        accessibilityLabel: String? = nil,
         confirmationTitle: String,
         confirmationMessage: String,
         confirmButtonLabel: String,
         action: @escaping () -> Void
     ) {
         self.title = title
+        self.accessibilityLabelOverride = accessibilityLabel
         self.confirmationTitle = confirmationTitle
         self.confirmationMessage = confirmationMessage
         self.confirmButtonLabel = confirmButtonLabel
@@ -31,10 +41,14 @@ struct SettingsDestructiveButton: View {
     }
 
     var body: some View {
-        Button(title, role: .destructive) {
+        Button(role: .destructive) {
             isPresented = true
+        } label: {
+            Text(title)
+                .foregroundStyle(DesignSystem.Colors.errorRed)
         }
         .buttonStyle(.bordered)
+        .accessibilityLabel(accessibilityLabelOverride ?? title)
         .alert(confirmationTitle, isPresented: $isPresented) {
             Button("Cancel", role: .cancel) {}
             Button(confirmButtonLabel, role: .destructive, action: action)

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -249,9 +249,9 @@ struct SettingsView: View {
     }
 
     /// System tab — everything that isn't daily-ops, ordered by frequency of
-    /// use. Destructive controls are fenced off at the bottom inside
-    /// `resetCleanupCard`, separated by a visible divider so a user
-    /// scrolling through configuration can't fat-finger a wipe.
+    /// use. The destructive `resetCleanupCard` lives at the very bottom and
+    /// fences itself with a red trash icon, a red "Destructive" chip, and a
+    /// per-action confirmation alert — no extra pre-card divider needed.
     private var systemTabContent: some View {
         scrollableTabBody {
             startupCard.id("system.startup")
@@ -261,8 +261,6 @@ struct SettingsView: View {
             privacyCard.id("system.privacy")
             onboardingCard.id("system.onboarding")
             aboutCard.id("system.about")
-
-            resetCleanupSeparator
             resetCleanupCard.id("system.reset")
         }
     }
@@ -299,25 +297,6 @@ struct SettingsView: View {
                 }
                 pendingScrollTarget = nil
             }
-        }
-    }
-
-    /// Visual fence between configuration and destructive operations.
-    /// "Danger zone"-style cue without the heavy chrome — a faint divider
-    /// plus a small caption is enough signal at the cadence the user
-    /// actually scans this tab.
-    private var resetCleanupSeparator: some View {
-        VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
-            Rectangle()
-                .fill(DesignSystem.Colors.border.opacity(0.4))
-                .frame(height: 0.5)
-                .padding(.top, DesignSystem.Spacing.sm)
-
-            Text("Reset & Cleanup")
-                .font(DesignSystem.Typography.caption.weight(.medium))
-                .foregroundStyle(.tertiary)
-                .textCase(.uppercase)
-                .tracking(0.6)
         }
     }
 
@@ -1001,59 +980,123 @@ struct SettingsView: View {
     // MARK: - Reset & Cleanup
 
     /// Holds every destructive operation in the app. Lives at the bottom of
-    /// the System tab behind a visible divider; the card itself uses the
-    /// `.required` chip semantically (red dot) to telegraph severity even
-    /// when the user lands here scrolled past the divider.
+    /// the System tab; the red trash icon, red "Destructive" chip, and
+    /// per-action confirmation alert do all the fencing — no inner panel,
+    /// no pre-card divider, no double "Reset & Cleanup" labeling.
+    ///
+    /// Body is two semantically labeled subgroups (Delete data vs Reset
+    /// counters), each containing one or more rows. Every row follows the
+    /// standard Settings rhythm: title + per-action detail on the left,
+    /// destructive button on the right — the same shape as
+    /// `SettingsToggleRow` so the eye doesn't have to relearn this card.
     private var resetCleanupCard: some View {
         SettingsCard(
             title: "Reset & Cleanup",
             subtitle: "Permanent. These cannot be undone.",
             icon: "trash",
+            iconTint: DesignSystem.Colors.errorRed,
             status: SettingsCardStatus(.required, label: "Destructive")
         ) {
-            VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
-                maintenanceGroup(
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
+                resetSection(
                     label: "Delete data",
-                    detail: "Removes rows from your library. Lifetime stats are preserved."
+                    caption: "Removes saved rows. Your lifetime stats stay."
                 ) {
-                    SettingsDestructiveButton(
-                        title: "Clear All Dictations...",
+                    resetActionRow(
+                        title: "Dictation history",
+                        detail: "All dictations and their audio files.",
+                        buttonTitle: "Clear…",
+                        accessibilityLabel: "Clear all dictations",
                         confirmationTitle: "Clear All Dictations?",
-                        confirmationMessage: "This will permanently delete all \(viewModel.dictationCount) dictation\(viewModel.dictationCount == 1 ? "" : "s"), their audio files, and any private metric-only entries. Lifetime stats are not affected. This cannot be undone.",
-                        confirmButtonLabel: "Clear All"
-                    ) {
-                        viewModel.clearAllDictations()
-                    }
+                        confirmationMessage: "This will delete all \(viewModel.dictationCount) dictation\(viewModel.dictationCount == 1 ? "" : "s"), their audio files, and any private metric-only entries. Your lifetime stats are not affected. This cannot be undone.",
+                        confirmButtonLabel: "Clear All",
+                        action: viewModel.clearAllDictations
+                    )
 
-                    SettingsDestructiveButton(
-                        title: "Clear Downloaded YouTube Audio...",
+                    Divider()
+
+                    resetActionRow(
+                        title: "Downloaded YouTube audio",
+                        detail: "Saved audio files only. Transcriptions stay; audio detaches.",
+                        buttonTitle: "Clear…",
+                        accessibilityLabel: "Clear downloaded YouTube audio",
                         confirmationTitle: "Clear Downloaded YouTube Audio?",
-                        confirmationMessage: "This will permanently delete all downloaded YouTube audio files and detach them from existing transcriptions.",
-                        confirmButtonLabel: "Clear Audio"
-                    ) {
-                        viewModel.clearDownloadedYouTubeAudio()
-                    }
+                        confirmationMessage: "This will delete all downloaded YouTube audio files and detach them from existing transcriptions. This cannot be undone.",
+                        confirmButtonLabel: "Clear Audio",
+                        action: viewModel.clearDownloadedYouTubeAudio
+                    )
                 }
 
-                maintenanceGroup(
+                resetSection(
                     label: "Reset counters",
-                    detail: "Zeros lifetime stats. Your dictation history is untouched."
+                    caption: "Zeros your lifetime stats. Your dictation history stays."
                 ) {
-                    SettingsDestructiveButton(
-                        title: "Reset Lifetime Stats...",
+                    resetActionRow(
+                        title: "Lifetime voice stats",
+                        detail: "Total words, time, count, and longest dictation.",
+                        buttonTitle: "Reset…",
+                        accessibilityLabel: "Reset lifetime voice stats",
                         confirmationTitle: "Reset Lifetime Stats?",
-                        confirmationMessage: "This will zero your total words, total time, total dictation count, and longest dictation. Your dictation history is not affected. This cannot be undone.",
-                        confirmButtonLabel: "Reset"
-                    ) {
-                        viewModel.resetLifetimeStats()
-                    }
+                        confirmationMessage: "This will zero your total words, time, count, and longest dictation. Your dictation history is not affected. This cannot be undone.",
+                        confirmButtonLabel: "Reset",
+                        action: viewModel.resetLifetimeStats
+                    )
                 }
             }
-            .padding(DesignSystem.Spacing.sm)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-                RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
-                    .fill(DesignSystem.Colors.errorRed.opacity(0.06))
+        }
+    }
+
+    /// One destructive subgroup — small section header above a list of
+    /// action rows. The header uses uppercase tracked caption styling so
+    /// the eye reads it as "section label," not "title": same trick the
+    /// rest of the app uses for thin section dividers.
+    @ViewBuilder
+    private func resetSection<Content: View>(
+        label: String,
+        caption: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            VStack(alignment: .leading, spacing: 1) {
+                Text(label)
+                    .font(DesignSystem.Typography.caption.weight(.semibold))
+                    .textCase(.uppercase)
+                    .tracking(0.6)
+                    .foregroundStyle(.secondary)
+                Text(caption)
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(.tertiary)
+            }
+
+            VStack(spacing: DesignSystem.Spacing.sm) {
+                content()
+            }
+        }
+    }
+
+    /// One destructive action — title + detail on the left, button on the
+    /// right. Mirrors `SettingsToggleRow` so the destructive card has the
+    /// same row rhythm as the rest of Settings.
+    private func resetActionRow(
+        title: String,
+        detail: String,
+        buttonTitle: String,
+        accessibilityLabel: String,
+        confirmationTitle: String,
+        confirmationMessage: String,
+        confirmButtonLabel: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        HStack(alignment: .center, spacing: DesignSystem.Spacing.md) {
+            rowText(title: title, detail: detail)
+            Spacer(minLength: DesignSystem.Spacing.md)
+            SettingsDestructiveButton(
+                title: buttonTitle,
+                accessibilityLabel: accessibilityLabel,
+                confirmationTitle: confirmationTitle,
+                confirmationMessage: confirmationMessage,
+                confirmButtonLabel: confirmButtonLabel,
+                action: action
             )
         }
     }
@@ -1467,28 +1510,6 @@ struct SettingsView: View {
             Text(detail)
                 .font(DesignSystem.Typography.caption)
                 .foregroundStyle(.secondary)
-        }
-    }
-
-    @ViewBuilder
-    private func maintenanceGroup<Buttons: View>(
-        label: String,
-        detail: String,
-        @ViewBuilder buttons: () -> Buttons
-    ) -> some View {
-        VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
-            HStack(alignment: .firstTextBaseline, spacing: DesignSystem.Spacing.sm) {
-                Text(label)
-                    .font(DesignSystem.Typography.caption.weight(.medium))
-                    .foregroundStyle(.secondary)
-                Text(detail)
-                    .font(DesignSystem.Typography.micro)
-                    .foregroundStyle(.tertiary)
-                Spacer(minLength: 0)
-            }
-            FlowLayout(spacing: DesignSystem.Spacing.sm) {
-                buttons()
-            }
         }
     }
 

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -1005,12 +1005,14 @@ struct SettingsView: View {
                     resetActionRow(
                         title: "Dictation history",
                         detail: "All dictations and their audio files.",
-                        buttonTitle: "Clear…",
-                        accessibilityLabel: "Clear all dictations",
-                        confirmationTitle: "Clear All Dictations?",
-                        confirmationMessage: "This will delete all \(viewModel.dictationCount) dictation\(viewModel.dictationCount == 1 ? "" : "s"), their audio files, and any private metric-only entries. Your lifetime stats are not affected. This cannot be undone.",
-                        confirmButtonLabel: "Clear All",
-                        action: viewModel.clearAllDictations
+                        action: ResetDestructiveAction(
+                            buttonTitle: "Clear…",
+                            accessibilityLabel: "Clear all dictations",
+                            confirmationTitle: "Clear All Dictations?",
+                            confirmationMessage: "This will delete all \(viewModel.dictationCount) dictation\(viewModel.dictationCount == 1 ? "" : "s"), their audio files, and any private metric-only entries. Your lifetime stats are not affected. This cannot be undone.",
+                            confirmButtonLabel: "Clear All",
+                            perform: viewModel.clearAllDictations
+                        )
                     )
 
                     Divider()
@@ -1018,12 +1020,14 @@ struct SettingsView: View {
                     resetActionRow(
                         title: "Downloaded YouTube audio",
                         detail: "Saved audio files only. Transcriptions stay; audio detaches.",
-                        buttonTitle: "Clear…",
-                        accessibilityLabel: "Clear downloaded YouTube audio",
-                        confirmationTitle: "Clear Downloaded YouTube Audio?",
-                        confirmationMessage: "This will delete all downloaded YouTube audio files and detach them from existing transcriptions. This cannot be undone.",
-                        confirmButtonLabel: "Clear Audio",
-                        action: viewModel.clearDownloadedYouTubeAudio
+                        action: ResetDestructiveAction(
+                            buttonTitle: "Clear…",
+                            accessibilityLabel: "Clear downloaded YouTube audio",
+                            confirmationTitle: "Clear Downloaded YouTube Audio?",
+                            confirmationMessage: "This will delete all downloaded YouTube audio files and detach them from existing transcriptions. This cannot be undone.",
+                            confirmButtonLabel: "Clear Audio",
+                            perform: viewModel.clearDownloadedYouTubeAudio
+                        )
                     )
                 }
 
@@ -1034,12 +1038,14 @@ struct SettingsView: View {
                     resetActionRow(
                         title: "Lifetime voice stats",
                         detail: "Total words, time, count, and longest dictation.",
-                        buttonTitle: "Reset…",
-                        accessibilityLabel: "Reset lifetime voice stats",
-                        confirmationTitle: "Reset Lifetime Stats?",
-                        confirmationMessage: "This will zero your total words, time, count, and longest dictation. Your dictation history is not affected. This cannot be undone.",
-                        confirmButtonLabel: "Reset",
-                        action: viewModel.resetLifetimeStats
+                        action: ResetDestructiveAction(
+                            buttonTitle: "Reset…",
+                            accessibilityLabel: "Reset lifetime voice stats",
+                            confirmationTitle: "Reset Lifetime Stats?",
+                            confirmationMessage: "This will zero your total words, time, count, and longest dictation. Your dictation history is not affected. This cannot be undone.",
+                            confirmButtonLabel: "Reset",
+                            perform: viewModel.resetLifetimeStats
+                        )
                     )
                 }
             }
@@ -1080,25 +1086,29 @@ struct SettingsView: View {
     private func resetActionRow(
         title: String,
         detail: String,
-        buttonTitle: String,
-        accessibilityLabel: String,
-        confirmationTitle: String,
-        confirmationMessage: String,
-        confirmButtonLabel: String,
-        action: @escaping () -> Void
+        action: ResetDestructiveAction
     ) -> some View {
         HStack(alignment: .center, spacing: DesignSystem.Spacing.md) {
             rowText(title: title, detail: detail)
             Spacer(minLength: DesignSystem.Spacing.md)
             SettingsDestructiveButton(
-                title: buttonTitle,
-                accessibilityLabel: accessibilityLabel,
-                confirmationTitle: confirmationTitle,
-                confirmationMessage: confirmationMessage,
-                confirmButtonLabel: confirmButtonLabel,
-                action: action
+                title: action.buttonTitle,
+                accessibilityLabel: action.accessibilityLabel,
+                confirmationTitle: action.confirmationTitle,
+                confirmationMessage: action.confirmationMessage,
+                confirmButtonLabel: action.confirmButtonLabel,
+                action: action.perform
             )
         }
+    }
+
+    private struct ResetDestructiveAction {
+        let buttonTitle: String
+        let accessibilityLabel: String
+        let confirmationTitle: String
+        let confirmationMessage: String
+        let confirmButtonLabel: String
+        let perform: () -> Void
     }
 
     // MARK: - Engine


### PR DESCRIPTION
## What this fixes

The **Reset & Cleanup** card on Settings → System was hard to scan:

- It said "Reset & Cleanup" three different ways — a header above the card, the card title, and a red "Destructive" chip.
- The body was wrapped in a card-within-a-card red panel — visual noise stacked on more visual noise.
- Two destructive buttons shared one explanation, so each button label had to do the explaining: "Clear All Dictations…", "Clear Downloaded YouTube Audio…". Long, ugly, and awkward to scan.
- Destructive buttons rendered in macOS's default `.bordered` style — barely visible as red in dark mode.

## Before / After

```
                BEFORE                                              AFTER
                                                ┌────────────────────────────────────────────┐
   RESET & CLEANUP                              │ 🗑(red)  Reset & Cleanup                   │
   ─────────────────────────────                │         Permanent. ...   [● Destructive]   │
                                                │                                            │
  ┌────────────────────────────┐                │ DELETE DATA                                │
  │ 🗑(orange) Reset & Cleanup │                │ Removes saved rows. Your stats stay.       │
  │           Permanent. ...   │                │                                            │
  │             [Destructive]  │                │ Dictation history              [ Clear… ]  │
  │ ┌────────────────────────┐ │                │ All dictations and audio files.            │
  │ │ Delete data  Removes… │ │                │ ──────────────────────────────────────────  │
  │ │ [Clear All Dictations…]│ │                │ Downloaded YouTube audio       [ Clear… ]  │
  │ │ [Clear Downloaded      │ │                │ Saved audio files only.                    │
  │ │  YouTube Audio…]       │ │                │                                            │
  │ │                        │ │                │ RESET COUNTERS                             │
  │ │ Reset counters Zeros… │ │                │ Zeros your lifetime stats. History stays.  │
  │ │ [Reset Lifetime Stats…]│ │                │                                            │
  │ └────────────────────────┘ │                │ Lifetime voice stats           [ Reset… ]  │
  └────────────────────────────┘                │ Total words, time, count, longest.         │
                                                └────────────────────────────────────────────┘
   • orange icon
   • red panel inside the red card               • red icon — matches the "Destructive" chip
   • shared explanations                         • flat card, no inner panel
   • long button labels do the talking           • each row carries its own explanation
   • subtle destructive buttons                  • short verb-only buttons in clearly red text
```

## What changed

- **Removed the duplicate framing.** The pre-card "RESET & CLEANUP" header and the inner red panel are gone. The card's red trash icon, red "Destructive" chip, and the macOS confirmation alert that fires before anything is touched are enough fence on their own.
- **Restructured the body** into two named subgroups (Delete data / Reset counters), each containing one row per action. Every row uses the same shape as the rest of Settings: title + short explanation on the left, the action button on the right.
- **Made destructive buttons clearly red.** macOS's default `.bordered` + destructive role is too subtle in dark mode, so the button text is now explicitly red.
- **Polished the copy.** Row titles say what they affect ("Dictation history"); buttons are short verbs ("Clear…", "Reset…"); confirmation messages are tighter.
- **Kept VoiceOver complete.** Short button labels would be ambiguous on their own, so each button gets a full instruction as its accessibility label ("Clear all dictations", etc.).

## What didn't change

- All three destructive operations behave identically — this PR is purely cosmetic.
- The macOS confirmation alert still fires before anything is deleted.
- Card position in the System tab is unchanged (still last).
- Settings search still finds this card from "reset", "clear", "destructive", etc.

## Files

- `Sources/MacParakeet/Views/Settings/SettingsView.swift` — rebuilt the card body, dropped two unused helpers (`maintenanceGroup`, `resetCleanupSeparator`).
- `Sources/MacParakeet/Views/Settings/Components/SettingsCard.swift` — added an opt-in `iconTint:` parameter so this one card can paint its icon red without affecting any other card.
- `Sources/MacParakeet/Views/Settings/Components/SettingsDestructiveButton.swift` — explicit red label color + an optional `accessibilityLabel:` so a terse "Clear…" reads as a complete instruction to VoiceOver.

## Test plan

- [x] `swift build` clean
- [x] `swift test --filter SettingsSearchIndex|SettingsStatusRules` — 21 tests pass
- [ ] Open Settings → System, scroll to Reset & Cleanup
  - [ ] Light mode: trash icon and button text read clearly red
  - [ ] Dark mode: button text still reads clearly red
- [ ] Click each of Clear / Clear / Reset and confirm the alert copy reads cleanly
- [ ] Search "reset" in Settings → tap result → confirm scroll still lands on this card

🤖 Generated with [Claude Code](https://claude.com/claude-code)