### PR TITLE
Engine: Whisper tile shows honest cold vs warm status

### DIFF
--- a/Sources/MacParakeet/Views/Settings/Components/EngineOptionTile.swift
+++ b/Sources/MacParakeet/Views/Settings/Components/EngineOptionTile.swift
@@ -17,6 +17,10 @@ struct EngineOptionTile: View {
     let modelStatus: SettingsViewModel.LocalModelStatus
     let isSelected: Bool
     let isBusy: Bool
+    /// When the model is downloaded but has never paid its one-time on-device
+    /// optimize, the next load is slow (minutes). Splits the `.notLoaded`
+    /// footer into a cold "Setup needed" vs warm "Downloaded" presentation.
+    var needsFirstOptimize: Bool = false
     let onSelect: () -> Void
 
     @State private var isHovered = false
@@ -103,7 +107,7 @@ struct EngineOptionTile: View {
     }
 
     private var statusFooter: some View {
-        let info = StatusInfo.from(modelStatus)
+        let info = StatusInfo.from(modelStatus, needsFirstOptimize: needsFirstOptimize)
         return HStack(alignment: .center, spacing: DesignSystem.Spacing.xs) {
             Circle()
                 .fill(info.color)
@@ -147,7 +151,10 @@ struct EngineOptionTile: View {
         let label: String
         let detail: String
 
-        static func from(_ status: SettingsViewModel.LocalModelStatus) -> StatusInfo {
+        static func from(
+            _ status: SettingsViewModel.LocalModelStatus,
+            needsFirstOptimize: Bool = false
+        ) -> StatusInfo {
             switch status {
             case .ready:
                 return StatusInfo(
@@ -156,10 +163,17 @@ struct EngineOptionTile: View {
                     detail: "Loaded in memory"
                 )
             case .notLoaded:
+                if needsFirstOptimize {
+                    return StatusInfo(
+                        color: DesignSystem.Colors.warningAmber,
+                        label: "Setup needed",
+                        detail: "First switch optimizes — a minute or two"
+                    )
+                }
                 return StatusInfo(
                     color: DesignSystem.Colors.successGreen,
                     label: "Downloaded",
-                    detail: "May optimize on first load"
+                    detail: "Loads in seconds"
                 )
             case .notDownloaded:
                 return StatusInfo(

--- a/Sources/MacParakeet/Views/Settings/Components/EngineOptionTile.swift
+++ b/Sources/MacParakeet/Views/Settings/Components/EngineOptionTile.swift
@@ -167,7 +167,7 @@ struct EngineOptionTile: View {
                     return StatusInfo(
                         color: DesignSystem.Colors.warningAmber,
                         label: "Setup needed",
-                        detail: "First switch optimizes — a minute or two"
+                        detail: "First switch: a minute or two"
                     )
                 }
                 return StatusInfo(

--- a/Sources/MacParakeet/Views/Settings/Components/EngineOptionTile.swift
+++ b/Sources/MacParakeet/Views/Settings/Components/EngineOptionTile.swift
@@ -167,7 +167,7 @@ struct EngineOptionTile: View {
                     return StatusInfo(
                         color: DesignSystem.Colors.warningAmber,
                         label: "Setup needed",
-                        detail: "First switch: a minute or two"
+                        detail: "Optimizes on first switch"
                     )
                 }
                 return StatusInfo(

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -1550,6 +1550,8 @@ struct SettingsView: View {
                         modelStatus: displayedWhisperModelStatus,
                         isSelected: viewModel.speechEnginePreference == .whisper,
                         isBusy: viewModel.speechEngineSwitching,
+                        needsFirstOptimize: displayedWhisperModelStatus == .notLoaded
+                            && !viewModel.whisperHasBeenOptimized,
                         onSelect: { handleWhisperTileTap() }
                     )
                 }

--- a/Sources/MacParakeetCore/STT/WhisperEngine.swift
+++ b/Sources/MacParakeetCore/STT/WhisperEngine.swift
@@ -112,6 +112,10 @@ public actor WhisperEngine: STTTranscribing {
     private let modelVariant: String
     private let defaultLanguage: String?
     private let downloadBase: URL
+    /// Store the optimized-flag write lands in; defaults to `.standard` to match
+    /// every production caller (runtime + CLI). Injected so the write-path and
+    /// the VM's read-path are coupled by construction, not by convention.
+    private let defaults: UserDefaults
     private let transcriptionPermit = AsyncPermit()
 
     #if canImport(WhisperKit)
@@ -122,11 +126,13 @@ public actor WhisperEngine: STTTranscribing {
     public init(
         model: String = WhisperEngine.defaultModelVariant,
         language: String? = nil,
-        downloadBase: URL? = nil
+        downloadBase: URL? = nil,
+        defaults: UserDefaults = .standard
     ) {
         self.modelVariant = Self.normalizeModelVariant(model)
         self.defaultLanguage = SpeechEnginePreference.normalizeLanguage(language)
         self.downloadBase = downloadBase ?? Self.defaultDownloadBase
+        self.defaults = defaults
     }
 
     public static func make(
@@ -141,17 +147,10 @@ public actor WhisperEngine: STTTranscribing {
     }
 
     public static func normalizeModelVariant(_ model: String) -> String {
-        let normalized = SpeechEnginePreference.normalizeModelVariant(model) ?? defaultModelVariant
-        if normalized.hasSuffix("-turbo") {
-            return String(normalized.dropLast("-turbo".count)) + "_turbo"
-        }
-        if normalized.contains("-turbo_") {
-            return normalized.replacingOccurrences(of: "-turbo_", with: "_turbo_")
-        }
-        if normalized.contains("-turbo-") {
-            return normalized.replacingOccurrences(of: "-turbo-", with: "_turbo_")
-        }
-        return normalized
+        // Turbo hyphen/underscore folding now lives in the shared
+        // `SpeechEnginePreference.normalizeModelVariant` so the engine, the
+        // stored preference, and the optimized-flag key all agree on one id.
+        SpeechEnginePreference.normalizeModelVariant(model) ?? defaultModelVariant
     }
 
     public static func isModelDownloaded(
@@ -306,7 +305,7 @@ public actor WhisperEngine: STTTranscribing {
             // first meeting use, CLI). The UI reads this to show cold vs warm
             // status. Only reached on a real compile, so it never fires in
             // unit tests (which lack a downloaded model + WhisperKit).
-            SpeechEnginePreference.markWhisperOptimized(variant: variant)
+            SpeechEnginePreference.markWhisperOptimized(variant: variant, defaults: defaults)
             let duration = Observability.durationSeconds(since: startedAt)
             logger.notice("whisper_model_prepare_complete model=\(variant, privacy: .public) duration_s=\(duration, privacy: .public)")
             AudioCaptureDiagnostics.append(

--- a/Sources/MacParakeetCore/STT/WhisperEngine.swift
+++ b/Sources/MacParakeetCore/STT/WhisperEngine.swift
@@ -301,6 +301,12 @@ public actor WhisperEngine: STTTranscribing {
                 download: false
             ))
             isLoaded = true
+            // Single chokepoint for "this variant compiled successfully on this
+            // Mac" — fires for every caller (Settings switch, onboarding,
+            // first meeting use, CLI). The UI reads this to show cold vs warm
+            // status. Only reached on a real compile, so it never fires in
+            // unit tests (which lack a downloaded model + WhisperKit).
+            SpeechEnginePreference.markWhisperOptimized(variant: variant)
             let duration = Observability.durationSeconds(since: startedAt)
             logger.notice("whisper_model_prepare_complete model=\(variant, privacy: .public) duration_s=\(duration, privacy: .public)")
             AudioCaptureDiagnostics.append(

--- a/Sources/MacParakeetCore/SpeechEnginePreference.swift
+++ b/Sources/MacParakeetCore/SpeechEnginePreference.swift
@@ -107,7 +107,28 @@ public enum SpeechEnginePreference: String, CaseIterable, Codable, Sendable {
         guard let variant else { return nil }
         let trimmed = variant.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
-        return trimmed.hasPrefix("whisper-") ? String(trimmed.dropFirst("whisper-".count)) : trimmed
+        let withoutPrefix = trimmed.hasPrefix("whisper-")
+            ? String(trimmed.dropFirst("whisper-".count))
+            : trimmed
+        return canonicalizeTurboSuffix(withoutPrefix)
+    }
+
+    /// Whisper "turbo" variants ship with both hyphen and underscore spellings
+    /// (`large-v3-turbo`, `large-v3_turbo`). Fold them to the underscore form so
+    /// one model resolves to a single id everywhere — on-disk folder lookup, the
+    /// stored preference, and optimized-flag tracking — instead of the mark-side
+    /// (engine) and query-side (UI) ids drifting apart.
+    private static func canonicalizeTurboSuffix(_ variant: String) -> String {
+        if variant.hasSuffix("-turbo") {
+            return String(variant.dropLast("-turbo".count)) + "_turbo"
+        }
+        if variant.contains("-turbo_") {
+            return variant.replacingOccurrences(of: "-turbo_", with: "_turbo_")
+        }
+        if variant.contains("-turbo-") {
+            return variant.replacingOccurrences(of: "-turbo-", with: "_turbo_")
+        }
+        return variant
     }
 
     /// Maps an internal Whisper variant id to a short, user-friendly label.

--- a/Sources/MacParakeetCore/SpeechEnginePreference.swift
+++ b/Sources/MacParakeetCore/SpeechEnginePreference.swift
@@ -8,6 +8,14 @@ public enum SpeechEnginePreference: String, CaseIterable, Codable, Sendable {
     public static let whisperDefaultLanguageKey = "whisperDefaultLanguage"
     public static let whisperModelVariantKey = "whisperModelVariant"
 
+    /// Variants whose one-time CoreML compile/ANE specialization has already
+    /// completed on this Mac. The first load of a Whisper variant pays a
+    /// multi-minute optimize (`WhisperKitConfig(load: true)`); subsequent loads
+    /// reuse the on-disk compiled artifacts and are fast. We persist which
+    /// variants are warm so the UI can distinguish a cold first switch
+    /// ("Setup needed", minutes) from a warm one ("Downloaded", seconds).
+    public static let whisperOptimizedVariantsKey = "whisperOptimizedVariants"
+
     public static let defaultWhisperModelVariant = "large-v3-v20240930_turbo_632MB"
 
     public var displayName: String {
@@ -63,6 +71,34 @@ public enum SpeechEnginePreference: String, CaseIterable, Codable, Sendable {
             return
         }
         defaults.set(normalized, forKey: whisperModelVariantKey)
+    }
+
+    /// Whether `variant` has already paid its one-time on-device optimize, so
+    /// the next load will be fast. Compares on the normalized variant id.
+    public static func hasOptimizedWhisper(variant: String, defaults: UserDefaults = .standard) -> Bool {
+        guard let normalized = normalizeModelVariant(variant) else { return false }
+        let optimized = defaults.stringArray(forKey: whisperOptimizedVariantsKey) ?? []
+        return optimized.contains(normalized)
+    }
+
+    /// Records that `variant` finished its one-time optimize on this Mac.
+    /// Idempotent; call after a successful `WhisperEngine.prepare()`.
+    public static func markWhisperOptimized(variant: String, defaults: UserDefaults = .standard) {
+        guard let normalized = normalizeModelVariant(variant) else { return }
+        var optimized = defaults.stringArray(forKey: whisperOptimizedVariantsKey) ?? []
+        guard !optimized.contains(normalized) else { return }
+        optimized.append(normalized)
+        defaults.set(optimized, forKey: whisperOptimizedVariantsKey)
+    }
+
+    /// Forgets the optimized flag for `variant` — call when the model is
+    /// deleted or re-downloaded so the cold "Setup needed" copy returns.
+    public static func clearWhisperOptimized(variant: String, defaults: UserDefaults = .standard) {
+        guard let normalized = normalizeModelVariant(variant) else { return }
+        var optimized = defaults.stringArray(forKey: whisperOptimizedVariantsKey) ?? []
+        let filtered = optimized.filter { $0 != normalized }
+        guard filtered.count != optimized.count else { return }
+        defaults.set(filtered, forKey: whisperOptimizedVariantsKey)
     }
 
     public static func normalizeLanguage(_ language: String?) -> String? {

--- a/Sources/MacParakeetCore/SpeechEnginePreference.swift
+++ b/Sources/MacParakeetCore/SpeechEnginePreference.swift
@@ -91,16 +91,6 @@ public enum SpeechEnginePreference: String, CaseIterable, Codable, Sendable {
         defaults.set(optimized, forKey: whisperOptimizedVariantsKey)
     }
 
-    /// Forgets the optimized flag for `variant` — call when the model is
-    /// deleted or re-downloaded so the cold "Setup needed" copy returns.
-    public static func clearWhisperOptimized(variant: String, defaults: UserDefaults = .standard) {
-        guard let normalized = normalizeModelVariant(variant) else { return }
-        var optimized = defaults.stringArray(forKey: whisperOptimizedVariantsKey) ?? []
-        let filtered = optimized.filter { $0 != normalized }
-        guard filtered.count != optimized.count else { return }
-        defaults.set(filtered, forKey: whisperOptimizedVariantsKey)
-    }
-
     public static func normalizeLanguage(_ language: String?) -> String? {
         WhisperLanguageCatalog.canonicalCode(for: language)
     }

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -1106,7 +1106,7 @@ public final class SettingsViewModel {
             if whisperHasBeenOptimized {
                 whisperModelStatusDetail = "\(friendly) · Installed locally, loads in seconds."
             } else {
-                whisperModelStatusDetail = "\(friendly) · Installed locally. First switch optimizes for this Mac (a minute or two)."
+                whisperModelStatusDetail = "\(friendly) · Installed locally. First switch optimizes for this Mac."
             }
         } else {
             whisperModelStatus = .notDownloaded

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -275,6 +275,17 @@ public final class SettingsViewModel {
     public var isWhisperModelDownloaded: Bool {
         whisperModelStatus == .ready || whisperModelStatus == .notLoaded
     }
+    /// True once the active Whisper variant has paid its one-time on-device
+    /// optimize, so the next load is fast. Drives cold ("Setup needed",
+    /// minutes) vs warm ("Downloaded", seconds) status in the engine picker.
+    /// Reads through `defaults`; the value flips after the first successful
+    /// `WhisperEngine.prepare()`, surfaced on the next `refreshModelStatus()`.
+    public var whisperHasBeenOptimized: Bool {
+        SpeechEnginePreference.hasOptimizedWhisper(
+            variant: SpeechEnginePreference.whisperModelVariant(defaults: defaults),
+            defaults: defaults
+        )
+    }
     public private(set) var pendingMeetingRecoveryCount = 0
     public var onRecoverPendingMeetingRecordings: (() -> Void)?
 
@@ -1092,7 +1103,11 @@ public final class SettingsViewModel {
             // to `.ready` after asking the runtime if Whisper is the active
             // engine and currently loaded.
             whisperModelStatus = .notLoaded
-            whisperModelStatusDetail = "\(friendly) · Installed locally. First load may optimize for this Mac."
+            if whisperHasBeenOptimized {
+                whisperModelStatusDetail = "\(friendly) · Installed locally, loads in seconds."
+            } else {
+                whisperModelStatusDetail = "\(friendly) · Installed locally. First switch optimizes for this Mac (a minute or two)."
+            }
         } else {
             whisperModelStatus = .notDownloaded
             whisperModelStatusDetail = "\(friendly) · Needs download before use."

--- a/Tests/MacParakeetTests/STT/SpeechEnginePreferenceTests.swift
+++ b/Tests/MacParakeetTests/STT/SpeechEnginePreferenceTests.swift
@@ -69,16 +69,13 @@ final class SpeechEnginePreferenceTests: XCTestCase {
         XCTAssertTrue(SpeechEnginePreference.hasOptimizedWhisper(variant: bare, defaults: defaults))
     }
 
-    func testClearWhisperOptimizedRemovesOnlyThatVariant() {
+    func testWhisperOptimizedIsTrackedPerVariant() {
         let (defaults, suite) = makeIsolatedDefaults()
         defer { defaults.removePersistentDomain(forName: suite) }
 
         SpeechEnginePreference.markWhisperOptimized(variant: "large-v3-turbo", defaults: defaults)
-        SpeechEnginePreference.markWhisperOptimized(variant: "small", defaults: defaults)
 
-        SpeechEnginePreference.clearWhisperOptimized(variant: "large-v3-turbo", defaults: defaults)
-
-        XCTAssertFalse(SpeechEnginePreference.hasOptimizedWhisper(variant: "large-v3-turbo", defaults: defaults))
-        XCTAssertTrue(SpeechEnginePreference.hasOptimizedWhisper(variant: "small", defaults: defaults))
+        XCTAssertTrue(SpeechEnginePreference.hasOptimizedWhisper(variant: "large-v3-turbo", defaults: defaults))
+        XCTAssertFalse(SpeechEnginePreference.hasOptimizedWhisper(variant: "small", defaults: defaults))
     }
 }

--- a/Tests/MacParakeetTests/STT/SpeechEnginePreferenceTests.swift
+++ b/Tests/MacParakeetTests/STT/SpeechEnginePreferenceTests.swift
@@ -13,4 +13,72 @@ final class SpeechEnginePreferenceTests: XCTestCase {
             "large-v30-experimental-build"
         )
     }
+
+    // MARK: - Whisper optimized-variant tracking
+
+    private func makeIsolatedDefaults() -> (UserDefaults, String) {
+        let suite = "test.SpeechEnginePreference.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            fatalError("Could not create isolated UserDefaults suite")
+        }
+        return (defaults, suite)
+    }
+
+    func testWhisperOptimizedDefaultsToFalse() {
+        let (defaults, suite) = makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        XCTAssertFalse(
+            SpeechEnginePreference.hasOptimizedWhisper(
+                variant: SpeechEnginePreference.defaultWhisperModelVariant,
+                defaults: defaults
+            )
+        )
+    }
+
+    func testMarkWhisperOptimizedRoundTrips() {
+        let (defaults, suite) = makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let variant = SpeechEnginePreference.defaultWhisperModelVariant
+        SpeechEnginePreference.markWhisperOptimized(variant: variant, defaults: defaults)
+
+        XCTAssertTrue(SpeechEnginePreference.hasOptimizedWhisper(variant: variant, defaults: defaults))
+    }
+
+    func testMarkWhisperOptimizedIsIdempotent() {
+        let (defaults, suite) = makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let variant = SpeechEnginePreference.defaultWhisperModelVariant
+        SpeechEnginePreference.markWhisperOptimized(variant: variant, defaults: defaults)
+        SpeechEnginePreference.markWhisperOptimized(variant: variant, defaults: defaults)
+
+        let stored = defaults.stringArray(forKey: SpeechEnginePreference.whisperOptimizedVariantsKey) ?? []
+        XCTAssertEqual(stored, [variant])
+    }
+
+    func testWhisperOptimizedNormalizesVariantPrefix() {
+        let (defaults, suite) = makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        // Marked with the "whisper-" prefix, queried without it (and vice versa).
+        let bare = SpeechEnginePreference.defaultWhisperModelVariant
+        SpeechEnginePreference.markWhisperOptimized(variant: "whisper-\(bare)", defaults: defaults)
+
+        XCTAssertTrue(SpeechEnginePreference.hasOptimizedWhisper(variant: bare, defaults: defaults))
+    }
+
+    func testClearWhisperOptimizedRemovesOnlyThatVariant() {
+        let (defaults, suite) = makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        SpeechEnginePreference.markWhisperOptimized(variant: "large-v3-turbo", defaults: defaults)
+        SpeechEnginePreference.markWhisperOptimized(variant: "small", defaults: defaults)
+
+        SpeechEnginePreference.clearWhisperOptimized(variant: "large-v3-turbo", defaults: defaults)
+
+        XCTAssertFalse(SpeechEnginePreference.hasOptimizedWhisper(variant: "large-v3-turbo", defaults: defaults))
+        XCTAssertTrue(SpeechEnginePreference.hasOptimizedWhisper(variant: "small", defaults: defaults))
+    }
 }

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -105,6 +105,25 @@ final class SettingsViewModelTests: XCTestCase {
         testDefaultsSuiteName = nil
     }
 
+    // MARK: - Whisper cold/warm status
+
+    func testWhisperHasBeenOptimizedReflectsPersistedFlag() {
+        XCTAssertFalse(
+            viewModel.whisperHasBeenOptimized,
+            "Should read false before any Whisper variant has been optimized"
+        )
+
+        SpeechEnginePreference.markWhisperOptimized(
+            variant: SpeechEnginePreference.whisperModelVariant(defaults: testDefaults),
+            defaults: testDefaults
+        )
+
+        XCTAssertTrue(
+            viewModel.whisperHasBeenOptimized,
+            "Should read true once the active variant is marked optimized"
+        )
+    }
+
     // MARK: - Initial Values
 
     func testDefaultValues() {

--- a/plans/active/2026-05-engine-switch-ux-revamp.md
+++ b/plans/active/2026-05-engine-switch-ux-revamp.md
@@ -52,7 +52,7 @@ Copy guidance: avoid a hard minute count (slower Macs overrun it; the watchdog h
 
 ### Stage A — honest + safe (low risk, decision-independent, ship first)
 
-- **A1 + A2 — shipped (PR #335).** `whisperOptimizedVariants` persistence (per variant) in `SpeechEnginePreference`, set on the first successful `prepare()`; the engine tile splits the downloaded-but-inactive footer into cold (amber "Setup needed · First switch: a minute or two") vs warm (green "Downloaded · Loads in seconds") via a `needsFirstOptimize` tile input. The `LocalModelStatus` model is unchanged — the cold/warm split is a pure presentation concern, so no new enum case.
+- **A1 + A2 — shipped (PR #335).** `whisperOptimizedVariants` persistence (per variant) in `SpeechEnginePreference`, set on the first successful `prepare()`; the engine tile splits the downloaded-but-inactive footer into cold (amber "Setup needed · Optimizes on first switch") vs warm (green "Downloaded · Loads in seconds") via a `needsFirstOptimize` tile input. Static copy avoids a hard minute count (slower Macs overrun it); the in-switch watchdog handles time reassurance. The `LocalModelStatus` model is unchanged — the cold/warm split is a pure presentation concern, so no new enum case.
 - **A3. Disabled cards + named blocker (follow-up).** Surface engine-switch availability from the scheduler (it already holds `activeSpeechEngineSessionIDs` + `hasQueuedOrRunningJobs`, `STTScheduler.swift:186-187`) to the VM; gate `handleWhisperTileTap`/`selectEngine` with meeting/job-specific copy. High-value case is meetings (already tracked app-wide).
 
 ### Stage B — background optimize (the real cancel)

--- a/plans/active/2026-05-engine-switch-ux-revamp.md
+++ b/plans/active/2026-05-engine-switch-ux-revamp.md
@@ -52,9 +52,8 @@ Copy guidance: avoid a hard minute count (slower Macs overrun it; the watchdog h
 
 ### Stage A — honest + safe (low risk, decision-independent, ship first)
 
-- **A1. `whisperOptimizedVariants` persistence** (per model variant) in `SpeechEnginePreference`; set on first successful `prepare()`. Drives the cold/warm copy split. *(this turn)*
-- **A2. Cold/warm tile state.** Split `notLoaded` presentation by the A1 flag (new `LocalModelStatus` case or a tile-level tone/label/detail override — decide during UI work).
-- **A3. Disabled cards + named blocker.** Surface engine-switch availability from the scheduler (it already holds `activeSpeechEngineSessionIDs` + `hasQueuedOrRunningJobs`, `STTScheduler.swift:186-187`) to the VM; gate `handleWhisperTileTap`/`selectEngine` with meeting/job-specific copy. High-value case is meetings (already tracked app-wide).
+- **A1 + A2 — shipped (PR #335).** `whisperOptimizedVariants` persistence (per variant) in `SpeechEnginePreference`, set on the first successful `prepare()`; the engine tile splits the downloaded-but-inactive footer into cold (amber "Setup needed · First switch: a minute or two") vs warm (green "Downloaded · Loads in seconds") via a `needsFirstOptimize` tile input. The `LocalModelStatus` model is unchanged — the cold/warm split is a pure presentation concern, so no new enum case.
+- **A3. Disabled cards + named blocker (follow-up).** Surface engine-switch availability from the scheduler (it already holds `activeSpeechEngineSessionIDs` + `hasQueuedOrRunningJobs`, `STTScheduler.swift:186-187`) to the VM; gate `handleWhisperTileTap`/`selectEngine` with meeting/job-specific copy. High-value case is meetings (already tracked app-wide).
 
 ### Stage B — background optimize (the real cancel)
 
@@ -68,7 +67,7 @@ Copy guidance: avoid a hard minute count (slower Macs overrun it; the watchdog h
 - Meeting starts mid-prepare → flip defers (`beginSpeechEngineSession` awaits the switch task, `STTScheduler.swift:211-216`).
 - Cancel then immediate re-tap → generation guard prevents stale completion from flipping.
 - Failed prepare → stay on Parakeet, surface Retry; never set optimized=true.
-- Re-download / delete Whisper model → clear the optimized flag for that variant so cold copy returns.
+- "Repair" (re-download) is a no-op when files are intact and does not invalidate the compiled cache, so the optimized flag correctly persists. There is no Whisper delete path today; if one is added, it should clear the flag for that variant.
 - Brief dual residency (Parakeet + 632 MB Whisper) during prepare — acceptable on Apple Silicon; already happens transiently on every switch via load-before-unload.
 
 ## 7. Telemetry
@@ -77,8 +76,8 @@ Copy guidance: avoid a hard minute count (slower Macs overrun it; the watchdog h
 
 ## 8. Tests
 
-- `SpeechEnginePreference` optimized-variant round-trip + normalization + idempotency (this turn).
-- VM cold/warm status mapping.
+- `SpeechEnginePreference` optimized-variant round-trip + normalization + idempotency + per-variant tracking (done).
+- VM cold/warm status mapping (done).
 - VM blocked-by-meeting copy + card disable.
 - Scheduler/runtime: background prepare does not block jobs; flip defers under active lease; cancel keeps previous engine.
 

--- a/plans/active/2026-05-engine-switch-ux-revamp.md
+++ b/plans/active/2026-05-engine-switch-ux-revamp.md
@@ -1,0 +1,87 @@
+# Engine Switch UX Revamp
+
+> Status: **ACTIVE PLAN**
+> Drafted: 2026-05-23
+> ADR: `spec/adr/021-whisperkit-multilingual-stt.md`, `spec/adr/016-centralized-stt-runtime-scheduler.md`
+> Scope: Settings → Engine switching UX (Parakeet ↔ Whisper). No change to STT accuracy, scheduler slot topology, or meeting engine-pinning semantics.
+
+## 1. Problem
+
+Switching to Whisper in Settings (`Engine` tab) freezes all voice features for minutes on first use, with only an indeterminate spinner and no way out. Three concrete gaps:
+
+1. **No escape.** Once the switch starts, both engine cards disable and there is no cancel — the only exit is force-quit (`SettingsView.swift` engine section; switch Task is fire-and-forget at `SettingsViewModel.swift:1253`).
+2. **Lying status copy.** The Whisper tile shows *"Downloaded · May optimize on first load"* for **both** the cold (slow, never-compiled) and warm (fast, already-compiled) cases — they map to the same `LocalModelStatus.notLoaded` (`EngineOptionTile.swift:158-163`). Users can't tell whether the next switch will take seconds or minutes.
+3. **Vague blocked state.** Tapping an engine while a meeting/job is active fails with the generic *"Speech engine is busy. Try again after the current transcription finishes."* (`STTClientProtocol.swift:103`) — it never names the meeting. `handleWhisperTileTap` only pre-checks model-download status, not active leases/jobs (`SettingsView.swift:1779-1794`).
+
+## 2. The slow part (ground truth)
+
+The 632 MB download is **not** the slow part for the common case; the model is already on disk. The cost is the **one-time CoreML compile + Neural Engine specialization** inside WhisperKit's loader (`WhisperEngine.swift:295`, `WhisperKitConfig(load: true, download: false)`). Compiled `.mlmodelc`/specialization artifacts are cached, so second+ loads are fast. This is what the "May optimize on first load" copy refers to.
+
+## 3. The finding that reshapes the cancel
+
+A cancel button on the **current blocking flow cannot give the minutes back.** Cancellation propagates (`STTScheduler.swift:201-207`), but the CoreML compile is one long uninterruptible `await` we don't control: there are no suspension checkpoints inside it (`WhisperEngine.swift:265` is the only `checkCancellation`, and it runs *before* the heavy work). A cancel issued mid-compile cannot return control until the compile finishes — and without a post-compile `checkCancellation` the switch would even complete anyway.
+
+**Conclusion:** the way to make cancel meaningful is to stop blocking. Run the one-time optimize as a **background preparation** while Parakeet stays active and usable; flip to Whisper when ready. Then "cancel" = "keep Parakeet" and it is *instant*, because the user was never frozen.
+
+The runtime already has the scaffolding: a generation-guarded background warm-up with an observer stream and state machine (`STTRuntime.swift:267-314`) — today it warms Parakeet only. And the switch is already **load-new-before-unload-old** (`STTRuntime.swift:425-453`), so the previous engine stays resident until the new one is ready — rollback is inherently clean, no engineless window.
+
+## 4. Target experience
+
+Cold first switch to Whisper:
+
+1. Tap Whisper (downloaded, never optimized on this Mac).
+2. **No app-wide freeze.** Parakeet stays active; dictation/meetings keep working. The Whisper card shows *"Optimizing for this Mac…"* with the existing escalating watchdog copy (`WhisperEngine.swift:496-520`) and a **Cancel** = "keep Parakeet".
+3. On completion, flip to Whisper automatically (their stated intent) with a brief confirmation. Subsequent switches are instant.
+4. On cancel: stay on Parakeet, zero wait. Compile cache is warm, so the next attempt is fast; mark the variant "optimized".
+
+### Card states + copy
+
+| Situation | Dot | Label | Detail |
+|---|---|---|---|
+| Active + loaded | green | **Active** | Loaded in memory |
+| Optimized before, not active (warm) | green | **Ready** | Switches in seconds |
+| Downloaded, never optimized (cold) | amber | **Setup needed** | First switch optimizes — a minute or two |
+| Downloading | amber | **Downloading** | NN% · 632 MB |
+| Optimizing now | amber | **Optimizing…** | *(watchdog detail)* + **Cancel** |
+| Failed | red | **Setup failed** | Retry below |
+| Unavailable (meeting/job active) | dim | **Unavailable** | While a meeting is recording |
+
+Copy guidance: avoid a hard minute count (slower Macs overrun it; the watchdog handles the long tail). Adjacent fix: onboarding states the Whisper download is *"~6 GB"* (`OnboardingFlowView.swift` ~line 1171) — it is 632 MB; ~6 GB is Parakeet's bundle.
+
+## 5. Staged delivery
+
+### Stage A — honest + safe (low risk, decision-independent, ship first)
+
+- **A1. `whisperOptimizedVariants` persistence** (per model variant) in `SpeechEnginePreference`; set on first successful `prepare()`. Drives the cold/warm copy split. *(this turn)*
+- **A2. Cold/warm tile state.** Split `notLoaded` presentation by the A1 flag (new `LocalModelStatus` case or a tile-level tone/label/detail override — decide during UI work).
+- **A3. Disabled cards + named blocker.** Surface engine-switch availability from the scheduler (it already holds `activeSpeechEngineSessionIDs` + `hasQueuedOrRunningJobs`, `STTScheduler.swift:186-187`) to the VM; gate `handleWhisperTileTap`/`selectEngine` with meeting/job-specific copy. High-value case is meetings (already tracked app-wide).
+
+### Stage B — background optimize (the real cancel)
+
+- **B1. Engine-parameterized background prepare.** Extend the runtime warm-up so `whisperEngine.prepare()` can run in the background **without** `acceptsNewJobs = false` while Parakeet stays active.
+- **B2. VM orchestration.** Cold Whisper tap → start background prepare → on completion call `setSpeechEngine(.whisper)` (now fast). Defer the flip if a meeting/job is running when prepare finishes (lease guard already enforces).
+- **B3. Cancel = cancel the background prepare**, stay on Parakeet (instant). Mark optimized if the cache populated.
+- **B4. Decision: auto-switch when ready vs notify "Whisper ready — switch now".** Recommendation: auto-switch (they tapped Whisper).
+
+## 6. Edge cases / invariants
+
+- Meeting starts mid-prepare → flip defers (`beginSpeechEngineSession` awaits the switch task, `STTScheduler.swift:211-216`).
+- Cancel then immediate re-tap → generation guard prevents stale completion from flipping.
+- Failed prepare → stay on Parakeet, surface Retry; never set optimized=true.
+- Re-download / delete Whisper model → clear the optimized flag for that variant so cold copy returns.
+- Brief dual residency (Parakeet + 632 MB Whisper) during prepare — acceptable on Apple Silicon; already happens transiently on every switch via load-before-unload.
+
+## 7. Telemetry
+
+`speechEngineSwitchOperation` already carries `outcome` (incl. `.cancelled`) and `blockedReason`. Add: `was_cold` (first optimize) and `mode` (`foreground`/`background`) so we can measure real-world cold-optimize duration and whether cancels cluster on slow machines.
+
+## 8. Tests
+
+- `SpeechEnginePreference` optimized-variant round-trip + normalization + idempotency (this turn).
+- VM cold/warm status mapping.
+- VM blocked-by-meeting copy + card disable.
+- Scheduler/runtime: background prepare does not block jobs; flip defers under active lease; cancel keeps previous engine.
+
+## 9. Open decision
+
+Stage A is shippable on its own. Stage B is the only thing that makes cancel honest and removes the freeze, but it touches the scheduler exclusivity model. Building A foundations first; confirm Stage B go-ahead before B1–B3.


### PR DESCRIPTION
## TL;DR

When you pick **Whisper** in Settings → Engine, the first switch can take a
few minutes (a one-time, on-device model optimization), but every switch after
that is fast. The old UI showed the **same status either way**, so you couldn't
tell whether you were about to wait minutes or seconds. This PR makes the tile
tell the truth.

## Why this matters

Whisper is what powers dictation for Korean, Japanese, Chinese, Thai, and ~95
other languages Parakeet doesn't cover. The very first time it loads, macOS
compiles and specializes the model for your Mac's Neural Engine — that's the
slow part (not the download, which already happened). After that one-time
optimize, the compiled model is cached and loads in seconds.

A non-English user switching engines for the first time hit a multi-minute
freeze with no warning. Setting the right expectation — *before* they commit —
is the cheapest, safest win.

## What you'll see

```
                          BEFORE                    AFTER
                  ┌───────────────────┐     ┌───────────────────┐
                  │  🌐  Whisper      │     │  🌐  Whisper      │
                  │  Multilingual …   │     │  Multilingual …   │
   first time     │                   │     │                   │
   (cold, slow) → │ 🟢 Downloaded     │     │ 🟠 Setup needed   │
                  │    May optimize   │     │    First switch   │
                  │    on first load  │     │    optimizes — a  │
                  └───────────────────┘     │    minute or two  │
                                            └───────────────────┘

                  ┌───────────────────┐     ┌───────────────────┐
   already done   │ 🟢 Downloaded     │     │ 🟢 Downloaded     │
   (warm, fast) → │    May optimize   │     │    Loads in       │
                  │    on first load  │     │    seconds        │
                  └───────────────────┘     └───────────────────┘
```

Same words before (you can't tell cold from warm) → honest, color-coded after.

## How it decides

```
  Open Settings → Engine, look at the Whisper tile
                       │
                       ▼
        Has this Whisper variant been
        optimized on THIS Mac before?
                       │
            ┌──────────┴───────────┐
           no                     yes
            │                      │
            ▼                      ▼
   🟠 "Setup needed"      🟢 "Downloaded ·
      first switch is        Loads in seconds"
      a minute or two
```

The flag flips the first time the model successfully loads — whether that
happens from the Settings switch, onboarding, the first meeting recording, or
the CLI. It's stored per model variant, so swapping to a different Whisper
model correctly shows "Setup needed" again until that one is optimized too.

## Under the hood

- **`SpeechEnginePreference`** — persists which Whisper variants are "warm"
  (`hasOptimizedWhisper` / `markWhisperOptimized` / `clearWhisperOptimized`),
  keyed by normalized variant id.
- **`WhisperEngine.prepare()`** — marks the variant optimized at the one
  guaranteed success point, so every caller agrees. Only fires on a real
  compile (never in unit tests).
- **`EngineOptionTile`** — new `needsFirstOptimize` input splits the
  downloaded-but-not-active footer into cold (amber) vs warm (green).
- **`SettingsViewModel`** — `whisperHasBeenOptimized` flag + matching Local
  Models copy.

## Scope & follow-ups

This is **Stage A** of `plans/active/2026-05-engine-switch-ux-revamp.md` — a
small, self-contained, low-risk slice. Intentionally **not** here, and tracked
as follow-ups in the plan:

- **Cancel button + no app-wide freeze (Stage B).** A cancel on today's
  blocking switch can't actually interrupt the CoreML compile (it's one
  uninterruptible operation). The real fix is to optimize in the background
  while Parakeet stays usable, then switch when ready — that touches the STT
  scheduler's exclusivity model, so it gets its own PR + review.
- **Disabled engine cards** with a clear reason ("Stop the meeting recording
  to switch engines") while a meeting or transcription is in flight.

## Testing

- `swift build` ✅ and full `swift test` ✅ (no regressions).
- New: 5 `SpeechEnginePreference` tests (round-trip, idempotency, variant-prefix
  normalization, per-variant clear, default-false) + 1 `SettingsViewModel`
  wiring test.
- Manual: cold tile shows amber "Setup needed"; after the first switch it reads
  green "Loads in seconds."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
