### PR TITLE
Reframe commit guidelines: spirit first, structure as scaffolding

### DIFF
--- a/docs/commit-guidelines.md
+++ b/docs/commit-guidelines.md
@@ -38,8 +38,8 @@ For comprehensive commits — multi-file UX polish, architectural moves,
 new features, anything where a future reader will need more than a
 glance — the following structure usually works:
 
-```
-<title>: short summary in imperative mood (under 70 chars)
+```text
+<title> (imperative mood, under 70 chars; `subject: detail` form is fine)
 
 ## What Changed
 What changed in the diff, grouped into themes when there are several.
@@ -128,19 +128,28 @@ section:
 These commits on `main` demonstrate the spirit at different scales.
 Read them with `git show <hash>`:
 
-- **Comprehensive UI polish** — `94f53067` (Polish Transforms spike
-  pill). Four themed subsections, quantitative reasoning for each
-  design knob, internal-pattern anchoring throughout, mathematical
-  detail for the rose curve, decoupling rationale.
-- **Multi-fix bugfix with refuted findings** — `be9757e2` (Address
-  bot-review correctness bugs on Transforms spike). Six numbered
-  fixes on safety-critical paths, each with the failure mode named;
-  three "Refuted" findings with reasoning; explicit Root Intent
-  about why this set of fixes ships together.
-- **Feature introduction behind a flag** — `75d8c1a4` (Add Transforms
-  AX-coverage spike). Multi-file feature wired end-to-end, each file
-  characterized by its specific role and the AX/clipboard fallback
-  design preserved in the prompt section.
+- **Comprehensive UI polish** — `6e7b61b5` (Polish Stats sub-tab:
+  brand glyph, rich hover popover, coral pill picker). Many themed
+  bullets covering picker chrome, heatmap hover popover, today's
+  breathing pulse, typography unification — each with quantitative
+  design rationale (cell size 12pt → 16pt, breathing-pulse 1.8s
+  ease-in-out, empty-cell `opacity(0.07)` vs near-invisible
+  `surfaceElevated` in dark mode). Internal-pattern anchoring
+  throughout (matched-geometry pill, brand accent, `design:
+  .rounded` typography).
+- **Multi-fix bugfix addressing review feedback** — `e2af13d7`
+  (Round 2 review: rename(2) commit, persist-then-delete, Sendable
+  tests). Three numbered fixes on safety-critical concurrency paths,
+  each with the failure mode named (POSIX `rename(2)` atomicity,
+  persist-then-delete ordering to prevent orphaned m4a + dangling
+  webm row, `@Sendable` closure capture hazard fixed via reference-
+  type wrappers).
+- **Feature introduction with schema migration** — `0442a2f4` (Split
+  Dictations into History + Stats sub-tabs with daily streak
+  heatmap). Multi-component feature with a v0.11 SQLite migration,
+  schema decisions explained alongside UI rationale, prior decisions
+  cross-referenced (mirrors #124's trade-off for surviving Clear
+  History), 19 new repository tests characterized by scenario.
 - **Short, well-articulated** — `f6edccc7` (Warn that Best-available
   YouTube audio breaks in-app playback). Three sentences. No
   template. Gives a future reader full understanding of why the
@@ -150,7 +159,7 @@ Read them with `git show <hash>`:
 
 ### Comprehensive (feature)
 
-```
+```text
 Add dictation overlay with waveform visualization
 
 ## What Changed
@@ -185,16 +194,19 @@ subscribe to audio levels.
 - ADR-001 + ADR-007: Parakeet TDT model with FluidAudio CoreML runtime
 
 ## Files Changed
-- Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift (+145)
-- Sources/MacParakeet/Views/Dictation/WaveformView.swift (+62)
+- Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
+  (+145) — borderless NSPanel + state-driven layout.
+- Sources/MacParakeet/Views/Dictation/WaveformView.swift (+62) —
+  real-time waveform rendering from audio-level data.
 - Sources/MacParakeetCore/Services/Dictation/DictationService.swift
-  (+28, ~12)
-- Tests/MacParakeetTests/DictationServiceTests.swift (+34)
+  (+28, ~12) — new `audioLevelPublisher` exposed to the overlay.
+- Tests/MacParakeetTests/DictationServiceTests.swift (+34) —
+  audio-level callback registration tests.
 ```
 
 ### Targeted bug fix
 
-```
+```text
 Fix clipboard not restoring after dictation paste
 
 ## What Changed
@@ -214,7 +226,7 @@ original.
 
 ### Short
 
-```
+```text
 Warn that Best-available YouTube audio breaks in-app playback
 
 AVPlayer on macOS can't decode WebM/Opus, which is what yt-dlp picks

--- a/docs/commit-guidelines.md
+++ b/docs/commit-guidelines.md
@@ -86,7 +86,7 @@ Examples of when departing from the scaffolding is the right call:
   it safe?"
 - **Doc-only commit**: a single paragraph explaining the editorial
   intent often beats the full template.
-- **Multi-fix bugfix with disputed findings**: a "## What Changed"
+- **Multi-fix bugfix with refuted findings**: a "## What Changed"
   list of numbered fixes + a "## Refuted" section for the findings
   you rejected with reasoning is often more useful than the standard
   Root Intent / Prompt split.

--- a/docs/commit-guidelines.md
+++ b/docs/commit-guidelines.md
@@ -2,60 +2,184 @@
 
 > Status: **ACTIVE**
 
-This project uses **rich commit messages** optimized for AI-assisted development. Each commit should capture enough context that a future agent (or human) can understand the full reasoning.
+This project uses **rich commit messages** as a primary form of project
+memory. The git log is durable; chat transcripts and slack threads are
+not. Treat each commit message as a small letter to the future reader
+who will land here via `git blame` or `git log` with no surrounding
+context.
 
-## Structure
+## The spirit
+
+The litmus test for any commit message:
+
+> *A future reader landing here via `git blame`, with no surrounding
+> context, should finish the message understanding the change as well
+> as you understood it the moment you wrote it.*
+
+That's the bar. Everything below is a scaffolding to help you clear
+it, not a specification you must satisfy. The shape of a commit
+message should follow whatever serves comprehension for *this specific
+change*:
+
+- A multi-system polish or architectural move earns depth — themed
+  subsections, quantitative justification, internal-pattern
+  anchoring.
+- A targeted bug fix earns a tight Root Intent + a few sentences on
+  why it broke + the fix.
+- A typo or one-line change earns one well-written paragraph and no
+  template at all.
+
+The agent (or human) writing the commit has full latitude to choose
+the shape. The bar is the litmus test, not the section count.
+
+## The standard scaffolding
+
+For comprehensive commits — multi-file UX polish, architectural moves,
+new features, anything where a future reader will need more than a
+glance — the following structure usually works:
 
 ```
-<title>: Short summary (imperative mood)
+<title>: short summary in imperative mood (under 70 chars)
 
 ## What Changed
-Detailed breakdown of every file/section modified.
+What changed in the diff, grouped into themes when there are several.
+For 3+ themes, use ### subheaders. Each item should answer "why this
+specifically?" — anchor decisions to existing internal patterns by
+name, cite evidence (observed timings, screenshots, mathematical
+reasoning), and call out the technical primitives behind non-obvious
+choices.
 
 ## Root Intent
-Why this commit exists. The underlying problem or goal.
+One paragraph naming the trigger that prompted this work (a specific
+bug, a demo blocker, a perf number, an audit finding). Enough that
+someone reading in 2027 with no project context understands the
+motivation.
 
 ## Prompt That Would Produce This Diff
-A detailed instruction that would recreate this work from scratch.
-This is the "recipe" - if you gave this prompt to an AI agent with
-access to the codebase, it should produce an equivalent diff.
+Self-contained enough that an agent with repo access could replay
+this work. Reference specific file paths, design docs, and ADRs by
+name. Include the constraints (don't break X, match Y's pattern).
 
 ## ADRs Applied (if any)
-Links to architectural decisions that informed the changes.
+Links to architectural decisions that informed the change. If none,
+say "None — this is X polish, not architecture" so the reader knows
+it's a deliberate omission rather than oversight.
 
 ## Files Changed
-Summary with line counts for quick scanning.
+Per-file rationale with line counts. For comprehensive changes, the
+rationale lines are more valuable than the line counts.
 ```
 
-## Example (Feature)
+The scaffolding is a **default**, not a specification. If a different
+shape serves the spirit better for this specific change, use that
+shape.
+
+## Latitude
+
+Examples of when departing from the scaffolding is the right call:
+
+- **Typo / one-line fix**: title + one paragraph explaining the bug
+  is plenty. No What Changed, no Root Intent, no Files Changed.
+- **Refactor with no behavior change**: a "Before / After" framing
+  may serve the reader better than "What Changed / Root Intent"
+  because the relevant question is "is the new shape better, and is
+  it safe?"
+- **Doc-only commit**: a single paragraph explaining the editorial
+  intent often beats the full template.
+- **Multi-fix bugfix with disputed findings**: a "## What Changed"
+  list of numbered fixes + a "## Refuted" section for the findings
+  you rejected with reasoning is often more useful than the standard
+  Root Intent / Prompt split.
+- **Cross-cutting polish session**: themed subsections inside What
+  Changed (`### 1. Bottom-anchored Capsule`, `### 2. Sacred-geometry
+  indicators`, ...) lets the reader navigate the change.
+
+The agent's judgment about shape is part of the work. A commit message
+mechanically filled out to match the template can fail the spirit
+test; a commit message in an unconventional shape can pass it.
+
+## Depth bar (when going comprehensive)
+
+When a change warrants the full treatment, the difference between a
+perfunctory rich commit and a great one is **substance density** per
+section:
+
+- **"Why this specifically?"** — for every non-obvious design knob,
+  answer this. Why 5 seconds and not 10? Why squared rose curves and
+  not standard `cos(kθ)`? Why `Task.yield()` and not `DispatchQueue`?
+  The answer should be quantitative, mathematical, or empirical —
+  not "it felt right."
+- **Anchor to internal patterns by name** — say "extends
+  `DictationOverlayView`'s `isIconOnly` branching" rather than
+  "follows a common pattern." The names are searchable; the platitudes
+  aren't.
+- **Name the technical primitives** behind subtle choices — e.g.,
+  "SwiftUI updates are runloop-bounded, so reading `fittingSize`
+  synchronously after mutating `@Published` returns the previous
+  layout — that's why we yield once before re-measuring."
+- **Trade-offs considered and rejected** — what you chose not to do
+  is often as informative as what you did. "Refuted" sections (with
+  reasoning) are valuable.
+- **What's out of scope** — name what this commit *doesn't* fix so a
+  future reader expecting more doesn't go hunting.
+
+## Exemplars
+
+These commits on `main` demonstrate the spirit at different scales.
+Read them with `git show <hash>`:
+
+- **Comprehensive UI polish** — `94f53067` (Polish Transforms spike
+  pill). Four themed subsections, quantitative reasoning for each
+  design knob, internal-pattern anchoring throughout, mathematical
+  detail for the rose curve, decoupling rationale.
+- **Multi-fix bugfix with refuted findings** — `be9757e2` (Address
+  bot-review correctness bugs on Transforms spike). Six numbered
+  fixes on safety-critical paths, each with the failure mode named;
+  three "Refuted" findings with reasoning; explicit Root Intent
+  about why this set of fixes ships together.
+- **Feature introduction behind a flag** — `75d8c1a4` (Add Transforms
+  AX-coverage spike). Multi-file feature wired end-to-end, each file
+  characterized by its specific role and the AX/clipboard fallback
+  design preserved in the prompt section.
+- **Short, well-articulated** — `f6edccc7` (Warn that Best-available
+  YouTube audio breaks in-app playback). Three sentences. No
+  template. Gives a future reader full understanding of why the
+  Settings copy was edited.
+
+## Inline examples
+
+### Comprehensive (feature)
 
 ```
 Add dictation overlay with waveform visualization
 
 ## What Changed
-- Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift: New compact dark pill overlay
-  with recording state indicator, waveform, and cancel button
-- Sources/MacParakeet/Views/Dictation/WaveformView.swift: Real-time audio level waveform using
-  AVAudioEngine tap data
-- Sources/MacParakeetCore/Services/Dictation/DictationService.swift: Added audioLevelPublisher for UI
-- Tests/MacParakeetTests/DictationServiceTests.swift: Test audio level callback registration
+- Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift: New
+  compact dark pill overlay with recording state indicator, waveform,
+  and cancel button.
+- Sources/MacParakeet/Views/Dictation/WaveformView.swift: Real-time
+  audio level waveform using AVAudioEngine tap data.
+- Sources/MacParakeetCore/Services/Dictation/DictationService.swift:
+  Added `audioLevelPublisher` for UI.
+- Tests/MacParakeetTests/DictationServiceTests.swift: Test audio
+  level callback registration.
 
 ## Root Intent
-Users need visual feedback when dictating -- they need to know the app is recording,
-see their voice levels, and have a clear way to cancel. The pill overlay appears over
-all apps without stealing focus.
+Users need visual feedback when dictating — they need to know the app
+is recording, see their voice levels, and have a clear way to cancel.
+The pill overlay appears over all apps without stealing focus.
 
 ## Prompt That Would Produce This Diff
-Implement a dictation overlay for MacParakeet modeled after OatFlow's pill overlay.
-Create a compact dark pill that:
+Implement a dictation overlay for MacParakeet. Create a compact dark
+pill that:
 1. Appears as a borderless NSPanel over all windows
-2. Shows recording state with pulsing indicator
+2. Shows recording state with a pulsing indicator
 3. Displays real-time waveform from AVAudioEngine audio levels
 4. Has a cancel button (Escape key also cancels)
 5. Does NOT steal focus from the active app (non-activating panel)
 
-Use KeyablePanel pattern if text input is needed. Add audioLevelPublisher
-to DictationService so the view can subscribe to audio levels.
+Add `audioLevelPublisher` to `DictationService` so the view can
+subscribe to audio levels.
 
 ## ADRs Applied
 - ADR-001 + ADR-007: Parakeet TDT model with FluidAudio CoreML runtime
@@ -63,39 +187,47 @@ to DictationService so the view can subscribe to audio levels.
 ## Files Changed
 - Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift (+145)
 - Sources/MacParakeet/Views/Dictation/WaveformView.swift (+62)
-- Sources/MacParakeetCore/Services/Dictation/DictationService.swift (+28, ~12)
+- Sources/MacParakeetCore/Services/Dictation/DictationService.swift
+  (+28, ~12)
 - Tests/MacParakeetTests/DictationServiceTests.swift (+34)
 ```
 
-## Example (Bug Fix)
+### Targeted bug fix
 
 ```
 Fix clipboard not restoring after dictation paste
 
 ## What Changed
-- Sources/MacParakeetCore/Services/Dictation/DictationService.swift: Save clipboard contents
-  before pasting transcription, restore after CGEvent paste completes
+Save clipboard contents in `DictationService.paste(_:)` before writing
+the transcription, restore after the CGEvent Cmd+V completes (100ms
+delay to let the receiving app consume the paste).
 
 ## Root Intent
-Users complained that dictation overwrites their clipboard. The paste
-operation should be transparent -- save what was on the clipboard, paste
-the transcription via simulated Cmd+V, then restore the original clipboard.
-
-## Prompt That Would Produce This Diff
-Fix the dictation paste flow in DictationService to preserve the user's
-clipboard. Before writing the transcription to NSPasteboard, save the
-current contents. After the CGEvent Cmd+V is dispatched and a short delay
-(100ms), restore the saved clipboard contents.
+Users reported that dictation overwrites their clipboard. The paste
+should be transparent: save → paste transcription → restore the
+original.
 
 ## Files Changed
-- Sources/MacParakeetCore/Services/Dictation/DictationService.swift (~18)
+- Sources/MacParakeetCore/Services/Dictation/DictationService.swift
+  (~18)
+```
+
+### Short
+
+```
+Warn that Best-available YouTube audio breaks in-app playback
+
+AVPlayer on macOS can't decode WebM/Opus, which is what yt-dlp picks
+under "Best available". The old Settings detail glossed this as "may
+save WebM/Opus files" without saying playback dies. Make the trade-off
+explicit so users know to fall back to Show Video.
 ```
 
 ## Subsystem READMEs
 
-Some folders under `Sources/MacParakeetCore/` carry a `README.md`
-that captures non-obvious rules (threading, ordering, retention)
-that aren't visible from grep. As of this writing: `Audio/`, `STT/`,
+Some folders under `Sources/MacParakeetCore/` carry a `README.md` that
+captures non-obvious rules (threading, ordering, retention) that
+aren't visible from grep. As of this writing: `Audio/`, `STT/`,
 `TextProcessing/`, `Database/`, `Licensing/`.
 
 **If your commit adds, removes, or renames files in one of those
@@ -107,18 +239,24 @@ caught at PR time, but only if the PR itself touches code.
 The READMEs are not exhaustive listings; they call out the files
 worth orienting around. If you add a new file that introduces a
 non-obvious rule (a threading invariant, a "do not delete this," an
-ordering constraint), document the rule in the README. If you add
-a file whose purpose is self-evident from its name and contents,
-no README change needed.
+ordering constraint), document the rule in the README. If you add a
+file whose purpose is self-evident from its name and contents, no
+README change needed.
 
-## Why This Matters
+## Why this matters
 
-1. **Git history becomes documentation** -- Rich context lives in version control, not lost chat logs
-2. **Reproducible changes** -- The prompt section is a recipe that could regenerate the diff
-3. **Onboarding via archaeology** -- New devs/agents understand decisions by reading commits
-4. **Auditable reasoning** -- The "why" is preserved alongside the "what"
+1. **Git history becomes the project's long-term memory** — rich
+   context lives in version control rather than disappearing into
+   chat transcripts and PR comments that nobody re-reads.
+2. **Reproducible changes** — the prompt section is a recipe that
+   could regenerate the diff if needed, and a record of the
+   constraints the author was working within.
+3. **Onboarding via archaeology** — new devs and agents understand
+   decisions by reading commits, not by scheduling explanations.
+4. **Auditable reasoning** — the "why" is preserved alongside the
+   "what," so future bug investigations can recover the original
+   trade-offs.
 
-## When to Use This Format
-
-- **Always** for significant changes (multi-file, architectural, spec updates)
-- **Optional** for trivial fixes (typos, single-line changes)
+The spirit test holds the whole system together: if a future reader
+can't reconstruct your reasoning from the commit, the commit didn't
+do its job — regardless of how many template sections it filled.


### PR DESCRIPTION
## Summary

Reorients `docs/commit-guidelines.md` from a template-first framing to a spirit-first one. The doc now opens with the litmus test that's been implicit in the project's best commits:

> *A future reader landing here via \`git blame\`, with no surrounding context, should finish the message understanding the change as well as you understood it the moment you wrote it.*

The 5-section template (What Changed / Root Intent / Prompt / ADRs / Files Changed) is retained but **demoted from \"the law\" to \"a scaffolding.\"** Form follows substance — comprehensive changes earn themed subsections and quantitative justification, targeted fixes earn a tight Root Intent, one-line fixes earn one well-written paragraph.

## What's new in the doc

- **\"The spirit\"** — opens with the litmus test, names the future-reader audience, makes explicit that shape follows substance.
- **\"The standard scaffolding\"** — the 5-section template, now framed as a default shape rather than a specification.
- **\"Latitude\"** — explicitly grants the author judgment about shape with concrete examples of when departing from the scaffolding is the right call.
- **\"Depth bar\"** — substance markers that separate a perfunctory rich commit from a gold-standard one (quantitative reasoning, internal-pattern anchoring, technical primitives explained, refuted findings, out-of-scope notes).
- **\"Exemplars\"** — four merged commits on \`main\` at different scales as living references:
  - \`94f53067\` — comprehensive UI polish (gold standard)
  - \`be9757e2\` — multi-fix bugfix with refuted findings
  - \`75d8c1a4\` — feature introduction behind a flag
  - \`f6edccc7\` — short three-sentence change with no template

## Trigger

Project owner asked to formalize the substance bar after the \`94f53067\` (\"Polish Transforms spike pill\") commit landed. The gap wasn't format — the template was followed — but rather the substance density per section, plus the absence of explicit latitude on shape. This PR closes both gaps.

## Test plan

- [ ] Read the new doc top to bottom and confirm the spirit lands clearly
- [ ] Spot-check the linked exemplar commits exist on main (they do — \`git show <hash>\`)
- [ ] No behavior changes (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote commit guidelines to introduce a "spirit" litmus test, a default scaffold template, "Latitude" guidance, and a "Depth bar" checklist.
  * Added expanded exemplars and full inline templates for feature, targeted bug fix, and short commits.
  * Tightened Subsystem README update rules and expanded the "Why this matters" rationale; removed the legacy guidance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moona3k/macparakeet/pull/280)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->