### PR TITLE
Lower dictation minimum audio threshold

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio",
       "state" : {
-        "revision" : "d302273d49ef4d8914b27f20d342be482e8810f1",
-        "version" : "0.14.1"
+        "revision" : "ce59fb14b8b8978b196f6a34282e20ea6762d164",
+        "version" : "0.14.5"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let packageDependencies: [Package.Dependency] = [
     // GRDB for SQLite (dictation history + transcription records)
     .package(url: "https://github.com/groue/GRDB.swift", from: "7.0.0"),
     // FluidAudio for Parakeet STT on CoreML/ANE
-    .package(url: "https://github.com/FluidInference/FluidAudio", .upToNextMinor(from: "0.14.1")),
+    .package(url: "https://github.com/FluidInference/FluidAudio", .upToNextMinor(from: "0.14.5")),
     // ArgumentParser for CLI
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
     // Sparkle for auto-updates (non-App Store distribution)

--- a/Sources/MacParakeetCore/Audio/AudioRecorder.swift
+++ b/Sources/MacParakeetCore/Audio/AudioRecorder.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import CoreAudio
+import FluidAudio
 import Foundation
 import os
 import OSLog
@@ -106,9 +107,13 @@ public actor AudioRecorder {
     /// caller of `stop()` just asked to end.
     private var startCallGeneration: Int = 0
 
-    /// Minimum samples before sending to STT.
-    /// FluidAudio requires at least 1 second of 16kHz audio (16,000 samples).
-    private static let minimumSamples = 16_000
+    private static let outputSampleRate = ASRConstants.sampleRate
+
+    /// Minimum samples before sending to STT. Mirrors FluidAudio's ASR guard,
+    /// currently 0.3 seconds at 16 kHz.
+    private static let minimumSamples = ASRConstants.minimumRequiredSamples(
+        forSampleRate: outputSampleRate
+    )
 
     /// Time after `engine_started` to wait for the first buffer before
     /// emitting `dictation_capture_no_buffers_within_timeout`. Mirrors the
@@ -180,7 +185,7 @@ public actor AudioRecorder {
 
         guard let outputFormat = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,
-            sampleRate: 16000,
+            sampleRate: Double(Self.outputSampleRate),
             channels: 1,
             interleaved: false
         ) else {
@@ -441,7 +446,7 @@ public actor AudioRecorder {
     }
 
     /// Stop recording and return the path to the recorded WAV file.
-    /// Throws `insufficientSamples` if the recording is shorter than 1 second.
+    /// Throws `insufficientSamples` if the recording is shorter than the STT minimum.
     public func stop() throws -> URL {
         if starting, !recording {
             // `start()` awaits the stream subscription. A stop/cancel during
@@ -487,7 +492,7 @@ public actor AudioRecorder {
         let sampleCount = sampleCounter.withLock { $0 }
         let metrics = runtimeMetrics.withLock { $0 }
         let fileBytes = Self.fileSizeBytes(at: url)
-        let duration = Double(sampleCount) / 16_000.0
+        let duration = Double(sampleCount) / Double(Self.outputSampleRate)
         logger.debug("stop sampleCount=\(sampleCount, privacy: .public)")
         AudioCaptureDiagnostics.append(
             "dictation_capture_stop sample_count=\(sampleCount) duration_s=\(String(format: "%.3f", duration)) file_bytes=\(fileBytes.map(String.init) ?? "unknown") input_buffers=\(metrics.inputBufferCount) output_buffers=\(metrics.outputBufferCount) input_frames=\(metrics.inputFrameCount) max_rms=\(String(format: "%.6f", metrics.maxRMS)) max_level=\(String(format: "%.3f", metrics.maxAudioLevel)) non_silent_buffers=\(metrics.nonSilentBufferCount) missing_float_buffers=\(metrics.missingFloatChannelDataBufferCount) invalid_format_buffers=\(metrics.invalidFormatBufferCount)"

--- a/Tests/MacParakeetTests/Audio/AudioRecorderFormatChangeTests.swift
+++ b/Tests/MacParakeetTests/Audio/AudioRecorderFormatChangeTests.swift
@@ -36,6 +36,43 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
         )
     }
 
+    func testSharedModeStopAcceptsFluidAudioMinimumSamples() async throws {
+        let platform = AudioRecorderBlockingPlatform()
+        let stream = SharedMicrophoneStream(platform: platform, bufferSize: 1024)
+        let recorder = AudioRecorder(
+            sharedStream: stream,
+            permissionProvider: { true }
+        )
+
+        try await recorder.start()
+        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 4_800))
+
+        let url = try await recorder.stop()
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    func testSharedModeStopRejectsBelowFluidAudioMinimumSamples() async throws {
+        let platform = AudioRecorderBlockingPlatform()
+        let stream = SharedMicrophoneStream(platform: platform, bufferSize: 1024)
+        let recorder = AudioRecorder(
+            sharedStream: stream,
+            permissionProvider: { true }
+        )
+
+        try await recorder.start()
+        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 4_799))
+
+        do {
+            _ = try await recorder.stop()
+            XCTFail("stop() should reject recordings below FluidAudio's current 0.3s floor")
+        } catch AudioProcessorError.insufficientSamples {
+            // Expected.
+        } catch {
+            XCTFail("Unexpected stop error: \(error)")
+        }
+    }
+
     func testSharedModeStopDuringStartAbortsPendingSubscription() async throws {
         let platform = AudioRecorderBlockingPlatform()
         let stream = SharedMicrophoneStream(platform: platform, bufferSize: 1024)
@@ -219,6 +256,33 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
             )
         )
     }
+
+    private func makeMonoFloatBuffer(
+        frameCount: Int,
+        sampleRate: Double = 16_000,
+        sampleValue: Float = 0.25
+    ) throws -> AVAudioPCMBuffer {
+        let format = try XCTUnwrap(
+            AVAudioFormat(
+                commonFormat: .pcmFormatFloat32,
+                sampleRate: sampleRate,
+                channels: 1,
+                interleaved: false
+            )
+        )
+        let buffer = try XCTUnwrap(
+            AVAudioPCMBuffer(
+                pcmFormat: format,
+                frameCapacity: AVAudioFrameCount(frameCount)
+            )
+        )
+        buffer.frameLength = AVAudioFrameCount(frameCount)
+        let samples = try XCTUnwrap(buffer.floatChannelData?[0])
+        for index in 0..<frameCount {
+            samples[index] = sampleValue
+        }
+        return buffer
+    }
 }
 
 private final class AudioRecorderBlockingPlatform: MicrophoneEnginePlatform, @unchecked Sendable {
@@ -258,5 +322,10 @@ private final class AudioRecorderBlockingPlatform: MicrophoneEnginePlatform, @un
             _isRunning = false
             _tapHandler = nil
         }
+    }
+
+    func deliverBuffer(_ buffer: AVAudioPCMBuffer) {
+        let handler = lock.withLock { _tapHandler }
+        handler?(buffer, AVAudioTime(hostTime: 1))
     }
 }

--- a/spec/05-audio-pipeline.md
+++ b/spec/05-audio-pipeline.md
@@ -17,7 +17,7 @@ Mic Input → SharedMicrophoneStream tap → temp WAV → selected local STT eng
 - **Shared mic engine**: `AudioRecorder` subscribes to the process-wide `SharedMicrophoneStream` with `wantsVPIO: false`
 - The stream owns the underlying `AVAudioEngine` input-node tap and handles device fallback centrally
 - **Output format**: temporary WAV, 16kHz mono Float32
-- **Minimum sample threshold**: 16,000 samples required before sending to STT. Header-only and near-empty recordings are rejected before they reach the speech engine.
+- **Minimum sample threshold**: 4,800 samples (0.3 seconds at 16kHz) required before sending to STT, mirroring FluidAudio's ASR guard. Header-only and near-empty recordings are rejected before they reach the speech engine.
 - Dictation always extracts channel 0 before conversion so VPIO duplex layouts produce the post-AEC mono stream instead of channel-mixed reference audio.
 - Dictation does not use the meeting crash-recovery lock-file pipeline. The current implementation writes a temp WAV and either moves it into retained storage or deletes it after processing.
 
@@ -40,7 +40,7 @@ User triggers dictation
     → Convert samples to 16kHz mono Float32
     → Write to temp WAV
     → User stops dictation (or release-to-stop)
-    → Validate sample count >= 16,000
+    → Validate sample count >= 4,800
     → Send to selected local STT engine through STTScheduler
     → Move WAV to dictations/ for storage (if enabled)
     → Clean up temp WAV (if storage disabled)


### PR DESCRIPTION
## Summary
Short hold-to-talk taps were being rejected with "More audio please" because MacParakeet enforced a 1-second app-side minimum left over from an older FluidAudio requirement. We now derive the floor from `ASRConstants.minimumRequiredSamples`, which is currently 4,800 samples (0.3 seconds at 16 kHz). Fixes #216.

## For users
- Quick taps as short as ~0.3 seconds are now transcribed instead of being dropped.
- The "More audio please" message still appears for anything below that floor (e.g. accidental key brushes or silent taps).
- No change to longer dictations — behavior is identical above the threshold.
- The minimum tracks FluidAudio upstream, so it will follow future improvements automatically.

## How it works

```
before:  hold ▮▮       release   → "more audio please" (dropped, <1.0s)
         hold ▮▮▮▮▮▮   release   → transcribed
after:   hold ▮         release   → "more audio please" (dropped, <0.3s)
         hold ▮▮       release   → transcribed
```

## Code touchpoints
- `Sources/MacParakeetCore/Audio/AudioRecorder.swift` — replace hard-coded `16_000` with `ASRConstants.minimumRequiredSamples(forSampleRate:)`; sample-rate constant also sourced from `ASRConstants`.
- `Tests/MacParakeetTests/Audio/AudioRecorderFormatChangeTests.swift` — boundary tests at 4,800 (accepted) and 4,799 (rejected).
- `Package.swift` / `spec/05-audio-pipeline.md` — bump FluidAudio to 0.14.5 and update the documented threshold.