### PR TITLE
Stabilize Whisper meeting transcription artifacts

### DIFF
--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -299,6 +299,7 @@ final class MeetingRecordingFlowCoordinator {
             panelVM.elapsedSeconds = 0
             panelVM.micLevel = 0
             panelVM.systemLevel = 0
+            panelVM.speechEngine = SpeechEngineSelection.current()
             panelVM.updatePreviewLines([], isTranscriptionLagging: false)
             panelVM.onStop = { [weak self] in self?.toggleRecording() }
             panelVM.onClose = { [weak self] in self?.hideMeetingPanel() }

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelView.swift
@@ -243,6 +243,14 @@ struct MeetingRecordingPanelView: View {
                     .foregroundStyle(DesignSystem.Colors.warningAmber)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
+
+            if viewModel.showsWhisperMeetingWarning {
+                Label(viewModel.whisperMeetingWarningMessage, systemImage: "exclamationmark.triangle.fill")
+                    .font(DesignSystem.Typography.caption.weight(.semibold))
+                    .foregroundStyle(DesignSystem.Colors.warningAmber)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
         }
         .padding(.horizontal, DesignSystem.Spacing.md)
         .padding(.vertical, DesignSystem.Spacing.sm)

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingTranscriptAssembler.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingTranscriptAssembler.swift
@@ -64,9 +64,17 @@ struct MeetingTranscriptAssembler {
                 speakerId: source.rawValue
             )
         }
+        let filteredOffsetWords: [WordTimestamp]
+        if result.engine == .whisper {
+            filteredOffsetWords = MeetingTranscriptNoiseFilter
+                .cleanWhisperSubtitleArtifacts(words: offsetWords)
+                .words
+        } else {
+            filteredOffsetWords = offsetWords
+        }
 
         let cutoff = lastCommittedEndMs[source] ?? Int.min
-        let deduplicated = offsetWords.filter { $0.endMs > cutoff }
+        let deduplicated = filteredOffsetWords.filter { $0.endMs > cutoff }
 
         if !deduplicated.isEmpty {
             wordsBySource[source, default: []].append(contentsOf: deduplicated)

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingTranscriptFinalizer.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingTranscriptFinalizer.swift
@@ -32,7 +32,8 @@ struct MeetingTranscriptFinalizer {
         }
 
         var removedWhisperArtifactWordCount = 0
-        let shiftedWordsBySource: [AudioSource: [WordTimestamp]] = Dictionary(uniqueKeysWithValues: normalized.map { sourceTranscript in
+        var shiftedWordsBySource: [AudioSource: [WordTimestamp]] = [:]
+        for sourceTranscript in normalized {
             let words = shiftedWords(
                 for: sourceTranscript.result,
                 source: sourceTranscript.source,
@@ -47,11 +48,8 @@ struct MeetingTranscriptFinalizer {
                 cleanedWords = words
             }
 
-            return (
-                sourceTranscript.source,
-                cleanedWords
-            )
-        })
+            shiftedWordsBySource[sourceTranscript.source, default: []].append(contentsOf: cleanedWords)
+        }
 
         let systemWords = shiftedWordsBySource[.system] ?? []
         let microphoneCleanup = MeetingTranscriptNoiseFilter.cleanFinalMicrophoneWords(

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingTranscriptFinalizer.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingTranscriptFinalizer.swift
@@ -31,14 +31,25 @@ struct MeetingTranscriptFinalizer {
             return lhs.startOffsetMs < rhs.startOffsetMs
         }
 
-        let shiftedWordsBySource = Dictionary(uniqueKeysWithValues: normalized.map { sourceTranscript in
-            (
+        var removedWhisperArtifactWordCount = 0
+        let shiftedWordsBySource: [AudioSource: [WordTimestamp]] = Dictionary(uniqueKeysWithValues: normalized.map { sourceTranscript in
+            let words = shiftedWords(
+                for: sourceTranscript.result,
+                source: sourceTranscript.source,
+                offsetMs: sourceTranscript.startOffsetMs
+            )
+            let cleanedWords: [WordTimestamp]
+            if sourceTranscript.result.engine == .whisper {
+                let cleanup = MeetingTranscriptNoiseFilter.cleanWhisperSubtitleArtifacts(words: words)
+                removedWhisperArtifactWordCount += cleanup.removedWordCount
+                cleanedWords = cleanup.words
+            } else {
+                cleanedWords = words
+            }
+
+            return (
                 sourceTranscript.source,
-                shiftedWords(
-                    for: sourceTranscript.result,
-                    source: sourceTranscript.source,
-                    offsetMs: sourceTranscript.startOffsetMs
-                )
+                cleanedWords
             )
         })
 
@@ -73,6 +84,7 @@ struct MeetingTranscriptFinalizer {
             from: normalized,
             mergedWords: mergedWords,
             forceMergedWordText: microphoneCleanup.removedMicrophoneWordCount > 0
+                || removedWhisperArtifactWordCount > 0
         )
 
         return FinalizedTranscript(

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingTranscriptNoiseFilter.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingTranscriptNoiseFilter.swift
@@ -120,7 +120,7 @@ struct MeetingTranscriptNoiseFilter {
 
             let candidate = normalizedTokens[startIndex..<endIndex]
             let range = startIndex..<endIndex
-            if candidate.elementsEqual(run.map(Optional.some)),
+            if candidate.elementsEqual(run, by: { $0 == $1 }),
                shouldDropWhisperSubtitleArtifactRun(words: words, range: range) {
                 return startIndex..<endIndex
             }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingTranscriptNoiseFilter.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingTranscriptNoiseFilter.swift
@@ -6,6 +6,11 @@ struct MeetingTranscriptNoiseFilter {
         let removedMicrophoneWordCount: Int
     }
 
+    struct WordCleanupResult: Sendable, Equatable {
+        let words: [WordTimestamp]
+        let removedWordCount: Int
+    }
+
     private struct IndexedRun {
         let indexes: [Int]
         let words: [WordTimestamp]
@@ -31,6 +36,12 @@ struct MeetingTranscriptNoiseFilter {
     private static let duplicateLowConfidenceThreshold = 0.65
     private static let duplicateShortConfidenceThreshold = 0.80
     private static let allowedTokenCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "'"))
+    private static let whisperArtifactLowConfidenceThreshold = 0.65
+    private static let whisperArtifactAverageConfidenceThreshold = 0.80
+    private static let whisperArtifactIsolationGapMs = 2_000
+    private static let whisperSubtitleArtifactRuns: [[String]] = [
+        ["продолжение", "следует"],
+    ]
 
     static func cleanFinalMicrophoneWords(
         microphoneWords: [WordTimestamp],
@@ -64,6 +75,90 @@ struct MeetingTranscriptNoiseFilter {
             microphoneWords: cleaned,
             removedMicrophoneWordCount: indexesToDrop.count
         )
+    }
+
+    static func cleanWhisperSubtitleArtifacts(words: [WordTimestamp]) -> WordCleanupResult {
+        guard !words.isEmpty else {
+            return WordCleanupResult(words: [], removedWordCount: 0)
+        }
+
+        let normalizedTokens = words.map { normalizedToken($0.word) }
+        var indexesToDrop = Set<Int>()
+        var index = 0
+
+        while index < words.count {
+            if let range = whisperSubtitleArtifactRange(
+                startingAt: index,
+                words: words,
+                normalizedTokens: normalizedTokens
+            ) {
+                indexesToDrop.formUnion(range)
+                index = range.upperBound
+            } else {
+                index += 1
+            }
+        }
+
+        guard !indexesToDrop.isEmpty else {
+            return WordCleanupResult(words: words, removedWordCount: 0)
+        }
+
+        let cleaned = words.enumerated().compactMap { index, word in
+            indexesToDrop.contains(index) ? nil : word
+        }
+        return WordCleanupResult(words: cleaned, removedWordCount: indexesToDrop.count)
+    }
+
+    private static func whisperSubtitleArtifactRange(
+        startingAt startIndex: Int,
+        words: [WordTimestamp],
+        normalizedTokens: [String?]
+    ) -> Range<Int>? {
+        for run in whisperSubtitleArtifactRuns {
+            let endIndex = startIndex + run.count
+            guard endIndex <= normalizedTokens.count else { continue }
+
+            let candidate = normalizedTokens[startIndex..<endIndex]
+            let range = startIndex..<endIndex
+            if candidate.elementsEqual(run.map(Optional.some)),
+               shouldDropWhisperSubtitleArtifactRun(words: words, range: range) {
+                return startIndex..<endIndex
+            }
+        }
+
+        return nil
+    }
+
+    private static func shouldDropWhisperSubtitleArtifactRun(
+        words: [WordTimestamp],
+        range: Range<Int>
+    ) -> Bool {
+        let run = Array(words[range])
+        let hasLowConfidenceToken = run.contains { $0.confidence <= whisperArtifactLowConfidenceThreshold }
+        let averageConfidence = run.reduce(0.0) { $0 + $1.confidence } / Double(run.count)
+        let confidenceLooksSuspicious = hasLowConfidenceToken
+            || averageConfidence <= whisperArtifactAverageConfidenceThreshold
+
+        return confidenceLooksSuspicious
+            && isIsolatedWhisperSubtitleArtifactRun(words: words, range: range)
+    }
+
+    private static func isIsolatedWhisperSubtitleArtifactRun(
+        words: [WordTimestamp],
+        range: Range<Int>
+    ) -> Bool {
+        guard let first = words[range].first, let last = words[range].last else {
+            return false
+        }
+
+        let separatedFromPrevious =
+            range.lowerBound == words.startIndex
+            || first.startMs - words[range.lowerBound - 1].endMs >= whisperArtifactIsolationGapMs
+        let separatedFromNext =
+            range.upperBound == words.endIndex
+            || words[range.upperBound].startMs - last.endMs >= whisperArtifactIsolationGapMs
+
+        return separatedFromPrevious && separatedFromNext
     }
 
     private static func contiguousRuns(in words: [WordTimestamp]) -> [IndexedRun] {

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Foundation
 import OSLog
 
@@ -158,6 +159,10 @@ private struct TranscriptionOperationContext: Sendable {
 
 public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
     private let logger = Logger(subsystem: "com.macparakeet.core", category: "TranscriptionService")
+    private static let meetingSystemSignalFloor: Float = 0.00025
+    private static let meetingSystemSignalFrameSeconds: Double = 0.1
+    private static let meetingSystemMinimumActiveSeconds: Double = 2.0
+    private static let meetingSystemMinimumActiveRatio: Double = 0.02
     private let audioProcessor: AudioProcessorProtocol
     private let sttTranscriber: STTTranscribing
     private let transcriptionRepo: TranscriptionRepositoryProtocol
@@ -742,6 +747,10 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
             temporaryWavURLs.append(wavURL)
             sourceWavURLs[source] = wavURL
 
+            if shouldSkipMeetingSystemSource(source: source, speechEngine: speechEngine, wavURL: wavURL) {
+                continue
+            }
+
             lifecycleStage = .stt
             onProgress?(.transcribing(percent: Int((Double(index) / Double(max(activeSources.count, 1))) * 100)))
             let result = try await transcribeSpeech(
@@ -765,6 +774,180 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
         }
 
         return outputs
+    }
+
+    private func shouldSkipMeetingSystemSource(
+        source: AudioSource,
+        speechEngine: SpeechEngineSelection?,
+        wavURL: URL
+    ) -> Bool {
+        guard source == .system,
+              speechEngine?.engine == .whisper else {
+            return false
+        }
+
+        do {
+            if !(try Self.containsTranscribableSignal(in: wavURL)) {
+                logger.notice("meeting_source_skipped reason=low_signal source=system engine=whisper")
+                return true
+            }
+        } catch {
+            logger.warning("meeting_source_signal_probe_failed source=system engine=whisper error=\(error.localizedDescription, privacy: .public)")
+        }
+
+        return false
+    }
+
+    static func containsTranscribableSignal(in audioURL: URL) throws -> Bool {
+        let file = try AVAudioFile(forReading: audioURL)
+        let format = file.processingFormat
+        guard let bufferFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: format.sampleRate,
+            channels: format.channelCount,
+            interleaved: false
+        ) else {
+            return true
+        }
+
+        return try containsTranscribableSignal(
+            file: file,
+            bufferFormat: bufferFormat,
+            floor: meetingSystemSignalFloor,
+            frameSeconds: meetingSystemSignalFrameSeconds,
+            minimumActiveSeconds: meetingSystemMinimumActiveSeconds,
+            minimumActiveRatio: meetingSystemMinimumActiveRatio
+        )
+    }
+
+    static func containsTranscribableSignal(
+        samples: [Float],
+        sampleRate: Double,
+        floor: Float = meetingSystemSignalFloor,
+        frameSeconds: Double = meetingSystemSignalFrameSeconds,
+        minimumActiveSeconds: Double = meetingSystemMinimumActiveSeconds,
+        minimumActiveRatio: Double = meetingSystemMinimumActiveRatio
+    ) -> Bool {
+        guard !samples.isEmpty, sampleRate > 0 else {
+            return false
+        }
+
+        var activity = SignalActivity(
+            sampleRate: sampleRate,
+            channelCount: 1,
+            floor: floor,
+            frameSeconds: frameSeconds
+        )
+        for sample in samples {
+            activity.add(sample)
+        }
+        return activity.containsTranscribableSignal(
+            minimumActiveSeconds: minimumActiveSeconds,
+            minimumActiveRatio: minimumActiveRatio
+        )
+    }
+
+    private static func containsTranscribableSignal(
+        file: AVAudioFile,
+        bufferFormat: AVAudioFormat,
+        floor: Float,
+        frameSeconds: Double,
+        minimumActiveSeconds: Double,
+        minimumActiveRatio: Double
+    ) throws -> Bool {
+        let readCapacity: AVAudioFrameCount = 4_096
+        var activity = SignalActivity(
+            sampleRate: bufferFormat.sampleRate,
+            channelCount: Int(bufferFormat.channelCount),
+            floor: floor,
+            frameSeconds: frameSeconds
+        )
+
+        while file.framePosition < file.length {
+            let remaining = file.length - file.framePosition
+            let framesToRead = min(readCapacity, AVAudioFrameCount(remaining))
+            guard framesToRead > 0,
+                  let buffer = AVAudioPCMBuffer(pcmFormat: bufferFormat, frameCapacity: framesToRead) else {
+                break
+            }
+
+            try file.read(into: buffer, frameCount: framesToRead)
+            let frameLength = Int(buffer.frameLength)
+            guard frameLength > 0 else {
+                break
+            }
+            guard let channelData = buffer.floatChannelData else {
+                return true
+            }
+
+            for frame in 0..<frameLength {
+                for channel in 0..<Int(buffer.format.channelCount) {
+                    activity.add(channelData[channel][frame])
+                }
+            }
+        }
+
+        return activity.containsTranscribableSignal(
+            minimumActiveSeconds: minimumActiveSeconds,
+            minimumActiveRatio: minimumActiveRatio
+        )
+    }
+
+    private struct SignalActivity {
+        let floor: Float
+        let frameSeconds: Double
+        private let frameSampleCount: Int
+        private var currentSumSquares = 0.0
+        private var currentSampleCount = 0
+        private var totalFrames = 0
+        private var activeFrames = 0
+
+        init(
+            sampleRate: Double,
+            channelCount: Int,
+            floor: Float,
+            frameSeconds: Double
+        ) {
+            self.floor = floor
+            self.frameSeconds = frameSeconds
+            self.frameSampleCount = max(1, Int(sampleRate * frameSeconds) * max(channelCount, 1))
+        }
+
+        mutating func add(_ sample: Float) {
+            currentSumSquares += Double(sample * sample)
+            currentSampleCount += 1
+
+            if currentSampleCount >= frameSampleCount {
+                finishFrame()
+            }
+        }
+
+        mutating func containsTranscribableSignal(
+            minimumActiveSeconds: Double,
+            minimumActiveRatio: Double
+        ) -> Bool {
+            if currentSampleCount > 0 {
+                finishFrame()
+            }
+
+            guard totalFrames > 0 else {
+                return false
+            }
+
+            let activeSeconds = Double(activeFrames) * frameSeconds
+            let activeRatio = Double(activeFrames) / Double(totalFrames)
+            return activeSeconds >= minimumActiveSeconds || activeRatio >= minimumActiveRatio
+        }
+
+        private mutating func finishFrame() {
+            let rms = sqrt(currentSumSquares / Double(max(currentSampleCount, 1)))
+            if rms > Double(floor) {
+                activeFrames += 1
+            }
+            totalFrames += 1
+            currentSumSquares = 0
+            currentSampleCount = 0
+        }
     }
 
     private func diarizeMeetingSystemIfNeeded(

--- a/Sources/MacParakeetViewModels/MeetingRecordingPanelViewModel.swift
+++ b/Sources/MacParakeetViewModels/MeetingRecordingPanelViewModel.swift
@@ -32,6 +32,7 @@ public final class MeetingRecordingPanelViewModel {
     public var elapsedSeconds: Int = 0
     public var micLevel: Float = 0
     public var systemLevel: Float = 0
+    public var speechEngine: SpeechEngineSelection = SpeechEngineSelection(engine: .parakeet)
     public var previewLines: [MeetingRecordingPreviewLine] = []
     public var isTranscriptionLagging: Bool = false
     public var showCopiedConfirmation: Bool = false
@@ -116,6 +117,7 @@ public final class MeetingRecordingPanelViewModel {
         elapsedSeconds = 0
         micLevel = 0
         systemLevel = 0
+        speechEngine = SpeechEngineSelection(engine: .parakeet)
         previewLines = []
         previewLineWordCounts = []
         wordCount = 0
@@ -185,6 +187,19 @@ public final class MeetingRecordingPanelViewModel {
             return isTranscriptionLagging
         }
         return false
+    }
+
+    public var showsWhisperMeetingWarning: Bool {
+        switch state {
+        case .recording, .transcribing:
+            return speechEngine.engine == .whisper
+        default:
+            return false
+        }
+    }
+
+    public var whisperMeetingWarningMessage: String {
+        "Whisper meeting transcription is experimental and may be inaccurate during recording and in the saved transcript."
     }
 
     public var showsElapsedTime: Bool {

--- a/Tests/MacParakeetTests/Audio/MockAudioProcessor.swift
+++ b/Tests/MacParakeetTests/Audio/MockAudioProcessor.swift
@@ -14,11 +14,19 @@ public actor MockAudioProcessor: AudioProcessorProtocol {
     public var convertCallCount = 0
     public var lastConvertURL: URL?
     public var convertURLs: [URL] = []
+    private var queuedConvertResults: [URL] = []
 
     public init() {}
 
     public func configure(convertResult: URL) {
         self.convertResult = convertResult
+        self.convertError = nil
+        self.queuedConvertResults = []
+    }
+
+    public func configureSequence(convertResults: [URL]) {
+        self.queuedConvertResults = convertResults
+        self.convertResult = nil
         self.convertError = nil
     }
 
@@ -60,6 +68,9 @@ public actor MockAudioProcessor: AudioProcessorProtocol {
         lastConvertURL = fileURL
         convertURLs.append(fileURL)
         if let error = convertError { throw error }
+        if !queuedConvertResults.isEmpty {
+            return queuedConvertResults.removeFirst()
+        }
         return convertResult ?? URL(fileURLWithPath: "/tmp/converted.wav")
     }
 

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingTranscriptAssemblerTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingTranscriptAssemblerTests.swift
@@ -23,6 +23,92 @@ final class MeetingTranscriptAssemblerTests: XCTestCase {
         XCTAssertEqual(update.words.map(\.speakerId), ["microphone", "microphone", "microphone"])
     }
 
+    func testApplyDropsWhisperSubtitleArtifactRun() {
+        var assembler = MeetingTranscriptAssembler()
+
+        _ = assembler.apply(
+            result: STTResult(text: "Okay", words: [
+                TimestampedWord(word: "Okay", startMs: 100, endMs: 400, confidence: 0.95),
+            ]),
+            chunk: AudioChunker.AudioChunk(samples: [0], startMs: 0, endMs: 5_000),
+            source: .microphone
+        )
+
+        let update = assembler.apply(
+            result: STTResult(
+                text: "Продолжение следует...",
+                words: [
+                    TimestampedWord(word: "Продолжение", startMs: 100, endMs: 1_400, confidence: 0.54),
+                    TimestampedWord(word: "следует...", startMs: 1_400, endMs: 2_800, confidence: 0.97),
+                ],
+                engine: .whisper,
+                engineVariant: "large-v3-v20240930_turbo_632MB"
+            ),
+            chunk: AudioChunker.AudioChunk(samples: [0], startMs: 4_000, endMs: 9_000),
+            source: .microphone
+        )
+
+        XCTAssertEqual(update.words.map(\.word), ["Okay"])
+    }
+
+    func testApplyKeepsSubtitleWordsFromNonWhisperEngine() {
+        var assembler = MeetingTranscriptAssembler()
+
+        let update = assembler.apply(
+            result: STTResult(text: "Продолжение следует...", words: [
+                TimestampedWord(word: "Продолжение", startMs: 100, endMs: 1_400, confidence: 0.54),
+                TimestampedWord(word: "следует...", startMs: 1_400, endMs: 2_800, confidence: 0.97),
+            ]),
+            chunk: AudioChunker.AudioChunk(samples: [0], startMs: 0, endMs: 5_000),
+            source: .microphone
+        )
+
+        XCTAssertEqual(update.words.map(\.word), ["Продолжение", "следует..."])
+    }
+
+    func testApplyKeepsContextualWhisperSubtitlePhrase() {
+        var assembler = MeetingTranscriptAssembler()
+
+        let update = assembler.apply(
+            result: STTResult(
+                text: "He said Продолжение следует today",
+                words: [
+                    TimestampedWord(word: "He", startMs: 0, endMs: 120, confidence: 0.96),
+                    TimestampedWord(word: "said", startMs: 180, endMs: 340, confidence: 0.96),
+                    TimestampedWord(word: "Продолжение", startMs: 390, endMs: 1_000, confidence: 0.54),
+                    TimestampedWord(word: "следует", startMs: 1_000, endMs: 1_520, confidence: 0.97),
+                    TimestampedWord(word: "today", startMs: 1_580, endMs: 1_900, confidence: 0.96),
+                ],
+                engine: .whisper,
+                engineVariant: "large-v3-v20240930_turbo_632MB"
+            ),
+            chunk: AudioChunker.AudioChunk(samples: [0], startMs: 0, endMs: 5_000),
+            source: .microphone
+        )
+
+        XCTAssertEqual(update.words.map(\.word), ["He", "said", "Продолжение", "следует", "today"])
+    }
+
+    func testApplyKeepsHighConfidenceWhisperSubtitlePhrase() {
+        var assembler = MeetingTranscriptAssembler()
+
+        let update = assembler.apply(
+            result: STTResult(
+                text: "Продолжение следует...",
+                words: [
+                    TimestampedWord(word: "Продолжение", startMs: 100, endMs: 1_400, confidence: 0.97),
+                    TimestampedWord(word: "следует...", startMs: 1_400, endMs: 2_800, confidence: 0.98),
+                ],
+                engine: .whisper,
+                engineVariant: "large-v3-v20240930_turbo_632MB"
+            ),
+            chunk: AudioChunker.AudioChunk(samples: [0], startMs: 0, endMs: 5_000),
+            source: .microphone
+        )
+
+        XCTAssertEqual(update.words.map(\.word), ["Продолжение", "следует..."])
+    }
+
     func testFinalizedTranscriptBuildsSpeakerMetadataAcrossSources() {
         var assembler = MeetingTranscriptAssembler()
 

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingTranscriptNoiseFilterTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingTranscriptNoiseFilterTests.swift
@@ -101,4 +101,49 @@ final class MeetingTranscriptNoiseFilterTests: XCTestCase {
             ["system", "microphone", "system", "system", "microphone", "microphone", "system", "microphone"]
         )
     }
+
+    func testFinalizeDropsWhisperSubtitleArtifactFromRawText() {
+        let finalized = MeetingTranscriptFinalizer.finalize(sourceTranscripts: [
+            .init(
+                source: .microphone,
+                result: STTResult(
+                    text: "What is happening? Продолжение следует...",
+                    words: [
+                        TimestampedWord(word: "What", startMs: 0, endMs: 150, confidence: 0.98),
+                        TimestampedWord(word: "is", startMs: 150, endMs: 270, confidence: 0.99),
+                        TimestampedWord(word: "happening?", startMs: 270, endMs: 610, confidence: 1.0),
+                        TimestampedWord(word: "Продолжение", startMs: 9_300, endMs: 10_700, confidence: 0.54),
+                        TimestampedWord(word: "следует...", startMs: 10_700, endMs: 12_100, confidence: 0.97),
+                    ],
+                    engine: .whisper,
+                    engineVariant: "large-v3-v20240930_turbo_632MB"
+                ),
+                startOffsetMs: 0
+            ),
+        ])
+
+        XCTAssertEqual(finalized.words.map(\.word), ["What", "is", "happening?"])
+        XCTAssertEqual(finalized.rawTranscript, "What is happening?")
+    }
+
+    func testFinalizeKeepsHighConfidenceWhisperSubtitlePhrase() {
+        let finalized = MeetingTranscriptFinalizer.finalize(sourceTranscripts: [
+            .init(
+                source: .microphone,
+                result: STTResult(
+                    text: "Продолжение следует...",
+                    words: [
+                        TimestampedWord(word: "Продолжение", startMs: 100, endMs: 1_400, confidence: 0.97),
+                        TimestampedWord(word: "следует...", startMs: 1_400, endMs: 2_800, confidence: 0.98),
+                    ],
+                    engine: .whisper,
+                    engineVariant: "large-v3-v20240930_turbo_632MB"
+                ),
+                startOffsetMs: 0
+            ),
+        ])
+
+        XCTAssertEqual(finalized.words.map(\.word), ["Продолжение", "следует..."])
+        XCTAssertEqual(finalized.rawTranscript, "Продолжение следует...")
+    }
 }

--- a/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import XCTest
 @testable import MacParakeetCore
 import os
@@ -594,6 +595,80 @@ final class TranscriptionServiceTests: XCTestCase {
         XCTAssertEqual(speakerCount, 2)
         XCTAssertFalse(diarizationRequested)
         XCTAssertFalse(diarizationApplied)
+    }
+
+    func testTranscribeMeetingSkipsLowSignalWhisperSystemSource() async throws {
+        let recordingFolder = URL(fileURLWithPath: AppPaths.tempDir)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: recordingFolder, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: recordingFolder) }
+
+        let mixedURL = recordingFolder.appendingPathComponent("meeting.m4a")
+        let microphoneURL = recordingFolder.appendingPathComponent("microphone.m4a")
+        let systemURL = recordingFolder.appendingPathComponent("system.m4a")
+        let microphoneWavURL = recordingFolder.appendingPathComponent("microphone.wav")
+        let silentSystemWavURL = recordingFolder.appendingPathComponent("system-silent.wav")
+        XCTAssertTrue(FileManager.default.createFile(atPath: mixedURL.path, contents: Data("mixed".utf8)))
+        XCTAssertTrue(FileManager.default.createFile(atPath: microphoneURL.path, contents: Data("microphone".utf8)))
+        XCTAssertTrue(FileManager.default.createFile(atPath: systemURL.path, contents: Data("system".utf8)))
+        XCTAssertTrue(FileManager.default.createFile(atPath: microphoneWavURL.path, contents: Data("converted microphone".utf8)))
+        try writeTestWAV(
+            samples: Array(repeating: 0.00001, count: 80_000),
+            to: silentSystemWavURL
+        )
+        await mockAudio.configureSequence(convertResults: [microphoneWavURL, silentSystemWavURL])
+
+        await mockSTT.configure(result: STTResult(
+            text: "Hello there",
+            words: [
+                TimestampedWord(word: "Hello", startMs: 50, endMs: 260, confidence: 0.9),
+                TimestampedWord(word: "there", startMs: 300, endMs: 540, confidence: 0.9),
+            ],
+            engine: .whisper,
+            engineVariant: SpeechEnginePreference.defaultWhisperModelVariant
+        ))
+
+        let recording = MeetingRecordingOutput(
+            sessionID: UUID(),
+            displayName: "Whisper Meeting",
+            folderURL: recordingFolder,
+            mixedAudioURL: mixedURL,
+            microphoneAudioURL: microphoneURL,
+            systemAudioURL: systemURL,
+            durationSeconds: 5.0,
+            sourceAlignment: MeetingSourceAlignment(
+                meetingOriginHostTime: nil,
+                microphone: .init(firstHostTime: nil, lastHostTime: nil, startOffsetMs: 0, writtenFrameCount: 240_000, sampleRate: 48_000),
+                system: .init(firstHostTime: nil, lastHostTime: nil, startOffsetMs: 0, writtenFrameCount: 240_000, sampleRate: 48_000)
+            ),
+            speechEngine: SpeechEngineSelection(engine: .whisper)
+        )
+
+        let result = try await service.transcribeMeeting(recording: recording)
+        let sttCallCount = await mockSTT.transcribeCallCount
+        let audioPaths = await mockSTT.audioPaths
+        let convertCallCount = await mockAudio.convertCallCount
+
+        XCTAssertEqual(result.rawTranscript, "Hello there")
+        XCTAssertEqual(result.speakerCount, 1)
+        XCTAssertEqual(result.wordTimestamps?.map(\.speakerId), ["microphone", "microphone"])
+        XCTAssertEqual(sttCallCount, 1)
+        XCTAssertEqual(audioPaths, [microphoneWavURL.path])
+        XCTAssertEqual(convertCallCount, 2)
+    }
+
+    func testMeetingSystemSignalDetectionRequiresSustainedActivity() {
+        XCTAssertFalse(TranscriptionService.containsTranscribableSignal(
+            samples: Array(repeating: 0.00001, count: 160_000),
+            sampleRate: 16_000
+        ))
+
+        let shortSpeech = Array(repeating: Float(0.01), count: 16_000)
+        let surroundingSilence = Array(repeating: Float(0.0), count: 64_000)
+        XCTAssertTrue(TranscriptionService.containsTranscribableSignal(
+            samples: shortSpeech + surroundingSilence,
+            sampleRate: 16_000
+        ))
     }
 
     func testTranscribeMeetingUsesCapturedSpeechEngineSelection() async throws {
@@ -1369,5 +1444,33 @@ final class TranscriptionServiceTests: XCTestCase {
         let created = FileManager.default.createFile(atPath: url.path, contents: Data("audio".utf8))
         XCTAssertTrue(created)
         return url
+    }
+
+    private func writeTestWAV(
+        samples: [Float],
+        sampleRate: Double = 16_000,
+        to url: URL
+    ) throws {
+        guard let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: sampleRate,
+            channels: 1,
+            interleaved: false
+        ),
+        let buffer = AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: AVAudioFrameCount(samples.count)
+        ) else {
+            return XCTFail("Failed to allocate test audio buffer")
+        }
+
+        buffer.frameLength = AVAudioFrameCount(samples.count)
+        let channel = buffer.floatChannelData![0]
+        for (index, sample) in samples.enumerated() {
+            channel[index] = sample
+        }
+
+        let file = try AVAudioFile(forWriting: url, settings: format.settings)
+        try file.write(from: buffer)
     }
 }

--- a/Tests/MacParakeetTests/ViewModels/MeetingRecordingPanelViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/MeetingRecordingPanelViewModelTests.swift
@@ -130,6 +130,34 @@ final class MeetingRecordingPanelViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.showsLaggingIndicator)
     }
 
+    func testWhisperRecordingShowsMeetingWarning() {
+        let viewModel = MeetingRecordingPanelViewModel()
+
+        viewModel.state = .recording
+        viewModel.speechEngine = SpeechEngineSelection(engine: .whisper)
+
+        XCTAssertTrue(viewModel.showsWhisperMeetingWarning)
+        XCTAssertTrue(viewModel.whisperMeetingWarningMessage.contains("saved transcript"))
+
+        viewModel.state = .transcribing
+        XCTAssertTrue(viewModel.showsWhisperMeetingWarning)
+
+        viewModel.state = .recording
+        viewModel.speechEngine = SpeechEngineSelection(engine: .parakeet)
+        XCTAssertFalse(viewModel.showsWhisperMeetingWarning)
+    }
+
+    func testResetClearsWhisperMeetingWarning() {
+        let viewModel = MeetingRecordingPanelViewModel()
+        viewModel.state = .recording
+        viewModel.speechEngine = SpeechEngineSelection(engine: .whisper)
+
+        viewModel.reset()
+
+        XCTAssertEqual(viewModel.speechEngine, SpeechEngineSelection(engine: .parakeet))
+        XCTAssertFalse(viewModel.showsWhisperMeetingWarning)
+    }
+
     func testResetClearsTranscriptPreview() {
         let viewModel = MeetingRecordingPanelViewModel()
         viewModel.state = .recording


### PR DESCRIPTION
## Summary
Refs #222. This keeps mostly-silent system audio out of Whisper meeting finalization, so background/system capture does not get merged into the saved transcript as subtitle-like hallucinations. It also keeps a narrow cleanup for the known low-confidence subtitle phrase if it still appears, and shows a clear warning when Whisper is used for meeting recording.

```
meeting recording
  |
  +-- microphone audio ------------> Whisper -> merge
  |
  +-- system audio -> activity check
          |
          +-- sustained speech ----> Whisper -> merge
          +-- too sparse/quiet ----> skip
```

## Validation
- Reproduced locally: the microphone excerpt was clean, while the matching system-audio excerpt produced the repeated subtitle artifact.
- `swift test --filter TranscriptionServiceTests`
- `swift test --filter MeetingTranscript`
- `swift test --filter MeetingRecordingPanelViewModelTests`
- `swift test` (`2231` passed, `1` skipped)

## Status
Draft while we QA Whisper meeting recordings end to end.