### PR TITLE
Keep meeting mic alive after system audio interruption

### DIFF
--- a/Sources/MacParakeetCore/Audio/MeetingAudioCaptureService.swift
+++ b/Sources/MacParakeetCore/Audio/MeetingAudioCaptureService.swift
@@ -5,6 +5,7 @@ import OSLog
 public enum MeetingAudioCaptureEvent: Sendable {
     case microphoneBuffer(AVAudioPCMBuffer, AVAudioTime)
     case systemBuffer(AVAudioPCMBuffer, AVAudioTime)
+    case sourceInterrupted(source: AudioSource, error: MeetingAudioError)
     case error(MeetingAudioError)
 }
 
@@ -140,6 +141,11 @@ public actor MeetingAudioCaptureService {
         eventSink.setHandler(handler)
         var microphoneStartReport: MeetingMicrophoneCaptureStartReport?
         var attemptedMicrophoneStart = false
+        let systemAudioFailureEvent: @Sendable (MeetingAudioError) -> MeetingAudioCaptureEvent = { error in
+            sourceMode.capturesMicrophone
+                ? .sourceInterrupted(source: .system, error: error)
+                : .error(error)
+        }
 
         do {
             if sourceMode.capturesMicrophone {
@@ -173,7 +179,7 @@ public actor MeetingAudioCaptureService {
                         Logger(subsystem: "com.macparakeet.core", category: "MeetingAudioCaptureService")
                             .warning("deepCopyBuffer nil for system capture: format=\(buffer.format.commonFormat.rawValue) rate=\(buffer.format.sampleRate) ch=\(buffer.format.channelCount) interleaved=\(buffer.format.isInterleaved) frames=\(buffer.frameLength)")
                         self?.eventSink.emit(
-                            .error(
+                            systemAudioFailureEvent(
                                 .captureRuntimeFailure(
                                     "system buffer copy failed (format=\(buffer.format.commonFormat.rawValue) rate=\(buffer.format.sampleRate) channels=\(buffer.format.channelCount))"
                                 )
@@ -184,7 +190,7 @@ public actor MeetingAudioCaptureService {
                     self?.eventSink.emit(.systemBuffer(copy, time))
                 },
                 onStall: { [weak self] error in
-                    self?.eventSink.emit(.error(error))
+                    self?.eventSink.emit(systemAudioFailureEvent(error))
                 }
             )
         } catch {

--- a/Sources/MacParakeetCore/Audio/SystemAudioStream.swift
+++ b/Sources/MacParakeetCore/Audio/SystemAudioStream.swift
@@ -364,7 +364,15 @@ extension SystemAudioStream: SCStreamOutput, SCStreamDelegate {
         AudioCaptureDiagnostics.append(
             "system_audio_stream_stopped_with_error \(AudioCaptureDiagnostics.errorFields(error))"
         )
-        let observer = watchdogLock.withLock { stallObserver }
+        let observer = watchdogLock.withLock { () -> StallObserver? in
+            guard !hasReportedStall else { return nil }
+            hasReportedStall = true
+            watchdogWorkItem?.cancel()
+            watchdogWorkItem = nil
+            heartbeatTimer?.cancel()
+            heartbeatTimer = nil
+            return stallObserver
+        }
         observer?(.captureRuntimeFailure("system audio stream stopped: \(error.localizedDescription)"))
     }
 }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -111,6 +111,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     private var transcriptAssembler = MeetingTranscriptAssembler()
     private var isTranscriptionLagging = false
     private var captureFailed = false
+    private var interruptedSources: Set<AudioSource> = []
     private var sourceCaptureMetrics: [AudioSource: SourceCaptureMetrics] = [:]
     private var latestLevels = MeetingAudioLevels()
     private var recentSystemRms: Float = 0
@@ -249,6 +250,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             transcriptAssembler.reset()
             isTranscriptionLagging = false
             captureFailed = false
+            interruptedSources = []
             sourceCaptureMetrics = [:]
             recentSystemRms = 0
             recentProcessedMicRms = 0
@@ -578,7 +580,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
                 await failCapture(error)
             }
         case .systemBuffer(let buffer, let time):
-            guard !captureFailed else { return }
+            guard !captureFailed, !interruptedSources.contains(.system) else { return }
             do {
                 recordCaptureMetrics(for: .system, time: time)
                 try writer?.write(buffer, source: .system)
@@ -594,9 +596,30 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             } catch {
                 await failCapture(error)
             }
+        case .sourceInterrupted(let source, let error):
+            guard !captureFailed else { return }
+            await handleSourceInterruption(source: source, error: error)
         case .error(let error):
             guard !captureFailed else { return }
             await failCapture(error)
+        }
+    }
+
+    private func handleSourceInterruption(source: AudioSource, error: Error) async {
+        guard !interruptedSources.contains(source) else { return }
+        interruptedSources.insert(source)
+        logger.warning("meeting_capture_source_interrupted source=\(source.rawValue, privacy: .public) error_type=\(AudioCaptureDiagnostics.errorType(error), privacy: .public) error_detail=\(error.localizedDescription, privacy: .private)")
+        AudioCaptureDiagnostics.append(
+            "meeting_capture_source_interrupted source=\(source.rawValue) \(AudioCaptureDiagnostics.errorFields(error))"
+        )
+
+        switch source {
+        case .microphone:
+            await failCapture(error)
+        case .system:
+            latestLevels.system = 0
+            recentSystemRms = 0
+            latestSystemSignalAt = nil
         }
     }
 
@@ -911,6 +934,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         micConditioner = PassthroughMicConditioner()
         latestLevels = MeetingAudioLevels()
         sourceCaptureMetrics = [:]
+        interruptedSources = []
         recentSystemRms = 0
         recentProcessedMicRms = 0
         latestSystemSignalAt = nil

--- a/Tests/MacParakeetTests/Audio/MeetingAudioCaptureServiceTests.swift
+++ b/Tests/MacParakeetTests/Audio/MeetingAudioCaptureServiceTests.swift
@@ -310,12 +310,41 @@ final class MeetingAudioCaptureServiceTests: XCTestCase {
         }
     }
 
-    func testEmitsRuntimeErrorEventWhenSystemCaptureStallsMidSession() async throws {
+    func testEmitsSourceInterruptedWhenSystemCaptureStallsInMicrophoneAndSystemMode() async throws {
         let microphone = MockMeetingMicrophoneCapture()
         let systemCapture = MockMeetingSystemAudioCapture()
         let service = MeetingAudioCaptureService(
             microphoneCapture: microphone,
             systemAudioCaptureFactory: { systemCapture }
+        )
+
+        let events = await service.events
+        _ = try await service.start()
+        defer { Task { await service.stop() } }
+
+        systemCapture.emitStall(.captureRuntimeFailure("system audio stream stopped delivering buffers (gap 6.0s)"))
+
+        var iterator = events.makeAsyncIterator()
+        let emitted = await iterator.next()
+        guard case let .sourceInterrupted(source, error)? = emitted else {
+            XCTFail("Expected .sourceInterrupted event, got \(String(describing: emitted))")
+            return
+        }
+        XCTAssertEqual(source, .system)
+        guard case .captureRuntimeFailure(let message) = error else {
+            XCTFail("Expected captureRuntimeFailure, got \(error)")
+            return
+        }
+        XCTAssertTrue(message.contains("stopped delivering buffers"))
+    }
+
+    func testEmitsRuntimeErrorWhenSystemCaptureStallsInSystemOnlyMode() async throws {
+        let microphone = MockMeetingMicrophoneCapture()
+        let systemCapture = MockMeetingSystemAudioCapture()
+        let service = MeetingAudioCaptureService(
+            microphoneCapture: microphone,
+            systemAudioCaptureFactory: { systemCapture },
+            sourceModeProvider: { .systemOnly }
         )
 
         let events = await service.events
@@ -492,6 +521,8 @@ private actor CapturedMeetingCaptureEvents {
             microphoneBufferCount += 1
         case .systemBuffer:
             systemBufferCount += 1
+        case .sourceInterrupted:
+            break
         case .error:
             break
         }

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
@@ -421,6 +421,49 @@ final class MeetingRecordingServiceTests: XCTestCase {
         await service.cancelRecording()
     }
 
+    func testSystemSourceInterruptionKeepsMicrophoneRecordingAlive() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let audioConverter = MockMeetingAudioFileConverter()
+        let sttClient = CountingMeetingSTTClient()
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: audioConverter,
+            sttTranscriber: sttClient
+        )
+
+        try await service.startRecording()
+
+        let systemBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.5))
+        await captureService.yield(.systemBuffer(
+            systemBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
+        ))
+        try await waitForSystemLevel(service) { $0 > 0 }
+
+        await captureService.yield(.sourceInterrupted(
+            source: .system,
+            error: .captureRuntimeFailure("system audio stream stopped: Failed to find any displays or windows to capture")
+        ))
+        try await waitForSystemLevel(service) { $0 == 0 }
+
+        let modeAfterSystemInterruption = await service.captureMode
+        let stopCallCountBeforeManualStop = await captureService.stopCallCount
+        XCTAssertEqual(modeAfterSystemInterruption, .full)
+        XCTAssertEqual(stopCallCountBeforeManualStop, 0)
+
+        let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.25))
+        await captureService.yield(.microphoneBuffer(
+            microphoneBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 101.0))
+        ))
+
+        let output = try await service.stopRecording()
+        defer { try? FileManager.default.removeItem(at: output.folderURL) }
+
+        XCTAssertNotNil(output.sourceAlignment.microphone)
+        XCTAssertNotNil(output.sourceAlignment.system)
+    }
+
     func testStopRecordingPreservesCrossStreamHostTimeOffsetsInSourceAlignment() async throws {
         let captureService = MockMeetingAudioCaptureService()
         let audioConverter = MockMeetingAudioFileConverter()
@@ -927,6 +970,21 @@ final class MeetingRecordingServiceTests: XCTestCase {
         }
     }
 
+    private func waitForSystemLevel(
+        _ service: MeetingRecordingService,
+        timeout: Duration = .seconds(1),
+        _ predicate: @escaping (Float) -> Bool
+    ) async throws {
+        let startedAt = ContinuousClock.now
+        while !predicate(await service.systemLevel) {
+            if startedAt.duration(to: .now) > timeout {
+                XCTFail("Timed out waiting for system level predicate")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+    }
+
     private func makeMonoFloatBuffer(frameCount: Int, sampleValue: Float) -> AVAudioPCMBuffer? {
         guard let format = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,
@@ -1149,6 +1207,7 @@ private actor MockMeetingAudioCaptureService: MeetingAudioCapturing {
     private var stream: AsyncStream<MeetingAudioCaptureEvent>?
     private let startReport: MeetingAudioCaptureStartReport
     private(set) var startCallCount = 0
+    private(set) var stopCallCount = 0
     private(set) var requestedSourceModes: [MeetingAudioSourceMode?] = []
 
     init(
@@ -1182,6 +1241,7 @@ private actor MockMeetingAudioCaptureService: MeetingAudioCapturing {
     }
 
     func stop() async {
+        stopCallCount += 1
         continuation?.finish()
         continuation = nil
         stream = nil

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
@@ -433,10 +433,11 @@ final class MeetingRecordingServiceTests: XCTestCase {
 
         try await service.startRecording()
 
+        let firstSystemHostTime = AVAudioTime.hostTime(forSeconds: 100.0)
         let systemBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.5))
         await captureService.yield(.systemBuffer(
             systemBuffer,
-            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
+            AVAudioTime(hostTime: firstSystemHostTime)
         ))
         try await waitForSystemLevel(service) { $0 > 0 }
 
@@ -451,6 +452,12 @@ final class MeetingRecordingServiceTests: XCTestCase {
         XCTAssertEqual(modeAfterSystemInterruption, .full)
         XCTAssertEqual(stopCallCountBeforeManualStop, 0)
 
+        let lateSystemBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.75))
+        await captureService.yield(.systemBuffer(
+            lateSystemBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 102.0))
+        ))
+
         let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.25))
         await captureService.yield(.microphoneBuffer(
             microphoneBuffer,
@@ -462,6 +469,7 @@ final class MeetingRecordingServiceTests: XCTestCase {
 
         XCTAssertNotNil(output.sourceAlignment.microphone)
         XCTAssertNotNil(output.sourceAlignment.system)
+        XCTAssertEqual(output.sourceAlignment.system?.lastHostTime, firstSystemHostTime)
     }
 
     func testStopRecordingPreservesCrossStreamHostTimeOffsetsInSourceAlignment() async throws {

--- a/plans/active/issue-224-screen-capturekit-recording-stop.md
+++ b/plans/active/issue-224-screen-capturekit-recording-stop.md
@@ -86,10 +86,41 @@ because no recording source remains.
 
 - Should the first fix only preserve mic recording, or also try to restart
   ScreenCaptureKit after display topology changes?
-- How should the UI communicate "system audio stopped, mic recording continues"
-  without alarming the user mid-meeting?
 - Should final metadata explicitly record source interruptions so Library export
   and debugging can explain partial system audio?
+
+## Follow-Up UX
+
+The live UI should use a subtle warning, not a modal alert:
+
+```text
+System audio stopped. Microphone recording continues.
+
+[Send Diagnostic Report]
+
+Sends a redacted audio diagnostic log excerpt.
+No audio or transcript is included.
+```
+
+The report button should reuse the existing feedback path:
+
+```text
+Interruption UI
+        |
+        v
+FeedbackService /api/feedback
+        |
+        v
+Server creates GitHub issue with bot account
+```
+
+The client should send structured diagnostics to the backend rather than open
+GitHub directly. That keeps the user action to one click, avoids exposing logs
+in a public issue form, and lets the server decide how to file or route the
+report. The diagnostic payload should include a redacted, capped excerpt of
+`dictation-audio.log`, the capture mode, interrupted source, ScreenCaptureKit
+error code, app version, macOS version, and timestamp. It must not include
+audio or transcript content.
 
 ## PR Scope
 

--- a/plans/active/issue-224-screen-capturekit-recording-stop.md
+++ b/plans/active/issue-224-screen-capturekit-recording-stop.md
@@ -72,7 +72,7 @@ ScreenCaptureKit system audio stops
 System source marked unavailable
         |
         +--> system level goes to 0
-        +--> warning is logged / telemetry is sent
+        +--> warning and diagnostic line are logged
         +--> mic capture continues
         |
         v
@@ -98,7 +98,7 @@ System audio stopped. Microphone recording continues.
 
 [Send Diagnostic Report]
 
-Sends a redacted audio diagnostic log excerpt.
+Sends a redacted audio diagnostic log.
 No audio or transcript is included.
 ```
 

--- a/plans/active/issue-224-screen-capturekit-recording-stop.md
+++ b/plans/active/issue-224-screen-capturekit-recording-stop.md
@@ -91,10 +91,14 @@ because no recording source remains.
 - Should final metadata explicitly record source interruptions so Library export
   and debugging can explain partial system audio?
 
-## Draft PR Scope
+## PR Scope
 
-This draft PR is an investigation and decision point, not a finished runtime
-fix. A proper implementation PR should add tests for:
+This PR implements the first safety fix: system-audio failure during
+`Microphone + System Audio` becomes source-specific, so the microphone keeps
+recording. A later PR can decide whether to restart ScreenCaptureKit after
+display topology changes.
+
+Coverage should verify:
 
 - system-audio failure during `Microphone + System Audio` keeps mic recording
   alive

--- a/plans/active/issue-224-screen-capturekit-recording-stop.md
+++ b/plans/active/issue-224-screen-capturekit-recording-stop.md
@@ -117,10 +117,17 @@ Server creates GitHub issue with bot account
 The client should send structured diagnostics to the backend rather than open
 GitHub directly. That keeps the user action to one click, avoids exposing logs
 in a public issue form, and lets the server decide how to file or route the
-report. The diagnostic payload should include a redacted, capped excerpt of
-`dictation-audio.log`, the capture mode, interrupted source, ScreenCaptureKit
-error code, app version, macOS version, and timestamp. It must not include
-audio or transcript content.
+report.
+
+Prefer a generous capped log payload over a narrow snippet. The audio
+diagnostic log is already designed to be shared: paths and URLs are sanitized,
+individual error details are capped, and microphone IDs, UIDs, and names are
+omitted. If the payload fits the backend limit, send the current
+`dictation-audio.log`; otherwise send a capped recent tail with enough lead-up
+context to diagnose display/audio state changes. Include structured context
+such as capture mode, interrupted source, ScreenCaptureKit error code, app
+version, macOS version, and timestamp. Do not include audio or transcript
+content.
 
 ## PR Scope
 

--- a/plans/active/issue-224-screen-capturekit-recording-stop.md
+++ b/plans/active/issue-224-screen-capturekit-recording-stop.md
@@ -1,0 +1,102 @@
+# Issue 224: Meeting Recording Stops After ScreenCaptureKit Loses Capture Source
+
+GitHub issue: https://github.com/moona3k/macparakeet/issues/224
+
+## What We Know
+
+The reporter confirmed that the app did not crash. The meeting recording UI
+closed, and the orange recording indicator stopped.
+
+Their `dictation-audio.log` shows repeated mid-recording failures from
+ScreenCaptureKit:
+
+```text
+system_audio_stream_stopped_with_error
+error_type=com.apple.ScreenCaptureKit.SCStreamErrorDomain.-3815
+error_detail="Failed to find any displays or windows to capture"
+```
+
+In the macOS SDK, `-3815` is `SCStreamErrorNoCaptureSource`: ScreenCaptureKit
+could not find a display or window to capture. This happened after recording
+had already started and system audio buffers had already arrived.
+
+## Current Behavior
+
+Any system-audio stream failure is treated as a whole-recording failure.
+
+```text
+ScreenCaptureKit system audio stops
+        |
+        v
+SystemAudioStream emits runtime error
+        |
+        v
+MeetingAudioCaptureService forwards .error
+        |
+        v
+MeetingRecordingService marks capture failed
+        |
+        v
+Mic + system capture stop
+        |
+        v
+UI closes and saved audio is finalized
+```
+
+That explains the user-visible behavior: no app crash, but the live recording
+session ends.
+
+## Likely Triggers
+
+The log does not prove the external trigger. Plausible triggers include:
+
+- display sleep or screen lock
+- external display disconnect/reconnect
+- KVM or dock display switching
+- Sidecar, AirPlay, DisplayLink, or virtual displays
+- moving the meeting app across Spaces or full-screen display contexts
+- a macOS 26.4.1 ScreenCaptureKit regression
+
+The important product point: losing system audio should not necessarily end a
+meeting if the microphone is still recording.
+
+## Preferred Handling
+
+For `Microphone + System Audio`, a system-audio interruption should degrade the
+session to mic-only instead of ending the meeting.
+
+```text
+ScreenCaptureKit system audio stops
+        |
+        v
+System source marked unavailable
+        |
+        +--> system level goes to 0
+        +--> warning is logged / telemetry is sent
+        +--> mic capture continues
+        |
+        v
+Final meeting contains mic audio plus any system audio captured before failure
+```
+
+For `System Audio Only`, the current stop/fail behavior is still reasonable
+because no recording source remains.
+
+## Open Decisions
+
+- Should the first fix only preserve mic recording, or also try to restart
+  ScreenCaptureKit after display topology changes?
+- How should the UI communicate "system audio stopped, mic recording continues"
+  without alarming the user mid-meeting?
+- Should final metadata explicitly record source interruptions so Library export
+  and debugging can explain partial system audio?
+
+## Draft PR Scope
+
+This draft PR is an investigation and decision point, not a finished runtime
+fix. A proper implementation PR should add tests for:
+
+- system-audio failure during `Microphone + System Audio` keeps mic recording
+  alive
+- system-audio failure during `System Audio Only` still stops/fails
+- final output preserves any source audio already captured before interruption


### PR DESCRIPTION
## Summary

Implements the first safety fix for #224: if ScreenCaptureKit drops system
audio during `Microphone + System Audio`, MacParakeet now keeps microphone
recording alive instead of ending the meeting.

`System Audio Only` still stops/fails, because no capture source remains.

## What the user's log showed

The app was not crashing. ScreenCaptureKit stopped the system-audio stream:

```text
system_audio_stream_stopped_with_error
error_type=com.apple.ScreenCaptureKit.SCStreamErrorDomain.-3815
error_detail="Failed to find any displays or windows to capture"
```

`-3815` is `SCStreamErrorNoCaptureSource`: ScreenCaptureKit could not find a
display or window to capture.

## Before

```text
ScreenCaptureKit system audio stops
        |
        v
SystemAudioStream emits runtime error
        |
        v
MeetingRecordingService marks capture failed
        |
        v
Mic + system capture stop
        |
        v
UI closes and captured audio is finalized
```

## After

```text
ScreenCaptureKit system audio stops
        |
        v
System source is marked interrupted
        |
        +--> system level goes to 0
        +--> diagnostic line is logged
        +--> mic capture continues
        |
        v
Final meeting includes mic audio plus any earlier system audio
```

## Changes

- Adds a source-specific `MeetingAudioCaptureEvent.sourceInterrupted`.
- Emits that event for system-audio stalls/copy failures in `Microphone + System Audio`.
- Keeps fatal `.error` behavior for `System Audio Only`.
- Keeps the meeting service in `.full` capture mode after a system-source interruption.
- Ignores late system buffers after a system-source interruption.
- Preserves already captured system audio in the final output.
- Cancels `SystemAudioStream` watchdog timers after `didStopWithError` to avoid duplicate callbacks.

## Reporting follow-up

For the live UI, prefer a subtle state over a modal alert:

```text
System audio stopped. Microphone recording continues.

[Send Diagnostic Report]

Sends a redacted audio diagnostic log.
No audio or transcript is included.
```

The report button should reuse the existing feedback path and let the server
create the GitHub issue with the bot account:

```text
Interruption UI
        |
        v
FeedbackService /api/feedback
        |
        v
Server creates GitHub issue with bot account
```

That keeps the user action to one click, avoids opening a public GitHub form
with logs, and gives the backend control over routing.

Prefer a generous capped log payload over a narrow snippet. The audio diagnostic
log is already designed to be shared: paths and URLs are sanitized, individual
error details are capped, and microphone IDs, UIDs, and names are omitted. If it
fits the backend limit, send the current `dictation-audio.log`; otherwise send a
capped recent tail with enough lead-up context to diagnose display/audio state
changes. Include structured context such as capture mode, interrupted source,
ScreenCaptureKit error code, app version, macOS version, and timestamp. Do not
send audio or transcript content.

## Still open

- Whether to try restarting ScreenCaptureKit after display topology changes.
- Whether final metadata should record partial source interruptions for Library/debugging.

## Validation

- `swift test --filter MeetingAudioCaptureServiceTests`
- `swift test --filter MeetingRecordingServiceTests/testSystemSourceInterruptionKeepsMicrophoneRecordingAlive`
- `swift test --filter MeetingRecordingServiceTests`
- `swift test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced resilience for combined microphone and system audio recording. When system audio is interrupted, microphone recording now continues unaffected, preventing unexpected session interruptions. System-audio-only recordings maintain existing behavior.

* **Documentation**
  * Added specification for handling system audio interruption scenarios and recovery strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->