### PR TITLE
Add interactive live-waveform hotkey preview to onboarding

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -28,6 +28,11 @@ final class AppEnvironmentConfigurer {
         let onHotkeyConflict: (HotkeyTrigger, [HotkeyTrigger]) -> Void
         let onRecoverPendingMeetingRecordings: () -> Void
         let isHotkeyRecordingActive: () -> Bool
+        /// True while the onboarding window is showing. Used to gate the real
+        /// dictation flow so a hotkey press during onboarding (e.g. the "Learn
+        /// the Hotkey" rehearsal, or a returning user whose taps are armed)
+        /// can never start a real, model-less dictation.
+        let isOnboardingVisible: () -> Bool
     }
 
     private let transcriptionViewModel: TranscriptionViewModel
@@ -234,6 +239,10 @@ final class AppEnvironmentConfigurer {
             shouldSuppressIdlePill: {
                 coordinatorRefs.meeting?.isMeetingRecordingActive == true
             },
+            // Gate every dictation start (hotkey *and* idle-pill click) while
+            // onboarding is up: the model isn't downloaded until a later step,
+            // and the "Learn the Hotkey" step runs its own no-STT rehearsal.
+            isStartSuppressed: { callbacks.isOnboardingVisible() },
             onMenuBarIconUpdate: { _ in callbacks.onMenuBarIconUpdate() },
             onHistoryReload: { [weak self] in self?.historyViewModel.loadDictations() },
             onPresentEntitlementsAlert: callbacks.onPresentEntitlementsAlert

--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -137,6 +137,10 @@ final class DictationFlowCoordinator {
     private let captionTiming: DictationProcessingLoadCaptionTiming
     private let overlayControllerFactory: @MainActor (DictationOverlayViewModel) -> any DictationOverlayControlling
     private let shouldSuppressIdlePill: () -> Bool
+    /// When true, `startDictation` is a no-op. Used to gate real dictation while
+    /// onboarding is visible (the model isn't ready yet and the hotkey step runs
+    /// its own no-STT rehearsal). Covers both the hotkey and idle-pill paths.
+    private let isStartSuppressed: () -> Bool
     private let onMenuBarIconUpdate: (BreathWaveIcon.MenuBarState) -> Void
     private let onHistoryReload: () -> Void
     private let onPresentEntitlementsAlert: (Error) -> Void
@@ -193,6 +197,7 @@ final class DictationFlowCoordinator {
             DictationOverlayController(viewModel: $0)
         },
         shouldSuppressIdlePill: @escaping () -> Bool = { false },
+        isStartSuppressed: @escaping () -> Bool = { false },
         onMenuBarIconUpdate: @escaping (BreathWaveIcon.MenuBarState) -> Void,
         onHistoryReload: @escaping () -> Void,
         onPresentEntitlementsAlert: @escaping (Error) -> Void
@@ -207,6 +212,7 @@ final class DictationFlowCoordinator {
         self.captionTiming = captionTiming
         self.overlayControllerFactory = overlayControllerFactory
         self.shouldSuppressIdlePill = shouldSuppressIdlePill
+        self.isStartSuppressed = isStartSuppressed
         self.onMenuBarIconUpdate = onMenuBarIconUpdate
         self.onHistoryReload = onHistoryReload
         self.onPresentEntitlementsAlert = onPresentEntitlementsAlert
@@ -291,6 +297,9 @@ final class DictationFlowCoordinator {
         mode: FnKeyStateMachine.RecordingMode,
         trigger: TelemetryDictationTrigger = .hotkey
     ) {
+        // Suppressed while onboarding is up — the speech model isn't ready and
+        // the hotkey step runs its own no-STT rehearsal. Covers hotkey + pill.
+        guard !isStartSuppressed() else { return }
         currentTrigger = trigger
         sendEvent(.startRequested(mode: mode))
     }

--- a/Sources/MacParakeet/App/OnboardingCoordinator.swift
+++ b/Sources/MacParakeet/App/OnboardingCoordinator.swift
@@ -9,6 +9,8 @@ final class OnboardingCoordinator {
     private let onOpenMainWindow: () -> Void
     private let onOpenSettings: () -> Void
     private let onCompleted: () -> Void
+    private let onHotkeyPreviewArm: () -> Void
+    private let onHotkeyPreviewDisarm: () -> Void
 
     private var reopenOnNextActivate = false
 
@@ -17,13 +19,17 @@ final class OnboardingCoordinator {
         onRefreshHotkeys: @escaping () -> Void,
         onOpenMainWindow: @escaping () -> Void,
         onOpenSettings: @escaping () -> Void,
-        onCompleted: @escaping () -> Void = {}
+        onCompleted: @escaping () -> Void = {},
+        onHotkeyPreviewArm: @escaping () -> Void = {},
+        onHotkeyPreviewDisarm: @escaping () -> Void = {}
     ) {
         self.onboardingWindowController = onboardingWindowController
         self.onRefreshHotkeys = onRefreshHotkeys
         self.onOpenMainWindow = onOpenMainWindow
         self.onOpenSettings = onOpenSettings
         self.onCompleted = onCompleted
+        self.onHotkeyPreviewArm = onHotkeyPreviewArm
+        self.onHotkeyPreviewDisarm = onHotkeyPreviewDisarm
     }
 
     var isVisible: Bool {
@@ -76,6 +82,8 @@ final class OnboardingCoordinator {
                     await entitlementsService.bootstrapTrialIfNeeded()
                 }
             },
+            onHotkeyPreviewArm: { [weak self] in self?.onHotkeyPreviewArm() },
+            onHotkeyPreviewDisarm: { [weak self] in self?.onHotkeyPreviewDisarm() },
             onOpenMainApp: { [weak self] in
                 self?.onOpenMainWindow()
             },

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -103,6 +103,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         meetingPillViewModel: meetingPillViewModel
     )
 
+    /// Drives the live, no-STT hotkey rehearsal on the onboarding "Learn the
+    /// Hotkey" step. Reads the user's configured triggers + shared mic at arm
+    /// time via providers, since the environment is set asynchronously after
+    /// launch.
+    private lazy var onboardingHotkeyPreviewController = OnboardingHotkeyPreviewController(
+        planProvider: { [weak self] in
+            guard let self else { return .init(specs: [], conflict: nil) }
+            return AppHotkeyCoordinator.dictationHotkeyPlan(
+                handsFree: self.settingsViewModel.hotkeyTrigger,
+                pushToTalk: self.settingsViewModel.pushToTalkHotkeyTrigger
+            )
+        },
+        micLevelingProvider: { [weak self] in
+            guard let stream = self?.appEnvironment?.sharedMicStream else { return nil }
+            return SharedMicLeveling(stream: stream)
+        },
+        suspendProductionHotkeys: { [weak self] in self?.hotkeyCoordinator?.suspend() },
+        resumeProductionHotkeys: { [weak self] in self?.hotkeyCoordinator?.resume() }
+    )
+
     private lazy var onboardingCoordinator = OnboardingCoordinator(
         onboardingWindowController: onboardingWindowController,
         onRefreshHotkeys: { [weak self] in
@@ -121,6 +141,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         onCompleted: { [weak self] in
             guard let self, let env = self.appEnvironment else { return }
             self.scheduleDeferredSpeechPreWarm(environment: env)
+        },
+        onHotkeyPreviewArm: { [weak self] in
+            self?.onboardingHotkeyPreviewController.arm()
+        },
+        onHotkeyPreviewDisarm: { [weak self] in
+            self?.onboardingHotkeyPreviewController.disarm()
         }
     )
 
@@ -368,13 +394,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     self?.windowCoordinator.openMainWindow()
                 },
                 onToggleMeetingRecordingFromHotkey: { [weak self] in
-                    self?.toggleMeetingRecording(originatesFromWindow: false, trigger: .hotkey)
+                    guard let self, !self.onboardingWindowController.isVisible else { return }
+                    self.toggleMeetingRecording(originatesFromWindow: false, trigger: .hotkey)
                 },
                 onTriggerFileTranscriptionFromHotkey: { [weak self] in
-                    self?.triggerFileTranscriptionFromHotkey()
+                    guard let self, !self.onboardingWindowController.isVisible else { return }
+                    self.triggerFileTranscriptionFromHotkey()
                 },
                 onTriggerYouTubeTranscriptionFromHotkey: { [weak self] in
-                    self?.triggerYouTubeTranscriptionFromHotkey()
+                    guard let self, !self.onboardingWindowController.isVisible else { return }
+                    self.triggerYouTubeTranscriptionFromHotkey()
                 },
                 onHotkeyBecameAvailable: { [weak self] in
                     self?.hasPresentedHotkeyUnavailableAlert = false
@@ -391,6 +420,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 },
                 isHotkeyRecordingActive: { [weak self] in
                     self?.isHotkeyRecorderActive == true
+                },
+                isOnboardingVisible: { [weak self] in
+                    self?.onboardingWindowController.isVisible ?? false
                 }
             )
         )

--- a/Sources/MacParakeet/Onboarding/OnboardingHotkeyPreviewController.swift
+++ b/Sources/MacParakeet/Onboarding/OnboardingHotkeyPreviewController.swift
@@ -1,0 +1,206 @@
+import AppKit
+import AVFoundation
+import MacParakeetCore
+import MacParakeetViewModels
+
+/// Drives the interactive hotkey *rehearsal* on the onboarding "Learn the
+/// Hotkey" step. Pressing the user's configured dictation trigger raises the
+/// real dictation overlay with a live, mic-driven waveform — but **never**
+/// touches STT, paste, history, or the dictation flow. It's a visual
+/// first-success that lands before the speech model is even downloaded (the
+/// next onboarding step).
+///
+/// Lifecycle: `arm()` when the hotkey step appears, `disarm()` when it
+/// disappears or the onboarding window closes. Both are idempotent so the
+/// SwiftUI `onDisappear` and the window's `windowWillClose` can both call
+/// `disarm()` without desyncing the suspend/resume refcount.
+///
+/// While armed, the production hotkey taps are suspended so only the preview
+/// taps own the key. The production dictation flow is *also* gated while
+/// onboarding is visible (see `AppEnvironmentConfigurer`), so the rehearsal can
+/// never collide with a real dictation.
+@MainActor
+final class OnboardingHotkeyPreviewController {
+
+    /// Live mic-level feed, abstracted so the controller is unit-testable
+    /// without real audio hardware. `onLevel` is delivered on the main actor.
+    @MainActor
+    protocol MicLeveling: AnyObject {
+        func start(onLevel: @escaping @MainActor (Float) -> Void)
+        func stop()
+    }
+
+    private let planProvider: () -> AppHotkeyCoordinator.DictationHotkeyPlan
+    private let micLevelingProvider: () -> MicLeveling?
+    private let overlayFactory: @MainActor (DictationOverlayViewModel) -> any DictationOverlayControlling
+    private let suspendProductionHotkeys: () -> Void
+    private let resumeProductionHotkeys: () -> Void
+
+    private var managers: [HotkeyManager] = []
+    private var overlayController: (any DictationOverlayControlling)?
+    private var overlayViewModel: DictationOverlayViewModel?
+    private var micLeveling: MicLeveling?
+
+    private(set) var isArmed = false
+    private(set) var isPreviewing = false
+
+    init(
+        planProvider: @escaping () -> AppHotkeyCoordinator.DictationHotkeyPlan,
+        micLevelingProvider: @escaping () -> MicLeveling?,
+        overlayFactory: @escaping @MainActor (DictationOverlayViewModel) -> any DictationOverlayControlling = {
+            DictationOverlayController(viewModel: $0)
+        },
+        suspendProductionHotkeys: @escaping () -> Void,
+        resumeProductionHotkeys: @escaping () -> Void
+    ) {
+        self.planProvider = planProvider
+        self.micLevelingProvider = micLevelingProvider
+        self.overlayFactory = overlayFactory
+        self.suspendProductionHotkeys = suspendProductionHotkeys
+        self.resumeProductionHotkeys = resumeProductionHotkeys
+    }
+
+    // MARK: - Arm / Disarm
+
+    func arm() {
+        guard !isArmed else { return }
+        isArmed = true
+        // Stand the production taps down so only the preview taps own the key
+        // for the duration of the step. Balanced by `resume()` in `disarm()`.
+        suspendProductionHotkeys()
+        buildManagers()
+    }
+
+    func disarm() {
+        guard isArmed else { return }
+        isArmed = false
+        endPreview()
+        managers.forEach { $0.stop() }
+        managers = []
+        resumeProductionHotkeys()
+    }
+
+    // MARK: - Hotkey wiring
+
+    private func buildManagers() {
+        for spec in planProvider().specs {
+            let manager = HotkeyManager(
+                trigger: spec.trigger,
+                gestureMode: spec.gestureMode,
+                startupDebounceMs: spec.startupDebounceMs
+            )
+            manager.onStartRecording = { [weak self, weak manager] mode in
+                guard let self, let manager else { return }
+                self.suppressPeers(of: manager)
+                self.beginPreview(mode: mode)
+            }
+            manager.onStopRecording = { [weak self] in self?.endPreviewAndResetGestures() }
+            manager.onCancelRecording = { [weak self] in self?.endPreviewAndResetGestures() }
+            if manager.start() {
+                managers.append(manager)
+            }
+        }
+    }
+
+    /// Mirror the production app: once one trigger fires, suppress the peer
+    /// trigger until reset so a held `fn` can't also fire an `fn+Space` toggle.
+    private func suppressPeers(of active: HotkeyManager) {
+        for manager in managers where manager !== active {
+            manager.suppressUntilReset()
+        }
+    }
+
+    // MARK: - Preview lifecycle (internal for tests)
+
+    func beginPreview(mode: FnKeyStateMachine.RecordingMode) {
+        guard isArmed, !isPreviewing else { return }
+        isPreviewing = true
+
+        let vm = DictationOverlayViewModel()
+        vm.recordingMode = mode
+        vm.state = .recording
+        // The stop/cancel affordances on the persistent-mode pill end the
+        // rehearsal (and reset gesture state) just like the second tap would.
+        vm.onStop = { [weak self] in self?.endPreviewAndResetGestures() }
+        vm.onCancel = { [weak self] in self?.endPreviewAndResetGestures() }
+        vm.onDismiss = { [weak self] in self?.endPreviewAndResetGestures() }
+        vm.startTimer()
+        overlayViewModel = vm
+
+        let controller = overlayFactory(vm)
+        controller.show()
+        overlayController = controller
+
+        // If the mic is unavailable (permission skipped) the leveling provider
+        // returns nil / its subscribe quietly fails — the overlay still appears,
+        // the waveform just stays at rest. Onboarding never blocks on this.
+        let leveling = micLevelingProvider()
+        micLeveling = leveling
+        leveling?.start { [weak self] level in
+            self?.overlayViewModel?.audioLevel = level
+        }
+    }
+
+    func endPreview() {
+        guard isPreviewing else { return }
+        isPreviewing = false
+        micLeveling?.stop()
+        micLeveling = nil
+        overlayViewModel?.stopTimer()
+        overlayController?.hide()
+        overlayController = nil
+        overlayViewModel = nil
+    }
+
+    private func endPreviewAndResetGestures() {
+        endPreview()
+        managers.forEach { $0.resetToIdle() }
+    }
+}
+
+// MARK: - SharedMicrophoneStream-backed leveling
+
+/// Concrete `MicLeveling` backed by the process-wide `SharedMicrophoneStream`.
+/// Subscribes with `wantsVPIO: false` (raw mic — no echo cancellation needed
+/// for a visual preview) and converts each buffer to an RMS level on the main
+/// actor. A subscribe failure (e.g. mic permission skipped) is swallowed; the
+/// overlay still appears, just without a moving waveform.
+@MainActor
+final class SharedMicLeveling: OnboardingHotkeyPreviewController.MicLeveling {
+    private let stream: SharedMicrophoneStream
+    private var token: SharedMicrophoneStream.SubscriberToken?
+    private var subscribeTask: Task<Void, Never>?
+
+    init(stream: SharedMicrophoneStream) {
+        self.stream = stream
+    }
+
+    func start(onLevel: @escaping @MainActor (Float) -> Void) {
+        subscribeTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                let token = try await self.stream.subscribe(wantsVPIO: false) { buffer, _ in
+                    let level = buffer.rmsLevel
+                    Task { @MainActor in onLevel(level) }
+                }
+                if Task.isCancelled {
+                    await self.stream.unsubscribe(token)
+                } else {
+                    self.token = token
+                }
+            } catch {
+                // Mic unavailable — leave the overlay on its fallback shimmer.
+            }
+        }
+    }
+
+    func stop() {
+        subscribeTask?.cancel()
+        subscribeTask = nil
+        if let token {
+            let stream = self.stream
+            Task { await stream.unsubscribe(token) }
+            self.token = nil
+        }
+    }
+}

--- a/Sources/MacParakeet/Onboarding/OnboardingWindowController.swift
+++ b/Sources/MacParakeet/Onboarding/OnboardingWindowController.swift
@@ -17,6 +17,8 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
         sttClient: STTClientProtocol,
         diarizationService: DiarizationServiceProtocol? = nil,
         onFinish: @escaping () -> Void,
+        onHotkeyPreviewArm: @escaping () -> Void = {},
+        onHotkeyPreviewDisarm: @escaping () -> Void = {},
         onOpenMainApp: @escaping () -> Void,
         onOpenSettings: @escaping () -> Void,
         onIncompleteDismiss: @escaping () -> Void
@@ -33,6 +35,11 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
             diarizationService: diarizationService
         )
         viewModel = vm
+        // Retained so the rehearsal taps/overlay are torn down if the window
+        // closes while the user is on the hotkey step (SwiftUI `onDisappear`
+        // can lag window teardown). `disarm()` is idempotent.
+        onHotkeyPreviewDisarmHandler = onHotkeyPreviewDisarm
+
         let view = OnboardingFlowView(
             viewModel: vm,
             onFinish: { [weak self] in
@@ -41,7 +48,9 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
                 onFinish()
             },
             onOpenMainApp: onOpenMainApp,
-            onOpenSettings: onOpenSettings
+            onOpenSettings: onOpenSettings,
+            onHotkeyPreviewArm: onHotkeyPreviewArm,
+            onHotkeyPreviewDisarm: onHotkeyPreviewDisarm
         )
 
         let hosting = NSHostingView(rootView: view)
@@ -84,6 +93,7 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
     }
 
     private var onIncompleteDismiss: (() -> Void)?
+    private var onHotkeyPreviewDisarmHandler: (() -> Void)?
 
     func windowShouldClose(_ sender: NSWindow) -> Bool {
         if allowCloseWithoutCompletion {
@@ -101,6 +111,8 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
     func windowWillClose(_ notification: Notification) {
         allowCloseWithoutCompletion = false
         onIncompleteDismiss = nil
+        onHotkeyPreviewDisarmHandler?()
+        onHotkeyPreviewDisarmHandler = nil
         viewModel?.stopObservingWarmUp()
         viewModel = nil
         // Defer teardown to the next run-loop tick so we don't destroy the

--- a/Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift
+++ b/Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift
@@ -7,6 +7,10 @@ struct OnboardingFlowView: View {
     let onFinish: () -> Void
     let onOpenMainApp: () -> Void
     let onOpenSettings: () -> Void
+    /// Arms/disarms the no-STT hotkey rehearsal while the "Learn the Hotkey"
+    /// step is on screen. Defaults to no-ops so previews/tests can omit them.
+    var onHotkeyPreviewArm: () -> Void = {}
+    var onHotkeyPreviewDisarm: () -> Void = {}
 
     /// Triggers shown in onboarding copy — fall back to defaults when disabled
     /// so instructional text stays readable.
@@ -554,6 +558,26 @@ struct OnboardingFlowView: View {
                 )
             }
 
+            // Live rehearsal nudge — only when Accessibility is granted, since
+            // the preview taps can't arm without it (and dictation won't work
+            // anyway). No model is needed: this is a visual preview only.
+            if viewModel.accessibilityGranted {
+                HStack(spacing: 8) {
+                    Image(systemName: "hand.tap.fill")
+                        .foregroundStyle(DesignSystem.Colors.accent)
+                    Text("Try it now — tap \(handsFreeDisplayTrigger.shortSymbol) or hold \(pushToTalkDisplayTrigger.shortSymbol). A live preview appears at the bottom of your screen.")
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(DesignSystem.Spacing.md)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
+                        .fill(DesignSystem.Colors.accent.opacity(0.08))
+                )
+            }
+
             // Hands-free mode card
             onboardingCard {
                 HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
@@ -623,8 +647,14 @@ struct OnboardingFlowView: View {
                 .font(DesignSystem.Typography.caption)
                 .foregroundStyle(.secondary)
         }
-        .onAppear { startAnimations() }
-        .onDisappear { stopAnimations() }
+        .onAppear {
+            startAnimations()
+            onHotkeyPreviewArm()
+        }
+        .onDisappear {
+            stopAnimations()
+            onHotkeyPreviewDisarm()
+        }
     }
 
     // MARK: - Hotkey Gesture Illustrations

--- a/Tests/MacParakeetTests/Onboarding/OnboardingHotkeyPreviewControllerTests.swift
+++ b/Tests/MacParakeetTests/Onboarding/OnboardingHotkeyPreviewControllerTests.swift
@@ -1,0 +1,169 @@
+import XCTest
+@testable import MacParakeet
+@testable import MacParakeetViewModels
+
+@MainActor
+final class OnboardingHotkeyPreviewControllerTests: XCTestCase {
+
+    // MARK: - Fakes
+
+    private final class SpyOverlayController: DictationOverlayControlling {
+        let viewModel: DictationOverlayViewModel
+        private(set) var showCount = 0
+        private(set) var hideCount = 0
+        var isShown: Bool { showCount > hideCount }
+
+        init(viewModel: DictationOverlayViewModel) {
+            self.viewModel = viewModel
+        }
+
+        func show() { showCount += 1 }
+        func hide() { hideCount += 1 }
+        func resignKeyWindow() {}
+    }
+
+    private final class FakeMicLeveling: OnboardingHotkeyPreviewController.MicLeveling {
+        private(set) var startCount = 0
+        private(set) var stopCount = 0
+        private var onLevel: (@MainActor (Float) -> Void)?
+
+        func start(onLevel: @escaping @MainActor (Float) -> Void) {
+            startCount += 1
+            self.onLevel = onLevel
+        }
+
+        func stop() {
+            stopCount += 1
+            onLevel = nil
+        }
+
+        /// Drive a level as if a mic buffer arrived.
+        func emit(_ level: Float) { onLevel?(level) }
+    }
+
+    /// Builds a controller wired to fakes with an empty hotkey plan so no real
+    /// CGEvent taps are created during the test.
+    private func makeHarness() -> (OnboardingHotkeyPreviewController, FakeMicLeveling, Box) {
+        let leveling = FakeMicLeveling()
+        let box = Box()
+        let controller = OnboardingHotkeyPreviewController(
+            planProvider: { .init(specs: [], conflict: nil) },
+            micLevelingProvider: { leveling },
+            overlayFactory: { vm in
+                let spy = SpyOverlayController(viewModel: vm)
+                box.lastOverlay = spy
+                return spy
+            },
+            suspendProductionHotkeys: { box.suspendCount += 1 },
+            resumeProductionHotkeys: { box.resumeCount += 1 }
+        )
+        return (controller, leveling, box)
+    }
+
+    /// Mutable capture box (the factory/closures need shared mutable state).
+    private final class Box {
+        var lastOverlay: SpyOverlayController?
+        var suspendCount = 0
+        var resumeCount = 0
+    }
+
+    // MARK: - Tests
+
+    func testArmSuspendsAndDisarmResumesBalanced() {
+        let (controller, _, box) = makeHarness()
+
+        controller.arm()
+        XCTAssertTrue(controller.isArmed)
+        XCTAssertEqual(box.suspendCount, 1)
+        XCTAssertEqual(box.resumeCount, 0)
+
+        controller.disarm()
+        XCTAssertFalse(controller.isArmed)
+        XCTAssertEqual(box.suspendCount, 1)
+        XCTAssertEqual(box.resumeCount, 1)
+    }
+
+    func testDoubleArmAndDisarmAreIdempotent() {
+        let (controller, _, box) = makeHarness()
+
+        controller.arm()
+        controller.arm()
+        XCTAssertEqual(box.suspendCount, 1, "Second arm() must not re-suspend")
+
+        controller.disarm()
+        controller.disarm()
+        XCTAssertEqual(box.resumeCount, 1, "Second disarm() must not re-resume")
+    }
+
+    func testBeginPreviewShowsOverlayAndStartsMic() {
+        let (controller, leveling, box) = makeHarness()
+        controller.arm()
+
+        controller.beginPreview(mode: .holdToTalk)
+
+        XCTAssertTrue(controller.isPreviewing)
+        XCTAssertEqual(box.lastOverlay?.showCount, 1)
+        XCTAssertEqual(box.lastOverlay?.isShown, true)
+        XCTAssertEqual(box.lastOverlay?.viewModel.recordingMode, .holdToTalk)
+        if case .recording = box.lastOverlay?.viewModel.state {} else {
+            XCTFail("Overlay should be in .recording state")
+        }
+        XCTAssertEqual(leveling.startCount, 1)
+    }
+
+    func testEndPreviewHidesOverlayAndStopsMic() {
+        let (controller, leveling, box) = makeHarness()
+        controller.arm()
+        controller.beginPreview(mode: .persistent)
+
+        controller.endPreview()
+
+        XCTAssertFalse(controller.isPreviewing)
+        XCTAssertEqual(box.lastOverlay?.isShown, false)
+        XCTAssertEqual(box.lastOverlay?.hideCount, 1)
+        XCTAssertEqual(leveling.stopCount, 1)
+    }
+
+    func testMicLevelUpdatesOverlayAudioLevel() {
+        let (controller, leveling, box) = makeHarness()
+        controller.arm()
+        controller.beginPreview(mode: .holdToTalk)
+
+        leveling.emit(0.42)
+
+        XCTAssertEqual(box.lastOverlay?.viewModel.audioLevel, 0.42)
+    }
+
+    func testDisarmWhilePreviewingTearsDownAndResumes() {
+        let (controller, leveling, box) = makeHarness()
+        controller.arm()
+        controller.beginPreview(mode: .persistent)
+
+        controller.disarm()
+
+        XCTAssertFalse(controller.isArmed)
+        XCTAssertFalse(controller.isPreviewing)
+        XCTAssertEqual(box.lastOverlay?.isShown, false, "Overlay must be hidden on disarm")
+        XCTAssertEqual(leveling.stopCount, 1, "Mic must be released on disarm")
+        XCTAssertEqual(box.resumeCount, 1, "Production hotkeys must be resumed exactly once")
+    }
+
+    func testBeginPreviewWithoutArmIsNoOp() {
+        let (controller, leveling, box) = makeHarness()
+
+        controller.beginPreview(mode: .holdToTalk)
+
+        XCTAssertFalse(controller.isPreviewing)
+        XCTAssertNil(box.lastOverlay)
+        XCTAssertEqual(leveling.startCount, 0)
+    }
+
+    func testSecondBeginPreviewWhileActiveIsNoOp() {
+        let (controller, leveling, _) = makeHarness()
+        controller.arm()
+        controller.beginPreview(mode: .holdToTalk)
+        controller.beginPreview(mode: .persistent)
+
+        XCTAssertEqual(leveling.startCount, 1, "Re-entrant beginPreview must not restart the mic")
+    }
+}

--- a/plans/active/2026-05-onboarding-hotkey-live-preview.md
+++ b/plans/active/2026-05-onboarding-hotkey-live-preview.md
@@ -1,0 +1,91 @@
+# Onboarding "Learn the Hotkey" — interactive live preview
+
+> Status: **ACTIVE** — 2026-05-22
+
+## Problem
+
+The onboarding "Learn the Hotkey" step (step 6 of 8) shows two animated cards
+("Tap fn+Space" / "Hold fn") that *imply* interactivity, but pressing the key
+does nothing. Confirmed in code: for a new user the global dictation CGEvent tap
+fails to arm at boot (Accessibility not yet granted) and is only re-armed at
+onboarding *completion* (`OnboardingCoordinator` → `onRefreshHotkeys`). Granting
+Accessibility at step 3 does not re-arm it. So the step is a dead "try me"
+affordance — a trust ding at the most fragile moment.
+
+## Goal
+
+Turn the step into a real first-success rehearsal: pressing the user's configured
+dictation trigger raises the **real dictation overlay** with a **live mic-driven
+waveform** — but with **no STT, no paste, no model** (the speech model is the
+*next* step). Press hold-fn → overlay while held → release dismisses; tap
+fn+Space → overlay → tap again dismisses. Mirrors both modes the cards teach.
+
+## Why feasible (existing seams)
+
+- Overlay + waveform are pure visual: `DictationOverlayController.show()` is
+  self-contained (positions bottom-center floating panel), `DictationOverlayViewModel`
+  exposes `state` + `audioLevel`, `WaveformView` consumes `audioLevel: Float`.
+  Zero STT dependency.
+- Live mic level: `SharedMicrophoneStream.subscribe(wantsVPIO:handler:)` +
+  `AVAudioPCMBuffer.rmsLevel` (public). Mic permission already granted (step 2).
+- Detection: reuse `HotkeyManager` with the user's configured triggers via
+  `AppHotkeyCoordinator.dictationHotkeyPlan(handsFree:pushToTalk:)`.
+
+## Design
+
+New `OnboardingHotkeyPreviewController` (`Sources/MacParakeet/Onboarding/`),
+`@MainActor`:
+
+- `arm()` (hotkey step appears): `suspend()` production hotkeys, build step-scoped
+  `HotkeyManager`s from the dictation plan, wire press→`beginPreview(mode:)`,
+  release/cancel→end.
+- `disarm()` (step disappears / window closes): end preview, stop managers,
+  `resume()` production hotkeys. Idempotent (guards `isArmed`).
+- `beginPreview(mode:)`: build a fresh `DictationOverlayViewModel` (`.recording`,
+  `recordingMode = mode`, start timer), show via injected overlay factory, start
+  a gentle fallback shimmer, subscribe to mic and feed `rmsLevel` → `audioLevel`
+  (first real level cancels the shimmer).
+- `endPreview()`: stop mic, stop shimmer, hide overlay, reset gesture state.
+- Mic abstracted behind a `MicLeveling` protocol (concrete `SharedMicLeveling`
+  wraps `SharedMicrophoneStream`) so the controller is testable without audio.
+
+**Gate the real flow during onboarding** (correctness + latent-bug fix): add
+`isOnboardingVisible` to `AppEnvironmentConfigurer.Callbacks`; `onStartDictation`
+no-ops while onboarding is visible. Prevents a returning user (model present,
+taps armed) from starting a real dictation mid-onboarding and double-stacking
+with the preview.
+
+**Graceful degradation**: mic skipped/denied → overlay shows with the breathing
+shimmer; never blocks Continue. Nudge copy ("Try it now…") only shown when
+Accessibility is granted (otherwise the preview taps can't arm).
+
+## Files
+
+- NEW `Sources/MacParakeet/Onboarding/OnboardingHotkeyPreviewController.swift`
+- `Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift` — arm/disarm
+  closures (default `{}`), call in `hotkeyStep` onAppear/onDisappear; "try it" nudge.
+- `Sources/MacParakeet/Onboarding/OnboardingWindowController.swift` — thread
+  closures into `show`/`OnboardingFlowView`; defensive disarm in `windowWillClose`.
+- `Sources/MacParakeet/App/OnboardingCoordinator.swift` — thread closures.
+- `Sources/MacParakeet/App/AppEnvironmentConfigurer.swift` — `isOnboardingVisible`
+  gate on `onStartDictation`.
+- `Sources/MacParakeet/AppDelegate.swift` — create controller, wire arm/disarm +
+  `isOnboardingVisible` callback.
+- NEW `Tests/MacParakeetTests/Onboarding/OnboardingHotkeyPreviewControllerTests.swift`
+
+## Tests
+
+Fakes for overlay (records show/hide), mic leveling (emits levels), suspend/resume
+counters; empty plan provider so no real CGEvent taps are created.
+
+1. arm→suspend once; disarm→resume once; double arm/disarm idempotent + balanced.
+2. beginPreview shows overlay + starts mic; endPreview hides overlay + stops mic.
+3. mic level → `audioLevel` updates.
+4. disarm while previewing hides overlay + resumes (no leak).
+5. beginPreview without arm is a no-op.
+
+## Out of scope / invariants
+
+- No STT, paste, history, or DB writes from the preview, ever.
+- Don't change production dictation behavior outside the onboarding-visible gate.
+- Don't block onboarding progression on mic/accessibility state.


### PR DESCRIPTION
## TL;DR

Onboarding's **"Learn the Hotkey"** step looked interactive but did nothing when you pressed the key. Now it's a real rehearsal: press your dictation trigger and the **actual dictation overlay rises with a live, mic-driven waveform** — a genuine first-success *before the speech model is even downloaded*. No STT, no paste, no model.

---

## The problem

The step shows two animated cards ("Tap `fn`+`Space`", "Hold `fn`") that *imply* "try me" — but pressing the key was a dead end. For a new user the global hotkey tap fails to arm at boot (Accessibility isn't granted yet) and is only re-armed *after* onboarding finishes. So the most teachable moment in the whole flow quietly does nothing.

```
            BEFORE                                       AFTER
 ┌────────────────────────────────┐        ┌────────────────────────────────┐
 │  Learn the Hotkey              │        │  Learn the Hotkey              │
 │                                │        │  ✋ Try it now — tap fn+Space   │
 │   [ Tap fn+Space ]  hands-free │        │   [ Tap fn+Space ]  hands-free │
 │   [ Hold fn ]       push-talk  │        │   [ Hold fn ]       push-talk  │
 │                                │        │                                │
 │     press fn  ─▶  (nothing)    │        │     press fn  ─▶  overlay!     │
 └────────────────────────────────┘        └────────────────────────────────┘
                                                          │
                                              bottom-center, just like the
                                              real thing:
                                                   ╭───────────────╮
                                                   │  ● ▁▃▅█▇▅▃▁ 0:03│  ← live,
                                                   ╰───────────────╯     mic-driven
```

## What it does

- **Both modes work, exactly as the cards teach** — *hold* `fn` shows the overlay while held; *tap* `fn`+`Space` toggles it until the second tap.
- **The waveform reacts to your actual voice** — fed from the real mic via `SharedMicrophoneStream` (`AVAudioPCMBuffer.rmsLevel`). Mic permission is already granted earlier in onboarding, so this is the real deal, not a canned animation.
- **Reuses the real overlay** — the same `DictationOverlayController` + `WaveformView` you'll see in daily use (they're pure-visual with zero STT dependency), so the rehearsal teaches the real thing, including *where* it appears on screen.
- **Graceful + non-blocking** — a "Try it now…" nudge shows only when Accessibility is granted; if the mic is unavailable (permission skipped) the overlay still appears, the waveform just stays at rest. Onboarding never blocks on this.

## How it works

```
 hotkey step appears ──▶ arm()
                          ├─ suspend production hotkeys (only the rehearsal owns the key)
                          └─ build step-scoped HotkeyManagers from the dictation plan
                                     │
               press trigger ───────┤
                                     ▼
                               beginPreview(mode)
                                 ├─ show REAL overlay  (state = .recording)
                                 ├─ subscribe mic → rmsLevel → overlay.audioLevel
                                 └─ ✗ no STT   ✗ no paste   ✗ no model
                                     │
               release / 2nd tap ───┤
                                     ▼
                                endPreview()   (hide overlay, release mic)

 step disappears / window closes ──▶ disarm()   ← idempotent; both call it
                                      ├─ tear down overlay + mic + taps
                                      └─ resume production hotkeys
```

A new `OnboardingHotkeyPreviewController` owns this lifecycle. `arm()`/`disarm()` guard on `isArmed` and `beginPreview`/`endPreview` guard on `isPreviewing`, so the SwiftUI `onDisappear` and the window's `windowWillClose` backstop can both fire `disarm()` without desyncing the suspend/resume refcount.

## Latent bug fixed along the way

Pressing the hotkey **— or clicking the idle pill —** during onboarding could previously start a *real, model-less dictation* (which then errors, since the model isn't downloaded yet). Both routes funnel through `startDictation`, so one guard closes both:

```
   hotkey press ─┐
                 ├─▶ DictationFlowCoordinator.startDictation()
 idle-pill click ┘            │
                              ▼
                  guard !isStartSuppressed()      ← "is onboarding visible?"
                              │
              onboarding up  ─┴─▶ return  (no-op — no model-less dictation)
              otherwise      ───▶ real dictation
```

The meeting / file / YouTube hotkeys are gated the same way while onboarding is visible.

## Testing

- **8 new unit tests** (`OnboardingHotkeyPreviewControllerTests`) — arm/disarm suspend↔resume balance, idempotency, overlay show/hide, mic→level plumbing, teardown-on-disarm, and the no-op guards. Fakes inject an empty hotkey plan so no real CGEvent taps are created.
- Full `swift test` suite green; clean Swift 6 strict-concurrency build.
- Independent review pass: design sound, STT unreachable during the rehearsal, no overlay/mic/tap leaks, no crash or progression-blocking paths without mic.

## Try it yourself

**Settings → "Re-run the guided setup"** → click through to the **Hotkey** step → press `fn` (hold) or `fn`+`Space` (tap). The preview pill appears bottom-center and the waveform tracks your voice.

## Notes for reviewers

- The rehearsal **never** calls `startDictation` — it drives the overlay directly, so STT/paste/history are unreachable by construction.
- `arm()` suspends production hotkeys so only the rehearsal taps own the key; the `isStartSuppressed` gate is a second, independent layer.
- Step sequence and progression are unchanged — this only enriches the existing step (ADR-005, first-run onboarding).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
