### PR TITLE
Implement dictation first-load caption

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -188,7 +188,10 @@ final class AppEnvironment {
             processingMode: processingModeClosure,
             llmService: llmService,
             shouldUseAIFormatter: aiFormatterEnabledClosure,
-            aiFormatterPromptTemplate: aiFormatterPromptClosure
+            aiFormatterPromptTemplate: aiFormatterPromptClosure,
+            markFirstDictationCompleted: { [runtimePreferences] in
+                runtimePreferences.markFirstDictationCompleted()
+            }
         )
 
         let telemetry = TelemetryService()

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -206,6 +206,8 @@ final class AppEnvironmentConfigurer {
             entitlementsService: env.entitlementsService,
             dictationRepo: env.dictationRepo,
             settingsViewModel: settingsViewModel,
+            sttRuntime: env.sttRuntime,
+            runtimePreferences: env.runtimePreferences,
             shouldSuppressIdlePill: {
                 coordinatorRefs.meeting?.isMeetingRecordingActive == true
             },

--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -30,7 +30,7 @@ private enum ProcessingLoadCaptionOutcome {
     var telemetryValue: String {
         switch self {
         case .success: return "success"
-        case .noSpeech: return "noSpeech"
+        case .noSpeech: return "no_speech"
         case .failure: return "failure"
         case .cancelled: return "cancelled"
         }

--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -3,6 +3,40 @@ import OSLog
 import MacParakeetCore
 import MacParakeetViewModels
 
+struct DictationProcessingLoadCaptionTiming: Sendable {
+    static let production = DictationProcessingLoadCaptionTiming(
+        graceMs: 600,
+        escalationMs: 4000,
+        failureDisplayMs: 2000
+    )
+
+    let graceMs: Int
+    let escalationMs: Int
+    let failureDisplayMs: Int
+}
+
+protocol DictationSTTReadinessChecking: Sendable {
+    func isReady() async -> Bool
+}
+
+extension STTRuntime: DictationSTTReadinessChecking {}
+
+private enum ProcessingLoadCaptionOutcome {
+    case success
+    case noSpeech
+    case failure
+    case cancelled
+
+    var telemetryValue: String {
+        switch self {
+        case .success: return "success"
+        case .noSpeech: return "noSpeech"
+        case .failure: return "failure"
+        case .cancelled: return "cancelled"
+        }
+    }
+}
+
 @MainActor
 final class DictationFlowCoordinator {
     private static let silenceAutoStopThreshold: Float = 0.03
@@ -70,6 +104,10 @@ final class DictationFlowCoordinator {
     private let entitlementsService: EntitlementsService
     private let dictationRepo: DictationRepository
     private let settingsViewModel: SettingsViewModel
+    private let sttRuntime: any DictationSTTReadinessChecking
+    private let runtimePreferences: AppRuntimePreferencesProtocol
+    private let captionTiming: DictationProcessingLoadCaptionTiming
+    private let overlayControllerFactory: @MainActor (DictationOverlayViewModel) -> any DictationOverlayControlling
     private let shouldSuppressIdlePill: () -> Bool
     private let onMenuBarIconUpdate: (BreathWaveIcon.MenuBarState) -> Void
     private let onHistoryReload: () -> Void
@@ -82,7 +120,7 @@ final class DictationFlowCoordinator {
 
     // MARK: - UI Resources (managed by effect executor)
 
-    private var overlayController: DictationOverlayController?
+    private var overlayController: (any DictationOverlayControlling)?
     private var overlayViewModel: DictationOverlayViewModel?
     private var idlePillController: IdlePillController?
     private var readyDismissTimer: DispatchWorkItem?
@@ -90,6 +128,10 @@ final class DictationFlowCoordinator {
     private var actionTask: Task<Void, Never>?
     private var cancelCountdownTask: Task<Void, Never>?
     private var displayDismissTask: Task<Void, Never>?
+    private var captionGraceTimer: DispatchWorkItem?
+    private var captionEscalationTimer: DispatchWorkItem?
+    private var captionFailureDismissTask: Task<Void, Never>?
+    private var captionShownAt: Date?
 
     // MARK: - Flow Context (not state machine concerns)
 
@@ -113,6 +155,12 @@ final class DictationFlowCoordinator {
         entitlementsService: EntitlementsService,
         dictationRepo: DictationRepository,
         settingsViewModel: SettingsViewModel,
+        sttRuntime: any DictationSTTReadinessChecking,
+        runtimePreferences: AppRuntimePreferencesProtocol,
+        captionTiming: DictationProcessingLoadCaptionTiming = .production,
+        overlayControllerFactory: @escaping @MainActor (DictationOverlayViewModel) -> any DictationOverlayControlling = {
+            DictationOverlayController(viewModel: $0)
+        },
         shouldSuppressIdlePill: @escaping () -> Bool = { false },
         onMenuBarIconUpdate: @escaping (BreathWaveIcon.MenuBarState) -> Void,
         onHistoryReload: @escaping () -> Void,
@@ -123,6 +171,10 @@ final class DictationFlowCoordinator {
         self.entitlementsService = entitlementsService
         self.dictationRepo = dictationRepo
         self.settingsViewModel = settingsViewModel
+        self.sttRuntime = sttRuntime
+        self.runtimePreferences = runtimePreferences
+        self.captionTiming = captionTiming
+        self.overlayControllerFactory = overlayControllerFactory
         self.shouldSuppressIdlePill = shouldSuppressIdlePill
         self.onMenuBarIconUpdate = onMenuBarIconUpdate
         self.onHistoryReload = onHistoryReload
@@ -166,6 +218,7 @@ final class DictationFlowCoordinator {
     private func promoteOverlayToFormatting() {
         guard let vm = overlayViewModel else { return }
         if case .processing = vm.state {
+            dismissCaption(outcome: .success)
             vm.isHovered = false
             vm.hoverTooltip = nil
             vm.state = .formatting
@@ -281,7 +334,7 @@ final class DictationFlowCoordinator {
             vm.state = .ready
             overlayViewModel = vm
 
-            let controller = DictationOverlayController(viewModel: vm)
+            let controller = overlayControllerFactory(vm)
             controller.show()
             overlayController = controller
 
@@ -309,13 +362,14 @@ final class DictationFlowCoordinator {
                 vm.onDismiss = { [weak self] in self?.sendEvent(.dismissRequested) }
                 overlayViewModel = vm
 
-                let controller = DictationOverlayController(viewModel: vm)
+                let controller = overlayControllerFactory(vm)
                 controller.show()
                 overlayController = controller
             }
             vm.recordingMode = mode
             vm.processingMessage = nil
             vm.busyProcessingMessage = nil
+            vm.processingLoadCaption = nil
             vm.state = .recording
             vm.startTimer()
 
@@ -323,7 +377,9 @@ final class DictationFlowCoordinator {
             overlayViewModel?.stopTimer()
             overlayViewModel?.processingMessage = nil
             overlayViewModel?.busyProcessingMessage = nil
+            overlayViewModel?.processingLoadCaption = nil
             overlayViewModel?.state = .processing
+            armProcessingLoadCaption()
 
         case .showBusyProcessingHint:
             overlayViewModel?.showBusyProcessingHint()
@@ -334,20 +390,24 @@ final class DictationFlowCoordinator {
             overlayViewModel?.state = .cancelled(timeRemaining: 5.0)
 
         case .showSuccess:
+            dismissCaption(outcome: .success)
             overlayViewModel?.state = .success
 
         case .showNoSpeech:
+            dismissCaption(outcome: .noSpeech)
             overlayViewModel?.state = .noSpeech
 
         case .showError(let message):
-            overlayViewModel?.state = .error(message)
+            showErrorAfterCaptionFailureIfNeeded(message: message)
 
         case .hideOverlay:
+            dismissCaption(outcome: .cancelled)
             overlayController?.hide()
             overlayController = nil
             overlayViewModel = nil
 
         case .dismissReadyPill:
+            dismissCaption(outcome: .cancelled)
             overlayController?.hide()
             overlayController = nil
             overlayViewModel = nil
@@ -577,6 +637,7 @@ final class DictationFlowCoordinator {
             cancelCountdownTask = nil
             displayDismissTask?.cancel()
             displayDismissTask = nil
+            dismissCaption(outcome: .cancelled)
 
         // MARK: Task management
 
@@ -592,6 +653,105 @@ final class DictationFlowCoordinator {
     }
 
     // MARK: - Private Helpers
+
+    var processingLoadCaptionForTesting: DictationOverlayViewModel.ProcessingLoadCaption? {
+        overlayViewModel?.processingLoadCaption
+    }
+
+    var overlayStateForTesting: DictationOverlayViewModel.OverlayState? {
+        overlayViewModel?.state
+    }
+
+    private func armProcessingLoadCaption() {
+        captionGraceTimer?.cancel()
+        captionEscalationTimer?.cancel()
+        captionFailureDismissTask?.cancel()
+        captionGraceTimer = nil
+        captionEscalationTimer = nil
+        captionFailureDismissTask = nil
+        captionShownAt = nil
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            guard await !self.sttRuntime.isReady() else { return }
+
+            let grace = DispatchWorkItem { [weak self] in
+                Task { @MainActor in
+                    self?.fireCaption()
+                }
+            }
+            self.captionGraceTimer = grace
+            DispatchQueue.main.asyncAfter(
+                deadline: .now() + .milliseconds(self.captionTiming.graceMs),
+                execute: grace
+            )
+        }
+    }
+
+    private func fireCaption() {
+        guard overlayViewModel?.processingLoadCaption == nil else { return }
+        guard let state = overlayViewModel?.state, case .processing = state else { return }
+
+        let firstInstall = !runtimePreferences.hasCompletedFirstDictation
+        overlayViewModel?.processingLoadCaption = .preparing
+        captionShownAt = Date()
+        Telemetry.send(.dictationFirstLoadCaptionShown(firstInstall: firstInstall))
+
+        guard firstInstall else { return }
+        let escalation = DispatchWorkItem { [weak self] in
+            Task { @MainActor in
+                guard self?.overlayViewModel?.processingLoadCaption == .preparing else { return }
+                self?.overlayViewModel?.processingLoadCaption = .preparingExtended
+            }
+        }
+        captionEscalationTimer = escalation
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + .milliseconds(captionTiming.escalationMs),
+            execute: escalation
+        )
+    }
+
+    private func dismissCaption(outcome: ProcessingLoadCaptionOutcome) {
+        captionGraceTimer?.cancel()
+        captionEscalationTimer?.cancel()
+        captionFailureDismissTask?.cancel()
+        captionGraceTimer = nil
+        captionEscalationTimer = nil
+        captionFailureDismissTask = nil
+
+        if let shownAt = captionShownAt {
+            let durationMs = max(0, Int(Date().timeIntervalSince(shownAt) * 1000))
+            Telemetry.send(.dictationFirstLoadCaptionDuration(
+                durationMs: durationMs,
+                outcome: outcome.telemetryValue
+            ))
+            captionShownAt = nil
+        }
+        overlayViewModel?.processingLoadCaption = nil
+    }
+
+    private func showErrorAfterCaptionFailureIfNeeded(message: String) {
+        captionGraceTimer?.cancel()
+        captionEscalationTimer?.cancel()
+        captionGraceTimer = nil
+        captionEscalationTimer = nil
+
+        switch overlayViewModel?.processingLoadCaption {
+        case .preparing, .preparingExtended:
+            overlayViewModel?.processingLoadCaption = .failed
+            captionFailureDismissTask?.cancel()
+            captionFailureDismissTask = Task { @MainActor [weak self] in
+                guard let self else { return }
+                try? await Task.sleep(for: .milliseconds(self.captionTiming.failureDisplayMs))
+                guard !Task.isCancelled else { return }
+                self.dismissCaption(outcome: .failure)
+                self.overlayViewModel?.state = .error(message)
+            }
+        default:
+            dismissCaption(outcome: .failure)
+            overlayViewModel?.state = .error(message)
+        }
+    }
 
     /// Whether the error represents "no speech" (empty transcript or recording too short).
     private func isNoSpeechError(_ error: Error) -> Bool {

--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -132,6 +132,7 @@ final class DictationFlowCoordinator {
     private var captionEscalationTimer: DispatchWorkItem?
     private var captionFailureDismissTask: Task<Void, Never>?
     private var captionShownAt: Date?
+    private var captionGeneration = 0
 
     // MARK: - Flow Context (not state machine concerns)
 
@@ -663,6 +664,8 @@ final class DictationFlowCoordinator {
     }
 
     private func armProcessingLoadCaption() {
+        captionGeneration += 1
+        let generation = captionGeneration
         captionGraceTimer?.cancel()
         captionEscalationTimer?.cancel()
         captionFailureDismissTask?.cancel()
@@ -674,10 +677,12 @@ final class DictationFlowCoordinator {
         Task { @MainActor [weak self] in
             guard let self else { return }
             guard await !self.sttRuntime.isReady() else { return }
+            guard self.captionGeneration == generation else { return }
+            guard let state = self.overlayViewModel?.state, case .processing = state else { return }
 
             let grace = DispatchWorkItem { [weak self] in
                 Task { @MainActor in
-                    self?.fireCaption()
+                    self?.fireCaption(generation: generation)
                 }
             }
             self.captionGraceTimer = grace
@@ -688,7 +693,8 @@ final class DictationFlowCoordinator {
         }
     }
 
-    private func fireCaption() {
+    private func fireCaption(generation: Int) {
+        guard captionGeneration == generation else { return }
         guard overlayViewModel?.processingLoadCaption == nil else { return }
         guard let state = overlayViewModel?.state, case .processing = state else { return }
 
@@ -700,6 +706,7 @@ final class DictationFlowCoordinator {
         guard firstInstall else { return }
         let escalation = DispatchWorkItem { [weak self] in
             Task { @MainActor in
+                guard self?.captionGeneration == generation else { return }
                 guard self?.overlayViewModel?.processingLoadCaption == .preparing else { return }
                 self?.overlayViewModel?.processingLoadCaption = .preparingExtended
             }
@@ -712,6 +719,7 @@ final class DictationFlowCoordinator {
     }
 
     private func dismissCaption(outcome: ProcessingLoadCaptionOutcome) {
+        captionGeneration += 1
         captionGraceTimer?.cancel()
         captionEscalationTimer?.cancel()
         captionFailureDismissTask?.cancel()

--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -682,7 +682,7 @@ final class DictationFlowCoordinator {
 
             let grace = DispatchWorkItem { [weak self] in
                 Task { @MainActor in
-                    self?.fireCaption(generation: generation)
+                    await self?.fireCaption(generation: generation)
                 }
             }
             self.captionGraceTimer = grace
@@ -693,7 +693,11 @@ final class DictationFlowCoordinator {
         }
     }
 
-    private func fireCaption(generation: Int) {
+    private func fireCaption(generation: Int) async {
+        guard captionGeneration == generation else { return }
+        guard overlayViewModel?.processingLoadCaption == nil else { return }
+        guard let state = overlayViewModel?.state, case .processing = state else { return }
+        guard await !sttRuntime.isReady() else { return }
         guard captionGeneration == generation else { return }
         guard overlayViewModel?.processingLoadCaption == nil else { return }
         guard let state = overlayViewModel?.state, case .processing = state else { return }

--- a/Sources/MacParakeet/App/OnboardingCoordinator.swift
+++ b/Sources/MacParakeet/App/OnboardingCoordinator.swift
@@ -8,6 +8,7 @@ final class OnboardingCoordinator {
     private let onRefreshHotkeys: () -> Void
     private let onOpenMainWindow: () -> Void
     private let onOpenSettings: () -> Void
+    private let onCompleted: () -> Void
 
     private var reopenOnNextActivate = false
 
@@ -15,12 +16,14 @@ final class OnboardingCoordinator {
         onboardingWindowController: OnboardingWindowController,
         onRefreshHotkeys: @escaping () -> Void,
         onOpenMainWindow: @escaping () -> Void,
-        onOpenSettings: @escaping () -> Void
+        onOpenSettings: @escaping () -> Void,
+        onCompleted: @escaping () -> Void = {}
     ) {
         self.onboardingWindowController = onboardingWindowController
         self.onRefreshHotkeys = onRefreshHotkeys
         self.onOpenMainWindow = onOpenMainWindow
         self.onOpenSettings = onOpenSettings
+        self.onCompleted = onCompleted
     }
 
     var isVisible: Bool {
@@ -68,6 +71,7 @@ final class OnboardingCoordinator {
             onFinish: { [weak self] in
                 self?.reopenOnNextActivate = false
                 self?.onRefreshHotkeys()
+                self?.onCompleted()
                 Task {
                     await entitlementsService.bootstrapTrialIfNeeded()
                 }

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -42,6 +42,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var hasPresentedHotkeyConflictAlert = false
     private var environmentSetupTask: Task<Void, Never>?
     private var meetingQuitTask: Task<Void, Never>?
+    private var speechPreWarmTask: Task<Void, Never>?
+    private let preWarmDeferralMs: Int = 1500
 
     // MARK: - View Models
 
@@ -102,6 +104,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         },
         onOpenSettings: { [weak self] in
             self?.windowCoordinator.openMainWindowToSettings()
+        },
+        onCompleted: { [weak self] in
+            guard let self, let env = self.appEnvironment else { return }
+            self.scheduleDeferredSpeechPreWarm(environment: env)
         }
     )
 
@@ -255,6 +261,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         meetingAutoStartCoordinator?.stop()
         settingsObserverCoordinator.stopObserving()
         environmentSetupTask?.cancel()
+        speechPreWarmTask?.cancel()
 
         // Bound the wait so termination does not hang, while still giving shutdown
         // a brief window to release resources cleanly.
@@ -364,7 +371,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         menuBarCoordinator.refreshMeetingHotkeyShortcut()
         menuBarCoordinator.refreshTranscriptionHotkeyShortcuts()
         onboardingCoordinator.maybeShow(environment: env)
+        scheduleDeferredSpeechPreWarm(environment: env)
         meetingRecoveryCoordinator.scheduleLaunchRecoveryScanIfReady(environment: env)
+    }
+
+    private func scheduleDeferredSpeechPreWarm(environment env: AppEnvironment) {
+        guard speechPreWarmTask == nil else { return }
+        let sttRuntime = env.sttRuntime
+        let deferralMs = preWarmDeferralMs
+        let onboardingCompletedKey = OnboardingViewModel.onboardingCompletedKey
+
+        speechPreWarmTask = Task.detached(priority: .utility) { [weak self, sttRuntime] in
+            defer {
+                Task { @MainActor in
+                    self?.speechPreWarmTask = nil
+                }
+            }
+
+            try? await Task.sleep(for: .milliseconds(deferralMs))
+            guard !Task.isCancelled else { return }
+            let onboardingDone = UserDefaults.standard.string(forKey: onboardingCompletedKey) != nil
+            guard onboardingDone else { return }
+            await sttRuntime.backgroundWarmUp()
+        }
     }
 
     private func presentEnvironmentSetupError(_ error: Error) {

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -43,6 +43,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var environmentSetupTask: Task<Void, Never>?
     private var meetingQuitTask: Task<Void, Never>?
     private var speechPreWarmTask: Task<Void, Never>?
+    // Let first paint and onboarding routing settle before starting CoreML cache work.
     private let preWarmDeferralMs: Int = 1500
 
     // MARK: - View Models
@@ -381,11 +382,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let deferralMs = preWarmDeferralMs
         let onboardingCompletedKey = OnboardingViewModel.onboardingCompletedKey
 
-        speechPreWarmTask = Task.detached(priority: .utility) { [weak self, sttRuntime] in
+        speechPreWarmTask = Task(priority: .utility) { @MainActor [weak self, sttRuntime] in
             defer {
-                Task { @MainActor in
-                    self?.speechPreWarmTask = nil
-                }
+                self?.speechPreWarmTask = nil
             }
 
             try? await Task.sleep(for: .milliseconds(deferralMs))

--- a/Sources/MacParakeet/Views/Dictation/DictationOverlayController.swift
+++ b/Sources/MacParakeet/Views/Dictation/DictationOverlayController.swift
@@ -47,12 +47,19 @@ private final class ClickablePanel: NSPanel {
     override var canBecomeKey: Bool { true }
 }
 
+@MainActor
+protocol DictationOverlayControlling: AnyObject {
+    func show()
+    func hide()
+    func resignKeyWindow()
+}
+
 // MARK: - Overlay Controller
 
 /// Manages the floating dictation overlay panel.
 /// Non-activating NSPanel that never steals focus from the active app.
 @MainActor
-final class DictationOverlayController {
+final class DictationOverlayController: DictationOverlayControlling {
     private var panel: NSPanel?
     private var hostingView: NSHostingView<DictationOverlayView>?
     private var trackingView: MouseTrackingView?
@@ -197,6 +204,12 @@ final class DictationOverlayViewModel {
         case error(String)
     }
 
+    enum ProcessingLoadCaption: Equatable {
+        case preparing
+        case preparingExtended
+        case failed
+    }
+
     var state: OverlayState = .recording
     var sessionKind: SessionKind = .dictation
     var recordingMode: FnKeyStateMachine.RecordingMode = .persistent
@@ -206,6 +219,7 @@ final class DictationOverlayViewModel {
     var hoverTooltip: String?
     var processingMessage: String?
     var busyProcessingMessage: String?
+    var processingLoadCaption: ProcessingLoadCaption?
     var commandPromptText: String = "Speak your command..."
     var commandSelectedText: String = ""
 

--- a/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
+++ b/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
@@ -213,6 +213,7 @@ private struct NoSpeechLightDrift: View {
 /// The dictation overlay — compact dark capsule during dictation, wider card for errors.
 struct DictationOverlayView: View {
     @Bindable var viewModel: DictationOverlayViewModel
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     /// Drives the no-speech pill's circle → oval width expansion. Starts `false`
     /// so the pill begins at 46×46 (matching the processing spinner), then flips
@@ -239,10 +240,17 @@ struct DictationOverlayView: View {
                 .frame(height: 36)
 
             // Content with state-appropriate shape
+            if let caption = viewModel.processingLoadCaption {
+                LoadingCaptionView(caption: caption)
+                    .transition(LoadingCaptionView.transition(reduceMotion: reduceMotion))
+                    .padding(.bottom, 2)
+            }
+
             overlayContent
         }
         .padding(.bottom, 8)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+        .animation(.easeInOut(duration: 0.22), value: viewModel.processingLoadCaption)
         .onChange(of: viewModel.pillStateKey) { _, newKey in
             handlePillStateChange(to: newKey)
         }

--- a/Sources/MacParakeet/Views/Dictation/LoadingCaptionView.swift
+++ b/Sources/MacParakeet/Views/Dictation/LoadingCaptionView.swift
@@ -1,4 +1,3 @@
-import MacParakeetCore
 import SwiftUI
 
 struct LoadingCaptionView: View {

--- a/Sources/MacParakeet/Views/Dictation/LoadingCaptionView.swift
+++ b/Sources/MacParakeet/Views/Dictation/LoadingCaptionView.swift
@@ -1,0 +1,80 @@
+import MacParakeetCore
+import SwiftUI
+
+struct LoadingCaptionView: View {
+    let caption: DictationOverlayViewModel.ProcessingLoadCaption
+
+    var body: some View {
+        VStack(spacing: 1) {
+            Text(title)
+                .font(.system(size: 11, weight: .medium, design: .rounded))
+                .foregroundStyle(titleColor)
+
+            if let subcopy {
+                Text(subcopy)
+                    .font(.system(size: 9.5, weight: .regular, design: .rounded))
+                    .foregroundStyle(.white.opacity(0.55))
+            }
+        }
+        .padding(.horizontal, 9)
+        .padding(.vertical, 5)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(DesignSystem.Colors.pillBackground.opacity(0.55))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(DesignSystem.Colors.pillBorder.opacity(0.6), lineWidth: 0.5)
+                )
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    static func transition(reduceMotion: Bool) -> AnyTransition {
+        reduceMotion ? .opacity : .opacity.combined(with: .offset(y: 4))
+    }
+
+    private var title: String {
+        switch caption {
+        case .preparing, .preparingExtended:
+            "Preparing speech engine…"
+        case .failed:
+            "Couldn't load speech engine."
+        }
+    }
+
+    private var subcopy: String? {
+        switch caption {
+        case .preparingExtended:
+            "First-time setup — this happens once"
+        case .preparing, .failed:
+            nil
+        }
+    }
+
+    private var titleColor: Color {
+        switch caption {
+        case .preparing, .preparingExtended:
+            .white.opacity(0.85)
+        case .failed:
+            DesignSystem.Colors.recordingRed
+        }
+    }
+
+    private var accessibilityLabel: String {
+        if let subcopy {
+            return "\(title) \(subcopy)"
+        }
+        return title
+    }
+}
+
+#Preview("Loading Caption") {
+    VStack(spacing: 10) {
+        LoadingCaptionView(caption: .preparing)
+        LoadingCaptionView(caption: .preparingExtended)
+        LoadingCaptionView(caption: .failed)
+    }
+    .padding(24)
+    .background(Color.black)
+}

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -12,6 +12,8 @@ public protocol AppRuntimePreferencesProtocol: Sendable {
     var aiFormatterPrompt: String { get }
     var selectedMicrophoneDeviceUID: String? { get }
     var meetingAudioSourceMode: MeetingAudioSourceMode { get }
+    var hasCompletedFirstDictation: Bool { get }
+    func markFirstDictationCompleted()
 }
 
 public enum YouTubeAudioQuality: String, CaseIterable, Hashable, Sendable, Equatable {
@@ -105,6 +107,7 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
     public static let aiFormatterPromptKey = "aiFormatterPrompt"
     public static let selectedMicrophoneDeviceUIDKey = "selectedMicrophoneDeviceUID"
     public static let meetingAudioSourceModeKey = "meetingAudioSourceMode"
+    public static let hasCompletedFirstDictationKey = "hasCompletedFirstDictation"
 
     private let defaults: UserDefaults
 
@@ -159,5 +162,14 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
 
     public var meetingAudioSourceMode: MeetingAudioSourceMode {
         MeetingAudioSourceMode.current(defaults: defaults)
+    }
+
+    public var hasCompletedFirstDictation: Bool {
+        defaults.bool(forKey: Self.hasCompletedFirstDictationKey)
+    }
+
+    public func markFirstDictationCompleted() {
+        guard !hasCompletedFirstDictation else { return }
+        defaults.set(true, forKey: Self.hasCompletedFirstDictationKey)
     }
 }

--- a/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
+++ b/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
@@ -58,6 +58,7 @@ public actor DictationService: DictationServiceProtocol {
     private let llmService: LLMServiceProtocol?
     private let shouldUseAIFormatter: @Sendable () -> Bool
     private let aiFormatterPromptTemplate: @Sendable () -> String
+    private let markFirstDictationCompleted: (@Sendable () -> Void)?
     private let cancelWindow: Duration
 
     private var _state: DictationState = .idle
@@ -95,6 +96,7 @@ public actor DictationService: DictationServiceProtocol {
         llmService: LLMServiceProtocol? = nil,
         shouldUseAIFormatter: (@Sendable () -> Bool)? = nil,
         aiFormatterPromptTemplate: (@Sendable () -> String)? = nil,
+        markFirstDictationCompleted: (@Sendable () -> Void)? = nil,
         cancelWindow: Duration = .seconds(5)
     ) {
         self.audioProcessor = audioProcessor
@@ -111,6 +113,7 @@ public actor DictationService: DictationServiceProtocol {
         self.llmService = llmService
         self.shouldUseAIFormatter = shouldUseAIFormatter ?? { false }
         self.aiFormatterPromptTemplate = aiFormatterPromptTemplate ?? { AIFormatter.defaultPromptTemplate }
+        self.markFirstDictationCompleted = markFirstDictationCompleted
         self.cancelWindow = cancelWindow
     }
 
@@ -628,6 +631,7 @@ public actor DictationService: DictationServiceProtocol {
             privateCopy.cleanTranscript = nil
             try dictationRepo.save(privateCopy)
         }
+        markFirstDictationCompleted?()
 
         if !expandedSnippetIDs.isEmpty {
             try? snippetRepo?.incrementUseCount(ids: refinement.expandedSnippetIDs)

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -719,10 +719,10 @@ extension TelemetryEventSpec {
                 ("cancel_reason", cancelReason?.rawValue)
             ), device)
         case .dictationFirstLoadCaptionShown(let firstInstall):
-            return ["firstInstall": Self.boolString(firstInstall)]
+            return ["first_install": Self.boolString(firstInstall)]
         case .dictationFirstLoadCaptionDuration(let durationMs, let outcome):
             return [
-                "durationMs": "\(durationMs)",
+                "duration_ms": "\(durationMs)",
                 "outcome": outcome,
             ]
         case .transcriptionStarted(let source, let audioDurationSeconds):
@@ -1233,8 +1233,8 @@ public enum TelemetryImplementedContract {
         .dictationEmpty: [],
         .dictationFailed: ["error_type"],
         .dictationOperation: ["operation_id", "outcome"],
-        .dictationFirstLoadCaptionShown: ["firstInstall"],
-        .dictationFirstLoadCaptionDuration: ["durationMs", "outcome"],
+        .dictationFirstLoadCaptionShown: ["first_install"],
+        .dictationFirstLoadCaptionDuration: ["duration_ms", "outcome"],
         .transcriptionStarted: ["source"],
         .transcriptionCompleted: ["source", "word_count", "diarization_requested", "diarization_applied"],
         .transcriptionCancelled: ["source", "stage"],

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -9,6 +9,8 @@ public enum TelemetryEventName: String, Sendable, CaseIterable {
     case dictationEmpty = "dictation_empty"
     case dictationFailed = "dictation_failed"
     case dictationOperation = "dictation_operation"
+    case dictationFirstLoadCaptionShown = "dictation_first_load_caption_shown"
+    case dictationFirstLoadCaptionDuration = "dictation_first_load_caption_duration"
     case transcriptionStarted = "transcription_started"
     case transcriptionCompleted = "transcription_completed"
     case transcriptionCancelled = "transcription_cancelled"
@@ -282,6 +284,8 @@ public enum TelemetryEventSpec: Sendable {
         engineVariant: String? = nil,
         device: RecordingDeviceInfo? = nil
     )
+    case dictationFirstLoadCaptionShown(firstInstall: Bool)
+    case dictationFirstLoadCaptionDuration(durationMs: Int, outcome: String)
     case transcriptionStarted(source: TelemetryTranscriptionSource, audioDurationSeconds: Double?)
     case transcriptionCompleted(
         source: TelemetryTranscriptionSource,
@@ -546,6 +550,8 @@ extension TelemetryEventSpec {
         case .dictationEmpty: return .dictationEmpty
         case .dictationFailed: return .dictationFailed
         case .dictationOperation: return .dictationOperation
+        case .dictationFirstLoadCaptionShown: return .dictationFirstLoadCaptionShown
+        case .dictationFirstLoadCaptionDuration: return .dictationFirstLoadCaptionDuration
         case .transcriptionStarted: return .transcriptionStarted
         case .transcriptionCompleted: return .transcriptionCompleted
         case .transcriptionCancelled: return .transcriptionCancelled
@@ -712,6 +718,13 @@ extension TelemetryEventSpec {
                 ("error_type", errorType),
                 ("cancel_reason", cancelReason?.rawValue)
             ), device)
+        case .dictationFirstLoadCaptionShown(let firstInstall):
+            return ["firstInstall": Self.boolString(firstInstall)]
+        case .dictationFirstLoadCaptionDuration(let durationMs, let outcome):
+            return [
+                "durationMs": "\(durationMs)",
+                "outcome": outcome,
+            ]
         case .transcriptionStarted(let source, let audioDurationSeconds):
             return Self.compactProps(
                 ("source", source.rawValue),
@@ -1220,6 +1233,8 @@ public enum TelemetryImplementedContract {
         .dictationEmpty: [],
         .dictationFailed: ["error_type"],
         .dictationOperation: ["operation_id", "outcome"],
+        .dictationFirstLoadCaptionShown: ["firstInstall"],
+        .dictationFirstLoadCaptionDuration: ["durationMs", "outcome"],
         .transcriptionStarted: ["source"],
         .transcriptionCompleted: ["source", "word_count", "diarization_requested", "diarization_applied"],
         .transcriptionCancelled: ["source", "stage"],

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorLoadCaptionTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorLoadCaptionTests.swift
@@ -122,6 +122,22 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
         XCTAssertTrue(harness.telemetry.snapshot().containsCaptionDuration(outcome: "failure"))
     }
 
+    func testNoSpeechDismissesCaptionWithSnakeCaseOutcome() async throws {
+        let harness = try makeHarness(
+            isReady: false,
+            transcribeDelayMs: 140,
+            transcribeError: DictationServiceError.emptyTranscript
+        )
+
+        try await harness.startAndStop()
+        let shown = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == .preparing }
+        XCTAssertTrue(shown)
+        let cleared = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == nil }
+        XCTAssertTrue(cleared)
+
+        XCTAssertTrue(harness.telemetry.snapshot().containsCaptionDuration(outcome: "no_speech"))
+    }
+
     func testCancelDuringVisibleCaptionClearsCaption() async throws {
         let harness = try makeHarness(isReady: false, transcribeDelayMs: 2_000)
 

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorLoadCaptionTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorLoadCaptionTests.swift
@@ -1,0 +1,402 @@
+import XCTest
+@testable import MacParakeet
+@testable import MacParakeetCore
+@testable import MacParakeetViewModels
+
+@MainActor
+final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
+    private let timing = DictationProcessingLoadCaptionTiming(
+        graceMs: 20,
+        escalationMs: 50,
+        failureDisplayMs: 40
+    )
+
+    override func tearDown() {
+        Telemetry.configure(NoOpTelemetryService())
+        super.tearDown()
+    }
+
+    func testModelReadyAtProcessingEntryNeverShowsCaption() async throws {
+        let harness = try makeHarness(isReady: true, transcribeDelayMs: 90)
+
+        try await harness.startAndStop()
+        try await Task.sleep(for: .milliseconds(60))
+
+        XCTAssertNil(harness.coordinator.processingLoadCaptionForTesting)
+        XCTAssertFalse(harness.telemetry.snapshot().containsCaptionShown)
+    }
+
+    func testProcessingExitBeforeGraceSuppressesCaption() async throws {
+        let harness = try makeHarness(
+            isReady: false,
+            transcribeDelayMs: 5,
+            timing: DictationProcessingLoadCaptionTiming(
+                graceMs: 700,
+                escalationMs: 1000,
+                failureDisplayMs: 40
+            )
+        )
+
+        try await harness.startAndStop()
+        try await Task.sleep(for: .milliseconds(620))
+
+        XCTAssertNil(harness.coordinator.processingLoadCaptionForTesting)
+        XCTAssertFalse(harness.telemetry.snapshot().containsCaptionShown)
+    }
+
+    func testFirstInstallShowsPreparingThenClearsOnSuccess() async throws {
+        let harness = try makeHarness(isReady: false, transcribeDelayMs: 90, hasCompletedFirstDictation: false)
+
+        try await harness.startAndStop()
+        let shown = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == .preparing }
+        XCTAssertTrue(shown)
+        let cleared = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == nil }
+        XCTAssertTrue(cleared)
+
+        let events = harness.telemetry.snapshot()
+        XCTAssertTrue(events.containsCaptionShown(firstInstall: true))
+        XCTAssertTrue(events.containsCaptionDuration(outcome: "success"))
+    }
+
+    func testFirstInstallEscalatesToSubcopyAfterDelay() async throws {
+        let harness = try makeHarness(isReady: false, transcribeDelayMs: 140, hasCompletedFirstDictation: false)
+
+        try await harness.startAndStop()
+
+        let escalated = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == .preparingExtended }
+        XCTAssertTrue(escalated)
+    }
+
+    func testSubsequentColdLaunchDoesNotEscalate() async throws {
+        let harness = try makeHarness(isReady: false, transcribeDelayMs: 140, hasCompletedFirstDictation: true)
+
+        try await harness.startAndStop()
+        let shown = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == .preparing }
+        XCTAssertTrue(shown)
+        try await Task.sleep(for: .milliseconds(70))
+
+        XCTAssertEqual(harness.coordinator.processingLoadCaptionForTesting, .preparing)
+        XCTAssertTrue(harness.telemetry.snapshot().containsCaptionShown(firstInstall: false))
+    }
+
+    func testFailureShowsFailureCaptionBeforeErrorCard() async throws {
+        let harness = try makeHarness(
+            isReady: false,
+            transcribeDelayMs: 60,
+            transcribeError: STTError.engineStartFailed("load failed")
+        )
+
+        try await harness.startAndStop()
+        let failedCaptionShown = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == .failed }
+        XCTAssertTrue(failedCaptionShown)
+        XCTAssertTrue(harness.coordinator.overlayStateForTesting?.isProcessingForTest == true)
+
+        let errorShown = await waitUntil { harness.coordinator.overlayStateForTesting?.isErrorForTest == true }
+        XCTAssertTrue(errorShown)
+        XCTAssertNil(harness.coordinator.processingLoadCaptionForTesting)
+        XCTAssertTrue(harness.telemetry.snapshot().containsCaptionDuration(outcome: "failure"))
+    }
+
+    func testCancelDuringVisibleCaptionClearsCaption() async throws {
+        let harness = try makeHarness(isReady: false, transcribeDelayMs: 200)
+
+        try await harness.startAndStop()
+        let shown = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == .preparing }
+        XCTAssertTrue(shown)
+
+        harness.coordinator.cancelDictation(reason: .escape)
+        let cleared = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == nil }
+        XCTAssertTrue(cleared)
+        XCTAssertTrue(harness.telemetry.snapshot().containsCaptionDuration(outcome: "cancelled"))
+    }
+
+    func testSecondDictationWarmRuntimeDoesNotShowCaption() async throws {
+        let harness = try makeHarness(isReady: false, transcribeDelayMs: 80)
+
+        try await harness.startAndStop()
+        let firstShown = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == .preparing }
+        XCTAssertTrue(firstShown)
+        let firstCleared = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == nil }
+        XCTAssertTrue(firstCleared)
+        let returnedToIdle = await waitUntil(timeoutMs: 2500) { harness.coordinator.overlayStateForTesting == nil }
+        XCTAssertTrue(returnedToIdle)
+
+        await harness.stt.setReady(true)
+        await harness.stt.setTranscribeDelay(milliseconds: 80)
+        try await harness.startAndStop()
+        try await Task.sleep(for: .milliseconds(60))
+
+        let shownCount = harness.telemetry.snapshot().captionShownCount
+        XCTAssertEqual(shownCount, 1)
+        XCTAssertNil(harness.coordinator.processingLoadCaptionForTesting)
+    }
+
+    private func makeHarness(
+        isReady: Bool,
+        transcribeDelayMs: UInt64,
+        transcribeError: Error? = nil,
+        hasCompletedFirstDictation: Bool = false,
+        timing: DictationProcessingLoadCaptionTiming? = nil
+    ) throws -> Harness {
+        let telemetry = LoadCaptionTelemetrySpy()
+        Telemetry.configure(telemetry)
+
+        let dbManager = try DatabaseManager()
+        let audio = MockAudioProcessor()
+        let stt = DelayedSTTClient(
+            ready: isReady,
+            transcribeDelayMs: transcribeDelayMs,
+            transcribeError: transcribeError
+        )
+        let repo = DictationRepository(dbQueue: dbManager.dbQueue)
+        let preferences = UserDefaultsAppRuntimePreferences(
+            defaults: UserDefaults(suiteName: "load-caption-\(UUID().uuidString)")!
+        )
+        if hasCompletedFirstDictation {
+            preferences.markFirstDictationCompleted()
+        }
+
+        let service = DictationService(
+            audioProcessor: audio,
+            sttTranscriber: stt,
+            dictationRepo: repo,
+            markFirstDictationCompleted: {
+                preferences.markFirstDictationCompleted()
+            }
+        )
+
+        let settingsDefaults = UserDefaults(suiteName: "load-caption-settings-\(UUID().uuidString)")!
+        settingsDefaults.set(false, forKey: UserDefaultsAppRuntimePreferences.showIdlePillKey)
+        let settings = SettingsViewModel(defaults: settingsDefaults)
+
+        let entitlements = EntitlementsService(
+            config: LicensingConfig(checkoutURL: nil, expectedVariantID: nil),
+            store: InMemoryKeyValueStore(),
+            api: StubLicenseAPI()
+        )
+
+        let coordinator = DictationFlowCoordinator(
+            dictationService: service,
+            clipboardService: MockClipboardService(),
+            entitlementsService: entitlements,
+            dictationRepo: repo,
+            settingsViewModel: settings,
+            sttRuntime: stt,
+            runtimePreferences: preferences,
+            captionTiming: timing ?? self.timing,
+            overlayControllerFactory: { SpyDictationOverlayController(viewModel: $0) },
+            onMenuBarIconUpdate: { _ in },
+            onHistoryReload: {},
+            onPresentEntitlementsAlert: { _ in }
+        )
+
+        return Harness(coordinator: coordinator, stt: stt, telemetry: telemetry)
+    }
+
+    private func waitUntil(
+        timeoutMs: UInt64 = 1200,
+        condition: @escaping @MainActor () -> Bool
+    ) async -> Bool {
+        let deadline = Date().addingTimeInterval(Double(timeoutMs) / 1000)
+        while Date() < deadline {
+            if condition() { return true }
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return condition()
+    }
+
+    private struct Harness {
+        let coordinator: DictationFlowCoordinator
+        let stt: DelayedSTTClient
+        let telemetry: LoadCaptionTelemetrySpy
+
+        @MainActor
+        func startAndStop() async throws {
+            coordinator.startDictation(mode: .persistent, trigger: .hotkey)
+            let started = await waitUntil { coordinator.overlayStateForTesting?.isRecordingForTest == true }
+            XCTAssertTrue(started)
+            coordinator.stopDictation()
+        }
+
+        @MainActor
+        private func waitUntil(
+            timeoutMs: UInt64 = 1200,
+            condition: @escaping @MainActor () -> Bool
+        ) async -> Bool {
+            let deadline = Date().addingTimeInterval(Double(timeoutMs) / 1000)
+            while Date() < deadline {
+                if condition() { return true }
+                try? await Task.sleep(for: .milliseconds(5))
+            }
+            return condition()
+        }
+    }
+}
+
+@MainActor
+private final class SpyDictationOverlayController: DictationOverlayControlling {
+    let viewModel: DictationOverlayViewModel
+    private(set) var isShown = false
+
+    init(viewModel: DictationOverlayViewModel) {
+        self.viewModel = viewModel
+    }
+
+    func show() {
+        isShown = true
+    }
+
+    func hide() {
+        isShown = false
+    }
+
+    func resignKeyWindow() {}
+}
+
+private actor DelayedSTTClient: STTClientProtocol, DictationSTTReadinessChecking {
+    private var ready: Bool
+    private var transcribeDelayMs: UInt64
+    private var transcribeError: Error?
+
+    init(ready: Bool, transcribeDelayMs: UInt64, transcribeError: Error?) {
+        self.ready = ready
+        self.transcribeDelayMs = transcribeDelayMs
+        self.transcribeError = transcribeError
+    }
+
+    func setReady(_ ready: Bool) {
+        self.ready = ready
+    }
+
+    func setTranscribeDelay(milliseconds: UInt64) {
+        transcribeDelayMs = milliseconds
+    }
+
+    func transcribe(
+        audioPath: String,
+        job: STTJobKind,
+        onProgress: (@Sendable (Int, Int) -> Void)?
+    ) async throws -> STTResult {
+        if transcribeDelayMs > 0 {
+            try await Task.sleep(for: .milliseconds(Int(transcribeDelayMs)))
+        }
+        if let transcribeError {
+            throw transcribeError
+        }
+        return STTResult(
+            text: "Mock transcription",
+            words: [
+                TimestampedWord(word: "Mock", startMs: 0, endMs: 300, confidence: 0.99),
+                TimestampedWord(word: "transcription", startMs: 320, endMs: 1000, confidence: 0.99),
+            ]
+        )
+    }
+
+    func warmUp(onProgress: (@Sendable (String) -> Void)?) async throws {
+        ready = true
+    }
+
+    func backgroundWarmUp() async {
+        ready = true
+    }
+
+    func observeWarmUpProgress() async -> (id: UUID, stream: AsyncStream<STTWarmUpState>) {
+        let id = UUID()
+        let stream = AsyncStream<STTWarmUpState> { continuation in
+            continuation.yield(ready ? .ready : .idle)
+            continuation.finish()
+        }
+        return (id, stream)
+    }
+
+    func removeWarmUpObserver(id: UUID) async {}
+
+    func isReady() async -> Bool {
+        ready
+    }
+
+    func clearModelCache() async {
+        ready = false
+    }
+
+    func shutdown() async {}
+}
+
+private final class LoadCaptionTelemetrySpy: TelemetryServiceProtocol, @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [TelemetryEventSpec] = []
+
+    func send(_ event: TelemetryEventSpec) {
+        lock.lock()
+        events.append(event)
+        lock.unlock()
+    }
+
+    func sendAndFlush(_ event: TelemetryEventSpec) async -> Bool {
+        send(event)
+        return true
+    }
+
+    func flush() async {}
+    func clearQueue() {
+        lock.lock()
+        events.removeAll()
+        lock.unlock()
+    }
+    func flushForTermination() {}
+
+    func snapshot() -> [TelemetryEventSpec] {
+        lock.lock()
+        defer { lock.unlock() }
+        return events
+    }
+}
+
+private extension Array where Element == TelemetryEventSpec {
+    var containsCaptionShown: Bool {
+        contains { event in
+            if case .dictationFirstLoadCaptionShown = event { return true }
+            return false
+        }
+    }
+
+    var captionShownCount: Int {
+        filter { event in
+            if case .dictationFirstLoadCaptionShown = event { return true }
+            return false
+        }.count
+    }
+
+    func containsCaptionShown(firstInstall: Bool) -> Bool {
+        contains { event in
+            guard case .dictationFirstLoadCaptionShown(let value) = event else { return false }
+            return value == firstInstall
+        }
+    }
+
+    func containsCaptionDuration(outcome: String) -> Bool {
+        contains { event in
+            guard case .dictationFirstLoadCaptionDuration(let durationMs, let value) = event else {
+                return false
+            }
+            return durationMs >= 0 && value == outcome
+        }
+    }
+}
+
+private extension DictationOverlayViewModel.OverlayState {
+    var isRecordingForTest: Bool {
+        if case .recording = self { return true }
+        return false
+    }
+
+    var isProcessingForTest: Bool {
+        if case .processing = self { return true }
+        return false
+    }
+
+    var isErrorForTest: Bool {
+        if case .error = self { return true }
+        return false
+    }
+}

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorLoadCaptionTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorLoadCaptionTests.swift
@@ -123,14 +123,18 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
     }
 
     func testCancelDuringVisibleCaptionClearsCaption() async throws {
-        let harness = try makeHarness(isReady: false, transcribeDelayMs: 200)
+        let harness = try makeHarness(isReady: false, transcribeDelayMs: 2_000)
 
         try await harness.startAndStop()
-        let shown = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == .preparing }
+        let shown = await waitUntil(timeoutMs: 3_000) {
+            harness.coordinator.processingLoadCaptionForTesting == .preparing
+        }
         XCTAssertTrue(shown)
 
         harness.coordinator.cancelDictation(reason: .escape)
-        let cleared = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == nil }
+        let cleared = await waitUntil(timeoutMs: 3_000) {
+            harness.coordinator.processingLoadCaptionForTesting == nil
+        }
         XCTAssertTrue(cleared)
         XCTAssertTrue(harness.telemetry.snapshot().containsCaptionDuration(outcome: "cancelled"))
     }

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorLoadCaptionTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorLoadCaptionTests.swift
@@ -44,6 +44,31 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
         XCTAssertFalse(harness.telemetry.snapshot().containsCaptionShown)
     }
 
+    func testRuntimeReadyBeforeGraceSuppressesCaption() async throws {
+        let harness = try makeHarness(
+            isReady: false,
+            transcribeDelayMs: 140,
+            timing: DictationProcessingLoadCaptionTiming(
+                graceMs: 80,
+                escalationMs: 160,
+                failureDisplayMs: 40
+            )
+        )
+
+        harness.coordinator.startDictation(mode: .persistent, trigger: .hotkey)
+        let started = await waitUntil { harness.coordinator.overlayStateForTesting?.isRecordingForTest == true }
+        XCTAssertTrue(started)
+        harness.coordinator.stopDictation()
+        let processing = await waitUntil { harness.coordinator.overlayStateForTesting?.isProcessingForTest == true }
+        XCTAssertTrue(processing)
+
+        await harness.stt.setReady(true)
+        try await Task.sleep(for: .milliseconds(120))
+
+        XCTAssertNil(harness.coordinator.processingLoadCaptionForTesting)
+        XCTAssertFalse(harness.telemetry.snapshot().containsCaptionShown)
+    }
+
     func testFirstInstallShowsPreparingThenClearsOnSuccess() async throws {
         let harness = try makeHarness(isReady: false, transcribeDelayMs: 90, hasCompletedFirstDictation: false)
 

--- a/Tests/MacParakeetTests/Services/Dictation/DictationServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/Dictation/DictationServiceTests.swift
@@ -254,6 +254,56 @@ final class DictationServiceTests: XCTestCase {
         XCTAssertEqual(operation["engine_variant"], SpeechEnginePreference.defaultWhisperModelVariant)
     }
 
+    func testFirstDictationFlagFlipsAfterSuccessfulSave() async throws {
+        let defaults = UserDefaults(suiteName: "dictation-first-success-\(UUID().uuidString)")!
+        let preferences = UserDefaultsAppRuntimePreferences(defaults: defaults)
+        XCTAssertFalse(preferences.hasCompletedFirstDictation)
+
+        service = DictationService(
+            audioProcessor: mockAudio,
+            sttTranscriber: mockSTT,
+            dictationRepo: dictationRepo,
+            markFirstDictationCompleted: {
+                preferences.markFirstDictationCompleted()
+            }
+        )
+        await mockSTT.configureSequence(results: [
+            STTResult(text: "first saved dictation"),
+            STTResult(text: "second saved dictation"),
+        ])
+
+        try await service.startRecording()
+        _ = try await service.stopRecording()
+        XCTAssertTrue(preferences.hasCompletedFirstDictation)
+
+        try await service.startRecording()
+        _ = try await service.stopRecording()
+        XCTAssertTrue(preferences.hasCompletedFirstDictation)
+    }
+
+    func testFirstDictationFlagDoesNotFlipOnFailedDictation() async throws {
+        let defaults = UserDefaults(suiteName: "dictation-first-failure-\(UUID().uuidString)")!
+        let preferences = UserDefaultsAppRuntimePreferences(defaults: defaults)
+
+        service = DictationService(
+            audioProcessor: mockAudio,
+            sttTranscriber: mockSTT,
+            dictationRepo: dictationRepo,
+            markFirstDictationCompleted: {
+                preferences.markFirstDictationCompleted()
+            }
+        )
+        await mockSTT.configure(error: STTError.transcriptionFailed("model load failed"))
+
+        try await service.startRecording()
+        do {
+            _ = try await service.stopRecording()
+            XCTFail("Expected failed dictation to throw")
+        } catch {
+            XCTAssertFalse(preferences.hasCompletedFirstDictation)
+        }
+    }
+
     func testStopRecordingAppliesAIFormatterAsFinalStep() async throws {
         await mockSTT.configure(result: STTResult(text: "hello world"))
         let mockLLMService = MockLLMService()

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -930,6 +930,8 @@ final class TelemetryServiceTests: XCTestCase {
                 wordCount: 84,
                 errorType: nil
             ),
+            .dictationFirstLoadCaptionShown(firstInstall: true),
+            .dictationFirstLoadCaptionDuration(durationMs: 8200, outcome: "success"),
             .transcriptionStarted(source: .file, audioDurationSeconds: 30.0),
             .transcriptionCompleted(
                 source: .dragDrop,

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -774,6 +774,17 @@ final class TelemetryServiceTests: XCTestCase {
         XCTAssertNil(props["requested_device_uid"])
     }
 
+    func testFirstLoadCaptionTelemetryUsesSnakeCaseProps() {
+        let shown = TelemetryEventSpec.dictationFirstLoadCaptionShown(firstInstall: true)
+        XCTAssertEqual(shown.props?["first_install"], "true")
+        XCTAssertNil(shown.props?["firstInstall"])
+
+        let duration = TelemetryEventSpec.dictationFirstLoadCaptionDuration(durationMs: 8200, outcome: "success")
+        XCTAssertEqual(duration.props?["duration_ms"], "8200")
+        XCTAssertEqual(duration.props?["outcome"], "success")
+        XCTAssertNil(duration.props?["durationMs"])
+    }
+
     func testImplementedContractCoversEveryTypedEventName() {
         XCTAssertEqual(
             Set(TelemetryEventName.allCases),

--- a/plans/active/2026-05-dictation-first-load-caption.md
+++ b/plans/active/2026-05-dictation-first-load-caption.md
@@ -26,6 +26,7 @@ Programmatic verification performed:
 - Focused first-dictation persistence tests: `swift test --filter DictationServiceTests` PASS, 13 tests.
 - Focused telemetry serialization/contract tests: `swift test --filter TelemetryServiceTests` PASS, 41 tests.
 - Swift 6 language-mode build without WhisperKit: `MACPARAKEET_SKIP_WHISPERKIT=1 swift build --build-path .build-swift6-no-whisper -Xswiftc -swift-version -Xswiftc 6` PASS.
+- CI-style parallel suite: `swift test --parallel` PASS, 2424 XCTest tests plus 16 Swift Testing tests.
 - Final full suite after cleanup: `swift test` PASS, 2424 XCTest tests, 10 skipped, plus 16 Swift Testing tests.
 
 Instrumented app verification performed with `scripts/dev/run_app.sh`:

--- a/plans/active/2026-05-dictation-first-load-caption.md
+++ b/plans/active/2026-05-dictation-first-load-caption.md
@@ -8,6 +8,38 @@
 >
 > Related ADRs: ADR-001 (Parakeet STT), ADR-005 (onboarding), ADR-016 (centralized STT runtime). No new ADR — implementation polish, not an architectural shift.
 
+## Implementation status
+
+Implemented on `feat/dictation-first-load-caption`; keep this plan active until the user verifies a real build and moves it to `plans/completed/`.
+
+Decisions made during implementation:
+
+- Pre-warm wiring lives in `AppDelegate`, scheduled after environment setup and again from `OnboardingCoordinator`'s completion callback. It is gated by `OnboardingViewModel.onboardingCompletedKey`, then calls the existing idempotent `STTRuntime.backgroundWarmUp()`.
+- Caption spacing is an effective 6pt above the pill (4pt stack spacing plus 2pt caption bottom padding). The pill remains the bottom-anchored element.
+- Animation timing stays at 220ms ease-in-out, with an opacity-only transition when Reduce Motion is enabled.
+- Subcopy escalation stays at 4s, scoped to `hasCompletedFirstDictation == false`.
+
+Programmatic verification performed:
+
+- Baseline `swift test` before code changes: PASS, 2412 XCTest tests, 10 skipped, 0 failures.
+- Focused caption coordinator tests: `swift test --filter DictationFlowCoordinatorLoadCaptionTests` PASS, 8 tests.
+- Focused first-dictation persistence tests: `swift test --filter DictationServiceTests` PASS, 13 tests.
+- Focused telemetry serialization/contract tests: `swift test --filter TelemetryServiceTests` PASS, 40 tests.
+- Final full suite after cleanup: `swift test` PASS, 2422 XCTest tests, 10 skipped, plus 16 Swift Testing tests.
+
+Instrumented app verification performed with `scripts/dev/run_app.sh`:
+
+- Normal launch with prior successful dictation: deferred pre-warm won; a short push-to-talk dictation entered processing without showing the first-load caption.
+- Forced slow STT load: first-install state showed `Preparing speech engine…`, then the first-time setup subcopy; subsequent cold-launch state showed only the main copy.
+- Forced STT initialization failure: caption switched to the red `Couldn't load speech engine.` variant before the existing overlay error card appeared.
+- Reduce Motion enabled: caption used the code path for opacity-only transition, with no slide offset.
+- Screenshot-based geometry checks confirmed the pill's bottom-of-screen position did not shift when the caption appeared or disappeared.
+
+Remaining human QA focus:
+
+- Subjective animation feel on a physical display, especially the 6pt spacing and 220ms curve.
+- Deployment order for the sibling website telemetry allowlist before any build containing these events ships.
+
 ## TL;DR
 
 On the very first dictation after each cold app launch, the Parakeet model has not yet been loaded into memory, so the `.processing` spinner spins silently for ~5–15s (longer on a truly-first install) before the first transcript appears. Every subsequent dictation drops to ~500ms. This contradicts the "fast and snappy" brand promise and is the dominant first-impression friction.

--- a/plans/active/2026-05-dictation-first-load-caption.md
+++ b/plans/active/2026-05-dictation-first-load-caption.md
@@ -22,12 +22,13 @@ Decisions made during implementation:
 Programmatic verification performed:
 
 - Baseline `swift test` before code changes: PASS, 2412 XCTest tests, 10 skipped, 0 failures.
-- Focused caption coordinator tests: `swift test --filter DictationFlowCoordinatorLoadCaptionTests` PASS, 9 tests.
+- Focused caption coordinator tests: `swift test --filter DictationFlowCoordinatorLoadCaptionTests` PASS, 10 tests.
+- Focused caption coordinator tests under parallel scheduling: `swift test --parallel --filter DictationFlowCoordinatorLoadCaptionTests` PASS, 10 tests.
 - Focused first-dictation persistence tests: `swift test --filter DictationServiceTests` PASS, 13 tests.
 - Focused telemetry serialization/contract tests: `swift test --filter TelemetryServiceTests` PASS, 41 tests.
 - Swift 6 language-mode build without WhisperKit: `MACPARAKEET_SKIP_WHISPERKIT=1 swift build --build-path .build-swift6-no-whisper -Xswiftc -swift-version -Xswiftc 6` PASS.
 - CI-style parallel suite: `swift test --parallel` PASS, 2424 XCTest tests plus 16 Swift Testing tests.
-- Final full suite after cleanup: `swift test` PASS, 2424 XCTest tests, 10 skipped, plus 16 Swift Testing tests.
+- Final full suite after cleanup: `swift test` PASS, 2425 XCTest tests, 10 skipped, plus 16 Swift Testing tests.
 
 Instrumented app verification performed with `scripts/dev/run_app.sh`:
 
@@ -348,7 +349,7 @@ public func markFirstDictationCompleted() {
 Add to `Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift`:
 
 - **`dictationFirstLoadCaptionShown`** — payload: `first_install: Bool`. Fired when the caption fades in.
-- **`dictationFirstLoadCaptionDuration`** — payload: `duration_ms: Int`, `outcome: "success" | "noSpeech" | "failure" | "cancelled"`. Fired when caption fades out.
+- **`dictationFirstLoadCaptionDuration`** — payload: `duration_ms: Int`, `outcome: "success" | "no_speech" | "failure" | "cancelled"`. Fired when caption fades out.
 
 **Two-repo change required:** Add both event names to `ALLOWED_EVENTS` in `macparakeet-website/functions/api/telemetry.ts` **BEFORE** the app build ships. Per `memory/feedback_telemetry_allowlist.md`, the Worker rejects the entire batch if any event is unknown, silently dropping valid co-batched events. Verify with curl after deploy.
 
@@ -421,7 +422,7 @@ Once the allowlist update lands and a build ships, query D1 (per `reference_clou
 SELECT
     COUNT(*) AS caption_shown_count,
     AVG(json_extract(payload, '$.duration_ms')) AS avg_duration_ms,
-    SUM(CASE WHEN json_extract(payload, '$.first_install') = 1 THEN 1 ELSE 0 END) AS first_install_shown,
+    SUM(CASE WHEN json_extract(payload, '$.first_install') = 'true' THEN 1 ELSE 0 END) AS first_install_shown,
     SUM(CASE WHEN json_extract(payload, '$.outcome') = 'failure' THEN 1 ELSE 0 END) AS failure_count
 FROM events
 WHERE name IN ('dictation_first_load_caption_shown', 'dictation_first_load_caption_duration')

--- a/plans/active/2026-05-dictation-first-load-caption.md
+++ b/plans/active/2026-05-dictation-first-load-caption.md
@@ -22,10 +22,11 @@ Decisions made during implementation:
 Programmatic verification performed:
 
 - Baseline `swift test` before code changes: PASS, 2412 XCTest tests, 10 skipped, 0 failures.
-- Focused caption coordinator tests: `swift test --filter DictationFlowCoordinatorLoadCaptionTests` PASS, 8 tests.
+- Focused caption coordinator tests: `swift test --filter DictationFlowCoordinatorLoadCaptionTests` PASS, 9 tests.
 - Focused first-dictation persistence tests: `swift test --filter DictationServiceTests` PASS, 13 tests.
-- Focused telemetry serialization/contract tests: `swift test --filter TelemetryServiceTests` PASS, 40 tests.
-- Final full suite after cleanup: `swift test` PASS, 2422 XCTest tests, 10 skipped, plus 16 Swift Testing tests.
+- Focused telemetry serialization/contract tests: `swift test --filter TelemetryServiceTests` PASS, 41 tests.
+- Swift 6 language-mode build without WhisperKit: `MACPARAKEET_SKIP_WHISPERKIT=1 swift build --build-path .build-swift6-no-whisper -Xswiftc -swift-version -Xswiftc 6` PASS.
+- Final full suite after cleanup: `swift test` PASS, 2424 XCTest tests, 10 skipped, plus 16 Swift Testing tests.
 
 Instrumented app verification performed with `scripts/dev/run_app.sh`:
 
@@ -109,9 +110,9 @@ Keeping them in separate visual regions preserves the distinction. The floating 
 
 Without grace, every cold start where the user dictated for 2s would briefly flash the caption even when the pre-warm finished 50ms before processing entry. 600ms means the caption is reserved for "this is actually taking a while" — never a flash on the warm path. Tuned for human-perceptible "noticing a wait" threshold (~500–800ms range; 600ms is the midpoint).
 
-### Why a `wasModelReadyAtEntry` snapshot instead of polling?
+### Why a readiness snapshot plus grace-boundary recheck instead of polling?
 
-We snapshot once on `.processing` entry. If model wasn't ready then, show the caption for the full `.processing` duration. We don't poll `isReady()` during the load because:
+We snapshot once on `.processing` entry to decide whether to arm the grace timer. At the 600ms grace boundary, we perform one final readiness check so AC3 stays true: if pre-warm lost at entry but finished before the grace expired, the caption never flashes. After the caption appears, we do not poll `isReady()` during the load because:
 
 1. The caption should display for the *entire* model-load period, even if the load finishes 200ms before transcription completes. Hiding it mid-`.processing` would create a confusing flicker.
 2. Polling adds complexity (timer, cancellation, race with `.processing` exit) for no UX gain.
@@ -345,8 +346,8 @@ public func markFirstDictationCompleted() {
 
 Add to `Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift`:
 
-- **`dictationFirstLoadCaptionShown`** — payload: `firstInstall: Bool`. Fired when the caption fades in.
-- **`dictationFirstLoadCaptionDuration`** — payload: `durationMs: Int`, `outcome: "success" | "noSpeech" | "failure" | "cancelled"`. Fired when caption fades out.
+- **`dictationFirstLoadCaptionShown`** — payload: `first_install: Bool`. Fired when the caption fades in.
+- **`dictationFirstLoadCaptionDuration`** — payload: `duration_ms: Int`, `outcome: "success" | "noSpeech" | "failure" | "cancelled"`. Fired when caption fades out.
 
 **Two-repo change required:** Add both event names to `ALLOWED_EVENTS` in `macparakeet-website/functions/api/telemetry.ts` **BEFORE** the app build ships. Per `memory/feedback_telemetry_allowlist.md`, the Worker rejects the entire batch if any event is unknown, silently dropping valid co-batched events. Verify with curl after deploy.
 
@@ -380,7 +381,7 @@ VoiceOver: caption text announced on appear via `accessibilityLabel`. No live re
 - **AC10.** `accessibilityReduceMotion`: caption cross-fades only, no offset animation.
 - **AC11.** `hasCompletedFirstDictation` flips from `false` to `true` exactly once, on the first successful dictation; remains `true` thereafter. Cancelled / failed dictations do not flip the flag.
 - **AC12.** No regression in any existing dictation flow (cancellation, mode switches, paste, history, ready-pill auto-dismiss, command mode, formatting mode, no-speech outcome).
-- **AC13.** Telemetry events fire correctly: `caption_shown` once on appear, `caption_duration` once on dismiss with accurate `durationMs` and `outcome`.
+- **AC13.** Telemetry events fire correctly: `caption_shown` once on appear, `caption_duration` once on dismiss with accurate `duration_ms` and `outcome`.
 
 ## Test plan
 
@@ -418,8 +419,8 @@ Once the allowlist update lands and a build ships, query D1 (per `reference_clou
 ```sql
 SELECT
     COUNT(*) AS caption_shown_count,
-    AVG(json_extract(payload, '$.durationMs')) AS avg_duration_ms,
-    SUM(CASE WHEN json_extract(payload, '$.firstInstall') = 1 THEN 1 ELSE 0 END) AS first_install_shown,
+    AVG(json_extract(payload, '$.duration_ms')) AS avg_duration_ms,
+    SUM(CASE WHEN json_extract(payload, '$.first_install') = 1 THEN 1 ELSE 0 END) AS first_install_shown,
     SUM(CASE WHEN json_extract(payload, '$.outcome') = 'failure' THEN 1 ELSE 0 END) AS failure_count
 FROM events
 WHERE name IN ('dictation_first_load_caption_shown', 'dictation_first_load_caption_duration')

--- a/plans/active/2026-05-dictation-first-load-caption.md
+++ b/plans/active/2026-05-dictation-first-load-caption.md
@@ -1,0 +1,450 @@
+# Dictation First-Load Caption + Proactive Pre-warm
+
+> Status: **ACTIVE**
+>
+> Owner: Daniel Moon (@moona3k) · 2026-05-10
+>
+> Branch: `feat/dictation-first-load-caption`
+>
+> Related ADRs: ADR-001 (Parakeet STT), ADR-005 (onboarding), ADR-016 (centralized STT runtime). No new ADR — implementation polish, not an architectural shift.
+
+## TL;DR
+
+On the very first dictation after each cold app launch, the Parakeet model has not yet been loaded into memory, so the `.processing` spinner spins silently for ~5–15s (longer on a truly-first install) before the first transcript appears. Every subsequent dictation drops to ~500ms. This contradicts the "fast and snappy" brand promise and is the dominant first-impression friction.
+
+This plan adds two changes:
+
+1. **Proactive pre-warm at app launch.** A deferred `backgroundWarmUp()` runs ~1.5s after `applicationDidFinishLaunching`, so the model is usually ready by the time the user presses Fn.
+2. **A floating caption above the dictation pill during `.processing`**, shown only when the engine wasn't ready at processing entry, with a 600ms grace to suppress flashes on the warm path. Copy escalates to a "first-time setup" subcopy after 4s on the truly-first-install case.
+
+No audio-capture, state-machine, or cancellation logic is touched. The state machine stays pure; all readiness wiring lives in the coordinator.
+
+## Context
+
+The lazy-init path: `STTRuntime.transcribe()` → `ensureInitialized()` (`Sources/MacParakeetCore/STT/STTRuntime.swift:459`) loads the CoreML model into ANE the first time it's needed. There is no progress reporting on this path — the spinner just spins.
+
+The existing dictation overlay (`Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift:540`) renders `SpinnerRingView` (two counter-rotating triangles, `Sources/MacParakeet/Views/Components/SacredGeometry.swift:24`) during `.processing`. There is an *inline* message slot beside the spinner (`HStack { Spinner; Text(message) }` at line 553), used today for the `"Still transcribing..."` hint when the user re-presses Fn during processing (`DictationOverlayController.swift:245`). This slot is **semantically reserved for user-triggered transient hints** and should not be repurposed for engine state.
+
+Mic capture is already decoupled from model load: `DictationService.startRecording()` (`Sources/MacParakeetCore/Services/Dictation/DictationService.swift:182`) calls `audioProcessor.startCapture()` immediately on Fn press, regardless of model state. **No ring-buffer or capture-and-queue is needed** — the existing file-based flow already gives us "capture-and-queue" for free.
+
+Pre-warm infrastructure already exists: `STTRuntime.backgroundWarmUp()` (`STTRuntime.swift:238`) is idempotent — short-circuits if state is already `.ready` (line 239), so it's safe to call concurrently with onboarding or meeting-recording warmup. Today the only caller is `MeetingRecordingFlowCoordinator.swift:807` when a meeting starts. We extend it to also fire on app launch.
+
+## Goals
+
+- **G1.** Most users on a normal cold launch never see a loading message — the model is pre-warmed in the background before they press Fn.
+- **G2.** Users who beat the pre-warm (or who run on truly-first install) get a clear, premium "model loading" affordance during `.processing` with no flashing on the warm path.
+- **G3.** No regression to existing dictation latency, cancellation, paste, history, or audio capture behavior.
+- **G4.** Premium polish: 600ms grace before fade-in; copy escalates with elapsed time; failure state has its own caption; respects `accessibilityReduceMotion`; pill geometry stays constant.
+
+## Non-goals
+
+- Changing the STT engine, model, audio capture, or processing pipeline.
+- Building a separate model-status UI in Settings.
+- Adding tap-to-retry to the failure caption (the overlay's existing `.error` state already provides retry pathways).
+- Touching meeting recording's pre-warm path (already done at `MeetingRecordingFlowCoordinator.swift:807`).
+- Pre-warm progress percentage in the caption.
+- Modifying `STTRuntime` to emit progress for the lazy `ensureInitialized()` path.
+
+## Locked design
+
+| Aspect | Decision |
+|---|---|
+| Pre-warm trigger | Unconditional after onboarding completion; deferred 1.5s post `applicationDidFinishLaunching` |
+| Pre-warm mechanism | `await env.sttRuntime.backgroundWarmUp()` (existing API) |
+| Caption trigger | Entering `.processing` with `await sttRuntime.isReady() == false` |
+| Caption grace | 600ms — caption only fades in if `.processing` is still active 600ms after entry |
+| Caption visual | Floating capsule positioned **above** the pill in the same NSPanel; pill geometry unchanged |
+| Caption styling | `DesignSystem.Colors.pillBackground.opacity(0.55)` bg, `DesignSystem.Colors.pillBorder.opacity(0.6)` stroke, 11pt rounded `.medium`, white at 0.85 opacity |
+| Caption copy (first-ever install) | After 600ms: `Preparing speech engine…`. After 4s: subcopy `First-time setup — this happens once` |
+| Caption copy (subsequent cold launches) | `Preparing speech engine…` only (no subcopy — load is faster on warm disk cache, less explaining needed) |
+| Failure caption | `Couldn't load speech engine.` — replaces caption, red foreground tint, dismisses with overlay's `.error` state |
+| Spinner behavior | Unchanged (two counter-rotating triangles, normal speed, no opacity changes) |
+| Audio buffering | None added — `audioProcessor.startCapture()` is already independent of model load |
+| Install-age flag | `hasCompletedFirstDictation` Bool on `UserDefaults` (via `UserDefaultsAppRuntimePreferences`) — set on first successful dictation completion (idempotent) |
+| Caption lifetime | Fades in 600ms after `.processing` entry (if model not ready at entry), fades out on `.processing` exit (any outcome) |
+| Caption observability | Captured via two new telemetry events (see Telemetry section) |
+
+### Why floating-above and not inline beside the spinner?
+
+The existing inline-message slot is used for `"Still transcribing…"` — a *user-triggered* transient hint when the user re-presses Fn during processing. Reusing it for engine state would conflate two semantics:
+
+- **Engine state** ("Preparing speech engine…") is passive, informational, persistent across the load.
+- **Transcription hint** ("Still transcribing…") is user-triggered, transient, auto-clears after 1.1s.
+
+Keeping them in separate visual regions preserves the distinction. The floating caption above the pill also keeps the pill geometry constant, which is the premium feel target. AC9 below explicitly requires both to coexist if both fire.
+
+### Why 600ms grace?
+
+Without grace, every cold start where the user dictated for 2s would briefly flash the caption even when the pre-warm finished 50ms before processing entry. 600ms means the caption is reserved for "this is actually taking a while" — never a flash on the warm path. Tuned for human-perceptible "noticing a wait" threshold (~500–800ms range; 600ms is the midpoint).
+
+### Why a `wasModelReadyAtEntry` snapshot instead of polling?
+
+We snapshot once on `.processing` entry. If model wasn't ready then, show the caption for the full `.processing` duration. We don't poll `isReady()` during the load because:
+
+1. The caption should display for the *entire* model-load period, even if the load finishes 200ms before transcription completes. Hiding it mid-`.processing` would create a confusing flicker.
+2. Polling adds complexity (timer, cancellation, race with `.processing` exit) for no UX gain.
+3. `.processing` exit is the natural fade-out trigger and is already wired through the state machine.
+
+Trade-off: if model loads in 1s and transcription takes 30s (long dictation, warm-cache load), the caption is shown for 30s when only the first 1s was actually "loading." Mitigation: this case is rare (model is almost always loaded before user dictates long, given pre-warm). If telemetry shows this is happening, we can add an explicit model-loaded signal later.
+
+## Implementation surface
+
+### 1. Pre-warm at app launch
+
+**File:** `Sources/MacParakeet/AppDelegate.swift:225` (in `applicationDidFinishLaunching`)
+   or `Sources/MacParakeet/App/AppEnvironmentConfigurer.swift:77` (in `configure`).
+
+After environment setup, schedule a deferred `Task.detached`:
+
+```swift
+// Pseudocode — actual placement decided at implementation time
+private func schedulePreWarm(env: AppEnvironment) {
+    Task.detached(priority: .utility) {
+        try? await Task.sleep(for: .milliseconds(1500))
+        guard env.onboarding.hasCompleted else { return }
+        await env.sttRuntime.backgroundWarmUp()
+    }
+}
+```
+
+`backgroundWarmUp()` is idempotent and gated on `.ready` state (`STTRuntime.swift:239`), so this is safe to call concurrently with onboarding or meeting-recording warmup. The 1.5s deferral prevents competition with first-paint and main-window layout.
+
+**Constant:** `private let preWarmDeferralMs: Int = 1500` — named so we can tune.
+
+**Gate:** skip if onboarding isn't complete (onboarding has its own download/warmup flow). Reference the existing onboarding-complete signal — locate during implementation (likely `OnboardingViewModel.hasCompleted` or a UserDefaults key already in use by `OnboardingCoordinator.swift:30`).
+
+### 2. STT readiness snapshot at `.processing` entry
+
+**File:** `Sources/MacParakeet/App/DictationFlowCoordinator.swift:322` (handler for `.showProcessingState`)
+
+```swift
+case .showProcessingState:
+    overlayViewModel?.stopTimer()
+    overlayViewModel?.processingMessage = nil
+    overlayViewModel?.busyProcessingMessage = nil
+    overlayViewModel?.state = .processing
+    overlayViewModel?.processingLoadCaption = nil
+
+    // NEW: snapshot readiness and arm caption timers
+    armProcessingLoadCaption()
+```
+
+`armProcessingLoadCaption()` (new private method on the coordinator):
+
+```swift
+private func armProcessingLoadCaption() {
+    captionGraceTimer?.cancel()
+    captionEscalationTimer?.cancel()
+
+    Task { @MainActor [weak self] in
+        guard let self else { return }
+        guard await !self.sttRuntime.isReady() else {
+            // Pre-warm won — no caption ever shown for this dictation
+            return
+        }
+
+        // Engine wasn't ready at processing entry. Arm 600ms grace.
+        let grace = DispatchWorkItem { [weak self] in
+            self?.fireCaption()
+        }
+        self.captionGraceTimer = grace
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(600), execute: grace)
+    }
+}
+
+private func fireCaption() {
+    guard overlayViewModel?.state.isProcessing == true else { return }
+    let firstInstall = !preferences.hasCompletedFirstDictation
+    overlayViewModel?.processingLoadCaption = .preparing
+    captionShownAt = Date()
+    sendCaptionShownTelemetry(firstInstall: firstInstall)
+
+    if firstInstall {
+        let escalate = DispatchWorkItem { [weak self] in
+            guard self?.overlayViewModel?.processingLoadCaption == .preparing else { return }
+            self?.overlayViewModel?.processingLoadCaption = .preparingExtended
+        }
+        self.captionEscalationTimer = escalate
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(4000), execute: escalate)
+    }
+}
+
+private func dismissCaption(outcome: CaptionOutcome) {
+    captionGraceTimer?.cancel()
+    captionEscalationTimer?.cancel()
+    captionGraceTimer = nil
+    captionEscalationTimer = nil
+
+    if let shownAt = captionShownAt {
+        let duration = Date().timeIntervalSince(shownAt)
+        sendCaptionDurationTelemetry(durationMs: Int(duration * 1000), outcome: outcome)
+        captionShownAt = nil
+    }
+    overlayViewModel?.processingLoadCaption = nil
+}
+```
+
+Wire `dismissCaption(...)` into all `.processing` exit effect handlers in `DictationFlowCoordinator.swift`:
+- `.showSuccess` → `dismissCaption(.success)`
+- `.showNoSpeech` → `dismissCaption(.noSpeech)`
+- `.showError` → if caption was in `.preparing`/`.preparingExtended`, transition to `.failed` for a 2s display, then dismiss; otherwise dismiss immediately
+- `.hideOverlay` → `dismissCaption(.cancelled)` if still showing
+
+### 3. New overlay VM state
+
+**File:** `Sources/MacParakeet/Views/Dictation/DictationOverlayController.swift:179` (`DictationOverlayViewModel`)
+
+Add:
+
+```swift
+enum ProcessingLoadCaption: Equatable {
+    case preparing                  // 600ms+: "Preparing speech engine…"
+    case preparingExtended          // 4s+ on first-ever install: + subcopy
+    case failed                     // load error: "Couldn't load speech engine."
+}
+
+var processingLoadCaption: ProcessingLoadCaption?
+```
+
+Independent of `state` (`OverlayState`) — caption shows during `.processing` but doesn't constrain or extend it. `@Observable` mutation triggers SwiftUI re-render automatically.
+
+### 4. New view: `LoadingCaptionView`
+
+**New file:** `Sources/MacParakeet/Views/Dictation/LoadingCaptionView.swift`
+
+A compact capsule:
+- Background: `DesignSystem.Colors.pillBackground.opacity(0.55)`
+- Stroke: `DesignSystem.Colors.pillBorder.opacity(0.6)`, 0.5pt
+- Title: 11pt `.rounded` `.medium`, white at 0.85 opacity
+- Subcopy: 9.5pt `.rounded` `.regular`, white at 0.55 opacity, appears below title with 1pt spacing
+- Padding: 9pt horizontal, 5pt vertical
+- Corner radius: 8pt
+- Transition: `.opacity.combined(with: .offset(y: 4))`, 220ms ease-in-out
+- Respects `accessibilityReduceMotion`: cross-fade only, no offset slide
+- Failure variant: `DesignSystem.Colors.recordingRed` foreground tint on title; subcopy hidden
+
+```swift
+struct LoadingCaptionView: View {
+    let caption: DictationOverlayViewModel.ProcessingLoadCaption
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        VStack(spacing: 1) {
+            Text(title)
+                .font(.system(size: 11, weight: .medium, design: .rounded))
+                .foregroundStyle(titleColor)
+            if let subcopy {
+                Text(subcopy)
+                    .font(.system(size: 9.5, weight: .regular, design: .rounded))
+                    .foregroundStyle(.white.opacity(0.55))
+            }
+        }
+        .padding(.horizontal, 9)
+        .padding(.vertical, 5)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(DesignSystem.Colors.pillBackground.opacity(0.55))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(DesignSystem.Colors.pillBorder.opacity(0.6), lineWidth: 0.5)
+                )
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    // title / subcopy / colors / accessibilityLabel switch on `caption`
+}
+```
+
+### 5. Mount the caption in the overlay
+
+**File:** `Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift`
+
+Wrap the existing pill content in a `VStack` (or `ZStack` with `.alignmentGuide`) so the caption floats above without displacing the pill's bottom-anchored screen position:
+
+```swift
+VStack(spacing: 6) {
+    Group {
+        if let caption = viewModel.processingLoadCaption {
+            LoadingCaptionView(caption: caption)
+        } else {
+            // empty placeholder preserves layout when caption absent
+            Color.clear.frame(height: 0)
+        }
+    }
+    .transition(.opacity)
+    .animation(.easeInOut(duration: 0.22), value: viewModel.processingLoadCaption)
+
+    pillContent  // existing pill rendering
+}
+```
+
+The dictation overlay panel is already 300×160 (`DictationOverlayController.swift:77-79`), with the pill content centered. Ample vertical room above the pill exists for a caption without resizing the panel. The pill stays bottom-anchored in the panel; the caption fades in/out above it.
+
+### 6. First-dictation flag
+
+**File:** `Sources/MacParakeetCore/AppRuntimePreferences.swift:92` (`UserDefaultsAppRuntimePreferences`)
+
+Add to `AppRuntimePreferencesProtocol`:
+
+```swift
+var hasCompletedFirstDictation: Bool { get }
+func markFirstDictationCompleted()
+```
+
+Add to `UserDefaultsAppRuntimePreferences`:
+
+```swift
+public static let hasCompletedFirstDictationKey = "hasCompletedFirstDictation"
+
+public var hasCompletedFirstDictation: Bool {
+    defaults.bool(forKey: Self.hasCompletedFirstDictationKey)
+}
+
+public func markFirstDictationCompleted() {
+    defaults.set(true, forKey: Self.hasCompletedFirstDictationKey)
+}
+```
+
+`markFirstDictationCompleted()` is called from `DictationService.stopRecording(sessionID:)` in the success path **after the dictation history insert succeeds**, so failed dictations don't burn the first-time flag. Idempotent — UserDefaults `set(true)` is cheap.
+
+### 7. Telemetry
+
+Add to `Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift`:
+
+- **`dictationFirstLoadCaptionShown`** — payload: `firstInstall: Bool`. Fired when the caption fades in.
+- **`dictationFirstLoadCaptionDuration`** — payload: `durationMs: Int`, `outcome: "success" | "noSpeech" | "failure" | "cancelled"`. Fired when caption fades out.
+
+**Two-repo change required:** Add both event names to `ALLOWED_EVENTS` in `macparakeet-website/functions/api/telemetry.ts` **BEFORE** the app build ships. Per `memory/feedback_telemetry_allowlist.md`, the Worker rejects the entire batch if any event is unknown, silently dropping valid co-batched events. Verify with curl after deploy.
+
+## State machine additions
+
+**None.** The state machine (`DictationFlowStateMachine.swift`) stays pure — no new effects, no new events. All caption logic lives in the coordinator's effect handlers (§2 above), because the state machine has no STT dependency by design (ADR-016).
+
+## Copy spec
+
+| Time after `.processing` entry | First-ever install | Subsequent cold launches |
+|---|---|---|
+| 0–600ms | (none — suppressed by grace) | (none — suppressed by grace) |
+| 600ms+ | `Preparing speech engine…` | `Preparing speech engine…` |
+| 4s+ (caption visible 3.4s+) | + subcopy: `First-time setup — this happens once` | (main copy only — no subcopy) |
+| On model-load failure | `Couldn't load speech engine.` (red tint) | `Couldn't load speech engine.` (red tint) |
+| On `.processing` exit | (fade out, 220ms) | (fade out, 220ms) |
+
+VoiceOver: caption text announced on appear via `accessibilityLabel`. No live region — we want a single announcement on first appearance, not a re-announce on subcopy change. Subcopy joins silently.
+
+## Acceptance criteria
+
+- **AC1.** Truly-first-install: after onboarding completes and the user reaches the main window, `backgroundWarmUp()` is invoked ~1.5s post-launch with no UI interaction required.
+- **AC2.** Pre-warm wins (typical 2nd+ cold launch): user dictates 2s on cold launch, model is loaded by the time `.processing` is entered, no caption appears.
+- **AC3.** Pre-warm loses by <600ms: caption never appears (grace suppression).
+- **AC4.** Pre-warm loses by 600ms–4s: caption appears with `Preparing speech engine…`, no subcopy, fades out on `.processing` exit.
+- **AC5.** First-ever install, model loads in 8s: caption appears at 600ms with main copy; at 4.6s the subcopy joins; both fade out at ~8s when transcription completes.
+- **AC6.** Subsequent cold launch, model loads in 8s: caption shows main copy only (no subcopy) for the full duration.
+- **AC7.** Model load fails mid-`.processing`: caption switches to failure variant (red) for ~2s before overlay transitions to `.error`.
+- **AC8.** User cancels dictation while caption is showing (Escape, dismissal, or app close): caption fades out alongside overlay close — no orphaned caption visible.
+- **AC9.** Existing "Still transcribing…" inline hint still works when user re-presses Fn during `.processing` — both messages can coexist (caption above, inline beside spinner).
+- **AC10.** `accessibilityReduceMotion`: caption cross-fades only, no offset animation.
+- **AC11.** `hasCompletedFirstDictation` flips from `false` to `true` exactly once, on the first successful dictation; remains `true` thereafter. Cancelled / failed dictations do not flip the flag.
+- **AC12.** No regression in any existing dictation flow (cancellation, mode switches, paste, history, ready-pill auto-dismiss, command mode, formatting mode, no-speech outcome).
+- **AC13.** Telemetry events fire correctly: `caption_shown` once on appear, `caption_duration` once on dismiss with accurate `durationMs` and `outcome`.
+
+## Test plan
+
+### Unit / ViewModel
+
+- `DictationOverlayViewModelTests` (existing) — verify `processingLoadCaption` set/clear, no timer leaks.
+- `LoadingCaptionViewTests` (optional) — render verification per caption variant; low ROI, defer.
+
+### Coordinator / integration
+
+- **New file:** `Tests/MacParakeetTests/Dictation/DictationFlowCoordinatorLoadCaptionTests.swift`
+- Mock `STTRuntime`'s `isReady()` to control readiness. Exercise:
+  - Model ready at entry → no caption ever.
+  - Model not ready, processing < 600ms → no caption (grace suppressed).
+  - Model not ready, processing 1s, first install → caption with main copy, no subcopy at 1s; subcopy would have arrived at 4.6s.
+  - Model not ready, processing 5s, first install → caption + subcopy at 4.6s mark; both clear at 5s.
+  - Model not ready, processing 5s, subsequent launch → caption main copy only, no subcopy ever.
+  - Failure: caption switches to failure variant; clears after 2s.
+  - Cancellation during caption: clears without flash.
+  - Second dictation in same session (model now warm): no caption regardless of duration.
+- Use injected `Clock` if available (precedent: commit `65ec19b0` deferred Clock injection for meeting-recording duration tests).
+
+### Manual / smoke
+
+- Cold launch on a clean install (no `hasCompletedFirstDictation` flag) → first dictation should produce the full main + subcopy sequence.
+- Force `STTRuntime` into a slow-load state (uninstall CoreML cache or insert artificial delay in `ensureInitialized`) → caption sequence as specified.
+- Subsequent app launches with prior dictation history → main copy only, no subcopy.
+- `Reduce Motion` enabled (System Settings → Accessibility → Display) → caption uses cross-fade with no slide.
+- Concurrent meeting recording warmup → no double-warmup, no UI glitch.
+
+## Telemetry validation
+
+Once the allowlist update lands and a build ships, query D1 (per `reference_cloudflare_queries.md`):
+
+```sql
+SELECT
+    COUNT(*) AS caption_shown_count,
+    AVG(json_extract(payload, '$.durationMs')) AS avg_duration_ms,
+    SUM(CASE WHEN json_extract(payload, '$.firstInstall') = 1 THEN 1 ELSE 0 END) AS first_install_shown,
+    SUM(CASE WHEN json_extract(payload, '$.outcome') = 'failure' THEN 1 ELSE 0 END) AS failure_count
+FROM events
+WHERE name IN ('dictation_first_load_caption_shown', 'dictation_first_load_caption_duration')
+  AND received_at >= ?;
+```
+
+**Success metric post-ship:** caption_shown_count / total_dictations < 10%. If higher (say, >25%), tune `preWarmDeferralMs` down or investigate warmup blockers. If `failure_count` is non-trivial, file a follow-up to surface tap-to-retry in the failure variant.
+
+## Open questions / decision points
+
+1. **Pre-warm deferral value (1.5s)** — pragmatic guess. Tune based on observed startup competition. Constant lives in code.
+2. **Caption position offset above pill** — 6pt or 8pt of vertical spacing? Pick during implementation based on visual feel; document the choice in commit message.
+3. **Failure copy actionability** — for v1, the failure caption is informational only. Revisit if telemetry shows failure caption being seen frequently — could add a retry button or "Open Settings" link.
+4. **Pre-warm gating signal** — needs identification at implementation time: which Onboarding flag is authoritative? Likely lives in `OnboardingViewModel` or `OnboardingCoordinator`. If onboarding completion is observed via a delegate callback, schedule pre-warm there instead of a fixed timer.
+
+## Out of scope / follow-ups
+
+- **Settings toggle** for pre-warm gating (some users might want to disable to save RAM). Add only if requested via feedback.
+- **Pre-warm progress in the caption** ("Loading speech engine… 47%"). Considered but adds visual noise; the 4s subcopy is already the escalation lever.
+- **Idle pill warmup indicator** — the idle pill could subtly indicate "warming up" via the breathing animation rate, but this is a deeper redesign.
+- **Whisper engine path** — Whisper isn't typically used for dictation today; if dictation-via-Whisper becomes common, revisit whether `isReady()` semantics differ per engine.
+- **Lazy-init progress emission** — modify `STTRuntime.ensureInitialized()` to emit `STTWarmUpState` events so the caption can show real progress instead of "indefinite spinner." Larger refactor; defer unless telemetry shows we need it.
+
+## References
+
+- ADR-001 (Parakeet TDT 0.6B-v3 as primary STT) — `spec/adr/001-parakeet-stt.md`
+- ADR-005 (Onboarding first-run) — `spec/adr/005-onboarding-first-run.md`
+- ADR-016 (Centralized STT runtime and two-slot scheduler) — `spec/adr/016-centralized-stt-runtime-scheduler.md`
+- `spec/06-stt-engine.md` — STT engine narrative
+- `spec/04-ui-patterns.md` — Overlay UI patterns (to be updated)
+- `memory/feedback_telemetry_allowlist.md` — two-repo telemetry change reminder
+- `reference_cloudflare_queries.md` — D1 query patterns for telemetry validation
+
+## Files touched
+
+### Source
+
+- `Sources/MacParakeet/AppDelegate.swift` — schedule deferred pre-warm
+- `Sources/MacParakeet/App/AppEnvironmentConfigurer.swift` — wire pre-warm trigger (alternative location)
+- `Sources/MacParakeet/App/DictationFlowCoordinator.swift` — readiness snapshot + caption timing + telemetry
+- `Sources/MacParakeet/Views/Dictation/DictationOverlayController.swift` — `ProcessingLoadCaption` enum, VM property
+- `Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift` — mount caption above pill via VStack
+- `Sources/MacParakeet/Views/Dictation/LoadingCaptionView.swift` — **new**
+- `Sources/MacParakeetCore/AppRuntimePreferences.swift` — `hasCompletedFirstDictation` accessor + setter
+- `Sources/MacParakeetCore/Services/Dictation/DictationService.swift` — flip flag on first success
+- `Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift` — two new event cases
+
+### Tests
+
+- `Tests/MacParakeetTests/Dictation/DictationFlowCoordinatorLoadCaptionTests.swift` — **new**
+
+### Sibling repo (must land before app ship)
+
+- `macparakeet-website/functions/api/telemetry.ts` — allowlist update for two new event names
+
+### Spec
+
+- `spec/04-ui-patterns.md` — document the loading caption pattern (dictation overlay section)
+- `spec/kernel/requirements.yaml` — add requirement ID (e.g. `REQ-DICTATION-COLD-LOAD-FEEDBACK`)
+- `spec/kernel/traceability.md` — map source files + test files to the requirement

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -304,7 +304,7 @@ Compact dark pill overlay, always-on-top, bottom-center of screen. This is the p
 
 ```
 ┌──────────────────────────────────────────┐
-│  [merkaba]  Processing...               │
+│                [merkaba]                 │
 └──────────────────────────────────────────┘
 
 - [merkaba]: Sacred geometry spinner — two counter-rotating equilateral triangles
@@ -313,8 +313,32 @@ Compact dark pill overlay, always-on-top, bottom-center of screen. This is the p
   - 6 vertex dots: 2.5pt core (white 80%) + 7pt blur glow, pulsing 0.6→1.0 over 1.5s
   - Center nexus: 3pt core (white 90%) + 10pt blur glow, pulsing 0.3→0.7 over 2s
   - Faint outer guide ring: white 8%, 0.5pt stroke
-- "Processing..." label
+- Non-command processing uses the spinner alone unless the transient
+  `"Still transcribing..."` hint is active after a repeated hotkey press.
+  Command processing keeps spinner + "Applying command...".
 - Cross-fades in from recording state via `.opacity` transition
+
+**First-load caption.** If `.processing` is entered while the speech engine is
+not ready, the coordinator arms a 600ms grace timer. If `.processing` is still
+active after the grace, a compact floating capsule appears above the pill in
+the same overlay panel; the pill remains bottom-anchored and its geometry does
+not shift. The caption is separate from the inline `"Still transcribing..."`
+hint so passive engine state and user-triggered processing feedback can
+coexist.
+
+- Copy: `Preparing speech engine…`
+- First-ever install escalation: after 4s, add subcopy
+  `First-time setup — this happens once`
+- Subsequent cold launches never show subcopy
+- Failure: `Couldn't load speech engine.` in `recordingRed`, then the normal
+  error card appears after the brief failure caption
+- Styling: `pillBackground.opacity(0.55)` fill,
+  `pillBorder.opacity(0.6)` 0.5pt stroke, 8pt radius, 11pt rounded medium
+  title, 9.5pt rounded regular subcopy
+- Motion: 220ms ease-in-out opacity + 4pt upward offset; Reduce Motion uses
+  opacity only
+- Telemetry: one `dictation_first_load_caption_shown` event on appear and one
+  `dictation_first_load_caption_duration` event on dismiss
 ```
 
 **4. Formatting (AI Formatter refinement)**

--- a/spec/kernel/requirements.yaml
+++ b/spec/kernel/requirements.yaml
@@ -128,6 +128,11 @@ REQ-DICT-005:
   version: v0.5
   status: implemented
 
+REQ-DICT-006:
+  description: First dictation after cold speech-engine load shows a graceful processing caption while launch pre-warm reduces normal exposure
+  version: v0.6
+  status: implemented
+
 REQ-DATA-003:
   description: Multi-conversation chat per transcription
   version: v0.5

--- a/spec/kernel/traceability.md
+++ b/spec/kernel/traceability.md
@@ -48,6 +48,7 @@ This matrix traces each requirement ID from `requirements.yaml` to its implement
 | Requirement | Source Files | Test Files |
 |------------|-------------|------------|
 | REQ-DICT-005 | `MacParakeetCore/Database/DictationRepository.swift` | `DictationRepositoryTests.swift` |
+| REQ-DICT-006 | `MacParakeet/App/AppDelegate.swift`, `MacParakeet/App/OnboardingCoordinator.swift`, `MacParakeet/App/DictationFlowCoordinator.swift`, `MacParakeet/Views/Dictation/DictationOverlayController.swift`, `MacParakeet/Views/Dictation/DictationOverlayView.swift`, `MacParakeet/Views/Dictation/LoadingCaptionView.swift`, `MacParakeetCore/AppRuntimePreferences.swift`, `MacParakeetCore/Services/Dictation/DictationService.swift`, `MacParakeetCore/Services/Telemetry/TelemetryEvent.swift` | `DictationFlowCoordinatorLoadCaptionTests.swift`, `DictationServiceTests.swift`, `TelemetryServiceTests.swift` |
 | REQ-DATA-003 | `MacParakeetCore/Database/ChatConversationRepository.swift`, `MacParakeetCore/Models/ChatConversation.swift` | `ChatConversationRepositoryTests.swift`, `TranscriptChatViewModelTests.swift` |
 | REQ-YT-002 | `MacParakeetCore/Database/TranscriptionRepository.swift` | `TranscriptionRepositoryTests.swift` |
 | REQ-TRANS-003 | `MacParakeetCore/Services/MediaMetadataExtractor.swift`, `MacParakeetCore/Services/TranscriptionService.swift`, `MacParakeetCore/Services/ThumbnailCacheService.swift` | `MediaMetadataExtractorTests.swift`, `TranscriptionServiceTests.swift`, `ThumbnailCacheServiceTests.swift` |


### PR DESCRIPTION
## Summary

First dictation of a fresh launch used to feel laggy while the speech engine loaded with no visible feedback. Now an unobtrusive caption appears above the pill while the model warms up and disappears as soon as transcription starts — and most users won't see it at all, because the engine pre-warms quietly in the background after onboarding.

## For users

- **Caption above the pill** while the speech engine initializes on first dictation of a launch — small, calm, non-blocking. It clears the moment transcription begins.
- **First-time setup messaging** on a true cold start (first install or rare slow load) escalates after ~4s so you know it's still working.
- **Proactive pre-warm** runs silently ~1.5s after launch (once onboarding is complete), so most subsequent first-dictations never show the caption at all.
- **Reduce Motion respected** — caption fades in/out without slide animation when the system setting is on.
- **Failure path** shows a brief red caption before the existing error card, so failures don't feel silent either.

## How it works

```
App launch ─┐
            ├─► onboarding complete ─► (1.5s defer) ─► STT pre-warm in background
            │
            └─► first dictation ─► [600ms grace] ─► caption visible while model loads ─► transcript arrives → caption clears
```

The 600ms grace means a fast-enough warm-up shows nothing at all.

## Code touchpoints

- `Sources/MacParakeet/App/DictationFlowCoordinator.swift` — caption arm/dismiss, grace + escalation timers, generation-guarded outcome telemetry.
- `Sources/MacParakeet/Views/Dictation/LoadingCaptionView.swift` — caption view + Reduce Motion transition.
- `Sources/MacParakeet/AppDelegate.swift` — deferred `backgroundWarmUp()` after onboarding completion.
- `Sources/MacParakeetCore/AppRuntimePreferences.swift` — `hasCompletedFirstDictation` marker.
- `Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift` — `dictationFirstLoadCaptionShown` + `dictationFirstLoadCaptionDuration` events.

Companion telemetry-website allowlist PR: https://github.com/moona3k/macparakeet-website/pull/9