### PR TITLE
Fix LM Studio prompt result generation

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -197,6 +197,13 @@ final class AppEnvironmentConfigurer {
             self?.transcriptionViewModel.handleGenerationCompleted(generationID, promptResultID: promptResultID)
         }
 
+        promptResultsViewModel.onGenerationFailed = { [weak self] generationID, replacingPromptResultID in
+            self?.transcriptionViewModel.handleGenerationFailed(
+                generationID,
+                replacingPromptResultID: replacingPromptResultID
+            )
+        }
+
         promptResultsViewModel.onDeletedPromptResult = { [weak self] promptResultID in
             self?.transcriptionViewModel.handlePromptResultDeleted(promptResultID)
         }

--- a/Sources/MacParakeetCore/Services/LLM/LLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLM/LLMClient.swift
@@ -178,10 +178,15 @@ public final class LLMClient: LLMClientProtocol, Sendable {
                             continuation.yield(text)
                         case .done:
                             sawDone = true
+                            try validateStreamCompletion(
+                                providerID: config.id,
+                                sawSentinel: sawDone,
+                                yieldedAnyContent: yieldedAnyContent
+                            )
                             continuation.finish()
                             return
                         case .error(let message):
-                            throw LLMError.streamingError(message)
+                            throw mapStreamingError(message: message)
                         case .skip:
                             break
                         }
@@ -294,6 +299,7 @@ public final class LLMClient: LLMClientProtocol, Sendable {
                     }
 
                     // Ollama streams NDJSON: one JSON object per line
+                    var yieldedAnyContent = false
                     for try await line in bytes.lines {
                         try Task.checkCancellation()
 
@@ -305,21 +311,32 @@ public final class LLMClient: LLMClientProtocol, Sendable {
 
                         // Check for errors
                         if let error = chunk.error {
-                            throw LLMError.streamingError(error)
+                            throw mapStreamingError(message: error)
                         }
 
                         let content = chunk.message.content
                         if !content.isEmpty {
+                            yieldedAnyContent = true
                             continuation.yield(content)
                         }
 
                         // done:true means stream is complete
                         if chunk.done == true {
+                            try validateStreamCompletion(
+                                providerID: config.id,
+                                sawSentinel: true,
+                                yieldedAnyContent: yieldedAnyContent
+                            )
                             continuation.finish()
                             return
                         }
                     }
 
+                    try validateStreamCompletion(
+                        providerID: config.id,
+                        sawSentinel: false,
+                        yieldedAnyContent: yieldedAnyContent
+                    )
                     continuation.finish()
                 } catch {
                     continuation.finish(throwing: error)
@@ -469,12 +486,17 @@ public final class LLMClient: LLMClientProtocol, Sendable {
                             continuation.yield(text)
                         } else if eventType == "message_stop" {
                             sawMessageStop = true
+                            try validateStreamCompletion(
+                                providerID: config.id,
+                                sawSentinel: sawMessageStop,
+                                yieldedAnyContent: yieldedAnyContent
+                            )
                             continuation.finish()
                             return
                         } else if eventType == "error",
                                   let error = json["error"] as? [String: Any],
                                   let message = error["message"] as? String {
-                            throw LLMError.streamingError(message)
+                            throw mapStreamingError(message: message)
                         }
                     }
 
@@ -779,8 +801,12 @@ public final class LLMClient: LLMClientProtocol, Sendable {
 
         guard let data = trimmed.data(using: .utf8) else { return .skip }
 
-        // Ollama can emit {"error": "..."} mid-stream on OOM or model failure.
-        // Detect and surface as a streaming error instead of silently dropping.
+        // Local/OpenAI-compatible servers can emit provider errors mid-stream
+        // instead of returning a non-2xx response. LM Studio, for example,
+        // sends `event: error` followed by a `data:` JSON object whose
+        // `error` field is an object and whose top-level `message` carries
+        // the human-readable context-length failure. Surface those as errors
+        // instead of silently dropping the frame and accepting an empty EOF.
         if let streamError = try? JSONDecoder().decode(StreamErrorResponse.self, from: data),
            let errorMessage = streamError.error {
             return .error(errorMessage)
@@ -842,16 +868,15 @@ public final class LLMClient: LLMClientProtocol, Sendable {
         sawSentinel: Bool,
         yieldedAnyContent: Bool
     ) throws {
+        guard yieldedAnyContent else {
+            throw LLMError.streamingError("stream produced no content before EOF")
+        }
         guard Self.providerEnforcesStreamSentinel(providerID), !sawSentinel else { return }
 
         // EOF before the sentinel from a provider that contractually emits one.
-        // Distinguish "no content at all" (likely auth/connection drop after
-        // headers — usually a backend issue) from "some content delivered"
-        // (mid-response truncation — the user-visible failure mode).
-        let detail = yieldedAnyContent
-            ? "stream ended before completion sentinel — response is truncated"
-            : "stream produced no content before EOF"
-        throw LLMError.streamingError(detail)
+        // Some content delivered means the user is otherwise looking at a
+        // silently truncated output.
+        throw LLMError.streamingError("stream ended before completion sentinel — response is truncated")
     }
 
     private func mapError(statusCode: Int, data: Data) -> LLMError {
@@ -895,6 +920,31 @@ public final class LLMClient: LLMClientProtocol, Sendable {
         default:
             return .providerError(message)
         }
+    }
+
+    private func mapStreamingError(message rawMessage: String) -> LLMError {
+        let message = Self.scrubAPIKeyArtifacts(from: rawMessage)
+        let lowered = message.lowercased()
+
+        if lowered.contains("context")
+            || lowered.contains("tokens to keep")
+            || lowered.contains("too many tokens")
+            || lowered.contains("maximum number of tokens") {
+            return .contextTooLong
+        }
+        if lowered.contains("rate limit") || lowered.contains("rate_limit") {
+            return .rateLimited
+        }
+        if lowered.contains("unauthorized")
+            || lowered.contains("authentication")
+            || lowered.contains("api key") {
+            return .authenticationFailed(message)
+        }
+        if lowered.contains("model")
+            && (lowered.contains("not found") || lowered.contains("does not exist")) {
+            return .modelNotFound(message)
+        }
+        return .streamingError(message)
     }
 
     /// Anthropic Messages API version pin. Anthropic dates each API version;
@@ -1022,9 +1072,41 @@ struct GeminiErrorWrapper: Decodable {
     }
 }
 
-/// Ollama can emit {"error": "..."} mid-stream on OOM or model failure.
+/// Providers can emit error payloads mid-stream. Shapes observed in practice:
+/// - Ollama: `{ "error": "..." }`
+/// - LM Studio: `{ "error": { "message": "..." }, "message": "..." }`
 struct StreamErrorResponse: Decodable {
     let error: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case error
+        case message
+    }
+
+    private struct ErrorObject: Decodable {
+        let message: String?
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let message = try? container.decode(String.self, forKey: .message),
+           !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            error = message
+            return
+        }
+        if let errorMessage = try? container.decode(String.self, forKey: .error),
+           !errorMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            error = errorMessage
+            return
+        }
+        if let errorObject = try? container.decode(ErrorObject.self, forKey: .error),
+           let message = errorObject.message,
+           !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            error = message
+            return
+        }
+        error = nil
+    }
 }
 
 struct ModelsListResponse: Decodable {

--- a/Sources/MacParakeetCore/Services/LLM/LLMService.swift
+++ b/Sources/MacParakeetCore/Services/LLM/LLMService.swift
@@ -78,6 +78,16 @@ public extension LLMServiceProtocol {
 public final class LLMService: LLMServiceProtocol, Sendable {
     private let client: LLMClientProtocol
     private let contextResolver: any LLMExecutionContextResolving
+    private struct MessageAssembly {
+        let messages: [ChatMessage]
+        let inputTruncated: Bool
+    }
+
+    private struct ChatSystemPromptBuild {
+        let prompt: String
+        let inputTruncated: Bool
+    }
+
     private static let lmStudioFormatterSchema = ChatJSONSchema(
         type: "object",
         properties: [
@@ -95,6 +105,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
     // un-truncated. ~3.5 chars/token in English.
     internal static let cloudContextBudget = 500_000   // ≈140K tokens
     internal static let localContextBudget =  80_000   // ≈ 22K tokens
+    internal static let lmStudioContextBudget = 8_000  // ≈2K tokens; LM Studio defaults vary by loaded model
 
     public init(
         client: LLMClientProtocol = RoutingLLMClient(),
@@ -167,12 +178,8 @@ public final class LLMService: LLMServiceProtocol, Sendable {
             messageCount: 2
         )
         let config = context.providerConfig
-        let budget = contextBudget(for: config)
-        let truncated = Self.truncateMiddle(transcript, limit: budget)
-        let messages = [
-            ChatMessage(role: .system, content: resolveSummaryPrompt(systemPrompt)),
-            ChatMessage(role: .user, content: truncated),
-        ]
+        let assembly = buildPromptResultMessages(transcript: transcript, systemPrompt: systemPrompt, config: config)
+        let messages = assembly.messages
         do {
             let response = try await client.chatCompletion(messages: messages, context: context, options: .default)
             let latencyMs = Self.latencyMs(since: startedAt)
@@ -186,7 +193,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                 startedAt: startedAt,
                 inputChars: transcript.count,
                 outputChars: response.content.count,
-                inputTruncated: transcript.count > budget,
+                inputTruncated: assembly.inputTruncated,
                 promptDefaultUsed: promptDefaultUsed,
                 messageCount: messages.count
             )
@@ -201,7 +208,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                     outcome: .cancelled,
                     startedAt: startedAt,
                     inputChars: transcript.count,
-                    inputTruncated: transcript.count > budget,
+                    inputTruncated: assembly.inputTruncated,
                     promptDefaultUsed: promptDefaultUsed,
                     messageCount: messages.count
                 )
@@ -225,7 +232,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                     outcome: .failure,
                     startedAt: startedAt,
                     inputChars: transcript.count,
-                    inputTruncated: transcript.count > budget,
+                    inputTruncated: assembly.inputTruncated,
                     promptDefaultUsed: promptDefaultUsed,
                     messageCount: messages.count,
                     errorType: kind
@@ -247,8 +254,14 @@ public final class LLMService: LLMServiceProtocol, Sendable {
             messageCount: history.count + 1
         )
         let config = context.providerConfig
-        let messages = buildChatMessages(question: question, transcript: transcript, userNotes: userNotes, history: history, config: config)
-        let budget = contextBudget(for: config)
+        let assembly = buildChatMessages(
+            question: question,
+            transcript: transcript,
+            userNotes: userNotes,
+            history: history,
+            config: config
+        )
+        let messages = assembly.messages
         do {
             let response = try await client.chatCompletion(messages: messages, context: context, options: .default)
             let latencyMs = Self.latencyMs(since: startedAt)
@@ -262,7 +275,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                 startedAt: startedAt,
                 inputChars: question.count + transcript.count,
                 outputChars: response.content.count,
-                inputTruncated: transcript.count > budget,
+                inputTruncated: assembly.inputTruncated,
                 messageCount: history.count + 1
             )
             return LLMResult(response: response, provider: config.id, latencyMs: latencyMs)
@@ -276,7 +289,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                     outcome: .cancelled,
                     startedAt: startedAt,
                     inputChars: question.count + transcript.count,
-                    inputTruncated: transcript.count > budget,
+                    inputTruncated: assembly.inputTruncated,
                     messageCount: history.count + 1
                 )
             } else {
@@ -299,7 +312,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                     outcome: .failure,
                     startedAt: startedAt,
                     inputChars: question.count + transcript.count,
-                    inputTruncated: transcript.count > budget,
+                    inputTruncated: assembly.inputTruncated,
                     messageCount: history.count + 1,
                     errorType: kind
                 )
@@ -320,12 +333,8 @@ public final class LLMService: LLMServiceProtocol, Sendable {
             messageCount: 2
         )
         let config = context.providerConfig
-        let budget = contextBudget(for: config)
-        let truncated = Self.truncateMiddle(text, limit: budget)
-        let messages = [
-            ChatMessage(role: .system, content: Prompts.transform),
-            ChatMessage(role: .user, content: "Transform the following text according to this instruction: \(prompt)\n\n---\n\n\(truncated)"),
-        ]
+        let assembly = buildTransformMessages(text: text, prompt: prompt, config: config)
+        let messages = assembly.messages
         do {
             let response = try await client.chatCompletion(messages: messages, context: context, options: .default)
             let latencyMs = Self.latencyMs(since: startedAt)
@@ -339,7 +348,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                 startedAt: startedAt,
                 inputChars: text.count + prompt.count,
                 outputChars: response.content.count,
-                inputTruncated: text.count > budget,
+                inputTruncated: assembly.inputTruncated,
                 messageCount: messages.count
             )
             return LLMResult(response: response, provider: config.id, latencyMs: latencyMs)
@@ -353,7 +362,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                     outcome: .cancelled,
                     startedAt: startedAt,
                     inputChars: text.count + prompt.count,
-                    inputTruncated: text.count > budget,
+                    inputTruncated: assembly.inputTruncated,
                     messageCount: messages.count
                 )
             } else {
@@ -376,7 +385,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                     outcome: .failure,
                     startedAt: startedAt,
                     inputChars: text.count + prompt.count,
-                    inputTruncated: text.count > budget,
+                    inputTruncated: assembly.inputTruncated,
                     messageCount: messages.count,
                     errorType: kind
                 )
@@ -583,13 +592,13 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                     }
                     let config = context.providerConfig
                     provider = config.id.rawValue
-                    let budget = self.contextBudget(for: config)
-                    inputTruncated = transcript.count > budget
-                    let truncated = Self.truncateMiddle(transcript, limit: budget)
-                    let messages = [
-                        ChatMessage(role: .system, content: self.resolveSummaryPrompt(systemPrompt)),
-                        ChatMessage(role: .user, content: truncated),
-                    ]
+                    let assembly = self.buildPromptResultMessages(
+                        transcript: transcript,
+                        systemPrompt: systemPrompt,
+                        config: config
+                    )
+                    inputTruncated = assembly.inputTruncated
+                    let messages = assembly.messages
                     let stream = self.client.chatCompletionStream(messages: messages, context: context, options: .default)
                     for try await token in stream {
                         outputChars += token.count
@@ -679,8 +688,15 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                     }
                     let config = context.providerConfig
                     provider = config.id.rawValue
-                    inputTruncated = transcript.count > self.contextBudget(for: config)
-                    let messages = self.buildChatMessages(question: question, transcript: transcript, userNotes: userNotes, history: history, config: config)
+                    let assembly = self.buildChatMessages(
+                        question: question,
+                        transcript: transcript,
+                        userNotes: userNotes,
+                        history: history,
+                        config: config
+                    )
+                    inputTruncated = assembly.inputTruncated
+                    let messages = assembly.messages
                     let stream = self.client.chatCompletionStream(messages: messages, context: context, options: .default)
                     for try await token in stream {
                         outputChars += token.count
@@ -767,13 +783,9 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                     }
                     let config = context.providerConfig
                     provider = config.id.rawValue
-                    let budget = self.contextBudget(for: config)
-                    inputTruncated = text.count > budget
-                    let truncated = Self.truncateMiddle(text, limit: budget)
-                    let messages = [
-                        ChatMessage(role: .system, content: Prompts.transform),
-                        ChatMessage(role: .user, content: "Transform the following text according to this instruction: \(prompt)\n\n---\n\n\(truncated)"),
-                    ]
+                    let assembly = self.buildTransformMessages(text: text, prompt: prompt, config: config)
+                    inputTruncated = assembly.inputTruncated
+                    let messages = assembly.messages
                     let stream = self.client.chatCompletionStream(messages: messages, context: context, options: .default)
                     for try await token in stream {
                         outputChars += token.count
@@ -870,7 +882,61 @@ public final class LLMService: LLMServiceProtocol, Sendable {
     }
 
     private func contextBudget(for config: LLMProviderConfig) -> Int {
-        config.isLocal ? Self.localContextBudget : Self.cloudContextBudget
+        if config.id == .lmstudio {
+            return Self.lmStudioContextBudget
+        }
+        return config.isLocal ? Self.localContextBudget : Self.cloudContextBudget
+    }
+
+    private func transcriptBudget(totalBudget: Int, systemPrompt: String) -> Int {
+        max(0, totalBudget - systemPrompt.count)
+    }
+
+    private func buildPromptResultMessages(
+        transcript: String,
+        systemPrompt: String?,
+        config: LLMProviderConfig
+    ) -> MessageAssembly {
+        let budget = contextBudget(for: config)
+        let resolvedPrompt = resolveSummaryPrompt(systemPrompt)
+        let promptWasTruncated = resolvedPrompt.count > budget
+        let boundedPrompt = promptWasTruncated
+            ? Self.truncateMiddle(resolvedPrompt, limit: budget)
+            : resolvedPrompt
+        let transcriptBudget = transcriptBudget(totalBudget: budget, systemPrompt: boundedPrompt)
+        let truncated = Self.truncateMiddle(transcript, limit: transcriptBudget)
+        return MessageAssembly(
+            messages: [
+                ChatMessage(role: .system, content: boundedPrompt),
+                ChatMessage(role: .user, content: truncated),
+            ],
+            inputTruncated: promptWasTruncated || transcript.count > transcriptBudget
+        )
+    }
+
+    private func buildTransformMessages(
+        text: String,
+        prompt: String,
+        config: LLMProviderConfig
+    ) -> MessageAssembly {
+        let systemPrompt = Prompts.transform
+        let instructionPrefix = "Transform the following text according to this instruction: "
+        let separator = "\n\n---\n\n"
+        let available = max(
+            0,
+            contextBudget(for: config) - systemPrompt.count - instructionPrefix.count - separator.count
+        )
+        let promptBudget = prompt.count <= available ? prompt.count : available / 2
+        let boundedPrompt = Self.truncateMiddle(prompt, limit: promptBudget)
+        let textBudget = max(0, available - boundedPrompt.count)
+        let truncated = Self.truncateMiddle(text, limit: textBudget)
+        return MessageAssembly(
+            messages: [
+                ChatMessage(role: .system, content: systemPrompt),
+                ChatMessage(role: .user, content: "\(instructionPrefix)\(boundedPrompt)\(separator)\(truncated)"),
+            ],
+            inputTruncated: prompt.count > promptBudget || text.count > textBudget
+        )
     }
 
     private func resolveSummaryPrompt(_ systemPrompt: String?) -> String {
@@ -975,14 +1041,15 @@ public final class LLMService: LLMServiceProtocol, Sendable {
         userNotes: String?,
         history: [ChatMessage],
         config: LLMProviderConfig
-    ) -> [ChatMessage] {
+    ) -> MessageAssembly {
         let budget = contextBudget(for: config)
-        let systemPrompt = Self.buildChatSystemPrompt(
+        let systemPromptBuild = Self.buildChatSystemPrompt(
             transcript: transcript,
             userNotes: userNotes,
             question: question,
             budget: budget
         )
+        let systemPrompt = systemPromptBuild.prompt
 
         var messages = [ChatMessage(role: .system, content: systemPrompt)]
 
@@ -1015,10 +1082,14 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                 keptTurns.insert([message], at: 0)
             }
         }
-        messages.append(contentsOf: keptTurns.flatMap { $0 })
+        let keptHistory = keptTurns.flatMap { $0 }
+        messages.append(contentsOf: keptHistory)
 
         messages.append(ChatMessage(role: .user, content: question))
-        return messages
+        return MessageAssembly(
+            messages: messages,
+            inputTruncated: systemPromptBuild.inputTruncated || keptHistory.count < history.count
+        )
     }
 
     private static func requestMessage(from message: ChatMessage) -> ChatMessage {
@@ -1030,7 +1101,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
         userNotes: String?,
         question: String,
         budget: Int
-    ) -> String {
+    ) -> ChatSystemPromptBuild {
         let trimmedNotes = userNotes?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let transcriptHeader = "\n\n---\nTranscript:\n"
         let notesHeader = "\n\n---\nUser's notes from the meeting (treat these as what the user thinks matters; the transcript is the source of truth for facts):\n"
@@ -1038,11 +1109,14 @@ public final class LLMService: LLMServiceProtocol, Sendable {
         let contextBudget = max(0, budget - Prompts.chat.count - question.count - historyReserve)
 
         let notesBlock: String
+        let notesWasTruncated: Bool
         if trimmedNotes.isEmpty {
             notesBlock = ""
+            notesWasTruncated = false
         } else {
             let notesTextBudget = max(0, min(trimmedNotes.count, contextBudget / 4))
             notesBlock = notesHeader + truncateMiddle(trimmedNotes, limit: notesTextBudget)
+            notesWasTruncated = trimmedNotes.count > notesTextBudget
         }
 
         let transcriptBudget = max(0, contextBudget - notesBlock.count - transcriptHeader.count)
@@ -1052,7 +1126,10 @@ public final class LLMService: LLMServiceProtocol, Sendable {
             ? truncateMiddle(context, limit: contextBudget)
             : context
 
-        return Prompts.chat + boundedContext
+        return ChatSystemPromptBuild(
+            prompt: Prompts.chat + boundedContext,
+            inputTruncated: notesWasTruncated || transcript.count > transcriptBudget || context.count > contextBudget
+        )
     }
 
     /// Truncate text from the middle, keeping the head and tail within the limit.

--- a/Sources/MacParakeetViewModels/PromptResultsViewModel.swift
+++ b/Sources/MacParakeetViewModels/PromptResultsViewModel.swift
@@ -69,6 +69,7 @@ public final class PromptResultsViewModel {
     public var onModelChanged: (() -> Void)?
     public var onPromptResultsChanged: ((UUID, Bool) -> Void)?
     public var onGenerationCompleted: ((UUID, UUID) -> Void)?
+    public var onGenerationFailed: ((UUID, UUID?) -> Void)?
     public var onDeletedPromptResult: ((UUID) -> Void)?
     public var shouldMarkPromptResultUnread: ((UUID) -> Bool)?
 
@@ -441,6 +442,9 @@ public final class PromptResultsViewModel {
         }
 
         let generation = pendingGenerations[index]
+        guard generation.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false else {
+            throw LLMError.streamingError("prompt result returned an empty response")
+        }
         let timestamp = Date()
         let promptResult = PromptResult(
             id: generation.id,
@@ -462,6 +466,7 @@ public final class PromptResultsViewModel {
 
         pendingGenerations.remove(at: index)
         streamingTask = nil
+        errorMessage = nil
 
         if currentTranscriptionID == generation.transcriptionId {
             if let replacingPromptResultID = generation.replacingPromptResultID {
@@ -493,11 +498,15 @@ public final class PromptResultsViewModel {
 
     private func finishFailedGeneration(id generationID: UUID, error: Error) {
         logger.error("Failed to generate prompt result error=\(error.localizedDescription, privacy: .public)")
+        let replacingPromptResultID = pendingGenerations
+            .first(where: { $0.id == generationID })?
+            .replacingPromptResultID
         if let index = pendingGenerations.firstIndex(where: { $0.id == generationID }) {
             pendingGenerations.remove(at: index)
         }
         streamingTask = nil
         errorMessage = error.localizedDescription
+        onGenerationFailed?(generationID, replacingPromptResultID)
         processNextQueuedGeneration()
     }
 

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -101,6 +101,15 @@ public final class TranscriptionViewModel {
         selectedTab = .result(id: promptResultID)
     }
 
+    public func handleGenerationFailed(_ generationID: UUID, replacingPromptResultID: UUID?) {
+        guard case .generation(let selectedID) = selectedTab, selectedID == generationID else { return }
+        if let replacingPromptResultID {
+            selectedTab = .result(id: replacingPromptResultID)
+        } else {
+            selectedTab = .transcript
+        }
+    }
+
     private var transcriptionService: TranscriptionServiceProtocol?
     private var transcriptionRepo: TranscriptionRepositoryProtocol?
     private var promptResultRepo: PromptResultRepositoryProtocol?

--- a/Tests/MacParakeetTests/Services/LLM/LLMClientTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMClientTests.swift
@@ -597,6 +597,17 @@ final class LLMClientTests: XCTestCase {
         }
     }
 
+    func testParseSSELineLMStudioErrorObject() {
+        let result = llmClient.parseSSELine("""
+        data: {"error":{"message":"The number of tokens to keep from the initial prompt is greater than the context length."},"message":"The number of tokens to keep from the initial prompt is greater than the context length."}
+        """)
+        if case .error(let message) = result {
+            XCTAssertTrue(message.contains("context length"))
+        } else {
+            XCTFail("Expected .error, got \(result)")
+        }
+    }
+
     func testParseSSELineDataWithNoSpace() {
         let result = llmClient.parseSSELine("data:{\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}")
         if case .content(let text) = result {
@@ -674,6 +685,25 @@ final class LLMClientTests: XCTestCase {
                 ),
                 "Lenient provider \(provider) should not throw on missing sentinel"
             )
+        }
+    }
+
+    func testValidateStreamCompletionThrowsWhenLenientProviderYieldsNoContent() {
+        for provider in [LLMProviderID.gemini, .openaiCompatible, .lmstudio, .ollama, .localCLI] {
+            XCTAssertThrowsError(
+                try llmClient.validateStreamCompletion(
+                    providerID: provider,
+                    sawSentinel: false,
+                    yieldedAnyContent: false
+                ),
+                "Provider \(provider) should not treat an empty stream as success"
+            ) { error in
+                guard let llmError = error as? LLMError, case .streamingError(let detail) = llmError else {
+                    XCTFail("Expected LLMError.streamingError for \(provider), got \(error)")
+                    return
+                }
+                XCTAssertTrue(detail.contains("no content"), "Detail should mention no content; got: \(detail)")
+            }
         }
     }
 
@@ -1021,6 +1051,81 @@ final class LLMClientTests: XCTestCase {
             XCTAssertEqual(msg, "out of memory")
         } else {
             XCTFail("Expected .error, got \(result)")
+        }
+    }
+
+    func testChatCompletionStreamThrowsWhenDoneArrivesWithoutContent() async throws {
+        MockURLProtocol.handler = { request in
+            (self.okResponse(for: request), Data("data: [DONE]\n\n".utf8))
+        }
+
+        let stream = llmClient.chatCompletionStream(
+            messages: [ChatMessage(role: .user, content: "Hi")],
+            config: .openai(apiKey: "sk-test"),
+            options: .default
+        )
+
+        do {
+            for try await _ in stream {}
+            XCTFail("Expected empty stream to throw")
+        } catch let error as LLMError {
+            guard case .streamingError(let detail) = error else {
+                XCTFail("Expected streamingError, got \(error)")
+                return
+            }
+            XCTAssertTrue(detail.contains("no content"))
+        }
+    }
+
+    func testChatCompletionStreamMapsLMStudioContextStreamError() async throws {
+        MockURLProtocol.handler = { request in
+            let body = """
+            event: error
+            data: {"error":{"message":"The number of tokens to keep from the initial prompt is greater than the context length."},"message":"The number of tokens to keep from the initial prompt is greater than the context length."}
+
+            """
+            return (self.okResponse(for: request), Data(body.utf8))
+        }
+
+        let stream = llmClient.chatCompletionStream(
+            messages: [ChatMessage(role: .user, content: "Hi")],
+            config: .lmstudio(model: "qwen/qwen3-4b-2507"),
+            options: .default
+        )
+
+        do {
+            for try await _ in stream {}
+            XCTFail("Expected LM Studio context stream error")
+        } catch let error as LLMError {
+            guard case .contextTooLong = error else {
+                XCTFail("Expected contextTooLong, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testChatCompletionStreamScrubsStreamErrorMessage() async throws {
+        MockURLProtocol.handler = { request in
+            let body = "data: {\"error\":\"backend leaked sk-1234567890abcdef\"}\n\n"
+            return (self.okResponse(for: request), Data(body.utf8))
+        }
+
+        let stream = llmClient.chatCompletionStream(
+            messages: [ChatMessage(role: .user, content: "Hi")],
+            config: .openai(apiKey: "sk-test"),
+            options: .default
+        )
+
+        do {
+            for try await _ in stream {}
+            XCTFail("Expected stream error")
+        } catch let error as LLMError {
+            guard case .streamingError(let detail) = error else {
+                XCTFail("Expected streamingError, got \(error)")
+                return
+            }
+            XCTAssertFalse(detail.contains("sk-1234567890abcdef"))
+            XCTAssertTrue(detail.contains("<api-key>"))
         }
     }
 

--- a/Tests/MacParakeetTests/Services/LLM/LLMServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMServiceTests.swift
@@ -756,6 +756,10 @@ final class LLMServiceTests: XCTestCase {
         XCTAssertEqual(LLMService.localContextBudget, 80_000)
     }
 
+    func testLMStudioContextBudget() {
+        XCTAssertEqual(LLMService.lmStudioContextBudget, 8_000)
+    }
+
     func testLocalProviderUsesLocalBudget() async throws {
         mockConfigStore.config = .ollama(model: "llama3.2")
 
@@ -766,6 +770,87 @@ final class LLMServiceTests: XCTestCase {
         // The user message should be truncated
         let userMessage = mockClient.capturedMessages.last!
         XCTAssertTrue(userMessage.content.contains("[... content truncated ...]"))
+    }
+
+    func testLMStudioPromptResultUsesConservativeBudgetIncludingSystemPrompt() async throws {
+        mockConfigStore.config = .lmstudio(model: "qwen/qwen3-4b-2507")
+
+        let text = String(repeating: "word ", count: 3_000)
+        _ = try await service.generatePromptResultDetailed(
+            transcript: text,
+            systemPrompt: "Extract the action items."
+        )
+
+        let systemMessage = try XCTUnwrap(mockClient.capturedMessages.first)
+        let userMessage = try XCTUnwrap(mockClient.capturedMessages.last)
+        XCTAssertTrue(userMessage.content.contains("[... content truncated ...]"))
+        XCTAssertLessThanOrEqual(
+            userMessage.content.count,
+            LLMService.lmStudioContextBudget - systemMessage.content.count
+        )
+    }
+
+    func testLMStudioPromptResultBoundsRenderedSystemPromptContainingTranscript() async throws {
+        mockConfigStore.config = .lmstudio(model: "qwen/qwen3-4b-2507")
+
+        let transcript = String(repeating: "word ", count: 3_000)
+        _ = try await service.generatePromptResultDetailed(
+            transcript: transcript,
+            systemPrompt: "Read this inline transcript:\n\(transcript)"
+        )
+
+        let systemMessage = try XCTUnwrap(mockClient.capturedMessages.first)
+        let userMessage = try XCTUnwrap(mockClient.capturedMessages.last)
+        XCTAssertLessThanOrEqual(
+            systemMessage.content.count + userMessage.content.count,
+            LLMService.lmStudioContextBudget
+        )
+        XCTAssertTrue(systemMessage.content.contains("[... content truncated ...]"))
+        XCTAssertEqual(userMessage.content, "")
+    }
+
+    func testLMStudioStreamingPromptResultUsesConservativeBudgetIncludingSystemPrompt() async throws {
+        mockConfigStore.config = .lmstudio(model: "qwen/qwen3-4b-2507")
+        mockClient.streamTokens = ["done"]
+
+        let text = String(repeating: "word ", count: 3_000)
+        let stream = service.generatePromptResultStream(
+            transcript: text,
+            systemPrompt: "Extract the action items."
+        )
+        for try await _ in stream {}
+
+        let systemMessage = try XCTUnwrap(mockClient.capturedMessages.first)
+        let userMessage = try XCTUnwrap(mockClient.capturedMessages.last)
+        XCTAssertTrue(userMessage.content.contains("[... content truncated ...]"))
+        XCTAssertLessThanOrEqual(
+            userMessage.content.count,
+            LLMService.lmStudioContextBudget - systemMessage.content.count
+        )
+    }
+
+    func testLMStudioTransformSubtractsPromptOverheadFromTextBudget() async throws {
+        mockConfigStore.config = .lmstudio(model: "qwen/qwen3-4b-2507")
+
+        let text = String(repeating: "word ", count: 3_000)
+        _ = try await service.transformDetailed(text: text, prompt: "Make it concise.")
+
+        let totalMessageChars = mockClient.capturedMessages.reduce(0) { $0 + $1.content.count }
+        XCTAssertLessThanOrEqual(totalMessageChars, LLMService.lmStudioContextBudget)
+        XCTAssertTrue(mockClient.capturedMessages.last?.content.contains("[... content truncated ...]") == true)
+    }
+
+    func testLMStudioStreamingTransformSubtractsPromptOverheadFromTextBudget() async throws {
+        mockConfigStore.config = .lmstudio(model: "qwen/qwen3-4b-2507")
+        mockClient.streamTokens = ["done"]
+
+        let text = String(repeating: "word ", count: 3_000)
+        let stream = service.transformStream(text: text, prompt: "Make it concise.")
+        for try await _ in stream {}
+
+        let totalMessageChars = mockClient.capturedMessages.reduce(0) { $0 + $1.content.count }
+        XCTAssertLessThanOrEqual(totalMessageChars, LLMService.lmStudioContextBudget)
+        XCTAssertTrue(mockClient.capturedMessages.last?.content.contains("[... content truncated ...]") == true)
     }
 
     func testCloudProviderDoesNotTruncateWithinBudget() async throws {

--- a/Tests/MacParakeetTests/ViewModels/PromptResultsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/PromptResultsViewModelTests.swift
@@ -80,6 +80,76 @@ final class PromptResultsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.promptResults.first?.content, "Task one")
     }
 
+    func testGeneratePromptResultDoesNotPersistEmptyStream() async throws {
+        let transcriptionID = UUID()
+        let prompt = Prompt(
+            name: "Action Items",
+            content: "Extract action items only.",
+            category: .result,
+            isBuiltIn: false,
+            sortOrder: 99
+        )
+        promptRepo.prompts.append(prompt)
+
+        viewModel.configure(
+            llmService: llm,
+            promptRepo: promptRepo,
+            promptResultRepo: promptResultRepo
+        )
+        viewModel.selectedPrompt = prompt
+        llm.streamTokens = []
+
+        viewModel.generatePromptResult(
+            transcript: "Alice will send the draft tomorrow.",
+            transcriptionId: transcriptionID
+        )
+
+        try await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertTrue(promptResultRepo.saveCalls.isEmpty)
+        XCTAssertTrue(viewModel.promptResults.isEmpty)
+        XCTAssertTrue(viewModel.pendingGenerations.isEmpty)
+        XCTAssertTrue(viewModel.errorMessage?.contains("empty response") == true)
+    }
+
+    func testSuccessfulQueuedGenerationClearsEarlierEmptyStreamError() async throws {
+        let transcriptionID = UUID()
+        let firstPrompt = Prompt(
+            name: "Action Items",
+            content: "Extract action items only.",
+            category: .result,
+            isBuiltIn: false,
+            sortOrder: 99
+        )
+        let secondPrompt = Prompt(
+            name: "Decisions",
+            content: "Extract decisions only.",
+            category: .result,
+            isBuiltIn: false,
+            sortOrder: 100
+        )
+        promptRepo.prompts.append(contentsOf: [firstPrompt, secondPrompt])
+
+        viewModel.configure(
+            llmService: llm,
+            promptRepo: promptRepo,
+            promptResultRepo: promptResultRepo
+        )
+        llm.streamTokenBatches = [[], ["Recovered"]]
+
+        viewModel.selectedPrompt = firstPrompt
+        viewModel.generatePromptResult(transcript: "Transcript", transcriptionId: transcriptionID)
+        viewModel.selectedPrompt = secondPrompt
+        viewModel.generatePromptResult(transcript: "Transcript", transcriptionId: transcriptionID)
+
+        try await Task.sleep(for: .milliseconds(300))
+
+        XCTAssertEqual(promptResultRepo.saveCalls.count, 1)
+        XCTAssertEqual(promptResultRepo.saveCalls.first?.promptName, "Decisions")
+        XCTAssertEqual(promptResultRepo.saveCalls.first?.content, "Recovered")
+        XCTAssertNil(viewModel.errorMessage)
+    }
+
     func testUnreadPromptResultsTrackMultipleCompletedResults() async throws {
         let transcriptionID = UUID()
         let secondPrompt = Prompt(
@@ -163,6 +233,44 @@ final class PromptResultsViewModelTests: XCTestCase {
         XCTAssertEqual(promptResultRepo.promptResults.first?.content, "New summary")
         XCTAssertEqual(viewModel.promptResults.first?.content, "New summary")
         XCTAssertEqual(viewModel.promptResults.first?.id, generationID)
+    }
+
+    func testRegenerateEmptyStreamKeepsExistingResultAndReportsFailedGeneration() async throws {
+        let transcriptionID = UUID()
+        let existing = PromptResult(
+            transcriptionId: transcriptionID,
+            promptName: "General Summary",
+            promptContent: Prompt.defaultPrompt.content,
+            content: "Old summary"
+        )
+        promptResultRepo.promptResults = [existing]
+
+        viewModel.configure(
+            llmService: llm,
+            promptRepo: promptRepo,
+            promptResultRepo: promptResultRepo
+        )
+        viewModel.loadPromptResults(transcriptionId: transcriptionID)
+        llm.streamTokens = []
+        var failedGeneration: (UUID, UUID?)?
+        viewModel.onGenerationFailed = { generationID, replacingPromptResultID in
+            failedGeneration = (generationID, replacingPromptResultID)
+        }
+
+        let generationID = try XCTUnwrap(viewModel.regeneratePromptResult(existing, transcript: "Transcript"))
+
+        try await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertTrue(promptResultRepo.replaceCalls.isEmpty)
+        XCTAssertEqual(promptResultRepo.promptResults.count, 1)
+        XCTAssertEqual(promptResultRepo.promptResults.first?.id, existing.id)
+        XCTAssertEqual(promptResultRepo.promptResults.first?.content, "Old summary")
+        XCTAssertEqual(viewModel.promptResults.count, 1)
+        XCTAssertEqual(viewModel.promptResults.first?.id, existing.id)
+        XCTAssertEqual(viewModel.promptResults.first?.content, "Old summary")
+        XCTAssertEqual(failedGeneration?.0, generationID)
+        XCTAssertEqual(failedGeneration?.1, existing.id)
+        XCTAssertTrue(viewModel.errorMessage?.contains("empty response") == true)
     }
 
     func testDeletePromptResultRemovesResultAndKeepsRemainingPromptResults() throws {

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -682,6 +682,25 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.hasConversations)
     }
 
+    func testFailedRegenerationRestoresOriginalResultTab() {
+        let generationID = UUID()
+        let promptResultID = UUID()
+        viewModel.selectedTab = .generation(id: generationID)
+
+        viewModel.handleGenerationFailed(generationID, replacingPromptResultID: promptResultID)
+
+        XCTAssertEqual(viewModel.selectedTab, .result(id: promptResultID))
+    }
+
+    func testFailedNewGenerationFallsBackToTranscriptTab() {
+        let generationID = UUID()
+        viewModel.selectedTab = .generation(id: generationID)
+
+        viewModel.handleGenerationFailed(generationID, replacingPromptResultID: nil)
+
+        XCTAssertEqual(viewModel.selectedTab, .transcript)
+    }
+
     // MARK: - File Drop
 
     func testHandleFileDropReturnsFalseWhenAlreadyTranscribing() {

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -586,6 +586,7 @@ final class MockLLMService: LLMServiceProtocol, @unchecked Sendable {
     var formatTranscriptStopReason: String?
     var formatTranscriptLatencyMs = 0
     var streamTokens: [String] = ["Hello", " world"]
+    var streamTokenBatches: [[String]] = []
     var streamDelayNs: UInt64 = 0
     var errorToThrow: Error?
     var summarizeCallCount = 0
@@ -681,7 +682,12 @@ final class MockLLMService: LLMServiceProtocol, @unchecked Sendable {
     func generatePromptResultStream(transcript: String, systemPrompt: String?) -> AsyncThrowingStream<String, Error> {
         summarizeCallCount += 1
         lastSummarySystemPrompt = systemPrompt
-        let tokens = streamTokens
+        let tokens: [String]
+        if streamTokenBatches.isEmpty {
+            tokens = streamTokens
+        } else {
+            tokens = streamTokenBatches.removeFirst()
+        }
         let error = errorToThrow
         let delay = streamDelayNs
         return AsyncThrowingStream { continuation in

--- a/spec/11-llm-integration.md
+++ b/spec/11-llm-integration.md
@@ -281,7 +281,7 @@ concise summary that captures the key points, decisions, and action items.
 Use bullet points for clarity. Keep the summary under 500 words.
 ```
 
-**Context assembly:** Full transcript text. If transcript exceeds the context budget, truncate from the middle with an ellipsis marker, preserving the head and tail within the limit. Truncation snaps to word boundaries to avoid slicing multi-byte Unicode. **Budget:** 500,000 characters for cloud providers, 80,000 characters for local providers (`isLocal == true`).
+**Context assembly:** Full transcript text. If transcript exceeds the context budget, truncate from the middle with an ellipsis marker, preserving the head and tail within the limit. Truncation snaps to word boundaries to avoid slicing multi-byte Unicode. The transcript budget accounts for the rendered summary system prompt so the combined request stays inside the provider budget; if a custom prompt has already rendered transcript text into the system prompt, that rendered prompt is bounded too. **Budget:** 500,000 characters for cloud providers, 80,000 characters for most local providers (`isLocal == true`), and 8,000 characters for LM Studio because its effective context depends on the model loaded in the desktop server.
 
 ### 2. Chat with Transcript
 
@@ -305,7 +305,7 @@ the transcript, say so. Be concise and specific, citing relevant parts when help
 </transcript>
 ```
 
-**Context assembly:** System prompt with full transcript + conversation history. Same context budget as summary (500K cloud / 80K local). Notes and transcript are budgeted together inside the system prompt with a small recent-history reserve; if the remaining context exceeds the budget, drop oldest conversation turns first (keep system prompt + recent turns).
+**Context assembly:** System prompt with full transcript + conversation history. Same context budget as summary (500K cloud / 80K local, 8K LM Studio). Notes and transcript are budgeted together inside the system prompt with a small recent-history reserve; if the remaining context exceeds the budget, drop oldest conversation turns first (keep system prompt + recent turns).
 
 **User notes (meeting recordings, optional):** When the transcription has non-empty `userNotes`, the chat system prompt gains a `User's notes from the meeting:\n…` block before the transcript block. Empty / nil / whitespace-only notes are omitted entirely — chat behavior is byte-identical to a chat without notes. Threaded via `LLMService.chat / chatStream / chatDetailed`'s `userNotes: String?` parameter; the GUI calls `TranscriptChatViewModel.bindUserNotesProvider(_:)` with a closure that returns the latest notes at chat-send time (static for saved transcriptions, live for in-meeting Ask). See ADR-020's 2026-05-02 amendment for context on why this is safe even though the auto-run "Memo-Steered Notes" prompt was reverted.
 
@@ -329,6 +329,8 @@ the transcript, say so. Be concise and specific, citing relevant parts when help
 
 Respond with only the transformed text. Do not add explanations or preamble.
 ```
+
+**Context assembly:** Selected text is truncated after accounting for the transform system prompt, instruction wrapper, and custom prompt. Same provider budgets as summary/chat (500K cloud / 80K local, 8K LM Studio).
 
 ---
 


### PR DESCRIPTION
## Summary
Fixes LM Studio post-recording AI tabs and Regenerate returning blank results for longer transcripts.

```text
long transcript
      |
      v
LM Studio stream error: context too long
      |
      +--> before: error dropped -> empty EOF accepted -> blank tab saved
      |
      +--> after: error surfaced, input budgeted, empty output rejected
```

## What Changed
- Parse LM Studio streamed error payloads and map context failures correctly.
- Use a safer LM Studio budget for prompt results, rendered prompt templates, and transforms.
- Reject zero-content streams before a blank result can be saved.
- Keep failed Regenerate attempts on the original result instead of leaving a missing generation tab.
- Add regression coverage for auto-run/Regenerate prompt generation.

## Validation
- `git diff --check`
- `swift test --filter 'LLMServiceTests|LLMClientTests|PromptResultsViewModelTests|TranscriptionViewModelTests'` — 244 tests, 0 failures
- `swift test --skip MeetingRecordingCrashRecoveryTests` — 2,791 tests, 10 skipped, 0 failures
- `swift test --filter MeetingRecordingCrashRecoveryTests/testKillNineMidRecordingProducesPlayableFiles` — 1 test, 0 failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Better handling of mid-stream LLM errors and explicit errors for truncated/empty streams
  * Prevented persisting empty streaming responses

* **Improvements**
  * Unified prompt/truncation budgeting; LM Studio capped at 8,000 chars
  * Improved transcript/system-prompt truncation and error-message scrubbing/mapping

* **New Features**
  * New generation-failure callback and handler to surface failed-generation events in the UI

* **Documentation**
  * Updated LLM integration spec with revised context-assembly rules

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moona3k/macparakeet/pull/315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->