### PR TITLE
Polish Transform history

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -104,6 +104,7 @@ final class AppEnvironmentConfigurer {
             permissionService: env.permissionService,
             dictationRepo: env.dictationRepo,
             transcriptionRepo: env.transcriptionRepo,
+            transformHistoryRepo: env.transformHistoryRepo,
             entitlementsService: env.entitlementsService,
             launchAtLoginService: env.launchAtLoginService,
             checkoutURL: env.checkoutURL,
@@ -141,6 +142,11 @@ final class AppEnvironmentConfigurer {
 
         settingsViewModel.onDictationStateChanged = { [weak self] in
             self?.historyViewModel.loadDictations()
+        }
+        settingsViewModel.onTransformHistoryChanged = { [weak self] in
+            Task {
+                await self?.transformsViewModel.loadHistory()
+            }
         }
 
         llmSettingsViewModel.onConfigurationChanged = { [weak self] in

--- a/Sources/MacParakeet/Views/Components/TransformSigilView.swift
+++ b/Sources/MacParakeet/Views/Components/TransformSigilView.swift
@@ -1,0 +1,192 @@
+import SwiftUI
+
+/// A deterministic before/after glyph for a saved Transform run.
+///
+/// Dictation rows use `SonicMandalaView` as a voice fingerprint. Transform
+/// rows need a sibling visual, not the same metaphor: the faint stroke comes
+/// from the selected input text, and the stronger stroke comes from the
+/// rewritten result. The same saved run always produces the same sigil.
+struct TransformSigilView: View {
+    let data: TransformSigilData
+    var size: CGFloat = 32
+
+    var body: some View {
+        Canvas { context, canvasSize in
+            let center = CGPoint(x: canvasSize.width / 2, y: canvasSize.height / 2)
+            let maxRadius = min(canvasSize.width, canvasSize.height) / 2 - 2
+
+            guard data.inputPoints.count >= 4, data.outputPoints.count >= 4 else { return }
+
+            let inputPath = buildSmoothPath(
+                points: data.inputPoints,
+                center: center,
+                maxRadius: maxRadius * 0.88,
+                phase: -.pi / 2
+            )
+            let outputPath = buildSmoothPath(
+                points: data.outputPoints,
+                center: center,
+                maxRadius: maxRadius,
+                phase: -.pi / 2 + .pi / 24
+            )
+
+            context.stroke(
+                inputPath,
+                with: .color(DesignSystem.Colors.accent.opacity(0.18)),
+                lineWidth: size > 48 ? 1.2 : 0.8
+            )
+            context.stroke(
+                outputPath,
+                with: .color(DesignSystem.Colors.accent.opacity(0.45)),
+                lineWidth: size > 48 ? 1.6 : 1.1
+            )
+
+            let dotSize: CGFloat = size > 48 ? 4 : 2.4
+            let dotRect = CGRect(
+                x: center.x - dotSize / 2,
+                y: center.y - dotSize / 2,
+                width: dotSize,
+                height: dotSize
+            )
+            context.fill(
+                Path(ellipseIn: dotRect),
+                with: .color(DesignSystem.Colors.accent.opacity(0.32))
+            )
+        }
+        .frame(width: size, height: size)
+        .accessibilityLabel("Transform before and after pattern")
+    }
+
+    private func buildSmoothPath(
+        points: [CGFloat],
+        center: CGPoint,
+        maxRadius: CGFloat,
+        phase: CGFloat
+    ) -> Path {
+        let count = points.count
+        let minRadius = maxRadius * 0.34
+        let radiusRange = maxRadius - minRadius
+
+        var cartesian: [CGPoint] = []
+        cartesian.reserveCapacity(count)
+
+        for index in 0..<count {
+            let angle = (CGFloat(index) / CGFloat(count)) * 2 * .pi + phase
+            let radius = minRadius + points[index] * radiusRange
+            cartesian.append(
+                CGPoint(
+                    x: center.x + cos(angle) * radius,
+                    y: center.y + sin(angle) * radius
+                )
+            )
+        }
+
+        var path = Path()
+        path.move(
+            to: catmullRomPoint(
+                p0: cartesian[(count - 1) % count],
+                p1: cartesian[0],
+                p2: cartesian[1],
+                p3: cartesian[2],
+                t: 0
+            )
+        )
+
+        for index in 0..<count {
+            let p0 = cartesian[(index - 1 + count) % count]
+            let p1 = cartesian[index]
+            let p2 = cartesian[(index + 1) % count]
+            let p3 = cartesian[(index + 2) % count]
+
+            for step in 1...6 {
+                let t = CGFloat(step) / 6
+                path.addLine(to: catmullRomPoint(p0: p0, p1: p1, p2: p2, p3: p3, t: t))
+            }
+        }
+
+        path.closeSubpath()
+        return path
+    }
+
+    private func catmullRomPoint(p0: CGPoint, p1: CGPoint, p2: CGPoint, p3: CGPoint, t: CGFloat) -> CGPoint {
+        let t2 = t * t
+        let t3 = t2 * t
+
+        let x = 0.5 * (
+            (2 * p1.x)
+                + (-p0.x + p2.x) * t
+                + (2 * p0.x - 5 * p1.x + 4 * p2.x - p3.x) * t2
+                + (-p0.x + 3 * p1.x - 3 * p2.x + p3.x) * t3
+        )
+        let y = 0.5 * (
+            (2 * p1.y)
+                + (-p0.y + p2.y) * t
+                + (2 * p0.y - 5 * p1.y + 4 * p2.y - p3.y) * t2
+                + (-p0.y + 3 * p1.y - 3 * p2.y + p3.y) * t3
+        )
+
+        return CGPoint(x: x, y: y)
+    }
+}
+
+struct TransformSigilData: Equatable {
+    let inputPoints: [CGFloat]
+    let outputPoints: [CGFloat]
+
+    static func from(inputText: String, outputText: String, transformName: String) -> TransformSigilData {
+        TransformSigilData(
+            inputPoints: radialPoints(
+                from: inputText,
+                fallback: transformName,
+                salt: 0x8f7c_3a29_41d5_b6e3,
+                mirrorStrength: 0.48
+            ),
+            outputPoints: radialPoints(
+                from: outputText,
+                fallback: "\(transformName)\n\(inputText)",
+                salt: 0xc2b2_ae35_87f6_4d1b,
+                mirrorStrength: 0.68
+            )
+        )
+    }
+
+    private static func radialPoints(
+        from text: String,
+        fallback: String,
+        salt: UInt64,
+        mirrorStrength: CGFloat
+    ) -> [CGFloat] {
+        let source = text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? fallback : text
+        let bytes = Array(source.utf8)
+        let sampleCount = 24
+        var seed = stableSeed(source, salt: salt)
+        var points: [CGFloat] = []
+        points.reserveCapacity(sampleCount)
+
+        for index in 0..<sampleCount {
+            let byte = bytes.isEmpty ? UInt8((index * 37) & 0xff) : bytes[index % bytes.count]
+            seed = seed &* 6364136223846793005 &+ UInt64(byte) &+ UInt64(index * 1447)
+            let random = CGFloat((seed >> 33) & 0xffff) / CGFloat(0xffff)
+            let harmonic = CGFloat(
+                0.5 + 0.5 * sin((Double(index) / Double(sampleCount)) * 2 * .pi * 3 + Double(seed & 0xff) / 255)
+            )
+            points.append(0.18 + random * 0.64 + harmonic * 0.18)
+        }
+
+        for index in 0..<(sampleCount / 2) {
+            let mirrorIndex = sampleCount - 1 - index
+            points[mirrorIndex] = points[index] * mirrorStrength + points[mirrorIndex] * (1 - mirrorStrength)
+        }
+
+        return points
+    }
+
+    private static func stableSeed(_ text: String, salt: UInt64) -> UInt64 {
+        var hash = 1469598103934665603 ^ salt
+        for byte in text.utf8 {
+            hash ^= UInt64(byte)
+            hash = hash &* 1099511628211
+        }
+        return hash
+    }
+}

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -1394,6 +1394,21 @@ struct SettingsView: View {
                     Divider()
 
                     resetActionRow(
+                        title: "Transform history",
+                        detail: "Saved Transform runs only. Transform definitions and shortcuts stay.",
+                        action: ResetDestructiveAction(
+                            buttonTitle: "Clear…",
+                            accessibilityLabel: "Clear Transform history",
+                            confirmationTitle: "Clear Transform History?",
+                            confirmationMessage: "This will delete all saved Transform runs. Transform definitions and shortcuts are not affected. This cannot be undone.",
+                            confirmButtonLabel: "Clear History",
+                            perform: viewModel.clearTransformHistory
+                        )
+                    )
+
+                    Divider()
+
+                    resetActionRow(
                         title: "Downloaded YouTube audio",
                         detail: "Saved audio files only. Transcriptions stay; audio detaches.",
                         action: ResetDestructiveAction(

--- a/Sources/MacParakeet/Views/Transforms/TransformsView.swift
+++ b/Sources/MacParakeet/Views/Transforms/TransformsView.swift
@@ -346,7 +346,7 @@ struct TransformsView: View {
                     }
                 }
 
-                if viewModel.totalHistoryCount > viewModel.history.count {
+                if !isHistoryFiltering && viewModel.totalHistoryCount > viewModel.history.count {
                     Text("Showing the most recent \(viewModel.history.count) of \(viewModel.totalHistoryCount) saved runs.")
                         .font(DesignSystem.Typography.caption)
                         .foregroundStyle(DesignSystem.Colors.textTertiary)
@@ -769,9 +769,7 @@ private extension TransformHistoryEntry {
             sourceAppDisplayName,
             sourceAppBundleID ?? "",
             inputText,
-            outputText,
-            capturePath,
-            replacementPath
+            outputText
         ].joined(separator: "\n")
 
         return terms.allSatisfy { searchableText.localizedCaseInsensitiveContains($0) }

--- a/Sources/MacParakeet/Views/Transforms/TransformsView.swift
+++ b/Sources/MacParakeet/Views/Transforms/TransformsView.swift
@@ -21,6 +21,22 @@ struct TransformsView: View {
     let onCreate: () -> Void
     let onBindingsChanged: () -> Void
 
+    @State private var historySearchText = ""
+    @State private var expandedHistoryEntryIDs: Set<UUID> = []
+
+    private var historySearchQuery: String {
+        historySearchText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var isHistoryFiltering: Bool {
+        !historySearchQuery.isEmpty
+    }
+
+    private var filteredHistory: [TransformHistoryEntry] {
+        guard isHistoryFiltering else { return viewModel.history }
+        return viewModel.history.filter { $0.matchesSearch(historySearchQuery) }
+    }
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: DesignSystem.Spacing.xl) {
@@ -268,6 +284,8 @@ struct TransformsView: View {
 
     @ViewBuilder
     private var historySection: some View {
+        let visibleHistory = filteredHistory
+
         VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
             HStack(alignment: .firstTextBaseline) {
                 Text("History")
@@ -293,6 +311,10 @@ struct TransformsView: View {
                 }
             }
 
+            if !viewModel.history.isEmpty {
+                TransformHistorySearchField(text: $historySearchText)
+            }
+
             if let historyError = viewModel.historyErrorMessage {
                 HStack(spacing: DesignSystem.Spacing.sm) {
                     Image(systemName: "exclamationmark.triangle.fill")
@@ -310,20 +332,46 @@ struct TransformsView: View {
 
             if viewModel.history.isEmpty {
                 TransformHistoryEmptyState()
+            } else if visibleHistory.isEmpty {
+                TransformHistoryNoResultsState(query: historySearchQuery) {
+                    historySearchText = ""
+                }
             } else {
                 LazyVStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
-                    ForEach(viewModel.history) { entry in
+                    ForEach(visibleHistory) { entry in
                         TransformHistoryRow(
                             entry: entry,
-                            isCopied: viewModel.copiedHistoryEntryID == entry.id,
-                            onCopy: {
+                            copiedTarget: viewModel.copiedHistoryEntryID == entry.id ? viewModel.copiedHistoryTarget : nil,
+                            isExpanded: expandedHistoryEntryIDs.contains(entry.id),
+                            onToggleExpanded: {
+                                withAnimation(DesignSystem.Animation.contentSwap) {
+                                    if expandedHistoryEntryIDs.contains(entry.id) {
+                                        expandedHistoryEntryIDs.remove(entry.id)
+                                    } else {
+                                        expandedHistoryEntryIDs.insert(entry.id)
+                                    }
+                                }
+                            },
+                            onCopyOutput: {
                                 Task {
                                     await viewModel.copyOutputToClipboard(entry)
+                                }
+                            },
+                            onCopyInput: {
+                                Task {
+                                    await viewModel.copyInputToClipboard(entry)
                                 }
                             },
                             onDelete: { viewModel.pendingDeleteHistoryEntry = entry }
                         )
                     }
+                }
+
+                if viewModel.totalHistoryCount > viewModel.history.count {
+                    Text("Showing the most recent \(viewModel.history.count) of \(viewModel.totalHistoryCount) saved runs.")
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(DesignSystem.Colors.textTertiary)
+                        .padding(.top, DesignSystem.Spacing.xs)
                 }
             }
         }
@@ -362,92 +410,98 @@ private struct TransformHistoryEmptyState: View {
     }
 }
 
+private struct TransformHistoryNoResultsState: View {
+    let query: String
+    let onClear: () -> Void
+
+    var body: some View {
+        HStack(spacing: DesignSystem.Spacing.md) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(DesignSystem.Colors.textTertiary)
+                .frame(width: 34, height: 34)
+                .background(Circle().fill(DesignSystem.Colors.surfaceElevated))
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text("No history matches \"\(query)\"")
+                    .font(DesignSystem.Typography.body.weight(.semibold))
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+                Text("Search checks Transform names, source apps, original text, and transformed text.")
+                    .font(DesignSystem.Typography.bodySmall)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+            }
+
+            Spacer(minLength: DesignSystem.Spacing.md)
+
+            Button("Clear Search", action: onClear)
+                .parakeetAction(.subtle)
+                .controlSize(.small)
+        }
+        .padding(DesignSystem.Spacing.lg)
+        .background(DesignSystem.Colors.cardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius))
+        .overlay {
+            RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
+                .stroke(DesignSystem.Colors.border.opacity(0.6), lineWidth: 0.5)
+        }
+    }
+}
+
+private struct TransformHistorySearchField: View {
+    @Binding var text: String
+
+    var body: some View {
+        HStack(spacing: DesignSystem.Spacing.sm) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(DesignSystem.Colors.textTertiary)
+
+            TextField("Search Transform history", text: $text)
+                .textFieldStyle(.plain)
+                .font(DesignSystem.Typography.bodySmall)
+                .foregroundStyle(DesignSystem.Colors.textPrimary)
+
+            if !text.isEmpty {
+                Button {
+                    text = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 12, weight: .semibold))
+                }
+                .parakeetAction(.subtle)
+                .help("Clear search")
+                .accessibilityLabel("Clear history search")
+            }
+        }
+        .padding(.horizontal, DesignSystem.Spacing.md)
+        .padding(.vertical, DesignSystem.Spacing.sm)
+        .background(DesignSystem.Colors.surfaceElevated.opacity(0.65))
+        .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius))
+        .overlay {
+            RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
+                .stroke(DesignSystem.Colors.border.opacity(0.55), lineWidth: 0.5)
+        }
+    }
+}
+
 private struct TransformHistoryRow: View {
     private static let todayTimeFormat = Date.FormatStyle(date: .omitted, time: .shortened)
     private static let dateTimeFormat = Date.FormatStyle(date: .numeric, time: .shortened)
 
     let entry: TransformHistoryEntry
-    let isCopied: Bool
-    let onCopy: () -> Void
+    let copiedTarget: TransformHistoryCopyTarget?
+    let isExpanded: Bool
+    let onToggleExpanded: () -> Void
+    let onCopyOutput: () -> Void
+    let onCopyInput: () -> Void
     let onDelete: () -> Void
 
     @State private var isHovered = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
-            HStack(alignment: .center, spacing: DesignSystem.Spacing.sm) {
-                Image(systemName: "wand.and.stars")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(DesignSystem.Colors.accent)
-                    .frame(width: 26, height: 26)
-                    .background(Circle().fill(DesignSystem.Colors.accentLight))
-
-                Text(entry.transformName)
-                    .font(DesignSystem.Typography.caption.weight(.semibold))
-                    .foregroundStyle(DesignSystem.Colors.textPrimary)
-
-                Text("·")
-                    .font(DesignSystem.Typography.caption)
-                    .foregroundStyle(DesignSystem.Colors.textTertiary)
-
-                Text(entry.sourceAppDisplayName)
-                    .font(DesignSystem.Typography.caption)
-                    .foregroundStyle(DesignSystem.Colors.textSecondary)
-                    .lineLimit(1)
-
-                Text("·")
-                    .font(DesignSystem.Typography.caption)
-                    .foregroundStyle(DesignSystem.Colors.textTertiary)
-
-                Text(formatTime(entry.createdAt))
-                    .font(DesignSystem.Typography.timestamp)
-                    .foregroundStyle(DesignSystem.Colors.textSecondary)
-
-                Spacer(minLength: DesignSystem.Spacing.sm)
-
-                if isCopied {
-                    Text("Copied")
-                        .font(DesignSystem.Typography.micro)
-                        .foregroundStyle(DesignSystem.Colors.successGreen)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 3)
-                        .background(Capsule().fill(DesignSystem.Colors.successGreen.opacity(0.12)))
-                        .transition(.opacity.combined(with: .scale(scale: 0.96)))
-                }
-
-                TransformHistoryIconButton(
-                    systemImage: isCopied ? "checkmark" : "doc.on.clipboard",
-                    color: isCopied ? DesignSystem.Colors.successGreen : DesignSystem.Colors.textSecondary,
-                    help: "Copy transformed text",
-                    action: onCopy
-                )
-                TransformHistoryIconButton(
-                    systemImage: "trash",
-                    color: DesignSystem.Colors.textSecondary,
-                    help: "Delete history item",
-                    action: onDelete
-                )
-            }
-
-            VStack(alignment: .leading, spacing: 6) {
-                Text(entry.outputText)
-                    .font(DesignSystem.Typography.body)
-                    .foregroundStyle(DesignSystem.Colors.textPrimary)
-                    .lineLimit(3)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                Text(entry.inputText)
-                    .font(DesignSystem.Typography.bodySmall)
-                    .foregroundStyle(DesignSystem.Colors.textSecondary)
-                    .lineLimit(2)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.leading, DesignSystem.Spacing.md)
-                    .overlay(alignment: .leading) {
-                        Rectangle()
-                            .fill(DesignSystem.Colors.border)
-                            .frame(width: 2)
-                    }
-            }
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+            headerRow
+            content
         }
         .padding(DesignSystem.Spacing.md)
         .background(
@@ -464,11 +518,243 @@ private struct TransformHistoryRow: View {
                 isHovered = hovering
             }
         }
-        .animation(DesignSystem.Animation.hoverTransition, value: isCopied)
+        .contextMenu {
+            Button("Copy Result", action: onCopyOutput)
+            Button("Copy Original", action: onCopyInput)
+            Button(isExpanded ? "Hide Details" : "Show Details", action: onToggleExpanded)
+        }
+        .animation(DesignSystem.Animation.hoverTransition, value: copiedTarget)
+        .animation(DesignSystem.Animation.contentSwap, value: isExpanded)
+    }
+
+    private var headerRow: some View {
+        HStack(alignment: .center, spacing: DesignSystem.Spacing.sm) {
+            Image(systemName: "wand.and.stars")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(DesignSystem.Colors.accent)
+                .frame(width: 26, height: 26)
+                .background(Circle().fill(DesignSystem.Colors.accentLight))
+
+            Text(entry.transformName)
+                .font(DesignSystem.Typography.caption.weight(.semibold))
+                .foregroundStyle(DesignSystem.Colors.textPrimary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .layoutPriority(1)
+
+            Text("·")
+                .font(DesignSystem.Typography.caption)
+                .foregroundStyle(DesignSystem.Colors.textTertiary)
+
+            Text(entry.sourceAppDisplayName)
+                .font(DesignSystem.Typography.caption)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+
+            Text("·")
+                .font(DesignSystem.Typography.caption)
+                .foregroundStyle(DesignSystem.Colors.textTertiary)
+
+            Text(formatTime(entry.createdAt))
+                .font(DesignSystem.Typography.timestamp)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+                .lineLimit(1)
+
+            Spacer(minLength: DesignSystem.Spacing.sm)
+
+            if let copiedTarget {
+                Text(copiedTarget.statusLabel)
+                    .font(DesignSystem.Typography.micro)
+                    .foregroundStyle(DesignSystem.Colors.successGreen)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 3)
+                    .background(Capsule().fill(DesignSystem.Colors.successGreen.opacity(0.12)))
+                    .transition(.opacity.combined(with: .scale(scale: 0.96)))
+            }
+
+            TransformHistoryTextButton(
+                title: copiedTarget == .output ? "Copied" : "Copy result",
+                systemImage: copiedTarget == .output ? "checkmark" : "doc.on.doc",
+                color: copiedTarget == .output ? DesignSystem.Colors.successGreen : DesignSystem.Colors.textSecondary,
+                help: "Copy transformed result",
+                action: onCopyOutput
+            )
+
+            TransformHistoryIconButton(
+                systemImage: isExpanded ? "chevron.up" : "chevron.down",
+                color: DesignSystem.Colors.textSecondary,
+                help: isExpanded ? "Hide details" : "Show details",
+                action: onToggleExpanded
+            )
+
+            TransformHistoryIconButton(
+                systemImage: "trash",
+                color: DesignSystem.Colors.textSecondary,
+                help: "Delete history item",
+                action: onDelete
+            )
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
+                if isExpanded {
+                    TransformHistorySectionLabel("Transformed")
+                }
+
+                Text(entry.outputText)
+                    .font(DesignSystem.Typography.body)
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+                    .lineLimit(isExpanded ? nil : 3)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            if isExpanded {
+                Divider()
+                    .overlay(DesignSystem.Colors.border.opacity(0.5))
+                    .padding(.vertical, DesignSystem.Spacing.xs)
+
+                VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
+                    HStack(alignment: .center, spacing: DesignSystem.Spacing.sm) {
+                        TransformHistorySectionLabel("Original")
+
+                        Spacer(minLength: DesignSystem.Spacing.sm)
+
+                        TransformHistoryInlineCopyButton(
+                            title: copiedTarget == .input ? "Copied" : "Copy original",
+                            systemImage: copiedTarget == .input ? "checkmark" : "doc.text",
+                            color: copiedTarget == .input ? DesignSystem.Colors.successGreen : DesignSystem.Colors.textSecondary,
+                            help: "Copy original text",
+                            action: onCopyInput
+                        )
+                    }
+
+                    originalText(lineLimit: nil)
+                }
+
+                TransformHistoryMetaStrip(
+                    llmDuration: formatMilliseconds(entry.llmElapsedMs),
+                    totalDuration: formatMilliseconds(entry.totalElapsedMs)
+                )
+                .padding(.top, DesignSystem.Spacing.xs)
+            } else {
+                originalText(lineLimit: 2)
+            }
+        }
+    }
+
+    private func originalText(lineLimit: Int?) -> some View {
+        Text(entry.inputText)
+            .font(DesignSystem.Typography.bodySmall)
+            .foregroundStyle(DesignSystem.Colors.textSecondary)
+            .lineLimit(lineLimit)
+            .textSelection(.enabled)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.leading, DesignSystem.Spacing.md)
+            .overlay(alignment: .leading) {
+                Rectangle()
+                    .fill(DesignSystem.Colors.border)
+                    .frame(width: 2)
+            }
     }
 
     private func formatTime(_ date: Date) -> String {
         date.formatted(Calendar.current.isDateInToday(date) ? Self.todayTimeFormat : Self.dateTimeFormat)
+    }
+
+    private func formatMilliseconds(_ value: Int) -> String {
+        guard value >= 1_000 else { return "\(value)ms" }
+        return String(format: "%.1fs", Double(value) / 1_000)
+    }
+
+}
+
+private struct TransformHistorySectionLabel: View {
+    let title: String
+
+    init(_ title: String) {
+        self.title = title
+    }
+
+    var body: some View {
+        Text(title.uppercased())
+            .font(DesignSystem.Typography.micro)
+            .foregroundStyle(DesignSystem.Colors.textTertiary)
+    }
+}
+
+private struct TransformHistoryMetaStrip: View {
+    let llmDuration: String
+    let totalDuration: String
+
+    var body: some View {
+        HStack(spacing: DesignSystem.Spacing.xs) {
+            TransformHistoryMetaChip(systemImage: "sparkles", text: "LLM \(llmDuration)")
+            TransformHistoryMetaChip(systemImage: "timer", text: "Total \(totalDuration)")
+        }
+    }
+}
+
+private struct TransformHistoryMetaChip: View {
+    let systemImage: String
+    let text: String
+
+    var body: some View {
+        Label(text, systemImage: systemImage)
+            .font(DesignSystem.Typography.micro)
+            .foregroundStyle(DesignSystem.Colors.textSecondary)
+            .lineLimit(1)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 4)
+            .background(Capsule().fill(DesignSystem.Colors.surfaceElevated.opacity(0.72)))
+            .overlay {
+                Capsule()
+                    .stroke(DesignSystem.Colors.border.opacity(0.55), lineWidth: 0.5)
+            }
+    }
+}
+
+private struct TransformHistoryTextButton: View {
+    let title: String
+    let systemImage: String
+    let color: Color
+    let help: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Label(title, systemImage: systemImage)
+                .font(DesignSystem.Typography.caption.weight(.medium))
+        }
+        .parakeetAction(.secondary)
+        .controlSize(.small)
+        .foregroundStyle(color)
+        .help(help)
+        .accessibilityLabel(help)
+    }
+}
+
+private struct TransformHistoryInlineCopyButton: View {
+    let title: String
+    let systemImage: String
+    let color: Color
+    let help: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Label(title, systemImage: systemImage)
+                .font(DesignSystem.Typography.micro.weight(.medium))
+        }
+        .parakeetAction(.subtle)
+        .controlSize(.small)
+        .foregroundStyle(color)
+        .help(help)
+        .accessibilityLabel(help)
     }
 }
 
@@ -495,6 +781,28 @@ private struct TransformHistoryIconButton: View {
         .foregroundStyle(isHovered ? DesignSystem.Colors.textPrimary : color)
         .help(help)
         .onHover { isHovered = $0 }
+    }
+}
+
+private extension TransformHistoryEntry {
+    func matchesSearch(_ query: String) -> Bool {
+        let terms = query
+            .split(whereSeparator: { $0.isWhitespace })
+            .map(String.init)
+
+        guard !terms.isEmpty else { return true }
+
+        let searchableText = [
+            transformName,
+            sourceAppDisplayName,
+            sourceAppBundleID ?? "",
+            inputText,
+            outputText,
+            capturePath,
+            replacementPath
+        ].joined(separator: "\n")
+
+        return terms.allSatisfy { searchableText.localizedCaseInsensitiveContains($0) }
     }
 }
 

--- a/Sources/MacParakeet/Views/Transforms/TransformsView.swift
+++ b/Sources/MacParakeet/Views/Transforms/TransformsView.swift
@@ -116,18 +116,6 @@ struct TransformsView: View {
         } message: { entry in
             Text("The saved “\(entry.transformName)” input and output will be removed from local history.")
         }
-        .alert("Clear Transform history?", isPresented: $viewModel.isConfirmingClearHistory) {
-            Button("Clear History", role: .destructive) {
-                Task {
-                    await viewModel.clearHistory()
-                }
-            }
-            Button("Cancel", role: .cancel) {
-                viewModel.isConfirmingClearHistory = false
-            }
-        } message: {
-            Text("All saved Transform runs will be removed from local history.")
-        }
     }
 
     // MARK: - Sections
@@ -300,15 +288,6 @@ struct TransformsView: View {
                         .background(Capsule().fill(DesignSystem.Colors.surfaceElevated))
                 }
                 Spacer()
-                if !viewModel.history.isEmpty {
-                    Button(role: .destructive) {
-                        viewModel.isConfirmingClearHistory = true
-                    } label: {
-                        Label("Clear", systemImage: "trash")
-                    }
-                    .parakeetAction(.subtle)
-                    .controlSize(.small)
-                }
             }
 
             if !viewModel.history.isEmpty {
@@ -529,11 +508,14 @@ private struct TransformHistoryRow: View {
 
     private var headerRow: some View {
         HStack(alignment: .center, spacing: DesignSystem.Spacing.sm) {
-            Image(systemName: "wand.and.stars")
-                .font(.system(size: 12, weight: .semibold))
-                .foregroundStyle(DesignSystem.Colors.accent)
-                .frame(width: 26, height: 26)
-                .background(Circle().fill(DesignSystem.Colors.accentLight))
+            TransformSigilView(
+                data: .from(
+                    inputText: entry.inputText,
+                    outputText: entry.outputText,
+                    transformName: entry.transformName
+                ),
+                size: 32
+            )
 
             Text(entry.transformName)
                 .font(DesignSystem.Typography.caption.weight(.semibold))
@@ -563,18 +545,8 @@ private struct TransformHistoryRow: View {
 
             Spacer(minLength: DesignSystem.Spacing.sm)
 
-            if let copiedTarget {
-                Text(copiedTarget.statusLabel)
-                    .font(DesignSystem.Typography.micro)
-                    .foregroundStyle(DesignSystem.Colors.successGreen)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 3)
-                    .background(Capsule().fill(DesignSystem.Colors.successGreen.opacity(0.12)))
-                    .transition(.opacity.combined(with: .scale(scale: 0.96)))
-            }
-
             TransformHistoryTextButton(
-                title: copiedTarget == .output ? "Copied" : "Copy result",
+                title: copiedTarget == .output ? "Copied result" : "Copy result",
                 systemImage: copiedTarget == .output ? "checkmark" : "doc.on.doc",
                 color: copiedTarget == .output ? DesignSystem.Colors.successGreen : DesignSystem.Colors.textSecondary,
                 help: "Copy transformed result",
@@ -625,7 +597,7 @@ private struct TransformHistoryRow: View {
                         Spacer(minLength: DesignSystem.Spacing.sm)
 
                         TransformHistoryInlineCopyButton(
-                            title: copiedTarget == .input ? "Copied" : "Copy original",
+                            title: copiedTarget == .input ? "Copied original" : "Copy original",
                             systemImage: copiedTarget == .input ? "checkmark" : "doc.text",
                             color: copiedTarget == .input ? DesignSystem.Colors.successGreen : DesignSystem.Colors.textSecondary,
                             help: "Copy original text",

--- a/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
+++ b/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
@@ -335,7 +335,7 @@ public enum SettingsSearchIndex {
             subtitle: "Destructive — clear history, reset stats.",
             keywords: [
                 "reset", "clear", "delete", "destructive", "wipe",
-                "lifetime stats", "clear all dictations", "clear youtube"
+                "lifetime stats", "clear all dictations", "clear transform history", "clear youtube"
             ],
             cardAnchor: "system.reset"
         )

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -413,6 +413,7 @@ public final class SettingsViewModel {
     private var permissionService: PermissionServiceProtocol?
     private var dictationRepo: DictationRepositoryProtocol?
     private var transcriptionRepo: TranscriptionRepositoryProtocol?
+    private var transformHistoryRepo: TransformHistoryRepositoryProtocol?
     private var customWordRepo: CustomWordRepositoryProtocol?
     private var snippetRepo: TextSnippetRepositoryProtocol?
     private var entitlementsService: EntitlementsService?
@@ -690,6 +691,7 @@ public final class SettingsViewModel {
         permissionService: PermissionServiceProtocol,
         dictationRepo: DictationRepositoryProtocol,
         transcriptionRepo: TranscriptionRepositoryProtocol? = nil,
+        transformHistoryRepo: TransformHistoryRepositoryProtocol? = nil,
         entitlementsService: EntitlementsService,
         launchAtLoginService: LaunchAtLoginControlling? = nil,
         checkoutURL: URL?,
@@ -703,6 +705,7 @@ public final class SettingsViewModel {
         self.permissionService = permissionService
         self.dictationRepo = dictationRepo
         self.transcriptionRepo = transcriptionRepo
+        self.transformHistoryRepo = transformHistoryRepo
         self.entitlementsService = entitlementsService
         self.launchAtLoginService = launchAtLoginService
         self.checkoutURL = checkoutURL
@@ -1407,6 +1410,7 @@ public final class SettingsViewModel {
     /// Fired after a dictation-state change (rows deleted or lifetime counters reset)
     /// so other VMs (e.g. the history view) can reload their derived data.
     public var onDictationStateChanged: (() -> Void)?
+    public var onTransformHistoryChanged: (() -> Void)?
 
     public func clearAllDictations() {
         guard let repo = dictationRepo else { return }
@@ -1443,6 +1447,16 @@ public final class SettingsViewModel {
         }
         refreshStats()
         onDictationStateChanged?()
+    }
+
+    public func clearTransformHistory() {
+        guard let repo = transformHistoryRepo else { return }
+        do {
+            try repo.deleteAll()
+            onTransformHistoryChanged?()
+        } catch {
+            logger.error("Failed to clear transform history error=\(error.localizedDescription, privacy: .public)")
+        }
     }
 
     public func clearDownloadedYouTubeAudio() {

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -1451,11 +1451,15 @@ public final class SettingsViewModel {
 
     public func clearTransformHistory() {
         guard let repo = transformHistoryRepo else { return }
-        do {
-            try repo.deleteAll()
-            onTransformHistoryChanged?()
-        } catch {
-            logger.error("Failed to clear transform history error=\(error.localizedDescription, privacy: .public)")
+        Task { @MainActor [repo, weak self] in
+            do {
+                try await Task.detached(priority: .userInitiated) {
+                    try repo.deleteAll()
+                }.value
+                self?.onTransformHistoryChanged?()
+            } catch {
+                self?.logger.error("Failed to clear transform history error=\(error.localizedDescription, privacy: .public)")
+            }
         }
     }
 

--- a/Sources/MacParakeetViewModels/TransformsViewModel.swift
+++ b/Sources/MacParakeetViewModels/TransformsViewModel.swift
@@ -1,6 +1,20 @@
 import Foundation
 import MacParakeetCore
 
+public enum TransformHistoryCopyTarget: Sendable, Equatable {
+    case input
+    case output
+
+    public var statusLabel: String {
+        switch self {
+        case .input:
+            return "Copied original"
+        case .output:
+            return "Copied output"
+        }
+    }
+}
+
 /// Drives the **Transforms** tab list (ADR-022). Owns the user-visible
 /// ordered set of `.transform` prompts plus the "no LLM provider" state
 /// surfaced in the hero card.
@@ -30,6 +44,7 @@ public final class TransformsViewModel {
     public var pendingDeleteHistoryEntry: TransformHistoryEntry?
     public var isConfirmingClearHistory: Bool = false
     public var copiedHistoryEntryID: UUID?
+    public var copiedHistoryTarget: TransformHistoryCopyTarget?
 
     /// True when the user has at least one LLM provider configured. Drives
     /// the calm "Configure in Settings" hero state.
@@ -251,25 +266,45 @@ public final class TransformsViewModel {
             && activeHistoryMutationCount == 0
     }
 
-    /// Copy a prior run's output back to the clipboard, with a brief
-    /// "copied" affordance keyed by entry ID so the UI can show a check
-    /// next to the right row.
+    /// Copy a prior run's output back to the clipboard.
     public func copyOutputToClipboard(_ entry: TransformHistoryEntry) async {
+        await copyHistoryTextToClipboard(entry, target: .output)
+    }
+
+    /// Copy a prior run's original selected text back to the clipboard.
+    public func copyInputToClipboard(_ entry: TransformHistoryEntry) async {
+        await copyHistoryTextToClipboard(entry, target: .input)
+    }
+
+    /// Copy a prior run's text back to the clipboard, with a brief affordance
+    /// keyed by entry ID and text target so the UI can show precise feedback.
+    public func copyHistoryTextToClipboard(
+        _ entry: TransformHistoryEntry,
+        target: TransformHistoryCopyTarget
+    ) async {
         guard let clipboardService else {
             historyErrorMessage = "Clipboard service is unavailable."
             return
         }
-        guard await clipboardService.copyToClipboard(entry.outputText) else {
-            historyErrorMessage = "Could not copy transformed text to the clipboard."
+        let text = switch target {
+        case .input:
+            entry.inputText
+        case .output:
+            entry.outputText
+        }
+        guard await clipboardService.copyToClipboard(text) else {
+            historyErrorMessage = "Could not copy text to the clipboard."
             return
         }
         historyErrorMessage = nil
         copiedResetTask?.cancel()
         copiedHistoryEntryID = entry.id
+        copiedHistoryTarget = target
         copiedResetTask = Task {
             try? await Task.sleep(for: .seconds(1.5))
             guard !Task.isCancelled else { return }
             self.copiedHistoryEntryID = nil
+            self.copiedHistoryTarget = nil
         }
     }
 

--- a/Sources/MacParakeetViewModels/TransformsViewModel.swift
+++ b/Sources/MacParakeetViewModels/TransformsViewModel.swift
@@ -300,9 +300,9 @@ public final class TransformsViewModel {
         copiedResetTask?.cancel()
         copiedHistoryEntryID = entry.id
         copiedHistoryTarget = target
-        copiedResetTask = Task {
+        copiedResetTask = Task { [weak self] in
             try? await Task.sleep(for: .seconds(1.5))
-            guard !Task.isCancelled else { return }
+            guard let self, !Task.isCancelled else { return }
             self.copiedHistoryEntryID = nil
             self.copiedHistoryTarget = nil
         }

--- a/Sources/MacParakeetViewModels/TransformsViewModel.swift
+++ b/Sources/MacParakeetViewModels/TransformsViewModel.swift
@@ -10,7 +10,7 @@ public enum TransformHistoryCopyTarget: Sendable, Equatable {
         case .input:
             return "Copied original"
         case .output:
-            return "Copied output"
+            return "Copied result"
         }
     }
 }

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -776,6 +776,28 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertTrue(mockRepo.dictations.isEmpty, "no dictation rows survive Clear All")
     }
 
+    // MARK: - Clear Transform History
+
+    func testClearTransformHistoryCallsRepoAndNotifies() {
+        let transformHistoryRepo = MockTransformHistoryRepository()
+
+        viewModel.configure(
+            permissionService: mockPermissions,
+            dictationRepo: mockRepo,
+            transformHistoryRepo: transformHistoryRepo,
+            entitlementsService: entitlements,
+            checkoutURL: nil
+        )
+
+        var stateChangedFireCount = 0
+        viewModel.onTransformHistoryChanged = { stateChangedFireCount += 1 }
+
+        viewModel.clearTransformHistory()
+
+        XCTAssertTrue(transformHistoryRepo.deleteAllCalled)
+        XCTAssertEqual(stateChangedFireCount, 1)
+    }
+
     // MARK: - Reset Lifetime Stats (#124)
 
     func testResetLifetimeStatsCallsRepo() {

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -778,7 +778,7 @@ final class SettingsViewModelTests: XCTestCase {
 
     // MARK: - Clear Transform History
 
-    func testClearTransformHistoryCallsRepoAndNotifies() {
+    func testClearTransformHistoryCallsRepoAndNotifies() async throws {
         let transformHistoryRepo = MockTransformHistoryRepository()
 
         viewModel.configure(
@@ -794,8 +794,35 @@ final class SettingsViewModelTests: XCTestCase {
 
         viewModel.clearTransformHistory()
 
+        try await waitUntil {
+            transformHistoryRepo.deleteAllCalled && stateChangedFireCount == 1
+        }
         XCTAssertTrue(transformHistoryRepo.deleteAllCalled)
         XCTAssertEqual(stateChangedFireCount, 1)
+    }
+
+    func testClearTransformHistoryTracksFailedDeleteAllCallWithoutNotifying() async throws {
+        let transformHistoryRepo = MockTransformHistoryRepository()
+        transformHistoryRepo.deleteAllError = NSError(domain: "test", code: 1)
+
+        viewModel.configure(
+            permissionService: mockPermissions,
+            dictationRepo: mockRepo,
+            transformHistoryRepo: transformHistoryRepo,
+            entitlementsService: entitlements,
+            checkoutURL: nil
+        )
+
+        var stateChangedFireCount = 0
+        viewModel.onTransformHistoryChanged = { stateChangedFireCount += 1 }
+
+        viewModel.clearTransformHistory()
+
+        try await waitUntil {
+            transformHistoryRepo.deleteAllCalled
+        }
+        XCTAssertTrue(transformHistoryRepo.deleteAllCalled)
+        XCTAssertEqual(stateChangedFireCount, 0)
     }
 
     // MARK: - Reset Lifetime Stats (#124)

--- a/Tests/MacParakeetTests/ViewModels/TransformsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TransformsViewModelTests.swift
@@ -473,6 +473,28 @@ final class TransformsViewModelTests: XCTestCase {
 
         XCTAssertEqual(clipboardService.lastCopied, "polished")
         XCTAssertEqual(viewModel.copiedHistoryEntryID, entry.id)
+        XCTAssertEqual(viewModel.copiedHistoryTarget, .output)
+        XCTAssertEqual(viewModel.copiedHistoryTarget?.statusLabel, "Copied output")
+        XCTAssertNil(viewModel.historyErrorMessage)
+    }
+
+    func testCopyInputToClipboardWritesOriginalTextAndFlagsCopiedTarget() async throws {
+        let entry = TransformHistoryEntry(
+            transformName: "Polish",
+            inputText: "rough",
+            outputText: "polished",
+            capturePath: "ax",
+            replacementPath: "ax",
+            llmElapsedMs: 1,
+            totalElapsedMs: 2
+        )
+
+        await viewModel.copyInputToClipboard(entry)
+
+        XCTAssertEqual(clipboardService.lastCopied, "rough")
+        XCTAssertEqual(viewModel.copiedHistoryEntryID, entry.id)
+        XCTAssertEqual(viewModel.copiedHistoryTarget, .input)
+        XCTAssertEqual(viewModel.copiedHistoryTarget?.statusLabel, "Copied original")
         XCTAssertNil(viewModel.historyErrorMessage)
     }
 }

--- a/Tests/MacParakeetTests/ViewModels/TransformsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TransformsViewModelTests.swift
@@ -474,7 +474,7 @@ final class TransformsViewModelTests: XCTestCase {
         XCTAssertEqual(clipboardService.lastCopied, "polished")
         XCTAssertEqual(viewModel.copiedHistoryEntryID, entry.id)
         XCTAssertEqual(viewModel.copiedHistoryTarget, .output)
-        XCTAssertEqual(viewModel.copiedHistoryTarget?.statusLabel, "Copied output")
+        XCTAssertEqual(viewModel.copiedHistoryTarget?.statusLabel, "Copied result")
         XCTAssertNil(viewModel.historyErrorMessage)
     }
 

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -295,10 +295,10 @@ final class MockTransformHistoryRepository: TransformHistoryRepositoryProtocol, 
     }
 
     func deleteAll() throws {
+        deleteAllCalled = true
         if let deleteAllError {
             throw deleteAllError
         }
-        deleteAllCalled = true
         entries.removeAll()
     }
 }

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -246,6 +246,63 @@ final class MockTranscriptionRepository: TranscriptionRepositoryProtocol, @unche
     }
 }
 
+// MARK: - MockTransformHistoryRepository
+
+final class MockTransformHistoryRepository: TransformHistoryRepositoryProtocol, @unchecked Sendable {
+    var entries: [TransformHistoryEntry] = []
+    var deleteAllCalled = false
+    var deleteAllError: Error?
+
+    func save(_ entry: TransformHistoryEntry) throws {
+        if let index = entries.firstIndex(where: { $0.id == entry.id }) {
+            entries[index] = entry
+        } else {
+            entries.append(entry)
+        }
+    }
+
+    func fetchAll() throws -> [TransformHistoryEntry] {
+        entries.sorted { $0.createdAt > $1.createdAt }
+    }
+
+    func fetchRecent(limit: Int) throws -> [TransformHistoryEntry] {
+        Array(try fetchAll().prefix(max(0, limit)))
+    }
+
+    func fetchRecentWithCount(limit: Int) throws -> (entries: [TransformHistoryEntry], totalCount: Int) {
+        (try fetchRecent(limit: limit), entries.count)
+    }
+
+    func fetch(id: UUID) throws -> TransformHistoryEntry? {
+        entries.first { $0.id == id }
+    }
+
+    func fetch(idPrefix: String) throws -> [TransformHistoryEntry] {
+        let normalizedPrefix = idPrefix.lowercased().replacingOccurrences(of: "-", with: "")
+        return try fetchAll().filter {
+            $0.id.uuidString.lowercased().replacingOccurrences(of: "-", with: "").hasPrefix(normalizedPrefix)
+        }
+    }
+
+    func count() throws -> Int {
+        entries.count
+    }
+
+    func delete(id: UUID) throws -> Bool {
+        let before = entries.count
+        entries.removeAll { $0.id == id }
+        return entries.count < before
+    }
+
+    func deleteAll() throws {
+        if let deleteAllError {
+            throw deleteAllError
+        }
+        deleteAllCalled = true
+        entries.removeAll()
+    }
+}
+
 // MARK: - MockLaunchAtLoginService
 
 final class MockLaunchAtLoginService: LaunchAtLoginControlling {


### PR DESCRIPTION
## Summary
- Adds a searchable, expandable Transform history built around reuse: copy result, inspect original, and delete individual runs.
- Moves bulk Transform history cleanup into Settings > Reset & Cleanup with the other destructive actions.
- Adds deterministic before/after sigils so saved Transform runs get the same visual fingerprint treatment as Dictations.

## Why
Transform History now feels like a saved-artifact surface instead of a storage admin panel. The high-value actions stay on each row, global cleanup lives in Settings, and the list is easier to scan.

## Validation
- `swift build --target MacParakeet`
- `swift test --filter TransformsViewModelTests --filter SettingsViewModelTests`
- `swift test`
- `scripts/dev/run_app.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search and filter saved transform history entries by keywords
  * Expand individual rows to view complete transform details
  * Copy original input or transformed output to clipboard separately
  * View visual sigil representation for before/after transform comparison
  * Clear all saved transform history from the settings panel

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moona3k/macparakeet/pull/296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->