### PR TITLE
Fix stale clipboard paste race

### DIFF
--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -471,8 +471,15 @@ final class DictationFlowCoordinator {
                         // Pure action-only dictation (e.g., "press return") — nothing to paste
                         self.sendEvent(.pasteFailed(generation: gen, message: "Keystroke failed. Check Accessibility permissions."))
                     } else {
-                        await self.clipboardService.copyToClipboard(transcript)
-                        self.sendEvent(.pasteFailed(generation: gen, message: "Copied to clipboard. Press Cmd+V."))
+                        let copied = await self.clipboardService.copyToClipboard(transcript)
+                        self.sendEvent(
+                            .pasteFailed(
+                                generation: gen,
+                                message: copied
+                                    ? "Copied to clipboard. Press Cmd+V."
+                                    : "Paste failed and the clipboard could not be updated."
+                            )
+                        )
                     }
                 }
             }

--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -472,12 +472,25 @@ final class DictationFlowCoordinator {
                         self.sendEvent(.pasteFailed(generation: gen, message: "Keystroke failed. Check Accessibility permissions."))
                     } else {
                         let copied = await self.clipboardService.copyToClipboard(transcript)
+                        let failedBeforeClipboardWrite: Bool
+                        if let clipboardError = error as? ClipboardServiceError,
+                           case .pasteboardWriteFailed = clipboardError {
+                            failedBeforeClipboardWrite = true
+                        } else {
+                            failedBeforeClipboardWrite = false
+                        }
+                        let message = if copied {
+                            "Copied to clipboard. Press Cmd+V."
+                        } else if failedBeforeClipboardWrite {
+                            "Paste failed and the clipboard could not be updated."
+                        } else {
+                            "Paste automation failed. The transcript is temporarily on the clipboard. Press Cmd+V now."
+                        }
+
                         self.sendEvent(
                             .pasteFailed(
                                 generation: gen,
-                                message: copied
-                                    ? "Copied to clipboard. Press Cmd+V."
-                                    : "Paste failed and the clipboard could not be updated."
+                                message: message
                             )
                         )
                     }

--- a/Sources/MacParakeetCore/Services/System/ClipboardService.swift
+++ b/Sources/MacParakeetCore/Services/System/ClipboardService.swift
@@ -204,7 +204,9 @@ public final class ClipboardService: ClipboardServiceProtocol {
             eventPosting: CGClipboardEventPosting(),
             clipboardRestoreDelay: Self.defaultClipboardRestoreDelay,
             restoreCoordinator: Self.sharedRestoreCoordinator,
-            pasteboardStringWriter: Self.writeString
+            pasteboardStringWriter: { pasteboard, text in
+                pasteboard.setString(text, forType: .string)
+            }
         )
     }
 
@@ -214,7 +216,9 @@ public final class ClipboardService: ClipboardServiceProtocol {
         eventPosting: ClipboardEventPosting = CGClipboardEventPosting(),
         clipboardRestoreDelay: TimeInterval = ClipboardService.defaultClipboardRestoreDelay,
         restoreAttemptObserver: (@MainActor () -> Void)? = nil,
-        pasteboardStringWriter: @escaping @MainActor (NSPasteboard, String) -> Bool = ClipboardService.writeString
+        pasteboardStringWriter: @escaping @MainActor (NSPasteboard, String) -> Bool = { pasteboard, text in
+            pasteboard.setString(text, forType: .string)
+        }
     ) {
         self.init(
             pasteboard: pasteboard,
@@ -356,7 +360,4 @@ public final class ClipboardService: ClipboardServiceProtocol {
         }
     }
 
-    private static func writeString(to pasteboard: NSPasteboard, text: String) -> Bool {
-        pasteboard.setString(text, forType: .string)
-    }
 }

--- a/Sources/MacParakeetCore/Services/System/ClipboardService.swift
+++ b/Sources/MacParakeetCore/Services/System/ClipboardService.swift
@@ -7,7 +7,8 @@ public protocol ClipboardServiceProtocol: Sendable {
     func pasteText(_ text: String) async throws
     /// Paste text then simulate a keystroke. Returns `true` if the keystroke was actually fired.
     func pasteTextWithAction(_ text: String, postPasteAction: KeyAction?) async throws -> Bool
-    func copyToClipboard(_ text: String) async
+    @discardableResult
+    func copyToClipboard(_ text: String) async -> Bool
 }
 
 public enum ClipboardServiceError: LocalizedError {
@@ -96,6 +97,11 @@ private final class ClipboardRestoreCoordinator {
 
     private var pendingRestore: PendingRestore?
     private var generation: UInt64 = 0
+    private let restoreAttemptObserver: (@MainActor () -> Void)?
+
+    init(restoreAttemptObserver: (@MainActor () -> Void)? = nil) {
+        self.restoreAttemptObserver = restoreAttemptObserver
+    }
 
     func originalItemsForNewPaste(
         currentItems: [NSPasteboardItem]?,
@@ -113,12 +119,18 @@ private final class ClipboardRestoreCoordinator {
         return currentItems
     }
 
-    func temporaryClipboardWasRestoredAfterFailedWrite(changeCount: Int) {
+    func temporaryClipboardWasRestoredAfterFailedWrite(
+        previousChangeCount: Int,
+        restoredChangeCount: Int
+    ) {
         guard var pendingRestore else {
             return
         }
+        guard previousChangeCount == pendingRestore.latestTemporaryChangeCount else {
+            return
+        }
 
-        pendingRestore.latestTemporaryChangeCount = changeCount
+        pendingRestore.latestTemporaryChangeCount = restoredChangeCount
         self.pendingRestore = pendingRestore
     }
 
@@ -148,6 +160,10 @@ private final class ClipboardRestoreCoordinator {
     }
 
     private func restoreIfCurrent(pasteboard: NSPasteboard, generation: UInt64) {
+        defer {
+            restoreAttemptObserver?()
+        }
+
         guard let pendingRestore, pendingRestore.generation == generation else {
             return
         }
@@ -179,6 +195,7 @@ public final class ClipboardService: ClipboardServiceProtocol {
     private let eventPosting: ClipboardEventPosting
     private let clipboardRestoreDelay: TimeInterval
     private let restoreCoordinator: ClipboardRestoreCoordinator
+    private let pasteboardStringWriter: @MainActor (NSPasteboard, String) -> Bool
 
     public convenience init() {
         self.init(
@@ -186,7 +203,8 @@ public final class ClipboardService: ClipboardServiceProtocol {
             pasteShortcutKeyResolver: PasteShortcutKeyResolver(),
             eventPosting: CGClipboardEventPosting(),
             clipboardRestoreDelay: Self.defaultClipboardRestoreDelay,
-            restoreCoordinator: Self.sharedRestoreCoordinator
+            restoreCoordinator: Self.sharedRestoreCoordinator,
+            pasteboardStringWriter: Self.writeString
         )
     }
 
@@ -194,14 +212,17 @@ public final class ClipboardService: ClipboardServiceProtocol {
         pasteboard: NSPasteboard = .general,
         pasteShortcutKeyResolver: PasteShortcutKeyResolver = PasteShortcutKeyResolver(),
         eventPosting: ClipboardEventPosting = CGClipboardEventPosting(),
-        clipboardRestoreDelay: TimeInterval = ClipboardService.defaultClipboardRestoreDelay
+        clipboardRestoreDelay: TimeInterval = ClipboardService.defaultClipboardRestoreDelay,
+        restoreAttemptObserver: (@MainActor () -> Void)? = nil,
+        pasteboardStringWriter: @escaping @MainActor (NSPasteboard, String) -> Bool = ClipboardService.writeString
     ) {
         self.init(
             pasteboard: pasteboard,
             pasteShortcutKeyResolver: pasteShortcutKeyResolver,
             eventPosting: eventPosting,
             clipboardRestoreDelay: clipboardRestoreDelay,
-            restoreCoordinator: ClipboardRestoreCoordinator()
+            restoreCoordinator: ClipboardRestoreCoordinator(restoreAttemptObserver: restoreAttemptObserver),
+            pasteboardStringWriter: pasteboardStringWriter
         )
     }
 
@@ -210,13 +231,15 @@ public final class ClipboardService: ClipboardServiceProtocol {
         pasteShortcutKeyResolver: PasteShortcutKeyResolver,
         eventPosting: ClipboardEventPosting,
         clipboardRestoreDelay: TimeInterval,
-        restoreCoordinator: ClipboardRestoreCoordinator
+        restoreCoordinator: ClipboardRestoreCoordinator,
+        pasteboardStringWriter: @escaping @MainActor (NSPasteboard, String) -> Bool
     ) {
         self.pasteboard = pasteboard
         self.pasteShortcutKeyResolver = pasteShortcutKeyResolver
         self.eventPosting = eventPosting
         self.clipboardRestoreDelay = clipboardRestoreDelay
         self.restoreCoordinator = restoreCoordinator
+        self.pasteboardStringWriter = pasteboardStringWriter
     }
 
     /// Paste text into the active app by:
@@ -229,17 +252,21 @@ public final class ClipboardService: ClipboardServiceProtocol {
 
         // 1. Save current clipboard contents
         let currentItems = Self.snapshotItems(from: pasteboard)
+        let previousChangeCount = pasteboard.changeCount
         let savedItems = restoreCoordinator.originalItemsForNewPaste(
             currentItems: currentItems,
-            currentChangeCount: pasteboard.changeCount
+            currentChangeCount: previousChangeCount
         )
 
         // 2. Set transcript
         pasteboard.clearContents()
-        guard pasteboard.setString(text, forType: .string) else {
+        guard pasteboardStringWriter(pasteboard, text) else {
             pasteboard.clearContents()
             Self.writeItems(currentItems, to: pasteboard)
-            restoreCoordinator.temporaryClipboardWasRestoredAfterFailedWrite(changeCount: pasteboard.changeCount)
+            restoreCoordinator.temporaryClipboardWasRestoredAfterFailedWrite(
+                previousChangeCount: previousChangeCount,
+                restoredChangeCount: pasteboard.changeCount
+            )
             throw ClipboardServiceError.pasteboardWriteFailed
         }
         let ourChangeCount = pasteboard.changeCount
@@ -256,10 +283,25 @@ public final class ClipboardService: ClipboardServiceProtocol {
     }
 
     /// Copy text to clipboard without paste simulation
-    public func copyToClipboard(_ text: String) async {
-        restoreCoordinator.cancelPendingRestore()
+    @discardableResult
+    public func copyToClipboard(_ text: String) async -> Bool {
+        let currentItems = Self.snapshotItems(from: pasteboard)
+        let previousChangeCount = pasteboard.changeCount
+
         pasteboard.clearContents()
-        pasteboard.setString(text, forType: .string)
+        guard pasteboardStringWriter(pasteboard, text) else {
+            pasteboard.clearContents()
+            Self.writeItems(currentItems, to: pasteboard)
+            restoreCoordinator.temporaryClipboardWasRestoredAfterFailedWrite(
+                previousChangeCount: previousChangeCount,
+                restoredChangeCount: pasteboard.changeCount
+            )
+            logger.error("Failed to write text to clipboard during copy fallback")
+            return false
+        }
+
+        restoreCoordinator.cancelPendingRestore()
+        return true
     }
 
     @discardableResult
@@ -312,5 +354,9 @@ public final class ClipboardService: ClipboardServiceProtocol {
         if let items, !items.isEmpty {
             pasteboard.writeObjects(items)
         }
+    }
+
+    private static func writeString(to pasteboard: NSPasteboard, text: String) -> Bool {
+        pasteboard.setString(text, forType: .string)
     }
 }

--- a/Sources/MacParakeetCore/Services/System/ClipboardService.swift
+++ b/Sources/MacParakeetCore/Services/System/ClipboardService.swift
@@ -30,122 +30,41 @@ public enum ClipboardServiceError: LocalizedError {
     }
 }
 
-/// Handles clipboard save/restore and paste simulation via Cmd+V.
-@MainActor
-public final class ClipboardService: ClipboardServiceProtocol {
-    nonisolated static let defaultClipboardRestoreDelay: TimeInterval = 1.0
+protocol ClipboardEventPosting {
+    @MainActor
+    func simulatePaste(using pasteShortcutKeyResolver: PasteShortcutKeyResolver) throws
+    @MainActor
+    func simulateKeystroke(_ keyCode: UInt16) throws
+}
 
-    private let logger = Logger(subsystem: "com.macparakeet.core", category: "ClipboardService")
-    private let pasteShortcutKeyResolver: PasteShortcutKeyResolver
-    private let clipboardRestoreDelay: TimeInterval
+struct CGClipboardEventPosting: ClipboardEventPosting {
+    @MainActor
+    func simulatePaste(using pasteShortcutKeyResolver: PasteShortcutKeyResolver) throws {
+        guard AXIsProcessTrusted() else {
+            throw ClipboardServiceError.accessibilityPermissionRequired
+        }
 
-    public init() {
-        pasteShortcutKeyResolver = PasteShortcutKeyResolver()
-        clipboardRestoreDelay = Self.defaultClipboardRestoreDelay
+        guard let source = CGEventSource(stateID: .hidSystemState) else {
+            throw ClipboardServiceError.eventSourceUnavailable
+        }
+
+        // Resolve under the same Command-modified layout state that the CGEvents carry.
+        let vKeyCode = pasteShortcutKeyResolver.virtualKeyCode(for: "v", modifierKeyState: UInt32(cmdKey >> 8))
+
+        guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: true),
+              let keyUp = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: false) else {
+            throw ClipboardServiceError.eventCreationFailed
+        }
+
+        keyDown.flags = .maskCommand
+        keyDown.post(tap: .cghidEventTap)
+
+        keyUp.flags = .maskCommand
+        keyUp.post(tap: .cghidEventTap)
     }
 
-    init(
-        pasteShortcutKeyResolver: PasteShortcutKeyResolver,
-        clipboardRestoreDelay: TimeInterval = ClipboardService.defaultClipboardRestoreDelay
-    ) {
-        self.pasteShortcutKeyResolver = pasteShortcutKeyResolver
-        self.clipboardRestoreDelay = clipboardRestoreDelay
-    }
-
-    /// Paste text into the active app by:
-    /// 1. Saving current clipboard
-    /// 2. Setting transcript on clipboard
-    /// 3. Simulating Cmd+V
-    /// 4. Restoring original clipboard after a delay long enough for slow paste targets
-    public func pasteText(_ text: String) async throws {
-        let pasteboard = NSPasteboard.general
-        let restoreDelay = clipboardRestoreDelay
-
-        // 1. Save current clipboard contents
-        let savedItems: [NSPasteboardItem]? = pasteboard.pasteboardItems?.map { item in
-            let restored = NSPasteboardItem()
-            for type in item.types {
-                if let data = item.data(forType: type) {
-                    restored.setData(data, forType: type)
-                }
-            }
-            return restored
-        }
-
-        // 2. Set transcript
-        pasteboard.clearContents()
-        guard pasteboard.setString(text, forType: .string) else {
-            pasteboard.clearContents()
-            if let savedItems, !savedItems.isEmpty {
-                pasteboard.writeObjects(savedItems)
-            }
-            throw ClipboardServiceError.pasteboardWriteFailed
-        }
-        let ourChangeCount = pasteboard.changeCount
-
-        // Always attempt to restore the previous clipboard contents after a short delay.
-        // The delay must cover apps that process the posted Cmd+V asynchronously.
-        // If the user intentionally rewrites the clipboard, changeCount guard prevents clobbering.
-        defer {
-            DispatchQueue.main.asyncAfter(deadline: .now() + restoreDelay) {
-                // If the user changed the clipboard after we wrote, do not clobber it.
-                guard pasteboard.changeCount == ourChangeCount else {
-                    return
-                }
-
-                pasteboard.clearContents()
-                if let savedItems, !savedItems.isEmpty {
-                    pasteboard.writeObjects(savedItems)
-                }
-            }
-        }
-
-        // 3. Simulate Cmd+V
-        try simulatePaste()
-    }
-
-    /// Copy text to clipboard without paste simulation
-    public func copyToClipboard(_ text: String) async {
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.setString(text, forType: .string)
-    }
-
-    @discardableResult
-    public func pasteTextWithAction(_ text: String, postPasteAction: KeyAction?) async throws -> Bool {
-        guard let action = postPasteAction else {
-            try await pasteText(text)
-            return false
-        }
-
-        // If text is empty (trigger was entire dictation), skip paste — just fire keystroke
-        if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            try simulateKeystroke(action.keyCode)
-            return true
-        }
-
-        // Paste text (no trailing space — action replaces the role of the space)
-        try await pasteText(text)
-
-        // After paste succeeds, the keystroke phase is entirely non-fatal.
-        // Task.sleep can throw CancellationError — catch it alongside keystroke errors
-        // so cancellation during the 200ms delay doesn't surface as a paste failure.
-        do {
-            try await Task.sleep(for: .milliseconds(200))
-            try simulateKeystroke(action.keyCode)
-            return true
-        } catch is CancellationError {
-            logger.notice("Post-paste keystroke skipped (task cancelled after paste succeeded)")
-            return false
-        } catch {
-            logger.error("Post-paste keystroke failed (text was pasted successfully): \(error.localizedDescription, privacy: .public)")
-            return false
-        }
-    }
-
-    // MARK: - Private
-
-    private func simulateKeystroke(_ keyCode: UInt16) throws {
+    @MainActor
+    func simulateKeystroke(_ keyCode: UInt16) throws {
         guard AXIsProcessTrusted() else {
             throw ClipboardServiceError.accessibilityPermissionRequired
         }
@@ -159,38 +78,239 @@ public final class ClipboardService: ClipboardServiceProtocol {
             throw ClipboardServiceError.eventCreationFailed
         }
 
-        // Explicitly clear modifier flags — .hidSystemState source may inherit
-        // stray modifiers if the user happens to hold a key during dictation.
         keyDown.flags = []
         keyUp.flags = []
 
         keyDown.post(tap: .cghidEventTap)
         keyUp.post(tap: .cghidEventTap)
     }
+}
 
-    private func simulatePaste() throws {
-        guard AXIsProcessTrusted() else {
-            throw ClipboardServiceError.accessibilityPermissionRequired
+@MainActor
+private final class ClipboardRestoreCoordinator {
+    private struct PendingRestore {
+        let originalItems: [NSPasteboardItem]?
+        var latestTemporaryChangeCount: Int
+        let generation: UInt64
+    }
+
+    private var pendingRestore: PendingRestore?
+    private var generation: UInt64 = 0
+
+    func originalItemsForNewPaste(
+        currentItems: [NSPasteboardItem]?,
+        currentChangeCount: Int
+    ) -> [NSPasteboardItem]? {
+        if let pendingRestore {
+            guard currentChangeCount == pendingRestore.latestTemporaryChangeCount else {
+                self.pendingRestore = nil
+                return currentItems
+            }
+
+            return pendingRestore.originalItems
         }
 
-        guard let source = CGEventSource(stateID: .hidSystemState) else {
-            throw ClipboardServiceError.eventSourceUnavailable
+        return currentItems
+    }
+
+    func temporaryClipboardWasRestoredAfterFailedWrite(changeCount: Int) {
+        guard var pendingRestore else {
+            return
         }
 
-        // Resolve the shortcut under the same Command-modified layout state that
-        // the generated CGEvents will carry. This preserves layouts such as
-        // "Dvorak - QWERTY ⌘" that intentionally remap only while Command is held.
-        let vKeyCode = pasteShortcutKeyResolver.virtualKeyCode(for: "v", modifierKeyState: UInt32(cmdKey >> 8))
+        pendingRestore.latestTemporaryChangeCount = changeCount
+        self.pendingRestore = pendingRestore
+    }
 
-        guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: true),
-              let keyUp = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: false) else {
-            throw ClipboardServiceError.eventCreationFailed
+    func scheduleRestore(
+        pasteboard: NSPasteboard,
+        originalItems: [NSPasteboardItem]?,
+        latestTemporaryChangeCount: Int,
+        delay: TimeInterval
+    ) {
+        generation += 1
+        let restoreGeneration = generation
+        pendingRestore = PendingRestore(
+            originalItems: originalItems,
+            latestTemporaryChangeCount: latestTemporaryChangeCount,
+            generation: restoreGeneration
+        )
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+            MainActor.assumeIsolated {
+                self.restoreIfCurrent(pasteboard: pasteboard, generation: restoreGeneration)
+            }
+        }
+    }
+
+    func cancelPendingRestore() {
+        pendingRestore = nil
+    }
+
+    private func restoreIfCurrent(pasteboard: NSPasteboard, generation: UInt64) {
+        guard let pendingRestore, pendingRestore.generation == generation else {
+            return
         }
 
-        keyDown.flags = .maskCommand
-        keyDown.post(tap: .cghidEventTap)
+        defer {
+            self.pendingRestore = nil
+        }
 
-        keyUp.flags = .maskCommand
-        keyUp.post(tap: .cghidEventTap)
+        guard pasteboard.changeCount == pendingRestore.latestTemporaryChangeCount else {
+            return
+        }
+
+        pasteboard.clearContents()
+        if let originalItems = pendingRestore.originalItems, !originalItems.isEmpty {
+            pasteboard.writeObjects(originalItems)
+        }
+    }
+}
+
+/// Handles clipboard save/restore and paste simulation via Cmd+V.
+@MainActor
+public final class ClipboardService: ClipboardServiceProtocol {
+    nonisolated static let defaultClipboardRestoreDelay: TimeInterval = 1.0
+    private static let sharedRestoreCoordinator = ClipboardRestoreCoordinator()
+
+    private let logger = Logger(subsystem: "com.macparakeet.core", category: "ClipboardService")
+    private let pasteboard: NSPasteboard
+    private let pasteShortcutKeyResolver: PasteShortcutKeyResolver
+    private let eventPosting: ClipboardEventPosting
+    private let clipboardRestoreDelay: TimeInterval
+    private let restoreCoordinator: ClipboardRestoreCoordinator
+
+    public convenience init() {
+        self.init(
+            pasteboard: .general,
+            pasteShortcutKeyResolver: PasteShortcutKeyResolver(),
+            eventPosting: CGClipboardEventPosting(),
+            clipboardRestoreDelay: Self.defaultClipboardRestoreDelay,
+            restoreCoordinator: Self.sharedRestoreCoordinator
+        )
+    }
+
+    convenience init(
+        pasteboard: NSPasteboard = .general,
+        pasteShortcutKeyResolver: PasteShortcutKeyResolver = PasteShortcutKeyResolver(),
+        eventPosting: ClipboardEventPosting = CGClipboardEventPosting(),
+        clipboardRestoreDelay: TimeInterval = ClipboardService.defaultClipboardRestoreDelay
+    ) {
+        self.init(
+            pasteboard: pasteboard,
+            pasteShortcutKeyResolver: pasteShortcutKeyResolver,
+            eventPosting: eventPosting,
+            clipboardRestoreDelay: clipboardRestoreDelay,
+            restoreCoordinator: ClipboardRestoreCoordinator()
+        )
+    }
+
+    private init(
+        pasteboard: NSPasteboard,
+        pasteShortcutKeyResolver: PasteShortcutKeyResolver,
+        eventPosting: ClipboardEventPosting,
+        clipboardRestoreDelay: TimeInterval,
+        restoreCoordinator: ClipboardRestoreCoordinator
+    ) {
+        self.pasteboard = pasteboard
+        self.pasteShortcutKeyResolver = pasteShortcutKeyResolver
+        self.eventPosting = eventPosting
+        self.clipboardRestoreDelay = clipboardRestoreDelay
+        self.restoreCoordinator = restoreCoordinator
+    }
+
+    /// Paste text into the active app by:
+    /// 1. Saving current clipboard
+    /// 2. Setting transcript on clipboard
+    /// 3. Simulating Cmd+V
+    /// 4. Restoring original clipboard after a delay long enough for slow paste targets
+    public func pasteText(_ text: String) async throws {
+        let restoreDelay = clipboardRestoreDelay
+
+        // 1. Save current clipboard contents
+        let currentItems = Self.snapshotItems(from: pasteboard)
+        let savedItems = restoreCoordinator.originalItemsForNewPaste(
+            currentItems: currentItems,
+            currentChangeCount: pasteboard.changeCount
+        )
+
+        // 2. Set transcript
+        pasteboard.clearContents()
+        guard pasteboard.setString(text, forType: .string) else {
+            pasteboard.clearContents()
+            Self.writeItems(currentItems, to: pasteboard)
+            restoreCoordinator.temporaryClipboardWasRestoredAfterFailedWrite(changeCount: pasteboard.changeCount)
+            throw ClipboardServiceError.pasteboardWriteFailed
+        }
+        let ourChangeCount = pasteboard.changeCount
+
+        restoreCoordinator.scheduleRestore(
+            pasteboard: pasteboard,
+            originalItems: savedItems,
+            latestTemporaryChangeCount: ourChangeCount,
+            delay: restoreDelay
+        )
+
+        // 3. Simulate Cmd+V
+        try eventPosting.simulatePaste(using: pasteShortcutKeyResolver)
+    }
+
+    /// Copy text to clipboard without paste simulation
+    public func copyToClipboard(_ text: String) async {
+        restoreCoordinator.cancelPendingRestore()
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+    }
+
+    @discardableResult
+    public func pasteTextWithAction(_ text: String, postPasteAction: KeyAction?) async throws -> Bool {
+        guard let action = postPasteAction else {
+            try await pasteText(text)
+            return false
+        }
+
+        // If text is empty (trigger was entire dictation), skip paste — just fire keystroke
+        if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            try eventPosting.simulateKeystroke(action.keyCode)
+            return true
+        }
+
+        // Paste text (no trailing space — action replaces the role of the space)
+        try await pasteText(text)
+
+        // After paste succeeds, the keystroke phase is entirely non-fatal.
+        // Task.sleep can throw CancellationError — catch it alongside keystroke errors
+        // so cancellation during the 200ms delay doesn't surface as a paste failure.
+        do {
+            try await Task.sleep(for: .milliseconds(200))
+            try eventPosting.simulateKeystroke(action.keyCode)
+            return true
+        } catch is CancellationError {
+            logger.notice("Post-paste keystroke skipped (task cancelled after paste succeeded)")
+            return false
+        } catch {
+            logger.error("Post-paste keystroke failed (text was pasted successfully): \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
+    // MARK: - Private
+
+    private static func snapshotItems(from pasteboard: NSPasteboard) -> [NSPasteboardItem]? {
+        pasteboard.pasteboardItems?.map { item in
+            let restored = NSPasteboardItem()
+            for type in item.types {
+                if let data = item.data(forType: type) {
+                    restored.setData(data, forType: type)
+                }
+            }
+            return restored
+        }
+    }
+
+    private static func writeItems(_ items: [NSPasteboardItem]?, to pasteboard: NSPasteboard) {
+        if let items, !items.isEmpty {
+            pasteboard.writeObjects(items)
+        }
     }
 }

--- a/Sources/MacParakeetCore/Services/System/ClipboardService.swift
+++ b/Sources/MacParakeetCore/Services/System/ClipboardService.swift
@@ -14,6 +14,7 @@ public enum ClipboardServiceError: LocalizedError {
     case accessibilityPermissionRequired
     case eventSourceUnavailable
     case eventCreationFailed
+    case pasteboardWriteFailed
 
     public var errorDescription: String? {
         switch self {
@@ -23,6 +24,8 @@ public enum ClipboardServiceError: LocalizedError {
             return "Paste automation unavailable (event source creation failed)."
         case .eventCreationFailed:
             return "Paste automation unavailable (could not create keyboard events)."
+        case .pasteboardWriteFailed:
+            return "Paste automation unavailable (could not write transcript to the clipboard)."
         }
     }
 }
@@ -30,24 +33,33 @@ public enum ClipboardServiceError: LocalizedError {
 /// Handles clipboard save/restore and paste simulation via Cmd+V.
 @MainActor
 public final class ClipboardService: ClipboardServiceProtocol {
+    nonisolated static let defaultClipboardRestoreDelay: TimeInterval = 1.0
+
     private let logger = Logger(subsystem: "com.macparakeet.core", category: "ClipboardService")
     private let pasteShortcutKeyResolver: PasteShortcutKeyResolver
+    private let clipboardRestoreDelay: TimeInterval
 
     public init() {
         pasteShortcutKeyResolver = PasteShortcutKeyResolver()
+        clipboardRestoreDelay = Self.defaultClipboardRestoreDelay
     }
 
-    init(pasteShortcutKeyResolver: PasteShortcutKeyResolver) {
+    init(
+        pasteShortcutKeyResolver: PasteShortcutKeyResolver,
+        clipboardRestoreDelay: TimeInterval = ClipboardService.defaultClipboardRestoreDelay
+    ) {
         self.pasteShortcutKeyResolver = pasteShortcutKeyResolver
+        self.clipboardRestoreDelay = clipboardRestoreDelay
     }
 
     /// Paste text into the active app by:
     /// 1. Saving current clipboard
     /// 2. Setting transcript on clipboard
     /// 3. Simulating Cmd+V
-    /// 4. Restoring original clipboard after 150ms delay
+    /// 4. Restoring original clipboard after a delay long enough for slow paste targets
     public func pasteText(_ text: String) async throws {
         let pasteboard = NSPasteboard.general
+        let restoreDelay = clipboardRestoreDelay
 
         // 1. Save current clipboard contents
         let savedItems: [NSPasteboardItem]? = pasteboard.pasteboardItems?.map { item in
@@ -62,13 +74,20 @@ public final class ClipboardService: ClipboardServiceProtocol {
 
         // 2. Set transcript
         pasteboard.clearContents()
-        pasteboard.setString(text, forType: .string)
+        guard pasteboard.setString(text, forType: .string) else {
+            pasteboard.clearContents()
+            if let savedItems, !savedItems.isEmpty {
+                pasteboard.writeObjects(savedItems)
+            }
+            throw ClipboardServiceError.pasteboardWriteFailed
+        }
         let ourChangeCount = pasteboard.changeCount
 
         // Always attempt to restore the previous clipboard contents after a short delay.
-        // If caller intentionally rewrites clipboard on error, changeCount guard prevents clobbering.
+        // The delay must cover apps that process the posted Cmd+V asynchronously.
+        // If the user intentionally rewrites the clipboard, changeCount guard prevents clobbering.
         defer {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + restoreDelay) {
                 // If the user changed the clipboard after we wrote, do not clobber it.
                 guard pasteboard.changeCount == ourChangeCount else {
                     return

--- a/Tests/MacParakeetTests/Services/System/ClipboardServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/System/ClipboardServiceTests.swift
@@ -19,6 +19,37 @@ final class ClipboardServiceTests: XCTestCase {
         )
     }
 
+    func testPasteTextWriteFailureRestoresClipboardAndDoesNotPostPaste() async throws {
+        let pasteboard = makeScratchPasteboard()
+        defer { pasteboard.releaseGlobally() }
+        replacePasteboard(pasteboard, with: "original")
+
+        var attemptedWrites: [String] = []
+        var pasteWasPosted = false
+        let service = ClipboardService(
+            pasteboard: pasteboard,
+            eventPosting: RecordingClipboardEventPosting {
+                pasteWasPosted = true
+            },
+            clipboardRestoreDelay: Self.shortRestoreDelay,
+            pasteboardStringWriter: { _, text in
+                attemptedWrites.append(text)
+                return false
+            }
+        )
+
+        do {
+            try await service.pasteText("dictation")
+            XCTFail("Expected pasteText to throw when writing to the pasteboard fails")
+        } catch ClipboardServiceError.pasteboardWriteFailed {
+            XCTAssertEqual(attemptedWrites, ["dictation"])
+            XCTAssertFalse(pasteWasPosted)
+            XCTAssertEqual(pasteboard.string(forType: .string), "original")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
     func testPasteTextRestoresOriginalClipboardAfterConfiguredDelay() async throws {
         let pasteboard = makeScratchPasteboard()
         defer { pasteboard.releaseGlobally() }
@@ -68,21 +99,82 @@ final class ClipboardServiceTests: XCTestCase {
         XCTAssertEqual(pasteboard.string(forType: .string), "original")
     }
 
-    func testUserClipboardChangeDuringRestoreWindowIsNotClobbered() async throws {
+    func testPasteTextWithActionSkipsPasteForEmptyTextAndFiresKeystroke() async throws {
         let pasteboard = makeScratchPasteboard()
         defer { pasteboard.releaseGlobally() }
         replacePasteboard(pasteboard, with: "original")
 
+        var pasteWasPosted = false
+        var keystrokes: [UInt16] = []
+        let service = ClipboardService(
+            pasteboard: pasteboard,
+            eventPosting: RecordingClipboardEventPosting(
+                onPaste: {
+                    pasteWasPosted = true
+                },
+                onKeystroke: { keyCode in
+                    keystrokes.append(keyCode)
+                }
+            ),
+            clipboardRestoreDelay: Self.shortRestoreDelay
+        )
+
+        let fired = try await service.pasteTextWithAction("  \n", postPasteAction: .returnKey)
+
+        XCTAssertTrue(fired)
+        XCTAssertFalse(pasteWasPosted)
+        XCTAssertEqual(keystrokes, [KeyAction.returnKey.keyCode])
+        XCTAssertEqual(pasteboard.string(forType: .string), "original")
+    }
+
+    func testPasteTextWithActionPastesTextThenFiresKeystroke() async throws {
+        let pasteboard = makeScratchPasteboard()
+        defer { pasteboard.releaseGlobally() }
+        replacePasteboard(pasteboard, with: "original")
+
+        var pastedStrings: [String] = []
+        var keystrokes: [UInt16] = []
+        let service = ClipboardService(
+            pasteboard: pasteboard,
+            eventPosting: RecordingClipboardEventPosting(
+                onPaste: {
+                    pastedStrings.append(pasteboard.string(forType: .string) ?? "")
+                },
+                onKeystroke: { keyCode in
+                    keystrokes.append(keyCode)
+                }
+            ),
+            clipboardRestoreDelay: Self.shortRestoreDelay
+        )
+
+        let fired = try await service.pasteTextWithAction("dictation", postPasteAction: .returnKey)
+
+        XCTAssertTrue(fired)
+        XCTAssertEqual(pastedStrings, ["dictation"])
+        XCTAssertEqual(keystrokes, [KeyAction.returnKey.keyCode])
+
+        try await waitForPasteboardString("original", on: pasteboard)
+    }
+
+    func testUserClipboardChangeDuringRestoreWindowIsNotClobbered() async throws {
+        let pasteboard = makeScratchPasteboard()
+        defer { pasteboard.releaseGlobally() }
+        replacePasteboard(pasteboard, with: "original")
+        let restoreAttempted = expectation(description: "scheduled restore attempted")
+
         let service = ClipboardService(
             pasteboard: pasteboard,
             eventPosting: RecordingClipboardEventPosting(),
-            clipboardRestoreDelay: Self.shortRestoreDelay
+            clipboardRestoreDelay: Self.shortRestoreDelay,
+            restoreAttemptObserver: {
+                restoreAttempted.fulfill()
+            }
         )
 
         try await service.pasteText("dictation")
         replacePasteboard(pasteboard, with: "user copy")
 
-        try await waitPastRestoreWindow()
+        await fulfillment(of: [restoreAttempted], timeout: 2)
 
         XCTAssertEqual(pasteboard.string(forType: .string), "user copy")
     }
@@ -111,19 +203,71 @@ final class ClipboardServiceTests: XCTestCase {
         let pasteboard = makeScratchPasteboard()
         defer { pasteboard.releaseGlobally() }
         replacePasteboard(pasteboard, with: "original")
+        let restoreAttempted = expectation(description: "scheduled restore attempted")
 
         let service = ClipboardService(
             pasteboard: pasteboard,
             eventPosting: RecordingClipboardEventPosting(),
-            clipboardRestoreDelay: Self.shortRestoreDelay
+            clipboardRestoreDelay: Self.shortRestoreDelay,
+            restoreAttemptObserver: {
+                restoreAttempted.fulfill()
+            }
         )
 
         try await service.pasteText("dictation")
         await service.copyToClipboard("manual copy")
 
-        try await waitPastRestoreWindow()
+        await fulfillment(of: [restoreAttempted], timeout: 2)
 
         XCTAssertEqual(pasteboard.string(forType: .string), "manual copy")
+    }
+
+    func testCopyToClipboardWriteFailurePreservesCurrentClipboard() async {
+        let pasteboard = makeScratchPasteboard()
+        defer { pasteboard.releaseGlobally() }
+        replacePasteboard(pasteboard, with: "original")
+
+        let service = ClipboardService(
+            pasteboard: pasteboard,
+            eventPosting: RecordingClipboardEventPosting(),
+            clipboardRestoreDelay: Self.shortRestoreDelay,
+            pasteboardStringWriter: { _, _ in false }
+        )
+
+        let copied = await service.copyToClipboard("manual copy")
+
+        XCTAssertFalse(copied)
+        XCTAssertEqual(pasteboard.string(forType: .string), "original")
+    }
+
+    func testFailedCopyToClipboardKeepsPendingOriginalRestore() async throws {
+        let pasteboard = makeScratchPasteboard()
+        defer { pasteboard.releaseGlobally() }
+        replacePasteboard(pasteboard, with: "original")
+
+        var failNextWrite = false
+        let service = ClipboardService(
+            pasteboard: pasteboard,
+            eventPosting: RecordingClipboardEventPosting(),
+            clipboardRestoreDelay: Self.shortRestoreDelay,
+            pasteboardStringWriter: { pasteboard, text in
+                guard !failNextWrite else {
+                    failNextWrite = false
+                    return false
+                }
+                return pasteboard.setString(text, forType: .string)
+            }
+        )
+
+        try await service.pasteText("dictation")
+        failNextWrite = true
+
+        let copied = await service.copyToClipboard("manual copy")
+
+        XCTAssertFalse(copied)
+        XCTAssertEqual(pasteboard.string(forType: .string), "dictation")
+
+        try await waitForPasteboardString("original", on: pasteboard)
     }
 
     private static let shortRestoreDelay: TimeInterval = 0.03
@@ -154,22 +298,26 @@ final class ClipboardServiceTests: XCTestCase {
         XCTAssertEqual(pasteboard.string(forType: .string), expected, file: file, line: line)
     }
 
-    private func waitPastRestoreWindow() async throws {
-        try await Task.sleep(for: .milliseconds(300))
-    }
 }
 
 @MainActor
 private final class RecordingClipboardEventPosting: ClipboardEventPosting {
     private let onPaste: @MainActor () throws -> Void
+    private let onKeystroke: @MainActor (UInt16) throws -> Void
 
-    init(onPaste: @escaping @MainActor () throws -> Void = {}) {
+    init(
+        onPaste: @escaping @MainActor () throws -> Void = {},
+        onKeystroke: @escaping @MainActor (UInt16) throws -> Void = { _ in }
+    ) {
         self.onPaste = onPaste
+        self.onKeystroke = onKeystroke
     }
 
     func simulatePaste(using pasteShortcutKeyResolver: PasteShortcutKeyResolver) throws {
         try onPaste()
     }
 
-    func simulateKeystroke(_ keyCode: UInt16) throws {}
+    func simulateKeystroke(_ keyCode: UInt16) throws {
+        try onKeystroke(keyCode)
+    }
 }

--- a/Tests/MacParakeetTests/Services/System/ClipboardServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/System/ClipboardServiceTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import XCTest
 @testable import MacParakeetCore
 
@@ -17,4 +18,158 @@ final class ClipboardServiceTests: XCTestCase {
             "Paste automation unavailable (could not write transcript to the clipboard)."
         )
     }
+
+    func testPasteTextRestoresOriginalClipboardAfterConfiguredDelay() async throws {
+        let pasteboard = makeScratchPasteboard()
+        defer { pasteboard.releaseGlobally() }
+        replacePasteboard(pasteboard, with: "original")
+
+        var pastedStrings: [String] = []
+        let service = ClipboardService(
+            pasteboard: pasteboard,
+            eventPosting: RecordingClipboardEventPosting {
+                pastedStrings.append(pasteboard.string(forType: .string) ?? "")
+            },
+            clipboardRestoreDelay: Self.shortRestoreDelay
+        )
+
+        try await service.pasteText("dictation")
+
+        XCTAssertEqual(pastedStrings, ["dictation"])
+        XCTAssertEqual(pasteboard.string(forType: .string), "dictation")
+
+        try await waitForPasteboardString("original", on: pasteboard)
+
+        XCTAssertEqual(pasteboard.string(forType: .string), "original")
+    }
+
+    func testOverlappingPasteTextRestoresPreExistingClipboard() async throws {
+        let pasteboard = makeScratchPasteboard()
+        defer { pasteboard.releaseGlobally() }
+        replacePasteboard(pasteboard, with: "original")
+
+        var pastedStrings: [String] = []
+        let service = ClipboardService(
+            pasteboard: pasteboard,
+            eventPosting: RecordingClipboardEventPosting {
+                pastedStrings.append(pasteboard.string(forType: .string) ?? "")
+            },
+            clipboardRestoreDelay: Self.shortRestoreDelay
+        )
+
+        try await service.pasteText("first dictation")
+        try await service.pasteText("second dictation")
+
+        XCTAssertEqual(pastedStrings, ["first dictation", "second dictation"])
+        XCTAssertEqual(pasteboard.string(forType: .string), "second dictation")
+
+        try await waitForPasteboardString("original", on: pasteboard)
+
+        XCTAssertEqual(pasteboard.string(forType: .string), "original")
+    }
+
+    func testUserClipboardChangeDuringRestoreWindowIsNotClobbered() async throws {
+        let pasteboard = makeScratchPasteboard()
+        defer { pasteboard.releaseGlobally() }
+        replacePasteboard(pasteboard, with: "original")
+
+        let service = ClipboardService(
+            pasteboard: pasteboard,
+            eventPosting: RecordingClipboardEventPosting(),
+            clipboardRestoreDelay: Self.shortRestoreDelay
+        )
+
+        try await service.pasteText("dictation")
+        replacePasteboard(pasteboard, with: "user copy")
+
+        try await waitPastRestoreWindow()
+
+        XCTAssertEqual(pasteboard.string(forType: .string), "user copy")
+    }
+
+    func testPasteAfterUserClipboardChangeUsesNewClipboardAsRestoreTarget() async throws {
+        let pasteboard = makeScratchPasteboard()
+        defer { pasteboard.releaseGlobally() }
+        replacePasteboard(pasteboard, with: "original")
+
+        let service = ClipboardService(
+            pasteboard: pasteboard,
+            eventPosting: RecordingClipboardEventPosting(),
+            clipboardRestoreDelay: Self.shortRestoreDelay
+        )
+
+        try await service.pasteText("first dictation")
+        replacePasteboard(pasteboard, with: "user copy")
+        try await service.pasteText("second dictation")
+
+        try await waitForPasteboardString("user copy", on: pasteboard)
+
+        XCTAssertEqual(pasteboard.string(forType: .string), "user copy")
+    }
+
+    func testCopyToClipboardCancelsPendingRestore() async throws {
+        let pasteboard = makeScratchPasteboard()
+        defer { pasteboard.releaseGlobally() }
+        replacePasteboard(pasteboard, with: "original")
+
+        let service = ClipboardService(
+            pasteboard: pasteboard,
+            eventPosting: RecordingClipboardEventPosting(),
+            clipboardRestoreDelay: Self.shortRestoreDelay
+        )
+
+        try await service.pasteText("dictation")
+        await service.copyToClipboard("manual copy")
+
+        try await waitPastRestoreWindow()
+
+        XCTAssertEqual(pasteboard.string(forType: .string), "manual copy")
+    }
+
+    private static let shortRestoreDelay: TimeInterval = 0.03
+
+    private func makeScratchPasteboard() -> NSPasteboard {
+        NSPasteboard(name: NSPasteboard.Name("com.macparakeet.tests.clipboard.\(UUID().uuidString)"))
+    }
+
+    private func replacePasteboard(_ pasteboard: NSPasteboard, with string: String) {
+        pasteboard.clearContents()
+        XCTAssertTrue(pasteboard.setString(string, forType: .string))
+    }
+
+    private func waitForPasteboardString(
+        _ expected: String,
+        on pasteboard: NSPasteboard,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        let deadline = Date().addingTimeInterval(2)
+        while Date() < deadline {
+            if pasteboard.string(forType: .string) == expected {
+                return
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+
+        XCTAssertEqual(pasteboard.string(forType: .string), expected, file: file, line: line)
+    }
+
+    private func waitPastRestoreWindow() async throws {
+        try await Task.sleep(for: .milliseconds(300))
+    }
+}
+
+@MainActor
+private final class RecordingClipboardEventPosting: ClipboardEventPosting {
+    private let onPaste: @MainActor () throws -> Void
+
+    init(onPaste: @escaping @MainActor () throws -> Void = {}) {
+        self.onPaste = onPaste
+    }
+
+    func simulatePaste(using pasteShortcutKeyResolver: PasteShortcutKeyResolver) throws {
+        try onPaste()
+    }
+
+    func simulateKeystroke(_ keyCode: UInt16) throws {}
 }

--- a/Tests/MacParakeetTests/Services/System/ClipboardServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/System/ClipboardServiceTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import MacParakeetCore
+
+@MainActor
+final class ClipboardServiceTests: XCTestCase {
+    func testDefaultRestoreDelayLeavesRoomForAsyncPasteConsumers() {
+        XCTAssertGreaterThanOrEqual(
+            ClipboardService.defaultClipboardRestoreDelay,
+            0.75,
+            "Restoring too soon can make slow target apps paste the previously saved clipboard item."
+        )
+    }
+
+    func testPasteboardWriteFailureHasActionableDescription() {
+        XCTAssertEqual(
+            ClipboardServiceError.pasteboardWriteFailed.errorDescription,
+            "Paste automation unavailable (could not write transcript to the clipboard)."
+        )
+    }
+}

--- a/Tests/MacParakeetTests/Services/System/MockClipboardService.swift
+++ b/Tests/MacParakeetTests/Services/System/MockClipboardService.swift
@@ -20,7 +20,8 @@ public actor MockClipboardService: ClipboardServiceProtocol {
         return postPasteAction != nil
     }
 
-    public func copyToClipboard(_ text: String) async {
+    public func copyToClipboard(_ text: String) async -> Bool {
         lastCopiedText = text
+        return true
     }
 }


### PR DESCRIPTION
## Summary
Dictation set the transcript on the pasteboard and then restored the previous clipboard 150 ms later — on slower paste targets, Cmd+V fired against the already-restored clipboard and pasted the old value. The restore now waits long enough for the paste to land, and back-to-back dictations no longer leak an earlier transcript as the "original" clipboard. Fixes #236.

## For users
- Dictation pastes the words you just spoke, even on slower or busy apps.
- Your original clipboard is still preserved — it returns automatically after the paste lands (about a second later).
- If you copy something during that brief window, your copy wins; the restore does not clobber it.
- Rapid back-to-back dictations restore the true original clipboard, not the previous transcript.

## How it works
```
before (150 ms restore):
  t=0    pasteboard <- dictation text
  t=10   send Cmd+V
  t=150  pasteboard <- previous clipboard (restored)
  t=200  slow app reads pasteboard -> gets PREVIOUS (wrong)

after (~1 s restore + coordinator):
  t=0    pasteboard <- dictation text
  t=10   send Cmd+V
  t=200  slow app reads pasteboard -> gets dictation (correct)
  t=1000 pasteboard <- original clipboard (restored, only if unchanged)
```
A shared `ClipboardRestoreCoordinator` tracks the pending restore by `changeCount` and generation, so user copies during the window cancel the restore and overlapping dictations chain back to the true original.

## Code touchpoints
- `Sources/MacParakeetCore/Services/System/ClipboardService.swift` — delayed restore, `ClipboardRestoreCoordinator`, pasteboard-write-failure handling.
- `Sources/MacParakeet/App/DictationFlowCoordinator.swift` — surfaces a clearer message when the manual-copy fallback also fails to write.
- `Tests/MacParakeetTests/Services/System/ClipboardServiceTests.swift` — scratch-pasteboard coverage for timing, overlap, user-copy, and write-failure paths.