### PR TITLE
Spike: Transforms AX-coverage on Opt+Ctrl+1

### DIFF
--- a/Sources/MacParakeet/App/TransformsSpikeCoordinator.swift
+++ b/Sources/MacParakeet/App/TransformsSpikeCoordinator.swift
@@ -76,7 +76,7 @@ final class TransformsSpikeCoordinator {
 
         guard let llmService = llmServiceProvider() else {
             panelController?.fail(
-                message: "Transforms need an LLM provider — configure in Settings."
+                message: "Add an LLM provider in Settings"
             )
             logger.notice("transforms-spike: no LLM provider configured, aborting")
             return
@@ -96,7 +96,10 @@ final class TransformsSpikeCoordinator {
         let runID = UUID()
         activeRunID = runID
 
-        panelController?.show(label: "Polishing…")
+        // Pill starts as an icon-only rose; if the run lasts past the panel
+        // controller's patience threshold the default "Still polishing…"
+        // label fades in.
+        panelController?.show()
 
         inFlightTask = Task { @MainActor [weak self] in
             guard let self else { return }

--- a/Sources/MacParakeet/App/TransformsSpikeCoordinator.swift
+++ b/Sources/MacParakeet/App/TransformsSpikeCoordinator.swift
@@ -27,6 +27,13 @@ final class TransformsSpikeCoordinator {
     private var panelController: TransformSpikeProgressPanelController?
     private var executor: TransformExecutor?
     private var inFlightTask: Task<Void, Never>?
+    /// Per-run identity for the cancellation guard. When the user re-triggers
+    /// the hotkey mid-flight we cancel the old `inFlightTask` and start a
+    /// new one — but the old task's terminal `do/catch` may still run after
+    /// cancellation lands, and without this guard it would close the *new*
+    /// run's panel and nil out the new `inFlightTask`. Every UI / state
+    /// mutation in the task body is gated on `activeRunID == myRunID`.
+    private var activeRunID: UUID?
 
     init(llmServiceProvider: @escaping () -> LLMServiceProtocol?) {
         self.llmServiceProvider = llmServiceProvider
@@ -86,23 +93,43 @@ final class TransformsSpikeCoordinator {
         let executor = TransformExecutor(llmService: llmService)
         self.executor = executor
 
+        let runID = UUID()
+        activeRunID = runID
+
         panelController?.show(label: "Polishing…")
 
         inFlightTask = Task { @MainActor [weak self] in
             guard let self else { return }
+            defer {
+                // Only clear `inFlightTask` if this run is still the active
+                // one. Otherwise the new run's task pointer (set by the
+                // outer code that started it) would be nil'd out by our
+                // late completion.
+                if self.activeRunID == runID {
+                    self.inFlightTask = nil
+                }
+            }
             do {
                 _ = try await executor.run(
                     prompt: TransformSpikePrompts.polish,
                     onProgress: { [weak self] progress in
                         // Progress callback fires on the executor's actor
-                        // context. Hop to main for any UI updates.
-                        Task { @MainActor [weak self] in
-                            self?.handleProgress(progress)
+                        // context. Hop to main only when the UI cares —
+                        // the spike's UI only reacts to terminal `.failed`
+                        // events. Spawning a Task per LLM-streaming token
+                        // would be wasteful (and the bot reviewers flagged
+                        // it).
+                        if case .failed = progress {
+                            Task { @MainActor [weak self] in
+                                self?.handleProgress(progress)
+                            }
                         }
                     }
                 )
+                guard self.activeRunID == runID else { return }
                 self.panelController?.done(message: "Done")
             } catch let error as TransformExecutorError {
+                guard self.activeRunID == runID else { return }
                 switch error {
                 case .cancelled:
                     self.panelController?.close()
@@ -110,9 +137,9 @@ final class TransformsSpikeCoordinator {
                     self.panelController?.fail(message: error.localizedDescription)
                 }
             } catch {
+                guard self.activeRunID == runID else { return }
                 self.panelController?.fail(message: error.localizedDescription)
             }
-            self.inFlightTask = nil
         }
     }
 

--- a/Sources/MacParakeet/App/TransformsSpikeCoordinator.swift
+++ b/Sources/MacParakeet/App/TransformsSpikeCoordinator.swift
@@ -123,7 +123,8 @@ final class TransformsSpikeCoordinator {
                         // would be wasteful (and the bot reviewers flagged
                         // it).
                         if case .failed = progress {
-                            Task { @MainActor [weak self] in
+                            Task { @MainActor [weak self, runID] in
+                                guard self?.activeRunID == runID else { return }
                                 self?.handleProgress(progress)
                             }
                         }

--- a/Sources/MacParakeet/App/TransformsSpikeCoordinator.swift
+++ b/Sources/MacParakeet/App/TransformsSpikeCoordinator.swift
@@ -1,0 +1,130 @@
+import AppKit
+import Foundation
+import MacParakeetCore
+import OSLog
+
+/// Wires the Opt+Ctrl+1 hotkey to the `TransformExecutor` pipeline and the
+/// floating spike progress panel.
+///
+/// Spike scope only — see `AppFeatures.transformsSpikeEnabled` and
+/// `docs/research/transforms-design-2026-05.md`. The coordinator is created
+/// even when the feature flag is off, but `start()` is a no-op in that case
+/// so the binary surface stays unchanged.
+@MainActor
+final class TransformsSpikeCoordinator {
+    /// Hardcoded chord for the spike: Opt+Ctrl+1. Ctrl is intentional during
+    /// development to avoid colliding with the long-tail of "Opt+1 produces an
+    /// alt-character" combinations during smoke-testing. Phase 2 binds via
+    /// the per-Transform recorder UI.
+    private static let spikeHotkey: HotkeyTrigger = .chord(
+        modifiers: ["control", "option"],
+        keyCode: 18  // ANSI '1' (kVK_ANSI_1)
+    )
+
+    private let llmServiceProvider: () -> LLMServiceProtocol?
+    private let logger = Logger(subsystem: "com.macparakeet", category: "TransformsSpikeCoordinator")
+    private var shortcutManager: GlobalShortcutManager?
+    private var panelController: TransformSpikeProgressPanelController?
+    private var executor: TransformExecutor?
+    private var inFlightTask: Task<Void, Never>?
+
+    init(llmServiceProvider: @escaping () -> LLMServiceProtocol?) {
+        self.llmServiceProvider = llmServiceProvider
+    }
+
+    /// Register the spike hotkey if the feature flag is enabled. Idempotent.
+    func start() {
+        guard AppFeatures.transformsSpikeEnabled else { return }
+        guard shortcutManager == nil else { return }
+
+        panelController = TransformSpikeProgressPanelController()
+        let manager = GlobalShortcutManager(trigger: Self.spikeHotkey)
+        manager.onTrigger = { [weak self] in
+            Task { @MainActor in
+                self?.handleHotkey()
+            }
+        }
+        if manager.start() {
+            shortcutManager = manager
+            logger.notice("transforms-spike: registered hotkey Opt+Ctrl+1")
+        } else {
+            logger.error("transforms-spike: failed to register Opt+Ctrl+1 event tap")
+        }
+    }
+
+    /// Tear down event tap + in-flight work. Called on app termination.
+    func stop() {
+        inFlightTask?.cancel()
+        inFlightTask = nil
+        shortcutManager?.stop()
+        shortcutManager = nil
+        panelController?.close()
+        panelController = nil
+    }
+
+    // MARK: - Hotkey handler
+
+    private func handleHotkey() {
+        guard AppFeatures.transformsSpikeEnabled else { return }
+
+        guard let llmService = llmServiceProvider() else {
+            panelController?.fail(
+                message: "Transforms need an LLM provider — configure in Settings."
+            )
+            logger.notice("transforms-spike: no LLM provider configured, aborting")
+            return
+        }
+
+        // Cancel any in-flight transform if the user re-triggers the hotkey
+        // before the previous one finishes. Phase 2's design doc calls for
+        // cancel-then-restart on re-trigger.
+        if let inFlightTask {
+            inFlightTask.cancel()
+            self.inFlightTask = nil
+        }
+
+        let executor = TransformExecutor(llmService: llmService)
+        self.executor = executor
+
+        panelController?.show(label: "Polishing…")
+
+        inFlightTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                _ = try await executor.run(
+                    prompt: TransformSpikePrompts.polish,
+                    onProgress: { [weak self] progress in
+                        // Progress callback fires on the executor's actor
+                        // context. Hop to main for any UI updates.
+                        Task { @MainActor [weak self] in
+                            self?.handleProgress(progress)
+                        }
+                    }
+                )
+                self.panelController?.done(message: "Done")
+            } catch let error as TransformExecutorError {
+                switch error {
+                case .cancelled:
+                    self.panelController?.close()
+                default:
+                    self.panelController?.fail(message: error.localizedDescription)
+                }
+            } catch {
+                self.panelController?.fail(message: error.localizedDescription)
+            }
+            self.inFlightTask = nil
+        }
+    }
+
+    private func handleProgress(_ progress: TransformProgress) {
+        // The spike UI is intentionally minimal — we surface the same
+        // "Polishing…" label across capturing/llm/pasting and let the final
+        // .done / .failed states swap the visual.
+        switch progress {
+        case .failed(let message):
+            panelController?.fail(message: message)
+        default:
+            break
+        }
+    }
+}

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -38,6 +38,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var dictationFlowCoordinator: DictationFlowCoordinator?
     private var meetingRecordingFlowCoordinator: MeetingRecordingFlowCoordinator?
     private var meetingAutoStartCoordinator: MeetingAutoStartCoordinator?
+    /// Transforms spike (see `AppFeatures.transformsSpikeEnabled` and
+    /// `docs/research/transforms-design-2026-05.md`). Always created; `start()`
+    /// is a no-op when the flag is off so the binary surface stays clean.
+    private var transformsSpikeCoordinator: TransformsSpikeCoordinator?
     private var hasPresentedHotkeyUnavailableAlert = false
     private var hasPresentedHotkeyConflictAlert = false
     private var environmentSetupTask: Task<Void, Never>?
@@ -273,6 +277,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         dictationFlowCoordinator?.hideIdlePill()
         hotkeyCoordinator?.stopAll()
         meetingAutoStartCoordinator?.stop()
+        transformsSpikeCoordinator?.stop()
         settingsObserverCoordinator.stopObserving()
         environmentSetupTask?.cancel()
         speechPreWarmTask?.cancel()
@@ -383,6 +388,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         meetingRecordingFlowCoordinator = runtime.meetingRecordingFlowCoordinator
         hotkeyCoordinator = runtime.hotkeyCoordinator
         meetingAutoStartCoordinator = runtime.meetingAutoStartCoordinator
+
+        // Transforms spike — registers Opt+Ctrl+1 only when the feature flag
+        // is on (see `AppFeatures.transformsSpikeEnabled`). Always-created so
+        // we can `stop()` it cleanly during termination even if the flag
+        // flipped after launch.
+        let configStore = env.llmConfigStore
+        let llmService = env.llmService
+        let spike = TransformsSpikeCoordinator(llmServiceProvider: { [weak configStore, llmService] in
+            guard let configStore else { return nil }
+            return (try? configStore.loadConfig()) != nil ? llmService : nil
+        })
+        spike.start()
+        transformsSpikeCoordinator = spike
 
         menuBarCoordinator.refreshHotkeyTitle()
         menuBarCoordinator.refreshMeetingHotkeyShortcut()

--- a/Sources/MacParakeet/Views/Transforms/TransformSpikeProgressPanelController.swift
+++ b/Sources/MacParakeet/Views/Transforms/TransformSpikeProgressPanelController.swift
@@ -17,20 +17,18 @@ private final class TransformsSpikePanel: NSPanel {
     override var canBecomeMain: Bool { false }
 }
 
-/// Tiny state object the panel binds to. ObservableObject (not @Observable)
-/// because the spike supports macOS 14 and the older binding still works
-/// reliably for one-shot panels.
 @MainActor
-final class TransformSpikeProgressViewModel: ObservableObject {
-    @Published var label: String = "Still polishing…"
-    @Published var phase: Phase = .working
+@Observable
+final class TransformSpikeProgressViewModel {
+    var label: String = "Still polishing…"
+    var phase: Phase = .working
     /// Hidden during the working state's first few seconds — the rose loader
     /// is enough signal that work is in flight, and the user just pressed the
     /// hotkey so they already know what's happening. The controller flips
     /// this on after a patience threshold (`labelRevealDelay`) so longer-than-
     /// usual runs get an empathetic "still working" cue without forcing every
     /// short transform to render text.
-    @Published var showLabel: Bool = false
+    var showLabel: Bool = false
 
     enum Phase: Equatable {
         case working
@@ -168,7 +166,7 @@ final class TransformSpikeProgressPanelController {
         })
     }
 
-    /// Yield once so SwiftUI processes the @Published phase change, then
+    /// Yield once so SwiftUI processes the observed phase change, then
     /// re-measure the hosting view and animate the panel into the right
     /// frame. Resilient to copy length: longer error strings wrap at
     /// `maximumWidth` and the panel grows vertically to fit.
@@ -245,7 +243,7 @@ final class TransformSpikeProgressPanelController {
 // MARK: - View
 
 private struct TransformSpikeProgressView: View {
-    @ObservedObject var viewModel: TransformSpikeProgressViewModel
+    var viewModel: TransformSpikeProgressViewModel
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {

--- a/Sources/MacParakeet/Views/Transforms/TransformSpikeProgressPanelController.swift
+++ b/Sources/MacParakeet/Views/Transforms/TransformSpikeProgressPanelController.swift
@@ -22,8 +22,15 @@ private final class TransformsSpikePanel: NSPanel {
 /// reliably for one-shot panels.
 @MainActor
 final class TransformSpikeProgressViewModel: ObservableObject {
-    @Published var label: String = "Polishing…"
+    @Published var label: String = "Still polishing…"
     @Published var phase: Phase = .working
+    /// Hidden during the working state's first few seconds — the rose loader
+    /// is enough signal that work is in flight, and the user just pressed the
+    /// hotkey so they already know what's happening. The controller flips
+    /// this on after a patience threshold (`labelRevealDelay`) so longer-than-
+    /// usual runs get an empathetic "still working" cue without forcing every
+    /// short transform to render text.
+    @Published var showLabel: Bool = false
 
     enum Phase: Equatable {
         case working
@@ -35,18 +42,45 @@ final class TransformSpikeProgressViewModel: ObservableObject {
 @MainActor
 final class TransformSpikeProgressPanelController {
     private var panel: NSPanel?
+    private var host: NSHostingView<TransformSpikeProgressView>?
     private var viewModel: TransformSpikeProgressViewModel?
     private var autoDismissTask: Task<Void, Never>?
+    private var labelRevealTask: Task<Void, Never>?
 
-    /// Open (or reuse) the panel showing the in-progress label. Idempotent —
-    /// calling `show` while a panel is visible just resets state.
-    func show(label: String = "Polishing…") {
+    /// Pill anchored at the same bottom-center slot the dictation overlay
+    /// uses. Visually unifies all "press hotkey → thing happens" surfaces
+    /// in one location so the user's eye knows where to look.
+    private static let bottomOffset: CGFloat = 12
+    /// Low floor so the done state can collapse to a perfect circle:
+    /// 22pt icon + 10pt inner padding * 2 + 10pt shadow padding * 2 = 62pt.
+    /// Working state starts here (icon-only) and grows once the patience
+    /// threshold reveals the "still polishing" label.
+    private static let minimumWidth: CGFloat = 62
+    private static let maximumWidth: CGFloat = 360
+    private static let baselineHeight: CGFloat = 64
+    /// How long the working state stays icon-only before revealing a label.
+    /// Chosen against observed LLM timings: short transforms (<2s) finish
+    /// before this fires and never show text; cold-start or large-text
+    /// transforms (>5s) get an empathetic "still working" cue. 10s felt too
+    /// late — by then users have already started wondering.
+    private static let labelRevealDelay: Duration = .seconds(5)
+
+    /// Open (or reuse) the panel showing the in-progress indicator. Idempotent
+    /// — calling `show` while a panel is visible just resets state. The pill
+    /// starts as an icon-only circle; if work runs past `labelRevealDelay` the
+    /// caller-supplied label is faded in.
+    func show(label: String = "Still polishing…") {
         autoDismissTask?.cancel()
         autoDismissTask = nil
+        labelRevealTask?.cancel()
+        labelRevealTask = nil
 
         if let viewModel {
             viewModel.label = label
             viewModel.phase = .working
+            viewModel.showLabel = false
+            scheduleRelayout()
+            scheduleLabelReveal()
             return
         }
 
@@ -55,8 +89,9 @@ final class TransformSpikeProgressPanelController {
         self.viewModel = vm
 
         let host = NSHostingView(rootView: TransformSpikeProgressView(viewModel: vm))
-        let initialSize = NSSize(width: 220, height: 64)
+        let initialSize = NSSize(width: Self.minimumWidth, height: Self.baselineHeight)
         host.frame = NSRect(origin: .zero, size: initialSize)
+        self.host = host
 
         let panel = TransformsSpikePanel(
             contentRect: host.frame,
@@ -72,13 +107,7 @@ final class TransformSpikeProgressPanelController {
         panel.contentView = host
         panel.alphaValue = 0
 
-        let panelSize = host.fittingSize.width > 0 ? host.fittingSize : initialSize
-        if let screen = Self.screenForPanel() {
-            let visible = screen.visibleFrame
-            let x = visible.midX - panelSize.width / 2
-            let y = visible.maxY - panelSize.height - 24
-            panel.setFrame(NSRect(origin: NSPoint(x: x, y: y), size: panelSize), display: true)
-        }
+        positionPanel(panel, size: initialSize, animated: false)
 
         panel.orderFrontRegardless()
         self.panel = panel
@@ -88,12 +117,20 @@ final class TransformSpikeProgressPanelController {
             context.timingFunction = CAMediaTimingFunction(name: .easeOut)
             panel.animator().alphaValue = 1
         }
+
+        // Run a relayout on the next tick so SwiftUI has a chance to
+        // measure the working-state content (icon-only at start).
+        scheduleRelayout()
+        scheduleLabelReveal()
     }
 
     /// Swap the loader for a "Done" affordance, auto-dismiss after 1.2s.
     func done(message: String = "Done") {
         guard let viewModel else { return }
+        labelRevealTask?.cancel()
+        labelRevealTask = nil
         viewModel.phase = .done(message: message)
+        scheduleRelayout()
         scheduleAutoDismiss(after: .milliseconds(1200))
     }
 
@@ -103,7 +140,10 @@ final class TransformSpikeProgressPanelController {
             // Spike-grade: surface the error briefly even if show() never ran.
             show(label: "Transforms")
         }
+        labelRevealTask?.cancel()
+        labelRevealTask = nil
         viewModel?.phase = .failed(message: message)
+        scheduleRelayout()
         scheduleAutoDismiss(after: .milliseconds(4000))
     }
 
@@ -113,8 +153,11 @@ final class TransformSpikeProgressPanelController {
     func close() {
         autoDismissTask?.cancel()
         autoDismissTask = nil
+        labelRevealTask?.cancel()
+        labelRevealTask = nil
         guard let panelRef = panel else { return }
         panel = nil
+        host = nil
         viewModel = nil
         NSAnimationContext.runAnimationGroup({ context in
             context.duration = 0.22
@@ -123,6 +166,62 @@ final class TransformSpikeProgressPanelController {
         }, completionHandler: {
             panelRef.orderOut(nil)
         })
+    }
+
+    /// Yield once so SwiftUI processes the @Published phase change, then
+    /// re-measure the hosting view and animate the panel into the right
+    /// frame. Resilient to copy length: longer error strings wrap at
+    /// `maximumWidth` and the panel grows vertically to fit.
+    private func scheduleRelayout() {
+        Task { @MainActor [weak self] in
+            await Task.yield()
+            self?.relayoutPanel()
+        }
+    }
+
+    private func relayoutPanel() {
+        guard let panel, let host else { return }
+        host.invalidateIntrinsicContentSize()
+        host.layoutSubtreeIfNeeded()
+        let measured = host.fittingSize
+        let width: CGFloat
+        let height: CGFloat
+        if measured.width > 0 && measured.height > 0 {
+            width = min(max(measured.width, Self.minimumWidth), Self.maximumWidth)
+            height = max(measured.height, Self.baselineHeight)
+        } else {
+            width = Self.minimumWidth
+            height = Self.baselineHeight
+        }
+        positionPanel(panel, size: NSSize(width: width, height: height), animated: true)
+    }
+
+    private func positionPanel(_ panel: NSPanel, size: NSSize, animated: Bool) {
+        guard let screen = Self.screenForPanel() else {
+            panel.setContentSize(size)
+            return
+        }
+        let visible = screen.visibleFrame
+        let x = visible.midX - size.width / 2
+        let y = visible.minY + Self.bottomOffset
+        let frame = NSRect(origin: NSPoint(x: x, y: y), size: size)
+        panel.setFrame(frame, display: true, animate: animated)
+    }
+
+    /// After the patience threshold, fade the label in (and trigger a panel
+    /// relayout so the capsule grows from circle → oblong). Cancelled by
+    /// done/fail/close — so transforms that finish quickly never show text.
+    private func scheduleLabelReveal() {
+        labelRevealTask?.cancel()
+        labelRevealTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: Self.labelRevealDelay)
+            guard !Task.isCancelled, let self else { return }
+            guard let vm = self.viewModel, case .working = vm.phase else { return }
+            withAnimation(.easeInOut(duration: 0.28)) {
+                vm.showLabel = true
+            }
+            self.scheduleRelayout()
+        }
     }
 
     private func scheduleAutoDismiss(after delay: Duration) {
@@ -150,7 +249,14 @@ private struct TransformSpikeProgressView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
-        HStack(spacing: 11) {
+        // Icon-only phases (.done) get equal padding so the Capsule renders
+        // as a perfect circle — matches the dictation overlay's success
+        // state. Phases with a label get the wider oblong-pill padding.
+        let isIconOnly = currentLabel == nil
+        let horizontalPadding: CGFloat = isIconOnly ? 10 : 14
+        let verticalPadding: CGFloat = isIconOnly ? 10 : 11
+
+        return HStack(spacing: 11) {
             indicator
                 .frame(width: 22, height: 22)
                 .id(indicatorIdentity)
@@ -159,24 +265,25 @@ private struct TransformSpikeProgressView: View {
                         .combined(with: .opacity)
                 )
 
-            Text(currentLabel)
-                .font(DesignSystem.Typography.meetingPillStatus)
-                .foregroundStyle(DesignSystem.Colors.meetingPillText)
-                .lineLimit(2)
-                .fixedSize(horizontal: false, vertical: true)
-                .id(labelIdentity)
-                .transition(.opacity)
-
-            Spacer(minLength: 0)
+            if let label = currentLabel {
+                Text(label)
+                    .font(DesignSystem.Typography.meetingPillStatus)
+                    .foregroundStyle(DesignSystem.Colors.meetingPillText)
+                    .lineLimit(3)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: 280, alignment: .leading)
+                    .id(labelIdentity)
+                    .transition(.opacity)
+            }
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 11)
+        .padding(.horizontal, horizontalPadding)
+        .padding(.vertical, verticalPadding)
         .background(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
+            Capsule()
                 .fill(DesignSystem.Colors.meetingPillBackground)
         )
         .overlay(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
+            Capsule()
                 .strokeBorder(DesignSystem.Colors.meetingPillStroke, lineWidth: 0.5)
         )
         .cardShadow(DesignSystem.Shadows.meetingPill)
@@ -188,18 +295,22 @@ private struct TransformSpikeProgressView: View {
     private var indicator: some View {
         switch viewModel.phase {
         case .working:
-            BezierScribeLoader(tint: DesignSystem.Colors.accent, paused: reduceMotion)
+            RhodoneaScribeLoader(tint: DesignSystem.Colors.accent, paused: reduceMotion)
         case .done:
-            RingCheckmarkView(tint: DesignSystem.Colors.successGreen)
+            CheckmarkView(tint: DesignSystem.Colors.successGreen)
         case .failed:
             FailingTriangleView(tint: DesignSystem.Colors.warningAmber)
         }
     }
 
-    private var currentLabel: String {
+    /// Working starts icon-only and the label only fades in after the
+    /// patience threshold (`showLabel`). Done is always icon-only — premium
+    /// "the thing happened" cue. Failed always surfaces its message so the
+    /// user gets the recovery hint.
+    private var currentLabel: String? {
         switch viewModel.phase {
-        case .working: return viewModel.label
-        case .done(let message): return message
+        case .working: return viewModel.showLabel ? viewModel.label : nil
+        case .done: return nil
         case .failed(let message): return message
         }
     }
@@ -213,7 +324,7 @@ private struct TransformSpikeProgressView: View {
     }
 
     private var labelIdentity: String {
-        currentLabel
+        currentLabel ?? ""
     }
 
     private var phaseIdentity: Int {
@@ -225,39 +336,57 @@ private struct TransformSpikeProgressView: View {
     }
 }
 
-// MARK: - Bezier Scribe Loader
+// MARK: - Rhodonea Scribe Loader
 
-/// A continuous coral curve traces a closed lissajous, head leading a fading
-/// tail — reads as "writing itself" rather than "spinning." Picked over a stock
-/// `ProgressView()` per `docs/research/transforms-design-2026-05.md` —
-/// Transforms is a writing/refinement surface that earns its own motion
-/// vocabulary, distinct from the dictation overlay's Merkaba and the meeting
-/// pill's rosette.
+/// Sacred-geometry rose curve (rhodonea), squared form for smooth motion:
+/// `r(θ) = sin²(5θ/2)`. Five petals radiate from the center with five-fold
+/// pentagonal symmetry — the same symmetry family as the golden ratio and the
+/// pentagram. Picked over a stock `ProgressView()` and over the prior generic
+/// lissajous per `docs/research/transforms-design-2026-05.md` — Transforms is
+/// a writing/refinement surface and earns its own motion vocabulary, distinct
+/// from the dictation overlay's Merkaba (4-fold) and the meeting pill's
+/// rosette (6-fold). Three modes, three symmetries.
 ///
-/// Implementation: TimelineView drives a 60Hz Canvas that walks a parametric
-/// curve. Each frame draws short line segments behind a moving "head," with
-/// alpha + width tapering toward the tail. The closed lissajous has no hard
-/// loop seam — the user can watch for two seconds or eight without seeing a
-/// repeat point.
-private struct BezierScribeLoader: View {
+/// Implementation: a faint base curve is always drawn so the full sacred
+/// figure is legible, then a brighter "scribe head" traces it with a fading
+/// trail. The squared form keeps `r ≥ 0` everywhere — no jumps through the
+/// origin — so the head sweeps smoothly out to each petal tip and back.
+/// 60Hz TimelineView drives a Canvas that walks the curve over a 3-second
+/// period.
+private struct RhodoneaScribeLoader: View {
     var tint: Color
     var paused: Bool = false
-    var period: Double = 2.4
+    var period: Double = 3.0
 
     var body: some View {
         TimelineView(.animation(minimumInterval: 1.0 / 60.0, paused: paused)) { context in
             Canvas { ctx, size in
                 let now = context.date.timeIntervalSinceReferenceDate
                 let t = (now.truncatingRemainder(dividingBy: period)) / period
-                Self.drawScribe(in: ctx, size: size, t: t, tint: tint)
+                Self.draw(in: ctx, size: size, t: t, tint: tint)
             }
         }
     }
 
-    private static func drawScribe(in ctx: GraphicsContext, size: CGSize, t: Double, tint: Color) {
-        let segments = 28
-        let trailArc = 0.5  // fraction of full period rendered behind the head
-        let baseLineWidth: CGFloat = 1.6
+    private static func draw(in ctx: GraphicsContext, size: CGSize, t: Double, tint: Color) {
+        // Step 1 — Faint full curve so the sacred figure is always readable.
+        var basePath = Path()
+        let baseSamples = 240
+        for i in 0...baseSamples {
+            let phase = Double(i) / Double(baseSamples)
+            let p = point(phase: phase, size: size)
+            if i == 0 { basePath.move(to: p) } else { basePath.addLine(to: p) }
+        }
+        ctx.stroke(
+            basePath,
+            with: .color(tint.opacity(0.18)),
+            style: StrokeStyle(lineWidth: 1.1, lineCap: .round, lineJoin: .round)
+        )
+
+        // Step 2 — Bright scribe trail behind the head, fading toward the tail.
+        let segments = 42
+        let trailArc = 0.30  // fraction of full period rendered as bright trail
+        let baseLineWidth: CGFloat = 1.7
 
         for i in 0..<segments {
             let frac = Double(i) / Double(segments - 1)
@@ -268,53 +397,58 @@ private struct BezierScribeLoader: View {
             let pA = point(phase: phaseA, size: size)
             let pB = point(phase: phaseB, size: size)
 
-            var p = Path()
-            p.move(to: pA)
-            p.addLine(to: pB)
+            var seg = Path()
+            seg.move(to: pA)
+            seg.addLine(to: pB)
 
-            let alpha = pow(1.0 - frac, 1.35)
-            let width = baseLineWidth * (1.0 - frac * 0.4)
+            let alpha = pow(1.0 - frac, 1.6)
+            let width = baseLineWidth * (1.0 - frac * 0.35)
 
             ctx.stroke(
-                p,
+                seg,
                 with: .color(tint.opacity(alpha)),
                 style: StrokeStyle(lineWidth: width, lineCap: .round)
             )
         }
 
-        // Bright head dot — gives the curve a clear "now" point.
+        // Step 3 — Bright head dot for a clear "now" point.
         let head = point(phase: t, size: size)
-        let dotR: CGFloat = 1.6
+        let dotR: CGFloat = 1.7
         let dotRect = CGRect(x: head.x - dotR, y: head.y - dotR, width: dotR * 2, height: dotR * 2)
         ctx.fill(Path(ellipseIn: dotRect), with: .color(tint))
     }
 
-    /// Lissajous-derived parametric: x = sin(θ)·cos(θ/2), y = sin(2θ).
-    /// Asymmetric frequency ratio yields a soft figure-8 that feels like a
-    /// hand drawing through a glyph rather than tracing a circle.
+    /// Squared rhodonea `r(θ) = sin²(5θ/2)` — 5 petals in θ ∈ [0, 2π], with
+    /// `r ≥ 0` everywhere so the head returns smoothly to the origin between
+    /// petals instead of jumping through it (which standard `cos(kθ)` roses do
+    /// when `r` flips negative).
     private static func point(phase: Double, size: CGSize) -> CGPoint {
         let theta = phase * 2 * .pi
         let cx = size.width / 2
         let cy = size.height / 2
-        let rx = size.width * 0.40
-        let ry = size.height * 0.30
-        let x = cx + rx * sin(theta) * cos(theta * 0.5)
-        let y = cy + ry * sin(theta * 2)
+        let radius = min(size.width, size.height) * 0.44
+        let s = sin(2.5 * theta)
+        let r = radius * s * s
+        let x = cx + r * cos(theta)
+        let y = cy + r * sin(theta)
         return CGPoint(x: x, y: y)
     }
 }
 
-// MARK: - Ring Checkmark (Done state)
+// MARK: - Checkmark (Done state)
 
-/// Apple-Pay style: ring strokes around, then the check strokes in. Borrowed
-/// shape from `MeetingRecordingPillView.MeetingCompletionCheckmarkView` but
-/// sized for the Transforms 22pt indicator slot.
-private struct RingCheckmarkView: View {
+/// Apple-style success checkmark — same atom the dictation overlay uses for
+/// completion (`DictationOverlayView.AnimatedCheckmarkView`). Ring strokes
+/// around first, then the check strokes in. Re-implemented inline rather than
+/// promoted to a shared component during the spike; a follow-up should
+/// extract this into `Views/Components/` so dictation, meeting, and transforms
+/// share one brand atom for "the thing happened."
+private struct CheckmarkView: View {
     var tint: Color
     @State private var ringTrim: CGFloat = 0
     @State private var checkTrim: CGFloat = 0
 
-    private let lineWidth: CGFloat = 1.4
+    private let lineWidth: CGFloat = 1.5
 
     var body: some View {
         ZStack {
@@ -332,10 +466,10 @@ private struct RingCheckmarkView: View {
                 .padding(6)
         }
         .onAppear {
-            withAnimation(.easeOut(duration: 0.32)) {
+            withAnimation(.easeOut(duration: 0.35)) {
                 ringTrim = 1
             }
-            withAnimation(.easeOut(duration: 0.22).delay(0.24)) {
+            withAnimation(.easeOut(duration: 0.25).delay(0.25)) {
                 checkTrim = 1
             }
         }

--- a/Sources/MacParakeet/Views/Transforms/TransformSpikeProgressPanelController.swift
+++ b/Sources/MacParakeet/Views/Transforms/TransformSpikeProgressPanelController.swift
@@ -3,15 +3,15 @@ import MacParakeetCore
 import SwiftUI
 
 /// Non-activating panel that hosts the Transforms spike progress UI. Spike
-/// scope only — see `docs/research/transforms-design-2026-05.md` Phase 2 for
-/// the custom-loader / pill anchored near the trigger context.
+/// scope only — see `docs/research/transforms-design-2026-05.md` for the
+/// production design (custom loader / pill anchored near the trigger context).
 ///
 /// NSPanel notes:
 /// - `canBecomeKey` is `false` so triggering the hotkey doesn't yank focus
 ///   from the user's frontmost app (which is the whole point — we paste back
 ///   into their text field).
-/// - `.nonactivatingPanel | .borderless` is the standard floating overlay
-///   style used elsewhere in MacParakeet.
+/// - `.nonactivatingPanel | .borderless` matches the dictation + meeting
+///   recording pill chrome elsewhere in the app.
 private final class TransformsSpikePanel: NSPanel {
     override var canBecomeKey: Bool { false }
     override var canBecomeMain: Bool { false }
@@ -23,9 +23,13 @@ private final class TransformsSpikePanel: NSPanel {
 @MainActor
 final class TransformSpikeProgressViewModel: ObservableObject {
     @Published var label: String = "Polishing…"
-    @Published var isWorking: Bool = true
-    @Published var errorMessage: String? = nil
-    @Published var doneMessage: String? = nil
+    @Published var phase: Phase = .working
+
+    enum Phase: Equatable {
+        case working
+        case done(message: String)
+        case failed(message: String)
+    }
 }
 
 @MainActor
@@ -35,16 +39,14 @@ final class TransformSpikeProgressPanelController {
     private var autoDismissTask: Task<Void, Never>?
 
     /// Open (or reuse) the panel showing the in-progress label. Idempotent —
-    /// calling `show` while a panel is visible just updates the label.
+    /// calling `show` while a panel is visible just resets state.
     func show(label: String = "Polishing…") {
         autoDismissTask?.cancel()
         autoDismissTask = nil
 
         if let viewModel {
             viewModel.label = label
-            viewModel.isWorking = true
-            viewModel.errorMessage = nil
-            viewModel.doneMessage = nil
+            viewModel.phase = .working
             return
         }
 
@@ -53,7 +55,8 @@ final class TransformSpikeProgressPanelController {
         self.viewModel = vm
 
         let host = NSHostingView(rootView: TransformSpikeProgressView(viewModel: vm))
-        host.frame = NSRect(x: 0, y: 0, width: 220, height: 56)
+        let initialSize = NSSize(width: 220, height: 64)
+        host.frame = NSRect(origin: .zero, size: initialSize)
 
         let panel = TransformsSpikePanel(
             contentRect: host.frame,
@@ -63,61 +66,63 @@ final class TransformSpikeProgressPanelController {
         )
         panel.isOpaque = false
         panel.backgroundColor = .clear
-        panel.hasShadow = false  // SwiftUI renders its own shadow.
+        panel.hasShadow = false  // SwiftUI renders its own shadow via cardShadow.
         panel.level = .floating
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         panel.contentView = host
+        panel.alphaValue = 0
 
+        let panelSize = host.fittingSize.width > 0 ? host.fittingSize : initialSize
         if let screen = Self.screenForPanel() {
-            let panelSize = host.fittingSize.width > 0
-                ? host.fittingSize
-                : NSSize(width: 220, height: 56)
             let visible = screen.visibleFrame
             let x = visible.midX - panelSize.width / 2
-            let y = visible.maxY - panelSize.height - 32
+            let y = visible.maxY - panelSize.height - 24
             panel.setFrame(NSRect(origin: NSPoint(x: x, y: y), size: panelSize), display: true)
         }
 
         panel.orderFrontRegardless()
         self.panel = panel
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.18
+            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            panel.animator().alphaValue = 1
+        }
     }
 
-    /// Replace the spinner with a brief "Done" message, then auto-dismiss
-    /// after 1.2s. Idempotent — repeated `done()` calls reset the timer.
+    /// Swap the loader for a "Done" affordance, auto-dismiss after 1.2s.
     func done(message: String = "Done") {
         guard let viewModel else { return }
-        viewModel.isWorking = false
-        viewModel.errorMessage = nil
-        viewModel.doneMessage = message
+        viewModel.phase = .done(message: message)
         scheduleAutoDismiss(after: .milliseconds(1200))
     }
 
-    /// Replace the spinner with an error message, auto-dismiss after 4s.
+    /// Swap the loader for an error affordance, auto-dismiss after 4s.
     func fail(message: String) {
-        guard let viewModel else {
-            // Spike-grade UX: if the panel hasn't been shown yet, surface
-            // the error briefly anyway.
+        if viewModel == nil {
+            // Spike-grade: surface the error briefly even if show() never ran.
             show(label: "Transforms")
-            self.viewModel?.label = "Transforms"
-            self.viewModel?.isWorking = false
-            self.viewModel?.errorMessage = message
-            scheduleAutoDismiss(after: .milliseconds(4000))
-            return
         }
-        viewModel.isWorking = false
-        viewModel.doneMessage = nil
-        viewModel.errorMessage = message
+        viewModel?.phase = .failed(message: message)
         scheduleAutoDismiss(after: .milliseconds(4000))
     }
 
-    /// Tear the panel down immediately. Used when the user re-triggers the
-    /// hotkey mid-run (cancel-then-restart semantics).
+    /// Tear the panel down with a brief fade. Cancel-then-restart from the
+    /// coordinator goes through `show()`, not `close()`, so this is reserved
+    /// for terminal dismissal.
     func close() {
         autoDismissTask?.cancel()
         autoDismissTask = nil
-        panel?.orderOut(nil)
+        guard let panelRef = panel else { return }
         panel = nil
         viewModel = nil
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = 0.22
+            context.timingFunction = CAMediaTimingFunction(name: .easeIn)
+            panelRef.animator().alphaValue = 0
+        }, completionHandler: {
+            panelRef.orderOut(nil)
+        })
     }
 
     private func scheduleAutoDismiss(after delay: Duration) {
@@ -142,41 +147,254 @@ final class TransformSpikeProgressPanelController {
 
 private struct TransformSpikeProgressView: View {
     @ObservedObject var viewModel: TransformSpikeProgressViewModel
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
-        HStack(spacing: 12) {
-            if viewModel.isWorking {
-                ProgressView()
-                    .progressViewStyle(.circular)
-                    .controlSize(.small)
-            } else if viewModel.errorMessage != nil {
-                Image(systemName: "exclamationmark.triangle.fill")
-                    .foregroundStyle(.yellow)
-            } else {
-                Image(systemName: "checkmark.circle.fill")
-                    .foregroundStyle(.green)
-            }
+        HStack(spacing: 11) {
+            indicator
+                .frame(width: 22, height: 22)
+                .id(indicatorIdentity)
+                .transition(
+                    .scale(scale: 0.65, anchor: .center)
+                        .combined(with: .opacity)
+                )
 
             Text(currentLabel)
-                .font(.system(size: 13, weight: .medium))
-                .foregroundStyle(.white)
+                .font(DesignSystem.Typography.meetingPillStatus)
+                .foregroundStyle(DesignSystem.Colors.meetingPillText)
                 .lineLimit(2)
                 .fixedSize(horizontal: false, vertical: true)
+                .id(labelIdentity)
+                .transition(.opacity)
+
             Spacer(minLength: 0)
         }
         .padding(.horizontal, 14)
-        .padding(.vertical, 12)
+        .padding(.vertical, 11)
         .background(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(Color.black.opacity(0.78))
-                .shadow(color: Color.black.opacity(0.35), radius: 8, x: 0, y: 4)
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(DesignSystem.Colors.meetingPillBackground)
         )
-        .padding(8)
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .strokeBorder(DesignSystem.Colors.meetingPillStroke, lineWidth: 0.5)
+        )
+        .cardShadow(DesignSystem.Shadows.meetingPill)
+        .padding(10)  // give the SwiftUI shadow room inside the NSPanel frame
+        .animation(.easeInOut(duration: 0.24), value: phaseIdentity)
+    }
+
+    @ViewBuilder
+    private var indicator: some View {
+        switch viewModel.phase {
+        case .working:
+            BezierScribeLoader(tint: DesignSystem.Colors.accent, paused: reduceMotion)
+        case .done:
+            RingCheckmarkView(tint: DesignSystem.Colors.successGreen)
+        case .failed:
+            FailingTriangleView(tint: DesignSystem.Colors.warningAmber)
+        }
     }
 
     private var currentLabel: String {
-        if let error = viewModel.errorMessage { return error }
-        if let done = viewModel.doneMessage { return done }
-        return viewModel.label
+        switch viewModel.phase {
+        case .working: return viewModel.label
+        case .done(let message): return message
+        case .failed(let message): return message
+        }
+    }
+
+    private var indicatorIdentity: String {
+        switch viewModel.phase {
+        case .working: return "working"
+        case .done: return "done"
+        case .failed: return "failed"
+        }
+    }
+
+    private var labelIdentity: String {
+        currentLabel
+    }
+
+    private var phaseIdentity: Int {
+        switch viewModel.phase {
+        case .working: return 0
+        case .done: return 1
+        case .failed: return 2
+        }
+    }
+}
+
+// MARK: - Bezier Scribe Loader
+
+/// A continuous coral curve traces a closed lissajous, head leading a fading
+/// tail — reads as "writing itself" rather than "spinning." Picked over a stock
+/// `ProgressView()` per `docs/research/transforms-design-2026-05.md` —
+/// Transforms is a writing/refinement surface that earns its own motion
+/// vocabulary, distinct from the dictation overlay's Merkaba and the meeting
+/// pill's rosette.
+///
+/// Implementation: TimelineView drives a 60Hz Canvas that walks a parametric
+/// curve. Each frame draws short line segments behind a moving "head," with
+/// alpha + width tapering toward the tail. The closed lissajous has no hard
+/// loop seam — the user can watch for two seconds or eight without seeing a
+/// repeat point.
+private struct BezierScribeLoader: View {
+    var tint: Color
+    var paused: Bool = false
+    var period: Double = 2.4
+
+    var body: some View {
+        TimelineView(.animation(minimumInterval: 1.0 / 60.0, paused: paused)) { context in
+            Canvas { ctx, size in
+                let now = context.date.timeIntervalSinceReferenceDate
+                let t = (now.truncatingRemainder(dividingBy: period)) / period
+                Self.drawScribe(in: ctx, size: size, t: t, tint: tint)
+            }
+        }
+    }
+
+    private static func drawScribe(in ctx: GraphicsContext, size: CGSize, t: Double, tint: Color) {
+        let segments = 28
+        let trailArc = 0.5  // fraction of full period rendered behind the head
+        let baseLineWidth: CGFloat = 1.6
+
+        for i in 0..<segments {
+            let frac = Double(i) / Double(segments - 1)
+            let nextFrac = Double(i + 1) / Double(segments - 1)
+            let phaseA = t - frac * trailArc
+            let phaseB = t - nextFrac * trailArc
+
+            let pA = point(phase: phaseA, size: size)
+            let pB = point(phase: phaseB, size: size)
+
+            var p = Path()
+            p.move(to: pA)
+            p.addLine(to: pB)
+
+            let alpha = pow(1.0 - frac, 1.35)
+            let width = baseLineWidth * (1.0 - frac * 0.4)
+
+            ctx.stroke(
+                p,
+                with: .color(tint.opacity(alpha)),
+                style: StrokeStyle(lineWidth: width, lineCap: .round)
+            )
+        }
+
+        // Bright head dot — gives the curve a clear "now" point.
+        let head = point(phase: t, size: size)
+        let dotR: CGFloat = 1.6
+        let dotRect = CGRect(x: head.x - dotR, y: head.y - dotR, width: dotR * 2, height: dotR * 2)
+        ctx.fill(Path(ellipseIn: dotRect), with: .color(tint))
+    }
+
+    /// Lissajous-derived parametric: x = sin(θ)·cos(θ/2), y = sin(2θ).
+    /// Asymmetric frequency ratio yields a soft figure-8 that feels like a
+    /// hand drawing through a glyph rather than tracing a circle.
+    private static func point(phase: Double, size: CGSize) -> CGPoint {
+        let theta = phase * 2 * .pi
+        let cx = size.width / 2
+        let cy = size.height / 2
+        let rx = size.width * 0.40
+        let ry = size.height * 0.30
+        let x = cx + rx * sin(theta) * cos(theta * 0.5)
+        let y = cy + ry * sin(theta * 2)
+        return CGPoint(x: x, y: y)
+    }
+}
+
+// MARK: - Ring Checkmark (Done state)
+
+/// Apple-Pay style: ring strokes around, then the check strokes in. Borrowed
+/// shape from `MeetingRecordingPillView.MeetingCompletionCheckmarkView` but
+/// sized for the Transforms 22pt indicator slot.
+private struct RingCheckmarkView: View {
+    var tint: Color
+    @State private var ringTrim: CGFloat = 0
+    @State private var checkTrim: CGFloat = 0
+
+    private let lineWidth: CGFloat = 1.4
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(tint.opacity(0.20), lineWidth: lineWidth)
+
+            Circle()
+                .trim(from: 0, to: ringTrim)
+                .stroke(tint, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+
+            CheckmarkShape()
+                .trim(from: 0, to: checkTrim)
+                .stroke(tint, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round, lineJoin: .round))
+                .padding(6)
+        }
+        .onAppear {
+            withAnimation(.easeOut(duration: 0.32)) {
+                ringTrim = 1
+            }
+            withAnimation(.easeOut(duration: 0.22).delay(0.24)) {
+                checkTrim = 1
+            }
+        }
+    }
+
+    private struct CheckmarkShape: Shape {
+        func path(in rect: CGRect) -> Path {
+            var path = Path()
+            let w = rect.width
+            let h = rect.height
+            path.move(to: CGPoint(x: w * 0.22, y: h * 0.52))
+            path.addLine(to: CGPoint(x: w * 0.42, y: h * 0.72))
+            path.addLine(to: CGPoint(x: w * 0.78, y: h * 0.28))
+            return path
+        }
+    }
+}
+
+// MARK: - Failing Triangle (Fail state)
+
+/// Triangle outline strokes in, then a centered bang fades up. Keeps the
+/// affordance warm (amber, not red) — failures are recoverable, the user just
+/// needs to retry or fix configuration.
+private struct FailingTriangleView: View {
+    var tint: Color
+    @State private var triangleTrim: CGFloat = 0
+    @State private var bangOpacity: Double = 0
+
+    var body: some View {
+        ZStack {
+            TriangleShape()
+                .trim(from: 0, to: triangleTrim)
+                .stroke(tint, style: StrokeStyle(lineWidth: 1.6, lineCap: .round, lineJoin: .round))
+
+            Text("!")
+                .font(.system(size: 13, weight: .bold, design: .rounded))
+                .foregroundStyle(tint)
+                .opacity(bangOpacity)
+                .offset(y: 1)
+        }
+        .onAppear {
+            withAnimation(.easeOut(duration: 0.32)) {
+                triangleTrim = 1
+            }
+            withAnimation(.easeOut(duration: 0.20).delay(0.22)) {
+                bangOpacity = 1
+            }
+        }
+    }
+
+    private struct TriangleShape: Shape {
+        func path(in rect: CGRect) -> Path {
+            var path = Path()
+            let inset: CGFloat = 1
+            path.move(to: CGPoint(x: rect.midX, y: rect.minY + inset))
+            path.addLine(to: CGPoint(x: rect.maxX - inset, y: rect.maxY - inset))
+            path.addLine(to: CGPoint(x: rect.minX + inset, y: rect.maxY - inset))
+            path.closeSubpath()
+            return path
+        }
     }
 }

--- a/Sources/MacParakeet/Views/Transforms/TransformSpikeProgressPanelController.swift
+++ b/Sources/MacParakeet/Views/Transforms/TransformSpikeProgressPanelController.swift
@@ -1,0 +1,182 @@
+import AppKit
+import MacParakeetCore
+import SwiftUI
+
+/// Non-activating panel that hosts the Transforms spike progress UI. Spike
+/// scope only — see `docs/research/transforms-design-2026-05.md` Phase 2 for
+/// the custom-loader / pill anchored near the trigger context.
+///
+/// NSPanel notes:
+/// - `canBecomeKey` is `false` so triggering the hotkey doesn't yank focus
+///   from the user's frontmost app (which is the whole point — we paste back
+///   into their text field).
+/// - `.nonactivatingPanel | .borderless` is the standard floating overlay
+///   style used elsewhere in MacParakeet.
+private final class TransformsSpikePanel: NSPanel {
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+}
+
+/// Tiny state object the panel binds to. ObservableObject (not @Observable)
+/// because the spike supports macOS 14 and the older binding still works
+/// reliably for one-shot panels.
+@MainActor
+final class TransformSpikeProgressViewModel: ObservableObject {
+    @Published var label: String = "Polishing…"
+    @Published var isWorking: Bool = true
+    @Published var errorMessage: String? = nil
+    @Published var doneMessage: String? = nil
+}
+
+@MainActor
+final class TransformSpikeProgressPanelController {
+    private var panel: NSPanel?
+    private var viewModel: TransformSpikeProgressViewModel?
+    private var autoDismissTask: Task<Void, Never>?
+
+    /// Open (or reuse) the panel showing the in-progress label. Idempotent —
+    /// calling `show` while a panel is visible just updates the label.
+    func show(label: String = "Polishing…") {
+        autoDismissTask?.cancel()
+        autoDismissTask = nil
+
+        if let viewModel {
+            viewModel.label = label
+            viewModel.isWorking = true
+            viewModel.errorMessage = nil
+            viewModel.doneMessage = nil
+            return
+        }
+
+        let vm = TransformSpikeProgressViewModel()
+        vm.label = label
+        self.viewModel = vm
+
+        let host = NSHostingView(rootView: TransformSpikeProgressView(viewModel: vm))
+        host.frame = NSRect(x: 0, y: 0, width: 220, height: 56)
+
+        let panel = TransformsSpikePanel(
+            contentRect: host.frame,
+            styleMask: [.nonactivatingPanel, .borderless],
+            backing: .buffered,
+            defer: false
+        )
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = false  // SwiftUI renders its own shadow.
+        panel.level = .floating
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        panel.contentView = host
+
+        if let screen = Self.screenForPanel() {
+            let panelSize = host.fittingSize.width > 0
+                ? host.fittingSize
+                : NSSize(width: 220, height: 56)
+            let visible = screen.visibleFrame
+            let x = visible.midX - panelSize.width / 2
+            let y = visible.maxY - panelSize.height - 32
+            panel.setFrame(NSRect(origin: NSPoint(x: x, y: y), size: panelSize), display: true)
+        }
+
+        panel.orderFrontRegardless()
+        self.panel = panel
+    }
+
+    /// Replace the spinner with a brief "Done" message, then auto-dismiss
+    /// after 1.2s. Idempotent — repeated `done()` calls reset the timer.
+    func done(message: String = "Done") {
+        guard let viewModel else { return }
+        viewModel.isWorking = false
+        viewModel.errorMessage = nil
+        viewModel.doneMessage = message
+        scheduleAutoDismiss(after: .milliseconds(1200))
+    }
+
+    /// Replace the spinner with an error message, auto-dismiss after 4s.
+    func fail(message: String) {
+        guard let viewModel else {
+            // Spike-grade UX: if the panel hasn't been shown yet, surface
+            // the error briefly anyway.
+            show(label: "Transforms")
+            self.viewModel?.label = "Transforms"
+            self.viewModel?.isWorking = false
+            self.viewModel?.errorMessage = message
+            scheduleAutoDismiss(after: .milliseconds(4000))
+            return
+        }
+        viewModel.isWorking = false
+        viewModel.doneMessage = nil
+        viewModel.errorMessage = message
+        scheduleAutoDismiss(after: .milliseconds(4000))
+    }
+
+    /// Tear the panel down immediately. Used when the user re-triggers the
+    /// hotkey mid-run (cancel-then-restart semantics).
+    func close() {
+        autoDismissTask?.cancel()
+        autoDismissTask = nil
+        panel?.orderOut(nil)
+        panel = nil
+        viewModel = nil
+    }
+
+    private func scheduleAutoDismiss(after delay: Duration) {
+        autoDismissTask?.cancel()
+        autoDismissTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: delay)
+            guard !Task.isCancelled else { return }
+            self?.close()
+        }
+    }
+
+    private static func screenForPanel() -> NSScreen? {
+        let mouseLocation = NSEvent.mouseLocation
+        if let screen = NSScreen.screens.first(where: { NSMouseInRect(mouseLocation, $0.frame, false) }) {
+            return screen
+        }
+        return NSScreen.main ?? NSScreen.screens.first
+    }
+}
+
+// MARK: - View
+
+private struct TransformSpikeProgressView: View {
+    @ObservedObject var viewModel: TransformSpikeProgressViewModel
+
+    var body: some View {
+        HStack(spacing: 12) {
+            if viewModel.isWorking {
+                ProgressView()
+                    .progressViewStyle(.circular)
+                    .controlSize(.small)
+            } else if viewModel.errorMessage != nil {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.yellow)
+            } else {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+            }
+
+            Text(currentLabel)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(.white)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color.black.opacity(0.78))
+                .shadow(color: Color.black.opacity(0.35), radius: 8, x: 0, y: 4)
+        )
+        .padding(8)
+    }
+
+    private var currentLabel: String {
+        if let error = viewModel.errorMessage { return error }
+        if let done = viewModel.doneMessage { return done }
+        return viewModel.label
+    }
+}

--- a/Sources/MacParakeetCore/AppFeatures.swift
+++ b/Sources/MacParakeetCore/AppFeatures.swift
@@ -20,4 +20,14 @@ public enum AppFeatures {
     /// point release once the auto-start flow has been exercised against real
     /// calendars.
     public static let calendarEnabled: Bool = false
+
+    /// Transforms spike (docs/research/transforms-design-2026-05.md, Phase 1
+    /// AX-coverage spike). When `false`, the entire Transforms pipeline is
+    /// hidden: no Opt+Ctrl+1 hotkey, no SelectionCaptureService/Executor wiring
+    /// from AppEnvironment, no floating progress panel. Flipping to `true` is
+    /// development-only — the spike is intentionally rough (hardcoded Polish
+    /// prompt, no management UI, hardcoded hotkey including Ctrl to avoid
+    /// collisions during dev). Used to answer the single question: does the
+    /// macOS AX API reliably return selected text in mainstream apps?
+    public static let transformsSpikeEnabled: Bool = false
 }

--- a/Sources/MacParakeetCore/Services/PasteShortcutKeyResolver.swift
+++ b/Sources/MacParakeetCore/Services/PasteShortcutKeyResolver.swift
@@ -26,7 +26,7 @@ struct PasteShortcutKeyResolver {
     }
 
     func virtualKeyCode(for character: Character, modifierKeyState: UInt32 = 0) -> CGKeyCode {
-        let fallbackKeyCode: CGKeyCode = 0x09
+        let fallbackKeyCode = Self.qwertyFallbackKeyCode(for: character)
         let layoutLookup = keyboardLayoutProvider()
 
         let layoutData: CFData
@@ -34,18 +34,18 @@ struct PasteShortcutKeyResolver {
         case .data(let data):
             layoutData = data
         case .missingInputSource:
-            logger.error("Failed to get current keyboard input source; falling back to QWERTY keycode 0x09")
+            logger.error("Failed to get current keyboard input source; falling back to QWERTY keycode \(fallbackKeyCode, privacy: .public)")
             return fallbackKeyCode
         case .missingLayoutData:
-            logger.error("Failed to resolve keyboard layout data for paste shortcut; falling back to QWERTY keycode 0x09")
+            logger.error("Failed to resolve keyboard layout data for paste shortcut; falling back to QWERTY keycode \(fallbackKeyCode, privacy: .public)")
             return fallbackKeyCode
         case .inaccessibleLayoutBytes:
-            logger.error("Failed to access keyboard layout bytes for paste shortcut; falling back to QWERTY keycode 0x09")
+            logger.error("Failed to access keyboard layout bytes for paste shortcut; falling back to QWERTY keycode \(fallbackKeyCode, privacy: .public)")
             return fallbackKeyCode
         }
 
         guard let target = String(character).utf16.first else {
-            logger.error("Failed to encode character for paste shortcut lookup; falling back to QWERTY keycode 0x09")
+            logger.error("Failed to encode character for paste shortcut lookup; falling back to QWERTY keycode \(fallbackKeyCode, privacy: .public)")
             return fallbackKeyCode
         }
 
@@ -60,8 +60,16 @@ struct PasteShortcutKeyResolver {
             }
         }
 
-        logger.error("Failed to resolve virtual keycode for character '\(String(character), privacy: .public)'; falling back to QWERTY keycode 0x09")
+        logger.error("Failed to resolve virtual keycode for character '\(String(character), privacy: .public)'; falling back to QWERTY keycode \(fallbackKeyCode, privacy: .public)")
         return fallbackKeyCode
+    }
+
+    private static func qwertyFallbackKeyCode(for character: Character) -> CGKeyCode {
+        switch String(character).lowercased() {
+        case "c": return 0x08
+        case "v": return 0x09
+        default: return 0x09
+        }
     }
 
     private static func liveKeyboardLayout() -> KeyboardLayoutLookupResult {

--- a/Sources/MacParakeetCore/Services/System/SelectionCaptureService.swift
+++ b/Sources/MacParakeetCore/Services/System/SelectionCaptureService.swift
@@ -118,6 +118,13 @@ protocol SelectionCaptureBackend: Sendable {
     /// Post a synthetic Cmd+C event pair.
     @MainActor
     func postCmdC() throws
+
+    /// Restore a previously-captured pasteboard snapshot. Called when the
+    /// hijack succeeded in moving the change count but didn't yield text
+    /// content (image / file etc.) — without this, the user's pre-hijack
+    /// clipboard is silently destroyed.
+    @MainActor
+    func restoreSnapshot(_ snapshot: PasteboardSnapshot)
 }
 
 // MARK: - Service
@@ -196,20 +203,26 @@ public actor SelectionCaptureService {
         // with the pasteboard mutating mid-Cmd+C.
         let deadline = ContinuousClock.now + clipboardPollTimeout
         while ContinuousClock.now < deadline {
+            if Task.isCancelled {
+                await restoreSnapshotOnMain(snapshot)
+                return .empty
+            }
             let now = await currentChangeCountOnMain()
             if now != snapshot.originalChangeCount {
                 if let text = await currentStringOnMain(), !text.isEmpty {
                     return .clipboard(text: text, savedClipboard: snapshot)
                 }
                 // Change count moved but no string available (image, file, etc.).
-                // Restore snapshot ourselves and treat as empty — there's
-                // nothing for the LLM to transform.
+                // Cmd+C *did* write — the user's pre-hijack clipboard is now
+                // gone unless we put it back. Restore before bailing.
+                await restoreSnapshotOnMain(snapshot)
                 return .empty
             }
             try? await Task.sleep(nanoseconds: pollIntervalNanos)
         }
 
-        // No change count delta — selection was empty.
+        // No change count delta — selection was empty. Pasteboard wasn't
+        // touched (Cmd+C with no selection is a no-op) so nothing to restore.
         return .empty
     }
 
@@ -231,6 +244,11 @@ public actor SelectionCaptureService {
     @MainActor
     private func postCmdCOnMain() throws {
         try backend.postCmdC()
+    }
+
+    @MainActor
+    private func restoreSnapshotOnMain(_ snapshot: PasteboardSnapshot) {
+        backend.restoreSnapshot(snapshot)
     }
 }
 
@@ -317,5 +335,15 @@ struct SystemSelectionCaptureBackend: SelectionCaptureBackend, @unchecked Sendab
         keyUp.flags = .maskCommand
         keyDown.post(tap: .cghidEventTap)
         keyUp.post(tap: .cghidEventTap)
+    }
+
+    @MainActor
+    func restoreSnapshot(_ snapshot: PasteboardSnapshot) {
+        guard let items = snapshot.items, !items.isEmpty else {
+            pasteboard.clearContents()
+            return
+        }
+        pasteboard.clearContents()
+        pasteboard.writeObjects(items)
     }
 }

--- a/Sources/MacParakeetCore/Services/System/SelectionCaptureService.swift
+++ b/Sources/MacParakeetCore/Services/System/SelectionCaptureService.swift
@@ -1,5 +1,6 @@
 import AppKit
 import ApplicationServices
+import Carbon
 import Foundation
 import OSLog
 
@@ -83,14 +84,28 @@ public struct AXFocusedElement: @unchecked Sendable {
 public struct PasteboardSnapshot: @unchecked Sendable {
     public let items: [NSPasteboardItem]?
     public let originalChangeCount: Int
+    public let temporaryChangeCount: Int?
 
-    public init(items: [NSPasteboardItem]?, originalChangeCount: Int) {
+    public init(
+        items: [NSPasteboardItem]?,
+        originalChangeCount: Int,
+        temporaryChangeCount: Int? = nil
+    ) {
         self.items = items
         self.originalChangeCount = originalChangeCount
+        self.temporaryChangeCount = temporaryChangeCount
     }
 
     /// Empty placeholder — useful for tests and the `.empty` no-op path.
     public static let none = PasteboardSnapshot(items: nil, originalChangeCount: 0)
+
+    public func withTemporaryChangeCount(_ changeCount: Int) -> PasteboardSnapshot {
+        PasteboardSnapshot(
+            items: items,
+            originalChangeCount: originalChangeCount,
+            temporaryChangeCount: changeCount
+        )
+    }
 }
 
 // MARK: - Backend Protocol (for testability)
@@ -186,6 +201,26 @@ public actor SelectionCaptureService {
         return await clipboardHijack()
     }
 
+    /// Restore a clipboard capture that is being abandoned before replacement.
+    /// The guard preserves user clipboard writes made while the LLM was running:
+    /// we only restore if the pasteboard is still at the Cmd+C change count
+    /// created by `clipboardHijack()`.
+    func restoreClipboardCaptureIfCurrent(_ result: SelectionCaptureResult) async {
+        guard case .clipboard(_, let snapshot) = result else { return }
+
+        guard let temporaryChangeCount = snapshot.temporaryChangeCount else {
+            await restoreSnapshotOnMain(snapshot)
+            return
+        }
+
+        let now = await currentChangeCountOnMain()
+        if now == temporaryChangeCount {
+            await restoreSnapshotOnMain(snapshot)
+        } else {
+            logger.notice("transforms-spike: skipping abandoned-capture clipboard restore — user copied content mid-transform (capture=\(temporaryChangeCount, privacy: .public), now=\(now, privacy: .public))")
+        }
+    }
+
     // MARK: - Clipboard Hijack
 
     private func clipboardHijack() async -> SelectionCaptureResult {
@@ -210,7 +245,7 @@ public actor SelectionCaptureService {
             let now = await currentChangeCountOnMain()
             if now != snapshot.originalChangeCount {
                 if let text = await currentStringOnMain(), !text.isEmpty {
-                    return .clipboard(text: text, savedClipboard: snapshot)
+                    return .clipboard(text: text, savedClipboard: snapshot.withTemporaryChangeCount(now))
                 }
                 // Change count moved but no string available (image, file, etc.).
                 // Cmd+C *did* write — the user's pre-hijack clipboard is now
@@ -259,9 +294,14 @@ public actor SelectionCaptureService {
 // mutable state).
 struct SystemSelectionCaptureBackend: SelectionCaptureBackend, @unchecked Sendable {
     private let pasteboard: NSPasteboard
+    private let shortcutKeyResolver: PasteShortcutKeyResolver
 
-    init(pasteboard: NSPasteboard = .general) {
+    init(
+        pasteboard: NSPasteboard = .general,
+        shortcutKeyResolver: PasteShortcutKeyResolver = PasteShortcutKeyResolver()
+    ) {
         self.pasteboard = pasteboard
+        self.shortcutKeyResolver = shortcutKeyResolver
     }
 
     func isAccessibilityTrusted() -> Bool {
@@ -326,7 +366,10 @@ struct SystemSelectionCaptureBackend: SelectionCaptureBackend, @unchecked Sendab
         guard let source = CGEventSource(stateID: .hidSystemState) else {
             throw SelectionCaptureError.eventSourceUnavailable
         }
-        let cKeyCode: CGKeyCode = 8  // ANSI 'C'
+        let cKeyCode = shortcutKeyResolver.virtualKeyCode(
+            for: "c",
+            modifierKeyState: UInt32(cmdKey >> 8)
+        )
         guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: cKeyCode, keyDown: true),
               let keyUp = CGEvent(keyboardEventSource: source, virtualKey: cKeyCode, keyDown: false) else {
             throw SelectionCaptureError.eventPostingFailed

--- a/Sources/MacParakeetCore/Services/System/SelectionCaptureService.swift
+++ b/Sources/MacParakeetCore/Services/System/SelectionCaptureService.swift
@@ -1,0 +1,321 @@
+import AppKit
+import ApplicationServices
+import Foundation
+import OSLog
+
+// MARK: - Result Types
+
+/// Source of a successful selection read. Used by `TransformExecutor` to pick
+/// the right replacement path: an `.ax` capture can attempt an AX-write first,
+/// while a `.clipboard` capture must paste-back via Cmd+V.
+public enum SelectionCaptureResult: @unchecked Sendable {
+    /// AX read returned a non-empty `kAXSelectedTextAttribute`. The element
+    /// handle is retained so the replacement service can try `AXUIElementSet`
+    /// before falling back to clipboard paste-back.
+    case ax(text: String, element: AXFocusedElement)
+
+    /// AX read returned empty/unsupported; clipboard hijack (Cmd+C + poll
+    /// `changeCount`) found non-empty text. The captured snapshot must be
+    /// restored after replacement completes.
+    case clipboard(text: String, savedClipboard: PasteboardSnapshot)
+
+    /// Neither AX nor clipboard hijack returned non-empty text.
+    case empty
+
+    /// A hard failure (e.g., AX permission denied at the system layer). The
+    /// pipeline should surface a user-visible error.
+    case failed(SelectionCaptureError)
+
+    public var capturedText: String? {
+        switch self {
+        case .ax(let text, _), .clipboard(let text, _):
+            return text
+        case .empty, .failed:
+            return nil
+        }
+    }
+
+    /// Telemetry/diagnostic tag for log lines.
+    public var pathTag: String {
+        switch self {
+        case .ax: return "ax"
+        case .clipboard: return "clipboard"
+        case .empty: return "empty"
+        case .failed: return "failed"
+        }
+    }
+}
+
+public enum SelectionCaptureError: Error, LocalizedError, Sendable {
+    case accessibilityNotAuthorized
+    case eventSourceUnavailable
+    case eventPostingFailed
+
+    public var errorDescription: String? {
+        switch self {
+        case .accessibilityNotAuthorized:
+            return "Accessibility permission required to read selected text."
+        case .eventSourceUnavailable:
+            return "Could not create a CGEventSource for the clipboard-fallback path."
+        case .eventPostingFailed:
+            return "Failed to post Cmd+C during clipboard-fallback selection capture."
+        }
+    }
+}
+
+/// `@unchecked Sendable` wrapper around an `AXUIElement` reference. `AXUIElement`
+/// is a CFType that the AX framework treats as thread-safe for the read/write
+/// calls the spike uses (`AXUIElementCopyAttributeValue` /
+/// `AXUIElementSetAttributeValue`). Wrapping it lets the result type cross
+/// actor boundaries without further annotation.
+public struct AXFocusedElement: @unchecked Sendable {
+    public let element: AXUIElement
+
+    public init(_ element: AXUIElement) {
+        self.element = element
+    }
+}
+
+/// Snapshot of the pasteboard items captured before a clipboard hijack. Held
+/// opaquely so callers don't have to know about AppKit types. `@unchecked
+/// Sendable` because `NSPasteboardItem` is not Sendable but our usage is
+/// effectively immutable after capture.
+public struct PasteboardSnapshot: @unchecked Sendable {
+    public let items: [NSPasteboardItem]?
+    public let originalChangeCount: Int
+
+    public init(items: [NSPasteboardItem]?, originalChangeCount: Int) {
+        self.items = items
+        self.originalChangeCount = originalChangeCount
+    }
+
+    /// Empty placeholder — useful for tests and the `.empty` no-op path.
+    public static let none = PasteboardSnapshot(items: nil, originalChangeCount: 0)
+}
+
+// MARK: - Backend Protocol (for testability)
+
+/// Minimal protocol the capture service depends on. Production wires up a
+/// `SystemSelectionCaptureBackend`; tests wire up a fake.
+protocol SelectionCaptureBackend: Sendable {
+    func isAccessibilityTrusted() -> Bool
+    func focusedElement() -> AXUIElement?
+    func selectedText(of element: AXUIElement) -> String?
+
+    /// Snapshot the pasteboard and return the saved items + the changeCount at
+    /// snapshot time (so the poll loop can detect the Cmd+C-triggered change).
+    @MainActor
+    func snapshotPasteboard() -> PasteboardSnapshot
+
+    /// Read the latest pasteboard string (used by the post-Cmd+C poll).
+    @MainActor
+    func currentPasteboardString() -> String?
+
+    /// Return the current pasteboard changeCount.
+    @MainActor
+    func currentPasteboardChangeCount() -> Int
+
+    /// Post a synthetic Cmd+C event pair.
+    @MainActor
+    func postCmdC() throws
+}
+
+// MARK: - Service
+
+/// Captures the currently-selected text in the frontmost macOS app.
+///
+/// AX-first, clipboard-hijack fallback. See
+/// `docs/research/transforms-design-2026-05.md` Architecture sketch §1 for
+/// the high-level design, and the Risk and unknowns section for why we keep
+/// the clipboard fallback unconditionally.
+///
+/// The poll budget after Cmd+C is **500 ms** (per Gemini review feedback —
+/// 250 ms was too tight in practice for apps like Mail / Slack that resolve
+/// pasteboard writes through their own event loop).
+public actor SelectionCaptureService {
+    /// Default poll budget while waiting for Cmd+C to land a new pasteboard
+    /// change count.
+    public static let defaultClipboardPollTimeout: Duration = .milliseconds(500)
+
+    private let backend: any SelectionCaptureBackend
+    private let logger: Logger
+    private let clipboardPollTimeout: Duration
+    private let pollIntervalNanos: UInt64
+
+    /// Production initializer — uses the real AX + pasteboard backend.
+    public init() {
+        self.init(backend: SystemSelectionCaptureBackend())
+    }
+
+    init(
+        backend: any SelectionCaptureBackend,
+        clipboardPollTimeout: Duration = SelectionCaptureService.defaultClipboardPollTimeout,
+        pollIntervalNanos: UInt64 = 15_000_000,  // 15 ms
+        logger: Logger = Logger(subsystem: "com.macparakeet.core", category: "SelectionCaptureService")
+    ) {
+        self.backend = backend
+        self.clipboardPollTimeout = clipboardPollTimeout
+        self.pollIntervalNanos = pollIntervalNanos
+        self.logger = logger
+    }
+
+    /// Try to capture the user's current selection. Never throws — returns a
+    /// `.failed` case for hard errors. Callers should treat `.empty` as the
+    /// "no selection" UX path (toast: select text first).
+    public func captureSelection() async -> SelectionCaptureResult {
+        // AX-first path.
+        guard backend.isAccessibilityTrusted() else {
+            return .failed(.accessibilityNotAuthorized)
+        }
+
+        if let element = backend.focusedElement() {
+            if let text = backend.selectedText(of: element),
+               !text.isEmpty {
+                return .ax(text: text, element: AXFocusedElement(element))
+            }
+        }
+
+        // Clipboard-hijack fallback.
+        return await clipboardHijack()
+    }
+
+    // MARK: - Clipboard Hijack
+
+    private func clipboardHijack() async -> SelectionCaptureResult {
+        let snapshot = await snapshotPasteboardOnMain()
+        do {
+            try await postCmdCOnMain()
+        } catch let error as SelectionCaptureError {
+            return .failed(error)
+        } catch {
+            return .failed(.eventPostingFailed)
+        }
+
+        // Poll for change count delta within the budget. The string read is
+        // intentionally done after the change-count check so we don't race
+        // with the pasteboard mutating mid-Cmd+C.
+        let deadline = ContinuousClock.now + clipboardPollTimeout
+        while ContinuousClock.now < deadline {
+            let now = await currentChangeCountOnMain()
+            if now != snapshot.originalChangeCount {
+                if let text = await currentStringOnMain(), !text.isEmpty {
+                    return .clipboard(text: text, savedClipboard: snapshot)
+                }
+                // Change count moved but no string available (image, file, etc.).
+                // Restore snapshot ourselves and treat as empty — there's
+                // nothing for the LLM to transform.
+                return .empty
+            }
+            try? await Task.sleep(nanoseconds: pollIntervalNanos)
+        }
+
+        // No change count delta — selection was empty.
+        return .empty
+    }
+
+    @MainActor
+    private func snapshotPasteboardOnMain() -> PasteboardSnapshot {
+        backend.snapshotPasteboard()
+    }
+
+    @MainActor
+    private func currentChangeCountOnMain() -> Int {
+        backend.currentPasteboardChangeCount()
+    }
+
+    @MainActor
+    private func currentStringOnMain() -> String? {
+        backend.currentPasteboardString()
+    }
+
+    @MainActor
+    private func postCmdCOnMain() throws {
+        try backend.postCmdC()
+    }
+}
+
+// MARK: - System Backend
+
+// `@unchecked Sendable` because the stored `NSPasteboard` reference is only
+// touched from `@MainActor` methods — the AX read paths are pure (no shared
+// mutable state).
+struct SystemSelectionCaptureBackend: SelectionCaptureBackend, @unchecked Sendable {
+    private let pasteboard: NSPasteboard
+
+    init(pasteboard: NSPasteboard = .general) {
+        self.pasteboard = pasteboard
+    }
+
+    func isAccessibilityTrusted() -> Bool {
+        AXIsProcessTrusted()
+    }
+
+    func focusedElement() -> AXUIElement? {
+        let systemElement = AXUIElementCreateSystemWide()
+        var raw: CFTypeRef?
+        let status = AXUIElementCopyAttributeValue(
+            systemElement,
+            kAXFocusedUIElementAttribute as CFString,
+            &raw
+        )
+        guard status == .success, let raw, CFGetTypeID(raw) == AXUIElementGetTypeID() else {
+            return nil
+        }
+        return unsafeDowncast(raw as AnyObject, to: AXUIElement.self)
+    }
+
+    func selectedText(of element: AXUIElement) -> String? {
+        var raw: CFTypeRef?
+        let status = AXUIElementCopyAttributeValue(
+            element,
+            kAXSelectedTextAttribute as CFString,
+            &raw
+        )
+        guard status == .success, let raw else { return nil }
+        let value = raw as? String
+        return value?.isEmpty == true ? nil : value
+    }
+
+    @MainActor
+    func snapshotPasteboard() -> PasteboardSnapshot {
+        let items = pasteboard.pasteboardItems?.map { item -> NSPasteboardItem in
+            let copy = NSPasteboardItem()
+            for type in item.types {
+                if let data = item.data(forType: type) {
+                    copy.setData(data, forType: type)
+                }
+            }
+            return copy
+        }
+        return PasteboardSnapshot(items: items, originalChangeCount: pasteboard.changeCount)
+    }
+
+    @MainActor
+    func currentPasteboardString() -> String? {
+        pasteboard.string(forType: .string)
+    }
+
+    @MainActor
+    func currentPasteboardChangeCount() -> Int {
+        pasteboard.changeCount
+    }
+
+    @MainActor
+    func postCmdC() throws {
+        guard AXIsProcessTrusted() else {
+            throw SelectionCaptureError.accessibilityNotAuthorized
+        }
+        guard let source = CGEventSource(stateID: .hidSystemState) else {
+            throw SelectionCaptureError.eventSourceUnavailable
+        }
+        let cKeyCode: CGKeyCode = 8  // ANSI 'C'
+        guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: cKeyCode, keyDown: true),
+              let keyUp = CGEvent(keyboardEventSource: source, virtualKey: cKeyCode, keyDown: false) else {
+            throw SelectionCaptureError.eventPostingFailed
+        }
+        keyDown.flags = .maskCommand
+        keyUp.flags = .maskCommand
+        keyDown.post(tap: .cghidEventTap)
+        keyUp.post(tap: .cghidEventTap)
+    }
+}

--- a/Sources/MacParakeetCore/Services/System/SelectionReplacementService.swift
+++ b/Sources/MacParakeetCore/Services/System/SelectionReplacementService.swift
@@ -1,5 +1,6 @@
 import AppKit
 import ApplicationServices
+import Carbon
 import Foundation
 import OSLog
 
@@ -64,6 +65,9 @@ protocol SelectionReplacementBackend: Sendable {
     func currentChangeCount() -> Int
 
     @MainActor
+    func snapshotPasteboard() -> PasteboardSnapshot
+
+    @MainActor
     func restoreSnapshot(_ snapshot: PasteboardSnapshot)
 }
 
@@ -122,8 +126,11 @@ public actor SelectionReplacementService {
 
         case .clipboard(_, let savedSnapshot):
             // Original capture already hijacked the clipboard. Paste then
-            // restore the snapshot we promised the user we'd put back.
-            try await pasteAndRestore(newText: newText, snapshot: savedSnapshot)
+            // restore the snapshot we promised the user we'd put back. If the
+            // user copied something else while the LLM was running, preserve
+            // that newer clipboard instead of the pre-transform snapshot.
+            let restoreSnapshot = await snapshotForClipboardContext(savedSnapshot)
+            try await pasteAndRestore(newText: newText, snapshot: restoreSnapshot)
             return .clipboardPaste
 
         case .empty, .failed:
@@ -133,17 +140,21 @@ public actor SelectionReplacementService {
 
     @MainActor
     private func snapshotPasteboardForFallback() -> PasteboardSnapshot {
-        let pb = NSPasteboard.general
-        let items = pb.pasteboardItems?.map { item -> NSPasteboardItem in
-            let copy = NSPasteboardItem()
-            for type in item.types {
-                if let data = item.data(forType: type) {
-                    copy.setData(data, forType: type)
-                }
-            }
-            return copy
+        backend.snapshotPasteboard()
+    }
+
+    private func snapshotForClipboardContext(_ savedSnapshot: PasteboardSnapshot) async -> PasteboardSnapshot {
+        guard let temporaryChangeCount = savedSnapshot.temporaryChangeCount else {
+            return savedSnapshot
         }
-        return PasteboardSnapshot(items: items, originalChangeCount: pb.changeCount)
+
+        let now = await currentChangeCountOnMain()
+        guard now != temporaryChangeCount else {
+            return savedSnapshot
+        }
+
+        logger.notice("transforms-spike: preserving clipboard content copied during LLM phase (capture=\(temporaryChangeCount, privacy: .public), now=\(now, privacy: .public))")
+        return await snapshotPasteboardForFallback()
     }
 
     private func pasteAndRestore(
@@ -222,9 +233,14 @@ public actor SelectionReplacementService {
 // from `@MainActor` methods. The AX write path is pure.
 struct SystemSelectionReplacementBackend: SelectionReplacementBackend, @unchecked Sendable {
     private let pasteboard: NSPasteboard
+    private let shortcutKeyResolver: PasteShortcutKeyResolver
 
-    init(pasteboard: NSPasteboard = .general) {
+    init(
+        pasteboard: NSPasteboard = .general,
+        shortcutKeyResolver: PasteShortcutKeyResolver = PasteShortcutKeyResolver()
+    ) {
         self.pasteboard = pasteboard
+        self.shortcutKeyResolver = shortcutKeyResolver
     }
 
     func isAccessibilityTrusted() -> Bool {
@@ -261,6 +277,20 @@ struct SystemSelectionReplacementBackend: SelectionReplacementBackend, @unchecke
     }
 
     @MainActor
+    func snapshotPasteboard() -> PasteboardSnapshot {
+        let items = pasteboard.pasteboardItems?.map { item -> NSPasteboardItem in
+            let copy = NSPasteboardItem()
+            for type in item.types {
+                if let data = item.data(forType: type) {
+                    copy.setData(data, forType: type)
+                }
+            }
+            return copy
+        }
+        return PasteboardSnapshot(items: items, originalChangeCount: pasteboard.changeCount)
+    }
+
+    @MainActor
     func postCmdV() throws {
         guard AXIsProcessTrusted() else {
             throw SelectionReplacementError.accessibilityNotAuthorized
@@ -268,7 +298,10 @@ struct SystemSelectionReplacementBackend: SelectionReplacementBackend, @unchecke
         guard let source = CGEventSource(stateID: .hidSystemState) else {
             throw SelectionReplacementError.eventSourceUnavailable
         }
-        let vKeyCode: CGKeyCode = 9  // ANSI 'V'
+        let vKeyCode = shortcutKeyResolver.virtualKeyCode(
+            for: "v",
+            modifierKeyState: UInt32(cmdKey >> 8)
+        )
         guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: true),
               let keyUp = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: false) else {
             throw SelectionReplacementError.eventPostingFailed

--- a/Sources/MacParakeetCore/Services/System/SelectionReplacementService.swift
+++ b/Sources/MacParakeetCore/Services/System/SelectionReplacementService.swift
@@ -1,0 +1,256 @@
+import AppKit
+import ApplicationServices
+import Foundation
+import OSLog
+
+// MARK: - Public Types
+
+public enum SelectionReplacementPath: String, Sendable, Equatable {
+    /// AX `kAXSelectedTextAttribute` write succeeded.
+    case ax
+    /// Paste-back via Cmd+V succeeded (either AX-write was unavailable or
+    /// failed, or the original capture was `.clipboard`).
+    case clipboardPaste
+}
+
+public enum SelectionReplacementError: Error, LocalizedError, Sendable {
+    case accessibilityNotAuthorized
+    case eventSourceUnavailable
+    case pasteboardWriteFailed
+    case eventPostingFailed
+    case allPathsFailed
+
+    public var errorDescription: String? {
+        switch self {
+        case .accessibilityNotAuthorized:
+            return "Accessibility permission required to replace selection."
+        case .eventSourceUnavailable:
+            return "Could not create a CGEventSource for paste simulation."
+        case .pasteboardWriteFailed:
+            return "Could not write replacement text to the clipboard."
+        case .eventPostingFailed:
+            return "Failed to post Cmd+V keystroke."
+        case .allPathsFailed:
+            return "Selection replacement failed via both AX-write and clipboard paste."
+        }
+    }
+}
+
+// MARK: - Backend Protocol
+
+protocol SelectionReplacementBackend: Sendable {
+    func isAccessibilityTrusted() -> Bool
+    /// Attempt to write the new text via AX. Returns `true` on success
+    /// (set + verifying read-back returned the same text). Returns `false`
+    /// when AX rejects the write or the read-back doesn't match.
+    func writeSelectionViaAX(_ text: String, element: AXUIElement) -> Bool
+
+    @MainActor
+    func writePasteboardString(_ text: String) -> Bool
+
+    @MainActor
+    func postCmdV() throws
+
+    @MainActor
+    func restoreSnapshot(_ snapshot: PasteboardSnapshot)
+}
+
+// MARK: - Service
+
+/// Replaces the user's current selection with new text. AX-write first
+/// (zero side effects on clipboard), paste-back via Cmd+V otherwise.
+///
+/// See `docs/research/transforms-design-2026-05.md` §2 — the design accepts
+/// a small clipboard race window (~500ms) in exchange for a working
+/// universal path across every macOS app. Snapshot restoration runs even on
+/// failure to keep the user's pre-transform clipboard contents safe.
+public actor SelectionReplacementService {
+    /// Time to wait for the paste to land before restoring the original
+    /// clipboard snapshot. 500ms matches the conventional "Espanso / Raycast"
+    /// value and the Gemini-review feedback on the capture side.
+    public static let defaultPostPasteDelay: Duration = .milliseconds(500)
+
+    private let backend: any SelectionReplacementBackend
+    private let postPasteDelay: Duration
+    private let logger: Logger
+
+    public init() {
+        self.init(backend: SystemSelectionReplacementBackend())
+    }
+
+    init(
+        backend: any SelectionReplacementBackend,
+        postPasteDelay: Duration = SelectionReplacementService.defaultPostPasteDelay,
+        logger: Logger = Logger(subsystem: "com.macparakeet.core", category: "SelectionReplacementService")
+    ) {
+        self.backend = backend
+        self.postPasteDelay = postPasteDelay
+        self.logger = logger
+    }
+
+    /// Replace the user's selection (captured via `SelectionCaptureService`)
+    /// with `newText`. Returns the path used, or throws on hard failure.
+    @discardableResult
+    public func replace(
+        with newText: String,
+        in context: SelectionCaptureResult
+    ) async throws -> SelectionReplacementPath {
+        switch context {
+        case .ax(_, let focused):
+            // AX-write is the no-side-effect path. If it succeeds, we're done.
+            if backend.writeSelectionViaAX(newText, element: focused.element) {
+                return .ax
+            }
+            // Fall through to clipboard paste (no original snapshot — the AX
+            // capture path didn't touch the clipboard, so we capture a fresh
+            // snapshot here to preserve whatever the user had on it).
+            let freshSnapshot = await snapshotPasteboardForFallback()
+            try await pasteAndRestore(newText: newText, snapshot: freshSnapshot)
+            return .clipboardPaste
+
+        case .clipboard(_, let savedSnapshot):
+            // Original capture already hijacked the clipboard. Paste then
+            // restore the snapshot we promised the user we'd put back.
+            try await pasteAndRestore(newText: newText, snapshot: savedSnapshot)
+            return .clipboardPaste
+
+        case .empty, .failed:
+            throw SelectionReplacementError.allPathsFailed
+        }
+    }
+
+    @MainActor
+    private func snapshotPasteboardForFallback() -> PasteboardSnapshot {
+        let pb = NSPasteboard.general
+        let items = pb.pasteboardItems?.map { item -> NSPasteboardItem in
+            let copy = NSPasteboardItem()
+            for type in item.types {
+                if let data = item.data(forType: type) {
+                    copy.setData(data, forType: type)
+                }
+            }
+            return copy
+        }
+        return PasteboardSnapshot(items: items, originalChangeCount: pb.changeCount)
+    }
+
+    private func pasteAndRestore(
+        newText: String,
+        snapshot: PasteboardSnapshot
+    ) async throws {
+        let pasteboardWriteSucceeded = await writePasteboardStringOnMain(newText)
+        guard pasteboardWriteSucceeded else {
+            // Try to put the user's clipboard back even on this failure.
+            await restoreSnapshotOnMain(snapshot)
+            throw SelectionReplacementError.pasteboardWriteFailed
+        }
+
+        do {
+            try await postCmdVOnMain()
+        } catch let error as SelectionReplacementError {
+            await restoreSnapshotOnMain(snapshot)
+            throw error
+        } catch {
+            await restoreSnapshotOnMain(snapshot)
+            throw SelectionReplacementError.eventPostingFailed
+        }
+
+        // Give the host app time to consume the paste before restoring the
+        // saved snapshot. Short enough that the user doesn't see a stale
+        // pasteboard, long enough that slow apps (Slack, Mail) finish.
+        try? await Task.sleep(for: postPasteDelay)
+        await restoreSnapshotOnMain(snapshot)
+    }
+
+    @MainActor
+    private func writePasteboardStringOnMain(_ text: String) -> Bool {
+        backend.writePasteboardString(text)
+    }
+
+    @MainActor
+    private func postCmdVOnMain() throws {
+        try backend.postCmdV()
+    }
+
+    @MainActor
+    private func restoreSnapshotOnMain(_ snapshot: PasteboardSnapshot) {
+        backend.restoreSnapshot(snapshot)
+    }
+}
+
+// MARK: - System Backend
+
+// `@unchecked Sendable` for the same reason as
+// `SystemSelectionCaptureBackend`: the `NSPasteboard` reference is only used
+// from `@MainActor` methods. The AX write path is pure.
+struct SystemSelectionReplacementBackend: SelectionReplacementBackend, @unchecked Sendable {
+    private let pasteboard: NSPasteboard
+
+    init(pasteboard: NSPasteboard = .general) {
+        self.pasteboard = pasteboard
+    }
+
+    func isAccessibilityTrusted() -> Bool {
+        AXIsProcessTrusted()
+    }
+
+    func writeSelectionViaAX(_ text: String, element: AXUIElement) -> Bool {
+        let setStatus = AXUIElementSetAttributeValue(
+            element,
+            kAXSelectedTextAttribute as CFString,
+            text as CFString
+        )
+        guard setStatus == .success else {
+            return false
+        }
+        // Verify by reading back the value attribute (best-effort — if the
+        // field doesn't expose `kAXValue`, we just trust the set succeeded).
+        var raw: CFTypeRef?
+        let readStatus = AXUIElementCopyAttributeValue(
+            element,
+            kAXValueAttribute as CFString,
+            &raw
+        )
+        if readStatus == .success, let raw, let value = raw as? String {
+            // The field's full value should *contain* the inserted text. Equality
+            // is too strict because the host app may already have surrounding text.
+            return value.contains(text) || value == text
+        }
+        return true
+    }
+
+    @MainActor
+    func writePasteboardString(_ text: String) -> Bool {
+        pasteboard.clearContents()
+        return pasteboard.setString(text, forType: .string)
+    }
+
+    @MainActor
+    func postCmdV() throws {
+        guard AXIsProcessTrusted() else {
+            throw SelectionReplacementError.accessibilityNotAuthorized
+        }
+        guard let source = CGEventSource(stateID: .hidSystemState) else {
+            throw SelectionReplacementError.eventSourceUnavailable
+        }
+        let vKeyCode: CGKeyCode = 9  // ANSI 'V'
+        guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: true),
+              let keyUp = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: false) else {
+            throw SelectionReplacementError.eventPostingFailed
+        }
+        keyDown.flags = .maskCommand
+        keyUp.flags = .maskCommand
+        keyDown.post(tap: .cghidEventTap)
+        keyUp.post(tap: .cghidEventTap)
+    }
+
+    @MainActor
+    func restoreSnapshot(_ snapshot: PasteboardSnapshot) {
+        guard let items = snapshot.items, !items.isEmpty else {
+            pasteboard.clearContents()
+            return
+        }
+        pasteboard.clearContents()
+        pasteboard.writeObjects(items)
+    }
+}

--- a/Sources/MacParakeetCore/Services/System/SelectionReplacementService.swift
+++ b/Sources/MacParakeetCore/Services/System/SelectionReplacementService.swift
@@ -40,9 +40,14 @@ public enum SelectionReplacementError: Error, LocalizedError, Sendable {
 
 protocol SelectionReplacementBackend: Sendable {
     func isAccessibilityTrusted() -> Bool
-    /// Attempt to write the new text via AX. Returns `true` on success
-    /// (set + verifying read-back returned the same text). Returns `false`
-    /// when AX rejects the write or the read-back doesn't match.
+    /// Attempt to write the new text via AX. Returns `true` when
+    /// `AXUIElementSetAttributeValue(kAXSelectedTextAttribute, …)` returns
+    /// `.success`. We deliberately do NOT verify via a re-read: substring
+    /// "contains" verification false-positives when the inserted text
+    /// already appeared elsewhere in the field, and reading `kAXValue` is
+    /// brittle (many web/Electron fields don't expose it). Apps where AX
+    /// claims success but doesn't actually update will surface in the smoke
+    /// matrix and we'll fall back to clipboard-paste for those.
     func writeSelectionViaAX(_ text: String, element: AXUIElement) -> Bool
 
     @MainActor
@@ -50,6 +55,13 @@ protocol SelectionReplacementBackend: Sendable {
 
     @MainActor
     func postCmdV() throws
+
+    /// Current `NSPasteboard.changeCount`. Used by the restore guard to
+    /// detect whether the user copied something else during the
+    /// paste-and-restore window — if so, we preserve their newer content
+    /// instead of clobbering it with our stale snapshot.
+    @MainActor
+    func currentChangeCount() -> Int
 
     @MainActor
     func restoreSnapshot(_ snapshot: PasteboardSnapshot)
@@ -138,9 +150,15 @@ public actor SelectionReplacementService {
         newText: String,
         snapshot: PasteboardSnapshot
     ) async throws {
-        let pasteboardWriteSucceeded = await writePasteboardStringOnMain(newText)
-        guard pasteboardWriteSucceeded else {
-            // Try to put the user's clipboard back even on this failure.
+        // Write our payload and capture the changeCount *after* the write —
+        // that's the value the restore guard compares against. If anyone
+        // else (the user) writes to the clipboard between now and the
+        // restore step, the count will be higher and we'll preserve their
+        // newer content instead of clobbering it.
+        guard let ourChangeCount = await writeAndCaptureChangeCountOnMain(newText) else {
+            // Write failed before we put anything user-relevant on the
+            // clipboard. Restore unconditionally — we may have already
+            // called clearContents().
             await restoreSnapshotOnMain(snapshot)
             throw SelectionReplacementError.pasteboardWriteFailed
         }
@@ -148,10 +166,10 @@ public actor SelectionReplacementService {
         do {
             try await postCmdVOnMain()
         } catch let error as SelectionReplacementError {
-            await restoreSnapshotOnMain(snapshot)
+            await restoreIfSafe(snapshot, ourChangeCount: ourChangeCount)
             throw error
         } catch {
-            await restoreSnapshotOnMain(snapshot)
+            await restoreIfSafe(snapshot, ourChangeCount: ourChangeCount)
             throw SelectionReplacementError.eventPostingFailed
         }
 
@@ -159,12 +177,13 @@ public actor SelectionReplacementService {
         // saved snapshot. Short enough that the user doesn't see a stale
         // pasteboard, long enough that slow apps (Slack, Mail) finish.
         try? await Task.sleep(for: postPasteDelay)
-        await restoreSnapshotOnMain(snapshot)
+        await restoreIfSafe(snapshot, ourChangeCount: ourChangeCount)
     }
 
     @MainActor
-    private func writePasteboardStringOnMain(_ text: String) -> Bool {
-        backend.writePasteboardString(text)
+    private func writeAndCaptureChangeCountOnMain(_ text: String) -> Int? {
+        guard backend.writePasteboardString(text) else { return nil }
+        return backend.currentChangeCount()
     }
 
     @MainActor
@@ -175,6 +194,24 @@ public actor SelectionReplacementService {
     @MainActor
     private func restoreSnapshotOnMain(_ snapshot: PasteboardSnapshot) {
         backend.restoreSnapshot(snapshot)
+    }
+
+    /// Only restore the saved snapshot if the pasteboard's changeCount is
+    /// still the one we set when we wrote our paste payload. A higher count
+    /// means the user copied something else during our paste window — we
+    /// preserve their content rather than reverting to our stale snapshot.
+    private func restoreIfSafe(_ snapshot: PasteboardSnapshot, ourChangeCount: Int) async {
+        let now = await currentChangeCountOnMain()
+        if now == ourChangeCount {
+            await restoreSnapshotOnMain(snapshot)
+        } else {
+            logger.notice("transforms-spike: skipping clipboard restore — user copied content mid-transform (ours=\(ourChangeCount, privacy: .public), now=\(now, privacy: .public))")
+        }
+    }
+
+    @MainActor
+    private func currentChangeCountOnMain() -> Int {
+        backend.currentChangeCount()
     }
 }
 
@@ -195,34 +232,32 @@ struct SystemSelectionReplacementBackend: SelectionReplacementBackend, @unchecke
     }
 
     func writeSelectionViaAX(_ text: String, element: AXUIElement) -> Bool {
+        // Trust the AX setStatus directly. The earlier post-write
+        // `value.contains(text)` verification looked safer but actually
+        // false-positively reported success whenever the inserted text
+        // already appeared anywhere else in the field — masking a real
+        // AX-write failure and skipping the clipboard fallback that would
+        // have worked. Apps that silently accept-and-discard
+        // `kAXSelectedTextAttribute` writes will show up in the smoke matrix
+        // as "AX capture Y, AX write Y, selection wasn't actually replaced"
+        // and we'll downgrade those to clipboard-only in Phase 2.
         let setStatus = AXUIElementSetAttributeValue(
             element,
             kAXSelectedTextAttribute as CFString,
             text as CFString
         )
-        guard setStatus == .success else {
-            return false
-        }
-        // Verify by reading back the value attribute (best-effort — if the
-        // field doesn't expose `kAXValue`, we just trust the set succeeded).
-        var raw: CFTypeRef?
-        let readStatus = AXUIElementCopyAttributeValue(
-            element,
-            kAXValueAttribute as CFString,
-            &raw
-        )
-        if readStatus == .success, let raw, let value = raw as? String {
-            // The field's full value should *contain* the inserted text. Equality
-            // is too strict because the host app may already have surrounding text.
-            return value.contains(text) || value == text
-        }
-        return true
+        return setStatus == .success
     }
 
     @MainActor
     func writePasteboardString(_ text: String) -> Bool {
         pasteboard.clearContents()
         return pasteboard.setString(text, forType: .string)
+    }
+
+    @MainActor
+    func currentChangeCount() -> Int {
+        pasteboard.changeCount
     }
 
     @MainActor

--- a/Sources/MacParakeetCore/Services/Transforms/TransformExecutor.swift
+++ b/Sources/MacParakeetCore/Services/Transforms/TransformExecutor.swift
@@ -1,0 +1,214 @@
+import Foundation
+import OSLog
+
+// MARK: - Progress
+
+/// Progress events for the Transforms pipeline. The UI overlay listens for
+/// these to drive its label / spinner state and to dismiss itself once a
+/// terminal event arrives.
+public enum TransformProgress: Sendable, Equatable {
+    case capturing
+    case llmStarted
+    /// Streamed token accumulation so the UI can show partial progress if it
+    /// wants. Phase-1 spike doesn't render this (paste happens only after
+    /// `llmCompleted`), but it's threaded through so a future iteration can.
+    case llmStreaming(String)
+    case llmCompleted(String)
+    case pasting
+    case done(SelectionReplacementPath)
+    case failed(String)
+
+    public var isTerminal: Bool {
+        switch self {
+        case .done, .failed:
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+// MARK: - Result
+
+public struct TransformExecutionResult: Sendable {
+    public let outputText: String
+    public let path: SelectionReplacementPath
+    public let totalElapsedMs: Int
+    public let llmElapsedMs: Int
+    public let captureTag: String
+
+    public init(
+        outputText: String,
+        path: SelectionReplacementPath,
+        totalElapsedMs: Int,
+        llmElapsedMs: Int,
+        captureTag: String
+    ) {
+        self.outputText = outputText
+        self.path = path
+        self.totalElapsedMs = totalElapsedMs
+        self.llmElapsedMs = llmElapsedMs
+        self.captureTag = captureTag
+    }
+}
+
+// MARK: - Errors
+
+public enum TransformExecutorError: Error, LocalizedError, Sendable {
+    case emptySelection
+    case captureFailed(SelectionCaptureError)
+    case llmNotConfigured
+    case llmFailed(String)
+    case replacementFailed(SelectionReplacementError)
+    case cancelled
+
+    public var errorDescription: String? {
+        switch self {
+        case .emptySelection:
+            return "No selection — select text first, then trigger the transform."
+        case .captureFailed(let underlying):
+            return underlying.errorDescription
+        case .llmNotConfigured:
+            return "Transforms need an LLM provider — configure one in Settings."
+        case .llmFailed(let detail):
+            return "Transform failed: \(detail)"
+        case .replacementFailed(let underlying):
+            return underlying.errorDescription
+        case .cancelled:
+            return "Transform cancelled."
+        }
+    }
+}
+
+// MARK: - Executor
+
+/// One-shot transforms pipeline: capture → LLM → replace.
+///
+/// The spike intentionally exposes a single `run(prompt:onProgress:)` entry
+/// point — no Prompt model, no rule toggles, no diff preview. Cancellation is
+/// cooperative: the caller cancels the Task wrapping `run(...)` (e.g., when
+/// the user presses Esc or triggers another transform).
+///
+/// See `docs/research/transforms-design-2026-05.md` §3 for the productized
+/// shape this spike will graduate to in Phase 2.
+public actor TransformExecutor {
+    private let captureService: SelectionCaptureService
+    private let replacementService: SelectionReplacementService
+    private let llmService: LLMServiceProtocol
+    private let logger: Logger
+
+    public init(
+        captureService: SelectionCaptureService = SelectionCaptureService(),
+        replacementService: SelectionReplacementService = SelectionReplacementService(),
+        llmService: LLMServiceProtocol
+    ) {
+        self.captureService = captureService
+        self.replacementService = replacementService
+        self.llmService = llmService
+        self.logger = Logger(subsystem: "com.macparakeet.core", category: "TransformExecutor")
+    }
+
+    /// Run the pipeline. The progress callback fires on the caller's context
+    /// — wrap it with `@MainActor` semantics at the call site if the UI
+    /// needs main-thread delivery.
+    public func run(
+        prompt: String,
+        onProgress: @escaping @Sendable (TransformProgress) -> Void
+    ) async throws -> TransformExecutionResult {
+        let start = ContinuousClock.now
+
+        // 1. Capture.
+        onProgress(.capturing)
+        let captured = await captureService.captureSelection()
+        try Task.checkCancellation()
+
+        switch captured {
+        case .empty:
+            onProgress(.failed(TransformExecutorError.emptySelection.localizedDescription))
+            throw TransformExecutorError.emptySelection
+        case .failed(let error):
+            onProgress(.failed(error.localizedDescription))
+            throw TransformExecutorError.captureFailed(error)
+        default:
+            break
+        }
+
+        guard let inputText = captured.capturedText, !inputText.isEmpty else {
+            onProgress(.failed(TransformExecutorError.emptySelection.localizedDescription))
+            throw TransformExecutorError.emptySelection
+        }
+
+        // 2. LLM transform stream.
+        onProgress(.llmStarted)
+        let llmStart = ContinuousClock.now
+        var accumulated = ""
+        do {
+            let stream = llmService.transformStream(text: inputText, prompt: prompt)
+            for try await chunk in stream {
+                try Task.checkCancellation()
+                accumulated += chunk
+                onProgress(.llmStreaming(accumulated))
+            }
+        } catch is CancellationError {
+            onProgress(.failed(TransformExecutorError.cancelled.localizedDescription))
+            throw TransformExecutorError.cancelled
+        } catch let error as LLMError {
+            if case .notConfigured = error {
+                onProgress(.failed(TransformExecutorError.llmNotConfigured.localizedDescription))
+                throw TransformExecutorError.llmNotConfigured
+            }
+            let detail = error.localizedDescription
+            onProgress(.failed(TransformExecutorError.llmFailed(detail).localizedDescription))
+            throw TransformExecutorError.llmFailed(detail)
+        } catch {
+            let detail = error.localizedDescription
+            onProgress(.failed(TransformExecutorError.llmFailed(detail).localizedDescription))
+            throw TransformExecutorError.llmFailed(detail)
+        }
+        let llmElapsedMs = Self.elapsedMs(from: llmStart)
+        try Task.checkCancellation()
+
+        guard !accumulated.isEmpty else {
+            onProgress(.failed(TransformExecutorError.llmFailed("LLM returned empty output.").localizedDescription))
+            throw TransformExecutorError.llmFailed("LLM returned empty output.")
+        }
+        onProgress(.llmCompleted(accumulated))
+
+        // 3. Replace.
+        onProgress(.pasting)
+        let path: SelectionReplacementPath
+        do {
+            path = try await replacementService.replace(with: accumulated, in: captured)
+        } catch let error as SelectionReplacementError {
+            onProgress(.failed(error.localizedDescription))
+            throw TransformExecutorError.replacementFailed(error)
+        } catch {
+            let mapped = SelectionReplacementError.allPathsFailed
+            onProgress(.failed(mapped.localizedDescription))
+            throw TransformExecutorError.replacementFailed(mapped)
+        }
+
+        let totalMs = Self.elapsedMs(from: start)
+        let result = TransformExecutionResult(
+            outputText: accumulated,
+            path: path,
+            totalElapsedMs: totalMs,
+            llmElapsedMs: llmElapsedMs,
+            captureTag: captured.pathTag
+        )
+        onProgress(.done(path))
+
+        logger.notice(
+            "transforms-spike: capture=\(captured.pathTag, privacy: .public) text_len=\(inputText.count, privacy: .public) llm_ms=\(llmElapsedMs, privacy: .public) replace=\(path.rawValue, privacy: .public) total_ms=\(totalMs, privacy: .public)"
+        )
+
+        return result
+    }
+
+    private static func elapsedMs(from start: ContinuousClock.Instant) -> Int {
+        let elapsed = ContinuousClock.now - start
+        let components = elapsed.components
+        return Int(components.seconds) * 1000 + Int(components.attoseconds / 1_000_000_000_000_000)
+    }
+}
+

--- a/Sources/MacParakeetCore/Services/Transforms/TransformExecutor.swift
+++ b/Sources/MacParakeetCore/Services/Transforms/TransformExecutor.swift
@@ -120,7 +120,13 @@ public actor TransformExecutor {
         // 1. Capture.
         onProgress(.capturing)
         let captured = await captureService.captureSelection()
-        try Task.checkCancellation()
+        do {
+            try Task.checkCancellation()
+        } catch {
+            await restoreIfAbandoning(captured)
+            onProgress(.failed(TransformExecutorError.cancelled.localizedDescription))
+            throw TransformExecutorError.cancelled
+        }
 
         switch captured {
         case .empty:
@@ -134,6 +140,7 @@ public actor TransformExecutor {
         }
 
         guard let inputText = captured.capturedText, !inputText.isEmpty else {
+            await restoreIfAbandoning(captured)
             onProgress(.failed(TransformExecutorError.emptySelection.localizedDescription))
             throw TransformExecutorError.emptySelection
         }
@@ -150,25 +157,36 @@ public actor TransformExecutor {
                 onProgress(.llmStreaming(accumulated))
             }
         } catch is CancellationError {
+            await restoreIfAbandoning(captured)
             onProgress(.failed(TransformExecutorError.cancelled.localizedDescription))
             throw TransformExecutorError.cancelled
         } catch let error as LLMError {
             if case .notConfigured = error {
+                await restoreIfAbandoning(captured)
                 onProgress(.failed(TransformExecutorError.llmNotConfigured.localizedDescription))
                 throw TransformExecutorError.llmNotConfigured
             }
             let detail = error.localizedDescription
+            await restoreIfAbandoning(captured)
             onProgress(.failed(TransformExecutorError.llmFailed(detail).localizedDescription))
             throw TransformExecutorError.llmFailed(detail)
         } catch {
             let detail = error.localizedDescription
+            await restoreIfAbandoning(captured)
             onProgress(.failed(TransformExecutorError.llmFailed(detail).localizedDescription))
             throw TransformExecutorError.llmFailed(detail)
         }
         let llmElapsedMs = Self.elapsedMs(from: llmStart)
-        try Task.checkCancellation()
+        do {
+            try Task.checkCancellation()
+        } catch {
+            await restoreIfAbandoning(captured)
+            onProgress(.failed(TransformExecutorError.cancelled.localizedDescription))
+            throw TransformExecutorError.cancelled
+        }
 
         guard !accumulated.isEmpty else {
+            await restoreIfAbandoning(captured)
             onProgress(.failed(TransformExecutorError.llmFailed("LLM returned empty output.").localizedDescription))
             throw TransformExecutorError.llmFailed("LLM returned empty output.")
         }
@@ -184,6 +202,7 @@ public actor TransformExecutor {
         do {
             try Task.checkCancellation()
         } catch {
+            await restoreIfAbandoning(captured)
             onProgress(.failed(TransformExecutorError.cancelled.localizedDescription))
             throw TransformExecutorError.cancelled
         }
@@ -222,5 +241,8 @@ public actor TransformExecutor {
         let components = elapsed.components
         return Int(components.seconds) * 1000 + Int(components.attoseconds / 1_000_000_000_000_000)
     }
-}
 
+    private func restoreIfAbandoning(_ captured: SelectionCaptureResult) async {
+        await captureService.restoreClipboardCaptureIfCurrent(captured)
+    }
+}

--- a/Sources/MacParakeetCore/Services/Transforms/TransformExecutor.swift
+++ b/Sources/MacParakeetCore/Services/Transforms/TransformExecutor.swift
@@ -175,6 +175,18 @@ public actor TransformExecutor {
         onProgress(.llmCompleted(accumulated))
 
         // 3. Replace.
+        //
+        // Final cancellation gate. Past this point the replace+restore path
+        // is *not* honored mid-flight: aborting once we've written the new
+        // text to the clipboard and posted Cmd+V leaves the host app in a
+        // partial state (paste happened, restore didn't), so we run replace
+        // to completion and only honor cancel before it begins.
+        do {
+            try Task.checkCancellation()
+        } catch {
+            onProgress(.failed(TransformExecutorError.cancelled.localizedDescription))
+            throw TransformExecutorError.cancelled
+        }
         onProgress(.pasting)
         let path: SelectionReplacementPath
         do {

--- a/Sources/MacParakeetCore/Services/Transforms/TransformPrompts.swift
+++ b/Sources/MacParakeetCore/Services/Transforms/TransformPrompts.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Hardcoded prompts used by the Transforms spike. Phase 2 replaces this with
+/// `Prompt` rows in the database (category `.transform`) — see
+/// `docs/research/transforms-design-2026-05.md` §3.
+public enum TransformSpikePrompts {
+    /// Default Polish prompt for the AX-coverage spike. Intentionally simple
+    /// and tone-preserving to give the smoke matrix a clean signal —
+    /// rule-toggle composition (WisprFlow's `Make more concise` etc.) is a
+    /// Phase 3 polish item, not a spike concern.
+    public static let polish: String = """
+    Polish the following text to sound clearer in the original author's voice. \
+    Preserve meaning and tone. Fix filler words, awkward phrasing, and grammar. \
+    Don't add new content or change the message. Return only the polished text, \
+    no explanation.
+    """
+}

--- a/Tests/MacParakeetTests/Services/PasteShortcutKeyResolverTests.swift
+++ b/Tests/MacParakeetTests/Services/PasteShortcutKeyResolverTests.swift
@@ -37,6 +37,26 @@ final class PasteShortcutKeyResolverTests: XCTestCase {
         XCTAssertEqual(resolver.virtualKeyCode(for: "v", modifierKeyState: commandModifierState), 9)
     }
 
+    func testUsesCommandModifiedMappingWhenResolvingCopyShortcut() {
+        let commandModifierState = UInt32(cmdKey >> 8)
+        let resolver = PasteShortcutKeyResolver(
+            keyboardLayoutProvider: { .data(Self.dummyLayoutData) },
+            translatedCharacterProvider: { _, keyCode, modifierKeyState, _ in
+                switch (keyCode, modifierKeyState) {
+                case (8, commandModifierState):
+                    return Self.cCharacter
+                case (17, 0):
+                    return Self.cCharacter
+                default:
+                    return nil
+                }
+            }
+        )
+
+        XCTAssertEqual(resolver.virtualKeyCode(for: "c", modifierKeyState: 0), 17)
+        XCTAssertEqual(resolver.virtualKeyCode(for: "c", modifierKeyState: commandModifierState), 8)
+    }
+
     func testFallsBackToQwertyWhenLayoutSourceIsMissing() {
         let resolver = PasteShortcutKeyResolver(
             keyboardLayoutProvider: { .missingInputSource },
@@ -47,6 +67,18 @@ final class PasteShortcutKeyResolverTests: XCTestCase {
         )
 
         XCTAssertEqual(resolver.virtualKeyCode(for: "v"), 0x09)
+    }
+
+    func testFallsBackToQwertyCopyKeyWhenResolvingCopyShortcut() {
+        let resolver = PasteShortcutKeyResolver(
+            keyboardLayoutProvider: { .missingInputSource },
+            translatedCharacterProvider: { _, _, _, _ in
+                XCTFail("Translator should not be called when input source is missing")
+                return nil
+            }
+        )
+
+        XCTAssertEqual(resolver.virtualKeyCode(for: "c"), 0x08)
     }
 
     func testFallsBackToQwertyWhenLayoutDataIsMissing() {
@@ -72,4 +104,5 @@ final class PasteShortcutKeyResolverTests: XCTestCase {
 
     private static let dummyLayoutData = Data([0x00]) as CFData
     private static let vCharacter = UniChar(("v" as UnicodeScalar).value)
+    private static let cCharacter = UniChar(("c" as UnicodeScalar).value)
 }

--- a/Tests/MacParakeetTests/Services/System/SelectionCaptureServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/System/SelectionCaptureServiceTests.swift
@@ -1,0 +1,173 @@
+import AppKit
+@preconcurrency import ApplicationServices
+import XCTest
+@testable import MacParakeetCore
+
+final class SelectionCaptureServiceTests: XCTestCase {
+    func testCaptureReturnsFailedWhenAccessibilityNotAuthorized() async {
+        let backend = FakeSelectionCaptureBackend(isTrusted: false)
+        let service = SelectionCaptureService(backend: backend)
+
+        let result = await service.captureSelection()
+
+        switch result {
+        case .failed(let error):
+            XCTAssertEqual(error, .accessibilityNotAuthorized)
+        default:
+            XCTFail("Expected .failed(.accessibilityNotAuthorized), got \(result.pathTag)")
+        }
+    }
+
+    func testCaptureReturnsAxWhenSelectedTextAttributeNonEmpty() async {
+        let backend = FakeSelectionCaptureBackend(
+            isTrusted: true,
+            focusedElement: AXUIElementCreateSystemWide(),
+            selectedText: "Hello world"
+        )
+        let service = SelectionCaptureService(backend: backend)
+
+        let result = await service.captureSelection()
+
+        switch result {
+        case .ax(let text, _):
+            XCTAssertEqual(text, "Hello world")
+        default:
+            XCTFail("Expected .ax, got \(result.pathTag)")
+        }
+    }
+
+    func testCaptureFallsBackToClipboardWhenAxEmptyAndPasteboardChanges() async {
+        let backend = FakeSelectionCaptureBackend(
+            isTrusted: true,
+            focusedElement: AXUIElementCreateSystemWide(),
+            selectedText: nil,
+            initialChangeCount: 1,
+            pasteboardAfterCmdC: "Clipboard selection",
+            changeCountAfterCmdC: 2
+        )
+        let service = SelectionCaptureService(
+            backend: backend,
+            clipboardPollTimeout: .milliseconds(200),
+            pollIntervalNanos: 1_000_000
+        )
+
+        let result = await service.captureSelection()
+
+        switch result {
+        case .clipboard(let text, let snapshot):
+            XCTAssertEqual(text, "Clipboard selection")
+            XCTAssertEqual(snapshot.originalChangeCount, 1)
+        default:
+            XCTFail("Expected .clipboard, got \(result.pathTag)")
+        }
+    }
+
+    func testCaptureReturnsEmptyWhenClipboardDidNotChange() async {
+        let backend = FakeSelectionCaptureBackend(
+            isTrusted: true,
+            focusedElement: AXUIElementCreateSystemWide(),
+            selectedText: nil,
+            initialChangeCount: 5,
+            pasteboardAfterCmdC: "ignored",
+            changeCountAfterCmdC: 5  // No change
+        )
+        let service = SelectionCaptureService(
+            backend: backend,
+            clipboardPollTimeout: .milliseconds(60),
+            pollIntervalNanos: 1_000_000
+        )
+
+        let result = await service.captureSelection()
+
+        switch result {
+        case .empty:
+            break
+        default:
+            XCTFail("Expected .empty, got \(result.pathTag)")
+        }
+    }
+
+    func testCaptureSnapshotIsCarriedForRestore() async {
+        let placeholder = NSPasteboardItem()
+        placeholder.setString("original", forType: .string)
+        let backend = FakeSelectionCaptureBackend(
+            isTrusted: true,
+            focusedElement: AXUIElementCreateSystemWide(),
+            selectedText: nil,
+            initialChangeCount: 7,
+            snapshotItems: [placeholder],
+            pasteboardAfterCmdC: "after",
+            changeCountAfterCmdC: 8
+        )
+        let service = SelectionCaptureService(
+            backend: backend,
+            clipboardPollTimeout: .milliseconds(60),
+            pollIntervalNanos: 1_000_000
+        )
+
+        let result = await service.captureSelection()
+
+        guard case .clipboard(_, let snapshot) = result else {
+            XCTFail("Expected .clipboard, got \(result.pathTag)")
+            return
+        }
+        XCTAssertEqual(snapshot.originalChangeCount, 7)
+        XCTAssertEqual(snapshot.items?.count, 1)
+    }
+}
+
+// MARK: - Fake Backend
+
+final class FakeSelectionCaptureBackend: SelectionCaptureBackend, @unchecked Sendable {
+    private let trusted: Bool
+    private let focused: AXUIElement?
+    private let selectedTextValue: String?
+    private var changeCount: Int
+    private let pasteboardAfterCmdC: String?
+    private let changeCountAfterCmdC: Int?
+    private let snapshotItems: [NSPasteboardItem]?
+
+    init(
+        isTrusted: Bool,
+        focusedElement: AXUIElement? = nil,
+        selectedText: String? = nil,
+        initialChangeCount: Int = 0,
+        snapshotItems: [NSPasteboardItem]? = nil,
+        pasteboardAfterCmdC: String? = nil,
+        changeCountAfterCmdC: Int? = nil
+    ) {
+        self.trusted = isTrusted
+        self.focused = focusedElement
+        self.selectedTextValue = selectedText
+        self.changeCount = initialChangeCount
+        self.snapshotItems = snapshotItems
+        self.pasteboardAfterCmdC = pasteboardAfterCmdC
+        self.changeCountAfterCmdC = changeCountAfterCmdC
+    }
+
+    func isAccessibilityTrusted() -> Bool { trusted }
+    func focusedElement() -> AXUIElement? { focused }
+    func selectedText(of element: AXUIElement) -> String? { selectedTextValue }
+
+    @MainActor
+    func snapshotPasteboard() -> PasteboardSnapshot {
+        PasteboardSnapshot(items: snapshotItems, originalChangeCount: changeCount)
+    }
+
+    @MainActor
+    func currentPasteboardString() -> String? {
+        pasteboardAfterCmdC
+    }
+
+    @MainActor
+    func currentPasteboardChangeCount() -> Int {
+        changeCount
+    }
+
+    @MainActor
+    func postCmdC() throws {
+        if let newCount = changeCountAfterCmdC {
+            changeCount = newCount
+        }
+    }
+}

--- a/Tests/MacParakeetTests/Services/System/SelectionCaptureServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/System/SelectionCaptureServiceTests.swift
@@ -57,6 +57,7 @@ final class SelectionCaptureServiceTests: XCTestCase {
         case .clipboard(let text, let snapshot):
             XCTAssertEqual(text, "Clipboard selection")
             XCTAssertEqual(snapshot.originalChangeCount, 1)
+            XCTAssertEqual(snapshot.temporaryChangeCount, 2)
         default:
             XCTFail("Expected .clipboard, got \(result.pathTag)")
         }
@@ -148,6 +149,28 @@ final class SelectionCaptureServiceTests: XCTestCase {
         }
         XCTAssertEqual(backend.restoreCount(), 1, "Snapshot must be restored — user's pre-hijack clipboard had non-text content we'd otherwise have lost")
     }
+
+    func testAbandonedClipboardCaptureSkipsRestoreWhenUserCopiedAfterCapture() async {
+        let backend = FakeSelectionCaptureBackend(
+            isTrusted: true,
+            focusedElement: AXUIElementCreateSystemWide(),
+            selectedText: nil,
+            initialChangeCount: 4,
+            pasteboardAfterCmdC: "captured-selection",
+            changeCountAfterCmdC: 5
+        )
+        let service = SelectionCaptureService(
+            backend: backend,
+            clipboardPollTimeout: .milliseconds(60),
+            pollIntervalNanos: 1_000_000
+        )
+
+        let result = await service.captureSelection()
+        backend.setChangeCountForTesting(6)
+        await service.restoreClipboardCaptureIfCurrent(result)
+
+        XCTAssertEqual(backend.restoreCount(), 0, "User clipboard writes after capture must not be clobbered by abandoned-transform cleanup")
+    }
 }
 
 // MARK: - Fake Backend
@@ -212,4 +235,5 @@ final class FakeSelectionCaptureBackend: SelectionCaptureBackend, @unchecked Sen
     }
 
     func restoreCount() -> Int { restoreCalls }
+    func setChangeCountForTesting(_ newValue: Int) { changeCount = newValue }
 }

--- a/Tests/MacParakeetTests/Services/System/SelectionCaptureServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/System/SelectionCaptureServiceTests.swift
@@ -114,6 +114,40 @@ final class SelectionCaptureServiceTests: XCTestCase {
         XCTAssertEqual(snapshot.originalChangeCount, 7)
         XCTAssertEqual(snapshot.items?.count, 1)
     }
+
+    /// Regression: when Cmd+C moves `changeCount` but the resulting
+    /// pasteboard content isn't text (image, file, etc.), the service used
+    /// to return `.empty` without restoring the snapshot — silently
+    /// destroying the user's pre-hijack clipboard. The fix restores the
+    /// snapshot before bailing.
+    func testCaptureRestoresClipboardWhenChangeMovedButNoText() async {
+        let placeholder = NSPasteboardItem()
+        placeholder.setString("original-user-content", forType: .string)
+        let backend = FakeSelectionCaptureBackend(
+            isTrusted: true,
+            focusedElement: AXUIElementCreateSystemWide(),
+            selectedText: nil,
+            initialChangeCount: 4,
+            snapshotItems: [placeholder],
+            pasteboardAfterCmdC: nil,           // image/file → no text
+            changeCountAfterCmdC: 5             // but Cmd+C did write something
+        )
+        let service = SelectionCaptureService(
+            backend: backend,
+            clipboardPollTimeout: .milliseconds(60),
+            pollIntervalNanos: 1_000_000
+        )
+
+        let result = await service.captureSelection()
+
+        switch result {
+        case .empty:
+            break
+        default:
+            XCTFail("Expected .empty, got \(result.pathTag)")
+        }
+        XCTAssertEqual(backend.restoreCount(), 1, "Snapshot must be restored — user's pre-hijack clipboard had non-text content we'd otherwise have lost")
+    }
 }
 
 // MARK: - Fake Backend
@@ -126,6 +160,7 @@ final class FakeSelectionCaptureBackend: SelectionCaptureBackend, @unchecked Sen
     private let pasteboardAfterCmdC: String?
     private let changeCountAfterCmdC: Int?
     private let snapshotItems: [NSPasteboardItem]?
+    private var restoreCalls: Int = 0
 
     init(
         isTrusted: Bool,
@@ -170,4 +205,11 @@ final class FakeSelectionCaptureBackend: SelectionCaptureBackend, @unchecked Sen
             changeCount = newCount
         }
     }
+
+    @MainActor
+    func restoreSnapshot(_ snapshot: PasteboardSnapshot) {
+        restoreCalls += 1
+    }
+
+    func restoreCount() -> Int { restoreCalls }
 }

--- a/Tests/MacParakeetTests/Services/System/SelectionReplacementServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/System/SelectionReplacementServiceTests.swift
@@ -117,6 +117,30 @@ final class SelectionReplacementServiceTests: XCTestCase {
         XCTAssertEqual(backend.cmdVPostCount(), 1, "Paste should still happen — we only suppress restore")
         XCTAssertEqual(backend.restoreCount(), 0, "Restore must be skipped — user wrote to clipboard mid-transform")
     }
+
+    func testReplacePreservesClipboardUserCopiedBetweenCaptureAndPaste() async throws {
+        let backend = FakeSelectionReplacementBackend(
+            isTrusted: true,
+            axWriteSucceeds: false,
+            pasteboardWriteSucceeds: true,
+            initialChangeCount: 12
+        )
+        let service = SelectionReplacementService(backend: backend, postPasteDelay: .milliseconds(1))
+        let preTransformSnapshot = PasteboardSnapshot(
+            items: nil,
+            originalChangeCount: 10,
+            temporaryChangeCount: 11
+        )
+
+        _ = try await service.replace(
+            with: "polished",
+            in: .clipboard(text: "raw", savedClipboard: preTransformSnapshot)
+        )
+
+        XCTAssertEqual(backend.cmdVPostCount(), 1)
+        XCTAssertEqual(backend.restoreCount(), 1)
+        XCTAssertEqual(backend.lastRestoredChangeCount(), 12, "Restore should use the user's newer clipboard snapshot, not the pre-transform one")
+    }
 }
 
 // MARK: - Fake Backend
@@ -137,22 +161,25 @@ final class FakeSelectionReplacementBackend: SelectionReplacementBackend, @unche
         var restoreSnapshots: [PasteboardSnapshot] = []
         /// Simulated pasteboard changeCount. Bumped on `writePasteboardString`
         /// (mirroring `setString`'s behavior in production) and optionally
-        /// bumped a second time on the second `currentChangeCount` read to
+        /// bumped after our own write-count has been observed once to
         /// simulate a concurrent user copy mid-transform.
         var changeCount: Int = 0
-        var currentChangeCountCallNumber: Int = 0
+        var pastePayloadWritten = false
+        var returnedOurChangeCountAfterWrite = false
     }
 
     init(
         isTrusted: Bool,
         axWriteSucceeds: Bool = false,
         pasteboardWriteSucceeds: Bool = true,
-        simulateUserCopyAfterWrite: Bool = false
+        simulateUserCopyAfterWrite: Bool = false,
+        initialChangeCount: Int = 0
     ) {
         self.trusted = isTrusted
         self.axWriteSucceedsValue = axWriteSucceeds
         self.pasteboardWriteSucceedsValue = pasteboardWriteSucceeds
         self.simulateUserCopyAfterWrite = simulateUserCopyAfterWrite
+        lock.withLock { $0.changeCount = initialChangeCount }
     }
 
     func isAccessibilityTrusted() -> Bool { trusted }
@@ -168,6 +195,8 @@ final class FakeSelectionReplacementBackend: SelectionReplacementBackend, @unche
             state.clipboardTexts.append(text)
             if pasteboardWriteSucceedsValue {
                 state.changeCount += 1
+                state.pastePayloadWritten = true
+                state.returnedOurChangeCountAfterWrite = false
             }
         }
         return pasteboardWriteSucceedsValue
@@ -182,16 +211,22 @@ final class FakeSelectionReplacementBackend: SelectionReplacementBackend, @unche
     func currentChangeCount() -> Int {
         let simulateBump = simulateUserCopyAfterWrite
         return lock.withLock { state in
-            state.currentChangeCountCallNumber += 1
-            // Service reads currentChangeCount twice: once right after our
-            // own write (to capture ourChangeCount) and once during the
-            // restore check. The simulated "user copied mid-transform"
-            // scenario bumps on the second call.
-            if simulateBump && state.currentChangeCountCallNumber >= 2 {
+            if simulateBump,
+               state.pastePayloadWritten,
+               state.returnedOurChangeCountAfterWrite {
                 return state.changeCount + 1
+            }
+            if state.pastePayloadWritten {
+                state.returnedOurChangeCountAfterWrite = true
             }
             return state.changeCount
         }
+    }
+
+    @MainActor
+    func snapshotPasteboard() -> PasteboardSnapshot {
+        let changeCount = lock.withLock { $0.changeCount }
+        return PasteboardSnapshot(items: nil, originalChangeCount: changeCount)
     }
 
     @MainActor

--- a/Tests/MacParakeetTests/Services/System/SelectionReplacementServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/System/SelectionReplacementServiceTests.swift
@@ -1,0 +1,170 @@
+import AppKit
+@preconcurrency import ApplicationServices
+import os
+import XCTest
+@testable import MacParakeetCore
+
+final class SelectionReplacementServiceTests: XCTestCase {
+    func testReplaceViaAxSucceeds() async throws {
+        let backend = FakeSelectionReplacementBackend(
+            isTrusted: true,
+            axWriteSucceeds: true
+        )
+        let service = SelectionReplacementService(backend: backend, postPasteDelay: .milliseconds(1))
+
+        let path = try await service.replace(
+            with: "polished",
+            in: .ax(text: "raw", element: AXFocusedElement(AXUIElementCreateSystemWide()))
+        )
+
+        XCTAssertEqual(path, .ax)
+        XCTAssertEqual(backend.lastAXText(), "polished")
+        XCTAssertEqual(backend.cmdVPostCount(), 0)
+    }
+
+    func testReplaceFallsBackToPasteWhenAXFails() async throws {
+        let backend = FakeSelectionReplacementBackend(
+            isTrusted: true,
+            axWriteSucceeds: false
+        )
+        let service = SelectionReplacementService(backend: backend, postPasteDelay: .milliseconds(1))
+
+        let path = try await service.replace(
+            with: "polished",
+            in: .ax(text: "raw", element: AXFocusedElement(AXUIElementCreateSystemWide()))
+        )
+
+        XCTAssertEqual(path, .clipboardPaste)
+        XCTAssertEqual(backend.lastClipboardText(), "polished")
+        XCTAssertEqual(backend.cmdVPostCount(), 1)
+        XCTAssertGreaterThanOrEqual(backend.restoreCount(), 1)
+    }
+
+    func testReplaceClipboardContextRestoresSnapshot() async throws {
+        let backend = FakeSelectionReplacementBackend(
+            isTrusted: true,
+            axWriteSucceeds: false
+        )
+        let service = SelectionReplacementService(backend: backend, postPasteDelay: .milliseconds(1))
+        let snapshot = PasteboardSnapshot(items: nil, originalChangeCount: 42)
+
+        let path = try await service.replace(
+            with: "polished",
+            in: .clipboard(text: "raw", savedClipboard: snapshot)
+        )
+
+        XCTAssertEqual(path, .clipboardPaste)
+        XCTAssertGreaterThanOrEqual(backend.restoreCount(), 1)
+        XCTAssertEqual(backend.lastRestoredChangeCount(), 42)
+    }
+
+    func testReplaceThrowsOnEmptyContext() async {
+        let backend = FakeSelectionReplacementBackend(isTrusted: true)
+        let service = SelectionReplacementService(backend: backend, postPasteDelay: .milliseconds(1))
+
+        do {
+            _ = try await service.replace(with: "polished", in: .empty)
+            XCTFail("Expected throw")
+        } catch let error as SelectionReplacementError {
+            XCTAssertEqual(error, .allPathsFailed)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testReplaceRestoresClipboardOnPasteboardWriteFailure() async {
+        let backend = FakeSelectionReplacementBackend(
+            isTrusted: true,
+            axWriteSucceeds: false,
+            pasteboardWriteSucceeds: false
+        )
+        let service = SelectionReplacementService(backend: backend, postPasteDelay: .milliseconds(1))
+        let snapshot = PasteboardSnapshot(items: nil, originalChangeCount: 99)
+
+        do {
+            _ = try await service.replace(
+                with: "polished",
+                in: .clipboard(text: "raw", savedClipboard: snapshot)
+            )
+            XCTFail("Expected pasteboardWriteFailed")
+        } catch let error as SelectionReplacementError {
+            XCTAssertEqual(error, .pasteboardWriteFailed)
+            XCTAssertGreaterThanOrEqual(backend.restoreCount(), 1)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+}
+
+// MARK: - Fake Backend
+
+/// Thread-safe state container so a Sendable backend can record calls and
+/// the test can read them back without coupling to actor isolation.
+final class FakeSelectionReplacementBackend: SelectionReplacementBackend, @unchecked Sendable {
+    private let trusted: Bool
+    private let axWriteSucceedsValue: Bool
+    private let pasteboardWriteSucceedsValue: Bool
+    private let lock = OSAllocatedUnfairLock<State>(initialState: State())
+
+    private struct State {
+        var axTexts: [String] = []
+        var clipboardTexts: [String] = []
+        var cmdVPosts: Int = 0
+        var restoreSnapshots: [PasteboardSnapshot] = []
+    }
+
+    init(
+        isTrusted: Bool,
+        axWriteSucceeds: Bool = false,
+        pasteboardWriteSucceeds: Bool = true
+    ) {
+        self.trusted = isTrusted
+        self.axWriteSucceedsValue = axWriteSucceeds
+        self.pasteboardWriteSucceedsValue = pasteboardWriteSucceeds
+    }
+
+    func isAccessibilityTrusted() -> Bool { trusted }
+
+    func writeSelectionViaAX(_ text: String, element: AXUIElement) -> Bool {
+        lock.withLock { $0.axTexts.append(text) }
+        return axWriteSucceedsValue
+    }
+
+    @MainActor
+    func writePasteboardString(_ text: String) -> Bool {
+        lock.withLock { $0.clipboardTexts.append(text) }
+        return pasteboardWriteSucceedsValue
+    }
+
+    @MainActor
+    func postCmdV() throws {
+        lock.withLock { $0.cmdVPosts += 1 }
+    }
+
+    @MainActor
+    func restoreSnapshot(_ snapshot: PasteboardSnapshot) {
+        lock.withLock { $0.restoreSnapshots.append(snapshot) }
+    }
+
+    // Test accessors
+
+    func lastAXText() -> String? {
+        lock.withLock { $0.axTexts.last }
+    }
+
+    func lastClipboardText() -> String? {
+        lock.withLock { $0.clipboardTexts.last }
+    }
+
+    func cmdVPostCount() -> Int {
+        lock.withLock { $0.cmdVPosts }
+    }
+
+    func restoreCount() -> Int {
+        lock.withLock { $0.restoreSnapshots.count }
+    }
+
+    func lastRestoredChangeCount() -> Int? {
+        lock.withLock { $0.restoreSnapshots.last?.originalChangeCount }
+    }
+}

--- a/Tests/MacParakeetTests/Services/System/SelectionReplacementServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/System/SelectionReplacementServiceTests.swift
@@ -94,6 +94,29 @@ final class SelectionReplacementServiceTests: XCTestCase {
             XCTFail("Unexpected error: \(error)")
         }
     }
+
+    /// Regression: if the user copies content during the post-paste window,
+    /// we must NOT restore the saved snapshot — that would silently destroy
+    /// what they just put on the clipboard. The fix gates `restoreSnapshot`
+    /// on `currentChangeCount() == ourChangeCount`.
+    func testReplaceSkipsRestoreWhenUserCopiesMidTransform() async throws {
+        let backend = FakeSelectionReplacementBackend(
+            isTrusted: true,
+            axWriteSucceeds: false,
+            pasteboardWriteSucceeds: true,
+            simulateUserCopyAfterWrite: true
+        )
+        let service = SelectionReplacementService(backend: backend, postPasteDelay: .milliseconds(1))
+        let snapshot = PasteboardSnapshot(items: nil, originalChangeCount: 42)
+
+        _ = try await service.replace(
+            with: "polished",
+            in: .clipboard(text: "raw", savedClipboard: snapshot)
+        )
+
+        XCTAssertEqual(backend.cmdVPostCount(), 1, "Paste should still happen — we only suppress restore")
+        XCTAssertEqual(backend.restoreCount(), 0, "Restore must be skipped — user wrote to clipboard mid-transform")
+    }
 }
 
 // MARK: - Fake Backend
@@ -104,6 +127,7 @@ final class FakeSelectionReplacementBackend: SelectionReplacementBackend, @unche
     private let trusted: Bool
     private let axWriteSucceedsValue: Bool
     private let pasteboardWriteSucceedsValue: Bool
+    private let simulateUserCopyAfterWrite: Bool
     private let lock = OSAllocatedUnfairLock<State>(initialState: State())
 
     private struct State {
@@ -111,16 +135,24 @@ final class FakeSelectionReplacementBackend: SelectionReplacementBackend, @unche
         var clipboardTexts: [String] = []
         var cmdVPosts: Int = 0
         var restoreSnapshots: [PasteboardSnapshot] = []
+        /// Simulated pasteboard changeCount. Bumped on `writePasteboardString`
+        /// (mirroring `setString`'s behavior in production) and optionally
+        /// bumped a second time on the second `currentChangeCount` read to
+        /// simulate a concurrent user copy mid-transform.
+        var changeCount: Int = 0
+        var currentChangeCountCallNumber: Int = 0
     }
 
     init(
         isTrusted: Bool,
         axWriteSucceeds: Bool = false,
-        pasteboardWriteSucceeds: Bool = true
+        pasteboardWriteSucceeds: Bool = true,
+        simulateUserCopyAfterWrite: Bool = false
     ) {
         self.trusted = isTrusted
         self.axWriteSucceedsValue = axWriteSucceeds
         self.pasteboardWriteSucceedsValue = pasteboardWriteSucceeds
+        self.simulateUserCopyAfterWrite = simulateUserCopyAfterWrite
     }
 
     func isAccessibilityTrusted() -> Bool { trusted }
@@ -132,13 +164,34 @@ final class FakeSelectionReplacementBackend: SelectionReplacementBackend, @unche
 
     @MainActor
     func writePasteboardString(_ text: String) -> Bool {
-        lock.withLock { $0.clipboardTexts.append(text) }
+        lock.withLock { state in
+            state.clipboardTexts.append(text)
+            if pasteboardWriteSucceedsValue {
+                state.changeCount += 1
+            }
+        }
         return pasteboardWriteSucceedsValue
     }
 
     @MainActor
     func postCmdV() throws {
         lock.withLock { $0.cmdVPosts += 1 }
+    }
+
+    @MainActor
+    func currentChangeCount() -> Int {
+        let simulateBump = simulateUserCopyAfterWrite
+        return lock.withLock { state in
+            state.currentChangeCountCallNumber += 1
+            // Service reads currentChangeCount twice: once right after our
+            // own write (to capture ourChangeCount) and once during the
+            // restore check. The simulated "user copied mid-transform"
+            // scenario bumps on the second call.
+            if simulateBump && state.currentChangeCountCallNumber >= 2 {
+                return state.changeCount + 1
+            }
+            return state.changeCount
+        }
     }
 
     @MainActor

--- a/Tests/MacParakeetTests/Services/Transforms/TransformExecutorTests.swift
+++ b/Tests/MacParakeetTests/Services/Transforms/TransformExecutorTests.swift
@@ -1,0 +1,254 @@
+import AppKit
+@preconcurrency import ApplicationServices
+import os
+import XCTest
+@testable import MacParakeetCore
+
+final class TransformExecutorTests: XCTestCase {
+    func testRunReturnsEmptySelectionWhenCaptureIsEmpty() async {
+        let captureBackend = FakeSelectionCaptureBackend(
+            isTrusted: true,
+            focusedElement: AXUIElementCreateSystemWide(),
+            selectedText: nil,
+            initialChangeCount: 0,
+            pasteboardAfterCmdC: nil,
+            changeCountAfterCmdC: 0  // No change
+        )
+        let captureService = SelectionCaptureService(
+            backend: captureBackend,
+            clipboardPollTimeout: .milliseconds(40),
+            pollIntervalNanos: 1_000_000
+        )
+        let replacementBackend = FakeSelectionReplacementBackend(isTrusted: true)
+        let replacementService = SelectionReplacementService(
+            backend: replacementBackend,
+            postPasteDelay: .milliseconds(1)
+        )
+        let llm = MockTransformLLMService()
+        let executor = TransformExecutor(
+            captureService: captureService,
+            replacementService: replacementService,
+            llmService: llm
+        )
+
+        let recorder = TransformProgressRecorder()
+        do {
+            _ = try await executor.run(prompt: "polish", onProgress: { recorder.record($0) })
+            XCTFail("Expected emptySelection")
+        } catch let error as TransformExecutorError {
+            switch error {
+            case .emptySelection: break
+            default: XCTFail("Unexpected error: \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        let events = recorder.snapshot()
+        XCTAssertEqual(events.first, .capturing)
+        XCTAssertTrue(events.contains(where: { if case .failed = $0 { return true } else { return false } }))
+        XCTAssertEqual(llm.callCount, 0, "LLM must not be invoked when capture returns empty")
+        XCTAssertEqual(replacementBackend.cmdVPostCount(), 0)
+    }
+
+    func testRunSurfacesLLMNotConfigured() async {
+        let captureBackend = FakeSelectionCaptureBackend(
+            isTrusted: true,
+            focusedElement: AXUIElementCreateSystemWide(),
+            selectedText: "Hello"
+        )
+        let captureService = SelectionCaptureService(
+            backend: captureBackend,
+            clipboardPollTimeout: .milliseconds(40),
+            pollIntervalNanos: 1_000_000
+        )
+        let replacementBackend = FakeSelectionReplacementBackend(isTrusted: true)
+        let replacementService = SelectionReplacementService(
+            backend: replacementBackend,
+            postPasteDelay: .milliseconds(1)
+        )
+        let llm = MockTransformLLMService()
+        llm.streamError = LLMError.notConfigured
+        let executor = TransformExecutor(
+            captureService: captureService,
+            replacementService: replacementService,
+            llmService: llm
+        )
+
+        do {
+            _ = try await executor.run(prompt: "polish", onProgress: { _ in })
+            XCTFail("Expected llmNotConfigured")
+        } catch let error as TransformExecutorError {
+            switch error {
+            case .llmNotConfigured: break
+            default: XCTFail("Unexpected error: \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testRunEmitsProgressInOrderAndCallsReplacementOnSuccess() async throws {
+        let captureBackend = FakeSelectionCaptureBackend(
+            isTrusted: true,
+            focusedElement: AXUIElementCreateSystemWide(),
+            selectedText: "Hello world"
+        )
+        let captureService = SelectionCaptureService(
+            backend: captureBackend,
+            clipboardPollTimeout: .milliseconds(40),
+            pollIntervalNanos: 1_000_000
+        )
+        let replacementBackend = FakeSelectionReplacementBackend(
+            isTrusted: true,
+            axWriteSucceeds: true
+        )
+        let replacementService = SelectionReplacementService(
+            backend: replacementBackend,
+            postPasteDelay: .milliseconds(1)
+        )
+        let llm = MockTransformLLMService()
+        llm.streamTokens = ["Hi ", "there!"]
+        let executor = TransformExecutor(
+            captureService: captureService,
+            replacementService: replacementService,
+            llmService: llm
+        )
+
+        let recorder = TransformProgressRecorder()
+        let result = try await executor.run(prompt: "polish") { recorder.record($0) }
+        XCTAssertEqual(result.outputText, "Hi there!")
+        XCTAssertEqual(result.path, .ax)
+        XCTAssertEqual(result.captureTag, "ax")
+
+        let events = recorder.snapshot()
+        // Required ordering: capturing → llmStarted → at least one
+        // llmStreaming → llmCompleted → pasting → done.
+        let names = events.map { eventName($0) }
+        XCTAssertEqual(names.first, "capturing")
+        guard let llmStartedIdx = names.firstIndex(of: "llmStarted"),
+              let pastingIdx = names.firstIndex(of: "pasting"),
+              let doneIdx = names.firstIndex(of: "done"),
+              let completedIdx = names.firstIndex(of: "llmCompleted") else {
+            XCTFail("Missing expected progress events: \(names)")
+            return
+        }
+        XCTAssertLessThan(llmStartedIdx, completedIdx)
+        XCTAssertLessThan(completedIdx, pastingIdx)
+        XCTAssertLessThan(pastingIdx, doneIdx)
+        XCTAssertTrue(names.contains("llmStreaming"))
+
+        XCTAssertEqual(replacementBackend.lastAXText(), "Hi there!")
+    }
+
+    func testRunPropagatesLLMStreamError() async {
+        let captureBackend = FakeSelectionCaptureBackend(
+            isTrusted: true,
+            focusedElement: AXUIElementCreateSystemWide(),
+            selectedText: "Hello"
+        )
+        let captureService = SelectionCaptureService(
+            backend: captureBackend,
+            clipboardPollTimeout: .milliseconds(40),
+            pollIntervalNanos: 1_000_000
+        )
+        let replacementBackend = FakeSelectionReplacementBackend(isTrusted: true)
+        let replacementService = SelectionReplacementService(
+            backend: replacementBackend,
+            postPasteDelay: .milliseconds(1)
+        )
+        let llm = MockTransformLLMService()
+        llm.streamError = LLMError.rateLimited
+        let executor = TransformExecutor(
+            captureService: captureService,
+            replacementService: replacementService,
+            llmService: llm
+        )
+
+        do {
+            _ = try await executor.run(prompt: "polish", onProgress: { _ in })
+            XCTFail("Expected llmFailed")
+        } catch let error as TransformExecutorError {
+            switch error {
+            case .llmFailed: break
+            default: XCTFail("Unexpected: \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        XCTAssertEqual(replacementBackend.cmdVPostCount(), 0)
+    }
+
+    // MARK: - Helpers
+
+    private func eventName(_ progress: TransformProgress) -> String {
+        switch progress {
+        case .capturing: return "capturing"
+        case .llmStarted: return "llmStarted"
+        case .llmStreaming: return "llmStreaming"
+        case .llmCompleted: return "llmCompleted"
+        case .pasting: return "pasting"
+        case .done: return "done"
+        case .failed: return "failed"
+        }
+    }
+}
+
+// MARK: - Recorder
+
+final class TransformProgressRecorder: @unchecked Sendable {
+    private let lock = OSAllocatedUnfairLock<[TransformProgress]>(initialState: [])
+
+    func record(_ progress: TransformProgress) {
+        lock.withLock { $0.append(progress) }
+    }
+
+    func snapshot() -> [TransformProgress] {
+        lock.withLock { $0 }
+    }
+}
+
+// MARK: - LLM mock
+
+final class MockTransformLLMService: LLMServiceProtocol, @unchecked Sendable {
+    private let lock = OSAllocatedUnfairLock<Int>(initialState: 0)
+    var streamTokens: [String] = ["polished"]
+    var streamError: Error?
+
+    var callCount: Int {
+        lock.withLock { $0 }
+    }
+
+    func generatePromptResult(transcript: String, systemPrompt: String?) async throws -> String { "" }
+    func chat(question: String, transcript: String, userNotes: String?, history: [ChatMessage]) async throws -> String { "" }
+    func transform(text: String, prompt: String) async throws -> String { "" }
+    func formatTranscript(transcript: String, promptTemplate: String, source: TelemetryFormatterSource, defaultPromptUsed: Bool) async throws -> String { "" }
+    func generatePromptResultStream(transcript: String, systemPrompt: String?) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+    func chatStream(question: String, transcript: String, userNotes: String?, history: [ChatMessage]) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+    func transformStream(text: String, prompt: String) -> AsyncThrowingStream<String, Error> {
+        lock.withLock { $0 += 1 }
+        let tokens = streamTokens
+        let error = streamError
+        return AsyncThrowingStream { continuation in
+            if let error {
+                continuation.finish(throwing: error)
+                return
+            }
+            for token in tokens { continuation.yield(token) }
+            continuation.finish()
+        }
+    }
+    func generatePromptResultDetailed(transcript: String, systemPrompt: String?) async throws -> LLMResult {
+        LLMResult(output: "", provider: "mock", model: "mock", latencyMs: 0)
+    }
+    func chatDetailed(question: String, transcript: String, userNotes: String?, history: [ChatMessage]) async throws -> LLMResult {
+        LLMResult(output: "", provider: "mock", model: "mock", latencyMs: 0)
+    }
+    func transformDetailed(text: String, prompt: String) async throws -> LLMResult {
+        LLMResult(output: "", provider: "mock", model: "mock", latencyMs: 0)
+    }
+}

--- a/Tests/MacParakeetTests/Services/Transforms/TransformExecutorTests.swift
+++ b/Tests/MacParakeetTests/Services/Transforms/TransformExecutorTests.swift
@@ -88,6 +88,92 @@ final class TransformExecutorTests: XCTestCase {
         }
     }
 
+    func testRunRestoresClipboardCaptureWhenLLMFailsBeforeReplacement() async {
+        let captureBackend = FakeSelectionCaptureBackend(
+            isTrusted: true,
+            focusedElement: AXUIElementCreateSystemWide(),
+            selectedText: nil,
+            initialChangeCount: 10,
+            pasteboardAfterCmdC: "Hello",
+            changeCountAfterCmdC: 11
+        )
+        let captureService = SelectionCaptureService(
+            backend: captureBackend,
+            clipboardPollTimeout: .milliseconds(40),
+            pollIntervalNanos: 1_000_000
+        )
+        let replacementBackend = FakeSelectionReplacementBackend(isTrusted: true)
+        let replacementService = SelectionReplacementService(
+            backend: replacementBackend,
+            postPasteDelay: .milliseconds(1)
+        )
+        let llm = MockTransformLLMService()
+        llm.streamError = LLMError.rateLimited
+        let executor = TransformExecutor(
+            captureService: captureService,
+            replacementService: replacementService,
+            llmService: llm
+        )
+
+        do {
+            _ = try await executor.run(prompt: "polish", onProgress: { _ in })
+            XCTFail("Expected llmFailed")
+        } catch let error as TransformExecutorError {
+            switch error {
+            case .llmFailed: break
+            default: XCTFail("Unexpected error: \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(captureBackend.restoreCount(), 1)
+        XCTAssertEqual(replacementBackend.cmdVPostCount(), 0)
+    }
+
+    func testRunRestoresClipboardCaptureWhenLLMReturnsEmptyOutput() async {
+        let captureBackend = FakeSelectionCaptureBackend(
+            isTrusted: true,
+            focusedElement: AXUIElementCreateSystemWide(),
+            selectedText: nil,
+            initialChangeCount: 20,
+            pasteboardAfterCmdC: "Hello",
+            changeCountAfterCmdC: 21
+        )
+        let captureService = SelectionCaptureService(
+            backend: captureBackend,
+            clipboardPollTimeout: .milliseconds(40),
+            pollIntervalNanos: 1_000_000
+        )
+        let replacementBackend = FakeSelectionReplacementBackend(isTrusted: true)
+        let replacementService = SelectionReplacementService(
+            backend: replacementBackend,
+            postPasteDelay: .milliseconds(1)
+        )
+        let llm = MockTransformLLMService()
+        llm.streamTokens = []
+        let executor = TransformExecutor(
+            captureService: captureService,
+            replacementService: replacementService,
+            llmService: llm
+        )
+
+        do {
+            _ = try await executor.run(prompt: "polish", onProgress: { _ in })
+            XCTFail("Expected llmFailed")
+        } catch let error as TransformExecutorError {
+            switch error {
+            case .llmFailed: break
+            default: XCTFail("Unexpected error: \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(captureBackend.restoreCount(), 1)
+        XCTAssertEqual(replacementBackend.cmdVPostCount(), 0)
+    }
+
     func testRunEmitsProgressInOrderAndCallsReplacementOnSuccess() async throws {
         let captureBackend = FakeSelectionCaptureBackend(
             isTrusted: true,


### PR DESCRIPTION
**SPIKE — feature-flagged off by default. Not for production.**

## Why this exists

To answer one question with field data: **does the macOS Accessibility API reliably return the user's selected text in mainstream apps?** The answer decides whether Phase 1 of Transforms commits to AX-first or pivots to clipboard-only. See \`docs/research/transforms-design-2026-05.md\` for the production design.

## What ⌥⌃1 does

```
  ┌──── frontmost app (Notes, Mail, Slack, Cursor, …) ──────┐
  │                                                          │
  │   \"hey so are we still on for coffee, i thi…\"           │  ◀ select text
  │    ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔                │   press ⌥⌃1
  └──────────────────────────┬───────────────────────────────┘
                             │
                ┌────────────▼────────────┐
                │ SelectionCapture        │  AX-first
                │ ────────────────────    │  fall back to
                │  • kAXSelectedText      │  ⌘C + poll
                │  • clipboard hijack     │  changeCount 500ms
                └────────────┬────────────┘  restore on non-text
                             │
                ┌────────────▼────────────┐
                │ TransformExecutor       │  hardcoded Polish
                │ ────────────────────    │  via user's
                │  • LLMService stream    │  configured LLM
                │  • cancellable          │  provider
                └────────────┬────────────┘
                             │
                ┌────────────▼────────────┐  AX-write first
                │ SelectionReplace        │  fall back to
                │ ────────────────────    │  ⌘V paste
                │  • kAXSelectedText      │  + restore
                │  • clipboard paste      │  (changeCount-
                └────────────┬────────────┘   guarded)
                             │
                             ▼
       ┌─────────────────────────────────────────┐
       │   transforms-spike: capture=ax          │  ◀ per-run
       │   text_len=308 llm_ms=1390 replace=ax   │    os.Logger line
       │   total_ms=1403                         │
       └─────────────────────────────────────────┘
```

## Floating pill (current shipped state)

The pill is anchored at the bottom-center of the screen — same slot the dictation overlay uses, so all three \"press hotkey → thing happens\" surfaces share one location.

- **Working** — perfect-circle pill with a 5-petal **rhodonea rose curve** (\`r(θ) = sin²(5θ/2)\`) tracing itself in coral. Squared form keeps \`r ≥ 0\` so the scribe head sweeps smoothly through the origin. Sits in the established sacred-geometry family alongside the dictation Merkaba (4-fold) and the meeting pill rosette (6-fold) — three modes, three symmetries.
- **Patient label reveal** — pill starts icon-only; if a run lasts past 5s, a \"Still polishing…\" label fades in and the Capsule grows from circle to oblong pill. Short transforms stay silent; long ones get an empathetic acknowledgment.
- **Done** — the same ring+check atom the dictation overlay uses for success completion. Same \`successGreen\`, same timings, same checkmark path.
- **Failed** — stroked warning triangle in \`warningAmber\` with a bang. Error copy wraps cleanly inside the 280pt-wide Capsule.

## In scope

- \`AppFeatures.transformsSpikeEnabled\` (default \`false\`)
- \`SelectionCaptureService\` — AX-first + 500ms clipboard hijack; restores user's clipboard if Cmd+C captured non-text content
- \`SelectionReplacementService\` — AX-write first + Cmd+V paste-back; restore is \`changeCount\`-guarded (preserves any clipboard write the user made mid-transform)
- \`TransformExecutor\` actor — cancellable, structured progress, final cancel-gate before replace begins
- \`GlobalShortcutManager\`-backed Opt+Ctrl+1 (Ctrl to dodge dev-time collisions — production binds via the per-Transform recorder UI in Phase 2)
- Floating pill matching MacParakeet's brand vocabulary (sacred-geometry indicator, bottom-anchor, Capsule, brand checkmark) with patient label reveal
- Per-run \`os.Logger\` line for the AX-vs-clipboard analysis
- Friendly toasts for empty selection + no LLM provider

## Out of scope (Phase 1+)

No management UI. No \`Prompt\` model wiring. No telemetry events. No diff preview. No rule toggles. No ADR-022 — that locks in after the systematic smoke matrix lands.

Extracting the brand checkmark into \`Views/Components/BrandCheckmark\` (currently three private copies across dictation, meeting pill, and Transforms) is noted as a follow-up.

## Edge cases handled

- **No selection** → toast, no LLM call, clipboard untouched
- **No LLM provider** → \"Add an LLM provider in Settings\" toast
- **Re-trigger mid-run** → old run cancelled with UUID generation guard; new run owns the panel
- **User copies during transform** → clipboard restore is \`changeCount\`-guarded and *skipped* if the user's newer copy arrived
- **Cmd+C grabs an image / file** → snapshot restored before bailing
- **AX claims success but doesn't actually update** → will surface in the smoke matrix as \"AX write Y, selection unchanged\" (no false-positive substring re-read)

## Validation so far

The end-to-end happy path has been **exercised once in one app** during the polish session — a handful of \`transforms-spike: capture=ax replace=ax\` log lines across text sizes from 73 to 2391 chars. Enough to confirm the AX path wires up correctly through real LLM calls and that MacParakeet's own capture+replace overhead is ~15–25ms (LLM latency dominates total time).

Also exercised by hand:
- No-selection path → toast, no LLM call
- No-LLM-provider path → \"Add an LLM provider in Settings\" toast
- Re-trigger mid-flight → cancellation guard fires, new run owns the panel
- 4 rounds of UX polish iterated against real runs (panel positioning, brand chrome, loader geometry, patient label reveal)
- 6 correctness fixes addressing bot-review feedback on the safety-critical paths (clipboard restore, AX-write verification, cancellation)

**The systematic 13-app matrix is still wide open.** That's the post-merge task whose data feeds ADR-022 and the Phase 1 plan.

## Smoke matrix (still to be done)

| App | AX capture | AX write | Clipboard fallback | Notes |
|---|---|---|---|---|
| Notes | | | | |
| Mail (Compose) | | | | |
| Slack desktop | | | | |
| Discord | | | | |
| Chrome — textarea | | | | |
| Chrome — Gmail compose | | | | |
| Safari — address bar | | | | |
| Safari — textarea | | | | |
| Cursor | | | | |
| Xcode editor | | | | |
| Terminal | | | | |
| iMessage | | | | |
| Bear / Obsidian | | | | |

Apps where AX capture works but the write is silently discarded are the most valuable signal — those get downgraded to clipboard-only in Phase 2.

## How to test

1. Flip \`AppFeatures.transformsSpikeEnabled\` to \`true\` in \`Sources/MacParakeetCore/AppFeatures.swift\`.
2. \`scripts/dev/run_app.sh\`. Grant Accessibility on first launch.
3. Configure an LLM provider in Settings ▸ LLM.
4. Select text anywhere on macOS → press **⌥⌃1** → pill shows the rose loader, then a green check → your text gets replaced.
5. \`Console.app\` → filter on \`com.macparakeet.core\` for \`transforms-spike:\` per-run lines.

## Tests

\`swift test\` — **2511 XCTest + 16 Swift Testing pass** (16 new for the Transforms spike), 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added text polishing transformation feature triggered by keyboard shortcut (Opt+Ctrl+1)
  * Captures selected text, processes via LLM, and replaces with polished result
  * Added visual progress panel showing transformation status with animated indicators

* **Tests**
  * Comprehensive test coverage for text capture, replacement, and transformation pipeline

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moona3k/macparakeet/pull/278)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->