### PR TITLE
Recovery UI for mic-permission denial + faster CLI timeout

### DIFF
--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -836,30 +836,43 @@ final class DictationFlowCoordinator {
         return false
     }
 
-    /// Shows the macOS Privacy → Microphone recovery prompt at most once per app launch.
+    /// Shows the macOS Privacy -> Microphone recovery prompt at most once per app launch.
     /// The alert is dispatched asynchronously so the flow state machine processes
-    /// the `.startFailed` event before the modal blocks the run loop.
+    /// the `.startFailed` event before any no-window modal fallback is needed.
     private func maybePresentMicPermissionAlert() {
         guard !micPermissionAlertShown else { return }
         micPermissionAlertShown = true
         Task { @MainActor in
-            self.presentMicPermissionAlert()
+            await self.presentMicPermissionAlert()
         }
     }
 
-    private func presentMicPermissionAlert() {
+    private func presentMicPermissionAlert() async {
         let alert = NSAlert()
         alert.messageText = "Microphone access required"
         alert.informativeText = "MacParakeet needs microphone access to record dictation. Open System Settings → Privacy & Security → Microphone to enable it, then try again."
         alert.alertStyle = .warning
         alert.addButton(withTitle: "Open System Settings")
         alert.addButton(withTitle: "Cancel")
-        NSApp.activate(ignoringOtherApps: true)
-        let response = alert.runModal()
+        let response = await presentMicPermissionAlert(alert)
         if response == .alertFirstButtonReturn,
            let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone") {
             NSWorkspace.shared.open(url)
         }
+    }
+
+    private func presentMicPermissionAlert(_ alert: NSAlert) async -> NSApplication.ModalResponse {
+        NSApp.activate(ignoringOtherApps: true)
+
+        if let window = [NSApp.keyWindow, NSApp.mainWindow].compactMap({ $0 }).first(where: \.isVisible) {
+            return await withCheckedContinuation { continuation in
+                alert.beginSheetModal(for: window) { response in
+                    continuation.resume(returning: response)
+                }
+            }
+        }
+
+        return alert.runModal()
     }
 
     private func stopRecordingTask(generation: Int, sessionID: Int) {

--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -144,6 +144,8 @@ final class DictationFlowCoordinator {
     private var pendingPostPasteAction: KeyAction?
     /// Error from the most recent entitlements check failure, consumed by presentEntitlementsAlert effect.
     private var lastEntitlementsError: Error?
+    /// Suppresses repeat mic-permission alerts within a session once the user has been shown the recovery prompt.
+    private var micPermissionAlertShown = false
     private var readyPillDismissDelayMs: Int {
         (hotkeyManagers.first?.tapThresholdMs ?? FnKeyStateMachine.defaultTapThresholdMs) * 2
     }
@@ -816,8 +818,47 @@ final class DictationFlowCoordinator {
                 self.dictationLog.error(
                     "start_recording_failed gen=\(generation) session=\(sessionID) error=\(error.localizedDescription, privacy: .public)"
                 )
-                self.sendEvent(.startFailed(generation: generation, message: error.localizedDescription))
+                if Self.isMicrophonePermissionDenied(error) {
+                    self.maybePresentMicPermissionAlert()
+                    self.sendEvent(.startFailed(generation: generation, message: "Microphone access required"))
+                } else {
+                    self.sendEvent(.startFailed(generation: generation, message: error.localizedDescription))
+                }
             }
+        }
+    }
+
+    private static func isMicrophonePermissionDenied(_ error: Error) -> Bool {
+        if let audioError = error as? AudioProcessorError,
+           case .microphonePermissionDenied = audioError {
+            return true
+        }
+        return false
+    }
+
+    /// Shows the macOS Privacy → Microphone recovery prompt at most once per app launch.
+    /// The alert is dispatched asynchronously so the flow state machine processes
+    /// the `.startFailed` event before the modal blocks the run loop.
+    private func maybePresentMicPermissionAlert() {
+        guard !micPermissionAlertShown else { return }
+        micPermissionAlertShown = true
+        Task { @MainActor in
+            self.presentMicPermissionAlert()
+        }
+    }
+
+    private func presentMicPermissionAlert() {
+        let alert = NSAlert()
+        alert.messageText = "Microphone access required"
+        alert.informativeText = "MacParakeet needs microphone access to record dictation. Open System Settings → Privacy & Security → Microphone to enable it, then try again."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Open System Settings")
+        alert.addButton(withTitle: "Cancel")
+        NSApp.activate(ignoringOtherApps: true)
+        let response = alert.runModal()
+        if response == .alertFirstButtonReturn,
+           let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone") {
+            NSWorkspace.shared.open(url)
         }
     }
 

--- a/Sources/MacParakeetCore/Services/LLM/LocalCLIExecutor.swift
+++ b/Sources/MacParakeetCore/Services/LLM/LocalCLIExecutor.swift
@@ -75,7 +75,7 @@ public enum LocalCLIError: Error, LocalizedError, Sendable {
         case .commandNotFound(let details):
             return "CLI command not found. Ensure it is installed and on your PATH. Details: \(details)"
         case .timeout(let seconds):
-            return "Timed out after \(Int(seconds))s with no output. Make sure the command runs from a terminal and is logged in if required."
+            return "Timed out after \(Int(seconds))s. Verify the command runs successfully in a terminal and is logged in if required."
         case .drainTimeout:
             return "CLI command exited, but its output pipes did not close in time."
         case .nonZeroExit(let code, let stderr):

--- a/Sources/MacParakeetCore/Services/LLM/LocalCLIExecutor.swift
+++ b/Sources/MacParakeetCore/Services/LLM/LocalCLIExecutor.swift
@@ -9,7 +9,7 @@ public struct LocalCLIConfig: Codable, Sendable, Equatable {
     public let timeoutSeconds: Double
 
     public static let minimumTimeout: Double = 5
-    public static let defaultTimeout: Double = 120
+    public static let defaultTimeout: Double = 45
 
     public init(commandTemplate: String, timeoutSeconds: Double = Self.defaultTimeout) {
         self.commandTemplate = commandTemplate
@@ -75,7 +75,7 @@ public enum LocalCLIError: Error, LocalizedError, Sendable {
         case .commandNotFound(let details):
             return "CLI command not found. Ensure it is installed and on your PATH. Details: \(details)"
         case .timeout(let seconds):
-            return "CLI command timed out after \(Int(seconds)) seconds."
+            return "Timed out after \(Int(seconds))s with no output. Make sure the command runs from a terminal and is logged in if required."
         case .drainTimeout:
             return "CLI command exited, but its output pipes did not close in time."
         case .nonZeroExit(let code, let stderr):

--- a/Tests/MacParakeetTests/Services/LLM/LocalCLIExecutorTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LocalCLIExecutorTests.swift
@@ -61,6 +61,14 @@ final class LocalCLIExecutorTests: XCTestCase {
         XCTAssertNil(store.load())
     }
 
+    func testDefaultTimeoutAndTimeoutDescription() {
+        XCTAssertEqual(LocalCLIConfig.defaultTimeout, 45)
+        XCTAssertEqual(
+            LocalCLIError.timeout(seconds: LocalCLIConfig.defaultTimeout).errorDescription,
+            "Timed out after 45s. Verify the command runs successfully in a terminal and is logged in if required."
+        )
+    }
+
     // MARK: - Templates
 
     func testTemplateDefaults() {


### PR DESCRIPTION
## Summary

Two narrow fixes for failure modes flagged in the 2026-05-10 telemetry deep-dive. Both targeted at the *recovery* path — happy-path behavior is unchanged.

### 1. Mic-permission-denied recovery prompt (dictation)

When `DictationFlowCoordinator` catches `AudioProcessorError.microphonePermissionDenied` while starting a dictation, it now surfaces a one-shot `NSAlert`:

> **Microphone access required**
> MacParakeet needs microphone access to record dictation. Open System Settings → Privacy & Security → Microphone to enable it, then try again.
>
> [Open System Settings] [Cancel]

Clicking **Open System Settings** deep-links to `x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone`. Suppressed for the rest of the app launch after first show.

Telemetry signal: one user hit this 19× across 14 hours via hotkey + 4 other sessions hit it once each via pill_click in the last 24h. Current behavior is "overlay flickers and dies with no explanation."

### 2. LocalCLI: faster, actionable timeout

- `LocalCLIConfig.defaultTimeout`: `120s` → `45s`
- `LocalCLIError.timeout` error description now reads: *"Timed out after Ns with no output. Make sure the command runs from a terminal and is logged in if required."* (was: *"CLI command timed out after N seconds."*)

Telemetry signal: one user hit `LLMError.cliError` × 4 times in 24h, each at exact 120.2–120.5s duration with `output_chars: 0` — i.e. the CLI is hanging (likely interactive auth), and the user wasted 8 minutes waiting before getting opaque feedback.

Users with legitimately longer prompts can still bump the timeout in Settings → LLM.

## Test plan

- [x] `swift test` — 2436 XCTest + 16 Swift Testing, all pass
- [x] `swift build` — clean
- [ ] Manual smoke: deny mic in System Settings, press hotkey, verify alert appears and "Open System Settings" opens the right pane
- [ ] Manual smoke: configure a LocalCLI command that hangs (e.g. `sleep 60`), verify timeout fires at 45s and the message is the new actionable one

## Scope notes

- **Not addressed** (deliberately): meeting-recording mic permission path (`MeetingAudioError.microphonePermissionDenied`). Zero telemetry events in window; meeting tile has its own permission affordance. File a follow-up if it shows up in future telemetry.
- **Not addressed**: Ollama retry storm (74 events / 24h, 96% from one session). Same May-9 pattern; circuit-breaker UI deferred to a separate PR.
- **Not addressed**: `STTSchedulerError.unavailable` drip (5 events / 24h, now in v0.6.4 too). Separate code-read of the slot-claim path.

Refs: 2026-05-10 telemetry deep-dive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved microphone permission error handling with a system-level privacy prompt that appears once per app session
  * Optimized command execution timeout duration for faster feedback to users

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moona3k/macparakeet/pull/261)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->