### PR TITLE
Telemetry: source on llm_chat_used + engine-level language attribution

### DIFF
--- a/Sources/CLI/Commands/LLMChatCommand.swift
+++ b/Sources/CLI/Commands/LLMChatCommand.swift
@@ -42,17 +42,23 @@ struct LLMChatCommand: AsyncParsableCommand {
                 contextResolver: StaticLLMExecutionContextResolver(context: execution.context)
             )
 
+            // CLI chat is one-shot and runs under `surface='cli'` in
+            // telemetry, so the `source` value mostly matters for the
+            // surface-blind chat-source dashboard. `transcriptChat` is the
+            // right bucket — the CLI passes an already-transcribed payload
+            // through `--text` / `--from-file`, mirroring the post-recording
+            // GUI chat surface, not the live in-meeting Ask flow.
             if json {
-                let result = try await service.chatDetailed(question: question, transcript: text, userNotes: nil, history: [])
+                let result = try await service.chatDetailed(question: question, transcript: text, userNotes: nil, history: [], source: .transcriptChat)
                 try printJSON(result)
             } else if stream {
-                let tokenStream = service.chatStream(question: question, transcript: text, userNotes: nil, history: [])
+                let tokenStream = service.chatStream(question: question, transcript: text, userNotes: nil, history: [], source: .transcriptChat)
                 for try await token in tokenStream {
                     print(token, terminator: "")
                 }
                 print()
             } else {
-                print(try await service.chat(question: question, transcript: text, userNotes: nil, history: []))
+                print(try await service.chat(question: question, transcript: text, userNotes: nil, history: [], source: .transcriptChat))
             }
         }
     }

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -169,7 +169,15 @@ public actor STTRuntime: STTRuntimeProtocol {
             let result = try await manager.transcribe(audioURL, decoderState: &decoderState)
             let words = Self.mergeTokenTimingsIntoWords(result.tokenTimings)
             onProgress?(100, 100)
-            return STTResult(text: result.text, words: words, engine: .parakeet, engineVariant: nil)
+            // MacParakeet exposes Parakeet TDT 0.6B-v3 as an English-only engine
+            // — there is no user-facing Parakeet language selector even though
+            // the model itself supports 25 European languages. Attributing
+            // "en" here lets the telemetry `language` field reflect what the
+            // engine actually produced in this app's configuration. If the
+            // app ever exposes Parakeet's multilingual modes, this attribution
+            // needs to consult the user's selection (or per-segment detection)
+            // instead of hard-coding the code.
+            return STTResult(text: result.text, words: words, language: "en", engine: .parakeet, engineVariant: nil)
         } catch {
             throw try Self.mapTranscriptionError(error)
         }

--- a/Sources/MacParakeetCore/Services/LLM/LLMService.swift
+++ b/Sources/MacParakeetCore/Services/LLM/LLMService.swift
@@ -302,7 +302,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                         feature: .chat
                     ))
                 } else {
-                    Telemetry.send(.llmChatFailed(provider: config.id.rawValue, errorType: kind))
+                    Telemetry.send(.llmChatFailed(provider: config.id.rawValue, source: source, errorType: kind))
                 }
                 sendLLMOperation(
                     operationID: operationID,
@@ -729,6 +729,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                         } else {
                             Telemetry.send(.llmChatFailed(
                                 provider: provider,
+                                source: source,
                                 errorType: kind
                             ))
                         }

--- a/Sources/MacParakeetCore/Services/LLM/LLMService.swift
+++ b/Sources/MacParakeetCore/Services/LLM/LLMService.swift
@@ -4,7 +4,7 @@ import Foundation
 
 public protocol LLMServiceProtocol: Sendable {
     func generatePromptResult(transcript: String, systemPrompt: String?) async throws -> String
-    func chat(question: String, transcript: String, userNotes: String?, history: [ChatMessage]) async throws -> String
+    func chat(question: String, transcript: String, userNotes: String?, history: [ChatMessage], source: TelemetryChatSource) async throws -> String
     func transform(text: String, prompt: String) async throws -> String
     func formatTranscript(
         transcript: String,
@@ -14,7 +14,7 @@ public protocol LLMServiceProtocol: Sendable {
     ) async throws -> String
 
     func generatePromptResultStream(transcript: String, systemPrompt: String?) -> AsyncThrowingStream<String, Error>
-    func chatStream(question: String, transcript: String, userNotes: String?, history: [ChatMessage]) -> AsyncThrowingStream<String, Error>
+    func chatStream(question: String, transcript: String, userNotes: String?, history: [ChatMessage], source: TelemetryChatSource) -> AsyncThrowingStream<String, Error>
     func transformStream(text: String, prompt: String) -> AsyncThrowingStream<String, Error>
 
     // MARK: Envelope variants
@@ -25,7 +25,7 @@ public protocol LLMServiceProtocol: Sendable {
     // `String`-returning callers (the GUI) are unaffected.
 
     func generatePromptResultDetailed(transcript: String, systemPrompt: String?) async throws -> LLMResult
-    func chatDetailed(question: String, transcript: String, userNotes: String?, history: [ChatMessage]) async throws -> LLMResult
+    func chatDetailed(question: String, transcript: String, userNotes: String?, history: [ChatMessage], source: TelemetryChatSource) async throws -> LLMResult
     func transformDetailed(text: String, prompt: String) async throws -> LLMResult
     func formatTranscriptDetailed(
         transcript: String,
@@ -140,8 +140,8 @@ public final class LLMService: LLMServiceProtocol, Sendable {
         try await generatePromptResultDetailed(transcript: transcript, systemPrompt: systemPrompt).output
     }
 
-    public func chat(question: String, transcript: String, userNotes: String?, history: [ChatMessage]) async throws -> String {
-        try await chatDetailed(question: question, transcript: transcript, userNotes: userNotes, history: history).output
+    public func chat(question: String, transcript: String, userNotes: String?, history: [ChatMessage], source: TelemetryChatSource) async throws -> String {
+        try await chatDetailed(question: question, transcript: transcript, userNotes: userNotes, history: history, source: source).output
     }
 
     public func transform(text: String, prompt: String) async throws -> String {
@@ -242,7 +242,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
         }
     }
 
-    public func chatDetailed(question: String, transcript: String, userNotes: String?, history: [ChatMessage]) async throws -> LLMResult {
+    public func chatDetailed(question: String, transcript: String, userNotes: String?, history: [ChatMessage], source: TelemetryChatSource) async throws -> LLMResult {
         let operationID = Observability.operationID()
         let startedAt = Date()
         let context = try loadContextForLLMOperation(
@@ -265,7 +265,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
         do {
             let response = try await client.chatCompletion(messages: messages, context: context, options: .default)
             let latencyMs = Self.latencyMs(since: startedAt)
-            Telemetry.send(.llmChatUsed(provider: config.id.rawValue, messageCount: history.count + 1))
+            Telemetry.send(.llmChatUsed(provider: config.id.rawValue, source: source, messageCount: history.count + 1))
             sendLLMOperation(
                 operationID: operationID,
                 feature: "chat",
@@ -659,7 +659,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
         }
     }
 
-    public func chatStream(question: String, transcript: String, userNotes: String?, history: [ChatMessage]) -> AsyncThrowingStream<String, Error> {
+    public func chatStream(question: String, transcript: String, userNotes: String?, history: [ChatMessage], source: TelemetryChatSource) -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { continuation in
             let operationID = Observability.operationID()
             let startedAt = Date()
@@ -702,7 +702,7 @@ public final class LLMService: LLMServiceProtocol, Sendable {
                         outputChars += token.count
                         continuation.yield(token)
                     }
-                    Telemetry.send(.llmChatUsed(provider: config.id.rawValue, messageCount: history.count + 1))
+                    Telemetry.send(.llmChatUsed(provider: config.id.rawValue, source: source, messageCount: history.count + 1))
                     self.sendLLMOperation(
                         operationID: operationID,
                         feature: "chat",

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -193,6 +193,20 @@ public enum TelemetryFormatterSource: String, Sendable, Equatable {
     case transcription
 }
 
+/// Which chat surface a `llm_chat_used` / chat-feature LLM operation came
+/// from. Pre-2026-05-19 builds emitted `llm_chat_used` without a source,
+/// which collapsed live meeting Ask chat and post-transcription transcript
+/// chat into one unattributable bucket. New rows carry `source` so the two
+/// surfaces are separable in production telemetry.
+public enum TelemetryChatSource: String, Sendable, Equatable {
+    /// Live in-meeting Ask tab (ADR-018). `userNotesProvider` is bound by
+    /// `MeetingRecordingPanelViewModel`.
+    case meetingAsk = "meeting_ask"
+    /// Post-transcription chat surface — file, YouTube, dictation, or a
+    /// finalized meeting transcript shown in `TranscriptResultView`.
+    case transcriptChat = "transcript_chat"
+}
+
 /// Which Transform (ADR-022) ran. Built-in names are transmitted verbatim
 /// (`polish`, `distill`, `decide`) so per-built-in usage is observable.
 /// Custom Transforms map to `custom` — a user-supplied name like "Boss
@@ -437,7 +451,7 @@ public enum TelemetryEventSpec: Sendable {
     case exportUsed(format: String)
     case llmPromptResultUsed(provider: String)
     case llmPromptResultFailed(provider: String, errorType: String, errorDetail: String? = nil)
-    case llmChatUsed(provider: String, messageCount: Int)
+    case llmChatUsed(provider: String, source: TelemetryChatSource, messageCount: Int)
     case llmChatFailed(provider: String, errorType: String, errorDetail: String? = nil)
     case llmTransformUsed(provider: String)
     case llmTransformFailed(provider: String, errorType: String, errorDetail: String? = nil)
@@ -1017,8 +1031,8 @@ extension TelemetryEventSpec {
             var props = ["provider": provider, "error_type": errorType]
             if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
             return props
-        case .llmChatUsed(let provider, let messageCount):
-            return ["provider": provider, "message_count": "\(messageCount)"]
+        case .llmChatUsed(let provider, let source, let messageCount):
+            return ["provider": provider, "source": source.rawValue, "message_count": "\(messageCount)"]
         case .llmChatFailed(let provider, let errorType, let errorDetail):
             var props = ["provider": provider, "error_type": errorType]
             if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
@@ -1517,7 +1531,7 @@ public enum TelemetryImplementedContract {
         .exportUsed: ["format"],
         .llmPromptResultUsed: ["provider"],
         .llmPromptResultFailed: ["provider", "error_type"],
-        .llmChatUsed: ["provider", "message_count"],
+        .llmChatUsed: ["provider", "source", "message_count"],
         .llmChatFailed: ["provider", "error_type"],
         .llmTransformUsed: ["provider"],
         .llmTransformFailed: ["provider", "error_type"],

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -452,7 +452,7 @@ public enum TelemetryEventSpec: Sendable {
     case llmPromptResultUsed(provider: String)
     case llmPromptResultFailed(provider: String, errorType: String, errorDetail: String? = nil)
     case llmChatUsed(provider: String, source: TelemetryChatSource, messageCount: Int)
-    case llmChatFailed(provider: String, errorType: String, errorDetail: String? = nil)
+    case llmChatFailed(provider: String, source: TelemetryChatSource, errorType: String, errorDetail: String? = nil)
     case llmTransformUsed(provider: String)
     case llmTransformFailed(provider: String, errorType: String, errorDetail: String? = nil)
     /// Transforms (ADR-022) feature-level success. Fired by
@@ -1033,8 +1033,8 @@ extension TelemetryEventSpec {
             return props
         case .llmChatUsed(let provider, let source, let messageCount):
             return ["provider": provider, "source": source.rawValue, "message_count": "\(messageCount)"]
-        case .llmChatFailed(let provider, let errorType, let errorDetail):
-            var props = ["provider": provider, "error_type": errorType]
+        case .llmChatFailed(let provider, let source, let errorType, let errorDetail):
+            var props = ["provider": provider, "source": source.rawValue, "error_type": errorType]
             if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
             return props
         case .llmTransformUsed(let provider):
@@ -1532,7 +1532,7 @@ public enum TelemetryImplementedContract {
         .llmPromptResultUsed: ["provider"],
         .llmPromptResultFailed: ["provider", "error_type"],
         .llmChatUsed: ["provider", "source", "message_count"],
-        .llmChatFailed: ["provider", "error_type"],
+        .llmChatFailed: ["provider", "source", "error_type"],
         .llmTransformUsed: ["provider"],
         .llmTransformFailed: ["provider", "error_type"],
         .transformExecuted: ["transform_name", "capture_path", "replace_path", "llm_ms", "total_ms"],

--- a/Sources/MacParakeetCore/WhisperLanguageCatalog.swift
+++ b/Sources/MacParakeetCore/WhisperLanguageCatalog.swift
@@ -137,8 +137,12 @@ public enum WhisperLanguageCatalog {
     /// the code when the model emits an unfamiliar token; without this map
     /// `normalizeKnownLanguage("english")` returns nil and the language
     /// attribution silently disappears from telemetry.
+    // English names are not guaranteed unique the way ISO codes are, so use the
+    // collision-tolerant initializer rather than `uniqueKeysWithValues:` (which
+    // traps at static-init time on a duplicate). Keep the first/canonical entry.
     private static let byEnglishName: [String: WhisperLanguage] = Dictionary(
-        uniqueKeysWithValues: all.map { ($0.englishName.lowercased(), $0) }
+        all.map { ($0.englishName.lowercased(), $0) },
+        uniquingKeysWith: { first, _ in first }
     )
 
     /// WhisperKit accepts a handful of alternate names for the same language

--- a/Sources/MacParakeetCore/WhisperLanguageCatalog.swift
+++ b/Sources/MacParakeetCore/WhisperLanguageCatalog.swift
@@ -130,6 +130,17 @@ public enum WhisperLanguageCatalog {
         uniqueKeysWithValues: all.map { ($0.code, $0) }
     )
 
+    /// Reverse lookup keyed by lower-cased English name so an engine result
+    /// arriving as "english" / "korean" / "japanese" — instead of the ISO-2
+    /// code — still resolves to a known catalog entry. WhisperKit's higher
+    /// layers occasionally fall back to the language NAME token instead of
+    /// the code when the model emits an unfamiliar token; without this map
+    /// `normalizeKnownLanguage("english")` returns nil and the language
+    /// attribution silently disappears from telemetry.
+    private static let byEnglishName: [String: WhisperLanguage] = Dictionary(
+        uniqueKeysWithValues: all.map { ($0.englishName.lowercased(), $0) }
+    )
+
     /// WhisperKit accepts a handful of alternate names for the same language
     /// token. Keep those searchable so the UI does not hide supported inputs
     /// behind one preferred English label.
@@ -163,6 +174,14 @@ public enum WhisperLanguageCatalog {
         if let primarySubtag = normalized.split(separator: "-", maxSplits: 1).first.map(String.init),
            byCode[primarySubtag] != nil {
             return primarySubtag
+        }
+
+        // Engine attributions sometimes arrive as the English language name
+        // ("english", "korean", "japanese") instead of the ISO-2 code. Resolve
+        // those back to the catalog code so downstream telemetry and UI work
+        // unchanged.
+        if let byName = byEnglishName[normalized] {
+            return byName.code
         }
 
         return normalized

--- a/Sources/MacParakeetViewModels/MeetingRecordingPanelViewModel.swift
+++ b/Sources/MacParakeetViewModels/MeetingRecordingPanelViewModel.swift
@@ -61,6 +61,12 @@ public final class MeetingRecordingPanelViewModel {
     private var previewLineWordCounts: [Int] = []
 
     public init() {
+        // Mark the chat VM as the live in-meeting Ask surface so
+        // `llm_chat_used` telemetry distinguishes Ask chat from
+        // post-transcription transcript chat. Without this the two sources
+        // collapse into one bucket and Ask adoption is invisible.
+        chatViewModel.markAsMeetingAskSurface()
+
         // Thread the live notepad into the live Ask chat: the closure is
         // called by `TranscriptChatViewModel` at chat-send time, so the
         // freshest keystroke up to the moment the user hits Send is what the

--- a/Sources/MacParakeetViewModels/TranscriptChatViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptChatViewModel.swift
@@ -53,6 +53,12 @@ public final class TranscriptChatViewModel {
     private var conversationRepo: ChatConversationRepositoryProtocol?
     private var transcriptionId: UUID?
     private var transcriptText: String = ""
+    /// Identifies which chat surface this VM instance is driving — meeting
+    /// Ask or post-transcription transcript chat — so `llm_chat_used`
+    /// telemetry can separate the two. Defaults to `.transcriptChat`;
+    /// `MeetingRecordingPanelViewModel` flips it via
+    /// `markAsMeetingAskSurface()` at construction.
+    private var chatSource: TelemetryChatSource = .transcriptChat
     /// Optional provider closure that returns the user's typed meeting notes
     /// at chat-send time. Returning nil/empty omits the notes block from the
     /// chat system prompt, leaving chat behavior byte-identical to a chat
@@ -263,7 +269,8 @@ public final class TranscriptChatViewModel {
                     question: question,
                     transcript: transcript,
                     userNotes: userNotes,
-                    history: historyForRequest
+                    history: historyForRequest,
+                    source: chatSource
                 )
                 for try await token in stream {
                     accumulated += token
@@ -357,6 +364,16 @@ public final class TranscriptChatViewModel {
     ///   to the moment the user hits Send.
     public func bindUserNotesProvider(_ provider: (@MainActor () -> String?)?) {
         self.userNotesProvider = provider
+    }
+
+    /// Marks this VM as driving the live in-meeting Ask surface so
+    /// `llm_chat_used` telemetry attributes the chat to `meeting_ask` rather
+    /// than the default `transcript_chat`. Callable once at construction —
+    /// `MeetingRecordingPanelViewModel.init()` flips this immediately and
+    /// the VM keeps the meeting-Ask attribution for its entire lifetime,
+    /// including post-meeting "Continue chat" persistence.
+    public func markAsMeetingAskSurface() {
+        self.chatSource = .meetingAsk
     }
 
     /// Promotes an in-memory live chat (no transcriptionId, no conversationRepo)

--- a/Sources/MacParakeetViewModels/TranscriptChatViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptChatViewModel.swift
@@ -373,6 +373,14 @@ public final class TranscriptChatViewModel {
     /// the VM keeps the meeting-Ask attribution for its entire lifetime,
     /// including post-meeting "Continue chat" persistence.
     public func markAsMeetingAskSurface() {
+        // Contract: call once at construction, before any chat activity. A later
+        // call would silently reclassify subsequent `llm_chat_used` telemetry.
+        // Debug-only assert so misuse surfaces in tests/dev without ever crashing
+        // a user's session over a telemetry-attribution slip.
+        assert(
+            chatSource == .transcriptChat && messages.isEmpty && chatHistory.isEmpty,
+            "markAsMeetingAskSurface() must be called once at construction, before any messages are sent"
+        )
         self.chatSource = .meetingAsk
     }
 

--- a/Tests/MacParakeetTests/STT/WhisperLanguageCatalogTests.swift
+++ b/Tests/MacParakeetTests/STT/WhisperLanguageCatalogTests.swift
@@ -124,4 +124,16 @@ final class WhisperLanguageCatalogTests: XCTestCase {
         XCTAssertNil(SpeechEnginePreference.normalizeKnownLanguage("auto"))
         XCTAssertNil(SpeechEnginePreference.normalizeKnownLanguage("/Users/alice/private-model"))
     }
+
+    /// Defensive: engine attributions sometimes arrive as the English name
+    /// (e.g. WhisperKit's fallback path emits "english" / "korean" rather
+    /// than "en" / "ko"). The catalog must canonicalize those back to the
+    /// ISO-2 code so language-attribution telemetry survives the path.
+    func testCanonicalCodeAcceptsEnglishLanguageNames() {
+        XCTAssertEqual(WhisperLanguageCatalog.canonicalCode(for: "english"), "en")
+        XCTAssertEqual(WhisperLanguageCatalog.canonicalCode(for: "Korean"), "ko")
+        XCTAssertEqual(WhisperLanguageCatalog.canonicalCode(for: "  Japanese  "), "ja")
+        XCTAssertEqual(SpeechEnginePreference.normalizeKnownLanguage("english"), "en")
+        XCTAssertEqual(SpeechEnginePreference.normalizeKnownLanguage("Japanese"), "ja")
+    }
 }

--- a/Tests/MacParakeetTests/Services/LLM/LLMServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMServiceTests.swift
@@ -225,7 +225,7 @@ final class LLMServiceTests: XCTestCase {
         mockConfigStore.config = nil
 
         do {
-            _ = try await service.chat(question: "Q", transcript: "T", userNotes: nil, history: [])
+            _ = try await service.chat(question: "Q", transcript: "T", userNotes: nil, history: [], source: .transcriptChat)
             XCTFail("Expected LLMError.notConfigured")
         } catch let error as LLMError {
             if case .notConfigured = error {} else {
@@ -312,7 +312,8 @@ final class LLMServiceTests: XCTestCase {
             question: "What was discussed?",
             transcript: "We talked about the release.",
             userNotes: nil,
-            history: []
+            history: [],
+            source: .transcriptChat
         )
 
         XCTAssertEqual(mockClient.capturedMessages.count, 2)
@@ -332,7 +333,8 @@ final class LLMServiceTests: XCTestCase {
             question: "What did Alice say?",
             transcript: "Alice said hello.",
             userNotes: nil,
-            history: history
+            history: history,
+            source: .transcriptChat
         )
 
         // system + 2 history + user question = 4
@@ -349,7 +351,8 @@ final class LLMServiceTests: XCTestCase {
             question: "Why did we delay?",
             transcript: "Alice: We're slipping by a week.",
             userNotes: "decision: ship Friday\nQA owns smoke tests",
-            history: []
+            history: [],
+            source: .transcriptChat
         )
 
         let systemPrompt = mockClient.capturedMessages[0].content
@@ -369,7 +372,8 @@ final class LLMServiceTests: XCTestCase {
             question: "Q",
             transcript: "T",
             userNotes: nil,
-            history: []
+            history: [],
+            source: .transcriptChat
         )
         XCTAssertFalse(
             mockClient.capturedMessages[0].content.contains("User's notes from the meeting"),
@@ -382,7 +386,8 @@ final class LLMServiceTests: XCTestCase {
             question: "Q",
             transcript: "T",
             userNotes: "",
-            history: []
+            history: [],
+            source: .transcriptChat
         )
         XCTAssertFalse(
             mockClient.capturedMessages[0].content.contains("User's notes from the meeting"),
@@ -395,7 +400,8 @@ final class LLMServiceTests: XCTestCase {
             question: "Q",
             transcript: "T",
             userNotes: "   \n\t  \n  ",
-            history: []
+            history: [],
+            source: .transcriptChat
         )
         XCTAssertFalse(
             mockClient.capturedMessages[0].content.contains("User's notes from the meeting"),
@@ -408,7 +414,8 @@ final class LLMServiceTests: XCTestCase {
             question: "Q",
             transcript: "T",
             userNotes: nil,
-            history: []
+            history: [],
+            source: .transcriptChat
         )
         let withoutNotes = mockClient.capturedMessages[0].content
 
@@ -420,7 +427,8 @@ final class LLMServiceTests: XCTestCase {
             question: "Q",
             transcript: "T",
             userNotes: "   ",
-            history: []
+            history: [],
+            source: .transcriptChat
         )
         let withWhitespace = mockClient.capturedMessages[0].content
         XCTAssertEqual(withoutNotes, withWhitespace)
@@ -468,7 +476,8 @@ final class LLMServiceTests: XCTestCase {
             question: "Who?",
             transcript: "Alice and Bob spoke.",
             userNotes: nil,
-            history: []
+            history: [],
+            source: .transcriptChat
         )
 
         XCTAssertEqual(result.output, "answer")
@@ -884,7 +893,8 @@ final class LLMServiceTests: XCTestCase {
             question: "Latest question",
             transcript: transcript,
             userNotes: nil,
-            history: history
+            history: history,
+            source: .transcriptChat
         )
 
         let messages = mockClient.capturedMessages
@@ -913,7 +923,8 @@ final class LLMServiceTests: XCTestCase {
             question: "New question",
             transcript: transcript,
             userNotes: nil,
-            history: history
+            history: history,
+            source: .transcriptChat
         )
 
         let messages = mockClient.capturedMessages
@@ -939,7 +950,8 @@ final class LLMServiceTests: XCTestCase {
             question: question,
             transcript: transcript,
             userNotes: notes,
-            history: history
+            history: history,
+            source: .transcriptChat
         )
 
         let messages = mockClient.capturedMessages
@@ -967,7 +979,8 @@ final class LLMServiceTests: XCTestCase {
             question: "What should we do next?",
             transcript: "The team discussed delivery risks.",
             userNotes: nil,
-            history: history
+            history: history,
+            source: .transcriptChat
         )
 
         let messages = mockClient.capturedMessages
@@ -995,7 +1008,8 @@ final class LLMServiceTests: XCTestCase {
             question: "What happened?",
             transcript: "Something happened.",
             userNotes: nil,
-            history: []
+            history: [],
+            source: .transcriptChat
         )
 
         var tokens: [String] = []
@@ -1068,7 +1082,7 @@ final class LLMServiceTests: XCTestCase {
 
     func testChatStreamThrowsWhenNotConfigured() async {
         mockConfigStore.config = nil
-        let stream = service.chatStream(question: "Q", transcript: "T", userNotes: nil, history: [])
+        let stream = service.chatStream(question: "Q", transcript: "T", userNotes: nil, history: [], source: .transcriptChat)
 
         do {
             for try await _ in stream {
@@ -1226,7 +1240,7 @@ final class LLMServiceTests: XCTestCase {
         mockClient.chatCompletionError = LLMError.cliError("not found")
 
         do {
-            _ = try await service.chat(question: "Q", transcript: "T", userNotes: nil, history: [])
+            _ = try await service.chat(question: "Q", transcript: "T", userNotes: nil, history: [], source: .transcriptChat)
             XCTFail("Expected throw")
         } catch {}
 
@@ -1313,7 +1327,7 @@ final class LLMServiceTests: XCTestCase {
             isLocal: true
         )
         mockClient.chatCompletionError = LLMError.modelNotFound("missing")
-        let stream = service.chatStream(question: "Q", transcript: "T", userNotes: nil, history: [])
+        let stream = service.chatStream(question: "Q", transcript: "T", userNotes: nil, history: [], source: .transcriptChat)
 
         do {
             for try await _ in stream {}
@@ -1368,7 +1382,7 @@ final class LLMServiceTests: XCTestCase {
         mockClient.chatCompletionError = LLMError.providerError("500 Internal")
 
         do {
-            _ = try await service.chat(question: "Q", transcript: "T", userNotes: nil, history: [])
+            _ = try await service.chat(question: "Q", transcript: "T", userNotes: nil, history: [], source: .transcriptChat)
             XCTFail("Expected throw")
         } catch {}
 

--- a/Tests/MacParakeetTests/Services/Transforms/TransformExecutorTests.swift
+++ b/Tests/MacParakeetTests/Services/Transforms/TransformExecutorTests.swift
@@ -397,7 +397,7 @@ final class MockTransformLLMService: LLMServiceProtocol, @unchecked Sendable {
     }
 
     func generatePromptResult(transcript: String, systemPrompt: String?) async throws -> String { "" }
-    func chat(question: String, transcript: String, userNotes: String?, history: [ChatMessage]) async throws -> String { "" }
+    func chat(question: String, transcript: String, userNotes: String?, history: [ChatMessage], source: TelemetryChatSource) async throws -> String { "" }
     func transform(text: String, prompt: String) async throws -> String { "" }
     func formatTranscript(transcript: String, promptTemplate: String, source: TelemetryFormatterSource, defaultPromptUsed: Bool) async throws -> String { "" }
     func formatTranscriptDetailed(transcript: String, promptTemplate: String, source: TelemetryFormatterSource, defaultPromptUsed: Bool) async throws -> LLMFormatterResult {
@@ -414,7 +414,7 @@ final class MockTransformLLMService: LLMServiceProtocol, @unchecked Sendable {
     func generatePromptResultStream(transcript: String, systemPrompt: String?) -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { $0.finish() }
     }
-    func chatStream(question: String, transcript: String, userNotes: String?, history: [ChatMessage]) -> AsyncThrowingStream<String, Error> {
+    func chatStream(question: String, transcript: String, userNotes: String?, history: [ChatMessage], source: TelemetryChatSource) -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { $0.finish() }
     }
     func transformStream(text: String, prompt: String) -> AsyncThrowingStream<String, Error> {
@@ -433,7 +433,7 @@ final class MockTransformLLMService: LLMServiceProtocol, @unchecked Sendable {
     func generatePromptResultDetailed(transcript: String, systemPrompt: String?) async throws -> LLMResult {
         LLMResult(output: "", provider: "mock", model: "mock", latencyMs: 0)
     }
-    func chatDetailed(question: String, transcript: String, userNotes: String?, history: [ChatMessage]) async throws -> LLMResult {
+    func chatDetailed(question: String, transcript: String, userNotes: String?, history: [ChatMessage], source: TelemetryChatSource) async throws -> LLMResult {
         LLMResult(output: "", provider: "mock", model: "mock", latencyMs: 0)
     }
     func transformDetailed(text: String, prompt: String) async throws -> LLMResult {

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -1111,7 +1111,7 @@ final class TelemetryServiceTests: XCTestCase {
             .exportUsed(format: "txt"),
             .llmPromptResultUsed(provider: "openai"),
             .llmPromptResultFailed(provider: "openai", errorType: "auth"),
-            .llmChatUsed(provider: "openai", messageCount: 3),
+            .llmChatUsed(provider: "openai", source: .transcriptChat, messageCount: 3),
             .llmChatFailed(provider: "openai", errorType: "network"),
             .llmTransformUsed(provider: "openai"),
             .llmTransformFailed(provider: "openai", errorType: "network"),

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -390,7 +390,7 @@ final class TelemetryServiceTests: XCTestCase {
             .transcriptionFailed(source: .file, stage: .stt, errorType: "runtime", errorDetail: rawDetail),
             .diarizationFailed(source: .meeting, errorType: "runtime", errorDetail: rawDetail),
             .llmPromptResultFailed(provider: "openai", errorType: "provider", errorDetail: rawDetail),
-            .llmChatFailed(provider: "openai", errorType: "provider", errorDetail: rawDetail),
+            .llmChatFailed(provider: "openai", source: .transcriptChat, errorType: "provider", errorDetail: rawDetail),
             .llmTransformFailed(provider: "openai", errorType: "provider", errorDetail: rawDetail),
             .licenseActivationFailed(errorType: "network", errorDetail: rawDetail),
             .restoreFailed(errorType: "network", errorDetail: rawDetail),
@@ -1112,7 +1112,7 @@ final class TelemetryServiceTests: XCTestCase {
             .llmPromptResultUsed(provider: "openai"),
             .llmPromptResultFailed(provider: "openai", errorType: "auth"),
             .llmChatUsed(provider: "openai", source: .transcriptChat, messageCount: 3),
-            .llmChatFailed(provider: "openai", errorType: "network"),
+            .llmChatFailed(provider: "openai", source: .transcriptChat, errorType: "network"),
             .llmTransformUsed(provider: "openai"),
             .llmTransformFailed(provider: "openai", errorType: "network"),
             .transformExecuted(

--- a/Tests/MacParakeetTests/ViewModels/TranscriptChatViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptChatViewModelTests.swift
@@ -989,6 +989,36 @@ final class TranscriptChatViewModelTests: XCTestCase {
         XCTAssertEqual(mockService.chatCallCount, chatCallsBefore, "Regenerate must not re-issue when tail isn't an assistant turn")
         XCTAssertEqual(viewModel.messages.count, 1)
     }
+
+    // MARK: - Chat source telemetry attribution
+
+    /// Default-constructed VMs are the post-transcription transcript chat
+    /// surface, so they pass `.transcriptChat` to the LLM service for
+    /// `llm_chat_used` attribution.
+    func testChatSourceDefaultsToTranscriptChat() async throws {
+        viewModel.loadTranscript("Transcript", transcriptionId: UUID())
+        mockService.streamTokens = ["hi"]
+        viewModel.inputText = "Q"
+        viewModel.sendMessage()
+        try await Task.sleep(nanoseconds: 150_000_000)
+
+        XCTAssertEqual(mockService.lastChatSource, .transcriptChat)
+    }
+
+    /// Once `markAsMeetingAskSurface()` flips the VM, every subsequent
+    /// chat call attributes to `.meetingAsk` — including post-meeting
+    /// continuation chats persisted to a conversation. This keeps the live
+    /// Ask telemetry intact even after the meeting finalizes.
+    func testChatSourceBecomesMeetingAskAfterFlip() async throws {
+        viewModel.markAsMeetingAskSurface()
+        viewModel.loadTranscript("Transcript", transcriptionId: UUID())
+        mockService.streamTokens = ["hi"]
+        viewModel.inputText = "Q"
+        viewModel.sendMessage()
+        try await Task.sleep(nanoseconds: 150_000_000)
+
+        XCTAssertEqual(mockService.lastChatSource, .meetingAsk)
+    }
 }
 
 /// Tiny @unchecked-Sendable string box used by the closure-reevaluation test.

--- a/Tests/MacParakeetTests/ViewModels/TranscriptChatViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptChatViewModelTests.swift
@@ -1000,7 +1000,8 @@ final class TranscriptChatViewModelTests: XCTestCase {
         mockService.streamTokens = ["hi"]
         viewModel.inputText = "Q"
         viewModel.sendMessage()
-        try await Task.sleep(nanoseconds: 150_000_000)
+        // Match the 200ms streaming-task settle used throughout this suite.
+        try await Task.sleep(nanoseconds: 200_000_000)
 
         XCTAssertEqual(mockService.lastChatSource, .transcriptChat)
     }
@@ -1015,7 +1016,8 @@ final class TranscriptChatViewModelTests: XCTestCase {
         mockService.streamTokens = ["hi"]
         viewModel.inputText = "Q"
         viewModel.sendMessage()
-        try await Task.sleep(nanoseconds: 150_000_000)
+        // Match the 200ms streaming-task settle used throughout this suite.
+        try await Task.sleep(nanoseconds: 200_000_000)
 
         XCTAssertEqual(mockService.lastChatSource, .meetingAsk)
     }

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -595,6 +595,7 @@ final class MockLLMService: LLMServiceProtocol, @unchecked Sendable {
     var lastChatQuestion: String?
     var lastChatHistory: [ChatMessage]?
     var lastChatUserNotes: String?
+    var lastChatSource: TelemetryChatSource?
     var lastSummarySystemPrompt: String?
     var lastFormattedTranscript: String?
     var lastFormatterPromptTemplate: String?
@@ -608,9 +609,10 @@ final class MockLLMService: LLMServiceProtocol, @unchecked Sendable {
         return summarizeResult
     }
 
-    func chat(question: String, transcript: String, userNotes: String?, history: [ChatMessage]) async throws -> String {
+    func chat(question: String, transcript: String, userNotes: String?, history: [ChatMessage], source: TelemetryChatSource) async throws -> String {
         chatCallCount += 1
         lastChatUserNotes = userNotes
+        lastChatSource = source
         if let error = errorToThrow { throw error }
         return chatResult
     }
@@ -625,8 +627,8 @@ final class MockLLMService: LLMServiceProtocol, @unchecked Sendable {
         return LLMResult(output: output, provider: "mock", model: "mock-model", latencyMs: 0)
     }
 
-    func chatDetailed(question: String, transcript: String, userNotes: String?, history: [ChatMessage]) async throws -> LLMResult {
-        let output = try await chat(question: question, transcript: transcript, userNotes: userNotes, history: history)
+    func chatDetailed(question: String, transcript: String, userNotes: String?, history: [ChatMessage], source: TelemetryChatSource) async throws -> LLMResult {
+        let output = try await chat(question: question, transcript: transcript, userNotes: userNotes, history: history, source: source)
         return LLMResult(output: output, provider: "mock", model: "mock-model", latencyMs: 0)
     }
 
@@ -709,11 +711,12 @@ final class MockLLMService: LLMServiceProtocol, @unchecked Sendable {
         }
     }
 
-    func chatStream(question: String, transcript: String, userNotes: String?, history: [ChatMessage]) -> AsyncThrowingStream<String, Error> {
+    func chatStream(question: String, transcript: String, userNotes: String?, history: [ChatMessage], source: TelemetryChatSource) -> AsyncThrowingStream<String, Error> {
         chatCallCount += 1
         lastChatQuestion = question
         lastChatHistory = history
         lastChatUserNotes = userNotes
+        lastChatSource = source
         let tokens = streamTokens
         let error = errorToThrow
         let delay = streamDelayNs

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -234,7 +234,7 @@ events remain useful for diarization-specific timing and failure analysis.
 | `export_used` | `format` (txt, md, srt, vtt, docx, pdf, json) | Which export formats matter? |
 | `llm_prompt_result_used` | `provider` | Are prompt-library results and generated summaries being used? Which providers matter? |
 | `llm_prompt_result_failed` | `provider`, `error_type` | Failure rates for prompt-library result generation per provider |
-| `llm_chat_used` | `provider`, `message_count` | Do people chat with transcripts? |
+| `llm_chat_used` | `provider`, `source` (`meeting_ask`, `transcript_chat`), `message_count` | Do people chat with transcripts? Live meeting Ask is separable from post-transcription chat. |
 | `llm_chat_failed` | `provider`, `error_type` | Chat failure rates per provider |
 | `llm_transform_used` | `provider` | One-off transform feature usage |
 | `llm_transform_failed` | `provider`, `error_type` | One-off transform failure rates |

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -235,7 +235,7 @@ events remain useful for diarization-specific timing and failure analysis.
 | `llm_prompt_result_used` | `provider` | Are prompt-library results and generated summaries being used? Which providers matter? |
 | `llm_prompt_result_failed` | `provider`, `error_type` | Failure rates for prompt-library result generation per provider |
 | `llm_chat_used` | `provider`, `source` (`meeting_ask`, `transcript_chat`), `message_count` | Do people chat with transcripts? Live meeting Ask is separable from post-transcription chat. |
-| `llm_chat_failed` | `provider`, `error_type` | Chat failure rates per provider |
+| `llm_chat_failed` | `provider`, `source` (`meeting_ask`, `transcript_chat`), `error_type` | Chat failure rates per provider and surface |
 | `llm_transform_used` | `provider` | One-off transform feature usage |
 | `llm_transform_failed` | `provider`, `error_type` | One-off transform failure rates |
 | `transform_executed` | `transform_name`, `capture_path`, `replace_path`, `llm_ms`, `total_ms` | End-to-end system-wide Transform completions by built-in/custom bucket |


### PR DESCRIPTION
## Summary

Closes two telemetry instrumentation gaps surfaced by the 2026-05-19 meeting-recording usage review (`journal/2026-05-19-meeting-recording-usage-deep-dive.md`):

1. **`llm_chat_used` carries a `source`** — a new `TelemetryChatSource` enum (`meeting_ask` | `transcript_chat`) is required on `LLMServiceProtocol.chat / chatStream / chatDetailed` and serialized on the event. `TranscriptChatViewModel` defaults to `.transcriptChat`; `MeetingRecordingPanelViewModel` flips it via `markAsMeetingAskSurface()` so live in-meeting Ask attributes to `meeting_ask` for the VM's lifetime (including post-meeting "Continue chat"). CLI passes `.transcriptChat`. Today's dashboard collapses 211 chat events / 73 sessions into one source-blind bucket; after this, Ask adoption is readable from production data.

2. **Engine-level language attribution** — production confirmed `json_extract(props,'$.language')` was `NULL` across the entire D1 store. Root cause: the Parakeet path returned `STTResult` with no `language:`, so `compactProps` dropped the prop. This attributes `language: "en"` at the Parakeet boundary (honest — MacParakeet exposes Parakeet TDT 0.6B-v3 as English-only in its UI; the call site documents the assumption for a future multilingual exposure). Adds a `byEnglishName` reverse index to `WhisperLanguageCatalog` so WhisperKit's name-form fallback (`"english"` → `"en"`) survives normalization.

## Notes for reviewers

- **No Worker allowlist change needed** — this adds a *prop* (`source`) to the existing `llm_chat_used` event and reuses existing `language` plumbing; no new `TelemetryEventName` cases. (New event *names* would require a companion `macparakeet-website` allowlist change; prop additions do not.)
- This branch was rebased clean onto current `main`. A parallel "Fix LM Studio prompt result generation" commit that originally rode along here was **dropped** — `main` already merged a superset via #315.
- The `language: "en"` Parakeet attribution is complementary to the already-shipped `81571e0e` (which deliberately left Parakeet `nil`); it fills that value at one documented call site.

## Testing

- `swift build` — clean
- `swift test` — **2845 XCTest (9 skipped, 0 failures) + 16 Swift Testing, 0 failures** (~125s)

## ADRs

None — privacy-safe instrumentation only (ADR-012 telemetry, ADR-021 multilingual STT observability). No content collected: `source` is an enum, `language` is a bounded ISO-2 code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
