### PR TITLE
Allow bare modifier dictation hotkeys to share chords

### DIFF
--- a/Sources/CLI/Commands/TransformsCommand.swift
+++ b/Sources/CLI/Commands/TransformsCommand.swift
@@ -887,13 +887,16 @@ private func shortcutsMatch(_ lhs: KeyboardShortcut, _ rhs: KeyboardShortcut) ->
     lhs.keyCode == rhs.keyCode && lhs.modifiers == rhs.modifiers
 }
 
-private func appHotkeyCollision(for shortcut: KeyboardShortcut) -> CLITransformsError? {
-    let defaults = macParakeetAppDefaults()
+func appHotkeyCollision(
+    for shortcut: KeyboardShortcut,
+    defaults: UserDefaults = macParakeetAppDefaults()
+) -> CLITransformsError? {
     let candidate = shortcut.hotkeyTrigger
-    let reservedHotkeys: [(name: String, trigger: HotkeyTrigger)] = [
+    let reservedHotkeys: [(name: String, trigger: HotkeyTrigger, mode: HotkeyTrigger.ConflictMode)] = [
         (
             "hands-free dictation",
-            HotkeyTrigger.current(defaults: defaults)
+            HotkeyTrigger.current(defaults: defaults),
+            .bareModifierDictation
         ),
         (
             "push-to-talk",
@@ -901,7 +904,8 @@ private func appHotkeyCollision(for shortcut: KeyboardShortcut) -> CLITransforms
                 defaults: defaults,
                 defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey,
                 fallback: .defaultPushToTalk
-            )
+            ),
+            .bareModifierDictation
         ),
         (
             "meeting recording",
@@ -909,7 +913,8 @@ private func appHotkeyCollision(for shortcut: KeyboardShortcut) -> CLITransforms
                 defaults: defaults,
                 defaultsKey: HotkeyTrigger.meetingDefaultsKey,
                 fallback: .defaultMeetingRecording
-            )
+            ),
+            .exclusive
         ),
         (
             "file transcription",
@@ -917,7 +922,8 @@ private func appHotkeyCollision(for shortcut: KeyboardShortcut) -> CLITransforms
                 defaults: defaults,
                 defaultsKey: HotkeyTrigger.fileTranscriptionDefaultsKey,
                 fallback: .disabled
-            )
+            ),
+            .exclusive
         ),
         (
             "YouTube transcription",
@@ -925,11 +931,12 @@ private func appHotkeyCollision(for shortcut: KeyboardShortcut) -> CLITransforms
                 defaults: defaults,
                 defaultsKey: HotkeyTrigger.youtubeTranscriptionDefaultsKey,
                 fallback: .disabled
-            )
+            ),
+            .exclusive
         ),
     ]
     for reserved in reservedHotkeys where !reserved.trigger.isDisabled {
-        if candidate.overlaps(with: reserved.trigger) {
+        if candidate.conflicts(with: reserved.trigger, otherMode: reserved.mode) {
             return .shortcutConflictsWithAppHotkey(shortcut.displayString, reserved.name)
         }
     }

--- a/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
+++ b/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
@@ -98,6 +98,16 @@ final class AppHotkeyCoordinator {
         let conflict: Conflict?
     }
 
+    struct HotkeyConflictCandidate: Equatable {
+        let trigger: HotkeyTrigger
+        let mode: HotkeyTrigger.ConflictMode
+
+        init(_ trigger: HotkeyTrigger, mode: HotkeyTrigger.ConflictMode = .exclusive) {
+            self.trigger = trigger
+            self.mode = mode
+        }
+    }
+
     static func menuTitle(for trigger: HotkeyTrigger) -> String {
         menuTitle(handsFree: trigger, pushToTalk: trigger)
     }
@@ -279,10 +289,10 @@ final class AppHotkeyCoordinator {
         meetingHotkeyManager = startAuxiliaryHotkey(
             trigger: settingsViewModel.meetingHotkeyTrigger,
             conflicts: [
-                settingsViewModel.hotkeyTrigger,
-                settingsViewModel.pushToTalkHotkeyTrigger,
-                settingsViewModel.fileTranscriptionHotkeyTrigger,
-                settingsViewModel.youtubeTranscriptionHotkeyTrigger,
+                .init(settingsViewModel.hotkeyTrigger, mode: .bareModifierDictation),
+                .init(settingsViewModel.pushToTalkHotkeyTrigger, mode: .bareModifierDictation),
+                .init(settingsViewModel.fileTranscriptionHotkeyTrigger),
+                .init(settingsViewModel.youtubeTranscriptionHotkeyTrigger),
             ],
             onTrigger: { [weak self] in
                 self?.onToggleMeetingRecording()
@@ -294,10 +304,10 @@ final class AppHotkeyCoordinator {
         fileTranscriptionHotkeyManager = startAuxiliaryHotkey(
             trigger: settingsViewModel.fileTranscriptionHotkeyTrigger,
             conflicts: [
-                settingsViewModel.hotkeyTrigger,
-                settingsViewModel.pushToTalkHotkeyTrigger,
-                settingsViewModel.meetingHotkeyTrigger,
-                settingsViewModel.youtubeTranscriptionHotkeyTrigger,
+                .init(settingsViewModel.hotkeyTrigger, mode: .bareModifierDictation),
+                .init(settingsViewModel.pushToTalkHotkeyTrigger, mode: .bareModifierDictation),
+                .init(settingsViewModel.meetingHotkeyTrigger),
+                .init(settingsViewModel.youtubeTranscriptionHotkeyTrigger),
             ],
             onTrigger: { [weak self] in
                 self?.onTriggerFileTranscription()
@@ -309,10 +319,10 @@ final class AppHotkeyCoordinator {
         youtubeTranscriptionHotkeyManager = startAuxiliaryHotkey(
             trigger: settingsViewModel.youtubeTranscriptionHotkeyTrigger,
             conflicts: [
-                settingsViewModel.hotkeyTrigger,
-                settingsViewModel.pushToTalkHotkeyTrigger,
-                settingsViewModel.meetingHotkeyTrigger,
-                settingsViewModel.fileTranscriptionHotkeyTrigger,
+                .init(settingsViewModel.hotkeyTrigger, mode: .bareModifierDictation),
+                .init(settingsViewModel.pushToTalkHotkeyTrigger, mode: .bareModifierDictation),
+                .init(settingsViewModel.meetingHotkeyTrigger),
+                .init(settingsViewModel.fileTranscriptionHotkeyTrigger),
             ],
             onTrigger: { [weak self] in
                 self?.onTriggerYouTubeTranscription()
@@ -325,12 +335,12 @@ final class AppHotkeyCoordinator {
     /// `GlobalShortcutManager`, and surface the availability callback.
     private func startAuxiliaryHotkey(
         trigger: HotkeyTrigger,
-        conflicts: [HotkeyTrigger],
+        conflicts: [HotkeyConflictCandidate],
         onTrigger: @escaping @MainActor () -> Void
     ) -> GlobalShortcutManager? {
         guard !trigger.isDisabled else { return nil }
         let overlappingTriggers = Self.uniqueTriggers(
-            conflicts.filter { !$0.isDisabled && $0.overlaps(with: trigger) }
+            Self.conflictingTriggers(for: trigger, among: conflicts)
         )
         if !overlappingTriggers.isEmpty {
             onHotkeyConflict(trigger, overlappingTriggers)
@@ -350,6 +360,19 @@ final class AppHotkeyCoordinator {
         } else {
             onHotkeyUnavailable()
             return nil
+        }
+    }
+
+    static func conflictingTriggers(
+        for trigger: HotkeyTrigger,
+        among conflicts: [HotkeyConflictCandidate]
+    ) -> [HotkeyTrigger] {
+        conflicts.compactMap { conflict in
+            guard !conflict.trigger.isDisabled,
+                  trigger.conflicts(with: conflict.trigger, otherMode: conflict.mode) else {
+                return nil
+            }
+            return conflict.trigger
         }
     }
 

--- a/Sources/MacParakeet/App/TransformsCoordinator.swift
+++ b/Sources/MacParakeet/App/TransformsCoordinator.swift
@@ -147,7 +147,10 @@ final class TransformsCoordinator {
         var bindings: [UUID: KeyboardShortcut] = [:]
         for prompt in prompts {
             if let shortcut = prompt.shortcut {
-                if let conflict = reservedHotkeys.first(where: { shortcut.hotkeyTrigger.overlaps(with: $0.trigger) }) {
+                let trigger = shortcut.hotkeyTrigger
+                if let conflict = reservedHotkeys.first(where: {
+                    trigger.conflicts(with: $0.trigger, otherMode: $0.conflictMode)
+                }) {
                     logger.notice(
                         "transforms: skipping binding for \(prompt.name, privacy: .public); conflicts with \(conflict.name, privacy: .public) \(conflict.trigger.formattedLabel, privacy: .public)"
                     )

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -538,8 +538,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func transformReservedHotkeysForTransforms() -> [TransformShortcutReservedHotkey] {
         var reserved: [TransformShortcutReservedHotkey] = [
-            TransformShortcutReservedHotkey(name: "hands-free dictation", trigger: settingsViewModel.hotkeyTrigger),
-            TransformShortcutReservedHotkey(name: "push to talk", trigger: settingsViewModel.pushToTalkHotkeyTrigger),
+            TransformShortcutReservedHotkey(
+                name: "hands-free dictation",
+                trigger: settingsViewModel.hotkeyTrigger,
+                conflictMode: .bareModifierDictation
+            ),
+            TransformShortcutReservedHotkey(
+                name: "push to talk",
+                trigger: settingsViewModel.pushToTalkHotkeyTrigger,
+                conflictMode: .bareModifierDictation
+            ),
             TransformShortcutReservedHotkey(name: "file transcription", trigger: settingsViewModel.fileTranscriptionHotkeyTrigger),
             TransformShortcutReservedHotkey(name: "YouTube transcription", trigger: settingsViewModel.youtubeTranscriptionHotkeyTrigger),
         ]

--- a/Sources/MacParakeet/Hotkey/TransformsHotkeyRegistry.swift
+++ b/Sources/MacParakeet/Hotkey/TransformsHotkeyRegistry.swift
@@ -266,7 +266,7 @@ public struct TransformsHotkeyCollisionChecker {
 
         let candidateTrigger = candidate.hotkeyTrigger
         for reserved in reservedHotkeys where !reserved.trigger.isDisabled {
-            if candidateTrigger.overlaps(with: reserved.trigger) {
+            if candidateTrigger.conflicts(with: reserved.trigger, otherMode: reserved.conflictMode) {
                 return .reservedHotkey(name: reserved.name)
             }
         }

--- a/Sources/MacParakeet/Views/MainWindowView.swift
+++ b/Sources/MacParakeet/Views/MainWindowView.swift
@@ -267,8 +267,16 @@ struct MainWindowView: View {
 
     private var transformReservedHotkeys: [TransformShortcutReservedHotkey] {
         var reserved: [TransformShortcutReservedHotkey] = [
-            TransformShortcutReservedHotkey(name: "hands-free dictation", trigger: settingsViewModel.hotkeyTrigger),
-            TransformShortcutReservedHotkey(name: "push to talk", trigger: settingsViewModel.pushToTalkHotkeyTrigger),
+            TransformShortcutReservedHotkey(
+                name: "hands-free dictation",
+                trigger: settingsViewModel.hotkeyTrigger,
+                conflictMode: .bareModifierDictation
+            ),
+            TransformShortcutReservedHotkey(
+                name: "push to talk",
+                trigger: settingsViewModel.pushToTalkHotkeyTrigger,
+                conflictMode: .bareModifierDictation
+            ),
             TransformShortcutReservedHotkey(name: "file transcription", trigger: settingsViewModel.fileTranscriptionHotkeyTrigger),
             TransformShortcutReservedHotkey(name: "YouTube transcription", trigger: settingsViewModel.youtubeTranscriptionHotkeyTrigger),
         ]

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -852,13 +852,16 @@ struct SettingsView: View {
                     defaultTrigger: .disabled,
                     additionalValidation: { candidate in
                         guard !candidate.isDisabled else { return .allowed }
-                        if candidate.overlaps(with: viewModel.hotkeyTrigger) {
+                        if candidate.conflicts(with: viewModel.hotkeyTrigger, otherMode: .bareModifierDictation) {
                             return .blocked(SettingsHotkeyConflictMessage.blocked(
                                 conflictingWith: "hands-free mode",
                                 trigger: viewModel.hotkeyTrigger
                             ))
                         }
-                        if candidate.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
+                        if candidate.conflicts(
+                            with: viewModel.pushToTalkHotkeyTrigger,
+                            otherMode: .bareModifierDictation
+                        ) {
                             return .blocked(SettingsHotkeyConflictMessage.blocked(
                                 conflictingWith: "push to talk",
                                 trigger: viewModel.pushToTalkHotkeyTrigger
@@ -904,13 +907,13 @@ struct SettingsView: View {
         otherTranscriptionName: String
     ) -> String? {
         guard !trigger.isDisabled else { return nil }
-        if trigger.overlaps(with: viewModel.hotkeyTrigger) {
+        if trigger.conflicts(with: viewModel.hotkeyTrigger, otherMode: .bareModifierDictation) {
             return SettingsHotkeyConflictMessage.disabled(
                 conflictingWith: "hands-free mode",
                 trigger: viewModel.hotkeyTrigger
             )
         }
-        if trigger.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
+        if trigger.conflicts(with: viewModel.pushToTalkHotkeyTrigger, otherMode: .bareModifierDictation) {
             return SettingsHotkeyConflictMessage.disabled(
                 conflictingWith: "push to talk",
                 trigger: viewModel.pushToTalkHotkeyTrigger
@@ -945,25 +948,26 @@ struct SettingsView: View {
                 trigger: viewModel.pushToTalkHotkeyTrigger
             ))
         }
-        if AppFeatures.meetingRecordingEnabled, candidate.overlaps(with: viewModel.meetingHotkeyTrigger) {
+        if AppFeatures.meetingRecordingEnabled,
+           candidate.conflicts(with: viewModel.meetingHotkeyTrigger, selfMode: .bareModifierDictation) {
             return .blocked(SettingsHotkeyConflictMessage.blocked(
                 conflictingWith: "meeting recording",
                 trigger: viewModel.meetingHotkeyTrigger
             ))
         }
-        if candidate.overlaps(with: viewModel.fileTranscriptionHotkeyTrigger) {
+        if candidate.conflicts(with: viewModel.fileTranscriptionHotkeyTrigger, selfMode: .bareModifierDictation) {
             return .blocked(SettingsHotkeyConflictMessage.blocked(
                 conflictingWith: "file transcription",
                 trigger: viewModel.fileTranscriptionHotkeyTrigger
             ))
         }
-        if candidate.overlaps(with: viewModel.youtubeTranscriptionHotkeyTrigger) {
+        if candidate.conflicts(with: viewModel.youtubeTranscriptionHotkeyTrigger, selfMode: .bareModifierDictation) {
             return .blocked(SettingsHotkeyConflictMessage.blocked(
                 conflictingWith: "YouTube transcription",
                 trigger: viewModel.youtubeTranscriptionHotkeyTrigger
             ))
         }
-        if let conflict = transformHotkeyConflict(for: candidate) {
+        if let conflict = transformHotkeyConflict(for: candidate, triggerMode: .bareModifierDictation) {
             return .blocked(SettingsHotkeyConflictMessage.blocked(
                 conflictingWith: conflict.name,
                 trigger: conflict.trigger
@@ -980,25 +984,26 @@ struct SettingsView: View {
                 trigger: viewModel.hotkeyTrigger
             ))
         }
-        if AppFeatures.meetingRecordingEnabled, candidate.overlaps(with: viewModel.meetingHotkeyTrigger) {
+        if AppFeatures.meetingRecordingEnabled,
+           candidate.conflicts(with: viewModel.meetingHotkeyTrigger, selfMode: .bareModifierDictation) {
             return .blocked(SettingsHotkeyConflictMessage.blocked(
                 conflictingWith: "meeting recording",
                 trigger: viewModel.meetingHotkeyTrigger
             ))
         }
-        if candidate.overlaps(with: viewModel.fileTranscriptionHotkeyTrigger) {
+        if candidate.conflicts(with: viewModel.fileTranscriptionHotkeyTrigger, selfMode: .bareModifierDictation) {
             return .blocked(SettingsHotkeyConflictMessage.blocked(
                 conflictingWith: "file transcription",
                 trigger: viewModel.fileTranscriptionHotkeyTrigger
             ))
         }
-        if candidate.overlaps(with: viewModel.youtubeTranscriptionHotkeyTrigger) {
+        if candidate.conflicts(with: viewModel.youtubeTranscriptionHotkeyTrigger, selfMode: .bareModifierDictation) {
             return .blocked(SettingsHotkeyConflictMessage.blocked(
                 conflictingWith: "YouTube transcription",
                 trigger: viewModel.youtubeTranscriptionHotkeyTrigger
             ))
         }
-        if let conflict = transformHotkeyConflict(for: candidate) {
+        if let conflict = transformHotkeyConflict(for: candidate, triggerMode: .bareModifierDictation) {
             return .blocked(SettingsHotkeyConflictMessage.blocked(
                 conflictingWith: conflict.name,
                 trigger: conflict.trigger
@@ -1009,13 +1014,16 @@ struct SettingsView: View {
 
     private func meetingHotkeyValidation(for candidate: HotkeyTrigger) -> HotkeyTrigger.ValidationResult {
         guard !candidate.isDisabled else { return .allowed }
-        if candidate.overlaps(with: viewModel.hotkeyTrigger) {
+        if candidate.conflicts(with: viewModel.hotkeyTrigger, otherMode: .bareModifierDictation) {
             return .blocked(SettingsHotkeyConflictMessage.blocked(
                 conflictingWith: "hands-free mode",
                 trigger: viewModel.hotkeyTrigger
             ))
         }
-        if candidate.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
+        if candidate.conflicts(
+            with: viewModel.pushToTalkHotkeyTrigger,
+            otherMode: .bareModifierDictation
+        ) {
             return .blocked(SettingsHotkeyConflictMessage.blocked(
                 conflictingWith: "push to talk",
                 trigger: viewModel.pushToTalkHotkeyTrigger
@@ -1050,25 +1058,26 @@ struct SettingsView: View {
                 trigger: viewModel.pushToTalkHotkeyTrigger
             )
         }
-        if AppFeatures.meetingRecordingEnabled, trigger.overlaps(with: viewModel.meetingHotkeyTrigger) {
+        if AppFeatures.meetingRecordingEnabled,
+           trigger.conflicts(with: viewModel.meetingHotkeyTrigger, selfMode: .bareModifierDictation) {
             return SettingsHotkeyConflictMessage.disabled(
                 conflictingWith: "meeting recording",
                 trigger: viewModel.meetingHotkeyTrigger
             )
         }
-        if trigger.overlaps(with: viewModel.fileTranscriptionHotkeyTrigger) {
+        if trigger.conflicts(with: viewModel.fileTranscriptionHotkeyTrigger, selfMode: .bareModifierDictation) {
             return SettingsHotkeyConflictMessage.disabled(
                 conflictingWith: "file transcription",
                 trigger: viewModel.fileTranscriptionHotkeyTrigger
             )
         }
-        if trigger.overlaps(with: viewModel.youtubeTranscriptionHotkeyTrigger) {
+        if trigger.conflicts(with: viewModel.youtubeTranscriptionHotkeyTrigger, selfMode: .bareModifierDictation) {
             return SettingsHotkeyConflictMessage.disabled(
                 conflictingWith: "YouTube transcription",
                 trigger: viewModel.youtubeTranscriptionHotkeyTrigger
             )
         }
-        if let conflict = transformHotkeyConflict(for: trigger) {
+        if let conflict = transformHotkeyConflict(for: trigger, triggerMode: .bareModifierDictation) {
             return SettingsHotkeyConflictMessage.disabled(
                 conflictingWith: conflict.name,
                 trigger: conflict.trigger
@@ -1085,25 +1094,26 @@ struct SettingsView: View {
                 trigger: viewModel.hotkeyTrigger
             )
         }
-        if AppFeatures.meetingRecordingEnabled, trigger.overlaps(with: viewModel.meetingHotkeyTrigger) {
+        if AppFeatures.meetingRecordingEnabled,
+           trigger.conflicts(with: viewModel.meetingHotkeyTrigger, selfMode: .bareModifierDictation) {
             return SettingsHotkeyConflictMessage.disabled(
                 conflictingWith: "meeting recording",
                 trigger: viewModel.meetingHotkeyTrigger
             )
         }
-        if trigger.overlaps(with: viewModel.fileTranscriptionHotkeyTrigger) {
+        if trigger.conflicts(with: viewModel.fileTranscriptionHotkeyTrigger, selfMode: .bareModifierDictation) {
             return SettingsHotkeyConflictMessage.disabled(
                 conflictingWith: "file transcription",
                 trigger: viewModel.fileTranscriptionHotkeyTrigger
             )
         }
-        if trigger.overlaps(with: viewModel.youtubeTranscriptionHotkeyTrigger) {
+        if trigger.conflicts(with: viewModel.youtubeTranscriptionHotkeyTrigger, selfMode: .bareModifierDictation) {
             return SettingsHotkeyConflictMessage.disabled(
                 conflictingWith: "YouTube transcription",
                 trigger: viewModel.youtubeTranscriptionHotkeyTrigger
             )
         }
-        if let conflict = transformHotkeyConflict(for: trigger) {
+        if let conflict = transformHotkeyConflict(for: trigger, triggerMode: .bareModifierDictation) {
             return SettingsHotkeyConflictMessage.disabled(
                 conflictingWith: conflict.name,
                 trigger: conflict.trigger
@@ -1114,13 +1124,13 @@ struct SettingsView: View {
 
     private func meetingHotkeyConflictMessage(for trigger: HotkeyTrigger) -> String? {
         guard !trigger.isDisabled else { return nil }
-        if trigger.overlaps(with: viewModel.hotkeyTrigger) {
+        if trigger.conflicts(with: viewModel.hotkeyTrigger, otherMode: .bareModifierDictation) {
             return SettingsHotkeyConflictMessage.disabled(
                 conflictingWith: "hands-free mode",
                 trigger: viewModel.hotkeyTrigger
             )
         }
-        if trigger.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
+        if trigger.conflicts(with: viewModel.pushToTalkHotkeyTrigger, otherMode: .bareModifierDictation) {
             return SettingsHotkeyConflictMessage.disabled(
                 conflictingWith: "push to talk",
                 trigger: viewModel.pushToTalkHotkeyTrigger
@@ -1147,13 +1157,16 @@ struct SettingsView: View {
         return nil
     }
 
-    private func transformHotkeyConflict(for trigger: HotkeyTrigger) -> (name: String, trigger: HotkeyTrigger)? {
+    private func transformHotkeyConflict(
+        for trigger: HotkeyTrigger,
+        triggerMode: HotkeyTrigger.ConflictMode = .exclusive
+    ) -> (name: String, trigger: HotkeyTrigger)? {
         guard !trigger.isDisabled else { return nil }
         for transform in transformHotkeys {
             guard let shortcut = transform.shortcut else { continue }
             let transformTrigger = shortcut.hotkeyTrigger
             guard !transformTrigger.isDisabled else { continue }
-            if trigger.overlaps(with: transformTrigger) {
+            if trigger.conflicts(with: transformTrigger, selfMode: triggerMode) {
                 return ("Transform \(transform.name)", transformTrigger)
             }
         }

--- a/Sources/MacParakeetCore/Models/TransformShortcutReservedHotkey.swift
+++ b/Sources/MacParakeetCore/Models/TransformShortcutReservedHotkey.swift
@@ -3,9 +3,15 @@ import Foundation
 public struct TransformShortcutReservedHotkey: Sendable, Equatable {
     public let name: String
     public let trigger: HotkeyTrigger
+    public let conflictMode: HotkeyTrigger.ConflictMode
 
-    public init(name: String, trigger: HotkeyTrigger) {
+    public init(
+        name: String,
+        trigger: HotkeyTrigger,
+        conflictMode: HotkeyTrigger.ConflictMode = .exclusive
+    ) {
         self.name = name
         self.trigger = trigger
+        self.conflictMode = conflictMode
     }
 }

--- a/Sources/MacParakeetCore/STT/HotkeyTrigger.swift
+++ b/Sources/MacParakeetCore/STT/HotkeyTrigger.swift
@@ -35,6 +35,11 @@ public struct HotkeyTrigger: Sendable {
         case blocked(String)
     }
 
+    public enum ConflictMode: Equatable, Sendable {
+        case exclusive
+        case bareModifierDictation
+    }
+
     // MARK: - Stored Properties (canonical identity only)
 
     public let kind: Kind
@@ -563,6 +568,46 @@ public struct HotkeyTrigger: Sendable {
             let rhs = Self.modifierRequirements(forChord: other)
             return Self.requirements(lhs, canBeSatisfiedBy: rhs)
                 || Self.requirements(rhs, canBeSatisfiedBy: lhs)
+        default:
+            return false
+        }
+    }
+
+    public func conflicts(
+        with other: HotkeyTrigger,
+        selfMode: ConflictMode = .exclusive,
+        otherMode: ConflictMode = .exclusive
+    ) -> Bool {
+        guard overlaps(with: other) else { return false }
+        if selfMode == .bareModifierDictation,
+           Self.bareModifierDictationCanShare(self, with: other) {
+            return false
+        }
+        if otherMode == .bareModifierDictation,
+           Self.bareModifierDictationCanShare(other, with: self) {
+            return false
+        }
+        return true
+    }
+
+    private static func bareModifierDictationCanShare(
+        _ dictationTrigger: HotkeyTrigger,
+        with other: HotkeyTrigger
+    ) -> Bool {
+        guard dictationTrigger.kind == .modifier,
+              let lhs = modifierRequirement(for: dictationTrigger) else {
+            return false
+        }
+
+        switch other.kind {
+        case .chord:
+            return modifierRequirements(forChord: other).contains {
+                modifierRequirementsAreCompatible(lhs, $0)
+            }
+        case .modifierChord:
+            return modifierRequirements(forModifierChord: other).contains {
+                modifierRequirementsAreCompatible(lhs, $0)
+            }
         default:
             return false
         }

--- a/Sources/MacParakeetViewModels/TransformsViewModel.swift
+++ b/Sources/MacParakeetViewModels/TransformsViewModel.swift
@@ -491,7 +491,8 @@ private func reservedHotkeyConflict(
 ) -> TransformShortcutReservedHotkey? {
     let candidate = shortcut.hotkeyTrigger
     return reservedHotkeys.first { reserved in
-        !reserved.trigger.isDisabled && candidate.overlaps(with: reserved.trigger)
+        !reserved.trigger.isDisabled
+            && candidate.conflicts(with: reserved.trigger, otherMode: reserved.conflictMode)
     }
 }
 

--- a/Tests/CLITests/TransformsCommandTests.swift
+++ b/Tests/CLITests/TransformsCommandTests.swift
@@ -438,6 +438,30 @@ final class TransformsCommandTests: XCTestCase {
         }
     }
 
+    func testAppHotkeyCollisionAllowsChordSharingBareModifierDictationHotkey() throws {
+        let suiteName = "com.macparakeet.tests.transforms.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        HotkeyTrigger.option.save(
+            to: defaults,
+            defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey
+        )
+
+        XCTAssertNil(
+            appHotkeyCollision(
+                for: try XCTUnwrap(KeyboardShortcut.parse("opt+5")),
+                defaults: defaults
+            )
+        )
+        XCTAssertNotNil(
+            appHotkeyCollision(
+                for: try XCTUnwrap(KeyboardShortcut.parse("cmd+shift+m")),
+                defaults: defaults
+            )
+        )
+    }
+
     func testCreateRejectsMacOSDeadKeyShortcut() throws {
         let tmp = FileManager.default.temporaryDirectory
             .appendingPathComponent("transforms-cli-\(UUID().uuidString)")

--- a/Tests/CLITests/TransformsCommandTests.swift
+++ b/Tests/CLITests/TransformsCommandTests.swift
@@ -454,6 +454,7 @@ final class TransformsCommandTests: XCTestCase {
                 defaults: defaults
             )
         )
+        // cmd+shift+m still conflicts because defaultMeetingRecording uses .exclusive mode.
         XCTAssertNotNil(
             appHotkeyCollision(
                 for: try XCTUnwrap(KeyboardShortcut.parse("cmd+shift+m")),

--- a/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
@@ -257,12 +257,7 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
         )
 
         viewModel.meetingHotkeyTrigger = .defaultMeetingRecording
-        viewModel.pushToTalkHotkeyTrigger = HotkeyTrigger(
-            kind: .modifier,
-            modifierName: "command",
-            keyCode: nil,
-            modifierKeyCode: 54
-        )
+        viewModel.pushToTalkHotkeyTrigger = .defaultMeetingRecording
 
         coordinator.suspend()
         coordinator.refreshAllHotkeys()
@@ -273,6 +268,34 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
 
         coordinator.resume()
         XCTAssertEqual(conflictReports, 1, "resume() must rebuild taps from current settings")
+    }
+
+    func testAuxiliaryHotkeysCanShareChordsWithBareModifierDictationTriggers() {
+        let rightCommand = HotkeyTrigger(
+            kind: .modifier,
+            modifierName: "command",
+            keyCode: nil,
+            modifierKeyCode: 54
+        )
+
+        XCTAssertEqual(
+            AppHotkeyCoordinator.conflictingTriggers(
+                for: .defaultMeetingRecording,
+                among: [
+                    .init(rightCommand, mode: .bareModifierDictation)
+                ]
+            ),
+            []
+        )
+        XCTAssertEqual(
+            AppHotkeyCoordinator.conflictingTriggers(
+                for: .defaultMeetingRecording,
+                among: [
+                    .init(rightCommand)
+                ]
+            ),
+            [rightCommand]
+        )
     }
 
     func testSetupAllHotkeysIsDeferredWhileSuspended() {

--- a/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
@@ -129,6 +129,36 @@ final class HotkeyManagerTests: XCTestCase {
         )
     }
 
+    func testHoldOnlyCommandCancelsBeforeStartupWhenUsedAsChord() {
+        let manager = HotkeyManager(trigger: .command, gestureMode: .holdOnly)
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskCommand],
+                timestampMs: 1_000
+            ),
+            [.scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs)]
+        )
+        XCTAssertEqual(
+            manager.modifierKeyDownOutputsForTesting(keyCode: 8, timestampMs: 1_025),
+            [
+                .cancelStartupDebounce,
+                .cancelHoldWindow,
+            ]
+        )
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [])
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_050
+            ),
+            [
+                .cancelStartupDebounce,
+                .cancelHoldWindow,
+            ]
+        )
+    }
+
     func testSuppressedHoldOnlyManagerDoesNotStartUntilReset() {
         let manager = HotkeyManager(trigger: .fn, gestureMode: .holdOnly)
 

--- a/Tests/MacParakeetTests/Hotkey/HotkeyTriggerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyTriggerTests.swift
@@ -916,6 +916,29 @@ final class HotkeyTriggerTests: XCTestCase {
         XCTAssertTrue(commandM.overlaps(with: bareM))
     }
 
+    func testBareModifierDictationCanShareModifierPlusKeyChord() {
+        let rightCommand = HotkeyTrigger(kind: .modifier, modifierName: "command", keyCode: nil, modifierKeyCode: 54)
+        let meeting = HotkeyTrigger.defaultMeetingRecording
+
+        XCTAssertTrue(rightCommand.overlaps(with: meeting))
+        XCTAssertFalse(rightCommand.conflicts(with: meeting, selfMode: .bareModifierDictation))
+        XCTAssertFalse(meeting.conflicts(with: rightCommand, otherMode: .bareModifierDictation))
+    }
+
+    func testBareModifierDictationCanShareTransformOptionChord() {
+        let optionOne = HotkeyTrigger.chord(modifiers: ["option"], keyCode: 0x12)
+
+        XCTAssertTrue(HotkeyTrigger.option.overlaps(with: optionOne))
+        XCTAssertFalse(HotkeyTrigger.option.conflicts(with: optionOne, selfMode: .bareModifierDictation))
+    }
+
+    func testBareModifierDictationStillConflictsWithBareModifier() {
+        let rightCommand = HotkeyTrigger(kind: .modifier, modifierName: "command", keyCode: nil, modifierKeyCode: 54)
+
+        XCTAssertTrue(rightCommand.conflicts(with: .command, selfMode: .bareModifierDictation))
+        XCTAssertTrue(rightCommand.conflicts(with: .command, otherMode: .bareModifierDictation))
+    }
+
     // MARK: - Telemetry
 
     func testTelemetryKindMapsOnlyStructuralTriggerKind() {

--- a/Tests/MacParakeetTests/Hotkey/TransformsHotkeyRegistryTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/TransformsHotkeyRegistryTests.swift
@@ -283,6 +283,28 @@ final class TransformsHotkeyRegistryTests: XCTestCase {
         )
     }
 
+    func testCollisionBareModifierDictationReservedHotkeyAllowsChordUsingThatModifier() {
+        let opt1 = KeyboardShortcut(
+            modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,
+            keyCode: 0x12,
+            keyLabel: "1"
+        )
+        XCTAssertNil(
+            checker.check(
+                candidate: opt1,
+                existing: [:],
+                excludingPromptID: nil,
+                reservedHotkeys: [
+                    TransformShortcutReservedHotkey(
+                        name: "push to talk",
+                        trigger: .option,
+                        conflictMode: .bareModifierDictation
+                    )
+                ]
+            )
+        )
+    }
+
     func testCollisionModifierChordReservedHotkeyDoesNotConflictWithSubsetTransformChord() {
         let opt4 = KeyboardShortcut(
             modifiers: KeyboardShortcut.ModifierFlag.option.rawValue,

--- a/Tests/MacParakeetTests/ViewModels/TransformsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TransformsViewModelTests.swift
@@ -200,6 +200,29 @@ final class TransformsViewModelTests: XCTestCase {
         XCTAssertEqual(reloadedPolish.shortcut?.displayString, "⌥4")
     }
 
+    func testResetBuiltInAllowsDefaultShortcutWhenReservedByBareModifierDictationHotkey() async throws {
+        var polish = try XCTUnwrap(viewModel.transforms.first(where: { $0.name == "Polish" }))
+        polish.content = "Custom polish prompt body."
+        polish.keyboardShortcut = KeyboardShortcut.parse("opt+4")!.encodedString()
+        let savedPolish = await viewModel.save(polish)
+        XCTAssertTrue(savedPolish)
+
+        let reset = await viewModel.resetBuiltIn(
+            polish,
+            reservedHotkeys: [
+                TransformShortcutReservedHotkey(
+                    name: "push to talk",
+                    trigger: .option,
+                    conflictMode: .bareModifierDictation
+                )
+            ]
+        )
+        XCTAssertTrue(reset)
+
+        let reloadedPolish = try XCTUnwrap(viewModel.transforms.first(where: { $0.id == polish.id }))
+        XCTAssertEqual(reloadedPolish.shortcut?.displayString, "⌥1")
+    }
+
     func testReseedMissingBuiltInsRecreatesDeletedDefault() async throws {
         // Force-delete Polish via raw SQL (bypassing the built-in protection)
         // to simulate a corrupted state where a built-in is missing.


### PR DESCRIPTION
## Summary
- Adds a policy-aware hotkey conflict mode for bare modifier dictation triggers.
- Applies it to both hands-free and push-to-talk, so solo Command/Option can coexist with normal chords like Cmd+Shift+M or Option+1.
- Keeps hands-free and push-to-talk mutually exclusive with each other.
- Aligns app, Transform binding/reset logic, and CLI Transform shortcut validation.

Closes #323.

## Testing
- git diff --check
- swift test --filter HotkeyTriggerTests --filter HotkeyManagerTests --filter AppHotkeyCoordinatorTests --filter TransformsHotkeyRegistryTests --filter TransformsViewModelTests --filter TransformsCommandTests
- swift test: 2841 XCTest tests, 9 skipped, 0 failures; 16 Swift Testing tests, 0 failures