### PR TITLE
Add AI setup UX foundation

### DIFF
--- a/Sources/MacParakeet/Views/MeetingRecording/LiveAskPaneView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/LiveAskPaneView.swift
@@ -172,11 +172,11 @@ struct LiveAskPaneView: View {
                 .padding(.bottom, 4)
                 .accessibilityHidden(true)
 
-            Text("Ask needs an AI provider")
+            Text("Turn on AI for meeting Ask")
                 .font(DesignSystem.Typography.body.weight(.medium))
                 .foregroundStyle(DesignSystem.Colors.textSecondary)
 
-            Text("Add one in Settings → AI Providers. Recording works without it.")
+            Text("MacParakeet can use a local AI app, your API key, or a command-line AI tool. Recording works without this.")
                 .font(DesignSystem.Typography.caption)
                 .foregroundStyle(DesignSystem.Colors.textTertiary)
                 .multilineTextAlignment(.center)

--- a/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
@@ -222,14 +222,14 @@ struct LLMSettingsView: View {
             localAIAppRow(
                 provider: .lmstudio,
                 subtitle: "Recommended. Start LM Studio's local server, then refresh models.",
-                buttonTitle: "Use LM Studio",
+                buttonTitle: "Choose LM Studio",
                 badge: "Recommended"
             )
 
             localAIAppRow(
                 provider: .ollama,
                 subtitle: "Also works. Start Ollama or run `ollama serve`, then refresh models.",
-                buttonTitle: "Use Ollama",
+                buttonTitle: "Choose Ollama",
                 badge: nil
             )
         }

--- a/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
@@ -7,28 +7,28 @@ struct LLMSettingsView: View {
 
     @State private var showAdvanced = false
 
+    private static let providerOrder: [LLMProviderID] = [
+        .lmstudio,
+        .ollama,
+        .anthropic,
+        .openai,
+        .gemini,
+        .openrouter,
+        .openaiCompatible,
+        .localCLI,
+    ]
+
     var body: some View {
         VStack(spacing: DesignSystem.Spacing.md) {
-            // Provider picker
-            HStack(alignment: .top) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Provider")
-                        .font(DesignSystem.Typography.body)
-                    Text("Choose your AI provider for summaries and chat.")
-                        .font(DesignSystem.Typography.caption)
-                        .foregroundStyle(.secondary)
-                }
-                Spacer(minLength: DesignSystem.Spacing.md)
-                Picker("Provider", selection: $viewModel.selectedProviderID) {
-                    Text("None").tag(LLMProviderID?.none)
-                    ForEach(LLMProviderID.allCases, id: \.self) { provider in
-                        Text(provider.displayName).tag(Optional(provider))
-                    }
-                }
-                .labelsHidden()
-                .pickerStyle(.menu)
-                .frame(width: 190)
-            }
+            setupStatusSection
+
+            Divider()
+
+            localAIAppSection
+
+            Divider()
+
+            selectedAIOptionSection
 
             if viewModel.selectedProviderID != nil {
                 Divider()
@@ -174,6 +174,240 @@ struct LLMSettingsView: View {
     }
 
     @ViewBuilder
+    private var setupStatusSection: some View {
+        let status = viewModel.setupStatus
+        HStack(alignment: .top, spacing: DesignSystem.Spacing.sm) {
+            Image(systemName: setupStatusIcon(for: status))
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(setupStatusTint(for: status))
+                .frame(width: 22, height: 22)
+                .background(
+                    Circle().fill(setupStatusTint(for: status).opacity(0.12))
+                )
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text("AI for summaries and chat")
+                    .font(DesignSystem.Typography.body.weight(.semibold))
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+                Text(setupStatusCopy(for: status))
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: DesignSystem.Spacing.md)
+
+            if case .ready = status {
+                Text("Ready")
+                    .font(DesignSystem.Typography.caption.weight(.medium))
+                    .foregroundStyle(DesignSystem.Colors.successGreen)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Capsule().fill(DesignSystem.Colors.successGreen.opacity(0.10)))
+            }
+        }
+    }
+
+    private var localAIAppSection: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Use a local AI app")
+                    .font(DesignSystem.Typography.body)
+                Text("Run AI on this Mac. Transcript text stays on this Mac.")
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            localAIAppRow(
+                provider: .lmstudio,
+                subtitle: "Recommended. Start LM Studio's local server, then refresh models.",
+                buttonTitle: "Use LM Studio",
+                badge: "Recommended"
+            )
+
+            localAIAppRow(
+                provider: .ollama,
+                subtitle: "Also works. Start Ollama or run `ollama serve`, then refresh models.",
+                buttonTitle: "Use Ollama",
+                badge: nil
+            )
+        }
+    }
+
+    private var selectedAIOptionSection: some View {
+        VStack(spacing: DesignSystem.Spacing.md) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Current choice")
+                        .font(DesignSystem.Typography.body)
+                    Text("Choose a local app, an API key, or a command-line AI tool.")
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: DesignSystem.Spacing.md)
+                Picker("AI option", selection: $viewModel.selectedProviderID) {
+                    Text("None").tag(LLMProviderID?.none)
+                    ForEach(Self.providerOrder, id: \.self) { provider in
+                        Text(provider.displayName).tag(Optional(provider))
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.menu)
+                .frame(width: 190)
+            }
+
+            if viewModel.selectedProviderID == nil {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("API keys and command-line tools are still available from this menu.")
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(.secondary)
+                    Text("Dictation, transcription, and meeting recording work without AI setup.")
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    private func localAIAppRow(
+        provider: LLMProviderID,
+        subtitle: String,
+        buttonTitle: String,
+        badge: String?
+    ) -> some View {
+        let isSelected = viewModel.selectedProviderID == provider
+        return HStack(alignment: .top, spacing: DesignSystem.Spacing.sm) {
+            Image(systemName: provider == .lmstudio ? "desktopcomputer" : "terminal")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(isSelected ? DesignSystem.Colors.accent : DesignSystem.Colors.textTertiary)
+                .frame(width: 22, height: 22)
+                .background(
+                    Circle().fill(
+                        isSelected
+                            ? DesignSystem.Colors.accent.opacity(0.10)
+                            : DesignSystem.Colors.surfaceElevated
+                    )
+                )
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 6) {
+                    Text(provider.displayName)
+                        .font(DesignSystem.Typography.bodySmall.weight(.medium))
+                    if let badge {
+                        Text(badge)
+                            .font(DesignSystem.Typography.micro.weight(.semibold))
+                            .foregroundStyle(DesignSystem.Colors.successGreen)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(Capsule().fill(DesignSystem.Colors.successGreen.opacity(0.10)))
+                    }
+                }
+                Text(subtitle)
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                if isSelected {
+                    Text(localAIAppStatusText(for: provider))
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(localAIAppStatusTint)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            Spacer(minLength: DesignSystem.Spacing.sm)
+
+            VStack(alignment: .trailing, spacing: 6) {
+                Button(isSelected ? "Selected" : buttonTitle) {
+                    viewModel.chooseLocalAIApp(provider)
+                }
+                .buttonStyle(.bordered)
+                .tint(DesignSystem.Colors.accent)
+                .disabled(isSelected)
+
+                if isSelected {
+                    Button(viewModel.isLoadingModelList ? "Refreshing..." : "Refresh models") {
+                        viewModel.refreshAvailableModels()
+                    }
+                    .buttonStyle(.plain)
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(.secondary)
+                    .disabled(viewModel.isLoadingModelList)
+                }
+            }
+        }
+        .padding(DesignSystem.Spacing.sm)
+        .background(
+            RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
+                .fill(isSelected ? DesignSystem.Colors.accentLight : DesignSystem.Colors.surfaceElevated.opacity(0.55))
+        )
+    }
+
+    private func setupStatusIcon(for status: LLMSettingsViewModel.AISetupStatus) -> String {
+        switch status {
+        case .setUpNeeded:
+            return "sparkles"
+        case .ready:
+            return "checkmark"
+        case .cannotConnect:
+            return "exclamationmark"
+        }
+    }
+
+    private func setupStatusTint(for status: LLMSettingsViewModel.AISetupStatus) -> Color {
+        switch status {
+        case .setUpNeeded:
+            return DesignSystem.Colors.accent
+        case .ready:
+            return DesignSystem.Colors.successGreen
+        case .cannotConnect:
+            return DesignSystem.Colors.warningAmber
+        }
+    }
+
+    private func setupStatusCopy(for status: LLMSettingsViewModel.AISetupStatus) -> String {
+        switch status {
+        case .setUpNeeded:
+            return "Choose how MacParakeet should run AI features. Transcription still works without this."
+        case .ready(let displayName):
+            return "Ready: using \(displayName)."
+        case .cannotConnect(let displayName, let message):
+            return "MacParakeet could not reach \(displayName): \(message)"
+        }
+    }
+
+    private func localAIAppStatusText(for provider: LLMProviderID) -> String {
+        if viewModel.isLoadingModelList {
+            return "Checking for models..."
+        }
+        if let error = viewModel.modelListErrorMessage {
+            return error
+        }
+        if viewModel.discoveredModelCount == 1 {
+            return "Detected 1 model."
+        }
+        if viewModel.discoveredModelCount > 1 {
+            return "Detected \(viewModel.discoveredModelCount) models."
+        }
+        if provider == .ollama {
+            return "No running Ollama server detected yet. You can still save a recommended model name."
+        }
+        return "No running LM Studio server detected yet."
+    }
+
+    private var localAIAppStatusTint: Color {
+        if viewModel.modelListErrorMessage != nil {
+            return DesignSystem.Colors.warningAmber
+        }
+        if viewModel.discoveredModelCount > 0 {
+            return DesignSystem.Colors.successGreen
+        }
+        return DesignSystem.Colors.textSecondary
+    }
+
+    @ViewBuilder
     private var modelPicker: some View {
         VStack(alignment: .trailing, spacing: 4) {
             if viewModel.useCustomModel {
@@ -242,7 +476,7 @@ struct LLMSettingsView: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("AI Formatter")
                         .font(DesignSystem.Typography.body)
-                    Text("Optionally run the final transcript through your AI provider after the usual cleanup step.")
+                    Text("Optionally run the final transcript through your selected AI option after the usual cleanup step.")
                         .font(DesignSystem.Typography.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -380,10 +614,10 @@ struct LLMSettingsView: View {
                 .foregroundStyle(isLocal ? DesignSystem.Colors.successGreen : DesignSystem.Colors.warningAmber)
 
             Text(isLocal
-                 ? "Everything stays on your device."
+                 ? "Transcript text stays on this Mac."
                  : isCLI
-                    ? "Runs via CLI on your device. The tool may send data to its cloud service."
-                    : "Transcription is always local. AI features send transcript text to your chosen provider.")
+                    ? "Runs a command on this Mac. The command may contact its own service."
+                    : "Transcription stays local. Transcript text is sent only when you run an AI action.")
                 .font(DesignSystem.Typography.caption)
                 .foregroundStyle(.secondary)
         }

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -235,13 +235,10 @@ struct SettingsView: View {
         }
     }
 
-    /// AI tab — LLM provider config. The card embeds `LLMSettingsView`,
-    /// which already serves as its own first-run UX (the provider picker
-    /// IS the call to action), so a separate empty-state card would be
-    /// redundant. The header chip rolls up the latest signal we have:
-    /// per locked decision #5 we never go red on the AI surface (it's
-    /// opt-in), and we only flag yellow on a real failure the user
-    /// can act on.
+    /// AI tab — optional setup for summaries, chat, prompt actions, and Ask.
+    /// The card body owns the guided local/API/CLI paths. The tab badge stays
+    /// quiet unless a real connection test fails; AI is opt-in and should not
+    /// create speculative warnings.
     private var aiTabContent: some View {
         scrollableTabBody {
             aiProviderCard.id("ai.provider")
@@ -913,8 +910,8 @@ struct SettingsView: View {
 
     private var aiProviderCard: some View {
         SettingsCard(
-            title: "AI Provider",
-            subtitle: "Optional. Powers transcript summaries and chat.",
+            title: "AI Setup",
+            subtitle: "Optional. Powers summaries, chat, and meeting Ask.",
             icon: "brain",
             status: aiProviderCardStatus
         ) {
@@ -924,16 +921,15 @@ struct SettingsView: View {
 
     /// AI tab is opt-in, so this never returns `.required`. We only show
     /// signal when there is something actionable: yellow when the last
-    /// connection test failed (the user pressed "Test Connection" and it
-    /// errored), green when a saved configuration exists and nothing is
-    /// currently broken. Silent in the not-yet-configured state — the
+    /// connection test failed, green when a saved setup exists and nothing is
+    /// currently broken. Silent in the not-yet-configured state because the
     /// card body already explains the empty case.
     private var aiProviderCardStatus: SettingsCardStatus? {
         if case .error = llmSettingsViewModel.connectionTestState {
             return SettingsCardStatus(.recommended, label: "Last test failed")
         }
         if llmSettingsViewModel.isConfigured {
-            return SettingsCardStatus(.ok, label: "Configured")
+            return SettingsCardStatus(.ok, label: "Ready")
         }
         return nil
     }

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -1965,10 +1965,10 @@ struct TranscriptResultView: View {
                 .foregroundStyle(DesignSystem.Colors.accent)
 
             VStack(alignment: .leading, spacing: 4) {
-                Text("Chat needs an AI provider")
+                Text("Turn on AI for summaries and chat")
                     .font(DesignSystem.Typography.body.weight(.semibold))
                     .foregroundStyle(DesignSystem.Colors.textPrimary)
-                Text("Configure Gemini, OpenAI, Anthropic, or another provider in Settings to ask follow-up questions about this transcript.")
+                Text("MacParakeet can use a local AI app, your API key, or a command-line AI tool. Transcription still works without this.")
                     .font(DesignSystem.Typography.bodySmall)
                     .foregroundStyle(DesignSystem.Colors.textSecondary)
             }

--- a/Sources/MacParakeetCore/Services/LLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLMClient.swift
@@ -553,6 +553,16 @@ public final class LLMClient: LLMClientProtocol, Sendable {
 
     public func listModels(context: LLMExecutionContext) async throws -> [String] {
         let config = context.providerConfig
+        if config.id == .ollama {
+            do {
+                return try await listOllamaModels(config: config)
+            } catch {
+                // Older Ollama installs exposed only the OpenAI-compatible
+                // /v1/models route. Fall through so users with those setups can
+                // still refresh models from Settings.
+            }
+        }
+
         let url = config.baseURL.appendingPathComponent("models")
         var request = URLRequest(url: url, timeoutInterval: 15)
         request.httpMethod = "GET"
@@ -606,6 +616,44 @@ public final class LLMClient: LLMClientProtocol, Sendable {
     }
 
     // MARK: - Private Helpers
+
+    private func listOllamaModels(config: LLMProviderConfig) async throws -> [String] {
+        guard let tagsURL = Self.ollamaTagsURL(from: config.baseURL) else {
+            throw LLMError.invalidResponse
+        }
+        var request = URLRequest(url: tagsURL, timeoutInterval: 15)
+        request.httpMethod = "GET"
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw LLMError.connectionFailed("Failed to fetch models.")
+        }
+
+        guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+            throw LLMError.connectionFailed("Failed to fetch models.")
+        }
+
+        let tags = try JSONDecoder().decode(OllamaTagsResponse.self, from: data)
+        return tags.models.map(\.name).sorted()
+    }
+
+    private static func ollamaTagsURL(from baseURL: URL) -> URL? {
+        var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)
+        guard components != nil else { return nil }
+        var segments = (components?.path ?? "")
+            .split(separator: "/")
+            .map(String.init)
+        if segments.last == "v1" {
+            segments.removeLast()
+        }
+        segments.append(contentsOf: ["api", "tags"])
+        components?.path = "/" + segments.joined(separator: "/")
+        components?.query = nil
+        return components?.url
+    }
 
     private func buildRequest(
         messages: [ChatMessage],
@@ -985,6 +1033,14 @@ struct ModelsListResponse: Decodable {
 
     struct ModelEntry: Decodable {
         let id: String
+    }
+}
+
+struct OllamaTagsResponse: Decodable {
+    let models: [ModelEntry]
+
+    struct ModelEntry: Decodable {
+        let name: String
     }
 }
 

--- a/Sources/MacParakeetCore/Services/LLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLMClient.swift
@@ -595,7 +595,7 @@ public final class LLMClient: LLMClientProtocol, Sendable {
         do {
             (data, response) = try await session.data(for: request)
         } catch {
-            throw LLMError.connectionFailed("Failed to fetch models.")
+            throw LLMError.connectionFailed(error.localizedDescription)
         }
 
         guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
@@ -629,7 +629,7 @@ public final class LLMClient: LLMClientProtocol, Sendable {
         do {
             (data, response) = try await session.data(for: request)
         } catch {
-            throw LLMError.connectionFailed("Failed to fetch models.")
+            throw LLMError.connectionFailed(error.localizedDescription)
         }
 
         guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
@@ -641,18 +641,17 @@ public final class LLMClient: LLMClientProtocol, Sendable {
     }
 
     private static func ollamaTagsURL(from baseURL: URL) -> URL? {
-        var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)
-        guard components != nil else { return nil }
-        var segments = (components?.path ?? "")
+        guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else { return nil }
+        var segments = components.path
             .split(separator: "/")
             .map(String.init)
         if segments.last == "v1" {
             segments.removeLast()
         }
         segments.append(contentsOf: ["api", "tags"])
-        components?.path = "/" + segments.joined(separator: "/")
-        components?.query = nil
-        return components?.url
+        components.path = "/" + segments.joined(separator: "/")
+        components.query = nil
+        return components.url
     }
 
     private func buildRequest(

--- a/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
@@ -98,11 +98,12 @@ public final class LLMSettingsViewModel {
     }
 
     public var setupStatus: AISetupStatus {
-        let displayName = savedAIOptionDisplayName ?? draft.providerID?.displayName ?? "AI"
         if case .error(let message) = connectionTestState {
+            let displayName = draftAIOptionDisplayName ?? savedAIOptionDisplayName ?? "AI"
             return .cannotConnect(displayName: displayName, message: message)
         }
         if isConfigured {
+            let displayName = savedAIOptionDisplayName ?? draftAIOptionDisplayName ?? "AI"
             return .ready(displayName: displayName)
         }
         return .setUpNeeded
@@ -266,6 +267,14 @@ public final class LLMSettingsViewModel {
                 ?? config.id.displayName
         }
         return config.id.displayName
+    }
+
+    private var draftAIOptionDisplayName: String? {
+        guard let providerID = draft.providerID else { return nil }
+        if providerID == .localCLI {
+            return LocalCLITemplate.displayName(for: draft.trimmedCommandTemplate)
+        }
+        return providerID.displayName
     }
 
     public var canResetAIFormatterPrompt: Bool {

--- a/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
@@ -612,7 +612,7 @@ public final class LLMSettingsViewModel {
         return Self.defaultModelName(for: providerID)
     }
 
-    private static func usesDiscoveredModelList(_ providerID: LLMProviderID) -> Bool {
+    private nonisolated static func usesDiscoveredModelList(_ providerID: LLMProviderID) -> Bool {
         providerID == .lmstudio || providerID == .ollama
     }
 

--- a/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
@@ -24,6 +24,12 @@ public final class LLMSettingsViewModel {
         case error(String)
     }
 
+    public enum AISetupStatus: Equatable {
+        case setUpNeeded
+        case ready(displayName: String)
+        case cannotConnect(displayName: String, message: String)
+    }
+
     public private(set) var draft: LLMSettingsDraft
     public var connectionTestState: ConnectionTestState = .idle
     public var saveState: SaveState = .idle
@@ -91,6 +97,17 @@ public final class LLMSettingsViewModel {
         configStore != nil && (try? configStore?.loadConfig()) != nil
     }
 
+    public var setupStatus: AISetupStatus {
+        let displayName = savedAIOptionDisplayName ?? draft.providerID?.displayName ?? "AI"
+        if case .error(let message) = connectionTestState {
+            return .cannotConnect(displayName: displayName, message: message)
+        }
+        if isConfigured {
+            return .ready(displayName: displayName)
+        }
+        return .setUpNeeded
+    }
+
     public var requiresAPIKey: Bool {
         draft.requiresAPIKey
     }
@@ -101,14 +118,17 @@ public final class LLMSettingsViewModel {
 
     public var availableModels: [String] {
         guard let providerID = draft.providerID else { return [] }
-        if providerID == .lmstudio {
+        if Self.usesDiscoveredModelList(providerID) {
+            if providerID == .ollama, discoveredModels.isEmpty {
+                return Self.suggestedModels(for: providerID)
+            }
             return discoveredModels
         }
         return Self.suggestedModels(for: providerID)
     }
 
     public var canRefreshModelList: Bool {
-        draft.providerID == .lmstudio
+        draft.providerID.map(Self.usesDiscoveredModelList) ?? false
     }
 
     public var canChooseModelFromList: Bool {
@@ -120,6 +140,10 @@ public final class LLMSettingsViewModel {
             return true
         }
         return false
+    }
+
+    public var discoveredModelCount: Int {
+        discoveredModels.count
     }
 
     public var modelListErrorMessage: String? {
@@ -217,13 +241,13 @@ public final class LLMSettingsViewModel {
 
     public var aiFormatterDisabledReason: String? {
         if draft.providerID == nil {
-            return "Set an AI provider to enable the formatter."
+            return "Set up AI to enable the formatter."
         }
         if !isConfigured {
-            return "Save your AI provider first. Formatter changes apply immediately after that."
+            return "Save your AI setup first. Formatter changes apply immediately after that."
         }
         if draft.providerID != savedProviderID {
-            return "Save this provider first. Formatter changes apply immediately after that."
+            return "Save this AI option first. Formatter changes apply immediately after that."
         }
         return nil
     }
@@ -231,6 +255,17 @@ public final class LLMSettingsViewModel {
     private var savedProviderID: LLMProviderID? {
         guard let configStore else { return nil }
         return (try? configStore.loadConfig())?.id
+    }
+
+    private var savedAIOptionDisplayName: String? {
+        guard let configStore, let config = try? configStore.loadConfig() else { return nil }
+        if config.id == .localCLI {
+            return cliConfigStore
+                .flatMap { $0.load() }
+                .map { LocalCLITemplate.displayName(for: $0.commandTemplate) }
+                ?? config.id.displayName
+        }
+        return config.id.displayName
     }
 
     public var canResetAIFormatterPrompt: Bool {
@@ -359,15 +394,15 @@ public final class LLMSettingsViewModel {
         draft = .defaults(
             for: currentProvider,
             apiKey: apiKey,
-            defaultModelName: currentProvider == .lmstudio
-                ? discoveredModels.first ?? ""
-                : currentProvider.map { Self.defaultModelName(for: $0) } ?? "",
+            defaultModelName: defaultModelNameAfterClearing(currentProvider),
             cliConfig: preservedCLIConfig,
             aiFormatterEnabled: false,
             aiFormatterPrompt: AIFormatter.defaultPromptTemplate
         )
         if currentProvider == .lmstudio {
             draft.useCustomModel = discoveredModels.isEmpty
+        } else if currentProvider == .ollama {
+            draft.useCustomModel = false
         } else {
             resetDiscoveredModels()
         }
@@ -378,6 +413,11 @@ public final class LLMSettingsViewModel {
 
     public func resetAIFormatterPrompt() {
         aiFormatterPrompt = AIFormatter.defaultPromptTemplate
+    }
+
+    public func chooseLocalAIApp(_ providerID: LLMProviderID) {
+        guard Self.usesDiscoveredModelList(providerID) else { return }
+        selectedProviderID = providerID
     }
 
     public func refreshAvailableModels() {
@@ -434,7 +474,7 @@ public final class LLMSettingsViewModel {
             )
             return
         }
-        if providerID != .lmstudio {
+        if !Self.usesDiscoveredModelList(providerID) {
             resetDiscoveredModels()
         }
         let apiKey = providerID.supportsAPIKey ? ((try? configStore?.loadAPIKey(for: providerID)) ?? "") : ""
@@ -447,12 +487,15 @@ public final class LLMSettingsViewModel {
             aiFormatterEnabled: formatterEnabled,
             aiFormatterPrompt: formatterPrompt
         )
-        // Auto-switch to custom model input when provider has no suggested models
-        if Self.suggestedModels(for: providerID).isEmpty && providerID != .localCLI {
+        // Auto-switch to custom model input when provider has no suggested models.
+        if providerID == .lmstudio
+            || (Self.suggestedModels(for: providerID).isEmpty
+                && providerID != .localCLI
+                && !Self.usesDiscoveredModelList(providerID)) {
             nextDraft.useCustomModel = true
         }
         updateDraft(nextDraft)
-        if providerID == .lmstudio {
+        if Self.usesDiscoveredModelList(providerID) {
             refreshAvailableModels()
         }
     }
@@ -478,7 +521,7 @@ public final class LLMSettingsViewModel {
             aiFormatterEnabled: Self.loadStoredAIFormatterEnabled(from: defaults),
             aiFormatterPrompt: Self.loadStoredAIFormatterPrompt(from: defaults)
         )
-        if config.id == .lmstudio {
+        if Self.usesDiscoveredModelList(config.id) {
             refreshAvailableModels()
         } else {
             resetDiscoveredModels()
@@ -493,7 +536,7 @@ public final class LLMSettingsViewModel {
     }
 
     private func buildModelListContext(from draft: LLMSettingsDraft) throws -> LLMExecutionContext? {
-        guard let providerID = draft.providerID, providerID == .lmstudio else { return nil }
+        guard let providerID = draft.providerID, Self.usesDiscoveredModelList(providerID) else { return nil }
         guard let config = try draft.buildConfig(
             defaultBaseURL: Self.defaultBaseURL(for: providerID),
             allowMissingModelName: true
@@ -547,6 +590,21 @@ public final class LLMSettingsViewModel {
     private func resetDiscoveredModels() {
         discoveredModels = []
         modelListState = .idle
+    }
+
+    private func defaultModelNameAfterClearing(_ providerID: LLMProviderID?) -> String {
+        guard let providerID else { return "" }
+        if providerID == .lmstudio {
+            return discoveredModels.first ?? ""
+        }
+        if providerID == .ollama {
+            return discoveredModels.first ?? Self.defaultModelName(for: providerID)
+        }
+        return Self.defaultModelName(for: providerID)
+    }
+
+    private static func usesDiscoveredModelList(_ providerID: LLMProviderID) -> Bool {
+        providerID == .lmstudio || providerID == .ollama
     }
 
     private func persistAIFormatterPreferences(from draft: LLMSettingsDraft) -> String {

--- a/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
+++ b/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
@@ -226,11 +226,12 @@ public enum SettingsSearchIndex {
         SettingsSearchEntry(
             id: "ai.provider",
             tab: .ai,
-            title: "AI Provider",
-            subtitle: "Optional. Powers transcript summaries and chat.",
+            title: "AI Setup",
+            subtitle: "Optional. Powers summaries, chat, and meeting Ask.",
             keywords: [
                 "ai", "llm", "openai", "anthropic", "claude", "gpt", "lm studio", "ollama",
-                "openai compatible", "summary", "summaries", "chat", "api key", "provider"
+                "openai compatible", "summary", "summaries", "chat", "ask", "api key",
+                "provider", "local ai", "local app", "command line", "cli"
             ],
             cardAnchor: "ai.provider"
         ),

--- a/Tests/MacParakeetTests/Services/LLMClientTests.swift
+++ b/Tests/MacParakeetTests/Services/LLMClientTests.swift
@@ -910,6 +910,26 @@ final class LLMClientTests: XCTestCase {
         XCTAssertEqual(models, ["gemma3:4b", "qwen3.5:4b"])
     }
 
+    func testOllamaListModelsPreservesBasePathWhenBuildingTagsEndpoint() async throws {
+        var capturedRequest: URLRequest?
+
+        MockURLProtocol.handler = { request in
+            capturedRequest = request
+            return (self.okResponse(for: request), Data("""
+            {"models":[{"name":"local-model"}]}
+            """.utf8))
+        }
+
+        let config = LLMProviderConfig.ollama(
+            model: "local-model",
+            baseURL: URL(string: "http://local-ai.example.test/custom/v1")!
+        )
+        let models = try await llmClient.listModels(config: config)
+
+        XCTAssertEqual(capturedRequest?.url?.absoluteString, "http://local-ai.example.test/custom/api/tags")
+        XCTAssertEqual(models, ["local-model"])
+    }
+
     func testOllamaListModelsFallsBackToOpenAICompatibleModelsEndpoint() async throws {
         var capturedURLs: [String] = []
 
@@ -940,6 +960,25 @@ final class LLMClientTests: XCTestCase {
             ]
         )
         XCTAssertEqual(models, ["qwen3.5:4b"])
+    }
+
+    func testListModelsConnectionFailureIncludesUnderlyingError() async {
+        let urlError = URLError(.cannotConnectToHost)
+        MockURLProtocol.handler = { _ in
+            throw urlError
+        }
+
+        do {
+            _ = try await llmClient.listModels(config: .lmstudio(model: "local-model"))
+            XCTFail("Expected LLMError.connectionFailed")
+        } catch let error as LLMError {
+            XCTAssertEqual(
+                error.localizedDescription,
+                "Connection failed: \(urlError.localizedDescription)"
+            )
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
     }
 
     // MARK: - Gemini Error Array Format

--- a/Tests/MacParakeetTests/Services/LLMClientTests.swift
+++ b/Tests/MacParakeetTests/Services/LLMClientTests.swift
@@ -892,6 +892,56 @@ final class LLMClientTests: XCTestCase {
         XCTAssertNil(capturedBody?["options"])
     }
 
+    func testOllamaListModelsUsesNativeTagsEndpoint() async throws {
+        var capturedRequest: URLRequest?
+
+        MockURLProtocol.handler = { request in
+            capturedRequest = request
+            return (self.okResponse(for: request), Data("""
+            {"models":[{"name":"qwen3.5:4b"},{"name":"gemma3:4b"}]}
+            """.utf8))
+        }
+
+        let config = LLMProviderConfig.ollama(model: "qwen3.5:4b")
+        let models = try await llmClient.listModels(config: config)
+
+        XCTAssertEqual(capturedRequest?.url?.absoluteString, "http://localhost:11434/api/tags")
+        XCTAssertEqual(capturedRequest?.httpMethod, "GET")
+        XCTAssertEqual(models, ["gemma3:4b", "qwen3.5:4b"])
+    }
+
+    func testOllamaListModelsFallsBackToOpenAICompatibleModelsEndpoint() async throws {
+        var capturedURLs: [String] = []
+
+        MockURLProtocol.handler = { request in
+            capturedURLs.append(request.url!.absoluteString)
+            if request.url?.path == "/api/tags" {
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 404,
+                    httpVersion: nil,
+                    headerFields: nil
+                )!
+                return (response, Data())
+            }
+            return (self.okResponse(for: request), Data("""
+            {"data":[{"id":"qwen3.5:4b"}]}
+            """.utf8))
+        }
+
+        let config = LLMProviderConfig.ollama(model: "qwen3.5:4b")
+        let models = try await llmClient.listModels(config: config)
+
+        XCTAssertEqual(
+            capturedURLs,
+            [
+                "http://localhost:11434/api/tags",
+                "http://localhost:11434/v1/models",
+            ]
+        )
+        XCTAssertEqual(models, ["qwen3.5:4b"])
+    }
+
     // MARK: - Gemini Error Array Format
 
     func testGeminiErrorArrayParsedCorrectly() async {

--- a/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
@@ -62,6 +62,19 @@ final class LLMSettingsViewModelTests: XCTestCase {
         )
     }
 
+    func testSetupStatusCannotConnectUsesDraftProviderDisplayName() {
+        mockConfigStore.config = .lmstudio(model: "local-model")
+        viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
+
+        viewModel.selectedProviderID = .ollama
+        viewModel.connectionTestState = .error("Connection failed")
+
+        XCTAssertEqual(
+            viewModel.setupStatus,
+            .cannotConnect(displayName: "Ollama", message: "Connection failed")
+        )
+    }
+
     // MARK: - Provider Change
 
     func testProviderChangeUpdatesModelName() {

--- a/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
@@ -38,8 +38,28 @@ final class LLMSettingsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.connectionTestState, .idle)
         XCTAssertFalse(viewModel.isConfigured)
         XCTAssertFalse(viewModel.requiresAPIKey)
+        XCTAssertEqual(viewModel.setupStatus, .setUpNeeded)
         XCTAssertFalse(viewModel.aiFormatterEnabled)
         XCTAssertEqual(viewModel.aiFormatterPrompt, AIFormatter.defaultPromptTemplate)
+    }
+
+    func testSetupStatusReadyUsesSavedProviderDisplayName() {
+        mockConfigStore.config = .lmstudio(model: "local-model")
+        viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
+
+        XCTAssertEqual(viewModel.setupStatus, .ready(displayName: "LM Studio"))
+    }
+
+    func testSetupStatusCannotConnectUsesConnectionError() {
+        mockConfigStore.config = .ollama(model: "qwen3.5:4b")
+        viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
+
+        viewModel.connectionTestState = .error("Connection failed")
+
+        XCTAssertEqual(
+            viewModel.setupStatus,
+            .cannotConnect(displayName: "Ollama", message: "Connection failed")
+        )
     }
 
     // MARK: - Provider Change
@@ -357,6 +377,20 @@ final class LLMSettingsViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.modelListErrorMessage)
     }
 
+    func testOllamaLoadsAvailableModelsAndDefaultsToFirstResult() async throws {
+        mockClient.modelsList = ["qwen3.5:9b", "gemma3:4b"]
+        viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
+
+        viewModel.selectedProviderID = .ollama
+
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertEqual(viewModel.availableModels, ["qwen3.5:9b", "gemma3:4b"])
+        XCTAssertEqual(viewModel.modelName, "qwen3.5:9b")
+        XCTAssertEqual(viewModel.discoveredModelCount, 2)
+        XCTAssertNil(viewModel.modelListErrorMessage)
+    }
+
     func testLMStudioModelListFailureKeepsCustomMode() async throws {
         mockClient.listModelsError = LLMError.connectionFailed("Failed to fetch models.")
         viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
@@ -367,6 +401,20 @@ final class LLMSettingsViewModelTests: XCTestCase {
 
         XCTAssertTrue(viewModel.availableModels.isEmpty)
         XCTAssertTrue(viewModel.useCustomModel)
+        XCTAssertEqual(viewModel.modelListErrorMessage, "Connection failed: Failed to fetch models.")
+    }
+
+    func testOllamaModelListFailureKeepsRecommendedModels() async throws {
+        mockClient.listModelsError = LLMError.connectionFailed("Failed to fetch models.")
+        viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
+
+        viewModel.selectedProviderID = .ollama
+
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertEqual(viewModel.availableModels, LLMSettingsViewModel.suggestedModels(for: .ollama))
+        XCTAssertFalse(viewModel.useCustomModel)
+        XCTAssertEqual(viewModel.modelName, "qwen3.5:4b")
         XCTAssertEqual(viewModel.modelListErrorMessage, "Connection failed: Failed to fetch models.")
     }
 

--- a/plans/active/2026-05-ai-setup-ux.md
+++ b/plans/active/2026-05-ai-setup-ux.md
@@ -1,0 +1,373 @@
+# AI Setup UX Plan
+
+> Status: **ACTIVE PLAN**
+> Drafted: 2026-05-02
+> ADR: `spec/adr/011-llm-cloud-and-local-providers.md`
+> Related history: `spec/adr/008-local-llm-runtime-and-model.md`
+> Scope: AI setup for summaries, transcript chat, prompt actions, and meeting Ask. Speech-to-text is unchanged.
+
+## 1. Decision
+
+Keep the stable product on the ADR-011 model: MacParakeet does not bundle a local LLM runtime or model in the app. Users can bring a local AI app, an API key, or a command-line AI tool.
+
+The product work is to make that setup feel first-class and low-friction:
+
+1. LM Studio is the recommended local path.
+2. Ollama is the secondary local path.
+3. API-key providers remain available for users who prefer cloud AI.
+4. Local CLI stays available for advanced users and agent workflows.
+5. Feature surfaces do not show provider plumbing once AI is configured.
+
+This gives users a clean path to local summaries and chat without reopening the bundled-MLX decision that was already tried and removed.
+
+## 2. Research Baseline
+
+Char/Hyprnote's public local-LLM path is provider-based, not a simple bundled-LLM experience. Their docs guide users through LM Studio or Ollama, and their app UI exposes provider setup rather than hiding all model/runtime complexity.
+
+Useful lessons:
+
+1. Put default local URLs and model refresh behind the UI.
+2. Detect running local apps instead of asking users to type endpoints.
+3. Filter or recommend models that are likely to work for the task.
+4. Keep a health check close to setup.
+5. Avoid making the main product onboarding depend on AI setup.
+
+MacParakeet should take the convenience lessons, but not copy the docs-heavy setup. The app should do more of the guiding directly in Settings.
+
+References:
+
+- Char quick start: https://char.com/docs/getting-started/quick-start/
+- Char local LLM setup: https://char.com/docs/faq/local-llm-setup/
+- Char local models: https://char.com/docs/developers/local-models/
+- Hyprnote/Char repository: https://github.com/fastrepl/anarlog
+
+## 3. Product Principles
+
+AI is optional. Dictation, transcription, and meeting recording must stay usable with no AI provider configured.
+
+Settings is the source of truth. Transcript chat, summaries, and meeting Ask may show a small setup prompt when AI is missing, but they should not become provider dashboards.
+
+Use audience-friendly language first:
+
+| Technical term | User-facing copy |
+|---|---|
+| LLM | AI |
+| Provider | AI option |
+| LM Studio/Ollama endpoint | Local AI app |
+| API endpoint/base URL | Advanced connection settings |
+| OpenAI-compatible | Advanced API connection |
+| Local CLI | Command-line AI tool |
+
+Preferred status labels:
+
+| Internal state | User-facing label |
+|---|---|
+| Configured and usable | Ready |
+| No saved config | Set up needed |
+| Last real attempt failed | Can't connect |
+
+Do not show "Cloud provider configured" as a main feature-surface status. If AI is ready, the feature should just work.
+
+## 4. Feature-Surface Behavior
+
+Feature surfaces include transcript summaries, transcript chat, prompt actions, and meeting Ask.
+
+### Ready
+
+When a saved AI configuration exists and the last real attempt did not fail, show the normal feature UI. No setup card, no provider status badge, no repeated explanation.
+
+### Set Up Needed
+
+When no AI configuration exists, show a compact empty state in the relevant feature surface:
+
+Title: `Turn on AI for summaries and chat`
+
+Body: `MacParakeet can use a local AI app, your API key, or a command-line AI tool. Transcription still works without this.`
+
+Primary action: `Set up AI`
+
+The action opens Settings directly to the AI section.
+
+### Can't Connect
+
+When the last actual summary/chat/Ask attempt failed because the saved AI option could not be reached, show a compact error state:
+
+Title: `AI can't connect`
+
+Body: `Check that your selected AI option is running, then try again.`
+
+Actions:
+
+1. `Try Again`
+2. `Open AI Settings`
+
+This state should be based on real user activity, not speculative background probing.
+
+## 5. Settings > AI Information Architecture
+
+The AI settings surface should answer one question first: "Can MacParakeet use AI for summaries and chat right now?"
+
+### Top Status
+
+Card title: `AI for summaries and chat`
+
+Possible states:
+
+| State | Copy |
+|---|---|
+| Ready | `Ready: using <AI option name>.` |
+| Set up needed | `Choose how MacParakeet should run AI features.` |
+| Can't connect | `MacParakeet could not reach <AI option name> the last time it tried.` |
+
+Primary actions:
+
+1. `Test`
+2. `Change`
+3. `Clear`
+
+### Setup Path 1: Use A Local AI App
+
+This is the recommended path, with LM Studio first.
+
+Card title: `Use a local AI app`
+
+Body: `Run AI on this Mac with a local app. Transcript text stays on this Mac.`
+
+#### LM Studio - Recommended
+
+LM Studio should be shown first and labeled `Recommended`.
+
+Detection:
+
+1. Probe `http://localhost:1234/v1/models`.
+2. If models are returned, show `LM Studio detected`.
+3. If no model is loaded or the server is not running, show clear next steps.
+
+Primary happy path:
+
+1. User starts LM Studio's local server.
+2. MacParakeet detects models.
+3. User clicks `Use LM Studio`.
+4. MacParakeet saves `LLMProviderID.lmstudio`, the default base URL, and the selected model.
+5. MacParakeet runs a connection test.
+
+Setup guidance:
+
+1. `Install LM Studio`
+2. `Download a recommended model`
+3. `Start the local server`
+4. `Refresh`
+
+Do not require the user to type `http://localhost:1234/v1` unless they open Advanced.
+
+#### Ollama - Secondary
+
+Ollama should be available below LM Studio, not ahead of it.
+
+Detection:
+
+1. Probe `http://localhost:11434/api/tags` or `http://localhost:11434/v1/models`.
+2. If models are returned, show `Ollama detected`.
+3. If no model is available, show setup commands.
+
+Primary happy path:
+
+1. User starts Ollama and pulls a model.
+2. MacParakeet detects models.
+3. User clicks `Use Ollama`.
+4. MacParakeet saves `LLMProviderID.ollama`, the default base URL, and the selected model.
+5. MacParakeet runs a connection test.
+
+Setup commands:
+
+```bash
+brew install ollama
+ollama pull qwen3.5:4b
+ollama serve
+```
+
+The UI should also allow users who installed the Ollama desktop app to simply start it and click `Refresh`.
+
+### Setup Path 2: Use An API Key
+
+Card title: `Use an API key`
+
+Body: `Use Claude, OpenAI, Gemini, OpenRouter, or another API service. Transcription stays local. Transcript text is sent only when you run an AI action.`
+
+This path maps to the existing cloud and OpenAI-compatible provider configuration.
+
+Providers:
+
+1. Anthropic
+2. OpenAI
+3. Google Gemini
+4. OpenRouter
+5. OpenAI-compatible
+
+### Setup Path 3: Use A Command-Line AI Tool
+
+Card title: `Use a command-line AI tool`
+
+Body: `Run a local command when MacParakeet needs AI. The command may contact its own service.`
+
+This maps to `LLMProviderID.localCLI` and existing Local CLI configuration.
+
+Good defaults:
+
+1. Claude Code template
+2. Codex template
+3. Custom command
+
+### Advanced
+
+Advanced fields stay available, but collapsed by default:
+
+1. Base URL
+2. Model ID
+3. Optional API key for compatible servers
+4. Timeout for Local CLI
+
+## 6. Readiness State Model
+
+Add a small readiness model in `MacParakeetViewModels` so feature surfaces can stay simple.
+
+Suggested shape:
+
+```swift
+public enum AIReadinessState: Equatable {
+    case setUpNeeded
+    case ready(displayName: String, isLocal: Bool)
+    case cannotConnect(displayName: String, message: String)
+}
+```
+
+Rules:
+
+1. No saved config means `.setUpNeeded`.
+2. Saved config with no failed last attempt means `.ready`.
+3. Saved config with a failed last actual attempt means `.cannotConnect`.
+4. Do not probe providers just because a transcript view appeared.
+5. Connection tests and real AI feature attempts may update the last-attempt state.
+
+This aligns with the Settings IA decision that AI is opt-in and should not create speculative warnings.
+
+## 7. Implementation Phases
+
+### Current PR Slice
+
+This branch starts with the low-risk UX foundation:
+
+1. Add the plan document.
+2. Make Settings > AI use audience-friendly "AI setup" language.
+3. Put LM Studio first as the recommended local app and Ollama second.
+4. Let Ollama refresh installed models, matching LM Studio's model-list behavior.
+5. Update transcript chat and meeting Ask no-provider copy.
+6. Leave mandatory onboarding, bundled MLX/runtime work, and settings deep links out of this slice.
+
+### Phase 1: Readiness State
+
+Files likely touched:
+
+1. `Sources/MacParakeetViewModels/LLMSettingsViewModel.swift`
+2. `Sources/MacParakeetCore/Services/LLMConfigStore.swift`
+3. `Sources/MacParakeetCore/Services/LLMService.swift`
+
+Work:
+
+1. Add `AIReadinessState`.
+2. Persist or derive "last actual AI attempt" state.
+3. Expose a simple readiness value for feature surfaces.
+4. Keep readiness independent from speculative detection.
+
+### Phase 2: Feature Empty States
+
+Files likely touched:
+
+1. `Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift`
+2. `Sources/MacParakeet/Views/MeetingRecording/LiveAskPaneView.swift`
+3. Any summary/prompt-action no-provider state.
+
+Work:
+
+1. Replace provider jargon with the audience-friendly setup copy.
+2. Hide setup UI entirely when AI is ready.
+3. Add `Set up AI` deep link to Settings > AI.
+4. Add retry/open-settings state for connection failures.
+
+### Phase 3: Settings > AI Refresh
+
+Files likely touched:
+
+1. `Sources/MacParakeet/Views/Settings/LLMSettingsView.swift`
+2. `Sources/MacParakeetViewModels/LLMSettingsViewModel.swift`
+3. Settings IA files if the active Settings overhaul lands first.
+
+Work:
+
+1. Add the top `AI for summaries and chat` status card.
+2. Replace the provider-first picker with three setup paths.
+3. Put LM Studio first under local AI apps.
+4. Keep Ollama below LM Studio.
+5. Move endpoint/model details into Advanced.
+6. Preserve the existing provider config store and Keychain behavior.
+
+### Phase 4: Local App Detection
+
+Files likely touched:
+
+1. New `LLMLocalProviderDetector` in `MacParakeetCore` or `MacParakeetViewModels`.
+2. `LLMSettingsViewModel`.
+3. Unit tests.
+
+Work:
+
+1. Detect LM Studio via `/v1/models`.
+2. Detect Ollama via `/api/tags` and/or `/v1/models`.
+3. Normalize discovered model names.
+4. Show model picker only when models exist.
+5. Never auto-save a detected provider without user action.
+
+### Phase 5: One-Click Adoption
+
+Work:
+
+1. Add `Use LM Studio` and `Use Ollama` actions.
+2. Save provider, base URL, and selected model.
+3. Immediately run `Test`.
+4. Surface clear failure copy if the local app stops responding.
+
+### Phase 6: Tests
+
+Required coverage:
+
+1. `AIReadinessState` derivation.
+2. Last-attempt success/failure behavior.
+3. LM Studio model-list parsing.
+4. Ollama model-list parsing.
+5. One-click provider save behavior.
+6. Feature-surface visibility rules for set-up-needed, ready, and can't-connect states.
+
+Run `swift test` before declaring implementation complete.
+
+## 8. Acceptance Criteria
+
+1. A new user can understand AI setup without knowing what an LLM provider is.
+2. Transcript chat, summaries, and meeting Ask show setup help only when AI is not configured.
+3. When AI is configured, feature surfaces show the feature itself, not a setup card.
+4. LM Studio is the first and recommended local path.
+5. Ollama is available but secondary.
+6. Users can connect to detected LM Studio or Ollama without typing a base URL.
+7. API-key and Local CLI users still have complete configuration paths.
+8. Advanced users can still override base URL and model ID.
+9. STT behavior and STT model packaging are untouched.
+10. No bundled local LLM runtime or model is added to the stable app.
+
+## 9. Explicit Non-Goals
+
+1. Do not add `mlx-swift` or `mlx-swift-lm` to stable builds in this plan.
+2. Do not bundle a local LLM model in the app DMG.
+3. Do not make AI setup part of mandatory first-run onboarding.
+4. Do not require AI for transcription, dictation, or meeting recording.
+5. Do not remove Local CLI.
+6. Do not remove cloud API providers.
+7. Do not rewrite the LLM provider architecture unless a specific implementation blocker appears.


### PR DESCRIPTION
## Summary
This PR makes local AI setup easier to understand without changing speech-to-text or bundling a local LLM.

Settings now presents AI as a clear setup flow: LM Studio is the recommended local path, Ollama is secondary, and API key or command-line options stay available for users who prefer them.

```text
AI Setup
  |
  +-- Local AI app
  |     +-- LM Studio (recommended)
  |     +-- Ollama
  |
  +-- API key
  |     +-- Anthropic / OpenAI / Gemini / OpenRouter / compatible
  |
  +-- Command-line AI tool
```

## What Changed
- Added the active AI setup UX plan.
- Renamed the Settings card from AI Provider to AI Setup.
- Added friendlier Settings copy for local apps, API keys, and command-line AI.
- Put LM Studio before Ollama in the local setup path.
- Added native Ollama model discovery through `/api/tags`, with `/v1/models` fallback.
- Updated transcript chat and meeting Ask empty states so users know AI is optional.
- Tightened setup status handling so draft connection failures name the option being tested.
- Addressed review comments around Ollama URL construction and model-list connection errors.
- Fixed the Swift 6 language-mode build for the AI setup view model.

## Non-Goals
- No STT changes.
- No bundled MLX runtime or local LLM model.
- No mandatory onboarding.
- No Settings deep links from feature surfaces in this slice.

## Tests
- `MACPARAKEET_SKIP_WHISPERKIT=1 swift build --build-path .build-swift6-no-whisper -Xswiftc -swift-version -Xswiftc 6`
- `swift test --filter 'LLMClientTests|LLMSettingsViewModelTests|SettingsSearchIndexTests'`
- `swift test`
