### PR TITLE
Polish Engine settings: large engine tiles, conditional language card, calmer Local Models

### DIFF
--- a/Sources/MacParakeet/Views/Settings/Components/EngineOptionTile.swift
+++ b/Sources/MacParakeet/Views/Settings/Components/EngineOptionTile.swift
@@ -32,7 +32,7 @@ struct EngineOptionTile: View {
                     .padding(.top, 2)
 
                 VStack(alignment: .leading, spacing: 6) {
-                    ForEach(strengths, id: \.self) { strength in
+                    ForEach(Array(strengths.enumerated()), id: \.offset) { _, strength in
                         HStack(alignment: .firstTextBaseline, spacing: 8) {
                             Circle()
                                 .fill(DesignSystem.Colors.accent.opacity(0.55))

--- a/Sources/MacParakeet/Views/Settings/Components/EngineOptionTile.swift
+++ b/Sources/MacParakeet/Views/Settings/Components/EngineOptionTile.swift
@@ -4,15 +4,11 @@ import SwiftUI
 
 /// Large selectable tile representing one speech recognition engine.
 ///
-/// Replaces the previous segmented picker because engine choice is the single
-/// most consequential decision on this page — the segmented control under-sold
-/// it. A tile carries an icon, name, tagline, three strength bullets, an
-/// availability footer, and (when missing) an inline Download CTA so first-run
-/// setup happens in place.
-///
-/// Selection visuals: accent border + background tint + checkmark when active.
-/// Hover: subtle border lift on unselected tiles. The full description sits
-/// under `.help()` for cursor hover so the surface stays calm at rest.
+/// Implementation note: the root is a tappable `VStack`, not a `Button`. The
+/// status footer hosts a real `Button` for the Download CTA, and SwiftUI on
+/// macOS does not reliably hit-test a Button nested inside a Button. The tile
+/// uses `.accessibilityElement(children: .contain)` so the inner Download
+/// button stays a separately-actionable element for VoiceOver.
 struct EngineOptionTile: View {
     let icon: String
     let name: String
@@ -29,52 +25,54 @@ struct EngineOptionTile: View {
     @State private var isHovered = false
 
     var body: some View {
-        Button(action: onSelect) {
-            VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
-                header
-                Text(tagline)
-                    .font(DesignSystem.Typography.bodySmall.weight(.medium))
-                    .foregroundStyle(DesignSystem.Colors.accent)
-                    .padding(.top, 2)
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            header
+            Text(tagline)
+                .font(DesignSystem.Typography.bodySmall.weight(.medium))
+                .foregroundStyle(DesignSystem.Colors.accent)
+                .padding(.top, 2)
 
-                VStack(alignment: .leading, spacing: 6) {
-                    ForEach(strengths, id: \.self) { strength in
-                        HStack(alignment: .firstTextBaseline, spacing: 8) {
-                            Circle()
-                                .fill(DesignSystem.Colors.accent.opacity(0.55))
-                                .frame(width: 4, height: 4)
-                                .offset(y: -2)
-                            Text(strength)
-                                .font(DesignSystem.Typography.caption)
-                                .foregroundStyle(DesignSystem.Colors.textSecondary)
-                                .fixedSize(horizontal: false, vertical: true)
-                        }
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(strengths, id: \.self) { strength in
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Circle()
+                            .fill(DesignSystem.Colors.accent.opacity(0.55))
+                            .frame(width: 4, height: 4)
+                            .offset(y: -2)
+                        Text(strength)
+                            .font(DesignSystem.Typography.caption)
+                            .foregroundStyle(DesignSystem.Colors.textSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
                 }
-                .padding(.top, 4)
-
-                Spacer(minLength: 0)
-                statusFooter
             }
-            .frame(maxWidth: .infinity, minHeight: 196, alignment: .topLeading)
-            .padding(DesignSystem.Spacing.md)
-            .background(background)
-            .overlay(border)
-            .contentShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius))
+            .padding(.top, 4)
+
+            Spacer(minLength: 0)
+            statusFooter
         }
-        .buttonStyle(.plain)
-        .disabled(isBusy)
+        .frame(maxWidth: .infinity, minHeight: 196, alignment: .topLeading)
+        .padding(DesignSystem.Spacing.md)
+        .background(background)
+        .overlay(border)
+        .contentShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius))
+        .onTapGesture { handleTileTap() }
         .help(helpText)
         .onHover { hovering in
             withAnimation(DesignSystem.Animation.hoverTransition) {
                 isHovered = hovering
             }
         }
-        .accessibilityElement(children: .combine)
+        .accessibilityElement(children: .contain)
         .accessibilityLabel("\(name) engine. \(tagline).")
-        .accessibilityValue(isSelected ? "Selected" : "Not selected")
         .accessibilityHint(helpText)
         .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+        .accessibilityAction { handleTileTap() }
+    }
+
+    private func handleTileTap() {
+        guard !isBusy, !isSelected else { return }
+        onSelect()
     }
 
     private var header: some View {
@@ -129,6 +127,7 @@ struct EngineOptionTile: View {
                     .buttonStyle(.borderedProminent)
                     .controlSize(.small)
                     .tint(DesignSystem.Colors.accent)
+                    .accessibilityLabel("Download \(name) model")
             }
         }
         .padding(.top, DesignSystem.Spacing.xs)
@@ -138,19 +137,19 @@ struct EngineOptionTile: View {
     private var background: some View {
         RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
             .fill(isSelected
-                  ? DesignSystem.Colors.accent.opacity(0.08)
+                  ? DesignSystem.Colors.accent.opacity(0.13)
                   : DesignSystem.Colors.surfaceElevated.opacity(isHovered ? 0.7 : 0.4))
     }
 
     private var border: some View {
         let strokeColor: Color = if isSelected {
-            DesignSystem.Colors.accent.opacity(0.55)
+            DesignSystem.Colors.accent.opacity(0.8)
         } else if isHovered {
-            DesignSystem.Colors.accent.opacity(0.25)
+            DesignSystem.Colors.accent.opacity(0.3)
         } else {
             DesignSystem.Colors.border.opacity(0.7)
         }
-        let lineWidth: CGFloat = isSelected ? 1.5 : 0.5
+        let lineWidth: CGFloat = isSelected ? 2.0 : 0.5
         return RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
             .strokeBorder(strokeColor, lineWidth: lineWidth)
     }
@@ -184,7 +183,7 @@ struct EngineOptionTile: View {
                 return StatusInfo(
                     color: DesignSystem.Colors.warningAmber,
                     label: "Working",
-                    detail: "Downloading model…"
+                    detail: "Updating model…"
                 )
             case .checking:
                 return StatusInfo(
@@ -214,13 +213,13 @@ struct EngineOptionTile: View {
         EngineOptionTile(
             icon: "bolt.fill",
             name: "Parakeet",
-            tagline: "Fastest · 25 European languages",
+            tagline: "Fastest local engine",
             strengths: [
+                "English + 24 European languages",
                 "155× realtime on Apple Silicon",
-                "~2.5% word error rate",
-                "Optimized for Neural Engine"
+                "Runs on the Neural Engine"
             ],
-            helpText: "Best for English and other European languages. Runs on the Neural Engine for the lowest latency.",
+            helpText: "Best for English and other European languages including Spanish, French, German, and Italian. Runs on the Neural Engine for the lowest latency on Apple Silicon.",
             modelStatus: .ready,
             isSelected: true,
             isBusy: false,
@@ -232,13 +231,13 @@ struct EngineOptionTile: View {
         EngineOptionTile(
             icon: "globe",
             name: "Whisper",
-            tagline: "Multilingual · 99 languages",
+            tagline: "Multilingual coverage",
             strengths: [
-                "Covers Korean, Japanese, Chinese, Thai",
+                "Korean, Japanese, Chinese, Thai +95 more",
                 "Auto language detection",
                 "Whisper Large v3 Turbo (632 MB)"
             ],
-            helpText: "Best for languages outside Parakeet's coverage. Adds Korean, Japanese, Chinese, Thai, Hindi, Arabic, Vietnamese, and 80+ more.",
+            helpText: "Best for languages outside Parakeet's coverage. Adds Korean, Japanese, Chinese, Thai, Hindi, Arabic, Vietnamese, and 80+ more — any language Whisper supports.",
             modelStatus: .notDownloaded,
             isSelected: false,
             isBusy: false,

--- a/Sources/MacParakeet/Views/Settings/Components/EngineOptionTile.swift
+++ b/Sources/MacParakeet/Views/Settings/Components/EngineOptionTile.swift
@@ -4,11 +4,11 @@ import SwiftUI
 
 /// Large selectable tile representing one speech recognition engine.
 ///
-/// Implementation note: the root is a tappable `VStack`, not a `Button`. The
-/// status footer hosts a real `Button` for the Download CTA, and SwiftUI on
-/// macOS does not reliably hit-test a Button nested inside a Button. The tile
-/// uses `.accessibilityElement(children: .contain)` so the inner Download
-/// button stays a separately-actionable element for VoiceOver.
+/// The tile is a plain-styled `Button` so it picks up macOS keyboard focus,
+/// the system focus ring, and Button accessibility traits for free. It only
+/// renders display state (status pill + label) — actionable affordances like
+/// Download / Retry live outside the tile (see `EngineDownloadBanner`) so we
+/// never nest one Button inside another, which is unreliable on macOS SwiftUI.
 struct EngineOptionTile: View {
     let icon: String
     let name: String
@@ -18,60 +18,59 @@ struct EngineOptionTile: View {
     let modelStatus: SettingsViewModel.LocalModelStatus
     let isSelected: Bool
     let isBusy: Bool
-    let downloadActionLabel: String?
     let onSelect: () -> Void
-    let onDownload: (() -> Void)?
 
     @State private var isHovered = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
-            header
-            Text(tagline)
-                .font(DesignSystem.Typography.bodySmall.weight(.medium))
-                .foregroundStyle(DesignSystem.Colors.accent)
-                .padding(.top, 2)
+        Button(action: handleTileTap) {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+                header
+                Text(tagline)
+                    .font(DesignSystem.Typography.bodySmall.weight(.medium))
+                    .foregroundStyle(DesignSystem.Colors.accent)
+                    .padding(.top, 2)
 
-            VStack(alignment: .leading, spacing: 6) {
-                ForEach(strengths, id: \.self) { strength in
-                    HStack(alignment: .firstTextBaseline, spacing: 8) {
-                        Circle()
-                            .fill(DesignSystem.Colors.accent.opacity(0.55))
-                            .frame(width: 4, height: 4)
-                            .offset(y: -2)
-                        Text(strength)
-                            .font(DesignSystem.Typography.caption)
-                            .foregroundStyle(DesignSystem.Colors.textSecondary)
-                            .fixedSize(horizontal: false, vertical: true)
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(strengths, id: \.self) { strength in
+                        HStack(alignment: .firstTextBaseline, spacing: 8) {
+                            Circle()
+                                .fill(DesignSystem.Colors.accent.opacity(0.55))
+                                .frame(width: 4, height: 4)
+                                .offset(y: -2)
+                            Text(strength)
+                                .font(DesignSystem.Typography.caption)
+                                .foregroundStyle(DesignSystem.Colors.textSecondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
                     }
                 }
-            }
-            .padding(.top, 4)
+                .padding(.top, 4)
 
-            Spacer(minLength: 0)
-            statusFooter
+                Spacer(minLength: 0)
+                statusFooter
+            }
+            .frame(maxWidth: .infinity, minHeight: 196, alignment: .topLeading)
+            .padding(DesignSystem.Spacing.md)
+            .background(background)
+            .overlay(border)
+            .contentShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius))
         }
-        .frame(maxWidth: .infinity, minHeight: 196, alignment: .topLeading)
-        .padding(DesignSystem.Spacing.md)
-        .background(background)
-        .overlay(border)
-        .contentShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius))
-        .onTapGesture { handleTileTap() }
+        .buttonStyle(.plain)
+        .disabled(isBusy)
         .help(helpText)
         .onHover { hovering in
             withAnimation(DesignSystem.Animation.hoverTransition) {
                 isHovered = hovering
             }
         }
-        .accessibilityElement(children: .contain)
         .accessibilityLabel("\(name) engine. \(tagline).")
         .accessibilityHint(helpText)
-        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
-        .accessibilityAction { handleTileTap() }
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 
     private func handleTileTap() {
-        guard !isBusy, !isSelected else { return }
+        guard !isSelected else { return }
         onSelect()
     }
 
@@ -104,10 +103,9 @@ struct EngineOptionTile: View {
         }
     }
 
-    @ViewBuilder
     private var statusFooter: some View {
         let info = StatusInfo.from(modelStatus)
-        HStack(alignment: .center, spacing: DesignSystem.Spacing.xs) {
+        return HStack(alignment: .center, spacing: DesignSystem.Spacing.xs) {
             Circle()
                 .fill(info.color)
                 .frame(width: 6, height: 6)
@@ -120,15 +118,6 @@ struct EngineOptionTile: View {
                 .lineLimit(1)
                 .truncationMode(.tail)
             Spacer(minLength: DesignSystem.Spacing.xs)
-            if modelStatus == .notDownloaded,
-               let label = downloadActionLabel,
-               let onDownload {
-                Button(label, action: onDownload)
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.small)
-                    .tint(DesignSystem.Colors.accent)
-                    .accessibilityLabel("Download \(name) model")
-            }
         }
         .padding(.top, DesignSystem.Spacing.xs)
         .padding(.horizontal, 2)
@@ -208,42 +197,104 @@ struct EngineOptionTile: View {
     }
 }
 
-#Preview("Engine tiles", traits: .fixedLayout(width: 760, height: 280)) {
-    HStack(spacing: DesignSystem.Spacing.md) {
-        EngineOptionTile(
-            icon: "bolt.fill",
-            name: "Parakeet",
-            tagline: "Fastest local engine",
-            strengths: [
-                "English + 24 European languages",
-                "155× realtime on Apple Silicon",
-                "Runs on the Neural Engine"
-            ],
-            helpText: "Best for English and other European languages including Spanish, French, German, and Italian. Runs on the Neural Engine for the lowest latency on Apple Silicon.",
-            modelStatus: .ready,
-            isSelected: true,
-            isBusy: false,
-            downloadActionLabel: nil,
-            onSelect: {},
-            onDownload: nil
-        )
+/// Inline call-to-action that appears below the engine tiles when the
+/// selected-but-unavailable engine needs a download. Lives outside the
+/// tiles so the tile root can stay a clean `Button` (no nested-button hit
+/// testing). Compact full-width row: model description on the left, download
+/// affordance on the right, with progress when in flight.
+struct EngineDownloadBanner: View {
+    let title: String
+    let subtitle: String
+    let isDownloading: Bool
+    let action: () -> Void
 
-        EngineOptionTile(
-            icon: "globe",
-            name: "Whisper",
-            tagline: "Multilingual coverage",
-            strengths: [
-                "Korean, Japanese, Chinese, Thai +95 more",
-                "Auto language detection",
-                "Whisper Large v3 Turbo (632 MB)"
-            ],
-            helpText: "Best for languages outside Parakeet's coverage. Adds Korean, Japanese, Chinese, Thai, Hindi, Arabic, Vietnamese, and 80+ more — any language Whisper supports.",
-            modelStatus: .notDownloaded,
-            isSelected: false,
-            isBusy: false,
-            downloadActionLabel: "Download",
-            onSelect: {},
-            onDownload: {}
+    var body: some View {
+        HStack(alignment: .center, spacing: DesignSystem.Spacing.md) {
+            Image(systemName: "arrow.down.circle.fill")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(DesignSystem.Colors.accent)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                    .font(DesignSystem.Typography.bodySmall.weight(.medium))
+                Text(subtitle)
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: DesignSystem.Spacing.md)
+
+            if isDownloading {
+                HStack(spacing: DesignSystem.Spacing.xs) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Downloading…")
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                Button("Download", action: action)
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.regular)
+                    .tint(DesignSystem.Colors.accent)
+                    .accessibilityLabel("Download \(title)")
+            }
+        }
+        .padding(.horizontal, DesignSystem.Spacing.md)
+        .padding(.vertical, DesignSystem.Spacing.sm)
+        .background(
+            RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
+                .fill(DesignSystem.Colors.accent.opacity(0.08))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
+                .strokeBorder(DesignSystem.Colors.accent.opacity(0.25), lineWidth: 0.5)
+        )
+    }
+}
+
+#Preview("Engine tiles + banner", traits: .fixedLayout(width: 760, height: 380)) {
+    VStack(spacing: DesignSystem.Spacing.md) {
+        HStack(spacing: DesignSystem.Spacing.md) {
+            EngineOptionTile(
+                icon: "bolt.fill",
+                name: "Parakeet",
+                tagline: "Fastest local engine",
+                strengths: [
+                    "English + 24 European languages",
+                    "155× realtime on Apple Silicon",
+                    "Runs on the Neural Engine"
+                ],
+                helpText: "Best for English and other European languages including Spanish, French, German, and Italian. Runs on the Neural Engine for the lowest latency on Apple Silicon.",
+                modelStatus: .ready,
+                isSelected: true,
+                isBusy: false,
+                onSelect: {}
+            )
+
+            EngineOptionTile(
+                icon: "globe",
+                name: "Whisper",
+                tagline: "Multilingual coverage",
+                strengths: [
+                    "Korean, Japanese, Chinese, Thai +95 more",
+                    "Auto language detection",
+                    "Whisper Large v3 Turbo (632 MB)"
+                ],
+                helpText: "Best for languages outside Parakeet's coverage. Adds Korean, Japanese, Chinese, Thai, Hindi, Arabic, Vietnamese, and 80+ more — any language Whisper supports.",
+                modelStatus: .notDownloaded,
+                isSelected: false,
+                isBusy: false,
+                onSelect: {}
+            )
+        }
+
+        EngineDownloadBanner(
+            title: "Whisper Large v3 Turbo",
+            subtitle: "632 MB · downloads once, runs locally afterwards",
+            isDownloading: false,
+            action: {}
         )
     }
     .padding(DesignSystem.Spacing.lg)

--- a/Sources/MacParakeet/Views/Settings/Components/EngineOptionTile.swift
+++ b/Sources/MacParakeet/Views/Settings/Components/EngineOptionTile.swift
@@ -1,4 +1,3 @@
-import MacParakeetCore
 import MacParakeetViewModels
 import SwiftUI
 

--- a/Sources/MacParakeet/Views/Settings/Components/EngineOptionTile.swift
+++ b/Sources/MacParakeet/Views/Settings/Components/EngineOptionTile.swift
@@ -1,0 +1,253 @@
+import MacParakeetCore
+import MacParakeetViewModels
+import SwiftUI
+
+/// Large selectable tile representing one speech recognition engine.
+///
+/// Replaces the previous segmented picker because engine choice is the single
+/// most consequential decision on this page — the segmented control under-sold
+/// it. A tile carries an icon, name, tagline, three strength bullets, an
+/// availability footer, and (when missing) an inline Download CTA so first-run
+/// setup happens in place.
+///
+/// Selection visuals: accent border + background tint + checkmark when active.
+/// Hover: subtle border lift on unselected tiles. The full description sits
+/// under `.help()` for cursor hover so the surface stays calm at rest.
+struct EngineOptionTile: View {
+    let icon: String
+    let name: String
+    let tagline: String
+    let strengths: [String]
+    let helpText: String
+    let modelStatus: SettingsViewModel.LocalModelStatus
+    let isSelected: Bool
+    let isBusy: Bool
+    let downloadActionLabel: String?
+    let onSelect: () -> Void
+    let onDownload: (() -> Void)?
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: onSelect) {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+                header
+                Text(tagline)
+                    .font(DesignSystem.Typography.bodySmall.weight(.medium))
+                    .foregroundStyle(DesignSystem.Colors.accent)
+                    .padding(.top, 2)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(strengths, id: \.self) { strength in
+                        HStack(alignment: .firstTextBaseline, spacing: 8) {
+                            Circle()
+                                .fill(DesignSystem.Colors.accent.opacity(0.55))
+                                .frame(width: 4, height: 4)
+                                .offset(y: -2)
+                            Text(strength)
+                                .font(DesignSystem.Typography.caption)
+                                .foregroundStyle(DesignSystem.Colors.textSecondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                }
+                .padding(.top, 4)
+
+                Spacer(minLength: 0)
+                statusFooter
+            }
+            .frame(maxWidth: .infinity, minHeight: 196, alignment: .topLeading)
+            .padding(DesignSystem.Spacing.md)
+            .background(background)
+            .overlay(border)
+            .contentShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius))
+        }
+        .buttonStyle(.plain)
+        .disabled(isBusy)
+        .help(helpText)
+        .onHover { hovering in
+            withAnimation(DesignSystem.Animation.hoverTransition) {
+                isHovered = hovering
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(name) engine. \(tagline).")
+        .accessibilityValue(isSelected ? "Selected" : "Not selected")
+        .accessibilityHint(helpText)
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+    }
+
+    private var header: some View {
+        HStack(alignment: .center, spacing: DesignSystem.Spacing.sm) {
+            Image(systemName: icon)
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundStyle(isSelected ? DesignSystem.Colors.accent : DesignSystem.Colors.textSecondary)
+                .frame(width: 36, height: 36)
+                .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(isSelected
+                              ? DesignSystem.Colors.accent.opacity(0.16)
+                              : DesignSystem.Colors.surfaceElevated)
+                )
+
+            Text(name)
+                .font(.system(size: 18, weight: .semibold, design: .rounded))
+                .foregroundStyle(DesignSystem.Colors.textPrimary)
+
+            Spacer(minLength: DesignSystem.Spacing.xs)
+
+            if isSelected {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(DesignSystem.Colors.accent)
+                    .transition(.scale.combined(with: .opacity))
+                    .accessibilityHidden(true)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var statusFooter: some View {
+        let info = StatusInfo.from(modelStatus)
+        HStack(alignment: .center, spacing: DesignSystem.Spacing.xs) {
+            Circle()
+                .fill(info.color)
+                .frame(width: 6, height: 6)
+            Text(info.label)
+                .font(DesignSystem.Typography.micro.weight(.medium))
+                .foregroundStyle(info.color)
+            Text(info.detail)
+                .font(DesignSystem.Typography.micro)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+            Spacer(minLength: DesignSystem.Spacing.xs)
+            if modelStatus == .notDownloaded,
+               let label = downloadActionLabel,
+               let onDownload {
+                Button(label, action: onDownload)
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .tint(DesignSystem.Colors.accent)
+            }
+        }
+        .padding(.top, DesignSystem.Spacing.xs)
+        .padding(.horizontal, 2)
+    }
+
+    private var background: some View {
+        RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
+            .fill(isSelected
+                  ? DesignSystem.Colors.accent.opacity(0.08)
+                  : DesignSystem.Colors.surfaceElevated.opacity(isHovered ? 0.7 : 0.4))
+    }
+
+    private var border: some View {
+        let strokeColor: Color = if isSelected {
+            DesignSystem.Colors.accent.opacity(0.55)
+        } else if isHovered {
+            DesignSystem.Colors.accent.opacity(0.25)
+        } else {
+            DesignSystem.Colors.border.opacity(0.7)
+        }
+        let lineWidth: CGFloat = isSelected ? 1.5 : 0.5
+        return RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
+            .strokeBorder(strokeColor, lineWidth: lineWidth)
+    }
+
+    private struct StatusInfo {
+        let color: Color
+        let label: String
+        let detail: String
+
+        static func from(_ status: SettingsViewModel.LocalModelStatus) -> StatusInfo {
+            switch status {
+            case .ready:
+                return StatusInfo(
+                    color: DesignSystem.Colors.successGreen,
+                    label: "Ready",
+                    detail: "Loaded in memory"
+                )
+            case .notLoaded:
+                return StatusInfo(
+                    color: DesignSystem.Colors.successGreen,
+                    label: "Downloaded",
+                    detail: "Loads on first use"
+                )
+            case .notDownloaded:
+                return StatusInfo(
+                    color: DesignSystem.Colors.warningAmber,
+                    label: "Not downloaded",
+                    detail: "Needed before first use"
+                )
+            case .repairing:
+                return StatusInfo(
+                    color: DesignSystem.Colors.warningAmber,
+                    label: "Working",
+                    detail: "Downloading model…"
+                )
+            case .checking:
+                return StatusInfo(
+                    color: DesignSystem.Colors.textSecondary,
+                    label: "Checking",
+                    detail: "Inspecting model state"
+                )
+            case .failed:
+                return StatusInfo(
+                    color: DesignSystem.Colors.errorRed,
+                    label: "Failed",
+                    detail: "Open Local Models to retry"
+                )
+            case .unknown:
+                return StatusInfo(
+                    color: DesignSystem.Colors.textSecondary,
+                    label: "Unknown",
+                    detail: "Status not yet checked"
+                )
+            }
+        }
+    }
+}
+
+#Preview("Engine tiles", traits: .fixedLayout(width: 760, height: 280)) {
+    HStack(spacing: DesignSystem.Spacing.md) {
+        EngineOptionTile(
+            icon: "bolt.fill",
+            name: "Parakeet",
+            tagline: "Fastest · 25 European languages",
+            strengths: [
+                "155× realtime on Apple Silicon",
+                "~2.5% word error rate",
+                "Optimized for Neural Engine"
+            ],
+            helpText: "Best for English and other European languages. Runs on the Neural Engine for the lowest latency.",
+            modelStatus: .ready,
+            isSelected: true,
+            isBusy: false,
+            downloadActionLabel: nil,
+            onSelect: {},
+            onDownload: nil
+        )
+
+        EngineOptionTile(
+            icon: "globe",
+            name: "Whisper",
+            tagline: "Multilingual · 99 languages",
+            strengths: [
+                "Covers Korean, Japanese, Chinese, Thai",
+                "Auto language detection",
+                "Whisper Large v3 Turbo (632 MB)"
+            ],
+            helpText: "Best for languages outside Parakeet's coverage. Adds Korean, Japanese, Chinese, Thai, Hindi, Arabic, Vietnamese, and 80+ more.",
+            modelStatus: .notDownloaded,
+            isSelected: false,
+            isBusy: false,
+            downloadActionLabel: "Download",
+            onSelect: {},
+            onDownload: {}
+        )
+    }
+    .padding(DesignSystem.Spacing.lg)
+    .background(DesignSystem.Colors.background)
+    .preferredColorScheme(.dark)
+}

--- a/Sources/MacParakeet/Views/Settings/Components/EngineOptionTile.swift
+++ b/Sources/MacParakeet/Views/Settings/Components/EngineOptionTile.swift
@@ -198,21 +198,27 @@ struct EngineOptionTile: View {
 }
 
 /// Inline call-to-action that appears below the engine tiles when the
-/// selected-but-unavailable engine needs a download. Lives outside the
-/// tiles so the tile root can stay a clean `Button` (no nested-button hit
-/// testing). Compact full-width row: model description on the left, download
-/// affordance on the right, with progress when in flight.
+/// selected-but-unavailable engine needs a download, is downloading, or
+/// failed. Lives outside the tiles so the tile root can stay a clean
+/// `Button` (no nested-button hit testing). Compact full-width row: model
+/// description on the left, mode-specific affordance on the right.
 struct EngineDownloadBanner: View {
+    enum Mode: Equatable {
+        case download           // first-run / not downloaded
+        case downloading        // download in flight (progress)
+        case retry              // last attempt failed
+    }
+
     let title: String
     let subtitle: String
-    let isDownloading: Bool
+    let mode: Mode
     let action: () -> Void
 
     var body: some View {
         HStack(alignment: .center, spacing: DesignSystem.Spacing.md) {
-            Image(systemName: "arrow.down.circle.fill")
+            Image(systemName: leadingIcon)
                 .font(.system(size: 18, weight: .semibold))
-                .foregroundStyle(DesignSystem.Colors.accent)
+                .foregroundStyle(accentColor)
                 .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 1) {
@@ -221,36 +227,65 @@ struct EngineDownloadBanner: View {
                 Text(subtitle)
                     .font(DesignSystem.Typography.caption)
                     .foregroundStyle(.secondary)
+                    .lineLimit(2)
             }
 
             Spacer(minLength: DesignSystem.Spacing.md)
 
-            if isDownloading {
-                HStack(spacing: DesignSystem.Spacing.xs) {
-                    ProgressView()
-                        .controlSize(.small)
-                    Text("Downloading…")
-                        .font(DesignSystem.Typography.caption)
-                        .foregroundStyle(.secondary)
-                }
-            } else {
-                Button("Download", action: action)
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.regular)
-                    .tint(DesignSystem.Colors.accent)
-                    .accessibilityLabel("Download \(title)")
-            }
+            trailingControl
         }
         .padding(.horizontal, DesignSystem.Spacing.md)
         .padding(.vertical, DesignSystem.Spacing.sm)
         .background(
             RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
-                .fill(DesignSystem.Colors.accent.opacity(0.08))
+                .fill(accentColor.opacity(0.08))
         )
         .overlay(
             RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
-                .strokeBorder(DesignSystem.Colors.accent.opacity(0.25), lineWidth: 0.5)
+                .strokeBorder(accentColor.opacity(0.25), lineWidth: 0.5)
         )
+    }
+
+    @ViewBuilder
+    private var trailingControl: some View {
+        switch mode {
+        case .download:
+            Button("Download", action: action)
+                .buttonStyle(.borderedProminent)
+                .controlSize(.regular)
+                .tint(DesignSystem.Colors.accent)
+                .accessibilityLabel("Download \(title)")
+        case .downloading:
+            HStack(spacing: DesignSystem.Spacing.xs) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Downloading…")
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .accessibilityLabel("Downloading \(title)")
+        case .retry:
+            Button("Retry Download", action: action)
+                .buttonStyle(.borderedProminent)
+                .controlSize(.regular)
+                .tint(DesignSystem.Colors.errorRed)
+                .accessibilityLabel("Retry downloading \(title)")
+        }
+    }
+
+    private var leadingIcon: String {
+        switch mode {
+        case .download: return "arrow.down.circle.fill"
+        case .downloading: return "arrow.down.circle.fill"
+        case .retry: return "exclamationmark.triangle.fill"
+        }
+    }
+
+    private var accentColor: Color {
+        switch mode {
+        case .download, .downloading: return DesignSystem.Colors.accent
+        case .retry: return DesignSystem.Colors.errorRed
+        }
     }
 }
 
@@ -293,7 +328,7 @@ struct EngineDownloadBanner: View {
         EngineDownloadBanner(
             title: "Whisper Large v3 Turbo",
             subtitle: "632 MB · downloads once, runs locally afterwards",
-            isDownloading: false,
+            mode: .download,
             action: {}
         )
     }

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -1207,14 +1207,19 @@ struct SettingsView: View {
         }
     }
 
-    /// Drives `EngineDownloadBanner` visibility + content. Returns nil when
-    /// Whisper is usable (`.ready` / `.notLoaded`) or in a transient
-    /// inspection state (`.checking` / `.unknown`); returns a populated
-    /// state when the user needs to act (download, wait, or retry). The
-    /// download lifecycle keeps the banner mounted across `.notDownloaded`
-    /// → `.repairing` → terminal state so the action surface is stable
-    /// rather than blinking out the moment the user clicks Download.
+    /// Drives `EngineDownloadBanner` visibility + content. Returns nil
+    /// unless Whisper is the actively-selected engine — Parakeet users
+    /// shouldn't be nagged to download a model they may never use; for
+    /// them, Whisper's status sits in the tile footer + Local Models card
+    /// and is surfaced only if they explicitly switch.
+    ///
+    /// When Whisper IS selected: returns nil for usable (`.ready` /
+    /// `.notLoaded`) or transient (`.checking` / `.unknown`) states, and a
+    /// populated state when the user needs to act (download, wait, retry).
+    /// The banner stays mounted across `.notDownloaded` → `.repairing` →
+    /// terminal state so the action surface doesn't blink out on click.
     private var whisperDownloadBannerState: (mode: EngineDownloadBanner.Mode, subtitle: String)? {
+        guard viewModel.speechEnginePreference == .whisper else { return nil }
         if viewModel.whisperDownloading {
             return (.downloading, viewModel.whisperModelStatusDetail)
         }
@@ -1242,7 +1247,7 @@ struct SettingsView: View {
         case .ready, .notLoaded:
             selectEngine(.whisper)
         case .notDownloaded:
-            viewModel.speechEngineError = "Download the Whisper model before switching engines."
+            viewModel.speechEngineError = "Download the Whisper model from Local Models below before switching engines."
         case .repairing:
             viewModel.speechEngineError = "Whisper model is downloading — switch engines once it finishes."
         case .failed:

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -1611,7 +1611,7 @@ struct SettingsView: View {
                 Group {
                     if let action = primaryAction {
                         modelRowPrimaryButton(action: action, isWorking: isWorking)
-                    } else if let overflow = overflowAction, !isWorking, status != .checking {
+                    } else if let overflow = overflowAction, !isWorking, status != .checking, status != .repairing {
                         Menu {
                             Button(overflow.label, action: overflow.run)
                         } label: {
@@ -1623,7 +1623,8 @@ struct SettingsView: View {
                         .menuIndicator(.hidden)
                         .fixedSize()
                         .help("More actions")
-                    } else if isWorking || status == .checking {
+                        .accessibilityLabel("More actions")
+                    } else if isWorking || status == .checking || status == .repairing {
                         ProgressView()
                             .controlSize(.small)
                             .frame(width: 22, height: 22)

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -1102,11 +1102,11 @@ struct SettingsView: View {
                     )
                 }
 
-                if viewModel.whisperModelStatus == .notDownloaded {
+                if let banner = whisperDownloadBannerState {
                     EngineDownloadBanner(
                         title: "Whisper Large v3 Turbo",
-                        subtitle: "632 MB · downloads once, runs locally afterwards",
-                        isDownloading: viewModel.whisperDownloading,
+                        subtitle: banner.subtitle,
+                        mode: banner.mode,
                         action: { viewModel.downloadWhisperModel() }
                     )
                 }
@@ -1207,6 +1207,29 @@ struct SettingsView: View {
         }
     }
 
+    /// Drives `EngineDownloadBanner` visibility + content. Returns nil when
+    /// Whisper is usable (`.ready` / `.notLoaded`) or in a transient
+    /// inspection state (`.checking` / `.unknown`); returns a populated
+    /// state when the user needs to act (download, wait, or retry). The
+    /// download lifecycle keeps the banner mounted across `.notDownloaded`
+    /// → `.repairing` → terminal state so the action surface is stable
+    /// rather than blinking out the moment the user clicks Download.
+    private var whisperDownloadBannerState: (mode: EngineDownloadBanner.Mode, subtitle: String)? {
+        if viewModel.whisperDownloading {
+            return (.downloading, viewModel.whisperModelStatusDetail)
+        }
+        switch viewModel.whisperModelStatus {
+        case .notDownloaded:
+            return (.download, "632 MB · downloads once, runs locally afterwards")
+        case .repairing:
+            return (.downloading, viewModel.whisperModelStatusDetail)
+        case .failed:
+            return (.retry, viewModel.whisperModelStatusDetail)
+        case .ready, .notLoaded, .checking, .unknown:
+            return nil
+        }
+    }
+
     /// Pre-empts every "Whisper isn't ready" state so the user never sees
     /// a briefly-selected-then-reverted tile. Mirrors the VM's
     /// `isWhisperModelAvailable` (`ready` or `notLoaded`); for everything
@@ -1223,7 +1246,7 @@ struct SettingsView: View {
         case .repairing:
             viewModel.speechEngineError = "Whisper model is downloading — switch engines once it finishes."
         case .failed:
-            viewModel.speechEngineError = "Whisper model failed to load. Open Local Models below to retry."
+            viewModel.speechEngineError = "Whisper model failed to load — retry below."
         case .checking, .unknown:
             selectEngine(.whisper)
         }

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -1060,19 +1060,6 @@ struct SettingsView: View {
 
     // MARK: - Engine
 
-    /// Engine card: which speech recognition engine to use.
-    ///
-    /// The choice between Parakeet (fast, English + 24 European languages)
-    /// and Whisper (slower, multilingual including Korean/Japanese/Chinese)
-    /// is the most consequential decision on the entire Settings page. The
-    /// previous segmented picker under-sold it. We give it two large
-    /// selectable tiles with strengths and an inline Download CTA when the
-    /// model is missing — the long descriptions live under hover tooltips
-    /// so the surface stays calm at rest.
-    ///
-    /// Status chip surfaces only signal: silent in the steady state, `.info`
-    /// while switching, `.required` if the last switch failed (the inline
-    /// error preserves the full message).
     private var engineSelectorCard: some View {
         SettingsCard(
             title: "Speech Recognition",
@@ -1085,13 +1072,13 @@ struct SettingsView: View {
                     EngineOptionTile(
                         icon: "bolt.fill",
                         name: "Parakeet",
-                        tagline: "Fastest · 25 European languages",
+                        tagline: "Fastest local engine",
                         strengths: [
+                            "English + 24 European languages",
                             "155× realtime on Apple Silicon",
-                            "~2.5% word error rate",
-                            "Optimized for the Neural Engine"
+                            "Runs on the Neural Engine"
                         ],
-                        helpText: "Best for English and 24 other European languages including Spanish, French, German, and Italian. Runs on the Neural Engine for the lowest latency on Apple Silicon.",
+                        helpText: "Best for English and other European languages including Spanish, French, German, and Italian. Runs on the Neural Engine for the lowest latency on Apple Silicon.",
                         modelStatus: viewModel.parakeetStatus,
                         isSelected: viewModel.speechEnginePreference == .parakeet,
                         isBusy: viewModel.speechEngineSwitching,
@@ -1103,9 +1090,9 @@ struct SettingsView: View {
                     EngineOptionTile(
                         icon: "globe",
                         name: "Whisper",
-                        tagline: "Multilingual · 99 languages",
+                        tagline: "Multilingual coverage",
                         strengths: [
-                            "Covers Korean, Japanese, Chinese, Thai",
+                            "Korean, Japanese, Chinese, Thai +95 more",
                             "Auto language detection",
                             "Whisper Large v3 Turbo (632 MB)"
                         ],
@@ -1113,8 +1100,8 @@ struct SettingsView: View {
                         modelStatus: viewModel.whisperModelStatus,
                         isSelected: viewModel.speechEnginePreference == .whisper,
                         isBusy: viewModel.speechEngineSwitching,
-                        downloadActionLabel: viewModel.whisperDownloading ? "Downloading…" : "Download",
-                        onSelect: { selectEngine(.whisper) },
+                        downloadActionLabel: "Download",
+                        onSelect: { handleWhisperTileTap() },
                         onDownload: viewModel.whisperDownloading ? nil : { viewModel.downloadWhisperModel() }
                     )
                 }
@@ -1128,12 +1115,6 @@ struct SettingsView: View {
         }
     }
 
-    /// Hides itself entirely when Parakeet is active. The "Inactive"
-    /// disabled-picker dead state we used to render added zero signal — when
-    /// Parakeet is selected, the language picker has nothing to do, so
-    /// removing it removes a row of dead pixels rather than dressing them up.
-    /// Discoverability is preserved via the Whisper tile's tooltip and the
-    /// fact that selecting Whisper reveals this card with a smooth transition.
     @ViewBuilder
     private var engineLanguageCard: some View {
         if viewModel.speechEnginePreference == .whisper {
@@ -1161,18 +1142,10 @@ struct SettingsView: View {
         }
     }
 
-    /// Local-model dashboard. Status chip rolls up the worst severity across
-    /// both engines: any `.failed` → `.required`; missing model on the
-    /// active engine → `.recommended`; all `.ready` → `.ok`; transient
-    /// states → no chip (the per-row status pills already telegraph it).
-    ///
-    /// Action layout: a fixed-width right column carries the status pill +
-    /// optional action button. We only render an inline button for
-    /// genuinely actionable states (Download missing, Retry failed). For
-    /// healthy models, Repair / Re-download tuck into a `…` menu so the
-    /// row is calm by default — the previous design rendered a permanently
-    /// disabled "Ready" button when Whisper was loaded into memory while
-    /// Parakeet was the active engine, which was pure noise.
+    /// Status chip rolls up the worst severity across both engines via
+    /// `SettingsStatusRules.localModelsCardStatus`. Inline action button
+    /// only renders for actionable states; Repair / Re-download for healthy
+    /// models tucks into a `…` menu so calm rows stay calm.
     private var enginesModelsCard: some View {
         SettingsCard(
             title: "Local Models",
@@ -1222,16 +1195,28 @@ struct SettingsView: View {
         )
     }
 
-    /// Routes a tile click through `speechEnginePreference`, which the VM
-    /// validates (e.g. blocks switching to Whisper before the model is
-    /// downloaded and surfaces `speechEngineError`). Wrapped in `withAnimation`
-    /// so the language card slide and tile selection state animate together.
+    /// Routes a tile click through `speechEnginePreference`. The VM's setter
+    /// validates (e.g. would revert if Whisper isn't downloaded), but we
+    /// pre-empt that case in `handleWhisperTileTap` so the user never sees
+    /// the briefly-selected-then-reverted state.
     private func selectEngine(_ engine: SpeechEnginePreference) {
         guard viewModel.speechEnginePreference != engine,
               !viewModel.speechEngineSwitching else { return }
         withAnimation(DesignSystem.Animation.contentSwap) {
             viewModel.speechEnginePreference = engine
         }
+    }
+
+    /// Pre-empts the Whisper-not-downloaded case: instead of letting the VM
+    /// briefly accept the switch and revert, we set the inline error and
+    /// leave the user on Parakeet. The Download CTA in the tile footer is
+    /// the only path forward when the model is missing.
+    private func handleWhisperTileTap() {
+        if viewModel.whisperModelStatus == .notDownloaded {
+            viewModel.speechEngineError = "Download the Whisper model before switching engines."
+            return
+        }
+        selectEngine(.whisper)
     }
 
     private var parakeetPrimaryAction: ModelRowAction? {
@@ -1286,9 +1271,6 @@ struct SettingsView: View {
         }
     }
 
-    /// One actionable button on a Local Models row. `primaryAction` renders
-    /// inline with bordered or prominent style; `overflowAction` hides under
-    /// a `…` menu so calm states never carry a button on the row.
     fileprivate struct ModelRowAction {
         let label: String
         let isProminent: Bool
@@ -1594,10 +1576,6 @@ struct SettingsView: View {
         )
     }
 
-    /// One Local Models row. The right column is a fixed-width status +
-    /// action group so Parakeet and Whisper line up vertically regardless of
-    /// label length. Only `primaryAction` renders inline; `overflowAction`
-    /// hides under a `…` menu so healthy rows stay calm.
     private func modelStatusRow(
         title: String,
         detail: String,
@@ -1623,7 +1601,7 @@ struct SettingsView: View {
                 Group {
                     if let action = primaryAction {
                         modelRowPrimaryButton(action: action, isWorking: isWorking)
-                    } else if let overflow = overflowAction, !isWorking {
+                    } else if let overflow = overflowAction, !isWorking, status != .checking {
                         Menu {
                             Button(overflow.label, action: overflow.run)
                         } label: {
@@ -1635,7 +1613,7 @@ struct SettingsView: View {
                         .menuIndicator(.hidden)
                         .fixedSize()
                         .help("More actions")
-                    } else if isWorking {
+                    } else if isWorking || status == .checking {
                         ProgressView()
                             .controlSize(.small)
                             .frame(width: 22, height: 22)
@@ -1655,10 +1633,12 @@ struct SettingsView: View {
             Button(label, action: action.run)
                 .buttonStyle(.borderedProminent)
                 .tint(DesignSystem.Colors.accent)
+                .controlSize(.small)
                 .disabled(isWorking)
         } else {
             Button(label, action: action.run)
                 .buttonStyle(.bordered)
+                .controlSize(.small)
                 .disabled(isWorking)
         }
     }

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -1060,34 +1060,63 @@ struct SettingsView: View {
 
     // MARK: - Engine
 
-    /// Engine card: which speech recognition engine to use. Status chip
-    /// surfaces only signal — silent in the steady state, `.info` while
-    /// switching, `.required` if the last switch failed (the existing red
-    /// inline error is preserved underneath for the full message).
+    /// Engine card: which speech recognition engine to use.
+    ///
+    /// The choice between Parakeet (fast, English + 24 European languages)
+    /// and Whisper (slower, multilingual including Korean/Japanese/Chinese)
+    /// is the most consequential decision on the entire Settings page. The
+    /// previous segmented picker under-sold it. We give it two large
+    /// selectable tiles with strengths and an inline Download CTA when the
+    /// model is missing — the long descriptions live under hover tooltips
+    /// so the surface stays calm at rest.
+    ///
+    /// Status chip surfaces only signal: silent in the steady state, `.info`
+    /// while switching, `.required` if the last switch failed (the inline
+    /// error preserves the full message).
     private var engineSelectorCard: some View {
         SettingsCard(
             title: "Speech Recognition",
-            subtitle: "Parakeet is fastest. Whisper adds Korean and broader multilingual coverage.",
+            subtitle: "Choose the engine that powers dictation, file transcription, and meetings.",
             icon: "cpu",
             status: engineSelectorCardStatus
         ) {
             VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
-                HStack(alignment: .center) {
-                    rowText(
-                        title: "Engine",
-                        detail: viewModel.speechEngineSwitching
-                            ? "Switching speech engine..."
-                            : "Used by dictation, file transcription, and meetings."
+                HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+                    EngineOptionTile(
+                        icon: "bolt.fill",
+                        name: "Parakeet",
+                        tagline: "Fastest · 25 European languages",
+                        strengths: [
+                            "155× realtime on Apple Silicon",
+                            "~2.5% word error rate",
+                            "Optimized for the Neural Engine"
+                        ],
+                        helpText: "Best for English and 24 other European languages including Spanish, French, German, and Italian. Runs on the Neural Engine for the lowest latency on Apple Silicon.",
+                        modelStatus: viewModel.parakeetStatus,
+                        isSelected: viewModel.speechEnginePreference == .parakeet,
+                        isBusy: viewModel.speechEngineSwitching,
+                        downloadActionLabel: nil,
+                        onSelect: { selectEngine(.parakeet) },
+                        onDownload: nil
                     )
-                    Spacer(minLength: DesignSystem.Spacing.md)
-                    Picker("Speech Engine", selection: $viewModel.speechEnginePreference) {
-                        Text("Parakeet").tag(SpeechEnginePreference.parakeet)
-                        Text("Whisper").tag(SpeechEnginePreference.whisper)
-                    }
-                    .labelsHidden()
-                    .pickerStyle(.segmented)
-                    .frame(width: 220)
-                    .disabled(viewModel.speechEngineSwitching)
+
+                    EngineOptionTile(
+                        icon: "globe",
+                        name: "Whisper",
+                        tagline: "Multilingual · 99 languages",
+                        strengths: [
+                            "Covers Korean, Japanese, Chinese, Thai",
+                            "Auto language detection",
+                            "Whisper Large v3 Turbo (632 MB)"
+                        ],
+                        helpText: "Best for languages outside Parakeet's coverage. Adds Korean, Japanese, Chinese, Thai, Hindi, Arabic, Vietnamese, and 80+ more — any language Whisper supports.",
+                        modelStatus: viewModel.whisperModelStatus,
+                        isSelected: viewModel.speechEnginePreference == .whisper,
+                        isBusy: viewModel.speechEngineSwitching,
+                        downloadActionLabel: viewModel.whisperDownloading ? "Downloading…" : "Download",
+                        onSelect: { selectEngine(.whisper) },
+                        onDownload: viewModel.whisperDownloading ? nil : { viewModel.downloadWhisperModel() }
+                    )
                 }
 
                 if let error = viewModel.speechEngineError {
@@ -1099,28 +1128,36 @@ struct SettingsView: View {
         }
     }
 
-    /// Whisper-only language card. Stays visible when Parakeet is active so
-    /// the user knows the control exists; the picker mutes itself and the
-    /// header chip reads "Inactive" so the visual state matches reality.
-    /// The picker button itself surfaces the current selection — no need for
-    /// a redundant left-side label.
+    /// Hides itself entirely when Parakeet is active. The "Inactive"
+    /// disabled-picker dead state we used to render added zero signal — when
+    /// Parakeet is selected, the language picker has nothing to do, so
+    /// removing it removes a row of dead pixels rather than dressing them up.
+    /// Discoverability is preserved via the Whisper tile's tooltip and the
+    /// fact that selecting Whisper reveals this card with a smooth transition.
+    @ViewBuilder
     private var engineLanguageCard: some View {
-        let isWhisperActive = viewModel.speechEnginePreference == .whisper
-        return SettingsCard(
-            title: "Whisper Language",
-            subtitle: "Only used when Whisper is the active engine. Auto-detect works for most files.",
-            icon: "globe",
-            status: isWhisperActive ? nil : SettingsCardStatus(.info, label: "Inactive")
-        ) {
-            HStack(alignment: .center) {
-                Text("Default language")
-                    .font(DesignSystem.Typography.body)
-                Spacer(minLength: DesignSystem.Spacing.md)
-                LanguagePickerButton(
-                    selection: $viewModel.whisperDefaultLanguage,
-                    isDisabled: !isWhisperActive
-                )
+        if viewModel.speechEnginePreference == .whisper {
+            SettingsCard(
+                title: "Whisper Language",
+                subtitle: "Auto-detect works for most files. Pin a language for faster startup or mixed-language audio.",
+                icon: "character.bubble"
+            ) {
+                HStack(alignment: .center) {
+                    Text("Default language")
+                        .font(DesignSystem.Typography.body)
+                    Spacer(minLength: DesignSystem.Spacing.md)
+                    LanguagePickerButton(
+                        selection: $viewModel.whisperDefaultLanguage,
+                        isDisabled: false
+                    )
+                }
             }
+            .transition(
+                .asymmetric(
+                    insertion: .opacity.combined(with: .move(edge: .top)),
+                    removal: .opacity
+                )
+            )
         }
     }
 
@@ -1128,6 +1165,14 @@ struct SettingsView: View {
     /// both engines: any `.failed` → `.required`; missing model on the
     /// active engine → `.recommended`; all `.ready` → `.ok`; transient
     /// states → no chip (the per-row status pills already telegraph it).
+    ///
+    /// Action layout: a fixed-width right column carries the status pill +
+    /// optional action button. We only render an inline button for
+    /// genuinely actionable states (Download missing, Retry failed). For
+    /// healthy models, Repair / Re-download tuck into a `…` menu so the
+    /// row is calm by default — the previous design rendered a permanently
+    /// disabled "Ready" button when Whisper was loaded into memory while
+    /// Parakeet was the active engine, which was pure noise.
     private var enginesModelsCard: some View {
         SettingsCard(
             title: "Local Models",
@@ -1140,11 +1185,10 @@ struct SettingsView: View {
                     title: "Parakeet",
                     detail: viewModel.parakeetStatusDetail,
                     status: viewModel.parakeetStatus,
-                    isRepairing: viewModel.parakeetRepairing,
-                    actionLabel: "Repair"
-                ) {
-                    viewModel.repairParakeetModel()
-                }
+                    isWorking: viewModel.parakeetRepairing,
+                    primaryAction: parakeetPrimaryAction,
+                    overflowAction: parakeetOverflowAction
+                )
 
                 Divider()
 
@@ -1152,12 +1196,10 @@ struct SettingsView: View {
                     title: "Whisper",
                     detail: viewModel.whisperModelStatusDetail,
                     status: viewModel.whisperModelStatus,
-                    isRepairing: viewModel.whisperDownloading,
-                    actionLabel: whisperModelActionLabel,
-                    actionDisabled: !isWhisperModelActionEnabled
-                ) {
-                    viewModel.downloadWhisperModel()
-                }
+                    isWorking: viewModel.whisperDownloading,
+                    primaryAction: whisperPrimaryAction,
+                    overflowAction: whisperOverflowAction
+                )
             }
         }
     }
@@ -1180,36 +1222,77 @@ struct SettingsView: View {
         )
     }
 
-    private var whisperModelActionLabel: String {
-        switch viewModel.whisperModelStatus {
-        case .notDownloaded:
-            return "Download"
-        case .notLoaded:
-            // The badge already says "Downloaded ✓"; pairing it with "Repair"
-            // implied the model was broken. The button actually re-runs the
-            // download (fast no-op via HuggingFace cache when files are
-            // intact), so name it for what it does.
-            return "Re-download"
-        case .failed:
-            return "Retry"
-        case .ready:
-            return "Ready"
-        case .checking:
-            return "Checking"
-        case .repairing:
-            return "Working..."
-        case .unknown:
-            return "Check"
+    /// Routes a tile click through `speechEnginePreference`, which the VM
+    /// validates (e.g. blocks switching to Whisper before the model is
+    /// downloaded and surfaces `speechEngineError`). Wrapped in `withAnimation`
+    /// so the language card slide and tile selection state animate together.
+    private func selectEngine(_ engine: SpeechEnginePreference) {
+        guard viewModel.speechEnginePreference != engine,
+              !viewModel.speechEngineSwitching else { return }
+        withAnimation(DesignSystem.Animation.contentSwap) {
+            viewModel.speechEnginePreference = engine
         }
     }
 
-    private var isWhisperModelActionEnabled: Bool {
-        switch viewModel.whisperModelStatus {
-        case .notDownloaded, .notLoaded, .failed:
-            return !viewModel.whisperDownloading
-        case .unknown, .checking, .ready, .repairing:
-            return false
+    private var parakeetPrimaryAction: ModelRowAction? {
+        switch viewModel.parakeetStatus {
+        case .failed:
+            return ModelRowAction(label: "Retry", isProminent: true) {
+                viewModel.repairParakeetModel()
+            }
+        case .notDownloaded:
+            return ModelRowAction(label: "Download", isProminent: true) {
+                viewModel.repairParakeetModel()
+            }
+        default:
+            return nil
         }
+    }
+
+    private var parakeetOverflowAction: ModelRowAction? {
+        switch viewModel.parakeetStatus {
+        case .ready, .notLoaded:
+            return ModelRowAction(label: "Repair…", isProminent: false) {
+                viewModel.repairParakeetModel()
+            }
+        default:
+            return nil
+        }
+    }
+
+    private var whisperPrimaryAction: ModelRowAction? {
+        switch viewModel.whisperModelStatus {
+        case .notDownloaded:
+            return ModelRowAction(label: "Download", isProminent: true) {
+                viewModel.downloadWhisperModel()
+            }
+        case .failed:
+            return ModelRowAction(label: "Retry", isProminent: true) {
+                viewModel.downloadWhisperModel()
+            }
+        default:
+            return nil
+        }
+    }
+
+    private var whisperOverflowAction: ModelRowAction? {
+        switch viewModel.whisperModelStatus {
+        case .ready, .notLoaded:
+            return ModelRowAction(label: "Re-download…", isProminent: false) {
+                viewModel.downloadWhisperModel()
+            }
+        default:
+            return nil
+        }
+    }
+
+    /// One actionable button on a Local Models row. `primaryAction` renders
+    /// inline with bordered or prominent style; `overflowAction` hides under
+    /// a `…` menu so calm states never carry a button on the row.
+    fileprivate struct ModelRowAction {
+        let label: String
+        let isProminent: Bool
+        let run: () -> Void
     }
 
     /// Roll-up of the three permissions. `.required` if any feature gate is
@@ -1511,16 +1594,19 @@ struct SettingsView: View {
         )
     }
 
+    /// One Local Models row. The right column is a fixed-width status +
+    /// action group so Parakeet and Whisper line up vertically regardless of
+    /// label length. Only `primaryAction` renders inline; `overflowAction`
+    /// hides under a `…` menu so healthy rows stay calm.
     private func modelStatusRow(
         title: String,
         detail: String,
         status: SettingsViewModel.LocalModelStatus,
-        isRepairing: Bool,
-        actionLabel: String = "Repair",
-        actionDisabled: Bool = false,
-        onRepair: @escaping () -> Void
+        isWorking: Bool,
+        primaryAction: ModelRowAction?,
+        overflowAction: ModelRowAction?
     ) -> some View {
-        HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+        HStack(alignment: .center, spacing: DesignSystem.Spacing.md) {
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
                     .font(DesignSystem.Typography.body)
@@ -1531,13 +1617,49 @@ struct SettingsView: View {
 
             Spacer(minLength: DesignSystem.Spacing.sm)
 
-            modelStatusPill(status)
+            HStack(spacing: DesignSystem.Spacing.sm) {
+                modelStatusPill(status)
 
-            Button(isRepairing ? "Working..." : actionLabel) {
-                onRepair()
+                Group {
+                    if let action = primaryAction {
+                        modelRowPrimaryButton(action: action, isWorking: isWorking)
+                    } else if let overflow = overflowAction, !isWorking {
+                        Menu {
+                            Button(overflow.label, action: overflow.run)
+                        } label: {
+                            Image(systemName: "ellipsis")
+                                .font(.system(size: 13, weight: .semibold))
+                                .frame(width: 22, height: 22)
+                        }
+                        .menuStyle(.borderlessButton)
+                        .menuIndicator(.hidden)
+                        .fixedSize()
+                        .help("More actions")
+                    } else if isWorking {
+                        ProgressView()
+                            .controlSize(.small)
+                            .frame(width: 22, height: 22)
+                    } else {
+                        Color.clear.frame(width: 22, height: 22)
+                    }
+                }
+                .frame(minWidth: 22, alignment: .trailing)
             }
-            .buttonStyle(.bordered)
-            .disabled(isRepairing || actionDisabled)
+        }
+    }
+
+    @ViewBuilder
+    private func modelRowPrimaryButton(action: ModelRowAction, isWorking: Bool) -> some View {
+        let label = isWorking ? "Working…" : action.label
+        if action.isProminent {
+            Button(label, action: action.run)
+                .buttonStyle(.borderedProminent)
+                .tint(DesignSystem.Colors.accent)
+                .disabled(isWorking)
+        } else {
+            Button(label, action: action.run)
+                .buttonStyle(.bordered)
+                .disabled(isWorking)
         }
     }
 

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -1296,7 +1296,12 @@ struct SettingsView: View {
     private var whisperOverflowAction: ModelRowAction? {
         switch viewModel.whisperModelStatus {
         case .ready, .notLoaded:
-            return ModelRowAction(label: "Re-download…", isProminent: false) {
+            // Symmetric with Parakeet's "Repair…" — both engines surface the
+            // same affordance to the user. Underneath, Parakeet re-runs warmup
+            // (which downloads if files are missing); Whisper re-runs the
+            // download (no-op via HuggingFace cache when files are intact).
+            // The user shouldn't have to reason about that asymmetry.
+            return ModelRowAction(label: "Repair…", isProminent: false) {
                 viewModel.downloadWhisperModel()
             }
         default:

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -1082,9 +1082,7 @@ struct SettingsView: View {
                         modelStatus: viewModel.parakeetStatus,
                         isSelected: viewModel.speechEnginePreference == .parakeet,
                         isBusy: viewModel.speechEngineSwitching,
-                        downloadActionLabel: nil,
-                        onSelect: { selectEngine(.parakeet) },
-                        onDownload: nil
+                        onSelect: { selectEngine(.parakeet) }
                     )
 
                     EngineOptionTile(
@@ -1100,9 +1098,16 @@ struct SettingsView: View {
                         modelStatus: viewModel.whisperModelStatus,
                         isSelected: viewModel.speechEnginePreference == .whisper,
                         isBusy: viewModel.speechEngineSwitching,
-                        downloadActionLabel: "Download",
-                        onSelect: { handleWhisperTileTap() },
-                        onDownload: viewModel.whisperDownloading ? nil : { viewModel.downloadWhisperModel() }
+                        onSelect: { handleWhisperTileTap() }
+                    )
+                }
+
+                if viewModel.whisperModelStatus == .notDownloaded {
+                    EngineDownloadBanner(
+                        title: "Whisper Large v3 Turbo",
+                        subtitle: "632 MB · downloads once, runs locally afterwards",
+                        isDownloading: viewModel.whisperDownloading,
+                        action: { viewModel.downloadWhisperModel() }
                     )
                 }
 
@@ -1133,12 +1138,7 @@ struct SettingsView: View {
                     )
                 }
             }
-            .transition(
-                .asymmetric(
-                    insertion: .opacity.combined(with: .move(edge: .top)),
-                    removal: .opacity
-                )
-            )
+            .transition(.opacity)
         }
     }
 
@@ -1207,16 +1207,26 @@ struct SettingsView: View {
         }
     }
 
-    /// Pre-empts the Whisper-not-downloaded case: instead of letting the VM
-    /// briefly accept the switch and revert, we set the inline error and
-    /// leave the user on Parakeet. The Download CTA in the tile footer is
-    /// the only path forward when the model is missing.
+    /// Pre-empts every "Whisper isn't ready" state so the user never sees
+    /// a briefly-selected-then-reverted tile. Mirrors the VM's
+    /// `isWhisperModelAvailable` (`ready` or `notLoaded`); for everything
+    /// else we set a state-specific inline message and leave the user on
+    /// Parakeet. `.checking` and `.unknown` are transient inspections that
+    /// usually settle within a frame, so we let those fall through to the
+    /// VM's normal accept/revert path rather than rejecting prematurely.
     private func handleWhisperTileTap() {
-        if viewModel.whisperModelStatus == .notDownloaded {
+        switch viewModel.whisperModelStatus {
+        case .ready, .notLoaded:
+            selectEngine(.whisper)
+        case .notDownloaded:
             viewModel.speechEngineError = "Download the Whisper model before switching engines."
-            return
+        case .repairing:
+            viewModel.speechEngineError = "Whisper model is downloading — switch engines once it finishes."
+        case .failed:
+            viewModel.speechEngineError = "Whisper model failed to load. Open Local Models below to retry."
+        case .checking, .unknown:
+            selectEngine(.whisper)
         }
-        selectEngine(.whisper)
     }
 
     private var parakeetPrimaryAction: ModelRowAction? {

--- a/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
+++ b/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
@@ -191,9 +191,14 @@ public enum SettingsSearchIndex {
             id: "engine.language",
             tab: .engine,
             title: "Whisper Language",
-            subtitle: "Default language for Whisper.",
+            subtitle: "Available when Whisper is the active engine.",
             keywords: ["language", "locale", "korean", "japanese", "multilingual", "auto detect", "whisper"],
-            cardAnchor: "engine.language"
+            // Anchored to the engine selector rather than the language card
+            // because the language card only renders when Whisper is active.
+            // Searching "language" while on Parakeet would otherwise jump
+            // to a hidden anchor; landing on the selector lets the user
+            // switch to Whisper, which then reveals the language picker.
+            cardAnchor: "engine.selector"
         ),
         SettingsSearchEntry(
             id: "engine.models",

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -955,6 +955,12 @@ public final class SettingsViewModel {
 
     public func downloadWhisperModel() {
         guard !whisperDownloading else { return }
+        // The user has taken the action that resolves any pending
+        // "Whisper isn't ready" error, so clear it. Otherwise the red
+        // banner persists through a successful download (the engine
+        // preference setter — the only other place that clears it —
+        // never fires for the same-state assignment).
+        speechEngineError = nil
         whisperDownloading = true
         whisperModelStatus = .repairing
         let modelVariant = SpeechEnginePreference.whisperModelVariant(defaults: defaults)
@@ -1027,6 +1033,7 @@ public final class SettingsViewModel {
     public func repairParakeetModel() {
         guard let sttClient else { return }
         guard !parakeetRepairing else { return }
+        speechEngineError = nil
         parakeetRepairing = true
         parakeetStatus = .repairing
         parakeetStatusDetail = "Preparing speech model..."


### PR DESCRIPTION
## Summary

Polish pass on **Settings → Engine**. The previous design used a 220-pixel segmented picker for the most consequential decision on the entire Settings page — which engine handles your speech-to-text. This PR replaces it with two large selectable tiles, hides UI that has nothing to do, and tidies the Local Models row.

## What it looks like

```
╭─ Speech Recognition ────────────────────────────────────────╮
│  Choose the engine that powers dictation, file              │
│  transcription, and meetings.                               │
│                                                             │
│  ╭─ ⚡ Parakeet ──────── ✓ ─╮  ╭─ 🌐 Whisper ────────────╮  │
│  │                          │  │                          │  │
│  │ Fastest local engine     │  │ Multilingual coverage    │  │
│  │                          │  │                          │  │
│  │ · English + 24 EU langs  │  │ · Korean, Japanese,      │  │
│  │ · 155× realtime          │  │   Chinese, Thai +95 more │  │
│  │ · Runs on Neural Engine  │  │ · Auto language detect   │  │
│  │                          │  │ · Whisper Large v3 632MB │  │
│  │                          │  │                          │  │
│  │ ● Ready · in memory      │  │ ⚠ Not downloaded         │  │
│  ╰──────────────────────────╯  ╰──────────────────────────╯  │
│                                                             │
│  ╭─ ⤓ Whisper Large v3 Turbo ──────────── [ Download ] ──╮  │
│  │   632 MB · downloads once, runs locally afterwards    │  │
│  ╰───────────────────────────────────────────────────────╯  │
│  (only renders when Whisper isn't downloaded yet)            │
╰─────────────────────────────────────────────────────────────╯

╭─ Whisper Language ──────────────────────────────────────────╮
│  Auto-detect works for most files. Pin a language for       │
│  faster startup or mixed-language audio.                    │
│                                                             │
│  Default language                       [ Auto-detect ▾ ]   │
╰─────────────────────────────────────────────────────────────╯
   (only renders when Whisper is the active engine)

╭─ Local Models ───────────────────────────────────── Ready ──╮
│  Models live on this Mac. No audio is sent to the cloud.    │
│                                                             │
│  Parakeet                            ● Ready          [ ⋯ ] │
│    Loaded in memory and ready.                              │
│  ────────                                                   │
│  Whisper                          ● Downloaded        [ ⋯ ] │
│    Whisper Large v3 Turbo · Loads on first use.             │
╰─────────────────────────────────────────────────────────────╯
```

## Three coordinated changes

### 1. Engine tiles replace the segmented picker

Each tile carries an icon, a one-line value prop, three strength bullets, and a status footer. Hover shows a longer tooltip that names the languages each engine handles best (Parakeet → English + 24 European; Whisper → Korean, Japanese, Chinese, Thai, Hindi, Arabic, Vietnamese, +80 more). The selected tile gets an accent border, tinted background, and checkmark.

### 2. Whisper Language card hides when Parakeet is active

The previous "Inactive" disabled-picker dead state added zero signal — when Parakeet is the engine, the Whisper language picker has nothing to do. The card now disappears entirely, with an opacity fade. Selecting Whisper reveals it again.

### 3. Local Models row is calm by default

Action buttons now only appear for genuinely actionable states (Download a missing model, Retry a failed one). For healthy models, Repair / Re-download tucks into a `…` overflow menu so calm rows stay calm. This also kills the disabled "Ready" button that used to appear when Whisper was loaded into memory while Parakeet was the active engine — pure visual noise.

## Implementation notes

- Engine tile is a plain-styled `Button(action:)` — full keyboard focus, focus ring, and Button accessibility traits come for free.
- Download CTA is a sibling `EngineDownloadBanner` view rendered **below** the tile row, never inside the tile. Keeps hit-testing unambiguous (no nested `Button` and no overlapping `onTapGesture` regions — both would have been fragile on macOS SwiftUI).
- Engine selection is wrapped in `withAnimation(DesignSystem.Animation.contentSwap)` so the tile selection visuals and the Whisper Language card fade animate together.
- Whisper-not-ready states are pre-empted at the call site (`handleWhisperTileTap`) so the user never sees the briefly-selected-then-reverted flicker. Each unavailable state surfaces a state-specific inline message (`.notDownloaded` → "Download the Whisper model…"; `.repairing` → "Whisper model is downloading…"; `.failed` → "Whisper model failed to load…").

## Test plan

- [ ] **Build**: `swift build` (clean — verified locally, ~6s incremental)
- [ ] **Tests**: `swift test` (all 1945 pass — verified locally, ~95s)
- [ ] **Visual — Parakeet selected (default)**:
  - [ ] Two tiles side-by-side; Parakeet has accent border + tinted background + checkmark
  - [ ] Whisper Language card is **not** visible
  - [ ] Local Models card shows status pills + `…` overflow menu (Repair / Re-download)
- [ ] **Visual — switch to Whisper (model already downloaded)**:
  - [ ] Whisper tile gains selection styling; Parakeet loses it; checkmark animates
  - [ ] Whisper Language card fades in with the language picker enabled
- [ ] **Visual — Whisper not yet downloaded**:
  - [ ] Whisper tile footer shows amber "Not downloaded"
  - [ ] `EngineDownloadBanner` appears below the tile row with a prominent Download button
  - [ ] Clicking Download triggers the download (label switches to "Downloading…" with spinner)
  - [ ] Clicking the Whisper tile while not-downloaded shows "Download the Whisper model before switching engines." instead of selecting-then-reverting
- [ ] **Hover tooltips**: cursor over Parakeet → "Best for English and 24 other European languages…"; cursor over Whisper → "Best for languages outside Parakeet's coverage. Adds Korean, Japanese, Chinese, Thai, Hindi, Arabic, Vietnamese, and 80+ more…"
- [ ] **Keyboard**: Tab moves focus between tiles; Return / Space activates the focused tile
- [ ] **VoiceOver**: each tile reads as a Button with selection state; Download CTA is independently accessible; `…` overflow menu announces "More actions"
- [ ] **Light & Dark mode**: tile contrast and accent intensity feel right in both

## Reviewer-comment status

- ✅ **Gemini Code Assist** — `ForEach(strengths, id: \.self)` swapped to `enumerated()` + `id: \.offset` for duplicate-safety
- ✅ **Gemini Code Assist** — `.accessibilityLabel("More actions")` added to the Local Models overflow menu
- ✅ **CodeRabbit** — `.repairing` added to the Local Models row's spinner condition for status/flag-drift safety
- ✅ **Two rounds of multi-LLM fresh-eye review** (Codex + Gemini) — all P0/P1 findings addressed across rounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)