### PR TITLE
Text processing: split fused letter+digit tokens (next30 → next 30)

### DIFF
--- a/Sources/CLI/Commands/ExportCommand.swift
+++ b/Sources/CLI/Commands/ExportCommand.swift
@@ -42,6 +42,12 @@ struct ExportCommand: AsyncParsableCommand {
     @Option(help: "Path to SQLite database file (defaults to the app database).")
     var database: String?
 
+    @Option(
+        name: .customLong("subtitle-preset"),
+        help: "Subtitle cue-shaping preset for SRT/VTT: standard, netflix, bbc, youtube. Defaults to the value set in the app's Settings."
+    )
+    var subtitlePreset: SubtitlePresetArgument?
+
     func run() async throws {
         try await emitJSONOrRethrow(json: stdout && format == .json) {
             try AppPaths.ensureDirectories()
@@ -75,16 +81,21 @@ struct ExportCommand: AsyncParsableCommand {
         return URL(fileURLWithPath: FileManager.default.currentDirectoryPath).appendingPathComponent(fileName)
     }
 
+    private func resolvedSubtitleConfig() -> SubtitleExportConfig {
+        (subtitlePreset?.preset ?? SubtitleExportPreferences.selectedPreset()).config
+    }
+
     private func formatContent(transcription: Transcription, exportService: ExportService) async -> String {
+        let subtitleConfig = resolvedSubtitleConfig()
         switch format {
         case .txt:
             return await exportService.formatForClipboard(transcription: transcription)
         case .markdown:
             return await exportService.formatMarkdown(transcription: transcription)
         case .srt:
-            return await exportService.formatSRT(transcription: transcription)
+            return await exportService.formatSRT(transcription: transcription, config: subtitleConfig)
         case .vtt:
-            return await exportService.formatVTT(transcription: transcription)
+            return await exportService.formatVTT(transcription: transcription, config: subtitleConfig)
         case .json:
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -98,17 +109,33 @@ struct ExportCommand: AsyncParsableCommand {
     }
 
     private func writeExport(transcription: Transcription, exportService: ExportService, url: URL) async throws {
+        let subtitleConfig = resolvedSubtitleConfig()
         switch format {
         case .txt:
             try await exportService.exportToTxt(transcription: transcription, url: url)
         case .markdown:
             try await exportService.exportToMarkdown(transcription: transcription, url: url)
         case .srt:
-            try await exportService.exportToSRT(transcription: transcription, url: url)
+            try await exportService.exportToSRT(transcription: transcription, url: url, config: subtitleConfig)
         case .vtt:
-            try await exportService.exportToVTT(transcription: transcription, url: url)
+            try await exportService.exportToVTT(transcription: transcription, url: url, config: subtitleConfig)
         case .json:
             try await exportService.exportToJSON(transcription: transcription, url: url)
         }
+    }
+}
+
+/// `ExpressibleByArgument` wrapper so ArgumentParser can parse `--subtitle-preset`
+/// without polluting `SubtitlePreset` (a Core type) with ArgumentParser dependencies.
+struct SubtitlePresetArgument: ExpressibleByArgument {
+    let preset: SubtitlePreset
+
+    init?(argument: String) {
+        guard let preset = SubtitlePreset(rawValue: argument.lowercased()) else { return nil }
+        self.preset = preset
+    }
+
+    static var allValueStrings: [String] {
+        SubtitlePreset.allCases.map(\.rawValue)
     }
 }

--- a/Sources/CLI/Commands/MeetingsCommand.swift
+++ b/Sources/CLI/Commands/MeetingsCommand.swift
@@ -109,11 +109,18 @@ struct MeetingsCommand: AsyncParsableCommand {
         @Option(help: "Path to SQLite database file (defaults to the app database).")
         var database: String?
 
+        @Option(
+            name: .customLong("subtitle-preset"),
+            help: "Subtitle preset for SRT/VTT: standard, netflix, bbc, youtube. Defaults to the app's Settings value."
+        )
+        var subtitlePreset: SubtitlePresetArgument?
+
         func run() async throws {
             try await emitJSONOrRethrow(json: format == .json) {
                 let repo = try makeTranscriptionRepository(database: database)
                 let transcription = try findMeeting(idOrName: meeting, repo: repo)
                 let exportService = await ExportService()
+                let subtitleConfig = (subtitlePreset?.preset ?? SubtitleExportPreferences.selectedPreset()).config
 
                 switch format {
                 case .text:
@@ -121,9 +128,9 @@ struct MeetingsCommand: AsyncParsableCommand {
                 case .json:
                     try printJSON(MeetingTranscriptRecord(transcription))
                 case .srt:
-                    print(await exportService.formatSRT(transcription: transcription))
+                    print(await exportService.formatSRT(transcription: transcription, config: subtitleConfig))
                 case .vtt:
-                    print(await exportService.formatVTT(transcription: transcription))
+                    print(await exportService.formatVTT(transcription: transcription, config: subtitleConfig))
                 }
             }
         }

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -831,7 +831,32 @@ struct SettingsView: View {
                 if viewModel.autoSaveTranscripts {
                     autoSaveOptionsView
                 }
+
+                Divider()
+
+                subtitleExportRow
             }
+        }
+    }
+
+    /// Preset picker for SRT/VTT cue shaping. The selection applies to all
+    /// subtitle exports (manual + auto-save) and to the CLI when the user has
+    /// not passed `--subtitle-preset` explicitly.
+    private var subtitleExportRow: some View {
+        HStack {
+            rowText(
+                title: "Subtitle preset",
+                detail: viewModel.subtitleExportPreset.subtitleDescription
+            )
+            Spacer(minLength: DesignSystem.Spacing.md)
+            Picker("", selection: $viewModel.subtitleExportPreset) {
+                ForEach(SubtitlePreset.allCases, id: \.self) { preset in
+                    Text(preset.displayName).tag(preset)
+                }
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+            .frame(minWidth: 170, idealWidth: 210, maxWidth: 260)
         }
     }
 

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
@@ -88,11 +88,13 @@ enum TranscriptResultActions {
         let fileURL = nextAvailableURL(in: downloadsURL, stem: stem, format: format)
         let exportService = ExportService()
 
+        let subtitleConfig = SubtitleExportPreferences.selectedPreset().config
+
         switch format {
         case .txt: try exportService.exportToTxt(transcription: transcription, url: fileURL, options: options)
         case .md: try exportService.exportToMarkdown(transcription: transcription, url: fileURL, options: options)
-        case .srt: try exportService.exportToSRT(transcription: transcription, url: fileURL)
-        case .vtt: try exportService.exportToVTT(transcription: transcription, url: fileURL)
+        case .srt: try exportService.exportToSRT(transcription: transcription, url: fileURL, config: subtitleConfig)
+        case .vtt: try exportService.exportToVTT(transcription: transcription, url: fileURL, config: subtitleConfig)
         case .docx: try exportService.exportToDocx(transcription: transcription, url: fileURL)
         case .pdf: try exportService.exportToPDF(transcription: transcription, url: fileURL)
         case .json: try exportService.exportToJSON(transcription: transcription, url: fileURL)

--- a/Sources/MacParakeetCore/AppPreferences.swift
+++ b/Sources/MacParakeetCore/AppPreferences.swift
@@ -27,3 +27,55 @@ public enum CalendarAutoStartPreferences {
 
     public static let defaultReminderMinutes = 5
 }
+
+/// User-selectable subtitle authoring presets. Maps 1:1 to `SubtitleExportConfig`
+/// constants. Selecting `.standard` keeps the default cue-shaping behavior; the
+/// other cases switch to the corresponding industry style guide.
+public enum SubtitlePreset: String, CaseIterable, Sendable {
+    case standard
+    case netflix
+    case bbc
+    case youtube
+
+    public var displayName: String {
+        switch self {
+        case .standard: "Standard"
+        case .netflix: "Netflix"
+        case .bbc: "BBC"
+        case .youtube: "YouTube"
+        }
+    }
+
+    public var subtitleDescription: String {
+        switch self {
+        case .standard: "Balanced defaults — 42 chars, 25 CPS"
+        case .netflix: "Netflix style guide — 17 CPS, 833ms minimum"
+        case .bbc: "BBC guidelines — 37 chars, 17 CPS, 1s minimum"
+        case .youtube: "Looser pacing, no minimum duration"
+        }
+    }
+
+    public var config: SubtitleExportConfig {
+        switch self {
+        case .standard: return .default
+        case .netflix: return .netflix
+        case .bbc: return .bbc
+        case .youtube: return .youtube
+        }
+    }
+}
+
+public enum SubtitleExportPreferences {
+    public static let presetKey = "SubtitleExport.preset"
+
+    public static func selectedPreset(defaults: UserDefaults = .standard) -> SubtitlePreset {
+        guard let raw = defaults.string(forKey: presetKey),
+              let preset = SubtitlePreset(rawValue: raw)
+        else { return .standard }
+        return preset
+    }
+
+    public static func setSelectedPreset(_ preset: SubtitlePreset, defaults: UserDefaults = .standard) {
+        defaults.set(preset.rawValue, forKey: presetKey)
+    }
+}

--- a/Sources/MacParakeetCore/Services/AutoSaveService.swift
+++ b/Sources/MacParakeetCore/Services/AutoSaveService.swift
@@ -96,11 +96,13 @@ public final class AutoSaveService {
             // Ensure the folder still exists
             try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
 
+            let subtitleConfig = SubtitleExportPreferences.selectedPreset().config
+
             switch format {
             case .txt: try exportService.exportToTxt(transcription: transcription, url: fileURL)
             case .md: try exportService.exportToMarkdown(transcription: transcription, url: fileURL)
-            case .srt: try exportService.exportToSRT(transcription: transcription, url: fileURL)
-            case .vtt: try exportService.exportToVTT(transcription: transcription, url: fileURL)
+            case .srt: try exportService.exportToSRT(transcription: transcription, url: fileURL, config: subtitleConfig)
+            case .vtt: try exportService.exportToVTT(transcription: transcription, url: fileURL, config: subtitleConfig)
             case .json: try exportService.exportToJSON(transcription: transcription, url: fileURL)
             }
 

--- a/Sources/MacParakeetCore/Services/ExportService.swift
+++ b/Sources/MacParakeetCore/Services/ExportService.swift
@@ -363,6 +363,23 @@ public final class ExportService: ExportServiceProtocol, Sendable {
         "unless", "until", "though", "who", "which", "where", "when"
     ]
 
+    // Words that should not END a cue (conjunctions, articles, common prepositions).
+    // Leaving these as the last word produces a dangling cue that hurts readability.
+    private static let badEnders: Set<String> = [
+        "and", "but", "or", "so", "yet", "nor", "for",
+        "the", "a", "an",
+        "in", "on", "at", "to", "of", "with", "from", "by"
+    ]
+
+    // Hard caps used by bad-ender deferral. We are willing to push past the soft 12/7000
+    // limits to avoid a bad ending, but not arbitrarily — these caps bound the overshoot.
+    private static let hardWordCap = 14
+    private static let hardDurationMs = 8000
+
+    // Total character budget for a single-line cue. Cues beyond this are wrapped into two
+    // balanced lines via wrapLongCues. Matches the common SRT/VTT safe width.
+    private static let maxLineChars = 42
+
     public func buildSubtitleCues(from words: [WordTimestamp]) -> [SubtitleCue] {
         guard !words.isEmpty else { return [] }
 
@@ -404,7 +421,25 @@ public final class ExportService: ExportServiceProtocol, Sendable {
                 && Self.clauseStarters.contains(
                     words[i + 1].word.lowercased().trimmingCharacters(in: .punctuationCharacters))
 
-            if isLast || (endsWithPunctuation && currentWords.count >= 2) || hasLongGap || tooManyWords || tooLong || nextIsClauseStart {
+            // Bad-ender deferral: if this break is only fired by a soft size limit
+            // (word count or duration) and the current word is in badEnders, defer the
+            // break by one iteration so we don't leave a dangling conjunction/article/
+            // preposition at the end of the cue. Bounded by hard caps to avoid runaway.
+            let semanticTrigger = (endsWithPunctuation && currentWords.count >= 2)
+                || nextIsClauseStart
+            let hardTrigger = isLast || hasLongGap
+            let softTrigger = tooManyWords || tooLong
+            let lastWordKey = word.word.lowercased().trimmingCharacters(in: .punctuationCharacters)
+            let isBadEnder = Self.badEnders.contains(lastWordKey)
+            let underHardCap = currentWords.count < Self.hardWordCap
+                && (cueEndMs - cueStartMs) < Self.hardDurationMs
+            let deferForBadEnder = softTrigger
+                && !hardTrigger
+                && !semanticTrigger
+                && isBadEnder
+                && underHardCap
+
+            if (isLast || semanticTrigger || hardTrigger || softTrigger) && !deferForBadEnder {
                 cues.append(SubtitleCue(
                     startMs: cueStartMs,
                     endMs: cueEndMs,
@@ -419,16 +454,17 @@ public final class ExportService: ExportServiceProtocol, Sendable {
             }
         }
 
-        // Enforce reading speed: split cues that exceed 17 CPS (Netflix/BBC standard).
-        return enforceReadingSpeed(cues, words: words)
+        // Enforce reading speed: split cues that exceed 25 CPS, then wrap long cues
+        // into two balanced lines for clean SRT/VTT display.
+        let paced = enforceReadingSpeed(cues, words: words)
+        return wrapLongCues(paced)
     }
 
     /// Split cues whose text/duration ratio exceeds maxCPS characters per second.
     /// 25 CPS is the safety threshold — the Netflix/BBC guideline is 17 CPS, but that
     /// standard is for display time compliance tools; 25 catches genuinely unreadable
-    /// cues without false-positiving on fast-but-readable speech.
-    /// Uses word timestamps to find a midpoint split. Cues that can't be cleanly
-    /// split (≤ 2 words) are left untouched.
+    /// cues without false-positiving on fast-but-readable speech. Cues that can't be
+    /// cleanly split (≤ 2 words) are left untouched.
     private func enforceReadingSpeed(_ cues: [SubtitleCue], words: [WordTimestamp], maxCPS: Double = 25.0) -> [SubtitleCue] {
         var result: [SubtitleCue] = []
         // Walk words with a single forward index — both cues and words are chronological,
@@ -455,10 +491,10 @@ public final class ExportService: ExportServiceProtocol, Sendable {
             }
             guard cueWords.count > 2 else { result.append(cue); continue }
 
-            // Split at the midpoint word.
-            let mid = cueWords.count / 2
-            let firstHalf = cueWords[0..<mid]
-            let secondHalf = cueWords[mid...]
+            // Score every candidate split index and pick the linguistically best.
+            let splitIdx = bestSplitIndex(in: cueWords)
+            let firstHalf = cueWords[0..<splitIdx]
+            let secondHalf = cueWords[splitIdx...]
 
             result.append(SubtitleCue(
                 startMs: cue.startMs,
@@ -474,6 +510,90 @@ public final class ExportService: ExportServiceProtocol, Sendable {
             ))
         }
         return result
+    }
+
+    /// Score each candidate split index `i` (meaning words[0..<i] | words[i...]) and
+    /// return the best one. Favours linguistic boundaries: real punctuation, clause
+    /// starters, capitalised words; penalises ending on conjunctions/articles. Distance
+    /// from midpoint is a small tiebreaker so two equally-good splits prefer the balanced
+    /// one. Falls back to the midpoint if no candidate scores above zero.
+    private func bestSplitIndex(in cueWords: [WordTimestamp]) -> Int {
+        let mid = cueWords.count / 2
+        var bestIdx = mid
+        var bestScore = Int.min
+        // Valid splits: 1...(count-1) so both halves have at least one word.
+        for i in 1..<cueWords.count {
+            let prevWord = cueWords[i - 1].word
+            let nextWord = cueWords[i].word
+            let prevKey = prevWord.lowercased().trimmingCharacters(in: .punctuationCharacters)
+            let nextKey = nextWord.lowercased().trimmingCharacters(in: .punctuationCharacters)
+
+            var score = 0
+            if let last = prevWord.last, ".!?".contains(last) { score += 3 }
+            if let last = prevWord.last, ",;:".contains(last) { score += 2 }
+            if Self.clauseStarters.contains(nextKey) { score += 2 }
+            if let first = nextWord.first, first.isUppercase { score += 1 }
+            if Self.badEnders.contains(prevKey) { score -= 2 }
+            // Distance penalty: -1 per word away from midpoint (tiebreaker).
+            score -= abs(i - mid)
+
+            if score > bestScore {
+                bestScore = score
+                bestIdx = i
+            }
+        }
+        // If every candidate scored ≤ 0 purely from the distance penalty, fall back
+        // to the midpoint — anything else is just a less-balanced version of the same.
+        return bestScore > -cueWords.count ? bestIdx : mid
+    }
+
+    /// Wrap cues whose text exceeds maxLineChars into two balanced lines separated by `\n`.
+    /// Picks the word boundary closest to the character midpoint, with a small bonus for
+    /// splits immediately after a comma or before a clause starter. Cues that fit on one
+    /// line pass through unchanged.
+    private func wrapLongCues(_ cues: [SubtitleCue]) -> [SubtitleCue] {
+        cues.map { cue in
+            guard cue.text.count > Self.maxLineChars else { return cue }
+            let tokens = cue.text.split(separator: " ", omittingEmptySubsequences: true).map(String.init)
+            guard tokens.count >= 2 else { return cue }
+
+            let totalLen = cue.text.count
+            let targetLen = totalLen / 2
+
+            // Build prefix character lengths so we can score each split point.
+            var prefixLen = 0
+            var bestIdx = tokens.count / 2
+            var bestScore = Int.min
+            for i in 1..<tokens.count {
+                prefixLen += tokens[i - 1].count + (i == 1 ? 0 : 1) // +1 for the joining space, except the first hop
+                let firstLen = prefixLen
+                let secondLen = totalLen - prefixLen - 1 // -1 for the space replaced by \n
+                let prevToken = tokens[i - 1]
+                let nextToken = tokens[i]
+                let nextKey = nextToken.lowercased().trimmingCharacters(in: .punctuationCharacters)
+
+                // Distance from target (lower is better).
+                var score = -abs(firstLen - targetLen)
+                if let last = prevToken.last, ",;:".contains(last) { score += 4 }
+                if Self.clauseStarters.contains(nextKey) { score += 3 }
+                // Discourage splits that leave one side wildly oversized.
+                if firstLen > Self.maxLineChars || secondLen > Self.maxLineChars { score -= 2 }
+
+                if score > bestScore {
+                    bestScore = score
+                    bestIdx = i
+                }
+            }
+
+            let firstLine = tokens[0..<bestIdx].joined(separator: " ")
+            let secondLine = tokens[bestIdx...].joined(separator: " ")
+            return SubtitleCue(
+                startMs: cue.startMs,
+                endMs: cue.endMs,
+                text: "\(firstLine)\n\(secondLine)",
+                speakerId: cue.speakerId
+            )
+        }
     }
 
     /// Resolve a speakerId to a display label using the speakers mapping.

--- a/Sources/MacParakeetCore/Services/ExportService.swift
+++ b/Sources/MacParakeetCore/Services/ExportService.swift
@@ -371,6 +371,13 @@ public final class ExportService: ExportServiceProtocol, Sendable {
         "in", "on", "at", "to", "of", "with", "from", "by"
     ]
 
+    // Coordinating conjunctions: prefer to START a new cue/line with these rather than
+    // end one with them. Breaking BEFORE a coordinator preserves the conjunction's link
+    // to the clause it introduces.
+    private static let coordinatingConjunctions: Set<String> = [
+        "and", "but", "or", "so", "yet", "nor"
+    ]
+
     // Hard caps used by bad-ender deferral. We are willing to push past the soft 12/7000
     // limits to avoid a bad ending, but not arbitrarily — these caps bound the overshoot.
     private static let hardWordCap = 14
@@ -380,11 +387,65 @@ public final class ExportService: ExportServiceProtocol, Sendable {
     // balanced lines via wrapLongCues. Matches the common SRT/VTT safe width.
     private static let maxLineChars = 42
 
-    public func buildSubtitleCues(from words: [WordTimestamp]) -> [SubtitleCue] {
+    /// Normalises raw word tokens before cue building. Three cleanups:
+    /// 1. Strip leading/trailing whitespace from each word's text. Whisper/Parakeet emit
+    ///    tokens with a leading space (" Hello") which, when joined with " ", produce
+    ///    double-spaced output AND inflate character counts enough to trip the CPS guard.
+    /// 2. Merge tokens that begin with a hyphen ("-up", "-minute") into the preceding
+    ///    word. The transcription engine sometimes splits hyphenated compounds across
+    ///    tokens; treating them as a single word avoids cues like "warm" / "-up." pairs.
+    /// 3. Carry the previous word's speakerId forward when a token has none. Some engines
+    ///    intermittently drop speakerId mid-utterance, producing label-less cues
+    ///    downstream. Treat a missing id as continuation of the same speaker.
+    /// Empty tokens (after trimming) are dropped.
+    private func sanitizeWordTokens(_ words: [WordTimestamp]) -> [WordTimestamp] {
+        var result: [WordTimestamp] = []
+        result.reserveCapacity(words.count)
+        var lastSpeakerId: String? = nil
+        for w in words {
+            let trimmed = w.word.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty { continue }
+            let resolvedSpeaker = w.speakerId ?? lastSpeakerId
+            // Hyphen-continuation: glue onto the previous token.
+            if trimmed.hasPrefix("-"), let prev = result.last {
+                result[result.count - 1] = WordTimestamp(
+                    word: prev.word + trimmed,
+                    startMs: prev.startMs,
+                    endMs: w.endMs,
+                    confidence: min(prev.confidence, w.confidence),
+                    speakerId: prev.speakerId
+                )
+                continue
+            }
+            result.append(WordTimestamp(
+                word: trimmed,
+                startMs: w.startMs,
+                endMs: w.endMs,
+                confidence: w.confidence,
+                speakerId: resolvedSpeaker
+            ))
+            if let s = resolvedSpeaker { lastSpeakerId = s }
+        }
+        return result
+    }
+
+    public func buildSubtitleCues(from rawWords: [WordTimestamp]) -> [SubtitleCue] {
+        guard !rawWords.isEmpty else { return [] }
+        // Sanitise tokens up front: strip surrounding whitespace (Whisper/Parakeet emit
+        // tokens like " Hello" with leading spaces) and merge hyphen-prefix continuations
+        // (" -up", " -minute") back onto the previous token. Without this, joining with
+        // " " produces double spaces and inflates character counts enough to trip the
+        // CPS guard on perfectly normal cues, causing spurious mid-sentence splits.
+        let words = sanitizeWordTokens(rawWords)
         guard !words.isEmpty else { return [] }
 
         var cues: [SubtitleCue] = []
+        // Track word strings + per-word start/end times in parallel so the look-back
+        // boundary search can produce a clean truncated cue and seed the leftover
+        // words into the next cue with correct timing.
         var currentWords: [String] = []
+        var currentStarts: [Int] = []
+        var currentEnds: [Int] = []
         var cueStartMs = words[0].startMs
         var cueEndMs = words[0].endMs
         var cueSpeakerId = words[0].speakerId
@@ -400,11 +461,15 @@ public final class ExportService: ExportServiceProtocol, Sendable {
                     speakerId: cueSpeakerId
                 ))
                 currentWords = []
+                currentStarts = []
+                currentEnds = []
                 cueStartMs = word.startMs
                 cueSpeakerId = word.speakerId
             }
 
             currentWords.append(word.word)
+            currentStarts.append(word.startMs)
+            currentEnds.append(word.endMs)
             cueEndMs = word.endMs
 
             let isLast = i == words.count - 1
@@ -412,6 +477,17 @@ public final class ExportService: ExportServiceProtocol, Sendable {
             let hasLongGap = !isLast && (words[i + 1].startMs - word.endMs) > 800
             let tooManyWords = currentWords.count >= 12
             let tooLong = (cueEndMs - cueStartMs) > 7000
+
+            // Single-word imperative break: if this word ends a sentence AND the next
+            // word starts a new sentence (capital letter), allow flushing even at
+            // count == 1. Catches fitness cueing like "Squat. Up. Down." which would
+            // otherwise be merged because of the count >= 2 floor.
+            let nextStartsCapital = !isLast
+                && (words[i + 1].word.first?.isUppercase ?? false)
+            let sentenceBreak = endsWithPunctuation && (
+                currentWords.count >= 2
+                || (currentWords.count >= 1 && nextStartsCapital)
+            )
 
             // Break before a subordinating conjunction or relative pronoun that opens a
             // new dependent clause — but only after at least 4 words have accumulated so
@@ -421,12 +497,10 @@ public final class ExportService: ExportServiceProtocol, Sendable {
                 && Self.clauseStarters.contains(
                     words[i + 1].word.lowercased().trimmingCharacters(in: .punctuationCharacters))
 
-            // Bad-ender deferral: if this break is only fired by a soft size limit
-            // (word count or duration) and the current word is in badEnders, defer the
-            // break by one iteration so we don't leave a dangling conjunction/article/
-            // preposition at the end of the cue. Bounded by hard caps to avoid runaway.
-            let semanticTrigger = (endsWithPunctuation && currentWords.count >= 2)
-                || nextIsClauseStart
+            // Classify the trigger so we can decide whether to look back for a better
+            // boundary or defer for a bad-ender. Semantic and hard triggers fire as-is;
+            // soft triggers (word count / duration) get the look-back treatment.
+            let semanticTrigger = sentenceBreak || nextIsClauseStart
             let hardTrigger = isLast || hasLongGap
             let softTrigger = tooManyWords || tooLong
             let lastWordKey = word.word.lowercased().trimmingCharacters(in: .punctuationCharacters)
@@ -440,16 +514,45 @@ public final class ExportService: ExportServiceProtocol, Sendable {
                 && underHardCap
 
             if (isLast || semanticTrigger || hardTrigger || softTrigger) && !deferForBadEnder {
-                cues.append(SubtitleCue(
-                    startMs: cueStartMs,
-                    endMs: cueEndMs,
-                    text: currentWords.joined(separator: " "),
-                    speakerId: cueSpeakerId
-                ))
-                currentWords = []
-                if !isLast {
-                    cueStartMs = words[i + 1].startMs
-                    cueSpeakerId = words[i + 1].speakerId
+                // Look-back boundary search: only for pure soft triggers where no
+                // semantic/hard reason forces a break at the current word. If a comma,
+                // coordinating conjunction, or clause starter sits within the recent
+                // window, retroactively split there and seed the leftover into the next
+                // cue. Keeps long fitness sentences ("Keep your back straight, engage
+                // your core, and breathe out") from breaking mid-phrase.
+                let lookBack: Int? = (softTrigger && !semanticTrigger && !hardTrigger)
+                    ? findLookBackBoundary(words: currentWords)
+                    : nil
+
+                if let p = lookBack {
+                    // Flush [0...p] as the cue.
+                    let cueText = currentWords[0...p].joined(separator: " ")
+                    cues.append(SubtitleCue(
+                        startMs: cueStartMs,
+                        endMs: currentEnds[p],
+                        text: cueText,
+                        speakerId: cueSpeakerId
+                    ))
+                    // Leftover [(p+1)...] seeds the next cue.
+                    currentWords = Array(currentWords[(p + 1)...])
+                    currentStarts = Array(currentStarts[(p + 1)...])
+                    currentEnds = Array(currentEnds[(p + 1)...])
+                    cueStartMs = currentStarts.first ?? cueStartMs
+                    cueEndMs = currentEnds.last ?? cueEndMs
+                } else {
+                    cues.append(SubtitleCue(
+                        startMs: cueStartMs,
+                        endMs: cueEndMs,
+                        text: currentWords.joined(separator: " "),
+                        speakerId: cueSpeakerId
+                    ))
+                    currentWords = []
+                    currentStarts = []
+                    currentEnds = []
+                    if !isLast {
+                        cueStartMs = words[i + 1].startMs
+                        cueSpeakerId = words[i + 1].speakerId
+                    }
                 }
             }
         }
@@ -514,9 +617,10 @@ public final class ExportService: ExportServiceProtocol, Sendable {
 
     /// Score each candidate split index `i` (meaning words[0..<i] | words[i...]) and
     /// return the best one. Favours linguistic boundaries: real punctuation, clause
-    /// starters, capitalised words; penalises ending on conjunctions/articles. Distance
-    /// from midpoint is a small tiebreaker so two equally-good splits prefer the balanced
-    /// one. Falls back to the midpoint if no candidate scores above zero.
+    /// starters, coordinating conjunctions, capitalised words; penalises ending on
+    /// conjunctions/articles. Distance from midpoint is a small tiebreaker so two
+    /// equally-good splits prefer the balanced one. Falls back to the midpoint if no
+    /// candidate scores above zero.
     private func bestSplitIndex(in cueWords: [WordTimestamp]) -> Int {
         let mid = cueWords.count / 2
         var bestIdx = mid
@@ -532,6 +636,9 @@ public final class ExportService: ExportServiceProtocol, Sendable {
             if let last = prevWord.last, ".!?".contains(last) { score += 3 }
             if let last = prevWord.last, ",;:".contains(last) { score += 2 }
             if Self.clauseStarters.contains(nextKey) { score += 2 }
+            // Coordinating conjunctions start a new clause cleanly — prefer to split
+            // immediately before them.
+            if Self.coordinatingConjunctions.contains(nextKey) { score += 2 }
             if let first = nextWord.first, first.isUppercase { score += 1 }
             if Self.badEnders.contains(prevKey) { score -= 2 }
             // Distance penalty: -1 per word away from midpoint (tiebreaker).
@@ -545,6 +652,42 @@ public final class ExportService: ExportServiceProtocol, Sendable {
         // If every candidate scored ≤ 0 purely from the distance penalty, fall back
         // to the midpoint — anything else is just a less-balanced version of the same.
         return bestScore > -cueWords.count ? bestIdx : mid
+    }
+
+    /// When a soft-limit break is about to fire, scan the recent `currentWords` for a
+    /// more natural boundary (comma/semicolon/colon, coordinating conjunction, or
+    /// clause starter) within the look-back window. Returns the index of the last word
+    /// to KEEP in the current cue, so caller flushes `[0...returned]` and re-seeds
+    /// `[(returned+1)...]` into the next cue. Returns nil if no scoring boundary exists.
+    /// Window size 6 catches typical fitness-style sentences with a comma 4-5 words
+    /// before the 12-word soft limit fires.
+    private func findLookBackBoundary(words: [String]) -> Int? {
+        let lastIdx = words.count - 1
+        // Need at least 2 words to have a meaningful split (1 in cue, 1 leftover).
+        guard lastIdx >= 1 else { return nil }
+        let windowStart = max(0, lastIdx - 6)
+
+        var bestIdx: Int? = nil
+        var bestScore = 0
+        // Candidate split-after positions p: flush [0...p], leftover [(p+1)...lastIdx].
+        // We don't allow p == lastIdx (no leftover) — that's just the default flush.
+        for p in windowStart..<lastIdx {
+            var score = 0
+            // Word at p ending with clause-level punctuation is the strongest signal.
+            if let last = words[p].last, ",;:".contains(last) { score += 3 }
+            let nextKey = words[p + 1]
+                .lowercased()
+                .trimmingCharacters(in: .punctuationCharacters)
+            // Break BEFORE a coordinator or clause starter so it leads the next cue.
+            if Self.coordinatingConjunctions.contains(nextKey) { score += 2 }
+            if Self.clauseStarters.contains(nextKey) { score += 2 }
+
+            if score > bestScore {
+                bestScore = score
+                bestIdx = p
+            }
+        }
+        return bestIdx
     }
 
     /// Wrap cues whose text exceeds maxLineChars into two balanced lines separated by `\n`.
@@ -576,6 +719,9 @@ public final class ExportService: ExportServiceProtocol, Sendable {
                 var score = -abs(firstLen - targetLen)
                 if let last = prevToken.last, ",;:".contains(last) { score += 4 }
                 if Self.clauseStarters.contains(nextKey) { score += 3 }
+                // Coordinating conjunctions (and/but/or) read more naturally at the
+                // start of line 2 than dangling at the end of line 1.
+                if Self.coordinatingConjunctions.contains(nextKey) { score += 3 }
                 // Discourage splits that leave one side wildly oversized.
                 if firstLen > Self.maxLineChars || secondLen > Self.maxLineChars { score -= 2 }
 

--- a/Sources/MacParakeetCore/Services/ExportService.swift
+++ b/Sources/MacParakeetCore/Services/ExportService.swift
@@ -523,10 +523,15 @@ public final class ExportService: ExportServiceProtocol, Sendable {
     ///    downstream. Treat a missing id as continuation of the same speaker.
     /// Empty tokens (after trimming) are dropped.
     private func sanitizeWordTokens(_ words: [WordTimestamp]) -> [WordTimestamp] {
+        // Pre-split fused letter+digit tokens (`next30` → `next` + `30`) before
+        // the rest of sanitisation runs. Doing it up front means downstream
+        // logic — hyphen merging, character counting for CPS, line wrapping —
+        // sees the same word stream a human would expect.
+        let split = WordNumberSplitter.splitWords(words)
         var result: [WordTimestamp] = []
-        result.reserveCapacity(words.count)
+        result.reserveCapacity(split.count)
         var lastSpeakerId: String? = nil
-        for w in words {
+        for w in split {
             let trimmed = w.word.trimmingCharacters(in: .whitespacesAndNewlines)
             if trimmed.isEmpty { continue }
             let resolvedSpeaker = w.speakerId ?? lastSpeakerId

--- a/Sources/MacParakeetCore/Services/ExportService.swift
+++ b/Sources/MacParakeetCore/Services/ExportService.swift
@@ -5,7 +5,9 @@ import AppKit
 public protocol ExportServiceProtocol: Sendable {
     func exportToTxt(transcription: Transcription, url: URL) throws
     func exportToSRT(transcription: Transcription, url: URL) throws
+    func exportToSRT(transcription: Transcription, url: URL, config: SubtitleExportConfig) throws
     func exportToVTT(transcription: Transcription, url: URL) throws
+    func exportToVTT(transcription: Transcription, url: URL, config: SubtitleExportConfig) throws
     func exportToMarkdown(transcription: Transcription, url: URL) throws
     func exportToJSON(transcription: Transcription, url: URL) throws
     @MainActor func exportToPDF(transcription: Transcription, url: URL) throws
@@ -166,16 +168,38 @@ public final class ExportService: ExportServiceProtocol, Sendable {
 
     /// Export transcription as SRT subtitle file
     public func exportToSRT(transcription: Transcription, url: URL) throws {
-        try formatSRT(transcription: transcription).write(to: url, atomically: true, encoding: .utf8)
+        try exportToSRT(transcription: transcription, url: url, config: .default)
+    }
+
+    public func exportToSRT(
+        transcription: Transcription,
+        url: URL,
+        config: SubtitleExportConfig
+    ) throws {
+        try formatSRT(transcription: transcription, config: config)
+            .write(to: url, atomically: true, encoding: .utf8)
     }
 
     /// Export transcription as WebVTT subtitle file
     public func exportToVTT(transcription: Transcription, url: URL) throws {
-        try formatVTT(transcription: transcription).write(to: url, atomically: true, encoding: .utf8)
+        try exportToVTT(transcription: transcription, url: url, config: .default)
+    }
+
+    public func exportToVTT(
+        transcription: Transcription,
+        url: URL,
+        config: SubtitleExportConfig
+    ) throws {
+        try formatVTT(transcription: transcription, config: config)
+            .write(to: url, atomically: true, encoding: .utf8)
     }
 
     /// Format a transcription as SRT, falling back to one full-transcript cue.
     public func formatSRT(transcription: Transcription) -> String {
+        formatSRT(transcription: transcription, config: .default)
+    }
+
+    public func formatSRT(transcription: Transcription, config: SubtitleExportConfig) -> String {
         if let text = editedTranscriptText(transcription: transcription) {
             let duration = transcription.durationMs ?? 0
             return "1\n00:00:00,000 --> \(srtTimestamp(ms: duration))\n\(singleCueSubtitleText(text))\n"
@@ -186,11 +210,15 @@ public final class ExportService: ExportServiceProtocol, Sendable {
             let duration = transcription.durationMs ?? 0
             return "1\n00:00:00,000 --> \(srtTimestamp(ms: duration))\n\(singleCueSubtitleText(text))\n"
         }
-        return formatSRT(words: words, speakers: transcription.speakers)
+        return formatSRT(words: words, speakers: transcription.speakers, config: config)
     }
 
     /// Format a transcription as WebVTT, falling back to one full-transcript cue.
     public func formatVTT(transcription: Transcription) -> String {
+        formatVTT(transcription: transcription, config: .default)
+    }
+
+    public func formatVTT(transcription: Transcription, config: SubtitleExportConfig) -> String {
         if let text = editedTranscriptText(transcription: transcription) {
             let duration = transcription.durationMs ?? 0
             return "WEBVTT\n\n\(vttTimestamp(ms: 0)) --> \(vttTimestamp(ms: duration))\n\(singleCueSubtitleText(text))\n"
@@ -201,7 +229,7 @@ public final class ExportService: ExportServiceProtocol, Sendable {
             let duration = transcription.durationMs ?? 0
             return "WEBVTT\n\n\(vttTimestamp(ms: 0)) --> \(vttTimestamp(ms: duration))\n\(singleCueSubtitleText(text))\n"
         }
-        return formatVTT(words: words, speakers: transcription.speakers)
+        return formatVTT(words: words, speakers: transcription.speakers, config: config)
     }
 
     /// Export transcription as JSON file

--- a/Sources/MacParakeetCore/Services/ExportService.swift
+++ b/Sources/MacParakeetCore/Services/ExportService.swift
@@ -401,7 +401,8 @@ public final class ExportService: ExportServiceProtocol, Sendable {
             // we don't produce single-word cues.
             let nextIsClauseStart = !isLast
                 && currentWords.count >= 4
-                && Self.clauseStarters.contains(words[i + 1].word.lowercased())
+                && Self.clauseStarters.contains(
+                    words[i + 1].word.lowercased().trimmingCharacters(in: .punctuationCharacters))
 
             if isLast || (endsWithPunctuation && currentWords.count >= 2) || hasLongGap || tooManyWords || tooLong || nextIsClauseStart {
                 cues.append(SubtitleCue(
@@ -430,6 +431,9 @@ public final class ExportService: ExportServiceProtocol, Sendable {
     /// split (≤ 2 words) are left untouched.
     private func enforceReadingSpeed(_ cues: [SubtitleCue], words: [WordTimestamp], maxCPS: Double = 25.0) -> [SubtitleCue] {
         var result: [SubtitleCue] = []
+        // Walk words with a single forward index — both cues and words are chronological,
+        // so we never need to scan the whole array per cue (O(N) overall).
+        var wordIdx = 0
         for cue in cues {
             let durationSec = Double(cue.endMs - cue.startMs) / 1000.0
             guard durationSec > 0.1 else { result.append(cue); continue }
@@ -437,8 +441,18 @@ public final class ExportService: ExportServiceProtocol, Sendable {
             let cps = Double(cue.text.count) / durationSec
             guard cps > maxCPS else { result.append(cue); continue }
 
-            // Find words that fall within this cue's time range.
-            let cueWords = words.filter { $0.startMs >= cue.startMs && $0.endMs <= cue.endMs }
+            // Advance past words that precede this cue.
+            while wordIdx < words.count && words[wordIdx].startMs < cue.startMs {
+                wordIdx += 1
+            }
+            // Collect words that belong to this cue (same speaker, within time range).
+            var cueWords: [WordTimestamp] = []
+            var scanIdx = wordIdx
+            while scanIdx < words.count && words[scanIdx].endMs <= cue.endMs {
+                let w = words[scanIdx]
+                if w.speakerId == cue.speakerId { cueWords.append(w) }
+                scanIdx += 1
+            }
             guard cueWords.count > 2 else { result.append(cue); continue }
 
             // Split at the midpoint word.

--- a/Sources/MacParakeetCore/Services/ExportService.swift
+++ b/Sources/MacParakeetCore/Services/ExportService.swift
@@ -355,6 +355,14 @@ public final class ExportService: ExportServiceProtocol, Sendable {
     /// Groups word timestamps into subtitle cues suitable for SRT/VTT and overlay display.
     /// Rules: max ~12 words per cue, break on sentence-ending punctuation,
     /// break on long pauses (>800ms), max ~7 seconds per cue, break on speaker change.
+    // Subordinating conjunctions and relative pronouns that open a new dependent clause.
+    // Breaking before these words produces more natural subtitle boundaries than breaking
+    // mid-clause at an arbitrary character limit.
+    private static let clauseStarters: Set<String> = [
+        "because", "although", "since", "while", "whereas",
+        "unless", "until", "though", "who", "which", "where", "when"
+    ]
+
     public func buildSubtitleCues(from words: [WordTimestamp]) -> [SubtitleCue] {
         guard !words.isEmpty else { return [] }
 
@@ -388,7 +396,14 @@ public final class ExportService: ExportServiceProtocol, Sendable {
             let tooManyWords = currentWords.count >= 12
             let tooLong = (cueEndMs - cueStartMs) > 7000
 
-            if isLast || (endsWithPunctuation && currentWords.count >= 2) || hasLongGap || tooManyWords || tooLong {
+            // Break before a subordinating conjunction or relative pronoun that opens a
+            // new dependent clause — but only after at least 4 words have accumulated so
+            // we don't produce single-word cues.
+            let nextIsClauseStart = !isLast
+                && currentWords.count >= 4
+                && Self.clauseStarters.contains(words[i + 1].word.lowercased())
+
+            if isLast || (endsWithPunctuation && currentWords.count >= 2) || hasLongGap || tooManyWords || tooLong || nextIsClauseStart {
                 cues.append(SubtitleCue(
                     startMs: cueStartMs,
                     endMs: cueEndMs,
@@ -403,7 +418,48 @@ public final class ExportService: ExportServiceProtocol, Sendable {
             }
         }
 
-        return cues
+        // Enforce reading speed: split cues that exceed 17 CPS (Netflix/BBC standard).
+        return enforceReadingSpeed(cues, words: words)
+    }
+
+    /// Split cues whose text/duration ratio exceeds maxCPS characters per second.
+    /// 25 CPS is the safety threshold — the Netflix/BBC guideline is 17 CPS, but that
+    /// standard is for display time compliance tools; 25 catches genuinely unreadable
+    /// cues without false-positiving on fast-but-readable speech.
+    /// Uses word timestamps to find a midpoint split. Cues that can't be cleanly
+    /// split (≤ 2 words) are left untouched.
+    private func enforceReadingSpeed(_ cues: [SubtitleCue], words: [WordTimestamp], maxCPS: Double = 25.0) -> [SubtitleCue] {
+        var result: [SubtitleCue] = []
+        for cue in cues {
+            let durationSec = Double(cue.endMs - cue.startMs) / 1000.0
+            guard durationSec > 0.1 else { result.append(cue); continue }
+
+            let cps = Double(cue.text.count) / durationSec
+            guard cps > maxCPS else { result.append(cue); continue }
+
+            // Find words that fall within this cue's time range.
+            let cueWords = words.filter { $0.startMs >= cue.startMs && $0.endMs <= cue.endMs }
+            guard cueWords.count > 2 else { result.append(cue); continue }
+
+            // Split at the midpoint word.
+            let mid = cueWords.count / 2
+            let firstHalf = cueWords[0..<mid]
+            let secondHalf = cueWords[mid...]
+
+            result.append(SubtitleCue(
+                startMs: cue.startMs,
+                endMs: firstHalf.last!.endMs,
+                text: firstHalf.map(\.word).joined(separator: " "),
+                speakerId: cue.speakerId
+            ))
+            result.append(SubtitleCue(
+                startMs: secondHalf.first!.startMs,
+                endMs: cue.endMs,
+                text: secondHalf.map(\.word).joined(separator: " "),
+                speakerId: cue.speakerId
+            ))
+        }
+        return result
     }
 
     /// Resolve a speakerId to a display label using the speakers mapping.

--- a/Sources/MacParakeetCore/Services/ExportService.swift
+++ b/Sources/MacParakeetCore/Services/ExportService.swift
@@ -36,6 +36,95 @@ public struct TranscriptExportOptions: Sendable, Equatable {
     public static let `default` = TranscriptExportOptions()
 }
 
+/// Tunable parameters that shape SRT/VTT cue building. Defaults mirror the values
+/// the pipeline used before this struct existed; preset constants reproduce the
+/// conventions of common subtitle authoring tools (Adobe Premiere defaults,
+/// Netflix Timed Text Style Guide, BBC Subtitle Guidelines, YouTube auto-captions).
+public struct SubtitleExportConfig: Sendable, Equatable {
+    /// Character budget per displayed line. Cues exceeding this are wrapped (or split
+    /// when `maxLines == 1`).
+    public var maxLineChars: Int
+    /// 1 = produce single-line cues only (long cues are split into multiple cues).
+    /// 2 = wrap long cues into two balanced lines separated by `\n`.
+    public var maxLines: Int
+    /// Reading speed ceiling. Cues exceeding this characters-per-second value are
+    /// split at the best linguistic boundary.
+    public var maxCPS: Double
+    /// Minimum on-screen duration. Cues shorter than this are extended into the
+    /// following gap (never overlapping the next cue).
+    public var minCueDurationMs: Int
+    /// Hard upper bound on cue duration; soft duration trigger sits at ~7/8 of this.
+    public var maxCueDurationMs: Int
+    /// Minimum gap preserved between consecutive cues. Closer pairs have the earlier
+    /// cue's `endMs` trimmed back (bounded by `minCueDurationMs`).
+    public var minGapMs: Int
+    /// Word count that triggers a soft break (look-back boundary search applies).
+    public var softWordCap: Int
+    /// Word count that forces a break even when the current word would be a bad ender.
+    public var hardWordCap: Int
+
+    public init(
+        maxLineChars: Int = 42,
+        maxLines: Int = 2,
+        maxCPS: Double = 25.0,
+        minCueDurationMs: Int = 800,
+        maxCueDurationMs: Int = 8000,
+        minGapMs: Int = 67,
+        softWordCap: Int = 12,
+        hardWordCap: Int = 14
+    ) {
+        self.maxLineChars = maxLineChars
+        self.maxLines = maxLines
+        self.maxCPS = maxCPS
+        self.minCueDurationMs = minCueDurationMs
+        self.maxCueDurationMs = maxCueDurationMs
+        self.minGapMs = minGapMs
+        self.softWordCap = softWordCap
+        self.hardWordCap = hardWordCap
+    }
+
+    /// Current pipeline defaults. Matches behavior prior to config plumbing.
+    public static let `default` = SubtitleExportConfig()
+
+    /// Netflix Timed Text Style Guide: 42 chars/line, 17 CPS, 5/6s display window,
+    /// 2-frame gap at 24fps (~83ms).
+    public static let netflix = SubtitleExportConfig(
+        maxLineChars: 42,
+        maxLines: 2,
+        maxCPS: 17.0,
+        minCueDurationMs: 833,
+        maxCueDurationMs: 7000,
+        minGapMs: 83,
+        softWordCap: 12,
+        hardWordCap: 14
+    )
+
+    /// BBC Subtitle Guidelines: narrower 37-char lines, 17 CPS, 1s minimum duration.
+    public static let bbc = SubtitleExportConfig(
+        maxLineChars: 37,
+        maxLines: 2,
+        maxCPS: 17.0,
+        minCueDurationMs: 1000,
+        maxCueDurationMs: 8000,
+        minGapMs: 80,
+        softWordCap: 12,
+        hardWordCap: 14
+    )
+
+    /// Looser pacing closer to YouTube auto-captions: no minimum duration or gap,
+    /// slightly wider word caps.
+    public static let youtube = SubtitleExportConfig(
+        maxLineChars: 42,
+        maxLines: 2,
+        maxCPS: 25.0,
+        minCueDurationMs: 0,
+        maxCueDurationMs: 8000,
+        minGapMs: 0,
+        softWordCap: 14,
+        hardWordCap: 16
+    )
+}
+
 /// Handles exporting transcriptions to files and clipboard.
 /// @MainActor because PDF/DOCX paths use NSTextStorage/NSLayoutManager (AppKit, not thread-safe).
 @MainActor
@@ -210,7 +299,15 @@ public final class ExportService: ExportServiceProtocol, Sendable {
 
     /// Format word timestamps as SRT subtitle string
     public func formatSRT(words: [WordTimestamp], speakers: [SpeakerInfo]? = nil) -> String {
-        let cues = buildSubtitleCues(from: words)
+        formatSRT(words: words, speakers: speakers, config: .default)
+    }
+
+    public func formatSRT(
+        words: [WordTimestamp],
+        speakers: [SpeakerInfo]? = nil,
+        config: SubtitleExportConfig
+    ) -> String {
+        let cues = buildSubtitleCues(from: words, config: config)
         var lines: [String] = []
         for (i, cue) in cues.enumerated() {
             lines.append("\(i + 1)")
@@ -227,7 +324,15 @@ public final class ExportService: ExportServiceProtocol, Sendable {
 
     /// Format word timestamps as WebVTT subtitle string
     public func formatVTT(words: [WordTimestamp], speakers: [SpeakerInfo]? = nil) -> String {
-        let cues = buildSubtitleCues(from: words)
+        formatVTT(words: words, speakers: speakers, config: .default)
+    }
+
+    public func formatVTT(
+        words: [WordTimestamp],
+        speakers: [SpeakerInfo]? = nil,
+        config: SubtitleExportConfig
+    ) -> String {
+        let cues = buildSubtitleCues(from: words, config: config)
         var lines: [String] = ["WEBVTT", ""]
         for cue in cues {
             lines.append("\(vttTimestamp(ms: cue.startMs)) --> \(vttTimestamp(ms: cue.endMs))")
@@ -378,15 +483,6 @@ public final class ExportService: ExportServiceProtocol, Sendable {
         "and", "but", "or", "so", "yet", "nor"
     ]
 
-    // Hard caps used by bad-ender deferral. We are willing to push past the soft 12/7000
-    // limits to avoid a bad ending, but not arbitrarily — these caps bound the overshoot.
-    private static let hardWordCap = 14
-    private static let hardDurationMs = 8000
-
-    // Total character budget for a single-line cue. Cues beyond this are wrapped into two
-    // balanced lines via wrapLongCues. Matches the common SRT/VTT safe width.
-    private static let maxLineChars = 42
-
     /// Normalises raw word tokens before cue building. Three cleanups:
     /// 1. Strip leading/trailing whitespace from each word's text. Whisper/Parakeet emit
     ///    tokens with a leading space (" Hello") which, when joined with " ", produce
@@ -430,6 +526,13 @@ public final class ExportService: ExportServiceProtocol, Sendable {
     }
 
     public func buildSubtitleCues(from rawWords: [WordTimestamp]) -> [SubtitleCue] {
+        buildSubtitleCues(from: rawWords, config: .default)
+    }
+
+    public func buildSubtitleCues(
+        from rawWords: [WordTimestamp],
+        config: SubtitleExportConfig
+    ) -> [SubtitleCue] {
         guard !rawWords.isEmpty else { return [] }
         // Sanitise tokens up front: strip surrounding whitespace (Whisper/Parakeet emit
         // tokens like " Hello" with leading spaces) and merge hyphen-prefix continuations
@@ -475,8 +578,11 @@ public final class ExportService: ExportServiceProtocol, Sendable {
             let isLast = i == words.count - 1
             let endsWithPunctuation = word.word.last.map { ".!?".contains($0) } ?? false
             let hasLongGap = !isLast && (words[i + 1].startMs - word.endMs) > 800
-            let tooManyWords = currentWords.count >= 12
-            let tooLong = (cueEndMs - cueStartMs) > 7000
+            let tooManyWords = currentWords.count >= config.softWordCap
+            // Soft duration trigger sits at ~7/8 of the hard cap so bad-ender deferral
+            // has room to overshoot without blowing the hard ceiling.
+            let softDurationMs = (config.maxCueDurationMs * 7) / 8
+            let tooLong = (cueEndMs - cueStartMs) > softDurationMs
 
             // Single-word imperative break: if this word ends a sentence AND the next
             // word starts a new sentence (capital letter), allow flushing even at
@@ -505,8 +611,8 @@ public final class ExportService: ExportServiceProtocol, Sendable {
             let softTrigger = tooManyWords || tooLong
             let lastWordKey = word.word.lowercased().trimmingCharacters(in: .punctuationCharacters)
             let isBadEnder = Self.badEnders.contains(lastWordKey)
-            let underHardCap = currentWords.count < Self.hardWordCap
-                && (cueEndMs - cueStartMs) < Self.hardDurationMs
+            let underHardCap = currentWords.count < config.hardWordCap
+                && (cueEndMs - cueStartMs) < config.maxCueDurationMs
             let deferForBadEnder = softTrigger
                 && !hardTrigger
                 && !semanticTrigger
@@ -557,10 +663,12 @@ public final class ExportService: ExportServiceProtocol, Sendable {
             }
         }
 
-        // Enforce reading speed: split cues that exceed 25 CPS, then wrap long cues
-        // into two balanced lines for clean SRT/VTT display.
-        let paced = enforceReadingSpeed(cues, words: words)
-        return wrapLongCues(paced)
+        // Pipeline: pace -> wrap (or split for single-line) -> extend short cues ->
+        // trim overlapping cues to preserve the minimum inter-cue gap.
+        let paced = enforceReadingSpeed(cues, words: words, config: config)
+        let wrapped = wrapLongCues(paced, config: config)
+        let durationEnforced = enforceMinDuration(wrapped, config: config)
+        return enforceMinGap(durationEnforced, config: config)
     }
 
     /// Split cues whose text/duration ratio exceeds maxCPS characters per second.
@@ -568,7 +676,12 @@ public final class ExportService: ExportServiceProtocol, Sendable {
     /// standard is for display time compliance tools; 25 catches genuinely unreadable
     /// cues without false-positiving on fast-but-readable speech. Cues that can't be
     /// cleanly split (≤ 2 words) are left untouched.
-    private func enforceReadingSpeed(_ cues: [SubtitleCue], words: [WordTimestamp], maxCPS: Double = 25.0) -> [SubtitleCue] {
+    private func enforceReadingSpeed(
+        _ cues: [SubtitleCue],
+        words: [WordTimestamp],
+        config: SubtitleExportConfig
+    ) -> [SubtitleCue] {
+        let maxCPS = config.maxCPS
         var result: [SubtitleCue] = []
         // Walk words with a single forward index — both cues and words are chronological,
         // so we never need to scan the whole array per cue (O(N) overall).
@@ -690,15 +803,21 @@ public final class ExportService: ExportServiceProtocol, Sendable {
         return bestIdx
     }
 
-    /// Wrap cues whose text exceeds maxLineChars into two balanced lines separated by `\n`.
-    /// Picks the word boundary closest to the character midpoint, with a small bonus for
-    /// splits immediately after a comma or before a clause starter. Cues that fit on one
-    /// line pass through unchanged.
-    private func wrapLongCues(_ cues: [SubtitleCue]) -> [SubtitleCue] {
-        cues.map { cue in
-            guard cue.text.count > Self.maxLineChars else { return cue }
+    /// Wrap (or split, when `config.maxLines == 1`) cues whose text exceeds the per-line
+    /// character budget. Picks the word boundary closest to the character midpoint, with
+    /// bonuses for splits after a comma or before a clause starter / coordinating
+    /// conjunction. Cues that fit on one line pass through unchanged.
+    private func wrapLongCues(
+        _ cues: [SubtitleCue],
+        config: SubtitleExportConfig
+    ) -> [SubtitleCue] {
+        let maxLineChars = config.maxLineChars
+        var result: [SubtitleCue] = []
+        result.reserveCapacity(cues.count)
+        for cue in cues {
+            guard cue.text.count > maxLineChars else { result.append(cue); continue }
             let tokens = cue.text.split(separator: " ", omittingEmptySubsequences: true).map(String.init)
-            guard tokens.count >= 2 else { return cue }
+            guard tokens.count >= 2 else { result.append(cue); continue }
 
             let totalLen = cue.text.count
             let targetLen = totalLen / 2
@@ -707,6 +826,7 @@ public final class ExportService: ExportServiceProtocol, Sendable {
             var prefixLen = 0
             var bestIdx = tokens.count / 2
             var bestScore = Int.min
+            var firstHalfLen = 0
             for i in 1..<tokens.count {
                 prefixLen += tokens[i - 1].count + (i == 1 ? 0 : 1) // +1 for the joining space, except the first hop
                 let firstLen = prefixLen
@@ -723,23 +843,113 @@ public final class ExportService: ExportServiceProtocol, Sendable {
                 // start of line 2 than dangling at the end of line 1.
                 if Self.coordinatingConjunctions.contains(nextKey) { score += 3 }
                 // Discourage splits that leave one side wildly oversized.
-                if firstLen > Self.maxLineChars || secondLen > Self.maxLineChars { score -= 2 }
+                if firstLen > maxLineChars || secondLen > maxLineChars { score -= 2 }
 
                 if score > bestScore {
                     bestScore = score
                     bestIdx = i
+                    firstHalfLen = firstLen
                 }
             }
 
             let firstLine = tokens[0..<bestIdx].joined(separator: " ")
             let secondLine = tokens[bestIdx...].joined(separator: " ")
-            return SubtitleCue(
-                startMs: cue.startMs,
-                endMs: cue.endMs,
-                text: "\(firstLine)\n\(secondLine)",
-                speakerId: cue.speakerId
-            )
+
+            if config.maxLines <= 1 {
+                // Single-line mode: emit two consecutive cues instead of wrapping.
+                // Divide the time span proportionally to character length so each
+                // cue's on-screen duration roughly matches its text weight.
+                let cueDuration = cue.endMs - cue.startMs
+                let firstCharShare = Double(firstHalfLen) / Double(max(1, totalLen - 1))
+                let firstDuration = Int((Double(cueDuration) * firstCharShare).rounded())
+                let splitMs = cue.startMs + max(0, min(cueDuration, firstDuration))
+                result.append(SubtitleCue(
+                    startMs: cue.startMs,
+                    endMs: splitMs,
+                    text: firstLine,
+                    speakerId: cue.speakerId
+                ))
+                result.append(SubtitleCue(
+                    startMs: splitMs,
+                    endMs: cue.endMs,
+                    text: secondLine,
+                    speakerId: cue.speakerId
+                ))
+            } else {
+                result.append(SubtitleCue(
+                    startMs: cue.startMs,
+                    endMs: cue.endMs,
+                    text: "\(firstLine)\n\(secondLine)",
+                    speakerId: cue.speakerId
+                ))
+            }
         }
+        return result
+    }
+
+    /// Extend cues whose display duration is shorter than `minCueDurationMs`. Extension
+    /// is capped by the next cue's start (minus `minGapMs`) so we never overlap. Cues
+    /// that can't be extended without overlapping pass through unchanged — we don't
+    /// merge into the next cue because that would undo the upstream cue-shaping work.
+    private func enforceMinDuration(
+        _ cues: [SubtitleCue],
+        config: SubtitleExportConfig
+    ) -> [SubtitleCue] {
+        guard config.minCueDurationMs > 0 else { return cues }
+        var result = cues
+        for i in result.indices {
+            let cue = result[i]
+            let duration = cue.endMs - cue.startMs
+            guard duration < config.minCueDurationMs else { continue }
+            let desiredEnd = cue.startMs + config.minCueDurationMs
+            let ceiling: Int = {
+                if i + 1 < result.count {
+                    return result[i + 1].startMs - config.minGapMs
+                }
+                return Int.max
+            }()
+            let newEnd = max(cue.endMs, min(desiredEnd, ceiling))
+            if newEnd != cue.endMs {
+                result[i] = SubtitleCue(
+                    startMs: cue.startMs,
+                    endMs: newEnd,
+                    text: cue.text,
+                    speakerId: cue.speakerId
+                )
+            }
+        }
+        return result
+    }
+
+    /// Trim consecutive cues that sit closer than `minGapMs` apart. Bounded so we never
+    /// shrink a cue below `minCueDurationMs` — when both constraints can't be honoured
+    /// we keep the cue at its minimum duration and accept the smaller gap.
+    func enforceMinGap(
+        _ cues: [SubtitleCue],
+        config: SubtitleExportConfig
+    ) -> [SubtitleCue] {
+        guard config.minGapMs > 0, cues.count > 1 else { return cues }
+        var result = cues
+        for i in 0..<(result.count - 1) {
+            let prev = result[i]
+            let next = result[i + 1]
+            let gap = next.startMs - prev.endMs
+            guard gap < config.minGapMs else { continue }
+            let desiredEnd = next.startMs - config.minGapMs
+            let floor = prev.startMs + config.minCueDurationMs
+            let newEnd = max(floor, desiredEnd)
+            // Only apply the trim if it actually moves us — avoids no-op writes when
+            // shrinking would violate the minimum duration.
+            if newEnd < prev.endMs {
+                result[i] = SubtitleCue(
+                    startMs: prev.startMs,
+                    endMs: newEnd,
+                    text: prev.text,
+                    speakerId: prev.speakerId
+                )
+            }
+        }
+        return result
     }
 
     /// Resolve a speakerId to a display label using the speakers mapping.

--- a/Sources/MacParakeetCore/TextProcessing/README.md
+++ b/Sources/MacParakeetCore/TextProcessing/README.md
@@ -40,7 +40,7 @@ mode.
 
 ## What to know before editing
 
-**The five pipeline steps run in this fixed order:**
+**The six pipeline steps run in this fixed order:**
 
 1. **Filler removal.** Strip pure hesitation sounds (`um`, `uh`,
    `umm`, `uhh`) only. Word-boundary regex, case-insensitive,
@@ -57,7 +57,13 @@ mode.
    expansion so the trigger phrase isn't mangled by step 4.
 4. **Text snippet expansion.** Plain text snippets (where
    `action == nil`) replace their trigger phrases with their bodies.
-5. **Whitespace cleanup.** Collapse repeated spaces, fix punctuation
+5. **Letter/digit split.** Re-introduce the missing space between
+   alphabetic prefixes and numeric suffixes that Parakeet sometimes
+   fuses into one token (`next30` → `next 30`). Conservative — only
+   touches all-lowercase / title-case prefixes followed by a digit
+   run of length ≥ 2. See `WordNumberSplitter.swift` for the exact
+   rule and rationale.
+6. **Whitespace cleanup.** Collapse repeated spaces, fix punctuation
    spacing, normalize.
 
 **The order is load-bearing.** Filler removal before custom words

--- a/Sources/MacParakeetCore/TextProcessing/TextProcessingPipeline.swift
+++ b/Sources/MacParakeetCore/TextProcessing/TextProcessingPipeline.swift
@@ -1,9 +1,9 @@
 import Foundation
 
-/// Deterministic 5-step text processing pipeline.
+/// Deterministic 6-step text processing pipeline.
 /// Pure function: same input always produces same output.
 ///
-/// Steps: Filler Removal → Custom Words → Trailing Action Extraction → Snippet Expansion → Whitespace Cleanup
+/// Steps: Filler Removal → Custom Words → Trailing Action Extraction → Snippet Expansion → Letter/Digit Split → Whitespace Cleanup
 public struct TextProcessingPipeline: Sendable {
 
     public init() {}
@@ -45,7 +45,14 @@ public struct TextProcessingPipeline: Sendable {
         let (expandedText, expandedIDs) = expandSnippets(in: result, snippets: textSnippets)
         result = expandedText
 
-        // Step 5: Whitespace cleanup
+        // Step 5: Letter/digit token split — fixes Parakeet-fused tokens like
+        // `next30` → `next 30`. Runs *after* custom words / snippets so users
+        // retain the ability to override either side via their own rules, and
+        // *before* whitespace cleanup so the newly-inserted space gets
+        // normalised alongside everything else.
+        result = WordNumberSplitter.splitInText(result)
+
+        // Step 6: Whitespace cleanup
         result = cleanWhitespace(in: result)
 
         return TextProcessingResult(

--- a/Sources/MacParakeetCore/TextProcessing/WordNumberSplitter.swift
+++ b/Sources/MacParakeetCore/TextProcessing/WordNumberSplitter.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// Splits Parakeet-style fused letter+digit tokens back into separate words.
+///
+/// Parakeet (and occasionally Whisper) emits tokens like `next30`, `the980`,
+/// `high90s,` as a single word with no space between the alphabetic prefix
+/// and the numeric portion. This helper re-introduces the missing space.
+///
+/// Conservative on purpose — only splits when:
+///   - prefix is **all lowercase** (`next`, `the`, `arms`) or **title case**
+///     (`Next`, `The`, `Hello`) and at least 2 letters long, AND
+///   - digit run is at least 2 characters long.
+///
+/// This intentionally leaves legitimate alphanumerics alone:
+///   - `MP3`, `MP4` — digit run too short
+///   - `iPhone15` — prefix is mixed case (camelCase)
+///   - `H2O`, `v3` — prefix too short and digit run too short
+///   - `1080p`, `90s` — tokens starting with digits
+///
+/// If a real-world false-positive shows up later, prefer narrowing the
+/// regex over adding a denylist.
+public enum WordNumberSplitter: Sendable {
+
+    /// Matches the *start* of a fused token: letter prefix, then 2+ digits.
+    /// Used by both the token-level and text-level entry points. Anything
+    /// after the digit run is preserved verbatim by both code paths.
+    ///
+    /// `\b` anchors at a word boundary so we don't slice into the middle of
+    /// surrounding text. `(?=\D|$)` (after the digits) keeps us from
+    /// matching only part of a longer digit run.
+    private static let pattern = #"\b((?:[\p{Ll}]{2,})|(?:\p{Lu}\p{Ll}+))(\d{2,})(?=\D|$)"#
+
+    private static let regex: NSRegularExpression? = {
+        try? NSRegularExpression(pattern: pattern, options: [])
+    }()
+
+    /// Apply the split to a free-form string. Inserts a single space between
+    /// each fused letter+digit pair. Idempotent: running it on already-split
+    /// text returns the same text.
+    public static func splitInText(_ text: String) -> String {
+        guard let regex, !text.isEmpty else { return text }
+        let range = NSRange(text.startIndex..., in: text)
+        return regex.stringByReplacingMatches(
+            in: text,
+            range: range,
+            withTemplate: "$1 $2"
+        )
+    }
+
+    /// Apply the split to a sequence of word tokens by rewriting each fused
+    /// token's `.word` string to contain an interior space (`"next30"` →
+    /// `"next 30"`). Timing, confidence, speaker id, and token *count* stay
+    /// exactly the same.
+    ///
+    /// Keeping the original `WordTimestamp` (rather than producing two
+    /// timestamps with proportional timing) deliberately avoids inflating
+    /// downstream word counts. The subtitle cue builder uses word count as
+    /// one of its split heuristics; splitting `arms30.` into two timestamps
+    /// would push borderline cues over the cap and create awkward
+    /// single-word trailing cues (`"30."` on its own line) that aren't
+    /// present in the original transcript.
+    ///
+    /// Trailing characters after the digit run (plural `s`, punctuation,
+    /// closing quotes) stay with the numeric half: `high90s,` becomes
+    /// `high 90s,`, never `high 90 s,`.
+    public static func splitWords(_ words: [WordTimestamp]) -> [WordTimestamp] {
+        guard regex != nil else { return words }
+        return words.map { w in
+            guard let parts = splitToken(w.word) else { return w }
+            return WordTimestamp(
+                word: parts.prefix + " " + parts.suffix,
+                startMs: w.startMs,
+                endMs: w.endMs,
+                confidence: w.confidence,
+                speakerId: w.speakerId
+            )
+        }
+    }
+
+    /// Returns `(prefix, suffix)` if `token` matches the fused pattern, else `nil`.
+    /// `prefix` is the alphabetic head; `suffix` is the digits plus anything
+    /// trailing (`s`, punctuation). Splits at most once per token — fused
+    /// stacks like `the30arms40` would only have the first pair separated,
+    /// which we accept as good-enough given how rarely they occur.
+    static func splitToken(_ token: String) -> (prefix: String, suffix: String)? {
+        guard let regex else { return nil }
+        let nsToken = token as NSString
+        let range = NSRange(location: 0, length: nsToken.length)
+        guard let match = regex.firstMatch(in: token, range: range) else { return nil }
+        // Group 1 is the letter prefix; the digit run begins at group 2's start.
+        let prefixRange = match.range(at: 1)
+        let digitsRange = match.range(at: 2)
+        guard prefixRange.location != NSNotFound, digitsRange.location != NSNotFound else { return nil }
+        let prefix = nsToken.substring(with: prefixRange)
+        // Suffix = everything from the start of the digit run to the end of
+        // the original token, so trailing punctuation / plural-s stays put.
+        let suffixStart = digitsRange.location
+        let suffix = nsToken.substring(with: NSRange(location: suffixStart, length: nsToken.length - suffixStart))
+        return (prefix, suffix)
+    }
+}

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -304,6 +304,14 @@ public final class SettingsViewModel {
     }
     public var meetingAutoSaveFolderPath: String?
 
+    /// Subtitle authoring preset applied to SRT/VTT exports (manual + auto-save).
+    /// Persisted under `SubtitleExportPreferences.presetKey`.
+    public var subtitleExportPreset: SubtitlePreset {
+        didSet {
+            SubtitleExportPreferences.setSelectedPreset(subtitleExportPreset, defaults: defaults)
+        }
+    }
+
     // Calendar auto-start (ADR-017)
     //
     // Each `didSet` writes the value through to `UserDefaults`, fires the
@@ -512,6 +520,7 @@ public final class SettingsViewModel {
         meetingAutoSave = defaults.bool(forKey: AutoSaveScope.meeting.enabledKey)
         meetingAutoSaveFormat = AutoSaveFormat(rawValue: defaults.string(forKey: AutoSaveScope.meeting.formatKey) ?? "md") ?? .md
         meetingAutoSaveFolderPath = Self.resolveAutoSaveFolderPath(defaults: defaults, scope: .meeting)
+        subtitleExportPreset = SubtitleExportPreferences.selectedPreset(defaults: defaults)
         calendarAutoStartMode = Self.resolveCalendarAutoStartMode(defaults: defaults)
         calendarReminderMinutes = Self.resolveCalendarReminderMinutes(defaults: defaults)
         meetingTriggerFilter = Self.resolveMeetingTriggerFilter(defaults: defaults)

--- a/Tests/MacParakeetTests/Services/ExportServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/ExportServiceTests.swift
@@ -1151,4 +1151,157 @@ final class ExportServiceTests: XCTestCase {
             status: .completed
         )
     }
+
+    // MARK: - SubtitleExportConfig
+
+    func testSubtitleConfigDefaultMatchesLegacyBehavior() {
+        let words: [WordTimestamp] = (0..<10).map { i in
+            WordTimestamp(
+                word: "word\(i)",
+                startMs: i * 300,
+                endMs: i * 300 + 250,
+                confidence: 0.95,
+                speakerId: nil
+            )
+        }
+        let legacy = exportService.buildSubtitleCues(from: words)
+        let configured = exportService.buildSubtitleCues(from: words, config: .default)
+        XCTAssertEqual(legacy.count, configured.count)
+        for (a, b) in zip(legacy, configured) {
+            XCTAssertEqual(a.startMs, b.startMs)
+            XCTAssertEqual(a.endMs, b.endMs)
+            XCTAssertEqual(a.text, b.text)
+            XCTAssertEqual(a.speakerId, b.speakerId)
+        }
+    }
+
+    func testMinCueDurationExtendsShortCue() {
+        // Single short cue with no follower → should extend to minCueDurationMs.
+        let words = [
+            WordTimestamp(word: "Hi.", startMs: 0, endMs: 200,
+                          confidence: 0.95, speakerId: nil)
+        ]
+        let config = SubtitleExportConfig(minCueDurationMs: 1000, minGapMs: 0)
+        let cues = exportService.buildSubtitleCues(from: words, config: config)
+        XCTAssertEqual(cues.count, 1)
+        XCTAssertGreaterThanOrEqual(cues[0].endMs - cues[0].startMs, 1000)
+    }
+
+    func testMinCueDurationCappedByNextCueStart() {
+        // Two short cues 500ms apart with a 1000ms minimum and 100ms gap. The first
+        // cue can only extend up to nextStart - minGap (i.e. 400ms total duration).
+        let words = [
+            WordTimestamp(word: "Hi.", startMs: 0, endMs: 200,
+                          confidence: 0.95, speakerId: nil),
+            WordTimestamp(word: "Bye.", startMs: 500, endMs: 700,
+                          confidence: 0.95, speakerId: nil)
+        ]
+        let config = SubtitleExportConfig(minCueDurationMs: 1000, minGapMs: 100)
+        let cues = exportService.buildSubtitleCues(from: words, config: config)
+        XCTAssertEqual(cues.count, 2)
+        XCTAssertLessThanOrEqual(cues[0].endMs, 400)
+    }
+
+    func testMinGapShortensOverlappingCues() {
+        // Two cues with no gap → first cue's endMs trimmed so the gap == minGapMs.
+        let cues = [
+            ExportService.SubtitleCue(startMs: 0, endMs: 1000,
+                                      text: "First.", speakerId: nil),
+            ExportService.SubtitleCue(startMs: 1000, endMs: 2000,
+                                      text: "Second.", speakerId: nil)
+        ]
+        let config = SubtitleExportConfig(minCueDurationMs: 100, minGapMs: 200)
+        let result = exportService.enforceMinGapForTesting(cues, config: config)
+        XCTAssertEqual(result[0].endMs, 800)
+        XCTAssertEqual(result[1].startMs, 1000)
+    }
+
+    func testMinGapDoesNotCrushBelowMinDuration() {
+        // Tight pair where honouring the full gap would push the first cue below the
+        // 500ms minimum duration. Expect the cue to hold at its 500ms floor.
+        let cues = [
+            ExportService.SubtitleCue(startMs: 0, endMs: 600,
+                                      text: "First.", speakerId: nil),
+            ExportService.SubtitleCue(startMs: 650, endMs: 1200,
+                                      text: "Second.", speakerId: nil)
+        ]
+        let config = SubtitleExportConfig(minCueDurationMs: 500, minGapMs: 200)
+        let result = exportService.enforceMinGapForTesting(cues, config: config)
+        XCTAssertEqual(result[0].endMs, 500)
+    }
+
+    func testSingleLineModeSplitsInsteadOfWrapping() {
+        // A 14-word cue that would normally wrap into two lines. With maxLines == 1
+        // it should split into two separate cues with no `\n` in either text.
+        let words = (0..<14).map { i in
+            WordTimestamp(
+                word: "word\(i)",
+                startMs: i * 200,
+                endMs: i * 200 + 180,
+                confidence: 0.95,
+                speakerId: nil
+            )
+        }
+        let config = SubtitleExportConfig(maxLines: 1, hardWordCap: 20)
+        let cues = exportService.buildSubtitleCues(from: words, config: config)
+        XCTAssertGreaterThanOrEqual(cues.count, 2)
+        for cue in cues {
+            XCTAssertFalse(cue.text.contains("\n"),
+                           "Single-line mode should not emit newline-wrapped cues")
+        }
+    }
+
+    func testNetflixPresetTriggers17CPSSplit() {
+        // ~30 chars over 1.4s ≈ 21 CPS — passes default 25 but fails Netflix 17.
+        let words = [
+            WordTimestamp(word: "Quick", startMs: 0, endMs: 200,
+                          confidence: 0.95, speakerId: nil),
+            WordTimestamp(word: "brown", startMs: 250, endMs: 450,
+                          confidence: 0.95, speakerId: nil),
+            WordTimestamp(word: "fox", startMs: 500, endMs: 700,
+                          confidence: 0.95, speakerId: nil),
+            WordTimestamp(word: "jumps", startMs: 750, endMs: 950,
+                          confidence: 0.95, speakerId: nil),
+            WordTimestamp(word: "high.", startMs: 1000, endMs: 1400,
+                          confidence: 0.95, speakerId: nil)
+        ]
+        let defaultCues = exportService.buildSubtitleCues(from: words, config: .default)
+        let netflixCues = exportService.buildSubtitleCues(from: words, config: .netflix)
+        XCTAssertEqual(defaultCues.count, 1)
+        XCTAssertGreaterThan(netflixCues.count, 1,
+                             "Netflix preset's 17 CPS limit should split this cue")
+    }
+
+    func testBBCPresetUsesNarrowerLineWrap() {
+        // Text length 39 chars: fits on one line under default (42), wraps under BBC (37).
+        let text = "Squat down and push back up with power."  // 39 chars
+        XCTAssertEqual(text.count, 39)
+        let tokens = text.split(separator: " ").map(String.init)
+        let words = tokens.enumerated().map { (i, w) in
+            WordTimestamp(
+                word: w,
+                startMs: i * 300,
+                endMs: i * 300 + 250,
+                confidence: 0.95,
+                speakerId: nil
+            )
+        }
+        let defaultCues = exportService.buildSubtitleCues(from: words, config: .default)
+        let bbcCues = exportService.buildSubtitleCues(from: words, config: .bbc)
+        XCTAssertFalse(defaultCues.contains(where: { $0.text.contains("\n") }))
+        XCTAssertTrue(bbcCues.contains(where: { $0.text.contains("\n") }),
+                      "BBC preset's 37-char line budget should wrap this cue")
+    }
+}
+
+// Test helpers exposed via @testable. These wrap the private enforcement passes so
+// tests can exercise them on hand-built SubtitleCue arrays without going through
+// the full word-timestamp pipeline.
+extension ExportService {
+    func enforceMinGapForTesting(
+        _ cues: [SubtitleCue],
+        config: SubtitleExportConfig
+    ) -> [SubtitleCue] {
+        enforceMinGap(cues, config: config)
+    }
 }

--- a/Tests/MacParakeetTests/Services/ExportServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/ExportServiceTests.swift
@@ -300,11 +300,16 @@ final class ExportServiceTests: XCTestCase {
     }
 
     func testBuildSubtitleCuesBreaksOnWordCount() {
-        // 14 words with no punctuation — should break at 12
+        // 14 words with no punctuation — should break at 12.
+        // Use letter-only token names so WordNumberSplitter (which splits
+        // letter+digit fusions like `next30`) does not turn `word10` into
+        // two tokens and skew the count.
+        let alphabet = ["aaa", "bbb", "ccc", "ddd", "eee", "fff", "ggg",
+                        "hhh", "iii", "jjj", "kkk", "lll", "mmm", "nnn"]
         var words: [WordTimestamp] = []
-        for i in 0..<14 {
+        for (i, w) in alphabet.enumerated() {
             words.append(WordTimestamp(
-                word: "word\(i)",
+                word: w,
                 startMs: i * 300,
                 endMs: i * 300 + 250,
                 confidence: 0.95

--- a/Tests/MacParakeetTests/Services/ExportServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/ExportServiceTests.swift
@@ -361,6 +361,103 @@ final class ExportServiceTests: XCTestCase {
         XCTAssertEqual(lines.count, 2)
     }
 
+    func testBuildSubtitleCuesStripsLeadingWhitespaceFromTokens() {
+        // Whisper/Parakeet emit tokens with a leading space (" Hello"). Without
+        // sanitization, joining with " " produces "  Hello  world" (double spaces) and
+        // inflates the character count enough to trip the CPS guard on normal cues.
+        let words = [
+            WordTimestamp(word: " Hello", startMs: 0, endMs: 400, confidence: 0.95),
+            WordTimestamp(word: " world.", startMs: 400, endMs: 800, confidence: 0.95),
+        ]
+        let cues = exportService.buildSubtitleCues(from: words)
+        XCTAssertEqual(cues.count, 1)
+        // No leading space, no double space
+        XCTAssertEqual(cues[0].text, "Hello world.")
+    }
+
+    func testBuildSubtitleCuesMergesHyphenContinuations() {
+        // Engines sometimes split "warm-up" as two tokens: "warm" + "-up".
+        let words = [
+            WordTimestamp(word: " The", startMs: 0, endMs: 200, confidence: 0.95),
+            WordTimestamp(word: " warm", startMs: 200, endMs: 500, confidence: 0.95),
+            WordTimestamp(word: " -up.", startMs: 500, endMs: 800, confidence: 0.95),
+        ]
+        let cues = exportService.buildSubtitleCues(from: words)
+        XCTAssertEqual(cues.count, 1)
+        XCTAssertEqual(cues[0].text, "The warm-up.")
+    }
+
+    func testBuildSubtitleCuesCarriesForwardMissingSpeakerId() {
+        // If an engine drops the speakerId mid-utterance, treat the gap as continuation
+        // of the previous speaker rather than emitting a label-less cue.
+        let words = [
+            WordTimestamp(word: "Hello", startMs: 0, endMs: 300, confidence: 0.95, speakerId: "S1"),
+            WordTimestamp(word: "there", startMs: 300, endMs: 600, confidence: 0.95, speakerId: nil),
+            WordTimestamp(word: "friend.", startMs: 600, endMs: 900, confidence: 0.95, speakerId: nil),
+        ]
+        let cues = exportService.buildSubtitleCues(from: words)
+        XCTAssertEqual(cues.count, 1)
+        XCTAssertEqual(cues[0].speakerId, "S1")
+    }
+
+    func testBuildSubtitleCuesLooksBackToCommaOnSoftLimit() {
+        // 14 words, comma after word 7 ("core,"). Without look-back the 12-word soft
+        // limit fires at word 12 ("you") and the cue ends mid-phrase. With look-back
+        // the boundary at the comma (position 6) wins and the cue ends cleanly there.
+        let strings = ["Keep", "your", "back", "straight,",
+                       "engage", "your", "core,",
+                       "and", "breathe", "out",
+                       "as", "you", "push", "up"]
+        let words = strings.enumerated().map { i, w in
+            WordTimestamp(word: w, startMs: i * 300, endMs: i * 300 + 250, confidence: 0.95)
+        }
+
+        let cues = exportService.buildSubtitleCues(from: words)
+        XCTAssertGreaterThanOrEqual(cues.count, 2)
+        let firstFlat = cues[0].text.components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        // First cue should end on a comma-terminated word, not mid-phrase like "you".
+        XCTAssertTrue(firstFlat.hasSuffix(",") || firstFlat.hasSuffix(".") || firstFlat.hasSuffix("!"),
+                      "Expected first cue to end on punctuation via look-back; got '\(firstFlat)'")
+    }
+
+    func testBuildSubtitleCuesSplitsConsecutiveSingleWordImperatives() {
+        // Fitness-style: "Squat. Up. Down." should become three cues, one per command.
+        let strings = ["Squat.", "Up.", "Down."]
+        let words = strings.enumerated().map { i, w in
+            WordTimestamp(word: w, startMs: i * 500, endMs: i * 500 + 400, confidence: 0.95)
+        }
+
+        let cues = exportService.buildSubtitleCues(from: words)
+        XCTAssertEqual(cues.count, 3)
+        XCTAssertEqual(cues[0].text, "Squat.")
+        XCTAssertEqual(cues[1].text, "Up.")
+        XCTAssertEqual(cues[2].text, "Down.")
+    }
+
+    func testWrapLongCuePutsCoordinatingConjunctionOnLineTwo() {
+        // A single sentence with a coordinating "and" mid-way that exceeds the 42-char
+        // single-line budget. After wrapping, the second line should start with "and".
+        let strings = ["Keep", "your", "back", "straight",
+                       "and", "your", "core", "engaged."]
+        let words = strings.enumerated().map { i, w in
+            WordTimestamp(word: w, startMs: i * 300, endMs: i * 300 + 250, confidence: 0.95)
+        }
+
+        let cues = exportService.buildSubtitleCues(from: words)
+        XCTAssertGreaterThanOrEqual(cues.count, 1)
+        // Find the cue containing both halves
+        guard let wrapped = cues.first(where: { $0.text.contains("\n") }) else {
+            XCTFail("Expected at least one wrapped cue")
+            return
+        }
+        let lines = wrapped.text.components(separatedBy: "\n")
+        XCTAssertEqual(lines.count, 2)
+        XCTAssertTrue(lines[1].hasPrefix("and"),
+                      "Expected second line to start with 'and', got '\(lines[1])'")
+    }
+
     func testCPSSplitPrefersPunctuationOverMidpoint() {
         // 8 short words packed into 1.5 seconds — easily over 25 CPS, with a comma
         // at index 3. The smart split should land after the comma rather than at
@@ -883,8 +980,12 @@ final class ExportServiceTests: XCTestCase {
         ]
 
         let srt = exportService.formatSRT(words: words, speakers: speakers)
-        XCTAssertTrue(srt.contains("Alice: Hello. Hi."))
-        XCTAssertTrue(srt.contains("Bob: Goodbye. Bye."))
+        // Single-word imperative breaks now split "Hello. Hi." into separate cues,
+        // so assert each piece appears with its speaker label rather than as merged text.
+        XCTAssertTrue(srt.contains("Alice: Hello."))
+        XCTAssertTrue(srt.contains("Alice: Hi."))
+        XCTAssertTrue(srt.contains("Bob: Goodbye."))
+        XCTAssertTrue(srt.contains("Bob: Bye."))
     }
 
     func testFormatVTTWithSpeakers() {
@@ -901,8 +1002,12 @@ final class ExportServiceTests: XCTestCase {
 
         let vtt = exportService.formatVTT(words: words, speakers: speakers)
         XCTAssertTrue(vtt.hasPrefix("WEBVTT\n"))
-        XCTAssertTrue(vtt.contains("<v Alice>Hello. Hi.</v>"))
-        XCTAssertTrue(vtt.contains("<v Bob>Goodbye. Bye.</v>"))
+        // Single-word imperative breaks split consecutive 1-word sentences into separate
+        // cues, so assert each piece is wrapped in a speaker tag.
+        XCTAssertTrue(vtt.contains("<v Alice>Hello.</v>"))
+        XCTAssertTrue(vtt.contains("<v Alice>Hi.</v>"))
+        XCTAssertTrue(vtt.contains("<v Bob>Goodbye.</v>"))
+        XCTAssertTrue(vtt.contains("<v Bob>Bye.</v>"))
     }
 
     func testCueSplitsOnSpeakerChange() {
@@ -976,7 +1081,10 @@ final class ExportServiceTests: XCTestCase {
 
         XCTAssertTrue(content.contains("Alice:"))
         XCTAssertTrue(content.contains("Bob:"))
-        XCTAssertTrue(content.contains("Hello. Hi."))
+        // Single-word imperative breaks split "Hello." and "Hi." into separate cues,
+        // so check both pieces appear under Alice's heading rather than as merged text.
+        XCTAssertTrue(content.contains("Hello."))
+        XCTAssertTrue(content.contains("Hi."))
         XCTAssertTrue(content.contains("Goodbye."))
     }
 

--- a/Tests/MacParakeetTests/Services/ExportServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/ExportServiceTests.swift
@@ -313,8 +313,73 @@ final class ExportServiceTests: XCTestCase {
 
         let cues = exportService.buildSubtitleCues(from: words)
         XCTAssertEqual(cues.count, 2)
-        XCTAssertEqual(cues[0].text.components(separatedBy: " ").count, 12)
-        XCTAssertEqual(cues[1].text.components(separatedBy: " ").count, 2)
+        // Count tokens by any whitespace — cue text may contain `\n` from line wrapping.
+        let firstTokens = cues[0].text.components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+        let secondTokens = cues[1].text.components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+        XCTAssertEqual(firstTokens.count, 12)
+        XCTAssertEqual(secondTokens.count, 2)
+    }
+
+    func testBuildSubtitleCuesDefersOnBadEnder() {
+        // 12 words where word11 is "and" — without deferral the cue would end on "and".
+        // The bad-ender check should defer the break so the cue ends on "stop" instead.
+        let strings = ["I", "walked", "to", "the", "store", "with",
+                       "my", "friend", "and", "had", "to", "and", "then", "stop"]
+        let words = strings.enumerated().map { i, w in
+            WordTimestamp(word: w, startMs: i * 300, endMs: i * 300 + 250, confidence: 0.95)
+        }
+
+        let cues = exportService.buildSubtitleCues(from: words)
+        // The first cue's last whitespace-separated token must not be a bad-ender.
+        let firstLastToken = cues[0].text
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .last!
+            .lowercased()
+        let badEnders: Set<String> = ["and", "but", "or", "the", "a", "an",
+                                      "in", "on", "at", "to", "of", "with", "from", "by"]
+        XCTAssertFalse(badEnders.contains(firstLastToken),
+                       "First cue ended on bad-ender '\(firstLastToken)'")
+    }
+
+    func testBuildSubtitleCuesWrapsLongCueInto2Lines() {
+        // A single long sentence that fits within the word/duration limits but exceeds
+        // the 42-char line budget should be wrapped into two lines separated by \n.
+        let strings = ["The", "quick", "brown", "fox", "jumped", "over",
+                       "the", "lazy", "dog", "near", "the", "river."]
+        let words = strings.enumerated().map { i, w in
+            WordTimestamp(word: w, startMs: i * 300, endMs: i * 300 + 250, confidence: 0.95)
+        }
+
+        let cues = exportService.buildSubtitleCues(from: words)
+        // First cue should be the full sentence, but text should contain a newline.
+        XCTAssertTrue(cues[0].text.contains("\n"),
+                      "Expected line wrap; got: '\(cues[0].text)'")
+        let lines = cues[0].text.components(separatedBy: "\n")
+        XCTAssertEqual(lines.count, 2)
+    }
+
+    func testCPSSplitPrefersPunctuationOverMidpoint() {
+        // 8 short words packed into 1.5 seconds — easily over 25 CPS, with a comma
+        // at index 3. The smart split should land after the comma rather than at
+        // the midpoint (index 4).
+        let strings = ["alpha", "beta", "gamma", "delta,", "epsilon", "zeta", "eta", "theta"]
+        let words = strings.enumerated().map { i, w in
+            WordTimestamp(word: w, startMs: i * 150, endMs: i * 150 + 100, confidence: 0.95)
+        }
+
+        let cues = exportService.buildSubtitleCues(from: words)
+        XCTAssertGreaterThanOrEqual(cues.count, 2,
+                                    "Expected CPS guard to split fast cue into multiple cues")
+        // The first cue should end with the comma word; smart split favours
+        // comma-ending boundaries over the midpoint.
+        let firstText = cues[0].text.components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        XCTAssertTrue(firstText.hasSuffix("delta,"),
+                      "Expected smart split after 'delta,', got '\(firstText)'")
     }
 
     func testBuildSubtitleCuesEmpty() {

--- a/Tests/MacParakeetTests/TextProcessing/WordNumberSplitterTests.swift
+++ b/Tests/MacParakeetTests/TextProcessing/WordNumberSplitterTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class WordNumberSplitterTests: XCTestCase {
+
+    // MARK: - Text path
+
+    func testSplitsLowercaseLetterPrefixFromDigits() {
+        XCTAssertEqual(WordNumberSplitter.splitInText("next30 minutes"), "next 30 minutes")
+        XCTAssertEqual(WordNumberSplitter.splitInText("the980 range"), "the 980 range")
+        XCTAssertEqual(WordNumberSplitter.splitInText("between80 and90."), "between 80 and 90.")
+    }
+
+    func testKeepsPluralAndPunctuationWithTheNumber() {
+        XCTAssertEqual(WordNumberSplitter.splitInText("high90s,"), "high 90s,")
+        XCTAssertEqual(WordNumberSplitter.splitInText("arms30."), "arms 30.")
+        XCTAssertEqual(WordNumberSplitter.splitInText("to100, then up95"), "to 100, then up 95")
+    }
+
+    func testSplitsTitleCasePrefix() {
+        XCTAssertEqual(WordNumberSplitter.splitInText("Next30 minutes"), "Next 30 minutes")
+        XCTAssertEqual(WordNumberSplitter.splitInText("Hello30"), "Hello 30")
+    }
+
+    func testLeavesCamelCaseAlphanumericsAlone() {
+        // Product names with embedded uppercase should not be touched.
+        XCTAssertEqual(WordNumberSplitter.splitInText("iPhone15"), "iPhone15")
+        XCTAssertEqual(WordNumberSplitter.splitInText("iPad15 vs iPhone15"), "iPad15 vs iPhone15")
+    }
+
+    func testLeavesShortDigitRunsAlone() {
+        // MP3 / v3 / H2O — digit run too short (< 2) or prefix too short.
+        XCTAssertEqual(WordNumberSplitter.splitInText("MP3 player"), "MP3 player")
+        XCTAssertEqual(WordNumberSplitter.splitInText("v3.0 release"), "v3.0 release")
+        XCTAssertEqual(WordNumberSplitter.splitInText("H2O bottle"), "H2O bottle")
+    }
+
+    func testLeavesAllCapsAlphanumericsAlone() {
+        // All-caps prefix (acronyms like LSU30, NASA90) — don't auto-split.
+        XCTAssertEqual(WordNumberSplitter.splitInText("LSU30 jersey"), "LSU30 jersey")
+        XCTAssertEqual(WordNumberSplitter.splitInText("HTTP200 OK"), "HTTP200 OK")
+    }
+
+    func testLeavesDigitPrefixedTokensAlone() {
+        // Tokens that *start* with digits ("90s", "1080p") shouldn't change.
+        XCTAssertEqual(WordNumberSplitter.splitInText("the 90s were great"), "the 90s were great")
+        XCTAssertEqual(WordNumberSplitter.splitInText("rendered at 1080p"), "rendered at 1080p")
+    }
+
+    func testIsIdempotent() {
+        let once = WordNumberSplitter.splitInText("next30 minutes between80 and90.")
+        let twice = WordNumberSplitter.splitInText(once)
+        XCTAssertEqual(once, twice)
+    }
+
+    func testHandlesEmptyAndPlainText() {
+        XCTAssertEqual(WordNumberSplitter.splitInText(""), "")
+        XCTAssertEqual(WordNumberSplitter.splitInText("nothing to split here"), "nothing to split here")
+    }
+
+    // MARK: - Token path
+
+    func testSplitTokenReturnsNilForCleanTokens() {
+        XCTAssertNil(WordNumberSplitter.splitToken("hello"))
+        XCTAssertNil(WordNumberSplitter.splitToken("MP3"))
+        XCTAssertNil(WordNumberSplitter.splitToken("iPhone15"))
+        XCTAssertNil(WordNumberSplitter.splitToken("90s"))
+    }
+
+    func testSplitTokenReturnsParts() {
+        guard let parts = WordNumberSplitter.splitToken("next30") else {
+            XCTFail("expected split for 'next30'")
+            return
+        }
+        XCTAssertEqual(parts.prefix, "next")
+        XCTAssertEqual(parts.suffix, "30")
+    }
+
+    func testSplitTokenKeepsTrailingPunctuationWithSuffix() {
+        let parts = WordNumberSplitter.splitToken("arms30.")
+        XCTAssertEqual(parts?.prefix, "arms")
+        XCTAssertEqual(parts?.suffix, "30.")
+
+        let plural = WordNumberSplitter.splitToken("high90s,")
+        XCTAssertEqual(plural?.prefix, "high")
+        XCTAssertEqual(plural?.suffix, "90s,")
+    }
+
+    // MARK: - WordTimestamp path
+
+    func testSplitWordsRewritesTokenWithInteriorSpace() {
+        let input = [
+            WordTimestamp(word: "next30", startMs: 1000, endMs: 1600, confidence: 0.9, speakerId: "S1")
+        ]
+        let out = WordNumberSplitter.splitWords(input)
+        XCTAssertEqual(out.count, 1)
+        XCTAssertEqual(out[0].word, "next 30")
+        XCTAssertEqual(out[0].startMs, 1000)
+        XCTAssertEqual(out[0].endMs, 1600)
+        XCTAssertEqual(out[0].confidence, 0.9)
+        XCTAssertEqual(out[0].speakerId, "S1")
+    }
+
+    func testSplitWordsLeavesCleanTokensUntouched() {
+        let input = [
+            WordTimestamp(word: "hello", startMs: 0, endMs: 200, confidence: 1, speakerId: nil),
+            WordTimestamp(word: "MP3", startMs: 200, endMs: 400, confidence: 1, speakerId: nil),
+            WordTimestamp(word: "iPhone15", startMs: 400, endMs: 700, confidence: 1, speakerId: nil)
+        ]
+        let out = WordNumberSplitter.splitWords(input)
+        XCTAssertEqual(out, input)
+    }
+
+    func testSplitWordsKeepsPunctuationWithNumber() {
+        let input = [
+            WordTimestamp(word: "arms30.", startMs: 0, endMs: 500, confidence: 0.95, speakerId: nil),
+            WordTimestamp(word: "high90s,", startMs: 500, endMs: 1000, confidence: 0.95, speakerId: nil)
+        ]
+        let out = WordNumberSplitter.splitWords(input)
+        XCTAssertEqual(out.count, 2)
+        XCTAssertEqual(out[0].word, "arms 30.")
+        XCTAssertEqual(out[1].word, "high 90s,")
+    }
+
+    // MARK: - Pipeline integration
+
+    func testPipelineRunsSplitStep() {
+        let pipeline = TextProcessingPipeline()
+        let result = pipeline.process(
+            text: "we'll spend the next30 minutes between80 and90.",
+            customWords: [],
+            snippets: []
+        )
+        XCTAssertEqual(result.text, "We'll spend the next 30 minutes between 80 and 90.")
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a small deterministic post-processing pass that splits Parakeet-fused letter+digit tokens back into separate words (`next30` → `next 30`, `the980` → `the 980`, `high90s,` → `high 90s,`).
- Applied at two layers: `ExportService.sanitizeWordTokens` so SRT/VTT cues render correctly, and `TextProcessingPipeline` so library cards / TXT / MD / JSON also get fixed.
- Conservative on purpose: only triggers on lowercase or title-case prefix ≥ 2 letters followed by a digit run ≥ 2 digits. Leaves `MP3`, `iPhone15`, `H2O`, `v3`, `1080p`, all-caps acronyms, and digit-prefixed tokens (`90s`) untouched.

## Stacked on #305 + #307

This branch is built on top of `subtitle-preset-ui` (which is itself on top of `subtitle-heuristics`). Until those two merge, this PR's diff will show all three commits; once they land the diff narrows to just the splitter commit. Review order should be #305 → #307 → this.

## Background

While hand-testing the subtitle preset PRs against a real 30-minute fitness video, I noticed cues like `welcome in to your intervals in arms30.` and `next30 minutes`. The fused tokens come straight from Parakeet's word output — the model doesn't insert a space between certain content words and adjacent numbers. Tokens observed in one transcript:

```
arms30.   next30   this30   between80   and90.   the980
up95   to100.   to105,   high90s,
```

Picked the deterministic-regex approach over an LLM cleanup pass per ADR-004 (default pipeline stays LLM-free). LLM-based polish remains a worthwhile separate exploration for the displayed-text path; subtitles need careful timestamp alignment that an LLM rewrite would lose.

## Implementation note

The token-level splitter rewrites `WordTimestamp.word` with an *interior space* rather than producing two tokens with proportional timing. The two-token approach inflated downstream word counts and caused borderline cues to spill `"30."` onto a tiny standalone cue. The interior-space approach keeps cue boundaries, word counts, and per-word timestamps byte-identical to pre-split aside from the inserted space.

## Test plan

- [x] `swift test --filter WordNumberSplitterTests` — 16 new tests pass
- [x] `swift test --filter ExportServiceTests` — 92 tests pass (one fixture renamed away from `word\(i)` names to avoid the splitter firing on test data)
- [x] `swift test` — full suite green
- [x] Manual: re-exported the Intervals & Arms 30 video through all four subtitle presets — zero fused tokens remain in any SRT

🤖 Generated with [Claude Code](https://claude.com/claude-code)