### PR TITLE
[codex] Align docs with current release state

### DIFF
--- a/docs/audits/2026-05-02-logging-telemetry-issues.md
+++ b/docs/audits/2026-05-02-logging-telemetry-issues.md
@@ -1,5 +1,6 @@
 # Logging & Telemetry Follow-Up Tracker -- 2026-05-02
 
+> Status: **ACTIVE** - Follow-up tracker for the 2026-05-02 telemetry/logging review.
 > Source review: [`2026-05-02-logging-telemetry-review.md`](2026-05-02-logging-telemetry-review.md)
 > Scope: MacParakeet app telemetry/logging plus the self-hosted telemetry
 > ingestion Worker in `macparakeet-website`.

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -25,7 +25,7 @@ This script builds the latest debug binary, stops stale `/Applications`/`dist` a
 ```
 macparakeet-cli
 ├── transcribe <input> [options]         Transcribe a file or YouTube URL
-│   └── --engine parakeet|whisper [--language <code>]
+│   └── --engine parakeet|whisper [--language <code>] [--youtube-audio-quality app-default|m4a|best-available]
 ├── history                              View and manage history
 │   ├── dictations [--limit] [--json]    List recent dictations (default)
 │   ├── transcriptions [--limit] [--json]  List recent transcriptions
@@ -65,6 +65,15 @@ macparakeet-cli
 │   ├── delete <id-or-name>              Delete custom prompt (built-ins protected)
 │   ├── restore-defaults                 Re-show all built-in prompts
 │   └── run <id-or-name> --transcription <id> [--no-store] [--stream] [--extra ...]
+├── quick-prompts                        Manage live meeting Ask quick prompts
+│   ├── list [--pinned true|false] [--visible-only] [--json]
+│   ├── show <id-or-label> [--json]
+│   ├── add --label X (--prompt Y | --from-file path) [--group X] [--pinned] [--hidden]
+│   ├── set <id-or-label> [--label X] [--prompt Y] [--group X] [--sort-order N] [--visible|--hidden]
+│   ├── delete <id-or-label>
+│   ├── pin <id-or-label> / unpin <id-or-label>
+│   ├── restore-defaults [--id UUID]
+│   └── export [--out path] [--pinned true|false] [--include-builtins] / import <path> [--mode merge|replace]
 ├── meetings                             Inspect and manage local meeting recordings
 │   ├── list [--limit] [--json]
 │   ├── show <meeting> [--json]
@@ -97,7 +106,8 @@ Uses app defaults for processing mode and YouTube audio retention.
 ```bash
 swift run macparakeet-cli transcribe "<FILE_OR_YOUTUBE_URL>" \
   --mode app-default \
-  --downloaded-audio app-default
+  --downloaded-audio app-default \
+  --youtube-audio-quality app-default
 ```
 
 ### 2) Deterministic Mode (recommended for CI/agent reproducibility)
@@ -107,7 +117,8 @@ Explicitly pins behavior.
 ```bash
 swift run macparakeet-cli transcribe "<FILE_OR_YOUTUBE_URL>" \
   --mode raw \
-  --downloaded-audio delete
+  --downloaded-audio delete \
+  --youtube-audio-quality m4a
 ```
 
 Or clean mode with retained downloads:
@@ -115,8 +126,14 @@ Or clean mode with retained downloads:
 ```bash
 swift run macparakeet-cli transcribe "<FILE_OR_YOUTUBE_URL>" \
   --mode clean \
-  --downloaded-audio keep
+  --downloaded-audio keep \
+  --youtube-audio-quality best-available
 ```
+
+`--youtube-audio-quality app-default` follows the GUI setting. `m4a` matches
+the app's default compatibility-first selector. `best-available` asks `yt-dlp`
+for the best audio stream and then lets the normal conversion pipeline prepare
+the STT input.
 
 ### Speech Engine Selection
 
@@ -464,6 +481,27 @@ swift run macparakeet-cli prompts run "Blog Post" \
 
 `prompts run` writes the model output to **stdout** and the "Saved PromptResult X"
 confirmation to **stderr**, so `> result.txt` captures only the prompt output.
+
+## Quick Prompts
+
+Quick prompts power the live meeting Ask tab shortcut pills. The CLI mirrors
+the GUI model so agents can seed, pin, hide, export, and import those prompts
+without launching the app.
+
+```bash
+swift run macparakeet-cli quick-prompts list --visible-only
+swift run macparakeet-cli quick-prompts show "Catch me up"
+
+swift run macparakeet-cli quick-prompts add \
+  --label "Risks?" \
+  --prompt "Identify risks, blockers, and open questions from the current meeting context." \
+  --pinned
+
+swift run macparakeet-cli quick-prompts pin "Risks?"
+swift run macparakeet-cli quick-prompts set "Risks?" --group "CHALLENGE"
+swift run macparakeet-cli quick-prompts export --out quick-prompts.json --include-builtins
+swift run macparakeet-cli quick-prompts import quick-prompts.json --mode merge --json
+```
 
 ## Feedback
 

--- a/docs/research/fluidaudio-stt-migration.md
+++ b/docs/research/fluidaudio-stt-migration.md
@@ -436,8 +436,8 @@ YouTube:   yt-dlp (standalone) → .m4a → AudioFileConverter (FFmpeg binary) �
 ## Related Documents
 
 - [Open Source Models Landscape (Feb 2026)](./open-source-models-landscape-2026.md) — full STT/LLM/MLX ecosystem research
-- [ADR-001: Parakeet TDT as Primary STT](../spec/adr/001-parakeet-stt.md) — original STT decision (model choice unchanged, runtime changes). Needs amendment post-migration.
-- [Distribution & Signing](./distribution.md) — current distribution approach (will simplify after migration)
+- [ADR-001: Parakeet TDT as Primary STT](../../spec/adr/001-parakeet-stt.md) — original STT decision (model choice unchanged, runtime changes). Needs amendment post-migration.
+- [Distribution & Signing](../distribution.md) — current distribution approach (will simplify after migration)
 
 ## Sources
 

--- a/plans/active/2026-05-voice-command-agent-mode.md
+++ b/plans/active/2026-05-voice-command-agent-mode.md
@@ -1,0 +1,77 @@
+# Voice Command and Agent Mode Exploration
+
+Status: **PROPOSED**
+Owner: Core app team
+Updated: 2026-05-10
+
+## Objective
+
+Explore a future mode where spoken intent can trigger app actions, selected-text
+rewrites, or constrained agent workflows without weakening MacParakeet's
+local-first dictation reliability.
+
+This is intentionally separate from paste-targeting UX. Plain dictation now
+defaults to the finish-target model documented in
+`plans/active/2026-05-dictation-paste-targeting-ux.md`: paste into the editable
+target focused when insertion happens. Command/agent behavior needs a separate
+safety and product pass before it can use stricter target locking.
+
+## Product Thesis
+
+MacParakeet should stay excellent at plain dictation first. Voice command or
+agent behavior is only worth shipping when it feels predictable:
+
+1. normal speech inserts text
+2. command speech is opt-in and visually distinct
+3. actions run only against the intended target app or an explicit MacParakeet tool
+4. failure never causes wrong-target paste, data loss, or hidden automation
+
+## Candidate Capabilities
+
+1. selected-text rewrite, building on the completed command-mode F10a plan
+2. app-local actions such as press return, tab, escape, or submit after dictation
+3. structured commands such as "summarize this selection" or "make this friendlier"
+4. agent handoff for explicit tasks such as "turn this note into todos"
+5. workflow macros with clear previews and confirmation before irreversible actions
+
+## Safety Requirements
+
+1. no arbitrary shell, network, file, or app automation by default
+2. explicit confirmation before destructive or externally visible actions
+3. allowlisted tools with typed arguments instead of free-form execution
+4. clear mode boundary so plain dictation cannot accidentally become a command
+5. no audio, transcript, selected text, or prompt content in telemetry
+6. failure buckets should be structural only, such as permission denied, no selection,
+   unsupported app, target changed, or action cancelled
+
+## Architecture Notes
+
+1. build on the existing clipboard delivery path:
+   - preserve full pasteboard item snapshot/restore
+   - keep plain dictation on finish-target paste semantics
+   - consider command-start target locking only as an explicit command-mode
+     contract after manual UX validation
+2. reuse command-mode de-risk work in
+   `plans/completed/2026-02-command-mode-f10a-de-risk-plan.md`
+3. keep command orchestration outside SwiftUI views
+4. keep Core APIs typed and testable; UI should only present state and confirmation
+5. prefer selected-text and paste replacement contracts before broader app automation
+
+## Open Questions
+
+1. Should command mode be a separate hotkey/chord or inferred from language?
+2. Should agent actions require a preview every time, or only for risky actions?
+3. Which apps are in the first manual reliability matrix?
+4. Is an LLM provider required, optional, or local-only for the first version?
+5. What is the minimum useful command set that does not compromise dictation UX?
+
+## First De-Risk Slice
+
+1. manually test finish-target paste delivery across TextEdit, Notes, Slack,
+   Safari textareas,
+   Chrome, VS Code, Cursor, Terminal, and Messages
+2. document unsupported or flaky target classes
+3. only then revisit direct insertion, menu paste fallback, insertion
+   verification, or explicit command-mode target locking
+4. start command/agent prototyping after the paste path has evidence across real
+   apps

--- a/spec/01-data-model.md
+++ b/spec/01-data-model.md
@@ -824,6 +824,7 @@ migrator.registerMigration("v0.7-prompts-and-summaries") { db in
 // v0.8 — dictations.engine/engineVariant and transcriptions.engine/engineVariant
 // v0.9 — transcriptions.derivedTitle and transcriptions.derivedSnippet
 // v0.10 — quick_prompts (v0.6 Live Ask product surface)
+// v0.10 — transcription library indexes (sourceType/favorite/status + createdAt)
 ```
 
 ### Migration Rules
@@ -871,6 +872,7 @@ migrator.registerMigration("v0.7-prompts-and-summaries") { db in
 | `transcriptions.derivedTitle` | v0.9 | Cached display title derived from transcript content |
 | `transcriptions.derivedSnippet` | v0.9 | Cached display preview snippet derived from transcript content |
 | `quick_prompts` | v0.10 | User-customizable live Ask tab shortcut pills; v0.6 product feature |
+| `idx_transcriptions_source_type_created_at` / `idx_transcriptions_favorite_created_at` / `idx_transcriptions_status_created_at` | v0.10 | Library filter/sort indexes for source type, favorites, and status |
 
 ### Tables NOT Planned (YAGNI)
 

--- a/spec/05-audio-pipeline.md
+++ b/spec/05-audio-pipeline.md
@@ -263,7 +263,7 @@ The primary concurrency use case remains meeting recording + dictation. File tra
 | Permission | Why | When Requested | Fallback |
 |------------|-----|----------------|----------|
 | Microphone | Dictation recording | First dictation attempt | Show permission dialog with instructions |
-| Accessibility | Global hotkey detection + text insertion | First dictation attempt | Show System Settings deep link |
+| Accessibility | Global shortcut detection + text insertion | First dictation attempt | Show System Settings deep link |
 | Screen & System Audio Recording | Meeting recording (system audio capture via ScreenCaptureKit) | First meeting recording attempt | Show error + "Open System Settings" button, block recording |
 
 ### Permission Flow

--- a/spec/06-stt-engine.md
+++ b/spec/06-stt-engine.md
@@ -41,7 +41,7 @@ Parakeet remains the default because it is faster, lower-latency, and lower-memo
 Each ML workload runs on the chip it was designed for:
 
 ```
-CPU:  MacParakeet app (UI, hotkeys, clipboard, history)
+CPU:  MacParakeet app (UI, shortcuts, clipboard, history)
 ANE:  Parakeet STT (via FluidAudio/CoreML) — dedicated ML accelerator
 CPU/GPU/CoreML as selected by WhisperKit: optional multilingual STT
 ```
@@ -54,7 +54,7 @@ The default Parakeet path runs on dedicated silicon, leaving CPU and GPU free fo
 
 ### Overview
 
-[FluidAudio](https://github.com/FluidInference/FluidAudio) is an open-source Swift SDK by FluidInference that runs Parakeet TDT on Apple's Neural Engine via CoreML. Apache 2.0 licensed. ~1,500 GitHub stars, 34 releases, 20+ production apps.
+[FluidAudio](https://github.com/FluidInference/FluidAudio) is an open-source Swift SDK by FluidInference that runs Parakeet TDT on Apple's Neural Engine via CoreML. It is Apache 2.0 licensed and is the active runtime integration point for MacParakeet's default STT path.
 
 **SwiftPM dependency:** Use the `FluidAudio` product only — NOT `FluidAudioEspeak` (GPL-3.0, includes Kokoro TTS via ESpeakNG). PocketTTS (GPL-free) is already included in the core `FluidAudio` product since v0.12.0.
 

--- a/spec/adr/017-calendar-meeting-auto-start.md
+++ b/spec/adr/017-calendar-meeting-auto-start.md
@@ -95,7 +95,7 @@ Skipping sets `calendarAutoStartMode = .off` explicitly so re-enabling later goe
 
 ### 10. Hotkey / manual start still works independently
 
-Nothing about this ADR removes the manual flow. The meeting hotkey, the menu bar "Record Meeting" item, and the Meetings panel's record button all continue to work even with auto-start fully on. If a user starts a recording manually and a calendar event's auto-start fires mid-call, the coordinator observes that a recording is already active and **no-ops** (does not restart, does not double-notify).
+Nothing about this ADR removes the manual flow. The meeting hotkey, the menu bar "Start Recording" item, and the Meetings panel's record button all continue to work even with auto-start fully on. If a user starts a recording manually and a calendar event's auto-start fires mid-call, the coordinator observes that a recording is already active and **no-ops** (does not restart, does not double-notify).
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- Keeps this PR docs/spec/plan-only: 8 files, no source or test changes.
- Updates CLI testing docs for already-implemented quick-prompts and YouTube audio quality options.
- Keeps `plans/active/2026-05-voice-command-agent-mode.md`, aligned to finish-target paste semantics instead of target-captured paste.
- Clarifies existing DB index, FluidAudio runtime, permission wording, telemetry tracker, and meeting menu docs.

## Scope Boundary
The split dictation shortcut implementation was removed from this PR and preserved separately on `feat/split-dictation-shortcuts-implementation`. This PR should not be treated as the implementation PR.

## Validation
- `git diff --check origin/main..HEAD`
- `scripts/check-readme-references.sh`
- diff scan for stale split-shortcut / PID-targeted / target-captured claims

## Notes
- Draft until we decide whether to merge this docs-only cleanup first.
- Full `swift test` passed earlier on the mixed implementation branch, but was not rerun after reducing this PR to docs-only changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI documentation with new `--youtube-audio-quality` option for transcription command configurations.
  * Added new `quick-prompts` CLI command group for managing quick prompts and shortcuts from the command line.
  * Updated technical specifications and planning documentation for platform architecture and future capability exploration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moona3k/macparakeet/pull/252)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->