### PR TITLE
Scale transcription library queries

### DIFF
--- a/Sources/CLI/Commands/HistoryCommand.swift
+++ b/Sources/CLI/Commands/HistoryCommand.swift
@@ -92,7 +92,10 @@ struct TranscriptionsSubcommand: ParsableCommand {
             try AppPaths.ensureDirectories()
             let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
             let repo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
-            let transcriptions = try repo.fetchAll(limit: limit)
+            let transcriptions = try repo.fetchLibraryPage(query: TranscriptionLibraryQuery(
+                limit: limit,
+                includeProcessing: true
+            )).items
 
             if json {
                 try printJSON(transcriptions)
@@ -199,7 +202,14 @@ struct SearchTranscriptionsSubcommand: ParsableCommand {
             try AppPaths.ensureDirectories()
             let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
             let repo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
-            let results = try repo.search(query: query, limit: limit)
+            let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+            let results = trimmedQuery.isEmpty
+                ? []
+                : try repo.fetchLibraryPage(query: TranscriptionLibraryQuery(
+                    searchText: trimmedQuery,
+                    limit: limit,
+                    includeProcessing: true
+                )).items
 
             if json {
                 try printJSON(results)
@@ -328,7 +338,11 @@ struct FavoritesSubcommand: ParsableCommand {
             try AppPaths.ensureDirectories()
             let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
             let repo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
-            let favorites = try repo.fetchFavorites()
+            let favorites = try repo.fetchLibraryPage(query: TranscriptionLibraryQuery(
+                favoritesOnly: true,
+                limit: Int.max,
+                includeProcessing: true
+            )).items
 
             if json {
                 try printJSON(favorites)

--- a/Sources/CLI/Commands/MeetingsCommand.swift
+++ b/Sources/CLI/Commands/MeetingsCommand.swift
@@ -37,7 +37,11 @@ struct MeetingsCommand: AsyncParsableCommand {
         func run() async throws {
             try emitJSONOrRethrow(json: json) {
                 let repo = try makeTranscriptionRepository(database: database)
-                let meetings = try repo.fetchBySourceType(.meeting, limit: limit)
+                let meetings = try repo.fetchLibraryPage(query: TranscriptionLibraryQuery(
+                    sourceType: .meeting,
+                    limit: limit,
+                    includeProcessing: true
+                )).items
                     .map(MeetingListItem.init)
 
                 if json {

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -83,13 +83,15 @@ struct TranscriptionLibraryView: View {
                     .padding(.bottom, DesignSystem.Spacing.sm)
             }
 
-            // Content — date-grouped list for Meetings filter, thumbnail grid otherwise.
+            // Content — date-grouped list for meetings, thumbnail grid otherwise.
             // Reason: meetings have no thumbnail-worthy visual asset, so a list with
             // preview text + speaker count is denser and more useful than a wall of
             // waveform placeholders.
-            if viewModel.filteredTranscriptions.isEmpty {
+            if viewModel.isLoading && viewModel.filteredTranscriptions.isEmpty {
+                loadingState
+            } else if viewModel.filteredTranscriptions.isEmpty {
                 emptyState
-            } else if viewModel.filter == .meeting {
+            } else if isMeetingListMode {
                 meetingsList
             } else {
                 thumbnailGrid
@@ -124,20 +126,23 @@ struct TranscriptionLibraryView: View {
 
     private var thumbnailGrid: some View {
         ScrollView {
-            LazyVGrid(
-                columns: [GridItem(.adaptive(minimum: DesignSystem.Layout.thumbnailCardMinWidth), spacing: DesignSystem.Spacing.md)],
-                spacing: DesignSystem.Spacing.md
-            ) {
-                ForEach(viewModel.filteredTranscriptions) { transcription in
-                    TranscriptionThumbnailCard(transcription: transcription, searchText: viewModel.searchText) {
-                        onSelect(transcription)
-                    } menuContent: {
-                        libraryMenuItems(for: transcription)
-                    }
-                    .contextMenu {
-                        libraryMenuItems(for: transcription)
+            VStack(spacing: DesignSystem.Spacing.md) {
+                LazyVGrid(
+                    columns: [GridItem(.adaptive(minimum: DesignSystem.Layout.thumbnailCardMinWidth), spacing: DesignSystem.Spacing.md)],
+                    spacing: DesignSystem.Spacing.md
+                ) {
+                    ForEach(viewModel.filteredTranscriptions) { transcription in
+                        TranscriptionThumbnailCard(transcription: transcription, searchText: viewModel.searchText) {
+                            onSelect(transcription)
+                        } menuContent: {
+                            libraryMenuItems(for: transcription)
+                        }
+                        .contextMenu {
+                            libraryMenuItems(for: transcription)
+                        }
                     }
                 }
+                loadMoreFooter
             }
             .padding(.horizontal, DesignSystem.Spacing.lg)
             .padding(.bottom, DesignSystem.Spacing.lg)
@@ -161,6 +166,9 @@ struct TranscriptionLibraryView: View {
                         }
                     }
                 }
+                loadMoreFooter
+                    .padding(.horizontal, DesignSystem.Spacing.lg)
+                    .padding(.top, DesignSystem.Spacing.md)
             }
             .padding(.bottom, DesignSystem.Spacing.lg)
         }
@@ -214,17 +222,52 @@ struct TranscriptionLibraryView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
+    private var loadingState: some View {
+        VStack {
+            Spacer()
+            ProgressView()
+                .controlSize(.small)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private var loadMoreFooter: some View {
+        if viewModel.hasMore {
+            HStack {
+                Spacer()
+                Button {
+                    viewModel.loadMoreTranscriptions()
+                } label: {
+                    Text(viewModel.isLoading ? "Loading..." : "Load More")
+                }
+                .parakeetAction(.secondary)
+                .disabled(viewModel.isLoading)
+                Spacer()
+            }
+        } else if viewModel.isLoading {
+            ProgressView()
+                .controlSize(.small)
+                .frame(maxWidth: .infinity)
+        }
+    }
+
+    private var isMeetingListMode: Bool {
+        viewModel.scope == .meetings || viewModel.filter == .meeting
+    }
+
     private var emptyStateIcon: String {
         if !viewModel.searchText.isEmpty { return "magnifyingglass" }
-        return viewModel.filter == .meeting ? "waveform.badge.mic" : "square.grid.2x2"
+        return isMeetingListMode ? "waveform.badge.mic" : "square.grid.2x2"
     }
 
     private var emptyStateTitle: String {
-        viewModel.filter == .meeting ? "No meetings recorded yet" : emptyTitle
+        isMeetingListMode ? "No meetings recorded yet" : emptyTitle
     }
 
     private var emptyStateMessage: String {
-        viewModel.filter == .meeting
+        isMeetingListMode
             ? "Press Record Meeting on the Transcribe tab to capture system audio and transcribe locally."
             : emptyMessage
     }

--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -592,6 +592,21 @@ public final class DatabaseManager: Sendable {
             )
         }
 
+        migrator.registerMigration("v0.10-transcription-library-indexes") { db in
+            try db.execute(sql: """
+                CREATE INDEX IF NOT EXISTS idx_transcriptions_source_type_created_at
+                ON transcriptions(sourceType, createdAt)
+            """)
+            try db.execute(sql: """
+                CREATE INDEX IF NOT EXISTS idx_transcriptions_favorite_created_at
+                ON transcriptions(isFavorite, createdAt)
+            """)
+            try db.execute(sql: """
+                CREATE INDEX IF NOT EXISTS idx_transcriptions_status_created_at
+                ON transcriptions(status, createdAt)
+            """)
+        }
+
         try migrator.migrate(dbQueue)
         try reconcileBuiltInPrompts()
         try reconcileBuiltInQuickPrompts()

--- a/Sources/MacParakeetCore/Database/TranscriptionLibraryQuery.swift
+++ b/Sources/MacParakeetCore/Database/TranscriptionLibraryQuery.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+public enum TranscriptionLibrarySortOrder: Sendable, Equatable {
+    case dateDescending
+    case dateAscending
+    case titleAscending
+}
+
+public struct TranscriptionLibraryQuery: Sendable, Equatable {
+    public var sourceType: Transcription.SourceType?
+    public var favoritesOnly: Bool
+    public var searchText: String?
+    public var sortOrder: TranscriptionLibrarySortOrder
+    public var limit: Int
+    public var offset: Int
+    public var includeProcessing: Bool
+
+    public init(
+        sourceType: Transcription.SourceType? = nil,
+        favoritesOnly: Bool = false,
+        searchText: String? = nil,
+        sortOrder: TranscriptionLibrarySortOrder = .dateDescending,
+        limit: Int = 100,
+        offset: Int = 0,
+        includeProcessing: Bool = false
+    ) {
+        self.sourceType = sourceType
+        self.favoritesOnly = favoritesOnly
+        self.searchText = searchText
+        self.sortOrder = sortOrder
+        self.limit = limit
+        self.offset = offset
+        self.includeProcessing = includeProcessing
+    }
+}
+
+public struct TranscriptionLibraryPage: Sendable {
+    public var items: [Transcription]
+    public var hasMore: Bool
+
+    public init(items: [Transcription], hasMore: Bool) {
+        self.items = items
+        self.hasMore = hasMore
+    }
+}

--- a/Sources/MacParakeetCore/Database/TranscriptionRepository.swift
+++ b/Sources/MacParakeetCore/Database/TranscriptionRepository.swift
@@ -5,6 +5,7 @@ public protocol TranscriptionRepositoryProtocol: Sendable {
     func save(_ transcription: Transcription) throws
     func fetch(id: UUID) throws -> Transcription?
     func fetchAll(limit: Int?) throws -> [Transcription]
+    func fetchLibraryPage(query: TranscriptionLibraryQuery) throws -> TranscriptionLibraryPage
     func fetchByFilePath(_ filePath: String, sourceType: Transcription.SourceType?) throws -> [Transcription]
     func fetchCompletedByVideoID(_ videoID: String) throws -> Transcription?
     func count() throws -> Int
@@ -34,6 +35,51 @@ extension TranscriptionRepositoryProtocol {
     public func fetchCompletedByVideoID(_ videoID: String) throws -> Transcription? { nil }
     public func count() throws -> Int { try fetchAll(limit: nil).count }
     public func search(query: String, limit: Int?) throws -> [Transcription] { [] }
+    public func fetchLibraryPage(query: TranscriptionLibraryQuery) throws -> TranscriptionLibraryPage {
+        var results = try fetchAll(limit: nil)
+
+        if !query.includeProcessing {
+            results = results.filter { $0.status != .processing }
+        }
+        if let sourceType = query.sourceType {
+            results = results.filter { $0.sourceType == sourceType }
+        }
+        if query.favoritesOnly {
+            results = results.filter(\.isFavorite)
+        }
+        if let searchText = query.searchText?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !searchText.isEmpty {
+            let lowered = searchText.lowercased()
+            results = results.filter { transcription in
+                transcription.fileName.lowercased().contains(lowered)
+                    || (transcription.rawTranscript?.lowercased().contains(lowered) ?? false)
+                    || (transcription.cleanTranscript?.lowercased().contains(lowered) ?? false)
+                    || (transcription.channelName?.lowercased().contains(lowered) ?? false)
+            }
+        }
+
+        switch query.sortOrder {
+        case .dateDescending:
+            results.sort { $0.createdAt > $1.createdAt }
+        case .dateAscending:
+            results.sort { $0.createdAt < $1.createdAt }
+        case .titleAscending:
+            results.sort {
+                $0.fileName.localizedCaseInsensitiveCompare($1.fileName) == .orderedAscending
+            }
+        }
+
+        let limit = max(0, query.limit)
+        let offset = max(0, query.offset)
+        guard offset < results.count else {
+            return TranscriptionLibraryPage(items: [], hasMore: false)
+        }
+        let end = min(results.count, offset + limit)
+        return TranscriptionLibraryPage(
+            items: Array(results[offset..<end]),
+            hasMore: results.count > end
+        )
+    }
     public func clearStoredAudioPathsForURLTranscriptions() throws {}
     public func updateFileName(id: UUID, fileName: String) throws {}
     public func updateChatMessages(id: UUID, chatMessages: [ChatMessage]?) throws {}
@@ -69,6 +115,60 @@ public final class TranscriptionRepository: TranscriptionRepositoryProtocol {
                 request = request.limit(limit)
             }
             return try request.fetchAll(db)
+        }
+    }
+
+    public func fetchLibraryPage(query: TranscriptionLibraryQuery) throws -> TranscriptionLibraryPage {
+        try dbQueue.read { db in
+            let limit = max(0, query.limit)
+            let offset = max(0, query.offset)
+            let fetchLimit = limit == Int.max ? Int.max : limit + 1
+            var whereClauses: [String] = []
+            var arguments: [any DatabaseValueConvertible] = []
+
+            if !query.includeProcessing {
+                whereClauses.append("status != ?")
+                arguments.append(Transcription.TranscriptionStatus.processing.rawValue)
+            }
+            if let sourceType = query.sourceType {
+                whereClauses.append("sourceType = ?")
+                arguments.append(sourceType.rawValue)
+            }
+            if query.favoritesOnly {
+                whereClauses.append("isFavorite = 1")
+            }
+            if let searchText = query.searchText?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !searchText.isEmpty {
+                let pattern = "%\(escapedLikePattern(searchText))%"
+                whereClauses.append("""
+                    (
+                        fileName LIKE ? ESCAPE '\\'
+                        OR rawTranscript LIKE ? ESCAPE '\\'
+                        OR cleanTranscript LIKE ? ESCAPE '\\'
+                        OR channelName LIKE ? ESCAPE '\\'
+                    )
+                    """)
+                arguments.append(contentsOf: [pattern, pattern, pattern, pattern])
+            }
+
+            var sql = "SELECT * FROM transcriptions"
+            if !whereClauses.isEmpty {
+                sql += " WHERE " + whereClauses.joined(separator: " AND ")
+            }
+            sql += " ORDER BY \(Self.libraryOrderClause(for: query.sortOrder))"
+            sql += " LIMIT ? OFFSET ?"
+            arguments.append(fetchLimit)
+            arguments.append(offset)
+
+            let fetched = try Transcription.fetchAll(
+                db,
+                sql: sql,
+                arguments: StatementArguments(arguments)
+            )
+            return TranscriptionLibraryPage(
+                items: limit == 0 ? [] : Array(fetched.prefix(limit)),
+                hasMore: fetched.count > limit
+            )
         }
     }
 
@@ -307,6 +407,17 @@ public final class TranscriptionRepository: TranscriptionRepositoryProtocol {
                 .filter(Transcription.Columns.isFavorite == true)
                 .order(Transcription.Columns.createdAt.desc)
                 .fetchAll(db)
+        }
+    }
+
+    private static func libraryOrderClause(for sortOrder: TranscriptionLibrarySortOrder) -> String {
+        switch sortOrder {
+        case .dateDescending:
+            return "createdAt DESC"
+        case .dateAscending:
+            return "createdAt ASC"
+        case .titleAscending:
+            return "fileName COLLATE NOCASE ASC, createdAt DESC"
         }
     }
 }

--- a/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
@@ -15,11 +15,7 @@ public enum TranscriptionLibraryScope: Sendable {
     case meetings
 }
 
-public enum LibrarySortOrder: Sendable {
-    case dateDescending
-    case dateAscending
-    case titleAscending
-}
+public typealias LibrarySortOrder = TranscriptionLibrarySortOrder
 
 /// Date-based bucket used to group meeting/library rows under headers like
 /// "Today", "Yesterday", "Previous 7 Days". Computed against the user's
@@ -64,19 +60,26 @@ public enum TranscriptionDateGroup: Hashable, Sendable {
 @MainActor @Observable
 public final class TranscriptionLibraryViewModel {
     private let logger = Logger(subsystem: "com.macparakeet.viewmodels", category: "TranscriptionLibrary")
-    public var transcriptions: [Transcription] = [] { didSet { recomputeFiltered() } }
-    public var filter: LibraryFilter = .all { didSet { recomputeFiltered() } }
-    public var searchText: String = "" { didSet { recomputeFiltered() } }
-    public var sortOrder: LibrarySortOrder = .dateDescending { didSet { recomputeFiltered() } }
+    public private(set) var transcriptions: [Transcription] = []
+    public var filter: LibraryFilter = .all { didSet { reloadAfterStateChange() } }
+    public var searchText: String = "" { didSet { debounceSearchReload() } }
+    public var sortOrder: LibrarySortOrder = .dateDescending { didSet { reloadAfterStateChange() } }
     public private(set) var filteredTranscriptions: [Transcription] = []
     public private(set) var groupedTranscriptions: [(group: TranscriptionDateGroup, items: [Transcription])] = []
+    public private(set) var hasMore = false
+    public private(set) var isLoading = false
     public var errorMessage: String?
+    public var pageSize = 100
+    public var searchDebounceInterval: Duration = .milliseconds(300)
 
     /// Override for tests; production code uses `Date()`.
     public var nowProvider: @Sendable () -> Date = { Date() }
     public var calendar: Calendar = .autoupdatingCurrent
 
     private var transcriptionRepo: TranscriptionRepositoryProtocol?
+    private var loadTask: Task<Void, Never>?
+    private var searchDebounceTask: Task<Void, Never>?
+    private var loadGeneration = 0
     public let scope: TranscriptionLibraryScope
 
     public init(scope: TranscriptionLibraryScope = .all) {
@@ -85,37 +88,6 @@ public final class TranscriptionLibraryViewModel {
 
     public func configure(transcriptionRepo: TranscriptionRepositoryProtocol) {
         self.transcriptionRepo = transcriptionRepo
-    }
-
-    private func recomputeFiltered() {
-        var result = transcriptions.filter { matchesScope($0) }
-
-        switch filter {
-        case .all: break
-        case .youtube: result = result.filter { $0.sourceType == .youtube }
-        case .local: result = result.filter { $0.sourceType == .file }
-        case .meeting: result = result.filter { $0.sourceType == .meeting }
-        case .favorites: result = result.filter(\.isFavorite)
-        }
-
-        if !searchText.isEmpty {
-            let query = searchText.lowercased()
-            result = result.filter { t in
-                t.fileName.lowercased().contains(query)
-                    || (t.rawTranscript?.lowercased().contains(query) ?? false)
-                    || (t.cleanTranscript?.lowercased().contains(query) ?? false)
-                    || (t.channelName?.lowercased().contains(query) ?? false)
-            }
-        }
-
-        switch sortOrder {
-        case .dateDescending: result.sort { $0.createdAt > $1.createdAt }
-        case .dateAscending: result.sort { $0.createdAt < $1.createdAt }
-        case .titleAscending: result.sort { $0.fileName.localizedCaseInsensitiveCompare($1.fileName) == .orderedAscending }
-        }
-
-        filteredTranscriptions = result
-        groupedTranscriptions = groupByDate(result)
     }
 
     private func groupByDate(_ items: [Transcription]) -> [(group: TranscriptionDateGroup, items: [Transcription])] {
@@ -143,23 +115,17 @@ public final class TranscriptionLibraryViewModel {
             .map { group in (group: group, items: bucketed[group] ?? []) }
     }
 
-    private func matchesScope(_ transcription: Transcription) -> Bool {
-        switch scope {
-        case .all:
-            return true
-        case .meetings:
-            return transcription.sourceType == .meeting
-        }
+    @discardableResult
+    public func loadTranscriptions() -> Task<Void, Never> {
+        searchDebounceTask?.cancel()
+        searchDebounceTask = nil
+        return loadPage(offset: 0, append: false)
     }
 
-    public func loadTranscriptions() {
-        do {
-            transcriptions = (try transcriptionRepo?.fetchAll(limit: nil) ?? [])
-                .filter { $0.status != .processing }
-        } catch {
-            logger.error("Failed to load transcriptions: \(error.localizedDescription)")
-            transcriptions = []
-        }
+    @discardableResult
+    public func loadMoreTranscriptions() -> Task<Void, Never>? {
+        guard hasMore, !isLoading else { return nil }
+        return loadPage(offset: transcriptions.count, append: true)
     }
 
     public func toggleFavorite(_ transcription: Transcription) {
@@ -168,7 +134,12 @@ public final class TranscriptionLibraryViewModel {
             errorMessage = nil
             try transcriptionRepo?.updateFavorite(id: transcription.id, isFavorite: newValue)
             if let idx = transcriptions.firstIndex(where: { $0.id == transcription.id }) {
-                transcriptions[idx].isFavorite = newValue
+                if filter == .favorites && !newValue {
+                    transcriptions.remove(at: idx)
+                } else {
+                    transcriptions[idx].isFavorite = newValue
+                }
+                publishLoadedItems(transcriptions, hasMore: hasMore)
             }
             Telemetry.send(.transcriptionFavorited(isFavorite: newValue))
         } catch {
@@ -184,10 +155,120 @@ public final class TranscriptionLibraryViewModel {
             let deleted = try transcriptionRepo?.delete(id: transcription.id) ?? false
             guard deleted else { return }
             transcriptions.removeAll { $0.id == transcription.id }
+            publishLoadedItems(transcriptions, hasMore: hasMore)
             Telemetry.send(.transcriptionDeleted)
         } catch {
             logger.error("Failed to delete transcription: \(error.localizedDescription, privacy: .private)")
             errorMessage = "Failed to delete transcription: \(error.localizedDescription)"
         }
+    }
+
+    private func reloadAfterStateChange() {
+        searchDebounceTask?.cancel()
+        searchDebounceTask = nil
+        loadTranscriptions()
+    }
+
+    private func debounceSearchReload() {
+        searchDebounceTask?.cancel()
+        searchDebounceTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            if self.searchDebounceInterval > .zero {
+                try? await Task.sleep(for: self.searchDebounceInterval)
+            }
+            guard !Task.isCancelled else { return }
+            self.searchDebounceTask = nil
+            self.loadPage(offset: 0, append: false)
+        }
+    }
+
+    @discardableResult
+    private func loadPage(offset: Int, append: Bool) -> Task<Void, Never> {
+        loadTask?.cancel()
+        loadGeneration += 1
+        let generation = loadGeneration
+
+        guard let repo = transcriptionRepo else {
+            isLoading = false
+            publishLoadedItems([], hasMore: false)
+            return Task {}
+        }
+        guard let query = makeQuery(offset: offset) else {
+            isLoading = false
+            publishLoadedItems([], hasMore: false)
+            return Task {}
+        }
+
+        isLoading = true
+        errorMessage = nil
+
+        let task = Task { @MainActor [weak self, repo, query] in
+            do {
+                let page = try await Task.detached(priority: .userInitiated) {
+                    try repo.fetchLibraryPage(query: query)
+                }.value
+                guard let self, !Task.isCancelled, self.loadGeneration == generation else { return }
+                let items = append ? self.transcriptions + page.items : page.items
+                self.publishLoadedItems(items, hasMore: page.hasMore)
+                self.isLoading = false
+            } catch {
+                guard let self, !Task.isCancelled, self.loadGeneration == generation else { return }
+                self.logger.error("Failed to load transcriptions: \(error.localizedDescription, privacy: .private)")
+                self.publishLoadedItems([], hasMore: false)
+                self.isLoading = false
+                self.errorMessage = "Failed to load transcriptions: \(error.localizedDescription)"
+            }
+        }
+        loadTask = task
+        return task
+    }
+
+    private func makeQuery(offset: Int) -> TranscriptionLibraryQuery? {
+        let sourceType: Transcription.SourceType?
+        let favoritesOnly: Bool
+
+        switch (scope, filter) {
+        case (.all, .all):
+            sourceType = nil
+            favoritesOnly = false
+        case (.all, .youtube):
+            sourceType = .youtube
+            favoritesOnly = false
+        case (.all, .local):
+            sourceType = .file
+            favoritesOnly = false
+        case (.all, .meeting):
+            sourceType = .meeting
+            favoritesOnly = false
+        case (.all, .favorites):
+            sourceType = nil
+            favoritesOnly = true
+        case (.meetings, .all), (.meetings, .meeting):
+            sourceType = .meeting
+            favoritesOnly = false
+        case (.meetings, .favorites):
+            sourceType = .meeting
+            favoritesOnly = true
+        case (.meetings, .youtube), (.meetings, .local):
+            return nil
+        }
+
+        let trimmedSearch = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        return TranscriptionLibraryQuery(
+            sourceType: sourceType,
+            favoritesOnly: favoritesOnly,
+            searchText: trimmedSearch.isEmpty ? nil : trimmedSearch,
+            sortOrder: sortOrder,
+            limit: pageSize,
+            offset: offset,
+            includeProcessing: false
+        )
+    }
+
+    private func publishLoadedItems(_ items: [Transcription], hasMore: Bool) {
+        transcriptions = items
+        filteredTranscriptions = items
+        groupedTranscriptions = groupByDate(items)
+        self.hasMore = hasMore
     }
 }

--- a/Tests/CLITests/HistoryCommandTests.swift
+++ b/Tests/CLITests/HistoryCommandTests.swift
@@ -191,6 +191,49 @@ final class HistoryCommandTests: XCTestCase {
         XCTAssertEqual(results.first?.id, t1.id)
     }
 
+    func testSearchTranscriptionsCommandSearchesChannelName() throws {
+        let dbURL = temporaryDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: dbURL) }
+        let db = try DatabaseManager(path: dbURL.path)
+        let repo = TranscriptionRepository(dbQueue: db.dbQueue)
+
+        let t1 = Transcription(fileName: "video.mp3", status: .completed, channelName: "Swift Talks")
+        let t2 = Transcription(fileName: "other.mp3", status: .completed, channelName: "Other Channel")
+        try repo.save(t1)
+        try repo.save(t2)
+
+        let command = try SearchTranscriptionsSubcommand.parse([
+            "swift",
+            "--database", dbURL.path,
+        ])
+        let output = try captureStandardOutput {
+            try command.run()
+        }
+
+        XCTAssertTrue(output.contains("video.mp3"))
+        XCTAssertFalse(output.contains("other.mp3"))
+    }
+
+    func testSearchTranscriptionsCommandEmptyQueryReturnsNoRows() throws {
+        let dbURL = temporaryDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: dbURL) }
+        let db = try DatabaseManager(path: dbURL.path)
+        let repo = TranscriptionRepository(dbQueue: db.dbQueue)
+
+        try repo.save(Transcription(fileName: "video.mp3", status: .completed))
+
+        let command = try SearchTranscriptionsSubcommand.parse([
+            "   ",
+            "--database", dbURL.path,
+        ])
+        let output = try captureStandardOutput {
+            try command.run()
+        }
+
+        XCTAssertTrue(output.contains("No transcriptions matching"))
+        XCTAssertFalse(output.contains("video.mp3"))
+    }
+
     func testSearchTranscriptionsRespectsLimit() throws {
         let db = try DatabaseManager()
         let repo = TranscriptionRepository(dbQueue: db.dbQueue)

--- a/Tests/MacParakeetTests/Database/DatabaseManagerTests.swift
+++ b/Tests/MacParakeetTests/Database/DatabaseManagerTests.swift
@@ -145,6 +145,9 @@ final class DatabaseManagerTests: XCTestCase {
 
             let transcriptionIndexes = try db.indexes(on: "transcriptions")
             XCTAssertTrue(transcriptionIndexes.contains { $0.name == "idx_transcriptions_created_at" })
+            XCTAssertTrue(transcriptionIndexes.contains { $0.name == "idx_transcriptions_source_type_created_at" })
+            XCTAssertTrue(transcriptionIndexes.contains { $0.name == "idx_transcriptions_favorite_created_at" })
+            XCTAssertTrue(transcriptionIndexes.contains { $0.name == "idx_transcriptions_status_created_at" })
 
             let promptIndexes = try db.indexes(on: "prompts")
             XCTAssertTrue(promptIndexes.contains { $0.name == "idx_prompts_name" })

--- a/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
@@ -292,6 +292,163 @@ final class TranscriptionRepositoryTests: XCTestCase {
         XCTAssertEqual(transcriptResults.count, 1)
     }
 
+    // MARK: - Library Queries
+
+    func testFetchLibraryPageExcludesProcessingButIncludesTerminalRowsByDefault() throws {
+        try repo.save(Transcription(fileName: "done.mp3", status: .completed))
+        try repo.save(Transcription(fileName: "working.mp3", status: .processing))
+        try repo.save(Transcription(fileName: "cancelled.mp3", status: .cancelled))
+        try repo.save(Transcription(fileName: "failed.mp3", status: .error))
+
+        let page = try repo.fetchLibraryPage(query: TranscriptionLibraryQuery(limit: 10))
+
+        XCTAssertEqual(Set(page.items.map(\.fileName)), ["done.mp3", "cancelled.mp3", "failed.mp3"])
+    }
+
+    func testFetchLibraryPageCanIncludeProcessingRows() throws {
+        try repo.save(Transcription(fileName: "done.mp3", status: .completed))
+        try repo.save(Transcription(fileName: "working.mp3", status: .processing))
+
+        let page = try repo.fetchLibraryPage(query: TranscriptionLibraryQuery(
+            limit: 10,
+            includeProcessing: true
+        ))
+
+        XCTAssertEqual(Set(page.items.map(\.fileName)), ["done.mp3", "working.mp3"])
+    }
+
+    func testFetchLibraryPageFiltersBySourceType() throws {
+        let local = Transcription(fileName: "local.mp3", status: .completed, sourceType: .file)
+        let youtube = Transcription(fileName: "video.mp3", status: .completed, sourceType: .youtube)
+        let meeting = Transcription(fileName: "meeting.m4a", status: .completed, sourceType: .meeting)
+        try repo.save(local)
+        try repo.save(youtube)
+        try repo.save(meeting)
+
+        let page = try repo.fetchLibraryPage(query: TranscriptionLibraryQuery(
+            sourceType: .meeting,
+            limit: 10
+        ))
+
+        XCTAssertEqual(page.items.map(\.id), [meeting.id])
+    }
+
+    func testFetchLibraryPageFiltersFavoritesAndComposesWithSourceType() throws {
+        let meetingFavorite = Transcription(
+            fileName: "fav meeting.m4a",
+            status: .completed,
+            isFavorite: true,
+            sourceType: .meeting
+        )
+        let fileFavorite = Transcription(
+            fileName: "fav file.mp3",
+            status: .completed,
+            isFavorite: true,
+            sourceType: .file
+        )
+        let meetingNormal = Transcription(
+            fileName: "normal meeting.m4a",
+            status: .completed,
+            sourceType: .meeting
+        )
+        try repo.save(meetingFavorite)
+        try repo.save(fileFavorite)
+        try repo.save(meetingNormal)
+
+        let page = try repo.fetchLibraryPage(query: TranscriptionLibraryQuery(
+            sourceType: .meeting,
+            favoritesOnly: true,
+            limit: 10
+        ))
+
+        XCTAssertEqual(page.items.map(\.id), [meetingFavorite.id])
+    }
+
+    func testFetchLibraryPageSearchesTitleTranscriptAndChannelName() throws {
+        let title = Transcription(fileName: "Design Notes", status: .completed)
+        let raw = Transcription(fileName: "raw.mp3", rawTranscript: "Budget review", status: .completed)
+        let clean = Transcription(fileName: "clean.mp3", cleanTranscript: "Launch proposal", status: .completed)
+        let channel = Transcription(fileName: "video.mp3", status: .completed, channelName: "Swift Talks")
+        let other = Transcription(fileName: "other.mp3", rawTranscript: "Unrelated", status: .completed)
+        try repo.save(title)
+        try repo.save(raw)
+        try repo.save(clean)
+        try repo.save(channel)
+        try repo.save(other)
+
+        XCTAssertEqual(
+            try repo.fetchLibraryPage(query: TranscriptionLibraryQuery(searchText: "design", limit: 10)).items.map(\.id),
+            [title.id]
+        )
+        XCTAssertEqual(
+            try repo.fetchLibraryPage(query: TranscriptionLibraryQuery(searchText: "budget", limit: 10)).items.map(\.id),
+            [raw.id]
+        )
+        XCTAssertEqual(
+            try repo.fetchLibraryPage(query: TranscriptionLibraryQuery(searchText: "proposal", limit: 10)).items.map(\.id),
+            [clean.id]
+        )
+        XCTAssertEqual(
+            try repo.fetchLibraryPage(query: TranscriptionLibraryQuery(searchText: "swift", limit: 10)).items.map(\.id),
+            [channel.id]
+        )
+    }
+
+    func testFetchLibraryPageSortsByDateAndTitle() throws {
+        let older = Transcription(
+            createdAt: Date(timeIntervalSinceReferenceDate: 100),
+            fileName: "Banana.mp3",
+            status: .completed,
+            updatedAt: Date(timeIntervalSinceReferenceDate: 100)
+        )
+        let newer = Transcription(
+            createdAt: Date(timeIntervalSinceReferenceDate: 200),
+            fileName: "Apple.mp3",
+            status: .completed,
+            updatedAt: Date(timeIntervalSinceReferenceDate: 200)
+        )
+        try repo.save(older)
+        try repo.save(newer)
+
+        XCTAssertEqual(
+            try repo.fetchLibraryPage(query: TranscriptionLibraryQuery(sortOrder: .dateDescending, limit: 10)).items.map(\.id),
+            [newer.id, older.id]
+        )
+        XCTAssertEqual(
+            try repo.fetchLibraryPage(query: TranscriptionLibraryQuery(sortOrder: .dateAscending, limit: 10)).items.map(\.id),
+            [older.id, newer.id]
+        )
+        XCTAssertEqual(
+            try repo.fetchLibraryPage(query: TranscriptionLibraryQuery(sortOrder: .titleAscending, limit: 10)).items.map(\.id),
+            [newer.id, older.id]
+        )
+    }
+
+    func testFetchLibraryPageSupportsLimitOffsetAndHasMore() throws {
+        var inserted: [Transcription] = []
+        for i in 0..<5 {
+            let transcription = Transcription(
+                createdAt: Date(timeIntervalSinceReferenceDate: TimeInterval(i)),
+                fileName: "file-\(i).mp3",
+                status: .completed,
+                updatedAt: Date(timeIntervalSinceReferenceDate: TimeInterval(i))
+            )
+            inserted.append(transcription)
+            try repo.save(transcription)
+        }
+
+        let first = try repo.fetchLibraryPage(query: TranscriptionLibraryQuery(limit: 2, offset: 0))
+        let second = try repo.fetchLibraryPage(query: TranscriptionLibraryQuery(limit: 2, offset: 2))
+        let final = try repo.fetchLibraryPage(query: TranscriptionLibraryQuery(limit: 2, offset: 4))
+
+        XCTAssertEqual(first.items.map(\.id), [inserted[4].id, inserted[3].id])
+        XCTAssertTrue(first.hasMore)
+        XCTAssertEqual(second.items.map(\.id), [inserted[2].id, inserted[1].id])
+        XCTAssertTrue(second.hasMore)
+        XCTAssertEqual(final.items.map(\.id), [inserted[0].id])
+        XCTAssertFalse(final.hasMore)
+    }
+
     // MARK: - Status Transitions
 
     func testUpdateStatus() throws {

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionDateGroupingTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionDateGroupingTests.swift
@@ -56,7 +56,7 @@ final class TranscriptionDateGroupingTests: XCTestCase {
 
     // MARK: - View model integration
 
-    func testViewModelGroupsAcrossDateBuckets() throws {
+    func testViewModelGroupsAcrossDateBuckets() async throws {
         let manager = try DatabaseManager()
         let repo = TranscriptionRepository(dbQueue: manager.dbQueue)
         let now = date(2026, 4, 28, 15)
@@ -71,7 +71,7 @@ final class TranscriptionDateGroupingTests: XCTestCase {
         try repo.save(Transcription(createdAt: date(2026, 4, 10, 10), fileName: "earlier_month.m4a", status: .completed))
         try repo.save(Transcription(createdAt: date(2026, 1, 12, 10), fileName: "january.m4a", status: .completed))
 
-        vm.loadTranscriptions()
+        await vm.loadTranscriptions().value
 
         let groups = vm.groupedTranscriptions.map(\.group)
         XCTAssertEqual(groups, [
@@ -84,7 +84,7 @@ final class TranscriptionDateGroupingTests: XCTestCase {
         XCTAssertEqual(vm.groupedTranscriptions.map { $0.items.count }, [1, 1, 1, 1, 1])
     }
 
-    func testGroupingDoesNotFragmentUnderTitleSort() throws {
+    func testGroupingDoesNotFragmentUnderTitleSort() async throws {
         let manager = try DatabaseManager()
         let repo = TranscriptionRepository(dbQueue: manager.dbQueue)
         let now = date(2026, 4, 28, 15)
@@ -101,7 +101,7 @@ final class TranscriptionDateGroupingTests: XCTestCase {
         try repo.save(Transcription(createdAt: date(2026, 4, 11, 10), fileName: "Cherry", status: .completed))
 
         vm.sortOrder = .titleAscending
-        vm.loadTranscriptions()
+        await vm.loadTranscriptions().value
 
         let groups = vm.groupedTranscriptions.map(\.group)
         XCTAssertEqual(groups, [.previous30Days, .month(year: 2026, month: 1)])
@@ -120,7 +120,7 @@ final class TranscriptionDateGroupingTests: XCTestCase {
         XCTAssertEqual(bucket, .previous30Days)
     }
 
-    func testEmptyGroupsAreOmitted() throws {
+    func testEmptyGroupsAreOmitted() async throws {
         let manager = try DatabaseManager()
         let repo = TranscriptionRepository(dbQueue: manager.dbQueue)
         let now = date(2026, 4, 28, 15)
@@ -130,7 +130,7 @@ final class TranscriptionDateGroupingTests: XCTestCase {
         vm.nowProvider = { now }
 
         try repo.save(Transcription(createdAt: date(2026, 4, 28, 10), fileName: "today.m4a", status: .completed))
-        vm.loadTranscriptions()
+        await vm.loadTranscriptions().value
 
         XCTAssertEqual(vm.groupedTranscriptions.count, 1)
         XCTAssertEqual(vm.groupedTranscriptions.first?.group, .today)

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
@@ -14,32 +14,36 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
         vm.configure(transcriptionRepo: repo)
     }
 
+    private func load(_ viewModel: TranscriptionLibraryViewModel? = nil) async {
+        await (viewModel ?? vm).loadTranscriptions().value
+    }
+
     // MARK: - Load
 
-    func testLoadTranscriptions() throws {
+    func testLoadTranscriptions() async throws {
         try repo.save(Transcription(fileName: "a.mp3", status: .completed))
         try repo.save(Transcription(fileName: "b.mp3", status: .completed))
 
-        vm.loadTranscriptions()
+        await load()
         XCTAssertEqual(vm.transcriptions.count, 2)
     }
 
-    func testLoadTranscriptionsExcludesProcessingRows() throws {
+    func testLoadTranscriptionsExcludesProcessingRows() async throws {
         try repo.save(Transcription(fileName: "done.mp3", status: .completed))
         try repo.save(Transcription(fileName: "working.mp3", status: .processing))
 
-        vm.loadTranscriptions()
+        await load()
 
         XCTAssertEqual(vm.transcriptions.map(\.fileName), ["done.mp3"])
         XCTAssertEqual(vm.filteredTranscriptions.map(\.fileName), ["done.mp3"])
     }
 
-    func testLoadTranscriptionsExcludesCancelledAndErrorRows() throws {
+    func testLoadTranscriptionsIncludesCancelledAndErrorRows() async throws {
         try repo.save(Transcription(fileName: "done.mp3", status: .completed))
         try repo.save(Transcription(fileName: "cancelled.mp3", status: .cancelled))
         try repo.save(Transcription(fileName: "failed.mp3", status: .error, errorMessage: "boom"))
 
-        vm.loadTranscriptions()
+        await load()
 
         XCTAssertEqual(vm.transcriptions.count, 3)
         XCTAssertEqual(Set(vm.transcriptions.map(\.fileName)), ["done.mp3", "cancelled.mp3", "failed.mp3"])
@@ -49,7 +53,7 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
 
     // MARK: - Filter
 
-    func testFilterAll() throws {
+    func testFilterAll() async throws {
         try repo.save(Transcription(fileName: "local.mp3", status: .completed))
         try repo.save(Transcription(
             fileName: "youtube.mp3",
@@ -57,13 +61,13 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
             sourceURL: "https://youtube.com/watch?v=abc",
             sourceType: .youtube
         ))
-        vm.loadTranscriptions()
 
         vm.filter = .all
+        await load()
         XCTAssertEqual(vm.filteredTranscriptions.count, 2)
     }
 
-    func testFilterYouTube() throws {
+    func testFilterYouTube() async throws {
         try repo.save(Transcription(fileName: "local.mp3", status: .completed))
         try repo.save(Transcription(
             fileName: "youtube.mp3",
@@ -71,82 +75,99 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
             sourceURL: "https://youtube.com/watch?v=abc",
             sourceType: .youtube
         ))
-        vm.loadTranscriptions()
 
         vm.filter = .youtube
+        await load()
         XCTAssertEqual(vm.filteredTranscriptions.count, 1)
         XCTAssertEqual(vm.filteredTranscriptions.first?.fileName, "youtube.mp3")
     }
 
-    func testFilterLocal() throws {
+    func testFilterLocal() async throws {
         try repo.save(Transcription(fileName: "local.mp3", status: .completed, sourceType: .file))
         try repo.save(Transcription(fileName: "meeting.mp3", status: .completed, sourceType: .meeting))
         try repo.save(Transcription(fileName: "youtube.mp3", status: .completed, sourceURL: "https://youtube.com/watch?v=abc", sourceType: .youtube))
-        vm.loadTranscriptions()
 
         vm.filter = .local
+        await load()
         XCTAssertEqual(vm.filteredTranscriptions.count, 1)
         XCTAssertEqual(vm.filteredTranscriptions.first?.fileName, "local.mp3")
     }
 
-    func testFilterFavorites() throws {
+    func testFilterFavorites() async throws {
         try repo.save(Transcription(fileName: "fav.mp3", status: .completed, isFavorite: true))
         try repo.save(Transcription(fileName: "normal.mp3", status: .completed))
-        vm.loadTranscriptions()
 
         vm.filter = .favorites
+        await load()
         XCTAssertEqual(vm.filteredTranscriptions.count, 1)
         XCTAssertEqual(vm.filteredTranscriptions.first?.fileName, "fav.mp3")
     }
 
-    func testFilterMeetings() throws {
+    func testFilterMeetings() async throws {
         try repo.save(Transcription(fileName: "meeting.mp3", status: .completed, sourceType: .meeting))
         try repo.save(Transcription(fileName: "local.mp3", status: .completed, sourceType: .file))
-        vm.loadTranscriptions()
 
         vm.filter = .meeting
+        await load()
         XCTAssertEqual(vm.filteredTranscriptions.count, 1)
         XCTAssertEqual(vm.filteredTranscriptions.first?.fileName, "meeting.mp3")
     }
 
-    func testMeetingsScopeOnlyShowsMeetings() throws {
+    func testMeetingsScopeOnlyShowsMeetings() async throws {
         let meetingVM = TranscriptionLibraryViewModel(scope: .meetings)
         meetingVM.configure(transcriptionRepo: repo)
 
         try repo.save(Transcription(fileName: "meeting.mp3", status: .completed, sourceType: .meeting))
         try repo.save(Transcription(fileName: "local.mp3", status: .completed, sourceType: .file))
 
-        meetingVM.loadTranscriptions()
+        await load(meetingVM)
 
         XCTAssertEqual(meetingVM.filteredTranscriptions.map(\.fileName), ["meeting.mp3"])
     }
 
+    func testMeetingsScopeComposesWithFavoritesAndConflictingFilters() async throws {
+        let meetingVM = TranscriptionLibraryViewModel(scope: .meetings)
+        meetingVM.configure(transcriptionRepo: repo)
+
+        try repo.save(Transcription(fileName: "fav meeting.mp3", status: .completed, isFavorite: true, sourceType: .meeting))
+        try repo.save(Transcription(fileName: "normal meeting.mp3", status: .completed, sourceType: .meeting))
+        try repo.save(Transcription(fileName: "fav local.mp3", status: .completed, isFavorite: true, sourceType: .file))
+
+        meetingVM.filter = .favorites
+        await load(meetingVM)
+        XCTAssertEqual(meetingVM.filteredTranscriptions.map(\.fileName), ["fav meeting.mp3"])
+
+        meetingVM.filter = .local
+        await load(meetingVM)
+        XCTAssertTrue(meetingVM.filteredTranscriptions.isEmpty)
+    }
+
     // MARK: - Search
 
-    func testSearchByTitle() throws {
+    func testSearchByTitle() async throws {
         try repo.save(Transcription(fileName: "Swift Tutorial", status: .completed))
         try repo.save(Transcription(fileName: "Python Basics", status: .completed))
-        vm.loadTranscriptions()
 
         vm.searchText = "swift"
+        await load()
         XCTAssertEqual(vm.filteredTranscriptions.count, 1)
         XCTAssertEqual(vm.filteredTranscriptions.first?.fileName, "Swift Tutorial")
     }
 
-    func testSearchByTranscript() throws {
+    func testSearchByTranscript() async throws {
         var t = Transcription(fileName: "Recording", status: .completed)
         t.rawTranscript = "The quick brown fox jumps over the lazy dog"
         try repo.save(t)
 
         try repo.save(Transcription(fileName: "Other", status: .completed))
-        vm.loadTranscriptions()
 
         vm.searchText = "brown fox"
+        await load()
         XCTAssertEqual(vm.filteredTranscriptions.count, 1)
         XCTAssertEqual(vm.filteredTranscriptions.first?.fileName, "Recording")
     }
 
-    func testSearchByChannel() throws {
+    func testSearchByChannel() async throws {
         try repo.save(Transcription(
             fileName: "Video",
             status: .completed,
@@ -154,40 +175,40 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
             channelName: "TechChannel"
         ))
         try repo.save(Transcription(fileName: "Other", status: .completed))
-        vm.loadTranscriptions()
 
         vm.searchText = "techchannel"
+        await load()
         XCTAssertEqual(vm.filteredTranscriptions.count, 1)
     }
 
     // MARK: - Sort
 
-    func testSortDateDescending() throws {
+    func testSortDateDescending() async throws {
         let older = Transcription(createdAt: Date().addingTimeInterval(-100), fileName: "older.mp3", status: .completed)
         let newer = Transcription(createdAt: Date(), fileName: "newer.mp3", status: .completed)
         try repo.save(older)
         try repo.save(newer)
-        vm.loadTranscriptions()
 
         vm.sortOrder = .dateDescending
+        await load()
         XCTAssertEqual(vm.filteredTranscriptions.first?.fileName, "newer.mp3")
     }
 
-    func testSortTitleAscending() throws {
+    func testSortTitleAscending() async throws {
         try repo.save(Transcription(fileName: "Banana.mp3", status: .completed))
         try repo.save(Transcription(fileName: "Apple.mp3", status: .completed))
-        vm.loadTranscriptions()
 
         vm.sortOrder = .titleAscending
+        await load()
         XCTAssertEqual(vm.filteredTranscriptions.first?.fileName, "Apple.mp3")
     }
 
     // MARK: - Favorites
 
-    func testToggleFavorite() throws {
+    func testToggleFavorite() async throws {
         let t = Transcription(fileName: "test.mp3", status: .completed)
         try repo.save(t)
-        vm.loadTranscriptions()
+        await load()
 
         XCTAssertFalse(vm.transcriptions[0].isFavorite)
         vm.toggleFavorite(vm.transcriptions[0])
@@ -198,12 +219,28 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
         XCTAssertTrue(fetched?.isFavorite ?? false)
     }
 
+    func testToggleFavoriteOffInFavoritesFilterRemovesRowWithoutReload() async throws {
+        let favorite = Transcription(fileName: "fav.mp3", status: .completed, isFavorite: true)
+        let normal = Transcription(fileName: "normal.mp3", status: .completed)
+        try repo.save(favorite)
+        try repo.save(normal)
+
+        vm.filter = .favorites
+        await load()
+
+        XCTAssertEqual(vm.filteredTranscriptions.map(\.id), [favorite.id])
+        vm.toggleFavorite(vm.filteredTranscriptions[0])
+
+        XCTAssertTrue(vm.filteredTranscriptions.isEmpty)
+        XCTAssertFalse(try repo.fetch(id: favorite.id)?.isFavorite ?? true)
+    }
+
     // MARK: - Delete
 
-    func testDeleteTranscription() throws {
+    func testDeleteTranscription() async throws {
         let t = Transcription(fileName: "test.mp3", status: .completed)
         try repo.save(t)
-        vm.loadTranscriptions()
+        await load()
 
         XCTAssertEqual(vm.transcriptions.count, 1)
         vm.deleteTranscription(t)

--- a/spec/01-data-model.md
+++ b/spec/01-data-model.md
@@ -123,6 +123,9 @@ CREATE TABLE transcriptions (
 );
 
 CREATE INDEX idx_transcriptions_created_at ON transcriptions(createdAt);
+CREATE INDEX idx_transcriptions_source_type_created_at ON transcriptions(sourceType, createdAt);
+CREATE INDEX idx_transcriptions_favorite_created_at ON transcriptions(isFavorite, createdAt);
+CREATE INDEX idx_transcriptions_status_created_at ON transcriptions(status, createdAt);
 ```
 
 **Notes:**


### PR DESCRIPTION
## Summary
- Add Core TranscriptionLibraryQuery/Page types and SQL-backed repository pagination/filter/search/sort.
- Refactor the library view model to load current pages off the main actor with debounced search and load-more state.
- Route CLI history/search/favorites and meetings list through the same query API, with indexes and focused tests.

## Shape
```
Before:
.searchable -> ViewModel
              fetchAll(nil)
              main-actor filter/search/sort over every row

After:
.searchable -> ViewModel debounce/page state
              TranscriptionLibraryQuery
              Repository SQL WHERE/ORDER/LIMIT
              current page -> SwiftUI and CLI
```

## Fresh-eye follow-up
- Preserved CLI search behavior for empty/whitespace queries: no accidental list-all result.
- Made meetings-only library scope render with the meetings list/empty state, not the generic thumbnail grid.
- Removed favorite-toggle page reloads while keeping Favorites-filter rows locally consistent.

## Known tradeoff
- Search intentionally uses pragmatic SQL LIKE for this PR. That keeps search/filter/sort out of the main actor without taking on FTS semantics in this change; FTS5/unicode61 remains the right follow-up for richer Unicode token behavior.

## Validation
- PASS: direct SwiftPM build through the Xcode toolchain for TranscriptionLibraryViewModelTests filter, including app/test targets.
- PASS: direct xctest CLITests.HistoryCommandTests, 12 tests.
- PASS: direct xctest MacParakeetTests.TranscriptionRepositoryTests, 41 tests.
- PASS: direct xctest MacParakeetTests.TranscriptionLibraryViewModelTests, 18 tests.
- PASS: direct xctest MacParakeetTests.TranscriptionDateGroupingTests, 11 tests.
- PASS: direct xctest MacParakeetTests.DatabaseManagerTests/testMigrationsCreateIndexes, 1 test.
- NOTE: normal swift test is blocked on this machine by the unaccepted Xcode license. A full direct xctest bundle ran 2256 tests and only failed in MeetingRecordingCrashRecoveryTests after the same license gate prevented the crash helper from writing playable audio.