### PR TITLE
Polish pause UI: amber semantic + freeze panel rosette

### DIFF
--- a/Sources/MacParakeet/Views/MeetingRecording/LiveNotesPaneView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/LiveNotesPaneView.swift
@@ -21,6 +21,10 @@ struct LiveNotesPaneView: View {
     /// `/now` slash command to format the inserted timestamp. Defaults to
     /// 0 so previews and unit tests don't need to plumb it.
     var elapsedSeconds: Int = 0
+    /// Mirrors the parent panel's paused state. Forwarded to the
+    /// background watermark rosette so the seed-of-life freezes
+    /// alongside the pill rosette while the meeting is paused.
+    var isPaused: Bool = false
 
     @FocusState private var editorFocused: Bool
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -49,7 +53,7 @@ struct LiveNotesPaneView: View {
             // breathing seed-of-life centered behind the editor, fading to
             // a watermark the moment the user starts typing. Purely
             // decorative — never intercepts clicks or assistive focus.
-            BreathingSeedOfLifeView()
+            BreathingSeedOfLifeView(freeze: isPaused)
                 .opacity(viewModel.notesText.isEmpty ? 1.0 : 0.15)
                 .animation(.easeInOut(duration: 0.8), value: viewModel.notesText.isEmpty)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelView.swift
@@ -431,7 +431,18 @@ struct BreathingSeedOfLifeView: View {
         // Vestibular-sensitive users get a still seed-of-life — same shape,
         // color, and brand vocabulary, just no rotation or pulse.
         TimelineView(.animation(paused: freeze || reduceMotion)) { context in
-            let elapsed = context.date.timeIntervalSince(startDate) - accumulatedPause
+            // Live pause adjustment: SwiftUI's `.onChange(of: freeze)` fires
+            // AFTER `body`, which would otherwise leave one transitional frame
+            // on resume where `accumulatedPause` is stale and the rotation
+            // snap-jumps forward by the full pause duration. Reading
+            // `pauseStartDate` here folds the in-flight pause window into
+            // `elapsed` so the math is correct even before onChange runs.
+            let activePauseAdjustment: TimeInterval = pauseStartDate.map {
+                context.date.timeIntervalSince($0)
+            } ?? 0
+            let elapsed = context.date.timeIntervalSince(startDate)
+                - accumulatedPause
+                - activePauseAdjustment
 
             let rotationProgress = elapsed
                 .truncatingRemainder(dividingBy: rotationPeriod) / rotationPeriod

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelView.swift
@@ -472,6 +472,12 @@ struct BreathingSeedOfLifeView: View {
                 pauseStartDate = nil
             }
         }
+        .onAppear {
+            startDate = Date()
+            if freeze {
+                pauseStartDate = startDate
+            }
+        }
     }
 
     /// Triangle-wave eased between 0 and 1 over a full breathing cycle.

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelView.swift
@@ -37,7 +37,8 @@ struct MeetingRecordingPanelView: View {
         case .notes:
             LiveNotesPaneView(
                 viewModel: viewModel.notesViewModel,
-                elapsedSeconds: viewModel.elapsedSeconds
+                elapsedSeconds: viewModel.elapsedSeconds,
+                isPaused: viewModel.isPaused
             )
         case .transcript:
             transcriptContent
@@ -262,7 +263,7 @@ struct MeetingRecordingPanelView: View {
             // Flower of life — always present, fades to watermark when text appears
             VStack(spacing: DesignSystem.Spacing.md) {
                 if viewModel.canStop {
-                    BreathingSeedOfLifeView()
+                    BreathingSeedOfLifeView(freeze: viewModel.isPaused)
                         .opacity(hasContent ? 0.15 : 1.0)
                         .animation(.easeInOut(duration: 0.8), value: hasContent)
                 } else {
@@ -344,12 +345,19 @@ struct MeetingRecordingPanelView: View {
     private var statusDot: some View {
         switch viewModel.state {
         case .hidden, .recording:
-            // Paused dot uses dimmed success-green rather than tertiary
-            // text so it reads "active but quiet" (matches pill dimming),
-            // not "disabled". Same hue as recording, lower opacity.
+            // Recording: vivid success green. Paused: shifts to warning
+            // amber — the same color language used by the pause button on
+            // hover, the pill's hover-badge pause glyph, and universal
+            // "paused / hold" signals (broadcast indicators, traffic
+            // lights). 0.85 opacity keeps it slightly quieter than the
+            // recording dot — paused is a held-breath, not a shout.
             Circle()
-                .fill(DesignSystem.Colors.successGreen.opacity(viewModel.isPaused ? 0.35 : 1.0))
+                .fill(viewModel.isPaused
+                    ? DesignSystem.Colors.warningAmber.opacity(0.85)
+                    : DesignSystem.Colors.successGreen
+                )
                 .frame(width: 8, height: 8)
+                .animation(.easeInOut(duration: 0.2), value: viewModel.isPaused)
         case .transcribing:
             ProgressView()
                 .controlSize(.small)
@@ -386,54 +394,101 @@ private struct AskStreamingDot: View {
 /// A slowly rotating seed-of-life (1 center + 6 outer circles) for the
 /// empty listening state. Matches the flower head from the recording pill,
 /// without the stem. Also reused as the summary-generation loading indicator.
+///
+/// `freeze`: when `true`, the rotation and glow-breathing animations halt
+/// at their current frame. Used by meeting surfaces while a recording is
+/// paused so the panel rosette stops spinning to match the dimmed,
+/// non-animating pill rosette. Defaults to `false` so non-meeting consumers
+/// (AI streaming indicator, summary generation) are unaffected.
+///
+/// Implementation note: driven by `TimelineView(.animation(paused:))` rather
+/// than `withAnimation(.linear.repeatForever)` because freezing a
+/// `repeatForever` mid-cycle isn't reliably cancellable from outside the
+/// withAnimation scope. `TimelineView`'s `paused:` parameter halts frame
+/// requests cleanly; `accumulatedPause` is subtracted from elapsed time so
+/// the rotation continues smoothly from where it stopped instead of
+/// snapping forward by the pause duration.
 struct BreathingSeedOfLifeView: View {
+    var freeze: Bool = false
+
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var rotation: Double = 0
-    @State private var glowBreathing = false
+    @State private var startDate = Date()
+    @State private var pauseStartDate: Date?
+    @State private var accumulatedPause: TimeInterval = 0
 
     private let size: CGFloat = 140
     private let circleRadius: CGFloat = 28
     private let strokeColor = DesignSystem.Colors.accent
+    private let rotationPeriod: TimeInterval = 18
+    /// Half-cycle of the breathing pulse — full ease-in-out up takes
+    /// `breathingHalfPeriod` seconds, the same back down. Matches the
+    /// 3s-up / 3s-down feel of the original `easeInOut(duration: 3)
+    /// .repeatForever(autoreverses: true)` shape.
+    private let breathingHalfPeriod: TimeInterval = 3
 
     var body: some View {
-        ZStack {
-            // Center glow
-            Circle()
-                .fill(strokeColor.opacity(glowBreathing ? 0.5 : 0.2))
-                .frame(width: circleRadius * 2, height: circleRadius * 2)
-                .shadow(color: strokeColor.opacity(glowBreathing ? 0.4 : 0.15), radius: 12)
-                .scaleEffect(glowBreathing ? 1.2 : 0.9)
+        // Honor System Settings → Accessibility → Display → Reduce Motion.
+        // Vestibular-sensitive users get a still seed-of-life — same shape,
+        // color, and brand vocabulary, just no rotation or pulse.
+        TimelineView(.animation(paused: freeze || reduceMotion)) { context in
+            let elapsed = context.date.timeIntervalSince(startDate) - accumulatedPause
 
-            // Center circle
-            Circle()
-                .stroke(strokeColor.opacity(0.7), lineWidth: 1.2)
-                .frame(width: circleRadius * 2, height: circleRadius * 2)
+            let rotationProgress = elapsed
+                .truncatingRemainder(dividingBy: rotationPeriod) / rotationPeriod
+            let rotation = rotationProgress * 360
 
-            // 6 outer circles (seed of life)
-            ForEach(0..<6, id: \.self) { i in
+            let breathFactor = breathFactor(for: elapsed)
+            let glowOpacity = 0.2 + 0.3 * breathFactor          // 0.2 → 0.5
+            let glowShadowOpacity = 0.15 + 0.25 * breathFactor   // 0.15 → 0.4
+            let glowScale = 0.9 + 0.3 * breathFactor             // 0.9 → 1.2
+
+            ZStack {
                 Circle()
-                    .stroke(strokeColor.opacity(0.5), lineWidth: 1.2)
+                    .fill(strokeColor.opacity(glowOpacity))
                     .frame(width: circleRadius * 2, height: circleRadius * 2)
-                    .offset(x: circleRadius * CGFloat(cos(Double(i) * .pi / 3)),
-                            y: circleRadius * CGFloat(sin(Double(i) * .pi / 3)))
+                    .shadow(color: strokeColor.opacity(glowShadowOpacity), radius: 12)
+                    .scaleEffect(glowScale)
+
+                Circle()
+                    .stroke(strokeColor.opacity(0.7), lineWidth: 1.2)
+                    .frame(width: circleRadius * 2, height: circleRadius * 2)
+
+                ForEach(0..<6, id: \.self) { i in
+                    Circle()
+                        .stroke(strokeColor.opacity(0.5), lineWidth: 1.2)
+                        .frame(width: circleRadius * 2, height: circleRadius * 2)
+                        .offset(x: circleRadius * CGFloat(cos(Double(i) * .pi / 3)),
+                                y: circleRadius * CGFloat(sin(Double(i) * .pi / 3)))
+                }
+            }
+            .frame(width: size, height: size)
+            .rotationEffect(.degrees(reduceMotion ? 0 : rotation))
+        }
+        .onChange(of: freeze) { _, isFrozen in
+            if isFrozen {
+                pauseStartDate = Date()
+            } else if let pauseStart = pauseStartDate {
+                accumulatedPause += Date().timeIntervalSince(pauseStart)
+                pauseStartDate = nil
             }
         }
-        .frame(width: size, height: size)
-        .rotationEffect(.degrees(rotation))
-        .onAppear {
-            // Honor System Settings → Accessibility → Display → Reduce
-            // Motion. Vestibular-sensitive users get a still seed-of-life
-            // mark — same shape, color, and brand vocabulary, just no
-            // rotation or glow pulse. Matches the accommodation already
-            // applied to the slash-menu transition in LiveNotesPaneView.
-            guard !reduceMotion else { return }
-            withAnimation(.linear(duration: 18).repeatForever(autoreverses: false)) {
-                rotation = 360
-            }
-            withAnimation(.easeInOut(duration: 3).repeatForever(autoreverses: true)) {
-                glowBreathing = true
-            }
+    }
+
+    /// Triangle-wave eased between 0 and 1 over a full breathing cycle.
+    /// `0` collapses to the rest values (low opacity, 0.9 scale); `1` blooms
+    /// to the peak (higher opacity, 1.2 scale). Ease-in-out shape matches
+    /// the feel of SwiftUI's `easeInOut` curve.
+    private func breathFactor(for elapsed: TimeInterval) -> Double {
+        let cycle = breathingHalfPeriod * 2
+        let phase = elapsed.truncatingRemainder(dividingBy: cycle)
+        let t: Double
+        if phase < breathingHalfPeriod {
+            t = phase / breathingHalfPeriod
+        } else {
+            t = 1 - (phase - breathingHalfPeriod) / breathingHalfPeriod
         }
+        // Smoothstep: 3t² − 2t³ — ease-in-out.
+        return t * t * (3 - 2 * t)
     }
 }
 

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPillView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPillView.swift
@@ -211,9 +211,14 @@ struct MeetingRecordingPillView: View {
             if isHovered && viewModel.elapsedSeconds > 0 {
                 HStack(spacing: 5) {
                     if isPaused {
+                        // Amber pause glyph — same color the panel status
+                        // dot, pause button hover, and tile hover all use,
+                        // so paused state reads as one consistent signal
+                        // across every meeting surface.
                         Image(systemName: "pause.fill")
                             .font(.system(size: 8, weight: .bold))
-                            .foregroundStyle(.white.opacity(0.85))
+                            .foregroundStyle(DesignSystem.Colors.warningAmber)
+                            .shadow(color: DesignSystem.Colors.warningAmber.opacity(0.5), radius: 3)
                     } else {
                         Circle()
                             .fill(DesignSystem.Colors.recordingRed)

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingStopButton.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingStopButton.swift
@@ -112,6 +112,17 @@ struct StopRecordingButton: View {
 /// Same vertical footprint as `StopRecordingButton` so pause + stop sit side
 /// by side without reflowing the row. Single-click toggle (no countdown
 /// confirmation — pausing is recoverable, unlike stop).
+///
+/// Color semantic: hover lights up `warningAmber` for the glyph, ring tint,
+/// and shadow glow. Amber reads universally as "hold / paused" (traffic
+/// lights, broadcast indicators, voice-memo paused state) — distinct from
+/// the stop button's `errorRed` (destructive) and the recording orb's
+/// `successGreen` (alive). Idle uses `textSecondary` so pause sits one
+/// notch louder than the destructive stop's `textTertiary.opacity(0.6)`,
+/// reflecting that pause is the recoverable action of the pair. When
+/// already paused, the resume affordance bumps to `textPrimary.opacity(0.85)`
+/// so the "click to come back" cue is more prominent than the pause cue
+/// — paused is a held-breath state; resume is the exhale.
 struct PauseResumeButton: View {
     var isPaused: Bool
     var onToggle: () -> Void
@@ -120,27 +131,46 @@ struct PauseResumeButton: View {
 
     private static let trackHeight: CGFloat = 31
 
+    private var idleGlyphColor: Color {
+        // Resume affordance reads louder than pause affordance — once you've
+        // pressed pause, the next-step action should pull the eye back.
+        isPaused
+            ? DesignSystem.Colors.textPrimary.opacity(0.85)
+            : DesignSystem.Colors.textSecondary
+    }
+
     var body: some View {
         Button(action: onToggle) {
             Image(systemName: isPaused ? "play.fill" : "pause.fill")
                 .font(.system(size: 11, weight: .semibold))
                 .foregroundStyle(
                     isHovered
-                        ? DesignSystem.Colors.textPrimary
-                        : DesignSystem.Colors.textTertiary
+                        ? DesignSystem.Colors.warningAmber
+                        : idleGlyphColor
                 )
                 .frame(width: 13, height: 13)
                 .padding(9)
                 .background(
                     Circle()
-                        .fill(isHovered ? DesignSystem.Colors.surfaceElevated : DesignSystem.Colors.surfaceElevated.opacity(0.6))
+                        .fill(isHovered
+                            ? DesignSystem.Colors.warningAmber.opacity(0.15)
+                            : DesignSystem.Colors.surfaceElevated.opacity(0.6)
+                        )
                         .overlay(
                             Circle()
                                 .stroke(
-                                    isHovered ? DesignSystem.Colors.border.opacity(0.7) : .clear,
+                                    isHovered
+                                        ? DesignSystem.Colors.warningAmber.opacity(0.3)
+                                        : .clear,
                                     lineWidth: 0.5
                                 )
                         )
+                )
+                .shadow(
+                    color: isHovered
+                        ? DesignSystem.Colors.warningAmber.opacity(0.25)
+                        : .clear,
+                    radius: 6
                 )
                 .scaleEffect(isHovered ? 1.08 : 1.0)
                 .animation(.easeOut(duration: 0.15), value: isHovered)
@@ -149,7 +179,11 @@ struct PauseResumeButton: View {
         .buttonStyle(.plain)
         .frame(height: Self.trackHeight)
         .accessibilityLabel(isPaused ? "Resume recording" : "Pause recording")
-        .help(isPaused ? "Resume recording" : "Pause recording")
+        .help(
+            isPaused
+                ? "Resume recording"
+                : "Pause recording — audio resumes when you click play"
+        )
         .onHover { hovering in
             isHovered = hovering
         }

--- a/Sources/MacParakeet/Views/Transcription/MeetingRecordingTile.swift
+++ b/Sources/MacParakeet/Views/Transcription/MeetingRecordingTile.swift
@@ -377,11 +377,25 @@ struct MeetingRecordingTile: View {
 /// is recoverable). Sits to the left of the red Stop pill so the row reads
 /// "pause | stop" — the recoverable action first, the destructive action
 /// last. Outline-style (not filled) to keep stop the visual emphasis.
+///
+/// Hover lights up `warningAmber` (glyph + label + capsule tint + stroke) so
+/// the tile button speaks the same color language as the panel header
+/// `PauseResumeButton`. Idle stays neutral so the row doesn't shout while at
+/// rest; the amber only declares intent on cursor approach.
 private struct TilePauseResumeButton: View {
     var isPaused: Bool
     var onToggle: () -> Void
 
     @State private var isHovered = false
+
+    private var idleForeground: Color {
+        // Resume affordance is one notch brighter than pause to pull the eye
+        // back once the user has paused — same rationale as the panel
+        // PauseResumeButton.
+        isPaused
+            ? DesignSystem.Colors.textPrimary.opacity(0.9)
+            : DesignSystem.Colors.textSecondary
+    }
 
     var body: some View {
         Button(action: onToggle) {
@@ -393,19 +407,24 @@ private struct TilePauseResumeButton: View {
             }
             .foregroundStyle(
                 isHovered
-                    ? DesignSystem.Colors.textPrimary
-                    : DesignSystem.Colors.textSecondary
+                    ? DesignSystem.Colors.warningAmber
+                    : idleForeground
             )
             .padding(.horizontal, 12)
             .padding(.vertical, 7)
             .background(
                 Capsule()
                     .fill(isHovered
-                        ? DesignSystem.Colors.surfaceElevated
+                        ? DesignSystem.Colors.warningAmber.opacity(0.12)
                         : DesignSystem.Colors.surfaceElevated.opacity(0.7))
                     .overlay(
                         Capsule()
-                            .stroke(DesignSystem.Colors.border.opacity(isHovered ? 1.0 : 0.7), lineWidth: 0.6)
+                            .stroke(
+                                isHovered
+                                    ? DesignSystem.Colors.warningAmber.opacity(0.45)
+                                    : DesignSystem.Colors.border.opacity(0.7),
+                                lineWidth: 0.6
+                            )
                     )
             )
             .scaleEffect(isHovered ? 1.03 : 1.0)
@@ -414,7 +433,11 @@ private struct TilePauseResumeButton: View {
         }
         .buttonStyle(.plain)
         .onHover { isHovered = $0 }
-        .help(isPaused ? "Resume recording" : "Pause recording")
+        .help(
+            isPaused
+                ? "Resume recording"
+                : "Pause recording — audio resumes when you click play"
+        )
         .accessibilityLabel(isPaused ? "Resume recording" : "Pause recording")
     }
 }

--- a/Sources/MacParakeet/Views/Transcription/MeetingRecordingTile.swift
+++ b/Sources/MacParakeet/Views/Transcription/MeetingRecordingTile.swift
@@ -393,7 +393,7 @@ private struct TilePauseResumeButton: View {
         // back once the user has paused — same rationale as the panel
         // PauseResumeButton.
         isPaused
-            ? DesignSystem.Colors.textPrimary.opacity(0.9)
+            ? DesignSystem.Colors.textPrimary.opacity(0.85)
             : DesignSystem.Colors.textSecondary
     }
 


### PR DESCRIPTION
## Summary
Visual polish on top of the pause/resume feature from #245 (which closed #235). Closes the visual-hierarchy gap with the stop button and addresses inline feedback that the panel rosette kept spinning while paused.

## For users
- Hovering the pause button (panel header + Transcribe-tab tile) now lights up warm amber — distinct from stop's red and the recording orb's green, so the three states read as one consistent color language.
- The status dot turns amber while paused (was a dimmed green that read as "disabled"). The pill's hover badge picks up the same amber pause glyph, so paused state speaks with one voice across every meeting surface.
- The seed-of-life rosette behind the panel actually freezes while paused — and resumes from where it stopped instead of snapping forward by however long you were paused.
- Reduce Motion is still honored: the rosette stays still and amber tokens read cleanly in dark mode.

## Code touchpoints
- `MeetingRecordingPanelView.swift` — amber status dot; `BreathingSeedOfLifeView` rewritten on `TimelineView(.animation(paused:))` with accumulated-pause subtraction so resume is smooth.
- `MeetingRecordingStopButton.swift` — `PauseResumeButton` hover gains amber glyph/ring/glow; idle weights tuned (resume one notch louder than pause).
- `MeetingRecordingTile.swift` — matching amber hover on the Transcribe-tab tile.
- `MeetingRecordingPillView.swift` — amber pause glyph + halo on the hover badge.
- `LiveNotesPaneView.swift` — forwards `isPaused` to the watermark rosette.

Follow-up to #245. Refs #235.