### PR TITLE
Harden Transform post-merge audit findings

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -102,10 +102,11 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
     bindings (must include a modifier).
   - `transforms delete <id|name> [--json]` — deletes a custom
     Transform. Built-ins are protected.
-  - All `--json` outputs use a snake-cased `TransformDTO` envelope
-    (`id`, `name`, `shortcut`, `running_label`, `is_built_in`,
-    `prompt`, `created_at`, `updated_at`) — consumers don't see the
-    internal `Prompt` shape.
+  - `list`, `show`, and `create --json` emit snake-cased
+    `TransformDTO` objects (`id`, `name`, `shortcut`, `running_label`,
+    `is_built_in`, `prompt`, `created_at`, `updated_at`) so consumers
+    don't see the internal `Prompt` shape. `run --json` emits the LLM
+    result envelope, and `delete --json` emits `{deleted,id,name}`.
 - `transforms history list / show / delete / clear` — new local Transform
   history surface for testing and recovering saved GUI Transform runs.
   - `transforms history [list] [--limit N] [--json]` — lists local

--- a/Sources/CLI/Commands/CLIHelpers.swift
+++ b/Sources/CLI/Commands/CLIHelpers.swift
@@ -293,6 +293,7 @@ enum CLIErrorType {
             case .notFound, .ambiguous:
                 return lookup
             case .duplicateName,
+                 .prefixTooShort,
                  .invalidShortcut,
                  .shortcutMissingModifier,
                  .shortcutMacOSDeadKey,

--- a/Sources/CLI/Commands/TransformsCommand.swift
+++ b/Sources/CLI/Commands/TransformsCommand.swift
@@ -534,26 +534,59 @@ extension TransformsCommand {
 
 // MARK: - Lookup helper
 
+private let transformIDPrefixMinimumLength = 4
+
 private func findTransform(idOrName: String, repo: PromptRepository) throws -> Prompt {
+    let query = idOrName.trimmingCharacters(in: .whitespacesAndNewlines)
     let all = try repo.fetchVisible(category: .transform)
     // Exact UUID match
-    if let uuid = UUID(uuidString: idOrName), let match = all.first(where: { $0.id == uuid }) {
+    if let uuid = UUID(uuidString: query), let match = all.first(where: { $0.id == uuid }) {
         return match
     }
-    // ID prefix
-    let prefix = idOrName.lowercased()
-    let prefixMatches = all.filter { $0.id.uuidString.lowercased().hasPrefix(prefix) }
-    if prefixMatches.count == 1 {
-        return prefixMatches[0]
+    // Case-insensitive name match. Names win over UUID prefixes so a custom
+    // Transform named "a" cannot be mistaken for an ID prefix.
+    let nameMatches = all.filter { $0.name.caseInsensitiveCompare(query) == .orderedSame }
+    if nameMatches.count == 1 {
+        return nameMatches[0]
     }
-    if prefixMatches.count > 1 {
-        throw CLITransformsError.ambiguous(idOrName, prefixMatches.map(\.name))
+    if nameMatches.count > 1 {
+        throw CLITransformsError.ambiguous(query, nameMatches.map(\.name))
     }
-    // Case-insensitive name match
-    if let nameMatch = all.first(where: { $0.name.caseInsensitiveCompare(idOrName) == .orderedSame }) {
-        return nameMatch
+    // ID prefix. Only UUID-looking input participates, and short prefixes are
+    // rejected instead of silently matching the first visible Transform.
+    if let normalizedPrefix = normalizedUUIDPrefix(query) {
+        guard normalizedPrefix.count >= transformIDPrefixMinimumLength else {
+            throw CLITransformsError.prefixTooShort(
+                min: transformIDPrefixMinimumLength,
+                provided: query
+            )
+        }
+        let prefixMatches = all.filter {
+            $0.id.uuidString
+                .lowercased()
+                .replacingOccurrences(of: "-", with: "")
+                .hasPrefix(normalizedPrefix)
+        }
+        if prefixMatches.count == 1 {
+            return prefixMatches[0]
+        }
+        if prefixMatches.count > 1 {
+            throw CLITransformsError.ambiguous(query, prefixMatches.map(\.name))
+        }
     }
-    throw CLITransformsError.notFound(idOrName)
+    throw CLITransformsError.notFound(query)
+}
+
+private func normalizedUUIDPrefix(_ value: String) -> String? {
+    let dash: UnicodeScalar = "-"
+    let hexCharacters = CharacterSet(charactersIn: "0123456789abcdefABCDEF")
+    var normalized = ""
+    for scalar in value.unicodeScalars {
+        if scalar == dash { continue }
+        guard hexCharacters.contains(scalar) else { return nil }
+        normalized.unicodeScalars.append(scalar)
+    }
+    return normalized.isEmpty ? nil : normalized.lowercased()
 }
 
 private func transformHistoryRepo(database: String?) throws -> TransformHistoryRepository {
@@ -718,6 +751,7 @@ struct TransformHistoryClearResult: Encodable {
 enum CLITransformsError: Error, CustomStringConvertible {
     case notFound(String)
     case ambiguous(String, [String])
+    case prefixTooShort(min: Int, provided: String)
     case duplicateName(String)
     case invalidShortcut(String)
     case shortcutMissingModifier
@@ -734,6 +768,8 @@ enum CLITransformsError: Error, CustomStringConvertible {
             return "No Transform found matching “\(q)”."
         case .ambiguous(let q, let names):
             return "“\(q)” matches multiple Transforms: \(names.joined(separator: ", ")). Use a longer ID prefix."
+        case .prefixTooShort(let min, let provided):
+            return "Transform ID prefix “\(provided)” is too short. Use at least \(min) UUID characters, or use the Transform name."
         case .duplicateName(let n):
             return "A prompt named “\(n)” already exists."
         case .invalidShortcut(let s):

--- a/Sources/MacParakeet/App/TransformsCoordinator.swift
+++ b/Sources/MacParakeet/App/TransformsCoordinator.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Foundation
 import MacParakeetCore
+import MacParakeetViewModels
 import OSLog
 
 /// Wires the productized Transforms feature to the app surface (ADR-022):
@@ -26,6 +27,7 @@ final class TransformsCoordinator {
     private let profileRepository: TransformProfileRepositoryProtocol
     private let historyRepository: TransformHistoryRepositoryProtocol
     private let writingSampleRepository: WritingSampleRepositoryProtocol
+    private let reservedHotkeysProvider: @MainActor () -> [TransformShortcutReservedHotkey]
     private let logger = Logger(subsystem: "com.macparakeet", category: "TransformsCoordinator")
 
     private var registry: TransformsHotkeyRegistry?
@@ -45,19 +47,22 @@ final class TransformsCoordinator {
     /// resolve a `KeyboardShortcut`-triggered ID back to its prompt body
     /// and running label without re-hitting the DB on every keystroke.
     private var promptIndex: [UUID: Prompt] = [:]
+    private var activeBindingIDs: Set<UUID> = []
 
     init(
         llmServiceProvider: @escaping () -> LLMServiceProtocol?,
         promptRepository: PromptRepositoryProtocol,
         profileRepository: TransformProfileRepositoryProtocol,
         historyRepository: TransformHistoryRepositoryProtocol,
-        writingSampleRepository: WritingSampleRepositoryProtocol
+        writingSampleRepository: WritingSampleRepositoryProtocol,
+        reservedHotkeysProvider: @escaping @MainActor () -> [TransformShortcutReservedHotkey] = { [] }
     ) {
         self.llmServiceProvider = llmServiceProvider
         self.promptRepository = promptRepository
         self.profileRepository = profileRepository
         self.historyRepository = historyRepository
         self.writingSampleRepository = writingSampleRepository
+        self.reservedHotkeysProvider = reservedHotkeysProvider
     }
 
     // MARK: - Lifecycle
@@ -90,7 +95,7 @@ final class TransformsCoordinator {
                     self?.reloadBindings()
                 }
             }
-            logger.notice("transforms: registry started with \(self.promptIndex.count, privacy: .public) bindings")
+            logger.notice("transforms: registry started with \(self.activeBindingIDs.count, privacy: .public) bindings")
         } else {
             logger.error("transforms: failed to install registry event tap")
         }
@@ -139,19 +144,39 @@ final class TransformsCoordinator {
 
         promptIndex = Dictionary(uniqueKeysWithValues: prompts.map { ($0.id, $0) })
 
+        let bindings = Self.validatedBindings(
+            for: prompts,
+            reservedHotkeys: reservedHotkeysProvider()
+        )
+        activeBindingIDs = Set(bindings.keys)
+        registry.replaceBindings(bindings)
+    }
+
+    nonisolated static func validatedBindings(
+        for prompts: [Prompt],
+        reservedHotkeys: [TransformShortcutReservedHotkey]
+    ) -> [UUID: KeyboardShortcut] {
+        let collisionChecker = TransformsHotkeyCollisionChecker()
         var bindings: [UUID: KeyboardShortcut] = [:]
         for prompt in prompts {
-            if let shortcut = prompt.shortcut {
-                bindings[prompt.id] = shortcut
+            guard let shortcut = prompt.shortcut else { continue }
+            guard collisionChecker.check(
+                candidate: shortcut,
+                existing: bindings,
+                excludingPromptID: nil,
+                reservedHotkeys: reservedHotkeys
+            ) == nil else {
+                continue
             }
+            bindings[prompt.id] = shortcut
         }
-        registry.replaceBindings(bindings)
+        return bindings
     }
 
     /// True when at least one Transform has a hotkey bound. Used by the
     /// Transforms tab to surface a calmer "no bindings yet" hint state.
     var hasActiveBindings: Bool {
-        promptIndex.values.contains(where: { $0.shortcut != nil })
+        !activeBindingIDs.isEmpty
     }
 
     // MARK: - Trigger handling
@@ -187,8 +212,6 @@ final class TransformsCoordinator {
 
         let runID = UUID()
         activeRunID = runID
-        let sourceApp = Self.currentSourceApp()
-
         panelController?.show(label: prompt.derivedRunningLabel)
 
         let promptBody = assembledPrompt(for: prompt)
@@ -224,15 +247,14 @@ final class TransformsCoordinator {
                 self.panelController?.done(message: "Done")
                 Telemetry.send(.transformExecuted(
                     transformName: telemetryName,
-                    capturePath: result.captureTag == "ax" ? .ax : .clipboard,
+                    capturePath: Self.telemetryCapturePath(for: result.capturePath),
                     replacePath: result.path == .ax ? .ax : .clipboardPaste,
                     llmMs: result.llmElapsedMs,
                     totalMs: result.totalElapsedMs
                 ))
                 self.saveHistory(
                     result: result,
-                    prompt: prompt,
-                    sourceApp: sourceApp
+                    prompt: prompt
                 )
                 self.logger.notice("transforms: \(runningTransformName, privacy: .public) completed")
             } catch let error as TransformExecutorError {
@@ -263,15 +285,18 @@ final class TransformsCoordinator {
         }
     }
 
-    private static func currentSourceApp() -> (bundleID: String?, name: String?) {
-        let app = NSWorkspace.shared.frontmostApplication
-        return (app?.bundleIdentifier, app?.localizedName)
+    private static func telemetryCapturePath(for path: SelectionCapturePath) -> TelemetryTransformCapturePath {
+        switch path {
+        case .ax:
+            return .ax
+        case .clipboard:
+            return .clipboard
+        }
     }
 
     private func saveHistory(
         result: TransformExecutionResult,
-        prompt: Prompt,
-        sourceApp: (bundleID: String?, name: String?)
+        prompt: Prompt
     ) {
         let now = Date()
         let entry = TransformHistoryEntry(
@@ -279,9 +304,9 @@ final class TransformsCoordinator {
             transformName: prompt.name,
             inputText: result.inputText,
             outputText: result.outputText,
-            sourceAppBundleID: sourceApp.bundleID,
-            sourceAppName: sourceApp.name,
-            capturePath: result.captureTag,
+            sourceAppBundleID: result.sourceTarget?.bundleIdentifier,
+            sourceAppName: result.sourceTarget?.localizedName,
+            capturePath: result.capturePath.rawValue,
             replacementPath: result.path.rawValue,
             llmElapsedMs: result.llmElapsedMs,
             totalElapsedMs: result.totalElapsedMs,

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -107,6 +107,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         onboardingWindowController: onboardingWindowController,
         onRefreshHotkeys: { [weak self] in
             self?.hotkeyCoordinator?.refreshAllHotkeys()
+            self?.transformsCoordinator?.reloadBindings()
             self?.menuBarCoordinator.refreshHotkeyTitle()
             self?.menuBarCoordinator.refreshMeetingHotkeyShortcut()
             self?.menuBarCoordinator.refreshTranscriptionHotkeyShortcuts()
@@ -422,7 +423,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             promptRepository: env.promptRepo,
             profileRepository: env.transformProfileRepo,
             historyRepository: env.transformHistoryRepo,
-            writingSampleRepository: env.writingSampleRepo
+            writingSampleRepository: env.writingSampleRepo,
+            reservedHotkeysProvider: { [weak self] in
+                self?.transformReservedHotkeys ?? []
+            }
         )
         transforms.start()
         transformsCoordinator = transforms
@@ -502,6 +506,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func handleHotkeyTriggerChange() {
         hotkeyCoordinator?.refreshAllHotkeys()
+        transformsCoordinator?.reloadBindings()
         menuBarCoordinator.refreshHotkeyTitle()
         menuBarCoordinator.refreshMeetingHotkeyShortcut()
     }
@@ -525,6 +530,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         hotkeyCoordinator?.refreshMeetingHotkey()
         hotkeyCoordinator?.refreshFileTranscriptionHotkey()
         hotkeyCoordinator?.refreshYouTubeTranscriptionHotkey()
+        transformsCoordinator?.reloadBindings()
         menuBarCoordinator.refreshMeetingHotkeyShortcut()
         menuBarCoordinator.refreshTranscriptionHotkeyShortcuts()
     }
@@ -553,6 +559,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 handsFree: settingsViewModel.hotkeyTrigger,
                 pushToTalk: settingsViewModel.pushToTalkHotkeyTrigger
             )
+    }
+
+    private var transformReservedHotkeys: [TransformShortcutReservedHotkey] {
+        [
+            TransformShortcutReservedHotkey(name: "Dictation", trigger: settingsViewModel.hotkeyTrigger),
+            TransformShortcutReservedHotkey(name: "Push-to-talk", trigger: settingsViewModel.pushToTalkHotkeyTrigger),
+            TransformShortcutReservedHotkey(name: "Meeting recording", trigger: settingsViewModel.meetingHotkeyTrigger),
+            TransformShortcutReservedHotkey(name: "File transcription", trigger: settingsViewModel.fileTranscriptionHotkeyTrigger),
+            TransformShortcutReservedHotkey(name: "YouTube transcription", trigger: settingsViewModel.youtubeTranscriptionHotkeyTrigger),
+        ].filter { !$0.trigger.isDisabled }
     }
 
     // MARK: - Menu Bar Icon State

--- a/Sources/MacParakeet/Views/Transforms/TransformsView.swift
+++ b/Sources/MacParakeet/Views/Transforms/TransformsView.swift
@@ -66,10 +66,11 @@ struct TransformsView: View {
                 set: { if !$0 { viewModel.pendingDeleteHistoryEntry = nil } }
             ),
             presenting: viewModel.pendingDeleteHistoryEntry
-        ) { _ in
+        ) { entry in
             Button("Delete", role: .destructive) {
+                viewModel.pendingDeleteHistoryEntry = nil
                 Task {
-                    await viewModel.confirmPendingHistoryDelete()
+                    await viewModel.deleteHistoryEntry(entry)
                 }
             }
             Button("Cancel", role: .cancel) {

--- a/Sources/MacParakeetCore/Services/System/SelectionCaptureService.swift
+++ b/Sources/MacParakeetCore/Services/System/SelectionCaptureService.swift
@@ -6,6 +6,11 @@ import OSLog
 
 // MARK: - Result Types
 
+public enum SelectionCapturePath: String, Sendable, Equatable {
+    case ax
+    case clipboard
+}
+
 /// Source of a successful selection read. Used by `TransformExecutor` to pick
 /// the right replacement path: an `.ax` capture can attempt an AX-write first,
 /// while a `.clipboard` capture must paste-back via Cmd+V.
@@ -90,10 +95,12 @@ public struct AXFocusedElement: @unchecked Sendable {
 public struct SelectionCaptureTarget: Sendable, Equatable {
     public let processIdentifier: pid_t
     public let bundleIdentifier: String
+    public let localizedName: String?
 
-    public init(processIdentifier: pid_t, bundleIdentifier: String) {
+    public init(processIdentifier: pid_t, bundleIdentifier: String, localizedName: String? = nil) {
         self.processIdentifier = processIdentifier
         self.bundleIdentifier = bundleIdentifier
+        self.localizedName = localizedName
     }
 }
 
@@ -373,7 +380,8 @@ struct SystemSelectionCaptureBackend: SelectionCaptureBackend, @unchecked Sendab
         }
         return SelectionCaptureTarget(
             processIdentifier: app.processIdentifier,
-            bundleIdentifier: bundleIdentifier
+            bundleIdentifier: bundleIdentifier,
+            localizedName: app.localizedName
         )
     }
 

--- a/Sources/MacParakeetCore/Services/Transforms/TransformExecutor.swift
+++ b/Sources/MacParakeetCore/Services/Transforms/TransformExecutor.swift
@@ -37,6 +37,8 @@ public struct TransformExecutionResult: Sendable {
     public let totalElapsedMs: Int
     public let llmElapsedMs: Int
     public let captureTag: String
+    public let capturePath: SelectionCapturePath
+    public let sourceTarget: SelectionCaptureTarget?
 
     public init(
         inputText: String,
@@ -44,7 +46,9 @@ public struct TransformExecutionResult: Sendable {
         path: SelectionReplacementPath,
         totalElapsedMs: Int,
         llmElapsedMs: Int,
-        captureTag: String
+        captureTag: String,
+        capturePath: SelectionCapturePath? = nil,
+        sourceTarget: SelectionCaptureTarget? = nil
     ) {
         self.inputText = inputText
         self.outputText = outputText
@@ -52,6 +56,8 @@ public struct TransformExecutionResult: Sendable {
         self.totalElapsedMs = totalElapsedMs
         self.llmElapsedMs = llmElapsedMs
         self.captureTag = captureTag
+        self.capturePath = capturePath ?? SelectionCapturePath(rawValue: captureTag) ?? .clipboard
+        self.sourceTarget = sourceTarget
     }
 }
 
@@ -131,6 +137,7 @@ public actor TransformExecutor {
             throw TransformExecutorError.cancelled
         }
 
+        let capturePath: SelectionCapturePath
         switch captured {
         case .empty:
             onProgress(.failed(TransformExecutorError.emptySelection.localizedDescription))
@@ -138,8 +145,10 @@ public actor TransformExecutor {
         case .failed(let error):
             onProgress(.failed(error.localizedDescription))
             throw TransformExecutorError.captureFailed(error)
-        default:
-            break
+        case .ax:
+            capturePath = .ax
+        case .clipboard:
+            capturePath = .clipboard
         }
 
         guard let inputText = captured.capturedText, !inputText.isEmpty else {
@@ -229,7 +238,9 @@ public actor TransformExecutor {
             path: path,
             totalElapsedMs: totalMs,
             llmElapsedMs: llmElapsedMs,
-            captureTag: captured.pathTag
+            captureTag: captured.pathTag,
+            capturePath: capturePath,
+            sourceTarget: captured.target
         )
         onProgress(.done(path))
 

--- a/Sources/MacParakeetViewModels/TransformsViewModel.swift
+++ b/Sources/MacParakeetViewModels/TransformsViewModel.swift
@@ -19,6 +19,12 @@ public struct TransformShortcutReservedHotkey: Sendable, Equatable {
 public final class TransformsViewModel {
     public nonisolated static let historyFetchLimit = 200
     public nonisolated static let minimumWritingSampleWords = 50
+    private typealias HistorySnapshot = (
+        entries: [TransformHistoryEntry],
+        totalCount: Int,
+        selectedEntries: [TransformHistoryEntry],
+        selectedTotalCount: Int
+    )
 
     public var transforms: [Prompt] = []
     public var profiles: [UUID: TransformProfile] = [:]
@@ -64,6 +70,7 @@ public final class TransformsViewModel {
     private var clipboardService: ClipboardServiceProtocol?
     private var writingSampleRepo: WritingSampleRepositoryProtocol?
     private var copiedResetTask: Task<Void, Never>?
+    private var historySnapshotGeneration = 0
 
     public init() {}
 
@@ -120,27 +127,31 @@ public final class TransformsViewModel {
     }
 
     public func loadHistory() async {
+        let generation = historySnapshotGeneration
+        let requestedSelection = selectedTransformID
         guard let historyRepo else {
             history = []
             totalHistoryCount = 0
+            selectedHistory = []
+            selectedHistoryTotalCount = 0
             return
         }
         do {
             let snapshot = try await Self.fetchHistorySnapshot(
                 repo: historyRepo,
-                selectedTransformID: selectedTransformID,
+                selectedTransformID: requestedSelection,
                 limit: Self.historyFetchLimit
             )
-            history = snapshot.entries
-            totalHistoryCount = snapshot.totalCount
-            selectedHistory = snapshot.selectedEntries
-            selectedHistoryTotalCount = snapshot.selectedTotalCount
+            guard shouldApplyHistorySnapshot(generation: generation, selectedTransformID: requestedSelection) else {
+                return
+            }
+            applyHistorySnapshot(snapshot)
             historyErrorMessage = nil
         } catch {
-            history = []
-            totalHistoryCount = 0
-            selectedHistory = []
-            selectedHistoryTotalCount = 0
+            guard shouldApplyHistorySnapshot(generation: generation, selectedTransformID: requestedSelection) else {
+                return
+            }
+            clearHistorySnapshot()
             historyErrorMessage = error.localizedDescription
         }
     }
@@ -302,61 +313,78 @@ public final class TransformsViewModel {
 
     public func deleteHistoryEntry(_ entry: TransformHistoryEntry) async {
         guard let historyRepo else { return }
+        let generation = nextHistorySnapshotGeneration()
+        let requestedSelection = selectedTransformID
         do {
             let snapshot = try await Self.deleteHistoryEntryAndFetchSnapshot(
                 repo: historyRepo,
                 id: entry.id,
-                selectedTransformID: selectedTransformID,
+                selectedTransformID: requestedSelection,
                 limit: Self.historyFetchLimit
             )
-            history = snapshot.entries
-            totalHistoryCount = snapshot.totalCount
-            selectedHistory = snapshot.selectedEntries
-            selectedHistoryTotalCount = snapshot.selectedTotalCount
+            guard shouldApplyHistorySnapshot(generation: generation, selectedTransformID: requestedSelection) else {
+                return
+            }
+            applyHistorySnapshot(snapshot)
             historyErrorMessage = nil
         } catch {
+            guard shouldApplyHistorySnapshot(generation: generation, selectedTransformID: requestedSelection) else {
+                return
+            }
             historyErrorMessage = error.localizedDescription
         }
     }
 
     public func clearHistory() async {
         guard let historyRepo else { return }
+        let generation = nextHistorySnapshotGeneration()
+        let requestedSelection = selectedTransformID
         do {
             let snapshot = try await Self.clearHistoryAndFetchSnapshot(
                 repo: historyRepo,
-                selectedTransformID: selectedTransformID,
+                selectedTransformID: requestedSelection,
                 limit: Self.historyFetchLimit
             )
-            history = snapshot.entries
-            totalHistoryCount = snapshot.totalCount
-            selectedHistory = snapshot.selectedEntries
-            selectedHistoryTotalCount = snapshot.selectedTotalCount
+            guard shouldApplyHistorySnapshot(generation: generation, selectedTransformID: requestedSelection) else {
+                return
+            }
+            applyHistorySnapshot(snapshot)
             isConfirmingClearHistory = false
             historyErrorMessage = nil
         } catch {
+            guard shouldApplyHistorySnapshot(generation: generation, selectedTransformID: requestedSelection) else {
+                return
+            }
             historyErrorMessage = error.localizedDescription
         }
     }
 
     public func clearSelectedHistory() async {
-        guard let historyRepo else { return }
+        guard let historyRepo else {
+            isConfirmingClearHistory = false
+            return
+        }
         guard let selectedTransformID else {
             isConfirmingClearHistory = false
             return
         }
+        let generation = nextHistorySnapshotGeneration()
         do {
             let snapshot = try await Self.deleteHistoryForTransformAndFetchSnapshot(
                 repo: historyRepo,
                 transformId: selectedTransformID,
                 limit: Self.historyFetchLimit
             )
-            history = snapshot.entries
-            totalHistoryCount = snapshot.totalCount
-            selectedHistory = snapshot.selectedEntries
-            selectedHistoryTotalCount = snapshot.selectedTotalCount
+            guard shouldApplyHistorySnapshot(generation: generation, selectedTransformID: selectedTransformID) else {
+                return
+            }
+            applyHistorySnapshot(snapshot)
             isConfirmingClearHistory = false
             historyErrorMessage = nil
         } catch {
+            guard shouldApplyHistorySnapshot(generation: generation, selectedTransformID: selectedTransformID) else {
+                return
+            }
             historyErrorMessage = error.localizedDescription
         }
     }
@@ -382,16 +410,34 @@ public final class TransformsViewModel {
         }
     }
 
+    private func nextHistorySnapshotGeneration() -> Int {
+        historySnapshotGeneration += 1
+        return historySnapshotGeneration
+    }
+
+    private func shouldApplyHistorySnapshot(generation: Int, selectedTransformID: UUID?) -> Bool {
+        generation == historySnapshotGeneration && self.selectedTransformID == selectedTransformID
+    }
+
+    private func applyHistorySnapshot(_ snapshot: HistorySnapshot) {
+        history = snapshot.entries
+        totalHistoryCount = snapshot.totalCount
+        selectedHistory = snapshot.selectedEntries
+        selectedHistoryTotalCount = snapshot.selectedTotalCount
+    }
+
+    private func clearHistorySnapshot() {
+        history = []
+        totalHistoryCount = 0
+        selectedHistory = []
+        selectedHistoryTotalCount = 0
+    }
+
     private static func fetchHistorySnapshot(
         repo: TransformHistoryRepositoryProtocol,
         selectedTransformID: UUID?,
         limit: Int
-    ) async throws -> (
-        entries: [TransformHistoryEntry],
-        totalCount: Int,
-        selectedEntries: [TransformHistoryEntry],
-        selectedTotalCount: Int
-    ) {
+    ) async throws -> HistorySnapshot {
         try await Task.detached(priority: .userInitiated) {
             let entries = try repo.fetchRecent(limit: limit)
             let totalCount = try repo.count()
@@ -413,12 +459,7 @@ public final class TransformsViewModel {
         id: UUID,
         selectedTransformID: UUID?,
         limit: Int
-    ) async throws -> (
-        entries: [TransformHistoryEntry],
-        totalCount: Int,
-        selectedEntries: [TransformHistoryEntry],
-        selectedTotalCount: Int
-    ) {
+    ) async throws -> HistorySnapshot {
         try await Task.detached(priority: .userInitiated) {
             _ = try repo.delete(id: id)
             let entries = try repo.fetchRecent(limit: limit)
@@ -440,12 +481,7 @@ public final class TransformsViewModel {
         repo: TransformHistoryRepositoryProtocol,
         transformId: UUID,
         limit: Int
-    ) async throws -> (
-        entries: [TransformHistoryEntry],
-        totalCount: Int,
-        selectedEntries: [TransformHistoryEntry],
-        selectedTotalCount: Int
-    ) {
+    ) async throws -> HistorySnapshot {
         try await Task.detached(priority: .userInitiated) {
             try repo.deleteAll(transformId: transformId)
             let entries = try repo.fetchRecent(limit: limit)
@@ -460,12 +496,7 @@ public final class TransformsViewModel {
         repo: TransformHistoryRepositoryProtocol,
         selectedTransformID: UUID?,
         limit: Int
-    ) async throws -> (
-        entries: [TransformHistoryEntry],
-        totalCount: Int,
-        selectedEntries: [TransformHistoryEntry],
-        selectedTotalCount: Int
-    ) {
+    ) async throws -> HistorySnapshot {
         try await Task.detached(priority: .userInitiated) {
             try repo.deleteAll()
             let entries = try repo.fetchRecent(limit: limit)

--- a/Tests/CLITests/TransformsCommandTests.swift
+++ b/Tests/CLITests/TransformsCommandTests.swift
@@ -253,6 +253,176 @@ final class TransformsCommandTests: XCTestCase {
         XCTAssertFalse(after.contains(where: { $0.name == "Sharpen" }))
     }
 
+    func testDeletePrefersExactNameOverUnsafeIDPrefix() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("transforms-cli-prefix-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let dbPath = tmp.appendingPathComponent("test.db").path
+
+        let db = try DatabaseManager(path: dbPath)
+        let repo = PromptRepository(dbQueue: db.dbQueue)
+        let prefixVictim = Prompt(
+            id: UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")!,
+            name: "Keep",
+            content: "Do not delete",
+            category: .transform,
+            isBuiltIn: false
+        )
+        let namedA = Prompt(
+            id: UUID(uuidString: "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB")!,
+            name: "a",
+            content: "Delete by name",
+            category: .transform,
+            isBuiltIn: false
+        )
+        try repo.save(prefixVictim)
+        try repo.save(namedA)
+
+        let del = try TransformsCommand.DeleteSubcommand.parse([
+            "a",
+            "--database", dbPath,
+        ])
+        try del.run()
+
+        XCTAssertNotNil(try repo.fetch(id: prefixVictim.id))
+        XCTAssertNil(try repo.fetch(id: namedA.id))
+    }
+
+    func testShowRejectsTooShortUUIDPrefix() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("transforms-cli-prefix-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let dbPath = tmp.appendingPathComponent("test.db").path
+
+        _ = try DatabaseManager(path: dbPath)
+
+        let show = try TransformsCommand.ShowSubcommand.parse([
+            "abc",
+            "--database", dbPath,
+        ])
+
+        XCTAssertThrowsError(try show.run()) { error in
+            guard case CLITransformsError.prefixTooShort(let min, let provided) = error else {
+                XCTFail("Expected prefixTooShort, got \(error)")
+                return
+            }
+            XCTAssertEqual(min, 4)
+            XCTAssertEqual(provided, "abc")
+        }
+    }
+
+    func testShowJSONMapsTooShortUUIDPrefixToValidationError() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("transforms-cli-prefix-json-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let dbPath = tmp.appendingPathComponent("test.db").path
+
+        _ = try DatabaseManager(path: dbPath)
+
+        let show = try TransformsCommand.ShowSubcommand.parse([
+            "abc",
+            "--database", dbPath,
+            "--json",
+        ])
+
+        var thrownError: Error?
+        let output = try captureStandardOutput {
+            do {
+                try show.run()
+            } catch {
+                thrownError = error
+            }
+        }
+
+        let exit = try XCTUnwrap(thrownError as? ExitCode)
+        XCTAssertEqual(exit.rawValue, 2)
+
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any])
+        XCTAssertEqual(object["ok"] as? Bool, false)
+        XCTAssertEqual(object["errorType"] as? String, "validation")
+        XCTAssertTrue((object["error"] as? String)?.contains("abc") == true)
+    }
+
+    func testShowRejectsAmbiguousExactNames() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("transforms-cli-name-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let dbPath = tmp.appendingPathComponent("test.db").path
+
+        let db = try DatabaseManager(path: dbPath)
+        let repo = PromptRepository(dbQueue: db.dbQueue)
+        let uppercaseName = "\u{00C5}ngstrom"
+        let lowercaseName = "\u{00E5}ngstrom"
+        try repo.save(
+            Prompt(
+                name: uppercaseName,
+                content: "First",
+                category: .transform,
+                isBuiltIn: false
+            )
+        )
+        try repo.save(
+            Prompt(
+                name: lowercaseName,
+                content: "Second",
+                category: .transform,
+                isBuiltIn: false
+            )
+        )
+
+        let show = try TransformsCommand.ShowSubcommand.parse([
+            uppercaseName.uppercased(),
+            "--database", dbPath,
+        ])
+
+        XCTAssertThrowsError(try show.run()) { error in
+            guard case CLITransformsError.ambiguous(let query, let names) = error else {
+                XCTFail("Expected ambiguous, got \(error)")
+                return
+            }
+            XCTAssertEqual(query, uppercaseName.uppercased())
+            XCTAssertEqual(Set(names), [uppercaseName, lowercaseName])
+        }
+    }
+
+    func testDeleteJSONUsesDocumentedShape() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("transforms-cli-json-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let dbPath = tmp.appendingPathComponent("test.db").path
+
+        let db = try DatabaseManager(path: dbPath)
+        let repo = PromptRepository(dbQueue: db.dbQueue)
+        let prompt = Prompt(
+            id: UUID(uuidString: "CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC")!,
+            name: "JSON Delete",
+            content: "Delete me",
+            category: .transform,
+            isBuiltIn: false
+        )
+        try repo.save(prompt)
+
+        let del = try TransformsCommand.DeleteSubcommand.parse([
+            "JSON Delete",
+            "--database", dbPath,
+            "--json",
+        ])
+        let output = try captureStandardOutput {
+            try del.run()
+        }
+
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any])
+        XCTAssertEqual(object["deleted"] as? Bool, true)
+        XCTAssertEqual(object["id"] as? String, "CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC")
+        XCTAssertEqual(object["name"] as? String, "JSON Delete")
+        XCTAssertNil(object["ok"])
+    }
+
     func testHistoryDeleteAndClearRoundTrip() throws {
         // These subcommands intentionally reopen the database from `--database`,
         // so this round-trip needs a file-backed path rather than one in-memory queue.

--- a/Tests/MacParakeetTests/Hotkey/TransformsHotkeyRegistryTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/TransformsHotkeyRegistryTests.swift
@@ -96,6 +96,41 @@ final class TransformsHotkeyRegistryTests: XCTestCase {
         XCTAssertTrue(registry.isEmpty)
     }
 
+    func testValidatedRuntimeBindingsSkipReservedHotkeyConflicts() {
+        let opt1 = KeyboardShortcut(
+            modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,
+            keyCode: 0x12,
+            keyLabel: "1"
+        )
+        let opt4 = KeyboardShortcut(
+            modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,
+            keyCode: 0x15,
+            keyLabel: "4"
+        )
+        let conflicting = Prompt(
+            id: UUID(),
+            name: "Conflicting",
+            content: "Body",
+            category: .transform,
+            keyboardShortcut: opt1.encodedString()
+        )
+        let allowed = Prompt(
+            id: UUID(),
+            name: "Allowed",
+            content: "Body",
+            category: .transform,
+            keyboardShortcut: opt4.encodedString()
+        )
+
+        let bindings = TransformsCoordinator.validatedBindings(
+            for: [conflicting, allowed],
+            reservedHotkeys: [reserved("Dictation", opt1.hotkeyTrigger)]
+        )
+
+        XCTAssertNil(bindings[conflicting.id])
+        XCTAssertEqual(bindings[allowed.id], opt4)
+    }
+
     func testHandleKeyUpSwallowsOwnedShortcutEvenAfterModifiersClear() throws {
         let registry = TransformsHotkeyRegistry()
         let id = UUID()

--- a/Tests/MacParakeetTests/Services/System/SelectionCaptureServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/System/SelectionCaptureServiceTests.swift
@@ -33,6 +33,7 @@ final class SelectionCaptureServiceTests: XCTestCase {
             XCTAssertEqual(text, "Hello world")
             XCTAssertEqual(target?.processIdentifier, 1234)
             XCTAssertEqual(target?.bundleIdentifier, "com.example.Source")
+            XCTAssertEqual(target?.localizedName, "Source")
         default:
             XCTFail("Expected .ax, got \(result.pathTag)")
         }
@@ -62,6 +63,7 @@ final class SelectionCaptureServiceTests: XCTestCase {
             XCTAssertEqual(snapshot.temporaryChangeCount, 2)
             XCTAssertEqual(target?.processIdentifier, 1234)
             XCTAssertEqual(target?.bundleIdentifier, "com.example.Source")
+            XCTAssertEqual(target?.localizedName, "Source")
         default:
             XCTFail("Expected .clipboard, got \(result.pathTag)")
         }
@@ -215,7 +217,8 @@ final class FakeSelectionCaptureBackend: SelectionCaptureBackend, @unchecked Sen
     func frontmostApplicationTarget() -> SelectionCaptureTarget? {
         SelectionCaptureTarget(
             processIdentifier: 1234,
-            bundleIdentifier: "com.example.Source"
+            bundleIdentifier: "com.example.Source",
+            localizedName: "Source"
         )
     }
 

--- a/Tests/MacParakeetTests/Services/Transforms/TransformExecutorTests.swift
+++ b/Tests/MacParakeetTests/Services/Transforms/TransformExecutorTests.swift
@@ -207,6 +207,8 @@ final class TransformExecutorTests: XCTestCase {
         XCTAssertEqual(result.outputText, "Hi there!")
         XCTAssertEqual(result.path, .ax)
         XCTAssertEqual(result.captureTag, "ax")
+        XCTAssertEqual(result.sourceTarget?.bundleIdentifier, "com.example.Source")
+        XCTAssertEqual(result.sourceTarget?.localizedName, "Source")
 
         let events = recorder.snapshot()
         // Required ordering: capturing → llmStarted → at least one


### PR DESCRIPTION
## Summary

This is a follow-up hardening PR after the extra post-merge Transform reviews. The reviews converged on a small set of valid issues: runtime hotkey collisions could still dispatch, Transform history loads could apply stale selection snapshots, the history-delete alert could lose its pending entry, source-app history could drift after a long LLM run, and CLI ID-prefix lookup accepted unsafe tiny prefixes.

## What changed

- Reuse Transform shortcut collision checks at runtime and reload Transform bindings when app-level hotkeys change.
- Guard async Transform history snapshots by selection/generation and delete the alert-presented history entry directly.
- Carry the original capture target and typed capture path through `TransformExecutor`, then use that for history and telemetry.
- Make CLI Transform lookup prefer exact names, reject UUID-looking prefixes under 4 hex chars, and document/test the delete JSON shape.

## Flow

```text
selected app
    |
    v
SelectionCaptureResult -- target + typed capture path --> TransformExecutor
    |                                                     |
    |                                                     v
    +----------------------------------------------> history + telemetry

Settings hotkey change --> AppDelegate --> TransformsCoordinator.reloadBindings()
                                      |--> reserved-hotkey collision filter
                                      |--> TransformsHotkeyRegistry
```

## Verification

- `swift test --filter 'TransformsCommandTests|TransformsHotkeyRegistryTests|SelectionCaptureServiceTests|TransformExecutorTests|TransformsViewModelTests|AppSettingsObserverCoordinatorTests|AppDelegateMenuBarResolverTests'`
- `swift test`

Full suite: `2664` tests, `10` skipped, `0` failures, `104.6s`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hotkey conflict detection: reserved shortcuts are honored and conflicting transform bindings are skipped.
  * Capture metadata: transform run results now include capture source and human-readable source name.

* **Bug Fixes**
  * Prevented stale history overwrites with generation-based snapshot gating.
  * Improved transform lookup: exact ID, case-insensitive name, and stricter prefix matching to avoid ambiguous/short-prefix matches.
  * Better hotkey binding sync after preference changes and onboarding.

* **Documentation**
  * Clarified CLI --json outputs per subcommand (including delete/run formats).

* **Tests**
  * Added CLI and hotkey tests to validate lookup, JSON output, and reserved-hotkey behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moona3k/macparakeet/pull/286)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->