### PR TITLE
Harden STT cancellation watchdog

### DIFF
--- a/Sources/MacParakeetCore/STT/STTClient.swift
+++ b/Sources/MacParakeetCore/STT/STTClient.swift
@@ -69,8 +69,8 @@ public actor STTClient: STTManaging, SpeechEngineRoutedTranscribing, SpeechEngin
         try await scheduler.setSpeechEngine(preference)
     }
 
-    public func beginSpeechEngineSession() async -> SpeechEngineLease {
-        await scheduler.beginSpeechEngineSession()
+    public func beginSpeechEngineSession() async throws -> SpeechEngineLease {
+        try await scheduler.beginSpeechEngineSession()
     }
 
     public func endSpeechEngineSession(_ lease: SpeechEngineLease) async {

--- a/Sources/MacParakeetCore/STT/STTClientProtocol.swift
+++ b/Sources/MacParakeetCore/STT/STTClientProtocol.swift
@@ -49,7 +49,7 @@ public protocol SpeechEngineSwitching: Sendable {
 }
 
 public protocol SpeechEngineSessionManaging: Sendable {
-    func beginSpeechEngineSession() async -> SpeechEngineLease
+    func beginSpeechEngineSession() async throws -> SpeechEngineLease
     func endSpeechEngineSession(_ lease: SpeechEngineLease) async
 }
 

--- a/Sources/MacParakeetCore/STT/STTScheduler.swift
+++ b/Sources/MacParakeetCore/STT/STTScheduler.swift
@@ -4,6 +4,7 @@ import OSLog
 public enum STTSchedulerError: Error, LocalizedError, Equatable {
     case droppedDueToBackpressure(job: STTJobKind)
     case unavailable
+    case runtimeUnhealthy
 
     public var errorDescription: String? {
         switch self {
@@ -11,7 +12,45 @@ public enum STTSchedulerError: Error, LocalizedError, Equatable {
             return "Speech job dropped due to backpressure: \(String(describing: job))"
         case .unavailable:
             return "Speech scheduler is temporarily unavailable"
+        case .runtimeUnhealthy:
+            return "Speech runtime is unavailable until the app or command is restarted"
         }
+    }
+}
+
+private final class JobCancellationFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cancelled = false
+
+    func cancel() {
+        lock.lock()
+        cancelled = true
+        lock.unlock()
+    }
+
+    var isCancelled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancelled
+    }
+}
+
+private final class TaskResultFlag<Success: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var result: Result<Success, Error>?
+
+    func finish(_ result: Result<Success, Error>) {
+        lock.lock()
+        if self.result == nil {
+            self.result = result
+        }
+        lock.unlock()
+    }
+
+    var currentResult: Result<Success, Error>? {
+        lock.lock()
+        defer { lock.unlock() }
+        return result
     }
 }
 
@@ -26,6 +65,7 @@ public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEn
         let job: STTJobKind
         let speechEngine: SpeechEngineSelection?
         let enqueueOrder: UInt64
+        let cancellationFlag: JobCancellationFlag
         let onProgress: (@Sendable (Int, Int) -> Void)?
 
         var slot: SchedulerSlot {
@@ -38,19 +78,30 @@ public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEn
         var currentJob: ScheduledJob?
         var currentExecutionTask: Task<STTResult, Error>?
         var currentWaitTask: Task<Void, Never>?
+        var currentWatchdogTask: Task<Void, Never>?
+    }
+
+    private struct RunningJobSnapshot {
+        let id: UUID
+        let slot: SchedulerSlot
     }
 
     private let logger = Logger(subsystem: "com.macparakeet.core", category: "STTScheduler")
     private let runtime: STTRuntimeProtocol
     private let meetingLiveChunkBacklogLimit: Int
+    private let runningJobCancellationTimeout: Duration
 
     private var enqueueCounter: UInt64 = 0
     private var continuations: [UUID: CheckedContinuation<STTResult, Error>] = [:]
     private var slotStates: [SchedulerSlot: SlotState] = Dictionary(
         uniqueKeysWithValues: SchedulerSlot.allCases.map { ($0, SlotState()) }
     )
-    private var cancelledJobIDs: Set<UUID> = []
+    private var cancelledRunningJobIDs: Set<UUID> = []
     private var acceptsNewJobs = true
+    private var exclusiveOperationCount = 0
+    private var clearModelCacheInProgress = false
+    private var shutdownRequested = false
+    private var runtimeUnhealthy = false
     private var activeSpeechEngineSessionIDs: Set<UUID> = []
     private var speechEngineSwitchTask: Task<Void, Error>?
 
@@ -59,18 +110,22 @@ public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEn
     ///   seconds, enough to absorb a prolonged dictation burst before preview starts dropping.
     public init(
         runtime: STTRuntime = STTRuntime(),
-        meetingLiveChunkBacklogLimit: Int = 120
+        meetingLiveChunkBacklogLimit: Int = 120,
+        runningJobCancellationTimeout: Duration = .seconds(10)
     ) {
         self.runtime = runtime as STTRuntimeProtocol
         self.meetingLiveChunkBacklogLimit = max(1, meetingLiveChunkBacklogLimit)
+        self.runningJobCancellationTimeout = runningJobCancellationTimeout
     }
 
     init(
         runtimeProvider: STTRuntimeProtocol,
-        meetingLiveChunkBacklogLimit: Int = 120
+        meetingLiveChunkBacklogLimit: Int = 120,
+        runningJobCancellationTimeout: Duration = .seconds(10)
     ) {
         self.runtime = runtimeProvider
         self.meetingLiveChunkBacklogLimit = max(1, meetingLiveChunkBacklogLimit)
+        self.runningJobCancellationTimeout = runningJobCancellationTimeout
     }
 
     public func transcribe(
@@ -79,6 +134,7 @@ public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEn
         onProgress: (@Sendable (Int, Int) -> Void)? = nil
     ) async throws -> STTResult {
         let id = UUID()
+        let cancellationFlag = JobCancellationFlag()
         try Task.checkCancellation()
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
@@ -89,12 +145,14 @@ public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEn
                         job: job,
                         speechEngine: nil,
                         enqueueOrder: nextEnqueueOrder(),
+                        cancellationFlag: cancellationFlag,
                         onProgress: onProgress
                     ),
                     continuation: continuation
                 )
             }
         } onCancel: {
+            cancellationFlag.cancel()
             Task { [weak self] in
                 await self?.cancel(jobID: id)
             }
@@ -108,6 +166,7 @@ public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEn
         onProgress: (@Sendable (Int, Int) -> Void)? = nil
     ) async throws -> STTResult {
         let id = UUID()
+        let cancellationFlag = JobCancellationFlag()
         try Task.checkCancellation()
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
@@ -118,12 +177,14 @@ public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEn
                         job: job,
                         speechEngine: speechEngine,
                         enqueueOrder: nextEnqueueOrder(),
+                        cancellationFlag: cancellationFlag,
                         onProgress: onProgress
                     ),
                     continuation: continuation
                 )
             }
         } onCancel: {
+            cancellationFlag.cancel()
             Task { [weak self] in
                 await self?.cancel(jobID: id)
             }
@@ -131,15 +192,26 @@ public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEn
     }
 
     public func warmUp(onProgress: (@Sendable (String) -> Void)?) async throws {
+        guard !runtimeUnhealthy else {
+            throw STTSchedulerError.runtimeUnhealthy
+        }
         try await runtime.warmUp(onProgress: onProgress)
     }
 
     public func backgroundWarmUp() async {
+        guard !runtimeUnhealthy else { return }
         await runtime.backgroundWarmUp()
     }
 
     public func observeWarmUpProgress() async -> (id: UUID, stream: AsyncStream<STTWarmUpState>) {
-        await runtime.observeWarmUpProgress()
+        if runtimeUnhealthy {
+            let stream = AsyncStream<STTWarmUpState> { continuation in
+                continuation.yield(.failed(message: STTSchedulerError.runtimeUnhealthy.localizedDescription))
+                continuation.finish()
+            }
+            return (UUID(), stream)
+        }
+        return await runtime.observeWarmUpProgress()
     }
 
     public func removeWarmUpObserver(id: UUID) async {
@@ -147,20 +219,74 @@ public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEn
     }
 
     public func isReady() async -> Bool {
-        await runtime.isReady()
+        guard !runtimeUnhealthy else { return false }
+        return await runtime.isReady()
     }
 
     public func clearModelCache() async {
-        await quiesce(restoreAcceptsNewJobs: true)
-        await runtime.clearModelCache()
+        guard !shutdownRequested else {
+            logger.error("stt_clear_model_cache_skipped shutdown_requested=true")
+            return
+        }
+        guard activeSpeechEngineSessionIDs.isEmpty else {
+            logger.error("stt_clear_model_cache_skipped active_speech_engine_sessions=\(self.activeSpeechEngineSessionIDs.count, privacy: .public)")
+            return
+        }
+        guard speechEngineSwitchTask == nil else {
+            logger.error("stt_clear_model_cache_skipped speech_engine_switch_in_flight=true")
+            return
+        }
+        guard !clearModelCacheInProgress else { return }
+
+        clearModelCacheInProgress = true
+        beginExclusiveOperation()
+        defer {
+            clearModelCacheInProgress = false
+            endExclusiveOperation(restoreAcceptsNewJobs: true)
+        }
+
+        let drained = await quiesce(restoreAcceptsNewJobs: false)
+        guard drained else {
+            logger.error("stt_clear_model_cache_skipped runtime_unhealthy=true")
+            return
+        }
+        let clearTask = Task { await runtime.clearModelCache() }
+        let cleared = await waitForNonThrowingTask(
+            clearTask,
+            timeoutReason: "timed out waiting for runtime model cache clear"
+        )
+        guard cleared else {
+            logger.error("stt_clear_model_cache_timed_out runtime_unhealthy=true")
+            return
+        }
     }
 
     public func shutdown() async {
-        await quiesce(restoreAcceptsNewJobs: false)
-        await runtime.shutdown()
+        shutdownRequested = true
+        let switchDrained = await cancelAndDrainSpeechEngineSwitchForShutdown()
+        let drained = await quiesce(restoreAcceptsNewJobs: false)
+        guard switchDrained, drained else {
+            logger.error("stt_runtime_shutdown_skipped runtime_unhealthy=true")
+            return
+        }
+        let shutdownTask = Task { await runtime.shutdown() }
+        let shutDown = await waitForNonThrowingTask(
+            shutdownTask,
+            timeoutReason: "timed out waiting for runtime shutdown"
+        )
+        guard shutDown else {
+            logger.error("stt_runtime_shutdown_timed_out runtime_unhealthy=true")
+            return
+        }
     }
 
     public func setSpeechEngine(_ preference: SpeechEnginePreference) async throws {
+        guard !runtimeUnhealthy else {
+            throw STTSchedulerError.runtimeUnhealthy
+        }
+        guard !shutdownRequested else {
+            throw STTSchedulerError.unavailable
+        }
         guard acceptsNewJobs,
               activeSpeechEngineSessionIDs.isEmpty,
               !hasQueuedOrRunningJobs,
@@ -168,32 +294,54 @@ public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEn
             throw STTError.engineBusy
         }
 
-        acceptsNewJobs = false
+        beginExclusiveOperation()
         let switchTask = Task {
             try await runtime.setSpeechEngine(preference)
         }
         speechEngineSwitchTask = switchTask
         defer {
             speechEngineSwitchTask = nil
-            acceptsNewJobs = true
+            endExclusiveOperation(restoreAcceptsNewJobs: true)
         }
-        try await withTaskCancellationHandler {
-            try await switchTask.value
-        } onCancel: {
-            switchTask.cancel()
-        }
+        try await awaitSpeechEngineSwitchForCaller(switchTask)
     }
 
-    public func beginSpeechEngineSession() async -> SpeechEngineLease {
-        if let speechEngineSwitchTask {
-            let result = await speechEngineSwitchTask.result
-            if case .failure(let error) = result {
-                logger.warning("Proceeding with speech engine session after failed engine switch: \(error.localizedDescription, privacy: .public)")
+    public func beginSpeechEngineSession() async throws -> SpeechEngineLease {
+        guard !runtimeUnhealthy else {
+            throw STTSchedulerError.runtimeUnhealthy
+        }
+        guard speechEngineSwitchTask == nil else {
+            throw STTError.engineBusy
+        }
+        guard !shutdownRequested,
+              exclusiveOperationCount == 0,
+              acceptsNewJobs,
+              !hasCancelledRunningJobPendingDrain,
+              !clearModelCacheInProgress else {
+            throw STTSchedulerError.unavailable
+        }
+        let leaseID = UUID()
+        activeSpeechEngineSessionIDs.insert(leaseID)
+        var leaseReturned = false
+        defer {
+            if !leaseReturned {
+                activeSpeechEngineSessionIDs.remove(leaseID)
             }
         }
-        let lease = SpeechEngineLease(selection: await runtime.currentSpeechEngineSelection())
-        activeSpeechEngineSessionIDs.insert(lease.id)
-        return lease
+
+        let selection = try await currentSpeechEngineSelectionForSession()
+        guard !runtimeUnhealthy else {
+            throw STTSchedulerError.runtimeUnhealthy
+        }
+        guard !shutdownRequested,
+              exclusiveOperationCount == 0,
+              acceptsNewJobs,
+              !hasCancelledRunningJobPendingDrain,
+              !clearModelCacheInProgress else {
+            throw STTSchedulerError.unavailable
+        }
+        leaseReturned = true
+        return SpeechEngineLease(id: leaseID, selection: selection)
     }
 
     public func endSpeechEngineSession(_ lease: SpeechEngineLease) async {
@@ -204,8 +352,19 @@ public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEn
         _ job: ScheduledJob,
         continuation: CheckedContinuation<STTResult, Error>
     ) {
-        if Task.isCancelled || cancelledJobIDs.remove(job.id) != nil {
+        if Task.isCancelled || job.cancellationFlag.isCancelled {
             continuation.resume(throwing: CancellationError())
+            return
+        }
+
+        guard !runtimeUnhealthy else {
+            continuation.resume(throwing: STTSchedulerError.runtimeUnhealthy)
+            return
+        }
+
+        if hasCancelledRunningJobPendingDrain {
+            acceptsNewJobs = false
+            continuation.resume(throwing: STTSchedulerError.unavailable)
             return
         }
 
@@ -230,7 +389,7 @@ public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEn
 
         currentSlotState.pendingJobs.append(job)
         setSlotState(currentSlotState, for: job.slot)
-        startNextJobIfNeeded(in: job.slot)
+        startQueuedJobsIfPossible()
     }
 
     private func nextEnqueueOrder() -> UInt64 {
@@ -273,6 +432,7 @@ public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEn
     private func startNextJobIfNeeded(in slot: SchedulerSlot) {
         var currentSlotState = slotState(for: slot)
         guard currentSlotState.currentJob == nil else { return }
+        guard canStartQueuedJobs else { return }
         guard let next = dequeueNextJob(in: &currentSlotState) else {
             setSlotState(currentSlotState, for: slot)
             return
@@ -327,14 +487,24 @@ public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEn
 
     private func finishCurrentJob(jobID: UUID, in slot: SchedulerSlot, result: Result<STTResult, Error>) {
         var slotState = slotState(for: slot)
-        guard slotState.currentJob?.id == jobID else { return }
+        guard let currentJob = slotState.currentJob, currentJob.id == jobID else { return }
 
         let continuation = continuations.removeValue(forKey: jobID)
-        cancelledJobIDs.remove(jobID)
+        let wasMarkedCancelled = cancelledRunningJobIDs.remove(jobID) != nil
+        let wasCancelled = currentJob.cancellationFlag.isCancelled || wasMarkedCancelled
         slotState.currentJob = nil
         slotState.currentExecutionTask = nil
         slotState.currentWaitTask = nil
+        slotState.currentWatchdogTask?.cancel()
+        slotState.currentWatchdogTask = nil
         setSlotState(slotState, for: slot)
+
+        guard !wasCancelled else {
+            continuation?.resume(throwing: CancellationError())
+            restoreAcceptsNewJobsIfPossible()
+            startQueuedJobsIfPossible()
+            return
+        }
 
         switch result {
         case .success(let value):
@@ -343,7 +513,7 @@ public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEn
             continuation?.resume(throwing: error)
         }
 
-        startNextJobIfNeeded(in: slot)
+        startQueuedJobsIfPossible()
     }
 
     private func cancel(jobID: UUID) {
@@ -352,51 +522,339 @@ public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEn
             if let index = currentSlotState.pendingJobs.firstIndex(where: { $0.id == jobID }) {
                 currentSlotState.pendingJobs.remove(at: index)
                 setSlotState(currentSlotState, for: slot)
-                cancelledJobIDs.remove(jobID)
+                cancelledRunningJobIDs.remove(jobID)
                 continuations.removeValue(forKey: jobID)?.resume(throwing: CancellationError())
                 return
             }
 
             if currentSlotState.currentJob?.id == jobID {
+                currentSlotState.currentJob?.cancellationFlag.cancel()
+                cancelledRunningJobIDs.insert(jobID)
+                acceptsNewJobs = false
                 currentSlotState.currentExecutionTask?.cancel()
-                cancelledJobIDs.remove(jobID)
+                currentSlotState.currentWatchdogTask?.cancel()
+                currentSlotState.currentWatchdogTask = makeRunningJobCancellationWatchdogTask(jobID: jobID, in: slot)
                 setSlotState(currentSlotState, for: slot)
                 return
             }
         }
 
-        cancelledJobIDs.insert(jobID)
+        cancelledRunningJobIDs.remove(jobID)
     }
 
     private func cancelAllPendingJobs() {
         let pendingIDs = SchedulerSlot.allCases.flatMap { slotState(for: $0).pendingJobs.map(\.id) }
         for slot in SchedulerSlot.allCases {
             var currentSlotState = slotState(for: slot)
+            for job in currentSlotState.pendingJobs {
+                job.cancellationFlag.cancel()
+            }
             currentSlotState.pendingJobs.removeAll()
             setSlotState(currentSlotState, for: slot)
         }
         for id in pendingIDs {
+            cancelledRunningJobIDs.remove(id)
             continuations.removeValue(forKey: id)?.resume(throwing: CancellationError())
         }
     }
 
-    private func quiesce(restoreAcceptsNewJobs: Bool) async {
+    private func quiesce(restoreAcceptsNewJobs: Bool) async -> Bool {
         acceptsNewJobs = false
         cancelAllPendingJobs()
-        await cancelAndDrainRunningJobs()
-        if restoreAcceptsNewJobs {
+        let drained = await cancelAndDrainRunningJobs()
+        if restoreAcceptsNewJobs, drained {
+            restoreAcceptsNewJobsIfPossible()
+        }
+        return drained && !runtimeUnhealthy
+    }
+
+    private func cancelAndDrainSpeechEngineSwitchForShutdown() async -> Bool {
+        guard let switchTask = speechEngineSwitchTask else { return true }
+        switchTask.cancel()
+        return await waitForThrowingTask(
+            switchTask,
+            timeoutReason: "timed out waiting for speech engine switch to cancel"
+        )
+    }
+
+    private func awaitSpeechEngineSwitchForCaller(_ switchTask: Task<Void, Error>) async throws {
+        let cancellationFlag = JobCancellationFlag()
+        let completion = watchThrowingTask(switchTask)
+
+        try await withTaskCancellationHandler {
+            while true {
+                if cancellationFlag.isCancelled {
+                    switchTask.cancel()
+                    _ = await waitForTaskCompletion(
+                        completion,
+                        timeoutReason: "timed out waiting for cancelled speech engine switch to drain"
+                    )
+                    throw CancellationError()
+                }
+                if runtimeUnhealthy {
+                    switchTask.cancel()
+                    throw STTSchedulerError.runtimeUnhealthy
+                }
+                if let result = completion.currentResult {
+                    return try result.get()
+                }
+                await Self.sleepIgnoringCallerCancellation(for: .milliseconds(20))
+            }
+        } onCancel: {
+            cancellationFlag.cancel()
+            switchTask.cancel()
+        }
+    }
+
+    private func currentSpeechEngineSelectionForSession() async throws -> SpeechEngineSelection {
+        let selectionTask = Task {
+            await runtime.currentSpeechEngineSelection()
+        }
+        let completion = TaskResultFlag<SpeechEngineSelection>()
+        Task {
+            completion.finish(.success(await selectionTask.value))
+        }
+        let cancellationFlag = JobCancellationFlag()
+
+        return try await withTaskCancellationHandler {
+            let start = ContinuousClock.now
+            while start.duration(to: .now) < runningJobCancellationTimeout {
+                if cancellationFlag.isCancelled {
+                    selectionTask.cancel()
+                    throw CancellationError()
+                }
+                if runtimeUnhealthy {
+                    selectionTask.cancel()
+                    throw STTSchedulerError.runtimeUnhealthy
+                }
+                if let result = completion.currentResult {
+                    return try result.get()
+                }
+                await Self.sleepIgnoringCallerCancellation(for: .milliseconds(20))
+            }
+
+            selectionTask.cancel()
+            if let result = completion.currentResult {
+                return try result.get()
+            }
+            markRuntimeUnhealthy(
+                reason: "timed out waiting for speech engine selection for session",
+                cancelledActiveJobIDs: []
+            )
+            throw STTSchedulerError.runtimeUnhealthy
+        } onCancel: {
+            cancellationFlag.cancel()
+            selectionTask.cancel()
+        }
+    }
+
+    private func waitForThrowingTask(
+        _ task: Task<Void, Error>,
+        timeoutReason: String
+    ) async -> Bool {
+        await waitForTaskCompletion(
+            watchThrowingTask(task),
+            timeoutReason: timeoutReason
+        )
+    }
+
+    private func waitForNonThrowingTask(
+        _ task: Task<Void, Never>,
+        timeoutReason: String
+    ) async -> Bool {
+        let completion = TaskResultFlag<Void>()
+        Task {
+            await task.value
+            completion.finish(.success(()))
+        }
+        let completed = await waitForTaskCompletion(
+            completion,
+            timeoutReason: timeoutReason
+        )
+        if !completed {
+            task.cancel()
+        }
+        return completed
+    }
+
+    private func watchThrowingTask(_ task: Task<Void, Error>) -> TaskResultFlag<Void> {
+        let completion = TaskResultFlag<Void>()
+        Task {
+            completion.finish(await task.result)
+        }
+        return completion
+    }
+
+    private func waitForTaskCompletion(
+        _ completion: TaskResultFlag<Void>,
+        timeoutReason: String
+    ) async -> Bool {
+        let start = ContinuousClock.now
+        while start.duration(to: .now) < runningJobCancellationTimeout {
+            if completion.currentResult != nil {
+                return true
+            }
+            await Self.sleepIgnoringCallerCancellation(for: .milliseconds(20))
+        }
+
+        guard completion.currentResult != nil else {
+            markRuntimeUnhealthy(
+                reason: timeoutReason,
+                cancelledActiveJobIDs: []
+            )
+            return false
+        }
+
+        return true
+    }
+
+    private func cancelAndDrainRunningJobs() async -> Bool {
+        let runningJobs = SchedulerSlot.allCases.compactMap { slot -> RunningJobSnapshot? in
+            let slotState = slotState(for: slot)
+            slotState.currentExecutionTask?.cancel()
+            guard let currentJob = slotState.currentJob else { return nil }
+            currentJob.cancellationFlag.cancel()
+            let jobID = currentJob.id
+            cancelledRunningJobIDs.insert(jobID)
+            return RunningJobSnapshot(id: jobID, slot: slot)
+        }
+
+        guard !runningJobs.isEmpty else { return true }
+
+        let start = ContinuousClock.now
+        while start.duration(to: .now) < runningJobCancellationTimeout {
+            if runningJobs.allSatisfy({ slotState(for: $0.slot).currentJob?.id != $0.id }) {
+                return true
+            }
+            await Self.sleepIgnoringCallerCancellation(for: .milliseconds(20))
+        }
+
+        let timedOutJobIDs = Set(
+            runningJobs.compactMap { job in
+                slotState(for: job.slot).currentJob?.id == job.id ? job.id : nil
+            }
+        )
+        guard timedOutJobIDs.isEmpty else {
+            markRuntimeUnhealthy(
+                reason: "timed out waiting for cancelled STT jobs to drain",
+                cancelledActiveJobIDs: timedOutJobIDs
+            )
+            return false
+        }
+
+        return true
+    }
+
+    private func makeRunningJobCancellationWatchdogTask(jobID: UUID, in slot: SchedulerSlot) -> Task<Void, Never> {
+        let timeout = runningJobCancellationTimeout
+        return Task { [weak self] in
+            do {
+                try await Task.sleep(for: timeout)
+            } catch {
+                return
+            }
+            await self?.runningJobCancellationDidTimeOut(jobID: jobID, in: slot)
+        }
+    }
+
+    private func runningJobCancellationDidTimeOut(jobID: UUID, in slot: SchedulerSlot) {
+        guard slotState(for: slot).currentJob?.id == jobID else { return }
+        markRuntimeUnhealthy(
+            reason: "cancelled STT job did not return before watchdog timeout",
+            cancelledActiveJobIDs: [jobID]
+        )
+    }
+
+    private func markRuntimeUnhealthy(reason: String, cancelledActiveJobIDs: Set<UUID>) {
+        if !runtimeUnhealthy {
+            logger.error("stt_runtime_unhealthy reason=\(reason, privacy: .public)")
+        }
+        runtimeUnhealthy = true
+        acceptsNewJobs = false
+
+        for slot in SchedulerSlot.allCases {
+            var currentSlotState = slotState(for: slot)
+            let pendingJobs = currentSlotState.pendingJobs
+            currentSlotState.pendingJobs.removeAll()
+
+            if let currentJob = currentSlotState.currentJob {
+                currentSlotState.currentExecutionTask?.cancel()
+                currentSlotState.currentJob = nil
+                currentSlotState.currentExecutionTask = nil
+                currentSlotState.currentWaitTask = nil
+                currentSlotState.currentWatchdogTask?.cancel()
+                currentSlotState.currentWatchdogTask = nil
+                let wasCancelled = currentJob.cancellationFlag.isCancelled
+                    || cancelledRunningJobIDs.contains(currentJob.id)
+                    || cancelledActiveJobIDs.contains(currentJob.id)
+                cancelledRunningJobIDs.remove(currentJob.id)
+                let error: Error = wasCancelled
+                    ? CancellationError()
+                    : STTSchedulerError.runtimeUnhealthy
+                continuations.removeValue(forKey: currentJob.id)?.resume(throwing: error)
+            }
+
+            setSlotState(currentSlotState, for: slot)
+
+            for job in pendingJobs {
+                let wasCancelled = job.cancellationFlag.isCancelled
+                job.cancellationFlag.cancel()
+                cancelledRunningJobIDs.remove(job.id)
+                let error: Error = wasCancelled
+                    ? CancellationError()
+                    : STTSchedulerError.runtimeUnhealthy
+                continuations.removeValue(forKey: job.id)?.resume(throwing: error)
+            }
+        }
+    }
+
+    private nonisolated static func sleepIgnoringCallerCancellation(for duration: Duration) async {
+        await Task.detached {
+            try? await Task.sleep(for: duration)
+        }.value
+    }
+
+    private var hasCancelledRunningJobPendingDrain: Bool {
+        if !cancelledRunningJobIDs.isEmpty {
+            return true
+        }
+        return slotStates.values.contains { state in
+            state.currentJob?.cancellationFlag.isCancelled == true
+        }
+    }
+
+    private var canStartQueuedJobs: Bool {
+        acceptsNewJobs
+            && !runtimeUnhealthy
+            && !shutdownRequested
+            && !hasCancelledRunningJobPendingDrain
+    }
+
+    private func restoreAcceptsNewJobsIfPossible() {
+        if !runtimeUnhealthy,
+           !shutdownRequested,
+           exclusiveOperationCount == 0,
+           !hasCancelledRunningJobPendingDrain {
             acceptsNewJobs = true
         }
     }
 
-    private func cancelAndDrainRunningJobs() async {
-        let waitTasks = SchedulerSlot.allCases.compactMap { slot -> Task<Void, Never>? in
-            let slotState = slotState(for: slot)
-            slotState.currentExecutionTask?.cancel()
-            return slotState.currentWaitTask
+    private func startQueuedJobsIfPossible() {
+        guard canStartQueuedJobs else { return }
+        for slot in SchedulerSlot.allCases {
+            startNextJobIfNeeded(in: slot)
         }
-        for task in waitTasks {
-            await task.value
+    }
+
+    private func beginExclusiveOperation() {
+        exclusiveOperationCount += 1
+        acceptsNewJobs = false
+    }
+
+    private func endExclusiveOperation(restoreAcceptsNewJobs: Bool) {
+        exclusiveOperationCount = max(0, exclusiveOperationCount - 1)
+        if restoreAcceptsNewJobs {
+            restoreAcceptsNewJobsIfPossible()
         }
     }
 }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -204,32 +204,34 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
 
         let folderURL = URL(fileURLWithPath: AppPaths.meetingRecordingsDir, isDirectory: true)
             .appendingPathComponent(sessionID.uuidString, isDirectory: true)
-        let writer = try MeetingAudioStorageWriter(folderURL: folderURL)
-        let chunkFolderURL = folderURL.appendingPathComponent("chunks", isDirectory: true)
-        try fileManager.createDirectory(at: chunkFolderURL, withIntermediateDirectories: true)
-        // Single timestamp shared between displayName fallback and
-        // startedAt — back-to-back `Date()` calls would only diverge if
-        // the clock ticked over a minute boundary between them, which is
-        // vanishingly rare but trivially avoidable.
-        let now = Date()
-        let speechEngineLease = await speechEngineSessionManager?.beginSpeechEngineSession()
-        currentSpeechEngineLease = speechEngineLease
-        let speechEngine = speechEngineLease?.selection ?? SpeechEngineSelection(engine: .parakeet)
-        let session = Session(
-            id: sessionID,
-            displayName: Self.resolveDisplayName(title: title, fallbackDate: now),
-            startedAt: now,
-            folderURL: folderURL,
-            chunkFolderURL: chunkFolderURL,
-            microphoneAudioURL: writer.microphoneAudioURL,
-            systemAudioURL: writer.systemAudioURL,
-            mixedAudioURL: writer.mixedAudioURL,
-            speechEngine: speechEngine
-        )
-        self.writer = writer
-        self.currentSession = session
 
         do {
+            let speechEngineLease = try await speechEngineSessionManager?.beginSpeechEngineSession()
+            currentSpeechEngineLease = speechEngineLease
+            let speechEngine = speechEngineLease?.selection ?? SpeechEngineSelection(engine: .parakeet)
+
+            let writer = try MeetingAudioStorageWriter(folderURL: folderURL)
+            self.writer = writer
+            let chunkFolderURL = folderURL.appendingPathComponent("chunks", isDirectory: true)
+            try fileManager.createDirectory(at: chunkFolderURL, withIntermediateDirectories: true)
+            // Single timestamp shared between displayName fallback and
+            // startedAt — back-to-back `Date()` calls would only diverge if
+            // the clock ticked over a minute boundary between them, which is
+            // vanishingly rare but trivially avoidable.
+            let now = Date()
+            let session = Session(
+                id: sessionID,
+                displayName: Self.resolveDisplayName(title: title, fallbackDate: now),
+                startedAt: now,
+                folderURL: folderURL,
+                chunkFolderURL: chunkFolderURL,
+                microphoneAudioURL: writer.microphoneAudioURL,
+                systemAudioURL: writer.systemAudioURL,
+                mixedAudioURL: writer.mixedAudioURL,
+                speechEngine: speechEngine
+            )
+            self.currentSession = session
+
             let initialLock = MeetingRecordingLockFile(
                 sessionId: session.id,
                 startedAt: session.startedAt,

--- a/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
+++ b/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
@@ -156,7 +156,7 @@ final class STTSchedulerTests: XCTestCase {
         let runtime = MockSTTRuntime()
         let scheduler = STTScheduler(runtimeProvider: runtime)
 
-        let lease = await scheduler.beginSpeechEngineSession()
+        let lease = try await scheduler.beginSpeechEngineSession()
         do {
             try await scheduler.setSpeechEngine(.whisper)
             XCTFail("Expected engine switch to fail while a speech engine session is active")
@@ -170,7 +170,47 @@ final class STTSchedulerTests: XCTestCase {
         XCTAssertEqual(count, 1)
     }
 
-    func testSpeechEngineSessionWaitsForInFlightEngineSwitch() async throws {
+    func testClearModelCacheSkipsWhileSessionLeaseIsActive() async throws {
+        let runtime = MockSTTRuntime()
+        let scheduler = STTScheduler(runtimeProvider: runtime)
+
+        let lease = try await scheduler.beginSpeechEngineSession()
+
+        await scheduler.clearModelCache()
+        var counts = await runtime.lifecycleCounts()
+        XCTAssertEqual(counts.clearModelCache, 0)
+
+        await scheduler.endSpeechEngineSession(lease)
+        await scheduler.clearModelCache()
+
+        counts = await runtime.lifecycleCounts()
+        XCTAssertEqual(counts.clearModelCache, 1)
+    }
+
+    func testClearModelCacheSkipsWhileSpeechEngineSessionIsStarting() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.blockNextCurrentSpeechEngineSelection()
+        let scheduler = STTScheduler(runtimeProvider: runtime)
+
+        let leaseTask = Task {
+            try await scheduler.beginSpeechEngineSession()
+        }
+        try await waitForCurrentSpeechEngineSelection(runtime: runtime, count: 1)
+
+        await scheduler.clearModelCache()
+        var counts = await runtime.lifecycleCounts()
+        XCTAssertEqual(counts.clearModelCache, 0)
+
+        await runtime.releaseCurrentSpeechEngineSelection()
+        let lease = try await leaseTask.value
+        await scheduler.endSpeechEngineSession(lease)
+
+        await scheduler.clearModelCache()
+        counts = await runtime.lifecycleCounts()
+        XCTAssertEqual(counts.clearModelCache, 1)
+    }
+
+    func testSpeechEngineSessionFailsWhileInFlightEngineSwitchIsActive() async throws {
         let runtime = MockSTTRuntime()
         await runtime.blockNextSpeechEngineSwitch()
         let scheduler = STTScheduler(runtimeProvider: runtime)
@@ -180,17 +220,73 @@ final class STTSchedulerTests: XCTestCase {
         }
         try await waitForSpeechEngineSwitch(runtime: runtime, count: 1)
 
-        let leaseTask = Task {
-            await scheduler.beginSpeechEngineSession()
+        do {
+            _ = try await scheduler.beginSpeechEngineSession()
+            XCTFail("Expected speech engine session to fail while an engine switch is active")
+        } catch let error as STTError {
+            XCTAssertEqual(error.localizedDescription, STTError.engineBusy.localizedDescription)
         }
-        try await Task.sleep(for: .milliseconds(50))
+
         await runtime.releaseSpeechEngineSwitch()
-
-        let lease = await leaseTask.value
-        XCTAssertEqual(lease.selection, SpeechEngineSelection(engine: .whisper))
-
-        await scheduler.endSpeechEngineSession(lease)
         _ = try await switchTask.value
+    }
+
+    func testSpeechEngineSessionFailsWhileCancelledRuntimeJobDrains() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.blockIgnoringCancellation(path: "slow-cancel")
+        let scheduler = STTScheduler(
+            runtimeProvider: runtime,
+            runningJobCancellationTimeout: .seconds(1)
+        )
+
+        let activeTask = Task {
+            try await scheduler.transcribe(audioPath: "slow-cancel", job: .fileTranscription)
+        }
+        try await waitForStartedPaths(runtime: runtime, count: 1)
+
+        activeTask.cancel()
+        do {
+            _ = try await scheduler.beginSpeechEngineSession()
+            XCTFail("Expected speech engine session to fail while a cancelled runtime task is draining")
+        } catch let error as STTSchedulerError {
+            XCTAssertEqual(error, .unavailable)
+        }
+
+        await runtime.release(path: "slow-cancel")
+        do {
+            _ = try await value(activeTask)
+            XCTFail("Expected active job cancellation to throw")
+        } catch is CancellationError {
+            // Expected.
+        }
+    }
+
+    func testCancelledSpeechEngineSessionStartReleasesReservation() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.blockNextCurrentSpeechEngineSelection()
+        let scheduler = STTScheduler(
+            runtimeProvider: runtime,
+            runningJobCancellationTimeout: .seconds(1)
+        )
+
+        let leaseTask = Task {
+            try await scheduler.beginSpeechEngineSession()
+        }
+        try await waitForCurrentSpeechEngineSelection(runtime: runtime, count: 1)
+
+        leaseTask.cancel()
+        do {
+            _ = try await value(leaseTask)
+            XCTFail("Expected speech engine session start cancellation to throw")
+        } catch is CancellationError {
+            // Expected.
+        }
+
+        await scheduler.clearModelCache()
+        let counts = await runtime.lifecycleCounts()
+        XCTAssertEqual(counts.clearModelCache, 1)
+
+        await runtime.releaseCurrentSpeechEngineSelection()
     }
 
     func testCancelledSpeechEngineSwitchRestoresSchedulerAvailability() async throws {
@@ -216,12 +312,116 @@ final class STTSchedulerTests: XCTestCase {
         XCTAssertEqual(count, 2)
     }
 
-    func testSpeechEngineSessionLeaseUsesRuntimeSelection() async {
+    func testCancelledSpeechEngineSwitchReturnsWhenRuntimeIgnoresCancellation() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.blockNextSpeechEngineSwitchIgnoringCancellation()
+        let scheduler = STTScheduler(
+            runtimeProvider: runtime,
+            runningJobCancellationTimeout: .milliseconds(50)
+        )
+
+        let switchTask = Task {
+            try await scheduler.setSpeechEngine(.whisper)
+        }
+        try await waitForSpeechEngineSwitch(runtime: runtime, count: 1)
+
+        switchTask.cancel()
+        do {
+            try await value(switchTask)
+            XCTFail("Expected cancelled engine switch to throw")
+        } catch is CancellationError {
+            // Expected.
+        }
+
+        do {
+            _ = try await scheduler.transcribe(audioPath: "after-wedged-cancelled-switch", job: .dictation)
+            XCTFail("Expected scheduler to reject jobs after wedged engine switch cancellation")
+        } catch let error as STTSchedulerError {
+            XCTAssertEqual(error, .runtimeUnhealthy)
+        }
+
+        await runtime.releaseSpeechEngineSwitch()
+    }
+
+    func testShutdownCancelsInFlightSpeechEngineSwitchBeforeRuntimeShutdown() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.blockNextSpeechEngineSwitch()
+        let scheduler = STTScheduler(runtimeProvider: runtime)
+
+        let switchTask = Task {
+            try await scheduler.setSpeechEngine(.whisper)
+        }
+        try await waitForSpeechEngineSwitch(runtime: runtime, count: 1)
+
+        await scheduler.shutdown()
+
+        do {
+            try await value(switchTask)
+            XCTFail("Expected shutdown to cancel in-flight engine switch")
+        } catch is CancellationError {
+            // Expected.
+        }
+
+        let counts = await runtime.lifecycleCounts()
+        XCTAssertEqual(counts.shutdown, 1)
+
+        do {
+            _ = try await scheduler.transcribe(audioPath: "after-shutdown", job: .dictation)
+            XCTFail("Expected shutdown to keep scheduler closed after an in-flight engine switch")
+        } catch let error as STTSchedulerError {
+            XCTAssertEqual(error, .unavailable)
+        }
+    }
+
+    func testShutdownReturnsWhenInFlightSpeechEngineSwitchIgnoresCancellation() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.blockNextSpeechEngineSwitchIgnoringCancellation()
+        let scheduler = STTScheduler(
+            runtimeProvider: runtime,
+            runningJobCancellationTimeout: .milliseconds(50)
+        )
+
+        let switchTask = Task {
+            try await scheduler.setSpeechEngine(.whisper)
+        }
+        try await waitForSpeechEngineSwitch(runtime: runtime, count: 1)
+
+        let shutdownFinished = expectation(description: "shutdown returns")
+        let shutdownTask = Task {
+            await scheduler.shutdown()
+            shutdownFinished.fulfill()
+        }
+
+        await fulfillment(of: [shutdownFinished], timeout: 1.0)
+
+        let counts = await runtime.lifecycleCounts()
+        XCTAssertEqual(counts.shutdown, 0)
+
+        do {
+            _ = try await scheduler.transcribe(audioPath: "after-wedged-switch", job: .dictation)
+            XCTFail("Expected scheduler to reject new jobs after wedged engine switch")
+        } catch let error as STTSchedulerError {
+            XCTAssertEqual(error, .runtimeUnhealthy)
+        }
+
+        await runtime.releaseSpeechEngineSwitch()
+        do {
+            try await value(switchTask)
+            XCTFail("Expected wedged engine switch to throw after shutdown marks runtime unhealthy")
+        } catch let error as STTSchedulerError {
+            XCTAssertEqual(error, .runtimeUnhealthy)
+        } catch is CancellationError {
+            // Expected.
+        }
+        await shutdownTask.value
+    }
+
+    func testSpeechEngineSessionLeaseUsesRuntimeSelection() async throws {
         let runtime = MockSTTRuntime()
         await runtime.setCurrentSelection(SpeechEngineSelection(engine: .whisper, language: "KO"))
         let scheduler = STTScheduler(runtimeProvider: runtime)
 
-        let lease = await scheduler.beginSpeechEngineSession()
+        let lease = try await scheduler.beginSpeechEngineSession()
 
         XCTAssertEqual(lease.selection, SpeechEngineSelection(engine: .whisper, language: "ko"))
     }
@@ -451,6 +651,377 @@ final class STTSchedulerTests: XCTestCase {
         _ = try await blockerTask.value
     }
 
+    func testActiveJobCancellationReturnsWhenRuntimeIgnoresCancellation() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.blockIgnoringCancellation(path: "stuck")
+        let scheduler = STTScheduler(
+            runtimeProvider: runtime,
+            runningJobCancellationTimeout: .milliseconds(50)
+        )
+
+        let activeTask = Task {
+            try await scheduler.transcribe(audioPath: "stuck", job: .fileTranscription)
+        }
+        try await waitForStartedPaths(runtime: runtime, count: 1)
+
+        let cancelled = expectation(description: "cancelled active job returns")
+        let recorder = AsyncResultRecorder<STTResult>()
+        let observerTask = Task {
+            do {
+                let value = try await activeTask.value
+                await recorder.record(.success(value))
+            } catch {
+                await recorder.record(.failure(error))
+            }
+            cancelled.fulfill()
+        }
+
+        activeTask.cancel()
+        await fulfillment(of: [cancelled], timeout: 1.0)
+
+        switch await recorder.result {
+        case .failure(let error):
+            XCTAssertTrue(error is CancellationError)
+        case .success:
+            XCTFail("Expected cancelled active job to throw CancellationError")
+        case nil:
+            XCTFail("Expected cancelled active job result")
+        }
+
+        do {
+            _ = try await scheduler.transcribe(audioPath: "after-wedge", job: .dictation)
+            XCTFail("Expected scheduler to reject new jobs after runtime watchdog timeout")
+        } catch let error as STTSchedulerError {
+            XCTAssertEqual(error, .runtimeUnhealthy)
+        }
+
+        await runtime.release(path: "stuck")
+        observerTask.cancel()
+    }
+
+    func testActiveJobCancellationWinsWhenRuntimeReturnsSuccessBeforeWatchdog() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.blockIgnoringCancellationAndSucceed(path: "returns")
+        let scheduler = STTScheduler(
+            runtimeProvider: runtime,
+            runningJobCancellationTimeout: .seconds(1)
+        )
+
+        let activeTask = Task {
+            try await scheduler.transcribe(audioPath: "returns", job: .fileTranscription)
+        }
+        try await waitForStartedPaths(runtime: runtime, count: 1)
+
+        activeTask.cancel()
+        await runtime.release(path: "returns")
+
+        do {
+            _ = try await value(activeTask)
+            XCTFail("Expected caller cancellation to win over a late successful runtime result")
+        } catch is CancellationError {
+            // Expected.
+        }
+
+        let result = try await scheduler.transcribe(audioPath: "after-cancel", job: .dictation)
+        XCTAssertEqual(result.text, "dictation:after-cancel")
+    }
+
+    func testActiveJobCancellationRejectsNewJobsUntilRuntimeReturns() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.blockIgnoringCancellation(path: "slow-cancel")
+        let scheduler = STTScheduler(
+            runtimeProvider: runtime,
+            runningJobCancellationTimeout: .seconds(1)
+        )
+
+        let activeTask = Task {
+            try await scheduler.transcribe(audioPath: "slow-cancel", job: .fileTranscription)
+        }
+        try await waitForStartedPaths(runtime: runtime, count: 1)
+
+        activeTask.cancel()
+
+        do {
+            _ = try await scheduler.transcribe(audioPath: "during-cancel", job: .dictation)
+            XCTFail("Expected scheduler to reject new jobs while a cancelled runtime task is draining")
+        } catch let error as STTSchedulerError {
+            XCTAssertEqual(error, .unavailable)
+        }
+
+        await runtime.release(path: "slow-cancel")
+        do {
+            _ = try await value(activeTask)
+            XCTFail("Expected active job cancellation to throw")
+        } catch is CancellationError {
+            // Expected.
+        }
+
+        let result = try await scheduler.transcribe(audioPath: "after-cancel-drained", job: .dictation)
+        XCTAssertEqual(result.text, "dictation:after-cancel-drained")
+    }
+
+    func testRuntimeUnhealthyPreservesCancellationForAllCancelledActiveSlots() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.blockIgnoringCancellation(path: "background-stuck")
+        await runtime.blockIgnoringCancellation(path: "dictation-stuck")
+        let scheduler = STTScheduler(
+            runtimeProvider: runtime,
+            runningJobCancellationTimeout: .milliseconds(50)
+        )
+
+        let backgroundTask = Task {
+            try await scheduler.transcribe(audioPath: "background-stuck", job: .fileTranscription)
+        }
+        let dictationTask = Task {
+            try await scheduler.transcribe(audioPath: "dictation-stuck", job: .dictation)
+        }
+        try await waitForStartedPaths(runtime: runtime, count: 2)
+
+        backgroundTask.cancel()
+        dictationTask.cancel()
+
+        do {
+            _ = try await value(backgroundTask)
+            XCTFail("Expected cancelled background job to throw")
+        } catch is CancellationError {
+            // Expected.
+        }
+
+        do {
+            _ = try await value(dictationTask)
+            XCTFail("Expected cancelled dictation job to throw")
+        } catch is CancellationError {
+            // Expected.
+        }
+
+        do {
+            _ = try await scheduler.transcribe(audioPath: "after-two-slot-wedge", job: .dictation)
+            XCTFail("Expected scheduler to reject new jobs after runtime watchdog timeout")
+        } catch let error as STTSchedulerError {
+            XCTAssertEqual(error, .runtimeUnhealthy)
+        }
+
+        await runtime.release(path: "background-stuck")
+        await runtime.release(path: "dictation-stuck")
+    }
+
+    func testClearModelCacheReturnsWhenActiveRuntimeIgnoresCancellation() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.blockIgnoringCancellation(path: "stuck")
+        let scheduler = STTScheduler(
+            runtimeProvider: runtime,
+            runningJobCancellationTimeout: .milliseconds(50)
+        )
+
+        let activeTask = Task {
+            try await scheduler.transcribe(audioPath: "stuck", job: .fileTranscription)
+        }
+        try await waitForStartedPaths(runtime: runtime, count: 1)
+
+        let clearFinished = expectation(description: "clear model cache returns")
+        let clearTask = Task {
+            await scheduler.clearModelCache()
+            clearFinished.fulfill()
+        }
+
+        await fulfillment(of: [clearFinished], timeout: 1.0)
+
+        do {
+            _ = try await value(activeTask)
+            XCTFail("Expected active job to be cancelled by cache clear")
+        } catch is CancellationError {
+            // Expected.
+        }
+
+        let counts = await runtime.lifecycleCounts()
+        XCTAssertEqual(counts.clearModelCache, 0)
+
+        do {
+            _ = try await scheduler.transcribe(audioPath: "after-wedge", job: .dictation)
+            XCTFail("Expected scheduler to reject new jobs after runtime watchdog timeout")
+        } catch let error as STTSchedulerError {
+            XCTAssertEqual(error, .runtimeUnhealthy)
+        }
+
+        await runtime.release(path: "stuck")
+        clearTask.cancel()
+    }
+
+    func testClearModelCacheRejectsJobsUntilRuntimeCacheClearFinishes() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.blockNextClearModelCache()
+        let scheduler = STTScheduler(runtimeProvider: runtime)
+
+        let clearTask = Task {
+            await scheduler.clearModelCache()
+        }
+        try await waitForClearModelCacheStarted(runtime: runtime)
+
+        do {
+            _ = try await scheduler.transcribe(audioPath: "during-clear", job: .dictation)
+            XCTFail("Expected scheduler to reject jobs while runtime cache clear is in progress")
+        } catch let error as STTSchedulerError {
+            XCTAssertEqual(error, .unavailable)
+        }
+
+        await runtime.releaseClearModelCache()
+        await clearTask.value
+
+        let result = try await scheduler.transcribe(audioPath: "after-clear", job: .dictation)
+        XCTAssertEqual(result.text, "dictation:after-clear")
+    }
+
+    func testClearModelCacheRejectsSpeechEngineSessionUntilRuntimeCacheClearFinishes() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.blockNextClearModelCache()
+        let scheduler = STTScheduler(runtimeProvider: runtime)
+
+        let clearTask = Task {
+            await scheduler.clearModelCache()
+        }
+        try await waitForClearModelCacheStarted(runtime: runtime)
+
+        do {
+            _ = try await scheduler.beginSpeechEngineSession()
+            XCTFail("Expected scheduler to reject speech engine sessions during cache clear")
+        } catch let error as STTSchedulerError {
+            XCTAssertEqual(error, .unavailable)
+        }
+
+        await runtime.releaseClearModelCache()
+        await clearTask.value
+
+        let lease = try await scheduler.beginSpeechEngineSession()
+        await scheduler.endSpeechEngineSession(lease)
+    }
+
+    func testClearModelCacheSkipsWhileInFlightEngineSwitchIsActive() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.blockNextSpeechEngineSwitch()
+        let scheduler = STTScheduler(runtimeProvider: runtime)
+
+        let switchTask = Task {
+            try await scheduler.setSpeechEngine(.whisper)
+        }
+        try await waitForSpeechEngineSwitch(runtime: runtime, count: 1)
+
+        await scheduler.clearModelCache()
+        var counts = await runtime.lifecycleCounts()
+        XCTAssertEqual(counts.clearModelCache, 0)
+
+        await runtime.releaseSpeechEngineSwitch()
+        _ = try await switchTask.value
+
+        await scheduler.clearModelCache()
+        counts = await runtime.lifecycleCounts()
+        XCTAssertEqual(counts.clearModelCache, 1)
+
+        let result = try await scheduler.transcribe(audioPath: "after-clear-switch", job: .dictation)
+        XCTAssertEqual(result.text, "dictation:after-clear-switch")
+    }
+
+    func testClearModelCacheReturnsWhenRuntimeCacheClearHangs() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.blockNextClearModelCache()
+        let scheduler = STTScheduler(
+            runtimeProvider: runtime,
+            runningJobCancellationTimeout: .milliseconds(50)
+        )
+
+        let clearFinished = expectation(description: "clear model cache returns")
+        let clearTask = Task {
+            await scheduler.clearModelCache()
+            clearFinished.fulfill()
+        }
+
+        await fulfillment(of: [clearFinished], timeout: 1.0)
+
+        let counts = await runtime.lifecycleCounts()
+        XCTAssertEqual(counts.clearModelCache, 1)
+
+        do {
+            _ = try await scheduler.transcribe(audioPath: "after-stuck-cache-clear", job: .dictation)
+            XCTFail("Expected scheduler to reject jobs after runtime cache clear timeout")
+        } catch let error as STTSchedulerError {
+            XCTAssertEqual(error, .runtimeUnhealthy)
+        }
+
+        await runtime.releaseClearModelCache()
+        await clearTask.value
+    }
+
+    func testShutdownReturnsWhenActiveRuntimeIgnoresCancellation() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.blockIgnoringCancellation(path: "stuck")
+        let scheduler = STTScheduler(
+            runtimeProvider: runtime,
+            runningJobCancellationTimeout: .milliseconds(50)
+        )
+
+        let activeTask = Task {
+            try await scheduler.transcribe(audioPath: "stuck", job: .meetingLiveChunk)
+        }
+        try await waitForStartedPaths(runtime: runtime, count: 1)
+
+        let shutdownFinished = expectation(description: "shutdown returns")
+        let shutdownTask = Task {
+            await scheduler.shutdown()
+            shutdownFinished.fulfill()
+        }
+
+        await fulfillment(of: [shutdownFinished], timeout: 1.0)
+
+        do {
+            _ = try await value(activeTask)
+            XCTFail("Expected active job to be cancelled by shutdown")
+        } catch is CancellationError {
+            // Expected.
+        }
+
+        let counts = await runtime.lifecycleCounts()
+        XCTAssertEqual(counts.shutdown, 0)
+
+        do {
+            _ = try await scheduler.transcribe(audioPath: "after-wedge", job: .dictation)
+            XCTFail("Expected scheduler to reject new jobs after runtime watchdog timeout")
+        } catch let error as STTSchedulerError {
+            XCTAssertEqual(error, .runtimeUnhealthy)
+        }
+
+        await runtime.release(path: "stuck")
+        shutdownTask.cancel()
+    }
+
+    func testShutdownReturnsWhenRuntimeShutdownHangs() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.blockNextShutdown()
+        let scheduler = STTScheduler(
+            runtimeProvider: runtime,
+            runningJobCancellationTimeout: .milliseconds(50)
+        )
+
+        let shutdownFinished = expectation(description: "shutdown returns")
+        let shutdownTask = Task {
+            await scheduler.shutdown()
+            shutdownFinished.fulfill()
+        }
+
+        await fulfillment(of: [shutdownFinished], timeout: 1.0)
+
+        let counts = await runtime.lifecycleCounts()
+        XCTAssertEqual(counts.shutdown, 1)
+
+        do {
+            _ = try await scheduler.transcribe(audioPath: "after-stuck-shutdown", job: .dictation)
+            XCTFail("Expected scheduler to reject jobs after runtime shutdown timeout")
+        } catch let error as STTSchedulerError {
+            XCTAssertEqual(error, .runtimeUnhealthy)
+        }
+
+        await runtime.releaseShutdown()
+        await shutdownTask.value
+    }
+
     private func waitForStartedPaths(
         runtime: MockSTTRuntime,
         count: Int,
@@ -481,6 +1052,35 @@ final class STTSchedulerTests: XCTestCase {
         }
     }
 
+    private func waitForCurrentSpeechEngineSelection(
+        runtime: MockSTTRuntime,
+        count: Int,
+        timeout: Duration = .seconds(2)
+    ) async throws {
+        let start = ContinuousClock.now
+        while await runtime.currentSpeechEngineSelectionCallCount < count {
+            if start.duration(to: .now) > timeout {
+                XCTFail("Timed out waiting for \(count) speech engine selection reads")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+    }
+
+    private func waitForClearModelCacheStarted(
+        runtime: MockSTTRuntime,
+        timeout: Duration = .seconds(2)
+    ) async throws {
+        let start = ContinuousClock.now
+        while await runtime.lifecycleCounts().clearModelCache < 1 {
+            if start.duration(to: .now) > timeout {
+                XCTFail("Timed out waiting for clearModelCache to start")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+    }
+
     private func value<T>(
         _ task: Task<T, any Error>,
         timeout: Duration = .seconds(1)
@@ -503,8 +1103,18 @@ private enum STTSchedulerTestError: Error {
     case timeout
 }
 
+private actor AsyncResultRecorder<Value: Sendable> {
+    private(set) var result: Result<Value, Error>?
+
+    func record(_ result: Result<Value, Error>) {
+        self.result = result
+    }
+}
+
 private actor MockSTTRuntime: STTRuntimeProtocol {
     private var blockedPaths: Set<String> = []
+    private var cancellationIgnoringPaths: Set<String> = []
+    private var cancellationIgnoringSuccessPaths: Set<String> = []
     private var waitingContinuations: [String: CheckedContinuation<Void, any Error>] = [:]
     private var progressScripts: [String: [Int]] = [:]
     private var started: [String] = []
@@ -515,9 +1125,17 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
     private(set) var clearModelCacheCallCount = 0
     private(set) var shutdownCallCount = 0
     private(set) var setSpeechEngineCallCount = 0
+    private(set) var currentSpeechEngineSelectionCallCount = 0
     private var selection = SpeechEngineSelection(engine: .parakeet)
     private var ready = false
+    private var shouldBlockNextClearModelCache = false
+    private var clearModelCacheContinuation: CheckedContinuation<Void, Never>?
+    private var shouldBlockNextShutdown = false
+    private var shutdownContinuation: CheckedContinuation<Void, Never>?
+    private var shouldBlockNextCurrentSpeechEngineSelection = false
+    private var currentSpeechEngineSelectionContinuation: CheckedContinuation<Void, Never>?
     private var shouldBlockNextSpeechEngineSwitch = false
+    private var shouldIgnoreNextSpeechEngineSwitchCancellation = false
     private var speechEngineSwitchContinuation: CheckedContinuation<Void, Never>?
 
     func transcribe(
@@ -526,6 +1144,8 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
         onProgress: (@Sendable (Int, Int) -> Void)?
     ) async throws -> STTResult {
         started.append(audioPath)
+        let ignoresCancellation = cancellationIgnoringPaths.contains(audioPath)
+        let skipsCancellationCheck = cancellationIgnoringSuccessPaths.contains(audioPath)
 
         if let script = progressScripts[audioPath] {
             for progress in script {
@@ -533,7 +1153,11 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
             }
         }
 
-        if blockedPaths.contains(audioPath) {
+        if ignoresCancellation {
+            try await withCheckedThrowingContinuation { continuation in
+                waitingContinuations[audioPath] = continuation
+            }
+        } else if blockedPaths.contains(audioPath) {
             try await withTaskCancellationHandler {
                 try await withCheckedThrowingContinuation { continuation in
                     waitingContinuations[audioPath] = continuation
@@ -543,7 +1167,9 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
             }
         }
 
-        try Task.checkCancellation()
+        if !skipsCancellationCheck {
+            try Task.checkCancellation()
+        }
         return STTResult(text: "\(job):\(audioPath)", words: [])
     }
 
@@ -582,10 +1208,22 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
 
     func shutdown() async {
         shutdownCallCount += 1
+        if shouldBlockNextShutdown {
+            shouldBlockNextShutdown = false
+            await withCheckedContinuation { continuation in
+                shutdownContinuation = continuation
+            }
+        }
     }
 
     func clearModelCache() async {
         clearModelCacheCallCount += 1
+        if shouldBlockNextClearModelCache {
+            shouldBlockNextClearModelCache = false
+            await withCheckedContinuation { continuation in
+                clearModelCacheContinuation = continuation
+            }
+        }
         ready = false
     }
 
@@ -593,13 +1231,21 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
         setSpeechEngineCallCount += 1
         if shouldBlockNextSpeechEngineSwitch {
             shouldBlockNextSpeechEngineSwitch = false
-            await withTaskCancellationHandler {
+            let ignoresCancellation = shouldIgnoreNextSpeechEngineSwitchCancellation
+            shouldIgnoreNextSpeechEngineSwitchCancellation = false
+            if ignoresCancellation {
                 await withCheckedContinuation { continuation in
                     speechEngineSwitchContinuation = continuation
                 }
-            } onCancel: {
-                Task {
-                    await self.releaseSpeechEngineSwitch()
+            } else {
+                await withTaskCancellationHandler {
+                    await withCheckedContinuation { continuation in
+                        speechEngineSwitchContinuation = continuation
+                    }
+                } onCancel: {
+                    Task {
+                        await self.releaseSpeechEngineSwitch()
+                    }
                 }
             }
             try Task.checkCancellation()
@@ -609,7 +1255,14 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
     }
 
     func currentSpeechEngineSelection() async -> SpeechEngineSelection {
-        selection
+        currentSpeechEngineSelectionCallCount += 1
+        if shouldBlockNextCurrentSpeechEngineSelection {
+            shouldBlockNextCurrentSpeechEngineSelection = false
+            await withCheckedContinuation { continuation in
+                currentSpeechEngineSelectionContinuation = continuation
+            }
+        }
+        return selection
     }
 
     func setCurrentSelection(_ selection: SpeechEngineSelection) {
@@ -618,6 +1271,11 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
 
     func blockNextSpeechEngineSwitch() {
         shouldBlockNextSpeechEngineSwitch = true
+    }
+
+    func blockNextSpeechEngineSwitchIgnoringCancellation() {
+        shouldBlockNextSpeechEngineSwitch = true
+        shouldIgnoreNextSpeechEngineSwitchCancellation = true
     }
 
     func releaseSpeechEngineSwitch() {
@@ -629,8 +1287,46 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
         blockedPaths.insert(path)
     }
 
+    func blockIgnoringCancellation(path: String) {
+        cancellationIgnoringPaths.insert(path)
+    }
+
+    func blockIgnoringCancellationAndSucceed(path: String) {
+        cancellationIgnoringPaths.insert(path)
+        cancellationIgnoringSuccessPaths.insert(path)
+    }
+
+    func blockNextClearModelCache() {
+        shouldBlockNextClearModelCache = true
+    }
+
+    func releaseClearModelCache() {
+        clearModelCacheContinuation?.resume()
+        clearModelCacheContinuation = nil
+    }
+
+    func blockNextShutdown() {
+        shouldBlockNextShutdown = true
+    }
+
+    func releaseShutdown() {
+        shutdownContinuation?.resume()
+        shutdownContinuation = nil
+    }
+
+    func blockNextCurrentSpeechEngineSelection() {
+        shouldBlockNextCurrentSpeechEngineSelection = true
+    }
+
+    func releaseCurrentSpeechEngineSelection() {
+        currentSpeechEngineSelectionContinuation?.resume()
+        currentSpeechEngineSelectionContinuation = nil
+    }
+
     func release(path: String) {
         blockedPaths.remove(path)
+        cancellationIgnoringPaths.remove(path)
+        cancellationIgnoringSuccessPaths.remove(path)
         waitingContinuations.removeValue(forKey: path)?.resume(returning: ())
     }
 

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
@@ -50,6 +50,36 @@ final class MeetingRecordingServiceTests: XCTestCase {
         await service.cancelRecording()
     }
 
+    func testStartRecordingCleansUpWhenSpeechEngineLeaseFails() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let lockStore = RecordingLockFileStore()
+        let sttClient = LeasingMeetingSTTClient(
+            selection: SpeechEngineSelection(engine: .whisper, language: "KO"),
+            beginSessionError: TestError.speechEngineLeaseFailed
+        )
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: MockMeetingAudioFileConverter(),
+            sttTranscriber: sttClient,
+            lockFileStore: lockStore
+        )
+        let entriesBefore = meetingRecordingDirectoryEntryNames()
+
+        do {
+            try await service.startRecording()
+            XCTFail("Expected speech engine lease failure")
+        } catch TestError.speechEngineLeaseFailed {
+            let startCallCount = await captureService.startCallCount
+            let activeLeaseCount = await sttClient.activeLeaseCount
+            XCTAssertEqual(startCallCount, 0)
+            XCTAssertEqual(activeLeaseCount, 0)
+            XCTAssertTrue(lockStore.writes.isEmpty)
+            XCTAssertEqual(meetingRecordingDirectoryEntryNames(), entriesBefore)
+            let isRecording = await service.isRecording
+            XCTAssertFalse(isRecording)
+        }
+    }
+
     func testCancelDuringAsyncStartMakesInFlightStartThrow() async throws {
         let captureService = BlockingStartMeetingAudioCaptureService()
         let lockStore = RecordingLockFileStore()
@@ -993,6 +1023,13 @@ final class MeetingRecordingServiceTests: XCTestCase {
         }
     }
 
+    private func meetingRecordingDirectoryEntryNames() -> Set<String> {
+        guard let names = try? FileManager.default.contentsOfDirectory(atPath: AppPaths.meetingRecordingsDir) else {
+            return []
+        }
+        return Set(names)
+    }
+
     private func makeMonoFloatBuffer(frameCount: Int, sampleValue: Float) -> AVAudioPCMBuffer? {
         guard let format = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,
@@ -1329,6 +1366,7 @@ private actor BlockingStartMeetingAudioCaptureService: MeetingAudioCapturing {
 
 private enum TestError: Error {
     case lockWriteFailed
+    case speechEngineLeaseFailed
 }
 
 private final class RecordingLockFileStore: MeetingRecordingLockFileStoring, @unchecked Sendable {
@@ -1671,18 +1709,23 @@ private actor CountingMeetingSTTClient: STTClientProtocol {
 
 private actor LeasingMeetingSTTClient: STTClientProtocol, SpeechEngineRoutedTranscribing, SpeechEngineSessionManaging {
     private let selection: SpeechEngineSelection
+    private let beginSessionError: Error?
     private var activeLeases: Set<UUID> = []
     private(set) var routedSelections: [SpeechEngineSelection] = []
 
-    init(selection: SpeechEngineSelection) {
+    init(selection: SpeechEngineSelection, beginSessionError: Error? = nil) {
         self.selection = selection
+        self.beginSessionError = beginSessionError
     }
 
     var activeLeaseCount: Int {
         activeLeases.count
     }
 
-    func beginSpeechEngineSession() async -> SpeechEngineLease {
+    func beginSpeechEngineSession() async throws -> SpeechEngineLease {
+        if let beginSessionError {
+            throw beginSessionError
+        }
         let lease = SpeechEngineLease(selection: selection)
         activeLeases.insert(lease.id)
         return lease


### PR DESCRIPTION
## What Changed
- Adds a bounded watchdog for active STT job cancellation.
- Makes shutdown and clear-model-cache quiesce paths return after a bounded drain timeout.
- Marks the shared scheduler runtime unhealthy after an uncooperative runtime timeout and rejects new STT work instead of reusing a possibly wedged FluidAudio/WhisperKit runtime.
- Adds XCTest coverage for caller cancellation, cache clear, and shutdown when the mock runtime ignores cancellation.

## Why
STTScheduler previously depended on the underlying STT runtime returning after task cancellation. If FluidAudio or WhisperKit ignored cancellation or wedged, callers and in-app maintenance flows could hang indefinitely.

## Validation
- `swift build --skip-update --target MacParakeetCore` via Xcode Swift toolchain: passed.
- Rebuilt `MacParakeetPackageTests.xctest` with Xcode XCTest search/link paths: passed build; SwiftPM runner itself is blocked by this host's /usr/bin/xcrun Xcode-license prompt.
- Direct Xcode `xctest -XCTest STTSchedulerTests .build/arm64-apple-macosx/debug/MacParakeetPackageTests.xctest`: 22 tests passed.

## Notes
No existing PR existed for this branch before publishing, so there were no prior GitHub review threads or comments to reply to.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and cleanup when speech engine initialization fails during recording startup
  * Added timeout handling to prevent the speech scheduler from becoming unresponsive during engine switching or job cancellation

* **Chores**
  * Expanded test coverage for error handling and cancellation edge cases

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moona3k/macparakeet/pull/242)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->