### PR TITLE
Polish Transform workbench UI

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -12,7 +12,9 @@ final class AppEnvironment {
     let chatConversationRepo: ChatConversationRepository
     let promptRepo: PromptRepository
     let promptResultRepo: PromptResultRepository
+    let transformProfileRepo: TransformProfileRepository
     let transformHistoryRepo: TransformHistoryRepository
+    let writingSampleRepo: WritingSampleRepository
     let quickPromptRepo: QuickPromptRepository
     let sttRuntime: STTRuntime
     let sttScheduler: STTScheduler
@@ -49,7 +51,9 @@ final class AppEnvironment {
         chatConversationRepo = ChatConversationRepository(dbQueue: databaseManager.dbQueue)
         promptRepo = PromptRepository(dbQueue: databaseManager.dbQueue)
         promptResultRepo = PromptResultRepository(dbQueue: databaseManager.dbQueue)
+        transformProfileRepo = TransformProfileRepository(dbQueue: databaseManager.dbQueue)
         transformHistoryRepo = TransformHistoryRepository(dbQueue: databaseManager.dbQueue)
+        writingSampleRepo = WritingSampleRepository(dbQueue: databaseManager.dbQueue)
         quickPromptRepo = QuickPromptRepository(dbQueue: databaseManager.dbQueue)
 
         // Services

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -130,8 +130,10 @@ final class AppEnvironmentConfigurer {
         promptsViewModel.configure(repo: env.promptRepo)
         transformsViewModel.configure(
             repo: env.promptRepo,
+            profileRepo: env.transformProfileRepo,
             historyRepo: env.transformHistoryRepo,
             clipboardService: env.clipboardService,
+            writingSampleRepo: env.writingSampleRepo,
             hasLLMProvider: hasLLMConfig
         )
         llmSettingsViewModel.configure(

--- a/Sources/MacParakeet/App/TransformsCoordinator.swift
+++ b/Sources/MacParakeet/App/TransformsCoordinator.swift
@@ -23,7 +23,9 @@ import OSLog
 final class TransformsCoordinator {
     private let llmServiceProvider: () -> LLMServiceProtocol?
     private let promptRepository: PromptRepositoryProtocol
+    private let profileRepository: TransformProfileRepositoryProtocol
     private let historyRepository: TransformHistoryRepositoryProtocol
+    private let writingSampleRepository: WritingSampleRepositoryProtocol
     private let logger = Logger(subsystem: "com.macparakeet", category: "TransformsCoordinator")
 
     private var registry: TransformsHotkeyRegistry?
@@ -47,11 +49,15 @@ final class TransformsCoordinator {
     init(
         llmServiceProvider: @escaping () -> LLMServiceProtocol?,
         promptRepository: PromptRepositoryProtocol,
-        historyRepository: TransformHistoryRepositoryProtocol
+        profileRepository: TransformProfileRepositoryProtocol,
+        historyRepository: TransformHistoryRepositoryProtocol,
+        writingSampleRepository: WritingSampleRepositoryProtocol
     ) {
         self.llmServiceProvider = llmServiceProvider
         self.promptRepository = promptRepository
+        self.profileRepository = profileRepository
         self.historyRepository = historyRepository
+        self.writingSampleRepository = writingSampleRepository
     }
 
     // MARK: - Lifecycle
@@ -185,7 +191,7 @@ final class TransformsCoordinator {
 
         panelController?.show(label: prompt.derivedRunningLabel)
 
-        let promptBody = prompt.content
+        let promptBody = assembledPrompt(for: prompt)
         let runningTransformName = prompt.name
 
         let telemetryName = TelemetryTransformName(
@@ -287,6 +293,21 @@ final class TransformsCoordinator {
             NotificationCenter.default.post(name: .transformHistoryChanged, object: nil)
         } catch {
             logger.error("transforms: failed to save local history: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func assembledPrompt(for prompt: Prompt) -> String {
+        do {
+            let profile = try profileRepository.fetch(promptId: prompt.id) ?? .defaultProfile(for: prompt)
+            let samples = profile.useWritingSamples ? try writingSampleRepository.fetchAll() : []
+            return TransformPromptAssembler.assemble(
+                prompt: prompt,
+                profile: profile,
+                writingSamples: samples
+            )
+        } catch {
+            logger.error("transforms: failed to assemble profile prompt, falling back to base prompt: \(error.localizedDescription, privacy: .public)")
+            return prompt.content
         }
     }
 }

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -420,7 +420,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let transforms = TransformsCoordinator(
             llmServiceProvider: llmServiceProvider,
             promptRepository: env.promptRepo,
-            historyRepository: env.transformHistoryRepo
+            profileRepository: env.transformProfileRepo,
+            historyRepository: env.transformHistoryRepo,
+            writingSampleRepository: env.writingSampleRepo
         )
         transforms.start()
         transformsCoordinator = transforms

--- a/Sources/MacParakeet/Hotkey/TransformsHotkeyRegistry+ViewModelAdapter.swift
+++ b/Sources/MacParakeet/Hotkey/TransformsHotkeyRegistry+ViewModelAdapter.swift
@@ -12,23 +12,20 @@ extension TransformsHotkeyCollisionChecker: TransformShortcutCollisionChecking {
         candidate: KeyboardShortcut,
         existing: [UUID: KeyboardShortcut],
         excludingPromptID: UUID?,
-        dictationHotkeys: [HotkeyTrigger],
-        meetingHotkey: HotkeyTrigger?
+        reservedHotkeys: [TransformShortcutReservedHotkey]
     ) -> TransformShortcutCollision? {
         let result: TransformsHotkeyCollision? = self.check(
             candidate: candidate,
             existing: existing,
             excludingPromptID: excludingPromptID,
-            dictationHotkeys: dictationHotkeys,
-            meetingHotkey: meetingHotkey
+            reservedHotkeys: reservedHotkeys
         )
         switch result {
         case nil: return nil
         case .missingModifier: return .missingModifier
         case .macOSDeadKey: return .macOSDeadKey
         case .duplicateTransform(let id): return .duplicateTransform(otherPromptID: id)
-        case .dictationHotkey: return .dictationHotkey
-        case .meetingHotkey: return .meetingHotkey
+        case .reservedHotkey(let name, let shortcut): return .reservedHotkey(name: name, shortcut: shortcut)
         }
     }
 }

--- a/Sources/MacParakeet/Hotkey/TransformsHotkeyRegistry.swift
+++ b/Sources/MacParakeet/Hotkey/TransformsHotkeyRegistry.swift
@@ -1,6 +1,7 @@
 import Cocoa
 import Foundation
 import MacParakeetCore
+import MacParakeetViewModels
 
 /// Single process-wide event tap that dispatches keyboard chords to bound
 /// Transforms. Owns one `CGEventTap` and a `[KeyMatch: Prompt.ID]` dispatch
@@ -213,10 +214,8 @@ public enum TransformsHotkeyCollision: Equatable, Sendable {
     case macOSDeadKey
     /// Another Transform already binds this combo.
     case duplicateTransform(otherPromptID: UUID)
-    /// The user's dictation hotkey conflicts with this combo.
-    case dictationHotkey
-    /// The user's meeting-toggle hotkey conflicts with this combo.
-    case meetingHotkey
+    /// Another app-level MacParakeet hotkey conflicts with this combo.
+    case reservedHotkey(name: String, shortcut: String)
 
     public var message: String {
         switch self {
@@ -226,10 +225,8 @@ public enum TransformsHotkeyCollision: Equatable, Sendable {
             return "This shortcut produces a special character on Mac (\u{2325} dead-key). Pick another combo."
         case .duplicateTransform:
             return "Another Transform already uses this shortcut."
-        case .dictationHotkey:
-            return "This shortcut conflicts with your dictation hotkey."
-        case .meetingHotkey:
-            return "This shortcut conflicts with your meeting recording hotkey."
+        case .reservedHotkey(let name, let shortcut):
+            return "This shortcut conflicts with \(name): \(shortcut)."
         }
     }
 }
@@ -248,8 +245,7 @@ public struct TransformsHotkeyCollisionChecker {
         candidate: KeyboardShortcut,
         existing: [UUID: KeyboardShortcut],
         excludingPromptID: UUID?,
-        dictationHotkeys: [HotkeyTrigger],
-        meetingHotkey: HotkeyTrigger?
+        reservedHotkeys: [TransformShortcutReservedHotkey]
     ) -> TransformsHotkeyCollision? {
         guard candidate.hasModifier else { return .missingModifier }
         if candidate.isMacOSDeadKey { return .macOSDeadKey }
@@ -262,11 +258,11 @@ public struct TransformsHotkeyCollisionChecker {
         }
 
         let candidateTrigger = candidate.hotkeyTrigger
-        for dictation in dictationHotkeys where candidateTrigger.overlaps(with: dictation) {
-            return .dictationHotkey
-        }
-        if let meeting = meetingHotkey, candidateTrigger.overlaps(with: meeting) {
-            return .meetingHotkey
+        for reserved in reservedHotkeys where candidateTrigger.overlaps(with: reserved.trigger) {
+            return .reservedHotkey(
+                name: reserved.name,
+                shortcut: reserved.trigger.formattedLabel
+            )
         }
         return nil
     }

--- a/Sources/MacParakeet/Views/MainWindowView.swift
+++ b/Sources/MacParakeet/Views/MainWindowView.swift
@@ -152,56 +152,12 @@ struct MainWindowView: View {
                         TransformsView(
                             viewModel: transformsViewModel,
                             llmConfiguredAction: { state.selectedItem = .settings },
-                            onEdit: { state.editingTransform = $0 },
-                            onCreate: { state.isCreatingTransform = true },
+                            reservedHotkeys: transformReservedHotkeys,
+                            onShortcutRecordingStateChanged: onHotkeyRecordingStateChanged,
                             onBindingsChanged: {
                                 NotificationCenter.default.post(name: .transformsBindingsChanged, object: nil)
                             }
                         )
-                        .sheet(isPresented: $state.isCreatingTransform) {
-                            TransformEditorSheet(
-                                viewModel: TransformEditorViewModel(mode: .create),
-                                existingTransforms: transformsViewModel.transforms,
-                                dictationHotkeys: [
-                                    settingsViewModel.hotkeyTrigger,
-                                    settingsViewModel.pushToTalkHotkeyTrigger,
-                                ],
-                                meetingHotkey: settingsViewModel.meetingHotkeyTrigger,
-                                onShortcutRecordingStateChanged: onHotkeyRecordingStateChanged,
-                                onSave: { prompt in
-                                    if transformsViewModel.save(prompt) {
-                                        state.isCreatingTransform = false
-                                        NotificationCenter.default.post(name: .transformsBindingsChanged, object: nil)
-                                    }
-                                },
-                                onCancel: { state.isCreatingTransform = false },
-                                onReset: nil
-                            )
-                        }
-                        .sheet(item: $state.editingTransform) { transform in
-                            TransformEditorSheet(
-                                viewModel: TransformEditorViewModel(mode: .edit(transform)),
-                                existingTransforms: transformsViewModel.transforms,
-                                dictationHotkeys: [
-                                    settingsViewModel.hotkeyTrigger,
-                                    settingsViewModel.pushToTalkHotkeyTrigger,
-                                ],
-                                meetingHotkey: settingsViewModel.meetingHotkeyTrigger,
-                                onShortcutRecordingStateChanged: onHotkeyRecordingStateChanged,
-                                onSave: { prompt in
-                                    if transformsViewModel.save(prompt) {
-                                        state.editingTransform = nil
-                                        NotificationCenter.default.post(name: .transformsBindingsChanged, object: nil)
-                                    }
-                                },
-                                onCancel: { state.editingTransform = nil },
-                                onReset: transform.isBuiltIn ? {
-                                    transformsViewModel.resetBuiltIn(transform)
-                                    state.editingTransform = nil
-                                    NotificationCenter.default.post(name: .transformsBindingsChanged, object: nil)
-                                } : nil
-                            )
-                        }
                     case .vocabulary:
                         VocabularyView(
                             settingsViewModel: settingsViewModel,
@@ -256,6 +212,14 @@ struct MainWindowView: View {
             screenRecordingGranted: settingsViewModel.screenRecordingGranted,
             sourceMode: settingsViewModel.meetingAudioSourceMode
         )
+    }
+
+    private var transformReservedHotkeys: [TransformShortcutReservedHotkey] {
+        [
+            TransformShortcutReservedHotkey(name: "Dictation", trigger: settingsViewModel.hotkeyTrigger),
+            TransformShortcutReservedHotkey(name: "Push-to-talk", trigger: settingsViewModel.pushToTalkHotkeyTrigger),
+            TransformShortcutReservedHotkey(name: "Meeting recording", trigger: settingsViewModel.meetingHotkeyTrigger),
+        ].filter { !$0.trigger.isDisabled }
     }
 
     private var globalTranscriptionBottomBar: some View {

--- a/Sources/MacParakeet/Views/Transforms/TransformEditorSheet.swift
+++ b/Sources/MacParakeet/Views/Transforms/TransformEditorSheet.swift
@@ -15,8 +15,7 @@ import MacParakeetViewModels
 struct TransformEditorSheet: View {
     @Bindable var viewModel: TransformEditorViewModel
     let existingTransforms: [Prompt]
-    let dictationHotkeys: [HotkeyTrigger]
-    let meetingHotkey: HotkeyTrigger?
+    let reservedHotkeys: [TransformShortcutReservedHotkey]
     let onShortcutRecordingStateChanged: (Bool) -> Void
     let onSave: (Prompt) -> Void
     let onCancel: () -> Void
@@ -206,8 +205,7 @@ struct TransformEditorSheet: View {
     private func revalidate() {
         viewModel.validate(
             existingTransforms: existingTransforms,
-            dictationHotkeys: dictationHotkeys,
-            meetingHotkey: meetingHotkey,
+            reservedHotkeys: reservedHotkeys,
             collisionChecker: collisionChecker
         )
     }

--- a/Sources/MacParakeet/Views/Transforms/TransformsView.swift
+++ b/Sources/MacParakeet/Views/Transforms/TransformsView.swift
@@ -2,47 +2,36 @@ import SwiftUI
 import MacParakeetCore
 import MacParakeetViewModels
 
-/// The **Transforms** tab — top-level sidebar destination (ADR-022).
-///
-/// Layout: hero strip → My Transforms grid (3-up cards + Create-your-own
-/// tile) → footer with reseed-missing affordance. Calmer no-provider
-/// banner replaces the hero when no LLM is configured.
-///
-/// Visual continuity: rounded display type (no serif — we use
-/// `.rounded` system font, not a literal serif copy of the reference
-/// screenshots), warm coral accent only on the keycap badges + primary
-/// CTAs, generous whitespace, hover lift on cards via the existing
-/// `cardRest`/`cardHover` shadow tokens.
+/// Native Transform Workbench: select a Transform, tune its shortcut/rules,
+/// attach writing samples, and review local run history in one persistent
+/// workspace.
 struct TransformsView: View {
     @Bindable var viewModel: TransformsViewModel
     let llmConfiguredAction: () -> Void
-    let onEdit: (Prompt) -> Void
-    let onCreate: () -> Void
+    let reservedHotkeys: [TransformShortcutReservedHotkey]
+    let onShortcutRecordingStateChanged: (Bool) -> Void
     let onBindingsChanged: () -> Void
 
+    @State private var isRecordingShortcut = false
+    @State private var showBuiltInPrompt = false
+    private let collisionChecker = TransformsHotkeyCollisionChecker()
+
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: DesignSystem.Spacing.xl) {
-                heroHeader
+        HStack(spacing: 0) {
+            sidebar
+                .frame(width: 292)
+                .background(DesignSystem.Colors.surface)
 
-                if viewModel.hasLLMProvider {
-                    heroExplainer
-                } else {
-                    noProviderBanner
-                }
+            Divider()
 
-                myTransformsHeader
-                transformGrid
-
-                historySection
-                footerActions
-            }
-            .padding(.horizontal, DesignSystem.Spacing.xl)
-            .padding(.vertical, DesignSystem.Spacing.lg)
-            .frame(maxWidth: .infinity, alignment: .leading)
+            detailPane
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(DesignSystem.Colors.background)
         }
-        .background(DesignSystem.Colors.background)
         .onAppear {
+            viewModel.load()
+            viewModel.loadProfiles()
+            viewModel.loadWritingSamples()
             Task {
                 await viewModel.loadHistory()
             }
@@ -59,7 +48,7 @@ struct TransformsView: View {
                 set: { if !$0 { viewModel.pendingDeleteTransform = nil } }
             ),
             presenting: viewModel.pendingDeleteTransform
-        ) { transform in
+        ) { _ in
             Button("Delete", role: .destructive) {
                 viewModel.confirmPendingDelete()
                 onBindingsChanged()
@@ -68,7 +57,7 @@ struct TransformsView: View {
                 viewModel.pendingDeleteTransform = nil
             }
         } message: { transform in
-            Text("“\(transform.name)” will be removed. You can re-create it later.")
+            Text("“\(transform.name)” will be removed. Its local history stays available.")
         }
         .alert(
             "Delete history item?",
@@ -89,6 +78,23 @@ struct TransformsView: View {
         } message: { entry in
             Text("The saved “\(entry.transformName)” input and output will be removed from local history.")
         }
+        .alert(
+            "Delete writing sample?",
+            isPresented: Binding(
+                get: { viewModel.pendingDeleteWritingSample != nil },
+                set: { if !$0 { viewModel.pendingDeleteWritingSample = nil } }
+            ),
+            presenting: viewModel.pendingDeleteWritingSample
+        ) { _ in
+            Button("Delete", role: .destructive) {
+                viewModel.confirmPendingWritingSampleDelete()
+            }
+            Button("Cancel", role: .cancel) {
+                viewModel.pendingDeleteWritingSample = nil
+            }
+        } message: { sample in
+            Text("“\(sample.title)” will no longer be used as a voice reference.")
+        }
         .alert("Clear Transform history?", isPresented: $viewModel.isConfirmingClearHistory) {
             Button("Clear History", role: .destructive) {
                 Task {
@@ -103,71 +109,71 @@ struct TransformsView: View {
         }
     }
 
-    // MARK: - Sections
-
-    @ViewBuilder
-    private var heroHeader: some View {
-        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
-            Text("Transforms")
-                .font(DesignSystem.Typography.heroTitle)
-                .foregroundStyle(DesignSystem.Colors.textPrimary)
-
-            Text("Press a hotkey on any selected text to rewrite it through your LLM provider — in Slack, Notes, Gmail, your editor, anywhere on Mac.")
-                .font(DesignSystem.Typography.bodyLarge)
-                .foregroundStyle(DesignSystem.Colors.textSecondary)
-                .frame(maxWidth: 640, alignment: .leading)
-        }
-        .padding(.top, DesignSystem.Spacing.md)
-    }
-
-    @ViewBuilder
-    private var heroExplainer: some View {
-        HStack(alignment: .top, spacing: DesignSystem.Spacing.lg) {
-            VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
-                Label("Highlight any text on your Mac.", systemImage: "1.circle.fill")
-                    .font(DesignSystem.Typography.body)
+    private var sidebar: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+                Text("Transforms")
+                    .font(DesignSystem.Typography.heroTitle)
                     .foregroundStyle(DesignSystem.Colors.textPrimary)
-                Label("Press a Transform's hotkey (⌥1, ⌥2, ⌥3, …).", systemImage: "2.circle.fill")
-                    .font(DesignSystem.Typography.body)
-                    .foregroundStyle(DesignSystem.Colors.textPrimary)
-                Label("The selection is rewritten in place. ⌘Z to undo.", systemImage: "3.circle.fill")
-                    .font(DesignSystem.Typography.body)
-                    .foregroundStyle(DesignSystem.Colors.textPrimary)
-            }
-            .padding(.vertical, DesignSystem.Spacing.lg)
-            .padding(.horizontal, DesignSystem.Spacing.lg)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(DesignSystem.Colors.surfaceElevated)
-            .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius))
-            .overlay {
-                RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
-                    .stroke(DesignSystem.Colors.border, lineWidth: 0.5)
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var noProviderBanner: some View {
-        HStack(alignment: .center, spacing: DesignSystem.Spacing.md) {
-            Image(systemName: "wand.and.stars")
-                .font(.system(size: 18, weight: .semibold))
-                .foregroundStyle(DesignSystem.Colors.accent)
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Add an LLM provider to apply Transforms")
-                    .font(DesignSystem.Typography.body.weight(.semibold))
-                    .foregroundStyle(DesignSystem.Colors.textPrimary)
-                Text("Transforms call your LLM provider on each run. Use Claude, GPT, Ollama, LM Studio — your key, your terms.")
+                Text("Rewrite selected text anywhere on your Mac with a hotkey.")
                     .font(DesignSystem.Typography.bodySmall)
                     .foregroundStyle(DesignSystem.Colors.textSecondary)
             }
+            .padding(.top, DesignSystem.Spacing.lg)
 
-            Spacer(minLength: DesignSystem.Spacing.md)
+            if !viewModel.hasLLMProvider {
+                noProviderBanner
+            }
 
+            ScrollView {
+                VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+                    transformGroup(title: "Built in", transforms: viewModel.builtInTransforms)
+                    if !viewModel.customTransforms.isEmpty {
+                        transformGroup(title: "Custom", transforms: viewModel.customTransforms)
+                    }
+
+                    Button {
+                        showBuiltInPrompt = true
+                        viewModel.startCreatingTransform()
+                    } label: {
+                        Label("Create Transform", systemImage: "plus")
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .parakeetAction(.primary)
+                    .padding(.top, DesignSystem.Spacing.sm)
+                }
+                .padding(.bottom, DesignSystem.Spacing.lg)
+            }
+
+            Spacer(minLength: 0)
+
+            Button {
+                viewModel.reseedMissingBuiltIns()
+                onBindingsChanged()
+            } label: {
+                Label("Restore defaults", systemImage: "arrow.counterclockwise")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .parakeetAction(.subtle)
+            .controlSize(.small)
+        }
+        .padding(.horizontal, DesignSystem.Spacing.lg)
+        .padding(.bottom, DesignSystem.Spacing.lg)
+    }
+
+    private var noProviderBanner: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            Label("LLM provider needed", systemImage: "wand.and.stars")
+                .font(DesignSystem.Typography.caption.weight(.semibold))
+                .foregroundStyle(DesignSystem.Colors.textPrimary)
+            Text("Transforms call your configured provider when you press a shortcut.")
+                .font(DesignSystem.Typography.caption)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
             Button("Open Settings", action: llmConfiguredAction)
                 .parakeetAction(.primary)
+                .controlSize(.small)
         }
-        .padding(DesignSystem.Spacing.lg)
+        .padding(DesignSystem.Spacing.md)
         .background(DesignSystem.Colors.accentLight)
         .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius))
         .overlay {
@@ -177,144 +183,429 @@ struct TransformsView: View {
     }
 
     @ViewBuilder
-    private var myTransformsHeader: some View {
-        HStack(alignment: .firstTextBaseline) {
-            Text("My Transforms")
-                .font(DesignSystem.Typography.pageTitle)
-                .foregroundStyle(DesignSystem.Colors.textPrimary)
-            Spacer()
-            Button(action: onCreate) {
-                Label("Create New", systemImage: "plus")
-            }
-            .parakeetAction(.primary)
-        }
-    }
-
-    @ViewBuilder
-    private var transformGrid: some View {
-        let columns = [
-            GridItem(.adaptive(minimum: 260, maximum: 360), spacing: DesignSystem.Spacing.md, alignment: .top)
-        ]
-        LazyVGrid(columns: columns, alignment: .leading, spacing: DesignSystem.Spacing.md) {
-            ForEach(viewModel.transforms) { transform in
-                TransformCard(
-                    transform: transform,
-                    onEdit: { onEdit(transform) },
-                    onDelete: {
-                        viewModel.pendingDeleteTransform = transform
-                    },
-                    onReset: {
-                        viewModel.resetBuiltIn(transform)
-                        onBindingsChanged()
-                    }
-                )
-            }
-
-            CreateYourOwnTile(action: onCreate)
-        }
-    }
-
-    @ViewBuilder
-    private var historySection: some View {
-        VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
-            HStack(alignment: .firstTextBaseline) {
-                Text("History")
-                    .font(DesignSystem.Typography.pageTitle)
-                    .foregroundStyle(DesignSystem.Colors.textPrimary)
-                if !viewModel.history.isEmpty {
-                    Text("\(viewModel.totalHistoryCount)")
-                        .font(DesignSystem.Typography.duration)
-                        .foregroundStyle(DesignSystem.Colors.textSecondary)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(Capsule().fill(DesignSystem.Colors.surfaceElevated))
+    private func transformGroup(title: String, transforms: [Prompt]) -> some View {
+        if !transforms.isEmpty {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
+                Text(title.uppercased())
+                    .font(DesignSystem.Typography.micro)
+                    .foregroundStyle(DesignSystem.Colors.textTertiary)
+                    .padding(.horizontal, 2)
+                ForEach(transforms) { transform in
+                    TransformListRow(
+                        transform: transform,
+                        isSelected: viewModel.selectedTransformID == transform.id && !viewModel.isCreatingDraft,
+                        historyCount: viewModel.history.filter { $0.transformId == transform.id }.count,
+                        action: {
+                            showBuiltInPrompt = false
+                            viewModel.selectTransform(transform)
+                        }
+                    )
                 }
-                Spacer()
-                if !viewModel.history.isEmpty {
-                    Button(role: .destructive) {
-                        viewModel.isConfirmingClearHistory = true
+            }
+        }
+    }
+
+    private var detailPane: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.xl) {
+                headerSection
+
+                if let error = viewModel.errorMessage {
+                    ErrorBanner(message: error)
+                }
+
+                shortcutSection
+                rulesSection
+                writingSamplesSection
+                promptSection
+                historySection
+            }
+            .padding(DesignSystem.Spacing.xl)
+            .frame(maxWidth: 980, alignment: .leading)
+        }
+    }
+
+    private var headerSection: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+            HStack(alignment: .top, spacing: DesignSystem.Spacing.lg) {
+                VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+                    TextField("Name this Transform", text: $viewModel.draftName)
+                        .textFieldStyle(.plain)
+                        .font(DesignSystem.Typography.heroTitle)
+                        .foregroundStyle(DesignSystem.Colors.textPrimary)
+                        .onChange(of: viewModel.draftName) { _, _ in revalidate() }
+
+                    Text(viewModel.selectedTransform?.transformPurpose ?? "Create a reusable text rewrite and bind it to a shortcut.")
+                        .font(DesignSystem.Typography.body)
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+                        .frame(maxWidth: 560, alignment: .leading)
+
+                    if let error = viewModel.nameError {
+                        InlineValidation(message: error)
+                    }
+                }
+
+                Spacer(minLength: DesignSystem.Spacing.lg)
+
+                VStack(alignment: .trailing, spacing: DesignSystem.Spacing.sm) {
+                    HStack(spacing: DesignSystem.Spacing.sm) {
+                        if viewModel.isCreatingDraft {
+                            Button("Cancel") {
+                                viewModel.cancelCreate()
+                            }
+                            .parakeetAction(.secondary)
+                        } else if let selected = viewModel.selectedTransform {
+                            if selected.isBuiltIn {
+                                Button {
+                                    viewModel.resetBuiltIn(selected)
+                                    onBindingsChanged()
+                                } label: {
+                                    Label("Reset", systemImage: "arrow.counterclockwise")
+                                }
+                                .parakeetAction(.subtle)
+                            } else {
+                                Button(role: .destructive) {
+                                    viewModel.pendingDeleteTransform = selected
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                                .parakeetAction(.destructive)
+                            }
+                        }
+
+                        Button(viewModel.isCreatingDraft ? "Create" : "Save") {
+                            if viewModel.saveDraft(
+                                reservedHotkeys: activeReservedHotkeys,
+                                collisionChecker: collisionChecker
+                            ) {
+                                onBindingsChanged()
+                            }
+                        }
+                        .parakeetAction(.primaryProminent)
+                        .disabled(!canSaveDraft)
+                    }
+
+                    Text(viewModel.isCreatingDraft ? "Not saved yet" : "Saved locally")
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(DesignSystem.Colors.textTertiary)
+                }
+            }
+        }
+        .padding(.bottom, DesignSystem.Spacing.sm)
+    }
+
+    private var shortcutSection: some View {
+        WorkbenchSection(title: "Keyboard shortcut", subtitle: "Press this after selecting text in any app.") {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+                ShortcutRecorderField(
+                    shortcut: $viewModel.draftShortcut,
+                    isRecording: $isRecordingShortcut,
+                    onRecordingStateChanged: onShortcutRecordingStateChanged
+                )
+                .onChange(of: viewModel.draftShortcut) { _, _ in revalidate() }
+
+                if let error = viewModel.shortcutError {
+                    InlineValidation(message: error)
+                } else if viewModel.draftShortcut == nil {
+                    Text("Leave empty to keep this Transform dormant.")
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(DesignSystem.Colors.textTertiary)
+                }
+            }
+        }
+    }
+
+    private var rulesSection: some View {
+        WorkbenchSection(title: "Rules", subtitle: "Shape the behavior without editing the full prompt.") {
+            VStack(spacing: 0) {
+                ForEach(viewModel.activeRules) { rule in
+                    RuleToggleRow(
+                        rule: rule,
+                        isOn: Binding(
+                            get: { viewModel.draftEnabledRuleIDs.contains(rule.id) },
+                            set: { enabled in
+                                if enabled {
+                                    viewModel.draftEnabledRuleIDs.insert(rule.id)
+                                } else {
+                                    viewModel.draftEnabledRuleIDs.remove(rule.id)
+                                }
+                            }
+                        )
+                    )
+                    if rule.id != viewModel.activeRules.last?.id {
+                        Divider()
+                    }
+                }
+            }
+        }
+    }
+
+    private var writingSamplesSection: some View {
+        WorkbenchSection(title: "Writing samples", subtitle: "Optional local examples for matching your voice.") {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+                Toggle(isOn: $viewModel.draftUseWritingSamples) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Match my writing style")
+                            .font(DesignSystem.Typography.body.weight(.semibold))
+                            .foregroundStyle(DesignSystem.Colors.textPrimary)
+                        Text("When enabled, samples are included only in Transform prompts sent to your configured LLM provider.")
+                            .font(DesignSystem.Typography.caption)
+                            .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    }
+                }
+                .toggleStyle(.switch)
+
+                if viewModel.writingSamples.isEmpty {
+                    WritingSamplesEmptyState {
+                        viewModel.isAddingWritingSample = true
+                    }
+                } else {
+                    VStack(spacing: DesignSystem.Spacing.sm) {
+                        ForEach(viewModel.writingSamples) { sample in
+                            WritingSampleRow(sample: sample) {
+                                viewModel.pendingDeleteWritingSample = sample
+                            }
+                        }
+                    }
+
+                    Button {
+                        viewModel.isAddingWritingSample = true
                     } label: {
-                        Label("Clear", systemImage: "trash")
+                        Label("Add Sample", systemImage: "plus")
                     }
                     .parakeetAction(.subtle)
                     .controlSize(.small)
                 }
-            }
 
-            if let historyError = viewModel.historyErrorMessage {
-                HStack(spacing: DesignSystem.Spacing.sm) {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .font(.system(size: 12, weight: .semibold))
-                        .foregroundStyle(DesignSystem.Colors.warningAmber)
-                    Text(historyError)
+                if viewModel.isAddingWritingSample {
+                    WritingSampleEditor(viewModel: viewModel)
+                }
+
+                if let error = viewModel.writingSampleErrorMessage {
+                    InlineValidation(message: error)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var promptSection: some View {
+        if viewModel.isCreatingDraft || viewModel.selectedTransform?.isBuiltIn == false {
+            promptEditorSection(title: "Instructions", subtitle: "Describe exactly how this Transform should rewrite selected text.")
+        } else {
+            DisclosureGroup(isExpanded: $showBuiltInPrompt) {
+                promptEditorBody
+                    .padding(.top, DesignSystem.Spacing.md)
+            } label: {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Advanced prompt")
+                        .font(DesignSystem.Typography.sectionTitle)
+                        .foregroundStyle(DesignSystem.Colors.textPrimary)
+                    Text("The built-in prompt remains editable, but most tuning belongs in rules above.")
                         .font(DesignSystem.Typography.caption)
                         .foregroundStyle(DesignSystem.Colors.textSecondary)
-                    Spacer()
                 }
-                .padding(DesignSystem.Spacing.md)
-                .background(DesignSystem.Colors.surfaceElevated)
-                .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius))
-            } else if viewModel.history.isEmpty {
-                TransformHistoryEmptyState()
-            } else {
-                LazyVStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
-                    ForEach(viewModel.history) { entry in
-                        TransformHistoryRow(
-                            entry: entry,
-                            isCopied: viewModel.copiedHistoryEntryID == entry.id,
-                            onCopy: {
-                                Task {
-                                    await viewModel.copyOutputToClipboard(entry)
-                                }
-                            },
-                            onDelete: { viewModel.pendingDeleteHistoryEntry = entry }
-                        )
+            }
+            .padding(DesignSystem.Spacing.lg)
+            .background(DesignSystem.Colors.surfaceElevated.opacity(0.55))
+            .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius))
+            .overlay {
+                RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
+                    .stroke(DesignSystem.Colors.border.opacity(0.6), lineWidth: 0.5)
+            }
+        }
+    }
+
+    private func promptEditorSection(title: String, subtitle: String) -> some View {
+        WorkbenchSection(title: title, subtitle: subtitle) {
+            promptEditorBody
+        }
+    }
+
+    private var promptEditorBody: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            TextEditor(text: $viewModel.draftContent)
+                .font(DesignSystem.Typography.body)
+                .scrollContentBackground(.hidden)
+                .padding(DesignSystem.Spacing.sm)
+                .frame(minHeight: 168)
+                .background(DesignSystem.Colors.surface)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(DesignSystem.Colors.border, lineWidth: 0.5)
+                }
+                .onChange(of: viewModel.draftContent) { _, _ in revalidate() }
+
+            TextEditor(text: $viewModel.draftCustomInstructions)
+                .font(DesignSystem.Typography.body)
+                .scrollContentBackground(.hidden)
+                .padding(DesignSystem.Spacing.sm)
+                .frame(minHeight: 86)
+                .background(DesignSystem.Colors.surface)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .overlay(alignment: .topLeading) {
+                    if viewModel.draftCustomInstructions.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        Text("Optional extra instructions")
+                            .font(DesignSystem.Typography.body)
+                            .foregroundStyle(DesignSystem.Colors.textTertiary)
+                            .padding(.horizontal, DesignSystem.Spacing.md + 1)
+                            .padding(.vertical, DesignSystem.Spacing.md)
+                            .allowsHitTesting(false)
+                    }
+                }
+                .overlay {
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(DesignSystem.Colors.border, lineWidth: 0.5)
+                }
+
+            if let error = viewModel.contentError {
+                InlineValidation(message: error)
+            }
+        }
+    }
+
+    private var historySection: some View {
+        WorkbenchSection(
+            title: "Recent runs",
+            subtitle: viewModel.selectedTransform == nil ? "Create the Transform to start saving local runs." : "Local input and output history for this Transform."
+        ) {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+                if let historyError = viewModel.historyErrorMessage {
+                    ErrorBanner(message: historyError)
+                } else if viewModel.selectedHistory.isEmpty {
+                    TransformHistoryEmptyState()
+                } else {
+                    HStack {
+                        Text("\(viewModel.selectedHistory.count) saved")
+                            .font(DesignSystem.Typography.caption)
+                            .foregroundStyle(DesignSystem.Colors.textSecondary)
+                        Spacer()
+                        Button(role: .destructive) {
+                            viewModel.isConfirmingClearHistory = true
+                        } label: {
+                            Label("Clear All", systemImage: "trash")
+                        }
+                        .parakeetAction(.subtle)
+                        .controlSize(.small)
+                    }
+
+                    LazyVStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+                        ForEach(viewModel.selectedHistory.prefix(8)) { entry in
+                            TransformHistoryRow(
+                                entry: entry,
+                                isCopied: viewModel.copiedHistoryEntryID == entry.id,
+                                onCopy: {
+                                    Task {
+                                        await viewModel.copyOutputToClipboard(entry)
+                                    }
+                                },
+                                onDelete: { viewModel.pendingDeleteHistoryEntry = entry }
+                            )
+                        }
                     }
                 }
             }
         }
-        .padding(.top, DesignSystem.Spacing.lg)
     }
 
-    @ViewBuilder
-    private var footerActions: some View {
-        HStack(spacing: DesignSystem.Spacing.md) {
-            Button(action: {
-                viewModel.reseedMissingBuiltIns()
-                onBindingsChanged()
-            }) {
-                Label("Restore missing defaults", systemImage: "arrow.counterclockwise")
-            }
-            .parakeetAction(.subtle)
-            Spacer()
-        }
-        .padding(.top, DesignSystem.Spacing.md)
+    private var activeReservedHotkeys: [TransformShortcutReservedHotkey] {
+        reservedHotkeys.filter { !$0.trigger.isDisabled }
+    }
+
+    private var canSaveDraft: Bool {
+        viewModel.normalizedDraftName.isEmpty == false
+            && viewModel.draftContent.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+            && viewModel.nameError == nil
+            && viewModel.contentError == nil
+            && viewModel.shortcutError == nil
+    }
+
+    private func revalidate() {
+        viewModel.validateDraft(
+            reservedHotkeys: activeReservedHotkeys,
+            collisionChecker: collisionChecker
+        )
     }
 }
 
-// MARK: - Transform history
+private struct TransformListRow: View {
+    let transform: Prompt
+    let isSelected: Bool
+    let historyCount: Int
+    let action: () -> Void
 
-private struct TransformHistoryEmptyState: View {
     var body: some View {
-        HStack(spacing: DesignSystem.Spacing.md) {
-            Image(systemName: "clock.arrow.circlepath")
-                .font(.system(size: 18, weight: .semibold))
-                .foregroundStyle(DesignSystem.Colors.textTertiary)
-                .frame(width: 34, height: 34)
-                .background(Circle().fill(DesignSystem.Colors.surfaceElevated))
+        Button(action: action) {
+            HStack(spacing: DesignSystem.Spacing.sm) {
+                VStack(alignment: .leading, spacing: 5) {
+                    HStack(spacing: DesignSystem.Spacing.xs) {
+                        Text(transform.name)
+                            .font(DesignSystem.Typography.body.weight(.semibold))
+                            .foregroundStyle(DesignSystem.Colors.textPrimary)
+                            .lineLimit(1)
+                        if transform.isBuiltIn {
+                            Text("Built in")
+                                .font(DesignSystem.Typography.micro)
+                                .foregroundStyle(DesignSystem.Colors.textTertiary)
+                                .padding(.horizontal, 5)
+                                .padding(.vertical, 2)
+                                .background(Capsule().fill(DesignSystem.Colors.surfaceElevated))
+                        }
+                    }
 
+                    HStack(spacing: DesignSystem.Spacing.xs) {
+                        if let shortcut = transform.shortcut {
+                            KeycapBadge(shortcut: shortcut)
+                        } else {
+                            Text("No shortcut")
+                                .font(DesignSystem.Typography.caption)
+                                .foregroundStyle(DesignSystem.Colors.textTertiary)
+                        }
+                        if historyCount > 0 {
+                            Text("\(historyCount)")
+                                .font(DesignSystem.Typography.micro)
+                                .foregroundStyle(DesignSystem.Colors.textSecondary)
+                                .padding(.horizontal, 5)
+                                .padding(.vertical, 2)
+                                .background(Capsule().fill(DesignSystem.Colors.surfaceElevated.opacity(0.7)))
+                        }
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, DesignSystem.Spacing.md)
+            .padding(.vertical, DesignSystem.Spacing.sm)
+            .background(isSelected ? DesignSystem.Colors.accentLight : Color.clear)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .overlay {
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(isSelected ? DesignSystem.Colors.accent.opacity(0.35) : Color.clear, lineWidth: 0.5)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private struct WorkbenchSection<Content: View>: View {
+    let title: String
+    let subtitle: String
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
             VStack(alignment: .leading, spacing: 3) {
-                Text("No saved Transform runs yet")
-                    .font(DesignSystem.Typography.body.weight(.semibold))
+                Text(title)
+                    .font(DesignSystem.Typography.sectionTitle)
                     .foregroundStyle(DesignSystem.Colors.textPrimary)
-                Text("Completed edits will appear here.")
-                    .font(DesignSystem.Typography.bodySmall)
+                Text(subtitle)
+                    .font(DesignSystem.Typography.caption)
                     .foregroundStyle(DesignSystem.Colors.textSecondary)
             }
-            Spacer()
+            content
         }
         .padding(DesignSystem.Spacing.lg)
-        .background(DesignSystem.Colors.cardBackground)
+        .background(DesignSystem.Colors.surfaceElevated.opacity(0.55))
         .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius))
         .overlay {
             RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
@@ -323,264 +614,272 @@ private struct TransformHistoryEmptyState: View {
     }
 }
 
-private struct TransformHistoryRow: View {
-    private static let todayTimeFormat = Date.FormatStyle(date: .omitted, time: .shortened)
-    private static let dateTimeFormat = Date.FormatStyle(date: .numeric, time: .shortened)
+private struct RuleToggleRow: View {
+    let rule: TransformRule
+    @Binding var isOn: Bool
 
+    var body: some View {
+        Toggle(isOn: $isOn) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(rule.title)
+                    .font(DesignSystem.Typography.body)
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+                Text(rule.detail)
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+            }
+        }
+        .toggleStyle(.switch)
+        .padding(.vertical, DesignSystem.Spacing.md)
+    }
+}
+
+private struct WritingSamplesEmptyState: View {
+    let action: () -> Void
+
+    var body: some View {
+        HStack(spacing: DesignSystem.Spacing.md) {
+            Image(systemName: "quote.bubble")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(DesignSystem.Colors.textTertiary)
+                .frame(width: 34, height: 34)
+                .background(Circle().fill(DesignSystem.Colors.surface))
+            VStack(alignment: .leading, spacing: 3) {
+                Text("No writing samples yet")
+                    .font(DesignSystem.Typography.body.weight(.semibold))
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+                Text("Add one sample of 50+ words to unlock voice matching.")
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+            }
+            Spacer()
+            Button("Add Sample", action: action)
+                .parakeetAction(.primary)
+                .controlSize(.small)
+        }
+        .padding(DesignSystem.Spacing.md)
+        .background(DesignSystem.Colors.surface)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+private struct WritingSampleRow: View {
+    let sample: WritingSample
+    let onDelete: () -> Void
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: DesignSystem.Spacing.md) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(sample.title)
+                    .font(DesignSystem.Typography.body.weight(.semibold))
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+                    .lineLimit(1)
+                Text("\(sample.wordCount) words")
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+            }
+            Spacer()
+            Button(role: .destructive, action: onDelete) {
+                Image(systemName: "trash")
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(DesignSystem.Colors.textSecondary)
+            .help("Delete writing sample")
+        }
+        .padding(DesignSystem.Spacing.md)
+        .background(DesignSystem.Colors.surface)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+private struct WritingSampleEditor: View {
+    @Bindable var viewModel: TransformsViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            TextField("Sample title", text: $viewModel.writingSampleTitle)
+                .textFieldStyle(.plain)
+                .font(DesignSystem.Typography.body)
+                .padding(.horizontal, DesignSystem.Spacing.md)
+                .padding(.vertical, DesignSystem.Spacing.sm)
+                .background(DesignSystem.Colors.surface)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(DesignSystem.Colors.border, lineWidth: 0.5)
+                }
+
+            TextEditor(text: $viewModel.writingSampleText)
+                .font(DesignSystem.Typography.body)
+                .scrollContentBackground(.hidden)
+                .padding(DesignSystem.Spacing.sm)
+                .frame(minHeight: 150)
+                .background(DesignSystem.Colors.surface)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .overlay(alignment: .topLeading) {
+                    if viewModel.writingSampleText.isEmpty {
+                        Text("Paste a real email, message, document excerpt, or note that sounds like you.")
+                            .font(DesignSystem.Typography.body)
+                            .foregroundStyle(DesignSystem.Colors.textTertiary)
+                            .padding(.horizontal, DesignSystem.Spacing.md + 1)
+                            .padding(.vertical, DesignSystem.Spacing.md)
+                            .allowsHitTesting(false)
+                    }
+                }
+                .overlay {
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(DesignSystem.Colors.border, lineWidth: 0.5)
+                }
+
+            HStack {
+                Text("\(WritingSample.countWords(in: viewModel.writingSampleText)) words")
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+                Spacer()
+                Button("Cancel") {
+                    viewModel.isAddingWritingSample = false
+                    viewModel.writingSampleTitle = ""
+                    viewModel.writingSampleText = ""
+                    viewModel.writingSampleErrorMessage = nil
+                }
+                .parakeetAction(.secondary)
+                Button("Save Sample") {
+                    _ = viewModel.saveWritingSample()
+                }
+                .parakeetAction(.primary)
+            }
+        }
+        .padding(DesignSystem.Spacing.md)
+        .background(DesignSystem.Colors.surface.opacity(0.7))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+private struct TransformHistoryEmptyState: View {
+    var body: some View {
+        HStack(spacing: DesignSystem.Spacing.md) {
+            Image(systemName: "clock.arrow.circlepath")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(DesignSystem.Colors.textTertiary)
+                .frame(width: 34, height: 34)
+                .background(Circle().fill(DesignSystem.Colors.surface))
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text("No saved runs yet")
+                    .font(DesignSystem.Typography.body.weight(.semibold))
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+                Text("Completed edits for this Transform will appear here.")
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+            }
+            Spacer()
+        }
+        .padding(DesignSystem.Spacing.md)
+        .background(DesignSystem.Colors.surface)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+private struct TransformHistoryRow: View {
     let entry: TransformHistoryEntry
     let isCopied: Bool
     let onCopy: () -> Void
     let onDelete: () -> Void
 
-    @State private var isHovered = false
-
     var body: some View {
         VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
-            HStack(alignment: .center, spacing: DesignSystem.Spacing.sm) {
-                Image(systemName: "wand.and.stars")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(DesignSystem.Colors.accent)
-                    .frame(width: 26, height: 26)
-                    .background(Circle().fill(DesignSystem.Colors.accentLight))
-
-                Text(entry.transformName)
+            HStack(spacing: DesignSystem.Spacing.sm) {
+                Text(entry.sourceAppDisplayName)
                     .font(DesignSystem.Typography.caption.weight(.semibold))
                     .foregroundStyle(DesignSystem.Colors.textPrimary)
-
-                Text("·")
-                    .font(DesignSystem.Typography.caption)
-                    .foregroundStyle(DesignSystem.Colors.textTertiary)
-
-                Text(entry.sourceAppDisplayName)
-                    .font(DesignSystem.Typography.caption)
-                    .foregroundStyle(DesignSystem.Colors.textSecondary)
                     .lineLimit(1)
-
-                Text("·")
-                    .font(DesignSystem.Typography.caption)
-                    .foregroundStyle(DesignSystem.Colors.textTertiary)
-
                 Text(formatTime(entry.createdAt))
                     .font(DesignSystem.Typography.timestamp)
                     .foregroundStyle(DesignSystem.Colors.textSecondary)
-
-                Spacer(minLength: DesignSystem.Spacing.sm)
-
+                Spacer()
                 if isCopied {
                     Text("Copied")
                         .font(DesignSystem.Typography.micro)
                         .foregroundStyle(DesignSystem.Colors.successGreen)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 3)
-                        .background(Capsule().fill(DesignSystem.Colors.successGreen.opacity(0.12)))
-                        .transition(.opacity.combined(with: .scale(scale: 0.96)))
                 }
+                Button(action: onCopy) {
+                    Image(systemName: isCopied ? "checkmark" : "doc.on.clipboard")
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+                .help("Copy transformed text")
 
-                TransformHistoryIconButton(
-                    systemImage: isCopied ? "checkmark" : "doc.on.clipboard",
-                    color: isCopied ? DesignSystem.Colors.successGreen : DesignSystem.Colors.textSecondary,
-                    help: "Copy transformed text",
-                    action: onCopy
-                )
-                TransformHistoryIconButton(
-                    systemImage: "trash",
-                    color: DesignSystem.Colors.textSecondary,
-                    help: "Delete history item",
-                    action: onDelete
-                )
+                Button(role: .destructive, action: onDelete) {
+                    Image(systemName: "trash")
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+                .help("Delete history item")
             }
 
-            VStack(alignment: .leading, spacing: 6) {
-                Text(entry.outputText)
-                    .font(DesignSystem.Typography.body)
-                    .foregroundStyle(DesignSystem.Colors.textPrimary)
-                    .lineLimit(3)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+            Text(entry.outputText)
+                .font(DesignSystem.Typography.body)
+                .foregroundStyle(DesignSystem.Colors.textPrimary)
+                .lineLimit(3)
+                .frame(maxWidth: .infinity, alignment: .leading)
 
-                Text(entry.inputText)
-                    .font(DesignSystem.Typography.bodySmall)
-                    .foregroundStyle(DesignSystem.Colors.textSecondary)
-                    .lineLimit(2)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.leading, DesignSystem.Spacing.md)
-                    .overlay(alignment: .leading) {
-                        Rectangle()
-                            .fill(DesignSystem.Colors.border)
-                            .frame(width: 2)
-                    }
-            }
+            Text(entry.inputText)
+                .font(DesignSystem.Typography.caption)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+                .lineLimit(2)
+                .padding(.leading, DesignSystem.Spacing.md)
+                .overlay(alignment: .leading) {
+                    Rectangle()
+                        .fill(DesignSystem.Colors.border)
+                        .frame(width: 2)
+                }
         }
         .padding(DesignSystem.Spacing.md)
-        .background(
-            RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
-                .fill(isHovered ? DesignSystem.Colors.surfaceElevated.opacity(0.7) : DesignSystem.Colors.cardBackground)
-                .cardShadow(isHovered ? DesignSystem.Shadows.cardHover : DesignSystem.Shadows.cardRest)
-        )
-        .overlay {
-            RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
-                .stroke(isHovered ? DesignSystem.Colors.accent.opacity(0.25) : DesignSystem.Colors.border.opacity(0.55), lineWidth: 0.5)
-        }
-        .onHover { hovering in
-            withAnimation(DesignSystem.Animation.hoverTransition) {
-                isHovered = hovering
-            }
-        }
-        .animation(DesignSystem.Animation.hoverTransition, value: isCopied)
+        .background(DesignSystem.Colors.surface)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
     }
 
     private func formatTime(_ date: Date) -> String {
-        date.formatted(Calendar.current.isDateInToday(date) ? Self.todayTimeFormat : Self.dateTimeFormat)
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        formatter.dateStyle = Calendar.current.isDateInToday(date) ? .none : .short
+        return formatter.string(from: date)
     }
 }
 
-private struct TransformHistoryIconButton: View {
-    let systemImage: String
-    let color: Color
-    let help: String
-    let action: () -> Void
-
-    @State private var isHovered = false
+private struct InlineValidation: View {
+    let message: String
 
     var body: some View {
-        Button(action: action) {
-            Image(systemName: systemImage)
-                .font(.system(size: 12, weight: .medium))
-                .frame(width: 28, height: 28)
-                .background(
-                    RoundedRectangle(cornerRadius: 6)
-                        .fill(isHovered ? Color.primary.opacity(0.08) : .clear)
-                )
-                .contentShape(Rectangle())
+        HStack(spacing: 6) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 11))
+                .foregroundStyle(DesignSystem.Colors.warningAmber)
+            Text(message)
+                .font(DesignSystem.Typography.caption)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
         }
-        .parakeetAction(.subtle)
-        .foregroundStyle(isHovered ? DesignSystem.Colors.textPrimary : color)
-        .help(help)
-        .onHover { isHovered = $0 }
     }
 }
 
-// MARK: - Transform card
-
-private struct TransformCard: View {
-    let transform: Prompt
-    let onEdit: () -> Void
-    let onDelete: () -> Void
-    let onReset: () -> Void
-
-    @State private var isHovered = false
+private struct ErrorBanner: View {
+    let message: String
 
     var body: some View {
-        Button(action: onEdit) {
-            VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
-                HStack(alignment: .center, spacing: DesignSystem.Spacing.sm) {
-                    if let shortcut = transform.shortcut {
-                        KeycapBadge(shortcut: shortcut)
-                    } else {
-                        UnboundShortcutChip()
-                    }
-                    Spacer()
-                    if isHovered {
-                        cardActions
-                    }
-                }
-
-                VStack(alignment: .leading, spacing: 6) {
-                    Text(transform.name)
-                        .font(DesignSystem.Typography.sectionTitle)
-                        .foregroundStyle(DesignSystem.Colors.textPrimary)
-                        .lineLimit(1)
-                    Text(firstSentence(of: transform.content))
-                        .font(DesignSystem.Typography.bodySmall)
-                        .foregroundStyle(DesignSystem.Colors.textSecondary)
-                        .lineLimit(3, reservesSpace: true)
-                        .multilineTextAlignment(.leading)
-                }
-            }
-            .padding(DesignSystem.Spacing.lg)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(DesignSystem.Colors.cardBackground)
-            .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius))
-            .overlay {
-                RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
-                    .stroke(isHovered ? DesignSystem.Colors.accent.opacity(0.35) : DesignSystem.Colors.border, lineWidth: 0.5)
-            }
-            .shadow(
-                color: (isHovered ? DesignSystem.Shadows.cardHover : DesignSystem.Shadows.cardRest).color,
-                radius: (isHovered ? DesignSystem.Shadows.cardHover : DesignSystem.Shadows.cardRest).radius,
-                y: (isHovered ? DesignSystem.Shadows.cardHover : DesignSystem.Shadows.cardRest).y
-            )
-            .animation(DesignSystem.Animation.hoverTransition, value: isHovered)
+        HStack(spacing: DesignSystem.Spacing.sm) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(DesignSystem.Colors.warningAmber)
+            Text(message)
+                .font(DesignSystem.Typography.caption)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+            Spacer()
         }
-        .buttonStyle(.plain)
-        .onHover { isHovered = $0 }
-    }
-
-    @ViewBuilder
-    private var cardActions: some View {
-        HStack(spacing: 4) {
-            if transform.isBuiltIn {
-                Button("Reset", action: onReset)
-                    .parakeetAction(.subtle)
-                    .controlSize(.small)
-            } else {
-                Button(action: onDelete) {
-                    Image(systemName: "trash")
-                }
-                .parakeetAction(.subtle)
-                .controlSize(.small)
-                .help("Delete this Transform")
-            }
-        }
-        .transition(.opacity)
-    }
-
-    private func firstSentence(of body: String) -> String {
-        let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let endIndex = trimmed.firstIndex(where: { ".!?".contains($0) }) else {
-            return trimmed
-        }
-        return String(trimmed[..<endIndex]) + "."
+        .padding(DesignSystem.Spacing.md)
+        .background(DesignSystem.Colors.surfaceElevated)
+        .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius))
     }
 }
-
-// MARK: - Create-your-own tile
-
-private struct CreateYourOwnTile: View {
-    let action: () -> Void
-    @State private var isHovered = false
-
-    var body: some View {
-        Button(action: action) {
-            VStack(spacing: DesignSystem.Spacing.md) {
-                Image(systemName: "plus")
-                    .font(.system(size: 22, weight: .medium))
-                    .foregroundStyle(isHovered ? DesignSystem.Colors.accent : DesignSystem.Colors.textTertiary)
-                Text("Create your own")
-                    .font(DesignSystem.Typography.sectionTitle)
-                    .foregroundStyle(isHovered ? DesignSystem.Colors.textPrimary : DesignSystem.Colors.textSecondary)
-                Text("Upload your own prompt")
-                    .font(DesignSystem.Typography.bodySmall)
-                    .foregroundStyle(DesignSystem.Colors.textTertiary)
-            }
-            .padding(DesignSystem.Spacing.lg)
-            .frame(maxWidth: .infinity, minHeight: 168, alignment: .center)
-            .background(isHovered ? DesignSystem.Colors.accentLight : DesignSystem.Colors.surfaceElevated.opacity(0.4))
-            .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius))
-            .overlay {
-                RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
-                    .strokeBorder(
-                        isHovered ? DesignSystem.Colors.accent.opacity(0.6) : DesignSystem.Colors.border,
-                        style: StrokeStyle(lineWidth: 1.0, dash: [4, 4])
-                    )
-            }
-            .animation(DesignSystem.Animation.hoverTransition, value: isHovered)
-        }
-        .buttonStyle(.plain)
-        .onHover { isHovered = $0 }
-    }
-}
-
-// MARK: - Keycap badge
 
 struct KeycapBadge: View {
     let shortcut: TransformShortcut
@@ -615,22 +914,9 @@ struct KeycapBadge: View {
     }
 
     private var orderedModifierGlyphs: [String] {
-        // Canonical macOS order: ⌃ ⌥ ⇧ ⌘.
         let ordered: [TransformShortcut.ModifierFlag] = [.control, .option, .shift, .command]
         return ordered
             .filter { (shortcut.modifiers & $0.rawValue) != 0 }
             .map(\.displayGlyph)
-    }
-}
-
-private struct UnboundShortcutChip: View {
-    var body: some View {
-        Text("No shortcut bound")
-            .font(DesignSystem.Typography.caption)
-            .foregroundStyle(DesignSystem.Colors.textTertiary)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
-            .background(DesignSystem.Colors.surfaceElevated.opacity(0.5))
-            .clipShape(Capsule())
     }
 }

--- a/Sources/MacParakeet/Views/Transforms/TransformsView.swift
+++ b/Sources/MacParakeet/Views/Transforms/TransformsView.swift
@@ -95,17 +95,17 @@ struct TransformsView: View {
         } message: { sample in
             Text("“\(sample.title)” will no longer be used as a voice reference.")
         }
-        .alert("Clear Transform history?", isPresented: $viewModel.isConfirmingClearHistory) {
-            Button("Clear History", role: .destructive) {
+        .alert("Clear this Transform's history?", isPresented: $viewModel.isConfirmingClearHistory) {
+            Button("Clear Runs", role: .destructive) {
                 Task {
-                    await viewModel.clearHistory()
+                    await viewModel.clearSelectedHistory()
                 }
             }
             Button("Cancel", role: .cancel) {
                 viewModel.isConfirmingClearHistory = false
             }
         } message: {
-            Text("This removes every saved Transform input and output from this Mac.")
+            Text("This removes the saved inputs and outputs for the selected Transform from this Mac.")
         }
     }
 
@@ -151,11 +151,12 @@ struct TransformsView: View {
                 viewModel.reseedMissingBuiltIns()
                 onBindingsChanged()
             } label: {
-                Label("Restore defaults", systemImage: "arrow.counterclockwise")
+                Label("Restore missing defaults", systemImage: "arrow.counterclockwise")
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
             .parakeetAction(.subtle)
             .controlSize(.small)
+            .help("Recreate any built-in Transforms that are missing")
         }
         .padding(.horizontal, DesignSystem.Spacing.lg)
         .padding(.bottom, DesignSystem.Spacing.lg)
@@ -285,9 +286,9 @@ struct TransformsView: View {
                         .disabled(!canSaveDraft)
                     }
 
-                    Text(viewModel.isCreatingDraft ? "Not saved yet" : "Saved locally")
+                    Text(draftStatusText)
                         .font(DesignSystem.Typography.caption)
-                        .foregroundStyle(DesignSystem.Colors.textTertiary)
+                        .foregroundStyle(viewModel.isDraftDirty ? DesignSystem.Colors.warningAmber : DesignSystem.Colors.textTertiary)
                 }
             }
         }
@@ -484,7 +485,7 @@ struct TransformsView: View {
                         Button(role: .destructive) {
                             viewModel.isConfirmingClearHistory = true
                         } label: {
-                            Label("Clear All", systemImage: "trash")
+                            Label("Clear Runs", systemImage: "trash")
                         }
                         .parakeetAction(.subtle)
                         .controlSize(.small)
@@ -519,6 +520,13 @@ struct TransformsView: View {
             && viewModel.nameError == nil
             && viewModel.contentError == nil
             && viewModel.shortcutError == nil
+    }
+
+    private var draftStatusText: String {
+        if viewModel.isCreatingDraft {
+            return "Not saved yet"
+        }
+        return viewModel.isDraftDirty ? "Unsaved changes" : "Saved locally"
     }
 
     private func revalidate() {
@@ -695,6 +703,10 @@ private struct WritingSampleRow: View {
 private struct WritingSampleEditor: View {
     @Bindable var viewModel: TransformsViewModel
 
+    private var wordCount: Int {
+        WritingSample.countWords(in: viewModel.writingSampleText)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
             TextField("Sample title", text: $viewModel.writingSampleTitle)
@@ -732,9 +744,9 @@ private struct WritingSampleEditor: View {
                 }
 
             HStack {
-                Text("\(WritingSample.countWords(in: viewModel.writingSampleText)) words")
+                Text("\(wordCount)/\(TransformsViewModel.minimumWritingSampleWords) words")
                     .font(DesignSystem.Typography.caption)
-                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    .foregroundStyle(wordCount >= TransformsViewModel.minimumWritingSampleWords ? DesignSystem.Colors.textSecondary : DesignSystem.Colors.textTertiary)
                 Spacer()
                 Button("Cancel") {
                     viewModel.isAddingWritingSample = false
@@ -747,6 +759,7 @@ private struct WritingSampleEditor: View {
                     _ = viewModel.saveWritingSample()
                 }
                 .parakeetAction(.primary)
+                .disabled(wordCount < TransformsViewModel.minimumWritingSampleWords)
             }
         }
         .padding(DesignSystem.Spacing.md)

--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -715,6 +715,34 @@ public final class DatabaseManager: Sendable {
             )
         }
 
+        // v0.15 — Transform Workbench profiles and writing samples. Profiles
+        // hold structured controls for each Transform; writing samples are
+        // local-only voice references that can be attached to assembled prompts
+        // when a user explicitly enables them.
+        migrator.registerMigration("v0.15-transform-workbench") { db in
+            try db.create(table: "transform_profiles") { t in
+                t.column("promptId", .text).primaryKey()
+                t.column("enabledRuleIDsJSON", .text).notNull().defaults(to: "[]")
+                t.column("customInstructions", .text)
+                t.column("useWritingSamples", .boolean).notNull().defaults(to: false)
+                t.column("createdAt", .text).notNull()
+                t.column("updatedAt", .text).notNull()
+            }
+            try db.create(table: "writing_samples") { t in
+                t.column("id", .text).primaryKey()
+                t.column("title", .text).notNull()
+                t.column("text", .text).notNull()
+                t.column("wordCount", .integer).notNull().defaults(to: 0)
+                t.column("createdAt", .text).notNull()
+                t.column("updatedAt", .text).notNull()
+            }
+            try db.create(
+                index: "idx_writing_samples_updated_at",
+                on: "writing_samples",
+                columns: ["updatedAt"]
+            )
+        }
+
         try migrator.migrate(dbQueue)
         try reconcileBuiltInPrompts()
         try reconcileBuiltInQuickPrompts()

--- a/Sources/MacParakeetCore/Database/README.md
+++ b/Sources/MacParakeetCore/Database/README.md
@@ -22,7 +22,9 @@ process.
   - `TextSnippetRepository.swift` — snippets (text + action).
   - `PromptRepository.swift` — prompt-library entries.
   - `PromptResultRepository.swift` — saved prompt outputs.
+  - `TransformProfileRepository.swift` — structured Transform rules and workbench settings.
   - `TransformHistoryRepository.swift` — local-only Transform input/output history.
+  - `WritingSampleRepository.swift` — local-only writing samples used by Transform voice matching.
   - `QuickPromptRepository.swift` — quick-prompt entries (Ask tab).
   - `ChatConversationRepository.swift` — multi-turn chat history.
 

--- a/Sources/MacParakeetCore/Database/TransformHistoryRepository.swift
+++ b/Sources/MacParakeetCore/Database/TransformHistoryRepository.swift
@@ -9,6 +9,7 @@ public protocol TransformHistoryRepositoryProtocol: Sendable {
     func fetch(idPrefix: String) throws -> [TransformHistoryEntry]
     func count() throws -> Int
     func delete(id: UUID) throws -> Bool
+    func deleteAll(transformId: UUID) throws
     func deleteAll() throws
 }
 
@@ -81,6 +82,14 @@ public final class TransformHistoryRepository: TransformHistoryRepositoryProtoco
     public func delete(id: UUID) throws -> Bool {
         try dbQueue.write { db in
             try TransformHistoryEntry.deleteOne(db, key: id)
+        }
+    }
+
+    public func deleteAll(transformId: UUID) throws {
+        _ = try dbQueue.write { db in
+            try TransformHistoryEntry
+                .filter(TransformHistoryEntry.Columns.transformId == transformId)
+                .deleteAll(db)
         }
     }
 

--- a/Sources/MacParakeetCore/Database/TransformProfileRepository.swift
+++ b/Sources/MacParakeetCore/Database/TransformProfileRepository.swift
@@ -1,0 +1,41 @@
+import Foundation
+import GRDB
+
+public protocol TransformProfileRepositoryProtocol: Sendable {
+    func save(_ profile: TransformProfile) throws
+    func fetch(promptId: UUID) throws -> TransformProfile?
+    func fetchAll() throws -> [TransformProfile]
+    func delete(promptId: UUID) throws -> Bool
+}
+
+public final class TransformProfileRepository: TransformProfileRepositoryProtocol {
+    private let dbQueue: DatabaseQueue
+
+    public init(dbQueue: DatabaseQueue) {
+        self.dbQueue = dbQueue
+    }
+
+    public func save(_ profile: TransformProfile) throws {
+        try dbQueue.write { db in
+            try profile.save(db)
+        }
+    }
+
+    public func fetch(promptId: UUID) throws -> TransformProfile? {
+        try dbQueue.read { db in
+            try TransformProfile.fetchOne(db, key: promptId)
+        }
+    }
+
+    public func fetchAll() throws -> [TransformProfile] {
+        try dbQueue.read { db in
+            try TransformProfile.fetchAll(db)
+        }
+    }
+
+    public func delete(promptId: UUID) throws -> Bool {
+        try dbQueue.write { db in
+            try TransformProfile.deleteOne(db, key: promptId)
+        }
+    }
+}

--- a/Sources/MacParakeetCore/Database/WritingSampleRepository.swift
+++ b/Sources/MacParakeetCore/Database/WritingSampleRepository.swift
@@ -1,0 +1,50 @@
+import Foundation
+import GRDB
+
+public protocol WritingSampleRepositoryProtocol: Sendable {
+    func save(_ sample: WritingSample) throws
+    func fetch(id: UUID) throws -> WritingSample?
+    func fetchAll() throws -> [WritingSample]
+    func delete(id: UUID) throws -> Bool
+    func deleteAll() throws
+}
+
+public final class WritingSampleRepository: WritingSampleRepositoryProtocol {
+    private let dbQueue: DatabaseQueue
+
+    public init(dbQueue: DatabaseQueue) {
+        self.dbQueue = dbQueue
+    }
+
+    public func save(_ sample: WritingSample) throws {
+        try dbQueue.write { db in
+            try sample.save(db)
+        }
+    }
+
+    public func fetch(id: UUID) throws -> WritingSample? {
+        try dbQueue.read { db in
+            try WritingSample.fetchOne(db, key: id)
+        }
+    }
+
+    public func fetchAll() throws -> [WritingSample] {
+        try dbQueue.read { db in
+            try WritingSample
+                .order(WritingSample.Columns.updatedAt.desc, WritingSample.Columns.title.asc)
+                .fetchAll(db)
+        }
+    }
+
+    public func delete(id: UUID) throws -> Bool {
+        try dbQueue.write { db in
+            try WritingSample.deleteOne(db, key: id)
+        }
+    }
+
+    public func deleteAll() throws {
+        _ = try dbQueue.write { db in
+            try WritingSample.deleteAll(db)
+        }
+    }
+}

--- a/Sources/MacParakeetCore/Models/TransformProfile.swift
+++ b/Sources/MacParakeetCore/Models/TransformProfile.swift
@@ -1,0 +1,69 @@
+import Foundation
+import GRDB
+
+public struct TransformProfile: Codable, Identifiable, Sendable, Equatable {
+    public var promptId: UUID
+    public var enabledRuleIDsJSON: String
+    public var customInstructions: String?
+    public var useWritingSamples: Bool
+    public var createdAt: Date
+    public var updatedAt: Date
+
+    public var id: UUID { promptId }
+
+    public init(
+        promptId: UUID,
+        enabledRuleIDsJSON: String,
+        customInstructions: String? = nil,
+        useWritingSamples: Bool = false,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.promptId = promptId
+        self.enabledRuleIDsJSON = enabledRuleIDsJSON
+        self.customInstructions = customInstructions
+        self.useWritingSamples = useWritingSamples
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+
+    public var enabledRuleIDs: Set<String> {
+        guard let data = enabledRuleIDsJSON.data(using: .utf8),
+              let decoded = try? JSONDecoder().decode([String].self, from: data)
+        else {
+            return []
+        }
+        return Set(decoded)
+    }
+
+    public mutating func setEnabledRuleIDs(_ ids: Set<String>) {
+        let sorted = ids.sorted()
+        let data = (try? JSONEncoder().encode(sorted)) ?? Data("[]".utf8)
+        enabledRuleIDsJSON = String(data: data, encoding: .utf8) ?? "[]"
+        updatedAt = Date()
+    }
+
+    public static func defaultProfile(for prompt: Prompt, now: Date = Date()) -> TransformProfile {
+        let defaultIDs = Set(TransformRule.rules(for: prompt).filter(\.defaultEnabled).map(\.id))
+        let data = (try? JSONEncoder().encode(defaultIDs.sorted())) ?? Data("[]".utf8)
+        return TransformProfile(
+            promptId: prompt.id,
+            enabledRuleIDsJSON: String(data: data, encoding: .utf8) ?? "[]",
+            createdAt: now,
+            updatedAt: now
+        )
+    }
+}
+
+extension TransformProfile: FetchableRecord, PersistableRecord {
+    public static let databaseTableName = "transform_profiles"
+
+    public enum Columns: String, ColumnExpression {
+        case promptId
+        case enabledRuleIDsJSON
+        case customInstructions
+        case useWritingSamples
+        case createdAt
+        case updatedAt
+    }
+}

--- a/Sources/MacParakeetCore/Models/TransformRule.swift
+++ b/Sources/MacParakeetCore/Models/TransformRule.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+public struct TransformRule: Identifiable, Sendable, Equatable {
+    public let id: String
+    public let title: String
+    public let detail: String
+    public let instruction: String
+    public let defaultEnabled: Bool
+
+    public init(
+        id: String,
+        title: String,
+        detail: String,
+        instruction: String,
+        defaultEnabled: Bool = true
+    ) {
+        self.id = id
+        self.title = title
+        self.detail = detail
+        self.instruction = instruction
+        self.defaultEnabled = defaultEnabled
+    }
+
+    public static func rules(for prompt: Prompt) -> [TransformRule] {
+        switch prompt.builtInTransformKind {
+        case .polish:
+            return [
+                TransformRule(
+                    id: "polish.concise",
+                    title: "Make more concise",
+                    detail: "Trim filler and repetition without losing intent.",
+                    instruction: "Make the output more concise by removing filler, repetition, throat-clearing, and weak hedges while preserving meaning."
+                ),
+                TransformRule(
+                    id: "polish.clarity",
+                    title: "Reword for clarity",
+                    detail: "Prefer direct, specific language.",
+                    instruction: "Reword unclear phrases for clarity. Prefer direct, specific language over vague or ornamental phrasing."
+                ),
+                TransformRule(
+                    id: "polish.reorder",
+                    title: "Reorder for readability",
+                    detail: "Move the strongest point where it belongs.",
+                    instruction: "Reorder sentences or clauses when doing so makes the text easier to read, but do not change the author's intent."
+                ),
+                TransformRule(
+                    id: "polish.structure",
+                    title: "Add structure for readability",
+                    detail: "Use bullets or short paragraphs when helpful.",
+                    instruction: "Add lightweight structure when the input is hard to scan. Use bullets only when they genuinely improve readability."
+                ),
+                TransformRule(
+                    id: "polish.tone",
+                    title: "Maintain your tone",
+                    detail: "Keep the same register and personality.",
+                    instruction: "Preserve the author's register, personality, and level of formality. Do not make casual text corporate or formal text chatty."
+                ),
+            ]
+        case .distill:
+            return [
+                TransformRule(
+                    id: "distill.signal",
+                    title: "Keep only signal",
+                    detail: "Compress without dropping action items.",
+                    instruction: "Keep only the highest-signal content. Preserve action items, decisions, constraints, names, numbers, and concrete claims."
+                ),
+                TransformRule(
+                    id: "distill.shape",
+                    title: "Match the output shape",
+                    detail: "Use prose or bullets based on the source.",
+                    instruction: "Match the output shape to the source and destination. Use compact prose for one idea, bullets for multiple separable ideas."
+                ),
+                TransformRule(
+                    id: "distill.why",
+                    title: "Keep the why",
+                    detail: "Preserve the reasoning behind the point.",
+                    instruction: "Do not lose the reasoning behind the point. If the input includes why something matters, keep that reason."
+                ),
+            ]
+        case .decide:
+            return [
+                TransformRule(
+                    id: "decide.question",
+                    title: "Name the decision",
+                    detail: "State what needs to be decided.",
+                    instruction: "State the decision or question explicitly, even when the input only implies it."
+                ),
+                TransformRule(
+                    id: "decide.tradeoffs",
+                    title: "Surface tradeoffs",
+                    detail: "Show what each option costs and buys.",
+                    instruction: "Surface the live options and their tradeoffs. Do not invent options or data the input does not support."
+                ),
+                TransformRule(
+                    id: "decide.recommendation",
+                    title: "Recommend the next move",
+                    detail: "End with a concrete next step when possible.",
+                    instruction: "End with a recommended next move and a short reason when the input contains enough information to support one."
+                ),
+                TransformRule(
+                    id: "decide.blocker",
+                    title: "Call out missing info",
+                    detail: "Name the smallest blocker if a decision is not possible.",
+                    instruction: "If there is not enough information to decide, name the smallest concrete question that must be answered next."
+                ),
+            ]
+        case .custom:
+            return [
+                TransformRule(
+                    id: "custom.facts",
+                    title: "Preserve facts",
+                    detail: "Keep names, numbers, links, and claims intact.",
+                    instruction: "Preserve names, numbers, URLs, quoted text, code identifiers, and factual claims unless the custom prompt explicitly says otherwise."
+                ),
+                TransformRule(
+                    id: "custom.intent",
+                    title: "Preserve intent",
+                    detail: "Change the wording, not the user's goal.",
+                    instruction: "Preserve the user's intent and do not add new ideas, claims, promises, or enthusiasm unless the custom prompt explicitly asks for it."
+                ),
+            ]
+        }
+    }
+}
+
+public enum BuiltInTransformKind: Sendable, Equatable {
+    case polish
+    case distill
+    case decide
+    case custom
+}
+
+public extension Prompt {
+    var builtInTransformKind: BuiltInTransformKind {
+        switch id.uuidString.uppercased() {
+        case "0FCE9DDB-7E2D-4B1A-AE3E-6F7C9B2A4D11":
+            return .polish
+        case "1AD7C2B0-9C6F-4F0E-9C39-5E4D1F1D2A55":
+            return .distill
+        case "2BE8D3C1-4A7F-4EBD-8F12-7C9A1E0B3D44":
+            return .decide
+        default:
+            return .custom
+        }
+    }
+
+    var transformPurpose: String {
+        switch builtInTransformKind {
+        case .polish:
+            return "Make selected text clearer and more finished while keeping your voice."
+        case .distill:
+            return "Compress selected text to the highest-signal version without losing meaning."
+        case .decide:
+            return "Turn messy discussion into a decision-ready note with tradeoffs and next steps."
+        case .custom:
+            return "Run your own instructions against selected text anywhere on your Mac."
+        }
+    }
+}

--- a/Sources/MacParakeetCore/Models/WritingSample.swift
+++ b/Sources/MacParakeetCore/Models/WritingSample.swift
@@ -1,0 +1,44 @@
+import Foundation
+import GRDB
+
+public struct WritingSample: Codable, Identifiable, Sendable, Equatable {
+    public var id: UUID
+    public var title: String
+    public var text: String
+    public var wordCount: Int
+    public var createdAt: Date
+    public var updatedAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        title: String,
+        text: String,
+        wordCount: Int? = nil,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.title = title
+        self.text = text
+        self.wordCount = wordCount ?? Self.countWords(in: text)
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+
+    public static func countWords(in text: String) -> Int {
+        text.split { $0.isWhitespace || $0.isNewline }.count
+    }
+}
+
+extension WritingSample: FetchableRecord, PersistableRecord {
+    public static let databaseTableName = "writing_samples"
+
+    public enum Columns: String, ColumnExpression {
+        case id
+        case title
+        case text
+        case wordCount
+        case createdAt
+        case updatedAt
+    }
+}

--- a/Sources/MacParakeetCore/Services/Transforms/TransformPromptAssembler.swift
+++ b/Sources/MacParakeetCore/Services/Transforms/TransformPromptAssembler.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+public enum TransformPromptAssembler {
+    private static let maxSamples = 3
+    private static let maxSampleCharacters = 1_500
+
+    public static func assemble(
+        prompt: Prompt,
+        profile: TransformProfile?,
+        writingSamples: [WritingSample]
+    ) -> String {
+        let profile = profile ?? .defaultProfile(for: prompt)
+        var sections = [prompt.content.trimmingCharacters(in: .whitespacesAndNewlines)]
+
+        let rules = TransformRule
+            .rules(for: prompt)
+            .filter { profile.enabledRuleIDs.contains($0.id) }
+        if !rules.isEmpty {
+            sections.append("""
+                User-selected rules:
+                \(rules.map { "- \($0.instruction)" }.joined(separator: "\n"))
+                """)
+        }
+
+        if let custom = profile.customInstructions?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !custom.isEmpty {
+            sections.append("""
+                Additional user instructions:
+                \(custom)
+                """)
+        }
+
+        if profile.useWritingSamples {
+            let usableSamples = writingSamples
+                .filter { !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+                .prefix(maxSamples)
+            if !usableSamples.isEmpty {
+                let sampleText = usableSamples.enumerated().map { index, sample in
+                    let trimmed = sample.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                    let clipped = String(trimmed.prefix(maxSampleCharacters))
+                    return """
+                        Sample \(index + 1) — \(sample.title):
+                        \(clipped)
+                        """
+                }.joined(separator: "\n\n")
+                sections.append("""
+                    Voice reference samples:
+                    Use these samples only to understand the author's natural voice, pacing, and word choice. Do not quote them, summarize them, or introduce facts from them.
+
+                    \(sampleText)
+                    """)
+            }
+        }
+
+        sections.append("Return only the transformed text.")
+        return sections.joined(separator: "\n\n")
+    }
+}

--- a/Sources/MacParakeetViewModels/TransformEditorViewModel.swift
+++ b/Sources/MacParakeetViewModels/TransformEditorViewModel.swift
@@ -96,16 +96,14 @@ public final class TransformEditorViewModel {
     /// editor's awareness.
     public func validate(
         existingTransforms: [Prompt],
-        dictationHotkeys: [HotkeyTrigger],
-        meetingHotkey: HotkeyTrigger?,
+        reservedHotkeys: [TransformShortcutReservedHotkey],
         collisionChecker: TransformShortcutCollisionChecking
     ) {
         validateName(against: existingTransforms)
         validateContent()
         validateShortcut(
             existingTransforms: existingTransforms,
-            dictationHotkeys: dictationHotkeys,
-            meetingHotkey: meetingHotkey,
+            reservedHotkeys: reservedHotkeys,
             collisionChecker: collisionChecker
         )
     }
@@ -131,8 +129,7 @@ public final class TransformEditorViewModel {
 
     private func validateShortcut(
         existingTransforms: [Prompt],
-        dictationHotkeys: [HotkeyTrigger],
-        meetingHotkey: HotkeyTrigger?,
+        reservedHotkeys: [TransformShortcutReservedHotkey],
         collisionChecker: TransformShortcutCollisionChecking
     ) {
         guard let candidate = shortcut else {
@@ -153,8 +150,7 @@ public final class TransformEditorViewModel {
             candidate: candidate,
             existing: bindings,
             excludingPromptID: editingID,
-            dictationHotkeys: dictationHotkeys,
-            meetingHotkey: meetingHotkey
+            reservedHotkeys: reservedHotkeys
         )
         shortcutError = collision?.message
     }
@@ -221,8 +217,7 @@ public protocol TransformShortcutCollisionChecking {
         candidate: KeyboardShortcut,
         existing: [UUID: KeyboardShortcut],
         excludingPromptID: UUID?,
-        dictationHotkeys: [HotkeyTrigger],
-        meetingHotkey: HotkeyTrigger?
+        reservedHotkeys: [TransformShortcutReservedHotkey]
     ) -> TransformShortcutCollision?
 }
 
@@ -232,8 +227,7 @@ public enum TransformShortcutCollision: Equatable, Sendable {
     case missingModifier
     case macOSDeadKey
     case duplicateTransform(otherPromptID: UUID)
-    case dictationHotkey
-    case meetingHotkey
+    case reservedHotkey(name: String, shortcut: String)
 
     public var message: String {
         switch self {
@@ -243,10 +237,8 @@ public enum TransformShortcutCollision: Equatable, Sendable {
             return "This shortcut produces a special character on Mac. Pick another combo."
         case .duplicateTransform:
             return "Another Transform already uses this shortcut."
-        case .dictationHotkey:
-            return "This shortcut conflicts with your dictation hotkey."
-        case .meetingHotkey:
-            return "This shortcut conflicts with your meeting recording hotkey."
+        case .reservedHotkey(let name, let shortcut):
+            return "This shortcut conflicts with \(name): \(shortcut)."
         }
     }
 }

--- a/Sources/MacParakeetViewModels/TransformsViewModel.swift
+++ b/Sources/MacParakeetViewModels/TransformsViewModel.swift
@@ -320,6 +320,27 @@ public final class TransformsViewModel {
         }
     }
 
+    public func clearSelectedHistory() async {
+        guard let historyRepo else { return }
+        guard let selectedTransformID else {
+            isConfirmingClearHistory = false
+            return
+        }
+        do {
+            let snapshot = try await Self.deleteHistoryForTransformAndFetchSnapshot(
+                repo: historyRepo,
+                transformId: selectedTransformID,
+                limit: Self.historyFetchLimit
+            )
+            history = snapshot.entries
+            totalHistoryCount = snapshot.totalCount
+            isConfirmingClearHistory = false
+            historyErrorMessage = nil
+        } catch {
+            historyErrorMessage = error.localizedDescription
+        }
+    }
+
     public func copyOutputToClipboard(_ entry: TransformHistoryEntry) async {
         guard let clipboardService else {
             historyErrorMessage = "Clipboard service is unavailable."
@@ -359,6 +380,19 @@ public final class TransformsViewModel {
     ) async throws -> (entries: [TransformHistoryEntry], totalCount: Int) {
         try await Task.detached(priority: .userInitiated) {
             _ = try repo.delete(id: id)
+            let entries = try repo.fetchRecent(limit: limit)
+            let totalCount = try repo.count()
+            return (entries, totalCount)
+        }.value
+    }
+
+    private static func deleteHistoryForTransformAndFetchSnapshot(
+        repo: TransformHistoryRepositoryProtocol,
+        transformId: UUID,
+        limit: Int
+    ) async throws -> (entries: [TransformHistoryEntry], totalCount: Int) {
+        try await Task.detached(priority: .userInitiated) {
+            try repo.deleteAll(transformId: transformId)
             let entries = try repo.fetchRecent(limit: limit)
             let totalCount = try repo.count()
             return (entries, totalCount)
@@ -511,6 +545,23 @@ public final class TransformsViewModel {
             && nameError == nil
             && contentError == nil
             && shortcutError == nil
+    }
+
+    public var isDraftDirty: Bool {
+        guard !isCreatingDraft, let prompt = selectedTransform else { return false }
+
+        let normalizedContent = draftContent.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedRunningLabel = draftRunningLabel.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedInstructions = draftCustomInstructions.trimmingCharacters(in: .whitespacesAndNewlines)
+        let profile = profiles[prompt.id] ?? .defaultProfile(for: prompt)
+
+        return normalizedDraftName != prompt.name
+            || normalizedContent != prompt.content.trimmingCharacters(in: .whitespacesAndNewlines)
+            || normalizedRunningLabel != (prompt.runningLabel ?? "")
+            || draftShortcut != prompt.shortcut
+            || draftEnabledRuleIDs != profile.enabledRuleIDs
+            || normalizedInstructions != (profile.customInstructions ?? "")
+            || draftUseWritingSamples != profile.useWritingSamples
     }
 
     public var customTransforms: [Prompt] {

--- a/Sources/MacParakeetViewModels/TransformsViewModel.swift
+++ b/Sources/MacParakeetViewModels/TransformsViewModel.swift
@@ -1,60 +1,97 @@
 import Foundation
 import MacParakeetCore
 
-/// Drives the **Transforms** tab list (ADR-022). Owns the user-visible
-/// ordered set of `.transform` prompts plus the "no LLM provider" state
-/// surfaced in the hero card.
-///
-/// Editing a single Transform happens in `TransformEditorViewModel` —
-/// this VM owns the *collection*; the editor VM owns one *row's draft state*.
+public struct TransformShortcutReservedHotkey: Sendable, Equatable {
+    public let name: String
+    public let trigger: HotkeyTrigger
+
+    public init(name: String, trigger: HotkeyTrigger) {
+        self.name = name
+        self.trigger = trigger
+    }
+}
+
+/// Drives the **Transforms** tab (ADR-022 + Workbench). Owns the ordered set of
+/// `.transform` prompts, the selected workbench draft, local history, structured
+/// rules, and writing samples.
 @MainActor
 @Observable
 public final class TransformsViewModel {
     public nonisolated static let historyFetchLimit = 200
+    public nonisolated static let minimumWritingSampleWords = 50
 
     public var transforms: [Prompt] = []
+    public var profiles: [UUID: TransformProfile] = [:]
     public var history: [TransformHistoryEntry] = []
     public var totalHistoryCount: Int = 0
+    public var writingSamples: [WritingSample] = []
     public var errorMessage: String?
     public var historyErrorMessage: String?
+    public var writingSampleErrorMessage: String?
 
-    /// Pending delete confirmation. Set when the user hits delete on a
-    /// (non-built-in) Transform; cleared on confirm or cancel.
+    public var selectedTransformID: UUID?
+    public var isCreatingDraft = false
+
+    public var draftName: String = ""
+    public var draftContent: String = ""
+    public var draftRunningLabel: String = ""
+    public var draftShortcut: KeyboardShortcut?
+    public var draftEnabledRuleIDs: Set<String> = []
+    public var draftCustomInstructions: String = ""
+    public var draftUseWritingSamples: Bool = false
+
+    public var nameError: String?
+    public var contentError: String?
+    public var shortcutError: String?
+
     public var pendingDeleteTransform: Prompt?
     public var pendingDeleteHistoryEntry: TransformHistoryEntry?
+    public var pendingDeleteWritingSample: WritingSample?
     public var isConfirmingClearHistory: Bool = false
     public var copiedHistoryEntryID: UUID?
 
-    /// True when the user has at least one LLM provider configured. Drives
-    /// the calm "Configure in Settings" hero state.
+    public var isAddingWritingSample: Bool = false
+    public var writingSampleTitle: String = ""
+    public var writingSampleText: String = ""
+
     public var hasLLMProvider: Bool = false
 
     private var repo: PromptRepositoryProtocol?
+    private var profileRepo: TransformProfileRepositoryProtocol?
     private var historyRepo: TransformHistoryRepositoryProtocol?
     private var clipboardService: ClipboardServiceProtocol?
+    private var writingSampleRepo: WritingSampleRepositoryProtocol?
     private var copiedResetTask: Task<Void, Never>?
 
     public init() {}
 
     public func configure(
         repo: PromptRepositoryProtocol,
+        profileRepo: TransformProfileRepositoryProtocol? = nil,
         historyRepo: TransformHistoryRepositoryProtocol? = nil,
         clipboardService: ClipboardServiceProtocol? = nil,
+        writingSampleRepo: WritingSampleRepositoryProtocol? = nil,
         hasLLMProvider: Bool
     ) {
         self.repo = repo
+        self.profileRepo = profileRepo
         self.historyRepo = historyRepo
         self.clipboardService = clipboardService
+        self.writingSampleRepo = writingSampleRepo
         self.hasLLMProvider = hasLLMProvider
         load()
+        loadProfiles()
+        loadWritingSamples()
+        if let selectedTransform {
+            loadDraft(from: selectedTransform)
+        } else {
+            ensureSelection()
+        }
         Task {
             await loadHistory()
         }
     }
 
-    /// Refresh the list from the repository. Built-ins are seeded by the
-    /// reconciler at launch — this view never sees an empty list under
-    /// normal operation.
     public func load() {
         guard let repo else { return }
         do {
@@ -65,6 +102,16 @@ public final class TransformsViewModel {
                     return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
                 })
             errorMessage = nil
+            ensureSelection()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    public func loadProfiles() {
+        guard let profileRepo else { return }
+        do {
+            profiles = Dictionary(uniqueKeysWithValues: try profileRepo.fetchAll().map { ($0.promptId, $0) })
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -91,23 +138,112 @@ public final class TransformsViewModel {
         }
     }
 
+    public func loadWritingSamples() {
+        guard let writingSampleRepo else { return }
+        do {
+            writingSamples = try writingSampleRepo.fetchAll()
+            writingSampleErrorMessage = nil
+        } catch {
+            writingSamples = []
+            writingSampleErrorMessage = error.localizedDescription
+        }
+    }
+
     public func setHasLLMProvider(_ value: Bool) {
         hasLLMProvider = value
     }
 
-    // MARK: - Mutations
+    public func selectTransform(_ prompt: Prompt) {
+        selectedTransformID = prompt.id
+        isCreatingDraft = false
+        loadDraft(from: prompt)
+    }
 
-    /// Save a new or edited Transform. Wraps the underlying GRDB save and
-    /// reloads the list so the UI reflects the change. Does NOT register
-    /// the hotkey — the coordinator's `reloadBindings()` is invoked by the
-    /// view layer after this returns successfully.
+    public func startCreatingTransform() {
+        selectedTransformID = nil
+        isCreatingDraft = true
+        let draft = Prompt(
+            name: "New Transform",
+            content: "",
+            category: .transform,
+            sortOrder: 200
+        )
+        draftName = ""
+        draftContent = ""
+        draftRunningLabel = ""
+        draftShortcut = nil
+        let profile = TransformProfile.defaultProfile(for: draft)
+        draftEnabledRuleIDs = profile.enabledRuleIDs
+        draftCustomInstructions = ""
+        draftUseWritingSamples = false
+        clearValidation()
+    }
+
+    public func cancelCreate() {
+        isCreatingDraft = false
+        ensureSelection(force: true)
+    }
+
     @discardableResult
-    public func save(_ prompt: Prompt) -> Bool {
-        guard let repo else { return false }
+    public func saveDraft(
+        reservedHotkeys: [TransformShortcutReservedHotkey],
+        collisionChecker: TransformShortcutCollisionChecking
+    ) -> Bool {
+        validateDraft(reservedHotkeys: reservedHotkeys, collisionChecker: collisionChecker)
+        guard isDraftValid, let repo else { return false }
+
+        let now = Date()
+        let trimmedName = normalizedDraftName
+        let trimmedContent = draftContent.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedLabel = draftRunningLabel.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedInstructions = draftCustomInstructions.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let saved: Prompt
+        if isCreatingDraft {
+            saved = Prompt(
+                id: UUID(),
+                name: trimmedName,
+                content: trimmedContent,
+                category: .transform,
+                isBuiltIn: false,
+                isVisible: true,
+                isAutoRun: false,
+                sortOrder: nextCustomSortOrder,
+                createdAt: now,
+                updatedAt: now,
+                keyboardShortcut: draftShortcut?.encodedString(),
+                runningLabel: trimmedLabel.isEmpty ? nil : trimmedLabel
+            )
+        } else if let original = selectedTransform {
+            var updated = original
+            updated.name = trimmedName
+            updated.content = trimmedContent
+            updated.keyboardShortcut = draftShortcut?.encodedString()
+            updated.runningLabel = trimmedLabel.isEmpty ? nil : trimmedLabel
+            updated.updatedAt = now
+            saved = updated
+        } else {
+            return false
+        }
+
         do {
-            try repo.save(prompt)
+            try repo.save(saved)
+            var profile = profiles[saved.id] ?? TransformProfile.defaultProfile(for: saved)
+            profile.promptId = saved.id
+            profile.setEnabledRuleIDs(draftEnabledRuleIDs)
+            profile.customInstructions = trimmedInstructions.isEmpty ? nil : trimmedInstructions
+            profile.useWritingSamples = draftUseWritingSamples
+            profile.updatedAt = now
+            if profile.createdAt > now {
+                profile.createdAt = now
+            }
+            try profileRepo?.save(profile)
+            profiles[saved.id] = profile
+            isCreatingDraft = false
+            selectedTransformID = saved.id
             errorMessage = nil
             load()
+            loadDraft(from: saved)
             return true
         } catch {
             errorMessage = error.localizedDescription
@@ -115,17 +251,17 @@ public final class TransformsViewModel {
         }
     }
 
-    /// Delete a non-built-in Transform. Built-ins are protected — the
-    /// underlying repository refuses them; this helper short-circuits so
-    /// the UI can hide the action entirely.
     @discardableResult
     public func delete(_ prompt: Prompt) -> Bool {
         guard let repo, !prompt.isBuiltIn else { return false }
         do {
             let deleted = try repo.delete(id: prompt.id)
             if deleted {
+                _ = try? profileRepo?.delete(promptId: prompt.id)
+                profiles[prompt.id] = nil
                 errorMessage = nil
                 load()
+                ensureSelection(force: true)
             }
             return deleted
         } catch {
@@ -134,7 +270,6 @@ public final class TransformsViewModel {
         }
     }
 
-    /// Confirm a pending delete that was queued via `pendingDeleteTransform`.
     public func confirmPendingDelete() {
         guard let pending = pendingDeleteTransform else { return }
         pendingDeleteTransform = nil
@@ -145,6 +280,12 @@ public final class TransformsViewModel {
         guard let pending = pendingDeleteHistoryEntry else { return }
         pendingDeleteHistoryEntry = nil
         await deleteHistoryEntry(pending)
+    }
+
+    public func confirmPendingWritingSampleDelete() {
+        guard let pending = pendingDeleteWritingSample else { return }
+        pendingDeleteWritingSample = nil
+        deleteWritingSample(pending)
     }
 
     public func deleteHistoryEntry(_ entry: TransformHistoryEntry) async {
@@ -252,12 +393,34 @@ public final class TransformsViewModel {
         restored.runningLabel = canonical.runningLabel
         restored.sortOrder = canonical.sortOrder
         restored.updatedAt = Date()
-        return save(restored)
+        do {
+            _ = try profileRepo?.delete(promptId: prompt.id)
+            profiles[prompt.id] = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        let saved = save(restored)
+        if saved {
+            selectedTransformID = restored.id
+            loadDraft(from: restored)
+        }
+        return saved
     }
 
-    /// Re-seed missing built-in Transforms only (does NOT overwrite user
-    /// edits to existing built-ins). The header's *Reset to defaults*
-    /// affordance maps to this.
+    @discardableResult
+    public func save(_ prompt: Prompt) -> Bool {
+        guard let repo else { return false }
+        do {
+            try repo.save(prompt)
+            errorMessage = nil
+            load()
+            return true
+        } catch {
+            errorMessage = error.localizedDescription
+            return false
+        }
+    }
+
     public func reseedMissingBuiltIns() {
         guard let repo else { return }
         let existingIDs = Set(transforms.map(\.id))
@@ -273,7 +436,82 @@ public final class TransformsViewModel {
         load()
     }
 
-    // MARK: - Convenience accessors
+    public func saveWritingSample() -> Bool {
+        guard let writingSampleRepo else { return false }
+        let text = writingSampleText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let words = WritingSample.countWords(in: text)
+        guard words >= Self.minimumWritingSampleWords else {
+            writingSampleErrorMessage = "Add at least \(Self.minimumWritingSampleWords) words so MacParakeet can learn from the sample."
+            return false
+        }
+        let title = writingSampleTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        let now = Date()
+        let sample = WritingSample(
+            title: title.isEmpty ? "Writing sample \(writingSamples.count + 1)" : title,
+            text: text,
+            wordCount: words,
+            createdAt: now,
+            updatedAt: now
+        )
+        do {
+            try writingSampleRepo.save(sample)
+            writingSampleTitle = ""
+            writingSampleText = ""
+            isAddingWritingSample = false
+            writingSampleErrorMessage = nil
+            loadWritingSamples()
+            return true
+        } catch {
+            writingSampleErrorMessage = error.localizedDescription
+            return false
+        }
+    }
+
+    public func deleteWritingSample(_ sample: WritingSample) {
+        guard let writingSampleRepo else { return }
+        do {
+            _ = try writingSampleRepo.delete(id: sample.id)
+            writingSamples.removeAll { $0.id == sample.id }
+            writingSampleErrorMessage = nil
+        } catch {
+            writingSampleErrorMessage = error.localizedDescription
+        }
+    }
+
+    public func validateDraft(
+        reservedHotkeys: [TransformShortcutReservedHotkey],
+        collisionChecker: TransformShortcutCollisionChecking
+    ) {
+        validateName()
+        validateContent()
+        validateShortcut(reservedHotkeys: reservedHotkeys, collisionChecker: collisionChecker)
+    }
+
+    public var selectedTransform: Prompt? {
+        guard let selectedTransformID else { return nil }
+        return transforms.first(where: { $0.id == selectedTransformID })
+    }
+
+    public var activeRules: [TransformRule] {
+        TransformRule.rules(for: selectedTransform ?? draftPromptForRules)
+    }
+
+    public var selectedHistory: [TransformHistoryEntry] {
+        guard let selectedTransformID else { return [] }
+        return history.filter { $0.transformId == selectedTransformID }
+    }
+
+    public var normalizedDraftName: String {
+        draftName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    public var isDraftValid: Bool {
+        normalizedDraftName.isEmpty == false
+            && draftContent.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+            && nameError == nil
+            && contentError == nil
+            && shortcutError == nil
+    }
 
     public var customTransforms: [Prompt] {
         transforms.filter { !$0.isBuiltIn }
@@ -283,9 +521,6 @@ public final class TransformsViewModel {
         transforms.filter(\.isBuiltIn)
     }
 
-    /// Bindings map for the registry — `[Prompt.ID: KeyboardShortcut]`.
-    /// View layer hands this to `TransformsCoordinator.reloadBindings()`
-    /// after a save / delete / reseed.
     public var shortcutBindings: [UUID: KeyboardShortcut] {
         var bindings: [UUID: KeyboardShortcut] = [:]
         for transform in transforms {
@@ -294,5 +529,88 @@ public final class TransformsViewModel {
             }
         }
         return bindings
+    }
+
+    private var nextCustomSortOrder: Int {
+        max(200, (customTransforms.map(\.sortOrder).max() ?? 199) + 1)
+    }
+
+    private var draftPromptForRules: Prompt {
+        Prompt(
+            name: normalizedDraftName.isEmpty ? "Custom" : normalizedDraftName,
+            content: draftContent,
+            category: .transform
+        )
+    }
+
+    private func ensureSelection(force: Bool = false) {
+        if isCreatingDraft && !force { return }
+        if let selectedTransformID,
+           transforms.contains(where: { $0.id == selectedTransformID }),
+           !force {
+            return
+        }
+        guard let first = transforms.first else { return }
+        selectTransform(first)
+    }
+
+    private func loadDraft(from prompt: Prompt) {
+        draftName = prompt.name
+        draftContent = prompt.content
+        draftRunningLabel = prompt.runningLabel ?? ""
+        draftShortcut = prompt.shortcut
+        let profile = profiles[prompt.id] ?? .defaultProfile(for: prompt)
+        draftEnabledRuleIDs = profile.enabledRuleIDs
+        draftCustomInstructions = profile.customInstructions ?? ""
+        draftUseWritingSamples = profile.useWritingSamples
+        clearValidation()
+    }
+
+    private func validateName() {
+        let trimmed = normalizedDraftName
+        if trimmed.isEmpty {
+            nameError = "Give your Transform a name."
+            return
+        }
+        let editingID = isCreatingDraft ? nil : selectedTransformID
+        let duplicate = transforms.contains { other in
+            other.id != editingID
+                && other.name.caseInsensitiveCompare(trimmed) == .orderedSame
+        }
+        nameError = duplicate ? "Another Transform already uses this name." : nil
+    }
+
+    private func validateContent() {
+        let trimmed = draftContent.trimmingCharacters(in: .whitespacesAndNewlines)
+        contentError = trimmed.isEmpty ? "Give your Transform a prompt to run on the selected text." : nil
+    }
+
+    private func validateShortcut(
+        reservedHotkeys: [TransformShortcutReservedHotkey],
+        collisionChecker: TransformShortcutCollisionChecking
+    ) {
+        guard let candidate = draftShortcut else {
+            shortcutError = nil
+            return
+        }
+        let editingID = isCreatingDraft ? nil : selectedTransformID
+        let bindings: [UUID: KeyboardShortcut] = Dictionary(uniqueKeysWithValues:
+            transforms.compactMap { prompt in
+                guard let shortcut = prompt.shortcut else { return nil }
+                return (prompt.id, shortcut)
+            }
+        )
+        shortcutError = collisionChecker.checkForEditor(
+            candidate: candidate,
+            existing: bindings,
+            excludingPromptID: editingID,
+            reservedHotkeys: reservedHotkeys
+        )?.message
+    }
+
+    private func clearValidation() {
+        nameError = nil
+        contentError = nil
+        shortcutError = nil
     }
 }

--- a/Tests/MacParakeetTests/Database/TransformHistoryRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/TransformHistoryRepositoryTests.swift
@@ -134,4 +134,50 @@ final class TransformHistoryRepositoryTests: XCTestCase {
         try repo.deleteAll()
         XCTAssertEqual(try repo.count(), 0)
     }
+
+    func testDeleteAllForTransformOnlyRemovesMatchingRows() throws {
+        let polishID = UUID(uuidString: "0FCE9DDB-7E2D-4B1A-AE3E-6F7C9B2A4D11")!
+        let distillID = UUID(uuidString: "1AD7C2B0-9C6F-4F0E-9C39-5E4D1F1D2A55")!
+        try repo.save(
+            TransformHistoryEntry(
+                transformId: polishID,
+                transformName: "Polish",
+                inputText: "one",
+                outputText: "One.",
+                capturePath: "ax",
+                replacementPath: "ax",
+                llmElapsedMs: 1,
+                totalElapsedMs: 2
+            )
+        )
+        try repo.save(
+            TransformHistoryEntry(
+                transformId: polishID,
+                transformName: "Polish",
+                inputText: "two",
+                outputText: "Two.",
+                capturePath: "clipboard",
+                replacementPath: "clipboardPaste",
+                llmElapsedMs: 3,
+                totalElapsedMs: 4
+            )
+        )
+        try repo.save(
+            TransformHistoryEntry(
+                transformId: distillID,
+                transformName: "Distill",
+                inputText: "three",
+                outputText: "Three.",
+                capturePath: "ax",
+                replacementPath: "ax",
+                llmElapsedMs: 5,
+                totalElapsedMs: 6
+            )
+        )
+
+        try repo.deleteAll(transformId: polishID)
+
+        XCTAssertEqual(try repo.fetchRecent(limit: 10).map(\.transformName), ["Distill"])
+        XCTAssertEqual(try repo.count(), 1)
+    }
 }

--- a/Tests/MacParakeetTests/Database/TransformProfileRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/TransformProfileRepositoryTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class TransformProfileRepositoryTests: XCTestCase {
+    var repo: TransformProfileRepository!
+
+    override func setUp() async throws {
+        let manager = try DatabaseManager()
+        repo = TransformProfileRepository(dbQueue: manager.dbQueue)
+    }
+
+    func testSaveFetchAndUpdateProfile() throws {
+        let polish = Prompt.builtInPrompts().first(where: { $0.name == "Polish" })!
+        let now = Date(timeIntervalSince1970: 100)
+        var profile = TransformProfile.defaultProfile(for: polish, now: now)
+
+        try repo.save(profile)
+
+        var fetched = try XCTUnwrap(repo.fetch(promptId: polish.id))
+        XCTAssertTrue(fetched.enabledRuleIDs.contains("polish.concise"))
+        XCTAssertTrue(fetched.enabledRuleIDs.contains("polish.tone"))
+        XCTAssertFalse(fetched.useWritingSamples)
+        XCTAssertEqual(fetched.createdAt, now)
+
+        profile.setEnabledRuleIDs(["polish.tone"])
+        profile.customInstructions = "Keep contractions."
+        profile.useWritingSamples = true
+        try repo.save(profile)
+
+        fetched = try XCTUnwrap(repo.fetch(promptId: polish.id))
+        XCTAssertEqual(fetched.enabledRuleIDs, ["polish.tone"])
+        XCTAssertEqual(fetched.customInstructions, "Keep contractions.")
+        XCTAssertTrue(fetched.useWritingSamples)
+        XCTAssertEqual(try repo.fetchAll().count, 1)
+    }
+
+    func testDeleteProfile() throws {
+        let promptID = UUID()
+        let profile = TransformProfile(
+            promptId: promptID,
+            enabledRuleIDsJSON: "[\"custom.facts\"]"
+        )
+        try repo.save(profile)
+
+        XCTAssertTrue(try repo.delete(promptId: promptID))
+        XCTAssertNil(try repo.fetch(promptId: promptID))
+        XCTAssertFalse(try repo.delete(promptId: promptID))
+    }
+}

--- a/Tests/MacParakeetTests/Database/WritingSampleRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/WritingSampleRepositoryTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class WritingSampleRepositoryTests: XCTestCase {
+    var repo: WritingSampleRepository!
+
+    override func setUp() async throws {
+        let manager = try DatabaseManager()
+        repo = WritingSampleRepository(dbQueue: manager.dbQueue)
+    }
+
+    func testWordCountIsDerivedFromText() {
+        let sample = WritingSample(title: "Email", text: "One two\nthree   four")
+        XCTAssertEqual(sample.wordCount, 4)
+    }
+
+    func testSaveFetchAndOrderWritingSamples() throws {
+        let older = WritingSample(
+            id: UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")!,
+            title: "Older",
+            text: "old sample",
+            createdAt: Date(timeIntervalSince1970: 10),
+            updatedAt: Date(timeIntervalSince1970: 10)
+        )
+        let newestB = WritingSample(
+            id: UUID(uuidString: "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB")!,
+            title: "Beta",
+            text: "new beta",
+            createdAt: Date(timeIntervalSince1970: 20),
+            updatedAt: Date(timeIntervalSince1970: 30)
+        )
+        let newestA = WritingSample(
+            id: UUID(uuidString: "CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC")!,
+            title: "Alpha",
+            text: "new alpha",
+            createdAt: Date(timeIntervalSince1970: 20),
+            updatedAt: Date(timeIntervalSince1970: 30)
+        )
+
+        try repo.save(older)
+        try repo.save(newestB)
+        try repo.save(newestA)
+
+        XCTAssertEqual(try repo.fetch(id: newestA.id)?.title, "Alpha")
+        XCTAssertEqual(try repo.fetchAll().map(\.title), ["Alpha", "Beta", "Older"])
+    }
+
+    func testDeleteOneAndDeleteAll() throws {
+        let first = WritingSample(title: "First", text: "one")
+        let second = WritingSample(title: "Second", text: "two")
+        try repo.save(first)
+        try repo.save(second)
+
+        XCTAssertTrue(try repo.delete(id: first.id))
+        XCTAssertEqual(try repo.fetchAll().map(\.id), [second.id])
+
+        try repo.deleteAll()
+        XCTAssertTrue(try repo.fetchAll().isEmpty)
+    }
+}

--- a/Tests/MacParakeetTests/Hotkey/TransformsHotkeyRegistryTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/TransformsHotkeyRegistryTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import MacParakeet
 @testable import MacParakeetCore
+@testable import MacParakeetViewModels
 
 final class TransformsHotkeyRegistryTests: XCTestCase {
 
@@ -129,6 +130,10 @@ final class TransformsHotkeyRegistryTests: XCTestCase {
 
     private let checker = TransformsHotkeyCollisionChecker()
 
+    private func reserved(_ name: String, _ trigger: HotkeyTrigger) -> TransformShortcutReservedHotkey {
+        TransformShortcutReservedHotkey(name: name, trigger: trigger)
+    }
+
     func testCollisionMissingModifierIsRejected() {
         let bareKey = KeyboardShortcut(modifiers: 0, keyCode: 0x12, keyLabel: "1")
         XCTAssertEqual(
@@ -136,8 +141,7 @@ final class TransformsHotkeyRegistryTests: XCTestCase {
                 candidate: bareKey,
                 existing: [:],
                 excludingPromptID: nil,
-                dictationHotkeys: [],
-                meetingHotkey: nil
+                reservedHotkeys: []
             ),
             .missingModifier
         )
@@ -154,8 +158,7 @@ final class TransformsHotkeyRegistryTests: XCTestCase {
                 candidate: optE,
                 existing: [:],
                 excludingPromptID: nil,
-                dictationHotkeys: [],
-                meetingHotkey: nil
+                reservedHotkeys: []
             ),
             .macOSDeadKey
         )
@@ -172,8 +175,7 @@ final class TransformsHotkeyRegistryTests: XCTestCase {
             candidate: opt1,
             existing: [otherID: opt1],
             excludingPromptID: nil,
-            dictationHotkeys: [],
-            meetingHotkey: nil
+                reservedHotkeys: []
         )
         XCTAssertEqual(result, .duplicateTransform(otherPromptID: otherID))
     }
@@ -192,8 +194,7 @@ final class TransformsHotkeyRegistryTests: XCTestCase {
                 candidate: opt1,
                 existing: [selfID: opt1],
                 excludingPromptID: selfID,
-                dictationHotkeys: [],
-                meetingHotkey: nil
+                reservedHotkeys: []
             )
         )
     }
@@ -209,10 +210,9 @@ final class TransformsHotkeyRegistryTests: XCTestCase {
                 candidate: opt1,
                 existing: [:],
                 excludingPromptID: nil,
-                dictationHotkeys: [opt1.hotkeyTrigger],
-                meetingHotkey: nil
+                reservedHotkeys: [reserved("Dictation", opt1.hotkeyTrigger)]
             ),
-            .dictationHotkey
+            .reservedHotkey(name: "Dictation", shortcut: opt1.hotkeyTrigger.formattedLabel)
         )
     }
 
@@ -227,10 +227,9 @@ final class TransformsHotkeyRegistryTests: XCTestCase {
                 candidate: opt1,
                 existing: [:],
                 excludingPromptID: nil,
-                dictationHotkeys: [.option],
-                meetingHotkey: nil
+                reservedHotkeys: [reserved("Dictation", .option)]
             ),
-            .dictationHotkey
+            .reservedHotkey(name: "Dictation", shortcut: HotkeyTrigger.option.formattedLabel)
         )
     }
 
@@ -245,11 +244,10 @@ final class TransformsHotkeyRegistryTests: XCTestCase {
                 candidate: opt4,
                 existing: [:],
                 excludingPromptID: nil,
-                dictationHotkeys: [
-                    .fn,
-                    .modifierChord(modifiers: ["option", "command"]),
-                ],
-                meetingHotkey: nil
+                reservedHotkeys: [
+                    reserved("Dictation", .fn),
+                    reserved("Push-to-talk", .modifierChord(modifiers: ["option", "command"])),
+                ]
             )
         )
     }
@@ -265,10 +263,9 @@ final class TransformsHotkeyRegistryTests: XCTestCase {
                 candidate: opt1,
                 existing: [:],
                 excludingPromptID: nil,
-                dictationHotkeys: [],
-                meetingHotkey: opt1.hotkeyTrigger
+                reservedHotkeys: [reserved("Meeting recording", opt1.hotkeyTrigger)]
             ),
-            .meetingHotkey
+            .reservedHotkey(name: "Meeting recording", shortcut: opt1.hotkeyTrigger.formattedLabel)
         )
     }
 
@@ -288,8 +285,7 @@ final class TransformsHotkeyRegistryTests: XCTestCase {
                 candidate: opt2,
                 existing: [UUID(): opt1],
                 excludingPromptID: nil,
-                dictationHotkeys: [],
-                meetingHotkey: nil
+                reservedHotkeys: []
             )
         )
     }
@@ -303,8 +299,7 @@ final class TransformsHotkeyRegistryTests: XCTestCase {
             candidate: bare,
             existing: [UUID(): bare],
             excludingPromptID: nil,
-            dictationHotkeys: [],
-            meetingHotkey: nil
+                reservedHotkeys: []
         )
         XCTAssertEqual(result, .missingModifier)
     }

--- a/Tests/MacParakeetTests/Services/TransformPromptAssemblerTests.swift
+++ b/Tests/MacParakeetTests/Services/TransformPromptAssemblerTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class TransformPromptAssemblerTests: XCTestCase {
+    func testAssembleIncludesEnabledRulesAndCustomInstructions() {
+        let polish = Prompt.builtInPrompts().first(where: { $0.name == "Polish" })!
+        var profile = TransformProfile.defaultProfile(for: polish)
+        profile.setEnabledRuleIDs(["polish.concise", "polish.tone"])
+        profile.customInstructions = "Keep contractions and do not add exclamation points."
+
+        let assembled = TransformPromptAssembler.assemble(
+            prompt: polish,
+            profile: profile,
+            writingSamples: []
+        )
+
+        XCTAssertTrue(assembled.contains(polish.content))
+        XCTAssertTrue(assembled.contains("Make the output more concise"))
+        XCTAssertTrue(assembled.contains("Preserve the author's register"))
+        XCTAssertFalse(assembled.contains("Reword unclear phrases"))
+        XCTAssertTrue(assembled.contains("Keep contractions and do not add exclamation points."))
+        XCTAssertTrue(assembled.hasSuffix("Return only the transformed text."))
+    }
+
+    func testAssembleUsesWritingSamplesOnlyWhenEnabled() {
+        let prompt = Prompt(name: "Custom", content: "Rewrite the selected text.", category: .transform)
+        let sample = WritingSample(title: "Email", text: "This is how I write in email.")
+
+        var disabled = TransformProfile.defaultProfile(for: prompt)
+        disabled.useWritingSamples = false
+        XCTAssertFalse(
+            TransformPromptAssembler
+                .assemble(prompt: prompt, profile: disabled, writingSamples: [sample])
+                .contains("Voice reference samples")
+        )
+
+        var enabled = disabled
+        enabled.useWritingSamples = true
+        let assembled = TransformPromptAssembler.assemble(
+            prompt: prompt,
+            profile: enabled,
+            writingSamples: [sample]
+        )
+
+        XCTAssertTrue(assembled.contains("Voice reference samples"))
+        XCTAssertTrue(assembled.contains("Email"))
+        XCTAssertTrue(assembled.contains("This is how I write in email."))
+    }
+
+    func testAssembleLimitsWritingSamples() {
+        let prompt = Prompt(name: "Custom", content: "Rewrite.", category: .transform)
+        var profile = TransformProfile.defaultProfile(for: prompt)
+        profile.useWritingSamples = true
+        let longText = String(repeating: "a", count: 1_600)
+        let samples = [
+            WritingSample(title: "One", text: longText),
+            WritingSample(title: "Two", text: "two"),
+            WritingSample(title: "Three", text: "three"),
+            WritingSample(title: "Four", text: "four"),
+        ]
+
+        let assembled = TransformPromptAssembler.assemble(
+            prompt: prompt,
+            profile: profile,
+            writingSamples: samples
+        )
+
+        XCTAssertTrue(assembled.contains("One"))
+        XCTAssertTrue(assembled.contains("two"))
+        XCTAssertTrue(assembled.contains("three"))
+        XCTAssertFalse(assembled.contains("four"))
+        XCTAssertTrue(assembled.contains(String(repeating: "a", count: 1_500)))
+        XCTAssertFalse(assembled.contains(String(repeating: "a", count: 1_501)))
+    }
+}

--- a/Tests/MacParakeetTests/ViewModels/TransformEditorViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TransformEditorViewModelTests.swift
@@ -7,17 +7,14 @@ final class TransformEditorViewModelTests: XCTestCase {
 
     private final class StubCollisionChecker: TransformShortcutCollisionChecking {
         var result: TransformShortcutCollision?
-        var receivedDictationHotkeys: [HotkeyTrigger]?
-        var receivedMeetingHotkey: HotkeyTrigger?
+        var receivedReservedHotkeys: [TransformShortcutReservedHotkey]?
         func checkForEditor(
             candidate: KeyboardShortcut,
             existing: [UUID: KeyboardShortcut],
             excludingPromptID: UUID?,
-            dictationHotkeys: [HotkeyTrigger],
-            meetingHotkey: HotkeyTrigger?
+            reservedHotkeys: [TransformShortcutReservedHotkey]
         ) -> TransformShortcutCollision? {
-            receivedDictationHotkeys = dictationHotkeys
-            receivedMeetingHotkey = meetingHotkey
+            receivedReservedHotkeys = reservedHotkeys
             return result
         }
     }
@@ -72,8 +69,7 @@ final class TransformEditorViewModelTests: XCTestCase {
         vm.content = "Some body."
         vm.validate(
             existingTransforms: [],
-            dictationHotkeys: [],
-            meetingHotkey: nil,
+            reservedHotkeys: [],
             collisionChecker: StubCollisionChecker()
         )
         XCTAssertNotNil(vm.nameError)
@@ -85,8 +81,7 @@ final class TransformEditorViewModelTests: XCTestCase {
         vm.name = "Sharpen"
         vm.validate(
             existingTransforms: [],
-            dictationHotkeys: [],
-            meetingHotkey: nil,
+            reservedHotkeys: [],
             collisionChecker: StubCollisionChecker()
         )
         XCTAssertNotNil(vm.contentError)
@@ -105,8 +100,7 @@ final class TransformEditorViewModelTests: XCTestCase {
         vm.content = "Body"
         vm.validate(
             existingTransforms: [other],
-            dictationHotkeys: [],
-            meetingHotkey: nil,
+            reservedHotkeys: [],
             collisionChecker: StubCollisionChecker()
         )
         XCTAssertNotNil(vm.nameError)
@@ -123,8 +117,7 @@ final class TransformEditorViewModelTests: XCTestCase {
         let vm = TransformEditorViewModel(mode: .edit(prompt))
         vm.validate(
             existingTransforms: [prompt],
-            dictationHotkeys: [],
-            meetingHotkey: nil,
+            reservedHotkeys: [],
             collisionChecker: StubCollisionChecker()
         )
         XCTAssertNil(vm.nameError, "Editing the same Transform with its existing name should not read as duplicate.")
@@ -140,8 +133,7 @@ final class TransformEditorViewModelTests: XCTestCase {
         vm.shortcut = KeyboardShortcut(modifiers: 0, keyCode: 0x12, keyLabel: "1")
         vm.validate(
             existingTransforms: [],
-            dictationHotkeys: [],
-            meetingHotkey: nil,
+            reservedHotkeys: [],
             collisionChecker: stub
         )
         XCTAssertNotNil(vm.shortcutError)
@@ -155,15 +147,18 @@ final class TransformEditorViewModelTests: XCTestCase {
         vm.name = "Sharpen"
         vm.content = "Body"
         vm.shortcut = opt1
+        let reserved = [
+            TransformShortcutReservedHotkey(name: "Dictation", trigger: .fn),
+            TransformShortcutReservedHotkey(name: "Push-to-talk", trigger: .option),
+            TransformShortcutReservedHotkey(name: "Meeting recording", trigger: .defaultMeetingRecording),
+        ]
         vm.validate(
             existingTransforms: [],
-            dictationHotkeys: [.fn, .option],
-            meetingHotkey: .defaultMeetingRecording,
+            reservedHotkeys: reserved,
             collisionChecker: stub
         )
 
-        XCTAssertEqual(stub.receivedDictationHotkeys, [.fn, .option])
-        XCTAssertEqual(stub.receivedMeetingHotkey, .defaultMeetingRecording)
+        XCTAssertEqual(stub.receivedReservedHotkeys, reserved)
     }
 
     func testNilShortcutIsValidDormantState() {
@@ -173,8 +168,7 @@ final class TransformEditorViewModelTests: XCTestCase {
         vm.shortcut = nil
         vm.validate(
             existingTransforms: [],
-            dictationHotkeys: [],
-            meetingHotkey: nil,
+            reservedHotkeys: [],
             collisionChecker: StubCollisionChecker()
         )
         XCTAssertNil(vm.shortcutError)
@@ -190,8 +184,7 @@ final class TransformEditorViewModelTests: XCTestCase {
         vm.content = ""
         vm.validate(
             existingTransforms: [],
-            dictationHotkeys: [],
-            meetingHotkey: nil,
+            reservedHotkeys: [],
             collisionChecker: StubCollisionChecker()
         )
         XCTAssertNil(vm.buildSavable())
@@ -205,8 +198,7 @@ final class TransformEditorViewModelTests: XCTestCase {
         vm.shortcut = opt1
         vm.validate(
             existingTransforms: [],
-            dictationHotkeys: [],
-            meetingHotkey: nil,
+            reservedHotkeys: [],
             collisionChecker: StubCollisionChecker()
         )
         let saved = vm.buildSavable()
@@ -235,8 +227,7 @@ final class TransformEditorViewModelTests: XCTestCase {
         vm.content = "New body"
         vm.validate(
             existingTransforms: [],
-            dictationHotkeys: [],
-            meetingHotkey: nil,
+            reservedHotkeys: [],
             collisionChecker: StubCollisionChecker()
         )
         let saved = vm.buildSavable()
@@ -253,8 +244,7 @@ final class TransformEditorViewModelTests: XCTestCase {
         vm.runningLabel = "   " // whitespace only
         vm.validate(
             existingTransforms: [],
-            dictationHotkeys: [],
-            meetingHotkey: nil,
+            reservedHotkeys: [],
             collisionChecker: StubCollisionChecker()
         )
         XCTAssertNil(vm.buildSavable()?.runningLabel, "Whitespace-only running label normalizes to nil.")

--- a/Tests/MacParakeetTests/ViewModels/TransformsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TransformsViewModelTests.swift
@@ -123,6 +123,39 @@ final class TransformsViewModelTests: XCTestCase {
         XCTAssertTrue(saved.useWritingSamples)
     }
 
+    func testDraftDirtyTracksPromptAndProfileChanges() throws {
+        let polish = viewModel.transforms.first(where: { $0.name == "Polish" })!
+        viewModel.selectTransform(polish)
+
+        XCTAssertFalse(viewModel.isDraftDirty)
+
+        viewModel.draftCustomInstructions = "Keep it direct."
+        XCTAssertTrue(viewModel.isDraftDirty)
+
+        XCTAssertTrue(
+            viewModel.saveDraft(
+                reservedHotkeys: [],
+                collisionChecker: StubCollisionChecker()
+            )
+        )
+        XCTAssertFalse(viewModel.isDraftDirty)
+
+        viewModel.draftName = "Polish better"
+        XCTAssertTrue(viewModel.isDraftDirty)
+    }
+
+    func testDraftDirtyComparesDecodedShortcutValue() throws {
+        var polish = viewModel.transforms.first(where: { $0.name == "Polish" })!
+        polish.keyboardShortcut = #"{"keyLabel":"1","modifiers":524288,"keyCode":18}"#
+        try repo.save(polish)
+        viewModel.load()
+        let reloaded = viewModel.transforms.first(where: { $0.name == "Polish" })!
+
+        viewModel.selectTransform(reloaded)
+
+        XCTAssertFalse(viewModel.isDraftDirty)
+    }
+
     func testDeleteCustomTransformRemovesRow() {
         let prompt = Prompt(
             id: UUID(),
@@ -342,6 +375,50 @@ final class TransformsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.history.isEmpty)
         XCTAssertEqual(viewModel.totalHistoryCount, 0)
         XCTAssertEqual(try historyRepo.count(), 0)
+    }
+
+    func testClearSelectedHistoryPreservesOtherTransforms() async throws {
+        let polish = viewModel.transforms.first(where: { $0.name == "Polish" })!
+        let distill = viewModel.transforms.first(where: { $0.name == "Distill" })!
+        for index in 0..<205 {
+            try historyRepo.save(
+                TransformHistoryEntry(
+                    transformId: polish.id,
+                    transformName: "Polish",
+                    inputText: "rough \(index)",
+                    outputText: "polished \(index)",
+                    capturePath: "ax",
+                    replacementPath: "ax",
+                    llmElapsedMs: 1,
+                    totalElapsedMs: 2,
+                    createdAt: Date(timeIntervalSince1970: TimeInterval(index)),
+                    updatedAt: Date(timeIntervalSince1970: TimeInterval(index))
+                )
+            )
+        }
+        try historyRepo.save(
+            TransformHistoryEntry(
+                transformId: distill.id,
+                transformName: "Distill",
+                inputText: "long",
+                outputText: "short",
+                capturePath: "clipboard",
+                replacementPath: "clipboardPaste",
+                llmElapsedMs: 3,
+                totalElapsedMs: 4,
+                createdAt: Date(timeIntervalSince1970: 1_000),
+                updatedAt: Date(timeIntervalSince1970: 1_000)
+            )
+        )
+        viewModel.selectTransform(polish)
+        await viewModel.loadHistory()
+
+        await viewModel.clearSelectedHistory()
+
+        XCTAssertTrue(viewModel.selectedHistory.isEmpty)
+        XCTAssertEqual(viewModel.history.map(\.transformName), ["Distill"])
+        XCTAssertEqual(viewModel.totalHistoryCount, 1)
+        XCTAssertEqual(try historyRepo.count(), 1)
     }
 
     func testCopyHistoryOutputUsesInjectedClipboardService() async {

--- a/Tests/MacParakeetTests/ViewModels/TransformsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TransformsViewModelTests.swift
@@ -4,22 +4,41 @@ import XCTest
 
 @MainActor
 final class TransformsViewModelTests: XCTestCase {
+    private final class StubCollisionChecker: TransformShortcutCollisionChecking {
+        var result: TransformShortcutCollision?
+
+        func checkForEditor(
+            candidate: KeyboardShortcut,
+            existing: [UUID: KeyboardShortcut],
+            excludingPromptID: UUID?,
+            reservedHotkeys: [TransformShortcutReservedHotkey]
+        ) -> TransformShortcutCollision? {
+            result
+        }
+    }
+
     var manager: DatabaseManager!
     var repo: PromptRepository!
+    var profileRepo: TransformProfileRepository!
     var historyRepo: TransformHistoryRepository!
     var clipboardService: MockClipboardService!
+    var writingSampleRepo: WritingSampleRepository!
     var viewModel: TransformsViewModel!
 
     override func setUp() async throws {
         manager = try DatabaseManager()
         repo = PromptRepository(dbQueue: manager.dbQueue)
+        profileRepo = TransformProfileRepository(dbQueue: manager.dbQueue)
         historyRepo = TransformHistoryRepository(dbQueue: manager.dbQueue)
         clipboardService = MockClipboardService()
+        writingSampleRepo = WritingSampleRepository(dbQueue: manager.dbQueue)
         viewModel = TransformsViewModel()
         viewModel.configure(
             repo: repo,
+            profileRepo: profileRepo,
             historyRepo: historyRepo,
             clipboardService: clipboardService,
+            writingSampleRepo: writingSampleRepo,
             hasLLMProvider: true
         )
     }
@@ -58,6 +77,50 @@ final class TransformsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.save(prompt))
         XCTAssertEqual(viewModel.transforms.count, 4)
         XCTAssertTrue(viewModel.customTransforms.contains(where: { $0.name == "Soften" }))
+    }
+
+    func testConfigureLoadsPersistedProfileIntoSelectedDraft() throws {
+        let polish = viewModel.transforms.first(where: { $0.name == "Polish" })!
+        var profile = TransformProfile.defaultProfile(for: polish)
+        profile.setEnabledRuleIDs(["polish.tone"])
+        profile.customInstructions = "Use contractions."
+        profile.useWritingSamples = true
+        try profileRepo.save(profile)
+
+        let fresh = TransformsViewModel()
+        fresh.configure(
+            repo: repo,
+            profileRepo: profileRepo,
+            historyRepo: historyRepo,
+            clipboardService: clipboardService,
+            writingSampleRepo: writingSampleRepo,
+            hasLLMProvider: true
+        )
+
+        XCTAssertEqual(fresh.selectedTransformID, polish.id)
+        XCTAssertEqual(fresh.draftEnabledRuleIDs, ["polish.tone"])
+        XCTAssertEqual(fresh.draftCustomInstructions, "Use contractions.")
+        XCTAssertTrue(fresh.draftUseWritingSamples)
+    }
+
+    func testSaveDraftPersistsProfileSettings() throws {
+        let polish = viewModel.transforms.first(where: { $0.name == "Polish" })!
+        viewModel.selectTransform(polish)
+        viewModel.draftEnabledRuleIDs = ["polish.concise", "polish.tone"]
+        viewModel.draftCustomInstructions = "Keep the user's punctuation style."
+        viewModel.draftUseWritingSamples = true
+
+        XCTAssertTrue(
+            viewModel.saveDraft(
+                reservedHotkeys: [],
+                collisionChecker: StubCollisionChecker()
+            )
+        )
+
+        let saved = try XCTUnwrap(profileRepo.fetch(promptId: polish.id))
+        XCTAssertEqual(saved.enabledRuleIDs, ["polish.concise", "polish.tone"])
+        XCTAssertEqual(saved.customInstructions, "Keep the user's punctuation style.")
+        XCTAssertTrue(saved.useWritingSamples)
     }
 
     func testDeleteCustomTransformRemovesRow() {
@@ -208,6 +271,44 @@ final class TransformsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.totalHistoryCount, 205)
     }
 
+    func testSelectedHistoryFiltersToSelectedTransform() async throws {
+        let polish = viewModel.transforms.first(where: { $0.name == "Polish" })!
+        let distill = viewModel.transforms.first(where: { $0.name == "Distill" })!
+        try historyRepo.save(
+            TransformHistoryEntry(
+                transformId: polish.id,
+                transformName: "Polish",
+                inputText: "rough",
+                outputText: "polished",
+                capturePath: "ax",
+                replacementPath: "ax",
+                llmElapsedMs: 1,
+                totalElapsedMs: 2,
+                createdAt: Date(timeIntervalSince1970: 10),
+                updatedAt: Date(timeIntervalSince1970: 10)
+            )
+        )
+        try historyRepo.save(
+            TransformHistoryEntry(
+                transformId: distill.id,
+                transformName: "Distill",
+                inputText: "long",
+                outputText: "short",
+                capturePath: "clipboard",
+                replacementPath: "clipboardPaste",
+                llmElapsedMs: 3,
+                totalElapsedMs: 4,
+                createdAt: Date(timeIntervalSince1970: 20),
+                updatedAt: Date(timeIntervalSince1970: 20)
+            )
+        )
+
+        viewModel.selectTransform(polish)
+        await viewModel.loadHistory()
+
+        XCTAssertEqual(viewModel.selectedHistory.map(\.transformName), ["Polish"])
+    }
+
     func testDeleteAndClearHistory() async throws {
         let first = TransformHistoryEntry(
             transformName: "Polish",
@@ -259,5 +360,33 @@ final class TransformsViewModelTests: XCTestCase {
         let copiedText = await clipboardService.lastCopiedText
         XCTAssertEqual(copiedText, "polished")
         XCTAssertEqual(viewModel.copiedHistoryEntryID, entry.id)
+    }
+
+    func testSaveWritingSampleRejectsShortSample() throws {
+        viewModel.writingSampleTitle = "Short"
+        viewModel.writingSampleText = "Too short."
+
+        XCTAssertFalse(viewModel.saveWritingSample())
+        XCTAssertTrue(viewModel.writingSamples.isEmpty)
+        XCTAssertTrue(try writingSampleRepo.fetchAll().isEmpty)
+        XCTAssertEqual(
+            viewModel.writingSampleErrorMessage,
+            "Add at least 50 words so MacParakeet can learn from the sample."
+        )
+    }
+
+    func testSaveWritingSamplePersistsValidSample() throws {
+        viewModel.writingSampleTitle = "Launch email"
+        viewModel.writingSampleText = (1...50).map { "word\($0)" }.joined(separator: " ")
+        viewModel.isAddingWritingSample = true
+
+        XCTAssertTrue(viewModel.saveWritingSample())
+
+        let saved = try XCTUnwrap(writingSampleRepo.fetchAll().first)
+        XCTAssertEqual(saved.title, "Launch email")
+        XCTAssertEqual(saved.wordCount, 50)
+        XCTAssertEqual(viewModel.writingSamples.map(\.id), [saved.id])
+        XCTAssertFalse(viewModel.isAddingWritingSample)
+        XCTAssertNil(viewModel.writingSampleErrorMessage)
     }
 }


### PR DESCRIPTION
## Summary
- Replaces the modal Transform editor with a persistent workbench for shortcuts, structured rules, prompt customization, writing samples, and recent local runs.
- Adds local Transform profiles, writing samples, and prompt assembly that combines enabled rules, custom instructions, and selected writing samples.
- Improves trust and polish: precise reserved-hotkey conflict labels, explicit unsaved-change state, scoped Clear Runs history deletion, clearer restore copy, and writing-sample word-count gating.

## Testing
- swift test --filter 'TransformHistoryRepositoryTests|TransformsViewModelTests|TransformEditorViewModelTests|TransformsHotkeyRegistryTests|TransformProfileRepositoryTests|WritingSampleRepositoryTests|TransformPromptAssemblerTests'
- swift test
- scripts/dev/run_app.sh

## Notes
Stacked on #283. After #283 merges, retarget or rebase this branch onto main.