### PR TITLE
[codex] Run auto prompts for short transcripts

### DIFF
--- a/Sources/MacParakeetViewModels/PromptResultsViewModel.swift
+++ b/Sources/MacParakeetViewModels/PromptResultsViewModel.swift
@@ -50,7 +50,6 @@ public final class PromptResultsViewModel {
         }
     }
 
-    private static let autoGenerationTranscriptLengthThreshold = 500
     /// Soft cap on user notes for prompt-assembly only — full notes remain on
     /// the Transcription row. ~11k tokens at typical English word→token ratio,
     /// leaving headroom for transcript + system prompt + response (ADR-020 §3).
@@ -314,7 +313,7 @@ public final class PromptResultsViewModel {
 
     @discardableResult
     public func autoGeneratePromptResults(transcript: String, transcriptionId: UUID) -> [UUID] {
-        guard transcript.count > Self.autoGenerationTranscriptLengthThreshold else { return [] }
+        guard transcript.contains(where: { !$0.isWhitespace }) else { return [] }
 
         let autoPrompts: [Prompt]
         do {

--- a/Tests/MacParakeetTests/ViewModels/PromptResultsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/PromptResultsViewModelTests.swift
@@ -192,7 +192,7 @@ final class PromptResultsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.promptResults.map(\.content), ["Older"])
     }
 
-    func testAutoGeneratePromptResultsSkipsShortTranscript() {
+    func testAutoGeneratePromptResultsRunsForShortNonEmptyTranscript() {
         viewModel.configure(
             llmService: llm,
             promptRepo: promptRepo,
@@ -200,12 +200,31 @@ final class PromptResultsViewModelTests: XCTestCase {
         )
 
         let queuedIDs = viewModel.autoGeneratePromptResults(
-            transcript: "too short",
+            transcript: "brief but important",
             transcriptionId: UUID()
         )
 
-        XCTAssertTrue(queuedIDs.isEmpty)
-        XCTAssertTrue(viewModel.pendingGenerations.isEmpty)
+        XCTAssertFalse(queuedIDs.isEmpty)
+        XCTAssertEqual(viewModel.pendingGenerations.map(\.id), queuedIDs)
+        XCTAssertEqual(viewModel.pendingGenerations.first?.transcript, "brief but important")
+    }
+
+    func testAutoGeneratePromptResultsSkipsEmptyAndWhitespaceOnlyTranscript() {
+        viewModel.configure(
+            llmService: llm,
+            promptRepo: promptRepo,
+            promptResultRepo: promptResultRepo
+        )
+
+        for transcript in ["", "   \n\t  "] {
+            let queuedIDs = viewModel.autoGeneratePromptResults(
+                transcript: transcript,
+                transcriptionId: UUID()
+            )
+
+            XCTAssertTrue(queuedIDs.isEmpty)
+            XCTAssertTrue(viewModel.pendingGenerations.isEmpty)
+        }
     }
 
     func testLoadPromptResultsClearsPendingGenerationsWhenSwitchingTranscriptions() {

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -1669,11 +1669,11 @@ final class TranscriptionViewModelTests: XCTestCase {
                        "Retranscribe must not invoke the LLM service via auto-run")
     }
 
-    func testFreshTranscribeStillFiresAutoRunPrompts() async throws {
-        let longTranscript = String(repeating: "Long transcript ", count: 50)
+    func testFreshTranscribeStillFiresAutoRunPromptsForShortTranscript() async throws {
+        let shortTranscript = "brief but important"
         let result = Transcription(
             fileName: "audio.mp3",
-            rawTranscript: longTranscript,
+            rawTranscript: shortTranscript,
             status: .completed
         )
         await mockService.configure(result: result)

--- a/spec/12-processing-layer.md
+++ b/spec/12-processing-layer.md
@@ -190,7 +190,7 @@ You are a helpful assistant that processes transcripts. Follow the user's instru
 
 Prompt cards may be marked `isAutoRun = true` in the prompt library.
 
-- When a new transcription finishes and `llmAvailable && transcript.count > 500`, the app auto-generates summaries for every prompt card with `isAutoRun = true`.
+- When a new transcription finishes and `llmAvailable && transcript` is not empty/whitespace-only, the app auto-generates summaries for every prompt card with `isAutoRun = true`.
 - Multiple auto-run prompt cards are allowed.
 - Zero auto-run prompt cards is a valid configuration. In that state, transcription and chat still work, and users generate prompt tabs manually from the summary UI.
 - Auto-run prompt cards are forced visible while auto-run is enabled.


### PR DESCRIPTION
## Summary
- Remove the hard 500-character threshold from prompt auto-run generation.
- Keep the useful safety guard for empty/whitespace-only transcripts without allocating a trimmed copy of large transcripts.
- Update ViewModel tests and processing-layer docs so short non-empty transcripts are expected to auto-run.

## Findings and Reasoning
The demo case that looked like a broken auto-run pipeline was a short transcript, not a failed prompt queue. The old guard silently returned before loading auto-run prompt cards whenever `transcript.count <= 500`.

That behavior is too surprising for meeting recording. A short meeting, a quick follow-up, or an abrupt note can still be the exact transcript where auto-generated action items are most useful. The token/cost impact is also bounded by the transcript size; the old threshold avoided very little cost while making the feature appear unreliable.

The new rule is simpler: if LLM is available and the transcript has any non-whitespace content, auto-run prompts are eligible. Empty and whitespace-only transcripts still skip because they have no useful content to summarize. Per review feedback, the implementation checks `transcript.contains(where: { !$0.isWhitespace })` directly instead of trimming into a new string.

## Validation
- `swift test --filter 'PromptResultsViewModelTests|TranscriptionViewModelTests/testFreshTranscribeStillFiresAutoRunPromptsForShortTranscript|TranscriptionViewModelTests/testRetranscribeDoesNotFireAutoRunPrompts'` (21 tests, 0 failures)
- `swift test` (2,689 tests, 10 skipped, 0 failures)
- `git diff --check -- Sources/MacParakeetViewModels/PromptResultsViewModel.swift Tests/MacParakeetTests/ViewModels/PromptResultsViewModelTests.swift Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift spec/12-processing-layer.md`