### PR TITLE
Fix meeting pill timestamp wrap past 99:59

### DIFF
--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPillView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPillView.swift
@@ -190,7 +190,9 @@ struct MeetingRecordingPillView: View {
                     Text(viewModel.formattedElapsed)
                         .font(.system(size: 11, weight: .semibold).monospacedDigit())
                         .foregroundStyle(.white.opacity(0.92))
+                        .lineLimit(1)
                 }
+                .fixedSize(horizontal: true, vertical: false)
                 .padding(.horizontal, 10)
                 .padding(.vertical, 5)
                 .background(


### PR DESCRIPTION
Fixes #200.

Once a meeting recording crossed 99:59, the elapsed-time tooltip on the recording pill wrapped to two lines (e.g. `114:44` rendered as `114:4` / `4`).

The tooltip is an overlay on the small merkaba pill, so SwiftUI proposed the pill's narrow width to the tooltip and the `Text` wrapped to fit. Added `.fixedSize(horizontal: true, vertical: false)` so the tooltip sizes to its ideal width, plus `.lineLimit(1)` as a safeguard.

## Test plan
- [ ] Start a meeting recording and hover the pill — tooltip looks unchanged for short durations.
- [ ] Hover after the timer crosses `100:00` (or seed `elapsedSeconds` in a debug build) — tooltip stays single-line and widens to fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)