### PR TITLE
Harden asset and process lifecycle

### DIFF
--- a/Sources/CLI/Commands/HistoryCommand.swift
+++ b/Sources/CLI/Commands/HistoryCommand.swift
@@ -302,10 +302,14 @@ struct DeleteTranscriptionSubcommand: ParsableCommand {
         let repo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
 
         let transcription = try findTranscription(id: id, repo: repo)
-        try TranscriptionAssetCleanup.removeOwnedAssets(for: transcription)
         let deleted = try repo.delete(id: transcription.id)
         guard deleted else {
             throw CLILookupError.notFound("No transcription matching '\(id)'")
+        }
+        do {
+            try TranscriptionAssetCleanup.removeOwnedAssets(for: transcription)
+        } catch {
+            fputs("Warning: deleted database row but could not remove stored audio: \(error.localizedDescription)\n", stderr)
         }
         print("Deleted transcription: \"\(transcription.fileName)\"")
     }

--- a/Sources/MacParakeetCore/Audio/AudioFileConverter.swift
+++ b/Sources/MacParakeetCore/Audio/AudioFileConverter.swift
@@ -314,50 +314,10 @@ public final class AudioFileConverter: AudioFileConverting, Sendable {
 
     private func runProcessAndWait(_ process: Process, timeout: TimeInterval) async throws {
         try process.run()
-
-        let resumed = OSAllocatedUnfairLock(initialState: false)
-        try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
-                    let shouldResume = resumed.withLock { done -> Bool in
-                        guard !done else { return false }
-                        done = true
-                        return true
-                    }
-                    if shouldResume {
-                        process.terminate()
-                        continuation.resume(
-                            throwing: AudioProcessorError.conversionFailed("FFmpeg conversion timed out")
-                        )
-                    }
-                }
-
-                process.terminationHandler = { _ in
-                    let shouldResume = resumed.withLock { done -> Bool in
-                        guard !done else { return false }
-                        done = true
-                        return true
-                    }
-                    if shouldResume {
-                        continuation.resume()
-                    }
-                }
-
-                if !process.isRunning {
-                    let shouldResume = resumed.withLock { done -> Bool in
-                        guard !done else { return false }
-                        done = true
-                        return true
-                    }
-                    if shouldResume {
-                        continuation.resume()
-                    }
-                }
-            }
-        } onCancel: {
-            process.terminate()
-        }
-
-        try Task.checkCancellation()
+        try await ChildProcessWaiter.waitUntilExit(
+            process,
+            timeout: timeout,
+            timeoutError: AudioProcessorError.conversionFailed("FFmpeg conversion timed out")
+        )
     }
 }

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -496,6 +496,13 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
 
             try await assertCanTranscribeOrEmitPreflight(operation)
 
+            var unownedDownloadedAudioURL: URL?
+            defer {
+                if let unownedDownloadedAudioURL {
+                    try? FileManager.default.removeItem(at: unownedDownloadedAudioURL)
+                }
+            }
+
             let downloadResult: YouTubeDownloader.DownloadResult
             do {
                 onProgress?(.downloading(percent: 0))
@@ -530,6 +537,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
                 }
                 throw error
             }
+            unownedDownloadedAudioURL = downloadResult.audioFileURL
             onProgress?(.downloading(percent: 100))
             do {
                 try Task.checkCancellation()
@@ -586,6 +594,9 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
             if downloadResult.thumbnailURL == nil {
                 await cacheEmbeddedArtworkIfPresent(embeddedMetadata, for: transcription.id)
             }
+            if keepDownloadedAudio {
+                unownedDownloadedAudioURL = nil
+            }
             Telemetry.send(.transcriptionStarted(
                 source: .youtube,
                 audioDurationSeconds: downloadResult.durationSeconds.map(Double.init)
@@ -606,6 +617,9 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
             }
 
             onProgress?(.transcribing(percent: 0))
+            if !keepDownloadedAudio {
+                unownedDownloadedAudioURL = nil
+            }
             return try await transcribeAudio(
                 fileURL: downloadResult.audioFileURL,
                 source: .youtube,

--- a/Sources/MacParakeetCore/Services/VideoStreamService.swift
+++ b/Sources/MacParakeetCore/Services/VideoStreamService.swift
@@ -1,4 +1,3 @@
-import Darwin
 import Foundation
 import os
 
@@ -96,49 +95,17 @@ public final class VideoStreamService: Sendable {
         // pipe buffer), so reading after termination cannot deadlock. If we ever
         // wrap a yt-dlp invocation that produces large output, switch to
         // incremental drain via `FileHandle.bytes`.
-        let result: (stdout: Data, stderr: Data) = try await withThrowingTaskGroup(of: ProcessOutcome.self) { group in
-            defer {
-                group.cancelAll()
-                if process.isRunning {
-                    process.terminate()
-                    // SIGKILL fallback if SIGTERM doesn't take. Holding `process`
-                    // strongly via the closure keeps it alive until the dispatch
-                    // fires, even if every other reference has been released.
-                    let stuckProcess = process
-                    DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 2) {
-                        guard stuckProcess.isRunning else { return }
-                        kill(stuckProcess.processIdentifier, SIGKILL)
-                    }
-                }
-            }
-
-            group.addTask {
-                // Wait for process to exit (terminationHandler fires when SIGTERM
-                // or natural exit completes), then drain pipes synchronously —
-                // they're at EOF, so the reads return immediately.
-                await Self.awaitProcessTermination(process)
-                let stdoutData = (try? stdoutPipe.fileHandleForReading.readToEnd()) ?? Data()
-                let stderrData = (try? stderrPipe.fileHandleForReading.readToEnd()) ?? Data()
-                return .completed(stdout: stdoutData, stderr: stderrData)
-            }
-
-            group.addTask {
-                try await Task.sleep(for: .seconds(Self.extractionTimeout))
-                throw VideoStreamError.extractionFailed(
-                    "Stream extraction timed out after \(Int(Self.extractionTimeout))s"
-                )
-            }
-
-            // First task to complete wins — either extraction finishes or timeout fires.
-            // The timeout task throws; the completion task returns `.completed`.
-            let outcome = try await group.next()!
-            guard case .completed(let stdout, let stderr) = outcome else {
-                // Unreachable — only the completion task returns a value, and it
-                // always returns `.completed`. The timeout task throws.
-                throw VideoStreamError.extractionFailed("Internal error: unexpected outcome")
-            }
-            return (stdout: stdout, stderr: stderr)
-        }
+        try await ChildProcessWaiter.waitUntilExit(
+            process,
+            timeout: Self.extractionTimeout,
+            timeoutError: VideoStreamError.extractionFailed(
+                "Stream extraction timed out after \(Int(Self.extractionTimeout))s"
+            )
+        )
+        let result = (
+            stdout: (try? stdoutPipe.fileHandleForReading.readToEnd()) ?? Data(),
+            stderr: (try? stderrPipe.fileHandleForReading.readToEnd()) ?? Data()
+        )
 
         let elapsed = ContinuousClock.now - startTime
         logger.notice("video_stream_yt_dlp_finished elapsed=\(String(describing: elapsed), privacy: .public) exit=\(process.terminationStatus, privacy: .public)")
@@ -169,34 +136,6 @@ public final class VideoStreamService: Sendable {
 
     private static func sanitizedYtDlpMessage(_ raw: String) -> String {
         String(TelemetryErrorClassifier.sanitize(raw).prefix(512))
-    }
-
-    private enum ProcessOutcome: Sendable {
-        case completed(stdout: Data, stderr: Data)
-    }
-
-    /// Resume-once wrapper around `Process.terminationHandler`. Resumes
-    /// immediately if the process has already exited by the time the handler
-    /// is wired, and never double-resumes if the handler fires concurrently.
-    private static func awaitProcessTermination(_ process: Process) async {
-        let resumed = OSAllocatedUnfairLock(initialState: false)
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            process.terminationHandler = { _ in
-                let already = resumed.withLock { flag -> Bool in
-                    let was = flag; flag = true; return was
-                }
-                if !already { continuation.resume() }
-            }
-            if !process.isRunning {
-                let already = resumed.withLock { flag -> Bool in
-                    let was = flag; flag = true; return was
-                }
-                if !already {
-                    process.terminationHandler = nil
-                    continuation.resume()
-                }
-            }
-        }
     }
 
     private func resolveYtDlpPath() throws -> String {

--- a/Sources/MacParakeetCore/Services/YouTubeDownloader.swift
+++ b/Sources/MacParakeetCore/Services/YouTubeDownloader.swift
@@ -226,6 +226,12 @@ public actor YouTubeDownloader {
 
         let uuid = UUID().uuidString
         let outputTemplate = "\(tempDir)/\(uuid).%(ext)s"
+        var succeeded = false
+        defer {
+            if !succeeded {
+                Self.removeDownloadArtifacts(in: URL(fileURLWithPath: tempDir, isDirectory: true), uuid: uuid)
+            }
+        }
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: ytDlpPath)
@@ -308,7 +314,11 @@ public actor YouTubeDownloader {
         }
 
         try process.run()
-        try await waitForProcess(process, timeout: Self.downloadTimeout)
+        try await ChildProcessWaiter.waitUntilExit(
+            process,
+            timeout: Self.downloadTimeout,
+            timeoutError: YouTubeDownloadError.timedOut
+        )
 
         // Drain remaining data from both pipes
         let stdoutTail = stdoutHandle.readDataToEndOfFile()
@@ -342,7 +352,22 @@ public actor YouTubeDownloader {
             throw YouTubeDownloadError.downloadFailed("Downloaded file not found")
         }
 
+        succeeded = true
         return URL(fileURLWithPath: "\(tempDir)/\(downloadedFile)")
+    }
+
+    nonisolated static func removeDownloadArtifacts(in directory: URL, uuid: String) {
+        let fm = FileManager.default
+        guard let files = try? fm.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil
+        ) else {
+            return
+        }
+
+        for file in files where file.lastPathComponent.hasPrefix(uuid) {
+            try? fm.removeItem(at: file)
+        }
     }
 
     nonisolated static func selectDownloadedAudioFile(from fileNames: [String], uuid: String) -> String? {
@@ -604,7 +629,11 @@ public actor YouTubeDownloader {
         process.standardError = stderrHandle
 
         try process.run()
-        try await waitForProcess(process, timeout: 30)
+        try await ChildProcessWaiter.waitUntilExit(
+            process,
+            timeout: 30,
+            timeoutError: YouTubeDownloadError.timedOut
+        )
 
         stderrHandle.synchronizeFile()
         stdoutHandle?.synchronizeFile()
@@ -619,51 +648,6 @@ public actor YouTubeDownloader {
         )
     }
 
-    private func waitForProcess(_ process: Process, timeout: TimeInterval) async throws {
-        let resumed = OSAllocatedUnfairLock(initialState: false)
-        try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                process.terminationHandler = { _ in
-                    let shouldResume = resumed.withLock { done -> Bool in
-                        guard !done else { return false }
-                        done = true
-                        return true
-                    }
-                    if shouldResume {
-                        continuation.resume()
-                    }
-                }
-
-                DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
-                    let shouldResume = resumed.withLock { done -> Bool in
-                        guard !done else { return false }
-                        done = true
-                        return true
-                    }
-                    if shouldResume {
-                        process.terminate()
-                        continuation.resume(throwing: YouTubeDownloadError.timedOut)
-                    }
-                }
-
-                // Handle race: process may have exited before terminationHandler was set
-                if !process.isRunning {
-                    let shouldResume = resumed.withLock { done -> Bool in
-                        guard !done else { return false }
-                        done = true
-                        return true
-                    }
-                    if shouldResume {
-                        continuation.resume()
-                    }
-                }
-            }
-        } onCancel: {
-            process.terminate()
-        }
-
-        try Task.checkCancellation()
-    }
 }
 
 extension YouTubeDownloader: YouTubeDownloading {}

--- a/Sources/MacParakeetCore/Utilities/ChildProcessWaiter.swift
+++ b/Sources/MacParakeetCore/Utilities/ChildProcessWaiter.swift
@@ -3,97 +3,120 @@ import Foundation
 import os
 
 enum ChildProcessWaiter {
-    private enum Outcome: Sendable {
+    private enum WaitEvent: Sendable {
         case exited
         case timedOut
+        case cancelled
+    }
+
+    private struct WaitState {
+        var outcome: WaitEvent?
+        var continuation: CheckedContinuation<WaitEvent, Never>?
+    }
+
+    private final class ExitWaiter: @unchecked Sendable {
+        private let state = OSAllocatedUnfairLock(initialState: WaitState())
+
+        func install(_ continuation: CheckedContinuation<WaitEvent, Never>) -> WaitEvent? {
+            state.withLock { state in
+                if let outcome = state.outcome {
+                    return outcome
+                }
+                state.continuation = continuation
+                return nil
+            }
+        }
+
+        func resume(_ outcome: WaitEvent, process: Process) {
+            let result = state.withLock { state -> (completed: Bool, continuation: CheckedContinuation<WaitEvent, Never>?) in
+                guard state.outcome == nil else { return (false, nil) }
+                state.outcome = outcome
+                let continuation = state.continuation
+                state.continuation = nil
+                return (true, continuation)
+            }
+            guard result.completed else { return }
+            process.terminationHandler = nil
+            result.continuation?.resume(returning: outcome)
+        }
     }
 
     static func waitUntilExit(
         _ process: Process,
         timeout: TimeInterval,
         killGracePeriod: TimeInterval = 2,
+        killConfirmationTimeout: TimeInterval = 5,
         timeoutError: @autoclosure @escaping @Sendable () -> Error
     ) async throws {
-        do {
-            try await withTaskCancellationHandler {
-                try await waitUntilExitBody(
-                    process,
-                    timeout: timeout,
-                    killGracePeriod: killGracePeriod,
-                    timeoutError: timeoutError
-                )
-            } onCancel: {
-                terminate(process, killGracePeriod: killGracePeriod)
-            }
-        } catch is CancellationError {
+        let firstEvent = await awaitProcessEvent(
+            process,
+            timeout: timeout,
+            resumeOnCancellation: true
+        )
+
+        switch firstEvent {
+        case .exited:
+            try Task.checkCancellation()
+        case .timedOut:
             terminate(process, killGracePeriod: killGracePeriod)
-            await awaitProcessTermination(process)
+            _ = await awaitProcessEvent(
+                process,
+                timeout: killGracePeriod + killConfirmationTimeout,
+                resumeOnCancellation: false
+            )
+            throw timeoutError()
+        case .cancelled:
+            terminate(process, killGracePeriod: killGracePeriod)
+            _ = await awaitProcessEvent(
+                process,
+                timeout: killGracePeriod + killConfirmationTimeout,
+                resumeOnCancellation: false
+            )
             throw CancellationError()
         }
-
-        try Task.checkCancellation()
     }
 
-    private static func waitUntilExitBody(
+    private static func awaitProcessEvent(
         _ process: Process,
         timeout: TimeInterval,
-        killGracePeriod: TimeInterval,
-        timeoutError: @escaping @Sendable () -> Error
-    ) async throws {
-        try await withThrowingTaskGroup(of: Outcome.self) { group in
-            group.addTask {
-                await awaitProcessTermination(process)
-                return .exited
-            }
-            group.addTask {
-                try await Task.sleep(nanoseconds: nanoseconds(for: timeout))
-                return .timedOut
-            }
+        resumeOnCancellation: Bool
+    ) async -> WaitEvent {
+        let waiter = ExitWaiter()
+        let operation = {
+            await withCheckedContinuation { (continuation: CheckedContinuation<WaitEvent, Never>) in
+                process.terminationHandler = { _ in
+                    waiter.resume(.exited, process: process)
+                }
 
-            guard let first = try await group.next() else { return }
-            switch first {
-            case .exited:
-                group.cancelAll()
-                return
-            case .timedOut:
-                terminate(process, killGracePeriod: killGracePeriod)
-                while let outcome = try await group.next() {
-                    if case .exited = outcome {
-                        group.cancelAll()
-                        throw timeoutError()
+                if let outcome = waiter.install(continuation) {
+                    process.terminationHandler = nil
+                    continuation.resume(returning: outcome)
+                    return
+                }
+
+                if timeout <= 0 {
+                    waiter.resume(.timedOut, process: process)
+                } else {
+                    DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + timeout) {
+                        waiter.resume(.timedOut, process: process)
                     }
                 }
-                throw timeoutError()
-            }
-        }
-    }
 
-    private static func awaitProcessTermination(_ process: Process) async {
-        let resumed = OSAllocatedUnfairLock(initialState: false)
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            process.terminationHandler = { _ in
-                let shouldResume = resumed.withLock { done -> Bool in
-                    guard !done else { return false }
-                    done = true
-                    return true
-                }
-                if shouldResume {
-                    continuation.resume()
-                }
-            }
-
-            if !process.isRunning {
-                let shouldResume = resumed.withLock { done -> Bool in
-                    guard !done else { return false }
-                    done = true
-                    return true
-                }
-                if shouldResume {
-                    process.terminationHandler = nil
-                    continuation.resume()
+                if !process.isRunning {
+                    waiter.resume(.exited, process: process)
                 }
             }
         }
+
+        if resumeOnCancellation {
+            return await withTaskCancellationHandler {
+                await operation()
+            } onCancel: {
+                waiter.resume(.cancelled, process: process)
+            }
+        }
+
+        return await operation()
     }
 
     private static func terminate(_ process: Process, killGracePeriod: TimeInterval) {
@@ -105,12 +128,5 @@ enum ChildProcessWaiter {
             guard stuckProcess.isRunning else { return }
             kill(stuckProcess.processIdentifier, SIGKILL)
         }
-    }
-
-    private static func nanoseconds(for seconds: TimeInterval) -> UInt64 {
-        guard seconds > 0 else { return 0 }
-        let nanoseconds = seconds * 1_000_000_000
-        guard nanoseconds < Double(UInt64.max) else { return UInt64.max }
-        return UInt64(nanoseconds)
     }
 }

--- a/Sources/MacParakeetCore/Utilities/ChildProcessWaiter.swift
+++ b/Sources/MacParakeetCore/Utilities/ChildProcessWaiter.swift
@@ -1,0 +1,116 @@
+import Darwin
+import Foundation
+import os
+
+enum ChildProcessWaiter {
+    private enum Outcome: Sendable {
+        case exited
+        case timedOut
+    }
+
+    static func waitUntilExit(
+        _ process: Process,
+        timeout: TimeInterval,
+        killGracePeriod: TimeInterval = 2,
+        timeoutError: @autoclosure @escaping @Sendable () -> Error
+    ) async throws {
+        do {
+            try await withTaskCancellationHandler {
+                try await waitUntilExitBody(
+                    process,
+                    timeout: timeout,
+                    killGracePeriod: killGracePeriod,
+                    timeoutError: timeoutError
+                )
+            } onCancel: {
+                terminate(process, killGracePeriod: killGracePeriod)
+            }
+        } catch is CancellationError {
+            terminate(process, killGracePeriod: killGracePeriod)
+            await awaitProcessTermination(process)
+            throw CancellationError()
+        }
+
+        try Task.checkCancellation()
+    }
+
+    private static func waitUntilExitBody(
+        _ process: Process,
+        timeout: TimeInterval,
+        killGracePeriod: TimeInterval,
+        timeoutError: @escaping @Sendable () -> Error
+    ) async throws {
+        try await withThrowingTaskGroup(of: Outcome.self) { group in
+            group.addTask {
+                await awaitProcessTermination(process)
+                return .exited
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: nanoseconds(for: timeout))
+                return .timedOut
+            }
+
+            guard let first = try await group.next() else { return }
+            switch first {
+            case .exited:
+                group.cancelAll()
+                return
+            case .timedOut:
+                terminate(process, killGracePeriod: killGracePeriod)
+                while let outcome = try await group.next() {
+                    if case .exited = outcome {
+                        group.cancelAll()
+                        throw timeoutError()
+                    }
+                }
+                throw timeoutError()
+            }
+        }
+    }
+
+    private static func awaitProcessTermination(_ process: Process) async {
+        let resumed = OSAllocatedUnfairLock(initialState: false)
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            process.terminationHandler = { _ in
+                let shouldResume = resumed.withLock { done -> Bool in
+                    guard !done else { return false }
+                    done = true
+                    return true
+                }
+                if shouldResume {
+                    continuation.resume()
+                }
+            }
+
+            if !process.isRunning {
+                let shouldResume = resumed.withLock { done -> Bool in
+                    guard !done else { return false }
+                    done = true
+                    return true
+                }
+                if shouldResume {
+                    process.terminationHandler = nil
+                    continuation.resume()
+                }
+            }
+        }
+    }
+
+    private static func terminate(_ process: Process, killGracePeriod: TimeInterval) {
+        guard process.isRunning else { return }
+        process.terminate()
+
+        let stuckProcess = process
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + killGracePeriod) {
+            guard stuckProcess.isRunning else { return }
+            kill(stuckProcess.processIdentifier, SIGKILL)
+        }
+    }
+
+    private static func nanoseconds(for seconds: TimeInterval) -> UInt64 {
+        guard seconds > 0 else { return 0 }
+        let nanoseconds = seconds * 1_000_000_000
+        guard nanoseconds < Double(UInt64.max) else { return UInt64.max }
+        return UInt64(nanoseconds)
+    }
+}

--- a/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
@@ -180,9 +180,14 @@ public final class TranscriptionLibraryViewModel {
     public func deleteTranscription(_ transcription: Transcription) {
         do {
             errorMessage = nil
-            try TranscriptionDeletionCleanup.removeOwnedAssets(for: transcription)
             let deleted = try transcriptionRepo?.delete(id: transcription.id) ?? false
             guard deleted else { return }
+            do {
+                try TranscriptionDeletionCleanup.removeOwnedAssets(for: transcription)
+            } catch {
+                logger.warning("Deleted transcription but failed to remove owned assets: \(error.localizedDescription, privacy: .private)")
+                errorMessage = "Deleted transcription, but failed to remove stored audio: \(error.localizedDescription)"
+            }
             transcriptions.removeAll { $0.id == transcription.id }
             Telemetry.send(.transcriptionDeleted)
         } catch {

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -438,9 +438,14 @@ public final class TranscriptionViewModel {
         }
 
         do {
-            try TranscriptionDeletionCleanup.removeOwnedAssets(for: transcription)
             let deleted = try repo.delete(id: transcription.id)
             guard deleted else { return }
+            do {
+                try TranscriptionDeletionCleanup.removeOwnedAssets(for: transcription)
+            } catch {
+                logger.warning("Deleted transcription but failed to remove owned assets: \(error.localizedDescription, privacy: .private)")
+                errorMessage = "Deleted transcription, but failed to remove stored audio: \(error.localizedDescription)"
+            }
             Telemetry.send(.transcriptionDeleted)
             if currentTranscription?.id == transcription.id {
                 currentTranscription = nil

--- a/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
@@ -67,6 +67,24 @@ private actor FailingYouTubeDownloader: YouTubeDownloading {
     }
 }
 
+private final class SaveFailingTranscriptionRepository: TranscriptionRepositoryProtocol, @unchecked Sendable {
+    private let error: Error
+
+    init(error: Error) {
+        self.error = error
+    }
+
+    func save(_ transcription: Transcription) throws {
+        throw error
+    }
+
+    func fetch(id: UUID) throws -> Transcription? { nil }
+    func fetchAll(limit: Int?) throws -> [Transcription] { [] }
+    func delete(id: UUID) throws -> Bool { false }
+    func deleteAll() throws {}
+    func updateStatus(id: UUID, status: Transcription.TranscriptionStatus, errorMessage: String?) throws {}
+}
+
 private struct StubMediaMetadataExtractor: MediaMetadataExtracting {
     let metadata: MediaMetadata
 
@@ -588,6 +606,36 @@ final class TranscriptionServiceTests: XCTestCase {
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: downloadedURL.path))
         XCTAssertNil(result.filePath)
+    }
+
+    func testTranscribeURLDeletesDownloadedAudioWhenPersistenceFails() async throws {
+        struct SaveError: Error {}
+
+        let downloadedURL = try makeTempDownloadedAudio()
+        defer { try? FileManager.default.removeItem(at: downloadedURL) }
+
+        let downloader = MockYouTubeDownloader(result: YouTubeDownloader.DownloadResult(
+            audioFileURL: downloadedURL,
+            title: "Video",
+            durationSeconds: 120
+        ))
+
+        let service = TranscriptionService(
+            audioProcessor: mockAudio,
+            sttTranscriber: mockSTT,
+            transcriptionRepo: SaveFailingTranscriptionRepository(error: SaveError()),
+            shouldKeepDownloadedAudio: { true },
+            youtubeDownloader: downloader
+        )
+
+        do {
+            _ = try await service.transcribeURL(urlString: "https://youtu.be/dQw4w9WgXcQ")
+            XCTFail("Expected save failure")
+        } catch is SaveError {
+            XCTAssertFalse(FileManager.default.fileExists(atPath: downloadedURL.path))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
     }
 
     func testTranscribeURLForwardsDownloadProgressToPhaseCallback() async throws {

--- a/Tests/MacParakeetTests/Services/YouTubeDownloaderTests.swift
+++ b/Tests/MacParakeetTests/Services/YouTubeDownloaderTests.swift
@@ -90,6 +90,27 @@ final class YouTubeDownloaderTests: XCTestCase {
         ))
     }
 
+    func testRemoveDownloadArtifactsDeletesOnlyMatchingFiles() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macparakeet-ytdlp-cleanup-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let uuid = UUID().uuidString
+        let matchingAudio = directory.appendingPathComponent("\(uuid).m4a")
+        let matchingPartial = directory.appendingPathComponent("\(uuid).m4a.part")
+        let unrelated = directory.appendingPathComponent("\(UUID().uuidString).m4a")
+        try Data("audio".utf8).write(to: matchingAudio)
+        try Data("partial".utf8).write(to: matchingPartial)
+        try Data("other".utf8).write(to: unrelated)
+
+        YouTubeDownloader.removeDownloadArtifacts(in: directory, uuid: uuid)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: matchingAudio.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: matchingPartial.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: unrelated.path))
+    }
+
     // MARK: - DownloadResult Metadata Fields
 
     func testDownloadResultWithVideoMetadata() {

--- a/Tests/MacParakeetTests/Utilities/ChildProcessWaiterTests.swift
+++ b/Tests/MacParakeetTests/Utilities/ChildProcessWaiterTests.swift
@@ -1,0 +1,71 @@
+import Darwin
+import XCTest
+@testable import MacParakeetCore
+
+final class ChildProcessWaiterTests: XCTestCase {
+    private enum TestError: Error {
+        case timedOut
+    }
+
+    func testTimeoutWaitsForStubbornProcessToExit() async throws {
+        let process = stubbornShellProcess()
+        try process.run()
+        defer { killIfStillRunning(process) }
+
+        do {
+            try await ChildProcessWaiter.waitUntilExit(
+                process,
+                timeout: 0.05,
+                killGracePeriod: 0.05,
+                timeoutError: TestError.timedOut
+            )
+            XCTFail("Expected timeout")
+        } catch TestError.timedOut {
+            XCTAssertFalse(process.isRunning)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testCancellationWaitsForStubbornProcessToExit() async throws {
+        let process = stubbornShellProcess()
+        try process.run()
+        defer { killIfStillRunning(process) }
+
+        let task = Task {
+            try await ChildProcessWaiter.waitUntilExit(
+                process,
+                timeout: 60,
+                killGracePeriod: 0.05,
+                timeoutError: TestError.timedOut
+            )
+        }
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+        task.cancel()
+
+        do {
+            try await task.value
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {
+            XCTAssertFalse(process.isRunning)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    private func stubbornShellProcess() -> Process {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", "trap '' TERM; while true; do :; done"]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        return process
+    }
+
+    private func killIfStillRunning(_ process: Process) {
+        guard process.isRunning else { return }
+        kill(process.processIdentifier, SIGKILL)
+        process.waitUntilExit()
+    }
+}

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -454,7 +454,7 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: audioURL.path))
     }
 
-    func testDeleteYouTubeTranscriptionRemovesStoredAudioBeforeRepoDelete() throws {
+    func testDeleteFailureKeepsStoredAudioFile() throws {
         try AppPaths.ensureDirectories()
         let audioURL = URL(fileURLWithPath: AppPaths.youtubeDownloadsDir, isDirectory: true)
             .appendingPathComponent("yt-audio-\(UUID().uuidString).m4a")
@@ -476,7 +476,7 @@ final class TranscriptionViewModelTests: XCTestCase {
         viewModel.configure(transcriptionService: mockService, transcriptionRepo: mockRepo)
         viewModel.deleteTranscription(t)
 
-        XCTAssertFalse(FileManager.default.fileExists(atPath: audioURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: audioURL.path))
         XCTAssertEqual(viewModel.transcriptions.count, 1)
         XCTAssertNotNil(viewModel.errorMessage)
     }


### PR DESCRIPTION
## Summary
This hardens three lifecycle edges:

- child process timeout/cancel now waits for confirmed exit and escalates to SIGKILL if SIGTERM is ignored
- failed/cancelled YouTube downloads clean only files from that download attempt, and completed downloads are removed if persistence fails before the DB row owns them
- transcription deletes now remove the DB row before best-effort app-owned media cleanup, preserving media if the DB delete fails

## Flow
```text
yt-dlp / ffmpeg
      |
      v
timeout or cancel
      |
      v
   SIGTERM
      |
      +-- exited --> return
      |
      +-- still running after grace
              |
              v
           SIGKILL
              |
              v
   bounded confirmation
```

```text
delete transcription
      |
      v
delete DB row
      |
      +-- failed --> keep media + show error
      |
      +-- succeeded
              |
              v
       best-effort asset cleanup
```

## Validation
- GitHub CI `swift-test` passed on both checks
- Passed local Swift Testing suite: `swift test --disable-xctest --enable-swift-testing` (16 tests)
- Passed focused XCTest regressions for subprocess timeout/cancel, YouTube cleanup, persistence-failure cleanup, and delete failure media retention (7 tests)
- Ran the full direct XCTest bundle locally: 2,251 tests executed; only the existing meeting crash-recovery helper failed after the machine printed the unaccepted Xcode license prompt, which left its generated temp audio invalid. PR-specific tests passed in that run.