### PR TITLE
[codex] Fix release readiness blockers

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -80,6 +80,8 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ## [Unreleased]
 
+## [2.1.0] -- 2026-05-10
+
 ### Added
 
 - `transcribe --youtube-audio-quality app-default|m4a|best-available`

--- a/Sources/CLI/Commands/HistoryCommand.swift
+++ b/Sources/CLI/Commands/HistoryCommand.swift
@@ -312,14 +312,10 @@ struct DeleteTranscriptionSubcommand: ParsableCommand {
         let repo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
 
         let transcription = try findTranscription(id: id, repo: repo)
+        try TranscriptionAssetCleanup.removeOwnedAssets(for: transcription)
         let deleted = try repo.delete(id: transcription.id)
         guard deleted else {
             throw CLILookupError.notFound("No transcription matching '\(id)'")
-        }
-        do {
-            try TranscriptionAssetCleanup.removeOwnedAssets(for: transcription)
-        } catch {
-            fputs("Warning: deleted database row but could not remove stored audio: \(error.localizedDescription)\n", stderr)
         }
         print("Deleted transcription: \"\(transcription.fileName)\"")
     }

--- a/Sources/CLI/MacParakeetCLI.swift
+++ b/Sources/CLI/MacParakeetCLI.swift
@@ -8,7 +8,7 @@ struct CLI: AsyncParsableCommand {
     /// distinguishable from synthesized Bundle.main values (the bare executable
     /// has no Info.plist and macOS otherwise reports an SDK marker like "16.0").
     /// Bump in lockstep with `Sources/CLI/CHANGELOG.md`.
-    static let cliVersion = "2.0.0"
+    static let cliVersion = "2.1.0"
 
     static let configuration = CommandConfiguration(
         commandName: "macparakeet-cli",

--- a/Sources/MacParakeetCore/Database/TranscriptionRepository.swift
+++ b/Sources/MacParakeetCore/Database/TranscriptionRepository.swift
@@ -49,12 +49,9 @@ extension TranscriptionRepositoryProtocol {
         }
         if let searchText = query.searchText?.trimmingCharacters(in: .whitespacesAndNewlines),
            !searchText.isEmpty {
-            let lowered = searchText.lowercased()
+            let normalizedQuery = UnicodeSearch.makeKey(searchText)
             results = results.filter { transcription in
-                transcription.fileName.lowercased().contains(lowered)
-                    || (transcription.rawTranscript?.lowercased().contains(lowered) ?? false)
-                    || (transcription.cleanTranscript?.lowercased().contains(lowered) ?? false)
-                    || (transcription.channelName?.lowercased().contains(lowered) ?? false)
+                transcriptionMatchesLibrarySearch(transcription, normalizedQuery: normalizedQuery)
             }
         }
 
@@ -139,16 +136,15 @@ public final class TranscriptionRepository: TranscriptionRepositoryProtocol {
             }
             if let searchText = query.searchText?.trimmingCharacters(in: .whitespacesAndNewlines),
                !searchText.isEmpty {
-                let pattern = "%\(escapedLikePattern(searchText))%"
-                whereClauses.append("""
-                    (
-                        fileName LIKE ? ESCAPE '\\'
-                        OR rawTranscript LIKE ? ESCAPE '\\'
-                        OR cleanTranscript LIKE ? ESCAPE '\\'
-                        OR channelName LIKE ? ESCAPE '\\'
-                    )
-                    """)
-                arguments.append(contentsOf: [pattern, pattern, pattern, pattern])
+                return try Self.fetchUnicodeSearchLibraryPage(
+                    db: db,
+                    whereClauses: whereClauses,
+                    arguments: arguments,
+                    normalizedQuery: UnicodeSearch.makeKey(searchText),
+                    sortOrder: query.sortOrder,
+                    limit: limit,
+                    offset: offset
+                )
             }
 
             var sql = "SELECT * FROM transcriptions"
@@ -170,6 +166,44 @@ public final class TranscriptionRepository: TranscriptionRepositoryProtocol {
                 hasMore: fetched.count > limit
             )
         }
+    }
+
+    private static func fetchUnicodeSearchLibraryPage(
+        db: Database,
+        whereClauses: [String],
+        arguments: [any DatabaseValueConvertible],
+        normalizedQuery: String,
+        sortOrder: TranscriptionLibrarySortOrder,
+        limit: Int,
+        offset: Int
+    ) throws -> TranscriptionLibraryPage {
+        var sql = "SELECT * FROM transcriptions"
+        if !whereClauses.isEmpty {
+            sql += " WHERE " + whereClauses.joined(separator: " AND ")
+        }
+        sql += " ORDER BY \(Self.libraryOrderClause(for: sortOrder))"
+
+        let cursor = try Transcription.fetchCursor(
+            db,
+            sql: sql,
+            arguments: StatementArguments(arguments)
+        )
+        var skipped = 0
+        var items: [Transcription] = []
+        while let transcription = try cursor.next() {
+            guard transcriptionMatchesLibrarySearch(transcription, normalizedQuery: normalizedQuery) else {
+                continue
+            }
+            if skipped < offset {
+                skipped += 1
+                continue
+            }
+            guard items.count < limit else {
+                return TranscriptionLibraryPage(items: items, hasMore: true)
+            }
+            items.append(transcription)
+        }
+        return TranscriptionLibraryPage(items: items, hasMore: false)
     }
 
     public func fetchBySourceType(_ sourceType: Transcription.SourceType, limit: Int? = nil) throws -> [Transcription] {
@@ -283,10 +317,7 @@ public final class TranscriptionRepository: TranscriptionRepositoryProtocol {
 
             var results: [Transcription] = []
             while let transcription = try cursor.next() {
-                guard UnicodeSearch.contains(transcription.fileName, normalizedQuery: normalizedQuery)
-                    || (transcription.rawTranscript.map { UnicodeSearch.contains($0, normalizedQuery: normalizedQuery) } ?? false)
-                    || (transcription.cleanTranscript.map { UnicodeSearch.contains($0, normalizedQuery: normalizedQuery) } ?? false)
-                else { continue }
+                guard transcriptionMatchesLibrarySearch(transcription, normalizedQuery: normalizedQuery) else { continue }
 
                 results.append(transcription)
                 if let limit, results.count >= limit {
@@ -427,4 +458,14 @@ private func escapedLikePattern(_ value: String) -> String {
         .replacingOccurrences(of: "\\", with: "\\\\")
         .replacingOccurrences(of: "%", with: "\\%")
         .replacingOccurrences(of: "_", with: "\\_")
+}
+
+private func transcriptionMatchesLibrarySearch(
+    _ transcription: Transcription,
+    normalizedQuery: String
+) -> Bool {
+    UnicodeSearch.contains(transcription.fileName, normalizedQuery: normalizedQuery)
+        || (transcription.rawTranscript.map { UnicodeSearch.contains($0, normalizedQuery: normalizedQuery) } ?? false)
+        || (transcription.cleanTranscript.map { UnicodeSearch.contains($0, normalizedQuery: normalizedQuery) } ?? false)
+        || (transcription.channelName.map { UnicodeSearch.contains($0, normalizedQuery: normalizedQuery) } ?? false)
 }

--- a/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
@@ -151,14 +151,9 @@ public final class TranscriptionLibraryViewModel {
     public func deleteTranscription(_ transcription: Transcription) {
         do {
             errorMessage = nil
+            try TranscriptionDeletionCleanup.removeOwnedAssets(for: transcription)
             let deleted = try transcriptionRepo?.delete(id: transcription.id) ?? false
             guard deleted else { return }
-            do {
-                try TranscriptionDeletionCleanup.removeOwnedAssets(for: transcription)
-            } catch {
-                logger.warning("Deleted transcription but failed to remove owned assets: \(error.localizedDescription, privacy: .private)")
-                errorMessage = "Deleted transcription, but failed to remove stored audio: \(error.localizedDescription)"
-            }
             transcriptions.removeAll { $0.id == transcription.id }
             publishLoadedItems(transcriptions, hasMore: hasMore)
             Telemetry.send(.transcriptionDeleted)

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -438,14 +438,9 @@ public final class TranscriptionViewModel {
         }
 
         do {
+            try TranscriptionDeletionCleanup.removeOwnedAssets(for: transcription)
             let deleted = try repo.delete(id: transcription.id)
             guard deleted else { return }
-            do {
-                try TranscriptionDeletionCleanup.removeOwnedAssets(for: transcription)
-            } catch {
-                logger.warning("Deleted transcription but failed to remove owned assets: \(error.localizedDescription, privacy: .private)")
-                errorMessage = "Deleted transcription, but failed to remove stored audio: \(error.localizedDescription)"
-            }
             Telemetry.send(.transcriptionDeleted)
             if currentTranscription?.id == transcription.id {
                 currentTranscription = nil

--- a/Tests/CLITests/HistoryCommandTests.swift
+++ b/Tests/CLITests/HistoryCommandTests.swift
@@ -115,6 +115,45 @@ final class HistoryCommandTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: audioURL.path))
     }
 
+    func testDeleteTranscriptionCommandKeepsRecordWhenOwnedAudioCleanupFails() throws {
+        let dbURL = temporaryDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: dbURL) }
+        let db = try DatabaseManager(path: dbURL.path)
+        let repo = TranscriptionRepository(dbQueue: db.dbQueue)
+
+        try AppPaths.ensureDirectories()
+        let protectedDir = URL(fileURLWithPath: AppPaths.youtubeDownloadsDir, isDirectory: true)
+            .appendingPathComponent("macparakeet-cli-protected-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: protectedDir, withIntermediateDirectories: true)
+        let audioURL = protectedDir.appendingPathComponent("asset.m4a")
+        _ = FileManager.default.createFile(atPath: audioURL.path, contents: Data("audio".utf8))
+        try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: protectedDir.path)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: protectedDir.path)
+            try? FileManager.default.removeItem(at: protectedDir)
+        }
+
+        let transcription = Transcription(
+            fileName: "delete-me.m4a",
+            filePath: audioURL.path,
+            rawTranscript: "Goodbye",
+            status: .completed,
+            sourceType: .youtube
+        )
+        try repo.save(transcription)
+
+        let command = try DeleteTranscriptionSubcommand.parse([
+            transcription.id.uuidString,
+            "--database", dbURL.path,
+        ])
+        XCTAssertThrowsError(try captureStandardOutput {
+            try command.run()
+        })
+
+        XCTAssertNotNil(try repo.fetch(id: transcription.id))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: audioURL.path))
+    }
+
     // MARK: - Favorites
 
     func testFavoriteAndUnfavoriteTranscription() throws {
@@ -211,6 +250,34 @@ final class HistoryCommandTests: XCTestCase {
         }
 
         XCTAssertTrue(output.contains("video.mp3"))
+        XCTAssertFalse(output.contains("other.mp3"))
+    }
+
+    func testSearchTranscriptionsCommandMatchesUnicodeCaseInsensitively() throws {
+        let dbURL = temporaryDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: dbURL) }
+        let db = try DatabaseManager(path: dbURL.path)
+        let repo = TranscriptionRepository(dbQueue: db.dbQueue)
+
+        let match = Transcription(
+            fileName: "CAFÉ-notes.m4a",
+            rawTranscript: "Travel guide for İSTANBUL",
+            cleanTranscript: "Résumé follow-up",
+            status: .completed
+        )
+        let other = Transcription(fileName: "other.mp3", rawTranscript: "Unrelated", status: .completed)
+        try repo.save(match)
+        try repo.save(other)
+
+        let command = try SearchTranscriptionsSubcommand.parse([
+            "istanbul",
+            "--database", dbURL.path,
+        ])
+        let output = try captureStandardOutput {
+            try command.run()
+        }
+
+        XCTAssertTrue(output.contains("CAFÉ-notes.m4a"))
         XCTAssertFalse(output.contains("other.mp3"))
     }
 

--- a/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
@@ -394,6 +394,36 @@ final class TranscriptionRepositoryTests: XCTestCase {
         )
     }
 
+    func testFetchLibraryPageSearchMatchesUnicodeCaseInsensitively() throws {
+        let match = Transcription(
+            fileName: "CAFÉ-notes.m4a",
+            rawTranscript: "Travel guide for İSTANBUL",
+            cleanTranscript: "Résumé follow-up",
+            status: .completed,
+            channelName: "CRÈME Channel"
+        )
+        let other = Transcription(fileName: "other.mp3", rawTranscript: "Unrelated", status: .completed)
+        try repo.save(match)
+        try repo.save(other)
+
+        XCTAssertEqual(
+            try repo.fetchLibraryPage(query: TranscriptionLibraryQuery(searchText: "café", limit: 10)).items.map(\.id),
+            [match.id]
+        )
+        XCTAssertEqual(
+            try repo.fetchLibraryPage(query: TranscriptionLibraryQuery(searchText: "istanbul", limit: 10)).items.map(\.id),
+            [match.id]
+        )
+        XCTAssertEqual(
+            try repo.fetchLibraryPage(query: TranscriptionLibraryQuery(searchText: "resume", limit: 10)).items.map(\.id),
+            [match.id]
+        )
+        XCTAssertEqual(
+            try repo.fetchLibraryPage(query: TranscriptionLibraryQuery(searchText: "creme", limit: 10)).items.map(\.id),
+            [match.id]
+        )
+    }
+
     func testFetchLibraryPageSortsByDateAndTitle() throws {
         let older = Transcription(
             createdAt: Date(timeIntervalSinceReferenceDate: 100),

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
@@ -249,4 +249,34 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
         let fetched = try repo.fetch(id: t.id)
         XCTAssertNil(fetched)
     }
+
+    func testDeleteCleanupFailureKeepsTranscriptionRowAndListItem() async throws {
+        try AppPaths.ensureDirectories()
+        let protectedDir = URL(fileURLWithPath: AppPaths.youtubeDownloadsDir, isDirectory: true)
+            .appendingPathComponent("library-protected-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: protectedDir, withIntermediateDirectories: true)
+        let audioURL = protectedDir.appendingPathComponent("asset.m4a")
+        _ = FileManager.default.createFile(atPath: audioURL.path, contents: Data("audio".utf8))
+        try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: protectedDir.path)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: protectedDir.path)
+            try? FileManager.default.removeItem(at: protectedDir)
+        }
+
+        let t = Transcription(
+            fileName: "yt",
+            filePath: audioURL.path,
+            status: .completed,
+            sourceType: .youtube
+        )
+        try repo.save(t)
+        await load()
+
+        vm.deleteTranscription(t)
+
+        XCTAssertNotNil(try repo.fetch(id: t.id))
+        XCTAssertEqual(vm.transcriptions.map(\.id), [t.id])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: audioURL.path))
+        XCTAssertNotNil(vm.errorMessage)
+    }
 }

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -454,9 +454,8 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: audioURL.path))
     }
 
-    func testDeleteFailureKeepsStoredAudioFile() throws {
-        try AppPaths.ensureDirectories()
-        let audioURL = URL(fileURLWithPath: AppPaths.youtubeDownloadsDir, isDirectory: true)
+    func testRepositoryDeleteFailureKeepsExternalAudioFile() throws {
+        let audioURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("yt-audio-\(UUID().uuidString).m4a")
         let created = FileManager.default.createFile(atPath: audioURL.path, contents: Data("audio".utf8))
         XCTAssertTrue(created)
@@ -468,7 +467,7 @@ final class TranscriptionViewModelTests: XCTestCase {
             rawTranscript: "Hello",
             status: .completed,
             sourceURL: "https://youtu.be/dQw4w9WgXcQ",
-            sourceType: .youtube
+            sourceType: .file
         )
         mockRepo.transcriptions = [t]
         mockRepo.deleteError = NSError(domain: "repo", code: 1)
@@ -478,6 +477,41 @@ final class TranscriptionViewModelTests: XCTestCase {
 
         XCTAssertTrue(FileManager.default.fileExists(atPath: audioURL.path))
         XCTAssertEqual(viewModel.transcriptions.count, 1)
+        XCTAssertNotNil(viewModel.errorMessage)
+    }
+
+    func testAssetCleanupFailureDoesNotDeleteTranscription() throws {
+        try AppPaths.ensureDirectories()
+        let protectedDir = URL(fileURLWithPath: AppPaths.youtubeDownloadsDir, isDirectory: true)
+            .appendingPathComponent("viewmodel-protected-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: protectedDir, withIntermediateDirectories: true)
+        let audioURL = protectedDir.appendingPathComponent("asset.m4a")
+        let created = FileManager.default.createFile(atPath: audioURL.path, contents: Data("audio".utf8))
+        XCTAssertTrue(created)
+        try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: protectedDir.path)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: protectedDir.path)
+            try? FileManager.default.removeItem(at: protectedDir)
+        }
+
+        let t = Transcription(
+            fileName: "yt",
+            filePath: audioURL.path,
+            rawTranscript: "Hello",
+            status: .completed,
+            sourceURL: "https://youtu.be/dQw4w9WgXcQ",
+            sourceType: .youtube
+        )
+        mockRepo.transcriptions = [t]
+
+        viewModel.configure(transcriptionService: mockService, transcriptionRepo: mockRepo)
+        viewModel.currentTranscription = t
+        viewModel.deleteTranscription(t)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: audioURL.path))
+        XCTAssertFalse(mockRepo.deleteCalledWith.contains(t.id))
+        XCTAssertEqual(viewModel.transcriptions.map(\.id), [t.id])
+        XCTAssertEqual(viewModel.currentTranscription?.id, t.id)
         XCTAssertNotNil(viewModel.errorMessage)
     }
 

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -1592,7 +1592,7 @@ Meeting transcription uses the current speech engine captured at recording start
 - [x] Audio buffers received while paused are dropped at the top of `handleCaptureEvent`; mic + ScreenCaptureKit subscriptions stay live so resume is instant
 - [x] `MeetingAudioStorageWriter` PTS counter is preserved across pause; the resumed audio appends with a continuous timeline (pauses are invisible in playback)
 - [x] `accumulatedPausedDuration` is subtracted from both live `elapsedSeconds` and persisted `durationSeconds`; stopping while paused settles the in-flight pause first
-- [x] `CaptureOrchestrator.reset()` is called on pause so pre-pause partial joiner / chunker state doesn't bridge into post-resume samples
+- [x] `CaptureOrchestrator.reset()` is not called on pause; the chunker counter stays monotonic so live transcript dedupe keeps post-resume words
 - [x] Mic + system level metrics zero on pause so the orb / pill rosette read silent immediately, not over the EMA decay window
 - [x] Pause/resume reachable from the floating pill's right-click menu, the Meeting Panel header (next to Stop), and the Transcribe-tab Meeting Recording tile
 - [x] Pill rosette dims and shows pause bars while paused; panel header swaps "Recording" for "Paused" and hides the dual-audio orb


### PR DESCRIPTION
## Summary
- bump the bundled CLI public surface to 2.1.0 and finalize the YouTube audio quality flag changelog entry
- restore Unicode-aware transcription library and CLI search on the paged query path
- ensure CLI and app transcription deletion clean app-owned assets before deleting DB rows, with regression coverage for cleanup failures
- align the pause/resume feature spec with ADR-014's no-reset behavior

## Root Cause
Latest main was build-green but still had release blockers: the CLI exposed a new additive flag while still reporting 2.0.0, the new paged library search path used SQLite LIKE instead of the existing UnicodeSearch normalizer, and three deletion surfaces could lose the DB pointer before app-owned audio cleanup completed.

## Validation
- Fresh-eye local review of the full diff
- `swift test --filter 'TranscriptionRepositoryTests|HistoryCommandTests|TranscriptionViewModelTests|TranscriptionLibraryViewModelTests'` passed: 151 tests
- `swift run macparakeet-cli --version` prints `2.1.0`
- `swift test` passed: 2,367 tests, 10 skipped, 0 failures
- `swift build -c release` passed
- `git diff --check` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unicode-aware search for transcriptions with case-insensitive and accent-insensitive matching
  * Improved transcription deletion with proper asset cleanup sequencing

* **Bug Fixes**
  * Fixed pause/resume behavior to maintain consistent chunking during recording sessions
  * Enhanced error handling for transcription deletion to prevent incomplete cleanup

* **Chores**
  * CLI version bumped to 2.1.0

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moona3k/macparakeet/pull/251)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->