### PR TITLE
Add Undo AI edit per-row affordance in dictation history

### DIFF
--- a/Sources/CLI/Commands/HistoryCommand.swift
+++ b/Sources/CLI/Commands/HistoryCommand.swift
@@ -60,7 +60,9 @@ struct DictationsSubcommand: ParsableCommand {
             for d in dictations {
                 let date = formatter.string(from: d.createdAt)
                 let seconds = d.durationMs / 1000
-                let text = d.cleanTranscript ?? d.rawTranscript
+                // displayText honors the per-row "Undo AI edit" override so
+                // the CLI matches what the GUI shows for the same row.
+                let text = d.displayText
                 let preview = text.count > 80 ? String(text.prefix(80)) + "..." : text
                 print("[\(date)] (\(seconds)s) \(preview)  (\(d.id.uuidString.prefix(8)))")
             }
@@ -168,7 +170,7 @@ struct SearchSubcommand: ParsableCommand {
 
             for d in results {
                 let date = formatter.string(from: d.createdAt)
-                let text = d.cleanTranscript ?? d.rawTranscript
+                let text = d.displayText
                 let preview = text.count > 80 ? String(text.prefix(80)) + "..." : text
                 print("[\(date)] \(preview)")
             }

--- a/Sources/MacParakeet/App/MenuBarCoordinator.swift
+++ b/Sources/MacParakeet/App/MenuBarCoordinator.swift
@@ -291,7 +291,8 @@ final class MenuBarCoordinator: NSObject, NSMenuDelegate {
         guard let env = environmentProvider() else { return }
         Task {
             guard let dictation = (try? env.dictationRepo.fetchAll(limit: 1))?.first else { return }
-            let text = dictation.cleanTranscript ?? dictation.rawTranscript
+            // displayText honors the per-row "Undo AI edit" override.
+            let text = dictation.displayText
             await pasteFromMenu(text: text, clipboardService: env.clipboardService)
         }
     }
@@ -301,7 +302,7 @@ final class MenuBarCoordinator: NSObject, NSMenuDelegate {
               let id = sender.representedObject as? UUID else { return }
         Task {
             guard let dictation = try? env.dictationRepo.fetch(id: id) else { return }
-            let text = dictation.cleanTranscript ?? dictation.rawTranscript
+            let text = dictation.displayText
             await pasteFromMenu(text: text, clipboardService: env.clipboardService)
         }
     }
@@ -380,7 +381,7 @@ final class MenuBarCoordinator: NSObject, NSMenuDelegate {
 
         let submenu = NSMenu()
         for dictation in dictations {
-            let text = (dictation.cleanTranscript ?? dictation.rawTranscript)
+            let text = dictation.displayText
                 .replacingOccurrences(of: "\n", with: " ")
             let truncated = text.count > 40 ? String(text.prefix(40)) + "…" : text
             let item = NSMenuItem(

--- a/Sources/MacParakeet/Views/History/DictationHistoryView.swift
+++ b/Sources/MacParakeet/Views/History/DictationHistoryView.swift
@@ -301,8 +301,13 @@ struct DictationCardRow: View {
                             .padding(.vertical, 2)
                             .background(Capsule().fill(Color.primary.opacity(0.06)))
                             .accessibilityLabel("Showing raw transcript")
+                            .transition(
+                                .scale(scale: 0.6, anchor: .leading)
+                                    .combined(with: .opacity)
+                            )
                     }
                 }
+                .animation(DesignSystem.Animation.portalLift, value: dictation.displayRawTranscript)
 
                 Spacer()
 
@@ -338,6 +343,8 @@ struct DictationCardRow: View {
                 .foregroundStyle(.primary)
                 .lineLimit(3)
                 .frame(maxWidth: .infinity, alignment: .leading)
+                .contentTransition(.opacity)
+                .animation(.easeInOut(duration: 0.22), value: dictation.displayRawTranscript)
         }
         .padding(DesignSystem.Spacing.md)
         .scaleEffect(isPlayingThis ? 1.005 : 1.0)

--- a/Sources/MacParakeet/Views/History/DictationHistoryView.swift
+++ b/Sources/MacParakeet/Views/History/DictationHistoryView.swift
@@ -329,11 +329,11 @@ struct DictationCardRow: View {
 
                     CardMenuButton(
                         hasAudio: dictation.audioPath != nil,
-                        hasAIEdit: dictation.hasAIEdit,
+                        hasAIEdit: dictation.hasAIEdit && onToggleAIEdit != nil,
                         isShowingRaw: dictation.displayRawTranscript,
                         onDownloadAudio: { onDownloadAudio?() },
                         onDelete: { onDelete() },
-                        onToggleAIEdit: { onToggleAIEdit?() }
+                        onToggleAIEdit: onToggleAIEdit
                     )
                 }
             }
@@ -450,7 +450,7 @@ private struct CardMenuButton: View {
     let isShowingRaw: Bool
     let onDownloadAudio: () -> Void
     let onDelete: () -> Void
-    let onToggleAIEdit: () -> Void
+    let onToggleAIEdit: (() -> Void)?
 
     var body: some View {
         CardActionButton(icon: "ellipsis", color: .secondary) {
@@ -469,7 +469,7 @@ private struct CardMenuButton: View {
         // Undo AI edit: only present rows whose cleaned text actually differs
         // from the raw STT output. Label flips so the menu item describes the
         // next action, not the current state.
-        if hasAIEdit {
+        if hasAIEdit, let onToggleAIEdit {
             let title = isShowingRaw ? "Re-apply AI edit" : "Undo AI edit"
             let icon = isShowingRaw ? "wand.and.stars" : "arrow.uturn.backward"
             menu.addItem(CallbackMenuItem(title: title, icon: icon, action: onToggleAIEdit))

--- a/Sources/MacParakeet/Views/History/DictationHistoryView.swift
+++ b/Sources/MacParakeet/Views/History/DictationHistoryView.swift
@@ -141,7 +141,8 @@ struct DictationHistoryView: View {
                             onDelete: {
                                 viewModel.pendingDeleteDictation = dictation
                             },
-                            onDownloadAudio: { viewModel.downloadAudio(for: dictation) }
+                            onDownloadAudio: { viewModel.downloadAudio(for: dictation) },
+                            onToggleAIEdit: { viewModel.toggleDisplayRawTranscript(for: dictation) }
                         )
                         .padding(.horizontal, DesignSystem.Spacing.lg)
                         .padding(.bottom, DesignSystem.Spacing.sm)
@@ -188,7 +189,7 @@ struct DictationHistoryView: View {
             }
             .buttonStyle(.plain)
 
-            Text(dictation.cleanTranscript ?? dictation.rawTranscript)
+            Text(dictation.displayText)
                 .lineLimit(1)
                 .font(DesignSystem.Typography.body)
                 .foregroundStyle(.primary)
@@ -243,6 +244,7 @@ struct DictationCardRow: View {
     var onCopy: () -> Void
     var onDelete: () -> Void
     var onDownloadAudio: (() -> Void)?
+    var onToggleAIEdit: (() -> Void)?
 
     @State private var isHovered = false
 
@@ -287,6 +289,18 @@ struct DictationCardRow: View {
                             .padding(.horizontal, 5)
                             .padding(.vertical, 2)
                             .background(Capsule().fill(DesignSystem.Colors.successGreen.opacity(0.12)))
+                    } else if dictation.displayRawTranscript && dictation.hasAIEdit {
+                        // Subtle "raw" affordance so users can see at a glance
+                        // which rows are showing the un-AI-edited transcript.
+                        // Muted styling (not coral/green) to keep the row calm
+                        // — this is a state indicator, not a CTA.
+                        Text("Raw")
+                            .font(DesignSystem.Typography.micro)
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 2)
+                            .background(Capsule().fill(Color.primary.opacity(0.06)))
+                            .accessibilityLabel("Showing raw transcript")
                     }
                 }
 
@@ -310,8 +324,11 @@ struct DictationCardRow: View {
 
                     CardMenuButton(
                         hasAudio: dictation.audioPath != nil,
+                        hasAIEdit: dictation.hasAIEdit,
+                        isShowingRaw: dictation.displayRawTranscript,
                         onDownloadAudio: { onDownloadAudio?() },
-                        onDelete: { onDelete() }
+                        onDelete: { onDelete() },
+                        onToggleAIEdit: { onToggleAIEdit?() }
                     )
                 }
             }
@@ -350,7 +367,7 @@ struct DictationCardRow: View {
     // MARK: - Highlighted Transcript
 
     private var highlightedTranscript: AttributedString {
-        let text = dictation.cleanTranscript ?? dictation.rawTranscript
+        let text = dictation.displayText
         let attributed = NSMutableAttributedString(string: text)
 
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -422,8 +439,11 @@ private struct CardActionButton: View {
 
 private struct CardMenuButton: View {
     let hasAudio: Bool
+    let hasAIEdit: Bool
+    let isShowingRaw: Bool
     let onDownloadAudio: () -> Void
     let onDelete: () -> Void
+    let onToggleAIEdit: () -> Void
 
     var body: some View {
         CardActionButton(icon: "ellipsis", color: .secondary) {
@@ -437,6 +457,18 @@ private struct CardMenuButton: View {
         if hasAudio {
             let downloadAction = onDownloadAudio
             menu.addItem(CallbackMenuItem(title: "Export Audio", icon: "square.and.arrow.up", action: downloadAction))
+        }
+
+        // Undo AI edit: only present rows whose cleaned text actually differs
+        // from the raw STT output. Label flips so the menu item describes the
+        // next action, not the current state.
+        if hasAIEdit {
+            let title = isShowingRaw ? "Re-apply AI edit" : "Undo AI edit"
+            let icon = isShowingRaw ? "wand.and.stars" : "arrow.uturn.backward"
+            menu.addItem(CallbackMenuItem(title: title, icon: icon, action: onToggleAIEdit))
+        }
+
+        if !menu.items.isEmpty {
             menu.addItem(.separator())
         }
 

--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -625,6 +625,21 @@ public final class DatabaseManager: Sendable {
             try DictationRepository.backfillDailyStats(db: db)
         }
 
+        // v0.12 — "Undo AI edit" per-row override. When true, history /
+        // history-copy / menu-bar-paste / export surfaces show `rawTranscript`
+        // even if `cleanTranscript` is non-nil. Reversible — the cleaned
+        // value stays on the row. Pre-check column existence so a hand-restored
+        // DB (or one whose grdb_migrations row was lost) doesn't fail with
+        // `duplicate column` on re-run.
+        migrator.registerMigration("v0.12-dictation-display-raw") { db in
+            let existingColumns = try db.columns(in: "dictations").map(\.name)
+            if !existingColumns.contains("displayRawTranscript") {
+                try db.alter(table: "dictations") { t in
+                    t.add(column: "displayRawTranscript", .boolean).notNull().defaults(to: false)
+                }
+            }
+        }
+
         try migrator.migrate(dbQueue)
         try reconcileBuiltInPrompts()
         try reconcileBuiltInQuickPrompts()

--- a/Sources/MacParakeetCore/Database/DictationRepository.swift
+++ b/Sources/MacParakeetCore/Database/DictationRepository.swift
@@ -16,6 +16,17 @@ public protocol DictationRepositoryProtocol: Sendable {
     /// Symmetric counterpart to `deleteAll()` (rows deleted, stats preserved).
     func resetLifetimeStats() throws
 
+    /// "Undo AI edit" toggle. Persists the per-row `displayRawTranscript`
+    /// override that controls whether downstream surfaces display
+    /// `rawTranscript` over `cleanTranscript`. Does not touch lifetime/daily
+    /// stats — the dictation's `durationMs` / `wordCount` are unchanged and a
+    /// view-only flag should not perturb counters.
+    ///
+    /// Returns `true` if the row was found and updated, `false` if no
+    /// matching dictation exists.
+    @discardableResult
+    func setDisplayRawTranscript(id: UUID, value: Bool) throws -> Bool
+
     // Daily rollup reads (Stats tab). The rollup is private write-side state —
     // only the read surface is exposed here. Conformers MUST implement these
     // explicitly: no default no-op implementations, because a "silently returns
@@ -257,6 +268,26 @@ public final class DictationRepository: DictationRepositoryProtocol {
     public func deleteHidden() throws {
         try dbQueue.write { db in
             try db.execute(sql: "DELETE FROM dictations WHERE hidden = 1")
+        }
+    }
+
+    /// Persists the per-row `displayRawTranscript` override ("Undo AI edit").
+    /// Uses GRDB's keyed update path (not raw SQL with UUID) per the project
+    /// gotcha note in CLAUDE.md: GRDB stores UUIDs via Codable encoding which
+    /// can differ from `uuidString`. Also bumps `updatedAt` so the change is
+    /// reflected if anything downstream sorts by it.
+    @discardableResult
+    public func setDisplayRawTranscript(id: UUID, value: Bool) throws -> Bool {
+        try dbQueue.write { db in
+            guard var dictation = try Dictation.fetchOne(db, key: id) else {
+                return false
+            }
+            // No-op short-circuit so we don't bump updatedAt for repeat clicks.
+            guard dictation.displayRawTranscript != value else { return true }
+            dictation.displayRawTranscript = value
+            dictation.updatedAt = Date()
+            try dictation.update(db)
+            return true
         }
     }
 

--- a/Sources/MacParakeetCore/Models/Dictation.swift
+++ b/Sources/MacParakeetCore/Models/Dictation.swift
@@ -21,6 +21,13 @@ public struct Dictation: Codable, Identifiable, Sendable {
     /// Engine-specific model variant id (e.g. the Whisper model id).
     /// `nil` for engines without variants and for legacy rows.
     public var engineVariant: String?
+    /// "Undo AI edit" toggle. When `true`, surfaces (`displayText`, history
+    /// copy, recent-paste menu, export) show `rawTranscript` even when a
+    /// `cleanTranscript` exists. Reversible — flipping back to `false`
+    /// restores the AI-edited text without recomputing it. Defaults to
+    /// `false` for new rows and for legacy rows backfilled by the
+    /// `v0.12-dictation-display-raw` migration.
+    public var displayRawTranscript: Bool
 
     public enum ProcessingMode: String, Codable, Sendable {
         case raw
@@ -65,7 +72,8 @@ public struct Dictation: Codable, Identifiable, Sendable {
         hidden: Bool = false,
         wordCount: Int = 0,
         engine: String? = nil,
-        engineVariant: String? = nil
+        engineVariant: String? = nil,
+        displayRawTranscript: Bool = false
     ) {
         self.id = id
         self.createdAt = createdAt
@@ -82,6 +90,68 @@ public struct Dictation: Codable, Identifiable, Sendable {
         self.wordCount = wordCount
         self.engine = engine
         self.engineVariant = engineVariant
+        self.displayRawTranscript = displayRawTranscript
+    }
+
+    // MARK: - Codable
+
+    private enum CodingKeys: String, CodingKey {
+        case id, createdAt, durationMs, rawTranscript, cleanTranscript
+        case audioPath, pastedToApp, processingMode, status, errorMessage
+        case updatedAt, hidden, wordCount, engine, engineVariant
+        case displayRawTranscript
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        durationMs = try container.decode(Int.self, forKey: .durationMs)
+        rawTranscript = try container.decode(String.self, forKey: .rawTranscript)
+        cleanTranscript = try container.decodeIfPresent(String.self, forKey: .cleanTranscript)
+        audioPath = try container.decodeIfPresent(String.self, forKey: .audioPath)
+        pastedToApp = try container.decodeIfPresent(String.self, forKey: .pastedToApp)
+        processingMode = try container.decode(ProcessingMode.self, forKey: .processingMode)
+        status = try container.decode(DictationStatus.self, forKey: .status)
+        errorMessage = try container.decodeIfPresent(String.self, forKey: .errorMessage)
+        updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+        hidden = try container.decode(Bool.self, forKey: .hidden)
+        wordCount = try container.decode(Int.self, forKey: .wordCount)
+        engine = try container.decodeIfPresent(String.self, forKey: .engine)
+        engineVariant = try container.decodeIfPresent(String.self, forKey: .engineVariant)
+        // Decode-if-present so legacy serialized snapshots (in-flight Codable
+        // payloads, tests) round-trip without explicitly setting the field.
+        displayRawTranscript = try container.decodeIfPresent(Bool.self, forKey: .displayRawTranscript) ?? false
+    }
+}
+
+// MARK: - Display helpers
+
+public extension Dictation {
+    /// Text shown in history, copied to the clipboard from history, pasted by
+    /// the menu-bar "recent dictations" submenu, and exported. Honors the
+    /// `displayRawTranscript` override added by the "Undo AI edit" feature.
+    ///
+    /// When `displayRawTranscript == true`, callers see `rawTranscript` even
+    /// if a `cleanTranscript` exists — the cleaned version is preserved on the
+    /// row so the override is reversible.
+    var displayText: String {
+        if displayRawTranscript {
+            return rawTranscript
+        }
+        return cleanTranscript ?? rawTranscript
+    }
+
+    /// True when the dictation has an AI-edited / deterministically-cleaned
+    /// version that differs from the raw STT output. Drives whether the
+    /// "Undo AI edit" affordance is offered on a row.
+    ///
+    /// `processingMode` isn't checked here — what matters is "is there a
+    /// distinct cleaned version we could revert from?" not "what mode was
+    /// selected at capture time."
+    var hasAIEdit: Bool {
+        guard let clean = cleanTranscript else { return false }
+        return clean != rawTranscript
     }
 }
 
@@ -108,5 +178,6 @@ extension Dictation: FetchableRecord, PersistableRecord {
         case id, createdAt, durationMs, rawTranscript, cleanTranscript
         case audioPath, pastedToApp, processingMode, status, errorMessage, updatedAt
         case hidden, wordCount, engine, engineVariant
+        case displayRawTranscript
     }
 }

--- a/Sources/MacParakeetViewModels/DictationHistoryViewModel.swift
+++ b/Sources/MacParakeetViewModels/DictationHistoryViewModel.swift
@@ -246,9 +246,27 @@ public final class DictationHistoryViewModel {
             logger.error("Failed to toggle displayRawTranscript for \(dictation.id): \(error.localizedDescription)")
             return
         }
-        // Reload without bouncing stats — the toggle leaves duration/wordCount
-        // untouched, so the lifetime/daily counters can't have shifted.
-        loadDictations(shouldRefreshStats: false)
+        // In-place update — the toggle only changes display state on one row.
+        // Re-fetching + re-grouping 200 dictations to flip a Bool would
+        // re-render the entire list (visible flicker on the active row's
+        // crossfade animation) and burn a database read. Sort order /
+        // grouping are driven by `createdAt`, which the toggle never
+        // touches, so a targeted mutation is safe.
+        updateDictationInPlace(id: dictation.id) { dictation in
+            dictation.displayRawTranscript = newValue
+        }
+    }
+
+    private func updateDictationInPlace(
+        id: UUID,
+        mutate: (inout Dictation) -> Void
+    ) {
+        for sectionIdx in groupedDictations.indices {
+            if let rowIdx = groupedDictations[sectionIdx].1.firstIndex(where: { $0.id == id }) {
+                mutate(&groupedDictations[sectionIdx].1[rowIdx])
+                return
+            }
+        }
     }
 
     // MARK: - Playback

--- a/Sources/MacParakeetViewModels/DictationHistoryViewModel.swift
+++ b/Sources/MacParakeetViewModels/DictationHistoryViewModel.swift
@@ -209,7 +209,10 @@ public final class DictationHistoryViewModel {
     }
 
     public func copyToClipboard(_ dictation: Dictation) {
-        let text = dictation.cleanTranscript ?? dictation.rawTranscript
+        // Use `displayText` so the "Undo AI edit" per-row override is honored
+        // — copying a row showing raw text should copy raw text, not the
+        // suppressed cleaned version.
+        let text = dictation.displayText
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(text, forType: .string)
         Telemetry.send(.copyToClipboard(source: .history))
@@ -221,6 +224,31 @@ public final class DictationHistoryViewModel {
             guard !Task.isCancelled else { return }
             self.copiedDictationId = nil
         }
+    }
+
+    // MARK: - Undo AI edit
+
+    /// Toggle the per-row "Undo AI edit" override. Flipping to `true` shows
+    /// `rawTranscript` on history / copy / export surfaces; flipping back to
+    /// `false` re-applies the cleaned version. Persisted via the repository.
+    public func toggleDisplayRawTranscript(for dictation: Dictation) {
+        guard let repo = dictationRepo else { return }
+        guard dictation.hasAIEdit else { return }
+        let newValue = !dictation.displayRawTranscript
+        do {
+            _ = try repo.setDisplayRawTranscript(id: dictation.id, value: newValue)
+            // Intentionally no telemetry event: adding a `TelemetryEventName`
+            // case would require a companion update to the Cloudflare Worker
+            // allowlist (the Worker rejects the entire batch on unknown
+            // events). Keeping this PR scoped to Undo AI edit — telemetry can
+            // be added as a follow-up if usage signal is needed.
+        } catch {
+            logger.error("Failed to toggle displayRawTranscript for \(dictation.id): \(error.localizedDescription)")
+            return
+        }
+        // Reload without bouncing stats — the toggle leaves duration/wordCount
+        // untouched, so the lifetime/daily counters can't have shifted.
+        loadDictations(shouldRefreshStats: false)
     }
 
     // MARK: - Playback

--- a/Tests/MacParakeetTests/Database/DictationRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/DictationRepositoryTests.swift
@@ -223,11 +223,17 @@ final class DictationRepositoryTests: XCTestCase {
         let updated = try repo.setDisplayRawTranscript(id: dictation.id, value: true)
         XCTAssertTrue(updated, "setDisplayRawTranscript returns true when the row exists")
 
-        let afterUndo = try repo.fetch(id: dictation.id)
-        XCTAssertEqual(afterUndo?.displayRawTranscript, true)
-        XCTAssertEqual(afterUndo?.displayText, "um hello world", "Once raw is forced, displayText returns rawTranscript")
-        XCTAssertEqual(afterUndo?.cleanTranscript, "Hello, world.", "Cleaned text is preserved so the undo is reversible")
-        XCTAssertEqual(afterUndo?.hasAIEdit, true, "hasAIEdit stays true so the affordance keeps reading 'Re-apply'")
+        let afterUndo = try XCTUnwrap(repo.fetch(id: dictation.id))
+        XCTAssertEqual(afterUndo.displayRawTranscript, true)
+        XCTAssertEqual(afterUndo.displayText, "um hello world", "Once raw is forced, displayText returns rawTranscript")
+        XCTAssertEqual(afterUndo.cleanTranscript, "Hello, world.", "Cleaned text is preserved so the undo is reversible")
+        XCTAssertEqual(afterUndo.hasAIEdit, true, "hasAIEdit stays true so the affordance keeps reading 'Re-apply'")
+
+        let noOpUpdated = try repo.setDisplayRawTranscript(id: dictation.id, value: true)
+        XCTAssertTrue(noOpUpdated, "Same-value writes still report that the row exists")
+
+        let afterNoOp = try XCTUnwrap(repo.fetch(id: dictation.id))
+        XCTAssertEqual(afterNoOp.updatedAt, afterUndo.updatedAt, "No-op toggle should not bump updatedAt")
     }
 
     func testSetDisplayRawTranscriptIsReversible() throws {
@@ -241,9 +247,15 @@ final class DictationRepositoryTests: XCTestCase {
         _ = try repo.setDisplayRawTranscript(id: dictation.id, value: true)
         _ = try repo.setDisplayRawTranscript(id: dictation.id, value: false)
 
-        let restored = try repo.fetch(id: dictation.id)
-        XCTAssertEqual(restored?.displayRawTranscript, false)
-        XCTAssertEqual(restored?.displayText, "Cleaned.", "Re-apply restores the AI-edited text")
+        let restored = try XCTUnwrap(repo.fetch(id: dictation.id))
+        XCTAssertEqual(restored.displayRawTranscript, false)
+        XCTAssertEqual(restored.displayText, "Cleaned.", "Re-apply restores the AI-edited text")
+
+        let noOpUpdated = try repo.setDisplayRawTranscript(id: dictation.id, value: false)
+        XCTAssertTrue(noOpUpdated, "Same-value writes still report that the row exists")
+
+        let afterNoOp = try XCTUnwrap(repo.fetch(id: dictation.id))
+        XCTAssertEqual(afterNoOp.updatedAt, restored.updatedAt, "No-op re-apply should not bump updatedAt")
     }
 
     func testSetDisplayRawTranscriptUnknownIdReturnsFalse() throws {

--- a/Tests/MacParakeetTests/Database/DictationRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/DictationRepositoryTests.swift
@@ -196,4 +196,79 @@ final class DictationRepositoryTests: XCTestCase {
         let fetched = try repo.fetch(id: dictation.id)
         XCTAssertEqual(fetched?.rawTranscript, "Updated")
     }
+
+    // MARK: - Undo AI edit (displayRawTranscript)
+
+    func testDisplayRawTranscriptDefaultsFalse() throws {
+        let dictation = Dictation(
+            durationMs: 1000,
+            rawTranscript: "Hello world",
+            cleanTranscript: "Hello, world."
+        )
+        try repo.save(dictation)
+
+        let fetched = try repo.fetch(id: dictation.id)
+        XCTAssertEqual(fetched?.displayRawTranscript, false, "New rows default to showing the cleaned text")
+        XCTAssertEqual(fetched?.displayText, "Hello, world.")
+    }
+
+    func testSetDisplayRawTranscriptPersists() throws {
+        let dictation = Dictation(
+            durationMs: 1000,
+            rawTranscript: "um hello world",
+            cleanTranscript: "Hello, world."
+        )
+        try repo.save(dictation)
+
+        let updated = try repo.setDisplayRawTranscript(id: dictation.id, value: true)
+        XCTAssertTrue(updated, "setDisplayRawTranscript returns true when the row exists")
+
+        let afterUndo = try repo.fetch(id: dictation.id)
+        XCTAssertEqual(afterUndo?.displayRawTranscript, true)
+        XCTAssertEqual(afterUndo?.displayText, "um hello world", "Once raw is forced, displayText returns rawTranscript")
+        XCTAssertEqual(afterUndo?.cleanTranscript, "Hello, world.", "Cleaned text is preserved so the undo is reversible")
+        XCTAssertEqual(afterUndo?.hasAIEdit, true, "hasAIEdit stays true so the affordance keeps reading 'Re-apply'")
+    }
+
+    func testSetDisplayRawTranscriptIsReversible() throws {
+        let dictation = Dictation(
+            durationMs: 1000,
+            rawTranscript: "raw",
+            cleanTranscript: "Cleaned."
+        )
+        try repo.save(dictation)
+
+        _ = try repo.setDisplayRawTranscript(id: dictation.id, value: true)
+        _ = try repo.setDisplayRawTranscript(id: dictation.id, value: false)
+
+        let restored = try repo.fetch(id: dictation.id)
+        XCTAssertEqual(restored?.displayRawTranscript, false)
+        XCTAssertEqual(restored?.displayText, "Cleaned.", "Re-apply restores the AI-edited text")
+    }
+
+    func testSetDisplayRawTranscriptUnknownIdReturnsFalse() throws {
+        let updated = try repo.setDisplayRawTranscript(id: UUID(), value: true)
+        XCTAssertFalse(updated, "Unknown id should report no-op")
+    }
+
+    func testSetDisplayRawTranscriptDoesNotPerturbLifetimeStats() throws {
+        let dictation = Dictation(
+            durationMs: 4_000,
+            rawTranscript: "raw",
+            cleanTranscript: "Cleaned.",
+            wordCount: 3
+        )
+        try repo.save(dictation)
+
+        let before = try repo.stats()
+
+        _ = try repo.setDisplayRawTranscript(id: dictation.id, value: true)
+        _ = try repo.setDisplayRawTranscript(id: dictation.id, value: false)
+
+        let after = try repo.stats()
+        XCTAssertEqual(before.totalCount, after.totalCount)
+        XCTAssertEqual(before.totalDurationMs, after.totalDurationMs)
+        XCTAssertEqual(before.totalWords, after.totalWords)
+        XCTAssertEqual(before.longestDurationMs, after.longestDurationMs)
+    }
 }

--- a/Tests/MacParakeetTests/Models/DictationModelTests.swift
+++ b/Tests/MacParakeetTests/Models/DictationModelTests.swift
@@ -139,4 +139,72 @@ final class DictationModelTests: XCTestCase {
         let d = Dictation(durationMs: 100, rawTranscript: "")
         XCTAssertTrue(d.rawTranscript.isEmpty)
     }
+
+    // MARK: - displayText / hasAIEdit / displayRawTranscript
+
+    func testDisplayTextDefaultsToCleanWhenPresent() {
+        let d = Dictation(
+            durationMs: 1000,
+            rawTranscript: "raw",
+            cleanTranscript: "cleaned"
+        )
+        XCTAssertEqual(d.displayText, "cleaned")
+        XCTAssertTrue(d.hasAIEdit)
+        XCTAssertFalse(d.displayRawTranscript)
+    }
+
+    func testDisplayTextFallsBackToRawWhenNoClean() {
+        let d = Dictation(durationMs: 1000, rawTranscript: "only raw")
+        XCTAssertEqual(d.displayText, "only raw")
+        XCTAssertFalse(d.hasAIEdit)
+    }
+
+    func testDisplayTextRespectsDisplayRawTranscriptOverride() {
+        let d = Dictation(
+            durationMs: 1000,
+            rawTranscript: "raw text",
+            cleanTranscript: "cleaned text",
+            displayRawTranscript: true
+        )
+        XCTAssertEqual(d.displayText, "raw text")
+        XCTAssertTrue(d.hasAIEdit, "hasAIEdit is independent of the override")
+    }
+
+    func testHasAIEditFalseWhenCleanEqualsRaw() {
+        // When the cleanup pipeline runs but produces no changes (e.g. raw
+        // already had no fillers), cleanTranscript == rawTranscript. There's
+        // nothing meaningful to undo, so hasAIEdit should be false.
+        let d = Dictation(
+            durationMs: 1000,
+            rawTranscript: "same",
+            cleanTranscript: "same"
+        )
+        XCTAssertFalse(d.hasAIEdit)
+        XCTAssertEqual(d.displayText, "same")
+    }
+
+    func testLegacyDictationDecodesWithDefaultDisplayRawTranscript() throws {
+        // Snapshot serialized before v0.12 has no `displayRawTranscript` key;
+        // decode-if-present must fall back to false to preserve current behavior.
+        let json = """
+        {
+          "id": "11111111-1111-1111-1111-111111111111",
+          "createdAt": "2026-05-12T00:00:00Z",
+          "durationMs": 1000,
+          "rawTranscript": "raw",
+          "cleanTranscript": "cleaned",
+          "processingMode": "clean",
+          "status": "completed",
+          "updatedAt": "2026-05-12T00:00:00Z",
+          "hidden": false,
+          "wordCount": 1
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(Dictation.self, from: json)
+        XCTAssertEqual(decoded.displayRawTranscript, false)
+        XCTAssertEqual(decoded.displayText, "cleaned")
+    }
 }

--- a/Tests/MacParakeetTests/ViewModels/DictationHistoryViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/DictationHistoryViewModelTests.swift
@@ -360,7 +360,7 @@ final class DictationHistoryViewModelTests: XCTestCase {
         XCTAssertEqual(reloaded?.displayText, "um hello world", "displayText should now return raw")
     }
 
-    func testToggleDisplayRawTranscriptIsReversible() {
+    func testToggleDisplayRawTranscriptIsReversible() throws {
         let dictation = Dictation(
             durationMs: 1000,
             rawTranscript: "raw",
@@ -376,7 +376,8 @@ final class DictationHistoryViewModelTests: XCTestCase {
         XCTAssertEqual(current?.displayRawTranscript, true)
 
         // Re-apply
-        viewModel.toggleDisplayRawTranscript(for: current!)
+        let currentDictation = try XCTUnwrap(current)
+        viewModel.toggleDisplayRawTranscript(for: currentDictation)
         current = viewModel.groupedDictations.flatMap(\.1).first { $0.id == dictation.id }
         XCTAssertEqual(current?.displayRawTranscript, false)
         XCTAssertEqual(current?.displayText, "Cleaned.")

--- a/Tests/MacParakeetTests/ViewModels/DictationHistoryViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/DictationHistoryViewModelTests.swift
@@ -339,6 +339,65 @@ final class DictationHistoryViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.stats.isEmpty)
     }
 
+    // MARK: - Undo AI edit
+
+    func testToggleDisplayRawTranscriptFlipsAndPersists() {
+        let dictation = Dictation(
+            durationMs: 1000,
+            rawTranscript: "um hello world",
+            cleanTranscript: "Hello, world."
+        )
+        mockRepo.dictations = [dictation]
+        viewModel.configure(dictationRepo: mockRepo)
+
+        viewModel.toggleDisplayRawTranscript(for: dictation)
+
+        XCTAssertEqual(mockRepo.setDisplayRawTranscriptCalls.count, 1)
+        XCTAssertEqual(mockRepo.setDisplayRawTranscriptCalls.first?.value, true)
+
+        let reloaded = viewModel.groupedDictations.flatMap(\.1).first { $0.id == dictation.id }
+        XCTAssertEqual(reloaded?.displayRawTranscript, true)
+        XCTAssertEqual(reloaded?.displayText, "um hello world", "displayText should now return raw")
+    }
+
+    func testToggleDisplayRawTranscriptIsReversible() {
+        let dictation = Dictation(
+            durationMs: 1000,
+            rawTranscript: "raw",
+            cleanTranscript: "Cleaned."
+        )
+        mockRepo.dictations = [dictation]
+        viewModel.configure(dictationRepo: mockRepo)
+
+        // Undo
+        viewModel.toggleDisplayRawTranscript(for: dictation)
+        // Reload picks up the mutated row from the mock
+        var current = viewModel.groupedDictations.flatMap(\.1).first { $0.id == dictation.id }
+        XCTAssertEqual(current?.displayRawTranscript, true)
+
+        // Re-apply
+        viewModel.toggleDisplayRawTranscript(for: current!)
+        current = viewModel.groupedDictations.flatMap(\.1).first { $0.id == dictation.id }
+        XCTAssertEqual(current?.displayRawTranscript, false)
+        XCTAssertEqual(current?.displayText, "Cleaned.")
+    }
+
+    func testToggleDisplayRawTranscriptIsNoOpWithoutAIEdit() {
+        // No cleanTranscript == no AI edit to undo. The toggle should refuse
+        // to act so the UI never lands in a state where "Undo AI edit" toggles
+        // a meaningless flag.
+        let dictation = Dictation(
+            durationMs: 1000,
+            rawTranscript: "raw only"
+        )
+        mockRepo.dictations = [dictation]
+        viewModel.configure(dictationRepo: mockRepo)
+
+        viewModel.toggleDisplayRawTranscript(for: dictation)
+
+        XCTAssertTrue(mockRepo.setDisplayRawTranscriptCalls.isEmpty, "Should not call repo when there's no AI edit to undo")
+    }
+
     // MARK: - Helpers
 
     private func totalDictationCount() -> Int {

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -81,6 +81,11 @@ final class MockDictationRepository: DictationRepositoryProtocol, @unchecked Sen
     func setDisplayRawTranscript(id: UUID, value: Bool) throws -> Bool {
         setDisplayRawTranscriptCalls.append((id, value))
         guard let idx = dictations.firstIndex(where: { $0.id == id }) else { return false }
+        // Mirror production's no-op short-circuit: when the value is
+        // unchanged, return true without bumping `updatedAt` (the prod repo
+        // uses this to avoid touching the row on repeat clicks). Tests that
+        // assert on timestamps depend on the mock behaving identically.
+        guard dictations[idx].displayRawTranscript != value else { return true }
         dictations[idx].displayRawTranscript = value
         dictations[idx].updatedAt = Date()
         return true

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -76,6 +76,16 @@ final class MockDictationRepository: DictationRepositoryProtocol, @unchecked Sen
         resetLifetimeStatsCalled = true
     }
 
+    var setDisplayRawTranscriptCalls: [(id: UUID, value: Bool)] = []
+    @discardableResult
+    func setDisplayRawTranscript(id: UUID, value: Bool) throws -> Bool {
+        setDisplayRawTranscriptCalls.append((id, value))
+        guard let idx = dictations.firstIndex(where: { $0.id == id }) else { return false }
+        dictations[idx].displayRawTranscript = value
+        dictations[idx].updatedAt = Date()
+        return true
+    }
+
     func stats() throws -> DictationStats {
         statsCallCount += 1
         let completed = dictations.filter { $0.status == .completed }


### PR DESCRIPTION
## What

Per-row **Undo AI edit** menu on dictation history — flip any AI-cleaned row back to the raw STT output. Reversible, persistent, plays nicely with the existing Copied badge slot.

```
┌──────────────────────────────────────────────────────┐
│ 9:33 AM · 0:08 · 🎤            [▶]  [⧉]  [⋯]         │
│ Hey, are we still on for coffee?                     │
└──────────────────────────────────────────────────────┘
                                            │
                                            ▼ click ⋯
                                ┌──────────────────────┐
                                │  Export Audio        │
                                │  Undo AI edit        │
                                │  ──────────────────  │
                                │  Delete              │
                                └──────────────────────┘
                                            │
                                            ▼ click
┌──────────────────────────────────────────────────────┐
│ 9:33 AM · 0:08 · 🎤  ⟨Raw⟩     [▶]  [⧉]  [⋯]         │
│ hey so are we still on for coffee, i think we shou…  │
└──────────────────────────────────────────────────────┘
                                            │
                                            ▼ click ⋯
                                ┌──────────────────────┐
                                │  Export Audio        │
                                │  Re-apply AI edit    │
                                │  ──────────────────  │
                                │  Delete              │
                                └──────────────────────┘
```

## How it works

\`Dictation\` already stored both \`rawTranscript\` and \`cleanTranscript\` separately. This PR adds a \`displayRawTranscript: Bool\` column and a \`Dictation.displayText\` computed property, then routes **every** display consumer — history list, copy-to-clipboard, menu-bar Recent Dictations / Paste Last, CLI list+search — through it. The toggle persists across launches and round-trips cleanly.

The naïve approach in the original task brief was to flip \`processingMode\` from \`.clean\` to \`.raw\` on the saved row. A grep of every display consumer showed they all use the pattern \`cleanTranscript ?? rawTranscript\` — nobody reads \`processingMode\`. Flipping it would silently no-op. A dedicated override column is the smallest correct change.

## How to verify

1. Find a dictation in history with an AI-cleaned transcript.
2. Click the row overflow menu (⋯) → **Undo AI edit**.
3. Row now shows the raw transcript + a muted **Raw** capsule; copy and export use the raw text.
4. Same menu now reads **Re-apply AI edit** — round-trips back cleanly.
5. Rows with no AI edit (or where \`cleanTranscript == rawTranscript\`) don't show the toggle.

## Polish + bot review (all addressed)

- Subtle scale+opacity spring on the **Raw** badge entry/exit
- Transcript text crossfades via \`.contentTransition(.opacity)\` on toggle
- In-place row mutation instead of a full re-fetch (avoids flicker on the active row)
- Mock repository now mirrors prod's no-op short-circuit semantics

## Tests

\`swift test\` — **2508 XCTest + 16 Swift Testing pass** (baseline + 13 new). Repository round-trip, ViewModel toggle/reversibility, model decoding without the new column key, edge cases (unknown id, no AI edit).

## Notes

- Migration is forward-only and re-run safe (pre-checks column existence).
- Live capture-time paste still uses \`cleanTranscript ?? rawTranscript\` — this PR is purely post-hoc history revert.
- No telemetry event: adding a \`TelemetryEventName\` case is a two-repo change with the website Worker allowlist; leaving as a follow-up if usage signal is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-dictation "Undo AI edit" toggle to switch between raw and AI-edited transcript display.
  * Toggle updates History rows, playback bar, recent-items menu preview, paste actions, CLI output, and clipboard contents.
  * "Raw" badge appears when raw transcript is active; menu action flips between “Undo AI edit” and “Re‑apply AI edit”.

* **Chores / Reliability**
  * Safe database migration added to persist the per-dictation setting.

* **Tests**
  * Added unit tests for toggle behavior, persistence, reversibility, no-op cases, and legacy decoding.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moona3k/macparakeet/pull/277)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->