### PR TITLE
Add hotkey telemetry props and preserve FFmpeg error details

### DIFF
--- a/Sources/MacParakeetCore/Audio/AudioFileConverter.swift
+++ b/Sources/MacParakeetCore/Audio/AudioFileConverter.swift
@@ -239,7 +239,7 @@ public final class AudioFileConverter: AudioFileConverting, Sendable {
         if process.terminationStatus != 0 {
             stderrHandle.synchronizeFile()
             let stderrStr = (try? String(contentsOf: stderrURL, encoding: .utf8)) ?? "Unknown error"
-            throw AudioProcessorError.conversionFailed(stderrStr)
+            throw AudioProcessorError.conversionFailed(Self.tailForError(stderrStr))
         }
 
         succeeded = true
@@ -287,10 +287,24 @@ public final class AudioFileConverter: AudioFileConverting, Sendable {
         if process.terminationStatus != 0 {
             stderrHandle.synchronizeFile()
             let stderrStr = (try? String(contentsOf: stderrURL, encoding: .utf8)) ?? "Unknown error"
-            throw AudioProcessorError.conversionFailed(stderrStr)
+            throw AudioProcessorError.conversionFailed(Self.tailForError(stderrStr))
         }
 
         succeeded = true
+    }
+
+    /// FFmpeg writes a long startup banner ("ffmpeg version X... configuration:
+    /// --prefix=... --enable-...") before the actual error message. The
+    /// telemetry path truncates `error_detail` to ~512 chars from the front,
+    /// so the banner used to crowd out the real failure reason. Keep the tail
+    /// instead — `dyld` / "Library not loaded" / "No such file" / etc. are all
+    /// emitted at the end of stderr, so this preserves diagnostics for the
+    /// fallback-path check at the call site too.
+    static func tailForError(_ stderr: String, limit: Int = 480) -> String {
+        let trimmed = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return "Unknown error" }
+        if trimmed.count <= limit { return trimmed }
+        return "...\(trimmed.suffix(limit))"
     }
 
     private func ensureTempDir() throws -> URL {

--- a/Sources/MacParakeetCore/Audio/AudioFileConverter.swift
+++ b/Sources/MacParakeetCore/Audio/AudioFileConverter.swift
@@ -301,10 +301,29 @@ public final class AudioFileConverter: AudioFileConverting, Sendable {
     /// emitted at the end of stderr, so this preserves diagnostics for the
     /// fallback-path check at the call site too.
     static func tailForError(_ stderr: String, limit: Int = 480) -> String {
-        let trimmed = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty { return "Unknown error" }
-        if trimmed.count <= limit { return trimmed }
-        return "...\(trimmed.suffix(limit))"
+        guard limit > 0 else { return "Unknown error" }
+
+        let whitespace = CharacterSet.whitespacesAndNewlines
+        let isMeaningful: (Character) -> Bool = { character in
+            !character.unicodeScalars.allSatisfy { whitespace.contains($0) }
+        }
+
+        guard let start = stderr.firstIndex(where: isMeaningful),
+              let end = stderr.lastIndex(where: isMeaningful)
+        else {
+            return "Unknown error"
+        }
+
+        let trimmed = stderr[start...end]
+        guard let suffixStart = trimmed.index(
+            trimmed.endIndex,
+            offsetBy: -limit,
+            limitedBy: trimmed.startIndex
+        ), suffixStart != trimmed.startIndex else {
+            return String(trimmed)
+        }
+
+        return "...\(trimmed[suffixStart...])"
     }
 
     private func ensureTempDir() throws -> URL {

--- a/Sources/MacParakeetCore/STT/HotkeyTrigger.swift
+++ b/Sources/MacParakeetCore/STT/HotkeyTrigger.swift
@@ -349,6 +349,53 @@ public struct HotkeyTrigger: Sendable {
     }
 }
 
+// MARK: - Telemetry payload
+
+extension HotkeyTrigger {
+    /// Maps `kind` to its telemetry counterpart. Kept inline here so callers
+    /// don't have to translate by hand at every emit site.
+    public var telemetryKind: TelemetryHotkeyKind {
+        switch kind {
+        case .disabled: return .disabled
+        case .modifier: return .modifier
+        case .keyCode:  return .keyCode
+        case .chord:    return .chord
+        }
+    }
+
+    /// Modifier name to send for `.modifier` triggers. Includes the
+    /// left/right side prefix when a side-specific modifier is configured —
+    /// that's the bit Logitech/SteerMouse compat conversations actually
+    /// hinge on. Returns nil for non-modifier kinds.
+    public var telemetryModifier: String? {
+        guard kind == .modifier else { return nil }
+        if let mkc = modifierKeyCode, let info = Self.modifierKeyCodeInfo[mkc] {
+            return "\(info.side.lowercased())_\(info.modifier)"
+        }
+        return modifierName
+    }
+
+    /// Sorted modifier list for `.chord` triggers (e.g. ["control","command"]).
+    /// Order matches the canonical macOS modifier ordering used in displayName.
+    public var telemetryChordModifiers: [String]? {
+        guard kind == .chord else { return nil }
+        guard let modifiers = chordModifiers else { return nil }
+        return Self.modifierOrder.filter { modifiers.contains($0) }
+    }
+
+    /// Builds the `.hotkeyCustomized` event spec for this trigger. Pulled into
+    /// a single helper so each settings call site stays a one-liner and the
+    /// (surface, kind, modifier, chord) projection can't drift between sites.
+    public func customizedEvent(surface: TelemetryHotkeySurface) -> TelemetryEventSpec {
+        .hotkeyCustomized(
+            surface: surface,
+            kind: telemetryKind,
+            modifier: telemetryModifier,
+            chordModifiers: telemetryChordModifiers
+        )
+    }
+}
+
 // MARK: - Equatable (canonical identity only)
 
 extension HotkeyTrigger: Equatable {

--- a/Sources/MacParakeetCore/STT/HotkeyTrigger.swift
+++ b/Sources/MacParakeetCore/STT/HotkeyTrigger.swift
@@ -354,6 +354,11 @@ public struct HotkeyTrigger: Sendable {
 extension HotkeyTrigger {
     /// Maps `kind` to its telemetry counterpart. Kept inline here so callers
     /// don't have to translate by hand at every emit site.
+    ///
+    /// We deliberately stop at the kind boundary — `docs/telemetry.md`
+    /// item 10 commits to "track boolean, not which key." Reading the
+    /// specific modifier name or keyCode out of `self` for telemetry
+    /// would cross that line.
     public var telemetryKind: TelemetryHotkeyKind {
         switch kind {
         case .disabled: return .disabled
@@ -363,36 +368,10 @@ extension HotkeyTrigger {
         }
     }
 
-    /// Modifier name to send for `.modifier` triggers. Includes the
-    /// left/right side prefix when a side-specific modifier is configured —
-    /// that's the bit Logitech/SteerMouse compat conversations actually
-    /// hinge on. Returns nil for non-modifier kinds.
-    public var telemetryModifier: String? {
-        guard kind == .modifier else { return nil }
-        if let mkc = modifierKeyCode, let info = Self.modifierKeyCodeInfo[mkc] {
-            return "\(info.side.lowercased())_\(info.modifier)"
-        }
-        return modifierName
-    }
-
-    /// Sorted modifier list for `.chord` triggers (e.g. ["control","command"]).
-    /// Order matches the canonical macOS modifier ordering used in displayName.
-    public var telemetryChordModifiers: [String]? {
-        guard kind == .chord else { return nil }
-        guard let modifiers = chordModifiers else { return nil }
-        return Self.modifierOrder.filter { modifiers.contains($0) }
-    }
-
-    /// Builds the `.hotkeyCustomized` event spec for this trigger. Pulled into
-    /// a single helper so each settings call site stays a one-liner and the
-    /// (surface, kind, modifier, chord) projection can't drift between sites.
+    /// Builds the `.hotkeyCustomized` event spec for this trigger. Pulled
+    /// into a single helper so each settings call site stays a one-liner.
     public func customizedEvent(surface: TelemetryHotkeySurface) -> TelemetryEventSpec {
-        .hotkeyCustomized(
-            surface: surface,
-            kind: telemetryKind,
-            modifier: telemetryModifier,
-            chordModifiers: telemetryChordModifiers
-        )
+        .hotkeyCustomized(surface: surface, kind: telemetryKind)
     }
 }
 

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -217,6 +217,11 @@ public enum TelemetryHotkeySurface: String, Sendable, Equatable {
 /// Mirrors `HotkeyTrigger.Kind` for telemetry. Kept separate so changes to the
 /// runtime model (e.g., the proposed modifier-only chord in #234) can land
 /// without forcing every prior value through a schema migration.
+///
+/// We deliberately track structural category only — see
+/// `docs/telemetry.md` item 10: "track boolean, not which key." `kind` is
+/// one step up from a boolean (4 categories of binding pattern); it does
+/// not reveal the actual modifier or keycode the user picked.
 public enum TelemetryHotkeyKind: String, Sendable, Equatable {
     case disabled
     case modifier
@@ -361,9 +366,7 @@ public enum TelemetryEventSpec: Sendable {
     case copyToClipboard(source: TelemetryCopySource)
     case hotkeyCustomized(
         surface: TelemetryHotkeySurface,
-        kind: TelemetryHotkeyKind,
-        modifier: String? = nil,
-        chordModifiers: [String]? = nil
+        kind: TelemetryHotkeyKind
     )
     case processingModeChanged(mode: String)
     case customWordAdded
@@ -641,12 +644,10 @@ extension TelemetryEventSpec {
              .restoreAttempted,
              .restoreSucceeded:
             return nil
-        case .hotkeyCustomized(let surface, let kind, let modifier, let chordModifiers):
+        case .hotkeyCustomized(let surface, let kind):
             return Self.compactProps(
                 ("surface", surface.rawValue),
-                ("kind", kind.rawValue),
-                ("modifier", modifier),
-                ("chord_modifiers", chordModifiers.flatMap { $0.isEmpty ? nil : $0.joined(separator: "+") })
+                ("kind", kind.rawValue)
             )
         case .appQuit(let sessionDurationSeconds):
             return ["session_duration_seconds": Self.format(sessionDurationSeconds)]

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -203,6 +203,27 @@ public enum TelemetryPermission: String, Sendable, Equatable {
     case calendar
 }
 
+/// Which capture surface a hotkey customization applies to. Lets us answer
+/// product questions like "do meeting hotkeys get customized as often as
+/// dictation?" and "which surface is most likely to land on a chord vs a
+/// single-key trigger?".
+public enum TelemetryHotkeySurface: String, Sendable, Equatable {
+    case dictation
+    case meeting
+    case fileTranscription = "file_transcription"
+    case youtubeTranscription = "youtube_transcription"
+}
+
+/// Mirrors `HotkeyTrigger.Kind` for telemetry. Kept separate so changes to the
+/// runtime model (e.g., the proposed modifier-only chord in #234) can land
+/// without forcing every prior value through a schema migration.
+public enum TelemetryHotkeyKind: String, Sendable, Equatable {
+    case disabled
+    case modifier
+    case keyCode = "key_code"
+    case chord
+}
+
 public enum TelemetrySettingName: String, Sendable, Equatable {
     case saveHistory = "save_history"
     case audioRetention = "audio_retention"
@@ -338,7 +359,12 @@ public enum TelemetryEventSpec: Sendable {
     case historySearched
     case historyReplayed
     case copyToClipboard(source: TelemetryCopySource)
-    case hotkeyCustomized
+    case hotkeyCustomized(
+        surface: TelemetryHotkeySurface,
+        kind: TelemetryHotkeyKind,
+        modifier: String? = nil,
+        chordModifiers: [String]? = nil
+    )
     case processingModeChanged(mode: String)
     case customWordAdded
     case customWordDeleted
@@ -596,7 +622,6 @@ extension TelemetryEventSpec {
         case .appLaunched,
              .historySearched,
              .historyReplayed,
-             .hotkeyCustomized,
              .customWordAdded,
              .customWordDeleted,
              .snippetAdded,
@@ -616,6 +641,13 @@ extension TelemetryEventSpec {
              .restoreAttempted,
              .restoreSucceeded:
             return nil
+        case .hotkeyCustomized(let surface, let kind, let modifier, let chordModifiers):
+            return Self.compactProps(
+                ("surface", surface.rawValue),
+                ("kind", kind.rawValue),
+                ("modifier", modifier),
+                ("chord_modifiers", chordModifiers.flatMap { $0.isEmpty ? nil : $0.joined(separator: "+") })
+            )
         case .appQuit(let sessionDurationSeconds):
             return ["session_duration_seconds": Self.format(sessionDurationSeconds)]
         case .dictationStarted(let trigger, let mode):
@@ -1197,7 +1229,7 @@ public enum TelemetryImplementedContract {
         .historySearched: [],
         .historyReplayed: [],
         .copyToClipboard: ["source"],
-        .hotkeyCustomized: [],
+        .hotkeyCustomized: ["surface", "kind"],
         .processingModeChanged: ["mode"],
         .customWordAdded: [],
         .customWordDeleted: [],

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -83,7 +83,7 @@ public final class SettingsViewModel {
         didSet {
             hotkeyTrigger.save(to: defaults)
             NotificationCenter.default.post(name: .macParakeetHotkeyTriggerDidChange, object: nil)
-            Telemetry.send(.hotkeyCustomized)
+            Telemetry.send(hotkeyTrigger.customizedEvent(surface: .dictation))
         }
     }
     public var meetingHotkeyTrigger: HotkeyTrigger {
@@ -93,7 +93,7 @@ public final class SettingsViewModel {
                 name: .macParakeetMeetingHotkeyTriggerDidChange,
                 object: nil
             )
-            Telemetry.send(.settingChanged(setting: .meetingHotkey))
+            Telemetry.send(meetingHotkeyTrigger.customizedEvent(surface: .meeting))
         }
     }
     public var fileTranscriptionHotkeyTrigger: HotkeyTrigger {
@@ -103,7 +103,7 @@ public final class SettingsViewModel {
                 name: .macParakeetFileTranscriptionHotkeyTriggerDidChange,
                 object: nil
             )
-            Telemetry.send(.settingChanged(setting: .fileTranscriptionHotkey))
+            Telemetry.send(fileTranscriptionHotkeyTrigger.customizedEvent(surface: .fileTranscription))
         }
     }
     public var youtubeTranscriptionHotkeyTrigger: HotkeyTrigger {
@@ -113,7 +113,7 @@ public final class SettingsViewModel {
                 name: .macParakeetYouTubeTranscriptionHotkeyTriggerDidChange,
                 object: nil
             )
-            Telemetry.send(.settingChanged(setting: .youtubeTranscriptionHotkey))
+            Telemetry.send(youtubeTranscriptionHotkeyTrigger.customizedEvent(surface: .youtubeTranscription))
         }
     }
     public var silenceAutoStop: Bool {

--- a/Tests/MacParakeetTests/Audio/AudioFileConverterTests.swift
+++ b/Tests/MacParakeetTests/Audio/AudioFileConverterTests.swift
@@ -119,6 +119,36 @@ final class AudioFileConverterTests: XCTestCase {
         XCTAssertTrue(filterArg.contains("normalize=0"))
     }
 
+    func testTailForErrorKeepsFailureReasonFromEnd() {
+        let stderr = """
+        ffmpeg version 8.1 Copyright ...
+          configuration: --prefix=/opt/homebrew --enable-libx264 --enable-libx265
+        Input #0, mov,mp4,m4a,3gp,3g2,mj2, from '/tmp/input.mp4':
+        Error opening input file /tmp/input.mp4.
+        Error opening input files: No such file or directory
+        """
+
+        let tail = AudioFileConverter.tailForError(stderr, limit: 90)
+
+        XCTAssertTrue(tail.hasPrefix("..."))
+        XCTAssertTrue(tail.contains("Error opening input files"))
+        XCTAssertTrue(tail.contains("No such file or directory"))
+        XCTAssertFalse(tail.contains("ffmpeg version"))
+    }
+
+    func testTailForErrorTrimsWithoutLosingErrorBeforeTrailingWhitespace() {
+        let stderr = "ffmpeg banner\nactual failure reason" + String(repeating: "\n ", count: 100)
+
+        let tail = AudioFileConverter.tailForError(stderr, limit: 64)
+
+        XCTAssertEqual(tail, "ffmpeg banner\nactual failure reason")
+    }
+
+    func testTailForErrorEmptyInputUsesUnknownError() {
+        XCTAssertEqual(AudioFileConverter.tailForError(" \n\t "), "Unknown error")
+        XCTAssertEqual(AudioFileConverter.tailForError("actual error", limit: 0), "Unknown error")
+    }
+
     func testConvertUnsupportedFormat() async {
         let converter = AudioFileConverter()
         let url = URL(fileURLWithPath: "/tmp/test.txt")

--- a/Tests/MacParakeetTests/Hotkey/HotkeyTriggerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyTriggerTests.swift
@@ -634,4 +634,33 @@ final class HotkeyTriggerTests: XCTestCase {
         let right = HotkeyTrigger(kind: .modifier, modifierName: "option", keyCode: nil, modifierKeyCode: 61)
         XCTAssertNotEqual(left, right)
     }
+
+    // MARK: - Telemetry
+
+    func testTelemetryKindMapsOnlyStructuralTriggerKind() {
+        XCTAssertEqual(HotkeyTrigger.disabled.telemetryKind, .disabled)
+        XCTAssertEqual(HotkeyTrigger.option.telemetryKind, .modifier)
+        XCTAssertEqual(HotkeyTrigger.fromKeyCode(119).telemetryKind, .keyCode)
+        XCTAssertEqual(HotkeyTrigger.chord(modifiers: ["command", "shift"], keyCode: 25).telemetryKind, .chord)
+    }
+
+    func testCustomizedEventDoesNotExposeSpecificKeySelection() {
+        let event = HotkeyTrigger.chord(modifiers: ["command", "shift"], keyCode: 25)
+            .customizedEvent(surface: .meeting)
+        let payload = TelemetryEvent(
+            spec: event,
+            appVer: "0.6.3",
+            osVer: "15.4",
+            locale: "en-US",
+            chip: "Apple M4",
+            session: "session"
+        )
+
+        XCTAssertEqual(payload.event, TelemetryEventName.hotkeyCustomized.rawValue)
+        XCTAssertEqual(payload.props?["surface"], "meeting")
+        XCTAssertEqual(payload.props?["kind"], "chord")
+        XCTAssertNil(payload.props?["modifier"])
+        XCTAssertNil(payload.props?["key_code"])
+        XCTAssertNil(payload.props?["chord_modifiers"])
+    }
 }

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -975,7 +975,7 @@ final class TelemetryServiceTests: XCTestCase {
             .historySearched,
             .historyReplayed,
             .copyToClipboard(source: .transcription),
-            .hotkeyCustomized,
+            .hotkeyCustomized(surface: .dictation, kind: .modifier, modifier: "fn", chordModifiers: nil),
             .processingModeChanged(mode: "precise"),
             .customWordAdded,
             .customWordDeleted,

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -792,6 +792,30 @@ final class TelemetryServiceTests: XCTestCase {
         }
     }
 
+    func testHotkeyCustomizedPropsUseStructuralCategoriesOnly() {
+        let cases: [(TelemetryHotkeySurface, TelemetryHotkeyKind, String, String)] = [
+            (.dictation, .disabled, "dictation", "disabled"),
+            (.meeting, .modifier, "meeting", "modifier"),
+            (.fileTranscription, .keyCode, "file_transcription", "key_code"),
+            (.youtubeTranscription, .chord, "youtube_transcription", "chord"),
+        ]
+
+        for (surface, kind, expectedSurface, expectedKind) in cases {
+            let event = TelemetryEvent(
+                spec: .hotkeyCustomized(surface: surface, kind: kind),
+                appVer: "0.6.3",
+                osVer: "15.4",
+                locale: "en-US",
+                chip: "Apple M4",
+                session: "session"
+            )
+
+            XCTAssertEqual(event.props?["surface"], expectedSurface)
+            XCTAssertEqual(event.props?["kind"], expectedKind)
+            XCTAssertEqual(Set(event.props?.keys ?? Dictionary<String, String>().keys), ["surface", "kind"])
+        }
+    }
+
     // MARK: - Session UUID
 
     func testSessionIdIsPerInstance() async {

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -975,7 +975,7 @@ final class TelemetryServiceTests: XCTestCase {
             .historySearched,
             .historyReplayed,
             .copyToClipboard(source: .transcription),
-            .hotkeyCustomized(surface: .dictation, kind: .modifier, modifier: "fn", chordModifiers: nil),
+            .hotkeyCustomized(surface: .dictation, kind: .modifier),
             .processingModeChanged(mode: "precise"),
             .customWordAdded,
             .customWordDeleted,

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -3,6 +3,37 @@ import CoreAudio
 @testable import MacParakeetCore
 @testable import MacParakeetViewModels
 
+private final class SettingsTelemetrySpy: TelemetryServiceProtocol, @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [TelemetryEventSpec] = []
+
+    func send(_ event: TelemetryEventSpec) {
+        lock.lock()
+        events.append(event)
+        lock.unlock()
+    }
+
+    func sendAndFlush(_ event: TelemetryEventSpec) async -> Bool {
+        send(event)
+        return true
+    }
+
+    func clearQueue() {
+        lock.lock()
+        events.removeAll()
+        lock.unlock()
+    }
+
+    func flush() async {}
+    func flushForTermination() {}
+
+    func snapshot() -> [TelemetryEventSpec] {
+        lock.lock()
+        defer { lock.unlock() }
+        return events
+    }
+}
+
 @MainActor
 final class SettingsViewModelTests: XCTestCase {
     var viewModel: SettingsViewModel!
@@ -61,6 +92,8 @@ final class SettingsViewModelTests: XCTestCase {
     }
 
     override func tearDown() {
+        Telemetry.configure(NoOpTelemetryService())
+
         // Clean up the test UserDefaults suite
         if let testDefaultsSuiteName {
             testDefaults.removePersistentDomain(forName: testDefaultsSuiteName)
@@ -491,6 +524,38 @@ final class SettingsViewModelTests: XCTestCase {
         )
         viewModel.youtubeTranscriptionHotkeyTrigger = .chord(modifiers: ["control", "shift"], keyCode: 16)
         wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testHotkeyChangesEmitHotkeyCustomizedTelemetryBySurface() {
+        let telemetry = SettingsTelemetrySpy()
+        Telemetry.configure(telemetry)
+
+        viewModel.hotkeyTrigger = .option
+        viewModel.meetingHotkeyTrigger = .chord(modifiers: ["control", "option"], keyCode: 46)
+        viewModel.fileTranscriptionHotkeyTrigger = .disabled
+        viewModel.youtubeTranscriptionHotkeyTrigger = .fromKeyCode(16)
+
+        let events = telemetry.snapshot()
+        let hotkeyEvents = events.compactMap { event -> String? in
+            guard case .hotkeyCustomized(let surface, let kind) = event else { return nil }
+            return "\(surface.rawValue):\(kind.rawValue)"
+        }
+        let hotkeySettingEvents = events.filter { event in
+            guard case .settingChanged(let setting) = event else { return false }
+            return [
+                .meetingHotkey,
+                .fileTranscriptionHotkey,
+                .youtubeTranscriptionHotkey,
+            ].contains(setting)
+        }
+
+        XCTAssertEqual(hotkeyEvents, [
+            "dictation:modifier",
+            "meeting:chord",
+            "file_transcription:disabled",
+            "youtube_transcription:key_code",
+        ])
+        XCTAssertTrue(hotkeySettingEvents.isEmpty)
     }
 
     func testTranscriptionHotkeysLoadFromUserDefaults() {

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -277,7 +277,7 @@ events remain useful for diarization-specific timing and failure analysis.
 
 | Event | Props | Question It Answers |
 |---|---|---|
-| `hotkey_customized` | — | Do people change the default hotkey? (not which key) |
+| `hotkey_customized` | `surface` (`dictation`, `meeting`, `file_transcription`, `youtube_transcription`), `kind` (`disabled`, `modifier`, `key_code`, `chord`) | Which capture surface gets its hotkey customized, and is the binding a single modifier vs a full chord vs a key? (still **not** which specific key — see Q&A item 10) |
 | `processing_mode_changed` | `mode` (raw, clean) | Is the clean pipeline valued? |
 | `custom_word_added` | — | Are custom words used? (NOT the word itself) |
 | `custom_word_deleted` | — | Are custom words removed often? |
@@ -666,7 +666,7 @@ External AI review of the telemetry design. Each point was evaluated and accepte
 | 7 | Missing model download cancellation visibility — onboarding funnel gap | Covered by canonical `model_operation` events with `action`, `outcome`, `stage`, model/engine dimensions, and duration. A separate `model_download_cancelled` event was intentionally not kept because it duplicates and blurs warm-up vs download cancellation. |
 | 8 | Missing LLM failure telemetry — need provider-level failure rates | Added `llm_prompt_result_failed`, `llm_chat_failed`, and formatter failure events with provider + error props. |
 | 9 | Cut `dictation_private` — sensitive signal, user explicitly wanted privacy | Removed. |
-| 10 | Cut `hotkey_changed.key` value — track boolean, not which key | Changed to `hotkey_customized` with no props. |
+| 10 | Cut `hotkey_changed.key` value — track boolean, not which key | Changed to `hotkey_customized`. The 2026-05-09 review found props were emitting NULL on every event so we couldn't tell hotkey customization apart by capture surface. Now emits `surface` (which feature) + `kind` (structural category: disabled / modifier / key_code / chord). The original "not which key" commitment still holds — we never emit the specific modifier name or keyCode value. |
 | 11 | Cut `pill_hidden` as separate event — redundant with `setting_changed` | Merged into `setting_changed` with `setting: "hide_pill"`. |
 | 12 | `error_occurred` needs allowlist — generic catch-all becomes junk | Added note: controlled allowlist of `domain` + `code`, no free-form text. |
 | 13 | Flush immediately for critical events (opt-out, onboarding, licensing) | Updated batching strategy with immediate flush list. |

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -286,7 +286,7 @@ events remain useful for diarization-specific timing and failure analysis.
 | `prompt_created` | — | Are custom prompt templates used? |
 | `prompt_updated` | — | Are custom prompts actively maintained? |
 | `prompt_deleted` | — | Are custom prompts abandoned or cleaned up? |
-| `setting_changed` | `setting` (save_history, audio_retention, menu_bar_only, hide_pill, save_transcription_audio, speaker_diarization, auto_save, meeting_auto_save, meeting_hotkey, file_transcription_hotkey, youtube_transcription_hotkey, microphone_selection, meeting_audio_source_mode, launch_at_login, silence_auto_stop, voice_return, calendar_auto_start_mode, calendar_reminder_minutes, calendar_trigger_filter, calendar_auto_stop_enabled, calendar_included_calendars) | Which settings get toggled? |
+| `setting_changed` | `setting` (save_history, audio_retention, menu_bar_only, hide_pill, save_transcription_audio, speaker_diarization, auto_save, meeting_auto_save, microphone_selection, meeting_audio_source_mode, launch_at_login, silence_auto_stop, voice_return, calendar_auto_start_mode, calendar_reminder_minutes, calendar_trigger_filter, calendar_auto_stop_enabled, calendar_included_calendars) | Which non-hotkey settings get toggled? Hotkey changes use `hotkey_customized`. |
 | `telemetry_opted_out` | — | How many opt out? (send this one last event, then stop) |
 
 ### 5b. Calendar Auto-Start — "Do calendar-driven meetings work?"


### PR DESCRIPTION
## Summary

Fixes two telemetry blind spots found in the 2026-05-09 telemetry review.

- `hotkey_customized` now sends `surface` and `kind`, so we can compare dictation, meeting, file, and YouTube hotkey changes without recording the actual key or modifier.
- `AudioFileConverter` now keeps the useful tail of ffmpeg stderr, so conversion failure telemetry contains the real failure reason instead of the startup banner.
- Review follow-ups are included: `tailForError` trims by index instead of copying a fully trimmed stderr string, and the old modifier-order comment is verified outdated because `modifier` and `chord_modifiers` are no longer emitted.

## Shape

```text
Hotkey change
  SettingsViewModel
        |
        v
  HotkeyTrigger.customizedEvent(surface)
        |
        v
  hotkey_customized { surface, kind }

  never emits: modifier, key_code, chord_modifiers
```

```text
FFmpeg stderr
  [startup banner ... configuration ...][real failure at end]
                                      |
                                      v
                             tailForError(limit: 480)
                                      |
                                      v
                         error_detail keeps real failure
```

## Validation

- `swift test --filter "AudioFileConverterTests|HotkeyTriggerTests|TelemetryServiceTests"` - 140 tests, 0 failures.
- `swift test --filter SettingsViewModelTests` - 132 tests, 0 failures.
- `swift test` - 2,254 XCTest tests, 1 expected calendar-feature skip, 0 failures; 16 Swift Testing tests, 0 failures.
- GitHub checks on `09b9ddd0`: CodeRabbit pass; both `swift-test` jobs pass.