### PR TITLE
Polish CLI transcription output and model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,13 +113,20 @@ The dev script creates a signed `.app` bundle so macOS grants mic and accessibil
 
 ```bash
 swift run macparakeet-cli transcribe /path/to/audio.mp3
+swift run macparakeet-cli transcribe /path/to/audio.mp3 --format transcript --no-history
 swift run macparakeet-cli models download whisper-large-v3-v20240930-turbo-632MB
+swift run macparakeet-cli models list
+swift run macparakeet-cli models select parakeet
 swift run macparakeet-cli transcribe /path/to/korean.mp3 --engine whisper --language ko --format json
 swift run macparakeet-cli models status
 swift run macparakeet-cli history
 ```
 
-The Whisper CLI commands above require a downloaded local WhisperKit model.
+Use `--format transcript` for transcript-only stdout in shell pipelines. Add
+`--no-history` when you want a one-off transcription without saving a completed
+row to MacParakeet history. `models list` and `models select` inspect or update
+the shared speech default used by the app and `--engine app-default`. The
+Whisper CLI commands above require a downloaded local WhisperKit model.
 
 ## Tech stack
 

--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -156,6 +156,19 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ### Added
 
+- `transcribe --format transcript` prints only the final transcript text to
+  stdout, with progress/status still isolated on stderr. This keeps the
+  existing human `--format text` view intact while giving shell pipelines a
+  clean `pbcopy`, `grep`, `tee`, or local-LLM input mode.
+- `transcribe --no-history` runs file/URL transcription without saving a
+  completed transcription row to MacParakeet history. For YouTube inputs,
+  downloaded audio is treated as temporary even when the shared app default is
+  to retain transcription audio.
+- `models list` and `models select <id>` provide user-facing aliases over the
+  shared speech-engine defaults. `models list` shows Parakeet plus the
+  configured WhisperKit variant with installed/selected state; `models select`
+  writes the same default that `config set speech-engine` writes, and validates
+  Whisper model availability before switching.
 - `transcribe --engine app-default` resolves the speech engine and Whisper
   language from the same saved defaults used by the GUI, while preserving
   Parakeet as the no-flag CLI default.

--- a/Sources/CLI/Commands/ModelsCommand.swift
+++ b/Sources/CLI/Commands/ModelsCommand.swift
@@ -8,6 +8,8 @@ struct ModelsCommand: AsyncParsableCommand {
         commandName: "models",
         abstract: "Inspect and manage the local speech and speaker models.",
         subcommands: [
+            List.self,
+            Select.self,
             Status.self,
             Download.self,
             WarmUp.self,
@@ -18,6 +20,75 @@ struct ModelsCommand: AsyncParsableCommand {
 }
 
 extension ModelsCommand {
+    struct List: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "list",
+            abstract: "List selectable speech models."
+        )
+
+        @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+        var json: Bool = false
+
+        func run() throws {
+            try emitJSONOrRethrow(json: json) {
+                let models = loadSelectableSpeechModels()
+                if json {
+                    try printJSON(models)
+                } else {
+                    printSelectableSpeechModels(models)
+                }
+            }
+        }
+    }
+
+    struct Select: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "select",
+            abstract: "Set the shared app/CLI default speech model."
+        )
+
+        @Argument(help: "Model ID from `models list`.")
+        var id: String
+
+        @Flag(name: .long, help: "Emit JSON instead of human-readable output.")
+        var json: Bool = false
+
+        func run() throws {
+            try emitJSONOrRethrow(json: json) {
+                let defaults = macParakeetAppDefaults()
+                let selection = try resolveSelectableSpeechModel(id, defaults: defaults)
+                if let whisperVariant = selection.whisperVariant,
+                   !WhisperEngine.isModelDownloaded(model: whisperVariant) {
+                    throw ValidationError(
+                        "Whisper model is not downloaded. Run `macparakeet-cli models download \(whisperModelID(for: whisperVariant))` first."
+                    )
+                }
+
+                selection.engine.save(to: defaults)
+                if let whisperVariant = selection.whisperVariant {
+                    SpeechEnginePreference.saveWhisperModelVariant(whisperVariant, defaults: defaults)
+                }
+
+                let selected = loadSelectableSpeechModels(defaults: defaults).first { $0.selected }
+                    ?? SelectableSpeechModel(
+                        id: selection.engine.rawValue,
+                        name: selection.engine.displayName,
+                        engine: selection.engine.rawValue,
+                        variant: selection.whisperVariant,
+                        size: nil,
+                        installed: true,
+                        selected: true,
+                        language: nil
+                    )
+                if json {
+                    try printJSON(selected)
+                } else {
+                    print("Selected: \(selected.id) (\(selected.name))")
+                }
+            }
+        }
+    }
+
     struct Status: AsyncParsableCommand {
         static let configuration = CommandConfiguration(
             commandName: "status",
@@ -252,6 +323,129 @@ func printSpeechStackStatus(_ status: SpeechStackStatus, includeHeader: Bool = t
     print("  Whisper model variant: \(status.whisperModelVariant)")
     print("  Whisper model downloaded: \(status.whisperModelDownloaded ? "Yes" : "No")")
     print("  Status: \(status.summary)")
+}
+
+struct SelectableSpeechModel: Encodable, Equatable {
+    let id: String
+    let name: String
+    let engine: String
+    let variant: String?
+    let size: String?
+    let installed: Bool
+    let selected: Bool
+    let language: String?
+}
+
+struct SelectableSpeechModelSelection: Equatable {
+    let engine: SpeechEnginePreference
+    let whisperVariant: String?
+}
+
+func loadSelectableSpeechModels(
+    defaults: UserDefaults = macParakeetAppDefaults(),
+    isParakeetModelCached: @escaping () -> Bool = { STTClient.isModelCached() },
+    isWhisperModelDownloaded: @escaping (String) -> Bool = { WhisperEngine.isModelDownloaded(model: $0) }
+) -> [SelectableSpeechModel] {
+    let currentEngine = SpeechEnginePreference.current(defaults: defaults)
+    let whisperVariant = SpeechEnginePreference.whisperModelVariant(defaults: defaults)
+    let whisperLanguage = SpeechEnginePreference.whisperDefaultLanguage(defaults: defaults)
+
+    return [
+        SelectableSpeechModel(
+            id: SpeechEnginePreference.parakeet.rawValue,
+            name: "Parakeet TDT 0.6B v3",
+            engine: SpeechEnginePreference.parakeet.rawValue,
+            variant: nil,
+            size: "6 GB",
+            installed: isParakeetModelCached(),
+            selected: currentEngine == .parakeet,
+            language: nil
+        ),
+        SelectableSpeechModel(
+            id: whisperModelID(for: whisperVariant),
+            name: "Whisper \(SpeechEnginePreference.friendlyVariantName(whisperVariant))",
+            engine: SpeechEnginePreference.whisper.rawValue,
+            variant: whisperVariant,
+            size: whisperModelSizeLabel(for: whisperVariant),
+            installed: isWhisperModelDownloaded(whisperVariant),
+            selected: currentEngine == .whisper,
+            language: whisperLanguage ?? WhisperLanguageCatalog.autoCode
+        ),
+    ]
+}
+
+func resolveSelectableSpeechModel(
+    _ id: String,
+    defaults: UserDefaults = macParakeetAppDefaults()
+) throws -> SelectableSpeechModelSelection {
+    let trimmed = id.trimmingCharacters(in: .whitespacesAndNewlines)
+    let lowered = trimmed.lowercased()
+    guard !trimmed.isEmpty else {
+        throw ValidationError("Model ID cannot be empty.")
+    }
+
+    if lowered == SpeechEnginePreference.parakeet.rawValue {
+        return SelectableSpeechModelSelection(engine: .parakeet, whisperVariant: nil)
+    }
+
+    if lowered == "whisper" {
+        return SelectableSpeechModelSelection(
+            engine: .whisper,
+            whisperVariant: SpeechEnginePreference.whisperModelVariant(defaults: defaults)
+        )
+    }
+
+    let variantInput: String?
+    if lowered.hasPrefix("whisper:") {
+        variantInput = String(trimmed.dropFirst("whisper:".count))
+    } else if lowered.hasPrefix("whisper-") {
+        variantInput = String(trimmed.dropFirst("whisper-".count))
+    } else {
+        variantInput = nil
+    }
+
+    guard let variantInput,
+          !variantInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        throw ValidationError("Unknown model ID: '\(id)'. Run `macparakeet-cli models list` for valid IDs.")
+    }
+
+    return SelectableSpeechModelSelection(
+        engine: .whisper,
+        whisperVariant: WhisperEngine.normalizeModelVariant(variantInput)
+    )
+}
+
+func whisperModelID(for variant: String) -> String {
+    "whisper-\(variant.replacingOccurrences(of: "_turbo_", with: "-turbo-").replacingOccurrences(of: "_", with: "-"))"
+}
+
+func whisperModelSizeLabel(for variant: String) -> String? {
+    let tokens = variant.split(separator: "_")
+    guard let last = tokens.last else { return nil }
+    let raw = String(last)
+    let lowered = raw.lowercased()
+    if lowered.hasSuffix("mb") {
+        return "\(raw.dropLast(2)) MB"
+    }
+    if lowered.hasSuffix("gb") {
+        return "\(raw.dropLast(2)) GB"
+    }
+    return nil
+}
+
+func printSelectableSpeechModels(_ models: [SelectableSpeechModel]) {
+    print("\(paddedModelColumn("ID", width: 44)) \(paddedModelColumn("NAME", width: 28)) \(paddedModelColumn("SIZE", width: 10)) INSTALLED")
+    for model in models {
+        let marker = model.selected ? "*" : " "
+        let size = model.size ?? "-"
+        let installed = model.installed ? "yes" : "no"
+        print("\(marker) \(paddedModelColumn(model.id, width: 42)) \(paddedModelColumn(model.name, width: 28)) \(paddedModelColumn(size, width: 10)) \(installed)")
+    }
+}
+
+private func paddedModelColumn(_ value: String, width: Int) -> String {
+    let padding = max(0, width - value.count)
+    return value + String(repeating: " ", count: padding)
 }
 
 func prepareSpeechStack(

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -23,6 +23,7 @@ enum YouTubeAudioQualityOption: String, ExpressibleByArgument {
 
 enum TranscribeOutputFormat: String, ExpressibleByArgument, CaseIterable, Sendable {
     case text
+    case transcript
     case json
 }
 
@@ -57,7 +58,7 @@ struct TranscribeCommand: AsyncParsableCommand {
     @Argument(help: "Path to audio/video file or YouTube URL to transcribe.")
     var input: String
 
-    @Option(name: .shortAndLong, help: "Output format: text, json.")
+    @Option(name: .shortAndLong, help: "Output format: text, transcript, json.")
     var format: TranscribeOutputFormat = .text
 
     @Option(help: "Processing mode: raw, clean, app-default.")
@@ -86,6 +87,15 @@ struct TranscribeCommand: AsyncParsableCommand {
 
     @Flag(help: "Run retained entitlement checks before transcribing. Current free builds remain unlocked.")
     var enforceEntitlements: Bool = false
+
+    @Flag(name: .long, help: "Do not save the completed transcription to MacParakeet history. YouTube audio is temporary.")
+    var noHistory: Bool = false
+
+    func validate() throws {
+        if noHistory && downloadedAudio == .keep {
+            throw ValidationError("--no-history cannot be combined with --downloaded-audio keep.")
+        }
+    }
 
     static func resolveProcessingMode(_ mode: TranscribeMode, storedMode: String?) -> Dictation.ProcessingMode {
         switch mode {
@@ -198,7 +208,7 @@ struct TranscribeCommand: AsyncParsableCommand {
                     self.youtubeAudioQuality,
                     storedQuality: defaults.string(forKey: UserDefaultsAppRuntimePreferences.youtubeAudioQualityKey)
                 )
-                let shouldKeepDownloadedAudio: Bool = switch self.downloadedAudio {
+                let configuredShouldKeepDownloadedAudio: Bool = switch self.downloadedAudio {
                 case .keep:
                     true
                 case .delete:
@@ -206,6 +216,7 @@ struct TranscribeCommand: AsyncParsableCommand {
                 case .appDefault:
                     defaults.object(forKey: UserDefaultsAppRuntimePreferences.saveTranscriptionAudioKey) as? Bool ?? true
                 }
+                let shouldKeepDownloadedAudio = self.noHistory ? false : configuredShouldKeepDownloadedAudio
                 let sttTranscriber: STTTranscribing
                 switch speechEngine.engine {
                 case .parakeet:
@@ -262,7 +273,7 @@ struct TranscribeCommand: AsyncParsableCommand {
                         }
                     }
 
-                    result = try await service.transcribeURL(urlString: trimmedInput) { progress in
+                    let progressHandler: @Sendable (TranscriptionProgress) -> Void = { progress in
                         switch progress {
                         case .converting: printProgressLine("Converting audio...")
                         case .downloading(let pct): printProgressLine("Downloading audio... \(pct)%")
@@ -270,6 +281,17 @@ struct TranscribeCommand: AsyncParsableCommand {
                         case .identifyingSpeakers: printProgressLine("Identifying speakers...")
                         case .finalizing: printProgressLine("Finalizing...")
                         }
+                    }
+                    if self.noHistory {
+                        result = try await service.transcribeURLTransient(
+                            urlString: trimmedInput,
+                            onProgress: progressHandler
+                        )
+                    } else {
+                        result = try await service.transcribeURL(
+                            urlString: trimmedInput,
+                            onProgress: progressHandler
+                        )
                     }
                 } else {
                     let url = Self.localFileURL(for: trimmedInput)
@@ -284,12 +306,18 @@ struct TranscribeCommand: AsyncParsableCommand {
                     }
 
                     printErr("Transcribing \(url.lastPathComponent) with \(speechEngine.engine.rawValue)...")
-                    result = try await service.transcribe(fileURL: url)
+                    if self.noHistory {
+                        result = try await service.transcribeTransient(fileURL: url)
+                    } else {
+                        result = try await service.transcribe(fileURL: url)
+                    }
                 }
 
                 switch format {
                 case .json:
                     try printJSON(result)
+                case .transcript:
+                    printTranscript(result)
                 case .text:
                     printText(result)
                 }
@@ -402,6 +430,20 @@ struct TranscribeCommand: AsyncParsableCommand {
                 print("[\(start)-\(end)] \(w.word) (\(String(format: "%.0f", w.confidence * 100))%)\(speaker)")
             }
         }
+    }
+
+    static func transcriptOutput(for t: Transcription) -> String {
+        for candidate in [t.cleanTranscript, t.rawTranscript] {
+            let trimmed = candidate?.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let trimmed, !trimmed.isEmpty {
+                return trimmed
+            }
+        }
+        return ""
+    }
+
+    private func printTranscript(_ t: Transcription) {
+        print(Self.transcriptOutput(for: t))
     }
 }
 

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -7,6 +7,11 @@ public protocol TranscriptionServiceProtocol: Sendable {
         source: TelemetryTranscriptionSource,
         onProgress: (@Sendable (TranscriptionProgress) -> Void)?
     ) async throws -> Transcription
+    func transcribeTransient(
+        fileURL: URL,
+        source: TelemetryTranscriptionSource,
+        onProgress: (@Sendable (TranscriptionProgress) -> Void)?
+    ) async throws -> Transcription
     func transcribeMeeting(
         recording: MeetingRecordingOutput,
         onProgress: (@Sendable (TranscriptionProgress) -> Void)?
@@ -23,6 +28,7 @@ public protocol TranscriptionServiceProtocol: Sendable {
         onProgress: (@Sendable (TranscriptionProgress) -> Void)?
     ) async throws -> Transcription
     func transcribeURL(urlString: String, onProgress: (@Sendable (TranscriptionProgress) -> Void)?) async throws -> Transcription
+    func transcribeURLTransient(urlString: String, onProgress: (@Sendable (TranscriptionProgress) -> Void)?) async throws -> Transcription
 }
 
 public protocol SpeechEngineOverrideTranscriptionService: TranscriptionServiceProtocol {
@@ -53,8 +59,23 @@ extension TranscriptionServiceProtocol {
         try await transcribe(fileURL: fileURL, source: source, onProgress: nil)
     }
 
+    public func transcribeTransient(fileURL: URL) async throws -> Transcription {
+        try await transcribeTransient(fileURL: fileURL, source: .file, onProgress: nil)
+    }
+
+    public func transcribeTransient(
+        fileURL: URL,
+        source: TelemetryTranscriptionSource
+    ) async throws -> Transcription {
+        try await transcribeTransient(fileURL: fileURL, source: source, onProgress: nil)
+    }
+
     public func transcribeURL(urlString: String) async throws -> Transcription {
         try await transcribeURL(urlString: urlString, onProgress: nil)
+    }
+
+    public func transcribeURLTransient(urlString: String) async throws -> Transcription {
+        try await transcribeURLTransient(urlString: urlString, onProgress: nil)
     }
 
     public func transcribeMeeting(recording: MeetingRecordingOutput) async throws -> Transcription {
@@ -221,6 +242,33 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
         source: TelemetryTranscriptionSource = .file,
         onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
     ) async throws -> Transcription {
+        try await transcribe(
+            fileURL: fileURL,
+            source: source,
+            persistResult: true,
+            onProgress: onProgress
+        )
+    }
+
+    public func transcribeTransient(
+        fileURL: URL,
+        source: TelemetryTranscriptionSource = .file,
+        onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
+    ) async throws -> Transcription {
+        try await transcribe(
+            fileURL: fileURL,
+            source: source,
+            persistResult: false,
+            onProgress: onProgress
+        )
+    }
+
+    private func transcribe(
+        fileURL: URL,
+        source: TelemetryTranscriptionSource,
+        persistResult: Bool,
+        onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
+    ) async throws -> Transcription {
         let sourceType: Transcription.SourceType = switch source {
         case .youtube:
             .youtube
@@ -236,6 +284,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
             source: source,
             sttJob: .fileTranscription,
             sourceType: sourceType,
+            persistResult: persistResult,
             onProgress: onProgress
         )
     }
@@ -403,6 +452,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
         source: TelemetryTranscriptionSource,
         sttJob: STTJobKind,
         sourceType: Transcription.SourceType,
+        persistResult: Bool = true,
         onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
     ) async throws -> Transcription {
         let embeddedMetadata = sourceType == .file
@@ -437,22 +487,24 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
                 videoDescription: embeddedMetadata.description,
                 sourceType: sourceType
             )
-            do {
-                try transcriptionRepo.save(transcription)
-            } catch {
-                sendTranscriptionOperation(
-                    operation,
-                    outcome: .failure,
-                    stage: .persistence,
-                    errorType: Self.errorType(for: error)
-                )
-                throw error
+            if persistResult {
+                do {
+                    try transcriptionRepo.save(transcription)
+                } catch {
+                    sendTranscriptionOperation(
+                        operation,
+                        outcome: .failure,
+                        stage: .persistence,
+                        errorType: Self.errorType(for: error)
+                    )
+                    throw error
+                }
+                await cacheEmbeddedArtworkIfPresent(embeddedMetadata, for: transcription.id)
             }
-            await cacheEmbeddedArtworkIfPresent(embeddedMetadata, for: transcription.id)
             Telemetry.send(.transcriptionStarted(source: source, audioDurationSeconds: nil))
 
             // Extract a representative frame when no embedded artwork was available.
-            if embeddedMetadata.artworkData == nil, Self.isVideoFile(fileURL) {
+            if persistResult, embeddedMetadata.artworkData == nil, Self.isVideoFile(fileURL) {
                 let transcriptionId = transcription.id
                 let path = fileURL.path
                 let logger = self.logger
@@ -473,12 +525,33 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
                 transcription: &transcription,
                 operation: operation,
                 tempFiles: [],
+                persistResult: persistResult,
                 onProgress: onProgress
             )
         }
     }
 
     public func transcribeURL(urlString: String, onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil) async throws -> Transcription {
+        try await transcribeURL(
+            urlString: urlString,
+            persistResult: true,
+            onProgress: onProgress
+        )
+    }
+
+    public func transcribeURLTransient(urlString: String, onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil) async throws -> Transcription {
+        try await transcribeURL(
+            urlString: urlString,
+            persistResult: false,
+            onProgress: onProgress
+        )
+    }
+
+    private func transcribeURL(
+        urlString: String,
+        persistResult: Bool,
+        onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
+    ) async throws -> Transcription {
         let operation = TranscriptionOperationContext(
             source: .youtube,
             inputKind: .youtube,
@@ -559,6 +632,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
                 throw error
             }
             let keepDownloadedAudio = shouldKeepDownloadedAudio()
+                && persistResult
             let embeddedMetadata = await mediaMetadataExtractor.metadata(for: downloadResult.audioFileURL)
             let title = Self.firstNonEmpty(
                 downloadResult.title == "Untitled" ? nil : downloadResult.title,
@@ -582,19 +656,21 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
                 videoDescription: videoDescription,
                 sourceType: .youtube
             )
-            do {
-                try transcriptionRepo.save(transcription)
-            } catch {
-                sendTranscriptionOperation(
-                    operation,
-                    outcome: .failure,
-                    stage: .persistence,
-                    audioDurationSeconds: downloadResult.durationSeconds.map(Double.init),
-                    errorType: Self.errorType(for: error)
-                )
-                throw error
+            if persistResult {
+                do {
+                    try transcriptionRepo.save(transcription)
+                } catch {
+                    sendTranscriptionOperation(
+                        operation,
+                        outcome: .failure,
+                        stage: .persistence,
+                        audioDurationSeconds: downloadResult.durationSeconds.map(Double.init),
+                        errorType: Self.errorType(for: error)
+                    )
+                    throw error
+                }
             }
-            if downloadResult.thumbnailURL == nil {
+            if persistResult, downloadResult.thumbnailURL == nil {
                 await cacheEmbeddedArtworkIfPresent(embeddedMetadata, for: transcription.id)
             }
             if keepDownloadedAudio {
@@ -606,7 +682,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
             ))
 
             // Cache YouTube thumbnail locally (non-blocking)
-            if let thumbURL = downloadResult.thumbnailURL {
+            if persistResult, let thumbURL = downloadResult.thumbnailURL {
                 let transcriptionId = transcription.id
                 let logger = self.logger
                 let thumbnailCache = self.thumbnailCache
@@ -631,6 +707,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
                 operation: operation,
                 tempFiles: [downloadResult.audioFileURL],
                 cleanUpDownloadedFiles: !keepDownloadedAudio,
+                persistResult: persistResult,
                 onProgress: onProgress
             )
 
@@ -988,6 +1065,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
         operation: TranscriptionOperationContext,
         tempFiles: [URL],
         cleanUpDownloadedFiles: Bool = true,
+        persistResult: Bool = true,
         persistFailureStatus: Bool = true,
         speechEngine: SpeechEngineSelection? = nil,
         onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
@@ -1087,7 +1165,8 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
                 rawText: result.text,
                 processingStartedAt: processingStartedAt,
                 diarizationRequested: diarizationRequested,
-                diarizationApplied: diarizationApplied
+                diarizationApplied: diarizationApplied,
+                persistResult: persistResult
             )
 
             try? FileManager.default.removeItem(at: wavURL)
@@ -1141,7 +1220,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
                 )
             }
 
-            if persistFailureStatus {
+            if persistResult && persistFailureStatus {
                 let txID = transcription.id
                 if error is CancellationError {
                     do {
@@ -1217,7 +1296,8 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
         rawText: String,
         processingStartedAt: Date,
         diarizationRequested: Bool,
-        diarizationApplied: Bool
+        diarizationApplied: Bool,
+        persistResult: Bool = true
     ) async throws -> Transcription {
         let mode = processingMode()
         var customWords: [CustomWord] = []
@@ -1239,7 +1319,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
         let formattedTranscript = try await formatTranscriptIfNeeded(baseText)
         transcription.cleanTranscript = formattedTranscript ?? refinement.text
 
-        if !refinement.expandedSnippetIDs.isEmpty {
+        if persistResult, !refinement.expandedSnippetIDs.isEmpty {
             try? snippetRepo?.incrementUseCount(ids: refinement.expandedSnippetIDs)
         }
 
@@ -1252,7 +1332,9 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
 
         transcription.status = .completed
         transcription.updatedAt = Date()
-        try transcriptionRepo.save(transcription)
+        if persistResult {
+            try transcriptionRepo.save(transcription)
+        }
 
         let outputText = transcription.cleanTranscript ?? transcription.rawTranscript ?? ""
         let wordCount = outputText.split(whereSeparator: \.isWhitespace).count

--- a/Tests/CLITests/ModelLifecycleCommandTests.swift
+++ b/Tests/CLITests/ModelLifecycleCommandTests.swift
@@ -34,6 +34,107 @@ final class ModelLifecycleCommandTests: XCTestCase {
         }
     }
 
+    func testLoadSelectableSpeechModelsReflectsSharedDefaults() throws {
+        let suiteName = "com.macparakeet.tests.cli.models.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        SpeechEnginePreference.whisper.save(to: defaults)
+        SpeechEnginePreference.saveWhisperDefaultLanguage("KO_kr", defaults: defaults)
+        SpeechEnginePreference.saveWhisperModelVariant(
+            "large-v3-v20240930_turbo_632MB",
+            defaults: defaults
+        )
+
+        let models = loadSelectableSpeechModels(
+            defaults: defaults,
+            isParakeetModelCached: { false },
+            isWhisperModelDownloaded: { $0 == "large-v3-v20240930_turbo_632MB" }
+        )
+
+        XCTAssertEqual(models.count, 2)
+        XCTAssertEqual(models[0], SelectableSpeechModel(
+            id: "parakeet",
+            name: "Parakeet TDT 0.6B v3",
+            engine: "parakeet",
+            variant: nil,
+            size: "6 GB",
+            installed: false,
+            selected: false,
+            language: nil
+        ))
+        XCTAssertEqual(models[1], SelectableSpeechModel(
+            id: "whisper-large-v3-v20240930-turbo-632MB",
+            name: "Whisper Large v3 Turbo",
+            engine: "whisper",
+            variant: "large-v3-v20240930_turbo_632MB",
+            size: "632 MB",
+            installed: true,
+            selected: true,
+            language: "ko"
+        ))
+    }
+
+    func testResolveSelectableSpeechModelAcceptsEngineAndWhisperIDs() throws {
+        let suiteName = "com.macparakeet.tests.cli.model-select.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        SpeechEnginePreference.saveWhisperModelVariant(
+            "large-v3-v20240930_turbo_632MB",
+            defaults: defaults
+        )
+
+        XCTAssertEqual(
+            try resolveSelectableSpeechModel("parakeet", defaults: defaults),
+            SelectableSpeechModelSelection(engine: .parakeet, whisperVariant: nil)
+        )
+        XCTAssertEqual(
+            try resolveSelectableSpeechModel("whisper", defaults: defaults),
+            SelectableSpeechModelSelection(
+                engine: .whisper,
+                whisperVariant: "large-v3-v20240930_turbo_632MB"
+            )
+        )
+        XCTAssertEqual(
+            try resolveSelectableSpeechModel("whisper-large-v3-v20240930-turbo-632MB", defaults: defaults),
+            SelectableSpeechModelSelection(
+                engine: .whisper,
+                whisperVariant: "large-v3-v20240930_turbo_632MB"
+            )
+        )
+        XCTAssertEqual(
+            try resolveSelectableSpeechModel("Whisper-large-v3-v20240930-turbo-632MB", defaults: defaults),
+            SelectableSpeechModelSelection(
+                engine: .whisper,
+                whisperVariant: "large-v3-v20240930_turbo_632MB"
+            )
+        )
+        XCTAssertEqual(
+            try resolveSelectableSpeechModel("whisper:large-v3-v20240930_turbo_632MB", defaults: defaults),
+            SelectableSpeechModelSelection(
+                engine: .whisper,
+                whisperVariant: "large-v3-v20240930_turbo_632MB"
+            )
+        )
+    }
+
+    func testResolveSelectableSpeechModelRejectsUnknownID() {
+        XCTAssertThrowsError(try resolveSelectableSpeechModel("tiny")) { error in
+            XCTAssertTrue(error is ValidationError)
+        }
+        XCTAssertThrowsError(try resolveSelectableSpeechModel("parakeet:large")) { error in
+            XCTAssertTrue(error is ValidationError)
+        }
+        XCTAssertThrowsError(try resolveSelectableSpeechModel("whisper-")) { error in
+            XCTAssertTrue(error is ValidationError)
+        }
+        XCTAssertThrowsError(try resolveSelectableSpeechModel("whisper:")) { error in
+            XCTAssertTrue(error is ValidationError)
+        }
+    }
+
     func testWarmUpRetriesConfiguredAttempts() async {
         let stt = StubSTTClient()
         let diarization = StubDiarizationService()

--- a/Tests/CLITests/TranscribeCommandTests.swift
+++ b/Tests/CLITests/TranscribeCommandTests.swift
@@ -167,6 +167,27 @@ final class TranscribeCommandTests: XCTestCase {
         XCTAssertEqual(command.youtubeAudioQuality, .bestAvailable)
     }
 
+    func testParsesTranscriptFormatAndNoHistory() throws {
+        let command = try TranscribeCommand.parse([
+            "sample.wav",
+            "--format", "transcript",
+            "--no-history",
+        ])
+
+        XCTAssertEqual(command.format, .transcript)
+        XCTAssertTrue(command.noHistory)
+    }
+
+    func testNoHistoryRejectsRetainedDownloadedAudio() throws {
+        XCTAssertThrowsError(try TranscribeCommand.parse([
+            "sample.wav",
+            "--no-history",
+            "--downloaded-audio", "keep",
+        ])) { error in
+            XCTAssertTrue(String(describing: error).contains("--no-history cannot be combined"))
+        }
+    }
+
     func testParakeetRemainsDefaultEngine() throws {
         let command = try TranscribeCommand.parse(["sample.wav"])
         XCTAssertEqual(command.engine, .parakeet)
@@ -181,6 +202,28 @@ final class TranscribeCommandTests: XCTestCase {
             url.path,
             FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("sample.wav").path
         )
+    }
+
+    func testTranscriptOutputPrefersCleanTranscriptAndTrims() {
+        let transcription = Transcription(
+            fileName: "sample.wav",
+            rawTranscript: " raw text ",
+            cleanTranscript: " clean text ",
+            status: .completed
+        )
+
+        XCTAssertEqual(TranscribeCommand.transcriptOutput(for: transcription), "clean text")
+    }
+
+    func testTranscriptOutputFallsBackToRawTranscript() {
+        let transcription = Transcription(
+            fileName: "sample.wav",
+            rawTranscript: " raw text ",
+            cleanTranscript: "   ",
+            status: .completed
+        )
+
+        XCTAssertEqual(TranscribeCommand.transcriptOutput(for: transcription), "raw text")
     }
 
     func testJSONFormatEmitsFailureEnvelopeForMissingFile() async throws {

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
@@ -547,6 +547,14 @@ private final class RecoveryMockTranscriptionService: TranscriptionServiceProtoc
         fatalError("Not used")
     }
 
+    func transcribeTransient(
+        fileURL: URL,
+        source: TelemetryTranscriptionSource,
+        onProgress: (@Sendable (TranscriptionProgress) -> Void)?
+    ) async throws -> Transcription {
+        fatalError("Not used")
+    }
+
     func transcribeMeeting(
         recording: MeetingRecordingOutput,
         onProgress: (@Sendable (TranscriptionProgress) -> Void)?
@@ -583,6 +591,13 @@ private final class RecoveryMockTranscriptionService: TranscriptionServiceProtoc
     }
 
     func transcribeURL(
+        urlString: String,
+        onProgress: (@Sendable (TranscriptionProgress) -> Void)?
+    ) async throws -> Transcription {
+        fatalError("Not used")
+    }
+
+    func transcribeURLTransient(
         urlString: String,
         onProgress: (@Sendable (TranscriptionProgress) -> Void)?
     ) async throws -> Transcription {

--- a/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
@@ -215,6 +215,32 @@ final class TranscriptionServiceTests: XCTestCase {
         XCTAssertEqual(props["engine_variant"], SpeechEnginePreference.defaultWhisperModelVariant)
     }
 
+    func testTranscribeTransientFileDoesNotPersistCompletedRow() async throws {
+        await mockSTT.configure(result: STTResult(text: "private transcript"))
+
+        let result = try await service.transcribeTransient(fileURL: URL(fileURLWithPath: "/tmp/private.mp3"))
+
+        XCTAssertEqual(result.rawTranscript, "private transcript")
+        XCTAssertEqual(result.status, .completed)
+        XCTAssertNil(try transcriptionRepo.fetch(id: result.id))
+        XCTAssertTrue(try transcriptionRepo.fetchAll(limit: nil).isEmpty)
+    }
+
+    func testTranscribeTransientFileDoesNotPersistFailureRow() async throws {
+        await mockSTT.configure(error: STTError.transcriptionFailed("Model error"))
+
+        do {
+            _ = try await service.transcribeTransient(fileURL: URL(fileURLWithPath: "/tmp/private.mp3"))
+            XCTFail("Expected transient transcription to throw")
+        } catch let error as STTError {
+            guard case .transcriptionFailed = error else {
+                return XCTFail("Unexpected STT error: \(error)")
+            }
+        }
+
+        XCTAssertTrue(try transcriptionRepo.fetchAll(limit: nil).isEmpty)
+    }
+
     func testTranscribeFileDurationUsesMaximumWordEnd() async throws {
         await mockSTT.configure(result: STTResult(
             text: "out of order",
@@ -606,6 +632,35 @@ final class TranscriptionServiceTests: XCTestCase {
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: downloadedURL.path))
         XCTAssertNil(result.filePath)
+    }
+
+    func testTranscribeURLTransientDeletesDownloadedAudioAndDoesNotPersist() async throws {
+        let downloadedURL = try makeTempDownloadedAudio()
+        defer { try? FileManager.default.removeItem(at: downloadedURL) }
+
+        let downloader = MockYouTubeDownloader(result: YouTubeDownloader.DownloadResult(
+            audioFileURL: downloadedURL,
+            title: "Video",
+            durationSeconds: 120
+        ))
+
+        await mockSTT.configure(result: STTResult(text: "Downloaded transcript"))
+
+        let service = TranscriptionService(
+            audioProcessor: mockAudio,
+            sttTranscriber: mockSTT,
+            transcriptionRepo: transcriptionRepo,
+            shouldKeepDownloadedAudio: { true },
+            youtubeDownloader: downloader
+        )
+
+        let result = try await service.transcribeURLTransient(urlString: "https://youtu.be/dQw4w9WgXcQ")
+
+        XCTAssertEqual(result.rawTranscript, "Downloaded transcript")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: downloadedURL.path))
+        XCTAssertNil(result.filePath)
+        XCTAssertNil(try transcriptionRepo.fetch(id: result.id))
+        XCTAssertTrue(try transcriptionRepo.fetchAll(limit: nil).isEmpty)
     }
 
     func testTranscribeURLDeletesDownloadedAudioWhenPersistenceFails() async throws {

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -343,6 +343,14 @@ actor MockTranscriptionService: SpeechEngineOverrideTranscriptionService {
         )
     }
 
+    func transcribeTransient(
+        fileURL: URL,
+        source: TelemetryTranscriptionSource,
+        onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
+    ) async throws -> Transcription {
+        try await transcribe(fileURL: fileURL, source: source, onProgress: onProgress)
+    }
+
     func transcribeMeeting(
         recording: MeetingRecordingOutput,
         onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
@@ -415,6 +423,13 @@ actor MockTranscriptionService: SpeechEngineOverrideTranscriptionService {
             status: .completed,
             sourceURL: urlString
         )
+    }
+
+    func transcribeURLTransient(
+        urlString: String,
+        onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
+    ) async throws -> Transcription {
+        try await transcribeURL(urlString: urlString, onProgress: onProgress)
     }
 }
 

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -25,6 +25,7 @@ This script builds the latest debug binary, stops stale `/Applications`/`dist` a
 ```
 macparakeet-cli
 ├── transcribe <input> [options]         Transcribe a file or YouTube URL
+│   ├── --format text|transcript|json [--no-history]
 │   └── --engine app-default|parakeet|whisper [--language <code>]
 │       --speaker-detection app-default|on|off
 │       --youtube-audio-quality app-default|m4a|best-available
@@ -47,6 +48,8 @@ macparakeet-cli
 ├── health [--repair-models] [--repair-binaries] [--json]
 │                                         System health and model/helper status
 ├── models                               Speech model lifecycle
+│   ├── list [--json]                    List selectable speech models
+│   ├── select <model-id> [--json]       Set shared app/CLI speech default
 │   ├── status [--json]                  Show model status
 │   ├── download <model-id>              Download explicit model (Whisper)
 │   ├── warm-up [--attempts]             Warm up speech model
@@ -217,7 +220,35 @@ swift run macparakeet-cli transcribe "<FILE>"
 
 # JSON output (full Transcription object)
 swift run macparakeet-cli transcribe "<FILE>" --format json
+
+# Transcript-only stdout for pipes
+swift run macparakeet-cli transcribe "<FILE>" --format transcript
+
+# Transient transcription: no completed row in Library/history
+swift run macparakeet-cli transcribe "<FILE_OR_YOUTUBE_URL>" --format transcript --no-history
 ```
+
+`--format transcript` prints only `cleanTranscript` when present, otherwise
+`rawTranscript`. Status and progress messages stay on stderr, so stdout can be
+piped directly into `pbcopy`, `grep`, `tee`, or a local LLM command.
+
+`--no-history` uses the same transcription pipeline without retaining a completed
+history row. For YouTube inputs, downloaded audio is temporary regardless of
+the shared audio-retention default.
+
+## Model Selection
+
+```bash
+swift run macparakeet-cli models list
+swift run macparakeet-cli models list --json
+swift run macparakeet-cli models select parakeet
+swift run macparakeet-cli models select whisper-large-v3-v20240930-turbo-632MB
+```
+
+`models list` reports the selectable speech engines MacParakeet exposes today:
+Parakeet and the configured WhisperKit variant. `models select` writes the same
+shared default used by the GUI and `transcribe --engine app-default`; Whisper
+selection requires the local Whisper model to be downloaded first.
 
 ## Retained Entitlements Parity
 

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -124,6 +124,17 @@ the latest managed helper binary.
 macparakeet-cli transcribe /path/to/audio.mp3 --format json
 ```
 
+For shell pipelines where stdout should contain only transcript text:
+
+```bash
+macparakeet-cli transcribe /path/to/audio.mp3 --format transcript
+macparakeet-cli transcribe /path/to/audio.mp3 --format transcript --no-history | pbcopy
+```
+
+`--no-history` avoids retaining the completed transcription in the shared
+MacParakeet history. For YouTube inputs, downloaded audio is temporary when
+`--no-history` is set.
+
 Parakeet is the default engine for compatibility with existing scripts. Use
 Whisper per invocation for Korean or other non-Parakeet languages:
 
@@ -131,6 +142,14 @@ Whisper requires a local model download before first use:
 
 ```bash
 macparakeet-cli models download whisper-large-v3-v20240930-turbo-632MB
+```
+
+Agents can inspect and switch the shared default speech model:
+
+```bash
+macparakeet-cli models list --json
+macparakeet-cli models select parakeet --json
+macparakeet-cli models select whisper-large-v3-v20240930-turbo-632MB --json
 ```
 
 ```bash
@@ -315,7 +334,10 @@ user wants YouTube transcription, run
 
 ```bash
 macparakeet-cli transcribe "<path-or-youtube-url>" --format json
+macparakeet-cli transcribe "<path-or-youtube-url>" --format transcript --no-history
 macparakeet-cli models download whisper-large-v3-v20240930-turbo-632MB
+macparakeet-cli models list --json
+macparakeet-cli models select parakeet --json
 macparakeet-cli transcribe "<path-or-youtube-url>" --engine whisper --language ko --format json
 macparakeet-cli transcribe "<path-or-youtube-url>" \
   --engine app-default \


### PR DESCRIPTION
## Summary

- Add transcript-only transcription output for shell and agent pipelines.
- Add `--no-history` for one-off transcriptions that do not save completed history rows and keep YouTube audio temporary.
- Add `models list` and `models select` aliases over the shared app/CLI speech default.
- Update README, CLI docs, integration notes, changelog, and focused tests.

## Validation

- `swift test`
- `swift run macparakeet-cli transcribe --help`
- `swift run macparakeet-cli models list --json`