### PR TITLE
Add local Transform history

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -106,6 +106,20 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
     (`id`, `name`, `shortcut`, `running_label`, `is_built_in`,
     `prompt`, `created_at`, `updated_at`) — consumers don't see the
     internal `Prompt` shape.
+- `transforms history list / show / delete / clear` — new local Transform
+  history surface for testing and recovering saved GUI Transform runs.
+  - `transforms history [list] [--limit N] [--json]` — lists local
+    Transform history, newest first.
+  - `transforms history show <id|prefix> [--json]` — prints one saved
+    input/output pair with app/path/timing metadata.
+  - `transforms history delete <id|prefix> [--json]` — removes one saved
+    history item.
+  - `transforms history clear [--json]` — removes all saved Transform
+    history from the local database.
+  - JSON uses snake-cased fields: `transform_id`, `transform_name`,
+    `input_text`, `output_text`, `source_app_bundle_id`,
+    `source_app_name`, `capture_path`, `replacement_path`,
+    `llm_elapsed_ms`, `total_elapsed_ms`, `created_at`, `updated_at`.
 
 ### Fixed
 

--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -116,7 +116,7 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
     history item.
   - `transforms history clear [--json]` — removes all saved Transform
     history from the local database.
-  - JSON uses snake-cased fields: `transform_id`, `transform_name`,
+  - JSON uses snake-cased fields: `id`, `transform_id`, `transform_name`,
     `input_text`, `output_text`, `source_app_bundle_id`,
     `source_app_name`, `capture_path`, `replacement_path`,
     `llm_elapsed_ms`, `total_elapsed_ms`, `created_at`, `updated_at`.

--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -120,6 +120,8 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
     `input_text`, `output_text`, `source_app_bundle_id`,
     `source_app_name`, `capture_path`, `replacement_path`,
     `llm_elapsed_ms`, `total_elapsed_ms`, `created_at`, `updated_at`.
+  - `delete --json` emits `{ "ok": true, "id": "..." }`.
+    `clear --json` emits `{ "ok": true, "deleted_count": N }`.
 
 ### Fixed
 

--- a/Sources/CLI/Commands/CLIHelpers.swift
+++ b/Sources/CLI/Commands/CLIHelpers.swift
@@ -288,6 +288,31 @@ enum CLIErrorType {
         }
         if error is CLILookupError { return lookup }
         if error is CLIInputError { return inputEmpty }
+        if let transforms = error as? CLITransformsError {
+            switch transforms {
+            case .notFound, .ambiguous:
+                return lookup
+            case .duplicateName,
+                 .invalidShortcut,
+                 .shortcutMissingModifier,
+                 .shortcutMacOSDeadKey,
+                 .duplicateShortcut,
+                 .shortcutConflictsWithDictation,
+                 .shortcutConflictsWithMeeting,
+                 .deleteBuiltIn:
+                return validation
+            }
+        }
+        if let transformHistory = error as? CLITransformHistoryError {
+            switch transformHistory {
+            case .notFound, .ambiguous:
+                return lookup
+            case .prefixTooShort:
+                return validation
+            case .deleteFailed:
+                return runtime
+            }
+        }
         if let qpe = error as? QuickPromptCLIError {
             switch qpe {
             case .cannotDeleteBuiltIn: return validation
@@ -375,7 +400,7 @@ private func rethrowWithOptionalJSONEnvelope(_ error: Error, json: Bool) throws 
     guard json else { throw error }
     let envelope = CLIErrorEnvelope(error: error)
     try? printJSON(envelope)
-    if error is ValidationError || error is CLIInputError {
+    if envelope.errorType == CLIErrorType.validation || error is CLIInputError {
         throw cliValidationMisuseExitCode
     }
     throw ExitCode.failure

--- a/Sources/CLI/Commands/TransformsCommand.swift
+++ b/Sources/CLI/Commands/TransformsCommand.swift
@@ -20,6 +20,7 @@ struct TransformsCommand: AsyncParsableCommand {
             RunSubcommand.self,
             CreateSubcommand.self,
             DeleteSubcommand.self,
+            HistorySubcommand.self,
         ],
         defaultSubcommand: ListSubcommand.self
     )
@@ -352,6 +353,177 @@ extension TransformsCommand {
     }
 }
 
+// MARK: - History
+
+extension TransformsCommand {
+    struct HistorySubcommand: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "history",
+            abstract: "Inspect and manage local Transform history.",
+            subcommands: [
+                ListSubcommand.self,
+                ShowSubcommand.self,
+                DeleteSubcommand.self,
+                ClearSubcommand.self,
+            ],
+            defaultSubcommand: ListSubcommand.self
+        )
+
+        struct ListSubcommand: ParsableCommand {
+            static let configuration = CommandConfiguration(
+                commandName: "list",
+                abstract: "List saved Transform runs, newest first."
+            )
+
+            @Option(help: "Maximum number of history rows to print.")
+            var limit: Int = 20
+
+            @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+            var json: Bool = false
+
+            @Option(help: "Path to SQLite database file (defaults to the app database).")
+            var database: String?
+
+            func validate() throws {
+                guard limit > 0 else {
+                    throw ValidationError("--limit must be greater than zero.")
+                }
+            }
+
+            func run() throws {
+                try emitJSONOrRethrow(json: json) {
+                    let repo = try transformHistoryRepo(database: database)
+                    let entries = try repo.fetchRecent(limit: limit)
+
+                    if json {
+                        try printJSON(entries.map(TransformHistoryDTO.init(entry:)))
+                        return
+                    }
+
+                    if entries.isEmpty {
+                        print("No Transform history found.")
+                        return
+                    }
+
+                    let formatter = ISO8601DateFormatter()
+                    for entry in entries {
+                        print("\(entry.id.uuidString.prefix(8))  \(formatter.string(from: entry.createdAt))  \(entry.transformName)  \(entry.sourceAppDisplayName)")
+                        print("  \(singleLinePreview(entry.outputText, maxLength: 140))")
+                    }
+                    print()
+                    print("\(entries.count) Transform history item(s)")
+                }
+            }
+        }
+
+        struct ShowSubcommand: ParsableCommand {
+            static let configuration = CommandConfiguration(
+                commandName: "show",
+                abstract: "Show one saved Transform run."
+            )
+
+            @Argument(help: "History item ID or ID prefix.")
+            var idPrefix: String
+
+            @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+            var json: Bool = false
+
+            @Option(help: "Path to SQLite database file (defaults to the app database).")
+            var database: String?
+
+            func run() throws {
+                try emitJSONOrRethrow(json: json) {
+                    let repo = try transformHistoryRepo(database: database)
+                    let entry = try findTransformHistoryEntry(idPrefix: idPrefix, repo: repo)
+
+                    if json {
+                        try printJSON(TransformHistoryDTO(entry: entry))
+                        return
+                    }
+
+                    let formatter = ISO8601DateFormatter()
+                    print("ID:           \(entry.id.uuidString)")
+                    print("Transform:    \(entry.transformName)")
+                    if let transformId = entry.transformId {
+                        print("Transform ID: \(transformId.uuidString)")
+                    }
+                    print("Source app:   \(entry.sourceAppDisplayName)")
+                    print("Capture:      \(entry.capturePath)")
+                    print("Replacement:  \(entry.replacementPath)")
+                    print("LLM:          \(entry.llmElapsedMs)ms")
+                    print("Total:        \(entry.totalElapsedMs)ms")
+                    print("Created:      \(formatter.string(from: entry.createdAt))")
+                    print()
+                    print("Input:")
+                    print(entry.inputText)
+                    print()
+                    print("Output:")
+                    print(entry.outputText)
+                }
+            }
+        }
+
+        struct DeleteSubcommand: ParsableCommand {
+            static let configuration = CommandConfiguration(
+                commandName: "delete",
+                abstract: "Delete one saved Transform history item."
+            )
+
+            @Argument(help: "History item ID or ID prefix.")
+            var idPrefix: String
+
+            @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+            var json: Bool = false
+
+            @Option(help: "Path to SQLite database file (defaults to the app database).")
+            var database: String?
+
+            func run() throws {
+                try emitJSONOrRethrow(json: json) {
+                    let repo = try transformHistoryRepo(database: database)
+                    let entry = try findTransformHistoryEntry(idPrefix: idPrefix, repo: repo)
+                    guard try repo.delete(id: entry.id) else {
+                        throw CLITransformHistoryError.deleteFailed(entry.id.uuidString)
+                    }
+
+                    if json {
+                        try printJSON(TransformHistoryDeleteResult(ok: true, id: entry.id.uuidString))
+                    } else {
+                        print("Deleted Transform history item \(entry.id.uuidString.prefix(8))")
+                    }
+                }
+            }
+        }
+
+        struct ClearSubcommand: ParsableCommand {
+            static let configuration = CommandConfiguration(
+                commandName: "clear",
+                abstract: "Clear all local Transform history."
+            )
+
+            @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+            var json: Bool = false
+
+            @Option(help: "Path to SQLite database file (defaults to the app database).")
+            var database: String?
+
+            func run() throws {
+                try emitJSONOrRethrow(json: json) {
+                    let repo = try transformHistoryRepo(database: database)
+                    let deletedCount = try repo.count()
+                    try repo.deleteAll()
+
+                    if json {
+                        try printJSON(TransformHistoryClearResult(ok: true, deletedCount: deletedCount))
+                    } else {
+                        print("Cleared \(deletedCount) Transform history item(s)")
+                    }
+                }
+            }
+        }
+    }
+}
+
 // MARK: - Lookup helper
 
 private func findTransform(idOrName: String, repo: PromptRepository) throws -> Prompt {
@@ -374,6 +546,43 @@ private func findTransform(idOrName: String, repo: PromptRepository) throws -> P
         return nameMatch
     }
     throw CLITransformsError.notFound(idOrName)
+}
+
+private func transformHistoryRepo(database: String?) throws -> TransformHistoryRepository {
+    try AppPaths.ensureDirectories()
+    let db = try DatabaseManager(path: resolvedDatabasePath(database))
+    return TransformHistoryRepository(dbQueue: db.dbQueue)
+}
+
+private func findTransformHistoryEntry(idPrefix: String, repo: TransformHistoryRepository) throws -> TransformHistoryEntry {
+    let trimmed = idPrefix.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+        throw CLITransformHistoryError.notFound(idPrefix)
+    }
+
+    let entries = try repo.fetchAll()
+    if let uuid = UUID(uuidString: trimmed), let exact = entries.first(where: { $0.id == uuid }) {
+        return exact
+    }
+
+    let lowered = trimmed.lowercased()
+    let matches = entries.filter { $0.id.uuidString.lowercased().hasPrefix(lowered) }
+    if matches.count == 1 {
+        return matches[0]
+    }
+    if matches.count > 1 {
+        throw CLITransformHistoryError.ambiguous(trimmed, matches.map { String($0.id.uuidString.prefix(8)) })
+    }
+    throw CLITransformHistoryError.notFound(trimmed)
+}
+
+private func singleLinePreview(_ text: String, maxLength: Int) -> String {
+    let collapsed = text
+        .replacingOccurrences(of: "\n", with: " ")
+        .replacingOccurrences(of: "\t", with: " ")
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    guard collapsed.count > maxLength else { return collapsed }
+    return String(collapsed.prefix(max(0, maxLength - 1))) + "..."
 }
 
 // MARK: - DTO + errors
@@ -414,6 +623,69 @@ struct TransformDTO: Encodable {
     }
 }
 
+struct TransformHistoryDTO: Encodable {
+    let id: String
+    let transformId: String?
+    let transformName: String
+    let inputText: String
+    let outputText: String
+    let sourceAppBundleID: String?
+    let sourceAppName: String?
+    let capturePath: String
+    let replacementPath: String
+    let llmElapsedMs: Int
+    let totalElapsedMs: Int
+    let createdAt: Date
+    let updatedAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case transformId = "transform_id"
+        case transformName = "transform_name"
+        case inputText = "input_text"
+        case outputText = "output_text"
+        case sourceAppBundleID = "source_app_bundle_id"
+        case sourceAppName = "source_app_name"
+        case capturePath = "capture_path"
+        case replacementPath = "replacement_path"
+        case llmElapsedMs = "llm_elapsed_ms"
+        case totalElapsedMs = "total_elapsed_ms"
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+    }
+
+    init(entry: TransformHistoryEntry) {
+        id = entry.id.uuidString
+        transformId = entry.transformId?.uuidString
+        transformName = entry.transformName
+        inputText = entry.inputText
+        outputText = entry.outputText
+        sourceAppBundleID = entry.sourceAppBundleID
+        sourceAppName = entry.sourceAppName
+        capturePath = entry.capturePath
+        replacementPath = entry.replacementPath
+        llmElapsedMs = entry.llmElapsedMs
+        totalElapsedMs = entry.totalElapsedMs
+        createdAt = entry.createdAt
+        updatedAt = entry.updatedAt
+    }
+}
+
+struct TransformHistoryDeleteResult: Encodable {
+    let ok: Bool
+    let id: String
+}
+
+struct TransformHistoryClearResult: Encodable {
+    let ok: Bool
+    let deletedCount: Int
+
+    enum CodingKeys: String, CodingKey {
+        case ok
+        case deletedCount = "deleted_count"
+    }
+}
+
 enum CLITransformsError: Error, CustomStringConvertible {
     case notFound(String)
     case ambiguous(String, [String])
@@ -450,6 +722,25 @@ enum CLITransformsError: Error, CustomStringConvertible {
             return "Cannot delete the built-in Transform “\(n)”. Reset it via the GUI or override its prompt body with `transforms create --name ...`."
         }
     }
+}
+
+enum CLITransformHistoryError: Error, CustomStringConvertible, LocalizedError {
+    case notFound(String)
+    case ambiguous(String, [String])
+    case deleteFailed(String)
+
+    var description: String {
+        switch self {
+        case .notFound(let value):
+            return "No Transform history item matching '\(value)'"
+        case .ambiguous(let value, let matches):
+            return "Ambiguous Transform history ID '\(value)' (matches: \(matches.joined(separator: ", ")))"
+        case .deleteFailed(let value):
+            return "Failed to delete Transform history item '\(value)'"
+        }
+    }
+
+    var errorDescription: String? { description }
 }
 
 private func shortcutsMatch(_ lhs: KeyboardShortcut, _ rhs: KeyboardShortcut) -> Bool {

--- a/Sources/CLI/Commands/TransformsCommand.swift
+++ b/Sources/CLI/Commands/TransformsCommand.swift
@@ -554,19 +554,26 @@ private func transformHistoryRepo(database: String?) throws -> TransformHistoryR
     return TransformHistoryRepository(dbQueue: db.dbQueue)
 }
 
-private func findTransformHistoryEntry(idPrefix: String, repo: TransformHistoryRepository) throws -> TransformHistoryEntry {
+private let transformHistoryIDPrefixMinimumLength = 4
+
+private func findTransformHistoryEntry(idPrefix: String, repo: TransformHistoryRepositoryProtocol) throws -> TransformHistoryEntry {
     let trimmed = idPrefix.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else {
         throw CLITransformHistoryError.notFound(idPrefix)
     }
 
-    let entries = try repo.fetchAll()
-    if let uuid = UUID(uuidString: trimmed), let exact = entries.first(where: { $0.id == uuid }) {
+    if let uuid = UUID(uuidString: trimmed), let exact = try repo.fetch(id: uuid) {
         return exact
     }
 
-    let lowered = trimmed.lowercased()
-    let matches = entries.filter { $0.id.uuidString.lowercased().hasPrefix(lowered) }
+    guard trimmed.count >= transformHistoryIDPrefixMinimumLength else {
+        throw CLITransformHistoryError.prefixTooShort(
+            min: transformHistoryIDPrefixMinimumLength,
+            provided: trimmed
+        )
+    }
+
+    let matches = try repo.fetch(idPrefix: trimmed)
     if matches.count == 1 {
         return matches[0]
     }
@@ -727,6 +734,7 @@ enum CLITransformsError: Error, CustomStringConvertible {
 enum CLITransformHistoryError: Error, CustomStringConvertible, LocalizedError {
     case notFound(String)
     case ambiguous(String, [String])
+    case prefixTooShort(min: Int, provided: String)
     case deleteFailed(String)
 
     var description: String {
@@ -735,6 +743,8 @@ enum CLITransformHistoryError: Error, CustomStringConvertible, LocalizedError {
             return "No Transform history item matching '\(value)'"
         case .ambiguous(let value, let matches):
             return "Ambiguous Transform history ID '\(value)' (matches: \(matches.joined(separator: ", ")))"
+        case .prefixTooShort(let min, let provided):
+            return "Transform history ID prefix '\(provided)' is too short. Use at least \(min) characters."
         case .deleteFailed(let value):
             return "Failed to delete Transform history item '\(value)'"
         }

--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -12,6 +12,7 @@ final class AppEnvironment {
     let chatConversationRepo: ChatConversationRepository
     let promptRepo: PromptRepository
     let promptResultRepo: PromptResultRepository
+    let transformHistoryRepo: TransformHistoryRepository
     let quickPromptRepo: QuickPromptRepository
     let sttRuntime: STTRuntime
     let sttScheduler: STTScheduler
@@ -48,6 +49,7 @@ final class AppEnvironment {
         chatConversationRepo = ChatConversationRepository(dbQueue: databaseManager.dbQueue)
         promptRepo = PromptRepository(dbQueue: databaseManager.dbQueue)
         promptResultRepo = PromptResultRepository(dbQueue: databaseManager.dbQueue)
+        transformHistoryRepo = TransformHistoryRepository(dbQueue: databaseManager.dbQueue)
         quickPromptRepo = QuickPromptRepository(dbQueue: databaseManager.dbQueue)
 
         // Services

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -128,7 +128,11 @@ final class AppEnvironmentConfigurer {
             self?.settingsViewModel.refreshStats()
         }
         promptsViewModel.configure(repo: env.promptRepo)
-        transformsViewModel.configure(repo: env.promptRepo, hasLLMProvider: hasLLMConfig)
+        transformsViewModel.configure(
+            repo: env.promptRepo,
+            historyRepo: env.transformHistoryRepo,
+            hasLLMProvider: hasLLMConfig
+        )
         llmSettingsViewModel.configure(
             configStore: env.llmConfigStore,
             llmClient: env.llmClient

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -131,6 +131,7 @@ final class AppEnvironmentConfigurer {
         transformsViewModel.configure(
             repo: env.promptRepo,
             historyRepo: env.transformHistoryRepo,
+            clipboardService: env.clipboardService,
             hasLLMProvider: hasLLMConfig
         )
         llmSettingsViewModel.configure(

--- a/Sources/MacParakeet/App/TransformsCoordinator.swift
+++ b/Sources/MacParakeet/App/TransformsCoordinator.swift
@@ -23,6 +23,7 @@ import OSLog
 final class TransformsCoordinator {
     private let llmServiceProvider: () -> LLMServiceProtocol?
     private let promptRepository: PromptRepositoryProtocol
+    private let historyRepository: TransformHistoryRepositoryProtocol
     private let logger = Logger(subsystem: "com.macparakeet", category: "TransformsCoordinator")
 
     private var registry: TransformsHotkeyRegistry?
@@ -45,10 +46,12 @@ final class TransformsCoordinator {
 
     init(
         llmServiceProvider: @escaping () -> LLMServiceProtocol?,
-        promptRepository: PromptRepositoryProtocol
+        promptRepository: PromptRepositoryProtocol,
+        historyRepository: TransformHistoryRepositoryProtocol
     ) {
         self.llmServiceProvider = llmServiceProvider
         self.promptRepository = promptRepository
+        self.historyRepository = historyRepository
     }
 
     // MARK: - Lifecycle
@@ -178,6 +181,7 @@ final class TransformsCoordinator {
 
         let runID = UUID()
         activeRunID = runID
+        let sourceApp = Self.currentSourceApp()
 
         panelController?.show(label: prompt.derivedRunningLabel)
 
@@ -219,6 +223,11 @@ final class TransformsCoordinator {
                     llmMs: result.llmElapsedMs,
                     totalMs: result.totalElapsedMs
                 ))
+                self.saveHistory(
+                    result: result,
+                    prompt: prompt,
+                    sourceApp: sourceApp
+                )
                 self.logger.notice("transforms: \(runningTransformName, privacy: .public) completed")
             } catch let error as TransformExecutorError {
                 guard self.activeRunID == runID else { return }
@@ -245,6 +254,39 @@ final class TransformsCoordinator {
                 self.panelController?.fail(message: error.localizedDescription)
                 Telemetry.send(.transformFailed(transformName: telemetryName, reason: .llmFailed))
             }
+        }
+    }
+
+    private static func currentSourceApp() -> (bundleID: String?, name: String?) {
+        let app = NSWorkspace.shared.frontmostApplication
+        return (app?.bundleIdentifier, app?.localizedName)
+    }
+
+    private func saveHistory(
+        result: TransformExecutionResult,
+        prompt: Prompt,
+        sourceApp: (bundleID: String?, name: String?)
+    ) {
+        let now = Date()
+        let entry = TransformHistoryEntry(
+            transformId: prompt.id,
+            transformName: prompt.name,
+            inputText: result.inputText,
+            outputText: result.outputText,
+            sourceAppBundleID: sourceApp.bundleID,
+            sourceAppName: sourceApp.name,
+            capturePath: result.captureTag,
+            replacementPath: result.path.rawValue,
+            llmElapsedMs: result.llmElapsedMs,
+            totalElapsedMs: result.totalElapsedMs,
+            createdAt: now,
+            updatedAt: now
+        )
+        do {
+            try historyRepository.save(entry)
+            NotificationCenter.default.post(name: .transformHistoryChanged, object: nil)
+        } catch {
+            logger.error("transforms: failed to save local history: \(error.localizedDescription, privacy: .public)")
         }
     }
 }

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -419,7 +419,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // feature flag is off.
         let transforms = TransformsCoordinator(
             llmServiceProvider: llmServiceProvider,
-            promptRepository: env.promptRepo
+            promptRepository: env.promptRepo,
+            historyRepository: env.transformHistoryRepo
         )
         transforms.start()
         transformsCoordinator = transforms

--- a/Sources/MacParakeet/Views/MainWindowState.swift
+++ b/Sources/MacParakeet/Views/MainWindowState.swift
@@ -28,5 +28,7 @@ extension Notification.Name {
     /// `TransformsCoordinator` can reload bindings into the hotkey
     /// registry.
     static let transformsBindingsChanged = Notification.Name("com.macparakeet.transforms.bindingsChanged")
+    /// Posted after a successful Transform is saved to local history so the
+    /// Transforms tab can refresh if it is visible.
+    static let transformHistoryChanged = Notification.Name("com.macparakeet.transforms.historyChanged")
 }
-

--- a/Sources/MacParakeet/Views/Transforms/TransformsView.swift
+++ b/Sources/MacParakeet/Views/Transforms/TransformsView.swift
@@ -34,6 +34,7 @@ struct TransformsView: View {
                 myTransformsHeader
                 transformGrid
 
+                historySection
                 footerActions
             }
             .padding(.horizontal, DesignSystem.Spacing.xl)
@@ -41,6 +42,12 @@ struct TransformsView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .background(DesignSystem.Colors.background)
+        .onAppear {
+            viewModel.loadHistory()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .transformHistoryChanged)) { _ in
+            viewModel.loadHistory()
+        }
         .alert(
             "Delete this Transform?",
             isPresented: Binding(
@@ -58,6 +65,33 @@ struct TransformsView: View {
             }
         } message: { transform in
             Text("“\(transform.name)” will be removed. You can re-create it later.")
+        }
+        .alert(
+            "Delete history item?",
+            isPresented: Binding(
+                get: { viewModel.pendingDeleteHistoryEntry != nil },
+                set: { if !$0 { viewModel.pendingDeleteHistoryEntry = nil } }
+            ),
+            presenting: viewModel.pendingDeleteHistoryEntry
+        ) { _ in
+            Button("Delete", role: .destructive) {
+                viewModel.confirmPendingHistoryDelete()
+            }
+            Button("Cancel", role: .cancel) {
+                viewModel.pendingDeleteHistoryEntry = nil
+            }
+        } message: { entry in
+            Text("The saved “\(entry.transformName)” input and output will be removed from local history.")
+        }
+        .alert("Clear Transform history?", isPresented: $viewModel.isConfirmingClearHistory) {
+            Button("Clear History", role: .destructive) {
+                viewModel.clearHistory()
+            }
+            Button("Cancel", role: .cancel) {
+                viewModel.isConfirmingClearHistory = false
+            }
+        } message: {
+            Text("This removes every saved Transform input and output from this Mac.")
         }
     }
 
@@ -173,6 +207,64 @@ struct TransformsView: View {
     }
 
     @ViewBuilder
+    private var historySection: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+            HStack(alignment: .firstTextBaseline) {
+                Text("History")
+                    .font(DesignSystem.Typography.pageTitle)
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+                if !viewModel.history.isEmpty {
+                    Text("\(viewModel.history.count)")
+                        .font(DesignSystem.Typography.duration)
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Capsule().fill(DesignSystem.Colors.surfaceElevated))
+                }
+                Spacer()
+                if !viewModel.history.isEmpty {
+                    Button(role: .destructive) {
+                        viewModel.isConfirmingClearHistory = true
+                    } label: {
+                        Label("Clear", systemImage: "trash")
+                    }
+                    .parakeetAction(.subtle)
+                    .controlSize(.small)
+                }
+            }
+
+            if let historyError = viewModel.historyErrorMessage {
+                HStack(spacing: DesignSystem.Spacing.sm) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(DesignSystem.Colors.warningAmber)
+                    Text(historyError)
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    Spacer()
+                }
+                .padding(DesignSystem.Spacing.md)
+                .background(DesignSystem.Colors.surfaceElevated)
+                .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius))
+            } else if viewModel.history.isEmpty {
+                TransformHistoryEmptyState()
+            } else {
+                LazyVStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+                    ForEach(viewModel.history) { entry in
+                        TransformHistoryRow(
+                            entry: entry,
+                            isCopied: viewModel.copiedHistoryEntryID == entry.id,
+                            onCopy: { viewModel.copyOutputToClipboard(entry) },
+                            onDelete: { viewModel.pendingDeleteHistoryEntry = entry }
+                        )
+                    }
+                }
+            }
+        }
+        .padding(.top, DesignSystem.Spacing.lg)
+    }
+
+    @ViewBuilder
     private var footerActions: some View {
         HStack(spacing: DesignSystem.Spacing.md) {
             Button(action: {
@@ -185,6 +277,173 @@ struct TransformsView: View {
             Spacer()
         }
         .padding(.top, DesignSystem.Spacing.md)
+    }
+}
+
+// MARK: - Transform history
+
+private struct TransformHistoryEmptyState: View {
+    var body: some View {
+        HStack(spacing: DesignSystem.Spacing.md) {
+            Image(systemName: "clock.arrow.circlepath")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(DesignSystem.Colors.textTertiary)
+                .frame(width: 34, height: 34)
+                .background(Circle().fill(DesignSystem.Colors.surfaceElevated))
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text("No saved Transform runs yet")
+                    .font(DesignSystem.Typography.body.weight(.semibold))
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+                Text("Completed edits will appear here.")
+                    .font(DesignSystem.Typography.bodySmall)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+            }
+            Spacer()
+        }
+        .padding(DesignSystem.Spacing.lg)
+        .background(DesignSystem.Colors.cardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius))
+        .overlay {
+            RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
+                .stroke(DesignSystem.Colors.border.opacity(0.6), lineWidth: 0.5)
+        }
+    }
+}
+
+private struct TransformHistoryRow: View {
+    let entry: TransformHistoryEntry
+    let isCopied: Bool
+    let onCopy: () -> Void
+    let onDelete: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            HStack(alignment: .center, spacing: DesignSystem.Spacing.sm) {
+                Image(systemName: "wand.and.stars")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(DesignSystem.Colors.accent)
+                    .frame(width: 26, height: 26)
+                    .background(Circle().fill(DesignSystem.Colors.accentLight))
+
+                Text(entry.transformName)
+                    .font(DesignSystem.Typography.caption.weight(.semibold))
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+
+                Text("·")
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textTertiary)
+
+                Text(entry.sourceAppDisplayName)
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    .lineLimit(1)
+
+                Text("·")
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textTertiary)
+
+                Text(formatTime(entry.createdAt))
+                    .font(DesignSystem.Typography.timestamp)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+
+                Spacer(minLength: DesignSystem.Spacing.sm)
+
+                if isCopied {
+                    Text("Copied")
+                        .font(DesignSystem.Typography.micro)
+                        .foregroundStyle(DesignSystem.Colors.successGreen)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 3)
+                        .background(Capsule().fill(DesignSystem.Colors.successGreen.opacity(0.12)))
+                        .transition(.opacity.combined(with: .scale(scale: 0.96)))
+                }
+
+                TransformHistoryIconButton(
+                    systemImage: isCopied ? "checkmark" : "doc.on.clipboard",
+                    color: isCopied ? DesignSystem.Colors.successGreen : DesignSystem.Colors.textSecondary,
+                    help: "Copy transformed text",
+                    action: onCopy
+                )
+                TransformHistoryIconButton(
+                    systemImage: "trash",
+                    color: DesignSystem.Colors.textSecondary,
+                    help: "Delete history item",
+                    action: onDelete
+                )
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(entry.outputText)
+                    .font(DesignSystem.Typography.body)
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+                    .lineLimit(3)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Text(entry.inputText)
+                    .font(DesignSystem.Typography.bodySmall)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    .lineLimit(2)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.leading, DesignSystem.Spacing.md)
+                    .overlay(alignment: .leading) {
+                        Rectangle()
+                            .fill(DesignSystem.Colors.border)
+                            .frame(width: 2)
+                    }
+            }
+        }
+        .padding(DesignSystem.Spacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
+                .fill(isHovered ? DesignSystem.Colors.surfaceElevated.opacity(0.7) : DesignSystem.Colors.cardBackground)
+                .cardShadow(isHovered ? DesignSystem.Shadows.cardHover : DesignSystem.Shadows.cardRest)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
+                .stroke(isHovered ? DesignSystem.Colors.accent.opacity(0.25) : DesignSystem.Colors.border.opacity(0.55), lineWidth: 0.5)
+        }
+        .onHover { hovering in
+            withAnimation(DesignSystem.Animation.hoverTransition) {
+                isHovered = hovering
+            }
+        }
+        .animation(DesignSystem.Animation.hoverTransition, value: isCopied)
+    }
+
+    private func formatTime(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        formatter.dateStyle = Calendar.current.isDateInToday(date) ? .none : .short
+        return formatter.string(from: date)
+    }
+}
+
+private struct TransformHistoryIconButton: View {
+    let systemImage: String
+    let color: Color
+    let help: String
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemImage)
+                .font(.system(size: 12, weight: .medium))
+                .frame(width: 28, height: 28)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(isHovered ? Color.primary.opacity(0.08) : .clear)
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(isHovered ? DesignSystem.Colors.textPrimary : color)
+        .help(help)
+        .onHover { isHovered = $0 }
     }
 }
 

--- a/Sources/MacParakeet/Views/Transforms/TransformsView.swift
+++ b/Sources/MacParakeet/Views/Transforms/TransformsView.swift
@@ -43,10 +43,14 @@ struct TransformsView: View {
         }
         .background(DesignSystem.Colors.background)
         .onAppear {
-            viewModel.loadHistory()
+            Task {
+                await viewModel.loadHistory()
+            }
         }
         .onReceive(NotificationCenter.default.publisher(for: .transformHistoryChanged)) { _ in
-            viewModel.loadHistory()
+            Task {
+                await viewModel.loadHistory()
+            }
         }
         .alert(
             "Delete this Transform?",
@@ -75,7 +79,9 @@ struct TransformsView: View {
             presenting: viewModel.pendingDeleteHistoryEntry
         ) { _ in
             Button("Delete", role: .destructive) {
-                viewModel.confirmPendingHistoryDelete()
+                Task {
+                    await viewModel.confirmPendingHistoryDelete()
+                }
             }
             Button("Cancel", role: .cancel) {
                 viewModel.pendingDeleteHistoryEntry = nil
@@ -85,7 +91,9 @@ struct TransformsView: View {
         }
         .alert("Clear Transform history?", isPresented: $viewModel.isConfirmingClearHistory) {
             Button("Clear History", role: .destructive) {
-                viewModel.clearHistory()
+                Task {
+                    await viewModel.clearHistory()
+                }
             }
             Button("Cancel", role: .cancel) {
                 viewModel.isConfirmingClearHistory = false
@@ -214,7 +222,7 @@ struct TransformsView: View {
                     .font(DesignSystem.Typography.pageTitle)
                     .foregroundStyle(DesignSystem.Colors.textPrimary)
                 if !viewModel.history.isEmpty {
-                    Text("\(viewModel.history.count)")
+                    Text("\(viewModel.totalHistoryCount)")
                         .font(DesignSystem.Typography.duration)
                         .foregroundStyle(DesignSystem.Colors.textSecondary)
                         .padding(.horizontal, 6)
@@ -254,7 +262,11 @@ struct TransformsView: View {
                         TransformHistoryRow(
                             entry: entry,
                             isCopied: viewModel.copiedHistoryEntryID == entry.id,
-                            onCopy: { viewModel.copyOutputToClipboard(entry) },
+                            onCopy: {
+                                Task {
+                                    await viewModel.copyOutputToClipboard(entry)
+                                }
+                            },
                             onDelete: { viewModel.pendingDeleteHistoryEntry = entry }
                         )
                     }
@@ -312,6 +324,9 @@ private struct TransformHistoryEmptyState: View {
 }
 
 private struct TransformHistoryRow: View {
+    private static let todayTimeFormat = Date.FormatStyle(date: .omitted, time: .shortened)
+    private static let dateTimeFormat = Date.FormatStyle(date: .numeric, time: .shortened)
+
     let entry: TransformHistoryEntry
     let isCopied: Bool
     let onCopy: () -> Void
@@ -414,10 +429,7 @@ private struct TransformHistoryRow: View {
     }
 
     private func formatTime(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.timeStyle = .short
-        formatter.dateStyle = Calendar.current.isDateInToday(date) ? .none : .short
-        return formatter.string(from: date)
+        date.formatted(Calendar.current.isDateInToday(date) ? Self.todayTimeFormat : Self.dateTimeFormat)
     }
 }
 
@@ -440,7 +452,7 @@ private struct TransformHistoryIconButton: View {
                 )
                 .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .parakeetAction(.subtle)
         .foregroundStyle(isHovered ? DesignSystem.Colors.textPrimary : color)
         .help(help)
         .onHover { isHovered = $0 }

--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -683,6 +683,38 @@ public final class DatabaseManager: Sendable {
             }
         }
 
+        // v0.14 — Local-only Transform history. Stores high-intent selected-text
+        // rewrites so users can recover and revisit prior edits. No foreign key
+        // to prompts: deleting a custom Transform should not delete the user's
+        // run history.
+        migrator.registerMigration("v0.14-transform-history") { db in
+            try db.create(table: "transform_history") { t in
+                t.column("id", .text).primaryKey()
+                t.column("transformId", .text)
+                t.column("transformName", .text).notNull()
+                t.column("inputText", .text).notNull()
+                t.column("outputText", .text).notNull()
+                t.column("sourceAppBundleID", .text)
+                t.column("sourceAppName", .text)
+                t.column("capturePath", .text).notNull()
+                t.column("replacementPath", .text).notNull()
+                t.column("llmElapsedMs", .integer).notNull().defaults(to: 0)
+                t.column("totalElapsedMs", .integer).notNull().defaults(to: 0)
+                t.column("createdAt", .text).notNull()
+                t.column("updatedAt", .text).notNull()
+            }
+            try db.create(
+                index: "idx_transform_history_created_at",
+                on: "transform_history",
+                columns: ["createdAt"]
+            )
+            try db.create(
+                index: "idx_transform_history_transform_id",
+                on: "transform_history",
+                columns: ["transformId"]
+            )
+        }
+
         try migrator.migrate(dbQueue)
         try reconcileBuiltInPrompts()
         try reconcileBuiltInQuickPrompts()

--- a/Sources/MacParakeetCore/Database/README.md
+++ b/Sources/MacParakeetCore/Database/README.md
@@ -22,6 +22,7 @@ process.
   - `TextSnippetRepository.swift` — snippets (text + action).
   - `PromptRepository.swift` — prompt-library entries.
   - `PromptResultRepository.swift` — saved prompt outputs.
+  - `TransformHistoryRepository.swift` — local-only Transform input/output history.
   - `QuickPromptRepository.swift` — quick-prompt entries (Ask tab).
   - `ChatConversationRepository.swift` — multi-turn chat history.
 

--- a/Sources/MacParakeetCore/Database/TransformHistoryRepository.swift
+++ b/Sources/MacParakeetCore/Database/TransformHistoryRepository.swift
@@ -1,0 +1,60 @@
+import Foundation
+import GRDB
+
+public protocol TransformHistoryRepositoryProtocol: Sendable {
+    func save(_ entry: TransformHistoryEntry) throws
+    func fetchAll() throws -> [TransformHistoryEntry]
+    func fetchRecent(limit: Int) throws -> [TransformHistoryEntry]
+    func count() throws -> Int
+    func delete(id: UUID) throws -> Bool
+    func deleteAll() throws
+}
+
+public final class TransformHistoryRepository: TransformHistoryRepositoryProtocol {
+    private let dbQueue: DatabaseQueue
+
+    public init(dbQueue: DatabaseQueue) {
+        self.dbQueue = dbQueue
+    }
+
+    public func save(_ entry: TransformHistoryEntry) throws {
+        try dbQueue.write { db in
+            try entry.save(db)
+        }
+    }
+
+    public func fetchAll() throws -> [TransformHistoryEntry] {
+        try dbQueue.read { db in
+            try TransformHistoryEntry
+                .order(TransformHistoryEntry.Columns.createdAt.desc)
+                .fetchAll(db)
+        }
+    }
+
+    public func fetchRecent(limit: Int = 200) throws -> [TransformHistoryEntry] {
+        try dbQueue.read { db in
+            try TransformHistoryEntry
+                .order(TransformHistoryEntry.Columns.createdAt.desc)
+                .limit(max(0, limit))
+                .fetchAll(db)
+        }
+    }
+
+    public func count() throws -> Int {
+        try dbQueue.read { db in
+            try TransformHistoryEntry.fetchCount(db)
+        }
+    }
+
+    public func delete(id: UUID) throws -> Bool {
+        try dbQueue.write { db in
+            try TransformHistoryEntry.deleteOne(db, key: id)
+        }
+    }
+
+    public func deleteAll() throws {
+        _ = try dbQueue.write { db in
+            try TransformHistoryEntry.deleteAll(db)
+        }
+    }
+}

--- a/Sources/MacParakeetCore/Database/TransformHistoryRepository.swift
+++ b/Sources/MacParakeetCore/Database/TransformHistoryRepository.swift
@@ -5,6 +5,8 @@ public protocol TransformHistoryRepositoryProtocol: Sendable {
     func save(_ entry: TransformHistoryEntry) throws
     func fetchAll() throws -> [TransformHistoryEntry]
     func fetchRecent(limit: Int) throws -> [TransformHistoryEntry]
+    func fetch(id: UUID) throws -> TransformHistoryEntry?
+    func fetch(idPrefix: String) throws -> [TransformHistoryEntry]
     func count() throws -> Int
     func delete(id: UUID) throws -> Bool
     func deleteAll() throws
@@ -40,6 +42,36 @@ public final class TransformHistoryRepository: TransformHistoryRepositoryProtoco
         }
     }
 
+    public func fetch(id: UUID) throws -> TransformHistoryEntry? {
+        try dbQueue.read { db in
+            try TransformHistoryEntry.fetchOne(db, key: id)
+        }
+    }
+
+    public func fetch(idPrefix: String) throws -> [TransformHistoryEntry] {
+        let escapedPrefix = Self.escapeLikePattern(
+            idPrefix
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased()
+                .replacingOccurrences(of: "-", with: "")
+        )
+        guard !escapedPrefix.isEmpty else { return [] }
+        let pattern = "\(escapedPrefix)%"
+
+        return try dbQueue.read { db in
+            try TransformHistoryEntry
+                .filter(
+                    sql: """
+                        (lower(hex(id)) LIKE ? ESCAPE '\\'
+                            OR replace(lower(id), '-', '') LIKE ? ESCAPE '\\')
+                        """,
+                    arguments: StatementArguments([pattern, pattern])
+                )
+                .order(TransformHistoryEntry.Columns.createdAt.desc)
+                .fetchAll(db)
+        }
+    }
+
     public func count() throws -> Int {
         try dbQueue.read { db in
             try TransformHistoryEntry.fetchCount(db)
@@ -56,5 +88,12 @@ public final class TransformHistoryRepository: TransformHistoryRepositoryProtoco
         _ = try dbQueue.write { db in
             try TransformHistoryEntry.deleteAll(db)
         }
+    }
+
+    private static func escapeLikePattern(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "%", with: "\\%")
+            .replacingOccurrences(of: "_", with: "\\_")
     }
 }

--- a/Sources/MacParakeetCore/Models/TransformHistoryEntry.swift
+++ b/Sources/MacParakeetCore/Models/TransformHistoryEntry.swift
@@ -1,0 +1,78 @@
+import Foundation
+import GRDB
+
+public struct TransformHistoryEntry: Codable, Identifiable, Sendable, Equatable {
+    public var id: UUID
+    public var transformId: UUID?
+    public var transformName: String
+    public var inputText: String
+    public var outputText: String
+    public var sourceAppBundleID: String?
+    public var sourceAppName: String?
+    public var capturePath: String
+    public var replacementPath: String
+    public var llmElapsedMs: Int
+    public var totalElapsedMs: Int
+    public var createdAt: Date
+    public var updatedAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        transformId: UUID? = nil,
+        transformName: String,
+        inputText: String,
+        outputText: String,
+        sourceAppBundleID: String? = nil,
+        sourceAppName: String? = nil,
+        capturePath: String,
+        replacementPath: String,
+        llmElapsedMs: Int,
+        totalElapsedMs: Int,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.transformId = transformId
+        self.transformName = transformName
+        self.inputText = inputText
+        self.outputText = outputText
+        self.sourceAppBundleID = sourceAppBundleID
+        self.sourceAppName = sourceAppName
+        self.capturePath = capturePath
+        self.replacementPath = replacementPath
+        self.llmElapsedMs = llmElapsedMs
+        self.totalElapsedMs = totalElapsedMs
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+
+    public var sourceAppDisplayName: String {
+        if let sourceAppName, !sourceAppName.isEmpty {
+            return sourceAppName
+        }
+        if let sourceAppBundleID, !sourceAppBundleID.isEmpty {
+            return sourceAppBundleID
+        }
+        return "Unknown app"
+    }
+}
+
+extension TransformHistoryEntry: FetchableRecord, PersistableRecord {
+    public static let databaseTableName = "transform_history"
+
+    public enum Columns: String, ColumnExpression {
+        case id
+        case transformId
+        case transformName
+        case inputText
+        case outputText
+        case sourceAppBundleID
+        case sourceAppName
+        case capturePath
+        case replacementPath
+        case llmElapsedMs
+        case totalElapsedMs
+        case createdAt
+        case updatedAt
+    }
+}

--- a/Sources/MacParakeetCore/Services/System/SelectionCaptureService.swift
+++ b/Sources/MacParakeetCore/Services/System/SelectionCaptureService.swift
@@ -13,12 +13,12 @@ public enum SelectionCaptureResult: @unchecked Sendable {
     /// AX read returned a non-empty `kAXSelectedTextAttribute`. The element
     /// handle is retained so the replacement service can try `AXUIElementSet`
     /// before falling back to clipboard paste-back.
-    case ax(text: String, element: AXFocusedElement)
+    case ax(text: String, element: AXFocusedElement, target: SelectionCaptureTarget?)
 
     /// AX read returned empty/unsupported; clipboard hijack (Cmd+C + poll
     /// `changeCount`) found non-empty text. The captured snapshot must be
     /// restored after replacement completes.
-    case clipboard(text: String, savedClipboard: PasteboardSnapshot)
+    case clipboard(text: String, savedClipboard: PasteboardSnapshot, target: SelectionCaptureTarget?)
 
     /// Neither AX nor clipboard hijack returned non-empty text.
     case empty
@@ -29,8 +29,17 @@ public enum SelectionCaptureResult: @unchecked Sendable {
 
     public var capturedText: String? {
         switch self {
-        case .ax(let text, _), .clipboard(let text, _):
+        case .ax(let text, _, _), .clipboard(let text, _, _):
             return text
+        case .empty, .failed:
+            return nil
+        }
+    }
+
+    public var target: SelectionCaptureTarget? {
+        switch self {
+        case .ax(_, _, let target), .clipboard(_, _, let target):
+            return target
         case .empty, .failed:
             return nil
         }
@@ -77,6 +86,15 @@ public struct AXFocusedElement: @unchecked Sendable {
     }
 }
 
+/// The app that owned the selection when the Transform was triggered.
+public struct SelectionCaptureTarget: Sendable, Equatable {
+    public let processIdentifier: pid_t
+
+    public init(processIdentifier: pid_t) {
+        self.processIdentifier = processIdentifier
+    }
+}
+
 /// Snapshot of the pasteboard items captured before a clipboard hijack. Held
 /// opaquely so callers don't have to know about AppKit types. `@unchecked
 /// Sendable` because `NSPasteboardItem` is not Sendable but our usage is
@@ -116,6 +134,9 @@ protocol SelectionCaptureBackend: Sendable {
     func isAccessibilityTrusted() -> Bool
     func focusedElement() -> AXUIElement?
     func selectedText(of element: AXUIElement) -> String?
+
+    @MainActor
+    func frontmostApplicationProcessIdentifier() -> pid_t?
 
     /// Snapshot the pasteboard and return the saved items + the changeCount at
     /// snapshot time (so the poll loop can detect the Cmd+C-triggered change).
@@ -190,15 +211,17 @@ public actor SelectionCaptureService {
             return .failed(.accessibilityNotAuthorized)
         }
 
+        let target = await captureTargetOnMain()
+
         if let element = backend.focusedElement() {
             if let text = backend.selectedText(of: element),
                !text.isEmpty {
-                return .ax(text: text, element: AXFocusedElement(element))
+                return .ax(text: text, element: AXFocusedElement(element), target: target)
             }
         }
 
         // Clipboard-hijack fallback.
-        return await clipboardHijack()
+        return await clipboardHijack(target: target)
     }
 
     /// Restore a clipboard capture that is being abandoned before replacement.
@@ -206,7 +229,7 @@ public actor SelectionCaptureService {
     /// we only restore if the pasteboard is still at the Cmd+C change count
     /// created by `clipboardHijack()`.
     func restoreClipboardCaptureIfCurrent(_ result: SelectionCaptureResult) async {
-        guard case .clipboard(_, let snapshot) = result else { return }
+        guard case .clipboard(_, let snapshot, _) = result else { return }
 
         guard let temporaryChangeCount = snapshot.temporaryChangeCount else {
             await restoreSnapshotOnMain(snapshot)
@@ -223,7 +246,7 @@ public actor SelectionCaptureService {
 
     // MARK: - Clipboard Hijack
 
-    private func clipboardHijack() async -> SelectionCaptureResult {
+    private func clipboardHijack(target: SelectionCaptureTarget?) async -> SelectionCaptureResult {
         let snapshot = await snapshotPasteboardOnMain()
         do {
             try await postCmdCOnMain()
@@ -245,7 +268,7 @@ public actor SelectionCaptureService {
             let now = await currentChangeCountOnMain()
             if now != snapshot.originalChangeCount {
                 if let text = await currentStringOnMain(), !text.isEmpty {
-                    return .clipboard(text: text, savedClipboard: snapshot.withTemporaryChangeCount(now))
+                    return .clipboard(text: text, savedClipboard: snapshot.withTemporaryChangeCount(now), target: target)
                 }
                 // Change count moved but no string available (image, file, etc.).
                 // Cmd+C *did* write — the user's pre-hijack clipboard is now
@@ -259,6 +282,11 @@ public actor SelectionCaptureService {
         // No change count delta — selection was empty. Pasteboard wasn't
         // touched (Cmd+C with no selection is a no-op) so nothing to restore.
         return .empty
+    }
+
+    @MainActor
+    private func captureTargetOnMain() -> SelectionCaptureTarget? {
+        backend.frontmostApplicationProcessIdentifier().map(SelectionCaptureTarget.init(processIdentifier:))
     }
 
     @MainActor
@@ -332,6 +360,11 @@ struct SystemSelectionCaptureBackend: SelectionCaptureBackend, @unchecked Sendab
         guard status == .success, let raw else { return nil }
         let value = raw as? String
         return value?.isEmpty == true ? nil : value
+    }
+
+    @MainActor
+    func frontmostApplicationProcessIdentifier() -> pid_t? {
+        NSWorkspace.shared.frontmostApplication?.processIdentifier
     }
 
     @MainActor

--- a/Sources/MacParakeetCore/Services/System/SelectionCaptureService.swift
+++ b/Sources/MacParakeetCore/Services/System/SelectionCaptureService.swift
@@ -89,9 +89,11 @@ public struct AXFocusedElement: @unchecked Sendable {
 /// The app that owned the selection when the Transform was triggered.
 public struct SelectionCaptureTarget: Sendable, Equatable {
     public let processIdentifier: pid_t
+    public let bundleIdentifier: String
 
-    public init(processIdentifier: pid_t) {
+    public init(processIdentifier: pid_t, bundleIdentifier: String) {
         self.processIdentifier = processIdentifier
+        self.bundleIdentifier = bundleIdentifier
     }
 }
 
@@ -136,7 +138,7 @@ protocol SelectionCaptureBackend: Sendable {
     func selectedText(of element: AXUIElement) -> String?
 
     @MainActor
-    func frontmostApplicationProcessIdentifier() -> pid_t?
+    func frontmostApplicationTarget() -> SelectionCaptureTarget?
 
     /// Snapshot the pasteboard and return the saved items + the changeCount at
     /// snapshot time (so the poll loop can detect the Cmd+C-triggered change).
@@ -286,7 +288,7 @@ public actor SelectionCaptureService {
 
     @MainActor
     private func captureTargetOnMain() -> SelectionCaptureTarget? {
-        backend.frontmostApplicationProcessIdentifier().map(SelectionCaptureTarget.init(processIdentifier:))
+        backend.frontmostApplicationTarget()
     }
 
     @MainActor
@@ -363,8 +365,16 @@ struct SystemSelectionCaptureBackend: SelectionCaptureBackend, @unchecked Sendab
     }
 
     @MainActor
-    func frontmostApplicationProcessIdentifier() -> pid_t? {
-        NSWorkspace.shared.frontmostApplication?.processIdentifier
+    func frontmostApplicationTarget() -> SelectionCaptureTarget? {
+        guard let app = NSWorkspace.shared.frontmostApplication,
+              let bundleIdentifier = app.bundleIdentifier
+        else {
+            return nil
+        }
+        return SelectionCaptureTarget(
+            processIdentifier: app.processIdentifier,
+            bundleIdentifier: bundleIdentifier
+        )
     }
 
     @MainActor

--- a/Sources/MacParakeetCore/Services/System/SelectionReplacementService.swift
+++ b/Sources/MacParakeetCore/Services/System/SelectionReplacementService.swift
@@ -19,6 +19,7 @@ public enum SelectionReplacementError: Error, LocalizedError, Sendable {
     case eventSourceUnavailable
     case pasteboardWriteFailed
     case eventPostingFailed
+    case targetActivationFailed
     case allPathsFailed
 
     public var errorDescription: String? {
@@ -31,6 +32,8 @@ public enum SelectionReplacementError: Error, LocalizedError, Sendable {
             return "Could not write replacement text to the clipboard."
         case .eventPostingFailed:
             return "Failed to post Cmd+V keystroke."
+        case .targetActivationFailed:
+            return "Could not reactivate the original app before pasting."
         case .allPathsFailed:
             return "Selection replacement failed via both AX-write and clipboard paste."
         }
@@ -53,6 +56,9 @@ protocol SelectionReplacementBackend: Sendable {
 
     @MainActor
     func writePasteboardString(_ text: String) -> Bool
+
+    @MainActor
+    func activateApplication(processIdentifier: pid_t) -> Bool
 
     @MainActor
     func postCmdV() throws
@@ -112,7 +118,7 @@ public actor SelectionReplacementService {
         in context: SelectionCaptureResult
     ) async throws -> SelectionReplacementPath {
         switch context {
-        case .ax(_, let focused):
+        case .ax(_, let focused, _):
             // AX-write is the no-side-effect path. If it succeeds, we're done.
             if backend.writeSelectionViaAX(newText, element: focused.element) {
                 return .ax
@@ -121,16 +127,16 @@ public actor SelectionReplacementService {
             // capture path didn't touch the clipboard, so we capture a fresh
             // snapshot here to preserve whatever the user had on it).
             let freshSnapshot = await snapshotPasteboardForFallback()
-            try await pasteAndRestore(newText: newText, snapshot: freshSnapshot)
+            try await pasteAndRestore(newText: newText, snapshot: freshSnapshot, target: context.target)
             return .clipboardPaste
 
-        case .clipboard(_, let savedSnapshot):
+        case .clipboard(_, let savedSnapshot, _):
             // Original capture already hijacked the clipboard. Paste then
             // restore the snapshot we promised the user we'd put back. If the
             // user copied something else while the LLM was running, preserve
             // that newer clipboard instead of the pre-transform snapshot.
             let restoreSnapshot = await snapshotForClipboardContext(savedSnapshot)
-            try await pasteAndRestore(newText: newText, snapshot: restoreSnapshot)
+            try await pasteAndRestore(newText: newText, snapshot: restoreSnapshot, target: context.target)
             return .clipboardPaste
 
         case .empty, .failed:
@@ -159,7 +165,8 @@ public actor SelectionReplacementService {
 
     private func pasteAndRestore(
         newText: String,
-        snapshot: PasteboardSnapshot
+        snapshot: PasteboardSnapshot,
+        target: SelectionCaptureTarget?
     ) async throws {
         // Write our payload and capture the changeCount *after* the write —
         // that's the value the restore guard compares against. If anyone
@@ -172,6 +179,15 @@ public actor SelectionReplacementService {
             // called clearContents().
             await restoreSnapshotOnMain(snapshot)
             throw SelectionReplacementError.pasteboardWriteFailed
+        }
+
+        if let target {
+            let didActivate = await activateApplicationOnMain(target.processIdentifier)
+            guard didActivate else {
+                await restoreIfSafe(snapshot, ourChangeCount: ourChangeCount)
+                throw SelectionReplacementError.targetActivationFailed
+            }
+            await Task.yield()
         }
 
         do {
@@ -195,6 +211,11 @@ public actor SelectionReplacementService {
     private func writeAndCaptureChangeCountOnMain(_ text: String) -> Int? {
         guard backend.writePasteboardString(text) else { return nil }
         return backend.currentChangeCount()
+    }
+
+    @MainActor
+    private func activateApplicationOnMain(_ processIdentifier: pid_t) -> Bool {
+        backend.activateApplication(processIdentifier: processIdentifier)
     }
 
     @MainActor
@@ -288,6 +309,14 @@ struct SystemSelectionReplacementBackend: SelectionReplacementBackend, @unchecke
             return copy
         }
         return PasteboardSnapshot(items: items, originalChangeCount: pasteboard.changeCount)
+    }
+
+    @MainActor
+    func activateApplication(processIdentifier: pid_t) -> Bool {
+        guard let app = NSRunningApplication(processIdentifier: processIdentifier) else {
+            return false
+        }
+        return app.activate()
     }
 
     @MainActor

--- a/Sources/MacParakeetCore/Services/System/SelectionReplacementService.swift
+++ b/Sources/MacParakeetCore/Services/System/SelectionReplacementService.swift
@@ -61,6 +61,9 @@ protocol SelectionReplacementBackend: Sendable {
     func activateApplication(target: SelectionCaptureTarget) -> Bool
 
     @MainActor
+    func isFrontmostApplication(target: SelectionCaptureTarget) -> Bool
+
+    @MainActor
     func postCmdV() throws
 
     /// Current `NSPasteboard.changeCount`. Used by the restore guard to
@@ -91,9 +94,12 @@ public actor SelectionReplacementService {
     /// clipboard snapshot. 500ms matches the conventional "Espanso / Raycast"
     /// value and the Gemini-review feedback on the capture side.
     public static let defaultPostPasteDelay: Duration = .milliseconds(500)
+    public static let defaultActivationTimeout: Duration = .milliseconds(500)
 
     private let backend: any SelectionReplacementBackend
     private let postPasteDelay: Duration
+    private let activationTimeout: Duration
+    private let activationPollIntervalNanos: UInt64
     private let logger: Logger
 
     public init() {
@@ -103,10 +109,14 @@ public actor SelectionReplacementService {
     init(
         backend: any SelectionReplacementBackend,
         postPasteDelay: Duration = SelectionReplacementService.defaultPostPasteDelay,
+        activationTimeout: Duration = SelectionReplacementService.defaultActivationTimeout,
+        activationPollIntervalNanos: UInt64 = 10_000_000,  // 10 ms
         logger: Logger = Logger(subsystem: "com.macparakeet.core", category: "SelectionReplacementService")
     ) {
         self.backend = backend
         self.postPasteDelay = postPasteDelay
+        self.activationTimeout = activationTimeout
+        self.activationPollIntervalNanos = activationPollIntervalNanos
         self.logger = logger
     }
 
@@ -182,12 +192,10 @@ public actor SelectionReplacementService {
         }
 
         if let target {
-            let didActivate = await activateApplicationOnMain(target)
-            guard didActivate else {
+            guard await activateAndWaitForTarget(target) else {
                 await restoreIfSafe(snapshot, ourChangeCount: ourChangeCount)
                 throw SelectionReplacementError.targetActivationFailed
             }
-            await Task.yield()
         }
 
         do {
@@ -216,6 +224,26 @@ public actor SelectionReplacementService {
     @MainActor
     private func activateApplicationOnMain(_ target: SelectionCaptureTarget) -> Bool {
         backend.activateApplication(target: target)
+    }
+
+    private func activateAndWaitForTarget(_ target: SelectionCaptureTarget) async -> Bool {
+        guard await activateApplicationOnMain(target) else {
+            return false
+        }
+
+        let deadline = ContinuousClock.now + activationTimeout
+        while ContinuousClock.now < deadline {
+            if await isFrontmostApplicationOnMain(target) {
+                return true
+            }
+            try? await Task.sleep(nanoseconds: activationPollIntervalNanos)
+        }
+        return await isFrontmostApplicationOnMain(target)
+    }
+
+    @MainActor
+    private func isFrontmostApplicationOnMain(_ target: SelectionCaptureTarget) -> Bool {
+        backend.isFrontmostApplication(target: target)
     }
 
     @MainActor
@@ -319,6 +347,15 @@ struct SystemSelectionReplacementBackend: SelectionReplacementBackend, @unchecke
             return false
         }
         return app.activate()
+    }
+
+    @MainActor
+    func isFrontmostApplication(target: SelectionCaptureTarget) -> Bool {
+        guard let app = NSWorkspace.shared.frontmostApplication else {
+            return false
+        }
+        return app.processIdentifier == target.processIdentifier
+            && app.bundleIdentifier == target.bundleIdentifier
     }
 
     @MainActor

--- a/Sources/MacParakeetCore/Services/System/SelectionReplacementService.swift
+++ b/Sources/MacParakeetCore/Services/System/SelectionReplacementService.swift
@@ -58,7 +58,7 @@ protocol SelectionReplacementBackend: Sendable {
     func writePasteboardString(_ text: String) -> Bool
 
     @MainActor
-    func activateApplication(processIdentifier: pid_t) -> Bool
+    func activateApplication(target: SelectionCaptureTarget) -> Bool
 
     @MainActor
     func postCmdV() throws
@@ -182,7 +182,7 @@ public actor SelectionReplacementService {
         }
 
         if let target {
-            let didActivate = await activateApplicationOnMain(target.processIdentifier)
+            let didActivate = await activateApplicationOnMain(target)
             guard didActivate else {
                 await restoreIfSafe(snapshot, ourChangeCount: ourChangeCount)
                 throw SelectionReplacementError.targetActivationFailed
@@ -214,8 +214,8 @@ public actor SelectionReplacementService {
     }
 
     @MainActor
-    private func activateApplicationOnMain(_ processIdentifier: pid_t) -> Bool {
-        backend.activateApplication(processIdentifier: processIdentifier)
+    private func activateApplicationOnMain(_ target: SelectionCaptureTarget) -> Bool {
+        backend.activateApplication(target: target)
     }
 
     @MainActor
@@ -312,8 +312,10 @@ struct SystemSelectionReplacementBackend: SelectionReplacementBackend, @unchecke
     }
 
     @MainActor
-    func activateApplication(processIdentifier: pid_t) -> Bool {
-        guard let app = NSRunningApplication(processIdentifier: processIdentifier) else {
+    func activateApplication(target: SelectionCaptureTarget) -> Bool {
+        guard let app = NSRunningApplication(processIdentifier: target.processIdentifier),
+              app.bundleIdentifier == target.bundleIdentifier
+        else {
             return false
         }
         return app.activate()

--- a/Sources/MacParakeetCore/Services/Transforms/TransformExecutor.swift
+++ b/Sources/MacParakeetCore/Services/Transforms/TransformExecutor.swift
@@ -31,6 +31,7 @@ public enum TransformProgress: Sendable, Equatable {
 // MARK: - Result
 
 public struct TransformExecutionResult: Sendable {
+    public let inputText: String
     public let outputText: String
     public let path: SelectionReplacementPath
     public let totalElapsedMs: Int
@@ -38,12 +39,14 @@ public struct TransformExecutionResult: Sendable {
     public let captureTag: String
 
     public init(
+        inputText: String,
         outputText: String,
         path: SelectionReplacementPath,
         totalElapsedMs: Int,
         llmElapsedMs: Int,
         captureTag: String
     ) {
+        self.inputText = inputText
         self.outputText = outputText
         self.path = path
         self.totalElapsedMs = totalElapsedMs
@@ -221,6 +224,7 @@ public actor TransformExecutor {
 
         let totalMs = Self.elapsedMs(from: start)
         let result = TransformExecutionResult(
+            inputText: inputText,
             outputText: accumulated,
             path: path,
             totalElapsedMs: totalMs,

--- a/Sources/MacParakeetViewModels/TransformsViewModel.swift
+++ b/Sources/MacParakeetViewModels/TransformsViewModel.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import MacParakeetCore
 
@@ -10,25 +11,40 @@ import MacParakeetCore
 @MainActor
 @Observable
 public final class TransformsViewModel {
+    public static let historyFetchLimit = 200
+
     public var transforms: [Prompt] = []
+    public var history: [TransformHistoryEntry] = []
     public var errorMessage: String?
+    public var historyErrorMessage: String?
 
     /// Pending delete confirmation. Set when the user hits delete on a
     /// (non-built-in) Transform; cleared on confirm or cancel.
     public var pendingDeleteTransform: Prompt?
+    public var pendingDeleteHistoryEntry: TransformHistoryEntry?
+    public var isConfirmingClearHistory: Bool = false
+    public var copiedHistoryEntryID: UUID?
 
     /// True when the user has at least one LLM provider configured. Drives
     /// the calm "Configure in Settings" hero state.
     public var hasLLMProvider: Bool = false
 
     private var repo: PromptRepositoryProtocol?
+    private var historyRepo: TransformHistoryRepositoryProtocol?
+    private var copiedResetTask: Task<Void, Never>?
 
     public init() {}
 
-    public func configure(repo: PromptRepositoryProtocol, hasLLMProvider: Bool) {
+    public func configure(
+        repo: PromptRepositoryProtocol,
+        historyRepo: TransformHistoryRepositoryProtocol? = nil,
+        hasLLMProvider: Bool
+    ) {
         self.repo = repo
+        self.historyRepo = historyRepo
         self.hasLLMProvider = hasLLMProvider
         load()
+        loadHistory()
     }
 
     /// Refresh the list from the repository. Built-ins are seeded by the
@@ -46,6 +62,17 @@ public final class TransformsViewModel {
             errorMessage = nil
         } catch {
             errorMessage = error.localizedDescription
+        }
+    }
+
+    public func loadHistory() {
+        guard let historyRepo else { return }
+        do {
+            history = try historyRepo.fetchRecent(limit: Self.historyFetchLimit)
+            historyErrorMessage = nil
+        } catch {
+            history = []
+            historyErrorMessage = error.localizedDescription
         }
     }
 
@@ -97,6 +124,47 @@ public final class TransformsViewModel {
         guard let pending = pendingDeleteTransform else { return }
         pendingDeleteTransform = nil
         delete(pending)
+    }
+
+    public func confirmPendingHistoryDelete() {
+        guard let pending = pendingDeleteHistoryEntry else { return }
+        pendingDeleteHistoryEntry = nil
+        deleteHistoryEntry(pending)
+    }
+
+    public func deleteHistoryEntry(_ entry: TransformHistoryEntry) {
+        guard let historyRepo else { return }
+        do {
+            _ = try historyRepo.delete(id: entry.id)
+            history.removeAll { $0.id == entry.id }
+            historyErrorMessage = nil
+        } catch {
+            historyErrorMessage = error.localizedDescription
+        }
+    }
+
+    public func clearHistory() {
+        guard let historyRepo else { return }
+        do {
+            try historyRepo.deleteAll()
+            history = []
+            isConfirmingClearHistory = false
+            historyErrorMessage = nil
+        } catch {
+            historyErrorMessage = error.localizedDescription
+        }
+    }
+
+    public func copyOutputToClipboard(_ entry: TransformHistoryEntry) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(entry.outputText, forType: .string)
+        copiedResetTask?.cancel()
+        copiedHistoryEntryID = entry.id
+        copiedResetTask = Task {
+            try? await Task.sleep(for: .seconds(1.5))
+            guard !Task.isCancelled else { return }
+            self.copiedHistoryEntryID = nil
+        }
     }
 
     /// Reset a built-in Transform's content / shortcut / runningLabel back

--- a/Sources/MacParakeetViewModels/TransformsViewModel.swift
+++ b/Sources/MacParakeetViewModels/TransformsViewModel.swift
@@ -200,7 +200,7 @@ public final class TransformsViewModel {
         }
     }
 
-    private nonisolated static func fetchHistorySnapshot(
+    private static func fetchHistorySnapshot(
         repo: TransformHistoryRepositoryProtocol,
         limit: Int
     ) async throws -> (entries: [TransformHistoryEntry], totalCount: Int) {
@@ -211,7 +211,7 @@ public final class TransformsViewModel {
         }.value
     }
 
-    private nonisolated static func deleteHistoryEntryAndFetchSnapshot(
+    private static func deleteHistoryEntryAndFetchSnapshot(
         repo: TransformHistoryRepositoryProtocol,
         id: UUID,
         limit: Int
@@ -224,7 +224,7 @@ public final class TransformsViewModel {
         }.value
     }
 
-    private nonisolated static func clearHistoryAndFetchSnapshot(
+    private static func clearHistoryAndFetchSnapshot(
         repo: TransformHistoryRepositoryProtocol,
         limit: Int
     ) async throws -> (entries: [TransformHistoryEntry], totalCount: Int) {

--- a/Sources/MacParakeetViewModels/TransformsViewModel.swift
+++ b/Sources/MacParakeetViewModels/TransformsViewModel.swift
@@ -1,4 +1,3 @@
-import AppKit
 import Foundation
 import MacParakeetCore
 
@@ -11,10 +10,11 @@ import MacParakeetCore
 @MainActor
 @Observable
 public final class TransformsViewModel {
-    public static let historyFetchLimit = 200
+    public nonisolated static let historyFetchLimit = 200
 
     public var transforms: [Prompt] = []
     public var history: [TransformHistoryEntry] = []
+    public var totalHistoryCount: Int = 0
     public var errorMessage: String?
     public var historyErrorMessage: String?
 
@@ -31,6 +31,7 @@ public final class TransformsViewModel {
 
     private var repo: PromptRepositoryProtocol?
     private var historyRepo: TransformHistoryRepositoryProtocol?
+    private var clipboardService: ClipboardServiceProtocol?
     private var copiedResetTask: Task<Void, Never>?
 
     public init() {}
@@ -38,13 +39,17 @@ public final class TransformsViewModel {
     public func configure(
         repo: PromptRepositoryProtocol,
         historyRepo: TransformHistoryRepositoryProtocol? = nil,
+        clipboardService: ClipboardServiceProtocol? = nil,
         hasLLMProvider: Bool
     ) {
         self.repo = repo
         self.historyRepo = historyRepo
+        self.clipboardService = clipboardService
         self.hasLLMProvider = hasLLMProvider
         load()
-        loadHistory()
+        Task {
+            await loadHistory()
+        }
     }
 
     /// Refresh the list from the repository. Built-ins are seeded by the
@@ -65,13 +70,23 @@ public final class TransformsViewModel {
         }
     }
 
-    public func loadHistory() {
-        guard let historyRepo else { return }
+    public func loadHistory() async {
+        guard let historyRepo else {
+            history = []
+            totalHistoryCount = 0
+            return
+        }
         do {
-            history = try historyRepo.fetchRecent(limit: Self.historyFetchLimit)
+            let snapshot = try await Self.fetchHistorySnapshot(
+                repo: historyRepo,
+                limit: Self.historyFetchLimit
+            )
+            history = snapshot.entries
+            totalHistoryCount = snapshot.totalCount
             historyErrorMessage = nil
         } catch {
             history = []
+            totalHistoryCount = 0
             historyErrorMessage = error.localizedDescription
         }
     }
@@ -126,28 +141,37 @@ public final class TransformsViewModel {
         delete(pending)
     }
 
-    public func confirmPendingHistoryDelete() {
+    public func confirmPendingHistoryDelete() async {
         guard let pending = pendingDeleteHistoryEntry else { return }
         pendingDeleteHistoryEntry = nil
-        deleteHistoryEntry(pending)
+        await deleteHistoryEntry(pending)
     }
 
-    public func deleteHistoryEntry(_ entry: TransformHistoryEntry) {
+    public func deleteHistoryEntry(_ entry: TransformHistoryEntry) async {
         guard let historyRepo else { return }
         do {
-            _ = try historyRepo.delete(id: entry.id)
-            history.removeAll { $0.id == entry.id }
+            let snapshot = try await Self.deleteHistoryEntryAndFetchSnapshot(
+                repo: historyRepo,
+                id: entry.id,
+                limit: Self.historyFetchLimit
+            )
+            history = snapshot.entries
+            totalHistoryCount = snapshot.totalCount
             historyErrorMessage = nil
         } catch {
             historyErrorMessage = error.localizedDescription
         }
     }
 
-    public func clearHistory() {
+    public func clearHistory() async {
         guard let historyRepo else { return }
         do {
-            try historyRepo.deleteAll()
-            history = []
+            let snapshot = try await Self.clearHistoryAndFetchSnapshot(
+                repo: historyRepo,
+                limit: Self.historyFetchLimit
+            )
+            history = snapshot.entries
+            totalHistoryCount = snapshot.totalCount
             isConfirmingClearHistory = false
             historyErrorMessage = nil
         } catch {
@@ -155,9 +179,18 @@ public final class TransformsViewModel {
         }
     }
 
-    public func copyOutputToClipboard(_ entry: TransformHistoryEntry) {
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(entry.outputText, forType: .string)
+    public func copyOutputToClipboard(_ entry: TransformHistoryEntry) async {
+        guard let clipboardService else {
+            historyErrorMessage = "Clipboard service is unavailable."
+            return
+        }
+
+        guard await clipboardService.copyToClipboard(entry.outputText) else {
+            historyErrorMessage = "Could not copy transformed text to the clipboard."
+            return
+        }
+
+        historyErrorMessage = nil
         copiedResetTask?.cancel()
         copiedHistoryEntryID = entry.id
         copiedResetTask = Task {
@@ -165,6 +198,42 @@ public final class TransformsViewModel {
             guard !Task.isCancelled else { return }
             self.copiedHistoryEntryID = nil
         }
+    }
+
+    private nonisolated static func fetchHistorySnapshot(
+        repo: TransformHistoryRepositoryProtocol,
+        limit: Int
+    ) async throws -> (entries: [TransformHistoryEntry], totalCount: Int) {
+        try await Task.detached(priority: .userInitiated) {
+            let entries = try repo.fetchRecent(limit: limit)
+            let totalCount = try repo.count()
+            return (entries, totalCount)
+        }.value
+    }
+
+    private nonisolated static func deleteHistoryEntryAndFetchSnapshot(
+        repo: TransformHistoryRepositoryProtocol,
+        id: UUID,
+        limit: Int
+    ) async throws -> (entries: [TransformHistoryEntry], totalCount: Int) {
+        try await Task.detached(priority: .userInitiated) {
+            _ = try repo.delete(id: id)
+            let entries = try repo.fetchRecent(limit: limit)
+            let totalCount = try repo.count()
+            return (entries, totalCount)
+        }.value
+    }
+
+    private nonisolated static func clearHistoryAndFetchSnapshot(
+        repo: TransformHistoryRepositoryProtocol,
+        limit: Int
+    ) async throws -> (entries: [TransformHistoryEntry], totalCount: Int) {
+        try await Task.detached(priority: .userInitiated) {
+            try repo.deleteAll()
+            let entries = try repo.fetchRecent(limit: limit)
+            let totalCount = try repo.count()
+            return (entries, totalCount)
+        }.value
     }
 
     /// Reset a built-in Transform's content / shortcut / runningLabel back

--- a/Tests/CLITests/TransformsCommandTests.swift
+++ b/Tests/CLITests/TransformsCommandTests.swift
@@ -101,6 +101,24 @@ final class TransformsCommandTests: XCTestCase {
         XCTAssertEqual(del.idOrName, "Sharpen")
     }
 
+    func testParsesHistoryListAsDefaultSubcommand() throws {
+        let cmd = try TransformsCommand.parseAsRoot(["history", "--limit", "5", "--json"])
+        let history = try XCTUnwrap(cmd as? TransformsCommand.HistorySubcommand.ListSubcommand)
+        XCTAssertEqual(history.limit, 5)
+        XCTAssertTrue(history.json)
+    }
+
+    func testParsesHistoryShowDeleteAndClear() throws {
+        let show = try TransformsCommand.parseAsRoot(["history", "show", "abc123"])
+        XCTAssertEqual(try XCTUnwrap(show as? TransformsCommand.HistorySubcommand.ShowSubcommand).idPrefix, "abc123")
+
+        let delete = try TransformsCommand.parseAsRoot(["history", "delete", "abc123"])
+        XCTAssertEqual(try XCTUnwrap(delete as? TransformsCommand.HistorySubcommand.DeleteSubcommand).idPrefix, "abc123")
+
+        let clear = try TransformsCommand.parseAsRoot(["history", "clear", "--json"])
+        XCTAssertTrue(try XCTUnwrap(clear as? TransformsCommand.HistorySubcommand.ClearSubcommand).json)
+    }
+
     // MARK: - JSON contract
 
     func testTransformDTOJSONUsesDocumentedSnakeCaseKeys() throws {
@@ -132,6 +150,37 @@ final class TransformsCommandTests: XCTestCase {
         XCTAssertNil(object["isBuiltIn"])
         XCTAssertNil(object["createdAt"])
         XCTAssertNil(object["updatedAt"])
+    }
+
+    func testTransformHistoryDTOJSONUsesDocumentedSnakeCaseKeys() throws {
+        let entry = TransformHistoryEntry(
+            id: UUID(uuidString: "22222222-2222-2222-2222-222222222222")!,
+            transformId: UUID(uuidString: "0FCE9DDB-7E2D-4B1A-AE3E-6F7C9B2A4D11"),
+            transformName: "Polish",
+            inputText: "rough",
+            outputText: "polished",
+            sourceAppBundleID: "com.apple.TextEdit",
+            sourceAppName: "TextEdit",
+            capturePath: "ax",
+            replacementPath: "ax",
+            llmElapsedMs: 12,
+            totalElapsedMs: 34,
+            createdAt: Date(timeIntervalSince1970: 0),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+
+        let data = try cliJSONEncoder.encode(TransformHistoryDTO(entry: entry))
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual(object["transform_name"] as? String, "Polish")
+        XCTAssertEqual(object["input_text"] as? String, "rough")
+        XCTAssertEqual(object["output_text"] as? String, "polished")
+        XCTAssertEqual(object["source_app_bundle_id"] as? String, "com.apple.TextEdit")
+        XCTAssertEqual(object["llm_elapsed_ms"] as? Int, 12)
+        XCTAssertNotNil(object["created_at"])
+        XCTAssertNil(object["transformName"])
+        XCTAssertNil(object["inputText"])
+        XCTAssertNil(object["outputText"])
     }
 
     // MARK: - End-to-end: create + list + show + delete against a real DB
@@ -170,6 +219,50 @@ final class TransformsCommandTests: XCTestCase {
         let after = try repo.fetchVisible(category: .transform)
         XCTAssertEqual(after.count, 3)
         XCTAssertFalse(after.contains(where: { $0.name == "Sharpen" }))
+    }
+
+    func testHistoryDeleteAndClearRoundTrip() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("transforms-history-cli-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let dbPath = tmp.appendingPathComponent("test.db").path
+
+        let db = try DatabaseManager(path: dbPath)
+        let repo = TransformHistoryRepository(dbQueue: db.dbQueue)
+        let first = TransformHistoryEntry(
+            transformName: "Polish",
+            inputText: "rough",
+            outputText: "polished",
+            capturePath: "ax",
+            replacementPath: "ax",
+            llmElapsedMs: 1,
+            totalElapsedMs: 2
+        )
+        let second = TransformHistoryEntry(
+            transformName: "Distill",
+            inputText: "long",
+            outputText: "short",
+            capturePath: "clipboard",
+            replacementPath: "clipboardPaste",
+            llmElapsedMs: 3,
+            totalElapsedMs: 4
+        )
+        try repo.save(first)
+        try repo.save(second)
+
+        let del = try TransformsCommand.HistorySubcommand.DeleteSubcommand.parse([
+            String(first.id.uuidString.prefix(8)),
+            "--database", dbPath,
+        ])
+        try del.run()
+        XCTAssertEqual(try repo.fetchAll().map(\.id), [second.id])
+
+        let clear = try TransformsCommand.HistorySubcommand.ClearSubcommand.parse([
+            "--database", dbPath,
+        ])
+        try clear.run()
+        XCTAssertEqual(try repo.count(), 0)
     }
 
     func testCreateRejectsBareKeyShortcut() throws {

--- a/Tests/CLITests/TransformsCommandTests.swift
+++ b/Tests/CLITests/TransformsCommandTests.swift
@@ -172,6 +172,7 @@ final class TransformsCommandTests: XCTestCase {
         let data = try cliJSONEncoder.encode(TransformHistoryDTO(entry: entry))
         let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
 
+        XCTAssertEqual(object["id"] as? String, "22222222-2222-2222-2222-222222222222")
         XCTAssertEqual(object["transform_name"] as? String, "Polish")
         XCTAssertEqual(object["input_text"] as? String, "rough")
         XCTAssertEqual(object["output_text"] as? String, "polished")
@@ -222,6 +223,8 @@ final class TransformsCommandTests: XCTestCase {
     }
 
     func testHistoryDeleteAndClearRoundTrip() throws {
+        // These subcommands intentionally reopen the database from `--database`,
+        // so this round-trip needs a file-backed path rather than one in-memory queue.
         let tmp = FileManager.default.temporaryDirectory
             .appendingPathComponent("transforms-history-cli-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
@@ -263,6 +266,30 @@ final class TransformsCommandTests: XCTestCase {
         ])
         try clear.run()
         XCTAssertEqual(try repo.count(), 0)
+    }
+
+    func testHistoryShowRejectsTooShortPrefix() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("transforms-history-cli-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let dbPath = tmp.appendingPathComponent("test.db").path
+
+        _ = try DatabaseManager(path: dbPath)
+
+        let show = try TransformsCommand.HistorySubcommand.ShowSubcommand.parse([
+            "abc",
+            "--database", dbPath,
+        ])
+
+        XCTAssertThrowsError(try show.run()) { error in
+            guard case CLITransformHistoryError.prefixTooShort(let min, let provided) = error else {
+                XCTFail("Expected prefixTooShort, got \(error)")
+                return
+            }
+            XCTAssertEqual(min, 4)
+            XCTAssertEqual(provided, "abc")
+        }
     }
 
     func testCreateRejectsBareKeyShortcut() throws {

--- a/Tests/CLITests/TransformsCommandTests.swift
+++ b/Tests/CLITests/TransformsCommandTests.swift
@@ -1,3 +1,4 @@
+import ArgumentParser
 import Foundation
 import XCTest
 @testable import CLI
@@ -290,6 +291,70 @@ final class TransformsCommandTests: XCTestCase {
             XCTAssertEqual(min, 4)
             XCTAssertEqual(provided, "abc")
         }
+    }
+
+    func testHistoryShowJSONMapsTooShortPrefixToValidationError() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("transforms-history-cli-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let dbPath = tmp.appendingPathComponent("test.db").path
+
+        _ = try DatabaseManager(path: dbPath)
+
+        let show = try TransformsCommand.HistorySubcommand.ShowSubcommand.parse([
+            "abc",
+            "--database", dbPath,
+            "--json",
+        ])
+
+        var thrownError: Error?
+        let output = try captureStandardOutput {
+            do {
+                try show.run()
+            } catch {
+                thrownError = error
+            }
+        }
+
+        let exit = try XCTUnwrap(thrownError as? ExitCode)
+        XCTAssertEqual(exit.rawValue, 2)
+
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any])
+        XCTAssertEqual(object["ok"] as? Bool, false)
+        XCTAssertEqual(object["errorType"] as? String, "validation")
+    }
+
+    func testHistoryShowJSONMapsMissingItemToLookupError() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("transforms-history-cli-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let dbPath = tmp.appendingPathComponent("test.db").path
+
+        _ = try DatabaseManager(path: dbPath)
+
+        let show = try TransformsCommand.HistorySubcommand.ShowSubcommand.parse([
+            "abcd",
+            "--database", dbPath,
+            "--json",
+        ])
+
+        var thrownError: Error?
+        let output = try captureStandardOutput {
+            do {
+                try show.run()
+            } catch {
+                thrownError = error
+            }
+        }
+
+        let exit = try XCTUnwrap(thrownError as? ExitCode)
+        XCTAssertEqual(exit, .failure)
+
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any])
+        XCTAssertEqual(object["ok"] as? Bool, false)
+        XCTAssertEqual(object["errorType"] as? String, "lookup")
     }
 
     func testCreateRejectsBareKeyShortcut() throws {

--- a/Tests/MacParakeetTests/Database/TransformHistoryRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/TransformHistoryRepositoryTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class TransformHistoryRepositoryTests: XCTestCase {
+    var repo: TransformHistoryRepository!
+
+    override func setUp() async throws {
+        let manager = try DatabaseManager()
+        repo = TransformHistoryRepository(dbQueue: manager.dbQueue)
+    }
+
+    func testSaveAndFetchRecentOrdersNewestFirst() throws {
+        let older = TransformHistoryEntry(
+            transformId: UUID(uuidString: "0FCE9DDB-7E2D-4B1A-AE3E-6F7C9B2A4D11"),
+            transformName: "Polish",
+            inputText: "rough",
+            outputText: "polished",
+            sourceAppBundleID: "com.apple.TextEdit",
+            sourceAppName: "TextEdit",
+            capturePath: "ax",
+            replacementPath: "ax",
+            llmElapsedMs: 10,
+            totalElapsedMs: 20,
+            createdAt: Date(timeIntervalSince1970: 10),
+            updatedAt: Date(timeIntervalSince1970: 10)
+        )
+        let newer = TransformHistoryEntry(
+            transformId: UUID(uuidString: "1AD7C2B0-9C6F-4F0E-9C39-5E4D1F1D2A55"),
+            transformName: "Distill",
+            inputText: "long",
+            outputText: "short",
+            sourceAppBundleID: "com.tinyspeck.slackmacgap",
+            sourceAppName: "Slack",
+            capturePath: "clipboard",
+            replacementPath: "clipboardPaste",
+            llmElapsedMs: 30,
+            totalElapsedMs: 45,
+            createdAt: Date(timeIntervalSince1970: 20),
+            updatedAt: Date(timeIntervalSince1970: 20)
+        )
+
+        try repo.save(older)
+        try repo.save(newer)
+
+        let fetched = try repo.fetchRecent(limit: 10)
+        XCTAssertEqual(fetched.map(\.transformName), ["Distill", "Polish"])
+        XCTAssertEqual(fetched.first?.inputText, "long")
+        XCTAssertEqual(fetched.first?.outputText, "short")
+        XCTAssertEqual(try repo.count(), 2)
+    }
+
+    func testFetchRecentHonorsLimitWithoutDeletingRows() throws {
+        for index in 0..<5 {
+            try repo.save(
+                TransformHistoryEntry(
+                    transformName: "Transform \(index)",
+                    inputText: "input \(index)",
+                    outputText: "output \(index)",
+                    capturePath: "ax",
+                    replacementPath: "ax",
+                    llmElapsedMs: index,
+                    totalElapsedMs: index + 1,
+                    createdAt: Date(timeIntervalSince1970: TimeInterval(index)),
+                    updatedAt: Date(timeIntervalSince1970: TimeInterval(index))
+                )
+            )
+        }
+
+        let fetched = try repo.fetchRecent(limit: 2)
+
+        XCTAssertEqual(fetched.map(\.transformName), ["Transform 4", "Transform 3"])
+        XCTAssertEqual(try repo.count(), 5)
+    }
+
+    func testDeleteSingleAndDeleteAll() throws {
+        let first = TransformHistoryEntry(
+            transformName: "Polish",
+            inputText: "one",
+            outputText: "One.",
+            capturePath: "ax",
+            replacementPath: "ax",
+            llmElapsedMs: 1,
+            totalElapsedMs: 2
+        )
+        let second = TransformHistoryEntry(
+            transformName: "Decide",
+            inputText: "two",
+            outputText: "Choose two.",
+            capturePath: "clipboard",
+            replacementPath: "clipboardPaste",
+            llmElapsedMs: 3,
+            totalElapsedMs: 4
+        )
+        try repo.save(first)
+        try repo.save(second)
+
+        XCTAssertTrue(try repo.delete(id: first.id))
+        XCTAssertEqual(try repo.fetchRecent(limit: 10).map(\.id), [second.id])
+
+        try repo.deleteAll()
+        XCTAssertEqual(try repo.count(), 0)
+    }
+}

--- a/Tests/MacParakeetTests/Database/TransformHistoryRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/TransformHistoryRepositoryTests.swift
@@ -72,6 +72,40 @@ final class TransformHistoryRepositoryTests: XCTestCase {
         XCTAssertEqual(try repo.count(), 5)
     }
 
+    func testFetchByIDAndIDPrefix() throws {
+        let first = TransformHistoryEntry(
+            id: UUID(uuidString: "11111111-1111-1111-1111-111111111111")!,
+            transformName: "Polish",
+            inputText: "one",
+            outputText: "One.",
+            capturePath: "ax",
+            replacementPath: "ax",
+            llmElapsedMs: 1,
+            totalElapsedMs: 2,
+            createdAt: Date(timeIntervalSince1970: 10),
+            updatedAt: Date(timeIntervalSince1970: 10)
+        )
+        let second = TransformHistoryEntry(
+            id: UUID(uuidString: "22222222-2222-2222-2222-222222222222")!,
+            transformName: "Distill",
+            inputText: "two",
+            outputText: "Two.",
+            capturePath: "clipboard",
+            replacementPath: "clipboardPaste",
+            llmElapsedMs: 3,
+            totalElapsedMs: 4,
+            createdAt: Date(timeIntervalSince1970: 20),
+            updatedAt: Date(timeIntervalSince1970: 20)
+        )
+        try repo.save(first)
+        try repo.save(second)
+
+        XCTAssertEqual(try repo.fetch(id: first.id)?.id, first.id)
+        XCTAssertEqual(try repo.fetch(idPrefix: "2222").map(\.id), [second.id])
+        XCTAssertEqual(try repo.fetch(idPrefix: "1111").map(\.id), [first.id])
+        XCTAssertTrue(try repo.fetch(idPrefix: "%").isEmpty)
+    }
+
     func testDeleteSingleAndDeleteAll() throws {
         let first = TransformHistoryEntry(
             transformName: "Polish",

--- a/Tests/MacParakeetTests/Services/System/SelectionCaptureServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/System/SelectionCaptureServiceTests.swift
@@ -29,8 +29,9 @@ final class SelectionCaptureServiceTests: XCTestCase {
         let result = await service.captureSelection()
 
         switch result {
-        case .ax(let text, _):
+        case .ax(let text, _, let target):
             XCTAssertEqual(text, "Hello world")
+            XCTAssertEqual(target?.processIdentifier, 1234)
         default:
             XCTFail("Expected .ax, got \(result.pathTag)")
         }
@@ -54,10 +55,11 @@ final class SelectionCaptureServiceTests: XCTestCase {
         let result = await service.captureSelection()
 
         switch result {
-        case .clipboard(let text, let snapshot):
+        case .clipboard(let text, let snapshot, let target):
             XCTAssertEqual(text, "Clipboard selection")
             XCTAssertEqual(snapshot.originalChangeCount, 1)
             XCTAssertEqual(snapshot.temporaryChangeCount, 2)
+            XCTAssertEqual(target?.processIdentifier, 1234)
         default:
             XCTFail("Expected .clipboard, got \(result.pathTag)")
         }
@@ -108,7 +110,7 @@ final class SelectionCaptureServiceTests: XCTestCase {
 
         let result = await service.captureSelection()
 
-        guard case .clipboard(_, let snapshot) = result else {
+        guard case .clipboard(_, let snapshot, _) = result else {
             XCTFail("Expected .clipboard, got \(result.pathTag)")
             return
         }
@@ -206,6 +208,9 @@ final class FakeSelectionCaptureBackend: SelectionCaptureBackend, @unchecked Sen
     func isAccessibilityTrusted() -> Bool { trusted }
     func focusedElement() -> AXUIElement? { focused }
     func selectedText(of element: AXUIElement) -> String? { selectedTextValue }
+
+    @MainActor
+    func frontmostApplicationProcessIdentifier() -> pid_t? { 1234 }
 
     @MainActor
     func snapshotPasteboard() -> PasteboardSnapshot {

--- a/Tests/MacParakeetTests/Services/System/SelectionCaptureServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/System/SelectionCaptureServiceTests.swift
@@ -32,6 +32,7 @@ final class SelectionCaptureServiceTests: XCTestCase {
         case .ax(let text, _, let target):
             XCTAssertEqual(text, "Hello world")
             XCTAssertEqual(target?.processIdentifier, 1234)
+            XCTAssertEqual(target?.bundleIdentifier, "com.example.Source")
         default:
             XCTFail("Expected .ax, got \(result.pathTag)")
         }
@@ -60,6 +61,7 @@ final class SelectionCaptureServiceTests: XCTestCase {
             XCTAssertEqual(snapshot.originalChangeCount, 1)
             XCTAssertEqual(snapshot.temporaryChangeCount, 2)
             XCTAssertEqual(target?.processIdentifier, 1234)
+            XCTAssertEqual(target?.bundleIdentifier, "com.example.Source")
         default:
             XCTFail("Expected .clipboard, got \(result.pathTag)")
         }
@@ -210,7 +212,12 @@ final class FakeSelectionCaptureBackend: SelectionCaptureBackend, @unchecked Sen
     func selectedText(of element: AXUIElement) -> String? { selectedTextValue }
 
     @MainActor
-    func frontmostApplicationProcessIdentifier() -> pid_t? { 1234 }
+    func frontmostApplicationTarget() -> SelectionCaptureTarget? {
+        SelectionCaptureTarget(
+            processIdentifier: 1234,
+            bundleIdentifier: "com.example.Source"
+        )
+    }
 
     @MainActor
     func snapshotPasteboard() -> PasteboardSnapshot {

--- a/Tests/MacParakeetTests/Services/System/SelectionReplacementServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/System/SelectionReplacementServiceTests.swift
@@ -14,7 +14,7 @@ final class SelectionReplacementServiceTests: XCTestCase {
 
         let path = try await service.replace(
             with: "polished",
-            in: .ax(text: "raw", element: AXFocusedElement(AXUIElementCreateSystemWide()))
+            in: .ax(text: "raw", element: AXFocusedElement(AXUIElementCreateSystemWide()), target: nil)
         )
 
         XCTAssertEqual(path, .ax)
@@ -31,7 +31,7 @@ final class SelectionReplacementServiceTests: XCTestCase {
 
         let path = try await service.replace(
             with: "polished",
-            in: .ax(text: "raw", element: AXFocusedElement(AXUIElementCreateSystemWide()))
+            in: .ax(text: "raw", element: AXFocusedElement(AXUIElementCreateSystemWide()), target: nil)
         )
 
         XCTAssertEqual(path, .clipboardPaste)
@@ -50,7 +50,7 @@ final class SelectionReplacementServiceTests: XCTestCase {
 
         let path = try await service.replace(
             with: "polished",
-            in: .clipboard(text: "raw", savedClipboard: snapshot)
+            in: .clipboard(text: "raw", savedClipboard: snapshot, target: nil)
         )
 
         XCTAssertEqual(path, .clipboardPaste)
@@ -84,7 +84,7 @@ final class SelectionReplacementServiceTests: XCTestCase {
         do {
             _ = try await service.replace(
                 with: "polished",
-                in: .clipboard(text: "raw", savedClipboard: snapshot)
+                in: .clipboard(text: "raw", savedClipboard: snapshot, target: nil)
             )
             XCTFail("Expected pasteboardWriteFailed")
         } catch let error as SelectionReplacementError {
@@ -111,7 +111,7 @@ final class SelectionReplacementServiceTests: XCTestCase {
 
         _ = try await service.replace(
             with: "polished",
-            in: .clipboard(text: "raw", savedClipboard: snapshot)
+            in: .clipboard(text: "raw", savedClipboard: snapshot, target: nil)
         )
 
         XCTAssertEqual(backend.cmdVPostCount(), 1, "Paste should still happen — we only suppress restore")
@@ -134,12 +134,61 @@ final class SelectionReplacementServiceTests: XCTestCase {
 
         _ = try await service.replace(
             with: "polished",
-            in: .clipboard(text: "raw", savedClipboard: preTransformSnapshot)
+            in: .clipboard(text: "raw", savedClipboard: preTransformSnapshot, target: nil)
         )
 
         XCTAssertEqual(backend.cmdVPostCount(), 1)
         XCTAssertEqual(backend.restoreCount(), 1)
         XCTAssertEqual(backend.lastRestoredChangeCount(), 12, "Restore should use the user's newer clipboard snapshot, not the pre-transform one")
+    }
+
+    func testClipboardPasteReactivatesOriginalTargetBeforeCmdV() async throws {
+        let backend = FakeSelectionReplacementBackend(
+            isTrusted: true,
+            axWriteSucceeds: false
+        )
+        let service = SelectionReplacementService(backend: backend, postPasteDelay: .milliseconds(1))
+        let snapshot = PasteboardSnapshot(items: nil, originalChangeCount: 42)
+
+        _ = try await service.replace(
+            with: "polished",
+            in: .clipboard(
+                text: "raw",
+                savedClipboard: snapshot,
+                target: SelectionCaptureTarget(processIdentifier: 1234)
+            )
+        )
+
+        XCTAssertEqual(backend.activatedProcessIdentifiers(), [1234])
+        XCTAssertEqual(backend.cmdVPostCount(), 1)
+    }
+
+    func testClipboardPasteDoesNotPostCmdVWhenTargetActivationFails() async {
+        let backend = FakeSelectionReplacementBackend(
+            isTrusted: true,
+            axWriteSucceeds: false,
+            targetActivationSucceeds: false
+        )
+        let service = SelectionReplacementService(backend: backend, postPasteDelay: .milliseconds(1))
+        let snapshot = PasteboardSnapshot(items: nil, originalChangeCount: 42)
+
+        do {
+            _ = try await service.replace(
+                with: "polished",
+                in: .clipboard(
+                    text: "raw",
+                    savedClipboard: snapshot,
+                    target: SelectionCaptureTarget(processIdentifier: 1234)
+                )
+            )
+            XCTFail("Expected targetActivationFailed")
+        } catch let error as SelectionReplacementError {
+            XCTAssertEqual(error, .targetActivationFailed)
+            XCTAssertEqual(backend.cmdVPostCount(), 0)
+            XCTAssertGreaterThanOrEqual(backend.restoreCount(), 1)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
     }
 }
 
@@ -152,11 +201,13 @@ final class FakeSelectionReplacementBackend: SelectionReplacementBackend, @unche
     private let axWriteSucceedsValue: Bool
     private let pasteboardWriteSucceedsValue: Bool
     private let simulateUserCopyAfterWrite: Bool
+    private let targetActivationSucceeds: Bool
     private let lock = OSAllocatedUnfairLock<State>(initialState: State())
 
     private struct State {
         var axTexts: [String] = []
         var clipboardTexts: [String] = []
+        var activatedProcessIdentifiers: [pid_t] = []
         var cmdVPosts: Int = 0
         var restoreSnapshots: [PasteboardSnapshot] = []
         /// Simulated pasteboard changeCount. Bumped on `writePasteboardString`
@@ -173,12 +224,14 @@ final class FakeSelectionReplacementBackend: SelectionReplacementBackend, @unche
         axWriteSucceeds: Bool = false,
         pasteboardWriteSucceeds: Bool = true,
         simulateUserCopyAfterWrite: Bool = false,
+        targetActivationSucceeds: Bool = true,
         initialChangeCount: Int = 0
     ) {
         self.trusted = isTrusted
         self.axWriteSucceedsValue = axWriteSucceeds
         self.pasteboardWriteSucceedsValue = pasteboardWriteSucceeds
         self.simulateUserCopyAfterWrite = simulateUserCopyAfterWrite
+        self.targetActivationSucceeds = targetActivationSucceeds
         lock.withLock { $0.changeCount = initialChangeCount }
     }
 
@@ -200,6 +253,12 @@ final class FakeSelectionReplacementBackend: SelectionReplacementBackend, @unche
             }
         }
         return pasteboardWriteSucceedsValue
+    }
+
+    @MainActor
+    func activateApplication(processIdentifier: pid_t) -> Bool {
+        lock.withLock { $0.activatedProcessIdentifiers.append(processIdentifier) }
+        return targetActivationSucceeds
     }
 
     @MainActor
@@ -246,6 +305,10 @@ final class FakeSelectionReplacementBackend: SelectionReplacementBackend, @unche
 
     func cmdVPostCount() -> Int {
         lock.withLock { $0.cmdVPosts }
+    }
+
+    func activatedProcessIdentifiers() -> [pid_t] {
+        lock.withLock { $0.activatedProcessIdentifiers }
     }
 
     func restoreCount() -> Int {

--- a/Tests/MacParakeetTests/Services/System/SelectionReplacementServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/System/SelectionReplacementServiceTests.swift
@@ -201,6 +201,44 @@ final class SelectionReplacementServiceTests: XCTestCase {
             XCTFail("Unexpected error: \(error)")
         }
     }
+
+    func testClipboardPasteDoesNotPostCmdVUntilTargetIsFrontmost() async {
+        let backend = FakeSelectionReplacementBackend(
+            isTrusted: true,
+            axWriteSucceeds: false,
+            targetActivationSucceeds: true,
+            activationMakesTargetFrontmost: false
+        )
+        let service = SelectionReplacementService(
+            backend: backend,
+            postPasteDelay: .milliseconds(1),
+            activationTimeout: .milliseconds(1),
+            activationPollIntervalNanos: 1_000_000
+        )
+        let snapshot = PasteboardSnapshot(items: nil, originalChangeCount: 42)
+
+        do {
+            _ = try await service.replace(
+                with: "polished",
+                in: .clipboard(
+                    text: "raw",
+                    savedClipboard: snapshot,
+                    target: SelectionCaptureTarget(
+                        processIdentifier: 1234,
+                        bundleIdentifier: "com.example.Source"
+                    )
+                )
+            )
+            XCTFail("Expected targetActivationFailed")
+        } catch let error as SelectionReplacementError {
+            XCTAssertEqual(error, .targetActivationFailed)
+            XCTAssertEqual(backend.cmdVPostCount(), 0)
+            XCTAssertGreaterThanOrEqual(backend.frontmostCheckCount(), 1)
+            XCTAssertGreaterThanOrEqual(backend.restoreCount(), 1)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
 }
 
 // MARK: - Fake Backend
@@ -213,12 +251,15 @@ final class FakeSelectionReplacementBackend: SelectionReplacementBackend, @unche
     private let pasteboardWriteSucceedsValue: Bool
     private let simulateUserCopyAfterWrite: Bool
     private let targetActivationSucceeds: Bool
+    private let activationMakesTargetFrontmost: Bool
     private let lock = OSAllocatedUnfairLock<State>(initialState: State())
 
     private struct State {
         var axTexts: [String] = []
         var clipboardTexts: [String] = []
         var activatedTargets: [SelectionCaptureTarget] = []
+        var frontmostTarget: SelectionCaptureTarget?
+        var frontmostChecks: Int = 0
         var cmdVPosts: Int = 0
         var restoreSnapshots: [PasteboardSnapshot] = []
         /// Simulated pasteboard changeCount. Bumped on `writePasteboardString`
@@ -236,6 +277,7 @@ final class FakeSelectionReplacementBackend: SelectionReplacementBackend, @unche
         pasteboardWriteSucceeds: Bool = true,
         simulateUserCopyAfterWrite: Bool = false,
         targetActivationSucceeds: Bool = true,
+        activationMakesTargetFrontmost: Bool = true,
         initialChangeCount: Int = 0
     ) {
         self.trusted = isTrusted
@@ -243,6 +285,7 @@ final class FakeSelectionReplacementBackend: SelectionReplacementBackend, @unche
         self.pasteboardWriteSucceedsValue = pasteboardWriteSucceeds
         self.simulateUserCopyAfterWrite = simulateUserCopyAfterWrite
         self.targetActivationSucceeds = targetActivationSucceeds
+        self.activationMakesTargetFrontmost = activationMakesTargetFrontmost
         lock.withLock { $0.changeCount = initialChangeCount }
     }
 
@@ -268,8 +311,21 @@ final class FakeSelectionReplacementBackend: SelectionReplacementBackend, @unche
 
     @MainActor
     func activateApplication(target: SelectionCaptureTarget) -> Bool {
-        lock.withLock { $0.activatedTargets.append(target) }
+        lock.withLock { state in
+            state.activatedTargets.append(target)
+            if targetActivationSucceeds, activationMakesTargetFrontmost {
+                state.frontmostTarget = target
+            }
+        }
         return targetActivationSucceeds
+    }
+
+    @MainActor
+    func isFrontmostApplication(target: SelectionCaptureTarget) -> Bool {
+        lock.withLock { state in
+            state.frontmostChecks += 1
+            return state.frontmostTarget == target
+        }
     }
 
     @MainActor
@@ -320,6 +376,10 @@ final class FakeSelectionReplacementBackend: SelectionReplacementBackend, @unche
 
     func activatedTargets() -> [SelectionCaptureTarget] {
         lock.withLock { $0.activatedTargets }
+    }
+
+    func frontmostCheckCount() -> Int {
+        lock.withLock { $0.frontmostChecks }
     }
 
     func restoreCount() -> Int {

--- a/Tests/MacParakeetTests/Services/System/SelectionReplacementServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/System/SelectionReplacementServiceTests.swift
@@ -155,11 +155,19 @@ final class SelectionReplacementServiceTests: XCTestCase {
             in: .clipboard(
                 text: "raw",
                 savedClipboard: snapshot,
-                target: SelectionCaptureTarget(processIdentifier: 1234)
+                target: SelectionCaptureTarget(
+                    processIdentifier: 1234,
+                    bundleIdentifier: "com.example.Source"
+                )
             )
         )
 
-        XCTAssertEqual(backend.activatedProcessIdentifiers(), [1234])
+        XCTAssertEqual(backend.activatedTargets(), [
+            SelectionCaptureTarget(
+                processIdentifier: 1234,
+                bundleIdentifier: "com.example.Source"
+            )
+        ])
         XCTAssertEqual(backend.cmdVPostCount(), 1)
     }
 
@@ -178,7 +186,10 @@ final class SelectionReplacementServiceTests: XCTestCase {
                 in: .clipboard(
                     text: "raw",
                     savedClipboard: snapshot,
-                    target: SelectionCaptureTarget(processIdentifier: 1234)
+                    target: SelectionCaptureTarget(
+                        processIdentifier: 1234,
+                        bundleIdentifier: "com.example.Source"
+                    )
                 )
             )
             XCTFail("Expected targetActivationFailed")
@@ -207,7 +218,7 @@ final class FakeSelectionReplacementBackend: SelectionReplacementBackend, @unche
     private struct State {
         var axTexts: [String] = []
         var clipboardTexts: [String] = []
-        var activatedProcessIdentifiers: [pid_t] = []
+        var activatedTargets: [SelectionCaptureTarget] = []
         var cmdVPosts: Int = 0
         var restoreSnapshots: [PasteboardSnapshot] = []
         /// Simulated pasteboard changeCount. Bumped on `writePasteboardString`
@@ -256,8 +267,8 @@ final class FakeSelectionReplacementBackend: SelectionReplacementBackend, @unche
     }
 
     @MainActor
-    func activateApplication(processIdentifier: pid_t) -> Bool {
-        lock.withLock { $0.activatedProcessIdentifiers.append(processIdentifier) }
+    func activateApplication(target: SelectionCaptureTarget) -> Bool {
+        lock.withLock { $0.activatedTargets.append(target) }
         return targetActivationSucceeds
     }
 
@@ -307,8 +318,8 @@ final class FakeSelectionReplacementBackend: SelectionReplacementBackend, @unche
         lock.withLock { $0.cmdVPosts }
     }
 
-    func activatedProcessIdentifiers() -> [pid_t] {
-        lock.withLock { $0.activatedProcessIdentifiers }
+    func activatedTargets() -> [SelectionCaptureTarget] {
+        lock.withLock { $0.activatedTargets }
     }
 
     func restoreCount() -> Int {

--- a/Tests/MacParakeetTests/Services/Transforms/TransformExecutorTests.swift
+++ b/Tests/MacParakeetTests/Services/Transforms/TransformExecutorTests.swift
@@ -203,6 +203,7 @@ final class TransformExecutorTests: XCTestCase {
 
         let recorder = TransformProgressRecorder()
         let result = try await executor.run(prompt: "polish") { recorder.record($0) }
+        XCTAssertEqual(result.inputText, "Hello world")
         XCTAssertEqual(result.outputText, "Hi there!")
         XCTAssertEqual(result.path, .ax)
         XCTAssertEqual(result.captureTag, "ax")

--- a/Tests/MacParakeetTests/ViewModels/TransformsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TransformsViewModelTests.swift
@@ -6,13 +6,15 @@ import XCTest
 final class TransformsViewModelTests: XCTestCase {
     var manager: DatabaseManager!
     var repo: PromptRepository!
+    var historyRepo: TransformHistoryRepository!
     var viewModel: TransformsViewModel!
 
     override func setUp() async throws {
         manager = try DatabaseManager()
         repo = PromptRepository(dbQueue: manager.dbQueue)
+        historyRepo = TransformHistoryRepository(dbQueue: manager.dbQueue)
         viewModel = TransformsViewModel()
-        viewModel.configure(repo: repo, hasLLMProvider: true)
+        viewModel.configure(repo: repo, historyRepo: historyRepo, hasLLMProvider: true)
     }
 
     func testLoadPullsOnlyTransformCategoryPrompts() {
@@ -140,5 +142,71 @@ final class TransformsViewModelTests: XCTestCase {
 
         let reloaded = viewModel.transforms.first(where: { $0.name == "Polish" })!
         XCTAssertEqual(reloaded.content, customContent, "Reseed must not overwrite existing built-in customizations.")
+    }
+
+    func testLoadHistoryOrdersNewestFirst() throws {
+        try historyRepo.save(
+            TransformHistoryEntry(
+                transformName: "Polish",
+                inputText: "rough",
+                outputText: "polished",
+                capturePath: "ax",
+                replacementPath: "ax",
+                llmElapsedMs: 1,
+                totalElapsedMs: 2,
+                createdAt: Date(timeIntervalSince1970: 10),
+                updatedAt: Date(timeIntervalSince1970: 10)
+            )
+        )
+        try historyRepo.save(
+            TransformHistoryEntry(
+                transformName: "Distill",
+                inputText: "long",
+                outputText: "short",
+                capturePath: "clipboard",
+                replacementPath: "clipboardPaste",
+                llmElapsedMs: 3,
+                totalElapsedMs: 4,
+                createdAt: Date(timeIntervalSince1970: 20),
+                updatedAt: Date(timeIntervalSince1970: 20)
+            )
+        )
+
+        viewModel.loadHistory()
+
+        XCTAssertEqual(viewModel.history.map(\.transformName), ["Distill", "Polish"])
+    }
+
+    func testDeleteAndClearHistory() throws {
+        let first = TransformHistoryEntry(
+            transformName: "Polish",
+            inputText: "one",
+            outputText: "One.",
+            capturePath: "ax",
+            replacementPath: "ax",
+            llmElapsedMs: 1,
+            totalElapsedMs: 2
+        )
+        let second = TransformHistoryEntry(
+            transformName: "Decide",
+            inputText: "two",
+            outputText: "Choose two.",
+            capturePath: "clipboard",
+            replacementPath: "clipboardPaste",
+            llmElapsedMs: 3,
+            totalElapsedMs: 4
+        )
+        try historyRepo.save(first)
+        try historyRepo.save(second)
+        viewModel.loadHistory()
+
+        viewModel.deleteHistoryEntry(first)
+
+        XCTAssertEqual(viewModel.history.map(\.id), [second.id])
+
+        viewModel.clearHistory()
+
+        XCTAssertTrue(viewModel.history.isEmpty)
+        XCTAssertEqual(try historyRepo.count(), 0)
     }
 }

--- a/Tests/MacParakeetTests/ViewModels/TransformsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TransformsViewModelTests.swift
@@ -7,14 +7,21 @@ final class TransformsViewModelTests: XCTestCase {
     var manager: DatabaseManager!
     var repo: PromptRepository!
     var historyRepo: TransformHistoryRepository!
+    var clipboardService: MockClipboardService!
     var viewModel: TransformsViewModel!
 
     override func setUp() async throws {
         manager = try DatabaseManager()
         repo = PromptRepository(dbQueue: manager.dbQueue)
         historyRepo = TransformHistoryRepository(dbQueue: manager.dbQueue)
+        clipboardService = MockClipboardService()
         viewModel = TransformsViewModel()
-        viewModel.configure(repo: repo, historyRepo: historyRepo, hasLLMProvider: true)
+        viewModel.configure(
+            repo: repo,
+            historyRepo: historyRepo,
+            clipboardService: clipboardService,
+            hasLLMProvider: true
+        )
     }
 
     func testLoadPullsOnlyTransformCategoryPrompts() {
@@ -144,7 +151,7 @@ final class TransformsViewModelTests: XCTestCase {
         XCTAssertEqual(reloaded.content, customContent, "Reseed must not overwrite existing built-in customizations.")
     }
 
-    func testLoadHistoryOrdersNewestFirst() throws {
+    func testLoadHistoryOrdersNewestFirst() async throws {
         try historyRepo.save(
             TransformHistoryEntry(
                 transformName: "Polish",
@@ -172,12 +179,36 @@ final class TransformsViewModelTests: XCTestCase {
             )
         )
 
-        viewModel.loadHistory()
+        await viewModel.loadHistory()
 
         XCTAssertEqual(viewModel.history.map(\.transformName), ["Distill", "Polish"])
+        XCTAssertEqual(viewModel.totalHistoryCount, 2)
     }
 
-    func testDeleteAndClearHistory() throws {
+    func testLoadHistoryTotalCountIncludesRowsPastFetchLimit() async throws {
+        for index in 0..<205 {
+            try historyRepo.save(
+                TransformHistoryEntry(
+                    transformName: "Transform \(index)",
+                    inputText: "input",
+                    outputText: "output",
+                    capturePath: "ax",
+                    replacementPath: "ax",
+                    llmElapsedMs: 1,
+                    totalElapsedMs: 2,
+                    createdAt: Date(timeIntervalSince1970: TimeInterval(index)),
+                    updatedAt: Date(timeIntervalSince1970: TimeInterval(index))
+                )
+            )
+        }
+
+        await viewModel.loadHistory()
+
+        XCTAssertEqual(viewModel.history.count, TransformsViewModel.historyFetchLimit)
+        XCTAssertEqual(viewModel.totalHistoryCount, 205)
+    }
+
+    func testDeleteAndClearHistory() async throws {
         let first = TransformHistoryEntry(
             transformName: "Polish",
             inputText: "one",
@@ -198,15 +229,35 @@ final class TransformsViewModelTests: XCTestCase {
         )
         try historyRepo.save(first)
         try historyRepo.save(second)
-        viewModel.loadHistory()
+        await viewModel.loadHistory()
 
-        viewModel.deleteHistoryEntry(first)
+        await viewModel.deleteHistoryEntry(first)
 
         XCTAssertEqual(viewModel.history.map(\.id), [second.id])
+        XCTAssertEqual(viewModel.totalHistoryCount, 1)
 
-        viewModel.clearHistory()
+        await viewModel.clearHistory()
 
         XCTAssertTrue(viewModel.history.isEmpty)
+        XCTAssertEqual(viewModel.totalHistoryCount, 0)
         XCTAssertEqual(try historyRepo.count(), 0)
+    }
+
+    func testCopyHistoryOutputUsesInjectedClipboardService() async {
+        let entry = TransformHistoryEntry(
+            transformName: "Polish",
+            inputText: "rough",
+            outputText: "polished",
+            capturePath: "ax",
+            replacementPath: "ax",
+            llmElapsedMs: 1,
+            totalElapsedMs: 2
+        )
+
+        await viewModel.copyOutputToClipboard(entry)
+
+        let copiedText = await clipboardService.lastCopiedText
+        XCTAssertEqual(copiedText, "polished")
+        XCTAssertEqual(viewModel.copiedHistoryEntryID, entry.id)
     }
 }

--- a/spec/01-data-model.md
+++ b/spec/01-data-model.md
@@ -35,6 +35,10 @@ MacParakeet uses **SQLite via GRDB** for all persistent storage. Single database
 └──────────────────┘
 
 ┌──────────────────┐
+│ transform_history│   v0.14 — Local-only Transform input/output history
+└──────────────────┘
+
+┌──────────────────┐
 │  quick_prompts   │   v0.10 migration — v0.6 Live Ask shortcut pills
 └──────────────────┘
 ```
@@ -245,6 +249,8 @@ CREATE TABLE prompts (
     isVisible INTEGER NOT NULL DEFAULT 1,                 -- false = hidden from picker
     isAutoRun INTEGER NOT NULL DEFAULT 0,                 -- true = auto-generate for new transcriptions
     sortOrder INTEGER NOT NULL DEFAULT 0,                 -- Display ordering
+    keyboardShortcut TEXT,                                -- v0.13: JSON KeyboardShortcut for transforms
+    runningLabel TEXT,                                    -- v0.13: optional progress-pill label
     createdAt TEXT NOT NULL,                              -- ISO 8601 timestamp
     updatedAt TEXT NOT NULL                               -- ISO 8601 timestamp
 );
@@ -257,6 +263,7 @@ CREATE UNIQUE INDEX idx_prompts_name ON prompts(name COLLATE NOCASE);
 - `isBuiltIn` prompts are seeded from `Prompt.builtInPrompts()` during migration. The repository layer enforces the hide-only invariant (delete returns `false` for built-in prompts).
 - `isAutoRun` is independent of `isVisible`, but repository/UI behavior forces auto-run prompts visible while auto-run is enabled.
 - `category` currently stores the raw value `"summary"` for compatibility, while the Swift enum case is `Prompt.Category.result`.
+- `.transform` rows use `keyboardShortcut` and `runningLabel`; `.result` rows ignore both columns.
 - Built-ins currently come from `Prompt.builtInPrompts()` in Swift. "Summary" is the lone auto-run built-in for users who have not disabled every auto-run prompt. ("Memo-Steered Notes" was a second auto-run built-in introduced in ADR-020 and reverted on 2026-05-02 — see ADR-020 amendment.)
 
 ---
@@ -287,6 +294,38 @@ CREATE INDEX idx_summaries_transcription_id ON summaries(transcriptionId);
 - `promptName` and `promptContent` are snapshots, not references to the `prompts` table. Editing or deleting a prompt after generation doesn't change the result's metadata.
 - `userNotesSnapshot` captures `Transcription.userNotes` at generation time so later note edits do not rewrite historical prompt results.
 - Migration from existing data: legacy `transcriptions.summary` values migrate into `summaries` with classic "Summary" prompt metadata, then the legacy column is dropped by `v0.7.6-drop-legacy-transcription-summary`.
+
+---
+
+### `transform_history` (v0.14)
+
+Stores local-only history for completed GUI Transform runs. This is intentionally persisted by default, like dictation history, because selecting text and running a Transform is high-intent user activity. Users can delete individual entries or clear the table.
+
+```sql
+CREATE TABLE transform_history (
+    id                 TEXT PRIMARY KEY,                  -- UUID string
+    transformId        TEXT,                              -- Prompt UUID snapshot; nullable for future/imported runs
+    transformName      TEXT NOT NULL,                     -- Snapshot: Transform name at run time
+    inputText          TEXT NOT NULL,                     -- Selected text before the Transform
+    outputText         TEXT NOT NULL,                     -- LLM output pasted/written back
+    sourceAppBundleID  TEXT,                              -- Frontmost app bundle ID at trigger time
+    sourceAppName      TEXT,                              -- Frontmost app display name at trigger time
+    capturePath        TEXT NOT NULL,                     -- ax | clipboard
+    replacementPath    TEXT NOT NULL,                     -- ax | clipboardPaste
+    llmElapsedMs       INTEGER NOT NULL DEFAULT 0,
+    totalElapsedMs     INTEGER NOT NULL DEFAULT 0,
+    createdAt          TEXT NOT NULL,                     -- ISO 8601 timestamp
+    updatedAt          TEXT NOT NULL                      -- ISO 8601 timestamp
+);
+
+CREATE INDEX idx_transform_history_created_at ON transform_history(createdAt);
+CREATE INDEX idx_transform_history_transform_id ON transform_history(transformId);
+```
+
+**Notes:**
+- No foreign key to `prompts`: deleting a custom Transform should not delete the user's local run history.
+- History content never leaves the device through telemetry. Telemetry for Transforms continues to exclude input/output text.
+- The UI reads a recent window for performance, but the table is not automatically pruned.
 
 ---
 
@@ -582,6 +621,8 @@ struct Prompt: Codable, Identifiable, Sendable {
     var sortOrder: Int
     var createdAt: Date
     var updatedAt: Date
+    var keyboardShortcut: String?
+    var runningLabel: String?
 
     enum Category: String, Codable, Sendable {
         case result = "summary"
@@ -614,6 +655,33 @@ struct PromptResult: Codable, Identifiable, Sendable {
 
 extension PromptResult: FetchableRecord, PersistableRecord {
     static let databaseTableName = "summaries"
+}
+```
+
+### TransformHistoryEntry
+
+```swift
+import Foundation
+import GRDB
+
+struct TransformHistoryEntry: Codable, Identifiable, Sendable {
+    var id: UUID
+    var transformId: UUID?
+    var transformName: String
+    var inputText: String
+    var outputText: String
+    var sourceAppBundleID: String?
+    var sourceAppName: String?
+    var capturePath: String
+    var replacementPath: String
+    var llmElapsedMs: Int
+    var totalElapsedMs: Int
+    var createdAt: Date
+    var updatedAt: Date
+}
+
+extension TransformHistoryEntry: FetchableRecord, PersistableRecord {
+    static let databaseTableName = "transform_history"
 }
 ```
 
@@ -849,6 +917,9 @@ migrator.registerMigration("v0.7-prompts-and-summaries") { db in
 // v0.10 — quick_prompts (v0.6 Live Ask product surface)
 // v0.10 — transcription library indexes (sourceType/favorite/status + createdAt)
 // v0.11 — daily_dictation_stats
+// v0.12 — dictations.displayRawTranscript
+// v0.13 — prompts.keyboardShortcut and prompts.runningLabel
+// v0.14 — transform_history
 ```
 
 ### Migration Rules
@@ -898,6 +969,10 @@ migrator.registerMigration("v0.7-prompts-and-summaries") { db in
 | `transcriptions.derivedSnippet` | v0.9 | Cached display preview snippet derived from transcript content |
 | `quick_prompts` | v0.10 | User-customizable live Ask tab shortcut pills; v0.6 product feature |
 | `idx_transcriptions_source_type_created_at` / `idx_transcriptions_favorite_created_at` / `idx_transcriptions_status_created_at` | v0.10 | Library filter/sort indexes for source type, favorites, and status |
+| `dictations.displayRawTranscript` | v0.12 | Per-row raw/AI-edited display override |
+| `prompts.keyboardShortcut` | v0.13 | Transform hotkey binding JSON |
+| `prompts.runningLabel` | v0.13 | Transform progress-pill label override |
+| `transform_history` | v0.14 | Local-only Transform input/output history |
 
 ### Tables NOT Planned (YAGNI)
 


### PR DESCRIPTION
## Summary
- Saves successful GUI Transform runs locally, including selected input, transformed output, source app, Transform name, replacement path, and timing metadata.
- Adds a recent Transform history surface in the Transforms tab with copy, delete, and clear-all controls.
- Adds `macparakeet-cli transforms history list/show/delete/clear` for local inspection and iteration.
- Reactivates the original source app before clipboard fallback paste, so Alt-Tab during the LLM phase does not redirect the paste to a different app.
- Documents the new `transform_history` table and CLI contract.

## Flow
```text
selected text in source app
        |
Transform hotkey
        v
capture selection + source app
        |
        v
LLM Transform -> replace original selection
        |              |
        |              v
        |       AX write or source-app clipboard paste
        |
        v
transform_history (local SQLite)
        |
        +--> Transforms tab history
        +--> macparakeet-cli transforms history
```

## Notes
- History is local-only and saved by default.
- Rows are independent of prompt rows, so deleting a custom Transform does not delete past runs.
- Clipboard fallback now carries the captured source process and fails safely instead of pasting into the wrong app if that app cannot be reactivated.

## Testing
- `swift test --filter TransformHistoryRepositoryTests`
- `swift test --filter TransformsViewModelTests`
- `swift test --filter TransformsCommandTests`
- `swift test --filter SelectionCaptureServiceTests`
- `swift test --filter SelectionReplacementServiceTests`
- `swift test --filter TransformExecutorTests`
- `swift test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transform history: local run records (input/output, timing, source-app) with UI History section to view, copy, delete, and clear entries
  * Selection capture now records the frontmost-app target for captures

* **Behavior Changes**
  * Pasteback now attempts to reactivate the original capture target and surfaces a failure when activation fails

* **CLI**
  * New `transforms history` subcommands: `list`, `show`, `delete`, `clear` with JSON output support

* **Documentation**
  * Changelog and data-model docs updated for transform history

* **Tests**
  * Added coverage for history CLI, repository, view model, and selection/replace behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->