### PR TITLE
Fix: meeting rows show the meeting name, not transcript content

### DIFF
--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
@@ -135,10 +135,15 @@ struct MeetingRowCard<MenuContent: View>: View {
 
     // MARK: - Derived display values
 
+    /// A meeting carries a real, user-editable title (`fileName`) — the same
+    /// value shown in the detail header and set by the rename pencil, defaulting
+    /// to "Meeting <date>" at recording time. The Meetings list mirrors that
+    /// title so the row matches the detail view and honors renames. The
+    /// transcript-content-derived `derivedTitle` is only a snippet/export aid
+    /// for meetings (it still drives titles for file/YouTube grid rows).
     private var displayedTitle: String {
-        if let derived = transcription.derivedTitle?.trimmingCharacters(in: .whitespacesAndNewlines), !derived.isEmpty {
-            return derived
-        }
+        let name = transcription.fileName.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !name.isEmpty { return name }
         if transcription.status == .processing { return "Transcribing…" }
         return transcription.fileName
     }

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionThumbnailCard.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionThumbnailCard.swift
@@ -159,6 +159,19 @@ struct TranscriptionThumbnailCard<MenuContent: View>: View {
     }
 
     private var displayTitle: String {
+        // Meetings have a real, user-editable title (the meeting name shown in
+        // the detail header). Honor it here too — the "All"/"Favorites" grid can
+        // include meetings — instead of the transcript-content-derived title.
+        // File/YouTube rows have no inherent title, so the smart `derivedTitle`
+        // is the better headline for them.
+        if transcription.sourceType == .meeting {
+            // A meeting's name is always its title — never fall through to the
+            // transcript-derived title (keeps meeting titles honest and matches
+            // MeetingRowCard). `fileName` is effectively never blank for
+            // meetings, but guard so a whitespace name can't leak content.
+            let name = transcription.fileName.trimmingCharacters(in: .whitespacesAndNewlines)
+            return name.isEmpty ? transcription.fileName : name
+        }
         if let derived = transcription.derivedTitle?.trimmingCharacters(in: .whitespacesAndNewlines), !derived.isEmpty {
             return derived
         }

--- a/Sources/MacParakeetCore/Database/TranscriptionRepository.swift
+++ b/Sources/MacParakeetCore/Database/TranscriptionRepository.swift
@@ -382,11 +382,12 @@ public final class TranscriptionRepository: TranscriptionRepositoryProtocol, @un
         try dbQueue.write { db in
             guard var transcription = try Transcription.fetchOne(db, key: id) else { return }
             transcription.fileName = fileName
-            // A user-driven rename is the source of truth for the display
-            // title. Mirror it into `derivedTitle` so the Meetings list
-            // doesn't keep showing the auto-derived title from the
-            // transcript content. Without this the rename is silently
-            // masked by the smart-title path.
+            // A user-driven rename (meetings only) is the source of truth for
+            // the meeting's name. The Library rows already read `fileName` for
+            // meetings, but `derivedTitle` still feeds the "Save Audio As…"
+            // export-filename helper — mirror the rename into it so the
+            // suggested export name follows the new title instead of the stale
+            // transcript-content title.
             transcription.derivedTitle = fileName
             transcription.updatedAt = Date()
             try transcription.update(db)

--- a/Sources/MacParakeetCore/TextProcessing/TranscriptDerivers.swift
+++ b/Sources/MacParakeetCore/TextProcessing/TranscriptDerivers.swift
@@ -1,9 +1,13 @@
 import Foundation
 
 /// Pure-function deriver that produces a display-ready title string from a raw
-/// transcript. The first substantive sentence (filler-stripped) becomes the row
-/// title in the Meetings list. Falls back through several tiers so that even
-/// short or filler-heavy transcripts get a usable title.
+/// transcript. The first substantive sentence (filler-stripped) becomes the
+/// headline for file/YouTube rows in the Library thumbnail grid — sources that
+/// have no inherent title. Meeting rows use their own editable meeting name
+/// (`Transcription.fileName`) instead; for meetings this derived value only
+/// feeds the snippet preview and the "Save Audio As…" export-filename helper.
+/// Falls back through several tiers so even short or filler-heavy transcripts
+/// get a usable title.
 ///
 /// Deterministic and synchronous — runs on the transcription completion path
 /// and persists into `Transcription.derivedTitle`.


### PR DESCRIPTION
## What Changed

The Library Meetings list (`MeetingRowCard`) and the All/Favorites thumbnail grid (`TranscriptionThumbnailCard`) preferred the transcript-content-derived `derivedTitle` as the row headline. For meetings this masked the meeting's real, editable name (`fileName`) — the same value shown in the detail header and set by the rename pencil:

- A **renamed** meeting was listed under a sentence pulled from its transcript instead of the name the user gave it.
- An **auto-named** meeting (e.g. `Meeting <date> at <time>`) was listed under its first transcript sentence instead of its name.

Now both surfaces show the meeting's `fileName` for `.meeting` rows, and never fall through to `derivedTitle`. File/YouTube rows keep `derivedTitle` as their headline — they have no inherent title, so the smart title is still the better choice there.

`derivedTitle` is unchanged on the data side; it continues to feed the snippet preview and the "Save Audio As…" export-filename helper, so the rename→`derivedTitle` mirror in `updateFileName` is retained (its comment is updated to cite the export helper instead of the list).

## Why

A meeting is an event with a name + date; the list should reflect the name the user sees and edits in the detail view, not a sentence pulled from the transcript. This restores list/detail consistency and honors renames and calendar-supplied titles.

## Scope decision

Un-named (manually-started) meetings keep their `Meeting <date>` placeholder as the title — honest and predictable. Auto-deriving a content title for un-named meetings was considered but deferred: it would require threading a "was auto-named" flag through the meeting recording pipeline to avoid clobbering calendar/renamed titles, which is the wrong risk/reward for a cosmetic gain. Clean follow-up if desired.

## Testing

- App target builds clean.
- Full suite green: 2885 XCTest + 16 Swift Testing, 0 failures.

## ADRs

- ADR-014 (meeting recording) — the meeting name is the user-facing title.