### PR TITLE
Add meeting echo suppression pipeline hooks

### DIFF
--- a/Sources/MacParakeetCore/Services/Capture/CaptureOrchestrator.swift
+++ b/Sources/MacParakeetCore/Services/Capture/CaptureOrchestrator.swift
@@ -77,7 +77,8 @@ actor CaptureOrchestrator {
             if pair.hasMicrophoneSignal {
                 let processedMic = micConditioner.condition(
                     microphone: pair.microphoneSamples,
-                    speaker: pair.systemSamples
+                    speaker: pair.systemSamples,
+                    hasSpeakerReference: pair.hasSystemSignal
                 )
                 processedMicrophoneRms = chunkRms(for: processedMic)
                 micSamples = processedMic

--- a/Sources/MacParakeetCore/Services/Capture/MeetingEchoSuppressionRuntime.swift
+++ b/Sources/MacParakeetCore/Services/Capture/MeetingEchoSuppressionRuntime.swift
@@ -1,6 +1,7 @@
 import CryptoKit
 import Darwin
 import Foundation
+import OSLog
 
 public enum MeetingEchoSuppressionMode: String, Sendable, Equatable {
     case automatic
@@ -17,7 +18,7 @@ public struct MeetingEchoSuppressionConfiguration: Sendable, Equatable {
     public static let sampleRateEnvironmentKey = "MACPARAKEET_MEETING_ECHO_SAMPLE_RATE"
 
     public static let defaultSampleRate = 16_000
-    public static let defaultFrameSize = 512
+    public static let defaultFrameSize = 256
 
     public var mode: MeetingEchoSuppressionMode
     public var libraryURL: URL?
@@ -57,9 +58,9 @@ public struct MeetingEchoSuppressionConfiguration: Sendable, Equatable {
                 return trimmed.isEmpty ? nil : trimmed
             }
         let sampleRate = environment[sampleRateEnvironmentKey]
-            .flatMap(Int.init) ?? defaultSampleRate
+            .flatMap(Self.integerValue(from:)) ?? defaultSampleRate
         let frameSize = environment[frameSizeEnvironmentKey]
-            .flatMap(Int.init) ?? defaultFrameSize
+            .flatMap(Self.integerValue(from:)) ?? defaultFrameSize
 
         return MeetingEchoSuppressionConfiguration(
             mode: mode,
@@ -74,10 +75,17 @@ public struct MeetingEchoSuppressionConfiguration: Sendable, Equatable {
     private static func fileURL(from value: String) -> URL? {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
-        if trimmed.hasPrefix("file://"), let url = URL(string: trimmed) {
-            return url
+        if trimmed.lowercased().hasPrefix("file://") {
+            if let url = URL(string: trimmed), url.isFileURL {
+                return url
+            }
+            return URL(fileURLWithPath: String(trimmed.dropFirst("file://".count)))
         }
         return URL(fileURLWithPath: trimmed)
+    }
+
+    private static func integerValue(from value: String) -> Int? {
+        Int(value.trimmingCharacters(in: .whitespacesAndNewlines))
     }
 }
 
@@ -101,6 +109,10 @@ enum MeetingEchoSuppressionFactory {
     static let defaultLibraryName = "liblocalvqe.dylib"
     static let defaultModelDirectoryName = "MeetingEchoSuppression"
     static let defaultModelName = "localvqe-v1.2-1.3M-f32.gguf"
+    private static let logger = Logger(
+        subsystem: "com.macparakeet.core",
+        category: "MeetingEchoSuppression"
+    )
 
     static func makeConditioner(
         configuration: MeetingEchoSuppressionConfiguration,
@@ -129,7 +141,7 @@ enum MeetingEchoSuppressionFactory {
                 bundle: bundle,
                 fileManager: fileManager
             ) else {
-                return unavailableDynamicConditioner()
+                return unavailableDynamicConditioner(reason: "assets_missing")
             }
             return makeDynamicConditioner(
                 resolved: resolved,
@@ -140,8 +152,15 @@ enum MeetingEchoSuppressionFactory {
     }
 
     static func sha256Hex(for url: URL) throws -> String {
-        let data = try Data(contentsOf: url)
-        let digest = SHA256.hash(data: data)
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+
+        var hasher = SHA256()
+        while let data = try handle.read(upToCount: 1024 * 1024), !data.isEmpty {
+            hasher.update(data: data)
+        }
+
+        let digest = hasher.finalize()
         return digest.map { String(format: "%02x", $0) }.joined()
     }
 
@@ -197,14 +216,14 @@ enum MeetingEchoSuppressionFactory {
             if let expectedSHA = configuration.modelSHA256 {
                 let actualSHA = try sha256Hex(for: resolved.modelURL)
                 guard actualSHA.caseInsensitiveCompare(expectedSHA) == .orderedSame else {
-                    return unavailableDynamicConditioner()
+                    return unavailableDynamicConditioner(reason: "checksum_mismatch")
                 }
             }
 
             guard fileManager.isReadableFile(atPath: resolved.libraryURL.path),
                   fileManager.isReadableFile(atPath: resolved.modelURL.path)
             else {
-                return unavailableDynamicConditioner()
+                return unavailableDynamicConditioner(reason: "assets_not_readable")
             }
 
             let processor = try DynamicLibraryMeetingEchoProcessor(
@@ -215,12 +234,24 @@ enum MeetingEchoSuppressionFactory {
             )
             return StreamingMeetingEchoSuppressor(processor: processor)
         } catch {
-            return unavailableDynamicConditioner()
+            return unavailableDynamicConditioner(reason: "load_failed", error: error)
         }
     }
 
-    private static func unavailableDynamicConditioner() -> any MicConditioning {
-        PassthroughMicConditioner(processorName: processorName, loaded: false)
+    private static func unavailableDynamicConditioner(
+        reason: String,
+        error: (any Error)? = nil
+    ) -> any MicConditioning {
+        if let error {
+            logger.warning(
+                "meeting_echo_processor_unavailable reason=\(reason, privacy: .public) error=\(String(describing: error), privacy: .private)"
+            )
+        } else {
+            logger.warning(
+                "meeting_echo_processor_unavailable reason=\(reason, privacy: .public)"
+            )
+        }
+        return PassthroughMicConditioner(processorName: processorName, loaded: false)
     }
 }
 
@@ -229,7 +260,7 @@ private enum DynamicLibraryMeetingEchoProcessorError: Error, CustomStringConvert
     case missingSymbol(String)
     case createFailed(String)
     case invalidFrameSize(expected: Int, microphone: Int, reference: Int)
-    case processingFailed(Int32)
+    case processingFailed(code: Int32, message: String)
 
     var description: String {
         switch self {
@@ -241,8 +272,8 @@ private enum DynamicLibraryMeetingEchoProcessorError: Error, CustomStringConvert
             return "create failed: \(message)"
         case let .invalidFrameSize(expected, microphone, reference):
             return "invalid frame size: expected=\(expected) microphone=\(microphone) reference=\(reference)"
-        case .processingFailed(let code):
-            return "processing failed: \(code)"
+        case let .processingFailed(code, message):
+            return "processing failed: code=\(code) message=\(message)"
         }
     }
 }
@@ -275,7 +306,11 @@ final class DynamicLibraryMeetingEchoProcessor: MeetingEchoSuppressing, @uncheck
     private let lock = NSLock()
 
     init(libraryURL: URL, modelURL: URL, sampleRate: Int, frameSize: Int) throws {
-        guard let handle = dlopen(libraryURL.path, RTLD_NOW | RTLD_LOCAL) else {
+        let loadedHandle = libraryURL.withUnsafeFileSystemRepresentation { path -> UnsafeMutableRawPointer? in
+            guard let path else { return nil }
+            return dlopen(path, RTLD_NOW | RTLD_LOCAL)
+        }
+        guard let handle = loadedHandle else {
             throw DynamicLibraryMeetingEchoProcessorError.libraryLoadFailed(Self.lastDLError())
         }
 
@@ -296,11 +331,14 @@ final class DynamicLibraryMeetingEchoProcessor: MeetingEchoSuppressing, @uncheck
                 "localvqe_last_error",
                 from: handle
             )
-            let context = modelURL.path.withCString { modelPath in
-                create(modelPath)
+            let context: ContextHandle = modelURL.withUnsafeFileSystemRepresentation { modelPath -> ContextHandle in
+                guard let modelPath else { return 0 }
+                return create(modelPath)
             }
             guard context != 0 else {
-                throw DynamicLibraryMeetingEchoProcessorError.createFailed("unknown")
+                throw DynamicLibraryMeetingEchoProcessorError.createFailed(
+                    "context allocation returned null"
+                )
             }
 
             self.handle = handle
@@ -328,8 +366,11 @@ final class DynamicLibraryMeetingEchoProcessor: MeetingEchoSuppressing, @uncheck
         resetFunction(context)
     }
 
-    func processFrame(microphone: [Float], reference: [Float]) throws -> [Float] {
-        guard microphone.count == frameSize, reference.count == frameSize else {
+    func processFrame(microphone: [Float], reference: [Float], output: inout [Float]) throws {
+        guard microphone.count == frameSize,
+              reference.count == frameSize,
+              output.count == frameSize
+        else {
             throw DynamicLibraryMeetingEchoProcessorError.invalidFrameSize(
                 expected: frameSize,
                 microphone: microphone.count,
@@ -337,7 +378,6 @@ final class DynamicLibraryMeetingEchoProcessor: MeetingEchoSuppressing, @uncheck
             )
         }
 
-        var output = [Float](repeating: 0, count: frameSize)
         lock.lock()
         defer { lock.unlock() }
         let result = microphone.withUnsafeBufferPointer { microphoneBuffer in
@@ -354,9 +394,15 @@ final class DynamicLibraryMeetingEchoProcessor: MeetingEchoSuppressing, @uncheck
             }
         }
         guard result == 0 else {
-            throw DynamicLibraryMeetingEchoProcessorError.processingFailed(result)
+            let message = Self.lastLocalVQEError(
+                context: context,
+                lastErrorFunction: lastErrorFunction
+            )
+            throw DynamicLibraryMeetingEchoProcessorError.processingFailed(
+                code: result,
+                message: message
+            )
         }
-        return output
     }
 
     private static func loadSymbol<T>(

--- a/Sources/MacParakeetCore/Services/Capture/MeetingEchoSuppressionRuntime.swift
+++ b/Sources/MacParakeetCore/Services/Capture/MeetingEchoSuppressionRuntime.swift
@@ -1,0 +1,402 @@
+import CryptoKit
+import Darwin
+import Foundation
+
+public enum MeetingEchoSuppressionMode: String, Sendable, Equatable {
+    case automatic
+    case off
+    case dynamicLibrary
+}
+
+public struct MeetingEchoSuppressionConfiguration: Sendable, Equatable {
+    public static let modeEnvironmentKey = "MACPARAKEET_MEETING_ECHO_SUPPRESSION"
+    public static let libraryPathEnvironmentKey = "MACPARAKEET_MEETING_ECHO_LIBRARY"
+    public static let modelPathEnvironmentKey = "MACPARAKEET_MEETING_ECHO_MODEL"
+    public static let modelSHA256EnvironmentKey = "MACPARAKEET_MEETING_ECHO_MODEL_SHA256"
+    public static let frameSizeEnvironmentKey = "MACPARAKEET_MEETING_ECHO_FRAME_SIZE"
+    public static let sampleRateEnvironmentKey = "MACPARAKEET_MEETING_ECHO_SAMPLE_RATE"
+
+    public static let defaultSampleRate = 16_000
+    public static let defaultFrameSize = 512
+
+    public var mode: MeetingEchoSuppressionMode
+    public var libraryURL: URL?
+    public var modelURL: URL?
+    public var modelSHA256: String?
+    public var sampleRate: Int
+    public var frameSize: Int
+
+    public init(
+        mode: MeetingEchoSuppressionMode = .automatic,
+        libraryURL: URL? = nil,
+        modelURL: URL? = nil,
+        modelSHA256: String? = nil,
+        sampleRate: Int = Self.defaultSampleRate,
+        frameSize: Int = Self.defaultFrameSize
+    ) {
+        self.mode = mode
+        self.libraryURL = libraryURL
+        self.modelURL = modelURL
+        self.modelSHA256 = modelSHA256
+        self.sampleRate = max(1, sampleRate)
+        self.frameSize = max(1, frameSize)
+    }
+
+    public static func fromEnvironment(
+        _ environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> MeetingEchoSuppressionConfiguration {
+        let mode = environment[modeEnvironmentKey]
+            .flatMap(MeetingEchoSuppressionMode.init(environmentValue:)) ?? .automatic
+        let libraryURL = environment[libraryPathEnvironmentKey]
+            .flatMap { Self.fileURL(from: $0) }
+        let modelURL = environment[modelPathEnvironmentKey]
+            .flatMap { Self.fileURL(from: $0) }
+        let modelSHA256 = environment[modelSHA256EnvironmentKey]
+            .flatMap { value in
+                let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+                return trimmed.isEmpty ? nil : trimmed
+            }
+        let sampleRate = environment[sampleRateEnvironmentKey]
+            .flatMap(Int.init) ?? defaultSampleRate
+        let frameSize = environment[frameSizeEnvironmentKey]
+            .flatMap(Int.init) ?? defaultFrameSize
+
+        return MeetingEchoSuppressionConfiguration(
+            mode: mode,
+            libraryURL: libraryURL,
+            modelURL: modelURL,
+            modelSHA256: modelSHA256,
+            sampleRate: sampleRate,
+            frameSize: frameSize
+        )
+    }
+
+    private static func fileURL(from value: String) -> URL? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if trimmed.hasPrefix("file://"), let url = URL(string: trimmed) {
+            return url
+        }
+        return URL(fileURLWithPath: trimmed)
+    }
+}
+
+private extension MeetingEchoSuppressionMode {
+    init?(environmentValue: String) {
+        switch environmentValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "auto", "automatic":
+            self = .automatic
+        case "off", "none", "disabled", "passthrough":
+            self = .off
+        case "dynamic", "dynamic-library", "dynamic_library", "localvqe":
+            self = .dynamicLibrary
+        default:
+            return nil
+        }
+    }
+}
+
+enum MeetingEchoSuppressionFactory {
+    static let processorName = "localvqe"
+    static let defaultLibraryName = "liblocalvqe.dylib"
+    static let defaultModelDirectoryName = "MeetingEchoSuppression"
+    static let defaultModelName = "localvqe-v1.2-1.3M-f32.gguf"
+
+    static func makeConditioner(
+        configuration: MeetingEchoSuppressionConfiguration,
+        bundle: Bundle = .main,
+        fileManager: FileManager = .default
+    ) -> any MicConditioning {
+        switch configuration.mode {
+        case .off:
+            return PassthroughMicConditioner()
+        case .automatic:
+            guard let resolved = resolveDynamicAssets(
+                configuration: configuration,
+                bundle: bundle,
+                fileManager: fileManager
+            ) else {
+                return PassthroughMicConditioner()
+            }
+            return makeDynamicConditioner(
+                resolved: resolved,
+                configuration: configuration,
+                fileManager: fileManager
+            )
+        case .dynamicLibrary:
+            guard let resolved = resolveDynamicAssets(
+                configuration: configuration,
+                bundle: bundle,
+                fileManager: fileManager
+            ) else {
+                return unavailableDynamicConditioner()
+            }
+            return makeDynamicConditioner(
+                resolved: resolved,
+                configuration: configuration,
+                fileManager: fileManager
+            )
+        }
+    }
+
+    static func sha256Hex(for url: URL) throws -> String {
+        let data = try Data(contentsOf: url)
+        let digest = SHA256.hash(data: data)
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private struct DynamicAssets {
+        let libraryURL: URL
+        let modelURL: URL
+    }
+
+    private static func resolveDynamicAssets(
+        configuration: MeetingEchoSuppressionConfiguration,
+        bundle: Bundle,
+        fileManager: FileManager
+    ) -> DynamicAssets? {
+        let libraryURL = existingFile(
+            candidates: [
+                configuration.libraryURL,
+                bundle.privateFrameworksURL?.appendingPathComponent(defaultLibraryName),
+                bundle.resourceURL?.appendingPathComponent(defaultLibraryName),
+            ],
+            fileManager: fileManager
+        )
+        let modelURL = existingFile(
+            candidates: [
+                configuration.modelURL,
+                bundle.resourceURL?
+                    .appendingPathComponent(defaultModelDirectoryName)
+                    .appendingPathComponent(defaultModelName),
+            ],
+            fileManager: fileManager
+        )
+
+        guard let libraryURL, let modelURL else { return nil }
+        return DynamicAssets(libraryURL: libraryURL, modelURL: modelURL)
+    }
+
+    private static func existingFile(
+        candidates: [URL?],
+        fileManager: FileManager
+    ) -> URL? {
+        candidates.compactMap { $0 }.first { url in
+            var isDirectory: ObjCBool = false
+            return fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory)
+                && !isDirectory.boolValue
+        }
+    }
+
+    private static func makeDynamicConditioner(
+        resolved: DynamicAssets,
+        configuration: MeetingEchoSuppressionConfiguration,
+        fileManager: FileManager
+    ) -> any MicConditioning {
+        do {
+            if let expectedSHA = configuration.modelSHA256 {
+                let actualSHA = try sha256Hex(for: resolved.modelURL)
+                guard actualSHA.caseInsensitiveCompare(expectedSHA) == .orderedSame else {
+                    return unavailableDynamicConditioner()
+                }
+            }
+
+            guard fileManager.isReadableFile(atPath: resolved.libraryURL.path),
+                  fileManager.isReadableFile(atPath: resolved.modelURL.path)
+            else {
+                return unavailableDynamicConditioner()
+            }
+
+            let processor = try DynamicLibraryMeetingEchoProcessor(
+                libraryURL: resolved.libraryURL,
+                modelURL: resolved.modelURL,
+                sampleRate: configuration.sampleRate,
+                frameSize: configuration.frameSize
+            )
+            return StreamingMeetingEchoSuppressor(processor: processor)
+        } catch {
+            return unavailableDynamicConditioner()
+        }
+    }
+
+    private static func unavailableDynamicConditioner() -> any MicConditioning {
+        PassthroughMicConditioner(processorName: processorName, loaded: false)
+    }
+}
+
+private enum DynamicLibraryMeetingEchoProcessorError: Error, CustomStringConvertible {
+    case libraryLoadFailed(String)
+    case missingSymbol(String)
+    case createFailed(String)
+    case invalidFrameSize(expected: Int, microphone: Int, reference: Int)
+    case processingFailed(Int32)
+
+    var description: String {
+        switch self {
+        case .libraryLoadFailed(let message):
+            return "library load failed: \(message)"
+        case .missingSymbol(let symbol):
+            return "missing symbol: \(symbol)"
+        case .createFailed(let message):
+            return "create failed: \(message)"
+        case let .invalidFrameSize(expected, microphone, reference):
+            return "invalid frame size: expected=\(expected) microphone=\(microphone) reference=\(reference)"
+        case .processingFailed(let code):
+            return "processing failed: \(code)"
+        }
+    }
+}
+
+final class DynamicLibraryMeetingEchoProcessor: MeetingEchoSuppressing, @unchecked Sendable {
+    private typealias ContextHandle = UInt
+    private typealias NewFunction = @convention(c) (UnsafePointer<CChar>) -> ContextHandle
+    private typealias ProcessFunction = @convention(c) (
+        ContextHandle,
+        UnsafePointer<Float>,
+        UnsafePointer<Float>,
+        Int32,
+        UnsafeMutablePointer<Float>
+    ) -> Int32
+    private typealias ResetFunction = @convention(c) (ContextHandle) -> Void
+    private typealias FreeFunction = @convention(c) (ContextHandle) -> Void
+    private typealias IntegerGetterFunction = @convention(c) (ContextHandle) -> Int32
+    private typealias LastErrorFunction = @convention(c) (ContextHandle) -> UnsafePointer<CChar>?
+
+    let name = MeetingEchoSuppressionFactory.processorName
+    let sampleRate: Int
+    let frameSize: Int
+
+    private let handle: UnsafeMutableRawPointer
+    private let context: ContextHandle
+    private let processFunction: ProcessFunction
+    private let resetFunction: ResetFunction
+    private let freeFunction: FreeFunction
+    private let lastErrorFunction: LastErrorFunction?
+    private let lock = NSLock()
+
+    init(libraryURL: URL, modelURL: URL, sampleRate: Int, frameSize: Int) throws {
+        guard let handle = dlopen(libraryURL.path, RTLD_NOW | RTLD_LOCAL) else {
+            throw DynamicLibraryMeetingEchoProcessorError.libraryLoadFailed(Self.lastDLError())
+        }
+
+        do {
+            let create: NewFunction = try Self.loadSymbol("localvqe_new", from: handle)
+            let process: ProcessFunction = try Self.loadSymbol("localvqe_process_frame_f32", from: handle)
+            let reset: ResetFunction = try Self.loadSymbol("localvqe_reset", from: handle)
+            let free: FreeFunction = try Self.loadSymbol("localvqe_free", from: handle)
+            let sampleRateGetter: IntegerGetterFunction? = Self.loadOptionalSymbol(
+                "localvqe_sample_rate",
+                from: handle
+            )
+            let hopLengthGetter: IntegerGetterFunction? = Self.loadOptionalSymbol(
+                "localvqe_hop_length",
+                from: handle
+            )
+            let lastError: LastErrorFunction? = Self.loadOptionalSymbol(
+                "localvqe_last_error",
+                from: handle
+            )
+            let context = modelURL.path.withCString { modelPath in
+                create(modelPath)
+            }
+            guard context != 0 else {
+                throw DynamicLibraryMeetingEchoProcessorError.createFailed("unknown")
+            }
+
+            self.handle = handle
+            self.context = context
+            self.processFunction = process
+            self.resetFunction = reset
+            self.freeFunction = free
+            self.lastErrorFunction = lastError
+            self.sampleRate = Self.validPositiveInt(sampleRateGetter?(context)) ?? sampleRate
+            self.frameSize = Self.validPositiveInt(hopLengthGetter?(context)) ?? frameSize
+        } catch {
+            dlclose(handle)
+            throw error
+        }
+    }
+
+    deinit {
+        freeFunction(context)
+        dlclose(handle)
+    }
+
+    func reset() {
+        lock.lock()
+        defer { lock.unlock() }
+        resetFunction(context)
+    }
+
+    func processFrame(microphone: [Float], reference: [Float]) throws -> [Float] {
+        guard microphone.count == frameSize, reference.count == frameSize else {
+            throw DynamicLibraryMeetingEchoProcessorError.invalidFrameSize(
+                expected: frameSize,
+                microphone: microphone.count,
+                reference: reference.count
+            )
+        }
+
+        var output = [Float](repeating: 0, count: frameSize)
+        lock.lock()
+        defer { lock.unlock() }
+        let result = microphone.withUnsafeBufferPointer { microphoneBuffer in
+            reference.withUnsafeBufferPointer { referenceBuffer in
+                output.withUnsafeMutableBufferPointer { outputBuffer in
+                    processFunction(
+                        context,
+                        microphoneBuffer.baseAddress!,
+                        referenceBuffer.baseAddress!,
+                        Int32(frameSize),
+                        outputBuffer.baseAddress!
+                    )
+                }
+            }
+        }
+        guard result == 0 else {
+            throw DynamicLibraryMeetingEchoProcessorError.processingFailed(result)
+        }
+        return output
+    }
+
+    private static func loadSymbol<T>(
+        _ name: String,
+        from handle: UnsafeMutableRawPointer
+    ) throws -> T {
+        guard let symbol = dlsym(handle, name) else {
+            throw DynamicLibraryMeetingEchoProcessorError.missingSymbol(name)
+        }
+        return unsafeBitCast(symbol, to: T.self)
+    }
+
+    private static func loadOptionalSymbol<T>(
+        _ name: String,
+        from handle: UnsafeMutableRawPointer
+    ) -> T? {
+        guard let symbol = dlsym(handle, name) else {
+            return nil
+        }
+        return unsafeBitCast(symbol, to: T.self)
+    }
+
+    private static func lastDLError() -> String {
+        guard let error = dlerror() else { return "unknown" }
+        return String(cString: error)
+    }
+
+    private static func lastLocalVQEError(
+        context: ContextHandle,
+        lastErrorFunction: LastErrorFunction?
+    ) -> String {
+        guard let pointer = lastErrorFunction?(context) else {
+            return "unknown"
+        }
+        let message = String(cString: pointer)
+        return message.isEmpty ? "unknown" : message
+    }
+
+    private static func validPositiveInt(_ value: Int32?) -> Int? {
+        guard let value, value > 0 else { return nil }
+        return Int(value)
+    }
+}

--- a/Sources/MacParakeetCore/Services/Capture/MicConditioner.swift
+++ b/Sources/MacParakeetCore/Services/Capture/MicConditioner.swift
@@ -34,7 +34,7 @@ protocol MeetingEchoSuppressing: AnyObject, Sendable {
     var sampleRate: Int { get }
     var frameSize: Int { get }
     func reset()
-    func processFrame(microphone: [Float], reference: [Float]) throws -> [Float]
+    func processFrame(microphone: [Float], reference: [Float], output: inout [Float]) throws
 }
 
 protocol MicConditioning: AnyObject, Sendable {
@@ -55,12 +55,19 @@ extension MicConditioning {
 final class PassthroughMicConditioner: MicConditioning, @unchecked Sendable {
     private let processorName: String
     private let loaded: Bool
-    private(set) var diagnostics: MeetingEchoSuppressionDiagnostics
+    private let lock = NSLock()
+    private var diagnosticsStorage: MeetingEchoSuppressionDiagnostics
+
+    var diagnostics: MeetingEchoSuppressionDiagnostics {
+        lock.lock()
+        defer { lock.unlock() }
+        return diagnosticsStorage
+    }
 
     init(processorName: String = "passthrough", loaded: Bool = true) {
         self.processorName = processorName
         self.loaded = loaded
-        self.diagnostics = MeetingEchoSuppressionDiagnostics.passthrough(
+        self.diagnosticsStorage = MeetingEchoSuppressionDiagnostics.passthrough(
             processorName: processorName,
             loaded: loaded
         )
@@ -71,7 +78,9 @@ final class PassthroughMicConditioner: MicConditioning, @unchecked Sendable {
     }
 
     func reset() {
-        diagnostics = MeetingEchoSuppressionDiagnostics.passthrough(
+        lock.lock()
+        defer { lock.unlock() }
+        diagnosticsStorage = MeetingEchoSuppressionDiagnostics.passthrough(
             processorName: processorName,
             loaded: loaded
         )
@@ -80,11 +89,18 @@ final class PassthroughMicConditioner: MicConditioning, @unchecked Sendable {
 
 final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable {
     private let processor: any MeetingEchoSuppressing
-    private(set) var diagnostics: MeetingEchoSuppressionDiagnostics
+    private let lock = NSLock()
+    private var diagnosticsStorage: MeetingEchoSuppressionDiagnostics
+
+    var diagnostics: MeetingEchoSuppressionDiagnostics {
+        lock.lock()
+        defer { lock.unlock() }
+        return diagnosticsStorage
+    }
 
     init(processor: any MeetingEchoSuppressing) {
         self.processor = processor
-        self.diagnostics = MeetingEchoSuppressionDiagnostics(
+        self.diagnosticsStorage = MeetingEchoSuppressionDiagnostics(
             processorName: processor.name,
             loaded: true,
             micFrames: 0,
@@ -103,44 +119,50 @@ final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable
         let frameSize = max(processor.frameSize, 1)
         var output: [Float] = []
         output.reserveCapacity(microphone.count)
+        var micFrame = [Float](repeating: 0, count: frameSize)
+        var referenceFrame = [Float](repeating: 0, count: frameSize)
+        var processedFrame = [Float](repeating: 0, count: frameSize)
 
+        lock.lock()
+        defer { lock.unlock() }
         var cursor = 0
         while cursor + frameSize <= microphone.count {
-            let micFrame = Array(microphone[cursor..<(cursor + frameSize)])
-            let referenceFrame = makeReferenceFrame(
+            copyFrame(from: microphone, start: cursor, into: &micFrame)
+            let referenceQuality = fillReferenceFrame(
+                &referenceFrame,
                 speaker: speaker,
                 start: cursor,
-                count: frameSize,
                 hasSpeakerReference: hasSpeakerReference
             )
 
-            diagnostics.micFrames += 1
-            switch referenceFrame.quality {
+            diagnosticsStorage.micFrames += 1
+            switch referenceQuality {
             case .full:
-                diagnostics.fullReferenceFrames += 1
+                diagnosticsStorage.fullReferenceFrames += 1
             case .partial:
-                diagnostics.partialReferenceFrames += 1
+                diagnosticsStorage.partialReferenceFrames += 1
             case .missing:
-                diagnostics.missingReferenceFrames += 1
+                diagnosticsStorage.missingReferenceFrames += 1
             }
 
             do {
-                let processed = try processor.processFrame(
+                try processor.processFrame(
                     microphone: micFrame,
-                    reference: referenceFrame.samples
+                    reference: referenceFrame,
+                    output: &processedFrame
                 )
-                if processed.count == frameSize {
-                    output.append(contentsOf: processed)
-                    diagnostics.processedFrames += 1
+                if processedFrame.count == frameSize {
+                    output.append(contentsOf: processedFrame)
+                    diagnosticsStorage.processedFrames += 1
                 } else {
                     output.append(contentsOf: micFrame)
-                    diagnostics.rawFallbackFrames += 1
-                    diagnostics.processingFailures += 1
+                    diagnosticsStorage.rawFallbackFrames += 1
+                    diagnosticsStorage.processingFailures += 1
                 }
             } catch {
                 output.append(contentsOf: micFrame)
-                diagnostics.rawFallbackFrames += 1
-                diagnostics.processingFailures += 1
+                diagnosticsStorage.rawFallbackFrames += 1
+                diagnosticsStorage.processingFailures += 1
             }
 
             cursor += frameSize
@@ -148,15 +170,17 @@ final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable
 
         if cursor < microphone.count {
             output.append(contentsOf: microphone[cursor...])
-            diagnostics.rawFallbackFrames += 1
+            diagnosticsStorage.rawFallbackFrames += 1
         }
 
         return output
     }
 
     func reset() {
+        lock.lock()
+        defer { lock.unlock() }
         processor.reset()
-        diagnostics = MeetingEchoSuppressionDiagnostics(
+        diagnosticsStorage = MeetingEchoSuppressionDiagnostics(
             processorName: processor.name,
             loaded: true,
             micFrames: 0,
@@ -175,27 +199,45 @@ final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable
         case missing
     }
 
-    private func makeReferenceFrame(
+    private func copyFrame(
+        from samples: [Float],
+        start: Int,
+        into frame: inout [Float]
+    ) {
+        for offset in frame.indices {
+            frame[offset] = samples[start + offset]
+        }
+    }
+
+    private func fillReferenceFrame(
+        _ frame: inout [Float],
         speaker: [Float],
         start: Int,
-        count: Int,
         hasSpeakerReference: Bool
-    ) -> (samples: [Float], quality: ReferenceQuality) {
-        guard hasSpeakerReference, !speaker.isEmpty, start < speaker.count else {
-            return ([Float](repeating: 0, count: count), .missing)
+    ) -> ReferenceQuality {
+        for index in frame.indices {
+            frame[index] = 0
         }
 
-        if start + count <= speaker.count {
-            return (Array(speaker[start..<(start + count)]), .full)
+        guard hasSpeakerReference, !speaker.isEmpty, start < speaker.count else {
+            return .missing
+        }
+
+        if start + frame.count <= speaker.count {
+            for offset in frame.indices {
+                frame[offset] = speaker[start + offset]
+            }
+            return .full
         }
 
         let available = speaker.count - start
         guard available > 0 else {
-            return ([Float](repeating: 0, count: count), .missing)
+            return .missing
         }
 
-        var frame = [Float](repeating: 0, count: count)
-        frame.replaceSubrange(0..<available, with: speaker[start..<speaker.count])
-        return (frame, .partial)
+        for offset in 0..<available {
+            frame[offset] = speaker[start + offset]
+        }
+        return .partial
     }
 }

--- a/Sources/MacParakeetCore/Services/Capture/MicConditioner.swift
+++ b/Sources/MacParakeetCore/Services/Capture/MicConditioner.swift
@@ -11,9 +11,12 @@ struct MeetingEchoSuppressionDiagnostics: Sendable, Equatable {
     var missingReferenceFrames: Int
     var processingFailures: Int
 
-    static func passthrough(loaded: Bool = true) -> MeetingEchoSuppressionDiagnostics {
+    static func passthrough(
+        processorName: String = "passthrough",
+        loaded: Bool = true
+    ) -> MeetingEchoSuppressionDiagnostics {
         MeetingEchoSuppressionDiagnostics(
-            processorName: "passthrough",
+            processorName: processorName,
             loaded: loaded,
             micFrames: 0,
             processedFrames: 0,
@@ -50,14 +53,28 @@ extension MicConditioning {
 /// mic capture and only enables model-backed cleanup when a local processor is
 /// explicitly configured and loaded.
 final class PassthroughMicConditioner: MicConditioning, @unchecked Sendable {
-    private(set) var diagnostics = MeetingEchoSuppressionDiagnostics.passthrough()
+    private let processorName: String
+    private let loaded: Bool
+    private(set) var diagnostics: MeetingEchoSuppressionDiagnostics
+
+    init(processorName: String = "passthrough", loaded: Bool = true) {
+        self.processorName = processorName
+        self.loaded = loaded
+        self.diagnostics = MeetingEchoSuppressionDiagnostics.passthrough(
+            processorName: processorName,
+            loaded: loaded
+        )
+    }
 
     func condition(microphone: [Float], speaker: [Float], hasSpeakerReference: Bool) -> [Float] {
         microphone
     }
 
     func reset() {
-        diagnostics = MeetingEchoSuppressionDiagnostics.passthrough()
+        diagnostics = MeetingEchoSuppressionDiagnostics.passthrough(
+            processorName: processorName,
+            loaded: loaded
+        )
     }
 }
 

--- a/Sources/MacParakeetCore/Services/Capture/MicConditioner.swift
+++ b/Sources/MacParakeetCore/Services/Capture/MicConditioner.swift
@@ -1,19 +1,184 @@
 import Foundation
 
+struct MeetingEchoSuppressionDiagnostics: Sendable, Equatable {
+    var processorName: String
+    var loaded: Bool
+    var micFrames: Int
+    var processedFrames: Int
+    var rawFallbackFrames: Int
+    var fullReferenceFrames: Int
+    var partialReferenceFrames: Int
+    var missingReferenceFrames: Int
+    var processingFailures: Int
+
+    static func passthrough(loaded: Bool = true) -> MeetingEchoSuppressionDiagnostics {
+        MeetingEchoSuppressionDiagnostics(
+            processorName: "passthrough",
+            loaded: loaded,
+            micFrames: 0,
+            processedFrames: 0,
+            rawFallbackFrames: 0,
+            fullReferenceFrames: 0,
+            partialReferenceFrames: 0,
+            missingReferenceFrames: 0,
+            processingFailures: 0
+        )
+    }
+}
+
+protocol MeetingEchoSuppressing: AnyObject, Sendable {
+    var name: String { get }
+    var sampleRate: Int { get }
+    var frameSize: Int { get }
+    func reset()
+    func processFrame(microphone: [Float], reference: [Float]) throws -> [Float]
+}
+
 protocol MicConditioning: AnyObject, Sendable {
-    func condition(microphone: [Float], speaker: [Float]) -> [Float]
+    var diagnostics: MeetingEchoSuppressionDiagnostics { get }
+    func condition(microphone: [Float], speaker: [Float], hasSpeakerReference: Bool) -> [Float]
     func reset()
 }
 
-/// No-op pass-through. The mic stream is cleaned upstream by macOS
-/// Voice Processing I/O (engaged via `MeetingMicProcessingMode.vpioPreferred`).
-/// Used both when VPIO engages (mic is already AEC'd) and as the fallback
-/// when VPIO fails to engage (mic is raw — speaker bleed will be present
-/// and logged loudly so we know it happened).
-final class PassthroughMicConditioner: MicConditioning {
+extension MicConditioning {
     func condition(microphone: [Float], speaker: [Float]) -> [Float] {
+        condition(microphone: microphone, speaker: speaker, hasSpeakerReference: !speaker.isEmpty)
+    }
+}
+
+/// No-op pass-through. This is the call-safe baseline: MacParakeet keeps raw
+/// mic capture and only enables model-backed cleanup when a local processor is
+/// explicitly configured and loaded.
+final class PassthroughMicConditioner: MicConditioning, @unchecked Sendable {
+    private(set) var diagnostics = MeetingEchoSuppressionDiagnostics.passthrough()
+
+    func condition(microphone: [Float], speaker: [Float], hasSpeakerReference: Bool) -> [Float] {
         microphone
     }
 
-    func reset() {}
+    func reset() {
+        diagnostics = MeetingEchoSuppressionDiagnostics.passthrough()
+    }
+}
+
+final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable {
+    private let processor: any MeetingEchoSuppressing
+    private(set) var diagnostics: MeetingEchoSuppressionDiagnostics
+
+    init(processor: any MeetingEchoSuppressing) {
+        self.processor = processor
+        self.diagnostics = MeetingEchoSuppressionDiagnostics(
+            processorName: processor.name,
+            loaded: true,
+            micFrames: 0,
+            processedFrames: 0,
+            rawFallbackFrames: 0,
+            fullReferenceFrames: 0,
+            partialReferenceFrames: 0,
+            missingReferenceFrames: 0,
+            processingFailures: 0
+        )
+    }
+
+    func condition(microphone: [Float], speaker: [Float], hasSpeakerReference: Bool) -> [Float] {
+        guard !microphone.isEmpty else { return [] }
+
+        let frameSize = max(processor.frameSize, 1)
+        var output: [Float] = []
+        output.reserveCapacity(microphone.count)
+
+        var cursor = 0
+        while cursor + frameSize <= microphone.count {
+            let micFrame = Array(microphone[cursor..<(cursor + frameSize)])
+            let referenceFrame = makeReferenceFrame(
+                speaker: speaker,
+                start: cursor,
+                count: frameSize,
+                hasSpeakerReference: hasSpeakerReference
+            )
+
+            diagnostics.micFrames += 1
+            switch referenceFrame.quality {
+            case .full:
+                diagnostics.fullReferenceFrames += 1
+            case .partial:
+                diagnostics.partialReferenceFrames += 1
+            case .missing:
+                diagnostics.missingReferenceFrames += 1
+            }
+
+            do {
+                let processed = try processor.processFrame(
+                    microphone: micFrame,
+                    reference: referenceFrame.samples
+                )
+                if processed.count == frameSize {
+                    output.append(contentsOf: processed)
+                    diagnostics.processedFrames += 1
+                } else {
+                    output.append(contentsOf: micFrame)
+                    diagnostics.rawFallbackFrames += 1
+                    diagnostics.processingFailures += 1
+                }
+            } catch {
+                output.append(contentsOf: micFrame)
+                diagnostics.rawFallbackFrames += 1
+                diagnostics.processingFailures += 1
+            }
+
+            cursor += frameSize
+        }
+
+        if cursor < microphone.count {
+            output.append(contentsOf: microphone[cursor...])
+            diagnostics.rawFallbackFrames += 1
+        }
+
+        return output
+    }
+
+    func reset() {
+        processor.reset()
+        diagnostics = MeetingEchoSuppressionDiagnostics(
+            processorName: processor.name,
+            loaded: true,
+            micFrames: 0,
+            processedFrames: 0,
+            rawFallbackFrames: 0,
+            fullReferenceFrames: 0,
+            partialReferenceFrames: 0,
+            missingReferenceFrames: 0,
+            processingFailures: 0
+        )
+    }
+
+    private enum ReferenceQuality {
+        case full
+        case partial
+        case missing
+    }
+
+    private func makeReferenceFrame(
+        speaker: [Float],
+        start: Int,
+        count: Int,
+        hasSpeakerReference: Bool
+    ) -> (samples: [Float], quality: ReferenceQuality) {
+        guard hasSpeakerReference, !speaker.isEmpty, start < speaker.count else {
+            return ([Float](repeating: 0, count: count), .missing)
+        }
+
+        if start + count <= speaker.count {
+            return (Array(speaker[start..<(start + count)]), .full)
+        }
+
+        let available = speaker.count - start
+        guard available > 0 else {
+            return ([Float](repeating: 0, count: count), .missing)
+        }
+
+        var frame = [Float](repeating: 0, count: count)
+        frame.replaceSubrange(0..<available, with: speaker[start..<speaker.count])
+        return (frame, .partial)
+    }
 }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -213,7 +213,8 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         audioConverter: any AudioFileConverting = AudioFileConverter(),
         sttTranscriber: STTTranscribing,
         lockFileStore: MeetingRecordingLockFileStoring = MeetingRecordingLockFileStore(),
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        echoSuppressionConfiguration: MeetingEchoSuppressionConfiguration = .fromEnvironment()
     ) {
         self.init(
             micProcessingMode: micProcessingMode,
@@ -223,7 +224,9 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             lockFileStore: lockFileStore,
             fileManager: fileManager,
             micConditionerFactory: {
-                PassthroughMicConditioner()
+                MeetingEchoSuppressionFactory.makeConditioner(
+                    configuration: echoSuppressionConfiguration
+                )
             }
         )
     }
@@ -235,9 +238,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         sttTranscriber: STTTranscribing,
         lockFileStore: MeetingRecordingLockFileStoring = MeetingRecordingLockFileStore(),
         fileManager: FileManager = .default,
-        micConditionerFactory: @escaping @Sendable () -> any MicConditioning = {
-            PassthroughMicConditioner()
-        }
+        micConditionerFactory: @escaping @Sendable () -> any MicConditioning
     ) {
         self.requestedMicProcessingMode = micProcessingMode
         self.audioCaptureService = audioCaptureService

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -144,6 +144,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     private let liveChunkTranscriber: LiveChunkTranscriber
     private let lockFileStore: MeetingRecordingLockFileStoring
     private let speechEngineSessionManager: (any SpeechEngineSessionManaging)?
+    private let micConditionerFactory: @Sendable () -> any MicConditioning
 
     private var currentSession: Session?
     /// Buffer-discard flag for pause/resume. Reset in `cleanupState`.
@@ -214,11 +215,36 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         lockFileStore: MeetingRecordingLockFileStoring = MeetingRecordingLockFileStore(),
         fileManager: FileManager = .default
     ) {
+        self.init(
+            micProcessingMode: micProcessingMode,
+            audioCaptureService: audioCaptureService,
+            audioConverter: audioConverter,
+            sttTranscriber: sttTranscriber,
+            lockFileStore: lockFileStore,
+            fileManager: fileManager,
+            micConditionerFactory: {
+                PassthroughMicConditioner()
+            }
+        )
+    }
+
+    init(
+        micProcessingMode: MeetingMicProcessingMode = .raw,
+        audioCaptureService: any MeetingAudioCapturing,
+        audioConverter: any AudioFileConverting = AudioFileConverter(),
+        sttTranscriber: STTTranscribing,
+        lockFileStore: MeetingRecordingLockFileStoring = MeetingRecordingLockFileStore(),
+        fileManager: FileManager = .default,
+        micConditionerFactory: @escaping @Sendable () -> any MicConditioning = {
+            PassthroughMicConditioner()
+        }
+    ) {
         self.requestedMicProcessingMode = micProcessingMode
         self.audioCaptureService = audioCaptureService
         self.audioConverter = audioConverter
         self.lockFileStore = lockFileStore
         self.fileManager = fileManager
+        self.micConditionerFactory = micConditionerFactory
         self.liveChunkTranscriber = LiveChunkTranscriber(sttTranscriber: sttTranscriber)
         self.speechEngineSessionManager = sttTranscriber as? any SpeechEngineSessionManaging
     }
@@ -334,7 +360,8 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             self.latestLevels = MeetingAudioLevels()
             await captureOrchestrator.reset()
             try await validateStartStillCurrent(session)
-            micConditioner = PassthroughMicConditioner()
+            micConditioner = micConditionerFactory()
+            micConditioner.reset()
             transcriptAssembler.reset()
             isTranscriptionLagging = false
             captureFailed = false
@@ -570,6 +597,9 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
                 writerMetrics: writerMetrics,
                 captureFailed: captureFailed
             )
+        )
+        AudioCaptureDiagnostics.append(
+            echoSuppressionSummaryLine(session: session)
         )
         cleanupState()
         return output
@@ -904,13 +934,6 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     }
 
     private func configureMicConditioner(from report: MeetingAudioCaptureStartReport) {
-        // Mic processing is owned by macOS Voice Processing I/O upstream of
-        // this service; the conditioner is now always a no-op pass-through.
-        // The branching here is purely diagnostic — VPIO failing to engage
-        // means the user's mic stream is raw (speaker bleed possible) so we
-        // warn loudly to surface the case in telemetry.
-        micConditioner = PassthroughMicConditioner()
-
         guard report.microphoneStarted else {
             logger.info(
                 "meeting_mic_conditioner_skipped source_mode=\(report.sourceMode.rawValue, privacy: .public)"
@@ -921,11 +944,11 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         let microphone = report.microphone
         if microphone.fellBackToRaw {
             logger.warning(
-                "meeting_mic_vpio_unavailable requested=\(String(describing: microphone.requestedMode), privacy: .public) effective=raw requested_policy=\(String(describing: self.requestedMicProcessingMode), privacy: .public) — mic stream is raw, speaker echo will not be cancelled"
+                "meeting_mic_vpio_unavailable requested=\(String(describing: microphone.requestedMode), privacy: .public) effective=raw requested_policy=\(String(describing: self.requestedMicProcessingMode), privacy: .public) echo_processor=\(self.micConditioner.diagnostics.processorName, privacy: .public)"
             )
         } else {
             logger.info(
-                "meeting_mic_processing requested=\(String(describing: microphone.requestedMode), privacy: .public) effective=\(microphone.effectiveMode.rawValue, privacy: .public)"
+                "meeting_mic_processing requested=\(String(describing: microphone.requestedMode), privacy: .public) effective=\(microphone.effectiveMode.rawValue, privacy: .public) echo_processor=\(self.micConditioner.diagnostics.processorName, privacy: .public)"
             )
         }
     }
@@ -1114,6 +1137,23 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             "transcription_failures=\(captureHealthMetrics.transcriptionFailures)",
             "interrupted_sources=\(interruptedSourceLabel.isEmpty ? "none" : interruptedSourceLabel)",
             "capture_failed=\(captureFailed)",
+        ].joined(separator: " ")
+    }
+
+    private func echoSuppressionSummaryLine(session: Session) -> String {
+        let diagnostics = micConditioner.diagnostics
+        return [
+            "meeting_echo_suppression_summary",
+            "session=\(session.id.uuidString)",
+            "processor=\(diagnostics.processorName)",
+            "loaded=\(diagnostics.loaded)",
+            "mic_frames=\(diagnostics.micFrames)",
+            "processed_frames=\(diagnostics.processedFrames)",
+            "raw_fallback_frames=\(diagnostics.rawFallbackFrames)",
+            "full_reference_frames=\(diagnostics.fullReferenceFrames)",
+            "partial_reference_frames=\(diagnostics.partialReferenceFrames)",
+            "missing_reference_frames=\(diagnostics.missingReferenceFrames)",
+            "processing_failures=\(diagnostics.processingFailures)",
         ].joined(separator: " ")
     }
 

--- a/Tests/MacParakeetTests/Services/Capture/CaptureOrchestratorTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/CaptureOrchestratorTests.swift
@@ -199,6 +199,27 @@ final class CaptureOrchestratorTests: XCTestCase {
         )
     }
 
+    func testProcessedMicrophoneSamplesFeedMicrophoneChunker() async {
+        let orchestrator = CaptureOrchestrator()
+        let conditioner = ConstantMicConditioner(sampleValue: 0.125)
+
+        let chunks = await driveCycles(
+            orchestrator: orchestrator,
+            conditioner: conditioner,
+            cycles: cyclesForOneChunk,
+            micHostTimeBaseSeconds: 92_721.0,
+            systemHostTimeBaseSeconds: 92_721.0
+        )
+
+        let micChunk = try? XCTUnwrap(chunks.first(where: { $0.source == .microphone })?.chunk)
+        guard let micChunk else { return }
+        XCTAssertTrue(
+            micChunk.samples.allSatisfy { abs($0 - 0.125) < 0.0001 },
+            "microphone chunker must receive conditioned mic samples, not raw mic samples"
+        )
+        XCTAssertEqual(conditioner.callCount, cyclesForOneChunk)
+    }
+
     // MARK: - helpers
 
     /// Push `cycles` paired 8 k-sample batches through the orchestrator so the
@@ -209,7 +230,7 @@ final class CaptureOrchestratorTests: XCTestCase {
     /// across the entire stream.
     private func driveCycles(
         orchestrator: CaptureOrchestrator,
-        conditioner: PassthroughMicConditioner,
+        conditioner: any MicConditioning,
         cycles: Int,
         micHostTimeBaseSeconds: Double?,
         systemHostTimeBaseSeconds: Double?
@@ -242,5 +263,25 @@ final class CaptureOrchestratorTests: XCTestCase {
             collected.append(contentsOf: outB.chunks)
         }
         return collected
+    }
+}
+
+private final class ConstantMicConditioner: MicConditioning, @unchecked Sendable {
+    private let sampleValue: Float
+    private(set) var callCount = 0
+    private(set) var diagnostics = MeetingEchoSuppressionDiagnostics.passthrough()
+
+    init(sampleValue: Float) {
+        self.sampleValue = sampleValue
+    }
+
+    func condition(microphone: [Float], speaker: [Float], hasSpeakerReference: Bool) -> [Float] {
+        callCount += 1
+        return [Float](repeating: sampleValue, count: microphone.count)
+    }
+
+    func reset() {
+        callCount = 0
+        diagnostics = MeetingEchoSuppressionDiagnostics.passthrough()
     }
 }

--- a/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressionRuntimeTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressionRuntimeTests.swift
@@ -8,8 +8,8 @@ final class MeetingEchoSuppressionRuntimeTests: XCTestCase {
             MeetingEchoSuppressionConfiguration.libraryPathEnvironmentKey: "/tmp/libecho.dylib",
             MeetingEchoSuppressionConfiguration.modelPathEnvironmentKey: "file:///tmp/model.gguf",
             MeetingEchoSuppressionConfiguration.modelSHA256EnvironmentKey: " ABC123 ",
-            MeetingEchoSuppressionConfiguration.sampleRateEnvironmentKey: "48000",
-            MeetingEchoSuppressionConfiguration.frameSizeEnvironmentKey: "256",
+            MeetingEchoSuppressionConfiguration.sampleRateEnvironmentKey: " 48000 ",
+            MeetingEchoSuppressionConfiguration.frameSizeEnvironmentKey: " 256 ",
         ])
 
         XCTAssertEqual(configuration.mode, .dynamicLibrary)
@@ -18,6 +18,21 @@ final class MeetingEchoSuppressionRuntimeTests: XCTestCase {
         XCTAssertEqual(configuration.modelSHA256, "abc123")
         XCTAssertEqual(configuration.sampleRate, 48_000)
         XCTAssertEqual(configuration.frameSize, 256)
+    }
+
+    func testDefaultFrameSizeMatchesLocalVQEHopLengthFallback() {
+        let configuration = MeetingEchoSuppressionConfiguration()
+
+        XCTAssertEqual(configuration.frameSize, 256)
+    }
+
+    func testConfigurationParsesUnescapedFileURLWithSpaces() {
+        let configuration = MeetingEchoSuppressionConfiguration.fromEnvironment([
+            MeetingEchoSuppressionConfiguration.modelPathEnvironmentKey:
+                "file:///tmp/meeting echo/local model.gguf",
+        ])
+
+        XCTAssertEqual(configuration.modelURL?.path, "/tmp/meeting echo/local model.gguf")
     }
 
     func testAutomaticWithoutAssetsUsesLoadedPassthrough() {

--- a/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressionRuntimeTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressionRuntimeTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class MeetingEchoSuppressionRuntimeTests: XCTestCase {
+    func testConfigurationParsesEnvironmentAliases() {
+        let configuration = MeetingEchoSuppressionConfiguration.fromEnvironment([
+            MeetingEchoSuppressionConfiguration.modeEnvironmentKey: "localvqe",
+            MeetingEchoSuppressionConfiguration.libraryPathEnvironmentKey: "/tmp/libecho.dylib",
+            MeetingEchoSuppressionConfiguration.modelPathEnvironmentKey: "file:///tmp/model.gguf",
+            MeetingEchoSuppressionConfiguration.modelSHA256EnvironmentKey: " ABC123 ",
+            MeetingEchoSuppressionConfiguration.sampleRateEnvironmentKey: "48000",
+            MeetingEchoSuppressionConfiguration.frameSizeEnvironmentKey: "256",
+        ])
+
+        XCTAssertEqual(configuration.mode, .dynamicLibrary)
+        XCTAssertEqual(configuration.libraryURL?.path, "/tmp/libecho.dylib")
+        XCTAssertEqual(configuration.modelURL?.path, "/tmp/model.gguf")
+        XCTAssertEqual(configuration.modelSHA256, "abc123")
+        XCTAssertEqual(configuration.sampleRate, 48_000)
+        XCTAssertEqual(configuration.frameSize, 256)
+    }
+
+    func testAutomaticWithoutAssetsUsesLoadedPassthrough() {
+        let conditioner = MeetingEchoSuppressionFactory.makeConditioner(
+            configuration: MeetingEchoSuppressionConfiguration(mode: .automatic),
+            bundle: Bundle(for: Self.self)
+        )
+
+        XCTAssertEqual(conditioner.condition(microphone: [0.1, 0.2], speaker: [0.5]), [0.1, 0.2])
+        XCTAssertEqual(conditioner.diagnostics.processorName, "passthrough")
+        XCTAssertTrue(conditioner.diagnostics.loaded)
+    }
+
+    func testDynamicModeWithoutAssetsUsesUnavailableDiagnostic() {
+        let conditioner = MeetingEchoSuppressionFactory.makeConditioner(
+            configuration: MeetingEchoSuppressionConfiguration(
+                mode: .dynamicLibrary,
+                libraryURL: URL(fileURLWithPath: "/tmp/missing-echo-runtime.dylib"),
+                modelURL: URL(fileURLWithPath: "/tmp/missing-echo-model.gguf")
+            ),
+            bundle: Bundle(for: Self.self)
+        )
+
+        XCTAssertEqual(conditioner.condition(microphone: [0.1, 0.2], speaker: [0.5]), [0.1, 0.2])
+        XCTAssertEqual(conditioner.diagnostics.processorName, "localvqe")
+        XCTAssertFalse(conditioner.diagnostics.loaded)
+    }
+
+    func testFactoryRejectsChecksumMismatchBeforeLoadingLibrary() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let libraryURL = root.appendingPathComponent("liblocalvqe.dylib")
+        let modelURL = root.appendingPathComponent("localvqe-v1.2-1.3M-f32.gguf")
+        try Data("not-a-real-dylib".utf8).write(to: libraryURL)
+        try Data("model".utf8).write(to: modelURL)
+
+        let conditioner = MeetingEchoSuppressionFactory.makeConditioner(
+            configuration: MeetingEchoSuppressionConfiguration(
+                mode: .dynamicLibrary,
+                libraryURL: libraryURL,
+                modelURL: modelURL,
+                modelSHA256: "0000"
+            ),
+            bundle: Bundle(for: Self.self)
+        )
+
+        XCTAssertEqual(conditioner.diagnostics.processorName, "localvqe")
+        XCTAssertFalse(conditioner.diagnostics.loaded)
+    }
+
+    func testSHA256HexIsStable() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let fileURL = root.appendingPathComponent("fixture.txt")
+        try Data("abc".utf8).write(to: fileURL)
+
+        XCTAssertEqual(
+            try MeetingEchoSuppressionFactory.sha256Hex(for: fileURL),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        )
+    }
+}

--- a/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressorTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressorTests.swift
@@ -108,8 +108,10 @@ private final class SubtractingEchoProcessor: MeetingEchoSuppressing, @unchecked
 
     func reset() {}
 
-    func processFrame(microphone: [Float], reference: [Float]) throws -> [Float] {
-        zip(microphone, reference).map { $0 - $1 }
+    func processFrame(microphone: [Float], reference: [Float], output: inout [Float]) throws {
+        for index in output.indices {
+            output[index] = microphone[index] - reference[index]
+        }
     }
 }
 
@@ -129,9 +131,11 @@ private final class RecordingEchoProcessor: MeetingEchoSuppressing, @unchecked S
         references.removeAll()
     }
 
-    func processFrame(microphone: [Float], reference: [Float]) throws -> [Float] {
+    func processFrame(microphone: [Float], reference: [Float], output: inout [Float]) throws {
         references.append(reference)
-        return microphone
+        for index in output.indices {
+            output[index] = microphone[index]
+        }
     }
 }
 
@@ -150,7 +154,7 @@ private final class ThrowingEchoProcessor: MeetingEchoSuppressing, @unchecked Se
 
     func reset() {}
 
-    func processFrame(microphone: [Float], reference: [Float]) throws -> [Float] {
+    func processFrame(microphone: [Float], reference: [Float], output: inout [Float]) throws {
         throw Failure.simulated
     }
 }

--- a/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressorTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressorTests.swift
@@ -1,0 +1,156 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class MeetingEchoSuppressorTests: XCTestCase {
+    func testProcessesFullReferenceFramesAndPreservesSampleCount() {
+        let processor = SubtractingEchoProcessor(frameSize: 4)
+        let suppressor = StreamingMeetingEchoSuppressor(processor: processor)
+
+        let output = suppressor.condition(
+            microphone: [0.5, 0.4, 0.3, 0.2, 0.9],
+            speaker: [0.1, 0.1, 0.2, 0.2, 0.8],
+            hasSpeakerReference: true
+        )
+
+        XCTAssertEqual(output.count, 5)
+        XCTAssertEqual(output.prefix(4).map { rounded($0) }, [0.4, 0.3, 0.1, 0.0])
+        XCTAssertEqual(output.last, 0.9, "tail samples that do not fill a processor frame pass through raw")
+        XCTAssertEqual(
+            suppressor.diagnostics,
+            MeetingEchoSuppressionDiagnostics(
+                processorName: "subtracting-test",
+                loaded: true,
+                micFrames: 1,
+                processedFrames: 1,
+                rawFallbackFrames: 1,
+                fullReferenceFrames: 1,
+                partialReferenceFrames: 0,
+                missingReferenceFrames: 0,
+                processingFailures: 0
+            )
+        )
+    }
+
+    func testMissingReferenceUsesZeroReferenceAndIncrementsDiagnostics() {
+        let processor = RecordingEchoProcessor(frameSize: 4)
+        let suppressor = StreamingMeetingEchoSuppressor(processor: processor)
+
+        let output = suppressor.condition(
+            microphone: [0.5, 0.4, 0.3, 0.2],
+            speaker: [0, 0, 0, 0],
+            hasSpeakerReference: false
+        )
+
+        XCTAssertEqual(output, [0.5, 0.4, 0.3, 0.2])
+        XCTAssertEqual(processor.references, [[0, 0, 0, 0]])
+        XCTAssertEqual(suppressor.diagnostics.missingReferenceFrames, 1)
+        XCTAssertEqual(suppressor.diagnostics.fullReferenceFrames, 0)
+    }
+
+    func testPartialReferenceZeroPadsUnavailableRegion() {
+        let processor = RecordingEchoProcessor(frameSize: 4)
+        let suppressor = StreamingMeetingEchoSuppressor(processor: processor)
+
+        _ = suppressor.condition(
+            microphone: [0.5, 0.4, 0.3, 0.2],
+            speaker: [0.1, 0.2],
+            hasSpeakerReference: true
+        )
+
+        XCTAssertEqual(processor.references, [[0.1, 0.2, 0, 0]])
+        XCTAssertEqual(suppressor.diagnostics.partialReferenceFrames, 1)
+    }
+
+    func testProcessorFailureFallsBackToRawFrame() {
+        let processor = ThrowingEchoProcessor(frameSize: 4)
+        let suppressor = StreamingMeetingEchoSuppressor(processor: processor)
+
+        let output = suppressor.condition(
+            microphone: [0.5, 0.4, 0.3, 0.2],
+            speaker: [0.1, 0.1, 0.1, 0.1],
+            hasSpeakerReference: true
+        )
+
+        XCTAssertEqual(output, [0.5, 0.4, 0.3, 0.2])
+        XCTAssertEqual(suppressor.diagnostics.rawFallbackFrames, 1)
+        XCTAssertEqual(suppressor.diagnostics.processingFailures, 1)
+    }
+
+    func testResetClearsProcessorAndDiagnostics() {
+        let processor = RecordingEchoProcessor(frameSize: 4)
+        let suppressor = StreamingMeetingEchoSuppressor(processor: processor)
+
+        _ = suppressor.condition(
+            microphone: [0.5, 0.4, 0.3, 0.2],
+            speaker: [0.1, 0.1, 0.1, 0.1],
+            hasSpeakerReference: true
+        )
+        suppressor.reset()
+
+        XCTAssertEqual(processor.resetCount, 1)
+        XCTAssertEqual(suppressor.diagnostics.processedFrames, 0)
+        XCTAssertEqual(suppressor.diagnostics.fullReferenceFrames, 0)
+    }
+
+    private func rounded(_ value: Float) -> Float {
+        (value * 1_000).rounded() / 1_000
+    }
+}
+
+private final class SubtractingEchoProcessor: MeetingEchoSuppressing, @unchecked Sendable {
+    let name = "subtracting-test"
+    let sampleRate = 16_000
+    let frameSize: Int
+
+    init(frameSize: Int) {
+        self.frameSize = frameSize
+    }
+
+    func reset() {}
+
+    func processFrame(microphone: [Float], reference: [Float]) throws -> [Float] {
+        zip(microphone, reference).map { $0 - $1 }
+    }
+}
+
+private final class RecordingEchoProcessor: MeetingEchoSuppressing, @unchecked Sendable {
+    let name = "recording-test"
+    let sampleRate = 16_000
+    let frameSize: Int
+    private(set) var references: [[Float]] = []
+    private(set) var resetCount = 0
+
+    init(frameSize: Int) {
+        self.frameSize = frameSize
+    }
+
+    func reset() {
+        resetCount += 1
+        references.removeAll()
+    }
+
+    func processFrame(microphone: [Float], reference: [Float]) throws -> [Float] {
+        references.append(reference)
+        return microphone
+    }
+}
+
+private final class ThrowingEchoProcessor: MeetingEchoSuppressing, @unchecked Sendable {
+    enum Failure: Error {
+        case simulated
+    }
+
+    let name = "throwing-test"
+    let sampleRate = 16_000
+    let frameSize: Int
+
+    init(frameSize: Int) {
+        self.frameSize = frameSize
+    }
+
+    func reset() {}
+
+    func processFrame(microphone: [Float], reference: [Float]) throws -> [Float] {
+        throw Failure.simulated
+    }
+}

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
@@ -402,6 +402,9 @@ final class MeetingRecordingServiceTests: XCTestCase {
         XCTAssertTrue(log.contains("system_chunks_low_signal_dropped=0"))
         XCTAssertTrue(log.contains("interrupted_sources=none"))
         XCTAssertTrue(log.contains("capture_failed=false"))
+        XCTAssertTrue(log.contains("meeting_echo_suppression_summary session=\(output.sessionID.uuidString)"))
+        XCTAssertTrue(log.contains("processor=passthrough"))
+        XCTAssertTrue(log.contains("loaded=true"))
     }
 
     func testCancelRecordingDeletesLockAndSessionFolder() async throws {
@@ -823,6 +826,67 @@ final class MeetingRecordingServiceTests: XCTestCase {
         let counts = await sttClient.callCounts
         XCTAssertGreaterThanOrEqual(counts.microphone, 1)
         XCTAssertEqual(counts.system, 0)
+    }
+
+    func testLivePreviewUsesConditionedMicrophoneSamplesForSignalGate() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let audioConverter = MockMeetingAudioFileConverter()
+        let sttClient = CountingMeetingSTTClient()
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: audioConverter,
+            sttTranscriber: sttClient,
+            micConditionerFactory: {
+                ZeroingMicConditioner()
+            }
+        )
+
+        try await service.startRecording()
+
+        let micBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.25))
+        await captureService.yield(.microphoneBuffer(
+            micBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
+        ))
+
+        let output = try await service.stopRecording()
+        defer { try? FileManager.default.removeItem(at: output.folderURL) }
+
+        let counts = await sttClient.callCounts
+        XCTAssertEqual(
+            counts.microphone,
+            0,
+            "live mic STT should see conditioned mic samples; the zeroed cleaned stream must be dropped as low signal"
+        )
+        XCTAssertNotNil(output.sourceAlignment.microphone, "raw mic source audio should still be retained")
+    }
+
+    func testStopRecordingWritesEchoSuppressionDiagnosticsForInjectedConditioner() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: MockMeetingAudioFileConverter(),
+            sttTranscriber: CountingMeetingSTTClient(),
+            micConditionerFactory: {
+                ZeroingMicConditioner()
+            }
+        )
+
+        try await service.startRecording()
+        let micBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.25))
+        await captureService.yield(.microphoneBuffer(
+            micBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
+        ))
+
+        let output = try await service.stopRecording()
+        defer { try? FileManager.default.removeItem(at: output.folderURL) }
+
+        let log = try String(contentsOf: AudioCaptureDiagnostics.diagnosticLogURL(), encoding: .utf8)
+        XCTAssertTrue(log.contains("meeting_echo_suppression_summary session=\(output.sessionID.uuidString)"))
+        XCTAssertTrue(log.contains("processor=zeroing-test"))
+        XCTAssertTrue(log.contains("processed_frames=1"))
+        XCTAssertTrue(log.contains("missing_reference_frames=1"))
     }
 
     func testSystemOnlyCaptureProducesSystemSourceOnly() async throws {
@@ -2105,6 +2169,45 @@ private actor CountingMeetingSTTClient: STTClientProtocol {
     func clearModelCache() async {}
 
     func shutdown() async {}
+}
+
+private final class ZeroingMicConditioner: MicConditioning, @unchecked Sendable {
+    private(set) var diagnostics = MeetingEchoSuppressionDiagnostics(
+        processorName: "zeroing-test",
+        loaded: true,
+        micFrames: 0,
+        processedFrames: 0,
+        rawFallbackFrames: 0,
+        fullReferenceFrames: 0,
+        partialReferenceFrames: 0,
+        missingReferenceFrames: 0,
+        processingFailures: 0
+    )
+
+    func condition(microphone: [Float], speaker: [Float], hasSpeakerReference: Bool) -> [Float] {
+        diagnostics.micFrames += 1
+        diagnostics.processedFrames += 1
+        if hasSpeakerReference {
+            diagnostics.fullReferenceFrames += 1
+        } else {
+            diagnostics.missingReferenceFrames += 1
+        }
+        return [Float](repeating: 0, count: microphone.count)
+    }
+
+    func reset() {
+        diagnostics = MeetingEchoSuppressionDiagnostics(
+            processorName: "zeroing-test",
+            loaded: true,
+            micFrames: 0,
+            processedFrames: 0,
+            rawFallbackFrames: 0,
+            fullReferenceFrames: 0,
+            partialReferenceFrames: 0,
+            missingReferenceFrames: 0,
+            processingFailures: 0
+        )
+    }
 }
 
 private actor LeasingMeetingSTTClient: STTClientProtocol, SpeechEngineRoutedTranscribing, SpeechEngineSessionManaging {

--- a/plans/active/2026-05-meeting-neural-echo-suppression.md
+++ b/plans/active/2026-05-meeting-neural-echo-suppression.md
@@ -1,0 +1,331 @@
+# Meeting Neural Echo Suppression
+
+> Status: ACTIVE PLAN
+> Date: 2026-05-22
+> Scope: meeting recording microphone cleanup, source separation, and release packaging.
+
+## Problem
+
+Meeting recording currently captures microphone and system audio as separate
+sources, which is the right foundation. The defect is that speaker playback can
+physically leak into the microphone. When that happens, remote participants can
+appear in both streams:
+
+- system audio correctly produces `Others` text
+- microphone audio also produces false `Me` text
+- live suggestions and post-meeting artifacts can treat remote speech as local
+  user speech
+
+The previous macOS Voice Processing I/O approach reduced bleed but created a
+higher-risk failure mode: it could affect the live microphone path used by Zoom,
+Meet, Teams, and similar apps. Meeting recording must not change how the other
+participants hear the user. The shipped baseline should stay raw/call-safe, with
+echo suppression implemented inside MacParakeet's meeting pipeline.
+
+## Goals
+
+- Keep microphone and system audio as first-class separate sources.
+- Preserve raw mic capture for retained source audio and recovery.
+- Add a call-safe neural echo-suppression stage for the meeting transcript path.
+- Drive live microphone VAD/STT from cleaned mic samples, not raw mic samples.
+- Use the captured system stream as the far-end reference for microphone
+  cleanup.
+- Keep final post-stop transcription source-aware and rebuild from retained
+  source files.
+- Make missing/silent/misaligned system reference visible in diagnostics.
+- Treat packaging, signing, and fallback behavior as release gates.
+
+## Non-Goals
+
+- Do not re-enable Voice Processing I/O by default.
+- Do not merge microphone and system audio into one STT input.
+- Do not rely on transcript-only dedupe as the primary fix.
+- Do not change the user-facing `Me` / `Others` model in this pass.
+- Do not delete existing VPIO plumbing; keep it as explicit experimental
+  fallback/testing infrastructure.
+
+## Current Architecture
+
+The useful existing seams are:
+
+- `MeetingAudioCaptureService`: emits microphone and system buffers.
+- `MeetingRecordingService`: writes source files, updates levels, orchestrates
+  live chunks, and finalizes meetings.
+- `CaptureOrchestrator`: aligns microphone/system sample batches and feeds
+  source-specific `AudioChunker`s.
+- `MicConditioning`: narrow hook for transforming microphone samples with system
+  reference samples.
+- `LiveChunkTranscriber`: performs source-aware live STT.
+- `TranscriptionService.transcribeMeetingAudio`: performs final source-aware
+  batch transcription from retained source files.
+- `MeetingTranscriptNoiseFilter`: final transcript cleanup safety net.
+
+The first implementation should build around `MicConditioning` and
+`CaptureOrchestrator`, then decide whether final batch transcription needs a
+cleaned mic artifact in addition to live cleaned chunks.
+
+## Proposed Design
+
+Add a production meeting echo-suppression subsystem with this shape:
+
+```text
+raw microphone buffers
+        |
+        +-- retained source writer -> microphone.m4a
+        |
+        +-- resampled float stream
+                  |
+                  v
+system reference buffers ---> MeetingEchoSuppressor ---> cleaned mic stream
+                  |                                      |
+                  |                                      +-- live mic VAD/STT
+                  |                                      +-- optional cleaned mic artifact
+                  |
+                  +-- retained source writer -> system.m4a -> live/final system STT
+```
+
+### Processor Abstraction
+
+Introduce a small processor contract, separate from capture ownership:
+
+```swift
+protocol MeetingEchoSuppressing: AnyObject, Sendable {
+    var name: String { get }
+    var sampleRate: Int { get }
+    var frameSize: Int { get }
+    func reset()
+    func processFrame(microphone: [Float], reference: [Float]) throws -> [Float]
+}
+```
+
+Then implement a streaming coordinator that:
+
+- accepts arbitrary microphone/reference sample batches
+- frames them at the processor's required hop size
+- buffers pending mic frames until enough reference exists
+- emits cleaned samples in input order
+- falls back to raw mic frames on processor errors
+- records diagnostics for full, partial, missing, and late reference frames
+
+`LocalVQE` should be the preferred processor once packaged. `DTLN` should remain
+the practical fallback because it has a simpler Apple-platform integration path.
+`PassthroughMicConditioner` remains the final fallback.
+
+### Reference Alignment
+
+The system reference must match the microphone sample position closely enough
+for cancellation to work. The coordinator needs:
+
+- per-source sample counters at the normalized processing sample rate
+- a system-reference history ring
+- pending mic frame queue
+- delay estimate or configured reference offset
+- a maximum wait threshold so live transcription cannot stall indefinitely
+- counters for reference quality:
+  - full reference frames
+  - partial reference frames
+  - missing reference frames
+  - frames passed through raw after processing failure
+
+Initial implementation can reuse the pair boundaries from `MeetingAudioPairJoiner`
+and add diagnostics. If live tests show residual bleed from delay mismatch, add a
+small cross-correlation delay estimator over recent mic/system windows.
+
+### Live Path
+
+Live mic chunks must be produced from cleaned mic samples. This is the core
+behavioral change. Raw mic-driven VAD/STT will keep generating false `Me`
+segments whenever speaker playback enters the mic.
+
+Expected behavior:
+
+- raw mic writes continue even if echo suppression fails
+- cleaned mic drives microphone chunking
+- system audio drives system chunking unchanged
+- system-dominance transcript suppression remains as a secondary guard
+- transcript updates can include echo-suppression health in diagnostics, not in
+  user-visible text
+
+### Final Path
+
+The safest final path is two-stage:
+
+1. Ship live cleaned mic first while retaining raw source artifacts.
+2. Add a cleaned mic final artifact when the streaming path is proven stable.
+
+The final artifact should be explicit, for example:
+
+```text
+meeting-recordings/<uuid>/
+|-- microphone.m4a              # raw mic source
+|-- system.m4a                  # raw system source
+|-- microphone-cleaned.m4a      # optional cleaned mic transcript source
+|-- meeting.m4a                 # playback/export mix
+`-- meeting-recording-metadata.json
+```
+
+Final transcription should prefer `microphone-cleaned.m4a` for the `Me` stream
+when it exists and passes basic health checks. It should fall back to
+`microphone.m4a` if cleaned audio is missing, silent, corrupt, or shorter than
+expected.
+
+## Packaging Plan
+
+### LocalVQE
+
+Expected assets:
+
+- native runtime library: `liblocalvqe*.dylib`
+- dependent native libraries: likely GGML-related dylibs
+- model: `localvqe-v1.2-1.3M-f32.gguf`
+- Swift/C bridge target for loading and frame processing
+
+Release requirements:
+
+- app build script copies native dylibs into the app bundle
+- each dylib is signed with hardened runtime compatible options
+- notarization validates the bundled dylibs
+- model is bundled or downloaded through the existing model-management pattern
+- model checksum is validated before use
+- model download failure never breaks meeting recording
+- runtime load failure falls back to DTLN or passthrough
+
+### DTLN Fallback
+
+DTLN is less attractive as the primary quality path, but useful as a fallback
+because CoreML packaging is more familiar to this app. Requirements:
+
+- resource bundle copied into the app bundle
+- bundle lookup tested in the distributed app layout
+- missing bundle is nonfatal and falls back to passthrough
+- signing/notarization verifies the model bundle
+
+## Diagnostics
+
+Add a concise diagnostic line at meeting stop:
+
+```text
+meeting_echo_suppression_summary
+session=<uuid>
+processor=<localvqe|dtln|passthrough>
+loaded=<true|false>
+mic_frames=<n>
+processed_frames=<n>
+raw_fallback_frames=<n>
+full_reference_frames=<n>
+partial_reference_frames=<n>
+missing_reference_frames=<n>
+processing_failures=<n>
+system_rms_avg=<bucket>
+cleaned_mic_rms_avg=<bucket>
+```
+
+Do not log transcript text, audio paths, device names, CoreAudio device IDs, or
+model paths in public diagnostics. Raw errors can go to private OSLog fields
+when needed.
+
+## Test Plan
+
+### Unit Tests
+
+- processor framing preserves sample count after flush
+- missing reference passes through raw mic and increments diagnostics
+- partial reference zero-pads only the unavailable region
+- processor exception falls back to raw frame
+- reset clears history and pending mic state
+- cleaned mic samples feed microphone chunker
+- system chunker remains aligned during mic-only and system-only stretches
+- final transcription prefers cleaned mic artifact when healthy
+- final transcription falls back to raw mic when cleaned artifact is missing or
+  invalid
+
+### Synthetic Audio Tests
+
+Create deterministic synthetic fixtures:
+
+- far-end-only: system speech echoed into mic should suppress mic energy
+- near-end-only: local speech should survive cleanup
+- double-talk: local and remote speech overlap; local speech must remain
+- delayed echo: system reference offset by 50-250 ms
+- silent system reference: no false confidence; raw fallback is visible
+
+Pass criteria should measure both:
+
+- echo return loss / reduced mic-system correlation
+- near-end speech preservation / non-silent cleaned mic where local speech exists
+
+### Manual Validation
+
+- Zoom, Google Meet, Teams, and Slack Huddle.
+- Built-in speakers + built-in mic.
+- Studio Display speakers + Studio Display mic.
+- AirPods output + built-in mic.
+- Headphones/earbuds baseline.
+- Long meeting, at least 30 minutes.
+- Pause/resume and stop while buffers are queued.
+- Dictation during meeting still works.
+- Output-device switch during recording is nonfatal.
+
+## Rollout Phases
+
+### Phase 1: Pipeline and Diagnostics
+
+- Add streaming echo-suppression coordinator around `MicConditioning`.
+- Keep default processor passthrough.
+- Wire diagnostics and tests.
+- Prove cleaned mic can drive live chunks without changing capture/storage.
+
+### Phase 2: DTLN Fallback
+
+- Add DTLN processor behind explicit configuration.
+- Package CoreML resources.
+- Verify build, signing, notarization, and distributed app lookup.
+- Run synthetic and manual meeting tests.
+
+### Phase 3: LocalVQE Primary
+
+- Add native bridge and model resolver.
+- Add build script support for dylib copy/signing.
+- Add checksum validation and nonfatal fallback.
+- Enable as preferred processor when runtime and model are available.
+
+### Phase 4: Final Cleaned Mic Artifact
+
+- Write `microphone-cleaned.m4a` during recording or derive it immediately after
+  stop from retained source files.
+- Prefer cleaned mic for final `Me` STT when healthy.
+- Preserve raw source files for audit/recovery/fallback.
+
+### Phase 5: Release Gate
+
+- Full `swift test`.
+- `git diff --check`.
+- Dev app smoke.
+- Real two-party call validation.
+- Release build verifies bundled model/library presence.
+- Notarization verifies app with native runtime assets.
+
+## Acceptance Criteria
+
+- Starting meeting recording does not degrade the outgoing mic heard by another
+  participant.
+- Far-end speaker playback no longer produces live false `Me` chunks in normal
+  speaker setups.
+- Near-end local speech remains intelligible during echo suppression.
+- Meeting recording works when the echo-suppression runtime fails to load.
+- Diagnostics distinguish capture silence from reference-misalignment from
+  processor failure.
+- Raw source audio remains available for recovery and debugging.
+- Release packaging catches missing model/library resources before shipment.
+
+## Open Questions
+
+- Should the first production release bundle the LocalVQE model or download it
+  on demand?
+- Where should the user-visible setting live, if any: hidden feature flag,
+  advanced meeting setting, or no setting until stable?
+- Should `microphone-cleaned.m4a` be retained permanently or treated as a
+  derived cache that can be regenerated?
+- Is ScreenCaptureKit system audio sufficiently reliable for all native meeting
+  apps, or do we need a device-level CoreAudio tap fallback later?
+- What minimum echo-suppression metric should block release?

--- a/plans/active/2026-05-meeting-neural-echo-suppression.md
+++ b/plans/active/2026-05-meeting-neural-echo-suppression.md
@@ -175,10 +175,13 @@ expected.
 
 Expected assets:
 
-- native runtime library: `liblocalvqe*.dylib`
+- native runtime library: `liblocalvqe.dylib`
 - dependent native libraries: likely GGML-related dylibs
 - model: `localvqe-v1.2-1.3M-f32.gguf`
-- Swift/C bridge target for loading and frame processing
+- Swift dynamic-loader bridge for `localvqe_new`,
+  `localvqe_process_frame_f32`, `localvqe_reset`, and `localvqe_free`
+- 16 kHz mono Float32 processing with the runtime-reported hop length
+  (currently 256 samples)
 
 Release requirements:
 

--- a/scripts/dist/build_app_bundle.sh
+++ b/scripts/dist/build_app_bundle.sh
@@ -31,6 +31,12 @@ set -euo pipefail
 #   YTDLP_PATH         (default: auto-download latest) source yt-dlp binary to bundle
 #   BUNDLE_NODE        (default: 1) bundle Node runtime for yt-dlp
 #   NODE_VERSION       (default: 24.13.1) Node version used when downloading
+#   BUNDLE_MEETING_ECHO_ASSETS (default: 1 when echo library+model paths are set, else 0)
+#   REQUIRE_MEETING_ECHO_ASSETS (default: 0) fail if echo assets are not bundled
+#   MACPARAKEET_MEETING_ECHO_LIBRARY source dylib for meeting echo suppression
+#   MACPARAKEET_MEETING_ECHO_DYLIB_DIR optional directory of dependent dylibs to copy into Frameworks
+#   MACPARAKEET_MEETING_ECHO_MODEL source GGUF model for meeting echo suppression
+#   MACPARAKEET_MEETING_ECHO_MODEL_SHA256 optional expected model SHA256
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DIST_DIR="$ROOT_DIR/dist"
@@ -398,6 +404,69 @@ if [[ "$BUNDLE_NODE" == "1" ]]; then
 else
   echo "Skipping Node bundling (BUNDLE_NODE=0)"
 fi
+
+bundle_meeting_echo_assets() {
+  local should_bundle="${BUNDLE_MEETING_ECHO_ASSETS:-}"
+  if [[ -z "$should_bundle" ]]; then
+    if [[ -n "${MACPARAKEET_MEETING_ECHO_LIBRARY:-}" && -n "${MACPARAKEET_MEETING_ECHO_MODEL:-}" ]]; then
+      should_bundle="1"
+    else
+      should_bundle="0"
+    fi
+  fi
+
+  if [[ "$should_bundle" != "1" ]]; then
+    if [[ "${REQUIRE_MEETING_ECHO_ASSETS:-0}" == "1" ]]; then
+      echo "Error: REQUIRE_MEETING_ECHO_ASSETS=1 but BUNDLE_MEETING_ECHO_ASSETS is not enabled." >&2
+      exit 1
+    fi
+    echo "Skipping meeting echo-suppression assets (BUNDLE_MEETING_ECHO_ASSETS=0)"
+    return 0
+  fi
+
+  local library_src="${MACPARAKEET_MEETING_ECHO_LIBRARY:-}"
+  local model_src="${MACPARAKEET_MEETING_ECHO_MODEL:-}"
+  if [[ -z "$library_src" || ! -f "$library_src" ]]; then
+    echo "Error: MACPARAKEET_MEETING_ECHO_LIBRARY must point to a dylib when bundling echo assets." >&2
+    exit 1
+  fi
+  if [[ -z "$model_src" || ! -f "$model_src" ]]; then
+    echo "Error: MACPARAKEET_MEETING_ECHO_MODEL must point to a GGUF model when bundling echo assets." >&2
+    exit 1
+  fi
+
+  if [[ -n "${MACPARAKEET_MEETING_ECHO_MODEL_SHA256:-}" ]]; then
+    local actual_sha
+    actual_sha="$(shasum -a 256 "$model_src" | awk '{print $1}')"
+    if [[ "$actual_sha" != "$MACPARAKEET_MEETING_ECHO_MODEL_SHA256" ]]; then
+      echo "Error: meeting echo model SHA256 verification failed." >&2
+      echo "  Expected: $MACPARAKEET_MEETING_ECHO_MODEL_SHA256" >&2
+      echo "  Actual:   $actual_sha" >&2
+      exit 1
+    fi
+    echo "Meeting echo model SHA256 verified: $actual_sha"
+  fi
+
+  if [[ -n "${MACPARAKEET_MEETING_ECHO_DYLIB_DIR:-}" ]]; then
+    if [[ ! -d "$MACPARAKEET_MEETING_ECHO_DYLIB_DIR" ]]; then
+      echo "Error: MACPARAKEET_MEETING_ECHO_DYLIB_DIR is not a directory: $MACPARAKEET_MEETING_ECHO_DYLIB_DIR" >&2
+      exit 1
+    fi
+    while IFS= read -r -d '' dylib; do
+      install -m 0755 "$dylib" "$FRAMEWORKS_DIR/$(basename "$dylib")"
+    done < <(find "$MACPARAKEET_MEETING_ECHO_DYLIB_DIR" -maxdepth 1 -type f -name '*.dylib' -print0)
+  fi
+
+  install -m 0755 "$library_src" "$FRAMEWORKS_DIR/liblocalvqe.dylib"
+  mkdir -p "$RESOURCES_DIR/MeetingEchoSuppression"
+  install -m 0644 "$model_src" "$RESOURCES_DIR/MeetingEchoSuppression/localvqe-v1.2-1.3M-f32.gguf"
+  echo "Bundled meeting echo runtime: $FRAMEWORKS_DIR/liblocalvqe.dylib"
+  echo "Bundled meeting echo model: $RESOURCES_DIR/MeetingEchoSuppression/localvqe-v1.2-1.3M-f32.gguf"
+
+  "$ROOT_DIR/scripts/dist/verify_meeting_echo_assets.sh" "$APP_DIR"
+}
+
+bundle_meeting_echo_assets
 
 # Embed Sparkle.framework for auto-updates.
 #

--- a/scripts/dist/sign_notarize.sh
+++ b/scripts/dist/sign_notarize.sh
@@ -116,6 +116,14 @@ if [[ -d "$SPARKLE_FW" ]]; then
   codesign --force --sign "$SIGN_IDENTITY" --options runtime --timestamp "$SPARKLE_FW"
 fi
 
+# Sign optional model-backed meeting echo-suppression dylibs.
+while IFS= read -r -d '' dylib; do
+  echo "Signing bundled dylib: $dylib"
+  codesign --force --sign "$SIGN_IDENTITY" --options runtime --timestamp "$dylib"
+done < <(
+  find "$APP_PATH/Contents/Frameworks" -maxdepth 1 -type f -name "*.dylib" -print0 2>/dev/null || true
+)
+
 # Sign helper binaries under Resources.
 NODE_RUNTIME_ENTITLEMENTS="$ROOT_DIR/scripts/dist/NodeRuntime.entitlements"
 YTDLP_RUNTIME_ENTITLEMENTS="$ROOT_DIR/scripts/dist/YtDlpRuntime.entitlements"
@@ -155,6 +163,7 @@ codesign --force --sign "$SIGN_IDENTITY" --options runtime --timestamp \
 
 echo "[4/8] Verifying signature…"
 codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+VERIFY_CODE_SIGNATURES=1 "$ROOT_DIR/scripts/dist/verify_meeting_echo_assets.sh" "$APP_PATH"
 
 ZIP_PATH="$DIST_DIR/${APP_NAME}.app.zip"
 rm -f "$ZIP_PATH"

--- a/scripts/dist/verify_meeting_echo_assets.sh
+++ b/scripts/dist/verify_meeting_echo_assets.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+APP_PATH="${1:-${APP_PATH:-$ROOT_DIR/dist/MacParakeet.app}}"
+REQUIRE_MEETING_ECHO_ASSETS="${REQUIRE_MEETING_ECHO_ASSETS:-0}"
+VERIFY_CODE_SIGNATURES="${VERIFY_CODE_SIGNATURES:-0}"
+
+LIB_PATH="$APP_PATH/Contents/Frameworks/liblocalvqe.dylib"
+MODEL_PATH="$APP_PATH/Contents/Resources/MeetingEchoSuppression/localvqe-v1.2-1.3M-f32.gguf"
+
+if [[ ! -d "$APP_PATH" ]]; then
+  echo "Missing app bundle: $APP_PATH" >&2
+  exit 1
+fi
+
+lib_present=0
+model_present=0
+[[ -f "$LIB_PATH" ]] && lib_present=1
+[[ -f "$MODEL_PATH" ]] && model_present=1
+
+if [[ "$lib_present" == "0" && "$model_present" == "0" ]]; then
+  if [[ "$REQUIRE_MEETING_ECHO_ASSETS" == "1" ]]; then
+    echo "Error: meeting echo assets are required but not bundled." >&2
+    exit 1
+  fi
+  echo "Meeting echo assets not bundled; runtime will use passthrough."
+  exit 0
+fi
+
+if [[ "$lib_present" != "$model_present" ]]; then
+  echo "Error: meeting echo assets must be bundled together." >&2
+  echo "  Library: $LIB_PATH ($lib_present)" >&2
+  echo "  Model:   $MODEL_PATH ($model_present)" >&2
+  exit 1
+fi
+
+if [[ ! -x "$LIB_PATH" ]]; then
+  echo "Error: meeting echo runtime is not executable: $LIB_PATH" >&2
+  exit 1
+fi
+
+if [[ -n "${MACPARAKEET_MEETING_ECHO_MODEL_SHA256:-}" ]]; then
+  actual_sha="$(shasum -a 256 "$MODEL_PATH" | awk '{print $1}')"
+  if [[ "$actual_sha" != "$MACPARAKEET_MEETING_ECHO_MODEL_SHA256" ]]; then
+    echo "Error: bundled meeting echo model SHA256 mismatch." >&2
+    echo "  Expected: $MACPARAKEET_MEETING_ECHO_MODEL_SHA256" >&2
+    echo "  Actual:   $actual_sha" >&2
+    exit 1
+  fi
+  echo "Meeting echo model SHA256 verified: $actual_sha"
+fi
+
+if command -v otool >/dev/null 2>&1; then
+  unresolved_deps="$(
+    otool -L "$LIB_PATH" |
+      tail -n +2 |
+      awk '{print $1}' |
+      grep -Ev '^@rpath/|^@loader_path/|^/System/Library/|^/usr/lib/|^\(' || true
+  )"
+  if [[ -n "$unresolved_deps" ]]; then
+    echo "Warning: meeting echo runtime has non-system dylib references; ensure they are bundled and use @rpath/@loader_path:" >&2
+    echo "$unresolved_deps" >&2
+  fi
+fi
+
+if [[ "$VERIFY_CODE_SIGNATURES" == "1" ]]; then
+  codesign --verify --strict --verbose=2 "$LIB_PATH"
+fi
+
+echo "Meeting echo assets verified."


### PR DESCRIPTION
## Summary
- Add a meeting mic-conditioning seam so live mic VAD/STT uses cleaned mic audio while raw mic/system sources remain retained for the meeting artifact.
- Add a fail-open LocalVQE dynamic runtime loader with environment and bundle configuration, checksum validation, diagnostics, and passthrough fallback when assets are absent or unavailable.
- Add release packaging checks for the echo suppression dylib/model pair plus a technical implementation plan.

## Validation
- `swift test`
- `swift test --filter 'MeetingEchoSuppressionRuntimeTests|MeetingEchoSuppressorTests|MeetingRecordingServiceTests|CaptureOrchestratorTests'`
- `git diff --check origin/main..HEAD`
- `bash -n scripts/dist/build_app_bundle.sh`
- `bash -n scripts/dist/sign_notarize.sh`
- `bash -n scripts/dist/verify_meeting_echo_assets.sh`
- Verified asset verifier accepts no-assets passthrough mode and rejects one-sided dylib/model bundles.

## Notes
This PR wires the runtime seam and packaging path. Actual acoustic echo reduction is enabled only when the app bundle or environment provides both `liblocalvqe.dylib` and `localvqe-v1.2-1.3M-f32.gguf`; otherwise meeting recording intentionally stays on passthrough behavior.
