### PR TITLE
[codex] Fix dictation clipboard restore window

### DIFF
--- a/Sources/MacParakeetCore/Services/System/ClipboardService.swift
+++ b/Sources/MacParakeetCore/Services/System/ClipboardService.swift
@@ -253,7 +253,7 @@ public final class ClipboardService: ClipboardServiceProtocol {
         pasteboard: NSPasteboard = .general,
         pasteShortcutKeyResolver: PasteShortcutKeyResolver = PasteShortcutKeyResolver(),
         eventPosting: ClipboardEventPosting = CGClipboardEventPosting(),
-        focusedTextInserter: ClipboardFocusedTextInserting? = nil,
+        focusedTextInserter: ClipboardFocusedTextInserting?,
         clipboardRestoreDelay: TimeInterval = ClipboardService.defaultClipboardRestoreDelay,
         restoreAttemptObserver: (@MainActor () -> Void)? = nil,
         pasteboardStringWriter: @escaping @MainActor (NSPasteboard, String) -> Bool = { pasteboard, text in

--- a/Sources/MacParakeetCore/Services/System/ClipboardService.swift
+++ b/Sources/MacParakeetCore/Services/System/ClipboardService.swift
@@ -1,4 +1,5 @@
 import AppKit
+import ApplicationServices
 import Carbon
 import Foundation
 import OSLog
@@ -36,6 +37,42 @@ protocol ClipboardEventPosting {
     func simulatePaste(using pasteShortcutKeyResolver: PasteShortcutKeyResolver) throws
     @MainActor
     func simulateKeystroke(_ keyCode: UInt16) throws
+}
+
+protocol ClipboardFocusedTextInserting {
+    @MainActor
+    func insertText(_ text: String) -> Bool
+}
+
+struct AXClipboardFocusedTextInserter: ClipboardFocusedTextInserting {
+    @MainActor
+    func insertText(_ text: String) -> Bool {
+        guard AXIsProcessTrusted() else {
+            return false
+        }
+
+        let systemElement = AXUIElementCreateSystemWide()
+        var rawFocusedElement: CFTypeRef?
+        let copyStatus = AXUIElementCopyAttributeValue(
+            systemElement,
+            kAXFocusedUIElementAttribute as CFString,
+            &rawFocusedElement
+        )
+        guard copyStatus == .success,
+              let rawFocusedElement,
+              CFGetTypeID(rawFocusedElement) == AXUIElementGetTypeID()
+        else {
+            return false
+        }
+
+        let focusedElement = unsafeDowncast(rawFocusedElement as AnyObject, to: AXUIElement.self)
+        let setStatus = AXUIElementSetAttributeValue(
+            focusedElement,
+            kAXSelectedTextAttribute as CFString,
+            text as CFString
+        )
+        return setStatus == .success
+    }
 }
 
 struct CGClipboardEventPosting: ClipboardEventPosting {
@@ -186,13 +223,14 @@ private final class ClipboardRestoreCoordinator {
 /// Handles clipboard save/restore and paste simulation via Cmd+V.
 @MainActor
 public final class ClipboardService: ClipboardServiceProtocol {
-    nonisolated static let defaultClipboardRestoreDelay: TimeInterval = 1.0
+    nonisolated static let defaultClipboardRestoreDelay: TimeInterval = 0.5
     private static let sharedRestoreCoordinator = ClipboardRestoreCoordinator()
 
     private let logger = Logger(subsystem: "com.macparakeet.core", category: "ClipboardService")
     private let pasteboard: NSPasteboard
     private let pasteShortcutKeyResolver: PasteShortcutKeyResolver
     private let eventPosting: ClipboardEventPosting
+    private let focusedTextInserter: ClipboardFocusedTextInserting?
     private let clipboardRestoreDelay: TimeInterval
     private let restoreCoordinator: ClipboardRestoreCoordinator
     private let pasteboardStringWriter: @MainActor (NSPasteboard, String) -> Bool
@@ -202,6 +240,7 @@ public final class ClipboardService: ClipboardServiceProtocol {
             pasteboard: .general,
             pasteShortcutKeyResolver: PasteShortcutKeyResolver(),
             eventPosting: CGClipboardEventPosting(),
+            focusedTextInserter: AXClipboardFocusedTextInserter(),
             clipboardRestoreDelay: Self.defaultClipboardRestoreDelay,
             restoreCoordinator: Self.sharedRestoreCoordinator,
             pasteboardStringWriter: { pasteboard, text in
@@ -214,6 +253,7 @@ public final class ClipboardService: ClipboardServiceProtocol {
         pasteboard: NSPasteboard = .general,
         pasteShortcutKeyResolver: PasteShortcutKeyResolver = PasteShortcutKeyResolver(),
         eventPosting: ClipboardEventPosting = CGClipboardEventPosting(),
+        focusedTextInserter: ClipboardFocusedTextInserting? = nil,
         clipboardRestoreDelay: TimeInterval = ClipboardService.defaultClipboardRestoreDelay,
         restoreAttemptObserver: (@MainActor () -> Void)? = nil,
         pasteboardStringWriter: @escaping @MainActor (NSPasteboard, String) -> Bool = { pasteboard, text in
@@ -224,6 +264,7 @@ public final class ClipboardService: ClipboardServiceProtocol {
             pasteboard: pasteboard,
             pasteShortcutKeyResolver: pasteShortcutKeyResolver,
             eventPosting: eventPosting,
+            focusedTextInserter: focusedTextInserter,
             clipboardRestoreDelay: clipboardRestoreDelay,
             restoreCoordinator: ClipboardRestoreCoordinator(restoreAttemptObserver: restoreAttemptObserver),
             pasteboardStringWriter: pasteboardStringWriter
@@ -234,6 +275,7 @@ public final class ClipboardService: ClipboardServiceProtocol {
         pasteboard: NSPasteboard,
         pasteShortcutKeyResolver: PasteShortcutKeyResolver,
         eventPosting: ClipboardEventPosting,
+        focusedTextInserter: ClipboardFocusedTextInserting?,
         clipboardRestoreDelay: TimeInterval,
         restoreCoordinator: ClipboardRestoreCoordinator,
         pasteboardStringWriter: @escaping @MainActor (NSPasteboard, String) -> Bool
@@ -241,17 +283,21 @@ public final class ClipboardService: ClipboardServiceProtocol {
         self.pasteboard = pasteboard
         self.pasteShortcutKeyResolver = pasteShortcutKeyResolver
         self.eventPosting = eventPosting
+        self.focusedTextInserter = focusedTextInserter
         self.clipboardRestoreDelay = clipboardRestoreDelay
         self.restoreCoordinator = restoreCoordinator
         self.pasteboardStringWriter = pasteboardStringWriter
     }
 
     /// Paste text into the active app by:
-    /// 1. Saving current clipboard
-    /// 2. Setting transcript on clipboard
-    /// 3. Simulating Cmd+V
-    /// 4. Restoring original clipboard after a delay long enough for slow paste targets
+    /// 1. Trying AX-focused text insertion without touching the clipboard.
+    /// 2. Falling back to saving current clipboard, setting transcript, and simulating Cmd+V.
+    /// 3. Restoring original clipboard after a delay long enough for slow paste targets.
     public func pasteText(_ text: String) async throws {
+        if focusedTextInserter?.insertText(text) == true {
+            return
+        }
+
         let restoreDelay = clipboardRestoreDelay
 
         // 1. Save current clipboard contents

--- a/Tests/MacParakeetTests/Services/System/ClipboardServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/System/ClipboardServiceTests.swift
@@ -4,12 +4,60 @@ import XCTest
 
 @MainActor
 final class ClipboardServiceTests: XCTestCase {
-    func testDefaultRestoreDelayLeavesRoomForAsyncPasteConsumers() {
-        XCTAssertGreaterThanOrEqual(
+    func testDefaultRestoreDelayUsesHalfSecondFallbackWindow() {
+        XCTAssertEqual(
             ClipboardService.defaultClipboardRestoreDelay,
-            0.75,
-            "Restoring too soon can make slow target apps paste the previously saved clipboard item."
+            0.5,
+            accuracy: 0.001,
+            "Fallback clipboard paste should keep the dictated text available briefly without leaving a long stale-clipboard window."
         )
+    }
+
+    func testPasteTextUsesFocusedTextInsertionWithoutTouchingClipboard() async throws {
+        let pasteboard = makeScratchPasteboard()
+        defer { pasteboard.releaseGlobally() }
+        replacePasteboard(pasteboard, with: "original")
+
+        var pasteWasPosted = false
+        let focusedInserter = RecordingFocusedTextInserter(insertSucceeds: true)
+        let service = ClipboardService(
+            pasteboard: pasteboard,
+            eventPosting: RecordingClipboardEventPosting {
+                pasteWasPosted = true
+            },
+            focusedTextInserter: focusedInserter,
+            clipboardRestoreDelay: Self.shortRestoreDelay
+        )
+
+        try await service.pasteText("dictation")
+
+        XCTAssertEqual(focusedInserter.insertedTexts, ["dictation"])
+        XCTAssertFalse(pasteWasPosted)
+        XCTAssertEqual(pasteboard.string(forType: .string), "original")
+    }
+
+    func testPasteTextFallsBackToClipboardWhenFocusedTextInsertionFails() async throws {
+        let pasteboard = makeScratchPasteboard()
+        defer { pasteboard.releaseGlobally() }
+        replacePasteboard(pasteboard, with: "original")
+
+        var pastedStrings: [String] = []
+        let focusedInserter = RecordingFocusedTextInserter(insertSucceeds: false)
+        let service = ClipboardService(
+            pasteboard: pasteboard,
+            eventPosting: RecordingClipboardEventPosting {
+                pastedStrings.append(pasteboard.string(forType: .string) ?? "")
+            },
+            focusedTextInserter: focusedInserter,
+            clipboardRestoreDelay: Self.shortRestoreDelay
+        )
+
+        try await service.pasteText("dictation")
+
+        XCTAssertEqual(focusedInserter.insertedTexts, ["dictation"])
+        XCTAssertEqual(pastedStrings, ["dictation"])
+
+        try await waitForPasteboardString("original", on: pasteboard)
     }
 
     func testPasteboardWriteFailureHasActionableDescription() {
@@ -156,6 +204,37 @@ final class ClipboardServiceTests: XCTestCase {
         try await waitForPasteboardString("original", on: pasteboard)
     }
 
+    func testPasteTextWithActionUsesFocusedTextInsertionThenFiresKeystroke() async throws {
+        let pasteboard = makeScratchPasteboard()
+        defer { pasteboard.releaseGlobally() }
+        replacePasteboard(pasteboard, with: "original")
+
+        var pasteWasPosted = false
+        var keystrokes: [UInt16] = []
+        let focusedInserter = RecordingFocusedTextInserter(insertSucceeds: true)
+        let service = ClipboardService(
+            pasteboard: pasteboard,
+            eventPosting: RecordingClipboardEventPosting(
+                onPaste: {
+                    pasteWasPosted = true
+                },
+                onKeystroke: { keyCode in
+                    keystrokes.append(keyCode)
+                }
+            ),
+            focusedTextInserter: focusedInserter,
+            clipboardRestoreDelay: Self.shortRestoreDelay
+        )
+
+        let fired = try await service.pasteTextWithAction("dictation", postPasteAction: .returnKey)
+
+        XCTAssertTrue(fired)
+        XCTAssertEqual(focusedInserter.insertedTexts, ["dictation"])
+        XCTAssertFalse(pasteWasPosted)
+        XCTAssertEqual(keystrokes, [KeyAction.returnKey.keyCode])
+        XCTAssertEqual(pasteboard.string(forType: .string), "original")
+    }
+
     func testUserClipboardChangeDuringRestoreWindowIsNotClobbered() async throws {
         let pasteboard = makeScratchPasteboard()
         defer { pasteboard.releaseGlobally() }
@@ -298,6 +377,21 @@ final class ClipboardServiceTests: XCTestCase {
         XCTAssertEqual(pasteboard.string(forType: .string), expected, file: file, line: line)
     }
 
+}
+
+@MainActor
+private final class RecordingFocusedTextInserter: ClipboardFocusedTextInserting {
+    private let insertSucceeds: Bool
+    private(set) var insertedTexts: [String] = []
+
+    init(insertSucceeds: Bool) {
+        self.insertSucceeds = insertSucceeds
+    }
+
+    func insertText(_ text: String) -> Bool {
+        insertedTexts.append(text)
+        return insertSucceeds
+    }
 }
 
 @MainActor

--- a/Tests/MacParakeetTests/Services/System/ClipboardServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/System/ClipboardServiceTests.swift
@@ -79,6 +79,7 @@ final class ClipboardServiceTests: XCTestCase {
             eventPosting: RecordingClipboardEventPosting {
                 pasteWasPosted = true
             },
+            focusedTextInserter: nil,
             clipboardRestoreDelay: Self.shortRestoreDelay,
             pasteboardStringWriter: { _, text in
                 attemptedWrites.append(text)
@@ -109,6 +110,7 @@ final class ClipboardServiceTests: XCTestCase {
             eventPosting: RecordingClipboardEventPosting {
                 pastedStrings.append(pasteboard.string(forType: .string) ?? "")
             },
+            focusedTextInserter: nil,
             clipboardRestoreDelay: Self.shortRestoreDelay
         )
 
@@ -133,6 +135,7 @@ final class ClipboardServiceTests: XCTestCase {
             eventPosting: RecordingClipboardEventPosting {
                 pastedStrings.append(pasteboard.string(forType: .string) ?? "")
             },
+            focusedTextInserter: nil,
             clipboardRestoreDelay: Self.shortRestoreDelay
         )
 
@@ -164,6 +167,7 @@ final class ClipboardServiceTests: XCTestCase {
                     keystrokes.append(keyCode)
                 }
             ),
+            focusedTextInserter: nil,
             clipboardRestoreDelay: Self.shortRestoreDelay
         )
 
@@ -192,6 +196,7 @@ final class ClipboardServiceTests: XCTestCase {
                     keystrokes.append(keyCode)
                 }
             ),
+            focusedTextInserter: nil,
             clipboardRestoreDelay: Self.shortRestoreDelay
         )
 
@@ -244,6 +249,7 @@ final class ClipboardServiceTests: XCTestCase {
         let service = ClipboardService(
             pasteboard: pasteboard,
             eventPosting: RecordingClipboardEventPosting(),
+            focusedTextInserter: nil,
             clipboardRestoreDelay: Self.shortRestoreDelay,
             restoreAttemptObserver: {
                 restoreAttempted.fulfill()
@@ -266,6 +272,7 @@ final class ClipboardServiceTests: XCTestCase {
         let service = ClipboardService(
             pasteboard: pasteboard,
             eventPosting: RecordingClipboardEventPosting(),
+            focusedTextInserter: nil,
             clipboardRestoreDelay: Self.shortRestoreDelay
         )
 
@@ -287,6 +294,7 @@ final class ClipboardServiceTests: XCTestCase {
         let service = ClipboardService(
             pasteboard: pasteboard,
             eventPosting: RecordingClipboardEventPosting(),
+            focusedTextInserter: nil,
             clipboardRestoreDelay: Self.shortRestoreDelay,
             restoreAttemptObserver: {
                 restoreAttempted.fulfill()
@@ -309,6 +317,7 @@ final class ClipboardServiceTests: XCTestCase {
         let service = ClipboardService(
             pasteboard: pasteboard,
             eventPosting: RecordingClipboardEventPosting(),
+            focusedTextInserter: nil,
             clipboardRestoreDelay: Self.shortRestoreDelay,
             pasteboardStringWriter: { _, _ in false }
         )
@@ -328,6 +337,7 @@ final class ClipboardServiceTests: XCTestCase {
         let service = ClipboardService(
             pasteboard: pasteboard,
             eventPosting: RecordingClipboardEventPosting(),
+            focusedTextInserter: nil,
             clipboardRestoreDelay: Self.shortRestoreDelay,
             pasteboardStringWriter: { pasteboard, text in
                 guard !failNextWrite else {

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -195,8 +195,8 @@ Both modes coexist with no configuration required. The 400ms threshold distingui
 │    - (v0.2) Raw → clean pipeline → polished text                 │
 ├─────────────────────────────────────────────────────────────────┤
 │ 6. Result                                                        │
-│    - Auto-paste into target app (NSPasteboard + simulated Cmd+V) │
-│    - Previous clipboard contents saved and restored after paste  │
+│    - Auto-insert into target app (AX first, clipboard fallback)   │
+│    - Previous clipboard saved/restored only on fallback paste     │
 │    - Save to dictation history (database)                        │
 │    - Save audio file (if storage enabled)                        │
 │    - Overlay shows success checkmark, auto-dismisses             │
@@ -206,26 +206,21 @@ Both modes coexist with no configuration required. The 400ms threshold distingui
 **Text insertion:**
 
 ```swift
-// 1. Save current clipboard
-let savedContents = NSPasteboard.general.pasteboardItems
+// 1. Try direct AX insertion into the focused editable element.
+if focusedElement.setSelectedText(transcript) {
+    return
+}
 
-// 2. Set transcript
+// 2. Fallback for apps that do not support AX insertion:
+//    save current clipboard, set transcript, simulate Cmd+V.
+let savedContents = NSPasteboard.general.pasteboardItems
 NSPasteboard.general.clearContents()
 NSPasteboard.general.setString(transcript, forType: .string)
+simulateCommandV()
 
-// 3. Simulate Cmd+V
-let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: 0x09, keyDown: true)
-keyDown?.flags = .maskCommand
-keyDown?.post(tap: .cghidEventTap)
-
-let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: 0x09, keyDown: false)
-keyUp?.flags = .maskCommand
-keyUp?.post(tap: .cghidEventTap)
-
-// 4. Restore clipboard after short delay
-DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-    NSPasteboard.general.clearContents()
-    // Restore savedContents
+// 3. Restore clipboard after a short delay for slower paste targets.
+DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+    restore(savedContents)
 }
 ```
 

--- a/spec/03-architecture.md
+++ b/spec/03-architecture.md
@@ -238,7 +238,7 @@ Core may use AppKit for small macOS adapter services (for example pasteboard, Sy
 
 #### 2.1 DictationService
 
-**Responsibility:** Orchestrates the full dictation lifecycle: hotkey detection, audio capture, STT, text processing, and clipboard paste.
+**Responsibility:** Orchestrates the full dictation lifecycle: hotkey detection, audio capture, STT, text processing, and text insertion.
 
 **Key Types/Protocols:**
 ```swift
@@ -281,7 +281,7 @@ DictationService.stopRecording()
     │ ── Receives raw transcript
     │ ── Runs TextProcessingPipeline (if mode == .clean)
     │ ── Saves to DictationRepository
-    │ ── Pastes via NSPasteboard + CGEvent (Cmd+V)
+    │ ── Inserts via AX-focused text insertion, with NSPasteboard + CGEvent fallback
     │
     ▼
 DictationResult returned

--- a/spec/kernel/requirements.yaml
+++ b/spec/kernel/requirements.yaml
@@ -32,7 +32,7 @@ REQ-DICT-002:
   status: implemented
 
 REQ-DICT-003:
-  description: Auto-paste transcribed text with clipboard save/restore
+  description: Auto-insert transcribed text with AX-first insertion and clipboard save/restore fallback
   version: v0.1
   status: implemented
 


### PR DESCRIPTION
## Summary
- Prefer AX focused-text insertion so supported dictation targets receive text without using the clipboard.
- Keep clipboard/Cmd+V as the fallback for unsupported targets, with the restore window reduced to 0.5s.
- Make fallback-only test wiring explicit and update the dictation insertion specs.

## Flow
```text
dictation text
    |
    v
try AX focused-text insertion
    | success
    v
done (clipboard untouched)

AX unavailable or rejected
    |
    v
save clipboard -> set dictated text -> Cmd+V -> restore after 0.5s
```

## Validation
- `swift test --filter ClipboardServiceTests`
- `swift test` (2732 tests, 10 skipped)
- `swift build -Xswiftc -warn-concurrency`
- `swift build -c release`
- GitHub CI `swift-test` x2

Fixes #298