### PR TITLE
[codex] Add playback speed control

### DIFF
--- a/Sources/MacParakeet/Views/Components/AudioScrubberBar.swift
+++ b/Sources/MacParakeet/Views/Components/AudioScrubberBar.swift
@@ -71,6 +71,8 @@ struct AudioScrubberBar: View {
                 .font(.system(size: 11, weight: .medium).monospacedDigit())
                 .foregroundStyle(DesignSystem.Colors.textTertiary)
                 .frame(width: 42, alignment: .leading)
+
+            PlaybackSpeedMenu(viewModel: viewModel)
         }
         .padding(.horizontal, 16)
         .frame(height: DesignSystem.Layout.audioScrubberHeight)

--- a/Sources/MacParakeet/Views/Components/PlaybackSpeedMenu.swift
+++ b/Sources/MacParakeet/Views/Components/PlaybackSpeedMenu.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+import MacParakeetViewModels
+
+struct PlaybackSpeedMenu: View {
+    @Bindable var viewModel: MediaPlayerViewModel
+
+    var body: some View {
+        Menu {
+            ForEach(PlaybackRate.options, id: \.self) { rate in
+                Button {
+                    viewModel.setPlaybackRate(rate)
+                } label: {
+                    HStack {
+                        Text(PlaybackRate.label(for: rate))
+                        if isSelected(rate) {
+                            Spacer()
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: "speedometer")
+                    .font(.system(size: 12, weight: .medium))
+                Text(viewModel.playbackRateLabel)
+                    .font(.system(size: 12, weight: .semibold).monospacedDigit())
+                    .frame(minWidth: 28, alignment: .leading)
+            }
+            .foregroundStyle(DesignSystem.Colors.textSecondary)
+            .padding(.horizontal, 9)
+            .frame(height: 28)
+            .background(
+                Capsule()
+                    .fill(DesignSystem.Colors.surfaceElevated)
+            )
+            .contentShape(Capsule())
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help("Playback speed")
+        .accessibilityLabel("Playback speed")
+        .accessibilityValue(viewModel.playbackRateLabel)
+    }
+
+    private func isSelected(_ rate: Float) -> Bool {
+        abs(viewModel.playbackRate - rate) < 0.001
+    }
+}

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionVideoPanel.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionVideoPanel.swift
@@ -27,9 +27,11 @@ struct TranscriptionVideoPanel: View {
                         .aspectRatio(16/9, contentMode: .fit)
                         .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius))
 
-                        // CC toggle
-                        HStack {
+                        HStack(spacing: 8) {
                             Spacer()
+
+                            PlaybackSpeedMenu(viewModel: playerViewModel)
+
                             Button {
                                 playerViewModel.showSubtitles.toggle()
                             } label: {

--- a/Sources/MacParakeetViewModels/MediaPlayerViewModel.swift
+++ b/Sources/MacParakeetViewModels/MediaPlayerViewModel.swift
@@ -19,12 +19,36 @@ public enum PlayerState: Equatable, Sendable {
     case unavailableOffline
 }
 
+public enum PlaybackRate: Sendable {
+    public static let defaultValue: Float = 1.0
+    public static let minimumValue: Float = 0.5
+    public static let maximumValue: Float = 2.0
+    public static let options: [Float] = [0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0]
+
+    public static func normalized(_ rate: Float) -> Float {
+        guard rate.isFinite else { return defaultValue }
+        return min(max(rate, minimumValue), maximumValue)
+    }
+
+    public static func label(for rate: Float) -> String {
+        let hundredths = Int((Double(rate) * 100).rounded())
+        if hundredths % 100 == 0 {
+            return "\(hundredths / 100)x"
+        }
+        if hundredths % 10 == 0 {
+            return String(format: "%.1fx", Double(hundredths) / 100)
+        }
+        return String(format: "%.2fx", Double(hundredths) / 100)
+    }
+}
+
 // MARK: - MediaPlayerViewModel
 
 @MainActor @Observable
 public final class MediaPlayerViewModel {
     public var player: AVPlayer?
     public var isPlaying: Bool = false
+    public var playbackRate: Float
     public var currentTimeMs: Int = 0
     public var durationMs: Int = 0
     public var playerState: PlayerState = .idle
@@ -58,14 +82,19 @@ public final class MediaPlayerViewModel {
     private var playbackConversionTask: Task<Void, Never>?
     private let videoStreamService: VideoStreamService
     private let playbackConverter: YouTubeAudioPlaybackConverting
+    private let playbackRateDefaults: UserDefaults?
     private let logger = Logger(subsystem: "com.macparakeet", category: "MediaPlayer")
+    private static let playbackRateDefaultsKey = "MediaPlayerViewModel.playbackRate"
 
     public init(
         videoStreamService: VideoStreamService = VideoStreamService(),
-        playbackConverter: YouTubeAudioPlaybackConverting = YouTubeAudioPlaybackConverter()
+        playbackConverter: YouTubeAudioPlaybackConverting = YouTubeAudioPlaybackConverter(),
+        playbackRateDefaults: UserDefaults? = .standard
     ) {
         self.videoStreamService = videoStreamService
         self.playbackConverter = playbackConverter
+        self.playbackRateDefaults = playbackRateDefaults
+        self.playbackRate = Self.loadPlaybackRate(from: playbackRateDefaults)
     }
 
     // MARK: - Public API
@@ -258,9 +287,26 @@ public final class MediaPlayerViewModel {
         if player.timeControlStatus == .playing {
             player.pause()
         } else {
+            player.defaultRate = playbackRate
             player.play()
         }
         // isPlaying is updated by the KVO observer on timeControlStatus
+    }
+
+    public var playbackRateLabel: String {
+        PlaybackRate.label(for: playbackRate)
+    }
+
+    public func setPlaybackRate(_ rate: Float) {
+        let normalizedRate = PlaybackRate.normalized(rate)
+        playbackRate = normalizedRate
+        playbackRateDefaults?.set(Double(normalizedRate), forKey: Self.playbackRateDefaultsKey)
+
+        guard let player else { return }
+        player.defaultRate = normalizedRate
+        if player.timeControlStatus == .playing || isPlaying {
+            player.rate = normalizedRate
+        }
     }
 
     /// Load subtitle cues from word timestamps for overlay display.
@@ -338,6 +384,7 @@ public final class MediaPlayerViewModel {
                 seek(toMs: savedTimeMs)
             }
             if wasPlaying {
+                player?.defaultRate = playbackRate
                 player?.play()
             }
             logger.info("YouTube video player ready")
@@ -384,7 +431,9 @@ public final class MediaPlayerViewModel {
             NotificationCenter.default.removeObserver(endOfTrackObserver)
         }
 
+        item.audioTimePitchAlgorithm = .timeDomain
         let avPlayer = AVPlayer(playerItem: item)
+        avPlayer.defaultRate = playbackRate
         self.player = avPlayer
 
         // Observe playback time at 10Hz for smooth transcript sync + subtitle updates
@@ -479,5 +528,12 @@ public final class MediaPlayerViewModel {
             lastCueIndex = found
             currentSubtitleText = found >= 0 ? subtitleCues[found].text : nil
         }
+    }
+
+    private static func loadPlaybackRate(from defaults: UserDefaults?) -> Float {
+        guard let storedRate = defaults?.object(forKey: playbackRateDefaultsKey) as? NSNumber else {
+            return PlaybackRate.defaultValue
+        }
+        return PlaybackRate.normalized(storedRate.floatValue)
     }
 }

--- a/Tests/MacParakeetTests/ViewModels/MediaPlayerViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/MediaPlayerViewModelTests.swift
@@ -117,6 +117,73 @@ final class MediaPlayerViewModelTests: XCTestCase {
         XCTAssertEqual(vm.playerState, .idle)
     }
 
+    // MARK: - Playback Rate
+
+    @MainActor
+    func testPlaybackRateLabelsUseCompactMediaPlayerFormat() {
+        XCTAssertEqual(PlaybackRate.label(for: 0.5), "0.5x")
+        XCTAssertEqual(PlaybackRate.label(for: 1.0), "1x")
+        XCTAssertEqual(PlaybackRate.label(for: 1.25), "1.25x")
+        XCTAssertEqual(PlaybackRate.label(for: 1.5), "1.5x")
+        XCTAssertEqual(PlaybackRate.label(for: 2.0), "2x")
+    }
+
+    @MainActor
+    func testPlaybackRateOptionsUseStandardMediaPlayerPresets() {
+        XCTAssertEqual(PlaybackRate.options, [0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0])
+    }
+
+    @MainActor
+    func testPlaybackRatePersistsAcrossViewModelInstances() {
+        let defaults = isolatedPlaybackDefaults()
+        let vm = MediaPlayerViewModel(playbackRateDefaults: defaults)
+
+        vm.setPlaybackRate(1.5)
+
+        let reloaded = MediaPlayerViewModel(playbackRateDefaults: defaults)
+        XCTAssertEqual(reloaded.playbackRate, 1.5, accuracy: 0.001)
+        XCTAssertEqual(reloaded.playbackRateLabel, "1.5x")
+    }
+
+    @MainActor
+    func testTogglePlayPauseUsesSelectedPlaybackRate() {
+        let vm = MediaPlayerViewModel(playbackRateDefaults: isolatedPlaybackDefaults())
+        let player = AVPlayer()
+        vm.player = player
+        vm.setPlaybackRate(1.5)
+
+        vm.togglePlayPause()
+
+        XCTAssertEqual(player.defaultRate, 1.5, accuracy: 0.001)
+        XCTAssertEqual(player.rate, 1.5, accuracy: 0.001)
+    }
+
+    @MainActor
+    func testChangingPlaybackRateUpdatesActivePlayerRate() {
+        let vm = MediaPlayerViewModel(playbackRateDefaults: isolatedPlaybackDefaults())
+        let player = AVPlayer()
+        vm.player = player
+        vm.isPlaying = true
+
+        vm.setPlaybackRate(1.25)
+
+        XCTAssertEqual(player.defaultRate, 1.25, accuracy: 0.001)
+        XCTAssertEqual(player.rate, 1.25, accuracy: 0.001)
+    }
+
+    @MainActor
+    func testCleanupPreservesPlaybackRatePreference() {
+        let vm = MediaPlayerViewModel(playbackRateDefaults: isolatedPlaybackDefaults())
+        vm.setPlaybackRate(1.5)
+        vm.player = AVPlayer()
+        vm.playerState = .ready
+
+        vm.cleanup()
+
+        XCTAssertEqual(vm.playbackRate, 1.5, accuracy: 0.001)
+        XCTAssertEqual(vm.playbackRateLabel, "1.5x")
+    }
+
     // MARK: - Lazy webm → m4a migration (issue #237 playback fix)
 
     @MainActor
@@ -293,6 +360,13 @@ final class MediaPlayerViewModelTests: XCTestCase {
         XCTAssertEqual(invocationCounter.value, 0,
                        "Cancelled conversion must not invoke the persist callback")
     }
+}
+
+private func isolatedPlaybackDefaults() -> UserDefaults {
+    let suiteName = "com.macparakeet.tests.playback-rate.\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    return defaults
 }
 
 /// Reference-type capture wrapper. Closures that have to mutate state can

--- a/spec/README.md
+++ b/spec/README.md
@@ -153,8 +153,9 @@ Dictation + transcription + history + settings. Get audio in, text out, pasted i
 - [x] Thumbnail cache service (download YouTube thumbnails, embedded local artwork, FFmpeg frame extraction for local video)
 - [x] HLS streaming for YouTube video playback (yt-dlp URL extraction + AVPlayer)
 - [x] AVPlayer SwiftUI wrapper with subtitle overlay
-- [x] MediaPlayerViewModel (state machine, 10Hz time sync, seek, play/pause)
+- [x] MediaPlayerViewModel (state machine, 10Hz time sync, seek, play/pause, speed)
 - [x] Audio scrubber bar for audio-only files (44px horizontal bar)
+- [x] Compact playback speed menu for audio and video playback
 - [x] Playback mode auto-detection (video/audio/none)
 - [x] Split-pane detail view (video 40% left, tabbed content 60% right)
 - [x] Synced transcript highlighting during playback (binary search, auto-scroll)

--- a/spec/kernel/requirements.yaml
+++ b/spec/kernel/requirements.yaml
@@ -176,6 +176,11 @@ REQ-PLAY-003:
   version: v0.5
   status: implemented
 
+REQ-PLAY-004:
+  description: Variable playback speed for audio and video transcript review
+  version: v0.6
+  status: implemented
+
 REQ-UI-004:
   description: Split-pane detail view (video left, content right)
   version: v0.5

--- a/spec/kernel/traceability.md
+++ b/spec/kernel/traceability.md
@@ -62,6 +62,7 @@ This matrix traces each requirement ID from `requirements.yaml` to its implement
 | REQ-PLAY-001 | `MacParakeetCore/Services/VideoStreamService.swift`, `MacParakeetViewModels/MediaPlayerViewModel.swift` | `VideoStreamServiceTests.swift`, `MediaPlayerViewModelTests.swift` |
 | REQ-PLAY-002 | `MacParakeet/Views/Components/AudioScrubberBar.swift`, `MacParakeetViewModels/MediaPlayerViewModel.swift` | `MediaPlayerViewModelTests.swift` |
 | REQ-PLAY-003 | `MacParakeet/Views/Transcription/TranscriptTimestampedContentView.swift`, `MacParakeetViewModels/MediaPlayerViewModel.swift` | `MediaPlayerViewModelTests.swift` |
+| REQ-PLAY-004 | `MacParakeet/Views/Components/PlaybackSpeedMenu.swift`, `MacParakeet/Views/Components/AudioScrubberBar.swift`, `MacParakeet/Views/Transcription/TranscriptionVideoPanel.swift`, `MacParakeetViewModels/MediaPlayerViewModel.swift` | `MediaPlayerViewModelTests.swift` |
 | REQ-UI-004 | `MacParakeet/Views/Transcription/TranscriptResultView.swift`, `MacParakeet/Views/Transcription/TranscriptionVideoPanel.swift` | (ViewModel tests) |
 | REQ-LIB-001 | `MacParakeet/Views/Transcription/TranscriptionLibraryView.swift` | `TranscriptionRepositoryTests.swift` |
 | REQ-UI-005 | `MacParakeet/Views/Transcription/TranscribeView.swift`, `MacParakeet/Views/Transcription/YouTubeInputPanelView.swift`, `MacParakeet/Views/Transcription/PortalDropZone.swift` | (ViewModel tests) |


### PR DESCRIPTION
## Summary

- Adds a compact playback speed menu to transcript audio and video playback.
- Persists the selected speed and applies it to active, resumed, and swapped players.
- Adds focused tests and spec traceability for REQ-PLAY-004.

## Why

Issue #300 asked for variable in-app playback speed. This uses a standard media-player preset ladder instead of a bespoke user-specific speed, keeping transcript review familiar, fast, and uncluttered.

## UX

- Presets: 0.5x, 0.75x, 1x, 1.25x, 1.5x, 1.75x, 2x.
- Default remains 1x.
- The same compact control appears in the audio scrubber and video panel.
- The current speed is visible directly on the control.

## Validation

- swift test --filter MediaPlayerViewModelTests
- swift build
- swift test
- git diff --check

Closes #300