### PR TITLE
Add customizable Ask tab quick prompts (GUI + CLI + JSON)

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -81,6 +81,19 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ### Added
 
+- `quick-prompts` subcommand surface for managing the live meeting Ask tab
+  pills (starter and follow-up prompts). Subcommands: `list`, `show`, `add`,
+  `set`, `delete`, `restore-defaults`, `export`, `import`. All mutation
+  subcommands honor `--json` for the success/failure envelope. Built-ins are
+  user-editable; `delete` rejects them with `errorType: "validation"`.
+  `import --mode merge` (default) UPSERTs by id and preserves untouched rows;
+  `import --mode replace` wipes customs, re-seeds built-ins, then applies the
+  file (prompts for confirmation unless `--json` or `--yes`). `import
+  --dry-run` reports planned `{added, updated, deleted, unchanged}` counts
+  without writing. Bundle format is versioned (`macparakeet.quick_prompts`
+  v1) and round-trippable.
+- `import_schema` `errorType` value for malformed quick-prompts import files
+  (e.g. wrong `schema`, unsupported `version`, JSON parse failure).
 - `flow vocabulary export`, `flow vocabulary import`, and `flow vocabulary
   schema` commands for round-trip backup of the combined vocabulary (custom
   words + text snippets). `import` supports `--policy skip|replace`,

--- a/Sources/CLI/Commands/CLIHelpers.swift
+++ b/Sources/CLI/Commands/CLIHelpers.swift
@@ -255,6 +255,7 @@ enum CLIErrorType {
     static let config = "config"
     static let connection = "connection"
     static let context = "context"
+    static let importSchema = "import_schema"
     static let inputEmpty = "input_empty"
     static let inputMissing = "input_missing"
     static let invalidResponse = "invalid_response"
@@ -285,6 +286,17 @@ enum CLIErrorType {
         }
         if error is CLILookupError { return lookup }
         if error is CLIInputError { return inputEmpty }
+        if let qpe = error as? QuickPromptCLIError {
+            switch qpe {
+            case .cannotDeleteBuiltIn: return validation
+            case .deleteFailed:        return runtime
+            case .emptyBody:           return inputEmpty
+            case .readFailed:          return inputMissing
+            case .writeFailed:         return runtime
+            case .importSchemaError:   return importSchema
+            case .importCancelled:     return validation
+            }
+        }
         if let cli = error as? CLIError {
             switch cli {
             case .fileNotFound:

--- a/Sources/CLI/Commands/QuickPromptsCommand.swift
+++ b/Sources/CLI/Commands/QuickPromptsCommand.swift
@@ -362,6 +362,12 @@ extension QuickPromptsCommand {
             if visible && hidden {
                 throw ValidationError("--visible and --hidden are mutually exclusive")
             }
+            if let label, label.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                throw ValidationError("--label must not be empty")
+            }
+            if let prompt, prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                throw ValidationError("--prompt must not be empty")
+            }
             if label == nil && prompt == nil && group == nil && sortOrder == nil && !visible && !hidden {
                 throw ValidationError("specify at least one field to change (--label / --prompt / --group / --sort-order / --visible / --hidden)")
             }
@@ -374,6 +380,9 @@ extension QuickPromptsCommand {
                 let repo = QuickPromptRepository(dbQueue: db.dbQueue)
 
                 var p = try findQuickPrompt(idOrLabel: idOrLabel, repo: repo)
+                if group != nil && p.kind == .followUp {
+                    throw ValidationError("--group is only valid for starter prompts")
+                }
 
                 if let label {
                     p.label = label.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -644,7 +653,12 @@ extension QuickPromptsCommand {
 
                 let db = try DatabaseManager(path: resolvedDatabasePath(database))
                 let repo = QuickPromptRepository(dbQueue: db.dbQueue)
-                let summary = try repo.applyImport(bundle, mode: mode.domain, dryRun: dryRun)
+                let summary: QuickPromptImport.Summary
+                do {
+                    summary = try repo.applyImport(bundle, mode: mode.domain, dryRun: dryRun)
+                } catch let importError as QuickPromptImportError {
+                    throw QuickPromptCLIError.importSchemaError(importError.localizedDescription)
+                }
 
                 if json {
                     struct ImportResult: Encodable {

--- a/Sources/CLI/Commands/QuickPromptsCommand.swift
+++ b/Sources/CLI/Commands/QuickPromptsCommand.swift
@@ -95,6 +95,11 @@ private func renderBadges(_ p: QuickPrompt) -> String {
     return "  [\(badges.joined(separator: ", "))]"
 }
 
+private struct QuickPromptWriteResult: Encodable {
+    let ok: Bool
+    let prompt: QuickPrompt
+}
+
 enum QuickPromptCLIError: Error, LocalizedError {
     case cannotDeleteBuiltIn(String)
     case deleteFailed(String)
@@ -313,7 +318,7 @@ extension QuickPromptsCommand {
                 try repo.save(p)
 
                 if json {
-                    try printJSON(p)
+                    try printJSON(QuickPromptWriteResult(ok: true, prompt: p))
                 } else {
                     print("Added quick prompt '\(p.label)' (\(p.id.uuidString.prefix(8)))")
                 }
@@ -404,7 +409,7 @@ extension QuickPromptsCommand {
                 try repo.save(p)
 
                 if json {
-                    try printJSON(p)
+                    try printJSON(QuickPromptWriteResult(ok: true, prompt: p))
                 } else {
                     print("Updated '\(p.label)':\(renderBadges(p))")
                 }

--- a/Sources/CLI/Commands/QuickPromptsCommand.swift
+++ b/Sources/CLI/Commands/QuickPromptsCommand.swift
@@ -1,0 +1,676 @@
+import ArgumentParser
+import Foundation
+import MacParakeetCore
+
+/// `macparakeet-cli quick-prompts` — manage the live meeting Ask tab pills
+/// (starter and follow-up prompts). Mirrors `prompts` shape for familiarity,
+/// adds `export` / `import` for portable JSON round-tripping (versioned wire
+/// format; see `QuickPromptBundle`).
+struct QuickPromptsCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "quick-prompts",
+        abstract: "Manage the live meeting Ask tab pills (starter + follow-up).",
+        subcommands: [
+            ListSubcommand.self,
+            ShowSubcommand.self,
+            AddSubcommand.self,
+            SetSubcommand.self,
+            DeleteSubcommand.self,
+            RestoreDefaultsSubcommand.self,
+            ExportSubcommand.self,
+            ImportSubcommand.self,
+        ],
+        defaultSubcommand: ListSubcommand.self
+    )
+}
+
+// MARK: - Shared
+
+enum QuickPromptKindArg: String, ExpressibleByArgument {
+    case starter
+    case followUp = "follow-up"
+
+    var domain: QuickPrompt.Kind {
+        switch self {
+        case .starter:  return .starter
+        case .followUp: return .followUp
+        }
+    }
+}
+
+/// Resolve a quick prompt by exact UUID, UUID prefix, or case-insensitive label.
+/// Names are checked only after no UUID-prefix match was found, mirroring
+/// `findPrompt`. Throws `CLILookupError` on miss / ambiguity.
+func findQuickPrompt(idOrLabel: String, repo: QuickPromptRepository) throws -> QuickPrompt {
+    let trimmed = idOrLabel.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { throw CLILookupError.emptyID }
+
+    if let uuid = UUID(uuidString: trimmed), let p = try repo.fetch(id: uuid) {
+        return p
+    }
+
+    let all = try repo.fetchAll()
+    let lowered = trimmed.lowercased()
+
+    if let prefix = quickPromptUUIDPrefixSearchKey(trimmed) {
+        let matches = all.filter { $0.id.uuidString.lowercased().hasPrefix(prefix) }
+        if matches.count == 1 { return matches[0] }
+        if matches.count > 1 {
+            throw CLILookupError.ambiguous("Multiple quick prompts match '\(trimmed)' as ID prefix. Be more specific.")
+        }
+    }
+
+    let labelMatches = all.filter { $0.label.lowercased() == lowered }
+    if labelMatches.count == 1 { return labelMatches[0] }
+    if labelMatches.count > 1 {
+        throw CLILookupError.ambiguous("Multiple quick prompts labeled '\(trimmed)'. Use ID instead.")
+    }
+    if let error = quickPromptShortPrefixErrorIfApplicable(trimmed) { throw error }
+
+    throw CLILookupError.notFound("No quick prompt matching '\(trimmed)'")
+}
+
+private func quickPromptUUIDPrefixSearchKey(_ value: String) -> String? {
+    let lowered = value.lowercased()
+    guard lowered.count >= 4,
+          lowered.allSatisfy({ $0 == "-" || $0.isHexDigit })
+    else { return nil }
+    return lowered
+}
+
+private func quickPromptShortPrefixErrorIfApplicable(_ value: String) -> CLILookupError? {
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty,
+          trimmed.count < 4,
+          trimmed.allSatisfy({ $0 == "-" || $0.isHexDigit })
+    else { return nil }
+    return .shortUUIDPrefix(minimumLength: 4)
+}
+
+private func renderBadges(_ p: QuickPrompt) -> String {
+    var badges: [String] = ["\(p.kind.rawValue)"]
+    if p.isBuiltIn { badges.append("built-in") }
+    if !p.isVisible { badges.append("hidden") }
+    if let group = p.groupLabel { badges.append("group: \(group)") }
+    return "  [\(badges.joined(separator: ", "))]"
+}
+
+enum QuickPromptCLIError: Error, LocalizedError {
+    case cannotDeleteBuiltIn(String)
+    case deleteFailed(String)
+    case emptyBody
+    case readFailed(String, underlying: Error)
+    case writeFailed(String, underlying: Error)
+    case importSchemaError(String)
+    case importCancelled
+
+    var errorDescription: String? {
+        switch self {
+        case .cannotDeleteBuiltIn(let label):
+            return "Cannot delete built-in quick prompt '\(label)'. Use `quick-prompts set <id> --hidden` to hide it instead."
+        case .deleteFailed(let label):
+            return "Delete failed for quick prompt '\(label)'."
+        case .emptyBody:
+            return "Prompt body is empty (provide --prompt, --from-file, or pipe via stdin)."
+        case .readFailed(let path, let underlying):
+            return "Failed to read '\(path)': \(underlying.localizedDescription)"
+        case .writeFailed(let path, let underlying):
+            return "Failed to write '\(path)': \(underlying.localizedDescription)"
+        case .importSchemaError(let message):
+            return "Import schema error: \(message)"
+        case .importCancelled:
+            return "Import cancelled."
+        }
+    }
+}
+
+// MARK: - List
+
+extension QuickPromptsCommand {
+    struct ListSubcommand: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "list",
+            abstract: "List quick prompts."
+        )
+
+        @Option(name: .long, help: "Filter by kind: starter or follow-up.")
+        var kind: QuickPromptKindArg?
+
+        @Flag(name: .long, help: "Only visible prompts.")
+        var visibleOnly: Bool = false
+
+        @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+        var json: Bool = false
+
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
+        func run() throws {
+            try emitJSONOrRethrow(json: json) {
+                try AppPaths.ensureDirectories()
+                let db = try DatabaseManager(path: resolvedDatabasePath(database))
+                let repo = QuickPromptRepository(dbQueue: db.dbQueue)
+
+                var prompts: [QuickPrompt]
+                if let kind = kind?.domain {
+                    prompts = visibleOnly
+                        ? try repo.fetchVisible(kind: kind)
+                        : try repo.fetchAll(kind: kind)
+                } else {
+                    prompts = try repo.fetchAll()
+                    if visibleOnly { prompts = prompts.filter { $0.isVisible } }
+                }
+
+                if json {
+                    try printJSON(prompts)
+                    return
+                }
+
+                if prompts.isEmpty {
+                    print("No quick prompts found.")
+                    return
+                }
+                for p in prompts {
+                    print("\(p.id.uuidString.prefix(8))  \(p.label)\(renderBadges(p))")
+                }
+                print()
+                print("\(prompts.count) quick prompt(s)")
+            }
+        }
+    }
+}
+
+// MARK: - Show
+
+extension QuickPromptsCommand {
+    struct ShowSubcommand: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "show",
+            abstract: "Show a quick prompt's full content."
+        )
+
+        @Argument(help: "Quick prompt ID, ID prefix, or label.")
+        var idOrLabel: String
+
+        @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+        var json: Bool = false
+
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
+        func run() throws {
+            try emitJSONOrRethrow(json: json) {
+                try AppPaths.ensureDirectories()
+                let db = try DatabaseManager(path: resolvedDatabasePath(database))
+                let repo = QuickPromptRepository(dbQueue: db.dbQueue)
+                let p = try findQuickPrompt(idOrLabel: idOrLabel, repo: repo)
+
+                if json {
+                    try printJSON(p)
+                    return
+                }
+
+                print("ID:        \(p.id.uuidString)")
+                print("Kind:      \(p.kind.rawValue)")
+                print("Label:     \(p.label)\(renderBadges(p))")
+                if let group = p.groupLabel { print("Group:     \(group)") }
+                print("Updated:   \(ISO8601DateFormatter().string(from: p.updatedAt))")
+                print()
+                print(p.prompt)
+            }
+        }
+    }
+}
+
+// MARK: - Add
+
+extension QuickPromptsCommand {
+    struct AddSubcommand: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "add",
+            abstract: "Add a custom quick prompt."
+        )
+
+        @Option(name: .long, help: "Pill kind: starter or follow-up.")
+        var kind: QuickPromptKindArg
+
+        @Option(name: .long, help: "Display label shown on the pill (short).")
+        var label: String
+
+        @Option(name: .long, help: "Full prompt body sent to the LLM. Mutually exclusive with --from-file.")
+        var prompt: String?
+
+        @Option(name: .long, help: "Path to a file containing the prompt body.")
+        var fromFile: String?
+
+        @Option(name: .long, help: "Optional group label (starters only — e.g. CATCH UP, CAPTURE, CHALLENGE).")
+        var group: String?
+
+        @Flag(name: .long, help: "Insert as hidden (visibility off).")
+        var hidden: Bool = false
+
+        @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+        var json: Bool = false
+
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
+        func validate() throws {
+            if prompt != nil && fromFile != nil {
+                throw ValidationError("--prompt and --from-file are mutually exclusive")
+            }
+            if label.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                throw ValidationError("--label must not be empty")
+            }
+            if kind.domain == .followUp && group != nil {
+                throw ValidationError("--group is only valid for starter prompts")
+            }
+        }
+
+        func run() throws {
+            try emitJSONOrRethrow(json: json) {
+                try AppPaths.ensureDirectories()
+                let db = try DatabaseManager(path: resolvedDatabasePath(database))
+                let repo = QuickPromptRepository(dbQueue: db.dbQueue)
+
+                let body: String
+                if let prompt {
+                    body = prompt
+                } else if let fromFile {
+                    do {
+                        body = try String(contentsOfFile: expandTilde(fromFile), encoding: .utf8)
+                    } catch {
+                        throw QuickPromptCLIError.readFailed(fromFile, underlying: error)
+                    }
+                } else {
+                    let data = FileHandle.standardInput.readDataToEndOfFile()
+                    body = String(data: data, encoding: .utf8) ?? ""
+                }
+                guard !body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                    throw QuickPromptCLIError.emptyBody
+                }
+
+                let nextSortOrder: Int = {
+                    let existing = (try? repo.fetchAll(kind: kind.domain)) ?? []
+                    return (existing.map(\.sortOrder).max() ?? -1) + 1
+                }()
+
+                let normalizedGroup: String? = {
+                    guard let raw = group else { return nil }
+                    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+                    return trimmed.isEmpty ? nil : trimmed
+                }()
+
+                let p = QuickPrompt(
+                    kind: kind.domain,
+                    label: label.trimmingCharacters(in: .whitespacesAndNewlines),
+                    prompt: body,
+                    groupLabel: normalizedGroup,
+                    sortOrder: nextSortOrder,
+                    isVisible: !hidden,
+                    isBuiltIn: false
+                )
+                try repo.save(p)
+
+                if json {
+                    try printJSON(p)
+                } else {
+                    print("Added quick prompt '\(p.label)' (\(p.id.uuidString.prefix(8)))")
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Set
+
+extension QuickPromptsCommand {
+    struct SetSubcommand: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "set",
+            abstract: "Update a quick prompt's fields or visibility."
+        )
+
+        @Argument(help: "Quick prompt ID, ID prefix, or label.")
+        var idOrLabel: String
+
+        @Option(name: .long, help: "Replace the display label.")
+        var label: String?
+
+        @Option(name: .long, help: "Replace the prompt body.")
+        var prompt: String?
+
+        @Option(name: .long, help: "Replace the group label (starters only). Pass empty string to clear.")
+        var group: String?
+
+        @Option(name: .long, help: "Replace the sort order (integer; lower = earlier).")
+        var sortOrder: Int?
+
+        @Flag(name: .long, help: "Make visible.")
+        var visible: Bool = false
+
+        @Flag(name: .long, help: "Hide.")
+        var hidden: Bool = false
+
+        @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+        var json: Bool = false
+
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
+        func validate() throws {
+            if visible && hidden {
+                throw ValidationError("--visible and --hidden are mutually exclusive")
+            }
+            if label == nil && prompt == nil && group == nil && sortOrder == nil && !visible && !hidden {
+                throw ValidationError("specify at least one field to change (--label / --prompt / --group / --sort-order / --visible / --hidden)")
+            }
+        }
+
+        func run() throws {
+            try emitJSONOrRethrow(json: json) {
+                try AppPaths.ensureDirectories()
+                let db = try DatabaseManager(path: resolvedDatabasePath(database))
+                let repo = QuickPromptRepository(dbQueue: db.dbQueue)
+
+                var p = try findQuickPrompt(idOrLabel: idOrLabel, repo: repo)
+
+                if let label {
+                    p.label = label.trimmingCharacters(in: .whitespacesAndNewlines)
+                }
+                if let prompt {
+                    p.prompt = prompt
+                }
+                if let group {
+                    let trimmed = group.trimmingCharacters(in: .whitespacesAndNewlines)
+                    p.groupLabel = trimmed.isEmpty ? nil : trimmed
+                }
+                if let sortOrder {
+                    p.sortOrder = sortOrder
+                }
+                if visible { p.isVisible = true }
+                if hidden  { p.isVisible = false }
+
+                p.updatedAt = Date()
+                try repo.save(p)
+
+                if json {
+                    try printJSON(p)
+                } else {
+                    print("Updated '\(p.label)':\(renderBadges(p))")
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Delete
+
+extension QuickPromptsCommand {
+    struct DeleteSubcommand: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "delete",
+            abstract: "Delete a custom quick prompt (built-ins cannot be deleted)."
+        )
+
+        @Argument(help: "Quick prompt ID, ID prefix, or label.")
+        var idOrLabel: String
+
+        @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+        var json: Bool = false
+
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
+        func run() throws {
+            try emitJSONOrRethrow(json: json) {
+                try AppPaths.ensureDirectories()
+                let db = try DatabaseManager(path: resolvedDatabasePath(database))
+                let repo = QuickPromptRepository(dbQueue: db.dbQueue)
+
+                let p = try findQuickPrompt(idOrLabel: idOrLabel, repo: repo)
+                if p.isBuiltIn {
+                    throw QuickPromptCLIError.cannotDeleteBuiltIn(p.label)
+                }
+                let deleted = try repo.delete(id: p.id)
+                guard deleted else { throw QuickPromptCLIError.deleteFailed(p.label) }
+
+                if json {
+                    struct DeleteResult: Encodable { let ok: Bool; let id: UUID; let label: String }
+                    try printJSON(DeleteResult(ok: true, id: p.id, label: p.label))
+                } else {
+                    print("Deleted quick prompt '\(p.label)'")
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Restore Defaults
+
+extension QuickPromptsCommand {
+    struct RestoreDefaultsSubcommand: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "restore-defaults",
+            abstract: "Reset built-in quick prompts to canonical values (preserves visibility, leaves customs alone)."
+        )
+
+        @Option(name: .long, help: "Limit restore to one kind: starter or follow-up.")
+        var kind: QuickPromptKindArg?
+
+        @Option(name: .long, help: "Limit restore to a single built-in by ID. Mutually exclusive with --kind.")
+        var id: String?
+
+        @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+        var json: Bool = false
+
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
+        func validate() throws {
+            if kind != nil && id != nil {
+                throw ValidationError("--kind and --id are mutually exclusive")
+            }
+        }
+
+        func run() throws {
+            try emitJSONOrRethrow(json: json) {
+                try AppPaths.ensureDirectories()
+                let db = try DatabaseManager(path: resolvedDatabasePath(database))
+                let repo = QuickPromptRepository(dbQueue: db.dbQueue)
+
+                if let id {
+                    let p = try findQuickPrompt(idOrLabel: id, repo: repo)
+                    guard p.isBuiltIn else {
+                        throw ValidationError("'\(p.label)' is not a built-in quick prompt; nothing to restore.")
+                    }
+                    try repo.restoreBuiltInDefault(id: p.id)
+                    if json {
+                        struct R: Encodable { let ok: Bool; let id: UUID; let label: String }
+                        try printJSON(R(ok: true, id: p.id, label: p.label))
+                    } else {
+                        print("Restored '\(p.label)' to built-in defaults.")
+                    }
+                } else {
+                    try repo.restoreBuiltInDefaults(kind: kind?.domain)
+                    if json {
+                        struct R: Encodable { let ok: Bool; let kind: String? }
+                        try printJSON(R(ok: true, kind: kind?.rawValue))
+                    } else {
+                        let scope = kind?.rawValue ?? "all kinds"
+                        print("Restored built-in defaults (\(scope)).")
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Export
+
+extension QuickPromptsCommand {
+    struct ExportSubcommand: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "export",
+            abstract: "Export quick prompts as a versioned JSON bundle."
+        )
+
+        @Option(name: .long, help: "Output file path. If omitted, writes JSON to stdout.")
+        var out: String?
+
+        @Option(name: .long, help: "Limit export to one kind: starter or follow-up.")
+        var kind: QuickPromptKindArg?
+
+        @Flag(name: .long, help: "Include built-in pills in the export. Default: customs only.")
+        var includeBuiltins: Bool = false
+
+        @Flag(name: .long, help: "Emit JSON envelope on failure (success always writes the bundle JSON).")
+        var json: Bool = false
+
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
+        func run() throws {
+            try emitJSONOrRethrow(json: json) {
+                try AppPaths.ensureDirectories()
+                let db = try DatabaseManager(path: resolvedDatabasePath(database))
+                let repo = QuickPromptRepository(dbQueue: db.dbQueue)
+
+                var prompts: [QuickPrompt]
+                if let kind = kind?.domain {
+                    prompts = try repo.fetchAll(kind: kind)
+                } else {
+                    prompts = try repo.fetchAll()
+                }
+                if !includeBuiltins {
+                    prompts = prompts.filter { !$0.isBuiltIn }
+                }
+
+                let bundle = QuickPromptBundle(from: prompts, exportedAt: Date(), appVersion: nil)
+                let data = try cliJSONEncoder.encode(bundle)
+
+                if let out {
+                    let path = expandTilde(out)
+                    let dir = URL(fileURLWithPath: path).deletingLastPathComponent()
+                    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+                    do {
+                        try data.write(to: URL(fileURLWithPath: path))
+                    } catch {
+                        throw QuickPromptCLIError.writeFailed(out, underlying: error)
+                    }
+                    printErr("Wrote \(prompts.count) quick prompt(s) to \(path)")
+                } else {
+                    if let s = String(data: data, encoding: .utf8) {
+                        print(s)
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Import
+
+extension QuickPromptsCommand {
+    struct ImportSubcommand: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "import",
+            abstract: "Import a quick prompts bundle from a JSON file."
+        )
+
+        @Argument(help: "Path to the bundle JSON file.")
+        var path: String
+
+        @Option(name: .long, help: "Import mode: merge (default; UPSERT by id, preserve untouched rows) or replace (wipe customs, re-seed built-ins, then apply).")
+        var mode: ModeArg = .merge
+
+        @Flag(name: .long, help: "Show planned changes without writing.")
+        var dryRun: Bool = false
+
+        @Flag(name: .long, help: "Skip the confirmation prompt for --mode replace. Implied by --json.")
+        var yes: Bool = false
+
+        @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+        var json: Bool = false
+
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
+        enum ModeArg: String, ExpressibleByArgument {
+            case merge, replace
+            var domain: QuickPromptImport.Mode {
+                switch self {
+                case .merge:   return .merge
+                case .replace: return .replace
+                }
+            }
+        }
+
+        func run() throws {
+            try emitJSONOrRethrow(json: json) {
+                try AppPaths.ensureDirectories()
+                let resolvedPath = expandTilde(path)
+                let data: Data
+                do {
+                    data = try Data(contentsOf: URL(fileURLWithPath: resolvedPath))
+                } catch {
+                    throw QuickPromptCLIError.readFailed(path, underlying: error)
+                }
+
+                let bundle: QuickPromptBundle
+                do {
+                    let decoder = JSONDecoder()
+                    decoder.dateDecodingStrategy = .iso8601
+                    bundle = try decoder.decode(QuickPromptBundle.self, from: data)
+                } catch {
+                    throw QuickPromptCLIError.importSchemaError(error.localizedDescription)
+                }
+
+                do {
+                    try bundle.validate()
+                } catch let validationError as QuickPromptBundleError {
+                    throw QuickPromptCLIError.importSchemaError(validationError.localizedDescription)
+                }
+
+                if mode.domain == .replace && !yes && !json && !dryRun {
+                    let banner = "About to delete all custom quick prompts and re-seed built-ins, then apply \(bundle.prompts.count) prompt(s) from '\(path)'."
+                    printErr(banner)
+                    printErr("Type 'yes' to continue, anything else to abort:")
+                    let response = readLine()?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+                    guard response == "yes" else {
+                        throw QuickPromptCLIError.importCancelled
+                    }
+                }
+
+                let db = try DatabaseManager(path: resolvedDatabasePath(database))
+                let repo = QuickPromptRepository(dbQueue: db.dbQueue)
+                let summary = try repo.applyImport(bundle, mode: mode.domain, dryRun: dryRun)
+
+                if json {
+                    struct ImportResult: Encodable {
+                        let ok: Bool
+                        let mode: String
+                        let dryRun: Bool
+                        let added: Int
+                        let updated: Int
+                        let deleted: Int
+                        let unchanged: Int
+                    }
+                    let result = ImportResult(
+                        ok: true,
+                        mode: mode.rawValue,
+                        dryRun: dryRun,
+                        added: summary.added,
+                        updated: summary.updated,
+                        deleted: summary.deleted,
+                        unchanged: summary.unchanged
+                    )
+                    try printJSON(result)
+                } else {
+                    let prefix = dryRun ? "[dry-run] " : ""
+                    print("\(prefix)added: \(summary.added), updated: \(summary.updated), deleted: \(summary.deleted), unchanged: \(summary.unchanged)")
+                }
+            }
+        }
+    }
+}

--- a/Sources/CLI/MacParakeetCLI.swift
+++ b/Sources/CLI/MacParakeetCLI.swift
@@ -6,7 +6,7 @@ struct CLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "macparakeet-cli",
         abstract: "Local STT, transcription, and prompt automation for Apple Silicon. Powered by Parakeet TDT, with optional Whisper multilingual recognition.",
-        version: "1.4.0",
+        version: "1.5.0",
         subcommands: [
             TranscribeCommand.self,
             HistoryCommand.self,
@@ -18,6 +18,7 @@ struct CLI: AsyncParsableCommand {
             FlowCommand.self,
             LLMCommand.self,
             PromptsCommand.self,
+            QuickPromptsCommand.self,
             MeetingsCommand.self,
             CalendarCommand.self,
             FeedbackCommand.self,

--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -12,6 +12,7 @@ final class AppEnvironment {
     let chatConversationRepo: ChatConversationRepository
     let promptRepo: PromptRepository
     let promptResultRepo: PromptResultRepository
+    let quickPromptRepo: QuickPromptRepository
     let sttRuntime: STTRuntime
     let sttScheduler: STTScheduler
     let sharedMicStream: SharedMicrophoneStream
@@ -47,6 +48,7 @@ final class AppEnvironment {
         chatConversationRepo = ChatConversationRepository(dbQueue: databaseManager.dbQueue)
         promptRepo = PromptRepository(dbQueue: databaseManager.dbQueue)
         promptResultRepo = PromptResultRepository(dbQueue: databaseManager.dbQueue)
+        quickPromptRepo = QuickPromptRepository(dbQueue: databaseManager.dbQueue)
 
         // Services
         let runtimePreferences = UserDefaultsAppRuntimePreferences()

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -221,6 +221,7 @@ final class AppEnvironmentConfigurer {
             permissionService: env.permissionService,
             transcriptionRepo: env.transcriptionRepo,
             conversationRepo: env.chatConversationRepo,
+            quickPromptRepo: env.quickPromptRepo,
             configStore: env.llmConfigStore,
             meetingAudioSourceModeProvider: { env.runtimePreferences.meetingAudioSourceMode },
             llmService: hasLLMConfig ? env.llmService : nil,

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -37,6 +37,7 @@ final class MeetingRecordingFlowCoordinator {
     private let permissionService: PermissionServiceProtocol
     private let transcriptionRepo: TranscriptionRepositoryProtocol
     private let conversationRepo: ChatConversationRepositoryProtocol
+    private let quickPromptRepo: QuickPromptRepositoryProtocol
     private let configStore: LLMConfigStoreProtocol
     private let cliConfigStore: LocalCLIConfigStore
     private let meetingAudioSourceModeProvider: @MainActor @Sendable () -> MeetingAudioSourceMode
@@ -67,6 +68,7 @@ final class MeetingRecordingFlowCoordinator {
         permissionService: PermissionServiceProtocol,
         transcriptionRepo: TranscriptionRepositoryProtocol,
         conversationRepo: ChatConversationRepositoryProtocol,
+        quickPromptRepo: QuickPromptRepositoryProtocol,
         configStore: LLMConfigStoreProtocol,
         cliConfigStore: LocalCLIConfigStore = LocalCLIConfigStore(),
         meetingAudioSourceModeProvider: @escaping @MainActor @Sendable () -> MeetingAudioSourceMode = { .microphoneAndSystem },
@@ -81,6 +83,7 @@ final class MeetingRecordingFlowCoordinator {
         self.permissionService = permissionService
         self.transcriptionRepo = transcriptionRepo
         self.conversationRepo = conversationRepo
+        self.quickPromptRepo = quickPromptRepo
         self.configStore = configStore
         self.cliConfigStore = cliConfigStore
         self.meetingAudioSourceModeProvider = meetingAudioSourceModeProvider
@@ -300,6 +303,7 @@ final class MeetingRecordingFlowCoordinator {
                 configStore: configStore,
                 cliConfigStore: cliConfigStore
             )
+            panelVM.quickPromptsViewModel.configure(repo: quickPromptRepo)
             // Wire the notepad's debounced persistence target through the
             // recording service. The service serializes lock-file writes and
             // carries the latest notes into MeetingRecordingOutput.userNotes,

--- a/Sources/MacParakeet/Views/MeetingRecording/AskPromptsSheet.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/AskPromptsSheet.swift
@@ -12,6 +12,7 @@ struct AskPromptsSheet: View {
 
     @State private var hoveredID: UUID?
     @State private var pendingDelete: QuickPrompt?
+    @State private var pendingResetKind: QuickPrompt.Kind?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -58,6 +59,23 @@ struct AskPromptsSheet: View {
             Button("Cancel", role: .cancel) { pendingDelete = nil }
         } message: {
             Text("This custom pill will be removed from the Ask tab.")
+        }
+        .alert(
+            "Reset built-ins?",
+            isPresented: Binding(
+                get: { pendingResetKind != nil },
+                set: { if !$0 { pendingResetKind = nil } }
+            )
+        ) {
+            Button("Reset", role: .destructive) {
+                if let kind = pendingResetKind {
+                    withAnimation { viewModel.restoreBuiltInDefaults(kind: kind) }
+                }
+                pendingResetKind = nil
+            }
+            Button("Cancel", role: .cancel) { pendingResetKind = nil }
+        } message: {
+            Text("Built-in labels, prompt text, and ordering for this section will return to defaults. Custom pills stay untouched.")
         }
         .sheet(
             isPresented: Binding(
@@ -134,7 +152,7 @@ struct AskPromptsSheet: View {
 
                 Menu {
                     Button("Reset built-ins") {
-                        withAnimation { viewModel.restoreBuiltInDefaults(kind: kind) }
+                        pendingResetKind = kind
                     }
                     Button("Add new \(kind == .starter ? "starter" : "follow-up")") {
                         viewModel.startCreating(kind: kind)
@@ -151,7 +169,7 @@ struct AskPromptsSheet: View {
 
             cardGroup {
                 ForEach(Array(rows.enumerated()), id: \.element.id) { index, prompt in
-                    promptRow(prompt, kind: kind)
+                    promptRow(prompt, kind: kind, rows: rows, index: index)
                     if index < rows.count - 1 { Divider().padding(.leading, 16) }
                 }
                 if rows.isEmpty {
@@ -193,7 +211,7 @@ struct AskPromptsSheet: View {
 
     // MARK: - Row
 
-    private func promptRow(_ prompt: QuickPrompt, kind: QuickPrompt.Kind) -> some View {
+    private func promptRow(_ prompt: QuickPrompt, kind: QuickPrompt.Kind, rows: [QuickPrompt], index: Int) -> some View {
         let isHovered = hoveredID == prompt.id
 
         return HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
@@ -253,6 +271,26 @@ struct AskPromptsSheet: View {
 
             HStack(spacing: 4) {
                 Button {
+                    movePrompt(prompt, by: -1, in: rows, kind: kind)
+                } label: {
+                    rowIcon("chevron.up", isHovered: isHovered)
+                }
+                .buttonStyle(.plain)
+                .disabled(index == 0)
+                .opacity(index == 0 ? 0.25 : 1)
+                .help("Move up")
+
+                Button {
+                    movePrompt(prompt, by: 1, in: rows, kind: kind)
+                } label: {
+                    rowIcon("chevron.down", isHovered: isHovered)
+                }
+                .buttonStyle(.plain)
+                .disabled(index >= rows.count - 1)
+                .opacity(index >= rows.count - 1 ? 0.25 : 1)
+                .help("Move down")
+
+                Button {
                     viewModel.editingPrompt = prompt
                 } label: {
                     rowIcon("pencil", isHovered: isHovered)
@@ -289,6 +327,15 @@ struct AskPromptsSheet: View {
                 hoveredID = hovering ? prompt.id : nil
             }
         }
+    }
+
+    private func movePrompt(_ prompt: QuickPrompt, by delta: Int, in rows: [QuickPrompt], kind: QuickPrompt.Kind) {
+        var ids = rows.map(\.id)
+        guard let currentIndex = ids.firstIndex(of: prompt.id) else { return }
+        let newIndex = currentIndex + delta
+        guard ids.indices.contains(newIndex) else { return }
+        ids.swapAt(currentIndex, newIndex)
+        withAnimation { viewModel.reorder(ids: ids, within: kind) }
     }
 
     private func rowIcon(_ system: String, isHovered: Bool, destructive: Bool = false) -> some View {
@@ -339,14 +386,14 @@ struct AskPromptsSheet: View {
 private struct EditPromptSheet: View {
     @Environment(\.dismiss) private var dismiss
     let initial: QuickPrompt
-    let onSave: (QuickPrompt) -> Void
+    let onSave: (QuickPrompt) -> Bool
     let onCancel: () -> Void
 
     @State private var label: String
     @State private var promptBody: String
     @State private var groupLabel: String
 
-    init(prompt: QuickPrompt, onSave: @escaping (QuickPrompt) -> Void, onCancel: @escaping () -> Void) {
+    init(prompt: QuickPrompt, onSave: @escaping (QuickPrompt) -> Bool, onCancel: @escaping () -> Void) {
         self.initial = prompt
         self.onSave = onSave
         self.onCancel = onCancel
@@ -442,8 +489,9 @@ private struct EditPromptSheet: View {
         updated.prompt = promptBody
         let trimmed = groupLabel.trimmingCharacters(in: .whitespacesAndNewlines)
         updated.groupLabel = trimmed.isEmpty ? nil : trimmed
-        onSave(updated)
-        dismiss()
+        if onSave(updated) {
+            dismiss()
+        }
     }
 }
 
@@ -462,8 +510,9 @@ private struct CreatePromptSheet: View {
                 Spacer()
                 Button("Cancel") { viewModel.cancelCreating(); dismiss() }
                 Button("Add") {
-                    viewModel.commitCreating()
-                    dismiss()
+                    if viewModel.commitCreating() {
+                        dismiss()
+                    }
                 }
                 .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.defaultAction)

--- a/Sources/MacParakeet/Views/MeetingRecording/AskPromptsSheet.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/AskPromptsSheet.swift
@@ -1,0 +1,554 @@
+import SwiftUI
+import MacParakeetCore
+import MacParakeetViewModels
+
+/// Manage Ask tab quick prompts (starter + follow-up). Reachable from the
+/// sparkle popover footer in `LiveAskPaneView`. Reuses Prompt Library design
+/// tokens for visual consistency, but is tighter — pills are micro-shortcuts,
+/// not heavyweight result templates, so we drop auto-run / expand chrome.
+struct AskPromptsSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Bindable var viewModel: QuickPromptsViewModel
+
+    @State private var hoveredID: UUID?
+    @State private var pendingDelete: QuickPrompt?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            ScrollView {
+                VStack(spacing: DesignSystem.Spacing.xxl) {
+                    if let errorMessage = viewModel.errorMessage {
+                        errorBanner(errorMessage)
+                    }
+
+                    section(
+                        title: "Starters",
+                        subtitle: "Shown when the Ask tab is empty and inside the sparkle menu mid-conversation. Optional group label clusters related pills (CATCH UP, CAPTURE, CHALLENGE).",
+                        kind: .starter,
+                        rows: viewModel.allStarters
+                    )
+
+                    section(
+                        title: "Follow-ups",
+                        subtitle: "Shown above the input mid-conversation. Universal next-moves on the previous response — keep this row tight.",
+                        kind: .followUp,
+                        rows: viewModel.allFollowUps
+                    )
+                }
+                .padding(DesignSystem.Spacing.xl)
+            }
+        }
+        .background(DesignSystem.Colors.background)
+        .frame(minWidth: 720, minHeight: 640)
+        .alert(
+            "Delete quick prompt?",
+            isPresented: Binding(
+                get: { pendingDelete != nil },
+                set: { if !$0 { pendingDelete = nil } }
+            )
+        ) {
+            Button("Delete", role: .destructive) {
+                if let prompt = pendingDelete {
+                    withAnimation { viewModel.delete(prompt) }
+                }
+                pendingDelete = nil
+            }
+            Button("Cancel", role: .cancel) { pendingDelete = nil }
+        } message: {
+            Text("This custom pill will be removed from the Ask tab.")
+        }
+        .sheet(
+            isPresented: Binding(
+                get: { viewModel.editingPrompt != nil },
+                set: { if !$0 { viewModel.editingPrompt = nil } }
+            )
+        ) {
+            if let editing = viewModel.editingPrompt {
+                EditPromptSheet(prompt: editing) { updated in
+                    viewModel.saveEdit(updated)
+                } onCancel: {
+                    viewModel.editingPrompt = nil
+                }
+            }
+        }
+        .sheet(
+            isPresented: Binding(
+                get: { viewModel.creating != nil },
+                set: { if !$0 { viewModel.cancelCreating() } }
+            )
+        ) {
+            if viewModel.creating != nil {
+                CreatePromptSheet(viewModel: viewModel)
+            }
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(alignment: .bottom) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Ask Prompts")
+                    .font(DesignSystem.Typography.heroTitle)
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+                Text("Customize the pills that show up above your live meeting Ask input.")
+                    .font(DesignSystem.Typography.body)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+            }
+            Spacer()
+            Button {
+                dismiss()
+            } label: {
+                Text("Done")
+                    .font(DesignSystem.Typography.body.weight(.semibold))
+                    .padding(.horizontal, DesignSystem.Spacing.sm)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+        }
+        .padding(DesignSystem.Spacing.xl)
+        .background(DesignSystem.Colors.surface)
+    }
+
+    // MARK: - Section
+
+    private func section(
+        title: String,
+        subtitle: String,
+        kind: QuickPrompt.Kind,
+        rows: [QuickPrompt]
+    ) -> some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+            HStack(alignment: .bottom) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(DesignSystem.Typography.sectionTitle)
+                        .foregroundStyle(DesignSystem.Colors.textPrimary)
+                    Text(subtitle)
+                        .font(DesignSystem.Typography.bodySmall)
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+                }
+                Spacer()
+
+                Menu {
+                    Button("Reset built-ins") {
+                        withAnimation { viewModel.restoreBuiltInDefaults(kind: kind) }
+                    }
+                    Button("Add new \(kind == .starter ? "starter" : "follow-up")") {
+                        viewModel.startCreating(kind: kind)
+                    }
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                        .font(.system(size: 16))
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+                }
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .frame(width: 28, height: 28)
+            }
+
+            cardGroup {
+                ForEach(Array(rows.enumerated()), id: \.element.id) { index, prompt in
+                    promptRow(prompt, kind: kind)
+                    if index < rows.count - 1 { Divider().padding(.leading, 16) }
+                }
+                if rows.isEmpty {
+                    Button {
+                        viewModel.startCreating(kind: kind)
+                    } label: {
+                        HStack(spacing: 6) {
+                            Image(systemName: "plus")
+                                .font(.system(size: 12, weight: .semibold))
+                            Text("Add \(kind == .starter ? "a starter" : "a follow-up")")
+                                .font(DesignSystem.Typography.body.weight(.medium))
+                        }
+                        .foregroundStyle(DesignSystem.Colors.accent)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, DesignSystem.Spacing.lg)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+            if !rows.isEmpty {
+                Button {
+                    viewModel.startCreating(kind: kind)
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "plus")
+                            .font(.system(size: 11, weight: .semibold))
+                        Text("Add \(kind == .starter ? "a starter" : "a follow-up")")
+                            .font(DesignSystem.Typography.bodySmall.weight(.medium))
+                    }
+                    .foregroundStyle(DesignSystem.Colors.accent)
+                    .padding(.vertical, 6)
+                    .padding(.horizontal, 4)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    // MARK: - Row
+
+    private func promptRow(_ prompt: QuickPrompt, kind: QuickPrompt.Kind) -> some View {
+        let isHovered = hoveredID == prompt.id
+
+        return HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+            Toggle("", isOn: Binding(
+                get: { prompt.isVisible },
+                set: { _ in withAnimation { viewModel.toggleVisibility(prompt) } }
+            ))
+            .toggleStyle(.switch)
+            .controlSize(.small)
+            .tint(DesignSystem.Colors.accent)
+            .padding(.top, 2)
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 8) {
+                    Text(prompt.label)
+                        .font(DesignSystem.Typography.bodyLarge.weight(.semibold))
+                        .foregroundStyle(prompt.isVisible
+                                         ? DesignSystem.Colors.textPrimary
+                                         : DesignSystem.Colors.textTertiary)
+
+                    if let group = prompt.groupLabel, !group.isEmpty {
+                        Text(group)
+                            .font(.system(size: 9, weight: .semibold))
+                            .tracking(0.6)
+                            .foregroundStyle(DesignSystem.Colors.textTertiary)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(
+                                Capsule().fill(DesignSystem.Colors.surfaceElevated.opacity(0.6))
+                            )
+                    }
+
+                    if prompt.isBuiltIn {
+                        Text("default")
+                            .font(.system(size: 9, weight: .semibold))
+                            .tracking(0.4)
+                            .foregroundStyle(DesignSystem.Colors.textTertiary)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(
+                                Capsule().strokeBorder(DesignSystem.Colors.border, lineWidth: 0.5)
+                            )
+                    }
+
+                    Spacer()
+                }
+
+                Text(prompt.prompt)
+                    .font(DesignSystem.Typography.body)
+                    .foregroundStyle(prompt.isVisible
+                                     ? DesignSystem.Colors.textSecondary
+                                     : DesignSystem.Colors.textTertiary)
+                    .lineLimit(2)
+                    .lineSpacing(2)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            HStack(spacing: 4) {
+                Button {
+                    viewModel.editingPrompt = prompt
+                } label: {
+                    rowIcon("pencil", isHovered: isHovered)
+                }
+                .buttonStyle(.plain)
+                .help("Edit")
+
+                if prompt.isBuiltIn {
+                    Button {
+                        withAnimation { viewModel.restoreSingleDefault(prompt) }
+                    } label: {
+                        rowIcon("arrow.uturn.backward", isHovered: isHovered)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Restore default")
+                } else {
+                    Button {
+                        pendingDelete = prompt
+                    } label: {
+                        rowIcon("trash", isHovered: isHovered, destructive: true)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Delete")
+                }
+            }
+            .opacity(isHovered ? 1.0 : 0.4)
+            .animation(.easeInOut(duration: 0.18), value: isHovered)
+        }
+        .padding(DesignSystem.Spacing.lg)
+        .background(isHovered ? DesignSystem.Colors.surfaceElevated.opacity(0.5) : Color.clear)
+        .contentShape(Rectangle())
+        .onHover { hovering in
+            withAnimation(DesignSystem.Animation.hoverTransition) {
+                hoveredID = hovering ? prompt.id : nil
+            }
+        }
+    }
+
+    private func rowIcon(_ system: String, isHovered: Bool, destructive: Bool = false) -> some View {
+        let foreground: Color = {
+            if destructive { return isHovered ? DesignSystem.Colors.errorRed : DesignSystem.Colors.textTertiary }
+            return isHovered ? DesignSystem.Colors.textSecondary : DesignSystem.Colors.textTertiary
+        }()
+        let background: Color = {
+            if destructive && isHovered { return DesignSystem.Colors.errorRed.opacity(0.1) }
+            return isHovered ? DesignSystem.Colors.rowHoverBackground : .clear
+        }()
+        return Image(systemName: system)
+            .font(.system(size: 13))
+            .foregroundStyle(foreground)
+            .frame(width: 26, height: 26)
+            .background(background)
+            .clipShape(Circle())
+    }
+
+    private func cardGroup<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        VStack(spacing: 0) { content() }
+            .background(DesignSystem.Colors.surface)
+            .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius))
+            .overlay(
+                RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
+                    .strokeBorder(DesignSystem.Colors.border, lineWidth: 1)
+            )
+            .cardShadow(DesignSystem.Shadows.cardRest)
+    }
+
+    private func errorBanner(_ message: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+            Text(message).font(DesignSystem.Typography.body.weight(.medium))
+            Spacer()
+        }
+        .foregroundStyle(DesignSystem.Colors.errorRed)
+        .padding()
+        .background(DesignSystem.Colors.errorRed.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius))
+    }
+}
+
+// MARK: - Edit / Create
+
+/// Edit-in-place sheet. Built-ins are editable here too — that is the
+/// intentional divergence from Prompt Library (where built-ins are read-only).
+private struct EditPromptSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    let initial: QuickPrompt
+    let onSave: (QuickPrompt) -> Void
+    let onCancel: () -> Void
+
+    @State private var label: String
+    @State private var promptBody: String
+    @State private var groupLabel: String
+
+    init(prompt: QuickPrompt, onSave: @escaping (QuickPrompt) -> Void, onCancel: @escaping () -> Void) {
+        self.initial = prompt
+        self.onSave = onSave
+        self.onCancel = onCancel
+        self._label = State(initialValue: prompt.label)
+        self._promptBody = State(initialValue: prompt.prompt)
+        self._groupLabel = State(initialValue: prompt.groupLabel ?? "")
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Edit \(initial.kind == .starter ? "starter" : "follow-up")")
+                    .font(DesignSystem.Typography.sectionTitle)
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+                Spacer()
+                Button("Cancel") { onCancel(); dismiss() }
+                Button("Save") { commit() }
+                    .buttonStyle(.borderedProminent)
+                    .keyboardShortcut(.defaultAction)
+            }
+            .padding(DesignSystem.Spacing.lg)
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
+                    field(title: "Label (shown on the pill)", text: $label, placeholder: "Tell me more")
+                    if initial.kind == .starter {
+                        field(
+                            title: "Group (optional — e.g. CATCH UP, CAPTURE, CHALLENGE)",
+                            text: $groupLabel,
+                            placeholder: "Leave blank for ungrouped"
+                        )
+                    }
+                    promptField
+                }
+                .padding(DesignSystem.Spacing.xl)
+            }
+        }
+        .frame(minWidth: 560, minHeight: 480)
+        .background(DesignSystem.Colors.background)
+    }
+
+    private func field(title: String, text: Binding<String>, placeholder: String) -> some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            Text(title)
+                .font(DesignSystem.Typography.caption.weight(.medium))
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+            TextField(placeholder, text: text)
+                .textFieldStyle(.plain)
+                .font(DesignSystem.Typography.bodyLarge)
+                .padding(10)
+                .background(DesignSystem.Colors.surface)
+                .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius))
+                .overlay(
+                    RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
+                        .strokeBorder(DesignSystem.Colors.border, lineWidth: 1)
+                )
+        }
+    }
+
+    private var promptField: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            Text("Prompt sent to the LLM")
+                .font(DesignSystem.Typography.caption.weight(.medium))
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+            ZStack(alignment: .topLeading) {
+                TextEditor(text: $promptBody)
+                    .font(DesignSystem.Typography.body)
+                    .scrollContentBackground(.hidden)
+                    .padding(6)
+                if promptBody.isEmpty {
+                    Text("Expand on your previous response with concrete detail from the meeting…")
+                        .font(DesignSystem.Typography.body)
+                        .foregroundStyle(DesignSystem.Colors.textTertiary)
+                        .padding(.top, 8)
+                        .padding(.leading, 10)
+                        .allowsHitTesting(false)
+                }
+            }
+            .frame(minHeight: 180)
+            .background(DesignSystem.Colors.surface)
+            .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius))
+            .overlay(
+                RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
+                    .strokeBorder(DesignSystem.Colors.border, lineWidth: 1)
+            )
+        }
+    }
+
+    private func commit() {
+        var updated = initial
+        updated.label = label
+        updated.prompt = promptBody
+        let trimmed = groupLabel.trimmingCharacters(in: .whitespacesAndNewlines)
+        updated.groupLabel = trimmed.isEmpty ? nil : trimmed
+        onSave(updated)
+        dismiss()
+    }
+}
+
+private struct CreatePromptSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Bindable var viewModel: QuickPromptsViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                if let kind = viewModel.creating?.kind {
+                    Text("New \(kind == .starter ? "starter" : "follow-up")")
+                        .font(DesignSystem.Typography.sectionTitle)
+                        .foregroundStyle(DesignSystem.Colors.textPrimary)
+                }
+                Spacer()
+                Button("Cancel") { viewModel.cancelCreating(); dismiss() }
+                Button("Add") {
+                    viewModel.commitCreating()
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+            }
+            .padding(DesignSystem.Spacing.lg)
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
+                    if viewModel.creating != nil {
+                        field(
+                            title: "Label (shown on the pill)",
+                            binding: Binding(
+                                get: { viewModel.creating?.label ?? "" },
+                                set: { viewModel.creating?.label = $0 }
+                            ),
+                            placeholder: "ELI5"
+                        )
+                        if viewModel.creating?.kind == .starter {
+                            field(
+                                title: "Group (optional)",
+                                binding: Binding(
+                                    get: { viewModel.creating?.groupLabel ?? "" },
+                                    set: { viewModel.creating?.groupLabel = $0 }
+                                ),
+                                placeholder: "CATCH UP / CAPTURE / CHALLENGE"
+                            )
+                        }
+                        promptField
+                    }
+                }
+                .padding(DesignSystem.Spacing.xl)
+            }
+        }
+        .frame(minWidth: 560, minHeight: 480)
+        .background(DesignSystem.Colors.background)
+    }
+
+    private func field(title: String, binding: Binding<String>, placeholder: String) -> some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            Text(title)
+                .font(DesignSystem.Typography.caption.weight(.medium))
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+            TextField(placeholder, text: binding)
+                .textFieldStyle(.plain)
+                .font(DesignSystem.Typography.bodyLarge)
+                .padding(10)
+                .background(DesignSystem.Colors.surface)
+                .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius))
+                .overlay(
+                    RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
+                        .strokeBorder(DesignSystem.Colors.border, lineWidth: 1)
+                )
+        }
+    }
+
+    private var promptField: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            Text("Prompt sent to the LLM")
+                .font(DesignSystem.Typography.caption.weight(.medium))
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+            ZStack(alignment: .topLeading) {
+                TextEditor(text: Binding(
+                    get: { viewModel.creating?.prompt ?? "" },
+                    set: { viewModel.creating?.prompt = $0 }
+                ))
+                .font(DesignSystem.Typography.body)
+                .scrollContentBackground(.hidden)
+                .padding(6)
+                if (viewModel.creating?.prompt ?? "").isEmpty {
+                    Text("Explain your previous response like I'm five…")
+                        .font(DesignSystem.Typography.body)
+                        .foregroundStyle(DesignSystem.Colors.textTertiary)
+                        .padding(.top, 8)
+                        .padding(.leading, 10)
+                        .allowsHitTesting(false)
+                }
+            }
+            .frame(minHeight: 180)
+            .background(DesignSystem.Colors.surface)
+            .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius))
+            .overlay(
+                RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
+                    .strokeBorder(DesignSystem.Colors.border, lineWidth: 1)
+            )
+        }
+    }
+}

--- a/Sources/MacParakeet/Views/MeetingRecording/AskPromptsSheet.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/AskPromptsSheet.swift
@@ -13,6 +13,10 @@ struct AskPromptsSheet: View {
     @State private var hoveredID: UUID?
     @State private var pendingDelete: QuickPrompt?
     @State private var pendingResetKind: QuickPrompt.Kind?
+    /// Tracks which row currently owns keyboard focus so we can mirror the
+    /// hover-revealed icon brightening for keyboard-only users. Set by
+    /// `.focused($focusedRowID, equals: prompt.id)` on each row's controls.
+    @FocusState private var focusedRowID: UUID?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -75,7 +79,7 @@ struct AskPromptsSheet: View {
             }
             Button("Cancel", role: .cancel) { pendingResetKind = nil }
         } message: {
-            Text("Built-in labels, prompt text, and ordering for this section will return to defaults. Custom pills stay untouched.")
+            Text("Built-in pills return to their default labels and prompt text. Your custom pills stay untouched.")
         }
         .sheet(
             isPresented: Binding(
@@ -125,6 +129,9 @@ struct AskPromptsSheet: View {
             }
             .buttonStyle(.borderedProminent)
             .controlSize(.large)
+            // Esc dismisses (Apple HIG default for sheets). `.cancelAction`
+            // is Esc + Cmd-. on macOS — both reach the close intent.
+            .keyboardShortcut(.cancelAction)
         }
         .padding(DesignSystem.Spacing.xl)
         .background(DesignSystem.Colors.surface)
@@ -165,6 +172,8 @@ struct AskPromptsSheet: View {
                 .menuStyle(.borderlessButton)
                 .menuIndicator(.hidden)
                 .frame(width: 28, height: 28)
+                .help("\(title) options")
+                .accessibilityLabel("\(title) options")
             }
 
             cardGroup {
@@ -212,7 +221,10 @@ struct AskPromptsSheet: View {
     // MARK: - Row
 
     private func promptRow(_ prompt: QuickPrompt, kind: QuickPrompt.Kind, rows: [QuickPrompt], index: Int) -> some View {
-        let isHovered = hoveredID == prompt.id
+        // Treat keyboard focus the same as hover so a Tab-only user gets the
+        // same icon brightening + row highlight that a mouse user does.
+        let isActive = hoveredID == prompt.id || focusedRowID == prompt.id
+        let kindNoun = kind == .starter ? "starter" : "follow-up"
 
         return HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
             Toggle("", isOn: Binding(
@@ -223,6 +235,8 @@ struct AskPromptsSheet: View {
             .controlSize(.small)
             .tint(DesignSystem.Colors.accent)
             .padding(.top, 2)
+            .focused($focusedRowID, equals: prompt.id)
+            .accessibilityLabel("Show \(prompt.label)")
 
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 8) {
@@ -231,6 +245,8 @@ struct AskPromptsSheet: View {
                         .foregroundStyle(prompt.isVisible
                                          ? DesignSystem.Colors.textPrimary
                                          : DesignSystem.Colors.textTertiary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
 
                     if let group = prompt.groupLabel, !group.isEmpty {
                         Text(group)
@@ -273,54 +289,64 @@ struct AskPromptsSheet: View {
                 Button {
                     movePrompt(prompt, by: -1, in: rows, kind: kind)
                 } label: {
-                    rowIcon("chevron.up", isHovered: isHovered)
+                    rowIcon("chevron.up", isHovered: isActive)
                 }
                 .buttonStyle(.plain)
                 .disabled(index == 0)
                 .opacity(index == 0 ? 0.25 : 1)
+                .focused($focusedRowID, equals: prompt.id)
                 .help("Move up")
+                .accessibilityLabel("Move \(prompt.label) up")
 
                 Button {
                     movePrompt(prompt, by: 1, in: rows, kind: kind)
                 } label: {
-                    rowIcon("chevron.down", isHovered: isHovered)
+                    rowIcon("chevron.down", isHovered: isActive)
                 }
                 .buttonStyle(.plain)
                 .disabled(index >= rows.count - 1)
                 .opacity(index >= rows.count - 1 ? 0.25 : 1)
+                .focused($focusedRowID, equals: prompt.id)
                 .help("Move down")
+                .accessibilityLabel("Move \(prompt.label) down")
 
                 Button {
                     viewModel.editingPrompt = prompt
                 } label: {
-                    rowIcon("pencil", isHovered: isHovered)
+                    rowIcon("pencil", isHovered: isActive)
                 }
                 .buttonStyle(.plain)
+                .focused($focusedRowID, equals: prompt.id)
                 .help("Edit")
+                .accessibilityLabel("Edit \(kindNoun) \(prompt.label)")
 
                 if prompt.isBuiltIn {
                     Button {
                         withAnimation { viewModel.restoreSingleDefault(prompt) }
                     } label: {
-                        rowIcon("arrow.uturn.backward", isHovered: isHovered)
+                        rowIcon("arrow.uturn.backward", isHovered: isActive)
                     }
                     .buttonStyle(.plain)
+                    .focused($focusedRowID, equals: prompt.id)
                     .help("Restore default")
+                    .accessibilityLabel("Restore \(prompt.label) to default")
                 } else {
                     Button {
                         pendingDelete = prompt
                     } label: {
-                        rowIcon("trash", isHovered: isHovered, destructive: true)
+                        rowIcon("trash", isHovered: isActive, destructive: true)
                     }
                     .buttonStyle(.plain)
+                    .focused($focusedRowID, equals: prompt.id)
                     .help("Delete")
+                    .accessibilityLabel("Delete \(kindNoun) \(prompt.label)")
                 }
             }
-            .opacity(isHovered ? 1.0 : 0.4)
-            .animation(.easeInOut(duration: 0.18), value: isHovered)
+            .opacity(isActive ? 1.0 : 0.4)
+            .animation(.easeInOut(duration: 0.18), value: isActive)
         }
         .padding(DesignSystem.Spacing.lg)
-        .background(isHovered ? DesignSystem.Colors.surfaceElevated.opacity(0.5) : Color.clear)
+        .background(isActive ? DesignSystem.Colors.surfaceElevated.opacity(0.5) : Color.clear)
         .contentShape(Rectangle())
         .onHover { hovering in
             withAnimation(DesignSystem.Animation.hoverTransition) {
@@ -392,6 +418,7 @@ private struct EditPromptSheet: View {
     @State private var label: String
     @State private var promptBody: String
     @State private var groupLabel: String
+    @State private var showingDiscardConfirm = false
 
     init(prompt: QuickPrompt, onSave: @escaping (QuickPrompt) -> Bool, onCancel: @escaping () -> Void) {
         self.initial = prompt
@@ -402,6 +429,19 @@ private struct EditPromptSheet: View {
         self._groupLabel = State(initialValue: prompt.groupLabel ?? "")
     }
 
+    /// True when the form's user-visible content differs from the row that was
+    /// opened. Drives the discard-confirm prompt: a no-op Cancel is silent;
+    /// a Cancel after real edits asks before throwing the work away (Apple's
+    /// document-close pattern). Trim the group string before comparing so a
+    /// trailing space added to "CATCH UP" doesn't trigger a phantom prompt.
+    private var hasChanges: Bool {
+        let normalizedGroup = groupLabel.trimmingCharacters(in: .whitespacesAndNewlines)
+        let initialGroup = initial.groupLabel ?? ""
+        return label != initial.label
+            || promptBody != initial.prompt
+            || normalizedGroup != initialGroup
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             HStack {
@@ -409,7 +449,8 @@ private struct EditPromptSheet: View {
                     .font(DesignSystem.Typography.sectionTitle)
                     .foregroundStyle(DesignSystem.Colors.textPrimary)
                 Spacer()
-                Button("Cancel") { onCancel(); dismiss() }
+                Button("Cancel") { attemptCancel() }
+                    .keyboardShortcut(.cancelAction)
                 Button("Save") { commit() }
                     .buttonStyle(.borderedProminent)
                     .keyboardShortcut(.defaultAction)
@@ -434,6 +475,24 @@ private struct EditPromptSheet: View {
         }
         .frame(minWidth: 560, minHeight: 480)
         .background(DesignSystem.Colors.background)
+        .alert("Discard changes?", isPresented: $showingDiscardConfirm) {
+            Button("Discard", role: .destructive) {
+                onCancel()
+                dismiss()
+            }
+            Button("Keep editing", role: .cancel) { }
+        } message: {
+            Text("Your edits to '\(initial.label)' will be lost.")
+        }
+    }
+
+    private func attemptCancel() {
+        if hasChanges {
+            showingDiscardConfirm = true
+        } else {
+            onCancel()
+            dismiss()
+        }
     }
 
     private func field(title: String, text: Binding<String>, placeholder: String) -> some View {
@@ -499,6 +558,17 @@ private struct CreatePromptSheet: View {
     @Environment(\.dismiss) private var dismiss
     @Bindable var viewModel: QuickPromptsViewModel
 
+    @State private var showingDiscardConfirm = false
+
+    /// True when any draft field has content. A clean Cancel from a blank
+    /// form is silent; otherwise we prompt before throwing the work away.
+    private var hasContent: Bool {
+        guard let draft = viewModel.creating else { return false }
+        return !draft.label.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !draft.prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !draft.groupLabel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             HStack {
@@ -508,7 +578,8 @@ private struct CreatePromptSheet: View {
                         .foregroundStyle(DesignSystem.Colors.textPrimary)
                 }
                 Spacer()
-                Button("Cancel") { viewModel.cancelCreating(); dismiss() }
+                Button("Cancel") { attemptCancel() }
+                    .keyboardShortcut(.cancelAction)
                 Button("Add") {
                     if viewModel.commitCreating() {
                         dismiss()
@@ -549,6 +620,24 @@ private struct CreatePromptSheet: View {
         }
         .frame(minWidth: 560, minHeight: 480)
         .background(DesignSystem.Colors.background)
+        .alert("Discard new pill?", isPresented: $showingDiscardConfirm) {
+            Button("Discard", role: .destructive) {
+                viewModel.cancelCreating()
+                dismiss()
+            }
+            Button("Keep editing", role: .cancel) { }
+        } message: {
+            Text("Your draft will be lost.")
+        }
+    }
+
+    private func attemptCancel() {
+        if hasContent {
+            showingDiscardConfirm = true
+        } else {
+            viewModel.cancelCreating()
+            dismiss()
+        }
     }
 
     private func field(title: String, binding: Binding<String>, placeholder: String) -> some View {

--- a/Sources/MacParakeet/Views/MeetingRecording/LiveAskPaneView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/LiveAskPaneView.swift
@@ -9,9 +9,11 @@ import SwiftUI
 /// the meeting is finalized (see TranscriptChatViewModel.bindPersistedConversation).
 struct LiveAskPaneView: View {
     @Bindable var viewModel: TranscriptChatViewModel
+    @Bindable var quickPromptsViewModel: QuickPromptsViewModel
 
     @FocusState private var inputFocused: Bool
     @State private var showingPromptMenu = false
+    @State private var showingPromptsSheet = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -50,6 +52,13 @@ struct LiveAskPaneView: View {
             // from an earlier bubble) it would sit there with non-firing prompts.
             if streaming { showingPromptMenu = false }
         }
+        .sheet(isPresented: $showingPromptsSheet, onDismiss: {
+            // Refresh after the user closes the sheet so any edits / new pills
+            // / restored defaults take effect immediately in the live pane.
+            quickPromptsViewModel.refresh()
+        }) {
+            AskPromptsSheet(viewModel: quickPromptsViewModel)
+        }
     }
 
     /// In-view popover for mid-conversation prompt browsing. Anchored above the
@@ -62,9 +71,33 @@ struct LiveAskPaneView: View {
                 .contentShape(Rectangle())
                 .onTapGesture { showingPromptMenu = false }
 
-            StarterPromptList(groups: LiveAskStarterPrompts.groups) { entry in
-                showingPromptMenu = false
-                fire(entry)
+            VStack(spacing: 0) {
+                StarterPromptList(groups: quickPromptsViewModel.visibleStarterGroups) { entry in
+                    showingPromptMenu = false
+                    fire(entry)
+                }
+
+                Divider()
+                    .padding(.top, DesignSystem.Spacing.sm)
+                    .padding(.bottom, 6)
+
+                Button {
+                    showingPromptMenu = false
+                    showingPromptsSheet = true
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "slider.horizontal.3")
+                            .font(.system(size: 11, weight: .medium))
+                        Text("Edit pills…")
+                            .font(.system(size: 11, weight: .medium))
+                    }
+                    .foregroundStyle(DesignSystem.Colors.textTertiary)
+                    .padding(.vertical, 6)
+                    .padding(.horizontal, 4)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
             }
             .padding(DesignSystem.Spacing.md)
             .background(
@@ -101,7 +134,7 @@ struct LiveAskPaneView: View {
     private var followUpRow: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 6) {
-                ForEach(LiveAskFollowUpPrompts.all, id: \.self) { entry in
+                ForEach(quickPromptsViewModel.visibleFollowUps) { entry in
                     FollowUpPill(label: entry.label) {
                         fire(entry)
                     }
@@ -118,7 +151,7 @@ struct LiveAskPaneView: View {
     }
 
     /// Pill tap → bubble shows the short label, LLM gets the comprehensive prompt.
-    private func fire(_ entry: LiveAskPrompt) {
+    private func fire(_ entry: QuickPrompt) {
         guard viewModel.canSendMessage, !viewModel.isStreaming else { return }
         viewModel.inputText = entry.label
         viewModel.sendMessage(richPrompt: entry.prompt)
@@ -170,8 +203,26 @@ struct LiveAskPaneView: View {
     // MARK: - Empty State
 
     private var emptyStateWithPills: some View {
-        StarterPromptList(groups: LiveAskStarterPrompts.groups) { entry in
-            fire(entry)
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+            StarterPromptList(groups: quickPromptsViewModel.visibleStarterGroups) { entry in
+                fire(entry)
+            }
+
+            Button {
+                showingPromptsSheet = true
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "slider.horizontal.3")
+                        .font(.system(size: 10, weight: .medium))
+                    Text("Edit pills…")
+                        .font(.system(size: 10, weight: .medium))
+                }
+                .foregroundStyle(DesignSystem.Colors.textTertiary)
+                .padding(.leading, 4)
+                .padding(.top, 4)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
         }
     }
 
@@ -295,90 +346,29 @@ struct LiveAskPaneView: View {
 
 // MARK: - Prompts
 
-/// A pill is two strings: a short, gestural `label` rendered on the chip AND in
-/// the user's bubble, and a more comprehensive `prompt` actually sent to the LLM.
-/// The thread reads conversational ("Tell me more") while the model gets enough
-/// scaffolding to answer well.
-struct LiveAskPrompt: Hashable {
-    let label: String
-    let prompt: String
-}
-
-/// Empty-state "thinking-partner" prompts — meant to start a thread and make the
-/// user sharper in the meeting, not just summarize. Grouped by intent so the empty
-/// state orients the user before they read any individual label. English-first;
-/// localization deferred.
-enum LiveAskStarterPrompts {
-    struct Group: Hashable {
-        let label: String
-        let prompts: [LiveAskPrompt]
-    }
-
-    static let groups: [Group] = [
-        Group(label: "CATCH UP", prompts: [
-            LiveAskPrompt(
-                label: "Summarize so far",
-                prompt: "Give a concise summary of the meeting so far. Focus on the main topics, decisions made, and any clear conclusions. Skip verbal filler."
-            ),
-            LiveAskPrompt(
-                label: "What did I miss?",
-                prompt: "Catch me up on the most recent shifts in the meeting — the latest decisions, new arguments, or topic changes. Skip what was clearly settled earlier. Be terse, signal-rich."
-            ),
-        ]),
-        Group(label: "CAPTURE", prompts: [
-            LiveAskPrompt(
-                label: "Decisions made",
-                prompt: "List the decisions reached in the meeting so far. For each, note what was decided and the brief context that explains why. Skip topics that were only discussed without a decision."
-            ),
-            LiveAskPrompt(
-                label: "Action items",
-                prompt: "List concrete action items from the meeting so far — what needs to happen next, by whom, and by when if mentioned. Be specific. Skip vague intentions."
-            ),
-            LiveAskPrompt(
-                label: "Who owns what?",
-                prompt: "Map who owns what from the meeting so far — assignments, commitments, areas of responsibility. If ownership for an item is unclear or unstated, flag that explicitly."
-            ),
-        ]),
-        Group(label: "CHALLENGE", prompts: [
-            LiveAskPrompt(
-                label: "What's unresolved?",
-                prompt: "List the open questions, unmade decisions, or topics still hanging from the meeting so far. Be specific."
-            ),
-            LiveAskPrompt(
-                label: "What question is worth asking?",
-                prompt: "Based on the meeting so far, suggest one sharp, useful question I could ask next that would advance the discussion or surface something important that hasn't been addressed."
-            ),
-            LiveAskPrompt(
-                label: "What's worth pushing back on?",
-                prompt: "Identify any claims, assumptions, or decisions in the meeting so far that deserve scrutiny. What might be wrong, weak, or worth challenging?"
-            ),
-            LiveAskPrompt(
-                label: "Where are we going in circles?",
-                prompt: "Have we revisited the same topic or argument without making progress? If so, point out where we're looping and what would actually move things forward."
-            ),
-        ]),
-    ]
-}
-
-/// Renders the 3-group starter prompt list. Single source of truth for both the
+/// Renders the grouped starter prompt list. Single source of truth for both the
 /// empty-state pane and the mid-conversation popover so the two surfaces stay
-/// visually identical and behavior never drifts.
+/// visually identical and behavior never drifts. Groups come from
+/// `QuickPromptsViewModel.visibleStarterGroups`, which preserves first-occurrence
+/// group order so users who reorder pills control how groups appear.
 private struct StarterPromptList: View {
-    let groups: [LiveAskStarterPrompts.Group]
-    let onSelect: (LiveAskPrompt) -> Void
+    let groups: [(label: String, prompts: [QuickPrompt])]
+    let onSelect: (QuickPrompt) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
-            ForEach(groups, id: \.self) { group in
+            ForEach(groups, id: \.label) { group in
                 VStack(alignment: .leading, spacing: 6) {
-                    Text(group.label)
-                        .font(.system(size: 10, weight: .semibold))
-                        .tracking(0.8)
-                        .foregroundStyle(DesignSystem.Colors.textTertiary)
-                        .padding(.leading, 4)
+                    if !group.label.isEmpty {
+                        Text(group.label)
+                            .font(.system(size: 10, weight: .semibold))
+                            .tracking(0.8)
+                            .foregroundStyle(DesignSystem.Colors.textTertiary)
+                            .padding(.leading, 4)
+                    }
 
                     VStack(spacing: 5) {
-                        ForEach(group.prompts, id: \.self) { entry in
+                        ForEach(group.prompts) { entry in
                             StarterPromptPill(entry: entry) {
                                 onSelect(entry)
                             }
@@ -430,38 +420,8 @@ private struct PromptMenuButton: View {
     }
 }
 
-/// Always-visible follow-up prompts above the input once a conversation exists.
-/// Strictly universal "next-moves on the last assistant message" — keep, expand,
-/// probe, push back, compress. Global meeting prompts (Summarize / What did I
-/// miss? / Action items) live in the empty-state starters so this row stays
-/// honest about its single job: continue the thread.
-enum LiveAskFollowUpPrompts {
-    static let all: [LiveAskPrompt] = [
-        LiveAskPrompt(
-            label: "Tell me more",
-            prompt: "Expand on your previous response with more concrete detail from the meeting itself — quotes, specifics, who said what. Surface nuances or caveats you compressed out the first time."
-        ),
-        LiveAskPrompt(
-            label: "Why?",
-            prompt: "Explain the reasoning behind your previous answer. What from the meeting transcript supports it?"
-        ),
-        LiveAskPrompt(
-            label: "Give an example",
-            prompt: "Give one specific, concrete example that illustrates your previous response. Pull it from the meeting itself — a moment, exchange, or quote. If the meeting doesn't contain a clean example, say so plainly and offer the closest analogue."
-        ),
-        LiveAskPrompt(
-            label: "Counter-argument?",
-            prompt: "What's the strongest counter-argument to your previous response? Steelman the opposing view, and use anything in the meeting that supports it."
-        ),
-        LiveAskPrompt(
-            label: "TL;DR",
-            prompt: "Give the punchy, no-fluff TL;DR of your previous response — one or two sentences. No headers, no list, no preamble."
-        ),
-    ]
-}
-
 private struct StarterPromptPill: View {
-    let entry: LiveAskPrompt
+    let entry: QuickPrompt
     let action: () -> Void
 
     @State private var isHovered = false

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelView.swift
@@ -42,7 +42,10 @@ struct MeetingRecordingPanelView: View {
         case .transcript:
             transcriptContent
         case .ask:
-            LiveAskPaneView(viewModel: viewModel.chatViewModel)
+            LiveAskPaneView(
+                viewModel: viewModel.chatViewModel,
+                quickPromptsViewModel: viewModel.quickPromptsViewModel
+            )
         }
     }
 

--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -562,8 +562,39 @@ public final class DatabaseManager: Sendable {
             }
         }
 
+        // v0.10 — Live meeting Ask tab quick prompts. User-customizable starter
+        // and follow-up pills shown above the chat composer. Built-ins seeded
+        // by the in-app reconciler (`QuickPromptRepository.seedIfNeeded()`),
+        // which is the single source of truth for canonical IDs and runs on
+        // both first launch and every subsequent launch.
+        migrator.registerMigration("v0.10-quick-prompts") { db in
+            try db.create(table: "quick_prompts") { t in
+                t.column("id", .text).primaryKey()
+                t.column("kind", .text).notNull()
+                t.column("label", .text).notNull()
+                t.column("prompt", .text).notNull()
+                t.column("groupLabel", .text)
+                t.column("sortOrder", .integer).notNull().defaults(to: 0)
+                t.column("isVisible", .boolean).notNull().defaults(to: true)
+                t.column("isBuiltIn", .boolean).notNull().defaults(to: false)
+                t.column("createdAt", .text).notNull()
+                t.column("updatedAt", .text).notNull()
+            }
+            try db.create(
+                index: "idx_quick_prompts_kind_sort",
+                on: "quick_prompts",
+                columns: ["kind", "sortOrder"]
+            )
+        }
+
         try migrator.migrate(dbQueue)
         try reconcileBuiltInPrompts()
+        try reconcileBuiltInQuickPrompts()
+    }
+
+    private func reconcileBuiltInQuickPrompts() throws {
+        let repo = QuickPromptRepository(dbQueue: dbQueue)
+        try repo.seedIfNeeded()
     }
 
     private func reconcileBuiltInPrompts() throws {

--- a/Sources/MacParakeetCore/Database/QuickPromptRepository.swift
+++ b/Sources/MacParakeetCore/Database/QuickPromptRepository.swift
@@ -28,6 +28,17 @@ public enum QuickPromptImport {
     }
 }
 
+public enum QuickPromptImportError: Error, LocalizedError, Equatable {
+    case duplicateID(UUID)
+
+    public var errorDescription: String? {
+        switch self {
+        case .duplicateID(let id):
+            return "Quick-prompts import contains duplicate id '\(id.uuidString)'."
+        }
+    }
+}
+
 /// CRUD + reconciliation + import/export for the live meeting Ask tab pills.
 ///
 /// Mirrors `PromptRepository` shape so the patterns are familiar, but with two
@@ -82,6 +93,7 @@ public final class QuickPromptRepository: QuickPromptRepositoryProtocol {
     public func save(_ prompt: QuickPrompt) throws {
         try dbQueue.write { db in
             var copy = prompt
+            copy = normalizedForWrite(copy)
             copy.updatedAt = Date()
             try copy.save(db)
         }
@@ -173,16 +185,20 @@ public final class QuickPromptRepository: QuickPromptRepositoryProtocol {
 
             // Retire built-ins removed from the canonical list. Customs are
             // never touched here — `isBuiltIn = 1` filter is load-bearing.
-            let placeholders = canonicalIDs.map { _ in "?" }.joined(separator: ",")
-            let arguments: [DatabaseValueConvertible] = canonicalIDs.map { $0 }
-            try db.execute(
-                sql: """
-                    DELETE FROM quick_prompts
-                    WHERE isBuiltIn = 1
-                      AND id NOT IN (\(placeholders))
-                    """,
-                arguments: StatementArguments(arguments)
-            )
+            if canonicalIDs.isEmpty {
+                try db.execute(sql: "DELETE FROM quick_prompts WHERE isBuiltIn = 1")
+            } else {
+                let placeholders = canonicalIDs.map { _ in "?" }.joined(separator: ",")
+                let arguments: [DatabaseValueConvertible] = canonicalIDs.map { $0 }
+                try db.execute(
+                    sql: """
+                        DELETE FROM quick_prompts
+                        WHERE isBuiltIn = 1
+                          AND id NOT IN (\(placeholders))
+                        """,
+                    arguments: StatementArguments(arguments)
+                )
+            }
         }
     }
 
@@ -217,10 +233,11 @@ public final class QuickPromptRepository: QuickPromptRepositoryProtocol {
         try db.execute(
             sql: """
                 UPDATE quick_prompts
-                SET label = ?, prompt = ?, groupLabel = ?, sortOrder = ?, isBuiltIn = 1, updatedAt = ?
+                SET kind = ?, label = ?, prompt = ?, groupLabel = ?, sortOrder = ?, isBuiltIn = 1, updatedAt = ?
                 WHERE id = ?
                 """,
             arguments: [
+                seed.kind.rawValue,
                 seed.label,
                 seed.prompt,
                 seed.groupLabel,
@@ -239,12 +256,21 @@ public final class QuickPromptRepository: QuickPromptRepositoryProtocol {
         dryRun: Bool
     ) throws -> QuickPromptImport.Summary {
         let now = Date()
-        let incoming = bundle.prompts.map { QuickPromptBundle.materialize($0, now: now) }
-        let incomingByID = Dictionary(uniqueKeysWithValues: incoming.map { ($0.id, $0) })
+        let incoming = bundle.prompts.map {
+            normalizedForWrite(QuickPromptBundle.materialize($0, now: now))
+        }
+        var incomingIDs = Set<UUID>()
+        for entry in incoming {
+            guard incomingIDs.insert(entry.id).inserted else {
+                throw QuickPromptImportError.duplicateID(entry.id)
+            }
+        }
 
         return try dbQueue.write { db in
             let existing = try QuickPrompt.fetchAll(db)
             let existingByID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
+            let canonicalSeeds = QuickPrompt.builtInPrompts(now: now)
+            let canonicalByID = Dictionary(uniqueKeysWithValues: canonicalSeeds.map { ($0.id, $0) })
 
             var added = 0
             var updated = 0
@@ -267,12 +293,16 @@ public final class QuickPromptRepository: QuickPromptRepositoryProtocol {
                     }
                 }
                 // Rows in DB but not in file are preserved on merge.
-                unchanged += existing.filter { incomingByID[$0.id] == nil }.count
+                unchanged += existing.filter { !incomingIDs.contains($0.id) }.count
 
             case .replace:
                 // 1. Delete every custom row.
                 let customIDs = existing.filter { !$0.isBuiltIn }.map(\.id)
                 deleted = customIDs.count
+                updated += existing.reduce(0) { count, row in
+                    guard row.isBuiltIn, let canonical = canonicalByID[row.id] else { return count }
+                    return areEquivalent(row, canonical) ? count : count + 1
+                }
                 if !dryRun {
                     let placeholders = customIDs.map { _ in "?" }.joined(separator: ",")
                     if !customIDs.isEmpty {
@@ -282,13 +312,12 @@ public final class QuickPromptRepository: QuickPromptRepositoryProtocol {
                         )
                     }
                     // 2. Re-seed built-ins to canonical so the slate is truly clean.
-                    for seed in QuickPrompt.builtInPrompts(now: now) {
+                    for seed in canonicalSeeds {
                         try seed.save(db)
                     }
                 }
                 // 3. Now apply the file as a merge over the cleaned-up state.
-                let cleanExisting = QuickPrompt.builtInPrompts(now: now)
-                let cleanByID = Dictionary(uniqueKeysWithValues: cleanExisting.map { ($0.id, $0) })
+                let cleanByID = canonicalByID
                 for entry in incoming {
                     if let prior = cleanByID[entry.id] {
                         if !areEquivalent(prior, entry) {
@@ -321,24 +350,34 @@ public final class QuickPromptRepository: QuickPromptRepositoryProtocol {
             && lhs.isBuiltIn == rhs.isBuiltIn
     }
 
-    /// Write a merged row, preserving the existing row's `createdAt` (so import
-    /// doesn't reset history) and `isBuiltIn` flag if the existing row already
-    /// owns that ID — `materialize` may have flipped a forged claim to false,
-    /// but if the existing row genuinely is built-in we keep it.
+    /// Write a merged row, preserving the existing row's `createdAt` so import
+    /// does not reset history. Reserved built-in UUIDs keep their canonical kind
+    /// and built-in status; custom rows cannot forge that status.
     private func writeMerged(entry: QuickPrompt, existing: QuickPrompt, db: Database, now: Date) throws {
-        var merged = entry
+        var merged = normalizedForWrite(entry)
         merged.createdAt = existing.createdAt
         merged.updatedAt = now
-        // Preserve true builtIn-ness from the DB; never silently demote a
-        // built-in via import.
-        merged.isBuiltIn = existing.isBuiltIn || entry.isBuiltIn
         try merged.save(db)
     }
 
     private func writeNew(entry: QuickPrompt, db: Database, now: Date) throws {
-        var fresh = entry
+        var fresh = normalizedForWrite(entry)
         fresh.createdAt = now
         fresh.updatedAt = now
         try fresh.save(db)
+    }
+
+    private func normalizedForWrite(_ prompt: QuickPrompt) -> QuickPrompt {
+        var normalized = prompt
+        if let canonical = QuickPrompt.builtInPrompt(id: prompt.id) {
+            normalized.kind = canonical.kind
+            normalized.isBuiltIn = true
+        } else {
+            normalized.isBuiltIn = false
+        }
+        if normalized.kind == .followUp {
+            normalized.groupLabel = nil
+        }
+        return normalized
     }
 }

--- a/Sources/MacParakeetCore/Database/QuickPromptRepository.swift
+++ b/Sources/MacParakeetCore/Database/QuickPromptRepository.swift
@@ -378,6 +378,13 @@ public final class QuickPromptRepository: QuickPromptRepositoryProtocol {
         if normalized.kind == .followUp {
             normalized.groupLabel = nil
         }
+        // Empty / whitespace-only group strings collapse to nil so the GUI never
+        // renders an empty capsule and equality checks match canonical seeds
+        // whose groupLabel is genuinely nil.
+        if let trimmed = normalized.groupLabel?.trimmingCharacters(in: .whitespacesAndNewlines),
+           trimmed.isEmpty {
+            normalized.groupLabel = nil
+        }
         return normalized
     }
 }

--- a/Sources/MacParakeetCore/Database/QuickPromptRepository.swift
+++ b/Sources/MacParakeetCore/Database/QuickPromptRepository.swift
@@ -1,0 +1,344 @@
+import Foundation
+import GRDB
+
+/// Namespace for import-related types. Lives at module scope because Swift
+/// disallows nested types inside protocols.
+public enum QuickPromptImport {
+    public enum Mode: String, Sendable, Codable, CaseIterable {
+        /// UPSERT by id; rows in DB but not in file are left alone.
+        case merge
+        /// Wipe customs, restore built-ins to canonical values, then apply
+        /// file. Most destructive mode — CLI prompts for confirmation unless
+        /// `--json`.
+        case replace
+    }
+
+    public struct Summary: Codable, Sendable, Equatable {
+        public let added: Int
+        public let updated: Int
+        public let deleted: Int
+        public let unchanged: Int
+
+        public init(added: Int, updated: Int, deleted: Int, unchanged: Int) {
+            self.added = added
+            self.updated = updated
+            self.deleted = deleted
+            self.unchanged = unchanged
+        }
+    }
+}
+
+/// CRUD + reconciliation + import/export for the live meeting Ask tab pills.
+///
+/// Mirrors `PromptRepository` shape so the patterns are familiar, but with two
+/// deliberate divergences:
+/// 1. **Reconciler is insert-only.** Built-ins are user-editable, so re-running
+///    the reconciler on launch must never overwrite a user's edited row.
+/// 2. **Restore default is the only update path for built-ins.** Per-row
+///    (`restoreBuiltInDefault`) and bulk (`restoreBuiltInDefaults`) variants
+///    rewrite the canonical fields in place; they never touch customs.
+public protocol QuickPromptRepositoryProtocol: Sendable {
+    func save(_ prompt: QuickPrompt) throws
+    func fetch(id: UUID) throws -> QuickPrompt?
+    func fetchAll() throws -> [QuickPrompt]
+    func fetchAll(kind: QuickPrompt.Kind) throws -> [QuickPrompt]
+    func fetchVisible(kind: QuickPrompt.Kind) throws -> [QuickPrompt]
+    func delete(id: UUID) throws -> Bool
+    func toggleVisibility(id: UUID) throws
+    func reorder(ids: [UUID], within kind: QuickPrompt.Kind) throws
+
+    /// Idempotent first-launch + upgrade-launch hydration. Inserts any built-in
+    /// rows missing by canonical UUID and removes built-in rows whose UUIDs are
+    /// no longer in the canonical list (retired built-ins). Never updates an
+    /// existing row.
+    func seedIfNeeded() throws
+
+    /// Rewrites every built-in row in `kind` back to canonical seed values
+    /// (label / prompt / groupLabel / sortOrder). Visibility is preserved —
+    /// "restore default" is about content, not whether the user has hidden the
+    /// pill. Customs are untouched.
+    func restoreBuiltInDefaults(kind: QuickPrompt.Kind?) throws
+
+    /// Per-row variant for the "Restore default" affordance on a single
+    /// edited built-in row.
+    func restoreBuiltInDefault(id: UUID) throws
+
+    /// Apply a parsed import bundle. Returns a count summary suitable for
+    /// surfacing through the CLI `--dry-run` and post-write success paths.
+    /// Caller has already validated the bundle envelope via
+    /// `QuickPromptBundle.validate()`.
+    func applyImport(_ bundle: QuickPromptBundle, mode: QuickPromptImport.Mode, dryRun: Bool) throws -> QuickPromptImport.Summary
+}
+
+public final class QuickPromptRepository: QuickPromptRepositoryProtocol {
+    private let dbQueue: DatabaseQueue
+
+    public init(dbQueue: DatabaseQueue) {
+        self.dbQueue = dbQueue
+    }
+
+    // MARK: CRUD
+
+    public func save(_ prompt: QuickPrompt) throws {
+        try dbQueue.write { db in
+            var copy = prompt
+            copy.updatedAt = Date()
+            try copy.save(db)
+        }
+    }
+
+    public func fetch(id: UUID) throws -> QuickPrompt? {
+        try dbQueue.read { db in
+            try QuickPrompt.fetchOne(db, key: id)
+        }
+    }
+
+    public func fetchAll() throws -> [QuickPrompt] {
+        try dbQueue.read { db in
+            try QuickPrompt
+                .order(QuickPrompt.Columns.kind.asc, QuickPrompt.Columns.sortOrder.asc)
+                .fetchAll(db)
+        }
+    }
+
+    public func fetchAll(kind: QuickPrompt.Kind) throws -> [QuickPrompt] {
+        try dbQueue.read { db in
+            try QuickPrompt
+                .filter(QuickPrompt.Columns.kind == kind.rawValue)
+                .order(QuickPrompt.Columns.sortOrder.asc)
+                .fetchAll(db)
+        }
+    }
+
+    public func fetchVisible(kind: QuickPrompt.Kind) throws -> [QuickPrompt] {
+        try dbQueue.read { db in
+            try QuickPrompt
+                .filter(QuickPrompt.Columns.kind == kind.rawValue)
+                .filter(QuickPrompt.Columns.isVisible == true)
+                .order(QuickPrompt.Columns.sortOrder.asc)
+                .fetchAll(db)
+        }
+    }
+
+    public func delete(id: UUID) throws -> Bool {
+        try dbQueue.write { db in
+            guard let existing = try QuickPrompt.fetchOne(db, key: id) else { return false }
+            guard !existing.isBuiltIn else { return false }
+            return try QuickPrompt.deleteOne(db, key: id)
+        }
+    }
+
+    public func toggleVisibility(id: UUID) throws {
+        try dbQueue.write { db in
+            guard var prompt = try QuickPrompt.fetchOne(db, key: id) else { return }
+            prompt.isVisible.toggle()
+            prompt.updatedAt = Date()
+            try prompt.update(db)
+        }
+    }
+
+    public func reorder(ids: [UUID], within kind: QuickPrompt.Kind) throws {
+        try dbQueue.write { db in
+            let now = Date()
+            for (index, id) in ids.enumerated() {
+                try db.execute(
+                    sql: """
+                        UPDATE quick_prompts
+                        SET sortOrder = ?, updatedAt = ?
+                        WHERE id = ? AND kind = ?
+                        """,
+                    arguments: [index, now, id, kind.rawValue]
+                )
+            }
+        }
+    }
+
+    // MARK: Reconciliation
+
+    public func seedIfNeeded() throws {
+        let canonical = QuickPrompt.builtInPrompts()
+        let canonicalIDs = Set(canonical.map(\.id))
+
+        try dbQueue.write { db in
+            for prompt in canonical {
+                let exists = try Bool.fetchOne(
+                    db,
+                    sql: "SELECT EXISTS(SELECT 1 FROM quick_prompts WHERE id = ?)",
+                    arguments: [prompt.id]
+                ) ?? false
+                if !exists {
+                    try prompt.insert(db)
+                }
+            }
+
+            // Retire built-ins removed from the canonical list. Customs are
+            // never touched here — `isBuiltIn = 1` filter is load-bearing.
+            let placeholders = canonicalIDs.map { _ in "?" }.joined(separator: ",")
+            let arguments: [DatabaseValueConvertible] = canonicalIDs.map { $0 }
+            try db.execute(
+                sql: """
+                    DELETE FROM quick_prompts
+                    WHERE isBuiltIn = 1
+                      AND id NOT IN (\(placeholders))
+                    """,
+                arguments: StatementArguments(arguments)
+            )
+        }
+    }
+
+    public func restoreBuiltInDefaults(kind: QuickPrompt.Kind?) throws {
+        let now = Date()
+        let canonical: [QuickPrompt]
+        if let kind {
+            canonical = QuickPrompt.builtInPrompts(kind: kind, now: now)
+        } else {
+            canonical = QuickPrompt.builtInPrompts(now: now)
+        }
+        try dbQueue.write { db in
+            for seed in canonical {
+                try restoreOne(seed: seed, db: db, now: now)
+            }
+        }
+    }
+
+    public func restoreBuiltInDefault(id: UUID) throws {
+        guard let seed = QuickPrompt.builtInPrompts().first(where: { $0.id == id }) else { return }
+        let now = Date()
+        try dbQueue.write { db in
+            try restoreOne(seed: seed, db: db, now: now)
+        }
+    }
+
+    /// Rewrite canonical fields for a single built-in seed. Visibility is
+    /// **preserved** — restoring default content shouldn't override an explicit
+    /// hide. If the row is missing entirely, this is a no-op (the reconciler
+    /// will re-insert it on the next `seedIfNeeded()`).
+    private func restoreOne(seed: QuickPrompt, db: Database, now: Date) throws {
+        try db.execute(
+            sql: """
+                UPDATE quick_prompts
+                SET label = ?, prompt = ?, groupLabel = ?, sortOrder = ?, isBuiltIn = 1, updatedAt = ?
+                WHERE id = ?
+                """,
+            arguments: [
+                seed.label,
+                seed.prompt,
+                seed.groupLabel,
+                seed.sortOrder,
+                now,
+                seed.id,
+            ]
+        )
+    }
+
+    // MARK: Import
+
+    public func applyImport(
+        _ bundle: QuickPromptBundle,
+        mode: QuickPromptImport.Mode,
+        dryRun: Bool
+    ) throws -> QuickPromptImport.Summary {
+        let now = Date()
+        let incoming = bundle.prompts.map { QuickPromptBundle.materialize($0, now: now) }
+        let incomingByID = Dictionary(uniqueKeysWithValues: incoming.map { ($0.id, $0) })
+
+        return try dbQueue.write { db in
+            let existing = try QuickPrompt.fetchAll(db)
+            let existingByID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
+
+            var added = 0
+            var updated = 0
+            var deleted = 0
+            var unchanged = 0
+
+            switch mode {
+            case .merge:
+                for entry in incoming {
+                    if let prior = existingByID[entry.id] {
+                        if !areEquivalent(prior, entry) {
+                            if !dryRun { try writeMerged(entry: entry, existing: prior, db: db, now: now) }
+                            updated += 1
+                        } else {
+                            unchanged += 1
+                        }
+                    } else {
+                        if !dryRun { try writeNew(entry: entry, db: db, now: now) }
+                        added += 1
+                    }
+                }
+                // Rows in DB but not in file are preserved on merge.
+                unchanged += existing.filter { incomingByID[$0.id] == nil }.count
+
+            case .replace:
+                // 1. Delete every custom row.
+                let customIDs = existing.filter { !$0.isBuiltIn }.map(\.id)
+                deleted = customIDs.count
+                if !dryRun {
+                    let placeholders = customIDs.map { _ in "?" }.joined(separator: ",")
+                    if !customIDs.isEmpty {
+                        try db.execute(
+                            sql: "DELETE FROM quick_prompts WHERE id IN (\(placeholders))",
+                            arguments: StatementArguments(customIDs.map { $0 as DatabaseValueConvertible })
+                        )
+                    }
+                    // 2. Re-seed built-ins to canonical so the slate is truly clean.
+                    for seed in QuickPrompt.builtInPrompts(now: now) {
+                        try seed.save(db)
+                    }
+                }
+                // 3. Now apply the file as a merge over the cleaned-up state.
+                let cleanExisting = QuickPrompt.builtInPrompts(now: now)
+                let cleanByID = Dictionary(uniqueKeysWithValues: cleanExisting.map { ($0.id, $0) })
+                for entry in incoming {
+                    if let prior = cleanByID[entry.id] {
+                        if !areEquivalent(prior, entry) {
+                            if !dryRun { try writeMerged(entry: entry, existing: prior, db: db, now: now) }
+                            updated += 1
+                        } else {
+                            unchanged += 1
+                        }
+                    } else {
+                        if !dryRun { try writeNew(entry: entry, db: db, now: now) }
+                        added += 1
+                    }
+                }
+            }
+
+            return .init(added: added, updated: updated, deleted: deleted, unchanged: unchanged)
+        }
+    }
+
+    /// Two prompts are "equivalent for import purposes" when every meaningful
+    /// content field matches; timestamps don't count. Used to classify
+    /// merge/replace results without spurious updates.
+    private func areEquivalent(_ lhs: QuickPrompt, _ rhs: QuickPrompt) -> Bool {
+        lhs.kind == rhs.kind
+            && lhs.label == rhs.label
+            && lhs.prompt == rhs.prompt
+            && lhs.groupLabel == rhs.groupLabel
+            && lhs.sortOrder == rhs.sortOrder
+            && lhs.isVisible == rhs.isVisible
+            && lhs.isBuiltIn == rhs.isBuiltIn
+    }
+
+    /// Write a merged row, preserving the existing row's `createdAt` (so import
+    /// doesn't reset history) and `isBuiltIn` flag if the existing row already
+    /// owns that ID — `materialize` may have flipped a forged claim to false,
+    /// but if the existing row genuinely is built-in we keep it.
+    private func writeMerged(entry: QuickPrompt, existing: QuickPrompt, db: Database, now: Date) throws {
+        var merged = entry
+        merged.createdAt = existing.createdAt
+        merged.updatedAt = now
+        // Preserve true builtIn-ness from the DB; never silently demote a
+        // built-in via import.
+        merged.isBuiltIn = existing.isBuiltIn || entry.isBuiltIn
+        try merged.save(db)
+    }
+
+    private func writeNew(entry: QuickPrompt, db: Database, now: Date) throws {
+        var fresh = entry
+        fresh.createdAt = now
+        fresh.updatedAt = now
+        try fresh.save(db)
+    }
+}

--- a/Sources/MacParakeetCore/Models/QuickPrompt.swift
+++ b/Sources/MacParakeetCore/Models/QuickPrompt.swift
@@ -90,6 +90,10 @@ extension QuickPrompt {
         }
     }
 
+    public static func builtInPrompt(id: UUID, now: Date = Date()) -> QuickPrompt? {
+        builtInPrompts(now: now).first { $0.id == id }
+    }
+
     /// Set of canonical built-in UUIDs. Used by the export DTO to coerce a
     /// claimed `isBuiltIn: true` to `false` on import unless the id is genuinely
     /// one of ours — prevents a malicious or careless import file from forging

--- a/Sources/MacParakeetCore/Models/QuickPrompt.swift
+++ b/Sources/MacParakeetCore/Models/QuickPrompt.swift
@@ -1,0 +1,257 @@
+import Foundation
+import GRDB
+
+/// A user-customizable shortcut surfaced as a pill in the live meeting Ask tab.
+///
+/// Two flavors, discriminated by `kind`:
+/// - **starter** — meeting-context prompts shown in the empty Ask state and the
+///   sparkle popover ("Summarize so far", "Action items", …). Optionally
+///   grouped via `groupLabel` (CATCH UP / CAPTURE / CHALLENGE).
+/// - **followUp** — response-shaping shortcuts shown above the input mid-conversation
+///   ("Tell me more", "Why?", "TL;DR"). Always flat, never grouped.
+///
+/// `label` is what the user sees on the chip and in their own message bubble;
+/// `prompt` is the more comprehensive instruction sent to the LLM. Keep them
+/// separate so the conversation reads cleanly while the model gets enough
+/// scaffolding to answer well.
+public struct QuickPrompt: Codable, Identifiable, Sendable, Hashable {
+    public var id: UUID
+    public var kind: Kind
+    public var label: String
+    public var prompt: String
+    public var groupLabel: String?
+    public var sortOrder: Int
+    public var isVisible: Bool
+    public var isBuiltIn: Bool
+    public var createdAt: Date
+    public var updatedAt: Date
+
+    public enum Kind: String, Codable, Sendable, CaseIterable {
+        case starter
+        case followUp = "follow_up"
+    }
+
+    public init(
+        id: UUID = UUID(),
+        kind: Kind,
+        label: String,
+        prompt: String,
+        groupLabel: String? = nil,
+        sortOrder: Int = 0,
+        isVisible: Bool = true,
+        isBuiltIn: Bool = false,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.kind = kind
+        self.label = label
+        self.prompt = prompt
+        self.groupLabel = groupLabel
+        self.sortOrder = sortOrder
+        self.isVisible = isVisible
+        self.isBuiltIn = isBuiltIn
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}
+
+extension QuickPrompt: FetchableRecord, PersistableRecord {
+    public static let databaseTableName = "quick_prompts"
+
+    public enum Columns: String, ColumnExpression {
+        case id, kind, label, prompt, groupLabel, sortOrder, isVisible, isBuiltIn, createdAt, updatedAt
+    }
+}
+
+// MARK: - Built-in seeds
+
+extension QuickPrompt {
+    /// Built-in pill definitions shipped with the app.
+    ///
+    /// Reserved UUIDs — never reuse, never repurpose. The reconciler matches
+    /// existing rows by these IDs; reusing one would silently rebrand a user's
+    /// edited row. If a built-in is retired, leave its UUID retired in this
+    /// list's history (commit log) and do not assign it to a new pill.
+    ///
+    /// See also `Prompt.builtInPrompts()` for the parallel pattern in the
+    /// summary-prompt library, and ADR-020's burned UUID
+    /// `1C5A1B4A-7E2C-4D38-B3EF-5C0F8A7E3E1A` (Memo-Steered Notes) which is
+    /// **not** owned by this list but documents the same don't-reuse rule.
+    public static func builtInPrompts(now: Date = Date()) -> [QuickPrompt] {
+        builtInStarters(now: now) + builtInFollowUps(now: now)
+    }
+
+    /// Subset by kind — convenience for the reconciler and tests.
+    public static func builtInPrompts(kind: Kind, now: Date = Date()) -> [QuickPrompt] {
+        switch kind {
+        case .starter:  return builtInStarters(now: now)
+        case .followUp: return builtInFollowUps(now: now)
+        }
+    }
+
+    /// Set of canonical built-in UUIDs. Used by the export DTO to coerce a
+    /// claimed `isBuiltIn: true` to `false` on import unless the id is genuinely
+    /// one of ours — prevents a malicious or careless import file from forging
+    /// "built-in" status on a custom row.
+    public static let builtInIDs: Set<UUID> = Set(builtInPrompts().map(\.id))
+
+    private static func builtInStarters(now: Date) -> [QuickPrompt] {
+        [
+            QuickPrompt(
+                id: UUID(uuidString: "242D9804-A7C5-4C0A-8A7A-B075957BC1E5")!,
+                kind: .starter,
+                label: "Summarize so far",
+                prompt: "Give a concise summary of the meeting so far. Focus on the main topics, decisions made, and any clear conclusions. Skip verbal filler.",
+                groupLabel: "CATCH UP",
+                sortOrder: 0,
+                isBuiltIn: true,
+                createdAt: now,
+                updatedAt: now
+            ),
+            QuickPrompt(
+                id: UUID(uuidString: "7218D518-9B15-41C1-B5A9-060FD1BB5554")!,
+                kind: .starter,
+                label: "What did I miss?",
+                prompt: "Catch me up on the most recent shifts in the meeting — the latest decisions, new arguments, or topic changes. Skip what was clearly settled earlier. Be terse, signal-rich.",
+                groupLabel: "CATCH UP",
+                sortOrder: 1,
+                isBuiltIn: true,
+                createdAt: now,
+                updatedAt: now
+            ),
+            QuickPrompt(
+                id: UUID(uuidString: "6D0E7D82-50C1-48A3-B485-6616DC273D18")!,
+                kind: .starter,
+                label: "Decisions made",
+                prompt: "List the decisions reached in the meeting so far. For each, note what was decided and the brief context that explains why. Skip topics that were only discussed without a decision.",
+                groupLabel: "CAPTURE",
+                sortOrder: 2,
+                isBuiltIn: true,
+                createdAt: now,
+                updatedAt: now
+            ),
+            QuickPrompt(
+                id: UUID(uuidString: "F678E4F0-4128-4FD5-80FC-96D6EDC330BF")!,
+                kind: .starter,
+                label: "Action items",
+                prompt: "List concrete action items from the meeting so far — what needs to happen next, by whom, and by when if mentioned. Be specific. Skip vague intentions.",
+                groupLabel: "CAPTURE",
+                sortOrder: 3,
+                isBuiltIn: true,
+                createdAt: now,
+                updatedAt: now
+            ),
+            QuickPrompt(
+                id: UUID(uuidString: "FEEDC4DD-D9B3-4AB0-BCCA-709A1517E23F")!,
+                kind: .starter,
+                label: "Who owns what?",
+                prompt: "Map who owns what from the meeting so far — assignments, commitments, areas of responsibility. If ownership for an item is unclear or unstated, flag that explicitly.",
+                groupLabel: "CAPTURE",
+                sortOrder: 4,
+                isBuiltIn: true,
+                createdAt: now,
+                updatedAt: now
+            ),
+            QuickPrompt(
+                id: UUID(uuidString: "AE32274B-E3E7-4950-A16E-F1DF64660FB2")!,
+                kind: .starter,
+                label: "What's unresolved?",
+                prompt: "List the open questions, unmade decisions, or topics still hanging from the meeting so far. Be specific.",
+                groupLabel: "CHALLENGE",
+                sortOrder: 5,
+                isBuiltIn: true,
+                createdAt: now,
+                updatedAt: now
+            ),
+            QuickPrompt(
+                id: UUID(uuidString: "7107DFB7-F2F0-44E6-864A-5FFD3BC45798")!,
+                kind: .starter,
+                label: "What question is worth asking?",
+                prompt: "Based on the meeting so far, suggest one sharp, useful question I could ask next that would advance the discussion or surface something important that hasn't been addressed.",
+                groupLabel: "CHALLENGE",
+                sortOrder: 6,
+                isBuiltIn: true,
+                createdAt: now,
+                updatedAt: now
+            ),
+            QuickPrompt(
+                id: UUID(uuidString: "9A80A522-A54C-4A57-BA71-43F5F054714F")!,
+                kind: .starter,
+                label: "What's worth pushing back on?",
+                prompt: "Identify any claims, assumptions, or decisions in the meeting so far that deserve scrutiny. What might be wrong, weak, or worth challenging?",
+                groupLabel: "CHALLENGE",
+                sortOrder: 7,
+                isBuiltIn: true,
+                createdAt: now,
+                updatedAt: now
+            ),
+            QuickPrompt(
+                id: UUID(uuidString: "AFC8F517-E186-41C7-A39F-0BE0FAF4E9EA")!,
+                kind: .starter,
+                label: "Where are we going in circles?",
+                prompt: "Have we revisited the same topic or argument without making progress? If so, point out where we're looping and what would actually move things forward.",
+                groupLabel: "CHALLENGE",
+                sortOrder: 8,
+                isBuiltIn: true,
+                createdAt: now,
+                updatedAt: now
+            ),
+        ]
+    }
+
+    private static func builtInFollowUps(now: Date) -> [QuickPrompt] {
+        [
+            QuickPrompt(
+                id: UUID(uuidString: "9EC1C9BC-92BC-417E-ACC4-7F7633102DB1")!,
+                kind: .followUp,
+                label: "Tell me more",
+                prompt: "Expand on your previous response with more concrete detail from the meeting itself — quotes, specifics, who said what. Surface nuances or caveats you compressed out the first time.",
+                sortOrder: 0,
+                isBuiltIn: true,
+                createdAt: now,
+                updatedAt: now
+            ),
+            QuickPrompt(
+                id: UUID(uuidString: "DE860BF2-E6B2-4E05-9A77-D678F68FA86D")!,
+                kind: .followUp,
+                label: "Why?",
+                prompt: "Explain the reasoning behind your previous answer. What from the meeting transcript supports it?",
+                sortOrder: 1,
+                isBuiltIn: true,
+                createdAt: now,
+                updatedAt: now
+            ),
+            QuickPrompt(
+                id: UUID(uuidString: "EB113B55-D5EE-44C1-A208-D5D5474CF4E2")!,
+                kind: .followUp,
+                label: "Give an example",
+                prompt: "Give one specific, concrete example that illustrates your previous response. Pull it from the meeting itself — a moment, exchange, or quote. If the meeting doesn't contain a clean example, say so plainly and offer the closest analogue.",
+                sortOrder: 2,
+                isBuiltIn: true,
+                createdAt: now,
+                updatedAt: now
+            ),
+            QuickPrompt(
+                id: UUID(uuidString: "3256EB3B-7436-4019-9367-7AAB5698B3EC")!,
+                kind: .followUp,
+                label: "Counter-argument?",
+                prompt: "What's the strongest counter-argument to your previous response? Steelman the opposing view, and use anything in the meeting that supports it.",
+                sortOrder: 3,
+                isBuiltIn: true,
+                createdAt: now,
+                updatedAt: now
+            ),
+            QuickPrompt(
+                id: UUID(uuidString: "D7216011-7568-4B1E-87E0-F32A5EF0EAA3")!,
+                kind: .followUp,
+                label: "TL;DR",
+                prompt: "Give the punchy, no-fluff TL;DR of your previous response — one or two sentences. No headers, no list, no preamble.",
+                sortOrder: 4,
+                isBuiltIn: true,
+                createdAt: now,
+                updatedAt: now
+            ),
+        ]
+    }
+}

--- a/Sources/MacParakeetCore/Models/QuickPromptBundle.swift
+++ b/Sources/MacParakeetCore/Models/QuickPromptBundle.swift
@@ -122,13 +122,15 @@ extension QuickPromptBundle {
         _ entry: ExportedQuickPrompt,
         now: Date = Date()
     ) -> QuickPrompt {
-        let trustedBuiltIn = entry.isBuiltIn && QuickPrompt.builtInIDs.contains(entry.id)
+        let canonicalBuiltIn = QuickPrompt.builtInPrompt(id: entry.id, now: now)
+        let resolvedKind = canonicalBuiltIn?.kind ?? entry.kind
+        let trustedBuiltIn = entry.isBuiltIn && canonicalBuiltIn != nil
         return QuickPrompt(
             id: entry.id,
-            kind: entry.kind,
+            kind: resolvedKind,
             label: entry.label,
             prompt: entry.prompt,
-            groupLabel: entry.groupLabel,
+            groupLabel: resolvedKind == .starter ? entry.groupLabel : nil,
             sortOrder: entry.sortOrder,
             isVisible: entry.isVisible,
             isBuiltIn: trustedBuiltIn,

--- a/Sources/MacParakeetCore/Models/QuickPromptBundle.swift
+++ b/Sources/MacParakeetCore/Models/QuickPromptBundle.swift
@@ -1,0 +1,154 @@
+import Foundation
+
+/// Portable, versioned representation of a user's Ask-tab quick prompts.
+///
+/// Designed for backup, sharing, version-controlling in git, and programmatic
+/// use by agents (OpenClaw, Hermes, …) reading/writing pills via the CLI.
+/// Mirrors `VocabularyBundle`'s envelope shape so the two export formats stay
+/// visually similar.
+///
+/// ## Schema policy (CLI semver contract)
+///
+/// `schema` and `version` are stable within a CLI MAJOR. Adding new optional
+/// fields to `ExportedQuickPrompt` is a MINOR change; renaming or removing
+/// fields, changing semantics of existing fields, or restructuring the
+/// top-level shape requires a MAJOR bump (and a new `version` value).
+///
+/// Decoders **must ignore unknown fields** (forward-compat). This is enforced
+/// for free by `Codable`'s default behavior and exercised in
+/// `QuickPromptBundleTests.testForwardCompatIgnoresUnknownFields`.
+public struct QuickPromptBundle: Codable, Sendable, Equatable {
+    public static let schemaIdentifier = "macparakeet.quick_prompts"
+    public static let currentVersion = 1
+
+    public let schema: String
+    public let version: Int
+    public let exportedAt: Date
+    public let appVersion: String?
+    public let prompts: [ExportedQuickPrompt]
+
+    public init(
+        exportedAt: Date,
+        appVersion: String?,
+        prompts: [ExportedQuickPrompt]
+    ) {
+        self.schema = Self.schemaIdentifier
+        self.version = Self.currentVersion
+        self.exportedAt = exportedAt
+        self.appVersion = appVersion
+        self.prompts = prompts
+    }
+
+    public struct ExportedQuickPrompt: Codable, Sendable, Equatable {
+        public let id: UUID
+        public let kind: QuickPrompt.Kind
+        public let label: String
+        public let prompt: String
+        public let groupLabel: String?
+        public let sortOrder: Int
+        public let isVisible: Bool
+        public let isBuiltIn: Bool
+
+        public init(
+            id: UUID,
+            kind: QuickPrompt.Kind,
+            label: String,
+            prompt: String,
+            groupLabel: String?,
+            sortOrder: Int,
+            isVisible: Bool,
+            isBuiltIn: Bool
+        ) {
+            self.id = id
+            self.kind = kind
+            self.label = label
+            self.prompt = prompt
+            self.groupLabel = groupLabel
+            self.sortOrder = sortOrder
+            self.isVisible = isVisible
+            self.isBuiltIn = isBuiltIn
+        }
+    }
+}
+
+// MARK: - Schema validation
+
+public enum QuickPromptBundleError: Error, LocalizedError, Equatable {
+    case wrongSchema(found: String)
+    case unsupportedVersion(found: Int, supported: Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .wrongSchema(let found):
+            return "Not a MacParakeet quick-prompts file (schema='\(found)', expected '\(QuickPromptBundle.schemaIdentifier)')."
+        case .unsupportedVersion(let found, let supported):
+            return "Unsupported quick-prompts schema version \(found); this build supports up to \(supported)."
+        }
+    }
+}
+
+extension QuickPromptBundle {
+    /// Conversion from domain model → wire format.
+    public init(
+        from prompts: [QuickPrompt],
+        exportedAt: Date = Date(),
+        appVersion: String? = nil
+    ) {
+        self.init(
+            exportedAt: exportedAt,
+            appVersion: appVersion,
+            prompts: prompts.map(ExportedQuickPrompt.init)
+        )
+    }
+
+    /// Validate envelope fields. Throws on schema or version mismatch.
+    /// Unknown fields and additive optional fields are tolerated by `Codable`.
+    public func validate() throws {
+        guard schema == Self.schemaIdentifier else {
+            throw QuickPromptBundleError.wrongSchema(found: schema)
+        }
+        guard version <= Self.currentVersion else {
+            throw QuickPromptBundleError.unsupportedVersion(
+                found: version,
+                supported: Self.currentVersion
+            )
+        }
+    }
+
+    /// Conversion from wire entry → domain model. Coerces `isBuiltIn` to `false`
+    /// unless the id matches a known seed, defending against forged "built-in"
+    /// markers in import files.
+    public static func materialize(
+        _ entry: ExportedQuickPrompt,
+        now: Date = Date()
+    ) -> QuickPrompt {
+        let trustedBuiltIn = entry.isBuiltIn && QuickPrompt.builtInIDs.contains(entry.id)
+        return QuickPrompt(
+            id: entry.id,
+            kind: entry.kind,
+            label: entry.label,
+            prompt: entry.prompt,
+            groupLabel: entry.groupLabel,
+            sortOrder: entry.sortOrder,
+            isVisible: entry.isVisible,
+            isBuiltIn: trustedBuiltIn,
+            createdAt: now,
+            updatedAt: now
+        )
+    }
+}
+
+extension QuickPromptBundle.ExportedQuickPrompt {
+    init(_ p: QuickPrompt) {
+        self.init(
+            id: p.id,
+            kind: p.kind,
+            label: p.label,
+            prompt: p.prompt,
+            groupLabel: p.groupLabel,
+            sortOrder: p.sortOrder,
+            isVisible: p.isVisible,
+            isBuiltIn: p.isBuiltIn
+        )
+    }
+}

--- a/Sources/MacParakeetViewModels/MeetingRecordingPanelViewModel.swift
+++ b/Sources/MacParakeetViewModels/MeetingRecordingPanelViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MacParakeetCore
 import SwiftUI
 
 @MainActor @Observable
@@ -39,6 +40,7 @@ public final class MeetingRecordingPanelViewModel {
     public var selectedTab: LivePanelTab = .notes
     public let chatViewModel: TranscriptChatViewModel = TranscriptChatViewModel()
     public let notesViewModel: MeetingNotesViewModel = MeetingNotesViewModel()
+    public let quickPromptsViewModel: QuickPromptsViewModel = QuickPromptsViewModel()
     public var onStop: (() -> Void)?
     public var onClose: (() -> Void)?
 

--- a/Sources/MacParakeetViewModels/QuickPromptsViewModel.swift
+++ b/Sources/MacParakeetViewModels/QuickPromptsViewModel.swift
@@ -77,13 +77,14 @@ public final class QuickPromptsViewModel {
     // MARK: - Mutations
 
     /// Save in-progress edit. Validates label/prompt non-empty.
-    public func saveEdit(_ prompt: QuickPrompt) {
-        guard let repo else { return }
+    @discardableResult
+    public func saveEdit(_ prompt: QuickPrompt) -> Bool {
+        guard let repo else { return false }
         let trimmedLabel = prompt.label.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedPrompt = prompt.prompt.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedLabel.isEmpty, !trimmedPrompt.isEmpty else {
             errorMessage = "Label and prompt are required."
-            return
+            return false
         }
 
         var updated = prompt
@@ -99,22 +100,26 @@ public final class QuickPromptsViewModel {
             editingPrompt = nil
             errorMessage = nil
             refresh()
+            return true
         } catch {
             errorMessage = error.localizedDescription
+            return false
         }
     }
 
     public func startCreating(kind: QuickPrompt.Kind) {
         creating = Draft(kind: kind)
+        errorMessage = nil
     }
 
-    public func commitCreating() {
-        guard let repo, let draft = creating else { return }
+    @discardableResult
+    public func commitCreating() -> Bool {
+        guard let repo, let draft = creating else { return false }
         let trimmedLabel = draft.label.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedPrompt = draft.prompt.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedLabel.isEmpty, !trimmedPrompt.isEmpty else {
             errorMessage = "Label and prompt are required."
-            return
+            return false
         }
 
         let nextSortOrder: Int = {
@@ -145,8 +150,10 @@ public final class QuickPromptsViewModel {
             creating = nil
             errorMessage = nil
             refresh()
+            return true
         } catch {
             errorMessage = error.localizedDescription
+            return false
         }
     }
 

--- a/Sources/MacParakeetViewModels/QuickPromptsViewModel.swift
+++ b/Sources/MacParakeetViewModels/QuickPromptsViewModel.swift
@@ -1,0 +1,229 @@
+import Foundation
+import MacParakeetCore
+
+/// View-model for the live meeting Ask tab quick prompts. Doubles as:
+///
+/// 1. **Pill data source** — `LiveAskPaneView` reads `visibleStarters` /
+///    `visibleFollowUps` to render the chip rows (replacing the old hardcoded
+///    `LiveAskStarterPrompts` / `LiveAskFollowUpPrompts` enums).
+/// 2. **Manage sheet state** — `AskPromptsSheet` reads `allStarters` /
+///    `allFollowUps` (including hidden), the editing/creating state, and
+///    invokes save/delete/reorder/restore-default.
+///
+/// One VM owned by the meeting panel, refreshed on sheet dismiss. Reading from
+/// GRDB on every action is fine — these tables are small (≤30 rows in
+/// practice) and we want the freshest state after edits.
+@MainActor
+@Observable
+public final class QuickPromptsViewModel {
+    public var allStarters: [QuickPrompt] = []
+    public var allFollowUps: [QuickPrompt] = []
+
+    /// In-progress edit state for a row in the management sheet.
+    public var editingPrompt: QuickPrompt?
+
+    /// Pending new-prompt buffer. `nil` when no creation is in progress;
+    /// otherwise holds the kind being created plus draft fields.
+    public var creating: Draft?
+
+    public var errorMessage: String?
+
+    private var repo: QuickPromptRepositoryProtocol?
+
+    public init() {}
+
+    public func configure(repo: QuickPromptRepositoryProtocol) {
+        self.repo = repo
+        refresh()
+    }
+
+    // MARK: - Read
+
+    /// Visible starters grouped by `groupLabel`, preserving first-occurrence
+    /// group order so users who reorder rows control how groups appear.
+    public var visibleStarters: [QuickPrompt] {
+        allStarters.filter(\.isVisible)
+    }
+
+    public var visibleFollowUps: [QuickPrompt] {
+        allFollowUps.filter(\.isVisible)
+    }
+
+    /// Visible starters grouped for `LiveAskPaneView`'s `StarterPromptList`.
+    /// Stable order: groups appear in the order their first member is seen
+    /// (mirrors the legacy hardcoded enum behavior).
+    public var visibleStarterGroups: [(label: String, prompts: [QuickPrompt])] {
+        var seen: [String] = []
+        var buckets: [String: [QuickPrompt]] = [:]
+        for prompt in visibleStarters {
+            let key = prompt.groupLabel ?? ""
+            if buckets[key] == nil { seen.append(key) }
+            buckets[key, default: []].append(prompt)
+        }
+        return seen.map { (label: $0, prompts: buckets[$0] ?? []) }
+    }
+
+    public func refresh() {
+        guard let repo else { return }
+        do {
+            allStarters = try repo.fetchAll(kind: .starter)
+            allFollowUps = try repo.fetchAll(kind: .followUp)
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    // MARK: - Mutations
+
+    /// Save in-progress edit. Validates label/prompt non-empty.
+    public func saveEdit(_ prompt: QuickPrompt) {
+        guard let repo else { return }
+        let trimmedLabel = prompt.label.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedPrompt = prompt.prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedLabel.isEmpty, !trimmedPrompt.isEmpty else {
+            errorMessage = "Label and prompt are required."
+            return
+        }
+
+        var updated = prompt
+        updated.label = trimmedLabel
+        updated.prompt = trimmedPrompt
+        if let group = updated.groupLabel?.trimmingCharacters(in: .whitespacesAndNewlines) {
+            updated.groupLabel = group.isEmpty ? nil : group
+        }
+        updated.updatedAt = Date()
+
+        do {
+            try repo.save(updated)
+            editingPrompt = nil
+            errorMessage = nil
+            refresh()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    public func startCreating(kind: QuickPrompt.Kind) {
+        creating = Draft(kind: kind)
+    }
+
+    public func commitCreating() {
+        guard let repo, let draft = creating else { return }
+        let trimmedLabel = draft.label.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedPrompt = draft.prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedLabel.isEmpty, !trimmedPrompt.isEmpty else {
+            errorMessage = "Label and prompt are required."
+            return
+        }
+
+        let nextSortOrder: Int = {
+            switch draft.kind {
+            case .starter:  return (allStarters.map(\.sortOrder).max() ?? -1) + 1
+            case .followUp: return (allFollowUps.map(\.sortOrder).max() ?? -1) + 1
+            }
+        }()
+
+        let group: String? = draft.kind == .starter
+            ? draft.groupLabel
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .nilIfEmpty
+            : nil
+
+        let prompt = QuickPrompt(
+            kind: draft.kind,
+            label: trimmedLabel,
+            prompt: trimmedPrompt,
+            groupLabel: group,
+            sortOrder: nextSortOrder,
+            isVisible: true,
+            isBuiltIn: false
+        )
+
+        do {
+            try repo.save(prompt)
+            creating = nil
+            errorMessage = nil
+            refresh()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    public func cancelCreating() {
+        creating = nil
+        errorMessage = nil
+    }
+
+    public func toggleVisibility(_ prompt: QuickPrompt) {
+        guard let repo else { return }
+        do {
+            try repo.toggleVisibility(id: prompt.id)
+            refresh()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    public func delete(_ prompt: QuickPrompt) {
+        guard let repo, !prompt.isBuiltIn else { return }
+        do {
+            _ = try repo.delete(id: prompt.id)
+            refresh()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    /// Reorder within a kind. Caller passes the new full ordered list of ids
+    /// for that kind.
+    public func reorder(ids: [UUID], within kind: QuickPrompt.Kind) {
+        guard let repo else { return }
+        do {
+            try repo.reorder(ids: ids, within: kind)
+            refresh()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    public func restoreSingleDefault(_ prompt: QuickPrompt) {
+        guard let repo, prompt.isBuiltIn else { return }
+        do {
+            try repo.restoreBuiltInDefault(id: prompt.id)
+            refresh()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    public func restoreBuiltInDefaults(kind: QuickPrompt.Kind) {
+        guard let repo else { return }
+        do {
+            try repo.restoreBuiltInDefaults(kind: kind)
+            refresh()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    // MARK: - Draft
+
+    public struct Draft: Sendable {
+        public var kind: QuickPrompt.Kind
+        public var label: String
+        public var prompt: String
+        public var groupLabel: String
+
+        public init(kind: QuickPrompt.Kind, label: String = "", prompt: String = "", groupLabel: String = "") {
+            self.kind = kind
+            self.label = label
+            self.prompt = prompt
+            self.groupLabel = groupLabel
+        }
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? { isEmpty ? nil : self }
+}

--- a/Tests/CLITests/QuickPromptsCommandTests.swift
+++ b/Tests/CLITests/QuickPromptsCommandTests.swift
@@ -142,6 +142,27 @@ final class QuickPromptsCommandTests: XCTestCase {
         XCTAssertNoThrow(try QuickPromptsCommand.SetSubcommand.parse(["x", "--label", "New"]))
     }
 
+    func testSetRejectsEmptyLabel() {
+        XCTAssertThrowsError(try QuickPromptsCommand.SetSubcommand.parse(["x", "--label", "   "]))
+    }
+
+    func testSetRejectsEmptyPrompt() {
+        XCTAssertThrowsError(try QuickPromptsCommand.SetSubcommand.parse(["x", "--prompt", "   "]))
+    }
+
+    func testSetRejectsGroupOnFollowUpAfterLookup() throws {
+        let dbURL = temporaryDatabaseURL()
+        let command = try QuickPromptsCommand.SetSubcommand.parse([
+            "Tell me more",
+            "--group", "CATCH UP",
+            "--database", dbURL.path,
+        ])
+
+        XCTAssertThrowsError(try command.run()) { error in
+            XCTAssertTrue(String(describing: error).contains("--group is only valid for starter"))
+        }
+    }
+
     // MARK: - RestoreDefaults validation
 
     func testRestoreRejectsKindAndIDTogether() {
@@ -185,5 +206,10 @@ final class QuickPromptsCommandTests: XCTestCase {
     func testErrorTypeMapsReadFailedToInputMissing() {
         let err = QuickPromptCLIError.readFailed("/no/such/path", underlying: NSError(domain: "test", code: 1))
         XCTAssertEqual(CLIErrorType.key(for: err), "input_missing")
+    }
+
+    private func temporaryDatabaseURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("macparakeet-quick-prompts-\(UUID().uuidString).db")
     }
 }

--- a/Tests/CLITests/QuickPromptsCommandTests.swift
+++ b/Tests/CLITests/QuickPromptsCommandTests.swift
@@ -126,6 +126,27 @@ final class QuickPromptsCommandTests: XCTestCase {
         )
     }
 
+    func testAddJSONReturnsSuccessEnvelope() throws {
+        let dbURL = temporaryDatabaseURL()
+        let command = try QuickPromptsCommand.AddSubcommand.parse([
+            "--kind", "follow-up",
+            "--label", "ELI5",
+            "--prompt", "Explain simply.",
+            "--database", dbURL.path,
+            "--json",
+        ])
+
+        let output = try captureStandardOutput {
+            try command.run()
+        }
+        let envelope = try decodedJSONObject(output)
+
+        XCTAssertEqual(envelope["ok"] as? Bool, true)
+        let prompt = try XCTUnwrap(envelope["prompt"] as? [String: Any])
+        XCTAssertEqual(prompt["label"] as? String, "ELI5")
+        XCTAssertNil(envelope["label"], "write responses should be wrapped under prompt")
+    }
+
     // MARK: - Set validation
 
     func testSetRejectsVisibleAndHidden() {
@@ -161,6 +182,31 @@ final class QuickPromptsCommandTests: XCTestCase {
         XCTAssertThrowsError(try command.run()) { error in
             XCTAssertTrue(String(describing: error).contains("--group is only valid for starter"))
         }
+    }
+
+    func testSetJSONReturnsSuccessEnvelope() throws {
+        let dbURL = temporaryDatabaseURL()
+        let db = try DatabaseManager(path: dbURL.path)
+        let repo = QuickPromptRepository(dbQueue: db.dbQueue)
+        let prompt = QuickPrompt(kind: .starter, label: "Original", prompt: "body")
+        try repo.save(prompt)
+
+        let command = try QuickPromptsCommand.SetSubcommand.parse([
+            prompt.id.uuidString,
+            "--label", "Updated",
+            "--database", dbURL.path,
+            "--json",
+        ])
+
+        let output = try captureStandardOutput {
+            try command.run()
+        }
+        let envelope = try decodedJSONObject(output)
+
+        XCTAssertEqual(envelope["ok"] as? Bool, true)
+        let saved = try XCTUnwrap(envelope["prompt"] as? [String: Any])
+        XCTAssertEqual(saved["id"] as? String, prompt.id.uuidString)
+        XCTAssertEqual(saved["label"] as? String, "Updated")
     }
 
     // MARK: - RestoreDefaults validation
@@ -211,5 +257,11 @@ final class QuickPromptsCommandTests: XCTestCase {
     private func temporaryDatabaseURL() -> URL {
         FileManager.default.temporaryDirectory
             .appendingPathComponent("macparakeet-quick-prompts-\(UUID().uuidString).db")
+    }
+
+    private func decodedJSONObject(_ output: String) throws -> [String: Any] {
+        let data = Data(output.utf8)
+        let object = try JSONSerialization.jsonObject(with: data)
+        return try XCTUnwrap(object as? [String: Any])
     }
 }

--- a/Tests/CLITests/QuickPromptsCommandTests.swift
+++ b/Tests/CLITests/QuickPromptsCommandTests.swift
@@ -1,0 +1,189 @@
+import Foundation
+import XCTest
+@testable import CLI
+@testable import MacParakeetCore
+
+final class QuickPromptsCommandTests: XCTestCase {
+
+    // MARK: - findQuickPrompt
+
+    func testFindByExactUUID() throws {
+        let db = try DatabaseManager()
+        let repo = QuickPromptRepository(dbQueue: db.dbQueue)
+        let p = QuickPrompt(kind: .followUp, label: "ELI5", prompt: "Explain like I'm five.")
+        try repo.save(p)
+
+        let found = try findQuickPrompt(idOrLabel: p.id.uuidString, repo: repo)
+        XCTAssertEqual(found.id, p.id)
+    }
+
+    func testFindByPrefix() throws {
+        let db = try DatabaseManager()
+        let repo = QuickPromptRepository(dbQueue: db.dbQueue)
+        let p = QuickPrompt(kind: .followUp, label: "Recap", prompt: "Recap.")
+        try repo.save(p)
+
+        let prefix = String(p.id.uuidString.prefix(8))
+        let found = try findQuickPrompt(idOrLabel: prefix, repo: repo)
+        XCTAssertEqual(found.id, p.id)
+    }
+
+    func testFindByLabelCaseInsensitive() throws {
+        let db = try DatabaseManager()
+        let repo = QuickPromptRepository(dbQueue: db.dbQueue)
+        let p = QuickPrompt(kind: .starter, label: "My Custom Pill", prompt: "x")
+        try repo.save(p)
+
+        let found = try findQuickPrompt(idOrLabel: "my custom pill", repo: repo)
+        XCTAssertEqual(found.id, p.id)
+    }
+
+    func testFindThrowsNotFound() throws {
+        let db = try DatabaseManager()
+        let repo = QuickPromptRepository(dbQueue: db.dbQueue)
+
+        XCTAssertThrowsError(try findQuickPrompt(idOrLabel: "nonexistent-pill-xyz", repo: repo)) { error in
+            guard let e = error as? CLILookupError else {
+                return XCTFail("Expected CLILookupError, got \(error)")
+            }
+            if case .notFound = e {} else {
+                XCTFail("Expected .notFound, got \(e)")
+            }
+        }
+    }
+
+    func testFindThrowsAmbiguousForSharedPrefix() throws {
+        let db = try DatabaseManager()
+        let repo = QuickPromptRepository(dbQueue: db.dbQueue)
+        let id1 = UUID(uuidString: "BEEFCAFE-1111-4111-8111-111111111111")!
+        let id2 = UUID(uuidString: "BEEFCAFE-2222-4222-8222-222222222222")!
+        try repo.save(QuickPrompt(id: id1, kind: .followUp, label: "X", prompt: "x"))
+        try repo.save(QuickPrompt(id: id2, kind: .followUp, label: "Y", prompt: "y"))
+
+        XCTAssertThrowsError(try findQuickPrompt(idOrLabel: "BEEFCAFE", repo: repo)) { error in
+            guard let e = error as? CLILookupError else {
+                return XCTFail("Expected CLILookupError, got \(error)")
+            }
+            if case .ambiguous = e {} else {
+                XCTFail("Expected .ambiguous, got \(e)")
+            }
+        }
+    }
+
+    func testFindThrowsEmptyIDForWhitespace() throws {
+        let db = try DatabaseManager()
+        let repo = QuickPromptRepository(dbQueue: db.dbQueue)
+
+        XCTAssertThrowsError(try findQuickPrompt(idOrLabel: "   ", repo: repo)) { error in
+            guard let e = error as? CLILookupError else {
+                return XCTFail("Expected CLILookupError, got \(error)")
+            }
+            if case .emptyID = e {} else {
+                XCTFail("Expected .emptyID, got \(e)")
+            }
+        }
+    }
+
+    // MARK: - Add validation
+
+    func testAddRequiresKindAndLabel() {
+        XCTAssertThrowsError(try QuickPromptsCommand.AddSubcommand.parse([]))
+        XCTAssertThrowsError(try QuickPromptsCommand.AddSubcommand.parse(["--label", "x", "--prompt", "y"]))
+    }
+
+    func testAddRejectsPromptAndFromFileTogether() {
+        XCTAssertThrowsError(
+            try QuickPromptsCommand.AddSubcommand.parse([
+                "--kind", "follow-up", "--label", "X", "--prompt", "body", "--from-file", "/tmp/x.txt"
+            ])
+        )
+    }
+
+    func testAddRejectsGroupOnFollowUp() {
+        XCTAssertThrowsError(
+            try QuickPromptsCommand.AddSubcommand.parse([
+                "--kind", "follow-up", "--label", "X", "--prompt", "y", "--group", "FOO"
+            ])
+        ) { error in
+            XCTAssertTrue(String(describing: error).contains("--group is only valid for starter"),
+                          "Expected message about --group requiring starter, got: \(error)")
+        }
+    }
+
+    func testAddAcceptsGroupOnStarter() {
+        XCTAssertNoThrow(
+            try QuickPromptsCommand.AddSubcommand.parse([
+                "--kind", "starter", "--label", "X", "--prompt", "y", "--group", "CATCH UP"
+            ])
+        )
+    }
+
+    func testAddRejectsEmptyLabel() {
+        XCTAssertThrowsError(
+            try QuickPromptsCommand.AddSubcommand.parse([
+                "--kind", "starter", "--label", "   ", "--prompt", "y"
+            ])
+        )
+    }
+
+    // MARK: - Set validation
+
+    func testSetRejectsVisibleAndHidden() {
+        XCTAssertThrowsError(
+            try QuickPromptsCommand.SetSubcommand.parse(["x", "--visible", "--hidden"])
+        )
+    }
+
+    func testSetRequiresAtLeastOneField() {
+        XCTAssertThrowsError(try QuickPromptsCommand.SetSubcommand.parse(["x"]))
+    }
+
+    func testSetAcceptsLabelOnly() {
+        XCTAssertNoThrow(try QuickPromptsCommand.SetSubcommand.parse(["x", "--label", "New"]))
+    }
+
+    // MARK: - RestoreDefaults validation
+
+    func testRestoreRejectsKindAndIDTogether() {
+        XCTAssertThrowsError(
+            try QuickPromptsCommand.RestoreDefaultsSubcommand.parse([
+                "--kind", "starter", "--id", "abcd"
+            ])
+        )
+    }
+
+    // MARK: - Kind argument parsing
+
+    func testKindArgAcceptsBothValues() throws {
+        let starter = try QuickPromptsCommand.AddSubcommand.parse([
+            "--kind", "starter", "--label", "X", "--prompt", "y"
+        ])
+        XCTAssertEqual(starter.kind, .starter)
+
+        let followUp = try QuickPromptsCommand.AddSubcommand.parse([
+            "--kind", "follow-up", "--label", "X", "--prompt", "y"
+        ])
+        XCTAssertEqual(followUp.kind, .followUp)
+    }
+
+    // MARK: - Error type mapping
+
+    func testErrorTypeMapsImportSchemaError() {
+        let err = QuickPromptCLIError.importSchemaError("bad shape")
+        XCTAssertEqual(CLIErrorType.key(for: err), "import_schema")
+    }
+
+    func testErrorTypeMapsDeleteBuiltInToValidation() {
+        let err = QuickPromptCLIError.cannotDeleteBuiltIn("Tell me more")
+        XCTAssertEqual(CLIErrorType.key(for: err), "validation")
+    }
+
+    func testErrorTypeMapsImportCancelledToValidation() {
+        XCTAssertEqual(CLIErrorType.key(for: QuickPromptCLIError.importCancelled), "validation")
+    }
+
+    func testErrorTypeMapsReadFailedToInputMissing() {
+        let err = QuickPromptCLIError.readFailed("/no/such/path", underlying: NSError(domain: "test", code: 1))
+        XCTAssertEqual(CLIErrorType.key(for: err), "input_missing")
+    }
+}

--- a/Tests/MacParakeetTests/Database/QuickPromptRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/QuickPromptRepositoryTests.swift
@@ -272,6 +272,71 @@ final class QuickPromptRepositoryTests: XCTestCase {
         XCTAssertEqual(try repo.fetch(id: forgedID)?.isBuiltIn, false)
     }
 
+    func testImportRejectsDuplicateIDsWithoutTrapping() throws {
+        let duplicateID = UUID(uuidString: "11111111-2222-4333-8444-555555555555")!
+        let first = QuickPromptBundle.ExportedQuickPrompt(
+            id: duplicateID,
+            kind: .followUp,
+            label: "First",
+            prompt: "first",
+            groupLabel: nil,
+            sortOrder: 0,
+            isVisible: true,
+            isBuiltIn: false
+        )
+        let second = QuickPromptBundle.ExportedQuickPrompt(
+            id: duplicateID,
+            kind: .followUp,
+            label: "Second",
+            prompt: "second",
+            groupLabel: nil,
+            sortOrder: 1,
+            isVisible: true,
+            isBuiltIn: false
+        )
+        let bundle = QuickPromptBundle(exportedAt: Date(), appVersion: nil, prompts: [first, second])
+
+        XCTAssertThrowsError(try repo.applyImport(bundle, mode: .merge, dryRun: false)) { error in
+            XCTAssertEqual(error as? QuickPromptImportError, .duplicateID(duplicateID))
+        }
+    }
+
+    func testImportCanonicalizesBuiltInKind() throws {
+        let starter = QuickPrompt.builtInPrompts(kind: .starter).first!
+        let entry = QuickPromptBundle.ExportedQuickPrompt(
+            id: starter.id,
+            kind: .followUp,
+            label: "Still a starter",
+            prompt: "updated body",
+            groupLabel: "CATCH UP",
+            sortOrder: 99,
+            isVisible: true,
+            isBuiltIn: true
+        )
+        let bundle = QuickPromptBundle(exportedAt: Date(), appVersion: nil, prompts: [entry])
+
+        _ = try repo.applyImport(bundle, mode: .merge, dryRun: false)
+
+        let saved = try repo.fetch(id: starter.id)
+        XCTAssertEqual(saved?.kind, .starter)
+        XCTAssertTrue(saved?.isBuiltIn ?? false)
+        XCTAssertEqual(saved?.label, "Still a starter")
+    }
+
+    func testRestoreDefaultRestoresKind() throws {
+        let starter = try repo.fetchAll(kind: .starter).first!
+        try manager.dbQueue.write { db in
+            try db.execute(
+                sql: "UPDATE quick_prompts SET kind = ? WHERE id = ?",
+                arguments: [QuickPrompt.Kind.followUp.rawValue, starter.id]
+            )
+        }
+
+        try repo.restoreBuiltInDefault(id: starter.id)
+
+        XCTAssertEqual(try repo.fetch(id: starter.id)?.kind, .starter)
+    }
+
     // MARK: Import — replace
 
     func testImportReplaceWipesCustomsAndReseeds() throws {
@@ -284,5 +349,22 @@ final class QuickPromptRepositoryTests: XCTestCase {
         XCTAssertEqual(summary.deleted, 1)
         XCTAssertNil(try repo.fetch(id: custom.id))
         XCTAssertEqual(try repo.fetchAll().count, QuickPrompt.builtInPrompts().count)
+    }
+
+    func testImportReplaceDryRunCountsBuiltInResetsWithoutWriting() throws {
+        var starter = try repo.fetchAll(kind: .starter).first!
+        let canonicalLabel = starter.label
+        starter.label = "Edited"
+        starter.isVisible = false
+        try repo.save(starter)
+
+        let bundle = QuickPromptBundle(exportedAt: Date(), appVersion: nil, prompts: [])
+        let summary = try repo.applyImport(bundle, mode: .replace, dryRun: true)
+
+        XCTAssertEqual(summary.updated, 1)
+        let after = try repo.fetch(id: starter.id)
+        XCTAssertEqual(after?.label, "Edited")
+        XCTAssertEqual(after?.isVisible, false)
+        XCTAssertNotEqual(after?.label, canonicalLabel)
     }
 }

--- a/Tests/MacParakeetTests/Database/QuickPromptRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/QuickPromptRepositoryTests.swift
@@ -1,0 +1,288 @@
+import XCTest
+import GRDB
+@testable import MacParakeetCore
+
+final class QuickPromptRepositoryTests: XCTestCase {
+    var manager: DatabaseManager!
+    var repo: QuickPromptRepository!
+
+    override func setUp() async throws {
+        manager = try DatabaseManager()
+        repo = QuickPromptRepository(dbQueue: manager.dbQueue)
+    }
+
+    // MARK: Seeding
+
+    func testBuiltInsSeededAfterMigration() throws {
+        let all = try repo.fetchAll()
+        XCTAssertEqual(all.count, QuickPrompt.builtInPrompts().count)
+        XCTAssertTrue(all.allSatisfy(\.isBuiltIn))
+        XCTAssertTrue(all.allSatisfy(\.isVisible))
+    }
+
+    func testStarterAndFollowUpCounts() throws {
+        let starters = try repo.fetchAll(kind: .starter)
+        let followUps = try repo.fetchAll(kind: .followUp)
+        XCTAssertEqual(starters.count, 9)
+        XCTAssertEqual(followUps.count, 5)
+    }
+
+    func testStartersHaveGroupLabels() throws {
+        let starters = try repo.fetchAll(kind: .starter)
+        XCTAssertTrue(starters.allSatisfy { $0.groupLabel != nil })
+    }
+
+    func testFollowUpsHaveNoGroupLabel() throws {
+        let followUps = try repo.fetchAll(kind: .followUp)
+        XCTAssertTrue(followUps.allSatisfy { $0.groupLabel == nil })
+    }
+
+    func testSeedIfNeededIsIdempotent() throws {
+        let countBefore = try repo.fetchAll().count
+        try repo.seedIfNeeded()
+        try repo.seedIfNeeded()
+        XCTAssertEqual(try repo.fetchAll().count, countBefore)
+    }
+
+    func testSeedIfNeededDoesNotClobberEdits() throws {
+        guard var firstStarter = try repo.fetchAll(kind: .starter).first else {
+            return XCTFail("expected built-in starter")
+        }
+        firstStarter.label = "EDITED LABEL"
+        firstStarter.prompt = "edited body"
+        try repo.save(firstStarter)
+
+        try repo.seedIfNeeded()
+
+        let after = try repo.fetch(id: firstStarter.id)
+        XCTAssertEqual(after?.label, "EDITED LABEL")
+        XCTAssertEqual(after?.prompt, "edited body")
+    }
+
+    func testNoUUIDCollisionsAcrossBuiltIns() {
+        let ids = QuickPrompt.builtInPrompts().map(\.id)
+        XCTAssertEqual(Set(ids).count, ids.count, "Duplicate UUIDs in built-in seed list")
+    }
+
+    func testRetiredBuiltInIsRemovedOnReseed() throws {
+        // Insert a fake "retired" built-in by a UUID not in the canonical list.
+        let retiredID = UUID(uuidString: "DEADBEEF-0000-4000-8000-000000000000")!
+        let retired = QuickPrompt(
+            id: retiredID,
+            kind: .starter,
+            label: "Retired",
+            prompt: "retired body",
+            groupLabel: "RETIRED",
+            isBuiltIn: true
+        )
+        try manager.dbQueue.write { db in try retired.insert(db) }
+
+        try repo.seedIfNeeded()
+
+        XCTAssertNil(try repo.fetch(id: retiredID))
+    }
+
+    func testRetiredBuiltInDoesNotDeleteCustoms() throws {
+        let custom = QuickPrompt(kind: .starter, label: "Mine", prompt: "my body")
+        try repo.save(custom)
+        try repo.seedIfNeeded()
+        XCTAssertNotNil(try repo.fetch(id: custom.id))
+    }
+
+    // MARK: CRUD
+
+    func testSaveAndFetchCustom() throws {
+        let custom = QuickPrompt(kind: .followUp, label: "ELI5", prompt: "Explain like I'm five.")
+        try repo.save(custom)
+        XCTAssertEqual(try repo.fetch(id: custom.id)?.label, "ELI5")
+    }
+
+    func testDeleteBuiltInRejected() throws {
+        let builtIn = try repo.fetchAll(kind: .starter).first!
+        let deleted = try repo.delete(id: builtIn.id)
+        XCTAssertFalse(deleted)
+        XCTAssertNotNil(try repo.fetch(id: builtIn.id))
+    }
+
+    func testDeleteCustomSucceeds() throws {
+        let custom = QuickPrompt(kind: .followUp, label: "X", prompt: "x")
+        try repo.save(custom)
+        XCTAssertTrue(try repo.delete(id: custom.id))
+        XCTAssertNil(try repo.fetch(id: custom.id))
+    }
+
+    func testToggleVisibility() throws {
+        let prompt = try repo.fetchAll(kind: .followUp).first!
+        try repo.toggleVisibility(id: prompt.id)
+        XCTAssertEqual(try repo.fetch(id: prompt.id)?.isVisible, false)
+        XCTAssertTrue(try repo.fetchVisible(kind: .followUp).allSatisfy { $0.id != prompt.id })
+        try repo.toggleVisibility(id: prompt.id)
+        XCTAssertEqual(try repo.fetch(id: prompt.id)?.isVisible, true)
+    }
+
+    func testReorderUpdatesSortOrder() throws {
+        var followUps = try repo.fetchAll(kind: .followUp)
+        XCTAssertEqual(followUps.count, 5)
+        followUps.reverse()
+        try repo.reorder(ids: followUps.map(\.id), within: .followUp)
+
+        let after = try repo.fetchAll(kind: .followUp)
+        XCTAssertEqual(after.map(\.id), followUps.map(\.id))
+    }
+
+    // MARK: Restore defaults
+
+    func testRestoreSingleDefaultRevertsLabelAndPromptButPreservesVisibility() throws {
+        guard var firstStarter = try repo.fetchAll(kind: .starter).first else {
+            return XCTFail("expected built-in starter")
+        }
+        let canonicalLabel = firstStarter.label
+        let canonicalPrompt = firstStarter.prompt
+        firstStarter.label = "DRIFTED"
+        firstStarter.prompt = "drifted"
+        firstStarter.isVisible = false
+        try repo.save(firstStarter)
+
+        try repo.restoreBuiltInDefault(id: firstStarter.id)
+
+        let restored = try repo.fetch(id: firstStarter.id)
+        XCTAssertEqual(restored?.label, canonicalLabel)
+        XCTAssertEqual(restored?.prompt, canonicalPrompt)
+        XCTAssertEqual(restored?.isVisible, false, "visibility should be preserved across restore")
+    }
+
+    func testRestoreDefaultsByKindLeavesOtherKindAlone() throws {
+        guard var followUp = try repo.fetchAll(kind: .followUp).first,
+              var starter = try repo.fetchAll(kind: .starter).first
+        else { return XCTFail("expected both built-in kinds") }
+        let originalFollowUpLabel = followUp.label
+        followUp.label = "DRIFT-FOLLOW"
+        starter.label = "DRIFT-STARTER"
+        try repo.save(followUp)
+        try repo.save(starter)
+
+        try repo.restoreBuiltInDefaults(kind: .starter)
+
+        XCTAssertEqual(try repo.fetch(id: followUp.id)?.label, "DRIFT-FOLLOW",
+                       "follow-up should be untouched when restoring starters only")
+        XCTAssertEqual(try repo.fetch(id: starter.id)?.label,
+                       QuickPrompt.builtInPrompts(kind: .starter).first { $0.id == starter.id }?.label)
+        _ = originalFollowUpLabel
+    }
+
+    func testRestoreDefaultsLeavesCustomsAlone() throws {
+        let custom = QuickPrompt(kind: .followUp, label: "Mine", prompt: "my body")
+        try repo.save(custom)
+        try repo.restoreBuiltInDefaults(kind: nil)
+        XCTAssertNotNil(try repo.fetch(id: custom.id))
+    }
+
+    // MARK: Import — merge
+
+    func testImportMergeUpsertsByID() throws {
+        // Existing custom that we'll update via import
+        let custom = QuickPrompt(kind: .followUp, label: "Old", prompt: "old body")
+        try repo.save(custom)
+
+        let updated = QuickPromptBundle.ExportedQuickPrompt(
+            id: custom.id,
+            kind: .followUp,
+            label: "New",
+            prompt: "new body",
+            groupLabel: nil,
+            sortOrder: 99,
+            isVisible: true,
+            isBuiltIn: false
+        )
+        let bundle = QuickPromptBundle(exportedAt: Date(), appVersion: nil, prompts: [updated])
+
+        let summary = try repo.applyImport(bundle, mode: .merge, dryRun: false)
+        XCTAssertEqual(summary.updated, 1)
+        XCTAssertEqual(summary.added, 0)
+        XCTAssertEqual(try repo.fetch(id: custom.id)?.label, "New")
+    }
+
+    func testImportMergeAddsNewRows() throws {
+        let newID = UUID()
+        let entry = QuickPromptBundle.ExportedQuickPrompt(
+            id: newID,
+            kind: .followUp,
+            label: "Brand New",
+            prompt: "fresh",
+            groupLabel: nil,
+            sortOrder: 100,
+            isVisible: true,
+            isBuiltIn: false
+        )
+        let bundle = QuickPromptBundle(exportedAt: Date(), appVersion: nil, prompts: [entry])
+
+        let summary = try repo.applyImport(bundle, mode: .merge, dryRun: false)
+        XCTAssertEqual(summary.added, 1)
+        XCTAssertNotNil(try repo.fetch(id: newID))
+    }
+
+    func testImportMergePreservesUntouchedRows() throws {
+        let starterCount = try repo.fetchAll(kind: .starter).count
+        let followUpCount = try repo.fetchAll(kind: .followUp).count
+
+        // Empty bundle — should change nothing.
+        let bundle = QuickPromptBundle(exportedAt: Date(), appVersion: nil, prompts: [])
+        let summary = try repo.applyImport(bundle, mode: .merge, dryRun: false)
+
+        XCTAssertEqual(summary.added, 0)
+        XCTAssertEqual(summary.updated, 0)
+        XCTAssertEqual(summary.deleted, 0)
+        XCTAssertEqual(try repo.fetchAll(kind: .starter).count, starterCount)
+        XCTAssertEqual(try repo.fetchAll(kind: .followUp).count, followUpCount)
+    }
+
+    func testImportDryRunMakesNoWrites() throws {
+        let entry = QuickPromptBundle.ExportedQuickPrompt(
+            id: UUID(),
+            kind: .followUp,
+            label: "Should not land",
+            prompt: "ghost",
+            groupLabel: nil,
+            sortOrder: 200,
+            isVisible: true,
+            isBuiltIn: false
+        )
+        let bundle = QuickPromptBundle(exportedAt: Date(), appVersion: nil, prompts: [entry])
+        let summary = try repo.applyImport(bundle, mode: .merge, dryRun: true)
+
+        XCTAssertEqual(summary.added, 1)
+        XCTAssertNil(try repo.fetch(id: entry.id))
+    }
+
+    func testImportForgedBuiltInIsCoercedToCustom() throws {
+        let forgedID = UUID(uuidString: "11111111-2222-4333-8444-555555555555")!
+        let entry = QuickPromptBundle.ExportedQuickPrompt(
+            id: forgedID,
+            kind: .followUp,
+            label: "I claim to be built-in",
+            prompt: "fake",
+            groupLabel: nil,
+            sortOrder: 0,
+            isVisible: true,
+            isBuiltIn: true
+        )
+        let bundle = QuickPromptBundle(exportedAt: Date(), appVersion: nil, prompts: [entry])
+        _ = try repo.applyImport(bundle, mode: .merge, dryRun: false)
+
+        XCTAssertEqual(try repo.fetch(id: forgedID)?.isBuiltIn, false)
+    }
+
+    // MARK: Import — replace
+
+    func testImportReplaceWipesCustomsAndReseeds() throws {
+        let custom = QuickPrompt(kind: .followUp, label: "Doomed", prompt: "doomed")
+        try repo.save(custom)
+
+        let bundle = QuickPromptBundle(exportedAt: Date(), appVersion: nil, prompts: [])
+        let summary = try repo.applyImport(bundle, mode: .replace, dryRun: false)
+
+        XCTAssertEqual(summary.deleted, 1)
+        XCTAssertNil(try repo.fetch(id: custom.id))
+        XCTAssertEqual(try repo.fetchAll().count, QuickPrompt.builtInPrompts().count)
+    }
+}

--- a/Tests/MacParakeetTests/Database/QuickPromptRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/QuickPromptRepositoryTests.swift
@@ -97,6 +97,17 @@ final class QuickPromptRepositoryTests: XCTestCase {
         XCTAssertEqual(try repo.fetch(id: custom.id)?.label, "ELI5")
     }
 
+    func testSaveCollapsesWhitespaceOnlyGroupLabelToNil() throws {
+        let custom = QuickPrompt(
+            kind: .starter,
+            label: "Custom",
+            prompt: "body",
+            groupLabel: "   "
+        )
+        try repo.save(custom)
+        XCTAssertNil(try repo.fetch(id: custom.id)?.groupLabel)
+    }
+
     func testDeleteBuiltInRejected() throws {
         let builtIn = try repo.fetchAll(kind: .starter).first!
         let deleted = try repo.delete(id: builtIn.id)

--- a/Tests/MacParakeetTests/QuickPromptBundleTests.swift
+++ b/Tests/MacParakeetTests/QuickPromptBundleTests.swift
@@ -158,6 +158,40 @@ final class QuickPromptBundleTests: XCTestCase {
         XCTAssertTrue(materialized.isBuiltIn)
     }
 
+    func testMaterializeCanonicalizesBuiltInKind() {
+        let starter = QuickPrompt.builtInPrompts(kind: .starter).first!
+        let entry = QuickPromptBundle.ExportedQuickPrompt(
+            id: starter.id,
+            kind: .followUp,
+            label: "Moved",
+            prompt: "should stay a starter",
+            groupLabel: "CATCH UP",
+            sortOrder: 0,
+            isVisible: true,
+            isBuiltIn: true
+        )
+
+        let materialized = QuickPromptBundle.materialize(entry)
+        XCTAssertEqual(materialized.kind, .starter)
+        XCTAssertTrue(materialized.isBuiltIn)
+    }
+
+    func testMaterializeDropsGroupLabelForFollowUps() {
+        let entry = QuickPromptBundle.ExportedQuickPrompt(
+            id: UUID(),
+            kind: .followUp,
+            label: "Flat",
+            prompt: "Stay flat.",
+            groupLabel: "SHOULD NOT STICK",
+            sortOrder: 0,
+            isVisible: true,
+            isBuiltIn: false
+        )
+
+        let materialized = QuickPromptBundle.materialize(entry)
+        XCTAssertNil(materialized.groupLabel)
+    }
+
     func testKindWireFormatIsSnakeCase() throws {
         let prompts = [QuickPrompt(kind: .followUp, label: "x", prompt: "y")]
         let bundle = QuickPromptBundle(from: prompts, exportedAt: Date(), appVersion: nil)

--- a/Tests/MacParakeetTests/QuickPromptBundleTests.swift
+++ b/Tests/MacParakeetTests/QuickPromptBundleTests.swift
@@ -1,0 +1,168 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class QuickPromptBundleTests: XCTestCase {
+    func testRoundTripPreservesAllFields() throws {
+        let now = Date(timeIntervalSince1970: 1_730_000_000)
+        let prompts = [
+            QuickPrompt(
+                id: UUID(uuidString: "11111111-2222-4333-8444-555555555555")!,
+                kind: .starter,
+                label: "Catch me up",
+                prompt: "Summarize the meeting so far.",
+                groupLabel: "CATCH UP",
+                sortOrder: 0,
+                isVisible: true,
+                isBuiltIn: false,
+                createdAt: now,
+                updatedAt: now
+            ),
+            QuickPrompt(
+                id: UUID(uuidString: "22222222-3333-4444-8555-666666666666")!,
+                kind: .followUp,
+                label: "TL;DR",
+                prompt: "Punchy two-line summary.",
+                groupLabel: nil,
+                sortOrder: 4,
+                isVisible: false,
+                isBuiltIn: false,
+                createdAt: now,
+                updatedAt: now
+            ),
+        ]
+
+        let bundle = QuickPromptBundle(from: prompts, exportedAt: now, appVersion: "0.7.0")
+        let data = try JSONEncoder().encode(bundle)
+        let decoded = try JSONDecoder().decode(QuickPromptBundle.self, from: data)
+
+        XCTAssertEqual(decoded.schema, "macparakeet.quick_prompts")
+        XCTAssertEqual(decoded.version, 1)
+        XCTAssertEqual(decoded.appVersion, "0.7.0")
+        XCTAssertEqual(decoded.prompts.count, 2)
+        XCTAssertEqual(decoded.prompts.map(\.label), ["Catch me up", "TL;DR"])
+        XCTAssertEqual(decoded.prompts.map(\.kind), [.starter, .followUp])
+        XCTAssertEqual(decoded.prompts[0].groupLabel, "CATCH UP")
+        XCTAssertNil(decoded.prompts[1].groupLabel)
+        XCTAssertEqual(decoded.prompts[1].isVisible, false)
+    }
+
+    func testValidateRejectsWrongSchema() throws {
+        let json = """
+            {
+              "schema": "macparakeet.vocabulary",
+              "version": 1,
+              "exportedAt": "2026-05-02T20:00:00Z",
+              "prompts": []
+            }
+            """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let bundle = try decoder.decode(QuickPromptBundle.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try bundle.validate()) { error in
+            XCTAssertEqual(error as? QuickPromptBundleError, .wrongSchema(found: "macparakeet.vocabulary"))
+        }
+    }
+
+    func testValidateRejectsFutureSchemaVersion() throws {
+        let json = """
+            {
+              "schema": "macparakeet.quick_prompts",
+              "version": 99,
+              "exportedAt": "2026-05-02T20:00:00Z",
+              "prompts": []
+            }
+            """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let bundle = try decoder.decode(QuickPromptBundle.self, from: Data(json.utf8))
+
+        XCTAssertThrowsError(try bundle.validate()) { error in
+            XCTAssertEqual(error as? QuickPromptBundleError, .unsupportedVersion(found: 99, supported: 1))
+        }
+    }
+
+    func testForwardCompatIgnoresUnknownTopLevelFields() throws {
+        let json = """
+            {
+              "schema": "macparakeet.quick_prompts",
+              "version": 1,
+              "exportedAt": "2026-05-02T20:00:00Z",
+              "iAmFromTheFuture": "whatever",
+              "prompts": []
+            }
+            """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let bundle = try decoder.decode(QuickPromptBundle.self, from: Data(json.utf8))
+        try bundle.validate()
+        XCTAssertEqual(bundle.prompts.count, 0)
+    }
+
+    func testForwardCompatIgnoresUnknownPromptFields() throws {
+        let json = """
+            {
+              "schema": "macparakeet.quick_prompts",
+              "version": 1,
+              "exportedAt": "2026-05-02T20:00:00Z",
+              "prompts": [
+                {
+                  "id": "11111111-2222-4333-8444-555555555555",
+                  "kind": "starter",
+                  "label": "Test",
+                  "prompt": "Test prompt",
+                  "groupLabel": null,
+                  "sortOrder": 0,
+                  "isVisible": true,
+                  "isBuiltIn": false,
+                  "experimental": "ignore me"
+                }
+              ]
+            }
+            """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let bundle = try decoder.decode(QuickPromptBundle.self, from: Data(json.utf8))
+        XCTAssertEqual(bundle.prompts.count, 1)
+        XCTAssertEqual(bundle.prompts.first?.label, "Test")
+    }
+
+    func testMaterializeCoercesForgedBuiltIn() {
+        let entry = QuickPromptBundle.ExportedQuickPrompt(
+            id: UUID(),
+            kind: .followUp,
+            label: "Forged",
+            prompt: "x",
+            groupLabel: nil,
+            sortOrder: 0,
+            isVisible: true,
+            isBuiltIn: true
+        )
+        let materialized = QuickPromptBundle.materialize(entry)
+        XCTAssertFalse(materialized.isBuiltIn)
+    }
+
+    func testMaterializeTrustsRealBuiltInID() {
+        let realID = QuickPrompt.builtInPrompts().first!.id
+        let entry = QuickPromptBundle.ExportedQuickPrompt(
+            id: realID,
+            kind: .starter,
+            label: "Re-styled",
+            prompt: "y",
+            groupLabel: "X",
+            sortOrder: 0,
+            isVisible: true,
+            isBuiltIn: true
+        )
+        let materialized = QuickPromptBundle.materialize(entry)
+        XCTAssertTrue(materialized.isBuiltIn)
+    }
+
+    func testKindWireFormatIsSnakeCase() throws {
+        let prompts = [QuickPrompt(kind: .followUp, label: "x", prompt: "y")]
+        let bundle = QuickPromptBundle(from: prompts, exportedAt: Date(), appVersion: nil)
+        let data = try JSONEncoder().encode(bundle)
+        let s = String(decoding: data, as: UTF8.self)
+        XCTAssertTrue(s.contains("\"kind\":\"follow_up\""), "JSON should use snake_case 'follow_up' wire value")
+    }
+}

--- a/Tests/MacParakeetTests/ViewModels/QuickPromptsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/QuickPromptsViewModelTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import MacParakeetCore
+@testable import MacParakeetViewModels
+
+@MainActor
+final class QuickPromptsViewModelTests: XCTestCase {
+    var manager: DatabaseManager!
+    var repo: QuickPromptRepository!
+    var viewModel: QuickPromptsViewModel!
+
+    override func setUp() async throws {
+        manager = try DatabaseManager()
+        repo = QuickPromptRepository(dbQueue: manager.dbQueue)
+        viewModel = QuickPromptsViewModel()
+        viewModel.configure(repo: repo)
+    }
+
+    func testSaveEditRejectsEmptyFieldsWithoutClearingEditingPrompt() {
+        var prompt = viewModel.allStarters.first!
+        viewModel.editingPrompt = prompt
+        prompt.label = " "
+
+        XCTAssertFalse(viewModel.saveEdit(prompt))
+        XCTAssertNotNil(viewModel.editingPrompt)
+        XCTAssertEqual(viewModel.errorMessage, "Label and prompt are required.")
+    }
+
+    func testCommitCreatingRejectsEmptyFieldsWithoutClearingDraft() {
+        viewModel.startCreating(kind: .starter)
+        viewModel.creating?.label = "New"
+
+        XCTAssertFalse(viewModel.commitCreating())
+        XCTAssertNotNil(viewModel.creating)
+        XCTAssertEqual(viewModel.errorMessage, "Label and prompt are required.")
+    }
+
+    func testCommitCreatingSuccessClearsDraft() {
+        viewModel.startCreating(kind: .followUp)
+        viewModel.creating?.label = "ELI5"
+        viewModel.creating?.prompt = "Explain simply."
+
+        XCTAssertTrue(viewModel.commitCreating())
+        XCTAssertNil(viewModel.creating)
+        XCTAssertTrue(viewModel.allFollowUps.contains { $0.label == "ELI5" })
+    }
+
+    func testReorderUpdatesFollowUpOrder() {
+        let original = viewModel.allFollowUps
+        let reversedIDs = original.reversed().map(\.id)
+
+        viewModel.reorder(ids: reversedIDs, within: .followUp)
+
+        XCTAssertEqual(viewModel.allFollowUps.map(\.id), reversedIDs)
+    }
+}

--- a/plans/completed/2026-05-ask-quick-prompts.md
+++ b/plans/completed/2026-05-ask-quick-prompts.md
@@ -22,7 +22,7 @@ Replace the hardcoded starter and follow-up pill enums in the live meeting Ask t
 1. **Independent table.** New `quick_prompts` table; no changes to `prompts`.
 2. **Two kinds in one table** — `starter` and `followUp`. Discriminated by a `kind` column. Single sheet shows both as stacked sections.
 3. **Built-ins are editable, not read-only** — divergence from Prompt Library. Users can rename, retune, reorder, and hide built-ins. Cannot delete them. Each built-in row offers per-row "Restore default."
-4. **Reset semantics** — per-section "Reset built-ins" restores label/prompt/order/visibility for built-ins only; never deletes user-created customs.
+4. **Reset semantics** — per-section "Reset built-ins" restores label/prompt/group/order for built-ins only while preserving visibility; never deletes user-created customs.
 5. **No template variables** — pills are plain strings. `TranscriptChatViewModel` already injects transcript + notes via system prompt; adding `{{transcript}}` here would duplicate context and reintroduce the source-scoping hazard from ADR-020.
 6. **Manage entry point: sparkle popover footer only.** No Settings entry, no transcript-detail entry. Pills are met in the Ask tab; managed from the Ask tab.
 7. **Group label optional, on starter only.** Follow-ups are flat; starters keep optional `groupLabel` so users can preserve CATCH UP / CAPTURE / CHALLENGE clustering.
@@ -35,13 +35,13 @@ Replace the hardcoded starter and follow-up pill enums in the live meeting Ask t
 | File | Target | Purpose |
 |------|--------|---------|
 | `Sources/MacParakeetCore/Models/QuickPrompt.swift` | Core | `QuickPrompt` model, `Kind` enum, built-in seed values |
-| `Sources/MacParakeetCore/Models/QuickPromptExportDTO.swift` | Core | Versioned wire format (`schemaVersion: 1`), encode/decode + coercion rules |
+| `Sources/MacParakeetCore/Models/QuickPromptBundle.swift` | Core | Versioned wire format (`version: 1`), encode/decode + coercion rules |
 | `Sources/MacParakeetCore/Database/QuickPromptRepository.swift` | Core | Protocol + GRDB-backed CRUD + reconciler + import-merge logic |
 | `Sources/MacParakeetViewModels/QuickPromptsViewModel.swift` | ViewModels | Sheet state, edit/create/reorder/restore-defaults |
 | `Sources/MacParakeet/Views/MeetingRecording/AskPromptsSheet.swift` | GUI | The "Ask Prompts" management sheet |
 | `Sources/CLI/Commands/QuickPromptsCommand.swift` | CLI | `quick-prompts list/show/add/set/delete/restore-defaults/export/import` |
 | `Tests/MacParakeetTests/QuickPromptRepositoryTests.swift` | Tests | CRUD + seeding + reconciler idempotency + import-merge |
-| `Tests/MacParakeetTests/QuickPromptExportDTOTests.swift` | Tests | Round-trip encode/decode, schema version, builtIn coercion |
+| `Tests/MacParakeetTests/QuickPromptBundleTests.swift` | Tests | Round-trip encode/decode, schema version, builtIn coercion |
 | `Tests/MacParakeetTests/QuickPromptsViewModelTests.swift` | Tests | Edit, reorder, restore-default, visibility |
 | `Tests/CLITests/QuickPromptsCommandTests.swift` | Tests | CLI parsing, JSON envelope, exit codes |
 
@@ -85,7 +85,7 @@ Built-in seed values live as a `static let builtIns: [QuickPrompt]` in `QuickPro
 ```json
 {
   "schema": "macparakeet.quick_prompts",
-  "schemaVersion": 1,
+  "version": 1,
   "exportedAt": "2026-05-02T20:00:00Z",
   "appVersion": "0.7.0",
   "prompts": [
@@ -105,7 +105,7 @@ Built-in seed values live as a `static let builtIns: [QuickPrompt]` in `QuickPro
 
 **Schema rules (locked under CLI semver from v1):**
 - Single flat `prompts` array; `kind` discriminates (`"starter"` | `"follow_up"`). Future kinds added in minor bumps.
-- Top-level `schemaVersion: 1`. Bump only on breaking changes; new optional fields don't bump.
+- Top-level `version: 1`. Bump only on breaking changes; new optional fields don't bump.
 - `id` is required and round-trippable. Imports match by id (UPSERT) — enables "edit built-in via export-edit-import."
 - `isBuiltIn` advisory: import trusts it only when id matches a known seed UUID; otherwise coerced to `false` (prevents shipping fake "built-ins").
 - Unknown fields in input are ignored (forward-compat). Missing optional fields default per model.
@@ -166,9 +166,9 @@ No unique index on label — users can have duplicate labels across customs (e.g
 - Tests: idempotent seeding, delete-built-in error, reorder ordering, restore-defaults preserves customs, merge import upserts, replace import wipes customs but re-seeds built-ins.
 
 ### Step 2.5 — Export DTO
-- Create `QuickPromptExportDTO` with `schema`, `schemaVersion`, `exportedAt`, `appVersion`, `prompts: [QuickPromptExportEntry]`.
+- Create `QuickPromptBundle` with `schema`, `version`, `exportedAt`, `appVersion`, `prompts: [ExportedQuickPrompt]`.
 - `encode(from: [QuickPrompt])` and `decode(from: Data) throws`.
-- `decode` enforces `schema == "macparakeet.quick_prompts"` and `schemaVersion == 1`; unknown fields ignored (forward-compat); missing required fields throw with clear path (e.g. `prompts[3].label`).
+- `decode` enforces `schema == "macparakeet.quick_prompts"` and `version == 1`; unknown fields ignored (forward-compat); missing required fields throw with clear path (e.g. `prompts[3].label`).
 - `isBuiltIn` coerced to `false` on decode unless `id` matches a known seed UUID (defended against forged built-ins).
 - Tests: round-trip, schema-version mismatch error, unknown-field tolerance, builtIn coercion.
 
@@ -222,7 +222,7 @@ No unique index on label — users can have duplicate labels across customs (e.g
   - `quick-prompts` subcommand surface: `list`, `show`, `add`, `set`,
     `delete`, `restore-defaults`, `export`, `import`. Manages live-meeting
     Ask tab pills (starter + follow-up). Stable JSON wire format
-    (`schema: "macparakeet.quick_prompts"`, `schemaVersion: 1`).
+    (`schema: "macparakeet.quick_prompts"`, `version: 1`).
   - `errorType: "import_schema"` for malformed import files.
   ```
 - Confirm version line in CHANGELOG bumps minor (additive).
@@ -238,7 +238,7 @@ No unique index on label — users can have duplicate labels across customs (e.g
   - [ ] Delete a custom → gone after restart.
   - [ ] Hide a built-in → not in pill row, still in management sheet.
   - [ ] "Reset built-ins" preserves user-created customs.
-  - [ ] Drag-reorder persists across restart.
+  - [ ] Move up/down reorder persists across restart.
   - [ ] Create starter with brand-new group label → group renders in StarterPromptList.
 
 ## Acceptance Criteria

--- a/plans/completed/2026-05-ask-quick-prompts.md
+++ b/plans/completed/2026-05-ask-quick-prompts.md
@@ -1,0 +1,276 @@
+# Ask Tab Quick Prompts — Implementation Plan
+
+> Status: **COMPLETED** — 2026-05-02
+> Ship target: **app v0.7.0**
+> Issue: TBD
+> Related: ADR-018 (Ask tab), ADR-013 (Prompt Library — pattern reference, not extension), `plans/active/cli-as-canonical-parakeet-surface.md`
+> Touches: `Sources/MacParakeet/Views/MeetingRecording/LiveAskPaneView.swift:311,438`, `Sources/CLI/Commands/`
+> Shipped on `feat/ask-quick-prompts` in three commits (data layer → CLI → GUI). 51 new tests; full suite 2160 / 2160 passing.
+
+## Overview
+
+Replace the hardcoded starter and follow-up pill enums in the live meeting Ask tab with a user-customizable, GRDB-backed system. Users can edit, reorder, hide, and create their own starter prompts (CATCH UP / CAPTURE / CHALLENGE) and follow-up prompts (Tell me more / Why? / TL;DR) from a dedicated **Ask Prompts** sheet, reachable via a footer link in the existing sparkle ✨ menu popover.
+
+**Three consumers of one core**: GUI sheet (the polished UI), CLI subcommand (`macparakeet-cli quick-prompts ...`), and JSON export/import (versioned wire format). Building all three in v1 keeps the data layer cleanly decoupled from any single UI and aligns with the CLI-canonical-surface direction. Power users can version-control their pills in git, agents (OpenClaw / Hermes) can read/write them programmatically, and the headless round-trip test path catches regressions the GUI alone wouldn't.
+
+## Why Not Reuse Prompt Library
+
+`Prompt` (in `Sources/MacParakeetCore/Models/Prompt.swift`) models heavyweight, document-producing transforms with `Auto-Run`, `summaries` table caching, and source-agnostic application. Ask pills are lightweight conversational shortcuts with a *display label* and a *richer prompt body* that fires as a chat message. Bolting a scope flag onto `Prompt` would conflate two different mental models. Instead: a parallel, smaller table that follows the same shape so the patterns are familiar and the design language stays consistent.
+
+## Design Decisions (Settled)
+
+1. **Independent table.** New `quick_prompts` table; no changes to `prompts`.
+2. **Two kinds in one table** — `starter` and `followUp`. Discriminated by a `kind` column. Single sheet shows both as stacked sections.
+3. **Built-ins are editable, not read-only** — divergence from Prompt Library. Users can rename, retune, reorder, and hide built-ins. Cannot delete them. Each built-in row offers per-row "Restore default."
+4. **Reset semantics** — per-section "Reset built-ins" restores label/prompt/order/visibility for built-ins only; never deletes user-created customs.
+5. **No template variables** — pills are plain strings. `TranscriptChatViewModel` already injects transcript + notes via system prompt; adding `{{transcript}}` here would duplicate context and reintroduce the source-scoping hazard from ADR-020.
+6. **Manage entry point: sparkle popover footer only.** No Settings entry, no transcript-detail entry. Pills are met in the Ask tab; managed from the Ask tab.
+7. **Group label optional, on starter only.** Follow-ups are flat; starters keep optional `groupLabel` so users can preserve CATCH UP / CAPTURE / CHALLENGE clustering.
+8. **Reconciler is insert-only.** On launch, INSERT IF NOT EXISTS by canonical UUID. Never UPDATE existing rows (would clobber edits). Hidden via `isVisible=false`.
+9. **Fresh UUID block.** Do not reuse the burned `1C5A1B4A-7E2C-4D38-B3EF-5C0F8A7E3E1A` slot from ADR-020.
+10. **No engine/AI dependency change.** Pill click still routes through `TranscriptChatViewModel.sendMessage(richPrompt:)` exactly as today.
+
+## New Files
+
+| File | Target | Purpose |
+|------|--------|---------|
+| `Sources/MacParakeetCore/Models/QuickPrompt.swift` | Core | `QuickPrompt` model, `Kind` enum, built-in seed values |
+| `Sources/MacParakeetCore/Models/QuickPromptExportDTO.swift` | Core | Versioned wire format (`schemaVersion: 1`), encode/decode + coercion rules |
+| `Sources/MacParakeetCore/Database/QuickPromptRepository.swift` | Core | Protocol + GRDB-backed CRUD + reconciler + import-merge logic |
+| `Sources/MacParakeetViewModels/QuickPromptsViewModel.swift` | ViewModels | Sheet state, edit/create/reorder/restore-defaults |
+| `Sources/MacParakeet/Views/MeetingRecording/AskPromptsSheet.swift` | GUI | The "Ask Prompts" management sheet |
+| `Sources/CLI/Commands/QuickPromptsCommand.swift` | CLI | `quick-prompts list/show/add/set/delete/restore-defaults/export/import` |
+| `Tests/MacParakeetTests/QuickPromptRepositoryTests.swift` | Tests | CRUD + seeding + reconciler idempotency + import-merge |
+| `Tests/MacParakeetTests/QuickPromptExportDTOTests.swift` | Tests | Round-trip encode/decode, schema version, builtIn coercion |
+| `Tests/MacParakeetTests/QuickPromptsViewModelTests.swift` | Tests | Edit, reorder, restore-default, visibility |
+| `Tests/CLITests/QuickPromptsCommandTests.swift` | Tests | CLI parsing, JSON envelope, exit codes |
+
+## Modified Files
+
+| File | Change |
+|------|--------|
+| `Sources/MacParakeetCore/Database/DatabaseManager.swift` | New migration `v0.10-quick-prompts` — create table, seed built-ins from existing enums |
+| `Sources/MacParakeet/Views/MeetingRecording/LiveAskPaneView.swift` | Read pills from `viewModel.quickPrompts.starters` / `.followUps` instead of `LiveAskStarterPrompts.groups` / `LiveAskFollowUpPrompts.all`; add "Edit pills…" footer link to `PromptMenuButton` popover; keep enums as built-in seed source only (or move to `QuickPrompt.swift`) |
+| `Sources/MacParakeetViewModels/TranscriptChatViewModel.swift` | Hold a `QuickPromptsViewModel` (or just expose `starters` / `followUps` reactive arrays); refresh on sheet dismiss |
+| `Sources/MacParakeet/App/AppEnvironment.swift` | Construct `QuickPromptRepository`, run reconciler on app start, inject into ViewModels |
+| `Sources/CLI/MacParakeetCLI.swift` | Register `QuickPromptsCommand` in subcommand list |
+| `Sources/CLI/CHANGELOG.md` | Add entry to `[Unreleased]` for new `quick-prompts` subcommand surface (minor bump) |
+
+## Data Model
+
+```swift
+public struct QuickPrompt: Codable, Identifiable, Sendable, Hashable {
+    public var id: UUID
+    public var kind: Kind                    // .starter | .followUp
+    public var label: String                 // Pill display text (short)
+    public var prompt: String                // Full prompt body sent to LLM
+    public var groupLabel: String?           // Starters only; nil for followUps
+    public var sortOrder: Int                // Within (kind, groupLabel) tuple
+    public var isVisible: Bool               // Toggle in UI
+    public var isBuiltIn: Bool               // Affects "Restore default" + delete affordances
+    public var createdAt: Date
+    public var updatedAt: Date
+
+    public enum Kind: String, Codable, Sendable {
+        case starter
+        case followUp = "follow_up"
+    }
+}
+```
+
+Built-in seed values live as a `static let builtIns: [QuickPrompt]` in `QuickPrompt.swift`, copy-paste-mapped 1:1 from the current `LiveAskStarterPrompts.groups` and `LiveAskFollowUpPrompts.all`. Each gets a fresh hardcoded UUID. For "Restore default" lookup we keep an in-memory dictionary `[UUID: QuickPrompt]` keyed off the seed list.
+
+## JSON Wire Format (CLI export/import)
+
+```json
+{
+  "schema": "macparakeet.quick_prompts",
+  "schemaVersion": 1,
+  "exportedAt": "2026-05-02T20:00:00Z",
+  "appVersion": "0.7.0",
+  "prompts": [
+    {
+      "id": "B7E1D4F0-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+      "kind": "starter",
+      "label": "Summarize so far",
+      "prompt": "Give a concise summary...",
+      "groupLabel": "CATCH UP",
+      "sortOrder": 0,
+      "isVisible": true,
+      "isBuiltIn": true
+    }
+  ]
+}
+```
+
+**Schema rules (locked under CLI semver from v1):**
+- Single flat `prompts` array; `kind` discriminates (`"starter"` | `"follow_up"`). Future kinds added in minor bumps.
+- Top-level `schemaVersion: 1`. Bump only on breaking changes; new optional fields don't bump.
+- `id` is required and round-trippable. Imports match by id (UPSERT) — enables "edit built-in via export-edit-import."
+- `isBuiltIn` advisory: import trusts it only when id matches a known seed UUID; otherwise coerced to `false` (prevents shipping fake "built-ins").
+- Unknown fields in input are ignored (forward-compat). Missing optional fields default per model.
+- Top-level `appVersion` is informational only — never gates import.
+
+## CLI Surface (locked under `Sources/CLI/CHANGELOG.md` semver)
+
+```
+macparakeet-cli quick-prompts list [--kind starter|follow-up] [--visible-only] [--json]
+macparakeet-cli quick-prompts show <id> [--json]
+macparakeet-cli quick-prompts add --kind <k> --label <s> --prompt <s> [--group <s>] [--hidden] [--json]
+macparakeet-cli quick-prompts set <id> [--label <s>] [--prompt <s>] [--group <s>] [--visible|--hidden] [--sort-order <n>] [--json]
+macparakeet-cli quick-prompts delete <id> [--json]                # rejects built-ins (errorType: "validation")
+macparakeet-cli quick-prompts restore-defaults [--kind <k>] [--id <uuid>] [--json]
+macparakeet-cli quick-prompts export [--out <path>] [--kind <k>] [--include-builtins] [--json]
+macparakeet-cli quick-prompts import <path> [--mode merge|replace] [--dry-run] [--json]
+```
+
+- `import --mode merge` (default): UPSERT by id; rows not in file preserved.
+- `import --mode replace`: wipe customs in scope, re-seed built-ins, then apply file. Confirmation prompt unless `--json` (scripted).
+- `import --dry-run`: emits `{added, updated, deleted, unchanged}` count summary; no DB writes.
+- All mutation commands honor existing `--json` failure envelope (`{ok, error, errorType}`); add new `errorType: "import_schema"` for malformed import files (minor bump).
+
+## Schema
+
+```sql
+CREATE TABLE quick_prompts (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,                  -- 'starter' | 'follow_up'
+    label TEXT NOT NULL,
+    prompt TEXT NOT NULL,
+    groupLabel TEXT,                     -- NULL for follow-ups
+    sortOrder INTEGER NOT NULL DEFAULT 0,
+    isVisible INTEGER NOT NULL DEFAULT 1,
+    isBuiltIn INTEGER NOT NULL DEFAULT 0,
+    createdAt TEXT NOT NULL,
+    updatedAt TEXT NOT NULL
+);
+CREATE INDEX idx_quick_prompts_kind_sort ON quick_prompts(kind, sortOrder);
+```
+
+No unique index on label — users can have duplicate labels across customs (e.g. two "Why?" with different bodies for different framings).
+
+## Implementation Steps
+
+### Step 1 — Model + Seeds
+- Create `QuickPrompt.swift` with struct, `Kind` enum, GRDB conformances (`FetchableRecord`, `PersistableRecord`, `databaseTableName = "quick_prompts"`, `Columns` enum).
+- Define `static let builtIns: [QuickPrompt]` — port every entry from `LiveAskStarterPrompts.groups` and `LiveAskFollowUpPrompts.all`. Each gets a fixed UUID literal.
+- Tests: round-trip Codable, built-in count assertions, no UUID collisions.
+
+### Step 2 — Repository
+- `QuickPromptRepositoryProtocol` with `fetchVisible(kind:)`, `fetchAll(kind:)`, `fetchAll()`, `fetch(id:)`, `save(_:)`, `delete(id:)`, `reorder(ids:within:)`, `toggleVisibility(id:)`, `seedIfNeeded()`, `restoreBuiltInDefaults(kind:)`, `restoreBuiltInDefault(id:)`, `applyImport(_:mode:)` returning `ImportSummary`.
+- `seedIfNeeded()` is the launch-time reconciler: for each built-in seed UUID, INSERT IF NOT EXISTS. Never UPDATE.
+- `restoreBuiltInDefaults(kind:)` UPDATEs every built-in row in the kind back to seed values (label/prompt/groupLabel/sortOrder/isVisible).
+- `restoreBuiltInDefault(id:)` per-row variant.
+- `applyImport(dto, mode:)` performs UPSERT-by-id (merge) or wipe-and-re-seed-then-apply (replace) inside a single GRDB transaction. Returns counts (`added`, `updated`, `deleted`, `unchanged`).
+- `delete(id:)` rejects `isBuiltIn == true` and throws — UI prevents the call; CLI surfaces as `errorType: "validation"`.
+- Tests: idempotent seeding, delete-built-in error, reorder ordering, restore-defaults preserves customs, merge import upserts, replace import wipes customs but re-seeds built-ins.
+
+### Step 2.5 — Export DTO
+- Create `QuickPromptExportDTO` with `schema`, `schemaVersion`, `exportedAt`, `appVersion`, `prompts: [QuickPromptExportEntry]`.
+- `encode(from: [QuickPrompt])` and `decode(from: Data) throws`.
+- `decode` enforces `schema == "macparakeet.quick_prompts"` and `schemaVersion == 1`; unknown fields ignored (forward-compat); missing required fields throw with clear path (e.g. `prompts[3].label`).
+- `isBuiltIn` coerced to `false` on decode unless `id` matches a known seed UUID (defended against forged built-ins).
+- Tests: round-trip, schema-version mismatch error, unknown-field tolerance, builtIn coercion.
+
+### Step 3 — Migration
+- New migration `v0.10-quick-prompts` in `DatabaseManager.swift` — create table + index + invoke seed insert via the same UUIDs the in-app reconciler uses (so first-launch path matches upgrade-launch path).
+- Tests: migration creates table, seeded count matches `QuickPrompt.builtIns.count`.
+
+### Step 4 — ViewModel
+- `QuickPromptsViewModel` (`@MainActor @Observable`):
+  - `starters: [QuickPrompt]`, `followUps: [QuickPrompt]` (visible-only convenience accessors + full lists for the sheet).
+  - `editing: QuickPrompt?` for the inline editor.
+  - `creatingKind: Kind?` for the "+ New" affordance.
+  - `save()`, `delete()`, `move(_:to:within:)`, `restoreDefaults(kind:)`, `restoreSingleDefault(id:)`, `toggleVisibility(id:)`.
+  - `refresh()` reloads from repo; called on sheet dismiss + after every mutation.
+- Tests: each public action against an in-memory repository.
+
+### Step 5 — Sheet UI (`AskPromptsSheet.swift`)
+- Reuse `PromptLibraryView`'s visual language: dark surface, accent toggles, rounded inset cards, 14pt corner radius.
+- Two stacked sections:
+  - **Starters** — grouped by `groupLabel` (CATCH UP / CAPTURE / CHALLENGE), each row: drag handle, visibility toggle, label, prompt preview, expand/edit chevron. Built-ins show subtle "default" badge with "Restore" on hover. "+ New starter" footer pinned to section.
+  - **Follow-ups** — flat list, same row anatomy, no group header. "+ New follow-up" footer.
+- Per-section footer: small "Reset built-ins" link with confirm-on-click.
+- Inline editor (sheet-within-sheet or expanded row): label field (short, 60-char cap), prompt body (multiline, 4000-char cap), group picker for starters (free-text combo: existing groups + "New group…").
+- "Done" button dismisses; closing without save discards in-progress edits.
+
+### Step 6 — Wire LiveAskPaneView
+- `LiveAskPaneView` reads from injected `viewModel.starters` / `viewModel.followUps` (or `quickPromptsVM.starters` / `.followUps`) instead of the hardcoded enums.
+- `StarterPromptList` continues to render groups as today; iterates over `Dictionary(grouping: starters, by: \.groupLabel)` with stable group order from first-occurrence.
+- Follow-up row iterates over `followUps` directly.
+- `PromptMenuButton` popover gets a footer row: small text button "Edit pills…" → presents `AskPromptsSheet`. Footer styled with hairline divider above, 11pt secondary text, accent on hover.
+- Delete the static enums `LiveAskStarterPrompts` / `LiveAskFollowUpPrompts` from `LiveAskPaneView.swift` (they live in `QuickPrompt.builtIns` now).
+
+### Step 7 — Environment Wiring
+- `AppEnvironment` constructs `QuickPromptRepository` using shared `DatabaseQueue`, calls `seedIfNeeded()` once during start.
+- Pass through to `TranscriptChatViewModel` (or its parent meeting-panel VM) so `LiveAskPaneView` can observe.
+- Refresh trigger on `AskPromptsSheet` dismiss → `quickPromptsVM.refresh()` → triggers re-render of pill rows.
+
+### Step 8 — CLI surface (`QuickPromptsCommand.swift`)
+- Mirror `PromptsCommand` structure: outer `AsyncParsableCommand` with subcommands.
+- Each subcommand reuses the same `QuickPromptRepository` instance via shared DB path.
+- `list` / `show` / `add` / `set` / `delete` / `restore-defaults` are sync (`ParsableCommand`).
+- `export` and `import` are async; honor `--json` envelope per CLI CHANGELOG.md.
+- Confirmation prompt for `import --mode replace` unless `--json`.
+- `import --dry-run` writes summary JSON, never opens write transaction.
+- Register in `MacParakeetCLI.swift` subcommands list.
+- Tests in `Tests/CLITests/QuickPromptsCommandTests.swift`: parse all subcommands, verify exit codes, verify `--json` envelope on success and failure paths.
+
+### Step 9 — CLI CHANGELOG
+- Add `[Unreleased]` entry under `### Added`:
+  ```
+  - `quick-prompts` subcommand surface: `list`, `show`, `add`, `set`,
+    `delete`, `restore-defaults`, `export`, `import`. Manages live-meeting
+    Ask tab pills (starter + follow-up). Stable JSON wire format
+    (`schema: "macparakeet.quick_prompts"`, `schemaVersion: 1`).
+  - `errorType: "import_schema"` for malformed import files.
+  ```
+- Confirm version line in CHANGELOG bumps minor (additive).
+
+### Step 10 — Tests + Polish
+- Snapshot the seeded count + UUIDs (regression guard against accidental UUID changes).
+- Run `swift test` — full suite must pass; expect ~6–10 new test cases.
+- Manual checklist:
+  - [ ] Empty Ask tab shows starter pills from DB, grouped correctly.
+  - [ ] Mid-conversation: follow-up row + sparkle popover both read from DB.
+  - [ ] Edit a built-in's label → sticks across app restart.
+  - [ ] "Restore default" on edited built-in reverts label/prompt/group.
+  - [ ] Delete a custom → gone after restart.
+  - [ ] Hide a built-in → not in pill row, still in management sheet.
+  - [ ] "Reset built-ins" preserves user-created customs.
+  - [ ] Drag-reorder persists across restart.
+  - [ ] Create starter with brand-new group label → group renders in StarterPromptList.
+
+## Acceptance Criteria
+
+- All `LiveAskStarterPrompts` / `LiveAskFollowUpPrompts` references removed from `LiveAskPaneView.swift`; enums live (renamed) on `QuickPrompt` as built-in seeds.
+- `quick_prompts` table seeded with the exact same labels/prompts as today's enums on first launch.
+- "Edit pills…" footer link in sparkle popover opens `AskPromptsSheet`.
+- Built-in edits, custom creations, reorders, visibility toggles, deletes (customs only), and per-section reset all persist via GRDB.
+- 1700+ existing XCTest count holds; new tests bring totals up.
+- No regression in pill-click behavior — `richPrompt` still routed through `TranscriptChatViewModel.sendMessage(richPrompt:)`.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Reconciler accidentally clobbers user edits | INSERT IF NOT EXISTS only; never UPDATE on launch. Tested with idempotency assertion. |
+| Schema drift across versions adding new built-ins | New built-ins added later get inserted on next-launch via reconciler with fresh UUIDs; existing user data untouched. |
+| Group rename leaves orphan group | UI surfaces "ungroup" affordance; renaming a group in one row only renames that row's `groupLabel` (intentional — users can split groups). Stable display order via first-occurrence. |
+| Sheet sprawl in already-busy meeting panel | Sheet is modal, reachable only from sparkle popover footer. No new top-level menu items. |
+| Built-in UUID collision with reserved `1C5A1B4A-…` slot | All new UUIDs hand-rolled in a fresh block; documented in `QuickPrompt.swift` reserved-UUID comment. |
+
+## Open Questions
+
+1. Should the "Edit pills…" footer also appear on the empty-state `StarterPromptList` (not just the sparkle popover)? Currently sparkle isn't visible in the empty state. Likely **yes** — surface a small footer link or a tiny pencil icon next to the column.
+2. Should `restoreBuiltInDefault(id:)` also un-hide the row, or preserve the visibility toggle? Lean toward **preserve visibility** — restoring text shouldn't override an explicit hide.
+3. Should the CLI `export` default include built-ins? Lean toward **no** by default (cleaner customs-only export for sharing); `--include-builtins` opts in.
+
+## Out of Scope
+
+- Sharing prompts across users / cloud sync (export/import via file is the bridge).
+- Variable substitution (`{{transcript}}` etc.) in pill bodies.
+- Per-pill model override (each pill always uses the active LLM provider).
+- Auto-Run for pills (no equivalent concept — pills are user-fired only).
+- Integration with Prompt Library (separate systems by design).
+- Schema version 2 — design only when a real breaking change shows up.


### PR DESCRIPTION
## Summary

- **Replaces hardcoded Ask tab pills with a fully customizable system** — edit, reorder, hide, restore, or create your own starter and follow-up pills from a new "Edit pills…" sheet reachable from the sparkle popover footer (mid-conversation) and the empty-state pane.
- **New `macparakeet-cli quick-prompts` subcommand** — `list / show / add / set / delete / restore-defaults / export / import` under the existing `--json` envelope contract, so agents (OpenClaw / Hermes) and scripts can manage pills headlessly. Includes a versioned JSON file format (`macparakeet.quick_prompts` v1) for `export` / `import` round-trips with merge or replace modes, dry-run, and forged-builtin coercion.

Ships in **app v0.7.0**.

## Architecture: two surfaces, one core

```
                       ┌────────────────────────┐
                       │   quick_prompts        │
                       │   (GRDB, v0.10 mig)    │
                       │                        │
                       │   • 14 built-in seeds  │
                       │   • user customs       │
                       │   • insert-only        │
                       │     reconciler keeps   │
                       │     edits across       │
                       │     launches           │
                       └────────────┬───────────┘
                                    │
                       ┌────────────┴────────────┐                       ▼                         ▼
              ┌────────────────┐        ┌────────────────┐
              │  GUI           │        │  CLI           │
              │  AskPrompts-   │        │  quick-prompts │
              │  Sheet +       │        │  (8 sub-       │
              │  LiveAsk-      │        │  commands,     │
              │  PaneView      │        │  incl. JSON    │
              │                │        │  export/import)│
              └────────────────┘        └────────────────┘
               live meeting              agents, scripts,
               users click pills         CI smoke tests,
                                         portable backups
```

JSON export/import is CLI-only — there's no Import/Export button in the GUI sheet. The wire format is locked under CLI semver from day one so users who do reach for the CLI can git-version their pill sets without churn.

The deliberate divergence from the existing **Prompt Library**: built-in pills here are **editable**. Library prompts are heavyweight curated result templates where locking labels protects quality; pills are micro-shortcuts where personalization is the point. The insert-only reconciler is what makes this safe — it never overwrites a user's edited row, so per-row "Restore default" stays the only update path users have to opt into.

## What's user-visible

In the live meeting Ask tab (`Sparkle ✨ → Edit pills…` or empty-state footer):

```
Ask Prompts                                                 Done

  Starters                                                    ⋯
  ┌─────────────────────────────────────────────────────────────┐
  │ ◉ Summarize so far    [CATCH UP]  [default]            ✎ ↺ │
  │ ◉ What did I miss?    [CATCH UP]  [default]            ✎ ↺ │
  │ ◉ Action items        [CAPTURE]   [default]            ✎ ↺ │
  │ …                                                            │
  │ + Add a starter                                              │
  └─────────────────────────────────────────────────────────────┘

  Follow-ups                                                  ⋯
  ┌─────────────────────────────────────────────────────────────┐
  │ ◉ Tell me more                    [default]            ✎ ↺ │
  │ ◉ Why?                            [default]            ✎ ↺ │
  │ ◉ TL;DR                           [default]            ✎ ↺ │
  │ + Add a follow-up                                            │
  └─────────────────────────────────────────────────────────────┘
```

- Toggle hides without deleting (built-ins can't be deleted, only hidden).
- ✎ opens an inline editor for label, prompt body, and group.
- ↺ restores a built-in's default content but preserves the user's visibility setting.
- Per-section ⋯ menu: "Reset built-ins" (customs untouched) or "Add new …".

## What's developer/agent-visible

```bash
# List, JSON envelope
macparakeet-cli quick-prompts list --json
macparakeet-cli quick-prompts list --kind starter --visible-only

# Add custom + edit
macparakeet-cli quick-prompts add --kind follow-up \
  --label "ELI5" --prompt "Explain like I'm five."
macparakeet-cli quick-prompts set "ELI5" --label "Make it simple"

# Round-trip portable bundle (CLI-only — no GUI counterpart)
macparakeet-cli quick-prompts export --out my-pills.json
macparakeet-cli quick-prompts import my-pills.json --mode merge
macparakeet-cli quick-prompts import shared.json --mode replace --dry-run
```

JSON envelope on failure (e.g. delete a built-in):

```json
{ "ok": false,
  "error": "Cannot delete built-in quick prompt 'Tell me more'. …",
  "errorType": "validation" }
```

## Three commits, bisect-friendly

| | Subject | Lines |
|---|---|---|
| 1 | Add QuickPrompt data layer for customizable Ask tab pills | +1,242 |
| 2 | Add macparakeet-cli quick-prompts subcommand surface | +892 / -1 |
| 3 | Wire QuickPrompt management into live meeting Ask tab | +1,146 / -115 |

Each commit builds and tests on its own (data layer has no consumers; CLI introduces only itself; GUI introduces only itself). Each commit carries the rich `## Root Intent` / `## Prompt That Would Produce This Diff` envelope per `docs/commit-guidelines.md`.

## Test plan

- [ ] `swift test` — full suite passes (currently 2160 / 0 failures / 1 skipped)
- [ ] **Live meeting**: start a recording → switch to Ask tab → starters render in CATCH UP / CAPTURE / CHALLENGE groups
- [ ] **Edit a built-in**: change "Tell me more" label → restart app → edit persists
- [ ] **Restore default**: ↺ on edited built-in → label/prompt revert; visibility toggle preserved
- [ ] **Hide a built-in**: toggle off → no longer in pill row, still in management sheet
- [ ] **Custom starter with new group**: create one labelled "BLOCKERS" → pill row renders the new group
- [ ] **Delete custom**: gone after restart
- [ ] **Built-in delete blocked**: trash icon hidden in UI; CLI returns `errorType: "validation"`
- [ ] **CLI round-trip**: `export --out /tmp/p.json` → fresh DB → `import /tmp/p.json` → all customs back
- [ ] **CLI dry-run replace**: `import x.json --mode replace --dry-run` shows planned `{added, updated, deleted, unchanged}` with no DB writes
- [ ] **Forged builtin defense**: hand-craft a JSON entry with `"isBuiltIn": true` and a fresh UUID → `import` lands it as a custom (`isBuiltIn: false`)

## Notes for reviewers

- **CLI version bumped** 1.4.0 → 1.5.0 (additive minor per `Sources/CLI/CHANGELOG.md` semver policy). New `errorType: "import_schema"` registered for malformed import files; existing values untouched.
- **Migration** is `v0.10-quick-prompts` (next sequence number; `v0.9-derived-title-snippet` is the previous). Empty table on creation; reconciler hydrates the 14 seeds on the first launch after migration.
- **Reserved UUIDs** for the 14 built-ins are documented inline in `QuickPrompt.swift`. None collide with the burned `1C5A1B4A-…` slot from ADR-020's reverted "Memo-Steered Notes" prompt.
- **Plan archived** to `plans/completed/2026-05-ask-quick-prompts.md` with status COMPLETED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)