### PR TITLE
Loosen pause-duration test margins so CI doesn't flake

### DIFF
--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
@@ -1274,14 +1274,18 @@ final class MeetingRecordingServiceTests: XCTestCase {
         // with `noAudioCaptured` on a clean session folder.
         try await Task.sleep(for: .milliseconds(50))
 
-        // Hold the recording in pause for 500ms so the accumulated paused
-        // duration is comfortably measurable even under CI load. Tighter
-        // budgets (200ms) flake on busy machines because Task.sleep can
-        // wake slightly early and the actor mailbox order around start
-        // adds ~50ms of pre-pause "active" time.
+        // Hold the recording in pause for 1s so the accumulated paused
+        // duration is comfortably measurable even under heavy CI load.
+        // The previous 500ms / 0.3s-slack combo flaked on GitHub macOS
+        // runners because the pre-pause buffer yield + actor mailbox
+        // drain can spike to ~220ms (only ~50-100ms locally) — that left
+        // negative margin against a wallclock of ~510ms minus 300ms slack.
+        // Doubling the pause and the slack keeps the proof strength
+        // ("at least 600ms of pause was carved out") while leaving 400ms
+        // of headroom for scheduler/actor jitter.
         let startedAt = Date()
         await service.pauseRecording()
-        try await Task.sleep(for: .milliseconds(500))
+        try await Task.sleep(for: .milliseconds(1000))
         await service.resumeRecording()
 
         let output = try await service.stopRecording()
@@ -1294,12 +1298,12 @@ final class MeetingRecordingServiceTests: XCTestCase {
             totalWallclock,
             "Paused interval must be subtracted from the persisted duration"
         )
-        // The pause was 500ms — assert at least 300ms was carved out
-        // (gives 200ms of headroom for scheduler jitter on top of the
-        // expected 200ms gap).
+        // The pause was 1000ms — assert at least 600ms was carved out
+        // (60% of the pause window), still proving subtraction happened
+        // while leaving CI-friendly headroom for pre-pause overhead.
         XCTAssertLessThan(
             output.durationSeconds,
-            totalWallclock - 0.3
+            totalWallclock - 0.6
         )
 
         await service.completeTranscription(for: output)
@@ -1325,9 +1329,12 @@ final class MeetingRecordingServiceTests: XCTestCase {
 
         let startedAt = Date()
         await service.pauseRecording()
-        try await Task.sleep(for: .milliseconds(500))
+        try await Task.sleep(for: .milliseconds(1000))
         // Stop without resuming — the in-flight pause must still be
-        // subtracted from the persisted duration.
+        // subtracted from the persisted duration. Pause is held 1s with
+        // 0.6s of carved-out slack — same CI-resilience math as the
+        // resume-sibling test above (see comment there for the rationale
+        // behind doubling from the original 500ms / 0.3s budget).
         let output = try await service.stopRecording()
         defer { try? FileManager.default.removeItem(at: output.folderURL) }
         let stoppedAt = Date()
@@ -1335,7 +1342,7 @@ final class MeetingRecordingServiceTests: XCTestCase {
 
         XCTAssertLessThan(
             output.durationSeconds,
-            totalWallclock - 0.3,
+            totalWallclock - 0.6,
             "Stopping while paused must still subtract the in-flight pause interval"
         )
 


### PR DESCRIPTION
## Summary

Fixes the CI failure on `main` introduced when #247 merged. The flaky test was actually shipped in #245 (the original pause feature's 9-agent-review cleanup commit `a1b6c7e6`); #247 didn't touch any service or test code, but it was the first merge afterward where the GitHub macOS runner happened to be slow enough to push the pre-pause overhead past the test's 200ms slack budget.

## Root cause

```
testStopRecordingWhilePausedSettlesOngoingPauseIntoDuration:
  XCTAssertLessThan failed: ("0.21773") is not less than ("0.21260")
  - Stopping while paused must still subtract the in-flight pause interval
```

Both tests measured `output.durationSeconds < totalWallclock - 0.3` with a 500ms pause sleep:

| | Component | Local | CI worst case |
|---|---|---|---|
| Pre-pause overhead | yield 80k-frame buffer + 50ms sleep + actor mailbox drain | ~50-100ms | ~220ms |
| Pause sleep | `Task.sleep(.milliseconds(500))` | 500ms | 500ms |
| Stop call | finalize + lock + flush | ~10-15ms | ~10-15ms |
| **wallclock** | | ~600ms | ~512ms |
| **threshold** (wallclock - 0.3) | | ~300ms | ~212ms |
| **actual durationSeconds** | (≈ pre-pause overhead, since pause subtracted) | ~80ms | ~218ms |

CI: 218 < 212 → fail by 6ms. Local: 80 < 300 → pass with 220ms of margin.

## Fix

Doubles both the pause sleep (`500 → 1000ms`) and the slack (`0.3 → 0.6`) in both tests. Proof strength is identical — each test still asserts that **60% of the pause window** was carved out of the persisted duration — but now the threshold leaves ~400ms of CI-friendly headroom for scheduler/actor jitter on top of the worst-case pre-pause overhead.

## Test plan

- [x] `swift test --filter testStopRecording` green locally
- [x] Stress-tested 5 consecutive iterations, all green
- [ ] CI green on this PR
- [ ] CI green on `main` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)