### PR TITLE
Instrument dictation tap-stall regression with diagnostic logging

### DIFF
--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -214,6 +214,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - App Lifecycle
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        // Process boot marker for the audio diagnostics log. The dev app and
+        // `swift test` write into the same on-disk file
+        // (`~/Library/Logs/MacParakeet/dictation-audio.log`); without this
+        // marker, splitting transitions across processes/relaunches has to be
+        // inferred. See journal/2026-05-03-dictation-silent-stall.md.
+        let identity = BuildIdentity.current
+        AudioCaptureDiagnostics.append(
+            "dictation_diagnostics_session_start pid=\(getpid()) version=\(identity.version) build=\(identity.buildNumber) source=\(identity.buildSource) commit=\(identity.gitCommit)"
+        )
+
         if isRunningFromDiskImage() {
             showMoveToApplicationsAlert()
             return

--- a/Sources/MacParakeetCore/Audio/AudioCaptureDiagnostics.swift
+++ b/Sources/MacParakeetCore/Audio/AudioCaptureDiagnostics.swift
@@ -2,7 +2,7 @@ import CoreAudio
 import Foundation
 import os
 
-enum AudioCaptureDiagnostics {
+public enum AudioCaptureDiagnostics {
     private static let lock = OSAllocatedUnfairLock(initialState: ())
     private static let maxLogBytes: UInt64 = 1_000_000
 
@@ -19,7 +19,7 @@ enum AudioCaptureDiagnostics {
         deviceLabel(AudioDeviceManager.defaultInputDevice())
     }
 
-    static func append(_ message: @autoclosure () -> String) {
+    public static func append(_ message: @autoclosure () -> String) {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         let line = "\(formatter.string(from: Date())) \(message())\n"

--- a/Sources/MacParakeetCore/Audio/AudioCaptureDiagnostics.swift
+++ b/Sources/MacParakeetCore/Audio/AudioCaptureDiagnostics.swift
@@ -4,7 +4,13 @@ import os
 
 public enum AudioCaptureDiagnostics {
     private static let lock = OSAllocatedUnfairLock(initialState: ())
-    private static let maxLogBytes: UInt64 = 1_000_000
+    /// On-disk cap for `dictation-audio.log`. Crossing it deletes the file
+    /// (not append-rotate). Sized so a heavy user dictating 30–60 min/day
+    /// retains tens of days of context — enough that a stall reported via
+    /// the in-app feedback flow still has its surrounding window in the
+    /// log when the user shares it. Bumped from 1 MB after PR #210 added
+    /// the 5 s heartbeat, which roughly doubles per-recording log volume.
+    private static let maxLogBytes: UInt64 = 5_000_000
 
     /// Format a device as `<id>:<name>` for log lines, or `none` if the
     /// device couldn't be resolved. Single canonical shape so grep works

--- a/Sources/MacParakeetCore/Audio/AudioRecorder.swift
+++ b/Sources/MacParakeetCore/Audio/AudioRecorder.swift
@@ -32,6 +32,28 @@ private struct RecordingRuntimeMetrics: Sendable {
     var invalidFormatBufferCount: Int = 0
 }
 
+/// Holds the per-recording diagnostic timers. The first-buffer timeout fires
+/// once if no buffer has been delivered within `firstBufferTimeoutSeconds`
+/// after `dictation_capture_engine_started`; the heartbeat repeats every
+/// `heartbeatIntervalSeconds` while the recording is active. Both are
+/// log-only — they exist to characterize tap-silence stalls in the field
+/// without altering the user's experience. See
+/// `journal/2026-05-03-dictation-silent-stall.md`.
+///
+/// Not declared `Sendable`: `DispatchWorkItem` and `DispatchSourceTimer`
+/// aren't Sendable in strict-concurrency mode. The state is only ever
+/// touched while holding the enclosing `OSAllocatedUnfairLock`, which is
+/// the moral equivalent — the lock owner has exclusive access.
+private struct CaptureDiagnosticsTimers {
+    var firstBufferTimeout: DispatchWorkItem?
+    var firstBufferSeen: Bool = false
+    var heartbeatTimer: DispatchSourceTimer?
+    /// Session generation captured when the timers were armed. The fired
+    /// closures bail out if the current generation has moved past this,
+    /// which catches the race where `stop()` cancels in flight.
+    var armedGeneration: Int = -1
+}
+
 /// Records dictation audio by subscribing to the process-wide
 /// `SharedMicrophoneStream` and writing converted 16 kHz mono Float32 buffers
 /// to a temporary WAV file. The buffer handler always extracts channel 0 —
@@ -66,6 +88,16 @@ public actor AudioRecorder {
     /// the stop() race (writes after audioFile is nilled) and the cross-session race
     /// (stale callback from session A writing after session B has started).
     nonisolated private let sessionGeneration = OSAllocatedUnfairLock(initialState: 0)
+    /// Diagnostic timers (first-buffer timeout + recording heartbeat). See
+    /// `CaptureDiagnosticsTimers` for the field contract. Lives off-actor
+    /// because the timer event handlers run on `diagnosticsQueue`.
+    nonisolated private let captureDiagnosticsTimers = OSAllocatedUnfairLock(
+        initialState: CaptureDiagnosticsTimers()
+    )
+    nonisolated private let diagnosticsQueue = DispatchQueue(
+        label: "com.macparakeet.audio-recorder.diagnostics",
+        qos: .utility
+    )
     private var outputURL: URL?
     private var recording = false
     private var starting = false
@@ -81,6 +113,15 @@ public actor AudioRecorder {
     /// Minimum samples before sending to STT.
     /// FluidAudio requires at least 1 second of 16kHz audio (16,000 samples).
     private static let minimumSamples = 16_000
+
+    /// Time after `engine_started` to wait for the first buffer before
+    /// emitting `dictation_capture_no_buffers_within_timeout`. Mirrors the
+    /// 2 s value used by `MicrophoneCapture.scheduleSilentBufferWatchdog`.
+    private static let firstBufferTimeoutSeconds: TimeInterval = 2.0
+    /// Cadence for the recording heartbeat log. Long enough that short
+    /// dictations (< 5 s) don't add log noise; short enough that a stalled
+    /// 18 s recording produces ~3 heartbeats showing `input_buffers=0`.
+    private static let heartbeatIntervalSeconds: TimeInterval = 5.0
 
     public init(
         sharedStream: SharedMicrophoneStream,
@@ -221,6 +262,7 @@ public actor AudioRecorder {
                 return true
             }
             if shouldLogFirstBuffer {
+                self.markFirstBufferReceivedForDiagnostics()
                 let sr = bufferFormat.sampleRate
                 let ch = bufferFormat.channelCount
                 let commonFormat = bufferFormat.commonFormat.rawValue
@@ -383,12 +425,23 @@ public actor AudioRecorder {
         self.recording = true
         self.sharedSubscriberToken = token
 
+        let liveFormat = sharedStream.inputFormat
+        let liveSampleRate = liveFormat?.sampleRate ?? 0
+        let liveChannelCount = liveFormat?.channelCount ?? 0
+        let defaultInput = AudioCaptureDiagnostics.defaultInputDeviceLabel()
         AudioCaptureDiagnostics.append(
-            "dictation_capture_engine_started file=\(url.lastPathComponent)"
+            "dictation_capture_engine_started file=\(url.lastPathComponent) default_input=\(defaultInput) sr=\(liveSampleRate) ch=\(liveChannelCount)"
         )
         logger.info(
             "dictation_capture_started file=\(url.lastPathComponent, privacy: .public)"
         )
+
+        // Diagnostic instrumentation. Strictly log-only — these timers fire
+        // observability events and never abort the recording. Treating the
+        // tap-silence condition as "the user's recording is over" would mask
+        // a regression behind a friendlier error message; we want to surface
+        // the regression instead. See journal/2026-05-03-dictation-silent-stall.md.
+        armCaptureDiagnostics(generation: tapGeneration)
     }
 
     /// Stop recording and return the path to the recorded WAV file.
@@ -400,6 +453,9 @@ public actor AudioRecorder {
             // in-flight start cannot claim a recording after cancellation.
             sessionGeneration.withLock { $0 += 1 }
             starting = false
+            AudioCaptureDiagnostics.append(
+                "dictation_capture_start_cancelled_during_subscribe"
+            )
             throw AudioProcessorError.recordingFailed("Not recording")
         }
         guard recording else {
@@ -419,6 +475,7 @@ public actor AudioRecorder {
             // the user stopped recording.
             sharedProcessingQueue.sync {}
             sessionGeneration.withLock { $0 += 1 }
+            disarmCaptureDiagnostics()
         }
         audioFile = nil
         recording = false
@@ -462,6 +519,94 @@ public actor AudioRecorder {
             return nil
         }
         return size
+    }
+
+    // MARK: - Capture diagnostics (log-only)
+
+    /// Arm the first-buffer timeout and recording heartbeat. Both are
+    /// log-only; firing them does not affect the recording.
+    ///
+    /// `armedGeneration` (captured by both closures) is the value of
+    /// `sessionGeneration` at the moment `start()` succeeded. If the closure
+    /// later finds the live generation has moved past it, a `stop()` already
+    /// raced ahead — in that case the closure bails out without logging.
+    /// Without that guard, a heartbeat fired between `cancel()` and the
+    /// queued event handler running could log against a session that has
+    /// already ended.
+    private func armCaptureDiagnostics(generation: Int) {
+        let stream = sharedStream
+        let armedGeneration = generation
+        let firstBufferItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            let shouldFire = self.captureDiagnosticsTimers.withLock { state -> Bool in
+                guard state.armedGeneration == armedGeneration else { return false }
+                guard !state.firstBufferSeen else { return false }
+                state.firstBufferTimeout = nil
+                return true
+            }
+            guard shouldFire else { return }
+            guard self.sessionGeneration.withLock({ $0 }) == armedGeneration else { return }
+            let isRunning = stream.diagnostics.engineRunning
+            let defaultInput = AudioCaptureDiagnostics.defaultInputDeviceLabel()
+            AudioCaptureDiagnostics.append(
+                "dictation_capture_no_buffers_within_timeout isRunning=\(isRunning) default_input=\(defaultInput)"
+            )
+        }
+
+        let timer = DispatchSource.makeTimerSource(queue: diagnosticsQueue)
+        timer.schedule(
+            deadline: .now() + Self.heartbeatIntervalSeconds,
+            repeating: Self.heartbeatIntervalSeconds
+        )
+        timer.setEventHandler { [weak self] in
+            guard let self else { return }
+            guard self.sessionGeneration.withLock({ $0 }) == armedGeneration else { return }
+            let metrics = self.runtimeMetrics.withLock { $0 }
+            let isRunning = stream.diagnostics.engineRunning
+            let defaultInput = AudioCaptureDiagnostics.defaultInputDeviceLabel()
+            AudioCaptureDiagnostics.append(
+                "dictation_capture_heartbeat input_buffers=\(metrics.inputBufferCount) input_frames=\(metrics.inputFrameCount) isRunning=\(isRunning) default_input=\(defaultInput)"
+            )
+        }
+
+        captureDiagnosticsTimers.withLock { state in
+            state.firstBufferTimeout?.cancel()
+            state.heartbeatTimer?.cancel()
+            state.firstBufferSeen = false
+            state.firstBufferTimeout = firstBufferItem
+            state.heartbeatTimer = timer
+            state.armedGeneration = armedGeneration
+        }
+        diagnosticsQueue.asyncAfter(
+            deadline: .now() + Self.firstBufferTimeoutSeconds,
+            execute: firstBufferItem
+        )
+        timer.resume()
+    }
+
+    /// Cancel both timers. Called from `stop()` and from the no-op-arming
+    /// paths so the lock state is always clean for the next `start()`.
+    private func disarmCaptureDiagnostics() {
+        captureDiagnosticsTimers.withLock { state in
+            state.firstBufferTimeout?.cancel()
+            state.firstBufferTimeout = nil
+            state.heartbeatTimer?.cancel()
+            state.heartbeatTimer = nil
+            state.firstBufferSeen = false
+            state.armedGeneration = -1
+        }
+    }
+
+    /// Called from the audio tap path on the very first buffer of a
+    /// session. Cancels the first-buffer timeout so it doesn't fire
+    /// behind a healthy recording. The heartbeat continues — its job is
+    /// to detect mid-session stalls, not just startup ones.
+    nonisolated fileprivate func markFirstBufferReceivedForDiagnostics() {
+        captureDiagnosticsTimers.withLock { state in
+            state.firstBufferSeen = true
+            state.firstBufferTimeout?.cancel()
+            state.firstBufferTimeout = nil
+        }
     }
 }
 

--- a/Sources/MacParakeetCore/Audio/AudioRecorder.swift
+++ b/Sources/MacParakeetCore/Audio/AudioRecorder.swift
@@ -46,7 +46,10 @@ private struct RecordingRuntimeMetrics: Sendable {
 /// the moral equivalent — the lock owner has exclusive access.
 private struct CaptureDiagnosticsTimers {
     var firstBufferTimeout: DispatchWorkItem?
-    var firstBufferSeen: Bool = false
+    /// Generation that delivered its first buffer. This may be set before
+    /// timers are armed because AVAudioEngine can deliver a tap buffer before
+    /// `SharedMicrophoneStream.subscribe` returns to `start()`.
+    var firstBufferSeenGeneration: Int?
     var heartbeatTimer: DispatchSourceTimer?
     /// Session generation captured when the timers were armed. The fired
     /// closures bail out if the current generation has moved past this,
@@ -262,7 +265,7 @@ public actor AudioRecorder {
                 return true
             }
             if shouldLogFirstBuffer {
-                self.markFirstBufferReceivedForDiagnostics()
+                self.markFirstBufferReceivedForDiagnostics(generation: tapGeneration)
                 let sr = bufferFormat.sampleRate
                 let ch = bufferFormat.channelCount
                 let commonFormat = bufferFormat.commonFormat.rawValue
@@ -540,7 +543,7 @@ public actor AudioRecorder {
             guard let self else { return }
             let shouldFire = self.captureDiagnosticsTimers.withLock { state -> Bool in
                 guard state.armedGeneration == armedGeneration else { return false }
-                guard !state.firstBufferSeen else { return false }
+                guard state.firstBufferSeenGeneration != armedGeneration else { return false }
                 state.firstBufferTimeout = nil
                 return true
             }
@@ -569,18 +572,24 @@ public actor AudioRecorder {
             )
         }
 
-        captureDiagnosticsTimers.withLock { state in
+        let shouldScheduleFirstBufferTimeout = captureDiagnosticsTimers.withLock { state -> Bool in
             state.firstBufferTimeout?.cancel()
             state.heartbeatTimer?.cancel()
-            state.firstBufferSeen = false
-            state.firstBufferTimeout = firstBufferItem
+            let alreadySawFirstBuffer = state.firstBufferSeenGeneration == armedGeneration
+            if !alreadySawFirstBuffer {
+                state.firstBufferSeenGeneration = nil
+            }
+            state.firstBufferTimeout = alreadySawFirstBuffer ? nil : firstBufferItem
             state.heartbeatTimer = timer
             state.armedGeneration = armedGeneration
+            return !alreadySawFirstBuffer
         }
-        diagnosticsQueue.asyncAfter(
-            deadline: .now() + Self.firstBufferTimeoutSeconds,
-            execute: firstBufferItem
-        )
+        if shouldScheduleFirstBufferTimeout {
+            diagnosticsQueue.asyncAfter(
+                deadline: .now() + Self.firstBufferTimeoutSeconds,
+                execute: firstBufferItem
+            )
+        }
         timer.resume()
     }
 
@@ -592,7 +601,7 @@ public actor AudioRecorder {
             state.firstBufferTimeout = nil
             state.heartbeatTimer?.cancel()
             state.heartbeatTimer = nil
-            state.firstBufferSeen = false
+            state.firstBufferSeenGeneration = nil
             state.armedGeneration = -1
         }
     }
@@ -601,9 +610,10 @@ public actor AudioRecorder {
     /// session. Cancels the first-buffer timeout so it doesn't fire
     /// behind a healthy recording. The heartbeat continues — its job is
     /// to detect mid-session stalls, not just startup ones.
-    nonisolated fileprivate func markFirstBufferReceivedForDiagnostics() {
+    nonisolated fileprivate func markFirstBufferReceivedForDiagnostics(generation: Int) {
         captureDiagnosticsTimers.withLock { state in
-            state.firstBufferSeen = true
+            state.firstBufferSeenGeneration = generation
+            guard state.armedGeneration == generation else { return }
             state.firstBufferTimeout?.cancel()
             state.firstBufferTimeout = nil
         }

--- a/Sources/MacParakeetCore/Audio/MicrophoneEnginePlatform.swift
+++ b/Sources/MacParakeetCore/Audio/MicrophoneEnginePlatform.swift
@@ -64,6 +64,15 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
     private var audioEngine = AVAudioEngine()
     private var running: Bool = false
     private var lastSucceededAttemptLocked: MeetingInputDeviceAttempt?
+    /// Token for the `AVAudioEngine.configurationChangeNotification` observer
+    /// installed on the current `audioEngine` instance. Cleared on
+    /// `tearDown` / `resetEngine` / `replaceEngineAfterFailure` so the
+    /// next instance gets its own observer. Recorded here purely to
+    /// surface the signal in `dictation-audio.log` — Core Audio sends
+    /// this when the input chain reconfigures (default-input change,
+    /// format change, sample-rate change), which is the most likely
+    /// trigger for the silent tap-stall under investigation.
+    private var configurationChangeObserver: NSObjectProtocol?
 
     public init(deviceAttemptsBuilder: DeviceAttemptsBuilder? = nil) {
         self.deviceAttemptsBuilder = deviceAttemptsBuilder
@@ -89,6 +98,9 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
             } catch {
                 logger.error(
                     "shared_mic_engine_input_format_failed reason=\(error.localizedDescription, privacy: .public)"
+                )
+                AudioCaptureDiagnostics.append(
+                    "shared_mic_engine_input_format_failed reason=\"\(error.localizedDescription)\""
                 )
                 return nil
             }
@@ -133,6 +145,9 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
                     logger.warning(
                         "shared_mic_engine_input_device_set_failed source=\(attempt.source.logValue, privacy: .public) id=\(attempt.deviceID, privacy: .public)"
                     )
+                    AudioCaptureDiagnostics.append(
+                        "shared_mic_engine_input_device_set_failed source=\(attempt.source.logValue) id=\(attempt.deviceID)"
+                    )
                     if lastError == nil {
                         lastError = AVAudioEngineMicrophonePlatformError.deviceSetFailed(attempt)
                     }
@@ -151,11 +166,17 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
                     logger.info(
                         "shared_mic_engine_input_device_started source=\(attempt.source.logValue, privacy: .public) id=\(attempt.deviceID, privacy: .public) name=\(name, privacy: .public) vpio=\(vpioEnabled, privacy: .public)"
                     )
+                    AudioCaptureDiagnostics.append(
+                        "shared_mic_engine_input_device_started source=\(attempt.source.logValue) id=\(attempt.deviceID) name=\(name) vpio=\(vpioEnabled)"
+                    )
                     return
                 } catch {
                     lastError = error
                     logger.warning(
                         "shared_mic_engine_input_device_start_failed source=\(attempt.source.logValue, privacy: .public) id=\(attempt.deviceID, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
+                    )
+                    AudioCaptureDiagnostics.append(
+                        "shared_mic_engine_input_device_start_failed source=\(attempt.source.logValue) id=\(attempt.deviceID) error=\"\(error.localizedDescription)\""
                     )
                     // startEngineLocked already replaces the engine on
                     // failure, so nothing more to reset here.
@@ -171,6 +192,7 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
             guard running else { return }
             tearDownLocked()
             logger.info("shared_mic_engine_stopped")
+            AudioCaptureDiagnostics.append("shared_mic_engine_stopped")
         }
     }
 
@@ -260,9 +282,11 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
             throw error
         }
         running = true
+        installConfigurationChangeObserverLocked()
     }
 
     private func tearDownLocked() {
+        removeConfigurationChangeObserverLocked()
         let inputNode = audioEngine.inputNode
         try? catchingObjCException {
             inputNode.removeTap(onBus: 0)
@@ -284,6 +308,7 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
     /// Reset between failed device attempts (no tap installed yet, just
     /// hand back a fresh engine for the next try).
     private func resetEngineLocked() {
+        removeConfigurationChangeObserverLocked()
         try? catchingObjCException {
             audioEngine.stop()
         }
@@ -293,12 +318,61 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
     }
 
     private func replaceEngineAfterFailureLocked() {
+        removeConfigurationChangeObserverLocked()
         try? catchingObjCException {
             audioEngine.stop()
         }
         audioEngine = AVAudioEngine()
         running = false
         lastSucceededAttemptLocked = nil
+    }
+
+    /// Observe `AVAudioEngine.configurationChangeNotification` on the
+    /// current `audioEngine` and log every fire to `dictation-audio.log`.
+    /// Core Audio posts this when the engine's input chain is renegotiated
+    /// out from under us — default-input device change, sample-rate
+    /// change, exclusive-access takeover by another process. Without
+    /// observing it, those events are invisible in our logs and the
+    /// silent tap-stall they can leave behind has no signature beyond
+    /// "buffers stopped arriving."
+    private func installConfigurationChangeObserverLocked() {
+        // Notification name spelled out: `AVAudioEngine.configurationChangeNotification`
+        // is iOS-only; macOS exposes the same notification under its raw
+        // C name. Using the string literal is the portable form.
+        let token = NotificationCenter.default.addObserver(
+            forName: Notification.Name("AVAudioEngineConfigurationChangeNotification"),
+            object: audioEngine,
+            queue: nil
+        ) { [weak self] notification in
+            guard let self else { return }
+            // Read format off the platform queue to avoid racing the
+            // engine state. Use try? — we just want the snapshot, and
+            // failing reads are fine to log as zeros.
+            let snapshot: (sr: Double, ch: AVAudioChannelCount, isRunning: Bool) = self.queue.sync {
+                let format = (try? catchingObjCException {
+                    self.audioEngine.inputNode.outputFormat(forBus: 0)
+                })
+                return (
+                    sr: format?.sampleRate ?? 0,
+                    ch: format?.channelCount ?? 0,
+                    isRunning: self.running
+                )
+            }
+            AudioCaptureDiagnostics.append(
+                "shared_mic_engine_configuration_changed sr=\(snapshot.sr) ch=\(snapshot.ch) isRunning=\(snapshot.isRunning) default_input=\(AudioCaptureDiagnostics.defaultInputDeviceLabel())"
+            )
+            self.logger.info(
+                "shared_mic_engine_configuration_changed sr=\(snapshot.sr, privacy: .public) ch=\(snapshot.ch, privacy: .public) isRunning=\(snapshot.isRunning, privacy: .public)"
+            )
+        }
+        configurationChangeObserver = token
+    }
+
+    private func removeConfigurationChangeObserverLocked() {
+        if let token = configurationChangeObserver {
+            NotificationCenter.default.removeObserver(token)
+            configurationChangeObserver = nil
+        }
     }
 }
 

--- a/Sources/MacParakeetCore/Audio/MicrophoneEnginePlatform.swift
+++ b/Sources/MacParakeetCore/Audio/MicrophoneEnginePlatform.swift
@@ -336,34 +336,30 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
     /// silent tap-stall they can leave behind has no signature beyond
     /// "buffers stopped arriving."
     private func installConfigurationChangeObserverLocked() {
-        // Notification name spelled out: `AVAudioEngine.configurationChangeNotification`
-        // is iOS-only; macOS exposes the same notification under its raw
-        // C name. Using the string literal is the portable form.
         let token = NotificationCenter.default.addObserver(
-            forName: Notification.Name("AVAudioEngineConfigurationChangeNotification"),
+            forName: .AVAudioEngineConfigurationChange,
             object: audioEngine,
             queue: nil
         ) { [weak self] notification in
-            guard let self else { return }
-            // Read format off the platform queue to avoid racing the
-            // engine state. Use try? — we just want the snapshot, and
-            // failing reads are fine to log as zeros.
-            let snapshot: (sr: Double, ch: AVAudioChannelCount, isRunning: Bool) = self.queue.sync {
+            guard let self, let engine = notification.object as? AVAudioEngine else { return }
+            self.queue.async { [weak self, engine] in
+                guard let self else { return }
                 let format = (try? catchingObjCException {
-                    self.audioEngine.inputNode.outputFormat(forBus: 0)
+                    engine.inputNode.outputFormat(forBus: 0)
                 })
-                return (
+                let snapshot = (
                     sr: format?.sampleRate ?? 0,
                     ch: format?.channelCount ?? 0,
                     isRunning: self.running
                 )
+                let defaultInput = AudioCaptureDiagnostics.defaultInputDeviceLabel()
+                AudioCaptureDiagnostics.append(
+                    "shared_mic_engine_configuration_changed sr=\(snapshot.sr) ch=\(snapshot.ch) isRunning=\(snapshot.isRunning) default_input=\(defaultInput)"
+                )
+                self.logger.info(
+                    "shared_mic_engine_configuration_changed sr=\(snapshot.sr, privacy: .public) ch=\(snapshot.ch, privacy: .public) isRunning=\(snapshot.isRunning, privacy: .public)"
+                )
             }
-            AudioCaptureDiagnostics.append(
-                "shared_mic_engine_configuration_changed sr=\(snapshot.sr) ch=\(snapshot.ch) isRunning=\(snapshot.isRunning) default_input=\(AudioCaptureDiagnostics.defaultInputDeviceLabel())"
-            )
-            self.logger.info(
-                "shared_mic_engine_configuration_changed sr=\(snapshot.sr, privacy: .public) ch=\(snapshot.ch, privacy: .public) isRunning=\(snapshot.isRunning, privacy: .public)"
-            )
         }
         configurationChangeObserver = token
     }

--- a/Sources/MacParakeetCore/Audio/SharedMicrophoneStream.swift
+++ b/Sources/MacParakeetCore/Audio/SharedMicrophoneStream.swift
@@ -182,12 +182,14 @@ public final class SharedMicrophoneStream: @unchecked Sendable {
                 }
 
                 if action == .none {
+                    self.emitDiagnosticsLog(transition: "subscribe", wantsVPIO: wantsVPIO)
                     cont.resume(returning: token)
                     return
                 }
 
                 do {
                     try self.executeEngineAction(action)
+                    self.emitDiagnosticsLog(transition: "subscribe", wantsVPIO: wantsVPIO)
                     cont.resume(returning: token)
                 } catch {
                     self.lock.withLock { state in
@@ -199,6 +201,7 @@ public final class SharedMicrophoneStream: @unchecked Sendable {
                         }
                         Self.refreshHandlersSnapshot(&state)
                     }
+                    self.emitDiagnosticsLog(transition: "subscribe_failed", wantsVPIO: wantsVPIO)
                     cont.resume(throwing: SubscribeError.engineStartFailed(error.localizedDescription))
                 }
             }
@@ -230,12 +233,14 @@ public final class SharedMicrophoneStream: @unchecked Sendable {
                 }
 
                 if action == .none {
+                    self.emitDiagnosticsLog(transition: "unsubscribe", wantsVPIO: nil)
                     cont.resume()
                     return
                 }
 
                 do {
                     try self.executeEngineAction(action)
+                    self.emitDiagnosticsLog(transition: "unsubscribe", wantsVPIO: nil)
                 } catch {
                     switch action {
                     case .reconfigureToVPIO:
@@ -254,6 +259,10 @@ public final class SharedMicrophoneStream: @unchecked Sendable {
                         self.logger.error(
                             "shared_mic_engine_reconfigure_failed engine_dead=true reason=\(error.localizedDescription, privacy: .public)"
                         )
+                        AudioCaptureDiagnostics.append(
+                            "shared_mic_engine_reconfigure_failed engine_dead=true reason=\"\(error.localizedDescription)\""
+                        )
+                        self.emitDiagnosticsLog(transition: "unsubscribe_engine_dead", wantsVPIO: nil)
                         // Fire callbacks off-lock and off the engine queue so
                         // a slow handler cannot block future stream operations.
                         if !deathCallbacks.isEmpty {
@@ -267,6 +276,10 @@ public final class SharedMicrophoneStream: @unchecked Sendable {
                         self.logger.error(
                             "shared_mic_engine_stop_failed reason=\(error.localizedDescription, privacy: .public)"
                         )
+                        AudioCaptureDiagnostics.append(
+                            "shared_mic_engine_stop_failed reason=\"\(error.localizedDescription)\""
+                        )
+                        self.emitDiagnosticsLog(transition: "unsubscribe_stop_failed", wantsVPIO: nil)
                     case .startEngine, .none:
                         break
                     }
@@ -393,6 +406,22 @@ public final class SharedMicrophoneStream: @unchecked Sendable {
         case .none:
             break
         }
+    }
+
+    // MARK: - Diagnostics
+
+    /// Emit the current `Diagnostics` snapshot as a single line in
+    /// `dictation-audio.log`. Called from `engineQueue` after every
+    /// transition (subscribe / unsubscribe / failure path) so the
+    /// log captures the state-machine evolution alongside the
+    /// dictation- and meeting-side events. `wantsVPIO` is the request
+    /// flavour for subscribe transitions; nil for unsubscribe.
+    private func emitDiagnosticsLog(transition: String, wantsVPIO: Bool?) {
+        let snapshot = diagnostics
+        let wantsField = wantsVPIO.map { "wants_vpio=\($0)" } ?? "wants_vpio=n/a"
+        AudioCaptureDiagnostics.append(
+            "shared_mic_diagnostics transition=\(transition) \(wantsField) subscribers=\(snapshot.subscriberCount) vpio_subs=\(snapshot.vpioSubscriberCount) engine_running=\(snapshot.engineRunning) vpio_engaged=\(snapshot.vpioEngaged) vpio_deferred=\(snapshot.vpioDeferred) vpio_deferral_count=\(snapshot.vpioDeferralCount)"
+        )
     }
 
     // MARK: - Audio-thread fan-out


### PR DESCRIPTION
## Summary

Intermittent silent tap stall in dictation: press Fn, talk for 10–18 s, release, see "more audio please" because zero buffers arrived. Reproduced 2026-05-03 — file `664D3EA7-…wav`, 18.3 s elapsed, `input_buffers=0` — while captures bracketing it on the same code path worked fine. Almost certainly a regression introduced by PR #189 (shared-mic-engine, Apr 30). The existing log goes silent between `engine_started` and `stop`, so we can't yet tell macOS-side HAL rearbitration apart from a teardown/start window we opened.

**Log-only diagnostic package. No UX change. No recording aborts.** A "microphone isn't responding" toast would mask the regression as a fact of life; the goal is to find what changed and fix *that*.

## What the log looks like now

Three signatures, all unambiguous:

```
HEALTHY (silent user, thinking before speaking)
─────────────────────────────────────────────────────────────────
engine_started file=…  default_input=89:MacBook Pro Microphone  sr=48000  ch=1
first_buffer                                                  ← +108 ms
heartbeat  input_buffers=300  isRunning=true                  ← +5 s
... user thinks → speaks → releases Fn ...
stop  sample_count=N  input_buffers=N  non_silent_buffers=M

STALL (the bug we're hunting)
─────────────────────────────────────────────────────────────────
engine_started file=…  default_input=89:MacBook Pro Microphone  sr=48000  ch=1
              ← no first_buffer ever fires
no_buffers_within_timeout  isRunning=true  default_input=…    ← +2 s
heartbeat  input_buffers=0  isRunning=true                    ← +5 s
heartbeat  input_buffers=0  isRunning=true                    ← +10 s
stop  sample_count=0  input_buffers=0

STALL CORRELATED WITH OS EVENT (cause: macOS,  fix: reactive)
─────────────────────────────────────────────────────────────────
engine_started …
shared_mic_engine_configuration_changed  sr=48000  ch=1  isRunning=true
no_buffers_within_timeout  isRunning=true  …
```

The heartbeat measures **buffer delivery**, not speech — silent users still receive buffers (full of zeros), so they're never conflated with the stall.

## New events (all in `~/Library/Logs/MacParakeet/dictation-audio.log`)

- `dictation_diagnostics_session_start pid=… version=… build=… commit=…` — once at app launch; splits dev-app and `swift test` runs in the shared on-disk log
- `dictation_capture_engine_started … default_input=… sr=… ch=…` — enriched with device + format
- `dictation_capture_no_buffers_within_timeout isRunning=… default_input=…` — fires 2 s after `engine_started` if no buffer arrived; recording continues
- `dictation_capture_heartbeat input_buffers=N input_frames=M isRunning=… default_input=…` — every 5 s while recording
- `dictation_capture_start_cancelled_during_subscribe` — `stop()` raced into `start()` mid-await
- `shared_mic_diagnostics transition=… subscribers=… vpio_engaged=… …` — on every state-machine transition
- `shared_mic_engine_configuration_changed sr=… ch=… isRunning=… default_input=…` — Core Audio renegotiated the input chain (most likely external trigger)
- Mirrored all remaining os.log-only platform events (`shared_mic_engine_stopped`, `_input_device_started`, `_set_failed`, `_start_failed`, `_input_format_failed`, `_reconfigure_failed`, `_stop_failed`) so the on-disk log is self-contained

## Decision rule for the next captured stall

```
       no_buffers_within_timeout
                  │
   ┌──────────────┴──────────────┐
   │                             │
preceded by                  preceded by
configuration_changed?       no signal at all?
   │                             │
   ▼                             ▼
macOS-side cause           our shared-engine
fix: reactive re-tap on    teardown/start window
configuration change       suspect: PR #189
                           in startEngineLocked
```

## Working hypothesis (lead, not proof)

**HAL deactivation during idle, racy wake-up on the freshly-created `AVAudioEngine`.** Pre-#189 dictation owned a long-lived engine; post-#189 the platform tears down and recreates `AVAudioEngine()` on every full unsubscribe. With nothing in our process holding the input device, macOS power-management deactivates the HAL after a short idle. The next `audioEngine.start()` returns success before the HAL has fully re-bound the input chain — engine reports `isRunning=true`, tap is installed against a node with no upstream audio source, no buffers flow.

Confidence: ~60–70 %. The new logging will resolve this — heartbeat showing `input_buffers=0 isRunning=true` plus the **absence** of a `shared_mic_engine_configuration_changed` event during the stall window is strong evidence for the hunch. Two competing hypotheses (residual VPAU state, configuration race) would each leave their own signature; the diagnostic package is built to distinguish them.

**Trigger conditions if the hunch is right.** All three required:
1. Previous dictation/meeting fully ended → no subscribers → engine torn down.
2. No other process holding the mic (no Zoom, Discord, Voice Memos, other transcription apps).
3. Enough idle time for the HAL to deactivate (empirically minutes; probably tens of seconds is enough).

Risk multipliers: battery / Low Power Mode, external Bluetooth/USB mics, just woke from sleep, newer macOS releases. Heavy dictators are basically immune (HAL stays warm). Sporadic dictators on battery with AirPods are the most exposed profile.

**Likely fix when the next stall confirms the hypothesis:** keep the shared engine alive once started, only stopping at app quit. Reverts the lifecycle behavior to what worked pre-#189. Marginal cost: trace mic activity when no one's using dictation. Marginal benefit: no HAL cold-start race.

## Where the log lives & how users share it

`~/Library/Logs/MacParakeet/dictation-audio.log` — same path on every build flavor (dev binary, DMG, eventual TestFlight). Written via `AudioCaptureDiagnostics.append` → `AppPaths.logsDir`. Local only; never auto-uploaded. Telemetry is a separate channel (ADR-012, anonymous counters only, no log content).

When a user reports the stall, ask them to share via either:
- Finder ⌘⇧G → paste `~/Library/Logs/MacParakeet/` → drag `dictation-audio.log` into the issue
- Terminal: `cat ~/Library/Logs/MacParakeet/dictation-audio.log | pbcopy` → paste

Privacy-safe: timestamps, device names, counters. **No audio, no transcripts.** Same content shape that already lives in feedback issues.

**Retention.** `maxLogBytes` is **5 MB** (bumped from 1 MB in this PR — the new heartbeat roughly doubled per-recording log volume). When the file crosses 5 MB it's **deleted** (not rotated). At the new event volume that's tens of days of cumulative recording for a heavy user — enough that a stall reported via the feedback flow still has its surrounding ~30 s context window intact.

## Follow-ups (not in this PR)

- **`dictation.silent_stall` telemetry counter** — fire from the watchdog. One event name, no payload beyond what telemetry already includes. Gives field frequency without exposing log content; pairs with the local log: counter says *how often*, log (when shared) says *why*.
- **Log-snippet capture in the feedback form** — when "audio problem" is picked from the category dropdown, attach the last N lines automatically. Turns every reported stall into actionable data without users needing to know about the log path.

## Why no tests

`MicrophoneCapture.scheduleSilentBufferWatchdog` (the reference watchdog this mirrors) has zero tests for the same reasons: timing-sensitive, observability-only, AVAudioEngine state is hard to fake without flake risk. Adding flaky tests for a log line would be net-negative.

## Test plan

- [x] `swift build --target MacParakeetCore` — clean
- [x] `swift test` — 2205 tests pass, 1 skipped, 0 failures (post-rebase onto `bd62e148`)
- [ ] Dev-app smoke: launch via `scripts/dev/run_app.sh`, dictate a few times, confirm `dictation_diagnostics_session_start` and `heartbeat` lines land at sensible cadence
- [ ] Reviewer: confirm `armCaptureDiagnostics` closures bail via the `sessionGeneration` guard when `stop()` raced ahead
- [ ] Reviewer: confirm the `AVAudioEngineConfigurationChangeNotification` observer is removed in **every** engine teardown path (`tearDownLocked`, `resetEngineLocked`, `replaceEngineAfterFailureLocked`)

## Background

Full diagnosis, regression hypothesis, surrounding-session evidence, and historical log excerpts: `journal/2026-05-03-dictation-silent-stall.md` (private journal, not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)