### PR TITLE
Improve paste diagnostics and Transform shortcuts

### DIFF
--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -105,6 +105,23 @@ final class DictationFlowCoordinator {
         }
     }
 
+    static func pasteFailureMessage(for error: Error, copiedToClipboard copied: Bool) -> String {
+        if copied {
+            if let clipboardError = error as? ClipboardServiceError,
+               case .accessibilityPermissionRequired = clipboardError {
+                return "Accessibility permission is required for auto-paste. Copied to clipboard. Press Cmd+V."
+            }
+            return "Copied to clipboard. Press Cmd+V."
+        }
+
+        if let clipboardError = error as? ClipboardServiceError,
+           case .pasteboardWriteFailed = clipboardError {
+            return "Paste failed and the clipboard could not be updated."
+        }
+
+        return "Paste automation failed. The transcript is temporarily on the clipboard. Press Cmd+V now."
+    }
+
     /// Set after init; updated when dictation hotkey managers are recreated.
     var hotkeyManagers: [HotkeyManager] = []
 
@@ -547,20 +564,7 @@ final class DictationFlowCoordinator {
                         self.sendEvent(.pasteFailed(generation: gen, message: "Keystroke failed. Check Accessibility permissions."))
                     } else {
                         let copied = await self.clipboardService.copyToClipboard(transcript)
-                        let failedBeforeClipboardWrite: Bool
-                        if let clipboardError = error as? ClipboardServiceError,
-                           case .pasteboardWriteFailed = clipboardError {
-                            failedBeforeClipboardWrite = true
-                        } else {
-                            failedBeforeClipboardWrite = false
-                        }
-                        let message = if copied {
-                            "Copied to clipboard. Press Cmd+V."
-                        } else if failedBeforeClipboardWrite {
-                            "Paste failed and the clipboard could not be updated."
-                        } else {
-                            "Paste automation failed. The transcript is temporarily on the clipboard. Press Cmd+V now."
-                        }
+                        let message = Self.pasteFailureMessage(for: error, copiedToClipboard: copied)
 
                         self.sendEvent(
                             .pasteFailed(

--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -106,20 +106,20 @@ final class DictationFlowCoordinator {
     }
 
     static func pasteFailureMessage(for error: Error, copiedToClipboard copied: Bool) -> String {
+        let clipboardError = error as? ClipboardServiceError
+
         if copied {
-            if let clipboardError = error as? ClipboardServiceError,
-               case .accessibilityPermissionRequired = clipboardError {
+            if case .accessibilityPermissionRequired? = clipboardError {
                 return "Accessibility permission is required for auto-paste. Copied to clipboard. Press Cmd+V."
             }
             return "Copied to clipboard. Press Cmd+V."
         }
 
-        if let clipboardError = error as? ClipboardServiceError,
-           case .pasteboardWriteFailed = clipboardError {
-            return "Paste failed and the clipboard could not be updated."
+        if case .accessibilityPermissionRequired? = clipboardError {
+            return "Accessibility permission is required for auto-paste, but the clipboard could not be updated."
         }
 
-        return "Paste automation failed. The transcript is temporarily on the clipboard. Press Cmd+V now."
+        return "Paste failed and the clipboard could not be updated."
     }
 
     /// Set after init; updated when dictation hotkey managers are recreated.

--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -557,7 +557,7 @@ final class DictationFlowCoordinator {
                     self.sendEvent(.pasteSucceeded(generation: gen))
                 } catch {
                     guard !Task.isCancelled else { return }
-                    let bucket = self.commandFailureBucket(for: error)
+                    let bucket = Self.commandFailureBucket(for: error)
                     self.dictationLog.error("dictation_paste_failed gen=\(gen) bucket=\(bucket, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
                     if transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                         // Pure action-only dictation (e.g., "press return") — nothing to paste
@@ -964,7 +964,7 @@ final class DictationFlowCoordinator {
         }
     }
 
-    private func commandFailureBucket(for error: Error) -> String {
+    static func commandFailureBucket(for error: Error) -> String {
         if let accessibilityError = error as? AccessibilityServiceError {
             switch accessibilityError {
             case .notAuthorized: return "accessibility_not_authorized"
@@ -974,7 +974,14 @@ final class DictationFlowCoordinator {
             case .unsupportedElement: return "unsupported_element"
             }
         }
-        if error is ClipboardServiceError { return "paste_failed" }
+        if let clipboardError = error as? ClipboardServiceError {
+            switch clipboardError {
+            case .accessibilityPermissionRequired: return "paste_accessibility_permission"
+            case .eventSourceUnavailable: return "paste_event_source_unavailable"
+            case .eventCreationFailed: return "paste_event_creation_failed"
+            case .pasteboardWriteFailed: return "pasteboard_write_failed"
+            }
+        }
         return "unknown"
     }
 

--- a/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
+++ b/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
@@ -689,11 +689,14 @@ struct DictationOverlayView: View {
         if lower.contains("microphone") || lower.contains("audio input") {
             return ("Microphone Unavailable", "Check your mic connection or select a different input.")
         }
+        if lower.contains("permission") || lower.contains("access") {
+            if lower.contains("copied to clipboard") || lower.contains("cmd+v") {
+                return ("Permission Required", "Copied to clipboard. Enable Accessibility or press Cmd+V now.")
+            }
+            return ("Permission Required", "Grant access in System Settings > Privacy & Security.")
+        }
         if lower.contains("copied to clipboard") || lower.contains("cmd+v") {
             return ("Copied to Clipboard", "Auto-paste wasn't available. Press Cmd+V where you want the text.")
-        }
-        if lower.contains("permission") || lower.contains("access") {
-            return ("Permission Required", "Grant access in System Settings > Privacy & Security.")
         }
         if lower.contains("not recording") {
             let trigger = HotkeyTrigger.current

--- a/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
@@ -382,8 +382,19 @@ struct LLMSettingsView: View {
 
             HStack(alignment: .top) {
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("Prompt")
-                        .font(DesignSystem.Typography.body)
+                    HStack(spacing: 7) {
+                        Text("Prompt")
+                            .font(DesignSystem.Typography.body)
+                        Text(viewModel.aiFormatterPromptModeText)
+                            .font(DesignSystem.Typography.micro.weight(.semibold))
+                            .foregroundStyle(DesignSystem.Colors.textSecondary)
+                            .padding(.horizontal, 7)
+                            .padding(.vertical, 3)
+                            .background(
+                                Capsule()
+                                    .fill(DesignSystem.Colors.surfaceElevated)
+                            )
+                    }
                     Text("Uses `{{TRANSCRIPT}}` as the transcript placeholder and runs as the last output step.")
                         .font(DesignSystem.Typography.caption)
                         .foregroundStyle(.secondary)

--- a/Sources/MacParakeet/Views/Transforms/TransformEditorSheet.swift
+++ b/Sources/MacParakeet/Views/Transforms/TransformEditorSheet.swift
@@ -295,7 +295,7 @@ struct ShortcutRecorderField: View {
         if let shortcut {
             HStack(spacing: 6) {
                 KeycapBadge(shortcut: shortcut)
-                Text(shortcut.keyLabel.uppercased())
+                Text(shortcut.displayKeyLabel)
                     .font(DesignSystem.Typography.bodySmall.monospacedDigit())
                     .foregroundStyle(DesignSystem.Colors.textTertiary)
                     .accessibilityHidden(true)
@@ -363,27 +363,28 @@ struct ShortcutRecorderField: View {
         let modifierNames = ordered
             .filter { (shortcut.modifiers & $0.rawValue) != 0 }
             .map(\.displayName)
-        return (modifierNames + [shortcut.keyLabel.uppercased()]).joined(separator: " ")
+        return (modifierNames + [shortcut.displayKeyLabel]).joined(separator: " ")
     }
 
     private func labelForKey(event: NSEvent) -> String {
+        let keyCode = UInt16(event.keyCode)
         if let chars = event.charactersIgnoringModifiers, !chars.isEmpty {
             let scalar = chars.first!
             // Map common control codes to display names.
             switch event.keyCode {
-            case 0x24: return "Return"
-            case 0x30: return "Tab"
-            case 0x31: return "Space"
-            case 0x35: return "Escape"
+            case 0x24: return TransformShortcut.displayKeyLabel(for: keyCode, fallback: "Return")
+            case 0x30: return TransformShortcut.displayKeyLabel(for: keyCode, fallback: "Tab")
+            case 0x31: return TransformShortcut.displayKeyLabel(for: keyCode, fallback: "Space")
+            case 0x35: return TransformShortcut.displayKeyLabel(for: keyCode, fallback: "Escape")
             default:
                 if scalar.isLetter || scalar.isNumber {
-                    return String(scalar).uppercased()
+                    return TransformShortcut.displayKeyLabel(for: keyCode, fallback: String(scalar).uppercased())
                 }
                 if scalar.asciiValue.map({ $0 >= 32 }) ?? false {
-                    return String(scalar)
+                    return TransformShortcut.displayKeyLabel(for: keyCode, fallback: String(scalar))
                 }
             }
         }
-        return "Key \(event.keyCode)"
+        return TransformShortcut.displayKeyLabel(for: keyCode, fallback: "Key \(event.keyCode)")
     }
 }

--- a/Sources/MacParakeet/Views/Transforms/TransformsView.swift
+++ b/Sources/MacParakeet/Views/Transforms/TransformsView.swift
@@ -142,7 +142,7 @@ struct TransformsView: View {
                 Label("Highlight any text on your Mac.", systemImage: "1.circle.fill")
                     .font(DesignSystem.Typography.body)
                     .foregroundStyle(DesignSystem.Colors.textPrimary)
-                Label("Press a Transform's hotkey (⌥1, ⌥2, ⌥3, …).", systemImage: "2.circle.fill")
+                Label(viewModel.heroShortcutInstruction, systemImage: "2.circle.fill")
                     .font(DesignSystem.Typography.body)
                     .foregroundStyle(DesignSystem.Colors.textPrimary)
                 Label("The selection is rewritten in place. ⌘Z to undo.", systemImage: "3.circle.fill")
@@ -1048,7 +1048,7 @@ struct KeycapBadge: View {
                             .stroke(DesignSystem.Colors.border, lineWidth: 0.5)
                     }
             }
-            Text(shortcut.keyLabel.uppercased())
+            Text(shortcut.displayKeyLabel)
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(DesignSystem.Colors.textPrimary)
                 .frame(minWidth: 22, minHeight: 22)
@@ -1077,7 +1077,7 @@ struct KeycapBadge: View {
         let modifierNames = ordered
             .filter { (shortcut.modifiers & $0.rawValue) != 0 }
             .map(\.displayName)
-        return (modifierNames + [shortcut.keyLabel.uppercased()]).joined(separator: " ")
+        return (modifierNames + [shortcut.displayKeyLabel]).joined(separator: " ")
     }
 }
 

--- a/Sources/MacParakeetCore/Models/KeyboardShortcut.swift
+++ b/Sources/MacParakeetCore/Models/KeyboardShortcut.swift
@@ -79,7 +79,21 @@ public struct KeyboardShortcut: Codable, Equatable, Hashable, Sendable {
             .filter { (modifiers & $0.rawValue) != 0 }
             .map(\.displayGlyph)
             .joined()
-        return glyphs + keyLabel.uppercased()
+        return glyphs + displayKeyLabel
+    }
+
+    public var displayKeyLabel: String {
+        Self.displayKeyLabel(for: keyCode, fallback: keyLabel)
+    }
+
+    public static func displayKeyLabel(for keyCode: UInt16, fallback keyLabel: String) -> String {
+        if let digit = digitKeyLabelsByKeyCode[keyCode] {
+            return digit
+        }
+        if let named = namedKeyLabelsByKeyCode[keyCode] {
+            return named
+        }
+        return keyLabel.uppercased()
     }
 
     // MARK: - String parsing (CLI input)
@@ -150,6 +164,11 @@ public struct KeyboardShortcut: Codable, Equatable, Hashable, Sendable {
         "6": 0x16, "7": 0x1A, "8": 0x1C, "9": 0x19, "0": 0x1D,
     ]
 
+    private static let digitKeyLabelsByKeyCode: [UInt16: String] = [
+        0x12: "1", 0x13: "2", 0x14: "3", 0x15: "4", 0x17: "5",
+        0x16: "6", 0x1A: "7", 0x1C: "8", 0x19: "9", 0x1D: "0",
+    ]
+
     private static let letterKeyCodes: [String: UInt16] = [
         "a": 0x00, "b": 0x0B, "c": 0x08, "d": 0x02, "e": 0x0E,
         "f": 0x03, "g": 0x05, "h": 0x04, "i": 0x22, "j": 0x26,
@@ -166,6 +185,13 @@ public struct KeyboardShortcut: Codable, Equatable, Hashable, Sendable {
         "tab":    (0x30, "Tab"),
         "escape": (0x35, "Escape"),
         "esc":    (0x35, "Escape"),
+    ]
+
+    private static let namedKeyLabelsByKeyCode: [UInt16: String] = [
+        0x24: "Return",
+        0x30: "Tab",
+        0x31: "Space",
+        0x35: "Escape",
     ]
 
     // MARK: - Dead-key blocklist

--- a/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
@@ -248,6 +248,12 @@ public final class LLMSettingsViewModel {
         aiFormatterEnabled ? "Enabled" : "Disabled"
     }
 
+    public var aiFormatterPromptModeText: String {
+        draft.normalizedAIFormatterPrompt == AIFormatter.defaultPromptTemplate
+            ? "Default prompt"
+            : "Custom prompt"
+    }
+
     public var aiFormatterDisabledReason: String? {
         if draft.providerID == nil {
             return "Set up AI to enable the formatter."

--- a/Sources/MacParakeetViewModels/TransformsViewModel.swift
+++ b/Sources/MacParakeetViewModels/TransformsViewModel.swift
@@ -443,6 +443,17 @@ public final class TransformsViewModel {
         }
         return bindings
     }
+
+    public var heroShortcutInstruction: String {
+        let shortcuts = transforms.compactMap { $0.shortcut?.displayString }
+        guard !shortcuts.isEmpty else {
+            return "Press a Transform's hotkey."
+        }
+
+        let visibleShortcuts = shortcuts.prefix(3).joined(separator: ", ")
+        let suffix = shortcuts.count > 3 ? ", ..." : ""
+        return "Press a Transform's hotkey (\(visibleShortcuts)\(suffix))."
+    }
 }
 
 private func transformShortcutConflict(

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorTests.swift
@@ -64,7 +64,19 @@ final class DictationFlowCoordinatorTests: XCTestCase {
         )
     }
 
-    func testPasteFailureMessageKeepsClipboardWriteFailureDistinct() {
+    func testPasteFailureMessagePreservesAccessibilityCauseWhenNotCopied() {
+        let message = DictationFlowCoordinator.pasteFailureMessage(
+            for: ClipboardServiceError.accessibilityPermissionRequired,
+            copiedToClipboard: false
+        )
+
+        XCTAssertEqual(
+            message,
+            "Accessibility permission is required for auto-paste, but the clipboard could not be updated."
+        )
+    }
+
+    func testPasteFailureMessageReportsClipboardWriteFailureWhenNotCopied() {
         let message = DictationFlowCoordinator.pasteFailureMessage(
             for: ClipboardServiceError.pasteboardWriteFailed,
             copiedToClipboard: false
@@ -75,7 +87,7 @@ final class DictationFlowCoordinatorTests: XCTestCase {
 
     func testPasteFailureMessageStaysGenericWhenCopiedWithoutAccessibilityCause() {
         // A non-permission paste failure (e.g. CGEvent infrastructure) that still
-        // landed on the clipboard must keep the generic copy — it must NOT claim
+        // landed on the clipboard must keep the generic copy - it must NOT claim
         // an Accessibility cause it cannot attribute.
         let message = DictationFlowCoordinator.pasteFailureMessage(
             for: ClipboardServiceError.eventSourceUnavailable,
@@ -85,7 +97,7 @@ final class DictationFlowCoordinatorTests: XCTestCase {
         XCTAssertEqual(message, "Copied to clipboard. Press Cmd+V.")
     }
 
-    func testPasteFailureMessageFallsBackWhenNotCopiedAndClipboardIntact() {
+    func testPasteFailureMessageDoesNotSuggestPasteWhenNotCopied() {
         let message = DictationFlowCoordinator.pasteFailureMessage(
             for: ClipboardServiceError.eventCreationFailed,
             copiedToClipboard: false
@@ -93,7 +105,7 @@ final class DictationFlowCoordinatorTests: XCTestCase {
 
         XCTAssertEqual(
             message,
-            "Paste automation failed. The transcript is temporarily on the clipboard. Press Cmd+V now."
+            "Paste failed and the clipboard could not be updated."
         )
     }
 

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorTests.swift
@@ -51,4 +51,49 @@ final class DictationFlowCoordinatorTests: XCTestCase {
             XCTAssertFalse(DictationFlowCoordinator.isCapturingAudio(for: state), "Expected false for \(state)")
         }
     }
+
+    func testPasteFailureMessagePreservesAccessibilityCauseWhenCopied() {
+        let message = DictationFlowCoordinator.pasteFailureMessage(
+            for: ClipboardServiceError.accessibilityPermissionRequired,
+            copiedToClipboard: true
+        )
+
+        XCTAssertEqual(
+            message,
+            "Accessibility permission is required for auto-paste. Copied to clipboard. Press Cmd+V."
+        )
+    }
+
+    func testPasteFailureMessageKeepsClipboardWriteFailureDistinct() {
+        let message = DictationFlowCoordinator.pasteFailureMessage(
+            for: ClipboardServiceError.pasteboardWriteFailed,
+            copiedToClipboard: false
+        )
+
+        XCTAssertEqual(message, "Paste failed and the clipboard could not be updated.")
+    }
+
+    func testPasteFailureMessageStaysGenericWhenCopiedWithoutAccessibilityCause() {
+        // A non-permission paste failure (e.g. CGEvent infrastructure) that still
+        // landed on the clipboard must keep the generic copy — it must NOT claim
+        // an Accessibility cause it cannot attribute.
+        let message = DictationFlowCoordinator.pasteFailureMessage(
+            for: ClipboardServiceError.eventSourceUnavailable,
+            copiedToClipboard: true
+        )
+
+        XCTAssertEqual(message, "Copied to clipboard. Press Cmd+V.")
+    }
+
+    func testPasteFailureMessageFallsBackWhenNotCopiedAndClipboardIntact() {
+        let message = DictationFlowCoordinator.pasteFailureMessage(
+            for: ClipboardServiceError.eventCreationFailed,
+            copiedToClipboard: false
+        )
+
+        XCTAssertEqual(
+            message,
+            "Paste automation failed. The transcript is temporarily on the clipboard. Press Cmd+V now."
+        )
+    }
 }

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorTests.swift
@@ -96,4 +96,26 @@ final class DictationFlowCoordinatorTests: XCTestCase {
             "Paste automation failed. The transcript is temporarily on the clipboard. Press Cmd+V now."
         )
     }
+
+    func testCommandFailureBucketSplitsClipboardPermissionFailure() {
+        XCTAssertEqual(
+            DictationFlowCoordinator.commandFailureBucket(for: ClipboardServiceError.accessibilityPermissionRequired),
+            "paste_accessibility_permission"
+        )
+    }
+
+    func testCommandFailureBucketSplitsClipboardInfrastructureFailures() {
+        XCTAssertEqual(
+            DictationFlowCoordinator.commandFailureBucket(for: ClipboardServiceError.eventSourceUnavailable),
+            "paste_event_source_unavailable"
+        )
+        XCTAssertEqual(
+            DictationFlowCoordinator.commandFailureBucket(for: ClipboardServiceError.eventCreationFailed),
+            "paste_event_creation_failed"
+        )
+        XCTAssertEqual(
+            DictationFlowCoordinator.commandFailureBucket(for: ClipboardServiceError.pasteboardWriteFailed),
+            "pasteboard_write_failed"
+        )
+    }
 }

--- a/Tests/MacParakeetTests/Models/KeyboardShortcutTests.swift
+++ b/Tests/MacParakeetTests/Models/KeyboardShortcutTests.swift
@@ -48,6 +48,18 @@ final class KeyboardShortcutTests: XCTestCase {
         XCTAssertEqual(lowercase.displayString, "⌥P")
     }
 
+    func testDisplayStringNormalizesShiftedDigitLabel() {
+        let shiftedDigit = KeyboardShortcut(
+            modifiers: KeyboardShortcut.ModifierFlag.command.rawValue
+                | KeyboardShortcut.ModifierFlag.shift.rawValue,
+            keyCode: 0x12,
+            keyLabel: "!"
+        )
+
+        XCTAssertEqual(shiftedDigit.displayKeyLabel, "1")
+        XCTAssertEqual(shiftedDigit.displayString, "⇧⌘1")
+    }
+
     // MARK: - Modifier introspection
 
     func testHasModifierIsFalseWithoutAnyModifiers() {

--- a/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
@@ -41,6 +41,7 @@ final class LLMSettingsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.setupStatus, .setUpNeeded)
         XCTAssertFalse(viewModel.aiFormatterEnabled)
         XCTAssertEqual(viewModel.aiFormatterPrompt, AIFormatter.defaultPromptTemplate)
+        XCTAssertEqual(viewModel.aiFormatterPromptModeText, "Default prompt")
     }
 
     func testSetupStatusReadyUsesSavedProviderDisplayName() {
@@ -601,6 +602,7 @@ final class LLMSettingsViewModelTests: XCTestCase {
 
         XCTAssertTrue(viewModel.aiFormatterEnabled)
         XCTAssertEqual(viewModel.aiFormatterPrompt, "Rewrite:\n\(AIFormatter.transcriptPlaceholder)")
+        XCTAssertEqual(viewModel.aiFormatterPromptModeText, "Custom prompt")
     }
 
     func testLoadsLegacyDefaultAIFormatterPromptAsUpdatedDefault() {

--- a/Tests/MacParakeetTests/ViewModels/TransformsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TransformsViewModelTests.swift
@@ -48,6 +48,24 @@ final class TransformsViewModelTests: XCTestCase {
         XCTAssertEqual(labels, ["1", "2", "3"])
     }
 
+    func testHeroShortcutInstructionUsesCurrentBindings() async throws {
+        var polish = try XCTUnwrap(viewModel.transforms.first(where: { $0.name == "Polish" }))
+        polish.keyboardShortcut = KeyboardShortcut(
+            modifiers: KeyboardShortcut.ModifierFlag.command.rawValue
+                | KeyboardShortcut.ModifierFlag.shift.rawValue,
+            keyCode: 0x12,
+            keyLabel: "!"
+        ).encodedString()
+
+        let saved = await viewModel.save(polish)
+        XCTAssertTrue(saved)
+
+        XCTAssertEqual(
+            viewModel.heroShortcutInstruction,
+            "Press a Transform's hotkey (⇧⌘1, ⌥2, ⌥3)."
+        )
+    }
+
     func testSaveNewCustomTransformAppendsToList() async {
         let prompt = Prompt(
             id: UUID(),


### PR DESCRIPTION
## Summary

- Preserve the Accessibility permission cause in dictation paste-failure messages.
- Do not suggest Cmd+V when the fallback clipboard copy also fails.
- Split paste-failure logs into actionable buckets.
- Show current Transform shortcut bindings and physical digit key labels.
- Show default/custom prompt state for AI Formatter settings.

## Flow

```text
auto-paste transcript
  |
  +-- success -> done
  |
  +-- failure -> copy transcript
        |
        +-- copy succeeds -> show Cmd+V fallback
        |
        +-- copy fails -> show clipboard unavailable
```

Accessibility failures keep the permission cause in both fallback paths.

## Testing

- `swift test --filter "DictationFlowCoordinatorTests/testPasteFailureMessage"`
- `git diff --check`
- `swift test` (2753 tests, 10 skipped, 0 failures)