### PR TITLE
Split LLM provider-unavailable telemetry from real failures

### DIFF
--- a/Sources/MacParakeetCore/Services/LLM/LLMService.swift
+++ b/Sources/MacParakeetCore/Services/LLM/LLMService.swift
@@ -186,8 +186,17 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                     messageCount: messages.count
                 )
             } else {
+                let kind = Self.errorType(for: error)
                 // No errorDetail for LLM errors — API responses may echo user transcript/prompt content
-                Telemetry.send(.llmPromptResultFailed(provider: config.id.rawValue, errorType: Self.errorType(for: error)))
+                if Self.isProviderUnavailable(error) {
+                    Telemetry.send(.llmProviderUnavailable(
+                        provider: config.id.rawValue,
+                        errorType: kind,
+                        feature: .promptResult
+                    ))
+                } else {
+                    Telemetry.send(.llmPromptResultFailed(provider: config.id.rawValue, errorType: kind))
+                }
                 sendLLMOperation(
                     operationID: operationID,
                     feature: "prompt_result",
@@ -199,7 +208,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                     inputTruncated: transcript.count > budget,
                     promptDefaultUsed: promptDefaultUsed,
                     messageCount: messages.count,
-                    errorType: Self.errorType(for: error)
+                    errorType: kind
                 )
             }
             throw error
@@ -251,8 +260,17 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                     messageCount: history.count + 1
                 )
             } else {
+                let kind = Self.errorType(for: error)
                 // No errorDetail for LLM errors — API responses may echo user transcript/prompt content
-                Telemetry.send(.llmChatFailed(provider: config.id.rawValue, errorType: Self.errorType(for: error)))
+                if Self.isProviderUnavailable(error) {
+                    Telemetry.send(.llmProviderUnavailable(
+                        provider: config.id.rawValue,
+                        errorType: kind,
+                        feature: .chat
+                    ))
+                } else {
+                    Telemetry.send(.llmChatFailed(provider: config.id.rawValue, errorType: kind))
+                }
                 sendLLMOperation(
                     operationID: operationID,
                     feature: "chat",
@@ -263,7 +281,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                     inputChars: question.count + transcript.count,
                     inputTruncated: transcript.count > budget,
                     messageCount: history.count + 1,
-                    errorType: Self.errorType(for: error)
+                    errorType: kind
                 )
             }
             throw error
@@ -319,8 +337,17 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                     messageCount: messages.count
                 )
             } else {
+                let kind = Self.errorType(for: error)
                 // No errorDetail for LLM errors — API responses may echo user transcript/prompt content
-                Telemetry.send(.llmTransformFailed(provider: config.id.rawValue, errorType: Self.errorType(for: error)))
+                if Self.isProviderUnavailable(error) {
+                    Telemetry.send(.llmProviderUnavailable(
+                        provider: config.id.rawValue,
+                        errorType: kind,
+                        feature: .transform
+                    ))
+                } else {
+                    Telemetry.send(.llmTransformFailed(provider: config.id.rawValue, errorType: kind))
+                }
                 sendLLMOperation(
                     operationID: operationID,
                     feature: "transform",
@@ -331,7 +358,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                     inputChars: text.count + prompt.count,
                     inputTruncated: text.count > budget,
                     messageCount: messages.count,
-                    errorType: Self.errorType(for: error)
+                    errorType: kind
                 )
             }
             throw error
@@ -449,15 +476,25 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                     messageCount: 2
                 )
             } else {
+                let kind = Self.errorType(for: error)
                 // No errorDetail for LLM errors — API responses may echo user transcript/prompt content
-                Telemetry.send(.llmFormatterFailed(
-                    provider: config.id.rawValue,
-                    source: source,
-                    durationSeconds: Date().timeIntervalSince(startedAt),
-                    errorType: Self.errorType(for: error),
-                    defaultPromptUsed: defaultPromptUsed,
-                    inputTruncated: inputTruncated
-                ))
+                if Self.isProviderUnavailable(error) {
+                    Telemetry.send(.llmProviderUnavailable(
+                        provider: config.id.rawValue,
+                        errorType: kind,
+                        feature: .formatter,
+                        source: source
+                    ))
+                } else {
+                    Telemetry.send(.llmFormatterFailed(
+                        provider: config.id.rawValue,
+                        source: source,
+                        durationSeconds: Date().timeIntervalSince(startedAt),
+                        errorType: kind,
+                        defaultPromptUsed: defaultPromptUsed,
+                        inputTruncated: inputTruncated
+                    ))
+                }
                 sendLLMOperation(
                     operationID: operationID,
                     feature: "formatter_\(source.rawValue)",
@@ -469,7 +506,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                     inputTruncated: inputTruncated,
                     promptDefaultUsed: defaultPromptUsed,
                     messageCount: 2,
-                    errorType: Self.errorType(for: error)
+                    errorType: kind
                 )
             }
             throw error
@@ -537,11 +574,20 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                     continuation.finish()
                 } catch {
                     if !(error is CancellationError) {
+                        let kind = Self.errorType(for: error)
                         // No errorDetail for LLM errors — API responses may echo user transcript/prompt content
-                        Telemetry.send(.llmPromptResultFailed(
-                            provider: provider,
-                            errorType: Self.errorType(for: error)
-                        ))
+                        if Self.isProviderUnavailable(error) {
+                            Telemetry.send(.llmProviderUnavailable(
+                                provider: provider,
+                                errorType: kind,
+                                feature: .promptResult
+                            ))
+                        } else {
+                            Telemetry.send(.llmPromptResultFailed(
+                                provider: provider,
+                                errorType: kind
+                            ))
+                        }
                     }
                     if provider != "unknown" {
                         self.sendLLMOperation(
@@ -618,11 +664,20 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                     continuation.finish()
                 } catch {
                     if !(error is CancellationError) {
+                        let kind = Self.errorType(for: error)
                         // No errorDetail for LLM errors — API responses may echo user transcript/prompt content
-                        Telemetry.send(.llmChatFailed(
-                            provider: provider,
-                            errorType: Self.errorType(for: error)
-                        ))
+                        if Self.isProviderUnavailable(error) {
+                            Telemetry.send(.llmProviderUnavailable(
+                                provider: provider,
+                                errorType: kind,
+                                feature: .chat
+                            ))
+                        } else {
+                            Telemetry.send(.llmChatFailed(
+                                provider: provider,
+                                errorType: kind
+                            ))
+                        }
                     }
                     if provider != "unknown" {
                         self.sendLLMOperation(
@@ -702,11 +757,20 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                     continuation.finish()
                 } catch {
                     if !(error is CancellationError) {
+                        let kind = Self.errorType(for: error)
                         // No errorDetail for LLM errors — API responses may echo user transcript/prompt content
-                        Telemetry.send(.llmTransformFailed(
-                            provider: provider,
-                            errorType: Self.errorType(for: error)
-                        ))
+                        if Self.isProviderUnavailable(error) {
+                            Telemetry.send(.llmProviderUnavailable(
+                                provider: provider,
+                                errorType: kind,
+                                feature: .transform
+                            ))
+                        } else {
+                            Telemetry.send(.llmTransformFailed(
+                                provider: provider,
+                                errorType: kind
+                            ))
+                        }
                     }
                     if provider != "unknown" {
                         self.sendLLMOperation(
@@ -806,6 +870,23 @@ public final class LLMService: LLMServiceProtocol, Sendable {
 
     private static func operationErrorType(for error: Error) -> String? {
         error is CancellationError ? nil : errorType(for: error)
+    }
+
+    /// True if `error` represents a drifted user environment rather than an
+    /// app/provider failure: the local LLM stopped running, the configured
+    /// model name no longer exists, a CLI tool is missing, or an API key is
+    /// invalid. These should be tagged as `llm_provider_unavailable` so the
+    /// `llm_*_failed` dashboards reflect failures actually worth
+    /// investigating, not "your Ollama isn't running."
+    private static func isProviderUnavailable(_ error: Error) -> Bool {
+        guard let llmError = error as? LLMError else { return false }
+        switch llmError {
+        case .connectionFailed, .modelNotFound, .cliError, .authenticationFailed:
+            return true
+        case .notConfigured, .rateLimited, .contextTooLong, .formatterTruncated,
+             .formatterEmptyResponse, .providerError, .streamingError, .invalidResponse:
+            return false
+        }
     }
 
     private static func outcomeForLLMSetupError(_ error: Error) -> ObservabilityOutcome {

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -28,6 +28,7 @@ public enum TelemetryEventName: String, Sendable, CaseIterable {
     case llmTransformFailed = "llm_transform_failed"
     case llmFormatterUsed = "llm_formatter_used"
     case llmFormatterFailed = "llm_formatter_failed"
+    case llmProviderUnavailable = "llm_provider_unavailable"
     case llmOperation = "llm_operation"
     case historySearched = "history_searched"
     case historyReplayed = "history_replayed"
@@ -175,6 +176,17 @@ public enum TelemetryCopySource: String, Sendable, Equatable {
 public enum TelemetryFormatterSource: String, Sendable, Equatable {
     case dictation
     case transcription
+}
+
+/// Which LLM call site produced a `llm_provider_unavailable` event. Lets a
+/// single event cover all the LLM entry points while still answering
+/// "which feature was the user trying to use when their provider wasn't
+/// reachable?" without minting four near-identical event names.
+public enum TelemetryLLMFeature: String, Sendable, Equatable {
+    case formatter
+    case promptResult = "prompt_result"
+    case chat
+    case transform
 }
 
 /// Why a meeting recording started. Lets us distinguish manual user action
@@ -353,6 +365,18 @@ public enum TelemetryEventSpec: Sendable {
         errorType: String,
         defaultPromptUsed: Bool,
         inputTruncated: Bool
+    )
+    /// User-environment state, not an app failure: the configured LLM
+    /// provider can't be reached (server not running, model name out of
+    /// date, API key invalid, CLI tool missing). Emitted *instead of*
+    /// `llm*Failed` for these cases so the `*_failed` buckets reflect
+    /// things actually worth investigating, while this event tracks
+    /// how many users have drifted-config installs.
+    case llmProviderUnavailable(
+        provider: String,
+        errorType: String,
+        feature: TelemetryLLMFeature,
+        source: TelemetryFormatterSource? = nil
     )
     case llmOperation(
         operationID: String,
@@ -569,6 +593,7 @@ extension TelemetryEventSpec {
         case .llmTransformFailed: return .llmTransformFailed
         case .llmFormatterUsed: return .llmFormatterUsed
         case .llmFormatterFailed: return .llmFormatterFailed
+        case .llmProviderUnavailable: return .llmProviderUnavailable
         case .llmOperation: return .llmOperation
         case .historySearched: return .historySearched
         case .historyReplayed: return .historyReplayed
@@ -869,6 +894,14 @@ extension TelemetryEventSpec {
                 "default_prompt_used": Self.boolString(defaultPromptUsed),
                 "input_truncated": Self.boolString(inputTruncated),
             ]
+        case .llmProviderUnavailable(let provider, let errorType, let feature, let source):
+            var props: [String: String] = [
+                "provider": provider,
+                "error_type": errorType,
+                "feature": feature.rawValue,
+            ]
+            if let source { props["source"] = source.rawValue }
+            return props
         case .llmOperation(
             let operationID,
             let operationContext,
@@ -1252,6 +1285,7 @@ public enum TelemetryImplementedContract {
         .llmTransformFailed: ["provider", "error_type"],
         .llmFormatterUsed: ["provider", "source", "duration_seconds", "input_chars", "output_chars", "default_prompt_used", "input_truncated"],
         .llmFormatterFailed: ["provider", "source", "duration_seconds", "error_type", "default_prompt_used", "input_truncated"],
+        .llmProviderUnavailable: ["provider", "error_type", "feature"],
         .llmOperation: ["operation_id", "feature", "provider", "streaming", "outcome", "duration_seconds"],
         .historySearched: [],
         .historyReplayed: [],

--- a/Tests/MacParakeetTests/Services/LLM/LLMServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMServiceTests.swift
@@ -15,6 +15,7 @@ final class MockLLMClient: LLMClientProtocol, @unchecked Sendable {
     var streamTokens: [String]?
     var testConnectionError: Error?
     var testConnectionDelayNs: UInt64 = 0
+    var chatCompletionError: Error?
 
     func chatCompletion(
         messages: [ChatMessage],
@@ -24,6 +25,7 @@ final class MockLLMClient: LLMClientProtocol, @unchecked Sendable {
         capturedMessages = messages
         capturedContext = context
         capturedOptions = options
+        if let chatCompletionError { throw chatCompletionError }
         return ChatCompletionResponse(
             content: responseContent,
             reasoningContent: responseReasoningContent,
@@ -41,6 +43,11 @@ final class MockLLMClient: LLMClientProtocol, @unchecked Sendable {
         capturedMessages = messages
         capturedContext = context
         capturedOptions = options
+        if let chatCompletionError {
+            return AsyncThrowingStream { continuation in
+                continuation.finish(throwing: chatCompletionError)
+            }
+        }
         let tokens = streamTokens ?? [responseContent]
         return AsyncThrowingStream { continuation in
             for token in tokens {
@@ -962,6 +969,287 @@ final class LLMServiceTests: XCTestCase {
         } catch {
             XCTFail("Unexpected error: \(error)")
         }
+    }
+
+    // MARK: - Provider-Unavailable Routing
+    //
+    // Persistent user-environment errors (Ollama down, model name typo,
+    // missing CLI, bad API key) are emitted as `llm_provider_unavailable`
+    // instead of `llm_*_failed`. The `*_failed` buckets should reflect real
+    // failures worth investigating, not "this user's Ollama isn't running."
+
+    func testFormatTranscriptEmitsProviderUnavailableOnConnectionFailed() async {
+        let telemetry = LLMTelemetrySpy()
+        Telemetry.configure(telemetry)
+        mockConfigStore.config = LLMProviderConfig(
+            id: .ollama,
+            baseURL: URL(string: "http://localhost:11434/v1")!,
+            apiKey: nil,
+            modelName: "llama3:8b",
+            isLocal: true
+        )
+        mockClient.chatCompletionError = LLMError.connectionFailed("refused")
+
+        do {
+            _ = try await service.formatTranscript(
+                transcript: "hello",
+                promptTemplate: AIFormatter.defaultPromptTemplate,
+                source: .dictation,
+                defaultPromptUsed: true
+            )
+            XCTFail("Expected throw")
+        } catch {}
+
+        let events = telemetry.snapshot()
+        XCTAssertTrue(events.contains { event in
+            if case .llmProviderUnavailable(let provider, let errorType, let feature, let source) = event {
+                return provider == "ollama"
+                    && errorType == "LLMError.connectionFailed"
+                    && feature == .formatter
+                    && source == .dictation
+            }
+            return false
+        }, "Expected llmProviderUnavailable in: \(events)")
+        XCTAssertFalse(events.contains { event in
+            if case .llmFormatterFailed = event { return true }
+            return false
+        }, "Expected NO llmFormatterFailed (user-config errors should not pollute the failure bucket)")
+    }
+
+    func testFormatTranscriptStillEmitsFormatterFailedOnRealFailure() async {
+        let telemetry = LLMTelemetrySpy()
+        Telemetry.configure(telemetry)
+        mockConfigStore.config = LLMProviderConfig(
+            id: .lmstudio,
+            baseURL: URL(string: "http://localhost:1234/v1")!,
+            apiKey: nil,
+            modelName: "qwen3.5-4b-mlx",
+            isLocal: true
+        )
+        mockClient.responseContent = "ignored"
+        mockClient.responseFinishReason = "length"
+
+        do {
+            _ = try await service.formatTranscript(
+                transcript: "hello",
+                promptTemplate: AIFormatter.defaultPromptTemplate,
+                source: .dictation,
+                defaultPromptUsed: true
+            )
+            XCTFail("Expected throw")
+        } catch {}
+
+        let events = telemetry.snapshot()
+        XCTAssertTrue(events.contains { event in
+            if case .llmFormatterFailed = event { return true }
+            return false
+        }, "Real formatter failures (truncation, etc.) should still emit llmFormatterFailed")
+        XCTAssertFalse(events.contains { event in
+            if case .llmProviderUnavailable = event { return true }
+            return false
+        })
+    }
+
+    func testGeneratePromptResultEmitsProviderUnavailableOnModelNotFound() async {
+        let telemetry = LLMTelemetrySpy()
+        Telemetry.configure(telemetry)
+        mockConfigStore.config = LLMProviderConfig(
+            id: .ollama,
+            baseURL: URL(string: "http://localhost:11434/v1")!,
+            apiKey: nil,
+            modelName: "missing-model",
+            isLocal: true
+        )
+        mockClient.chatCompletionError = LLMError.modelNotFound("missing-model")
+
+        do {
+            _ = try await service.generatePromptResult(transcript: "hi", systemPrompt: nil)
+            XCTFail("Expected throw")
+        } catch {}
+
+        let events = telemetry.snapshot()
+        XCTAssertTrue(events.contains { event in
+            if case .llmProviderUnavailable(let provider, let errorType, let feature, _) = event {
+                return provider == "ollama"
+                    && errorType == "LLMError.modelNotFound"
+                    && feature == .promptResult
+            }
+            return false
+        })
+        XCTAssertFalse(events.contains { event in
+            if case .llmPromptResultFailed = event { return true }
+            return false
+        })
+    }
+
+    func testChatEmitsProviderUnavailableOnCLIError() async {
+        let telemetry = LLMTelemetrySpy()
+        Telemetry.configure(telemetry)
+        mockConfigStore.config = LLMProviderConfig(
+            id: .localCLI,
+            baseURL: URL(string: "file:///usr/local/bin/llm")!,
+            apiKey: nil,
+            modelName: "claude",
+            isLocal: false
+        )
+        mockClient.chatCompletionError = LLMError.cliError("not found")
+
+        do {
+            _ = try await service.chat(question: "Q", transcript: "T", userNotes: nil, history: [])
+            XCTFail("Expected throw")
+        } catch {}
+
+        let events = telemetry.snapshot()
+        XCTAssertTrue(events.contains { event in
+            if case .llmProviderUnavailable(let provider, let errorType, let feature, _) = event {
+                return provider == "localCLI"
+                    && errorType == "LLMError.cliError"
+                    && feature == .chat
+            }
+            return false
+        })
+        XCTAssertFalse(events.contains { event in
+            if case .llmChatFailed = event { return true }
+            return false
+        })
+    }
+
+    func testTransformEmitsProviderUnavailableOnAuthFailed() async {
+        let telemetry = LLMTelemetrySpy()
+        Telemetry.configure(telemetry)
+        mockConfigStore.config = .anthropic(apiKey: "bad-key")
+        mockClient.chatCompletionError = LLMError.authenticationFailed(nil)
+
+        do {
+            _ = try await service.transform(text: "T", prompt: "P")
+            XCTFail("Expected throw")
+        } catch {}
+
+        let events = telemetry.snapshot()
+        XCTAssertTrue(events.contains { event in
+            if case .llmProviderUnavailable(let provider, let errorType, let feature, _) = event {
+                return provider == "anthropic"
+                    && errorType == "LLMError.authenticationFailed"
+                    && feature == .transform
+            }
+            return false
+        })
+        XCTAssertFalse(events.contains { event in
+            if case .llmTransformFailed = event { return true }
+            return false
+        })
+    }
+
+    func testStreamingPromptResultEmitsProviderUnavailableOnConnectionFailed() async {
+        let telemetry = LLMTelemetrySpy()
+        Telemetry.configure(telemetry)
+        mockConfigStore.config = LLMProviderConfig(
+            id: .ollama,
+            baseURL: URL(string: "http://localhost:11434/v1")!,
+            apiKey: nil,
+            modelName: "llama3:8b",
+            isLocal: true
+        )
+        mockClient.chatCompletionError = LLMError.connectionFailed("refused")
+        let stream = service.generatePromptResultStream(transcript: "hi", systemPrompt: nil)
+
+        do {
+            for try await _ in stream {}
+            XCTFail("Expected throw")
+        } catch {}
+
+        let events = telemetry.snapshot()
+        XCTAssertTrue(events.contains { event in
+            if case .llmProviderUnavailable(let provider, _, let feature, _) = event {
+                return provider == "ollama" && feature == .promptResult
+            }
+            return false
+        })
+        XCTAssertFalse(events.contains { event in
+            if case .llmPromptResultFailed = event { return true }
+            return false
+        })
+    }
+
+    func testStreamingChatEmitsProviderUnavailableOnModelNotFound() async {
+        let telemetry = LLMTelemetrySpy()
+        Telemetry.configure(telemetry)
+        mockConfigStore.config = LLMProviderConfig(
+            id: .ollama,
+            baseURL: URL(string: "http://localhost:11434/v1")!,
+            apiKey: nil,
+            modelName: "missing",
+            isLocal: true
+        )
+        mockClient.chatCompletionError = LLMError.modelNotFound("missing")
+        let stream = service.chatStream(question: "Q", transcript: "T", userNotes: nil, history: [])
+
+        do {
+            for try await _ in stream {}
+            XCTFail("Expected throw")
+        } catch {}
+
+        let events = telemetry.snapshot()
+        XCTAssertTrue(events.contains { event in
+            if case .llmProviderUnavailable(let provider, _, let feature, _) = event {
+                return provider == "ollama" && feature == .chat
+            }
+            return false
+        })
+        XCTAssertFalse(events.contains { event in
+            if case .llmChatFailed = event { return true }
+            return false
+        })
+    }
+
+    func testStreamingTransformEmitsProviderUnavailableOnAuthFailed() async {
+        let telemetry = LLMTelemetrySpy()
+        Telemetry.configure(telemetry)
+        mockConfigStore.config = .anthropic(apiKey: "bad-key")
+        mockClient.chatCompletionError = LLMError.authenticationFailed(nil)
+        let stream = service.transformStream(text: "T", prompt: "P")
+
+        do {
+            for try await _ in stream {}
+            XCTFail("Expected throw")
+        } catch {}
+
+        let events = telemetry.snapshot()
+        XCTAssertTrue(events.contains { event in
+            if case .llmProviderUnavailable(let provider, _, let feature, _) = event {
+                return provider == "anthropic" && feature == .transform
+            }
+            return false
+        })
+        XCTAssertFalse(events.contains { event in
+            if case .llmTransformFailed = event { return true }
+            return false
+        })
+    }
+
+    func testProviderErrorStillRoutedToLegacyFailedBucket() async {
+        let telemetry = LLMTelemetrySpy()
+        Telemetry.configure(telemetry)
+        mockConfigStore.config = .openai(apiKey: "sk-test")
+        // providerError indicates an API-side failure with a message; the
+        // user's environment is fine. This should stay in llm_chat_failed,
+        // not get reclassified as user-config drift.
+        mockClient.chatCompletionError = LLMError.providerError("500 Internal")
+
+        do {
+            _ = try await service.chat(question: "Q", transcript: "T", userNotes: nil, history: [])
+            XCTFail("Expected throw")
+        } catch {}
+
+        let events = telemetry.snapshot()
+        XCTAssertTrue(events.contains { event in
+            if case .llmChatFailed = event { return true }
+            return false
+        })
+        XCTAssertFalse(events.contains { event in
+            if case .llmProviderUnavailable = event { return true }
+            return false
+        })
     }
 
     // MARK: - Model Selection

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -996,6 +996,12 @@ final class TelemetryServiceTests: XCTestCase {
                 defaultPromptUsed: false,
                 inputTruncated: true
             ),
+            .llmProviderUnavailable(
+                provider: "ollama",
+                errorType: "LLMError.connectionFailed",
+                feature: .formatter,
+                source: .dictation
+            ),
             .llmOperation(
                 operationID: "op-llm",
                 feature: "chat",


### PR DESCRIPTION
## Summary
- New `llm_provider_unavailable` event for the persistent user-environment cases (Ollama not running, wrong model name, missing CLI, bad API key) that today account for ~85% of `llm_*_failed` volume but aren't real app failures.
- The existing `llm_*_failed` buckets keep emitting only for things actually worth investigating: empty response, output truncation, provider 5xx, streaming errors, rate limits.
- No app behavior change. Same fallback to deterministic cleanup, same `llmOperation` events.

## Why
Telemetry over recent weeks shows ~700 `llm_formatter_failed` and ~118 `llm_prompt_result_failed` events. The data is dominated by single sessions where one user kept dictating against an unreachable Ollama, emitting ~150 "failures" per session for what's really one drifted-config state. After this split, the failure dashboard drops from ~847 → ~60 (the count worth alerting on), and `llm_provider_unavailable` becomes a calm product signal — "how many users have a configured LLM provider that isn't currently reachable?"

## Test plan
- [x] `swift test` — 2474 tests pass, 0 failures, 10 skipped.
- [x] Focused: `swift test --filter "LLMServiceTests|TelemetryServiceTests"` — 96 tests, 0 failures.
- [x] Codex code review pass — all blocking findings addressed (Worker allowlist sequencing operationalized; required-props contract sample added; streaming chat/transform provider-unavailable tests added).
- [x] No behavior change verified: `DictationService.formatTranscriptIfNeeded` and `TranscriptionService.formatTranscriptIfNeeded` catch + fallback paths untouched.

## Deploy ordering (do NOT skip)

Per the existing "Worker rejects the entire batch if any event is unknown" behavior:

1. Merge this PR to `main`.
2. Deploy the companion Worker allowlist change in `macparakeet-website` (one-line addition of `"llm_provider_unavailable"` to `ALLOWED_EVENTS` in `functions/api/telemetry.ts`).
3. Only then build/release a new DMG. If the order flips, fresh-install users' first telemetry batch containing the new event gets rejected silently — losing co-batched `app_launched` / `onboarding_completed` / etc.

The Worker change is strictly additive — old apps stay fully compatible, new apps gain the new event in addition to all existing ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved error diagnostics for LLM operations by distinguishing between provider connectivity issues, authentication failures, and other unavailability scenarios.

* **Tests**
  * Added comprehensive test coverage for provider unavailability error classification and reporting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moona3k/macparakeet/pull/271)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->