### PR TITLE
Transforms Phase 2: productize the spike into a ship-ready feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,7 @@ All ADRs are in `spec/adr/`. These are locked decisions -- don't second-guess th
 | ADR-019 | Crash-resilient meeting recording (implemented) | `spec/adr/019-crash-resilient-meeting-recording.md` |
 | ADR-020 | Live meeting notepad + memo-steered summaries (implemented) | `spec/adr/020-live-meeting-notepad-and-memo-summaries.md` |
 | ADR-021 | WhisperKit as optional multilingual STT engine (implemented) | `spec/adr/021-whisperkit-multilingual-stt.md` |
+| ADR-022 | Transforms — system-wide LLM rewrites on selected text (Phase 2 productized; flag-gated) | `spec/adr/022-transforms-system-wide-rewrite.md` |
 
 > Historical/dormant ADRs (still in `spec/adr/`, kept for context): ADR-003 (one-time purchase pricing), ADR-006 (trial + license activation), ADR-008 (local LLM runtime). Current public builds are free/GPL-3.0 and unlocked. The old LemonSqueezy/trial entitlement plumbing is intentionally retained as future-option code for GPL-compatible official paid distribution/support; do not remove it as dead code without explicit owner direction and an ADR/spec update.
 
@@ -139,15 +140,16 @@ All ADRs are in `spec/adr/`. These are locked decisions -- don't second-guess th
 
 ## Key Patterns
 
-### Three Co-Equal Modes
+### Three Primary Modes + Transforms
 
-MacParakeet has three primary modes in the `main` branch product direction:
+MacParakeet has three primary capture modes plus a system-wide text-rewrite surface (ADR-022) in the `main` branch product direction:
 
 1. **System-wide dictation** -- Press hotkey anywhere on macOS, speak, text is pasted (WisprFlow-style)
 2. **File transcription** -- Drag-drop audio/video files or paste a YouTube link (MacWhisper-style)
 3. **Meeting recording** -- Capture system audio + mic simultaneously, transcribe locally (simple Granola-style)
+4. **Transforms** -- Select text anywhere on macOS, press a bound hotkey (⌥1 / ⌥2 / ⌥3 by default), and the selection is rewritten in place through the user's LLM provider. ADR-022. Phase 2 productized behind `AppFeatures.transformsEnabled` (default `false`, flipped after the website telemetry-allowlist deploy). Ships with three built-in Transforms: *Polish*, *Distill*, *Decide* — synthesized by a paired creative-director + staff-PM review on 2026-05-12 (Improve → Re-shape → Re-direct pedagogy). Reuses the spike's brand-finished floating pill (ADR-022 §4); user-bound shortcuts dispatch through a single process-wide `TransformsHotkeyRegistry`.
 
-All three modes share the same STT scheduler/runtime path on `main` but have different UI flows, audio sources, and data models. Parakeet is the default engine; Whisper can be selected globally or per CLI call for languages Parakeet does not cover. **Dictation and meeting recording run concurrently** (ADR-015) -- a user can dictate freely during a meeting recording. Dictation and meeting microphone capture fan out from one process-wide `SharedMicrophoneStream`/AVAudioEngine; meeting system audio remains a separate ScreenCaptureKit stream.
+The three capture modes share the same STT scheduler/runtime path on `main` but have different UI flows, audio sources, and data models. Parakeet is the default engine; Whisper can be selected globally or per CLI call for languages Parakeet does not cover. **Dictation and meeting recording run concurrently** (ADR-015) -- a user can dictate freely during a meeting recording. Dictation and meeting microphone capture fan out from one process-wide `SharedMicrophoneStream`/AVAudioEngine; meeting system audio remains a separate ScreenCaptureKit stream. Transforms is unrelated to STT — it operates on whatever text is currently selected and sends it through the configured LLM provider.
 
 The Transcribe tab is the unified capture surface — one place for all three modes (dictation can also start there via hotkey/menu bar, since dictation is global):
 

--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -80,6 +80,33 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ## [Unreleased]
 
+### Added (2.2.0)
+
+- `transforms list / show / run / create / delete` — new subcommand tree
+  for managing user-defined Transforms (ADR-022). Same surface that the
+  GUI's Transforms tab edits, headlessly accessible so agent operators
+  can provision a fresh device, run a saved prompt against arbitrary
+  text from CI, and verify the dispatch table without launching the
+  app.
+  - `transforms list [--json]` — lists Transforms with their bound
+    shortcuts in human-readable rows or a JSON array.
+  - `transforms show <id|name> [--json]` — prints the prompt body and
+    the bound shortcut.
+  - `transforms run <id|name> --input FILE|- [--stream] [--json]` —
+    invokes the saved prompt body via the user's configured LLM
+    provider. Distinct from `llm transform --prompt "..."`, which
+    takes an ad-hoc prompt string.
+  - `transforms create --name --prompt|--from-file [--shortcut "opt+1"]
+    [--running-label] [--json]` — headless install of a new Transform.
+    Shortcut format: `opt+1`, `cmd+shift+P`, etc. Refuses bare-key
+    bindings (must include a modifier).
+  - `transforms delete <id|name> [--json]` — deletes a custom
+    Transform. Built-ins are protected.
+  - All `--json` outputs use a snake-cased `TransformDTO` envelope
+    (`id`, `name`, `shortcut`, `running_label`, `is_built_in`,
+    `prompt`, `created_at`, `updated_at`) — consumers don't see the
+    internal `Prompt` shape.
+
 ### Fixed
 
 - YouTube transcriptions captured under `--youtube-audio-quality

--- a/Sources/CLI/Commands/CLIHelpers.swift
+++ b/Sources/CLI/Commands/CLIHelpers.swift
@@ -182,11 +182,13 @@ func findPrompt(idOrName: String, repo: PromptRepository) throws -> Prompt {
     let trimmed = idOrName.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { throw CLILookupError.emptyID }
 
-    if let uuid = UUID(uuidString: trimmed), let prompt = try repo.fetch(id: uuid) {
+    if let uuid = UUID(uuidString: trimmed),
+       let prompt = try repo.fetch(id: uuid),
+       prompt.category == .result {
         return prompt
     }
 
-    let all = try repo.fetchAll()
+    let all = try repo.fetchAll().filter { $0.category == .result }
     let lowered = trimmed.lowercased()
 
     if let prefix = uuidPrefixSearchKey(trimmed) {

--- a/Sources/CLI/Commands/PromptsCommand.swift
+++ b/Sources/CLI/Commands/PromptsCommand.swift
@@ -53,8 +53,8 @@ extension PromptsCommand {
 
                 let prompts: [Prompt]
                 switch filter {
-                case .all:     prompts = try repo.fetchAll()
-                case .visible: prompts = try repo.fetchVisible(category: nil)
+                case .all:     prompts = try repo.fetchAll().filter { $0.category == .result }
+                case .visible: prompts = try repo.fetchVisible(category: .result)
                 case .autoRun: prompts = try repo.fetchAutoRunPrompts()
                 }
 

--- a/Sources/CLI/Commands/TransformsCommand.swift
+++ b/Sources/CLI/Commands/TransformsCommand.swift
@@ -252,6 +252,24 @@ extension TransformsCommand {
                     guard parsed.hasModifier else {
                         throw CLITransformsError.shortcutMissingModifier
                     }
+                    guard !parsed.isMacOSDeadKey else {
+                        throw CLITransformsError.shortcutMacOSDeadKey
+                    }
+                    if let duplicate = existing.first(where: { prompt in
+                        guard prompt.category == .transform,
+                              let shortcut = prompt.shortcut
+                        else { return false }
+                        return shortcutsMatch(shortcut, parsed)
+                    }) {
+                        throw CLITransformsError.duplicateShortcut(
+                            parsed.displayString,
+                            duplicate.name
+                        )
+                    }
+                    let appHotkeyCollision = appHotkeyCollision(for: parsed)
+                    if let appHotkeyCollision {
+                        throw appHotkeyCollision
+                    }
                     shortcutValue = parsed
                 } else {
                     shortcutValue = nil
@@ -373,6 +391,17 @@ struct TransformDTO: Encodable {
     let createdAt: Date
     let updatedAt: Date
 
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case shortcut
+        case runningLabel = "running_label"
+        case isBuiltIn = "is_built_in"
+        case prompt
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+    }
+
     init(prompt: Prompt) {
         self.id = prompt.id.uuidString
         self.name = prompt.name
@@ -391,6 +420,10 @@ enum CLITransformsError: Error, CustomStringConvertible {
     case duplicateName(String)
     case invalidShortcut(String)
     case shortcutMissingModifier
+    case shortcutMacOSDeadKey
+    case duplicateShortcut(String, String)
+    case shortcutConflictsWithDictation(String)
+    case shortcutConflictsWithMeeting(String)
     case deleteBuiltIn(String)
 
     var description: String {
@@ -405,8 +438,47 @@ enum CLITransformsError: Error, CustomStringConvertible {
             return "Couldn't parse shortcut “\(s)”. Try forms like 'opt+1', 'cmd+shift+P', 'ctrl+opt+space'."
         case .shortcutMissingModifier:
             return "Shortcut must include a modifier key (cmd, opt, ctrl, or shift)."
+        case .shortcutMacOSDeadKey:
+            return "This shortcut produces a special character on Mac. Pick another combo."
+        case .duplicateShortcut(let shortcut, let name):
+            return "Shortcut “\(shortcut)” is already used by Transform “\(name)”."
+        case .shortcutConflictsWithDictation(let shortcut):
+            return "Shortcut “\(shortcut)” conflicts with your dictation hotkey."
+        case .shortcutConflictsWithMeeting(let shortcut):
+            return "Shortcut “\(shortcut)” conflicts with your meeting recording hotkey."
         case .deleteBuiltIn(let n):
             return "Cannot delete the built-in Transform “\(n)”. Reset it via the GUI or override its prompt body with `transforms create --name ...`."
         }
     }
+}
+
+private func shortcutsMatch(_ lhs: KeyboardShortcut, _ rhs: KeyboardShortcut) -> Bool {
+    lhs.keyCode == rhs.keyCode && lhs.modifiers == rhs.modifiers
+}
+
+private func appHotkeyCollision(for shortcut: KeyboardShortcut) -> CLITransformsError? {
+    let defaults = macParakeetAppDefaults()
+    let candidate = shortcut.hotkeyTrigger
+    let dictationHotkeys = [
+        HotkeyTrigger.current(defaults: defaults),
+        HotkeyTrigger.current(
+            defaults: defaults,
+            defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey,
+            fallback: .defaultPushToTalk
+        ),
+    ]
+    if dictationHotkeys.contains(where: { candidate.overlaps(with: $0) }) {
+        return .shortcutConflictsWithDictation(shortcut.displayString)
+    }
+
+    let meetingHotkey = HotkeyTrigger.current(
+        defaults: defaults,
+        defaultsKey: HotkeyTrigger.meetingDefaultsKey,
+        fallback: .defaultMeetingRecording
+    )
+    if candidate.overlaps(with: meetingHotkey) {
+        return .shortcutConflictsWithMeeting(shortcut.displayString)
+    }
+
+    return nil
 }

--- a/Sources/CLI/Commands/TransformsCommand.swift
+++ b/Sources/CLI/Commands/TransformsCommand.swift
@@ -1,0 +1,412 @@
+import ArgumentParser
+import Foundation
+import MacParakeetCore
+
+/// `macparakeet-cli transforms` — manage and run user-defined Transforms
+/// (ADR-022) headlessly. Built so an agent operator can provision a fresh
+/// device, dispatch a saved prompt against arbitrary text from CI, and
+/// verify the dispatch table without launching the GUI.
+///
+/// Versus `llm transform --prompt "..."` (which is the raw-prompt ad-hoc
+/// primitive), `transforms run <name>` invokes the **saved** prompt body
+/// stored in the prompts table.
+struct TransformsCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "transforms",
+        abstract: "Manage and run user-defined Transforms (saved prompt + hotkey rewrite shortcuts).",
+        subcommands: [
+            ListSubcommand.self,
+            ShowSubcommand.self,
+            RunSubcommand.self,
+            CreateSubcommand.self,
+            DeleteSubcommand.self,
+        ],
+        defaultSubcommand: ListSubcommand.self
+    )
+}
+
+// MARK: - List
+
+extension TransformsCommand {
+    struct ListSubcommand: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "list",
+            abstract: "List Transforms with their bound shortcuts."
+        )
+
+        @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+        var json: Bool = false
+
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
+        func run() throws {
+            try emitJSONOrRethrow(json: json) {
+                try AppPaths.ensureDirectories()
+                let db = try DatabaseManager(path: resolvedDatabasePath(database))
+                let repo = PromptRepository(dbQueue: db.dbQueue)
+                let transforms = try repo
+                    .fetchVisible(category: .transform)
+                    .sorted(by: { $0.sortOrder < $1.sortOrder })
+
+                if json {
+                    try printJSON(transforms.map(TransformDTO.init(prompt:)))
+                    return
+                }
+
+                if transforms.isEmpty {
+                    print("No Transforms found.")
+                    return
+                }
+
+                for t in transforms {
+                    let badge = t.isBuiltIn ? " [built-in]" : ""
+                    let shortcut = t.shortcut?.displayString ?? "—"
+                    print("\(t.id.uuidString.prefix(8))  \(shortcut.padding(toLength: 12, withPad: " ", startingAt: 0))  \(t.name)\(badge)")
+                }
+                print()
+                print("\(transforms.count) Transform(s)")
+            }
+        }
+    }
+}
+
+// MARK: - Show
+
+extension TransformsCommand {
+    struct ShowSubcommand: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "show",
+            abstract: "Show a Transform's full prompt body and bound shortcut."
+        )
+
+        @Argument(help: "Transform ID, ID prefix, or name.")
+        var idOrName: String
+
+        @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+        var json: Bool = false
+
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
+        func run() throws {
+            try emitJSONOrRethrow(json: json) {
+                try AppPaths.ensureDirectories()
+                let db = try DatabaseManager(path: resolvedDatabasePath(database))
+                let repo = PromptRepository(dbQueue: db.dbQueue)
+                let transform = try findTransform(idOrName: idOrName, repo: repo)
+
+                if json {
+                    try printJSON(TransformDTO(prompt: transform))
+                    return
+                }
+
+                print("ID:        \(transform.id.uuidString)")
+                print("Name:      \(transform.name)\(transform.isBuiltIn ? " [built-in]" : "")")
+                print("Shortcut:  \(transform.shortcut?.displayString ?? "—")")
+                print("Running:   \(transform.derivedRunningLabel)")
+                print("Updated:   \(ISO8601DateFormatter().string(from: transform.updatedAt))")
+                print()
+                print(transform.content)
+            }
+        }
+    }
+}
+
+// MARK: - Run
+
+extension TransformsCommand {
+    struct RunSubcommand: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "run",
+            abstract: "Run a saved Transform against text from a file or stdin."
+        )
+
+        @OptionGroup var llm: LLMInlineOptions
+
+        @Argument(help: "Transform ID, ID prefix, or name.")
+        var idOrName: String
+
+        @Option(name: .shortAndLong, help: "Path to text file to transform. Use '-' for stdin.")
+        var input: String
+
+        @Flag(name: .long, help: "Stream the response token by token. Incompatible with --json.")
+        var stream: Bool = false
+
+        @Flag(name: .long, help: "Emit a structured JSON envelope instead of plain text.")
+        var json: Bool = false
+
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
+        func validate() throws {
+            if json && stream {
+                throw ValidationError("--json with --stream is not yet supported. Run without --stream for the envelope, or omit --json for token streaming.")
+            }
+        }
+
+        func run() async throws {
+            try await emitJSONOrRethrow(json: json) {
+                try AppPaths.ensureDirectories()
+                let db = try DatabaseManager(path: resolvedDatabasePath(database))
+                let repo = PromptRepository(dbQueue: db.dbQueue)
+                let transform = try findTransform(idOrName: idOrName, repo: repo)
+
+                let text = try readInput(input)
+                guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                    throw CLIInputError.empty
+                }
+
+                let execution = try llm.buildExecutionContext()
+                let service = LLMService(
+                    client: execution.client,
+                    contextResolver: StaticLLMExecutionContextResolver(context: execution.context)
+                )
+
+                if json {
+                    let result = try await service.transformDetailed(text: text, prompt: transform.content)
+                    try printJSON(result)
+                } else if stream {
+                    let tokenStream = service.transformStream(text: text, prompt: transform.content)
+                    for try await token in tokenStream {
+                        print(token, terminator: "")
+                    }
+                    print()
+                } else {
+                    print(try await service.transform(text: text, prompt: transform.content))
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Create
+
+extension TransformsCommand {
+    struct CreateSubcommand: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "create",
+            abstract: "Headless-install a new Transform with an optional bound shortcut."
+        )
+
+        @Option(name: .long, help: "Transform name (must be unique across Transforms).")
+        var name: String
+
+        @Option(name: .long, help: "Prompt body text. Mutually exclusive with --from-file.")
+        var prompt: String?
+
+        @Option(name: .long, help: "Path to a file containing the prompt body.")
+        var fromFile: String?
+
+        @Option(name: .long, help: "Keyboard shortcut, e.g. 'opt+1', 'cmd+shift+P'. Modifier required.")
+        var shortcut: String?
+
+        @Option(name: .long, help: "Optional running-pill label. Defaults to a 'Naming…' heuristic.")
+        var runningLabel: String?
+
+        @Flag(name: .long, help: "Emit a JSON envelope on success.")
+        var json: Bool = false
+
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
+        func validate() throws {
+            if prompt != nil && fromFile != nil {
+                throw ValidationError("--prompt and --from-file are mutually exclusive.")
+            }
+            if prompt == nil && fromFile == nil {
+                throw ValidationError("Provide a prompt body via --prompt or --from-file.")
+            }
+            if name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                throw ValidationError("--name must not be empty.")
+            }
+        }
+
+        func run() throws {
+            try emitJSONOrRethrow(json: json) {
+                try AppPaths.ensureDirectories()
+                let db = try DatabaseManager(path: resolvedDatabasePath(database))
+                let repo = PromptRepository(dbQueue: db.dbQueue)
+
+                let body: String
+                if let p = prompt {
+                    body = p
+                } else if let path = fromFile {
+                    body = try String(contentsOfFile: path, encoding: .utf8)
+                } else {
+                    throw ValidationError("Provide a prompt body via --prompt or --from-file.")
+                }
+
+                let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+
+                let existing = try repo.fetchAll()
+                if existing.contains(where: { $0.name.caseInsensitiveCompare(trimmedName) == .orderedSame }) {
+                    throw CLITransformsError.duplicateName(trimmedName)
+                }
+
+                let shortcutValue: KeyboardShortcut?
+                if let s = shortcut {
+                    guard let parsed = KeyboardShortcut.parse(s) else {
+                        throw CLITransformsError.invalidShortcut(s)
+                    }
+                    guard parsed.hasModifier else {
+                        throw CLITransformsError.shortcutMissingModifier
+                    }
+                    shortcutValue = parsed
+                } else {
+                    shortcutValue = nil
+                }
+
+                let now = Date()
+                let transform = Prompt(
+                    id: UUID(),
+                    name: trimmedName,
+                    content: body,
+                    category: .transform,
+                    isBuiltIn: false,
+                    isVisible: true,
+                    isAutoRun: false,
+                    sortOrder: 200,
+                    createdAt: now,
+                    updatedAt: now,
+                    keyboardShortcut: shortcutValue?.encodedString(),
+                    runningLabel: runningLabel?.trimmingCharacters(in: .whitespacesAndNewlines)
+                )
+                try repo.save(transform)
+
+                if json {
+                    try printJSON(TransformDTO(prompt: transform))
+                } else {
+                    print("Created Transform \(transform.id.uuidString.prefix(8))  \(transform.name)")
+                    if let shortcutValue {
+                        print("Bound to \(shortcutValue.displayString)")
+                    } else {
+                        print("Dormant (no shortcut bound)")
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Delete
+
+extension TransformsCommand {
+    struct DeleteSubcommand: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "delete",
+            abstract: "Delete a custom Transform. Built-ins are protected."
+        )
+
+        @Argument(help: "Transform ID, ID prefix, or name.")
+        var idOrName: String
+
+        @Flag(name: .long, help: "Emit a JSON envelope on success.")
+        var json: Bool = false
+
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
+        func run() throws {
+            try emitJSONOrRethrow(json: json) {
+                try AppPaths.ensureDirectories()
+                let db = try DatabaseManager(path: resolvedDatabasePath(database))
+                let repo = PromptRepository(dbQueue: db.dbQueue)
+                let transform = try findTransform(idOrName: idOrName, repo: repo)
+
+                if transform.isBuiltIn {
+                    throw CLITransformsError.deleteBuiltIn(transform.name)
+                }
+
+                let deleted = try repo.delete(id: transform.id)
+                guard deleted else {
+                    throw CLITransformsError.notFound(idOrName)
+                }
+
+                if json {
+                    struct DeleteResult: Encodable { let deleted: Bool; let id: String; let name: String }
+                    try printJSON(DeleteResult(deleted: true, id: transform.id.uuidString, name: transform.name))
+                } else {
+                    print("Deleted Transform \(transform.id.uuidString.prefix(8))  \(transform.name)")
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Lookup helper
+
+private func findTransform(idOrName: String, repo: PromptRepository) throws -> Prompt {
+    let all = try repo.fetchVisible(category: .transform)
+    // Exact UUID match
+    if let uuid = UUID(uuidString: idOrName), let match = all.first(where: { $0.id == uuid }) {
+        return match
+    }
+    // ID prefix
+    let prefix = idOrName.lowercased()
+    let prefixMatches = all.filter { $0.id.uuidString.lowercased().hasPrefix(prefix) }
+    if prefixMatches.count == 1 {
+        return prefixMatches[0]
+    }
+    if prefixMatches.count > 1 {
+        throw CLITransformsError.ambiguous(idOrName, prefixMatches.map(\.name))
+    }
+    // Case-insensitive name match
+    if let nameMatch = all.first(where: { $0.name.caseInsensitiveCompare(idOrName) == .orderedSame }) {
+        return nameMatch
+    }
+    throw CLITransformsError.notFound(idOrName)
+}
+
+// MARK: - DTO + errors
+
+/// Snake-cased DTO for the `--json` envelope so CLI consumers don't have to
+/// learn about the internal `Prompt` shape (which conflates `.result` rows
+/// with this surface).
+struct TransformDTO: Encodable {
+    let id: String
+    let name: String
+    let shortcut: String?
+    let runningLabel: String?
+    let isBuiltIn: Bool
+    let prompt: String
+    let createdAt: Date
+    let updatedAt: Date
+
+    init(prompt: Prompt) {
+        self.id = prompt.id.uuidString
+        self.name = prompt.name
+        self.shortcut = prompt.shortcut?.displayString
+        self.runningLabel = prompt.runningLabel
+        self.isBuiltIn = prompt.isBuiltIn
+        self.prompt = prompt.content
+        self.createdAt = prompt.createdAt
+        self.updatedAt = prompt.updatedAt
+    }
+}
+
+enum CLITransformsError: Error, CustomStringConvertible {
+    case notFound(String)
+    case ambiguous(String, [String])
+    case duplicateName(String)
+    case invalidShortcut(String)
+    case shortcutMissingModifier
+    case deleteBuiltIn(String)
+
+    var description: String {
+        switch self {
+        case .notFound(let q):
+            return "No Transform found matching “\(q)”."
+        case .ambiguous(let q, let names):
+            return "“\(q)” matches multiple Transforms: \(names.joined(separator: ", ")). Use a longer ID prefix."
+        case .duplicateName(let n):
+            return "A prompt named “\(n)” already exists."
+        case .invalidShortcut(let s):
+            return "Couldn't parse shortcut “\(s)”. Try forms like 'opt+1', 'cmd+shift+P', 'ctrl+opt+space'."
+        case .shortcutMissingModifier:
+            return "Shortcut must include a modifier key (cmd, opt, ctrl, or shift)."
+        case .deleteBuiltIn(let n):
+            return "Cannot delete the built-in Transform “\(n)”. Reset it via the GUI or override its prompt body with `transforms create --name ...`."
+        }
+    }
+}

--- a/Sources/CLI/MacParakeetCLI.swift
+++ b/Sources/CLI/MacParakeetCLI.swift
@@ -8,7 +8,7 @@ struct CLI: AsyncParsableCommand {
     /// distinguishable from synthesized Bundle.main values (the bare executable
     /// has no Info.plist and macOS otherwise reports an SDK marker like "16.0").
     /// Bump in lockstep with `Sources/CLI/CHANGELOG.md`.
-    static let cliVersion = "2.1.0"
+    static let cliVersion = "2.2.0"
 
     static let configuration = CommandConfiguration(
         commandName: "macparakeet-cli",
@@ -26,6 +26,7 @@ struct CLI: AsyncParsableCommand {
             LLMCommand.self,
             PromptsCommand.self,
             QuickPromptsCommand.self,
+            TransformsCommand.self,
             MeetingsCommand.self,
             CalendarCommand.self,
             FeedbackCommand.self,

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -343,6 +343,7 @@ final class AppEnvironmentConfigurer {
         transcriptionViewModel.updateLLMAvailability(hasConfig, llmService: service)
         chatViewModel.updateLLMService(service)
         promptResultsViewModel.updateLLMService(service)
+        transformsViewModel.setHasLLMProvider(hasConfig)
         liveMeetingCoordinator?.updateLLMService(service)
     }
 }

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -41,6 +41,7 @@ final class AppEnvironmentConfigurer {
     private let chatViewModel: TranscriptChatViewModel
     private let promptResultsViewModel: PromptResultsViewModel
     private let promptsViewModel: PromptsViewModel
+    private let transformsViewModel: TransformsViewModel
     private let mainWindowState: MainWindowState
     private let meetingPillViewModel: MeetingRecordingPillViewModel
     private weak var liveMeetingCoordinator: MeetingRecordingFlowCoordinator?
@@ -57,6 +58,7 @@ final class AppEnvironmentConfigurer {
         chatViewModel: TranscriptChatViewModel,
         promptResultsViewModel: PromptResultsViewModel,
         promptsViewModel: PromptsViewModel,
+        transformsViewModel: TransformsViewModel,
         mainWindowState: MainWindowState,
         meetingPillViewModel: MeetingRecordingPillViewModel
     ) {
@@ -71,6 +73,7 @@ final class AppEnvironmentConfigurer {
         self.chatViewModel = chatViewModel
         self.promptResultsViewModel = promptResultsViewModel
         self.promptsViewModel = promptsViewModel
+        self.transformsViewModel = transformsViewModel
         self.mainWindowState = mainWindowState
         self.meetingPillViewModel = meetingPillViewModel
     }
@@ -125,6 +128,7 @@ final class AppEnvironmentConfigurer {
             self?.settingsViewModel.refreshStats()
         }
         promptsViewModel.configure(repo: env.promptRepo)
+        transformsViewModel.configure(repo: env.promptRepo, hasLLMProvider: hasLLMConfig)
         llmSettingsViewModel.configure(
             configStore: env.llmConfigStore,
             llmClient: env.llmClient

--- a/Sources/MacParakeet/App/AppWindowCoordinator.swift
+++ b/Sources/MacParakeet/App/AppWindowCoordinator.swift
@@ -14,6 +14,7 @@ final class AppWindowCoordinator: NSObject, NSWindowDelegate {
     private let chatViewModel: TranscriptChatViewModel
     private let promptResultsViewModel: PromptResultsViewModel
     private let promptsViewModel: PromptsViewModel
+    private let transformsViewModel: TransformsViewModel
     private let customWordsViewModel: CustomWordsViewModel
     private let textSnippetsViewModel: TextSnippetsViewModel
     private let vocabularyBackupViewModel: VocabularyBackupViewModel
@@ -39,6 +40,7 @@ final class AppWindowCoordinator: NSObject, NSWindowDelegate {
         chatViewModel: TranscriptChatViewModel,
         promptResultsViewModel: PromptResultsViewModel,
         promptsViewModel: PromptsViewModel,
+        transformsViewModel: TransformsViewModel,
         customWordsViewModel: CustomWordsViewModel,
         textSnippetsViewModel: TextSnippetsViewModel,
         vocabularyBackupViewModel: VocabularyBackupViewModel,
@@ -61,6 +63,7 @@ final class AppWindowCoordinator: NSObject, NSWindowDelegate {
         self.chatViewModel = chatViewModel
         self.promptResultsViewModel = promptResultsViewModel
         self.promptsViewModel = promptsViewModel
+        self.transformsViewModel = transformsViewModel
         self.customWordsViewModel = customWordsViewModel
         self.textSnippetsViewModel = textSnippetsViewModel
         self.vocabularyBackupViewModel = vocabularyBackupViewModel
@@ -170,6 +173,7 @@ final class AppWindowCoordinator: NSObject, NSWindowDelegate {
             chatViewModel: chatViewModel,
             promptResultsViewModel: promptResultsViewModel,
             promptsViewModel: promptsViewModel,
+            transformsViewModel: transformsViewModel,
             customWordsViewModel: customWordsViewModel,
             textSnippetsViewModel: textSnippetsViewModel,
             vocabularyBackupViewModel: vocabularyBackupViewModel,

--- a/Sources/MacParakeet/App/TransformsCoordinator.swift
+++ b/Sources/MacParakeet/App/TransformsCoordinator.swift
@@ -143,6 +143,10 @@ final class TransformsCoordinator {
         guard let llmService = llmServiceProvider() else {
             panelController?.show(label: prompt.derivedRunningLabel)
             panelController?.fail(message: "Add an LLM provider in Settings")
+            Telemetry.send(.transformFailed(
+                transformName: TelemetryTransformName(builtInName: prompt.name, isBuiltIn: prompt.isBuiltIn),
+                reason: .noProvider
+            ))
             logger.notice("transforms: no LLM provider configured for \(prompt.name, privacy: .public)")
             return
         }
@@ -165,6 +169,11 @@ final class TransformsCoordinator {
         let promptBody = prompt.content
         let runningTransformName = prompt.name
 
+        let telemetryName = TelemetryTransformName(
+            builtInName: prompt.name,
+            isBuiltIn: prompt.isBuiltIn
+        )
+
         inFlightTask = Task { @MainActor [weak self] in
             guard let self else { return }
             defer {
@@ -173,7 +182,7 @@ final class TransformsCoordinator {
                 }
             }
             do {
-                _ = try await executor.run(
+                let result = try await executor.run(
                     prompt: promptBody,
                     onProgress: { [weak self] progress in
                         if case .failed = progress {
@@ -188,19 +197,38 @@ final class TransformsCoordinator {
                 )
                 guard self.activeRunID == runID else { return }
                 self.panelController?.done(message: "Done")
+                Telemetry.send(.transformExecuted(
+                    transformName: telemetryName,
+                    capturePath: result.captureTag == "ax" ? .ax : .clipboard,
+                    replacePath: result.path == .ax ? .ax : .clipboardPaste,
+                    llmMs: result.llmElapsedMs,
+                    totalMs: result.totalElapsedMs
+                ))
                 self.logger.notice("transforms: \(runningTransformName, privacy: .public) completed")
             } catch let error as TransformExecutorError {
                 guard self.activeRunID == runID else { return }
                 switch error {
                 case .cancelled:
                     self.panelController?.close()
-                default:
+                    Telemetry.send(.transformFailed(transformName: telemetryName, reason: .cancelled))
+                case .emptySelection:
                     self.panelController?.fail(message: error.localizedDescription)
+                    Telemetry.send(.transformFailed(transformName: telemetryName, reason: .emptySelection))
+                case .llmNotConfigured:
+                    self.panelController?.fail(message: error.localizedDescription)
+                    Telemetry.send(.transformFailed(transformName: telemetryName, reason: .noProvider))
+                case .llmFailed, .captureFailed:
+                    self.panelController?.fail(message: error.localizedDescription)
+                    Telemetry.send(.transformFailed(transformName: telemetryName, reason: .llmFailed))
+                case .replacementFailed:
+                    self.panelController?.fail(message: error.localizedDescription)
+                    Telemetry.send(.transformFailed(transformName: telemetryName, reason: .replacementFailed))
                 }
                 self.logger.notice("transforms: \(runningTransformName, privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
             } catch {
                 guard self.activeRunID == runID else { return }
                 self.panelController?.fail(message: error.localizedDescription)
+                Telemetry.send(.transformFailed(transformName: telemetryName, reason: .llmFailed))
             }
         }
     }

--- a/Sources/MacParakeet/App/TransformsCoordinator.swift
+++ b/Sources/MacParakeet/App/TransformsCoordinator.swift
@@ -29,6 +29,7 @@ final class TransformsCoordinator {
     private var panelController: TransformSpikeProgressPanelController?
     private var executor: TransformExecutor?
     private var inFlightTask: Task<Void, Never>?
+    private var bindingsChangedObserver: NSObjectProtocol?
 
     /// Per-run identity for stale-event guarding. See the same pattern in
     /// the spike coordinator: if the user re-triggers a hotkey mid-flight,
@@ -70,6 +71,16 @@ final class TransformsCoordinator {
         if registry.start() {
             self.registry = registry
             reloadBindings()
+            // Save/delete/reset on the Transforms tab posts this notification.
+            bindingsChangedObserver = NotificationCenter.default.addObserver(
+                forName: .transformsBindingsChanged,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.reloadBindings()
+                }
+            }
             logger.notice("transforms: registry started with \(self.promptIndex.count, privacy: .public) bindings")
         } else {
             logger.error("transforms: failed to install registry event tap")
@@ -84,6 +95,10 @@ final class TransformsCoordinator {
         registry = nil
         panelController?.close()
         panelController = nil
+        if let observer = bindingsChangedObserver {
+            NotificationCenter.default.removeObserver(observer)
+            bindingsChangedObserver = nil
+        }
     }
 
     /// Re-read `.transform` prompts from the repository and rebuild the

--- a/Sources/MacParakeet/App/TransformsCoordinator.swift
+++ b/Sources/MacParakeet/App/TransformsCoordinator.swift
@@ -101,6 +101,21 @@ final class TransformsCoordinator {
         }
     }
 
+    func suspendHotkeys() {
+        registry?.stop()
+    }
+
+    func resumeHotkeys() {
+        guard AppFeatures.transformsEnabled else { return }
+        if let registry {
+            if registry.start() {
+                reloadBindings()
+            }
+        } else {
+            start()
+        }
+    }
+
     /// Re-read `.transform` prompts from the repository and rebuild the
     /// registry's dispatch table. Call after any save/delete/import.
     func reloadBindings() {

--- a/Sources/MacParakeet/App/TransformsCoordinator.swift
+++ b/Sources/MacParakeet/App/TransformsCoordinator.swift
@@ -1,0 +1,192 @@
+import AppKit
+import Foundation
+import MacParakeetCore
+import OSLog
+
+/// Wires the productized Transforms feature to the app surface (ADR-022):
+///
+/// - reads `.transform` prompts from `PromptRepository`
+/// - installs them with the process-wide `TransformsHotkeyRegistry`
+/// - on hotkey trigger, drives `TransformExecutor` with that Transform's
+///   prompt body and surfaces progress in the brand-finished floating
+///   pill (`TransformSpikeProgressPanelController`, retained from the
+///   spike)
+/// - manages cancel-then-restart on re-trigger, run-ID stale-event
+///   guarding, and per-Transform telemetry
+///
+/// Replaces `TransformsSpikeCoordinator` (which bound a single hardcoded
+/// Opt+Ctrl+1 to a baked-in Polish prompt). The new coordinator is gated
+/// by `AppFeatures.transformsEnabled` (defaults to `false` at merge so
+/// the website telemetry-allowlist deploy can land first; flipped to
+/// `true` in a follow-up commit per the rollout plan).
+@MainActor
+final class TransformsCoordinator {
+    private let llmServiceProvider: () -> LLMServiceProtocol?
+    private let promptRepository: PromptRepositoryProtocol
+    private let logger = Logger(subsystem: "com.macparakeet", category: "TransformsCoordinator")
+
+    private var registry: TransformsHotkeyRegistry?
+    private var panelController: TransformSpikeProgressPanelController?
+    private var executor: TransformExecutor?
+    private var inFlightTask: Task<Void, Never>?
+
+    /// Per-run identity for stale-event guarding. See the same pattern in
+    /// the spike coordinator: if the user re-triggers a hotkey mid-flight,
+    /// the previous task may emit a terminal event after cancellation
+    /// lands. We gate every UI/state mutation in the task body on
+    /// `activeRunID == myRunID`.
+    private var activeRunID: UUID?
+
+    /// Cached snapshot of bound `.transform` prompts, keyed by ID. Used to
+    /// resolve a `KeyboardShortcut`-triggered ID back to its prompt body
+    /// and running label without re-hitting the DB on every keystroke.
+    private var promptIndex: [UUID: Prompt] = [:]
+
+    init(
+        llmServiceProvider: @escaping () -> LLMServiceProtocol?,
+        promptRepository: PromptRepositoryProtocol
+    ) {
+        self.llmServiceProvider = llmServiceProvider
+        self.promptRepository = promptRepository
+    }
+
+    // MARK: - Lifecycle
+
+    /// Install the event tap and load the initial set of bindings from the
+    /// repository. Idempotent. No-op when the feature flag is off.
+    func start() {
+        guard AppFeatures.transformsEnabled else { return }
+        guard registry == nil else { return }
+
+        panelController = TransformSpikeProgressPanelController()
+        let registry = TransformsHotkeyRegistry()
+        registry.onTrigger = { [weak self] promptID in
+            // The event tap callback runs on the runloop thread. Hop to main
+            // for everything that touches state / UI.
+            Task { @MainActor in
+                self?.handleTrigger(promptID: promptID)
+            }
+        }
+        if registry.start() {
+            self.registry = registry
+            reloadBindings()
+            logger.notice("transforms: registry started with \(self.promptIndex.count, privacy: .public) bindings")
+        } else {
+            logger.error("transforms: failed to install registry event tap")
+        }
+    }
+
+    /// Tear down event tap + in-flight work. Called from `applicationWillTerminate`.
+    func stop() {
+        inFlightTask?.cancel()
+        inFlightTask = nil
+        registry?.stop()
+        registry = nil
+        panelController?.close()
+        panelController = nil
+    }
+
+    /// Re-read `.transform` prompts from the repository and rebuild the
+    /// registry's dispatch table. Call after any save/delete/import.
+    func reloadBindings() {
+        guard let registry else { return }
+        let prompts: [Prompt]
+        do {
+            prompts = try promptRepository.fetchVisible(category: .transform)
+        } catch {
+            logger.error("transforms: fetchVisible failed: \(error.localizedDescription, privacy: .public)")
+            return
+        }
+
+        promptIndex = Dictionary(uniqueKeysWithValues: prompts.map { ($0.id, $0) })
+
+        var bindings: [UUID: KeyboardShortcut] = [:]
+        for prompt in prompts {
+            if let shortcut = prompt.shortcut {
+                bindings[prompt.id] = shortcut
+            }
+        }
+        registry.replaceBindings(bindings)
+    }
+
+    /// True when at least one Transform has a hotkey bound. Used by the
+    /// Transforms tab to surface a calmer "no bindings yet" hint state.
+    var hasActiveBindings: Bool {
+        promptIndex.values.contains(where: { $0.shortcut != nil })
+    }
+
+    // MARK: - Trigger handling
+
+    private func handleTrigger(promptID: UUID) {
+        guard AppFeatures.transformsEnabled else { return }
+        guard let prompt = promptIndex[promptID] else {
+            logger.notice("transforms: trigger for unknown promptID, reloading bindings")
+            reloadBindings()
+            return
+        }
+
+        guard let llmService = llmServiceProvider() else {
+            panelController?.show(label: prompt.derivedRunningLabel)
+            panelController?.fail(message: "Add an LLM provider in Settings")
+            logger.notice("transforms: no LLM provider configured for \(prompt.name, privacy: .public)")
+            return
+        }
+
+        // Cancel any in-flight Transform if the user re-triggers a hotkey
+        // before the previous one finishes. ADR-022 §4 / spike pattern.
+        if let inFlightTask {
+            inFlightTask.cancel()
+            self.inFlightTask = nil
+        }
+
+        let executor = TransformExecutor(llmService: llmService)
+        self.executor = executor
+
+        let runID = UUID()
+        activeRunID = runID
+
+        panelController?.show(label: prompt.derivedRunningLabel)
+
+        let promptBody = prompt.content
+        let runningTransformName = prompt.name
+
+        inFlightTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer {
+                if self.activeRunID == runID {
+                    self.inFlightTask = nil
+                }
+            }
+            do {
+                _ = try await executor.run(
+                    prompt: promptBody,
+                    onProgress: { [weak self] progress in
+                        if case .failed = progress {
+                            Task { @MainActor [weak self, runID] in
+                                guard self?.activeRunID == runID else { return }
+                                if case .failed(let message) = progress {
+                                    self?.panelController?.fail(message: message)
+                                }
+                            }
+                        }
+                    }
+                )
+                guard self.activeRunID == runID else { return }
+                self.panelController?.done(message: "Done")
+                self.logger.notice("transforms: \(runningTransformName, privacy: .public) completed")
+            } catch let error as TransformExecutorError {
+                guard self.activeRunID == runID else { return }
+                switch error {
+                case .cancelled:
+                    self.panelController?.close()
+                default:
+                    self.panelController?.fail(message: error.localizedDescription)
+                }
+                self.logger.notice("transforms: \(runningTransformName, privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
+            } catch {
+                guard self.activeRunID == runID else { return }
+                self.panelController?.fail(message: error.localizedDescription)
+            }
+        }
+    }
+}

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -169,8 +169,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // recording from inside Settings).
             if isRecording {
                 self?.hotkeyCoordinator?.suspend()
+                self?.transformsCoordinator?.suspendHotkeys()
             } else {
                 self?.hotkeyCoordinator?.resume()
+                self?.transformsCoordinator?.resumeHotkeys()
             }
         },
         onQuit: { [weak self] in

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -70,6 +70,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let chatViewModel = TranscriptChatViewModel()
     private let promptResultsViewModel = PromptResultsViewModel()
     private let promptsViewModel = PromptsViewModel()
+    private let transformsViewModel = TransformsViewModel()
     private let mainWindowState = MainWindowState()
     /// Long-lived companion for the meeting recording pill + Transcribe-tab tile.
     /// `MeetingRecordingFlowCoordinator` writes state into it; both the floating
@@ -97,6 +98,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         chatViewModel: chatViewModel,
         promptResultsViewModel: promptResultsViewModel,
         promptsViewModel: promptsViewModel,
+        transformsViewModel: transformsViewModel,
         mainWindowState: mainWindowState,
         meetingPillViewModel: meetingPillViewModel
     )
@@ -144,6 +146,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         chatViewModel: chatViewModel,
         promptResultsViewModel: promptResultsViewModel,
         promptsViewModel: promptsViewModel,
+        transformsViewModel: transformsViewModel,
         customWordsViewModel: customWordsViewModel,
         textSnippetsViewModel: textSnippetsViewModel,
         vocabularyBackupViewModel: vocabularyBackupViewModel,

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -42,6 +42,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// `docs/research/transforms-design-2026-05.md`). Always created; `start()`
     /// is a no-op when the flag is off so the binary surface stays clean.
     private var transformsSpikeCoordinator: TransformsSpikeCoordinator?
+    /// Productized Transforms coordinator (ADR-022). Owns the process-wide
+    /// `TransformsHotkeyRegistry` + dispatch from registered hotkeys to the
+    /// `TransformExecutor` pipeline. Gated on `AppFeatures.transformsEnabled`.
+    private var transformsCoordinator: TransformsCoordinator?
     private var hasPresentedHotkeyUnavailableAlert = false
     private var hasPresentedHotkeyConflictAlert = false
     private var environmentSetupTask: Task<Void, Never>?
@@ -278,6 +282,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         hotkeyCoordinator?.stopAll()
         meetingAutoStartCoordinator?.stop()
         transformsSpikeCoordinator?.stop()
+        transformsCoordinator?.stop()
         settingsObserverCoordinator.stopObserving()
         environmentSetupTask?.cancel()
         speechPreWarmTask?.cancel()
@@ -395,12 +400,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // flipped after launch.
         let configStore = env.llmConfigStore
         let llmService = env.llmService
-        let spike = TransformsSpikeCoordinator(llmServiceProvider: { [weak configStore, llmService] in
+        let llmServiceProvider: () -> LLMServiceProtocol? = { [weak configStore, llmService] in
             guard let configStore else { return nil }
             return (try? configStore.loadConfig()) != nil ? llmService : nil
-        })
+        }
+        let spike = TransformsSpikeCoordinator(llmServiceProvider: llmServiceProvider)
         spike.start()
         transformsSpikeCoordinator = spike
+
+        // Productized Transforms coordinator (ADR-022). Reads `.transform`
+        // prompts from the shared `PromptRepository` and dispatches their
+        // bound hotkeys through `TransformsHotkeyRegistry`. No-op when the
+        // feature flag is off.
+        let transforms = TransformsCoordinator(
+            llmServiceProvider: llmServiceProvider,
+            promptRepository: env.promptRepo
+        )
+        transforms.start()
+        transformsCoordinator = transforms
 
         menuBarCoordinator.refreshHotkeyTitle()
         menuBarCoordinator.refreshMeetingHotkeyShortcut()

--- a/Sources/MacParakeet/Hotkey/TransformsHotkeyRegistry+ViewModelAdapter.swift
+++ b/Sources/MacParakeet/Hotkey/TransformsHotkeyRegistry+ViewModelAdapter.swift
@@ -12,14 +12,14 @@ extension TransformsHotkeyCollisionChecker: TransformShortcutCollisionChecking {
         candidate: KeyboardShortcut,
         existing: [UUID: KeyboardShortcut],
         excludingPromptID: UUID?,
-        dictationHotkey: KeyboardShortcut?,
-        meetingHotkey: KeyboardShortcut?
+        dictationHotkeys: [HotkeyTrigger],
+        meetingHotkey: HotkeyTrigger?
     ) -> TransformShortcutCollision? {
         let result: TransformsHotkeyCollision? = self.check(
             candidate: candidate,
             existing: existing,
             excludingPromptID: excludingPromptID,
-            dictationHotkey: dictationHotkey,
+            dictationHotkeys: dictationHotkeys,
             meetingHotkey: meetingHotkey
         )
         switch result {

--- a/Sources/MacParakeet/Hotkey/TransformsHotkeyRegistry+ViewModelAdapter.swift
+++ b/Sources/MacParakeet/Hotkey/TransformsHotkeyRegistry+ViewModelAdapter.swift
@@ -1,0 +1,34 @@
+import Foundation
+import MacParakeetCore
+import MacParakeetViewModels
+
+/// Adapter that lets the editor sheet's ViewModel layer call into the
+/// GUI's `TransformsHotkeyCollisionChecker` without importing it
+/// (MacParakeetViewModels can't depend on MacParakeet — only the other
+/// way around). The protocol mirror is defined in
+/// `TransformEditorViewModel.swift`; this file is the binding.
+extension TransformsHotkeyCollisionChecker: TransformShortcutCollisionChecking {
+    public func checkForEditor(
+        candidate: KeyboardShortcut,
+        existing: [UUID: KeyboardShortcut],
+        excludingPromptID: UUID?,
+        dictationHotkey: KeyboardShortcut?,
+        meetingHotkey: KeyboardShortcut?
+    ) -> TransformShortcutCollision? {
+        let result: TransformsHotkeyCollision? = self.check(
+            candidate: candidate,
+            existing: existing,
+            excludingPromptID: excludingPromptID,
+            dictationHotkey: dictationHotkey,
+            meetingHotkey: meetingHotkey
+        )
+        switch result {
+        case nil: return nil
+        case .missingModifier: return .missingModifier
+        case .macOSDeadKey: return .macOSDeadKey
+        case .duplicateTransform(let id): return .duplicateTransform(otherPromptID: id)
+        case .dictationHotkey: return .dictationHotkey
+        case .meetingHotkey: return .meetingHotkey
+        }
+    }
+}

--- a/Sources/MacParakeet/Hotkey/TransformsHotkeyRegistry.swift
+++ b/Sources/MacParakeet/Hotkey/TransformsHotkeyRegistry.swift
@@ -153,7 +153,7 @@ public final class TransformsHotkeyRegistry {
 
     // MARK: - Event handling
 
-    private func handleEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+    func handleEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
             if let tap = eventTap {
                 CGEvent.tapEnable(tap: tap, enable: true)
@@ -177,10 +177,9 @@ public final class TransformsHotkeyRegistry {
             return nil
 
         case .keyUp:
-            pressedKeys.remove(keyCode)
             // Only swallow the keyUp if its keyDown had been ours.
-            let match = KeyMatch(keyCode: keyCode, modifierBits: modifierBits)
-            return dispatchTable[match] != nil ? nil : Unmanaged.passUnretained(event)
+            let wasPressedByTransform = pressedKeys.remove(keyCode) != nil
+            return wasPressedByTransform ? nil : Unmanaged.passUnretained(event)
 
         default:
             return Unmanaged.passUnretained(event)
@@ -249,8 +248,8 @@ public struct TransformsHotkeyCollisionChecker {
         candidate: KeyboardShortcut,
         existing: [UUID: KeyboardShortcut],
         excludingPromptID: UUID?,
-        dictationHotkey: KeyboardShortcut?,
-        meetingHotkey: KeyboardShortcut?
+        dictationHotkeys: [HotkeyTrigger],
+        meetingHotkey: HotkeyTrigger?
     ) -> TransformsHotkeyCollision? {
         guard candidate.hasModifier else { return .missingModifier }
         if candidate.isMacOSDeadKey { return .macOSDeadKey }
@@ -262,10 +261,11 @@ public struct TransformsHotkeyCollisionChecker {
             }
         }
 
-        if let dictation = dictationHotkey, matches(candidate, dictation) {
+        let candidateTrigger = candidate.hotkeyTrigger
+        for dictation in dictationHotkeys where candidateTrigger.overlaps(with: dictation) {
             return .dictationHotkey
         }
-        if let meeting = meetingHotkey, matches(candidate, meeting) {
+        if let meeting = meetingHotkey, candidateTrigger.overlaps(with: meeting) {
             return .meetingHotkey
         }
         return nil

--- a/Sources/MacParakeet/Hotkey/TransformsHotkeyRegistry.swift
+++ b/Sources/MacParakeet/Hotkey/TransformsHotkeyRegistry.swift
@@ -1,0 +1,279 @@
+import Cocoa
+import Foundation
+import MacParakeetCore
+
+/// Single process-wide event tap that dispatches keyboard chords to bound
+/// Transforms. Owns one `CGEventTap` and a `[KeyMatch: Prompt.ID]` dispatch
+/// table — replaces the per-Transform `GlobalShortcutManager` pattern that
+/// would compete on the same tap.
+///
+/// Each Transform's shortcut is a `KeyboardShortcut` (modifiers + virtual
+/// keycode + display label). The registry collapses that into an internal
+/// `KeyMatch(keyCode:modifierFlags:)` used for `O(1)` lookup on keyDown.
+///
+/// **Threading.** The CGEvent tap callback runs on the runloop that installed
+/// the tap (typically the main runloop). The registry's public `onTrigger`
+/// closure is invoked synchronously from that callback — callers should
+/// hop to `@MainActor` for any UI work, the same way
+/// `TransformsSpikeCoordinator` does for the spike's single hotkey.
+///
+/// See ADR-022 §4 for the architectural rationale (one tap, N transforms).
+public final class TransformsHotkeyRegistry {
+    /// Fired when a registered shortcut's keyDown event is observed.
+    /// The argument is the Prompt.ID bound to the shortcut.
+    public var onTrigger: ((UUID) -> Void)?
+
+    private struct KeyMatch: Hashable {
+        let keyCode: UInt16
+        /// Modifier flags, masked to the bits we care about
+        /// (Cmd/Option/Control/Shift). Same `relevantModifierBits` mask used
+        /// by `HotkeyTrigger` for chord matching elsewhere in the app.
+        let modifierBits: UInt64
+    }
+
+    private var dispatchTable: [KeyMatch: UUID] = [:]
+    private var pressedKeys: Set<UInt16> = []
+
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+    private var retainedSelf: Unmanaged<TransformsHotkeyRegistry>?
+    private var installedRunLoop: CFRunLoop?
+
+    public init() {}
+
+    deinit {
+        if let tap = eventTap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+        }
+        if let source = runLoopSource, let runLoop = installedRunLoop {
+            CFRunLoopRemoveSource(runLoop, source, .commonModes)
+        }
+        retainedSelf?.release()
+    }
+
+    // MARK: - Public API
+
+    /// Register or update the binding for a Transform. If `shortcut` is nil,
+    /// the Transform is unbound (its row stays in the DB; just no hotkey
+    /// dispatch). Replaces any existing binding for the same `promptID`.
+    public func register(promptID: UUID, shortcut: KeyboardShortcut?) {
+        // Drop any prior binding for this prompt.
+        unregister(promptID: promptID)
+        guard let shortcut else { return }
+        let match = KeyMatch(
+            keyCode: shortcut.keyCode,
+            modifierBits: cgFlags(for: shortcut.modifiers)
+        )
+        dispatchTable[match] = promptID
+    }
+
+    /// Remove any binding for the given Transform.
+    public func unregister(promptID: UUID) {
+        let staleMatches = dispatchTable.filter { $0.value == promptID }.keys
+        for key in staleMatches {
+            dispatchTable[key] = nil
+        }
+    }
+
+    /// Replace the entire binding set in one shot. Useful when the prompt
+    /// repository reloads after a save/delete/import.
+    public func replaceBindings(_ bindings: [UUID: KeyboardShortcut]) {
+        dispatchTable.removeAll(keepingCapacity: true)
+        for (promptID, shortcut) in bindings {
+            let match = KeyMatch(
+                keyCode: shortcut.keyCode,
+                modifierBits: cgFlags(for: shortcut.modifiers)
+            )
+            dispatchTable[match] = promptID
+        }
+    }
+
+    /// Returns true if no bindings are currently active.
+    public var isEmpty: Bool { dispatchTable.isEmpty }
+
+    // MARK: - Tap lifecycle
+
+    /// Install the system-wide event tap. Idempotent; safe to call again if
+    /// the tap was previously stopped.
+    @discardableResult
+    public func start() -> Bool {
+        if eventTap != nil {
+            stop()
+        }
+
+        let eventMask: CGEventMask = (1 << CGEventType.keyDown.rawValue)
+            | (1 << CGEventType.keyUp.rawValue)
+
+        guard let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: eventMask,
+            callback: { _, type, event, refcon -> Unmanaged<CGEvent>? in
+                guard let refcon else { return Unmanaged.passUnretained(event) }
+                let registry = Unmanaged<TransformsHotkeyRegistry>
+                    .fromOpaque(refcon)
+                    .takeUnretainedValue()
+                return registry.handleEvent(type: type, event: event)
+            },
+            userInfo: {
+                let retained = Unmanaged.passRetained(self)
+                self.retainedSelf = retained
+                return retained.toOpaque()
+            }()
+        ) else {
+            retainedSelf?.release()
+            retainedSelf = nil
+            return false
+        }
+
+        eventTap = tap
+        runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        let runLoop = CFRunLoopGetCurrent()
+        installedRunLoop = runLoop
+        CFRunLoopAddSource(runLoop, runLoopSource, .commonModes)
+        CGEvent.tapEnable(tap: tap, enable: true)
+        return true
+    }
+
+    public func stop() {
+        if let tap = eventTap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+        }
+        if let source = runLoopSource, let runLoop = installedRunLoop {
+            CFRunLoopRemoveSource(runLoop, source, .commonModes)
+        }
+        retainedSelf?.release()
+        retainedSelf = nil
+        eventTap = nil
+        runLoopSource = nil
+        installedRunLoop = nil
+        pressedKeys.removeAll(keepingCapacity: true)
+    }
+
+    // MARK: - Event handling
+
+    private func handleEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            if let tap = eventTap {
+                CGEvent.tapEnable(tap: tap, enable: true)
+            }
+            return Unmanaged.passUnretained(event)
+        }
+
+        let keyCode = UInt16(event.getIntegerValueField(.keyboardEventKeycode))
+        let modifierBits = event.flags.rawValue & HotkeyTrigger.relevantModifierBits
+
+        switch type {
+        case .keyDown:
+            let match = KeyMatch(keyCode: keyCode, modifierBits: modifierBits)
+            guard let promptID = dispatchTable[match] else {
+                return Unmanaged.passUnretained(event)
+            }
+            // Debounce: don't refire while the key is held.
+            guard !pressedKeys.contains(keyCode) else { return nil }
+            pressedKeys.insert(keyCode)
+            onTrigger?(promptID)
+            return nil
+
+        case .keyUp:
+            pressedKeys.remove(keyCode)
+            // Only swallow the keyUp if its keyDown had been ours.
+            let match = KeyMatch(keyCode: keyCode, modifierBits: modifierBits)
+            return dispatchTable[match] != nil ? nil : Unmanaged.passUnretained(event)
+
+        default:
+            return Unmanaged.passUnretained(event)
+        }
+    }
+
+    /// Map our NSEvent-compatible modifier bits to CGEventFlags bits. The
+    /// raw values are co-designed — `KeyboardShortcut.ModifierFlag`'s raw
+    /// values match `NSEvent.ModifierFlags`, which match the high bits of
+    /// `CGEventFlags`. So the mapping is identity on the relevant bits;
+    /// we just mask down to the bits the event tap reports.
+    private func cgFlags(for modifierBits: UInt) -> UInt64 {
+        UInt64(modifierBits) & HotkeyTrigger.relevantModifierBits
+    }
+}
+
+// MARK: - Collision detection
+
+/// Pure functions for validating a candidate Transform shortcut. Lives next
+/// to the registry so the editor sheet can call into it without owning a
+/// live event tap.
+public enum TransformsHotkeyCollision: Equatable, Sendable {
+    /// Bare-key bindings are rejected. Every Transform shortcut must include
+    /// at least one modifier (Cmd, Option, Control, or Shift) — matches the
+    /// "Shortcut must include modifier key…" constraint surfaced by
+    /// reference implementations.
+    case missingModifier
+    /// macOS Opt+letter combos that produce alt-characters (Opt+e, Opt+u,
+    /// Opt+i, Opt+n, Opt+`). Stealing these breaks the user's typing of
+    /// accented characters across the entire OS.
+    case macOSDeadKey
+    /// Another Transform already binds this combo.
+    case duplicateTransform(otherPromptID: UUID)
+    /// The user's dictation hotkey conflicts with this combo.
+    case dictationHotkey
+    /// The user's meeting-toggle hotkey conflicts with this combo.
+    case meetingHotkey
+
+    public var message: String {
+        switch self {
+        case .missingModifier:
+            return "Shortcut must include a modifier key (⌃, ⌥, ⇧, or ⌘)."
+        case .macOSDeadKey:
+            return "This shortcut produces a special character on Mac (\u{2325} dead-key). Pick another combo."
+        case .duplicateTransform:
+            return "Another Transform already uses this shortcut."
+        case .dictationHotkey:
+            return "This shortcut conflicts with your dictation hotkey."
+        case .meetingHotkey:
+            return "This shortcut conflicts with your meeting recording hotkey."
+        }
+    }
+}
+
+public struct TransformsHotkeyCollisionChecker {
+    public init() {}
+
+    /// Validate a candidate shortcut against the current set of bindings
+    /// and known system hotkeys. Returns nil if the shortcut is acceptable,
+    /// or a `TransformsHotkeyCollision` describing the first problem found.
+    ///
+    /// `excludingPromptID` is the prompt being edited — its existing
+    /// binding is ignored so re-saving a Transform without changing its
+    /// shortcut doesn't read as a duplicate.
+    public func check(
+        candidate: KeyboardShortcut,
+        existing: [UUID: KeyboardShortcut],
+        excludingPromptID: UUID?,
+        dictationHotkey: KeyboardShortcut?,
+        meetingHotkey: KeyboardShortcut?
+    ) -> TransformsHotkeyCollision? {
+        guard candidate.hasModifier else { return .missingModifier }
+        if candidate.isMacOSDeadKey { return .macOSDeadKey }
+
+        for (otherID, other) in existing {
+            if let exclude = excludingPromptID, exclude == otherID { continue }
+            if matches(candidate, other) {
+                return .duplicateTransform(otherPromptID: otherID)
+            }
+        }
+
+        if let dictation = dictationHotkey, matches(candidate, dictation) {
+            return .dictationHotkey
+        }
+        if let meeting = meetingHotkey, matches(candidate, meeting) {
+            return .meetingHotkey
+        }
+        return nil
+    }
+
+    /// Two shortcuts match if their modifier bits AND their virtual key code
+    /// are identical. Display label is for humans only.
+    private func matches(_ lhs: KeyboardShortcut, _ rhs: KeyboardShortcut) -> Bool {
+        lhs.keyCode == rhs.keyCode && lhs.modifiers == rhs.modifiers
+    }
+}

--- a/Sources/MacParakeet/Hotkey/TransformsShortcutAlias.swift
+++ b/Sources/MacParakeet/Hotkey/TransformsShortcutAlias.swift
@@ -1,0 +1,7 @@
+import MacParakeetCore
+
+/// SwiftUI also defines a `KeyboardShortcut` type (used by `.keyboardShortcut`
+/// view modifiers). The Transforms feature uses MacParakeetCore's storage-
+/// shaped `KeyboardShortcut` — bind a stable alias so SwiftUI files don't
+/// need to fully qualify every reference.
+typealias TransformShortcut = MacParakeetCore.KeyboardShortcut

--- a/Sources/MacParakeet/Views/MainWindowState.swift
+++ b/Sources/MacParakeet/Views/MainWindowState.swift
@@ -1,10 +1,17 @@
 import Foundation
+import MacParakeetCore
 
 @MainActor
 @Observable
 final class MainWindowState {
     var selectedItem: SidebarItem = .transcribe
     var showingProgressDetail = false
+
+    /// Transforms tab — pending sheet state (ADR-022). When non-nil the
+    /// editor sheet appears for that Transform.
+    var editingTransform: Prompt?
+    /// True when the Create-your-own sheet should be presented.
+    var isCreatingTransform: Bool = false
 
     /// Switch the sidebar to Library so the transcription detail surfaces in
     /// its natural home. The Transcribe tab is the capture surface (YouTube,
@@ -14,5 +21,12 @@ final class MainWindowState {
         _ = current
         selectedItem = .library
     }
+}
+
+extension Notification.Name {
+    /// Posted after a Transforms save/delete/reset so the
+    /// `TransformsCoordinator` can reload bindings into the hotkey
+    /// registry.
+    static let transformsBindingsChanged = Notification.Name("com.macparakeet.transforms.bindingsChanged")
 }
 

--- a/Sources/MacParakeet/Views/MainWindowView.swift
+++ b/Sources/MacParakeet/Views/MainWindowView.swift
@@ -162,8 +162,12 @@ struct MainWindowView: View {
                             TransformEditorSheet(
                                 viewModel: TransformEditorViewModel(mode: .create),
                                 existingTransforms: transformsViewModel.transforms,
-                                dictationHotkey: nil,
-                                meetingHotkey: nil,
+                                dictationHotkeys: [
+                                    settingsViewModel.hotkeyTrigger,
+                                    settingsViewModel.pushToTalkHotkeyTrigger,
+                                ],
+                                meetingHotkey: settingsViewModel.meetingHotkeyTrigger,
+                                onShortcutRecordingStateChanged: onHotkeyRecordingStateChanged,
                                 onSave: { prompt in
                                     if transformsViewModel.save(prompt) {
                                         state.isCreatingTransform = false
@@ -178,8 +182,12 @@ struct MainWindowView: View {
                             TransformEditorSheet(
                                 viewModel: TransformEditorViewModel(mode: .edit(transform)),
                                 existingTransforms: transformsViewModel.transforms,
-                                dictationHotkey: nil,
-                                meetingHotkey: nil,
+                                dictationHotkeys: [
+                                    settingsViewModel.hotkeyTrigger,
+                                    settingsViewModel.pushToTalkHotkeyTrigger,
+                                ],
+                                meetingHotkey: settingsViewModel.meetingHotkeyTrigger,
+                                onShortcutRecordingStateChanged: onHotkeyRecordingStateChanged,
                                 onSave: { prompt in
                                     if transformsViewModel.save(prompt) {
                                         state.editingTransform = nil

--- a/Sources/MacParakeet/Views/MainWindowView.swift
+++ b/Sources/MacParakeet/Views/MainWindowView.swift
@@ -7,6 +7,7 @@ enum SidebarItem: String, CaseIterable, Identifiable {
     case transcribe = "Transcribe"
     case library = "Library"
     case dictations = "Dictations"
+    case transforms = "Transforms"
     case vocabulary = "Vocabulary"
     case feedback = "Feedback"
     case settings = "Settings"
@@ -19,6 +20,7 @@ enum SidebarItem: String, CaseIterable, Identifiable {
         case .transcribe: return "waveform"
         case .library: return "square.grid.2x2"
         case .dictations: return "clock.arrow.circlepath"
+        case .transforms: return "wand.and.stars"
         case .vocabulary: return "book.fill"
         case .feedback: return "bubble.left.and.text.bubble.right"
         case .settings: return "gearshape"
@@ -31,8 +33,15 @@ enum SidebarItem: String, CaseIterable, Identifiable {
     /// on); meeting browse lives in `Library` under the `Meetings` filter.
     static let primaryItems: [SidebarItem] = [.transcribe, .library, .dictations]
 
-    /// Configuration and support items
-    static let configItems: [SidebarItem] = [.vocabulary, .feedback, .settings]
+    /// Configuration and support items. Transforms (ADR-022) is inserted
+    /// here at runtime when `AppFeatures.transformsEnabled == true`.
+    static var configItems: [SidebarItem] {
+        var items: [SidebarItem] = [.vocabulary, .feedback, .settings]
+        if AppFeatures.transformsEnabled {
+            items.insert(.transforms, at: 0)
+        }
+        return items
+    }
 
     /// Note: `.discover` is intentionally excluded from the arrays above.
     /// It renders as a pinned card below the sidebar list via `safeAreaInset`.
@@ -48,6 +57,7 @@ struct MainWindowView: View {
     let chatViewModel: TranscriptChatViewModel
     let promptResultsViewModel: PromptResultsViewModel
     let promptsViewModel: PromptsViewModel
+    let transformsViewModel: TransformsViewModel
     let customWordsViewModel: CustomWordsViewModel
     let textSnippetsViewModel: TextSnippetsViewModel
     let vocabularyBackupViewModel: VocabularyBackupViewModel
@@ -138,6 +148,52 @@ struct MainWindowView: View {
                         }
                     case .dictations:
                         DictationHistoryView(viewModel: historyViewModel)
+                    case .transforms:
+                        TransformsView(
+                            viewModel: transformsViewModel,
+                            llmConfiguredAction: { state.selectedItem = .settings },
+                            onEdit: { state.editingTransform = $0 },
+                            onCreate: { state.isCreatingTransform = true },
+                            onBindingsChanged: {
+                                NotificationCenter.default.post(name: .transformsBindingsChanged, object: nil)
+                            }
+                        )
+                        .sheet(isPresented: $state.isCreatingTransform) {
+                            TransformEditorSheet(
+                                viewModel: TransformEditorViewModel(mode: .create),
+                                existingTransforms: transformsViewModel.transforms,
+                                dictationHotkey: nil,
+                                meetingHotkey: nil,
+                                onSave: { prompt in
+                                    if transformsViewModel.save(prompt) {
+                                        state.isCreatingTransform = false
+                                        NotificationCenter.default.post(name: .transformsBindingsChanged, object: nil)
+                                    }
+                                },
+                                onCancel: { state.isCreatingTransform = false },
+                                onReset: nil
+                            )
+                        }
+                        .sheet(item: $state.editingTransform) { transform in
+                            TransformEditorSheet(
+                                viewModel: TransformEditorViewModel(mode: .edit(transform)),
+                                existingTransforms: transformsViewModel.transforms,
+                                dictationHotkey: nil,
+                                meetingHotkey: nil,
+                                onSave: { prompt in
+                                    if transformsViewModel.save(prompt) {
+                                        state.editingTransform = nil
+                                        NotificationCenter.default.post(name: .transformsBindingsChanged, object: nil)
+                                    }
+                                },
+                                onCancel: { state.editingTransform = nil },
+                                onReset: transform.isBuiltIn ? {
+                                    transformsViewModel.resetBuiltIn(transform)
+                                    state.editingTransform = nil
+                                    NotificationCenter.default.post(name: .transformsBindingsChanged, object: nil)
+                                } : nil
+                            )
+                        }
                     case .vocabulary:
                         VocabularyView(
                             settingsViewModel: settingsViewModel,

--- a/Sources/MacParakeet/Views/Transforms/TransformEditorSheet.swift
+++ b/Sources/MacParakeet/Views/Transforms/TransformEditorSheet.swift
@@ -15,8 +15,9 @@ import MacParakeetViewModels
 struct TransformEditorSheet: View {
     @Bindable var viewModel: TransformEditorViewModel
     let existingTransforms: [Prompt]
-    let dictationHotkey: TransformShortcut?
-    let meetingHotkey: TransformShortcut?
+    let dictationHotkeys: [HotkeyTrigger]
+    let meetingHotkey: HotkeyTrigger?
+    let onShortcutRecordingStateChanged: (Bool) -> Void
     let onSave: (Prompt) -> Void
     let onCancel: () -> Void
     let onReset: (() -> Void)?
@@ -107,7 +108,8 @@ struct TransformEditorSheet: View {
             VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
                 ShortcutRecorderField(
                     shortcut: $viewModel.shortcut,
-                    isRecording: $isRecordingShortcut
+                    isRecording: $isRecordingShortcut,
+                    onRecordingStateChanged: onShortcutRecordingStateChanged
                 )
                 .onChange(of: viewModel.shortcut) { _, _ in revalidate() }
 
@@ -204,7 +206,7 @@ struct TransformEditorSheet: View {
     private func revalidate() {
         viewModel.validate(
             existingTransforms: existingTransforms,
-            dictationHotkey: dictationHotkey,
+            dictationHotkeys: dictationHotkeys,
             meetingHotkey: meetingHotkey,
             collisionChecker: collisionChecker
         )
@@ -260,7 +262,9 @@ private struct ValidationRow: View {
 struct ShortcutRecorderField: View {
     @Binding var shortcut: TransformShortcut?
     @Binding var isRecording: Bool
+    let onRecordingStateChanged: (Bool) -> Void
     @State private var localMonitor: Any?
+    @State private var notifiedRecordingActive = false
 
     var body: some View {
         HStack {
@@ -311,12 +315,14 @@ struct ShortcutRecorderField: View {
         }
         .onChange(of: isRecording) { _, recording in
             if recording {
+                notifyRecordingState(true)
                 installMonitor()
             } else {
                 removeMonitor()
+                notifyRecordingState(false)
             }
         }
-        .onDisappear { removeMonitor() }
+        .onDisappear { stopRecordingIfNeeded() }
     }
 
     private func installMonitor() {
@@ -340,6 +346,20 @@ struct ShortcutRecorderField: View {
             NSEvent.removeMonitor(monitor)
             localMonitor = nil
         }
+    }
+
+    private func stopRecordingIfNeeded() {
+        if isRecording {
+            isRecording = false
+        }
+        removeMonitor()
+        notifyRecordingState(false)
+    }
+
+    private func notifyRecordingState(_ active: Bool) {
+        guard notifiedRecordingActive != active else { return }
+        notifiedRecordingActive = active
+        onRecordingStateChanged(active)
     }
 
     private func labelForKey(event: NSEvent) -> String {

--- a/Sources/MacParakeet/Views/Transforms/TransformEditorSheet.swift
+++ b/Sources/MacParakeet/Views/Transforms/TransformEditorSheet.swift
@@ -1,0 +1,365 @@
+import SwiftUI
+import MacParakeetCore
+import MacParakeetViewModels
+
+/// Modal sheet for Create-your-own and Edit-Transform flows (ADR-022).
+///
+/// Two-column layout: framing copy on the left (~32% width), three stacked
+/// field cards on the right (Name → Keyboard shortcut → Customize prompt
+/// → optional Running label). Footer: *Autosave On* indicator on builtins,
+/// Cancel + Save on the right.
+///
+/// Validation is reactive — fires on every field change after the first
+/// interaction, surfacing per-card error rows. Save button gates on
+/// `viewModel.isValid`.
+struct TransformEditorSheet: View {
+    @Bindable var viewModel: TransformEditorViewModel
+    let existingTransforms: [Prompt]
+    let dictationHotkey: TransformShortcut?
+    let meetingHotkey: TransformShortcut?
+    let onSave: (Prompt) -> Void
+    let onCancel: () -> Void
+    let onReset: (() -> Void)?
+
+    @State private var isRecordingShortcut = false
+    private let collisionChecker = TransformsHotkeyCollisionChecker()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(alignment: .top, spacing: 0) {
+                leftRail
+                    .frame(width: 280)
+                    .padding(DesignSystem.Spacing.xl)
+
+                Divider()
+
+                ScrollView {
+                    VStack(spacing: DesignSystem.Spacing.lg) {
+                        nameCard
+                        shortcutCard
+                        contentCard
+                        runningLabelCard
+                    }
+                    .padding(DesignSystem.Spacing.xl)
+                }
+                .frame(maxWidth: .infinity)
+                .background(DesignSystem.Colors.surfaceElevated.opacity(0.3))
+            }
+            .frame(maxHeight: .infinity)
+
+            Divider()
+            footer
+        }
+        .frame(minWidth: 760, idealWidth: 880, minHeight: 540, idealHeight: 620)
+        .background(DesignSystem.Colors.surface)
+    }
+
+    // MARK: - Sections
+
+    @ViewBuilder
+    private var leftRail: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+            Text(viewModel.mode.isCreating ? "Create your own" : "Edit Transform")
+                .font(DesignSystem.Typography.heroTitle)
+                .foregroundStyle(DesignSystem.Colors.textPrimary)
+
+            Text("Set up a keyboard shortcut and a prompt. MacParakeet runs the prompt against your selected text every time you press the shortcut.")
+                .font(DesignSystem.Typography.body)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+
+            Spacer(minLength: 0)
+
+            if viewModel.isBuiltIn {
+                Label("Built-in Transform — you can edit it freely. Your changes survive app launches.", systemImage: "checkmark.seal")
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textTertiary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var nameCard: some View {
+        EditorCard(title: "Name your Transform shortcut") {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
+                TextField("Boss Mode", text: $viewModel.name)
+                    .textFieldStyle(.plain)
+                    .font(DesignSystem.Typography.bodyLarge)
+                    .padding(.horizontal, DesignSystem.Spacing.md)
+                    .padding(.vertical, DesignSystem.Spacing.sm + 2)
+                    .background(DesignSystem.Colors.surface)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(DesignSystem.Colors.border, lineWidth: 0.5)
+                    }
+                    .onChange(of: viewModel.name) { _, _ in revalidate() }
+
+                if let error = viewModel.nameError {
+                    ValidationRow(message: error)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var shortcutCard: some View {
+        EditorCard(title: "Choose a keyboard shortcut") {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
+                ShortcutRecorderField(
+                    shortcut: $viewModel.shortcut,
+                    isRecording: $isRecordingShortcut
+                )
+                .onChange(of: viewModel.shortcut) { _, _ in revalidate() }
+
+                if let error = viewModel.shortcutError {
+                    ValidationRow(message: error)
+                } else if viewModel.shortcut == nil {
+                    Text("Optional — leave empty to keep this Transform dormant.")
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(DesignSystem.Colors.textTertiary)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var contentCard: some View {
+        EditorCard(title: "Customize prompt") {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
+                TextEditor(text: $viewModel.content)
+                    .font(DesignSystem.Typography.body)
+                    .scrollContentBackground(.hidden)
+                    .padding(DesignSystem.Spacing.sm)
+                    .frame(minHeight: 180)
+                    .background(DesignSystem.Colors.surface)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(DesignSystem.Colors.border, lineWidth: 0.5)
+                    }
+                    .onChange(of: viewModel.content) { _, _ in revalidate() }
+
+                if let error = viewModel.contentError {
+                    ValidationRow(message: error)
+                } else {
+                    Text("Tell the LLM how to change the selected text. Be specific — the prompt runs verbatim on every press.")
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(DesignSystem.Colors.textTertiary)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var runningLabelCard: some View {
+        EditorCard(title: "Running label (optional)") {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
+                TextField("Polishing\u{2026}", text: $viewModel.runningLabel)
+                    .textFieldStyle(.plain)
+                    .font(DesignSystem.Typography.body)
+                    .padding(.horizontal, DesignSystem.Spacing.md)
+                    .padding(.vertical, DesignSystem.Spacing.sm)
+                    .background(DesignSystem.Colors.surface)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(DesignSystem.Colors.border, lineWidth: 0.5)
+                    }
+                Text("Shown in the floating pill while this Transform runs. Defaults to “\(viewModel.normalizedName.isEmpty ? "Transforming\u{2026}" : "\(viewModel.normalizedName)ing\u{2026}")”.")
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textTertiary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var footer: some View {
+        HStack(spacing: DesignSystem.Spacing.md) {
+            if let onReset, viewModel.isBuiltIn {
+                Button("Reset to default", action: onReset)
+                    .parakeetAction(.subtle)
+            }
+
+            Spacer()
+
+            Button("Cancel", action: onCancel)
+                .parakeetAction(.secondary)
+                .keyboardShortcut(.cancelAction)
+
+            Button(viewModel.mode.isCreating ? "Create Transform" : "Save Changes") {
+                guard let prompt = viewModel.buildSavable() else { return }
+                onSave(prompt)
+            }
+            .parakeetAction(.primary)
+            .disabled(!viewModel.isValid)
+            .keyboardShortcut(.defaultAction)
+        }
+        .padding(.horizontal, DesignSystem.Spacing.xl)
+        .padding(.vertical, DesignSystem.Spacing.md)
+        .background(DesignSystem.Colors.surface)
+    }
+
+    // MARK: - Validation hook
+
+    private func revalidate() {
+        viewModel.validate(
+            existingTransforms: existingTransforms,
+            dictationHotkey: dictationHotkey,
+            meetingHotkey: meetingHotkey,
+            collisionChecker: collisionChecker
+        )
+    }
+}
+
+// MARK: - Editor card chrome
+
+private struct EditorCard<Content: View>: View {
+    let title: String
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            Text(title)
+                .font(DesignSystem.Typography.sectionTitle)
+                .foregroundStyle(DesignSystem.Colors.textPrimary)
+            content
+        }
+        .padding(DesignSystem.Spacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(DesignSystem.Colors.surfaceElevated.opacity(0.45))
+        .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius))
+        .overlay {
+            RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
+                .stroke(DesignSystem.Colors.border, lineWidth: 0.5)
+        }
+    }
+}
+
+private struct ValidationRow: View {
+    let message: String
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 11))
+                .foregroundStyle(DesignSystem.Colors.warningAmber)
+            Text(message)
+                .font(DesignSystem.Typography.caption)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+        }
+        .padding(.top, 2)
+    }
+}
+
+// MARK: - Shortcut recorder field
+//
+// Lightweight recorder that listens for the next key chord while focused.
+// Keeps the AppKit-level NSEvent monitor scoped to its focused state, so
+// the surrounding sheet keeps normal text-field behaviour.
+
+struct ShortcutRecorderField: View {
+    @Binding var shortcut: TransformShortcut?
+    @Binding var isRecording: Bool
+    @State private var localMonitor: Any?
+
+    var body: some View {
+        HStack {
+            Group {
+                if let shortcut {
+                    HStack(spacing: 6) {
+                        KeycapBadge(shortcut: shortcut)
+                        Text(shortcut.keyLabel.uppercased())
+                            .font(DesignSystem.Typography.bodySmall.monospacedDigit())
+                            .foregroundStyle(DesignSystem.Colors.textTertiary)
+                            .accessibilityHidden(true)
+                    }
+                } else {
+                    Text(isRecording ? "Press a keyboard combo\u{2026}" : "Click to add a shortcut")
+                        .font(DesignSystem.Typography.body)
+                        .foregroundStyle(isRecording ? DesignSystem.Colors.accent : DesignSystem.Colors.textSecondary)
+                }
+            }
+            Spacer()
+            Button(action: { isRecording.toggle() }) {
+                Image(systemName: isRecording ? "stop.circle" : "pencil")
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+            }
+            .buttonStyle(.plain)
+            if shortcut != nil {
+                Button(action: { shortcut = nil }) {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(DesignSystem.Colors.textTertiary)
+                }
+                .buttonStyle(.plain)
+                .help("Clear shortcut")
+            }
+        }
+        .padding(.horizontal, DesignSystem.Spacing.md)
+        .padding(.vertical, DesignSystem.Spacing.sm + 2)
+        .background(DesignSystem.Colors.surface)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(
+                    isRecording ? DesignSystem.Colors.accent : DesignSystem.Colors.border,
+                    lineWidth: isRecording ? 1.0 : 0.5
+                )
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            isRecording.toggle()
+        }
+        .onChange(of: isRecording) { _, recording in
+            if recording {
+                installMonitor()
+            } else {
+                removeMonitor()
+            }
+        }
+        .onDisappear { removeMonitor() }
+    }
+
+    private func installMonitor() {
+        removeMonitor()
+        localMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { event in
+            let modifierBits = UInt(event.modifierFlags.intersection([.command, .option, .control, .shift]).rawValue)
+            let keyCode = event.keyCode
+            let label = labelForKey(event: event)
+            shortcut = TransformShortcut(
+                modifiers: modifierBits,
+                keyCode: keyCode,
+                keyLabel: label
+            )
+            isRecording = false
+            return nil // swallow the event
+        }
+    }
+
+    private func removeMonitor() {
+        if let monitor = localMonitor {
+            NSEvent.removeMonitor(monitor)
+            localMonitor = nil
+        }
+    }
+
+    private func labelForKey(event: NSEvent) -> String {
+        if let chars = event.charactersIgnoringModifiers, !chars.isEmpty {
+            let scalar = chars.first!
+            // Map common control codes to display names.
+            switch event.keyCode {
+            case 0x24: return "Return"
+            case 0x30: return "Tab"
+            case 0x31: return "Space"
+            case 0x35: return "Escape"
+            default:
+                if scalar.isLetter || scalar.isNumber {
+                    return String(scalar).uppercased()
+                }
+                if scalar.asciiValue.map({ $0 >= 32 }) ?? false {
+                    return String(scalar)
+                }
+            }
+        }
+        return "Key \(event.keyCode)"
+    }
+}

--- a/Sources/MacParakeet/Views/Transforms/TransformsView.swift
+++ b/Sources/MacParakeet/Views/Transforms/TransformsView.swift
@@ -1,0 +1,365 @@
+import SwiftUI
+import MacParakeetCore
+import MacParakeetViewModels
+
+/// The **Transforms** tab — top-level sidebar destination (ADR-022).
+///
+/// Layout: hero strip → My Transforms grid (3-up cards + Create-your-own
+/// tile) → footer with reseed-missing affordance. Calmer no-provider
+/// banner replaces the hero when no LLM is configured.
+///
+/// Visual continuity: rounded display type (no serif — we use
+/// `.rounded` system font, not a literal serif copy of the reference
+/// screenshots), warm coral accent only on the keycap badges + primary
+/// CTAs, generous whitespace, hover lift on cards via the existing
+/// `cardRest`/`cardHover` shadow tokens.
+struct TransformsView: View {
+    @Bindable var viewModel: TransformsViewModel
+    let llmConfiguredAction: () -> Void
+    let onEdit: (Prompt) -> Void
+    let onCreate: () -> Void
+    let onBindingsChanged: () -> Void
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.xl) {
+                heroHeader
+
+                if viewModel.hasLLMProvider {
+                    heroExplainer
+                } else {
+                    noProviderBanner
+                }
+
+                myTransformsHeader
+                transformGrid
+
+                footerActions
+            }
+            .padding(.horizontal, DesignSystem.Spacing.xl)
+            .padding(.vertical, DesignSystem.Spacing.lg)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(DesignSystem.Colors.background)
+        .alert(
+            "Delete this Transform?",
+            isPresented: Binding(
+                get: { viewModel.pendingDeleteTransform != nil },
+                set: { if !$0 { viewModel.pendingDeleteTransform = nil } }
+            ),
+            presenting: viewModel.pendingDeleteTransform
+        ) { transform in
+            Button("Delete", role: .destructive) {
+                viewModel.confirmPendingDelete()
+                onBindingsChanged()
+            }
+            Button("Cancel", role: .cancel) {
+                viewModel.pendingDeleteTransform = nil
+            }
+        } message: { transform in
+            Text("“\(transform.name)” will be removed. You can re-create it later.")
+        }
+    }
+
+    // MARK: - Sections
+
+    @ViewBuilder
+    private var heroHeader: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            Text("Transforms")
+                .font(DesignSystem.Typography.heroTitle)
+                .foregroundStyle(DesignSystem.Colors.textPrimary)
+
+            Text("Press a hotkey on any selected text to rewrite it through your LLM provider — in Slack, Notes, Gmail, your editor, anywhere on Mac.")
+                .font(DesignSystem.Typography.bodyLarge)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+                .frame(maxWidth: 640, alignment: .leading)
+        }
+        .padding(.top, DesignSystem.Spacing.md)
+    }
+
+    @ViewBuilder
+    private var heroExplainer: some View {
+        HStack(alignment: .top, spacing: DesignSystem.Spacing.lg) {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+                Label("Highlight any text on your Mac.", systemImage: "1.circle.fill")
+                    .font(DesignSystem.Typography.body)
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+                Label("Press a Transform's hotkey (⌥1, ⌥2, ⌥3, …).", systemImage: "2.circle.fill")
+                    .font(DesignSystem.Typography.body)
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+                Label("The selection is rewritten in place. ⌘Z to undo.", systemImage: "3.circle.fill")
+                    .font(DesignSystem.Typography.body)
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+            }
+            .padding(.vertical, DesignSystem.Spacing.lg)
+            .padding(.horizontal, DesignSystem.Spacing.lg)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(DesignSystem.Colors.surfaceElevated)
+            .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius))
+            .overlay {
+                RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
+                    .stroke(DesignSystem.Colors.border, lineWidth: 0.5)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var noProviderBanner: some View {
+        HStack(alignment: .center, spacing: DesignSystem.Spacing.md) {
+            Image(systemName: "wand.and.stars")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(DesignSystem.Colors.accent)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Add an LLM provider to apply Transforms")
+                    .font(DesignSystem.Typography.body.weight(.semibold))
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+                Text("Transforms call your LLM provider on each run. Use Claude, GPT, Ollama, LM Studio — your key, your terms.")
+                    .font(DesignSystem.Typography.bodySmall)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+            }
+
+            Spacer(minLength: DesignSystem.Spacing.md)
+
+            Button("Open Settings", action: llmConfiguredAction)
+                .parakeetAction(.primary)
+        }
+        .padding(DesignSystem.Spacing.lg)
+        .background(DesignSystem.Colors.accentLight)
+        .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius))
+        .overlay {
+            RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
+                .stroke(DesignSystem.Colors.accent.opacity(0.25), lineWidth: 0.5)
+        }
+    }
+
+    @ViewBuilder
+    private var myTransformsHeader: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text("My Transforms")
+                .font(DesignSystem.Typography.pageTitle)
+                .foregroundStyle(DesignSystem.Colors.textPrimary)
+            Spacer()
+            Button(action: onCreate) {
+                Label("Create New", systemImage: "plus")
+            }
+            .parakeetAction(.primary)
+        }
+    }
+
+    @ViewBuilder
+    private var transformGrid: some View {
+        let columns = [
+            GridItem(.adaptive(minimum: 260, maximum: 360), spacing: DesignSystem.Spacing.md, alignment: .top)
+        ]
+        LazyVGrid(columns: columns, alignment: .leading, spacing: DesignSystem.Spacing.md) {
+            ForEach(viewModel.transforms) { transform in
+                TransformCard(
+                    transform: transform,
+                    onEdit: { onEdit(transform) },
+                    onDelete: {
+                        viewModel.pendingDeleteTransform = transform
+                    },
+                    onReset: {
+                        viewModel.resetBuiltIn(transform)
+                        onBindingsChanged()
+                    }
+                )
+            }
+
+            CreateYourOwnTile(action: onCreate)
+        }
+    }
+
+    @ViewBuilder
+    private var footerActions: some View {
+        HStack(spacing: DesignSystem.Spacing.md) {
+            Button(action: {
+                viewModel.reseedMissingBuiltIns()
+                onBindingsChanged()
+            }) {
+                Label("Restore missing defaults", systemImage: "arrow.counterclockwise")
+            }
+            .parakeetAction(.subtle)
+            Spacer()
+        }
+        .padding(.top, DesignSystem.Spacing.md)
+    }
+}
+
+// MARK: - Transform card
+
+private struct TransformCard: View {
+    let transform: Prompt
+    let onEdit: () -> Void
+    let onDelete: () -> Void
+    let onReset: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: onEdit) {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+                HStack(alignment: .center, spacing: DesignSystem.Spacing.sm) {
+                    if let shortcut = transform.shortcut {
+                        KeycapBadge(shortcut: shortcut)
+                    } else {
+                        UnboundShortcutChip()
+                    }
+                    Spacer()
+                    if isHovered {
+                        cardActions
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(transform.name)
+                        .font(DesignSystem.Typography.sectionTitle)
+                        .foregroundStyle(DesignSystem.Colors.textPrimary)
+                        .lineLimit(1)
+                    Text(firstSentence(of: transform.content))
+                        .font(DesignSystem.Typography.bodySmall)
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+                        .lineLimit(3, reservesSpace: true)
+                        .multilineTextAlignment(.leading)
+                }
+            }
+            .padding(DesignSystem.Spacing.lg)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(DesignSystem.Colors.cardBackground)
+            .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius))
+            .overlay {
+                RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
+                    .stroke(isHovered ? DesignSystem.Colors.accent.opacity(0.35) : DesignSystem.Colors.border, lineWidth: 0.5)
+            }
+            .shadow(
+                color: (isHovered ? DesignSystem.Shadows.cardHover : DesignSystem.Shadows.cardRest).color,
+                radius: (isHovered ? DesignSystem.Shadows.cardHover : DesignSystem.Shadows.cardRest).radius,
+                y: (isHovered ? DesignSystem.Shadows.cardHover : DesignSystem.Shadows.cardRest).y
+            )
+            .animation(DesignSystem.Animation.hoverTransition, value: isHovered)
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+    }
+
+    @ViewBuilder
+    private var cardActions: some View {
+        HStack(spacing: 4) {
+            if transform.isBuiltIn {
+                Button("Reset", action: onReset)
+                    .parakeetAction(.subtle)
+                    .controlSize(.small)
+            } else {
+                Button(action: onDelete) {
+                    Image(systemName: "trash")
+                }
+                .parakeetAction(.subtle)
+                .controlSize(.small)
+                .help("Delete this Transform")
+            }
+        }
+        .transition(.opacity)
+    }
+
+    private func firstSentence(of body: String) -> String {
+        let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let endIndex = trimmed.firstIndex(where: { ".!?".contains($0) }) else {
+            return trimmed
+        }
+        return String(trimmed[..<endIndex]) + "."
+    }
+}
+
+// MARK: - Create-your-own tile
+
+private struct CreateYourOwnTile: View {
+    let action: () -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: DesignSystem.Spacing.md) {
+                Image(systemName: "plus")
+                    .font(.system(size: 22, weight: .medium))
+                    .foregroundStyle(isHovered ? DesignSystem.Colors.accent : DesignSystem.Colors.textTertiary)
+                Text("Create your own")
+                    .font(DesignSystem.Typography.sectionTitle)
+                    .foregroundStyle(isHovered ? DesignSystem.Colors.textPrimary : DesignSystem.Colors.textSecondary)
+                Text("Upload your own prompt")
+                    .font(DesignSystem.Typography.bodySmall)
+                    .foregroundStyle(DesignSystem.Colors.textTertiary)
+            }
+            .padding(DesignSystem.Spacing.lg)
+            .frame(maxWidth: .infinity, minHeight: 168, alignment: .center)
+            .background(isHovered ? DesignSystem.Colors.accentLight : DesignSystem.Colors.surfaceElevated.opacity(0.4))
+            .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius))
+            .overlay {
+                RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
+                    .strokeBorder(
+                        isHovered ? DesignSystem.Colors.accent.opacity(0.6) : DesignSystem.Colors.border,
+                        style: StrokeStyle(lineWidth: 1.0, dash: [4, 4])
+                    )
+            }
+            .animation(DesignSystem.Animation.hoverTransition, value: isHovered)
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+    }
+}
+
+// MARK: - Keycap badge
+
+struct KeycapBadge: View {
+    let shortcut: TransformShortcut
+
+    var body: some View {
+        HStack(spacing: 4) {
+            ForEach(orderedModifierGlyphs, id: \.self) { glyph in
+                Text(glyph)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    .frame(minWidth: 22, minHeight: 22)
+                    .padding(.horizontal, 6)
+                    .background(DesignSystem.Colors.surfaceElevated)
+                    .clipShape(RoundedRectangle(cornerRadius: 5))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 5)
+                            .stroke(DesignSystem.Colors.border, lineWidth: 0.5)
+                    }
+            }
+            Text(shortcut.keyLabel.uppercased())
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(DesignSystem.Colors.textPrimary)
+                .frame(minWidth: 22, minHeight: 22)
+                .padding(.horizontal, 6)
+                .background(DesignSystem.Colors.surfaceElevated)
+                .clipShape(RoundedRectangle(cornerRadius: 5))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 5)
+                        .stroke(DesignSystem.Colors.border, lineWidth: 0.5)
+                }
+        }
+    }
+
+    private var orderedModifierGlyphs: [String] {
+        // Canonical macOS order: ⌃ ⌥ ⇧ ⌘.
+        let ordered: [TransformShortcut.ModifierFlag] = [.control, .option, .shift, .command]
+        return ordered
+            .filter { (shortcut.modifiers & $0.rawValue) != 0 }
+            .map(\.displayGlyph)
+    }
+}
+
+private struct UnboundShortcutChip: View {
+    var body: some View {
+        Text("No shortcut bound")
+            .font(DesignSystem.Typography.caption)
+            .foregroundStyle(DesignSystem.Colors.textTertiary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(DesignSystem.Colors.surfaceElevated.opacity(0.5))
+            .clipShape(Capsule())
+    }
+}

--- a/Sources/MacParakeetCore/AppFeatures.swift
+++ b/Sources/MacParakeetCore/AppFeatures.swift
@@ -22,12 +22,26 @@ public enum AppFeatures {
     public static let calendarEnabled: Bool = false
 
     /// Transforms spike (docs/research/transforms-design-2026-05.md, Phase 1
-    /// AX-coverage spike). When `false`, the entire Transforms pipeline is
-    /// hidden: no Opt+Ctrl+1 hotkey, no SelectionCaptureService/Executor wiring
-    /// from AppEnvironment, no floating progress panel. Flipping to `true` is
-    /// development-only — the spike is intentionally rough (hardcoded Polish
-    /// prompt, no management UI, hardcoded hotkey including Ctrl to avoid
-    /// collisions during dev). Used to answer the single question: does the
-    /// macOS AX API reliably return selected text in mainstream apps?
+    /// AX-coverage spike). When `true`, installs the spike's hardcoded
+    /// Opt+Ctrl+1 path alongside the productized registry — kept only as
+    /// a development-only escape hatch. The spike's Polish prompt is now
+    /// also a built-in `.transform` row, so any release build should
+    /// leave this `false` and rely on `transformsEnabled` instead.
     public static let transformsSpikeEnabled: Bool = false
+
+    /// Transforms — productized Phase 2 (ADR-022). When `true`:
+    /// - the Transforms tab appears in the main sidebar
+    /// - `TransformsHotkeyRegistry` installs its event tap on launch
+    /// - the user's bound `.transform` prompts dispatch on hotkey press
+    ///
+    /// When `false`, the tab is hidden and no event tap is installed.
+    /// Data model + repository are migrated either way — built-in
+    /// Transforms exist in the DB so flipping this flag is a no-data
+    /// operation.
+    ///
+    /// Default is `false` at merge so the website telemetry-allowlist
+    /// deploy (`transform_executed` / `transform_failed`) can land
+    /// first (ADR-022 §9). Flip to `true` in a follow-up commit once
+    /// the Worker accepts the new events.
+    public static let transformsEnabled: Bool = false
 }

--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -371,8 +371,32 @@ public final class DatabaseManager: Sendable {
 
             let now = Date()
             let legacySummaryPrompt = Prompt.classicSummaryPrompt(now: now)
-            for prompt in Prompt.builtInPrompts(now: now) {
-                try prompt.insert(db)
+            // Historical v0.7 prompts only — `.transform` category arrives in
+            // v0.13. Raw SQL with the v0.7-era column list (no
+            // `keyboardShortcut`, no `runningLabel`) so this migration is
+            // decoupled from later additions to the Prompt model — same
+            // pattern as the `summaries` insert below.
+            for prompt in Prompt.builtInPrompts(now: now) where prompt.category == .result {
+                try db.execute(
+                    sql: """
+                        INSERT INTO prompts (
+                            id, name, content, category, isBuiltIn, isVisible,
+                            isAutoRun, sortOrder, createdAt, updatedAt
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                    arguments: [
+                        prompt.id,
+                        prompt.name,
+                        prompt.content,
+                        prompt.category.rawValue,
+                        prompt.isBuiltIn,
+                        prompt.isVisible,
+                        prompt.isAutoRun,
+                        prompt.sortOrder,
+                        prompt.createdAt,
+                        prompt.updatedAt,
+                    ]
+                )
             }
 
             try db.create(table: "summaries") { t in
@@ -636,6 +660,25 @@ public final class DatabaseManager: Sendable {
             if !existingColumns.contains("displayRawTranscript") {
                 try db.alter(table: "dictations") { t in
                     t.add(column: "displayRawTranscript", .boolean).notNull().defaults(to: false)
+                }
+            }
+        }
+
+        // v0.13 — Transforms (ADR-022). Adds two nullable columns to
+        // `prompts` so `.transform`-category rows can carry their bound
+        // hotkey and an optional running-pill label. `.result` (summary)
+        // rows ignore both columns — they remain NULL there. Pre-check
+        // existence for re-run safety.
+        migrator.registerMigration("v0.13-prompt-transforms") { db in
+            let existingColumns = try db.columns(in: "prompts").map(\.name)
+            if !existingColumns.contains("keyboardShortcut") || !existingColumns.contains("runningLabel") {
+                try db.alter(table: "prompts") { t in
+                    if !existingColumns.contains("keyboardShortcut") {
+                        t.add(column: "keyboardShortcut", .text)
+                    }
+                    if !existingColumns.contains("runningLabel") {
+                        t.add(column: "runningLabel", .text)
+                    }
                 }
             }
         }

--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -726,21 +726,36 @@ public final class DatabaseManager: Sendable {
 
             for prompt in builtInPrompts {
                 if let existing = try Prompt.fetchOne(db, key: prompt.id) {
-                    try db.execute(
-                        sql: """
-                            UPDATE prompts
-                            SET name = ?, content = ?, category = ?, isBuiltIn = 1, sortOrder = ?, updatedAt = ?
-                            WHERE id = ?
-                            """,
-                        arguments: [
-                            prompt.name,
-                            prompt.content,
-                            prompt.category.rawValue,
-                            prompt.sortOrder,
-                            prompt.updatedAt,
-                            existing.id,
-                        ]
-                    )
+                    if prompt.category == .transform {
+                        try db.execute(
+                            sql: """
+                                UPDATE prompts
+                                SET category = ?, isBuiltIn = 1, isVisible = 1, isAutoRun = 0, sortOrder = ?
+                                WHERE id = ?
+                                """,
+                            arguments: [
+                                prompt.category.rawValue,
+                                prompt.sortOrder,
+                                existing.id,
+                            ]
+                        )
+                    } else {
+                        try db.execute(
+                            sql: """
+                                UPDATE prompts
+                                SET name = ?, content = ?, category = ?, isBuiltIn = 1, sortOrder = ?, updatedAt = ?
+                                WHERE id = ?
+                                """,
+                            arguments: [
+                                prompt.name,
+                                prompt.content,
+                                prompt.category.rawValue,
+                                prompt.sortOrder,
+                                prompt.updatedAt,
+                                existing.id,
+                            ]
+                        )
+                    }
                     continue
                 }
 

--- a/Sources/MacParakeetCore/Database/PromptRepository.swift
+++ b/Sources/MacParakeetCore/Database/PromptRepository.swift
@@ -56,6 +56,8 @@ public final class PromptRepository: PromptRepositoryProtocol {
         try dbQueue.read { db in
             try Prompt
                 .filter(Prompt.Columns.isAutoRun == true)
+                .filter(Prompt.Columns.isVisible == true)
+                .filter(Prompt.Columns.category == Prompt.Category.result.rawValue)
                 .order(Prompt.Columns.sortOrder.asc, Prompt.Columns.name.asc)
                 .fetchAll(db)
         }
@@ -84,6 +86,7 @@ public final class PromptRepository: PromptRepositoryProtocol {
     public func toggleAutoRun(id: UUID) throws {
         try dbQueue.write { db in
             guard var prompt = try Prompt.fetchOne(db, key: id) else { return }
+            guard prompt.category == .result else { return }
             
             prompt.isAutoRun.toggle()
             // Auto-run prompts must be visible

--- a/Sources/MacParakeetCore/Models/KeyboardShortcut.swift
+++ b/Sources/MacParakeetCore/Models/KeyboardShortcut.swift
@@ -1,0 +1,199 @@
+import Foundation
+
+/// A keyboard shortcut bound to a Transform (or any other surface that needs
+/// a serializable hotkey binding).
+///
+/// Persisted on `Prompt` (category `.transform`) as a JSON-encoded string in
+/// the `keyboardShortcut` column. NULL means "no shortcut bound" — a valid,
+/// dormant state. Built-ins ship with a default binding; users can clear it.
+///
+/// The struct intentionally stores the *recorded* shortcut, not the
+/// resolved-against-current-layout shortcut. The system event tap matches on
+/// virtual keycode (`keyCode`), which is layout-agnostic, so a binding made
+/// on QWERTY keeps working on Dvorak. The `keyLabel` is for display only —
+/// it captures what the user saw on their keyboard when they bound it.
+public struct KeyboardShortcut: Codable, Equatable, Hashable, Sendable {
+    /// Carbon-style modifier flags. Bitwise OR of `ModifierFlag` raw values.
+    public let modifiers: UInt
+    /// Virtual keycode (`kVK_*`) — layout-agnostic.
+    public let keyCode: UInt16
+    /// Human-readable label of the bound key (e.g. "1", "P", "F13") as the
+    /// user saw it when they bound the shortcut. Used for display only.
+    public let keyLabel: String
+
+    public init(modifiers: UInt, keyCode: UInt16, keyLabel: String) {
+        self.modifiers = modifiers
+        self.keyCode = keyCode
+        self.keyLabel = keyLabel
+    }
+
+    /// Standalone modifier flags — value matches NSEvent.ModifierFlags raw
+    /// values for the Cocoa-side checks, intentionally compatible with the
+    /// existing hotkey infrastructure.
+    public enum ModifierFlag: UInt, CaseIterable, Sendable {
+        case command  = 0x100000   // NSEvent.ModifierFlags.command
+        case option   = 0x080000   // NSEvent.ModifierFlags.option
+        case control  = 0x040000   // NSEvent.ModifierFlags.control
+        case shift    = 0x020000   // NSEvent.ModifierFlags.shift
+
+        public var displayGlyph: String {
+            switch self {
+            case .command: return "⌘"
+            case .option:  return "⌥"
+            case .control: return "⌃"
+            case .shift:   return "⇧"
+            }
+        }
+
+        public var displayName: String {
+            switch self {
+            case .command: return "Command"
+            case .option:  return "Option"
+            case .control: return "Control"
+            case .shift:   return "Shift"
+            }
+        }
+    }
+
+    public var modifierFlags: Set<ModifierFlag> {
+        Set(ModifierFlag.allCases.filter { (modifiers & $0.rawValue) != 0 })
+    }
+
+    public var hasModifier: Bool {
+        !modifierFlags.isEmpty
+    }
+
+    /// Render modifiers in the canonical macOS order: ⌃ ⌥ ⇧ ⌘.
+    public var displayString: String {
+        let ordered: [ModifierFlag] = [.control, .option, .shift, .command]
+        let glyphs = ordered
+            .filter { (modifiers & $0.rawValue) != 0 }
+            .map(\.displayGlyph)
+            .joined()
+        return glyphs + keyLabel.uppercased()
+    }
+
+    // MARK: - String parsing (CLI input)
+
+    /// Parse a human-readable shortcut string from the CLI, e.g. `"opt+1"`,
+    /// `"cmd+shift+p"`, `"ctrl+opt+space"`. Order-insensitive among
+    /// modifiers. Returns nil if the format is unrecognizable.
+    ///
+    /// Recognized modifier tokens (case-insensitive):
+    /// `cmd`, `command`, `meta`, `⌘` → command
+    /// `opt`, `option`, `alt`, `⌥` → option
+    /// `ctrl`, `control`, `⌃` → control
+    /// `shift`, `⇧` → shift
+    public static func parse(_ raw: String) -> KeyboardShortcut? {
+        let tokens = raw
+            .split(whereSeparator: { "+- ".contains($0) })
+            .map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
+            .filter { !$0.isEmpty }
+        guard !tokens.isEmpty else { return nil }
+
+        var mods: UInt = 0
+        var keyToken: String?
+        for token in tokens {
+            if let flag = parseModifier(token) {
+                mods |= flag.rawValue
+            } else {
+                guard keyToken == nil else { return nil } // two non-modifier tokens
+                keyToken = token
+            }
+        }
+        guard let key = keyToken else { return nil }
+        guard let (keyCode, label) = parseKey(key) else { return nil }
+
+        return KeyboardShortcut(modifiers: mods, keyCode: keyCode, keyLabel: label)
+    }
+
+    private static func parseModifier(_ token: String) -> ModifierFlag? {
+        switch token {
+        case "cmd", "command", "meta", "⌘": return .command
+        case "opt", "option", "alt", "⌥":   return .option
+        case "ctrl", "control", "⌃":         return .control
+        case "shift", "⇧":                   return .shift
+        default: return nil
+        }
+    }
+
+    /// Map a key token to (virtual keycode, display label). Covers the common
+    /// surface used by Transform bindings — digits, letters, and a small
+    /// set of named keys. Returns nil for unrecognized keys.
+    private static func parseKey(_ token: String) -> (UInt16, String)? {
+        if let digit = digitKeyCodes[token] {
+            return (digit, token)
+        }
+        if token.count == 1, let letter = letterKeyCodes[token] {
+            return (letter, token.uppercased())
+        }
+        if let named = namedKeyCodes[token] {
+            return named
+        }
+        return nil
+    }
+
+    // Subset of Carbon's `kVK_*` virtual key codes. The values match
+    // <Carbon/HIToolbox/Events.h>. We avoid importing Carbon at the model
+    // layer to keep MacParakeetCore portable; the values are stable.
+    private static let digitKeyCodes: [String: UInt16] = [
+        "1": 0x12, "2": 0x13, "3": 0x14, "4": 0x15, "5": 0x17,
+        "6": 0x16, "7": 0x1A, "8": 0x1C, "9": 0x19, "0": 0x1D,
+    ]
+
+    private static let letterKeyCodes: [String: UInt16] = [
+        "a": 0x00, "b": 0x0B, "c": 0x08, "d": 0x02, "e": 0x0E,
+        "f": 0x03, "g": 0x05, "h": 0x04, "i": 0x22, "j": 0x26,
+        "k": 0x28, "l": 0x25, "m": 0x2E, "n": 0x2D, "o": 0x1F,
+        "p": 0x23, "q": 0x0C, "r": 0x0F, "s": 0x01, "t": 0x11,
+        "u": 0x20, "v": 0x09, "w": 0x0D, "x": 0x07, "y": 0x10,
+        "z": 0x06,
+    ]
+
+    private static let namedKeyCodes: [String: (UInt16, String)] = [
+        "space":  (0x31, "Space"),
+        "return": (0x24, "Return"),
+        "enter":  (0x24, "Return"),
+        "tab":    (0x30, "Tab"),
+        "escape": (0x35, "Escape"),
+        "esc":    (0x35, "Escape"),
+    ]
+
+    // MARK: - Dead-key blocklist
+    //
+    // macOS Opt+letter combos that produce alt-characters and would be hostile
+    // to steal. The collision detector flags these at bind time. Source:
+    // Apple's "Special Characters" table — the most commonly typed dead keys.
+    private static let optionDeadKeyLabels: Set<String> = [
+        "E", "U", "I", "N", "`",
+    ]
+
+    /// True if this shortcut maps to a known macOS dead key combo (`Opt+e`,
+    /// `Opt+u`, etc.). Bindings on these combos are rejected by the
+    /// `TransformsHotkeyRegistry` collision rules.
+    public var isMacOSDeadKey: Bool {
+        let onlyOption = (modifiers == ModifierFlag.option.rawValue)
+        return onlyOption && Self.optionDeadKeyLabels.contains(keyLabel.uppercased())
+    }
+}
+
+// MARK: - Persistence helpers
+
+extension KeyboardShortcut {
+    /// Encode the shortcut to a JSON string suitable for the SQLite TEXT
+    /// column. Returns nil if encoding fails (shouldn't happen with the
+    /// fixed shape, but caller handles it defensively).
+    public func encodedString() -> String? {
+        guard let data = try? JSONEncoder().encode(self) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    /// Decode a JSON-string-encoded shortcut from the DB column. Returns nil
+    /// on bad input — the caller should treat that as "no shortcut bound"
+    /// rather than crashing, since the persistence column is user-mutable
+    /// only through this struct's round-trip.
+    public static func decoded(from raw: String?) -> KeyboardShortcut? {
+        guard let raw, let data = raw.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(KeyboardShortcut.self, from: data)
+    }
+}

--- a/Sources/MacParakeetCore/Models/KeyboardShortcut.swift
+++ b/Sources/MacParakeetCore/Models/KeyboardShortcut.swift
@@ -53,6 +53,15 @@ public struct KeyboardShortcut: Codable, Equatable, Hashable, Sendable {
             case .shift:   return "Shift"
             }
         }
+
+        fileprivate var hotkeyTriggerModifierName: String {
+            switch self {
+            case .command: return "command"
+            case .option:  return "option"
+            case .control: return "control"
+            case .shift:   return "shift"
+            }
+        }
     }
 
     public var modifierFlags: Set<ModifierFlag> {
@@ -174,6 +183,15 @@ public struct KeyboardShortcut: Codable, Equatable, Hashable, Sendable {
     public var isMacOSDeadKey: Bool {
         let onlyOption = (modifiers == ModifierFlag.option.rawValue)
         return onlyOption && Self.optionDeadKeyLabels.contains(keyLabel.uppercased())
+    }
+
+    /// Equivalent `HotkeyTrigger` used for overlap checks against the app's
+    /// existing dictation / meeting hotkey model.
+    public var hotkeyTrigger: HotkeyTrigger {
+        HotkeyTrigger.chord(
+            modifiers: modifierFlags.map(\.hotkeyTriggerModifierName),
+            keyCode: keyCode
+        )
     }
 }
 

--- a/Sources/MacParakeetCore/Models/Prompt.swift
+++ b/Sources/MacParakeetCore/Models/Prompt.swift
@@ -13,6 +13,17 @@ public struct Prompt: Codable, Identifiable, Sendable {
     public var createdAt: Date
     public var updatedAt: Date
 
+    /// JSON-encoded `KeyboardShortcut`. Persisted on `.transform` prompts as
+    /// the bound hotkey for the floating Transforms registry. NULL on
+    /// `.result` prompts (they have no hotkey concept). Decode via
+    /// `KeyboardShortcut.decoded(from:)`.
+    public var keyboardShortcut: String?
+
+    /// Optional override for the running pill label (e.g. *"Polishing…"*).
+    /// NULL means "derive from name via the `{Name}ing…` heuristic, falling
+    /// back to *Transforming…* for awkward names."
+    public var runningLabel: String?
+
     public enum Category: String, Codable, Sendable {
         // Keep the stored raw value as "summary" until the prompts table itself is migrated.
         case result = "summary"
@@ -29,7 +40,9 @@ public struct Prompt: Codable, Identifiable, Sendable {
         isAutoRun: Bool = false,
         sortOrder: Int = 0,
         createdAt: Date = Date(),
-        updatedAt: Date = Date()
+        updatedAt: Date = Date(),
+        keyboardShortcut: String? = nil,
+        runningLabel: String? = nil
     ) {
         self.id = id
         self.name = name
@@ -41,6 +54,41 @@ public struct Prompt: Codable, Identifiable, Sendable {
         self.sortOrder = sortOrder
         self.createdAt = createdAt
         self.updatedAt = updatedAt
+        self.keyboardShortcut = keyboardShortcut
+        self.runningLabel = runningLabel
+    }
+
+    // MARK: - Transform convenience
+
+    /// Decoded shortcut binding for `.transform` prompts, or nil if unbound
+    /// (or if the column is malformed — treated as "no binding").
+    public var shortcut: KeyboardShortcut? {
+        KeyboardShortcut.decoded(from: keyboardShortcut)
+    }
+
+    /// Verb-form label rendered by the floating Transforms pill while this
+    /// transform is running. Honors `runningLabel` if set, otherwise uses
+    /// the `{Name}ing…` heuristic. Falls back to *Transforming…* for awkward
+    /// names that don't form a clean gerund.
+    public var derivedRunningLabel: String {
+        if let runningLabel, !runningLabel.isEmpty { return runningLabel }
+        let trimmed = name.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return "Transforming…" }
+        let lower = trimmed.lowercased()
+        // Awkward gerunds — names ending in -ing, -ed, -er, etc. fall through
+        // to the generic label rather than producing "Polishinging…".
+        let awkwardSuffixes = ["ing", "tion", "ment", "ness", "ed", "er"]
+        for suffix in awkwardSuffixes where lower.hasSuffix(suffix) {
+            return "Transforming…"
+        }
+        // English drop-e: "Polish" → "Polishing", "Make" → "Making".
+        let stem: String
+        if lower.hasSuffix("e") && !lower.hasSuffix("ee") {
+            stem = String(trimmed.dropLast())
+        } else {
+            stem = trimmed
+        }
+        return "\(stem)ing…"
     }
 
     // Used for compatibility fallback paths. This is not a fallback for the
@@ -75,6 +123,31 @@ public struct Prompt: Codable, Identifiable, Sendable {
         )
     }
 
+    private static func makeBuiltInTransform(
+        id: String,
+        name: String,
+        content: String,
+        sortOrder: Int,
+        defaultShortcut: KeyboardShortcut?,
+        runningLabel: String?,
+        now: Date
+    ) -> Prompt {
+        Prompt(
+            id: UUID(uuidString: id) ?? UUID(),
+            name: name,
+            content: content,
+            category: .transform,
+            isBuiltIn: true,
+            isVisible: true,
+            isAutoRun: false,
+            sortOrder: sortOrder,
+            createdAt: now,
+            updatedAt: now,
+            keyboardShortcut: defaultShortcut?.encodedString(),
+            runningLabel: runningLabel
+        )
+    }
+
     /// Built-in prompt definitions shipped with the app.
     /// `community-prompts.json` is kept in sync as a contribution/reference artifact.
     ///
@@ -84,7 +157,16 @@ public struct Prompt: Codable, Identifiable, Sendable {
     /// that ID on next launch (because it is no longer in the canonical list),
     /// and reissuing the UUID would resurrect the prompt on installs that still
     /// have its row in their DB. See ADR-020 (2026-05-02 amendment).
+    ///
+    /// Reserved Transform UUIDs (ADR-022, do not reuse):
+    /// - `0FCE9DDB-7E2D-4B1A-AE3E-6F7C9B2A4D11` — Polish
+    /// - `1AD7C2B0-9C6F-4F0E-9C39-5E4D1F1D2A55` — Distill
+    /// - `2BE8D3C1-4A7F-4EBD-8F12-7C9A1E0B3D44` — Decide
     public static func builtInPrompts(now: Date = Date()) -> [Prompt] {
+        builtInResultPrompts(now: now) + builtInTransformPrompts(now: now)
+    }
+
+    private static func builtInResultPrompts(now: Date) -> [Prompt] {
         [
             makeBuiltInPrompt(
                 id: "A4882688-E72C-415A-9A5E-1F6AC82DF0D0",
@@ -211,12 +293,109 @@ public struct Prompt: Codable, Identifiable, Sendable {
             ),
         ]
     }
+
+    /// Built-in `.transform` prompts (ADR-022). Three shipped Transforms,
+    /// each pedagogically distinct so the lineup itself teaches what
+    /// Transforms is for:
+    ///
+    /// - *Polish* (⌥1) — make text read like the writer's best version, voice
+    ///   intact. The everyday driver.
+    /// - *Distill* (⌥2) — compress to signal, raise information density.
+    ///   The "I have a rambling braindump" tool.
+    /// - *Decide* (⌥3) — turn discussion into a decision-ready note with
+    ///   tradeoffs + recommended next step. The forward-motion tool.
+    ///
+    /// Together: **Improve → Re-shape → Re-direct**. Three slots; ⌥4–9
+    /// reserved for user customization.
+    ///
+    /// Each row is seeded by the reconciler at app launch if missing; user
+    /// edits to the row are preserved — the reconciler never overwrites
+    /// content, shortcut, or runningLabel on existing built-in transform
+    /// rows.
+    ///
+    /// UUIDs are reserved — never reuse for a different prompt.
+    private static func builtInTransformPrompts(now: Date) -> [Prompt] {
+        [
+            makeBuiltInTransform(
+                id: "0FCE9DDB-7E2D-4B1A-AE3E-6F7C9B2A4D11",
+                name: "Polish",
+                content: """
+                    Rewrite the selected text so it reads like the best version of itself: clear, specific, finished. Preserve the author's intent, factual claims, structure, and level of formality.
+
+                    Remove hedging, filler, repetition, throat-clearing, and vague intensifiers. Prefer plain words over performative polish. Keep technical terms, names, code identifiers, URLs, numbers, and quoted text exactly intact.
+
+                    Do not change the register. If the input is casual, keep it casual; if formal, keep it formal. Do not add new ideas, examples, claims, apologies, or enthusiasm. Do not make it sound like marketing copy. Do not introduce AI tells ("delve," "comprehensive," "navigate the landscape of," "in today's fast-paced world"). If the input is a single short fragment (a label, a search query, a name), return it unchanged or with the smallest correction necessary.
+
+                    Return ONLY the rewritten text. No preamble, no quoting, no commentary, no headings.
+                    """.replacingOccurrences(of: "                    ", with: ""),
+                sortOrder: 100,
+                defaultShortcut: KeyboardShortcut(
+                    modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,
+                    keyCode: 0x12, // kVK_ANSI_1
+                    keyLabel: "1"
+                ),
+                runningLabel: "Polishing…",
+                now: now
+            ),
+            makeBuiltInTransform(
+                id: "1AD7C2B0-9C6F-4F0E-9C39-5E4D1F1D2A55",
+                name: "Distill",
+                content: """
+                    Compress the selected text to its signal. Reduce volume by 40–60% while keeping 100% of the actionable meaning.
+
+                    Identify the core point, the primary insight, or the bottom line. Discard the preamble, the connective tissue, and the throat-clearing. Replace passive voice and weak phrasing with active, precise verbs. Replace vague hedges with the specific claim underneath them.
+
+                    Architecture: use bullets when the input is a list of points or a sequence of ideas; use compact prose when it's a single argument. Don't lose the "why" — the reasoning behind a decision belongs in the distillation. Don't lose the "who" — if the input names people, parties, or systems, keep them.
+
+                    Match output shape to context: a Slack message becomes a tight paragraph, an email becomes a short list, a long doc becomes a few crisp bullets. The result should be readable in three seconds and lose nothing important.
+
+                    Return ONLY the distilled text. No preamble, no "Here is the condensed version," no meta-commentary.
+                    """.replacingOccurrences(of: "                    ", with: ""),
+                sortOrder: 101,
+                defaultShortcut: KeyboardShortcut(
+                    modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,
+                    keyCode: 0x13, // kVK_ANSI_2
+                    keyLabel: "2"
+                ),
+                runningLabel: "Distilling…",
+                now: now
+            ),
+            makeBuiltInTransform(
+                id: "2BE8D3C1-4A7F-4EBD-8F12-7C9A1E0B3D44",
+                name: "Decide",
+                content: """
+                    Rewrite the selected text as a decision-ready note. The reader is busy and needs to understand what is being decided and what should happen next.
+
+                    Separate signal from noise. Surface:
+                    - **The question** — what's actually being decided. State it explicitly, even if the input only implied it.
+                    - **The options** — the live choices, named clearly. Drop dead options unless their absence would surprise the reader.
+                    - **The tradeoffs** — what each option costs and what it buys. One clean line each, no padding.
+                    - **The recommendation** — your suggested next move, with a single-sentence reason. If the input already chose, make the choice explicit.
+                    - **The block** — if there isn't enough information to decide yet, name the smallest concrete question that must be answered next.
+
+                    Honor unresolved disagreement when it's there — don't flatten it into false consensus. Don't manufacture pros-and-cons that the input doesn't support. Don't invent data. Don't write a strategy memo unless the input warrants one — most decisions earn a paragraph, not a page.
+
+                    Return ONLY the rewritten note. No preamble, no "Here is the decision-ready version," no headings beyond what the structure above requires.
+                    """.replacingOccurrences(of: "                    ", with: ""),
+                sortOrder: 102,
+                defaultShortcut: KeyboardShortcut(
+                    modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,
+                    keyCode: 0x14, // kVK_ANSI_3
+                    keyLabel: "3"
+                ),
+                runningLabel: "Deciding…",
+                now: now
+            ),
+        ]
+    }
 }
 
 extension Prompt: FetchableRecord, PersistableRecord {
     public static let databaseTableName = "prompts"
 
     public enum Columns: String, ColumnExpression {
-        case id, name, content, category, isBuiltIn, isVisible, isAutoRun, sortOrder, createdAt, updatedAt
+        case id, name, content, category, isBuiltIn, isVisible, isAutoRun
+        case sortOrder, createdAt, updatedAt
+        case keyboardShortcut, runningLabel
     }
 }

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -26,6 +26,18 @@ public enum TelemetryEventName: String, Sendable, CaseIterable {
     case llmChatFailed = "llm_chat_failed"
     case llmTransformUsed = "llm_transform_used"
     case llmTransformFailed = "llm_transform_failed"
+    /// Transforms feature surface (ADR-022). Distinct from
+    /// `llm_transform_used` (the call-level event fired by
+    /// `LLMService.transformStream`). `transform_executed` is the
+    /// product-level event fired by `TransformsCoordinator` after a
+    /// hotkey-bound Transform completes end-to-end. Properties:
+    /// `transform_name` (built-in name or `custom`), `capture_path`
+    /// (`ax | clipboard`), `replace_path` (`ax | clipboardPaste`),
+    /// `llm_ms`, `total_ms`. NO prompt body, NO selected text, NO output.
+    /// Custom-Transform names map to `custom` so a Transform named after
+    /// e.g. an employer never leaves the device.
+    case transformExecuted = "transform_executed"
+    case transformFailed = "transform_failed"
     case llmFormatterUsed = "llm_formatter_used"
     case llmFormatterFailed = "llm_formatter_failed"
     case llmProviderUnavailable = "llm_provider_unavailable"
@@ -176,6 +188,55 @@ public enum TelemetryCopySource: String, Sendable, Equatable {
 public enum TelemetryFormatterSource: String, Sendable, Equatable {
     case dictation
     case transcription
+}
+
+/// Which Transform (ADR-022) ran. Built-in names are transmitted verbatim
+/// (`polish`, `distill`, `decide`) so per-built-in usage is observable.
+/// Custom Transforms map to `custom` — a user-supplied name like "Boss
+/// Mode" or a company name never leaves the device.
+public enum TelemetryTransformName: String, Sendable, Equatable {
+    case polish
+    case distill
+    case decide
+    case custom
+
+    public init(builtInName: String?, isBuiltIn: Bool) {
+        guard isBuiltIn, let name = builtInName?.lowercased() else {
+            self = .custom
+            return
+        }
+        switch name {
+        case "polish": self = .polish
+        case "distill": self = .distill
+        case "decide": self = .decide
+        default: self = .custom
+        }
+    }
+}
+
+/// Selection-capture path the Transforms pipeline used. Mirrors
+/// `SelectionCaptureResult` minus the payloads.
+public enum TelemetryTransformCapturePath: String, Sendable, Equatable {
+    case ax
+    case clipboard
+}
+
+/// Selection-replacement path the Transforms pipeline used. Mirrors
+/// `SelectionReplacementPath`.
+public enum TelemetryTransformReplacePath: String, Sendable, Equatable {
+    case ax
+    case clipboardPaste = "clipboard_paste"
+}
+
+/// Why a Transforms run terminated abnormally. Maps onto
+/// `TransformExecutorError` cases plus a `noProvider` rollup for the
+/// "user hasn't configured an LLM yet" gate.
+public enum TelemetryTransformFailureReason: String, Sendable, Equatable {
+    case emptySelection = "empty_selection"
+    case noProvider = "no_provider"
+    case llmFailed = "llm_failed"
+    case replacementFailed = "replacement_failed"
+    case cancelled
 }
 
 /// Which LLM call site produced a `llm_provider_unavailable` event. Lets a
@@ -349,6 +410,21 @@ public enum TelemetryEventSpec: Sendable {
     case llmChatFailed(provider: String, errorType: String, errorDetail: String? = nil)
     case llmTransformUsed(provider: String)
     case llmTransformFailed(provider: String, errorType: String, errorDetail: String? = nil)
+    /// Transforms (ADR-022) feature-level success. Fired by
+    /// `TransformsCoordinator` when a hotkey-bound Transform finishes
+    /// end-to-end. NO content captured — see
+    /// `TelemetryTransformName.custom` for the privacy contract.
+    case transformExecuted(
+        transformName: TelemetryTransformName,
+        capturePath: TelemetryTransformCapturePath,
+        replacePath: TelemetryTransformReplacePath,
+        llmMs: Int,
+        totalMs: Int
+    )
+    case transformFailed(
+        transformName: TelemetryTransformName,
+        reason: TelemetryTransformFailureReason
+    )
     case llmFormatterUsed(
         provider: String,
         source: TelemetryFormatterSource,
@@ -591,6 +667,8 @@ extension TelemetryEventSpec {
         case .llmChatFailed: return .llmChatFailed
         case .llmTransformUsed: return .llmTransformUsed
         case .llmTransformFailed: return .llmTransformFailed
+        case .transformExecuted: return .transformExecuted
+        case .transformFailed: return .transformFailed
         case .llmFormatterUsed: return .llmFormatterUsed
         case .llmFormatterFailed: return .llmFormatterFailed
         case .llmProviderUnavailable: return .llmProviderUnavailable
@@ -860,6 +938,19 @@ extension TelemetryEventSpec {
             var props = ["provider": provider, "error_type": errorType]
             if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
             return props
+        case .transformExecuted(let name, let capture, let replace, let llmMs, let totalMs):
+            return [
+                "transform_name": name.rawValue,
+                "capture_path": capture.rawValue,
+                "replace_path": replace.rawValue,
+                "llm_ms": "\(llmMs)",
+                "total_ms": "\(totalMs)",
+            ]
+        case .transformFailed(let name, let reason):
+            return [
+                "transform_name": name.rawValue,
+                "reason": reason.rawValue,
+            ]
         case .llmFormatterUsed(
             let provider,
             let source,
@@ -1283,6 +1374,8 @@ public enum TelemetryImplementedContract {
         .llmChatFailed: ["provider", "error_type"],
         .llmTransformUsed: ["provider"],
         .llmTransformFailed: ["provider", "error_type"],
+        .transformExecuted: ["transform_name", "capture_path", "replace_path", "llm_ms", "total_ms"],
+        .transformFailed: ["transform_name", "reason"],
         .llmFormatterUsed: ["provider", "source", "duration_seconds", "input_chars", "output_chars", "default_prompt_used", "input_truncated"],
         .llmFormatterFailed: ["provider", "source", "duration_seconds", "error_type", "default_prompt_used", "input_truncated"],
         .llmProviderUnavailable: ["provider", "error_type", "feature"],

--- a/Sources/MacParakeetViewModels/PromptsViewModel.swift
+++ b/Sources/MacParakeetViewModels/PromptsViewModel.swift
@@ -27,7 +27,7 @@ public final class PromptsViewModel {
     public func loadPrompts() {
         guard let repo else { return }
         do {
-            prompts = try repo.fetchAll()
+            prompts = try repo.fetchAll().filter { $0.category == .result }
             errorMessage = nil
         } catch {
             errorMessage = error.localizedDescription
@@ -42,8 +42,13 @@ public final class PromptsViewModel {
             errorMessage = "Prompt name and content are required."
             return
         }
-        guard isUniqueName(trimmedName) else {
-            errorMessage = "'\(trimmedName)' already exists"
+        do {
+            guard try isUniqueName(trimmedName, repo: repo) else {
+                errorMessage = "'\(trimmedName)' already exists"
+                return
+            }
+        } catch {
+            errorMessage = error.localizedDescription
             return
         }
 
@@ -77,8 +82,13 @@ public final class PromptsViewModel {
             errorMessage = "Prompt name and content are required."
             return
         }
-        guard isUniqueName(trimmedName, excluding: prompt.id) else {
-            errorMessage = "'\(trimmedName)' already exists"
+        do {
+            guard try isUniqueName(trimmedName, excluding: prompt.id, repo: repo) else {
+                errorMessage = "'\(trimmedName)' already exists"
+                return
+            }
+        } catch {
+            errorMessage = error.localizedDescription
             return
         }
 
@@ -149,8 +159,13 @@ public final class PromptsViewModel {
         }
     }
 
-    private func isUniqueName(_ name: String, excluding promptID: UUID? = nil) -> Bool {
-        !prompts.contains {
+    private func isUniqueName(
+        _ name: String,
+        excluding promptID: UUID? = nil,
+        repo: PromptRepositoryProtocol
+    ) throws -> Bool {
+        let allPrompts = try repo.fetchAll()
+        return !allPrompts.contains {
             $0.id != promptID && $0.name.caseInsensitiveCompare(name) == .orderedSame
         }
     }

--- a/Sources/MacParakeetViewModels/TransformEditorViewModel.swift
+++ b/Sources/MacParakeetViewModels/TransformEditorViewModel.swift
@@ -96,15 +96,15 @@ public final class TransformEditorViewModel {
     /// editor's awareness.
     public func validate(
         existingTransforms: [Prompt],
-        dictationHotkey: KeyboardShortcut?,
-        meetingHotkey: KeyboardShortcut?,
+        dictationHotkeys: [HotkeyTrigger],
+        meetingHotkey: HotkeyTrigger?,
         collisionChecker: TransformShortcutCollisionChecking
     ) {
         validateName(against: existingTransforms)
         validateContent()
         validateShortcut(
             existingTransforms: existingTransforms,
-            dictationHotkey: dictationHotkey,
+            dictationHotkeys: dictationHotkeys,
             meetingHotkey: meetingHotkey,
             collisionChecker: collisionChecker
         )
@@ -131,8 +131,8 @@ public final class TransformEditorViewModel {
 
     private func validateShortcut(
         existingTransforms: [Prompt],
-        dictationHotkey: KeyboardShortcut?,
-        meetingHotkey: KeyboardShortcut?,
+        dictationHotkeys: [HotkeyTrigger],
+        meetingHotkey: HotkeyTrigger?,
         collisionChecker: TransformShortcutCollisionChecking
     ) {
         guard let candidate = shortcut else {
@@ -153,7 +153,7 @@ public final class TransformEditorViewModel {
             candidate: candidate,
             existing: bindings,
             excludingPromptID: editingID,
-            dictationHotkey: dictationHotkey,
+            dictationHotkeys: dictationHotkeys,
             meetingHotkey: meetingHotkey
         )
         shortcutError = collision?.message
@@ -221,8 +221,8 @@ public protocol TransformShortcutCollisionChecking {
         candidate: KeyboardShortcut,
         existing: [UUID: KeyboardShortcut],
         excludingPromptID: UUID?,
-        dictationHotkey: KeyboardShortcut?,
-        meetingHotkey: KeyboardShortcut?
+        dictationHotkeys: [HotkeyTrigger],
+        meetingHotkey: HotkeyTrigger?
     ) -> TransformShortcutCollision?
 }
 

--- a/Sources/MacParakeetViewModels/TransformEditorViewModel.swift
+++ b/Sources/MacParakeetViewModels/TransformEditorViewModel.swift
@@ -1,0 +1,252 @@
+import Foundation
+import MacParakeetCore
+
+/// Drives the **Create your own** / **Edit Transform** sheet (ADR-022).
+/// Owns the draft state of one Transform (name + shortcut + prompt body +
+/// optional running label) plus the live validation that surfaces in the
+/// editor card chrome.
+///
+/// Validation is deliberately strict — every field has a clear rule so the
+/// user knows what's needed before they can save. Inline rules:
+///
+/// - Name: required, no leading/trailing whitespace, must be unique
+///   case-insensitively across all Transforms (matches the existing
+///   `idx_prompts_name` SQLite uniqueness index).
+/// - Shortcut: optional in the draft (the editor pre-fills it), but if
+///   present must include a modifier, not be a macOS dead-key, and not
+///   collide with another Transform / dictation / meeting hotkey.
+/// - Prompt body: required.
+///
+/// The view layer pairs this with a `TransformsHotkeyCollisionChecker`
+/// instance (Sources/MacParakeet/Hotkey) for the shortcut-collision
+/// branch. The collision results map directly to `shortcutError`.
+@MainActor
+@Observable
+public final class TransformEditorViewModel {
+    public enum Mode {
+        case create
+        case edit(Prompt)
+
+        var initialPrompt: Prompt? {
+            switch self {
+            case .create: return nil
+            case .edit(let prompt): return prompt
+            }
+        }
+
+        public var isEditing: Bool {
+            if case .edit = self { return true }
+            return false
+        }
+
+        public var isCreating: Bool {
+            if case .create = self { return true }
+            return false
+        }
+    }
+
+    public let mode: Mode
+
+    public var name: String = "" {
+        didSet { nameError = nil }
+    }
+    public var content: String = "" {
+        didSet { contentError = nil }
+    }
+    public var runningLabel: String = ""
+    public var shortcut: KeyboardShortcut? {
+        didSet { shortcutError = nil }
+    }
+
+    // Per-field validation messages. Nil = valid (or not yet checked).
+    public var nameError: String?
+    public var contentError: String?
+    public var shortcutError: String?
+
+    /// True when every required field is valid. Save buttons gate on this.
+    public var isValid: Bool {
+        normalizedName.isEmpty == false
+            && nameError == nil
+            && content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+            && contentError == nil
+            && shortcutError == nil
+    }
+
+    public var isBuiltIn: Bool {
+        guard case .edit(let prompt) = mode else { return false }
+        return prompt.isBuiltIn
+    }
+
+    public init(mode: Mode) {
+        self.mode = mode
+        if let initial = mode.initialPrompt {
+            name = initial.name
+            content = initial.content
+            runningLabel = initial.runningLabel ?? ""
+            shortcut = initial.shortcut
+        }
+    }
+
+    // MARK: - Validation
+
+    /// Run all validation rules against the current draft + the surrounding
+    /// state passed in by the view layer. The view layer is responsible
+    /// for providing the *other* transforms' bindings, the user's dictation
+    /// hotkey, and the meeting-toggle hotkey — they live outside the
+    /// editor's awareness.
+    public func validate(
+        existingTransforms: [Prompt],
+        dictationHotkey: KeyboardShortcut?,
+        meetingHotkey: KeyboardShortcut?,
+        collisionChecker: TransformShortcutCollisionChecking
+    ) {
+        validateName(against: existingTransforms)
+        validateContent()
+        validateShortcut(
+            existingTransforms: existingTransforms,
+            dictationHotkey: dictationHotkey,
+            meetingHotkey: meetingHotkey,
+            collisionChecker: collisionChecker
+        )
+    }
+
+    private func validateName(against existing: [Prompt]) {
+        let trimmed = normalizedName
+        if trimmed.isEmpty {
+            nameError = "Give your Transform a name."
+            return
+        }
+        let editingID: UUID? = mode.initialPrompt?.id
+        let duplicate = existing.contains { other in
+            other.id != editingID
+                && other.name.caseInsensitiveCompare(trimmed) == .orderedSame
+        }
+        nameError = duplicate ? "Another Transform already uses this name." : nil
+    }
+
+    private func validateContent() {
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        contentError = trimmed.isEmpty ? "Give your Transform a prompt to run on the selected text." : nil
+    }
+
+    private func validateShortcut(
+        existingTransforms: [Prompt],
+        dictationHotkey: KeyboardShortcut?,
+        meetingHotkey: KeyboardShortcut?,
+        collisionChecker: TransformShortcutCollisionChecking
+    ) {
+        guard let candidate = shortcut else {
+            // A nil shortcut is a valid dormant state. Surface a friendly
+            // hint (rather than an error) at the view layer; the VM keeps
+            // shortcutError nil so save is unblocked.
+            shortcutError = nil
+            return
+        }
+        let editingID = mode.initialPrompt?.id
+        let bindings: [UUID: KeyboardShortcut] = Dictionary(uniqueKeysWithValues:
+            existingTransforms.compactMap { prompt in
+                guard let s = prompt.shortcut else { return nil }
+                return (prompt.id, s)
+            }
+        )
+        let collision = collisionChecker.checkForEditor(
+            candidate: candidate,
+            existing: bindings,
+            excludingPromptID: editingID,
+            dictationHotkey: dictationHotkey,
+            meetingHotkey: meetingHotkey
+        )
+        shortcutError = collision?.message
+    }
+
+    // MARK: - Build the persistable Prompt
+
+    /// Returns the Prompt the view should persist on save. Returns nil if
+    /// validation has flagged any blocking error.
+    public func buildSavable() -> Prompt? {
+        guard isValid else { return nil }
+        let now = Date()
+        let trimmedName = normalizedName
+        let trimmedContent = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedLabel = runningLabel.trimmingCharacters(in: .whitespacesAndNewlines)
+        let encodedShortcut = shortcut?.encodedString()
+
+        switch mode {
+        case .create:
+            return Prompt(
+                id: UUID(),
+                name: trimmedName,
+                content: trimmedContent,
+                category: .transform,
+                isBuiltIn: false,
+                isVisible: true,
+                isAutoRun: false,
+                sortOrder: 200,
+                createdAt: now,
+                updatedAt: now,
+                keyboardShortcut: encodedShortcut,
+                runningLabel: trimmedLabel.isEmpty ? nil : trimmedLabel
+            )
+        case .edit(let original):
+            var updated = original
+            updated.name = trimmedName
+            updated.content = trimmedContent
+            updated.keyboardShortcut = encodedShortcut
+            updated.runningLabel = trimmedLabel.isEmpty ? nil : trimmedLabel
+            updated.updatedAt = now
+            return updated
+        }
+    }
+
+    // MARK: - Helpers
+
+    public var normalizedName: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+// MARK: - Collision-checking abstraction
+//
+// `TransformsHotkeyCollisionChecker` itself lives in the MacParakeet GUI
+// target (alongside the registry). The ViewModels target can't import
+// MacParakeet, so we define a small protocol here that the GUI side
+// retroactively conforms to. Tests can fake it without dragging in
+// CGEvent infrastructure.
+
+public protocol TransformShortcutCollisionChecking {
+    /// Named distinctly from the GUI checker's `check(...)` so the adapter
+    /// in MacParakeet doesn't introduce an ambiguity with the underlying
+    /// type's own method of the same shape.
+    func checkForEditor(
+        candidate: KeyboardShortcut,
+        existing: [UUID: KeyboardShortcut],
+        excludingPromptID: UUID?,
+        dictationHotkey: KeyboardShortcut?,
+        meetingHotkey: KeyboardShortcut?
+    ) -> TransformShortcutCollision?
+}
+
+/// Mirror of the GUI's `TransformsHotkeyCollision` for ViewModel-layer use.
+/// The GUI's checker has a small adapter that maps between the two.
+public enum TransformShortcutCollision: Equatable, Sendable {
+    case missingModifier
+    case macOSDeadKey
+    case duplicateTransform(otherPromptID: UUID)
+    case dictationHotkey
+    case meetingHotkey
+
+    public var message: String {
+        switch self {
+        case .missingModifier:
+            return "Shortcut must include a modifier key (\u{2303}, \u{2325}, \u{21E7}, or \u{2318})."
+        case .macOSDeadKey:
+            return "This shortcut produces a special character on Mac. Pick another combo."
+        case .duplicateTransform:
+            return "Another Transform already uses this shortcut."
+        case .dictationHotkey:
+            return "This shortcut conflicts with your dictation hotkey."
+        case .meetingHotkey:
+            return "This shortcut conflicts with your meeting recording hotkey."
+        }
+    }
+}

--- a/Sources/MacParakeetViewModels/TransformsViewModel.swift
+++ b/Sources/MacParakeetViewModels/TransformsViewModel.swift
@@ -104,7 +104,7 @@ public final class TransformsViewModel {
     /// custom Transforms (they don't have a default to revert to).
     @discardableResult
     public func resetBuiltIn(_ prompt: Prompt) -> Bool {
-        guard let repo, prompt.isBuiltIn else { return false }
+        guard prompt.isBuiltIn, repo != nil else { return false }
         guard let canonical = Prompt.builtInPrompts().first(where: { $0.id == prompt.id }) else {
             return false
         }

--- a/Sources/MacParakeetViewModels/TransformsViewModel.swift
+++ b/Sources/MacParakeetViewModels/TransformsViewModel.swift
@@ -1,0 +1,161 @@
+import Foundation
+import MacParakeetCore
+
+/// Drives the **Transforms** tab list (ADR-022). Owns the user-visible
+/// ordered set of `.transform` prompts plus the "no LLM provider" state
+/// surfaced in the hero card.
+///
+/// Editing a single Transform happens in `TransformEditorViewModel` —
+/// this VM owns the *collection*; the editor VM owns one *row's draft state*.
+@MainActor
+@Observable
+public final class TransformsViewModel {
+    public var transforms: [Prompt] = []
+    public var errorMessage: String?
+
+    /// Pending delete confirmation. Set when the user hits delete on a
+    /// (non-built-in) Transform; cleared on confirm or cancel.
+    public var pendingDeleteTransform: Prompt?
+
+    /// True when the user has at least one LLM provider configured. Drives
+    /// the calm "Configure in Settings" hero state.
+    public var hasLLMProvider: Bool = false
+
+    private var repo: PromptRepositoryProtocol?
+
+    public init() {}
+
+    public func configure(repo: PromptRepositoryProtocol, hasLLMProvider: Bool) {
+        self.repo = repo
+        self.hasLLMProvider = hasLLMProvider
+        load()
+    }
+
+    /// Refresh the list from the repository. Built-ins are seeded by the
+    /// reconciler at launch — this view never sees an empty list under
+    /// normal operation.
+    public func load() {
+        guard let repo else { return }
+        do {
+            transforms = try repo
+                .fetchVisible(category: .transform)
+                .sorted(by: { lhs, rhs in
+                    if lhs.sortOrder != rhs.sortOrder { return lhs.sortOrder < rhs.sortOrder }
+                    return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+                })
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    public func setHasLLMProvider(_ value: Bool) {
+        hasLLMProvider = value
+    }
+
+    // MARK: - Mutations
+
+    /// Save a new or edited Transform. Wraps the underlying GRDB save and
+    /// reloads the list so the UI reflects the change. Does NOT register
+    /// the hotkey — the coordinator's `reloadBindings()` is invoked by the
+    /// view layer after this returns successfully.
+    @discardableResult
+    public func save(_ prompt: Prompt) -> Bool {
+        guard let repo else { return false }
+        do {
+            try repo.save(prompt)
+            errorMessage = nil
+            load()
+            return true
+        } catch {
+            errorMessage = error.localizedDescription
+            return false
+        }
+    }
+
+    /// Delete a non-built-in Transform. Built-ins are protected — the
+    /// underlying repository refuses them; this helper short-circuits so
+    /// the UI can hide the action entirely.
+    @discardableResult
+    public func delete(_ prompt: Prompt) -> Bool {
+        guard let repo, !prompt.isBuiltIn else { return false }
+        do {
+            let deleted = try repo.delete(id: prompt.id)
+            if deleted {
+                errorMessage = nil
+                load()
+            }
+            return deleted
+        } catch {
+            errorMessage = error.localizedDescription
+            return false
+        }
+    }
+
+    /// Confirm a pending delete that was queued via `pendingDeleteTransform`.
+    public func confirmPendingDelete() {
+        guard let pending = pendingDeleteTransform else { return }
+        pendingDeleteTransform = nil
+        delete(pending)
+    }
+
+    /// Reset a built-in Transform's content / shortcut / runningLabel back
+    /// to its canonical defaults from `Prompt.builtInPrompts()`. No-op for
+    /// custom Transforms (they don't have a default to revert to).
+    @discardableResult
+    public func resetBuiltIn(_ prompt: Prompt) -> Bool {
+        guard let repo, prompt.isBuiltIn else { return false }
+        guard let canonical = Prompt.builtInPrompts().first(where: { $0.id == prompt.id }) else {
+            return false
+        }
+        var restored = prompt
+        restored.name = canonical.name
+        restored.content = canonical.content
+        restored.keyboardShortcut = canonical.keyboardShortcut
+        restored.runningLabel = canonical.runningLabel
+        restored.sortOrder = canonical.sortOrder
+        restored.updatedAt = Date()
+        return save(restored)
+    }
+
+    /// Re-seed missing built-in Transforms only (does NOT overwrite user
+    /// edits to existing built-ins). The header's *Reset to defaults*
+    /// affordance maps to this.
+    public func reseedMissingBuiltIns() {
+        guard let repo else { return }
+        let existingIDs = Set(transforms.map(\.id))
+        let canonical = Prompt.builtInPrompts().filter { $0.category == .transform }
+        for prompt in canonical where !existingIDs.contains(prompt.id) {
+            do {
+                try repo.save(prompt)
+            } catch {
+                errorMessage = error.localizedDescription
+                return
+            }
+        }
+        load()
+    }
+
+    // MARK: - Convenience accessors
+
+    public var customTransforms: [Prompt] {
+        transforms.filter { !$0.isBuiltIn }
+    }
+
+    public var builtInTransforms: [Prompt] {
+        transforms.filter(\.isBuiltIn)
+    }
+
+    /// Bindings map for the registry — `[Prompt.ID: KeyboardShortcut]`.
+    /// View layer hands this to `TransformsCoordinator.reloadBindings()`
+    /// after a save / delete / reseed.
+    public var shortcutBindings: [UUID: KeyboardShortcut] {
+        var bindings: [UUID: KeyboardShortcut] = [:]
+        for transform in transforms {
+            if let shortcut = transform.shortcut {
+                bindings[transform.id] = shortcut
+            }
+        }
+        return bindings
+    }
+}

--- a/Tests/CLITests/PromptsCommandTests.swift
+++ b/Tests/CLITests/PromptsCommandTests.swift
@@ -62,6 +62,32 @@ final class PromptsCommandTests: XCTestCase {
         XCTAssertEqual(found.id, p.id)
     }
 
+    func testFindPromptIgnoresTransformRows() throws {
+        let db = try DatabaseManager()
+        let repo = PromptRepository(dbQueue: db.dbQueue)
+        let polish = try XCTUnwrap(
+            (try repo.fetchVisible(category: .transform))
+                .first(where: { $0.name == "Polish" })
+        )
+
+        XCTAssertThrowsError(try findPrompt(idOrName: "Polish", repo: repo)) { error in
+            guard let lookupError = error as? CLILookupError else {
+                return XCTFail("Expected CLILookupError, got \(error)")
+            }
+            if case .notFound = lookupError {} else {
+                XCTFail("Expected .notFound, got \(lookupError)")
+            }
+        }
+        XCTAssertThrowsError(try findPrompt(idOrName: polish.id.uuidString, repo: repo)) { error in
+            guard let lookupError = error as? CLILookupError else {
+                return XCTFail("Expected CLILookupError, got \(error)")
+            }
+            if case .notFound = lookupError {} else {
+                XCTFail("Expected .notFound, got \(lookupError)")
+            }
+        }
+    }
+
     func testFindPromptThrowsNotFoundForBogusInput() throws {
         let db = try DatabaseManager()
         let repo = PromptRepository(dbQueue: db.dbQueue)
@@ -125,6 +151,29 @@ final class PromptsCommandTests: XCTestCase {
     }
 
     // MARK: - cliJSONEncoder smoke
+
+    func testListJSONExcludesTransformPrompts() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("prompts-cli-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let dbPath = tmp.appendingPathComponent("test.db").path
+
+        _ = try DatabaseManager(path: dbPath)
+
+        let command = try PromptsCommand.ListSubcommand.parse([
+            "--json",
+            "--database", dbPath,
+        ])
+        let output = try captureStandardOutput { try command.run() }
+        let prompts = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(output.utf8)) as? [[String: Any]]
+        )
+
+        XCTAssertEqual(prompts.count, 6)
+        XCTAssertTrue(prompts.allSatisfy { $0["category"] as? String == Prompt.Category.result.rawValue })
+        XCTAssertFalse(prompts.contains(where: { $0["name"] as? String == "Polish" }))
+    }
 
     // MARK: - Set validation
     // .parse() runs validate() automatically, so a failed parse with our error

--- a/Tests/CLITests/TransformsCommandTests.swift
+++ b/Tests/CLITests/TransformsCommandTests.swift
@@ -101,6 +101,39 @@ final class TransformsCommandTests: XCTestCase {
         XCTAssertEqual(del.idOrName, "Sharpen")
     }
 
+    // MARK: - JSON contract
+
+    func testTransformDTOJSONUsesDocumentedSnakeCaseKeys() throws {
+        let shortcut = KeyboardShortcut(
+            modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,
+            keyCode: 0x12,
+            keyLabel: "1"
+        )
+        let prompt = Prompt(
+            id: UUID(uuidString: "11111111-1111-1111-1111-111111111111")!,
+            name: "Sharpen",
+            content: "Make it crisp.",
+            category: .transform,
+            isBuiltIn: true,
+            createdAt: Date(timeIntervalSince1970: 0),
+            updatedAt: Date(timeIntervalSince1970: 1),
+            keyboardShortcut: shortcut.encodedString(),
+            runningLabel: "Sharpening..."
+        )
+
+        let data = try cliJSONEncoder.encode(TransformDTO(prompt: prompt))
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual(object["running_label"] as? String, "Sharpening...")
+        XCTAssertEqual(object["is_built_in"] as? Bool, true)
+        XCTAssertNotNil(object["created_at"])
+        XCTAssertNotNil(object["updated_at"])
+        XCTAssertNil(object["runningLabel"])
+        XCTAssertNil(object["isBuiltIn"])
+        XCTAssertNil(object["createdAt"])
+        XCTAssertNil(object["updatedAt"])
+    }
+
     // MARK: - End-to-end: create + list + show + delete against a real DB
 
     func testCreateListShowDeleteRoundTrip() throws {
@@ -110,10 +143,9 @@ final class TransformsCommandTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: tmp) }
         let dbPath = tmp.appendingPathComponent("test.db").path
 
-        var create = try TransformsCommand.CreateSubcommand.parse([
+        let create = try TransformsCommand.CreateSubcommand.parse([
             "--name", "Sharpen",
             "--prompt", "Make it crisp.",
-            "--shortcut", "opt+5",
             "--database", dbPath,
         ])
         try create.validate()
@@ -126,11 +158,10 @@ final class TransformsCommandTests: XCTestCase {
         XCTAssertEqual(all.count, 4)
         let sharpen = try XCTUnwrap(all.first(where: { $0.name == "Sharpen" }))
         XCTAssertFalse(sharpen.isBuiltIn)
-        XCTAssertEqual(sharpen.shortcut?.keyLabel, "5")
-        XCTAssertEqual(sharpen.shortcut?.modifierFlags, [.option])
+        XCTAssertNil(sharpen.shortcut)
 
         // Delete by name.
-        var del = try TransformsCommand.DeleteSubcommand.parse([
+        let del = try TransformsCommand.DeleteSubcommand.parse([
             "Sharpen",
             "--database", dbPath,
         ])
@@ -151,7 +182,7 @@ final class TransformsCommandTests: XCTestCase {
         // First seed the built-ins so the DB exists.
         _ = try DatabaseManager(path: dbPath)
 
-        var create = try TransformsCommand.CreateSubcommand.parse([
+        let create = try TransformsCommand.CreateSubcommand.parse([
             "--name", "Bare",
             "--prompt", "Body",
             "--shortcut", "5",  // no modifier
@@ -169,6 +200,51 @@ final class TransformsCommandTests: XCTestCase {
         }
     }
 
+    func testCreateRejectsDuplicateShortcut() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("transforms-cli-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let dbPath = tmp.appendingPathComponent("test.db").path
+
+        _ = try DatabaseManager(path: dbPath)
+
+        let create = try TransformsCommand.CreateSubcommand.parse([
+            "--name", "Duplicate Hotkey",
+            "--prompt", "Body",
+            "--shortcut", "opt+1",
+            "--database", dbPath,
+        ])
+        try create.validate()
+        XCTAssertThrowsError(try create.run()) { error in
+            let message = String(describing: error)
+            XCTAssertTrue(message.contains("already used"), "Expected duplicate-shortcut error, got: \(message)")
+            XCTAssertTrue(message.contains("Polish"), "Expected duplicate owner name, got: \(message)")
+        }
+    }
+
+    func testCreateRejectsMacOSDeadKeyShortcut() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("transforms-cli-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let dbPath = tmp.appendingPathComponent("test.db").path
+
+        _ = try DatabaseManager(path: dbPath)
+
+        let create = try TransformsCommand.CreateSubcommand.parse([
+            "--name", "Accent Breaker",
+            "--prompt", "Body",
+            "--shortcut", "opt+e",
+            "--database", dbPath,
+        ])
+        try create.validate()
+        XCTAssertThrowsError(try create.run()) { error in
+            let message = String(describing: error)
+            XCTAssertTrue(message.contains("special character"), "Expected dead-key error, got: \(message)")
+        }
+    }
+
     func testCreateRejectsDuplicateName() throws {
         let tmp = FileManager.default.temporaryDirectory
             .appendingPathComponent("transforms-cli-\(UUID().uuidString)")
@@ -178,7 +254,7 @@ final class TransformsCommandTests: XCTestCase {
 
         // Polish is a built-in — try to create a custom Transform with the
         // same name.
-        var create = try TransformsCommand.CreateSubcommand.parse([
+        let create = try TransformsCommand.CreateSubcommand.parse([
             "--name", "Polish",
             "--prompt", "Body",
             "--database", dbPath,
@@ -198,7 +274,7 @@ final class TransformsCommandTests: XCTestCase {
         let dbPath = tmp.appendingPathComponent("test.db").path
         _ = try DatabaseManager(path: dbPath)
 
-        var del = try TransformsCommand.DeleteSubcommand.parse([
+        let del = try TransformsCommand.DeleteSubcommand.parse([
             "Polish",
             "--database", dbPath,
         ])

--- a/Tests/CLITests/TransformsCommandTests.swift
+++ b/Tests/CLITests/TransformsCommandTests.swift
@@ -1,0 +1,210 @@
+import Foundation
+import XCTest
+@testable import CLI
+@testable import MacParakeetCore
+
+final class TransformsCommandTests: XCTestCase {
+
+    // MARK: - Command parsing
+
+    func testParsesListAsDefaultSubcommand() throws {
+        // `macparakeet-cli transforms` (no subcommand) → ListSubcommand.
+        let cmd = try TransformsCommand.parseAsRoot([])
+        XCTAssertTrue(cmd is TransformsCommand.ListSubcommand,
+                      "Bare `transforms` should default to ListSubcommand.")
+    }
+
+    func testParsesListWithJSON() throws {
+        let cmd = try TransformsCommand.parseAsRoot(["list", "--json"])
+        let list = try XCTUnwrap(cmd as? TransformsCommand.ListSubcommand)
+        XCTAssertTrue(list.json)
+    }
+
+    func testParsesShowWithIdArgument() throws {
+        let cmd = try TransformsCommand.parseAsRoot(["show", "Polish"])
+        let show = try XCTUnwrap(cmd as? TransformsCommand.ShowSubcommand)
+        XCTAssertEqual(show.idOrName, "Polish")
+        XCTAssertFalse(show.json)
+    }
+
+    func testParsesRunWithFileInput() throws {
+        let cmd = try TransformsCommand.parseAsRoot([
+            "run", "Polish",
+            "--provider", "anthropic", "--api-key", "test",
+            "--input", "/tmp/in.txt",
+        ])
+        let run = try XCTUnwrap(cmd as? TransformsCommand.RunSubcommand)
+        XCTAssertEqual(run.idOrName, "Polish")
+        XCTAssertEqual(run.input, "/tmp/in.txt")
+        XCTAssertFalse(run.stream)
+        XCTAssertFalse(run.json)
+    }
+
+    func testRunRejectsJSONWithStream() throws {
+        // `parseAsRoot` runs `validate()` itself; both --json and --stream
+        // present should surface the mutual-exclusivity error at parse time.
+        XCTAssertThrowsError(
+            try TransformsCommand.parseAsRoot([
+                "run", "Polish",
+                "--provider", "anthropic", "--api-key", "test",
+                "--input", "-",
+                "--json", "--stream",
+            ])
+        ) { error in
+            let message = String(describing: error)
+            XCTAssertTrue(message.contains("--json with --stream"))
+        }
+    }
+
+    func testParsesCreateRequiresPromptOrFromFile() throws {
+        XCTAssertThrowsError(
+            try TransformsCommand.parseAsRoot([
+                "create",
+                "--name", "Sharpen",
+            ]),
+            "Either --prompt or --from-file is required."
+        ) { error in
+            let message = String(describing: error)
+            XCTAssertTrue(message.contains("--prompt or --from-file"))
+        }
+    }
+
+    func testParsesCreateAcceptsShortcut() throws {
+        let cmd = try TransformsCommand.parseAsRoot([
+            "create",
+            "--name", "Sharpen",
+            "--prompt", "Make it crisp.",
+            "--shortcut", "opt+5",
+        ])
+        let create = try XCTUnwrap(cmd as? TransformsCommand.CreateSubcommand)
+        XCTAssertNoThrow(try create.validate())
+        XCTAssertEqual(create.shortcut, "opt+5")
+    }
+
+    func testParsesCreateRejectsMutuallyExclusivePromptAndFromFile() throws {
+        XCTAssertThrowsError(
+            try TransformsCommand.parseAsRoot([
+                "create",
+                "--name", "Sharpen",
+                "--prompt", "Inline",
+                "--from-file", "/tmp/x.txt",
+            ])
+        ) { error in
+            let message = String(describing: error)
+            XCTAssertTrue(message.contains("mutually exclusive"))
+        }
+    }
+
+    func testParsesDeleteSubcommand() throws {
+        let cmd = try TransformsCommand.parseAsRoot(["delete", "Sharpen"])
+        let del = try XCTUnwrap(cmd as? TransformsCommand.DeleteSubcommand)
+        XCTAssertEqual(del.idOrName, "Sharpen")
+    }
+
+    // MARK: - End-to-end: create + list + show + delete against a real DB
+
+    func testCreateListShowDeleteRoundTrip() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("transforms-cli-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let dbPath = tmp.appendingPathComponent("test.db").path
+
+        var create = try TransformsCommand.CreateSubcommand.parse([
+            "--name", "Sharpen",
+            "--prompt", "Make it crisp.",
+            "--shortcut", "opt+5",
+            "--database", dbPath,
+        ])
+        try create.validate()
+        try create.run()
+
+        // After create, the DB should have the three built-ins + Sharpen.
+        let db = try DatabaseManager(path: dbPath)
+        let repo = PromptRepository(dbQueue: db.dbQueue)
+        let all = try repo.fetchVisible(category: .transform)
+        XCTAssertEqual(all.count, 4)
+        let sharpen = try XCTUnwrap(all.first(where: { $0.name == "Sharpen" }))
+        XCTAssertFalse(sharpen.isBuiltIn)
+        XCTAssertEqual(sharpen.shortcut?.keyLabel, "5")
+        XCTAssertEqual(sharpen.shortcut?.modifierFlags, [.option])
+
+        // Delete by name.
+        var del = try TransformsCommand.DeleteSubcommand.parse([
+            "Sharpen",
+            "--database", dbPath,
+        ])
+        try del.run()
+
+        let after = try repo.fetchVisible(category: .transform)
+        XCTAssertEqual(after.count, 3)
+        XCTAssertFalse(after.contains(where: { $0.name == "Sharpen" }))
+    }
+
+    func testCreateRejectsBareKeyShortcut() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("transforms-cli-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let dbPath = tmp.appendingPathComponent("test.db").path
+
+        // First seed the built-ins so the DB exists.
+        _ = try DatabaseManager(path: dbPath)
+
+        var create = try TransformsCommand.CreateSubcommand.parse([
+            "--name", "Bare",
+            "--prompt", "Body",
+            "--shortcut", "5",  // no modifier
+            "--database", dbPath,
+        ])
+        try create.validate()
+        XCTAssertThrowsError(try create.run()) { error in
+            // The error should describe an unparseable or modifier-missing
+            // shortcut — either branch is acceptable as the user's signal.
+            let message = String(describing: error)
+            XCTAssertTrue(
+                message.contains("modifier") || message.contains("parse"),
+                "Expected shortcut-validation error, got: \(message)"
+            )
+        }
+    }
+
+    func testCreateRejectsDuplicateName() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("transforms-cli-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let dbPath = tmp.appendingPathComponent("test.db").path
+
+        // Polish is a built-in — try to create a custom Transform with the
+        // same name.
+        var create = try TransformsCommand.CreateSubcommand.parse([
+            "--name", "Polish",
+            "--prompt", "Body",
+            "--database", dbPath,
+        ])
+        try create.validate()
+        XCTAssertThrowsError(try create.run()) { error in
+            let message = String(describing: error)
+            XCTAssertTrue(message.contains("already exists"), "Expected duplicate-name error, got: \(message)")
+        }
+    }
+
+    func testDeleteRefusesBuiltIn() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("transforms-cli-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let dbPath = tmp.appendingPathComponent("test.db").path
+        _ = try DatabaseManager(path: dbPath)
+
+        var del = try TransformsCommand.DeleteSubcommand.parse([
+            "Polish",
+            "--database", dbPath,
+        ])
+        XCTAssertThrowsError(try del.run()) { error in
+            let message = String(describing: error)
+            XCTAssertTrue(message.contains("built-in"), "Expected built-in-protection error, got: \(message)")
+        }
+    }
+}

--- a/Tests/MacParakeetTests/Database/PromptRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/PromptRepositoryTests.swift
@@ -37,13 +37,86 @@ final class PromptRepositoryTests: XCTestCase {
             .appendingPathComponent("Sources/MacParakeetCore/Resources/community-prompts.json")
         let data = try Data(contentsOf: artifactURL)
         let artifactPrompts = try JSONDecoder().decode([PromptArtifact].self, from: data)
-        let builtIns = Prompt.builtInPrompts()
+        // The community-prompts artifact is the curated set of `.result`
+        // (transcript-summary) prompts. `.transform` built-ins (ADR-022) are
+        // shipped UX, not community content, and are intentionally not
+        // included.
+        let builtIns = Prompt.builtInPrompts().filter { $0.category == .result }
 
         XCTAssertEqual(artifactPrompts.count, builtIns.count)
         XCTAssertEqual(artifactPrompts.map(\.name), builtIns.map(\.name))
         XCTAssertEqual(artifactPrompts.map(\.content), builtIns.map(\.content))
         XCTAssertEqual(artifactPrompts.map(\.category), builtIns.map { $0.category.rawValue })
         XCTAssertEqual(artifactPrompts.map(\.sortOrder), builtIns.map(\.sortOrder))
+    }
+
+    func testBuiltInTransformsSeededWithDefaultShortcuts() throws {
+        let transforms = try repo.fetchVisible(category: .transform)
+            .sorted(by: { $0.sortOrder < $1.sortOrder })
+
+        XCTAssertEqual(transforms.count, 3, "Phase 2 ships exactly three built-in Transforms: Polish, Distill, Decide.")
+        XCTAssertEqual(transforms.map(\.name), ["Polish", "Distill", "Decide"])
+
+        let polish = transforms[0]
+        XCTAssertTrue(polish.isBuiltIn)
+        XCTAssertEqual(polish.category, .transform)
+        XCTAssertEqual(polish.runningLabel, "Polishing…")
+        let polishShortcut = try XCTUnwrap(polish.shortcut)
+        XCTAssertEqual(polishShortcut.keyLabel, "1")
+        XCTAssertEqual(polishShortcut.modifierFlags, [.option])
+
+        let distill = transforms[1]
+        XCTAssertEqual(distill.runningLabel, "Distilling…")
+        let distillShortcut = try XCTUnwrap(distill.shortcut)
+        XCTAssertEqual(distillShortcut.keyLabel, "2")
+
+        let decide = transforms[2]
+        XCTAssertEqual(decide.runningLabel, "Deciding…")
+        let decideShortcut = try XCTUnwrap(decide.shortcut)
+        XCTAssertEqual(decideShortcut.keyLabel, "3")
+    }
+
+    func testReconcilerPreservesUserCustomizedShortcutOnBuiltInTransform() throws {
+        // User customizes Polish's hotkey to Opt+Shift+P. A subsequent app
+        // launch (simulated by re-running the reconciler via a fresh
+        // DatabaseManager on the same file-backed DB) must NOT overwrite
+        // the user's binding back to the default Opt+1.
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("reconciler-shortcut-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+        let dbPath = tmpDir.appendingPathComponent("macparakeet.db").path
+
+        let first = try DatabaseManager(path: dbPath)
+        let firstRepo = PromptRepository(dbQueue: first.dbQueue)
+        var polish = try XCTUnwrap(
+            (try firstRepo.fetchVisible(category: .transform))
+                .first(where: { $0.name == "Polish" })
+        )
+
+        let customShortcut = KeyboardShortcut(
+            modifiers: KeyboardShortcut.ModifierFlag.option.rawValue
+                | KeyboardShortcut.ModifierFlag.shift.rawValue,
+            keyCode: 0x23, // kVK_ANSI_P
+            keyLabel: "P"
+        )
+        polish.keyboardShortcut = customShortcut.encodedString()
+        polish.runningLabel = "Refining…"
+        polish.updatedAt = Date()
+        try firstRepo.save(polish)
+
+        // Simulate a fresh boot — reconciler runs again. The user's
+        // customizations must survive.
+        let second = try DatabaseManager(path: dbPath)
+        let secondRepo = PromptRepository(dbQueue: second.dbQueue)
+        let reloaded = try XCTUnwrap(
+            (try secondRepo.fetchVisible(category: .transform))
+                .first(where: { $0.name == "Polish" })
+        )
+
+        XCTAssertEqual(reloaded.shortcut?.keyLabel, "P", "Reconciler must not overwrite user-set Transform shortcuts.")
+        XCTAssertEqual(reloaded.shortcut?.modifierFlags, [.option, .shift])
+        XCTAssertEqual(reloaded.runningLabel, "Refining…", "Reconciler must not overwrite user-set running labels.")
     }
 
     func testSaveAndFetchCustomPrompt() throws {

--- a/Tests/MacParakeetTests/Database/PromptRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/PromptRepositoryTests.swift
@@ -76,13 +76,40 @@ final class PromptRepositoryTests: XCTestCase {
         XCTAssertEqual(decideShortcut.keyLabel, "3")
     }
 
-    func testReconcilerPreservesUserCustomizedShortcutOnBuiltInTransform() throws {
-        // User customizes Polish's hotkey to Opt+Shift+P. A subsequent app
+    func testFetchAutoRunPromptsIgnoresTransformPrompts() throws {
+        var polish = try XCTUnwrap(
+            (try repo.fetchVisible(category: .transform))
+                .first(where: { $0.name == "Polish" })
+        )
+        polish.isAutoRun = true
+        polish.updatedAt = Date()
+        try repo.save(polish)
+
+        let autoRun = try repo.fetchAutoRunPrompts()
+
+        XCTAssertTrue(autoRun.allSatisfy { $0.category == .result })
+        XCTAssertFalse(autoRun.contains(where: { $0.id == polish.id }))
+    }
+
+    func testToggleAutoRunIgnoresTransformPrompts() throws {
+        let polish = try XCTUnwrap(
+            (try repo.fetchVisible(category: .transform))
+                .first(where: { $0.name == "Polish" })
+        )
+
+        try repo.toggleAutoRun(id: polish.id)
+
+        let reloaded = try XCTUnwrap(try repo.fetch(id: polish.id))
+        XCTAssertFalse(reloaded.isAutoRun)
+    }
+
+    func testReconcilerPreservesUserCustomizedBuiltInTransformFields() throws {
+        // User customizes Polish. A subsequent app
         // launch (simulated by re-running the reconciler via a fresh
         // DatabaseManager on the same file-backed DB) must NOT overwrite
-        // the user's binding back to the default Opt+1.
+        // the user's fields back to the shipped defaults.
         let tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("reconciler-shortcut-\(UUID().uuidString)")
+            .appendingPathComponent("reconciler-transform-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tmpDir) }
         let dbPath = tmpDir.appendingPathComponent("macparakeet.db").path
@@ -100,20 +127,25 @@ final class PromptRepositoryTests: XCTestCase {
             keyCode: 0x23, // kVK_ANSI_P
             keyLabel: "P"
         )
+        polish.name = "Personal Polish"
+        polish.content = "Rewrite this in my house style."
+        polish.isAutoRun = true
+        let editDate = Date(timeIntervalSince1970: 1_234_567)
         polish.keyboardShortcut = customShortcut.encodedString()
         polish.runningLabel = "Refining…"
-        polish.updatedAt = Date()
+        polish.updatedAt = editDate
         try firstRepo.save(polish)
 
         // Simulate a fresh boot — reconciler runs again. The user's
         // customizations must survive.
         let second = try DatabaseManager(path: dbPath)
         let secondRepo = PromptRepository(dbQueue: second.dbQueue)
-        let reloaded = try XCTUnwrap(
-            (try secondRepo.fetchVisible(category: .transform))
-                .first(where: { $0.name == "Polish" })
-        )
+        let reloaded = try XCTUnwrap(try secondRepo.fetch(id: polish.id))
 
+        XCTAssertEqual(reloaded.name, "Personal Polish", "Reconciler must not overwrite user-set Transform names.")
+        XCTAssertEqual(reloaded.content, "Rewrite this in my house style.", "Reconciler must not overwrite user-set Transform prompt bodies.")
+        XCTAssertEqual(reloaded.updatedAt.timeIntervalSince1970, editDate.timeIntervalSince1970, accuracy: 0.001, "Reconciler must not overwrite the user's Transform edit timestamp.")
+        XCTAssertFalse(reloaded.isAutoRun, "Built-in Transforms must not keep leaked auto-run state.")
         XCTAssertEqual(reloaded.shortcut?.keyLabel, "P", "Reconciler must not overwrite user-set Transform shortcuts.")
         XCTAssertEqual(reloaded.shortcut?.modifierFlags, [.option, .shift])
         XCTAssertEqual(reloaded.runningLabel, "Refining…", "Reconciler must not overwrite user-set running labels.")

--- a/Tests/MacParakeetTests/Database/PromptRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/PromptRepositoryTests.swift
@@ -69,11 +69,13 @@ final class PromptRepositoryTests: XCTestCase {
         XCTAssertEqual(distill.runningLabel, "Distilling…")
         let distillShortcut = try XCTUnwrap(distill.shortcut)
         XCTAssertEqual(distillShortcut.keyLabel, "2")
+        XCTAssertEqual(distillShortcut.modifierFlags, [.option])
 
         let decide = transforms[2]
         XCTAssertEqual(decide.runningLabel, "Deciding…")
         let decideShortcut = try XCTUnwrap(decide.shortcut)
         XCTAssertEqual(decideShortcut.keyLabel, "3")
+        XCTAssertEqual(decideShortcut.modifierFlags, [.option])
     }
 
     func testFetchAutoRunPromptsIgnoresTransformPrompts() throws {

--- a/Tests/MacParakeetTests/Hotkey/TransformsHotkeyRegistryTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/TransformsHotkeyRegistryTests.swift
@@ -95,6 +95,36 @@ final class TransformsHotkeyRegistryTests: XCTestCase {
         XCTAssertTrue(registry.isEmpty)
     }
 
+    func testHandleKeyUpSwallowsOwnedShortcutEvenAfterModifiersClear() throws {
+        let registry = TransformsHotkeyRegistry()
+        let id = UUID()
+        registry.register(
+            promptID: id,
+            shortcut: KeyboardShortcut(
+                modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,
+                keyCode: 0x12,
+                keyLabel: "1"
+            )
+        )
+
+        var triggeredIDs: [UUID] = []
+        registry.onTrigger = { triggeredIDs.append($0) }
+
+        let keyDown = try XCTUnwrap(CGEvent(keyboardEventSource: nil, virtualKey: 0x12, keyDown: true))
+        keyDown.flags = .maskAlternate
+
+        XCTAssertNil(registry.handleEvent(type: .keyDown, event: keyDown))
+        XCTAssertEqual(triggeredIDs, [id])
+
+        let keyUp = try XCTUnwrap(CGEvent(keyboardEventSource: nil, virtualKey: 0x12, keyDown: false))
+        keyUp.flags = []
+
+        XCTAssertNil(registry.handleEvent(type: .keyUp, event: keyUp))
+
+        let unrelatedKeyUp = try XCTUnwrap(CGEvent(keyboardEventSource: nil, virtualKey: 0x13, keyDown: false))
+        XCTAssertNotNil(registry.handleEvent(type: .keyUp, event: unrelatedKeyUp))
+    }
+
     // MARK: - Collision detection
 
     private let checker = TransformsHotkeyCollisionChecker()
@@ -106,7 +136,7 @@ final class TransformsHotkeyRegistryTests: XCTestCase {
                 candidate: bareKey,
                 existing: [:],
                 excludingPromptID: nil,
-                dictationHotkey: nil,
+                dictationHotkeys: [],
                 meetingHotkey: nil
             ),
             .missingModifier
@@ -124,7 +154,7 @@ final class TransformsHotkeyRegistryTests: XCTestCase {
                 candidate: optE,
                 existing: [:],
                 excludingPromptID: nil,
-                dictationHotkey: nil,
+                dictationHotkeys: [],
                 meetingHotkey: nil
             ),
             .macOSDeadKey
@@ -142,7 +172,7 @@ final class TransformsHotkeyRegistryTests: XCTestCase {
             candidate: opt1,
             existing: [otherID: opt1],
             excludingPromptID: nil,
-            dictationHotkey: nil,
+            dictationHotkeys: [],
             meetingHotkey: nil
         )
         XCTAssertEqual(result, .duplicateTransform(otherPromptID: otherID))
@@ -162,7 +192,7 @@ final class TransformsHotkeyRegistryTests: XCTestCase {
                 candidate: opt1,
                 existing: [selfID: opt1],
                 excludingPromptID: selfID,
-                dictationHotkey: nil,
+                dictationHotkeys: [],
                 meetingHotkey: nil
             )
         )
@@ -179,7 +209,25 @@ final class TransformsHotkeyRegistryTests: XCTestCase {
                 candidate: opt1,
                 existing: [:],
                 excludingPromptID: nil,
-                dictationHotkey: opt1,
+                dictationHotkeys: [opt1.hotkeyTrigger],
+                meetingHotkey: nil
+            ),
+            .dictationHotkey
+        )
+    }
+
+    func testCollisionModifierOnlyDictationHotkeyConflictsWithChordUsingThatModifier() {
+        let opt1 = KeyboardShortcut(
+            modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,
+            keyCode: 0x12,
+            keyLabel: "1"
+        )
+        XCTAssertEqual(
+            checker.check(
+                candidate: opt1,
+                existing: [:],
+                excludingPromptID: nil,
+                dictationHotkeys: [.option],
                 meetingHotkey: nil
             ),
             .dictationHotkey
@@ -197,8 +245,8 @@ final class TransformsHotkeyRegistryTests: XCTestCase {
                 candidate: opt1,
                 existing: [:],
                 excludingPromptID: nil,
-                dictationHotkey: nil,
-                meetingHotkey: opt1
+                dictationHotkeys: [],
+                meetingHotkey: opt1.hotkeyTrigger
             ),
             .meetingHotkey
         )
@@ -220,7 +268,7 @@ final class TransformsHotkeyRegistryTests: XCTestCase {
                 candidate: opt2,
                 existing: [UUID(): opt1],
                 excludingPromptID: nil,
-                dictationHotkey: nil,
+                dictationHotkeys: [],
                 meetingHotkey: nil
             )
         )
@@ -235,7 +283,7 @@ final class TransformsHotkeyRegistryTests: XCTestCase {
             candidate: bare,
             existing: [UUID(): bare],
             excludingPromptID: nil,
-            dictationHotkey: nil,
+            dictationHotkeys: [],
             meetingHotkey: nil
         )
         XCTAssertEqual(result, .missingModifier)

--- a/Tests/MacParakeetTests/Hotkey/TransformsHotkeyRegistryTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/TransformsHotkeyRegistryTests.swift
@@ -1,0 +1,243 @@
+import XCTest
+@testable import MacParakeet
+@testable import MacParakeetCore
+
+final class TransformsHotkeyRegistryTests: XCTestCase {
+
+    // MARK: - Dispatch table
+
+    func testRegisterReplacesPriorBindingForSamePromptID() {
+        let registry = TransformsHotkeyRegistry()
+        let id = UUID()
+
+        let opt1 = KeyboardShortcut(
+            modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,
+            keyCode: 0x12,
+            keyLabel: "1"
+        )
+        let opt2 = KeyboardShortcut(
+            modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,
+            keyCode: 0x13,
+            keyLabel: "2"
+        )
+
+        registry.register(promptID: id, shortcut: opt1)
+        XCTAssertFalse(registry.isEmpty)
+
+        // Rebinding the same prompt to a new shortcut drops the old binding.
+        registry.register(promptID: id, shortcut: opt2)
+
+        // Re-binding twice means the only mapping should still be one entry,
+        // and the old opt1 slot is free.
+        registry.unregister(promptID: id)
+        XCTAssertTrue(registry.isEmpty)
+    }
+
+    func testUnregisterDropsBinding() {
+        let registry = TransformsHotkeyRegistry()
+        let id = UUID()
+        registry.register(
+            promptID: id,
+            shortcut: KeyboardShortcut(
+                modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,
+                keyCode: 0x12,
+                keyLabel: "1"
+            )
+        )
+        XCTAssertFalse(registry.isEmpty)
+        registry.unregister(promptID: id)
+        XCTAssertTrue(registry.isEmpty)
+    }
+
+    func testRegisterNilShortcutIsUnbind() {
+        let registry = TransformsHotkeyRegistry()
+        let id = UUID()
+        registry.register(
+            promptID: id,
+            shortcut: KeyboardShortcut(
+                modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,
+                keyCode: 0x12,
+                keyLabel: "1"
+            )
+        )
+        registry.register(promptID: id, shortcut: nil)
+        XCTAssertTrue(registry.isEmpty)
+    }
+
+    func testReplaceBindingsRebuildsTableFromScratch() {
+        let registry = TransformsHotkeyRegistry()
+        let a = UUID()
+        let b = UUID()
+        registry.register(
+            promptID: a,
+            shortcut: KeyboardShortcut(
+                modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,
+                keyCode: 0x12,
+                keyLabel: "1"
+            )
+        )
+
+        registry.replaceBindings([
+            b: KeyboardShortcut(
+                modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,
+                keyCode: 0x13,
+                keyLabel: "2"
+            ),
+        ])
+
+        // The previous binding for `a` is gone, only `b` remains.
+        XCTAssertFalse(registry.isEmpty)
+        // (We can't introspect the dispatch table directly, but the empty
+        // check + the unbind below confirms the reset.)
+        registry.unregister(promptID: a)
+        XCTAssertFalse(registry.isEmpty)
+        registry.unregister(promptID: b)
+        XCTAssertTrue(registry.isEmpty)
+    }
+
+    // MARK: - Collision detection
+
+    private let checker = TransformsHotkeyCollisionChecker()
+
+    func testCollisionMissingModifierIsRejected() {
+        let bareKey = KeyboardShortcut(modifiers: 0, keyCode: 0x12, keyLabel: "1")
+        XCTAssertEqual(
+            checker.check(
+                candidate: bareKey,
+                existing: [:],
+                excludingPromptID: nil,
+                dictationHotkey: nil,
+                meetingHotkey: nil
+            ),
+            .missingModifier
+        )
+    }
+
+    func testCollisionMacOSDeadKeyIsRejected() {
+        let optE = KeyboardShortcut(
+            modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,
+            keyCode: 0x0E,
+            keyLabel: "E"
+        )
+        XCTAssertEqual(
+            checker.check(
+                candidate: optE,
+                existing: [:],
+                excludingPromptID: nil,
+                dictationHotkey: nil,
+                meetingHotkey: nil
+            ),
+            .macOSDeadKey
+        )
+    }
+
+    func testCollisionDuplicateTransformReturnsOtherID() {
+        let opt1 = KeyboardShortcut(
+            modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,
+            keyCode: 0x12,
+            keyLabel: "1"
+        )
+        let otherID = UUID()
+        let result = checker.check(
+            candidate: opt1,
+            existing: [otherID: opt1],
+            excludingPromptID: nil,
+            dictationHotkey: nil,
+            meetingHotkey: nil
+        )
+        XCTAssertEqual(result, .duplicateTransform(otherPromptID: otherID))
+    }
+
+    func testCollisionDuplicateIgnoresExcludedPromptID() {
+        let opt1 = KeyboardShortcut(
+            modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,
+            keyCode: 0x12,
+            keyLabel: "1"
+        )
+        let selfID = UUID()
+        // The user is re-saving their own Transform without changing its
+        // shortcut; the existing binding shouldn't read as a duplicate.
+        XCTAssertNil(
+            checker.check(
+                candidate: opt1,
+                existing: [selfID: opt1],
+                excludingPromptID: selfID,
+                dictationHotkey: nil,
+                meetingHotkey: nil
+            )
+        )
+    }
+
+    func testCollisionDictationHotkeyConflictReturnsDictation() {
+        let opt1 = KeyboardShortcut(
+            modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,
+            keyCode: 0x12,
+            keyLabel: "1"
+        )
+        XCTAssertEqual(
+            checker.check(
+                candidate: opt1,
+                existing: [:],
+                excludingPromptID: nil,
+                dictationHotkey: opt1,
+                meetingHotkey: nil
+            ),
+            .dictationHotkey
+        )
+    }
+
+    func testCollisionMeetingHotkeyConflictReturnsMeeting() {
+        let opt1 = KeyboardShortcut(
+            modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,
+            keyCode: 0x12,
+            keyLabel: "1"
+        )
+        XCTAssertEqual(
+            checker.check(
+                candidate: opt1,
+                existing: [:],
+                excludingPromptID: nil,
+                dictationHotkey: nil,
+                meetingHotkey: opt1
+            ),
+            .meetingHotkey
+        )
+    }
+
+    func testCollisionAcceptsValidCandidate() {
+        let opt1 = KeyboardShortcut(
+            modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,
+            keyCode: 0x12,
+            keyLabel: "1"
+        )
+        let opt2 = KeyboardShortcut(
+            modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,
+            keyCode: 0x13,
+            keyLabel: "2"
+        )
+        XCTAssertNil(
+            checker.check(
+                candidate: opt2,
+                existing: [UUID(): opt1],
+                excludingPromptID: nil,
+                dictationHotkey: nil,
+                meetingHotkey: nil
+            )
+        )
+    }
+
+    func testCollisionPriorityModifierBeatsDuplicate() {
+        // A bare-key candidate is rejected for missing-modifier even if
+        // it would also be a duplicate. Modifier check runs first because
+        // it's the more actionable user-facing error.
+        let bare = KeyboardShortcut(modifiers: 0, keyCode: 0x12, keyLabel: "1")
+        let result = checker.check(
+            candidate: bare,
+            existing: [UUID(): bare],
+            excludingPromptID: nil,
+            dictationHotkey: nil,
+            meetingHotkey: nil
+        )
+        XCTAssertEqual(result, .missingModifier)
+    }
+}

--- a/Tests/MacParakeetTests/Models/KeyboardShortcutTests.swift
+++ b/Tests/MacParakeetTests/Models/KeyboardShortcutTests.swift
@@ -1,0 +1,148 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class KeyboardShortcutTests: XCTestCase {
+
+    // MARK: - Round-trip
+
+    func testCodableRoundTrip() throws {
+        let shortcut = KeyboardShortcut(
+            modifiers: KeyboardShortcut.ModifierFlag.option.rawValue
+                | KeyboardShortcut.ModifierFlag.shift.rawValue,
+            keyCode: 0x23,
+            keyLabel: "P"
+        )
+        let encoded = try XCTUnwrap(shortcut.encodedString())
+        let decoded = try XCTUnwrap(KeyboardShortcut.decoded(from: encoded))
+        XCTAssertEqual(decoded, shortcut)
+    }
+
+    func testDecodedFromMalformedReturnsNil() {
+        XCTAssertNil(KeyboardShortcut.decoded(from: nil))
+        XCTAssertNil(KeyboardShortcut.decoded(from: "not json"))
+        XCTAssertNil(KeyboardShortcut.decoded(from: "{}"))
+    }
+
+    // MARK: - Display
+
+    func testDisplayStringUsesCanonicalMacOSOrder() {
+        // Canonical order is ⌃ ⌥ ⇧ ⌘ regardless of which order the bits are
+        // set in the underlying integer.
+        let allFour = KeyboardShortcut(
+            modifiers: KeyboardShortcut.ModifierFlag.command.rawValue
+                | KeyboardShortcut.ModifierFlag.shift.rawValue
+                | KeyboardShortcut.ModifierFlag.option.rawValue
+                | KeyboardShortcut.ModifierFlag.control.rawValue,
+            keyCode: 0x12,
+            keyLabel: "1"
+        )
+        XCTAssertEqual(allFour.displayString, "⌃⌥⇧⌘1")
+    }
+
+    func testDisplayStringUppercasesKeyLabel() {
+        let lowercase = KeyboardShortcut(
+            modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,
+            keyCode: 0x23,
+            keyLabel: "p"
+        )
+        XCTAssertEqual(lowercase.displayString, "⌥P")
+    }
+
+    // MARK: - Modifier introspection
+
+    func testHasModifierIsFalseWithoutAnyModifiers() {
+        let bare = KeyboardShortcut(modifiers: 0, keyCode: 0x12, keyLabel: "1")
+        XCTAssertFalse(bare.hasModifier)
+        XCTAssertTrue(bare.modifierFlags.isEmpty)
+    }
+
+    func testHasModifierIsTrueWithSingleModifier() {
+        let opt = KeyboardShortcut(
+            modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,
+            keyCode: 0x12,
+            keyLabel: "1"
+        )
+        XCTAssertTrue(opt.hasModifier)
+        XCTAssertEqual(opt.modifierFlags, [.option])
+    }
+
+    // MARK: - Dead-key detection
+
+    func testOptionPlusEIsRecognizedAsDeadKey() {
+        let optE = KeyboardShortcut(
+            modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,
+            keyCode: 0x0E,
+            keyLabel: "E"
+        )
+        XCTAssertTrue(optE.isMacOSDeadKey)
+    }
+
+    func testOptionPlusOneIsNotDeadKey() {
+        let optOne = KeyboardShortcut(
+            modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,
+            keyCode: 0x12,
+            keyLabel: "1"
+        )
+        XCTAssertFalse(optOne.isMacOSDeadKey)
+    }
+
+    func testOptionShiftEIsNotDeadKey() {
+        // Adding shift takes us out of the dead-key territory.
+        let optShiftE = KeyboardShortcut(
+            modifiers: KeyboardShortcut.ModifierFlag.option.rawValue
+                | KeyboardShortcut.ModifierFlag.shift.rawValue,
+            keyCode: 0x0E,
+            keyLabel: "E"
+        )
+        XCTAssertFalse(optShiftE.isMacOSDeadKey)
+    }
+
+    // MARK: - CLI parsing
+
+    func testParseOptDigit() {
+        let parsed = try? XCTUnwrap(KeyboardShortcut.parse("opt+1"))
+        XCTAssertEqual(parsed?.modifierFlags, [.option])
+        XCTAssertEqual(parsed?.keyLabel, "1")
+        XCTAssertEqual(parsed?.keyCode, 0x12)
+    }
+
+    func testParseIsCaseAndOrderInsensitive() {
+        let parsed = try? XCTUnwrap(KeyboardShortcut.parse("SHIFT+cmd+P"))
+        XCTAssertEqual(parsed?.modifierFlags, [.command, .shift])
+        XCTAssertEqual(parsed?.keyLabel, "P")
+    }
+
+    func testParseAcceptsHyphenOrSpaceSeparators() {
+        let plus = KeyboardShortcut.parse("opt+1")
+        let dash = KeyboardShortcut.parse("opt-1")
+        let spc  = KeyboardShortcut.parse("opt 1")
+        XCTAssertEqual(plus, dash)
+        XCTAssertEqual(plus, spc)
+    }
+
+    func testParseAcceptsGlyphAliases() {
+        let parsed = try? XCTUnwrap(KeyboardShortcut.parse("⌥+⇧+P"))
+        XCTAssertEqual(parsed?.modifierFlags, [.option, .shift])
+        XCTAssertEqual(parsed?.keyLabel, "P")
+    }
+
+    func testParseRejectsTwoNonModifierTokens() {
+        XCTAssertNil(KeyboardShortcut.parse("opt+1+2"))
+        XCTAssertNil(KeyboardShortcut.parse("a+b"))
+    }
+
+    func testParseRejectsModifierOnly() {
+        XCTAssertNil(KeyboardShortcut.parse("opt"))
+        XCTAssertNil(KeyboardShortcut.parse("cmd+shift"))
+    }
+
+    func testParseRejectsUnknownKey() {
+        XCTAssertNil(KeyboardShortcut.parse("opt+f24"))
+    }
+
+    func testParseRecognizesNamedKeys() {
+        let space = try? XCTUnwrap(KeyboardShortcut.parse("ctrl+opt+space"))
+        XCTAssertEqual(space?.keyCode, 0x31)
+        XCTAssertEqual(space?.keyLabel, "Space")
+    }
+}

--- a/Tests/MacParakeetTests/ViewModels/PromptsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/PromptsViewModelTests.swift
@@ -20,11 +20,11 @@ final class PromptsViewModelTests: XCTestCase {
 
         viewModel.addPrompt()
 
-        // 6 built-ins after ADR-020's 2026-05-02 revert of Memo-Steered Notes
-        // + 1 custom = 7.
-        XCTAssertEqual(viewModel.prompts.count, 7)
-        XCTAssertEqual(viewModel.prompts.last?.name, "Standup Notes")
-        XCTAssertFalse(viewModel.prompts.last?.isBuiltIn ?? true)
+        // 6 `.result` built-ins (after ADR-020's 2026-05-02 Memo-Steered Notes
+        // revert) + 3 `.transform` built-ins (ADR-022 Phase 2: Polish, Distill,
+        // Decide) + 1 custom = 10.
+        XCTAssertEqual(viewModel.prompts.count, 10)
+        XCTAssertTrue(viewModel.prompts.contains(where: { $0.name == "Standup Notes" && !$0.isBuiltIn }))
     }
 
     func testAddPromptRejectsDuplicateNameCaseInsensitive() {
@@ -33,8 +33,8 @@ final class PromptsViewModelTests: XCTestCase {
 
         viewModel.addPrompt()
 
-        // Rejected; the 6 built-ins remain (no add).
-        XCTAssertEqual(viewModel.prompts.count, 6)
+        // Rejected; the 6 `.result` + 3 `.transform` built-ins remain (no add).
+        XCTAssertEqual(viewModel.prompts.count, 9)
         XCTAssertEqual(viewModel.errorMessage, "'summary' already exists")
     }
 

--- a/Tests/MacParakeetTests/ViewModels/PromptsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/PromptsViewModelTests.swift
@@ -14,16 +14,21 @@ final class PromptsViewModelTests: XCTestCase {
         viewModel.configure(repo: repo)
     }
 
+    func testLoadPromptsFiltersOutTransformCategory() {
+        XCTAssertEqual(viewModel.prompts.count, 6)
+        XCTAssertTrue(viewModel.prompts.allSatisfy { $0.category == .result })
+        XCTAssertFalse(viewModel.prompts.contains(where: { $0.name == "Polish" }))
+    }
+
     func testAddPromptCreatesCustomSummaryPrompt() {
         viewModel.newName = "Standup Notes"
         viewModel.newContent = "Summarize as a daily standup."
 
         viewModel.addPrompt()
 
-        // 6 `.result` built-ins (after ADR-020's 2026-05-02 Memo-Steered Notes
-        // revert) + 3 `.transform` built-ins (ADR-022 Phase 2: Polish, Distill,
-        // Decide) + 1 custom = 10.
-        XCTAssertEqual(viewModel.prompts.count, 10)
+        // 6 `.result` built-ins + 1 custom. Transform built-ins live in the
+        // same table but are intentionally not part of the summary library.
+        XCTAssertEqual(viewModel.prompts.count, 7)
         XCTAssertTrue(viewModel.prompts.contains(where: { $0.name == "Standup Notes" && !$0.isBuiltIn }))
     }
 
@@ -33,9 +38,31 @@ final class PromptsViewModelTests: XCTestCase {
 
         viewModel.addPrompt()
 
-        // Rejected; the 6 `.result` + 3 `.transform` built-ins remain (no add).
-        XCTAssertEqual(viewModel.prompts.count, 9)
+        // Rejected; the 6 summary built-ins remain (no add).
+        XCTAssertEqual(viewModel.prompts.count, 6)
         XCTAssertEqual(viewModel.errorMessage, "'summary' already exists")
+    }
+
+    func testAddPromptRejectsDuplicateTransformNameHiddenFromLibrary() {
+        viewModel.newName = "Polish"
+        viewModel.newContent = "Duplicate transform name"
+
+        viewModel.addPrompt()
+
+        XCTAssertEqual(viewModel.prompts.count, 6)
+        XCTAssertEqual(viewModel.errorMessage, "'Polish' already exists")
+    }
+
+    func testUpdatePromptRejectsDuplicateTransformNameHiddenFromLibrary() {
+        let custom = Prompt(name: "Old", content: "Old content", isBuiltIn: false, sortOrder: 99)
+        repo.prompts.append(custom)
+        viewModel.loadPrompts()
+
+        viewModel.updatePrompt(custom, name: "Polish", content: "New content")
+
+        let unchanged = repo.prompts.first(where: { $0.id == custom.id })
+        XCTAssertEqual(unchanged?.name, "Old")
+        XCTAssertEqual(viewModel.errorMessage, "'Polish' already exists")
     }
 
     func testAddPromptValidationClearsWhenFieldsChange() {

--- a/Tests/MacParakeetTests/ViewModels/TransformEditorViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TransformEditorViewModelTests.swift
@@ -7,13 +7,17 @@ final class TransformEditorViewModelTests: XCTestCase {
 
     private final class StubCollisionChecker: TransformShortcutCollisionChecking {
         var result: TransformShortcutCollision?
+        var receivedDictationHotkeys: [HotkeyTrigger]?
+        var receivedMeetingHotkey: HotkeyTrigger?
         func checkForEditor(
             candidate: KeyboardShortcut,
             existing: [UUID: KeyboardShortcut],
             excludingPromptID: UUID?,
-            dictationHotkey: KeyboardShortcut?,
-            meetingHotkey: KeyboardShortcut?
+            dictationHotkeys: [HotkeyTrigger],
+            meetingHotkey: HotkeyTrigger?
         ) -> TransformShortcutCollision? {
+            receivedDictationHotkeys = dictationHotkeys
+            receivedMeetingHotkey = meetingHotkey
             return result
         }
     }
@@ -68,7 +72,7 @@ final class TransformEditorViewModelTests: XCTestCase {
         vm.content = "Some body."
         vm.validate(
             existingTransforms: [],
-            dictationHotkey: nil,
+            dictationHotkeys: [],
             meetingHotkey: nil,
             collisionChecker: StubCollisionChecker()
         )
@@ -81,7 +85,7 @@ final class TransformEditorViewModelTests: XCTestCase {
         vm.name = "Sharpen"
         vm.validate(
             existingTransforms: [],
-            dictationHotkey: nil,
+            dictationHotkeys: [],
             meetingHotkey: nil,
             collisionChecker: StubCollisionChecker()
         )
@@ -101,7 +105,7 @@ final class TransformEditorViewModelTests: XCTestCase {
         vm.content = "Body"
         vm.validate(
             existingTransforms: [other],
-            dictationHotkey: nil,
+            dictationHotkeys: [],
             meetingHotkey: nil,
             collisionChecker: StubCollisionChecker()
         )
@@ -119,7 +123,7 @@ final class TransformEditorViewModelTests: XCTestCase {
         let vm = TransformEditorViewModel(mode: .edit(prompt))
         vm.validate(
             existingTransforms: [prompt],
-            dictationHotkey: nil,
+            dictationHotkeys: [],
             meetingHotkey: nil,
             collisionChecker: StubCollisionChecker()
         )
@@ -136,12 +140,30 @@ final class TransformEditorViewModelTests: XCTestCase {
         vm.shortcut = KeyboardShortcut(modifiers: 0, keyCode: 0x12, keyLabel: "1")
         vm.validate(
             existingTransforms: [],
-            dictationHotkey: nil,
+            dictationHotkeys: [],
             meetingHotkey: nil,
             collisionChecker: stub
         )
         XCTAssertNotNil(vm.shortcutError)
         XCTAssertFalse(vm.isValid)
+    }
+
+    func testValidationPassesAppHotkeysToCollisionChecker() {
+        let stub = StubCollisionChecker()
+
+        let vm = TransformEditorViewModel(mode: .create)
+        vm.name = "Sharpen"
+        vm.content = "Body"
+        vm.shortcut = opt1
+        vm.validate(
+            existingTransforms: [],
+            dictationHotkeys: [.fn, .option],
+            meetingHotkey: .defaultMeetingRecording,
+            collisionChecker: stub
+        )
+
+        XCTAssertEqual(stub.receivedDictationHotkeys, [.fn, .option])
+        XCTAssertEqual(stub.receivedMeetingHotkey, .defaultMeetingRecording)
     }
 
     func testNilShortcutIsValidDormantState() {
@@ -151,7 +173,7 @@ final class TransformEditorViewModelTests: XCTestCase {
         vm.shortcut = nil
         vm.validate(
             existingTransforms: [],
-            dictationHotkey: nil,
+            dictationHotkeys: [],
             meetingHotkey: nil,
             collisionChecker: StubCollisionChecker()
         )
@@ -168,7 +190,7 @@ final class TransformEditorViewModelTests: XCTestCase {
         vm.content = ""
         vm.validate(
             existingTransforms: [],
-            dictationHotkey: nil,
+            dictationHotkeys: [],
             meetingHotkey: nil,
             collisionChecker: StubCollisionChecker()
         )
@@ -183,7 +205,7 @@ final class TransformEditorViewModelTests: XCTestCase {
         vm.shortcut = opt1
         vm.validate(
             existingTransforms: [],
-            dictationHotkey: nil,
+            dictationHotkeys: [],
             meetingHotkey: nil,
             collisionChecker: StubCollisionChecker()
         )
@@ -213,7 +235,7 @@ final class TransformEditorViewModelTests: XCTestCase {
         vm.content = "New body"
         vm.validate(
             existingTransforms: [],
-            dictationHotkey: nil,
+            dictationHotkeys: [],
             meetingHotkey: nil,
             collisionChecker: StubCollisionChecker()
         )
@@ -231,7 +253,7 @@ final class TransformEditorViewModelTests: XCTestCase {
         vm.runningLabel = "   " // whitespace only
         vm.validate(
             existingTransforms: [],
-            dictationHotkey: nil,
+            dictationHotkeys: [],
             meetingHotkey: nil,
             collisionChecker: StubCollisionChecker()
         )

--- a/Tests/MacParakeetTests/ViewModels/TransformEditorViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TransformEditorViewModelTests.swift
@@ -1,0 +1,240 @@
+import XCTest
+@testable import MacParakeetCore
+@testable import MacParakeetViewModels
+
+@MainActor
+final class TransformEditorViewModelTests: XCTestCase {
+
+    private final class StubCollisionChecker: TransformShortcutCollisionChecking {
+        var result: TransformShortcutCollision?
+        func checkForEditor(
+            candidate: KeyboardShortcut,
+            existing: [UUID: KeyboardShortcut],
+            excludingPromptID: UUID?,
+            dictationHotkey: KeyboardShortcut?,
+            meetingHotkey: KeyboardShortcut?
+        ) -> TransformShortcutCollision? {
+            return result
+        }
+    }
+
+    private let opt1 = KeyboardShortcut(
+        modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,
+        keyCode: 0x12,
+        keyLabel: "1"
+    )
+
+    // MARK: - Mode
+
+    func testCreateModeStartsBlank() {
+        let vm = TransformEditorViewModel(mode: .create)
+        XCTAssertTrue(vm.name.isEmpty)
+        XCTAssertTrue(vm.content.isEmpty)
+        XCTAssertNil(vm.shortcut)
+        XCTAssertTrue(vm.runningLabel.isEmpty)
+        XCTAssertTrue(vm.mode.isCreating)
+        XCTAssertFalse(vm.mode.isEditing)
+        XCTAssertFalse(vm.isBuiltIn)
+    }
+
+    func testEditModeSeedsFromExistingPrompt() {
+        let prompt = Prompt(
+            id: UUID(),
+            name: "Custom",
+            content: "Body",
+            category: .transform,
+            isBuiltIn: false,
+            keyboardShortcut: opt1.encodedString(),
+            runningLabel: "Customizing…"
+        )
+        let vm = TransformEditorViewModel(mode: .edit(prompt))
+        XCTAssertEqual(vm.name, "Custom")
+        XCTAssertEqual(vm.content, "Body")
+        XCTAssertEqual(vm.shortcut?.keyLabel, "1")
+        XCTAssertEqual(vm.runningLabel, "Customizing…")
+        XCTAssertTrue(vm.mode.isEditing)
+    }
+
+    func testEditModeOnBuiltInExposesIsBuiltInTrue() {
+        let polish = Prompt.builtInPrompts().first(where: { $0.name == "Polish" })!
+        let vm = TransformEditorViewModel(mode: .edit(polish))
+        XCTAssertTrue(vm.isBuiltIn)
+    }
+
+    // MARK: - Validation
+
+    func testValidationRejectsEmptyName() {
+        let vm = TransformEditorViewModel(mode: .create)
+        vm.content = "Some body."
+        vm.validate(
+            existingTransforms: [],
+            dictationHotkey: nil,
+            meetingHotkey: nil,
+            collisionChecker: StubCollisionChecker()
+        )
+        XCTAssertNotNil(vm.nameError)
+        XCTAssertFalse(vm.isValid)
+    }
+
+    func testValidationRejectsEmptyContent() {
+        let vm = TransformEditorViewModel(mode: .create)
+        vm.name = "Sharpen"
+        vm.validate(
+            existingTransforms: [],
+            dictationHotkey: nil,
+            meetingHotkey: nil,
+            collisionChecker: StubCollisionChecker()
+        )
+        XCTAssertNotNil(vm.contentError)
+        XCTAssertFalse(vm.isValid)
+    }
+
+    func testValidationRejectsDuplicateNameCaseInsensitive() {
+        let other = Prompt(
+            id: UUID(),
+            name: "Polish",
+            content: "body",
+            category: .transform
+        )
+        let vm = TransformEditorViewModel(mode: .create)
+        vm.name = "polish"  // different case
+        vm.content = "Body"
+        vm.validate(
+            existingTransforms: [other],
+            dictationHotkey: nil,
+            meetingHotkey: nil,
+            collisionChecker: StubCollisionChecker()
+        )
+        XCTAssertNotNil(vm.nameError)
+        XCTAssertFalse(vm.isValid)
+    }
+
+    func testValidationDuplicateIgnoresSelfInEditMode() {
+        let prompt = Prompt(
+            id: UUID(),
+            name: "Polish",
+            content: "Body",
+            category: .transform
+        )
+        let vm = TransformEditorViewModel(mode: .edit(prompt))
+        vm.validate(
+            existingTransforms: [prompt],
+            dictationHotkey: nil,
+            meetingHotkey: nil,
+            collisionChecker: StubCollisionChecker()
+        )
+        XCTAssertNil(vm.nameError, "Editing the same Transform with its existing name should not read as duplicate.")
+    }
+
+    func testShortcutCollisionSurfacesAsError() {
+        let stub = StubCollisionChecker()
+        stub.result = .missingModifier
+
+        let vm = TransformEditorViewModel(mode: .create)
+        vm.name = "Sharpen"
+        vm.content = "Body"
+        vm.shortcut = KeyboardShortcut(modifiers: 0, keyCode: 0x12, keyLabel: "1")
+        vm.validate(
+            existingTransforms: [],
+            dictationHotkey: nil,
+            meetingHotkey: nil,
+            collisionChecker: stub
+        )
+        XCTAssertNotNil(vm.shortcutError)
+        XCTAssertFalse(vm.isValid)
+    }
+
+    func testNilShortcutIsValidDormantState() {
+        let vm = TransformEditorViewModel(mode: .create)
+        vm.name = "Sharpen"
+        vm.content = "Body"
+        vm.shortcut = nil
+        vm.validate(
+            existingTransforms: [],
+            dictationHotkey: nil,
+            meetingHotkey: nil,
+            collisionChecker: StubCollisionChecker()
+        )
+        XCTAssertNil(vm.shortcutError)
+        XCTAssertTrue(vm.isValid, "A Transform with no shortcut is a valid dormant state.")
+    }
+
+    // MARK: - buildSavable
+
+    func testBuildSavableReturnsNilWhenInvalid() {
+        let vm = TransformEditorViewModel(mode: .create)
+        // Missing content + name.
+        vm.name = ""
+        vm.content = ""
+        vm.validate(
+            existingTransforms: [],
+            dictationHotkey: nil,
+            meetingHotkey: nil,
+            collisionChecker: StubCollisionChecker()
+        )
+        XCTAssertNil(vm.buildSavable())
+    }
+
+    func testBuildSavableForCreateGeneratesNewUUID() {
+        let vm = TransformEditorViewModel(mode: .create)
+        vm.name = "Sharpen"
+        vm.content = "Make it crisp."
+        vm.runningLabel = "Sharpening…"
+        vm.shortcut = opt1
+        vm.validate(
+            existingTransforms: [],
+            dictationHotkey: nil,
+            meetingHotkey: nil,
+            collisionChecker: StubCollisionChecker()
+        )
+        let saved = vm.buildSavable()
+        XCTAssertNotNil(saved)
+        XCTAssertEqual(saved?.name, "Sharpen")
+        XCTAssertEqual(saved?.category, .transform)
+        XCTAssertFalse(saved?.isBuiltIn ?? true)
+        XCTAssertEqual(saved?.runningLabel, "Sharpening…")
+        XCTAssertNotNil(saved?.keyboardShortcut)
+    }
+
+    func testBuildSavableForEditPreservesIDAndCreatedAt() {
+        let originalID = UUID()
+        let originalCreatedAt = Date(timeIntervalSinceReferenceDate: 100)
+        let prompt = Prompt(
+            id: originalID,
+            name: "Polish",
+            content: "Old body",
+            category: .transform,
+            isBuiltIn: true,
+            createdAt: originalCreatedAt,
+            keyboardShortcut: opt1.encodedString(),
+            runningLabel: "Polishing…"
+        )
+        let vm = TransformEditorViewModel(mode: .edit(prompt))
+        vm.content = "New body"
+        vm.validate(
+            existingTransforms: [],
+            dictationHotkey: nil,
+            meetingHotkey: nil,
+            collisionChecker: StubCollisionChecker()
+        )
+        let saved = vm.buildSavable()
+        XCTAssertEqual(saved?.id, originalID)
+        XCTAssertEqual(saved?.createdAt, originalCreatedAt)
+        XCTAssertEqual(saved?.content, "New body")
+        XCTAssertTrue(saved?.isBuiltIn ?? false, "Built-in flag must survive editing — protects the row from custom-transform deletion semantics.")
+    }
+
+    func testBuildSavableEmptyRunningLabelEncodesNil() {
+        let vm = TransformEditorViewModel(mode: .create)
+        vm.name = "Sharpen"
+        vm.content = "Body"
+        vm.runningLabel = "   " // whitespace only
+        vm.validate(
+            existingTransforms: [],
+            dictationHotkey: nil,
+            meetingHotkey: nil,
+            collisionChecker: StubCollisionChecker()
+        )
+        XCTAssertNil(vm.buildSavable()?.runningLabel, "Whitespace-only running label normalizes to nil.")
+    }
+}

--- a/Tests/MacParakeetTests/ViewModels/TransformsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TransformsViewModelTests.swift
@@ -1,0 +1,144 @@
+import XCTest
+@testable import MacParakeetCore
+@testable import MacParakeetViewModels
+
+@MainActor
+final class TransformsViewModelTests: XCTestCase {
+    var manager: DatabaseManager!
+    var repo: PromptRepository!
+    var viewModel: TransformsViewModel!
+
+    override func setUp() async throws {
+        manager = try DatabaseManager()
+        repo = PromptRepository(dbQueue: manager.dbQueue)
+        viewModel = TransformsViewModel()
+        viewModel.configure(repo: repo, hasLLMProvider: true)
+    }
+
+    func testLoadPullsOnlyTransformCategoryPrompts() {
+        XCTAssertEqual(viewModel.transforms.count, 3, "Three built-in Transforms ship with the app.")
+        XCTAssertTrue(viewModel.transforms.allSatisfy { $0.category == .transform })
+        // Built-in count is exposed via the helper.
+        XCTAssertEqual(viewModel.builtInTransforms.count, 3)
+        XCTAssertEqual(viewModel.customTransforms.count, 0)
+    }
+
+    func testLoadOrdersBySortOrder() {
+        let names = viewModel.transforms.map(\.name)
+        XCTAssertEqual(names, ["Polish", "Distill", "Decide"])
+    }
+
+    func testShortcutBindingsExposesNonNilShortcuts() {
+        let bindings = viewModel.shortcutBindings
+        XCTAssertEqual(bindings.count, 3, "All three built-ins ship with default shortcuts.")
+        let labels = Set(bindings.values.map(\.keyLabel))
+        XCTAssertEqual(labels, ["1", "2", "3"])
+    }
+
+    func testSaveNewCustomTransformAppendsToList() {
+        let prompt = Prompt(
+            id: UUID(),
+            name: "Soften",
+            content: "Make the message warmer.",
+            category: .transform,
+            isBuiltIn: false,
+            sortOrder: 200,
+            keyboardShortcut: nil,
+            runningLabel: nil
+        )
+        XCTAssertTrue(viewModel.save(prompt))
+        XCTAssertEqual(viewModel.transforms.count, 4)
+        XCTAssertTrue(viewModel.customTransforms.contains(where: { $0.name == "Soften" }))
+    }
+
+    func testDeleteCustomTransformRemovesRow() {
+        let prompt = Prompt(
+            id: UUID(),
+            name: "Sharpen",
+            content: "Make it crisper.",
+            category: .transform,
+            isBuiltIn: false,
+            sortOrder: 201
+        )
+        viewModel.save(prompt)
+        XCTAssertEqual(viewModel.transforms.count, 4)
+
+        XCTAssertTrue(viewModel.delete(prompt))
+        XCTAssertEqual(viewModel.transforms.count, 3)
+        XCTAssertFalse(viewModel.transforms.contains(where: { $0.id == prompt.id }))
+    }
+
+    func testDeleteBuiltInIsRejected() {
+        let polish = viewModel.transforms.first(where: { $0.name == "Polish" })!
+        XCTAssertFalse(viewModel.delete(polish), "Built-ins must be protected from deletion.")
+        XCTAssertEqual(viewModel.transforms.count, 3)
+    }
+
+    func testConfirmPendingDeleteClearsAndDeletes() {
+        let prompt = Prompt(
+            id: UUID(),
+            name: "Temp",
+            content: "Body.",
+            category: .transform,
+            isBuiltIn: false
+        )
+        viewModel.save(prompt)
+        viewModel.pendingDeleteTransform = prompt
+
+        viewModel.confirmPendingDelete()
+
+        XCTAssertNil(viewModel.pendingDeleteTransform)
+        XCTAssertFalse(viewModel.transforms.contains(where: { $0.id == prompt.id }))
+    }
+
+    func testResetBuiltInRestoresDefaultContent() {
+        // User customizes Polish: prompt body + shortcut + label.
+        var polish = viewModel.transforms.first(where: { $0.name == "Polish" })!
+        let customized = polish
+        polish.content = "Custom polish prompt body."
+        polish.keyboardShortcut = KeyboardShortcut(
+            modifiers: KeyboardShortcut.ModifierFlag.option.rawValue
+                | KeyboardShortcut.ModifierFlag.shift.rawValue,
+            keyCode: 0x23,
+            keyLabel: "P"
+        ).encodedString()
+        polish.runningLabel = "Refining…"
+        viewModel.save(polish)
+
+        XCTAssertTrue(viewModel.resetBuiltIn(polish))
+
+        let restored = viewModel.transforms.first(where: { $0.id == customized.id })!
+        XCTAssertNotEqual(restored.content, "Custom polish prompt body.")
+        XCTAssertEqual(restored.shortcut?.keyLabel, "1", "Default shortcut should be restored.")
+        XCTAssertEqual(restored.runningLabel, "Polishing…", "Default running label should be restored.")
+    }
+
+    func testReseedMissingBuiltInsRecreatesDeletedDefault() throws {
+        // Force-delete Polish via raw SQL (bypassing the built-in protection)
+        // to simulate a corrupted state where a built-in is missing.
+        let polish = viewModel.transforms.first(where: { $0.name == "Polish" })!
+        try manager.dbQueue.write { db in
+            try db.execute(sql: "DELETE FROM prompts WHERE id = ?", arguments: [polish.id])
+        }
+        viewModel.load()
+        XCTAssertEqual(viewModel.transforms.count, 2, "Polish should be gone before reseed.")
+
+        viewModel.reseedMissingBuiltIns()
+
+        XCTAssertEqual(viewModel.transforms.count, 3)
+        XCTAssertTrue(viewModel.transforms.contains(where: { $0.name == "Polish" }))
+    }
+
+    func testReseedDoesNotOverwriteExistingBuiltIn() {
+        // Customize Polish, then reseed — the custom values must survive.
+        var polish = viewModel.transforms.first(where: { $0.name == "Polish" })!
+        let customContent = "User-customized Polish body."
+        polish.content = customContent
+        viewModel.save(polish)
+
+        viewModel.reseedMissingBuiltIns()
+
+        let reloaded = viewModel.transforms.first(where: { $0.name == "Polish" })!
+        XCTAssertEqual(reloaded.content, customContent, "Reseed must not overwrite existing built-in customizations.")
+    }
+}

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -679,7 +679,9 @@ final class MockPromptRepository: PromptRepositoryProtocol, @unchecked Sendable 
         if let fetchAutoRunPromptsError {
             throw fetchAutoRunPromptsError
         }
-        return try fetchAll().filter(\.isAutoRun)
+        return try fetchAll().filter {
+            $0.isAutoRun && $0.isVisible && $0.category == .result
+        }
     }
 
     func delete(id: UUID) throws -> Bool {
@@ -699,6 +701,7 @@ final class MockPromptRepository: PromptRepositoryProtocol, @unchecked Sendable 
 
     func toggleAutoRun(id: UUID) throws {
         guard let index = prompts.firstIndex(where: { $0.id == id }) else { return }
+        guard prompts[index].category == .result else { return }
         prompts[index].isAutoRun.toggle()
         if prompts[index].isAutoRun {
             prompts[index].isVisible = true

--- a/plans/active/2026-05-transforms-phase-2-productize.md
+++ b/plans/active/2026-05-transforms-phase-2-productize.md
@@ -17,7 +17,7 @@
 
 The Transforms spike (PR #278) validated the AX-capture → LLM → in-place-replace primitive end-to-end against a hardcoded Polish prompt on Opt+Ctrl+1, with all the hard-won correctness work already landed: clipboard backup/restore, AX-write with paste-back fallback, layout-aware Cmd+C/V resolution, stale-progress guarding by run-ID, premium "rose loader" pill with patience-threshold label reveal.
 
-**Phase 2 is now: productize the surface.** Wire `Prompt.category == .transform` rows to the executor through a new `TransformsHotkeyRegistry` (single event tap, dispatch by combo), ship Polish + Prompt Engineer as built-in transforms on Opt+1 / Opt+2, build a new top-level **Transforms** tab with a premium *Create your own* editor, expose the feature through a new `macparakeet-cli transforms` subcommand tree so coding agents can drive and test it headlessly, gate it behind a single `AppFeatures.transformsEnabled` flag, instrument per-name telemetry.
+**Phase 2 is now: productize the surface.** Wire `Prompt.category == .transform` rows to the executor through a new `TransformsHotkeyRegistry` (single event tap, dispatch by combo), ship Polish / Distill / Decide as built-in transforms on Opt+1 / Opt+2 / Opt+3, build a new top-level **Transforms** tab with a premium *Create your own* editor, expose the feature through a new `macparakeet-cli transforms` subcommand tree so coding agents can drive and test it headlessly, gate it behind a single `AppFeatures.transformsEnabled` flag, instrument per-name telemetry.
 
 Three deliberate cuts up front:
 1. **No global "Opt in" toggle** (rejected by user 2026-05-12). Always-on; gating happens through whether a user has bound a hotkey to a Transform — same mental model as the dictation hotkey itself.
@@ -76,7 +76,7 @@ A new top-level sidebar item (sibling of Vocabulary, Library, Settings — IA co
    - The card itself is the click target for Edit
    - Plus a **Create your own** tile (plus glyph + label) as the final cell
 
-3. **Secondary actions** in the header — *Reset to defaults* (regenerates the two built-in transforms if user deleted/edited them), and *Create New* primary action button.
+3. **Secondary actions** in the header — *Reset to defaults* (re-seeds any missing built-in transforms), and *Create New* primary action button.
 
 4. **No-provider banner** — when no LLM provider is configured, replace the hero with a calmer inline state: *"Transforms need an LLM provider — configure in Settings."* + `[Open Settings]` button. Doesn't yank the user away; just states the dependency. Disappears once a provider is configured.
 
@@ -96,7 +96,7 @@ Modal sheet. Two-column layout matching the reference shape but earning its own 
 
 ### Floating progress pill (already shipped from the spike)
 
-The pill already exists from the spike — bottom-anchored Capsule, rhodonea loader, brand checkmark, patience-threshold label. **Phase 2 changes nothing in its visual design.** The only wiring change is that the label now derives from the bound Transform's name (e.g., *Polishing…*, *Engineering prompt…*) instead of being hardcoded — Phase 2 adds an optional `runningLabel` field on the Prompt model with the existing `{Name}ing…` heuristic as fallback.
+The pill already exists from the spike — bottom-anchored Capsule, rhodonea loader, brand checkmark, patience-threshold label. **Phase 2 changes nothing in its visual design.** The only wiring change is that the label now derives from the bound Transform's name (e.g., *Polishing…*, *Distilling…*, *Deciding…*) instead of being hardcoded — Phase 2 adds an optional `runningLabel` field on the Prompt model with the existing `{Name}ing…` heuristic as fallback.
 
 ### Premium-finish bar
 
@@ -135,16 +135,17 @@ public struct KeyboardShortcut: Codable, Equatable, Hashable, Sendable {
 
 ### Built-in transforms
 
-Two seeded rows, `isBuiltIn=true`, `category=.transform`. Stable UUIDs (reserved and documented inline next to `1C5A1B4A-7E2C-4D38-B3EF-5C0F8A7E3E1A`, the "Memo-Steered Notes" reserved sentinel):
+Three seeded rows, `isBuiltIn=true`, `category=.transform`. Stable UUIDs (reserved and documented inline next to `1C5A1B4A-7E2C-4D38-B3EF-5C0F8A7E3E1A`, the "Memo-Steered Notes" reserved sentinel):
 
 | Name | UUID (reserved) | Default shortcut | Default prompt |
 |---|---|---|---|
 | Polish | `0FCE9DDB-7E2D-4B1A-AE3E-6F7C9B2A4D11` | `⌥ Opt + 1` | Promotes tone-preserving clarity. Rewrites the input text to be cleaner, more concise, and grammatically correct without changing register or stylistic voice. Returns only the rewritten text. |
-| Prompt Engineer | `1AD7C2B0-9C6F-4F0E-9C39-5E4D1F1D2A55` | `⌥ Opt + 2` | Rewrites loose, conversational instructions as well-structured prompts suitable for an LLM. Adds explicit role framing, output constraints, and worked examples only when the input demands them. Returns only the rewritten prompt. |
+| Distill | `1AD7C2B0-9C6F-4F0E-9C39-5E4D1F1D2A55` | `⌥ Opt + 2` | Compresses rambling text to its signal while preserving actionable meaning, context, and the reasoning behind decisions. Returns only the distilled text. |
+| Decide | `2BE8D3C1-4A7F-4EBD-8F12-7C9A1E0B3D44` | `⌥ Opt + 3` | Rewrites discussion into a decision-ready note with the question, options, tradeoffs, recommendation, and any blocking uncertainty. Returns only the rewritten note. |
 
 The prompt bodies will land in the implementation commit with a deliberate, premium tone — these are user-facing built-ins.
 
-Reconciler updates: the existing prompt reconciler (`PromptRepository.reconcileBuiltIns`) gains awareness of `.transform` built-ins. It re-seeds missing rows but **never overwrites a user-edited built-in row** — same contract as `.result` built-ins today.
+Reconciler updates: the existing prompt reconciler gains awareness of `.transform` built-ins. It re-seeds missing rows and preserves user-editable fields on existing Transform built-ins (name, content, shortcut, running label, and edit timestamp), while still normalizing structural fields such as category, visibility, auto-run state, and sort order.
 
 ### TransformsHotkeyRegistry (single event tap, N transforms)
 
@@ -217,7 +218,7 @@ Single sprint, single branch, multiple logical commits.
 1. Migration: extend `prompts` table.
 2. `KeyboardShortcut` model + Codable.
 3. Update `Prompt.Columns` + Codable to round-trip new fields.
-4. Seed Polish + Prompt Engineer built-ins. Reserve UUIDs. Update reconciler.
+4. Seed Polish / Distill / Decide built-ins. Reserve UUIDs. Update reconciler.
 5. `TransformsHotkeyRegistry` actor + collision detection.
 6. `TransformsCoordinator` (replaces spike coordinator).
 7. Tests: migration, reconciler, registry collision rules, coordinator lifecycle.
@@ -297,8 +298,8 @@ All tests deterministic. No network. LLM mocked via `LLMServiceProtocol`.
 
 ## Open questions (very few — most settled by design doc)
 
-1. **Default shortcut for Prompt Engineer.** Design doc suggests `Opt+2`. Confirming that's fine vs. e.g. `Opt+P`.
-2. **Reset to defaults scope.** Does *Reset to defaults* on the Transforms tab header restore both built-ins to their defaults (overwriting user edits), or does it only re-seed missing built-ins? Recommend: only re-seed missing. A per-card *Reset* button on each built-in handles overwrite-with-confirmation. → **Locked: only re-seed missing; per-card reset for individual overwrite.**
+1. **Built-in lineup and shortcuts.** Locked 2026-05-12: Polish (`Opt+1`), Distill (`Opt+2`), Decide (`Opt+3`); `Opt+4` through `Opt+9` remain open for user customization.
+2. **Reset to defaults scope.** Does *Reset to defaults* on the Transforms tab header restore all built-ins to their defaults (overwriting user edits), or does it only re-seed missing built-ins? Recommend: only re-seed missing. A per-card *Reset* button on each built-in handles overwrite-with-confirmation. → **Locked: only re-seed missing; per-card reset for individual overwrite.**
 3. **Custom transform name in telemetry.** Currently planned to send `custom` for any non-built-in. Alternative is to send a hash of the name. Recommend: stick with `custom` for privacy.
 
 If anything else surfaces during implementation, this plan gets amended in place; the implementation commit references the amendment.

--- a/plans/active/2026-05-transforms-phase-2-productize.md
+++ b/plans/active/2026-05-transforms-phase-2-productize.md
@@ -1,0 +1,312 @@
+# Plan: Transforms — Phase 2 (Productize)
+
+> Status: **ACTIVE** — vertical slice from spike to ship-ready feature.
+> Author: agent (Claude) + Daniel
+> Date: 2026-05-12
+> Related:
+> - Design exploration: `docs/research/transforms-design-2026-05.md` (PROPOSAL, 2026-05-11)
+> - WisprFlow parity audit: `docs/research/wisprflow-parity-2026-05.md`
+> - Voice command / Agent Mode plan: `plans/active/2026-05-voice-command-agent-mode.md`
+> - Agent Mode vision: `docs/agent-mode-vision.md`
+> - Phase 1 spike: PR #278 (`spike/transforms-ax-coverage`, merged 2026-05-12 as `2a729f9a`), polish/correctness follow-ups `94f53067`, `69c2dda8`, `5a977cd6`
+> - Locks-on-merge ADR: `spec/adr/022-transforms-system-wide-rewrite.md` (drafted alongside this plan)
+
+---
+
+## TL;DR
+
+The Transforms spike (PR #278) validated the AX-capture → LLM → in-place-replace primitive end-to-end against a hardcoded Polish prompt on Opt+Ctrl+1, with all the hard-won correctness work already landed: clipboard backup/restore, AX-write with paste-back fallback, layout-aware Cmd+C/V resolution, stale-progress guarding by run-ID, premium "rose loader" pill with patience-threshold label reveal.
+
+**Phase 2 is now: productize the surface.** Wire `Prompt.category == .transform` rows to the executor through a new `TransformsHotkeyRegistry` (single event tap, dispatch by combo), ship Polish + Prompt Engineer as built-in transforms on Opt+1 / Opt+2, build a new top-level **Transforms** tab with a premium *Create your own* editor, expose the feature through a new `macparakeet-cli transforms` subcommand tree so coding agents can drive and test it headlessly, gate it behind a single `AppFeatures.transformsEnabled` flag, instrument per-name telemetry.
+
+Three deliberate cuts up front:
+1. **No global "Opt in" toggle** (rejected by user 2026-05-12). Always-on; gating happens through whether a user has bound a hotkey to a Transform — same mental model as the dictation hotkey itself.
+2. **No diff viewer / rule toggles / per-Transform model picker.** Phase 3 polish. macOS Cmd+Z is the v1 escape hatch.
+3. **No voice-driven trigger.** Owned by `2026-05-voice-command-agent-mode.md`.
+
+The bar is **premium, enterprise-grade UI/UX** that reads as the third member of an existing MacParakeet visual system (the dictation overlay, the meeting pill, the Transforms pill), not as a WisprFlow pixel-copy. The reference screenshots inform the *shape* of the surface; our visual language fills it in.
+
+---
+
+## Where the spike got us
+
+PR #278 + the three follow-up commits delivered a substantial foundation. From the merge stats:
+
+| Layer | Status | Path |
+|---|---|---|
+| `SelectionCaptureService` (AX-first + 250ms clipboard hijack with snapshot) | Built | `Sources/MacParakeetCore/Services/System/SelectionCaptureService.swift` |
+| `SelectionReplacementService` (AX-write + Cmd+V paste-back + clipboard restore) | Built | `Sources/MacParakeetCore/Services/System/SelectionReplacementService.swift` |
+| `TransformExecutor` (capture → LLM stream → replace; cooperative cancellation; restore-on-abandon) | Built | `Sources/MacParakeetCore/Services/Transforms/TransformExecutor.swift` |
+| `TransformPrompts.polish` (hardcoded spike prompt) | Built | `Sources/MacParakeetCore/Services/Transforms/TransformPrompts.swift` |
+| `PasteShortcutKeyResolver` (layout-aware Cmd+C/V resolution) | Built | `Sources/MacParakeetCore/Services/PasteShortcutKeyResolver.swift` |
+| Floating progress panel — bottom-anchored Capsule, rhodonea (5-petal squared rose, `r(θ) = sin²(5θ/2)`) loader, brand checkmark, "Still polishing…" patience reveal at 5s | Built | `Sources/MacParakeet/Views/Transforms/TransformSpikeProgressPanelController.swift` |
+| `TransformsSpikeCoordinator` (Opt+Ctrl+1 hotkey, run-ID stale-event guarding, panel lifecycle) | Built | `Sources/MacParakeet/App/TransformsSpikeCoordinator.swift` |
+| LLM service path: `LLMService.transform / transformStream / transformDetailed` | Built (pre-spike) | `Sources/MacParakeetCore/Services/LLM/LLMService.swift` |
+| CLI `macparakeet-cli llm transform --prompt … <input>` | Built (pre-spike) | `Sources/CLI/Commands/LLMTransformCommand.swift` |
+| Feature flag `AppFeatures.transformsSpikeEnabled` (default `false`) | Built | `Sources/MacParakeetCore/AppFeatures.swift:32` |
+| `Prompt.Category.transform` enum case (no built-ins shipped under this category yet) | Built (pre-spike) | `Sources/MacParakeetCore/Models/Prompt.swift:19` |
+| Test coverage: capture, replacement, executor, paste resolver | Built | `Tests/MacParakeetTests/Services/{System,Transforms}/…` |
+
+**What the spike intentionally skipped:**
+
+- No Transforms tab. The spike has no navigation surface at all.
+- No persistence for transforms — the Polish prompt is a hardcoded constant.
+- No support for N transforms. The coordinator binds exactly one hotkey to exactly one prompt.
+- No Create-your-own editor. No hotkey binding UI for Transforms.
+- No CLI subcommand tree for Transforms (the existing `llm transform` is the raw-prompt primitive).
+- No telemetry beyond the `llmTransformUsed` / `llmTransformFailed` events the LLM service already emits.
+
+Phase 2 closes every one of those gaps.
+
+---
+
+## What we're building (the product surface)
+
+### The Transforms tab
+
+A new top-level sidebar item (sibling of Vocabulary, Library, Settings — IA confirmed by the design doc). The tab contains:
+
+1. **Hero card** — short framing of what Transforms does, with a *Try it out* and *How it works* affordance. Reference screenshots show a screenshot-collage of target apps (Slack, Notes, Gmail, Linear, ChatGPT, Claude, …) — we'll do our version using MacParakeet's brand visual vocabulary, not a literal collage. The hero is not the toggle; **there is no global toggle.**
+
+2. **My Transforms** grid — three-up cards by default, each showing:
+   - Bound hotkey badge (e.g. `⌥ Opt 1`) in our existing key-cap style (same atom as the Discover sidebar / Settings)
+   - Transform name (e.g. *Polish*)
+   - One-line description (e.g. *Improve clarity and conciseness*)
+   - Hover state reveals: Edit button, Reset (for built-ins only)
+   - The card itself is the click target for Edit
+   - Plus a **Create your own** tile (plus glyph + label) as the final cell
+
+3. **Secondary actions** in the header — *Reset to defaults* (regenerates the two built-in transforms if user deleted/edited them), and *Create New* primary action button.
+
+4. **No-provider banner** — when no LLM provider is configured, replace the hero with a calmer inline state: *"Transforms need an LLM provider — configure in Settings."* + `[Open Settings]` button. Doesn't yank the user away; just states the dependency. Disappears once a provider is configured.
+
+5. **Per-Transform empty state for shortcuts** — if a user has cleared a built-in's hotkey, the card shows a *"No shortcut bound"* secondary chip in place of the key-cap; clicking the card opens the editor with the shortcut field already focused.
+
+### Create your own / Edit Transform sheet
+
+Modal sheet. Two-column layout matching the reference shape but earning its own finish:
+
+- **Left rail** — `Create your own` (or `Edit {name}` for existing) title in our serif display face, plus framing copy ("Set up a keyboard shortcut to apply this Transform.")
+- **Right column** — three stacked field cards:
+  1. **Name** (text field, placeholder *"Boss Mode"*)
+  2. **Keyboard shortcut** (hotkey recorder card, reusing `HotkeyRecorderView` from the dictation/meeting hotkey settings flow). Surfaces inline collision detection ("This shortcut conflicts with Dictation").
+  3. **Customize prompt** (multi-line text editor with placeholder *"How do you want this Transform to change your text?"*)
+- **Footer** — *Autosave On* indicator (consistent with the reference) on the left, *Reset* (built-ins only) on the right, *Save / Cancel* trailing actions. For built-ins, *Save* commits edits; for new transforms, *Save* persists the new row.
+- **Writing-samples section** — the reference shows a "Set up the name, shortcut, and prompt above to add writing samples" affordance. **Out of scope for Phase 2.** We won't show the disabled placeholder either — the section simply isn't there. Phase 3 adds few-shot sample editing.
+
+### Floating progress pill (already shipped from the spike)
+
+The pill already exists from the spike — bottom-anchored Capsule, rhodonea loader, brand checkmark, patience-threshold label. **Phase 2 changes nothing in its visual design.** The only wiring change is that the label now derives from the bound Transform's name (e.g., *Polishing…*, *Engineering prompt…*) instead of being hardcoded — Phase 2 adds an optional `runningLabel` field on the Prompt model with the existing `{Name}ing…` heuristic as fallback.
+
+### Premium-finish bar
+
+The reference screenshots are baseline references, not pixel targets. The bar we're building to:
+
+- **Visual continuity.** Every new component reuses existing atoms (key-cap chip, card chrome, button roles via `parakeetAction`, sacred-geometry indicators) rather than inventing parallel ones. Same rule as the spike pill polish commit `94f53067`.
+- **Empty/error states are first-class.** No empty list of transforms (built-ins are always seeded). No-provider state is calmer than the running state, not louder.
+- **Microinteractions are considered.** Hover reveals are eased (not instant), shortcut-recording state has its own visual emphasis, save confirmations are tactile.
+- **Typography hierarchy is intentional.** Display serif for the title, body sans for descriptions, monospace only inside the prompt-body editor.
+- **Accessibility.** Every interactive element has a label; focus rings honor the system; sheet is dismissible with Esc; recorder is keyboard-only-operable.
+
+---
+
+## Architecture
+
+### Data model — extend the existing `prompts` table
+
+The design doc and the existing `Prompt.Category.transform` enum case make this decision for us: **the Prompts table is the unit of Transform storage.** We add two nullable columns:
+
+| Column | Type | Notes |
+|---|---|---|
+| `keyboardShortcut` | TEXT (JSON-encoded `KeyboardShortcut` struct), nullable | Modifier bitmask + virtual keycode. Nullable so built-ins shipped without an active binding still persist. |
+| `runningLabel` | TEXT, nullable | Optional override for the progress-pill verb form (e.g., *Polishing…*). When `nil`, derive via the `{Name}ing…` heuristic; if even that's awkward, fall back to *Transforming…*. |
+
+Schema migration is additive — no breaking change to `.result` (summary) prompts. GRDB migration `addTransformColumnsToPrompts` runs at app boot.
+
+The `KeyboardShortcut` struct:
+
+```swift
+public struct KeyboardShortcut: Codable, Equatable, Hashable, Sendable {
+    public let modifiers: UInt          // Carbon-style flags (cmd/option/control/shift)
+    public let keyCode: UInt16          // virtual keycode (kVK_*)
+    public let keyLabel: String         // display string for the recorded key ("1", "A", etc.)
+}
+```
+
+### Built-in transforms
+
+Two seeded rows, `isBuiltIn=true`, `category=.transform`. Stable UUIDs (reserved and documented inline next to `1C5A1B4A-7E2C-4D38-B3EF-5C0F8A7E3E1A`, the "Memo-Steered Notes" reserved sentinel):
+
+| Name | UUID (reserved) | Default shortcut | Default prompt |
+|---|---|---|---|
+| Polish | `0FCE9DDB-7E2D-4B1A-AE3E-6F7C9B2A4D11` | `⌥ Opt + 1` | Promotes tone-preserving clarity. Rewrites the input text to be cleaner, more concise, and grammatically correct without changing register or stylistic voice. Returns only the rewritten text. |
+| Prompt Engineer | `1AD7C2B0-9C6F-4F0E-9C39-5E4D1F1D2A55` | `⌥ Opt + 2` | Rewrites loose, conversational instructions as well-structured prompts suitable for an LLM. Adds explicit role framing, output constraints, and worked examples only when the input demands them. Returns only the rewritten prompt. |
+
+The prompt bodies will land in the implementation commit with a deliberate, premium tone — these are user-facing built-ins.
+
+Reconciler updates: the existing prompt reconciler (`PromptRepository.reconcileBuiltIns`) gains awareness of `.transform` built-ins. It re-seeds missing rows but **never overwrites a user-edited built-in row** — same contract as `.result` built-ins today.
+
+### TransformsHotkeyRegistry (single event tap, N transforms)
+
+New actor in `Sources/MacParakeetCore/Services/Transforms/TransformsHotkeyRegistry.swift`. Owns one process-wide event tap and a `[KeyboardShortcut: Prompt.ID]` dispatch table. Re-registers on prompt repository updates via NotificationCenter.
+
+Collision detection (lifted from the design doc §4):
+- Modifier required. Bare keys are rejected with a clear error in the recorder UI.
+- No collision with the dictation hotkey or the meeting-toggle hotkey. Surface inline error.
+- Cannot duplicate another Transform's binding.
+- macOS Opt+letter dead-key combos (Opt+e, Opt+u, Opt+i, Opt+n, Opt+`) blocked with a "this combo produces a special character on Mac" message. `Opt+digit` (1-9) is the safe default range.
+
+The existing `TransformsSpikeCoordinator` is **replaced** by a new `TransformsCoordinator` that:
+- Loads `.transform` prompts from the repository
+- Registers each bound prompt with the registry
+- On hotkey fire, looks up the prompt body and runs `TransformExecutor.run(prompt: ..., onProgress: ...)` (the spike's executor is reused as-is — no changes needed to its contract)
+- Manages a single floating-pill instance, cancel-then-restart on re-trigger (existing pattern from the spike)
+- Emits per-prompt telemetry events
+
+### CLI surface
+
+New `macparakeet-cli transforms` parent command with subcommands. CLI semver bumps to a new minor — see `Sources/CLI/CHANGELOG.md`.
+
+```
+macparakeet-cli transforms list [--json]
+    # List all transforms with id, name, hotkey, isBuiltIn.
+
+macparakeet-cli transforms show <name|id> [--json]
+    # Print full transform definition including prompt body.
+
+macparakeet-cli transforms run <name|id> [--input FILE | --stdin] [--json] [--stream]
+    # Run a transform's prompt body against text input. Uses the saved
+    # prompt body, not an ad-hoc one. CLI takes text input directly —
+    # there is no AX-capture from the CLI surface. Output goes to
+    # stdout.
+
+macparakeet-cli transforms create --name "..." --prompt "..." [--shortcut "..."] [--running-label "..."] [--json]
+    # Headless install of a new Transform. Useful for agent-driven
+    # provisioning. --shortcut format: "opt+1", "cmd+shift+p", etc.
+
+macparakeet-cli transforms delete <name|id> [--json]
+    # Delete a non-built-in Transform. Refuses to delete built-ins
+    # (use `transforms reset` if we add one in a follow-up).
+```
+
+`--json` envelopes follow the `LLMResult` shape established by PR #138 (the unified `--json` contract). `transforms run --stream` streams tokens to stdout one by one; `--stream` is incompatible with `--json` (same constraint as `llm transform`).
+
+The existing `llm transform --prompt "..." <input>` stays as the raw-prompt ad-hoc primitive. `transforms run` is the saved-prompt productized surface. They coexist.
+
+### Telemetry
+
+Two events per ADR-012's allowlist convention:
+
+- `transform_executed` — fired on successful completion. Properties: `transform_name` (built-in name or `custom`), `capture_path` (`ax | clipboard`), `replace_path` (`ax | clipboardPaste`), `llm_ms`, `total_ms`. **No** prompt body, **no** selected text, **no** output text. Custom-transform names are not transmitted (telemetry sees `custom` for any non-built-in).
+- `transform_failed` — fired on failure. Properties: `transform_name` (or `custom`), `reason` (one of `empty_selection | llm_not_configured | llm_failed | replacement_failed | cancelled`). No error message bodies.
+
+**Both events require a two-repo update** before they fire in production: add to `ALLOWED_EVENTS` in `macparakeet-website/functions/api/telemetry.ts` (per `memory/feedback_telemetry_allowlist.md`). The Worker rejects entire batches if any event is unknown — co-batched valid events get silently dropped. This is flagged as a release-gate step in §"Rollout."
+
+### Feature flag
+
+Replace `AppFeatures.transformsSpikeEnabled` with `AppFeatures.transformsEnabled`. Default for the ship build: **`false`** during merge, flipped to **`true`** in the same release that ships the website telemetry-allowlist update. Two-step rollout protects against the silent-batch-drop risk.
+
+---
+
+## Implementation phases (this plan)
+
+Single sprint, single branch, multiple logical commits.
+
+### Phase A — Data + service layer (~3 hr)
+
+1. Migration: extend `prompts` table.
+2. `KeyboardShortcut` model + Codable.
+3. Update `Prompt.Columns` + Codable to round-trip new fields.
+4. Seed Polish + Prompt Engineer built-ins. Reserve UUIDs. Update reconciler.
+5. `TransformsHotkeyRegistry` actor + collision detection.
+6. `TransformsCoordinator` (replaces spike coordinator).
+7. Tests: migration, reconciler, registry collision rules, coordinator lifecycle.
+
+### Phase B — UI layer (~4 hr)
+
+1. `TransformsViewModel` (list).
+2. `TransformEditorViewModel` (create/edit, validation, autosave).
+3. `TransformsView` (premium-finish list/grid).
+4. `TransformEditorSheet` (modal editor).
+5. Wire into main navigation. Hidden behind `transformsEnabled`.
+6. Onboarding-style empty/no-provider state.
+7. Tests: ViewModels.
+
+### Phase C — CLI (~2 hr)
+
+1. `TransformsCommand` parent + `list / show / run / create / delete` subcommands.
+2. `--json` envelope wiring consistent with `llm transform`.
+3. CLI tests (`CLITests/TransformsCommandTests`).
+4. `Sources/CLI/CHANGELOG.md` minor bump.
+
+### Phase D — Polish, telemetry, docs (~2 hr)
+
+1. Telemetry events + Swift-side allowlist additions.
+2. Replace feature flag (`transformsSpikeEnabled` → `transformsEnabled`).
+3. Spec updates: `kernel/requirements.yaml`, `kernel/traceability.md`, `spec/02-features.md`, `spec/12-processing-layer.md`.
+4. ADR-022 finalized (Status: PROPOSAL → IMPLEMENTED on merge).
+5. CLAUDE.md framing update (Transforms as a fourth surface, sibling to the three primary modes).
+6. AGENTS.md + integrations/README.md vocabulary update.
+7. `swift test` green; dev-build smoke pass.
+
+### Phase E — Rollout (post-merge, owner-driven)
+
+1. Update `ALLOWED_EVENTS` in `macparakeet-website/functions/api/telemetry.ts`. Deploy.
+2. In a follow-up commit on this branch (or a fresh micro-PR), flip `transformsEnabled = true`.
+3. Tag a release point that includes both the allowlist deploy timestamp + the flag flip.
+
+---
+
+## Test matrix
+
+| Layer | Tests |
+|---|---|
+| Migration | Adding `keyboardShortcut` + `runningLabel` columns is idempotent. Existing rows unaffected. Built-in reseed honors user edits. |
+| `KeyboardShortcut` | Codable round-trip. Display string for common combos. Modifier-required validation. |
+| `TransformsHotkeyRegistry` | Register / unregister. Collision rejection (dictation, meeting, duplicate, dead-key). Re-register on repo change. |
+| `TransformsCoordinator` | Hotkey fire → executor invoked with correct prompt body. Cancel-then-restart on re-trigger. Telemetry on success / failure. |
+| `TransformsViewModel` | List load, create, delete, reset built-in. No-provider state correctness. |
+| `TransformEditorViewModel` | Validation (name, shortcut, prompt). Collision detection inline. Autosave debounce. Reset behavior on built-ins. |
+| CLI `transforms` | Argument parsing for each subcommand. `--json` envelope shape matches LLMResult conventions. `run` with `--input` vs `--stdin`. `create` happy path + shortcut-parse failures. `delete` refuses built-ins. |
+| Smoke | Dev-build: open Transforms tab, create custom transform, bind shortcut, run on selected text in TextEdit, verify pill animation, verify result paste, verify Cmd+Z undoes. |
+
+All tests deterministic. No network. LLM mocked via `LLMServiceProtocol`.
+
+---
+
+## Out of scope (deferred to Phase 3 or later)
+
+- Diff preview (`See changes in diff` modal from the reference). Cmd+Z is the v1 escape hatch.
+- Rule toggles (WisprFlow's "Make more concise" composable polish rules).
+- Per-Transform LLM model override picker.
+- Writing samples / few-shot example editing.
+- Voice-driven trigger ("hold Fn, say 'make this more formal'"). Owned by `2026-05-voice-command-agent-mode.md`.
+- Inline streaming into the target text field (deemed too fragile across host apps).
+- Per-app routing (Polish-in-Slack behaves differently from Polish-in-Gmail).
+
+---
+
+## Rollout & gates
+
+1. **Merge gate:** `swift test` green, dev-build smoke pass, ADR-022 finalized, spec/kernel updated, plan archived to `plans/completed/`.
+2. **Pre-ship gate (telemetry):** `macparakeet-website` Worker `ALLOWED_EVENTS` deployment includes `transform_executed` + `transform_failed`. Confirmed via curl test.
+3. **Ship gate:** `AppFeatures.transformsEnabled = true` flip. Single small commit.
+4. **Post-ship:** monitor `transform_executed` / `transform_failed` counts for 48 hours. Compare to spike's `llm_transform_used` baseline. Flag any unexpected `reason=replacement_failed` spike (host-app AX coverage regression).
+
+---
+
+## Open questions (very few — most settled by design doc)
+
+1. **Default shortcut for Prompt Engineer.** Design doc suggests `Opt+2`. Confirming that's fine vs. e.g. `Opt+P`.
+2. **Reset to defaults scope.** Does *Reset to defaults* on the Transforms tab header restore both built-ins to their defaults (overwriting user edits), or does it only re-seed missing built-ins? Recommend: only re-seed missing. A per-card *Reset* button on each built-in handles overwrite-with-confirmation. → **Locked: only re-seed missing; per-card reset for individual overwrite.**
+3. **Custom transform name in telemetry.** Currently planned to send `custom` for any non-built-in. Alternative is to send a hash of the name. Recommend: stick with `custom` for privacy.
+
+If anything else surfaces during implementation, this plan gets amended in place; the implementation commit references the amendment.
+
+---
+
+## Connection to the broader product narrative
+
+Transforms is the hotkey-driven half of what `docs/agent-mode-vision.md` calls *Command Mode* — a primitive that will also be reachable via voice once `plans/active/2026-05-voice-command-agent-mode.md` ships. Building the hotkey path first is the conservative move: it validates the AX/clipboard primitive (done by the spike) and the management UI (this plan), and leaves the voice trigger layer as a thin replacement on the input edge.
+
+The framing in CLAUDE.md needs to evolve from *three co-equal modes* (dictation, file transcription, meeting recording) to *three primary modes + Transforms as a system-wide surface*. Transforms isn't a fourth "mode" — it doesn't have its own capture pipeline; it operates on whatever's selected anywhere in macOS. It earns its own sidebar tab, but the conceptual hierarchy is preserved.

--- a/spec/adr/022-transforms-system-wide-rewrite.md
+++ b/spec/adr/022-transforms-system-wide-rewrite.md
@@ -71,7 +71,7 @@ Collision rules (rejected at bind time in `TransformEditorViewModel`):
 - **No collision with the meeting-toggle hotkey.**
 - **No duplicate Transform binding.**
 - **macOS Opt+letter dead-key combos blocked** (`Opt+e`, `Opt+u`, `Opt+i`, `Opt+n`, ``Opt+` `` — these produce alt-characters and stealing them is hostile).
-- **Reserved space:** `Opt+digit` (1–9) is the recommended default range. The Phase 2 built-ins use `⌥+1` (Polish), `⌥+2` (Distill), `⌥+3` (Decide). The lineup was synthesized from independent creative-director and staff-PM reviews (2026-05-12); the *Improve → Re-shape → Re-direct* pedagogy is intentional, and replaces the WisprFlow-inherited *Polish + Prompt Engineer* placeholders. "Prompt Engineer" was rejected as too AI-insider; *Distill* and *Decide* generalize better across the user's full surface (Slack, Linear, email, design docs, tickets).
+- **Reserved space:** `Opt+digit` (1–9) is the recommended default range. The Phase 2 built-ins use `⌥+1` (Polish), `⌥+2` (Distill), `⌥+3` (Decide). The lineup was synthesized from independent creative-director and staff-PM reviews (2026-05-12); the *Improve → Re-shape → Re-direct* pedagogy is intentional, and the shipped set avoids AI-insider naming in favor of verbs that generalize across the user's full surface (Slack, Linear, email, design docs, tickets).
 
 ### 5. No global "Opt in" toggle
 
@@ -87,13 +87,13 @@ The product-level feature flag `AppFeatures.transformsEnabled` exists for staged
 
 Transforms use the user's configured LLM provider (cloud API key, local Ollama / LM Studio, local Apple Foundation Models when available). The product ships with **no** first-party LLM — every transform call is on the user's dime against their configured provider. Matches the AI Formatter (PR #100) precedent.
 
-`Polish` and `Prompt Engineer` are not gated behind paid tiers. The public build is free / GPL-3.0; Transforms is free.
+`Polish`, `Distill`, and `Decide` are not gated behind paid tiers. The public build is free / GPL-3.0; Transforms is free.
 
 ### 7. CLI parity via `macparakeet-cli transforms` subcommand tree
 
 The CLI is a public, semver-tracked contract (`Sources/CLI/CHANGELOG.md`). Coding agents (OpenClaw / Hermes path per `plans/active/cli-as-canonical-parakeet-surface.md`) need to drive Transforms headlessly for testing and provisioning.
 
-```
+```text
 transforms list [--json]
 transforms show <name|id> [--json]
 transforms run <name|id> [--input FILE | --stdin] [--stream] [--json]
@@ -123,7 +123,7 @@ Replaces the spike flag `transformsSpikeEnabled`. Default `false` at merge; flip
 When `false`:
 - Transforms tab is hidden from the sidebar.
 - `TransformsHotkeyRegistry` is not initialized — no event tap registered, no key dispatch.
-- Existing data (Polish + Prompt Engineer built-in rows) remain in the DB; reconciler still seeds them so flipping the flag is a no-data-migration operation.
+- Existing data (Polish / Distill / Decide built-in rows) remain in the DB; reconciler still seeds them so flipping the flag is a no-data-migration operation.
 - CLI `transforms` subcommands still work (the CLI doesn't gate on the GUI flag).
 
 ## Consequences

--- a/spec/adr/022-transforms-system-wide-rewrite.md
+++ b/spec/adr/022-transforms-system-wide-rewrite.md
@@ -71,7 +71,7 @@ Collision rules (rejected at bind time in `TransformEditorViewModel`):
 - **No collision with the meeting-toggle hotkey.**
 - **No duplicate Transform binding.**
 - **macOS Opt+letter dead-key combos blocked** (`Opt+e`, `Opt+u`, `Opt+i`, `Opt+n`, ``Opt+` `` — these produce alt-characters and stealing them is hostile).
-- **Reserved space:** `Opt+digit` (1–9) is the recommended default range. The Phase 2 built-ins use `Opt+1` (Polish) and `Opt+2` (Prompt Engineer).
+- **Reserved space:** `Opt+digit` (1–9) is the recommended default range. The Phase 2 built-ins use `⌥+1` (Polish), `⌥+2` (Distill), `⌥+3` (Decide). The lineup was synthesized from independent creative-director and staff-PM reviews (2026-05-12); the *Improve → Re-shape → Re-direct* pedagogy is intentional, and replaces the WisprFlow-inherited *Polish + Prompt Engineer* placeholders. "Prompt Engineer" was rejected as too AI-insider; *Distill* and *Decide* generalize better across the user's full surface (Slack, Linear, email, design docs, tickets).
 
 ### 5. No global "Opt in" toggle
 

--- a/spec/adr/022-transforms-system-wide-rewrite.md
+++ b/spec/adr/022-transforms-system-wide-rewrite.md
@@ -1,0 +1,182 @@
+# ADR-022: Transforms — System-Wide LLM Rewrites on Selected Text
+
+> Status: PROPOSAL
+> Date: 2026-05-12
+> Related: ADR-002 (local-first processing, BYO-key amendment), ADR-009 (custom hotkey support), ADR-011 (LLM via cloud + optional local providers), ADR-012 (telemetry), ADR-013 (Prompt Library + multi-summary)
+
+## Context
+
+PR #278 shipped a behind-flag spike of *Transforms* — hotkey-triggered LLM rewrites that operate on whatever text is currently selected anywhere on macOS, replacing the selection in place with the LLM's response. The spike validated the end-to-end primitive (AX-capture → LLM stream → in-place replace) against a hardcoded *Polish* prompt on `⌥⌃ Opt + Ctrl + 1`, including the hard cases: AX failures fall back to clipboard hijack with snapshot/restore; layout-aware Cmd+C/V resolution; stale-progress guarding by run-ID; restore-on-abandon on every error/cancel path.
+
+The design exploration (`docs/research/transforms-design-2026-05.md`) frames Transforms as the **hotkey-driven half of a future Command Mode** primitive — the same selection-capture → LLM-rewrite → in-place-replace pipeline that the voice variant tracked in `plans/active/2026-05-voice-command-agent-mode.md` will need, with a simpler trigger. Building the hotkey path first validates the AX coverage question (decision gate of Phase 1) before we invest in voice routing.
+
+This ADR locks the architecture for productizing the spike — Phase 2 in the design doc, planned in `plans/active/2026-05-transforms-phase-2-productize.md`.
+
+## Decision
+
+### 1. Transforms are stored as `Prompt` rows with `category == .transform`
+
+The existing `Prompt` model (introduced by ADR-013 for the multi-summary system) already has `Category.transform`. Phase 2 adopts that category as the unit of Transform storage, rather than introducing a parallel `transforms` table.
+
+Rationale:
+- `Prompt` already gives us identity (UUID), name, content (prompt body), `isBuiltIn`, `isVisible`, `sortOrder`, `createdAt`, `updatedAt`. All of those are Transform-shaped.
+- A separate table would force a join for what is essentially the same lifecycle (CRUD, reconcile-built-ins-on-launch).
+- The `prompts` table is small (single-digit-to-low-tens of rows in practice) — adding two nullable columns for Transform-specific concerns is a smaller cost than the duplicated CRUD + repository + reconciler that a parallel table would require.
+
+`.result` prompts (transcript summaries) and `.transform` prompts (selection rewrites) share storage but never share UI surfaces. They are functionally separate features with the same persistence shape.
+
+### 2. Schema extensions
+
+Two nullable columns are added to `prompts` via a forward-only migration:
+
+| Column | Type | Purpose |
+|---|---|---|
+| `keyboardShortcut` | TEXT (JSON), nullable | Encodes a `KeyboardShortcut { modifiers, keyCode, keyLabel }` struct. NULL means "this Transform has no bound shortcut" (a valid, dormant state). |
+| `runningLabel` | TEXT, nullable | Optional gerund-form label for the floating progress pill (e.g., *"Polishing…"*). NULL means "derive via the `{Name}ing…` heuristic; fall back to *Transforming…* for awkward names." |
+
+Migration is additive. `.result` prompts ignore both columns (they will always read NULL, and they have no UI to set them). No data migration needed for existing rows.
+
+### 3. AX-first capture with clipboard-hijack fallback (locked by spike)
+
+`SelectionCaptureService.captureSelection()` returns one of:
+
+```swift
+public enum SelectionCaptureResult {
+    case ax(text: String, element: AXUIElement)
+    case clipboard(text: String, savedClipboard: NSPasteboardItemSnapshot?)
+    case empty
+    case failed(SelectionCaptureError)
+}
+```
+
+Strategy:
+1. Query `AXUIElementCreateSystemWide` + `kAXFocusedUIElementAttribute` + `kAXSelectedTextAttribute`. If non-empty → `.ax`.
+2. AX path fails or empty → snapshot clipboard → simulate Cmd+C (layout-aware via `PasteShortcutKeyResolver`) → poll changeCount with 250ms timeout → if changed, return `.clipboard` with snapshot; else `.empty`.
+3. Restore the original clipboard snapshot **only after** the paste-back path completes or the run is abandoned. Restore-on-abandon hooks fire on every failure / cancel path (locked by PR #278 commit `69c2dda8`).
+
+`SelectionReplacementService.replace(with:in:)` returns `SelectionReplacementPath` (`.ax | .clipboardPaste`):
+1. `.ax` capture → try AX-write (`AXUIElementSetAttributeValue(elem, kAXSelectedTextAttribute, newText)`). On read-back match, done.
+2. AX-write failure OR `.clipboard` capture → set new text on clipboard → simulate Cmd+V → wait ~500ms → restore the original clipboard snapshot.
+3. Any clipboard activity is run inside a snapshot-take/restore guard that detects intervening user copies (PR #278 `69c2dda8`).
+
+The 250ms read timeout and ~500ms post-paste delay are conventional values cribbed from Raycast / Espanso. They are the right empirical defaults; documented here for future tuning.
+
+### 4. One process-wide `TransformsHotkeyRegistry` (single event tap, N transforms)
+
+A single global event tap dispatches `KeyboardShortcut → Prompt.ID`. Replaces the spike's hardcoded single-hotkey coordinator.
+
+Collision rules (rejected at bind time in `TransformEditorViewModel`):
+- **Modifier required.** Bare-key bindings rejected. Matches WisprFlow's *"Shortcut must include modifier key…"* constraint.
+- **No collision with the dictation hotkey** (`HotkeyManager` + `GlobalShortcutManager` user-bound combos).
+- **No collision with the meeting-toggle hotkey.**
+- **No duplicate Transform binding.**
+- **macOS Opt+letter dead-key combos blocked** (`Opt+e`, `Opt+u`, `Opt+i`, `Opt+n`, ``Opt+` `` — these produce alt-characters and stealing them is hostile).
+- **Reserved space:** `Opt+digit` (1–9) is the recommended default range. The Phase 2 built-ins use `Opt+1` (Polish) and `Opt+2` (Prompt Engineer).
+
+### 5. No global "Opt in" toggle
+
+The reference (WisprFlow) gates the entire Transforms surface behind a global *Opt in* toggle. We reject that pattern. Justification (settled with the owner 2026-05-12):
+
+> *"User just explicitly presses the key to use it. It's the same with all other features. No need for toggle on or off — it just means that the keys have been set/provided/used or not."*
+
+The mental model: a Transform is "on" if and only if a hotkey is bound to it. Built-ins ship with default hotkeys bound; users can clear them. There is no second-order gate. This is consistent with how the dictation hotkey, the meeting-toggle hotkey, and the global shortcuts in other surfaces work.
+
+The product-level feature flag `AppFeatures.transformsEnabled` exists for staged rollout (replaces `transformsSpikeEnabled`) — when false, the Transforms tab is hidden and the hotkey registry isn't initialized at all. This is a release-gate, not a user preference.
+
+### 6. BYO-key only (no first-party LLM)
+
+Transforms use the user's configured LLM provider (cloud API key, local Ollama / LM Studio, local Apple Foundation Models when available). The product ships with **no** first-party LLM — every transform call is on the user's dime against their configured provider. Matches the AI Formatter (PR #100) precedent.
+
+`Polish` and `Prompt Engineer` are not gated behind paid tiers. The public build is free / GPL-3.0; Transforms is free.
+
+### 7. CLI parity via `macparakeet-cli transforms` subcommand tree
+
+The CLI is a public, semver-tracked contract (`Sources/CLI/CHANGELOG.md`). Coding agents (OpenClaw / Hermes path per `plans/active/cli-as-canonical-parakeet-surface.md`) need to drive Transforms headlessly for testing and provisioning.
+
+```
+transforms list [--json]
+transforms show <name|id> [--json]
+transforms run <name|id> [--input FILE | --stdin] [--stream] [--json]
+transforms create --name --prompt [--shortcut] [--running-label] [--json]
+transforms delete <name|id> [--json]
+```
+
+`transforms run` operates on **text the CLI is given directly** (file or stdin). There is no AX-capture from the CLI; that's a GUI-only concern. The CLI is the headless test / provisioning surface.
+
+The existing `llm transform --prompt "..." <input>` continues to exist as the raw-prompt ad-hoc primitive. `transforms run <name>` is the saved-prompt productized surface. They coexist.
+
+### 8. Telemetry — opt-out, per-name counts, no content
+
+Two events:
+
+- `transform_executed` — `transform_name` (built-in name, or `custom`), `capture_path`, `replace_path`, `llm_ms`, `total_ms`. **No** prompt body. **No** selected text. **No** output text.
+- `transform_failed` — `transform_name` (or `custom`), `reason` (enumerated).
+
+Custom-Transform names are never transmitted (every non-built-in maps to `custom` in telemetry). This protects users who name a Transform after the company they're using it for, etc.
+
+Both events must be added to `ALLOWED_EVENTS` in `macparakeet-website/functions/api/telemetry.ts` before they fire in production (per `memory/feedback_telemetry_allowlist.md` — the Worker drops the entire batch on any unknown event). This is a two-repo coordination point baked into the rollout plan.
+
+### 9. Feature-flag rollout (`AppFeatures.transformsEnabled`)
+
+Replaces the spike flag `transformsSpikeEnabled`. Default `false` at merge; flipped to `true` in a separate, small commit after the website telemetry-allowlist deploy is confirmed.
+
+When `false`:
+- Transforms tab is hidden from the sidebar.
+- `TransformsHotkeyRegistry` is not initialized — no event tap registered, no key dispatch.
+- Existing data (Polish + Prompt Engineer built-in rows) remain in the DB; reconciler still seeds them so flipping the flag is a no-data-migration operation.
+- CLI `transforms` subcommands still work (the CLI doesn't gate on the GUI flag).
+
+## Consequences
+
+### Positive
+
+- The Transforms feature ships on top of existing, exercised infrastructure: `Prompt` table, `LLMService.transform*`, `GlobalShortcutManager`, accessibility permission, paste-back simulation, telemetry pipeline. No new subsystem, just a new top-level surface.
+- A single dispatch table means the in-flight model is clear: at most one Transform runs at a time; cancel-then-restart on re-trigger is locally enforceable.
+- CLI parity means agent operators (per `cli-as-canonical-parakeet-surface.md`) can drive Transforms headlessly — useful both for our own dogfooding and for the agent-audience growth angle.
+- The "no global toggle" decision keeps the feature consistent with the rest of the app's gesture-as-affordance model.
+
+### Negative / accepted trade-offs
+
+- Adding nullable Transform-specific columns to the `prompts` table is mild schema clutter for `.result` rows. Accepted; the cost is a few NULL bytes per summary prompt and is dominated by the joins it avoids.
+- Clipboard hijack / restore dance is racy by definition (user copies during the ~500ms window are partially clobbered). Mitigated by PR #278's intervening-copy detection; an unrecoverable edge case is logged and the user's most-recent copy is preserved. Documented as a known limitation.
+- The feature ships free, against user-paid LLM providers. If users hammer Transforms against an expensive cloud model, that cost is theirs. The pill's patience threshold + the per-Transform telemetry helps us notice runaway-latency patterns.
+- macOS Cmd+Z is the v1 escape hatch for unwanted Transforms. No inline diff or preview. Phase 3 adds the diff viewer; until then, users accept "press it, Cmd+Z if you didn't like it."
+
+### Non-decisions (still open, will be locked in later ADRs if needed)
+
+- **Voice-driven trigger.** Owned by `2026-05-voice-command-agent-mode.md`. The architecture here is general enough to be reused if/when that ships, but this ADR makes no commitment.
+- **Per-Transform LLM model override.** Phase 3.
+- **Rule toggles (composable Polish rules).** Phase 3.
+- **Few-shot writing samples.** Phase 3.
+
+## Alternatives considered
+
+### Alternative A — Separate `transforms` table
+
+Make Transforms a first-class table with its own model, repository, and reconciler. Foreign-key to `prompts` for the prompt body or duplicate it.
+
+Rejected: doubles the lifecycle (two reconcilers, two migrations to keep in sync, two CRUD surfaces) for what is essentially the same data shape. The `Prompt.Category.transform` enum case was added in ADR-013 in anticipation of exactly this — the foundation was laid intentionally.
+
+### Alternative B — Per-Transform `GlobalShortcutManager` instance
+
+Spawn one `GlobalShortcutManager` per active Transform binding (the design doc's Option A). Simpler at first glance.
+
+Rejected: multiple managers compete on the same event tap; one-tap-to-rule-them-all (`TransformsHotkeyRegistry`) is structurally cleaner, makes collision detection trivial, and keeps the cancel-then-restart semantics centralized.
+
+### Alternative C — Inline streaming into the target text field
+
+Stream LLM tokens directly into the focused field as they arrive, instead of waiting for completion + pasting once.
+
+Rejected: every host app handles "rapid-fire inserts via paste" differently — some batch undo, some flicker, some fight with autocomplete. The cost-of-getting-it-wrong is "the user's document looks scrambled mid-transform." The cost of waiting is "the user sees a small rose loader for 1-3 seconds." The patience-threshold pattern from PR #278 commit `94f53067` covers the long-tail latency cases. Streaming-into-field can be revisited if streaming-into-pill ever loses its appeal.
+
+### Alternative D — Implicit Cmd+A on empty selection
+
+WisprFlow appears to do an implicit "select all in focused field" when the hotkey fires with no selection, then transforms the resulting all-text.
+
+Rejected (design doc §"No-selection and error UX"): dangerous in long-text contexts. Imagine pressing Opt+1 in an open Notes document expecting a small adjustment and instead the entire document gets sent to an LLM and replaced. Even Cmd+Z to restore feels scary at that scale. AX `Cmd+A` semantics also vary across apps. The educational toast does the teaching job at far lower risk.
+
+## Implementation pointer
+
+Phase 2 of `docs/research/transforms-design-2026-05.md`, executed per `plans/active/2026-05-transforms-phase-2-productize.md`. The spike code from PR #278 graduates with minimal change to its low-level services (`SelectionCaptureService`, `SelectionReplacementService`, `TransformExecutor`); the new code is the registry, the productized coordinator, the management UI, and the CLI subcommand tree.
+
+This ADR moves from PROPOSAL → IMPLEMENTED when the Phase 2 work merges to `main`.


### PR DESCRIPTION
System-wide LLM rewrites on selected text. Select anywhere on macOS, press a bound hotkey, the selection is rewritten in place through your configured LLM provider. ⌘Z undoes.

```
   Selection anywhere                 Press hotkey               In-place rewrite
        on macOS                                                  via your LLM

  ┌──────────────────────┐         ┌────────────────┐         ┌──────────────────────┐
  │ "yeah we should      │         │   ⌥1  Polish   │         │ "Yeah, we should     │
  │  prob just ship it   │  ─────► │   ⌥2  Distill  │ ─────►  │  probably ship it    │
  │  tmrw idk lol"       │         │   ⌥3  Decide   │         │  tomorrow."          │
  └──────────────────────┘         └────────────────┘         └──────────────────────┘
       any app on Mac              ⌥4–9 reserved              ⌘Z restores the original
                                   for user customs
```

## What ships

- **Three premium-built Transforms** as defaults: *Polish*, *Distill*, *Decide* — synthesized from independent creative-director + staff-PM reviews. Pedagogy: **Improve → Re-shape → Re-direct**. Replaces the WisprFlow-inherited *Polish + Prompt Engineer*.
- **Transforms tab** + **Create-your-own editor sheet** with a live shortcut recorder and inline collision validation.
- **Single process-wide hotkey registry** — one `CGEvent` tap, `[KeyboardShortcut: UUID]` dispatch table, modifier-required + dead-key-blocked + dictation/meeting collision detection.
- **CLI parity** via `macparakeet-cli transforms list / show / run / create / delete` (semver 2.1.0 → 2.2.0). `--json` envelopes use a snake-cased `TransformDTO` shape.
- **Privacy-preserving telemetry** — `transform_executed` / `transform_failed` events. Built-in names verbatim (`polish` / `distill` / `decide`); customs anonymized to `custom`. No prompt body, no selected text, no output.

## Architecture (ADR-022)

`Prompt.category == .transform` is the storage unit — additive migration adds `keyboardShortcut` (JSON) and `runningLabel` columns. AX-first selection capture with clipboard-hijack fallback (shipped + battle-tested by the spike PR #278). The brand-finished floating pill — bottom-anchored Capsule, 5-petal rhodonea loader, patience-threshold label — is reused unchanged.

## Rollout

Behind `AppFeatures.transformsEnabled = false` at merge. Two-step deploy to avoid the silent-batch-drop hazard documented in `memory/feedback_telemetry_allowlist.md`:

1. **Merge this PR.** Tab hidden, registry not installed, CLI works regardless.
2. **Deploy** `transform_executed` / `transform_failed` to `ALLOWED_EVENTS` in [`macparakeet-website/functions/api/telemetry.ts`](https://github.com/moona3k/macparakeet-website/blob/main/functions/api/telemetry.ts).
3. **Flip** `transformsEnabled = true` in a one-line follow-up commit. Ship via Sparkle.

## Test plan

- [x] `swift build` clean across all targets
- [x] `swift test` — **2621 tests pass** (10 skipped, 0 failures, ~100s)
- [x] CLI smoke: `transforms list` shows the three built-ins with default hotkeys
- [ ] Dev-build smoke: tab loads → editor records a hotkey → *Polish* runs end-to-end in TextEdit / Notes / Slack → ⌘Z undoes cleanly
- [ ] Keypath sanity: registry's keyDown swallowing doesn't leak into host-app typing flow

## Deferred to Phase 3

Diff viewer · rule-toggle composition · per-Transform model override · writing samples · voice-driven trigger (owned by `plans/active/2026-05-voice-command-agent-mode.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a Transforms tab with Create/Edit flows, progress pill, per-transform running labels, shortcut capture/validation, and a system-wide hotkey registry.
  * Seeds three built-in transforms (Polish, Distill, Decide) and exposes a CLI `transforms` suite (list/show/run/create/delete) with JSON/streaming output and validation.

* **Behavior Changes**
  * Persists optional transform shortcuts & running labels; built-ins are protected from deletion.

* **Tests**
  * Comprehensive unit & integration tests for CLI, hotkeys, models, view models, and persistence.

* **Documentation**
  * ADR and product plan for Transforms Phase 2.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moona3k/macparakeet/pull/282)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->