### PR TITLE
Fix side-specific Command hotkey capture

### DIFF
--- a/Sources/MacParakeet/Hotkey/GlobalShortcutManager.swift
+++ b/Sources/MacParakeet/Hotkey/GlobalShortcutManager.swift
@@ -122,13 +122,20 @@ public final class GlobalShortcutManager {
             return Unmanaged.passUnretained(event)
         }
 
-        handleModifierFlagsChanged(flags: event.flags)
+        handleModifierFlagsChanged(
+            flags: event.flags,
+            changedKeyCode: UInt16(event.getIntegerValueField(.keyboardEventKeycode))
+        )
         return Unmanaged.passUnretained(event)
     }
 
-    private func handleModifierFlagsChanged(flags: CGEventFlags) {
+    private func handleModifierFlagsChanged(flags: CGEventFlags, changedKeyCode: UInt16? = nil) {
         if let targetKeyCode = trigger.modifierKeyCode {
-            handleSideSpecificModifierFlagsChanged(flags: flags, targetKeyCode: targetKeyCode)
+            handleSideSpecificModifierFlagsChanged(
+                flags: flags,
+                targetKeyCode: targetKeyCode,
+                changedKeyCode: changedKeyCode
+            )
             return
         }
 
@@ -141,9 +148,22 @@ public final class GlobalShortcutManager {
         }
     }
 
-    private func handleSideSpecificModifierFlagsChanged(flags: CGEventFlags, targetKeyCode: UInt16) {
-        let isPressed = ModifierKeyMatcher.sideSpecificModifierIsPressed(flags: flags, keyCode: targetKeyCode)
-        let oppositeIsPressed = ModifierKeyMatcher.oppositeSideModifierIsPressed(flags: flags, keyCode: targetKeyCode)
+    private func handleSideSpecificModifierFlagsChanged(
+        flags: CGEventFlags,
+        targetKeyCode: UInt16,
+        changedKeyCode: UInt16?
+    ) {
+        let isPressed = ModifierKeyMatcher.sideSpecificModifierIsPressed(
+            flags: flags,
+            keyCode: targetKeyCode,
+            changedKeyCode: changedKeyCode,
+            previouslyPressed: targetModifierWasPressed
+        )
+        let oppositeIsPressed = ModifierKeyMatcher.oppositeSideModifierIsPressed(
+            flags: flags,
+            keyCode: targetKeyCode,
+            changedKeyCode: changedKeyCode
+        )
 
         guard isPressed else {
             targetModifierWasPressed = false
@@ -326,9 +346,9 @@ public final class GlobalShortcutManager {
         )
     }
 
-    func modifierFlagsChangedForTesting(flags: CGEventFlags) {
+    func modifierFlagsChangedForTesting(flags: CGEventFlags, changedKeyCode: UInt16? = nil) {
         guard trigger.kind == .modifier else { return }
-        handleModifierFlagsChanged(flags: flags)
+        handleModifierFlagsChanged(flags: flags, changedKeyCode: changedKeyCode)
     }
 
     func modifierChordFlagsChangedForTesting(flags: CGEventFlags) {

--- a/Sources/MacParakeet/Hotkey/HotkeyManager.swift
+++ b/Sources/MacParakeet/Hotkey/HotkeyManager.swift
@@ -202,10 +202,12 @@ public final class HotkeyManager {
 
         if type == .flagsChanged {
             let flags = event.flags
+            let changedKeyCode = UInt16(event.getIntegerValueField(.keyboardEventKeycode))
             handleOutputs(
                 modifierFlagsChangedOutputs(
                     flags: flags,
-                    timestampMs: timestampMs
+                    timestampMs: timestampMs,
+                    changedKeyCode: changedKeyCode
                 )
             )
             previousModifierFlags = flags
@@ -224,17 +226,27 @@ public final class HotkeyManager {
 
     private func modifierFlagsChangedOutputs(
         flags: CGEventFlags,
-        timestampMs: UInt64
+        timestampMs: UInt64,
+        changedKeyCode: UInt16? = nil
     ) -> [HotkeyGestureController.Output] {
         if let targetKeyCode = trigger.modifierKeyCode {
             // ── Side-specific detection (e.g. right-option only) ──
-            let isPressed = ModifierKeyMatcher.sideSpecificModifierIsPressed(flags: flags, keyCode: targetKeyCode)
             let wasPressed = targetModifierWasPressed
+            let isPressed = ModifierKeyMatcher.sideSpecificModifierIsPressed(
+                flags: flags,
+                keyCode: targetKeyCode,
+                changedKeyCode: changedKeyCode,
+                previouslyPressed: wasPressed
+            )
             targetModifierWasPressed = isPressed
 
             if isPressed != wasPressed {
                 if isPressed {
-                    guard !ModifierKeyMatcher.oppositeSideModifierIsPressed(flags: flags, keyCode: targetKeyCode) else {
+                    guard !ModifierKeyMatcher.oppositeSideModifierIsPressed(
+                        flags: flags,
+                        keyCode: targetKeyCode,
+                        changedKeyCode: changedKeyCode
+                    ) else {
                         return []
                     }
 
@@ -261,19 +273,29 @@ public final class HotkeyManager {
                 return outputs
             }
 
-            // Derive tracked modifier changes from the previous/current flags instead of
-            // relying on kCGKeyboardEventKeycode, which is undefined for flagsChanged.
+            // Prefer side-specific flag transitions, but include the changed
+            // modifier keyCode as a fallback when macOS only reports the
+            // generic modifier bit.
             let changedTrackedModifiers = Self.changedTrackedModifierKeyCodes(
                 from: previousModifierFlags,
-                to: flags
+                to: flags,
+                changedKeyCode: changedKeyCode
             ).subtracting([targetKeyCode])
             if targetModifierGestureIsActive, !changedTrackedModifiers.isEmpty {
                 bareTap = false
                 return gestureMode == .singleTapToggle ? [] : gestureController.interrupted()
             }
+            // The target gesture is inactive while double-tap mode waits for a
+            // second tap. Opposite-side modifier taps still need to cancel
+            // that pending tap.
             if let oppositeKeyCode = HotkeyTrigger.oppositeModifierKeyCode(for: targetKeyCode),
                changedTrackedModifiers.contains(oppositeKeyCode),
-               ModifierKeyMatcher.sideSpecificModifierIsPressed(flags: flags, keyCode: oppositeKeyCode) {
+               ModifierKeyMatcher.sideSpecificModifierIsPressed(
+                   flags: flags,
+                   keyCode: oppositeKeyCode,
+                   changedKeyCode: changedKeyCode,
+                   previouslyPressed: false
+               ) {
                 return gestureMode == .singleTapToggle ? [] : gestureController.interrupted()
             }
             return []
@@ -351,9 +373,14 @@ public final class HotkeyManager {
     // without constructing CGEvents or arming timers.
     func modifierFlagsChangedOutputsForTesting(
         flags: CGEventFlags,
-        timestampMs: UInt64
+        timestampMs: UInt64,
+        changedKeyCode: UInt16? = nil
     ) -> [HotkeyGestureController.Output] {
-        let outputs = modifierFlagsChangedOutputs(flags: flags, timestampMs: timestampMs)
+        let outputs = modifierFlagsChangedOutputs(
+            flags: flags,
+            timestampMs: timestampMs,
+            changedKeyCode: changedKeyCode
+        )
         rememberRecordingState(for: outputs)
         previousModifierFlags = flags
         return outputs
@@ -932,9 +959,14 @@ public final class HotkeyManager {
 
     private static func changedTrackedModifierKeyCodes(
         from previousFlags: CGEventFlags,
-        to currentFlags: CGEventFlags
+        to currentFlags: CGEventFlags,
+        changedKeyCode: UInt16?
     ) -> Set<UInt16> {
-        ModifierKeyMatcher.changedTrackedModifierKeyCodes(from: previousFlags, to: currentFlags)
+        ModifierKeyMatcher.changedTrackedModifierKeyCodes(
+            from: previousFlags,
+            to: currentFlags,
+            changedKeyCode: changedKeyCode
+        )
     }
 
     private func handleOutputs(_ outputs: [HotkeyGestureController.Output]) {

--- a/Sources/MacParakeet/Hotkey/ModifierKeyMatcher.swift
+++ b/Sources/MacParakeet/Hotkey/ModifierKeyMatcher.swift
@@ -73,9 +73,76 @@ enum ModifierKeyMatcher {
         return (flags.rawValue & mask) != 0
     }
 
+    static func sideSpecificModifierIsPressed(
+        flags: CGEventFlags,
+        keyCode: UInt16,
+        changedKeyCode: UInt16?,
+        previouslyPressed: Bool
+    ) -> Bool {
+        guard let changedKeyCode else {
+            return sideSpecificModifierIsPressed(flags: flags, keyCode: keyCode)
+        }
+        if sideSpecificModifierSideIsPressed(flags: flags, keyCode: keyCode) {
+            return sideSpecificModifierIsPressed(flags: flags, keyCode: keyCode)
+        }
+        guard changedKeyCode == keyCode,
+              let modifierName = HotkeyTrigger.modifierName(forKeyCode: keyCode),
+              let mask = mask(for: modifierName) else {
+            return previouslyPressed
+        }
+        return flags.contains(mask)
+    }
+
     static func oppositeSideModifierIsPressed(flags: CGEventFlags, keyCode: UInt16) -> Bool {
         guard let oppositeKeyCode = HotkeyTrigger.oppositeModifierKeyCode(for: keyCode) else { return false }
         return sideSpecificModifierIsPressed(flags: flags, keyCode: oppositeKeyCode)
+    }
+
+    static func oppositeSideModifierIsPressed(
+        flags: CGEventFlags,
+        keyCode: UInt16,
+        changedKeyCode: UInt16?
+    ) -> Bool {
+        guard let changedKeyCode else {
+            return oppositeSideModifierIsPressed(flags: flags, keyCode: keyCode)
+        }
+        guard let oppositeKeyCode = HotkeyTrigger.oppositeModifierKeyCode(for: keyCode) else { return false }
+        if sideSpecificModifierSideIsPressed(flags: flags, keyCode: keyCode) {
+            return sideSpecificModifierIsPressed(flags: flags, keyCode: oppositeKeyCode)
+        }
+        // Without side-specific device bits, the current event can only prove
+        // which physical modifier changed; it cannot prove the opposite side
+        // was already held from an earlier event.
+        guard changedKeyCode == oppositeKeyCode,
+              let modifierName = HotkeyTrigger.modifierName(forKeyCode: oppositeKeyCode),
+              let mask = mask(for: modifierName) else {
+            return false
+        }
+        return flags.contains(mask)
+    }
+
+    static func changedTrackedModifierKeyCodes(
+        from previousFlags: CGEventFlags,
+        to currentFlags: CGEventFlags,
+        changedKeyCode: UInt16?
+    ) -> Set<UInt16> {
+        var changed = changedTrackedModifierKeyCodes(from: previousFlags, to: currentFlags)
+        guard let changedKeyCode else { return changed }
+        if HotkeyTrigger.isFnKeyCode(changedKeyCode) {
+            changed.insert(HotkeyTrigger.canonicalFnKeyCode)
+        } else if HotkeyTrigger.modifierComponent(forKeyCode: changedKeyCode) != nil {
+            changed.insert(changedKeyCode)
+        }
+        return changed
+    }
+
+    private static func sideSpecificModifierSideIsPressed(flags: CGEventFlags, keyCode: UInt16) -> Bool {
+        guard let oppositeKeyCode = HotkeyTrigger.oppositeModifierKeyCode(for: keyCode),
+              let mask = sideSpecificModifierMasks[keyCode],
+              let oppositeMask = sideSpecificModifierMasks[oppositeKeyCode] else {
+            return false
+        }
+        return (flags.rawValue & (mask | oppositeMask)) != 0
     }
 
     static func mask(for name: String?) -> CGEventFlags? {

--- a/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
+++ b/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 ///                    Warning text shown below.
 struct HotkeyRecorderView: View {
     enum ModifierCaptureMode {
+        case standard
         case generic
         case sideSpecific
     }
@@ -29,7 +30,7 @@ struct HotkeyRecorderView: View {
     /// Tracks held modifiers during recording for two-phase chord capture.
     @State private var pendingModifierComponents: [HotkeyTrigger.ModifierComponent] = []
     @State private var candidateModifierComponents: [HotkeyTrigger.ModifierComponent] = []
-    @State private var modifierCaptureMode: ModifierCaptureMode = .generic
+    @State private var modifierCaptureMode: ModifierCaptureMode = .standard
 
     var body: some View {
         VStack(alignment: .trailing, spacing: 4) {
@@ -69,7 +70,7 @@ struct HotkeyRecorderView: View {
             }
 
             Button(trigger.isDisabled ? "Set Hotkey..." : "Change...") {
-                startRecording(modifierCaptureMode: .generic)
+                startRecording(modifierCaptureMode: .standard)
             }
             .parakeetAction(.secondary)
 
@@ -91,7 +92,11 @@ struct HotkeyRecorderView: View {
 
                 Divider()
 
-                Button("Record Specific Modifier Side") {
+                Button("Record Either-Side Modifier") {
+                    startRecording(modifierCaptureMode: .generic)
+                }
+
+                Button("Record Specific-Side Modifier Chord") {
                     startRecording(modifierCaptureMode: .sideSpecific)
                 }
             } label: {
@@ -134,7 +139,7 @@ struct HotkeyRecorderView: View {
 
     /// Symbols for currently held modifiers in standard macOS order (⌃⌥⇧⌘).
     private var pendingModifierSymbols: String {
-        if modifierCaptureMode == .sideSpecific {
+        if modifierCaptureMode == .standard || modifierCaptureMode == .sideSpecific {
             if pendingModifierComponents.map(\.modifierName) == ["fn"] { return "fn" }
             return HotkeyTrigger.modifierChord(components: pendingModifierComponents).shortSymbol
         }
@@ -149,7 +154,7 @@ struct HotkeyRecorderView: View {
 
     // MARK: - Recording Logic
 
-    private func startRecording(modifierCaptureMode: ModifierCaptureMode = .generic) {
+    private func startRecording(modifierCaptureMode: ModifierCaptureMode = .standard) {
         // Guard against double-start leaking the existing monitor
         if eventMonitor != nil { stopRecording() }
 
@@ -323,7 +328,7 @@ struct HotkeyRecorderView: View {
             return chordModifiersFromFlags(event.modifierFlags).map {
                 HotkeyTrigger.ModifierComponent(modifierName: $0)
             }
-        case .sideSpecific:
+        case .standard, .sideSpecific:
             return Self.sideSpecificModifierComponentsAfterFlagsChanged(
                 pending: pendingModifierComponents,
                 eventKeyCode: event.keyCode,
@@ -387,7 +392,7 @@ struct HotkeyRecorderView: View {
         switch captureMode {
         case .generic:
             return HotkeyTrigger(kind: .modifier, modifierName: name, keyCode: nil)
-        case .sideSpecific:
+        case .standard, .sideSpecific:
             return HotkeyTrigger(kind: .modifier, modifierName: name, keyCode: nil, modifierKeyCode: keyCode)
         }
     }
@@ -398,7 +403,7 @@ struct HotkeyRecorderView: View {
     ) -> HotkeyTrigger? {
         let trigger: HotkeyTrigger
         switch captureMode {
-        case .generic:
+        case .standard, .generic:
             trigger = HotkeyTrigger.modifierChord(
                 components: components.map {
                     HotkeyTrigger.ModifierComponent(modifierName: $0.modifierName)
@@ -420,7 +425,7 @@ struct HotkeyRecorderView: View {
         keyCode: UInt16,
         captureMode: ModifierCaptureMode
     ) -> HotkeyTrigger? {
-        guard captureMode == .generic else { return nil }
+        guard captureMode == .standard || captureMode == .generic else { return nil }
         return HotkeyTrigger.chord(modifiers: modifiers, keyCode: keyCode)
     }
 
@@ -452,7 +457,7 @@ struct HotkeyRecorderView: View {
         isRecording = false
         pendingModifierComponents = []
         candidateModifierComponents = []
-        modifierCaptureMode = .generic
+        modifierCaptureMode = .standard
         if let monitor = eventMonitor {
             NSEvent.removeMonitor(monitor)
             eventMonitor = nil

--- a/Tests/MacParakeetTests/Hotkey/GlobalShortcutManagerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/GlobalShortcutManagerTests.swift
@@ -237,6 +237,21 @@ final class GlobalShortcutManagerTests: XCTestCase {
         XCTAssertEqual(triggerCount, 2)
     }
 
+    func testSideSpecificRightCommandTriggersFromChangedKeyCodeWhenSideFlagsAreMissing() {
+        let trigger = HotkeyTrigger(kind: .modifier, modifierName: "command", keyCode: nil, modifierKeyCode: 54)
+        let manager = GlobalShortcutManager(trigger: trigger)
+        var triggerCount = 0
+        manager.onTrigger = { triggerCount += 1 }
+
+        manager.modifierFlagsChangedForTesting(flags: [.maskCommand], changedKeyCode: 55)
+        manager.modifierFlagsChangedForTesting(flags: [.maskCommand], changedKeyCode: 54)
+        manager.modifierFlagsChangedForTesting(flags: [.maskCommand], changedKeyCode: 54)
+        manager.modifierFlagsChangedForTesting(flags: [], changedKeyCode: 54)
+        manager.modifierFlagsChangedForTesting(flags: [.maskCommand], changedKeyCode: 54)
+
+        XCTAssertEqual(triggerCount, 2)
+    }
+
     func testSideSpecificModifierChordDoesNotTriggerAfterOppositeSideIsReleased() {
         let trigger = HotkeyTrigger.modifierChord(
             components: [

--- a/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
@@ -957,6 +957,79 @@ final class HotkeyManagerTests: XCTestCase {
 
     // MARK: - Side-Specific Modifier Detection
 
+    func testSideSpecificRightCommandTriggersFromChangedKeyCodeWhenSideFlagsAreMissing() {
+        let trigger = HotkeyTrigger(kind: .modifier, modifierName: "command", keyCode: nil, modifierKeyCode: 54)
+        let manager = HotkeyManager(trigger: trigger)
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskCommand],
+                timestampMs: 1_000,
+                changedKeyCode: 54
+            ),
+            [
+                .scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs),
+                .scheduleHoldWindow(milliseconds: FnKeyStateMachine.defaultTapThresholdMs),
+            ]
+        )
+    }
+
+    func testSideSpecificRightCommandIgnoresLeftCommandWhenSideFlagsAreMissing() {
+        let trigger = HotkeyTrigger(kind: .modifier, modifierName: "command", keyCode: nil, modifierKeyCode: 54)
+        let manager = HotkeyManager(trigger: trigger)
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskCommand],
+                timestampMs: 1_000,
+                changedKeyCode: 55
+            ),
+            []
+        )
+    }
+
+    func testSideSpecificRightCommandReleaseFromChangedKeyCodeWhenSideFlagsAreMissing() {
+        let trigger = HotkeyTrigger(kind: .modifier, modifierName: "command", keyCode: nil, modifierKeyCode: 54)
+        let manager = HotkeyManager(trigger: trigger)
+
+        _ = manager.modifierFlagsChangedOutputsForTesting(
+            flags: [.maskCommand],
+            timestampMs: 1_000,
+            changedKeyCode: 54
+        )
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_050,
+                changedKeyCode: 54
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow, .showReadyForSecondTap]
+        )
+    }
+
+    func testHoldOnlySideSpecificCommandCancelsBeforeStartupWhenUsedAsChord() {
+        let trigger = HotkeyTrigger(kind: .modifier, modifierName: "command", keyCode: nil, modifierKeyCode: 54)
+        let manager = HotkeyManager(trigger: trigger, gestureMode: .holdOnly)
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskCommand],
+                timestampMs: 1_000,
+                changedKeyCode: 54
+            ),
+            [.scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs)]
+        )
+        XCTAssertEqual(
+            manager.modifierKeyDownOutputsForTesting(keyCode: 8, timestampMs: 1_025),
+            [
+                .cancelStartupDebounce,
+                .cancelHoldWindow,
+            ]
+        )
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [])
+    }
+
     func testSideSpecificRightOptionOnlyTriggersOnRightKey() {
         let trigger = HotkeyTrigger(kind: .modifier, modifierName: "option", keyCode: nil, modifierKeyCode: 61)
         let manager = HotkeyManager(trigger: trigger)
@@ -1093,6 +1166,62 @@ final class HotkeyManagerTests: XCTestCase {
                     rightOptionMask
                 ),
                 timestampMs: 1_200
+            ),
+            [
+                .scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs),
+                .scheduleHoldWindow(milliseconds: FnKeyStateMachine.defaultTapThresholdMs),
+            ]
+        )
+    }
+
+    func testSideSpecificOppositeSideTapCancelsPendingSecondTapWhenSideFlagsAreMissing() {
+        let trigger = HotkeyTrigger(kind: .modifier, modifierName: "command", keyCode: nil, modifierKeyCode: 54)
+        let manager = HotkeyManager(trigger: trigger)
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskCommand],
+                timestampMs: 1_000,
+                changedKeyCode: 54
+            ),
+            [
+                .scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs),
+                .scheduleHoldWindow(milliseconds: FnKeyStateMachine.defaultTapThresholdMs),
+            ]
+        )
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_050,
+                changedKeyCode: 54
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow, .showReadyForSecondTap]
+        )
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskCommand],
+                timestampMs: 1_100,
+                changedKeyCode: 55
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow]
+        )
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_150,
+                changedKeyCode: 55
+            ),
+            []
+        )
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskCommand],
+                timestampMs: 1_200,
+                changedKeyCode: 54
             ),
             [
                 .scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs),

--- a/Tests/MacParakeetTests/Views/Settings/HotkeyRecorderViewTests.swift
+++ b/Tests/MacParakeetTests/Views/Settings/HotkeyRecorderViewTests.swift
@@ -4,6 +4,29 @@ import XCTest
 @testable import MacParakeetCore
 
 final class HotkeyRecorderViewTests: XCTestCase {
+    func testStandardBareModifierCaptureRecordsPhysicalModifierSide() {
+        let candidate = HotkeyRecorderView.bareModifierTrigger(
+            for: "command",
+            keyCode: 54,
+            captureMode: .standard
+        )
+
+        XCTAssertEqual(
+            candidate,
+            HotkeyTrigger(kind: .modifier, modifierName: "command", keyCode: nil, modifierKeyCode: 54)
+        )
+    }
+
+    func testStandardModifierKeyChordCapturePreservesGenericChordBehavior() {
+        let candidate = HotkeyRecorderView.keyChordTrigger(
+            modifiers: ["command"],
+            keyCode: 8,
+            captureMode: .standard
+        )
+
+        XCTAssertEqual(candidate, .chord(modifiers: ["command"], keyCode: 8))
+    }
+
     func testGenericBareModifierCapturePreservesEitherSideBehavior() {
         let candidate = HotkeyRecorderView.bareModifierTrigger(
             for: "option",


### PR DESCRIPTION
## Summary
- Record bare modifier presses from the normal hotkey recorder as physical left/right modifiers, so Left Command and Right Command save distinctly.
- Keep modifier+key chords generic, and add an advanced menu option for recording either modifier side when desired.
- Add a runtime fallback for side-specific modifier hotkeys when flagsChanged carries the changed keyCode but not side-specific flag bits.

## Verification
- `git diff --check`
- `swift test --filter HotkeyRecorderViewTests --filter HotkeyManagerTests --filter GlobalShortcutManagerTests`
- `swift test`

## Notes
This is a dedicated follow-up to the bare-modifier hotkey work. It targets the observed Left/Right Command recognition gap without changing the default Fn+Space behavior.