### PR TITLE
Vocabulary surface refinement: chrome out, content forward

### DIFF
--- a/Sources/MacParakeet/Views/Components/ParakeetActionStyle.swift
+++ b/Sources/MacParakeet/Views/Components/ParakeetActionStyle.swift
@@ -48,4 +48,12 @@ extension View {
                 .foregroundStyle(.secondary)
         }
     }
+
+    /// Brand-consistent switch styling. Use for every `Toggle` styled as a
+    /// switch so on-state reads coral app-wide rather than the system blue that
+    /// an untinted `.switch` falls back to. Keeps sibling toggles consistent.
+    func parakeetSwitch() -> some View {
+        self.toggleStyle(.switch)
+            .tint(DesignSystem.Colors.accent)
+    }
 }

--- a/Sources/MacParakeet/Views/MainWindowView.swift
+++ b/Sources/MacParakeet/Views/MainWindowView.swift
@@ -91,6 +91,7 @@ struct MainWindowView: View {
                     }
                 }
                 .listStyle(.sidebar)
+                .tint(DesignSystem.Colors.accent)
                 .safeAreaInset(edge: .bottom, spacing: 0) {
                     DiscoverSidebarCard(
                         viewModel: discoverViewModel,

--- a/Sources/MacParakeet/Views/MainWindowView.swift
+++ b/Sources/MacParakeet/Views/MainWindowView.swift
@@ -72,10 +72,6 @@ struct MainWindowView: View {
     /// recorder is active. Passed through to `SettingsView`.
     let onHotkeyRecordingStateChanged: (Bool) -> Void
 
-    /// Vocabulary management panel presented as a window-level overlay, so the
-    /// scrim covers the whole window and clicking outside dismisses it.
-    @State private var activeVocabularySheet: VocabularySheetKind?
-
     var body: some View {
         VStack(spacing: 0) {
             NavigationSplitView {
@@ -220,8 +216,7 @@ struct MainWindowView: View {
                             settingsViewModel: settingsViewModel,
                             customWordsViewModel: customWordsViewModel,
                             textSnippetsViewModel: textSnippetsViewModel,
-                            backupViewModel: vocabularyBackupViewModel,
-                            activeSheet: $activeVocabularySheet
+                            backupViewModel: vocabularyBackupViewModel
                         )
                     case .feedback:
                         FeedbackView(viewModel: feedbackViewModel)
@@ -262,39 +257,12 @@ struct MainWindowView: View {
                 state.selectedItem = .library
             }
         }
-        .overlay {
-            vocabularyModalOverlay
-        }
-        .animation(DesignSystem.Animation.contentSwap, value: activeVocabularySheet)
     }
 
     /// Show the global bottom bar when transcribing on any tab except Transcribe (which has its own detailed view)
     private var showGlobalProgressBar: Bool {
         transcriptionViewModel.isTranscribing
             && state.selectedItem != .transcribe
-    }
-
-    /// Window-level overlay for the Vocabulary management panels. Presented here
-    /// (not via `.sheet`) so the dimmed scrim covers the whole window, clicking
-    /// outside the panel dismisses it, and nothing auto-grabs keyboard focus.
-    @ViewBuilder
-    private var vocabularyModalOverlay: some View {
-        if let sheet = activeVocabularySheet {
-            ModalScrimContainer(onScrimTap: closeVocabularySheet) {
-                switch sheet {
-                case .customWords:
-                    CustomWordsView(viewModel: customWordsViewModel, onClose: closeVocabularySheet)
-                case .textSnippets:
-                    TextSnippetsView(viewModel: textSnippetsViewModel, onClose: closeVocabularySheet)
-                }
-            }
-            .transition(.opacity)
-        }
-    }
-
-    private func closeVocabularySheet() {
-        activeVocabularySheet = nil
-        settingsViewModel.refreshStats()
     }
 
     private var transformReservedHotkeys: [TransformShortcutReservedHotkey] {

--- a/Sources/MacParakeet/Views/MainWindowView.swift
+++ b/Sources/MacParakeet/Views/MainWindowView.swift
@@ -72,6 +72,10 @@ struct MainWindowView: View {
     /// recorder is active. Passed through to `SettingsView`.
     let onHotkeyRecordingStateChanged: (Bool) -> Void
 
+    /// Vocabulary management panel presented as a window-level overlay, so the
+    /// scrim covers the whole window and clicking outside dismisses it.
+    @State private var activeVocabularySheet: VocabularySheetKind?
+
     var body: some View {
         VStack(spacing: 0) {
             NavigationSplitView {
@@ -216,7 +220,8 @@ struct MainWindowView: View {
                             settingsViewModel: settingsViewModel,
                             customWordsViewModel: customWordsViewModel,
                             textSnippetsViewModel: textSnippetsViewModel,
-                            backupViewModel: vocabularyBackupViewModel
+                            backupViewModel: vocabularyBackupViewModel,
+                            activeSheet: $activeVocabularySheet
                         )
                     case .feedback:
                         FeedbackView(viewModel: feedbackViewModel)
@@ -257,12 +262,39 @@ struct MainWindowView: View {
                 state.selectedItem = .library
             }
         }
+        .overlay {
+            vocabularyModalOverlay
+        }
+        .animation(DesignSystem.Animation.contentSwap, value: activeVocabularySheet)
     }
 
     /// Show the global bottom bar when transcribing on any tab except Transcribe (which has its own detailed view)
     private var showGlobalProgressBar: Bool {
         transcriptionViewModel.isTranscribing
             && state.selectedItem != .transcribe
+    }
+
+    /// Window-level overlay for the Vocabulary management panels. Presented here
+    /// (not via `.sheet`) so the dimmed scrim covers the whole window, clicking
+    /// outside the panel dismisses it, and nothing auto-grabs keyboard focus.
+    @ViewBuilder
+    private var vocabularyModalOverlay: some View {
+        if let sheet = activeVocabularySheet {
+            ModalScrimContainer(onScrimTap: closeVocabularySheet) {
+                switch sheet {
+                case .customWords:
+                    CustomWordsView(viewModel: customWordsViewModel, onClose: closeVocabularySheet)
+                case .textSnippets:
+                    TextSnippetsView(viewModel: textSnippetsViewModel, onClose: closeVocabularySheet)
+                }
+            }
+            .transition(.opacity)
+        }
+    }
+
+    private func closeVocabularySheet() {
+        activeVocabularySheet = nil
+        settingsViewModel.refreshStats()
     }
 
     private var transformReservedHotkeys: [TransformShortcutReservedHotkey] {

--- a/Sources/MacParakeet/Views/Vocabulary/CustomWordsView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/CustomWordsView.swift
@@ -7,6 +7,7 @@ struct CustomWordsView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var hoveredWordID: UUID?
     @FocusState private var wordFieldFocused: Bool
+    @FocusState private var replacementFieldFocused: Bool
 
     var body: some View {
         VStack(spacing: 0) {
@@ -102,13 +103,14 @@ struct CustomWordsView: View {
                 ParakeetTextField(
                     placeholder: "Word or phrase",
                     text: $viewModel.newWord,
-                    onSubmit: attemptAdd,
+                    onSubmit: { replacementFieldFocused = true },
                     externalFocus: $wordFieldFocused
                 )
                 ParakeetTextField(
                     placeholder: "Replacement (optional)",
                     text: $viewModel.newReplacement,
-                    onSubmit: attemptAdd
+                    onSubmit: attemptAdd,
+                    externalFocus: $replacementFieldFocused
                 )
                 Button("Add", action: attemptAdd)
                     .parakeetAction(.primaryProminent)

--- a/Sources/MacParakeet/Views/Vocabulary/CustomWordsView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/CustomWordsView.swift
@@ -4,17 +4,20 @@ import MacParakeetViewModels
 
 struct CustomWordsView: View {
     @Bindable var viewModel: CustomWordsViewModel
-    let onClose: () -> Void
+    @Environment(\.dismiss) private var dismiss
     @State private var hoveredWordID: UUID?
     @FocusState private var wordFieldFocused: Bool
     @FocusState private var replacementFieldFocused: Bool
 
     var body: some View {
         VStack(spacing: 0) {
+            SheetAutoFocusSuppressor()
+                .frame(width: 0, height: 0)
+
             VocabSheetHeader(
                 title: "Custom Words",
                 subtitle: "Teach MacParakeet how you say things.",
-                onDone: onClose
+                onDone: { dismiss() }
             )
 
             Divider()
@@ -74,7 +77,7 @@ struct CustomWordsView: View {
                 VStack(spacing: 0) {
                     ForEach(Array(viewModel.filteredWords.enumerated()), id: \.element.id) { index, word in
                         if index > 0 {
-                            Divider().padding(.leading, 52)
+                            Divider().padding(.leading, VocabMetrics.rowDividerInset)
                         }
                         wordRow(word)
                     }

--- a/Sources/MacParakeet/Views/Vocabulary/CustomWordsView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/CustomWordsView.swift
@@ -4,9 +4,8 @@ import MacParakeetViewModels
 
 struct CustomWordsView: View {
     @Bindable var viewModel: CustomWordsViewModel
-    @Environment(\.dismiss) private var dismiss
+    let onClose: () -> Void
     @State private var hoveredWordID: UUID?
-    @FocusState private var searchFocused: Bool
     @FocusState private var wordFieldFocused: Bool
     @FocusState private var replacementFieldFocused: Bool
 
@@ -15,7 +14,7 @@ struct CustomWordsView: View {
             VocabSheetHeader(
                 title: "Custom Words",
                 subtitle: "Teach MacParakeet how you say things.",
-                onDone: { dismiss() }
+                onDone: onClose
             )
 
             Divider()
@@ -26,8 +25,7 @@ struct CustomWordsView: View {
                         placeholder: "Search words…",
                         text: $viewModel.searchText,
                         leadingSystemImage: "magnifyingglass",
-                        showsClearButton: true,
-                        externalFocus: $searchFocused
+                        showsClearButton: true
                     )
 
                     wordsSection
@@ -35,11 +33,6 @@ struct CustomWordsView: View {
                 }
                 .padding(DesignSystem.Spacing.lg)
             }
-        }
-        .onAppear {
-            // Open neutral — don't let the freshly presented sheet auto-focus
-            // the search field. The eye should land on the content.
-            Task { @MainActor in searchFocused = false }
         }
         .alert(
             "Delete Word?",

--- a/Sources/MacParakeet/Views/Vocabulary/CustomWordsView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/CustomWordsView.swift
@@ -5,18 +5,33 @@ import MacParakeetViewModels
 struct CustomWordsView: View {
     @Bindable var viewModel: CustomWordsViewModel
     @Environment(\.dismiss) private var dismiss
-    @State private var hoveredCardTitle: String?
     @State private var hoveredWordID: UUID?
+    @FocusState private var wordFieldFocused: Bool
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
-                headerCard
-                searchCard
-                wordsCard
-                addWordCard
+        VStack(spacing: 0) {
+            VocabSheetHeader(
+                title: "Custom Words",
+                subtitle: "Teach MacParakeet how you say things.",
+                onDone: { dismiss() }
+            )
+
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
+                    ParakeetTextField(
+                        placeholder: "Search words…",
+                        text: $viewModel.searchText,
+                        leadingSystemImage: "magnifyingglass",
+                        showsClearButton: true
+                    )
+
+                    wordsSection
+                    addSection
+                }
+                .padding(DesignSystem.Spacing.lg)
             }
-            .padding(DesignSystem.Spacing.lg)
         }
         .background(.thickMaterial)
         .alert(
@@ -39,87 +54,66 @@ struct CustomWordsView: View {
         }
     }
 
-    // MARK: - Cards
+    // MARK: - Sections
 
-    private var headerCard: some View {
-        managementCard(
-            title: "Custom Words",
-            subtitle: "Teach MacParakeet how you say things.",
-            icon: "character.book.closed"
-        ) {
-            LazyVGrid(
-                columns: [GridItem(.adaptive(minimum: 100), spacing: DesignSystem.Spacing.sm)],
-                spacing: DesignSystem.Spacing.sm
-            ) {
-                metricChip(title: "Total", value: "\(viewModel.words.count)")
-                metricChip(title: "Visible", value: "\(viewModel.filteredWords.count)")
-                metricChip(title: "Enabled", value: "\(viewModel.words.filter(\.isEnabled).count)")
+    private var wordsSection: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            VocabSectionHeader(title: "Word Rules") {
+                Text(wordsCountLabel)
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(.tertiary)
+                    .monospacedDigit()
             }
 
-            HStack {
-                Spacer()
-                Button("Done") { dismiss() }
-                    .parakeetAction(.primaryProminent)
-                    .keyboardShortcut(.cancelAction)
-            }
-        }
-    }
-
-    private var searchCard: some View {
-        managementCard(
-            title: "Search",
-            subtitle: "Filter by source word or replacement.",
-            icon: "magnifyingglass"
-        ) {
-            TextField("Search words...", text: $viewModel.searchText)
-                .textFieldStyle(.roundedBorder)
-        }
-    }
-
-    private var wordsCard: some View {
-        managementCard(
-            title: "Word Rules",
-            subtitle: "Toggle to enable or disable each rule.",
-            icon: "list.bullet"
-        ) {
             if viewModel.filteredWords.isEmpty {
                 emptyWordsState
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, DesignSystem.Spacing.xl)
+                    .vocabGroup()
             } else {
-                VStack(spacing: DesignSystem.Spacing.sm) {
-                    ForEach(viewModel.filteredWords) { word in
+                VStack(spacing: 0) {
+                    ForEach(Array(viewModel.filteredWords.enumerated()), id: \.element.id) { index, word in
+                        if index > 0 {
+                            Divider().padding(.leading, 52)
+                        }
                         wordRow(word)
                     }
                 }
+                .vocabGroup()
             }
         }
     }
 
-    private var addWordCard: some View {
-        managementCard(
-            title: "Add Rule",
-            subtitle: "Add a word to correct, or leave replacement blank to enforce its spelling.",
-            icon: "plus.circle"
-        ) {
-            VStack(spacing: DesignSystem.Spacing.sm) {
-                if let error = viewModel.errorMessage {
-                    Text(error)
-                        .font(DesignSystem.Typography.caption)
-                        .foregroundStyle(DesignSystem.Colors.errorRed)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
+    private var addSection: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            VocabSectionHeader(
+                title: "Add Rule",
+                subtitle: "Add a word to correct, or leave the replacement blank to enforce its spelling."
+            )
 
-                HStack(spacing: DesignSystem.Spacing.sm) {
-                    TextField("Word or phrase", text: $viewModel.newWord)
-                        .textFieldStyle(.roundedBorder)
-                        .focused($wordFieldFocused)
-                    TextField("Replacement (optional)", text: $viewModel.newReplacement)
-                        .textFieldStyle(.roundedBorder)
-                    Button("Add") {
-                        viewModel.addWord()
-                    }
+            if let error = viewModel.errorMessage {
+                Text(error)
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.errorRed)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            HStack(spacing: DesignSystem.Spacing.sm) {
+                ParakeetTextField(
+                    placeholder: "Word or phrase",
+                    text: $viewModel.newWord,
+                    onSubmit: attemptAdd,
+                    externalFocus: $wordFieldFocused
+                )
+                ParakeetTextField(
+                    placeholder: "Replacement (optional)",
+                    text: $viewModel.newReplacement,
+                    onSubmit: attemptAdd
+                )
+                Button("Add", action: attemptAdd)
                     .parakeetAction(.primaryProminent)
+                    .controlSize(.large)
                     .disabled(viewModel.newWord.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                }
             }
         }
     }
@@ -135,7 +129,7 @@ struct CustomWordsView: View {
                 set: { _ in viewModel.toggleEnabled(word) }
             ))
             .labelsHidden()
-            .toggleStyle(.switch)
+            .parakeetSwitch()
             .controlSize(.small)
             .accessibilityLabel("Enable \(word.word)")
             .accessibilityHint(toggleHint)
@@ -156,24 +150,19 @@ struct CustomWordsView: View {
                 }
             }
 
-            Spacer()
+            Spacer(minLength: DesignSystem.Spacing.sm)
 
-            Button(role: .destructive) {
+            DeleteIconButton(
+                helpText: "Delete \(word.word)",
+                accessibilityName: "Delete \(word.word)"
+            ) {
                 viewModel.pendingDeleteWord = word
-            } label: {
-                Image(systemName: "trash")
-                    .font(.system(size: 12, weight: .medium))
             }
-            .buttonStyle(.plain)
-            .foregroundStyle(.secondary)
-            .help("Delete \(word.word)")
-            .accessibilityLabel("Delete \(word.word)")
         }
-        .padding(DesignSystem.Spacing.sm)
-        .background(
-            RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
-                .fill(isHovered ? DesignSystem.Colors.rowHoverBackground : DesignSystem.Colors.surfaceElevated)
-        )
+        .padding(.horizontal, DesignSystem.Spacing.md)
+        .padding(.vertical, DesignSystem.Spacing.sm + 2)
+        .background(isHovered ? DesignSystem.Colors.rowHoverBackground : Color.clear)
+        .contentShape(Rectangle())
         .onHover { hovering in
             withAnimation(DesignSystem.Animation.hoverTransition) {
                 hoveredWordID = hovering ? word.id : nil
@@ -181,12 +170,10 @@ struct CustomWordsView: View {
         }
     }
 
-    @FocusState private var wordFieldFocused: Bool
-
     private var emptyWordsState: some View {
         VStack(spacing: DesignSystem.Spacing.sm) {
             Image(systemName: "character.textbox")
-                .font(.system(size: 28))
+                .font(.system(size: 26))
                 .foregroundStyle(.secondary)
             Text(viewModel.words.isEmpty ? "No custom words yet" : "No matches")
                 .font(DesignSystem.Typography.body)
@@ -196,83 +183,34 @@ struct CustomWordsView: View {
                     .font(DesignSystem.Typography.caption)
                     .foregroundStyle(.tertiary)
                     .multilineTextAlignment(.center)
+                    .frame(maxWidth: 320)
                 Button("Add Your First Rule") {
                     wordFieldFocused = true
                 }
-                .parakeetAction(.primaryProminent)
+                .parakeetAction(.primary)
                 .controlSize(.small)
-            }
-        }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, DesignSystem.Spacing.lg)
-    }
-
-    // MARK: - Reusable
-
-    private func managementCard<Content: View>(
-        title: String,
-        subtitle: String,
-        icon: String,
-        @ViewBuilder content: () -> Content
-    ) -> some View {
-        let isHovered = hoveredCardTitle == title
-        return VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
-            HStack(alignment: .top, spacing: DesignSystem.Spacing.sm) {
-                Image(systemName: icon)
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(DesignSystem.Colors.accent)
-                    .frame(width: 30, height: 30)
-                    .background(
-                        RoundedRectangle(cornerRadius: 8)
-                            .fill(DesignSystem.Colors.accent.opacity(0.12))
-                    )
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(title)
-                        .font(DesignSystem.Typography.sectionTitle)
-                    Text(subtitle)
-                        .font(DesignSystem.Typography.caption)
-                        .foregroundStyle(.secondary)
-                }
-            }
-
-            content()
-        }
-        .padding(DesignSystem.Spacing.lg)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
-                .fill(DesignSystem.Colors.cardBackground)
-                .cardShadow(isHovered ? DesignSystem.Shadows.cardHover : DesignSystem.Shadows.cardRest)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
-                .strokeBorder(
-                    isHovered ? DesignSystem.Colors.accent.opacity(0.2) : DesignSystem.Colors.border.opacity(0.6),
-                    lineWidth: 0.5
-                )
-        )
-        .onHover { hovering in
-            withAnimation(DesignSystem.Animation.hoverTransition) {
-                hoveredCardTitle = hovering ? title : nil
+                .padding(.top, 2)
             }
         }
     }
 
-    private func metricChip(title: String, value: String) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(title)
-                .font(DesignSystem.Typography.micro)
-                .foregroundStyle(.secondary)
-            Text(value)
-                .font(DesignSystem.Typography.body.weight(.semibold))
-                .contentTransition(.numericText())
+    // MARK: - Helpers
+
+    private var wordsCountLabel: String {
+        let total = viewModel.words.count
+        let searching = !viewModel.searchText.trimmingCharacters(in: .whitespaces).isEmpty
+        if searching {
+            return "\(viewModel.filteredWords.count) of \(total)"
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
-        .background(
-            RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
-                .fill(DesignSystem.Colors.surfaceElevated)
-        )
+        let disabled = viewModel.words.filter { !$0.isEnabled }.count
+        if disabled > 0 {
+            return "\(total) · \(disabled) off"
+        }
+        return total == 1 ? "1 rule" : "\(total) rules"
+    }
+
+    private func attemptAdd() {
+        guard !viewModel.newWord.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        viewModel.addWord()
     }
 }

--- a/Sources/MacParakeet/Views/Vocabulary/CustomWordsView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/CustomWordsView.swift
@@ -6,6 +6,7 @@ struct CustomWordsView: View {
     @Bindable var viewModel: CustomWordsViewModel
     @Environment(\.dismiss) private var dismiss
     @State private var hoveredWordID: UUID?
+    @FocusState private var searchFocused: Bool
     @FocusState private var wordFieldFocused: Bool
     @FocusState private var replacementFieldFocused: Bool
 
@@ -25,7 +26,8 @@ struct CustomWordsView: View {
                         placeholder: "Search words…",
                         text: $viewModel.searchText,
                         leadingSystemImage: "magnifyingglass",
-                        showsClearButton: true
+                        showsClearButton: true,
+                        externalFocus: $searchFocused
                     )
 
                     wordsSection
@@ -34,7 +36,11 @@ struct CustomWordsView: View {
                 .padding(DesignSystem.Spacing.lg)
             }
         }
-        .background(.thickMaterial)
+        .onAppear {
+            // Open neutral — don't let the freshly presented sheet auto-focus
+            // the search field. The eye should land on the content.
+            Task { @MainActor in searchFocused = false }
+        }
         .alert(
             "Delete Word?",
             isPresented: Binding(
@@ -89,7 +95,7 @@ struct CustomWordsView: View {
         VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
             VocabSectionHeader(
                 title: "Add Rule",
-                subtitle: "Add a word to correct, or leave the replacement blank to enforce its spelling."
+                subtitle: "Replace a word, or leave the replacement blank to lock its spelling and capitalization."
             )
 
             if let error = viewModel.errorMessage {
@@ -117,7 +123,40 @@ struct CustomWordsView: View {
                     .controlSize(.large)
                     .disabled(viewModel.newWord.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }
+
+            if !viewModel.newWord.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                rulePreview
+                    .transition(.opacity)
+            }
         }
+        .animation(DesignSystem.Animation.hoverTransition, value: viewModel.newWord.isEmpty)
+    }
+
+    @ViewBuilder
+    private var rulePreview: some View {
+        let word = viewModel.newWord.trimmingCharacters(in: .whitespacesAndNewlines)
+        let replacement = viewModel.newReplacement.trimmingCharacters(in: .whitespacesAndNewlines)
+        HStack(spacing: DesignSystem.Spacing.xs) {
+            if replacement.isEmpty {
+                Text("“\(word)”")
+                    .font(DesignSystem.Typography.caption.monospaced())
+                    .foregroundStyle(.primary)
+                Text("kept exactly — fixes spelling & capitalization")
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                Text("“\(word)”")
+                    .font(DesignSystem.Typography.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                Image(systemName: "arrow.right")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.tertiary)
+                Text("“\(replacement)”")
+                    .font(DesignSystem.Typography.caption.monospaced())
+                    .foregroundStyle(.primary)
+            }
+        }
+        .padding(.leading, 2)
     }
 
     // MARK: - Rows

--- a/Sources/MacParakeet/Views/Vocabulary/TextSnippetsView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/TextSnippetsView.swift
@@ -5,19 +5,35 @@ import MacParakeetViewModels
 struct TextSnippetsView: View {
     @Bindable var viewModel: TextSnippetsViewModel
     @Environment(\.dismiss) private var dismiss
-    @State private var hoveredCardTitle: String?
     @State private var hoveredSnippetID: UUID?
+    @State private var showTips = false
+    @FocusState private var triggerFieldFocused: Bool
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
-                headerCard
-                guidanceCard
-                searchCard
-                snippetsCard
-                addSnippetCard
+        VStack(spacing: 0) {
+            VocabSheetHeader(
+                title: "Text Snippets",
+                subtitle: "Say a short phrase, paste a longer one.",
+                onDone: { dismiss() }
+            )
+
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
+                    ParakeetTextField(
+                        placeholder: "Search snippets…",
+                        text: $viewModel.searchText,
+                        leadingSystemImage: "magnifyingglass",
+                        showsClearButton: true
+                    )
+
+                    snippetsSection
+                    addSection
+                    tipsDisclosure
+                }
+                .padding(DesignSystem.Spacing.lg)
             }
-            .padding(DesignSystem.Spacing.lg)
         }
         .background(.thickMaterial)
         .alert(
@@ -40,116 +56,91 @@ struct TextSnippetsView: View {
         }
     }
 
-    // MARK: - Cards
+    // MARK: - Sections
 
-    private var headerCard: some View {
-        managementCard(
-            title: "Text Snippets",
-            subtitle: "Say a short phrase, paste a longer one.",
-            icon: "text.insert"
-        ) {
-            LazyVGrid(
-                columns: [GridItem(.adaptive(minimum: 100), spacing: DesignSystem.Spacing.sm)],
-                spacing: DesignSystem.Spacing.sm
-            ) {
-                metricChip(title: "Total", value: "\(viewModel.snippets.count)")
-                metricChip(title: "Visible", value: "\(viewModel.filteredSnippets.count)")
-                metricChip(title: "Enabled", value: "\(viewModel.snippets.filter(\.isEnabled).count)")
+    private var snippetsSection: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            VocabSectionHeader(title: "Snippet Rules") {
+                Text(snippetsCountLabel)
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(.tertiary)
+                    .monospacedDigit()
             }
 
-            HStack {
-                Spacer()
-                Button("Done") { dismiss() }
-                    .parakeetAction(.primaryProminent)
-                    .keyboardShortcut(.cancelAction)
-            }
-        }
-    }
-
-    private var guidanceCard: some View {
-        managementCard(
-            title: "Guidance",
-            subtitle: "Tips for reliable phrase detection.",
-            icon: "lightbulb.fill"
-        ) {
-            HStack(alignment: .top, spacing: DesignSystem.Spacing.sm) {
-                Image(systemName: "quote.bubble")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(DesignSystem.Colors.warningAmber)
-                Text("Use natural trigger phrases (for example, \"my signature\") rather than abbreviations, since Parakeet recognizes natural speech.")
-                    .font(DesignSystem.Typography.bodySmall)
-                    .foregroundStyle(.secondary)
-            }
-            HStack(alignment: .top, spacing: DesignSystem.Spacing.sm) {
-                Image(systemName: "return")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(DesignSystem.Colors.warningAmber)
-                Text("Type \\n in the expansion to insert a line break. Example: trigger \"new paragraph\" with expansion \\n\\n inserts a blank line.")
-                    .font(DesignSystem.Typography.bodySmall)
-                    .foregroundStyle(.secondary)
-            }
-        }
-    }
-
-    private var searchCard: some View {
-        managementCard(
-            title: "Search",
-            subtitle: "Filter by trigger phrase or expansion text.",
-            icon: "magnifyingglass"
-        ) {
-            TextField("Search snippets...", text: $viewModel.searchText)
-                .textFieldStyle(.roundedBorder)
-        }
-    }
-
-    private var snippetsCard: some View {
-        managementCard(
-            title: "Snippet Rules",
-            subtitle: "Toggle each snippet and track usage volume.",
-            icon: "list.bullet"
-        ) {
             if viewModel.filteredSnippets.isEmpty {
                 emptyState
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, DesignSystem.Spacing.xl)
+                    .vocabGroup()
             } else {
-                VStack(spacing: DesignSystem.Spacing.sm) {
-                    ForEach(viewModel.filteredSnippets) { snippet in
+                VStack(spacing: 0) {
+                    ForEach(Array(viewModel.filteredSnippets.enumerated()), id: \.element.id) { index, snippet in
+                        if index > 0 {
+                            Divider().padding(.leading, 52)
+                        }
                         snippetRow(snippet)
                     }
                 }
+                .vocabGroup()
             }
         }
     }
 
-    private var addSnippetCard: some View {
-        managementCard(
-            title: "Add Snippet",
-            subtitle: "Define a trigger phrase and what it expands to.",
-            icon: "plus.circle"
-        ) {
-            VStack(spacing: DesignSystem.Spacing.sm) {
-                if let error = viewModel.errorMessage {
-                    Text(error)
-                        .font(DesignSystem.Typography.caption)
-                        .foregroundStyle(DesignSystem.Colors.errorRed)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
+    private var addSection: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            VocabSectionHeader(
+                title: "Add Snippet",
+                subtitle: "Define a trigger phrase and what it expands to."
+            )
 
-                HStack(spacing: DesignSystem.Spacing.sm) {
-                    TextField("Trigger phrase", text: $viewModel.newTrigger)
-                        .textFieldStyle(.roundedBorder)
-                        .focused($triggerFieldFocused)
-                    TextField("Expansion", text: $viewModel.newExpansion)
-                        .textFieldStyle(.roundedBorder)
-                    Button("Add") {
-                        viewModel.addSnippet()
-                    }
+            if let error = viewModel.errorMessage {
+                Text(error)
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.errorRed)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            HStack(spacing: DesignSystem.Spacing.sm) {
+                ParakeetTextField(
+                    placeholder: "Trigger phrase",
+                    text: $viewModel.newTrigger,
+                    onSubmit: attemptAdd,
+                    externalFocus: $triggerFieldFocused
+                )
+                ParakeetTextField(
+                    placeholder: "Expansion",
+                    text: $viewModel.newExpansion,
+                    onSubmit: attemptAdd
+                )
+                Button("Add", action: attemptAdd)
                     .parakeetAction(.primaryProminent)
+                    .controlSize(.large)
                     .disabled(
                         viewModel.newTrigger.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                             || viewModel.newExpansion.trimmingCharacters(in: .whitespaces).isEmpty
                     )
-                }
             }
+        }
+    }
+
+    private var tipsDisclosure: some View {
+        DisclosureGroup(isExpanded: $showTips) {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+                tipRow(
+                    icon: "quote.bubble",
+                    text: "Use natural trigger phrases (for example, \"my signature\") rather than abbreviations — Parakeet recognizes natural speech."
+                )
+                tipRow(
+                    icon: "return",
+                    text: "Type \\n in the expansion to insert a line break. Example: trigger \"new paragraph\" with expansion \\n\\n inserts a blank line."
+                )
+            }
+            .padding(.top, DesignSystem.Spacing.sm)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        } label: {
+            Text("Tips for reliable detection")
+                .font(DesignSystem.Typography.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
         }
     }
 
@@ -158,7 +149,7 @@ struct TextSnippetsView: View {
     private func snippetRow(_ snippet: TextSnippet) -> some View {
         let isHovered = hoveredSnippetID == snippet.id
         let usageHint: String = snippet.useCount > 0
-            ? "Used \(snippet.useCount) times"
+            ? "Used \(snippet.useCount) time\(snippet.useCount == 1 ? "" : "s")"
             : "Not yet used"
         return HStack(spacing: DesignSystem.Spacing.md) {
             Toggle("", isOn: Binding(
@@ -166,20 +157,15 @@ struct TextSnippetsView: View {
                 set: { _ in viewModel.toggleEnabled(snippet) }
             ))
             .labelsHidden()
-            .toggleStyle(.switch)
+            .parakeetSwitch()
             .controlSize(.small)
             .accessibilityLabel("Enable \(snippet.trigger)")
             .accessibilityHint("Expands during dictation to a saved phrase")
 
             VStack(alignment: .leading, spacing: 3) {
-                HStack(spacing: 4) {
-                    Text("Trigger:")
-                        .font(DesignSystem.Typography.caption)
-                        .foregroundStyle(.secondary)
-                    Text("\"\(snippet.trigger)\"")
-                        .font(DesignSystem.Typography.body)
-                        .opacity(snippet.isEnabled ? 1.0 : 0.55)
-                }
+                Text("\"\(snippet.trigger)\"")
+                    .font(DesignSystem.Typography.body)
+                    .opacity(snippet.isEnabled ? 1.0 : 0.55)
 
                 Text("Expands to: \(snippet.expansion.replacingOccurrences(of: "\n", with: " ↵ "))")
                     .font(DesignSystem.Typography.caption)
@@ -187,35 +173,35 @@ struct TextSnippetsView: View {
                     .lineLimit(2)
             }
 
-            Spacer()
+            Spacer(minLength: DesignSystem.Spacing.sm)
 
             if snippet.useCount > 0 {
-                Text("\(snippet.useCount)")
-                    .font(DesignSystem.Typography.micro)
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 3)
-                    .background(Capsule().fill(DesignSystem.Colors.surfaceElevated))
-                    .help(usageHint)
-                    .accessibilityLabel(usageHint)
+                HStack(spacing: 3) {
+                    Image(systemName: "chart.bar.fill")
+                        .font(.system(size: 9, weight: .semibold))
+                    Text("\(snippet.useCount)")
+                        .font(DesignSystem.Typography.micro.weight(.medium))
+                        .monospacedDigit()
+                }
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 7)
+                .padding(.vertical, 3)
+                .background(Capsule().fill(DesignSystem.Colors.surfaceElevated))
+                .help(usageHint)
+                .accessibilityLabel(usageHint)
             }
 
-            Button(role: .destructive) {
+            DeleteIconButton(
+                helpText: "Delete \(snippet.trigger)",
+                accessibilityName: "Delete \(snippet.trigger)"
+            ) {
                 viewModel.pendingDeleteSnippet = snippet
-            } label: {
-                Image(systemName: "trash")
-                    .font(.system(size: 12, weight: .medium))
             }
-            .buttonStyle(.plain)
-            .foregroundStyle(.secondary)
-            .help("Delete \(snippet.trigger)")
-            .accessibilityLabel("Delete \(snippet.trigger)")
         }
-        .padding(DesignSystem.Spacing.sm)
-        .background(
-            RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
-                .fill(isHovered ? DesignSystem.Colors.rowHoverBackground : DesignSystem.Colors.surfaceElevated)
-        )
+        .padding(.horizontal, DesignSystem.Spacing.md)
+        .padding(.vertical, DesignSystem.Spacing.sm + 2)
+        .background(isHovered ? DesignSystem.Colors.rowHoverBackground : Color.clear)
+        .contentShape(Rectangle())
         .onHover { hovering in
             withAnimation(DesignSystem.Animation.hoverTransition) {
                 hoveredSnippetID = hovering ? snippet.id : nil
@@ -223,12 +209,10 @@ struct TextSnippetsView: View {
         }
     }
 
-    @FocusState private var triggerFieldFocused: Bool
-
     private var emptyState: some View {
         VStack(spacing: DesignSystem.Spacing.sm) {
             Image(systemName: "text.insert")
-                .font(.system(size: 28))
+                .font(.system(size: 26))
                 .foregroundStyle(.secondary)
             Text(viewModel.snippets.isEmpty ? "No text snippets yet" : "No matches")
                 .font(DesignSystem.Typography.body)
@@ -238,83 +222,49 @@ struct TextSnippetsView: View {
                     .font(DesignSystem.Typography.caption)
                     .foregroundStyle(.tertiary)
                     .multilineTextAlignment(.center)
+                    .frame(maxWidth: 320)
                 Button("Add Your First Snippet") {
                     triggerFieldFocused = true
                 }
-                .parakeetAction(.primaryProminent)
+                .parakeetAction(.primary)
                 .controlSize(.small)
-            }
-        }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, DesignSystem.Spacing.lg)
-    }
-
-    // MARK: - Reusable
-
-    private func managementCard<Content: View>(
-        title: String,
-        subtitle: String,
-        icon: String,
-        @ViewBuilder content: () -> Content
-    ) -> some View {
-        let isHovered = hoveredCardTitle == title
-        return VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
-            HStack(alignment: .top, spacing: DesignSystem.Spacing.sm) {
-                Image(systemName: icon)
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(DesignSystem.Colors.accent)
-                    .frame(width: 30, height: 30)
-                    .background(
-                        RoundedRectangle(cornerRadius: 8)
-                            .fill(DesignSystem.Colors.accent.opacity(0.12))
-                    )
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(title)
-                        .font(DesignSystem.Typography.sectionTitle)
-                    Text(subtitle)
-                        .font(DesignSystem.Typography.caption)
-                        .foregroundStyle(.secondary)
-                }
-            }
-
-            content()
-        }
-        .padding(DesignSystem.Spacing.lg)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
-                .fill(DesignSystem.Colors.cardBackground)
-                .cardShadow(isHovered ? DesignSystem.Shadows.cardHover : DesignSystem.Shadows.cardRest)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
-                .strokeBorder(
-                    isHovered ? DesignSystem.Colors.accent.opacity(0.2) : DesignSystem.Colors.border.opacity(0.6),
-                    lineWidth: 0.5
-                )
-        )
-        .onHover { hovering in
-            withAnimation(DesignSystem.Animation.hoverTransition) {
-                hoveredCardTitle = hovering ? title : nil
+                .padding(.top, 2)
             }
         }
     }
 
-    private func metricChip(title: String, value: String) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(title)
-                .font(DesignSystem.Typography.micro)
+    private func tipRow(icon: String, text: String) -> some View {
+        HStack(alignment: .top, spacing: DesignSystem.Spacing.sm) {
+            Image(systemName: icon)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(DesignSystem.Colors.warningAmber)
+                .frame(width: 16)
+            Text(text)
+                .font(DesignSystem.Typography.caption)
                 .foregroundStyle(.secondary)
-            Text(value)
-                .font(DesignSystem.Typography.body.weight(.semibold))
-                .contentTransition(.numericText())
+                .fixedSize(horizontal: false, vertical: true)
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
-        .background(
-            RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
-                .fill(DesignSystem.Colors.surfaceElevated)
-        )
+    }
+
+    // MARK: - Helpers
+
+    private var snippetsCountLabel: String {
+        let total = viewModel.snippets.count
+        let searching = !viewModel.searchText.trimmingCharacters(in: .whitespaces).isEmpty
+        if searching {
+            return "\(viewModel.filteredSnippets.count) of \(total)"
+        }
+        let disabled = viewModel.snippets.filter { !$0.isEnabled }.count
+        if disabled > 0 {
+            return "\(total) · \(disabled) off"
+        }
+        return total == 1 ? "1 snippet" : "\(total) snippets"
+    }
+
+    private func attemptAdd() {
+        let triggerEmpty = viewModel.newTrigger.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let expansionEmpty = viewModel.newExpansion.trimmingCharacters(in: .whitespaces).isEmpty
+        guard !triggerEmpty && !expansionEmpty else { return }
+        viewModel.addSnippet()
     }
 }

--- a/Sources/MacParakeet/Views/Vocabulary/TextSnippetsView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/TextSnippetsView.swift
@@ -4,10 +4,9 @@ import MacParakeetViewModels
 
 struct TextSnippetsView: View {
     @Bindable var viewModel: TextSnippetsViewModel
-    @Environment(\.dismiss) private var dismiss
+    let onClose: () -> Void
     @State private var hoveredSnippetID: UUID?
     @State private var showTips = false
-    @FocusState private var searchFocused: Bool
     @FocusState private var triggerFieldFocused: Bool
     @FocusState private var expansionFieldFocused: Bool
 
@@ -16,7 +15,7 @@ struct TextSnippetsView: View {
             VocabSheetHeader(
                 title: "Text Snippets",
                 subtitle: "Say a short phrase, paste a longer one.",
-                onDone: { dismiss() }
+                onDone: onClose
             )
 
             Divider()
@@ -27,8 +26,7 @@ struct TextSnippetsView: View {
                         placeholder: "Search snippets…",
                         text: $viewModel.searchText,
                         leadingSystemImage: "magnifyingglass",
-                        showsClearButton: true,
-                        externalFocus: $searchFocused
+                        showsClearButton: true
                     )
 
                     snippetsSection
@@ -37,11 +35,6 @@ struct TextSnippetsView: View {
                 }
                 .padding(DesignSystem.Spacing.lg)
             }
-        }
-        .onAppear {
-            // Open neutral — don't let the freshly presented sheet auto-focus
-            // the search field.
-            Task { @MainActor in searchFocused = false }
         }
         .alert(
             "Delete Snippet?",

--- a/Sources/MacParakeet/Views/Vocabulary/TextSnippetsView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/TextSnippetsView.swift
@@ -4,7 +4,7 @@ import MacParakeetViewModels
 
 struct TextSnippetsView: View {
     @Bindable var viewModel: TextSnippetsViewModel
-    let onClose: () -> Void
+    @Environment(\.dismiss) private var dismiss
     @State private var hoveredSnippetID: UUID?
     @State private var showTips = false
     @FocusState private var triggerFieldFocused: Bool
@@ -12,10 +12,13 @@ struct TextSnippetsView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            SheetAutoFocusSuppressor()
+                .frame(width: 0, height: 0)
+
             VocabSheetHeader(
                 title: "Text Snippets",
                 subtitle: "Say a short phrase, paste a longer one.",
-                onDone: onClose
+                onDone: { dismiss() }
             )
 
             Divider()
@@ -76,7 +79,7 @@ struct TextSnippetsView: View {
                 VStack(spacing: 0) {
                     ForEach(Array(viewModel.filteredSnippets.enumerated()), id: \.element.id) { index, snippet in
                         if index > 0 {
-                            Divider().padding(.leading, 52)
+                            Divider().padding(.leading, VocabMetrics.rowDividerInset)
                         }
                         snippetRow(snippet)
                     }

--- a/Sources/MacParakeet/Views/Vocabulary/TextSnippetsView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/TextSnippetsView.swift
@@ -7,6 +7,7 @@ struct TextSnippetsView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var hoveredSnippetID: UUID?
     @State private var showTips = false
+    @FocusState private var searchFocused: Bool
     @FocusState private var triggerFieldFocused: Bool
     @FocusState private var expansionFieldFocused: Bool
 
@@ -26,7 +27,8 @@ struct TextSnippetsView: View {
                         placeholder: "Search snippets…",
                         text: $viewModel.searchText,
                         leadingSystemImage: "magnifyingglass",
-                        showsClearButton: true
+                        showsClearButton: true,
+                        externalFocus: $searchFocused
                     )
 
                     snippetsSection
@@ -36,7 +38,11 @@ struct TextSnippetsView: View {
                 .padding(DesignSystem.Spacing.lg)
             }
         }
-        .background(.thickMaterial)
+        .onAppear {
+            // Open neutral — don't let the freshly presented sheet auto-focus
+            // the search field.
+            Task { @MainActor in searchFocused = false }
+        }
         .alert(
             "Delete Snippet?",
             isPresented: Binding(
@@ -127,14 +133,16 @@ struct TextSnippetsView: View {
 
     private var tipsDisclosure: some View {
         DisclosureGroup(isExpanded: $showTips) {
-            VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
                 tipRow(
-                    icon: "quote.bubble",
-                    text: "Use natural trigger phrases (for example, \"my signature\") rather than abbreviations — Parakeet recognizes natural speech."
+                    icon: "waveform",
+                    title: "Speak naturally",
+                    detail: "Use real phrases like \"my signature\" — not abbreviations."
                 )
                 tipRow(
                     icon: "return",
-                    text: "Type \\n in the expansion to insert a line break. Example: trigger \"new paragraph\" with expansion \\n\\n inserts a blank line."
+                    title: "Add line breaks",
+                    detail: "Put `\\n` in an expansion. `\\n\\n` makes a blank line."
                 )
             }
             .padding(.top, DesignSystem.Spacing.sm)
@@ -235,16 +243,21 @@ struct TextSnippetsView: View {
         }
     }
 
-    private func tipRow(icon: String, text: String) -> some View {
+    private func tipRow(icon: String, title: String, detail: LocalizedStringKey) -> some View {
         HStack(alignment: .top, spacing: DesignSystem.Spacing.sm) {
             Image(systemName: icon)
-                .font(.system(size: 12, weight: .semibold))
-                .foregroundStyle(DesignSystem.Colors.warningAmber)
-                .frame(width: 16)
-            Text(text)
-                .font(DesignSystem.Typography.caption)
+                .font(.system(size: 13, weight: .semibold))
                 .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
+                .frame(width: 18)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                    .font(DesignSystem.Typography.caption.weight(.semibold))
+                    .foregroundStyle(.primary)
+                Text(detail)
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
         }
     }
 

--- a/Sources/MacParakeet/Views/Vocabulary/TextSnippetsView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/TextSnippetsView.swift
@@ -8,6 +8,7 @@ struct TextSnippetsView: View {
     @State private var hoveredSnippetID: UUID?
     @State private var showTips = false
     @FocusState private var triggerFieldFocused: Bool
+    @FocusState private var expansionFieldFocused: Bool
 
     var body: some View {
         VStack(spacing: 0) {
@@ -104,13 +105,14 @@ struct TextSnippetsView: View {
                 ParakeetTextField(
                     placeholder: "Trigger phrase",
                     text: $viewModel.newTrigger,
-                    onSubmit: attemptAdd,
+                    onSubmit: { expansionFieldFocused = true },
                     externalFocus: $triggerFieldFocused
                 )
                 ParakeetTextField(
                     placeholder: "Expansion",
                     text: $viewModel.newExpansion,
-                    onSubmit: attemptAdd
+                    onSubmit: attemptAdd,
+                    externalFocus: $expansionFieldFocused
                 )
                 Button("Add", action: attemptAdd)
                     .parakeetAction(.primaryProminent)

--- a/Sources/MacParakeet/Views/Vocabulary/VocabularyComponents.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/VocabularyComponents.swift
@@ -1,5 +1,13 @@
 import SwiftUI
 
+/// Which Vocabulary management panel is presented as a window-level overlay.
+/// Owned by `MainWindowView` so the scrim covers the whole window (a `.sheet`
+/// can't dismiss on outside-click and auto-focuses its first field).
+enum VocabularySheetKind: Equatable {
+    case customWords
+    case textSnippets
+}
+
 // Shared building blocks for the Vocabulary surfaces (the Vocabulary tab and
 // the Custom Words / Text Snippets sheets). These replace the old "every
 // subsection is its own icon-tiled card" pattern with lighter, list-native

--- a/Sources/MacParakeet/Views/Vocabulary/VocabularyComponents.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/VocabularyComponents.swift
@@ -1,0 +1,198 @@
+import SwiftUI
+
+// Shared building blocks for the Vocabulary surfaces (the Vocabulary tab and
+// the Custom Words / Text Snippets sheets). These replace the old "every
+// subsection is its own icon-tiled card" pattern with lighter, list-native
+// primitives: one grouped surface per collection, plain section headers, and
+// fields whose focus reads coral instead of the system blue ring.
+
+// MARK: - Styled text field
+
+/// A text field with a coral focus ring instead of the system blue one, an
+/// optional leading glyph (for search), and an optional clear button.
+///
+/// Focus can be driven internally (default) or bound to an external
+/// `@FocusState` so callers can focus it programmatically — e.g. an empty
+/// state's "Add your first…" button focusing the add form.
+struct ParakeetTextField: View {
+    let placeholder: String
+    @Binding var text: String
+    var leadingSystemImage: String? = nil
+    var showsClearButton: Bool = false
+    var onSubmit: (() -> Void)? = nil
+    var externalFocus: FocusState<Bool>.Binding? = nil
+
+    @FocusState private var localFocus: Bool
+
+    private var focusBinding: FocusState<Bool>.Binding {
+        externalFocus ?? $localFocus
+    }
+
+    private var isFocused: Bool {
+        externalFocus?.wrappedValue ?? localFocus
+    }
+
+    var body: some View {
+        HStack(spacing: DesignSystem.Spacing.sm) {
+            if let leadingSystemImage {
+                Image(systemName: leadingSystemImage)
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+            }
+
+            TextField(placeholder, text: $text)
+                .textFieldStyle(.plain)
+                .font(DesignSystem.Typography.body)
+                .tint(DesignSystem.Colors.accent)
+                .focused(focusBinding)
+                .onSubmit { onSubmit?() }
+
+            if showsClearButton && !text.isEmpty {
+                Button {
+                    text = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 13))
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear")
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
+                .fill(DesignSystem.Colors.surfaceElevated)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
+                .strokeBorder(
+                    isFocused
+                        ? DesignSystem.Colors.accent.opacity(0.7)
+                        : DesignSystem.Colors.border.opacity(0.7),
+                    lineWidth: isFocused ? 1.5 : 0.5
+                )
+        )
+        .animation(DesignSystem.Animation.hoverTransition, value: isFocused)
+    }
+}
+
+// MARK: - Section header
+
+/// A plain section header — uppercase label with an optional trailing accessory
+/// (typically a contextual count) and an optional one-line subtitle. Replaces
+/// the heavy icon-tile card header for content that doesn't warrant a card.
+struct VocabSectionHeader<Trailing: View>: View {
+    private let title: String
+    private let subtitle: String?
+    private let trailing: Trailing
+
+    init(title: String, subtitle: String? = nil, @ViewBuilder trailing: () -> Trailing) {
+        self.title = title
+        self.subtitle = subtitle
+        self.trailing = trailing()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(title.uppercased())
+                    .font(.system(size: 11, weight: .semibold))
+                    .tracking(0.6)
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: DesignSystem.Spacing.sm)
+                trailing
+            }
+            if let subtitle {
+                Text(subtitle)
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(.tertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+}
+
+extension VocabSectionHeader where Trailing == EmptyView {
+    init(title: String, subtitle: String? = nil) {
+        self.init(title: title, subtitle: subtitle) { EmptyView() }
+    }
+}
+
+// MARK: - Grouped collection surface
+
+extension View {
+    /// Wraps a vertical stack of rows in one grouped "collection" surface —
+    /// subtle fill, hairline border, rounded and clipped so per-row hover fills
+    /// stay inside the corners. One surface per collection, instead of one card
+    /// per row or a card around everything.
+    func vocabGroup() -> some View {
+        self
+            .background(
+                RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
+                    .fill(DesignSystem.Colors.surface)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius))
+            .overlay(
+                RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
+                    .strokeBorder(DesignSystem.Colors.border.opacity(0.7), lineWidth: 0.5)
+            )
+    }
+}
+
+// MARK: - Sheet header
+
+/// Title + subtitle on the left, a neutral Done button on the right. Gives the
+/// management sheets a real header bar so Done is sheet-level chrome rather than
+/// a second coral button buried mid-content.
+struct VocabSheetHeader: View {
+    let title: String
+    let subtitle: String
+    let onDone: () -> Void
+
+    var body: some View {
+        HStack(alignment: .center, spacing: DesignSystem.Spacing.md) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(DesignSystem.Typography.pageTitle)
+                Text(subtitle)
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: DesignSystem.Spacing.md)
+
+            Button("Done", action: onDone)
+                .parakeetAction(.secondary)
+                .controlSize(.large)
+                .keyboardShortcut(.cancelAction)
+        }
+        .padding(.horizontal, DesignSystem.Spacing.lg)
+        .padding(.vertical, DesignSystem.Spacing.md)
+    }
+}
+
+// MARK: - Delete icon button
+
+/// A trash button that rests in the secondary color and warms to red on hover,
+/// giving the destructive affordance a clear, contained signal.
+struct DeleteIconButton: View {
+    let helpText: String
+    let accessibilityName: String
+    let action: () -> Void
+
+    @State private var hovered = false
+
+    var body: some View {
+        Button(role: .destructive, action: action) {
+            Image(systemName: "trash")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(hovered ? DesignSystem.Colors.errorRed : .secondary)
+        }
+        .buttonStyle(.plain)
+        .onHover { hovered = $0 }
+        .help(helpText)
+        .accessibilityLabel(accessibilityName)
+    }
+}

--- a/Sources/MacParakeet/Views/Vocabulary/VocabularyComponents.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/VocabularyComponents.swift
@@ -38,6 +38,7 @@ struct ParakeetTextField: View {
                 Image(systemName: leadingSystemImage)
                     .font(.system(size: 13))
                     .foregroundStyle(.secondary)
+                    .accessibilityHidden(true)
             }
 
             TextField(placeholder, text: $text)
@@ -56,7 +57,7 @@ struct ParakeetTextField: View {
                         .foregroundStyle(.tertiary)
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel("Clear")
+                .accessibilityLabel("Clear search")
             }
         }
         .padding(.horizontal, 10)

--- a/Sources/MacParakeet/Views/Vocabulary/VocabularyComponents.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/VocabularyComponents.swift
@@ -208,10 +208,11 @@ struct DeleteIconButton: View {
 
 // MARK: - Modal scrim container
 
-/// Wraps a sheet's panel in a full-bleed dimmed scrim so clicking outside the
-/// panel dismisses it (macOS sheets don't dismiss on outside-click natively).
-/// The panel carries its own rounded material background, border, and shadow;
-/// the modal views inside no longer set their own background.
+/// Wraps a modal panel in a full-bleed dimmed scrim so clicking outside the
+/// panel dismisses it. Presented as a window-level overlay rather than a
+/// `.sheet` — a sheet can't dismiss on outside-click and auto-focuses its first
+/// text field. The panel carries its own rounded material background, border,
+/// and shadow; the modal views inside don't set their own background.
 struct ModalScrimContainer<Content: View>: View {
     private let onScrimTap: () -> Void
     private let content: Content

--- a/Sources/MacParakeet/Views/Vocabulary/VocabularyComponents.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/VocabularyComponents.swift
@@ -197,3 +197,43 @@ struct DeleteIconButton: View {
         .accessibilityLabel(accessibilityName)
     }
 }
+
+// MARK: - Modal scrim container
+
+/// Wraps a sheet's panel in a full-bleed dimmed scrim so clicking outside the
+/// panel dismisses it (macOS sheets don't dismiss on outside-click natively).
+/// The panel carries its own rounded material background, border, and shadow;
+/// the modal views inside no longer set their own background.
+struct ModalScrimContainer<Content: View>: View {
+    private let onScrimTap: () -> Void
+    private let content: Content
+
+    init(onScrimTap: @escaping () -> Void, @ViewBuilder content: () -> Content) {
+        self.onScrimTap = onScrimTap
+        self.content = content()
+    }
+
+    var body: some View {
+        ZStack {
+            Rectangle()
+                .fill(Color.black.opacity(0.18))
+                .ignoresSafeArea()
+                .contentShape(Rectangle())
+                .onTapGesture(perform: onScrimTap)
+                .accessibilityAddTraits(.isButton)
+                .accessibilityLabel("Close")
+
+            content
+                .frame(width: 640, height: 540)
+                .background(.thickMaterial, in: RoundedRectangle(cornerRadius: DesignSystem.Layout.cornerRadius))
+                .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.cornerRadius))
+                .overlay(
+                    RoundedRectangle(cornerRadius: DesignSystem.Layout.cornerRadius)
+                        .strokeBorder(DesignSystem.Colors.border.opacity(0.5), lineWidth: 0.5)
+                )
+                .shadow(color: .black.opacity(0.35), radius: 40, x: 0, y: 16)
+                .contentShape(Rectangle())
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/Sources/MacParakeet/Views/Vocabulary/VocabularyComponents.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/VocabularyComponents.swift
@@ -1,18 +1,20 @@
 import SwiftUI
-
-/// Which Vocabulary management panel is presented as a window-level overlay.
-/// Owned by `MainWindowView` so the scrim covers the whole window (a `.sheet`
-/// can't dismiss on outside-click and auto-focuses its first field).
-enum VocabularySheetKind: Equatable {
-    case customWords
-    case textSnippets
-}
+import AppKit
 
 // Shared building blocks for the Vocabulary surfaces (the Vocabulary tab and
 // the Custom Words / Text Snippets sheets). These replace the old "every
 // subsection is its own icon-tiled card" pattern with lighter, list-native
 // primitives: one grouped surface per collection, plain section headers, and
 // fields whose focus reads coral instead of the system blue ring.
+
+// MARK: - Layout metrics
+
+/// Layout metrics shared across the Vocabulary management sheets.
+enum VocabMetrics {
+    /// Leading inset for in-group row dividers so they begin under the row's
+    /// text — clearing the small toggle plus the row's leading padding + gap.
+    static let rowDividerInset: CGFloat = 52
+}
 
 // MARK: - Styled text field
 
@@ -106,10 +108,11 @@ struct VocabSectionHeader<Trailing: View>: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
             HStack(alignment: .firstTextBaseline) {
-                Text(title.uppercased())
+                Text(title)
                     .font(.system(size: 11, weight: .semibold))
                     .tracking(0.6)
                     .foregroundStyle(.secondary)
+                    .textCase(.uppercase)
                 Spacer(minLength: DesignSystem.Spacing.sm)
                 trailing
             }
@@ -206,43 +209,22 @@ struct DeleteIconButton: View {
     }
 }
 
-// MARK: - Modal scrim container
+// MARK: - Sheet auto-focus suppressor
 
-/// Wraps a modal panel in a full-bleed dimmed scrim so clicking outside the
-/// panel dismisses it. Presented as a window-level overlay rather than a
-/// `.sheet` — a sheet can't dismiss on outside-click and auto-focuses its first
-/// text field. The panel carries its own rounded material background, border,
-/// and shadow; the modal views inside don't set their own background.
-struct ModalScrimContainer<Content: View>: View {
-    private let onScrimTap: () -> Void
-    private let content: Content
+/// Stops a freshly presented `.sheet` from auto-focusing its first text field.
+/// macOS makes the first text field the window's initial first responder;
+/// pointing `initialFirstResponder` at a non-editable view instead means the
+/// sheet opens with nothing focused — no caret, no flash. Drop a zero-size
+/// instance inside the sheet's content.
+struct SheetAutoFocusSuppressor: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSView { BlockerView() }
+    func updateNSView(_ nsView: NSView, context: Context) {}
 
-    init(onScrimTap: @escaping () -> Void, @ViewBuilder content: () -> Content) {
-        self.onScrimTap = onScrimTap
-        self.content = content()
-    }
-
-    var body: some View {
-        ZStack {
-            Rectangle()
-                .fill(Color.black.opacity(0.18))
-                .ignoresSafeArea()
-                .contentShape(Rectangle())
-                .onTapGesture(perform: onScrimTap)
-                .accessibilityAddTraits(.isButton)
-                .accessibilityLabel("Close")
-
-            content
-                .frame(width: 640, height: 540)
-                .background(.thickMaterial, in: RoundedRectangle(cornerRadius: DesignSystem.Layout.cornerRadius))
-                .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.cornerRadius))
-                .overlay(
-                    RoundedRectangle(cornerRadius: DesignSystem.Layout.cornerRadius)
-                        .strokeBorder(DesignSystem.Colors.border.opacity(0.5), lineWidth: 0.5)
-                )
-                .shadow(color: .black.opacity(0.35), radius: 40, x: 0, y: 16)
-                .contentShape(Rectangle())
+    private final class BlockerView: NSView {
+        override var acceptsFirstResponder: Bool { false }
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            window?.initialFirstResponder = self
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }

--- a/Sources/MacParakeet/Views/Vocabulary/VocabularyView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/VocabularyView.swift
@@ -8,7 +8,8 @@ struct VocabularyView: View {
     @Bindable var textSnippetsViewModel: TextSnippetsViewModel
     @Bindable var backupViewModel: VocabularyBackupViewModel
 
-    @Binding var activeSheet: VocabularySheetKind?
+    @State private var showCustomWords = false
+    @State private var showTextSnippets = false
     @State private var hoveredCardTitle: String?
     @State private var hoveredModeTitle: String?
 
@@ -36,6 +37,18 @@ struct VocabularyView: View {
             .padding(DesignSystem.Spacing.lg)
         }
         .background(DesignSystem.Colors.background)
+        .sheet(isPresented: $showCustomWords) {
+            settingsViewModel.refreshStats()
+        } content: {
+            CustomWordsView(viewModel: customWordsViewModel)
+                .frame(width: 640, height: 560)
+        }
+        .sheet(isPresented: $showTextSnippets) {
+            settingsViewModel.refreshStats()
+        } content: {
+            TextSnippetsView(viewModel: textSnippetsViewModel)
+                .frame(width: 640, height: 560)
+        }
         .onAppear {
             settingsViewModel.refreshStats()
         }
@@ -117,7 +130,7 @@ struct VocabularyView: View {
                     actionTitle: "Manage words",
                     action: {
                         customWordsViewModel.loadWords()
-                        activeSheet = .customWords
+                        showCustomWords = true
                     }
                 )
 
@@ -130,7 +143,7 @@ struct VocabularyView: View {
                     actionTitle: "Manage snippets",
                     action: {
                         textSnippetsViewModel.loadSnippets()
-                        activeSheet = .textSnippets
+                        showTextSnippets = true
                     }
                 )
 
@@ -196,8 +209,7 @@ struct VocabularyView: View {
                             exampleRow(input: "the \(trigger) was broken", result: "Pastes as-is — trigger is mid-sentence", fires: false)
                             exampleRow(input: "git status", result: "Pastes as-is — no trigger spoken", fires: false)
                         }
-                        .padding(.leading, 24)
-                        .padding(.top, 2)
+                        .padding(.leading, DesignSystem.Spacing.lg)
                     }
 
                 }

--- a/Sources/MacParakeet/Views/Vocabulary/VocabularyView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/VocabularyView.swift
@@ -40,14 +40,16 @@ struct VocabularyView: View {
         .sheet(isPresented: $showCustomWords) {
             settingsViewModel.refreshStats()
         } content: {
-            CustomWordsView(viewModel: customWordsViewModel)
-                .frame(minWidth: 620, minHeight: 460)
+            ModalScrimContainer(onScrimTap: { showCustomWords = false }) {
+                CustomWordsView(viewModel: customWordsViewModel)
+            }
         }
         .sheet(isPresented: $showTextSnippets) {
             settingsViewModel.refreshStats()
         } content: {
-            TextSnippetsView(viewModel: textSnippetsViewModel)
-                .frame(minWidth: 620, minHeight: 460)
+            ModalScrimContainer(onScrimTap: { showTextSnippets = false }) {
+                TextSnippetsView(viewModel: textSnippetsViewModel)
+            }
         }
         .onAppear {
             settingsViewModel.refreshStats()

--- a/Sources/MacParakeet/Views/Vocabulary/VocabularyView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/VocabularyView.swift
@@ -8,8 +8,7 @@ struct VocabularyView: View {
     @Bindable var textSnippetsViewModel: TextSnippetsViewModel
     @Bindable var backupViewModel: VocabularyBackupViewModel
 
-    @State private var showCustomWords = false
-    @State private var showTextSnippets = false
+    @Binding var activeSheet: VocabularySheetKind?
     @State private var hoveredCardTitle: String?
     @State private var hoveredModeTitle: String?
 
@@ -37,20 +36,6 @@ struct VocabularyView: View {
             .padding(DesignSystem.Spacing.lg)
         }
         .background(DesignSystem.Colors.background)
-        .sheet(isPresented: $showCustomWords) {
-            settingsViewModel.refreshStats()
-        } content: {
-            ModalScrimContainer(onScrimTap: { showCustomWords = false }) {
-                CustomWordsView(viewModel: customWordsViewModel)
-            }
-        }
-        .sheet(isPresented: $showTextSnippets) {
-            settingsViewModel.refreshStats()
-        } content: {
-            ModalScrimContainer(onScrimTap: { showTextSnippets = false }) {
-                TextSnippetsView(viewModel: textSnippetsViewModel)
-            }
-        }
         .onAppear {
             settingsViewModel.refreshStats()
         }
@@ -132,7 +117,7 @@ struct VocabularyView: View {
                     actionTitle: "Manage words",
                     action: {
                         customWordsViewModel.loadWords()
-                        showCustomWords = true
+                        activeSheet = .customWords
                     }
                 )
 
@@ -145,7 +130,7 @@ struct VocabularyView: View {
                     actionTitle: "Manage snippets",
                     action: {
                         textSnippetsViewModel.loadSnippets()
-                        showTextSnippets = true
+                        activeSheet = .textSnippets
                     }
                 )
 

--- a/Sources/MacParakeet/Views/Vocabulary/VocabularyView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/VocabularyView.swift
@@ -20,7 +20,7 @@ struct VocabularyView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
-                policyHeaderCard
+                pageHeader
                 modeSelectionCard
                 voiceReturnCard
                 if selectedMode == .raw {
@@ -56,30 +56,16 @@ struct VocabularyView: View {
 
     // MARK: - Header
 
-    private var policyHeaderCard: some View {
-        vocabularyCard(
-            title: "Text Processing",
-            subtitle: "How your voice becomes text — entirely on your Mac.",
-            icon: "text.quote"
-        ) {
-            LazyVGrid(
-                columns: [GridItem(.adaptive(minimum: 130), spacing: DesignSystem.Spacing.sm)],
-                spacing: DesignSystem.Spacing.sm
-            ) {
-                summaryChip(
-                    title: "Current Mode",
-                    value: selectedMode.displayName
-                )
-                summaryChip(
-                    title: "Custom Words",
-                    value: "\(settingsViewModel.customWordCount)"
-                )
-                summaryChip(
-                    title: "Snippets",
-                    value: "\(settingsViewModel.snippetCount)"
-                )
-            }
+    private var pageHeader: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Vocabulary")
+                .font(DesignSystem.Typography.pageTitle)
+            Text("How your voice becomes text — entirely on your Mac.")
+                .font(DesignSystem.Typography.bodySmall)
+                .foregroundStyle(.secondary)
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.bottom, DesignSystem.Spacing.xs)
     }
 
     // MARK: - Mode Selection
@@ -189,9 +175,7 @@ struct VocabularyView: View {
                         Text("Enable Voice Return")
                             .font(DesignSystem.Typography.body)
                     }
-                    .toggleStyle(.switch)
-                    .tint(DesignSystem.Colors.accent)
-
+                    .parakeetSwitch()
                 }
 
                 if settingsViewModel.voiceReturnEnabled {
@@ -199,8 +183,7 @@ struct VocabularyView: View {
                         Text("Trigger phrase")
                             .font(DesignSystem.Typography.caption)
                             .foregroundStyle(.secondary)
-                        TextField("press return", text: $settingsViewModel.voiceReturnTrigger)
-                            .textFieldStyle(.roundedBorder)
+                        ParakeetTextField(placeholder: "press return", text: $settingsViewModel.voiceReturnTrigger)
                             .frame(maxWidth: 250)
                         if settingsViewModel.voiceReturnTrigger.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                             Text("Enter a trigger phrase to activate Voice Return.")
@@ -220,13 +203,14 @@ struct VocabularyView: View {
                         }
 
                         let trigger = settingsViewModel.voiceReturnTrigger.isEmpty ? "press return" : settingsViewModel.voiceReturnTrigger
-                        VStack(alignment: .leading, spacing: 4) {
+                        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
                             exampleRow(input: "git status \(trigger)", result: "Pastes \"git status\" + presses ⏎", fires: true)
                             exampleRow(input: "\(trigger)", result: "Just presses ⏎ (nothing to paste)", fires: true)
                             exampleRow(input: "the \(trigger) was broken", result: "Pastes as-is — trigger is mid-sentence", fires: false)
                             exampleRow(input: "git status", result: "Pastes as-is — no trigger spoken", fires: false)
                         }
                         .padding(.leading, 24)
+                        .padding(.top, 2)
                     }
 
                 }
@@ -303,37 +287,19 @@ struct VocabularyView: View {
         }
     }
 
-    private func summaryChip(title: String, value: String) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(title)
-                .font(DesignSystem.Typography.micro)
-                .foregroundStyle(.secondary)
-            Text(value)
-                .font(DesignSystem.Typography.body.weight(.semibold))
-                .contentTransition(.numericText())
-        }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
-                .fill(DesignSystem.Colors.surfaceElevated)
-        )
-    }
-
     private func exampleRow(input: String, result: String, fires: Bool) -> some View {
-        HStack(spacing: DesignSystem.Spacing.xs) {
+        HStack(alignment: .firstTextBaseline, spacing: DesignSystem.Spacing.sm) {
             Image(systemName: fires ? "checkmark.circle.fill" : "xmark.circle")
-                .font(.system(size: 11))
+                .font(.system(size: 12))
                 .foregroundStyle(fires ? DesignSystem.Colors.successGreen : .secondary)
             Text("\"\(input)\"")
-                .font(DesignSystem.Typography.micro.monospaced())
+                .font(DesignSystem.Typography.caption.monospaced())
                 .foregroundStyle(.primary)
             Text("→")
-                .font(DesignSystem.Typography.micro)
+                .font(DesignSystem.Typography.caption)
                 .foregroundStyle(.tertiary)
             Text(result)
-                .font(DesignSystem.Typography.micro)
+                .font(DesignSystem.Typography.caption)
                 .foregroundStyle(.secondary)
         }
     }
@@ -357,7 +323,7 @@ struct VocabularyView: View {
                     if isSelected {
                         Image(systemName: "checkmark.circle.fill")
                             .font(.system(size: 14))
-                            .foregroundStyle(DesignSystem.Colors.successGreen)
+                            .foregroundStyle(DesignSystem.Colors.accent)
                     }
                 }
 

--- a/plans/active/vocabulary-surface-refinement.md
+++ b/plans/active/vocabulary-surface-refinement.md
@@ -1,0 +1,68 @@
+# Vocabulary Surface Refinement
+
+> Status: **ACTIVE** — UI polish pass on the Vocabulary tab + Custom Words /
+> Text Snippets sheets, holding them to the bar set by the Dictation Stats
+> screen.
+
+## Why
+
+The Dictation Stats screen subordinates chrome to data: distinct metrics, one
+coral accent (the lead tile), minimal decoration. The Vocabulary surfaces invert
+that ratio — high chrome density, low information density. A single search field
+sits inside a full icon-tiled card; coral is everywhere, so it signals nothing;
+the actual list (the point of the screen) is the least-emphasized element.
+
+This violates the documented coral discipline (`docs/brand-identity.md`: coral is
+a *moment of attention*, not chrome) and the "simplicity is the product"
+principle.
+
+## Scope
+
+The three reviewed surfaces only:
+
+- `Views/Vocabulary/VocabularyView.swift`
+- `Views/Vocabulary/CustomWordsView.swift`
+- `Views/Vocabulary/TextSnippetsView.swift`
+- `Views/MainWindowView.swift` (sidebar selection tint)
+
+Shared primitives added in `Views/Vocabulary/VocabularyComponents.swift` and a
+`parakeetSwitch()` modifier in `Views/Components/ParakeetActionStyle.swift`.
+
+## Changes
+
+### Coherence (P0)
+- **One toggle treatment.** `parakeetSwitch()` (coral) everywhere on these
+  surfaces — kills the Voice-Return-coral vs list-toggle-blue split.
+- **One coral CTA per sheet.** `Add` stays coral; `Done` moves to a neutral
+  header-bar button.
+- **Drop Total/Visible/Enabled tiles.** Replaced by a single contextual count
+  ("3 rules", "2 off", or "2 of 5" while searching).
+
+### Layout & native feel (P1)
+- Sheets get a real header bar (title + subtitle + neutral Done).
+- The rule/snippet list leads, in one grouped "collection" surface, instead of
+  being the third stacked card.
+- Search demoted from a card to an inline coral-focus field.
+- Vocabulary tab: redundant "Text Processing" summary card replaced by a slim
+  plain page header (the chips just restated the Mode card + Pipeline steps).
+- Sidebar selection tinted coral so it stops reading as a stray system-blue pill.
+
+### Detail polish (P2)
+- Selected Mode card check: green → coral (green read as "valid", not
+  "selected").
+- Voice Return examples: `micro` → `caption`, more breathing room.
+- Snippet usage count: bare "9" → glyph + count badge.
+- Snippet rows drop the redundant "Trigger:" prefix.
+- Trash glyph warms to red on hover.
+- Text fields use a coral focus ring instead of the system blue one.
+- Text Snippets "Guidance" card → collapsed "Tips" disclosure.
+
+## Out of scope / follow-ups
+- Settings tab shares the icon-tile card + blue `SettingsToggleRow` patterns.
+  Not touched here to keep blast radius to reviewed screens; a future pass could
+  adopt `parakeetSwitch()` app-wide for full toggle consistency.
+
+## Verification
+- `swift build` green.
+- `swift test` green (no ViewModel/logic changes; views are not unit-tested).
+- Manual: launch app, eyeball Vocabulary tab + both sheets in light/dark.

--- a/plans/completed/vocabulary-surface-refinement.md
+++ b/plans/completed/vocabulary-surface-refinement.md
@@ -1,8 +1,9 @@
 # Vocabulary Surface Refinement
 
-> Status: **ACTIVE** — UI polish pass on the Vocabulary tab + Custom Words /
+> Status: **IMPLEMENTED** — UI polish pass on the Vocabulary tab + Custom Words /
 > Text Snippets sheets, holding them to the bar set by the Dictation Stats
-> screen.
+> screen. Shipped on branch `design/vocabulary-refinement`; build + `swift test`
+> green. Pending visual sign-off + merge.
 
 ## Why
 
@@ -63,6 +64,9 @@ Shared primitives added in `Views/Vocabulary/VocabularyComponents.swift` and a
   adopt `parakeetSwitch()` app-wide for full toggle consistency.
 
 ## Verification
-- `swift build` green.
-- `swift test` green (no ViewModel/logic changes; views are not unit-tested).
-- Manual: launch app, eyeball Vocabulary tab + both sheets in light/dark.
+- `swift build --target MacParakeet` green (85s).
+- `swift test` green — full suite exit 0 (no ViewModel/logic changes; views are
+  not unit-tested).
+- Manual (pending): launch app, eyeball Vocabulary tab + both sheets in
+  light/dark — grouped-surface contrast in dark mode, divider inset alignment,
+  Add-button vs field height, and coral sidebar-selection weight.


### PR DESCRIPTION
## Why

The Dictation **Stats** screen sets the design bar: it subordinates chrome to data — distinct metrics, one coral accent (the lead tile), minimal decoration. The **Vocabulary** surfaces (Vocabulary tab + Custom Words / Text Snippets sheets) inverted that ratio — high chrome density, low information density. A single search field sat inside a full icon-tiled card; coral was everywhere, so it signaled nothing; the actual list (the point of each sheet) was the least-emphasized element. This also violated the documented coral discipline (`docs/brand-identity.md`: coral is a *moment of attention*, not chrome).

This PR holds those three surfaces to the Stats bar.

## What changed

**Coherence (P0)**
- One toggle treatment — new `parakeetSwitch()` (coral) everywhere on these surfaces, killing the Voice-Return-coral vs list-toggle-blue split.
- One coral CTA per sheet — `Add` stays coral; `Done` moves to a neutral header-bar button.
- Dropped the Total / Visible / Enabled tiles (all read "1" in the common case) for a single contextual count: "3 rules", "2 off", or "2 of 5" while searching.

**Layout & native feel (P1)**
- Sheets get a real header bar (title + subtitle + neutral Done).
- The rule/snippet list now **leads**, in one grouped "collection" surface, instead of being the third stacked card.
- Search demoted from a card to an inline coral-focus field.
- Vocabulary tab: the redundant "Text Processing" summary card (its chips just restated the Mode card + Pipeline steps) → a slim plain page header.
- Sidebar selection tinted coral so it stops reading as a stray system-blue pill.

**Detail polish (P2)**
- Selected Mode card check: green → coral (green read as "valid", not "selected").
- Voice Return examples: `micro` → `caption`, more breathing room.
- Snippet usage count: bare "9" → glyph + count badge.
- Snippet rows drop the redundant "Trigger:" prefix.
- Trash glyph warms to red on hover; text fields use a coral focus ring instead of the system blue one.
- Text Snippets "Guidance" card → collapsed "Tips" disclosure.

Net **−408 / +537** lines, but both modals *shrank* (CustomWords −156, TextSnippets −198): chrome removed, content promoted.

## Shared primitives added
`ParakeetTextField`, `VocabSectionHeader`, `vocabGroup()`, `VocabSheetHeader`, `DeleteIconButton` (in `Views/Vocabulary/VocabularyComponents.swift`), and `parakeetSwitch()` (in `Views/Components/ParakeetActionStyle.swift`).

## Out of scope / follow-up
Settings shares the icon-tile card + blue `SettingsToggleRow` patterns. Left untouched here to keep the blast radius on the reviewed screens; a future pass could adopt `parakeetSwitch()` app-wide for full toggle consistency.

## Verification
- `swift build --target MacParakeet` green (85s).
- `swift test` green — full suite exit 0 (no ViewModel/logic changes; views aren't unit-tested).
- **Manual sign-off pending** — worth eyeballing in light/dark: grouped-surface contrast (dark mode), divider inset alignment, Add-button vs field height, and coral sidebar-selection weight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)