### PR TITLE
Settings: stop dictation keycap from wrapping for textual shortcuts

### DIFF
--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -2250,7 +2250,7 @@ struct SettingsView: View {
 
             if !viewModel.pushToTalkHotkeyTrigger.isDisabled && !viewModel.hotkeyTrigger.isDisabled {
                 Divider()
-                    .padding(.leading, 88)
+                    .padding(.leading, 108)
             }
 
             if !viewModel.hotkeyTrigger.isDisabled {
@@ -2292,7 +2292,7 @@ struct SettingsView: View {
                     miniSettingsKeyCap(keys[0])
                 }
             }
-            .frame(width: 80, alignment: .center)
+            .frame(minWidth: 100, alignment: .leading)
 
             Text(action)
                 .font(DesignSystem.Typography.bodySmall.weight(.medium))
@@ -2309,6 +2309,8 @@ struct SettingsView: View {
     private func miniSettingsKeyCap(_ label: String) -> some View {
         Text(label)
             .font(.system(size: 10, weight: .medium, design: .rounded))
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
             .padding(.horizontal, 6)
             .padding(.vertical, 3)
             .background(


### PR DESCRIPTION
## Problem

In **Settings → Modes**, the dictation guide's hands-free keycap rendered the default `fn+Space` shortcut across two lines (`fn+Spac` / `e`). The leading verb+keycap group was pinned to a fixed `width: 80, .center`, and the keycap `Text` had no anti-wrap modifier — so a *textual* shortcut (wider than symbol-only caps like `⌥⌘`) overflowed the group and SwiftUI compressed it.

## Fix

- `miniSettingsKeyCap` gains `.lineLimit(1)` + `.fixedSize(horizontal: true, vertical: false)` → the badge always renders its full label on one line.
- Leading group: `.frame(width: 80, alignment: .center)` → `.frame(minWidth: 100, alignment: .leading)` → reserves room for textual caps, left-aligns the verbs, and lets unusually wide custom shortcuts grow rather than clip.
- Divider inset `88 → 108` to track the new action-column start (100 + `Spacing.sm`).

Shortcuts are user-customizable and can be arbitrarily wide, so correctness ("never wrap/clip") comes from `fixedSize`; `minWidth` only governs preferred alignment.

## Notes
- Pure SwiftUI layout change in one private helper region; no logic, no tests affected. `swift build` clean.
- The separate "Labs" notice on the Meeting Recording card (visible in older builds) was already removed on `main` in `df731329` when the feature was productized — not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)