### PR TITLE
Fix auto-save bad state: always have a default folder configured

### DIFF
--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -684,7 +684,7 @@ struct SettingsView: View {
             formatDetail: "File format for saved meetings.",
             panelMessage: "Select a folder for auto-saved meeting recordings",
             onChooseFolder: { viewModel.chooseMeetingAutoSaveFolder(url: $0) },
-            onClearFolder: { viewModel.clearMeetingAutoSaveFolder() }
+            onResetFolder: { viewModel.resetMeetingAutoSaveFolder() }
         )
     }
 
@@ -824,7 +824,7 @@ struct SettingsView: View {
             formatDetail: "File format for saved transcripts.",
             panelMessage: "Select a folder for auto-saved transcripts",
             onChooseFolder: { viewModel.chooseAutoSaveFolder(url: $0) },
-            onClearFolder: { viewModel.clearAutoSaveFolder() }
+            onResetFolder: { viewModel.resetAutoSaveFolder() }
         )
     }
 
@@ -834,7 +834,7 @@ struct SettingsView: View {
         formatDetail: String,
         panelMessage: String,
         onChooseFolder: @escaping (URL) -> Void,
-        onClearFolder: @escaping () -> Void
+        onResetFolder: @escaping () -> Void
     ) -> some View {
         VStack(spacing: DesignSystem.Spacing.sm) {
             HStack {
@@ -866,19 +866,11 @@ struct SettingsView: View {
                     }
                 }
                 Spacer(minLength: DesignSystem.Spacing.md)
-                if folderPath != nil {
-                    Button("Clear") { onClearFolder() }
-                        .buttonStyle(.bordered)
-                }
+                Button("Reset") { onResetFolder() }
+                    .buttonStyle(.bordered)
+                    .help("Reset to the default folder (~/Documents/MacParakeet)")
                 Button("Choose…") {
-                    let panel = NSOpenPanel()
-                    panel.canChooseDirectories = true
-                    panel.canChooseFiles = false
-                    panel.canCreateDirectories = true
-                    panel.allowsMultipleSelection = false
-                    panel.prompt = "Choose"
-                    panel.message = panelMessage
-                    if panel.runModal() == .OK, let url = panel.url {
+                    if let url = Self.presentAutoSaveFolderPicker(message: panelMessage) {
                         onChooseFolder(url)
                     }
                 }
@@ -890,6 +882,21 @@ struct SettingsView: View {
             RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
                 .fill(DesignSystem.Colors.surfaceElevated)
         )
+    }
+
+    /// Open the system folder picker. Returns the chosen URL or `nil` if the
+    /// user cancelled. Used both by the "Choose…" button in the auto-save
+    /// options row and by the toggle-binding interceptor that gathers a
+    /// folder before letting the toggle flip ON for the first time.
+    static func presentAutoSaveFolderPicker(message: String) -> URL? {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.canCreateDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Choose"
+        panel.message = message
+        return panel.runModal() == .OK ? panel.url : nil
     }
 
     // MARK: - AI Provider

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -885,9 +885,7 @@ struct SettingsView: View {
     }
 
     /// Open the system folder picker. Returns the chosen URL or `nil` if the
-    /// user cancelled. Used both by the "Choose…" button in the auto-save
-    /// options row and by the toggle-binding interceptor that gathers a
-    /// folder before letting the toggle flip ON for the first time.
+    /// user cancelled. Used by the "Choose…" button in the auto-save options row.
     static func presentAutoSaveFolderPicker(message: String) -> URL? {
         let panel = NSOpenPanel()
         panel.canChooseDirectories = true

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -683,6 +683,7 @@ struct SettingsView: View {
             folderPath: viewModel.meetingAutoSaveFolderPath,
             formatDetail: "File format for saved meetings.",
             panelMessage: "Select a folder for auto-saved meeting recordings",
+            resetHelp: "Reset to the default folder (~/Documents/MacParakeet/Meetings)",
             onChooseFolder: { viewModel.chooseMeetingAutoSaveFolder(url: $0) },
             onResetFolder: { viewModel.resetMeetingAutoSaveFolder() }
         )
@@ -823,6 +824,7 @@ struct SettingsView: View {
             folderPath: viewModel.autoSaveFolderPath,
             formatDetail: "File format for saved transcripts.",
             panelMessage: "Select a folder for auto-saved transcripts",
+            resetHelp: "Reset to the default folder (~/Documents/MacParakeet/Transcriptions)",
             onChooseFolder: { viewModel.chooseAutoSaveFolder(url: $0) },
             onResetFolder: { viewModel.resetAutoSaveFolder() }
         )
@@ -833,6 +835,7 @@ struct SettingsView: View {
         folderPath: String?,
         formatDetail: String,
         panelMessage: String,
+        resetHelp: String,
         onChooseFolder: @escaping (URL) -> Void,
         onResetFolder: @escaping () -> Void
     ) -> some View {
@@ -868,7 +871,7 @@ struct SettingsView: View {
                 Spacer(minLength: DesignSystem.Spacing.md)
                 Button("Reset") { onResetFolder() }
                     .buttonStyle(.bordered)
-                    .help("Reset to the default folder (~/Documents/MacParakeet)")
+                    .help(resetHelp)
                 Button("Choose…") {
                     if let url = Self.presentAutoSaveFolderPicker(message: panelMessage) {
                         onChooseFolder(url)

--- a/Sources/MacParakeetCore/Services/AutoSaveService.swift
+++ b/Sources/MacParakeetCore/Services/AutoSaveService.swift
@@ -128,6 +128,12 @@ public final class AutoSaveService {
     /// Resolve the stored bookmark data back to a URL for the given scope.
     /// Re-creates the bookmark if it has gone stale.
     public func resolveFolder(scope: AutoSaveScope = .transcription) -> URL? {
+        Self.resolveFolder(scope: scope, defaults: defaults)
+    }
+
+    /// Resolve the stored bookmark data back to a URL for the given scope.
+    /// Re-creates the bookmark if it has gone stale.
+    public static func resolveFolder(scope: AutoSaveScope = .transcription, defaults: UserDefaults = .standard) -> URL? {
         guard let bookmarkData = defaults.data(forKey: scope.folderBookmarkKey) else { return nil }
         var isStale = false
         guard let url = try? URL(
@@ -215,7 +221,7 @@ public final class AutoSaveService {
     ///   its bookmark.
     ///
     /// Returns the resolved folder URL on success, or `nil` if no bookmark
-    /// was stored and the default folder couldn't be created (extremely
+    /// was stored and the default folder couldn't be created or bookmarked (extremely
     /// rare — disk full, `~/Documents` read-only, etc.).
     @discardableResult
     public static func ensureFolderConfigured(scope: AutoSaveScope, defaults: UserDefaults = .standard) -> URL? {
@@ -223,12 +229,14 @@ public final class AutoSaveService {
             // Bookmark exists — preserve it even if stale / currently
             // unresolvable. The user's previously-chosen destination is
             // sacred; don't stomp it with a default.
-            return AutoSaveService(defaults: defaults).resolveFolder(scope: scope)
+            return resolveFolder(scope: scope, defaults: defaults)
         }
         let defaultURL = defaultFolder(for: scope)
         do {
             try FileManager.default.createDirectory(at: defaultURL, withIntermediateDirectories: true)
-            _ = storeFolder(defaultURL, scope: scope, defaults: defaults)
+            guard storeFolder(defaultURL, scope: scope, defaults: defaults) != nil else {
+                return nil
+            }
             return defaultURL
         } catch {
             return nil
@@ -244,7 +252,9 @@ public final class AutoSaveService {
         let defaultURL = defaultFolder(for: scope)
         do {
             try FileManager.default.createDirectory(at: defaultURL, withIntermediateDirectories: true)
-            _ = storeFolder(defaultURL, scope: scope, defaults: defaults)
+            guard storeFolder(defaultURL, scope: scope, defaults: defaults) != nil else {
+                return nil
+            }
             return defaultURL
         } catch {
             return nil

--- a/Sources/MacParakeetCore/Services/AutoSaveService.swift
+++ b/Sources/MacParakeetCore/Services/AutoSaveService.swift
@@ -190,6 +190,67 @@ public final class AutoSaveService {
         defaults.removeObject(forKey: scope.folderBookmarkKey)
     }
 
+    /// The default destination for auto-saved files when the user hasn't
+    /// chosen one. Lives under `~/Documents/MacParakeet/{Transcriptions|Meetings}`
+    /// so the user can find their output via Finder / Spotlight without
+    /// digging into `~/Library`.
+    public static func defaultFolder(for scope: AutoSaveScope) -> URL {
+        let docs = FileManager.default
+            .urls(for: .documentDirectory, in: .userDomainMask)
+            .first
+            ?? URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Documents")
+        let parent = docs.appendingPathComponent("MacParakeet", isDirectory: true)
+        switch scope {
+        case .transcription: return parent.appendingPathComponent("Transcriptions", isDirectory: true)
+        case .meeting: return parent.appendingPathComponent("Meetings", isDirectory: true)
+        }
+    }
+
+    /// Ensure the auto-save folder is configured for `scope`. Idempotent:
+    ///
+    /// - If a bookmark is already stored (even one that fails to resolve right
+    ///   now, e.g. a disconnected external drive) it is left untouched —
+    ///   never overwrite a user-chosen destination.
+    /// - If no bookmark exists, create the default folder on disk and store
+    ///   its bookmark.
+    ///
+    /// Returns the resolved folder URL on success, or `nil` if no bookmark
+    /// was stored and the default folder couldn't be created (extremely
+    /// rare — disk full, `~/Documents` read-only, etc.).
+    @discardableResult
+    public static func ensureFolderConfigured(scope: AutoSaveScope, defaults: UserDefaults = .standard) -> URL? {
+        if defaults.data(forKey: scope.folderBookmarkKey) != nil {
+            // Bookmark exists — preserve it even if stale / currently
+            // unresolvable. The user's previously-chosen destination is
+            // sacred; don't stomp it with a default.
+            return AutoSaveService(defaults: defaults).resolveFolder(scope: scope)
+        }
+        let defaultURL = defaultFolder(for: scope)
+        do {
+            try FileManager.default.createDirectory(at: defaultURL, withIntermediateDirectories: true)
+            _ = storeFolder(defaultURL, scope: scope, defaults: defaults)
+            return defaultURL
+        } catch {
+            return nil
+        }
+    }
+
+    /// Explicit reset to the default folder. Unlike `ensureFolderConfigured`,
+    /// this overwrites any existing bookmark — used by the "Reset" button so
+    /// the user can deliberately revert to default after picking a custom
+    /// destination.
+    @discardableResult
+    public static func resetFolderToDefault(scope: AutoSaveScope = .transcription, defaults: UserDefaults = .standard) -> URL? {
+        let defaultURL = defaultFolder(for: scope)
+        do {
+            try FileManager.default.createDirectory(at: defaultURL, withIntermediateDirectories: true)
+            _ = storeFolder(defaultURL, scope: scope, defaults: defaults)
+            return defaultURL
+        } catch {
+            return nil
+        }
+    }
+
     // MARK: - Filename
 
     /// Build a deduplicated file URL for the given transcription.

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -595,8 +595,7 @@ public final class SettingsViewModel {
 
     /// Resolve the stored bookmark to a display path.
     private static func resolveAutoSaveFolderPath(defaults: UserDefaults, scope: AutoSaveScope = .transcription) -> String? {
-        let service = AutoSaveService(defaults: defaults)
-        return service.resolveFolder(scope: scope)?.path
+        AutoSaveService.resolveFolder(scope: scope, defaults: defaults)?.path
     }
 
     public func chooseAutoSaveFolder(url: URL) {

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -470,6 +470,14 @@ public final class SettingsViewModel {
         speakerDiarization = defaults.object(forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey) as? Bool ?? true
         speechEnginePreference = SpeechEnginePreference.current(defaults: defaults)
         whisperDefaultLanguage = SpeechEnginePreference.whisperDefaultLanguage(defaults: defaults) ?? "auto"
+        // Ensure auto-save folders are configured before reading paths.
+        // Idempotent: existing user-chosen folders are preserved; only
+        // unset bookmarks get the default. This guarantees the read
+        // below sees a non-nil path in the common case so the toggle
+        // can never sit in the bad "ON · no folder" combination.
+        AutoSaveService.ensureFolderConfigured(scope: .transcription, defaults: defaults)
+        AutoSaveService.ensureFolderConfigured(scope: .meeting, defaults: defaults)
+
         autoSaveTranscripts = defaults.bool(forKey: AutoSaveService.enabledKey)
         autoSaveFormat = AutoSaveFormat(rawValue: defaults.string(forKey: AutoSaveService.formatKey) ?? "md") ?? .md
         autoSaveFolderPath = Self.resolveAutoSaveFolderPath(defaults: defaults, scope: .transcription)
@@ -481,6 +489,23 @@ public final class SettingsViewModel {
         meetingTriggerFilter = Self.resolveMeetingTriggerFilter(defaults: defaults)
         calendarAutoStopEnabled = defaults.object(forKey: CalendarAutoStartPreferences.autoStopEnabledKey) as? Bool ?? true
         calendarExcludedIdentifiers = Self.resolveCalendarExcludedIdentifiers(defaults: defaults)
+
+        // Defense-in-depth self-heal: in the rare case that
+        // `ensureFolderConfigured` couldn't create the default folder
+        // (disk full, `~/Documents` not writable, stale bookmark
+        // unresolvable), folder may still be nil. Toggling ON in that
+        // state silently no-ops every save, so reset the toggle to
+        // match reality. Writes through to defaults because didSet
+        // doesn't fire during init.
+        if autoSaveTranscripts && autoSaveFolderPath == nil {
+            autoSaveTranscripts = false
+            defaults.set(false, forKey: AutoSaveService.enabledKey)
+        }
+        if meetingAutoSave && meetingAutoSaveFolderPath == nil {
+            meetingAutoSave = false
+            defaults.set(false, forKey: AutoSaveScope.meeting.enabledKey)
+        }
+
         refreshMicrophoneDevices()
         observeCalendarSettings()
     }
@@ -580,9 +605,16 @@ public final class SettingsViewModel {
         }
     }
 
-    public func clearAutoSaveFolder() {
-        AutoSaveService.clearFolder(scope: .transcription, defaults: defaults)
-        autoSaveFolderPath = nil
+    /// Reset the auto-save destination to the default location
+    /// (`~/Documents/MacParakeet/Transcriptions`). The toggle is left in
+    /// whatever state the user had it — folder is *always* set, so the
+    /// toggle is a pure on/off feature flag. This replaces the older
+    /// "Clear" semantic (which was a footgun: ON + no folder silently
+    /// no-op'd every save).
+    public func resetAutoSaveFolder() {
+        if let url = AutoSaveService.resetFolderToDefault(scope: .transcription, defaults: defaults) {
+            autoSaveFolderPath = url.path
+        }
     }
 
     public func chooseMeetingAutoSaveFolder(url: URL) {
@@ -591,9 +623,10 @@ public final class SettingsViewModel {
         }
     }
 
-    public func clearMeetingAutoSaveFolder() {
-        AutoSaveService.clearFolder(scope: .meeting, defaults: defaults)
-        meetingAutoSaveFolderPath = nil
+    public func resetMeetingAutoSaveFolder() {
+        if let url = AutoSaveService.resetFolderToDefault(scope: .meeting, defaults: defaults) {
+            meetingAutoSaveFolderPath = url.path
+        }
     }
 
     private static func resolveMeetingHotkeyTrigger(defaults: UserDefaults) -> HotkeyTrigger {

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -294,11 +294,15 @@ final class SettingsViewModelTests: XCTestCase {
     }
 
     func testEnsureFolderConfiguredIsIdempotent() {
-        // Running ensureFolderConfigured twice on a fresh defaults must
+        // Running ensureFolderConfigured twice on fresh defaults must
         // produce the same path — the second call should see the first
         // call's bookmark and not re-create or move the folder.
-        let first = AutoSaveService.ensureFolderConfigured(scope: .transcription, defaults: testDefaults)
-        let second = AutoSaveService.ensureFolderConfigured(scope: .transcription, defaults: testDefaults)
+        let suite = "com.macparakeet.tests.idempotent.\(UUID().uuidString)"
+        let fresh = UserDefaults(suiteName: suite)!
+        defer { fresh.removePersistentDomain(forName: suite) }
+
+        let first = AutoSaveService.ensureFolderConfigured(scope: .transcription, defaults: fresh)
+        let second = AutoSaveService.ensureFolderConfigured(scope: .transcription, defaults: fresh)
 
         XCTAssertNotNil(first)
         XCTAssertNotNil(second)

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -204,11 +204,19 @@ final class SettingsViewModelTests: XCTestCase {
     }
 
     func testMeetingAutoSaveMigratesLegacyTranscriptionSettings() {
-        testDefaults.set(true, forKey: AutoSaveService.enabledKey)
-        testDefaults.set(AutoSaveFormat.json.rawValue, forKey: AutoSaveService.formatKey)
-        AutoSaveService.storeFolder(youtubeDownloadsTestDir, defaults: testDefaults)
+        // setUp's vm already populated `testDefaults` for both scopes.
+        // To exercise the legacy upgrade path (transcription configured,
+        // meeting empty) we need a separate suite that hasn't been
+        // touched by ensureFolderConfigured yet.
+        let suite = "com.macparakeet.tests.legacy.\(UUID().uuidString)"
+        let fresh = UserDefaults(suiteName: suite)!
+        defer { fresh.removePersistentDomain(forName: suite) }
 
-        let vm = SettingsViewModel(defaults: testDefaults)
+        fresh.set(true, forKey: AutoSaveService.enabledKey)
+        fresh.set(AutoSaveFormat.json.rawValue, forKey: AutoSaveService.formatKey)
+        AutoSaveService.storeFolder(youtubeDownloadsTestDir, defaults: fresh)
+
+        let vm = SettingsViewModel(defaults: fresh)
 
         XCTAssertTrue(vm.meetingAutoSave)
         XCTAssertEqual(vm.meetingAutoSaveFormat, .json)
@@ -216,9 +224,85 @@ final class SettingsViewModelTests: XCTestCase {
             vm.meetingAutoSaveFolderPath.map { URL(fileURLWithPath: $0).standardizedFileURL.path },
             youtubeDownloadsTestDir.standardizedFileURL.path
         )
-        XCTAssertEqual(testDefaults.object(forKey: AutoSaveScope.meeting.enabledKey) as? Bool, true)
-        XCTAssertEqual(testDefaults.string(forKey: AutoSaveScope.meeting.formatKey), AutoSaveFormat.json.rawValue)
-        XCTAssertNotNil(testDefaults.data(forKey: AutoSaveScope.meeting.folderBookmarkKey))
+        XCTAssertEqual(fresh.object(forKey: AutoSaveScope.meeting.enabledKey) as? Bool, true)
+        XCTAssertEqual(fresh.string(forKey: AutoSaveScope.meeting.formatKey), AutoSaveFormat.json.rawValue)
+        XCTAssertNotNil(fresh.data(forKey: AutoSaveScope.meeting.folderBookmarkKey))
+    }
+
+    // MARK: - Auto-save folder configuration
+    //
+    // The folder is always set after init — to the user's chosen folder if
+    // they have one, or to the default `~/Documents/MacParakeet/...`
+    // otherwise. This collapses the entire bug class around "toggle ON ·
+    // no folder" because the no-folder state is unreachable in practice.
+
+    func testInitConfiguresDefaultFoldersWhenNoneStored() {
+        // setUp's `viewModel` already populated `testDefaults` via
+        // ensureFolderConfigured, so use a separate suite to observe
+        // the fresh-defaults case.
+        let suite = "com.macparakeet.tests.fresh.\(UUID().uuidString)"
+        let fresh = UserDefaults(suiteName: suite)!
+        defer { fresh.removePersistentDomain(forName: suite) }
+
+        XCTAssertNil(fresh.data(forKey: AutoSaveService.folderBookmarkKey))
+        XCTAssertNil(fresh.data(forKey: AutoSaveScope.meeting.folderBookmarkKey))
+
+        let vm = SettingsViewModel(defaults: fresh)
+
+        XCTAssertNotNil(vm.autoSaveFolderPath)
+        XCTAssertNotNil(vm.meetingAutoSaveFolderPath)
+        XCTAssertTrue(vm.autoSaveFolderPath?.contains("MacParakeet/Transcriptions") ?? false)
+        XCTAssertTrue(vm.meetingAutoSaveFolderPath?.contains("MacParakeet/Meetings") ?? false)
+    }
+
+    func testInitPreservesUserChosenFolder() {
+        // The user previously picked a custom folder. ensureFolderConfigured
+        // must not stomp it with the default.
+        AutoSaveService.storeFolder(youtubeDownloadsTestDir, defaults: testDefaults)
+
+        let vm = SettingsViewModel(defaults: testDefaults)
+
+        XCTAssertEqual(
+            vm.autoSaveFolderPath.map { URL(fileURLWithPath: $0).standardizedFileURL.path },
+            youtubeDownloadsTestDir.standardizedFileURL.path,
+            "User-chosen folders must survive init untouched."
+        )
+    }
+
+    func testResetAutoSaveFolderRestoresDefault() {
+        AutoSaveService.storeFolder(youtubeDownloadsTestDir, defaults: testDefaults)
+        viewModel.autoSaveTranscripts = true
+        viewModel.autoSaveFolderPath = youtubeDownloadsTestDir.path
+
+        viewModel.resetAutoSaveFolder()
+
+        XCTAssertNotNil(viewModel.autoSaveFolderPath)
+        XCTAssertTrue(viewModel.autoSaveFolderPath?.contains("MacParakeet/Transcriptions") ?? false)
+        XCTAssertTrue(viewModel.autoSaveTranscripts, "Reset must not silently disable the toggle.")
+    }
+
+    func testResetMeetingAutoSaveFolderRestoresDefault() {
+        AutoSaveService.storeFolder(youtubeDownloadsTestDir, scope: .meeting, defaults: testDefaults)
+        viewModel.meetingAutoSave = true
+        viewModel.meetingAutoSaveFolderPath = youtubeDownloadsTestDir.path
+
+        viewModel.resetMeetingAutoSaveFolder()
+
+        XCTAssertNotNil(viewModel.meetingAutoSaveFolderPath)
+        XCTAssertTrue(viewModel.meetingAutoSaveFolderPath?.contains("MacParakeet/Meetings") ?? false)
+        XCTAssertTrue(viewModel.meetingAutoSave)
+    }
+
+    func testEnsureFolderConfiguredIsIdempotent() {
+        // Running ensureFolderConfigured twice on a fresh defaults must
+        // produce the same path — the second call should see the first
+        // call's bookmark and not re-create or move the folder.
+        let first = AutoSaveService.ensureFolderConfigured(scope: .transcription, defaults: testDefaults)
+        let second = AutoSaveService.ensureFolderConfigured(scope: .transcription, defaults: testDefaults)
+
+        XCTAssertNotNil(first)
+        XCTAssertNotNil(second)
+        XCTAssertEqual(first?.standardizedFileURL.path, second?.standardizedFileURL.path)
     }
 
     func testSilenceDelayDefaultsTo2WhenZero() {


### PR DESCRIPTION
## Summary

This PR fixes an auto-save footgun where the app could show auto-save as enabled while no destination folder was configured. In that state, saves silently no-op'd, so users could reasonably believe their transcripts or meeting notes were being written to disk when nothing was saved.

Auto-save now always has a destination after Settings initializes. The toggle is a simple on/off switch, and folder management is handled separately through Choose and Reset.

## User impact

- Fresh installs get sensible default folders in Documents:
  - `~/Documents/MacParakeet/Transcriptions`
  - `~/Documents/MacParakeet/Meetings`
- Existing custom folders are preserved, including bookmarks that are temporarily unresolvable, such as a disconnected external drive.
- Reset restores the relevant default folder without turning auto-save off.
- Choose still lets users pick a custom folder.
- If the app cannot create or persist the default folder bookmark, it does not pretend configuration succeeded.

## Flow

```text
Before

Auto-save ON
     |
     v
No folder bookmark
     |
     v
saveIfEnabled()
     |
     v
Silent no-op

After

Settings init
     |
     +-- existing bookmark? ---- yes --> preserve user folder
     |
     no
     |
     v
Create default folder for scope
     |
     v
Store bookmark successfully?
     |
     +-- yes --> auto-save has a destination
     |
     +-- no  --> report no configured folder; do not claim success

User controls

Toggle: ON/OFF saving
Choose: pick custom folder
Reset : restore default folder for that row
```

## Implementation notes

- `AutoSaveService.defaultFolder(for:)` defines scope-specific defaults under `~/Documents/MacParakeet/`.
- `ensureFolderConfigured(scope:defaults:)` is idempotent and keys on bookmark presence, not bookmark resolvability, so it does not overwrite a user's custom destination during temporary failures.
- `resetFolderToDefault(scope:defaults:)` intentionally overwrites the bookmark with the default folder for that scope.
- Bookmark persistence is now checked before returning success from default-folder setup/reset.
- Folder resolution can now use a static helper, avoiding unnecessary `AutoSaveService` initialization just to resolve a bookmark.
- Settings UI replaces Clear with Reset and uses scope-specific tooltip copy.
- The legacy meeting auto-save migration path remains covered.

## Review comments addressed

- Removed stale folder-picker comment text about the old toggle interceptor.
- Checked `storeFolder(...)` success before returning default folder URLs.
- Avoided constructing `AutoSaveService` just to resolve a bookmark.
- Made the idempotency test use a truly fresh isolated `UserDefaults` suite.
- Made Reset tooltip copy scope-aware for Transcriptions vs Meetings.

## Validation

- [x] Local `swift test` passed on final head: 2008 XCTest tests + 16 Swift Testing tests, 0 failures.
- [x] GitHub Actions `swift-test` passed on final head.
- [x] CodeRabbit passed on final head.
- [x] All PR review threads are resolved.