### PR TITLE
Fix system-default microphone fallback

### DIFF
--- a/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
+++ b/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
@@ -9,12 +9,52 @@ public struct MeetingInputDeviceAttempt: Equatable, Sendable {
         case builtIn
     }
 
+    public enum Routing: Equatable, Sendable {
+        case explicit(AudioDeviceID)
+        case implicitSystemDefault(resolvedDeviceID: AudioDeviceID?)
+    }
+
     public let source: Source
-    public let deviceID: AudioDeviceID
+    public let routing: Routing
 
     public init(source: Source, deviceID: AudioDeviceID) {
         self.source = source
-        self.deviceID = deviceID
+        self.routing = .explicit(deviceID)
+    }
+
+    private init(source: Source, routing: Routing) {
+        self.source = source
+        self.routing = routing
+    }
+
+    public static func implicitSystemDefault(resolvedDeviceID: AudioDeviceID? = nil) -> MeetingInputDeviceAttempt {
+        MeetingInputDeviceAttempt(
+            source: .systemDefault,
+            routing: .implicitSystemDefault(resolvedDeviceID: resolvedDeviceID)
+        )
+    }
+
+    public var deviceID: AudioDeviceID? {
+        switch routing {
+        case .explicit(let deviceID):
+            return deviceID
+        case .implicitSystemDefault(let resolvedDeviceID):
+            return resolvedDeviceID
+        }
+    }
+
+    public var explicitDeviceID: AudioDeviceID? {
+        switch routing {
+        case .explicit(let deviceID):
+            return deviceID
+        case .implicitSystemDefault:
+            return nil
+        }
+    }
+
+    public var usesImplicitSystemDefault: Bool {
+        if case .implicitSystemDefault = routing { return true }
+        return false
     }
 }
 
@@ -40,17 +80,22 @@ public func meetingInputDeviceAttempts(
     var attempts: [MeetingInputDeviceAttempt] = []
     var seenDeviceIDs = Set<AudioDeviceID>()
 
-    func append(_ source: MeetingInputDeviceAttempt.Source, deviceID: AudioDeviceID?) {
+    func appendExplicit(_ source: MeetingInputDeviceAttempt.Source, deviceID: AudioDeviceID?) {
         guard let deviceID, seenDeviceIDs.insert(deviceID).inserted else { return }
         attempts.append(MeetingInputDeviceAttempt(source: source, deviceID: deviceID))
     }
 
     if let selectedUID {
-        append(.selected(uid: selectedUID), deviceID: selectedInputDeviceID(selectedUID))
+        appendExplicit(.selected(uid: selectedUID), deviceID: selectedInputDeviceID(selectedUID))
     }
 
-    append(.systemDefault, deviceID: defaultInputDevice())
-    append(.builtIn, deviceID: builtInMicrophone())
+    let defaultDeviceID = defaultInputDevice()
+    if let defaultDeviceID {
+        seenDeviceIDs.insert(defaultDeviceID)
+    }
+    attempts.append(.implicitSystemDefault(resolvedDeviceID: defaultDeviceID))
+
+    appendExplicit(.builtIn, deviceID: builtInMicrophone())
 
     return attempts
 }

--- a/Sources/MacParakeetCore/Audio/MicrophoneEnginePlatform.swift
+++ b/Sources/MacParakeetCore/Audio/MicrophoneEnginePlatform.swift
@@ -49,11 +49,18 @@ public protocol MicrophoneEnginePlatform: AnyObject, Sendable {
 ///   the VPAU aggregate device. A long-lived engine keeps the VPAU alive
 ///   indefinitely, which inherits the duplex layout into other engines.
 /// - When configured with a `deviceAttemptsBuilder`, each `configureAndStart`
-///   walks the resolved attempt list (selected → systemDefault → builtIn) and
-///   recreates the engine on every failed attempt before trying the next —
-///   the same fallback shape `MicrophoneCapture` uses today.
+///   walks the resolved attempt list (selected → implicit systemDefault →
+///   builtIn) and recreates the engine on every failed attempt before trying
+///   the next — the same fallback shape `MicrophoneCapture` uses today.
 public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @unchecked Sendable {
     public typealias DeviceAttemptsBuilder = @Sendable () -> [MeetingInputDeviceAttempt]
+    public typealias InputDeviceSetter = @Sendable (AudioDeviceID, AVAudioEngine) -> Bool
+    typealias EngineStarter = @Sendable (
+        AVAudioEngine,
+        Bool,
+        AVAudioFrameCount,
+        @Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void
+    ) throws -> Void
 
     private let logger = Logger(
         subsystem: "com.macparakeet.core",
@@ -61,6 +68,8 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
     )
     private let queue = DispatchQueue(label: "com.macparakeet.shared-mic-platform")
     private let deviceAttemptsBuilder: DeviceAttemptsBuilder?
+    private let inputDeviceSetter: InputDeviceSetter
+    private let engineStarter: EngineStarter?
     private var audioEngine = AVAudioEngine()
     private var running: Bool = false
     private var lastSucceededAttemptLocked: MeetingInputDeviceAttempt?
@@ -74,8 +83,27 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
     /// trigger for the silent tap-stall under investigation.
     private var configurationChangeObserver: NSObjectProtocol?
 
-    public init(deviceAttemptsBuilder: DeviceAttemptsBuilder? = nil) {
+    public init(
+        deviceAttemptsBuilder: DeviceAttemptsBuilder? = nil,
+        inputDeviceSetter: @escaping InputDeviceSetter = { deviceID, engine in
+            AudioDeviceManager.setInputDevice(deviceID, on: engine)
+        }
+    ) {
         self.deviceAttemptsBuilder = deviceAttemptsBuilder
+        self.inputDeviceSetter = inputDeviceSetter
+        self.engineStarter = nil
+    }
+
+    init(
+        deviceAttemptsBuilder: DeviceAttemptsBuilder? = nil,
+        inputDeviceSetter: @escaping InputDeviceSetter = { deviceID, engine in
+            AudioDeviceManager.setInputDevice(deviceID, on: engine)
+        },
+        engineStarter: @escaping EngineStarter
+    ) {
+        self.deviceAttemptsBuilder = deviceAttemptsBuilder
+        self.inputDeviceSetter = inputDeviceSetter
+        self.engineStarter = engineStarter
     }
 
     public var isEngineRunning: Bool {
@@ -131,7 +159,7 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
             let attempts = deviceAttemptsBuilder?() ?? []
             if attempts.isEmpty {
                 // No device chain — use whatever the engine's input node picks.
-                try startEngineLocked(
+                try startConfiguredEngineLocked(
                     vpioEnabled: vpioEnabled,
                     bufferSize: bufferSize,
                     tapHandler: tapHandler
@@ -143,22 +171,25 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
             var lastError: Error?
             for attempt in attempts {
                 let transport = AudioCaptureDiagnostics.deviceTransportLabel(attempt.deviceID)
-                guard AudioDeviceManager.setInputDevice(attempt.deviceID, on: audioEngine) else {
-                    logger.warning(
-                        "shared_mic_engine_input_device_set_failed source=\(attempt.source.logValue, privacy: .public) transport=\(transport, privacy: .public)"
-                    )
-                    AudioCaptureDiagnostics.append(
-                        "shared_mic_engine_input_device_set_failed source=\(attempt.source.logValue) device=present transport=\(transport)"
-                    )
-                    if lastError == nil {
-                        lastError = AVAudioEngineMicrophonePlatformError.deviceSetFailed(attempt)
+                let deviceLabel = AudioCaptureDiagnostics.deviceLabel(attempt.deviceID)
+                if let deviceID = attempt.explicitDeviceID {
+                    guard inputDeviceSetter(deviceID, audioEngine) else {
+                        logger.warning(
+                            "shared_mic_engine_input_device_set_failed source=\(attempt.source.logValue, privacy: .public) transport=\(transport, privacy: .public)"
+                        )
+                        AudioCaptureDiagnostics.append(
+                            "shared_mic_engine_input_device_set_failed source=\(attempt.source.logValue) device=\(deviceLabel) transport=\(transport)"
+                        )
+                        if lastError == nil {
+                            lastError = AVAudioEngineMicrophonePlatformError.deviceSetFailed(attempt)
+                        }
+                        resetEngineLocked()
+                        continue
                     }
-                    resetEngineLocked()
-                    continue
                 }
 
                 do {
-                    try startEngineLocked(
+                    try startConfiguredEngineLocked(
                         vpioEnabled: vpioEnabled,
                         bufferSize: bufferSize,
                         tapHandler: tapHandler
@@ -168,7 +199,7 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
                         "shared_mic_engine_input_device_started source=\(attempt.source.logValue, privacy: .public) transport=\(transport, privacy: .public) vpio=\(vpioEnabled, privacy: .public)"
                     )
                     AudioCaptureDiagnostics.append(
-                        "shared_mic_engine_input_device_started source=\(attempt.source.logValue) device=present transport=\(transport) vpio=\(vpioEnabled)"
+                        "shared_mic_engine_input_device_started source=\(attempt.source.logValue) device=\(deviceLabel) transport=\(transport) vpio=\(vpioEnabled)"
                     )
                     return
                 } catch {
@@ -178,9 +209,9 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
                         "shared_mic_engine_input_device_start_failed source=\(attempt.source.logValue, privacy: .public) transport=\(transport, privacy: .public) error_type=\(errorType, privacy: .public) error_detail=\(error.localizedDescription, privacy: .private)"
                     )
                     AudioCaptureDiagnostics.append(
-                        "shared_mic_engine_input_device_start_failed source=\(attempt.source.logValue) device=present transport=\(transport) \(AudioCaptureDiagnostics.errorFields(error))"
+                        "shared_mic_engine_input_device_start_failed source=\(attempt.source.logValue) device=\(deviceLabel) transport=\(transport) \(AudioCaptureDiagnostics.errorFields(error))"
                     )
-                    // startEngineLocked already replaces the engine on
+                    // startConfiguredEngineLocked already replaces the engine on
                     // failure, so nothing more to reset here.
                 }
             }
@@ -199,6 +230,30 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
     }
 
     // MARK: - Internals (queue-held)
+
+    private func startConfiguredEngineLocked(
+        vpioEnabled: Bool,
+        bufferSize: AVAudioFrameCount,
+        tapHandler: @escaping @Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void
+    ) throws {
+        guard let engineStarter else {
+            try startEngineLocked(
+                vpioEnabled: vpioEnabled,
+                bufferSize: bufferSize,
+                tapHandler: tapHandler
+            )
+            return
+        }
+
+        do {
+            try engineStarter(audioEngine, vpioEnabled, bufferSize, tapHandler)
+        } catch {
+            replaceEngineAfterFailureLocked()
+            throw error
+        }
+        running = true
+        installConfigurationChangeObserverLocked()
+    }
 
     private func startEngineLocked(
         vpioEnabled: Bool,

--- a/Tests/MacParakeetTests/Audio/MicrophoneCaptureTests.swift
+++ b/Tests/MacParakeetTests/Audio/MicrophoneCaptureTests.swift
@@ -323,7 +323,7 @@ final class MicrophoneCaptureTests: XCTestCase {
             attempts,
             [
                 MeetingInputDeviceAttempt(source: .selected(uid: "usb-mic"), deviceID: 10),
-                MeetingInputDeviceAttempt(source: .systemDefault, deviceID: 20),
+                .implicitSystemDefault(resolvedDeviceID: 20),
                 MeetingInputDeviceAttempt(source: .builtIn, deviceID: 30),
             ]
         )
@@ -340,7 +340,7 @@ final class MicrophoneCaptureTests: XCTestCase {
         XCTAssertEqual(
             attempts,
             [
-                MeetingInputDeviceAttempt(source: .systemDefault, deviceID: 20),
+                .implicitSystemDefault(resolvedDeviceID: 20),
                 MeetingInputDeviceAttempt(source: .builtIn, deviceID: 30),
             ]
         )
@@ -357,7 +357,7 @@ final class MicrophoneCaptureTests: XCTestCase {
         XCTAssertEqual(
             attempts,
             [
-                MeetingInputDeviceAttempt(source: .systemDefault, deviceID: 30),
+                .implicitSystemDefault(resolvedDeviceID: 30),
             ]
         )
     }
@@ -373,9 +373,66 @@ final class MicrophoneCaptureTests: XCTestCase {
         XCTAssertEqual(
             attempts,
             [
+                .implicitSystemDefault(resolvedDeviceID: nil),
                 MeetingInputDeviceAttempt(source: .builtIn, deviceID: 30),
             ]
         )
+    }
+
+    func testSystemDefaultAttemptUsesImplicitEngineRouting() {
+        let attempts = meetingInputDeviceAttempts(
+            selectedUID: "usb-mic",
+            selectedInputDeviceID: { uid in uid == "usb-mic" ? AudioDeviceID(10) : nil },
+            defaultInputDevice: { AudioDeviceID(10) },
+            builtInMicrophone: { nil }
+        )
+
+        XCTAssertEqual(
+            attempts,
+            [
+                MeetingInputDeviceAttempt(source: .selected(uid: "usb-mic"), deviceID: 10),
+                .implicitSystemDefault(resolvedDeviceID: 10),
+            ]
+        )
+        XCTAssertFalse(attempts[0].usesImplicitSystemDefault)
+        XCTAssertTrue(attempts[1].usesImplicitSystemDefault)
+        XCTAssertEqual(attempts[0].explicitDeviceID, 10)
+        XCTAssertNil(attempts[1].explicitDeviceID)
+    }
+
+    func testExplicitSystemDefaultAttemptCanStillPinDevice() {
+        let attempt = MeetingInputDeviceAttempt(source: .systemDefault, deviceID: 20)
+
+        XCTAssertFalse(attempt.usesImplicitSystemDefault)
+        XCTAssertEqual(attempt.explicitDeviceID, 20)
+    }
+
+    func testPlatformSkipsInputDeviceSetterForImplicitSystemDefaultAttempt() throws {
+        let recorder = MicrophoneCaptureInputDeviceSetterRecorder()
+        let platform = AVAudioEngineMicrophonePlatform(
+            deviceAttemptsBuilder: {
+                [
+                    MeetingInputDeviceAttempt(source: .selected(uid: "usb-mic"), deviceID: 10),
+                    .implicitSystemDefault(resolvedDeviceID: 20),
+                    MeetingInputDeviceAttempt(source: .builtIn, deviceID: 30),
+                ]
+            },
+            inputDeviceSetter: { deviceID, _ in
+                recorder.record(deviceID)
+                return false
+            },
+            engineStarter: { _, _, _, _ in }
+        )
+
+        try platform.configureAndStart(
+            vpioEnabled: false,
+            bufferSize: 1024,
+            tapHandler: { _, _ in }
+        )
+        defer { platform.stopEngine() }
+
+        XCTAssertEqual(recorder.deviceIDs, [10])
+        XCTAssertEqual(platform.lastSucceededAttempt, .implicitSystemDefault(resolvedDeviceID: 20))
     }
 
     private func makeSharedTestBuffer() -> AVAudioPCMBuffer {
@@ -414,6 +471,21 @@ final class MicrophoneCaptureTests: XCTestCase {
 
 private enum MicrophoneCaptureMockError: Error, Equatable {
     case simulatedFailure
+}
+
+private final class MicrophoneCaptureInputDeviceSetterRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var deviceIDsLocked: [AudioDeviceID] = []
+
+    var deviceIDs: [AudioDeviceID] {
+        lock.withLock { deviceIDsLocked }
+    }
+
+    func record(_ deviceID: AudioDeviceID) {
+        lock.withLock {
+            deviceIDsLocked.append(deviceID)
+        }
+    }
 }
 
 private final class MicrophoneCaptureTestCounter: @unchecked Sendable {


### PR DESCRIPTION
## Summary
Fixes a v0.6.0 microphone regression where some system-default USB/camera mics can fail the Audio Input test after MacParakeet explicitly sets the default CoreAudio device.

The fix keeps explicit routing for user-selected microphones, but restores AVAudioEngine's implicit System Default path before falling back to the built-in mic. This matches the v0.5.6 behavior that worked for the reported OBSBOT Meet 2 setup.

```text
Before
Selected mic -> explicit CoreAudio set -> start
System Default -> explicit CoreAudio set -> start/fail
Built-in -> explicit CoreAudio set -> start

After
Selected mic -> explicit CoreAudio set -> start
System Default -> AVAudioEngine implicit default -> start
Built-in -> explicit CoreAudio set -> start
```

## Tests
- swift test --filter MicrophoneCaptureTests
- swift test --filter Audio
- swift test (2223 tests, 1 skipped, 0 failures)

Fixes #218
