### PR TITLE
Add stt_runtime_unhealthy watchdog probe (detection only)

### DIFF
--- a/Sources/MacParakeetCore/STT/STTScheduler.swift
+++ b/Sources/MacParakeetCore/STT/STTScheduler.swift
@@ -43,6 +43,7 @@ public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEn
     private let logger = Logger(subsystem: "com.macparakeet.core", category: "STTScheduler")
     private let runtime: STTRuntimeProtocol
     private let meetingLiveChunkBacklogLimit: Int
+    private let runtimeOperationWatchdogTimeout: Duration
 
     private var enqueueCounter: UInt64 = 0
     private var continuations: [UUID: CheckedContinuation<STTResult, Error>] = [:]
@@ -57,20 +58,29 @@ public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEn
     /// - Parameter meetingLiveChunkBacklogLimit: Maximum pending live-preview chunks before the
     ///   oldest is dropped. 120 ≈ 4 minutes of dual-source 5-second chunks emitted every ~4
     ///   seconds, enough to absorb a prolonged dictation burst before preview starts dropping.
+    /// - Parameter runtimeOperationWatchdogTimeout: How long an STT runtime call (cancel-drain,
+    ///   model-cache clear, shutdown, engine swap) may take before we emit
+    ///   `stt_runtime_unhealthy` telemetry. Detection-only — no behavior changes; the caller
+    ///   continues to await regardless. 30 s is generous enough that legitimate slow operations
+    ///   on thermally throttled hardware should not trip it.
     public init(
         runtime: STTRuntime = STTRuntime(),
-        meetingLiveChunkBacklogLimit: Int = 120
+        meetingLiveChunkBacklogLimit: Int = 120,
+        runtimeOperationWatchdogTimeout: Duration = .seconds(30)
     ) {
         self.runtime = runtime as STTRuntimeProtocol
         self.meetingLiveChunkBacklogLimit = max(1, meetingLiveChunkBacklogLimit)
+        self.runtimeOperationWatchdogTimeout = runtimeOperationWatchdogTimeout
     }
 
     init(
         runtimeProvider: STTRuntimeProtocol,
-        meetingLiveChunkBacklogLimit: Int = 120
+        meetingLiveChunkBacklogLimit: Int = 120,
+        runtimeOperationWatchdogTimeout: Duration = .seconds(30)
     ) {
         self.runtime = runtimeProvider
         self.meetingLiveChunkBacklogLimit = max(1, meetingLiveChunkBacklogLimit)
+        self.runtimeOperationWatchdogTimeout = runtimeOperationWatchdogTimeout
     }
 
     public func transcribe(
@@ -152,12 +162,16 @@ public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEn
 
     public func clearModelCache() async {
         await quiesce(restoreAcceptsNewJobs: true)
-        await runtime.clearModelCache()
+        await observingRuntimeTimeout(reason: "clear_model_cache") {
+            await runtime.clearModelCache()
+        }
     }
 
     public func shutdown() async {
         await quiesce(restoreAcceptsNewJobs: false)
-        await runtime.shutdown()
+        await observingRuntimeTimeout(reason: "shutdown") {
+            await runtime.shutdown()
+        }
     }
 
     public func setSpeechEngine(_ preference: SpeechEnginePreference) async throws {
@@ -177,10 +191,12 @@ public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEn
             speechEngineSwitchTask = nil
             acceptsNewJobs = true
         }
-        try await withTaskCancellationHandler {
-            try await switchTask.value
-        } onCancel: {
-            switchTask.cancel()
+        try await observingRuntimeTimeoutThrowing(reason: "set_speech_engine") {
+            try await withTaskCancellationHandler {
+                try await switchTask.value
+            } onCancel: {
+                switchTask.cancel()
+            }
         }
     }
 
@@ -395,8 +411,51 @@ public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEn
             slotState.currentExecutionTask?.cancel()
             return slotState.currentWaitTask
         }
-        for task in waitTasks {
-            await task.value
+        guard !waitTasks.isEmpty else { return }
+        await observingRuntimeTimeout(reason: "cancel_drain") {
+            for task in waitTasks {
+                await task.value
+            }
+        }
+    }
+
+    /// Watchdog probe for an STT runtime call that may hang if the underlying
+    /// runtime (FluidAudio / WhisperKit) ignores cancellation. If `operation`
+    /// exceeds `runtimeOperationWatchdogTimeout`, emits
+    /// `stt_runtime_unhealthy` telemetry. The caller continues to await; this
+    /// is observability-only.
+    private func observingRuntimeTimeout<T>(
+        reason: String,
+        operation: () async -> T
+    ) async -> T {
+        let watchdog = Self.makeRuntimeWatchdog(
+            reason: reason,
+            timeout: runtimeOperationWatchdogTimeout
+        )
+        defer { watchdog.cancel() }
+        return await operation()
+    }
+
+    private func observingRuntimeTimeoutThrowing<T>(
+        reason: String,
+        operation: () async throws -> T
+    ) async throws -> T {
+        let watchdog = Self.makeRuntimeWatchdog(
+            reason: reason,
+            timeout: runtimeOperationWatchdogTimeout
+        )
+        defer { watchdog.cancel() }
+        return try await operation()
+    }
+
+    private nonisolated static func makeRuntimeWatchdog(
+        reason: String,
+        timeout: Duration
+    ) -> Task<Void, Never> {
+        Task.detached(priority: .background) {
+            try? await Task.sleep(for: timeout)
+            guard !Task.isCancelled else { return }
+            Telemetry.send(.sttRuntimeUnhealthy(reason: reason))
         }
     }
 }

--- a/Sources/MacParakeetCore/STT/STTScheduler.swift
+++ b/Sources/MacParakeetCore/STT/STTScheduler.swift
@@ -424,7 +424,7 @@ public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEn
     /// exceeds `runtimeOperationWatchdogTimeout`, emits
     /// `stt_runtime_unhealthy` telemetry. The caller continues to await; this
     /// is observability-only.
-    private func observingRuntimeTimeout<T>(
+    private func observingRuntimeTimeout<T: Sendable>(
         reason: String,
         operation: () async -> T
     ) async -> T {
@@ -436,7 +436,7 @@ public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEn
         return await operation()
     }
 
-    private func observingRuntimeTimeoutThrowing<T>(
+    private func observingRuntimeTimeoutThrowing<T: Sendable>(
         reason: String,
         operation: () async throws -> T
     ) async throws -> T {

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -89,6 +89,8 @@ public enum TelemetryEventName: String, Sendable, CaseIterable {
     case calendarAutoStartFailed = "calendar_auto_start_failed"
     case calendarAutoStopShown = "calendar_auto_stop_shown"
     case calendarAutoStopCancelled = "calendar_auto_stop_cancelled"
+    // STT runtime observability
+    case sttRuntimeUnhealthy = "stt_runtime_unhealthy"
     // Errors
     case errorOccurred = "error_occurred"
     // Crashes
@@ -495,6 +497,10 @@ public enum TelemetryEventSpec: Sendable {
     /// User extended past the calendar event's end time (suppressed
     /// auto-stop). Tells us how often the 30s lead is wrong.
     case calendarAutoStopCancelled
+    // STT runtime observability. Fires when an STT runtime call (cancel-drain,
+    // model-cache clear, shutdown, engine swap) exceeds the watchdog timeout.
+    // Detection-only; the caller continues to await as today.
+    case sttRuntimeUnhealthy(reason: String)
     // Errors
     case errorOccurred(domain: String, code: String, description: String)
     // Crashes
@@ -614,6 +620,7 @@ extension TelemetryEventSpec {
         case .calendarAutoStartFailed: return .calendarAutoStartFailed
         case .calendarAutoStopShown: return .calendarAutoStopShown
         case .calendarAutoStopCancelled: return .calendarAutoStopCancelled
+        case .sttRuntimeUnhealthy: return .sttRuntimeUnhealthy
         case .errorOccurred: return .errorOccurred
         case .crashOccurred: return .crashOccurred
         case .cliOperation: return .cliOperation
@@ -1079,6 +1086,8 @@ extension TelemetryEventSpec {
             return ["event_duration_seconds": Self.format(eventDurationSeconds)]
         case .calendarAutoStopCancelled:
             return nil
+        case .sttRuntimeUnhealthy(let reason):
+            return ["reason": reason]
         case .errorOccurred(let domain, let code, let description):
             // Defense in depth: sanitize() at the boundary so any caller route
             // (including future call sites that forget to run
@@ -1285,6 +1294,7 @@ public enum TelemetryImplementedContract {
         .calendarAutoStartFailed: ["reason"],
         .calendarAutoStopShown: ["event_duration_seconds"],
         .calendarAutoStopCancelled: [],
+        .sttRuntimeUnhealthy: ["reason"],
         .errorOccurred: ["domain", "code", "description"],
         .crashOccurred: ["crash_type", "signal", "name", "crash_ts", "crash_app_ver"],
         .cliOperation: ["operation_id", "command", "outcome", "duration_seconds"],

--- a/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
+++ b/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
@@ -497,6 +497,124 @@ final class STTSchedulerTests: XCTestCase {
             return try await group.next()!
         }
     }
+
+    // MARK: - Watchdog probe (stt_runtime_unhealthy telemetry)
+
+    func testWatchdogFiresWhenCancelDrainExceedsTimeout() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.setIgnoreCancellation(true)
+        await runtime.block(path: "wedge")
+
+        let spy = STTRuntimeUnhealthySpy()
+        Telemetry.configure(spy)
+        defer { Telemetry.configure(NoOpTelemetryService()) }
+
+        let scheduler = STTScheduler(
+            runtimeProvider: runtime,
+            meetingLiveChunkBacklogLimit: 8,
+            runtimeOperationWatchdogTimeout: .milliseconds(50)
+        )
+
+        let wedgedTask = Task {
+            try await scheduler.transcribe(audioPath: "wedge", job: .fileTranscription)
+        }
+        try await waitForStartedPaths(runtime: runtime, count: 1)
+
+        // clearModelCache calls quiesce → cancelAndDrainRunningJobs. The runtime
+        // ignores cancellation, so the drain blocks past the watchdog timeout
+        // and we expect a `cancel_drain` telemetry event.
+        let clearTask = Task { await scheduler.clearModelCache() }
+
+        try await waitForUnhealthyEvent(
+            spy: spy,
+            reason: "cancel_drain",
+            timeout: .seconds(2)
+        )
+
+        // Cleanup: unwedge the runtime so the in-flight call completes and the
+        // scheduler-level Task can return.
+        await runtime.forceReleaseAll()
+        await runtime.setIgnoreCancellation(false)
+        _ = try? await wedgedTask.value
+        _ = await clearTask.value
+    }
+
+    func testWatchdogStaysSilentOnHappyPath() async throws {
+        let runtime = MockSTTRuntime()
+
+        let spy = STTRuntimeUnhealthySpy()
+        Telemetry.configure(spy)
+        defer { Telemetry.configure(NoOpTelemetryService()) }
+
+        let scheduler = STTScheduler(
+            runtimeProvider: runtime,
+            meetingLiveChunkBacklogLimit: 8,
+            runtimeOperationWatchdogTimeout: .seconds(5)
+        )
+
+        // Normal lifecycle: idle scheduler, no in-flight jobs. clearModelCache
+        // and shutdown should both return well under the timeout, so the
+        // watchdog must not fire.
+        await scheduler.clearModelCache()
+        await scheduler.shutdown()
+
+        // Give any latent watchdog Task time to (incorrectly) fire — it
+        // shouldn't, but we want a positive assertion of silence.
+        try await Task.sleep(for: .milliseconds(100))
+
+        let unhealthyEvents = spy.unhealthyEvents()
+        XCTAssertTrue(
+            unhealthyEvents.isEmpty,
+            "Watchdog fired spuriously on happy path: \(unhealthyEvents)"
+        )
+    }
+
+    private func waitForUnhealthyEvent(
+        spy: STTRuntimeUnhealthySpy,
+        reason: String,
+        timeout: Duration
+    ) async throws {
+        let start = ContinuousClock.now
+        while !spy.unhealthyEvents().contains(where: { $0 == reason }) {
+            if start.duration(to: .now) > timeout {
+                XCTFail("Timed out waiting for stt_runtime_unhealthy reason=\(reason); saw=\(spy.unhealthyEvents())")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+    }
+}
+
+private final class STTRuntimeUnhealthySpy: TelemetryServiceProtocol, @unchecked Sendable {
+    private let lock = NSLock()
+    private var reasons: [String] = []
+
+    func send(_ event: TelemetryEventSpec) {
+        if case .sttRuntimeUnhealthy(let reason) = event {
+            lock.lock()
+            reasons.append(reason)
+            lock.unlock()
+        }
+    }
+
+    func sendAndFlush(_ event: TelemetryEventSpec) async -> Bool {
+        send(event)
+        return true
+    }
+
+    func flush() async {}
+    func clearQueue() {
+        lock.lock()
+        reasons.removeAll()
+        lock.unlock()
+    }
+    func flushForTermination() {}
+
+    func unhealthyEvents() -> [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return reasons
+    }
 }
 
 private enum STTSchedulerTestError: Error {
@@ -518,6 +636,7 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
     private var selection = SpeechEngineSelection(engine: .parakeet)
     private var ready = false
     private var shouldBlockNextSpeechEngineSwitch = false
+    private var ignoreCancellation = false
     private var speechEngineSwitchContinuation: CheckedContinuation<Void, Never>?
 
     func transcribe(
@@ -634,7 +753,25 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
         waitingContinuations.removeValue(forKey: path)?.resume(returning: ())
     }
 
+    /// When true, `cancelBlocked` becomes a no-op so a cancelled blocked
+    /// transcribe stays wedged. Lets us simulate a runtime that ignores
+    /// `Task.cancel()` for watchdog tests.
+    func setIgnoreCancellation(_ value: Bool) {
+        ignoreCancellation = value
+    }
+
+    /// Force-resume any held continuations regardless of `ignoreCancellation`.
+    /// Used by tests to clean up after a deliberately-wedged path.
+    func forceReleaseAll() {
+        for (path, continuation) in waitingContinuations {
+            blockedPaths.remove(path)
+            continuation.resume(throwing: CancellationError())
+        }
+        waitingContinuations.removeAll()
+    }
+
     private func cancelBlocked(path: String) {
+        guard !ignoreCancellation else { return }
         waitingContinuations.removeValue(forKey: path)?.resume(throwing: CancellationError())
     }
 


### PR DESCRIPTION
## Why this PR exists

We don't actually know if the STT runtime (FluidAudio for Parakeet, WhisperKit for Whisper) ever ignores cancellation in production. Closed PR #242 was a defensive fix for that scenario — but defending against an unobserved failure means paying real complexity cost (~500 LOC, sticky unhealthy state, refuse-new-work remediation) for a hypothetical benefit.

This PR ships **only the observability**, with zero behavior change. Over the next few weeks the data will tell us whether this is a real problem worth fixing, or speculative complexity we can delete entirely.

## What this PR does

Wraps the four STT runtime call sites that could hang if cancellation is ignored:

- `cancelAndDrainRunningJobs` (post-cancel drain)
- `runtime.clearModelCache()`
- `runtime.shutdown()`
- `runtime.setSpeechEngine()`

Each is wrapped with `observingRuntimeTimeout`, which spawns a detached watchdog `Task`. If the runtime call exceeds the timeout (default 30 s), the watchdog emits a `stt_runtime_unhealthy` telemetry event with a `reason` prop identifying which call site stalled.

```
                  ┌─────────────────────┐
                  │ STTScheduler caller │
                  └──────────┬──────────┘
                             │ await observingRuntimeTimeout
                             ▼
                  ┌─────────────────────┐
                  │  observingRuntime…  │
                  └──────────┬──────────┘
                             │
                       ┌─────┴───────┐
                       ▼             ▼
                 ┌──────────┐  ┌──────────────┐
                 │ runtime  │  │ 30s detached │
                 │ call     │  │ watchdog     │
                 └────┬─────┘  └──────┬───────┘
                      │               │
              caller waits      if still running
              indefinitely      at timeout: fire
              if wedged         stt_runtime_unhealthy
                                (reason: <site>)
                                — caller keeps waiting
```

## What this PR explicitly does NOT do

- ❌ No new error messages to users
- ❌ No \`runtimeUnhealthy\` state machine
- ❌ No \"must restart the app\" prompts
- ❌ No refusing new STT work after a wedge
- ❌ No behavior change at all

If the runtime really is wedged, the user experiences the same silent stuck state they would today — they restart the app and move on. We just record that it happened so we can decide whether to fix it.

## Decision rule

After ~4 weeks of production exposure:

- **Event fires regularly** → escalate to PR #242's full remediation design. We now know the problem is real.
- **Event never fires** → delete \`observingRuntimeTimeout\` and the four wraps. We saved ~500 LOC of speculative complexity.

## Test plan

- [x] Unit test: mock runtime ignores cancellation → watchdog fires \`cancel_drain\` (\`testWatchdogFiresWhenCancelDrainExceedsTimeout\`)
- [x] Unit test: normal mock runtime → no spurious telemetry on happy path (\`testWatchdogStaysSilentOnHappyPath\`)
- [x] \`swift test\` — 2345 tests pass, 10 skipped, 0 failures
- [ ] Stage check: confirm \`stt_runtime_unhealthy\` is allowlisted in \`macparakeet-website\` (companion PR — see below)

## Companion change (must deploy before merge)

\`stt_runtime_unhealthy\` must be added to \`ALLOWED_EVENTS\` in \`macparakeet-website/functions/api/telemetry.ts\` *before* this Swift PR ships, otherwise the Cloudflare Worker rejects entire telemetry batches that contain this event (silently dropping co-batched valid events).

Companion branch already pushed: [\`feat/telemetry-allowlist-stt-runtime-unhealthy\`](https://github.com/moona3k/macparakeet-website/tree/feat/telemetry-allowlist-stt-runtime-unhealthy) on \`macparakeet-website\`. Merge + deploy that first.

## Relationship to PR #242

Closed in favor of this PR. PR #242's full hardening design — sticky unhealthy state, exclusive-operation flags, fail-closed remediation — is the candidate response *if* the data here shows the failure mode is real. Until then, that complexity is overhead defending against a phantom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime operation watchdog to monitor speech recognition processes with configurable timeout (30 seconds default), emitting health diagnostics when operations exceed the threshold.

* **Tests**
  * Added test coverage for watchdog monitoring and telemetry behavior under normal and timeout scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moona3k/macparakeet/pull/246)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->