### PR TITLE
Remove "Best available" YouTube audio quality (CLI 3.0.0)

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -80,6 +80,38 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ## [Unreleased]
 
+## [3.0.0] -- 2026-05-11
+
+### Removed (breaking)
+
+- `transcribe --youtube-audio-quality best-available` is no longer accepted.
+  ArgumentParser rejects the value at parse time with a usage error (exit
+  code 2). The flag still accepts `app-default` and `m4a`; `m4a` is the only
+  saved-file format going forward.
+- `config set youtube-audio-quality best-available` is rejected with a
+  `ValidationError` ("Use m4a."). `config get youtube-audio-quality` returns
+  `m4a` for any legacy stored value, including the now-unknown
+  `best_available` raw string.
+- `YouTubeAudioQuality.bestAvailable` enum case removed from
+  `MacParakeetCore`. Existing UserDefaults values of `best_available`
+  silently coerce to `.m4a` on read; no migration code is needed.
+
+  **Rationale.** AVPlayer on macOS cannot decode WebM or Opus, the formats
+  yt-dlp produces under "best available." The saved audio file silently
+  failed to play through the in-app audio scrubber while the video panel
+  worked (because the video panel re-extracts a fresh playable stream URL).
+  The option's only nominal benefit — a marginally higher upstream Opus
+  bitrate — disappears after the 16 kHz mono WAV downsample used for STT,
+  so transcription quality is unaffected by this removal. We considered
+  three alternatives before the cut: (1) transcoding Opus → AAC at download
+  time, which adds a second generation of lossy encoding and makes "best
+  available" worse than `m4a`; (2) falling back to a streamed YouTube URL
+  for audio playback, which violates the project's local-first stance,
+  reintroduces yt-dlp rate-limit exposure on every detail-view open, and
+  breaks offline playback; (3) keeping the option with a sharper warning
+  string, which leaves the trap intact for users who skim Settings copy.
+  Removal is the only path that respects "Simplicity is the product."
+
 ### Added
 
 - `transcribe --engine app-default` resolves the speech engine and Whisper

--- a/Sources/CLI/Commands/ConfigCommand.swift
+++ b/Sources/CLI/Commands/ConfigCommand.swift
@@ -27,7 +27,7 @@ struct ConfigCommand: ParsableCommand {
           whisper-language          auto|<Whisper language code>    default: auto
           speaker-detection         on|off                          default: off
           save-transcription-audio  on|off                          default: on
-          youtube-audio-quality     m4a|best-available              default: m4a
+          youtube-audio-quality     m4a                             default: m4a
 
         Full event catalog:
           https://github.com/moona3k/macparakeet/blob/main/docs/telemetry.md
@@ -255,10 +255,8 @@ struct ConfigCommand: ParsableCommand {
         switch raw {
         case "m4a":
             return .m4a
-        case "best-available", "bestavailable":
-            return .bestAvailable
         default:
-            throw ValidationError("Invalid value for youtube-audio-quality: '\(value)'. Use m4a or best-available.")
+            throw ValidationError("Invalid value for youtube-audio-quality: '\(value)'. Use m4a.")
         }
     }
 
@@ -266,8 +264,6 @@ struct ConfigCommand: ParsableCommand {
         switch quality {
         case .m4a:
             return "m4a"
-        case .bestAvailable:
-            return "best-available"
         }
     }
 

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -18,7 +18,6 @@ enum DownloadedAudioPolicy: String, ExpressibleByArgument {
 enum YouTubeAudioQualityOption: String, ExpressibleByArgument {
     case appDefault = "app-default"
     case m4a
-    case bestAvailable = "best-available"
 }
 
 enum TranscribeOutputFormat: String, ExpressibleByArgument, CaseIterable, Sendable {
@@ -72,7 +71,7 @@ struct TranscribeCommand: AsyncParsableCommand {
     @Option(help: "Downloaded YouTube audio retention: app-default, keep, delete.")
     var downloadedAudio: DownloadedAudioPolicy = .appDefault
 
-    @Option(help: "YouTube audio quality: app-default, m4a, best-available.")
+    @Option(help: "YouTube audio quality: app-default, m4a.")
     var youtubeAudioQuality: YouTubeAudioQualityOption = .appDefault
 
     @Option(help: "Path to SQLite database file (defaults to the app database).")
@@ -103,8 +102,6 @@ struct TranscribeCommand: AsyncParsableCommand {
         storedQuality: String?
     ) -> YouTubeAudioQuality {
         switch quality {
-        case .bestAvailable:
-            return .bestAvailable
         case .m4a:
             return .m4a
         case .appDefault:

--- a/Sources/CLI/MacParakeetCLI.swift
+++ b/Sources/CLI/MacParakeetCLI.swift
@@ -8,7 +8,7 @@ struct CLI: AsyncParsableCommand {
     /// distinguishable from synthesized Bundle.main values (the bare executable
     /// has no Info.plist and macOS otherwise reports an SDK marker like "16.0").
     /// Bump in lockstep with `Sources/CLI/CHANGELOG.md`.
-    static let cliVersion = "2.1.0"
+    static let cliVersion = "3.0.0"
 
     static let configuration = CommandConfiguration(
         commandName: "macparakeet-cli",

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -772,24 +772,6 @@ struct SettingsView: View {
 
                 Divider()
 
-                HStack(alignment: .center) {
-                    rowText(
-                        title: "YouTube audio quality",
-                        detail: viewModel.youtubeAudioQuality.detail
-                    )
-                    Spacer(minLength: DesignSystem.Spacing.md)
-                    Picker("YouTube audio quality", selection: $viewModel.youtubeAudioQuality) {
-                        ForEach(YouTubeAudioQuality.allCases, id: \.self) { quality in
-                            Text(quality.displayTitle).tag(quality)
-                        }
-                    }
-                    .labelsHidden()
-                    .pickerStyle(.menu)
-                    .frame(minWidth: 170, idealWidth: 210, maxWidth: 260)
-                }
-
-                Divider()
-
                 settingsToggleRow(
                     title: "Speaker detection",
                     detail: "Optional. Adds speaker labels when audio is clear; leave off if labels are unreliable.",

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -18,14 +18,11 @@ public protocol AppRuntimePreferencesProtocol: Sendable {
 
 public enum YouTubeAudioQuality: String, CaseIterable, Hashable, Sendable, Equatable {
     case m4a
-    case bestAvailable = "best_available"
 
     public var displayTitle: String {
         switch self {
         case .m4a:
             return "M4A"
-        case .bestAvailable:
-            return "Best available"
         }
     }
 
@@ -33,8 +30,6 @@ public enum YouTubeAudioQuality: String, CaseIterable, Hashable, Sendable, Equat
         switch self {
         case .m4a:
             return "Download an Apple-friendly m4a file for reliable playback and sharing. Falls back if m4a is unavailable."
-        case .bestAvailable:
-            return "YouTube's highest-quality audio stream. Often saves WebM/Opus, which the in-app audio scrubber can't decode — use Show Video for playback. Transcription is unaffected."
         }
     }
 
@@ -42,8 +37,6 @@ public enum YouTubeAudioQuality: String, CaseIterable, Hashable, Sendable, Equat
         switch self {
         case .m4a:
             return "bestaudio[ext=m4a]/bestaudio/best"
-        case .bestAvailable:
-            return "bestaudio/best"
         }
     }
 

--- a/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
+++ b/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
@@ -159,14 +159,6 @@ public enum SettingsSearchIndex {
             cardAnchor: "transcription"
         ),
         SettingsSearchEntry(
-            id: "transcription.youtube.audio.quality",
-            tab: .modes,
-            title: "YouTube audio quality",
-            subtitle: "in Transcription",
-            keywords: ["youtube", "audio", "quality", "m4a", "best available", "opus", "webm"],
-            cardAnchor: "transcription"
-        ),
-        SettingsSearchEntry(
             id: "transcription.diarization",
             tab: .modes,
             title: "Speaker detection",

--- a/Tests/CLITests/ConfigCommandTests.swift
+++ b/Tests/CLITests/ConfigCommandTests.swift
@@ -63,8 +63,15 @@ final class ConfigCommandTests: XCTestCase {
     }
 
     func testReadCanonicalizesUnderscoreKeys() throws {
-        defaults.set(YouTubeAudioQuality.bestAvailable.rawValue, forKey: UserDefaultsAppRuntimePreferences.youtubeAudioQualityKey)
-        XCTAssertEqual(try ConfigCommand.read(key: "youtube_audio_quality", defaults: defaults), "best-available")
+        defaults.set(YouTubeAudioQuality.m4a.rawValue, forKey: UserDefaultsAppRuntimePreferences.youtubeAudioQualityKey)
+        XCTAssertEqual(try ConfigCommand.read(key: "youtube_audio_quality", defaults: defaults), "m4a")
+    }
+
+    func testReadFallsBackToM4AForLegacyBestAvailable() throws {
+        // Existing UserDefaults from CLI 2.1.0 may still hold "best_available";
+        // YouTubeAudioQuality.current() coerces unknown raw values to .m4a.
+        defaults.set("best_available", forKey: UserDefaultsAppRuntimePreferences.youtubeAudioQualityKey)
+        XCTAssertEqual(try ConfigCommand.read(key: "youtube-audio-quality", defaults: defaults), "m4a")
     }
 
     func testCanonicalKeyNormalizesUnderscoreAliases() throws {
@@ -114,11 +121,20 @@ final class ConfigCommandTests: XCTestCase {
         XCTAssertEqual(try ConfigCommand.write(key: "save-transcription-audio", value: "off", defaults: defaults), "off")
         XCTAssertEqual(defaults.object(forKey: UserDefaultsAppRuntimePreferences.saveTranscriptionAudioKey) as? Bool, false)
 
-        XCTAssertEqual(try ConfigCommand.write(key: "youtube-audio-quality", value: "best-available", defaults: defaults), "best-available")
+        XCTAssertEqual(try ConfigCommand.write(key: "youtube-audio-quality", value: "m4a", defaults: defaults), "m4a")
         XCTAssertEqual(
             defaults.string(forKey: UserDefaultsAppRuntimePreferences.youtubeAudioQualityKey),
-            YouTubeAudioQuality.bestAvailable.rawValue
+            YouTubeAudioQuality.m4a.rawValue
         )
+    }
+
+    func testWriteYouTubeAudioQualityRejectsRemovedBestAvailable() {
+        // 3.0.0 removed the "best-available" value; writing it now must fail
+        // with a validation error so scripted callers learn during migration.
+        XCTAssertThrowsError(try ConfigCommand.write(key: "youtube-audio-quality", value: "best-available", defaults: defaults)) { error in
+            XCTAssertTrue(error is ValidationError, "Expected ValidationError, got \(type(of: error))")
+            XCTAssertTrue("\(error)".contains("m4a"))
+        }
     }
 
     func testWriteCanonicalizesUnderscoreKeys() throws {

--- a/Tests/CLITests/TranscribeCommandTests.swift
+++ b/Tests/CLITests/TranscribeCommandTests.swift
@@ -34,20 +34,23 @@ final class TranscribeCommandTests: XCTestCase {
         XCTAssertEqual(quality, .m4a)
     }
 
-    func testResolveYouTubeAudioQualityUsesStoredQualityForAppDefaultWhenValid() {
+    func testResolveYouTubeAudioQualityFallsBackToM4AForLegacyBestAvailableStoredValue() {
+        // After 3.0.0 removed `best_available`, existing UserDefaults values
+        // from CLI 2.1.0 are no longer valid raw values — they must coerce to
+        // .m4a rather than crash or surface an option that no longer exists.
         let quality = TranscribeCommand.resolveYouTubeAudioQuality(
             .appDefault,
-            storedQuality: YouTubeAudioQuality.bestAvailable.rawValue
+            storedQuality: "best_available"
         )
-        XCTAssertEqual(quality, .bestAvailable)
+        XCTAssertEqual(quality, .m4a)
     }
 
-    func testResolveYouTubeAudioQualityRespectsExplicitQuality() {
+    func testResolveYouTubeAudioQualityRespectsExplicitM4A() {
         let quality = TranscribeCommand.resolveYouTubeAudioQuality(
-            .bestAvailable,
+            .m4a,
             storedQuality: YouTubeAudioQuality.m4a.rawValue
         )
-        XCTAssertEqual(quality, .bestAvailable)
+        XCTAssertEqual(quality, .m4a)
     }
 
     func testResolveSpeechEngineUsesStoredDefaultWhenRequested() {
@@ -158,13 +161,22 @@ final class TranscribeCommandTests: XCTestCase {
         XCTAssertEqual(command.speakerDetection, .appDefault)
     }
 
-    func testParsesYouTubeAudioQuality() throws {
+    func testParsesYouTubeAudioQualityM4A() throws {
         let command = try TranscribeCommand.parse([
             "https://www.youtube.com/watch?v=abc",
-            "--youtube-audio-quality", "best-available",
+            "--youtube-audio-quality", "m4a",
         ])
 
-        XCTAssertEqual(command.youtubeAudioQuality, .bestAvailable)
+        XCTAssertEqual(command.youtubeAudioQuality, .m4a)
+    }
+
+    func testParsingYouTubeAudioQualityBestAvailableFails() {
+        // 3.0.0 removed `best-available`; ArgumentParser should reject the
+        // value at parse time so scripted callers see a clear migration error.
+        XCTAssertThrowsError(try TranscribeCommand.parse([
+            "https://www.youtube.com/watch?v=abc",
+            "--youtube-audio-quality", "best-available",
+        ]))
     }
 
     func testParakeetRemainsDefaultEngine() throws {

--- a/Tests/MacParakeetTests/Services/YouTubeDownloaderTests.swift
+++ b/Tests/MacParakeetTests/Services/YouTubeDownloaderTests.swift
@@ -69,17 +69,6 @@ final class YouTubeDownloaderTests: XCTestCase {
         ])
     }
 
-    func testDownloadAudioArgumentsUseBestAvailableSelector() {
-        let args = YouTubeDownloader.downloadAudioArguments(
-            ffmpegDir: "/opt/macparakeet/bin",
-            outputTemplate: "/tmp/video.%(ext)s",
-            url: "https://www.youtube.com/watch?v=abc",
-            quality: .bestAvailable
-        )
-
-        XCTAssertEqual(formatSelector(in: args), "bestaudio/best")
-    }
-
     func testDownloadAudioArgumentsIncludeJavaScriptRuntimeArgsBeforeFFmpeg() {
         let args = YouTubeDownloader.downloadAudioArguments(
             ffmpegDir: "/opt/macparakeet/bin",

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -136,7 +136,7 @@ final class SettingsViewModelTests: XCTestCase {
         testDefaults.set(false, forKey: "saveAudioRecordings")
         testDefaults.set(false, forKey: "saveTranscriptionAudio")
         testDefaults.set(
-            YouTubeAudioQuality.bestAvailable.rawValue,
+            YouTubeAudioQuality.m4a.rawValue,
             forKey: UserDefaultsAppRuntimePreferences.youtubeAudioQualityKey
         )
         testDefaults.set(true, forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey)
@@ -157,7 +157,7 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(vm.silenceDelay, 3.0)
         XCTAssertFalse(vm.saveAudioRecordings)
         XCTAssertFalse(vm.saveTranscriptionAudio)
-        XCTAssertEqual(vm.youtubeAudioQuality, .bestAvailable)
+        XCTAssertEqual(vm.youtubeAudioQuality, .m4a)
         XCTAssertTrue(vm.speakerDiarization)
         XCTAssertEqual(vm.selectedMicrophoneDeviceUID, "usb-mic-uid")
         XCTAssertEqual(vm.meetingAudioSourceMode, .systemOnly)
@@ -446,12 +446,23 @@ final class SettingsViewModelTests: XCTestCase {
     }
 
     func testSettingYouTubeAudioQualityPersists() {
-        viewModel.youtubeAudioQuality = .bestAvailable
+        viewModel.youtubeAudioQuality = .m4a
 
         XCTAssertEqual(
             testDefaults.string(forKey: UserDefaultsAppRuntimePreferences.youtubeAudioQualityKey),
-            YouTubeAudioQuality.bestAvailable.rawValue
+            YouTubeAudioQuality.m4a.rawValue
         )
+    }
+
+    func testYouTubeAudioQualityFallsBackToM4AForLegacyBestAvailable() {
+        // Existing UserDefaults from CLI 2.1.0 / app builds before this PR
+        // may hold "best_available" — `YouTubeAudioQuality.current()` coerces
+        // unknown raw values to .m4a so the VM never surfaces a removed case.
+        testDefaults.set("best_available", forKey: UserDefaultsAppRuntimePreferences.youtubeAudioQualityKey)
+
+        let vm = SettingsViewModel(defaults: testDefaults)
+
+        XCTAssertEqual(vm.youtubeAudioQuality, .m4a)
     }
 
     func testSettingSpeakerDiarizationPersists() {

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -27,7 +27,7 @@ macparakeet-cli
 ├── transcribe <input> [options]         Transcribe a file or YouTube URL
 │   └── --engine app-default|parakeet|whisper [--language <code>]
 │       --speaker-detection app-default|on|off
-│       --youtube-audio-quality app-default|m4a|best-available
+│       --youtube-audio-quality app-default|m4a
 ├── history                              View and manage history
 │   ├── dictations [--limit] [--json]    List recent dictations (default)
 │   ├── transcriptions [--limit] [--json]  List recent transcriptions
@@ -143,13 +143,13 @@ swift run macparakeet-cli transcribe "<FILE_OR_YOUTUBE_URL>" \
   --speaker-detection on \
   --mode clean \
   --downloaded-audio keep \
-  --youtube-audio-quality best-available
+  --youtube-audio-quality m4a
 ```
 
-`--youtube-audio-quality app-default` follows the GUI setting. `m4a` matches
-the app's default compatibility-first selector. `best-available` asks `yt-dlp`
-for the best audio stream and then lets the normal conversion pipeline prepare
-the STT input.
+`--youtube-audio-quality app-default` follows the GUI setting; `m4a` pins
+the m4a-first selector so the saved audio file plays through AVPlayer.
+(`best-available` existed in 2.1.0 but was removed in 3.0.0 — see
+`Sources/CLI/CHANGELOG.md`.)
 
 ### Speech Engine Selection
 

--- a/spec/05-audio-pipeline.md
+++ b/spec/05-audio-pipeline.md
@@ -97,9 +97,12 @@ YouTube URL → yt-dlp (audio only) → downloaded audio file → FFmpeg → 16k
 ```
 
 - `yt-dlp` is used with `--no-playlist` for single-video processing
-- YouTube audio quality is configurable:
-  - **M4A** (default): `bestaudio[ext=m4a]/bestaudio/best`, preferring Apple-friendly saved audio files while falling back when m4a is unavailable
-  - **Best available**: `bestaudio/best`, allowing higher-quality source streams such as Opus/WebM when YouTube offers them. Transcription still converts the downloaded file to WAV before STT, but retained downloads may be less predictable for Apple playback and sharing workflows.
+- YouTube audio is downloaded as **M4A** (`bestaudio[ext=m4a]/bestaudio/best`),
+  preferring Apple-friendly saved audio files while falling back when m4a is
+  unavailable. A "Best available" mode existed in CLI 2.1.0 / pre-3.0 app
+  builds but was removed: AVPlayer on macOS cannot decode WebM/Opus, so the
+  saved audio file silently failed to play through the in-app scrubber. See
+  `Sources/CLI/CHANGELOG.md` for the 3.0.0 removal rationale.
 - Download progress is parsed from yt-dlp output and surfaced as percent updates
 - Downloaded files are written to:
 


### PR DESCRIPTION
## Summary

- Removes the **Best available** YouTube audio quality option from the GUI, the CLI, and `YouTubeAudioQuality` in `MacParakeetCore`.
- Bumps `macparakeet-cli` to **3.0.0** (breaking removal of an enum value on `transcribe --youtube-audio-quality` and `config set youtube-audio-quality`).
- Folds the previously-Unreleased CLI work (`--engine app-default`, `--speaker-detection app-default|on|off`, expanded `config`) into the 3.0.0 release entry.
- 217+ focused tests pass locally (`swift test`).

## The bug behind the cut

A user opened a YouTube transcription and the audio scrubber's play button did nothing. Investigation showed the saved audio file was `.webm` (Opus codec). **AVPlayer on macOS has no native WebM demuxer and no native Opus decoder** — so the in-app audio scrubber silently failed while the video panel still worked (because the video panel re-extracts a fresh playable HLS/MP4 stream URL via yt-dlp on demand).

That mismatch is exactly the "Best available" path: `yt-dlp -f bestaudio/best` almost always picks YouTube's Opus-in-WebM stream because it's the highest bitrate the API exposes.

## Why removal beats the alternatives

We worked through three other options before landing here. None of them earn their keep:

| Option | Problem |
|---|---|
| **Transcode Opus → AAC at download time** (~3–5s for 1h video via bundled ffmpeg) | Adds a second generation of lossy encoding. After the transcode, "Best available" is *worse* than `m4a` (one generation from YouTube's master vs two), so the option's name becomes dishonest. |
| **Stream-URL fallback for unplayable local files** | Violates local-first. Re-introduces yt-dlp rate-limit exposure on every detail-view open — the exact reason `MediaPlayerViewModel.prepare()` vs `load()` were split (see the comment at `MediaPlayerViewModel.swift:59`). Breaks offline playback. Fails entirely for taken-down / geo-blocked videos. |
| **Sharper warning copy** | We actually shipped this to main as `f6edccc7`. It's a band-aid: users skim Settings detail text and still hit the dead play button. This PR supersedes that commit. |

**STT quality is unaffected** by this change — Parakeet sees 16 kHz mono WAV after the FluidAudio AudioConverter step regardless of the source format. The "Best available" mode never improved transcription accuracy; it only changed the *saved file* format.

## Why a MAJOR bump

`macparakeet-cli` 2.1.0 introduced `--youtube-audio-quality best-available` on **2026-05-10** (one day before this PR). Per `Sources/CLI/CHANGELOG.md`'s compatibility policy, removing an accepted flag value is a MAJOR change. The CLI surface is young enough that a clean 3.0.0 cut is more honest than a deprecation window for a value that's been live for ~24 hours and was broken from day one.

## Migration / backward compatibility

- **Existing UserDefaults values of `best_available`** silently coerce to `.m4a` on read. `YouTubeAudioQuality.current()` already returned `.m4a` for unknown raw values; the removal makes `best_available` "unknown." No migration code needed.
- **CLI scripts passing `--youtube-audio-quality best-available`** will now exit with code 2 (validation error). The error message points at `m4a` as the only supported value.
- **`config set youtube-audio-quality best-available`** throws `ValidationError("...Use m4a.")`.
- **Previously-downloaded `.webm` audio files** are left on disk. Their transcripts work; their video panels work (yt-dlp re-extracts a stream); their audio scrubber stays mute. This is a known limitation, not a regression — they were already broken. Cleanup affordances are out of scope for this PR.

## Caveat (not a regression)

With `m4a` quality the yt-dlp format selector remains `bestaudio[ext=m4a]/bestaudio/best`, so a rare YouTube video that exposes *no* m4a stream at all can still produce webm via the fallback. The audio scrubber is broken for that rare case, same as before. Eliminating that edge case would require either a hard `m4a`-only selector (which fails entirely on m4a-less videos) or the transcode path (rejected above). We'd address it case-by-case if it shows up in the wild.

## Test plan

- [x] `swift build` (clean)
- [x] `swift test` (full suite, exit 0)
- [x] Focused tests: `ConfigCommandTests | TranscribeCommandTests | YouTubeDownloaderTests | SettingsViewModelTests` (217 tests, 0 failures)
- [x] Manual: open `Settings → Transcription` and confirm "YouTube audio quality" row is gone (previous row was the YouTube transcription hotkey, next row is Speaker detection)
- [ ] Manual (post-merge sanity): transcribe a YouTube video, confirm the saved file is `.m4a` and the in-app audio scrubber plays

## ADRs / spec changes

No ADRs touched. `spec/05-audio-pipeline.md` updated to describe only the m4a-first selector and reference `Sources/CLI/CHANGELOG.md` for the removal rationale. `docs/cli-testing.md` updated to drop `best-available` from the CLI tree + example transcribe command.

## Commit

See `9bfef1ab` for the full rationale in the rich commit message (`What Changed` / `Root Intent` / `Prompt That Would Produce This Diff` / `Files Changed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Removed `--youtube-audio-quality best-available` option; only `m4a` is now supported
  * Removed YouTube audio quality picker from Settings UI

* **New Features**
  * Added `--engine app-default` flag to use shared app defaults for speech engine
  * Added `--speaker-detection` option with `app-default|on|off` modes (with alias `--no-diarize`)
  * Expanded CLI config commands to manage transcription defaults (engine, language, speaker detection, save audio)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moona3k/macparakeet/pull/274)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->