### PR TITLE
Pin Transcribe footer to a single quote

### DIFF
--- a/Sources/MacParakeet/Views/Transcription/TranscribeView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscribeView.swift
@@ -17,7 +17,10 @@ struct TranscribeView: View {
     /// Fixed footer attribution. Previously rotated through 19 randomly-picked
     /// quotes per view init; pinned to a single quote until the rotation
     /// system has a clear product role.
-    private static let inspirationQuote = "Be the change you wish to see in the world."
+    ///
+    /// Typed as `LocalizedStringKey` so `Text(_:)` uses the localization-aware
+    /// initializer rather than the raw `String` overload.
+    private static let inspirationQuote: LocalizedStringKey = "Be the change you wish to see in the world."
 
     private enum PipelineStep: CaseIterable {
         case download

--- a/Sources/MacParakeet/Views/Transcription/TranscribeView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscribeView.swift
@@ -13,45 +13,11 @@ struct TranscribeView: View {
     var onRecordMeeting: () -> Void
     @State private var showCancelConfirmation = false
     @State private var aiFormatterWarningMessage: String?
-    @State private var inspirationQuote: InspirationQuote = InspirationQuote.random()
 
-    private struct InspirationQuote {
-        let text: String
-        let author: String?
-
-        static let rotation: [InspirationQuote] = [
-            InspirationQuote(text: "Comprehend and copy nature.", author: "Viktor Schauberger"),
-            InspirationQuote(text: "Prevailing science thinks one octave too low.", author: "Viktor Schauberger"),
-            InspirationQuote(text: "All matter exists by reason of vibratory force.", author: "John Worrell Keely"),
-            InspirationQuote(text: "Throughout space there is energy.", author: "Nikola Tesla"),
-            InspirationQuote(text: "Knowledge can only be acquired through awareness.", author: "Walter Russell"),
-            InspirationQuote(text: "Love, work, and knowledge are the wellsprings of our life.", author: "Wilhelm Reich"),
-            InspirationQuote(text: "Orgone is the primordial cosmic energy.", author: "Wilhelm Reich"),
-            InspirationQuote(text: "The laws of nature may be more like habits.", author: "Rupert Sheldrake"),
-            InspirationQuote(text: "Nothing is the prey of death; everything is the prey of life.", author: "Antoine Béchamp"),
-            InspirationQuote(text: "All matter consists of magnets.", author: "Edward Leedskalnin"),
-            InspirationQuote(text: "We see only what we know.", author: "Goethe"),
-            InspirationQuote(text: "Wholeness is what is real.", author: "David Bohm"),
-            InspirationQuote(text: "As above, so below; as within, so without.", author: "The Kybalion"),
-            InspirationQuote(text: "There is no coming to consciousness without pain.", author: "Carl Jung"),
-            InspirationQuote(text: "Truth is a pathless land.", author: "Jiddu Krishnamurti"),
-            InspirationQuote(text: "What you seek is seeking you.", author: "Rumi"),
-            InspirationQuote(text: "Be calmly active, and actively calm.", author: "Paramahansa Yogananda"),
-            InspirationQuote(text: "You didn't come into this world. You came out of it.", author: "Alan Watts"),
-            InspirationQuote(text: "Be the change you wish to see in the world.", author: nil),
-        ]
-
-        static func random() -> InspirationQuote {
-            rotation.randomElement() ?? rotation[0]
-        }
-
-        var rendered: String {
-            if let author {
-                return "\(text) — \(author)"
-            }
-            return text
-        }
-    }
+    /// Fixed footer attribution. Previously rotated through 19 randomly-picked
+    /// quotes per view init; pinned to a single quote until the rotation
+    /// system has a clear product role.
+    private static let inspirationQuote = "Be the change you wish to see in the world."
 
     private enum PipelineStep: CaseIterable {
         case download
@@ -163,7 +129,7 @@ struct TranscribeView: View {
                             .padding(.horizontal, DesignSystem.Spacing.xl)
                     }
 
-                    Text(inspirationQuote.rendered)
+                    Text(Self.inspirationQuote)
                         .font(DesignSystem.Typography.caption)
                         .foregroundStyle(.tertiary)
                         .multilineTextAlignment(.center)


### PR DESCRIPTION
Pin the Transcribe page footer to a single quote. Previously picked at random from a 19-entry table on every view init.

```
┌─ before ─────────────────────────┐      ┌─ after ──────────────────────┐
│ @State InspirationQuote (random) │      │ static let (fixed)           │
│ struct InspirationQuote {        │      │                              │
│   rotation: [19 quotes…]         │  →   │ "Be the change you wish      │
│   random()                       │      │  to see in the world."       │
│   rendered                       │      │                              │
│ }                                │      │                              │
└──────────────────────────────────┘      └──────────────────────────────┘
            44 lines                                 6 lines
```

Typed as `LocalizedStringKey` so SwiftUI's `Text(_:)` keeps the localization-aware initializer (per gemini-code-assist review).

`swift build` clean.