### PR TITLE
Harden dictation paste targeting

### DIFF
--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -99,6 +99,8 @@ final class DictationFlowCoordinator {
     private var currentDictation: Dictation?
     /// Ephemeral post-paste action from the text processing pipeline (e.g., simulate Return key).
     private var pendingPostPasteAction: KeyAction?
+    /// App captured when dictation starts, so paste delivery is not dependent on later focus churn.
+    private var pasteTargetForCurrentDictation: ClipboardPasteTarget?
     /// Error from the most recent entitlements check failure, consumed by presentEntitlementsAlert effect.
     private var lastEntitlementsError: Error?
     private var readyPillDismissDelayMs: Int {
@@ -208,6 +210,9 @@ final class DictationFlowCoordinator {
         trigger: TelemetryDictationTrigger = .hotkey
     ) {
         currentTrigger = trigger
+        if Self.shouldCapturePasteTarget(for: stateMachine.state) {
+            pasteTargetForCurrentDictation = Self.currentPasteTarget()
+        }
         sendEvent(.startRequested(mode: mode))
     }
 
@@ -420,6 +425,7 @@ final class DictationFlowCoordinator {
                 return
             }
             let transcript = dictation.cleanTranscript ?? dictation.rawTranscript
+            let pasteTarget = pasteTargetForCurrentDictation
             actionTask = Task { @MainActor in
                 // Brief pause so user sees the checkmark before paste
                 try? await Task.sleep(for: .milliseconds(200))
@@ -433,19 +439,20 @@ final class DictationFlowCoordinator {
                         // Action mode: no trailing space, action replaces the space role
                         let keystrokeFired = try await self.clipboardService.pasteTextWithAction(
                             transcript,
-                            postPasteAction: action
+                            postPasteAction: action,
+                            target: pasteTarget
                         )
                         if keystrokeFired {
                             Telemetry.send(.keystrokeSnippetFired(action: action.rawValue))
                         }
                     } else {
                         // Normal mode: trailing space as before
-                        try await self.clipboardService.pasteText(transcript + " ")
+                        try await self.clipboardService.pasteText(transcript + " ", target: pasteTarget)
                     }
                     guard !Task.isCancelled else { return }
 
                     // Save pastedToApp metadata
-                    if let pastedToApp = NSWorkspace.shared.frontmostApplication?.bundleIdentifier {
+                    if let pastedToApp = pasteTarget?.bundleIdentifier ?? NSWorkspace.shared.frontmostApplication?.bundleIdentifier {
                         self.currentDictation?.pastedToApp = pastedToApp
                         self.currentDictation?.updatedAt = Date()
                         if let d = self.currentDictation {
@@ -503,6 +510,7 @@ final class DictationFlowCoordinator {
             onHistoryReload()
             currentDictation = nil
             pendingPostPasteAction = nil
+            pasteTargetForCurrentDictation = nil
 
         // MARK: App integration
 
@@ -587,6 +595,7 @@ final class DictationFlowCoordinator {
             actionTask?.cancel()
             actionTask = nil
             pendingPostPasteAction = nil
+            pasteTargetForCurrentDictation = nil
         }
     }
 
@@ -611,6 +620,27 @@ final class DictationFlowCoordinator {
         case .escape: return .escape
         case .ui: return .ui
         }
+    }
+
+    private static func shouldCapturePasteTarget(for state: DictationFlowState) -> Bool {
+        switch state {
+        case .idle, .ready, .recording, .pendingStop:
+            return true
+        case .checkingEntitlements, .startingService, .processing, .cancelCountdown, .finishing:
+            return false
+        }
+    }
+
+    private static func currentPasteTarget() -> ClipboardPasteTarget? {
+        guard let app = NSWorkspace.shared.frontmostApplication else { return nil }
+        guard !app.isTerminated else { return nil }
+        guard app.processIdentifier != ProcessInfo.processInfo.processIdentifier else { return nil }
+        guard app.bundleIdentifier != Bundle.main.bundleIdentifier else { return nil }
+
+        return ClipboardPasteTarget(
+            processIdentifier: app.processIdentifier,
+            bundleIdentifier: app.bundleIdentifier
+        )
     }
 
     private func startRecordingTask(

--- a/Sources/MacParakeetCore/Services/System/ClipboardService.swift
+++ b/Sources/MacParakeetCore/Services/System/ClipboardService.swift
@@ -3,12 +3,35 @@ import Carbon
 import Foundation
 import OSLog
 
+public struct ClipboardPasteTarget: Sendable, Equatable {
+    public let processIdentifier: Int32
+    public let bundleIdentifier: String?
+
+    public init(processIdentifier: Int32, bundleIdentifier: String? = nil) {
+        self.processIdentifier = processIdentifier
+        self.bundleIdentifier = bundleIdentifier
+    }
+}
+
 public protocol ClipboardServiceProtocol: Sendable {
     func pasteText(_ text: String) async throws
+    func pasteText(_ text: String, target: ClipboardPasteTarget?) async throws
     /// Paste text then simulate a keystroke. Returns `true` if the keystroke was actually fired.
     func pasteTextWithAction(_ text: String, postPasteAction: KeyAction?) async throws -> Bool
+    func pasteTextWithAction(_ text: String, postPasteAction: KeyAction?, target: ClipboardPasteTarget?) async throws -> Bool
     @discardableResult
     func copyToClipboard(_ text: String) async -> Bool
+}
+
+public extension ClipboardServiceProtocol {
+    func pasteText(_ text: String, target: ClipboardPasteTarget?) async throws {
+        try await pasteText(text)
+    }
+
+    /// Paste text then simulate a keystroke. Returns `true` if the keystroke was actually fired.
+    func pasteTextWithAction(_ text: String, postPasteAction: KeyAction?, target: ClipboardPasteTarget?) async throws -> Bool {
+        try await pasteTextWithAction(text, postPasteAction: postPasteAction)
+    }
 }
 
 public enum ClipboardServiceError: LocalizedError {
@@ -16,6 +39,7 @@ public enum ClipboardServiceError: LocalizedError {
     case eventSourceUnavailable
     case eventCreationFailed
     case pasteboardWriteFailed
+    case targetApplicationUnavailable
 
     public var errorDescription: String? {
         switch self {
@@ -27,20 +51,22 @@ public enum ClipboardServiceError: LocalizedError {
             return "Paste automation unavailable (could not create keyboard events)."
         case .pasteboardWriteFailed:
             return "Paste automation unavailable (could not write transcript to the clipboard)."
+        case .targetApplicationUnavailable:
+            return "Paste automation unavailable (target app is no longer running)."
         }
     }
 }
 
 protocol ClipboardEventPosting {
     @MainActor
-    func simulatePaste(using pasteShortcutKeyResolver: PasteShortcutKeyResolver) throws
+    func simulatePaste(using pasteShortcutKeyResolver: PasteShortcutKeyResolver, target: ClipboardPasteTarget?) throws
     @MainActor
-    func simulateKeystroke(_ keyCode: UInt16) throws
+    func simulateKeystroke(_ keyCode: UInt16, target: ClipboardPasteTarget?) throws
 }
 
 struct CGClipboardEventPosting: ClipboardEventPosting {
     @MainActor
-    func simulatePaste(using pasteShortcutKeyResolver: PasteShortcutKeyResolver) throws {
+    func simulatePaste(using pasteShortcutKeyResolver: PasteShortcutKeyResolver, target: ClipboardPasteTarget?) throws {
         guard AXIsProcessTrusted() else {
             throw ClipboardServiceError.accessibilityPermissionRequired
         }
@@ -58,14 +84,13 @@ struct CGClipboardEventPosting: ClipboardEventPosting {
         }
 
         keyDown.flags = .maskCommand
-        keyDown.post(tap: .cghidEventTap)
-
         keyUp.flags = .maskCommand
-        keyUp.post(tap: .cghidEventTap)
+
+        try post(keyDown: keyDown, keyUp: keyUp, target: target)
     }
 
     @MainActor
-    func simulateKeystroke(_ keyCode: UInt16) throws {
+    func simulateKeystroke(_ keyCode: UInt16, target: ClipboardPasteTarget?) throws {
         guard AXIsProcessTrusted() else {
             throw ClipboardServiceError.accessibilityPermissionRequired
         }
@@ -82,8 +107,29 @@ struct CGClipboardEventPosting: ClipboardEventPosting {
         keyDown.flags = []
         keyUp.flags = []
 
-        keyDown.post(tap: .cghidEventTap)
-        keyUp.post(tap: .cghidEventTap)
+        try post(keyDown: keyDown, keyUp: keyUp, target: target)
+    }
+
+    @MainActor
+    private func post(keyDown: CGEvent, keyUp: CGEvent, target: ClipboardPasteTarget?) throws {
+        guard let target, target.processIdentifier > 0 else {
+            keyDown.post(tap: .cghidEventTap)
+            keyUp.post(tap: .cghidEventTap)
+            return
+        }
+
+        let processIdentifier = pid_t(target.processIdentifier)
+        guard let app = NSRunningApplication(processIdentifier: processIdentifier), !app.isTerminated else {
+            throw ClipboardServiceError.targetApplicationUnavailable
+        }
+        if let expectedBundleIdentifier = target.bundleIdentifier,
+           app.bundleIdentifier != expectedBundleIdentifier {
+            throw ClipboardServiceError.targetApplicationUnavailable
+        }
+
+        _ = app.activate(options: [.activateAllWindows])
+        keyDown.postToPid(processIdentifier)
+        keyUp.postToPid(processIdentifier)
     }
 }
 
@@ -252,6 +298,10 @@ public final class ClipboardService: ClipboardServiceProtocol {
     /// 3. Simulating Cmd+V
     /// 4. Restoring original clipboard after a delay long enough for slow paste targets
     public func pasteText(_ text: String) async throws {
+        try await pasteText(text, target: nil)
+    }
+
+    public func pasteText(_ text: String, target: ClipboardPasteTarget?) async throws {
         let restoreDelay = clipboardRestoreDelay
 
         // 1. Save current clipboard contents
@@ -283,7 +333,7 @@ public final class ClipboardService: ClipboardServiceProtocol {
         )
 
         // 3. Simulate Cmd+V
-        try eventPosting.simulatePaste(using: pasteShortcutKeyResolver)
+        try eventPosting.simulatePaste(using: pasteShortcutKeyResolver, target: target)
     }
 
     /// Copy text to clipboard without paste simulation
@@ -310,26 +360,31 @@ public final class ClipboardService: ClipboardServiceProtocol {
 
     @discardableResult
     public func pasteTextWithAction(_ text: String, postPasteAction: KeyAction?) async throws -> Bool {
+        try await pasteTextWithAction(text, postPasteAction: postPasteAction, target: nil)
+    }
+
+    @discardableResult
+    public func pasteTextWithAction(_ text: String, postPasteAction: KeyAction?, target: ClipboardPasteTarget?) async throws -> Bool {
         guard let action = postPasteAction else {
-            try await pasteText(text)
+            try await pasteText(text, target: target)
             return false
         }
 
         // If text is empty (trigger was entire dictation), skip paste — just fire keystroke
         if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            try eventPosting.simulateKeystroke(action.keyCode)
+            try eventPosting.simulateKeystroke(action.keyCode, target: target)
             return true
         }
 
         // Paste text (no trailing space — action replaces the role of the space)
-        try await pasteText(text)
+        try await pasteText(text, target: target)
 
         // After paste succeeds, the keystroke phase is entirely non-fatal.
         // Task.sleep can throw CancellationError — catch it alongside keystroke errors
         // so cancellation during the 200ms delay doesn't surface as a paste failure.
         do {
             try await Task.sleep(for: .milliseconds(200))
-            try eventPosting.simulateKeystroke(action.keyCode)
+            try eventPosting.simulateKeystroke(action.keyCode, target: target)
             return true
         } catch is CancellationError {
             logger.notice("Post-paste keystroke skipped (task cancelled after paste succeeded)")

--- a/Tests/MacParakeetTests/Services/System/ClipboardServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/System/ClipboardServiceTests.swift
@@ -19,6 +19,13 @@ final class ClipboardServiceTests: XCTestCase {
         )
     }
 
+    func testTargetApplicationUnavailableHasActionableDescription() {
+        XCTAssertEqual(
+            ClipboardServiceError.targetApplicationUnavailable.errorDescription,
+            "Paste automation unavailable (target app is no longer running)."
+        )
+    }
+
     func testPasteTextWriteFailureRestoresClipboardAndDoesNotPostPaste() async throws {
         let pasteboard = makeScratchPasteboard()
         defer { pasteboard.releaseGlobally() }
@@ -72,6 +79,46 @@ final class ClipboardServiceTests: XCTestCase {
         try await waitForPasteboardString("original", on: pasteboard)
 
         XCTAssertEqual(pasteboard.string(forType: .string), "original")
+    }
+
+    func testPasteTextPostsPasteToTargetProcess() async throws {
+        let pasteboard = makeScratchPasteboard()
+        defer { pasteboard.releaseGlobally() }
+        replacePasteboard(pasteboard, with: "original")
+
+        let target = ClipboardPasteTarget(processIdentifier: 12345, bundleIdentifier: "com.example.Editor")
+        var pasteTargets: [ClipboardPasteTarget?] = []
+        let service = ClipboardService(
+            pasteboard: pasteboard,
+            eventPosting: RecordingClipboardEventPosting(
+                onPasteTarget: { target in
+                    pasteTargets.append(target)
+                }
+            ),
+            clipboardRestoreDelay: Self.shortRestoreDelay
+        )
+
+        try await service.pasteText("dictation", target: target)
+
+        XCTAssertEqual(pasteTargets, [target])
+    }
+
+    func testTargetedProtocolDefaultsPreserveLegacyConformers() async throws {
+        let legacyService = LegacyClipboardService()
+        let service: ClipboardServiceProtocol = legacyService
+        let target = ClipboardPasteTarget(processIdentifier: 12345, bundleIdentifier: "com.example.Editor")
+
+        try await service.pasteText("dictation", target: target)
+        let fired = try await service.pasteTextWithAction(
+            "send it",
+            postPasteAction: .returnKey,
+            target: target
+        )
+
+        let snapshot = await legacyService.snapshot()
+        XCTAssertEqual(snapshot.pastedTexts, ["dictation", "send it"])
+        XCTAssertEqual(snapshot.postPasteActions, [.returnKey])
+        XCTAssertTrue(fired)
     }
 
     func testOverlappingPasteTextRestoresPreExistingClipboard() async throws {
@@ -152,6 +199,46 @@ final class ClipboardServiceTests: XCTestCase {
         XCTAssertTrue(fired)
         XCTAssertEqual(pastedStrings, ["dictation"])
         XCTAssertEqual(keystrokes, [KeyAction.returnKey.keyCode])
+
+        try await waitForPasteboardString("original", on: pasteboard)
+    }
+
+    func testPasteTextWithActionPostsPasteAndKeystrokeToTargetProcess() async throws {
+        let pasteboard = makeScratchPasteboard()
+        defer { pasteboard.releaseGlobally() }
+        replacePasteboard(pasteboard, with: "original")
+
+        let target = ClipboardPasteTarget(processIdentifier: 12345, bundleIdentifier: "com.example.Editor")
+        var pastedStrings: [String] = []
+        var pasteTargets: [ClipboardPasteTarget?] = []
+        var keystrokes: [UInt16] = []
+        var keystrokeTargets: [ClipboardPasteTarget?] = []
+        let service = ClipboardService(
+            pasteboard: pasteboard,
+            eventPosting: RecordingClipboardEventPosting(
+                onPasteTarget: { target in
+                    pastedStrings.append(pasteboard.string(forType: .string) ?? "")
+                    pasteTargets.append(target)
+                },
+                onKeystrokeTarget: { keyCode, target in
+                    keystrokes.append(keyCode)
+                    keystrokeTargets.append(target)
+                }
+            ),
+            clipboardRestoreDelay: Self.shortRestoreDelay
+        )
+
+        let fired = try await service.pasteTextWithAction(
+            "dictation",
+            postPasteAction: .returnKey,
+            target: target
+        )
+
+        XCTAssertTrue(fired)
+        XCTAssertEqual(pastedStrings, ["dictation"])
+        XCTAssertEqual(pasteTargets, [target])
+        XCTAssertEqual(keystrokes, [KeyAction.returnKey.keyCode])
+        XCTAssertEqual(keystrokeTargets, [target])
 
         try await waitForPasteboardString("original", on: pasteboard)
     }
@@ -302,22 +389,55 @@ final class ClipboardServiceTests: XCTestCase {
 
 @MainActor
 private final class RecordingClipboardEventPosting: ClipboardEventPosting {
-    private let onPaste: @MainActor () throws -> Void
-    private let onKeystroke: @MainActor (UInt16) throws -> Void
+    private let onPaste: @MainActor (ClipboardPasteTarget?) throws -> Void
+    private let onKeystroke: @MainActor (UInt16, ClipboardPasteTarget?) throws -> Void
 
     init(
         onPaste: @escaping @MainActor () throws -> Void = {},
         onKeystroke: @escaping @MainActor (UInt16) throws -> Void = { _ in }
     ) {
-        self.onPaste = onPaste
-        self.onKeystroke = onKeystroke
+        self.onPaste = { _ in try onPaste() }
+        self.onKeystroke = { keyCode, _ in try onKeystroke(keyCode) }
     }
 
-    func simulatePaste(using pasteShortcutKeyResolver: PasteShortcutKeyResolver) throws {
-        try onPaste()
+    init(
+        onPasteTarget: @escaping @MainActor (ClipboardPasteTarget?) throws -> Void,
+        onKeystrokeTarget: @escaping @MainActor (UInt16, ClipboardPasteTarget?) throws -> Void = { _, _ in }
+    ) {
+        self.onPaste = onPasteTarget
+        self.onKeystroke = onKeystrokeTarget
     }
 
-    func simulateKeystroke(_ keyCode: UInt16) throws {
-        try onKeystroke(keyCode)
+    func simulatePaste(using pasteShortcutKeyResolver: PasteShortcutKeyResolver, target: ClipboardPasteTarget?) throws {
+        try onPaste(target)
+    }
+
+    func simulateKeystroke(_ keyCode: UInt16, target: ClipboardPasteTarget?) throws {
+        try onKeystroke(keyCode, target)
+    }
+}
+
+private actor LegacyClipboardService: ClipboardServiceProtocol {
+    private var pastedTexts: [String] = []
+    private var postPasteActions: [KeyAction?] = []
+    private var copiedTexts: [String] = []
+
+    func pasteText(_ text: String) async throws {
+        pastedTexts.append(text)
+    }
+
+    func pasteTextWithAction(_ text: String, postPasteAction: KeyAction?) async throws -> Bool {
+        pastedTexts.append(text)
+        postPasteActions.append(postPasteAction)
+        return postPasteAction != nil
+    }
+
+    func copyToClipboard(_ text: String) async -> Bool {
+        copiedTexts.append(text)
+        return true
+    }
+
+    func snapshot() -> (pastedTexts: [String], postPasteActions: [KeyAction?], copiedTexts: [String]) {
+        (pastedTexts, postPasteActions, copiedTexts)
     }
 }

--- a/Tests/MacParakeetTests/Services/System/MockClipboardService.swift
+++ b/Tests/MacParakeetTests/Services/System/MockClipboardService.swift
@@ -5,18 +5,28 @@ public actor MockClipboardService: ClipboardServiceProtocol {
     public var lastPastedText: String?
     public var lastCopiedText: String?
     public var lastPostPasteAction: KeyAction?
+    public var lastPasteTarget: ClipboardPasteTarget?
     public var pasteCallCount = 0
 
     public init() {}
 
     public func pasteText(_ text: String) async throws {
+        try await pasteText(text, target: nil)
+    }
+
+    public func pasteText(_ text: String, target: ClipboardPasteTarget?) async throws {
         lastPastedText = text
+        lastPasteTarget = target
         pasteCallCount += 1
     }
 
     public func pasteTextWithAction(_ text: String, postPasteAction: KeyAction?) async throws -> Bool {
+        try await pasteTextWithAction(text, postPasteAction: postPasteAction, target: nil)
+    }
+
+    public func pasteTextWithAction(_ text: String, postPasteAction: KeyAction?, target: ClipboardPasteTarget?) async throws -> Bool {
         lastPostPasteAction = postPasteAction
-        try await pasteText(text)
+        try await pasteText(text, target: target)
         return postPasteAction != nil
     }
 

--- a/plans/active/2026-05-voice-command-agent-mode.md
+++ b/plans/active/2026-05-voice-command-agent-mode.md
@@ -1,0 +1,72 @@
+# Voice Command and Agent Mode Exploration
+
+Status: **PROPOSED**
+Owner: Core app team
+Updated: 2026-05-10
+
+## Objective
+
+Explore a future mode where spoken intent can trigger app actions, selected-text
+rewrites, or constrained agent workflows without weakening MacParakeet's
+local-first dictation reliability.
+
+This is intentionally separate from the paste hardening work. The immediate PR
+should improve text delivery by targeting the app captured at dictation start.
+Command/agent behavior needs a separate safety and product pass.
+
+## Product Thesis
+
+MacParakeet should stay excellent at plain dictation first. Voice command or
+agent behavior is only worth shipping when it feels predictable:
+
+1. normal speech inserts text
+2. command speech is opt-in and visually distinct
+3. actions run only against the intended target app or an explicit MacParakeet tool
+4. failure never causes wrong-target paste, data loss, or hidden automation
+
+## Candidate Capabilities
+
+1. selected-text rewrite, building on the completed command-mode F10a plan
+2. app-local actions such as press return, tab, escape, or submit after dictation
+3. structured commands such as "summarize this selection" or "make this friendlier"
+4. agent handoff for explicit tasks such as "turn this note into todos"
+5. workflow macros with clear previews and confirmation before irreversible actions
+
+## Safety Requirements
+
+1. no arbitrary shell, network, file, or app automation by default
+2. explicit confirmation before destructive or externally visible actions
+3. allowlisted tools with typed arguments instead of free-form execution
+4. clear mode boundary so plain dictation cannot accidentally become a command
+5. no audio, transcript, selected text, or prompt content in telemetry
+6. failure buckets should be structural only, such as permission denied, no selection,
+   unsupported app, target changed, or action cancelled
+
+## Architecture Notes
+
+1. build on hardened clipboard delivery:
+   - capture target process at command start
+   - use PID-targeted paste/action delivery
+   - preserve full pasteboard item snapshot/restore
+2. reuse command-mode de-risk work in
+   `plans/completed/2026-02-command-mode-f10a-de-risk-plan.md`
+3. keep command orchestration outside SwiftUI views
+4. keep Core APIs typed and testable; UI should only present state and confirmation
+5. prefer selected-text and paste replacement contracts before broader app automation
+
+## Open Questions
+
+1. Should command mode be a separate hotkey/chord or inferred from language?
+2. Should agent actions require a preview every time, or only for risky actions?
+3. Which apps are in the first manual reliability matrix?
+4. Is an LLM provider required, optional, or local-only for the first version?
+5. What is the minimum useful command set that does not compromise dictation UX?
+
+## First De-Risk Slice
+
+1. implement target-captured paste delivery for dictation
+2. manually test paste delivery across TextEdit, Notes, Slack, Safari textareas,
+   Chrome, VS Code, Cursor, Terminal, and Messages
+3. document unsupported or flaky target classes
+4. only then revisit direct insertion, menu paste fallback, and insertion verification
+5. start command/agent prototyping after the paste path has evidence across real apps


### PR DESCRIPTION
## Summary
- Capture the frontmost app when dictation starts and paste back to that PID.
- Send post-paste actions to the same target when available.
- Keep the existing pasteboard snapshot/restore and copy fallback behavior.
- Add a planning note for future voice command and agent-mode work.

## Flow
```text
Before:
  dictation stops
        |
        v
  wait + global Cmd+V
        |
        v
  app focused at paste time

After:
  dictation starts
        |
        v
  capture target PID + bundle
        |
        v
  dictation stops
        |
        v
  write temp clipboard -> Cmd+V to PID
        |
        +--> target gone/mismatch: fail safely + copy fallback
```

## Why
This removes the fragile dependency on whichever app is frontmost at paste time, while preserving MacParakeet's clipboard restore safety.

## Validation
- `swift test --filter ClipboardServiceTests`
- `swift test`
