### PR TITLE
Fix macOS 14.x crash loop in Observability.withOperationContext

### DIFF
--- a/Sources/MacParakeetCore/Services/Telemetry/Observability.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/Observability.swift
@@ -51,7 +51,22 @@ public enum Observability {
         isolation: isolated (any Actor)? = #isolation,
         operation: () async throws -> T
     ) async rethrows -> T {
-        try await $currentOperationContext.withValue(context, operation: operation, isolation: isolation)
+        if #available(macOS 15.0, *) {
+            return try await $currentOperationContext.withValue(
+                context,
+                operation: operation,
+                isolation: isolation
+            )
+        } else {
+            // macOS 14.x: skip the TaskLocal binding to avoid the Swift 6
+            // back-deployment shim for `TaskLocal.withValue(_:operation:isolation:)`,
+            // which a v0.6.4 crash cluster traces to. Children that call
+            // `childOperationContext()` will start a fresh workflow root;
+            // parent-child telemetry stitching weakens on macOS 14.x but the
+            // app no longer crashes.
+            // See journal/2026-05-11-v0.6.4-macos14-taskdealloc-crash-loop.md.
+            return try await operation()
+        }
     }
 
     public static func childOperationContext(startedAt: Date = Date()) -> ObservabilityOperationContext {

--- a/Sources/MacParakeetCore/Services/Telemetry/Observability.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/Observability.swift
@@ -46,12 +46,12 @@ public struct ObservabilityOperationContext: Sendable, Equatable {
 public enum Observability {
     @TaskLocal public static var currentOperationContext: ObservabilityOperationContext?
 
-    public static func withOperationContext<T>(
+    public static func withOperationContext<T: Sendable>(
         _ context: ObservabilityOperationContext,
         isolation: isolated (any Actor)? = #isolation,
         operation: () async throws -> T
     ) async rethrows -> T {
-        if #available(macOS 15.0, *) {
+        if #available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {
             return try await $currentOperationContext.withValue(
                 context,
                 operation: operation,


### PR DESCRIPTION
## Summary
- Gates `$currentOperationContext.withValue(_:operation:isolation:)` behind `if #available(macOS 15.0, *)`. macOS 14.x falls back to running the closure directly without installing the TaskLocal.

**User-facing issue:** #268 — fixed in v0.6.5.

## Post-merge outcome
- Merged in `acc658f0` and shipped in [v0.6.5](https://github.com/moona3k/macparakeet/releases/tag/v0.6.5).
- v0.6.5 was built, signed, notarized, published to Sparkle, and issue #268 was closed after release.
- The regression was triggered by the v0.6.4 release build environment: after an Xcode / Command Line Tools update, the newer Apple Swift / SDK toolchain emitted a different macOS 14 back-deployment path for an existing Swift `TaskLocal.withValue(... isolation:)` call.
- The missed Sonoma smoke test let the regression ship, but the crash itself appears to be a Swift toolchain/back-deployment compatibility issue. This PR avoids that generated runtime path on macOS 14.x.

## Why
v0.6.4 telemetry shows a binary new-user funnel split on macOS major version:

| outcome | profiles | macOS bucket |
| --- | --- | --- |
| Onboarded + ≥1 `dictation_completed` | 13 | all macOS 15.x / 26.x |
| Onboarded, never tried dictating | 3 | all macOS 15.x / 26.x |
| Started dictation, 0 completed | 3 | all macOS 26.4 (no crashes) |
| Didn't complete onboarding | 3 | all macOS 15.x / 26.x |
| **Catastrophic crash loop** | **2** | **GB / 14.5 + MX / 14.6** |

12 `crash_occurred` events on v0.6.4 — all from those 2 macOS 14.x users, all SIGABRT, all landing at `DictationService.swift:535` (the `Observability.withOperationContext` call) after subtracting ASLR slide. Zero crashes from non-macOS-14.x users.

Local release-artifact diff isolates the cause:
- v0.6.0 / v0.6.1 / v0.6.2 built with **Apple Swift 6.2.1 / SDK 26.1** — emit the older, non-crashing macOS-14 fallback.
- v0.6.4 built with **Apple Swift 6.3.1 / SDK 26.4** — emits a new fallback shape where `_swift_task_dealloc` is called immediately after `_swift_task_localValuePush`, and the crash return address sits right after that `_swift_task_dealloc`.

Source-level `isolation: isolated (any Actor)? = #isolation` has existed since `a1b49ec1` (v0.6.0); the emission changed with the toolchain. Skipping the buggy `TaskLocal.withValue(...isolation:)` call on macOS 14 sidesteps the shim entirely.

## What the fallback gives up
- `Observability.currentOperationContext` is not set during the operation on macOS 14.
- Downstream `Observability.childOperationContext()` reads (in `STTRuntime`, `TranscriptionService`, `AutoSaveService`) fall back to fresh workflow roots instead of stitching to the parent operation.
- Net effect: telemetry workflow IDs lose parent-child linkage on macOS 14 — annoying for analysis, harmless for users. No behavioral or correctness change in the dictation / transcription flow.

## Risk acknowledgment
This ships **without a reproduction** on a macOS 14 machine. The artifact diff is strong evidence that the back-deployment shim is the cause, but the fix has not been runtime-verified. If macOS 14 users still hit the same `DictationService:535` signature in v0.6.5 telemetry, the next step is bisecting `33634a0f` (first-load caption / STT pre-warm) and `1a46663b` (watchdog probe) on the v0.6.3 commit.

The fallback path is strictly more conservative than the broken code — it cannot introduce a new crash mode on macOS 14, and it has no effect on macOS 15+. Worst case is "v0.6.5 macOS 14 users still crash and we ship v0.6.6," not "we regress macOS 15+."

## Test plan
- [x] `swift test` — 2437 XCTest pass (10 skipped), 16 Swift Testing pass on host (macOS 26.x, Swift 6.3.1).
- [ ] Manual smoke on macOS 14.5 or 14.6 if a machine becomes accessible before release.
- [ ] **Post-release telemetry check:** re-run the v0.6.4 newly-onboarded funnel query against v0.6.5 24h after appcast promotion. If any macOS 14.x user crashes with the same DictationService:535 signature, the hypothesis is wrong and we bisect.
- [ ] Close #268 once v0.6.5 is shipped + verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
