### PR TITLE
Restore Transform history without the workbench

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -116,7 +116,7 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
     limit 20.
   - `transforms history show <id-prefix> [--json]` — full input/output for
     one row. ID prefixes must be at least 4 hex chars; `--json` maps
-    too-short-prefix to `errorType: "validation"`, missing-row to
+    invalid-prefix errors to `errorType: "validation"`, missing-row to
     `errorType: "lookup"`.
   - `transforms history delete <id-prefix> [--json]` / `transforms history
     clear [--json]` — single-row delete and bulk clear. `--json` emits

--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -107,6 +107,25 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
     `prompt`, `created_at`, `updated_at`). `transforms run --json`
     emits the LLM result envelope, and `transforms delete --json` emits
     `{deleted,id,name}`.
+- `transforms history list / show / delete / clear` — read/manage the
+  local Transform run history that the GUI's Transforms tab also surfaces.
+  Each completed Transform run records input, output, source app, capture
+  and replacement paths, and timing. Local-only; agents can use it to
+  verify what the dispatch table just produced without launching the app.
+  - `transforms history list [--limit N] [--json]` — newest first; default
+    limit 20.
+  - `transforms history show <id-prefix> [--json]` — full input/output for
+    one row. ID prefixes must be at least 4 hex chars; `--json` maps
+    too-short-prefix to `errorType: "validation"`, missing-row to
+    `errorType: "lookup"`.
+  - `transforms history delete <id-prefix> [--json]` / `transforms history
+    clear [--json]` — single-row delete and bulk clear. `--json` emits
+    `{ok, id}` / `{ok, deleted_count}` respectively.
+  - JSON payloads use a snake-cased `TransformHistoryDTO`
+    (`id`, `transform_id`, `transform_name`, `input_text`, `output_text`,
+    `source_app_bundle_id`, `source_app_name`, `capture_path`,
+    `replacement_path`, `llm_elapsed_ms`, `total_elapsed_ms`,
+    `created_at`, `updated_at`).
 
 ### Fixed
 

--- a/Sources/CLI/Commands/CLIHelpers.swift
+++ b/Sources/CLI/Commands/CLIHelpers.swift
@@ -294,7 +294,7 @@ enum CLIErrorType {
         if let history = error as? CLITransformHistoryError {
             switch history {
             case .notFound, .ambiguous: return lookup
-            case .prefixTooShort:       return validation
+            case .invalidPrefix:        return validation
             case .deleteFailed:         return runtime
             }
         }
@@ -391,7 +391,7 @@ private func rethrowWithOptionalJSONEnvelope(_ error: Error, json: Bool) throws 
     if let transforms = error as? CLITransformsError, transforms.isValidationMisuse {
         throw cliValidationMisuseExitCode
     }
-    if let history = error as? CLITransformHistoryError, case .prefixTooShort = history {
+    if let history = error as? CLITransformHistoryError, case .invalidPrefix = history {
         throw cliValidationMisuseExitCode
     }
     throw ExitCode.failure

--- a/Sources/CLI/Commands/CLIHelpers.swift
+++ b/Sources/CLI/Commands/CLIHelpers.swift
@@ -291,6 +291,13 @@ enum CLIErrorType {
         if let transforms = error as? CLITransformsError {
             return transforms.errorType
         }
+        if let history = error as? CLITransformHistoryError {
+            switch history {
+            case .notFound, .ambiguous: return lookup
+            case .prefixTooShort:       return validation
+            case .deleteFailed:         return runtime
+            }
+        }
         if let qpe = error as? QuickPromptCLIError {
             switch qpe {
             case .cannotDeleteBuiltIn: return validation
@@ -382,6 +389,9 @@ private func rethrowWithOptionalJSONEnvelope(_ error: Error, json: Bool) throws 
         throw cliValidationMisuseExitCode
     }
     if let transforms = error as? CLITransformsError, transforms.isValidationMisuse {
+        throw cliValidationMisuseExitCode
+    }
+    if let history = error as? CLITransformHistoryError, case .prefixTooShort = history {
         throw cliValidationMisuseExitCode
     }
     throw ExitCode.failure

--- a/Sources/CLI/Commands/TransformsCommand.swift
+++ b/Sources/CLI/Commands/TransformsCommand.swift
@@ -151,6 +151,7 @@ extension TransformsCommand {
                 try AppPaths.ensureDirectories()
                 let db = try DatabaseManager(path: resolvedDatabasePath(database))
                 let repo = PromptRepository(dbQueue: db.dbQueue)
+                let historyRepo = TransformHistoryRepository(dbQueue: db.dbQueue)
                 let transform = try findTransform(idOrName: idOrName, repo: repo)
 
                 let text = try readInput(input)
@@ -166,15 +167,47 @@ extension TransformsCommand {
 
                 if json {
                     let result = try await service.transformDetailed(text: text, prompt: transform.content)
+                    try saveCLITransformHistory(
+                        repo: historyRepo,
+                        transform: transform,
+                        inputText: text,
+                        outputText: result.output,
+                        inputPath: input,
+                        llmElapsedMs: result.latencyMs,
+                        totalElapsedMs: result.latencyMs
+                    )
                     try printJSON(result)
                 } else if stream {
+                    let startedAt = Date()
+                    var output = ""
                     let tokenStream = service.transformStream(text: text, prompt: transform.content)
                     for try await token in tokenStream {
+                        output += token
                         print(token, terminator: "")
                     }
                     print()
+                    let elapsedMs = elapsedMilliseconds(since: startedAt)
+                    try saveCLITransformHistory(
+                        repo: historyRepo,
+                        transform: transform,
+                        inputText: text,
+                        outputText: output,
+                        inputPath: input,
+                        llmElapsedMs: elapsedMs,
+                        totalElapsedMs: elapsedMs
+                    )
                 } else {
-                    print(try await service.transform(text: text, prompt: transform.content))
+                    let result = try await service.transformDetailed(text: text, prompt: transform.content)
+                    try saveCLITransformHistory(
+                        repo: historyRepo,
+                        transform: transform,
+                        inputText: text,
+                        outputText: result.output,
+                        inputPath: input,
+                        llmElapsedMs: result.latencyMs,
+                        totalElapsedMs: result.latencyMs
+                    )
+                    print(result.output)
                 }
             }
         }
@@ -532,6 +565,32 @@ private func transformHistoryRepo(database: String?) throws -> TransformHistoryR
     try AppPaths.ensureDirectories()
     let db = try DatabaseManager(path: resolvedDatabasePath(database))
     return TransformHistoryRepository(dbQueue: db.dbQueue)
+}
+
+private func saveCLITransformHistory(
+    repo: TransformHistoryRepositoryProtocol,
+    transform: Prompt,
+    inputText: String,
+    outputText: String,
+    inputPath: String,
+    llmElapsedMs: Int,
+    totalElapsedMs: Int
+) throws {
+    try repo.save(TransformHistoryEntry(
+        transformId: transform.id,
+        transformName: transform.name,
+        inputText: inputText,
+        outputText: outputText,
+        sourceAppName: "macparakeet-cli",
+        capturePath: inputPath == "-" ? "stdin" : "file",
+        replacementPath: "stdout",
+        llmElapsedMs: llmElapsedMs,
+        totalElapsedMs: totalElapsedMs
+    ))
+}
+
+private func elapsedMilliseconds(since startedAt: Date) -> Int {
+    max(0, Int(Date().timeIntervalSince(startedAt) * 1_000))
 }
 
 private func findTransformHistoryEntry(

--- a/Sources/CLI/Commands/TransformsCommand.swift
+++ b/Sources/CLI/Commands/TransformsCommand.swift
@@ -20,6 +20,7 @@ struct TransformsCommand: AsyncParsableCommand {
             RunSubcommand.self,
             CreateSubcommand.self,
             DeleteSubcommand.self,
+            HistorySubcommand.self,
         ],
         defaultSubcommand: ListSubcommand.self
     )
@@ -350,6 +351,311 @@ extension TransformsCommand {
             }
         }
     }
+}
+
+// MARK: - History
+
+extension TransformsCommand {
+    struct HistorySubcommand: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "history",
+            abstract: "Inspect and manage local Transform history.",
+            subcommands: [
+                ListSubcommand.self,
+                ShowSubcommand.self,
+                DeleteSubcommand.self,
+                ClearSubcommand.self,
+            ],
+            defaultSubcommand: ListSubcommand.self
+        )
+
+        struct ListSubcommand: ParsableCommand {
+            static let configuration = CommandConfiguration(
+                commandName: "list",
+                abstract: "List saved Transform runs, newest first."
+            )
+
+            @Option(help: "Maximum number of history rows to print.")
+            var limit: Int = 20
+
+            @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+            var json: Bool = false
+
+            @Option(help: "Path to SQLite database file (defaults to the app database).")
+            var database: String?
+
+            func validate() throws {
+                guard limit > 0 else {
+                    throw ValidationError("--limit must be greater than zero.")
+                }
+            }
+
+            func run() throws {
+                try emitJSONOrRethrow(json: json) {
+                    let repo = try transformHistoryRepo(database: database)
+                    let entries = try repo.fetchRecent(limit: limit)
+
+                    if json {
+                        try printJSON(entries.map(TransformHistoryDTO.init(entry:)))
+                        return
+                    }
+
+                    if entries.isEmpty {
+                        print("No Transform history found.")
+                        return
+                    }
+
+                    let formatter = ISO8601DateFormatter()
+                    for entry in entries {
+                        print("\(entry.id.uuidString.prefix(8))  \(formatter.string(from: entry.createdAt))  \(entry.transformName)  \(entry.sourceAppDisplayName)")
+                        print("  \(singleLineHistoryPreview(entry.outputText, maxLength: 140))")
+                    }
+                    print()
+                    print("\(entries.count) Transform history item(s)")
+                }
+            }
+        }
+
+        struct ShowSubcommand: ParsableCommand {
+            static let configuration = CommandConfiguration(
+                commandName: "show",
+                abstract: "Show one saved Transform run."
+            )
+
+            @Argument(help: "History item ID or ID prefix.")
+            var idPrefix: String
+
+            @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+            var json: Bool = false
+
+            @Option(help: "Path to SQLite database file (defaults to the app database).")
+            var database: String?
+
+            func run() throws {
+                try emitJSONOrRethrow(json: json) {
+                    let repo = try transformHistoryRepo(database: database)
+                    let entry = try findTransformHistoryEntry(idPrefix: idPrefix, repo: repo)
+
+                    if json {
+                        try printJSON(TransformHistoryDTO(entry: entry))
+                        return
+                    }
+
+                    let formatter = ISO8601DateFormatter()
+                    print("ID:           \(entry.id.uuidString)")
+                    print("Transform:    \(entry.transformName)")
+                    if let transformId = entry.transformId {
+                        print("Transform ID: \(transformId.uuidString)")
+                    }
+                    print("Source app:   \(entry.sourceAppDisplayName)")
+                    print("Capture:      \(entry.capturePath)")
+                    print("Replacement:  \(entry.replacementPath)")
+                    print("LLM:          \(entry.llmElapsedMs)ms")
+                    print("Total:        \(entry.totalElapsedMs)ms")
+                    print("Created:      \(formatter.string(from: entry.createdAt))")
+                    print()
+                    print("Input:")
+                    print(entry.inputText)
+                    print()
+                    print("Output:")
+                    print(entry.outputText)
+                }
+            }
+        }
+
+        struct DeleteSubcommand: ParsableCommand {
+            static let configuration = CommandConfiguration(
+                commandName: "delete",
+                abstract: "Delete one saved Transform history item."
+            )
+
+            @Argument(help: "History item ID or ID prefix.")
+            var idPrefix: String
+
+            @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+            var json: Bool = false
+
+            @Option(help: "Path to SQLite database file (defaults to the app database).")
+            var database: String?
+
+            func run() throws {
+                try emitJSONOrRethrow(json: json) {
+                    let repo = try transformHistoryRepo(database: database)
+                    let entry = try findTransformHistoryEntry(idPrefix: idPrefix, repo: repo)
+                    guard try repo.delete(id: entry.id) else {
+                        throw CLITransformHistoryError.deleteFailed(entry.id.uuidString)
+                    }
+
+                    if json {
+                        try printJSON(TransformHistoryDeleteResult(ok: true, id: entry.id.uuidString))
+                    } else {
+                        print("Deleted Transform history item \(entry.id.uuidString.prefix(8))")
+                    }
+                }
+            }
+        }
+
+        struct ClearSubcommand: ParsableCommand {
+            static let configuration = CommandConfiguration(
+                commandName: "clear",
+                abstract: "Clear all local Transform history."
+            )
+
+            @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+            var json: Bool = false
+
+            @Option(help: "Path to SQLite database file (defaults to the app database).")
+            var database: String?
+
+            func run() throws {
+                try emitJSONOrRethrow(json: json) {
+                    let repo = try transformHistoryRepo(database: database)
+                    let deletedCount = try repo.count()
+                    try repo.deleteAll()
+
+                    if json {
+                        try printJSON(TransformHistoryClearResult(ok: true, deletedCount: deletedCount))
+                    } else {
+                        print("Cleared \(deletedCount) Transform history item(s)")
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - History helpers
+
+private let transformHistoryIDPrefixMinimumLength = 4
+
+private func transformHistoryRepo(database: String?) throws -> TransformHistoryRepository {
+    try AppPaths.ensureDirectories()
+    let db = try DatabaseManager(path: resolvedDatabasePath(database))
+    return TransformHistoryRepository(dbQueue: db.dbQueue)
+}
+
+private func findTransformHistoryEntry(
+    idPrefix: String,
+    repo: TransformHistoryRepositoryProtocol
+) throws -> TransformHistoryEntry {
+    let trimmed = idPrefix.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+        throw CLITransformHistoryError.notFound(idPrefix)
+    }
+
+    if let uuid = UUID(uuidString: trimmed), let exact = try repo.fetch(id: uuid) {
+        return exact
+    }
+
+    guard trimmed.count >= transformHistoryIDPrefixMinimumLength else {
+        throw CLITransformHistoryError.prefixTooShort(
+            min: transformHistoryIDPrefixMinimumLength,
+            provided: trimmed
+        )
+    }
+
+    let matches = try repo.fetch(idPrefix: trimmed)
+    if matches.count == 1 {
+        return matches[0]
+    }
+    if matches.count > 1 {
+        throw CLITransformHistoryError.ambiguous(trimmed, matches.map { String($0.id.uuidString.prefix(8)) })
+    }
+    throw CLITransformHistoryError.notFound(trimmed)
+}
+
+private func singleLineHistoryPreview(_ text: String, maxLength: Int) -> String {
+    let collapsed = text
+        .replacingOccurrences(of: "\n", with: " ")
+        .replacingOccurrences(of: "\t", with: " ")
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    guard collapsed.count > maxLength else { return collapsed }
+    return String(collapsed.prefix(max(0, maxLength - 1))) + "..."
+}
+
+struct TransformHistoryDTO: Encodable {
+    let id: String
+    let transformId: String?
+    let transformName: String
+    let inputText: String
+    let outputText: String
+    let sourceAppBundleID: String?
+    let sourceAppName: String?
+    let capturePath: String
+    let replacementPath: String
+    let llmElapsedMs: Int
+    let totalElapsedMs: Int
+    let createdAt: Date
+    let updatedAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case transformId = "transform_id"
+        case transformName = "transform_name"
+        case inputText = "input_text"
+        case outputText = "output_text"
+        case sourceAppBundleID = "source_app_bundle_id"
+        case sourceAppName = "source_app_name"
+        case capturePath = "capture_path"
+        case replacementPath = "replacement_path"
+        case llmElapsedMs = "llm_elapsed_ms"
+        case totalElapsedMs = "total_elapsed_ms"
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+    }
+
+    init(entry: TransformHistoryEntry) {
+        id = entry.id.uuidString
+        transformId = entry.transformId?.uuidString
+        transformName = entry.transformName
+        inputText = entry.inputText
+        outputText = entry.outputText
+        sourceAppBundleID = entry.sourceAppBundleID
+        sourceAppName = entry.sourceAppName
+        capturePath = entry.capturePath
+        replacementPath = entry.replacementPath
+        llmElapsedMs = entry.llmElapsedMs
+        totalElapsedMs = entry.totalElapsedMs
+        createdAt = entry.createdAt
+        updatedAt = entry.updatedAt
+    }
+}
+
+struct TransformHistoryDeleteResult: Encodable {
+    let ok: Bool
+    let id: String
+}
+
+struct TransformHistoryClearResult: Encodable {
+    let ok: Bool
+    let deletedCount: Int
+
+    enum CodingKeys: String, CodingKey {
+        case ok
+        case deletedCount = "deleted_count"
+    }
+}
+
+enum CLITransformHistoryError: Error, CustomStringConvertible, LocalizedError {
+    case notFound(String)
+    case ambiguous(String, [String])
+    case prefixTooShort(min: Int, provided: String)
+    case deleteFailed(String)
+
+    var description: String {
+        switch self {
+        case .notFound(let value):
+            return "No Transform history item matching '\(value)'"
+        case .ambiguous(let value, let matches):
+            return "Ambiguous Transform history ID '\(value)' (matches: \(matches.joined(separator: ", ")))"
+        case .prefixTooShort(let min, let provided):
+            return "Transform history ID prefix '\(provided)' is too short. Use at least \(min) characters."
+        case .deleteFailed(let value):
+            return "Failed to delete Transform history item '\(value)'"
+        }
+    }
+
+    var errorDescription: String? { description }
 }
 
 // MARK: - Lookup helper

--- a/Sources/CLI/Commands/TransformsCommand.swift
+++ b/Sources/CLI/Commands/TransformsCommand.swift
@@ -548,14 +548,23 @@ private func findTransformHistoryEntry(
     }
 
     // Length and hex-character validation against the hyphenless form so
-    // inputs like "12--" don't pass length-only checks then silently miss.
+    // inputs like "12--" don't pass length-only checks then silently miss
+    // and "12zz" surfaces as a clearer error than "too short".
     let normalized = trimmed.replacingOccurrences(of: "-", with: "")
     let hexCharacters = Set("0123456789abcdefABCDEF")
     let isHex = !normalized.isEmpty && normalized.allSatisfy { hexCharacters.contains($0) }
-    guard isHex, normalized.count >= transformHistoryIDPrefixMinimumLength else {
-        throw CLITransformHistoryError.prefixTooShort(
+    if !isHex {
+        throw CLITransformHistoryError.invalidPrefix(
             min: transformHistoryIDPrefixMinimumLength,
-            provided: trimmed
+            provided: trimmed,
+            reason: .nonHex
+        )
+    }
+    guard normalized.count >= transformHistoryIDPrefixMinimumLength else {
+        throw CLITransformHistoryError.invalidPrefix(
+            min: transformHistoryIDPrefixMinimumLength,
+            provided: trimmed,
+            reason: .tooShort
         )
     }
 
@@ -644,8 +653,13 @@ struct TransformHistoryClearResult: Encodable {
 enum CLITransformHistoryError: Error, CustomStringConvertible, LocalizedError {
     case notFound(String)
     case ambiguous(String, [String])
-    case prefixTooShort(min: Int, provided: String)
+    case invalidPrefix(min: Int, provided: String, reason: InvalidPrefixReason)
     case deleteFailed(String)
+
+    enum InvalidPrefixReason {
+        case tooShort
+        case nonHex
+    }
 
     var description: String {
         switch self {
@@ -653,8 +667,13 @@ enum CLITransformHistoryError: Error, CustomStringConvertible, LocalizedError {
             return "No Transform history item matching '\(value)'"
         case .ambiguous(let value, let matches):
             return "Ambiguous Transform history ID '\(value)' (matches: \(matches.joined(separator: ", ")))"
-        case .prefixTooShort(let min, let provided):
-            return "Transform history ID prefix '\(provided)' is too short. Use at least \(min) characters."
+        case .invalidPrefix(let min, let provided, let reason):
+            switch reason {
+            case .tooShort:
+                return "Transform history ID prefix '\(provided)' is too short. Use at least \(min) hex characters."
+            case .nonHex:
+                return "Transform history ID prefix '\(provided)' contains non-hex characters. Use \(min)+ hex characters (0-9, a-f), optionally with hyphens."
+            }
         case .deleteFailed(let value):
             return "Failed to delete Transform history item '\(value)'"
         }

--- a/Sources/CLI/Commands/TransformsCommand.swift
+++ b/Sources/CLI/Commands/TransformsCommand.swift
@@ -547,7 +547,12 @@ private func findTransformHistoryEntry(
         return exact
     }
 
-    guard trimmed.count >= transformHistoryIDPrefixMinimumLength else {
+    // Length and hex-character validation against the hyphenless form so
+    // inputs like "12--" don't pass length-only checks then silently miss.
+    let normalized = trimmed.replacingOccurrences(of: "-", with: "")
+    let hexCharacters = Set("0123456789abcdefABCDEF")
+    let isHex = !normalized.isEmpty && normalized.allSatisfy { hexCharacters.contains($0) }
+    guard isHex, normalized.count >= transformHistoryIDPrefixMinimumLength else {
         throw CLITransformHistoryError.prefixTooShort(
             min: transformHistoryIDPrefixMinimumLength,
             provided: trimmed

--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -12,6 +12,7 @@ final class AppEnvironment {
     let chatConversationRepo: ChatConversationRepository
     let promptRepo: PromptRepository
     let promptResultRepo: PromptResultRepository
+    let transformHistoryRepo: TransformHistoryRepository
     let quickPromptRepo: QuickPromptRepository
     let sttRuntime: STTRuntime
     let sttScheduler: STTScheduler
@@ -48,6 +49,7 @@ final class AppEnvironment {
         chatConversationRepo = ChatConversationRepository(dbQueue: databaseManager.dbQueue)
         promptRepo = PromptRepository(dbQueue: databaseManager.dbQueue)
         promptResultRepo = PromptResultRepository(dbQueue: databaseManager.dbQueue)
+        transformHistoryRepo = TransformHistoryRepository(dbQueue: databaseManager.dbQueue)
         quickPromptRepo = QuickPromptRepository(dbQueue: databaseManager.dbQueue)
 
         // Services

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -128,7 +128,12 @@ final class AppEnvironmentConfigurer {
             self?.settingsViewModel.refreshStats()
         }
         promptsViewModel.configure(repo: env.promptRepo)
-        transformsViewModel.configure(repo: env.promptRepo, hasLLMProvider: hasLLMConfig)
+        transformsViewModel.configure(
+            repo: env.promptRepo,
+            historyRepo: env.transformHistoryRepo,
+            clipboardService: env.clipboardService,
+            hasLLMProvider: hasLLMConfig
+        )
         llmSettingsViewModel.configure(
             configStore: env.llmConfigStore,
             llmClient: env.llmClient

--- a/Sources/MacParakeet/App/TransformsCoordinator.swift
+++ b/Sources/MacParakeet/App/TransformsCoordinator.swift
@@ -278,6 +278,10 @@ final class TransformsCoordinator {
             llmElapsedMs: result.llmElapsedMs,
             totalElapsedMs: result.totalElapsedMs
         )
+        // Intentional silent-on-failure: the rewrite already succeeded
+        // (text was pasted into the host app), so a failed history write
+        // is a secondary concern. We log to os.log for support workflows
+        // but don't surface to the user — they already got their result.
         Task.detached { [historyRepository, logger] in
             do {
                 try historyRepository.save(entry)

--- a/Sources/MacParakeet/App/TransformsCoordinator.swift
+++ b/Sources/MacParakeet/App/TransformsCoordinator.swift
@@ -23,6 +23,7 @@ import OSLog
 final class TransformsCoordinator {
     private let llmServiceProvider: () -> LLMServiceProtocol?
     private let promptRepository: PromptRepositoryProtocol
+    private let historyRepository: TransformHistoryRepositoryProtocol?
     private let reservedHotkeysProvider: () -> [TransformShortcutReservedHotkey]
     private let logger = Logger(subsystem: "com.macparakeet", category: "TransformsCoordinator")
 
@@ -48,10 +49,12 @@ final class TransformsCoordinator {
     init(
         llmServiceProvider: @escaping () -> LLMServiceProtocol?,
         promptRepository: PromptRepositoryProtocol,
+        historyRepository: TransformHistoryRepositoryProtocol? = nil,
         reservedHotkeysProvider: @escaping () -> [TransformShortcutReservedHotkey] = { [] }
     ) {
         self.llmServiceProvider = llmServiceProvider
         self.promptRepository = promptRepository
+        self.historyRepository = historyRepository
         self.reservedHotkeysProvider = reservedHotkeysProvider
     }
 
@@ -231,6 +234,7 @@ final class TransformsCoordinator {
                     llmMs: result.llmElapsedMs,
                     totalMs: result.totalElapsedMs
                 ))
+                self.saveHistoryEntry(prompt: prompt, result: result)
                 self.logger.notice("transforms: \(runningTransformName, privacy: .public) completed")
             } catch let error as TransformExecutorError {
                 guard self.activeRunID == runID else { return }
@@ -256,6 +260,32 @@ final class TransformsCoordinator {
                 guard self.activeRunID == runID else { return }
                 self.panelController?.fail(message: error.localizedDescription)
                 Telemetry.send(.transformFailed(transformName: telemetryName, reason: .llmFailed))
+            }
+        }
+    }
+
+    private func saveHistoryEntry(prompt: Prompt, result: TransformExecutionResult) {
+        guard let historyRepository else { return }
+        let entry = TransformHistoryEntry(
+            transformId: prompt.id,
+            transformName: prompt.name,
+            inputText: result.inputText,
+            outputText: result.outputText,
+            sourceAppBundleID: result.target?.bundleIdentifier,
+            sourceAppName: result.target?.localizedName,
+            capturePath: result.captureTag,
+            replacementPath: result.path.rawValue,
+            llmElapsedMs: result.llmElapsedMs,
+            totalElapsedMs: result.totalElapsedMs
+        )
+        Task.detached { [historyRepository, logger] in
+            do {
+                try historyRepository.save(entry)
+                await MainActor.run {
+                    NotificationCenter.default.post(name: .transformHistoryChanged, object: nil)
+                }
+            } catch {
+                logger.error("transforms: failed to save history entry: \(error.localizedDescription, privacy: .public)")
             }
         }
     }

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -421,6 +421,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let transforms = TransformsCoordinator(
             llmServiceProvider: llmServiceProvider,
             promptRepository: env.promptRepo,
+            historyRepository: env.transformHistoryRepo,
             reservedHotkeysProvider: { [weak self] in
                 self?.transformReservedHotkeysForTransforms() ?? []
             }

--- a/Sources/MacParakeet/Views/MainWindowState.swift
+++ b/Sources/MacParakeet/Views/MainWindowState.swift
@@ -28,4 +28,7 @@ extension Notification.Name {
     /// `TransformsCoordinator` can reload bindings into the hotkey
     /// registry.
     static let transformsBindingsChanged = Notification.Name("com.macparakeet.transforms.bindingsChanged")
+    /// Posted after a successful Transform is saved to local history so the
+    /// Transforms tab can refresh if it is visible.
+    static let transformHistoryChanged = Notification.Name("com.macparakeet.transforms.historyChanged")
 }

--- a/Sources/MacParakeet/Views/Transforms/TransformsView.swift
+++ b/Sources/MacParakeet/Views/Transforms/TransformsView.swift
@@ -39,6 +39,8 @@ struct TransformsView: View {
                 myTransformsHeader
                 transformGrid
 
+                historySection
+
                 footerActions
             }
             .padding(.horizontal, DesignSystem.Spacing.xl)
@@ -46,6 +48,12 @@ struct TransformsView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .background(DesignSystem.Colors.background)
+        .onAppear {
+            Task { await viewModel.loadHistory() }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .transformHistoryChanged)) { _ in
+            Task { await viewModel.loadHistory() }
+        }
         .alert(
             "Delete this Transform?",
             isPresented: Binding(
@@ -67,6 +75,37 @@ struct TransformsView: View {
             }
         } message: { transform in
             Text("“\(transform.name)” will be removed. You can re-create it later.")
+        }
+        .alert(
+            "Delete history item?",
+            isPresented: Binding(
+                get: { viewModel.pendingDeleteHistoryEntry != nil },
+                set: { if !$0 { viewModel.pendingDeleteHistoryEntry = nil } }
+            ),
+            presenting: viewModel.pendingDeleteHistoryEntry
+        ) { entry in
+            Button("Delete", role: .destructive) {
+                Task {
+                    await viewModel.confirmPendingHistoryDelete()
+                }
+            }
+            Button("Cancel", role: .cancel) {
+                viewModel.pendingDeleteHistoryEntry = nil
+            }
+        } message: { entry in
+            Text("The saved “\(entry.transformName)” input and output will be removed from local history.")
+        }
+        .alert("Clear Transform history?", isPresented: $viewModel.isConfirmingClearHistory) {
+            Button("Clear History", role: .destructive) {
+                Task {
+                    await viewModel.clearHistory()
+                }
+            }
+            Button("Cancel", role: .cancel) {
+                viewModel.isConfirmingClearHistory = false
+            }
+        } message: {
+            Text("All saved Transform runs will be removed from local history.")
         }
     }
 
@@ -220,6 +259,235 @@ struct TransformsView: View {
             Spacer()
         }
         .padding(.top, DesignSystem.Spacing.md)
+    }
+
+    @ViewBuilder
+    private var historySection: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+            HStack(alignment: .firstTextBaseline) {
+                Text("History")
+                    .font(DesignSystem.Typography.pageTitle)
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+                if !viewModel.history.isEmpty {
+                    Text("\(viewModel.totalHistoryCount)")
+                        .font(DesignSystem.Typography.duration)
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Capsule().fill(DesignSystem.Colors.surfaceElevated))
+                }
+                Spacer()
+                if !viewModel.history.isEmpty {
+                    Button(role: .destructive) {
+                        viewModel.isConfirmingClearHistory = true
+                    } label: {
+                        Label("Clear", systemImage: "trash")
+                    }
+                    .parakeetAction(.subtle)
+                    .controlSize(.small)
+                }
+            }
+
+            if let historyError = viewModel.historyErrorMessage {
+                HStack(spacing: DesignSystem.Spacing.sm) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(DesignSystem.Colors.warningAmber)
+                    Text(historyError)
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    Spacer()
+                }
+                .padding(DesignSystem.Spacing.md)
+                .background(DesignSystem.Colors.surfaceElevated)
+                .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius))
+            } else if viewModel.history.isEmpty {
+                TransformHistoryEmptyState()
+            } else {
+                LazyVStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+                    ForEach(viewModel.history) { entry in
+                        TransformHistoryRow(
+                            entry: entry,
+                            isCopied: viewModel.copiedHistoryEntryID == entry.id,
+                            onCopy: {
+                                Task {
+                                    await viewModel.copyOutputToClipboard(entry)
+                                }
+                            },
+                            onDelete: { viewModel.pendingDeleteHistoryEntry = entry }
+                        )
+                    }
+                }
+            }
+        }
+        .padding(.top, DesignSystem.Spacing.lg)
+    }
+}
+
+// MARK: - Transform history
+
+private struct TransformHistoryEmptyState: View {
+    var body: some View {
+        HStack(spacing: DesignSystem.Spacing.md) {
+            Image(systemName: "clock.arrow.circlepath")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(DesignSystem.Colors.textTertiary)
+                .frame(width: 34, height: 34)
+                .background(Circle().fill(DesignSystem.Colors.surfaceElevated))
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text("No saved Transform runs yet")
+                    .font(DesignSystem.Typography.body.weight(.semibold))
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+                Text("Completed edits will appear here.")
+                    .font(DesignSystem.Typography.bodySmall)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+            }
+            Spacer()
+        }
+        .padding(DesignSystem.Spacing.lg)
+        .background(DesignSystem.Colors.cardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius))
+        .overlay {
+            RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
+                .stroke(DesignSystem.Colors.border.opacity(0.6), lineWidth: 0.5)
+        }
+    }
+}
+
+private struct TransformHistoryRow: View {
+    private static let todayTimeFormat = Date.FormatStyle(date: .omitted, time: .shortened)
+    private static let dateTimeFormat = Date.FormatStyle(date: .numeric, time: .shortened)
+
+    let entry: TransformHistoryEntry
+    let isCopied: Bool
+    let onCopy: () -> Void
+    let onDelete: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            HStack(alignment: .center, spacing: DesignSystem.Spacing.sm) {
+                Image(systemName: "wand.and.stars")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(DesignSystem.Colors.accent)
+                    .frame(width: 26, height: 26)
+                    .background(Circle().fill(DesignSystem.Colors.accentLight))
+
+                Text(entry.transformName)
+                    .font(DesignSystem.Typography.caption.weight(.semibold))
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+
+                Text("·")
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textTertiary)
+
+                Text(entry.sourceAppDisplayName)
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    .lineLimit(1)
+
+                Text("·")
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textTertiary)
+
+                Text(formatTime(entry.createdAt))
+                    .font(DesignSystem.Typography.timestamp)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+
+                Spacer(minLength: DesignSystem.Spacing.sm)
+
+                if isCopied {
+                    Text("Copied")
+                        .font(DesignSystem.Typography.micro)
+                        .foregroundStyle(DesignSystem.Colors.successGreen)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 3)
+                        .background(Capsule().fill(DesignSystem.Colors.successGreen.opacity(0.12)))
+                        .transition(.opacity.combined(with: .scale(scale: 0.96)))
+                }
+
+                TransformHistoryIconButton(
+                    systemImage: isCopied ? "checkmark" : "doc.on.clipboard",
+                    color: isCopied ? DesignSystem.Colors.successGreen : DesignSystem.Colors.textSecondary,
+                    help: "Copy transformed text",
+                    action: onCopy
+                )
+                TransformHistoryIconButton(
+                    systemImage: "trash",
+                    color: DesignSystem.Colors.textSecondary,
+                    help: "Delete history item",
+                    action: onDelete
+                )
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(entry.outputText)
+                    .font(DesignSystem.Typography.body)
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+                    .lineLimit(3)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Text(entry.inputText)
+                    .font(DesignSystem.Typography.bodySmall)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    .lineLimit(2)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.leading, DesignSystem.Spacing.md)
+                    .overlay(alignment: .leading) {
+                        Rectangle()
+                            .fill(DesignSystem.Colors.border)
+                            .frame(width: 2)
+                    }
+            }
+        }
+        .padding(DesignSystem.Spacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
+                .fill(isHovered ? DesignSystem.Colors.surfaceElevated.opacity(0.7) : DesignSystem.Colors.cardBackground)
+                .cardShadow(isHovered ? DesignSystem.Shadows.cardHover : DesignSystem.Shadows.cardRest)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
+                .stroke(isHovered ? DesignSystem.Colors.accent.opacity(0.25) : DesignSystem.Colors.border.opacity(0.55), lineWidth: 0.5)
+        }
+        .onHover { hovering in
+            withAnimation(DesignSystem.Animation.hoverTransition) {
+                isHovered = hovering
+            }
+        }
+        .animation(DesignSystem.Animation.hoverTransition, value: isCopied)
+    }
+
+    private func formatTime(_ date: Date) -> String {
+        date.formatted(Calendar.current.isDateInToday(date) ? Self.todayTimeFormat : Self.dateTimeFormat)
+    }
+}
+
+private struct TransformHistoryIconButton: View {
+    let systemImage: String
+    let color: Color
+    let help: String
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemImage)
+                .font(.system(size: 12, weight: .medium))
+                .frame(width: 28, height: 28)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(isHovered ? Color.primary.opacity(0.08) : .clear)
+                )
+                .contentShape(Rectangle())
+        }
+        .parakeetAction(.subtle)
+        .foregroundStyle(isHovered ? DesignSystem.Colors.textPrimary : color)
+        .help(help)
+        .onHover { isHovered = $0 }
     }
 }
 

--- a/Sources/MacParakeet/Views/Transforms/TransformsView.swift
+++ b/Sources/MacParakeet/Views/Transforms/TransformsView.swift
@@ -84,9 +84,14 @@ struct TransformsView: View {
             ),
             presenting: viewModel.pendingDeleteHistoryEntry
         ) { entry in
+            // Use the closure-captured `entry`, not `pendingDeleteHistoryEntry`
+            // via a wrapper method. SwiftUI clears the binding (and the
+            // pending field) before this Task runs, so reading the pending
+            // field would silently no-op the deletion.
             Button("Delete", role: .destructive) {
                 Task {
-                    await viewModel.confirmPendingHistoryDelete()
+                    viewModel.pendingDeleteHistoryEntry = nil
+                    await viewModel.deleteHistoryEntry(entry)
                 }
             }
             Button("Cancel", role: .cancel) {

--- a/Sources/MacParakeet/Views/Transforms/TransformsView.swift
+++ b/Sources/MacParakeet/Views/Transforms/TransformsView.swift
@@ -306,7 +306,9 @@ struct TransformsView: View {
                 .padding(DesignSystem.Spacing.md)
                 .background(DesignSystem.Colors.surfaceElevated)
                 .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius))
-            } else if viewModel.history.isEmpty {
+            }
+
+            if viewModel.history.isEmpty {
                 TransformHistoryEmptyState()
             } else {
                 LazyVStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {

--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -747,9 +747,16 @@ public final class DatabaseManager: Sendable {
         // existing developer/prerelease databases from retaining selected-text
         // rewrite history or writing samples after the feature was reverted.
         migrator.registerMigration("v0.16-drop-transform-workbench-tables") { db in
+            let historyAlreadyRestored = try Bool.fetchOne(
+                db,
+                sql: "SELECT EXISTS(SELECT 1 FROM grdb_migrations WHERE identifier = ?)",
+                arguments: ["v0.17-recreate-transform-history"]
+            ) ?? false
             try db.execute(sql: "DROP TABLE IF EXISTS transform_profiles")
             try db.execute(sql: "DROP TABLE IF EXISTS writing_samples")
-            try db.execute(sql: "DROP TABLE IF EXISTS transform_history")
+            if !historyAlreadyRestored {
+                try db.execute(sql: "DROP TABLE IF EXISTS transform_history")
+            }
         }
 
         // v0.17 — Restore local Transform run history (without the workbench

--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -752,6 +752,40 @@ public final class DatabaseManager: Sendable {
             try db.execute(sql: "DROP TABLE IF EXISTS transform_history")
         }
 
+        // v0.17 — Restore local Transform run history (without the workbench
+        // profiles/writing-samples that v0.16 cleaned up). Recreates the same
+        // table v0.14 defined so dev databases that lost it in v0.16 get it
+        // back; fresh installs land here after v0.14/v0.15/v0.16 run in order.
+        migrator.registerMigration("v0.17-recreate-transform-history") { db in
+            try db.create(table: "transform_history", ifNotExists: true) { t in
+                t.column("id", .text).primaryKey()
+                t.column("transformId", .text)
+                t.column("transformName", .text).notNull()
+                t.column("inputText", .text).notNull()
+                t.column("outputText", .text).notNull()
+                t.column("sourceAppBundleID", .text)
+                t.column("sourceAppName", .text)
+                t.column("capturePath", .text).notNull()
+                t.column("replacementPath", .text).notNull()
+                t.column("llmElapsedMs", .integer).notNull().defaults(to: 0)
+                t.column("totalElapsedMs", .integer).notNull().defaults(to: 0)
+                t.column("createdAt", .text).notNull()
+                t.column("updatedAt", .text).notNull()
+            }
+            try db.create(
+                index: "idx_transform_history_created_at",
+                on: "transform_history",
+                columns: ["createdAt"],
+                ifNotExists: true
+            )
+            try db.create(
+                index: "idx_transform_history_transform_id",
+                on: "transform_history",
+                columns: ["transformId"],
+                ifNotExists: true
+            )
+        }
+
         try migrator.migrate(dbQueue)
         try reconcileBuiltInPrompts()
         try reconcileBuiltInQuickPrompts()

--- a/Sources/MacParakeetCore/Database/README.md
+++ b/Sources/MacParakeetCore/Database/README.md
@@ -24,6 +24,7 @@ process.
   - `PromptResultRepository.swift` — saved prompt outputs.
   - `QuickPromptRepository.swift` — quick-prompt entries (Ask tab).
   - `ChatConversationRepository.swift` — multi-turn chat history.
+  - `TransformHistoryRepository.swift` — local Transform run history (input/output/source app/timings; ADR-022).
 
 ## Cross-references
 

--- a/Sources/MacParakeetCore/Database/TransformHistoryRepository.swift
+++ b/Sources/MacParakeetCore/Database/TransformHistoryRepository.swift
@@ -104,7 +104,17 @@ public final class TransformHistoryRepository: TransformHistoryRepositoryProtoco
 
     public func delete(id: UUID) throws -> Bool {
         try dbQueue.write { db in
-            try TransformHistoryEntry.deleteOne(db, key: id)
+            if try TransformHistoryEntry.deleteOne(db, key: id) {
+                return true
+            }
+            // Historical/prerelease rows may have TEXT UUID primary keys,
+            // while GRDB persists new UUID keys as BLOBs. Prefix lookup can
+            // surface either form, so delete needs the same legacy fallback.
+            try db.execute(
+                sql: "DELETE FROM transform_history WHERE lower(id) = ?",
+                arguments: [id.uuidString.lowercased()]
+            )
+            return db.changesCount > 0
         }
     }
 

--- a/Sources/MacParakeetCore/Database/TransformHistoryRepository.swift
+++ b/Sources/MacParakeetCore/Database/TransformHistoryRepository.swift
@@ -1,0 +1,99 @@
+import Foundation
+import GRDB
+
+public protocol TransformHistoryRepositoryProtocol: Sendable {
+    func save(_ entry: TransformHistoryEntry) throws
+    func fetchAll() throws -> [TransformHistoryEntry]
+    func fetchRecent(limit: Int) throws -> [TransformHistoryEntry]
+    func fetch(id: UUID) throws -> TransformHistoryEntry?
+    func fetch(idPrefix: String) throws -> [TransformHistoryEntry]
+    func count() throws -> Int
+    func delete(id: UUID) throws -> Bool
+    func deleteAll() throws
+}
+
+public final class TransformHistoryRepository: TransformHistoryRepositoryProtocol {
+    private let dbQueue: DatabaseQueue
+
+    public init(dbQueue: DatabaseQueue) {
+        self.dbQueue = dbQueue
+    }
+
+    public func save(_ entry: TransformHistoryEntry) throws {
+        try dbQueue.write { db in
+            try entry.save(db)
+        }
+    }
+
+    public func fetchAll() throws -> [TransformHistoryEntry] {
+        try dbQueue.read { db in
+            try TransformHistoryEntry
+                .order(TransformHistoryEntry.Columns.createdAt.desc)
+                .fetchAll(db)
+        }
+    }
+
+    public func fetchRecent(limit: Int = 200) throws -> [TransformHistoryEntry] {
+        try dbQueue.read { db in
+            try TransformHistoryEntry
+                .order(TransformHistoryEntry.Columns.createdAt.desc)
+                .limit(max(0, limit))
+                .fetchAll(db)
+        }
+    }
+
+    public func fetch(id: UUID) throws -> TransformHistoryEntry? {
+        try dbQueue.read { db in
+            try TransformHistoryEntry.fetchOne(db, key: id)
+        }
+    }
+
+    public func fetch(idPrefix: String) throws -> [TransformHistoryEntry] {
+        let escapedPrefix = Self.escapeLikePattern(
+            idPrefix
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased()
+                .replacingOccurrences(of: "-", with: "")
+        )
+        guard !escapedPrefix.isEmpty else { return [] }
+        let pattern = "\(escapedPrefix)%"
+
+        return try dbQueue.read { db in
+            try TransformHistoryEntry
+                .filter(
+                    sql: """
+                        (lower(hex(id)) LIKE ? ESCAPE '\\'
+                            OR replace(lower(id), '-', '') LIKE ? ESCAPE '\\')
+                        """,
+                    arguments: StatementArguments([pattern, pattern])
+                )
+                .order(TransformHistoryEntry.Columns.createdAt.desc)
+                .fetchAll(db)
+        }
+    }
+
+    public func count() throws -> Int {
+        try dbQueue.read { db in
+            try TransformHistoryEntry.fetchCount(db)
+        }
+    }
+
+    public func delete(id: UUID) throws -> Bool {
+        try dbQueue.write { db in
+            try TransformHistoryEntry.deleteOne(db, key: id)
+        }
+    }
+
+    public func deleteAll() throws {
+        _ = try dbQueue.write { db in
+            try TransformHistoryEntry.deleteAll(db)
+        }
+    }
+
+    private static func escapeLikePattern(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "%", with: "\\%")
+            .replacingOccurrences(of: "_", with: "\\_")
+    }
+}

--- a/Sources/MacParakeetCore/Database/TransformHistoryRepository.swift
+++ b/Sources/MacParakeetCore/Database/TransformHistoryRepository.swift
@@ -66,6 +66,13 @@ public final class TransformHistoryRepository: TransformHistoryRepositoryProtoco
     }
 
     public func fetch(idPrefix: String) throws -> [TransformHistoryEntry] {
+        // GRDB's `PersistableRecord` writes a Codable `UUID` as a 16-byte
+        // BLOB into the `.text`-affinity `id` column (SQLite's type system
+        // is dynamic). `hex(id)` returns the lowercase hex of those bytes
+        // — that's the branch that matches a hex prefix. The `replace(...)`
+        // branch handles the (rare) case where a row was written as a
+        // TEXT UUID string by another path. Both branches present so the
+        // lookup keeps working if GRDB's storage encoding ever shifts.
         let escapedPrefix = Self.escapeLikePattern(
             idPrefix
                 .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/MacParakeetCore/Database/TransformHistoryRepository.swift
+++ b/Sources/MacParakeetCore/Database/TransformHistoryRepository.swift
@@ -5,6 +5,10 @@ public protocol TransformHistoryRepositoryProtocol: Sendable {
     func save(_ entry: TransformHistoryEntry) throws
     func fetchAll() throws -> [TransformHistoryEntry]
     func fetchRecent(limit: Int) throws -> [TransformHistoryEntry]
+    /// Atomic `(recent rows, total count)` read so the UI's "showing N of M"
+    /// footer is consistent with the visible rows. Splitting into two reads
+    /// can interleave with a concurrent write and produce mismatched values.
+    func fetchRecentWithCount(limit: Int) throws -> (entries: [TransformHistoryEntry], totalCount: Int)
     func fetch(id: UUID) throws -> TransformHistoryEntry?
     func fetch(idPrefix: String) throws -> [TransformHistoryEntry]
     func count() throws -> Int
@@ -39,6 +43,19 @@ public final class TransformHistoryRepository: TransformHistoryRepositoryProtoco
                 .order(TransformHistoryEntry.Columns.createdAt.desc)
                 .limit(max(0, limit))
                 .fetchAll(db)
+        }
+    }
+
+    public func fetchRecentWithCount(
+        limit: Int = 200
+    ) throws -> (entries: [TransformHistoryEntry], totalCount: Int) {
+        try dbQueue.read { db in
+            let entries = try TransformHistoryEntry
+                .order(TransformHistoryEntry.Columns.createdAt.desc)
+                .limit(max(0, limit))
+                .fetchAll(db)
+            let totalCount = try TransformHistoryEntry.fetchCount(db)
+            return (entries, totalCount)
         }
     }
 

--- a/Sources/MacParakeetCore/Models/TransformHistoryEntry.swift
+++ b/Sources/MacParakeetCore/Models/TransformHistoryEntry.swift
@@ -1,0 +1,78 @@
+import Foundation
+import GRDB
+
+public struct TransformHistoryEntry: Codable, Identifiable, Sendable, Equatable {
+    public var id: UUID
+    public var transformId: UUID?
+    public var transformName: String
+    public var inputText: String
+    public var outputText: String
+    public var sourceAppBundleID: String?
+    public var sourceAppName: String?
+    public var capturePath: String
+    public var replacementPath: String
+    public var llmElapsedMs: Int
+    public var totalElapsedMs: Int
+    public var createdAt: Date
+    public var updatedAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        transformId: UUID? = nil,
+        transformName: String,
+        inputText: String,
+        outputText: String,
+        sourceAppBundleID: String? = nil,
+        sourceAppName: String? = nil,
+        capturePath: String,
+        replacementPath: String,
+        llmElapsedMs: Int,
+        totalElapsedMs: Int,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.transformId = transformId
+        self.transformName = transformName
+        self.inputText = inputText
+        self.outputText = outputText
+        self.sourceAppBundleID = sourceAppBundleID
+        self.sourceAppName = sourceAppName
+        self.capturePath = capturePath
+        self.replacementPath = replacementPath
+        self.llmElapsedMs = llmElapsedMs
+        self.totalElapsedMs = totalElapsedMs
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+
+    public var sourceAppDisplayName: String {
+        if let sourceAppName, !sourceAppName.isEmpty {
+            return sourceAppName
+        }
+        if let sourceAppBundleID, !sourceAppBundleID.isEmpty {
+            return sourceAppBundleID
+        }
+        return "Unknown app"
+    }
+}
+
+extension TransformHistoryEntry: FetchableRecord, PersistableRecord {
+    public static let databaseTableName = "transform_history"
+
+    public enum Columns: String, ColumnExpression {
+        case id
+        case transformId
+        case transformName
+        case inputText
+        case outputText
+        case sourceAppBundleID
+        case sourceAppName
+        case capturePath
+        case replacementPath
+        case llmElapsedMs
+        case totalElapsedMs
+        case createdAt
+        case updatedAt
+    }
+}

--- a/Sources/MacParakeetCore/Services/Transforms/TransformExecutor.swift
+++ b/Sources/MacParakeetCore/Services/Transforms/TransformExecutor.swift
@@ -31,24 +31,30 @@ public enum TransformProgress: Sendable, Equatable {
 // MARK: - Result
 
 public struct TransformExecutionResult: Sendable {
+    public let inputText: String
     public let outputText: String
     public let path: SelectionReplacementPath
     public let totalElapsedMs: Int
     public let llmElapsedMs: Int
     public let captureTag: String
+    public let target: SelectionCaptureTarget?
 
     public init(
+        inputText: String,
         outputText: String,
         path: SelectionReplacementPath,
         totalElapsedMs: Int,
         llmElapsedMs: Int,
-        captureTag: String
+        captureTag: String,
+        target: SelectionCaptureTarget?
     ) {
+        self.inputText = inputText
         self.outputText = outputText
         self.path = path
         self.totalElapsedMs = totalElapsedMs
         self.llmElapsedMs = llmElapsedMs
         self.captureTag = captureTag
+        self.target = target
     }
 }
 
@@ -221,11 +227,13 @@ public actor TransformExecutor {
 
         let totalMs = Self.elapsedMs(from: start)
         let result = TransformExecutionResult(
+            inputText: inputText,
             outputText: accumulated,
             path: path,
             totalElapsedMs: totalMs,
             llmElapsedMs: llmElapsedMs,
-            captureTag: captured.pathTag
+            captureTag: captured.pathTag,
+            target: captured.target
         )
         onProgress(.done(path))
 

--- a/Sources/MacParakeetViewModels/TransformsViewModel.swift
+++ b/Sources/MacParakeetViewModels/TransformsViewModel.swift
@@ -40,14 +40,13 @@ public final class TransformsViewModel {
     private var clipboardService: ClipboardServiceProtocol?
     private var copiedResetTask: Task<Void, Never>?
 
-    /// Monotonic counter advanced on every load / delete / clear so that
-    /// an older in-flight snapshot can't overwrite a newer one. Concurrent
-    /// `loadHistory()` (triggered by `.transformHistoryChanged`
-    /// notifications during rapid runs) racing a user-triggered delete is
-    /// the realistic race this guards against — without it the older
-    /// snapshot would briefly resurrect the just-deleted row until the
-    /// next notification reloaded.
-    private var historySnapshotGeneration: Int = 0
+    /// Passive reloads are allowed to coalesce with each other, but never to
+    /// outrank a user mutation. A `.transformHistoryChanged` reload can start
+    /// after delete/clear begins and still read the old rows before the write
+    /// reaches SQLite; mutation generation keeps that stale snapshot out.
+    private var historyLoadGeneration: Int = 0
+    private var historyMutationGeneration: Int = 0
+    private var activeHistoryMutationCount: Int = 0
 
     public init() {}
 
@@ -157,24 +156,34 @@ public final class TransformsViewModel {
     /// the "showing N of M" footer.
     public func loadHistory() async {
         guard let historyRepo else {
-            historySnapshotGeneration += 1
+            historyLoadGeneration += 1
             history = []
             totalHistoryCount = 0
             return
         }
-        historySnapshotGeneration += 1
-        let myGeneration = historySnapshotGeneration
+        historyLoadGeneration += 1
+        let myLoadGeneration = historyLoadGeneration
+        let mutationGenerationAtStart = historyMutationGeneration
+        let startedDuringMutation = activeHistoryMutationCount > 0
         do {
             let snapshot = try await Self.fetchHistorySnapshot(
                 repo: historyRepo,
                 limit: Self.historyFetchLimit
             )
-            guard myGeneration == historySnapshotGeneration else { return }
+            guard shouldApplyHistoryLoad(
+                loadGeneration: myLoadGeneration,
+                mutationGenerationAtStart: mutationGenerationAtStart,
+                startedDuringMutation: startedDuringMutation
+            ) else { return }
             history = snapshot.entries
             totalHistoryCount = snapshot.totalCount
             historyErrorMessage = nil
         } catch {
-            guard myGeneration == historySnapshotGeneration else { return }
+            guard shouldApplyHistoryLoad(
+                loadGeneration: myLoadGeneration,
+                mutationGenerationAtStart: mutationGenerationAtStart,
+                startedDuringMutation: startedDuringMutation
+            ) else { return }
             history = []
             totalHistoryCount = 0
             historyErrorMessage = error.localizedDescription
@@ -183,42 +192,63 @@ public final class TransformsViewModel {
 
     public func deleteHistoryEntry(_ entry: TransformHistoryEntry) async {
         guard let historyRepo else { return }
-        historySnapshotGeneration += 1
-        let myGeneration = historySnapshotGeneration
+        let myGeneration = beginHistoryMutation()
+        defer { endHistoryMutation() }
         do {
             let snapshot = try await Self.deleteHistoryEntryAndFetchSnapshot(
                 repo: historyRepo,
                 id: entry.id,
                 limit: Self.historyFetchLimit
             )
-            guard myGeneration == historySnapshotGeneration else { return }
+            guard myGeneration == historyMutationGeneration else { return }
             history = snapshot.entries
             totalHistoryCount = snapshot.totalCount
             historyErrorMessage = nil
         } catch {
-            guard myGeneration == historySnapshotGeneration else { return }
+            guard myGeneration == historyMutationGeneration else { return }
             historyErrorMessage = error.localizedDescription
         }
     }
 
     public func clearHistory() async {
         guard let historyRepo else { return }
-        historySnapshotGeneration += 1
-        let myGeneration = historySnapshotGeneration
+        let myGeneration = beginHistoryMutation()
+        defer { endHistoryMutation() }
         do {
             let snapshot = try await Self.clearHistoryAndFetchSnapshot(
                 repo: historyRepo,
                 limit: Self.historyFetchLimit
             )
-            guard myGeneration == historySnapshotGeneration else { return }
+            guard myGeneration == historyMutationGeneration else { return }
             history = snapshot.entries
             totalHistoryCount = snapshot.totalCount
             isConfirmingClearHistory = false
             historyErrorMessage = nil
         } catch {
-            guard myGeneration == historySnapshotGeneration else { return }
+            guard myGeneration == historyMutationGeneration else { return }
             historyErrorMessage = error.localizedDescription
         }
+    }
+
+    private func beginHistoryMutation() -> Int {
+        historyMutationGeneration += 1
+        activeHistoryMutationCount += 1
+        return historyMutationGeneration
+    }
+
+    private func endHistoryMutation() {
+        activeHistoryMutationCount = max(0, activeHistoryMutationCount - 1)
+    }
+
+    private func shouldApplyHistoryLoad(
+        loadGeneration: Int,
+        mutationGenerationAtStart: Int,
+        startedDuringMutation: Bool
+    ) -> Bool {
+        !startedDuringMutation
+            && loadGeneration == historyLoadGeneration
+            && mutationGenerationAtStart == historyMutationGeneration
+            && activeHistoryMutationCount == 0
     }
 
     /// Copy a prior run's output back to the clipboard, with a brief

--- a/Sources/MacParakeetViewModels/TransformsViewModel.swift
+++ b/Sources/MacParakeetViewModels/TransformsViewModel.swift
@@ -10,26 +10,52 @@ import MacParakeetCore
 @MainActor
 @Observable
 public final class TransformsViewModel {
+    public nonisolated static let historyFetchLimit = 200
+
     public var transforms: [Prompt] = []
     public var allPrompts: [Prompt] = []
     public var errorMessage: String?
 
+    /// Recent Transform runs, newest first. Surfaced read-only in the
+    /// Transforms tab (copy, delete, clear-all). Capped at
+    /// `historyFetchLimit` rows; the DB keeps the full set so power users
+    /// who clear and re-fill keep their working window intact.
+    public var history: [TransformHistoryEntry] = []
+    public var totalHistoryCount: Int = 0
+    public var historyErrorMessage: String?
+
     /// Pending delete confirmation. Set when the user hits delete on a
     /// (non-built-in) Transform; cleared on confirm or cancel.
     public var pendingDeleteTransform: Prompt?
+    public var pendingDeleteHistoryEntry: TransformHistoryEntry?
+    public var isConfirmingClearHistory: Bool = false
+    public var copiedHistoryEntryID: UUID?
 
     /// True when the user has at least one LLM provider configured. Drives
     /// the calm "Configure in Settings" hero state.
     public var hasLLMProvider: Bool = false
 
     private var repo: PromptRepositoryProtocol?
+    private var historyRepo: TransformHistoryRepositoryProtocol?
+    private var clipboardService: ClipboardServiceProtocol?
+    private var copiedResetTask: Task<Void, Never>?
 
     public init() {}
 
-    public func configure(repo: PromptRepositoryProtocol, hasLLMProvider: Bool) {
+    public func configure(
+        repo: PromptRepositoryProtocol,
+        historyRepo: TransformHistoryRepositoryProtocol? = nil,
+        clipboardService: ClipboardServiceProtocol? = nil,
+        hasLLMProvider: Bool
+    ) {
         self.repo = repo
+        self.historyRepo = historyRepo
+        self.clipboardService = clipboardService
         self.hasLLMProvider = hasLLMProvider
-        Task { await load() }
+        Task {
+            await load()
+            await loadHistory()
+        }
     }
 
     /// Refresh the list from the repository. Built-ins are seeded by the
@@ -112,6 +138,128 @@ public final class TransformsViewModel {
         guard let pending = pendingDeleteTransform else { return false }
         pendingDeleteTransform = nil
         return await delete(pending)
+    }
+
+    // MARK: - History
+
+    /// Refresh the recent runs window from the repository. Capped at
+    /// `historyFetchLimit`; `totalHistoryCount` carries the full count for
+    /// the "showing N of M" footer.
+    public func loadHistory() async {
+        guard let historyRepo else {
+            history = []
+            totalHistoryCount = 0
+            return
+        }
+        do {
+            let snapshot = try await Self.fetchHistorySnapshot(
+                repo: historyRepo,
+                limit: Self.historyFetchLimit
+            )
+            history = snapshot.entries
+            totalHistoryCount = snapshot.totalCount
+            historyErrorMessage = nil
+        } catch {
+            history = []
+            totalHistoryCount = 0
+            historyErrorMessage = error.localizedDescription
+        }
+    }
+
+    public func deleteHistoryEntry(_ entry: TransformHistoryEntry) async {
+        guard let historyRepo else { return }
+        do {
+            let snapshot = try await Self.deleteHistoryEntryAndFetchSnapshot(
+                repo: historyRepo,
+                id: entry.id,
+                limit: Self.historyFetchLimit
+            )
+            history = snapshot.entries
+            totalHistoryCount = snapshot.totalCount
+            historyErrorMessage = nil
+        } catch {
+            historyErrorMessage = error.localizedDescription
+        }
+    }
+
+    public func confirmPendingHistoryDelete() async {
+        guard let pending = pendingDeleteHistoryEntry else { return }
+        pendingDeleteHistoryEntry = nil
+        await deleteHistoryEntry(pending)
+    }
+
+    public func clearHistory() async {
+        guard let historyRepo else { return }
+        do {
+            let snapshot = try await Self.clearHistoryAndFetchSnapshot(
+                repo: historyRepo,
+                limit: Self.historyFetchLimit
+            )
+            history = snapshot.entries
+            totalHistoryCount = snapshot.totalCount
+            isConfirmingClearHistory = false
+            historyErrorMessage = nil
+        } catch {
+            historyErrorMessage = error.localizedDescription
+        }
+    }
+
+    /// Copy a prior run's output back to the clipboard, with a brief
+    /// "copied" affordance keyed by entry ID so the UI can show a check
+    /// next to the right row.
+    public func copyOutputToClipboard(_ entry: TransformHistoryEntry) async {
+        guard let clipboardService else {
+            historyErrorMessage = "Clipboard service is unavailable."
+            return
+        }
+        guard await clipboardService.copyToClipboard(entry.outputText) else {
+            historyErrorMessage = "Could not copy transformed text to the clipboard."
+            return
+        }
+        historyErrorMessage = nil
+        copiedResetTask?.cancel()
+        copiedHistoryEntryID = entry.id
+        copiedResetTask = Task {
+            try? await Task.sleep(for: .seconds(1.5))
+            guard !Task.isCancelled else { return }
+            self.copiedHistoryEntryID = nil
+        }
+    }
+
+    private static func fetchHistorySnapshot(
+        repo: TransformHistoryRepositoryProtocol,
+        limit: Int
+    ) async throws -> (entries: [TransformHistoryEntry], totalCount: Int) {
+        try await Task.detached(priority: .userInitiated) {
+            let entries = try repo.fetchRecent(limit: limit)
+            let totalCount = try repo.count()
+            return (entries, totalCount)
+        }.value
+    }
+
+    private static func deleteHistoryEntryAndFetchSnapshot(
+        repo: TransformHistoryRepositoryProtocol,
+        id: UUID,
+        limit: Int
+    ) async throws -> (entries: [TransformHistoryEntry], totalCount: Int) {
+        try await Task.detached(priority: .userInitiated) {
+            _ = try repo.delete(id: id)
+            let entries = try repo.fetchRecent(limit: limit)
+            let totalCount = try repo.count()
+            return (entries, totalCount)
+        }.value
+    }
+
+    private static func clearHistoryAndFetchSnapshot(
+        repo: TransformHistoryRepositoryProtocol,
+        limit: Int
+    ) async throws -> (entries: [TransformHistoryEntry], totalCount: Int) {
+        try await Task.detached(priority: .userInitiated) {
+            try repo.deleteAll()
+            let entries = try repo.fetchRecent(limit: limit)
+            let totalCount = try repo.count()
+            return (entries, totalCount)
+        }.value
     }
 
     /// Reset a built-in Transform's content / shortcut / runningLabel back

--- a/Sources/MacParakeetViewModels/TransformsViewModel.swift
+++ b/Sources/MacParakeetViewModels/TransformsViewModel.swift
@@ -40,6 +40,15 @@ public final class TransformsViewModel {
     private var clipboardService: ClipboardServiceProtocol?
     private var copiedResetTask: Task<Void, Never>?
 
+    /// Monotonic counter advanced on every load / delete / clear so that
+    /// an older in-flight snapshot can't overwrite a newer one. Concurrent
+    /// `loadHistory()` (triggered by `.transformHistoryChanged`
+    /// notifications during rapid runs) racing a user-triggered delete is
+    /// the realistic race this guards against — without it the older
+    /// snapshot would briefly resurrect the just-deleted row until the
+    /// next notification reloaded.
+    private var historySnapshotGeneration: Int = 0
+
     public init() {}
 
     public func configure(
@@ -52,10 +61,11 @@ public final class TransformsViewModel {
         self.historyRepo = historyRepo
         self.clipboardService = clipboardService
         self.hasLLMProvider = hasLLMProvider
-        Task {
-            await load()
-            await loadHistory()
-        }
+        // `loadHistory()` is driven by the view (`.onAppear` and the
+        // `.transformHistoryChanged` notification). Doing it here too
+        // would race the view's first explicit load and clobber state
+        // when the generation-guarded snapshot resolves out of order.
+        Task { await load() }
     }
 
     /// Refresh the list from the repository. Built-ins are seeded by the
@@ -147,19 +157,24 @@ public final class TransformsViewModel {
     /// the "showing N of M" footer.
     public func loadHistory() async {
         guard let historyRepo else {
+            historySnapshotGeneration += 1
             history = []
             totalHistoryCount = 0
             return
         }
+        historySnapshotGeneration += 1
+        let myGeneration = historySnapshotGeneration
         do {
             let snapshot = try await Self.fetchHistorySnapshot(
                 repo: historyRepo,
                 limit: Self.historyFetchLimit
             )
+            guard myGeneration == historySnapshotGeneration else { return }
             history = snapshot.entries
             totalHistoryCount = snapshot.totalCount
             historyErrorMessage = nil
         } catch {
+            guard myGeneration == historySnapshotGeneration else { return }
             history = []
             totalHistoryCount = 0
             historyErrorMessage = error.localizedDescription
@@ -168,16 +183,20 @@ public final class TransformsViewModel {
 
     public func deleteHistoryEntry(_ entry: TransformHistoryEntry) async {
         guard let historyRepo else { return }
+        historySnapshotGeneration += 1
+        let myGeneration = historySnapshotGeneration
         do {
             let snapshot = try await Self.deleteHistoryEntryAndFetchSnapshot(
                 repo: historyRepo,
                 id: entry.id,
                 limit: Self.historyFetchLimit
             )
+            guard myGeneration == historySnapshotGeneration else { return }
             history = snapshot.entries
             totalHistoryCount = snapshot.totalCount
             historyErrorMessage = nil
         } catch {
+            guard myGeneration == historySnapshotGeneration else { return }
             historyErrorMessage = error.localizedDescription
         }
     }
@@ -190,16 +209,20 @@ public final class TransformsViewModel {
 
     public func clearHistory() async {
         guard let historyRepo else { return }
+        historySnapshotGeneration += 1
+        let myGeneration = historySnapshotGeneration
         do {
             let snapshot = try await Self.clearHistoryAndFetchSnapshot(
                 repo: historyRepo,
                 limit: Self.historyFetchLimit
             )
+            guard myGeneration == historySnapshotGeneration else { return }
             history = snapshot.entries
             totalHistoryCount = snapshot.totalCount
             isConfirmingClearHistory = false
             historyErrorMessage = nil
         } catch {
+            guard myGeneration == historySnapshotGeneration else { return }
             historyErrorMessage = error.localizedDescription
         }
     }
@@ -231,9 +254,7 @@ public final class TransformsViewModel {
         limit: Int
     ) async throws -> (entries: [TransformHistoryEntry], totalCount: Int) {
         try await Task.detached(priority: .userInitiated) {
-            let entries = try repo.fetchRecent(limit: limit)
-            let totalCount = try repo.count()
-            return (entries, totalCount)
+            try repo.fetchRecentWithCount(limit: limit)
         }.value
     }
 
@@ -244,9 +265,7 @@ public final class TransformsViewModel {
     ) async throws -> (entries: [TransformHistoryEntry], totalCount: Int) {
         try await Task.detached(priority: .userInitiated) {
             _ = try repo.delete(id: id)
-            let entries = try repo.fetchRecent(limit: limit)
-            let totalCount = try repo.count()
-            return (entries, totalCount)
+            return try repo.fetchRecentWithCount(limit: limit)
         }.value
     }
 
@@ -256,9 +275,7 @@ public final class TransformsViewModel {
     ) async throws -> (entries: [TransformHistoryEntry], totalCount: Int) {
         try await Task.detached(priority: .userInitiated) {
             try repo.deleteAll()
-            let entries = try repo.fetchRecent(limit: limit)
-            let totalCount = try repo.count()
-            return (entries, totalCount)
+            return try repo.fetchRecentWithCount(limit: limit)
         }.value
     }
 

--- a/Sources/MacParakeetViewModels/TransformsViewModel.swift
+++ b/Sources/MacParakeetViewModels/TransformsViewModel.swift
@@ -201,12 +201,6 @@ public final class TransformsViewModel {
         }
     }
 
-    public func confirmPendingHistoryDelete() async {
-        guard let pending = pendingDeleteHistoryEntry else { return }
-        pendingDeleteHistoryEntry = nil
-        await deleteHistoryEntry(pending)
-    }
-
     public func clearHistory() async {
         guard let historyRepo else { return }
         historySnapshotGeneration += 1

--- a/Tests/CLITests/TransformsCommandTests.swift
+++ b/Tests/CLITests/TransformsCommandTests.swift
@@ -566,12 +566,13 @@ final class TransformsCommandTests: XCTestCase {
         ])
 
         XCTAssertThrowsError(try show.run()) { error in
-            guard case CLITransformHistoryError.prefixTooShort(let min, let provided) = error else {
-                XCTFail("Expected prefixTooShort, got \(error)")
+            guard case CLITransformHistoryError.invalidPrefix(let min, let provided, let reason) = error else {
+                XCTFail("Expected invalidPrefix, got \(error)")
                 return
             }
             XCTAssertEqual(min, 4)
             XCTAssertEqual(provided, "abc")
+            XCTAssertEqual(reason, .tooShort)
         }
     }
 
@@ -593,10 +594,11 @@ final class TransformsCommandTests: XCTestCase {
         ])
 
         XCTAssertThrowsError(try show.run()) { error in
-            guard case CLITransformHistoryError.prefixTooShort = error else {
-                XCTFail("Expected prefixTooShort for non-hex prefix, got \(error)")
+            guard case CLITransformHistoryError.invalidPrefix(_, _, let reason) = error else {
+                XCTFail("Expected invalidPrefix for non-hex prefix, got \(error)")
                 return
             }
+            XCTAssertEqual(reason, .nonHex)
         }
     }
 

--- a/Tests/CLITests/TransformsCommandTests.swift
+++ b/Tests/CLITests/TransformsCommandTests.swift
@@ -574,4 +574,93 @@ final class TransformsCommandTests: XCTestCase {
             XCTAssertEqual(provided, "abc")
         }
     }
+
+    func testHistoryShowRejectsNonHexPrefix() throws {
+        // Regression: a length-only check accepted inputs like "12--" that
+        // would never match any UUID. Validate against the hyphenless hex
+        // form so non-hex characters surface as a validation error.
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("transforms-history-cli-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let dbPath = tmp.appendingPathComponent("test.db").path
+
+        _ = try DatabaseManager(path: dbPath)
+
+        let show = try TransformsCommand.HistorySubcommand.ShowSubcommand.parse([
+            "12zz",
+            "--database", dbPath,
+        ])
+
+        XCTAssertThrowsError(try show.run()) { error in
+            guard case CLITransformHistoryError.prefixTooShort = error else {
+                XCTFail("Expected prefixTooShort for non-hex prefix, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testHistoryShowJSONMapsTooShortPrefixToValidationError() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("transforms-history-cli-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let dbPath = tmp.appendingPathComponent("test.db").path
+
+        _ = try DatabaseManager(path: dbPath)
+
+        let show = try TransformsCommand.HistorySubcommand.ShowSubcommand.parse([
+            "abc",
+            "--database", dbPath,
+            "--json",
+        ])
+
+        var thrownError: Error?
+        let output = try captureStandardOutput {
+            do {
+                try show.run()
+            } catch {
+                thrownError = error
+            }
+        }
+
+        let exit = try XCTUnwrap(thrownError as? ExitCode)
+        XCTAssertEqual(exit.rawValue, 2)
+
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any])
+        XCTAssertEqual(object["ok"] as? Bool, false)
+        XCTAssertEqual(object["errorType"] as? String, "validation")
+    }
+
+    func testHistoryShowJSONMapsMissingItemToLookupError() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("transforms-history-cli-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let dbPath = tmp.appendingPathComponent("test.db").path
+
+        _ = try DatabaseManager(path: dbPath)
+
+        let show = try TransformsCommand.HistorySubcommand.ShowSubcommand.parse([
+            "abcd",
+            "--database", dbPath,
+            "--json",
+        ])
+
+        var thrownError: Error?
+        let output = try captureStandardOutput {
+            do {
+                try show.run()
+            } catch {
+                thrownError = error
+            }
+        }
+
+        let exit = try XCTUnwrap(thrownError as? ExitCode)
+        XCTAssertEqual(exit, .failure)
+
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any])
+        XCTAssertEqual(object["ok"] as? Bool, false)
+        XCTAssertEqual(object["errorType"] as? String, "lookup")
+    }
 }

--- a/Tests/CLITests/TransformsCommandTests.swift
+++ b/Tests/CLITests/TransformsCommandTests.swift
@@ -454,4 +454,124 @@ final class TransformsCommandTests: XCTestCase {
             XCTAssertTrue(message.contains("built-in"), "Expected built-in-protection error, got: \(message)")
         }
     }
+
+    // MARK: - History
+
+    func testParsesHistoryListAsDefaultSubcommand() throws {
+        let cmd = try TransformsCommand.parseAsRoot(["history", "--limit", "5", "--json"])
+        let history = try XCTUnwrap(cmd as? TransformsCommand.HistorySubcommand.ListSubcommand)
+        XCTAssertEqual(history.limit, 5)
+        XCTAssertTrue(history.json)
+    }
+
+    func testParsesHistoryShowDeleteAndClear() throws {
+        let show = try TransformsCommand.parseAsRoot(["history", "show", "abc123"])
+        XCTAssertEqual(try XCTUnwrap(show as? TransformsCommand.HistorySubcommand.ShowSubcommand).idPrefix, "abc123")
+
+        let delete = try TransformsCommand.parseAsRoot(["history", "delete", "abc123"])
+        XCTAssertEqual(try XCTUnwrap(delete as? TransformsCommand.HistorySubcommand.DeleteSubcommand).idPrefix, "abc123")
+
+        let clear = try TransformsCommand.parseAsRoot(["history", "clear", "--json"])
+        XCTAssertTrue(try XCTUnwrap(clear as? TransformsCommand.HistorySubcommand.ClearSubcommand).json)
+    }
+
+    func testTransformHistoryDTOJSONUsesDocumentedSnakeCaseKeys() throws {
+        let entry = TransformHistoryEntry(
+            id: UUID(uuidString: "22222222-2222-2222-2222-222222222222")!,
+            transformId: UUID(uuidString: "0FCE9DDB-7E2D-4B1A-AE3E-6F7C9B2A4D11"),
+            transformName: "Polish",
+            inputText: "rough",
+            outputText: "polished",
+            sourceAppBundleID: "com.apple.TextEdit",
+            sourceAppName: "TextEdit",
+            capturePath: "ax",
+            replacementPath: "ax",
+            llmElapsedMs: 12,
+            totalElapsedMs: 34,
+            createdAt: Date(timeIntervalSince1970: 0),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+
+        let data = try cliJSONEncoder.encode(TransformHistoryDTO(entry: entry))
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual(object["id"] as? String, "22222222-2222-2222-2222-222222222222")
+        XCTAssertEqual(object["transform_name"] as? String, "Polish")
+        XCTAssertEqual(object["input_text"] as? String, "rough")
+        XCTAssertEqual(object["output_text"] as? String, "polished")
+        XCTAssertEqual(object["source_app_bundle_id"] as? String, "com.apple.TextEdit")
+        XCTAssertEqual(object["llm_elapsed_ms"] as? Int, 12)
+        XCTAssertNotNil(object["created_at"])
+        XCTAssertNil(object["transformName"])
+        XCTAssertNil(object["inputText"])
+        XCTAssertNil(object["outputText"])
+    }
+
+    func testHistoryDeleteAndClearRoundTrip() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("transforms-history-cli-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let dbPath = tmp.appendingPathComponent("test.db").path
+
+        let db = try DatabaseManager(path: dbPath)
+        let repo = TransformHistoryRepository(dbQueue: db.dbQueue)
+        let first = TransformHistoryEntry(
+            transformName: "Polish",
+            inputText: "rough",
+            outputText: "polished",
+            capturePath: "ax",
+            replacementPath: "ax",
+            llmElapsedMs: 1,
+            totalElapsedMs: 2
+        )
+        let second = TransformHistoryEntry(
+            transformName: "Distill",
+            inputText: "long",
+            outputText: "short",
+            capturePath: "clipboard",
+            replacementPath: "clipboardPaste",
+            llmElapsedMs: 3,
+            totalElapsedMs: 4
+        )
+        try repo.save(first)
+        try repo.save(second)
+
+        let del = try TransformsCommand.HistorySubcommand.DeleteSubcommand.parse([
+            String(first.id.uuidString.prefix(8)),
+            "--database", dbPath,
+        ])
+        try del.run()
+        XCTAssertEqual(try repo.fetchAll().map(\.id), [second.id])
+
+        let clear = try TransformsCommand.HistorySubcommand.ClearSubcommand.parse([
+            "--database", dbPath,
+        ])
+        try clear.run()
+        XCTAssertEqual(try repo.count(), 0)
+    }
+
+    func testHistoryShowRejectsTooShortPrefix() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("transforms-history-cli-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let dbPath = tmp.appendingPathComponent("test.db").path
+
+        _ = try DatabaseManager(path: dbPath)
+
+        let show = try TransformsCommand.HistorySubcommand.ShowSubcommand.parse([
+            "abc",
+            "--database", dbPath,
+        ])
+
+        XCTAssertThrowsError(try show.run()) { error in
+            guard case CLITransformHistoryError.prefixTooShort(let min, let provided) = error else {
+                XCTFail("Expected prefixTooShort, got \(error)")
+                return
+            }
+            XCTAssertEqual(min, 4)
+            XCTAssertEqual(provided, "abc")
+        }
+    }
 }

--- a/Tests/CLITests/TransformsCommandTests.swift
+++ b/Tests/CLITests/TransformsCommandTests.swift
@@ -238,6 +238,50 @@ final class TransformsCommandTests: XCTestCase {
         XCTAssertFalse(after.contains(where: { $0.name == "Sharpen" }))
     }
 
+    func testRunRecordsTransformHistory() async throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("transforms-cli-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let dbPath = tmp.appendingPathComponent("test.db").path
+        let inputPath = tmp.appendingPathComponent("input.txt").path
+        try "rough".write(toFile: inputPath, atomically: true, encoding: .utf8)
+
+        let db = try DatabaseManager(path: dbPath)
+        let repo = PromptRepository(dbQueue: db.dbQueue)
+        let transform = Prompt(
+            id: UUID(),
+            name: "Sharpen",
+            content: "Make it crisp.",
+            category: .transform,
+            isBuiltIn: false,
+            sortOrder: 200
+        )
+        try repo.save(transform)
+
+        let run = try TransformsCommand.RunSubcommand.parse([
+            "Sharpen",
+            "--provider", "cli",
+            "--command", "printf 'polished'",
+            "--input", inputPath,
+            "--database", dbPath,
+        ])
+        let output = try await captureStandardOutput {
+            try await run.run()
+        }
+
+        XCTAssertEqual(output.trimmingCharacters(in: .whitespacesAndNewlines), "polished")
+        let historyRepo = TransformHistoryRepository(dbQueue: db.dbQueue)
+        let entry = try XCTUnwrap(try historyRepo.fetchRecent(limit: 1).first)
+        XCTAssertEqual(entry.transformId, transform.id)
+        XCTAssertEqual(entry.transformName, "Sharpen")
+        XCTAssertEqual(entry.inputText, "rough")
+        XCTAssertEqual(entry.outputText, "polished")
+        XCTAssertEqual(entry.sourceAppDisplayName, "macparakeet-cli")
+        XCTAssertEqual(entry.capturePath, "file")
+        XCTAssertEqual(entry.replacementPath, "stdout")
+    }
+
     func testLookupRequiresAtLeastFourHexCharactersForIDPrefix() throws {
         let tmp = FileManager.default.temporaryDirectory
             .appendingPathComponent("transforms-cli-\(UUID().uuidString)")
@@ -458,6 +502,11 @@ final class TransformsCommandTests: XCTestCase {
     // MARK: - History
 
     func testParsesHistoryListAsDefaultSubcommand() throws {
+        let bare = try TransformsCommand.parseAsRoot(["history"])
+        let bareHistory = try XCTUnwrap(bare as? TransformsCommand.HistorySubcommand.ListSubcommand)
+        XCTAssertEqual(bareHistory.limit, 20)
+        XCTAssertFalse(bareHistory.json)
+
         let cmd = try TransformsCommand.parseAsRoot(["history", "--limit", "5", "--json"])
         let history = try XCTUnwrap(cmd as? TransformsCommand.HistorySubcommand.ListSubcommand)
         XCTAssertEqual(history.limit, 5)
@@ -497,14 +546,27 @@ final class TransformsCommandTests: XCTestCase {
 
         XCTAssertEqual(object["id"] as? String, "22222222-2222-2222-2222-222222222222")
         XCTAssertEqual(object["transform_name"] as? String, "Polish")
+        XCTAssertEqual(object["transform_id"] as? String, "0FCE9DDB-7E2D-4B1A-AE3E-6F7C9B2A4D11")
         XCTAssertEqual(object["input_text"] as? String, "rough")
         XCTAssertEqual(object["output_text"] as? String, "polished")
         XCTAssertEqual(object["source_app_bundle_id"] as? String, "com.apple.TextEdit")
+        XCTAssertEqual(object["source_app_name"] as? String, "TextEdit")
+        XCTAssertEqual(object["capture_path"] as? String, "ax")
+        XCTAssertEqual(object["replacement_path"] as? String, "ax")
         XCTAssertEqual(object["llm_elapsed_ms"] as? Int, 12)
+        XCTAssertEqual(object["total_elapsed_ms"] as? Int, 34)
         XCTAssertNotNil(object["created_at"])
+        XCTAssertNotNil(object["updated_at"])
         XCTAssertNil(object["transformName"])
+        XCTAssertNil(object["transformId"])
         XCTAssertNil(object["inputText"])
         XCTAssertNil(object["outputText"])
+        XCTAssertNil(object["sourceAppBundleID"])
+        XCTAssertNil(object["sourceAppName"])
+        XCTAssertNil(object["capturePath"])
+        XCTAssertNil(object["replacementPath"])
+        XCTAssertNil(object["llmElapsedMs"])
+        XCTAssertNil(object["totalElapsedMs"])
     }
 
     func testHistoryDeleteAndClearRoundTrip() throws {
@@ -540,15 +602,133 @@ final class TransformsCommandTests: XCTestCase {
         let del = try TransformsCommand.HistorySubcommand.DeleteSubcommand.parse([
             String(first.id.uuidString.prefix(8)),
             "--database", dbPath,
+            "--json",
         ])
-        try del.run()
+        let deleteOutput = try captureStandardOutput {
+            try del.run()
+        }
+        let deleteObject = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(deleteOutput.utf8)) as? [String: Any])
+        XCTAssertEqual(deleteObject["ok"] as? Bool, true)
+        XCTAssertEqual(deleteObject["id"] as? String, first.id.uuidString)
         XCTAssertEqual(try repo.fetchAll().map(\.id), [second.id])
 
         let clear = try TransformsCommand.HistorySubcommand.ClearSubcommand.parse([
             "--database", dbPath,
+            "--json",
         ])
-        try clear.run()
+        let clearOutput = try captureStandardOutput {
+            try clear.run()
+        }
+        let clearObject = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(clearOutput.utf8)) as? [String: Any])
+        XCTAssertEqual(clearObject["ok"] as? Bool, true)
+        XCTAssertEqual(clearObject["deleted_count"] as? Int, 1)
         XCTAssertEqual(try repo.count(), 0)
+    }
+
+    func testHistoryListAndShowJSONExecuteDocumentedShape() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("transforms-history-cli-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let dbPath = tmp.appendingPathComponent("test.db").path
+
+        let db = try DatabaseManager(path: dbPath)
+        let repo = TransformHistoryRepository(dbQueue: db.dbQueue)
+        try repo.save(TransformHistoryEntry(
+            id: UUID(uuidString: "44444444-4444-4444-4444-444444444444")!,
+            transformName: "Older",
+            inputText: "old",
+            outputText: "older out",
+            capturePath: "ax",
+            replacementPath: "ax",
+            llmElapsedMs: 1,
+            totalElapsedMs: 2,
+            createdAt: Date(timeIntervalSince1970: 1)
+        ))
+        try repo.save(TransformHistoryEntry(
+            id: UUID(uuidString: "55555555-5555-5555-5555-555555555555")!,
+            transformName: "Newer",
+            inputText: "new",
+            outputText: "newer out",
+            capturePath: "stdin",
+            replacementPath: "stdout",
+            llmElapsedMs: 3,
+            totalElapsedMs: 4,
+            createdAt: Date(timeIntervalSince1970: 2)
+        ))
+
+        let list = try TransformsCommand.HistorySubcommand.ListSubcommand.parse([
+            "--limit", "1",
+            "--database", dbPath,
+            "--json",
+        ])
+        let listOutput = try captureStandardOutput {
+            try list.run()
+        }
+        let listArray = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(listOutput.utf8)) as? [[String: Any]])
+        XCTAssertEqual(listArray.count, 1)
+        XCTAssertEqual(listArray.first?["id"] as? String, "55555555-5555-5555-5555-555555555555")
+        XCTAssertEqual(listArray.first?["transform_name"] as? String, "Newer")
+        XCTAssertEqual(listArray.first?["capture_path"] as? String, "stdin")
+
+        let show = try TransformsCommand.HistorySubcommand.ShowSubcommand.parse([
+            "5555",
+            "--database", dbPath,
+            "--json",
+        ])
+        let showOutput = try captureStandardOutput {
+            try show.run()
+        }
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(showOutput.utf8)) as? [String: Any])
+        XCTAssertEqual(object["id"] as? String, "55555555-5555-5555-5555-555555555555")
+        XCTAssertEqual(object["input_text"] as? String, "new")
+        XCTAssertEqual(object["output_text"] as? String, "newer out")
+        XCTAssertEqual(object["replacement_path"] as? String, "stdout")
+    }
+
+    func testHistoryShowRejectsAmbiguousPrefix() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("transforms-history-cli-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let dbPath = tmp.appendingPathComponent("test.db").path
+
+        let db = try DatabaseManager(path: dbPath)
+        let repo = TransformHistoryRepository(dbQueue: db.dbQueue)
+        try repo.save(TransformHistoryEntry(
+            id: UUID(uuidString: "ABCD1111-1111-1111-1111-111111111111")!,
+            transformName: "First",
+            inputText: "one",
+            outputText: "One.",
+            capturePath: "ax",
+            replacementPath: "ax",
+            llmElapsedMs: 1,
+            totalElapsedMs: 2
+        ))
+        try repo.save(TransformHistoryEntry(
+            id: UUID(uuidString: "ABCD2222-2222-2222-2222-222222222222")!,
+            transformName: "Second",
+            inputText: "two",
+            outputText: "Two.",
+            capturePath: "ax",
+            replacementPath: "ax",
+            llmElapsedMs: 3,
+            totalElapsedMs: 4
+        ))
+
+        let show = try TransformsCommand.HistorySubcommand.ShowSubcommand.parse([
+            "abcd",
+            "--database", dbPath,
+        ])
+
+        XCTAssertThrowsError(try show.run()) { error in
+            guard case CLITransformHistoryError.ambiguous(let prefix, let matches) = error else {
+                XCTFail("Expected ambiguous prefix, got \(error)")
+                return
+            }
+            XCTAssertEqual(prefix, "abcd")
+            XCTAssertEqual(matches.count, 2)
+        }
     }
 
     func testHistoryShowRejectsTooShortPrefix() throws {

--- a/Tests/MacParakeetTests/Database/DatabaseManagerTests.swift
+++ b/Tests/MacParakeetTests/Database/DatabaseManagerTests.swift
@@ -899,7 +899,7 @@ final class DatabaseManagerTests: XCTestCase {
         try? FileManager.default.removeItem(atPath: dbPath)
     }
 
-    func testTransformWorkbenchCleanupMigrationDropsLegacyTables() throws {
+    func testTransformWorkbenchCleanupMigrationPreservesRestoredHistoryWhenRerun() throws {
         let dbPath = FileManager.default.temporaryDirectory
             .appendingPathComponent("transform_workbench_cleanup_\(UUID().uuidString).db")
             .path
@@ -936,20 +936,26 @@ final class DatabaseManagerTests: XCTestCase {
 
         let manager = try DatabaseManager(path: dbPath)
         try manager.dbQueue.read { db in
-            XCTAssertFalse(try db.tableExists("transform_history"))
+            XCTAssertTrue(try db.tableExists("transform_history"))
             XCTAssertFalse(try db.tableExists("transform_profiles"))
             XCTAssertFalse(try db.tableExists("writing_samples"))
+
+            let historyColumns = try db.columns(in: "transform_history").map(\.name)
+            XCTAssertTrue(historyColumns.contains("transformName"))
+            XCTAssertTrue(historyColumns.contains("sourceAppBundleID"))
+            XCTAssertTrue(historyColumns.contains("totalElapsedMs"))
 
             let appliedMigrationIDs = try String.fetchAll(
                 db,
                 sql: """
                     SELECT identifier FROM grdb_migrations
-                    WHERE identifier IN (?, ?, ?)
+                    WHERE identifier IN (?, ?, ?, ?)
                 """,
                 arguments: [
                     "v0.14-transform-history",
                     "v0.15-transform-workbench",
                     "v0.16-drop-transform-workbench-tables",
+                    "v0.17-recreate-transform-history",
                 ]
             )
             XCTAssertEqual(
@@ -958,6 +964,7 @@ final class DatabaseManagerTests: XCTestCase {
                     "v0.14-transform-history",
                     "v0.15-transform-workbench",
                     "v0.16-drop-transform-workbench-tables",
+                    "v0.17-recreate-transform-history",
                 ]
             )
         }

--- a/Tests/MacParakeetTests/Database/TransformHistoryRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/TransformHistoryRepositoryTests.swift
@@ -2,10 +2,11 @@ import XCTest
 @testable import MacParakeetCore
 
 final class TransformHistoryRepositoryTests: XCTestCase {
+    var manager: DatabaseManager!
     var repo: TransformHistoryRepository!
 
     override func setUp() async throws {
-        let manager = try DatabaseManager()
+        manager = try DatabaseManager()
         repo = TransformHistoryRepository(dbQueue: manager.dbQueue)
     }
 
@@ -132,6 +133,39 @@ final class TransformHistoryRepositoryTests: XCTestCase {
         XCTAssertEqual(try repo.fetchRecent(limit: 10).map(\.id), [second.id])
 
         try repo.deleteAll()
+        XCTAssertEqual(try repo.count(), 0)
+    }
+
+    func testDeleteHandlesLegacyTextUUIDRowsResolvedByPrefixLookup() throws {
+        let id = UUID(uuidString: "33333333-3333-3333-3333-333333333333")!
+        try repo.save(TransformHistoryEntry(
+            id: id,
+            transformName: "Legacy",
+            inputText: "old",
+            outputText: "new",
+            capturePath: "ax",
+            replacementPath: "ax",
+            llmElapsedMs: 1,
+            totalElapsedMs: 2
+        ))
+        try manager.dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    UPDATE transform_history
+                    SET id = ?
+                    WHERE lower(hex(id)) = ?
+                    """,
+                arguments: [
+                    id.uuidString.lowercased(),
+                    id.uuidString.replacingOccurrences(of: "-", with: "").lowercased(),
+                ]
+            )
+        }
+
+        let legacy = try XCTUnwrap(try repo.fetch(idPrefix: "3333").first)
+
+        XCTAssertEqual(legacy.id, id)
+        XCTAssertTrue(try repo.delete(id: legacy.id))
         XCTAssertEqual(try repo.count(), 0)
     }
 }

--- a/Tests/MacParakeetTests/Database/TransformHistoryRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/TransformHistoryRepositoryTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class TransformHistoryRepositoryTests: XCTestCase {
+    var repo: TransformHistoryRepository!
+
+    override func setUp() async throws {
+        let manager = try DatabaseManager()
+        repo = TransformHistoryRepository(dbQueue: manager.dbQueue)
+    }
+
+    func testSaveAndFetchRecentOrdersNewestFirst() throws {
+        let older = TransformHistoryEntry(
+            transformId: UUID(uuidString: "0FCE9DDB-7E2D-4B1A-AE3E-6F7C9B2A4D11"),
+            transformName: "Polish",
+            inputText: "rough",
+            outputText: "polished",
+            sourceAppBundleID: "com.apple.TextEdit",
+            sourceAppName: "TextEdit",
+            capturePath: "ax",
+            replacementPath: "ax",
+            llmElapsedMs: 10,
+            totalElapsedMs: 20,
+            createdAt: Date(timeIntervalSince1970: 10),
+            updatedAt: Date(timeIntervalSince1970: 10)
+        )
+        let newer = TransformHistoryEntry(
+            transformId: UUID(uuidString: "1AD7C2B0-9C6F-4F0E-9C39-5E4D1F1D2A55"),
+            transformName: "Distill",
+            inputText: "long",
+            outputText: "short",
+            sourceAppBundleID: "com.tinyspeck.slackmacgap",
+            sourceAppName: "Slack",
+            capturePath: "clipboard",
+            replacementPath: "clipboardPaste",
+            llmElapsedMs: 30,
+            totalElapsedMs: 45,
+            createdAt: Date(timeIntervalSince1970: 20),
+            updatedAt: Date(timeIntervalSince1970: 20)
+        )
+
+        try repo.save(older)
+        try repo.save(newer)
+
+        let fetched = try repo.fetchRecent(limit: 10)
+        XCTAssertEqual(fetched.map(\.transformName), ["Distill", "Polish"])
+        XCTAssertEqual(fetched.first?.inputText, "long")
+        XCTAssertEqual(fetched.first?.outputText, "short")
+        XCTAssertEqual(try repo.count(), 2)
+    }
+
+    func testFetchRecentHonorsLimitWithoutDeletingRows() throws {
+        for index in 0..<5 {
+            try repo.save(
+                TransformHistoryEntry(
+                    transformName: "Transform \(index)",
+                    inputText: "input \(index)",
+                    outputText: "output \(index)",
+                    capturePath: "ax",
+                    replacementPath: "ax",
+                    llmElapsedMs: index,
+                    totalElapsedMs: index + 1,
+                    createdAt: Date(timeIntervalSince1970: TimeInterval(index)),
+                    updatedAt: Date(timeIntervalSince1970: TimeInterval(index))
+                )
+            )
+        }
+
+        let fetched = try repo.fetchRecent(limit: 2)
+
+        XCTAssertEqual(fetched.map(\.transformName), ["Transform 4", "Transform 3"])
+        XCTAssertEqual(try repo.count(), 5)
+    }
+
+    func testFetchByIDAndIDPrefix() throws {
+        let first = TransformHistoryEntry(
+            id: UUID(uuidString: "11111111-1111-1111-1111-111111111111")!,
+            transformName: "Polish",
+            inputText: "one",
+            outputText: "One.",
+            capturePath: "ax",
+            replacementPath: "ax",
+            llmElapsedMs: 1,
+            totalElapsedMs: 2,
+            createdAt: Date(timeIntervalSince1970: 10),
+            updatedAt: Date(timeIntervalSince1970: 10)
+        )
+        let second = TransformHistoryEntry(
+            id: UUID(uuidString: "22222222-2222-2222-2222-222222222222")!,
+            transformName: "Distill",
+            inputText: "two",
+            outputText: "Two.",
+            capturePath: "clipboard",
+            replacementPath: "clipboardPaste",
+            llmElapsedMs: 3,
+            totalElapsedMs: 4,
+            createdAt: Date(timeIntervalSince1970: 20),
+            updatedAt: Date(timeIntervalSince1970: 20)
+        )
+        try repo.save(first)
+        try repo.save(second)
+
+        XCTAssertEqual(try repo.fetch(id: first.id)?.id, first.id)
+        XCTAssertEqual(try repo.fetch(idPrefix: "2222").map(\.id), [second.id])
+        XCTAssertEqual(try repo.fetch(idPrefix: "1111").map(\.id), [first.id])
+        XCTAssertTrue(try repo.fetch(idPrefix: "%").isEmpty)
+    }
+
+    func testDeleteSingleAndDeleteAll() throws {
+        let first = TransformHistoryEntry(
+            transformName: "Polish",
+            inputText: "one",
+            outputText: "One.",
+            capturePath: "ax",
+            replacementPath: "ax",
+            llmElapsedMs: 1,
+            totalElapsedMs: 2
+        )
+        let second = TransformHistoryEntry(
+            transformName: "Decide",
+            inputText: "two",
+            outputText: "Choose two.",
+            capturePath: "clipboard",
+            replacementPath: "clipboardPaste",
+            llmElapsedMs: 3,
+            totalElapsedMs: 4
+        )
+        try repo.save(first)
+        try repo.save(second)
+
+        XCTAssertTrue(try repo.delete(id: first.id))
+        XCTAssertEqual(try repo.fetchRecent(limit: 10).map(\.id), [second.id])
+
+        try repo.deleteAll()
+        XCTAssertEqual(try repo.count(), 0)
+    }
+}

--- a/Tests/MacParakeetTests/Services/System/SelectionCaptureServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/System/SelectionCaptureServiceTests.swift
@@ -190,6 +190,7 @@ final class FakeSelectionCaptureBackend: SelectionCaptureBackend, @unchecked Sen
     private let changeCountAfterCmdC: Int?
     private let snapshotItems: [NSPasteboardItem]?
     private var restoreCalls: Int = 0
+    private var frontmostTargetCalls: Int = 0
 
     init(
         isTrusted: Bool,
@@ -215,12 +216,15 @@ final class FakeSelectionCaptureBackend: SelectionCaptureBackend, @unchecked Sen
 
     @MainActor
     func frontmostApplicationTarget() -> SelectionCaptureTarget? {
-        SelectionCaptureTarget(
+        frontmostTargetCalls += 1
+        return SelectionCaptureTarget(
             processIdentifier: 1234,
             bundleIdentifier: "com.example.Source",
             localizedName: "Source"
         )
     }
+
+    func frontmostTargetCallCount() -> Int { frontmostTargetCalls }
 
     @MainActor
     func snapshotPasteboard() -> PasteboardSnapshot {

--- a/Tests/MacParakeetTests/Services/Transforms/TransformExecutorTests.swift
+++ b/Tests/MacParakeetTests/Services/Transforms/TransformExecutorTests.swift
@@ -174,6 +174,57 @@ final class TransformExecutorTests: XCTestCase {
         XCTAssertEqual(replacementBackend.cmdVPostCount(), 0)
     }
 
+    func testRunPropagatesCaptureTargetIntoResultExactlyOnce() async throws {
+        // Regression guard: PR #283 originally read
+        // `NSWorkspace.frontmostApplication` at history-write time, which
+        // drifts during long LLM runs (Alt-Tab → wrong source app
+        // recorded). The fix threads the typed capture target through
+        // `TransformExecutionResult.target`, captured ONCE at the start of
+        // `captureSelection()`. This test asserts both invariants:
+        //   1. The captured target reaches `result.target`.
+        //   2. `frontmostApplicationTarget()` is called exactly once
+        //      (not re-queried after the LLM), so the recorded app
+        //      can't drift mid-run.
+        let captureBackend = FakeSelectionCaptureBackend(
+            isTrusted: true,
+            focusedElement: AXUIElementCreateSystemWide(),
+            selectedText: "Hello"
+        )
+        let captureService = SelectionCaptureService(
+            backend: captureBackend,
+            clipboardPollTimeout: .milliseconds(40),
+            pollIntervalNanos: 1_000_000
+        )
+        let replacementBackend = FakeSelectionReplacementBackend(
+            isTrusted: true,
+            axWriteSucceeds: true
+        )
+        let replacementService = SelectionReplacementService(
+            backend: replacementBackend,
+            postPasteDelay: .milliseconds(1)
+        )
+        let llm = MockTransformLLMService()
+        llm.streamTokens = ["polished"]
+        let executor = TransformExecutor(
+            captureService: captureService,
+            replacementService: replacementService,
+            llmService: llm
+        )
+
+        let result = try await executor.run(prompt: "polish", onProgress: { _ in })
+
+        XCTAssertEqual(result.inputText, "Hello")
+        XCTAssertEqual(result.outputText, "polished")
+        let target = try XCTUnwrap(result.target, "Captured target must be propagated to result")
+        XCTAssertEqual(target.processIdentifier, 1234)
+        XCTAssertEqual(target.bundleIdentifier, "com.example.Source")
+        XCTAssertEqual(target.localizedName, "Source")
+        XCTAssertEqual(
+            captureBackend.frontmostTargetCallCount(), 1,
+            "Frontmost app must be queried exactly once — at capture time — to prevent drift during long LLM runs."
+        )
+    }
+
     func testRunEmitsProgressInOrderAndCallsReplacementOnSuccess() async throws {
         let captureBackend = FakeSelectionCaptureBackend(
             isTrusted: true,

--- a/Tests/MacParakeetTests/ViewModels/TransformsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TransformsViewModelTests.swift
@@ -365,8 +365,8 @@ final class TransformsViewModelTests: XCTestCase {
         // Regression: SwiftUI alert sets `pendingDeleteHistoryEntry = nil`
         // before the Delete button's Task runs. The view must call
         // `deleteHistoryEntry(entry)` with the closure-captured entry, not
-        // route through `confirmPendingHistoryDelete()` (which would read a
-        // now-nil pending field and silently no-op).
+        // route through a pending-field wrapper that would read a now-nil
+        // value and silently no-op.
         let entry = TransformHistoryEntry(
             transformName: "Polish",
             inputText: "rough",

--- a/Tests/MacParakeetTests/ViewModels/TransformsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TransformsViewModelTests.swift
@@ -361,6 +361,61 @@ final class TransformsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isConfirmingClearHistory)
     }
 
+    func testDeleteHistoryEntryWorksWithoutPendingState() async throws {
+        // Regression: SwiftUI alert sets `pendingDeleteHistoryEntry = nil`
+        // before the Delete button's Task runs. The view must call
+        // `deleteHistoryEntry(entry)` with the closure-captured entry, not
+        // route through `confirmPendingHistoryDelete()` (which would read a
+        // now-nil pending field and silently no-op).
+        let entry = TransformHistoryEntry(
+            transformName: "Polish",
+            inputText: "rough",
+            outputText: "polished",
+            capturePath: "ax",
+            replacementPath: "ax",
+            llmElapsedMs: 1,
+            totalElapsedMs: 2
+        )
+        try historyRepo.save(entry)
+        await viewModel.loadHistory()
+        XCTAssertEqual(viewModel.history.count, 1)
+
+        viewModel.pendingDeleteHistoryEntry = nil  // simulate SwiftUI binding clear
+
+        await viewModel.deleteHistoryEntry(entry)
+
+        XCTAssertTrue(viewModel.history.isEmpty)
+        XCTAssertEqual(viewModel.totalHistoryCount, 0)
+    }
+
+    func testHistorySnapshotGenerationGuardsAgainstStaleLoadAfterDelete() async throws {
+        // Regression: a `loadHistory` triggered by a transformHistoryChanged
+        // notification can race a user-triggered delete. Without a
+        // generation guard, the stale load could resurrect the just-deleted
+        // row until the next notification reloaded.
+        let first = TransformHistoryEntry(
+            transformName: "Polish",
+            inputText: "rough",
+            outputText: "polished",
+            capturePath: "ax",
+            replacementPath: "ax",
+            llmElapsedMs: 1,
+            totalElapsedMs: 2
+        )
+        try historyRepo.save(first)
+        await viewModel.loadHistory()
+        XCTAssertEqual(viewModel.history.count, 1)
+
+        // Kick off concurrent load + delete. The delete should win the
+        // visible state regardless of which detached fetch lands first.
+        async let load: Void = viewModel.loadHistory()
+        async let delete: Void = viewModel.deleteHistoryEntry(first)
+        _ = await (load, delete)
+
+        XCTAssertTrue(viewModel.history.isEmpty)
+        XCTAssertEqual(viewModel.totalHistoryCount, 0)
+    }
+
     func testCopyOutputToClipboardWritesToClipboardAndFlagsCopied() async throws {
         let entry = TransformHistoryEntry(
             transformName: "Polish",

--- a/Tests/MacParakeetTests/ViewModels/TransformsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TransformsViewModelTests.swift
@@ -6,6 +6,8 @@ import XCTest
 final class TransformsViewModelTests: XCTestCase {
     var manager: DatabaseManager!
     var repo: PromptRepository!
+    var historyRepo: TransformHistoryRepository!
+    var clipboardService: MockTransformsClipboardService!
     var viewModel: TransformsViewModel!
 
     override func setUp() async throws {
@@ -13,8 +15,15 @@ final class TransformsViewModelTests: XCTestCase {
         // `DatabaseManager(path:)` is the file-backed production path.
         manager = try DatabaseManager()
         repo = PromptRepository(dbQueue: manager.dbQueue)
+        historyRepo = TransformHistoryRepository(dbQueue: manager.dbQueue)
+        clipboardService = MockTransformsClipboardService()
         viewModel = TransformsViewModel()
-        viewModel.configure(repo: repo, hasLLMProvider: true)
+        viewModel.configure(
+            repo: repo,
+            historyRepo: historyRepo,
+            clipboardService: clipboardService,
+            hasLLMProvider: true
+        )
         await viewModel.load()
     }
 
@@ -264,5 +273,126 @@ final class TransformsViewModelTests: XCTestCase {
         let restoredPolish = try XCTUnwrap(viewModel.transforms.first(where: { $0.name == "Polish" }))
         XCTAssertNil(restoredPolish.shortcut)
         XCTAssertTrue(viewModel.errorMessage?.contains("conflicts with hands-free dictation") ?? false)
+    }
+
+    // MARK: - History
+
+    func testLoadHistoryOrdersNewestFirst() async throws {
+        try historyRepo.save(
+            TransformHistoryEntry(
+                transformName: "Polish",
+                inputText: "first",
+                outputText: "first-out",
+                capturePath: "ax",
+                replacementPath: "ax",
+                llmElapsedMs: 1,
+                totalElapsedMs: 2,
+                createdAt: Date(timeIntervalSince1970: 1_000)
+            )
+        )
+        try historyRepo.save(
+            TransformHistoryEntry(
+                transformName: "Distill",
+                inputText: "second",
+                outputText: "second-out",
+                capturePath: "ax",
+                replacementPath: "ax",
+                llmElapsedMs: 1,
+                totalElapsedMs: 2,
+                createdAt: Date(timeIntervalSince1970: 2_000)
+            )
+        )
+
+        await viewModel.loadHistory()
+
+        XCTAssertEqual(viewModel.history.map(\.transformName), ["Distill", "Polish"])
+        XCTAssertEqual(viewModel.totalHistoryCount, 2)
+    }
+
+    func testDeleteHistoryEntryRemovesRowAndKeepsSnapshotFresh() async throws {
+        let first = TransformHistoryEntry(
+            transformName: "Polish",
+            inputText: "rough",
+            outputText: "polished",
+            capturePath: "ax",
+            replacementPath: "ax",
+            llmElapsedMs: 1,
+            totalElapsedMs: 2
+        )
+        let second = TransformHistoryEntry(
+            transformName: "Distill",
+            inputText: "long",
+            outputText: "short",
+            capturePath: "clipboard",
+            replacementPath: "clipboardPaste",
+            llmElapsedMs: 3,
+            totalElapsedMs: 4
+        )
+        try historyRepo.save(first)
+        try historyRepo.save(second)
+        await viewModel.loadHistory()
+        XCTAssertEqual(viewModel.history.count, 2)
+
+        await viewModel.deleteHistoryEntry(first)
+
+        XCTAssertEqual(viewModel.history.map(\.id), [second.id])
+        XCTAssertEqual(viewModel.totalHistoryCount, 1)
+    }
+
+    func testClearHistoryEmptiesTheTableAndResetsConfirmFlag() async throws {
+        try historyRepo.save(
+            TransformHistoryEntry(
+                transformName: "Polish",
+                inputText: "rough",
+                outputText: "polished",
+                capturePath: "ax",
+                replacementPath: "ax",
+                llmElapsedMs: 1,
+                totalElapsedMs: 2
+            )
+        )
+        await viewModel.loadHistory()
+        viewModel.isConfirmingClearHistory = true
+
+        await viewModel.clearHistory()
+
+        XCTAssertTrue(viewModel.history.isEmpty)
+        XCTAssertEqual(viewModel.totalHistoryCount, 0)
+        XCTAssertFalse(viewModel.isConfirmingClearHistory)
+    }
+
+    func testCopyOutputToClipboardWritesToClipboardAndFlagsCopied() async throws {
+        let entry = TransformHistoryEntry(
+            transformName: "Polish",
+            inputText: "rough",
+            outputText: "polished",
+            capturePath: "ax",
+            replacementPath: "ax",
+            llmElapsedMs: 1,
+            totalElapsedMs: 2
+        )
+
+        await viewModel.copyOutputToClipboard(entry)
+
+        XCTAssertEqual(clipboardService.lastCopied, "polished")
+        XCTAssertEqual(viewModel.copiedHistoryEntryID, entry.id)
+        XCTAssertNil(viewModel.historyErrorMessage)
+    }
+}
+
+final class MockTransformsClipboardService: ClipboardServiceProtocol, @unchecked Sendable {
+    var lastCopied: String?
+    var copyReturnValue = true
+
+    func pasteText(_ text: String) async throws {}
+
+    func pasteTextWithAction(_ text: String, postPasteAction: KeyAction?) async throws -> Bool {
+        false
+    }
+
+    @discardableResult
+    func copyToClipboard(_ text: String) async -> Bool {
+        lastCopied = text
+        return copyReturnValue
     }
 }

--- a/Tests/MacParakeetTests/ViewModels/TransformsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TransformsViewModelTests.swift
@@ -416,6 +416,48 @@ final class TransformsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.totalHistoryCount, 0)
     }
 
+    func testPassiveLoadStartedDuringDeleteCannotOverrideMutationSnapshot() async throws {
+        let entry = TransformHistoryEntry(
+            transformName: "Polish",
+            inputText: "rough",
+            outputText: "polished",
+            capturePath: "ax",
+            replacementPath: "ax",
+            llmElapsedMs: 1,
+            totalElapsedMs: 2
+        )
+        let blockingRepo = BlockingTransformHistoryRepository(entries: [entry])
+        let viewModel = TransformsViewModel()
+        viewModel.configure(
+            repo: repo,
+            historyRepo: blockingRepo,
+            clipboardService: clipboardService,
+            hasLLMProvider: true
+        )
+        await viewModel.loadHistory()
+        XCTAssertEqual(viewModel.history.map(\.id), [entry.id])
+
+        blockingRepo.shouldBlockDelete = true
+        let delete = Task { await viewModel.deleteHistoryEntry(entry) }
+        let deleteBlocked = await Task.detached {
+            blockingRepo.waitForDeleteToBlock()
+        }.value
+        XCTAssertTrue(deleteBlocked, "Delete did not reach the controlled block point.")
+
+        let load = Task { await viewModel.loadHistory() }
+        let staleLoadRead = await Task.detached {
+            blockingRepo.waitForFetchDuringBlockedDelete()
+        }.value
+        XCTAssertTrue(staleLoadRead, "Passive load did not read while delete was blocked.")
+        blockingRepo.releaseDelete()
+
+        await load.value
+        await delete.value
+
+        XCTAssertTrue(viewModel.history.isEmpty)
+        XCTAssertEqual(viewModel.totalHistoryCount, 0)
+    }
+
     func testCopyOutputToClipboardWritesToClipboardAndFlagsCopied() async throws {
         let entry = TransformHistoryEntry(
             transformName: "Polish",
@@ -449,5 +491,109 @@ final class MockTransformsClipboardService: ClipboardServiceProtocol, @unchecked
     func copyToClipboard(_ text: String) async -> Bool {
         lastCopied = text
         return copyReturnValue
+    }
+}
+
+private final class BlockingTransformHistoryRepository: TransformHistoryRepositoryProtocol, @unchecked Sendable {
+    private let lock = NSLock()
+    private var entries: [TransformHistoryEntry]
+    private var deleteIsBlocked = false
+    private let deleteBlocked = DispatchSemaphore(value: 0)
+    private let releaseBlockedDelete = DispatchSemaphore(value: 0)
+    private let fetchDuringBlockedDelete = DispatchSemaphore(value: 0)
+
+    var shouldBlockDelete = false
+
+    init(entries: [TransformHistoryEntry]) {
+        self.entries = entries
+    }
+
+    func save(_ entry: TransformHistoryEntry) throws {
+        lock.lock()
+        entries.append(entry)
+        lock.unlock()
+    }
+
+    func fetchAll() throws -> [TransformHistoryEntry] {
+        lock.lock()
+        let snapshot = entries
+        lock.unlock()
+        return snapshot.sorted { $0.createdAt > $1.createdAt }
+    }
+
+    func fetchRecent(limit: Int) throws -> [TransformHistoryEntry] {
+        Array(try fetchAll().prefix(max(0, limit)))
+    }
+
+    func fetchRecentWithCount(limit: Int) throws -> (entries: [TransformHistoryEntry], totalCount: Int) {
+        lock.lock()
+        let snapshot = entries
+        let blocked = deleteIsBlocked
+        lock.unlock()
+        if blocked {
+            fetchDuringBlockedDelete.signal()
+        }
+        return (Array(snapshot.sorted { $0.createdAt > $1.createdAt }.prefix(max(0, limit))), snapshot.count)
+    }
+
+    func fetch(id: UUID) throws -> TransformHistoryEntry? {
+        lock.lock()
+        let entry = entries.first { $0.id == id }
+        lock.unlock()
+        return entry
+    }
+
+    func fetch(idPrefix: String) throws -> [TransformHistoryEntry] {
+        let prefix = idPrefix.replacingOccurrences(of: "-", with: "").lowercased()
+        lock.lock()
+        let snapshot = entries.filter {
+            $0.id.uuidString.replacingOccurrences(of: "-", with: "").lowercased().hasPrefix(prefix)
+        }
+        lock.unlock()
+        return snapshot
+    }
+
+    func count() throws -> Int {
+        lock.lock()
+        let count = entries.count
+        lock.unlock()
+        return count
+    }
+
+    func delete(id: UUID) throws -> Bool {
+        if shouldBlockDelete {
+            lock.lock()
+            deleteIsBlocked = true
+            lock.unlock()
+            deleteBlocked.signal()
+            _ = releaseBlockedDelete.wait(timeout: .now() + 5)
+            lock.lock()
+            deleteIsBlocked = false
+            lock.unlock()
+        }
+
+        lock.lock()
+        defer { lock.unlock() }
+        guard let index = entries.firstIndex(where: { $0.id == id }) else { return false }
+        entries.remove(at: index)
+        return true
+    }
+
+    func deleteAll() throws {
+        lock.lock()
+        entries.removeAll()
+        lock.unlock()
+    }
+
+    func waitForDeleteToBlock() -> Bool {
+        deleteBlocked.wait(timeout: .now() + 5) == .success
+    }
+
+    func waitForFetchDuringBlockedDelete() -> Bool {
+        fetchDuringBlockedDelete.wait(timeout: .now() + 5) == .success
+    }
+
+    func releaseDelete() {
+        releaseBlockedDelete.signal()
     }
 }

--- a/spec/01-data-model.md
+++ b/spec/01-data-model.md
@@ -859,6 +859,7 @@ migrator.registerMigration("v0.7-prompts-and-summaries") { db in
 // v0.14 — transform_history (removed by v0.16 before merge)
 // v0.15 — transform_profiles and writing_samples (removed by v0.16 before merge)
 // v0.16 — drop abandoned Transform Workbench tables
+// v0.17 — recreate transform_history (workbench tables stay dropped)
 ```
 
 ### Migration Rules
@@ -908,8 +909,8 @@ migrator.registerMigration("v0.7-prompts-and-summaries") { db in
 | `transcriptions.derivedSnippet` | v0.9 | Cached display preview snippet derived from transcript content |
 | `quick_prompts` | v0.10 | User-customizable live Ask tab shortcut pills; v0.6 product feature |
 | `idx_transcriptions_source_type_created_at` / `idx_transcriptions_favorite_created_at` / `idx_transcriptions_status_created_at` | v0.10 | Library filter/sort indexes for source type, favorites, and status |
-| ~~`transform_history`~~ | ~~v0.14~~ | ~~Local Transform run history~~ (dropped in v0.16 before merge) |
-| ~~`transform_profiles`~~ / ~~`writing_samples`~~ | ~~v0.15~~ | ~~Transform Workbench tables~~ (dropped in v0.16 before merge) |
+| `transform_history` | v0.14 (re-created v0.17) | Local Transform run history (input/output/source app/timings). Dropped by v0.16 along with the workbench tables, then recreated standalone in v0.17 once history was restored without the workbench. |
+| ~~`transform_profiles`~~ / ~~`writing_samples`~~ | ~~v0.15~~ | ~~Transform Workbench tables~~ (dropped in v0.16; workbench feature removed) |
 
 ### Tables NOT Planned (YAGNI)
 


### PR DESCRIPTION
## Summary

Brings back the local Transform history that PR #288 reverted alongside the workbench. The workbench (profiles, rule toggles, writing samples, custom-instruction sidecar) was Phase-3 overreach; history is an independent decision and the case for it is strong. This PR ships history-only, on the simpler post-#288 base, and improves on PR #283's original wiring.

```
selected text in any app
        |
   ⌥1 / ⌥2 / ⌥3
        |
        v
TransformsCoordinator → TransformExecutor (capture → LLM → replace)
        |                       |
        |                       └→ TransformExecutionResult (now carries
        |                          inputText + typed SelectionCaptureTarget)
        |
        v (detached task)
TransformHistoryRepository.save(entry)
        |
        ├→ Notification.Name.transformHistoryChanged
        |       → TransformsView refreshes if open
        └→ Local SQLite (transform_history)
                → Transforms tab History section (read/copy/delete/clear)
                → `macparakeet-cli transforms history list/show/delete/clear`
```

## Why history (not the workbench)

- **⌘Z is fragile.** Switch focus, close the doc, come back tomorrow — host app's undo stack is gone and the original is lost. For a privacy-forward local app, we already have the input/output bytes; not keeping them is a self-inflicted UX loss.
- **Iteration loop for custom prompts.** Power users will tune their own Transforms by comparing inputs/outputs across runs. Without history they can't.
- **Debug + support workflow.** When a Transform produces a weird result, `transforms history show <id> --json` is a one-liner to capture the exact in/out for a bug report.
- **CLI completeness.** The CLI is positioned as the canonical headless Parakeet surface for agent operators. If `transforms run` exists, the natural follow-up is "what did the last run produce" — answering "use the GUI" is friction every time.

## What's better than the original PR #283

PR #283 used `NSWorkspace.shared.frontmostApplication` at history-write time. That drifts during long LLM runs — if the user Alt-Tabbed mid-stream, the source app recorded into history was wherever they ended up, not where they captured from. PR #288's followups (`2698bf07`) introduced a typed `SelectionCaptureTarget` and propagated it through the capture pipeline; this PR threads it through `TransformExecutionResult.target` so history records the *captured* app, not the *current* app. Same fix `68e60324` made post-workbench-merge, applied at restore time.

## Schema

Forward-only migration `v0.17-recreate-transform-history`:
- v0.14 (original `transform_history`) and v0.15 (workbench tables) stay byte-identical in the ledger — immutable per GRDB rules.
- v0.16 still drops everything (workbench cleanup).
- v0.17 idempotently recreates `transform_history` via `CREATE TABLE IF NOT EXISTS`. Dev DBs that ran v0.16 get the table back; workbench tables stay gone.
- Fresh installs run v0.14 → v0.15 → v0.16 → v0.17 in order; end state is the same.

## CLI

```
transforms history list   [--limit N] [--json]
transforms history show   <id-prefix> [--json]
transforms history delete <id-prefix> [--json]
transforms history clear  [--json]
```

UUID prefixes must be ≥4 hex chars (matches the safety floor PR #288 followups added for `transforms show <id>`). Snake-cased `TransformHistoryDTO` payload, `errorType: "validation"` on too-short prefix, `errorType: "lookup"` on missing row. CLI changelog updated.

## Verification

- `swift build` clean
- `swift test` — **2667 tests, 10 skipped, 0 failures, ~117s** (was 2658; +9 are new VM history tests + CLI parse/JSON/round-trip tests; the repository tests came back from PR #283 intact)
- `macparakeet-cli transforms history --help` lists the four subcommands
- Dev app boots; Transforms tab shows the simple Phase 2 editor plus the new History section below the grid

## Test plan

- [ ] Press ⌥1 on selected text in TextEdit / Notes / Slack — history row appears with the right `sourceAppName`
- [ ] Alt-Tab to a different app *during* the LLM stream — history still records the original source app, not the destination
- [ ] Open Transforms tab — recent rows render newest-first
- [ ] Copy a row's output — clipboard receives the transformed text, button shows "Copied" briefly
- [ ] Delete a row via the row's trash icon — alert confirms, row disappears from list and `totalHistoryCount` decrements
- [ ] "Clear" header button — alert confirms, all rows disappear
- [ ] `macparakeet-cli transforms history list` shows the same rows the GUI shows
- [ ] `macparakeet-cli transforms history show <prefix> --json` returns the snake-cased DTO
- [ ] `macparakeet-cli transforms history show abc --json` (too short) exits 2 with `errorType: "validation"`

## Follow-ups (not in this PR)

- Update ADR-022 §"Non-decisions" to remove "rule toggles" and "writing samples" from the Phase 3 candidate list — they're decided-against now, not deferred. History is no longer a Phase 3 candidate either; it's shipped.
- Consider an in-memory `historyFetchLimit`-bounded ring for the UI to avoid re-fetching the whole 200 every notification — only needed if heavy users start to feel a hitch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `transforms history` CLI (list/show/delete/clear) with JSON output, prefix lookup, and --limit.
  * Added Transform History panel in Transforms tab showing recent runs, timestamp, single-line preview, copy, delete, and clear-all actions.

* **Bug Fixes / Validation**
  * CLI now validates ID prefixes (too-short/non-hex/ambiguous) with distinct JSON error mappings.

* **Tests**
  * Added unit and integration tests covering CLI, repository, migrations, view model, and executor behavior.

* **Documentation**
  * Changelog and schema docs updated for Transform history.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moona3k/macparakeet/pull/289)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->