### PR TITLE
Prevent YouTube card buttons from wrapping at narrow widths

### DIFF
--- a/Sources/MacParakeet/Views/Transcription/TranscribeView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscribeView.swift
@@ -210,7 +210,7 @@ struct TranscribeView: View {
                                 .font(DesignSystem.Typography.caption.weight(.semibold))
                                 .foregroundStyle(.secondary)
                                 .lineLimit(1)
-                                .fixedSize()
+                                .layoutPriority(1)
                                 .padding(.horizontal, 8)
                                 .padding(.vertical, 4)
                                 .background(
@@ -244,7 +244,7 @@ struct TranscribeView: View {
                             .font(DesignSystem.Typography.caption.weight(.semibold))
                             .foregroundStyle(DesignSystem.Colors.onAccent)
                             .lineLimit(1)
-                            .fixedSize()
+                            .layoutPriority(1)
                             .padding(.horizontal, 12)
                             .padding(.vertical, 9)
                             .background(

--- a/Sources/MacParakeet/Views/Transcription/TranscribeView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscribeView.swift
@@ -209,6 +209,8 @@ struct TranscribeView: View {
                             Text("Paste")
                                 .font(DesignSystem.Typography.caption.weight(.semibold))
                                 .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                                .fixedSize()
                                 .padding(.horizontal, 8)
                                 .padding(.vertical, 4)
                                 .background(
@@ -241,6 +243,8 @@ struct TranscribeView: View {
                         Label("Transcribe", systemImage: "arrow.right")
                             .font(DesignSystem.Typography.caption.weight(.semibold))
                             .foregroundStyle(DesignSystem.Colors.onAccent)
+                            .lineLimit(1)
+                            .fixedSize()
                             .padding(.horizontal, 12)
                             .padding(.vertical, 9)
                             .background(

--- a/Sources/MacParakeet/Views/Transcription/YouTubeInputPanelView.swift
+++ b/Sources/MacParakeet/Views/Transcription/YouTubeInputPanelView.swift
@@ -79,6 +79,8 @@ struct YouTubeInputPanelView: View {
                     Text("Paste")
                         .font(DesignSystem.Typography.caption.weight(.semibold))
                         .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .fixedSize()
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)
                         .background(
@@ -114,6 +116,7 @@ struct YouTubeInputPanelView: View {
                         ? DesignSystem.Colors.onAccent
                         : DesignSystem.Colors.textTertiary
                 )
+                .lineLimit(1)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 10)
                 .background(

--- a/Sources/MacParakeet/Views/Transcription/YouTubeInputPanelView.swift
+++ b/Sources/MacParakeet/Views/Transcription/YouTubeInputPanelView.swift
@@ -80,7 +80,7 @@ struct YouTubeInputPanelView: View {
                         .font(DesignSystem.Typography.caption.weight(.semibold))
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
-                        .fixedSize()
+                        .layoutPriority(1)
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)
                         .background(


### PR DESCRIPTION
## Summary
Fix the YouTube card's Paste and Transcribe buttons wrapping their labels to two lines when the main window is not full-screen — `Paste` rendered as `Pas\nte`.

## Root cause
At the 860pt window minimum (sidebar ~170pt), the YouTube card receives ~290pt as half of the 50/50 HStack with the file-drop card. That's narrow enough for the row's icon + TextField + Paste + Transcribe buttons to crowd each other, and SwiftUI's default text wrapping kicks in.

## Changes
- `TranscribeView.swift` `youTubeCard`: `.lineLimit(1) + .fixedSize()` on the Paste button's `Text` and the Transcribe button's `Label`. Labels now keep their natural width; the TextField compresses first.
- `YouTubeInputPanelView.swift`: same fix on the popover variant that hosts the same widget. Currently shielded by `.frame(width: 460)`, but the widget is a copy of the in-card version and should harden against future width changes. The full-width Transcribe button there gets `.lineLimit(1)` only (omits `.fixedSize()` because it uses `.frame(maxWidth: .infinity)`).

## Test plan
- [ ] Open MacParakeet, go to Transcribe tab, resize the window narrow (~860–1000pt). The "Paste" and "→ Transcribe" buttons each stay on one line.
- [ ] Trigger the YouTube popover via global hotkey from another app and verify the same buttons there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed button label wrapping in transcription UI—Paste and Transcribe buttons now render on a single line with stable layout priority for improved visual consistency and reduced layout shifts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moona3k/macparakeet/pull/281)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->