### PR TITLE
Fix P1 JSON failures and meeting engine pinning

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -89,6 +89,11 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
   (or `--json` structured form) so a local coding agent can generate valid
   bundles. Bundle format is versioned (`macparakeet.vocabulary` v1).
 
+### Fixed
+
+- `transcribe --format json` and `export --format json --stdout` now emit the
+  documented JSON failure envelope for post-parse failures.
+
 ## [1.4.0] -- 2026-04-28
 
 ### Added

--- a/Sources/CLI/Commands/CLIHelpers.swift
+++ b/Sources/CLI/Commands/CLIHelpers.swift
@@ -285,6 +285,14 @@ enum CLIErrorType {
         }
         if error is CLILookupError { return lookup }
         if error is CLIInputError { return inputEmpty }
+        if let cli = error as? CLIError {
+            switch cli {
+            case .fileNotFound:
+                return inputMissing
+            case .unsupportedFormat:
+                return validation
+            }
+        }
         // ArgumentParser surfaces `validate()` failures as `ValidationError`.
         // The taxonomy has carried the `validation` value since 1.2.0; map
         // ValidationError to it so downstream agents can branch on user

--- a/Sources/CLI/Commands/ExportCommand.swift
+++ b/Sources/CLI/Commands/ExportCommand.swift
@@ -43,24 +43,26 @@ struct ExportCommand: AsyncParsableCommand {
     var database: String?
 
     func run() async throws {
-        try AppPaths.ensureDirectories()
-        let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
-        let repo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
+        try await emitJSONOrRethrow(json: stdout && format == .json) {
+            try AppPaths.ensureDirectories()
+            let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
+            let repo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
 
-        let transcription = try findTranscription(id: id, repo: repo)
-        let exportService = await ExportService()
+            let transcription = try findTranscription(id: id, repo: repo)
+            let exportService = await ExportService()
 
-        if stdout {
-            let content = await formatContent(transcription: transcription, exportService: exportService)
-            print(content)
-        } else {
-            let outputURL = resolveOutputURL(transcription: transcription)
-            try FileManager.default.createDirectory(
-                at: outputURL.deletingLastPathComponent(),
-                withIntermediateDirectories: true
-            )
-            try await writeExport(transcription: transcription, exportService: exportService, url: outputURL)
-            print("Exported to \(outputURL.path)")
+            if stdout {
+                let content = await formatContent(transcription: transcription, exportService: exportService)
+                print(content)
+            } else {
+                let outputURL = resolveOutputURL(transcription: transcription)
+                try FileManager.default.createDirectory(
+                    at: outputURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try await writeExport(transcription: transcription, exportService: exportService, url: outputURL)
+                print("Exported to \(outputURL.path)")
+            }
         }
     }
 

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -229,7 +229,9 @@ struct TranscribeCommand: AsyncParsableCommand {
             exitCode: exitCode,
             errorType: errorType
         )
-        try runResult.get()
+        try emitJSONOrRethrow(json: format == .json) {
+            try runResult.get()
+        }
     }
 
     private func makeEntitlementsService() -> EntitlementsService {

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -451,6 +451,9 @@ final class MeetingRecordingFlowCoordinator {
                     self.completedTranscription = transcription
                     self.sendEvent(.transcriptionCompleted(generation: gen, transcriptionID: transcription.id))
                 } catch {
+                    if let stoppedOutput {
+                        await meetingRecordingService.finishTranscriptionAttempt(for: stoppedOutput)
+                    }
                     Telemetry.send(.meetingRecordingFailed(
                         errorType: TelemetryErrorClassifier.classify(error),
                         errorDetail: TelemetryErrorClassifier.errorDetail(error)

--- a/Sources/MacParakeetCore/STT/STTScheduler.swift
+++ b/Sources/MacParakeetCore/STT/STTScheduler.swift
@@ -52,6 +52,7 @@ public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEn
     private var cancelledJobIDs: Set<UUID> = []
     private var acceptsNewJobs = true
     private var activeSpeechEngineSessionIDs: Set<UUID> = []
+    private var speechEngineSwitchTask: Task<Void, Error>?
 
     /// - Parameter meetingLiveChunkBacklogLimit: Maximum pending live-preview chunks before the
     ///   oldest is dropped. 120 ≈ 4 minutes of dual-source 5-second chunks emitted every ~4
@@ -160,21 +161,36 @@ public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEn
     }
 
     public func setSpeechEngine(_ preference: SpeechEnginePreference) async throws {
-        guard acceptsNewJobs, activeSpeechEngineSessionIDs.isEmpty, !hasQueuedOrRunningJobs else {
+        guard acceptsNewJobs,
+              activeSpeechEngineSessionIDs.isEmpty,
+              !hasQueuedOrRunningJobs,
+              speechEngineSwitchTask == nil else {
             throw STTError.engineBusy
         }
 
         acceptsNewJobs = false
-        do {
+        let switchTask = Task {
             try await runtime.setSpeechEngine(preference)
+        }
+        speechEngineSwitchTask = switchTask
+        defer {
+            speechEngineSwitchTask = nil
             acceptsNewJobs = true
-        } catch {
-            acceptsNewJobs = true
-            throw error
+        }
+        try await withTaskCancellationHandler {
+            try await switchTask.value
+        } onCancel: {
+            switchTask.cancel()
         }
     }
 
     public func beginSpeechEngineSession() async -> SpeechEngineLease {
+        if let speechEngineSwitchTask {
+            let result = await speechEngineSwitchTask.result
+            if case .failure(let error) = result {
+                logger.warning("Proceeding with speech engine session after failed engine switch: \(error.localizedDescription, privacy: .public)")
+            }
+        }
         let lease = SpeechEngineLease(selection: await runtime.currentSpeechEngineSelection())
         activeSpeechEngineSessionIDs.insert(lease.id)
         return lease

--- a/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecordingService.swift
@@ -24,6 +24,11 @@ public protocol MeetingRecordingServiceProtocol: Sendable {
     func startRecording(title: String?, sourceMode: MeetingAudioSourceMode?) async throws
     func stopRecording() async throws -> MeetingRecordingOutput
     func completeTranscription(for recording: MeetingRecordingOutput) async
+    /// Release any retained speech-engine lease for a stopped recording after
+    /// the final transcription attempt has ended. Use `completeTranscription`
+    /// on success so the recovery lock is deleted; call this directly on failure
+    /// to leave the lock available for retry.
+    func finishTranscriptionAttempt(for recording: MeetingRecordingOutput) async
     func cancelRecording() async
     /// Persist the user's in-flight notepad text to the recording's lock file
     /// without changing the recording state. Called by the notes view model on
@@ -95,6 +100,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     /// `cleanupState` / `cancelRecording`.
     private var currentLockFile: MeetingRecordingLockFile?
     private var currentSpeechEngineLease: SpeechEngineLease?
+    private var stoppedSpeechEngineLeases: [UUID: SpeechEngineLease] = [:]
     /// Keeps replacement starts out while `audioCaptureService.start()` is still
     /// unwinding after cancellation. `currentSession` may already be nil then.
     private var startingSessionID: UUID?
@@ -432,7 +438,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         )
 
         await liveChunkTranscriber.finishSession()
-        await releaseSpeechEngineLease()
+        retainSpeechEngineLeaseForTranscription(sessionID: session.id)
         cleanupState()
         logger.info("Meeting recording finalized: \(session.id.uuidString, privacy: .public)")
         AudioCaptureDiagnostics.append(
@@ -447,6 +453,11 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         } catch {
             logger.error("meeting_recording_lock_cleanup_failed session=\(recording.sessionID.uuidString, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
         }
+        await finishTranscriptionAttempt(for: recording)
+    }
+
+    public func finishTranscriptionAttempt(for recording: MeetingRecordingOutput) async {
+        await releaseStoppedSpeechEngineLease(sessionID: recording.sessionID)
     }
 
     public func updateNotes(_ notes: String) async {
@@ -511,6 +522,17 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     private func releaseSpeechEngineLease() async {
         guard let lease = currentSpeechEngineLease else { return }
         currentSpeechEngineLease = nil
+        await speechEngineSessionManager?.endSpeechEngineSession(lease)
+    }
+
+    private func retainSpeechEngineLeaseForTranscription(sessionID: UUID) {
+        guard let lease = currentSpeechEngineLease else { return }
+        currentSpeechEngineLease = nil
+        stoppedSpeechEngineLeases[sessionID] = lease
+    }
+
+    private func releaseStoppedSpeechEngineLease(sessionID: UUID) async {
+        guard let lease = stoppedSpeechEngineLeases.removeValue(forKey: sessionID) else { return }
         await speechEngineSessionManager?.endSpeechEngineSession(lease)
     }
 

--- a/Tests/CLITests/ExportCommandTests.swift
+++ b/Tests/CLITests/ExportCommandTests.swift
@@ -1,3 +1,4 @@
+import ArgumentParser
 import XCTest
 @testable import CLI
 @testable import MacParakeetCore
@@ -50,6 +51,35 @@ final class ExportCommandTests: XCTestCase {
         let url = command.resolveOutputURL(transcription: transcription)
 
         XCTAssertEqual(url.lastPathComponent, "folder Meeting notes.md")
+    }
+
+    func testJSONStdoutEmitsFailureEnvelopeForLookupMiss() async throws {
+        let dbURL = temporaryDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: dbURL) }
+        let command = try ExportCommand.parse([
+            "missing-id",
+            "--format", "json",
+            "--stdout",
+            "--database", dbURL.path,
+        ])
+
+        var thrownError: Error?
+        let output = try await captureStandardOutput {
+            do {
+                try await command.run()
+            } catch {
+                thrownError = error
+            }
+        }
+
+        let exit = try XCTUnwrap(thrownError as? ExitCode)
+        XCTAssertEqual(exit, .failure)
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any]
+        )
+        XCTAssertEqual(object["ok"] as? Bool, false)
+        XCTAssertEqual(object["errorType"] as? String, "lookup")
+        XCTAssertTrue((object["error"] as? String)?.contains("No transcription matching") == true)
     }
 
     @MainActor func testExportToTxtWritesFile() throws {
@@ -162,5 +192,10 @@ final class ExportCommandTests: XCTestCase {
         let decoded = try decoder.decode(Transcription.self, from: data)
         XCTAssertEqual(decoded.fileName, "json-test.mp3")
         XCTAssertEqual(decoded.rawTranscript, "JSON content")
+    }
+
+    private func temporaryDatabaseURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("macparakeet-cli-\(UUID().uuidString).db")
     }
 }

--- a/Tests/CLITests/StandardOutputCapture.swift
+++ b/Tests/CLITests/StandardOutputCapture.swift
@@ -38,3 +38,42 @@ func captureStandardOutput(_ body: () throws -> Void) throws -> String {
     }
     return String(decoding: data, as: UTF8.self)
 }
+
+/// Async variant for `AsyncParsableCommand.run()` tests.
+/// Keep usage focused: stdout is process-global, so these tests must not run
+/// bodies that concurrently print unrelated output.
+func captureStandardOutput(_ body: () async throws -> Void) async throws -> String {
+    let pipe = Pipe()
+    let originalStdout = dup(STDOUT_FILENO)
+    guard originalStdout >= 0 else {
+        throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+    }
+
+    fflush(stdout)
+    guard dup2(pipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO) >= 0 else {
+        close(originalStdout)
+        throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+    }
+
+    var bodyError: Error?
+    do {
+        try await body()
+    } catch {
+        bodyError = error
+    }
+
+    fflush(stdout)
+    guard dup2(originalStdout, STDOUT_FILENO) >= 0 else {
+        let restoreErrno = errno
+        close(originalStdout)
+        throw NSError(domain: NSPOSIXErrorDomain, code: Int(restoreErrno))
+    }
+    close(originalStdout)
+    pipe.fileHandleForWriting.closeFile()
+
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    if let bodyError {
+        throw bodyError
+    }
+    return String(decoding: data, as: UTF8.self)
+}

--- a/Tests/CLITests/TranscribeCommandTests.swift
+++ b/Tests/CLITests/TranscribeCommandTests.swift
@@ -1,3 +1,4 @@
+import ArgumentParser
 import XCTest
 @testable import CLI
 @testable import MacParakeetCore
@@ -46,5 +47,40 @@ final class TranscribeCommandTests: XCTestCase {
             url.path,
             FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("sample.wav").path
         )
+    }
+
+    func testJSONFormatEmitsFailureEnvelopeForMissingFile() async throws {
+        let dbURL = temporaryDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: dbURL) }
+        let missingURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macparakeet-missing-\(UUID().uuidString).wav")
+        let command = try TranscribeCommand.parse([
+            missingURL.path,
+            "--format", "json",
+            "--database", dbURL.path,
+        ])
+
+        var thrownError: Error?
+        let output = try await captureStandardOutput {
+            do {
+                try await command.run()
+            } catch {
+                thrownError = error
+            }
+        }
+
+        let exit = try XCTUnwrap(thrownError as? ExitCode)
+        XCTAssertEqual(exit, .failure)
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any]
+        )
+        XCTAssertEqual(object["ok"] as? Bool, false)
+        XCTAssertEqual(object["errorType"] as? String, "input_missing")
+        XCTAssertTrue((object["error"] as? String)?.contains("File not found") == true)
+    }
+
+    private func temporaryDatabaseURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("macparakeet-cli-\(UUID().uuidString).db")
     }
 }

--- a/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
+++ b/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
@@ -170,6 +170,52 @@ final class STTSchedulerTests: XCTestCase {
         XCTAssertEqual(count, 1)
     }
 
+    func testSpeechEngineSessionWaitsForInFlightEngineSwitch() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.blockNextSpeechEngineSwitch()
+        let scheduler = STTScheduler(runtimeProvider: runtime)
+
+        let switchTask = Task {
+            try await scheduler.setSpeechEngine(.whisper)
+        }
+        try await waitForSpeechEngineSwitch(runtime: runtime, count: 1)
+
+        let leaseTask = Task {
+            await scheduler.beginSpeechEngineSession()
+        }
+        try await Task.sleep(for: .milliseconds(50))
+        await runtime.releaseSpeechEngineSwitch()
+
+        let lease = await leaseTask.value
+        XCTAssertEqual(lease.selection, SpeechEngineSelection(engine: .whisper))
+
+        await scheduler.endSpeechEngineSession(lease)
+        _ = try await switchTask.value
+    }
+
+    func testCancelledSpeechEngineSwitchRestoresSchedulerAvailability() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.blockNextSpeechEngineSwitch()
+        let scheduler = STTScheduler(runtimeProvider: runtime)
+
+        let switchTask = Task {
+            try await scheduler.setSpeechEngine(.whisper)
+        }
+        try await waitForSpeechEngineSwitch(runtime: runtime, count: 1)
+
+        switchTask.cancel()
+        do {
+            try await value(switchTask)
+            XCTFail("Expected cancelled engine switch to throw")
+        } catch is CancellationError {
+            // Expected.
+        }
+
+        try await scheduler.setSpeechEngine(.parakeet)
+        let count = await runtime.setSpeechEngineCallCount
+        XCTAssertEqual(count, 2)
+    }
+
     func testSpeechEngineSessionLeaseUsesRuntimeSelection() async {
         let runtime = MockSTTRuntime()
         await runtime.setCurrentSelection(SpeechEngineSelection(engine: .whisper, language: "KO"))
@@ -419,6 +465,42 @@ final class STTSchedulerTests: XCTestCase {
             try await Task.sleep(for: .milliseconds(20))
         }
     }
+
+    private func waitForSpeechEngineSwitch(
+        runtime: MockSTTRuntime,
+        count: Int,
+        timeout: Duration = .seconds(2)
+    ) async throws {
+        let start = ContinuousClock.now
+        while await runtime.setSpeechEngineCallCount < count {
+            if start.duration(to: .now) > timeout {
+                XCTFail("Timed out waiting for \(count) speech engine switches")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+    }
+
+    private func value<T>(
+        _ task: Task<T, any Error>,
+        timeout: Duration = .seconds(1)
+    ) async throws -> T {
+        try await withThrowingTaskGroup(of: T.self) { group in
+            defer { group.cancelAll() }
+            group.addTask {
+                try await task.value
+            }
+            group.addTask {
+                try await Task.sleep(for: timeout)
+                throw STTSchedulerTestError.timeout
+            }
+            return try await group.next()!
+        }
+    }
+}
+
+private enum STTSchedulerTestError: Error {
+    case timeout
 }
 
 private actor MockSTTRuntime: STTRuntimeProtocol {
@@ -435,6 +517,8 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
     private(set) var setSpeechEngineCallCount = 0
     private var selection = SpeechEngineSelection(engine: .parakeet)
     private var ready = false
+    private var shouldBlockNextSpeechEngineSwitch = false
+    private var speechEngineSwitchContinuation: CheckedContinuation<Void, Never>?
 
     func transcribe(
         audioPath: String,
@@ -507,6 +591,19 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
 
     func setSpeechEngine(_ preference: SpeechEnginePreference) async throws {
         setSpeechEngineCallCount += 1
+        if shouldBlockNextSpeechEngineSwitch {
+            shouldBlockNextSpeechEngineSwitch = false
+            await withTaskCancellationHandler {
+                await withCheckedContinuation { continuation in
+                    speechEngineSwitchContinuation = continuation
+                }
+            } onCancel: {
+                Task {
+                    await self.releaseSpeechEngineSwitch()
+                }
+            }
+            try Task.checkCancellation()
+        }
         selection = SpeechEngineSelection(engine: preference)
         ready = false
     }
@@ -517,6 +614,15 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
 
     func setCurrentSelection(_ selection: SpeechEngineSelection) {
         self.selection = selection
+    }
+
+    func blockNextSpeechEngineSwitch() {
+        shouldBlockNextSpeechEngineSwitch = true
+    }
+
+    func releaseSpeechEngineSwitch() {
+        speechEngineSwitchContinuation?.resume()
+        speechEngineSwitchContinuation = nil
     }
 
     func block(path: String) {

--- a/Tests/MacParakeetTests/Services/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecordingServiceTests.swift
@@ -262,7 +262,42 @@ final class MeetingRecordingServiceTests: XCTestCase {
         XCTAssertEqual(metadata.speechEngine, SpeechEngineSelection(engine: .whisper, language: "ko"))
         XCTAssertEqual(lockStore.writes.last?.file.speechEngine, SpeechEngineSelection(engine: .whisper, language: "ko"))
         let activeLeaseCountAfterStop = await sttClient.activeLeaseCount
-        XCTAssertEqual(activeLeaseCountAfterStop, 0)
+        XCTAssertEqual(activeLeaseCountAfterStop, 1)
+
+        await service.completeTranscription(for: output)
+        let activeLeaseCountAfterCompletion = await sttClient.activeLeaseCount
+        XCTAssertEqual(activeLeaseCountAfterCompletion, 0)
+    }
+
+    func testFailedTranscriptionAttemptReleasesRetainedSpeechEngineLeaseWithoutDeletingLock() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let lockStore = RecordingLockFileStore()
+        let speechEngine = SpeechEngineSelection(engine: .whisper, language: "KO")
+        let sttClient = LeasingMeetingSTTClient(selection: speechEngine)
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: MockMeetingAudioFileConverter(),
+            sttTranscriber: sttClient,
+            lockFileStore: lockStore
+        )
+
+        try await service.startRecording()
+        let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.25))
+        await captureService.yield(.microphoneBuffer(
+            microphoneBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
+        ))
+
+        let output = try await service.stopRecording()
+        defer { try? FileManager.default.removeItem(at: output.folderURL) }
+
+        let activeLeaseCountAfterStop = await sttClient.activeLeaseCount
+        XCTAssertEqual(activeLeaseCountAfterStop, 1)
+
+        await service.finishTranscriptionAttempt(for: output)
+        let activeLeaseCountAfterFailure = await sttClient.activeLeaseCount
+        XCTAssertEqual(activeLeaseCountAfterFailure, 0)
+        XCTAssertTrue(lockStore.deletes.isEmpty)
     }
 
     func testLivePreviewUsesCapturedSpeechEngineSelection() async throws {


### PR DESCRIPTION
## Summary
This fixes two P1 audit issues:
- CLI JSON mode now stays machine-readable on post-parse failures for `transcribe --format json` and `export --format json --stdout`.
- Meeting final transcription now stays pinned to the STT engine captured when recording started, even if settings change while finishing.
- Adds focused regressions plus a CLI changelog note.

## Behavior
```text
CLI JSON failure:
  fail after parse
        |
        v
  JSON error envelope on stdout
        |
        v
  nonzero exit code

Meeting engine pinning:
  start recording -> capture engine lease
        |
        v
  stop recording -> retain lease for final transcription
        |
        +--> success: delete lock, release lease
        |
        +--> failure: keep recovery lock, release lease
```

## Fresh-Eye Review
- Reuses the existing JSON envelope helper; no output schema change.
- Scheduler change is scoped to one in-flight engine-switch task.
- Meeting cleanup keeps recovery behavior intact: failure releases the engine pin but leaves retry data in place.

## Verification
- Focused regressions cover the CLI envelopes, scheduler race, and meeting lease lifecycle.
- `swift test` passed locally: 2061 XCTest tests + 16 Swift Testing tests.