### PR TITLE
Fix double-tap dictation race in AudioRecorder lostRace check

### DIFF
--- a/Sources/MacParakeetCore/Audio/AudioRecorder.swift
+++ b/Sources/MacParakeetCore/Audio/AudioRecorder.swift
@@ -69,6 +69,14 @@ public actor AudioRecorder {
     private var outputURL: URL?
     private var recording = false
     private var starting = false
+    /// Bumped on every `start()` entry that passes the entry guard. Each call
+    /// captures its value as `myStartCallGeneration`; the `defer` only clears
+    /// `starting` if no newer call has claimed the slot. Without this, an
+    /// aborted sibling's defer would clobber a legitimate replacement start
+    /// AND mislead `stop()` into taking its no-op path (which doesn't bump
+    /// `sessionGeneration`), letting the replacement claim a recording the
+    /// caller of `stop()` just asked to end.
+    private var startCallGeneration: Int = 0
 
     /// Minimum samples before sending to STT.
     /// FluidAudio requires at least 1 second of 16kHz audio (16,000 samples).
@@ -108,7 +116,20 @@ public actor AudioRecorder {
     public func start() async throws {
         guard !recording, !starting else { return }
         starting = true
-        defer { starting = false }
+        startCallGeneration += 1
+        let myStartCallGeneration = startCallGeneration
+        defer {
+            // Only clear `starting` if this call still owns the slot. If
+            // `stop()` reset `starting=false` mid-await and a newer `start()`
+            // entered, the newer call bumped `startCallGeneration` and now
+            // owns `starting=true`. Clobbering it here would (a) trip the
+            // newer call's lostRace `!self.starting` check and (b) hide the
+            // newer call from a subsequent `stop()`, which would take its
+            // no-op path and skip bumping `sessionGeneration`.
+            if startCallGeneration == myStartCallGeneration {
+                starting = false
+            }
+        }
 
         AudioCaptureDiagnostics.append(
             "dictation_capture_start permission_status=\(AVCaptureDevice.authorizationStatus(for: .audio).rawValue)"
@@ -339,15 +360,14 @@ public actor AudioRecorder {
         // method (typically `stop()`) may have run on this actor — `stop()`
         // bumps the generation, so a generation mismatch means we're an
         // orphan. Unsubscribe and clean up rather than claim a recording
-        // session that nobody asked for.
-        //
-        // We deliberately do NOT consult `self.starting` here. The flag is
-        // shared across calls and an aborted sibling's `defer { starting =
-        // false }` would clobber a legitimate replacement start that entered
-        // after stop() reset `starting`. The generation bump is the canonical
-        // "lost the race" signal — sibling defers do not bump generation.
+        // session that nobody asked for. The `!self.starting` clause catches
+        // the rarer case where another `start()` entered after `stop()` reset
+        // `starting`, took the slot, and is now in flight; we should not
+        // claim a recording on its behalf. The per-call defer guard above
+        // makes this safe — a sibling's defer cannot clobber the active
+        // claim, so this check fires only when we genuinely lost the slot.
         let postSubscribeGeneration = self.sessionGeneration.withLock { $0 }
-        let lostRace = preSubscribeGeneration != postSubscribeGeneration || self.recording
+        let lostRace = preSubscribeGeneration != postSubscribeGeneration || !self.starting || self.recording
         if lostRace {
             let stream = sharedStream
             Task { await stream.unsubscribe(token) }

--- a/Sources/MacParakeetCore/Audio/AudioRecorder.swift
+++ b/Sources/MacParakeetCore/Audio/AudioRecorder.swift
@@ -340,8 +340,14 @@ public actor AudioRecorder {
         // bumps the generation, so a generation mismatch means we're an
         // orphan. Unsubscribe and clean up rather than claim a recording
         // session that nobody asked for.
+        //
+        // We deliberately do NOT consult `self.starting` here. The flag is
+        // shared across calls and an aborted sibling's `defer { starting =
+        // false }` would clobber a legitimate replacement start that entered
+        // after stop() reset `starting`. The generation bump is the canonical
+        // "lost the race" signal — sibling defers do not bump generation.
         let postSubscribeGeneration = self.sessionGeneration.withLock { $0 }
-        let lostRace = preSubscribeGeneration != postSubscribeGeneration || !self.starting || self.recording
+        let lostRace = preSubscribeGeneration != postSubscribeGeneration || self.recording
         if lostRace {
             let stream = sharedStream
             Task { await stream.unsubscribe(token) }

--- a/Sources/MacParakeetCore/Services/DictationService.swift
+++ b/Sources/MacParakeetCore/Services/DictationService.swift
@@ -176,15 +176,25 @@ public actor DictationService: DictationServiceProtocol {
         _state = .recording
         do {
             try await audioProcessor.startCapture()
-            // Guard against reentrancy: cancel may have run during the await above
-            guard case .recording = _state else {
-                if await audioProcessor.isRecording,
+            // Guard against reentrancy: cancel or replacement may have run during the await above.
+            let activeAtStartCompletion = activeSessionID
+            guard activeAtStartCompletion == requestedSessionID, case .recording = _state else {
+                let processorIsRecording: Bool
+                if activeAtStartCompletion == requestedSessionID {
+                    processorIsRecording = await audioProcessor.isRecording
+                } else {
+                    processorIsRecording = false
+                }
+                if activeSessionID == requestedSessionID,
+                   processorIsRecording,
                    let audioURL = try? await audioProcessor.stopCapture() {
                     try? FileManager.default.removeItem(at: audioURL)
                 }
-                recordingStartedAt = nil
+                if activeSessionID == requestedSessionID {
+                    recordingStartedAt = nil
+                }
                 logger.notice(
-                    "startRecording aborted session=\(requestedSessionID) state=\(self.debugStateLabel(self._state), privacy: .public)"
+                    "startRecording aborted session=\(requestedSessionID) active=\(activeAtStartCompletion) state=\(self.debugStateLabel(self._state), privacy: .public)"
                 )
                 return
             }
@@ -193,10 +203,23 @@ public actor DictationService: DictationServiceProtocol {
             Telemetry.send(.dictationStarted(trigger: context.trigger, mode: context.mode))
             logger.debug("startRecording capture started session=\(requestedSessionID)")
         } catch {
+            let activeAtFailure = activeSessionID
+            guard activeAtFailure == requestedSessionID else {
+                logger.notice(
+                    "startRecording stale failure ignored session=\(requestedSessionID) active=\(activeAtFailure) error=\(error.localizedDescription, privacy: .public)"
+                )
+                throw error
+            }
+            let device = await audioProcessor.recordingDeviceInfo
+            guard activeSessionID == requestedSessionID else {
+                logger.notice(
+                    "startRecording stale failure ignored session=\(requestedSessionID) active=\(self.activeSessionID) error=\(error.localizedDescription, privacy: .public)"
+                )
+                throw error
+            }
             let operationID = currentOperationID
             let telemetryContext = currentOperationTelemetryContext
             let observabilityOperationContext = currentObservabilityOperationContext
-            let device = await audioProcessor.recordingDeviceInfo
             _state = .idle
             recordingStartedAt = nil
             sendDictationOperation(

--- a/Tests/MacParakeetTests/Audio/AudioRecorderFormatChangeTests.swift
+++ b/Tests/MacParakeetTests/Audio/AudioRecorderFormatChangeTests.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import os
 import XCTest
 @testable import MacParakeetCore
 
@@ -86,20 +87,39 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
     ///   1. start #1 (provisional hold-to-talk) suspends in subscribe
     ///   2. stop runs (fn-up discard) — bumps generation, resets `starting`
     ///   3. start #2 (persistent double-tap) enters and suspends in subscribe
-    ///   4. start #1's subscribe resumes — lostRace throws, defer clears `starting`
+    ///   4. start #1's subscribe resumes — lostRace throws, defer fires
     ///   5. start #2's subscribe resumes — must succeed
     ///
     /// Today's bug: start #1's `defer { starting = false }` clobbers start #2's
     /// `starting = true` between #1's throw and #2's lostRace check, so #2's
     /// `!self.starting` clause trips lostRace and the user-wanted persistent
-    /// recording also aborts. After the fix, only the generation check governs
-    /// lostRace, and start #2 succeeds.
+    /// recording also aborts. After the fix (per-call defer guard via
+    /// `startCallGeneration`), the sibling defer leaves the active claim alone
+    /// and start #2 succeeds.
+    ///
+    /// The `permissionProvider` is the synchronization gate: every `start()`
+    /// invokes it after passing the entry guard, so signaling on the second
+    /// call gives a deterministic "task #2 has entered start()" sync point.
+    /// A blanket `Task.sleep` would risk task #2 entering AFTER task #1
+    /// resolves, missing the bug entirely (false-pass regression sentinel).
     func testSharedModeStartAfterStopDuringFirstStartSucceeds() async throws {
         let platform = AudioRecorderBlockingPlatform()
         let stream = SharedMicrophoneStream(platform: platform, bufferSize: 1024)
+
+        let permissionCallCount = OSAllocatedUnfairLock<Int>(initialState: 0)
+        let task2EnteredStart = DispatchSemaphore(value: 0)
         let recorder = AudioRecorder(
             sharedStream: stream,
-            permissionProvider: { true }
+            permissionProvider: {
+                let n = permissionCallCount.withLock { v in
+                    v += 1
+                    return v
+                }
+                if n == 2 {
+                    task2EnteredStart.signal()
+                }
+                return true
+            }
         )
 
         let arrived = DispatchSemaphore(value: 0)
@@ -128,10 +148,12 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
         // Launch start #2 while start #1 is still suspended in subscribe.
         let task2 = Task { try await recorder.start() }
 
-        // Give task2 time to enter the actor and reach its own subscribe await.
-        // The actor is suspended on subscribe(#1), so task2 reentrant entry is
-        // immediate; the sleep just covers Task scheduling latency.
-        try await Task.sleep(for: .milliseconds(50))
+        // Wait for task2 to reach permissionProvider — proof it's inside the
+        // actor with `starting=true` set. From there to `await subscribe` is
+        // a few lines of synchronous code (no awaits between), so a short
+        // yield suffices to let the await be reached before we release.
+        XCTAssertEqual(task2EnteredStart.wait(timeout: .now() + 5), .success)
+        for _ in 0..<5 { await Task.yield() }
 
         // Release start #1's blocked engine startup. Subscribe #1 completes,
         // its continuation resumes on the actor, lostRace throws, defer fires.
@@ -157,15 +179,28 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
         XCTAssertTrue(isRecording, "start #2 must leave the recorder in recording state")
 
         // Drain the fire-and-forget unsubscribe(token #1) before asserting
-        // subscriber count, then clean up. The cleanup stop() throws
-        // `insufficientSamples` because the mock platform never delivers
-        // buffers — that's expected here and unrelated to the race we're
-        // verifying.
-        try await Task.sleep(for: .milliseconds(50))
-        XCTAssertEqual(stream.diagnostics.subscriberCount, 1)
+        // subscriber count. Poll instead of sleep — bounded, deterministic.
+        let drained = await pollUntil(timeout: .seconds(2)) {
+            stream.diagnostics.subscriberCount == 1
+        }
+        XCTAssertTrue(drained, "expected exactly one remaining subscriber after #1 unsubscribed")
         XCTAssertTrue(stream.diagnostics.engineRunning)
 
+        // Cleanup stop() throws `insufficientSamples` because the mock platform
+        // never delivers buffers — expected here and unrelated to the race.
         _ = try? await recorder.stop()
+    }
+
+    private func pollUntil(
+        timeout: Duration,
+        condition: @Sendable () -> Bool
+    ) async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            if condition() { return true }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return condition()
     }
 
     private func makeFormat(

--- a/Tests/MacParakeetTests/Audio/AudioRecorderFormatChangeTests.swift
+++ b/Tests/MacParakeetTests/Audio/AudioRecorderFormatChangeTests.swift
@@ -76,11 +76,13 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
             XCTFail("Unexpected start error: \(error)")
         }
 
-        try await Task.sleep(for: .milliseconds(50))
         let isRecording = await recorder.isRecording
         XCTAssertFalse(isRecording)
-        XCTAssertEqual(stream.diagnostics.subscriberCount, 0)
-        XCTAssertFalse(stream.diagnostics.engineRunning)
+
+        let drained = await pollUntil(timeout: .seconds(2)) {
+            stream.diagnostics.subscriberCount == 0 && !stream.diagnostics.engineRunning
+        }
+        XCTAssertTrue(drained, "expected pending unsubscribe to drain after interrupted start")
     }
 
     /// Reproduces the double-tap dictation race. Sequence is:

--- a/Tests/MacParakeetTests/Audio/AudioRecorderFormatChangeTests.swift
+++ b/Tests/MacParakeetTests/Audio/AudioRecorderFormatChangeTests.swift
@@ -82,6 +82,92 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
         XCTAssertFalse(stream.diagnostics.engineRunning)
     }
 
+    /// Reproduces the double-tap dictation race. Sequence is:
+    ///   1. start #1 (provisional hold-to-talk) suspends in subscribe
+    ///   2. stop runs (fn-up discard) — bumps generation, resets `starting`
+    ///   3. start #2 (persistent double-tap) enters and suspends in subscribe
+    ///   4. start #1's subscribe resumes — lostRace throws, defer clears `starting`
+    ///   5. start #2's subscribe resumes — must succeed
+    ///
+    /// Today's bug: start #1's `defer { starting = false }` clobbers start #2's
+    /// `starting = true` between #1's throw and #2's lostRace check, so #2's
+    /// `!self.starting` clause trips lostRace and the user-wanted persistent
+    /// recording also aborts. After the fix, only the generation check governs
+    /// lostRace, and start #2 succeeds.
+    func testSharedModeStartAfterStopDuringFirstStartSucceeds() async throws {
+        let platform = AudioRecorderBlockingPlatform()
+        let stream = SharedMicrophoneStream(platform: platform, bufferSize: 1024)
+        let recorder = AudioRecorder(
+            sharedStream: stream,
+            permissionProvider: { true }
+        )
+
+        let arrived = DispatchSemaphore(value: 0)
+        let release = DispatchSemaphore(value: 0)
+        platform.configureAndStartHook = {
+            arrived.signal()
+            release.wait()
+        }
+
+        let task1 = Task { try await recorder.start() }
+        XCTAssertEqual(arrived.wait(timeout: .now() + 5), .success)
+
+        do {
+            _ = try await recorder.stop()
+            XCTFail("stop() should throw while start #1 is still pending")
+        } catch AudioProcessorError.recordingFailed(let reason) {
+            XCTAssertEqual(reason, "Not recording")
+        } catch {
+            XCTFail("Unexpected stop error: \(error)")
+        }
+
+        // Disarm the hook so the engineQueue can drain start #2's subscribe
+        // (no-op for an already-running engine) without re-blocking.
+        platform.configureAndStartHook = nil
+
+        // Launch start #2 while start #1 is still suspended in subscribe.
+        let task2 = Task { try await recorder.start() }
+
+        // Give task2 time to enter the actor and reach its own subscribe await.
+        // The actor is suspended on subscribe(#1), so task2 reentrant entry is
+        // immediate; the sleep just covers Task scheduling latency.
+        try await Task.sleep(for: .milliseconds(50))
+
+        // Release start #1's blocked engine startup. Subscribe #1 completes,
+        // its continuation resumes on the actor, lostRace throws, defer fires.
+        // Then subscribe #2 completes (engine already running) and resumes.
+        release.signal()
+
+        do {
+            try await task1.value
+            XCTFail("start #1 should abort — its generation was bumped by stop")
+        } catch AudioProcessorError.recordingFailed(let reason) {
+            XCTAssertEqual(reason, "interrupted during subscribe")
+        } catch {
+            XCTFail("Unexpected start #1 error: \(error)")
+        }
+
+        do {
+            try await task2.value
+        } catch {
+            XCTFail("start #2 should succeed after start #1 aborted; got: \(error)")
+        }
+
+        let isRecording = await recorder.isRecording
+        XCTAssertTrue(isRecording, "start #2 must leave the recorder in recording state")
+
+        // Drain the fire-and-forget unsubscribe(token #1) before asserting
+        // subscriber count, then clean up. The cleanup stop() throws
+        // `insufficientSamples` because the mock platform never delivers
+        // buffers — that's expected here and unrelated to the race we're
+        // verifying.
+        try await Task.sleep(for: .milliseconds(50))
+        XCTAssertEqual(stream.diagnostics.subscriberCount, 1)
+        XCTAssertTrue(stream.diagnostics.engineRunning)
+
+        _ = try? await recorder.stop()
+    }
+
     private func makeFormat(
         sampleRate: Double = 48_000,
         channels: AVAudioChannelCount = 2,

--- a/Tests/MacParakeetTests/Services/DictationServiceSessionTests.swift
+++ b/Tests/MacParakeetTests/Services/DictationServiceSessionTests.swift
@@ -64,4 +64,106 @@ final class DictationServiceSessionTests: XCTestCase {
         let captureStopped = await mockAudio.stopCaptureCalled
         XCTAssertTrue(captureStopped, "Confirm cancel should target the captured session, not the latest reserved one")
     }
+
+    func testStaleStartFailureDoesNotClearReplacementSession() async throws {
+        let audio = DictationRaceAudioProcessor()
+        service = DictationService(
+            audioProcessor: audio,
+            sttTranscriber: mockSTT,
+            dictationRepo: dictationRepo
+        )
+        session = DictationServiceSession(service: service)
+
+        let firstSessionID = session.reserveNextSessionID()
+        let firstStart = Task {
+            try await session.startRecording(sessionID: firstSessionID, context: DictationTelemetryContext())
+        }
+        await audio.waitForStartCall(1)
+
+        await session.confirmCancel(sessionID: firstSessionID)
+
+        let secondSessionID = session.reserveNextSessionID()
+        let secondStart = Task {
+            try await session.startRecording(sessionID: secondSessionID, context: DictationTelemetryContext())
+        }
+        await audio.waitForStartCall(2)
+
+        await audio.releaseStartCall(1)
+        do {
+            try await firstStart.value
+            XCTFail("First start should fail after being replaced")
+        } catch AudioProcessorError.recordingFailed(let reason) {
+            XCTAssertEqual(reason, "interrupted during subscribe")
+        } catch {
+            XCTFail("Unexpected first start error: \(error)")
+        }
+
+        await audio.releaseStartCall(2)
+        try await secondStart.value
+
+        let state = await session.state
+        if case .recording = state {} else {
+            XCTFail("Expected replacement session to still be recording, got \(state)")
+        }
+    }
+}
+
+private actor DictationRaceAudioProcessor: AudioProcessorProtocol {
+    private var startCalls = 0
+    private var waitersByCall: [Int: [CheckedContinuation<Void, Never>]] = [:]
+    private var releaseWaitersByCall: [Int: CheckedContinuation<Void, Never>] = [:]
+    private var releasedCalls: Set<Int> = []
+    private var recording = false
+
+    var audioLevel: Float { 0 }
+    var isRecording: Bool { recording }
+    var recordingDeviceInfo: RecordingDeviceInfo? { nil }
+
+    func convert(fileURL: URL) async throws -> URL {
+        fileURL
+    }
+
+    func startCapture() async throws {
+        startCalls += 1
+        let call = startCalls
+        signalStartCall(call)
+        await waitUntilReleased(call)
+
+        if call == 1 {
+            throw AudioProcessorError.recordingFailed("interrupted during subscribe")
+        }
+
+        recording = true
+    }
+
+    func stopCapture() async throws -> URL {
+        recording = false
+        return URL(fileURLWithPath: "/tmp/race.wav")
+    }
+
+    func waitForStartCall(_ call: Int) async {
+        guard startCalls < call else { return }
+        await withCheckedContinuation { continuation in
+            waitersByCall[call, default: []].append(continuation)
+        }
+    }
+
+    func releaseStartCall(_ call: Int) {
+        releasedCalls.insert(call)
+        releaseWaitersByCall.removeValue(forKey: call)?.resume()
+    }
+
+    private func signalStartCall(_ call: Int) {
+        let waiters = waitersByCall.removeValue(forKey: call) ?? []
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    private func waitUntilReleased(_ call: Int) async {
+        guard !releasedCalls.contains(call) else { return }
+        await withCheckedContinuation { continuation in
+            releaseWaitersByCall[call] = continuation
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a race where quickly double-tapping Fn could make persistent dictation fail with:

`Recording failed: interrupted during subscribe`

This happens when the first provisional start is still starting up while the second, user-intended persistent start begins.

## Race Shape

```text
Before

Time ->

Start #1   set starting=true ---- await subscribe ---- stale, fails
Stop #1                         bump generation, clear starting
Start #2                                set starting=true ---- await subscribe
Start #1 defer                                      clear starting=false
Start #2 resume                                             sees stale flag, fails

Result: the replacement recording also fails.
```

```text
After

Time ->

Start #1   owns token A -------- await subscribe ---- stale, fails
Stop #1                         bump generation, clear starting
Start #2                                owns token B -------- await subscribe
Start #1 defer                                      token A is stale, no clear
Start #2 resume                                             token B still owns start, records

Result: the user-intended persistent recording stays alive.
```

## What Changed

- `AudioRecorder` now uses per-start ownership for the shared `starting` flag, so an older start cannot clear a newer start's in-flight state.
- `DictationService` now checks session ownership before mutating state after async start work, so a stale failed start cannot reset a replacement session to idle.
- Race tests now use explicit rendezvous/polling instead of fixed sleeps.

## Validation

- `swift test --filter AudioRecorderFormatChangeTests`
- `swift test --filter DictationServiceSessionTests`
- Full `swift test`: 2053 XCTest tests + 16 Swift Testing tests passed
- GitHub CI on head `7003fdb2`: both `swift-test` jobs passed
