### PR TITLE
Fix hotkey recorder swallowing the key the user is recording (#263)

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -27,6 +27,7 @@ final class AppEnvironmentConfigurer {
         let onHotkeyUnavailable: () -> Void
         let onHotkeyConflict: (HotkeyTrigger, [HotkeyTrigger]) -> Void
         let onRecoverPendingMeetingRecordings: () -> Void
+        let isHotkeyRecordingActive: () -> Bool
     }
 
     private let transcriptionViewModel: TranscriptionViewModel
@@ -277,13 +278,16 @@ final class AppEnvironmentConfigurer {
             },
             onAnyHotkeyEnabled: callbacks.onHotkeyBecameAvailable,
             onHotkeyUnavailable: callbacks.onHotkeyUnavailable,
-            onHotkeyConflict: callbacks.onHotkeyConflict
+            onHotkeyConflict: callbacks.onHotkeyConflict,
+            dictationRecordingModeProvider: {
+                coordinatorRefs.dictation?.hotkeyRecordingMode
+            }
         )
 
-        hotkeyCoordinator.setupDictationHotkeys()
-        hotkeyCoordinator.setupMeetingHotkey()
-        hotkeyCoordinator.setupFileTranscriptionHotkey()
-        hotkeyCoordinator.setupYouTubeTranscriptionHotkey()
+        if callbacks.isHotkeyRecordingActive() {
+            hotkeyCoordinator.suspend()
+        }
+        hotkeyCoordinator.setupAllHotkeys()
         dictationCoordinator.showIdlePill()
 
         // Calendar auto-start (ADR-017 Phases 1 + 2 — reminders +

--- a/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
+++ b/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
@@ -23,6 +23,12 @@ final class AppHotkeyCoordinator {
     private var meetingHotkeyManager: GlobalShortcutManager?
     private var fileTranscriptionHotkeyManager: GlobalShortcutManager?
     private var youtubeTranscriptionHotkeyManager: GlobalShortcutManager?
+    /// Count of active `HotkeyRecorderView` sessions that have asked for the
+    /// global CGEvent taps to stand down so the recorder can capture the
+    /// user's keyDown. Reaches > 1 only across pathological re-entry — the
+    /// counter exists so balanced suspend/resume calls never desync the
+    /// underlying taps.
+    private var suspendCount = 0
 
     init(
         settingsViewModel: SettingsViewModel,
@@ -320,36 +326,70 @@ final class AppHotkeyCoordinator {
     }
 
     func refreshAllHotkeys() {
-        stopDictationHotkeys()
-        meetingHotkeyManager?.stop()
-        fileTranscriptionHotkeyManager?.stop()
-        youtubeTranscriptionHotkeyManager?.stop()
-        meetingHotkeyManager = nil
-        fileTranscriptionHotkeyManager = nil
-        youtubeTranscriptionHotkeyManager = nil
-        setupDictationHotkeys()
-        setupMeetingHotkey()
-        setupFileTranscriptionHotkey()
-        setupYouTubeTranscriptionHotkey()
+        // While a recorder is active, the SettingsViewModel observer can race
+        // us — skip and rely on `resume()` to rebuild from current settings.
+        guard suspendCount == 0 else { return }
+        stopAll()
+        setupAllHotkeys()
     }
 
     func refreshMeetingHotkey() {
+        guard suspendCount == 0 else { return }
         meetingHotkeyManager?.stop()
         meetingHotkeyManager = nil
         setupMeetingHotkey()
     }
 
     func refreshFileTranscriptionHotkey() {
+        guard suspendCount == 0 else { return }
         fileTranscriptionHotkeyManager?.stop()
         fileTranscriptionHotkeyManager = nil
         setupFileTranscriptionHotkey()
     }
 
     func refreshYouTubeTranscriptionHotkey() {
+        guard suspendCount == 0 else { return }
         youtubeTranscriptionHotkeyManager?.stop()
         youtubeTranscriptionHotkeyManager = nil
         setupYouTubeTranscriptionHotkey()
     }
+
+    // MARK: - Suspend / Resume
+
+    /// Stand down every global hotkey CGEvent tap while a hotkey recorder UI
+    /// is capturing keystrokes. Without this, the head-of-tap chord and
+    /// key-code handlers swallow the keyDown the user is trying to record,
+    /// silently fire their own actions (e.g. start a meeting recording mid-
+    /// Settings), and leave the recorder to commit a wrong modifier-chord on
+    /// release. Pair every call with `resume()`.
+    func suspend() {
+        suspendCount += 1
+        if suspendCount == 1 {
+            stopAll()
+        }
+    }
+
+    /// Re-arm every global hotkey CGEvent tap after recording finishes,
+    /// reading current values from `settingsViewModel` so a freshly-recorded
+    /// trigger comes online immediately.
+    func resume() {
+        guard suspendCount > 0 else { return }
+        suspendCount -= 1
+        if suspendCount == 0 {
+            setupAllHotkeys()
+        }
+    }
+
+    private func setupAllHotkeys() {
+        setupDictationHotkeys()
+        setupMeetingHotkey()
+        setupFileTranscriptionHotkey()
+        setupYouTubeTranscriptionHotkey()
+    }
+
+    /// Test-only inspection. Exists so the suspend/resume refcount can be
+    /// asserted without exposing the storage to production callers.
+    var suspendCountForTesting: Int { suspendCount }
 
     func applyMeetingHotkey(to item: NSMenuItem) {
         let trigger = settingsViewModel.meetingHotkeyTrigger

--- a/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
+++ b/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
@@ -18,6 +18,7 @@ final class AppHotkeyCoordinator {
     private let onAnyHotkeyEnabled: () -> Void
     private let onHotkeyUnavailable: () -> Void
     private let onHotkeyConflict: (HotkeyTrigger, [HotkeyTrigger]) -> Void
+    private let dictationRecordingModeProvider: () -> FnKeyStateMachine.RecordingMode?
 
     private var dictationHotkeyManagers: [HotkeyManager] = []
     private var meetingHotkeyManager: GlobalShortcutManager?
@@ -44,7 +45,8 @@ final class AppHotkeyCoordinator {
         onDictationHotkeyManagersChanged: @escaping ([HotkeyManager]) -> Void,
         onAnyHotkeyEnabled: @escaping () -> Void,
         onHotkeyUnavailable: @escaping () -> Void,
-        onHotkeyConflict: @escaping (HotkeyTrigger, [HotkeyTrigger]) -> Void
+        onHotkeyConflict: @escaping (HotkeyTrigger, [HotkeyTrigger]) -> Void,
+        dictationRecordingModeProvider: @escaping () -> FnKeyStateMachine.RecordingMode? = { nil }
     ) {
         self.settingsViewModel = settingsViewModel
         self.onStartDictation = onStartDictation
@@ -60,6 +62,7 @@ final class AppHotkeyCoordinator {
         self.onAnyHotkeyEnabled = onAnyHotkeyEnabled
         self.onHotkeyUnavailable = onHotkeyUnavailable
         self.onHotkeyConflict = onHotkeyConflict
+        self.dictationRecordingModeProvider = dictationRecordingModeProvider
     }
 
     var hotkeyMenuTitle: String {
@@ -170,10 +173,13 @@ final class AppHotkeyCoordinator {
             onHotkeyConflict(conflict.trigger, conflict.conflicts)
         }
 
+        let activeRecordingMode = dictationRecordingModeProvider()
         let managers = plan.specs.compactMap { spec in
             startDictationHotkey(
                 trigger: spec.trigger,
-                gestureMode: spec.gestureMode
+                gestureMode: spec.gestureMode,
+                resumeMode: Self.resumeMode(activeRecordingMode, for: spec.gestureMode),
+                suppressUntilReset: Self.shouldSuppressPeer(activeRecordingMode, for: spec.gestureMode)
             )
         }
         dictationHotkeyManagers = managers
@@ -188,7 +194,9 @@ final class AppHotkeyCoordinator {
 
     private func startDictationHotkey(
         trigger: HotkeyTrigger,
-        gestureMode: HotkeyGestureController.Mode
+        gestureMode: HotkeyGestureController.Mode,
+        resumeMode: FnKeyStateMachine.RecordingMode? = nil,
+        suppressUntilReset: Bool = false
     ) -> HotkeyManager? {
         guard !trigger.isDisabled else { return nil }
 
@@ -215,8 +223,14 @@ final class AppHotkeyCoordinator {
         manager.onEscapeWhileIdle = { [weak self] in
             self?.onEscapeWhileIdle()
         }
+        if let resumeMode {
+            manager.resumeRecording(mode: resumeMode)
+        }
 
         if manager.start() {
+            if suppressUntilReset {
+                manager.suppressUntilReset()
+            }
             onAnyHotkeyEnabled()
             return manager
         } else {
@@ -325,6 +339,31 @@ final class AppHotkeyCoordinator {
         return unique
     }
 
+    static func resumeMode(
+        _ activeMode: FnKeyStateMachine.RecordingMode?,
+        for gestureMode: HotkeyGestureController.Mode
+    ) -> FnKeyStateMachine.RecordingMode? {
+        guard let activeMode else { return nil }
+        switch (activeMode, gestureMode) {
+        case (.persistent, .doubleTapOnly),
+             (.persistent, .doubleTapAndHold),
+             (.holdToTalk, .holdOnly),
+             (.holdToTalk, .doubleTapAndHold):
+            return activeMode
+        case (.persistent, .holdOnly),
+             (.holdToTalk, .doubleTapOnly):
+            return nil
+        }
+    }
+
+    static func shouldSuppressPeer(
+        _ activeMode: FnKeyStateMachine.RecordingMode?,
+        for gestureMode: HotkeyGestureController.Mode
+    ) -> Bool {
+        guard activeMode != nil else { return false }
+        return resumeMode(activeMode, for: gestureMode) == nil
+    }
+
     func refreshAllHotkeys() {
         // While a recorder is active, the SettingsViewModel observer can race
         // us — skip and rely on `resume()` to rebuild from current settings.
@@ -380,7 +419,8 @@ final class AppHotkeyCoordinator {
         }
     }
 
-    private func setupAllHotkeys() {
+    func setupAllHotkeys() {
+        guard suspendCount == 0 else { return }
         setupDictationHotkeys()
         setupMeetingHotkey()
         setupFileTranscriptionHotkey()

--- a/Sources/MacParakeet/App/AppWindowCoordinator.swift
+++ b/Sources/MacParakeet/App/AppWindowCoordinator.swift
@@ -24,6 +24,7 @@ final class AppWindowCoordinator: NSObject, NSWindowDelegate {
     private let updaterController: SPUStandardUpdaterController
     private let onRecordMeeting: () -> Void
     private let onPauseToggleMeeting: (() -> Void)?
+    private let onHotkeyRecordingStateChanged: (Bool) -> Void
     private let onQuit: () -> Void
     private let isOnboardingVisible: () -> Bool
 
@@ -48,6 +49,7 @@ final class AppWindowCoordinator: NSObject, NSWindowDelegate {
         updaterController: SPUStandardUpdaterController,
         onRecordMeeting: @escaping () -> Void,
         onPauseToggleMeeting: (() -> Void)? = nil,
+        onHotkeyRecordingStateChanged: @escaping (Bool) -> Void,
         onQuit: @escaping () -> Void,
         isOnboardingVisible: @escaping () -> Bool
     ) {
@@ -69,6 +71,7 @@ final class AppWindowCoordinator: NSObject, NSWindowDelegate {
         self.updaterController = updaterController
         self.onRecordMeeting = onRecordMeeting
         self.onPauseToggleMeeting = onPauseToggleMeeting
+        self.onHotkeyRecordingStateChanged = onHotkeyRecordingStateChanged
         self.onQuit = onQuit
         self.isOnboardingVisible = isOnboardingVisible
     }
@@ -176,7 +179,8 @@ final class AppWindowCoordinator: NSObject, NSWindowDelegate {
             meetingPillViewModel: meetingPillViewModel,
             updater: updaterController.updater,
             onRecordMeeting: onRecordMeeting,
-            onPauseToggleMeeting: onPauseToggleMeeting
+            onPauseToggleMeeting: onPauseToggleMeeting,
+            onHotkeyRecordingStateChanged: onHotkeyRecordingStateChanged
         )
 
         let window = NSWindow(

--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -74,6 +74,17 @@ final class DictationFlowCoordinator {
         Self.isCapturingAudio(for: stateMachine.state)
     }
 
+    /// Mode that an active dictation hotkey manager must preserve if global
+    /// taps are rebuilt while dictation is starting or recording.
+    var hotkeyRecordingMode: FnKeyStateMachine.RecordingMode? {
+        switch stateMachine.state {
+        case .checkingEntitlements(let mode), .startingService(let mode), .recording(let mode):
+            return mode
+        case .idle, .ready, .pendingStop, .processing, .cancelCountdown, .finishing:
+            return nil
+        }
+    }
+
     static func menuBarPreference(for state: DictationFlowState) -> BreathWaveIcon.MenuBarState? {
         switch state {
         case .startingService, .recording, .pendingStop:

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -149,6 +149,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         onPauseToggleMeeting: { [weak self] in
             self?.meetingRecordingFlowCoordinator?.togglePause()
         },
+        onHotkeyRecordingStateChanged: { [weak self] isRecording in
+            // While Settings is recording a new hotkey, stand the global
+            // CGEvent taps down so they can't swallow the user's keyDown
+            // and silently fire their own actions (e.g. start a meeting
+            // recording from inside Settings).
+            if isRecording {
+                self?.hotkeyCoordinator?.suspend()
+            } else {
+                self?.hotkeyCoordinator?.resume()
+            }
+        },
         onQuit: { [weak self] in
             self?.quitApp()
         },

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -43,6 +43,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var environmentSetupTask: Task<Void, Never>?
     private var meetingQuitTask: Task<Void, Never>?
     private var speechPreWarmTask: Task<Void, Never>?
+    private var isHotkeyRecorderActive = false
     // Let first paint and onboarding routing settle before starting CoreML cache work.
     private let preWarmDeferralMs: Int = 1500
 
@@ -150,6 +151,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.meetingRecordingFlowCoordinator?.togglePause()
         },
         onHotkeyRecordingStateChanged: { [weak self] isRecording in
+            self?.isHotkeyRecorderActive = isRecording
             // While Settings is recording a new hotkey, stand the global
             // CGEvent taps down so they can't swallow the user's keyDown
             // and silently fire their own actions (e.g. start a meeting
@@ -370,6 +372,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 },
                 onRecoverPendingMeetingRecordings: { [weak self] in
                     self?.meetingRecoveryCoordinator.presentPendingMeetingRecoveryDialog()
+                },
+                isHotkeyRecordingActive: { [weak self] in
+                    self?.isHotkeyRecorderActive == true
                 }
             )
         )

--- a/Sources/MacParakeet/Views/MainWindowView.swift
+++ b/Sources/MacParakeet/Views/MainWindowView.swift
@@ -58,6 +58,9 @@ struct MainWindowView: View {
     let updater: SPUUpdater
     let onRecordMeeting: () -> Void
     let onPauseToggleMeeting: (() -> Void)?
+    /// Routed to `AppHotkeyCoordinator.suspend` / `resume` while a hotkey
+    /// recorder is active. Passed through to `SettingsView`.
+    let onHotkeyRecordingStateChanged: (Bool) -> Void
 
     var body: some View {
         VStack(spacing: 0) {
@@ -145,7 +148,12 @@ struct MainWindowView: View {
                     case .feedback:
                         FeedbackView(viewModel: feedbackViewModel)
                     case .settings:
-                        SettingsView(viewModel: settingsViewModel, llmSettingsViewModel: llmSettingsViewModel, updater: updater)
+                        SettingsView(
+                            viewModel: settingsViewModel,
+                            llmSettingsViewModel: llmSettingsViewModel,
+                            updater: updater,
+                            onHotkeyRecordingStateChanged: onHotkeyRecordingStateChanged
+                        )
                     case .discover:
                         DiscoverView(viewModel: discoverViewModel, thoughtsService: DiscoverThoughtsService())
                     }

--- a/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
+++ b/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
@@ -432,7 +432,13 @@ struct HotkeyRecorderView: View {
     }
 
     private func stopRecording() {
-        let wasActive = eventMonitor != nil
+        // Tracking against `isRecording` (the canonical UI state) keeps the
+        // (true)/(false) pair balanced even if `addLocalMonitorForEvents`
+        // returns nil — the start callback fired before the monitor was
+        // attached, so the stop callback must mirror that fact, not the
+        // monitor's presence. Also ensures spurious `onDisappear` calls
+        // don't unbalance the coordinator's suspend refcount.
+        let wasRecording = isRecording
         isRecording = false
         pendingModifierComponents = []
         candidateModifierComponents = []
@@ -441,10 +447,7 @@ struct HotkeyRecorderView: View {
             NSEvent.removeMonitor(monitor)
             eventMonitor = nil
         }
-        // Symmetric with startRecording — only fire `false` if we actually
-        // had an attached monitor, so spurious `onDisappear` calls don't
-        // unbalance the coordinator's suspend refcount.
-        if wasActive {
+        if wasRecording {
             onRecordingStateChanged?(false)
         }
     }

--- a/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
+++ b/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
@@ -16,6 +16,11 @@ struct HotkeyRecorderView: View {
     @Binding var trigger: HotkeyTrigger
     var defaultTrigger: HotkeyTrigger = .fn
     var additionalValidation: ((HotkeyTrigger) -> HotkeyTrigger.ValidationResult)? = nil
+    /// Called with `true` when an event monitor is attached and `false` when
+    /// it is torn down. Settings wires this to `AppHotkeyCoordinator.suspend`
+    /// / `resume` so the global CGEvent taps don't swallow the keyDown the
+    /// user is trying to record.
+    var onRecordingStateChanged: ((Bool) -> Void)? = nil
     @State private var isRecording = false
     @State private var validationMessage: String?
     @State private var validationIsBlocked = false
@@ -152,6 +157,11 @@ struct HotkeyRecorderView: View {
         pendingModifierComponents = []
         candidateModifierComponents = []
         self.modifierCaptureMode = modifierCaptureMode
+
+        // Suspend global hotkey taps BEFORE attaching our local monitor so
+        // existing chord/key-code listeners can't swallow the very first
+        // keyDown we're trying to capture.
+        onRecordingStateChanged?(true)
 
         eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown, .flagsChanged]) { [self] event in
             if event.type == .keyDown {
@@ -422,6 +432,7 @@ struct HotkeyRecorderView: View {
     }
 
     private func stopRecording() {
+        let wasActive = eventMonitor != nil
         isRecording = false
         pendingModifierComponents = []
         candidateModifierComponents = []
@@ -429,6 +440,12 @@ struct HotkeyRecorderView: View {
         if let monitor = eventMonitor {
             NSEvent.removeMonitor(monitor)
             eventMonitor = nil
+        }
+        // Symmetric with startRecording — only fire `false` if we actually
+        // had an attached monitor, so spurious `onDisappear` calls don't
+        // unbalance the coordinator's suspend refcount.
+        if wasActive {
+            onRecordingStateChanged?(false)
         }
     }
 

--- a/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
+++ b/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
@@ -16,10 +16,11 @@ struct HotkeyRecorderView: View {
     @Binding var trigger: HotkeyTrigger
     var defaultTrigger: HotkeyTrigger = .fn
     var additionalValidation: ((HotkeyTrigger) -> HotkeyTrigger.ValidationResult)? = nil
-    /// Called with `true` when an event monitor is attached and `false` when
-    /// it is torn down. Settings wires this to `AppHotkeyCoordinator.suspend`
-    /// / `resume` so the global CGEvent taps don't swallow the keyDown the
-    /// user is trying to record.
+    /// Called with `true` when the user enters recording mode (just before
+    /// the local NSEvent monitor is attached) and `false` when the matching
+    /// recording session ends. Settings wires this to
+    /// `AppHotkeyCoordinator.suspend` / `resume` so global CGEvent taps
+    /// don't swallow the keyDown the user is trying to record.
     var onRecordingStateChanged: ((Bool) -> Void)? = nil
     @State private var isRecording = false
     @State private var validationMessage: String?

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -5,6 +5,16 @@ import AppKit
 import MacParakeetCore
 import MacParakeetViewModels
 
+enum SettingsHotkeyConflictMessage {
+    static func disabled(conflictingWith rowName: String, trigger: HotkeyTrigger) -> String {
+        "Disabled — conflicts with \(rowName) (\(trigger.formattedLabel))."
+    }
+
+    static func blocked(conflictingWith rowName: String, trigger: HotkeyTrigger) -> String {
+        "Conflicts with \(rowName) (\(trigger.formattedLabel))."
+    }
+}
+
 struct SettingsView: View {
     @Bindable var viewModel: SettingsViewModel
     @Bindable var llmSettingsViewModel: LLMSettingsViewModel
@@ -816,15 +826,29 @@ struct SettingsView: View {
                     defaultTrigger: .disabled,
                     additionalValidation: { candidate in
                         guard !candidate.isDisabled else { return .allowed }
-                        if candidate.overlaps(with: viewModel.hotkeyTrigger)
-                            || candidate.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
-                            return .blocked("Already used by dictation.")
+                        if candidate.overlaps(with: viewModel.hotkeyTrigger) {
+                            return .blocked(SettingsHotkeyConflictMessage.blocked(
+                                conflictingWith: "hands-free mode",
+                                trigger: viewModel.hotkeyTrigger
+                            ))
+                        }
+                        if candidate.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
+                            return .blocked(SettingsHotkeyConflictMessage.blocked(
+                                conflictingWith: "push to talk",
+                                trigger: viewModel.pushToTalkHotkeyTrigger
+                            ))
                         }
                         if AppFeatures.meetingRecordingEnabled, candidate.overlaps(with: viewModel.meetingHotkeyTrigger) {
-                            return .blocked("Already used by meeting recording.")
+                            return .blocked(SettingsHotkeyConflictMessage.blocked(
+                                conflictingWith: "meeting recording",
+                                trigger: viewModel.meetingHotkeyTrigger
+                            ))
                         }
                         if candidate.overlaps(with: otherTranscriptionTrigger) {
-                            return .blocked("Already used by \(otherTranscriptionName).")
+                            return .blocked(SettingsHotkeyConflictMessage.blocked(
+                                conflictingWith: otherTranscriptionName,
+                                trigger: otherTranscriptionTrigger
+                            ))
                         }
                         return .allowed
                     },
@@ -849,16 +873,28 @@ struct SettingsView: View {
     ) -> String? {
         guard !trigger.isDisabled else { return nil }
         if trigger.overlaps(with: viewModel.hotkeyTrigger) {
-            return "Disabled — conflicts with hands-free dictation (\(viewModel.hotkeyTrigger.formattedLabel))."
+            return SettingsHotkeyConflictMessage.disabled(
+                conflictingWith: "hands-free mode",
+                trigger: viewModel.hotkeyTrigger
+            )
         }
         if trigger.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
-            return "Disabled — conflicts with push to talk (\(viewModel.pushToTalkHotkeyTrigger.formattedLabel))."
+            return SettingsHotkeyConflictMessage.disabled(
+                conflictingWith: "push to talk",
+                trigger: viewModel.pushToTalkHotkeyTrigger
+            )
         }
         if AppFeatures.meetingRecordingEnabled, trigger.overlaps(with: viewModel.meetingHotkeyTrigger) {
-            return "Disabled — conflicts with meeting recording (\(viewModel.meetingHotkeyTrigger.formattedLabel))."
+            return SettingsHotkeyConflictMessage.disabled(
+                conflictingWith: "meeting recording",
+                trigger: viewModel.meetingHotkeyTrigger
+            )
         }
         if trigger.overlaps(with: otherTranscription) {
-            return "Disabled — conflicts with \(otherTranscriptionName) (\(otherTranscription.formattedLabel))."
+            return SettingsHotkeyConflictMessage.disabled(
+                conflictingWith: otherTranscriptionName,
+                trigger: otherTranscription
+            )
         }
         return nil
     }
@@ -867,16 +903,28 @@ struct SettingsView: View {
         guard !candidate.isDisabled else { return .allowed }
         if candidate != viewModel.pushToTalkHotkeyTrigger,
            candidate.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
-            return .blocked("Overlaps with push to talk.")
+            return .blocked(SettingsHotkeyConflictMessage.blocked(
+                conflictingWith: "push to talk",
+                trigger: viewModel.pushToTalkHotkeyTrigger
+            ))
         }
         if AppFeatures.meetingRecordingEnabled, candidate.overlaps(with: viewModel.meetingHotkeyTrigger) {
-            return .blocked("Already used by meeting recording.")
+            return .blocked(SettingsHotkeyConflictMessage.blocked(
+                conflictingWith: "meeting recording",
+                trigger: viewModel.meetingHotkeyTrigger
+            ))
         }
         if candidate.overlaps(with: viewModel.fileTranscriptionHotkeyTrigger) {
-            return .blocked("Already used by file transcription.")
+            return .blocked(SettingsHotkeyConflictMessage.blocked(
+                conflictingWith: "file transcription",
+                trigger: viewModel.fileTranscriptionHotkeyTrigger
+            ))
         }
         if candidate.overlaps(with: viewModel.youtubeTranscriptionHotkeyTrigger) {
-            return .blocked("Already used by YouTube transcription.")
+            return .blocked(SettingsHotkeyConflictMessage.blocked(
+                conflictingWith: "YouTube transcription",
+                trigger: viewModel.youtubeTranscriptionHotkeyTrigger
+            ))
         }
         return .allowed
     }
@@ -885,31 +933,57 @@ struct SettingsView: View {
         guard !candidate.isDisabled else { return .allowed }
         if candidate != viewModel.hotkeyTrigger,
            candidate.overlaps(with: viewModel.hotkeyTrigger) {
-            return .blocked("Overlaps with hands-free mode.")
+            return .blocked(SettingsHotkeyConflictMessage.blocked(
+                conflictingWith: "hands-free mode",
+                trigger: viewModel.hotkeyTrigger
+            ))
         }
         if AppFeatures.meetingRecordingEnabled, candidate.overlaps(with: viewModel.meetingHotkeyTrigger) {
-            return .blocked("Already used by meeting recording.")
+            return .blocked(SettingsHotkeyConflictMessage.blocked(
+                conflictingWith: "meeting recording",
+                trigger: viewModel.meetingHotkeyTrigger
+            ))
         }
         if candidate.overlaps(with: viewModel.fileTranscriptionHotkeyTrigger) {
-            return .blocked("Already used by file transcription.")
+            return .blocked(SettingsHotkeyConflictMessage.blocked(
+                conflictingWith: "file transcription",
+                trigger: viewModel.fileTranscriptionHotkeyTrigger
+            ))
         }
         if candidate.overlaps(with: viewModel.youtubeTranscriptionHotkeyTrigger) {
-            return .blocked("Already used by YouTube transcription.")
+            return .blocked(SettingsHotkeyConflictMessage.blocked(
+                conflictingWith: "YouTube transcription",
+                trigger: viewModel.youtubeTranscriptionHotkeyTrigger
+            ))
         }
         return .allowed
     }
 
     private func meetingHotkeyValidation(for candidate: HotkeyTrigger) -> HotkeyTrigger.ValidationResult {
         guard !candidate.isDisabled else { return .allowed }
-        if candidate.overlaps(with: viewModel.hotkeyTrigger)
-            || candidate.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
-            return .blocked("Already used by dictation.")
+        if candidate.overlaps(with: viewModel.hotkeyTrigger) {
+            return .blocked(SettingsHotkeyConflictMessage.blocked(
+                conflictingWith: "hands-free mode",
+                trigger: viewModel.hotkeyTrigger
+            ))
+        }
+        if candidate.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
+            return .blocked(SettingsHotkeyConflictMessage.blocked(
+                conflictingWith: "push to talk",
+                trigger: viewModel.pushToTalkHotkeyTrigger
+            ))
         }
         if candidate.overlaps(with: viewModel.fileTranscriptionHotkeyTrigger) {
-            return .blocked("Already used by file transcription.")
+            return .blocked(SettingsHotkeyConflictMessage.blocked(
+                conflictingWith: "file transcription",
+                trigger: viewModel.fileTranscriptionHotkeyTrigger
+            ))
         }
         if candidate.overlaps(with: viewModel.youtubeTranscriptionHotkeyTrigger) {
-            return .blocked("Already used by YouTube transcription.")
+            return .blocked(SettingsHotkeyConflictMessage.blocked(
+                conflictingWith: "YouTube transcription",
+                trigger: viewModel.youtubeTranscriptionHotkeyTrigger
+            ))
         }
         return .allowed
     }
@@ -918,16 +992,28 @@ struct SettingsView: View {
         guard !trigger.isDisabled else { return nil }
         if trigger != viewModel.pushToTalkHotkeyTrigger,
            trigger.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
-            return "Disabled — overlaps with push to talk (\(viewModel.pushToTalkHotkeyTrigger.formattedLabel))."
+            return SettingsHotkeyConflictMessage.disabled(
+                conflictingWith: "push to talk",
+                trigger: viewModel.pushToTalkHotkeyTrigger
+            )
         }
         if AppFeatures.meetingRecordingEnabled, trigger.overlaps(with: viewModel.meetingHotkeyTrigger) {
-            return "Disabled — conflicts with meeting recording (\(viewModel.meetingHotkeyTrigger.formattedLabel))."
+            return SettingsHotkeyConflictMessage.disabled(
+                conflictingWith: "meeting recording",
+                trigger: viewModel.meetingHotkeyTrigger
+            )
         }
         if trigger.overlaps(with: viewModel.fileTranscriptionHotkeyTrigger) {
-            return "Disabled — conflicts with file transcription (\(viewModel.fileTranscriptionHotkeyTrigger.formattedLabel))."
+            return SettingsHotkeyConflictMessage.disabled(
+                conflictingWith: "file transcription",
+                trigger: viewModel.fileTranscriptionHotkeyTrigger
+            )
         }
         if trigger.overlaps(with: viewModel.youtubeTranscriptionHotkeyTrigger) {
-            return "Disabled — conflicts with YouTube transcription (\(viewModel.youtubeTranscriptionHotkeyTrigger.formattedLabel))."
+            return SettingsHotkeyConflictMessage.disabled(
+                conflictingWith: "YouTube transcription",
+                trigger: viewModel.youtubeTranscriptionHotkeyTrigger
+            )
         }
         return nil
     }
@@ -936,16 +1022,28 @@ struct SettingsView: View {
         guard !trigger.isDisabled else { return nil }
         if trigger != viewModel.hotkeyTrigger,
            trigger.overlaps(with: viewModel.hotkeyTrigger) {
-            return "Disabled — overlaps with hands-free mode (\(viewModel.hotkeyTrigger.formattedLabel))."
+            return SettingsHotkeyConflictMessage.disabled(
+                conflictingWith: "hands-free mode",
+                trigger: viewModel.hotkeyTrigger
+            )
         }
         if AppFeatures.meetingRecordingEnabled, trigger.overlaps(with: viewModel.meetingHotkeyTrigger) {
-            return "Disabled — conflicts with meeting recording (\(viewModel.meetingHotkeyTrigger.formattedLabel))."
+            return SettingsHotkeyConflictMessage.disabled(
+                conflictingWith: "meeting recording",
+                trigger: viewModel.meetingHotkeyTrigger
+            )
         }
         if trigger.overlaps(with: viewModel.fileTranscriptionHotkeyTrigger) {
-            return "Disabled — conflicts with file transcription (\(viewModel.fileTranscriptionHotkeyTrigger.formattedLabel))."
+            return SettingsHotkeyConflictMessage.disabled(
+                conflictingWith: "file transcription",
+                trigger: viewModel.fileTranscriptionHotkeyTrigger
+            )
         }
         if trigger.overlaps(with: viewModel.youtubeTranscriptionHotkeyTrigger) {
-            return "Disabled — conflicts with YouTube transcription (\(viewModel.youtubeTranscriptionHotkeyTrigger.formattedLabel))."
+            return SettingsHotkeyConflictMessage.disabled(
+                conflictingWith: "YouTube transcription",
+                trigger: viewModel.youtubeTranscriptionHotkeyTrigger
+            )
         }
         return nil
     }
@@ -953,16 +1051,28 @@ struct SettingsView: View {
     private func meetingHotkeyConflictMessage(for trigger: HotkeyTrigger) -> String? {
         guard !trigger.isDisabled else { return nil }
         if trigger.overlaps(with: viewModel.hotkeyTrigger) {
-            return "Disabled — conflicts with hands-free dictation (\(viewModel.hotkeyTrigger.formattedLabel))."
+            return SettingsHotkeyConflictMessage.disabled(
+                conflictingWith: "hands-free mode",
+                trigger: viewModel.hotkeyTrigger
+            )
         }
         if trigger.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
-            return "Disabled — conflicts with push to talk (\(viewModel.pushToTalkHotkeyTrigger.formattedLabel))."
+            return SettingsHotkeyConflictMessage.disabled(
+                conflictingWith: "push to talk",
+                trigger: viewModel.pushToTalkHotkeyTrigger
+            )
         }
         if trigger.overlaps(with: viewModel.fileTranscriptionHotkeyTrigger) {
-            return "Disabled — conflicts with file transcription (\(viewModel.fileTranscriptionHotkeyTrigger.formattedLabel))."
+            return SettingsHotkeyConflictMessage.disabled(
+                conflictingWith: "file transcription",
+                trigger: viewModel.fileTranscriptionHotkeyTrigger
+            )
         }
         if trigger.overlaps(with: viewModel.youtubeTranscriptionHotkeyTrigger) {
-            return "Disabled — conflicts with YouTube transcription (\(viewModel.youtubeTranscriptionHotkeyTrigger.formattedLabel))."
+            return SettingsHotkeyConflictMessage.disabled(
+                conflictingWith: "YouTube transcription",
+                trigger: viewModel.youtubeTranscriptionHotkeyTrigger
+            )
         }
         return nil
     }

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -9,6 +9,10 @@ struct SettingsView: View {
     @Bindable var viewModel: SettingsViewModel
     @Bindable var llmSettingsViewModel: LLMSettingsViewModel
     let updater: SPUUpdater
+    /// Fired by each `HotkeyRecorderView` when it starts/stops capturing
+    /// keystrokes. Wired up to `AppHotkeyCoordinator.suspend` / `resume` so
+    /// active global taps don't swallow the keyDown the user is recording.
+    let onHotkeyRecordingStateChanged: (Bool) -> Void
 
     @State private var rootViewModel = SettingsRootViewModel()
     @FocusState private var searchFieldFocused: Bool
@@ -24,10 +28,16 @@ struct SettingsView: View {
     @State private var automaticallyDownloadsUpdates: Bool
     @State private var copiedBuildIdentity = false
 
-    init(viewModel: SettingsViewModel, llmSettingsViewModel: LLMSettingsViewModel, updater: SPUUpdater) {
+    init(
+        viewModel: SettingsViewModel,
+        llmSettingsViewModel: LLMSettingsViewModel,
+        updater: SPUUpdater,
+        onHotkeyRecordingStateChanged: @escaping (Bool) -> Void
+    ) {
         self.viewModel = viewModel
         self.llmSettingsViewModel = llmSettingsViewModel
         self.updater = updater
+        self.onHotkeyRecordingStateChanged = onHotkeyRecordingStateChanged
         self._automaticallyChecksForUpdates = State(initialValue: updater.automaticallyChecksForUpdates)
         self._automaticallyDownloadsUpdates = State(initialValue: updater.automaticallyDownloadsUpdates)
     }
@@ -493,10 +503,12 @@ struct SettingsView: View {
                     VStack(alignment: .trailing, spacing: 4) {
                         HotkeyRecorderView(
                             trigger: $viewModel.pushToTalkHotkeyTrigger,
-                            defaultTrigger: .defaultPushToTalk
-                        ) { candidate in
-                            pushToTalkHotkeyValidation(for: candidate)
-                        }
+                            defaultTrigger: .defaultPushToTalk,
+                            additionalValidation: { candidate in
+                                pushToTalkHotkeyValidation(for: candidate)
+                            },
+                            onRecordingStateChanged: onHotkeyRecordingStateChanged
+                        )
 
                         if let conflict = pushToTalkHotkeyConflictMessage(for: viewModel.pushToTalkHotkeyTrigger) {
                             hotkeyConflictText(conflict)
@@ -515,10 +527,12 @@ struct SettingsView: View {
                     VStack(alignment: .trailing, spacing: 4) {
                         HotkeyRecorderView(
                             trigger: $viewModel.hotkeyTrigger,
-                            defaultTrigger: .defaultDictation
-                        ) { candidate in
-                            dictationHotkeyValidation(for: candidate)
-                        }
+                            defaultTrigger: .defaultDictation,
+                            additionalValidation: { candidate in
+                                dictationHotkeyValidation(for: candidate)
+                            },
+                            onRecordingStateChanged: onHotkeyRecordingStateChanged
+                        )
 
                         if let conflict = dictationHotkeyConflictMessage(for: viewModel.hotkeyTrigger) {
                             hotkeyConflictText(conflict)
@@ -600,10 +614,12 @@ struct SettingsView: View {
                     VStack(alignment: .trailing, spacing: 4) {
                         HotkeyRecorderView(
                             trigger: $viewModel.meetingHotkeyTrigger,
-                            defaultTrigger: .defaultMeetingRecording
-                        ) { candidate in
-                            meetingHotkeyValidation(for: candidate)
-                        }
+                            defaultTrigger: .defaultMeetingRecording,
+                            additionalValidation: { candidate in
+                                meetingHotkeyValidation(for: candidate)
+                            },
+                            onRecordingStateChanged: onHotkeyRecordingStateChanged
+                        )
 
                         if let conflict = meetingHotkeyConflictMessage(for: viewModel.meetingHotkeyTrigger) {
                             hotkeyConflictText(conflict)
@@ -797,21 +813,23 @@ struct SettingsView: View {
             VStack(alignment: .trailing, spacing: 4) {
                 HotkeyRecorderView(
                     trigger: trigger,
-                    defaultTrigger: .disabled
-                ) { candidate in
-                    guard !candidate.isDisabled else { return .allowed }
-                    if candidate.overlaps(with: viewModel.hotkeyTrigger)
-                        || candidate.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
-                        return .blocked("Already used by dictation.")
-                    }
-                    if AppFeatures.meetingRecordingEnabled, candidate.overlaps(with: viewModel.meetingHotkeyTrigger) {
-                        return .blocked("Already used by meeting recording.")
-                    }
-                    if candidate.overlaps(with: otherTranscriptionTrigger) {
-                        return .blocked("Already used by \(otherTranscriptionName).")
-                    }
-                    return .allowed
-                }
+                    defaultTrigger: .disabled,
+                    additionalValidation: { candidate in
+                        guard !candidate.isDisabled else { return .allowed }
+                        if candidate.overlaps(with: viewModel.hotkeyTrigger)
+                            || candidate.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
+                            return .blocked("Already used by dictation.")
+                        }
+                        if AppFeatures.meetingRecordingEnabled, candidate.overlaps(with: viewModel.meetingHotkeyTrigger) {
+                            return .blocked("Already used by meeting recording.")
+                        }
+                        if candidate.overlaps(with: otherTranscriptionTrigger) {
+                            return .blocked("Already used by \(otherTranscriptionName).")
+                        }
+                        return .allowed
+                    },
+                    onRecordingStateChanged: onHotkeyRecordingStateChanged
+                )
 
                 if let conflict = conflictMessage(
                     trigger: trigger.wrappedValue,
@@ -830,15 +848,17 @@ struct SettingsView: View {
         otherTranscriptionName: String
     ) -> String? {
         guard !trigger.isDisabled else { return nil }
-        if trigger.overlaps(with: viewModel.hotkeyTrigger)
-            || trigger.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
-            return "Disabled — conflicts with dictation hotkey."
+        if trigger.overlaps(with: viewModel.hotkeyTrigger) {
+            return "Disabled — conflicts with hands-free dictation (\(viewModel.hotkeyTrigger.formattedLabel))."
+        }
+        if trigger.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
+            return "Disabled — conflicts with push to talk (\(viewModel.pushToTalkHotkeyTrigger.formattedLabel))."
         }
         if AppFeatures.meetingRecordingEnabled, trigger.overlaps(with: viewModel.meetingHotkeyTrigger) {
-            return "Disabled — conflicts with meeting recording hotkey."
+            return "Disabled — conflicts with meeting recording (\(viewModel.meetingHotkeyTrigger.formattedLabel))."
         }
         if trigger.overlaps(with: otherTranscription) {
-            return "Disabled — conflicts with \(otherTranscriptionName) hotkey."
+            return "Disabled — conflicts with \(otherTranscriptionName) (\(otherTranscription.formattedLabel))."
         }
         return nil
     }
@@ -898,16 +918,16 @@ struct SettingsView: View {
         guard !trigger.isDisabled else { return nil }
         if trigger != viewModel.pushToTalkHotkeyTrigger,
            trigger.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
-            return "Disabled — overlaps with push to talk."
+            return "Disabled — overlaps with push to talk (\(viewModel.pushToTalkHotkeyTrigger.formattedLabel))."
         }
         if AppFeatures.meetingRecordingEnabled, trigger.overlaps(with: viewModel.meetingHotkeyTrigger) {
-            return "Disabled — conflicts with meeting recording hotkey."
+            return "Disabled — conflicts with meeting recording (\(viewModel.meetingHotkeyTrigger.formattedLabel))."
         }
         if trigger.overlaps(with: viewModel.fileTranscriptionHotkeyTrigger) {
-            return "Disabled — conflicts with file transcription hotkey."
+            return "Disabled — conflicts with file transcription (\(viewModel.fileTranscriptionHotkeyTrigger.formattedLabel))."
         }
         if trigger.overlaps(with: viewModel.youtubeTranscriptionHotkeyTrigger) {
-            return "Disabled — conflicts with YouTube transcription hotkey."
+            return "Disabled — conflicts with YouTube transcription (\(viewModel.youtubeTranscriptionHotkeyTrigger.formattedLabel))."
         }
         return nil
     }
@@ -916,31 +936,33 @@ struct SettingsView: View {
         guard !trigger.isDisabled else { return nil }
         if trigger != viewModel.hotkeyTrigger,
            trigger.overlaps(with: viewModel.hotkeyTrigger) {
-            return "Disabled — overlaps with hands-free mode."
+            return "Disabled — overlaps with hands-free mode (\(viewModel.hotkeyTrigger.formattedLabel))."
         }
         if AppFeatures.meetingRecordingEnabled, trigger.overlaps(with: viewModel.meetingHotkeyTrigger) {
-            return "Disabled — conflicts with meeting recording hotkey."
+            return "Disabled — conflicts with meeting recording (\(viewModel.meetingHotkeyTrigger.formattedLabel))."
         }
         if trigger.overlaps(with: viewModel.fileTranscriptionHotkeyTrigger) {
-            return "Disabled — conflicts with file transcription hotkey."
+            return "Disabled — conflicts with file transcription (\(viewModel.fileTranscriptionHotkeyTrigger.formattedLabel))."
         }
         if trigger.overlaps(with: viewModel.youtubeTranscriptionHotkeyTrigger) {
-            return "Disabled — conflicts with YouTube transcription hotkey."
+            return "Disabled — conflicts with YouTube transcription (\(viewModel.youtubeTranscriptionHotkeyTrigger.formattedLabel))."
         }
         return nil
     }
 
     private func meetingHotkeyConflictMessage(for trigger: HotkeyTrigger) -> String? {
         guard !trigger.isDisabled else { return nil }
-        if trigger.overlaps(with: viewModel.hotkeyTrigger)
-            || trigger.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
-            return "Disabled — conflicts with dictation hotkey."
+        if trigger.overlaps(with: viewModel.hotkeyTrigger) {
+            return "Disabled — conflicts with hands-free dictation (\(viewModel.hotkeyTrigger.formattedLabel))."
+        }
+        if trigger.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
+            return "Disabled — conflicts with push to talk (\(viewModel.pushToTalkHotkeyTrigger.formattedLabel))."
         }
         if trigger.overlaps(with: viewModel.fileTranscriptionHotkeyTrigger) {
-            return "Disabled — conflicts with file transcription hotkey."
+            return "Disabled — conflicts with file transcription (\(viewModel.fileTranscriptionHotkeyTrigger.formattedLabel))."
         }
         if trigger.overlaps(with: viewModel.youtubeTranscriptionHotkeyTrigger) {
-            return "Disabled — conflicts with YouTube transcription hotkey."
+            return "Disabled — conflicts with YouTube transcription (\(viewModel.youtubeTranscriptionHotkeyTrigger.formattedLabel))."
         }
         return nil
     }

--- a/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
@@ -154,4 +154,86 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
             AppHotkeyCoordinator.DictationHotkeyPlan(specs: [], conflict: nil)
         )
     }
+
+    // MARK: - Suspend / Resume
+
+    func testSuspendAndResumeArePaired() {
+        let viewModel = makeViewModel()
+        let coordinator = makeCoordinator(
+            settingsViewModel: viewModel,
+            onHotkeyConflict: { _, _ in }
+        )
+
+        XCTAssertEqual(coordinator.suspendCountForTesting, 0)
+
+        coordinator.suspend()
+        XCTAssertEqual(coordinator.suspendCountForTesting, 1)
+
+        coordinator.resume()
+        XCTAssertEqual(coordinator.suspendCountForTesting, 0)
+    }
+
+    func testSuspendNestsAndResumeUnwinds() {
+        let viewModel = makeViewModel()
+        let coordinator = makeCoordinator(
+            settingsViewModel: viewModel,
+            onHotkeyConflict: { _, _ in }
+        )
+
+        coordinator.suspend()
+        coordinator.suspend()
+        XCTAssertEqual(coordinator.suspendCountForTesting, 2)
+
+        coordinator.resume()
+        XCTAssertEqual(coordinator.suspendCountForTesting, 1)
+
+        coordinator.resume()
+        XCTAssertEqual(coordinator.suspendCountForTesting, 0)
+    }
+
+    func testResumeWithoutSuspendIsNoop() {
+        let viewModel = makeViewModel()
+        let coordinator = makeCoordinator(
+            settingsViewModel: viewModel,
+            onHotkeyConflict: { _, _ in }
+        )
+
+        coordinator.resume()
+        coordinator.resume()
+        XCTAssertEqual(coordinator.suspendCountForTesting, 0)
+    }
+
+    func testRefreshAllHotkeysIsSkippedWhileSuspended() {
+        // The SettingsViewModel observer in AppDelegate calls
+        // refreshAllHotkeys / refreshMeetingHotkey when the user records a
+        // new trigger. That call would race resume() and double-restart the
+        // taps — guarded by `suspendCount == 0`. This test pins the guard.
+        let viewModel = makeViewModel()
+        var conflictReports = 0
+        let coordinator = makeCoordinator(
+            settingsViewModel: viewModel,
+            onHotkeyConflict: { _, _ in conflictReports += 1 }
+        )
+
+        viewModel.meetingHotkeyTrigger = .defaultMeetingRecording
+        viewModel.pushToTalkHotkeyTrigger = HotkeyTrigger(
+            kind: .modifier,
+            modifierName: "command",
+            keyCode: nil,
+            modifierKeyCode: 54
+        )
+
+        coordinator.suspend()
+        coordinator.refreshAllHotkeys()
+        coordinator.refreshMeetingHotkey()
+        coordinator.refreshFileTranscriptionHotkey()
+        coordinator.refreshYouTubeTranscriptionHotkey()
+
+        // None of the refreshers should have reported a conflict, because
+        // they should have short-circuited before reaching the conflict
+        // detection inside setupMeetingHotkey.
+        XCTAssertEqual(conflictReports, 0)
+
+        coordinator.resume()
+    }
 }

--- a/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
@@ -236,4 +236,56 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
         coordinator.resume()
         XCTAssertEqual(conflictReports, 1, "resume() must rebuild taps from current settings")
     }
+
+    func testSetupAllHotkeysIsDeferredWhileSuspended() {
+        let viewModel = makeViewModel()
+        let conflictingTrigger = HotkeyTrigger.modifierChord(modifiers: ["command", "option"])
+        viewModel.hotkeyTrigger = .disabled
+        viewModel.pushToTalkHotkeyTrigger = .disabled
+        viewModel.meetingHotkeyTrigger = .disabled
+        viewModel.fileTranscriptionHotkeyTrigger = conflictingTrigger
+        viewModel.youtubeTranscriptionHotkeyTrigger = conflictingTrigger
+        var conflictReports = 0
+        let coordinator = makeCoordinator(
+            settingsViewModel: viewModel,
+            onHotkeyConflict: { _, _ in conflictReports += 1 }
+        )
+
+        coordinator.suspend()
+        coordinator.setupAllHotkeys()
+        XCTAssertEqual(conflictReports, 0)
+
+        coordinator.resume()
+        XCTAssertEqual(conflictReports, 2)
+    }
+
+    func testResumeModeMatchesActiveDictationRole() {
+        XCTAssertEqual(
+            AppHotkeyCoordinator.resumeMode(.persistent, for: .doubleTapOnly),
+            .persistent
+        )
+        XCTAssertFalse(AppHotkeyCoordinator.shouldSuppressPeer(.persistent, for: .doubleTapOnly))
+        XCTAssertEqual(
+            AppHotkeyCoordinator.resumeMode(.persistent, for: .doubleTapAndHold),
+            .persistent
+        )
+        XCTAssertFalse(AppHotkeyCoordinator.shouldSuppressPeer(.persistent, for: .doubleTapAndHold))
+        XCTAssertNil(AppHotkeyCoordinator.resumeMode(.persistent, for: .holdOnly))
+        XCTAssertTrue(AppHotkeyCoordinator.shouldSuppressPeer(.persistent, for: .holdOnly))
+
+        XCTAssertEqual(
+            AppHotkeyCoordinator.resumeMode(.holdToTalk, for: .holdOnly),
+            .holdToTalk
+        )
+        XCTAssertFalse(AppHotkeyCoordinator.shouldSuppressPeer(.holdToTalk, for: .holdOnly))
+        XCTAssertEqual(
+            AppHotkeyCoordinator.resumeMode(.holdToTalk, for: .doubleTapAndHold),
+            .holdToTalk
+        )
+        XCTAssertFalse(AppHotkeyCoordinator.shouldSuppressPeer(.holdToTalk, for: .doubleTapAndHold))
+        XCTAssertNil(AppHotkeyCoordinator.resumeMode(.holdToTalk, for: .doubleTapOnly))
+        XCTAssertTrue(AppHotkeyCoordinator.shouldSuppressPeer(.holdToTalk, for: .doubleTapOnly))
+        XCTAssertNil(AppHotkeyCoordinator.resumeMode(nil, for: .doubleTapAndHold))
+        XCTAssertFalse(AppHotkeyCoordinator.shouldSuppressPeer(nil, for: .doubleTapAndHold))
+    }
 }

--- a/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
@@ -207,7 +207,10 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
         // The SettingsViewModel observer in AppDelegate calls
         // refreshAllHotkeys / refreshMeetingHotkey when the user records a
         // new trigger. That call would race resume() and double-restart the
-        // taps — guarded by `suspendCount == 0`. This test pins the guard.
+        // taps — guarded by `suspendCount == 0`. This test pins both halves:
+        // refresh* short-circuits during suspension (no conflict reports
+        // appear), and resume() actually rebuilds from current settings
+        // (the same conflict is reported exactly once after resume).
         let viewModel = makeViewModel()
         var conflictReports = 0
         let coordinator = makeCoordinator(
@@ -228,12 +231,9 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
         coordinator.refreshMeetingHotkey()
         coordinator.refreshFileTranscriptionHotkey()
         coordinator.refreshYouTubeTranscriptionHotkey()
-
-        // None of the refreshers should have reported a conflict, because
-        // they should have short-circuited before reaching the conflict
-        // detection inside setupMeetingHotkey.
-        XCTAssertEqual(conflictReports, 0)
+        XCTAssertEqual(conflictReports, 0, "refresh* must short-circuit while suspended")
 
         coordinator.resume()
+        XCTAssertEqual(conflictReports, 1, "resume() must rebuild taps from current settings")
     }
 }

--- a/Tests/MacParakeetTests/Views/Settings/SettingsHotkeyConflictMessageTests.swift
+++ b/Tests/MacParakeetTests/Views/Settings/SettingsHotkeyConflictMessageTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+import MacParakeetCore
+@testable import MacParakeet
+
+final class SettingsHotkeyConflictMessageTests: XCTestCase {
+    func testDisabledConflictMessageNamesRowAndFormattedLabel() {
+        let trigger = HotkeyTrigger(
+            kind: .modifier,
+            modifierName: "command",
+            keyCode: nil,
+            modifierKeyCode: 54
+        )
+
+        XCTAssertEqual(
+            SettingsHotkeyConflictMessage.disabled(conflictingWith: "push to talk", trigger: trigger),
+            "Disabled — conflicts with push to talk (R⌘ Right Command)."
+        )
+    }
+
+    func testBlockedConflictMessageNamesRowAndFormattedLabel() {
+        XCTAssertEqual(
+            SettingsHotkeyConflictMessage.blocked(
+                conflictingWith: "meeting recording",
+                trigger: .defaultMeetingRecording
+            ),
+            "Conflicts with meeting recording (⇧⌘M)."
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Fixes [#263](https://github.com/moona3k/macparakeet/issues/263). When the user opens **Settings → Meeting hotkey → Change…** and presses the chord that's *currently* set as a hotkey, three things were silently going wrong:

- The existing global tap matched the chord and **started a meeting recording in the background**.
- That same tap **swallowed** the key the user was trying to record.
- The recorder gave up on the missing keyDown and **persisted the wrong value** (a modifier-only chord) instead.

Plus a confused conflict warning ("Already used by dictation") that didn't say which dictation row.

## Before / after

```
BEFORE
─────────────────────────────────────────────────────────────────────
  Settings: Meeting hotkey  ⇧⌘M  [ Change… ]
                              │
       user presses ⌘⇧M ─────┤
                              │
                   ┌──────────▼──────────┐
                   │ Global CGEvent tap  │   <— matches active chord
                   │   onTrigger() ─────────→  meeting recording starts (silent)
                   │   return nil (swallow)
                   └──────────┬──────────┘
                              │  keyDown gone
                   ┌──────────▼──────────┐
                   │ NSEvent local mon.  │   <— only sees modifiers
                   │  pending = ⌘⇧       │
                   │  on release → commit modifierChord ⌘⇧  ✗
                   └─────────────────────┘

AFTER
─────────────────────────────────────────────────────────────────────
  user clicks Change…
       │
       ▼
  HotkeyRecorderView.startRecording
       │ onRecordingStateChanged(true)
       ▼
  AppHotkeyCoordinator.suspend()   ── stopAll() ──→  taps off
       │
       │   user presses ⌘⇧M
       ▼
  NSEvent local monitor sees the full chord
       │
       ▼  acceptTrigger(⇧⌘M)        ── trigger persisted, recorder closes
       │ onRecordingStateChanged(false)
       ▼
  AppHotkeyCoordinator.resume()    ── setupAllHotkeys() ──→  taps back on
                                    (rebuilt from current SettingsViewModel,
                                     so the new ⇧⌘M is live immediately)
```

## What's in the change

- **`AppHotkeyCoordinator`** — refcounted \`suspend()\` / \`resume()\`. While suspended, the four \`refresh*\` methods short-circuit so the \`SettingsViewModel\` observer can't race the recorder's teardown.
- **\`HotkeyRecorderView\`** — new \`onRecordingStateChanged\` closure, fired \`(true)\` once the NSEvent monitor is attached and \`(false)\` only when an attached monitor is actually torn down (so stray \`onDisappear\` calls don't unbalance the refcount).
- **Plumbing** — drilled the callback through \`SettingsView\` → \`MainWindowView\` → \`AppWindowCoordinator\` → \`AppDelegate\`, where it routes to suspend/resume. Same pattern as the existing \`onRecordMeeting\`.
- **Conflict text** — \`Disabled — conflicts with dictation hotkey\` was vague when the user had distinct push-to-talk and hands-free rows. Now names the specific row + its formatted label, e.g.:

```
Disabled — conflicts with push to talk (R⌘ Right Command).
```

## Tests

\`swift test\` — 2441 tests, 0 failures, 10 skipped.

New coordinator coverage:

| Test | Verifies |
| --- | --- |
| \`testSuspendAndResumeArePaired\` | balanced suspend/resume zeroes the refcount |
| \`testSuspendNestsAndResumeUnwinds\` | nested calls don't desync |
| \`testResumeWithoutSuspendIsNoop\` | unbalanced resume is harmless |
| \`testRefreshAllHotkeysIsSkippedWhileSuspended\` | the observer-vs-resume race is closed |

## Test plan

- [ ] Set dictation to **Right Command**, leave meeting at default **⌘⇧M**. Click **Reset to Default** on Meeting → row now says \`Disabled — conflicts with push to talk (R⌘ Right Command).\` (was: \`Already used by dictation.\`)
- [ ] With meeting set to **⌘⇧M**, click **Change…** on meeting, press **⌘⇧M** → recorder accepts **⌘⇧M**, no background meeting recording starts, the new value persists.
- [ ] Repeat with dictation hotkey, file transcription hotkey, YouTube transcription hotkey — each recorder should now capture any chord cleanly, including one that overlaps the currently-active trigger.
- [ ] Press **Esc** mid-record → recorder closes, original hotkey reactivates.
- [ ] Close Settings tab mid-record (\`onDisappear\`) → recorder cleans up, no resume callback fires twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where global hotkeys could interfere with recording new hotkeys in the Settings panel
  * Enhanced hotkey conflict detection messages to clearly identify which hotkey is causing the conflict

* **Tests**
  * Added comprehensive test coverage for hotkey suspension and resumption functionality

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moona3k/macparakeet/pull/266)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->