### PR TITLE
Calendar auto-start reliability hardening (pre-enable)

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -323,7 +323,10 @@ final class AppEnvironmentConfigurer {
                     meetingCoordinator?.startFromCalendar(title: title)
                 },
                 onAutoStopConfirmed: { [weak meetingCoordinator] in
-                    meetingCoordinator?.toggleRecording()
+                    // Idempotent stop — never a toggle. A toggle would *start*
+                    // a new recording if the user already stopped the
+                    // auto-started one during the 30s auto-stop countdown.
+                    meetingCoordinator?.stopFromCalendar()
                 }
             )
             // The recording flow tells the calendar coordinator when an

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -322,11 +322,11 @@ final class AppEnvironmentConfigurer {
                 onAutoStartConfirmed: { [weak meetingCoordinator] title in
                     meetingCoordinator?.startFromCalendar(title: title)
                 },
-                onAutoStopConfirmed: { [weak meetingCoordinator] in
+                onAutoStopConfirmed: { [weak meetingCoordinator] recordingGeneration in
                     // Idempotent stop — never a toggle. A toggle would *start*
                     // a new recording if the user already stopped the
                     // auto-started one during the 30s auto-stop countdown.
-                    meetingCoordinator?.stopFromCalendar()
+                    meetingCoordinator?.stopFromCalendar(recordingGeneration: recordingGeneration)
                 }
             )
             // The recording flow tells the calendar coordinator when an

--- a/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
@@ -40,8 +40,8 @@ final class MeetingAutoStartCoordinator {
     /// an auto-start recording. The event title is forwarded so the
     /// recording flow can pre-name the saved transcription with the
     /// calendar event name instead of the date-based default.
-    private let onAutoStartConfirmed: @MainActor (_ title: String) -> Void
-    private let onAutoStopConfirmed: @MainActor () -> Void
+    private let onAutoStartConfirmed: @MainActor (_ title: String) -> Int?
+    private let onAutoStopConfirmed: @MainActor (_ recordingGeneration: Int) -> Void
     private let toastController: MeetingCountdownToastController
     private let logger = Logger(subsystem: "com.macparakeet", category: "MeetingAutoStart")
 
@@ -70,6 +70,7 @@ final class MeetingAutoStartCoordinator {
     /// (detected by next poll seeing `isRecordingActive() == false` while we
     /// still hold one) or when auto-stop fires.
     private var autoStartedEvent: CalendarEvent?
+    private var autoStartedRecordingGeneration: Int?
     /// `event.id` of an auto-started recording for which we're currently
     /// showing the auto-stop countdown. Prevents re-firing the toast on
     /// every poll tick during the 30s window. Bare `id` (not `dedupeKey`) on
@@ -96,8 +97,8 @@ final class MeetingAutoStartCoordinator {
         calendarService: any CalendarServicing = CalendarService.shared,
         settingsViewModel: SettingsViewModel,
         isRecordingActive: @escaping @MainActor () -> Bool = { false },
-        onAutoStartConfirmed: @escaping @MainActor (_ title: String) -> Void = { _ in },
-        onAutoStopConfirmed: @escaping @MainActor () -> Void = {},
+        onAutoStartConfirmed: @escaping @MainActor (_ title: String) -> Int? = { _ in nil },
+        onAutoStopConfirmed: @escaping @MainActor (_ recordingGeneration: Int) -> Void = { _ in },
         toastController: MeetingCountdownToastController? = nil
     ) {
         self.calendarService = calendarService
@@ -218,6 +219,7 @@ final class MeetingAutoStartCoordinator {
         // mode to .off). Re-evaluate immediately and reset adaptive polling
         // back to baseline so we don't keep the 5s timer alive for a feature
         // that's now disabled.
+        toastController.close()
         rescheduleTimer(interval: 60)
         Task { await pollAsync() }
     }
@@ -254,6 +256,7 @@ final class MeetingAutoStartCoordinator {
         let activeRecording = isRecordingActive()
         if !activeRecording, autoStartedEvent != nil {
             autoStartedEvent = nil
+            autoStartedRecordingGeneration = nil
             autoStopCountdownEventId = nil
             // Dismiss any stale auto-stop countdown — the recording it was
             // about to stop is already gone. Without this the toast keeps
@@ -263,8 +266,14 @@ final class MeetingAutoStartCoordinator {
         }
 
         // Fast-path guards before the (awaited) fetch.
-        guard settingsViewModel.calendarAutoStartMode != .off else { return }
-        guard calendarService.permissionStatus == .granted else { return }
+        guard settingsViewModel.calendarAutoStartMode != .off else {
+            toastController.close()
+            return
+        }
+        guard calendarService.permissionStatus == .granted else {
+            toastController.close()
+            return
+        }
 
         let events: [CalendarEvent]
         do {
@@ -283,8 +292,14 @@ final class MeetingAutoStartCoordinator {
         // pre-fetch values are stale; honoring the latest stops us from
         // processing a now-disabled feature one last time.
         let mode = settingsViewModel.calendarAutoStartMode
-        guard mode != .off else { return }
-        guard calendarService.permissionStatus == .granted else { return }
+        guard mode != .off else {
+            toastController.close()
+            return
+        }
+        guard calendarService.permissionStatus == .granted else {
+            toastController.close()
+            return
+        }
 
         let config = currentConfig(mode: mode)
         // Re-inject the owned in-flight recording's event if it has dropped
@@ -364,7 +379,10 @@ final class MeetingAutoStartCoordinator {
         // is actually on screen. Otherwise the cadence could relax to 60s right
         // when we need to surface the missed auto-stop.
         if isRecordingActive(), settingsViewModel.calendarAutoStopEnabled,
-           autoStartedEvent != nil, autoStopCountdownEventId == nil {
+           let autoStartedEvent,
+           autoStopCountdownEventId == nil,
+           !dismissedEventIds.contains(autoStartedEvent.dedupeKey),
+           Date() <= autoStartedEvent.endTime.addingTimeInterval(MeetingMonitor.autoStopForgiveness) {
             rescheduleTimer(interval: 5)
             return
         }
@@ -487,6 +505,7 @@ final class MeetingAutoStartCoordinator {
     /// binding can suppress the *next* meeting's auto-stop window.
     func clearAutoStartBinding() {
         autoStartedEvent = nil
+        autoStartedRecordingGeneration = nil
         autoStopCountdownEventId = nil
         logger.info("Auto-start binding cleared (start failed or state busy)")
     }
@@ -498,9 +517,13 @@ final class MeetingAutoStartCoordinator {
     func handleAutoStartOutcome(_ outcome: MeetingCountdownToastOutcome, for event: CalendarEvent) {
         switch outcome {
         case .completed, .primedEarly:
-            autoStartedEvent = event
-            onAutoStartConfirmed(event.title)
-            if autoStartedEvent == nil {
+            guard settingsViewModel.calendarAutoStartMode == .autoStart,
+                  calendarService.permissionStatus == .granted else {
+                countdownShownEventIds.remove(event.dedupeKey)
+                logger.info("Auto-start completion ignored — calendar auto-start is no longer enabled")
+                return
+            }
+            guard let recordingGeneration = onAutoStartConfirmed(event.title) else {
                 // Start was rejected (state_busy — a prior recording is still
                 // wrapping up): `onAutoStartFailed` cleared the binding
                 // synchronously. Drop this occurrence's countdown-shown mark
@@ -511,9 +534,11 @@ final class MeetingAutoStartCoordinator {
                 // Phase-3 late-join territory.
                 countdownShownEventIds.remove(event.dedupeKey)
                 logger.info("Auto-start rejected (state busy) for event id=\(event.id, privacy: .public) — will retry after current recording ends")
-            } else {
-                logger.info("Auto-start confirmed for event id=\(event.id, privacy: .public) outcome=\(String(describing: outcome), privacy: .public)")
+                return
             }
+            autoStartedEvent = event
+            autoStartedRecordingGeneration = recordingGeneration
+            logger.info("Auto-start confirmed for event id=\(event.id, privacy: .public) outcome=\(String(describing: outcome), privacy: .public)")
         case .userDismissed:
             dismissedEventIds.insert(event.dedupeKey)
             Telemetry.send(.calendarAutoStartCancelled(reason: "user_cancel"))
@@ -554,18 +579,27 @@ final class MeetingAutoStartCoordinator {
     func handleAutoStopOutcome(_ outcome: MeetingCountdownToastOutcome, for event: CalendarEvent) {
         switch outcome {
         case .completed, .primedEarly:
+            guard settingsViewModel.calendarAutoStartMode == .autoStart,
+                  settingsViewModel.calendarAutoStopEnabled,
+                  calendarService.permissionStatus == .granted else {
+                autoStopCountdownEventId = nil
+                logger.info("Auto-stop completion ignored — calendar auto-stop is no longer enabled")
+                return
+            }
             // Re-verify ownership at *fire* time, not just at show time. If the
             // recording stopped (or was replaced) during the 30s countdown,
             // the self-heal cleared the binding — don't stop whatever is
             // recording now. Belt-and-suspenders with the toast dismissal in
             // `pollAsync`; keeps this handler correct in isolation.
-            guard autoStartedEvent?.id == event.id else {
+            guard autoStartedEvent?.id == event.id,
+                  let recordingGeneration = autoStartedRecordingGeneration else {
                 autoStopCountdownEventId = nil
                 logger.info("Auto-stop completion ignored — binding no longer owns event id=\(event.id, privacy: .public)")
                 return
             }
-            onAutoStopConfirmed()
+            onAutoStopConfirmed(recordingGeneration)
             autoStartedEvent = nil
+            autoStartedRecordingGeneration = nil
             autoStopCountdownEventId = nil
             logger.info("Auto-stop confirmed for event id=\(event.id, privacy: .public)")
         case .userDismissed:
@@ -586,6 +620,8 @@ final class MeetingAutoStartCoordinator {
 /// links — the methods are `internal` so they don't escape the module.
 extension MeetingAutoStartCoordinator {
     var testHook_autoStartedEventId: String? { autoStartedEvent?.id }
+    var testHook_autoStartedRecordingGeneration: Int? { autoStartedRecordingGeneration }
+    var testHook_pollingInterval: TimeInterval { pollingInterval }
 
     /// Simulate the private `showAutoStartCountdown` having marked an event as
     /// countdown-shown (without driving real toast UI).

--- a/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
@@ -462,7 +462,20 @@ final class MeetingAutoStartCoordinator {
         case .completed, .primedEarly:
             autoStartedEvent = event
             onAutoStartConfirmed(event.title)
-            logger.info("Auto-start confirmed for event id=\(event.id, privacy: .public) outcome=\(String(describing: outcome), privacy: .public)")
+            if autoStartedEvent == nil {
+                // Start was rejected (state_busy — a prior recording is still
+                // wrapping up): `onAutoStartFailed` cleared the binding
+                // synchronously. Drop this occurrence's countdown-shown mark
+                // so it can retry on a later poll once the blocking recording
+                // ends. Otherwise a true back-to-back meeting is permanently
+                // suppressed. Retry only helps while still inside the
+                // auto-start window [start-5s, start+30s]; later than that is
+                // Phase-3 late-join territory.
+                countdownShownEventIds.remove(event.dedupeKey)
+                logger.info("Auto-start rejected (state busy) for event id=\(event.id, privacy: .public) — will retry after current recording ends")
+            } else {
+                logger.info("Auto-start confirmed for event id=\(event.id, privacy: .public) outcome=\(String(describing: outcome), privacy: .public)")
+            }
         case .userDismissed:
             dismissedEventIds.insert(event.dedupeKey)
             Telemetry.send(.calendarAutoStartCancelled(reason: "user_cancel"))
@@ -535,6 +548,16 @@ final class MeetingAutoStartCoordinator {
 /// links — the methods are `internal` so they don't escape the module.
 extension MeetingAutoStartCoordinator {
     var testHook_autoStartedEventId: String? { autoStartedEvent?.id }
+
+    /// Simulate the private `showAutoStartCountdown` having marked an event as
+    /// countdown-shown (without driving real toast UI).
+    func testHook_markCountdownShown(_ event: CalendarEvent) {
+        countdownShownEventIds.insert(event.dedupeKey)
+    }
+
+    func testHook_isCountdownShown(_ event: CalendarEvent) -> Bool {
+        countdownShownEventIds.contains(event.dedupeKey)
+    }
 
     func testHook_simulateAutoStartConfirmed(eventId: String) {
         let event = CalendarEvent(

--- a/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
@@ -52,8 +52,12 @@ final class MeetingAutoStartCoordinator {
     private var pollingInterval: TimeInterval = 0  // 0 = uninitialized
 
     /// Reentrancy guard for `pollAsync` — see the guard there for why a
-    /// coincident poll is dropped rather than allowed to interleave.
+    /// coincident poll is coalesced rather than allowed to interleave.
     private var isPolling = false
+    /// Set when a poll is requested while one is already in flight. The
+    /// in-flight poll runs exactly one more pass on completion so a settings
+    /// change (or reschedule) made mid-fetch isn't lost until the next tick.
+    private var pollAgainRequested = false
 
     private var dismissedEventIds: Set<String> = []
     private var remindedEventIds: Set<String> = []
@@ -68,7 +72,12 @@ final class MeetingAutoStartCoordinator {
     private var autoStartedEvent: CalendarEvent?
     /// `event.id` of an auto-started recording for which we're currently
     /// showing the auto-stop countdown. Prevents re-firing the toast on
-    /// every poll tick during the 30s window.
+    /// every poll tick during the 30s window. Bare `id` (not `dedupeKey`) on
+    /// purpose: this is *live recording identity*, like `autoStartedEvent` —
+    /// not occurrence-level suppression. The dedup sets use `dedupeKey`;
+    /// dismissing an auto-stop suppresses the occurrence via `dismissedEventIds`
+    /// (which is keyed by `dedupeKey`), so the toast can't re-fire after a
+    /// "Keep Recording".
     private var autoStopCountdownEventId: String?
 
     // `nonisolated(unsafe)` so the nonisolated `deinit` can read these to
@@ -224,9 +233,19 @@ final class MeetingAutoStartCoordinator {
         // dedupe of its own). One poll at a time; a coincident request is
         // safely dropped because the in-flight poll already reflects current
         // state (it re-reads settings, permission, and events itself).
-        guard !isPolling else { return }
+        guard !isPolling else {
+            // A poll arrived while one is in flight — coalesce it.
+            pollAgainRequested = true
+            return
+        }
         isPolling = true
-        defer { isPolling = false }
+        defer {
+            isPolling = false
+            if pollAgainRequested {
+                pollAgainRequested = false
+                Task { @MainActor [weak self] in await self?.pollAsync() }
+            }
+        }
 
         // Run binding-cleanup *before* the early returns so toggling mode
         // off (or losing permission) while an auto-started recording is in
@@ -243,8 +262,8 @@ final class MeetingAutoStartCoordinator {
             toastController.close()
         }
 
-        let mode = settingsViewModel.calendarAutoStartMode
-        guard mode != .off else { return }
+        // Fast-path guards before the (awaited) fetch.
+        guard settingsViewModel.calendarAutoStartMode != .off else { return }
         guard calendarService.permissionStatus == .granted else { return }
 
         let events: [CalendarEvent]
@@ -258,6 +277,14 @@ final class MeetingAutoStartCoordinator {
             logger.error("Failed to fetch events: \(error.localizedDescription, privacy: .public)")
             return
         }
+
+        // Re-read mode/permission AFTER the await: the user may have toggled
+        // the feature off (or revoked Calendar access) during the fetch. The
+        // pre-fetch values are stale; honoring the latest stops us from
+        // processing a now-disabled feature one last time.
+        let mode = settingsViewModel.calendarAutoStartMode
+        guard mode != .off else { return }
+        guard calendarService.permissionStatus == .granted else { return }
 
         let config = currentConfig(mode: mode)
         // Re-inject the owned in-flight recording's event if it has dropped
@@ -331,6 +358,17 @@ final class MeetingAutoStartCoordinator {
     }
 
     private func adjustPollingFrequency(events: [CalendarEvent]) {
+        // If we still owe an auto-stop for an owned recording (its window may
+        // have been missed — e.g. resumed from sleep — and the event has since
+        // dropped out of the forward fetch), poll fast until the stop countdown
+        // is actually on screen. Otherwise the cadence could relax to 60s right
+        // when we need to surface the missed auto-stop.
+        if isRecordingActive(), settingsViewModel.calendarAutoStopEnabled,
+           autoStartedEvent != nil, autoStopCountdownEventId == nil {
+            rescheduleTimer(interval: 5)
+            return
+        }
+
         let now = Date()
         // Soonest *future* start — drives auto-start window accuracy.
         let nextStart = events
@@ -558,6 +596,8 @@ extension MeetingAutoStartCoordinator {
     func testHook_isCountdownShown(_ event: CalendarEvent) -> Bool {
         countdownShownEventIds.contains(event.dedupeKey)
     }
+
+    var testHook_pollAgainRequested: Bool { pollAgainRequested }
 
     func testHook_simulateAutoStartConfirmed(eventId: String) {
         let event = CalendarEvent(

--- a/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
@@ -51,6 +51,10 @@ final class MeetingAutoStartCoordinator {
     private var pollingTimer: Timer?
     private var pollingInterval: TimeInterval = 0  // 0 = uninitialized
 
+    /// Reentrancy guard for `pollAsync` — see the guard there for why a
+    /// coincident poll is dropped rather than allowed to interleave.
+    private var isPolling = false
+
     private var dismissedEventIds: Set<String> = []
     private var remindedEventIds: Set<String> = []
     private var countdownShownEventIds: Set<String> = []
@@ -212,6 +216,18 @@ final class MeetingAutoStartCoordinator {
     // MARK: - Polling
 
     private func pollAsync() async {
+        // Reentrancy guard. Timer ticks, EKEventStoreChanged bursts, settings
+        // changes, and wake all spawn `Task { await pollAsync() }`. Without
+        // this, two polls can interleave across the `await` fetch and both
+        // pass the `!remindedEventIds.contains(...)` check before either
+        // inserts — posting a *duplicate* reminder notification (which has no
+        // dedupe of its own). One poll at a time; a coincident request is
+        // safely dropped because the in-flight poll already reflects current
+        // state (it re-reads settings, permission, and events itself).
+        guard !isPolling else { return }
+        isPolling = true
+        defer { isPolling = false }
+
         // Run binding-cleanup *before* the early returns so toggling mode
         // off (or losing permission) while an auto-started recording is in
         // flight doesn't strand a stale `autoStartedEvent` until the

--- a/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
@@ -333,7 +333,7 @@ final class MeetingAutoStartCoordinator {
     /// - `.userDismissed` → add to dismissed set so monitor stops emitting
     /// - `.programmaticClose` → no-op (another toast preempted us)
     private func showAutoStartCountdown(_ event: CalendarEvent) {
-        countdownShownEventIds.insert(event.id)
+        countdownShownEventIds.insert(event.dedupeKey)
         // Actual lead time — how far before T-0 the toast went up. The
         // auto-start window allows up to +30s past T-0, so clamp to 0
         // when we surface it after the event has already started.
@@ -391,7 +391,7 @@ final class MeetingAutoStartCoordinator {
             onAutoStartConfirmed(event.title)
             logger.info("Auto-start confirmed for event id=\(event.id, privacy: .public) outcome=\(String(describing: outcome), privacy: .public)")
         case .userDismissed:
-            dismissedEventIds.insert(event.id)
+            dismissedEventIds.insert(event.dedupeKey)
             Telemetry.send(.calendarAutoStartCancelled(reason: "user_cancel"))
             logger.info("Auto-start cancelled by user for event id=\(event.id, privacy: .public)")
         case .programmaticClose:
@@ -445,7 +445,7 @@ final class MeetingAutoStartCoordinator {
             autoStopCountdownEventId = nil
             logger.info("Auto-stop confirmed for event id=\(event.id, privacy: .public)")
         case .userDismissed:
-            dismissedEventIds.insert(event.id)
+            dismissedEventIds.insert(event.dedupeKey)
             autoStopCountdownEventId = nil
             Telemetry.send(.calendarAutoStopCancelled)
             logger.info("Auto-stop cancelled by user for event id=\(event.id, privacy: .public)")
@@ -506,7 +506,7 @@ private extension MeetingAutoStartCoordinator {
         // Mark before posting so a failed delivery doesn't cause us to
         // re-attempt every poll tick — better to miss one reminder than
         // spam the user.
-        remindedEventIds.insert(event.id)
+        remindedEventIds.insert(event.dedupeKey)
 
         // Defense in depth: we requested authorization at calendar grant
         // time, but the user may have revoked notifications since. Without
@@ -584,7 +584,7 @@ private extension MeetingAutoStartCoordinator {
     /// `try?` — silent failure is acceptable for a 24-hour janitor.
     private func cleanupStaleIds() async {
         guard let events = try? await calendarService.fetchUpcomingEvents(days: 7) else { return }
-        let liveIds = Set(events.map(\.id))
+        let liveIds = Set(events.map(\.dedupeKey))
         dismissedEventIds.formIntersection(liveIds)
         remindedEventIds.formIntersection(liveIds)
         countdownShownEventIds.formIntersection(liveIds)

--- a/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
@@ -190,6 +190,11 @@ final class MeetingAutoStartCoordinator {
         if !activeRecording, autoStartedEventId != nil {
             autoStartedEventId = nil
             autoStopCountdownEventId = nil
+            // Dismiss any stale auto-stop countdown — the recording it was
+            // about to stop is already gone. Without this the toast keeps
+            // ticking and its completion would fire the stop against whatever
+            // recording exists next. `close()` is a no-op when nothing's up.
+            toastController.close()
         }
 
         let mode = settingsViewModel.calendarAutoStartMode
@@ -425,6 +430,16 @@ final class MeetingAutoStartCoordinator {
     func handleAutoStopOutcome(_ outcome: MeetingCountdownToastOutcome, for event: CalendarEvent) {
         switch outcome {
         case .completed, .primedEarly:
+            // Re-verify ownership at *fire* time, not just at show time. If the
+            // recording stopped (or was replaced) during the 30s countdown,
+            // the self-heal cleared the binding — don't stop whatever is
+            // recording now. Belt-and-suspenders with the toast dismissal in
+            // `pollAsync`; keeps this handler correct in isolation.
+            guard autoStartedEventId == event.id else {
+                autoStopCountdownEventId = nil
+                logger.info("Auto-stop completion ignored — binding no longer owns event id=\(event.id, privacy: .public)")
+                return
+            }
             onAutoStopConfirmed()
             autoStartedEventId = nil
             autoStopCountdownEventId = nil

--- a/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
@@ -54,13 +54,14 @@ final class MeetingAutoStartCoordinator {
     private var dismissedEventIds: Set<String> = []
     private var remindedEventIds: Set<String> = []
     private var countdownShownEventIds: Set<String> = []
-    /// `event.id` of the calendar event that triggered the *current*
-    /// recording. Lets `.autoStopDue` only act on auto-started recordings —
-    /// a manually-started recording during a calendar event is not auto-
-    /// stopped (per ADR-017 §10). Cleared when recording ends (detected by
-    /// next poll seeing `isRecordingActive() == false` while we still hold
-    /// an id) or when auto-stop fires.
-    private var autoStartedEventId: String?
+    /// The calendar event that triggered the *current* recording (full event,
+    /// so we keep its `endTime` for the auto-stop window even after EventKit
+    /// stops returning it). Lets `.autoStopDue` only act on auto-started
+    /// recordings — a manually-started recording during a calendar event is
+    /// not auto-stopped (per ADR-017 §10). Cleared when recording ends
+    /// (detected by next poll seeing `isRecordingActive() == false` while we
+    /// still hold one) or when auto-stop fires.
+    private var autoStartedEvent: CalendarEvent?
     /// `event.id` of an auto-started recording for which we're currently
     /// showing the auto-stop countdown. Prevents re-firing the toast on
     /// every poll tick during the 30s window.
@@ -71,6 +72,11 @@ final class MeetingAutoStartCoordinator {
     // mutation always happens on the main actor — no race.
     nonisolated(unsafe) private var settingsObserver: NSObjectProtocol?
     nonisolated(unsafe) private var calendarChangeObserver: NSObjectProtocol?
+    /// `NSWorkspace.didWakeNotification` — polls immediately on wake so a
+    /// meeting whose auto-start/stop window opened while the Mac slept gets
+    /// caught (the repeating `Timer` doesn't fire during sleep). Lives on
+    /// `NSWorkspace.shared.notificationCenter`, not `NotificationCenter.default`.
+    nonisolated(unsafe) private var wakeObserver: NSObjectProtocol?
     private var cleanupTask: Task<Void, Never>?
 
     init(
@@ -100,6 +106,9 @@ final class MeetingAutoStartCoordinator {
         if let observer = calendarChangeObserver {
             NotificationCenter.default.removeObserver(observer)
         }
+        if let observer = wakeObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(observer)
+        }
     }
 
     // MARK: - Lifecycle
@@ -117,6 +126,7 @@ final class MeetingAutoStartCoordinator {
         scheduleCleanupTask()
         registerCalendarChangeObserver()
         registerSettingsObserver()
+        registerWakeObserver()
         rescheduleTimer(interval: 60)
         // Poll immediately so a meeting starting in the next minute doesn't
         // wait for the first tick.
@@ -139,6 +149,10 @@ final class MeetingAutoStartCoordinator {
         if let observer = calendarChangeObserver {
             NotificationCenter.default.removeObserver(observer)
             calendarChangeObserver = nil
+        }
+        if let observer = wakeObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(observer)
+            wakeObserver = nil
         }
         logger.info("Meeting auto-start coordinator stopped")
     }
@@ -170,6 +184,22 @@ final class MeetingAutoStartCoordinator {
         }
     }
 
+    private func registerWakeObserver() {
+        wakeObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didWakeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.logger.debug("System woke — polling immediately")
+                // pollAsync re-tunes the cadence at the end, so we don't need
+                // to wait for the (possibly 60s-out) next timer tick to catch
+                // a window that opened during sleep.
+                await self?.pollAsync()
+            }
+        }
+    }
+
     private func handleSettingsChanged() {
         // Setting changes can disable a feature mid-flight (e.g., toggling
         // mode to .off). Re-evaluate immediately and reset adaptive polling
@@ -184,11 +214,11 @@ final class MeetingAutoStartCoordinator {
     private func pollAsync() async {
         // Run binding-cleanup *before* the early returns so toggling mode
         // off (or losing permission) while an auto-started recording is in
-        // flight doesn't strand a stale `autoStartedEventId` until the
+        // flight doesn't strand a stale `autoStartedEvent` until the
         // user re-enables.
         let activeRecording = isRecordingActive()
-        if !activeRecording, autoStartedEventId != nil {
-            autoStartedEventId = nil
+        if !activeRecording, autoStartedEvent != nil {
+            autoStartedEvent = nil
             autoStopCountdownEventId = nil
             // Dismiss any stale auto-stop countdown — the recording it was
             // about to stop is already gone. Without this the toast keeps
@@ -214,8 +244,18 @@ final class MeetingAutoStartCoordinator {
         }
 
         let config = currentConfig(mode: mode)
+        // Re-inject the owned in-flight recording's event if it has dropped
+        // out of the forward fetch (EventKit's overlap predicate stops
+        // returning it once `now` passes its endTime). Without this, an
+        // auto-stop missed during sleep — or for a meeting that ran long —
+        // could never fire because the event simply vanishes from the poll.
+        let eventsForMonitor = Self.mergingOwnedEvent(
+            into: events,
+            owned: autoStartedEvent,
+            activeRecording: activeRecording
+        )
         let monitorEvents = MeetingMonitor.evaluate(
-            events: events,
+            events: eventsForMonitor,
             now: Date(),
             config: config,
             activeRecording: activeRecording,
@@ -241,6 +281,23 @@ final class MeetingAutoStartCoordinator {
             triggerFilter: settingsViewModel.meetingTriggerFilter,
             lateJoinGraceMinutes: 10
         )
+    }
+
+    /// Re-inject the owned, in-flight recording's event when it has dropped
+    /// out of the forward fetch. Pure + `static` so it's unit-testable without
+    /// driving the live poll. No-op when not recording, when there's no owned
+    /// event, or when the event is already present.
+    static func mergingOwnedEvent(
+        into fetched: [CalendarEvent],
+        owned: CalendarEvent?,
+        activeRecording: Bool
+    ) -> [CalendarEvent] {
+        guard activeRecording,
+              let owned,
+              !fetched.contains(where: { $0.id == owned.id }) else {
+            return fetched
+        }
+        return fetched + [owned]
     }
 
     private func filterByIncludedCalendars(_ events: [CalendarEvent]) -> [CalendarEvent] {
@@ -375,7 +432,7 @@ final class MeetingAutoStartCoordinator {
     /// during the underlying `startRecording()`. Without this, a stale
     /// binding can suppress the *next* meeting's auto-stop window.
     func clearAutoStartBinding() {
-        autoStartedEventId = nil
+        autoStartedEvent = nil
         autoStopCountdownEventId = nil
         logger.info("Auto-start binding cleared (start failed or state busy)")
     }
@@ -387,7 +444,7 @@ final class MeetingAutoStartCoordinator {
     func handleAutoStartOutcome(_ outcome: MeetingCountdownToastOutcome, for event: CalendarEvent) {
         switch outcome {
         case .completed, .primedEarly:
-            autoStartedEventId = event.id
+            autoStartedEvent = event
             onAutoStartConfirmed(event.title)
             logger.info("Auto-start confirmed for event id=\(event.id, privacy: .public) outcome=\(String(describing: outcome), privacy: .public)")
         case .userDismissed:
@@ -408,7 +465,7 @@ final class MeetingAutoStartCoordinator {
     private func showAutoStopCountdown(_ event: CalendarEvent) {
         // Only act on the binding the coordinator owns. Manual recordings
         // are sovereign — auto-stop never touches them.
-        guard autoStartedEventId == event.id else { return }
+        guard autoStartedEvent?.id == event.id else { return }
         // Don't re-stack the toast on every poll while it's already up.
         guard autoStopCountdownEventId != event.id else { return }
         autoStopCountdownEventId = event.id
@@ -435,13 +492,13 @@ final class MeetingAutoStartCoordinator {
             // the self-heal cleared the binding — don't stop whatever is
             // recording now. Belt-and-suspenders with the toast dismissal in
             // `pollAsync`; keeps this handler correct in isolation.
-            guard autoStartedEventId == event.id else {
+            guard autoStartedEvent?.id == event.id else {
                 autoStopCountdownEventId = nil
                 logger.info("Auto-stop completion ignored — binding no longer owns event id=\(event.id, privacy: .public)")
                 return
             }
             onAutoStopConfirmed()
-            autoStartedEventId = nil
+            autoStartedEvent = nil
             autoStopCountdownEventId = nil
             logger.info("Auto-stop confirmed for event id=\(event.id, privacy: .public)")
         case .userDismissed:
@@ -461,7 +518,7 @@ final class MeetingAutoStartCoordinator {
 /// `#if DEBUG`-gated so `swift test -c release` (CI perf lane) still
 /// links — the methods are `internal` so they don't escape the module.
 extension MeetingAutoStartCoordinator {
-    var testHook_autoStartedEventId: String? { autoStartedEventId }
+    var testHook_autoStartedEventId: String? { autoStartedEvent?.id }
 
     func testHook_simulateAutoStartConfirmed(eventId: String) {
         let event = CalendarEvent(
@@ -486,7 +543,7 @@ extension MeetingAutoStartCoordinator {
     func testHook_simulateAutoStopFired(eventId: String) {
         // Mimic the production guard: only proceed if the event matches
         // the coordinator's auto-started binding.
-        guard autoStartedEventId == eventId else { return }
+        guard autoStartedEvent?.id == eventId else { return }
         let event = CalendarEvent(
             id: eventId,
             title: "Test",

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -215,6 +215,24 @@ final class MeetingRecordingFlowCoordinator {
         sendEvent(.startRequested)
     }
 
+    /// Calendar-driven stop. **Idempotent: stops an in-flight recording but
+    /// NEVER starts one.** The auto-stop countdown completion routes here
+    /// instead of `toggleRecording()` — a blind toggle would *start* a brand
+    /// new recording if the user had already stopped the auto-started one
+    /// during the 30s countdown, which for a privacy-first app is the worst
+    /// kind of surprise (silent mic + system-audio capture nobody asked for).
+    /// Only `.stopRequested` is ever sent, and only from states that have
+    /// something to stop — `(.idle, .stopRequested)` is a state-machine no-op
+    /// anyway, but we don't even send it.
+    func stopFromCalendar() {
+        switch stateMachine.state {
+        case .recording, .starting, .stopping:
+            sendEvent(.stopRequested)
+        case .idle, .checkingPermissions, .transcribing, .finishing:
+            break  // nothing to stop — and never start
+        }
+    }
+
     /// Discard the pending start context (trigger + title) when the start
     /// sequence exits without ever reaching the `.startRecording` effect —
     /// today, only the permissions-denied path. The `.startRecording`

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -203,16 +203,18 @@ final class MeetingRecordingFlowCoordinator {
     /// calendar coordinator can drop its binding, and emits
     /// `calendar_auto_start_failed{reason=state_busy}` so we can see how
     /// often back-to-back meetings actually collide in the wild.
-    func startFromCalendar(title: String? = nil) {
+    @discardableResult
+    func startFromCalendar(title: String? = nil) -> Int? {
         guard stateMachine.state == .idle else {
             Telemetry.send(.calendarAutoStartFailed(reason: "state_busy"))
             onAutoStartFailed?()
-            return
+            return nil
         }
         pendingTrigger = .calendarAutoStart
         pendingTitle = title
         currentMeetingOperationContext = ObservabilityOperationContext()
         sendEvent(.startRequested)
+        return stateMachine.generation
     }
 
     /// Calendar-driven stop. **Idempotent: stops an in-flight recording but
@@ -224,11 +226,14 @@ final class MeetingRecordingFlowCoordinator {
     /// Only `.stopRequested` is ever sent, and only from states that have
     /// something to stop — `(.idle, .stopRequested)` is a state-machine no-op
     /// anyway, but we don't even send it.
-    func stopFromCalendar() {
+    func stopFromCalendar(recordingGeneration: Int) {
+        guard stateMachine.generation == recordingGeneration else { return }
         switch stateMachine.state {
+        case .checkingPermissions:
+            sendEvent(.cancelRequested)
         case .recording, .starting, .stopping:
             sendEvent(.stopRequested)
-        case .idle, .checkingPermissions, .transcribing, .finishing:
+        case .idle, .transcribing, .finishing:
             break  // nothing to stop — and never start
         }
     }

--- a/Sources/MacParakeet/Views/Settings/CalendarSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/CalendarSettingsView.swift
@@ -3,8 +3,8 @@ import MacParakeetViewModels
 import SwiftUI
 
 /// Calendar auto-start section. Slotted into Settings between Meeting
-/// Recording and Transcription. Phase D — only `.off` and `.notify` modes
-/// are exposed; `.autoStart` ships in Phase E (ADR-017).
+/// Recording and Transcription. Exposes all three modes — `.off`, `.notify`,
+/// and `.autoStart` (with the auto-stop sub-toggle) per ADR-017 Phases 1+2.
 struct CalendarSettingsView: View {
     @Bindable var viewModel: SettingsViewModel
     @State private var availableCalendars: [CalendarInfo] = []
@@ -20,6 +20,10 @@ struct CalendarSettingsView: View {
                 modeRow
 
                 if viewModel.calendarAutoStartMode != .off {
+                    if !viewModel.calendarNotificationsAuthorized {
+                        Divider()
+                        notificationWarningRow
+                    }
                     Divider()
                     reminderLeadRow
                     Divider()
@@ -37,8 +41,40 @@ struct CalendarSettingsView: View {
                 }
             }
         }
-        .onAppear { reloadCalendars() }
+        .onAppear {
+            reloadCalendars()
+            refreshNotificationAuth()
+        }
         .onChange(of: viewModel.calendarPermissionGranted) { _, _ in reloadCalendars() }
+        .onChange(of: viewModel.calendarAutoStartMode) { _, _ in refreshNotificationAuth() }
+    }
+
+    // MARK: - Notification permission warning
+
+    /// macOS notifications are a separate TCC scope from Calendar. When they're
+    /// off, `.notify` reminders (and the `.autoStart` pre-meeting reminder) are
+    /// silently dropped — surface that instead of letting the feature look on
+    /// but do nothing.
+    @ViewBuilder
+    private var notificationWarningRow: some View {
+        HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Notifications are off")
+                    .font(DesignSystem.Typography.body)
+                Text("Calendar reminders won't appear until you allow MacParakeet notifications in System Settings.")
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: DesignSystem.Spacing.md)
+            Button("Open System Settings") {
+                viewModel.openNotificationSystemSettings()
+            }
+            .controlSize(.small)
+        }
+    }
+
+    private func refreshNotificationAuth() {
+        Task { await viewModel.refreshCalendarNotificationAuthorization() }
     }
 
     // MARK: - Permission

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -116,6 +116,7 @@ struct SettingsView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             viewModel.refreshPermissions()
+            Task { await viewModel.refreshCalendarNotificationAuthorization() }
         }
         .onAppear {
             if requestedTab != nil {

--- a/Sources/MacParakeetCore/Calendar/CalendarEvent.swift
+++ b/Sources/MacParakeetCore/Calendar/CalendarEvent.swift
@@ -128,6 +128,16 @@ public extension CalendarEvent {
         participants.count
     }
 
+    /// Stable key for the coordinator's per-occurrence suppression sets
+    /// (reminded / countdown-shown / dismissed). Combines `id` with the start
+    /// time so rescheduling an event to a different time is treated as a fresh
+    /// occurrence that can re-fire — keying on `id` alone permanently
+    /// suppressed a same-day reschedule. Whole-second granularity is plenty;
+    /// meetings don't move by sub-second amounts.
+    var dedupeKey: String {
+        "\(id)|\(Int(startTime.timeIntervalSinceReferenceDate))"
+    }
+
     var isMeeting: Bool {
         !participants.isEmpty || meetUrl != nil
     }

--- a/Sources/MacParakeetCore/Calendar/CalendarService.swift
+++ b/Sources/MacParakeetCore/Calendar/CalendarService.swift
@@ -178,6 +178,11 @@ public actor CalendarService {
             return nil
         }
 
+        // Drop zero-duration / inverted events. The auto-stop window math
+        // assumes endTime > startTime; a zero-duration event would satisfy
+        // its auto-stop window the instant it auto-starts.
+        guard endDate > startDate else { return nil }
+
         // Capture the user's status *before* filtering them out of the
         // participant list — otherwise we lose the signal needed to honor
         // declined events.

--- a/Sources/MacParakeetCore/Calendar/MeetingLinkParser.swift
+++ b/Sources/MacParakeetCore/Calendar/MeetingLinkParser.swift
@@ -19,9 +19,12 @@ public struct MeetingLinkParser: Sendable {
     private static let wherebyPattern = #"https?://(?:[\w-]+\.)?whereby\.com/[\w/.-]+"#
     // Word-boundaried tokens so the generic fallback no longer matches
     // `call` inside `recall`/`teamcall`/`?utm_campaign=fallcall` or `video`
-    // inside `videogame.com`. It still catches delimited tokens like
-    // `/meet/`, `/video-call`, `/conference/`.
-    private static let genericVideoPattern = #"https?://[^\s]*\b(?:meet|video|call|conference)\b[^\s]*"#
+    // inside `videogame.com`. The keyword must appear in the host/path
+    // (the `[^\s?#]*` prefix stops at `?`/`#`) so a query param like
+    // `?type=conference` on a non-meeting link (Jira, CRM) doesn't count.
+    // Still catches delimited path tokens like `/meet/`, `/video-call`,
+    // `/conference?id=1`.
+    private static let genericVideoPattern = #"https?://[^\s?#]*\b(?:meet|video|call|conference)\b[^\s]*"#
 
     private static let patterns: [(name: String, pattern: String)] = [
         ("zoom", zoomPattern),

--- a/Sources/MacParakeetCore/Calendar/MeetingLinkParser.swift
+++ b/Sources/MacParakeetCore/Calendar/MeetingLinkParser.swift
@@ -8,12 +8,20 @@ import Foundation
 public struct MeetingLinkParser: Sendable {
     public init() {}
 
-    private static let zoomPattern = #"https?://(?:[\w-]+\.)?zoom\.us/j/\d+(?:\?[^\s]*)?"#
+    // Zoom: join (`/j/`), webinar (`/w/`), and personal-room (`/my/`) links,
+    // on both zoom.us and the government tenant zoomgov.com. The old pattern
+    // only matched `/j/<digits>`, silently missing `/w/`, `/my/`, and gov.
+    private static let zoomPattern = #"https?://(?:[\w-]+\.)?(?:zoom\.us|zoomgov\.com)/(?:j|w|my)/[\w.@-]+(?:\?[^\s]*)?"#
     private static let meetPattern = #"https?://meet\.google\.com/[\w-]+"#
     private static let teamsPattern = #"https?://teams\.microsoft\.com/[\w/.%-]+"#
     private static let webexPattern = #"https?://[\w-]+\.webex\.com/[\w/.%-]+"#
     private static let aroundPattern = #"https?://around\.co/[\w/-]+"#
-    private static let genericVideoPattern = #"https?://[^\s]+(?:meet|video|call|conference)[^\s]*"#
+    private static let wherebyPattern = #"https?://(?:[\w-]+\.)?whereby\.com/[\w/.-]+"#
+    // Word-boundaried tokens so the generic fallback no longer matches
+    // `call` inside `recall`/`teamcall`/`?utm_campaign=fallcall` or `video`
+    // inside `videogame.com`. It still catches delimited tokens like
+    // `/meet/`, `/video-call`, `/conference/`.
+    private static let genericVideoPattern = #"https?://[^\s]*\b(?:meet|video|call|conference)\b[^\s]*"#
 
     private static let patterns: [(name: String, pattern: String)] = [
         ("zoom", zoomPattern),
@@ -21,6 +29,7 @@ public struct MeetingLinkParser: Sendable {
         ("teams", teamsPattern),
         ("webex", webexPattern),
         ("around", aroundPattern),
+        ("whereby", wherebyPattern),
         ("generic", genericVideoPattern),
     ]
 
@@ -66,11 +75,12 @@ public struct MeetingLinkParser: Sendable {
     /// Friendly service name for UI ("Zoom", "Google Meet", …).
     public func identifyService(from url: String?) -> String? {
         guard let url, !url.isEmpty else { return nil }
-        if url.contains("zoom.us") { return "Zoom" }
+        if url.contains("zoom.us") || url.contains("zoomgov.com") { return "Zoom" }
         if url.contains("meet.google.com") { return "Google Meet" }
         if url.contains("teams.microsoft.com") { return "Microsoft Teams" }
         if url.contains("webex.com") { return "Webex" }
         if url.contains("around.co") { return "Around" }
+        if url.contains("whereby.com") { return "Whereby" }
         return nil
     }
 

--- a/Sources/MacParakeetCore/Calendar/MeetingMonitor.swift
+++ b/Sources/MacParakeetCore/Calendar/MeetingMonitor.swift
@@ -92,9 +92,14 @@ public enum MeetingMonitor {
             }
 
             // Auto-start and late-join only fire when mode allows it AND we're
-            // not already recording. Phase D keeps these as harmless no-ops
-            // because the coordinator only handles `.reminderDue`.
-            if config.mode == .autoStart && !activeRecording && !countdownShownEventIds.contains(event.id) {
+            // not already recording. They are *also* gated on RSVP: we don't
+            // auto-record an invite the user declined or hasn't accepted
+            // (`.pending`). Reminders stay lenient (declined-only) since a
+            // notification is low-cost, but auto-recording a meeting you might
+            // not attend is a surprise.
+            if config.mode == .autoStart && !activeRecording
+                && !countdownShownEventIds.contains(event.id)
+                && shouldAutoStart(forStatus: event.userStatus) {
                 let autoStartBegin = event.startTime.addingTimeInterval(-5)
                 let autoStartEnd = event.startTime.addingTimeInterval(30)
                 if now >= autoStartBegin && now <= autoStartEnd {
@@ -118,6 +123,21 @@ public enum MeetingMonitor {
         }
 
         return result
+    }
+
+    /// Whether an event is eligible for *auto-start* (and late-join) based on
+    /// the user's RSVP. `.declined` is already filtered out of candidates;
+    /// this additionally blocks `.pending` (invited, not yet accepted). Own
+    /// meetings and personal blocks surface as `.unknown`/`nil` and remain
+    /// eligible. Auto-*stop* is intentionally NOT gated by this — once we're
+    /// recording an event we still want to stop at its end regardless of RSVP.
+    private static func shouldAutoStart(forStatus status: EventParticipant.ParticipantStatus?) -> Bool {
+        switch status {
+        case .declined, .pending:
+            return false
+        case .accepted, .tentative, .unknown, .none:
+            return true
+        }
     }
 
     private static func passesFilter(_ event: CalendarEvent, filter: MeetingTriggerFilter) -> Bool {

--- a/Sources/MacParakeetCore/Calendar/MeetingMonitor.swift
+++ b/Sources/MacParakeetCore/Calendar/MeetingMonitor.swift
@@ -62,6 +62,9 @@ public enum MeetingMonitor {
 
     /// Evaluate calendar events and return any pending monitor events.
     /// Pure function — all state passed in, no side effects.
+    ///
+    /// The three suppression sets hold `CalendarEvent.dedupeKey` values (id +
+    /// start time), not bare ids — so a rescheduled occurrence re-fires.
     public static func evaluate(
         events: [CalendarEvent],
         now: Date,
@@ -76,14 +79,14 @@ public enum MeetingMonitor {
         let candidates = events.filter { event in
             guard !event.isAllDay else { return false }
             guard event.userStatus != .declined else { return false }
-            guard !dismissedEventIds.contains(event.id) else { return false }
+            guard !dismissedEventIds.contains(event.dedupeKey) else { return false }
             return passesFilter(event, filter: config.triggerFilter)
         }
 
         var result: [MonitorEvent] = []
 
         for event in candidates {
-            if config.reminderMinutes > 0 && !remindedEventIds.contains(event.id) {
+            if config.reminderMinutes > 0 && !remindedEventIds.contains(event.dedupeKey) {
                 let reminderTime = event.startTime.addingTimeInterval(-Double(config.reminderMinutes * 60))
                 let reminderWindowEnd = reminderTime.addingTimeInterval(90)
                 if now >= reminderTime && now <= reminderWindowEnd {
@@ -98,7 +101,7 @@ public enum MeetingMonitor {
             // notification is low-cost, but auto-recording a meeting you might
             // not attend is a surprise.
             if config.mode == .autoStart && !activeRecording
-                && !countdownShownEventIds.contains(event.id)
+                && !countdownShownEventIds.contains(event.dedupeKey)
                 && shouldAutoStart(forStatus: event.userStatus) {
                 let autoStartBegin = event.startTime.addingTimeInterval(-5)
                 let autoStartEnd = event.startTime.addingTimeInterval(30)

--- a/Sources/MacParakeetCore/Calendar/MeetingMonitor.swift
+++ b/Sources/MacParakeetCore/Calendar/MeetingMonitor.swift
@@ -138,7 +138,12 @@ public enum MeetingMonitor {
     /// leaving the recording running. Beyond this the recording is left for a
     /// manual stop — we don't force-stop a recording for a meeting that ended
     /// long ago.
-    private static let autoStopForgiveness: TimeInterval = 5 * 60
+    ///
+    /// Public so the coordinator's adaptive-polling logic can mirror this
+    /// exact window: it polls fast through the forgiveness tail (when the
+    /// event has dropped out of the forward fetch and the normal cadence
+    /// math goes blind) and relaxes once the tail closes.
+    public static let autoStopForgiveness: TimeInterval = 5 * 60
 
     /// Whether an event is eligible for *auto-start* (and late-join) based on
     /// the user's RSVP. `.declined` is already filtered out of candidates;

--- a/Sources/MacParakeetCore/Calendar/MeetingMonitor.swift
+++ b/Sources/MacParakeetCore/Calendar/MeetingMonitor.swift
@@ -22,8 +22,12 @@ public enum MeetingMonitor {
         /// keeps the case but does not wire UI — see ADR-017.
         case lateJoinAvailable(CalendarEvent)
 
-        /// Fires in the window `[endTime - autoStopLeadSeconds, endTime]`.
-        /// Only emitted when `activeRecording == true`.
+        /// Fires in the window `[endTime - autoStopLeadSeconds,
+        /// endTime + autoStopForgiveness]`. Only emitted when
+        /// `activeRecording == true`. The forgiveness tail past `endTime`
+        /// catches a window missed during sleep or for a meeting that ran
+        /// long — without it, the event drops out of the forward fetch the
+        /// instant `now` passes `endTime` and the recording never auto-stops.
         case autoStopDue(CalendarEvent)
     }
 
@@ -118,7 +122,7 @@ public enum MeetingMonitor {
 
             if config.mode == .autoStart && config.autoStopEnabled && activeRecording {
                 let autoStopBegin = event.endTime.addingTimeInterval(-Double(config.autoStopLeadSeconds))
-                let autoStopEnd = event.endTime
+                let autoStopEnd = event.endTime.addingTimeInterval(autoStopForgiveness)
                 if now >= autoStopBegin && now <= autoStopEnd {
                     result.append(.autoStopDue(event))
                 }
@@ -127,6 +131,14 @@ public enum MeetingMonitor {
 
         return result
     }
+
+    /// How long past an event's `endTime` the auto-stop window stays open.
+    /// Lets a poll that lands late (resumed from sleep, or a meeting that ran
+    /// long) still surface the auto-stop countdown rather than silently
+    /// leaving the recording running. Beyond this the recording is left for a
+    /// manual stop — we don't force-stop a recording for a meeting that ended
+    /// long ago.
+    private static let autoStopForgiveness: TimeInterval = 5 * 60
 
     /// Whether an event is eligible for *auto-start* (and late-join) based on
     /// the user's RSVP. `.declined` is already filtered out of candidates;

--- a/Sources/MacParakeetViewModels/OnboardingViewModel.swift
+++ b/Sources/MacParakeetViewModels/OnboardingViewModel.swift
@@ -340,15 +340,15 @@ public final class OnboardingViewModel {
         Telemetry.send(.permissionPrompted(permission: .calendar))
         Task {
             let granted = await CalendarService.shared.requestPermission()
-            if granted {
-                await CalendarNotificationAuthorization.requestIfNeeded()
-            }
+            let notificationsGranted = granted
+                ? await CalendarNotificationAuthorization.requestIfNeeded()
+                : false
             await MainActor.run {
                 self.isBusy = false
                 self.calendarPermissionGranted = granted
                 if granted {
                     Telemetry.send(.permissionGranted(permission: .calendar))
-                    self.applyCalendarMode(.notify)
+                    self.applyCalendarMode(notificationsGranted ? .notify : .off)
                 } else {
                     Telemetry.send(.permissionDenied(permission: .calendar))
                 }

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -380,6 +380,13 @@ public final class SettingsViewModel {
     public var calendarPermissionGranted: Bool {
         calendarPermissionStatus == .granted
     }
+    /// Whether macOS notification authorization is granted. Calendar reminders
+    /// (`.notify`, and the pre-meeting reminder in `.autoStart`) are delivered
+    /// via `UNUserNotificationCenter`, a *separate* TCC scope from Calendar —
+    /// so a user can grant Calendar yet have reminders silently dropped.
+    /// Settings surfaces this; refreshed by the view (defaults to `true` so the
+    /// warning never flashes before the first async check resolves).
+    public var calendarNotificationsAuthorized: Bool = true
 
     // Permission status
     public var microphoneGranted = false
@@ -888,6 +895,25 @@ public final class SettingsViewModel {
 
     public func openCalendarSystemSettings() {
         if NSWorkspace.shared.open(CalendarService.settingsURL) { return }
+    }
+
+    /// Refresh the cached notification-authorization state. Cheap async read
+    /// of `UNUserNotificationCenter` settings; the view calls this on appear
+    /// and when the calendar mode changes.
+    public func refreshCalendarNotificationAuthorization() async {
+        calendarNotificationsAuthorized = await CalendarNotificationAuthorization.isAuthorized()
+    }
+
+    /// Deep-link to the Notifications pane in System Settings. The pane id
+    /// changed across macOS versions, so try the modern one first.
+    public func openNotificationSystemSettings() {
+        let candidates = [
+            "x-apple.systempreferences:com.apple.Notifications-Settings.extension",
+            "x-apple.systempreferences:com.apple.preference.notifications",
+        ]
+        for string in candidates {
+            if let url = URL(string: string), NSWorkspace.shared.open(url) { return }
+        }
     }
 
     public func startPermissionPolling() {

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -889,6 +889,14 @@ public final class SettingsViewModel {
         Telemetry.send(granted ? .permissionGranted(permission: .calendar) : .permissionDenied(permission: .calendar))
         if granted {
             await CalendarNotificationAuthorization.requestIfNeeded()
+            // Match the onboarding grant flow (OnboardingViewModel applies
+            // .notify on grant): a user who explicitly grants Calendar access
+            // from Settings intends to use the feature, so default them into
+            // the safe .notify mode. Only when still .off — never clobber an
+            // existing .autoStart choice.
+            if calendarAutoStartMode == .off {
+                calendarAutoStartMode = .notify
+            }
         }
         return granted
     }

--- a/Tests/MacParakeetTests/Calendar/MeetingAutoStartCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/Calendar/MeetingAutoStartCoordinatorTests.swift
@@ -272,4 +272,73 @@ final class MeetingAutoStartCoordinatorTests: XCTestCase {
 
         coordinator.stop()
     }
+
+    // MARK: - Auto-stop idempotency (#1 — privacy)
+
+    func testAutoStopCompletionAfterExternalStopDoesNotConfirm() async {
+        // The privacy regression: a calendar auto-stop countdown was up,
+        // the user manually stopped the recording during the 30s window, and
+        // when the countdown completed the old code blindly toggled — which,
+        // with no recording in flight, *started* a brand-new one. The fix:
+        // the completion re-verifies ownership (cleared by the self-heal) and
+        // routes through an idempotent stop. Here we assert the completion is
+        // a no-op once the binding is gone.
+        calendarService.stubPermissionStatus = .granted
+        seedSettings(mode: .autoStart)
+
+        let coordinator = makeCoordinator()
+        coordinator.start()
+        await waitForPoll()
+
+        recordingActiveStub = true
+        coordinator.testHook_simulateAutoStartConfirmed(eventId: "evt-1")
+        XCTAssertEqual(coordinator.testHook_autoStartedEventId, "evt-1")
+
+        // User stops the recording themselves; the next poll self-heals the
+        // binding (and dismisses any live auto-stop toast).
+        recordingActiveStub = false
+        calendarService.stubEvents = []
+        coordinator.testHook_forcePoll()
+        await waitForPoll()
+        XCTAssertNil(coordinator.testHook_autoStartedEventId)
+
+        // The auto-stop countdown completes *after* the external stop.
+        let event = CalendarEvent(
+            id: "evt-1",
+            title: "Wrap",
+            startTime: Date().addingTimeInterval(-1800),
+            endTime: Date().addingTimeInterval(5)
+        )
+        coordinator.handleAutoStopOutcome(.completed, for: event)
+        XCTAssertEqual(autoStopConfirmedCount, 0,
+                       "Auto-stop completion after an external stop must NOT confirm — otherwise the idempotent stop could hit a replacement recording, and the old toggle would have *started* one")
+
+        coordinator.stop()
+    }
+
+    func testAutoStopCompletionWhileOwnedAndActiveConfirms() async {
+        // Guard against the ownership recheck being too aggressive: the happy
+        // path (binding still owns the active recording) must still stop.
+        calendarService.stubPermissionStatus = .granted
+        seedSettings(mode: .autoStart)
+
+        let coordinator = makeCoordinator()
+        coordinator.start()
+        await waitForPoll()
+
+        recordingActiveStub = true
+        coordinator.testHook_simulateAutoStartConfirmed(eventId: "evt-1")
+
+        let event = CalendarEvent(
+            id: "evt-1",
+            title: "Wrap",
+            startTime: Date().addingTimeInterval(-1800),
+            endTime: Date().addingTimeInterval(5)
+        )
+        coordinator.handleAutoStopOutcome(.completed, for: event)
+        XCTAssertEqual(autoStopConfirmedCount, 1,
+                       "An owned, still-active recording must auto-stop on completion")
+
+        coordinator.stop()
+    }
 }

--- a/Tests/MacParakeetTests/Calendar/MeetingAutoStartCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/Calendar/MeetingAutoStartCoordinatorTests.swift
@@ -17,6 +17,11 @@ final class MeetingAutoStartCoordinatorTests: XCTestCase {
     private var autoStartConfirmedCount = 0
     private var autoStartConfirmedTitles: [String] = []
     private var autoStopConfirmedCount = 0
+    /// When true, the `onAutoStartConfirmed` stub mimics the real flow
+    /// coordinator's `state_busy` rejection by clearing the binding —
+    /// exercising the back-to-back retry path (#8).
+    private var simulateAutoStartBusy = false
+    private weak var coordinatorRef: MeetingAutoStartCoordinator?
 
     override func setUp() {
         super.setUp()
@@ -33,6 +38,8 @@ final class MeetingAutoStartCoordinatorTests: XCTestCase {
         autoStartConfirmedCount = 0
         autoStartConfirmedTitles = []
         autoStopConfirmedCount = 0
+        simulateAutoStartBusy = false
+        coordinatorRef = nil
     }
 
     /// Seed `UserDefaults` *before* the SettingsViewModel is constructed
@@ -67,8 +74,14 @@ final class MeetingAutoStartCoordinatorTests: XCTestCase {
             settingsViewModel: settingsViewModel,
             isRecordingActive: { [weak self] in self?.recordingActiveStub ?? false },
             onAutoStartConfirmed: { [weak self] title in
-                self?.autoStartConfirmedCount += 1
-                self?.autoStartConfirmedTitles.append(title)
+                guard let self else { return }
+                self.autoStartConfirmedCount += 1
+                self.autoStartConfirmedTitles.append(title)
+                if self.simulateAutoStartBusy {
+                    // Mimic MeetingRecordingFlowCoordinator.startFromCalendar's
+                    // synchronous state_busy path: clear the optimistic binding.
+                    self.coordinatorRef?.clearAutoStartBinding()
+                }
             },
             onAutoStopConfirmed: { [weak self] in self?.autoStopConfirmedCount += 1 },
             toastController: toastController
@@ -269,6 +282,60 @@ final class MeetingAutoStartCoordinatorTests: XCTestCase {
         await waitForPoll()
         XCTAssertNil(coordinator.testHook_autoStartedEventId,
                      "Binding must clear when recording stops outside coordinator's control")
+
+        coordinator.stop()
+    }
+
+    // MARK: - Back-to-back retry (#8)
+
+    func testStateBusyAutoStartClearsSuppressionForRetry() async {
+        calendarService.stubPermissionStatus = .granted
+        seedSettings(mode: .autoStart)
+
+        let coordinator = makeCoordinator()
+        coordinatorRef = coordinator
+        simulateAutoStartBusy = true
+        coordinator.start()
+        await waitForPoll()
+
+        let event = CalendarEvent(
+            id: "B",
+            title: "Back-to-back",
+            startTime: Date(),
+            endTime: Date().addingTimeInterval(1800)
+        )
+        coordinator.testHook_markCountdownShown(event)
+        XCTAssertTrue(coordinator.testHook_isCountdownShown(event))
+
+        // Completion attempts the start; the stub rejects it (state_busy) and
+        // clears the binding synchronously → suppression must be dropped.
+        coordinator.handleAutoStartOutcome(.completed, for: event)
+        XCTAssertFalse(coordinator.testHook_isCountdownShown(event),
+                       "A state_busy auto-start must clear suppression so a true back-to-back meeting can retry once the first recording ends")
+
+        coordinator.stop()
+    }
+
+    func testSuccessfulAutoStartRetainsSuppression() async {
+        calendarService.stubPermissionStatus = .granted
+        seedSettings(mode: .autoStart)
+
+        let coordinator = makeCoordinator()
+        coordinatorRef = coordinator
+        simulateAutoStartBusy = false  // success path
+        coordinator.start()
+        await waitForPoll()
+
+        let event = CalendarEvent(
+            id: "B",
+            title: "Solo",
+            startTime: Date(),
+            endTime: Date().addingTimeInterval(1800)
+        )
+        coordinator.testHook_markCountdownShown(event)
+        coordinator.handleAutoStartOutcome(.completed, for: event)
+        XCTAssertTrue(coordinator.testHook_isCountdownShown(event),
+                      "A successful auto-start must keep its suppression — no duplicate countdown")
 
         coordinator.stop()
     }

--- a/Tests/MacParakeetTests/Calendar/MeetingAutoStartCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/Calendar/MeetingAutoStartCoordinatorTests.swift
@@ -17,6 +17,7 @@ final class MeetingAutoStartCoordinatorTests: XCTestCase {
     private var autoStartConfirmedCount = 0
     private var autoStartConfirmedTitles: [String] = []
     private var autoStopConfirmedCount = 0
+    private var autoStopConfirmedGenerations: [Int] = []
     /// When true, the `onAutoStartConfirmed` stub mimics the real flow
     /// coordinator's `state_busy` rejection by clearing the binding —
     /// exercising the back-to-back retry path (#8).
@@ -38,6 +39,7 @@ final class MeetingAutoStartCoordinatorTests: XCTestCase {
         autoStartConfirmedCount = 0
         autoStartConfirmedTitles = []
         autoStopConfirmedCount = 0
+        autoStopConfirmedGenerations = []
         simulateAutoStartBusy = false
         coordinatorRef = nil
     }
@@ -74,16 +76,21 @@ final class MeetingAutoStartCoordinatorTests: XCTestCase {
             settingsViewModel: settingsViewModel,
             isRecordingActive: { [weak self] in self?.recordingActiveStub ?? false },
             onAutoStartConfirmed: { [weak self] title in
-                guard let self else { return }
+                guard let self else { return nil }
                 self.autoStartConfirmedCount += 1
                 self.autoStartConfirmedTitles.append(title)
                 if self.simulateAutoStartBusy {
                     // Mimic MeetingRecordingFlowCoordinator.startFromCalendar's
                     // synchronous state_busy path: clear the optimistic binding.
                     self.coordinatorRef?.clearAutoStartBinding()
+                    return nil
                 }
+                return 1
             },
-            onAutoStopConfirmed: { [weak self] in self?.autoStopConfirmedCount += 1 },
+            onAutoStopConfirmed: { [weak self] generation in
+                self?.autoStopConfirmedCount += 1
+                self?.autoStopConfirmedGenerations.append(generation)
+            },
             toastController: toastController
         )
     }
@@ -220,6 +227,30 @@ final class MeetingAutoStartCoordinatorTests: XCTestCase {
         // recording will be titled, not the date-based default.
         XCTAssertEqual(autoStartConfirmedTitles, [uniqueTitle],
                        "Auto-start must forward the event title so the saved recording is named after the meeting")
+
+        coordinator.stop()
+    }
+
+    func testAutoStartCompletionIgnoredAfterModeTurnsOff() {
+        calendarService.stubPermissionStatus = .granted
+        seedSettings(mode: .autoStart)
+
+        let coordinator = makeCoordinator()
+        let event = CalendarEvent(
+            id: "evt-1",
+            title: "Standup",
+            startTime: Date(),
+            endTime: Date().addingTimeInterval(1800)
+        )
+        coordinator.testHook_markCountdownShown(event)
+
+        settingsViewModel.calendarAutoStartMode = .off
+        coordinator.handleAutoStartOutcome(.completed, for: event)
+
+        XCTAssertEqual(autoStartConfirmedCount, 0,
+                       "A countdown that completes after calendar auto-start is disabled must not start recording")
+        XCTAssertFalse(coordinator.testHook_isCountdownShown(event),
+                       "Disabled-mode completion should not permanently suppress a later re-enable")
 
         coordinator.stop()
     }
@@ -475,6 +506,62 @@ final class MeetingAutoStartCoordinatorTests: XCTestCase {
         coordinator.handleAutoStopOutcome(.completed, for: event)
         XCTAssertEqual(autoStopConfirmedCount, 1,
                        "An owned, still-active recording must auto-stop on completion")
+        XCTAssertEqual(autoStopConfirmedGenerations, [1],
+                       "Auto-stop must target the recording generation returned by calendar auto-start")
+
+        coordinator.stop()
+    }
+
+    func testAutoStopCompletionIgnoredAfterAutoStopDisabled() async {
+        calendarService.stubPermissionStatus = .granted
+        seedSettings(mode: .autoStart)
+
+        let coordinator = makeCoordinator()
+        coordinator.start()
+        await waitForPoll()
+
+        recordingActiveStub = true
+        coordinator.testHook_simulateAutoStartConfirmed(eventId: "evt-1")
+        settingsViewModel.calendarAutoStopEnabled = false
+
+        let event = CalendarEvent(
+            id: "evt-1",
+            title: "Wrap",
+            startTime: Date().addingTimeInterval(-1800),
+            endTime: Date().addingTimeInterval(5)
+        )
+        coordinator.handleAutoStopOutcome(.completed, for: event)
+
+        XCTAssertEqual(autoStopConfirmedCount, 0,
+                       "A countdown that completes after calendar auto-stop is disabled must not stop recording")
+
+        coordinator.stop()
+    }
+
+    func testKeepRecordingDoesNotLeaveFastPollingStuck() async {
+        calendarService.stubPermissionStatus = .granted
+        seedSettings(mode: .autoStart)
+
+        let coordinator = makeCoordinator()
+        coordinator.start()
+        await waitForPoll()
+
+        recordingActiveStub = true
+        let event = CalendarEvent(
+            id: "evt-1",
+            title: "Wrap",
+            startTime: Date().addingTimeInterval(-1800),
+            endTime: Date().addingTimeInterval(5)
+        )
+        coordinator.handleAutoStartOutcome(.completed, for: event)
+        coordinator.handleAutoStopOutcome(.userDismissed, for: event)
+
+        calendarService.stubEvents = []
+        coordinator.testHook_forcePoll()
+        await waitForPoll()
+
+        XCTAssertEqual(coordinator.testHook_pollingInterval, 60,
+                       "After Keep Recording, dismissed auto-stop should not force 5s polling forever")
 
         coordinator.stop()
     }

--- a/Tests/MacParakeetTests/Calendar/MeetingAutoStartCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/Calendar/MeetingAutoStartCoordinatorTests.swift
@@ -273,6 +273,41 @@ final class MeetingAutoStartCoordinatorTests: XCTestCase {
         coordinator.stop()
     }
 
+    // MARK: - Owned-event merge for reliable auto-stop (#2)
+
+    func testMergeReinjectsOwnedEventWhenDroppedFromFetch() {
+        // EventKit stops returning the event once `now` passes its endTime, so
+        // a still-active owned recording must be re-injected for the auto-stop
+        // window to remain evaluable.
+        let owned = event(id: "owned", startsIn: -1800)
+        let merged = MeetingAutoStartCoordinator.mergingOwnedEvent(
+            into: [],
+            owned: owned,
+            activeRecording: true
+        )
+        XCTAssertEqual(merged.map(\.id), ["owned"])
+    }
+
+    func testMergeDoesNotDuplicateWhenOwnedEventStillPresent() {
+        let owned = event(id: "owned", startsIn: -600)
+        let merged = MeetingAutoStartCoordinator.mergingOwnedEvent(
+            into: [owned],
+            owned: owned,
+            activeRecording: true
+        )
+        XCTAssertEqual(merged.map(\.id), ["owned"], "Must not duplicate an event already in the fetch")
+    }
+
+    func testMergeNoOpWhenNotRecording() {
+        let owned = event(id: "owned", startsIn: -600)
+        let merged = MeetingAutoStartCoordinator.mergingOwnedEvent(
+            into: [],
+            owned: owned,
+            activeRecording: false
+        )
+        XCTAssertTrue(merged.isEmpty, "No merge when there's no active recording to protect")
+    }
+
     // MARK: - Auto-stop idempotency (#1 — privacy)
 
     func testAutoStopCompletionAfterExternalStopDoesNotConfirm() async {

--- a/Tests/MacParakeetTests/Calendar/MeetingAutoStartCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/Calendar/MeetingAutoStartCoordinatorTests.swift
@@ -357,13 +357,20 @@ final class MeetingAutoStartCoordinatorTests: XCTestCase {
         XCTAssertEqual(calendarService.fetchUpcomingEventsCallCount, 1,
                        "First poll should be mid-fetch")
 
-        coordinator.testHook_forcePoll()   // poll B — should be dropped
+        coordinator.testHook_forcePoll()   // poll B — should be coalesced
         await waitForPoll()
+        XCTAssertTrue(coordinator.testHook_pollAgainRequested,
+                      "The reentrant poll must register a coalesced re-run (proves it entered and hit the guard, not merely queued)")
         XCTAssertEqual(calendarService.fetchUpcomingEventsCallCount, 1,
-                       "A reentrant poll must be dropped, not run a second fetch")
+                       "A reentrant poll must not run a second concurrent fetch")
 
+        // Releasing A lets it finish and run exactly one coalesced re-poll.
         calendarService.releaseHeldFetch()
         await waitForPoll()
+        XCTAssertFalse(coordinator.testHook_pollAgainRequested,
+                       "Coalesced flag should be consumed by the re-run")
+        XCTAssertEqual(calendarService.fetchUpcomingEventsCallCount, 2,
+                       "The dropped poll must be honored once after the in-flight poll completes")
 
         coordinator.stop()
     }

--- a/Tests/MacParakeetTests/Calendar/MeetingAutoStartCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/Calendar/MeetingAutoStartCoordinatorTests.swift
@@ -273,6 +273,34 @@ final class MeetingAutoStartCoordinatorTests: XCTestCase {
         coordinator.stop()
     }
 
+    // MARK: - Poll reentrancy (#3)
+
+    func testConcurrentPollsDoNotInterleave() async {
+        // Hold one poll inside its fetch, then issue a second. The reentrancy
+        // guard must drop the second so it can't double-post a reminder.
+        calendarService.stubPermissionStatus = .granted
+        calendarService.stubEvents = [event(startsIn: 5 * 60)]
+        seedSettings(mode: .notify, reminderMinutes: 5)
+
+        let coordinator = makeCoordinator()
+        calendarService.holdNextFetch = true
+
+        coordinator.testHook_forcePoll()   // poll A enters and parks in fetch
+        await waitForPoll()
+        XCTAssertEqual(calendarService.fetchUpcomingEventsCallCount, 1,
+                       "First poll should be mid-fetch")
+
+        coordinator.testHook_forcePoll()   // poll B — should be dropped
+        await waitForPoll()
+        XCTAssertEqual(calendarService.fetchUpcomingEventsCallCount, 1,
+                       "A reentrant poll must be dropped, not run a second fetch")
+
+        calendarService.releaseHeldFetch()
+        await waitForPoll()
+
+        coordinator.stop()
+    }
+
     // MARK: - Owned-event merge for reliable auto-stop (#2)
 
     func testMergeReinjectsOwnedEventWhenDroppedFromFetch() {

--- a/Tests/MacParakeetTests/Calendar/MeetingLinkParserTests.swift
+++ b/Tests/MacParakeetTests/Calendar/MeetingLinkParserTests.swift
@@ -41,6 +41,53 @@ final class MeetingLinkParserTests: XCTestCase {
         XCTAssertEqual(parser.extractMeetingUrl(from: text), "https://example.com/meet/room-1")
     }
 
+    // MARK: - Zoom variants (#4 — false negatives)
+
+    func testExtractsZoomPersonalRoom() {
+        XCTAssertEqual(
+            parser.extractMeetingUrl(from: "Join https://zoom.us/my/jane.doe"),
+            "https://zoom.us/my/jane.doe"
+        )
+    }
+
+    func testExtractsZoomWebinar() {
+        XCTAssertEqual(
+            parser.extractMeetingUrl(from: "https://company.zoom.us/w/1234567890"),
+            "https://company.zoom.us/w/1234567890"
+        )
+    }
+
+    func testExtractsZoomGov() {
+        XCTAssertEqual(
+            parser.extractMeetingUrl(from: "https://zoomgov.com/j/1234567890"),
+            "https://zoomgov.com/j/1234567890"
+        )
+    }
+
+    func testExtractsWhereby() {
+        XCTAssertEqual(
+            parser.extractMeetingUrl(from: "https://whereby.com/standup-room"),
+            "https://whereby.com/standup-room"
+        )
+    }
+
+    // MARK: - Generic precision (#4 — false positives)
+
+    func testGenericDoesNotMatchCallSubstringInRecall() {
+        XCTAssertFalse(parser.isMeetingUrl("https://example.com/recall"))
+        XCTAssertFalse(parser.isMeetingUrl("https://example.com/teamcall"))
+        XCTAssertFalse(parser.isMeetingUrl("https://site.com/page?utm_campaign=fallcall"))
+    }
+
+    func testGenericDoesNotMatchVideoSubstringInVideogame() {
+        XCTAssertFalse(parser.isMeetingUrl("https://videogame.com/play"))
+    }
+
+    func testGenericStillMatchesDelimitedTokens() {
+        XCTAssertTrue(parser.isMeetingUrl("https://example.com/video-call"))
+        XCTAssertTrue(parser.isMeetingUrl("https://acme.com/conference/room"))
+    }
+
     func testReturnsNilForPlainText() {
         XCTAssertNil(parser.extractMeetingUrl(from: "Just a calendar block, no link"))
     }
@@ -121,6 +168,8 @@ final class MeetingLinkParserTests: XCTestCase {
         XCTAssertEqual(parser.identifyService(from: "https://teams.microsoft.com/x"), "Microsoft Teams")
         XCTAssertEqual(parser.identifyService(from: "https://acme.webex.com/x"), "Webex")
         XCTAssertEqual(parser.identifyService(from: "https://around.co/r/x"), "Around")
+        XCTAssertEqual(parser.identifyService(from: "https://zoomgov.com/j/1"), "Zoom")
+        XCTAssertEqual(parser.identifyService(from: "https://whereby.com/room"), "Whereby")
         XCTAssertNil(parser.identifyService(from: "https://example.com"))
         XCTAssertNil(parser.identifyService(from: nil))
     }

--- a/Tests/MacParakeetTests/Calendar/MeetingLinkParserTests.swift
+++ b/Tests/MacParakeetTests/Calendar/MeetingLinkParserTests.swift
@@ -88,6 +88,18 @@ final class MeetingLinkParserTests: XCTestCase {
         XCTAssertTrue(parser.isMeetingUrl("https://acme.com/conference/room"))
     }
 
+    func testGenericIgnoresKeywordInQueryString() {
+        // A keyword only in the query string (Jira/CRM links) is not a meeting.
+        XCTAssertFalse(parser.isMeetingUrl("https://jira.corp.com?type=conference&id=PROJ-123"))
+        XCTAssertFalse(parser.isMeetingUrl("https://helpdesk.com?mode=call&ticket=456"))
+        XCTAssertFalse(parser.isMeetingUrl("https://example.com?video=1"))
+    }
+
+    func testGenericMatchesPathTokenEvenWithQuery() {
+        // Token in the path is still a match, query after it is fine.
+        XCTAssertTrue(parser.isMeetingUrl("https://example.com/conference?id=1"))
+    }
+
     func testReturnsNilForPlainText() {
         XCTAssertNil(parser.extractMeetingUrl(from: "Just a calendar block, no link"))
     }

--- a/Tests/MacParakeetTests/Calendar/MeetingMonitorTests.swift
+++ b/Tests/MacParakeetTests/Calendar/MeetingMonitorTests.swift
@@ -377,6 +377,83 @@ final class MeetingMonitorTests: XCTestCase {
         XCTAssertTrue(result.isEmpty)
     }
 
+    // MARK: - RSVP gating for auto-start (#5)
+
+    func testAutoStartSkipsPendingInvite() {
+        let now = Date()
+        let evt = event(startsIn: 0, from: now, userStatus: .pending)
+        let result = MeetingMonitor.evaluate(
+            events: [evt],
+            now: now,
+            config: config(mode: .autoStart, reminderMinutes: 0),
+            activeRecording: false,
+            dismissedEventIds: [],
+            remindedEventIds: [],
+            countdownShownEventIds: []
+        )
+        XCTAssertTrue(result.isEmpty,
+                      "An invite the user hasn't accepted (.pending) must not auto-record")
+    }
+
+    func testAutoStartFiresForTentative() {
+        let now = Date()
+        let evt = event(startsIn: 0, from: now, userStatus: .tentative)
+        let result = MeetingMonitor.evaluate(
+            events: [evt],
+            now: now,
+            config: config(mode: .autoStart, reminderMinutes: 0),
+            activeRecording: false,
+            dismissedEventIds: [],
+            remindedEventIds: [],
+            countdownShownEventIds: []
+        )
+        XCTAssertTrue(result.contains { if case .autoStartDue = $0 { return true } else { return false } },
+                      "A tentatively-accepted meeting is still likely-attending — auto-start should fire")
+    }
+
+    func testReminderStillFiresForPendingInvite() {
+        let now = Date()
+        // Reminders are lenient: a pending invite still gets a notification.
+        let evt = event(startsIn: 5 * 60, from: now, userStatus: .pending)
+        let result = MeetingMonitor.evaluate(
+            events: [evt],
+            now: now,
+            config: config(mode: .notify, reminderMinutes: 5),
+            activeRecording: false,
+            dismissedEventIds: [],
+            remindedEventIds: [],
+            countdownShownEventIds: []
+        )
+        XCTAssertTrue(result.contains { if case .reminderDue = $0 { return true } else { return false } },
+                      "Reminders should remain lenient for pending invites")
+    }
+
+    func testAutoStopFiresForPendingInviteOnceRecording() {
+        let now = Date()
+        // RSVP gates auto-START only. If we're already recording a meeting
+        // (regardless of RSVP), auto-stop must still fire at its end.
+        let evt = CalendarEvent(
+            id: "ending",
+            title: "Wrap",
+            startTime: now.addingTimeInterval(-1500),
+            endTime: now.addingTimeInterval(20),
+            meetUrl: "https://zoom.us/j/1",
+            participants: [EventParticipant(email: "x@y")],
+            userStatus: .pending
+        )
+        let result = MeetingMonitor.evaluate(
+            events: [evt],
+            now: now,
+            config: config(mode: .autoStart, autoStopEnabled: true),
+            activeRecording: true,
+            dismissedEventIds: [],
+            remindedEventIds: [],
+            countdownShownEventIds: []
+        )
+        XCTAssertTrue(result.contains { if case .autoStopDue = $0 { return true } else { return false } },
+                      "Auto-stop is not RSVP-gated — a recording in flight must still stop at meeting end")
+    }
+
     // MARK: - Late join
 
     func testLateJoinFiresAfter30sUntilGracePeriod() {

--- a/Tests/MacParakeetTests/Calendar/MeetingMonitorTests.swift
+++ b/Tests/MacParakeetTests/Calendar/MeetingMonitorTests.swift
@@ -193,10 +193,34 @@ final class MeetingMonitorTests: XCTestCase {
             config: config(reminderMinutes: 5),
             activeRecording: false,
             dismissedEventIds: [],
-            remindedEventIds: ["evt-1"],
+            remindedEventIds: [evt.dedupeKey],
             countdownShownEventIds: []
         )
         XCTAssertTrue(result.isEmpty)
+    }
+
+    func testRescheduledEventReFiresReminder() {
+        let now = Date()
+        // Reminded at an earlier slot, then moved. Same id, different start
+        // time → different dedupeKey → the reminder fires again.
+        let rescheduled = event(id: "evt-1", startsIn: 5 * 60, from: now)
+        let oldSlotKey = CalendarEvent(
+            id: "evt-1",
+            title: "Standup",
+            startTime: now.addingTimeInterval(-3600),
+            endTime: now.addingTimeInterval(-1800)
+        ).dedupeKey
+        let result = MeetingMonitor.evaluate(
+            events: [rescheduled],
+            now: now,
+            config: config(reminderMinutes: 5),
+            activeRecording: false,
+            dismissedEventIds: [],
+            remindedEventIds: [oldSlotKey],
+            countdownShownEventIds: []
+        )
+        XCTAssertEqual(extractIds(result), ["evt-1"],
+                       "A reschedule to a new time must re-fire — the old slot's key must not suppress it")
     }
 
     func testReminderMinutesZeroDisablesReminder() {
@@ -321,7 +345,7 @@ final class MeetingMonitorTests: XCTestCase {
             now: now,
             config: config(),
             activeRecording: false,
-            dismissedEventIds: ["evt-1"],
+            dismissedEventIds: [evt.dedupeKey],
             remindedEventIds: [],
             countdownShownEventIds: []
         )
@@ -372,7 +396,7 @@ final class MeetingMonitorTests: XCTestCase {
             activeRecording: false,
             dismissedEventIds: [],
             remindedEventIds: [],
-            countdownShownEventIds: ["evt-1"]
+            countdownShownEventIds: [evt.dedupeKey]
         )
         XCTAssertTrue(result.isEmpty)
     }
@@ -549,7 +573,7 @@ final class MeetingMonitorTests: XCTestCase {
             now: now,
             config: config(),
             activeRecording: false,
-            dismissedEventIds: ["dismissed"],
+            dismissedEventIds: [dismissed.dedupeKey],
             remindedEventIds: [],
             countdownShownEventIds: []
         )

--- a/Tests/MacParakeetTests/Calendar/MeetingMonitorTests.swift
+++ b/Tests/MacParakeetTests/Calendar/MeetingMonitorTests.swift
@@ -562,6 +562,58 @@ final class MeetingMonitorTests: XCTestCase {
         XCTAssertFalse(result.contains { if case .autoStopDue = $0 { return true } else { return false } })
     }
 
+    func testAutoStopFiresWithinForgivenessTailPastEnd() {
+        let now = Date()
+        // Meeting already ended 60s ago, recording still active (we woke from
+        // sleep / it ran long). Within the 5-min forgiveness tail → auto-stop
+        // should still fire so the recording doesn't run forever.
+        let evt = CalendarEvent(
+            id: "ended",
+            title: "Wrap",
+            startTime: now.addingTimeInterval(-1800),
+            endTime: now.addingTimeInterval(-60),
+            meetUrl: "https://zoom.us/j/1",
+            participants: [EventParticipant(email: "x@y")],
+            userStatus: .accepted
+        )
+        let result = MeetingMonitor.evaluate(
+            events: [evt],
+            now: now,
+            config: config(mode: .autoStart, autoStopEnabled: true),
+            activeRecording: true,
+            dismissedEventIds: [],
+            remindedEventIds: [],
+            countdownShownEventIds: []
+        )
+        XCTAssertTrue(result.contains { if case .autoStopDue = $0 { return true } else { return false } },
+                      "Auto-stop must still fire shortly after endTime (sleep / long meeting)")
+    }
+
+    func testAutoStopDoesNotFireBeyondForgivenessTail() {
+        let now = Date()
+        // Ended 6 minutes ago — beyond the 5-min forgiveness tail. Leave it
+        // for a manual stop rather than force-stopping a long-past meeting.
+        let evt = CalendarEvent(
+            id: "ended",
+            title: "Wrap",
+            startTime: now.addingTimeInterval(-3600),
+            endTime: now.addingTimeInterval(-6 * 60),
+            meetUrl: "https://zoom.us/j/1",
+            participants: [EventParticipant(email: "x@y")],
+            userStatus: .accepted
+        )
+        let result = MeetingMonitor.evaluate(
+            events: [evt],
+            now: now,
+            config: config(mode: .autoStart, autoStopEnabled: true),
+            activeRecording: true,
+            dismissedEventIds: [],
+            remindedEventIds: [],
+            countdownShownEventIds: []
+        )
+        XCTAssertFalse(result.contains { if case .autoStopDue = $0 { return true } else { return false } })
+    }
+
     // MARK: - Multiple events
 
     func testHandlesMultipleEventsIndependently() {

--- a/Tests/MacParakeetTests/Calendar/MockCalendarService.swift
+++ b/Tests/MacParakeetTests/Calendar/MockCalendarService.swift
@@ -22,6 +22,12 @@ final class MockCalendarService: CalendarServicing, @unchecked Sendable {
     nonisolated(unsafe) private(set) var fetchUpcomingEventsCallCount = 0
     nonisolated(unsafe) private(set) var availableCalendarsCallCount = 0
 
+    /// When set, the *next* fetch parks until `releaseHeldFetch()` is called.
+    /// Lets reentrancy tests hold one poll inside its `await` so a second poll
+    /// can be issued deterministically (no sleeps).
+    nonisolated(unsafe) var holdNextFetch = false
+    nonisolated(unsafe) private var fetchContinuation: CheckedContinuation<Void, Never>?
+
     nonisolated var permissionStatus: CalendarService.PermissionStatus {
         stubPermissionStatus
     }
@@ -43,9 +49,19 @@ final class MockCalendarService: CalendarServicing, @unchecked Sendable {
 
     func fetchUpcomingEvents(from: Date, days: Int?) async throws -> [CalendarEvent] {
         fetchUpcomingEventsCallCount += 1
+        if holdNextFetch {
+            holdNextFetch = false
+            await withCheckedContinuation { fetchContinuation = $0 }
+        }
         if let stubFetchError {
             throw stubFetchError
         }
         return stubEvents
+    }
+
+    /// Resume a fetch parked by `holdNextFetch`.
+    func releaseHeldFetch() {
+        fetchContinuation?.resume()
+        fetchContinuation = nil
     }
 }

--- a/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowStateMachineTests.swift
+++ b/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowStateMachineTests.swift
@@ -12,6 +12,22 @@ final class MeetingRecordingFlowStateMachineTests: XCTestCase {
         XCTAssertEqual(effects, [.checkPermissions])
     }
 
+    func testStopRequestedWhileIdleIsNoOp() {
+        // `MeetingRecordingFlowCoordinator.stopFromCalendar()` (the idempotent
+        // calendar auto-stop path) relies on `.stopRequested` being a no-op
+        // from `.idle` — it must NEVER start a recording. This invariant is
+        // what makes auto-stop safe to fire even if the recording already
+        // ended (see #1 privacy fix).
+        var machine = MeetingRecordingFlowStateMachine()
+
+        let effects = machine.handle(.stopRequested)
+
+        XCTAssertEqual(machine.state, .idle)
+        XCTAssertTrue(effects.isEmpty)
+        XCTAssertEqual(machine.generation, 0,
+                       "No generation bump means no recording was started")
+    }
+
     func testPermissionDeniedReturnsToIdleAndPresentsAlert() {
         var machine = MeetingRecordingFlowStateMachine()
         _ = machine.handle(.startRequested)

--- a/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowStateMachineTests.swift
+++ b/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowStateMachineTests.swift
@@ -13,11 +13,10 @@ final class MeetingRecordingFlowStateMachineTests: XCTestCase {
     }
 
     func testStopRequestedWhileIdleIsNoOp() {
-        // `MeetingRecordingFlowCoordinator.stopFromCalendar()` (the idempotent
-        // calendar auto-stop path) relies on `.stopRequested` being a no-op
-        // from `.idle` — it must NEVER start a recording. This invariant is
-        // what makes auto-stop safe to fire even if the recording already
-        // ended (see #1 privacy fix).
+        // `MeetingRecordingFlowCoordinator.stopFromCalendar(recordingGeneration:)`
+        // relies on `.stopRequested` being a no-op from `.idle` — it must NEVER
+        // start a recording. This invariant keeps auto-stop safe to fire even
+        // if the recording already ended (see #1 privacy fix).
         var machine = MeetingRecordingFlowStateMachine()
 
         let effects = machine.handle(.stopRequested)


### PR DESCRIPTION
Closes the correctness gaps two independent audit passes found in the calendar-driven meeting auto-start feature (ADR-017), so it's safe to enable. **The `AppFeatures.calendarEnabled` flag is intentionally left OFF in this PR** — this makes the feature *correct*; flipping it is a separate decision after the hands-on E2E pass the flag comment calls for.

## Why
Marketing MacParakeet as a Granola alternative needs calendar auto-start ("you never press record"). The audits found no crash/data-loss/leak/telemetry blockers, but a cluster of correctness gaps concentrated in auto-stop and multi-meeting transitions — exactly the back-to-back-meeting power-user path. Round 2 also caught a reachable **privacy** defect round 1 missed.

## What's fixed (commit-by-commit)
1. **Idempotent auto-stop (privacy must-fix)** — auto-stop confirm was a blind `toggleRecording()`. If you manually stopped the auto-started recording during the 30s countdown, completion *started a brand-new* mic + system-audio recording. Now routes through `stopFromCalendar()` (never starts) + dismisses the stale toast on external stop + re-verifies ownership at fire time.
2. **Parser precision** — generic fallback no longer matches `call` in `recall`/`teamcall`/`?utm=fallcall` or `video` in `videogame.com`; adds Zoom `/w/` `/my/` + `zoomgov.com` + Whereby.
3. **RSVP gating** — don't auto-record `.declined`/`.pending` invites; reminders stay lenient; auto-stop is not RSVP-gated.
4. **Reschedule re-fire** — suppression sets key on `(id, startTime)` so a same-day move re-fires.
5. **Auto-stop reliability** — poll on `NSWorkspace.didWake`, re-inject the owned event when EventKit drops it past `endTime`, and a 5-min forgiveness tail so sleep / long meetings still auto-stop.
6. **Poll reentrancy guard** — `EKEventStoreChanged` bursts can no longer interleave polls into duplicate reminder notifications.
7. **Back-to-back retry** — a meeting rejected as `state_busy` retries once the blocking recording ends (within its auto-start window).
8. **Notification-permission UI** — Settings now surfaces "Notifications are off" so `.notify` can't be a silent no-op; also fixes a stale header comment.
9. **Zero-duration event filter.**

## Tests
Full suite green: **2800 XCTest (10 skipped, 0 failures)** + all Swift Testing suites. Added coverage: idempotent/ownership-recheck auto-stop, parser variants & false-positives, RSVP gating, reschedule re-fire, forgiveness window, owned-event merge, deterministic poll-reentrancy (new mock fetch gate), back-to-back retry, and a state-machine invariant that `.stopRequested` from idle never starts.

## Not in scope (deliberate)
- **Flipping `calendarEnabled`** — still OFF. Recommend: one more focused audit pass on this diff, then the hands-on E2E (CLI read-path against a real calendar + a real Zoom/Meet run incl. the full-screen-toast check), then flip with `.notify` as the safe default.
- Late-join after a missed auto-start window (Phase 3).
- Observed-but-unrelated: the reminder picker's "At start time" maps to `reminderMinutes = 0`, which disables reminders — pre-existing, worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added calendar notification authorization checking with quick access to notification settings.
  * Improved meeting link detection for Zoom variants (personal rooms, webinars, GOV) and Whereby.
  * Extended auto-stop window with forgiveness period past event end time.
  * Added RSVP status filtering for auto-start (skips declined/pending invites).

* **Bug Fixes**
  * Prevented accidental recording restart when stopping auto-started recordings.
  * Fixed reminders/auto-start to properly track rescheduled event occurrences.
  * Improved handling of auto-start/auto-stop after Mac sleep/wake.
  * Eliminated duplicate reminder notifications from concurrent polling.
  * Filtered invalid calendar events with invalid date ranges.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moona3k/macparakeet/pull/318?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->