### PR TITLE
test(audio): integration test infrastructure for dictation silent-stall regression

### DIFF
--- a/Sources/MacParakeetCore/Audio/MicrophoneEnginePlatform.swift
+++ b/Sources/MacParakeetCore/Audio/MicrophoneEnginePlatform.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import CoreAudio
 import Foundation
 import os
 
@@ -60,6 +61,9 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
         category: "AVAudioEngineMicrophonePlatform"
     )
     private let queue = DispatchQueue(label: "com.macparakeet.shared-mic-platform")
+    private let defaultInputListenerQueue = DispatchQueue(
+        label: "com.macparakeet.shared-mic-platform.default-input-listener"
+    )
     private let deviceAttemptsBuilder: DeviceAttemptsBuilder?
     private var audioEngine = AVAudioEngine()
     private var running: Bool = false
@@ -73,6 +77,7 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
     /// format change, sample-rate change), which is the most likely
     /// trigger for the silent tap-stall under investigation.
     private var configurationChangeObserver: NSObjectProtocol?
+    private var defaultInputChangeObserver: AudioObjectPropertyListenerBlock?
 
     public init(deviceAttemptsBuilder: DeviceAttemptsBuilder? = nil) {
         self.deviceAttemptsBuilder = deviceAttemptsBuilder
@@ -286,10 +291,12 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
         }
         running = true
         installConfigurationChangeObserverLocked()
+        installDefaultInputChangeObserverLocked()
     }
 
     private func tearDownLocked() {
         removeConfigurationChangeObserverLocked()
+        removeDefaultInputChangeObserverLocked()
         let inputNode = audioEngine.inputNode
         try? catchingObjCException {
             inputNode.removeTap(onBus: 0)
@@ -312,6 +319,7 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
     /// hand back a fresh engine for the next try).
     private func resetEngineLocked() {
         removeConfigurationChangeObserverLocked()
+        removeDefaultInputChangeObserverLocked()
         try? catchingObjCException {
             audioEngine.stop()
         }
@@ -322,6 +330,7 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
 
     private func replaceEngineAfterFailureLocked() {
         removeConfigurationChangeObserverLocked()
+        removeDefaultInputChangeObserverLocked()
         try? catchingObjCException {
             audioEngine.stop()
         }
@@ -371,6 +380,49 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
             NotificationCenter.default.removeObserver(token)
             configurationChangeObserver = nil
         }
+    }
+
+    private func installDefaultInputChangeObserverLocked() {
+        guard defaultInputChangeObserver == nil else { return }
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let block: AudioObjectPropertyListenerBlock = { _, _ in
+            AudioCaptureDiagnostics.append(
+                "audio_default_input_changed \(AudioCaptureDiagnostics.defaultInputDeviceSummary())"
+            )
+        }
+        let status = AudioObjectAddPropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            defaultInputListenerQueue,
+            block
+        )
+        guard status == noErr else {
+            AudioCaptureDiagnostics.append(
+                "audio_default_input_listener_failed status=\(status)"
+            )
+            return
+        }
+        defaultInputChangeObserver = block
+    }
+
+    private func removeDefaultInputChangeObserverLocked() {
+        guard let block = defaultInputChangeObserver else { return }
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        AudioObjectRemovePropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            defaultInputListenerQueue,
+            block
+        )
+        defaultInputChangeObserver = nil
     }
 }
 

--- a/Tests/MacParakeetTests/Audio/MicrophoneEngineRealPlatformTests.swift
+++ b/Tests/MacParakeetTests/Audio/MicrophoneEngineRealPlatformTests.swift
@@ -1,0 +1,179 @@
+import AVFoundation
+import os
+import XCTest
+@testable import MacParakeetCore
+
+/// Integration tests that drive the real `AVAudioEngineMicrophonePlatform`
+/// against a real microphone, verifying the contract `SharedMicrophoneStream`
+/// is supposed to enforce per ADR-015 and PR #189:
+///
+///   Subscribe → buffers arrive within deadline, regardless of prior state.
+///
+/// These complement the existing mock-based `SharedMicrophoneStreamTests`,
+/// which exercise orchestration but cannot reach the real macOS HAL where
+/// the `2026-05-03` silent-tap-stall bug lives. See:
+///   - `journal/2026-05-03-dictation-silent-stall.md` (diagnosis)
+///   - `plans/active/2026-05-dictation-stall-integration-tests.md` (this plan)
+///   - PR #210 (passive instrumentation that paired with this work)
+///
+/// ## Running
+///
+/// Default `swift test` skips this suite. To run:
+///
+/// ```
+/// MACPARAKEET_HARDWARE_TESTS=1 swift test \
+///     --filter MicrophoneEngineRealPlatformTests
+/// ```
+///
+/// The 3-minute idle-gap test is additionally gated on
+/// `MACPARAKEET_SLOW_HARDWARE_TESTS=1` so a normal hardware run stays under
+/// ~30 seconds.
+///
+/// ## Why these can't run in CI
+///
+/// Real microphone access requires TCC permission for the test runner and a
+/// live (or virtual) input device on the host. Headless CI has neither.
+/// Wiring this into CI would mean per-runner mic provisioning plus
+/// non-deterministic outputs — both bigger problems than this suite solves.
+final class MicrophoneEngineRealPlatformTests: XCTestCase {
+
+    /// First-buffer deadline. Production captures show 100–200 ms first-buffer
+    /// latency on a healthy system; 1 s is a 5× safety margin.
+    private static let firstBufferDeadline: TimeInterval = 1.0
+
+    /// Production buffer size used by both dictation and meeting recording.
+    private static let bufferSize: AVAudioFrameCount = 4096
+
+    private var platform: AVAudioEngineMicrophonePlatform!
+
+    override func setUpWithError() throws {
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["MACPARAKEET_HARDWARE_TESTS"] == "1",
+            "Set MACPARAKEET_HARDWARE_TESTS=1 to run real-platform integration tests."
+        )
+        platform = AVAudioEngineMicrophonePlatform()
+    }
+
+    override func tearDown() async throws {
+        platform?.stopEngine()
+        platform = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Tests
+
+    /// Cold-start case: a fresh `AVAudioEngineMicrophonePlatform` in a fresh
+    /// process must deliver buffers within the deadline. If this fails, the
+    /// platform itself is broken and the bug doesn't even need a transition
+    /// to manifest.
+    func testColdStartDeliversBuffers() async throws {
+        let count = try await subscribeAndAwaitFirstBuffer(vpioEnabled: false)
+        XCTAssertGreaterThan(
+            count, 0,
+            "Cold-start subscribe should deliver at least one buffer within \(Self.firstBufferDeadline)s."
+        )
+    }
+
+    /// Cycle case: subscribe → stop → subscribe. Exercises the engine
+    /// teardown/recreate path that PR #189 introduced. The bug hypothesis is
+    /// that the freshly-created `AVAudioEngine` reports `isRunning = true`
+    /// from `start()` but the HAL hasn't actually attached yet.
+    func testPostCycleDeliversBuffers() async throws {
+        _ = try await subscribeAndAwaitFirstBuffer(vpioEnabled: false)
+        platform.stopEngine()
+
+        let count = try await subscribeAndAwaitFirstBuffer(vpioEnabled: false)
+        XCTAssertGreaterThan(
+            count, 0,
+            "Subscribe immediately after stop should deliver buffers — engine recreate must not lose the input chain."
+        )
+    }
+
+    /// VPIO transition case: subscribe with VPIO enabled (simulates meeting
+    /// recording starting), then with VPIO disabled (simulates dictation).
+    /// This is the path the journal originally suspected before the
+    /// invariant framing widened the hypothesis.
+    func testPostVPIODeliversBuffers() async throws {
+        _ = try await subscribeAndAwaitFirstBuffer(vpioEnabled: true)
+        platform.stopEngine()
+
+        let count = try await subscribeAndAwaitFirstBuffer(vpioEnabled: false)
+        XCTAssertGreaterThan(
+            count, 0,
+            "Subscribe after VPIO teardown should deliver buffers — coreaudiod's VPAU aggregate must release cleanly."
+        )
+    }
+
+    /// Stress: 10 back-to-back subscribe/stop cycles. If any one cycle fails
+    /// to deliver buffers, surface which cycle. Catches timing-flaky variants
+    /// of the bug that pass single-shot tests.
+    func testStressTenCycles() async throws {
+        for cycle in 0..<10 {
+            let count = try await subscribeAndAwaitFirstBuffer(vpioEnabled: false)
+            XCTAssertGreaterThan(
+                count, 0,
+                "Cycle \(cycle) should deliver buffers within \(Self.firstBufferDeadline)s."
+            )
+            platform.stopEngine()
+        }
+    }
+
+    /// Idle-gap case: matches the wall-clock signature of the journal-reported
+    /// stall (2:42 idle gap before the failure). Coreaudiod state during long
+    /// idle is the leading suspect; tests with shorter gaps may not surface it.
+    ///
+    /// Gated separately because it sleeps 3 minutes wall-clock.
+    func testIdleGapDeliversBuffers() async throws {
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["MACPARAKEET_SLOW_HARDWARE_TESTS"] == "1",
+            "Set MACPARAKEET_SLOW_HARDWARE_TESTS=1 to run the 3-minute idle-gap test."
+        )
+
+        _ = try await subscribeAndAwaitFirstBuffer(vpioEnabled: false)
+        platform.stopEngine()
+
+        try await Task.sleep(for: .seconds(180))
+
+        let count = try await subscribeAndAwaitFirstBuffer(vpioEnabled: false)
+        XCTAssertGreaterThan(
+            count, 0,
+            "Subscribe after 3-min idle should deliver buffers — coreaudiod state during long idle must not break the input chain."
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// Configure the platform, install a counting tap, and return the buffer
+    /// count seen by the deadline. Throws if `configureAndStart` itself fails
+    /// (e.g. mic permission denied) — tests should propagate that.
+    private func subscribeAndAwaitFirstBuffer(vpioEnabled: Bool) async throws -> Int {
+        let counter = OSAllocatedUnfairLock(initialState: 0)
+
+        try platform.configureAndStart(
+            vpioEnabled: vpioEnabled,
+            bufferSize: Self.bufferSize
+        ) { _, _ in
+            counter.withLock { $0 += 1 }
+        }
+
+        return await awaitNonZero(counter: counter, timeout: Self.firstBufferDeadline)
+    }
+
+    /// Poll the counter every 20 ms until it goes nonzero or the deadline
+    /// passes. Returns the final count. Polling beats `XCTestExpectation`
+    /// here because the tap closure is `@Sendable` and must remain so —
+    /// expectations under Swift 6 strict concurrency add ceremony for no
+    /// diagnostic gain.
+    private func awaitNonZero(
+        counter: OSAllocatedUnfairLock<Int>,
+        timeout: TimeInterval
+    ) async -> Int {
+        let deadline = ContinuousClock.now + .seconds(timeout)
+        while ContinuousClock.now < deadline {
+            let n = counter.withLock { $0 }
+            if n > 0 { return n }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        return counter.withLock { $0 }
+    }
+}

--- a/Tests/MacParakeetTests/Audio/MicrophoneEngineRealPlatformTests.swift
+++ b/Tests/MacParakeetTests/Audio/MicrophoneEngineRealPlatformTests.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import CoreAudio
 import os
 import XCTest
 @testable import MacParakeetCore
@@ -29,6 +30,10 @@ import XCTest
 /// `MACPARAKEET_SLOW_HARDWARE_TESTS=1` so a normal hardware run stays under
 /// ~30 seconds.
 ///
+/// The tests that mutate system audio state have their own gates:
+/// `MACPARAKEET_STRESS_HARDWARE_TESTS=1` for long cycle stress and
+/// `MACPARAKEET_HAL_MUTATION_TESTS=1` for default-input switching.
+///
 /// ## Why these can't run in CI
 ///
 /// Real microphone access requires TCC permission for the test runner and a
@@ -43,6 +48,9 @@ final class MicrophoneEngineRealPlatformTests: XCTestCase {
 
     /// Production buffer size used by both dictation and meeting recording.
     private static let bufferSize: AVAudioFrameCount = 4096
+
+    private static let halMutationBufferDeadline: TimeInterval = 2.0
+    private static let halMutationDeviceDeadline: TimeInterval = 5.0
 
     private var platform: AVAudioEngineMicrophonePlatform!
 
@@ -104,6 +112,129 @@ final class MicrophoneEngineRealPlatformTests: XCTestCase {
         )
     }
 
+    /// Product-path concurrency case: meeting mic subscribes first with VPIO,
+    /// then dictation joins as a non-VPIO subscriber. This drives the real
+    /// `SharedMicrophoneStream` and verifies both subscribers keep seeing
+    /// buffers from the single VPIO engine.
+    func testConcurrentVPIODeliversBuffersToLateNonVPIOSubscriber() async throws {
+        let stream = SharedMicrophoneStream(platform: platform, bufferSize: Self.bufferSize)
+        let vpioCounter = OSAllocatedUnfairLock(initialState: 0)
+        let dictationCounter = OSAllocatedUnfairLock(initialState: 0)
+        var tokens: [SharedMicrophoneStream.SubscriberToken] = []
+
+        do {
+            let vpioToken = try await stream.subscribe(wantsVPIO: true) { _, _ in
+                vpioCounter.withLock { $0 += 1 }
+            }
+            tokens.append(vpioToken)
+
+            let firstVPIOCount = try await awaitCounterIncrease(
+                counter: vpioCounter,
+                from: 0,
+                timeout: Self.firstBufferDeadline
+            )
+            XCTAssertGreaterThan(firstVPIOCount, 0, "VPIO subscriber should receive buffers.")
+            XCTAssertTrue(stream.diagnostics.vpioEngaged)
+
+            let dictationToken = try await stream.subscribe(wantsVPIO: false) { _, _ in
+                dictationCounter.withLock { $0 += 1 }
+            }
+            tokens.append(dictationToken)
+
+            let dictationCount = try await awaitCounterIncrease(
+                counter: dictationCounter,
+                from: 0,
+                timeout: Self.firstBufferDeadline
+            )
+            XCTAssertGreaterThan(
+                dictationCount,
+                0,
+                "Non-VPIO subscriber joining an active VPIO engine should receive buffers."
+            )
+
+            let secondVPIOCount = try await awaitCounterIncrease(
+                counter: vpioCounter,
+                from: firstVPIOCount,
+                timeout: Self.firstBufferDeadline
+            )
+            XCTAssertGreaterThan(
+                secondVPIOCount,
+                firstVPIOCount,
+                "Existing VPIO subscriber should keep receiving buffers after dictation joins."
+            )
+            XCTAssertEqual(stream.diagnostics.subscriberCount, 2)
+        } catch {
+            await unsubscribeAll(&tokens, from: stream)
+            throw error
+        }
+
+        await unsubscribeAll(&tokens, from: stream)
+    }
+
+    /// Edge-path concurrency case: dictation subscribes first, a meeting wants
+    /// VPIO while dictation is still in flight, then dictation leaves and the
+    /// remaining meeting subscriber must survive the raw -> VPIO promotion.
+    func testDeferredVPIOPromotionDeliversBuffersAfterRawSubscriberLeaves() async throws {
+        let stream = SharedMicrophoneStream(platform: platform, bufferSize: Self.bufferSize)
+        let dictationCounter = OSAllocatedUnfairLock(initialState: 0)
+        let vpioCounter = OSAllocatedUnfairLock(initialState: 0)
+        var tokens: [SharedMicrophoneStream.SubscriberToken] = []
+
+        do {
+            let dictationToken = try await stream.subscribe(wantsVPIO: false) { _, _ in
+                dictationCounter.withLock { $0 += 1 }
+            }
+            tokens.append(dictationToken)
+
+            _ = try await awaitCounterIncrease(
+                counter: dictationCounter,
+                from: 0,
+                timeout: Self.firstBufferDeadline
+            )
+
+            let vpioToken = try await stream.subscribe(wantsVPIO: true) { _, _ in
+                vpioCounter.withLock { $0 += 1 }
+            }
+            tokens.append(vpioToken)
+
+            XCTAssertFalse(stream.diagnostics.vpioEngaged)
+            XCTAssertTrue(stream.diagnostics.vpioDeferred)
+
+            let deferredVPIOCount = try await awaitCounterIncrease(
+                counter: vpioCounter,
+                from: 0,
+                timeout: Self.firstBufferDeadline
+            )
+            XCTAssertGreaterThan(
+                deferredVPIOCount,
+                0,
+                "Deferred VPIO subscriber should still receive raw-engine buffers."
+            )
+
+            await stream.unsubscribe(dictationToken)
+            tokens.removeAll { $0 == dictationToken }
+
+            XCTAssertTrue(stream.diagnostics.vpioEngaged)
+            XCTAssertFalse(stream.diagnostics.vpioDeferred)
+
+            let promotedVPIOCount = try await awaitCounterIncrease(
+                counter: vpioCounter,
+                from: deferredVPIOCount,
+                timeout: Self.firstBufferDeadline
+            )
+            XCTAssertGreaterThan(
+                promotedVPIOCount,
+                deferredVPIOCount,
+                "Remaining VPIO subscriber should keep receiving buffers after promotion."
+            )
+        } catch {
+            await unsubscribeAll(&tokens, from: stream)
+            throw error
+        }
+
+        await unsubscribeAll(&tokens, from: stream)
+    }
+
     /// Stress: 10 back-to-back subscribe/stop cycles. If any one cycle fails
     /// to deliver buffers, surface which cycle. Catches timing-flaky variants
     /// of the bug that pass single-shot tests.
@@ -116,6 +247,129 @@ final class MicrophoneEngineRealPlatformTests: XCTestCase {
             )
             platform.stopEngine()
         }
+    }
+
+    /// Heavier opt-in stress: repeat the product-path shared stream lifecycle
+    /// while alternating raw and VPIO starts. This is intentionally separate
+    /// from the normal hardware gate so routine local runs stay short.
+    func testStressFiftySharedStreamCycles() async throws {
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["MACPARAKEET_STRESS_HARDWARE_TESTS"] == "1",
+            "Set MACPARAKEET_STRESS_HARDWARE_TESTS=1 to run long shared-stream stress."
+        )
+
+        let stream = SharedMicrophoneStream(platform: platform, bufferSize: Self.bufferSize)
+        var tokens: [SharedMicrophoneStream.SubscriberToken] = []
+
+        do {
+            for cycle in 0..<50 {
+                let wantsVPIO = cycle % 2 == 0
+                let counter = OSAllocatedUnfairLock(initialState: 0)
+                let token = try await stream.subscribe(wantsVPIO: wantsVPIO) { _, _ in
+                    counter.withLock { $0 += 1 }
+                }
+                tokens.append(token)
+
+                let count = try await awaitCounterIncrease(
+                    counter: counter,
+                    from: 0,
+                    timeout: Self.firstBufferDeadline
+                )
+                XCTAssertGreaterThan(
+                    count,
+                    0,
+                    "Shared-stream stress cycle \(cycle) should deliver buffers within \(Self.firstBufferDeadline)s."
+                )
+
+                await stream.unsubscribe(token)
+                tokens.removeAll { $0 == token }
+                try await Task.sleep(for: .milliseconds(10))
+            }
+        } catch {
+            await unsubscribeAll(&tokens, from: stream)
+            throw error
+        }
+
+        await unsubscribeAll(&tokens, from: stream)
+    }
+
+    /// HAL mutation case: while the shared stream is running, switch the
+    /// system default input device away and back, then assert buffers still
+    /// arrive. This is the closest active reproducer for the field signature
+    /// where Core Audio configuration changed around the stall window.
+    ///
+    /// Gated separately because it changes the user's default microphone.
+    func testDefaultInputSwitchWhileSharedStreamRunningKeepsDeliveringBuffers() async throws {
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["MACPARAKEET_HAL_MUTATION_TESTS"] == "1",
+            "Set MACPARAKEET_HAL_MUTATION_TESTS=1 to run default-input mutation."
+        )
+
+        guard let originalDefault = AudioDeviceManager.defaultInputDevice(),
+              let alternate = alternateInputDevice(excluding: originalDefault)
+        else {
+            throw XCTSkip("Need at least two input devices to run default-input mutation.")
+        }
+
+        let stream = SharedMicrophoneStream(platform: platform, bufferSize: Self.bufferSize)
+        let counter = OSAllocatedUnfairLock(initialState: 0)
+        var tokens: [SharedMicrophoneStream.SubscriberToken] = []
+
+        do {
+            let token = try await stream.subscribe(wantsVPIO: false) { _, _ in
+                counter.withLock { $0 += 1 }
+            }
+            tokens.append(token)
+
+            _ = try await awaitCounterIncrease(
+                counter: counter,
+                from: 0,
+                timeout: Self.firstBufferDeadline
+            )
+
+            try setSystemDefaultInputDevice(alternate.id)
+            try await waitForDefaultInputDevice(
+                alternate.id,
+                timeout: Self.halMutationDeviceDeadline
+            )
+
+            let switchedBaseline = counter.withLock { $0 }
+            let switchedCount = try await awaitCounterIncrease(
+                counter: counter,
+                from: switchedBaseline,
+                timeout: Self.halMutationBufferDeadline
+            )
+            XCTAssertGreaterThan(
+                switchedCount,
+                switchedBaseline,
+                "Shared stream should keep delivering buffers after default-input switch."
+            )
+
+            try setSystemDefaultInputDevice(originalDefault)
+            try await waitForDefaultInputDevice(
+                originalDefault,
+                timeout: Self.halMutationDeviceDeadline
+            )
+
+            let restoredBaseline = counter.withLock { $0 }
+            let restoredCount = try await awaitCounterIncrease(
+                counter: counter,
+                from: restoredBaseline,
+                timeout: Self.halMutationBufferDeadline
+            )
+            XCTAssertGreaterThan(
+                restoredCount,
+                restoredBaseline,
+                "Shared stream should keep delivering buffers after restoring default input."
+            )
+        } catch {
+            try? setSystemDefaultInputDevice(originalDefault)
+            await unsubscribeAll(&tokens, from: stream)
+            throw error
+        }
+
+        try? setSystemDefaultInputDevice(originalDefault)
+        await unsubscribeAll(&tokens, from: stream)
     }
 
     /// Idle-gap case: matches the wall-clock signature of the journal-reported
@@ -156,24 +410,79 @@ final class MicrophoneEngineRealPlatformTests: XCTestCase {
             counter.withLock { $0 += 1 }
         }
 
-        return await awaitNonZero(counter: counter, timeout: Self.firstBufferDeadline)
+        return try await awaitCounterIncrease(
+            counter: counter,
+            from: 0,
+            timeout: Self.firstBufferDeadline
+        )
     }
 
-    /// Poll the counter every 20 ms until it goes nonzero or the deadline
-    /// passes. Returns the final count. Polling beats `XCTestExpectation`
-    /// here because the tap closure is `@Sendable` and must remain so —
-    /// expectations under Swift 6 strict concurrency add ceremony for no
-    /// diagnostic gain.
-    private func awaitNonZero(
+    /// Poll the counter every 20 ms until it increases past `baseline` or the
+    /// deadline passes. Returns the final count. Polling beats
+    /// `XCTestExpectation` here because the tap closure is `@Sendable` and
+    /// must remain so — expectations under Swift 6 strict concurrency add
+    /// ceremony for no diagnostic gain.
+    private func awaitCounterIncrease(
         counter: OSAllocatedUnfairLock<Int>,
+        from baseline: Int,
         timeout: TimeInterval
-    ) async -> Int {
+    ) async throws -> Int {
         let deadline = ContinuousClock.now + .seconds(timeout)
         while ContinuousClock.now < deadline {
             let n = counter.withLock { $0 }
-            if n > 0 { return n }
-            try? await Task.sleep(for: .milliseconds(20))
+            if n > baseline { return n }
+            try await Task.sleep(for: .milliseconds(20))
         }
         return counter.withLock { $0 }
+    }
+
+    private func unsubscribeAll(
+        _ tokens: inout [SharedMicrophoneStream.SubscriberToken],
+        from stream: SharedMicrophoneStream
+    ) async {
+        while let token = tokens.popLast() {
+            await stream.unsubscribe(token)
+        }
+    }
+
+    private func alternateInputDevice(
+        excluding original: AudioDeviceID
+    ) -> AudioDeviceManager.InputDevice? {
+        let candidates = AudioDeviceManager.inputDevices().filter { $0.id != original }
+        return candidates.first(where: { $0.isBuiltIn })
+            ?? candidates.first(where: { $0.transportType != kAudioDeviceTransportTypeAggregate })
+            ?? candidates.first
+    }
+
+    private func setSystemDefaultInputDevice(_ deviceID: AudioDeviceID) throws {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var mutableDeviceID = deviceID
+        let status = AudioObjectSetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            0,
+            nil,
+            UInt32(MemoryLayout<AudioDeviceID>.size),
+            &mutableDeviceID
+        )
+        guard status == noErr else {
+            throw XCTSkip("Set default input failed with OSStatus \(status).")
+        }
+    }
+
+    private func waitForDefaultInputDevice(
+        _ expected: AudioDeviceID,
+        timeout: TimeInterval
+    ) async throws {
+        let deadline = ContinuousClock.now + .seconds(timeout)
+        while ContinuousClock.now < deadline {
+            if AudioDeviceManager.defaultInputDevice() == expected { return }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        throw XCTSkip("Default input mutation was not observable for device \(expected).")
     }
 }

--- a/plans/active/2026-05-dictation-stall-integration-tests.md
+++ b/plans/active/2026-05-dictation-stall-integration-tests.md
@@ -1,8 +1,17 @@
 # Dictation stall — integration tests against the real audio platform
 
-> Status: **ACTIVE**
+> Status: **ACTIVE — Tier 1 shipped, Tier 2 deferred**
 > Created: 2026-05-03
+> Branch: `plan/dictation-stall-tests`
 > Related: `journal/2026-05-03-dictation-silent-stall.md`, ADR-015, PR #189 (shared-mic-engine), PR #210 (diagnostic package)
+
+## Status (2026-05-03)
+
+- **Tier 1 shipped** — 5 tests in `Tests/MacParakeetTests/Audio/MicrophoneEngineRealPlatformTests.swift`. Run with `MACPARAKEET_HARDWARE_TESTS=1`. The 3-min idle test gates additionally on `MACPARAKEET_SLOW_HARDWARE_TESTS=1`.
+- **Local results**: 4 of 5 tests passed in ~5 s; idle-gap test was skipped. Cold start, post-cycle, post-VPIO, and 10-cycle stress paths are healthy on developer hardware. The bug did not reproduce in these scenarios. Trigger likely needs the 3-min idle gap, cross-process VPAU residue, or system-level events (sleep/wake). Tier 1 still earns its keep as permanent regression coverage for the healthy paths.
+- **Tier 2 deferred** — needs a test seam that doesn't exist today. Two routes documented below; recommended route is a small pure-function extraction.
+- **Tier 3 not started** — gated on Tier 1 idle-gap test result + a manual cross-process repro.
+- **Next**: run `MACPARAKEET_SLOW_HARDWARE_TESTS=1 swift test --filter testIdleGapDeliversBuffers` on a developer machine to test the most likely remaining trigger. If that reproduces, fix path (HAL probe + retry behind `dictationStallRecovery` flag) becomes concrete.
 
 ## Context
 
@@ -64,16 +73,40 @@ Each test uses `OSAllocatedUnfairLock` to count tap callbacks
 thread-safely from the audio render thread. Assert `count > 0` after
 the deadline.
 
-### Tier 2 — watchdog unit test (mock platform, fast)
+### Tier 2 — watchdog unit test (mock platform, fast) — **deferred**
 
-New file: `Tests/MacParakeetTests/Audio/AudioRecorderWatchdogTests.swift`
+> Status: **DEFERRED** — needs a test seam that doesn't exist today.
 
-Uses the existing `MockMicrophonePlatform` to simulate the bug shape
-("configureAndStart succeeds but no buffers ever arrive") and verifies
-PR #210's diagnostic watchdog actually logs
+Original intent: use the existing `MockMicrophonePlatform` to simulate
+the bug shape ("configureAndStart succeeds but no buffers ever arrive")
+and verify PR #210's diagnostic watchdog actually logs
 `dictation_capture_no_buffers_within_timeout`. This catches *future
-regressions in the diagnostic itself* — without it, we'd only know
-the watchdog is broken when a stall happens and we get no log.
+regressions in the diagnostic itself* — without it, we'd only know the
+watchdog is broken when a stall happens and we get no log.
+
+Why deferred: the watchdog has no observable signal short of writing
+to the user's log file. `AudioCaptureDiagnostics.append` writes via a
+private static `FileHandle` to the path computed in
+`AppPaths.logsDir`; there is no injection point, and the firing-decision
+state (`captureDiagnosticsTimers` in `AudioRecorder`) is private and
+unreachable even via `@testable import`.
+
+Two routes available, each requiring source changes outside the
+test-only scope of this plan:
+
+1. **Extract the firing decision to a pure function.** Pull the
+   "should this timer fire?" logic out of
+   `AudioRecorder.scheduleFirstBufferTimeout` into a small testable
+   helper (`WatchdogTimerDecision.shouldFire(armed:firstBufferSeen:current:for:)`).
+   Tiny extraction, comprehensive test coverage, no behavior change.
+   **Recommended.**
+
+2. **Inject a logger sink into `AudioCaptureDiagnostics`.** Make the
+   `append` destination overridable for tests. Broader API change with
+   blast radius across all callers; not justified for one watchdog.
+
+Pick (1) when we're willing to take a small source change. Until then,
+the watchdog is verified by code review and field signal only.
 
 ### Tier 3 — cross-process VPAU residue (optional, if Tier 1 misses)
 

--- a/plans/active/2026-05-dictation-stall-integration-tests.md
+++ b/plans/active/2026-05-dictation-stall-integration-tests.md
@@ -1,26 +1,43 @@
 # Dictation stall — integration tests against the real audio platform
 
-> Status: **ACTIVE — Tier 1 shipped, Tier 2 deferred**
+> Status: **ACTIVE — Tier 1 expanded, Tier 2 deferred**
 > Created: 2026-05-03
-> Branch: `plan/dictation-stall-tests`
+> Branch: `test/dictation-stall-integration`
 > Related: `journal/2026-05-03-dictation-silent-stall.md`, ADR-015, PR #189 (shared-mic-engine), PR #210 (diagnostic package)
 
-## Status (2026-05-03)
+## Status (2026-05-04)
 
-- **Tier 1 shipped** — 5 tests in `Tests/MacParakeetTests/Audio/MicrophoneEngineRealPlatformTests.swift`. Run with `MACPARAKEET_HARDWARE_TESTS=1`. The 3-min idle test gates additionally on `MACPARAKEET_SLOW_HARDWARE_TESTS=1`.
-- **Local results — ALL 5 tests pass on developer hardware**:
-  - `testColdStartDeliversBuffers` ✓ 0.39 s
-  - `testPostCycleDeliversBuffers` ✓ 0.61 s
-  - `testPostVPIODeliversBuffers` ✓ 0.99 s
-  - `testStressTenCycles` ✓ 2.94 s
-  - `testIdleGapDeliversBuffers` ✓ 180.75 s (gated)
+- **Tier 1 shipped + expanded** — 9 tests in `Tests/MacParakeetTests/Audio/MicrophoneEngineRealPlatformTests.swift`. Run the normal hardware subset with `MACPARAKEET_HARDWARE_TESTS=1`.
+- **Normal hardware subset** — 6 tests: cold start, post-cycle, post-VPIO, active-VPIO + late non-VPIO subscriber, deferred-VPIO promotion, and 10-cycle raw stress.
+- **Additional opt-in tests**:
+  - `MACPARAKEET_SLOW_HARDWARE_TESTS=1` — 3-minute idle-gap test.
+  - `MACPARAKEET_STRESS_HARDWARE_TESTS=1` — 50-cycle shared-stream raw/VPIO stress.
+  - `MACPARAKEET_HAL_MUTATION_TESTS=1` — default-input device switch while the shared stream is running. Skips unless at least two input devices are available and the OS reports the default-device mutation back to the test runner. This test mutates the user's selected microphone and restores the original default in cleanup.
+- **Local results after the 2026-05-04 expansion**:
+  - `swift test --filter MicrophoneEngineRealPlatformTests` — 9 skipped, 0 failures (hardware gate off; compile verified)
+  - `MACPARAKEET_HARDWARE_TESTS=1 swift test --filter MicrophoneEngineRealPlatformTests` — 6 passed, 3 skipped, 0 failures in 7.61 s
+    - `testColdStartDeliversBuffers` ✓ 0.395 s
+    - `testConcurrentVPIODeliversBuffersToLateNonVPIOSubscriber` ✓ 0.779 s
+    - `testDeferredVPIOPromotionDeliversBuffersAfterRawSubscriberLeaves` ✓ 1.062 s
+    - `testPostCycleDeliversBuffers` ✓ 0.614 s
+    - `testPostVPIODeliversBuffers` ✓ 0.972 s
+    - `testStressTenCycles` ✓ 3.782 s
+  - `MACPARAKEET_HARDWARE_TESTS=1 MACPARAKEET_STRESS_HARDWARE_TESTS=1 swift test --filter MicrophoneEngineRealPlatformTests` — 7 passed, 2 skipped, 0 failures in 35.21 s
+    - `testStressFiftySharedStreamCycles` ✓ 27.542 s
+  - `MACPARAKEET_HARDWARE_TESTS=1 MACPARAKEET_HAL_MUTATION_TESTS=1 swift test --filter MicrophoneEngineRealPlatformTests/testDefaultInputSwitchWhileSharedStreamRunningKeepsDeliveringBuffers` — skipped: default-input mutation was not observable on this machine
+  - `swift test` — 2220 XCTest, 10 skipped, 0 failures in 99.57 s; 16 Swift Testing tests passed
+- **Earlier idle result retained**: `MACPARAKEET_HARDWARE_TESTS=1 MACPARAKEET_SLOW_HARDWARE_TESTS=1 swift test --filter testIdleGapDeliversBuffers` passed in 180.75 s before this expansion.
+- **2026-05-04 review finding addressed**: the plan listed `testConcurrentVPIODeliversBuffers`, but the test file did not cover the real `SharedMicrophoneStream` concurrent path. The suite now adds:
+  - `testConcurrentVPIODeliversBuffersToLateNonVPIOSubscriber`
+  - `testDeferredVPIOPromotionDeliversBuffersAfterRawSubscriberLeaves`
 - **What this narrows the hypothesis to**: the bug is not triggered by any same-process scenario we can reach from a test — neither engine recreate, nor VPIO transition, nor 3-min idle. The remaining suspects are external triggers we haven't yet exercised:
   1. **HAL configuration change mid-session** (default-input device switch, sample-rate change, virtual-audio routing toggle). The user's reported-stall log shows 9+ `engine_configuration_changed` events, including one with `ch=9` (multichannel virtual-audio). The idle-gap test sits idle without inducing a config change, so it can't catch this.
   2. **Cross-process VPAU residue** (Tier 3 below).
   3. **System-level events** — sleep/wake, exclusive-access takeover by another process.
 - **Tier 2 deferred** — needs a test seam that doesn't exist today.
 - **Tier 3 not started** — feasible follow-up.
-- **Tier 4 (new) — proposed**: HAL config-change injection. Programmatically toggle the default input device via `AudioObjectSetPropertyData(kAudioHardwarePropertyDefaultInputDevice)` mid-session and assert the platform survives + buffers continue. This is the most direct match for the bug signature seen in the field log.
+- **Tier 4 scaffolded**: `testDefaultInputSwitchWhileSharedStreamRunningKeepsDeliveringBuffers` programmatically toggles the default input device via `AudioObjectSetPropertyData(kAudioHardwarePropertyDefaultInputDevice)` mid-session and asserts the shared stream continues delivering buffers. It is gated by `MACPARAKEET_HAL_MUTATION_TESTS=1` because it mutates system audio state.
+- **Instrumentation gap closed in this branch**: `AVAudioEngineMicrophonePlatform` now installs a log-only Core Audio listener for `kAudioHardwarePropertyDefaultInputDevice` while the shared mic engine is running and emits `audio_default_input_changed ...` to `dictation-audio.log`. This completes the decision rule that separates HAL route churn from a fresh-engine attach failure on the next field stall.
 - **Tier 1 earns its keep** as permanent regression coverage for the healthy paths even though it didn't reproduce the bug. Any future change that breaks the contract on these paths fails immediately.
 
 ## Context
@@ -70,14 +87,17 @@ Each test method:
 2. Drives a specific scenario sequence.
 3. Asserts a tap callback fires within 1 second of `configureAndStart`.
 
-| Test method | Scenario |
-|-------------|----------|
-| `testColdStartDeliversBuffers` | Fresh process, single subscribe |
-| `testPostCycleDeliversBuffers` | Subscribe → unsubscribe → resubscribe immediately |
-| `testIdleGapDeliversBuffers` | Subscribe → unsubscribe → wait 3 min → subscribe |
-| `testConcurrentVPIODeliversBuffers` | VPIO=true subscribe still active, then non-VPIO |
-| `testPostVPIODeliversBuffers` | VPIO=true subscribe → unsubscribe → non-VPIO subscribe |
-| `testStressTenCycles` | 10 back-to-back subscribe/unsubscribe pairs |
+| Test method | Scenario | Gate |
+|-------------|----------|------|
+| `testColdStartDeliversBuffers` | Fresh process, single platform start | `MACPARAKEET_HARDWARE_TESTS=1` |
+| `testPostCycleDeliversBuffers` | Platform start → stop → start immediately | `MACPARAKEET_HARDWARE_TESTS=1` |
+| `testPostVPIODeliversBuffers` | Platform VPIO start → stop → raw start | `MACPARAKEET_HARDWARE_TESTS=1` |
+| `testConcurrentVPIODeliversBuffersToLateNonVPIOSubscriber` | Shared stream: VPIO subscriber active, then non-VPIO subscriber joins | `MACPARAKEET_HARDWARE_TESTS=1` |
+| `testDeferredVPIOPromotionDeliversBuffersAfterRawSubscriberLeaves` | Shared stream: raw subscriber blocks VPIO, then leaves and VPIO promotes | `MACPARAKEET_HARDWARE_TESTS=1` |
+| `testStressTenCycles` | 10 back-to-back raw platform start/stop cycles | `MACPARAKEET_HARDWARE_TESTS=1` |
+| `testIdleGapDeliversBuffers` | Platform start → stop → wait 3 min → start | `MACPARAKEET_HARDWARE_TESTS=1 MACPARAKEET_SLOW_HARDWARE_TESTS=1` |
+| `testStressFiftySharedStreamCycles` | 50 shared-stream cycles alternating raw and VPIO | `MACPARAKEET_HARDWARE_TESTS=1 MACPARAKEET_STRESS_HARDWARE_TESTS=1` |
+| `testDefaultInputSwitchWhileSharedStreamRunningKeepsDeliveringBuffers` | Shared stream stays alive across default-input switch away/back | `MACPARAKEET_HARDWARE_TESTS=1 MACPARAKEET_HAL_MUTATION_TESTS=1` |
 
 Each test uses `OSAllocatedUnfairLock` to count tap callbacks
 thread-safely from the audio render thread. Assert `count > 0` after
@@ -132,6 +152,30 @@ Implement as two test fixtures + a shell harness that runs them in
 sequence. Slow, but the only way to falsify the cross-process
 hypothesis.
 
+### Tier 4 — HAL default-input mutation (real platform, opt-in)
+
+> Status: **SCAFFOLDED** — gated by `MACPARAKEET_HAL_MUTATION_TESTS=1`.
+
+`testDefaultInputSwitchWhileSharedStreamRunningKeepsDeliveringBuffers`
+targets the strongest field-log signature we have: Core Audio
+configuration changing around the stall window. It:
+
+1. Requires at least two input devices and an observable default-device switch.
+2. Starts the real `SharedMicrophoneStream`.
+3. Verifies buffers arrive.
+4. Switches the system default input device to an alternate device via
+   `AudioObjectSetPropertyData(kAudioHardwarePropertyDefaultInputDevice)`.
+5. Verifies buffers keep arriving.
+6. Restores the original default input and verifies buffers again.
+
+This is opt-in because it mutates the user's selected microphone. The
+test restores the original default in both success and error paths, but
+it should still be treated as a local forensic tool rather than a
+routine developer-machine check. If Core Audio accepts the mutation call
+but the test runner cannot observe the default-device change, the test
+skips rather than fails; that is an environment limitation, not the
+silent-stall signal.
+
 ## Gating
 
 These tests require real microphone access. They can't run in CI
@@ -143,6 +187,10 @@ runner and provides a real or emulated input device. For now:
 - `swift test` skips them by default.
 - Developers run locally:
   `MACPARAKEET_HARDWARE_TESTS=1 swift test --filter MicrophoneEngineRealPlatform`
+- Slow/forensic additions are separately gated:
+  `MACPARAKEET_SLOW_HARDWARE_TESTS=1`,
+  `MACPARAKEET_STRESS_HARDWARE_TESTS=1`, and
+  `MACPARAKEET_HAL_MUTATION_TESTS=1`.
 - Document the variable in `docs/cli-testing.md` and AGENTS.md once
   the pattern is proven.
 
@@ -155,9 +203,9 @@ runner and provides a real or emulated input device. For now:
 - **CGEvent / accessibility-based keyboard simulation.**
   `FnKeyStateMachine` is directly testable; reaching the OS event
   layer adds fragility for no diagnostic gain.
-- **System-level event injection** (sleep/wake, default-input device
-  toggle via `AudioObjectSetPropertyData`). Hard to make reliable.
-  Keep as manual repro.
+- **System-level event injection** beyond default-input switching
+  (sleep/wake, exclusive-access takeover by another process). Hard to
+  make reliable. Keep as manual repro.
 - **Codifying the new test tier in `spec/09-testing.md`.** Premature
   until the pattern proves out. Revisit once tests land.
 

--- a/plans/active/2026-05-dictation-stall-integration-tests.md
+++ b/plans/active/2026-05-dictation-stall-integration-tests.md
@@ -8,10 +8,20 @@
 ## Status (2026-05-03)
 
 - **Tier 1 shipped** — 5 tests in `Tests/MacParakeetTests/Audio/MicrophoneEngineRealPlatformTests.swift`. Run with `MACPARAKEET_HARDWARE_TESTS=1`. The 3-min idle test gates additionally on `MACPARAKEET_SLOW_HARDWARE_TESTS=1`.
-- **Local results**: 4 of 5 tests passed in ~5 s; idle-gap test was skipped. Cold start, post-cycle, post-VPIO, and 10-cycle stress paths are healthy on developer hardware. The bug did not reproduce in these scenarios. Trigger likely needs the 3-min idle gap, cross-process VPAU residue, or system-level events (sleep/wake). Tier 1 still earns its keep as permanent regression coverage for the healthy paths.
-- **Tier 2 deferred** — needs a test seam that doesn't exist today. Two routes documented below; recommended route is a small pure-function extraction.
-- **Tier 3 not started** — gated on Tier 1 idle-gap test result + a manual cross-process repro.
-- **Next**: run `MACPARAKEET_SLOW_HARDWARE_TESTS=1 swift test --filter testIdleGapDeliversBuffers` on a developer machine to test the most likely remaining trigger. If that reproduces, fix path (HAL probe + retry behind `dictationStallRecovery` flag) becomes concrete.
+- **Local results — ALL 5 tests pass on developer hardware**:
+  - `testColdStartDeliversBuffers` ✓ 0.39 s
+  - `testPostCycleDeliversBuffers` ✓ 0.61 s
+  - `testPostVPIODeliversBuffers` ✓ 0.99 s
+  - `testStressTenCycles` ✓ 2.94 s
+  - `testIdleGapDeliversBuffers` ✓ 180.75 s (gated)
+- **What this narrows the hypothesis to**: the bug is not triggered by any same-process scenario we can reach from a test — neither engine recreate, nor VPIO transition, nor 3-min idle. The remaining suspects are external triggers we haven't yet exercised:
+  1. **HAL configuration change mid-session** (default-input device switch, sample-rate change, virtual-audio routing toggle). The user's reported-stall log shows 9+ `engine_configuration_changed` events, including one with `ch=9` (multichannel virtual-audio). The idle-gap test sits idle without inducing a config change, so it can't catch this.
+  2. **Cross-process VPAU residue** (Tier 3 below).
+  3. **System-level events** — sleep/wake, exclusive-access takeover by another process.
+- **Tier 2 deferred** — needs a test seam that doesn't exist today.
+- **Tier 3 not started** — feasible follow-up.
+- **Tier 4 (new) — proposed**: HAL config-change injection. Programmatically toggle the default input device via `AudioObjectSetPropertyData(kAudioHardwarePropertyDefaultInputDevice)` mid-session and assert the platform survives + buffers continue. This is the most direct match for the bug signature seen in the field log.
+- **Tier 1 earns its keep** as permanent regression coverage for the healthy paths even though it didn't reproduce the bug. Any future change that breaks the contract on these paths fails immediately.
 
 ## Context
 

--- a/plans/active/2026-05-dictation-stall-integration-tests.md
+++ b/plans/active/2026-05-dictation-stall-integration-tests.md
@@ -1,0 +1,178 @@
+# Dictation stall — integration tests against the real audio platform
+
+> Status: **ACTIVE**
+> Created: 2026-05-03
+> Related: `journal/2026-05-03-dictation-silent-stall.md`, ADR-015, PR #189 (shared-mic-engine), PR #210 (diagnostic package)
+
+## Context
+
+The dictation silent stall (May 3, 2026) is a regression: dictation
+worked before some recent change, doesn't always work now. PR #210
+shipped passive instrumentation — watchdog, heartbeat,
+configuration-change observer, HAL listener. That's "wait-and-watch."
+We need an **active reproducer** so we can:
+
+1. Trigger the bug deterministically (or at least, frequently)
+2. Verify any candidate fix actually closes the gap
+3. Catch future regressions before they reach users
+
+The existing `MockMicrophonePlatform`-based unit tests (~150 of them
+in `SharedMicrophoneStreamTests.swift`) cover orchestration. They
+**mock away the bug** — `MockMicrophonePlatform.configureAndStart`
+immediately marks the engine running and stores the tap handler.
+The bug lives one layer below: in the real
+`AVAudioEngineMicrophonePlatform`'s interaction with macOS HAL.
+
+## The contract being tested
+
+`SharedMicrophoneStream` invariant per ADR-015 and PR #189:
+
+> **Subscribe → buffers arrive within deadline, regardless of prior
+> state.**
+
+Operationally:
+
+- Regardless of: cold/warm process start, prior subscribe history,
+  VPIO state of co-subscribers, idle duration since the last subscribe,
+  prior process audio activity.
+- "Within deadline" = first buffer within ~1 second on a healthy
+  system. Real-world successful captures show 100–200 ms first-buffer
+  latency; 1 s gives a 5× safety margin.
+
+## Test design
+
+### Tier 1 — invariant under varied state (real platform, real mic)
+
+New file: `Tests/MacParakeetTests/Audio/MicrophoneEngineRealPlatformTests.swift`
+
+Each test method:
+
+1. Constructs a real `AVAudioEngineMicrophonePlatform` (no mocks).
+2. Drives a specific scenario sequence.
+3. Asserts a tap callback fires within 1 second of `configureAndStart`.
+
+| Test method | Scenario |
+|-------------|----------|
+| `testColdStartDeliversBuffers` | Fresh process, single subscribe |
+| `testPostCycleDeliversBuffers` | Subscribe → unsubscribe → resubscribe immediately |
+| `testIdleGapDeliversBuffers` | Subscribe → unsubscribe → wait 3 min → subscribe |
+| `testConcurrentVPIODeliversBuffers` | VPIO=true subscribe still active, then non-VPIO |
+| `testPostVPIODeliversBuffers` | VPIO=true subscribe → unsubscribe → non-VPIO subscribe |
+| `testStressTenCycles` | 10 back-to-back subscribe/unsubscribe pairs |
+
+Each test uses `OSAllocatedUnfairLock` to count tap callbacks
+thread-safely from the audio render thread. Assert `count > 0` after
+the deadline.
+
+### Tier 2 — watchdog unit test (mock platform, fast)
+
+New file: `Tests/MacParakeetTests/Audio/AudioRecorderWatchdogTests.swift`
+
+Uses the existing `MockMicrophonePlatform` to simulate the bug shape
+("configureAndStart succeeds but no buffers ever arrive") and verifies
+PR #210's diagnostic watchdog actually logs
+`dictation_capture_no_buffers_within_timeout`. This catches *future
+regressions in the diagnostic itself* — without it, we'd only know
+the watchdog is broken when a stall happens and we get no log.
+
+### Tier 3 — cross-process VPAU residue (optional, if Tier 1 misses)
+
+If Tier 1 doesn't reproduce, the bug needs cross-process state.
+A scripted sequence:
+
+1. Process A engages VPIO via `AVAudioEngineMicrophonePlatform`,
+   exits cleanly.
+2. Process B, within ~200 ms, subscribes non-VPIO; assert buffers
+   arrive within 1 s.
+
+Implement as two test fixtures + a shell harness that runs them in
+sequence. Slow, but the only way to falsify the cross-process
+hypothesis.
+
+## Gating
+
+These tests require real microphone access. They can't run in CI
+without infrastructure that grants TCC microphone access to the test
+runner and provides a real or emulated input device. For now:
+
+- Gated via `XCTSkipIf` on a `MACPARAKEET_HARDWARE_TESTS=1` environment
+  variable.
+- `swift test` skips them by default.
+- Developers run locally:
+  `MACPARAKEET_HARDWARE_TESTS=1 swift test --filter MicrophoneEngineRealPlatform`
+- Document the variable in `docs/cli-testing.md` and AGENTS.md once
+  the pattern is proven.
+
+## Out of scope
+
+- **WAV-via-virtual-loopback** (BlackHole, Loopback). Useful for
+  content-correctness tests; this bug is "any buffers at all," so
+  unnecessary. If we need content-deterministic tests later, that's a
+  separate plan.
+- **CGEvent / accessibility-based keyboard simulation.**
+  `FnKeyStateMachine` is directly testable; reaching the OS event
+  layer adds fragility for no diagnostic gain.
+- **System-level event injection** (sleep/wake, default-input device
+  toggle via `AudioObjectSetPropertyData`). Hard to make reliable.
+  Keep as manual repro.
+- **Codifying the new test tier in `spec/09-testing.md`.** Premature
+  until the pattern proves out. Revisit once tests land.
+
+## Success criteria
+
+- At least one Tier 1 test reliably reproduces the stall on a
+  developer machine that has hit the bug in the wild.
+  - **If yes:** we have a deterministic reproducer. Pre-write the
+    candidate fix (HAL probe + retry in `startEngineLocked`),
+    guard with `AppFeatures.dictationStallRecovery`, ship in
+    v0.5.8, flip flag and verify test goes green.
+  - **If no:** bug needs cross-process state or system-level events.
+    Tier 3 + manual repro carry forward.
+- All non-idle Tier 1 tests pass on a healthy system within total
+  wall-clock < 60 s. The idle-gap test intentionally sleeps 3 min and
+  is the only slow one.
+- Watchdog unit test (Tier 2) deterministically passes / fails based
+  on whether `AudioRecorder` arms the watchdog correctly.
+
+## Estimated effort
+
+| Step | Effort |
+|------|--------|
+| Tier 1 scaffolding + first scenario | 1 hour |
+| All Tier 1 scenarios | 2–3 hours |
+| Watchdog unit test (Tier 2) | 30 min |
+| Doc updates (AGENTS.md, cli-testing.md, spec/09 if proven) | 30 min |
+| Tier 3 cross-process (if needed) | 1–2 hours |
+
+**Total: half a day to a day.**
+
+## Open questions
+
+- Should the idle-gap test really wait 3 minutes? Could we artificially
+  trigger the engine teardown that idle would cause (force the shared
+  stream to release, then resubscribe immediately)? Faster test, but
+  narrower coverage — the real bug may need real wall-clock idle for
+  coreaudiod to enter the failure window.
+- Should we also add a HAL probe in `AVAudioEngineMicrophonePlatform`
+  unconditionally — call `inputNode.outputFormat(forBus: 0)` again
+  after `start()` returns, log if it changed? Defensive and low-cost.
+- Where does the "Hardware integration" tier fit in
+  `spec/09-testing.md` long-term? Add an entry once this pattern proves
+  out across at least two investigations.
+
+## Why this is also generally valuable
+
+This investment isn't only for this bug. The audio capture layer is:
+
+- **Opaque** — bugs manifest as silence, not exceptions.
+- **OS-dependent** — the same code can succeed or fail based on
+  HAL state we don't control.
+- **Regression-prone** — every refactor that touches
+  `MicrophoneEnginePlatform` or `SharedMicrophoneStream` has the
+  potential to silently break the contract.
+
+Once a real-platform integration test target exists with the gating
+convention established, future audio investigations get a 30-minute
+on-ramp instead of a 4-hour one. That said, the real-mic constraint
+makes this a developer-machine tool, not a CI safety net — the trick
+is to keep the harness thin enough that maintenance is cheap.


### PR DESCRIPTION
## Summary

Investigation + integration-test scaffolding for the **2026-05-03 dictation silent stall** (AVAudioEngine input tap delivered zero buffers for 18 s; user-visible as "more audio please" after dictating). This PR is **a draft** — it ships the plan, the test infrastructure, and the local results, but **does not contain a fix**. The bug was not reproduced by any same-process scenario these tests can reach. Field signal from PR #210's diagnostic is still required to choose between candidate fix shapes.

This PR is **independent of the v0.6.0 release**. Do not gate the release on it.

## Codex follow-up — 2026-05-04

I reviewed the original 5-test draft and expanded this PR branch into broader real-platform coverage. This section supersedes the older 5-test snapshot below.

### Additional coverage prepared

- Added real `SharedMicrophoneStream` product-path concurrency coverage:
  - `testConcurrentVPIODeliversBuffersToLateNonVPIOSubscriber`
  - `testDeferredVPIOPromotionDeliversBuffersAfterRawSubscriberLeaves`
- Added opt-in stress coverage:
  - `testStressFiftySharedStreamCycles` — 50 shared-stream subscribe/unsubscribe cycles, alternating raw and VPIO starts.
- Added opt-in HAL mutation scaffold:
  - `testDefaultInputSwitchWhileSharedStreamRunningKeepsDeliveringBuffers` — switches the system default input device while the shared stream is running, then restores it.
- Added log-only Core Audio default-input listener in `AVAudioEngineMicrophonePlatform`, emitting `audio_default_input_changed ...` to `dictation-audio.log` while the shared mic engine is running.
- Fixed the async polling helper so cancellation propagates through `try await Task.sleep`.

### Test results run locally

- `swift test --filter MicrophoneEngineRealPlatformTests` — 9 skipped, 0 failures; hardware gate off, compile verified.
- `MACPARAKEET_HARDWARE_TESTS=1 swift test --filter MicrophoneEngineRealPlatformTests` — 6 passed, 3 skipped, 0 failures in 7.61 s.
- `MACPARAKEET_HARDWARE_TESTS=1 MACPARAKEET_STRESS_HARDWARE_TESTS=1 swift test --filter MicrophoneEngineRealPlatformTests` — 7 passed, 2 skipped, 0 failures in 35.21 s.
  - `testStressFiftySharedStreamCycles` passed in 27.542 s.
- `MACPARAKEET_HARDWARE_TESTS=1 MACPARAKEET_HAL_MUTATION_TESTS=1 swift test --filter MicrophoneEngineRealPlatformTests/testDefaultInputSwitchWhileSharedStreamRunningKeepsDeliveringBuffers` — skipped because default-input mutation was not observable on this machine. This is an environment limitation, not a product failure.
- Earlier slow run retained: `MACPARAKEET_HARDWARE_TESTS=1 MACPARAKEET_SLOW_HARDWARE_TESTS=1 swift test --filter testIdleGapDeliversBuffers` passed in 180.75 s.
- Full suite after the follow-up changes: `swift test` — 2220 XCTest cases, 10 skipped, 0 failures in 99.57 s; 16 Swift Testing tests passed.
- `git diff --check` — clean.

### Current read on root cause

No repro under controlled same-process stress. The app looks robust across the paths these tests can actually exercise: cold start, engine recreate, post-VPIO teardown, active VPIO + late dictation subscriber, deferred VPIO promotion, repeated raw cycles, 50 shared-stream raw/VPIO cycles, and 3-minute idle restart.

The proximal field failure remains: `AVAudioEngine.start()` succeeded, but the input tap delivered zero buffers. Since same-process stress did not reproduce it, the remaining likely causes are external or lower-level:

1. HAL/default-input route churn, sample-rate changes, virtual-audio/multichannel route changes.
2. Cross-process VPIO/VPAU residue.
3. Sleep/wake or exclusive mic takeover by another process.
4. Rare fresh-engine/tap attach race after Core Audio reports the engine started.

### Recommendations

- Keep this PR as permanent developer-machine regression coverage; it has value even without a deterministic reproducer.
- Do not treat this PR as a fix. It narrows the bug and improves observability.
- On the next field stall, inspect `dictation-audio.log` around the no-buffer watchdog:
  - If `audio_default_input_changed` or `shared_mic_engine_configuration_changed` appears near the stall, prioritize a HAL-route-change recovery fix: probe input format after config changes, rebuild/retry the engine when first-buffer deadline is missed, and preserve the watchdog evidence.
  - If neither appears, prioritize the fresh-engine/tap attach path and/or a cross-process VPIO residue harness.
- Keep the HAL mutation test opt-in only; it mutates the user’s selected microphone and should not run in routine CI.
- Next best test investment: a small test seam for the watchdog decision path, then a cross-process VPIO residue harness if field logs point there.

## What's in the PR

```
plans/active/2026-05-dictation-stall-integration-tests.md           ← the plan (status section + tier breakdown)
Tests/MacParakeetTests/Audio/MicrophoneEngineRealPlatformTests.swift ← Tier 1 — 5 integration tests
```

### Tier 1 — real-platform integration tests (shipped)

5 tests that drive the real `AVAudioEngineMicrophonePlatform` (no mocks) and verify the contract from ADR-015 + PR #189 — *"subscribe → buffers within deadline, regardless of prior state."*

| Test | Local result |
|------|-------------|
| `testColdStartDeliversBuffers` | ✓ 0.39 s |
| `testPostCycleDeliversBuffers` | ✓ 0.61 s |
| `testPostVPIODeliversBuffers` | ✓ 0.99 s |
| `testStressTenCycles` | ✓ 2.94 s |
| `testIdleGapDeliversBuffers` (3-min idle) | ✓ 180.75 s |

Gated behind `MACPARAKEET_HARDWARE_TESTS=1` (real mic required, can't run in CI). The 3-min idle test gates additionally on `MACPARAKEET_SLOW_HARDWARE_TESTS=1`.

### Tier 2 — watchdog unit test (deferred)

`AudioCaptureDiagnostics.append` writes directly to a hardcoded log path with no test seam. The watchdog state in `AudioRecorder` is private. Plan documents two routes for adding the seam (extract pure decision function — recommended; or inject a logger sink — broader). Deferred until we're willing to take a small source change.

### Tier 3 — cross-process VPAU residue (not started)

Plan documents the shape; would need two test fixtures + a shell harness.

### Tier 4 — HAL config-change injection (proposed)

Added to the plan after Tier 1 results came in. Field log shows 9+ `engine_configuration_changed` events including a `ch=9` multichannel-routing transition. The 3-min idle-gap test sits idle without inducing one, so it can't catch this signature. Tier 4 would programmatically toggle the default input device via `AudioObjectSetPropertyData` mid-session and assert the platform survives. Has setup risk (needs to restore the user's original default in `tearDown` unconditionally) — not auto-spawned.

## What this narrows

The bug is **not** triggered by any same-process scenario — neither cold start, nor engine teardown→recreate, nor VPIO transition, nor 10-cycle stress, nor 3-min idle. Remaining suspects are **external triggers**:

1. HAL configuration change mid-session (most likely match for the field signature)
2. Cross-process VPAU residue from `swift test`
3. System-level events — sleep/wake, exclusive-access takeover by another process

## Why this still ships value even without reproducing the bug

The 5 tests are now **permanent regression coverage** for the contract `SharedMicrophoneStream` is supposed to enforce. Any future change that breaks the platform's healthy paths (e.g., reverting PR #189-style engine recreation, or refactoring `MicrophoneEnginePlatform`) fails immediately on a developer machine — 5 seconds wall-clock for the fast tests.

## Test plan

- [x] `swift build` clean
- [x] `MACPARAKEET_HARDWARE_TESTS=1 swift test --filter MicrophoneEngineRealPlatformTests` — 4/5 pass in 4.94 s (idle test skipped)
- [x] `MACPARAKEET_HARDWARE_TESTS=1 MACPARAKEET_SLOW_HARDWARE_TESTS=1 swift test --filter testIdleGapDeliversBuffers` — passed in 180.75 s

## Background

- `journal/2026-05-03-dictation-silent-stall.md` (gitignored, on-disk) — original diagnosis + the appended "invariant framing" refinement
- ADR-015 — concurrent dictation + meeting recording (the contract being verified)
- PR #189 — shared-mic-engine (the regression candidate)
- PR #210 — diagnostic logging (this PR's passive counterpart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)