### PR TITLE
Suppress false dictation failure telemetry

### DIFF
--- a/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
+++ b/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
@@ -70,6 +70,7 @@ public actor DictationService: DictationServiceProtocol {
     private var currentOperationTelemetryContext = DictationTelemetryContext()
     private var currentObservabilityOperationContext: ObservabilityOperationContext?
     private var activeSessionID: Int = 0
+    private var cancellationRequestedDuringStartSessionID: Int?
 
     public var state: DictationState {
         _state
@@ -170,6 +171,7 @@ public actor DictationService: DictationServiceProtocol {
 
         let requestedSessionID = sessionID ?? activeSessionID + 1
         activeSessionID = requestedSessionID
+        cancellationRequestedDuringStartSessionID = nil
         currentOperationID = operationContext.operationID
         currentOperationTelemetryContext = context
         currentObservabilityOperationContext = operationContext
@@ -177,6 +179,9 @@ public actor DictationService: DictationServiceProtocol {
         do {
             try await audioProcessor.startCapture()
             // Guard against reentrancy: cancel or replacement may have run during the await above.
+            if cancellationRequestedDuringStartSessionID == requestedSessionID {
+                cancellationRequestedDuringStartSessionID = nil
+            }
             let activeAtStartCompletion = activeSessionID
             guard activeAtStartCompletion == requestedSessionID, case .recording = _state else {
                 let processorIsRecording: Bool
@@ -209,6 +214,20 @@ public actor DictationService: DictationServiceProtocol {
                     "startRecording stale failure ignored session=\(requestedSessionID) active=\(activeAtFailure) error=\(error.localizedDescription, privacy: .public)"
                 )
                 throw error
+            }
+            let cancellationRequestedDuringStart = cancellationRequestedDuringStartSessionID == requestedSessionID
+            if cancellationRequestedDuringStart {
+                cancellationRequestedDuringStartSessionID = nil
+            }
+            if Self.isInterruptedDuringSubscribe(error), cancellationRequestedDuringStart {
+                if cancellationRequestedDuringStart, case .recording = _state {
+                    _state = .cancelled
+                }
+                recordingStartedAt = nil
+                logger.notice(
+                    "startRecording interrupted after cancellation session=\(requestedSessionID) state=\(self.debugStateLabel(self._state), privacy: .public)"
+                )
+                return
             }
             let device = await audioProcessor.recordingDeviceInfo
             guard activeSessionID == requestedSessionID else {
@@ -358,6 +377,7 @@ public actor DictationService: DictationServiceProtocol {
         cancelGeneration += 1
         let generation = cancelGeneration
 
+        cancellationRequestedDuringStartSessionID = activeSessionID
         let audioURL = try? await audioProcessor.stopCapture()
         let device = await audioProcessor.recordingDeviceInfo
         pendingCancelledAudioURL = audioURL
@@ -392,6 +412,7 @@ public actor DictationService: DictationServiceProtocol {
         discardPendingCancelledAudio()
 
         if case .recording = _state {
+            cancellationRequestedDuringStartSessionID = activeSessionID
             if let url = try? await audioProcessor.stopCapture() {
                 try? FileManager.default.removeItem(at: url)
             }
@@ -481,6 +502,14 @@ public actor DictationService: DictationServiceProtocol {
         if let e = error as? DictationServiceError, e == .emptyTranscript { return true }
         if let e = error as? AudioProcessorError, case .insufficientSamples = e { return true }
         return false
+    }
+
+    private static func isInterruptedDuringSubscribe(_ error: Error) -> Bool {
+        guard let e = error as? AudioProcessorError,
+              case .recordingFailed(let reason) = e else {
+            return false
+        }
+        return reason == "interrupted during subscribe"
     }
 
     private func discardPendingCancelledAudio() {

--- a/Tests/MacParakeetTests/Services/Dictation/DictationServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/Dictation/DictationServiceTests.swift
@@ -99,6 +99,37 @@ final class DictationServiceTests: XCTestCase {
         XCTAssertEqual(operation["mode"], "hold")
     }
 
+    func testInterruptedSubscribeWithoutCancelEmitsFailureTelemetry() async throws {
+        let telemetry = DictationTelemetrySpy()
+        Telemetry.configure(telemetry)
+
+        await mockAudio.configureCaptureError(AudioProcessorError.recordingFailed("interrupted during subscribe"))
+
+        do {
+            try await service.startRecording(context: DictationTelemetryContext(trigger: .hotkey, mode: .hold))
+            XCTFail("Expected startRecording to throw")
+        } catch let error as AudioProcessorError {
+            if case .recordingFailed(let reason) = error {
+                XCTAssertEqual(reason, "interrupted during subscribe")
+            } else {
+                XCTFail("Expected interrupted recording failure, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        let events = telemetry.snapshot()
+        XCTAssertTrue(events.contains { event in
+            if case .dictationFailed = event { return true }
+            return false
+        })
+
+        let operation = try XCTUnwrap(dictationOperationProps(in: events).last)
+        XCTAssertEqual(operation["outcome"], "failure")
+        XCTAssertEqual(operation["trigger"], "hotkey")
+        XCTAssertEqual(operation["mode"], "hold")
+    }
+
     func testCancelDuringStartCaptureStillEmitsCancelledOperation() async throws {
         let telemetry = DictationTelemetrySpy()
         Telemetry.configure(telemetry)
@@ -119,6 +150,71 @@ final class DictationServiceTests: XCTestCase {
                 && operation["trigger"] == "hotkey"
                 && operation["mode"] == "hold"
         })
+    }
+
+    func testInterruptedSubscribeAfterCancelDoesNotEmitFailureTelemetry() async throws {
+        let telemetry = DictationTelemetrySpy()
+        Telemetry.configure(telemetry)
+
+        let audio = StartInterruptedAudioProcessor()
+        service = DictationService(
+            audioProcessor: audio,
+            sttTranscriber: mockSTT,
+            dictationRepo: dictationRepo
+        )
+
+        let startTask = Task {
+            try await self.service.startRecording(context: DictationTelemetryContext(trigger: .hotkey, mode: .hold))
+        }
+
+        await audio.waitForStartCapture()
+        await service.confirmCancel()
+        try await startTask.value
+
+        let events = telemetry.snapshot()
+        XCTAssertFalse(events.contains { event in
+            if case .dictationFailed = event { return true }
+            return false
+        })
+
+        let operations = dictationOperationProps(in: events)
+        XCTAssertTrue(operations.contains { operation in
+            operation["outcome"] == "cancelled"
+                && operation["trigger"] == "hotkey"
+                && operation["mode"] == "hold"
+        })
+    }
+
+    func testInterruptedSubscribeAfterCancelLeavesServiceNonRecordingBeforeCancelCompletes() async throws {
+        let telemetry = DictationTelemetrySpy()
+        Telemetry.configure(telemetry)
+
+        let audio = StartInterruptedDelayedStopAudioProcessor()
+        service = DictationService(
+            audioProcessor: audio,
+            sttTranscriber: mockSTT,
+            dictationRepo: dictationRepo
+        )
+
+        let startTask = Task {
+            try await self.service.startRecording(context: DictationTelemetryContext(trigger: .hotkey, mode: .hold))
+            return await self.service.state
+        }
+
+        await audio.waitForStartCapture()
+        let cancelTask = Task { await service.confirmCancel() }
+        await audio.waitForStopCapture()
+
+        let stateAfterSuppressedStart = try await startTask.value
+        XCTAssertFalse(Self.isRecording(stateAfterSuppressedStart))
+
+        await audio.allowStopCaptureToReturn()
+        await cancelTask.value
+
+        let finalState = await service.state
+        if case .idle = finalState {} else {
+            XCTFail("Expected idle after confirmCancel, got \(finalState)")
+        }
     }
 
     func testStopRecordingTranscribesAndSaves() async throws {
@@ -261,5 +357,118 @@ final class DictationServiceTests: XCTestCase {
             guard case .dictationOperation = event else { return nil }
             return event.props ?? [:]
         }
+    }
+
+    private static func isRecording(_ state: DictationState) -> Bool {
+        if case .recording = state { return true }
+        return false
+    }
+}
+
+private actor StartInterruptedAudioProcessor: AudioProcessorProtocol {
+    private var startWaiters: [CheckedContinuation<Void, Never>] = []
+    private var startRelease: CheckedContinuation<Void, Never>?
+    private var startCaptureEntered = false
+
+    var audioLevel: Float { 0 }
+    var isRecording: Bool { false }
+    var recordingDeviceInfo: RecordingDeviceInfo? { nil }
+
+    func convert(fileURL: URL) async throws -> URL {
+        fileURL
+    }
+
+    func startCapture() async throws {
+        startCaptureEntered = true
+        for waiter in startWaiters {
+            waiter.resume()
+        }
+        startWaiters.removeAll()
+
+        await withCheckedContinuation { continuation in
+            startRelease = continuation
+        }
+
+        throw AudioProcessorError.recordingFailed("interrupted during subscribe")
+    }
+
+    func stopCapture() async throws -> URL {
+        startRelease?.resume()
+        startRelease = nil
+        return URL(fileURLWithPath: "/tmp/interrupted-start.wav")
+    }
+
+    func waitForStartCapture() async {
+        guard !startCaptureEntered else { return }
+        await withCheckedContinuation { continuation in
+            startWaiters.append(continuation)
+        }
+    }
+}
+
+private actor StartInterruptedDelayedStopAudioProcessor: AudioProcessorProtocol {
+    private var startWaiters: [CheckedContinuation<Void, Never>] = []
+    private var startRelease: CheckedContinuation<Void, Never>?
+    private var stopWaiters: [CheckedContinuation<Void, Never>] = []
+    private var stopRelease: CheckedContinuation<Void, Never>?
+    private var startCaptureEntered = false
+    private var stopCaptureEntered = false
+
+    var audioLevel: Float { 0 }
+    var isRecording: Bool { false }
+    var recordingDeviceInfo: RecordingDeviceInfo? { nil }
+
+    func convert(fileURL: URL) async throws -> URL {
+        fileURL
+    }
+
+    func startCapture() async throws {
+        startCaptureEntered = true
+        for waiter in startWaiters {
+            waiter.resume()
+        }
+        startWaiters.removeAll()
+
+        await withCheckedContinuation { continuation in
+            startRelease = continuation
+        }
+
+        throw AudioProcessorError.recordingFailed("interrupted during subscribe")
+    }
+
+    func stopCapture() async throws -> URL {
+        stopCaptureEntered = true
+        for waiter in stopWaiters {
+            waiter.resume()
+        }
+        stopWaiters.removeAll()
+
+        startRelease?.resume()
+        startRelease = nil
+
+        await withCheckedContinuation { continuation in
+            stopRelease = continuation
+        }
+
+        return URL(fileURLWithPath: "/tmp/interrupted-start-delayed-stop.wav")
+    }
+
+    func waitForStartCapture() async {
+        guard !startCaptureEntered else { return }
+        await withCheckedContinuation { continuation in
+            startWaiters.append(continuation)
+        }
+    }
+
+    func waitForStopCapture() async {
+        guard !stopCaptureEntered else { return }
+        await withCheckedContinuation { continuation in
+            stopWaiters.append(continuation)
+        }
+    }
+
+    func allowStopCaptureToReturn() {
+        stopRelease?.resume()
+        stopRelease = nil
     }
 }


### PR DESCRIPTION
## Summary
- Suppresses the exact `AudioProcessorError.recordingFailed("interrupted during subscribe")` path only when it is caused by cancelling while microphone startup is still in flight.
- Preserves the existing `dictation_operation` cancellation telemetry so the user action is still counted as cancelled, not silently dropped.
- Adds async tests for the cancel/start race, state behavior while `stopCapture()` is still suspended, and the negative case where the same error still reports as a failure without cancellation.

## Diagnosis
Telemetry review found that the high `Dictation Failed` count was dominated by a false-failure race, not by completed dictation attempts failing.

In the sampled 24h Cloudflare D1 window, every `interrupted during subscribe` failure was paired with a nearby `dictation_operation` cancellation within 2 seconds:
- `0.6.0`: 40/40 paired, 13 sessions
- `0.6.1`: 9/9 paired, 1 session
- `0.0.0`: 4/4 paired, 2 sessions

Local logs also showed the same ordering: `dictation_capture_start_cancelled_during_subscribe` before `dictation_capture_start_aborted reason="interrupted_during_subscribe"`.

## Impact
This PR fixes telemetry accuracy for hold-to-dictate cancellation during mic startup. It should reduce noisy `dictation_failed` events and make the error log reflect actual failures.

This does not claim to fix real microphone startup failures such as CoreAudio `-10868`; those remain on the failure telemetry path and should be monitored separately. The default-mic routing code path was addressed in `0.6.1`, but usage is still too low to field-prove that independently.

## Scope
Small `0.6.2` candidate patch only:
- No release/appcast changes
- No telemetry schema changes
- No audio routing changes
- No unrelated local dirty work included

## Verification
- `git diff --check`
- `swift test --filter DictationService` -> 18 tests, 0 failures
- `swift test` -> 2227 tests, 1 skipped, 0 failures
