### PR TITLE
Add per-subsystem READMEs to load-bearing folders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,13 @@ jobs:
           xcodebuild -version
           swift --version
 
+      - name: Check Subsystem README References
+        timeout-minutes: 1
+        run: |
+          mkdir -p .ci-logs
+          set -o pipefail
+          ./scripts/check-readme-references.sh 2>&1 | tee .ci-logs/check-readme-references.log
+
       - name: Cache SwiftPM Dependencies
         uses: actions/cache@v4
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,14 @@ Tests/
 Full spec is in [`spec/`](./spec/). Architectural decisions (locked) are in
 [`spec/adr/`](./spec/adr/). Don't second-guess ADRs.
 
+**Subsystem READMEs.** Load-bearing folders inside
+[`Sources/MacParakeetCore/`](./Sources/MacParakeetCore/) carry their own
+`README.md` capturing non-obvious rules (threading, ordering,
+retention) that aren't visible from grep. **When you're about to edit
+inside one of these folders, read its README first.** Folders with
+READMEs today: `Audio/`, `STT/`, `TextProcessing/`, `Database/`,
+`Licensing/`.
+
 ## Security & Privacy
 
 - **Local-first speech.** STT runs on the Apple Neural Engine. Audio and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,14 @@ pending hands-on end-to-end validation.
 | Cross-agent coding-agent guide | `AGENTS.md` -> slim, convention-following |
 | Downstream agent integration (calling the CLI) | `integrations/README.md` |
 | CLI semver + compatibility policy | `Sources/CLI/CHANGELOG.md` |
+| Subsystem rules (Audio, STT, Database, etc.) | `Sources/MacParakeetCore/<subsystem>/README.md` -> non-obvious threading, ordering, retention rules colocated with the code |
+
+**When working in `Sources/MacParakeetCore/<subsystem>/`, read the
+`README.md` in that folder before reading code.** The READMEs capture
+non-obvious rules — threading invariants, "do not delete this,"
+ordering constraints, ADR cross-references — that aren't visible
+from grep. Folders with READMEs today: `Audio/`, `STT/`,
+`TextProcessing/`, `Database/`, `Licensing/`.
 
 ## Tech Stack (Locked Decisions)
 

--- a/Sources/MacParakeetCore/Audio/README.md
+++ b/Sources/MacParakeetCore/Audio/README.md
@@ -1,0 +1,174 @@
+# Audio
+
+> One mic engine per process, fanned out to dictation and meeting
+> recording. This folder owns capture, format conversion, and on-disk
+> diagnostic logging.
+
+## Entry point
+
+`SharedMicrophoneStream` — the process-wide microphone source. Every
+consumer (dictation, meeting mic) calls
+`subscribe(wantsVPIO:onEngineDeath:handler:)` and receives every
+buffer. The stream owns engine lifecycle, VPIO arbitration, and
+fan-out. There is exactly one instance per process, owned by
+`AppEnvironment`.
+
+## What's here
+
+**Shared mic engine (the core of this folder)**
+- `SharedMicrophoneStream.swift` — fan-out, VPIO state machine,
+  subscriber tokens, `Diagnostics` snapshot. ADR-015 + ADR-016.
+- `MicrophoneEnginePlatform.swift` — `AVAudioEngine` wrapper. Device
+  fallback chain, VPIO toggle, tap install, engine recreation on
+  every teardown (so coreaudiod releases the VPAU aggregate
+  device), `AVAudioEngineConfigurationChangeNotification` observer.
+
+**Mic consumers (each subscribes to the shared stream)**
+- `AudioRecorder.swift` — dictation capture.
+  `subscribe(wantsVPIO: false)`. Writes 16 kHz mono Float32 WAVs to
+  `$TMPDIR/macparakeet/`. Owns the dictation diagnostic timers
+  (first-buffer watchdog + recording heartbeat).
+- `MicrophoneCapture.swift` — meeting microphone capture. Subscribes
+  with `wantsVPIO: true` (typically called with
+  `MeetingMicProcessingMode.vpioPreferred`) and falls back to raw
+  if VPIO is unavailable. Has its own silent-buffer watchdog with a
+  stall observer wired up to the meeting flow.
+
+**Meeting-side audio (independent of the mic stream)**
+- `SystemAudioStream.swift` — meeting system audio via
+  `ScreenCaptureKit` (`SCStream`). Independent of the
+  `AVAudioEngine`. Has its own first-buffer watchdog.
+- `MeetingAudioCaptureService.swift` — composes mic + system audio
+  for meeting recording.
+- `MeetingAudioStorageWriter.swift` — fragmented MP4 writer for
+  meeting source files (ADR-019 crash recovery).
+- `MeetingAudioError.swift`, `MeetingMicProcessingMode.swift` —
+  value types.
+
+**Helpers**
+- `AudioCaptureDiagnostics.swift` — public `append(_:)` to
+  `~/Library/Logs/MacParakeet/dictation-audio.log`. 5 MB cap;
+  delete-on-overflow (not rotated). Used by every file in this
+  folder and by `AppDelegate`'s boot marker.
+- `AudioChunker.swift` — actor that buffers resampled audio for
+  incremental STT (live meeting transcription).
+- `AudioFileConverter.swift` — file-side converter (FFmpeg /
+  AVFoundation) for file/YouTube/meeting transcription inputs.
+- `AudioProcessor.swift` + `AudioProcessorProtocol.swift` — thin
+  facade composing `AudioRecorder` + `AudioFileConverter` behind a
+  single protocol. Useful where a caller wants both the dictation
+  and file-conversion entry points behind one injection seam.
+- `AudioDeviceManager.swift` — Core Audio HAL helpers (default
+  device, set input on engine, list devices).
+- `extractChannelZero` (in `AudioRecorder.swift`),
+  `CMSampleBufferToPCMBuffer.swift`, `PCMBufferToSampleBuffer.swift`,
+  `UncheckedSendableAudioPCMBuffer.swift`,
+  `ObjCExceptionBridge.swift` — pure utilities.
+
+## Cross-references
+
+- ADR-014 — meeting recording (system + mic dual stream, ScreenCaptureKit).
+- ADR-015 — concurrent dictation and meeting recording, the shared
+  mic engine, and the channel-0 mono-extraction rule.
+- ADR-016 — centralized STT scheduler. Audio buffers feed the
+  scheduler; STT lifecycle lives in `../STT/`.
+- ADR-019 — crash-resilient meeting recording; explains the
+  fragmented MP4 writer + lock-file conventions in the meeting
+  audio files above.
+- ADR-021 — engine routing for multilingual STT. Active meetings
+  hold a speech-engine lease; this folder enforces the audio side
+  of that contract by keeping the meeting capture pipeline
+  independent of dictation.
+- `spec/05-audio-pipeline.md` — narrative spec.
+- `journal/2026-05-03-dictation-silent-stall.md` — active
+  regression hunt; the diagnostic logging in `AudioRecorder`,
+  `SharedMicrophoneStream`, and `MicrophoneEnginePlatform` is part
+  of that investigation.
+
+## What to know before editing
+
+**VPIO is sticky once engaged (process-wide).** Once any subscriber
+requests VPIO, it stays on for the engine's lifetime. The state
+machine in `SharedMicrophoneStream.decideSubscribeAction` enforces
+this. Don't try to disengage VPIO mid-session — coreaudiod attaches
+the VPAU aggregate device to the **process**, and toggling VPIO mid-
+flight changes the input format under live subscribers.
+
+**Channel 0 mono extraction is mandatory when VPIO is engaged.** VPIO
+exposes a duplex layout (typically `ch=9`) where only ch[0] is the
+post-AEC processed mono and the rest are reference channels. Use
+`extractChannelZero(from:)` — never let `AVAudioConverter`'s default
+channel reduction average across them. This was the bug PR #189
+fixed; do not regress it.
+
+**The `AVAudioEngine` is recreated on every teardown.** `tearDownLocked`
+in `MicrophoneEnginePlatform` does `audioEngine = AVAudioEngine()`
+deliberately. Releasing the old instance triggers coreaudiod to drop
+the VPAU aggregate device. Long-lived engines inherit duplex layout
+into sibling engines in the same process — exactly the bug PR #189
+fixed. Do not optimize this away by caching the engine.
+
+**Tap closures run on the audio render thread.** No allocation, no
+actor hops, no `await`. State touched from the tap path uses
+`OSAllocatedUnfairLock`-protected nonisolated fields. The buffer
+passed in is valid only for the synchronous duration of the call —
+copy via `copyPCMBufferForAsyncUse` before retaining or dispatching
+async.
+
+**Diagnostic logging is observability-only.** The first-buffer
+watchdog and recording heartbeat in `AudioRecorder` log to
+`dictation-audio.log` but **never** abort the recording. PR #210
+shipped this deliberately; converting any of those signals into a
+user-facing error would mask a regression as a fact of life.
+Telemetry counters can be added separately, but the log path stays
+non-disruptive.
+
+**First-buffer can arrive before timers are armed.** When subscribing
+from an actor, the AVAudioEngine tap can fire its first buffer
+during the `await sharedStream.subscribe(...)` suspension, before
+post-await `armCaptureDiagnostics` runs. State that tracks "have we
+seen the first buffer yet" must be generation-keyed (see
+`firstBufferSeenGeneration` in `AudioRecorder`) and the arming code
+must check it before scheduling the watchdog. Bool flags get reset
+on arm and lose the early buffer.
+
+**Concurrent dictation and meeting recording is supported (ADR-015).**
+A user can dictate while a meeting recording is active. Both flows
+fan out from the same `SharedMicrophoneStream` instance. Don't add
+state that assumes a single consumer at a time.
+
+**System audio is a separate stream.** `SystemAudioStream` uses
+`ScreenCaptureKit`, not `AVAudioEngine`. It does not share lifecycle,
+VPIO state, or the fan-out path with the mic stream. Meeting
+recording composes both via `MeetingAudioCaptureService`.
+
+**The diagnostic log file is shared across processes.** Both the dev
+app and `swift test` write to
+`~/Library/Logs/MacParakeet/dictation-audio.log`. The
+`dictation_diagnostics_session_start` line emitted by `AppDelegate`
+on launch is the only reliable per-process separator. The 5 MB cap
+deletes the file when crossed (no rotation); a heavy user retains
+tens of days of context.
+
+## How to verify a change
+
+- `swift test --filter Audio` — covers the shared stream's state
+  machine, the platform adapter, the recorder, and the diagnostic
+  helpers under deterministic mocks.
+- `swift test --filter SharedMicrophoneStream` — the VPIO state
+  machine specifically.
+- `swift test` — full suite (~100 s). Audio changes ripple into
+  dictation, meeting, and STT scheduler tests.
+- Dev-app smoke (the canonical happy-path check):
+  1. `scripts/dev/run_app.sh`.
+  2. Dictate three times in sequence.
+  3. Start a meeting recording.
+  4. Dictate during the meeting.
+  5. Stop the meeting; dictate once more.
+  6. Inspect `~/Library/Logs/MacParakeet/dictation-audio.log` —
+     expect clean `engine_started → first_buffer → heartbeat → stop`
+     cycles for each dictation and a clean
+     `meeting_mic_capture_started → meeting_mic_first_buffer →
+     meeting_mic_capture_stopped` cycle for the meeting.
+- After a stall report: cross-reference the user's log against the
+  decision tree in PR #210's description.

--- a/Sources/MacParakeetCore/Database/README.md
+++ b/Sources/MacParakeetCore/Database/README.md
@@ -1,0 +1,93 @@
+# Database
+
+> SQLite via GRDB. One file (`macparakeet.db`), one repository per
+> table, inline migrations registered in `DatabaseManager`.
+
+## Entry point
+
+`DatabaseManager` — owns the `DatabaseQueue` and runs migrations on
+init. Every repository takes a `DatabaseManager` (or its `dbQueue`)
+and reads/writes through it. There is one `DatabaseManager` per app
+process.
+
+## What's here
+
+- `DatabaseManager.swift` — connection setup, migrator registration,
+  schema versions. The single source of truth for the database
+  schema.
+- One repository per table:
+  - `DictationRepository.swift` — dictation history + lifetime stats.
+  - `TranscriptionRepository.swift` — file/YouTube/meeting transcriptions.
+  - `CustomWordRepository.swift` — vocabulary entries.
+  - `TextSnippetRepository.swift` — snippets (text + action).
+  - `PromptRepository.swift` — prompt-library entries.
+  - `PromptResultRepository.swift` — saved prompt outputs.
+  - `QuickPromptRepository.swift` — quick-prompt entries (Ask tab).
+  - `ChatConversationRepository.swift` — multi-turn chat history.
+
+## Cross-references
+
+- `spec/01-data-model.md` — the canonical schema spec; mirrors
+  what's in `DatabaseManager`'s migrator. Update both when schema
+  changes.
+- ADR-013 — prompt library + multi-summary architecture (drives
+  several of the repositories above).
+- `Sources/MacParakeetCore/Models/` — the row types each repository
+  reads and writes.
+
+## What to know before editing
+
+**Migrations are inline in `DatabaseManager`, not separate files.**
+Each migration is a `migrator.registerMigration("vX.Y-name") { db in
+... }` block. The naming convention is `vX.Y-<table-or-feature>` so
+the migration ledger doubles as a release-version trail. Migrations
+run once and are never edited after a release ships — to change a
+shipped schema, register a *new* migration that performs the
+adjustment.
+
+**One repository per table. Don't combine tables in one repo.**
+Each repository implements a `…Protocol` so callers can be tested
+against a mock. The repository owns CRUD plus any table-specific
+helpers (FTS search, stats aggregation). Cross-table joins live at
+the service layer, not in repositories.
+
+**Never use raw SQL `WHERE id = ?` with `uuid.uuidString`.**
+GRDB stores UUID values via Codable encoding, which produces a
+representation that is not always equal to `UUID.uuidString`. Use
+GRDB's `fetchOne(key:)` + `update()` pattern for primary-key
+lookups, and `Codable`-aware filter expressions for predicates. A
+raw-SQL UUID lookup will silently miss rows. This has bitten the
+repo before and is the single most common database bug shape we see.
+
+**In-memory databases for tests.** `DatabaseManager()` (no args)
+returns an in-memory queue with the same migrator applied. Use
+this in unit and integration tests — never write to the on-disk
+file from tests. In-memory fixtures are fast, isolated, and don't
+require cleanup.
+
+**Foreign keys are on.** `Configuration().foreignKeysEnabled = true`
+is set in `makeConfiguration`. Migrations and inserts must respect
+foreign-key constraints; cascading deletes are explicit on each FK.
+
+**SQL tracing in DEBUG.** Set the env var `MACPARAKEET_DEBUG_SQL=1`
+to print every executed statement. Useful for diagnosing slow
+queries or accidental N+1 patterns during development; off by
+default and unavailable in release builds.
+
+**Lifetime-stats counter row.** `DictationRepository` maintains a
+singleton row (`lifetime_dictation_stats`) that survives history
+deletion. Increments happen in the same transaction as the
+dictation save (issue #124). If you add a stat, add it to that row,
+the migration for the column, and the `resetLifetimeStats()` path.
+
+## How to verify a change
+
+- `swift test --filter Database` — repository unit tests.
+- `swift test --filter Migration` (where applicable) — confirm new
+  migrations apply cleanly to an empty database and to a
+  previous-version snapshot.
+- `swift test` — full suite. Schema changes ripple through services
+  and view models.
+- Manual: delete `~/Library/Application Support/MacParakeet/macparakeet.db`,
+  relaunch the app, confirm migrations run cleanly from empty.
+  (Only do this on a dev install you don't mind resetting.)

--- a/Sources/MacParakeetCore/Licensing/README.md
+++ b/Sources/MacParakeetCore/Licensing/README.md
@@ -1,0 +1,65 @@
+# Licensing
+
+> Retained purchase-activation plumbing. Currently dormant; **do not delete**.
+
+## Entry point
+
+`EntitlementsService` — the single read/write surface for entitlement
+state. Every code path that asks "is this build licensed?" goes
+through it.
+
+## What's here
+
+- `EntitlementsService.swift` — entitlement state machine; owns trial
+  and licensed transitions and persists to keychain via
+  `KeyValueStore`.
+- `Entitlements.swift` — pure value types describing the entitlement
+  state.
+- `LemonSqueezyLicenseAPI.swift` — network client for license-key
+  activation and validation against LemonSqueezy.
+- `KeychainKeyValueStore.swift` + `KeyValueStore.swift` — generic
+  keychain-backed K/V used by this folder. Not licensing-specific in
+  shape, but currently used only here.
+
+## Cross-references
+
+- ADR-003 — one-time purchase pricing (historical, kept for context).
+- ADR-006 — trial + license activation (historical, kept for context).
+- `CLAUDE.md` § "Known Pitfalls — General" — repeats the
+  do-not-delete rule for project agents.
+
+## What to know before editing
+
+**This is retained future-option code, not dead code.** Current
+public DMG builds are free and GPL-3.0; entitlements are always
+unlocked. The plumbing here exists so a future GPL-compatible paid
+distribution channel can be activated without re-implementing
+licensing from scratch.
+
+**Do not delete `EntitlementsService`, `LemonSqueezyLicenseAPI`,
+entitlement state types, or trial/license telemetry as dead code.**
+This applies to refactors, "cleanup" passes, lint sweeps, and any
+agent that thinks the unused code looks suspicious. The only
+acceptable removal path is: explicit owner direction + an ADR or
+spec update reflecting the decision.
+
+**Do not introduce active gating from these types into user-facing
+flows.** Calling `EntitlementsService.isLicensed` to enable a
+feature is fine if the feature already gates correctly when
+licensed == true (which it always is today). Adding a *new*
+gate on dormant infrastructure is the wrong direction and would
+need owner sign-off.
+
+**Keychain access is not free on first call.** The first read after
+launch can take tens of milliseconds. Cache results in callers if
+hot-pathing.
+
+## How to verify a change
+
+- `swift test --filter EntitlementsService` (and any
+  `LemonSqueezy*` tests that exist).
+- `swift test` — full suite. Licensing changes can ripple through
+  telemetry (entitlement state is included in some events).
+- Manual: confirm a fresh launch still treats the build as licensed
+  (current behaviour) and that no UI surface gates on entitlement
+  state.

--- a/Sources/MacParakeetCore/STT/README.md
+++ b/Sources/MacParakeetCore/STT/README.md
@@ -25,7 +25,9 @@ to one `STTRuntime`; callers do not own model lifecycles directly.
   scheduler, bypassing the process singleton. App code must use the
   shared scheduler from `AppEnvironment`.
 - `STTResult.swift` — value type returned by every transcribe call
-  (text + word-level timing + language).
+  (text, word-level timing, optional detected language, the engine
+  that produced the result, and an optional engine-specific model
+  variant).
 - `WhisperEngine.swift` — WhisperKit wrapper conforming to the same
   shape as the Parakeet path.
 

--- a/Sources/MacParakeetCore/STT/README.md
+++ b/Sources/MacParakeetCore/STT/README.md
@@ -1,0 +1,116 @@
+# STT
+
+> One process-wide speech-to-text control plane. Parakeet (FluidAudio /
+> CoreML) is default; WhisperKit is optional for languages outside
+> Parakeet's coverage.
+
+## Entry point
+
+`STTScheduler` — the public actor every feature submits work to.
+Owns slot assignment, queueing, priority, backpressure, cancellation,
+and progress fan-out. App code reaches it as
+`AppEnvironment.sttScheduler`. The scheduler delegates model lifecycle
+to one `STTRuntime`; callers do not own model lifecycles directly.
+
+## What's here
+
+**Speech control plane**
+- `STTScheduler.swift` — public broker. Job admission, slot scheduling,
+  engine routing, session leases for active meetings.
+- `STTRuntime.swift` — sole owner of the Parakeet `AsrManager`s and
+  the optional `WhisperEngine`. Handles warm-up, model init, cache
+  clearing, shutdown.
+- `STTClient.swift` + `STTClientProtocol.swift` — **CLI / test
+  facade only**. Each `STTClient` instantiates its own runtime and
+  scheduler, bypassing the process singleton. App code must use the
+  shared scheduler from `AppEnvironment`.
+- `STTResult.swift` — value type returned by every transcribe call
+  (text + word-level timing + language).
+- `WhisperEngine.swift` — WhisperKit wrapper conforming to the same
+  shape as the Parakeet path.
+
+**Hotkey state (lives here for testability)**
+- `FnKeyStateMachine.swift` — pure state machine for the Fn-key
+  gesture (double-tap → persistent, hold → push-to-talk, Esc → cancel
+  window).
+- `HotkeyGestureController.swift` — wraps the state machine for the
+  app's hotkey driver.
+- `HotkeyTrigger.swift` — value types describing trigger kinds.
+- `KeyCodeNames.swift` — display strings for keys.
+- `OnboardingProgressParser.swift` — parses FluidAudio model-download
+  progress lines for the onboarding UI.
+
+These hotkey/onboarding files live in `STT/` because they were
+originally tied to the dictation start path and need to be in
+`MacParakeetCore` for cross-target test access. Folder naming is a
+minor historical wart, not a design statement.
+
+## Cross-references
+
+- ADR-001 — Parakeet TDT 0.6B-v3 as primary STT.
+- ADR-007 — FluidAudio CoreML migration; Parakeet runs on the Apple
+  Neural Engine via CoreML.
+- ADR-016 — centralized STT runtime + 2-slot scheduler; this folder
+  is the implementation.
+- ADR-021 — WhisperKit as optional multilingual engine; engine
+  routing and meeting engine leases live in `STTScheduler`.
+- ADR-009 — custom hotkey support (relevant to the hotkey files
+  above).
+- `spec/06-stt-engine.md` — narrative spec.
+- Audio buffers feeding the scheduler: `../Audio/`.
+
+## What to know before editing
+
+**One scheduler per process.** ADR-016 is non-negotiable. App code
+gets `STTScheduler` from `AppEnvironment`. Never instantiate
+`STTRuntime`, `STTScheduler`, or `STTClient` from a feature service
+— that fragments the control plane and breaks admission control.
+The lone exception is `STTClient`, which is intentionally
+self-contained for the CLI and tests.
+
+**Two execution slots, four job classes.** The scheduler exposes
+`dictation`, `meetingFinalize`, `meetingLiveChunk`, and
+`fileTranscription`. Dictation has its own reserved slot so
+interactive latency is preserved. The other three share a
+background slot, with explicit priority: meeting finalize
+> meeting live chunk > file transcription. Backpressure on the
+shared slot drops the lowest-priority pending work.
+
+**Engine routing is per-job.** Parakeet stays default. A subscriber
+can request WhisperKit globally (Settings) or per call (CLI
+`--engine whisper --language ko`). When set globally, dictation
+also routes there; when set per-job, only that job uses Whisper.
+
+**Active meetings hold an engine lease.** Once a meeting recording
+starts, its engine selection is captured for the session's duration.
+Engine switching is blocked while the lease is held — switching
+mid-meeting would split a single recording across two engines'
+output formats, which the transcript assembler does not support.
+The lease releases when the meeting stops or recovery completes.
+
+**Model lifecycle is the runtime's job, not yours.** Don't call
+`AsrManager` directly from app code, don't `Task { try await
+manager.initialize() }`, and don't reach into `STTRuntime`'s
+private state. Warm-up happens automatically (background or
+explicit); use `STTRuntime.observeWarmUpProgress()` to surface UI.
+
+**Hotkey state is pure and testable.** `FnKeyStateMachine` takes
+abstract up/down events with timestamps and emits actions. Don't
+add CGEvent or NSEvent imports here — that machinery lives in the
+GUI target's `Hotkey/` folder and translates real events into the
+state machine's input shape.
+
+## How to verify a change
+
+- `swift test --filter STT` — scheduler, runtime, slot ordering,
+  backpressure, engine routing, lease semantics.
+- `swift test --filter FnKeyStateMachine` — gesture state machine.
+- `swift test` — full suite (~100 s). STT changes ripple through
+  dictation and meeting recording tests.
+- Manual: dev-app smoke covering all four job classes — dictate
+  during a file transcription (file work should yield to
+  dictation), start a meeting and dictate during it, kick off a
+  long file transcription and confirm cancellation works mid-job.
+- For engine routing: run the CLI
+  `swift run macparakeet-cli transcribe --engine whisper --language ja
+  /path/to/japanese.m4a` and confirm Whisper is used.

--- a/Sources/MacParakeetCore/TextProcessing/README.md
+++ b/Sources/MacParakeetCore/TextProcessing/README.md
@@ -1,0 +1,96 @@
+# Text Processing
+
+> Deterministic post-processing for raw STT output. No LLM in the
+> default path; the AI formatter is opt-in and lives behind a separate
+> entry point.
+
+## Entry point
+
+`TextProcessingPipeline` — pure value type, `process(text:customWords:snippets:)`
+returns a `TextProcessingResult`. Same input always produces the same
+output. This is the function called for every dictation in "clean"
+mode.
+
+## What's here
+
+- `TextProcessingPipeline.swift` — the deterministic pipeline. Five
+  steps in fixed order; details below.
+- `TextProcessingResult.swift` — value type returned by the pipeline.
+  Carries the cleaned text, the set of expanded-snippet IDs, and an
+  optional `postPasteAction` for trailing-action snippets.
+- `TextRefinementService.swift` — opt-in LLM refinement (formal,
+  email, code rewrites). Independent of the deterministic pipeline;
+  invoked from dedicated UI flows, not from the dictation hot path.
+- `AIFormatter.swift` — supporting types for `TextRefinementService`
+  (formatter modes, prompts).
+- `TranscriptDerivers.swift` — derives display-side fields
+  (search-friendly text, summaries' rendering helpers, etc.) from
+  stored transcripts. Read-only; doesn't mutate the canonical text.
+
+## Cross-references
+
+- ADR-004 — deterministic pipeline over LLM-based refinement. Captures
+  the *principle* that default cleanup must be deterministic and
+  fast. (The ADR's step table predates the trailing-action step; the
+  code below is authoritative on step count.)
+- `spec/07-text-processing.md` — narrative spec.
+- ADR-011 — the LLM provider model that `TextRefinementService` rides
+  on.
+
+## What to know before editing
+
+**The five pipeline steps run in this fixed order:**
+
+1. **Filler removal.** Strip pure hesitation sounds (`um`, `uh`,
+   `umm`, `uhh`) only. Word-boundary regex, case-insensitive,
+   pre-compiled at type level. The list is intentionally short —
+   anything longer ("like", "you know", "kind of") changes meaning
+   too often to delete by default.
+2. **Custom word replacement.** User-defined `CustomWord` entries.
+   Replaces matches whole-word, case-insensitive, in the order
+   provided. Disabled entries skip silently.
+3. **Trailing action extraction.** If the user's text ends with an
+   action-snippet trigger (snippet whose `action != nil`), strip the
+   trigger from the text and surface the action through
+   `postPasteAction` on the result. Done **before** snippet
+   expansion so the trigger phrase isn't mangled by step 4.
+4. **Text snippet expansion.** Plain text snippets (where
+   `action == nil`) replace their trigger phrases with their bodies.
+5. **Whitespace cleanup.** Collapse repeated spaces, fix punctuation
+   spacing, normalize.
+
+**The order is load-bearing.** Filler removal before custom words
+prevents a custom rule from accidentally matching `"um"` as a
+substring. Action extraction before snippet expansion prevents a
+plain-text snippet from consuming the action trigger. Don't reorder
+without writing a test that exercises every adjacent-step
+interaction.
+
+**The pipeline is a pure function.** No I/O, no side effects, no
+state. This makes it trivial to test exhaustively (see
+`Tests/MacParakeetTests/`) and means you should not introduce
+file/network/logging into the steps. If you need observability, do
+it at the call site, not inside the pipeline.
+
+**Filler removal is intentionally narrow.** Any expansion of the
+`alwaysSafeFillers` list needs a thoughtful test case demonstrating
+it doesn't change meaning. "I want to like Slack the team" must not
+become "I want to Slack the team."
+
+**`TextRefinementService` is a different code path.** It is *not*
+the dictation cleanup path. It handles LLM-powered rewrites the
+user explicitly invokes from a transcript view. Don't conflate the
+two — the deterministic pipeline must remain LLM-free per ADR-004.
+
+## How to verify a change
+
+- `swift test --filter TextProcessing` — covers the pipeline at the
+  step level and end-to-end. Add a focused test for any new behaviour
+  before changing the pipeline body.
+- `swift test` — full suite (~100 s). Pipeline regressions ripple
+  into transcription tests because every dictation runs through it.
+- Manual: dictate something with each kind of trigger (filler word,
+  custom word, text snippet, action snippet) and confirm the result
+  is unsurprising. Edge cases worth checking: empty input, input
+  that's only fillers, snippet that expands into another snippet's
+  trigger (we do not recurse on purpose).

--- a/docs/commit-guidelines.md
+++ b/docs/commit-guidelines.md
@@ -91,6 +91,26 @@ current contents. After the CGEvent Cmd+V is dispatched and a short delay
 - Sources/MacParakeetCore/Services/DictationService.swift (~18)
 ```
 
+## Subsystem READMEs
+
+Some folders under `Sources/MacParakeetCore/` carry a `README.md`
+that captures non-obvious rules (threading, ordering, retention)
+that aren't visible from grep. As of this writing: `Audio/`, `STT/`,
+`TextProcessing/`, `Database/`, `Licensing/`.
+
+**If your commit adds, removes, or renames files in one of those
+folders, update the folder's `README.md` in the same commit.** CI
+runs `scripts/check-readme-references.sh` and fails the build when
+a backticked `.swift` reference no longer resolves — so drift is
+caught at PR time, but only if the PR itself touches code.
+
+The READMEs are not exhaustive listings; they call out the files
+worth orienting around. If you add a new file that introduces a
+non-obvious rule (a threading invariant, a "do not delete this," an
+ordering constraint), document the rule in the README. If you add
+a file whose purpose is self-evident from its name and contents,
+no README change needed.
+
 ## Why This Matters
 
 1. **Git history becomes documentation** -- Rich context lives in version control, not lost chat logs

--- a/scripts/check-readme-references.sh
+++ b/scripts/check-readme-references.sh
@@ -28,12 +28,16 @@ ERRORS=0
 
 while IFS= read -r README; do
   README_DIR="$(dirname "$README")"
-  SWIFT_REFS=$(grep -oE '`[A-Za-z_][A-Za-z0-9_]*\.swift`' "$README" | tr -d '`' | sort -u)
+  # `|| true` so a README with no .swift backticks doesn't fail the
+  # whole script under `set -euo pipefail` (grep exits 1 on no match).
+  SWIFT_REFS=$(grep -oE '`[A-Za-z_][A-Za-z0-9_]*\.swift`' "$README" | tr -d '`' | sort -u || true)
   for ref in $SWIFT_REFS; do
     if [[ -f "$README_DIR/$ref" ]]; then
       continue
     fi
-    if find Sources -type f -name "$ref" -print -quit | grep -q .; then
+    # No `-quit`: BSD find (macOS) doesn't support it. Pipe scan is
+    # fine — Sources/ is small and the script runs in ~150 ms.
+    if find Sources -type f -name "$ref" | grep -q .; then
       continue
     fi
     echo "ERROR: $README references missing file: $ref"

--- a/scripts/check-readme-references.sh
+++ b/scripts/check-readme-references.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Verify backticked .swift references in Sources/**/README.md still exist.
+#
+# Why: per-subsystem READMEs reference Swift files by name (e.g.,
+# `MeetingRecordingService.swift`). When code is renamed or deleted,
+# those references rot silently. This script runs in CI on every code
+# change and fails the build if any reference is broken — making
+# drift visible at PR time, when it's cheapest to fix.
+#
+# Scope: extracts single-backtick tokens ending in `.swift` from each
+# README, resolves them against the README's own folder first, then
+# falls back to a repo-wide Sources/ search. Paths in fenced code
+# blocks (```...```) are also caught, which is fine — they should also
+# resolve.
+#
+# Not in scope: cross-folder relative paths in Markdown links,
+# function names like `extractChannelZero(from:)`, event names
+# like `engine_started`, or any non-`.swift` reference. The dominant
+# drift case is "file got renamed inside the subsystem folder," which
+# this script catches.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+ERRORS=0
+
+while IFS= read -r README; do
+  README_DIR="$(dirname "$README")"
+  SWIFT_REFS=$(grep -oE '`[A-Za-z_][A-Za-z0-9_]*\.swift`' "$README" | tr -d '`' | sort -u)
+  for ref in $SWIFT_REFS; do
+    if [[ -f "$README_DIR/$ref" ]]; then
+      continue
+    fi
+    if find Sources -type f -name "$ref" -print -quit | grep -q .; then
+      continue
+    fi
+    echo "ERROR: $README references missing file: $ref"
+    ERRORS=$((ERRORS + 1))
+  done
+done < <(find Sources -type f -name 'README.md')
+
+if [[ $ERRORS -gt 0 ]]; then
+  echo ""
+  echo "Found $ERRORS missing file reference(s) across Sources/**/README.md."
+  echo "Either update the README or restore the referenced file."
+  exit 1
+fi
+
+echo "All Sources/**/README.md backticked .swift references resolve."


### PR DESCRIPTION
## What this is

Five `README.md` files at the highest-stakes subsystem folders in
`Sources/MacParakeetCore/`, plus a CI-enforced drift check. Pure
docs and one shell script — no code changes.

## Why

The repo has great top-level docs (CLAUDE.md, AGENTS.md, `spec/`,
ADRs, `journal/`). What's missing is *subsystem-local* rules — the
non-obvious threading/ordering/retention invariants an agent
dropping into `Audio/` or `STT/` needs to know before touching code.
Those rules currently live in code comments, ADRs, and incident
journals. This PR pins them next to the code.

## What lands

```
Sources/MacParakeetCore/
├── Audio/         README.md   ← VPIO sticky, ch[0] mono, engine recreate, watchdog rules
├── STT/           README.md   ← 1 control plane, 2 slots, 4 job classes, engine lease
├── TextProcessing/README.md   ← 5-step pipeline, order is load-bearing, pure function
├── Database/      README.md   ← inline migrations, NEVER raw-SQL UUID lookups
├── Licensing/     README.md   ← DO NOT DELETE retained-purchase plumbing
└── …other folders unchanged

scripts/
└── check-readme-references.sh   ← runs in CI; fails when a `.swift` ref no longer resolves

.github/workflows/ci.yml         ← +1 step (runs the script)
AGENTS.md / CLAUDE.md            ← read README.md in subsystem folders before code
docs/commit-guidelines.md        ← update the README in the same commit when files move
```

Total: 5 READMEs (174 / 118 / 96 / 93 / 65 lines), one 51-line shell
script, four small doc additions.

## The template (every README, same shape)

```
# <Subsystem>
> One-line elevator pitch.

## Entry point
## What's here
## Cross-references
## What to know before editing       ← the load-bearing section
## How to verify a change
```

## Drift defense

```
       README references file by backtick
                  │
                  ▼
       file gets renamed / deleted
                  │
        ┌─────────┴──────────┐
        │                    │
   in same PR?         in another PR?
        │                    │
        ▼                    ▼
   author updates    CI fails with:
   the README        "ERROR: <README>
                      references missing
                      file: <name>"
```

`scripts/check-readme-references.sh` runs on every code-touching CI
job (markdown-only PRs already skip CI per existing `paths-ignore`).
~150 ms. Catches the dominant drift case.

## Verification

- [x] `swift build` — clean
- [x] `swift test` — **2210 tests pass**, 0 failures, 1 skipped
- [x] `./scripts/check-readme-references.sh` — clean (positive path)
- [x] Negative path verified: synthetic broken reference produces
      `exit 1` with a clear error message
- [x] Every README claim cross-checked against the actual code and
      relevant ADR before writing — not from memory
- [x] Self-review caught two errors (wrong VPIO enum case;
      unverified "legacy callers" claim) — fixed before commit
- [x] Independent agent fresh-eye review confirmed factual accuracy
- [x] gemini-code-assist bot raised 2 high-severity issues on the
      shell script (`grep` under `set -e`, GNU-only `find -quit`) —
      fixed in `43e0c2e2`, both threads replied

## Out of scope (deliberate)

- `Services/` reorganization — separate decision
- READMEs for self-evident folders (Models, Extensions, Utilities,
  Calendar, MeetingRecordingFlow, DictationFlow, most GUI views)
- Tier-3 candidates (Hotkey, DesignSystem) — defer until friction
- `dictation.silent_stall` telemetry counter — follow-up to PR #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)