### PR TITLE
Hide calendar auto-start behind AppFeatures.calendarEnabled flag

### DIFF
--- a/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
@@ -109,6 +109,10 @@ final class MeetingAutoStartCoordinator {
         // compile time. Keeps test runs and CI clean even if AppDelegate
         // forgot to gate.
         guard AppFeatures.meetingRecordingEnabled else { return }
+        // Calendar auto-start is independently gated. When the calendar flag
+        // is off we never poll, never request EventKit access, and never
+        // schedule countdown toasts — even if meeting recording is enabled.
+        guard AppFeatures.calendarEnabled else { return }
 
         scheduleCleanupTask()
         registerCalendarChangeObserver()

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -643,12 +643,16 @@ struct SettingsView: View {
                     meetingAutoSaveOptionsView
                 }
 
-                Divider()
+                if AppFeatures.calendarEnabled {
+                    Divider()
 
-                // Calendar section folded in from the legacy standalone
-                // `calendarCard`. Calendar is meeting-only — folding it
-                // here removes a card without losing any controls.
-                meetingCalendarSection
+                    // Calendar section folded in from the legacy standalone
+                    // `calendarCard`. Calendar is meeting-only — folding it
+                    // here removes a card without losing any controls.
+                    // Hidden in v0.6 pending E2E validation; gate at the
+                    // section boundary so the divider also disappears.
+                    meetingCalendarSection
+                }
             }
         }
     }

--- a/Sources/MacParakeetCore/AppFeatures.swift
+++ b/Sources/MacParakeetCore/AppFeatures.swift
@@ -9,4 +9,14 @@ public enum AppFeatures {
     /// hotkey, settings card, library filter, onboarding step, and the screen
     /// recording permission row. Data model, services, and tests remain intact.
     public static let meetingRecordingEnabled: Bool = true
+
+    /// Calendar auto-start (ADR-017). When `false`, all calendar entry points
+    /// are hidden: onboarding calendar step, Settings calendar subsection,
+    /// search-index calendar entry, and the auto-start coordinator never starts
+    /// polling. CalendarService, MeetingAutoStartCoordinator, models, and tests
+    /// remain intact — only the surfaces that would invoke them are gated.
+    /// Hidden in v0.6 pending hands-on E2E validation; flip to `true` in a
+    /// point release once the auto-start flow has been exercised against real
+    /// calendars.
+    public static let calendarEnabled: Bool = false
 }

--- a/Sources/MacParakeetViewModels/OnboardingViewModel.swift
+++ b/Sources/MacParakeetViewModels/OnboardingViewModel.swift
@@ -177,12 +177,16 @@ public final class OnboardingViewModel {
 
     /// Steps the user actually sees. Hidden steps (gated by `AppFeatures`) are
     /// filtered out so next/back/jump all walk the visible list — no flicker or
-    /// silent no-ops when flags are off.
+    /// silent no-ops when flags are off. Calendar requires BOTH meeting
+    /// recording and calendar to be enabled; gating the inner flag alone lets
+    /// us hide the (untested) calendar flow without dropping meeting recording.
     public static var visibleSteps: [Step] {
         Step.allCases.filter { step in
             switch step {
-            case .meetingRecording, .calendar:
+            case .meetingRecording:
                 return AppFeatures.meetingRecordingEnabled
+            case .calendar:
+                return AppFeatures.meetingRecordingEnabled && AppFeatures.calendarEnabled
             default:
                 return true
             }

--- a/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
+++ b/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
@@ -178,8 +178,8 @@ public enum SettingsSearchIndex {
             id: "meeting",
             tab: .modes,
             title: "Meeting Recording",
-            subtitle: "System audio + microphone capture, calendar auto-start.",
-            keywords: ["meeting", "system audio", "screen recording", "calendar", "auto start", "core audio taps"],
+            subtitle: "Dedicated controls for meeting audio capture.",
+            keywords: ["meeting", "system audio", "screen recording", "meeting capture", "core audio taps"],
             cardAnchor: "meeting"
         ),
         SettingsSearchEntry(
@@ -187,7 +187,7 @@ public enum SettingsSearchIndex {
             tab: .modes,
             title: "Calendar",
             subtitle: "in Meeting Recording",
-            keywords: ["calendar", "auto start", "reminders", "events", "ics"],
+            keywords: ["calendar", "auto start", "auto-start", "reminders", "events", "ics"],
             cardAnchor: "meeting"
         ),
 

--- a/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
+++ b/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
@@ -87,9 +87,22 @@ public enum SettingsSearchIndex {
         "system.permissions.screen"
     ]
 
+    /// Ids gated on `AppFeatures.calendarEnabled` independently of meeting
+    /// recording. Filtered when calendar is hidden so search doesn't land
+    /// on the (currently invisible) calendar subsection.
+    private static let calendarGatedIds: Set<String> = [
+        "meeting.calendar"
+    ]
+
     public static var entries: [SettingsSearchEntry] {
-        guard !AppFeatures.meetingRecordingEnabled else { return allEntries }
-        return allEntries.filter { !meetingGatedIds.contains($0.id) }
+        var result = allEntries
+        if !AppFeatures.meetingRecordingEnabled {
+            result = result.filter { !meetingGatedIds.contains($0.id) }
+        }
+        if !AppFeatures.calendarEnabled {
+            result = result.filter { !calendarGatedIds.contains($0.id) }
+        }
+        return result
     }
 
     /// Full unfiltered catalog. Order matters: result lists are produced

--- a/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
+++ b/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
@@ -94,7 +94,7 @@ public enum SettingsSearchIndex {
         "meeting.calendar"
     ]
 
-    public static var entries: [SettingsSearchEntry] {
+    public static let entries: [SettingsSearchEntry] = {
         var result = allEntries
         if !AppFeatures.meetingRecordingEnabled {
             result = result.filter { !meetingGatedIds.contains($0.id) }
@@ -103,7 +103,7 @@ public enum SettingsSearchIndex {
             result = result.filter { !calendarGatedIds.contains($0.id) }
         }
         return result
-    }
+    }()
 
     /// Full unfiltered catalog. Order matters: result lists are produced
     /// by `entries.filter(...)`, and tests assert that the filter is

--- a/Tests/MacParakeetTests/Calendar/MeetingAutoStartCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/Calendar/MeetingAutoStartCoordinatorTests.swift
@@ -116,7 +116,16 @@ final class MeetingAutoStartCoordinatorTests: XCTestCase {
         coordinator.stop()  // double-stop after initial
     }
 
-    func testSettingsChangeNotificationTriggersImmediateRePoll() async {
+    func testSettingsChangeNotificationTriggersImmediateRePoll() async throws {
+        // When `calendarEnabled` is gated off, `coordinator.start()` returns
+        // before registering the settings observer or scheduling polling, so
+        // the re-poll behavior under test cannot be exercised. Skip rather
+        // than assert false negatives.
+        try XCTSkipUnless(
+            AppFeatures.calendarEnabled,
+            "Calendar feature is gated off; coordinator.start() short-circuits"
+        )
+
         calendarService.stubPermissionStatus = .granted
         calendarService.stubEvents = [event(startsIn: 5 * 60)]
         seedSettings(mode: .notify, reminderMinutes: 5)

--- a/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
@@ -159,9 +159,11 @@ final class OnboardingViewModelTests: XCTestCase {
 
         XCTAssertTrue(vm.meetingRecordingSkipped)
         XCTAssertTrue(defaults.bool(forKey: OnboardingViewModel.meetingRecordingSkippedKey))
-        // Skip advances to the next visible step — `.calendar` (only present
-        // when meeting recording is enabled, which it is in tests).
-        XCTAssertEqual(vm.step, .calendar)
+        // Skip advances to the next *visible* step. With `calendarEnabled` on
+        // that's `.calendar`; with it off the calendar step is filtered out
+        // and the flow jumps straight to `.hotkey`.
+        let expected: OnboardingViewModel.Step = AppFeatures.calendarEnabled ? .calendar : .hotkey
+        XCTAssertEqual(vm.step, expected)
     }
 
     func testResetOnboardingClearsMeetingRecordingSkippedFlag() {

--- a/Tests/MacParakeetTests/ViewModels/SettingsSearchIndexTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsSearchIndexTests.swift
@@ -42,9 +42,22 @@ final class SettingsSearchIndexTests: XCTestCase {
     }
 
     func testSubtitleMatches() {
-        // "calendar auto-start" appears in the meeting card subtitle.
-        let results = SettingsSearchIndex.matches("auto-start")
+        let results = SettingsSearchIndex.matches("meeting audio")
         XCTAssertTrue(results.contains(where: { $0.id == "meeting" }))
+    }
+
+    func testCalendarQueriesHonorCalendarFeatureFlag() {
+        for query in ["calendar", "auto-start", "auto start", "reminders"] {
+            let results = SettingsSearchIndex.matches(query)
+            let ids = Set(results.map(\.id))
+
+            if AppFeatures.calendarEnabled {
+                XCTAssertTrue(ids.contains("meeting.calendar"), "Query \(query) should find the calendar row")
+            } else {
+                XCTAssertFalse(ids.contains("meeting"), "Query \(query) should not reveal the hidden meeting card")
+                XCTAssertFalse(ids.contains("meeting.calendar"), "Query \(query) should not reveal the hidden calendar row")
+            }
+        }
     }
 
     func testRowEntryHasBreadcrumbSubtitle() {

--- a/Tests/MacParakeetTests/ViewModels/SettingsSearchIndexTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsSearchIndexTests.swift
@@ -81,19 +81,25 @@ final class SettingsSearchIndexTests: XCTestCase {
     }
 
     func testMeetingEntriesGatedOnFeatureFlag() {
-        // The flag is a compile-time constant, so only one arm runs in
+        // The flags are compile-time constants, so only one arm runs in
         // any given build. Asserting both directions documents the
         // contract and forces a deliberate update if the gate semantics
         // change. Ids: card + sub-card + cross-tab permission row.
         let meetingGatedIds: Set<String> = ["meeting", "meeting.calendar", "system.permissions.screen"]
+        let calendarGatedIds: Set<String> = ["meeting.calendar"]
         let presentIds = Set(SettingsSearchIndex.entries.map(\.id))
         let intersection = presentIds.intersection(meetingGatedIds)
 
         if AppFeatures.meetingRecordingEnabled {
+            // Calendar entry drops out independently when calendarEnabled
+            // is off, even though meeting recording is on.
+            let expected = AppFeatures.calendarEnabled
+                ? meetingGatedIds
+                : meetingGatedIds.subtracting(calendarGatedIds)
             XCTAssertEqual(
                 intersection,
-                meetingGatedIds,
-                "All meeting-gated entries should be present when the flag is on"
+                expected,
+                "Meeting-gated entries should match the active flag combination"
             )
         } else {
             XCTAssertTrue(


### PR DESCRIPTION
## TL;DR

Hides the calendar auto-start feature (ADR-017) for v0.6 by adding a single compile-time flag. Code stays intact; surfaces disappear. Will be re-enabled in a point release once validated end-to-end against real calendars.

## Why

Calendar auto-start (Phases 1+2+3, shipped via #132 + #135) hasn't been exercised hands-on. Shipping an untested onboarding flow to every new user is exactly how v0.4.22 stranded ~23 users for ~24h. v0.6 graduates Meeting Recording from Labs — calendar isn't ready to ride along.

## Gate Topology

```
AppFeatures.calendarEnabled = false
        │
        ├──► OnboardingViewModel.visibleSteps
        │       └─ filters .calendar out of step sequence
        │          (goNext walks straight from .meetingRecording to .hotkey)
        │
        ├──► SettingsView.meetingCalendarSection
        │       └─ gated, including its Divider
        │
        ├──► SettingsSearchIndex.entries
        │       └─ "meeting.calendar" id filtered out
        │
        └──► MeetingAutoStartCoordinator.start()
                └─ guard returns early; no polling, no observers,
                   no EventKit access, no toast subscriptions
```

## What Stays Intact

- `CalendarService` — initialized lazily; never invoked when gated
- `MeetingAutoStartCoordinator` — class instantiates; `start()` no-ops
- `MeetingMonitor`, `MeetingCountdownToastViewModel`, all calendar models
- All calendar tests (one uses `XCTSkipUnless` for the start-gated path)
- ADR-017 stays in `spec/adr/` — historical record of the design

## Test Updates

Three tests asserted the un-gated behavior and now branch on the flag:
- `OnboardingViewModelTests.testSkipMeetingRecordingStepSetsFlagAndAdvances` — next visible step is `.calendar` or `.hotkey` depending on flag
- `SettingsSearchIndexTests.testMeetingEntriesGatedOnFeatureFlag` — expected ID set adjusts to active flag combination
- `MeetingAutoStartCoordinatorTests.testSettingsChangeNotificationTriggersImmediateRePoll` — `XCTSkipUnless(calendarEnabled)` since `start()` short-circuits

## How to Re-Enable

Flip the literal in one place:

```swift
public static let calendarEnabled: Bool = true  // was false
```

That's the entire change. No rollback migrations, no UserDefaults cleanup, no schema changes.

## Test Plan

- [x] `swift test` — 2057 tests pass, 1 correctly skipped (`XCTSkipUnless`)
- [ ] Manual verification on a fresh install: onboarding goes Microphone → Accessibility → Meeting Recording → Hotkey → Speech Model → Done (no calendar step)
- [ ] Manual verification: Settings → Meeting Recording card has no calendar subsection
- [ ] Manual verification: Settings search for "calendar" returns no result pointing to Meeting Recording

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar functionality is now conditionally available and can be controlled via feature configuration. When disabled, calendar options in settings and onboarding are hidden from the user interface.

* **Tests**
  * Updated test coverage to validate calendar feature gating across settings, onboarding, and search functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->