### PR TITLE
[codex] Implement split dictation shortcuts

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -270,15 +270,15 @@ final class AppEnvironmentConfigurer {
             onToggleMeetingRecording: callbacks.onToggleMeetingRecordingFromHotkey,
             onTriggerFileTranscription: callbacks.onTriggerFileTranscriptionFromHotkey,
             onTriggerYouTubeTranscription: callbacks.onTriggerYouTubeTranscriptionFromHotkey,
-            onPrimaryHotkeyManagerChanged: { manager in
-                coordinatorRefs.dictation?.hotkeyManager = manager
+            onDictationHotkeyManagersChanged: { managers in
+                coordinatorRefs.dictation?.hotkeyManagers = managers
             },
             onAnyHotkeyEnabled: callbacks.onHotkeyBecameAvailable,
             onHotkeyUnavailable: callbacks.onHotkeyUnavailable,
             onHotkeyConflict: callbacks.onHotkeyConflict
         )
 
-        hotkeyCoordinator.setupPrimaryHotkey()
+        hotkeyCoordinator.setupDictationHotkeys()
         hotkeyCoordinator.setupMeetingHotkey()
         hotkeyCoordinator.setupFileTranscriptionHotkey()
         hotkeyCoordinator.setupYouTubeTranscriptionHotkey()

--- a/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
+++ b/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
@@ -187,10 +187,14 @@ final class AppHotkeyCoordinator {
         guard !trigger.isDisabled else { return nil }
 
         let manager = HotkeyManager(trigger: trigger, gestureMode: gestureMode)
-        manager.onStartRecording = { [weak self] mode in
+        manager.onStartRecording = { [weak self, weak manager] mode in
+            if let manager {
+                self?.suppressOtherDictationHotkeys(activeManager: manager)
+            }
             self?.onStartDictation(mode)
         }
         manager.onStopRecording = { [weak self] in
+            self?.resetDictationHotkeyGestures()
             self?.onStopDictation()
         }
         manager.onCancelRecording = { [weak self] in
@@ -213,6 +217,16 @@ final class AppHotkeyCoordinator {
             onHotkeyUnavailable()
             return nil
         }
+    }
+
+    private func suppressOtherDictationHotkeys(activeManager: HotkeyManager) {
+        for manager in dictationHotkeyManagers where manager !== activeManager {
+            manager.suppressUntilReset()
+        }
+    }
+
+    private func resetDictationHotkeyGestures() {
+        dictationHotkeyManagers.forEach { $0.resetToIdle() }
     }
 
     func setupMeetingHotkey() {

--- a/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
+++ b/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
@@ -14,12 +14,12 @@ final class AppHotkeyCoordinator {
     private let onToggleMeetingRecording: () -> Void
     private let onTriggerFileTranscription: () -> Void
     private let onTriggerYouTubeTranscription: () -> Void
-    private let onPrimaryHotkeyManagerChanged: (HotkeyManager?) -> Void
+    private let onDictationHotkeyManagersChanged: ([HotkeyManager]) -> Void
     private let onAnyHotkeyEnabled: () -> Void
     private let onHotkeyUnavailable: () -> Void
     private let onHotkeyConflict: (HotkeyTrigger, [HotkeyTrigger]) -> Void
 
-    private var hotkeyManager: HotkeyManager?
+    private var dictationHotkeyManagers: [HotkeyManager] = []
     private var meetingHotkeyManager: GlobalShortcutManager?
     private var fileTranscriptionHotkeyManager: GlobalShortcutManager?
     private var youtubeTranscriptionHotkeyManager: GlobalShortcutManager?
@@ -35,7 +35,7 @@ final class AppHotkeyCoordinator {
         onToggleMeetingRecording: @escaping () -> Void,
         onTriggerFileTranscription: @escaping () -> Void,
         onTriggerYouTubeTranscription: @escaping () -> Void,
-        onPrimaryHotkeyManagerChanged: @escaping (HotkeyManager?) -> Void,
+        onDictationHotkeyManagersChanged: @escaping ([HotkeyManager]) -> Void,
         onAnyHotkeyEnabled: @escaping () -> Void,
         onHotkeyUnavailable: @escaping () -> Void,
         onHotkeyConflict: @escaping (HotkeyTrigger, [HotkeyTrigger]) -> Void
@@ -50,32 +50,143 @@ final class AppHotkeyCoordinator {
         self.onToggleMeetingRecording = onToggleMeetingRecording
         self.onTriggerFileTranscription = onTriggerFileTranscription
         self.onTriggerYouTubeTranscription = onTriggerYouTubeTranscription
-        self.onPrimaryHotkeyManagerChanged = onPrimaryHotkeyManagerChanged
+        self.onDictationHotkeyManagersChanged = onDictationHotkeyManagersChanged
         self.onAnyHotkeyEnabled = onAnyHotkeyEnabled
         self.onHotkeyUnavailable = onHotkeyUnavailable
         self.onHotkeyConflict = onHotkeyConflict
     }
 
     var hotkeyMenuTitle: String {
-        Self.menuTitle(for: HotkeyTrigger.current)
+        Self.menuTitle(
+            handsFree: settingsViewModel.hotkeyTrigger,
+            pushToTalk: settingsViewModel.pushToTalkHotkeyTrigger
+        )
+    }
+
+    struct DictationHotkeyPlan: Equatable {
+        struct Spec: Equatable {
+            let trigger: HotkeyTrigger
+            let gestureMode: HotkeyGestureController.Mode
+        }
+
+        struct Conflict: Equatable {
+            let trigger: HotkeyTrigger
+            let conflicts: [HotkeyTrigger]
+        }
+
+        let specs: [Spec]
+        let conflict: Conflict?
     }
 
     static func menuTitle(for trigger: HotkeyTrigger) -> String {
-        if trigger.isDisabled {
-            return "Hotkey: Disabled"
-        }
-        return "Hotkey: \(trigger.displayName) (double-tap / hold)"
+        menuTitle(handsFree: trigger, pushToTalk: trigger)
     }
 
-    func setupPrimaryHotkey() {
-        let trigger = HotkeyTrigger.current
-        guard !trigger.isDisabled else {
-            hotkeyManager = nil
-            onPrimaryHotkeyManagerChanged(nil)
-            return
+    static func menuTitle(handsFree: HotkeyTrigger, pushToTalk: HotkeyTrigger) -> String {
+        if handsFree.isDisabled && pushToTalk.isDisabled {
+            return "Dictation Shortcuts: Disabled"
+        }
+        if !handsFree.isDisabled, handsFree == pushToTalk {
+            return "Dictation: \(handsFree.displayName) (hold or double-tap)"
+        }
+        if handsFree.isDisabled {
+            return "Push-to-talk: Hold \(pushToTalk.displayName)"
+        }
+        if pushToTalk.isDisabled {
+            return "Hands-free: Double-tap \(handsFree.displayName)"
+        }
+        return "Dictation: Hold \(pushToTalk.displayName) / Double-tap \(handsFree.displayName)"
+    }
+
+    static func dictationHotkeyPlan(
+        handsFree handsFreeTrigger: HotkeyTrigger,
+        pushToTalk pushToTalkTrigger: HotkeyTrigger
+    ) -> DictationHotkeyPlan {
+        guard !handsFreeTrigger.isDisabled || !pushToTalkTrigger.isDisabled else {
+            return DictationHotkeyPlan(specs: [], conflict: nil)
         }
 
-        let manager = HotkeyManager(trigger: trigger)
+        if !handsFreeTrigger.isDisabled, !pushToTalkTrigger.isDisabled {
+            if handsFreeTrigger == pushToTalkTrigger {
+                return DictationHotkeyPlan(
+                    specs: [
+                        DictationHotkeyPlan.Spec(
+                            trigger: handsFreeTrigger,
+                            gestureMode: .doubleTapAndHold
+                        ),
+                    ],
+                    conflict: nil
+                )
+            }
+
+            if handsFreeTrigger.overlaps(with: pushToTalkTrigger) {
+                return DictationHotkeyPlan(
+                    specs: [
+                        DictationHotkeyPlan.Spec(
+                            trigger: handsFreeTrigger,
+                            gestureMode: .doubleTapOnly
+                        ),
+                    ],
+                    conflict: DictationHotkeyPlan.Conflict(
+                        trigger: pushToTalkTrigger,
+                        conflicts: [handsFreeTrigger]
+                    )
+                )
+            }
+        }
+
+        var specs: [DictationHotkeyPlan.Spec] = []
+        if !handsFreeTrigger.isDisabled {
+            specs.append(
+                DictationHotkeyPlan.Spec(
+                    trigger: handsFreeTrigger,
+                    gestureMode: .doubleTapOnly
+                )
+            )
+        }
+        if !pushToTalkTrigger.isDisabled {
+            specs.append(
+                DictationHotkeyPlan.Spec(
+                    trigger: pushToTalkTrigger,
+                    gestureMode: .holdOnly
+                )
+            )
+        }
+        return DictationHotkeyPlan(specs: specs, conflict: nil)
+    }
+
+    func setupDictationHotkeys() {
+        let plan = Self.dictationHotkeyPlan(
+            handsFree: settingsViewModel.hotkeyTrigger,
+            pushToTalk: settingsViewModel.pushToTalkHotkeyTrigger
+        )
+        if let conflict = plan.conflict {
+            onHotkeyConflict(conflict.trigger, conflict.conflicts)
+        }
+
+        let managers = plan.specs.compactMap { spec in
+            startDictationHotkey(
+                trigger: spec.trigger,
+                gestureMode: spec.gestureMode
+            )
+        }
+        dictationHotkeyManagers = managers
+        onDictationHotkeyManagersChanged(managers)
+    }
+
+    private func stopDictationHotkeys() {
+        dictationHotkeyManagers.forEach { $0.stop() }
+        dictationHotkeyManagers = []
+        onDictationHotkeyManagersChanged([])
+    }
+
+    private func startDictationHotkey(
+        trigger: HotkeyTrigger,
+        gestureMode: HotkeyGestureController.Mode
+    ) -> HotkeyManager? {
+        guard !trigger.isDisabled else { return nil }
+
+        let manager = HotkeyManager(trigger: trigger, gestureMode: gestureMode)
         manager.onStartRecording = { [weak self] mode in
             self?.onStartDictation(mode)
         }
@@ -96,13 +207,11 @@ final class AppHotkeyCoordinator {
         }
 
         if manager.start() {
-            hotkeyManager = manager
-            onPrimaryHotkeyManagerChanged(manager)
             onAnyHotkeyEnabled()
+            return manager
         } else {
-            hotkeyManager = nil
-            onPrimaryHotkeyManagerChanged(nil)
             onHotkeyUnavailable()
+            return nil
         }
     }
 
@@ -115,6 +224,7 @@ final class AppHotkeyCoordinator {
             trigger: settingsViewModel.meetingHotkeyTrigger,
             conflicts: [
                 settingsViewModel.hotkeyTrigger,
+                settingsViewModel.pushToTalkHotkeyTrigger,
                 settingsViewModel.fileTranscriptionHotkeyTrigger,
                 settingsViewModel.youtubeTranscriptionHotkeyTrigger,
             ],
@@ -129,6 +239,7 @@ final class AppHotkeyCoordinator {
             trigger: settingsViewModel.fileTranscriptionHotkeyTrigger,
             conflicts: [
                 settingsViewModel.hotkeyTrigger,
+                settingsViewModel.pushToTalkHotkeyTrigger,
                 settingsViewModel.meetingHotkeyTrigger,
                 settingsViewModel.youtubeTranscriptionHotkeyTrigger,
             ],
@@ -143,6 +254,7 @@ final class AppHotkeyCoordinator {
             trigger: settingsViewModel.youtubeTranscriptionHotkeyTrigger,
             conflicts: [
                 settingsViewModel.hotkeyTrigger,
+                settingsViewModel.pushToTalkHotkeyTrigger,
                 settingsViewModel.meetingHotkeyTrigger,
                 settingsViewModel.fileTranscriptionHotkeyTrigger,
             ],
@@ -161,7 +273,9 @@ final class AppHotkeyCoordinator {
         onTrigger: @escaping @MainActor () -> Void
     ) -> GlobalShortcutManager? {
         guard !trigger.isDisabled else { return nil }
-        let overlappingTriggers = conflicts.filter { !$0.isDisabled && $0.overlaps(with: trigger) }
+        let overlappingTriggers = Self.uniqueTriggers(
+            conflicts.filter { !$0.isDisabled && $0.overlaps(with: trigger) }
+        )
         if !overlappingTriggers.isEmpty {
             onHotkeyConflict(trigger, overlappingTriggers)
             return nil
@@ -183,17 +297,23 @@ final class AppHotkeyCoordinator {
         }
     }
 
+    private static func uniqueTriggers(_ triggers: [HotkeyTrigger]) -> [HotkeyTrigger] {
+        var unique: [HotkeyTrigger] = []
+        for trigger in triggers where !unique.contains(trigger) {
+            unique.append(trigger)
+        }
+        return unique
+    }
+
     func refreshAllHotkeys() {
-        hotkeyManager?.stop()
+        stopDictationHotkeys()
         meetingHotkeyManager?.stop()
         fileTranscriptionHotkeyManager?.stop()
         youtubeTranscriptionHotkeyManager?.stop()
-        hotkeyManager = nil
         meetingHotkeyManager = nil
         fileTranscriptionHotkeyManager = nil
         youtubeTranscriptionHotkeyManager = nil
-        onPrimaryHotkeyManagerChanged(nil)
-        setupPrimaryHotkey()
+        setupDictationHotkeys()
         setupMeetingHotkey()
         setupFileTranscriptionHotkey()
         setupYouTubeTranscriptionHotkey()
@@ -240,14 +360,12 @@ final class AppHotkeyCoordinator {
     }
 
     func stopAll() {
-        hotkeyManager?.stop()
+        stopDictationHotkeys()
         meetingHotkeyManager?.stop()
         fileTranscriptionHotkeyManager?.stop()
         youtubeTranscriptionHotkeyManager?.stop()
-        hotkeyManager = nil
         meetingHotkeyManager = nil
         fileTranscriptionHotkeyManager = nil
         youtubeTranscriptionHotkeyManager = nil
-        onPrimaryHotkeyManagerChanged(nil)
     }
 }

--- a/Sources/MacParakeet/App/AppSettingsObserverCoordinator.swift
+++ b/Sources/MacParakeet/App/AppSettingsObserverCoordinator.swift
@@ -6,6 +6,7 @@ final class AppSettingsObserverCoordinator {
     private let onOpenOnboarding: () -> Void
     private let onOpenSettings: () -> Void
     private let onHotkeyTriggerChanged: () -> Void
+    private let onPushToTalkHotkeyTriggerChanged: () -> Void
     private let onMeetingHotkeyTriggerChanged: () -> Void
     private let onFileTranscriptionHotkeyTriggerChanged: () -> Void
     private let onYouTubeTranscriptionHotkeyTriggerChanged: () -> Void
@@ -15,6 +16,7 @@ final class AppSettingsObserverCoordinator {
     private var onboardingObserver: Any?
     private var settingsObserver: Any?
     private var hotkeyTriggerObserver: Any?
+    private var pushToTalkHotkeyTriggerObserver: Any?
     private var meetingHotkeyTriggerObserver: Any?
     private var fileTranscriptionHotkeyTriggerObserver: Any?
     private var youtubeTranscriptionHotkeyTriggerObserver: Any?
@@ -26,6 +28,7 @@ final class AppSettingsObserverCoordinator {
         onOpenOnboarding: @escaping () -> Void,
         onOpenSettings: @escaping () -> Void,
         onHotkeyTriggerChanged: @escaping () -> Void,
+        onPushToTalkHotkeyTriggerChanged: @escaping () -> Void,
         onMeetingHotkeyTriggerChanged: @escaping () -> Void,
         onFileTranscriptionHotkeyTriggerChanged: @escaping () -> Void,
         onYouTubeTranscriptionHotkeyTriggerChanged: @escaping () -> Void,
@@ -36,6 +39,7 @@ final class AppSettingsObserverCoordinator {
         self.onOpenOnboarding = onOpenOnboarding
         self.onOpenSettings = onOpenSettings
         self.onHotkeyTriggerChanged = onHotkeyTriggerChanged
+        self.onPushToTalkHotkeyTriggerChanged = onPushToTalkHotkeyTriggerChanged
         self.onMeetingHotkeyTriggerChanged = onMeetingHotkeyTriggerChanged
         self.onFileTranscriptionHotkeyTriggerChanged = onFileTranscriptionHotkeyTriggerChanged
         self.onYouTubeTranscriptionHotkeyTriggerChanged = onYouTubeTranscriptionHotkeyTriggerChanged
@@ -73,6 +77,16 @@ final class AppSettingsObserverCoordinator {
         ) { [weak self] _ in
             Task { @MainActor in
                 self?.onHotkeyTriggerChanged()
+            }
+        }
+
+        pushToTalkHotkeyTriggerObserver = notificationCenter.addObserver(
+            forName: .macParakeetPushToTalkHotkeyTriggerDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.onPushToTalkHotkeyTriggerChanged()
             }
         }
 
@@ -139,6 +153,10 @@ final class AppSettingsObserverCoordinator {
         if let hotkeyTriggerObserver {
             notificationCenter.removeObserver(hotkeyTriggerObserver)
             self.hotkeyTriggerObserver = nil
+        }
+        if let pushToTalkHotkeyTriggerObserver {
+            notificationCenter.removeObserver(pushToTalkHotkeyTriggerObserver)
+            self.pushToTalkHotkeyTriggerObserver = nil
         }
         if let meetingHotkeyTriggerObserver {
             notificationCenter.removeObserver(meetingHotkeyTriggerObserver)

--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -60,8 +60,8 @@ final class DictationFlowCoordinator {
         }
     }
 
-    /// Set after init; updated when hotkey manager is recreated
-    var hotkeyManager: HotkeyManager?
+    /// Set after init; updated when dictation hotkey managers are recreated.
+    var hotkeyManagers: [HotkeyManager] = []
 
     // MARK: - Dependencies
 
@@ -102,7 +102,7 @@ final class DictationFlowCoordinator {
     /// Error from the most recent entitlements check failure, consumed by presentEntitlementsAlert effect.
     private var lastEntitlementsError: Error?
     private var readyPillDismissDelayMs: Int {
-        (hotkeyManager?.tapThresholdMs ?? FnKeyStateMachine.defaultTapThresholdMs) * 2
+        (hotkeyManagers.first?.tapThresholdMs ?? FnKeyStateMachine.defaultTapThresholdMs) * 2
     }
 
     // MARK: - Init
@@ -516,10 +516,10 @@ final class DictationFlowCoordinator {
             onMenuBarIconUpdate(iconState)
 
         case .resetHotkeyStateMachine:
-            hotkeyManager?.resetToIdle()
+            hotkeyManagers.forEach { $0.resetToIdle() }
 
         case .notifyHotkeyCancelledByUI:
-            hotkeyManager?.notifyCancelledByUI()
+            hotkeyManagers.forEach { $0.notifyCancelledByUI() }
 
         case .presentEntitlementsAlert:
             if let error = lastEntitlementsError {

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -158,7 +158,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.appEnvironment
         },
         hotkeyMenuTitleProvider: { [weak self] in
-            self?.hotkeyMenuTitle ?? AppHotkeyCoordinator.menuTitle(for: HotkeyTrigger.current)
+            self?.hotkeyMenuTitle ?? AppHotkeyCoordinator.menuTitle(handsFree: .defaultDictation, pushToTalk: .defaultPushToTalk)
         },
         meetingHotkeyTriggerProvider: { [weak self] in
             self?.settingsViewModel.meetingHotkeyTrigger ?? .defaultMeetingRecording
@@ -198,6 +198,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.windowCoordinator.openMainWindowToSettings()
         },
         onHotkeyTriggerChanged: { [weak self] in
+            self?.handleHotkeyTriggerChange()
+        },
+        onPushToTalkHotkeyTriggerChanged: { [weak self] in
             self?.handleHotkeyTriggerChange()
         },
         onMeetingHotkeyTriggerChanged: { [weak self] in
@@ -459,7 +462,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private var hotkeyMenuTitle: String {
         hotkeyCoordinator?.hotkeyMenuTitle
-            ?? AppHotkeyCoordinator.menuTitle(for: HotkeyTrigger.current)
+            ?? AppHotkeyCoordinator.menuTitle(
+                handsFree: settingsViewModel.hotkeyTrigger,
+                pushToTalk: settingsViewModel.pushToTalkHotkeyTrigger
+            )
     }
 
     // MARK: - Menu Bar Icon State

--- a/Sources/MacParakeet/Hotkey/HotkeyManager.swift
+++ b/Sources/MacParakeet/Hotkey/HotkeyManager.swift
@@ -664,6 +664,13 @@ public final class HotkeyManager {
         activeRecordingMode = nil
     }
 
+    public func suppressUntilReset() {
+        cancelStartupTimer()
+        cancelHoldTimer()
+        gestureController.suppressUntilReset()
+        activeRecordingMode = nil
+    }
+
     /// Resume recording mode after undo, so hotkey stops the recording correctly.
     public func resumeRecording(mode: FnKeyStateMachine.RecordingMode) {
         gestureController.resumeRecording(mode: mode)

--- a/Sources/MacParakeet/Hotkey/HotkeyManager.swift
+++ b/Sources/MacParakeet/Hotkey/HotkeyManager.swift
@@ -58,10 +58,14 @@ public final class HotkeyManager {
 
     public init(
         trigger: HotkeyTrigger = .fn,
+        gestureMode: HotkeyGestureController.Mode = .doubleTapAndHold,
         tapThresholdMs: Int = FnKeyStateMachine.defaultTapThresholdMs
     ) {
         self.trigger = trigger
-        self.gestureController = HotkeyGestureController(tapThresholdMs: tapThresholdMs)
+        self.gestureController = HotkeyGestureController(
+            mode: gestureMode,
+            tapThresholdMs: tapThresholdMs
+        )
         self.tapThresholdMs = self.gestureController.tapThresholdMs
         self.targetMask = trigger.kind == .modifier ? ModifierKeyMatcher.mask(for: trigger.modifierName) : nil
         self.requiredChordFlags = trigger.chordEventFlags
@@ -400,6 +404,24 @@ public final class HotkeyManager {
         return decision
     }
 
+    func keyCodeEventDecisionForTesting(
+        type: CGEventType,
+        keyCode: UInt16,
+        timestampMs: UInt64
+    ) -> (outputs: [HotkeyGestureController.Output], shouldSwallow: Bool) {
+        guard let triggerCode = trigger.keyCode else {
+            return ([], false)
+        }
+        let decision = keyCodeEventDecision(
+            type: type,
+            keyCode: keyCode,
+            triggerCode: triggerCode,
+            timestampMs: timestampMs
+        )
+        rememberRecordingState(for: decision.outputs)
+        return decision
+    }
+
     func modifierChordFlagsChangedOutputsForTesting(
         flags: CGEventFlags,
         timestampMs: UInt64
@@ -427,39 +449,51 @@ public final class HotkeyManager {
 
         let timestampMs = UInt64(event.timestamp / 1_000_000)
         let keyCode = UInt16(event.getIntegerValueField(.keyboardEventKeycode))
+        let decision = keyCodeEventDecision(
+            type: type,
+            keyCode: keyCode,
+            triggerCode: triggerCode,
+            timestampMs: timestampMs
+        )
+        handleOutputs(decision.outputs)
 
+        return decision.shouldSwallow ? nil : Unmanaged.passUnretained(event)
+    }
+
+    private func keyCodeEventDecision(
+        type: CGEventType,
+        keyCode: UInt16,
+        triggerCode: UInt16,
+        timestampMs: UInt64
+    ) -> (outputs: [HotkeyGestureController.Output], shouldSwallow: Bool) {
         if type == .keyDown {
             if keyCode == triggerCode {
                 // Edge detection: ignore key-repeat (macOS sends repeated keyDown for held keys)
                 guard !triggerKeyIsPressed else {
-                    return nil // Swallow repeated keyDown
+                    return ([], true)
                 }
                 triggerKeyIsPressed = true
 
-                handleOutputs(gestureController.triggerPressed(timestampMs: timestampMs))
-
-                return nil // Swallow the trigger key event
+                return (gestureController.triggerPressed(timestampMs: timestampMs), true)
             } else if keyCode == 53 { // Escape
-                handleOutputs(gestureController.escapePressed())
+                return (gestureController.escapePressed(), false)
             } else {
                 // Gesture interruption: if waiting for second tap, a regular key press
                 // means the user is typing, not double-tapping the hotkey
-                handleOutputs(gestureController.interrupted())
+                return (gestureController.interrupted(), false)
             }
         } else if type == .keyUp {
             if keyCode == triggerCode {
                 guard triggerKeyIsPressed else {
-                    return nil // Swallow stale keyUp
+                    return ([], true)
                 }
                 triggerKeyIsPressed = false
-                handleOutputs(gestureController.triggerReleased(timestampMs: timestampMs))
-
-                return nil // Swallow the trigger key event
+                return (gestureController.triggerReleased(timestampMs: timestampMs), true)
             }
         }
         // flagsChanged events are ignored for keyCode triggers
 
-        return Unmanaged.passUnretained(event)
+        return ([], false)
     }
 
     // MARK: - Chord Trigger Path

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -480,18 +480,43 @@ struct SettingsView: View {
     private var dictationCard: some View {
         settingsCard(
             title: "Dictation",
-            subtitle: "Global hotkey and silence behavior.",
+            subtitle: "Global shortcuts and silence behavior.",
             icon: "waveform"
         ) {
             VStack(spacing: DesignSystem.Spacing.md) {
                 HStack(alignment: .center) {
                     rowText(
-                        title: "Hotkey",
-                        detail: "System-wide key used to start and stop dictation."
+                        title: "Push to talk",
+                        detail: "Hold to dictate, release to stop."
                     )
                     Spacer(minLength: DesignSystem.Spacing.md)
                     VStack(alignment: .trailing, spacing: 4) {
-                        HotkeyRecorderView(trigger: $viewModel.hotkeyTrigger) { candidate in
+                        HotkeyRecorderView(
+                            trigger: $viewModel.pushToTalkHotkeyTrigger,
+                            defaultTrigger: .defaultPushToTalk
+                        ) { candidate in
+                            pushToTalkHotkeyValidation(for: candidate)
+                        }
+
+                        if let conflict = pushToTalkHotkeyConflictMessage(for: viewModel.pushToTalkHotkeyTrigger) {
+                            hotkeyConflictText(conflict)
+                        }
+                    }
+                }
+
+                Divider()
+
+                HStack(alignment: .center) {
+                    rowText(
+                        title: "Hands-free mode",
+                        detail: "Double-tap to start; tap again to stop."
+                    )
+                    Spacer(minLength: DesignSystem.Spacing.md)
+                    VStack(alignment: .trailing, spacing: 4) {
+                        HotkeyRecorderView(
+                            trigger: $viewModel.hotkeyTrigger,
+                            defaultTrigger: .defaultDictation
+                        ) { candidate in
                             dictationHotkeyValidation(for: candidate)
                         }
 
@@ -501,7 +526,7 @@ struct SettingsView: View {
                     }
                 }
 
-                if !viewModel.hotkeyTrigger.isDisabled {
+                if !viewModel.hotkeyTrigger.isDisabled || !viewModel.pushToTalkHotkeyTrigger.isDisabled {
                     Divider()
 
                     dictationModeGuide
@@ -775,7 +800,8 @@ struct SettingsView: View {
                     defaultTrigger: .disabled
                 ) { candidate in
                     guard !candidate.isDisabled else { return .allowed }
-                    if candidate.overlaps(with: viewModel.hotkeyTrigger) {
+                    if candidate.overlaps(with: viewModel.hotkeyTrigger)
+                        || candidate.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
                         return .blocked("Already used by dictation.")
                     }
                     if AppFeatures.meetingRecordingEnabled, candidate.overlaps(with: viewModel.meetingHotkeyTrigger) {
@@ -804,7 +830,8 @@ struct SettingsView: View {
         otherTranscriptionName: String
     ) -> String? {
         guard !trigger.isDisabled else { return nil }
-        if trigger.overlaps(with: viewModel.hotkeyTrigger) {
+        if trigger.overlaps(with: viewModel.hotkeyTrigger)
+            || trigger.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
             return "Disabled — conflicts with dictation hotkey."
         }
         if AppFeatures.meetingRecordingEnabled, trigger.overlaps(with: viewModel.meetingHotkeyTrigger) {
@@ -818,6 +845,28 @@ struct SettingsView: View {
 
     private func dictationHotkeyValidation(for candidate: HotkeyTrigger) -> HotkeyTrigger.ValidationResult {
         guard !candidate.isDisabled else { return .allowed }
+        if candidate != viewModel.pushToTalkHotkeyTrigger,
+           candidate.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
+            return .blocked("Overlaps with push to talk.")
+        }
+        if AppFeatures.meetingRecordingEnabled, candidate.overlaps(with: viewModel.meetingHotkeyTrigger) {
+            return .blocked("Already used by meeting recording.")
+        }
+        if candidate.overlaps(with: viewModel.fileTranscriptionHotkeyTrigger) {
+            return .blocked("Already used by file transcription.")
+        }
+        if candidate.overlaps(with: viewModel.youtubeTranscriptionHotkeyTrigger) {
+            return .blocked("Already used by YouTube transcription.")
+        }
+        return .allowed
+    }
+
+    private func pushToTalkHotkeyValidation(for candidate: HotkeyTrigger) -> HotkeyTrigger.ValidationResult {
+        guard !candidate.isDisabled else { return .allowed }
+        if candidate != viewModel.hotkeyTrigger,
+           candidate.overlaps(with: viewModel.hotkeyTrigger) {
+            return .blocked("Overlaps with hands-free mode.")
+        }
         if AppFeatures.meetingRecordingEnabled, candidate.overlaps(with: viewModel.meetingHotkeyTrigger) {
             return .blocked("Already used by meeting recording.")
         }
@@ -832,7 +881,8 @@ struct SettingsView: View {
 
     private func meetingHotkeyValidation(for candidate: HotkeyTrigger) -> HotkeyTrigger.ValidationResult {
         guard !candidate.isDisabled else { return .allowed }
-        if candidate.overlaps(with: viewModel.hotkeyTrigger) {
+        if candidate.overlaps(with: viewModel.hotkeyTrigger)
+            || candidate.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
             return .blocked("Already used by dictation.")
         }
         if candidate.overlaps(with: viewModel.fileTranscriptionHotkeyTrigger) {
@@ -846,6 +896,28 @@ struct SettingsView: View {
 
     private func dictationHotkeyConflictMessage(for trigger: HotkeyTrigger) -> String? {
         guard !trigger.isDisabled else { return nil }
+        if trigger != viewModel.pushToTalkHotkeyTrigger,
+           trigger.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
+            return "Disabled — overlaps with push to talk."
+        }
+        if AppFeatures.meetingRecordingEnabled, trigger.overlaps(with: viewModel.meetingHotkeyTrigger) {
+            return "Disabled — conflicts with meeting recording hotkey."
+        }
+        if trigger.overlaps(with: viewModel.fileTranscriptionHotkeyTrigger) {
+            return "Disabled — conflicts with file transcription hotkey."
+        }
+        if trigger.overlaps(with: viewModel.youtubeTranscriptionHotkeyTrigger) {
+            return "Disabled — conflicts with YouTube transcription hotkey."
+        }
+        return nil
+    }
+
+    private func pushToTalkHotkeyConflictMessage(for trigger: HotkeyTrigger) -> String? {
+        guard !trigger.isDisabled else { return nil }
+        if trigger != viewModel.hotkeyTrigger,
+           trigger.overlaps(with: viewModel.hotkeyTrigger) {
+            return "Disabled — overlaps with hands-free mode."
+        }
         if AppFeatures.meetingRecordingEnabled, trigger.overlaps(with: viewModel.meetingHotkeyTrigger) {
             return "Disabled — conflicts with meeting recording hotkey."
         }
@@ -860,7 +932,8 @@ struct SettingsView: View {
 
     private func meetingHotkeyConflictMessage(for trigger: HotkeyTrigger) -> String? {
         guard !trigger.isDisabled else { return nil }
-        if trigger.overlaps(with: viewModel.hotkeyTrigger) {
+        if trigger.overlaps(with: viewModel.hotkeyTrigger)
+            || trigger.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
             return "Disabled — conflicts with dictation hotkey."
         }
         if trigger.overlaps(with: viewModel.fileTranscriptionHotkeyTrigger) {
@@ -1798,22 +1871,28 @@ struct SettingsView: View {
 
     private var dictationModeGuide: some View {
         VStack(spacing: 0) {
-            modeShortcutRow(
-                keys: [viewModel.hotkeyTrigger.shortSymbol, viewModel.hotkeyTrigger.shortSymbol],
-                separator: "·",
-                action: "Persistent dictation",
-                detail: "Tap again to stop"
-            )
+            if !viewModel.pushToTalkHotkeyTrigger.isDisabled {
+                modeShortcutRow(
+                    keys: [viewModel.pushToTalkHotkeyTrigger.shortSymbol],
+                    separator: nil,
+                    action: "Push to talk",
+                    detail: "Release to stop"
+                )
+            }
 
-            Divider()
-                .padding(.leading, 88)
+            if !viewModel.pushToTalkHotkeyTrigger.isDisabled && !viewModel.hotkeyTrigger.isDisabled {
+                Divider()
+                    .padding(.leading, 88)
+            }
 
-            modeShortcutRow(
-                keys: [viewModel.hotkeyTrigger.shortSymbol],
-                separator: nil,
-                action: "Push-to-talk",
-                detail: "Release to stop"
-            )
+            if !viewModel.hotkeyTrigger.isDisabled {
+                modeShortcutRow(
+                    keys: [viewModel.hotkeyTrigger.shortSymbol, viewModel.hotkeyTrigger.shortSymbol],
+                    separator: "·",
+                    action: "Hands-free mode",
+                    detail: "Tap again to stop"
+                )
+            }
         }
         .padding(DesignSystem.Spacing.sm)
         .background(

--- a/Sources/MacParakeetCore/AppNotifications.swift
+++ b/Sources/MacParakeetCore/AppNotifications.swift
@@ -4,6 +4,7 @@ public extension Notification.Name {
     static let macParakeetOpenOnboarding = Notification.Name("macparakeet.openOnboarding")
     static let macParakeetOpenSettings = Notification.Name("macparakeet.openSettings")
     static let macParakeetHotkeyTriggerDidChange = Notification.Name("macparakeet.hotkeyTriggerDidChange")
+    static let macParakeetPushToTalkHotkeyTriggerDidChange = Notification.Name("macparakeet.pushToTalkHotkeyTriggerDidChange")
     static let macParakeetMeetingHotkeyTriggerDidChange = Notification.Name("macparakeet.meetingHotkeyTriggerDidChange")
     static let macParakeetFileTranscriptionHotkeyTriggerDidChange = Notification.Name("macparakeet.fileTranscriptionHotkeyTriggerDidChange")
     static let macParakeetYouTubeTranscriptionHotkeyTriggerDidChange = Notification.Name("macparakeet.youtubeTranscriptionHotkeyTriggerDidChange")

--- a/Sources/MacParakeetCore/STT/FnKeyStateMachine.swift
+++ b/Sources/MacParakeetCore/STT/FnKeyStateMachine.swift
@@ -206,6 +206,12 @@ public final class FnKeyStateMachine {
         }
     }
 
+    /// Block this trigger until the owning flow explicitly resets it.
+    public func blockUntilReset() {
+        state = .cancelWindow
+        hasActiveProvisionalRecording = false
+    }
+
     /// Resume recording after undo — sets the state machine to the active recording mode
     /// so Fn key gestures work correctly.
     public func resumeRecording(mode: RecordingMode) {

--- a/Sources/MacParakeetCore/STT/HotkeyGestureController.swift
+++ b/Sources/MacParakeetCore/STT/HotkeyGestureController.swift
@@ -135,10 +135,18 @@ public final class HotkeyGestureController {
             return nonBareTriggerReleased()
         }
 
-        guard stateMachine.state == .waitingForSecondTap else { return [] }
         var results: [Output] = [.cancelStartupDebounce, .cancelHoldWindow]
-        results.append(contentsOf: outputs(for: stateMachine.interruptWaitingForSecondTap()))
-        return results
+        switch stateMachine.state {
+        case .waitingForSecondTap:
+            results.append(contentsOf: outputs(for: stateMachine.interruptWaitingForSecondTap()))
+            return results
+        case .holdToTalk:
+            stateMachine.reset()
+            results.append(.cancelRecording)
+            return results
+        default:
+            return []
+        }
     }
 
     public func escapePressed() -> [Output] {

--- a/Sources/MacParakeetCore/STT/HotkeyGestureController.swift
+++ b/Sources/MacParakeetCore/STT/HotkeyGestureController.swift
@@ -36,6 +36,7 @@ public final class HotkeyGestureController {
     private let mode: Mode
     private let stateMachine: FnKeyStateMachine
     private var holdOnlyState: HoldOnlyState = .idle
+    private var suppressedUntilReset = false
 
     public init(
         mode: Mode = .doubleTapAndHold,
@@ -50,6 +51,8 @@ public final class HotkeyGestureController {
     }
 
     public func triggerPressed(timestampMs: UInt64) -> [Output] {
+        guard !suppressedUntilReset else { return [] }
+
         if mode == .holdOnly {
             switch holdOnlyState {
             case .idle:
@@ -73,6 +76,8 @@ public final class HotkeyGestureController {
     }
 
     public func triggerReleased(timestampMs: UInt64) -> [Output] {
+        guard !suppressedUntilReset else { return [] }
+
         var results: [Output] = [.cancelStartupDebounce, .cancelHoldWindow]
         if mode == .holdOnly {
             switch holdOnlyState {
@@ -98,6 +103,8 @@ public final class HotkeyGestureController {
     }
 
     public func nonBareTriggerReleased() -> [Output] {
+        guard !suppressedUntilReset else { return [] }
+
         var results: [Output] = [.cancelStartupDebounce, .cancelHoldWindow]
 
         if mode == .holdOnly {
@@ -131,6 +138,8 @@ public final class HotkeyGestureController {
     }
 
     public func interrupted() -> [Output] {
+        guard !suppressedUntilReset else { return [] }
+
         if mode == .holdOnly {
             return nonBareTriggerReleased()
         }
@@ -150,6 +159,8 @@ public final class HotkeyGestureController {
     }
 
     public func escapePressed() -> [Output] {
+        guard !suppressedUntilReset else { return [] }
+
         if mode == .holdOnly {
             var results: [Output] = [.cancelStartupDebounce, .cancelHoldWindow]
             switch holdOnlyState {
@@ -184,6 +195,8 @@ public final class HotkeyGestureController {
     }
 
     public func startupDebounceElapsed() -> [Output] {
+        guard !suppressedUntilReset else { return [] }
+
         if mode == .doubleTapOnly { return [] }
         if mode == .holdOnly {
             guard holdOnlyState == .pressed else { return [] }
@@ -194,15 +207,24 @@ public final class HotkeyGestureController {
     }
 
     public func holdWindowElapsed() -> [Output] {
+        guard !suppressedUntilReset else { return [] }
+
         if mode == .doubleTapOnly { return [] }
         if mode == .holdOnly { return [] }
         return outputs(for: stateMachine.holdTimerFired())
+    }
+
+    public func suppressUntilReset() {
+        suppressedUntilReset = true
+        holdOnlyState = .idle
+        stateMachine.reset()
     }
 
     public func notifyCancelledByUI() {
         // The dictation flow resets all managers when the cancel window exits.
         // Until then, every dictation trigger stays blocked, even if it did not
         // start the recording that was cancelled.
+        suppressedUntilReset = false
         if mode == .holdOnly {
             holdOnlyState = .cancelWindow
             return
@@ -211,6 +233,7 @@ public final class HotkeyGestureController {
     }
 
     public func resumeRecording(mode: FnKeyStateMachine.RecordingMode) {
+        suppressedUntilReset = false
         if self.mode == .holdOnly {
             holdOnlyState = mode == .holdToTalk ? .active : .idle
             return
@@ -219,6 +242,7 @@ public final class HotkeyGestureController {
     }
 
     public func reset() {
+        suppressedUntilReset = false
         holdOnlyState = .idle
         stateMachine.reset()
     }

--- a/Sources/MacParakeetCore/STT/HotkeyGestureController.swift
+++ b/Sources/MacParakeetCore/STT/HotkeyGestureController.swift
@@ -3,6 +3,12 @@ import Foundation
 /// Pure controller for hotkey gesture flow.
 /// Owns gesture semantics and timer directives, but no OS event-tap wiring.
 public final class HotkeyGestureController {
+    public enum Mode: Equatable, Sendable {
+        case doubleTapAndHold
+        case doubleTapOnly
+        case holdOnly
+    }
+
     public enum Output: Equatable, Sendable {
         case startRecording(mode: FnKeyStateMachine.RecordingMode)
         case stopRecording
@@ -19,22 +25,47 @@ public final class HotkeyGestureController {
     public let tapThresholdMs: Int
     public let startupDebounceMs: Int
 
+    private enum HoldOnlyState: Equatable {
+        case idle
+        case pressed
+        case active
+        case cancelWindow
+        case blocked
+    }
+
+    private let mode: Mode
     private let stateMachine: FnKeyStateMachine
+    private var holdOnlyState: HoldOnlyState = .idle
 
     public init(
+        mode: Mode = .doubleTapAndHold,
         tapThresholdMs: Int = FnKeyStateMachine.defaultTapThresholdMs,
         startupDebounceMs: Int = FnKeyStateMachine.defaultStartupDebounceMs
     ) {
         let clampedTapThreshold = FnKeyStateMachine.clampTapThresholdMs(tapThresholdMs)
+        self.mode = mode
         self.tapThresholdMs = clampedTapThreshold
         self.startupDebounceMs = min(clampedTapThreshold, max(0, startupDebounceMs))
         self.stateMachine = FnKeyStateMachine(tapThresholdMs: clampedTapThreshold)
     }
 
     public func triggerPressed(timestampMs: UInt64) -> [Output] {
+        if mode == .holdOnly {
+            switch holdOnlyState {
+            case .idle:
+                holdOnlyState = .pressed
+                return [.scheduleStartupDebounce(milliseconds: startupDebounceMs)]
+            case .cancelWindow, .blocked:
+                holdOnlyState = .blocked
+                return []
+            case .pressed, .active:
+                return []
+            }
+        }
+
         let action = stateMachine.fnDown(timestampMs: timestampMs)
         var results = outputs(for: action)
-        if action == .none, stateMachine.state == .waitingForSecondTap {
+        if mode == .doubleTapAndHold, action == .none, stateMachine.state == .waitingForSecondTap {
             results.append(.scheduleStartupDebounce(milliseconds: startupDebounceMs))
             results.append(.scheduleHoldWindow(milliseconds: tapThresholdMs))
         }
@@ -43,6 +74,21 @@ public final class HotkeyGestureController {
 
     public func triggerReleased(timestampMs: UInt64) -> [Output] {
         var results: [Output] = [.cancelStartupDebounce, .cancelHoldWindow]
+        if mode == .holdOnly {
+            switch holdOnlyState {
+            case .pressed:
+                holdOnlyState = .idle
+            case .active:
+                holdOnlyState = .idle
+                results.append(.stopRecording)
+            case .blocked:
+                holdOnlyState = .cancelWindow
+            case .idle, .cancelWindow:
+                break
+            }
+            return results
+        }
+
         let action = stateMachine.fnUp(timestampMs: timestampMs)
         results.append(contentsOf: outputs(for: action))
         if action == .none, stateMachine.state == .waitingForSecondTap {
@@ -53,6 +99,21 @@ public final class HotkeyGestureController {
 
     public func nonBareTriggerReleased() -> [Output] {
         var results: [Output] = [.cancelStartupDebounce, .cancelHoldWindow]
+
+        if mode == .holdOnly {
+            switch holdOnlyState {
+            case .pressed:
+                holdOnlyState = .idle
+            case .active:
+                holdOnlyState = .idle
+                results.append(.cancelRecording)
+            case .blocked:
+                holdOnlyState = .cancelWindow
+            case .idle, .cancelWindow:
+                break
+            }
+            return results
+        }
 
         switch stateMachine.state {
         case .holdToTalk:
@@ -70,6 +131,10 @@ public final class HotkeyGestureController {
     }
 
     public func interrupted() -> [Output] {
+        if mode == .holdOnly {
+            return nonBareTriggerReleased()
+        }
+
         guard stateMachine.state == .waitingForSecondTap else { return [] }
         var results: [Output] = [.cancelStartupDebounce, .cancelHoldWindow]
         results.append(contentsOf: outputs(for: stateMachine.interruptWaitingForSecondTap()))
@@ -77,6 +142,23 @@ public final class HotkeyGestureController {
     }
 
     public func escapePressed() -> [Output] {
+        if mode == .holdOnly {
+            var results: [Output] = [.cancelStartupDebounce, .cancelHoldWindow]
+            switch holdOnlyState {
+            case .pressed:
+                holdOnlyState = .idle
+            case .active:
+                holdOnlyState = .cancelWindow
+                results.append(.cancelRecording)
+            case .cancelWindow, .blocked:
+                holdOnlyState = .idle
+                results.append(.cancelRecording)
+            case .idle:
+                return [.escapeWhileIdle]
+            }
+            return results
+        }
+
         let wasWaitingForSecondTap = stateMachine.state == .waitingForSecondTap
         let action = stateMachine.escapePressed()
 
@@ -94,22 +176,42 @@ public final class HotkeyGestureController {
     }
 
     public func startupDebounceElapsed() -> [Output] {
-        outputs(for: stateMachine.startupTimerFired())
+        if mode == .doubleTapOnly { return [] }
+        if mode == .holdOnly {
+            guard holdOnlyState == .pressed else { return [] }
+            holdOnlyState = .active
+            return [.startRecording(mode: .holdToTalk)]
+        }
+        return outputs(for: stateMachine.startupTimerFired())
     }
 
     public func holdWindowElapsed() -> [Output] {
-        outputs(for: stateMachine.holdTimerFired())
+        if mode == .doubleTapOnly { return [] }
+        if mode == .holdOnly { return [] }
+        return outputs(for: stateMachine.holdTimerFired())
     }
 
     public func notifyCancelledByUI() {
-        stateMachine.cancelledByUI()
+        // The dictation flow resets all managers when the cancel window exits.
+        // Until then, every dictation trigger stays blocked, even if it did not
+        // start the recording that was cancelled.
+        if mode == .holdOnly {
+            holdOnlyState = .cancelWindow
+            return
+        }
+        stateMachine.blockUntilReset()
     }
 
     public func resumeRecording(mode: FnKeyStateMachine.RecordingMode) {
+        if self.mode == .holdOnly {
+            holdOnlyState = mode == .holdToTalk ? .active : .idle
+            return
+        }
         stateMachine.resumeRecording(mode: mode)
     }
 
     public func reset() {
+        holdOnlyState = .idle
         stateMachine.reset()
     }
 

--- a/Sources/MacParakeetCore/STT/HotkeyTrigger.swift
+++ b/Sources/MacParakeetCore/STT/HotkeyTrigger.swift
@@ -323,6 +323,7 @@ public struct HotkeyTrigger: Sendable {
     // MARK: - Default Triggers
 
     public static let defaultDictation: HotkeyTrigger = .fn
+    public static let defaultPushToTalk: HotkeyTrigger = .fn
     public static let defaultMeetingRecording: HotkeyTrigger = .chord(modifiers: ["command", "shift"], keyCode: 46)
 
     // MARK: - Factory
@@ -579,6 +580,7 @@ public struct HotkeyTrigger: Sendable {
     // MARK: - Persistence
 
     public static let defaultsKey = "hotkeyTrigger"
+    public static let pushToTalkDefaultsKey = "pushToTalkHotkeyTrigger"
     public static let meetingDefaultsKey = "meetingHotkeyTrigger"
     public static let fileTranscriptionDefaultsKey = "fileTranscriptionHotkeyTrigger"
     public static let youtubeTranscriptionDefaultsKey = "youtubeTranscriptionHotkeyTrigger"

--- a/Sources/MacParakeetCore/STT/README.md
+++ b/Sources/MacParakeetCore/STT/README.md
@@ -32,11 +32,12 @@ to one `STTRuntime`; callers do not own model lifecycles directly.
   shape as the Parakeet path.
 
 **Hotkey state (lives here for testability)**
-- `FnKeyStateMachine.swift` — pure state machine for the Fn-key
-  gesture (double-tap → persistent, hold → push-to-talk, Esc → cancel
-  window).
+- `FnKeyStateMachine.swift` — pure state machine for combined
+  dictation gestures (double-tap → persistent, hold → push-to-talk,
+  Esc → cancel window).
 - `HotkeyGestureController.swift` — wraps the state machine for the
-  app's hotkey driver.
+  app's hotkey driver and scopes behavior to combined, hands-free-only,
+  or push-to-talk-only roles.
 - `HotkeyTrigger.swift` — value types describing trigger kinds.
 - `KeyCodeNames.swift` — display strings for keys.
 - `OnboardingProgressParser.swift` — parses FluidAudio model-download
@@ -96,11 +97,11 @@ manager.initialize() }`, and don't reach into `STTRuntime`'s
 private state. Warm-up happens automatically (background or
 explicit); use `STTRuntime.observeWarmUpProgress()` to surface UI.
 
-**Hotkey state is pure and testable.** `FnKeyStateMachine` takes
-abstract up/down events with timestamps and emits actions. Don't
-add CGEvent or NSEvent imports here — that machinery lives in the
-GUI target's `Hotkey/` folder and translates real events into the
-state machine's input shape.
+**Hotkey state is pure and testable.** `FnKeyStateMachine` and
+`HotkeyGestureController` take abstract gesture events with timestamps
+and emit actions. Don't add CGEvent or NSEvent imports here — that
+machinery lives in the GUI target's `Hotkey/` folder and translates
+real events into the controller's input shape.
 
 ## How to verify a change
 

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -211,6 +211,7 @@ public enum TelemetryPermission: String, Sendable, Equatable {
 /// single-key trigger?".
 public enum TelemetryHotkeySurface: String, Sendable, Equatable {
     case dictation
+    case pushToTalk = "push_to_talk"
     case meeting
     case fileTranscription = "file_transcription"
     case youtubeTranscription = "youtube_transcription"

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -86,6 +86,16 @@ public final class SettingsViewModel {
             Telemetry.send(hotkeyTrigger.customizedEvent(surface: .dictation))
         }
     }
+    public var pushToTalkHotkeyTrigger: HotkeyTrigger {
+        didSet {
+            pushToTalkHotkeyTrigger.save(to: defaults, defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey)
+            NotificationCenter.default.post(
+                name: .macParakeetPushToTalkHotkeyTriggerDidChange,
+                object: nil
+            )
+            Telemetry.send(pushToTalkHotkeyTrigger.customizedEvent(surface: .pushToTalk))
+        }
+    }
     public var meetingHotkeyTrigger: HotkeyTrigger {
         didSet {
             meetingHotkeyTrigger.save(to: defaults, defaultsKey: HotkeyTrigger.meetingDefaultsKey)
@@ -453,6 +463,12 @@ public final class SettingsViewModel {
         showIdlePill = defaults.object(forKey: UserDefaultsAppRuntimePreferences.showIdlePillKey) as? Bool ?? true
         telemetryEnabled = AppPreferences.isTelemetryEnabled(defaults: defaults)
         hotkeyTrigger = HotkeyTrigger.current(defaults: defaults)
+        let shouldPersistPushToTalkMigration = defaults.object(forKey: HotkeyTrigger.pushToTalkDefaultsKey) == nil
+        let resolvedPushToTalkHotkeyTrigger = Self.resolvePushToTalkHotkeyTrigger(defaults: defaults)
+        pushToTalkHotkeyTrigger = resolvedPushToTalkHotkeyTrigger
+        if shouldPersistPushToTalkMigration {
+            resolvedPushToTalkHotkeyTrigger.save(to: defaults, defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey)
+        }
         meetingHotkeyTrigger = Self.resolveMeetingHotkeyTrigger(defaults: defaults)
         fileTranscriptionHotkeyTrigger = Self.resolveTranscriptionHotkeyTrigger(
             defaults: defaults,
@@ -642,6 +658,17 @@ public final class SettingsViewModel {
             defaults: defaults,
             defaultsKey: HotkeyTrigger.meetingDefaultsKey,
             fallback: .defaultMeetingRecording
+        )
+    }
+
+    private static func resolvePushToTalkHotkeyTrigger(defaults: UserDefaults) -> HotkeyTrigger {
+        guard defaults.object(forKey: HotkeyTrigger.pushToTalkDefaultsKey) != nil else {
+            return HotkeyTrigger.current(defaults: defaults, fallback: .defaultPushToTalk)
+        }
+        return HotkeyTrigger.current(
+            defaults: defaults,
+            defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey,
+            fallback: .defaultPushToTalk
         )
     }
 

--- a/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
@@ -30,7 +30,7 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
             onToggleMeetingRecording: {},
             onTriggerFileTranscription: {},
             onTriggerYouTubeTranscription: {},
-            onPrimaryHotkeyManagerChanged: { _ in },
+            onDictationHotkeyManagersChanged: { _ in },
             onAnyHotkeyEnabled: onAnyHotkeyEnabled,
             onHotkeyUnavailable: onHotkeyUnavailable,
             onHotkeyConflict: onHotkeyConflict
@@ -63,5 +63,95 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
         XCTAssertEqual(reportedConflicts, [conflictingTrigger])
         XCTAssertEqual(enabledCount, 0)
         XCTAssertEqual(unavailableCount, 0)
+    }
+
+    func testMenuTitleDescribesSharedDictationTrigger() {
+        XCTAssertEqual(
+            AppHotkeyCoordinator.menuTitle(handsFree: .fn, pushToTalk: .fn),
+            "Dictation: Fn (hold or double-tap)"
+        )
+    }
+
+    func testMenuTitleDescribesDistinctDictationTriggers() {
+        XCTAssertEqual(
+            AppHotkeyCoordinator.menuTitle(handsFree: .control, pushToTalk: .option),
+            "Dictation: Hold Option / Double-tap Control"
+        )
+    }
+
+    func testDictationHotkeyPlanUsesOneCombinedManagerForSharedTrigger() {
+        let plan = AppHotkeyCoordinator.dictationHotkeyPlan(
+            handsFree: .fn,
+            pushToTalk: .fn
+        )
+
+        XCTAssertEqual(
+            plan,
+            AppHotkeyCoordinator.DictationHotkeyPlan(
+                specs: [
+                    .init(trigger: .fn, gestureMode: .doubleTapAndHold),
+                ],
+                conflict: nil
+            )
+        )
+    }
+
+    func testDictationHotkeyPlanUsesSeparateManagersForDistinctTriggers() {
+        let plan = AppHotkeyCoordinator.dictationHotkeyPlan(
+            handsFree: .control,
+            pushToTalk: .option
+        )
+
+        XCTAssertEqual(
+            plan,
+            AppHotkeyCoordinator.DictationHotkeyPlan(
+                specs: [
+                    .init(trigger: .control, gestureMode: .doubleTapOnly),
+                    .init(trigger: .option, gestureMode: .holdOnly),
+                ],
+                conflict: nil
+            )
+        )
+    }
+
+    func testDictationHotkeyPlanKeepsHandsFreeOnlyWhenTriggersOverlapButDiffer() {
+        let pushToTalk = HotkeyTrigger.modifierChord(modifiers: ["control", "option"])
+        let plan = AppHotkeyCoordinator.dictationHotkeyPlan(
+            handsFree: .control,
+            pushToTalk: pushToTalk
+        )
+
+        XCTAssertEqual(
+            plan,
+            AppHotkeyCoordinator.DictationHotkeyPlan(
+                specs: [
+                    .init(trigger: .control, gestureMode: .doubleTapOnly),
+                ],
+                conflict: .init(trigger: pushToTalk, conflicts: [.control])
+            )
+        )
+    }
+
+    func testDictationHotkeyPlanHandlesDisabledRoles() {
+        XCTAssertEqual(
+            AppHotkeyCoordinator.dictationHotkeyPlan(
+                handsFree: .disabled,
+                pushToTalk: .option
+            ),
+            AppHotkeyCoordinator.DictationHotkeyPlan(
+                specs: [
+                    .init(trigger: .option, gestureMode: .holdOnly),
+                ],
+                conflict: nil
+            )
+        )
+
+        XCTAssertEqual(
+            AppHotkeyCoordinator.dictationHotkeyPlan(
+                handsFree: .disabled,
+                pushToTalk: .disabled
+            ),
+            AppHotkeyCoordinator.DictationHotkeyPlan(specs: [], conflict: nil)
+        )
     }
 }

--- a/Tests/MacParakeetTests/App/AppSettingsObserverCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/App/AppSettingsObserverCoordinatorTests.swift
@@ -16,6 +16,7 @@ final class AppSettingsObserverCoordinatorTests: XCTestCase {
         var onboardingCount = 0
         var settingsCount = 0
         var hotkeyTriggerCount = 0
+        var pushToTalkHotkeyTriggerCount = 0
         var meetingHotkeyTriggerCount = 0
         var fileTranscriptionHotkeyTriggerCount = 0
         var youtubeTranscriptionHotkeyTriggerCount = 0
@@ -35,6 +36,10 @@ final class AppSettingsObserverCoordinatorTests: XCTestCase {
             },
             onHotkeyTriggerChanged: { [unowned self] in
                 self.hotkeyTriggerCount += 1
+                self.onCallback?()
+            },
+            onPushToTalkHotkeyTriggerChanged: { [unowned self] in
+                self.pushToTalkHotkeyTriggerCount += 1
                 self.onCallback?()
             },
             onMeetingHotkeyTriggerChanged: { [unowned self] in
@@ -65,13 +70,14 @@ final class AppSettingsObserverCoordinatorTests: XCTestCase {
     func test_startObserving_routesEachNotificationToItsCallback() async {
         let fx = Fixture()
         let callbacks = expectation(description: "all callbacks fire")
-        callbacks.expectedFulfillmentCount = 8
+        callbacks.expectedFulfillmentCount = 9
         fx.onCallback = { callbacks.fulfill() }
         fx.coordinator.startObserving()
 
         fx.center.post(name: .macParakeetOpenOnboarding, object: nil)
         fx.center.post(name: .macParakeetOpenSettings, object: nil)
         fx.center.post(name: .macParakeetHotkeyTriggerDidChange, object: nil)
+        fx.center.post(name: .macParakeetPushToTalkHotkeyTriggerDidChange, object: nil)
         fx.center.post(name: .macParakeetMeetingHotkeyTriggerDidChange, object: nil)
         fx.center.post(name: .macParakeetFileTranscriptionHotkeyTriggerDidChange, object: nil)
         fx.center.post(name: .macParakeetYouTubeTranscriptionHotkeyTriggerDidChange, object: nil)
@@ -83,6 +89,7 @@ final class AppSettingsObserverCoordinatorTests: XCTestCase {
         XCTAssertEqual(fx.onboardingCount, 1)
         XCTAssertEqual(fx.settingsCount, 1)
         XCTAssertEqual(fx.hotkeyTriggerCount, 1)
+        XCTAssertEqual(fx.pushToTalkHotkeyTriggerCount, 1)
         XCTAssertEqual(fx.meetingHotkeyTriggerCount, 1)
         XCTAssertEqual(fx.fileTranscriptionHotkeyTriggerCount, 1)
         XCTAssertEqual(fx.youtubeTranscriptionHotkeyTriggerCount, 1)
@@ -101,6 +108,7 @@ final class AppSettingsObserverCoordinatorTests: XCTestCase {
         fx.center.post(name: .macParakeetOpenOnboarding, object: nil)
         fx.center.post(name: .macParakeetOpenSettings, object: nil)
         fx.center.post(name: .macParakeetHotkeyTriggerDidChange, object: nil)
+        fx.center.post(name: .macParakeetPushToTalkHotkeyTriggerDidChange, object: nil)
         fx.center.post(name: .macParakeetMeetingHotkeyTriggerDidChange, object: nil)
         fx.center.post(name: .macParakeetFileTranscriptionHotkeyTriggerDidChange, object: nil)
         fx.center.post(name: .macParakeetYouTubeTranscriptionHotkeyTriggerDidChange, object: nil)
@@ -112,6 +120,7 @@ final class AppSettingsObserverCoordinatorTests: XCTestCase {
         XCTAssertEqual(fx.onboardingCount, 0)
         XCTAssertEqual(fx.settingsCount, 0)
         XCTAssertEqual(fx.hotkeyTriggerCount, 0)
+        XCTAssertEqual(fx.pushToTalkHotkeyTriggerCount, 0)
         XCTAssertEqual(fx.meetingHotkeyTriggerCount, 0)
         XCTAssertEqual(fx.fileTranscriptionHotkeyTriggerCount, 0)
         XCTAssertEqual(fx.youtubeTranscriptionHotkeyTriggerCount, 0)
@@ -171,6 +180,7 @@ final class AppSettingsObserverCoordinatorTests: XCTestCase {
         XCTAssertEqual(fx.onboardingCount, 1)
         XCTAssertEqual(fx.settingsCount, 0)
         XCTAssertEqual(fx.hotkeyTriggerCount, 0)
+        XCTAssertEqual(fx.pushToTalkHotkeyTriggerCount, 0)
         XCTAssertEqual(fx.meetingHotkeyTriggerCount, 0)
         XCTAssertEqual(fx.fileTranscriptionHotkeyTriggerCount, 0)
         XCTAssertEqual(fx.youtubeTranscriptionHotkeyTriggerCount, 0)

--- a/Tests/MacParakeetTests/Hotkey/HotkeyGestureControllerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyGestureControllerTests.swift
@@ -306,4 +306,38 @@ final class HotkeyGestureControllerTests: XCTestCase {
             [.scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs)]
         )
     }
+
+    func testSuppressedControllerIgnoresGesturesUntilReset() {
+        let controller = HotkeyGestureController(mode: .holdOnly)
+
+        controller.suppressUntilReset()
+
+        XCTAssertEqual(controller.triggerPressed(timestampMs: 1_000), [])
+        XCTAssertEqual(controller.startupDebounceElapsed(), [])
+        XCTAssertEqual(controller.escapePressed(), [])
+        XCTAssertEqual(controller.triggerReleased(timestampMs: 1_200), [])
+
+        controller.reset()
+
+        XCTAssertEqual(
+            controller.triggerPressed(timestampMs: 1_300),
+            [.scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs)]
+        )
+    }
+
+    func testCancelWindowNotificationOverridesSuppression() {
+        let controller = HotkeyGestureController(mode: .holdOnly)
+
+        controller.suppressUntilReset()
+        controller.notifyCancelledByUI()
+
+        XCTAssertEqual(
+            controller.escapePressed(),
+            [
+                .cancelStartupDebounce,
+                .cancelHoldWindow,
+                .cancelRecording,
+            ]
+        )
+    }
 }

--- a/Tests/MacParakeetTests/Hotkey/HotkeyGestureControllerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyGestureControllerTests.swift
@@ -88,6 +88,30 @@ final class HotkeyGestureControllerTests: XCTestCase {
         )
     }
 
+    func testInterruptionDuringConfirmedHoldCancelsRecordingImmediately() {
+        let controller = HotkeyGestureController()
+        _ = controller.triggerPressed(timestampMs: 1_000)
+        _ = controller.holdWindowElapsed()
+
+        let outputs = controller.interrupted()
+
+        XCTAssertEqual(
+            outputs,
+            [
+                .cancelStartupDebounce,
+                .cancelHoldWindow,
+                .cancelRecording,
+            ]
+        )
+        XCTAssertEqual(
+            controller.triggerReleased(timestampMs: 1_500),
+            [
+                .cancelStartupDebounce,
+                .cancelHoldWindow,
+            ]
+        )
+    }
+
     func testEscapeWhileIdleDelegatesToIdleHandler() {
         let controller = HotkeyGestureController()
 
@@ -252,6 +276,33 @@ final class HotkeyGestureControllerTests: XCTestCase {
 
         XCTAssertEqual(
             controller.triggerPressed(timestampMs: 1_100),
+            [.scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs)]
+        )
+    }
+
+    func testHoldOnlyEscapeDuringCancelWindowConfirmsAndUnblocks() {
+        let controller = HotkeyGestureController(mode: .holdOnly)
+        _ = controller.triggerPressed(timestampMs: 1_000)
+        _ = controller.startupDebounceElapsed()
+
+        XCTAssertEqual(
+            controller.escapePressed(),
+            [
+                .cancelStartupDebounce,
+                .cancelHoldWindow,
+                .cancelRecording,
+            ]
+        )
+        XCTAssertEqual(
+            controller.escapePressed(),
+            [
+                .cancelStartupDebounce,
+                .cancelHoldWindow,
+                .cancelRecording,
+            ]
+        )
+        XCTAssertEqual(
+            controller.triggerPressed(timestampMs: 1_200),
             [.scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs)]
         )
     }

--- a/Tests/MacParakeetTests/Hotkey/HotkeyGestureControllerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyGestureControllerTests.swift
@@ -151,4 +151,108 @@ final class HotkeyGestureControllerTests: XCTestCase {
             ]
         )
     }
+
+    func testDoubleTapOnlyDoesNotStartHoldToTalk() {
+        let controller = HotkeyGestureController(mode: .doubleTapOnly)
+
+        XCTAssertEqual(controller.triggerPressed(timestampMs: 1_000), [])
+        XCTAssertEqual(controller.startupDebounceElapsed(), [])
+        XCTAssertEqual(controller.holdWindowElapsed(), [])
+        XCTAssertEqual(
+            controller.triggerReleased(timestampMs: 1_050),
+            [
+                .cancelStartupDebounce,
+                .cancelHoldWindow,
+                .showReadyForSecondTap,
+            ]
+        )
+        XCTAssertEqual(
+            controller.triggerPressed(timestampMs: 1_200),
+            [.startRecording(mode: .persistent)]
+        )
+    }
+
+    func testHoldOnlyStartsAfterStartupAndStopsOnRelease() {
+        let controller = HotkeyGestureController(mode: .holdOnly)
+
+        XCTAssertEqual(
+            controller.triggerPressed(timestampMs: 1_000),
+            [.scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs)]
+        )
+        XCTAssertEqual(
+            controller.startupDebounceElapsed(),
+            [.startRecording(mode: .holdToTalk)]
+        )
+        XCTAssertEqual(
+            controller.triggerReleased(timestampMs: 1_300),
+            [
+                .cancelStartupDebounce,
+                .cancelHoldWindow,
+                .stopRecording,
+            ]
+        )
+    }
+
+    func testHoldOnlyQuickReleaseDoesNotShowSecondTapReadyState() {
+        let controller = HotkeyGestureController(mode: .holdOnly)
+
+        _ = controller.triggerPressed(timestampMs: 1_000)
+
+        XCTAssertEqual(
+            controller.triggerReleased(timestampMs: 1_050),
+            [
+                .cancelStartupDebounce,
+                .cancelHoldWindow,
+            ]
+        )
+    }
+
+    func testNotifyCancelledByUIBlocksDoubleTapOnlyUntilReset() {
+        let controller = HotkeyGestureController(mode: .doubleTapOnly)
+
+        controller.notifyCancelledByUI()
+
+        XCTAssertEqual(controller.triggerPressed(timestampMs: 1_000), [])
+        XCTAssertEqual(
+            controller.triggerReleased(timestampMs: 1_050),
+            [
+                .cancelStartupDebounce,
+                .cancelHoldWindow,
+            ]
+        )
+
+        controller.reset()
+
+        _ = controller.triggerPressed(timestampMs: 1_100)
+        XCTAssertEqual(
+            controller.triggerReleased(timestampMs: 1_150),
+            [
+                .cancelStartupDebounce,
+                .cancelHoldWindow,
+                .showReadyForSecondTap,
+            ]
+        )
+    }
+
+    func testNotifyCancelledByUIBlocksHoldOnlyUntilReset() {
+        let controller = HotkeyGestureController(mode: .holdOnly)
+
+        controller.notifyCancelledByUI()
+
+        XCTAssertEqual(controller.triggerPressed(timestampMs: 1_000), [])
+        XCTAssertEqual(
+            controller.triggerReleased(timestampMs: 1_050),
+            [
+                .cancelStartupDebounce,
+                .cancelHoldWindow,
+            ]
+        )
+
+        controller.reset()
+
+        XCTAssertEqual(
+            controller.triggerPressed(timestampMs: 1_100),
+            [.scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs)]
+        )
+    }
 }

--- a/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
@@ -660,6 +660,41 @@ final class HotkeyManagerTests: XCTestCase {
         XCTAssertEqual(manager.holdWindowElapsedForTesting(), [])
     }
 
+    func testRegularKeyInterruptsConfirmedFnHoldAndCancelsImmediately() {
+        let manager = HotkeyManager(trigger: .fn)
+
+        _ = manager.modifierFlagsChangedOutputsForTesting(
+            flags: [.maskSecondaryFn],
+            timestampMs: 1_000
+        )
+        XCTAssertEqual(
+            manager.holdWindowElapsedForTesting(),
+            [.startRecording(mode: .holdToTalk)]
+        )
+
+        XCTAssertEqual(
+            manager.modifierKeyDownOutputsForTesting(
+                keyCode: 0,
+                timestampMs: 1_450
+            ),
+            [
+                .cancelStartupDebounce,
+                .cancelHoldWindow,
+                .cancelRecording,
+            ]
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_500
+            ),
+            [
+                .cancelStartupDebounce,
+                .cancelHoldWindow,
+            ]
+        )
+    }
+
     func testAdditionalModifierSilentlyDiscardsAfterProvisionalStartup() {
         let manager = HotkeyManager(trigger: .fn)
 

--- a/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
@@ -73,6 +73,38 @@ final class HotkeyManagerTests: XCTestCase {
         )
     }
 
+    func testSuppressedHoldOnlyManagerDoesNotStartUntilReset() {
+        let manager = HotkeyManager(trigger: .fn, gestureMode: .holdOnly)
+
+        manager.suppressUntilReset()
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_000
+            ),
+            []
+        )
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [])
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_100
+            ),
+            []
+        )
+
+        manager.resetToIdle(flags: [])
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_200
+            ),
+            [.scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs)]
+        )
+    }
+
     func testDoubleTapOnlyGestureModeWorksForKeyCodeTriggers() {
         let trigger = HotkeyTrigger.fromKeyCode(119)
         let manager = HotkeyManager(trigger: trigger, gestureMode: .doubleTapOnly)

--- a/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
@@ -14,6 +14,196 @@ final class HotkeyManagerTests: XCTestCase {
         CGEventFlags(rawValue: masks.reduce(0, |))
     }
 
+    func testDoubleTapOnlyGestureModeDoesNotStartHoldRecording() {
+        let manager = HotkeyManager(trigger: .fn, gestureMode: .doubleTapOnly)
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_000
+            ),
+            []
+        )
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [])
+        XCTAssertEqual(manager.holdWindowElapsedForTesting(), [])
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_050
+            ),
+            [
+                .cancelStartupDebounce,
+                .cancelHoldWindow,
+                .showReadyForSecondTap,
+            ]
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_100
+            ),
+            [.startRecording(mode: .persistent)]
+        )
+    }
+
+    func testHoldOnlyGestureModeStartsAndStopsHoldRecording() {
+        let manager = HotkeyManager(trigger: .fn, gestureMode: .holdOnly)
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_000
+            ),
+            [.scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs)]
+        )
+        XCTAssertEqual(
+            manager.startupDebounceElapsedForTesting(),
+            [.startRecording(mode: .holdToTalk)]
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_250
+            ),
+            [
+                .cancelStartupDebounce,
+                .cancelHoldWindow,
+                .stopRecording,
+            ]
+        )
+    }
+
+    func testDoubleTapOnlyGestureModeWorksForKeyCodeTriggers() {
+        let trigger = HotkeyTrigger.fromKeyCode(119)
+        let manager = HotkeyManager(trigger: trigger, gestureMode: .doubleTapOnly)
+
+        let firstDown = manager.keyCodeEventDecisionForTesting(
+            type: .keyDown,
+            keyCode: 119,
+            timestampMs: 1_000
+        )
+        XCTAssertEqual(firstDown.outputs, [])
+        XCTAssertTrue(firstDown.shouldSwallow)
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [])
+        XCTAssertEqual(manager.holdWindowElapsedForTesting(), [])
+
+        let firstUp = manager.keyCodeEventDecisionForTesting(
+            type: .keyUp,
+            keyCode: 119,
+            timestampMs: 1_050
+        )
+        XCTAssertEqual(firstUp.outputs, [.cancelStartupDebounce, .cancelHoldWindow, .showReadyForSecondTap])
+        XCTAssertTrue(firstUp.shouldSwallow)
+
+        let secondDown = manager.keyCodeEventDecisionForTesting(
+            type: .keyDown,
+            keyCode: 119,
+            timestampMs: 1_100
+        )
+        XCTAssertEqual(secondDown.outputs, [.startRecording(mode: .persistent)])
+        XCTAssertTrue(secondDown.shouldSwallow)
+    }
+
+    func testHoldOnlyGestureModeWorksForKeyCodeTriggers() {
+        let trigger = HotkeyTrigger.fromKeyCode(119)
+        let manager = HotkeyManager(trigger: trigger, gestureMode: .holdOnly)
+
+        let keyDown = manager.keyCodeEventDecisionForTesting(
+            type: .keyDown,
+            keyCode: 119,
+            timestampMs: 1_000
+        )
+        XCTAssertEqual(
+            keyDown.outputs,
+            [.scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs)]
+        )
+        XCTAssertTrue(keyDown.shouldSwallow)
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [.startRecording(mode: .holdToTalk)])
+
+        let keyUp = manager.keyCodeEventDecisionForTesting(
+            type: .keyUp,
+            keyCode: 119,
+            timestampMs: 1_250
+        )
+        XCTAssertEqual(
+            keyUp.outputs,
+            [
+                .cancelStartupDebounce,
+                .cancelHoldWindow,
+                .stopRecording,
+            ]
+        )
+        XCTAssertTrue(keyUp.shouldSwallow)
+    }
+
+    func testHoldOnlyGestureModeStopsChordWhenRequiredModifierReleasesFirst() {
+        let trigger = HotkeyTrigger.chord(modifiers: ["control", "shift"], keyCode: 15)
+        let manager = HotkeyManager(trigger: trigger, gestureMode: .holdOnly)
+
+        let keyDown = manager.chordEventDecisionForTesting(
+            type: .keyDown,
+            keyCode: 15,
+            flags: trigger.chordEventFlags,
+            timestampMs: 1_000
+        )
+        XCTAssertEqual(
+            keyDown.outputs,
+            [.scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs)]
+        )
+        XCTAssertTrue(keyDown.shouldSwallow)
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [.startRecording(mode: .holdToTalk)])
+
+        let flagsChanged = manager.chordEventDecisionForTesting(
+            type: .flagsChanged,
+            keyCode: 0,
+            flags: 0,
+            timestampMs: 1_250
+        )
+        XCTAssertEqual(
+            flagsChanged.outputs,
+            [
+                .cancelStartupDebounce,
+                .cancelHoldWindow,
+                .stopRecording,
+            ]
+        )
+        XCTAssertFalse(flagsChanged.shouldSwallow)
+
+        let keyUp = manager.chordEventDecisionForTesting(
+            type: .keyUp,
+            keyCode: 15,
+            flags: 0,
+            timestampMs: 1_300
+        )
+        XCTAssertEqual(keyUp.outputs, [])
+        XCTAssertTrue(keyUp.shouldSwallow)
+    }
+
+    func testHoldOnlyGestureModeWorksForModifierChordTriggers() {
+        let trigger = HotkeyTrigger.modifierChord(modifiers: ["control", "option"])
+        let manager = HotkeyManager(trigger: trigger, gestureMode: .holdOnly)
+
+        XCTAssertEqual(
+            manager.modifierChordFlagsChangedOutputsForTesting(
+                flags: [.maskControl, .maskAlternate],
+                timestampMs: 1_000
+            ),
+            [.scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs)]
+        )
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [.startRecording(mode: .holdToTalk)])
+        XCTAssertEqual(
+            manager.modifierChordFlagsChangedOutputsForTesting(
+                flags: [.maskControl],
+                timestampMs: 1_250
+            ),
+            [
+                .cancelStartupDebounce,
+                .cancelHoldWindow,
+                .stopRecording,
+            ]
+        )
+    }
+
     func testTapRecoveryResetsPendingModifierGesture() {
         let manager = HotkeyManager(trigger: .fn)
 

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -795,6 +795,7 @@ final class TelemetryServiceTests: XCTestCase {
     func testHotkeyCustomizedPropsUseStructuralCategoriesOnly() {
         let cases: [(TelemetryHotkeySurface, TelemetryHotkeyKind, String, String)] = [
             (.dictation, .disabled, "dictation", "disabled"),
+            (.pushToTalk, .modifier, "push_to_talk", "modifier"),
             (.meeting, .modifier, "meeting", "modifier"),
             (.fileTranscription, .keyCode, "file_transcription", "key_code"),
             (.youtubeTranscription, .chord, "youtube_transcription", "chord"),

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -488,6 +488,15 @@ final class SettingsViewModelTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    func testPushToTalkHotkeyPostsNotificationOnChange() {
+        let expectation = expectation(
+            forNotification: Notification.Name("macparakeet.pushToTalkHotkeyTriggerDidChange"),
+            object: nil
+        )
+        viewModel.pushToTalkHotkeyTrigger = .control
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     // MARK: - File/YouTube Transcription Hotkeys
 
     func testTranscriptionHotkeysDefaultToDisabled() {
@@ -546,6 +555,7 @@ final class SettingsViewModelTests: XCTestCase {
         Telemetry.configure(telemetry)
 
         viewModel.hotkeyTrigger = .option
+        viewModel.pushToTalkHotkeyTrigger = .control
         viewModel.meetingHotkeyTrigger = .chord(modifiers: ["control", "option"], keyCode: 46)
         viewModel.fileTranscriptionHotkeyTrigger = .disabled
         viewModel.youtubeTranscriptionHotkeyTrigger = .fromKeyCode(16)
@@ -566,6 +576,7 @@ final class SettingsViewModelTests: XCTestCase {
 
         XCTAssertEqual(hotkeyEvents, [
             "dictation:modifier",
+            "push_to_talk:modifier",
             "meeting:chord",
             "file_transcription:disabled",
             "youtube_transcription:key_code",
@@ -1010,6 +1021,10 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.hotkeyTrigger, .fn)
     }
 
+    func testPushToTalkHotkeyTriggerDefaultsToFn() {
+        XCTAssertEqual(viewModel.pushToTalkHotkeyTrigger, .fn)
+    }
+
     func testHotkeyTriggerPersistsKeyCode() {
         let endKey = HotkeyTrigger.fromKeyCode(119)
         viewModel.hotkeyTrigger = endKey
@@ -1024,6 +1039,46 @@ final class SettingsViewModelTests: XCTestCase {
 
         let vm2 = SettingsViewModel(defaults: testDefaults)
         XCTAssertEqual(vm2.hotkeyTrigger, .control)
+    }
+
+    func testPushToTalkHotkeyTriggerPersistsToDedicatedDefaultsKey() {
+        viewModel.pushToTalkHotkeyTrigger = .control
+
+        let vm2 = SettingsViewModel(defaults: testDefaults)
+        XCTAssertEqual(vm2.pushToTalkHotkeyTrigger, .control)
+        XCTAssertEqual(
+            HotkeyTrigger.current(
+                defaults: testDefaults,
+                defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey,
+                fallback: .defaultPushToTalk
+            ),
+            .control
+        )
+    }
+
+    func testPushToTalkHotkeyTriggerMigratesFromLegacyDictationHotkey() {
+        let legacyTrigger = HotkeyTrigger.fromKeyCode(119)
+        testDefaults.removeObject(forKey: HotkeyTrigger.pushToTalkDefaultsKey)
+        legacyTrigger.save(to: testDefaults)
+
+        let vm = SettingsViewModel(defaults: testDefaults)
+
+        XCTAssertEqual(vm.pushToTalkHotkeyTrigger, legacyTrigger)
+
+        vm.hotkeyTrigger = .control
+        let vm2 = SettingsViewModel(defaults: testDefaults)
+        XCTAssertEqual(vm2.pushToTalkHotkeyTrigger, legacyTrigger)
+    }
+
+    func testPushToTalkDedicatedDefaultsKeyWinsOverLegacyDictationHotkey() {
+        let dedicatedTrigger = HotkeyTrigger.fromKeyCode(119)
+        testDefaults.set("option", forKey: HotkeyTrigger.defaultsKey)
+        dedicatedTrigger.save(to: testDefaults, defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey)
+
+        let vm = SettingsViewModel(defaults: testDefaults)
+
+        XCTAssertEqual(vm.hotkeyTrigger, .option)
+        XCTAssertEqual(vm.pushToTalkHotkeyTrigger, dedicatedTrigger)
     }
 
     func testHotkeyTriggerBackwardCompatibleWithLegacyString() {

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -154,8 +154,9 @@ Both modes coexist with no configuration required. The 400ms threshold distingui
 - Bare-tap filtering (modifiers only): if a regular key is pressed while the modifier is held (e.g., Ctrl+C), the release is not counted as a tap — prevents keyboard shortcuts from triggering dictation
 - Gesture interruption: if a non-Escape key is pressed during `waitingForSecondTap`, the state machine resets — prevents double-tap detection across typing
 - Chord validation: Escape blocked for all kinds. Modifier+key chords containing Command warn about system shortcut conflicts (Cmd+Tab, Cmd+Space, Cmd+Q/W/H/M). Fn is bare-modifier-only — not allowed in chords.
-- On key-down: schedule a 400ms `DispatchWorkItem`. If a second tap arrives before it fires, enter double-tap (persistent mode). If the timer fires with the key still held, enter hold-mode and begin recording.
-- On key-up: if hold timer still pending, cancel it (was a quick tap). If recording in hold-mode, auto-stop and process.
+- Combined-trigger key-down: schedule startup debounce and a 400ms hold window. A second tap inside the window enters hands-free persistent mode; holding past the window confirms push-to-talk.
+- Dedicated push-to-talk key-down: schedule only the startup debounce, then start hold-to-talk because there is no double-tap ambiguity.
+- On key-up: quick taps discard any provisional capture for combined/double-tap detection; dedicated push-to-talk releases after startup debounce stop and process.
 - Escape is permanently reserved for cancel-dictation and cannot be assigned as hotkey
 - Requires Accessibility permission (prompted on first activation).
 - Stop orchestration is state-driven (proceed, defer-until-recording, reject-not-recording) to avoid first-start races when stop arrives before `startRecording()` fully transitions to `.recording`.


### PR DESCRIPTION
## Summary
Before, MacParakeet had one dictation hotkey that handled both hold (push-to-talk) and double-tap (hands-free) on the same key. Now push-to-talk and hands-free are independent bindings, configurable separately in Settings.

## For users
- Settings now exposes two dictation shortcuts: **Hands-free** (double-tap to start, tap again to stop) and **Push-to-talk** (hold to dictate, release to finish).
- Defaults preserve today's behavior: bind both roles to the same key (e.g. Fn) and you get the familiar double-tap-or-hold flow on one trigger.
- Bind them to different keys for two-handed comfort: e.g. Fn double-tap for hands-free, Right-Option hold for push-to-talk.
- If a dictation shortcut collides with the Meeting / File / YouTube hotkeys, the conflict warning fires just like before and the duplicate role is dropped.

## How it works
- A new `dictationHotkeyPlan` resolves the two roles into 1 or 2 `HotkeyManager`s with explicit gesture modes (`doubleTapAndHold`, `doubleTapOnly`, `holdOnly`).
- When the two roles share a key, the legacy single-manager `doubleTapAndHold` path is reused — zero behavior change for existing users.
- While one role is mid-gesture, the sibling manager is suppressed so a double-tap can't fire a stale push-to-talk session.

## Code touchpoints
- `Sources/MacParakeet/App/AppHotkeyCoordinator.swift` — plan resolution, conflict detection, manager fan-out.
- `Sources/MacParakeet/Hotkey/HotkeyManager.swift` — per-manager `gestureMode`, suppress / reset hooks.
- `Sources/MacParakeetCore/STT/HotkeyGestureController.swift` — three explicit gesture modes.
- `Sources/MacParakeet/Views/Settings/SettingsView.swift` + `SettingsViewModel.swift` — second picker, persistence, change notification.
- `Tests/MacParakeetTests/Hotkey/{HotkeyManagerTests,HotkeyGestureControllerTests}.swift` + `AppHotkeyCoordinatorTests.swift` — planning, gesture mode, and coordinator coverage.