### PR TITLE
Add app_category dimension + first_dictation_completed activation event

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MacParakeetCore
+import MacParakeetViewModels
 
 /// Service container: creates and wires up all dependencies.
 @MainActor
@@ -193,7 +194,17 @@ final class AppEnvironment {
             shouldUseAIFormatter: aiFormatterEnabledClosure,
             aiFormatterPromptTemplate: aiFormatterPromptClosure,
             markFirstDictationCompleted: { [runtimePreferences] in
-                runtimePreferences.markFirstDictationCompleted()
+                // Fire the activation milestone exactly once, the first time a
+                // dictation ever completes on this install. `activation_window`
+                // buckets the time since onboarding completed (coarse only).
+                guard runtimePreferences.markFirstDictationCompleted() else { return }
+                let secondsSinceOnboarding = UserDefaults.standard
+                    .string(forKey: OnboardingViewModel.onboardingCompletedKey)
+                    .flatMap { ISO8601DateFormatter().date(from: $0) }
+                    .map { Date().timeIntervalSince($0) }
+                Telemetry.send(.firstDictationCompleted(
+                    activationWindow: TelemetryActivationWindow(secondsSinceOnboarding: secondsSinceOnboarding)
+                ))
             }
         )
 

--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -813,7 +813,13 @@ final class DictationFlowCoordinator {
             do {
                 try await self.serviceSession.startRecording(
                     sessionID: sessionID,
-                    context: DictationTelemetryContext(trigger: trigger, mode: self.telemetryMode(for: mode))
+                    context: DictationTelemetryContext(
+                        trigger: trigger,
+                        mode: self.telemetryMode(for: mode),
+                        appCategory: TelemetryAppCategory(
+                            bundleIdentifier: NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+                        )
+                    )
                 )
                 let serviceState = await self.serviceSession.state
                 guard case .recording = serviceState else {

--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -815,10 +815,7 @@ final class DictationFlowCoordinator {
                     sessionID: sessionID,
                     context: DictationTelemetryContext(
                         trigger: trigger,
-                        mode: self.telemetryMode(for: mode),
-                        appCategory: TelemetryAppCategory(
-                            bundleIdentifier: NSWorkspace.shared.frontmostApplication?.bundleIdentifier
-                        )
+                        mode: self.telemetryMode(for: mode)
                     )
                 )
                 let serviceState = await self.serviceSession.state
@@ -903,6 +900,12 @@ final class DictationFlowCoordinator {
                 self.dictationLog.notice(
                     "stop_recording_requested gen=\(generation) session=\(sessionID) flowState=\(self.describeState(self.stateMachine.state), privacy: .public) serviceState=\(self.describeServiceState(serviceState), privacy: .public)"
                 )
+                await self.serviceSession.updateTelemetryAppCategory(
+                    TelemetryAppCategory(
+                        bundleIdentifier: NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+                    ),
+                    sessionID: sessionID
+                )
                 let result = try await self.serviceSession.stopRecording(sessionID: sessionID)
                 guard !Task.isCancelled else { return }
                 self.consumeDictationResult(result)
@@ -916,6 +919,13 @@ final class DictationFlowCoordinator {
     private func undoCancelTask(generation: Int) {
         actionTask = Task { @MainActor in
             do {
+                let sessionID = self.serviceSession.currentSessionID
+                await self.serviceSession.updateTelemetryAppCategory(
+                    TelemetryAppCategory(
+                        bundleIdentifier: NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+                    ),
+                    sessionID: sessionID
+                )
                 let result = try await self.serviceSession.undoCancel()
                 guard !Task.isCancelled else { return }
                 self.consumeDictationResult(result)

--- a/Sources/MacParakeet/App/TransformsCoordinator.swift
+++ b/Sources/MacParakeet/App/TransformsCoordinator.swift
@@ -240,12 +240,16 @@ final class TransformsCoordinator {
                 self.panelController?.done(message: "Done")
                 let capturePath: TelemetryTransformCapturePath = result.captureTag == "ax" ? .ax : .clipboard
                 let replacePath: TelemetryTransformReplacePath = result.path == .ax ? .ax : .clipboardPaste
+                // The target captured at trigger time is the app the rewritten
+                // text was pasted back into — map it to a coarse category only.
+                let appCategory = TelemetryAppCategory(bundleIdentifier: result.target?.bundleIdentifier)
                 Telemetry.send(.transformExecuted(
                     transformName: telemetryName,
                     capturePath: capturePath,
                     replacePath: replacePath,
                     llmMs: result.llmElapsedMs,
-                    totalMs: result.totalElapsedMs
+                    totalMs: result.totalElapsedMs,
+                    appCategory: appCategory
                 ))
                 self.sendTransformOperation(
                     operationContext: operationContext,
@@ -256,6 +260,7 @@ final class TransformsCoordinator {
                     replacePath: replacePath,
                     llmMs: result.llmElapsedMs,
                     totalMs: result.totalElapsedMs,
+                    appCategory: appCategory,
                     errorType: nil
                 )
                 self.saveHistoryEntry(prompt: prompt, result: result)
@@ -370,6 +375,7 @@ final class TransformsCoordinator {
         replacePath: TelemetryTransformReplacePath? = nil,
         llmMs: Int? = nil,
         totalMs: Int? = nil,
+        appCategory: TelemetryAppCategory? = nil,
         errorType: TelemetryTransformFailureReason? = nil
     ) {
         Telemetry.send(.transformOperation(
@@ -384,6 +390,7 @@ final class TransformsCoordinator {
                 ?? Observability.durationSeconds(since: operationContext.startedAt),
             llmMs: llmMs,
             totalMs: totalMs,
+            appCategory: appCategory,
             errorType: errorType
         ))
     }

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -13,7 +13,12 @@ public protocol AppRuntimePreferencesProtocol: Sendable {
     var selectedMicrophoneDeviceUID: String? { get }
     var meetingAudioSourceMode: MeetingAudioSourceMode { get }
     var hasCompletedFirstDictation: Bool { get }
-    func markFirstDictationCompleted()
+    /// Flip the one-shot "first dictation completed" flag. Returns `true` only
+    /// the first time it transitions (so callers can fire a one-shot side
+    /// effect like the activation telemetry event); `false` on every
+    /// subsequent call.
+    @discardableResult
+    func markFirstDictationCompleted() -> Bool
 }
 
 public enum YouTubeAudioQuality: String, CaseIterable, Hashable, Sendable, Equatable {
@@ -168,8 +173,10 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
         defaults.bool(forKey: Self.hasCompletedFirstDictationKey)
     }
 
-    public func markFirstDictationCompleted() {
-        guard !hasCompletedFirstDictation else { return }
+    @discardableResult
+    public func markFirstDictationCompleted() -> Bool {
+        guard !hasCompletedFirstDictation else { return false }
         defaults.set(true, forKey: Self.hasCompletedFirstDictationKey)
+        return true
     }
 }

--- a/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
+++ b/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
@@ -13,10 +13,10 @@ public enum DictationState: Sendable {
 public struct DictationTelemetryContext: Sendable, Equatable {
     public var trigger: TelemetryDictationTrigger?
     public var mode: TelemetryDictationMode?
-    /// Coarse category of the app that was frontmost when this dictation was
-    /// started — i.e. where the text will be pasted. Captured at the call site
-    /// (MainActor) since the overlay is non-activating, so frontmost stays the
-    /// user's target app. See `TelemetryAppCategory` for the privacy contract.
+    /// Coarse category of the app expected to receive the dictation paste.
+    /// The app layer refreshes this near stop/undo time so the value follows
+    /// the finish-target paste model instead of locking to the app active at
+    /// recording start. See `TelemetryAppCategory` for the privacy contract.
     public var appCategory: TelemetryAppCategory?
 
     public init(
@@ -139,6 +139,20 @@ public actor DictationService: DictationServiceProtocol {
 
     public func startRecording(context: DictationTelemetryContext = DictationTelemetryContext()) async throws {
         try await startRecording(context: context, sessionID: nil)
+    }
+
+    public func updateTelemetryAppCategory(
+        _ appCategory: TelemetryAppCategory?,
+        sessionID: Int? = nil
+    ) {
+        if let sessionID, sessionID != activeSessionID { return }
+        switch _state {
+        case .recording, .cancelled, .processing:
+            currentTelemetryContext.appCategory = appCategory
+            currentOperationTelemetryContext.appCategory = appCategory
+        case .idle, .success, .error:
+            return
+        }
     }
 
     public func startRecording(

--- a/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
+++ b/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
@@ -13,10 +13,20 @@ public enum DictationState: Sendable {
 public struct DictationTelemetryContext: Sendable, Equatable {
     public var trigger: TelemetryDictationTrigger?
     public var mode: TelemetryDictationMode?
+    /// Coarse category of the app that was frontmost when this dictation was
+    /// started — i.e. where the text will be pasted. Captured at the call site
+    /// (MainActor) since the overlay is non-activating, so frontmost stays the
+    /// user's target app. See `TelemetryAppCategory` for the privacy contract.
+    public var appCategory: TelemetryAppCategory?
 
-    public init(trigger: TelemetryDictationTrigger? = nil, mode: TelemetryDictationMode? = nil) {
+    public init(
+        trigger: TelemetryDictationTrigger? = nil,
+        mode: TelemetryDictationMode? = nil,
+        appCategory: TelemetryAppCategory? = nil
+    ) {
         self.trigger = trigger
         self.mode = mode
+        self.appCategory = appCategory
     }
 }
 
@@ -329,6 +339,7 @@ public actor DictationService: DictationServiceProtocol {
                 speechEngine: result.dictation.engine,
                 engineVariant: result.dictation.engineVariant,
                 language: result.dictation.language,
+                appCategory: currentTelemetryContext.appCategory,
                 device: device
             ))
             logger.debug(
@@ -487,6 +498,7 @@ public actor DictationService: DictationServiceProtocol {
                 speechEngine: result.dictation.engine,
                 engineVariant: result.dictation.engineVariant,
                 language: result.dictation.language,
+                appCategory: currentTelemetryContext.appCategory,
                 device: device
             ))
             try? await Task.sleep(for: .milliseconds(500))
@@ -835,6 +847,7 @@ public actor DictationService: DictationServiceProtocol {
             speechEngine: speechEngine,
             engineVariant: engineVariant,
             language: language,
+            appCategory: context.appCategory,
             device: device
         ))
     }

--- a/Sources/MacParakeetCore/Services/Dictation/DictationServiceSession.swift
+++ b/Sources/MacParakeetCore/Services/Dictation/DictationServiceSession.swift
@@ -46,6 +46,13 @@ public final class DictationServiceSession {
         try await service.stopRecording(sessionID: sessionID)
     }
 
+    public func updateTelemetryAppCategory(
+        _ appCategory: TelemetryAppCategory?,
+        sessionID: Int
+    ) async {
+        await service.updateTelemetryAppCategory(appCategory, sessionID: sessionID)
+    }
+
     public func cancelRecording(
         reason: TelemetryDictationCancelReason?,
         sessionID: Int

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryAppCategory.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryAppCategory.swift
@@ -1,0 +1,163 @@
+import Foundation
+
+/// Coarse category of the macOS application a dictation was pasted into, or
+/// that a Transform rewrote text inside.
+///
+/// Privacy contract (mirrors `docs/telemetry.md` item 10 — "track structural
+/// category only"): the frontmost app's bundle identifier is mapped to one of
+/// a small fixed set of buckets on-device, and **only the bucket** is
+/// transmitted. The bundle identifier itself never leaves the device, and any
+/// app we do not recognize maps to `.other` — so a user's niche or otherwise
+/// identifying app is never observable in telemetry.
+///
+/// Answers product questions like "what kinds of apps do people dictate into?"
+/// and "where do Transforms get used?" without identifying individual apps.
+public enum TelemetryAppCategory: String, Sendable, Equatable, CaseIterable {
+    case messaging
+    case email
+    case browser
+    case notes
+    case docs
+    case code
+    case terminal
+    case other
+
+    /// Map a frontmost-app bundle identifier to a coarse category. Returns
+    /// `.other` for a nil/empty/unknown identifier so unrecognized apps never
+    /// leak.
+    public init(bundleIdentifier: String?) {
+        guard
+            let raw = bundleIdentifier?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased(),
+            !raw.isEmpty
+        else {
+            self = .other
+            return
+        }
+        self = Self.category(forBundleID: raw)
+    }
+
+    private static func category(forBundleID id: String) -> TelemetryAppCategory {
+        // Vendor families with many sub-bundles are matched by prefix so we
+        // catch Canary/Insiders/EAP variants without enumerating each one.
+        if id.hasPrefix("com.jetbrains.") { return .code }
+        if id.hasPrefix("com.microsoft.vscode") { return .code }
+        if id.hasPrefix("com.google.chrome") { return .browser }
+
+        if browserIDs.contains(id) { return .browser }
+        if messagingIDs.contains(id) { return .messaging }
+        if emailIDs.contains(id) { return .email }
+        if notesIDs.contains(id) { return .notes }
+        if docsIDs.contains(id) { return .docs }
+        if codeIDs.contains(id) { return .code }
+        if terminalIDs.contains(id) { return .terminal }
+        return .other
+    }
+
+    // All identifiers are stored lowercased to match the normalized input.
+
+    private static let browserIDs: Set<String> = [
+        "com.apple.safari",
+        "com.apple.safaritechnologypreview",
+        "org.mozilla.firefox",
+        "org.mozilla.firefoxdeveloperedition",
+        "com.microsoft.edgemac",
+        "com.brave.browser",
+        "company.thebrowser.browser",     // Arc
+        "company.thebrowser.dia",         // Dia
+        "com.operasoftware.opera",
+        "com.vivaldi.vivaldi",
+    ]
+
+    private static let messagingIDs: Set<String> = [
+        "com.tinyspeck.slackmacgap",          // Slack
+        "com.apple.ichat",                    // Messages (legacy id)
+        "com.apple.mobilesms",                // Messages
+        "net.whatsapp.whatsapp",              // WhatsApp
+        "com.hnc.discord",                    // Discord
+        "ru.keepcoder.telegram",              // Telegram (macOS)
+        "org.telegram.desktop",               // Telegram Desktop
+        "com.microsoft.teams",                // Teams
+        "com.microsoft.teams2",               // Teams (new)
+        "org.whispersystems.signal-desktop",  // Signal
+        "com.facebook.archon",                // Messenger
+    ]
+
+    private static let emailIDs: Set<String> = [
+        "com.apple.mail",
+        "com.microsoft.outlook",
+        "com.readdle.smartemail-mac",         // Spark
+        "it.bloop.airmail2",                  // Airmail
+        "com.mimestream.mimestream",          // Mimestream
+    ]
+
+    private static let notesIDs: Set<String> = [
+        "com.apple.notes",
+        "md.obsidian",                        // Obsidian
+        "net.shinyfrog.bear",                 // Bear
+        "notion.id",                          // Notion
+        "com.lukilabs.lukiapp",               // Craft
+        "com.agiletortoise.drafts-osx",       // Drafts
+    ]
+
+    private static let docsIDs: Set<String> = [
+        "com.apple.iwork.pages",              // Pages
+        "com.apple.textedit",                 // TextEdit
+        "com.microsoft.word",                 // Word
+        "com.ulyssesapp.mac",                 // Ulysses
+        "com.soulmen.ulysses3",               // Ulysses (older)
+        "pro.writer.mac",                     // iA Writer
+        "com.literatureandlatte.scrivener3",  // Scrivener
+    ]
+
+    private static let codeIDs: Set<String> = [
+        "com.apple.dt.xcode",                 // Xcode
+        "com.todesktop.230313mzl4w4u92",      // Cursor
+        "com.sublimetext.4",                  // Sublime Text 4
+        "com.sublimetext.3",                  // Sublime Text 3
+        "dev.zed.zed",                        // Zed
+        "com.panic.nova",                     // Nova
+        "com.github.atom",                    // Atom
+    ]
+
+    private static let terminalIDs: Set<String> = [
+        "com.apple.terminal",
+        "com.googlecode.iterm2",              // iTerm2
+        "dev.warp.warp-stable",               // Warp
+        "com.mitchellh.ghostty",              // Ghostty
+        "org.alacritty",                      // Alacritty
+        "net.kovidgoyal.kitty",               // kitty
+        "co.zeit.hyper",                      // Hyper
+        "com.github.wez.wezterm",             // WezTerm
+    ]
+}
+
+/// Bucketed elapsed time between onboarding completion and a user's first
+/// completed dictation. Coarse buckets only — never the raw timestamp or
+/// duration — so the activation funnel is observable without a per-install
+/// clock that could be used to fingerprint.
+public enum TelemetryActivationWindow: String, Sendable, Equatable, CaseIterable {
+    case underMinute = "under_1m"
+    case underHour = "under_1h"
+    case underDay = "under_1d"
+    case underWeek = "under_1w"
+    case overWeek = "over_1w"
+    /// No onboarding timestamp on record (e.g. a pre-existing install from
+    /// before the timestamp was persisted), or a clock-skew negative value.
+    case unknown
+
+    public init(secondsSinceOnboarding seconds: TimeInterval?) {
+        guard let seconds, seconds >= 0 else {
+            self = .unknown
+            return
+        }
+        switch seconds {
+        case ..<60: self = .underMinute
+        case ..<3_600: self = .underHour
+        case ..<86_400: self = .underDay
+        case ..<604_800: self = .underWeek
+        default: self = .overWeek
+        }
+    }
+}

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryAppCategory.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryAppCategory.swift
@@ -3,9 +3,8 @@ import Foundation
 /// Coarse category of the macOS application a dictation was pasted into, or
 /// that a Transform rewrote text inside.
 ///
-/// Privacy contract (mirrors `docs/telemetry.md` item 10 — "track structural
-/// category only"): the frontmost app's bundle identifier is mapped to one of
-/// a small fixed set of buckets on-device, and **only the bucket** is
+/// Privacy contract: the frontmost app's bundle identifier is mapped to one of
+/// a small fixed set of structural buckets on-device, and **only the bucket** is
 /// transmitted. The bundle identifier itself never leaves the device, and any
 /// app we do not recognize maps to `.other` — so a user's niche or otherwise
 /// identifying app is never observable in telemetry.
@@ -119,6 +118,7 @@ public enum TelemetryAppCategory: String, Sendable, Equatable, CaseIterable {
         "dev.zed.zed",                        // Zed
         "com.panic.nova",                     // Nova
         "com.github.atom",                    // Atom
+        "com.google.android.studio",          // Android Studio
     ]
 
     private static let terminalIDs: Set<String> = [

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -39,9 +39,9 @@ public enum TelemetryEventName: String, Sendable, CaseIterable {
     /// hotkey-bound Transform completes end-to-end. Properties:
     /// `transform_name` (built-in name or `custom`), `capture_path`
     /// (`ax | clipboard`), `replace_path` (`ax | clipboardPaste`),
-    /// `llm_ms`, `total_ms`. NO prompt body, NO selected text, NO output.
-    /// Custom-Transform names map to `custom` so a Transform named after
-    /// e.g. an employer never leaves the device.
+    /// `llm_ms`, `total_ms`, and optional `app_category`. NO prompt body, NO
+    /// selected text, NO output. Custom-Transform names map to `custom` so a
+    /// Transform named after e.g. an employer never leaves the device.
     case transformExecuted = "transform_executed"
     case transformFailed = "transform_failed"
     case transformOperation = "transform_operation"
@@ -1076,15 +1076,14 @@ extension TelemetryEventSpec {
             if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
             return props
         case .transformExecuted(let name, let capture, let replace, let llmMs, let totalMs, let appCategory):
-            var props = [
-                "transform_name": name.rawValue,
-                "capture_path": capture.rawValue,
-                "replace_path": replace.rawValue,
-                "llm_ms": "\(llmMs)",
-                "total_ms": "\(totalMs)",
-            ]
-            if let appCategory { props["app_category"] = appCategory.rawValue }
-            return props
+            return Self.compactProps(
+                ("transform_name", name.rawValue),
+                ("capture_path", capture.rawValue),
+                ("replace_path", replace.rawValue),
+                ("llm_ms", "\(llmMs)"),
+                ("total_ms", "\(totalMs)"),
+                ("app_category", appCategory?.rawValue)
+            )
         case .transformFailed(let name, let reason):
             return [
                 "transform_name": name.rawValue,

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -5,6 +5,12 @@ public enum TelemetryEventName: String, Sendable, CaseIterable {
     case appQuit = "app_quit"
     case dictationStarted = "dictation_started"
     case dictationCompleted = "dictation_completed"
+    /// One-shot activation milestone: fired exactly once per install, the
+    /// first time a dictation completes end-to-end. Forward-looking — existing
+    /// users already carry the `hasCompletedFirstDictation` flag, so this never
+    /// produces a retroactive spike. Counted against `onboarding_completed` to
+    /// derive the activation rate.
+    case firstDictationCompleted = "first_dictation_completed"
     case dictationCancelled = "dictation_cancelled"
     case dictationEmpty = "dictation_empty"
     case dictationFailed = "dictation_failed"
@@ -396,8 +402,13 @@ public enum TelemetryEventSpec: Sendable {
         speechEngine: String? = nil,
         engineVariant: String? = nil,
         language: String? = nil,
+        appCategory: TelemetryAppCategory? = nil,
         device: RecordingDeviceInfo? = nil
     )
+    /// First-ever completed dictation for this install (see
+    /// `TelemetryEventName.firstDictationCompleted`). `activationWindow` is the
+    /// bucketed time since onboarding completed — coarse buckets only.
+    case firstDictationCompleted(activationWindow: TelemetryActivationWindow)
     case dictationCancelled(durationSeconds: Double?, reason: TelemetryDictationCancelReason?, device: RecordingDeviceInfo? = nil)
     case dictationEmpty(durationSeconds: Double?, device: RecordingDeviceInfo? = nil)
     case dictationFailed(errorType: String, errorDetail: String? = nil, device: RecordingDeviceInfo? = nil)
@@ -414,6 +425,7 @@ public enum TelemetryEventSpec: Sendable {
         speechEngine: String? = nil,
         engineVariant: String? = nil,
         language: String? = nil,
+        appCategory: TelemetryAppCategory? = nil,
         device: RecordingDeviceInfo? = nil
     )
     case dictationFirstLoadCaptionShown(firstInstall: Bool)
@@ -482,7 +494,8 @@ public enum TelemetryEventSpec: Sendable {
         capturePath: TelemetryTransformCapturePath,
         replacePath: TelemetryTransformReplacePath,
         llmMs: Int,
-        totalMs: Int
+        totalMs: Int,
+        appCategory: TelemetryAppCategory? = nil
     )
     case transformFailed(
         transformName: TelemetryTransformName,
@@ -499,6 +512,7 @@ public enum TelemetryEventSpec: Sendable {
         durationSeconds: Double,
         llmMs: Int?,
         totalMs: Int?,
+        appCategory: TelemetryAppCategory? = nil,
         errorType: TelemetryTransformFailureReason?
     )
     case askMenuOpened
@@ -739,6 +753,7 @@ extension TelemetryEventSpec {
         case .appQuit: return .appQuit
         case .dictationStarted: return .dictationStarted
         case .dictationCompleted: return .dictationCompleted
+        case .firstDictationCompleted: return .firstDictationCompleted
         case .dictationCancelled: return .dictationCancelled
         case .dictationEmpty: return .dictationEmpty
         case .dictationFailed: return .dictationFailed
@@ -876,6 +891,7 @@ extension TelemetryEventSpec {
             let speechEngine,
             let engineVariant,
             let language,
+            let appCategory,
             let device
         ):
             return Self.mergeDevice(Self.compactProps(
@@ -884,8 +900,11 @@ extension TelemetryEventSpec {
                 ("mode", mode?.rawValue),
                 ("speech_engine", speechEngine),
                 ("engine_variant", Self.safeEngineVariant(engineVariant)),
-                ("language", Self.safeLanguageCode(language))
+                ("language", Self.safeLanguageCode(language)),
+                ("app_category", appCategory?.rawValue)
             ), device)
+        case .firstDictationCompleted(let activationWindow):
+            return ["activation_window": activationWindow.rawValue]
         case .dictationCancelled(let durationSeconds, let reason, let device):
             return Self.mergeDevice(Self.compactProps(
                 ("duration_seconds", durationSeconds.map(Self.format)),
@@ -912,6 +931,7 @@ extension TelemetryEventSpec {
             let speechEngine,
             let engineVariant,
             let language,
+            let appCategory,
             let device
         ):
             return Self.mergeDevice(Self.compactProps(
@@ -926,6 +946,7 @@ extension TelemetryEventSpec {
                 ("speech_engine", speechEngine),
                 ("engine_variant", Self.safeEngineVariant(engineVariant)),
                 ("language", Self.safeLanguageCode(language)),
+                ("app_category", appCategory?.rawValue),
                 ("error_type", errorType),
                 ("cancel_reason", cancelReason?.rawValue)
             ), device)
@@ -1054,14 +1075,16 @@ extension TelemetryEventSpec {
             var props = ["provider": provider, "error_type": errorType]
             if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
             return props
-        case .transformExecuted(let name, let capture, let replace, let llmMs, let totalMs):
-            return [
+        case .transformExecuted(let name, let capture, let replace, let llmMs, let totalMs, let appCategory):
+            var props = [
                 "transform_name": name.rawValue,
                 "capture_path": capture.rawValue,
                 "replace_path": replace.rawValue,
                 "llm_ms": "\(llmMs)",
                 "total_ms": "\(totalMs)",
             ]
+            if let appCategory { props["app_category"] = appCategory.rawValue }
+            return props
         case .transformFailed(let name, let reason):
             return [
                 "transform_name": name.rawValue,
@@ -1078,6 +1101,7 @@ extension TelemetryEventSpec {
             let durationSeconds,
             let llmMs,
             let totalMs,
+            let appCategory,
             let errorType
         ):
             return Self.compactProps(
@@ -1092,6 +1116,7 @@ extension TelemetryEventSpec {
                 ("duration_seconds", Self.format(durationSeconds)),
                 ("llm_ms", llmMs.map(String.init)),
                 ("total_ms", totalMs.map(String.init)),
+                ("app_category", appCategory?.rawValue),
                 ("error_type", errorType?.rawValue)
             )
         case .askPromptFired(let source, let group, let label):
@@ -1521,6 +1546,7 @@ public enum TelemetryImplementedContract {
         .appQuit: ["session_duration_seconds"],
         .dictationStarted: [],
         .dictationCompleted: ["duration_seconds", "word_count"],
+        .firstDictationCompleted: ["activation_window"],
         .dictationCancelled: [],
         .dictationEmpty: [],
         .dictationFailed: ["error_type"],

--- a/Sources/MacParakeetViewModels/OnboardingViewModel.swift
+++ b/Sources/MacParakeetViewModels/OnboardingViewModel.swift
@@ -104,9 +104,9 @@ public final class OnboardingViewModel {
     private let requiredDiarizationSetupDiskBytes: Int64 = 512 * 1_024 * 1_024
     private let requiredWhisperSetupDiskBytes: Int64 = 2 * 1_024 * 1_024 * 1_024
 
-    public static let onboardingCompletedKey = "onboarding.completedAtISO"
-    public static let meetingRecordingSkippedKey = "onboarding.meetingRecordingSkipped"
-    public static let calendarSkippedKey = "onboarding.calendarSkipped"
+    public nonisolated static let onboardingCompletedKey = "onboarding.completedAtISO"
+    public nonisolated static let meetingRecordingSkippedKey = "onboarding.meetingRecordingSkipped"
+    public nonisolated static let calendarSkippedKey = "onboarding.calendarSkipped"
 
     public init(
         permissionService: PermissionServiceProtocol,

--- a/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
+++ b/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import XCTest
+
+@testable import MacParakeetCore
+
+final class AppRuntimePreferencesTests: XCTestCase {
+    private func makePreferences() -> UserDefaultsAppRuntimePreferences {
+        UserDefaultsAppRuntimePreferences(
+            defaults: UserDefaults(suiteName: "app-runtime-prefs-\(UUID().uuidString)")!
+        )
+    }
+
+    func testMarkFirstDictationCompletedReturnsTrueOnlyOnFirstTransition() {
+        let preferences = makePreferences()
+        XCTAssertFalse(preferences.hasCompletedFirstDictation)
+
+        // First call flips the flag and reports the transition so the caller
+        // can fire the one-shot activation telemetry event.
+        XCTAssertTrue(preferences.markFirstDictationCompleted())
+        XCTAssertTrue(preferences.hasCompletedFirstDictation)
+
+        // Every subsequent call is a no-op and reports no transition.
+        XCTAssertFalse(preferences.markFirstDictationCompleted())
+        XCTAssertFalse(preferences.markFirstDictationCompleted())
+        XCTAssertTrue(preferences.hasCompletedFirstDictation)
+    }
+
+    func testFirstDictationFlagPersistsAcrossInstances() {
+        let suite = "app-runtime-prefs-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+
+        let first = UserDefaultsAppRuntimePreferences(defaults: defaults)
+        XCTAssertTrue(first.markFirstDictationCompleted())
+
+        // A fresh instance over the same store already sees the flag set, so a
+        // user who has dictated before never re-emits the activation event.
+        let second = UserDefaultsAppRuntimePreferences(defaults: defaults)
+        XCTAssertTrue(second.hasCompletedFirstDictation)
+        XCTAssertFalse(second.markFirstDictationCompleted())
+    }
+}

--- a/Tests/MacParakeetTests/Services/Dictation/DictationServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/Dictation/DictationServiceTests.swift
@@ -260,6 +260,32 @@ final class DictationServiceTests: XCTestCase {
         XCTAssertEqual(operation["language"], "ko")
     }
 
+    func testStopRecordingUsesLatestAppCategoryForTelemetry() async throws {
+        let telemetry = DictationTelemetrySpy()
+        Telemetry.configure(telemetry)
+        await mockSTT.configure(result: STTResult(text: "finish target"))
+
+        try await service.startRecording(
+            context: DictationTelemetryContext(
+                trigger: .hotkey,
+                mode: .hold,
+                appCategory: .browser
+            )
+        )
+        await service.updateTelemetryAppCategory(.email)
+        _ = try await service.stopRecording()
+
+        let events = telemetry.snapshot()
+        let completed = try XCTUnwrap(events.last { event in
+            if case .dictationCompleted = event { return true }
+            return false
+        })
+        XCTAssertEqual(completed.props?["app_category"], "email")
+
+        let operation = try XCTUnwrap(dictationOperationProps(in: events).last)
+        XCTAssertEqual(operation["app_category"], "email")
+    }
+
     func testFirstDictationFlagFlipsAfterSuccessfulSave() async throws {
         let defaults = UserDefaults(suiteName: "dictation-first-success-\(UUID().uuidString)")!
         let preferences = UserDefaultsAppRuntimePreferences(defaults: defaults)

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -921,6 +921,115 @@ final class TelemetryServiceTests: XCTestCase {
         XCTAssertNil(props?["output_text"])
     }
 
+    // MARK: - App Category (privacy-safe bucketing)
+
+    func testAppCategoryMapsKnownBundleIdentifiersToBuckets() {
+        let cases: [(String, TelemetryAppCategory)] = [
+            ("com.apple.Safari", .browser),
+            ("com.google.Chrome", .browser),
+            ("com.google.Chrome.canary", .browser),       // prefix match
+            ("company.thebrowser.Browser", .browser),     // Arc
+            ("com.tinyspeck.slackmacgap", .messaging),    // Slack
+            ("com.hnc.Discord", .messaging),
+            ("com.apple.mail", .email),
+            ("com.microsoft.Outlook", .email),
+            ("md.obsidian", .notes),
+            ("com.apple.Notes", .notes),
+            ("com.apple.iWork.Pages", .docs),
+            ("com.microsoft.Word", .docs),
+            ("com.apple.dt.Xcode", .code),
+            ("com.microsoft.VSCode", .code),
+            ("com.microsoft.VSCodeInsiders", .code),      // prefix match
+            ("com.jetbrains.intellij", .code),            // prefix match
+            ("com.todesktop.230313mzl4w4u92", .code),     // Cursor
+            ("com.apple.Terminal", .terminal),
+            ("com.googlecode.iterm2", .terminal),
+        ]
+        for (bundleID, expected) in cases {
+            XCTAssertEqual(
+                TelemetryAppCategory(bundleIdentifier: bundleID),
+                expected,
+                "Expected \(bundleID) -> \(expected.rawValue)"
+            )
+        }
+    }
+
+    func testAppCategoryMapsUnknownAndEmptyToOther() {
+        XCTAssertEqual(TelemetryAppCategory(bundleIdentifier: nil), .other)
+        XCTAssertEqual(TelemetryAppCategory(bundleIdentifier: ""), .other)
+        XCTAssertEqual(TelemetryAppCategory(bundleIdentifier: "   "), .other)
+        XCTAssertEqual(TelemetryAppCategory(bundleIdentifier: "com.example.SomeNicheApp"), .other)
+        // Our own app is not a meaningful external target.
+        XCTAssertEqual(TelemetryAppCategory(bundleIdentifier: "com.macparakeet"), .other)
+    }
+
+    func testActivationWindowBucketsSecondsCoarsely() {
+        XCTAssertEqual(TelemetryActivationWindow(secondsSinceOnboarding: 0), .underMinute)
+        XCTAssertEqual(TelemetryActivationWindow(secondsSinceOnboarding: 59), .underMinute)
+        XCTAssertEqual(TelemetryActivationWindow(secondsSinceOnboarding: 60), .underHour)
+        XCTAssertEqual(TelemetryActivationWindow(secondsSinceOnboarding: 3_599), .underHour)
+        XCTAssertEqual(TelemetryActivationWindow(secondsSinceOnboarding: 3_600), .underDay)
+        XCTAssertEqual(TelemetryActivationWindow(secondsSinceOnboarding: 86_399), .underDay)
+        XCTAssertEqual(TelemetryActivationWindow(secondsSinceOnboarding: 86_400), .underWeek)
+        XCTAssertEqual(TelemetryActivationWindow(secondsSinceOnboarding: 604_799), .underWeek)
+        XCTAssertEqual(TelemetryActivationWindow(secondsSinceOnboarding: 604_800), .overWeek)
+        XCTAssertEqual(TelemetryActivationWindow(secondsSinceOnboarding: nil), .unknown)
+        XCTAssertEqual(TelemetryActivationWindow(secondsSinceOnboarding: -5), .unknown)
+    }
+
+    func testDictationCompletedSerializesAppCategoryButOmitsWhenNil() {
+        let withCategory = TelemetryEventSpec.dictationCompleted(
+            durationSeconds: 5.0,
+            wordCount: 12,
+            mode: .hold,
+            appCategory: .messaging
+        )
+        XCTAssertEqual(withCategory.props?["app_category"], "messaging")
+
+        let withoutCategory = TelemetryEventSpec.dictationCompleted(
+            durationSeconds: 5.0,
+            wordCount: 12,
+            mode: .hold
+        )
+        XCTAssertNil(withoutCategory.props?["app_category"])
+    }
+
+    func testTransformExecutedSerializesAppCategoryButOmitsWhenNil() {
+        let withCategory = TelemetryEventSpec.transformExecuted(
+            transformName: .polish,
+            capturePath: .ax,
+            replacePath: .clipboardPaste,
+            llmMs: 1200,
+            totalMs: 1500,
+            appCategory: .code
+        )
+        XCTAssertEqual(withCategory.props?["app_category"], "code")
+
+        let withoutCategory = TelemetryEventSpec.transformExecuted(
+            transformName: .polish,
+            capturePath: .ax,
+            replacePath: .clipboardPaste,
+            llmMs: 1200,
+            totalMs: 1500
+        )
+        XCTAssertNil(withoutCategory.props?["app_category"])
+    }
+
+    func testFirstDictationCompletedSerializesActivationWindow() {
+        let event = TelemetryEvent(
+            spec: .firstDictationCompleted(activationWindow: .underHour),
+            appVer: "0.6.9",
+            osVer: "15.4",
+            locale: "en-US",
+            chip: "Apple M4",
+            session: "session"
+        )
+
+        XCTAssertEqual(event.event, "first_dictation_completed")
+        XCTAssertEqual(event.props?["activation_window"], "under_1h")
+        XCTAssertEqual(Set(event.props?.keys ?? Dictionary<String, String>().keys), ["activation_window"])
+    }
+
     func testImplementedContractCoversEveryTypedEventName() {
         XCTAssertEqual(
             Set(TelemetryEventName.allCases),
@@ -1065,6 +1174,7 @@ final class TelemetryServiceTests: XCTestCase {
             .appQuit(sessionDurationSeconds: 12.5),
             .dictationStarted(trigger: .hotkey, mode: .persistent),
             .dictationCompleted(durationSeconds: 12.5, wordCount: 84, mode: .persistent),
+            .firstDictationCompleted(activationWindow: .underMinute),
             .dictationCancelled(durationSeconds: 1.5, reason: .escape),
             .dictationEmpty(durationSeconds: 1.5),
             .dictationFailed(errorType: "network"),

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -942,6 +942,7 @@ final class TelemetryServiceTests: XCTestCase {
             ("com.microsoft.VSCodeInsiders", .code),      // prefix match
             ("com.jetbrains.intellij", .code),            // prefix match
             ("com.todesktop.230313mzl4w4u92", .code),     // Cursor
+            ("com.google.android.studio", .code),
             ("com.apple.Terminal", .terminal),
             ("com.googlecode.iterm2", .terminal),
         ]

--- a/docs/research/wisprflow-parity-2026-05.md
+++ b/docs/research/wisprflow-parity-2026-05.md
@@ -14,19 +14,19 @@ After walking through this audit with the owner, three calls were made:
 
 1. **Auto Cleanup gradations — skip.** Keep `processingMode` as the current binary raw/clean deterministic pipeline. AI Formatter stays as a single optional polish layer with one customizable prompt. Don't ship Light/Medium/High named levels.
 2. **Undo AI edit — ship.** Surface a per-row affordance in the dictation history that swaps the displayed/exported text from `cleanTranscript` back to `rawTranscript`. Schema already stores both — pure UI work.
-3. **Transforms — prioritize.** Build the hotkey-driven version (Opt+N to rewrite selected text in any app) as the next major surface. Treated as foundation work for the already-planned voice-driven Command Mode (see `plans/active/2026-05-voice-command-agent-mode.md` candidate capability #1 and `docs/agent-mode-vision.md` lines 350–351). The hotkey and voice variants share the same underlying primitives — capture selection, run prompt through LLM, replace in place — so the hotkey form is the shortest path to those primitives.
+3. **Transforms — prioritized and shipped.** The hotkey-driven version (Opt+N-style bindings to rewrite selected text in any app) is now productized on `main`. It remains foundation work for the already-planned voice-driven Command Mode (see `plans/active/2026-05-voice-command-agent-mode.md` candidate capability #1 and `docs/agent-mode-vision.md` lines 350–351). The hotkey and voice variants share the same underlying primitives — capture selection, run prompt through LLM, replace in place.
 
 The full design exploration for Transforms lives in `transforms-design-2026-05.md`.
 
 ## TL;DR
 
-WisprFlow Pro now organizes its post-dictation cleanup into five sidebar sections: **Dictionary**, **Snippets**, **Style**, **Auto Cleanup**, and **Transforms**. We have rough parity on Dictionary and Snippets (different UI shape, same underlying capability). We have nothing comparable to Style (per-app tone routing) or Transforms (Opt+N hotkeys that LLM-rewrite selected text anywhere). Auto Cleanup is binary in MacParakeet (raw vs clean) where WisprFlow ships four gradations.
+WisprFlow Pro now organizes its post-dictation cleanup into five sidebar sections: **Dictionary**, **Snippets**, **Style**, **Auto Cleanup**, and **Transforms**. We have rough parity on Dictionary and Snippets (different UI shape, same underlying capability), productized core parity on Transforms, and no comparable Style routing. Auto Cleanup is binary in MacParakeet (raw vs clean) where WisprFlow ships four gradations.
 
 | WisprFlow surface | MacParakeet today | Coverage | Strategic fit |
 |---|---|---|---|
 | Dictionary (word teach + misspelling correction) | Custom Words (`word` + optional `replacement`) | Capability parity, UX-lite | Aligned — already shipped |
 | Snippets (trigger → expansion) | Text Snippets in Vocabulary panel | Capability parity, UX-lite | Aligned — already shipped |
-| Style (per-app tone: Slack vs Gmail vs Discord) | None | **Zero coverage** | Tension with local-first; LLM-dependent |
+| Style (per-app tone: Slack vs Gmail vs Discord) | No style routing; only coarse app-category telemetry/history context | No product coverage | Tension with local-first; LLM-dependent |
 | Auto Cleanup (None / Light / Medium / High) | `processingMode` raw/clean + binary AI Formatter | Partial — coarse | Easy to expand; aligned |
 | Transforms (Opt+N to rewrite selected text in any app) | Productized Transforms tab, hotkey registry, built-ins, history, and CLI | Core parity, lighter than WisprFlow | Aligned, but expands product scope |
 
@@ -125,7 +125,10 @@ The mechanism is clear: WisprFlow reads frontmost-app bundle ID, picks the match
 
 ### MacParakeet today
 
-Zero coverage. Confirmed by grep — we don't query `NSWorkspace.frontmostApplication` for routing, we have no per-app preference surface, and our `processingMode` is a single global enum.
+No style-routing coverage. MacParakeet now reads the frontmost app for local
+history and coarse, privacy-safe telemetry buckets, but not for choosing
+dictation cleanup behavior: we still have no per-app preference surface, and
+our `processingMode` is a single global enum.
 
 We do have `Sources/MacParakeetCore/TextProcessing/AIFormatter.swift` with a user-customizable prompt template that runs through whichever LLM provider the user has configured. But it's a single global prompt — no per-app branching.
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -182,13 +182,24 @@ when the question is "what happened to this operation?"
 | Event | Props | Question It Answers |
 |---|---|---|
 | `dictation_started` | `trigger` (hotkey, pill_click, menu_bar) | How do people start dictating? |
-| `dictation_completed` | `duration_seconds`, `word_count`, `mode` (hold, persistent), `speech_engine`, `engine_variant`, `language`, `device_*` | How long are dictations? Which mode, language, and STT engine are popular? |
+| `dictation_completed` | `duration_seconds`, `word_count`, `mode` (hold, persistent), `speech_engine`, `engine_variant`, `language`, `app_category`, `device_*` | How long are dictations? Which mode, language, and STT engine are popular? Where do people dictate? |
+| `first_dictation_completed` | `activation_window` (under_1m, under_1h, under_1d, under_1w, over_1w, unknown) | Activation: do new users reach first value, and how fast? One-shot per install; counted against `onboarding_completed` |
 | `dictation_cancelled` | `duration_seconds`, `reason` (escape, hotkey, ui), `device_*` | Are people cancelling often? Why? |
 | `dictation_empty` | `duration_seconds`, `device_*` | Are people getting empty results? (quality signal) |
 | `dictation_failed` | `error_type`, `device_*` | Core feature failures — blind spot without this |
-| `dictation_operation` | `operation_id`, `workflow_id`, `parent_operation_id`, `outcome`, `trigger`, `mode`, `duration_seconds`, `word_count`, `speech_engine`, `engine_variant`, `language`, `error_type`, `cancel_reason`, `device_*` | One wide outcome event per dictation attempt |
+| `dictation_operation` | `operation_id`, `workflow_id`, `parent_operation_id`, `outcome`, `trigger`, `mode`, `duration_seconds`, `word_count`, `speech_engine`, `engine_variant`, `language`, `app_category`, `error_type`, `cancel_reason`, `device_*` | One wide outcome event per dictation attempt |
 
 > **Device props** (optional, included when available): `device_transport`, `device_sub_transport`, `device_sample_rate`, `device_channels`, `device_fallback`, `device_selected`. Raw device names and UIDs are intentionally not serialized.
+
+`app_category` (optional) is the coarse category of the frontmost app the
+dictation was pasted into — one of `messaging`, `email`, `browser`, `notes`,
+`docs`, `code`, `terminal`, `other`. Following item 10 below ("track
+structural category only"), the frontmost app's bundle identifier is mapped to
+a bucket on-device and **only the bucket is transmitted** — the bundle id never
+leaves the device, and any unrecognized app maps to `other`, so a niche or
+identifying app is never observable. The same prop appears on
+`transform_executed` / `transform_operation` (the app a Transform rewrote text
+in).
 
 `speech_engine` and `engine_variant` describe the STT engine that actually
 processed the audio. They come from `STTResult` attribution or persisted
@@ -238,9 +249,9 @@ events remain useful for diarization-specific timing and failure analysis.
 | `llm_chat_failed` | `provider`, `source` (`meeting_ask`, `transcript_chat`), `error_type` | Chat failure rates per provider and surface |
 | `llm_transform_used` | `provider` | One-off transform feature usage |
 | `llm_transform_failed` | `provider`, `error_type` | One-off transform failure rates |
-| `transform_executed` | `transform_name`, `capture_path`, `replace_path`, `llm_ms`, `total_ms` | End-to-end system-wide Transform completions by built-in/custom bucket |
+| `transform_executed` | `transform_name`, `capture_path`, `replace_path`, `llm_ms`, `total_ms`, `app_category` | End-to-end system-wide Transform completions by built-in/custom bucket, and where they're used |
 | `transform_failed` | `transform_name`, `reason` | End-to-end system-wide Transform failure reasons (`empty_selection`, `no_provider`, `capture_failed`, `llm_failed`, `replacement_failed`, `cancelled`) |
-| `transform_operation` | `operation_id`, `workflow_id`, `parent_operation_id`, `outcome`, `transform_name`, `stage`, `capture_path`, `replace_path`, `duration_seconds`, `llm_ms`, `total_ms`, `error_type` | One safe outcome event per system-wide Transform attempt, without prompts, selected text, or output text |
+| `transform_operation` | `operation_id`, `workflow_id`, `parent_operation_id`, `outcome`, `transform_name`, `stage`, `capture_path`, `replace_path`, `duration_seconds`, `llm_ms`, `total_ms`, `app_category`, `error_type` | One safe outcome event per system-wide Transform attempt, without prompts, selected text, or output text |
 | `ask_menu_opened` | — | Whether users discover the live meeting Ask prompt menu |
 | `ask_prompt_fired` | `source`, `group`, `label` | Which built-in live Ask prompts are used, using stable built-in slugs. Edited built-ins and custom prompts collapse to `custom`. |
 | `llm_formatter_used` | `provider`, `source`, `duration_seconds`, `input_chars`, `output_chars`, `default_prompt_used`, `input_truncated` | Is transcript/dictation formatting useful, and how expensive is it? |

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -188,18 +188,19 @@ when the question is "what happened to this operation?"
 | `dictation_empty` | `duration_seconds`, `device_*` | Are people getting empty results? (quality signal) |
 | `dictation_failed` | `error_type`, `device_*` | Core feature failures — blind spot without this |
 | `dictation_operation` | `operation_id`, `workflow_id`, `parent_operation_id`, `outcome`, `trigger`, `mode`, `duration_seconds`, `word_count`, `speech_engine`, `engine_variant`, `language`, `app_category`, `error_type`, `cancel_reason`, `device_*` | One wide outcome event per dictation attempt |
+| `dictation_first_load_caption_shown` | `first_install` | How often the first model-load caption is shown |
+| `dictation_first_load_caption_duration` | `duration_ms`, `outcome` | How long the first model-load caption stays visible, and whether it resolves, extends, or fails |
 
 > **Device props** (optional, included when available): `device_transport`, `device_sub_transport`, `device_sample_rate`, `device_channels`, `device_fallback`, `device_selected`. Raw device names and UIDs are intentionally not serialized.
 
-`app_category` (optional) is the coarse category of the frontmost app the
-dictation was pasted into — one of `messaging`, `email`, `browser`, `notes`,
-`docs`, `code`, `terminal`, `other`. Following item 10 below ("track
-structural category only"), the frontmost app's bundle identifier is mapped to
-a bucket on-device and **only the bucket is transmitted** — the bundle id never
-leaves the device, and any unrecognized app maps to `other`, so a niche or
-identifying app is never observable. The same prop appears on
-`transform_executed` / `transform_operation` (the app a Transform rewrote text
-in).
+`app_category` (optional) is the coarse category of the frontmost app selected
+as the dictation finish target — one of `messaging`, `email`, `browser`,
+`notes`, `docs`, `code`, `terminal`, `other`. The app's bundle identifier is
+mapped to a structural bucket on-device and **only the bucket is transmitted** —
+the bundle id never leaves the device, and any unrecognized app maps to
+`other`, so a niche or identifying app is never observable. The same prop
+appears on `transform_executed` / `transform_operation` (the app a Transform
+rewrote text in).
 
 `speech_engine` and `engine_variant` describe the STT engine that actually
 processed the audio. They come from `STTResult` attribution or persisted
@@ -256,6 +257,7 @@ events remain useful for diarization-specific timing and failure analysis.
 | `ask_prompt_fired` | `source`, `group`, `label` | Which built-in live Ask prompts are used, using stable built-in slugs. Edited built-ins and custom prompts collapse to `custom`. |
 | `llm_formatter_used` | `provider`, `source`, `duration_seconds`, `input_chars`, `output_chars`, `default_prompt_used`, `input_truncated` | Is transcript/dictation formatting useful, and how expensive is it? |
 | `llm_formatter_failed` | `provider`, `source`, `duration_seconds`, `error_type`, `default_prompt_used`, `input_truncated` | Formatter failure rates and prompt-shape correlations |
+| `llm_provider_unavailable` | `provider`, `error_type`, `feature`, `source` | Provider setup/config drift distinct from true LLM request failures |
 | `llm_operation` | `operation_id`, `workflow_id`, `parent_operation_id`, `feature`, `provider`, `streaming`, `outcome`, `duration_seconds`, `input_chars`, `output_chars`, `input_truncated`, `prompt_default_used`, `message_count`, `error_type` | One safe outcome event per LLM call, without prompts, responses, or provider error bodies |
 | `history_searched` | — | Is search useful? |
 | `history_replayed` | — | Do people re-listen to audio? |
@@ -353,6 +355,7 @@ events remain useful for diarization-specific timing and failure analysis.
 | `model_download_failed` | `error_type`, `model_kind`, `speech_engine`, `engine_variant` | Are downloads failing for Parakeet setup or Whisper downloads? |
 | `model_operation` | `operation_id`, `workflow_id`, `parent_operation_id`, `action`, `outcome`, `stage`, `model_kind`, `speech_engine`, `engine_variant`, `duration_seconds`, `error_type` | Canonical model lifecycle event for downloads, warm-up, repairs, cache clears, and cancellations |
 | `speech_engine_switch_operation` | `operation_id`, `workflow_id`, `parent_operation_id`, `from_engine`, `to_engine`, `outcome`, `duration_seconds`, `blocked_reason`, `error_type` | Why engine switches succeed, fail, cancel, or get blocked |
+| `stt_runtime_unhealthy` | `reason` | Whether the STT runtime watchdog detects a stuck speech runtime |
 
 ### 8. Permissions — "Is onboarding smooth?"
 


### PR DESCRIPTION
## Summary

Two privacy-clean telemetry additions that together form the **activation funnel** — *do new users reach value, and where do they use the product?* Both close current blind spots.

### `app_category` (where dictation/Transforms are used)
- New `TelemetryAppCategory` enum: maps a frontmost-app **bundle identifier → one of 8 coarse buckets** (`messaging`, `email`, `browser`, `notes`, `docs`, `code`, `terminal`, `other`) **on-device**, and transmits **only the bucket**. The bundle id never leaves the device; any unrecognized app maps to `other`. Mirrors the existing privacy stance in `docs/telemetry.md` item 10 ("track structural category only").
- Added to `dictation_completed` + `transform_executed` **and their wide operation twins** (`dictation_operation`, `transform_operation`) — the codebase already puts every dimension (device, engine, mode, language) on both the product event and its twin.
- **Dictation:** captured at the **finish target** — the frontmost app is re-read right before `stopRecording` / `undoCancel` via `DictationService.updateTelemetryAppCategory(_:sessionID:)` and threaded through `DictationTelemetryContext`. This follows the actual paste destination even in persistent mode (start in app A, paste into app B). Session-id + state guarded so a stale update can't mutate a finished/replaced session.
- **Transforms:** derived from the already-captured `result.target?.bundleIdentifier` (success path).

### `first_dictation_completed` (activation rate)
- One-shot milestone fired **exactly once per install** on the first completed dictation. Reuses `markFirstDictationCompleted()` (now `@discardableResult -> Bool`) so the `AppEnvironment` closure emits only on the first transition.
- Carries `activation_window`: bucketed time since `onboarding.completedAtISO` (`under_1m` / `under_1h` / `under_1d` / `under_1w` / `over_1w` / `unknown`) — coarse buckets only, never a raw timestamp.
- **Forward-looking, no retroactive spike:** existing users already carry the `hasCompletedFirstDictation` flag. Counted against `onboarding_completed` for the activation rate.

## Why both, now
`app_category`'s value is delayed (needs weeks to accumulate before it answers a roadmap question), so it starts the clock now; activation is a perpetual gauge we'll watch every release. They're orthogonal (where vs. whether) and share the dictation-completion code path.

## Privacy (ADR-002 / ADR-012)
Only coarse buckets — never the bundle id, never a raw timestamp/duration. No content, no persistent IDs.

## Companion website change (deployed)
`first_dictation_completed` added to the worker `ALLOWED_EVENTS` and **deployed first** (`moona3k/macparakeet-website` `d76ede3`) — the worker rejects whole batches with unknown event names. Verified live: the new name passes the allowlist (fails only at prop validation, no DB row inserted) while a bogus name returns `Unknown event`. `app_category` is a prop → no allowlist change.

## Fresh-eye review (Codex + Gemini + project-aware pass)
- **Resolved:** start-vs-paste accuracy → reworked to the finish-target refresh model (commit `3113932d`).
- **Fixed:** `transform_executed` props → `compactProps` for consistency; Android Studio → `code` bucket.
- **Refuted:** `ISO8601DateFormatter` needs `en_US_POSIX` (locale-independent by design); `app_category` should be required (it's optional — stays out of the contract like `device_*`/`language`).
- **Safe:** first-dictation one-shot "race" — sole writer is actor-serialized.
- **Deferred:** `app_category` on Transform *failure* paths — the captured target isn't surfaced on `TransformExecutorError`; the success path (primary signal) is fully covered.

## Testing
- `swift test`: **2885 tests, 0 failures** (9 skipped).
- Coverage: bundle-id→bucket mapping, activation-window bucketing, serialize/omit on dictation + transform, `first_dictation_completed` serialization, the `markFirstDictationCompleted()` one-shot Bool contract, and finish-target "latest category wins" on completion + operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)