### PR TITLE
Show meeting transcript startup status

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -222,6 +222,7 @@ final class AppEnvironmentConfigurer {
             conversationRepo: env.chatConversationRepo,
             quickPromptRepo: env.quickPromptRepo,
             configStore: env.llmConfigStore,
+            sttManager: env.sttScheduler,
             meetingAudioSourceModeProvider: { env.runtimePreferences.meetingAudioSourceMode },
             llmService: hasLLMConfig ? env.llmService : nil,
             pillViewModel: meetingPillViewModel,

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -40,6 +40,7 @@ final class MeetingRecordingFlowCoordinator {
     private let quickPromptRepo: QuickPromptRepositoryProtocol
     private let configStore: LLMConfigStoreProtocol
     private let cliConfigStore: LocalCLIConfigStore
+    private let sttManager: (any STTRuntimeManaging)?
     private let meetingAudioSourceModeProvider: @MainActor @Sendable () -> MeetingAudioSourceMode
     private var llmService: LLMServiceProtocol?
     private let onMenuBarIconUpdate: (BreathWaveIcon.MenuBarState) -> Void
@@ -59,6 +60,7 @@ final class MeetingRecordingFlowCoordinator {
     private var autoDismissTask: Task<Void, Never>?
     private var pillPollingTask: Task<Void, Never>?
     private var transcriptObservationTask: Task<Void, Never>?
+    private var speechWarmUpObservationTask: Task<Void, Never>?
     private var activeFlowSettlementWaiters: [CheckedContinuation<Void, Never>] = []
     private var completedTranscription: Transcription?
     private var currentMeetingOperationContext: ObservabilityOperationContext?
@@ -74,6 +76,7 @@ final class MeetingRecordingFlowCoordinator {
         quickPromptRepo: QuickPromptRepositoryProtocol,
         configStore: LLMConfigStoreProtocol,
         cliConfigStore: LocalCLIConfigStore = LocalCLIConfigStore(),
+        sttManager: (any STTRuntimeManaging)? = nil,
         meetingAudioSourceModeProvider: @escaping @MainActor @Sendable () -> MeetingAudioSourceMode = { .microphoneAndSystem },
         llmService: LLMServiceProtocol?,
         pillViewModel: MeetingRecordingPillViewModel,
@@ -90,6 +93,7 @@ final class MeetingRecordingFlowCoordinator {
         self.quickPromptRepo = quickPromptRepo
         self.configStore = configStore
         self.cliConfigStore = cliConfigStore
+        self.sttManager = sttManager
         self.meetingAudioSourceModeProvider = meetingAudioSourceModeProvider
         self.llmService = llmService
         self.pillViewModel = pillViewModel
@@ -299,6 +303,7 @@ final class MeetingRecordingFlowCoordinator {
             panelVM.elapsedSeconds = 0
             panelVM.micLevel = 0
             panelVM.systemLevel = 0
+            panelVM.updateLiveTranscriptStatus(.startingAudio)
             panelVM.updatePreviewLines([], isTranscriptionLagging: false)
             panelVM.onStop = { [weak self] in self?.toggleRecording() }
             panelVM.onClose = { [weak self] in self?.hideMeetingPanel() }
@@ -348,6 +353,7 @@ final class MeetingRecordingFlowCoordinator {
                 panelController = controller
             }
             pillController?.show()
+            startSpeechWarmUpObservation()
             startPillPolling()
             startTranscriptObservation()
 
@@ -367,6 +373,12 @@ final class MeetingRecordingFlowCoordinator {
             actionTask = Task { @MainActor in
                 do {
                     try await meetingRecordingService.startRecording(title: title, sourceMode: sourceMode)
+                    switch self.panelViewModel?.liveTranscriptStatus {
+                    case .some(.startingAudio), .some(.preparingSpeechModel):
+                        self.panelViewModel?.updateLiveTranscriptStatus(.listening)
+                    case .some(.listening), .some(.live), .some(.previewUnavailable), .none:
+                        break
+                    }
                     Telemetry.send(.meetingRecordingStarted(trigger: trigger))
                     self.onRecordingBegan()
                     self.sendEvent(.recordingStarted(generation: gen))
@@ -400,6 +412,7 @@ final class MeetingRecordingFlowCoordinator {
         case .showTranscribingState:
             stopPillPolling()
             stopTranscriptObservation()
+            stopSpeechWarmUpObservation()
             pillViewModel.micLevel = 0
             pillViewModel.systemLevel = 0
             pillViewModel.state = .completing
@@ -489,6 +502,7 @@ final class MeetingRecordingFlowCoordinator {
         case .showCompleted:
             stopPillPolling()
             stopTranscriptObservation()
+            stopSpeechWarmUpObservation()
             // If flower is still collapsing, the callback will check completedTranscription
             // If spinner is showing, transition to checkmark now
             if pillViewModel.state == .transcribing {
@@ -526,6 +540,7 @@ final class MeetingRecordingFlowCoordinator {
         case .showError(let message):
             stopPillPolling()
             stopTranscriptObservation()
+            stopSpeechWarmUpObservation()
             panelViewModel?.state = .error(message)
             pillViewModel.state = .error(
                 panelViewModel?.compactErrorRecoveryMessage
@@ -536,6 +551,7 @@ final class MeetingRecordingFlowCoordinator {
         case .hidePill:
             stopPillPolling()
             stopTranscriptObservation()
+            stopSpeechWarmUpObservation()
             pillController?.hide()
             pillController = nil
             // Pill view model is long-lived (also drives the Transcribe-tab
@@ -713,6 +729,49 @@ final class MeetingRecordingFlowCoordinator {
     private func stopTranscriptObservation() {
         transcriptObservationTask?.cancel()
         transcriptObservationTask = nil
+    }
+
+    private func startSpeechWarmUpObservation() {
+        guard let sttManager else { return }
+
+        speechWarmUpObservationTask?.cancel()
+        speechWarmUpObservationTask = Task { @MainActor [weak self, sttManager] in
+            let (observerId, stream) = await sttManager.observeWarmUpProgress()
+            defer {
+                Task {
+                    await sttManager.removeWarmUpObserver(id: observerId)
+                }
+            }
+
+            await sttManager.backgroundWarmUp()
+
+            for await state in stream {
+                guard !Task.isCancelled else { break }
+                self?.handleSpeechWarmUpState(state)
+            }
+        }
+    }
+
+    private func stopSpeechWarmUpObservation() {
+        speechWarmUpObservationTask?.cancel()
+        speechWarmUpObservationTask = nil
+    }
+
+    private func handleSpeechWarmUpState(_ state: STTWarmUpState) {
+        guard let panelViewModel, panelViewModel.previewLines.isEmpty else { return }
+
+        switch state {
+        case .idle:
+            break
+        case .working(let message, _):
+            panelViewModel.updateLiveTranscriptStatus(.preparingSpeechModel(message: message))
+        case .ready:
+            if stateMachine.state != .starting {
+                panelViewModel.updateLiveTranscriptStatus(.listening)
+            }
+        case .failed:
+            panelViewModel.updateLiveTranscriptStatus(.previewUnavailable)
+        }
     }
 
     nonisolated private static func makePreviewLines(from update: MeetingTranscriptUpdate) -> [MeetingRecordingPreviewLine] {

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -373,10 +373,17 @@ final class MeetingRecordingFlowCoordinator {
             actionTask = Task { @MainActor in
                 do {
                     try await meetingRecordingService.startRecording(title: title, sourceMode: sourceMode)
+                    let isSpeechModelReady = await self.sttManager?.isReady() ?? true
                     switch self.panelViewModel?.liveTranscriptStatus {
-                    case .some(.startingAudio), .some(.preparingSpeechModel):
+                    case .some(.startingAudio) where isSpeechModelReady:
+                        self.panelViewModel?.updateLiveTranscriptStatus(.listening)
+                    case .some(.startingAudio):
+                        self.panelViewModel?.updateLiveTranscriptStatus(.preparingSpeechModel(message: nil))
+                    case .some(.preparingSpeechModel) where isSpeechModelReady:
                         self.panelViewModel?.updateLiveTranscriptStatus(.listening)
                     case .some(.listening), .some(.live), .some(.previewUnavailable), .none:
+                        break
+                    case .some(.preparingSpeechModel):
                         break
                     }
                     Telemetry.send(.meetingRecordingStarted(trigger: trigger))

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelView.swift
@@ -266,10 +266,22 @@ struct MeetingRecordingPanelView: View {
                 }
 
                 if !hasContent {
-                    Text(viewModel.canStop ? "Listening…" : "Transcription in progress…")
-                        .font(.system(size: 13, weight: .light, design: .default))
-                        .foregroundStyle(DesignSystem.Colors.textTertiary.opacity(0.6))
-                        .transition(.opacity)
+                    VStack(spacing: 5) {
+                        Text(viewModel.transcriptEmptyStateTitle)
+                            .font(.system(size: 13, weight: .light, design: .default))
+                            .foregroundStyle(DesignSystem.Colors.textTertiary.opacity(0.65))
+
+                        if let detail = viewModel.transcriptEmptyStateDetail {
+                            Text(detail)
+                                .font(DesignSystem.Typography.caption)
+                                .foregroundStyle(DesignSystem.Colors.textTertiary.opacity(0.55))
+                                .multilineTextAlignment(.center)
+                                .lineLimit(2)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                    .padding(.horizontal, DesignSystem.Spacing.lg)
+                    .transition(.opacity)
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Sources/MacParakeetViewModels/MeetingRecordingPanelViewModel.swift
+++ b/Sources/MacParakeetViewModels/MeetingRecordingPanelViewModel.swift
@@ -42,7 +42,7 @@ public final class MeetingRecordingPanelViewModel {
     public var systemLevel: Float = 0
     public var previewLines: [MeetingRecordingPreviewLine] = []
     public var isTranscriptionLagging: Bool = false
-    public var liveTranscriptStatus: LiveTranscriptStatus = .listening
+    public private(set) var liveTranscriptStatus: LiveTranscriptStatus = .listening
     public var showCopiedConfirmation: Bool = false
     /// Default to `.notes` per ADR-020 §2 — opening the panel should put the
     /// cursor in the notepad, not stare the user down with raw transcript.

--- a/Sources/MacParakeetViewModels/MeetingRecordingPanelViewModel.swift
+++ b/Sources/MacParakeetViewModels/MeetingRecordingPanelViewModel.swift
@@ -11,6 +11,14 @@ public final class MeetingRecordingPanelViewModel {
         case error(String)
     }
 
+    public enum LiveTranscriptStatus: Equatable, Sendable {
+        case startingAudio
+        case preparingSpeechModel(message: String?)
+        case listening
+        case live
+        case previewUnavailable
+    }
+
     /// Tab order chosen so the user lands in Notes by default — note-taking is
     /// the primary "active" surface in a live meeting (ADR-020 §1, §2). Transcript
     /// is the rolling reference, Ask is the on-demand thinking-partner.
@@ -34,6 +42,7 @@ public final class MeetingRecordingPanelViewModel {
     public var systemLevel: Float = 0
     public var previewLines: [MeetingRecordingPreviewLine] = []
     public var isTranscriptionLagging: Bool = false
+    public var liveTranscriptStatus: LiveTranscriptStatus = .listening
     public var showCopiedConfirmation: Bool = false
     /// Default to `.notes` per ADR-020 §2 — opening the panel should put the
     /// cursor in the notepad, not stare the user down with raw transcript.
@@ -89,6 +98,9 @@ public final class MeetingRecordingPanelViewModel {
             wordCount += addedWordCounts.reduce(0, +) - removedWordCount
             previewLineWordCounts = Array(previewLineWordCounts.prefix(firstChangedIndex)) + addedWordCounts
             previewLines = lines
+            if !lines.isEmpty {
+                liveTranscriptStatus = .live
+            }
             // Keep the live Ask tab fed with the latest transcript without disturbing
             // chat history. Bracketed timestamps stripped — LLMs do better without them.
             chatViewModel.updateTranscriptText(chatTranscript)
@@ -120,6 +132,7 @@ public final class MeetingRecordingPanelViewModel {
         previewLineWordCounts = []
         wordCount = 0
         isTranscriptionLagging = false
+        liveTranscriptStatus = .listening
         copiedResetTask?.cancel()
         showCopiedConfirmation = false
         selectedTab = .notes
@@ -198,6 +211,45 @@ public final class MeetingRecordingPanelViewModel {
         state == .recording
     }
 
+    public func updateLiveTranscriptStatus(_ status: LiveTranscriptStatus) {
+        guard previewLines.isEmpty else { return }
+        liveTranscriptStatus = status
+    }
+
+    public var transcriptEmptyStateTitle: String {
+        if isTranscriptionLagging {
+            return "Catching up..."
+        }
+
+        switch liveTranscriptStatus {
+        case .startingAudio:
+            return "Starting audio..."
+        case .preparingSpeechModel:
+            return "Preparing speech model..."
+        case .listening, .live:
+            return canStop ? "Listening..." : "Transcription in progress..."
+        case .previewUnavailable:
+            return "Live preview unavailable"
+        }
+    }
+
+    public var transcriptEmptyStateDetail: String? {
+        if isTranscriptionLagging {
+            return "Final transcript will still include the full meeting."
+        }
+
+        switch liveTranscriptStatus {
+        case .startingAudio:
+            return nil
+        case .preparingSpeechModel(let message):
+            return Self.cleanWarmUpMessage(message) ?? "Recording continues while local transcription starts."
+        case .listening, .live:
+            return nil
+        case .previewUnavailable:
+            return "Audio keeps recording; retry transcription from Library if needed."
+        }
+    }
+
     private static func firstChangedLineIndex(
         oldLines: [MeetingRecordingPreviewLine],
         newLines: [MeetingRecordingPreviewLine]
@@ -211,6 +263,15 @@ public final class MeetingRecordingPanelViewModel {
 
     private static func wordCount(for text: String) -> Int {
         text.split(whereSeparator: \.isWhitespace).count
+    }
+
+    private static func cleanWarmUpMessage(_ message: String?) -> String? {
+        guard let message else { return nil }
+        let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let prefix = "Speech model: "
+        guard trimmed.hasPrefix(prefix) else { return trimmed }
+        return String(trimmed.dropFirst(prefix.count))
     }
 
     // MARK: - Tab badges (ADR-020 §1)

--- a/Tests/MacParakeetTests/ViewModels/MeetingRecordingPanelViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/MeetingRecordingPanelViewModelTests.swift
@@ -125,9 +125,57 @@ final class MeetingRecordingPanelViewModelTests: XCTestCase {
 
         XCTAssertTrue(viewModel.showsLaggingIndicator)
         XCTAssertTrue(viewModel.statusMessage.contains("catching up"))
+        XCTAssertEqual(viewModel.transcriptEmptyStateTitle, "Catching up...")
+        XCTAssertEqual(
+            viewModel.transcriptEmptyStateDetail,
+            "Final transcript will still include the full meeting."
+        )
 
         viewModel.state = .transcribing
         XCTAssertFalse(viewModel.showsLaggingIndicator)
+    }
+
+    func testLiveTranscriptStatusDrivesEmptyTranscriptCopy() {
+        let viewModel = MeetingRecordingPanelViewModel()
+        viewModel.state = .recording
+
+        viewModel.updateLiveTranscriptStatus(.startingAudio)
+        XCTAssertEqual(viewModel.transcriptEmptyStateTitle, "Starting audio...")
+        XCTAssertNil(viewModel.transcriptEmptyStateDetail)
+
+        viewModel.updateLiveTranscriptStatus(.preparingSpeechModel(message: "Speech model: Loading model into memory..."))
+        XCTAssertEqual(viewModel.transcriptEmptyStateTitle, "Preparing speech model...")
+        XCTAssertEqual(viewModel.transcriptEmptyStateDetail, "Loading model into memory...")
+
+        viewModel.updateLiveTranscriptStatus(.previewUnavailable)
+        XCTAssertEqual(viewModel.transcriptEmptyStateTitle, "Live preview unavailable")
+        XCTAssertEqual(
+            viewModel.transcriptEmptyStateDetail,
+            "Audio keeps recording; retry transcription from Library if needed."
+        )
+
+        viewModel.updateLiveTranscriptStatus(.listening)
+        XCTAssertEqual(viewModel.transcriptEmptyStateTitle, "Listening...")
+        XCTAssertNil(viewModel.transcriptEmptyStateDetail)
+    }
+
+    func testTranscriptContentLocksOutAdvisoryEmptyStatus() {
+        let viewModel = MeetingRecordingPanelViewModel()
+        let lines = [
+            MeetingRecordingPreviewLine(
+                id: "1",
+                timestamp: "0:05",
+                speakerLabel: "Me",
+                text: "Words arrived",
+                source: .microphone
+            )
+        ]
+
+        viewModel.updatePreviewLines(lines)
+        viewModel.updateLiveTranscriptStatus(.preparingSpeechModel(message: "Loading"))
+
+        XCTAssertEqual(viewModel.liveTranscriptStatus, .live)
+        XCTAssertEqual(viewModel.previewLines, lines)
     }
 
     func testResetClearsTranscriptPreview() {
@@ -156,6 +204,7 @@ final class MeetingRecordingPanelViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.systemLevel, 0)
         XCTAssertTrue(viewModel.previewLines.isEmpty)
         XCTAssertFalse(viewModel.isTranscriptionLagging)
+        XCTAssertEqual(viewModel.liveTranscriptStatus, .listening)
         XCTAssertEqual(viewModel.selectedTab, .notes, "reset() returns the panel to the default Notes tab (ADR-020 §2)")
     }
 


### PR DESCRIPTION
## Summary
- Shows explicit Transcript-tab startup copy while meeting audio starts or the local speech model warms up.
- Reuses the existing STT background warm-up progress stream; transcript text still takes over as soon as words arrive.
- Keeps fallback behavior simple: if warm-up state is unavailable, the panel still falls back to the normal Listening state.

## Flow
```
Start meeting
    |
    v
Start audio  ------>  Record audio
    |                    |
    v                    v
Warm speech model --> Live transcript words
    |                    |
    v                    v
Preparing...         Transcript text
```

## Tests
- `swift test --filter MeetingRecordingPanelViewModelTests`
- `swift test --filter MeetingRecordingFlowStateMachineTests`
- `swift test` (2,247 tests, 1 skipped, 0 failures; plus 16 Swift Testing tests)

Fixes #228

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added speech model warm-up initialization during recording setup for improved performance
  * Enhanced empty transcript UI with contextual messaging based on transcription state

* **Improvements**
  * Better visual feedback during recording preparation and transcription phases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->