### PR TITLE
Harden Transform workbench edge cases

### DIFF
--- a/Sources/MacParakeet/App/TransformsCoordinator.swift
+++ b/Sources/MacParakeet/App/TransformsCoordinator.swift
@@ -136,18 +136,22 @@ final class TransformsCoordinator {
         guard let registry else { return }
         let prompts: [Prompt]
         do {
-            prompts = try promptRepository.fetchVisible(category: .transform)
+            prompts = try promptRepository
+                .fetchVisible(category: .transform)
+                .sorted(by: { lhs, rhs in
+                    if lhs.sortOrder != rhs.sortOrder { return lhs.sortOrder < rhs.sortOrder }
+                    return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+                })
         } catch {
             logger.error("transforms: fetchVisible failed: \(error.localizedDescription, privacy: .public)")
             return
         }
 
-        promptIndex = Dictionary(uniqueKeysWithValues: prompts.map { ($0.id, $0) })
-
         let bindings = Self.validatedBindings(
             for: prompts,
             reservedHotkeys: reservedHotkeysProvider()
         )
+        promptIndex = Dictionary(uniqueKeysWithValues: prompts.map { ($0.id, $0) })
         activeBindingIDs = Set(bindings.keys)
         registry.replaceBindings(bindings)
     }
@@ -157,6 +161,7 @@ final class TransformsCoordinator {
         reservedHotkeys: [TransformShortcutReservedHotkey]
     ) -> [UUID: KeyboardShortcut] {
         let collisionChecker = TransformsHotkeyCollisionChecker()
+        let activeReservedHotkeys = reservedHotkeys.filter { !$0.trigger.isDisabled }
         var bindings: [UUID: KeyboardShortcut] = [:]
         for prompt in prompts {
             guard let shortcut = prompt.shortcut else { continue }
@@ -164,7 +169,7 @@ final class TransformsCoordinator {
                 candidate: shortcut,
                 existing: bindings,
                 excludingPromptID: nil,
-                reservedHotkeys: reservedHotkeys
+                reservedHotkeys: activeReservedHotkeys
             ) == nil else {
                 continue
             }

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -509,6 +509,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         transformsCoordinator?.reloadBindings()
         menuBarCoordinator.refreshHotkeyTitle()
         menuBarCoordinator.refreshMeetingHotkeyShortcut()
+        NotificationCenter.default.post(name: .transformsBindingsChanged, object: nil)
     }
 
     /// Any auxiliary hotkey change refreshes all three auxiliary hotkeys so a
@@ -533,6 +534,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         transformsCoordinator?.reloadBindings()
         menuBarCoordinator.refreshMeetingHotkeyShortcut()
         menuBarCoordinator.refreshTranscriptionHotkeyShortcuts()
+        NotificationCenter.default.post(name: .transformsBindingsChanged, object: nil)
+    }
+
+    private var transformReservedHotkeys: [TransformShortcutReservedHotkey] {
+        [
+            TransformShortcutReservedHotkey(name: "Dictation", trigger: settingsViewModel.hotkeyTrigger),
+            TransformShortcutReservedHotkey(name: "Push-to-talk", trigger: settingsViewModel.pushToTalkHotkeyTrigger),
+            TransformShortcutReservedHotkey(name: "Meeting recording", trigger: settingsViewModel.meetingHotkeyTrigger),
+            TransformShortcutReservedHotkey(name: "File transcription", trigger: settingsViewModel.fileTranscriptionHotkeyTrigger),
+            TransformShortcutReservedHotkey(name: "YouTube transcription", trigger: settingsViewModel.youtubeTranscriptionHotkeyTrigger),
+        ].filter { !$0.trigger.isDisabled }
     }
 
     private func triggerFileTranscriptionFromHotkey() {
@@ -559,16 +571,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 handsFree: settingsViewModel.hotkeyTrigger,
                 pushToTalk: settingsViewModel.pushToTalkHotkeyTrigger
             )
-    }
-
-    private var transformReservedHotkeys: [TransformShortcutReservedHotkey] {
-        [
-            TransformShortcutReservedHotkey(name: "Dictation", trigger: settingsViewModel.hotkeyTrigger),
-            TransformShortcutReservedHotkey(name: "Push-to-talk", trigger: settingsViewModel.pushToTalkHotkeyTrigger),
-            TransformShortcutReservedHotkey(name: "Meeting recording", trigger: settingsViewModel.meetingHotkeyTrigger),
-            TransformShortcutReservedHotkey(name: "File transcription", trigger: settingsViewModel.fileTranscriptionHotkeyTrigger),
-            TransformShortcutReservedHotkey(name: "YouTube transcription", trigger: settingsViewModel.youtubeTranscriptionHotkeyTrigger),
-        ].filter { !$0.trigger.isDisabled }
     }
 
     // MARK: - Menu Bar Icon State

--- a/Sources/MacParakeet/Hotkey/TransformsHotkeyRegistry.swift
+++ b/Sources/MacParakeet/Hotkey/TransformsHotkeyRegistry.swift
@@ -65,6 +65,9 @@ public final class TransformsHotkeyRegistry {
             keyCode: shortcut.keyCode,
             modifierBits: cgFlags(for: shortcut.modifiers)
         )
+        if let existingPromptID = dispatchTable[match], existingPromptID != promptID {
+            return
+        }
         dispatchTable[match] = promptID
     }
 
@@ -80,11 +83,13 @@ public final class TransformsHotkeyRegistry {
     /// repository reloads after a save/delete/import.
     public func replaceBindings(_ bindings: [UUID: KeyboardShortcut]) {
         dispatchTable.removeAll(keepingCapacity: true)
+        pressedKeys.removeAll(keepingCapacity: true)
         for (promptID, shortcut) in bindings {
             let match = KeyMatch(
                 keyCode: shortcut.keyCode,
                 modifierBits: cgFlags(for: shortcut.modifiers)
             )
+            guard dispatchTable[match] == nil else { continue }
             dispatchTable[match] = promptID
         }
     }
@@ -156,6 +161,7 @@ public final class TransformsHotkeyRegistry {
 
     func handleEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            pressedKeys.removeAll(keepingCapacity: true)
             if let tap = eventTap {
                 CGEvent.tapEnable(tap: tap, enable: true)
             }

--- a/Sources/MacParakeet/Views/MainWindowView.swift
+++ b/Sources/MacParakeet/Views/MainWindowView.swift
@@ -172,6 +172,7 @@ struct MainWindowView: View {
                             viewModel: settingsViewModel,
                             llmSettingsViewModel: llmSettingsViewModel,
                             updater: updater,
+                            transformHotkeys: settingsReservedTransformHotkeys,
                             onHotkeyRecordingStateChanged: onHotkeyRecordingStateChanged
                         )
                     case .discover:
@@ -222,6 +223,16 @@ struct MainWindowView: View {
             TransformShortcutReservedHotkey(name: "File transcription", trigger: settingsViewModel.fileTranscriptionHotkeyTrigger),
             TransformShortcutReservedHotkey(name: "YouTube transcription", trigger: settingsViewModel.youtubeTranscriptionHotkeyTrigger),
         ].filter { !$0.trigger.isDisabled }
+    }
+
+    private var settingsReservedTransformHotkeys: [TransformShortcutReservedHotkey] {
+        transformsViewModel.transforms.compactMap { transform in
+            guard let shortcut = transform.shortcut else { return nil }
+            return TransformShortcutReservedHotkey(
+                name: "Transform \(transform.name)",
+                trigger: shortcut.hotkeyTrigger
+            )
+        }
     }
 
     private var globalTranscriptionBottomBar: some View {

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -19,6 +19,7 @@ struct SettingsView: View {
     @Bindable var viewModel: SettingsViewModel
     @Bindable var llmSettingsViewModel: LLMSettingsViewModel
     let updater: SPUUpdater
+    let transformHotkeys: [TransformShortcutReservedHotkey]
     /// Fired by each `HotkeyRecorderView` when it starts/stops capturing
     /// keystrokes. Wired up to `AppHotkeyCoordinator.suspend` / `resume` so
     /// active global taps don't swallow the keyDown the user is recording.
@@ -42,11 +43,13 @@ struct SettingsView: View {
         viewModel: SettingsViewModel,
         llmSettingsViewModel: LLMSettingsViewModel,
         updater: SPUUpdater,
+        transformHotkeys: [TransformShortcutReservedHotkey] = [],
         onHotkeyRecordingStateChanged: @escaping (Bool) -> Void
     ) {
         self.viewModel = viewModel
         self.llmSettingsViewModel = llmSettingsViewModel
         self.updater = updater
+        self.transformHotkeys = transformHotkeys
         self.onHotkeyRecordingStateChanged = onHotkeyRecordingStateChanged
         self._automaticallyChecksForUpdates = State(initialValue: updater.automaticallyChecksForUpdates)
         self._automaticallyDownloadsUpdates = State(initialValue: updater.automaticallyDownloadsUpdates)
@@ -855,6 +858,12 @@ struct SettingsView: View {
                                 trigger: otherTranscriptionTrigger
                             ))
                         }
+                        if let conflict = transformHotkeyConflict(for: candidate) {
+                            return .blocked(SettingsHotkeyConflictMessage.blocked(
+                                conflictingWith: conflict.name,
+                                trigger: conflict.trigger
+                            ))
+                        }
                         return .allowed
                     },
                     onRecordingStateChanged: onHotkeyRecordingStateChanged
@@ -901,6 +910,12 @@ struct SettingsView: View {
                 trigger: otherTranscription
             )
         }
+        if let conflict = transformHotkeyConflict(for: trigger) {
+            return SettingsHotkeyConflictMessage.disabled(
+                conflictingWith: conflict.name,
+                trigger: conflict.trigger
+            )
+        }
         return nil
     }
 
@@ -929,6 +944,12 @@ struct SettingsView: View {
             return .blocked(SettingsHotkeyConflictMessage.blocked(
                 conflictingWith: "YouTube transcription",
                 trigger: viewModel.youtubeTranscriptionHotkeyTrigger
+            ))
+        }
+        if let conflict = transformHotkeyConflict(for: candidate) {
+            return .blocked(SettingsHotkeyConflictMessage.blocked(
+                conflictingWith: conflict.name,
+                trigger: conflict.trigger
             ))
         }
         return .allowed
@@ -961,6 +982,12 @@ struct SettingsView: View {
                 trigger: viewModel.youtubeTranscriptionHotkeyTrigger
             ))
         }
+        if let conflict = transformHotkeyConflict(for: candidate) {
+            return .blocked(SettingsHotkeyConflictMessage.blocked(
+                conflictingWith: conflict.name,
+                trigger: conflict.trigger
+            ))
+        }
         return .allowed
     }
 
@@ -988,6 +1015,12 @@ struct SettingsView: View {
             return .blocked(SettingsHotkeyConflictMessage.blocked(
                 conflictingWith: "YouTube transcription",
                 trigger: viewModel.youtubeTranscriptionHotkeyTrigger
+            ))
+        }
+        if let conflict = transformHotkeyConflict(for: candidate) {
+            return .blocked(SettingsHotkeyConflictMessage.blocked(
+                conflictingWith: conflict.name,
+                trigger: conflict.trigger
             ))
         }
         return .allowed
@@ -1020,6 +1053,12 @@ struct SettingsView: View {
                 trigger: viewModel.youtubeTranscriptionHotkeyTrigger
             )
         }
+        if let conflict = transformHotkeyConflict(for: trigger) {
+            return SettingsHotkeyConflictMessage.disabled(
+                conflictingWith: conflict.name,
+                trigger: conflict.trigger
+            )
+        }
         return nil
     }
 
@@ -1048,6 +1087,12 @@ struct SettingsView: View {
             return SettingsHotkeyConflictMessage.disabled(
                 conflictingWith: "YouTube transcription",
                 trigger: viewModel.youtubeTranscriptionHotkeyTrigger
+            )
+        }
+        if let conflict = transformHotkeyConflict(for: trigger) {
+            return SettingsHotkeyConflictMessage.disabled(
+                conflictingWith: conflict.name,
+                trigger: conflict.trigger
             )
         }
         return nil
@@ -1079,7 +1124,20 @@ struct SettingsView: View {
                 trigger: viewModel.youtubeTranscriptionHotkeyTrigger
             )
         }
+        if let conflict = transformHotkeyConflict(for: trigger) {
+            return SettingsHotkeyConflictMessage.disabled(
+                conflictingWith: conflict.name,
+                trigger: conflict.trigger
+            )
+        }
         return nil
+    }
+
+    private func transformHotkeyConflict(for trigger: HotkeyTrigger) -> TransformShortcutReservedHotkey? {
+        guard AppFeatures.transformsEnabled, !trigger.isDisabled else { return nil }
+        return transformHotkeys.first { conflict in
+            trigger.overlaps(with: conflict.trigger)
+        }
     }
 
     private func transcriptionHotkeyConflictText(_ message: String) -> some View {

--- a/Sources/MacParakeet/Views/Transforms/ShortcutRecorderField.swift
+++ b/Sources/MacParakeet/Views/Transforms/ShortcutRecorderField.swift
@@ -13,13 +13,9 @@ struct ShortcutRecorderField: View {
         HStack {
             Group {
                 if let shortcut {
-                    HStack(spacing: 6) {
-                        KeycapBadge(shortcut: shortcut)
-                        Text(shortcut.keyLabel.uppercased())
-                            .font(DesignSystem.Typography.bodySmall.monospacedDigit())
-                            .foregroundStyle(DesignSystem.Colors.textTertiary)
-                            .accessibilityHidden(true)
-                    }
+                    KeycapBadge(shortcut: shortcut)
+                        .accessibilityElement(children: .ignore)
+                        .accessibilityLabel("Shortcut \(shortcut.displayString)")
                 } else {
                     Text(isRecording ? "Press a keyboard combo..." : "Click to add a shortcut")
                         .font(DesignSystem.Typography.body)
@@ -74,6 +70,10 @@ struct ShortcutRecorderField: View {
     private func installMonitor() {
         removeMonitor()
         localMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { event in
+            if Self.shouldCancelRecording(event) {
+                isRecording = false
+                return nil
+            }
             let modifierBits = UInt(event.modifierFlags.intersection([.command, .option, .control, .shift]).rawValue)
             let keyCode = event.keyCode
             let label = labelForKey(event: event)
@@ -126,5 +126,9 @@ struct ShortcutRecorderField: View {
             }
         }
         return "Key \(event.keyCode)"
+    }
+
+    static func shouldCancelRecording(_ event: NSEvent) -> Bool {
+        event.keyCode == 0x35
     }
 }

--- a/Sources/MacParakeet/Views/Transforms/TransformsView.swift
+++ b/Sources/MacParakeet/Views/Transforms/TransformsView.swift
@@ -14,7 +14,14 @@ struct TransformsView: View {
 
     @State private var isRecordingShortcut = false
     @State private var showBuiltInPrompt = false
+    @State private var pendingDraftNavigation: PendingDraftNavigation?
     private let collisionChecker = TransformsHotkeyCollisionChecker()
+
+    private enum PendingDraftNavigation {
+        case select(Prompt)
+        case create
+        case cancelCreate
+    }
 
     var body: some View {
         HStack(spacing: 0) {
@@ -57,7 +64,7 @@ struct TransformsView: View {
                 viewModel.pendingDeleteTransform = nil
             }
         } message: { transform in
-            Text("“\(transform.name)” will be removed. Its local history stays available.")
+            Text("“\(transform.name)” and its local run history will be removed.")
         }
         .alert(
             "Delete history item?",
@@ -108,6 +115,22 @@ struct TransformsView: View {
         } message: {
             Text("This removes the saved inputs and outputs for the selected Transform from this Mac.")
         }
+        .alert(
+            "Discard unsaved changes?",
+            isPresented: Binding(
+                get: { pendingDraftNavigation != nil },
+                set: { if !$0 { pendingDraftNavigation = nil } }
+            )
+        ) {
+            Button("Discard Changes", role: .destructive) {
+                performPendingDraftNavigation()
+            }
+            Button("Cancel", role: .cancel) {
+                pendingDraftNavigation = nil
+            }
+        } message: {
+            Text("Your current Transform edits have not been saved.")
+        }
     }
 
     private var sidebar: some View {
@@ -134,8 +157,7 @@ struct TransformsView: View {
                     }
 
                     Button {
-                        showBuiltInPrompt = true
-                        viewModel.startCreatingTransform()
+                        requestDraftNavigation(.create)
                     } label: {
                         Label("Create Transform", systemImage: "plus")
                             .frame(maxWidth: .infinity, alignment: .leading)
@@ -196,10 +218,9 @@ struct TransformsView: View {
                     TransformListRow(
                         transform: transform,
                         isSelected: viewModel.selectedTransformID == transform.id && !viewModel.isCreatingDraft,
-                        historyCount: viewModel.selectedTransformID == transform.id ? viewModel.selectedHistoryTotalCount : viewModel.history.filter { $0.transformId == transform.id }.count,
+                        historyCount: viewModel.historyCountsByTransformID[transform.id] ?? 0,
                         action: {
-                            showBuiltInPrompt = false
-                            viewModel.selectTransform(transform)
+                            requestDraftNavigation(.select(transform))
                         }
                     )
                 }
@@ -245,6 +266,8 @@ struct TransformsView: View {
                     if let error = viewModel.nameError {
                         InlineValidation(message: error)
                     }
+
+                    runningLabelField
                 }
 
                 Spacer(minLength: DesignSystem.Spacing.lg)
@@ -253,14 +276,16 @@ struct TransformsView: View {
                     HStack(spacing: DesignSystem.Spacing.sm) {
                         if viewModel.isCreatingDraft {
                             Button("Cancel") {
-                                viewModel.cancelCreate()
+                                requestDraftNavigation(.cancelCreate)
                             }
                             .parakeetAction(.secondary)
                         } else if let selected = viewModel.selectedTransform {
                             if selected.isBuiltIn {
                                 Button {
-                                    viewModel.resetBuiltIn(selected)
-                                    onBindingsChanged()
+                                    if viewModel.resetBuiltIn(selected) {
+                                        revalidate()
+                                        onBindingsChanged()
+                                    }
                                 } label: {
                                     Label("Reset", systemImage: "arrow.counterclockwise")
                                 }
@@ -317,6 +342,32 @@ struct TransformsView: View {
         }
     }
 
+    private var runningLabelField: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text("Progress label")
+                .font(DesignSystem.Typography.micro)
+                .foregroundStyle(DesignSystem.Colors.textTertiary)
+            TextField("Transforming...", text: $viewModel.draftRunningLabel)
+                .textFieldStyle(.plain)
+                .font(DesignSystem.Typography.bodySmall)
+                .foregroundStyle(DesignSystem.Colors.textPrimary)
+                .padding(.horizontal, DesignSystem.Spacing.md)
+                .padding(.vertical, DesignSystem.Spacing.sm)
+                .background(DesignSystem.Colors.surface)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(DesignSystem.Colors.border, lineWidth: 0.5)
+                }
+                .accessibilityLabel("Transform progress label")
+            Text("Shown in the floating pill while this Transform runs.")
+                .font(DesignSystem.Typography.caption)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+        }
+        .frame(maxWidth: 360, alignment: .leading)
+        .padding(.top, DesignSystem.Spacing.sm)
+    }
+
     private var rulesSection: some View {
         WorkbenchSection(title: "Rules", subtitle: "Shape the behavior without editing the full prompt.") {
             VStack(spacing: 0) {
@@ -345,7 +396,10 @@ struct TransformsView: View {
     private var writingSamplesSection: some View {
         WorkbenchSection(title: "Writing samples", subtitle: "Optional local examples for matching your voice.") {
             VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
-                Toggle(isOn: $viewModel.draftUseWritingSamples) {
+                Toggle(isOn: Binding(
+                    get: { viewModel.draftUseWritingSamples && viewModel.canUseWritingSamples },
+                    set: { viewModel.setDraftUseWritingSamples($0) }
+                )) {
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Match my writing style")
                             .font(DesignSystem.Typography.body.weight(.semibold))
@@ -538,6 +592,38 @@ struct TransformsView: View {
             collisionChecker: collisionChecker
         )
     }
+
+    private func requestDraftNavigation(_ navigation: PendingDraftNavigation) {
+        if case .select(let prompt) = navigation,
+           viewModel.selectedTransformID == prompt.id,
+           !viewModel.isCreatingDraft {
+            return
+        }
+        guard viewModel.hasUnsavedDraft else {
+            performDraftNavigation(navigation)
+            return
+        }
+        pendingDraftNavigation = navigation
+    }
+
+    private func performPendingDraftNavigation() {
+        guard let navigation = pendingDraftNavigation else { return }
+        pendingDraftNavigation = nil
+        performDraftNavigation(navigation)
+    }
+
+    private func performDraftNavigation(_ navigation: PendingDraftNavigation) {
+        switch navigation {
+        case .select(let prompt):
+            showBuiltInPrompt = false
+            viewModel.selectTransform(prompt)
+        case .create:
+            showBuiltInPrompt = true
+            viewModel.startCreatingTransform()
+        case .cancelCreate:
+            viewModel.cancelCreate()
+        }
+    }
 }
 
 private struct TransformListRow: View {
@@ -696,7 +782,7 @@ private struct WritingSampleRow: View {
             .buttonStyle(.plain)
             .foregroundStyle(DesignSystem.Colors.textSecondary)
             .help("Delete writing sample")
-            .accessibilityLabel("Delete writing sample")
+            .accessibilityLabel("Delete writing sample \(sample.title)")
         }
         .padding(DesignSystem.Spacing.md)
         .background(DesignSystem.Colors.surface)
@@ -826,7 +912,7 @@ private struct TransformHistoryRow: View {
                 .buttonStyle(.plain)
                 .foregroundStyle(DesignSystem.Colors.textSecondary)
                 .help("Copy transformed text")
-                .accessibilityLabel("Copy transformed text")
+                .accessibilityLabel("Copy \(entry.transformName) output from \(entry.sourceAppDisplayName)")
 
                 Button(role: .destructive, action: onDelete) {
                     Image(systemName: "trash")
@@ -834,7 +920,7 @@ private struct TransformHistoryRow: View {
                 .buttonStyle(.plain)
                 .foregroundStyle(DesignSystem.Colors.textSecondary)
                 .help("Delete history item")
-                .accessibilityLabel("Delete history item")
+                .accessibilityLabel("Delete \(entry.transformName) history item from \(entry.sourceAppDisplayName)")
             }
 
             Text(entry.outputText)

--- a/Sources/MacParakeetViewModels/TransformsViewModel.swift
+++ b/Sources/MacParakeetViewModels/TransformsViewModel.swift
@@ -19,17 +19,12 @@ public struct TransformShortcutReservedHotkey: Sendable, Equatable {
 public final class TransformsViewModel {
     public nonisolated static let historyFetchLimit = 200
     public nonisolated static let minimumWritingSampleWords = 50
-    private typealias HistorySnapshot = (
-        entries: [TransformHistoryEntry],
-        totalCount: Int,
-        selectedEntries: [TransformHistoryEntry],
-        selectedTotalCount: Int
-    )
 
     public var transforms: [Prompt] = []
     public var profiles: [UUID: TransformProfile] = [:]
     public var history: [TransformHistoryEntry] = []
     public var totalHistoryCount: Int = 0
+    public var historyCountsByTransformID: [UUID: Int] = [:]
     public var selectedHistory: [TransformHistoryEntry] = []
     public var selectedHistoryTotalCount: Int = 0
     public var writingSamples: [WritingSample] = []
@@ -71,6 +66,14 @@ public final class TransformsViewModel {
     private var writingSampleRepo: WritingSampleRepositoryProtocol?
     private var copiedResetTask: Task<Void, Never>?
     private var historySnapshotGeneration = 0
+
+    private struct HistorySnapshot: Sendable {
+        let entries: [TransformHistoryEntry]
+        let totalCount: Int
+        let countsByTransformID: [UUID: Int]
+        let selectedEntries: [TransformHistoryEntry]
+        let selectedTotalCount: Int
+    }
 
     public init() {}
 
@@ -130,16 +133,15 @@ public final class TransformsViewModel {
         let generation = historySnapshotGeneration
         let requestedSelection = selectedTransformID
         guard let historyRepo else {
-            history = []
-            totalHistoryCount = 0
-            selectedHistory = []
-            selectedHistoryTotalCount = 0
+            clearHistorySnapshot()
             return
         }
+        let trackedTransformIDs = transforms.map(\.id)
         do {
             let snapshot = try await Self.fetchHistorySnapshot(
                 repo: historyRepo,
                 selectedTransformID: requestedSelection,
+                trackedTransformIDs: trackedTransformIDs,
                 limit: Self.historyFetchLimit
             )
             guard shouldApplyHistorySnapshot(generation: generation, selectedTransformID: requestedSelection) else {
@@ -255,7 +257,7 @@ public final class TransformsViewModel {
             profile.promptId = saved.id
             profile.setEnabledRuleIDs(draftEnabledRuleIDs)
             profile.customInstructions = trimmedInstructions.isEmpty ? nil : trimmedInstructions
-            profile.useWritingSamples = draftUseWritingSamples
+            profile.useWritingSamples = draftUseWritingSamples && !writingSamples.isEmpty
             profile.updatedAt = now
             if profile.createdAt > now {
                 profile.createdAt = now
@@ -278,6 +280,7 @@ public final class TransformsViewModel {
     public func delete(_ prompt: Prompt) -> Bool {
         guard let repo, !prompt.isBuiltIn else { return false }
         do {
+            try historyRepo?.deleteAll(transformId: prompt.id)
             let deleted = try repo.delete(id: prompt.id)
             if deleted {
                 _ = try? profileRepo?.delete(promptId: prompt.id)
@@ -315,11 +318,13 @@ public final class TransformsViewModel {
         guard let historyRepo else { return }
         let generation = nextHistorySnapshotGeneration()
         let requestedSelection = selectedTransformID
+        let trackedTransformIDs = transforms.map(\.id)
         do {
             let snapshot = try await Self.deleteHistoryEntryAndFetchSnapshot(
                 repo: historyRepo,
                 id: entry.id,
                 selectedTransformID: requestedSelection,
+                trackedTransformIDs: trackedTransformIDs,
                 limit: Self.historyFetchLimit
             )
             guard shouldApplyHistorySnapshot(generation: generation, selectedTransformID: requestedSelection) else {
@@ -339,10 +344,12 @@ public final class TransformsViewModel {
         guard let historyRepo else { return }
         let generation = nextHistorySnapshotGeneration()
         let requestedSelection = selectedTransformID
+        let trackedTransformIDs = transforms.map(\.id)
         do {
             let snapshot = try await Self.clearHistoryAndFetchSnapshot(
                 repo: historyRepo,
                 selectedTransformID: requestedSelection,
+                trackedTransformIDs: trackedTransformIDs,
                 limit: Self.historyFetchLimit
             )
             guard shouldApplyHistorySnapshot(generation: generation, selectedTransformID: requestedSelection) else {
@@ -369,10 +376,12 @@ public final class TransformsViewModel {
             return
         }
         let generation = nextHistorySnapshotGeneration()
+        let trackedTransformIDs = transforms.map(\.id)
         do {
             let snapshot = try await Self.deleteHistoryForTransformAndFetchSnapshot(
                 repo: historyRepo,
                 transformId: selectedTransformID,
+                trackedTransformIDs: trackedTransformIDs,
                 limit: Self.historyFetchLimit
             )
             guard shouldApplyHistorySnapshot(generation: generation, selectedTransformID: selectedTransformID) else {
@@ -422,6 +431,7 @@ public final class TransformsViewModel {
     private func applyHistorySnapshot(_ snapshot: HistorySnapshot) {
         history = snapshot.entries
         totalHistoryCount = snapshot.totalCount
+        historyCountsByTransformID = snapshot.countsByTransformID
         selectedHistory = snapshot.selectedEntries
         selectedHistoryTotalCount = snapshot.selectedTotalCount
     }
@@ -429,6 +439,7 @@ public final class TransformsViewModel {
     private func clearHistorySnapshot() {
         history = []
         totalHistoryCount = 0
+        historyCountsByTransformID = [:]
         selectedHistory = []
         selectedHistoryTotalCount = 0
     }
@@ -436,11 +447,16 @@ public final class TransformsViewModel {
     private static func fetchHistorySnapshot(
         repo: TransformHistoryRepositoryProtocol,
         selectedTransformID: UUID?,
+        trackedTransformIDs: [UUID],
         limit: Int
     ) async throws -> HistorySnapshot {
         try await Task.detached(priority: .userInitiated) {
             let entries = try repo.fetchRecent(limit: limit)
             let totalCount = try repo.count()
+            let countsByTransformID = try Self.fetchCounts(
+                repo: repo,
+                trackedTransformIDs: trackedTransformIDs
+            )
             let selectedEntries: [TransformHistoryEntry]
             let selectedTotalCount: Int
             if let selectedTransformID {
@@ -450,7 +466,13 @@ public final class TransformsViewModel {
                 selectedEntries = []
                 selectedTotalCount = 0
             }
-            return (entries, totalCount, selectedEntries, selectedTotalCount)
+            return HistorySnapshot(
+                entries: entries,
+                totalCount: totalCount,
+                countsByTransformID: countsByTransformID,
+                selectedEntries: selectedEntries,
+                selectedTotalCount: selectedTotalCount
+            )
         }.value
     }
 
@@ -458,12 +480,17 @@ public final class TransformsViewModel {
         repo: TransformHistoryRepositoryProtocol,
         id: UUID,
         selectedTransformID: UUID?,
+        trackedTransformIDs: [UUID],
         limit: Int
     ) async throws -> HistorySnapshot {
         try await Task.detached(priority: .userInitiated) {
             _ = try repo.delete(id: id)
             let entries = try repo.fetchRecent(limit: limit)
             let totalCount = try repo.count()
+            let countsByTransformID = try Self.fetchCounts(
+                repo: repo,
+                trackedTransformIDs: trackedTransformIDs
+            )
             let selectedEntries: [TransformHistoryEntry]
             let selectedTotalCount: Int
             if let selectedTransformID {
@@ -473,34 +500,56 @@ public final class TransformsViewModel {
                 selectedEntries = []
                 selectedTotalCount = 0
             }
-            return (entries, totalCount, selectedEntries, selectedTotalCount)
+            return HistorySnapshot(
+                entries: entries,
+                totalCount: totalCount,
+                countsByTransformID: countsByTransformID,
+                selectedEntries: selectedEntries,
+                selectedTotalCount: selectedTotalCount
+            )
         }.value
     }
 
     private static func deleteHistoryForTransformAndFetchSnapshot(
         repo: TransformHistoryRepositoryProtocol,
         transformId: UUID,
+        trackedTransformIDs: [UUID],
         limit: Int
     ) async throws -> HistorySnapshot {
         try await Task.detached(priority: .userInitiated) {
             try repo.deleteAll(transformId: transformId)
             let entries = try repo.fetchRecent(limit: limit)
             let totalCount = try repo.count()
+            let countsByTransformID = try Self.fetchCounts(
+                repo: repo,
+                trackedTransformIDs: trackedTransformIDs
+            )
             let selectedEntries = try repo.fetchRecent(transformId: transformId, limit: limit)
             let selectedTotalCount = try repo.count(transformId: transformId)
-            return (entries, totalCount, selectedEntries, selectedTotalCount)
+            return HistorySnapshot(
+                entries: entries,
+                totalCount: totalCount,
+                countsByTransformID: countsByTransformID,
+                selectedEntries: selectedEntries,
+                selectedTotalCount: selectedTotalCount
+            )
         }.value
     }
 
     private static func clearHistoryAndFetchSnapshot(
         repo: TransformHistoryRepositoryProtocol,
         selectedTransformID: UUID?,
+        trackedTransformIDs: [UUID],
         limit: Int
     ) async throws -> HistorySnapshot {
         try await Task.detached(priority: .userInitiated) {
             try repo.deleteAll()
             let entries = try repo.fetchRecent(limit: limit)
             let totalCount = try repo.count()
+            let countsByTransformID = try Self.fetchCounts(
+                repo: repo,
+                trackedTransformIDs: trackedTransformIDs
+            )
             let selectedEntries: [TransformHistoryEntry]
             let selectedTotalCount: Int
             if let selectedTransformID {
@@ -510,8 +559,25 @@ public final class TransformsViewModel {
                 selectedEntries = []
                 selectedTotalCount = 0
             }
-            return (entries, totalCount, selectedEntries, selectedTotalCount)
+            return HistorySnapshot(
+                entries: entries,
+                totalCount: totalCount,
+                countsByTransformID: countsByTransformID,
+                selectedEntries: selectedEntries,
+                selectedTotalCount: selectedTotalCount
+            )
         }.value
+    }
+
+    private nonisolated static func fetchCounts(
+        repo: TransformHistoryRepositoryProtocol,
+        trackedTransformIDs: [UUID]
+    ) throws -> [UUID: Int] {
+        var counts: [UUID: Int] = [:]
+        for id in Set(trackedTransformIDs) {
+            counts[id] = try repo.count(transformId: id)
+        }
+        return counts
     }
 
     /// Reset a built-in Transform's content / shortcut / runningLabel back
@@ -609,6 +675,9 @@ public final class TransformsViewModel {
         do {
             _ = try writingSampleRepo.delete(id: sample.id)
             writingSamples.removeAll { $0.id == sample.id }
+            if writingSamples.isEmpty {
+                draftUseWritingSamples = false
+            }
             writingSampleErrorMessage = nil
         } catch {
             writingSampleErrorMessage = error.localizedDescription
@@ -637,6 +706,23 @@ public final class TransformsViewModel {
         draftName.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    public var canUseWritingSamples: Bool {
+        !writingSamples.isEmpty
+    }
+
+    public func setDraftUseWritingSamples(_ enabled: Bool) {
+        guard enabled else {
+            draftUseWritingSamples = false
+            return
+        }
+        guard canUseWritingSamples else {
+            draftUseWritingSamples = false
+            isAddingWritingSample = true
+            return
+        }
+        draftUseWritingSamples = true
+    }
+
     public var isDraftValid: Bool {
         normalizedDraftName.isEmpty == false
             && draftContent.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
@@ -652,6 +738,8 @@ public final class TransformsViewModel {
         let normalizedRunningLabel = draftRunningLabel.trimmingCharacters(in: .whitespacesAndNewlines)
         let normalizedInstructions = draftCustomInstructions.trimmingCharacters(in: .whitespacesAndNewlines)
         let profile = profiles[prompt.id] ?? .defaultProfile(for: prompt)
+        let normalizedUseWritingSamples = draftUseWritingSamples && !writingSamples.isEmpty
+        let savedUseWritingSamples = profile.useWritingSamples && !writingSamples.isEmpty
 
         return normalizedDraftName != prompt.name
             || normalizedContent != prompt.content.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -659,7 +747,24 @@ public final class TransformsViewModel {
             || draftShortcut != prompt.shortcut
             || draftEnabledRuleIDs != profile.enabledRuleIDs
             || normalizedInstructions != (profile.customInstructions ?? "")
-            || draftUseWritingSamples != profile.useWritingSamples
+            || normalizedUseWritingSamples != savedUseWritingSamples
+    }
+
+    public var hasUnsavedDraft: Bool {
+        if isCreatingDraft {
+            let normalizedContent = draftContent.trimmingCharacters(in: .whitespacesAndNewlines)
+            let normalizedRunningLabel = draftRunningLabel.trimmingCharacters(in: .whitespacesAndNewlines)
+            let normalizedInstructions = draftCustomInstructions.trimmingCharacters(in: .whitespacesAndNewlines)
+            let defaultRuleIDs = TransformProfile.defaultProfile(for: draftPromptForRules).enabledRuleIDs
+            return !normalizedDraftName.isEmpty
+                || !normalizedContent.isEmpty
+                || !normalizedRunningLabel.isEmpty
+                || draftShortcut != nil
+                || draftEnabledRuleIDs != defaultRuleIDs
+                || !normalizedInstructions.isEmpty
+                || draftUseWritingSamples
+        }
+        return isDraftDirty
     }
 
     public var customTransforms: [Prompt] {

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorLoadCaptionTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorLoadCaptionTests.swift
@@ -73,7 +73,9 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
         let harness = try makeHarness(isReady: false, transcribeDelayMs: 90, hasCompletedFirstDictation: false)
 
         try await harness.startAndStop()
-        let shown = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == .preparing }
+        let shown = await waitUntil {
+            harness.coordinator.processingLoadCaptionForTesting?.isPreparingForTest == true
+        }
         XCTAssertTrue(shown)
         let cleared = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == nil }
         XCTAssertTrue(cleared)
@@ -96,7 +98,9 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
         let harness = try makeHarness(isReady: false, transcribeDelayMs: 140, hasCompletedFirstDictation: true)
 
         try await harness.startAndStop()
-        let shown = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == .preparing }
+        let shown = await waitUntil {
+            harness.coordinator.processingLoadCaptionForTesting?.isPreparingForTest == true
+        }
         XCTAssertTrue(shown)
         try await Task.sleep(for: .milliseconds(70))
 
@@ -130,7 +134,9 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
         )
 
         try await harness.startAndStop()
-        let shown = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == .preparing }
+        let shown = await waitUntil {
+            harness.coordinator.processingLoadCaptionForTesting?.isPreparingForTest == true
+        }
         XCTAssertTrue(shown)
         let cleared = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == nil }
         XCTAssertTrue(cleared)
@@ -143,7 +149,7 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
 
         try await harness.startAndStop()
         let shown = await waitUntil(timeoutMs: 3_000) {
-            harness.coordinator.processingLoadCaptionForTesting == .preparing
+            harness.coordinator.processingLoadCaptionForTesting?.isPreparingForTest == true
         }
         XCTAssertTrue(shown)
 
@@ -159,7 +165,9 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
         let harness = try makeHarness(isReady: false, transcribeDelayMs: 80)
 
         try await harness.startAndStop()
-        let firstShown = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == .preparing }
+        let firstShown = await waitUntil {
+            harness.coordinator.processingLoadCaptionForTesting?.isPreparingForTest == true
+        }
         XCTAssertTrue(firstShown)
         let firstCleared = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == nil }
         XCTAssertTrue(firstCleared)
@@ -443,5 +451,14 @@ private extension DictationOverlayViewModel.OverlayState {
     var isErrorForTest: Bool {
         if case .error = self { return true }
         return false
+    }
+}
+
+private extension DictationOverlayViewModel.ProcessingLoadCaption {
+    var isPreparingForTest: Bool {
+        switch self {
+        case .preparing, .preparingExtended: true
+        case .failed: false
+        }
     }
 }

--- a/Tests/MacParakeetTests/Hotkey/TransformsHotkeyRegistryTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/TransformsHotkeyRegistryTests.swift
@@ -65,6 +65,29 @@ final class TransformsHotkeyRegistryTests: XCTestCase {
         XCTAssertTrue(registry.isEmpty)
     }
 
+    func testDuplicateRegistrationKeepsFirstBinding() throws {
+        let registry = TransformsHotkeyRegistry()
+        let first = UUID()
+        let second = UUID()
+        let opt1 = KeyboardShortcut(
+            modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,
+            keyCode: 0x12,
+            keyLabel: "1"
+        )
+
+        registry.register(promptID: first, shortcut: opt1)
+        registry.register(promptID: second, shortcut: opt1)
+
+        var triggeredIDs: [UUID] = []
+        registry.onTrigger = { triggeredIDs.append($0) }
+
+        let keyDown = try XCTUnwrap(CGEvent(keyboardEventSource: nil, virtualKey: 0x12, keyDown: true))
+        keyDown.flags = .maskAlternate
+
+        XCTAssertNil(registry.handleEvent(type: .keyDown, event: keyDown))
+        XCTAssertEqual(triggeredIDs, [first])
+    }
+
     func testReplaceBindingsRebuildsTableFromScratch() {
         let registry = TransformsHotkeyRegistry()
         let a = UUID()
@@ -159,6 +182,36 @@ final class TransformsHotkeyRegistryTests: XCTestCase {
 
         let unrelatedKeyUp = try XCTUnwrap(CGEvent(keyboardEventSource: nil, virtualKey: 0x13, keyDown: false))
         XCTAssertNotNil(registry.handleEvent(type: .keyUp, event: unrelatedKeyUp))
+    }
+
+    func testTapDisabledRecoveryClearsPressedKeys() throws {
+        let registry = TransformsHotkeyRegistry()
+        let id = UUID()
+        registry.register(
+            promptID: id,
+            shortcut: KeyboardShortcut(
+                modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,
+                keyCode: 0x12,
+                keyLabel: "1"
+            )
+        )
+
+        var triggeredIDs: [UUID] = []
+        registry.onTrigger = { triggeredIDs.append($0) }
+
+        let keyDown = try XCTUnwrap(CGEvent(keyboardEventSource: nil, virtualKey: 0x12, keyDown: true))
+        keyDown.flags = .maskAlternate
+
+        XCTAssertNil(registry.handleEvent(type: .keyDown, event: keyDown))
+        XCTAssertEqual(triggeredIDs, [id])
+
+        _ = registry.handleEvent(type: .tapDisabledByTimeout, event: keyDown)
+
+        let recoveredKeyDown = try XCTUnwrap(CGEvent(keyboardEventSource: nil, virtualKey: 0x12, keyDown: true))
+        recoveredKeyDown.flags = .maskAlternate
+
+        XCTAssertNil(registry.handleEvent(type: .keyDown, event: recoveredKeyDown))
+        XCTAssertEqual(triggeredIDs, [id, id])
     }
 
     // MARK: - Collision detection

--- a/Tests/MacParakeetTests/ViewModels/TransformsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TransformsViewModelTests.swift
@@ -101,10 +101,13 @@ final class TransformsViewModelTests: XCTestCase {
         XCTAssertEqual(fresh.draftEnabledRuleIDs, ["polish.tone"])
         XCTAssertEqual(fresh.draftCustomInstructions, "Use contractions.")
         XCTAssertTrue(fresh.draftUseWritingSamples)
+        XCTAssertFalse(fresh.isDraftDirty)
     }
 
     func testSaveDraftPersistsProfileSettings() throws {
         let polish = viewModel.transforms.first(where: { $0.name == "Polish" })!
+        try writingSampleRepo.save(WritingSample(title: "Sample", text: (1...50).map { "word\($0)" }.joined(separator: " ")))
+        viewModel.loadWritingSamples()
         viewModel.selectTransform(polish)
         viewModel.draftEnabledRuleIDs = ["polish.concise", "polish.tone"]
         viewModel.draftCustomInstructions = "Keep the user's punctuation style."
@@ -166,11 +169,22 @@ final class TransformsViewModelTests: XCTestCase {
             sortOrder: 201
         )
         viewModel.save(prompt)
+        try? historyRepo.save(TransformHistoryEntry(
+            transformId: prompt.id,
+            transformName: prompt.name,
+            inputText: "rough",
+            outputText: "sharp",
+            capturePath: "ax",
+            replacementPath: "ax",
+            llmElapsedMs: 1,
+            totalElapsedMs: 2
+        ))
         XCTAssertEqual(viewModel.transforms.count, 4)
 
         XCTAssertTrue(viewModel.delete(prompt))
         XCTAssertEqual(viewModel.transforms.count, 3)
         XCTAssertFalse(viewModel.transforms.contains(where: { $0.id == prompt.id }))
+        XCTAssertEqual(try? historyRepo.count(transformId: prompt.id), 0)
     }
 
     func testDeleteBuiltInIsRejected() {
@@ -382,6 +396,8 @@ final class TransformsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.history.contains(where: { $0.transformId == polish.id }))
         XCTAssertEqual(viewModel.selectedHistory.map(\.inputText), ["old polish"])
         XCTAssertEqual(viewModel.selectedHistoryTotalCount, 1)
+        XCTAssertEqual(viewModel.historyCountsByTransformID[polish.id], 1)
+        XCTAssertEqual(viewModel.historyCountsByTransformID[distill.id], TransformsViewModel.historyFetchLimit)
     }
 
     func testDeleteAndClearHistory() async throws {
@@ -508,5 +524,62 @@ final class TransformsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.writingSamples.map(\.id), [saved.id])
         XCTAssertFalse(viewModel.isAddingWritingSample)
         XCTAssertNil(viewModel.writingSampleErrorMessage)
+    }
+
+    func testSavingDraftDoesNotPersistWritingSamplePreferenceWithoutSamples() throws {
+        let polish = viewModel.transforms.first(where: { $0.name == "Polish" })!
+        viewModel.selectTransform(polish)
+        viewModel.draftUseWritingSamples = true
+
+        XCTAssertTrue(
+            viewModel.saveDraft(
+                reservedHotkeys: [],
+                collisionChecker: StubCollisionChecker()
+            )
+        )
+
+        let saved = try XCTUnwrap(profileRepo.fetch(promptId: polish.id))
+        XCTAssertFalse(saved.useWritingSamples)
+        XCTAssertFalse(viewModel.draftUseWritingSamples)
+    }
+
+    func testTurningOnWritingSamplesWithoutSamplesStartsSampleEditor() {
+        XCTAssertTrue(viewModel.writingSamples.isEmpty)
+
+        viewModel.setDraftUseWritingSamples(true)
+
+        XCTAssertFalse(viewModel.draftUseWritingSamples)
+        XCTAssertTrue(viewModel.isAddingWritingSample)
+    }
+
+    func testDeletingLastWritingSampleDisablesDraftWritingSamples() throws {
+        let sample = WritingSample(
+            title: "Launch email",
+            text: (1...50).map { "word\($0)" }.joined(separator: " ")
+        )
+        try writingSampleRepo.save(sample)
+        viewModel.loadWritingSamples()
+        viewModel.draftUseWritingSamples = true
+
+        viewModel.deleteWritingSample(sample)
+
+        XCTAssertTrue(viewModel.writingSamples.isEmpty)
+        XCTAssertFalse(viewModel.draftUseWritingSamples)
+    }
+
+    func testHasUnsavedDraftCoversCreatingAndEditingStates() {
+        XCTAssertFalse(viewModel.hasUnsavedDraft)
+
+        viewModel.startCreatingTransform()
+        XCTAssertFalse(viewModel.hasUnsavedDraft)
+
+        viewModel.draftName = "Boss Mode"
+        XCTAssertTrue(viewModel.hasUnsavedDraft)
+
+        viewModel.cancelCreate()
+        XCTAssertFalse(viewModel.hasUnsavedDraft)
+
+        viewModel.draftCustomInstructions = "Be crisp."
+        XCTAssertTrue(viewModel.hasUnsavedDraft)
     }
 }

--- a/Tests/MacParakeetTests/Views/Settings/HotkeyRecorderViewTests.swift
+++ b/Tests/MacParakeetTests/Views/Settings/HotkeyRecorderViewTests.swift
@@ -147,4 +147,34 @@ final class HotkeyRecorderViewTests: XCTestCase {
             "⇧⌘M"
         )
     }
+
+    func testTransformShortcutRecorderUsesEscapeToCancelRecording() throws {
+        let escape = try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "\u{1b}",
+            charactersIgnoringModifiers: "\u{1b}",
+            isARepeat: false,
+            keyCode: 0x35
+        ))
+        let one = try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "1",
+            charactersIgnoringModifiers: "1",
+            isARepeat: false,
+            keyCode: 0x12
+        ))
+
+        XCTAssertTrue(ShortcutRecorderField.shouldCancelRecording(escape))
+        XCTAssertFalse(ShortcutRecorderField.shouldCancelRecording(one))
+    }
 }


### PR DESCRIPTION
## Summary
- Protect unsaved Transform draft edits before switching, creating, or canceling.
- Align Transform shortcut collision handling across the workbench, Settings, and runtime registration.
- Fix exact history badges, stale async history refreshes, custom Transform history cleanup, writing-sample no-op saves, and shortcut recorder polish.
- Surface the Transform progress label and improve accessibility labels for repeated icon actions.
- Harden a load-caption timing test that CI exposed as flaky while this PR was being verified.

## Verification
- swift test --filter Transform
- swift test --filter TransformsViewModelTests
- swift test --filter DictationFlowCoordinatorLoadCaptionTests
- swift test
- swift build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transform shortcuts surfaced to Settings for conflict detection
  * Unsaved-draft flow with confirmation before navigating away from edited transforms
  * New progress label in Transforms header

* **Bug Fixes**
  * Prevent duplicate shortcut bindings across transforms
  * Clear keyboard-event state after tap timeout to avoid stuck input
  * Deleting a transform also clears its history
  * Escape cancels shortcut recording

* **Improvements**
  * Better writing-samples preference handling and conditional toggle behavior
  * Refined accessibility labels and deterministic transform ordering

* **Tests**
  * Expanded tests for hotkey behavior, draft/writing-sample rules, and history tracking

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moona3k/macparakeet/pull/287)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->