### PR TITLE
Fix yt-dlp helper signing repair

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -417,6 +417,8 @@ Full guide: `docs/distribution.md`. Quick steps:
 0. **Pre-flight:** Run `swift test` (all must pass). Check current version: `curl -s "https://macparakeet.com/appcast.xml" | grep sparkle:shortVersionString`. Decide version bump -- patch (0.1.x) for fixes, minor (0.x.0) for features.
 1. **Build:** `VERSION=X.Y.Z scripts/dist/build_app_bundle.sh`
 2. **Sign + notarize:** `scripts/dist/sign_notarize.sh`
+   - After signing, smoke-test bundled helpers: `dist/MacParakeet.app/Contents/Resources/yt-dlp --version`.
+   - `yt-dlp_macos` is a PyInstaller binary. If it is signed with hardened runtime, it must have `com.apple.security.cs.disable-library-validation=true`; otherwise fresh installs can fail on first YouTube use with `[PYI:ERROR] Failed to load Python shared library ... different Team IDs`.
 3. **Upload DMG to R2:** `npx wrangler r2 object put macparakeet-downloads/MacParakeet.dmg --file dist/MacParakeet.dmg --content-type "application/x-apple-diskimage" --remote`
 4. **Verify R2 file size matches local:** `curl -sI "https://downloads.macparakeet.com/MacParakeet.dmg?ts=$(date +%s)" | grep content-length` -- must equal `stat -f%z dist/MacParakeet.dmg`
 5. **Sign for Sparkle:** `.build/artifacts/sparkle/Sparkle/bin/sign_update dist/MacParakeet.dmg`
@@ -571,6 +573,7 @@ These are hard-won lessons. Don't repeat them.
 - **Retained purchase activation is intentional** -- Do not delete `EntitlementsService`, `LemonSqueezyLicenseAPI`, entitlement state, or trial/license telemetry as dead code unless the project owner explicitly requests it and the decision is reflected in an ADR/spec update.
 - **Meeting recovery artifacts are user data** -- Do not delete meeting session folders, lock files, or source audio outside the recovery/discard flows without explicit user intent.
 - **CLI is a public contract** -- Preserve `macparakeet-cli` behavior and update `Sources/CLI/CHANGELOG.md` for compatibility-relevant changes.
+- **PyInstaller helpers need library-validation care** -- Bundled `yt-dlp_macos` unpacks and `dlopen`s an embedded Python framework. Developer ID + hardened runtime signing without `com.apple.security.cs.disable-library-validation=true` breaks fresh installs at first YouTube transcription/playback with a Team ID mismatch.
 - **Review agents catch real bugs** -- Running a review agent on critical flows catches P0 issues. Worth the 60 seconds.
 - **CI duplicates without workflow concurrency** -- Add `concurrency` with `cancel-in-progress: true` and a stable group key to avoid duplicate pipelines.
 

--- a/Sources/MacParakeetCore/Services/BinaryBootstrap.swift
+++ b/Sources/MacParakeetCore/Services/BinaryBootstrap.swift
@@ -91,6 +91,22 @@ public actor BinaryBootstrap {
         return targetPath
     }
 
+    public func reinstallYtDlpFromBundledSeedOrDownload() async throws -> String {
+        try ensureDirectories()
+
+        let targetPath = ytDlpBinaryPath()
+        if let bundledPath = bundledYtDlpPath(),
+           fileManager.isExecutableFile(atPath: bundledPath)
+        {
+            try installExecutable(from: URL(fileURLWithPath: bundledPath), toPath: targetPath)
+            return targetPath
+        }
+
+        try await installYtDlp(at: targetPath)
+        defaults.set(now(), forKey: Self.ytDlpLastUpdateCheckKey)
+        return targetPath
+    }
+
     public nonisolated static func resolveYtDlpPath(
         fileManager: FileManager = .default,
         managedPath: String = AppPaths.ytDlpBinaryPath,

--- a/Sources/MacParakeetCore/Services/YouTubeDownloader.swift
+++ b/Sources/MacParakeetCore/Services/YouTubeDownloader.swift
@@ -68,6 +68,25 @@ public actor YouTubeDownloader {
         }
 
         let ytDlpPath = try await resolveYtDlpPath()
+        do {
+            return try await download(url: url, ytDlpPath: ytDlpPath, onProgress: onProgress)
+        } catch {
+            guard Self.isPyInstallerLibraryValidationError(error) else {
+                throw error
+            }
+
+            let repairedPath = try await binaryBootstrap.reinstallYtDlpFromBundledSeedOrDownload()
+            return try await download(url: url, ytDlpPath: repairedPath, onProgress: onProgress)
+        }
+    }
+
+    // MARK: - Private
+
+    private func download(
+        url: String,
+        ytDlpPath: String,
+        onProgress: (@Sendable (Int) -> Void)?
+    ) async throws -> DownloadResult {
 
         // Step 1: Fetch metadata
         let metadata = try await fetchMetadata(ytDlpPath: ytDlpPath, url: url)
@@ -84,8 +103,6 @@ public actor YouTubeDownloader {
             videoDescription: metadata.videoDescription
         )
     }
-
-    // MARK: - Private
 
     /// Build a PATH that includes common binary locations plus app-managed bin directory.
     private nonisolated static func extendedPATH() -> String {
@@ -463,6 +480,15 @@ public actor YouTubeDownloader {
         }
 
         return sanitized(lines.first ?? trimmed)
+    }
+
+    nonisolated static func isPyInstallerLibraryValidationError(_ error: Error) -> Bool {
+        guard case YouTubeDownloadError.downloadFailed(let reason) = error else {
+            return false
+        }
+        let normalized = reason.lowercased()
+        return normalized.contains("failed to load python shared library")
+            || (normalized.contains("pyi-") && normalized.contains("different team ids"))
     }
 
     private func runYtDlp(

--- a/Tests/MacParakeetTests/Services/BinaryBootstrapTests.swift
+++ b/Tests/MacParakeetTests/Services/BinaryBootstrapTests.swift
@@ -149,6 +149,69 @@ final class BinaryBootstrapTests: XCTestCase {
         )
     }
 
+    func testReinstallYtDlpFromBundledSeedOrDownloadPrefersBundledSeed() async throws {
+        try FileManager.default.createDirectory(at: binDir, withIntermediateDirectories: true)
+        try Data("bad-managed-yt-dlp".utf8).write(to: ytDlpPath)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: ytDlpPath.path)
+
+        let bundledPath = rootDir
+            .appendingPathComponent("bundle", isDirectory: true)
+            .appendingPathComponent("yt-dlp")
+        try FileManager.default.createDirectory(at: bundledPath.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let bundledData = Data("fixed-bundled-yt-dlp".utf8)
+        try bundledData.write(to: bundledPath)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: bundledPath.path)
+
+        let bootstrap = makeBootstrap(
+            bundledYtDlpPath: { bundledPath.path },
+            handler: { _ in
+                XCTFail("Bundled repair should avoid network install")
+                throw BinaryBootstrapError.downloadFailed("unexpected request")
+            }
+        )
+
+        let installedPath = try await bootstrap.reinstallYtDlpFromBundledSeedOrDownload()
+
+        XCTAssertEqual(installedPath, ytDlpPath.path)
+        XCTAssertEqual(try Data(contentsOf: ytDlpPath), bundledData)
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: installedPath))
+    }
+
+    func testReinstallYtDlpFromBundledSeedOrDownloadDownloadsWhenNoBundledSeedExists() async throws {
+        try FileManager.default.createDirectory(at: binDir, withIntermediateDirectories: true)
+        try Data("bad-managed-yt-dlp".utf8).write(to: ytDlpPath)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: ytDlpPath.path)
+
+        let binaryData = Data("downloaded-repaired-yt-dlp".utf8)
+        let checksum = sha256Hex(binaryData)
+        let bootstrap = makeBootstrap { request in
+            guard let url = request.url else {
+                throw BinaryBootstrapError.downloadFailed("Missing URL")
+            }
+
+            switch url.lastPathComponent {
+            case "yt-dlp_macos":
+                return (Self.httpResponse(url: url, statusCode: 200), binaryData)
+            case "SHA2-256SUMS":
+                return (Self.httpResponse(url: url, statusCode: 200), Data("\(checksum) yt-dlp_macos\n".utf8))
+            default:
+                return (Self.httpResponse(url: url, statusCode: 404), Data())
+            }
+        }
+
+        let installedPath = try await bootstrap.reinstallYtDlpFromBundledSeedOrDownload()
+
+        XCTAssertEqual(installedPath, ytDlpPath.path)
+        XCTAssertEqual(try Data(contentsOf: ytDlpPath), binaryData)
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: installedPath))
+
+        let defaults = UserDefaults(suiteName: suiteName)!
+        XCTAssertEqual(
+            defaults.object(forKey: "ytDlp.lastUpdateCheckAt") as? Date,
+            Date(timeIntervalSince1970: 1_700_000_000)
+        )
+    }
+
     func testEnsureYtDlpAvailableChecksumMismatchRemovesTempBinary() async throws {
         let binaryData = Data("yt-dlp-test-binary".utf8)
 

--- a/Tests/MacParakeetTests/Services/YouTubeDownloaderTests.swift
+++ b/Tests/MacParakeetTests/Services/YouTubeDownloaderTests.swift
@@ -74,4 +74,21 @@ final class YouTubeDownloaderTests: XCTestCase {
         XCTAssertNil(result.thumbnailURL)
         XCTAssertNil(result.videoDescription)
     }
+
+    func testPyInstallerLibraryValidationErrorDetection() {
+        let error = YouTubeDownloadError.downloadFailed(
+            "[PYI-5863:ERROR] Failed to load Python shared library '<path>': dlopen(<path>): code signature not valid for use in process: mapping process and mapped file (non-platform) have different Team IDs"
+        )
+
+        XCTAssertTrue(YouTubeDownloader.isPyInstallerLibraryValidationError(error))
+    }
+
+    func testPyInstallerLibraryValidationErrorDetectionIgnoresOtherFailures() {
+        XCTAssertFalse(YouTubeDownloader.isPyInstallerLibraryValidationError(
+            YouTubeDownloadError.downloadFailed("ERROR: Video unavailable")
+        ))
+        XCTAssertFalse(YouTubeDownloader.isPyInstallerLibraryValidationError(
+            YouTubeDownloadError.ytDlpNotFound
+        ))
+    }
 }

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -170,6 +170,9 @@ Verify:
 ```bash
 spctl --assess --type execute --verbose=4 dist/MacParakeet.app
 # Expected: "accepted / source=Notarized Developer ID"
+
+dist/MacParakeet.app/Contents/Resources/yt-dlp --version
+# Expected: prints a yt-dlp version, not a [PYI:ERROR] Python shared library failure
 ```
 
 ### Step 3: Upload DMG to R2
@@ -270,6 +273,7 @@ npx wrangler r2 object put macparakeet-downloads/MacParakeet.dmg \
 | Update found but same version | Build number in appcast ≤ installed build | Ensure `sparkle:version` (build number) is strictly greater |
 | `notarytool` bus error / crash | Using `--wait` flag | **Never use `xcrun notarytool submit --wait`.** Submit without `--wait`, then poll with `xcrun notarytool info <submission-id>`. See gotcha #1 below. |
 | TCC permissions silently fail | User ran app from DMG volume instead of /Applications | DMG must include Applications symlink. See gotcha #3 below. |
+| YouTube transcription fails with `[PYI:ERROR] Failed to load Python shared library ... different Team IDs` | Bundled `yt-dlp_macos` was re-signed with hardened runtime but without disabling library validation | Sign `yt-dlp` with `com.apple.security.cs.disable-library-validation=true`, smoke-test `Contents/Resources/yt-dlp --version`, and repair any bad managed copy in Application Support |
 
 ### Known gotchas (hard-won lessons)
 
@@ -337,6 +341,34 @@ The Sparkle `sign_update` tool produces an EdDSA signature over the exact bytes 
 4. Put the signature in the appcast
 
 If another process or agent overwrites the R2 object between steps 2 and 3, the signature won't match. Always verify file sizes match after upload (Step 3 in the release workflow).
+
+#### 5. `yt-dlp_macos` is PyInstaller and needs a special signing entitlement
+
+MacParakeet bundles `yt-dlp` as a helper seed. Fresh installs copy that seed
+from `Contents/Resources/yt-dlp` into
+`~/Library/Application Support/MacParakeet/bin/yt-dlp` before first YouTube
+transcription. Existing users may already have a working managed helper, so a
+bad bundled seed can appear as a fresh-install-only bug.
+
+The official `yt-dlp_macos` asset is a PyInstaller binary. If the release script
+re-signs it with Developer ID + hardened runtime but does not include
+`com.apple.security.cs.disable-library-validation=true`, macOS library
+validation blocks PyInstaller's extracted embedded `Python.framework` at runtime:
+
+```text
+[PYI:ERROR] Failed to load Python shared library ... different Team IDs
+```
+
+This fails when a user starts YouTube transcription or opens the YouTube video
+playback stream extraction path. It does not affect dictation, local file
+transcription, meeting recording, or STT model loading.
+
+Release requirements:
+- Sign bundled `yt-dlp` with hardened runtime plus `com.apple.security.cs.disable-library-validation=true`, or do not apply hardened runtime to that helper.
+- Smoke-test after signing: `dist/MacParakeet.app/Contents/Resources/yt-dlp --version`.
+- If a bad build shipped, repair existing users by replacing
+  `~/Library/Application Support/MacParakeet/bin/yt-dlp`; a fixed bundled seed
+  alone will not help users who already copied the bad managed helper.
 
 ## Auto-Updates (Sparkle)
 

--- a/scripts/dist/YtDlpRuntime.entitlements
+++ b/scripts/dist/YtDlpRuntime.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>

--- a/scripts/dist/sign_notarize.sh
+++ b/scripts/dist/sign_notarize.sh
@@ -67,12 +67,16 @@ fi
 
 # Sign helper binaries under Resources.
 NODE_RUNTIME_ENTITLEMENTS="$ROOT_DIR/scripts/dist/NodeRuntime.entitlements"
+YTDLP_RUNTIME_ENTITLEMENTS="$ROOT_DIR/scripts/dist/YtDlpRuntime.entitlements"
 while IFS= read -r -d '' bin; do
   base="$(basename "$bin")"
   echo "Signing: $bin"
   if [[ "$base" == "node" || "$base" == "node-arm64" || "$base" == "node-x86_64" ]]; then
     codesign --force --sign "$SIGN_IDENTITY" --options runtime --timestamp \
       --entitlements "$NODE_RUNTIME_ENTITLEMENTS" "$bin"
+  elif [[ "$base" == "yt-dlp" ]]; then
+    codesign --force --sign "$SIGN_IDENTITY" --options runtime --timestamp \
+      --entitlements "$YTDLP_RUNTIME_ENTITLEMENTS" "$bin"
   else
     codesign --force --sign "$SIGN_IDENTITY" --options runtime --timestamp "$bin"
   fi


### PR DESCRIPTION
## Summary
- signs bundled yt-dlp with the PyInstaller library-validation entitlement
- repairs bad managed yt-dlp copies by reinstalling from the fixed bundled seed or verified download
- documents the release smoke test for this failure mode

Fixes https://github.com/moona3k/macparakeet/issues/226

## Testing
- swift test --filter BinaryBootstrapTests
- swift test --filter YouTubeDownloaderTests
- swift test