### PR TITLE
[codex] Align CLI integration docs with 2.1 surface

### DIFF
--- a/integrations/README.md
+++ b/integrations/README.md
@@ -27,11 +27,11 @@ testing.
 - **Persisted history** -- list, search, and inspect prior dictations and
   transcriptions via the shared SQLite database.
 - **Prompt and meeting inspection** -- list and run prompt library entries
-  against transcriptions; list, show, transcript-dump, notes-append, and
+  against transcriptions; list, show, transcript, notes append, and
   export meeting recordings.
 - **Headless verification hooks** -- agents can drive deterministic runs (pin
-  all flags) or smoke-test GUI-default behavior (`--engine app-default`,
-  `--speaker-detection app-default`, `--mode app-default`).
+  all flags) or smoke-test GUI-default behavior with the explicit
+  `app-default` flag group.
 
 ### Out of scope (by design)
 
@@ -147,6 +147,7 @@ macparakeet-cli transcribe /path/to/audio.mp3 \
   --speaker-detection app-default \
   --mode app-default \
   --downloaded-audio app-default \
+  --youtube-audio-quality app-default \
   --format json
 ```
 
@@ -316,7 +317,13 @@ user wants YouTube transcription, run
 macparakeet-cli transcribe "<path-or-youtube-url>" --format json
 macparakeet-cli models download whisper-large-v3-v20240930-turbo-632MB
 macparakeet-cli transcribe "<path-or-youtube-url>" --engine whisper --language ko --format json
-macparakeet-cli transcribe "<path-or-youtube-url>" --engine app-default --speaker-detection app-default --mode app-default --format json
+macparakeet-cli transcribe "<path-or-youtube-url>" \
+  --engine app-default \
+  --speaker-detection app-default \
+  --mode app-default \
+  --downloaded-audio app-default \
+  --youtube-audio-quality app-default \
+  --format json
 macparakeet-cli config list
 macparakeet-cli config set speech-engine parakeet
 macparakeet-cli config set speaker-detection off
@@ -353,7 +360,9 @@ macparakeet-cli prompts run "<prompt-name>" \
 - Never delete user database records unless the user explicitly requests it.
 - Prefer meeting ID or UUID prefix over title when mutating notes.
 - Keep API keys in environment variables; do not put literal keys in commands.
-- Use `--engine app-default --speaker-detection app-default --mode app-default`
+- Use the full app-default group (`--engine app-default`,
+  `--speaker-detection app-default`, `--mode app-default`,
+  `--downloaded-audio app-default`, and `--youtube-audio-quality app-default`)
   only when you are intentionally checking GUI-default behavior. Pin explicit
   flags for reproducible agent tests.
 - `config get speaker-detection` reports the saved app-default value. Bare

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -23,7 +23,7 @@ the local Parakeet TDT pipeline without any cloud STT dependency.
 ln -s /Applications/MacParakeet.app/Contents/MacOS/macparakeet-cli \
       /usr/local/bin/macparakeet-cli
 # 3. Verify
-macparakeet-cli --version   # 2.0.0
+macparakeet-cli --version   # 2.1.0
 macparakeet-cli health --json
 ```
 

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -31,7 +31,7 @@ All execution is local on the Apple Neural Engine. No cloud STT.
 ln -s /Applications/MacParakeet.app/Contents/MacOS/macparakeet-cli \
       /usr/local/bin/macparakeet-cli
 # 3. Verify
-macparakeet-cli --version   # 2.0.0
+macparakeet-cli --version   # 2.1.0
 macparakeet-cli health --json
 ```
 
@@ -75,7 +75,7 @@ fields and validation rules may have evolved.
 ````markdown
 ---
 name: macparakeet-stt
-version: 2.0.0
+version: 2.1.0
 author: <your-username>
 description: Local Parakeet TDT speech-to-text on Apple Silicon. Wraps macparakeet-cli (GPL-3.0-or-later).
 tags: [stt, transcription, voice, apple-silicon, local, parakeet]


### PR DESCRIPTION
## Summary
- Update agent-facing integration docs from stale 2.0 examples to the current 2.1 CLI version.
- Replace old meeting command wording with the actual nested commands: `meetings transcript` and `meetings notes append`.
- Document the complete `app-default` smoke-test group, including downloaded-audio retention and YouTube audio quality.

## Why
Latest main already has the right CLI behavior, but a fresh docs audit found small integration README drift. Agents use these docs as their command vocabulary, so stale command names and partial app-default examples can lead to false failures during CLI-driven GUI-default checks.

## Surface Map
```text
GUI defaults
    |
    v
shared UserDefaults suite
    |
    +--> macparakeet-cli config get|set|list
    |
    +--> macparakeet-cli transcribe --engine app-default
                                      --speaker-detection app-default
                                      --mode app-default
                                      --downloaded-audio app-default
                                      --youtube-audio-quality app-default
```

## Validation
- `swift run macparakeet-cli --help`
- `swift run macparakeet-cli --version` -> `2.1.0`
- `.build/debug/macparakeet-cli config get youtube_audio_quality --json`
- `.build/debug/macparakeet-cli transcribe /tmp/macparakeet-cli-audit-missing-file --format json`
- `swift test --filter CLITests` -> 207 tests, 0 failures
- `swift test` -> 2384 tests, 10 skipped hardware tests, 0 failures
- `git diff --check`
