### PR TITLE
Support optional LM Studio API tokens

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -84,6 +84,8 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 - LLM-backed commands now expose `--allow-insecure-http` for intentional
   non-loopback `http://` endpoints on non-local providers.
+- `llm` commands using `--provider lmstudio` now honor optional LM Studio API
+  tokens via `--api-key`, `--api-key-env`, or `LM_API_TOKEN`.
 
 ### Changed
 

--- a/Sources/CLI/Commands/LLMInlineConfig.swift
+++ b/Sources/CLI/Commands/LLMInlineConfig.swift
@@ -170,7 +170,11 @@ struct LLMInlineOptions: ParsableArguments {
                   !rawModel.isEmpty else {
                 throw ValidationError("--model is required for LM Studio")
             }
-            providerConfig = .lmstudio(model: rawModel, baseURL: overrideURL)
+            providerConfig = .lmstudio(
+                apiKey: try optionalAPIKey(defaultEnvNames: ["LM_API_TOKEN"], environment: environment),
+                model: rawModel,
+                baseURL: overrideURL
+            )
         case .localCLI:
             guard let rawCommand = command,
                   !rawCommand.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {

--- a/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
@@ -29,7 +29,7 @@ struct LLMSettingsView: View {
             if viewModel.selectedProviderID != nil {
                 Divider()
 
-                // API key (hidden for local providers)
+                // API key (hidden for providers that cannot use one)
                 if viewModel.supportsAPIKey {
                     HStack(alignment: .top) {
                         VStack(alignment: .leading, spacing: 2) {
@@ -44,7 +44,7 @@ struct LLMSettingsView: View {
                                 .foregroundStyle(.secondary)
                         }
                         Spacer(minLength: DesignSystem.Spacing.md)
-                        SecureField("sk-...", text: $viewModel.apiKeyInput)
+                        SecureField(viewModel.selectedProviderID == .lmstudio ? "LM Studio token" : "sk-...", text: $viewModel.apiKeyInput)
                             .textFieldStyle(.roundedBorder)
                             .frame(width: 220)
                     }
@@ -501,7 +501,7 @@ struct LLMSettingsView: View {
                 .foregroundStyle(isLocal ? DesignSystem.Colors.successGreen : DesignSystem.Colors.warningAmber)
 
             Text(isLocal
-                 ? "Transcript text stays on this Mac."
+                 ? "Transcript text is sent only to your local AI endpoint."
                  : isCLI
                     ? "Runs a command on this Mac. The command may contact its own service."
                     : "Transcription stays local. Transcript text is sent only when you run an AI action.")

--- a/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
@@ -44,7 +44,7 @@ struct LLMSettingsView: View {
                                 .foregroundStyle(.secondary)
                         }
                         Spacer(minLength: DesignSystem.Spacing.md)
-                        SecureField(viewModel.selectedProviderID == .lmstudio ? "LM Studio token" : "sk-...", text: $viewModel.apiKeyInput)
+                        SecureField(viewModel.apiKeyPlaceholder, text: $viewModel.apiKeyInput)
                             .textFieldStyle(.roundedBorder)
                             .frame(width: 220)
                     }

--- a/Sources/MacParakeetCore/Models/LLMProvider.swift
+++ b/Sources/MacParakeetCore/Models/LLMProvider.swift
@@ -37,8 +37,8 @@ public enum LLMProviderID: String, Codable, Sendable, CaseIterable {
     /// Whether the provider supports API-key-based auth.
     public var supportsAPIKey: Bool {
         switch self {
-        case .ollama, .lmstudio, .localCLI: return false
-        case .anthropic, .openai, .openaiCompatible, .gemini, .openrouter: return true
+        case .ollama, .localCLI: return false
+        case .anthropic, .openai, .openaiCompatible, .gemini, .openrouter, .lmstudio: return true
         }
     }
 
@@ -157,11 +157,11 @@ public struct LLMProviderConfig: Codable, Sendable, Equatable {
         )
     }
 
-    public static func lmstudio(model: String = "", baseURL: URL? = nil) -> LLMProviderConfig {
+    public static func lmstudio(apiKey: String? = nil, model: String = "", baseURL: URL? = nil) -> LLMProviderConfig {
         LLMProviderConfig(
             id: .lmstudio,
             baseURL: baseURL ?? URL(string: "http://localhost:1234/v1")!,
-            apiKey: nil,
+            apiKey: apiKey,
             modelName: model,
             isLocal: true
         )

--- a/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
@@ -75,6 +75,25 @@ public final class LLMSettingsViewModel {
         return defaultURL.isEmpty ? fallback : defaultURL
     }
 
+    public var apiKeyPlaceholder: String {
+        switch draft.providerID {
+        case .lmstudio:
+            return "LM Studio token"
+        case .anthropic:
+            return "sk-ant-..."
+        case .gemini:
+            return "Gemini API key"
+        case .openrouter:
+            return "sk-or-..."
+        case .openaiCompatible:
+            return "Optional API key"
+        case .openai:
+            return "sk-..."
+        case .ollama, .localCLI, nil:
+            return ""
+        }
+    }
+
     public var useCustomModel: Bool {
         get { draft.useCustomModel }
         set {

--- a/Tests/CLITests/LLMConfigCommandTests.swift
+++ b/Tests/CLITests/LLMConfigCommandTests.swift
@@ -84,6 +84,20 @@ final class LLMConfigCommandTests: XCTestCase {
         XCTAssertNil(config.apiKey)
     }
 
+    func testInlineOptionsBuildLMStudioConfigWithOptionalAPIKeyEnvironment() throws {
+        let options = try LLMInlineOptions.parse([
+            "--provider", "lmstudio",
+            "--model", "local-model",
+        ])
+
+        let config = try options.buildConfig(environment: ["LM_API_TOKEN": "lm-token"])
+        XCTAssertEqual(config.id, .lmstudio)
+        XCTAssertEqual(config.apiKey, "lm-token")
+        XCTAssertEqual(config.baseURL.absoluteString, "http://localhost:1234/v1")
+        XCTAssertEqual(config.modelName, "local-model")
+        XCTAssertTrue(config.isLocal)
+    }
+
     func testInlineOptionsReadStandardProviderEnvironment() throws {
         let options = try LLMInlineOptions.parse([
             "--provider", "anthropic",

--- a/Tests/CLITests/LLMConfigCommandTests.swift
+++ b/Tests/CLITests/LLMConfigCommandTests.swift
@@ -98,6 +98,20 @@ final class LLMConfigCommandTests: XCTestCase {
         XCTAssertTrue(config.isLocal)
     }
 
+    func testInlineOptionsBuildLMStudioConfigWithoutAPIKey() throws {
+        let options = try LLMInlineOptions.parse([
+            "--provider", "lmstudio",
+            "--model", "local-model",
+        ])
+
+        let config = try options.buildConfig(environment: [:])
+        XCTAssertEqual(config.id, .lmstudio)
+        XCTAssertNil(config.apiKey)
+        XCTAssertEqual(config.baseURL.absoluteString, "http://localhost:1234/v1")
+        XCTAssertEqual(config.modelName, "local-model")
+        XCTAssertTrue(config.isLocal)
+    }
+
     func testInlineOptionsReadStandardProviderEnvironment() throws {
         let options = try LLMInlineOptions.parse([
             "--provider", "anthropic",

--- a/Tests/MacParakeetTests/Services/LLM/LLMClientTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMClientTests.swift
@@ -223,6 +223,25 @@ final class LLMClientTests: XCTestCase {
         XCTAssertNil(capturedRequest?.value(forHTTPHeaderField: "Authorization"))
     }
 
+    func testLMStudioAuthHeaderSetFromOptionalAPIKey() async throws {
+        var capturedRequest: URLRequest?
+
+        MockURLProtocol.handler = { request in
+            capturedRequest = request
+            return (self.okResponse(for: request), self.validResponseData())
+        }
+
+        let config = LLMProviderConfig.lmstudio(apiKey: "lm-token", model: "local-model")
+        _ = try await llmClient.chatCompletion(
+            messages: [ChatMessage(role: .user, content: "Hi")],
+            config: config,
+            options: .default
+        )
+
+        XCTAssertEqual(capturedRequest?.url?.absoluteString, "http://localhost:1234/v1/chat/completions")
+        XCTAssertEqual(capturedRequest?.value(forHTTPHeaderField: "Authorization"), "Bearer lm-token")
+    }
+
     // MARK: - Request Body
 
     func testRequestBodyContainsModelAndMessages() async throws {

--- a/Tests/MacParakeetTests/Services/LLM/LLMConfigStoreTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMConfigStoreTests.swift
@@ -73,6 +73,20 @@ final class LLMConfigStoreTests: XCTestCase {
         XCTAssertEqual(loaded?.isLocal, true)
     }
 
+    func testLMStudioOptionalAPIKeyStoredInKeychain() throws {
+        let config = LLMProviderConfig.lmstudio(apiKey: "lm-token", model: "local-model")
+        try store.saveConfig(config)
+
+        XCTAssertEqual(try keychain.getString("llm_api_key_lmstudio"), "lm-token")
+        let data = defaults.data(forKey: "llm_provider_config")!
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        XCTAssertNil(json["apiKey"])
+
+        let loaded = try store.loadConfig()
+        XCTAssertEqual(loaded?.id, .lmstudio)
+        XCTAssertEqual(loaded?.apiKey, "lm-token")
+    }
+
     func testOverwriteAPIKey() throws {
         let config1 = LLMProviderConfig.openai(apiKey: "old-key")
         try store.saveConfig(config1)

--- a/Tests/MacParakeetTests/ViewModels/LLMSettingsDraftTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LLMSettingsDraftTests.swift
@@ -136,6 +136,21 @@ final class LLMSettingsDraftTests: XCTestCase {
         XCTAssertEqual(config?.modelName, "")
     }
 
+    func testLMStudioAllowsOptionalAPIKey() throws {
+        let draft = LLMSettingsDraft(
+            providerID: .lmstudio,
+            apiKeyInput: "lm-token",
+            suggestedModelName: "local-model"
+        )
+
+        XCTAssertNil(draft.validationError)
+
+        let config = try draft.buildConfig(defaultBaseURL: "http://localhost:1234/v1")
+        XCTAssertEqual(config?.id, .lmstudio)
+        XCTAssertEqual(config?.apiKey, "lm-token")
+        XCTAssertTrue(config?.isLocal == true)
+    }
+
     func testOpenAICompatibleProviderRequiresCustomEndpoint() {
         let draft = LLMSettingsDraft(
             providerID: .openaiCompatible,

--- a/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
@@ -110,6 +110,25 @@ final class LLMSettingsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.requiresAPIKey)
     }
 
+    func testAPIKeyPlaceholderIsProviderSpecific() {
+        viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
+
+        viewModel.selectedProviderID = .lmstudio
+        XCTAssertEqual(viewModel.apiKeyPlaceholder, "LM Studio token")
+
+        viewModel.selectedProviderID = .anthropic
+        XCTAssertEqual(viewModel.apiKeyPlaceholder, "sk-ant-...")
+
+        viewModel.selectedProviderID = .openrouter
+        XCTAssertEqual(viewModel.apiKeyPlaceholder, "sk-or-...")
+
+        viewModel.selectedProviderID = .gemini
+        XCTAssertEqual(viewModel.apiKeyPlaceholder, "Gemini API key")
+
+        viewModel.selectedProviderID = .openaiCompatible
+        XCTAssertEqual(viewModel.apiKeyPlaceholder, "Optional API key")
+    }
+
     func testOpenAICompatibleProviderStartsInCustomModelMode() {
         viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
         viewModel.selectedProviderID = .openaiCompatible

--- a/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
@@ -101,6 +101,7 @@ final class LLMSettingsViewModelTests: XCTestCase {
         viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
         viewModel.selectedProviderID = .lmstudio
         XCTAssertFalse(viewModel.requiresAPIKey)
+        XCTAssertTrue(viewModel.supportsAPIKey)
     }
 
     func testCloudProviderRequiresAPIKey() {
@@ -414,6 +415,21 @@ final class LLMSettingsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.useCustomModel)
         XCTAssertEqual(viewModel.modelName, "llama-3.2")
         XCTAssertNil(viewModel.modelListErrorMessage)
+    }
+
+    func testLMStudioSavesOptionalAPIKey() async throws {
+        mockClient.modelsList = ["local-model"]
+        viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
+
+        viewModel.selectedProviderID = .lmstudio
+        try await Task.sleep(nanoseconds: 100_000_000)
+        viewModel.apiKeyInput = "lm-token"
+        viewModel.saveConfiguration()
+
+        let saved = mockConfigStore.config
+        XCTAssertEqual(saved?.id, .lmstudio)
+        XCTAssertEqual(saved?.apiKey, "lm-token")
+        XCTAssertEqual(saved?.modelName, "local-model")
     }
 
     func testOllamaLoadsAvailableModelsAndDefaultsToFirstResult() async throws {

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -416,7 +416,8 @@ swift run macparakeet-cli vocab snippets delete <ID>
 
 All LLM commands require `--provider`; `--api-key` is required only for providers
 that need one. Ollama, LM Studio, OpenAI-compatible local endpoints, and Local
-CLI can run without an API key.
+CLI can run without an API key; LM Studio also accepts an optional API token
+when its server-side authentication is enabled.
 
 ### Supported Providers
 
@@ -428,7 +429,7 @@ CLI can run without an API key.
 | `gemini` | gemini-2.5-flash | Yes |
 | `openrouter` | anthropic/claude-sonnet-4 | Yes |
 | `ollama` | qwen3.5:4b | No (local) |
-| `lmstudio` | user-selected in LM Studio | No (local) |
+| `lmstudio` | user-selected in LM Studio | Optional (local) |
 | `cli` | N/A (tool decides) | No (tool manages auth) |
 
 ### Test Connection
@@ -477,6 +478,9 @@ swift run macparakeet-cli llm test-connection --provider lmstudio --model qwen3.
 
 # Summarize via LM Studio's OpenAI-compatible endpoint
 swift run macparakeet-cli llm summarize transcript.txt --provider lmstudio --model qwen3.5-27b
+
+# Use an LM Studio API token when Require Authentication is enabled
+swift run macparakeet-cli llm summarize transcript.txt --provider lmstudio --model qwen3.5-27b --api-key-env LM_API_TOKEN
 ```
 
 ### Common Options

--- a/spec/11-llm-integration.md
+++ b/spec/11-llm-integration.md
@@ -67,7 +67,7 @@ The service boundary stays stable even though the transport is mixed.
 | OpenAI-Compatible | Custom | User-supplied | Optional API key; local loopback endpoints are treated as local |
 | Google Gemini | Cloud | `https://generativelanguage.googleapis.com/v1beta/openai` | `Authorization: Bearer` |
 | Ollama | Local | `http://localhost:11434/v1` | `apiKey: nil` in config; client injects `Bearer ollama` |
-| LM Studio | Local | `http://localhost:1234/v1` | `apiKey: nil` in config |
+| LM Studio | Local | `http://localhost:1234/v1` | Optional API token (`Authorization: Bearer`) |
 | OpenRouter | Cloud | `https://openrouter.ai/api/v1` | `Authorization: Bearer` |
 | Local CLI | CLI | N/A (subprocess) | N/A (tool manages its own auth) |
 
@@ -83,7 +83,7 @@ The service boundary stays stable even though the transport is mixed.
 public struct LLMProviderConfig: Codable, Sendable, Equatable {
     public let id: LLMProviderID
     public let baseURL: URL
-    public let apiKey: String?         // nil for local providers; client injects Bearer ollama for Ollama
+    public let apiKey: String?         // nil for providers without auth; optional for LM Studio/OpenAI-compatible
     public let modelName: String       // e.g. "claude-sonnet-4-6", "gpt-4.1", "qwen3.5:4b"
     public let isLocal: Bool           // true for Ollama, LM Studio, and loopback OpenAI-compatible endpoints
 }
@@ -446,9 +446,10 @@ macparakeet-cli llm chat transcript.txt --provider openai --api-key sk-... --que
 # Transform text with custom instruction
 macparakeet-cli llm transform input.txt --provider anthropic --api-key sk-ant-... --prompt "Make formal"
 
-# LM Studio provider (no API key needed)
+# LM Studio provider (API key optional)
 macparakeet-cli llm test-connection --provider lmstudio --model qwen3.5-27b
 macparakeet-cli llm summarize transcript.txt --provider lmstudio --model qwen3.5-27b
+macparakeet-cli llm summarize transcript.txt --provider lmstudio --model qwen3.5-27b --api-key-env LM_API_TOKEN
 ```
 
 ```bash

--- a/spec/adr/011-llm-cloud-and-local-providers.md
+++ b/spec/adr/011-llm-cloud-and-local-providers.md
@@ -44,7 +44,7 @@ The current branch supports these provider/runtime types through one shared serv
 | Google (Gemini) | Cloud | `https://generativelanguage.googleapis.com/v1beta/openai` | API key (`Authorization: Bearer`) |
 | OpenRouter | Cloud | `https://openrouter.ai/api/v1` | API key (`Authorization: Bearer`) |
 | Ollama | Local | `http://localhost:11434/v1` | `apiKey: nil` in config; client injects `Bearer ollama` |
-| LM Studio | Local | `http://localhost:1234/v1` | `apiKey: nil` in config |
+| LM Studio | Local | `http://localhost:1234/v1` | Optional API token (`Authorization: Bearer`) |
 | Local CLI | CLI | N/A (subprocess) | N/A (tool manages its own auth) |
 
 **Amendment (2026-04-03): Local CLI provider.** Users with Claude Code or Codex subscriptions can use their CLI tools (`claude -p`, `codex exec`, or any custom command) for summaries, chat, and transforms — no separate API key needed. The CLI tool runs as a subprocess via `posix_spawn` with process group management. Prompts are delivered via stdin and `MACPARAKEET_*` environment variables. This extends the provider model without changing the `LLMClientProtocol` — a `RoutingLLMClient` dispatches `.localCLI` contexts to `LocalCLILLMClient` and everything else to the HTTP `LLMClient`. See PR #47.
@@ -162,7 +162,7 @@ Users who want local-only LLM can install Ollama (`brew install ollama && ollama
 public struct LLMProviderConfig: Codable, Sendable, Equatable {
     public let id: LLMProviderID       // .anthropic, .openai, .ollama, etc.
     public let baseURL: URL
-    public let apiKey: String?         // nil for local providers; client injects Bearer ollama for Ollama
+    public let apiKey: String?         // nil for providers without auth; optional for LM Studio/OpenAI-compatible
     public let modelName: String       // "claude-sonnet-4-6", "gpt-4.1", "qwen3.5:4b"
     public let isLocal: Bool           // true for Ollama, LM Studio, and loopback OpenAI-compatible endpoints
 }


### PR DESCRIPTION
## Summary
- Fixes #314.
- Allows LM Studio to store and send an optional API token while preserving the default no-auth local setup.
- Threads the token through Settings, saved provider config, CLI inline config, and HTTP Authorization headers.
- Updates specs, ADR-011, CLI docs, and changelog to document LM Studio's optional authenticated mode.

## Official docs checked
- LM Studio Authentication: API tokens are supported in LM Studio 0.4.0+ and sent as Authorization: Bearer tokens.
- LM Studio Server Settings: Require Authentication makes API clients provide a valid API token via the Authorization header.
- LM Studio OpenAI Compatibility: LM Studio exposes OpenAI-compatible /v1 endpoints, so the existing provider boundary remains correct.

## Validation
- swift test --filter LLMSettingsDraftTests --filter LLMSettingsViewModelTests --filter LLMClientTests --filter LLMConfigStoreTests --filter LLMConfigCommandTests
- swift test
- swift test --filter LLMConfigStoreTests
- git diff --check