### PR TITLE
Drop leading sparkle icons from starter prompt rows

### DIFF
--- a/Sources/MacParakeet/Views/MeetingRecording/LiveAskPaneView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/LiveAskPaneView.swift
@@ -451,12 +451,10 @@ private struct StarterPromptPill: View {
     var body: some View {
         Button(action: action) {
             VStack(alignment: .leading, spacing: 6) {
-                HStack(spacing: 0) {
-                    Text(entry.label)
-                        .font(DesignSystem.Typography.bodySmall)
-                        .foregroundStyle(DesignSystem.Colors.textPrimary)
-                    Spacer(minLength: 0)
-                }
+                Text(entry.label)
+                    .font(DesignSystem.Typography.bodySmall)
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
 
                 if isRevealed {
                     Text(entry.prompt)

--- a/Sources/MacParakeet/Views/MeetingRecording/LiveAskPaneView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/LiveAskPaneView.swift
@@ -451,10 +451,7 @@ private struct StarterPromptPill: View {
     var body: some View {
         Button(action: action) {
             VStack(alignment: .leading, spacing: 6) {
-                HStack(spacing: DesignSystem.Spacing.sm) {
-                    Image(systemName: "sparkles")
-                        .font(.system(size: 11))
-                        .foregroundStyle(DesignSystem.Colors.accent.opacity(0.75))
+                HStack(spacing: 0) {
                     Text(entry.label)
                         .font(DesignSystem.Typography.bodySmall)
                         .foregroundStyle(DesignSystem.Colors.textPrimary)
@@ -467,7 +464,6 @@ private struct StarterPromptPill: View {
                         .foregroundStyle(DesignSystem.Colors.textSecondary)
                         .multilineTextAlignment(.leading)
                         .fixedSize(horizontal: false, vertical: true)
-                        .padding(.leading, 19)
                         .transition(.opacity.combined(with: .move(edge: .top)))
                 }
             }

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -176,7 +176,7 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.isTranscribing)
 
         viewModel.cancelTranscription()
-        try await Task.sleep(for: .milliseconds(100))
+        try await waitUntil { !self.viewModel.isTranscribing }
 
         XCTAssertFalse(viewModel.isTranscribing)
         XCTAssertEqual(viewModel.progress, "")
@@ -564,14 +564,12 @@ final class TranscriptionViewModelTests: XCTestCase {
             try? FileManager.default.removeItem(at: supportedURL)
         }
 
-        let unsupportedProvider = NSItemProvider(contentsOf: unsupportedURL)
-        let supportedProvider = NSItemProvider(contentsOf: supportedURL)
-        XCTAssertNotNil(unsupportedProvider)
-        XCTAssertNotNil(supportedProvider)
+        let unsupportedProvider = try XCTUnwrap(NSItemProvider(contentsOf: unsupportedURL))
+        let supportedProvider = try XCTUnwrap(NSItemProvider(contentsOf: supportedURL))
 
         var accepted = false
         let handled = viewModel.handleFileDrop(
-            providers: [unsupportedProvider!, supportedProvider!],
+            providers: [unsupportedProvider, supportedProvider],
             onAccepted: { accepted = true }
         )
         XCTAssertTrue(handled)


### PR DESCRIPTION
Tiny follow-up to #205 polish: every row of the Ask starter list rendered an identical coral sparkle next to the label, stacking 12+ identical stamps in a vertical column. The polish opportunity wasn't the glyph choice — it was the column-of-stamps pattern.

```
                  Before                              After
    ┌────────────────────────────┐      ┌────────────────────────────┐
    │ CATCH UP                   │      │ CATCH UP                   │
    │  ✨ Summarize so far       │      │    Summarize so far        │
    │  ✨ What did I miss?       │      │    What did I miss?        │
    │ CAPTURE                    │      │ CAPTURE                    │
    │  ✨ Decisions made         │      │    Decisions made          │
    │  ✨ Action items           │      │    Action items            │
    │  ✨ Who owns what?         │      │    Who owns what?          │
    │ CHALLENGE                  │      │ CHALLENGE                  │
    │  ✨ What's unresolved?     │      │    What's unresolved?      │
    │  ✨ …                      │      │    …                       │
    └────────────────────────────┘      └────────────────────────────┘
```

Group headers and the follow-up tail do the structural work; labels carry each row; hover-reveal of the prompt body becomes the primary affordance. Closer to Linear / Raycast cadence.

## What stays

- The composer's `PromptMenuButton` ✨ — semantic anchor users click to open the menu, the universal "AI prompts here" affordance across the industry.
- The hero ✨ in the no-provider empty state — single decorative anchor, not a row repetition.
- "Edit prompts…" link's `slider.horizontal.3` — different glyph, different affordance.
- `FollowUpPill` (the persistent above-input row) was already icon-free.

## Single source of truth

`StarterPromptPill` is the same component used by both the empty-Ask state and the mid-conversation `✨` popover, so one edit covers both render surfaces.

## Test plan

- [ ] `swift test` green
- [ ] Smoke: open Ask tab empty state — no leading ✨ on prompt rows; group headers + labels intact
- [ ] Smoke: open ✨ menu mid-conversation — same calm row treatment, hover-reveal works
- [ ] Smoke: composer `PromptMenuButton` ✨ still present and functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined spacing around prompt icons and adjusted indentation of revealed prompt text for improved visual alignment and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->