### PR TITLE
Use single-tap hands-free dictation shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Calendar reminders, auto-start, and auto-stop are implemented in source but hidd
 
 ## What it does
 
-**Dictation** — Press a hotkey in any app, speak, text gets pasted. Hold for push-to-talk, double-tap for persistent recording. Works system-wide.
+**Dictation** — Press a hotkey in any app, speak, text gets pasted. Hold for push-to-talk, or tap the hands-free shortcut to start and stop longer dictations. Works system-wide.
 
 **File transcription** — Drag audio or video files, or paste a YouTube URL. Full transcript with word-level timestamps, speaker labels, and export to 7 formats (TXT, Markdown, SRT, VTT, DOCX, PDF, JSON). Assign global hotkeys to trigger File or YouTube transcription from anywhere.
 

--- a/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
+++ b/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
@@ -76,6 +76,17 @@ final class AppHotkeyCoordinator {
         struct Spec: Equatable {
             let trigger: HotkeyTrigger
             let gestureMode: HotkeyGestureController.Mode
+            let startupDebounceMs: Int
+
+            init(
+                trigger: HotkeyTrigger,
+                gestureMode: HotkeyGestureController.Mode,
+                startupDebounceMs: Int = FnKeyStateMachine.defaultStartupDebounceMs
+            ) {
+                self.trigger = trigger
+                self.gestureMode = gestureMode
+                self.startupDebounceMs = startupDebounceMs
+            }
         }
 
         struct Conflict: Equatable {
@@ -145,11 +156,28 @@ final class AppHotkeyCoordinator {
             specs.append(
                 DictationHotkeyPlan.Spec(
                     trigger: pushToTalkTrigger,
-                    gestureMode: .holdOnly
+                    gestureMode: .holdOnly,
+                    startupDebounceMs: pushToTalkStartupDebounceMs(
+                        handsFree: handsFreeTrigger,
+                        pushToTalk: pushToTalkTrigger
+                    )
                 )
             )
         }
         return DictationHotkeyPlan(specs: specs, conflict: nil)
+    }
+
+    private static func pushToTalkStartupDebounceMs(
+        handsFree handsFreeTrigger: HotkeyTrigger,
+        pushToTalk pushToTalkTrigger: HotkeyTrigger
+    ) -> Int {
+        guard pushToTalkTrigger.kind == .modifier,
+              pushToTalkTrigger.modifierName == "fn",
+              handsFreeTrigger.kind == .chord,
+              handsFreeTrigger.chordModifiers?.contains("fn") == true else {
+            return FnKeyStateMachine.defaultStartupDebounceMs
+        }
+        return FnKeyStateMachine.defaultTapThresholdMs
     }
 
     func setupDictationHotkeys() {
@@ -166,6 +194,7 @@ final class AppHotkeyCoordinator {
             startDictationHotkey(
                 trigger: spec.trigger,
                 gestureMode: spec.gestureMode,
+                startupDebounceMs: spec.startupDebounceMs,
                 resumeMode: Self.resumeMode(activeRecordingMode, for: spec.gestureMode),
                 suppressUntilReset: Self.shouldSuppressPeer(activeRecordingMode, for: spec.gestureMode)
             )
@@ -183,12 +212,17 @@ final class AppHotkeyCoordinator {
     private func startDictationHotkey(
         trigger: HotkeyTrigger,
         gestureMode: HotkeyGestureController.Mode,
+        startupDebounceMs: Int = FnKeyStateMachine.defaultStartupDebounceMs,
         resumeMode: FnKeyStateMachine.RecordingMode? = nil,
         suppressUntilReset: Bool = false
     ) -> HotkeyManager? {
         guard !trigger.isDisabled else { return nil }
 
-        let manager = HotkeyManager(trigger: trigger, gestureMode: gestureMode)
+        let manager = HotkeyManager(
+            trigger: trigger,
+            gestureMode: gestureMode,
+            startupDebounceMs: startupDebounceMs
+        )
         manager.onStartRecording = { [weak self, weak manager] mode in
             if let manager {
                 self?.suppressOtherDictationHotkeys(activeManager: manager)

--- a/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
+++ b/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
@@ -96,15 +96,15 @@ final class AppHotkeyCoordinator {
             return "Dictation Shortcuts: Disabled"
         }
         if !handsFree.isDisabled, handsFree == pushToTalk {
-            return "Dictation: \(handsFree.displayName) (hold or double-tap)"
+            return "Dictation Shortcuts: Conflict on \(handsFree.displayName)"
         }
         if handsFree.isDisabled {
             return "Push-to-talk: Hold \(pushToTalk.displayName)"
         }
         if pushToTalk.isDisabled {
-            return "Hands-free: Double-tap \(handsFree.displayName)"
+            return "Hands-free: Tap \(handsFree.displayName)"
         }
-        return "Dictation: Hold \(pushToTalk.displayName) / Double-tap \(handsFree.displayName)"
+        return "Dictation: Hold \(pushToTalk.displayName) / Tap \(handsFree.displayName)"
     }
 
     static func dictationHotkeyPlan(
@@ -116,24 +116,12 @@ final class AppHotkeyCoordinator {
         }
 
         if !handsFreeTrigger.isDisabled, !pushToTalkTrigger.isDisabled {
-            if handsFreeTrigger == pushToTalkTrigger {
-                return DictationHotkeyPlan(
-                    specs: [
-                        DictationHotkeyPlan.Spec(
-                            trigger: handsFreeTrigger,
-                            gestureMode: .doubleTapAndHold
-                        ),
-                    ],
-                    conflict: nil
-                )
-            }
-
             if handsFreeTrigger.overlaps(with: pushToTalkTrigger) {
                 return DictationHotkeyPlan(
                     specs: [
                         DictationHotkeyPlan.Spec(
                             trigger: handsFreeTrigger,
-                            gestureMode: .doubleTapOnly
+                            gestureMode: .singleTapToggle
                         ),
                     ],
                     conflict: DictationHotkeyPlan.Conflict(
@@ -149,7 +137,7 @@ final class AppHotkeyCoordinator {
             specs.append(
                 DictationHotkeyPlan.Spec(
                     trigger: handsFreeTrigger,
-                    gestureMode: .doubleTapOnly
+                    gestureMode: .singleTapToggle
                 )
             )
         }
@@ -345,12 +333,14 @@ final class AppHotkeyCoordinator {
     ) -> FnKeyStateMachine.RecordingMode? {
         guard let activeMode else { return nil }
         switch (activeMode, gestureMode) {
-        case (.persistent, .doubleTapOnly),
+        case (.persistent, .singleTapToggle),
+             (.persistent, .doubleTapOnly),
              (.persistent, .doubleTapAndHold),
              (.holdToTalk, .holdOnly),
              (.holdToTalk, .doubleTapAndHold):
             return activeMode
         case (.persistent, .holdOnly),
+             (.holdToTalk, .singleTapToggle),
              (.holdToTalk, .doubleTapOnly):
             return nil
         }

--- a/Sources/MacParakeet/Hotkey/GlobalShortcutManager.swift
+++ b/Sources/MacParakeet/Hotkey/GlobalShortcutManager.swift
@@ -4,7 +4,7 @@ import MacParakeetCore
 
 /// Lightweight global shortcut listener for immediate actions like toggling
 /// meeting recording. Unlike `HotkeyManager`, this does not model hold or
-/// double-tap gestures.
+/// dictation gesture handling.
 public final class GlobalShortcutManager {
     public var onTrigger: (() -> Void)?
 

--- a/Sources/MacParakeet/Hotkey/HotkeyManager.swift
+++ b/Sources/MacParakeet/Hotkey/HotkeyManager.swift
@@ -20,6 +20,7 @@ public final class HotkeyManager {
 
     private let gestureController: HotkeyGestureController
     private let trigger: HotkeyTrigger
+    private let gestureMode: HotkeyGestureController.Mode
     private let targetMask: CGEventFlags?
     public let tapThresholdMs: Int
     private var eventTap: CFMachPort?
@@ -62,6 +63,7 @@ public final class HotkeyManager {
         tapThresholdMs: Int = FnKeyStateMachine.defaultTapThresholdMs
     ) {
         self.trigger = trigger
+        self.gestureMode = gestureMode
         self.gestureController = HotkeyGestureController(
             mode: gestureMode,
             tapThresholdMs: tapThresholdMs
@@ -236,6 +238,9 @@ public final class HotkeyManager {
 
                     targetModifierGestureIsActive = true
                     bareTap = true
+                    if gestureMode == .singleTapToggle {
+                        return []
+                    }
                     return gestureController.triggerPressed(timestampMs: timestampMs)
                 }
 
@@ -244,9 +249,11 @@ public final class HotkeyManager {
 
                 let outputs: [HotkeyGestureController.Output]
                 if bareTap {
-                    outputs = gestureController.triggerReleased(timestampMs: timestampMs)
+                    outputs = gestureMode == .singleTapToggle
+                        ? gestureController.triggerPressed(timestampMs: timestampMs)
+                        : gestureController.triggerReleased(timestampMs: timestampMs)
                 } else {
-                    outputs = gestureController.nonBareTriggerReleased()
+                    outputs = gestureMode == .singleTapToggle ? [] : gestureController.nonBareTriggerReleased()
                 }
                 bareTap = true
                 return outputs
@@ -260,12 +267,12 @@ public final class HotkeyManager {
             ).subtracting([targetKeyCode])
             if targetModifierGestureIsActive, !changedTrackedModifiers.isEmpty {
                 bareTap = false
-                return gestureController.interrupted()
+                return gestureMode == .singleTapToggle ? [] : gestureController.interrupted()
             }
             if let oppositeKeyCode = HotkeyTrigger.oppositeModifierKeyCode(for: targetKeyCode),
                changedTrackedModifiers.contains(oppositeKeyCode),
                ModifierKeyMatcher.sideSpecificModifierIsPressed(flags: flags, keyCode: oppositeKeyCode) {
-                return gestureController.interrupted()
+                return gestureMode == .singleTapToggle ? [] : gestureController.interrupted()
             }
             return []
         }
@@ -281,6 +288,9 @@ public final class HotkeyManager {
                 targetModifierGestureIsActive = true
                 // Modifier down — start bare-tap tracking
                 bareTap = true
+                if gestureMode == .singleTapToggle {
+                    return []
+                }
                 return gestureController.triggerPressed(timestampMs: timestampMs)
             }
 
@@ -288,9 +298,11 @@ public final class HotkeyManager {
             targetModifierGestureIsActive = false
             let outputs: [HotkeyGestureController.Output]
             if bareTap {
-                outputs = gestureController.triggerReleased(timestampMs: timestampMs)
+                outputs = gestureMode == .singleTapToggle
+                    ? gestureController.triggerPressed(timestampMs: timestampMs)
+                    : gestureController.triggerReleased(timestampMs: timestampMs)
             } else {
-                outputs = gestureController.nonBareTriggerReleased()
+                outputs = gestureMode == .singleTapToggle ? [] : gestureController.nonBareTriggerReleased()
             }
             bareTap = true
             return outputs
@@ -304,7 +316,7 @@ public final class HotkeyManager {
         guard !nonTargetTrackedModifiers.isEmpty else { return [] }
 
         bareTap = false
-        return gestureController.interrupted()
+        return gestureMode == .singleTapToggle ? [] : gestureController.interrupted()
     }
 
     private func modifierKeyDownOutputs(
@@ -316,15 +328,18 @@ public final class HotkeyManager {
         } else if !HotkeyTrigger.isFnKeyCode(UInt16(keyCode)) {
             // Skip Fn/Globe key (63/179) — macOS generates a synthetic keyDown
             // with keyCode 179 when Fn is released (for "Change Input Source" or
-            // "Show Emoji & Symbols"). Without this guard, that keyDown resets
-            // the state machine between the first and second tap of a double-tap.
+            // "Show Emoji & Symbols"). Without this guard, that keyDown resets the
+            // gesture state machine during modifier-only gestures.
             // Non-Escape key pressed — invalidate bare-tap if modifier is held
             if targetModifierGestureIsActive {
                 bareTap = false
             }
 
-            // Gesture interruption: if waiting for second tap, a regular key press
-            // means the user is typing, not double-tapping the hotkey
+            // Gesture interruption: a regular key press means the user is typing,
+            // not performing a bare hotkey gesture.
+            if gestureMode == .singleTapToggle {
+                return []
+            }
             return gestureController.interrupted()
         }
         return []
@@ -478,8 +493,8 @@ public final class HotkeyManager {
             } else if keyCode == 53 { // Escape
                 return (gestureController.escapePressed(), false)
             } else {
-                // Gesture interruption: if waiting for second tap, a regular key press
-                // means the user is typing, not double-tapping the hotkey
+                // Gesture interruption: a regular key press means the user is typing,
+                // not performing a bare hotkey gesture.
                 return (gestureController.interrupted(), false)
             }
         } else if type == .keyUp {
@@ -612,9 +627,11 @@ public final class HotkeyManager {
 
             let outputs: [HotkeyGestureController.Output]
             if bareTap {
-                outputs = gestureController.triggerReleased(timestampMs: timestampMs)
+                outputs = gestureMode == .singleTapToggle
+                    ? gestureController.triggerPressed(timestampMs: timestampMs)
+                    : gestureController.triggerReleased(timestampMs: timestampMs)
             } else {
-                outputs = gestureController.nonBareTriggerReleased()
+                outputs = gestureMode == .singleTapToggle ? [] : gestureController.nonBareTriggerReleased()
             }
             bareTap = true
             return outputs
@@ -629,13 +646,16 @@ public final class HotkeyManager {
             modifierChordBlockedUntilRelease = true
             guard bareTap else { return [] }
             bareTap = false
-            return gestureController.interrupted()
+            return gestureMode == .singleTapToggle ? [] : gestureController.interrupted()
         }
 
         if exactPressed, !modifierChordGestureIsActive {
             guard !modifierChordBlockedUntilRelease else { return [] }
             modifierChordGestureIsActive = true
             bareTap = true
+            if gestureMode == .singleTapToggle {
+                return []
+            }
             return gestureController.triggerPressed(timestampMs: timestampMs)
         }
 
@@ -651,6 +671,9 @@ public final class HotkeyManager {
         } else if !HotkeyTrigger.isFnKeyCode(UInt16(keyCode)) {
             if modifierChordGestureIsActive {
                 bareTap = false
+            }
+            if gestureMode == .singleTapToggle {
+                return []
             }
             return gestureController.interrupted()
         }

--- a/Sources/MacParakeet/Hotkey/HotkeyManager.swift
+++ b/Sources/MacParakeet/Hotkey/HotkeyManager.swift
@@ -60,13 +60,15 @@ public final class HotkeyManager {
     public init(
         trigger: HotkeyTrigger = .fn,
         gestureMode: HotkeyGestureController.Mode = .doubleTapAndHold,
-        tapThresholdMs: Int = FnKeyStateMachine.defaultTapThresholdMs
+        tapThresholdMs: Int = FnKeyStateMachine.defaultTapThresholdMs,
+        startupDebounceMs: Int = FnKeyStateMachine.defaultStartupDebounceMs
     ) {
         self.trigger = trigger
         self.gestureMode = gestureMode
         self.gestureController = HotkeyGestureController(
             mode: gestureMode,
-            tapThresholdMs: tapThresholdMs
+            tapThresholdMs: tapThresholdMs,
+            startupDebounceMs: startupDebounceMs
         )
         self.tapThresholdMs = self.gestureController.tapThresholdMs
         self.targetMask = trigger.kind == .modifier ? ModifierKeyMatcher.mask(for: trigger.modifierName) : nil

--- a/Sources/MacParakeet/Views/Components/SacredGeometry.swift
+++ b/Sources/MacParakeet/Views/Components/SacredGeometry.swift
@@ -205,8 +205,8 @@ struct MerkabaDissipateView: View {
 // MARK: - Breathing Ring (Ready / Waiting)
 
 /// Gentle breath indicator for the dictation overlay's ephemeral `.ready`
-/// state — shown briefly (~800ms) between the first Fn tap and the double-tap
-/// window closing. A soft white ring inhales around a warm coral nexus: the
+/// state — shown briefly (~800ms) while dictation waits for a gesture to
+/// become active. A soft white ring inhales around a warm coral nexus: the
 /// smallest, lightest member of the sacred-geometry family, signalling
 /// "listening, poised, waiting" without competing with the active Merkaba
 /// (processing) or the dissolving Merkaba (no speech).

--- a/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
+++ b/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
@@ -392,9 +392,8 @@ struct DictationOverlayView: View {
 
     // MARK: - Ready State
 
-    /// Ready pill — a gentle breathing ring that appears briefly after the
-    /// first Fn tap while the state machine waits to see if a second tap lands
-    /// (double-tap = persistent recording) or the window elapses (back to
+    /// Ready pill — a gentle breathing ring that appears briefly while the
+    /// state machine waits to see if the gesture becomes active or elapses (back to
     /// idle). The breath ring belongs to the same sacred-geometry family as
     /// `SpinnerRingView` (processing) and `MerkabaDissipateView` (no speech),
     /// but is the smallest and lightest member — a poised inhale rather than

--- a/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
+++ b/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
@@ -404,7 +404,7 @@ struct DictationOverlayView: View {
 
     // MARK: - Hold-to-Talk State
 
-    /// Red dot + timer + waveform — no buttons needed since releasing Fn stops recording.
+    /// Red dot + timer + waveform — no buttons needed since releasing push-to-talk stops recording.
     private var holdToTalkContent: some View {
         HStack(spacing: 12) {
             // Recording indicator dot
@@ -698,10 +698,19 @@ struct DictationOverlayView: View {
             return ("Copied to Clipboard", "Auto-paste wasn't available. Press Cmd+V where you want the text.")
         }
         if lower.contains("not recording") {
-            let trigger = HotkeyTrigger.current
-            let hint = trigger.isDisabled
-                ? "Click the dictation pill to start recording."
-                : "Press \(trigger.displayName) to start recording first."
+            let handsFreeTrigger = HotkeyTrigger.current
+            let pushToTalkTrigger = HotkeyTrigger.current(
+                defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey,
+                fallback: .defaultPushToTalk
+            )
+            let hint: String
+            if !handsFreeTrigger.isDisabled {
+                hint = "Tap \(handsFreeTrigger.displayName) to start recording first."
+            } else if !pushToTalkTrigger.isDisabled {
+                hint = "Hold \(pushToTalkTrigger.displayName) to start recording first."
+            } else {
+                hint = "Click the dictation pill to start recording."
+            }
             return ("Not Recording", hint)
         }
         if lower.contains("timeout") || lower.contains("timed out") {

--- a/Sources/MacParakeet/Views/Dictation/IdlePillView.swift
+++ b/Sources/MacParakeet/Views/Dictation/IdlePillView.swift
@@ -3,7 +3,7 @@ import MacParakeetCore
 import MacParakeetViewModels
 
 /// Persistent floating pill shown when idle — always visible at bottom of screen.
-/// Expands on hover to show "Click or hold <trigger key> to start dictating" tooltip.
+/// Expands on hover to show the available dictation entry points.
 struct IdlePillView: View {
     @Bindable var viewModel: IdlePillViewModel
 
@@ -63,19 +63,33 @@ struct IdlePillView: View {
 
     private var tooltip: some View {
         Group {
-            if HotkeyTrigger.current.isDisabled {
+            let handsFreeTrigger = HotkeyTrigger.current
+            let pushToTalkTrigger = HotkeyTrigger.current(
+                defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey,
+                fallback: .defaultPushToTalk
+            )
+            if handsFreeTrigger.isDisabled, pushToTalkTrigger.isDisabled {
                 Text("Click to start dictating")
                     .font(.system(size: 14, weight: .medium))
                     .foregroundStyle(.white.opacity(0.9))
             } else {
                 HStack(spacing: 0) {
-                    Text("Click or hold ")
+                    Text("Click")
                         .font(.system(size: 14, weight: .medium))
                         .foregroundStyle(.white.opacity(0.9))
-                    Text(HotkeyTrigger.current.shortSymbol)
-                        .font(.system(size: 14, weight: .semibold))
-                        .foregroundStyle(Color(nsColor: NSColor(red: 0.85, green: 0.55, blue: 0.75, alpha: 1.0)))
-                    Text(" to start dictating")
+                    if !handsFreeTrigger.isDisabled {
+                        Text(", tap ")
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundStyle(.white.opacity(0.9))
+                        shortcutText(handsFreeTrigger.shortSymbol)
+                    }
+                    if !pushToTalkTrigger.isDisabled {
+                        Text(" or hold ")
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundStyle(.white.opacity(0.9))
+                        shortcutText(pushToTalkTrigger.shortSymbol)
+                    }
+                    Text(" to dictate")
                         .font(.system(size: 14, weight: .medium))
                         .foregroundStyle(.white.opacity(0.9))
                 }
@@ -92,6 +106,12 @@ struct IdlePillView: View {
                 )
                 .shadow(color: .black.opacity(0.3), radius: 8, y: 4)
         )
+    }
+
+    private func shortcutText(_ value: String) -> some View {
+        Text(value)
+            .font(.system(size: 14, weight: .semibold))
+            .foregroundStyle(Color(nsColor: NSColor(red: 0.85, green: 0.55, blue: 0.75, alpha: 1.0)))
     }
 }
 

--- a/Sources/MacParakeet/Views/History/DictationHistoryView.swift
+++ b/Sources/MacParakeet/Views/History/DictationHistoryView.swift
@@ -94,9 +94,9 @@ struct DictationHistoryView: View {
                     .foregroundStyle(.primary)
 
                 Text(viewModel.searchText.isEmpty
-	                     ? (HotkeyTrigger.current.isDisabled
-	                        ? "Click the dictation pill or set a hotkey in Settings to start dictating."
-	                        : "Tap \(HotkeyTrigger.current.displayName) to start dictating from any app.")
+                     ? (HotkeyTrigger.current.isDisabled
+                        ? "Click the dictation pill or set a hotkey in Settings to start dictating."
+                        : "Tap \(HotkeyTrigger.current.displayName) to start dictating from any app.")
                      : "Try different words or clear your search.")
                     .font(DesignSystem.Typography.bodySmall)
                     .foregroundStyle(.secondary)

--- a/Sources/MacParakeet/Views/History/DictationHistoryView.swift
+++ b/Sources/MacParakeet/Views/History/DictationHistoryView.swift
@@ -94,9 +94,9 @@ struct DictationHistoryView: View {
                     .foregroundStyle(.primary)
 
                 Text(viewModel.searchText.isEmpty
-                     ? (HotkeyTrigger.current.isDisabled
-                        ? "Click the dictation pill or set a hotkey in Settings to start dictating."
-                        : "Double-tap \(HotkeyTrigger.current.displayName) to start dictating from any app.")
+	                     ? (HotkeyTrigger.current.isDisabled
+	                        ? "Click the dictation pill or set a hotkey in Settings to start dictating."
+	                        : "Tap \(HotkeyTrigger.current.displayName) to start dictating from any app.")
                      : "Try different words or clear your search.")
                     .font(DesignSystem.Typography.bodySmall)
                     .foregroundStyle(.secondary)

--- a/Sources/MacParakeet/Views/History/DictationStatsView.swift
+++ b/Sources/MacParakeet/Views/History/DictationStatsView.swift
@@ -38,7 +38,7 @@ struct DictationStatsView: View {
                     .foregroundStyle(.primary)
                 Text(HotkeyTrigger.current.isDisabled
                      ? "Click the dictation pill or set a hotkey in Settings to start dictating."
-                     : "Double-tap \(HotkeyTrigger.current.displayName) to start dictating from any app.")
+                     : "Tap \(HotkeyTrigger.current.displayName) to start dictating from any app.")
                     .font(DesignSystem.Typography.bodySmall)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)

--- a/Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift
+++ b/Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift
@@ -8,11 +8,19 @@ struct OnboardingFlowView: View {
     let onOpenMainApp: () -> Void
     let onOpenSettings: () -> Void
 
-    /// Trigger shown in onboarding copy — falls back to the default (.fn) when
-    /// the user has disabled their hotkey, so instructional text stays readable.
-    private var displayTrigger: HotkeyTrigger {
+    /// Triggers shown in onboarding copy — fall back to defaults when disabled
+    /// so instructional text stays readable.
+    private var handsFreeDisplayTrigger: HotkeyTrigger {
         let current = HotkeyTrigger.current
-        return current.isDisabled ? .fn : current
+        return current.isDisabled ? .defaultDictation : current
+    }
+
+    private var pushToTalkDisplayTrigger: HotkeyTrigger {
+        let current = HotkeyTrigger.current(
+            defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey,
+            fallback: .defaultPushToTalk
+        )
+        return current.isDisabled ? .defaultPushToTalk : current
     }
 
     private let windowWidth: CGFloat = 740
@@ -377,7 +385,7 @@ struct OnboardingFlowView: View {
                 featureRow(
                     icon: "mic.fill",
                     title: "Dictate anywhere",
-                    detail: "Double-tap \(displayTrigger.displayName) for persistent dictation, or hold-to-talk and release to stop. Text appears where your cursor is."
+                    detail: "Tap \(handsFreeDisplayTrigger.displayName) for hands-free dictation, or hold \(pushToTalkDisplayTrigger.displayName) and release to stop. Text appears where your cursor is."
                 )
                 featureRow(
                     icon: "bolt.fill",
@@ -534,7 +542,7 @@ struct OnboardingFlowView: View {
         }
     }
 
-    @State private var doubleTapPhase = 0
+    @State private var tapPhase = 0
     @State private var holdPhase: CGFloat = 0
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -544,7 +552,7 @@ struct OnboardingFlowView: View {
                 HStack(spacing: 8) {
                     Image(systemName: "info.circle.fill")
                         .foregroundStyle(DesignSystem.Colors.accent)
-                    Text("Your dictation hotkey is currently disabled. The examples below show the default key (\(displayTrigger.shortSymbol)). You can set a hotkey anytime in Settings.")
+                    Text("Your hands-free hotkey is currently disabled. The examples below show the default shortcuts. You can set hotkeys anytime in Settings.")
                         .font(DesignSystem.Typography.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -555,24 +563,24 @@ struct OnboardingFlowView: View {
                 )
             }
 
-            // Persistent Mode card
+            // Hands-free mode card
             onboardingCard {
                 HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
-                    doubleTapIllustration
+                    singleTapIllustration
                         .frame(width: 80)
 
                     VStack(alignment: .leading, spacing: 6) {
-                        Text("Persistent Mode")
+                        Text("Hands-free mode")
                             .font(DesignSystem.Typography.micro)
                             .foregroundStyle(DesignSystem.Colors.accent)
                             .padding(.horizontal, 8)
                             .padding(.vertical, 3)
                             .background(Capsule().fill(DesignSystem.Colors.accent.opacity(0.12)))
 
-                        Text("Double-tap \(displayTrigger.shortSymbol)")
+                        Text("Tap \(handsFreeDisplayTrigger.shortSymbol)")
                             .font(DesignSystem.Typography.sectionTitle)
 
-                        Text("Starts persistent recording.\nTap \(displayTrigger.shortSymbol) again to stop and paste.")
+                        Text("Starts persistent recording.\nTap \(handsFreeDisplayTrigger.shortSymbol) again to stop and paste.")
                             .font(DesignSystem.Typography.bodySmall)
                             .foregroundStyle(.secondary)
                             .fixedSize(horizontal: false, vertical: true)
@@ -595,7 +603,7 @@ struct OnboardingFlowView: View {
                             .padding(.vertical, 3)
                             .background(Capsule().fill(DesignSystem.Colors.accent.opacity(0.12)))
 
-                        Text("Hold \(displayTrigger.shortSymbol)")
+                        Text("Hold \(pushToTalkDisplayTrigger.shortSymbol)")
                             .font(DesignSystem.Typography.sectionTitle)
 
                         Text("Records while you hold the key.\nRelease to stop and paste.")
@@ -620,7 +628,7 @@ struct OnboardingFlowView: View {
                     .foregroundStyle(.tertiary)
             }
 
-            Text("Tip: If your keyboard doesn't send \(displayTrigger.displayName) events, you can still use file transcription from the main app window.")
+            Text("Tip: If your keyboard doesn't send Fn events, you can still use file transcription from the main app window.")
                 .font(DesignSystem.Typography.caption)
                 .foregroundStyle(.secondary)
         }
@@ -632,24 +640,16 @@ struct OnboardingFlowView: View {
 
     @State private var animationTask: Task<Void, Never>?
 
-    private var doubleTapIllustration: some View {
-        HStack(spacing: 4) {
-            keyCap(displayTrigger.shortSymbol)
-                .scaleEffect(doubleTapPhase == 1 ? 0.9 : 1.0)
-                .opacity(reduceMotion || doubleTapPhase == 1 ? 1.0 : 0.5)
-            Text("·")
-                .font(.system(size: 14, weight: .bold))
-                .foregroundStyle(.tertiary)
-            keyCap(displayTrigger.shortSymbol)
-                .scaleEffect(doubleTapPhase == 2 ? 0.9 : 1.0)
-                .opacity(reduceMotion || doubleTapPhase == 2 ? 1.0 : 0.5)
-        }
-        .animation(.easeInOut(duration: 0.15), value: doubleTapPhase)
+    private var singleTapIllustration: some View {
+        keyCap(handsFreeDisplayTrigger.shortSymbol)
+            .scaleEffect(tapPhase == 1 ? 0.9 : 1.0)
+            .opacity(reduceMotion || tapPhase == 1 ? 1.0 : 0.5)
+            .animation(.easeInOut(duration: 0.15), value: tapPhase)
     }
 
     private var holdIllustration: some View {
         VStack(spacing: 6) {
-            keyCap(displayTrigger.shortSymbol)
+            keyCap(pushToTalkDisplayTrigger.shortSymbol)
                 .scaleEffect(holdPhase > 0 ? 0.93 : 1.0)
                 .opacity(reduceMotion || holdPhase > 0 ? 1.0 : 0.5)
                 .animation(.easeInOut(duration: 0.15), value: holdPhase > 0)
@@ -670,17 +670,11 @@ struct OnboardingFlowView: View {
         animationTask?.cancel()
         animationTask = Task { @MainActor in
             while !Task.isCancelled {
-                // Double-tap: press, pause, press
-                doubleTapPhase = 1
+                // Hands-free tap.
+                tapPhase = 1
                 try? await Task.sleep(for: .milliseconds(200))
                 guard !Task.isCancelled else { break }
-                doubleTapPhase = 0
-                try? await Task.sleep(for: .milliseconds(150))
-                guard !Task.isCancelled else { break }
-                doubleTapPhase = 2
-                try? await Task.sleep(for: .milliseconds(200))
-                guard !Task.isCancelled else { break }
-                doubleTapPhase = 0
+                tapPhase = 0
 
                 // Hold: press and grow bar
                 holdPhase = 0.01 // trigger "pressed" state
@@ -856,7 +850,7 @@ struct OnboardingFlowView: View {
                 VStack(alignment: .leading, spacing: 14) {
                     quickTip(icon: "mic.fill", text: HotkeyTrigger.current.isDisabled
                         ? "Click the dictation pill or set a hotkey in Settings to start dictating"
-                        : "Double-tap \(displayTrigger.displayName) to start dictating anywhere")
+                        : "Tap \(handsFreeDisplayTrigger.displayName) to start dictating anywhere")
                     quickTip(icon: "doc.fill", text: "Drop an audio file onto the main window to transcribe")
                     quickTip(icon: "gearshape", text: "Visit Settings to customize your experience")
                 }

--- a/Sources/MacParakeet/Views/Settings/Components/SettingsRow.swift
+++ b/Sources/MacParakeet/Views/Settings/Components/SettingsRow.swift
@@ -72,7 +72,7 @@ struct SettingsToggleRow: View {
     return VStack(spacing: DesignSystem.Spacing.md) {
         SettingsToggleRow(
             title: "Show dictation pill at all times",
-            detail: "When off, the pill hides until you press the hotkey.",
+            detail: "When off, the pill hides until you use a dictation shortcut.",
             isOn: $toggleOn
         )
 
@@ -107,7 +107,7 @@ struct SettingsToggleRow: View {
     return VStack(spacing: DesignSystem.Spacing.md) {
         SettingsToggleRow(
             title: "Show dictation pill at all times",
-            detail: "When off, the pill hides until you press the hotkey.",
+            detail: "When off, the pill hides until you use a dictation shortcut.",
             isOn: $toggleOn
         )
 

--- a/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
+++ b/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
@@ -135,15 +135,16 @@ struct HotkeyRecorderView: View {
     /// Symbols for currently held modifiers in standard macOS order (⌃⌥⇧⌘).
     private var pendingModifierSymbols: String {
         if modifierCaptureMode == .sideSpecific {
+            if pendingModifierComponents.map(\.modifierName) == ["fn"] { return "fn" }
             return HotkeyTrigger.modifierChord(components: pendingModifierComponents).shortSymbol
         }
 
-        let order = ["control", "option", "shift", "command"]
-        let symbols: [String: String] = ["control": "⌃", "option": "⌥", "shift": "⇧", "command": "⌘"]
+        let order = ["fn", "control", "option", "shift", "command"]
+        let symbols: [String: String] = ["fn": "fn", "control": "⌃", "option": "⌥", "shift": "⇧", "command": "⌘"]
         let names = pendingModifierComponents.map(\.modifierName)
-        return order.filter { names.contains($0) }
+        let parts = order.filter { names.contains($0) }
             .compactMap { symbols[$0] }
-            .joined()
+        return parts.joined(separator: names.contains("fn") ? "+" : "")
     }
 
     // MARK: - Recording Logic
@@ -174,7 +175,7 @@ struct HotkeyRecorderView: View {
                     return nil
                 }
 
-                // Check if chord modifiers are held (Cmd, Ctrl, Option, Shift — excluding Fn/Caps Lock)
+                // Check if chord modifiers are held. Caps Lock remains excluded.
                 let heldModifiers = chordModifiersFromFlags(event.modifierFlags)
 
                 if !heldModifiers.isEmpty {
@@ -225,8 +226,12 @@ struct HotkeyRecorderView: View {
 
                 if let name = modifierName {
                     if name == "fn" {
-                        // Fn is bare modifier only — accept immediately on key-down
                         if event.modifierFlags.contains(.function) {
+                            pendingModifierComponents = [.init(modifierName: "fn")]
+                            candidateModifierComponents = pendingModifierComponents
+                        } else if candidateModifierComponents.contains(.init(modifierName: "fn")) {
+                            pendingModifierComponents = []
+                            candidateModifierComponents = []
                             switch combinedValidation(for: .fn) {
                             case .blocked(let msg):
                                 validationMessage = msg
@@ -298,13 +303,14 @@ struct HotkeyRecorderView: View {
     }
 
     /// Extract chord-eligible modifier names from NSEvent modifier flags.
-    /// Excludes Fn (bare modifier only per plan).
+    /// Caps Lock is intentionally excluded.
     private func chordModifiersFromFlags(_ flags: NSEvent.ModifierFlags) -> [String] {
         var modifiers: [String] = []
         if flags.contains(.control) { modifiers.append("control") }
         if flags.contains(.option) { modifiers.append("option") }
         if flags.contains(.shift) { modifiers.append("shift") }
         if flags.contains(.command) { modifiers.append("command") }
+        if flags.contains(.function) { modifiers.append("fn") }
         return modifiers
     }
 
@@ -373,8 +379,11 @@ struct HotkeyRecorderView: View {
         keyCode: UInt16,
         captureMode: ModifierCaptureMode
     ) -> HotkeyTrigger? {
-        let genericNames: Set<String> = ["control", "option", "shift", "command"]
+        let genericNames: Set<String> = ["fn", "control", "option", "shift", "command"]
         guard genericNames.contains(name) else { return nil }
+        if name == "fn" {
+            return .fn
+        }
         switch captureMode {
         case .generic:
             return HotkeyTrigger(kind: .modifier, modifierName: name, keyCode: nil)

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -622,7 +622,7 @@ struct SettingsView: View {
                 // OS-integration startup section.
                 settingsToggleRow(
                     title: "Show dictation pill at all times",
-                    detail: "When off, the pill hides until you press the hotkey.",
+                    detail: "When off, the pill hides until you use a dictation shortcut.",
                     isOn: $viewModel.showIdlePill
                 )
             }
@@ -2246,6 +2246,7 @@ struct SettingsView: View {
                 modeShortcutRow(
                     keys: [viewModel.pushToTalkHotkeyTrigger.shortSymbol],
                     separator: nil,
+                    verb: "Hold",
                     action: "Push to talk",
                     detail: "Release to stop"
                 )
@@ -2260,6 +2261,7 @@ struct SettingsView: View {
                 modeShortcutRow(
                     keys: [viewModel.hotkeyTrigger.shortSymbol],
                     separator: nil,
+                    verb: "Tap",
                     action: "Hands-free mode",
                     detail: "Tap again to stop"
                 )
@@ -2272,7 +2274,13 @@ struct SettingsView: View {
         )
     }
 
-    private func modeShortcutRow(keys: [String], separator: String?, action: String, detail: String) -> some View {
+    private func modeShortcutRow(
+        keys: [String],
+        separator: String?,
+        verb: String,
+        action: String,
+        detail: String
+    ) -> some View {
         HStack(spacing: DesignSystem.Spacing.sm) {
             HStack(spacing: 3) {
                 if keys.count == 2, let sep = separator {
@@ -2282,7 +2290,7 @@ struct SettingsView: View {
                         .foregroundStyle(.tertiary)
                     miniSettingsKeyCap(keys[1])
                 } else {
-                    Text("Hold")
+                    Text(verb)
                         .font(DesignSystem.Typography.micro)
                         .foregroundStyle(.secondary)
                     miniSettingsKeyCap(keys[0])

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -560,7 +560,7 @@ struct SettingsView: View {
                 HStack(alignment: .center) {
                     rowText(
                         title: "Hands-free mode",
-                        detail: "Double-tap to start; tap again to stop."
+                        detail: "Tap to start; tap again to stop."
                     )
                     Spacer(minLength: DesignSystem.Spacing.md)
                     VStack(alignment: .trailing, spacing: 4) {
@@ -942,8 +942,7 @@ struct SettingsView: View {
 
     private func dictationHotkeyValidation(for candidate: HotkeyTrigger) -> HotkeyTrigger.ValidationResult {
         guard !candidate.isDisabled else { return .allowed }
-        if candidate != viewModel.pushToTalkHotkeyTrigger,
-           candidate.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
+        if candidate.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
             return .blocked(SettingsHotkeyConflictMessage.blocked(
                 conflictingWith: "push to talk",
                 trigger: viewModel.pushToTalkHotkeyTrigger
@@ -978,8 +977,7 @@ struct SettingsView: View {
 
     private func pushToTalkHotkeyValidation(for candidate: HotkeyTrigger) -> HotkeyTrigger.ValidationResult {
         guard !candidate.isDisabled else { return .allowed }
-        if candidate != viewModel.hotkeyTrigger,
-           candidate.overlaps(with: viewModel.hotkeyTrigger) {
+        if candidate.overlaps(with: viewModel.hotkeyTrigger) {
             return .blocked(SettingsHotkeyConflictMessage.blocked(
                 conflictingWith: "hands-free mode",
                 trigger: viewModel.hotkeyTrigger
@@ -1049,8 +1047,7 @@ struct SettingsView: View {
 
     private func dictationHotkeyConflictMessage(for trigger: HotkeyTrigger) -> String? {
         guard !trigger.isDisabled else { return nil }
-        if trigger != viewModel.pushToTalkHotkeyTrigger,
-           trigger.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
+        if trigger.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
             return SettingsHotkeyConflictMessage.disabled(
                 conflictingWith: "push to talk",
                 trigger: viewModel.pushToTalkHotkeyTrigger
@@ -1085,8 +1082,7 @@ struct SettingsView: View {
 
     private func pushToTalkHotkeyConflictMessage(for trigger: HotkeyTrigger) -> String? {
         guard !trigger.isDisabled else { return nil }
-        if trigger != viewModel.hotkeyTrigger,
-           trigger.overlaps(with: viewModel.hotkeyTrigger) {
+        if trigger.overlaps(with: viewModel.hotkeyTrigger) {
             return SettingsHotkeyConflictMessage.disabled(
                 conflictingWith: "hands-free mode",
                 trigger: viewModel.hotkeyTrigger
@@ -2262,8 +2258,8 @@ struct SettingsView: View {
 
             if !viewModel.hotkeyTrigger.isDisabled {
                 modeShortcutRow(
-                    keys: [viewModel.hotkeyTrigger.shortSymbol, viewModel.hotkeyTrigger.shortSymbol],
-                    separator: "·",
+                    keys: [viewModel.hotkeyTrigger.shortSymbol],
+                    separator: nil,
                     action: "Hands-free mode",
                     detail: "Tap again to stop"
                 )

--- a/Sources/MacParakeetCore/STT/HotkeyGestureController.swift
+++ b/Sources/MacParakeetCore/STT/HotkeyGestureController.swift
@@ -7,6 +7,7 @@ public final class HotkeyGestureController {
         case doubleTapAndHold
         case doubleTapOnly
         case holdOnly
+        case singleTapToggle
     }
 
     public enum Output: Equatable, Sendable {
@@ -33,9 +34,17 @@ public final class HotkeyGestureController {
         case blocked
     }
 
+    private enum SingleTapState: Equatable {
+        case idle
+        case active
+        case cancelWindow
+        case blocked
+    }
+
     private let mode: Mode
     private let stateMachine: FnKeyStateMachine
     private var holdOnlyState: HoldOnlyState = .idle
+    private var singleTapState: SingleTapState = .idle
     private var suppressedUntilReset = false
 
     public init(
@@ -62,6 +71,20 @@ public final class HotkeyGestureController {
                 holdOnlyState = .blocked
                 return []
             case .pressed, .active:
+                return []
+            }
+        }
+
+        if mode == .singleTapToggle {
+            switch singleTapState {
+            case .idle:
+                singleTapState = .active
+                return [.startRecording(mode: .persistent)]
+            case .active:
+                singleTapState = .idle
+                return [.stopRecording]
+            case .cancelWindow, .blocked:
+                singleTapState = .blocked
                 return []
             }
         }
@@ -94,6 +117,10 @@ public final class HotkeyGestureController {
             return results
         }
 
+        if mode == .singleTapToggle {
+            return []
+        }
+
         let action = stateMachine.fnUp(timestampMs: timestampMs)
         results.append(contentsOf: outputs(for: action))
         if action == .none, stateMachine.state == .waitingForSecondTap {
@@ -122,6 +149,10 @@ public final class HotkeyGestureController {
             return results
         }
 
+        if mode == .singleTapToggle {
+            return []
+        }
+
         switch stateMachine.state {
         case .holdToTalk:
             // Non-bare releases bypass outputs(for:) so the hotkey returns to idle
@@ -142,6 +173,10 @@ public final class HotkeyGestureController {
 
         if mode == .holdOnly {
             return nonBareTriggerReleased()
+        }
+
+        if mode == .singleTapToggle {
+            return []
         }
 
         var results: [Output] = [.cancelStartupDebounce, .cancelHoldWindow]
@@ -178,6 +213,19 @@ public final class HotkeyGestureController {
             return results
         }
 
+        if mode == .singleTapToggle {
+            switch singleTapState {
+            case .active:
+                singleTapState = .cancelWindow
+                return [.cancelRecording]
+            case .cancelWindow, .blocked:
+                singleTapState = .idle
+                return [.cancelRecording]
+            case .idle:
+                return [.escapeWhileIdle]
+            }
+        }
+
         let wasWaitingForSecondTap = stateMachine.state == .waitingForSecondTap
         let action = stateMachine.escapePressed()
 
@@ -198,6 +246,7 @@ public final class HotkeyGestureController {
         guard !suppressedUntilReset else { return [] }
 
         if mode == .doubleTapOnly { return [] }
+        if mode == .singleTapToggle { return [] }
         if mode == .holdOnly {
             guard holdOnlyState == .pressed else { return [] }
             holdOnlyState = .active
@@ -210,6 +259,7 @@ public final class HotkeyGestureController {
         guard !suppressedUntilReset else { return [] }
 
         if mode == .doubleTapOnly { return [] }
+        if mode == .singleTapToggle { return [] }
         if mode == .holdOnly { return [] }
         return outputs(for: stateMachine.holdTimerFired())
     }
@@ -217,6 +267,7 @@ public final class HotkeyGestureController {
     public func suppressUntilReset() {
         suppressedUntilReset = true
         holdOnlyState = .idle
+        singleTapState = .idle
         stateMachine.reset()
     }
 
@@ -229,6 +280,10 @@ public final class HotkeyGestureController {
             holdOnlyState = .cancelWindow
             return
         }
+        if mode == .singleTapToggle {
+            singleTapState = .cancelWindow
+            return
+        }
         stateMachine.blockUntilReset()
     }
 
@@ -238,12 +293,17 @@ public final class HotkeyGestureController {
             holdOnlyState = mode == .holdToTalk ? .active : .idle
             return
         }
+        if self.mode == .singleTapToggle {
+            singleTapState = mode == .persistent ? .active : .idle
+            return
+        }
         stateMachine.resumeRecording(mode: mode)
     }
 
     public func reset() {
         suppressedUntilReset = false
         holdOnlyState = .idle
+        singleTapState = .idle
         stateMachine.reset()
     }
 

--- a/Sources/MacParakeetCore/STT/HotkeyTrigger.swift
+++ b/Sources/MacParakeetCore/STT/HotkeyTrigger.swift
@@ -125,10 +125,13 @@ public struct HotkeyTrigger: Sendable {
             return KeyCodeNames.name(for: code).shortSymbol
         case .chord:
             guard let code = keyCode else { return "?" }
-            let modifierPart = Self.sortedModifierSymbols(chordModifiers)
+            let modifierSymbols = Self.sortedModifierSymbols(chordModifiers)
             let keyPart = KeyCodeNames.name(for: code).shortSymbol
-            if modifierPart.isEmpty { return keyPart }
-            return "\(modifierPart)\(keyPart)"
+            if modifierSymbols.isEmpty { return keyPart }
+            if modifierSymbols.contains("fn") {
+                return (modifierSymbols + [keyPart]).joined(separator: "+")
+            }
+            return "\(modifierSymbols.joined())\(keyPart)"
         case .modifierChord:
             let modifierPart = Self.sortedModifierComponentSymbols(modifierChordComponents)
             return modifierPart.isEmpty ? "?" : modifierPart
@@ -171,22 +174,22 @@ public struct HotkeyTrigger: Sendable {
         54: 55,
     ]
 
-    /// Standard macOS modifier ordering: ⌃ ⌥ ⇧ ⌘
+    /// Standard macOS modifier ordering for modifier-only triggers: ⌃ ⌥ ⇧ ⌘.
     private static let modifierOrder: [String] = ["control", "option", "shift", "command"]
+    private static let keyChordModifierOrder: [String] = ["fn", "control", "option", "shift", "command"]
 
     /// Returns sorted display names for chord modifiers (e.g. ["Control", "Command"]).
     private static func sortedModifierDisplayNames(_ modifiers: [String]?) -> [String] {
         guard let modifiers else { return [] }
-        return modifierOrder.filter { modifiers.contains($0) }
+        return keyChordModifierOrder.filter { modifiers.contains($0) }
             .compactMap { modifierDisplayNames[$0]?.displayName }
     }
 
     /// Returns concatenated short symbols for chord modifiers (e.g. "⌃⌘").
-    private static func sortedModifierSymbols(_ modifiers: [String]?) -> String {
-        guard let modifiers else { return "" }
-        return modifierOrder.filter { modifiers.contains($0) }
+    private static func sortedModifierSymbols(_ modifiers: [String]?) -> [String] {
+        guard let modifiers else { return [] }
+        return keyChordModifierOrder.filter { modifiers.contains($0) }
             .compactMap { modifierDisplayNames[$0]?.shortSymbol }
-            .joined()
     }
 
     private static func sortedModifierComponentDisplayNames(_ components: [ModifierComponent]?) -> [String] {
@@ -217,9 +220,10 @@ public struct HotkeyTrigger: Sendable {
     private static let maskShift: UInt64     = 0x00020000  // NX_SHIFTMASK
     private static let maskControl: UInt64   = 0x00040000  // NX_CONTROLMASK
     private static let maskAlternate: UInt64 = 0x00080000  // NX_ALTERNATEMASK
+    private static let maskSecondaryFn: UInt64 = 0x00800000 // NX_SECONDARYFNMASK
 
-    /// All 4 relevant modifier bits OR'd together.
-    public static let relevantModifierBits: UInt64 = maskCommand | maskShift | maskControl | maskAlternate
+    /// All relevant modifier bits OR'd together.
+    public static let relevantModifierBits: UInt64 = maskCommand | maskShift | maskControl | maskAlternate | maskSecondaryFn
 
     /// CGEventFlags raw value for chord modifiers, computed at runtime.
     /// Maps modifier names to their CGEventFlags mask bits and OR's them together.
@@ -285,6 +289,7 @@ public struct HotkeyTrigger: Sendable {
         var flags: UInt64 = 0
         for name in modifiers {
             switch name {
+            case "fn": flags |= Self.maskSecondaryFn
             case "command": flags |= Self.maskCommand
             case "shift": flags |= Self.maskShift
             case "control": flags |= Self.maskControl
@@ -349,7 +354,7 @@ public struct HotkeyTrigger: Sendable {
 
     // MARK: - Default Triggers
 
-    public static let defaultDictation: HotkeyTrigger = .fn
+    public static let defaultDictation: HotkeyTrigger = .chord(modifiers: ["fn"], keyCode: 49)
     public static let defaultPushToTalk: HotkeyTrigger = .fn
     public static let defaultMeetingRecording: HotkeyTrigger = .chord(modifiers: ["command", "shift"], keyCode: 46)
 
@@ -361,9 +366,9 @@ public struct HotkeyTrigger: Sendable {
     }
 
     /// Create a chord trigger from modifier names and a CGKeyCode (e.g., `chord(modifiers: ["command"], keyCode: 25)` for Cmd+9).
-    /// Modifier order is normalized to ⌃⌥⇧⌘ regardless of input order.
+    /// Modifier order is normalized to fn⌃⌥⇧⌘ regardless of input order.
     public static func chord(modifiers: [String], keyCode: UInt16) -> HotkeyTrigger {
-        let sorted = modifierOrder.filter { modifiers.contains($0) }
+        let sorted = keyChordModifierOrder.filter { modifiers.contains($0) }
         return HotkeyTrigger(kind: .chord, modifierName: nil, keyCode: keyCode, chordModifiers: sorted)
     }
 
@@ -626,11 +631,11 @@ public struct HotkeyTrigger: Sendable {
     ]
 
     /// Resolve the configured trigger from the provided defaults store.
-    /// Tries JSON decode first, falls back to legacy string, defaults to `.fn`.
+    /// Tries JSON decode first, falls back to legacy string, defaults to the hands-free shortcut.
     public static func current(
         defaults: UserDefaults = .standard,
         defaultsKey: String = defaultsKey,
-        fallback: HotkeyTrigger = .fn
+        fallback: HotkeyTrigger = .defaultDictation
     ) -> HotkeyTrigger {
         guard let stored = defaults.object(forKey: defaultsKey) else {
             return fallback

--- a/Sources/MacParakeetCore/STT/README.md
+++ b/Sources/MacParakeetCore/STT/README.md
@@ -32,9 +32,8 @@ to one `STTRuntime`; callers do not own model lifecycles directly.
   shape as the Parakeet path.
 
 **Hotkey state (lives here for testability)**
-- `FnKeyStateMachine.swift` — pure state machine for combined
-  dictation gestures (double-tap → persistent, hold → push-to-talk,
-  Esc → cancel window).
+- `FnKeyStateMachine.swift` — pure state machine for legacy combined
+  dictation gestures and shared timing constants.
 - `HotkeyGestureController.swift` — wraps the state machine for the
   app's hotkey driver and scopes behavior to combined, hands-free-only,
   or push-to-talk-only roles.

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -467,10 +467,14 @@ public final class SettingsViewModel {
         menuBarOnlyMode = AppPreferences.isMenuBarOnlyModeEnabled(defaults: defaults)
         showIdlePill = defaults.object(forKey: UserDefaultsAppRuntimePreferences.showIdlePillKey) as? Bool ?? true
         telemetryEnabled = AppPreferences.isTelemetryEnabled(defaults: defaults)
-        hotkeyTrigger = HotkeyTrigger.current(defaults: defaults)
+        let resolvedDictationHotkeyTrigger = Self.resolveDictationHotkeyTrigger(defaults: defaults)
+        hotkeyTrigger = resolvedDictationHotkeyTrigger.trigger
         let shouldPersistPushToTalkMigration = defaults.object(forKey: HotkeyTrigger.pushToTalkDefaultsKey) == nil
         let resolvedPushToTalkHotkeyTrigger = Self.resolvePushToTalkHotkeyTrigger(defaults: defaults)
         pushToTalkHotkeyTrigger = resolvedPushToTalkHotkeyTrigger
+        if resolvedDictationHotkeyTrigger.shouldPersist {
+            resolvedDictationHotkeyTrigger.trigger.save(to: defaults)
+        }
         if shouldPersistPushToTalkMigration {
             resolvedPushToTalkHotkeyTrigger.save(to: defaults, defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey)
         }
@@ -664,6 +668,24 @@ public final class SettingsViewModel {
             defaultsKey: HotkeyTrigger.meetingDefaultsKey,
             fallback: .defaultMeetingRecording
         )
+    }
+
+    private static func resolveDictationHotkeyTrigger(defaults: UserDefaults) -> (
+        trigger: HotkeyTrigger,
+        shouldPersist: Bool
+    ) {
+        let hasHandsFreeTrigger = defaults.object(forKey: HotkeyTrigger.defaultsKey) != nil
+        let hasDedicatedPushToTalkTrigger = defaults.object(forKey: HotkeyTrigger.pushToTalkDefaultsKey) != nil
+
+        guard hasHandsFreeTrigger else {
+            return (.defaultDictation, true)
+        }
+
+        let stored = HotkeyTrigger.current(defaults: defaults, fallback: .fn)
+        if !hasDedicatedPushToTalkTrigger, stored == .fn {
+            return (.defaultDictation, true)
+        }
+        return (stored, false)
     }
 
     private static func resolvePushToTalkHotkeyTrigger(defaults: UserDefaults) -> HotkeyTrigger {

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -467,16 +467,14 @@ public final class SettingsViewModel {
         menuBarOnlyMode = AppPreferences.isMenuBarOnlyModeEnabled(defaults: defaults)
         showIdlePill = defaults.object(forKey: UserDefaultsAppRuntimePreferences.showIdlePillKey) as? Bool ?? true
         telemetryEnabled = AppPreferences.isTelemetryEnabled(defaults: defaults)
-        let resolvedDictationHotkeyTrigger = Self.resolveDictationHotkeyTrigger(defaults: defaults)
-        hotkeyTrigger = resolvedDictationHotkeyTrigger.trigger
-        let shouldPersistPushToTalkMigration = defaults.object(forKey: HotkeyTrigger.pushToTalkDefaultsKey) == nil
-        let resolvedPushToTalkHotkeyTrigger = Self.resolvePushToTalkHotkeyTrigger(defaults: defaults)
-        pushToTalkHotkeyTrigger = resolvedPushToTalkHotkeyTrigger
-        if resolvedDictationHotkeyTrigger.shouldPersist {
-            resolvedDictationHotkeyTrigger.trigger.save(to: defaults)
+        let resolvedDictationHotkeys = Self.resolveDictationHotkeyTriggers(defaults: defaults)
+        hotkeyTrigger = resolvedDictationHotkeys.handsFree
+        pushToTalkHotkeyTrigger = resolvedDictationHotkeys.pushToTalk
+        if resolvedDictationHotkeys.shouldPersistHandsFree {
+            resolvedDictationHotkeys.handsFree.save(to: defaults)
         }
-        if shouldPersistPushToTalkMigration {
-            resolvedPushToTalkHotkeyTrigger.save(to: defaults, defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey)
+        if resolvedDictationHotkeys.shouldPersistPushToTalk {
+            resolvedDictationHotkeys.pushToTalk.save(to: defaults, defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey)
         }
         meetingHotkeyTrigger = Self.resolveMeetingHotkeyTrigger(defaults: defaults)
         fileTranscriptionHotkeyTrigger = Self.resolveTranscriptionHotkeyTrigger(
@@ -670,33 +668,63 @@ public final class SettingsViewModel {
         )
     }
 
-    private static func resolveDictationHotkeyTrigger(defaults: UserDefaults) -> (
-        trigger: HotkeyTrigger,
-        shouldPersist: Bool
+    private static func resolveDictationHotkeyTriggers(defaults: UserDefaults) -> (
+        handsFree: HotkeyTrigger,
+        pushToTalk: HotkeyTrigger,
+        shouldPersistHandsFree: Bool,
+        shouldPersistPushToTalk: Bool
     ) {
         let hasHandsFreeTrigger = defaults.object(forKey: HotkeyTrigger.defaultsKey) != nil
         let hasDedicatedPushToTalkTrigger = defaults.object(forKey: HotkeyTrigger.pushToTalkDefaultsKey) != nil
 
-        guard hasHandsFreeTrigger else {
-            return (.defaultDictation, true)
+        if !hasHandsFreeTrigger {
+            let pushToTalk = hasDedicatedPushToTalkTrigger
+                ? HotkeyTrigger.current(
+                    defaults: defaults,
+                    defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey,
+                    fallback: .defaultPushToTalk
+                )
+                : .defaultPushToTalk
+            return (
+                defaultHandsFreeTrigger(avoiding: pushToTalk),
+                pushToTalk,
+                true,
+                !hasDedicatedPushToTalkTrigger
+            )
         }
 
-        let stored = HotkeyTrigger.current(defaults: defaults, fallback: .fn)
-        if !hasDedicatedPushToTalkTrigger, stored == .fn {
-            return (.defaultDictation, true)
+        let storedHandsFree = HotkeyTrigger.current(defaults: defaults, fallback: .defaultDictation)
+        if !hasDedicatedPushToTalkTrigger {
+            if storedHandsFree.isDisabled {
+                return (.disabled, .disabled, false, true)
+            }
+            return (
+                defaultHandsFreeTrigger(avoiding: storedHandsFree),
+                storedHandsFree,
+                true,
+                true
+            )
         }
-        return (stored, false)
-    }
 
-    private static func resolvePushToTalkHotkeyTrigger(defaults: UserDefaults) -> HotkeyTrigger {
-        guard defaults.object(forKey: HotkeyTrigger.pushToTalkDefaultsKey) != nil else {
-            return HotkeyTrigger.current(defaults: defaults, fallback: .defaultPushToTalk)
-        }
-        return HotkeyTrigger.current(
+        let pushToTalk = HotkeyTrigger.current(
             defaults: defaults,
             defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey,
             fallback: .defaultPushToTalk
         )
+        if !storedHandsFree.isDisabled,
+           !pushToTalk.isDisabled,
+           storedHandsFree.overlaps(with: pushToTalk) {
+            return (defaultHandsFreeTrigger(avoiding: pushToTalk), pushToTalk, true, false)
+        }
+        return (storedHandsFree, pushToTalk, false, false)
+    }
+
+    private static func defaultHandsFreeTrigger(avoiding pushToTalk: HotkeyTrigger) -> HotkeyTrigger {
+        guard !pushToTalk.isDisabled,
+              HotkeyTrigger.defaultDictation.overlaps(with: pushToTalk) else {
+            return .defaultDictation
+        }
+        return .disabled
     }
 
     /// Transcription hotkeys (file / YouTube) default to `.disabled` — users opt in.

--- a/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
@@ -114,6 +114,44 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
         )
     }
 
+    func testDictationHotkeyPlanUsesSeparateManagersForDefaults() {
+        let plan = AppHotkeyCoordinator.dictationHotkeyPlan(
+            handsFree: .defaultDictation,
+            pushToTalk: .defaultPushToTalk
+        )
+
+        XCTAssertEqual(
+            plan,
+            AppHotkeyCoordinator.DictationHotkeyPlan(
+                specs: [
+                    .init(trigger: .defaultDictation, gestureMode: .singleTapToggle),
+                    .init(
+                        trigger: .defaultPushToTalk,
+                        gestureMode: .holdOnly,
+                        startupDebounceMs: FnKeyStateMachine.defaultTapThresholdMs
+                    ),
+                ],
+                conflict: nil
+            )
+        )
+    }
+
+    func testDictationHotkeyPlanKeepsStandardPushToTalkDebounceWhenNoFnChordConflict() {
+        let plan = AppHotkeyCoordinator.dictationHotkeyPlan(
+            handsFree: .control,
+            pushToTalk: .defaultPushToTalk
+        )
+
+        XCTAssertEqual(
+            plan.specs.last,
+            .init(
+                trigger: .defaultPushToTalk,
+                gestureMode: .holdOnly,
+                startupDebounceMs: FnKeyStateMachine.defaultStartupDebounceMs
+            )
+        )
+    }
+
     func testDictationHotkeyPlanKeepsHandsFreeOnlyWhenTriggersOverlapButDiffer() {
         let pushToTalk = HotkeyTrigger.modifierChord(modifiers: ["control", "option"])
         let plan = AppHotkeyCoordinator.dictationHotkeyPlan(

--- a/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
@@ -68,18 +68,18 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
     func testMenuTitleDescribesSharedDictationTrigger() {
         XCTAssertEqual(
             AppHotkeyCoordinator.menuTitle(handsFree: .fn, pushToTalk: .fn),
-            "Dictation: Fn (hold or double-tap)"
+            "Dictation Shortcuts: Conflict on Fn"
         )
     }
 
     func testMenuTitleDescribesDistinctDictationTriggers() {
         XCTAssertEqual(
             AppHotkeyCoordinator.menuTitle(handsFree: .control, pushToTalk: .option),
-            "Dictation: Hold Option / Double-tap Control"
+            "Dictation: Hold Option / Tap Control"
         )
     }
 
-    func testDictationHotkeyPlanUsesOneCombinedManagerForSharedTrigger() {
+    func testDictationHotkeyPlanKeepsHandsFreeWhenSharedTriggerWouldConflict() {
         let plan = AppHotkeyCoordinator.dictationHotkeyPlan(
             handsFree: .fn,
             pushToTalk: .fn
@@ -89,9 +89,9 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
             plan,
             AppHotkeyCoordinator.DictationHotkeyPlan(
                 specs: [
-                    .init(trigger: .fn, gestureMode: .doubleTapAndHold),
+                    .init(trigger: .fn, gestureMode: .singleTapToggle),
                 ],
-                conflict: nil
+                conflict: .init(trigger: .fn, conflicts: [.fn])
             )
         )
     }
@@ -106,7 +106,7 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
             plan,
             AppHotkeyCoordinator.DictationHotkeyPlan(
                 specs: [
-                    .init(trigger: .control, gestureMode: .doubleTapOnly),
+                    .init(trigger: .control, gestureMode: .singleTapToggle),
                     .init(trigger: .option, gestureMode: .holdOnly),
                 ],
                 conflict: nil
@@ -125,7 +125,7 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
             plan,
             AppHotkeyCoordinator.DictationHotkeyPlan(
                 specs: [
-                    .init(trigger: .control, gestureMode: .doubleTapOnly),
+                    .init(trigger: .control, gestureMode: .singleTapToggle),
                 ],
                 conflict: .init(trigger: pushToTalk, conflicts: [.control])
             )
@@ -261,6 +261,11 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
 
     func testResumeModeMatchesActiveDictationRole() {
         XCTAssertEqual(
+            AppHotkeyCoordinator.resumeMode(.persistent, for: .singleTapToggle),
+            .persistent
+        )
+        XCTAssertFalse(AppHotkeyCoordinator.shouldSuppressPeer(.persistent, for: .singleTapToggle))
+        XCTAssertEqual(
             AppHotkeyCoordinator.resumeMode(.persistent, for: .doubleTapOnly),
             .persistent
         )
@@ -283,6 +288,8 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
             .holdToTalk
         )
         XCTAssertFalse(AppHotkeyCoordinator.shouldSuppressPeer(.holdToTalk, for: .doubleTapAndHold))
+        XCTAssertNil(AppHotkeyCoordinator.resumeMode(.holdToTalk, for: .singleTapToggle))
+        XCTAssertTrue(AppHotkeyCoordinator.shouldSuppressPeer(.holdToTalk, for: .singleTapToggle))
         XCTAssertNil(AppHotkeyCoordinator.resumeMode(.holdToTalk, for: .doubleTapOnly))
         XCTAssertTrue(AppHotkeyCoordinator.shouldSuppressPeer(.holdToTalk, for: .doubleTapOnly))
         XCTAssertNil(AppHotkeyCoordinator.resumeMode(nil, for: .doubleTapAndHold))

--- a/Tests/MacParakeetTests/Hotkey/HotkeyGestureControllerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyGestureControllerTests.swift
@@ -231,6 +231,39 @@ final class HotkeyGestureControllerTests: XCTestCase {
         )
     }
 
+    func testSingleTapToggleStartsAndStopsPersistentRecordingOnPresses() {
+        let controller = HotkeyGestureController(mode: .singleTapToggle)
+
+        XCTAssertEqual(
+            controller.triggerPressed(timestampMs: 1_000),
+            [.startRecording(mode: .persistent)]
+        )
+        XCTAssertEqual(controller.triggerReleased(timestampMs: 1_050), [])
+        XCTAssertEqual(
+            controller.triggerPressed(timestampMs: 1_200),
+            [.stopRecording]
+        )
+        XCTAssertEqual(controller.triggerReleased(timestampMs: 1_250), [])
+    }
+
+    func testSingleTapToggleDoesNotUseStartupOrHoldTimers() {
+        let controller = HotkeyGestureController(mode: .singleTapToggle)
+
+        XCTAssertEqual(controller.triggerPressed(timestampMs: 1_000), [.startRecording(mode: .persistent)])
+        XCTAssertEqual(controller.startupDebounceElapsed(), [])
+        XCTAssertEqual(controller.holdWindowElapsed(), [])
+    }
+
+    func testSingleTapToggleEscapeCancelsActiveRecording() {
+        let controller = HotkeyGestureController(mode: .singleTapToggle)
+        _ = controller.triggerPressed(timestampMs: 1_000)
+
+        XCTAssertEqual(controller.escapePressed(), [.cancelRecording])
+        XCTAssertEqual(controller.triggerPressed(timestampMs: 1_100), [])
+        controller.reset()
+        XCTAssertEqual(controller.triggerPressed(timestampMs: 1_200), [.startRecording(mode: .persistent)])
+    }
+
     func testNotifyCancelledByUIBlocksDoubleTapOnlyUntilReset() {
         let controller = HotkeyGestureController(mode: .doubleTapOnly)
 

--- a/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
@@ -73,6 +73,62 @@ final class HotkeyManagerTests: XCTestCase {
         )
     }
 
+    func testSingleTapToggleModifierStartsOnBareReleaseAndStopsOnNextBareRelease() {
+        let manager = HotkeyManager(trigger: .fn, gestureMode: .singleTapToggle)
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_000
+            ),
+            []
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_050
+            ),
+            [.startRecording(mode: .persistent)]
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_200
+            ),
+            []
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_250
+            ),
+            [.stopRecording]
+        )
+    }
+
+    func testSingleTapToggleModifierIgnoresNonBareShortcutUse() {
+        let manager = HotkeyManager(trigger: .command, gestureMode: .singleTapToggle)
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskCommand],
+                timestampMs: 1_000
+            ),
+            []
+        )
+        XCTAssertEqual(
+            manager.modifierKeyDownOutputsForTesting(keyCode: 8, timestampMs: 1_025),
+            []
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_050
+            ),
+            []
+        )
+    }
+
     func testSuppressedHoldOnlyManagerDoesNotStartUntilReset() {
         let manager = HotkeyManager(trigger: .fn, gestureMode: .holdOnly)
 
@@ -168,6 +224,35 @@ final class HotkeyManagerTests: XCTestCase {
         XCTAssertTrue(keyUp.shouldSwallow)
     }
 
+    func testSingleTapToggleGestureModeWorksForKeyCodeTriggers() {
+        let trigger = HotkeyTrigger.fromKeyCode(119)
+        let manager = HotkeyManager(trigger: trigger, gestureMode: .singleTapToggle)
+
+        let firstDown = manager.keyCodeEventDecisionForTesting(
+            type: .keyDown,
+            keyCode: 119,
+            timestampMs: 1_000
+        )
+        XCTAssertEqual(firstDown.outputs, [.startRecording(mode: .persistent)])
+        XCTAssertTrue(firstDown.shouldSwallow)
+
+        let firstUp = manager.keyCodeEventDecisionForTesting(
+            type: .keyUp,
+            keyCode: 119,
+            timestampMs: 1_050
+        )
+        XCTAssertEqual(firstUp.outputs, [])
+        XCTAssertTrue(firstUp.shouldSwallow)
+
+        let secondDown = manager.keyCodeEventDecisionForTesting(
+            type: .keyDown,
+            keyCode: 119,
+            timestampMs: 1_200
+        )
+        XCTAssertEqual(secondDown.outputs, [.stopRecording])
+        XCTAssertTrue(secondDown.shouldSwallow)
+    }
+
     func testHoldOnlyGestureModeStopsChordWhenRequiredModifierReleasesFirst() {
         let trigger = HotkeyTrigger.chord(modifiers: ["control", "shift"], keyCode: 15)
         let manager = HotkeyManager(trigger: trigger, gestureMode: .holdOnly)
@@ -211,6 +296,38 @@ final class HotkeyManagerTests: XCTestCase {
         XCTAssertTrue(keyUp.shouldSwallow)
     }
 
+    func testSingleTapToggleGestureModeWorksForFnSpaceChord() {
+        let trigger = HotkeyTrigger.defaultDictation
+        let manager = HotkeyManager(trigger: trigger, gestureMode: .singleTapToggle)
+
+        let firstDown = manager.chordEventDecisionForTesting(
+            type: .keyDown,
+            keyCode: 49,
+            flags: trigger.chordEventFlags,
+            timestampMs: 1_000
+        )
+        XCTAssertEqual(firstDown.outputs, [.startRecording(mode: .persistent)])
+        XCTAssertTrue(firstDown.shouldSwallow)
+
+        let firstUp = manager.chordEventDecisionForTesting(
+            type: .keyUp,
+            keyCode: 49,
+            flags: trigger.chordEventFlags,
+            timestampMs: 1_050
+        )
+        XCTAssertEqual(firstUp.outputs, [])
+        XCTAssertTrue(firstUp.shouldSwallow)
+
+        let secondDown = manager.chordEventDecisionForTesting(
+            type: .keyDown,
+            keyCode: 49,
+            flags: trigger.chordEventFlags,
+            timestampMs: 1_200
+        )
+        XCTAssertEqual(secondDown.outputs, [.stopRecording])
+        XCTAssertTrue(secondDown.shouldSwallow)
+    }
+
     func testHoldOnlyGestureModeWorksForModifierChordTriggers() {
         let trigger = HotkeyTrigger.modifierChord(modifiers: ["control", "option"])
         let manager = HotkeyManager(trigger: trigger, gestureMode: .holdOnly)
@@ -233,6 +350,26 @@ final class HotkeyManagerTests: XCTestCase {
                 .cancelHoldWindow,
                 .stopRecording,
             ]
+        )
+    }
+
+    func testSingleTapToggleModifierChordStartsOnBareRelease() {
+        let trigger = HotkeyTrigger.modifierChord(modifiers: ["control", "option"])
+        let manager = HotkeyManager(trigger: trigger, gestureMode: .singleTapToggle)
+
+        XCTAssertEqual(
+            manager.modifierChordFlagsChangedOutputsForTesting(
+                flags: [.maskControl, .maskAlternate],
+                timestampMs: 1_000
+            ),
+            []
+        )
+        XCTAssertEqual(
+            manager.modifierChordFlagsChangedOutputsForTesting(
+                flags: [.maskControl],
+                timestampMs: 1_050
+            ),
+            [.startRecording(mode: .persistent)]
         )
     }
 

--- a/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
@@ -328,6 +328,41 @@ final class HotkeyManagerTests: XCTestCase {
         XCTAssertTrue(secondDown.shouldSwallow)
     }
 
+    func testDefaultFnSpaceChordCancelsPendingPushToTalkBeforeHandsFreeStarts() {
+        let pushToTalk = HotkeyManager(
+            trigger: .defaultPushToTalk,
+            gestureMode: .holdOnly,
+            startupDebounceMs: FnKeyStateMachine.defaultTapThresholdMs
+        )
+        let handsFree = HotkeyManager(trigger: .defaultDictation, gestureMode: .singleTapToggle)
+
+        XCTAssertEqual(
+            pushToTalk.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_000
+            ),
+            [.scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultTapThresholdMs)]
+        )
+
+        XCTAssertEqual(
+            pushToTalk.modifierKeyDownOutputsForTesting(keyCode: 49, timestampMs: 1_200),
+            [
+                .cancelStartupDebounce,
+                .cancelHoldWindow,
+            ]
+        )
+        XCTAssertEqual(pushToTalk.startupDebounceElapsedForTesting(), [])
+
+        let handsFreeStart = handsFree.chordEventDecisionForTesting(
+            type: .keyDown,
+            keyCode: 49,
+            flags: HotkeyTrigger.defaultDictation.chordEventFlags,
+            timestampMs: 1_200
+        )
+        XCTAssertEqual(handsFreeStart.outputs, [.startRecording(mode: .persistent)])
+        XCTAssertTrue(handsFreeStart.shouldSwallow)
+    }
+
     func testHoldOnlyGestureModeWorksForModifierChordTriggers() {
         let trigger = HotkeyTrigger.modifierChord(modifiers: ["control", "option"])
         let manager = HotkeyManager(trigger: trigger, gestureMode: .holdOnly)

--- a/Tests/MacParakeetTests/Hotkey/HotkeyTriggerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyTriggerTests.swift
@@ -396,6 +396,11 @@ final class HotkeyTriggerTests: XCTestCase {
         XCTAssertEqual(trigger.validation, .allowed)
     }
 
+    func testDefaultHandsFreeAndPushToTalkDoNotOverlap() {
+        XCTAssertFalse(HotkeyTrigger.defaultDictation.overlaps(with: .defaultPushToTalk))
+        XCTAssertFalse(HotkeyTrigger.defaultPushToTalk.overlaps(with: .defaultDictation))
+    }
+
     // MARK: - Chord Validation
 
     func testChordValidationDefaultAllowed() {

--- a/Tests/MacParakeetTests/Hotkey/HotkeyTriggerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyTriggerTests.swift
@@ -194,9 +194,9 @@ final class HotkeyTriggerTests: XCTestCase {
 
     // MARK: - Persistence
 
-    func testCurrentDefaultsToFn() {
+    func testCurrentDefaultsToHandsFreeShortcut() {
         testDefaults.removeObject(forKey: "hotkeyTrigger")
-        XCTAssertEqual(HotkeyTrigger.current(defaults: testDefaults), .fn)
+        XCTAssertEqual(HotkeyTrigger.current(defaults: testDefaults), .defaultDictation)
     }
 
     func testSaveAndLoad() throws {
@@ -250,9 +250,9 @@ final class HotkeyTriggerTests: XCTestCase {
         )
     }
 
-    func testLegacyStringInvalidFallsBackToFn() {
+    func testLegacyStringInvalidFallsBackToHandsFreeDefault() {
         testDefaults.set("invalid_key", forKey: "hotkeyTrigger")
-        XCTAssertEqual(HotkeyTrigger.current(defaults: testDefaults), .fn)
+        XCTAssertEqual(HotkeyTrigger.current(defaults: testDefaults), .defaultDictation)
     }
 
     // MARK: - Validation
@@ -384,6 +384,16 @@ final class HotkeyTriggerTests: XCTestCase {
         let trigger = HotkeyTrigger.chord(modifiers: ["option"], keyCode: 96)
         XCTAssertEqual(trigger.displayName, "Option+F5")
         XCTAssertEqual(trigger.shortSymbol, "⌥F5")
+    }
+
+    func testFnSpaceChordDisplayAndFlags() {
+        let trigger = HotkeyTrigger.defaultDictation
+
+        XCTAssertEqual(trigger, .chord(modifiers: ["fn"], keyCode: 49))
+        XCTAssertEqual(trigger.displayName, "Fn+Space")
+        XCTAssertEqual(trigger.shortSymbol, "fn+Space")
+        XCTAssertEqual(trigger.chordEventFlags, 0x00800000)
+        XCTAssertEqual(trigger.validation, .allowed)
     }
 
     // MARK: - Chord Validation

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -1194,11 +1194,51 @@ final class SettingsViewModelTests: XCTestCase {
 
         let vm = SettingsViewModel(defaults: testDefaults)
 
+        XCTAssertEqual(vm.hotkeyTrigger, .defaultDictation)
         XCTAssertEqual(vm.pushToTalkHotkeyTrigger, legacyTrigger)
 
-        vm.hotkeyTrigger = .control
         let vm2 = SettingsViewModel(defaults: testDefaults)
+        XCTAssertEqual(vm2.hotkeyTrigger, .defaultDictation)
         XCTAssertEqual(vm2.pushToTalkHotkeyTrigger, legacyTrigger)
+    }
+
+    func testLegacyHotkeyOverlappingDefaultHandsFreeDisablesHandsFreeDuringMigration() {
+        let legacyTrigger = HotkeyTrigger.fromKeyCode(49)
+        testDefaults.removeObject(forKey: HotkeyTrigger.pushToTalkDefaultsKey)
+        legacyTrigger.save(to: testDefaults)
+
+        let vm = SettingsViewModel(defaults: testDefaults)
+
+        XCTAssertEqual(vm.hotkeyTrigger, .disabled)
+        XCTAssertEqual(vm.pushToTalkHotkeyTrigger, legacyTrigger)
+        XCTAssertEqual(HotkeyTrigger.current(defaults: testDefaults), .disabled)
+        XCTAssertEqual(
+            HotkeyTrigger.current(
+                defaults: testDefaults,
+                defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey,
+                fallback: .defaultPushToTalk
+            ),
+            legacyTrigger
+        )
+    }
+
+    func testMissingHandsFreeKeyAvoidsExistingDedicatedPushToTalkDuringDefaultMigration() {
+        testDefaults.removeObject(forKey: HotkeyTrigger.defaultsKey)
+        HotkeyTrigger.defaultDictation.save(to: testDefaults, defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey)
+
+        let vm = SettingsViewModel(defaults: testDefaults)
+
+        XCTAssertEqual(vm.hotkeyTrigger, .disabled)
+        XCTAssertEqual(vm.pushToTalkHotkeyTrigger, .defaultDictation)
+        XCTAssertEqual(HotkeyTrigger.current(defaults: testDefaults), .disabled)
+        XCTAssertEqual(
+            HotkeyTrigger.current(
+                defaults: testDefaults,
+                defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey,
+                fallback: .defaultPushToTalk
+            ),
+            .defaultDictation
+        )
     }
 
     func testLegacyDefaultFnHandsFreeMigratesToFnSpaceWithoutChangingPushToTalk() {
@@ -1231,13 +1271,35 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(vm.pushToTalkHotkeyTrigger, dedicatedTrigger)
     }
 
+    func testStoredFnHandsFreePersistsWhenDedicatedPushToTalkDiffers() {
+        let dedicatedTrigger = HotkeyTrigger.fromKeyCode(119)
+        HotkeyTrigger.fn.save(to: testDefaults)
+        dedicatedTrigger.save(to: testDefaults, defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey)
+
+        let vm = SettingsViewModel(defaults: testDefaults)
+
+        XCTAssertEqual(vm.hotkeyTrigger, .fn)
+        XCTAssertEqual(vm.pushToTalkHotkeyTrigger, dedicatedTrigger)
+    }
+
+    func testStoredFnHandsFreePersistsWhenDedicatedPushToTalkUsesFnSpace() {
+        HotkeyTrigger.fn.save(to: testDefaults)
+        HotkeyTrigger.defaultDictation.save(to: testDefaults, defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey)
+
+        let vm = SettingsViewModel(defaults: testDefaults)
+
+        XCTAssertEqual(vm.hotkeyTrigger, .fn)
+        XCTAssertEqual(vm.pushToTalkHotkeyTrigger, .defaultDictation)
+    }
+
     func testHotkeyTriggerBackwardCompatibleWithLegacyString() {
         // Simulate a legacy UserDefaults value from the old TriggerKey enum
+        testDefaults.removeObject(forKey: HotkeyTrigger.pushToTalkDefaultsKey)
         testDefaults.set("option", forKey: "hotkeyTrigger")
 
         let vm = SettingsViewModel(defaults: testDefaults)
-        XCTAssertEqual(vm.hotkeyTrigger, .option)
-        XCTAssertEqual(vm.hotkeyTrigger.displayName, "Option")
+        XCTAssertEqual(vm.hotkeyTrigger, .defaultDictation)
+        XCTAssertEqual(vm.pushToTalkHotkeyTrigger, .option)
     }
 
     // MARK: - Round-trip

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -1132,12 +1132,28 @@ final class SettingsViewModelTests: XCTestCase {
 
     // MARK: - Hotkey Trigger
 
-    func testHotkeyTriggerDefaultsToFn() {
-        XCTAssertEqual(viewModel.hotkeyTrigger, .fn)
+    func testHotkeyTriggerDefaultsToFnSpace() {
+        XCTAssertEqual(viewModel.hotkeyTrigger, .defaultDictation)
     }
 
     func testPushToTalkHotkeyTriggerDefaultsToFn() {
         XCTAssertEqual(viewModel.pushToTalkHotkeyTrigger, .fn)
+    }
+
+    func testDefaultDictationAndPushToTalkHotkeysPersistForFreshDefaults() {
+        let vm = SettingsViewModel(defaults: testDefaults)
+
+        XCTAssertEqual(vm.hotkeyTrigger, .defaultDictation)
+        XCTAssertEqual(vm.pushToTalkHotkeyTrigger, .defaultPushToTalk)
+        XCTAssertEqual(HotkeyTrigger.current(defaults: testDefaults), .defaultDictation)
+        XCTAssertEqual(
+            HotkeyTrigger.current(
+                defaults: testDefaults,
+                defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey,
+                fallback: .defaultPushToTalk
+            ),
+            .defaultPushToTalk
+        )
     }
 
     func testHotkeyTriggerPersistsKeyCode() {
@@ -1183,6 +1199,25 @@ final class SettingsViewModelTests: XCTestCase {
         vm.hotkeyTrigger = .control
         let vm2 = SettingsViewModel(defaults: testDefaults)
         XCTAssertEqual(vm2.pushToTalkHotkeyTrigger, legacyTrigger)
+    }
+
+    func testLegacyDefaultFnHandsFreeMigratesToFnSpaceWithoutChangingPushToTalk() {
+        testDefaults.removeObject(forKey: HotkeyTrigger.pushToTalkDefaultsKey)
+        HotkeyTrigger.fn.save(to: testDefaults)
+
+        let vm = SettingsViewModel(defaults: testDefaults)
+
+        XCTAssertEqual(vm.hotkeyTrigger, .defaultDictation)
+        XCTAssertEqual(vm.pushToTalkHotkeyTrigger, .defaultPushToTalk)
+        XCTAssertEqual(HotkeyTrigger.current(defaults: testDefaults), .defaultDictation)
+        XCTAssertEqual(
+            HotkeyTrigger.current(
+                defaults: testDefaults,
+                defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey,
+                fallback: .defaultPushToTalk
+            ),
+            .defaultPushToTalk
+        )
     }
 
     func testPushToTalkDedicatedDefaultsKeyWinsOverLegacyDictationHotkey() {

--- a/Tests/MacParakeetTests/Views/Settings/HotkeyRecorderViewTests.swift
+++ b/Tests/MacParakeetTests/Views/Settings/HotkeyRecorderViewTests.swift
@@ -87,6 +87,26 @@ final class HotkeyRecorderViewTests: XCTestCase {
         XCTAssertEqual(candidate, .chord(modifiers: ["option"], keyCode: 8))
     }
 
+    func testGenericRecordingAllowsFnKeyChords() {
+        let candidate = HotkeyRecorderView.keyChordTrigger(
+            modifiers: ["fn"],
+            keyCode: 49,
+            captureMode: .generic
+        )
+
+        XCTAssertEqual(candidate, .defaultDictation)
+    }
+
+    func testBareFnCaptureRemainsSupported() {
+        let candidate = HotkeyRecorderView.bareModifierTrigger(
+            for: "fn",
+            keyCode: 63,
+            captureMode: .generic
+        )
+
+        XCTAssertEqual(candidate, .fn)
+    }
+
     func testSingleModifierDoesNotBecomeModifierChord() {
         let candidate = HotkeyRecorderView.modifierChordTrigger(
             components: [.init(modifierName: "option", keyCode: 61)],

--- a/docs/agents/demo-agents.md
+++ b/docs/agents/demo-agents.md
@@ -151,7 +151,7 @@ ffmpeg -y -i /tmp/demo.mov -i /tmp/narration.aiff \
   outside the app, and other apps never bleed in.
 - `cliclick kp:f18` deterministically fires the dictation hotkey — F18 is
   unbound by macOS and matches ADR-009 single-key support; no
-  accidental modifier collisions like the Fn-double-tap chord case.
+  accidental modifier collisions like the Fn-chord case.
 - `afplay -d BlackHole2ch` is the magic step: it sends a pre-recorded
   utterance to the BlackHole virtual output, which MacParakeet sees as a
   mic input. Same Parakeet pipeline, fully scripted, byte-identical every run.

--- a/docs/agents/qa-agents.md
+++ b/docs/agents/qa-agents.md
@@ -6,7 +6,7 @@
 
 Every quarter someone pitches an "AI does QA" tool. Most are web-first or
 mobile-first. MacParakeet is a menu-bar macOS app with a non-activating
-`KeylessPanel` overlay, a global Fn-double-tap hotkey, and TCC-gated
+`KeylessPanel` overlay, global dictation hotkeys, and TCC-gated
 microphone/screen-recording flows. The general AI-QA frontier doesn't speak
 our shape yet. This doc tracks who's close, where the real gaps are, and the
 hybrid 2026 play that actually works for us today.
@@ -46,7 +46,7 @@ beat:
 | **`mediar-ai/mcp-server-macos-use`** (Swift MCP server) | Promising, active 2026 | Walks `AXUIElement` trees, posts `AXPress`/`AXSetValue`; structured KB-sized AX trees instead of pixels | No assertion harness — it's a control surface, not a test framework |
 | **`l-priebe/XCUITestAgent`** | Experimental, single-dev | LLM watches debug+screen state, taps elements without `accessibilityIdentifier` | Demo-quality; GPT-4o-pinned; no macOS-target story |
 | **AgentSkill** (Jan 2026) | Promising SaaS | Plain-English → flake-free XCUITest **and** patches the app to add missing identifiers — closes the testability loop | iOS-focused; not validated on menu-bar/NSPanel/hotkey shapes |
-| **Hammerspoon** (Lua + `hs.eventtap`) | Mature classic | Synthesizes Fn double-taps, drives menu-bar items, watches system events | Not LLM-aware; no assertion library; **but the only reliable Fn-chord simulator in existence** |
+| **Hammerspoon** (Lua + `hs.eventtap`) | Mature classic | Synthesizes Fn holds and Fn+key chords, drives menu-bar items, watches system events | Not LLM-aware; no assertion library; **but the only reliable Fn-chord simulator in existence** |
 | Maestro, Sauce Labs, BrowserStack, TestSprite, testRigor | Mobile/web-first | — | None target macOS-app native; Sauce's Apple Silicon support is browser-only |
 
 ## What blocks "describe a flow → agent verifies it" for MacParakeet today
@@ -58,7 +58,7 @@ in 2026:
    address it via the AX tree, but `canBecomeKey == false` plus
    `.activeAlways` tracking-area workarounds make SwiftUI gestures and
    inspectors flaky.
-2. **Global hotkey, especially Fn double-tap.** XCUITest cannot generate
+2. **Global hotkeys, especially Fn and Fn+key chords.** XCUITest cannot generate
    `CGEventTap`-level Fn presses outside the app under test. Hammerspoon's
    `hs.eventtap` is the only reliable simulator — or bind to F18/F19 via
    ADR-009 so a single keypress works.
@@ -98,7 +98,7 @@ four-layer hybrid:
    exists for Mac native today; speaks structured AX trees instead of slow
    screenshots. ~90 minutes to wire up locally.
 4. **A small Hammerspoon harness** (~200 lines of Lua + osascript) as the
-   stopgap for the things AI agents can't do — Fn double-tap, drag-drop,
+   stopgap for the things AI agents can't do — Fn holds/chords, drag-drop,
    menu-bar interaction. Buys 12–18 months until native-Mac AI test agents
    mature.
 

--- a/docs/design-overhaul.md
+++ b/docs/design-overhaul.md
@@ -344,8 +344,8 @@ The overall tone is **warm, organic, slightly mystical**. Think singing bowls, s
 
 | Event | Sound Character | Duration | Notes |
 |-------|----------------|----------|-------|
-| Recording start | Soft ascending chime — like tapping a small singing bowl | 300-500ms | Plays when Fn double-tap starts recording |
-| Recording stop | Gentle descending tone — the bowl settling | 200-400ms | Plays when Fn stops recording |
+| Recording start | Soft ascending chime — like tapping a small singing bowl | 300-500ms | Plays when hands-free dictation starts recording |
+| Recording stop | Gentle descending tone — the bowl settling | 200-400ms | Plays when dictation stops |
 | Transcription complete | Warm "ding" — a bell with slow decay | 400-600ms | Success moment, should feel satisfying |
 | File dropped into portal | Soft whoosh + subtle crystal tone | 300-500ms | Accompanies the portal animation |
 | Error | Low, muted tone — not alarming, just "hmm" | 300ms | Should not startle |
@@ -554,7 +554,7 @@ Every empty state is a **personality moment**:
 
 | Empty State | Copy | Visual |
 |-------------|------|--------|
-| No dictations | "Your voice, captured. Press Fn to start." | Large warm merkaba, gentle pulse |
+| No dictations | "Your voice, captured. Tap Fn+Space to start." | Large warm merkaba, gentle pulse |
 | No transcriptions | "Drop a file and watch the magic happen." | Merkaba with subtle upward particle drift |
 | Search no results | "Nothing matched. Try different words?" | Merkaba at low opacity, still |
 | Error | "Hmm, something went wrong." + actionable detail | Warm error card, not stark red |

--- a/docs/research/wisprflow-reverse-engineering-2026-05.md
+++ b/docs/research/wisprflow-reverse-engineering-2026-05.md
@@ -421,7 +421,7 @@ This feeds back into personalization — WisprFlow learns from how users correct
 
 | Mode | Trigger | Behavior |
 |------|---------|----------|
-| PTT (push-to-talk) | Hold Fn (or double-tap Fn) | Hold to record, release to transcribe |
+| PTT (push-to-talk) | Hold Fn | Hold to record, release to transcribe |
 | Popo (tap-to-talk) | Fn+Space (macOS) / Ctrl+Win+Space (Windows) | Tap to start, tap to stop |
 
 The state machine tracks `ACTIVE_PTT` and `ACTIVE_POPO` as parallel states with separate debounce logic (`DebouncePTT` vs `DebouncePOPO`). The `transcriptCommand` column categorizes recordings as `"ptt"` or `"popo"` (or `"lens"` or `"command"`).

--- a/spec/00-vision.md
+++ b/spec/00-vision.md
@@ -30,7 +30,7 @@
 
 Three capture modes plus one optional selected-text AI utility. That is the product:
 
-1. **Dictate anywhere** -- Press Fn (or your configured hotkey), speak, release. Text appears where your cursor is.
+1. **Dictate anywhere** -- Tap Fn+Space for hands-free dictation, or hold Fn for push-to-talk. Text appears where your cursor is.
 2. **Drop a file** -- Drag audio/video in. Get a transcript out.
 3. **Record a meeting** -- Capture system audio + mic, get a transcript when you stop.
 4. **Transform selected text** -- Press a bound Transform hotkey to rewrite selected text through your configured LLM provider.
@@ -81,7 +81,7 @@ This is not privacy theater ("your data is encrypted in transit"). This is priva
 
 MacWhisper has 50+ features. MacParakeet has three capture modes plus Transforms.
 
-- **Dictate** -- Press Fn, speak, text appears at cursor. Works in any app.
+- **Dictate** -- Tap Fn+Space or hold Fn, speak, and text appears at cursor. Works in any app.
 - **Transcribe** -- Drop a file, get text out. Audio, video, YouTube links.
 - **Record** -- Capture a meeting (system audio + mic), get a transcript.
 - **Transform** -- Select text anywhere, press a bound hotkey, rewrite it through your configured LLM provider.

--- a/spec/00-vision.md
+++ b/spec/00-vision.md
@@ -136,9 +136,9 @@ That does not mean monetization is permanently forbidden. GPL permits charging f
 +-----------------------------------------------------------------------+
 |  Any app. Any text field. Any time.                                   |
 |                                                                       |
-|  1. Press and hold Fn (or double-tap Fn)                              |
+|  1. Hold Fn for push-to-talk or tap Fn+Space for hands-free           |
 |  2. Speak naturally                                                   |
-|  3. Release Fn                                                        |
+|  3. Release Fn, or tap Fn+Space again                                 |
 |  4. Clean text appears at cursor in <500ms                            |
 |                                                                       |
 |  +-----------------------------------------+                          |

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -16,7 +16,7 @@ See [00-vision.md](./00-vision.md) for positioning and market context.
 │  v0.1 - "Core" (MVP)                                            │
 │  "Dictation + Transcription — fast, private, done"              │
 ├─────────────────────────────────────────────────────────────────┤
-│  • System-wide dictation (Fn key: double-tap + hold-to-talk)    │
+│  • System-wide dictation (Fn hold + Fn+Space hands-free)        │
 │  • Persistent idle pill (always-visible click-to-dictate pill)  │
 │  • File transcription (drag-and-drop audio/video)               │
 │  • Menu bar app with main window                                │
@@ -137,29 +137,29 @@ See [00-vision.md](./00-vision.md) for positioning and market context.
 
 **Activation — Configurable Hotkey:**
 
-The hotkey (default: `Fn`, configurable via a "record a shortcut" UI in Settings) serves as the universal activation trigger with two coexisting modes. Supports bare modifiers (Fn, Control, etc.), standalone keys (F5, Tab, etc.), modifier+key chords (Cmd+9 or Ctrl+Shift+D), and modifier-only chords (Command+Option, including side-specific variants like Right Command+Right Option). See ADR-009 for full details.
+Dictation has two configurable shortcuts: push-to-talk defaults to `Fn`, and hands-free mode defaults to `Fn+Space`. The "record a shortcut" UI supports bare modifiers (Fn, Control, etc.), standalone keys (F5, Tab, etc.), modifier+key chords (Fn+Space, Cmd+9, Ctrl+Shift+D), and modifier-only chords (Command+Option, including side-specific variants like Right Command+Right Option). See ADR-009 for full details.
 
 | Mode | Gesture | Behavior |
 |------|---------|----------|
-| **Double-tap** | Tap hotkey twice within 400ms | Persistent recording. Press hotkey again to stop. |
-| **Press-and-hold** | Hold hotkey for > 400ms | Hold-to-talk. Release auto-stops and pastes. |
+| **Hands-free** | Tap the hands-free shortcut | Persistent recording. Tap the shortcut again to stop. |
+| **Press-and-hold** | Hold the push-to-talk shortcut | Hold-to-talk. Release auto-stops and pastes. |
 
-Both modes coexist with no configuration required. The 400ms threshold distinguishes taps from holds.
+Both modes coexist with no double-tap requirement.
 
 **Implementation:**
 - `CGEvent` tap for system-wide key event interception
 - `HotkeyTrigger` struct with `.modifier` / `.keyCode` / `.chord` / `.modifierChord` kind discriminator (see ADR-009)
 - Modifier triggers: `flagsChanged` events with `CGEventFlags` mask, bare-tap filtering
 - KeyCode triggers: `keyDown`/`keyUp` events with event swallowing, edge detection via `triggerKeyIsPressed` boolean
-- Modifier+key chord triggers: require ALL modifier flags present on `keyDown` of the trigger key. Release-any-part behavior: releasing either the trigger key or any required modifier stops dictation. `chordModifierReleased` flag prevents double-fire when modifier is released while trigger key is still held.
+- Modifier+key chord triggers: require ALL modifier flags present on `keyDown` of the trigger key. Hold-to-talk chord triggers use release-any-part behavior: releasing either the trigger key or any required modifier stops dictation. `chordModifierReleased` flag prevents double-fire when modifier is released while trigger key is still held.
 - Modifier-only chord triggers: require an exact set of 2+ chord-eligible modifiers before emitting the same key-agnostic gesture signals as single-key triggers. Generic and side-specific variants are persisted distinctly, and overlap checks block ambiguous assignments.
 - Edge detection: only fire on actual transitions of the target key state
 - Bare-tap filtering (modifiers only): if a regular key is pressed while the modifier is held (e.g., Ctrl+C), the release is not counted as a tap — prevents keyboard shortcuts from triggering dictation
-- Gesture interruption: if a non-Escape key is pressed during `waitingForSecondTap`, the state machine resets — prevents double-tap detection across typing
-- Chord validation: Escape blocked for all kinds. Modifier+key chords containing Command warn about system shortcut conflicts (Cmd+Tab, Cmd+Space, Cmd+Q/W/H/M). Fn is bare-modifier-only — not allowed in chords.
-- Combined-trigger key-down: schedule startup debounce and a 400ms hold window. A second tap inside the window enters hands-free persistent mode; holding past the window confirms push-to-talk.
-- Dedicated push-to-talk key-down: schedule only the startup debounce, then start hold-to-talk because there is no double-tap ambiguity.
-- On key-up: quick taps discard any provisional capture for combined/double-tap detection; dedicated push-to-talk releases after startup debounce stop and process.
+- Gesture interruption: if a non-Escape key is pressed during the legacy double-tap waiting window, the state machine resets — prevents detection across typing
+- Chord validation: Escape blocked for all kinds. Modifier+key chords containing Command warn about system shortcut conflicts (Cmd+Tab, Cmd+Space, Cmd+Q/W/H/M). Fn is allowed in modifier+key chords such as Fn+Space.
+- Hands-free key-down: toggles persistent recording immediately for key and modifier+key triggers; bare modifier hands-free triggers toggle on bare release so normal modifier shortcuts are not captured.
+- Dedicated push-to-talk key-down: schedule only the startup debounce, then start hold-to-talk.
+- On key-up: dedicated push-to-talk releases after startup debounce stop and process.
 - Escape is permanently reserved for cancel-dictation and cannot be assigned as hotkey
 - Requires Accessibility permission (prompted on first activation).
 - Stop orchestration is state-driven (proceed, defer-until-recording, reject-not-recording) to avoid first-start races when stop arrives before `startRecording()` fully transitions to `.recording`.
@@ -170,8 +170,8 @@ Both modes coexist with no configuration required. The 400ms threshold distingui
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │ 1. User activates recording:                                     │
-│    - Double-tap Fn (persistent mode), OR                         │
-│    - Hold Fn > 400ms (hold-to-talk mode)                        │
+│    - Tap Fn+Space (hands-free persistent mode), OR               │
+│    - Hold Fn (hold-to-talk mode)                                 │
 ├─────────────────────────────────────────────────────────────────┤
 │ 2. Overlay appears (bottom-center pill)                          │
 │    - Recording indicator (waveform animation)                    │
@@ -309,9 +309,9 @@ Space is always reserved for the tooltip (opacity toggle, not conditional render
 ```
 
 **Acceptance criteria:**
-- [x] Double-tap hotkey activates persistent recording from any app
-- [x] Hold hotkey (> 400ms) activates hold-mode, release auto-stops and pastes
-- [x] Hotkey trigger configurable to bare modifiers, standalone keys, modifier+key chords, and modifier-only chords via record-a-shortcut UI; Fn remains bare-modifier-only and Escape remains reserved
+- [x] Hands-free shortcut activates persistent recording from any app
+- [x] Hold shortcut activates hold-mode, release auto-stops and pastes
+- [x] Hotkey trigger configurable to bare modifiers, standalone keys, modifier+key chords, and modifier-only chords via record-a-shortcut UI; Fn+Space is supported and Escape remains reserved
 - [x] Overlay appears at bottom-center with waveform animation
 - [x] Hover tooltips display correctly on non-activating panel
 - [ ] Parakeet transcribes with <500ms end-to-end latency for short dictations
@@ -456,7 +456,7 @@ The app lives primarily in the menu bar. Click the icon for quick actions, or op
 
 - Menu bar icon always visible, shows state: idle, recording (animated), processing
 - Click icon opens dropdown menu
-- "Start Dictation" activates recording (same as Fn double-tap)
+- "Start Dictation" activates recording (same as the hands-free shortcut)
 - "Recent Files" shows last 5 transcriptions with one-click copy
 - Dynamic dock behavior: dock icon appears when main window is open, hidden otherwise
 
@@ -607,7 +607,8 @@ Audio path is computed from ID by default. Files stored as WAV (16kHz mono). Use
 │                                                                  │
 │ DICTATION                                                        │
 │ ┌──────────────────────────────────────────────────────────────┐ │
-│ │ Hotkey: [fn Fn   Change...]  (double-tap / hold)            │ │
+│ │ Push to talk: [fn Fn   Change...]                          │ │
+│ │ Hands-free:  [fn+Space Change...]                          │ │
 │ │                                                              │ │
 │ │ Stop mode:                                                   │ │
 │ │   ( ) Auto-stop after silence     Delay: [2 sec ▾]          │ │
@@ -645,7 +646,8 @@ Audio path is computed from ID by default. Files stored as WAV (16kHz mono). Use
 | Setting | Options | Default |
 |---------|---------|---------|
 | Launch at login | On / Off | Off |
-| Dictation hotkey | Bare modifiers, standalone keys, modifier+key chords, and modifier-only chords with overlap checks | Fn (double-tap / hold) |
+| Push-to-talk hotkey | Bare modifiers, standalone keys, modifier+key chords, and modifier-only chords with overlap checks | Fn |
+| Hands-free hotkey | Bare modifiers, standalone keys, modifier+key chords, and modifier-only chords with overlap checks | Fn+Space |
 | Stop mode | Auto-stop after silence / Manual | Manual |
 | Silence delay | 1s, 1.5s, 2s, 3s, 5s | 2s |
 | Save audio recordings | On / Off | On |

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -155,7 +155,7 @@ Both modes coexist with no double-tap requirement.
 - Modifier-only chord triggers: require an exact set of 2+ chord-eligible modifiers before emitting the same key-agnostic gesture signals as single-key triggers. Generic and side-specific variants are persisted distinctly, and overlap checks block ambiguous assignments.
 - Edge detection: only fire on actual transitions of the target key state
 - Bare-tap filtering (modifiers only): if a regular key is pressed while the modifier is held (e.g., Ctrl+C), the release is not counted as a tap — prevents keyboard shortcuts from triggering dictation
-- Gesture interruption: if a non-Escape key is pressed during the legacy double-tap waiting window, the state machine resets — prevents detection across typing
+- Gesture interruption: if a non-Escape key is pressed during a pending tap/hold window, the state machine resets — prevents detection across typing
 - Chord validation: Escape blocked for all kinds. Modifier+key chords containing Command warn about system shortcut conflicts (Cmd+Tab, Cmd+Space, Cmd+Q/W/H/M). Fn is allowed in modifier+key chords such as Fn+Space.
 - Hands-free key-down: toggles persistent recording immediately for key and modifier+key triggers; bare modifier hands-free triggers toggle on bare release so normal modifier shortcuts are not captured.
 - Dedicated push-to-talk key-down: schedule only the startup debounce, then start hold-to-talk.
@@ -183,7 +183,7 @@ Both modes coexist with no double-tap requirement.
 ├─────────────────────────────────────────────────────────────────┤
 │ 4. User stops recording:                                         │
 │    - Release Fn (hold-to-talk auto-stop), OR                     │
-│    - Press Fn again (persistent mode), OR                        │
+│    - Tap Fn+Space again (hands-free mode), OR                    │
 │    - Press Escape (soft cancel with undo window), OR             │
 │    - Silence auto-stop (2s default, if enabled in settings)      │
 │    - If stop is requested while startup is in-flight, stop is     │
@@ -226,7 +226,7 @@ DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
 **Soft cancel (Esc):**
 - Pressing Escape during recording triggers soft cancel
 - 5-second undo window: overlay shows countdown ring + Undo button
-- During undo window, Fn key is blocked (prevents accidental re-activation)
+- During undo window, dictation shortcuts are blocked (prevents accidental re-activation)
 - Audio buffer preserved until countdown expires or user confirms discard
 - Tapping the countdown ring dismisses immediately (confirms discard)
 - Tapping Undo resumes processing (transcribe + paste)
@@ -237,7 +237,7 @@ Compact dark pill, icon-only controls, positioned at bottom-center of screen (40
 
 ```
          ┌───────────────────────────────┐
-         │  Stop & paste (Fn)            │  ← Hover tooltip (dark capsule)
+         │  Stop & paste                 │  ← Hover tooltip (dark capsule)
          └───────────────────────────────┘
          ┌─────────────────────────────┐
          │  [X] ∿∿∿∿∿∿∿∿∿∿∿∿  [■]    │  ← Recording pill
@@ -251,12 +251,12 @@ Compact dark pill, icon-only controls, positioned at bottom-center of screen (40
 **Controls:** Icon buttons only, no text labels
 **Border:** Subtle white stroke (`Color.white.opacity(0.1)`, 1px)
 
-**Hover tooltips:** AppKit-level `MouseTrackingOverlay` using `NSTrackingArea` with `.activeAlways` flag (required because the overlay is a non-activating `NSPanel`). Sits on top of the hosting view with `hitTest -> nil` for click passthrough. Zone-based detection by relative X position. Tooltips render as dark capsule positioned above the pill with 13pt medium white text. Keyboard shortcuts highlighted in light blue.
+**Hover tooltips:** AppKit-level `MouseTrackingOverlay` using `NSTrackingArea` with `.activeAlways` flag (required because the overlay is a non-activating `NSPanel`). Sits on top of the hosting view with `hitTest -> nil` for click passthrough. Zone-based detection by relative X position. Tooltips render as dark capsule positioned above the pill with 13pt medium white text. Keyboard shortcuts are highlighted only when the action has a fixed shortcut.
 
 | Zone | Tooltip | Shortcut Highlight |
 |------|---------|-------------------|
 | X button (left) | Cancel | `Esc` in blue |
-| Stop button (right) | Stop & paste | Trigger key name in blue |
+| Stop button (right) | Stop & paste | -- |
 | Countdown ring | Dismiss | -- |
 | Undo button | Undo | -- |
 
@@ -267,14 +267,14 @@ Space is always reserved for the tooltip (opacity toggle, not conditional render
 1. **Recording** -- `[X cancel] [waveform 12 bars] [stop]` (~150px)
    - X button: white icon on dark circle (0.2 opacity background), triggers soft cancel (Esc)
    - Waveform: 12 white bars, 3px wide, max 20px tall, center-peaking wave pattern, updates in real-time from audio level
-   - Stop button: white square (10x10, cornerRadius 3) inside red circle, triggers stop (Fn)
+   - Stop button: white square (10x10, cornerRadius 3) inside red circle, triggers stop
    - Recording timer displayed (e.g., "0:03") -- hover tooltips provide additional guidance
 
 2. **Cancelled** -- `[countdown ring] [Undo button]` (~140px)
    - Countdown ring: circular progress indicator (accent color, depletes over 5 seconds) with remaining seconds number in center
    - Tap ring to dismiss immediately (confirms discard)
    - Undo button: "Undo" text on subtle white background (0.15 opacity), rounded rect
-   - 5-second countdown, Fn key blocked during cancel window
+   - 5-second countdown, dictation shortcuts blocked during cancel window
    - Audio buffer preserved until confirmed discard
 
 3. **Processing** -- `[spinner] [red dot]` (~100px)
@@ -444,7 +444,7 @@ The app lives primarily in the menu bar. Click the icon for quick actions, or op
 ┌────────────────────────────┐
 │ 🎙 MacParakeet              │
 ├────────────────────────────┤
-│ Start Dictation        Fn   │
+│ Start Dictation  Fn+Space   │
 │ Open Window            ⌘O   │
 ├────────────────────────────┤
 │ Recent Files            ►   │
@@ -612,7 +612,7 @@ Audio path is computed from ID by default. Files stored as WAV (16kHz mono). Use
 │ │                                                              │ │
 │ │ Stop mode:                                                   │ │
 │ │   ( ) Auto-stop after silence     Delay: [2 sec ▾]          │ │
-│ │   (•) Manual stop (press Fn again)                           │ │
+│ │   (•) Manual stop (tap hands-free shortcut again)             │ │
 │ │                                                              │ │
 │ └──────────────────────────────────────────────────────────────┘ │
 │                                                                  │

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -242,7 +242,7 @@ Persistent floating pill at the bottom-center of the screen, always visible when
 
 - **Show:** On app launch and after every dictation exit (stop, cancel, error, dismiss)
 - **Hide:** When dictation starts
-- **Click:** Starts persistent dictation (same as double-tap Fn)
+- **Click:** Starts persistent dictation (same as the hands-free shortcut)
 - **Hover:** Expands pill, shows tooltip
 - **Mouse exit:** Collapses pill, hides tooltip
 - **Focus:** Never steals focus (non-activating panel)
@@ -744,12 +744,11 @@ Settings open in the content area when "Settings" is selected in the sidebar. Th
 │  DICTATION                                                │
 │  ─────────────────────────────────────────────────────    │
 │                                                           │
-│  Hotkey                       [fn Fn        ▾]          │
-│  (Double-tap to start dictation)                         │
+│  Push to talk                [fn Fn        ▾]          │
+│  (Hold to dictate, release to stop)                       │
 │                                                           │
-│  Stop mode                    [● Hold to record]         │
-│                               [  Double-tap toggle]      │
-│  (Hold: release key to stop. Toggle: tap again to stop)  │
+│  Hands-free mode             [fn+Space    ▾]          │
+│  (Tap to start, tap again to stop)                       │
 │                                                           │
 │  Silence threshold            [──●──────── 2.0s]        │
 │  (Auto-stop after this much silence)                     │

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -223,7 +223,7 @@ Persistent floating pill at the bottom-center of the screen, always visible when
 
 ```
   ╭────────────────────────────────────────────╮
-  │  Click or hold fn to start dictating       │  ← tooltip bubble
+  │  Click, tap fn+Space or hold fn to dictate │  ← tooltip bubble
   ╰────────────────────────────────────────────╯
 ┌──────────────────────────────────────────┐
 │    ╭──────────────────────────────╮      │
@@ -233,8 +233,8 @@ Persistent floating pill at the bottom-center of the screen, always visible when
 
 - 148×30pt expanded dark capsule (black 85%)
 - 12 small dots (3pt, white 25%) inside pill
-- Tooltip bubble above: "Click or hold fn to start dictating"
-  - "fn" in pink (0.85, 0.55, 0.75)
+- Tooltip bubble above: "Click, tap fn+Space or hold fn to dictate"
+  - Shortcut tokens in pink (0.85, 0.55, 0.75)
   - Dark capsule background (black 90%) with white 10% stroke
 ```
 
@@ -288,7 +288,7 @@ Compact dark pill overlay, always-on-top, bottom-center of screen. This is the p
 - [■] Stop button (SF Symbol: stop.circle.fill, white)
   - Hover: red glow (red 30% background), 10% scale-up
 - Tooltip on [✕]: "Cancel (Esc)"
-- Tooltip on [■]: "Stop & Paste (↵)"
+- Tooltip on [■]: "Stop & Paste"
 ```
 
 **2. Cancelled**

--- a/spec/09-testing.md
+++ b/spec/09-testing.md
@@ -278,47 +278,47 @@ Tests/
 
 These flows must be tested manually after any overlay or hotkey changes. Automated unit tests cover the state machine logic, but the full UX requires human verification.
 
-> **Note:** "Fn" below refers to whichever trigger key is configured (Fn, Control, Option, Shift, or Command). Default is Fn. Test with at least two different trigger keys.
+> **Note:** "Fn+Space" below refers to the configured hands-free shortcut, and "Fn" refers to the configured push-to-talk shortcut. Defaults are Fn+Space for hands-free and Fn for push-to-talk. Test with at least two different trigger keys.
 
 ### Happy Path
 
 | # | Flow | Steps | Expected |
 |---|------|-------|----------|
-| 1 | Persistent recording | Fn+Fn → speak → Fn | Pill appears → waveform animates → checkmark → text pasted |
+| 1 | Persistent recording | Fn+Space → speak → Fn+Space | Pill appears → waveform animates → checkmark → text pasted |
 | 2 | Hold-to-talk | Hold Fn (>400ms) → speak → release Fn | Pill appears → waveform → checkmark → text pasted |
 
 ### Cancel & Undo Flows
 
 | # | Flow | Steps | Expected |
 |---|------|-------|----------|
-| 3 | Cancel via Esc | Fn+Fn → Esc | Pill shows countdown ring (5s) → auto-dismiss |
-| 4 | Cancel via X button | Fn+Fn → click X | Same as Esc cancel — countdown → auto-dismiss |
-| 5 | Undo after Esc cancel | Fn+Fn → Esc → click Undo | Recording restarts, pill shows waveform again |
-| 6 | Undo after X cancel | Fn+Fn → click X → click Undo | Recording restarts, pill shows waveform again |
-| 7 | **Fn after undo** | Fn+Fn → cancel → Undo → Fn | Recording stops, checkmark, text pasted |
-| 8 | **Fn+Fn after undo** | Fn+Fn → cancel → Undo → Fn → Fn+Fn | New recording starts |
-| 9 | Fn blocked during cancel | Fn+Fn → Esc → Fn (during countdown) | Nothing happens — Fn is blocked |
-| 10 | Cancel countdown expires | Fn+Fn → Esc → wait 5s | Pill auto-dismisses, Fn+Fn works again |
+| 3 | Cancel via Esc | Fn+Space → Esc | Pill shows countdown ring (5s) → auto-dismiss |
+| 4 | Cancel via X button | Fn+Space → click X | Same as Esc cancel — countdown → auto-dismiss |
+| 5 | Undo after Esc cancel | Fn+Space → Esc → click Undo | Recording restarts, pill shows waveform again |
+| 6 | Undo after X cancel | Fn+Space → click X → click Undo | Recording restarts, pill shows waveform again |
+| 7 | **Hands-free after undo** | Fn+Space → cancel → Undo → Fn+Space | Recording stops, checkmark, text pasted |
+| 8 | **New hands-free recording after undo** | Fn+Space → cancel → Undo → Fn+Space → Fn+Space | New recording starts |
+| 9 | Hands-free blocked during cancel | Fn+Space → Esc → Fn+Space (during countdown) | Nothing happens — shortcut is blocked |
+| 10 | Cancel countdown expires | Fn+Space → Esc → wait 5s | Pill auto-dismisses, Fn+Space works again |
 
 ### Configurable Hotkey
 
 | # | Flow | Steps | Expected |
 |---|------|-------|----------|
-| 10a | Change trigger key | Settings → Hotkey → select Control | Menu bar shows "Hotkey: Control (double-tap / hold)" |
-| 10b | New trigger works | Ctrl+Ctrl → speak → Ctrl | Recording starts/stops with new key |
+| 10a | Change hands-free shortcut | Settings → Shortcuts → Hands-free mode → select Control+Space | Menu bar shows "Tap Control+Space" for hands-free |
+| 10b | New trigger works | Ctrl+Space → speak → Ctrl+Space | Recording starts/stops with new shortcut |
 | 10c | Bare-tap filtering | Hold Ctrl → press C → release Ctrl | Does NOT trigger dictation (keyboard shortcut) |
-| 10d | Gesture interruption | Ctrl → type "hello" → Ctrl | Does NOT trigger double-tap (typing interrupted) |
-| 10e | Switch back to Fn | Settings → Hotkey → select Fn | Fn works again, Ctrl no longer triggers |
-| 10f | Dynamic UI text | Change to Option → check overlay/pill/history | All say "Option" instead of "Fn" |
+| 10d | Single-tap modifier filtering | Ctrl → type "hello" → release Ctrl | Does NOT trigger dictation |
+| 10e | Switch back to Fn+Space | Settings → Shortcuts → Hands-free mode → select Fn+Space | Fn+Space works again, Ctrl no longer triggers |
+| 10f | Dynamic UI text | Change to Option+Space → check overlay/pill/history | All say "Option+Space" instead of "Fn+Space" |
 
 ### State Transitions
 
 | # | Flow | Steps | Expected |
 |---|------|-------|----------|
-| 11 | Recording → Processing | Fn+Fn → speak → Fn | Pill smoothly transitions from waveform to spinner |
+| 11 | Recording → Processing | Fn+Space → speak → Fn+Space | Pill smoothly transitions from waveform to spinner |
 | 12 | Processing → Success | (after transcription completes) | Animated checkmark appears, then text pastes |
 | 13 | Error display | (trigger STT error) | Error card (rounded rect, icon, title+subtitle, dismiss button) |
-| 13a | Delayed first-stop race | Fn+Fn, then immediately Fn while first start is still spinning up | Stop is deferred, then processing/paste completes once recording is active (no silent drop) |
+| 13a | Delayed first-stop race | Fn+Space, then immediately Fn+Space while first start is still spinning up | Stop is deferred, then processing/paste completes once recording is active (no silent drop) |
 
 ### Hover Tooltips
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -95,7 +95,7 @@ All ADRs live in `spec/adr/`. These are locked -- they record decisions already 
 
 Dictation + transcription + history + settings. Get audio in, text out, pasted into any app.
 
-- [x] System-wide dictation: Configurable hotkey (Fn default), double-tap (persistent) + hold-to-talk
+- [x] System-wide dictation: Configurable shortcuts for hands-free tap-to-toggle and hold-to-talk
 - [x] File transcription: Drag-drop audio/video files
 - [x] Compact dark pill overlay with recording timer + waveform
 - [x] Persistent idle pill (always-visible, click-to-dictate)

--- a/spec/adr/009-custom-hotkey.md
+++ b/spec/adr/009-custom-hotkey.md
@@ -14,7 +14,7 @@ Replace `TriggerKey` enum with a `HotkeyTrigger` struct that supports both modif
 
 ### Key Design Choices
 
-1. **Single keys only, no combos** — Key combos (Cmd+K) conflict with system shortcuts and create ambiguity for double-tap/hold gesture detection. Single keys fully cover the use case.
+1. **Initial single-key model** — The original design avoided key combos because common combos conflict with system shortcuts and created ambiguity for shared double-tap/hold detection. The chord-support amendments below add explicit modifier+key and modifier-only shortcuts.
 
 2. **`HotkeyTrigger` struct with `kind` discriminator** — A `.modifier` vs `.keyCode` discriminator cleanly separates the two event detection paths while sharing the same state machine.
 
@@ -49,9 +49,9 @@ Community issue #17 requested modifier+key combos (e.g., Cmd+9) because Logitech
 1. **New `.chord` kind** added to `HotkeyTrigger.Kind` — stores `chordModifiers: [String]` (e.g. `["command"]`) alongside `keyCode`.
 2. **Release-any-part stops** — For hold-to-talk with Cmd+9, releasing either Cmd or 9 ends dictation.
 3. **Key swallowed, modifiers passed** — The trigger key event is swallowed; modifier flag changes pass through to the active app.
-4. **Required modifiers must be present** — Mask to 4 relevant bits (⌃⌥⇧⌘) before comparing. Caps Lock, NumPad, etc. are stripped.
-5. **Fn excluded from chord modifiers** — Fn modifies F-key behavior on macOS. Stays as bare modifier only.
-6. **FnKeyStateMachine unchanged** — Key-agnostic. Chords generate the same down/up signals. Both hold-to-talk and double-tap work.
+4. **Required modifiers must be present** — Mask to 5 relevant bits (fn⌃⌥⇧⌘) before comparing. Caps Lock, NumPad, etc. are stripped.
+5. **Fn allowed in key chords** — Fn+Space is the default hands-free dictation shortcut. Bare Fn remains available for push-to-talk.
+6. **FnKeyStateMachine unchanged** — Key-agnostic. Chords generate role-specific down/up signals, including hands-free single-tap toggle and hold-to-talk.
 7. **Modifier names stored as `[String]`** — Not raw `CGEventFlags.rawValue` (has phantom bits). Readable JSON: `{"kind":"chord","keyCode":25,"chordModifiers":["command"]}`.
 8. **HotkeyRecorderView two-phase capture** — Held modifiers show as preview (e.g. "⌘..."); pressing a key with modifiers held creates a chord; releasing all modifiers without a key press creates a bare modifier trigger.
 9. **Validation** — Chords are `.allowed` by default. Escape blocked. Cmd+Tab and Cmd+Space warned (system intercepts them).
@@ -77,4 +77,4 @@ Community issue #234 requested hotkeys such as Right Command+Right Option. The e
 
 ### Original decision preserved
 
-Existing `.modifier`, `.keyCode`, and `.chord` persisted values decode unchanged. Modifier-only chords are additive and use the existing key-agnostic gesture state machine for double-tap and hold-to-talk semantics.
+Existing `.modifier`, `.keyCode`, and `.chord` persisted values decode unchanged. Modifier-only chords are additive and use the existing key-agnostic gesture controller for the configured role semantics.

--- a/spec/kernel/requirements.yaml
+++ b/spec/kernel/requirements.yaml
@@ -27,7 +27,7 @@ REQ-DICT-001:
   status: implemented
 
 REQ-DICT-002:
-  description: Double-tap for persistent recording, hold for push-to-talk
+  description: Separate hands-free tap-to-toggle and hold-to-talk shortcuts
   version: v0.1
   status: implemented
 


### PR DESCRIPTION
## Summary
This changes dictation shortcuts from one overloaded double-tap/hold gesture to two explicit actions:

```text
Before
  Fn double-tap  -> hands-free dictation
  Fn hold        -> push-to-talk

After
  Fn+Space tap   -> hands-free dictation
  Fn hold        -> push-to-talk
```

The defaults now match Flow-style behavior: tap `Fn+Space` to start/stop hands-free dictation, or hold `Fn` for short push-to-talk dictation.

## Details
- Adds single-tap toggle handling for hands-free dictation.
- Keeps push-to-talk as hold-only.
- Migrates existing dictation hotkeys into separate hands-free and push-to-talk settings without creating overlapping defaults.
- Preserves intentional post-split custom choices like hands-free `Fn` when push-to-talk is a different shortcut.
- Updates Settings, overlay/idle copy, specs, and related docs.

## Related Issues
- Implements #297 - single-tap hands-free dictation shortcut request; close after release deploy.
- Addresses #302 - one-key/modifier-only hotkey settings report; close after release deploy/confirmation.

## Verification
- `swift test --filter Hotkey`
- `swift test --filter SettingsViewModelTests`
- `swift test`
- Multi-agent review and Oracle `gpt-5.5-pro` review blockers addressed.
