### PR TITLE
Fix chord hotkey key-up swallowing

### DIFF
--- a/Sources/MacParakeet/Hotkey/HotkeyManager.swift
+++ b/Sources/MacParakeet/Hotkey/HotkeyManager.swift
@@ -402,6 +402,22 @@ public final class HotkeyManager {
         return outputs
     }
 
+    func chordEventDecisionForTesting(
+        type: CGEventType,
+        keyCode: UInt16,
+        flags: UInt64,
+        timestampMs: UInt64
+    ) -> (outputs: [HotkeyGestureController.Output], shouldSwallow: Bool) {
+        let decision = chordEventDecision(
+            type: type,
+            keyCode: keyCode,
+            flags: flags & Self.relevantModifierBits,
+            timestampMs: timestampMs
+        )
+        rememberRecordingState(for: decision.outputs)
+        return decision
+    }
+
     // MARK: - KeyCode Trigger Path
 
     private func handleKeyCodeEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
@@ -449,56 +465,70 @@ public final class HotkeyManager {
     // MARK: - Chord Trigger Path
 
     private func handleChordEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
-        guard let triggerCode = trigger.keyCode else {
-            return Unmanaged.passUnretained(event)
-        }
-
         let timestampMs = UInt64(event.timestamp / 1_000_000)
         let keyCode = UInt16(event.getIntegerValueField(.keyboardEventKeycode))
+        let decision = chordEventDecision(
+            type: type,
+            keyCode: keyCode,
+            flags: event.flags.rawValue & Self.relevantModifierBits,
+            timestampMs: timestampMs
+        )
+        handleOutputs(decision.outputs)
+
+        return decision.shouldSwallow ? nil : Unmanaged.passUnretained(event)
+    }
+
+    private func chordEventDecision(
+        type: CGEventType,
+        keyCode: UInt16,
+        flags: UInt64,
+        timestampMs: UInt64
+    ) -> (outputs: [HotkeyGestureController.Output], shouldSwallow: Bool) {
+        guard let triggerCode = trigger.keyCode else {
+            return ([], false)
+        }
 
         if type == .keyDown {
             if keyCode == triggerCode {
                 // Check required modifiers are held
-                let flags = event.flags.rawValue & Self.relevantModifierBits
                 guard flags & requiredChordFlags == requiredChordFlags else {
-                    return Unmanaged.passUnretained(event)
+                    return ([], false)
                 }
 
                 // Edge detection: ignore key-repeat
                 guard !triggerKeyIsPressed else {
-                    return nil // Swallow repeated keyDown
+                    return ([], true) // Swallow repeated keyDown
                 }
                 triggerKeyIsPressed = true
                 chordModifierReleased = false
 
-                handleOutputs(gestureController.triggerPressed(timestampMs: timestampMs))
-
-                return nil // Swallow the trigger key
+                return (gestureController.triggerPressed(timestampMs: timestampMs), true)
             } else if keyCode == 53 { // Escape
-                handleOutputs(gestureController.escapePressed())
+                return (gestureController.escapePressed(), false)
             } else {
                 // Gesture interruption
-                handleOutputs(gestureController.interrupted())
+                return (gestureController.interrupted(), false)
             }
         } else if type == .keyUp {
             if keyCode == triggerCode {
-                handleOutputs(chordTriggerKeyUpOutputs(timestampMs: timestampMs))
-                // Always swallow the trigger key's keyUp
-                return nil
+                guard triggerKeyIsPressed else {
+                    return ([], false)
+                }
+                let outputs = chordTriggerKeyUpOutputs(timestampMs: timestampMs)
+                return (outputs, true)
             }
         } else if type == .flagsChanged {
             // Release-any-part: if a required modifier is released while trigger key is held,
             // end dictation and mark that we already sent fnUp.
             if triggerKeyIsPressed && !chordModifierReleased {
-                let flags = event.flags.rawValue & Self.relevantModifierBits
                 if flags & requiredChordFlags != requiredChordFlags {
                     chordModifierReleased = true
-                    handleOutputs(gestureController.triggerReleased(timestampMs: timestampMs))
+                    return (gestureController.triggerReleased(timestampMs: timestampMs), false)
                 }
             }
         }
 
-        return Unmanaged.passUnretained(event)
+        return ([], false)
     }
 
     /// Notify state machine that cancel was triggered via UI (not Esc).

--- a/Sources/MacParakeet/Hotkey/HotkeyManager.swift
+++ b/Sources/MacParakeet/Hotkey/HotkeyManager.swift
@@ -492,7 +492,7 @@ public final class HotkeyManager {
             if keyCode == triggerCode {
                 // Check required modifiers are held
                 guard flags & requiredChordFlags == requiredChordFlags else {
-                    return ([], false)
+                    return (gestureController.interrupted(), false)
                 }
 
                 // Edge detection: ignore key-repeat

--- a/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
@@ -197,6 +197,58 @@ final class HotkeyManagerTests: XCTestCase {
         )
     }
 
+    func testChordTriggerKeyUpPassesThroughWhenChordWasNotHandled() {
+        let trigger = HotkeyTrigger.chord(modifiers: ["control", "shift"], keyCode: 15)
+        let manager = HotkeyManager(trigger: trigger)
+
+        let keyDown = manager.chordEventDecisionForTesting(
+            type: .keyDown,
+            keyCode: 15,
+            flags: 0,
+            timestampMs: 1_000
+        )
+        let keyUp = manager.chordEventDecisionForTesting(
+            type: .keyUp,
+            keyCode: 15,
+            flags: 0,
+            timestampMs: 1_050
+        )
+
+        XCTAssertEqual(keyDown.outputs, [])
+        XCTAssertFalse(keyDown.shouldSwallow)
+        XCTAssertEqual(keyUp.outputs, [])
+        XCTAssertFalse(keyUp.shouldSwallow)
+    }
+
+    func testChordTriggerKeyUpSwallowsAfterHandledKeyDown() {
+        let trigger = HotkeyTrigger.chord(modifiers: ["control", "shift"], keyCode: 15)
+        let manager = HotkeyManager(trigger: trigger)
+
+        let keyDown = manager.chordEventDecisionForTesting(
+            type: .keyDown,
+            keyCode: 15,
+            flags: trigger.chordEventFlags,
+            timestampMs: 1_000
+        )
+        let keyUp = manager.chordEventDecisionForTesting(
+            type: .keyUp,
+            keyCode: 15,
+            flags: trigger.chordEventFlags,
+            timestampMs: 1_050
+        )
+
+        XCTAssertEqual(
+            keyDown.outputs,
+            [
+                .scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs),
+                .scheduleHoldWindow(milliseconds: FnKeyStateMachine.defaultTapThresholdMs),
+            ]
+        )
+        XCTAssertTrue(keyDown.shouldSwallow)
+        XCTAssertEqual(keyUp.outputs, [.cancelStartupDebounce, .cancelHoldWindow, .showReadyForSecondTap])
+        XCTAssertTrue(keyUp.shouldSwallow)
+    }
+
     func testAdditionalModifierInterruptsBareFnBeforeStartup() {
         let manager = HotkeyManager(trigger: .fn)
 

--- a/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
@@ -249,6 +249,89 @@ final class HotkeyManagerTests: XCTestCase {
         XCTAssertTrue(keyUp.shouldSwallow)
     }
 
+    func testChordTriggerWithoutRequiredModifiersInterruptsPendingSecondTap() {
+        let trigger = HotkeyTrigger.chord(modifiers: ["control", "shift"], keyCode: 15)
+        let manager = HotkeyManager(trigger: trigger)
+
+        _ = manager.chordEventDecisionForTesting(
+            type: .keyDown,
+            keyCode: 15,
+            flags: trigger.chordEventFlags,
+            timestampMs: 1_000
+        )
+        _ = manager.chordEventDecisionForTesting(
+            type: .keyUp,
+            keyCode: 15,
+            flags: trigger.chordEventFlags,
+            timestampMs: 1_050
+        )
+
+        let bareKeyDown = manager.chordEventDecisionForTesting(
+            type: .keyDown,
+            keyCode: 15,
+            flags: 0,
+            timestampMs: 1_100
+        )
+        let bareKeyUp = manager.chordEventDecisionForTesting(
+            type: .keyUp,
+            keyCode: 15,
+            flags: 0,
+            timestampMs: 1_150
+        )
+        let nextChordKeyDown = manager.chordEventDecisionForTesting(
+            type: .keyDown,
+            keyCode: 15,
+            flags: trigger.chordEventFlags,
+            timestampMs: 1_200
+        )
+
+        XCTAssertEqual(bareKeyDown.outputs, [.cancelStartupDebounce, .cancelHoldWindow])
+        XCTAssertFalse(bareKeyDown.shouldSwallow)
+        XCTAssertEqual(bareKeyUp.outputs, [])
+        XCTAssertFalse(bareKeyUp.shouldSwallow)
+        XCTAssertEqual(
+            nextChordKeyDown.outputs,
+            [
+                .scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs),
+                .scheduleHoldWindow(milliseconds: FnKeyStateMachine.defaultTapThresholdMs),
+            ]
+        )
+        XCTAssertTrue(nextChordKeyDown.shouldSwallow)
+    }
+
+    func testChordTriggerKeyUpSwallowsAfterModifierReleasedFirst() {
+        let trigger = HotkeyTrigger.chord(modifiers: ["control", "shift"], keyCode: 15)
+        let manager = HotkeyManager(trigger: trigger)
+
+        let keyDown = manager.chordEventDecisionForTesting(
+            type: .keyDown,
+            keyCode: 15,
+            flags: trigger.chordEventFlags,
+            timestampMs: 1_000
+        )
+        let flagsChanged = manager.chordEventDecisionForTesting(
+            type: .flagsChanged,
+            keyCode: 0,
+            flags: 0,
+            timestampMs: 1_050
+        )
+        let keyUp = manager.chordEventDecisionForTesting(
+            type: .keyUp,
+            keyCode: 15,
+            flags: 0,
+            timestampMs: 1_100
+        )
+
+        XCTAssertTrue(keyDown.shouldSwallow)
+        XCTAssertEqual(
+            flagsChanged.outputs,
+            [.cancelStartupDebounce, .cancelHoldWindow, .showReadyForSecondTap]
+        )
+        XCTAssertFalse(flagsChanged.shouldSwallow)
+        XCTAssertEqual(keyUp.outputs, [])
+        XCTAssertTrue(keyUp.shouldSwallow)
+    }
+
     func testAdditionalModifierInterruptsBareFnBeforeStartup() {
         let manager = HotkeyManager(trigger: .fn)
 


### PR DESCRIPTION
Fixes #187.

## Summary
When a chord hotkey uses a normal character key, for example Ctrl+Shift+R, typing the bare key should pass both keyDown and keyUp through to the active app. This PR fixes the chord path so MacParakeet only swallows the trigger keyUp after it handled the matching chord keyDown.

The follow-up commit also resets any pending double-tap gesture when the bare trigger key is typed without the required modifiers, so a later chord press is treated as a fresh gesture.

## Tests
- Added coverage for bare trigger key down/up pass-through.
- Added coverage for pending double-tap interruption.
- Added coverage for modifier-released-before-trigger keyUp.
- `swift test --filter HotkeyManagerTests`
- `swift test` (2057 XCTest cases + 16 Swift Testing cases)
