### PR TITLE
docs: WisprFlow parity audit + Transforms design exploration

### DIFF
--- a/docs/research/transforms-design-2026-05.md
+++ b/docs/research/transforms-design-2026-05.md
@@ -1,0 +1,307 @@
+# Transforms — Design Exploration
+
+> Status: **PROPOSAL**. Design exploration; not yet an ADR or implementation plan. Next step is either an ADR (if architectural questions need locking) or a plan under `plans/active/`.
+> Updated: 2026-05-11
+> Related: `wisprflow-parity-2026-05.md` (audit that triggered this), `plans/active/2026-05-voice-command-agent-mode.md` (the voice-driven sibling), `docs/agent-mode-vision.md` (north-star framing)
+
+## Thesis
+
+**Transforms — system-wide hotkey-driven LLM rewrites on selected text — is the right next major surface for MacParakeet.** It's commonly framed as a writing-assistant feature (WisprFlow's `Polish` and `Prompt Engineer` on Opt+1/Opt+2), but for us it's better understood as the **hotkey-driven half of Command Mode**: the same selection-capture → LLM-rewrite → in-place-replace primitive that voice Command Mode will need, with a much simpler trigger.
+
+Building Transforms first lays the foundation. The voice variant ("select text, hold Fn, say 'make this more formal'") becomes a swap on the trigger layer once the primitive is solid.
+
+## Why this is more conservative than it looks
+
+Reading the audit, it's tempting to characterize this as scope creep — MacParakeet drifting from "voice app" into "writing assistant." Two reasons that framing is wrong:
+
+1. **The roadmap already says this.** `plans/active/2026-05-voice-command-agent-mode.md` lists "selected-text rewrite" as candidate capability #1. `docs/agent-mode-vision.md` names "rewrite selected text" as an Agent Mode primitive. We are not adding a new product direction; we are picking the shortest path to a primitive we've already committed to.
+
+2. **The pieces are mostly built.**
+
+   | Piece | Status |
+   |---|---|
+   | LLM provider stack (`LLMService.transform`, `transformStream`, `transformDetailed`) | Built; used by CLI today |
+   | Prompt model with `.transform` category | Built; no built-ins ship in that category yet |
+   | Global hotkey infrastructure (`GlobalShortcutManager` for chord-triggered actions; `HotkeyManager` for gesture-based; `HotkeyRecorderView` for binding UI) | Built; used for dictation and meeting recording toggle |
+   | Dictation has both `rawTranscript` and `cleanTranscript` stored separately | Built; ready for Undo AI edit too |
+   | Accessibility permission already requested (for paste simulation) | Built |
+   | Paste-back via simulated Cmd+V | Built; used by dictation insertion |
+   | CLI surface that proves the prompt-driven rewrite shape works | Built (`macparakeet-cli llm transform`) |
+
+   The genuinely new pieces are narrow: AX-based selection capture, the Transforms management UI, and the bind-N-hotkeys-to-N-transforms mux.
+
+## What we're building
+
+A user-facing surface where:
+
+1. The user binds a hotkey (e.g., Opt+1) to a Transform.
+2. A Transform is `{name, hotkey, prompt, optional model override}` — backed by the existing `Prompt` model with `category = .transform`.
+3. With text selected in any macOS app, pressing the hotkey:
+   - Captures the selected text (AX-first; clipboard-hijack fallback)
+   - Runs it through the bound prompt via the user's configured LLM provider
+   - Replaces the selection in place with the result
+4. Ships with two built-in transforms (`Polish` and `Prompt Engineer` analogues, on Opt+1 / Opt+2). Users can edit them, disable them, or create their own.
+5. Fails loudly and recoverably when something goes wrong (no selection, no provider configured, AX denied, LLM timeout).
+
+Explicit non-goals for v1:
+
+- Voice-driven trigger. Out of scope. The hotkey path is explicit (user has visibly highlighted the text they want transformed), which is the right shape for a first cut. Voice-driven rewrites of selected text are tracked in `plans/active/2026-05-voice-command-agent-mode.md` and stay there; the architecture below is general enough to be reused if/when we ship that, but we make no commitment in this design.
+- Live streaming tokens into the target text field. Too fragile across app variants. Show progress in a small overlay; paste the full result when streaming completes.
+- Rule-toggle composition (WisprFlow's `Make more concise` / `Reword for clarity` togglable rules that re-render a diff preview live). Polished detail; not v1.
+- Diff preview pane in settings. Same — polish, not v1.
+- Per-app transform routing (Polish behaves differently in Gmail vs Slack). Defer.
+- Inline acceptance UI ("accept change?" preview before paste). The "Cmd+Z to undo" macOS default is the v1 escape hatch.
+
+## Trigger
+
+A Transform is invoked by **pressing its bound hotkey** (e.g., `Opt+1`) while text is selected in any macOS app. That's the only trigger path in v1.
+
+The user-facing model is deliberately explicit: the user has *visibly* highlighted the text they want transformed, then presses a key. No mode disambiguation, no listening for spoken intent, no implicit context grabbing. The whole feature reads as "this hotkey does that to that highlighted text" — which is what makes it easy to learn and trust.
+
+Other trigger surfaces (right-click context menu, floating action button, menu bar dropdown) are explicitly out of scope. Right-click requires AX-injecting into the host app's native menu (not viable on macOS); floating action buttons require heavy window-management work; a menu bar dropdown solves discoverability but not speed, which is what the management page's hotkey badges and the in-app explainer are for.
+
+## Architecture sketch
+
+Five components. Three are new; two are extensions of existing code.
+
+### 1. `SelectionCaptureService` (new, in `MacParakeetCore/Services/System/`)
+
+```swift
+public enum SelectionCaptureResult {
+    case ax(text: String, element: AXUIElement)   // can write back via AX
+    case clipboard(text: String, savedClipboard: NSPasteboardItemSnapshot?)  // must paste-back via Cmd+V
+    case empty                                     // selection was empty
+    case failed(SelectionCaptureError)
+}
+
+public actor SelectionCaptureService {
+    public func captureSelection(
+        timeout: Duration = .milliseconds(250)
+    ) async -> SelectionCaptureResult
+}
+```
+
+Strategy:
+
+1. Query the system-wide focused UI element via `AXUIElementCreateSystemWide` + `kAXFocusedUIElementAttribute`.
+2. Read `kAXSelectedTextAttribute` from the focused element. If non-empty, return `.ax`.
+3. If AX path fails or returns empty, fall back to clipboard hijack:
+   - Snapshot current clipboard contents (multiple types, not just string).
+   - Simulate `Cmd+C`.
+   - Poll the clipboard for a change with the 250ms timeout (changeCount delta is the right signal).
+   - If the clipboard changed, return `.clipboard` with the saved snapshot.
+   - If it didn't change, return `.empty`.
+
+Trap to avoid: don't restore the clipboard immediately after reading. The paste-back path (component 5) needs the result text on the clipboard. Restore only after paste-back completes or fails.
+
+### 2. `SelectionReplacementService` (new, in `MacParakeetCore/Services/System/`)
+
+```swift
+public actor SelectionReplacementService {
+    public func replace(
+        with newText: String,
+        in context: SelectionCaptureResult,
+        cancellation: AnyCancellable?
+    ) async throws
+}
+```
+
+Strategy by context:
+
+- `.ax`: try `AXUIElementSetAttributeValue(element, kAXSelectedTextAttribute, newText)`. If it succeeds and the read-back matches, done.
+- AX-write failure or `.clipboard` context: put `newText` on the clipboard, simulate `Cmd+V`, wait for the paste to complete (a few hundred ms), restore the original clipboard snapshot.
+- On any failure, attempt clipboard restore and propagate.
+
+The clipboard backup/restore dance is well-known to be racy; cribbing from Raycast / Espanso's approach is the right move. The 250ms read timeout and ~500ms write timeout match conventional values.
+
+### 3. `TransformExecutor` (new, in `MacParakeetCore/Services/Transforms/`)
+
+```swift
+public actor TransformExecutor {
+    public func execute(
+        transform: Prompt,                    // category == .transform
+        captured: SelectionCaptureResult,
+        progress: @Sendable (TransformProgress) -> Void
+    ) async throws -> TransformResult
+}
+
+public enum TransformProgress: Sendable {
+    case capturing
+    case llmStarted
+    case llmStreaming(String)   // accumulated text
+    case llmCompleted(String)
+    case pasting
+    case done
+    case failed(Error)
+}
+```
+
+Wraps the capture → LLM call → replace pipeline as one async task. Owns cancellation: pressing Esc, triggering another transform, or the user clicking the overlay's cancel button cancels the in-flight task. Reports progress for the UI overlay.
+
+Calls into existing `LLMService.transformStream(...)` for the LLM stage.
+
+### 4. Hotkey routing (extension of existing `GlobalShortcutManager`)
+
+The existing `GlobalShortcutManager` already handles "single key chord triggers an action." It currently has a single `onTrigger` closure. We need N of them — one per Transform binding.
+
+Options:
+
+- **A — multiple `GlobalShortcutManager` instances.** One per active Transform. Simple. May fight each other if they share an event tap; needs validation.
+- **B — new `TransformsHotkeyRegistry`** that owns a single event tap and maps key combos to Transform IDs. Cleaner; one event tap, one dispatch table. Recommended.
+
+Either way, the existing `HotkeyRecorderView` should be reusable for the per-Transform binding UI (it already renders modifier badges and detects key combos).
+
+Collision rules:
+- Transforms hotkeys MUST include a modifier (matches WisprFlow's behavior — the screenshot literally validates this with "Shortcut must include modifier key…").
+- Transforms hotkeys must not collide with the user's dictation hotkey or the meeting-toggle hotkey. Surface a clear inline error in the binding UI.
+- Don't collide with the well-known macOS Opt+letter combos that produce alt-characters (Opt+e, Opt+u, etc. are dead keys). Restrict the default Opt+1..Opt+9 range and let users override.
+
+### 5. Transforms management UI (new, in `Sources/MacParakeet/Views/Transforms/`)
+
+A new top-level sidebar item — sibling of Vocabulary, Library, Settings.
+
+Layout (sketched, not pixel-final):
+
+```
++----------------------------------------------------+
+|  Transforms                              [+ New]   |
+|  -----------------------------------------------   |
+|  ⓘ Need an LLM provider configured. [Configure]    |  (only when no provider)
+|                                                    |
+|  Polish              ⌥1   [Edit]  [⬤ Enabled]      |
+|  Prompt Engineer     ⌥2   [Edit]  [⬤ Enabled]      |
+|  My custom one       ⌥3   [Edit]  [⬤ Enabled]      |
+|                                                    |
+|  + Create new                                      |
++----------------------------------------------------+
+```
+
+Edit pane: Name field, Hotkey recorder, Prompt body editor, optional Model override picker. Saves immediately on edit; "Reset" reverts to built-in defaults for shipped transforms.
+
+Discoverability: show the bound hotkey badge inline with each Transform row (WisprFlow's pattern is good here). Surface a brief Transforms tour on first launch after an LLM provider gets configured.
+
+## Visual feedback while a Transform runs
+
+Two paths considered:
+
+1. **Inline streaming** into the target text field. Pro: feels magical. Con: every text field handles "rapid-fire inserts via paste" differently — many apps batch undo, some flicker, some fight with autocomplete. Skip for v1.
+2. **Small floating pill** anchored near the trigger context (cursor area, or screen-edge fallback). Shows the verb form of the Transform's name + a custom animated loader. Disappears on completion. **Pick this.** WisprFlow's reference: a small dark pill reading *"Polishing…"* with a spinning loader on the right.
+
+### Copy
+
+Pill text is the Transform's name in its gerund/verb form:
+
+| Transform | Pill copy |
+|---|---|
+| Polish | *Polishing…* |
+| Prompt Engineer | *Engineering prompt…* |
+| Summarize (custom) | *Summarizing…* |
+| (any user-defined Transform without a verb form) | *Transforming…* (fallback) |
+
+Each Transform definition gets an optional `runningLabel: String?` field. If unset, we use *"{Name}ing…"* as a heuristic, falling back to *"Transforming…"* for awkward names. Users can edit `runningLabel` in the Transform's edit pane.
+
+### Animated loader — new visuals, please
+
+We want a **custom loader animation** for this surface, not a stock spinner and not a copy of the dictation/meeting indicators. Transforms is a new surface and deserves its own motion vocabulary that says "thinking" and "refining" rather than "listening" or "recording."
+
+Design constraints:
+- Small (fits inside a ~28pt-tall pill)
+- 60fps-smooth, ideally GPU-friendly (Canvas or TimelineView in SwiftUI)
+- Coherent with our brand: warm coral, sacred-geometry / organic feel, not techy/digital
+- Looks "endless" without a hard loop seam — the user might watch it for 2 seconds or 8 seconds depending on LLM latency
+
+Three concrete directions worth prototyping (pick one for v1, the others stay in a research note):
+
+1. **Coral particle orbit.** A handful of small coral dots orbit a center point on a slowly precessing axis. Each dot has a faint trailing fade. Feels alive and "thinking," not mechanical. Reads at any duration.
+2. **Morphing rosette.** A miniature version of the meeting-pill rosette continuously morphs between regular polygons (hexagon → heptagon → octagon → back). Ties into our existing geometric language but doesn't read as "recording." Slow tempo (~1.5s per morph cycle) to feel deliberate.
+3. **Bezier scribe.** A single coral curve traces a continuous loop — drawing forward, then erasing from the tail at the same rate, so the curve appears to be "writing" itself indefinitely. Cursive feel. Best fit for the "polishing your words" mental model.
+
+My lean: **#3 (Bezier scribe)** for v1. It's the most on-theme for a writing/refinement surface, the least likely to be confused with the dictation overlay's waveform or the meeting pill's rosette, and the easiest to communicate as "MacParakeet has its own animation language."
+
+Implementation note: the loader is a self-contained SwiftUI view (`TransformLoader.swift` under `Sources/MacParakeet/Views/Transforms/`). It exposes a single `isActive: Bool` binding so the same view can be reused in the management UI's preview pane (showing the loader idle at the corner of each Transform card on hover, as a discovery hint).
+
+## No-selection and error UX
+
+The "no selection when the hotkey fired" case is the most common failure mode and the most teachable moment. WisprFlow handles it with a friendly educational toast rather than an error — *"Hey, select text first! First, highlight the text you want to transform, then press opt + 1"* (one screenshot also showed *"Select text to apply a transform — Highlight any text, then press opt + 2"*). The pasteboard-pill icon and warm copy turn the failure into onboarding. We should match that tone.
+
+| Situation | UX |
+|---|---|
+| Hotkey fired with no selection (AX returns empty, clipboard fallback also returns empty) | Friendly toast near the trigger: *"Hey, select text first! Highlight the text you want to transform, then press {hotkey} again."* — uses the actual bound hotkey in the copy, not a generic placeholder. |
+| No LLM provider configured | Toast: *"Transforms need an LLM provider"* with a `[Configure]` action that opens Settings. |
+| LLM error (network, rate limit, timeout) | Toast: *"Transform failed — clipboard restored."* Restore the original clipboard snapshot. |
+| AX-write failure mid-replace | Auto-fallback to clipboard paste path. Only surface an error if both paths fail. |
+
+In all cases: if the original clipboard was preserved, restore it. Users who triggered a transform should not lose their copied-but-uncommitted state.
+
+### Decision: no implicit Cmd+A on empty selection
+
+WisprFlow appears to do an implicit `Cmd+A` (select-all-in-focused-field) when the hotkey fires with no current selection, then transforms the resulting all-text. We are **not** mirroring this. On empty selection, show only the educational toast.
+
+Reasoning:
+- Dangerous in long-text contexts (a whole Notes document, a code editor file, a Cursor pane). The user presses Opt+1 expecting a small adjustment and instead the entire document gets sent to an LLM and replaced. Even Cmd+Z to restore feels scary at that scale.
+- AX `Cmd+A` semantics vary by app — some apps select the entire document, some select only the visible line. Inconsistent behavior across apps is worse than always-explicit.
+- The educational toast already does the teaching job. Friction from "press Opt+1 → see toast → highlight → press Opt+1" is a one-time cost; surprise document replacement is recoverable but trust-eroding.
+
+The behavior is therefore: hotkey fires with empty selection → friendly educational toast surfaces, nothing else happens, no clipboard or AX state touched.
+
+## Phasing
+
+Tight phasing keeps scope small and lets us validate the AX path before investing in UI.
+
+**Phase 1 — Spine end-to-end (~1 sprint).** Goal: hardcoded Opt+1 → Polish working against the user's currently-configured LLM provider, no UI.
+
+- Implement `SelectionCaptureService` with AX-first + clipboard fallback.
+- Implement `SelectionReplacementService` with AX-write + paste-back fallback.
+- Implement `TransformExecutor` calling `LLMService.transformStream`.
+- Wire a single hardcoded transform on Opt+1 using a baked-in Polish prompt.
+- Manual smoke test across: Notes, Mail, Slack desktop, Discord, Chrome, Safari address bar, Cursor, Xcode editor, Terminal. Each app gets a row in a spreadsheet of "AX worked / clipboard fallback / both failed."
+- Decision gate: ship to nightly users on `main`. If the app coverage is bad (e.g., fails on Slack and Mail), step back and rethink before building UI.
+
+**Phase 2 — Productize (~1 sprint).** Goal: shippable feature behind a feature flag.
+
+- Wire `Prompt.category == .transform` to the executor via the new registry.
+- Build the Transforms management UI (sidebar tab + edit pane).
+- Ship two built-in transforms (`Polish` + `Prompt Engineer`).
+- Failure toasts and the floating progress pill.
+- Onboarding nudge when LLM provider is unset.
+- Feature flag in `AppFeatures` (`transformsEnabled`, default false; flip to true before release).
+
+**Phase 3 — Polish (~½ sprint).** Goal: removes feature-flag, ships to all users.
+
+- Rule-toggle composition for `Polish` (the WisprFlow micro-pattern).
+- Diff preview in the Transforms edit pane.
+- Per-Transform usage telemetry (opt-out, no content captured — follow the existing telemetry shape).
+
+## Risk and unknowns
+
+| Risk | Mitigation |
+|---|---|
+| AX `kAXSelectedTextAttribute` is inconsistent across apps (web fields, Electron, Xcode editor) | Always have the clipboard fallback. Treat AX as the fast path, not the only path. Phase 1's smoke matrix tells us how often we'll fall back. |
+| Clipboard backup/restore dance is racy with user activity | Snapshot before triggering Cmd+C; restore after Cmd+V completes; if the user copies during the transform, we accept some clipboard loss (logged warning). Document this trade-off. |
+| Hotkey collisions with macOS / app shortcuts | Validate at bind time. Default to Opt+1..Opt+9 (mostly safe). Provide collision diagnostics in the binding UI. |
+| Latency from LLM round-trip makes the feature feel slow | Phase 2 shows a progress pill so the user knows work is happening. Phase 3+: explore streaming-into-paste-buffer (high risk, deferred). |
+| Cost / privacy of cloud LLM round-trips on every transform | Default to local Apple Foundation Models / Ollama when available. User picks per-transform via the model override picker. |
+| Feature flag accidentally enabled in release before app coverage is proven | Phase 1 has an explicit decision gate before any UI work begins. |
+| Existing dictation hotkey conflicts during transform run | Suppress dictation triggers while a transform is in-flight (one transform at a time; cancel-then-restart if the user re-triggers). |
+
+## What needs locking (open questions for the owner)
+
+1. **Sidebar IA**: new top-level `Transforms` item, or nested under a larger surface (e.g., a new `Prompts` parent that contains both transform-prompts and meeting-result-prompts)? My lean: top-level for v1, refactor later if it crowds the sidebar.
+2. **Built-in default count**: two (Polish + Prompt Engineer) or three (add Summarize)? My lean: two — fewer defaults means less curation overhead and clearer "create your own" affordance.
+3. **Model selection per Transform**: ship in Phase 2 or defer to Phase 3? My lean: defer; v1 uses the user's global AIFormatter provider.
+4. **Telemetry scope**: count of transform-triggers per built-in name (opt-out), or no telemetry on this surface at all? My lean: per-name counts only, no prompts, no content — consistent with ADR-012 and the telemetry allowlist process.
+5. **Free vs paid gating**: WisprFlow gates Transforms behind Pro. We're free/GPL. Stays free, but does it require BYO LLM key (since each call costs money against the user's API)? My lean: yes, BYO-key only — same model as AIFormatter today. The Apple Foundation Models path (when usable on-device) makes this cost-free.
+
+## Connection to Undo AI edit
+
+The same conversation that prioritized Transforms accepted Undo AI edit as a small follow-up. The work is independent of this design — `Dictation` already stores `rawTranscript` and `cleanTranscript` separately, so it's a context-menu affordance in `DictationHistoryView.swift` that swaps the displayed and exported text back to `rawTranscript`. A separate ~1-day task that doesn't need an ADR.
+
+## Open work to start
+
+The next concrete artifacts, in order:
+
+1. **Spike** — wire Opt+1 to a hardcoded Polish prompt and run the app-coverage smoke matrix. Single afternoon.
+2. **ADR** — `ADR-022-transforms-system-wide-rewrite.md`. Locks: AX-first + clipboard-fallback strategy, `Prompt.category == .transform` as the unit, BYO-key requirement, feature-flag rollout.
+3. **Plan** — `plans/active/2026-05-transforms-phase-1.md` covering the Phase 1 spine. Phase 2 gets its own plan after the smoke matrix passes.
+
+I'd recommend the spike first — the AX coverage question dominates everything downstream. If AX is solid across the apps our users care about, this is straightforward. If it's bad, the design rebalances toward clipboard-only with different latency/UX trade-offs.

--- a/docs/research/wisprflow-parity-2026-05.md
+++ b/docs/research/wisprflow-parity-2026-05.md
@@ -1,0 +1,308 @@
+# WisprFlow Feature Parity Audit — May 2026
+
+> Status: **ACTIVE**. Snapshot of WisprFlow Pro's current feature surface (May 2026, captured from the macOS app) and how MacParakeet stacks up against each surface today.
+>
+> Companion doc: `wisprflow-deep-dive.md` (Feb 2026, HISTORICAL) covers the high-level positioning. Design follow-on: `transforms-design-2026-05.md` covers the chosen build-direction for Transforms.
+
+## Decisions (2026-05-11)
+
+After walking through this audit with the owner, three calls were made:
+
+1. **Auto Cleanup gradations — skip.** Keep `processingMode` as the current binary raw/clean deterministic pipeline. AI Formatter stays as a single optional polish layer with one customizable prompt. Don't ship Light/Medium/High named levels.
+2. **Undo AI edit — ship.** Surface a per-row affordance in the dictation history that swaps the displayed/exported text from `cleanTranscript` back to `rawTranscript`. Schema already stores both — pure UI work.
+3. **Transforms — prioritize.** Build the hotkey-driven version (Opt+N to rewrite selected text in any app) as the next major surface. Treated as foundation work for the already-planned voice-driven Command Mode (see `plans/active/2026-05-voice-command-agent-mode.md` candidate capability #1 and `docs/agent-mode-vision.md` lines 350–351). The hotkey and voice variants share the same underlying primitives — capture selection, run prompt through LLM, replace in place — so the hotkey form is the shortest path to those primitives.
+
+The full design exploration for Transforms lives in `transforms-design-2026-05.md`.
+
+## TL;DR
+
+WisprFlow Pro now organizes its post-dictation cleanup into five sidebar sections: **Dictionary**, **Snippets**, **Style**, **Auto Cleanup**, and **Transforms**. We have rough parity on Dictionary and Snippets (different UI shape, same underlying capability). We have nothing comparable to Style (per-app tone routing) or Transforms (Opt+N hotkeys that LLM-rewrite selected text anywhere). Auto Cleanup is binary in MacParakeet (raw vs clean) where WisprFlow ships four gradations.
+
+| WisprFlow surface | MacParakeet today | Coverage | Strategic fit |
+|---|---|---|---|
+| Dictionary (word teach + misspelling correction) | Custom Words (`word` + optional `replacement`) | Capability parity, UX-lite | Aligned — already shipped |
+| Snippets (trigger → expansion) | Text Snippets in Vocabulary panel | Capability parity, UX-lite | Aligned — already shipped |
+| Style (per-app tone: Slack vs Gmail vs Discord) | None | **Zero coverage** | Tension with local-first; LLM-dependent |
+| Auto Cleanup (None / Light / Medium / High) | `processingMode` raw/clean + binary AI Formatter | Partial — coarse | Easy to expand; aligned |
+| Transforms (Opt+N to rewrite selected text in any app) | CLI `llm transform` only | **Zero GUI coverage** | Net-new surface; expands product scope |
+
+The interesting strategic question is whether we want to follow WisprFlow toward "writing assistant that lives over every text field" or stay "fast local dictation + transcription + meetings." Each gap below is annotated with that lens.
+
+---
+
+## 1. Dictionary
+
+### WisprFlow
+
+Sidebar item `Dictionary`. Three tabs: All / Personal / Shared with team. "Add new" modal exposes two toggles:
+
+- **Correct a misspelling** — when OFF, a single text field "Add a new word" (just teach the recognizer the existence of the word, e.g. proper names, jargon). When ON, two fields appear: `Misspelling → Correct spelling`. So it's one feature with two intents in one modal.
+- **Share with team** — surfaces the entry to teammates (team is a Pro/business concept, not relevant solo).
+
+Empty-state copy: *"Flow learns your unique words and names — automatically or manually. Add personal terms, company jargon, client names, or industry-specific lingo."* The "automatically" hint is interesting — WisprFlow learns words from corrections, which we already model via `CustomWord.Source.learned`.
+
+### MacParakeet today
+
+- Model: `Sources/MacParakeetCore/Models/CustomWord.swift` — fields `word`, `replacement: String?`, `source: .manual | .learned`, `isEnabled`.
+- Pipeline: step 2 of the deterministic `TextProcessingPipeline` — regex word-boundary replacements, case-insensitive, longest-trigger-first.
+- UI: `Sources/MacParakeet/Views/Vocabulary/CustomWordsView.swift` — search, add, delete, enable/disable. Word and replacement displayed side-by-side.
+- Storage: `custom_words` table.
+
+### Gap analysis
+
+| Capability | WisprFlow | MacParakeet | Gap |
+|---|---|---|---|
+| Teach a single word (no replacement) | Yes (toggle off) | Yes (`replacement` is optional) | UX framing only |
+| Misspelling → correction | Yes (toggle on) | Yes (`replacement` non-nil) | UX framing only |
+| `.learned` from corrections | Yes ("automatically") | Schema supports it, **no producer wired up** | Behavior gap |
+| Share with team | Yes | N/A | Out of scope (solo app) |
+
+The capability gap is small. Two meaningful UX nits worth fixing:
+
+1. **Modal framing.** Our add form shows two fields side-by-side; users have to infer that leaving the replacement empty means "just teach the word." A WisprFlow-style toggle (`Correct a misspelling`) makes the intent explicit and matches how users think about it.
+2. **`.learned` is dead enum case.** We model auto-learning but don't actually populate `.learned` entries from user corrections. Either wire it up (e.g., when a user edits a freshly-pasted dictation, diff against the raw transcript and offer to save the correction as a learned word) or drop the case to remove dead surface.
+
+### Recommendation
+
+Keep — this is on-spec. Two small follow-ups:
+
+- Add `Correct a misspelling` toggle to the Add Word modal (cosmetic but clarifying).
+- Decide whether to ship auto-learning (interesting power-user behavior) or remove the `.learned` enum case (dead-code cleanup). Auto-learning is a real differentiator if we do it locally — WisprFlow ships it but their cloud sees every correction; ours could be 100% on-device.
+
+---
+
+## 2. Snippets
+
+### WisprFlow
+
+Sidebar item `Snippets`. Same All / Personal / Shared layout. Empty-state copy: *"Save anything you type often — your email, an intro, a prompt — and say a word or phrase to immediately replace it in place."* Examples shown: `"my LinkedIn"` → URL, `"rewrite prompt"` → "Rewrite this to be more concise…", `"intro email"` → email body.
+
+Add modal: `Snippet` (trigger) + `Expansion` text field + Share with team toggle.
+
+### MacParakeet today
+
+- Model: `Sources/MacParakeetCore/Models/TextSnippet.swift` — fields `trigger`, `expansion`, `isEnabled`, `useCount`, optional `action: KeyAction?`.
+- Pipeline: text-only snippets at step 4; action snippets (trailing trigger + key action like Enter) at step 3.
+- UI: `Sources/MacParakeet/Views/Vocabulary/TextSnippetsView.swift` — same management surface as Custom Words.
+- Bonus we have that they don't: trailing action snippets (e.g., say "send it" → expand to "Best, Dan" + press Enter). WisprFlow only shows pure text expansion.
+
+### Gap analysis
+
+| Capability | WisprFlow | MacParakeet | Gap |
+|---|---|---|---|
+| Trigger → text expansion | Yes | Yes | — |
+| Trigger → text + keystroke | No (apparently) | Yes (KeyAction) | We're ahead |
+| Use-count tracking | Not shown | Yes (`useCount`) | We're ahead, just don't surface it |
+| Standalone sidebar page | Yes | Embedded in Vocabulary | UX framing |
+
+### Recommendation
+
+Capability parity (plus a small lead on action snippets). The only real opportunity is presentational: WisprFlow promotes Snippets to a top-level sidebar item with a bold hero card; our Snippets are buried inside Vocabulary alongside Custom Words and processing mode toggles. If we ever do a sidebar overhaul, splitting these into discoverable top-level items would help — users probably don't realize we have snippets at all. Low priority; ship-blocker no.
+
+---
+
+## 3. Style — per-app tone routing
+
+### WisprFlow
+
+Sidebar item `Style`. Four context tabs, each pinned to a set of apps detected from the frontmost app's bundle ID:
+
+| Tab | Apps it covers (logos shown) | Preset cards |
+|---|---|---|
+| Personal messages | WhatsApp, Telegram, Discord, Instagram, … | Formal / Casual / very casual |
+| Work messages | Slack, Teams, LinkedIn, … | Formal / Casual / Excited! |
+| Email | Gmail, Spark, Outlook, Mail, … | Formal / Casual / Excited! |
+| Other | Linear, ChatGPT, Notes, … | Formal / Casual / Excited! |
+| Auto Cleanup (Beta) | All apps | None / Light / Medium / High |
+
+Each preset shows a worked example. "Formal" gets `Hey,` and a period; "very casual" drops capitalization and final punctuation entirely. Caveat banner: *"Style formatting only applies in English. More languages coming soon."*
+
+The mechanism is clear: WisprFlow reads frontmost-app bundle ID, picks the matching tab's preset, and sends both the transcript and the style preset to a cloud LLM. The LLM rewrites accordingly before paste.
+
+### MacParakeet today
+
+Zero coverage. Confirmed by grep — we don't query `NSWorkspace.frontmostApplication` for routing, we have no per-app preference surface, and our `processingMode` is a single global enum.
+
+We do have `Sources/MacParakeetCore/TextProcessing/AIFormatter.swift` with a user-customizable prompt template that runs through whichever LLM provider the user has configured. But it's a single global prompt — no per-app branching.
+
+### Gap analysis
+
+This is the largest capability gap. It's also the one with the most direct tension with our north star.
+
+**Why this is interesting:**
+- Real value when it works. The example deltas in the screenshots (formal email vs lowercase Discord DM) are exactly the friction users currently fix by hand.
+- The mechanism is straightforward to implement: bundle-ID lookup → preset selection → prompt suffix.
+
+**Why we'd think twice:**
+- It only works well with an LLM in the loop. Deterministic pipelines (our current `clean` mode) can't pull off "rewrite this with the energy of an excited Slack message." So shipping this means making LLM cleanup a first-class path, not a side feature.
+- Local-first commitment. We can mitigate by routing through Apple Foundation Models or a local Ollama provider when available, and falling back to user-configured cloud providers. ADR-002 allows opt-in cloud LLM, so this is consistent in principle — but defaulting users into LLM-rewriting every dictation crosses a line we haven't crossed before.
+- App-list churn. WisprFlow ships a hardcoded list of which apps map to which tab. Maintaining that list (and answering "why isn't $APP in the work-messages tab?") becomes ongoing product work.
+
+### Recommendation
+
+Don't blindly copy. But there's a coherent smaller version we could ship:
+
+1. **Make AIFormatter context-aware.** Pass the frontmost app's bundle ID (and optionally the bundle name and category) into the prompt as a `{{contextApp}}` template variable. Power users get per-app behavior through prompt engineering; we ship none of the UI.
+2. **Or ship a single "Tone" preset switcher.** Three or four global presets (`Faithful`, `Polished`, `Casual`, `Excited`) on the Auto Cleanup card — no per-app routing, just a global mood. This is the 80/20.
+
+The full WisprFlow Style page is feature-creepy for our product shape. The bundle-ID-as-prompt-context move is cheap and aligned.
+
+---
+
+## 4. Auto Cleanup gradations
+
+### WisprFlow
+
+Auto Cleanup tab inside Style. Four levels with worked examples (same input "hey joey, we still on for coffee or…"):
+
+- **None** — exact transcript, including mistakes.
+- **Light** — fixes filler words and grammar. *"Hey Joey, are we still on for coffee? I think we should leave earlier to make it there in time. There might be traffic. What are you thinking?"*
+- **Medium** — clarity and conciseness. Adds semicolons, restructures.
+- **High** — rewrites for brevity and polish. *"Hey Joey, are we still on for coffee? Let's leave early to beat traffic. What do you think?"*
+
+Important note: *"Note your original dictation is never lost. Just go to the three dots next to a recent dictation in the Home tab, then click 'Undo AI edit.'"* — original transcript is preserved separately, edit is reversible.
+
+### MacParakeet today
+
+Two independent layers:
+
+- `Dictation.ProcessingMode` = `.raw` or `.clean`. `.raw` = no edits. `.clean` = deterministic 5-step pipeline (filler removal + custom words + snippet expansion + whitespace).
+- `AIFormatter` — optional LLM polish layer, controlled by `aiFormatterEnabled: Bool` + `aiFormatterPrompt: String` in `AppRuntimePreferences`. Off by default; one global prompt.
+
+So we have two levers that map roughly to "no edits" / "deterministic clean" / "deterministic + LLM polish" — three states, where WisprFlow has four with clearer naming.
+
+We also already keep the raw transcript in the dictation history, so "Undo AI edit" is structurally feasible — we just don't expose a one-click revert.
+
+### Gap analysis
+
+| Level | WisprFlow | MacParakeet equivalent |
+|---|---|---|
+| None | Exact STT output | `processingMode = .raw` |
+| Light | Filler + grammar | `processingMode = .clean` (no LLM) |
+| Medium | Clarity/conciseness | `aiFormatterEnabled = true` with a Medium-shaped prompt |
+| High | Brevity/polish rewrite | `aiFormatterEnabled = true` with a High-shaped prompt |
+| Undo AI edit | One-click revert | Raw is stored, no UI |
+
+The gap is mostly UI framing plus prompt curation. The hard part is already solved: we store the raw transcript.
+
+### Recommendation
+
+Worth doing, and it's the cleanest WisprFlow surface to borrow. Concrete shape:
+
+1. Collapse the two existing toggles (`processingMode`, `aiFormatterEnabled`) into one **Cleanup Level** picker: `None`, `Light`, `Medium`, `High`. `None` and `Light` stay LLM-free (current behavior). `Medium` and `High` enable the LLM with curated default prompts.
+2. Expose **Undo AI edit** on each history row — we already have the raw transcript saved next to the cleaned one.
+3. Keep the customizable `aiFormatterPrompt` as an "advanced" override that replaces the High preset when set.
+
+This is on-spec for the existing AIFormatter architecture and meaningfully closes the gap users will notice when comparing tools. ADR-implication: we'd want an ADR or amendment to ADR-004 (deterministic pipeline) to capture that Levels 3–4 deliberately add a non-deterministic LLM stage on top of the deterministic floor.
+
+---
+
+## 5. Transforms — system-wide hotkey rewrites
+
+### WisprFlow
+
+Sidebar item `Transforms` (Beta). The model is: select text in any app, press `Opt+1` (or `Opt+2`, etc.), and the selected text is replaced in place with an LLM rewrite per the bound transform's prompt.
+
+Ships two defaults plus user-defined slots:
+
+- **Opt+1: Polish** — *"Polish rewrites your text to sound clearer, in your voice."* Toggleable rules: Make more concise, Reword for clarity, Reorder for readability, Add structure for readability. Diff view shows strikethroughs (deleted text) and highlights (insertions): `hey so` → `Hey,`, `kinda long` → struck through, `cuz` → `because`. Each rule toggle re-renders the diff live.
+- **Opt+2: Prompt Engineer** — *"Takes messy, spoken, unstructured thoughts and converts them into a clean, optimized AI prompt."* Output template includes **Title**, **Role & stance**, **Task**, **Context**, **Inputs available**, **Examples / References**, **Execution checklist**, **Conflict resolution**. Customizable prompt body in the right pane.
+- **Create your own** — name + hotkey + prompt body. Empty state hints `Boss Mode` as a placeholder name. Validation: shortcut must include a modifier and a valid key/mouse.
+
+There's also a global `Opt in` toggle for the whole Transforms feature, with copy: *"Toggles the Transforms feature to update your text with a single shortcut. Resets the shortcuts to default when disabled."*
+
+Failure mode shown in one screenshot: *"Couldn't detect text in your text box — please click into your text box and try again."* — confirms they use AX text selection / focused element APIs, and gracefully fail when the AX path isn't viable.
+
+### MacParakeet today
+
+Zero GUI coverage. The pieces exist but are not wired into a system-wide hotkey path:
+
+- `Sources/MacParakeetCore/Services/LLM/LLMService.swift` — has `transform(text:prompt:)`, `transformStream`, `transformDetailed`.
+- `Sources/CLI/Commands/LLMTransformCommand.swift` — `macparakeet-cli llm transform` works on stdin/file.
+- `Prompt` model has a `.transform` category that's never populated with shipped prompts. The Prompt Library is wired into meeting transcripts only (category `.result`).
+- Hotkey infrastructure exists (custom hotkey support, ADR-009), but is currently bound to dictation triggers, not transform-on-selection.
+
+So the LLM-rewrite primitive exists; what's missing is the surface: hotkey routing → AX-driven selection grab → paste-back.
+
+### Gap analysis
+
+This is the biggest net-new capability surface. Stack of pieces needed:
+
+1. **Selection capture.** AX query for focused element + selected text. We do not currently do this. Fallback: copy-via-Cmd+C-simulation, read clipboard, write back. (WisprFlow's error message suggests they use AX-first and gracefully fail.)
+2. **Hotkey routing.** Our hotkey system today is single-purpose (dictation trigger). Would need to extend to N transform-hotkeys with collision detection and per-transform binding UI.
+3. **Transform definition UI.** Name + shortcut + prompt + rule toggles (the rule toggles are a nice WisprFlow detail — they let users tune a built-in prompt without writing one). We have prompt infrastructure but no "rule toggle" composition.
+4. **Diff preview pane.** Showing a live diff of the expected transformation as you toggle rules — this is genuinely well done in their UI and is the kind of polish that signals "this is a real feature."
+5. **Paste-back path.** Replace selection in place via AX (or fall back to clipboard-paste). We have paste simulation for dictation; this would reuse most of it.
+6. **Built-in defaults.** Shipping a Polish-equivalent and a Prompt-Engineer-equivalent is the on-ramp.
+
+### Recommendation
+
+This is where the strategic decision actually lives. Two coherent answers:
+
+**Path A — stay focused.** Ship nothing here. We are a dictation + transcription + meeting tool. Writing assistance is what Raycast AI, ChatGPT's macOS app, Claude's macOS app, and TextSnipped already do. We compete on "fastest local dictation," not "best inline rewrites." This is the lower-risk path and matches the existing positioning.
+
+**Path B — add Transforms as a third leg.** If we believe dictation users also want post-dictation rewrites (and the conversion of dictation → polished prose → paste is genuinely the same job), then Transforms belongs in MacParakeet. Sequence:
+
+1. Wire `Prompt.category = .transform` to a hotkey-driven path. Reuse the existing Prompt Library UI for the management surface.
+2. Implement AX selection-capture with clipboard fallback (the WisprFlow error toast tells us this is the right boundary).
+3. Ship two defaults that mirror Polish and Prompt Engineer (we already have similar prompt shapes in our Prompt Library for meetings — porting is mostly copy).
+4. Skip the rule-toggle composition in v1 — it's a delightful detail but adds a lot of UI surface. Ship raw editable prompts only.
+5. Skip the live diff preview in v1. Hard to implement well, easy to live without.
+
+The hidden cost on Path B is the AX integration; once we ship system-wide selection capture, users will expect everything else (commands like "translate this," "make it bullets," etc.) and our scope expands.
+
+My honest read: **defer.** This is the surface most worth watching but probably not the next thing we ship. If we ever do build voice-driven Command Mode (mentioned in the historical wisprflow-deep-dive doc and partially echoed by Agent Mode vision), Transforms is the natural prerequisite — but speak-to-rewrite-selection is a much higher-leverage version of the same primitive than hotkey-to-rewrite-selection.
+
+---
+
+## Cross-cutting observations
+
+### Local-first vs cloud LLM-dependent
+
+Style, Auto Cleanup Medium/High, and Transforms all assume a fast cloud LLM. WisprFlow defaults users into cloud — they're a $12-15/mo subscription with their own GPT-4-class pipeline behind it.
+
+Our current architecture (per ADR-002 amendment + ADR-011) is local-first with **opt-in** cloud LLM providers. That means every feature that depends on the LLM has to either:
+- Degrade gracefully when the user hasn't configured a provider (just show the deterministic level), or
+- Push users to configure a provider as part of onboarding the feature.
+
+This isn't a blocker but it shapes every shipping decision. The local-first commitment is a real product asset (privacy, no subscription, offline-capable) — features that erode it should clear a high bar.
+
+### Solo vs team
+
+Every WisprFlow page shows All / Personal / Shared with team tabs. We are a solo app. We have no business case for team features and the existing competitive set above us (Granola for meetings, Notion AI for writing) owns that lane. The Shared tabs are noise for our roadmap; ignore.
+
+### Hotkey discoverability
+
+WisprFlow leans hard on Opt+number bindings, with the hotkey shown inline on every transform card. This is a UI pattern worth studying even if we don't ship Transforms — it works because the hotkey is the primary affordance, not a hidden shortcut. If we ever build a multi-hotkey surface (e.g., separate hotkeys for dictation modes or for transforms), the WisprFlow visual treatment is a good reference.
+
+### What WisprFlow doesn't have that we do
+
+- Local file/video transcription (Drop a file, get a transcript, free).
+- YouTube transcription.
+- Meeting recording (ScreenCaptureKit + mic dual-stream).
+- Live meeting Notes/Transcript/Ask three-tab panel.
+- Multi-language local STT via WhisperKit (KO/JA/ZH coverage).
+- A real CLI (`macparakeet-cli`) for scripting and downstream agents.
+- 100% local default. Free. Open source.
+
+The audit above is "what could we steal from them" — but their feature set is also conspicuously narrower than ours in the dimensions that matter for our positioning.
+
+---
+
+## Prioritized next moves (post-decision)
+
+Ranked after the 2026-05-11 decisions above:
+
+| # | Move | Cost | Fit |
+|---|---|---|---|
+| 1 | **Transforms (Opt+N → rewrite selection in any app)** — full design in `transforms-design-2026-05.md`. Foundation for already-planned voice Command Mode. | Large | High |
+| 2 | **Undo AI edit** — per-row affordance in dictation history to restore `rawTranscript` over `cleanTranscript`. Schema already stores both; pure UI. | Trivial | High |
+| 3 | Dictionary modal toggle: `Correct a misspelling` framing. | Trivial | High |
+| 4 | Decide on `.learned` source case: wire up auto-learning from corrections, or remove the dead enum case. | Small-Medium (if shipping) | High if shipped |
+| 5 | Promote Snippets / Custom Words to top-level sidebar items in the next IA overhaul. | Small (UI only) | Medium |
+
+**Explicitly deferred / declined:**
+
+- Auto Cleanup gradations (None/Light/Medium/High) — declined 2026-05-11. Current binary raw/clean + optional AI Formatter is the chosen shape.
+- Full Style page (per-app tabs with presets) — deferred. Tension with local-first; high maintenance overhead. The `{{contextApp}}` template-variable approach captures the 80/20 if we ever want it.
+- "Shared with team" surfaces in Dictionary/Snippets — out of scope (solo app).


### PR DESCRIPTION
## Summary
- New **WisprFlow parity audit** (`docs/research/wisprflow-parity-2026-05.md`) — feature-by-feature comparison of WisprFlow Pro's current sidebar (Dictionary / Snippets / Style / Auto Cleanup / Transforms) against what we ship today, grounded in concrete file paths and capabilities.
- New **Transforms design exploration** (`docs/research/transforms-design-2026-05.md`) — five-component architecture (`SelectionCaptureService` + `SelectionReplacementService` + `TransformExecutor` + hotkey routing + management UI), three-phase shipping plan with an AX-coverage smoke spike as the explicit decision gate, custom animated loader directions, and locked decisions (no implicit Cmd+A on empty selection, no master Opt-in toggle, hotkey trigger only in v1).

## Decisions locked in the parity doc
1. **Skip Auto Cleanup gradations.** Keep our binary raw/clean + optional AI Formatter; don't ship Light/Medium/High.
2. **Ship Undo AI edit.** Schema already stores both `rawTranscript` and `cleanTranscript` separately; pure UI work.
3. **Prioritize Transforms.** Hotkey-driven only in v1; voice-driven version stays in the existing `plans/active/2026-05-voice-command-agent-mode.md`.

## Why two docs, not one
- The parity audit is the input — the "what's the gap" artifact.
- The Transforms design is the output — the "here's how we close the biggest one" artifact.
- They reference each other but are independently reviewable.

## What this PR is NOT
- Not an ADR. The Transforms work will need its own ADR (proposed ADR-022) to lock the AX-first + clipboard-fallback strategy, BYO-key requirement, and feature-flag rollout — written as a follow-up after the AX-coverage spike.
- Not a plan in `plans/active/`. Plans come after the spike answers the AX-coverage question.
- No code changes. Docs only.

## Next steps after this lands
- Small separate PR for the Undo AI edit affordance in `DictationHistoryView`.
- AX-coverage spike (single afternoon) — wire `Opt+1 → hardcoded Polish` end-to-end and run a smoke matrix across Notes, Mail, Slack desktop, Discord, Chrome, Safari address bar, Cursor, Xcode, Terminal. Decision gate before any Transforms UI work.
- Then ADR-022 + Phase 1 plan + the actual implementation PR.

## Test plan
- [ ] Read the parity audit's TL;DR matrix — does each row match your understanding of what we ship today?
- [ ] Read the Transforms design's "Trigger" section — confirms hotkey-only v1, no voice.
- [ ] Read "No-selection and error UX" — confirms the educational toast pattern with the user's actual bound hotkey in the copy, and the decline of implicit Cmd+A.
- [ ] Read "Visual feedback while a Transform runs" — three loader animation directions (coral particle orbit / morphing rosette / bezier scribe) with bezier scribe as the lean.
- [ ] Skim the five open product questions at the bottom of the Transforms design — flag any you'd answer differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added research and design documentation for planning purposes, including feature specifications and competitive analysis.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moona3k/macparakeet/pull/276)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->