### PR TITLE
Restrained brand + Apple-grade polish

### DIFF
--- a/Sources/MacParakeet/App/AppWindowCoordinator.swift
+++ b/Sources/MacParakeet/App/AppWindowCoordinator.swift
@@ -194,7 +194,7 @@ final class AppWindowCoordinator: NSObject, NSWindowDelegate {
             height: DesignSystem.Layout.windowMinHeight
         )
         window.titlebarAppearsTransparent = true
-        window.contentView = NSHostingView(rootView: contentView.tint(DesignSystem.Colors.accent))
+        window.contentView = NSHostingView(rootView: contentView)
         window.delegate = self
         window.isReleasedWhenClosed = false
 

--- a/Sources/MacParakeet/Onboarding/OnboardingWindowController.swift
+++ b/Sources/MacParakeet/Onboarding/OnboardingWindowController.swift
@@ -44,7 +44,7 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
             onOpenSettings: onOpenSettings
         )
 
-        let hosting = NSHostingView(rootView: view.tint(DesignSystem.Colors.accent))
+        let hosting = NSHostingView(rootView: view)
         let w = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 740, height: 500),
                          styleMask: [.titled, .closable, .miniaturizable],
                          backing: .buffered,

--- a/Sources/MacParakeet/Views/Components/DesignSystem.swift
+++ b/Sources/MacParakeet/Views/Components/DesignSystem.swift
@@ -30,6 +30,11 @@ enum DesignSystem {
         static let textTertiary = Color(light: .init(red: 0.61, green: 0.61, blue: 0.61),
                                         dark: .init(red: 0.39, green: 0.39, blue: 0.40))
 
+        /// Neutral label tint — for `.bordered` buttons that should NOT carry
+        /// brand color. Resolves to the system label color (white in dark mode,
+        /// near-black in light). Used via `.parakeetAction(.secondary)`.
+        static let tintNeutral = Color.primary
+
         // Semantic
         static let successGreen = Color(light: .init(red: 0.20, green: 0.66, blue: 0.33),
                                         dark: .init(red: 0.29, green: 0.87, blue: 0.50))

--- a/Sources/MacParakeet/Views/Components/DesignSystem.swift
+++ b/Sources/MacParakeet/Views/Components/DesignSystem.swift
@@ -147,12 +147,6 @@ enum DesignSystem {
         /// naturally beside the 26pt Merkaba glyph inside a low-profile horizontal
         /// oval pill.
         static let dictationOverlayTerminalLabel = Font.system(size: 9.5, weight: .medium, design: .rounded)
-
-        // Legacy aliases (kept for existing references)
-        static let headline = Font.system(size: 17, weight: .semibold, design: .rounded)
-        static let title = Font.system(size: 22, weight: .semibold, design: .rounded)
-        static let largeTitle = Font.system(size: 28, weight: .bold, design: .rounded)
-        static let sectionHeader = Font.system(size: 13, weight: .semibold)
     }
 
     // MARK: - Layout

--- a/Sources/MacParakeet/Views/Components/DesignSystemGalleryView.swift
+++ b/Sources/MacParakeet/Views/Components/DesignSystemGalleryView.swift
@@ -1,0 +1,295 @@
+#if DEBUG
+import SwiftUI
+
+/// One-stop drift catcher for the MacParakeet design system. Renders every
+/// button role, typography token, color, shadow, and spacing scale in a
+/// single scrollable canvas so a 30-second visual sweep surfaces any token
+/// that fell out of sync with the rest of the app.
+///
+/// Open with the SwiftUI canvas in Xcode (the `#Preview` at the bottom)
+/// or instantiate directly inside a debug-only window.
+///
+/// Light/dark are exercised side-by-side via the canvas environment in
+/// the preview block.
+struct DesignSystemGalleryView: View {
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.xxl) {
+                section("Buttons") { buttonRoles }
+                section("Typography") { typographyScale }
+                section("Colors") { colorSwatches }
+                section("Shadows") { shadowSamples }
+                section("Spacing") { spacingRulers }
+                section("Layout radii") { radiiSamples }
+            }
+            .padding(DesignSystem.Spacing.xl)
+        }
+        .frame(minWidth: 760, minHeight: 800)
+        .background(.thickMaterial)
+    }
+
+    // MARK: - Buttons
+
+    @ViewBuilder
+    private var buttonRoles: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+            roleRow(label: "primary",          prominent: false, role: .primary)
+            roleRow(label: "primary prominent", prominent: true,  role: .primary)
+            roleRow(label: "secondary",        prominent: false, role: .secondary)
+            roleRow(label: "destructive",      prominent: false, role: .destructive)
+            roleRow(label: "destructive prominent", prominent: true, role: .destructive)
+            roleRow(label: "subtle",           prominent: false, role: .subtle)
+        }
+    }
+
+    private func roleRow(label: String, prominent: Bool, role: ParakeetActionRole) -> some View {
+        HStack(spacing: DesignSystem.Spacing.lg) {
+            Text(label)
+                .font(DesignSystem.Typography.caption.monospaced())
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+                .frame(width: 200, alignment: .leading)
+            Button("Action") { }
+                .parakeetAction(role, prominent: prominent)
+            Button("Disabled") { }
+                .parakeetAction(role, prominent: prominent)
+                .disabled(true)
+            Spacer()
+        }
+    }
+
+    // MARK: - Typography
+
+    @ViewBuilder
+    private var typographyScale: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+            typeRow("heroTitle",      DesignSystem.Typography.heroTitle,      "28 / bold rounded")
+            typeRow("pageTitle",      DesignSystem.Typography.pageTitle,      "22 / semibold rounded")
+            typeRow("sectionTitle",   DesignSystem.Typography.sectionTitle,   "17 / semibold")
+            typeRow("bodyLarge",      DesignSystem.Typography.bodyLarge,      "15")
+            typeRow("body",           DesignSystem.Typography.body,           "14")
+            typeRow("bodySmall",      DesignSystem.Typography.bodySmall,      "13")
+            typeRow("caption",        DesignSystem.Typography.caption,        "12")
+            typeRow("micro",          DesignSystem.Typography.micro,          "11")
+            typeRow("timestamp",      DesignSystem.Typography.timestamp,      "12 monodigit · 12:34")
+            typeRow("duration",       DesignSystem.Typography.duration,       "11 monodigit · 04:21")
+        }
+    }
+
+    private func typeRow(_ name: String, _ font: Font, _ note: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: DesignSystem.Spacing.lg) {
+            Text(name)
+                .font(DesignSystem.Typography.caption.monospaced())
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+                .frame(width: 140, alignment: .leading)
+            Text("The quick brown fox jumps")
+                .font(font)
+                .foregroundStyle(DesignSystem.Colors.textPrimary)
+            Spacer()
+            Text(note)
+                .font(DesignSystem.Typography.micro)
+                .foregroundStyle(DesignSystem.Colors.textTertiary)
+        }
+    }
+
+    // MARK: - Colors
+
+    @ViewBuilder
+    private var colorSwatches: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+            colorGroup(
+                title: "Brand",
+                items: [
+                    ("accent",      DesignSystem.Colors.accent),
+                    ("accentLight", DesignSystem.Colors.accentLight),
+                    ("accentDark",  DesignSystem.Colors.accentDark),
+                ]
+            )
+            colorGroup(
+                title: "Surfaces",
+                items: [
+                    ("background",       DesignSystem.Colors.background),
+                    ("surface",          DesignSystem.Colors.surface),
+                    ("surfaceElevated",  DesignSystem.Colors.surfaceElevated),
+                    ("cardBackground",   DesignSystem.Colors.cardBackground),
+                    ("rowHoverBackground", DesignSystem.Colors.rowHoverBackground),
+                ]
+            )
+            colorGroup(
+                title: "Text",
+                items: [
+                    ("textPrimary",   DesignSystem.Colors.textPrimary),
+                    ("textSecondary", DesignSystem.Colors.textSecondary),
+                    ("textTertiary",  DesignSystem.Colors.textTertiary),
+                    ("tintNeutral",   DesignSystem.Colors.tintNeutral),
+                ]
+            )
+            colorGroup(
+                title: "Semantic",
+                items: [
+                    ("successGreen", DesignSystem.Colors.successGreen),
+                    ("warningAmber", DesignSystem.Colors.warningAmber),
+                    ("errorRed",     DesignSystem.Colors.errorRed),
+                ]
+            )
+            colorGroup(
+                title: "Lines",
+                items: [
+                    ("border",  DesignSystem.Colors.border),
+                    ("divider", DesignSystem.Colors.divider),
+                ]
+            )
+            colorGroup(
+                title: "Speakers",
+                items: DesignSystem.Colors.speakerColors.enumerated().map { idx, color in
+                    ("speaker[\(idx)]", color)
+                }
+            )
+        }
+    }
+
+    private func colorGroup(title: String, items: [(String, Color)]) -> some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            Text(title.uppercased())
+                .font(DesignSystem.Typography.micro.weight(.semibold))
+                .tracking(0.8)
+                .foregroundStyle(DesignSystem.Colors.textTertiary)
+            LazyVGrid(
+                columns: [GridItem(.adaptive(minimum: 140), spacing: DesignSystem.Spacing.sm)],
+                alignment: .leading,
+                spacing: DesignSystem.Spacing.sm
+            ) {
+                ForEach(items, id: \.0) { name, color in
+                    swatch(name: name, color: color)
+                }
+            }
+        }
+    }
+
+    private func swatch(name: String, color: Color) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            RoundedRectangle(cornerRadius: 6)
+                .fill(color)
+                .frame(height: 36)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(DesignSystem.Colors.border.opacity(0.6), lineWidth: 0.5)
+                )
+            Text(name)
+                .font(DesignSystem.Typography.micro.monospaced())
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+                .lineLimit(1)
+        }
+    }
+
+    // MARK: - Shadows
+
+    @ViewBuilder
+    private var shadowSamples: some View {
+        HStack(spacing: DesignSystem.Spacing.lg) {
+            shadowCard(label: "cardRest",    style: DesignSystem.Shadows.cardRest)
+            shadowCard(label: "cardHover",   style: DesignSystem.Shadows.cardHover)
+            shadowCard(label: "portalLift",  style: DesignSystem.Shadows.portalLift)
+            shadowCard(label: "meetingPill", style: DesignSystem.Shadows.meetingPill)
+        }
+    }
+
+    private func shadowCard(label: String, style: ShadowStyle) -> some View {
+        VStack(spacing: DesignSystem.Spacing.sm) {
+            RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
+                .fill(DesignSystem.Colors.cardBackground)
+                .frame(width: 140, height: 80)
+                .cardShadow(style)
+            Text(label)
+                .font(DesignSystem.Typography.micro.monospaced())
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+        }
+    }
+
+    // MARK: - Spacing
+
+    @ViewBuilder
+    private var spacingRulers: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            spacingRow("xs",  DesignSystem.Spacing.xs)
+            spacingRow("sm",  DesignSystem.Spacing.sm)
+            spacingRow("md",  DesignSystem.Spacing.md)
+            spacingRow("lg",  DesignSystem.Spacing.lg)
+            spacingRow("xl",  DesignSystem.Spacing.xl)
+            spacingRow("xxl", DesignSystem.Spacing.xxl)
+            spacingRow("hero", DesignSystem.Spacing.hero)
+        }
+    }
+
+    private func spacingRow(_ name: String, _ value: CGFloat) -> some View {
+        HStack(spacing: DesignSystem.Spacing.lg) {
+            Text(name)
+                .font(DesignSystem.Typography.caption.monospaced())
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+                .frame(width: 60, alignment: .leading)
+            Rectangle()
+                .fill(DesignSystem.Colors.accent)
+                .frame(width: value, height: 12)
+            Text("\(Int(value))pt")
+                .font(DesignSystem.Typography.micro.monospaced())
+                .foregroundStyle(DesignSystem.Colors.textTertiary)
+            Spacer()
+        }
+    }
+
+    // MARK: - Layout radii
+
+    @ViewBuilder
+    private var radiiSamples: some View {
+        HStack(spacing: DesignSystem.Spacing.lg) {
+            radiusCard("cornerRadius",     DesignSystem.Layout.cornerRadius)
+            radiusCard("cardCornerRadius", DesignSystem.Layout.cardCornerRadius)
+            radiusCard("rowCornerRadius",  DesignSystem.Layout.rowCornerRadius)
+            radiusCard("buttonCorner",     DesignSystem.Layout.buttonCornerRadius)
+        }
+    }
+
+    private func radiusCard(_ name: String, _ radius: CGFloat) -> some View {
+        VStack(spacing: DesignSystem.Spacing.sm) {
+            RoundedRectangle(cornerRadius: radius)
+                .fill(DesignSystem.Colors.surfaceElevated)
+                .frame(width: 100, height: 60)
+                .overlay(
+                    RoundedRectangle(cornerRadius: radius)
+                        .strokeBorder(DesignSystem.Colors.border, lineWidth: 0.5)
+                )
+            VStack(spacing: 0) {
+                Text(name)
+                    .font(DesignSystem.Typography.micro.monospaced())
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+                Text("\(Int(radius))pt")
+                    .font(DesignSystem.Typography.micro)
+                    .foregroundStyle(DesignSystem.Colors.textTertiary)
+            }
+        }
+    }
+
+    // MARK: - Section frame
+
+    private func section<Content: View>(
+        _ title: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+            Text(title)
+                .font(DesignSystem.Typography.sectionTitle)
+                .foregroundStyle(DesignSystem.Colors.textPrimary)
+            content()
+        }
+    }
+}
+
+#Preview("DesignSystem · Dark") {
+    DesignSystemGalleryView()
+        .preferredColorScheme(.dark)
+}
+
+#Preview("DesignSystem · Light") {
+    DesignSystemGalleryView()
+        .preferredColorScheme(.light)
+}
+#endif

--- a/Sources/MacParakeet/Views/Components/DesignSystemGalleryView.swift
+++ b/Sources/MacParakeet/Views/Components/DesignSystemGalleryView.swift
@@ -33,25 +33,25 @@ struct DesignSystemGalleryView: View {
     @ViewBuilder
     private var buttonRoles: some View {
         VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
-            roleRow(label: "primary",          prominent: false, role: .primary)
-            roleRow(label: "primary prominent", prominent: true,  role: .primary)
-            roleRow(label: "secondary",        prominent: false, role: .secondary)
-            roleRow(label: "destructive",      prominent: false, role: .destructive)
-            roleRow(label: "destructive prominent", prominent: true, role: .destructive)
-            roleRow(label: "subtle",           prominent: false, role: .subtle)
+            roleRow(label: "primary", role: .primary)
+            roleRow(label: "primary prominent", role: .primaryProminent)
+            roleRow(label: "secondary", role: .secondary)
+            roleRow(label: "destructive", role: .destructive)
+            roleRow(label: "destructive prominent", role: .destructiveProminent)
+            roleRow(label: "subtle", role: .subtle)
         }
     }
 
-    private func roleRow(label: String, prominent: Bool, role: ParakeetActionRole) -> some View {
+    private func roleRow(label: String, role: ParakeetActionRole) -> some View {
         HStack(spacing: DesignSystem.Spacing.lg) {
             Text(label)
                 .font(DesignSystem.Typography.caption.monospaced())
                 .foregroundStyle(DesignSystem.Colors.textSecondary)
                 .frame(width: 200, alignment: .leading)
             Button("Action") { }
-                .parakeetAction(role, prominent: prominent)
+                .parakeetAction(role)
             Button("Disabled") { }
-                .parakeetAction(role, prominent: prominent)
+                .parakeetAction(role)
                 .disabled(true)
             Spacer()
         }

--- a/Sources/MacParakeet/Views/Components/MarkdownContentView.swift
+++ b/Sources/MacParakeet/Views/Components/MarkdownContentView.swift
@@ -79,27 +79,13 @@ struct MarkdownContentView: NSViewRepresentable {
     private func buildAttributedString(blocks: [MarkdownBlock]) -> NSAttributedString {
         let result = NSMutableAttributedString()
 
-        // Use dynamic NSColors that auto-adapt to light/dark mode.
-        // NSApp.effectiveAppearance is unreliable when the view isn't in the hierarchy yet.
-        let textColor = NSColor(name: nil) { appearance in
-            let dark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-            return dark ? .white : NSColor(red: 0.10, green: 0.10, blue: 0.10, alpha: 1)
-        }
-        let secondaryColor = NSColor(name: nil) { appearance in
-            let dark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-            return dark ? NSColor(red: 0.63, green: 0.63, blue: 0.65, alpha: 1)
-                        : NSColor(red: 0.42, green: 0.42, blue: 0.42, alpha: 1)
-        }
-        let tertiaryColor = NSColor(name: nil) { appearance in
-            let dark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-            return dark ? NSColor(red: 0.39, green: 0.39, blue: 0.40, alpha: 1)
-                        : NSColor(red: 0.61, green: 0.61, blue: 0.61, alpha: 1)
-        }
-        let accentColor = NSColor(name: nil) { appearance in
-            let dark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-            return dark ? NSColor(red: 1.0, green: 0.54, blue: 0.36, alpha: 1)
-                        : NSColor(red: 0.91, green: 0.42, blue: 0.23, alpha: 1)
-        }
+        // Bridge SwiftUI design tokens into appearance-aware NSColors. The
+        // `NSColor(_ swiftuiColor:)` initializer preserves the dynamic light/dark
+        // resolution of `Color(light:dark:)`.
+        let textColor = NSColor(DesignSystem.Colors.textPrimary)
+        let secondaryColor = NSColor(DesignSystem.Colors.textSecondary)
+        let tertiaryColor = NSColor(DesignSystem.Colors.textTertiary)
+        let accentColor = NSColor(DesignSystem.Colors.accent)
 
         let bodyFont = NSFont.systemFont(ofSize: baseFontSize)
         let bodyParagraphStyle = NSMutableParagraphStyle()
@@ -201,11 +187,7 @@ struct MarkdownContentView: NSViewRepresentable {
                     .font: codeFont,
                     .foregroundColor: textColor,
                     .paragraphStyle: codeStyle,
-                    .backgroundColor: NSColor(name: nil) { appearance in
-                        let dark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-                        return dark ? NSColor(red: 0.23, green: 0.23, blue: 0.24, alpha: 0.7)
-                                    : NSColor(red: 0.96, green: 0.96, blue: 0.94, alpha: 0.7)
-                    }
+                    .backgroundColor: NSColor(DesignSystem.Colors.surfaceElevated.opacity(0.7))
                 ])
                 result.append(codeStr)
                 result.append(NSAttributedString(string: "\n"))

--- a/Sources/MacParakeet/Views/Components/MarkdownContentView.swift
+++ b/Sources/MacParakeet/Views/Components/MarkdownContentView.swift
@@ -183,11 +183,23 @@ struct MarkdownContentView: NSViewRepresentable {
                 codeStyle.lineSpacing = 2
                 codeStyle.paragraphSpacing = 10
 
+                // Apply the alpha inside a dynamic NSColor provider so the result
+                // re-resolves on light/dark flip. We resolve `surfaceElevated` under
+                // the supplied appearance, then attach the alpha — this keeps the
+                // single source of truth (`DesignSystem.Colors.surfaceElevated`)
+                // without snapping to the appearance that was current at first draw.
+                let codeBackground = NSColor(name: nil) { appearance in
+                    var resolved = NSColor.clear
+                    appearance.performAsCurrentDrawingAppearance {
+                        resolved = NSColor(DesignSystem.Colors.surfaceElevated)
+                    }
+                    return resolved.withAlphaComponent(0.7)
+                }
                 let codeStr = NSMutableAttributedString(string: code, attributes: [
                     .font: codeFont,
                     .foregroundColor: textColor,
                     .paragraphStyle: codeStyle,
-                    .backgroundColor: NSColor(DesignSystem.Colors.surfaceElevated.opacity(0.7))
+                    .backgroundColor: codeBackground
                 ])
                 result.append(codeStr)
                 result.append(NSAttributedString(string: "\n"))

--- a/Sources/MacParakeet/Views/Components/ParakeetActionStyle.swift
+++ b/Sources/MacParakeet/Views/Components/ParakeetActionStyle.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+/// Semantic role for an actionable control. Apply via `.parakeetAction(_:)`.
+///
+/// Replaces ad-hoc `.buttonStyle(.bordered) + .tint(...)` composition with a
+/// single intent-carrying modifier. The role drives visual treatment so
+/// callsites carry meaning, not styling primitives.
+enum ParakeetActionRole {
+    /// The single primary CTA on a surface. Brand coral.
+    case primary
+    /// Default action weight. System label color, neutral chrome.
+    case secondary
+    /// Irreversible action. System destructive red.
+    /// Pair with `Button(role: .destructive)` to also carry VoiceOver semantics.
+    case destructive
+    /// Lower visual weight than `.secondary`. Borderless, secondary label
+    /// color. For non-essential actions in dense rows or as inline links.
+    case subtle
+}
+
+extension View {
+    /// Apply a semantic action role to a control.
+    ///
+    /// - Parameters:
+    ///   - role: The action's intent.
+    ///   - prominent: If true, use `.borderedProminent`. Reserve for the
+    ///     single highest-priority action on a sheet or modal. Default false.
+    @ViewBuilder
+    func parakeetAction(_ role: ParakeetActionRole, prominent: Bool = false) -> some View {
+        switch role {
+        case .primary:
+            if prominent {
+                self.buttonStyle(.borderedProminent)
+                    .tint(DesignSystem.Colors.accent)
+            } else {
+                self.buttonStyle(.bordered)
+                    .tint(DesignSystem.Colors.accent)
+            }
+        case .secondary:
+            self.buttonStyle(.bordered)
+                .tint(DesignSystem.Colors.tintNeutral)
+        case .destructive:
+            if prominent {
+                self.buttonStyle(.borderedProminent)
+                    .tint(DesignSystem.Colors.errorRed)
+            } else {
+                self.buttonStyle(.bordered)
+                    .tint(DesignSystem.Colors.errorRed)
+            }
+        case .subtle:
+            self.buttonStyle(.borderless)
+                .foregroundStyle(.secondary)
+        }
+    }
+}

--- a/Sources/MacParakeet/Views/Components/ParakeetActionStyle.swift
+++ b/Sources/MacParakeet/Views/Components/ParakeetActionStyle.swift
@@ -6,13 +6,18 @@ import SwiftUI
 /// single intent-carrying modifier. The role drives visual treatment so
 /// callsites carry meaning, not styling primitives.
 enum ParakeetActionRole {
-    /// The single primary CTA on a surface. Brand coral.
+    /// Primary action. Brand coral.
     case primary
+    /// The single highest-priority primary CTA on a surface. Brand coral.
+    case primaryProminent
     /// Default action weight. System label color, neutral chrome.
     case secondary
     /// Irreversible action. System destructive red.
     /// Pair with `Button(role: .destructive)` to also carry VoiceOver semantics.
     case destructive
+    /// Highest-priority irreversible action. System destructive red.
+    /// Pair with `Button(role: .destructive)` to also carry VoiceOver semantics.
+    case destructiveProminent
     /// Lower visual weight than `.secondary`. Borderless, secondary label
     /// color. For non-essential actions in dense rows or as inline links.
     case subtle
@@ -20,33 +25,24 @@ enum ParakeetActionRole {
 
 extension View {
     /// Apply a semantic action role to a control.
-    ///
-    /// - Parameters:
-    ///   - role: The action's intent.
-    ///   - prominent: If true, use `.borderedProminent`. Reserve for the
-    ///     single highest-priority action on a sheet or modal. Default false.
     @ViewBuilder
-    func parakeetAction(_ role: ParakeetActionRole, prominent: Bool = false) -> some View {
+    func parakeetAction(_ role: ParakeetActionRole) -> some View {
         switch role {
         case .primary:
-            if prominent {
-                self.buttonStyle(.borderedProminent)
-                    .tint(DesignSystem.Colors.accent)
-            } else {
-                self.buttonStyle(.bordered)
-                    .tint(DesignSystem.Colors.accent)
-            }
+            self.buttonStyle(.bordered)
+                .tint(DesignSystem.Colors.accent)
+        case .primaryProminent:
+            self.buttonStyle(.borderedProminent)
+                .tint(DesignSystem.Colors.accent)
         case .secondary:
             self.buttonStyle(.bordered)
                 .tint(DesignSystem.Colors.tintNeutral)
         case .destructive:
-            if prominent {
-                self.buttonStyle(.borderedProminent)
-                    .tint(DesignSystem.Colors.errorRed)
-            } else {
-                self.buttonStyle(.bordered)
-                    .tint(DesignSystem.Colors.errorRed)
-            }
+            self.buttonStyle(.bordered)
+                .tint(DesignSystem.Colors.errorRed)
+        case .destructiveProminent:
+            self.buttonStyle(.borderedProminent)
+                .tint(DesignSystem.Colors.errorRed)
         case .subtle:
             self.buttonStyle(.borderless)
                 .foregroundStyle(.secondary)

--- a/Sources/MacParakeet/Views/Feedback/FeedbackView.swift
+++ b/Sources/MacParakeet/Views/Feedback/FeedbackView.swift
@@ -237,14 +237,13 @@ struct FeedbackView: View {
                 Button("Cancel") {
                     viewModel.resetForm()
                 }
-                .buttonStyle(.bordered)
+                .parakeetAction(.secondary)
                 .keyboardShortcut(.cancelAction)
 
                 Button(viewModel.submissionState == .submitting ? "Sending..." : "Send Feedback") {
                     viewModel.submit()
                 }
-                .buttonStyle(.borderedProminent)
-                .tint(DesignSystem.Colors.accent)
+                .parakeetAction(.primary, prominent: true)
                 .disabled(!viewModel.canSubmit)
                 .keyboardShortcut(.defaultAction)
             }
@@ -359,7 +358,7 @@ struct FeedbackView: View {
                         .font(DesignSystem.Typography.body)
                 }
             }
-            .buttonStyle(.bordered)
+            .parakeetAction(.secondary)
         }
     }
 

--- a/Sources/MacParakeet/Views/Feedback/FeedbackView.swift
+++ b/Sources/MacParakeet/Views/Feedback/FeedbackView.swift
@@ -243,7 +243,7 @@ struct FeedbackView: View {
                 Button(viewModel.submissionState == .submitting ? "Sending..." : "Send Feedback") {
                     viewModel.submit()
                 }
-                .parakeetAction(.primary, prominent: true)
+                .parakeetAction(.primaryProminent)
                 .disabled(!viewModel.canSubmit)
                 .keyboardShortcut(.defaultAction)
             }

--- a/Sources/MacParakeet/Views/History/DictationHistoryView.swift
+++ b/Sources/MacParakeet/Views/History/DictationHistoryView.swift
@@ -524,12 +524,7 @@ struct DictationCardRow: View {
 
         let nsText = text as NSString
         var searchRange = NSRange(location: 0, length: nsText.length)
-        let highlightColor = NSColor(name: nil) { appearance in
-            let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-            return isDark
-                ? NSColor(red: 1.0, green: 0.54, blue: 0.36, alpha: 0.2)
-                : NSColor(red: 0.91, green: 0.42, blue: 0.23, alpha: 0.2)
-        }
+        let highlightColor = NSColor(DesignSystem.Colors.accent.opacity(0.2))
 
         while searchRange.length > 0 {
             let found = nsText.range(of: query, options: .caseInsensitive, range: searchRange)

--- a/Sources/MacParakeet/Views/History/DictationHistoryView.swift
+++ b/Sources/MacParakeet/Views/History/DictationHistoryView.swift
@@ -281,7 +281,7 @@ struct DictationHistoryView: View {
                 ForEach(viewModel.groupedDictations, id: \.0) { dateHeader, dictations in
                     HStack(alignment: .firstTextBaseline, spacing: DesignSystem.Spacing.sm) {
                         Text(dateHeader.uppercased())
-                            .font(DesignSystem.Typography.sectionHeader)
+                            .font(DesignSystem.Typography.bodySmall.weight(.semibold))
                             .foregroundStyle(DesignSystem.Colors.accent.opacity(0.8))
                         Text("\(dictations.count)")
                             .font(DesignSystem.Typography.duration)

--- a/Sources/MacParakeet/Views/History/DictationHistoryView.swift
+++ b/Sources/MacParakeet/Views/History/DictationHistoryView.swift
@@ -524,7 +524,18 @@ struct DictationCardRow: View {
 
         let nsText = text as NSString
         var searchRange = NSRange(location: 0, length: nsText.length)
-        let highlightColor = NSColor(DesignSystem.Colors.accent.opacity(0.2))
+        // Apply the alpha inside a dynamic provider so the highlight re-resolves
+        // on light/dark flip. Resolves `accent` under the supplied appearance,
+        // then attaches alpha — keeps `DesignSystem.Colors.accent` as the single
+        // source of truth without snapping to whatever appearance was current
+        // when the attributed string was built.
+        let highlightColor = NSColor(name: nil) { appearance in
+            var resolved = NSColor.clear
+            appearance.performAsCurrentDrawingAppearance {
+                resolved = NSColor(DesignSystem.Colors.accent)
+            }
+            return resolved.withAlphaComponent(0.2)
+        }
 
         while searchRange.length > 0 {
             let found = nsText.range(of: query, options: .caseInsensitive, range: searchRange)

--- a/Sources/MacParakeet/Views/MainWindowView.swift
+++ b/Sources/MacParakeet/Views/MainWindowView.swift
@@ -84,7 +84,6 @@ struct MainWindowView: View {
                     }
                 }
                 .listStyle(.sidebar)
-                .tint(DesignSystem.Colors.accent)
                 .safeAreaInset(edge: .bottom, spacing: 0) {
                     DiscoverSidebarCard(
                         viewModel: discoverViewModel,

--- a/Sources/MacParakeet/Views/MeetingRecording/AskPromptsSheet.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/AskPromptsSheet.swift
@@ -130,12 +130,6 @@ struct AskPromptsSheet: View {
                 CreatePromptSheet(viewModel: viewModel)
             }
         }
-        // Cascade our brand accent into every `.borderedProminent` /
-        // `.tint`-aware native control inside this sheet (Done, plus the Save
-        // and Add inside child edit / create sheets, which inherit the
-        // environment). System blue would otherwise leak through against the
-        // coral brand.
-        .tint(DesignSystem.Colors.accent)
     }
 
     // MARK: - Header
@@ -531,7 +525,6 @@ private struct EditPromptSheet: View {
         }
         .frame(minWidth: 560, minHeight: 480)
         .background(DesignSystem.Colors.background)
-        .tint(DesignSystem.Colors.accent)
         .alert("Discard changes?", isPresented: $showingDiscardConfirm) {
             Button("Discard", role: .destructive) {
                 onCancel()
@@ -705,7 +698,6 @@ private struct CreatePromptSheet: View {
         }
         .frame(minWidth: 560, minHeight: 480)
         .background(DesignSystem.Colors.background)
-        .tint(DesignSystem.Colors.accent)
         .alert("Discard new prompt?", isPresented: $showingDiscardConfirm) {
             Button("Discard", role: .destructive) {
                 viewModel.cancelCreating()

--- a/Sources/MacParakeet/Views/MeetingRecording/AskPromptsSheet.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/AskPromptsSheet.swift
@@ -174,7 +174,7 @@ struct AskPromptsSheet: View {
                     .font(DesignSystem.Typography.body.weight(.semibold))
                     .padding(.horizontal, DesignSystem.Spacing.sm)
             }
-            .buttonStyle(.borderedProminent)
+            .parakeetAction(.primary, prominent: true)
             .controlSize(.large)
             // Esc dismisses (Apple HIG default for sheets). `.cancelAction`
             // is Esc + Cmd-. on macOS — both reach the close intent.
@@ -507,9 +507,10 @@ private struct EditPromptSheet: View {
                 }
                 Spacer()
                 Button("Cancel") { attemptCancel() }
+                    .parakeetAction(.secondary)
                     .keyboardShortcut(.cancelAction)
                 Button("Save") { commit() }
-                    .buttonStyle(.borderedProminent)
+                    .parakeetAction(.primary, prominent: true)
                     .keyboardShortcut(.defaultAction)
             }
             .padding(DesignSystem.Spacing.lg)
@@ -661,13 +662,14 @@ private struct CreatePromptSheet: View {
                     .foregroundStyle(DesignSystem.Colors.textPrimary)
                 Spacer()
                 Button("Cancel") { attemptCancel() }
+                    .parakeetAction(.secondary)
                     .keyboardShortcut(.cancelAction)
                 Button("Add") {
                     if viewModel.commitCreating() {
                         dismiss()
                     }
                 }
-                .buttonStyle(.borderedProminent)
+                .parakeetAction(.primary, prominent: true)
                 .keyboardShortcut(.defaultAction)
             }
             .padding(DesignSystem.Spacing.lg)

--- a/Sources/MacParakeet/Views/MeetingRecording/AskPromptsSheet.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/AskPromptsSheet.swift
@@ -168,7 +168,7 @@ struct AskPromptsSheet: View {
                     .font(DesignSystem.Typography.body.weight(.semibold))
                     .padding(.horizontal, DesignSystem.Spacing.sm)
             }
-            .parakeetAction(.primary, prominent: true)
+            .parakeetAction(.primaryProminent)
             .controlSize(.large)
             // Esc dismisses (Apple HIG default for sheets). `.cancelAction`
             // is Esc + Cmd-. on macOS — both reach the close intent.
@@ -504,7 +504,7 @@ private struct EditPromptSheet: View {
                     .parakeetAction(.secondary)
                     .keyboardShortcut(.cancelAction)
                 Button("Save") { commit() }
-                    .parakeetAction(.primary, prominent: true)
+                    .parakeetAction(.primaryProminent)
                     .keyboardShortcut(.defaultAction)
             }
             .padding(DesignSystem.Spacing.lg)
@@ -662,7 +662,7 @@ private struct CreatePromptSheet: View {
                         dismiss()
                     }
                 }
-                .parakeetAction(.primary, prominent: true)
+                .parakeetAction(.primaryProminent)
                 .keyboardShortcut(.defaultAction)
             }
             .padding(DesignSystem.Spacing.lg)

--- a/Sources/MacParakeet/Views/MeetingRecording/AskPromptsSheet.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/AskPromptsSheet.swift
@@ -68,7 +68,7 @@ struct AskPromptsSheet: View {
                 .padding(DesignSystem.Spacing.xl)
             }
         }
-        .background(DesignSystem.Colors.background)
+        .background(.thickMaterial)
         .frame(minWidth: 720, minHeight: 640)
         .alert(
             "Delete prompt?",
@@ -524,7 +524,7 @@ private struct EditPromptSheet: View {
             }
         }
         .frame(minWidth: 560, minHeight: 480)
-        .background(DesignSystem.Colors.background)
+        .background(.thickMaterial)
         .alert("Discard changes?", isPresented: $showingDiscardConfirm) {
             Button("Discard", role: .destructive) {
                 onCancel()
@@ -697,7 +697,7 @@ private struct CreatePromptSheet: View {
             }
         }
         .frame(minWidth: 560, minHeight: 480)
-        .background(DesignSystem.Colors.background)
+        .background(.thickMaterial)
         .alert("Discard new prompt?", isPresented: $showingDiscardConfirm) {
             Button("Discard", role: .destructive) {
                 viewModel.cancelCreating()

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingCountdownToastController.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingCountdownToastController.swift
@@ -120,7 +120,7 @@ final class MeetingCountdownToastController {
                 : { [weak self] in self?.finish(.primedEarly) }
         )
 
-        let hosting = NSHostingView(rootView: view.tint(DesignSystem.Colors.accent))
+        let hosting = NSHostingView(rootView: view)
         hosting.frame = NSRect(x: 0, y: 0, width: 280, height: 130)
 
         let panel = CountdownPanel(

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingCountdownToastView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingCountdownToastView.swift
@@ -72,7 +72,7 @@ struct MeetingCountdownToastView: View {
                     Text(viewModel.primaryActionLabel)
                         .frame(maxWidth: .infinity)
                 }
-                .buttonStyle(.bordered)
+                .parakeetAction(.secondary)
                 .controlSize(.small)
                 .keyboardShortcut(.escape, modifiers: [])
 
@@ -82,7 +82,7 @@ struct MeetingCountdownToastView: View {
                         Text(confirmLabel)
                             .frame(maxWidth: .infinity)
                     }
-                    .buttonStyle(.borderedProminent)
+                    .parakeetAction(.primary, prominent: true)
                     .controlSize(.small)
                     .keyboardShortcut(.return, modifiers: [])
                 }

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingCountdownToastView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingCountdownToastView.swift
@@ -82,7 +82,7 @@ struct MeetingCountdownToastView: View {
                         Text(confirmLabel)
                             .frame(maxWidth: .infinity)
                     }
-                    .parakeetAction(.primary, prominent: true)
+                    .parakeetAction(.primaryProminent)
                     .controlSize(.small)
                     .keyboardShortcut(.return, modifiers: [])
                 }

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelController.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelController.swift
@@ -58,7 +58,7 @@ final class MeetingRecordingPanelController {
         panel.isReleasedWhenClosed = false
         panel.minSize = NSSize(width: 360, height: 320)
         panel.setFrameAutosaveName("MeetingRecordingPanel")
-        panel.contentView = NSHostingView(rootView: MeetingRecordingPanelView(viewModel: viewModel).tint(DesignSystem.Colors.accent))
+        panel.contentView = NSHostingView(rootView: MeetingRecordingPanelView(viewModel: viewModel))
 
         if panel.frame.origin == .zero, let screen = NSScreen.main {
             let frame = screen.visibleFrame

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPillController.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPillController.swift
@@ -85,7 +85,7 @@ final class MeetingRecordingPillController {
                 }
             }
         )
-        let hosting = NSHostingView(rootView: view.tint(DesignSystem.Colors.accent))
+        let hosting = NSHostingView(rootView: view)
 
         let panelWidth: CGFloat = 240
         let panelHeight: CGFloat = 150

--- a/Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift
+++ b/Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift
@@ -455,7 +455,7 @@ struct OnboardingFlowView: View {
                     Button("Skip — I'll set this up later") {
                         viewModel.skipMeetingRecordingStep()
                     }
-                    .buttonStyle(.bordered)
+                    .parakeetAction(.secondary)
                 }
 
                 if !viewModel.screenRecordingGranted {
@@ -527,7 +527,7 @@ struct OnboardingFlowView: View {
                     Button("Skip — I'll set this up later") {
                         viewModel.skipCalendarStep()
                     }
-                    .buttonStyle(.bordered)
+                    .parakeetAction(.secondary)
                 }
             }
             .padding(DesignSystem.Spacing.lg)
@@ -776,7 +776,7 @@ struct OnboardingFlowView: View {
                             Button("Open Settings") {
                                 onOpenSettings()
                             }
-                            .buttonStyle(.bordered)
+                            .parakeetAction(.secondary)
                         }
                     }
 

--- a/Sources/MacParakeet/Views/Settings/Components/EngineOptionTile.swift
+++ b/Sources/MacParakeet/Views/Settings/Components/EngineOptionTile.swift
@@ -250,9 +250,8 @@ struct EngineDownloadBanner: View {
         switch mode {
         case .download:
             Button("Download", action: action)
-                .buttonStyle(.borderedProminent)
+                .parakeetAction(.primary, prominent: true)
                 .controlSize(.regular)
-                .tint(DesignSystem.Colors.accent)
                 .accessibilityLabel("Download \(title)")
         case .downloading:
             HStack(spacing: DesignSystem.Spacing.xs) {
@@ -265,9 +264,8 @@ struct EngineDownloadBanner: View {
             .accessibilityLabel("Downloading \(title)")
         case .retry:
             Button("Retry Download", action: action)
-                .buttonStyle(.borderedProminent)
+                .parakeetAction(.destructive, prominent: true)
                 .controlSize(.regular)
-                .tint(DesignSystem.Colors.errorRed)
                 .accessibilityLabel("Retry downloading \(title)")
         }
     }

--- a/Sources/MacParakeet/Views/Settings/Components/EngineOptionTile.swift
+++ b/Sources/MacParakeet/Views/Settings/Components/EngineOptionTile.swift
@@ -250,7 +250,7 @@ struct EngineDownloadBanner: View {
         switch mode {
         case .download:
             Button("Download", action: action)
-                .parakeetAction(.primary, prominent: true)
+                .parakeetAction(.primaryProminent)
                 .controlSize(.regular)
                 .accessibilityLabel("Download \(title)")
         case .downloading:
@@ -264,7 +264,7 @@ struct EngineDownloadBanner: View {
             .accessibilityLabel("Downloading \(title)")
         case .retry:
             Button("Retry Download", action: action)
-                .parakeetAction(.destructive, prominent: true)
+                .parakeetAction(.primaryProminent)
                 .controlSize(.regular)
                 .accessibilityLabel("Retry downloading \(title)")
         }

--- a/Sources/MacParakeet/Views/Settings/Components/SettingsDestructiveButton.swift
+++ b/Sources/MacParakeet/Views/Settings/Components/SettingsDestructiveButton.swift
@@ -45,9 +45,8 @@ struct SettingsDestructiveButton: View {
             isPresented = true
         } label: {
             Text(title)
-                .foregroundStyle(DesignSystem.Colors.errorRed)
         }
-        .buttonStyle(.bordered)
+        .parakeetAction(.destructive)
         .accessibilityLabel(accessibilityLabelOverride ?? title)
         .alert(confirmationTitle, isPresented: $isPresented) {
             Button("Cancel", role: .cancel) {}

--- a/Sources/MacParakeet/Views/Settings/Components/SettingsEmptyState.swift
+++ b/Sources/MacParakeet/Views/Settings/Components/SettingsEmptyState.swift
@@ -45,8 +45,7 @@ struct SettingsEmptyState: View {
 
             if let actionLabel, let action {
                 Button(actionLabel, action: action)
-                    .buttonStyle(.borderedProminent)
-                    .tint(DesignSystem.Colors.accent)
+                    .parakeetAction(.primary, prominent: true)
                     .padding(.top, 6)
             }
         }

--- a/Sources/MacParakeet/Views/Settings/Components/SettingsEmptyState.swift
+++ b/Sources/MacParakeet/Views/Settings/Components/SettingsEmptyState.swift
@@ -45,7 +45,7 @@ struct SettingsEmptyState: View {
 
             if let actionLabel, let action {
                 Button(actionLabel, action: action)
-                    .parakeetAction(.primary, prominent: true)
+                    .parakeetAction(.primaryProminent)
                     .padding(.top, 6)
             }
         }

--- a/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
+++ b/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
@@ -63,7 +63,7 @@ struct HotkeyRecorderView: View {
             Button(trigger.isDisabled ? "Set Hotkey..." : "Change...") {
                 startRecording(modifierCaptureMode: .generic)
             }
-            .buttonStyle(.bordered)
+            .parakeetAction(.secondary)
 
             Menu {
                 if !trigger.isDisabled {
@@ -116,7 +116,7 @@ struct HotkeyRecorderView: View {
             Button("Cancel") {
                 stopRecording()
             }
-            .buttonStyle(.bordered)
+            .parakeetAction(.secondary)
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 6)

--- a/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
@@ -322,7 +322,7 @@ struct LLMSettingsView: View {
                 Button(isSelected ? "Selected" : buttonTitle) {
                     viewModel.chooseLocalAIApp(provider)
                 }
-                .parakeetAction(.primary)
+                .parakeetAction(.secondary)
                 .disabled(isSelected)
 
                 if isSelected {

--- a/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
@@ -123,7 +123,7 @@ struct LLMSettingsView: View {
                     Button("Test Connection") {
                         viewModel.testConnection()
                     }
-                    .buttonStyle(.bordered)
+                    .parakeetAction(.secondary)
                     .disabled(viewModel.connectionTestState == .testing || !viewModel.canTestConnection)
 
                     connectionStatusIndicator
@@ -155,15 +155,14 @@ struct LLMSettingsView: View {
                 Button("Save") {
                     viewModel.saveConfiguration()
                 }
-                .buttonStyle(.borderedProminent)
-                .tint(DesignSystem.Colors.accent)
+                .parakeetAction(.primary, prominent: true)
                 .disabled(!viewModel.canSave)
 
                 if viewModel.isConfigured {
                     Button("Clear", role: .destructive) {
                         viewModel.clearConfiguration()
                     }
-                    .buttonStyle(.bordered)
+                    .parakeetAction(.destructive)
                 }
 
                 saveStateIndicator
@@ -323,8 +322,7 @@ struct LLMSettingsView: View {
                 Button(isSelected ? "Selected" : buttonTitle) {
                     viewModel.chooseLocalAIApp(provider)
                 }
-                .buttonStyle(.bordered)
-                .tint(DesignSystem.Colors.accent)
+                .parakeetAction(.primary)
                 .disabled(isSelected)
 
                 if isSelected {

--- a/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
@@ -155,7 +155,7 @@ struct LLMSettingsView: View {
                 Button("Save") {
                     viewModel.saveConfiguration()
                 }
-                .parakeetAction(.primary, prominent: true)
+                .parakeetAction(.primaryProminent)
                 .disabled(!viewModel.canSave)
 
                 if viewModel.isConfigured {

--- a/Sources/MacParakeet/Views/Settings/LanguagePickerPopover.swift
+++ b/Sources/MacParakeet/Views/Settings/LanguagePickerPopover.swift
@@ -28,7 +28,7 @@ struct LanguagePickerButton: View {
             }
             .frame(width: LanguagePickerLayout.buttonWidth)
         }
-        .buttonStyle(.bordered)
+        .parakeetAction(.secondary)
         .disabled(isDisabled)
         .accessibilityLabel("Whisper language: \(WhisperLanguageCatalog.displayLabel(for: selection))")
         .popover(isPresented: $isShowing, arrowEdge: .bottom) {

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -331,7 +331,7 @@ struct SettingsView: View {
                         } label: {
                             Image(systemName: "arrow.clockwise")
                         }
-                        .buttonStyle(.bordered)
+                        .parakeetAction(.secondary)
                         .help("Refresh microphones")
                         .accessibilityLabel("Refresh microphones")
                     }
@@ -355,8 +355,7 @@ struct SettingsView: View {
                             systemImage: viewModel.microphoneTestState == .testing ? "stop.fill" : "waveform"
                         )
                     }
-                    .buttonStyle(.borderedProminent)
-                    .tint(DesignSystem.Colors.accent)
+                    .parakeetAction(.primary, prominent: true)
                     .disabled(!viewModel.microphoneGranted && viewModel.microphoneTestState != .testing)
                 }
             }
@@ -624,7 +623,7 @@ struct SettingsView: View {
                         } label: {
                             Label("Recover", systemImage: "arrow.clockwise")
                         }
-                        .buttonStyle(.bordered)
+                        .parakeetAction(.secondary)
                     }
                 }
 
@@ -876,14 +875,14 @@ struct SettingsView: View {
                 }
                 Spacer(minLength: DesignSystem.Spacing.md)
                 Button("Reset") { onResetFolder() }
-                    .buttonStyle(.bordered)
+                    .parakeetAction(.secondary)
                     .help(resetHelp)
                 Button("Choose…") {
                     if let url = Self.presentAutoSaveFolderPicker(message: panelMessage) {
                         onChooseFolder(url)
                     }
                 }
-                .buttonStyle(.bordered)
+                .parakeetAction(.secondary)
             }
         }
         .padding(DesignSystem.Spacing.sm)
@@ -1445,21 +1444,19 @@ struct SettingsView: View {
                             Button("Open Accessibility Settings") {
                                 openAccessibilitySettings()
                             }
-                            .buttonStyle(.borderedProminent)
-                            .tint(DesignSystem.Colors.accent)
+                            .parakeetAction(.primary, prominent: true)
                         }
 
                         if needsScreenRecordingAction {
                             Button("Enable meeting recording") {
                                 viewModel.requestScreenRecordingAccess()
                             }
-                            .buttonStyle(.borderedProminent)
-                            .tint(DesignSystem.Colors.accent)
+                            .parakeetAction(.primary, prominent: true)
 
                             Button("Open Screen Recording Settings") {
                                 viewModel.openScreenRecordingSystemSettings()
                             }
-                            .buttonStyle(.bordered)
+                            .parakeetAction(.secondary)
                         }
                     }
                 }
@@ -1537,8 +1534,7 @@ struct SettingsView: View {
                     Button("Check for Updates...") {
                         updater.checkForUpdates()
                     }
-                    .buttonStyle(.borderedProminent)
-                    .tint(DesignSystem.Colors.accent)
+                    .parakeetAction(.primary, prominent: true)
                     .disabled(!updater.canCheckForUpdates)
                 }
             }
@@ -1562,8 +1558,7 @@ struct SettingsView: View {
                 Button("Open Setup...") {
                     NotificationCenter.default.post(name: .macParakeetOpenOnboarding, object: nil)
                 }
-                .buttonStyle(.borderedProminent)
-                .tint(DesignSystem.Colors.accent)
+                .parakeetAction(.primary, prominent: true)
             }
         }
     }
@@ -1601,7 +1596,7 @@ struct SettingsView: View {
                             copiedBuildIdentity = false
                         }
                     }
-                    .buttonStyle(.bordered)
+                    .parakeetAction(.secondary)
                 }
 
                 Divider()
@@ -1719,13 +1714,12 @@ struct SettingsView: View {
         let label = isWorking ? "Working…" : action.label
         if action.isProminent {
             Button(label, action: action.run)
-                .buttonStyle(.borderedProminent)
-                .tint(DesignSystem.Colors.accent)
+                .parakeetAction(.primary, prominent: true)
                 .controlSize(.small)
                 .disabled(isWorking)
         } else {
             Button(label, action: action.run)
-                .buttonStyle(.bordered)
+                .parakeetAction(.secondary)
                 .controlSize(.small)
                 .disabled(isWorking)
         }

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -355,7 +355,7 @@ struct SettingsView: View {
                             systemImage: viewModel.microphoneTestState == .testing ? "stop.fill" : "waveform"
                         )
                     }
-                    .parakeetAction(.primary, prominent: true)
+                    .parakeetAction(.primaryProminent)
                     .disabled(!viewModel.microphoneGranted && viewModel.microphoneTestState != .testing)
                 }
             }
@@ -1444,14 +1444,14 @@ struct SettingsView: View {
                             Button("Open Accessibility Settings") {
                                 openAccessibilitySettings()
                             }
-                            .parakeetAction(.primary, prominent: true)
+                            .parakeetAction(.primaryProminent)
                         }
 
                         if needsScreenRecordingAction {
                             Button("Enable meeting recording") {
                                 viewModel.requestScreenRecordingAccess()
                             }
-                            .parakeetAction(.primary, prominent: true)
+                            .parakeetAction(.primaryProminent)
 
                             Button("Open Screen Recording Settings") {
                                 viewModel.openScreenRecordingSystemSettings()
@@ -1534,7 +1534,7 @@ struct SettingsView: View {
                     Button("Check for Updates...") {
                         updater.checkForUpdates()
                     }
-                    .parakeetAction(.primary, prominent: true)
+                    .parakeetAction(.primaryProminent)
                     .disabled(!updater.canCheckForUpdates)
                 }
             }
@@ -1558,7 +1558,7 @@ struct SettingsView: View {
                 Button("Open Setup...") {
                     NotificationCenter.default.post(name: .macParakeetOpenOnboarding, object: nil)
                 }
-                .parakeetAction(.primary, prominent: true)
+                .parakeetAction(.primaryProminent)
             }
         }
     }
@@ -1714,7 +1714,7 @@ struct SettingsView: View {
         let label = isWorking ? "Working…" : action.label
         if action.isProminent {
             Button(label, action: action.run)
-                .parakeetAction(.primary, prominent: true)
+                .parakeetAction(.primaryProminent)
                 .controlSize(.small)
                 .disabled(isWorking)
         } else {

--- a/Sources/MacParakeet/Views/Transcription/PromptLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/PromptLibraryView.swift
@@ -143,7 +143,6 @@ struct PromptLibraryView: View {
         ) {
             if let prompt = viewModel.editingPrompt {
                 editSheet(prompt: prompt)
-                    .tint(DesignSystem.Colors.accent)
                     .alert("Discard changes?", isPresented: $showingDiscardConfirm) {
                         Button("Discard", role: .destructive) {
                             viewModel.editingPrompt = nil

--- a/Sources/MacParakeet/Views/Transcription/PromptLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/PromptLibraryView.swift
@@ -35,7 +35,7 @@ struct PromptLibraryView: View {
                         .font(DesignSystem.Typography.body.weight(.semibold))
                         .padding(.horizontal, DesignSystem.Spacing.sm)
                 }
-                .buttonStyle(.borderedProminent)
+                .parakeetAction(.primary, prominent: true)
                 .controlSize(.large)
                 // Esc dismisses (Apple HIG default for sheets).
                 .keyboardShortcut(.cancelAction)
@@ -453,9 +453,8 @@ struct PromptLibraryView: View {
                     }
                     .padding(.horizontal, DesignSystem.Spacing.sm)
                 }
-                .buttonStyle(.borderedProminent)
+                .parakeetAction(.primary, prominent: true)
                 .controlSize(.large)
-                .tint(DesignSystem.Colors.accent)
                 .disabled(viewModel.newName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || viewModel.newContent.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }
             .padding(DesignSystem.Spacing.md)
@@ -540,7 +539,7 @@ struct PromptLibraryView: View {
                 Button("Cancel") {
                     attemptCancelEdit(prompt: prompt)
                 }
-                .buttonStyle(.bordered)
+                .parakeetAction(.secondary)
                 .controlSize(.large)
                 // Esc cancels (HIG default). hasChanges check inside
                 // attemptCancelEdit decides whether to confirm or dismiss.
@@ -549,9 +548,8 @@ struct PromptLibraryView: View {
                 Button("Save Changes") {
                     viewModel.updatePrompt(prompt, name: editName, content: editContent)
                 }
-                .buttonStyle(.borderedProminent)
+                .parakeetAction(.primary, prominent: true)
                 .controlSize(.large)
-                .tint(DesignSystem.Colors.accent)
                 // Cmd+Return (not bare Return) because the Instructions
                 // TextEditor below treats Return as a literal newline; bare
                 // Return would steal that.

--- a/Sources/MacParakeet/Views/Transcription/PromptLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/PromptLibraryView.swift
@@ -99,7 +99,7 @@ struct PromptLibraryView: View {
         }
         .background {
             ZStack {
-                DesignSystem.Colors.background
+                Rectangle().fill(.thickMaterial)
                 VStack {
                     Spacer()
                     HStack {
@@ -559,7 +559,7 @@ struct PromptLibraryView: View {
             .background(DesignSystem.Colors.surfaceElevated.opacity(0.3))
         }
         .frame(width: 540, height: 500)
-        .background(DesignSystem.Colors.surface)
+        .background(.thickMaterial)
     }
 }
 

--- a/Sources/MacParakeet/Views/Transcription/PromptLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/PromptLibraryView.swift
@@ -35,7 +35,7 @@ struct PromptLibraryView: View {
                         .font(DesignSystem.Typography.body.weight(.semibold))
                         .padding(.horizontal, DesignSystem.Spacing.sm)
                 }
-                .parakeetAction(.primary, prominent: true)
+                .parakeetAction(.primaryProminent)
                 .controlSize(.large)
                 // Esc dismisses (Apple HIG default for sheets).
                 .keyboardShortcut(.cancelAction)
@@ -452,7 +452,7 @@ struct PromptLibraryView: View {
                     }
                     .padding(.horizontal, DesignSystem.Spacing.sm)
                 }
-                .parakeetAction(.primary, prominent: true)
+                .parakeetAction(.primaryProminent)
                 .controlSize(.large)
                 .disabled(viewModel.newName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || viewModel.newContent.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }
@@ -547,7 +547,7 @@ struct PromptLibraryView: View {
                 Button("Save Changes") {
                     viewModel.updatePrompt(prompt, name: editName, content: editContent)
                 }
-                .parakeetAction(.primary, prominent: true)
+                .parakeetAction(.primaryProminent)
                 .controlSize(.large)
                 // Cmd+Return (not bare Return) because the Instructions
                 // TextEditor below treats Return as a literal newline; bare

--- a/Sources/MacParakeet/Views/Transcription/TranscribeView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscribeView.swift
@@ -442,7 +442,7 @@ struct TranscribeView: View {
                 Button("Cancel Transcription", role: .destructive) {
                     showCancelConfirmation = true
                 }
-                .buttonStyle(.bordered)
+                .parakeetAction(.destructive)
                 .padding(.top, DesignSystem.Spacing.sm)
                 .alert("Cancel Transcription?", isPresented: $showCancelConfirmation) {
                     Button("Cancel Transcription", role: .destructive) {

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -424,14 +424,14 @@ struct TranscriptResultView: View {
                 )
                 .foregroundStyle(copied ? DesignSystem.Colors.successGreen : .primary)
             }
-            .buttonStyle(.bordered)
+            .parakeetAction(.secondary)
 
             Button {
                 showingExportOptions.toggle()
             } label: {
                 Label("Export", systemImage: "arrow.down.doc")
             }
-            .buttonStyle(.bordered)
+            .parakeetAction(.secondary)
             .popover(isPresented: $showingExportOptions, arrowEdge: .top) {
                 exportOptionsPopover
             }
@@ -460,7 +460,7 @@ struct TranscriptResultView: View {
                         }
                     }
                 }
-                .buttonStyle(.bordered)
+                .parakeetAction(.secondary)
                 .help(engineOption != nil ? "Choose a speech engine for this rerun" : "Retranscribe this file")
                 .popover(isPresented: $showingRetranscribeOptions, arrowEdge: .top) {
                     if let engineOption {
@@ -477,8 +477,7 @@ struct TranscriptResultView: View {
                 } label: {
                     Label("New Transcription", systemImage: "plus")
                 }
-                .buttonStyle(.bordered)
-                .tint(DesignSystem.Colors.accent)
+                .parakeetAction(.primary)
             }
         }
         .padding(DesignSystem.Spacing.md)
@@ -1078,7 +1077,7 @@ struct TranscriptResultView: View {
                     } label: {
                         Label("Revert", systemImage: "arrow.uturn.backward")
                     }
-                    .buttonStyle(.bordered)
+                    .parakeetAction(.secondary)
                 }
 
                 Button {
@@ -1086,15 +1085,14 @@ struct TranscriptResultView: View {
                 } label: {
                     Label("Cancel", systemImage: "xmark")
                 }
-                .buttonStyle(.bordered)
+                .parakeetAction(.secondary)
 
                 Button {
                     commitTranscriptEdit()
                 } label: {
                     Label("Save", systemImage: "checkmark")
                 }
-                .buttonStyle(.borderedProminent)
-                .tint(DesignSystem.Colors.accent)
+                .parakeetAction(.primary, prominent: true)
                 .disabled(transcriptDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             } else {
                 Button {
@@ -1102,7 +1100,7 @@ struct TranscriptResultView: View {
                 } label: {
                     Label("Edit", systemImage: "pencil")
                 }
-                .buttonStyle(.bordered)
+                .parakeetAction(.secondary)
             }
         }
     }
@@ -1393,7 +1391,7 @@ struct TranscriptResultView: View {
                             }
                             .font(DesignSystem.Typography.caption)
                         }
-                        .buttonStyle(.bordered)
+                        .parakeetAction(.secondary)
                         .controlSize(.small)
                         .disabled(!promptResultsViewModel.canGeneratePromptResult || transcriptText.isEmpty)
 
@@ -1414,7 +1412,7 @@ struct TranscriptResultView: View {
                             .font(DesignSystem.Typography.caption)
                             .foregroundStyle(isCopied ? DesignSystem.Colors.successGreen : .primary)
                         }
-                        .buttonStyle(.bordered)
+                        .parakeetAction(.secondary)
                         .controlSize(.small)
 
                         Menu {
@@ -1428,6 +1426,7 @@ struct TranscriptResultView: View {
                             .font(DesignSystem.Typography.caption)
                         }
                         .menuStyle(.borderedButton)
+                        .tint(DesignSystem.Colors.tintNeutral)
                         .controlSize(.small)
 
                         Button(role: .destructive) {
@@ -1439,7 +1438,7 @@ struct TranscriptResultView: View {
                             }
                             .font(DesignSystem.Typography.caption)
                         }
-                        .buttonStyle(.bordered)
+                        .parakeetAction(.destructive)
                         .controlSize(.small)
                     }
 

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -216,7 +216,6 @@ struct TranscriptResultView: View {
             promptResultsViewModel.loadVisiblePrompts()
         }) {
             PromptLibraryView(viewModel: promptsViewModel)
-                .tint(DesignSystem.Colors.accent)
         }
         .alert(
             "Delete Result?",

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -1165,7 +1165,7 @@ struct TranscriptResultView: View {
                     .font(DesignSystem.Typography.caption)
                     .foregroundStyle(notesCopied ? DesignSystem.Colors.successGreen : .primary)
                 }
-                .buttonStyle(.bordered)
+                .parakeetAction(.secondary)
                 .controlSize(.small)
                 .accessibilityLabel(notesCopied ? "Notes copied" : "Copy your notes")
             }
@@ -1480,7 +1480,7 @@ struct TranscriptResultView: View {
                         }
                         .font(DesignSystem.Typography.caption)
                     }
-                    .buttonStyle(.bordered)
+                    .parakeetAction(.secondary)
                     .controlSize(.small)
                 }
 
@@ -1581,7 +1581,7 @@ struct TranscriptResultView: View {
                 } label: {
                     Label("Manage Prompts", systemImage: "slider.horizontal.3")
                 }
-                .buttonStyle(.bordered)
+                .parakeetAction(.secondary)
                 .controlSize(.regular)
 
                 Spacer()
@@ -1597,7 +1597,7 @@ struct TranscriptResultView: View {
                 } label: {
                     Label("Generate", systemImage: "sparkles")
                 }
-                .buttonStyle(.borderedProminent)
+                .parakeetAction(.primary, prominent: true)
                 .controlSize(.regular)
                 .keyboardShortcut(.return, modifiers: .command)
                 .disabled(!promptResultsViewModel.canGenerateManualPromptResult || transcriptText.isEmpty)
@@ -1838,7 +1838,7 @@ struct TranscriptResultView: View {
                 Label("New Chat", systemImage: "plus.bubble")
                     .font(DesignSystem.Typography.caption)
             }
-            .buttonStyle(.bordered)
+            .parakeetAction(.secondary)
             .controlSize(.small)
         }
         .padding(.horizontal, DesignSystem.Spacing.md)
@@ -2583,7 +2583,7 @@ struct TranscriptResultView: View {
                 } label: {
                     Label("Export", systemImage: "arrow.down.doc")
                 }
-                .buttonStyle(.borderedProminent)
+                .parakeetAction(.primary, prominent: true)
                 .keyboardShortcut(.defaultAction)
             }
         }
@@ -2635,7 +2635,7 @@ struct TranscriptResultView: View {
                 Label("Show in Finder", systemImage: "folder")
                     .font(DesignSystem.Typography.caption)
             }
-            .buttonStyle(.bordered)
+            .parakeetAction(.secondary)
         }
         .padding(DesignSystem.Spacing.md)
         .frame(minWidth: 220)

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -1091,7 +1091,7 @@ struct TranscriptResultView: View {
                 } label: {
                     Label("Save", systemImage: "checkmark")
                 }
-                .parakeetAction(.primary, prominent: true)
+                .parakeetAction(.primaryProminent)
                 .disabled(transcriptDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             } else {
                 Button {
@@ -1596,7 +1596,7 @@ struct TranscriptResultView: View {
                 } label: {
                     Label("Generate", systemImage: "sparkles")
                 }
-                .parakeetAction(.primary, prominent: true)
+                .parakeetAction(.primaryProminent)
                 .controlSize(.regular)
                 .keyboardShortcut(.return, modifiers: .command)
                 .disabled(!promptResultsViewModel.canGenerateManualPromptResult || transcriptText.isEmpty)
@@ -2582,7 +2582,7 @@ struct TranscriptResultView: View {
                 } label: {
                     Label("Export", systemImage: "arrow.down.doc")
                 }
-                .parakeetAction(.primary, prominent: true)
+                .parakeetAction(.primaryProminent)
                 .keyboardShortcut(.defaultAction)
             }
         }

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -32,8 +32,7 @@ struct TranscriptionLibraryView: View {
 
                 if let primaryActionTitle, let onPrimaryAction {
                     Button(primaryActionTitle, action: onPrimaryAction)
-                        .buttonStyle(.borderedProminent)
-                        .tint(DesignSystem.Colors.accent)
+                        .parakeetAction(.primary, prominent: true)
                 }
             }
             .padding(.horizontal, DesignSystem.Spacing.lg)

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -32,7 +32,7 @@ struct TranscriptionLibraryView: View {
 
                 if let primaryActionTitle, let onPrimaryAction {
                     Button(primaryActionTitle, action: onPrimaryAction)
-                        .parakeetAction(.primary, prominent: true)
+                        .parakeetAction(.primaryProminent)
                 }
             }
             .padding(.horizontal, DesignSystem.Spacing.lg)

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionVideoPanel.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionVideoPanel.swift
@@ -123,7 +123,7 @@ struct TranscriptionVideoPanel: View {
                     await playerViewModel.load(for: transcription)
                 }
             }
-            .buttonStyle(.bordered)
+            .parakeetAction(.secondary)
         }
         .frame(maxWidth: .infinity)
         .aspectRatio(16/9, contentMode: .fit)

--- a/Sources/MacParakeet/Views/Transcription/YouTubeInputPanelController.swift
+++ b/Sources/MacParakeet/Views/Transcription/YouTubeInputPanelController.swift
@@ -48,7 +48,7 @@ final class YouTubeInputPanelController {
             }
         )
 
-        let hosting = NSHostingView(rootView: view.tint(DesignSystem.Colors.accent))
+        let hosting = NSHostingView(rootView: view)
         // Extra padding around the 460pt SwiftUI card for shadow clearance
         let panelWidth: CGFloat = 540
         let panelHeight: CGFloat = 280

--- a/Sources/MacParakeet/Views/Vocabulary/CustomWordsView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/CustomWordsView.swift
@@ -59,8 +59,7 @@ struct CustomWordsView: View {
             HStack {
                 Spacer()
                 Button("Done") { dismiss() }
-                    .buttonStyle(.borderedProminent)
-                    .tint(DesignSystem.Colors.accent)
+                    .parakeetAction(.primary, prominent: true)
                     .keyboardShortcut(.cancelAction)
             }
         }
@@ -118,8 +117,7 @@ struct CustomWordsView: View {
                     Button("Add") {
                         viewModel.addWord()
                     }
-                    .buttonStyle(.borderedProminent)
-                    .tint(DesignSystem.Colors.accent)
+                    .parakeetAction(.primary, prominent: true)
                     .disabled(viewModel.newWord.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
@@ -201,8 +199,7 @@ struct CustomWordsView: View {
                 Button("Add Your First Rule") {
                     wordFieldFocused = true
                 }
-                .buttonStyle(.borderedProminent)
-                .tint(DesignSystem.Colors.accent)
+                .parakeetAction(.primary, prominent: true)
                 .controlSize(.small)
             }
         }

--- a/Sources/MacParakeet/Views/Vocabulary/CustomWordsView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/CustomWordsView.swift
@@ -59,7 +59,7 @@ struct CustomWordsView: View {
             HStack {
                 Spacer()
                 Button("Done") { dismiss() }
-                    .parakeetAction(.primary, prominent: true)
+                    .parakeetAction(.primaryProminent)
                     .keyboardShortcut(.cancelAction)
             }
         }
@@ -117,7 +117,7 @@ struct CustomWordsView: View {
                     Button("Add") {
                         viewModel.addWord()
                     }
-                    .parakeetAction(.primary, prominent: true)
+                    .parakeetAction(.primaryProminent)
                     .disabled(viewModel.newWord.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
@@ -199,7 +199,7 @@ struct CustomWordsView: View {
                 Button("Add Your First Rule") {
                     wordFieldFocused = true
                 }
-                .parakeetAction(.primary, prominent: true)
+                .parakeetAction(.primaryProminent)
                 .controlSize(.small)
             }
         }

--- a/Sources/MacParakeet/Views/Vocabulary/CustomWordsView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/CustomWordsView.swift
@@ -18,7 +18,7 @@ struct CustomWordsView: View {
             }
             .padding(DesignSystem.Spacing.lg)
         }
-        .background(DesignSystem.Colors.background)
+        .background(.thickMaterial)
         .alert(
             "Delete Word?",
             isPresented: Binding(

--- a/Sources/MacParakeet/Views/Vocabulary/TextSnippetsView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/TextSnippetsView.swift
@@ -60,8 +60,7 @@ struct TextSnippetsView: View {
             HStack {
                 Spacer()
                 Button("Done") { dismiss() }
-                    .buttonStyle(.borderedProminent)
-                    .tint(DesignSystem.Colors.accent)
+                    .parakeetAction(.primary, prominent: true)
                     .keyboardShortcut(.cancelAction)
             }
         }
@@ -144,8 +143,7 @@ struct TextSnippetsView: View {
                     Button("Add") {
                         viewModel.addSnippet()
                     }
-                    .buttonStyle(.borderedProminent)
-                    .tint(DesignSystem.Colors.accent)
+                    .parakeetAction(.primary, prominent: true)
                     .disabled(
                         viewModel.newTrigger.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                             || viewModel.newExpansion.trimmingCharacters(in: .whitespaces).isEmpty
@@ -243,8 +241,7 @@ struct TextSnippetsView: View {
                 Button("Add Your First Snippet") {
                     triggerFieldFocused = true
                 }
-                .buttonStyle(.borderedProminent)
-                .tint(DesignSystem.Colors.accent)
+                .parakeetAction(.primary, prominent: true)
                 .controlSize(.small)
             }
         }

--- a/Sources/MacParakeet/Views/Vocabulary/TextSnippetsView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/TextSnippetsView.swift
@@ -19,7 +19,7 @@ struct TextSnippetsView: View {
             }
             .padding(DesignSystem.Spacing.lg)
         }
-        .background(DesignSystem.Colors.background)
+        .background(.thickMaterial)
         .alert(
             "Delete Snippet?",
             isPresented: Binding(

--- a/Sources/MacParakeet/Views/Vocabulary/TextSnippetsView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/TextSnippetsView.swift
@@ -60,7 +60,7 @@ struct TextSnippetsView: View {
             HStack {
                 Spacer()
                 Button("Done") { dismiss() }
-                    .parakeetAction(.primary, prominent: true)
+                    .parakeetAction(.primaryProminent)
                     .keyboardShortcut(.cancelAction)
             }
         }
@@ -143,7 +143,7 @@ struct TextSnippetsView: View {
                     Button("Add") {
                         viewModel.addSnippet()
                     }
-                    .parakeetAction(.primary, prominent: true)
+                    .parakeetAction(.primaryProminent)
                     .disabled(
                         viewModel.newTrigger.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                             || viewModel.newExpansion.trimmingCharacters(in: .whitespaces).isEmpty
@@ -241,7 +241,7 @@ struct TextSnippetsView: View {
                 Button("Add Your First Snippet") {
                     triggerFieldFocused = true
                 }
-                .parakeetAction(.primary, prominent: true)
+                .parakeetAction(.primaryProminent)
                 .controlSize(.small)
             }
         }

--- a/Sources/MacParakeet/Views/Vocabulary/VocabularyBackupSection.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/VocabularyBackupSection.swift
@@ -72,7 +72,6 @@ struct VocabularyBackupSection: View {
                     preview: preview
                 )
                 .frame(minWidth: 460)
-                .tint(DesignSystem.Colors.accent)
             }
         }
     }

--- a/Sources/MacParakeet/Views/Vocabulary/VocabularyImportPreviewSheet.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/VocabularyImportPreviewSheet.swift
@@ -281,7 +281,7 @@ struct VocabularyImportPreviewSheet: View {
                 viewModel.cancelImport()
                 dismiss()
             }
-            .buttonStyle(.bordered)
+            .parakeetAction(.secondary)
             .keyboardShortcut(.cancelAction)
 
             Button(importButtonTitle) {
@@ -291,8 +291,7 @@ struct VocabularyImportPreviewSheet: View {
                     }
                 }
             }
-            .buttonStyle(.borderedProminent)
-            .tint(DesignSystem.Colors.accent)
+            .parakeetAction(.primary, prominent: true)
             .keyboardShortcut(.defaultAction)
             .disabled(preview.wordsTotal == 0 && preview.snippetsTotal == 0)
         }

--- a/Sources/MacParakeet/Views/Vocabulary/VocabularyImportPreviewSheet.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/VocabularyImportPreviewSheet.swift
@@ -41,7 +41,7 @@ struct VocabularyImportPreviewSheet: View {
 
             VStack(alignment: .leading, spacing: 2) {
                 Text("Import Vocabulary")
-                    .font(DesignSystem.Typography.title)
+                    .font(DesignSystem.Typography.pageTitle)
                 Text("Review what's in this backup before importing.")
                     .font(DesignSystem.Typography.caption)
                     .foregroundStyle(.secondary)
@@ -98,7 +98,7 @@ struct VocabularyImportPreviewSheet: View {
                 )
             VStack(alignment: .leading, spacing: 1) {
                 Text(value)
-                    .font(DesignSystem.Typography.title.weight(.semibold))
+                    .font(DesignSystem.Typography.pageTitle.weight(.semibold))
                 Text(title)
                     .font(DesignSystem.Typography.micro)
                     .foregroundStyle(.secondary)

--- a/Sources/MacParakeet/Views/Vocabulary/VocabularyImportPreviewSheet.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/VocabularyImportPreviewSheet.swift
@@ -23,7 +23,7 @@ struct VocabularyImportPreviewSheet: View {
             actionRow
         }
         .padding(DesignSystem.Spacing.lg)
-        .background(DesignSystem.Colors.background)
+        .background(.thickMaterial)
     }
 
     // MARK: - Header

--- a/Sources/MacParakeet/Views/Vocabulary/VocabularyImportPreviewSheet.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/VocabularyImportPreviewSheet.swift
@@ -291,7 +291,7 @@ struct VocabularyImportPreviewSheet: View {
                     }
                 }
             }
-            .parakeetAction(.primary, prominent: true)
+            .parakeetAction(.primaryProminent)
             .keyboardShortcut(.defaultAction)
             .disabled(preview.wordsTotal == 0 && preview.snippetsTotal == 0)
         }

--- a/Sources/MacParakeet/Views/Vocabulary/VocabularyView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/VocabularyView.swift
@@ -42,14 +42,12 @@ struct VocabularyView: View {
         } content: {
             CustomWordsView(viewModel: customWordsViewModel)
                 .frame(minWidth: 620, minHeight: 460)
-                .tint(DesignSystem.Colors.accent)
         }
         .sheet(isPresented: $showTextSnippets) {
             settingsViewModel.refreshStats()
         } content: {
             TextSnippetsView(viewModel: textSnippetsViewModel)
                 .frame(minWidth: 620, minHeight: 460)
-                .tint(DesignSystem.Colors.accent)
         }
         .onAppear {
             settingsViewModel.refreshStats()

--- a/Sources/MacParakeet/Views/Vocabulary/VocabularyView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/VocabularyView.swift
@@ -431,8 +431,7 @@ struct VocabularyView: View {
                     action()
                 }
                 .font(DesignSystem.Typography.caption.weight(.semibold))
-                .buttonStyle(.bordered)
-                .tint(DesignSystem.Colors.accent)
+                .parakeetAction(.primary)
             }
         }
         .padding(.horizontal, DesignSystem.Spacing.lg)

--- a/Sources/MacParakeet/Views/Vocabulary/VocabularyView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/VocabularyView.swift
@@ -429,7 +429,7 @@ struct VocabularyView: View {
                     action()
                 }
                 .font(DesignSystem.Typography.caption.weight(.semibold))
-                .parakeetAction(.primary)
+                .parakeetAction(.secondary)
             }
         }
         .padding(.horizontal, DesignSystem.Spacing.lg)

--- a/plans/active/2026-05-restrained-brand-apple-grade-polish.md
+++ b/plans/active/2026-05-restrained-brand-apple-grade-polish.md
@@ -53,19 +53,22 @@ extension DesignSystem.Colors {
 
 // Sources/MacParakeet/Views/Components/ParakeetActionStyle.swift (new)
 enum ParakeetActionRole {
-    case primary       // brand coral; one per surface
-    case secondary     // neutral — system label color, .bordered
-    case destructive   // red — system destructive role
-    case subtle        // lower-weight neutral; .borderless or .plain
+    case primary               // brand coral, .bordered
+    case primaryProminent      // brand coral, .borderedProminent
+    case secondary             // neutral — system label color, .bordered
+    case destructive           // red — system destructive role
+    case destructiveProminent  // red, .borderedProminent
+    case subtle                // lower-weight neutral; .borderless or .plain
 }
 
 extension View {
     /// Apply a semantic action role. Replaces ad-hoc `.buttonStyle + .tint`.
-    func parakeetAction(_ role: ParakeetActionRole, prominent: Bool = false) -> some View
+    func parakeetAction(_ role: ParakeetActionRole) -> some View
 }
 ```
 
-`prominent: true` maps to `.borderedProminent`; default is `.bordered`.
+Prominence is encoded in the role so secondary/subtle controls cannot receive
+an ignored prominence flag.
 
 ### Tint cascade removed from
 
@@ -75,6 +78,7 @@ extension View {
 - `Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelController.swift`
 - `Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPillController.swift`
 - `Sources/MacParakeet/Views/Transcription/YouTubeInputPanelController.swift`
+- `Sources/MacParakeet/Views/MainWindowView.swift` sidebar list selection tint
 - Cross-window sheet patches: `TranscriptResultView` L219, `PromptLibraryView` L146/L238, `VocabularyView`, `VocabularyBackupSection`, `AskPromptsSheet` L138/L282/L533/L706
 
 ### Role mapping (representative; full sweep in PR)
@@ -93,7 +97,7 @@ extension View {
 | Button | Role |
 |--------|------|
 | Edit | `.secondary` |
-| Save (commit edit) | `.primary` (prominent) |
+| Save (commit edit) | `.primaryProminent` |
 | Cancel | `.secondary` |
 | Revert | `.secondary` |
 

--- a/plans/active/2026-05-restrained-brand-apple-grade-polish.md
+++ b/plans/active/2026-05-restrained-brand-apple-grade-polish.md
@@ -1,0 +1,190 @@
+# Restrained Brand + Apple-Grade Polish
+
+> Status: **ACTIVE** - 2026-05-03
+> Ship target: **post-v0.7.0**
+> Branch: `refactor/restrained-tint-and-button-roles` (off `main` post-#205 merge)
+> Shape: **single PR**, commits split per phase for bisect/readability
+> Related: docs/design-overhaul.md, docs/brand-identity.md
+> Focus rings: follow system accent (Apple-correct, makes coral CTAs read louder)
+
+## Context
+
+PR #205 merged the unified Ask quick prompts (`af23a55d`). During review the user flagged two visual smells, both rooted in the same gap:
+
+1. Action bars on the transcript page and prompt-result page all read coral — no visual hierarchy between primary and secondary actions ("everything is orange, so nothing is").
+2. Destructive buttons (Delete) render coral instead of red, because the cascading `.tint(coral)` set in `AppWindowCoordinator.swift:197` overrides destructive role styling.
+
+Root cause: there's no semantic button-role abstraction. Every callsite reaches for `.buttonStyle(.bordered) + .tint(...)` directly. The "App-wide brand-accent sweep" (commit `044f6a74`) was a band-aid for this missing layer.
+
+This plan introduces button roles, pulls the cascading tint, and uses that cleanliness as the foundation for an Apple-grade polish pass *calibrated to MacParakeet*. Not a theming system. Not customizable accent. Discipline at the chrome layer.
+
+## Calibrated principles ("Apple-grade for MacParakeet")
+
+Reference points: macOS Voice Memos, Reminders, Stocks. We are a menu-bar utility — restraint over expression.
+
+1. **Coral is brand, not chrome.** Coral on: CTAs (one per surface max), recording state, AssistantHead, idle/recording pills, BreathingSeedOfLife, brand mark, sacred geometry. Coral OFF: secondary buttons, mode pickers, focus rings, selection, hover.
+2. **Hierarchy via type weight + size + spacing, not color.** Color is the third tool, not the first.
+3. **Material adoption.** Floating chrome (sheets, popovers, sidebars) gets `.regularMaterial` / `.thickMaterial` / `NSVisualEffectView`. Solid opacity-fills are for in-content surfaces.
+4. **System accent for selection/focus.** Respect `NSColor.controlAccentColor`. Don't repaint focus rings coral.
+5. **Apple HIG type semantics.** Align our scale to system text style names.
+6. **Motion uses Apple's named curves** (`.snappy`, `.smooth`, `.bouncy`) unless a hand-tuned curve is genuinely better. Honor `accessibilityReduceMotion` everywhere.
+7. **Light mode is equal.** Visual audit pass.
+8. **One Gallery preview.** Single SwiftUI Preview rendering every token side-by-side — drift catcher.
+
+## Anti-goals
+
+- No user-customizable theme. Coral is the parakeet.
+- No density toggle.
+- No build pipeline (Style Dictionary etc.). Swift static enums stay.
+- No new animation framework.
+- No backwards-compat shims. Single owner; delete cleanly.
+
+## Phase 1 — Button roles + tint pull
+
+### New API
+
+```swift
+// Sources/MacParakeet/Views/Components/DesignSystem.swift
+extension DesignSystem.Colors {
+    /// Neutral label tint — for `.bordered` buttons that should NOT carry brand.
+    /// Resolves to system label color (white in dark, near-black in light).
+    static let tintNeutral = Color.primary
+}
+
+// Sources/MacParakeet/Views/Components/ParakeetActionStyle.swift (new)
+enum ParakeetActionRole {
+    case primary       // brand coral; one per surface
+    case secondary     // neutral — system label color, .bordered
+    case destructive   // red — system destructive role
+    case subtle        // lower-weight neutral; .borderless or .plain
+}
+
+extension View {
+    /// Apply a semantic action role. Replaces ad-hoc `.buttonStyle + .tint`.
+    func parakeetAction(_ role: ParakeetActionRole, prominent: Bool = false) -> some View
+}
+```
+
+`prominent: true` maps to `.borderedProminent`; default is `.bordered`.
+
+### Tint cascade removed from
+
+- `Sources/MacParakeet/App/AppWindowCoordinator.swift:197`
+- `Sources/MacParakeet/Onboarding/OnboardingWindowController.swift`
+- `Sources/MacParakeet/Views/MeetingRecording/MeetingCountdownToastController.swift`
+- `Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelController.swift`
+- `Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPillController.swift`
+- `Sources/MacParakeet/Views/Transcription/YouTubeInputPanelController.swift`
+- Cross-window sheet patches: `TranscriptResultView` L219, `PromptLibraryView` L146/L238, `VocabularyView`, `VocabularyBackupSection`, `AskPromptsSheet` L138/L282/L533/L706
+
+### Role mapping (representative; full sweep in PR)
+
+**TranscriptResultView action bar:**
+
+| Button | Role |
+|--------|------|
+| Copy | `.secondary` |
+| Export | `.secondary` |
+| Retranscribe | `.secondary` |
+| New Transcription | `.primary` |
+
+**TranscriptResultView transcript-pane header:**
+
+| Button | Role |
+|--------|------|
+| Edit | `.secondary` |
+| Save (commit edit) | `.primary` (prominent) |
+| Cancel | `.secondary` |
+| Revert | `.secondary` |
+
+**TranscriptResultView prompt-result actions:**
+
+| Button | Role |
+|--------|------|
+| Regenerate | `.secondary` |
+| Copy | `.secondary` |
+| Export menu | `.secondary` |
+| Delete | `.destructive` |
+
+**Settings, Onboarding, AskPromptsSheet, PromptLibraryView, Vocabulary sheets:** mapped during sweep — most fall into `.primary` (one per sheet) or `.secondary` (everything else).
+
+### Validation
+
+- Manual smoke: every screen, dark mode + light mode
+- `swift test` clean (no test changes expected)
+- Visual: only Save / New Transcription / "Add Word" / Done style buttons render coral; everything else neutral; Delete red
+
+## Phase 2 — Material adoption
+
+| Surface | Today | Target |
+|---------|-------|--------|
+| Sheets (export, vocab, prompt library, ask prompts edit) | `.surface` solid | `.thickMaterial` |
+| Popovers (export options, retranscribe options, slash menu) | rounded rect solid fill | `.regularMaterial` |
+| Sidebars (main window) | likely already NSVisualEffectView via SwiftUI sidebar style | audit, confirm |
+| Floating dropdowns (Picker, Menu) | system default | leave |
+| In-content cards (transcription thumbnails) | solid surface | leave (in-content, not floating) |
+
+Single biggest "looks Apple-grade" lift. Each callsite is small.
+
+Risk: material can render badly when stacked over `BreathingSeedOfLife` behind the meeting panel. Test each surface; fall back to solid where material muddies the imagery.
+
+## Phase 3 — Markdown color fold
+
+`MarkdownContentView.swift` lines 86-101 use raw `NSColor(red:green:blue:)` literals duplicating `Colors.textPrimary`, `Colors.textSecondary`, `Colors.textTertiary`, `Colors.accent`, `Colors.surfaceElevated`. Fold into `DesignSystem.Colors` tokens via an `NSColor(_ swiftuiColor:)` bridge. Removes a drift target.
+
+## Phase 4 — Light mode visual audit
+
+Screenshot every screen in light mode; fix anything that screams "tested in dark only." Common culprits: borders too subtle in light, opacity values tuned for dark backgrounds, custom-drawn glows that look milky over white.
+
+## Phase 5 — Focus + Tab pass
+
+- Every focusable control has a visible focus ring
+- Tab traverses logically across each screen
+- Tooltips include keyboard shortcut hints with ⌘ ⌥ ⇧ glyphs where applicable
+- Default-button keyboard semantics (`Return` triggers primary CTA on sheets)
+
+## Phase 6 — Motion calibration
+
+- Replace `Animation.selectionChange` / `.hoverTransition` / `.contentSwap` etc. with Apple's named curves (`.snappy`, `.smooth`, `.bouncy`) where appropriate. Keep custom springs only when genuinely better.
+- Honor `@Environment(\.accessibilityReduceMotion)` on every animated state change. Today only `BreathingSeedOfLifeView` honors it.
+
+## Phase 7 — Hygiene
+
+- Delete dead Typography aliases (`headline`, `title`, `largeTitle`, `sectionHeader`) — 4 lines.
+- Do **not** rename the rest of the Typography scale. ~60 callsites of internal renaming for zero user-visible benefit fails the cost/benefit test.
+
+## Phase 8 — DesignSystemGalleryView
+
+Single SwiftUI Preview rendering:
+- Every button role × prominent (`primary`, `secondary`, `destructive`, `subtle`)
+- Every typography token (live text samples)
+- Every color (with name labels, light/dark side-by-side)
+- Every shadow style (on cards)
+- Every spacing scale (rulers)
+
+Debug-only, gated behind `#if DEBUG`. Single screen catches drift in 30 seconds.
+
+## Deferred (not in this PR)
+
+- Typography scale rename (cost/benefit fails today)
+- Custom shortcut-glyph rendering beyond tooltips
+- Spring-curve consistency audit
+- `AppTheme` extraction (only if user theming becomes a real feature ask)
+
+## Risk register
+
+- **Phase 1 partial state.** If we merge mid-sweep, some buttons read coral and others neutral. Mitigation: every callsite migrated in one PR; atomic merge.
+- **Phase 2 material over BreathingSeedOfLife.** Custom imagery behind meeting panel could fight `.regularMaterial`. Per-surface test.
+- **System accent vs coral for focus rings.** Today the cascade paints rings coral. Pulling the cascade reverts rings to user's system accent (red, purple, blue, etc.). This is the *correct* macOS behavior, but it's a visible change — flag for owner approval before Phase 1 lands.
+
+## Tests
+
+No test changes anticipated across all three PRs (purely visual). Existing 2200+ XCTest suite is the safety net. Each PR runs `swift test` to verify no regressions.
+
+## Resolved decisions
+
+1. **Selection/focus ring color** → follow system accent (Apple-correct; makes coral CTAs read louder against neutral focus chrome). Easy to reverse if it looks wrong post-Phase-1.
+2. **Sheet material** → `.thickMaterial`. Sheets are primary floating surfaces.
+3. **Popover material** → `.regularMaterial`.
+4. **Typography rename** → deferred. Cost/benefit fails for 60-callsite churn at zero user-visible benefit.
+5. **PR shape** → single PR, commits split per phase.


### PR DESCRIPTION
## Summary

Inverts the cascading-coral approach. Coral is now reserved for actual CTAs; everything else reads like Mac chrome.

The trigger was post-#205 visual smells — Delete buttons rendering coral instead of red, transcript action bars showing four coral buttons with no visual hierarchy. Both flowed from a single root cause: a `.tint(coral)` applied at every NSHostingView root, which overrode `Button(role: .destructive)` and erased the difference between primary and secondary actions.

## What changed

```
                    BEFORE                            AFTER
                    ──────                            ─────

  NSHostingView ──┐                          NSHostingView
                  │                                │
       .tint(coral)   ←  cascade overrides        (no cascade)
                  │      destructive role           │
                  ▼                                 ▼
         ┌──────────────┐                  ┌──────────────┐
         │  Copy        │  coral           │  Copy        │  neutral
         │  Export      │  coral           │  Export      │  neutral
         │  Retranscribe│  coral           │  Retranscribe│  neutral
         │  Delete      │  coral (!)       │  Delete      │  red ✓
         │  New ⤴       │  coral           │  New ⤴       │  CORAL ★
         └──────────────┘                  └──────────────┘
            "everything                       "one CTA pops,
             is orange"                        Delete is red"
```

Eight phases, one PR, separate commits per phase for bisect-friendliness.

| Phase | Commit | What |
|---|---|---|
| 1 | `e5d3a636 → 3863a231` | New `parakeetAction(.primary/.secondary/.destructive/.subtle)` modifier; pulled cascading tint from 6 NSHostingView roots + sheet patches; migrated every callsite |
| 2 | `3ba040b8` | Sheet roots → `.thickMaterial` (Sonoma-era backdrop blur on AskPrompts, PromptLibrary, Vocab sheets, ImportPreview) |
| 3 | `6c1539ed` | Folded `MarkdownContentView`'s hand-rolled appearance-aware NSColors into `DesignSystem.Colors` via `NSColor(_ swiftuiColor:)` |
| 4 | `971085aa` | Light-mode static audit — folded `DictationHistoryView` highlight color drift; documented audited surfaces |
| 5 | (no diff) | Focus + Tab pass — sheets already have `.keyboardShortcut(.defaultAction)` / `.cancelAction` plumbing; system focus rings now follow user's macOS accent (correct, not coral) |
| 6 | (no diff) | Motion calibration — existing tokens are tasteful Apple-canonical curves; reduce-motion already honored across the high-motion components |
| 7 | `5e88fc1a` | Dropped four dead Typography aliases; migrated 4 remaining callsites to canonical tokens |
| 8 | `5a8a3dff` | New `DesignSystemGalleryView` (`#if DEBUG`) — every button × role × prominent, every typography token, every color group, shadows, spacing rulers, radii — single 30-second drift-catcher pane |

## Reviewer paths

The biggest visible change is the focus ring color flipping from coral to your macOS system accent (System Settings → Appearance → Accent). That's intentional — Apple-correct, and the contrast with neutral focus chrome is what makes the coral CTA feel earned.

If you'd rather keep coral focus rings, revert just the cascade-pull commit (`71d18ca5`) and the rest still stands.

## Test plan

- [x] `swift test` — 2205 XCTest + 16 Swift Testing pass
- [ ] Smoke: walk every screen, dark + light, eyeball `parakeetAction(.primary)` is the only coral button on each surface
- [ ] Sheets: confirm `.thickMaterial` reads OK; if any sheet over `BreathingSeedOfLife` muddies, fall back to solid for that sheet
- [ ] Open `DesignSystemGalleryView.swift` Preview in Xcode (dark + light) — confirm all swatches match the running app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new semantic button styling system with consistent primary, secondary, and destructive action variants across the app.
  * Added debug-only design system gallery for visual reference.

* **Refactor**
  * Unified button styling throughout the app for a more cohesive user experience.
  * Updated sheet and panel backgrounds to use modern material design.
  * Consolidated color usage to design system tokens for improved visual consistency.
  * Removed deprecated typography styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->