### PR TITLE
Support first-class CLI defaults for agent testing

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -92,7 +92,8 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 - `config get|set|list` now covers the shared app/CLI transcription defaults
   agents need for deterministic setup: `processing-mode`, `speech-engine`,
   `whisper-language`, `speaker-detection`, `save-transcription-audio`, and
-  `youtube-audio-quality`.
+  `youtube-audio-quality`. Config keys accept underscore aliases on input and
+  JSON output uses the canonical hyphenated key names.
 
 ## [2.1.0] -- 2026-05-10
 

--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -80,6 +80,20 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ## [Unreleased]
 
+### Added
+
+- `transcribe --engine app-default` resolves the speech engine and Whisper
+  language from the same saved defaults used by the GUI, while preserving
+  Parakeet as the no-flag CLI default.
+- `transcribe --speaker-detection app-default|on|off` lets agents choose
+  GUI-default speaker detection or pin diarization explicitly. The no-flag
+  CLI default remains `on`; `--no-diarize` continues to work as a
+  compatibility alias for `--speaker-detection off`.
+- `config get|set|list` now covers the shared app/CLI transcription defaults
+  agents need for deterministic setup: `processing-mode`, `speech-engine`,
+  `whisper-language`, `speaker-detection`, `save-transcription-audio`, and
+  `youtube-audio-quality`.
+
 ## [2.1.0] -- 2026-05-10
 
 ### Added

--- a/Sources/CLI/Commands/ConfigCommand.swift
+++ b/Sources/CLI/Commands/ConfigCommand.swift
@@ -8,25 +8,26 @@ import MacParakeetCore
 /// (`com.macparakeet.MacParakeet`). This lets users who only install the CLI
 /// (no GUI) persist preferences like opting out of telemetry — and a later GUI
 /// install picks the same values up automatically. Without this, CLI-only
-/// users would have no way to opt out of telemetry or set GUI-parity
-/// transcription defaults for agent-driven smoke tests.
+/// users would have no way to opt out of telemetry or set app-default
+/// transcription state for agent-driven smoke tests.
 struct ConfigCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "config",
         abstract: "Read or write CLI/app configuration values.",
         discussion: """
         Configuration is stored in the shared MacParakeet UserDefaults suite \
-        (com.macparakeet.MacParakeet). The GUI reads the same suite, so values \
-        set here apply to both surfaces.
+        (com.macparakeet.MacParakeet). The GUI and CLI read the same suite, so \
+        values set here apply to later app-default reads. A running GUI may \
+        cache some settings until relaunch or an in-app change.
 
         Supported keys:
-          telemetry                 on|off
-          processing-mode           raw|clean
-          speech-engine             parakeet|whisper
-          whisper-language          auto|<Whisper language code>
-          speaker-detection         on|off
-          save-transcription-audio  on|off
-          youtube-audio-quality     m4a|best-available
+          telemetry                 on|off                         default: on
+          processing-mode           raw|clean                       default: raw
+          speech-engine             parakeet|whisper                default: parakeet
+          whisper-language          auto|<Whisper language code>    default: auto
+          speaker-detection         on|off                          default: off
+          save-transcription-audio  on|off                          default: on
+          youtube-audio-quality     m4a|best-available              default: m4a
 
         Full event catalog:
           https://github.com/moona3k/macparakeet/blob/main/docs/telemetry.md
@@ -67,8 +68,9 @@ struct ConfigCommand: ParsableCommand {
 
         func run() throws {
             try emitJSONOrRethrow(json: json) {
-                let value = try ConfigCommand.read(key: key)
-                try printResult(key: key, value: value, json: json)
+                let canonicalKey = try ConfigCommand.canonicalKey(key)
+                let value = try ConfigCommand.read(key: canonicalKey)
+                try printResult(key: canonicalKey, value: value, json: json)
             }
         }
     }
@@ -90,8 +92,9 @@ struct ConfigCommand: ParsableCommand {
 
         func run() throws {
             try emitJSONOrRethrow(json: json) {
-                let written = try ConfigCommand.write(key: key, value: value)
-                try printResult(key: key, value: written, json: json)
+                let canonicalKey = try ConfigCommand.canonicalKey(key)
+                let written = try ConfigCommand.write(key: canonicalKey, value: value)
+                try printResult(key: canonicalKey, value: written, json: json)
             }
         }
     }
@@ -138,7 +141,7 @@ struct ConfigCommand: ParsableCommand {
             return on ? "on" : "off"
         case "processing-mode":
             let raw = store.string(forKey: UserDefaultsAppRuntimePreferences.processingModeKey)
-            return (Dictation.ProcessingMode(rawValue: raw ?? "raw") ?? .raw).rawValue
+            return (Dictation.ProcessingMode(rawValue: raw ?? Dictation.ProcessingMode.raw.rawValue) ?? .raw).rawValue
         case "speech-engine":
             return SpeechEnginePreference.current(defaults: store).rawValue
         case "whisper-language":
@@ -199,18 +202,10 @@ struct ConfigCommand: ParsableCommand {
         let normalized = key.trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
             .replacingOccurrences(of: "_", with: "-")
-        switch normalized {
-        case "telemetry",
-             "processing-mode",
-             "speech-engine",
-             "whisper-language",
-             "speaker-detection",
-             "save-transcription-audio",
-             "youtube-audio-quality":
+        if supportedKeys.contains(normalized) {
             return normalized
-        default:
-            throw unknownKeyError(key)
         }
+        throw unknownKeyError(key)
     }
 
     static func parseBool(_ value: String, key: String) throws -> Bool {

--- a/Sources/CLI/Commands/ConfigCommand.swift
+++ b/Sources/CLI/Commands/ConfigCommand.swift
@@ -8,7 +8,8 @@ import MacParakeetCore
 /// (`com.macparakeet.MacParakeet`). This lets users who only install the CLI
 /// (no GUI) persist preferences like opting out of telemetry — and a later GUI
 /// install picks the same values up automatically. Without this, CLI-only
-/// users would have no way to opt out of telemetry except per-process env vars.
+/// users would have no way to opt out of telemetry or set GUI-parity
+/// transcription defaults for agent-driven smoke tests.
 struct ConfigCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "config",
@@ -19,8 +20,13 @@ struct ConfigCommand: ParsableCommand {
         set here apply to both surfaces.
 
         Supported keys:
-          telemetry   on|off   Anonymous, non-identifying usage analytics
-                               (default: on)
+          telemetry                 on|off
+          processing-mode           raw|clean
+          speech-engine             parakeet|whisper
+          whisper-language          auto|<Whisper language code>
+          speaker-detection         on|off
+          save-transcription-audio  on|off
+          youtube-audio-quality     m4a|best-available
 
         Full event catalog:
           https://github.com/moona3k/macparakeet/blob/main/docs/telemetry.md
@@ -35,7 +41,15 @@ struct ConfigCommand: ParsableCommand {
     )
 
     /// Keys recognized by `get`/`set`/`list`.
-    static let supportedKeys: [String] = ["telemetry"]
+    static let supportedKeys: [String] = [
+        "telemetry",
+        "processing-mode",
+        "speech-engine",
+        "whisper-language",
+        "speaker-detection",
+        "save-transcription-audio",
+        "youtube-audio-quality",
+    ]
 
     // MARK: - Subcommands
 
@@ -118,10 +132,25 @@ struct ConfigCommand: ParsableCommand {
 
     static func read(key: String, defaults: UserDefaults? = nil) throws -> String {
         let store = defaults ?? macParakeetAppDefaults()
-        switch key {
+        switch try canonicalKey(key) {
         case "telemetry":
             let on = AppPreferences.isTelemetryEnabled(defaults: store)
             return on ? "on" : "off"
+        case "processing-mode":
+            let raw = store.string(forKey: UserDefaultsAppRuntimePreferences.processingModeKey)
+            return (Dictation.ProcessingMode(rawValue: raw ?? "raw") ?? .raw).rawValue
+        case "speech-engine":
+            return SpeechEnginePreference.current(defaults: store).rawValue
+        case "whisper-language":
+            return SpeechEnginePreference.whisperDefaultLanguage(defaults: store) ?? WhisperLanguageCatalog.autoCode
+        case "speaker-detection":
+            let on = store.object(forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey) as? Bool ?? false
+            return on ? "on" : "off"
+        case "save-transcription-audio":
+            let on = store.object(forKey: UserDefaultsAppRuntimePreferences.saveTranscriptionAudioKey) as? Bool ?? true
+            return on ? "on" : "off"
+        case "youtube-audio-quality":
+            return displayYouTubeAudioQuality(YouTubeAudioQuality.current(defaults: store))
         default:
             throw unknownKeyError(key)
         }
@@ -132,11 +161,53 @@ struct ConfigCommand: ParsableCommand {
     @discardableResult
     static func write(key: String, value: String, defaults: UserDefaults? = nil) throws -> String {
         let store = defaults ?? macParakeetAppDefaults()
-        switch key {
+        switch try canonicalKey(key) {
         case "telemetry":
             let parsed = try parseBool(value, key: key)
             store.set(parsed, forKey: AppPreferences.telemetryEnabledKey)
             return parsed ? "on" : "off"
+        case "processing-mode":
+            let mode = try parseProcessingMode(value)
+            store.set(mode.rawValue, forKey: UserDefaultsAppRuntimePreferences.processingModeKey)
+            return mode.rawValue
+        case "speech-engine":
+            let engine = try parseSpeechEngine(value)
+            engine.save(to: store)
+            return engine.rawValue
+        case "whisper-language":
+            let language = try parseWhisperLanguage(value)
+            SpeechEnginePreference.saveWhisperDefaultLanguage(language, defaults: store)
+            return language ?? WhisperLanguageCatalog.autoCode
+        case "speaker-detection":
+            let parsed = try parseBool(value, key: key)
+            store.set(parsed, forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey)
+            return parsed ? "on" : "off"
+        case "save-transcription-audio":
+            let parsed = try parseBool(value, key: key)
+            store.set(parsed, forKey: UserDefaultsAppRuntimePreferences.saveTranscriptionAudioKey)
+            return parsed ? "on" : "off"
+        case "youtube-audio-quality":
+            let quality = try parseYouTubeAudioQuality(value)
+            store.set(quality.rawValue, forKey: UserDefaultsAppRuntimePreferences.youtubeAudioQualityKey)
+            return displayYouTubeAudioQuality(quality)
+        default:
+            throw unknownKeyError(key)
+        }
+    }
+
+    static func canonicalKey(_ key: String) throws -> String {
+        let normalized = key.trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "_", with: "-")
+        switch normalized {
+        case "telemetry",
+             "processing-mode",
+             "speech-engine",
+             "whisper-language",
+             "speaker-detection",
+             "save-transcription-audio",
+             "youtube-audio-quality":
+            return normalized
         default:
             throw unknownKeyError(key)
         }
@@ -151,6 +222,57 @@ struct ConfigCommand: ParsableCommand {
             return false
         default:
             throw ValidationError("Invalid value for \(key): '\(value)'. Use on/off (or true/false, yes/no, 1/0).")
+        }
+    }
+
+    static func parseProcessingMode(_ value: String) throws -> Dictation.ProcessingMode {
+        let raw = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard let mode = Dictation.ProcessingMode(rawValue: raw) else {
+            throw ValidationError("Invalid value for processing-mode: '\(value)'. Use raw or clean.")
+        }
+        return mode
+    }
+
+    static func parseSpeechEngine(_ value: String) throws -> SpeechEnginePreference {
+        let raw = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard let engine = SpeechEnginePreference(rawValue: raw) else {
+            throw ValidationError("Invalid value for speech-engine: '\(value)'. Use parakeet or whisper.")
+        }
+        return engine
+    }
+
+    static func parseWhisperLanguage(_ value: String) throws -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lowered = trimmed.lowercased()
+        if lowered == WhisperLanguageCatalog.autoCode || lowered == "auto-detect" {
+            return nil
+        }
+        guard let language = SpeechEnginePreference.normalizeLanguage(trimmed) else {
+            throw ValidationError("Invalid value for whisper-language: '\(value)'. Use auto or a Whisper language code.")
+        }
+        return language
+    }
+
+    static func parseYouTubeAudioQuality(_ value: String) throws -> YouTubeAudioQuality {
+        let raw = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "_", with: "-")
+        switch raw {
+        case "m4a":
+            return .m4a
+        case "best-available", "bestavailable":
+            return .bestAvailable
+        default:
+            throw ValidationError("Invalid value for youtube-audio-quality: '\(value)'. Use m4a or best-available.")
+        }
+    }
+
+    static func displayYouTubeAudioQuality(_ quality: YouTubeAudioQuality) -> String {
+        switch quality {
+        case .m4a:
+            return "m4a"
+        case .bestAvailable:
+            return "best-available"
         }
     }
 

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -63,7 +63,7 @@ struct TranscribeCommand: AsyncParsableCommand {
     @Option(help: "Processing mode: raw, clean, app-default.")
     var mode: TranscribeMode = .appDefault
 
-    @Option(help: "Speech engine: app-default, parakeet, whisper.")
+    @Option(help: "Speech engine: app-default, parakeet, whisper. Default: parakeet; app-default follows the saved GUI preference.")
     var engine: TranscribeSpeechEngine = .parakeet
 
     @Option(help: "Language hint for Whisper, as a Whisper code such as ko or en. Parakeet ignores this flag.")
@@ -78,10 +78,10 @@ struct TranscribeCommand: AsyncParsableCommand {
     @Option(help: "Path to SQLite database file (defaults to the app database).")
     var database: String?
 
-    @Option(name: .long, help: "Speaker detection: app-default, on, off.")
+    @Option(name: .long, help: "Speaker detection: app-default, on, off. Default: on; app-default follows the saved GUI preference.")
     var speakerDetection: SpeakerDetectionOption = .on
 
-    @Flag(help: "Deprecated alias for --speaker-detection off.")
+    @Flag(help: "Compatibility alias for --speaker-detection off.")
     var noDiarize: Bool = false
 
     @Flag(help: "Run retained entitlement checks before transcribing. Current free builds remain unlocked.")
@@ -182,7 +182,7 @@ struct TranscribeCommand: AsyncParsableCommand {
                 let speechEngine = Self.resolveSpeechEngine(
                     self.engine,
                     storedEngine: defaults.string(forKey: SpeechEnginePreference.defaultsKey),
-                    storedLanguage: defaults.string(forKey: SpeechEnginePreference.whisperDefaultLanguageKey),
+                    storedLanguage: SpeechEnginePreference.whisperDefaultLanguage(defaults: defaults),
                     explicitLanguage: self.language
                 )
                 let speakerDetectionEnabled = Self.resolveSpeakerDetection(

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -27,8 +27,15 @@ enum TranscribeOutputFormat: String, ExpressibleByArgument, CaseIterable, Sendab
 }
 
 enum TranscribeSpeechEngine: String, ExpressibleByArgument, CaseIterable, Sendable {
+    case appDefault = "app-default"
     case parakeet
     case whisper
+}
+
+enum SpeakerDetectionOption: String, ExpressibleByArgument, CaseIterable, Sendable {
+    case appDefault = "app-default"
+    case on
+    case off
 }
 
 struct TranscribeCommand: AsyncParsableCommand {
@@ -56,7 +63,7 @@ struct TranscribeCommand: AsyncParsableCommand {
     @Option(help: "Processing mode: raw, clean, app-default.")
     var mode: TranscribeMode = .appDefault
 
-    @Option(help: "Speech engine: parakeet, whisper.")
+    @Option(help: "Speech engine: app-default, parakeet, whisper.")
     var engine: TranscribeSpeechEngine = .parakeet
 
     @Option(help: "Language hint for Whisper, as a Whisper code such as ko or en. Parakeet ignores this flag.")
@@ -71,7 +78,10 @@ struct TranscribeCommand: AsyncParsableCommand {
     @Option(help: "Path to SQLite database file (defaults to the app database).")
     var database: String?
 
-    @Flag(help: "Disable speaker diarization.")
+    @Option(name: .long, help: "Speaker detection: app-default, on, off.")
+    var speakerDetection: SpeakerDetectionOption = .on
+
+    @Flag(help: "Deprecated alias for --speaker-detection off.")
     var noDiarize: Bool = false
 
     @Flag(help: "Run retained entitlement checks before transcribing. Current free builds remain unlocked.")
@@ -106,6 +116,44 @@ struct TranscribeCommand: AsyncParsableCommand {
         }
     }
 
+    static func resolveSpeechEngine(
+        _ engine: TranscribeSpeechEngine,
+        storedEngine: String?,
+        storedLanguage: String?,
+        explicitLanguage: String?
+    ) -> SpeechEngineSelection {
+        let preference: SpeechEnginePreference
+        let language: String?
+        switch engine {
+        case .appDefault:
+            preference = SpeechEnginePreference(rawValue: storedEngine ?? "") ?? .parakeet
+            language = preference == .whisper ? explicitLanguage ?? storedLanguage : nil
+        case .parakeet:
+            preference = .parakeet
+            language = nil
+        case .whisper:
+            preference = .whisper
+            language = explicitLanguage
+        }
+        return SpeechEngineSelection(engine: preference, language: language)
+    }
+
+    static func resolveSpeakerDetection(
+        _ option: SpeakerDetectionOption,
+        storedEnabled: Bool?,
+        noDiarize: Bool
+    ) -> Bool {
+        if noDiarize { return false }
+        switch option {
+        case .appDefault:
+            return storedEnabled ?? false
+        case .on:
+            return true
+        case .off:
+            return false
+        }
+    }
+
     static func localFileURL(for input: String) -> URL {
         URL(fileURLWithPath: expandTilde(input))
     }
@@ -130,24 +178,48 @@ struct TranscribeCommand: AsyncParsableCommand {
                 let transcriptionRepo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
                 let customWordRepo = CustomWordRepository(dbQueue: dbManager.dbQueue)
                 let snippetRepo = TextSnippetRepository(dbQueue: dbManager.dbQueue)
+                let defaults = macParakeetAppDefaults()
+                let speechEngine = Self.resolveSpeechEngine(
+                    self.engine,
+                    storedEngine: defaults.string(forKey: SpeechEnginePreference.defaultsKey),
+                    storedLanguage: defaults.string(forKey: SpeechEnginePreference.whisperDefaultLanguageKey),
+                    explicitLanguage: self.language
+                )
+                let speakerDetectionEnabled = Self.resolveSpeakerDetection(
+                    self.speakerDetection,
+                    storedEnabled: defaults.object(forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey) as? Bool,
+                    noDiarize: self.noDiarize
+                )
+                let processingMode = Self.resolveProcessingMode(
+                    self.mode,
+                    storedMode: defaults.string(forKey: UserDefaultsAppRuntimePreferences.processingModeKey)
+                )
+                let resolvedYouTubeAudioQuality = Self.resolveYouTubeAudioQuality(
+                    self.youtubeAudioQuality,
+                    storedQuality: defaults.string(forKey: UserDefaultsAppRuntimePreferences.youtubeAudioQualityKey)
+                )
+                let shouldKeepDownloadedAudio: Bool = switch self.downloadedAudio {
+                case .keep:
+                    true
+                case .delete:
+                    false
+                case .appDefault:
+                    defaults.object(forKey: UserDefaultsAppRuntimePreferences.saveTranscriptionAudioKey) as? Bool ?? true
+                }
                 let sttTranscriber: STTTranscribing
-                switch engine {
+                switch speechEngine.engine {
                 case .parakeet:
                     let createdSTTClient = STTClient()
                     sttClient = createdSTTClient
                     sttTranscriber = createdSTTClient
                 case .whisper:
-                    let createdWhisperEngine = WhisperEngine(language: language)
+                    let createdWhisperEngine = WhisperEngine(language: speechEngine.language)
                     whisperEngine = createdWhisperEngine
                     sttTranscriber = createdWhisperEngine
                 }
                 let audioProcessor = AudioProcessor()
                 let youtubeDownloader = YouTubeDownloader(audioQuality: {
-                    let defaults = macParakeetAppDefaults()
-                    return Self.resolveYouTubeAudioQuality(
-                        self.youtubeAudioQuality,
-                        storedQuality: defaults.string(forKey: UserDefaultsAppRuntimePreferences.youtubeAudioQualityKey)
-                    )
+                    resolvedYouTubeAudioQuality
                 })
                 let entitlementsService = enforceEntitlements ? makeEntitlementsService() : nil
 
@@ -156,7 +228,7 @@ struct TranscribeCommand: AsyncParsableCommand {
                     await entitlementsService.refreshValidationIfNeeded()
                 }
 
-                let diarizationService: DiarizationService? = noDiarize ? nil : DiarizationService()
+                let diarizationService: DiarizationService? = speakerDetectionEnabled ? DiarizationService() : nil
                 let service = TranscriptionService(
                     audioProcessor: audioProcessor,
                     sttTranscriber: sttTranscriber,
@@ -165,23 +237,12 @@ struct TranscribeCommand: AsyncParsableCommand {
                     customWordRepo: customWordRepo,
                     snippetRepo: snippetRepo,
                     processingMode: {
-                        let defaults = macParakeetAppDefaults()
-                        return Self.resolveProcessingMode(
-                            self.mode,
-                            storedMode: defaults.string(forKey: UserDefaultsAppRuntimePreferences.processingModeKey)
-                        )
+                        processingMode
                     },
                     shouldKeepDownloadedAudio: {
-                        switch self.downloadedAudio {
-                        case .keep:
-                            return true
-                        case .delete:
-                            return false
-                        case .appDefault:
-                            let defaults = macParakeetAppDefaults()
-                            return defaults.object(forKey: UserDefaultsAppRuntimePreferences.saveTranscriptionAudioKey) as? Bool ?? true
-                        }
+                        shouldKeepDownloadedAudio
                     },
+                    shouldDiarize: { speakerDetectionEnabled },
                     youtubeDownloader: youtubeDownloader,
                     diarizationService: diarizationService
                 )
@@ -222,7 +283,7 @@ struct TranscribeCommand: AsyncParsableCommand {
                         throw CLIError.unsupportedFormat(ext)
                     }
 
-                    printErr("Transcribing \(url.lastPathComponent) with \(engine.rawValue)...")
+                    printErr("Transcribing \(url.lastPathComponent) with \(speechEngine.engine.rawValue)...")
                     result = try await service.transcribe(fileURL: url)
                 }
 

--- a/Tests/CLITests/ConfigCommandTests.swift
+++ b/Tests/CLITests/ConfigCommandTests.swift
@@ -67,6 +67,11 @@ final class ConfigCommandTests: XCTestCase {
         XCTAssertEqual(try ConfigCommand.read(key: "youtube_audio_quality", defaults: defaults), "best-available")
     }
 
+    func testCanonicalKeyNormalizesUnderscoreAliases() throws {
+        XCTAssertEqual(try ConfigCommand.canonicalKey(" youtube_audio_quality "), "youtube-audio-quality")
+        XCTAssertEqual(try ConfigCommand.canonicalKey("SPEAKER_DETECTION"), "speaker-detection")
+    }
+
     func testReadUnknownKeyThrowsValidationError() {
         // Maps to errorType="validation" / exit code 2 in --json failure envelope.
         XCTAssertThrowsError(try ConfigCommand.read(key: "bogus", defaults: defaults)) { error in
@@ -114,6 +119,11 @@ final class ConfigCommandTests: XCTestCase {
             defaults.string(forKey: UserDefaultsAppRuntimePreferences.youtubeAudioQualityKey),
             YouTubeAudioQuality.bestAvailable.rawValue
         )
+    }
+
+    func testWriteCanonicalizesUnderscoreKeys() throws {
+        XCTAssertEqual(try ConfigCommand.write(key: "speaker_detection", value: "on", defaults: defaults), "on")
+        XCTAssertEqual(defaults.object(forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey) as? Bool, true)
     }
 
     func testWriteWhisperLanguageAutoClearsStoredDefault() throws {

--- a/Tests/CLITests/ConfigCommandTests.swift
+++ b/Tests/CLITests/ConfigCommandTests.swift
@@ -25,6 +25,18 @@ final class ConfigCommandTests: XCTestCase {
 
     // MARK: - read
 
+    func testSupportedKeysIncludeAgentTranscriptionDefaults() {
+        XCTAssertEqual(ConfigCommand.supportedKeys, [
+            "telemetry",
+            "processing-mode",
+            "speech-engine",
+            "whisper-language",
+            "speaker-detection",
+            "save-transcription-audio",
+            "youtube-audio-quality",
+        ])
+    }
+
     func testReadTelemetryDefaultsToOn() throws {
         // Mirror AppPreferences.isTelemetryEnabled: missing key → on.
         let value = try ConfigCommand.read(key: "telemetry", defaults: defaults)
@@ -39,6 +51,20 @@ final class ConfigCommandTests: XCTestCase {
     func testReadTelemetryReflectsExplicitTrue() throws {
         defaults.set(true, forKey: AppPreferences.telemetryEnabledKey)
         XCTAssertEqual(try ConfigCommand.read(key: "telemetry", defaults: defaults), "on")
+    }
+
+    func testReadAgentDefaultsReflectGUIFallbacks() throws {
+        XCTAssertEqual(try ConfigCommand.read(key: "processing-mode", defaults: defaults), "raw")
+        XCTAssertEqual(try ConfigCommand.read(key: "speech-engine", defaults: defaults), "parakeet")
+        XCTAssertEqual(try ConfigCommand.read(key: "whisper-language", defaults: defaults), "auto")
+        XCTAssertEqual(try ConfigCommand.read(key: "speaker-detection", defaults: defaults), "off")
+        XCTAssertEqual(try ConfigCommand.read(key: "save-transcription-audio", defaults: defaults), "on")
+        XCTAssertEqual(try ConfigCommand.read(key: "youtube-audio-quality", defaults: defaults), "m4a")
+    }
+
+    func testReadCanonicalizesUnderscoreKeys() throws {
+        defaults.set(YouTubeAudioQuality.bestAvailable.rawValue, forKey: UserDefaultsAppRuntimePreferences.youtubeAudioQualityKey)
+        XCTAssertEqual(try ConfigCommand.read(key: "youtube_audio_quality", defaults: defaults), "best-available")
     }
 
     func testReadUnknownKeyThrowsValidationError() {
@@ -64,6 +90,39 @@ final class ConfigCommandTests: XCTestCase {
         XCTAssertEqual(defaults.object(forKey: AppPreferences.telemetryEnabledKey) as? Bool, true)
     }
 
+    func testWriteAgentTranscriptionDefaultsPersist() throws {
+        XCTAssertEqual(try ConfigCommand.write(key: "processing-mode", value: "clean", defaults: defaults), "clean")
+        XCTAssertEqual(
+            defaults.string(forKey: UserDefaultsAppRuntimePreferences.processingModeKey),
+            Dictation.ProcessingMode.clean.rawValue
+        )
+
+        XCTAssertEqual(try ConfigCommand.write(key: "speech-engine", value: "whisper", defaults: defaults), "whisper")
+        XCTAssertEqual(defaults.string(forKey: SpeechEnginePreference.defaultsKey), SpeechEnginePreference.whisper.rawValue)
+
+        XCTAssertEqual(try ConfigCommand.write(key: "whisper-language", value: "ko", defaults: defaults), "ko")
+        XCTAssertEqual(defaults.string(forKey: SpeechEnginePreference.whisperDefaultLanguageKey), "ko")
+
+        XCTAssertEqual(try ConfigCommand.write(key: "speaker-detection", value: "on", defaults: defaults), "on")
+        XCTAssertEqual(defaults.object(forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey) as? Bool, true)
+
+        XCTAssertEqual(try ConfigCommand.write(key: "save-transcription-audio", value: "off", defaults: defaults), "off")
+        XCTAssertEqual(defaults.object(forKey: UserDefaultsAppRuntimePreferences.saveTranscriptionAudioKey) as? Bool, false)
+
+        XCTAssertEqual(try ConfigCommand.write(key: "youtube-audio-quality", value: "best-available", defaults: defaults), "best-available")
+        XCTAssertEqual(
+            defaults.string(forKey: UserDefaultsAppRuntimePreferences.youtubeAudioQualityKey),
+            YouTubeAudioQuality.bestAvailable.rawValue
+        )
+    }
+
+    func testWriteWhisperLanguageAutoClearsStoredDefault() throws {
+        defaults.set("ko", forKey: SpeechEnginePreference.whisperDefaultLanguageKey)
+
+        XCTAssertEqual(try ConfigCommand.write(key: "whisper-language", value: "auto", defaults: defaults), "auto")
+        XCTAssertNil(defaults.string(forKey: SpeechEnginePreference.whisperDefaultLanguageKey))
+    }
+
     func testWriteAcceptsAllBoolSynonyms() throws {
         for (synonym, expectedBool) in [
             ("on", true), ("ON", true), ("true", true), ("yes", true),
@@ -75,6 +134,18 @@ final class ConfigCommandTests: XCTestCase {
             XCTAssertEqual(canonical, expectedBool ? "on" : "off",
                            "Synonym '\(synonym)' should canonicalize to \(expectedBool ? "on" : "off")")
             XCTAssertEqual(defaults.object(forKey: AppPreferences.telemetryEnabledKey) as? Bool, expectedBool)
+        }
+    }
+
+    func testWriteRejectsInvalidAgentDefaultValues() {
+        XCTAssertThrowsError(try ConfigCommand.write(key: "processing-mode", value: "fancy", defaults: defaults)) { error in
+            XCTAssertTrue(error is ValidationError)
+        }
+        XCTAssertThrowsError(try ConfigCommand.write(key: "speech-engine", value: "cloud", defaults: defaults)) { error in
+            XCTAssertTrue(error is ValidationError)
+        }
+        XCTAssertThrowsError(try ConfigCommand.write(key: "youtube-audio-quality", value: "wav", defaults: defaults)) { error in
+            XCTAssertTrue(error is ValidationError)
         }
     }
 

--- a/Tests/CLITests/TranscribeCommandTests.swift
+++ b/Tests/CLITests/TranscribeCommandTests.swift
@@ -86,6 +86,45 @@ final class TranscribeCommandTests: XCTestCase {
         XCTAssertNil(selection.language)
     }
 
+    func testResolveSpeechEngineFallsBackToParakeetWhenStoredEngineUnset() {
+        // Fresh-install case: CLI-only user with no .app present, no key ever
+        // written to the shared UserDefaults suite. Agents should be able to
+        // install the CLI without the .app and still call `--engine app-default`.
+        let selection = TranscribeCommand.resolveSpeechEngine(
+            .appDefault,
+            storedEngine: nil,
+            storedLanguage: nil,
+            explicitLanguage: nil
+        )
+
+        XCTAssertEqual(selection.engine, .parakeet)
+        XCTAssertNil(selection.language)
+    }
+
+    func testResolveSpeechEngineExplicitWhisperUsesExplicitLanguageOnly() {
+        let selection = TranscribeCommand.resolveSpeechEngine(
+            .whisper,
+            storedEngine: SpeechEnginePreference.parakeet.rawValue,
+            storedLanguage: "ko",
+            explicitLanguage: nil
+        )
+
+        XCTAssertEqual(selection.engine, .whisper)
+        XCTAssertNil(selection.language)
+    }
+
+    func testResolveSpeechEngineExplicitParakeetDropsLanguage() {
+        let selection = TranscribeCommand.resolveSpeechEngine(
+            .parakeet,
+            storedEngine: SpeechEnginePreference.whisper.rawValue,
+            storedLanguage: "ko",
+            explicitLanguage: "ja"
+        )
+
+        XCTAssertEqual(selection.engine, .parakeet)
+        XCTAssertNil(selection.language)
+    }
+
     func testResolveSpeakerDetectionUsesStoredDefaultWhenRequested() {
         XCTAssertTrue(TranscribeCommand.resolveSpeakerDetection(.appDefault, storedEnabled: true, noDiarize: false))
         XCTAssertFalse(TranscribeCommand.resolveSpeakerDetection(.appDefault, storedEnabled: nil, noDiarize: false))

--- a/Tests/CLITests/TranscribeCommandTests.swift
+++ b/Tests/CLITests/TranscribeCommandTests.swift
@@ -50,6 +50,53 @@ final class TranscribeCommandTests: XCTestCase {
         XCTAssertEqual(quality, .bestAvailable)
     }
 
+    func testResolveSpeechEngineUsesStoredDefaultWhenRequested() {
+        let selection = TranscribeCommand.resolveSpeechEngine(
+            .appDefault,
+            storedEngine: SpeechEnginePreference.whisper.rawValue,
+            storedLanguage: "ko",
+            explicitLanguage: nil
+        )
+
+        XCTAssertEqual(selection.engine, .whisper)
+        XCTAssertEqual(selection.language, "ko")
+    }
+
+    func testResolveSpeechEngineExplicitLanguageOverridesStoredDefault() {
+        let selection = TranscribeCommand.resolveSpeechEngine(
+            .appDefault,
+            storedEngine: SpeechEnginePreference.whisper.rawValue,
+            storedLanguage: "ko",
+            explicitLanguage: "ja"
+        )
+
+        XCTAssertEqual(selection.engine, .whisper)
+        XCTAssertEqual(selection.language, "ja")
+    }
+
+    func testResolveSpeechEngineFallsBackToParakeetForInvalidStoredDefault() {
+        let selection = TranscribeCommand.resolveSpeechEngine(
+            .appDefault,
+            storedEngine: "bogus",
+            storedLanguage: "ko",
+            explicitLanguage: nil
+        )
+
+        XCTAssertEqual(selection.engine, .parakeet)
+        XCTAssertNil(selection.language)
+    }
+
+    func testResolveSpeakerDetectionUsesStoredDefaultWhenRequested() {
+        XCTAssertTrue(TranscribeCommand.resolveSpeakerDetection(.appDefault, storedEnabled: true, noDiarize: false))
+        XCTAssertFalse(TranscribeCommand.resolveSpeakerDetection(.appDefault, storedEnabled: nil, noDiarize: false))
+    }
+
+    func testResolveSpeakerDetectionRespectsExplicitAndLegacyDisableFlag() {
+        XCTAssertTrue(TranscribeCommand.resolveSpeakerDetection(.on, storedEnabled: false, noDiarize: false))
+        XCTAssertFalse(TranscribeCommand.resolveSpeakerDetection(.off, storedEnabled: true, noDiarize: false))
+        XCTAssertFalse(TranscribeCommand.resolveSpeakerDetection(.on, storedEnabled: true, noDiarize: true))
+    }
+
     func testParsesWhisperEngineAndLanguage() throws {
         let command = try TranscribeCommand.parse([
             "sample.wav",
@@ -59,6 +106,17 @@ final class TranscribeCommandTests: XCTestCase {
 
         XCTAssertEqual(command.engine, .whisper)
         XCTAssertEqual(command.language, "ko")
+    }
+
+    func testParsesAppDefaultEngineAndSpeakerDetection() throws {
+        let command = try TranscribeCommand.parse([
+            "sample.wav",
+            "--engine", "app-default",
+            "--speaker-detection", "app-default",
+        ])
+
+        XCTAssertEqual(command.engine, .appDefault)
+        XCTAssertEqual(command.speakerDetection, .appDefault)
     }
 
     func testParsesYouTubeAudioQuality() throws {
@@ -74,6 +132,7 @@ final class TranscribeCommandTests: XCTestCase {
         let command = try TranscribeCommand.parse(["sample.wav"])
         XCTAssertEqual(command.engine, .parakeet)
         XCTAssertNil(command.language)
+        XCTAssertEqual(command.speakerDetection, .on)
         XCTAssertEqual(command.youtubeAudioQuality, .appDefault)
     }
 

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -25,7 +25,9 @@ This script builds the latest debug binary, stops stale `/Applications`/`dist` a
 ```
 macparakeet-cli
 ├── transcribe <input> [options]         Transcribe a file or YouTube URL
-│   └── --engine parakeet|whisper [--language <code>] [--youtube-audio-quality app-default|m4a|best-available]
+│   └── --engine app-default|parakeet|whisper [--language <code>]
+│       --speaker-detection app-default|on|off
+│       --youtube-audio-quality app-default|m4a|best-available
 ├── history                              View and manage history
 │   ├── dictations [--limit] [--json]    List recent dictations (default)
 │   ├── transcriptions [--limit] [--json]  List recent transcriptions
@@ -38,6 +40,10 @@ macparakeet-cli
 │   └── unfavorite <id>                  Remove from favorites
 ├── export <id> [options]                Export a transcription to file
 ├── stats [--json]                       Show voice stats dashboard
+├── config                               Shared app/CLI preferences
+│   ├── list
+│   ├── get <key>
+│   └── set <key> <value>
 ├── health [--repair-models] [--repair-binaries] [--json]
 │                                         System health and model/helper status
 ├── models                               Speech model lifecycle
@@ -99,12 +105,18 @@ macparakeet-cli
 
 ## Core Modes
 
-### 1) GUI-Parity Mode (recommended for behavior checks)
+### 1) App-Default Mode (recommended for behavior checks)
 
-Uses app defaults for processing mode and YouTube audio retention.
+Uses app defaults for processing mode, speech engine, speaker detection, and
+YouTube audio retention. This is the best CLI mode for checking GUI behavior
+without controlling the GUI, but it is not full GUI parity: the CLI does not
+exercise GUI-only windowing, playback, hotkeys, PDF/DOCX export, or optional
+AI formatter output.
 
 ```bash
 swift run macparakeet-cli transcribe "<FILE_OR_YOUTUBE_URL>" \
+  --engine app-default \
+  --speaker-detection app-default \
   --mode app-default \
   --downloaded-audio app-default \
   --youtube-audio-quality app-default
@@ -116,6 +128,8 @@ Explicitly pins behavior.
 
 ```bash
 swift run macparakeet-cli transcribe "<FILE_OR_YOUTUBE_URL>" \
+  --engine parakeet \
+  --speaker-detection off \
   --mode raw \
   --downloaded-audio delete \
   --youtube-audio-quality m4a
@@ -125,6 +139,8 @@ Or clean mode with retained downloads:
 
 ```bash
 swift run macparakeet-cli transcribe "<FILE_OR_YOUTUBE_URL>" \
+  --engine parakeet \
+  --speaker-detection on \
   --mode clean \
   --downloaded-audio keep \
   --youtube-audio-quality best-available
@@ -137,7 +153,11 @@ the STT input.
 
 ### Speech Engine Selection
 
-Parakeet is the default and ignores `--language`. Use Whisper for languages outside Parakeet coverage after downloading the local Whisper model:
+Parakeet remains the no-flag default for semver stability and ignores
+`--language`. Use `--engine app-default` when you want the CLI to follow the
+GUI's saved speech engine and Whisper language defaults. Use Whisper explicitly
+for languages outside Parakeet coverage after downloading the local Whisper
+model:
 
 ```bash
 swift run macparakeet-cli models download whisper-large-v3-v20240930-turbo-632MB
@@ -148,14 +168,46 @@ swift run macparakeet-cli transcribe "<FILE_OR_YOUTUBE_URL>" \
 ```
 
 `--language auto` or omitting `--language` lets Whisper detect the language.
+When `--engine app-default` resolves to Whisper, an explicit `--language`
+overrides the saved Whisper language for that invocation. When `--engine
+whisper` is explicit, pass `--language` explicitly if you do not want
+auto-detect; the saved Whisper language is only used by `--engine app-default`.
 
 ### Speaker Diarization
 
-Diarization runs by default when transcribing. Disable with:
+Speaker detection runs by default for existing CLI compatibility. Disable with
+either the explicit option or the legacy alias:
 
 ```bash
+swift run macparakeet-cli transcribe "<FILE>" --speaker-detection off
 swift run macparakeet-cli transcribe "<FILE>" --no-diarize
 ```
+
+Use `--speaker-detection app-default` when validating the GUI's saved speaker
+detection preference. `config get speaker-detection` reports that saved
+app-default value, not the no-flag CLI default.
+
+### Shared Config
+
+`config` writes the same UserDefaults suite the GUI reads. This lets agents set
+up deterministic or app-default state before running a smoke test. Treat it as
+pre-run setup: a running GUI may cache some settings until relaunch or an
+in-app change.
+
+```bash
+swift run macparakeet-cli config list
+swift run macparakeet-cli config set processing-mode raw
+swift run macparakeet-cli config set speech-engine whisper
+swift run macparakeet-cli config set whisper-language ko
+swift run macparakeet-cli config set speaker-detection off
+swift run macparakeet-cli config set save-transcription-audio off
+swift run macparakeet-cli config set youtube-audio-quality m4a
+```
+
+Supported keys: `telemetry`, `processing-mode`, `speech-engine`,
+`whisper-language`, `speaker-detection`, `save-transcription-audio`,
+`youtube-audio-quality`. Underscore aliases such as `youtube_audio_quality`
+are accepted on input; JSON output uses canonical hyphenated keys.
 
 ### Output Formats
 

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -5,6 +5,49 @@
 > people running them) that want to *call* `macparakeet-cli` to add local STT
 > to their stack.
 
+## Scope of the CLI
+
+The CLI is a first-class automation surface, **not a GUI mirror.** It intentionally
+does not replicate every affordance the .app provides -- it exposes the parts
+that map cleanly to headless automation, agent invocation, and scriptable
+testing.
+
+### In scope
+
+- **Local transcription** -- audio, video, and YouTube to text, with engine
+  selection (Parakeet / Whisper) and per-invocation language hints.
+- **Scriptable shared defaults** -- `config get|set|list` over the same
+  preference suite the GUI reads (`com.macparakeet.MacParakeet`). CLI-only
+  installs work; a later GUI install picks up the same values.
+- **Stable JSON / read surfaces** -- every read-only command emits JSON with
+  schemas pinned to the major CLI version. Failure envelopes carry a stable
+  `errorType` so agents can branch deterministically.
+- **Model and binary health** -- `health` probes Parakeet / Whisper model
+  readiness, database accessibility, FFmpeg, and yt-dlp without mutating state.
+- **Persisted history** -- list, search, and inspect prior dictations and
+  transcriptions via the shared SQLite database.
+- **Prompt and meeting inspection** -- list and run prompt library entries
+  against transcriptions; list, show, transcript-dump, notes-append, and
+  export meeting recordings.
+- **Headless verification hooks** -- agents can drive deterministic runs (pin
+  all flags) or smoke-test GUI-default behavior (`--engine app-default`,
+  `--speaker-detection app-default`, `--mode app-default`).
+
+### Out of scope (by design)
+
+- **Interactive dictation** -- live mic capture, push-to-talk, the global
+  hotkey, and the dictation overlay are GUI surfaces. The CLI does not record
+  from the microphone.
+- **Live meeting UI** -- the Notes / Transcript / Ask three-tab live panel,
+  the floating meeting pill, and live recording controls are GUI-only. The CLI
+  inspects meeting artifacts after the fact.
+- **Onboarding, settings UI, library grids, sounds, overlays** -- none of these
+  have automation analogues; they remain in the .app.
+
+The principle: if a use case can be automated, scripted, or driven by an agent,
+the CLI should support it through a stable contract. If it requires a user
+sitting at a keyboard, it lives in the .app.
+
 ## What `macparakeet-cli` gives your agent
 
 - **Local Parakeet TDT speech-to-text** at ~155x realtime on Apple Silicon
@@ -95,7 +138,8 @@ macparakeet-cli transcribe /path/to/korean.mp3 --engine whisper --language ko --
 ```
 
 To test the same defaults a user selected in the GUI, opt into app-default
-resolution explicitly:
+resolution explicitly. This follows saved transcription defaults; it does not
+exercise GUI-only UI, playback, hotkey, export, or optional AI formatter output.
 
 ```bash
 macparakeet-cli transcribe /path/to/audio.mp3 \
@@ -106,7 +150,9 @@ macparakeet-cli transcribe /path/to/audio.mp3 \
   --format json
 ```
 
-Agents can also set those shared defaults without opening the GUI:
+Agents can also set those shared defaults without opening the GUI. Treat this
+as pre-run setup: a running GUI may cache some settings until relaunch or an
+in-app change.
 
 ```bash
 macparakeet-cli config set speech-engine whisper
@@ -116,6 +162,10 @@ macparakeet-cli config set speaker-detection off
 macparakeet-cli config set save-transcription-audio off
 macparakeet-cli config set youtube-audio-quality m4a
 ```
+
+`--engine whisper` uses Whisper with auto-detected language unless `--language`
+is passed. The saved Whisper language is used when `--engine app-default`
+resolves to Whisper.
 
 ### Transcribe a YouTube video
 
@@ -306,6 +356,9 @@ macparakeet-cli prompts run "<prompt-name>" \
 - Use `--engine app-default --speaker-detection app-default --mode app-default`
   only when you are intentionally checking GUI-default behavior. Pin explicit
   flags for reproducible agent tests.
+- `config get speaker-detection` reports the saved app-default value. Bare
+  `transcribe` keeps speaker detection on for compatibility, so pass
+  `--speaker-detection app-default` when you want the saved GUI preference.
 ````
 
 ## Conventions

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -16,6 +16,9 @@
   into MacParakeet's Application Support folder before first YouTube use.
 - **Persistent SQLite memory layer** -- everything transcribed is queryable
   later: dictation history, transcriptions, prompt outputs.
+- **Shared app/CLI preferences** -- agents can set speech engine, processing
+  mode, speaker detection, audio retention, YouTube audio quality, and
+  telemetry without driving the GUI.
 - **Prompt library + LLM-backed summarization** -- bring your own provider
   (OpenAI, Anthropic, Ollama, LM Studio, OpenAI-compatible local, or a
   configured CLI subprocess), or skip the LLM entirely and consume raw
@@ -78,8 +81,8 @@ the latest managed helper binary.
 macparakeet-cli transcribe /path/to/audio.mp3 --format json
 ```
 
-Parakeet is the default engine. Use Whisper per invocation for Korean or other
-non-Parakeet languages:
+Parakeet is the default engine for compatibility with existing scripts. Use
+Whisper per invocation for Korean or other non-Parakeet languages:
 
 Whisper requires a local model download before first use:
 
@@ -89,6 +92,29 @@ macparakeet-cli models download whisper-large-v3-v20240930-turbo-632MB
 
 ```bash
 macparakeet-cli transcribe /path/to/korean.mp3 --engine whisper --language ko --format json
+```
+
+To test the same defaults a user selected in the GUI, opt into app-default
+resolution explicitly:
+
+```bash
+macparakeet-cli transcribe /path/to/audio.mp3 \
+  --engine app-default \
+  --speaker-detection app-default \
+  --mode app-default \
+  --downloaded-audio app-default \
+  --format json
+```
+
+Agents can also set those shared defaults without opening the GUI:
+
+```bash
+macparakeet-cli config set speech-engine whisper
+macparakeet-cli config set whisper-language ko
+macparakeet-cli config set processing-mode raw
+macparakeet-cli config set speaker-detection off
+macparakeet-cli config set save-transcription-audio off
+macparakeet-cli config set youtube-audio-quality m4a
 ```
 
 ### Transcribe a YouTube video
@@ -240,6 +266,10 @@ user wants YouTube transcription, run
 macparakeet-cli transcribe "<path-or-youtube-url>" --format json
 macparakeet-cli models download whisper-large-v3-v20240930-turbo-632MB
 macparakeet-cli transcribe "<path-or-youtube-url>" --engine whisper --language ko --format json
+macparakeet-cli transcribe "<path-or-youtube-url>" --engine app-default --speaker-detection app-default --mode app-default --format json
+macparakeet-cli config list
+macparakeet-cli config set speech-engine parakeet
+macparakeet-cli config set speaker-detection off
 macparakeet-cli history transcriptions --json
 macparakeet-cli history search-transcriptions "<query>" --json
 macparakeet-cli history search "<query>" --json
@@ -273,6 +303,9 @@ macparakeet-cli prompts run "<prompt-name>" \
 - Never delete user database records unless the user explicitly requests it.
 - Prefer meeting ID or UUID prefix over title when mutating notes.
 - Keep API keys in environment variables; do not put literal keys in commands.
+- Use `--engine app-default --speaker-detection app-default --mode app-default`
+  only when you are intentionally checking GUI-default behavior. Pin explicit
+  flags for reproducible agent tests.
 ````
 
 ## Conventions


### PR DESCRIPTION
## Summary

- Treat the CLI as a first-class automation and agent feedback surface without chasing full GUI parity.
- Add explicit app-default transcription controls: `transcribe --engine app-default` and `--speaker-detection app-default|on|off`.
- Preserve semver-safe no-flag behavior: `transcribe` still defaults to Parakeet with speaker detection on, and `--no-diarize` still works.
- Expand `macparakeet-cli config get|set|list` so agents can set shared app/CLI defaults for processing mode, speech engine, Whisper language, speaker detection, transcription audio retention, and YouTube audio quality.
- Update CLI docs, integration guidance, changelog, and focused CLI tests.

## Surface Model

```text
              +-------------------+
              |   GUI Settings    |
              +---------+---------+
                        |
                        v
              +-------------------+
              | Shared Defaults   |
              | com.macparakeet   |
              +----+---------+----+
                   |         |
        +----------+         +-------------------+
        |                                      |
        v                                      v
+-------------------+              +---------------------------+
| GUI transcription |              | macparakeet-cli config    |
| and meeting flows |              | get / set / list          |
+-------------------+              +-------------+-------------+
                                                  |
                                                  v
                                    +---------------------------+
                                    | macparakeet-cli transcribe|
                                    +-------------+-------------+
                                                  |
               +----------------------------------+----------------------------------+
               |                                                                     |
               v                                                                     v
  deterministic agent run                                                app-default behavior check
  --engine parakeet                                                      --engine app-default
  --speaker-detection off                                                --speaker-detection app-default
  --mode raw                                                             --mode app-default
```

## Review Notes

- This intentionally does not make the CLI mirror every GUI affordance. The important support areas are local transcription, scriptable shared defaults, stable JSON/read surfaces, model/binary health, persisted history, prompt/meeting inspection, and headless verification hooks.
- The existing calendar CLI remains useful for headless inspection of the EventKit pipeline even while the GUI calendar surfaces are gated.
- `--engine app-default` follows the GUI's saved speech engine and Whisper language only when requested. This avoids turning a minor additive CLI change into a breaking default change.
- `--speaker-detection app-default` follows the GUI speaker-detection preference only when requested. Bare CLI transcription keeps the historical diarization-on behavior.
- Fresh review follow-up clarified app-default docs, canonicalized config JSON key output, documented default asymmetries, and addressed Gemini's maintainability comments on processing-mode defaults and key validation.

## Validation

- `swift test --filter 'TranscribeCommandTests|ConfigCommandTests'`
- `swift test --filter ConfigCommandTests`
- `swift run macparakeet-cli transcribe --help`
- `swift run macparakeet-cli config --help`
- `swift test`
  - 2384 XCTest tests passed
  - 10 tests skipped
  - 16 Swift Testing checks passed
