### PR TITLE
Fix live transcript colors on light backgrounds

### DIFF
--- a/Sources/MacParakeet/Views/Components/DesignSystem.swift
+++ b/Sources/MacParakeet/Views/Components/DesignSystem.swift
@@ -61,6 +61,7 @@ enum DesignSystem {
         static let playbackFill = Color.accentColor
 
         // Speaker diarization palette — distinct, readable in both light/dark
+        static let transcriptSpeakerLabelAlpha: CGFloat = 0.85
         static let speakerColors: [Color] = [
             Color(light: .init(red: 0.20, green: 0.51, blue: 0.84),
                   dark: .init(red: 0.42, green: 0.68, blue: 0.96)),   // Blue

--- a/Sources/MacParakeet/Views/MeetingRecording/TranscriptTextView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/TranscriptTextView.swift
@@ -19,6 +19,7 @@ struct TranscriptTextView: NSViewRepresentable {
         textView.isEditable = false
         textView.isSelectable = true
         textView.isRichText = true
+        textView.usesAdaptiveColorMappingForDarkAppearance = true
         textView.backgroundColor = .clear
         textView.drawsBackground = false
         textView.textContainerInset = NSSize(width: 16, height: 8)
@@ -124,8 +125,8 @@ struct TranscriptTextView: NSViewRepresentable {
         let speakerFont = NSFont.systemFont(ofSize: 11, weight: .medium)
         let dotFont = NSFont.systemFont(ofSize: 10, weight: .medium)
         let timestampFont = NSFont.monospacedDigitSystemFont(ofSize: 10, weight: .regular)
-        let textColor = NSColor.white.withAlphaComponent(0.9)
-        let timestampColor = NSColor.white.withAlphaComponent(0.3)
+        let textColor = Self.nsColor(DesignSystem.Colors.textPrimary)
+        let timestampColor = Self.nsColor(DesignSystem.Colors.textTertiary)
 
         for (offset, line) in lineSlice.enumerated() {
             let globalIndex = startingIndex + offset
@@ -150,7 +151,7 @@ struct TranscriptTextView: NSViewRepresentable {
 
                 let speaker = NSAttributedString(string: "\(line.speakerLabel)  ", attributes: [
                     .font: speakerFont,
-                    .foregroundColor: color.withAlphaComponent(0.85),
+                    .foregroundColor: nsColor(for: line.source, alpha: 0.85),
                 ])
                 result.append(speaker)
 
@@ -191,14 +192,42 @@ struct TranscriptTextView: NSViewRepresentable {
         return oldLines.count == newLines.count ? nil : sharedCount
     }
 
-    private func nsColor(for source: AudioSource?) -> NSColor {
+    private func nsColor(for source: AudioSource?, alpha: CGFloat = 1.0) -> NSColor {
         switch source {
         case .microphone:
-            return NSColor(DesignSystem.Colors.accent)
+            return Self.nsColor(DesignSystem.Colors.accent, alpha: alpha)
         case .system:
-            return NSColor(DesignSystem.Colors.speakerColor(for: 0))
+            return Self.nsColor(DesignSystem.Colors.speakerColor(for: 0), alpha: alpha)
         case .none:
-            return NSColor(DesignSystem.Colors.textSecondary)
+            return Self.nsColor(DesignSystem.Colors.textSecondary, alpha: alpha)
+        }
+    }
+
+    private static func nsColor(_ color: Color, alpha: CGFloat = 1.0) -> NSColor {
+        NSColor(name: nil) { appearance in
+            var resolved = NSColor(color)
+            appearance.performAsCurrentDrawingAppearance {
+                resolved = NSColor(color)
+            }
+            return resolved.withAlphaComponent(alpha)
         }
     }
 }
+
+#if DEBUG
+extension TranscriptTextView {
+    func renderedAttributedStringForTesting(
+        lines: ArraySlice<MeetingRecordingPreviewLine>,
+        startingIndex: Int = 0,
+        previousSource: AudioSource? = nil,
+        isFirstInDocument: Bool = true
+    ) -> NSAttributedString {
+        buildRenderedSlice(
+            for: lines,
+            startingIndex: startingIndex,
+            previousSource: previousSource,
+            isFirstInDocument: isFirstInDocument
+        ).attributedString
+    }
+}
+#endif

--- a/Sources/MacParakeet/Views/MeetingRecording/TranscriptTextView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/TranscriptTextView.swift
@@ -150,7 +150,10 @@ struct TranscriptTextView: NSViewRepresentable {
 
                 let speaker = NSAttributedString(string: "\(line.speakerLabel)  ", attributes: [
                     .font: speakerFont,
-                    .foregroundColor: nsColor(for: line.source, alpha: 0.85),
+                    .foregroundColor: nsColor(
+                        for: line.source,
+                        alpha: DesignSystem.Colors.transcriptSpeakerLabelAlpha
+                    ),
                 ])
                 result.append(speaker)
 

--- a/Sources/MacParakeet/Views/MeetingRecording/TranscriptTextView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/TranscriptTextView.swift
@@ -19,7 +19,6 @@ struct TranscriptTextView: NSViewRepresentable {
         textView.isEditable = false
         textView.isSelectable = true
         textView.isRichText = true
-        textView.usesAdaptiveColorMappingForDarkAppearance = true
         textView.backgroundColor = .clear
         textView.drawsBackground = false
         textView.textContainerInset = NSSize(width: 16, height: 8)
@@ -204,13 +203,7 @@ struct TranscriptTextView: NSViewRepresentable {
     }
 
     private static func nsColor(_ color: Color, alpha: CGFloat = 1.0) -> NSColor {
-        NSColor(name: nil) { appearance in
-            var resolved = NSColor(color)
-            appearance.performAsCurrentDrawingAppearance {
-                resolved = NSColor(color)
-            }
-            return resolved.withAlphaComponent(alpha)
-        }
+        NSColor(color).withAlphaComponent(alpha)
     }
 }
 

--- a/Tests/MacParakeetTests/Views/TranscriptTextViewTests.swift
+++ b/Tests/MacParakeetTests/Views/TranscriptTextViewTests.swift
@@ -1,0 +1,58 @@
+import AppKit
+import XCTest
+import MacParakeetCore
+import MacParakeetViewModels
+@testable import MacParakeet
+
+final class TranscriptTextViewTests: XCTestCase {
+    func testLiveTranscriptBodyTextUsesDesignSystemPrimaryColor() throws {
+        let view = TranscriptTextView(lines: [], autoScroll: true)
+        let line = MeetingRecordingPreviewLine(
+            id: "1",
+            timestamp: "0:05",
+            speakerLabel: "Me",
+            text: "Visible transcript body",
+            source: .microphone
+        )
+
+        let rendered = view.renderedAttributedStringForTesting(lines: [line][...])
+        let range = (rendered.string as NSString).range(of: line.text)
+
+        let actual = try XCTUnwrap(
+            rendered.attribute(
+                NSAttributedString.Key.foregroundColor,
+                at: range.location,
+                effectiveRange: nil
+            ) as? NSColor
+        )
+        let expected = NSColor(DesignSystem.Colors.textPrimary)
+
+        assertColor(actual, matches: expected, appearance: .aqua)
+        assertColor(actual, matches: expected, appearance: .darkAqua)
+    }
+
+    private func assertColor(
+        _ actual: NSColor,
+        matches expected: NSColor,
+        appearance name: NSAppearance.Name,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let actual = resolvedRGBColor(actual, appearance: name)
+        let expected = resolvedRGBColor(expected, appearance: name)
+
+        XCTAssertEqual(actual.redComponent, expected.redComponent, accuracy: 0.01, file: file, line: line)
+        XCTAssertEqual(actual.greenComponent, expected.greenComponent, accuracy: 0.01, file: file, line: line)
+        XCTAssertEqual(actual.blueComponent, expected.blueComponent, accuracy: 0.01, file: file, line: line)
+        XCTAssertEqual(actual.alphaComponent, expected.alphaComponent, accuracy: 0.01, file: file, line: line)
+    }
+
+    private func resolvedRGBColor(_ color: NSColor, appearance name: NSAppearance.Name) -> NSColor {
+        let appearance = NSAppearance(named: name)!
+        var resolved = color
+        appearance.performAsCurrentDrawingAppearance {
+            resolved = color.usingColorSpace(.deviceRGB) ?? color
+        }
+        return resolved
+    }
+}


### PR DESCRIPTION
## Summary
Fixes live meeting transcripts that could appear invisible in light mode.

The live transcript view was drawing transcript text in hard-coded white while sitting on an adaptive app background. This PR switches that renderer to the app's semantic text colors so transcripts stay readable in both light and dark appearances.

```text
Before: Live transcript -> white text        -> low contrast on light bg
After:  Live transcript -> DesignSystem text -> readable in light/dark
```

## Validation
- Added a regression test for Aqua and Dark Aqua text color resolution.
- Ran `swift test` locally.
- GitHub CI is green.

Closes #219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced color consistency in transcript display by aligning visual elements with design system standards.

* **Tests**
  * Added test suite to verify transcript view rendering accuracy across different macOS appearance modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->