### PR TITLE
Add configurable YouTube audio quality

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -82,9 +82,10 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ### Added
 
-- `transcribe --youtube-audio-quality app-default|compatibility|best-available`
-  lets callers choose between the app default, the historical m4a-first
-  selector, and yt-dlp's best available audio stream for YouTube URLs.
+- `transcribe --youtube-audio-quality app-default|m4a|best-available`
+  lets callers choose between the app default, an m4a-first selector for
+  Apple-friendly saved audio files, and yt-dlp's best available source stream,
+  which may save WebM/Opus files.
 
 ## [2.0.0] -- 2026-05-03
 

--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -80,6 +80,12 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ## [Unreleased]
 
+### Added
+
+- `transcribe --youtube-audio-quality app-default|compatibility|best-available`
+  lets callers choose between the app default, the historical m4a-first
+  selector, and yt-dlp's best available audio stream for YouTube URLs.
+
 ## [2.0.0] -- 2026-05-03
 
 ### Added — `quick-prompts`

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -15,6 +15,12 @@ enum DownloadedAudioPolicy: String, ExpressibleByArgument {
     case delete
 }
 
+enum YouTubeAudioQualityOption: String, ExpressibleByArgument {
+    case appDefault = "app-default"
+    case compatibility
+    case bestAvailable = "best-available"
+}
+
 enum TranscribeOutputFormat: String, ExpressibleByArgument, CaseIterable, Sendable {
     case text
     case json
@@ -59,6 +65,9 @@ struct TranscribeCommand: AsyncParsableCommand {
     @Option(help: "Downloaded YouTube audio retention: app-default, keep, delete.")
     var downloadedAudio: DownloadedAudioPolicy = .appDefault
 
+    @Option(help: "YouTube audio quality: app-default, compatibility, best-available.")
+    var youtubeAudioQuality: YouTubeAudioQualityOption = .appDefault
+
     @Option(help: "Path to SQLite database file (defaults to the app database).")
     var database: String?
 
@@ -76,6 +85,20 @@ struct TranscribeCommand: AsyncParsableCommand {
             return .clean
         case .appDefault:
             return Dictation.ProcessingMode(rawValue: storedMode ?? Dictation.ProcessingMode.raw.rawValue) ?? .raw
+        }
+    }
+
+    static func resolveYouTubeAudioQuality(
+        _ quality: YouTubeAudioQualityOption,
+        storedQuality: String?
+    ) -> YouTubeAudioQuality {
+        switch quality {
+        case .compatibility:
+            return .compatibility
+        case .bestAvailable:
+            return .bestAvailable
+        case .appDefault:
+            return storedQuality.flatMap(YouTubeAudioQuality.init(rawValue:)) ?? .compatibility
         }
     }
 
@@ -115,7 +138,13 @@ struct TranscribeCommand: AsyncParsableCommand {
                     sttTranscriber = createdWhisperEngine
                 }
                 let audioProcessor = AudioProcessor()
-                let youtubeDownloader = YouTubeDownloader()
+                let youtubeDownloader = YouTubeDownloader(audioQuality: {
+                    let defaults = macParakeetAppDefaults()
+                    return Self.resolveYouTubeAudioQuality(
+                        self.youtubeAudioQuality,
+                        storedQuality: defaults.string(forKey: UserDefaultsAppRuntimePreferences.youtubeAudioQualityKey)
+                    )
+                })
                 let entitlementsService = enforceEntitlements ? makeEntitlementsService() : nil
 
                 if let entitlementsService {
@@ -133,7 +162,10 @@ struct TranscribeCommand: AsyncParsableCommand {
                     snippetRepo: snippetRepo,
                     processingMode: {
                         let defaults = macParakeetAppDefaults()
-                        return Self.resolveProcessingMode(self.mode, storedMode: defaults.string(forKey: "processingMode"))
+                        return Self.resolveProcessingMode(
+                            self.mode,
+                            storedMode: defaults.string(forKey: UserDefaultsAppRuntimePreferences.processingModeKey)
+                        )
                     },
                     shouldKeepDownloadedAudio: {
                         switch self.downloadedAudio {
@@ -143,7 +175,7 @@ struct TranscribeCommand: AsyncParsableCommand {
                             return false
                         case .appDefault:
                             let defaults = macParakeetAppDefaults()
-                            return defaults.object(forKey: "saveTranscriptionAudio") as? Bool ?? true
+                            return defaults.object(forKey: UserDefaultsAppRuntimePreferences.saveTranscriptionAudioKey) as? Bool ?? true
                         }
                     },
                     youtubeDownloader: youtubeDownloader,

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -17,7 +17,7 @@ enum DownloadedAudioPolicy: String, ExpressibleByArgument {
 
 enum YouTubeAudioQualityOption: String, ExpressibleByArgument {
     case appDefault = "app-default"
-    case compatibility
+    case m4a
     case bestAvailable = "best-available"
 }
 
@@ -65,7 +65,7 @@ struct TranscribeCommand: AsyncParsableCommand {
     @Option(help: "Downloaded YouTube audio retention: app-default, keep, delete.")
     var downloadedAudio: DownloadedAudioPolicy = .appDefault
 
-    @Option(help: "YouTube audio quality: app-default, compatibility, best-available.")
+    @Option(help: "YouTube audio quality: app-default, m4a, best-available.")
     var youtubeAudioQuality: YouTubeAudioQualityOption = .appDefault
 
     @Option(help: "Path to SQLite database file (defaults to the app database).")
@@ -93,12 +93,16 @@ struct TranscribeCommand: AsyncParsableCommand {
         storedQuality: String?
     ) -> YouTubeAudioQuality {
         switch quality {
-        case .compatibility:
-            return .compatibility
         case .bestAvailable:
             return .bestAvailable
+        case .m4a:
+            return .m4a
         case .appDefault:
-            return storedQuality.flatMap(YouTubeAudioQuality.init(rawValue:)) ?? .compatibility
+            guard let storedQuality,
+                  let quality = YouTubeAudioQuality(rawValue: storedQuality) else {
+                return .m4a
+            }
+            return quality
         }
     }
 

--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -144,7 +144,10 @@ final class AppEnvironment {
         }
 
         let binaryBootstrap = BinaryBootstrap()
-        youtubeDownloader = YouTubeDownloader(binaryBootstrap: binaryBootstrap)
+        youtubeDownloader = YouTubeDownloader(
+            binaryBootstrap: binaryBootstrap,
+            audioQuality: { [runtimePreferences] in runtimePreferences.youtubeAudioQuality }
+        )
         Task.detached(priority: .utility) {
             await binaryBootstrap.autoUpdateYtDlpIfNeeded()
         }

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -721,6 +721,24 @@ struct SettingsView: View {
 
                 Divider()
 
+                HStack(alignment: .center) {
+                    rowText(
+                        title: "YouTube audio quality",
+                        detail: viewModel.youtubeAudioQuality.detail
+                    )
+                    Spacer(minLength: DesignSystem.Spacing.md)
+                    Picker("YouTube audio quality", selection: $viewModel.youtubeAudioQuality) {
+                        ForEach(YouTubeAudioQuality.allCases, id: \.self) { quality in
+                            Text(quality.displayTitle).tag(quality)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .frame(minWidth: 170, idealWidth: 210, maxWidth: 260)
+                }
+
+                Divider()
+
                 settingsToggleRow(
                     title: "Speaker detection",
                     detail: "Optional. Adds speaker labels when audio is clear; leave off if labels are unreliable.",

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -6,11 +6,52 @@ public protocol AppRuntimePreferencesProtocol: Sendable {
     var shouldSaveAudioRecordings: Bool { get }
     var shouldSaveDictationHistory: Bool { get }
     var shouldSaveTranscriptionAudio: Bool { get }
+    var youtubeAudioQuality: YouTubeAudioQuality { get }
     var shouldDiarize: Bool { get }
     var aiFormatterEnabled: Bool { get }
     var aiFormatterPrompt: String { get }
     var selectedMicrophoneDeviceUID: String? { get }
     var meetingAudioSourceMode: MeetingAudioSourceMode { get }
+}
+
+public enum YouTubeAudioQuality: String, CaseIterable, Hashable, Sendable, Equatable {
+    case compatibility
+    case bestAvailable = "best_available"
+
+    public var displayTitle: String {
+        switch self {
+        case .compatibility:
+            return "Compatibility"
+        case .bestAvailable:
+            return "Best available"
+        }
+    }
+
+    public var detail: String {
+        switch self {
+        case .compatibility:
+            return "Prefer m4a audio for broad compatibility. Matches previous MacParakeet downloads."
+        case .bestAvailable:
+            return "Prefer the highest-quality audio stream YouTube exposes, often Opus/WebM."
+        }
+    }
+
+    public var ytDlpFormatSelector: String {
+        switch self {
+        case .compatibility:
+            return "bestaudio[ext=m4a]/bestaudio/best"
+        case .bestAvailable:
+            return "bestaudio/best"
+        }
+    }
+
+    public static func current(defaults: UserDefaults = .standard) -> YouTubeAudioQuality {
+        guard let raw = defaults.string(forKey: UserDefaultsAppRuntimePreferences.youtubeAudioQualityKey),
+              let quality = YouTubeAudioQuality(rawValue: raw) else {
+            return .compatibility
+        }
+        return quality
+    }
 }
 
 public enum MeetingAudioSourceMode: String, CaseIterable, Hashable, Sendable, Equatable {
@@ -58,6 +99,7 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
     public static let saveDictationHistoryKey = "saveDictationHistory"
     public static let saveAudioRecordingsKey = "saveAudioRecordings"
     public static let saveTranscriptionAudioKey = "saveTranscriptionAudio"
+    public static let youtubeAudioQualityKey = "youtubeAudioQuality"
     public static let speakerDiarizationKey = "speakerDiarization"
     public static let aiFormatterEnabledKey = "aiFormatterEnabled"
     public static let aiFormatterPromptKey = "aiFormatterPrompt"
@@ -92,6 +134,10 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
 
     public var shouldSaveTranscriptionAudio: Bool {
         defaults.object(forKey: Self.saveTranscriptionAudioKey) as? Bool ?? true
+    }
+
+    public var youtubeAudioQuality: YouTubeAudioQuality {
+        YouTubeAudioQuality.current(defaults: defaults)
     }
 
     public var shouldDiarize: Bool {

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -15,13 +15,13 @@ public protocol AppRuntimePreferencesProtocol: Sendable {
 }
 
 public enum YouTubeAudioQuality: String, CaseIterable, Hashable, Sendable, Equatable {
-    case compatibility
+    case m4a
     case bestAvailable = "best_available"
 
     public var displayTitle: String {
         switch self {
-        case .compatibility:
-            return "Compatibility"
+        case .m4a:
+            return "M4A"
         case .bestAvailable:
             return "Best available"
         }
@@ -29,16 +29,16 @@ public enum YouTubeAudioQuality: String, CaseIterable, Hashable, Sendable, Equat
 
     public var detail: String {
         switch self {
-        case .compatibility:
-            return "Prefer m4a audio for broad compatibility. Matches previous MacParakeet downloads."
+        case .m4a:
+            return "Download an Apple-friendly m4a file for reliable playback and sharing. Falls back if m4a is unavailable."
         case .bestAvailable:
-            return "Prefer the highest-quality audio stream YouTube exposes, often Opus/WebM."
+            return "Use YouTube's highest-quality audio stream. May save WebM/Opus files; transcription still converts them to WAV."
         }
     }
 
     public var ytDlpFormatSelector: String {
         switch self {
-        case .compatibility:
+        case .m4a:
             return "bestaudio[ext=m4a]/bestaudio/best"
         case .bestAvailable:
             return "bestaudio/best"
@@ -48,7 +48,7 @@ public enum YouTubeAudioQuality: String, CaseIterable, Hashable, Sendable, Equat
     public static func current(defaults: UserDefaults = .standard) -> YouTubeAudioQuality {
         guard let raw = defaults.string(forKey: UserDefaultsAppRuntimePreferences.youtubeAudioQualityKey),
               let quality = YouTubeAudioQuality(rawValue: raw) else {
-            return .compatibility
+            return .m4a
         }
         return quality
     }

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -235,6 +235,7 @@ public enum TelemetrySettingName: String, Sendable, Equatable {
     case menuBarOnly = "menu_bar_only"
     case hidePill = "hide_pill"
     case saveTranscriptionAudio = "save_transcription_audio"
+    case youtubeAudioQuality = "youtube_audio_quality"
     case speakerDiarization = "speaker_diarization"
     case autoSave = "auto_save"
     case meetingAutoSave = "meeting_auto_save"

--- a/Sources/MacParakeetCore/Services/YouTubeDownloader.swift
+++ b/Sources/MacParakeetCore/Services/YouTubeDownloader.swift
@@ -374,11 +374,10 @@ public actor YouTubeDownloader {
         quality: YouTubeAudioQuality,
         javaScriptRuntimeArguments: [String] = []
     ) -> [String] {
-        var args: [String] = []
-        if !javaScriptRuntimeArguments.isEmpty {
-            args += ["--no-js-runtimes"] + javaScriptRuntimeArguments
-        }
-        args += ["--ffmpeg-location", ffmpegDir]
+        var args = commonYtDlpArguments(
+            ffmpegDir: ffmpegDir,
+            javaScriptRuntimeArguments: javaScriptRuntimeArguments
+        )
         args += [
             "-f", quality.ytDlpFormatSelector,
             "--no-playlist",
@@ -388,6 +387,18 @@ public actor YouTubeDownloader {
             "-o", outputTemplate,
             "--", url,
         ]
+        return args
+    }
+
+    nonisolated static func commonYtDlpArguments(
+        ffmpegDir: String,
+        javaScriptRuntimeArguments: [String] = []
+    ) -> [String] {
+        var args: [String] = []
+        if !javaScriptRuntimeArguments.isEmpty {
+            args += ["--no-js-runtimes"] + javaScriptRuntimeArguments
+        }
+        args += ["--ffmpeg-location", ffmpegDir]
         return args
     }
 
@@ -637,15 +648,10 @@ public actor YouTubeDownloader {
         env["PATH"] = Self.extendedPATH()
         process.environment = env
 
-        var fullArgs = arguments
-        let jsRuntimeArgs = javaScriptRuntimeArguments()
-        if !jsRuntimeArgs.isEmpty {
-            fullArgs = ["--no-js-runtimes"] + jsRuntimeArgs + fullArgs
-        }
-        let ffmpegDir = try ffmpegDirectory()
-        fullArgs = ["--ffmpeg-location", ffmpegDir] + fullArgs
-
-        process.arguments = fullArgs
+        process.arguments = Self.commonYtDlpArguments(
+            ffmpegDir: try ffmpegDirectory(),
+            javaScriptRuntimeArguments: javaScriptRuntimeArguments()
+        ) + arguments
         process.standardOutput = captureStdout ? stdoutHandle : FileHandle.nullDevice
         process.standardError = stderrHandle
 

--- a/Sources/MacParakeetCore/Services/YouTubeDownloader.swift
+++ b/Sources/MacParakeetCore/Services/YouTubeDownloader.swift
@@ -72,9 +72,14 @@ public actor YouTubeDownloader {
     }
 
     private let binaryBootstrap: BinaryBootstrap
+    private let audioQuality: @Sendable () -> YouTubeAudioQuality
 
-    public init(binaryBootstrap: BinaryBootstrap = BinaryBootstrap()) {
+    public init(
+        binaryBootstrap: BinaryBootstrap = BinaryBootstrap(),
+        audioQuality: @escaping @Sendable () -> YouTubeAudioQuality = { .compatibility }
+    ) {
         self.binaryBootstrap = binaryBootstrap
+        self.audioQuality = audioQuality
     }
 
     /// Download audio from a YouTube URL.
@@ -239,21 +244,13 @@ public actor YouTubeDownloader {
         env["PATH"] = Self.extendedPATH()
         process.environment = env
 
-        var args: [String] = []
-        let jsRuntimeArgs = javaScriptRuntimeArguments()
-        if !jsRuntimeArgs.isEmpty {
-            args += ["--no-js-runtimes"] + jsRuntimeArgs
-        }
-        args += ["--ffmpeg-location", ffmpegDir]
-        args += [
-            "-f", "bestaudio[ext=m4a]/bestaudio/best",
-            "--no-playlist",
-            "--retries", "3",
-            "--concurrent-fragments", "4",
-            "--newline",
-            "-o", outputTemplate,
-            "--", url,
-        ]
+        let args = Self.downloadAudioArguments(
+            ffmpegDir: ffmpegDir,
+            outputTemplate: outputTemplate,
+            url: url,
+            quality: audioQuality(),
+            javaScriptRuntimeArguments: javaScriptRuntimeArguments()
+        )
         process.arguments = args
 
         // yt-dlp sends [download] progress lines to stdout (not stderr).
@@ -368,6 +365,30 @@ public actor YouTubeDownloader {
         for file in files where file.lastPathComponent.hasPrefix(uuid) {
             try? fm.removeItem(at: file)
         }
+    }
+
+    nonisolated static func downloadAudioArguments(
+        ffmpegDir: String,
+        outputTemplate: String,
+        url: String,
+        quality: YouTubeAudioQuality,
+        javaScriptRuntimeArguments: [String] = []
+    ) -> [String] {
+        var args: [String] = []
+        if !javaScriptRuntimeArguments.isEmpty {
+            args += ["--no-js-runtimes"] + javaScriptRuntimeArguments
+        }
+        args += ["--ffmpeg-location", ffmpegDir]
+        args += [
+            "-f", quality.ytDlpFormatSelector,
+            "--no-playlist",
+            "--retries", "3",
+            "--concurrent-fragments", "4",
+            "--newline",
+            "-o", outputTemplate,
+            "--", url,
+        ]
+        return args
     }
 
     nonisolated static func selectDownloadedAudioFile(from fileNames: [String], uuid: String) -> String? {

--- a/Sources/MacParakeetCore/Services/YouTubeDownloader.swift
+++ b/Sources/MacParakeetCore/Services/YouTubeDownloader.swift
@@ -76,7 +76,7 @@ public actor YouTubeDownloader {
 
     public init(
         binaryBootstrap: BinaryBootstrap = BinaryBootstrap(),
-        audioQuality: @escaping @Sendable () -> YouTubeAudioQuality = { .compatibility }
+        audioQuality: @escaping @Sendable () -> YouTubeAudioQuality = { .m4a }
     ) {
         self.binaryBootstrap = binaryBootstrap
         self.audioQuality = audioQuality
@@ -407,13 +407,16 @@ public actor YouTubeDownloader {
             .filter { $0.hasPrefix(uuid) }
             .filter { !isYtDlpTemporaryArtifact($0) }
 
-        if let audioCandidate = candidates.first(where: {
-            audioFileExtensions.contains(URL(fileURLWithPath: $0).pathExtension.lowercased())
-        }) {
+        if let audioCandidate = candidates.first(where: { isSupportedDownloadedAudioFile($0) }) {
             return audioCandidate
         }
 
         return nil
+    }
+
+    private nonisolated static func isSupportedDownloadedAudioFile(_ fileName: String) -> Bool {
+        let ext = URL(fileURLWithPath: fileName).pathExtension.lowercased()
+        return audioFileExtensions.contains(ext) && AudioFileConverter.isSupported(extension: ext)
     }
 
     private nonisolated static func isYtDlpTemporaryArtifact(_ fileName: String) -> Bool {

--- a/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
+++ b/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
@@ -159,6 +159,14 @@ public enum SettingsSearchIndex {
             cardAnchor: "transcription"
         ),
         SettingsSearchEntry(
+            id: "transcription.youtube.audio.quality",
+            tab: .modes,
+            title: "YouTube audio quality",
+            subtitle: "in Transcription",
+            keywords: ["youtube", "audio", "quality", "best available", "compatibility", "opus", "m4a"],
+            cardAnchor: "transcription"
+        ),
+        SettingsSearchEntry(
             id: "transcription.diarization",
             tab: .modes,
             title: "Speaker detection",

--- a/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
+++ b/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
@@ -163,7 +163,7 @@ public enum SettingsSearchIndex {
             tab: .modes,
             title: "YouTube audio quality",
             subtitle: "in Transcription",
-            keywords: ["youtube", "audio", "quality", "best available", "compatibility", "opus", "m4a"],
+            keywords: ["youtube", "audio", "quality", "m4a", "best available", "opus", "webm"],
             cardAnchor: "transcription"
         ),
         SettingsSearchEntry(

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -230,6 +230,12 @@ public final class SettingsViewModel {
     }
 
     // Transcription
+    public var youtubeAudioQuality: YouTubeAudioQuality {
+        didSet {
+            defaults.set(youtubeAudioQuality.rawValue, forKey: UserDefaultsAppRuntimePreferences.youtubeAudioQualityKey)
+            Telemetry.send(.settingChanged(setting: .youtubeAudioQuality))
+        }
+    }
     public var speakerDiarization: Bool {
         didSet {
             defaults.set(speakerDiarization, forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey)
@@ -469,6 +475,7 @@ public final class SettingsViewModel {
         saveDictationHistory = defaults.object(forKey: UserDefaultsAppRuntimePreferences.saveDictationHistoryKey) as? Bool ?? true
         saveAudioRecordings = defaults.object(forKey: UserDefaultsAppRuntimePreferences.saveAudioRecordingsKey) as? Bool ?? true
         saveTranscriptionAudio = defaults.object(forKey: UserDefaultsAppRuntimePreferences.saveTranscriptionAudioKey) as? Bool ?? true
+        youtubeAudioQuality = YouTubeAudioQuality.current(defaults: defaults)
         speakerDiarization = defaults.object(forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey) as? Bool ?? false
         speechEnginePreference = SpeechEnginePreference.current(defaults: defaults)
         whisperDefaultLanguage = SpeechEnginePreference.whisperDefaultLanguage(defaults: defaults) ?? "auto"

--- a/Tests/CLITests/TranscribeCommandTests.swift
+++ b/Tests/CLITests/TranscribeCommandTests.swift
@@ -24,14 +24,14 @@ final class TranscribeCommandTests: XCTestCase {
         XCTAssertEqual(mode, .clean)
     }
 
-    func testResolveYouTubeAudioQualityUsesCompatibilityForAppDefaultWhenUnset() {
+    func testResolveYouTubeAudioQualityUsesM4AForAppDefaultWhenUnset() {
         let quality = TranscribeCommand.resolveYouTubeAudioQuality(.appDefault, storedQuality: nil)
-        XCTAssertEqual(quality, .compatibility)
+        XCTAssertEqual(quality, .m4a)
     }
 
-    func testResolveYouTubeAudioQualityUsesCompatibilityForAppDefaultWhenStoredQualityInvalid() {
+    func testResolveYouTubeAudioQualityUsesM4AForAppDefaultWhenStoredQualityInvalid() {
         let quality = TranscribeCommand.resolveYouTubeAudioQuality(.appDefault, storedQuality: "not-a-quality")
-        XCTAssertEqual(quality, .compatibility)
+        XCTAssertEqual(quality, .m4a)
     }
 
     func testResolveYouTubeAudioQualityUsesStoredQualityForAppDefaultWhenValid() {
@@ -45,7 +45,7 @@ final class TranscribeCommandTests: XCTestCase {
     func testResolveYouTubeAudioQualityRespectsExplicitQuality() {
         let quality = TranscribeCommand.resolveYouTubeAudioQuality(
             .bestAvailable,
-            storedQuality: YouTubeAudioQuality.compatibility.rawValue
+            storedQuality: YouTubeAudioQuality.m4a.rawValue
         )
         XCTAssertEqual(quality, .bestAvailable)
     }

--- a/Tests/CLITests/TranscribeCommandTests.swift
+++ b/Tests/CLITests/TranscribeCommandTests.swift
@@ -24,6 +24,32 @@ final class TranscribeCommandTests: XCTestCase {
         XCTAssertEqual(mode, .clean)
     }
 
+    func testResolveYouTubeAudioQualityUsesCompatibilityForAppDefaultWhenUnset() {
+        let quality = TranscribeCommand.resolveYouTubeAudioQuality(.appDefault, storedQuality: nil)
+        XCTAssertEqual(quality, .compatibility)
+    }
+
+    func testResolveYouTubeAudioQualityUsesCompatibilityForAppDefaultWhenStoredQualityInvalid() {
+        let quality = TranscribeCommand.resolveYouTubeAudioQuality(.appDefault, storedQuality: "not-a-quality")
+        XCTAssertEqual(quality, .compatibility)
+    }
+
+    func testResolveYouTubeAudioQualityUsesStoredQualityForAppDefaultWhenValid() {
+        let quality = TranscribeCommand.resolveYouTubeAudioQuality(
+            .appDefault,
+            storedQuality: YouTubeAudioQuality.bestAvailable.rawValue
+        )
+        XCTAssertEqual(quality, .bestAvailable)
+    }
+
+    func testResolveYouTubeAudioQualityRespectsExplicitQuality() {
+        let quality = TranscribeCommand.resolveYouTubeAudioQuality(
+            .bestAvailable,
+            storedQuality: YouTubeAudioQuality.compatibility.rawValue
+        )
+        XCTAssertEqual(quality, .bestAvailable)
+    }
+
     func testParsesWhisperEngineAndLanguage() throws {
         let command = try TranscribeCommand.parse([
             "sample.wav",
@@ -35,10 +61,20 @@ final class TranscribeCommandTests: XCTestCase {
         XCTAssertEqual(command.language, "ko")
     }
 
+    func testParsesYouTubeAudioQuality() throws {
+        let command = try TranscribeCommand.parse([
+            "https://www.youtube.com/watch?v=abc",
+            "--youtube-audio-quality", "best-available",
+        ])
+
+        XCTAssertEqual(command.youtubeAudioQuality, .bestAvailable)
+    }
+
     func testParakeetRemainsDefaultEngine() throws {
         let command = try TranscribeCommand.parse(["sample.wav"])
         XCTAssertEqual(command.engine, .parakeet)
         XCTAssertNil(command.language)
+        XCTAssertEqual(command.youtubeAudioQuality, .appDefault)
     }
 
     func testLocalFileURLExpandsTilde() {

--- a/Tests/MacParakeetTests/Services/YouTubeDownloaderTests.swift
+++ b/Tests/MacParakeetTests/Services/YouTubeDownloaderTests.swift
@@ -48,12 +48,12 @@ final class YouTubeDownloaderTests: XCTestCase {
         XCTAssertNil(YouTubeDownloader.parseDownloadProgressPercent(from: "some random log line"))
     }
 
-    func testDownloadAudioArgumentsUseCompatibilitySelector() {
+    func testDownloadAudioArgumentsUseM4ASelector() {
         let args = YouTubeDownloader.downloadAudioArguments(
             ffmpegDir: "/opt/macparakeet/bin",
             outputTemplate: "/tmp/video.%(ext)s",
             url: "https://www.youtube.com/watch?v=abc",
-            quality: .compatibility
+            quality: .m4a
         )
 
         XCTAssertEqual(formatSelector(in: args), "bestaudio[ext=m4a]/bestaudio/best")
@@ -85,7 +85,7 @@ final class YouTubeDownloaderTests: XCTestCase {
             ffmpegDir: "/opt/macparakeet/bin",
             outputTemplate: "/tmp/video.%(ext)s",
             url: "https://www.youtube.com/watch?v=abc",
-            quality: .compatibility,
+            quality: .m4a,
             javaScriptRuntimeArguments: ["--js-runtimes", "node:/opt/homebrew/bin/node"]
         )
 
@@ -128,6 +128,27 @@ final class YouTubeDownloaderTests: XCTestCase {
             ),
             "\(uuid).m4a"
         )
+    }
+
+    func testSelectDownloadedAudioFileAcceptsWebMForBestAvailableDownloads() {
+        let uuid = UUID().uuidString
+
+        XCTAssertEqual(
+            YouTubeDownloader.selectDownloadedAudioFile(
+                from: ["\(uuid).webm"],
+                uuid: uuid
+            ),
+            "\(uuid).webm"
+        )
+    }
+
+    func testSelectDownloadedAudioFileIgnoresUnsupportedAudioContainers() {
+        let uuid = UUID().uuidString
+
+        XCTAssertNil(YouTubeDownloader.selectDownloadedAudioFile(
+            from: ["\(uuid).mka"],
+            uuid: uuid
+        ))
     }
 
     func testSelectDownloadedAudioFileReturnsNilWhenOnlyPartialArtifactsExist() {

--- a/Tests/MacParakeetTests/Services/YouTubeDownloaderTests.swift
+++ b/Tests/MacParakeetTests/Services/YouTubeDownloaderTests.swift
@@ -48,6 +48,55 @@ final class YouTubeDownloaderTests: XCTestCase {
         XCTAssertNil(YouTubeDownloader.parseDownloadProgressPercent(from: "some random log line"))
     }
 
+    func testDownloadAudioArgumentsUseCompatibilitySelector() {
+        let args = YouTubeDownloader.downloadAudioArguments(
+            ffmpegDir: "/opt/macparakeet/bin",
+            outputTemplate: "/tmp/video.%(ext)s",
+            url: "https://www.youtube.com/watch?v=abc",
+            quality: .compatibility
+        )
+
+        XCTAssertEqual(formatSelector(in: args), "bestaudio[ext=m4a]/bestaudio/best")
+        XCTAssertEqual(args, [
+            "--ffmpeg-location", "/opt/macparakeet/bin",
+            "-f", "bestaudio[ext=m4a]/bestaudio/best",
+            "--no-playlist",
+            "--retries", "3",
+            "--concurrent-fragments", "4",
+            "--newline",
+            "-o", "/tmp/video.%(ext)s",
+            "--", "https://www.youtube.com/watch?v=abc",
+        ])
+    }
+
+    func testDownloadAudioArgumentsUseBestAvailableSelector() {
+        let args = YouTubeDownloader.downloadAudioArguments(
+            ffmpegDir: "/opt/macparakeet/bin",
+            outputTemplate: "/tmp/video.%(ext)s",
+            url: "https://www.youtube.com/watch?v=abc",
+            quality: .bestAvailable
+        )
+
+        XCTAssertEqual(formatSelector(in: args), "bestaudio/best")
+    }
+
+    func testDownloadAudioArgumentsIncludeJavaScriptRuntimeArgsBeforeFFmpeg() {
+        let args = YouTubeDownloader.downloadAudioArguments(
+            ffmpegDir: "/opt/macparakeet/bin",
+            outputTemplate: "/tmp/video.%(ext)s",
+            url: "https://www.youtube.com/watch?v=abc",
+            quality: .compatibility,
+            javaScriptRuntimeArguments: ["--js-runtimes", "node:/opt/homebrew/bin/node"]
+        )
+
+        XCTAssertEqual(Array(args.prefix(4)), [
+            "--no-js-runtimes",
+            "--js-runtimes",
+            "node:/opt/homebrew/bin/node",
+            "--ffmpeg-location",
+        ])
+    }
+
     func testSelectDownloadedAudioFileIgnoresYtDlpPartialArtifacts() {
         let uuid = UUID().uuidString
 
@@ -153,5 +202,13 @@ final class YouTubeDownloaderTests: XCTestCase {
         XCTAssertFalse(YouTubeDownloader.isPyInstallerLibraryValidationError(
             YouTubeDownloadError.ytDlpNotFound
         ))
+    }
+
+    private func formatSelector(in args: [String]) -> String? {
+        guard let index = args.firstIndex(of: "-f"),
+              args.indices.contains(args.index(after: index)) else {
+            return nil
+        }
+        return args[args.index(after: index)]
     }
 }

--- a/Tests/MacParakeetTests/Services/YouTubeDownloaderTests.swift
+++ b/Tests/MacParakeetTests/Services/YouTubeDownloaderTests.swift
@@ -97,6 +97,22 @@ final class YouTubeDownloaderTests: XCTestCase {
         ])
     }
 
+    func testCommonYtDlpArgumentsShareJavaScriptRuntimeAndFFmpegPrefix() {
+        XCTAssertEqual(
+            YouTubeDownloader.commonYtDlpArguments(
+                ffmpegDir: "/opt/macparakeet/bin",
+                javaScriptRuntimeArguments: ["--js-runtimes", "node:/opt/homebrew/bin/node"]
+            ),
+            [
+                "--no-js-runtimes",
+                "--js-runtimes",
+                "node:/opt/homebrew/bin/node",
+                "--ffmpeg-location",
+                "/opt/macparakeet/bin",
+            ]
+        )
+    }
+
     func testSelectDownloadedAudioFileIgnoresYtDlpPartialArtifacts() {
         let uuid = UUID().uuidString
 

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -115,7 +115,7 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.silenceDelay, 2.0, "silenceDelay should default to 2.0")
         XCTAssertTrue(viewModel.saveAudioRecordings, "saveAudioRecordings should default to true")
         XCTAssertTrue(viewModel.saveTranscriptionAudio, "saveTranscriptionAudio should default to true")
-        XCTAssertEqual(viewModel.youtubeAudioQuality, .compatibility, "youtubeAudioQuality should preserve prior default behavior")
+        XCTAssertEqual(viewModel.youtubeAudioQuality, .m4a, "youtubeAudioQuality should default to Apple-friendly saved audio")
         XCTAssertFalse(viewModel.speakerDiarization, "speakerDiarization should default to false")
         XCTAssertEqual(viewModel.meetingHotkeyTrigger, .chord(modifiers: ["command", "shift"], keyCode: 46))
         XCTAssertEqual(viewModel.meetingAudioSourceMode, .microphoneAndSystem)

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -115,6 +115,7 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.silenceDelay, 2.0, "silenceDelay should default to 2.0")
         XCTAssertTrue(viewModel.saveAudioRecordings, "saveAudioRecordings should default to true")
         XCTAssertTrue(viewModel.saveTranscriptionAudio, "saveTranscriptionAudio should default to true")
+        XCTAssertEqual(viewModel.youtubeAudioQuality, .compatibility, "youtubeAudioQuality should preserve prior default behavior")
         XCTAssertFalse(viewModel.speakerDiarization, "speakerDiarization should default to false")
         XCTAssertEqual(viewModel.meetingHotkeyTrigger, .chord(modifiers: ["command", "shift"], keyCode: 46))
         XCTAssertEqual(viewModel.meetingAudioSourceMode, .microphoneAndSystem)
@@ -134,6 +135,10 @@ final class SettingsViewModelTests: XCTestCase {
         testDefaults.set(3.0, forKey: "silenceDelay")
         testDefaults.set(false, forKey: "saveAudioRecordings")
         testDefaults.set(false, forKey: "saveTranscriptionAudio")
+        testDefaults.set(
+            YouTubeAudioQuality.bestAvailable.rawValue,
+            forKey: UserDefaultsAppRuntimePreferences.youtubeAudioQualityKey
+        )
         testDefaults.set(true, forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey)
         testDefaults.set("usb-mic-uid", forKey: UserDefaultsAppRuntimePreferences.selectedMicrophoneDeviceUIDKey)
         testDefaults.set(
@@ -152,6 +157,7 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(vm.silenceDelay, 3.0)
         XCTAssertFalse(vm.saveAudioRecordings)
         XCTAssertFalse(vm.saveTranscriptionAudio)
+        XCTAssertEqual(vm.youtubeAudioQuality, .bestAvailable)
         XCTAssertTrue(vm.speakerDiarization)
         XCTAssertEqual(vm.selectedMicrophoneDeviceUID, "usb-mic-uid")
         XCTAssertEqual(vm.meetingAudioSourceMode, .systemOnly)
@@ -437,6 +443,15 @@ final class SettingsViewModelTests: XCTestCase {
         viewModel.saveTranscriptionAudio = false
 
         XCTAssertFalse(testDefaults.bool(forKey: "saveTranscriptionAudio"))
+    }
+
+    func testSettingYouTubeAudioQualityPersists() {
+        viewModel.youtubeAudioQuality = .bestAvailable
+
+        XCTAssertEqual(
+            testDefaults.string(forKey: UserDefaultsAppRuntimePreferences.youtubeAudioQualityKey),
+            YouTubeAudioQuality.bestAvailable.rawValue
+        )
     }
 
     func testSettingSpeakerDiarizationPersists() {

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -286,7 +286,7 @@ events remain useful for diarization-specific timing and failure analysis.
 | `prompt_created` | — | Are custom prompt templates used? |
 | `prompt_updated` | — | Are custom prompts actively maintained? |
 | `prompt_deleted` | — | Are custom prompts abandoned or cleaned up? |
-| `setting_changed` | `setting` (save_history, audio_retention, menu_bar_only, hide_pill, save_transcription_audio, speaker_diarization, auto_save, meeting_auto_save, microphone_selection, meeting_audio_source_mode, launch_at_login, silence_auto_stop, voice_return, calendar_auto_start_mode, calendar_reminder_minutes, calendar_trigger_filter, calendar_auto_stop_enabled, calendar_included_calendars) | Which non-hotkey settings get toggled? Hotkey changes use `hotkey_customized`. |
+| `setting_changed` | `setting` (save_history, audio_retention, menu_bar_only, hide_pill, save_transcription_audio, youtube_audio_quality, speaker_diarization, auto_save, meeting_auto_save, microphone_selection, meeting_audio_source_mode, launch_at_login, silence_auto_stop, voice_return, calendar_auto_start_mode, calendar_reminder_minutes, calendar_trigger_filter, calendar_auto_stop_enabled, calendar_included_calendars) | Which non-hotkey settings get toggled? Hotkey changes use `hotkey_customized`. |
 | `telemetry_opted_out` | — | How many opt out? (send this one last event, then stop) |
 
 ### 5b. Calendar Auto-Start — "Do calendar-driven meetings work?"

--- a/spec/05-audio-pipeline.md
+++ b/spec/05-audio-pipeline.md
@@ -97,6 +97,9 @@ YouTube URL → yt-dlp (audio only) → downloaded audio file → FFmpeg → 16k
 ```
 
 - `yt-dlp` is used with `--no-playlist` for single-video processing
+- YouTube audio quality is configurable:
+  - **Compatibility** (default): `bestaudio[ext=m4a]/bestaudio/best`, matching prior releases
+  - **Best available**: `bestaudio/best`, allowing higher-quality streams such as Opus/WebM when YouTube offers them
 - Download progress is parsed from yt-dlp output and surfaced as percent updates
 - Downloaded files are written to:
 

--- a/spec/05-audio-pipeline.md
+++ b/spec/05-audio-pipeline.md
@@ -98,8 +98,8 @@ YouTube URL → yt-dlp (audio only) → downloaded audio file → FFmpeg → 16k
 
 - `yt-dlp` is used with `--no-playlist` for single-video processing
 - YouTube audio quality is configurable:
-  - **Compatibility** (default): `bestaudio[ext=m4a]/bestaudio/best`, matching prior releases
-  - **Best available**: `bestaudio/best`, allowing higher-quality streams such as Opus/WebM when YouTube offers them
+  - **M4A** (default): `bestaudio[ext=m4a]/bestaudio/best`, preferring Apple-friendly saved audio files while falling back when m4a is unavailable
+  - **Best available**: `bestaudio/best`, allowing higher-quality source streams such as Opus/WebM when YouTube offers them. Transcription still converts the downloaded file to WAV before STT, but retained downloads may be less predictable for Apple playback and sharing workflows.
 - Download progress is parsed from yt-dlp output and surfaced as percent updates
 - Downloaded files are written to:
 


### PR DESCRIPTION
## Summary

Adds a **YouTube audio quality** picker in Settings (Transcribe section) and a matching `--youtube-audio-quality` flag on `macparakeet-cli`. **M4A** (default) downloads an Apple-friendly `.m4a` file that plays and shares cleanly across Apple apps; **Best available** lets yt-dlp pick the highest-quality source stream (often WebM/Opus), which can improve STT accuracy on speech-dense audio at the cost of a less Apple-native saved file. Fixes #237.

## For users

- Settings -> Transcribe -> **YouTube audio quality** picker. Default is **M4A** so saved files Just Work in Finder/QuickTime/iMessage.
- Pick **Best available** when you care more about transcription accuracy than playback compatibility -- yt-dlp will grab the highest-bitrate audio it can, which is frequently Opus inside a `.webm` container.
- Either tier still gets converted to WAV for local STT, so engine behavior is unchanged -- only the *saved* file format differs when retention is on.
- CLI parity: `macparakeet-cli transcribe --youtube-audio-quality app-default|m4a|best-available <url>` (see `Sources/CLI/CHANGELOG.md`).

## How it works

The picker maps to a yt-dlp format selector: **M4A** -> `bestaudio[ext=m4a]/bestaudio/best` (m4a first, fall back if no m4a track exists); **Best available** -> `bestaudio/best` (let yt-dlp choose). Downloaded candidates are then filtered through `AudioFileConverter`'s supported-extension set before STT runs, so unsupported containers never reach the transcriber.

## Code touchpoints

- `Sources/MacParakeetCore/AppRuntimePreferences.swift` -- new `YouTubeAudioQuality` enum with `ytDlpFormatSelector`, persisted under `youtubeAudioQuality` key.
- `Sources/MacParakeetCore/Services/YouTubeDownloader.swift` -- accepts an `audioQuality` closure; shared `commonYtDlpArguments` between metadata + audio paths.
- `Sources/CLI/Commands/TranscribeCommand.swift` -- `--youtube-audio-quality` option with `app-default` resolution against UserDefaults.
- `Sources/MacParakeet/Views/Settings/SettingsView.swift` + `SettingsViewModel.swift` + `SettingsSearchIndex.swift` -- Settings picker, binding, and search keywords (m4a / opus / webm).
- Tests: `YouTubeDownloaderTests`, `TranscribeCommandTests`, `SettingsViewModelTests`.