### PR TITLE
Preserve combined dictation hotkey mode

### DIFF
--- a/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
+++ b/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
@@ -117,7 +117,7 @@ final class AppHotkeyCoordinator {
             return "Dictation Shortcuts: Disabled"
         }
         if !handsFree.isDisabled, handsFree == pushToTalk {
-            return "Dictation Shortcuts: Conflict on \(handsFree.displayName)"
+            return "Dictation: Hold \(pushToTalk.displayName) / Double-tap \(handsFree.displayName)"
         }
         if handsFree.isDisabled {
             return "Push-to-talk: Hold \(pushToTalk.displayName)"
@@ -137,6 +137,18 @@ final class AppHotkeyCoordinator {
         }
 
         if !handsFreeTrigger.isDisabled, !pushToTalkTrigger.isDisabled {
+            if handsFreeTrigger == pushToTalkTrigger {
+                return DictationHotkeyPlan(
+                    specs: [
+                        DictationHotkeyPlan.Spec(
+                            trigger: handsFreeTrigger,
+                            gestureMode: .doubleTapAndHold
+                        ),
+                    ],
+                    conflict: nil
+                )
+            }
+
             if handsFreeTrigger.overlaps(with: pushToTalkTrigger) {
                 return DictationHotkeyPlan(
                     specs: [

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -528,6 +528,12 @@ struct SettingsView: View {
 
     // MARK: - Dictation
 
+    private var dictationShortcutsAreCombined: Bool {
+        let handsFree = viewModel.hotkeyTrigger
+        let pushToTalk = viewModel.pushToTalkHotkeyTrigger
+        return !handsFree.isDisabled && !pushToTalk.isDisabled && handsFree == pushToTalk
+    }
+
     private var dictationCard: some View {
         settingsCard(
             title: "Dictation",
@@ -562,7 +568,9 @@ struct SettingsView: View {
                 HStack(alignment: .center) {
                     rowText(
                         title: "Hands-free mode",
-                        detail: "Tap to start; tap again to stop."
+                        detail: dictationShortcutsAreCombined
+                            ? "Double tap to start; tap once to stop."
+                            : "Tap to start; tap again to stop."
                     )
                     Spacer(minLength: DesignSystem.Spacing.md)
                     VStack(alignment: .trailing, spacing: 4) {
@@ -940,7 +948,8 @@ struct SettingsView: View {
 
     private func dictationHotkeyValidation(for candidate: HotkeyTrigger) -> HotkeyTrigger.ValidationResult {
         guard !candidate.isDisabled else { return .allowed }
-        if candidate.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
+        if candidate != viewModel.pushToTalkHotkeyTrigger,
+           candidate.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
             return .blocked(SettingsHotkeyConflictMessage.blocked(
                 conflictingWith: "push to talk",
                 trigger: viewModel.pushToTalkHotkeyTrigger
@@ -976,7 +985,8 @@ struct SettingsView: View {
 
     private func pushToTalkHotkeyValidation(for candidate: HotkeyTrigger) -> HotkeyTrigger.ValidationResult {
         guard !candidate.isDisabled else { return .allowed }
-        if candidate.overlaps(with: viewModel.hotkeyTrigger) {
+        if candidate != viewModel.hotkeyTrigger,
+           candidate.overlaps(with: viewModel.hotkeyTrigger) {
             return .blocked(SettingsHotkeyConflictMessage.blocked(
                 conflictingWith: "hands-free mode",
                 trigger: viewModel.hotkeyTrigger
@@ -1050,7 +1060,8 @@ struct SettingsView: View {
 
     private func dictationHotkeyConflictMessage(for trigger: HotkeyTrigger) -> String? {
         guard !trigger.isDisabled else { return nil }
-        if trigger.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
+        if trigger != viewModel.pushToTalkHotkeyTrigger,
+           trigger.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
             return SettingsHotkeyConflictMessage.disabled(
                 conflictingWith: "push to talk",
                 trigger: viewModel.pushToTalkHotkeyTrigger
@@ -1086,7 +1097,8 @@ struct SettingsView: View {
 
     private func pushToTalkHotkeyConflictMessage(for trigger: HotkeyTrigger) -> String? {
         guard !trigger.isDisabled else { return nil }
-        if trigger.overlaps(with: viewModel.hotkeyTrigger) {
+        if trigger != viewModel.hotkeyTrigger,
+           trigger.overlaps(with: viewModel.hotkeyTrigger) {
             return SettingsHotkeyConflictMessage.disabled(
                 conflictingWith: "hands-free mode",
                 trigger: viewModel.hotkeyTrigger
@@ -2269,9 +2281,9 @@ struct SettingsView: View {
                 modeShortcutRow(
                     keys: [viewModel.hotkeyTrigger.shortSymbol],
                     separator: nil,
-                    verb: "Tap",
+                    verb: dictationShortcutsAreCombined ? "Double tap" : "Tap",
                     action: "Hands-free mode",
-                    detail: "Tap again to stop"
+                    detail: dictationShortcutsAreCombined ? "Tap once to stop" : "Tap again to stop"
                 )
             }
         }

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -694,9 +694,9 @@ public final class SettingsViewModel {
                 return (.disabled, .disabled, false, true)
             }
             return (
-                defaultHandsFreeTrigger(avoiding: storedHandsFree),
                 storedHandsFree,
-                true,
+                storedHandsFree,
+                false,
                 true
             )
         }
@@ -708,6 +708,7 @@ public final class SettingsViewModel {
         )
         if !storedHandsFree.isDisabled,
            !pushToTalk.isDisabled,
+           storedHandsFree != pushToTalk,
            storedHandsFree.overlaps(with: pushToTalk) {
             return (defaultHandsFreeTrigger(avoiding: pushToTalk), pushToTalk, true, false)
         }

--- a/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
@@ -68,7 +68,7 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
     func testMenuTitleDescribesSharedDictationTrigger() {
         XCTAssertEqual(
             AppHotkeyCoordinator.menuTitle(handsFree: .fn, pushToTalk: .fn),
-            "Dictation Shortcuts: Conflict on Fn"
+            "Dictation: Hold Fn / Double-tap Fn"
         )
     }
 
@@ -79,7 +79,7 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
         )
     }
 
-    func testDictationHotkeyPlanKeepsHandsFreeWhenSharedTriggerWouldConflict() {
+    func testDictationHotkeyPlanUsesCombinedModeForSharedTrigger() {
         let plan = AppHotkeyCoordinator.dictationHotkeyPlan(
             handsFree: .fn,
             pushToTalk: .fn
@@ -89,9 +89,9 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
             plan,
             AppHotkeyCoordinator.DictationHotkeyPlan(
                 specs: [
-                    .init(trigger: .fn, gestureMode: .singleTapToggle),
+                    .init(trigger: .fn, gestureMode: .doubleTapAndHold),
                 ],
-                conflict: .init(trigger: .fn, conflicts: [.fn])
+                conflict: nil
             )
         )
     }

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -1194,24 +1194,24 @@ final class SettingsViewModelTests: XCTestCase {
 
         let vm = SettingsViewModel(defaults: testDefaults)
 
-        XCTAssertEqual(vm.hotkeyTrigger, .defaultDictation)
+        XCTAssertEqual(vm.hotkeyTrigger, legacyTrigger)
         XCTAssertEqual(vm.pushToTalkHotkeyTrigger, legacyTrigger)
 
         let vm2 = SettingsViewModel(defaults: testDefaults)
-        XCTAssertEqual(vm2.hotkeyTrigger, .defaultDictation)
+        XCTAssertEqual(vm2.hotkeyTrigger, legacyTrigger)
         XCTAssertEqual(vm2.pushToTalkHotkeyTrigger, legacyTrigger)
     }
 
-    func testLegacyHotkeyOverlappingDefaultHandsFreeDisablesHandsFreeDuringMigration() {
+    func testLegacyHotkeyOverlappingDefaultHandsFreeMigratesToCombinedMode() {
         let legacyTrigger = HotkeyTrigger.fromKeyCode(49)
         testDefaults.removeObject(forKey: HotkeyTrigger.pushToTalkDefaultsKey)
         legacyTrigger.save(to: testDefaults)
 
         let vm = SettingsViewModel(defaults: testDefaults)
 
-        XCTAssertEqual(vm.hotkeyTrigger, .disabled)
+        XCTAssertEqual(vm.hotkeyTrigger, legacyTrigger)
         XCTAssertEqual(vm.pushToTalkHotkeyTrigger, legacyTrigger)
-        XCTAssertEqual(HotkeyTrigger.current(defaults: testDefaults), .disabled)
+        XCTAssertEqual(HotkeyTrigger.current(defaults: testDefaults), legacyTrigger)
         XCTAssertEqual(
             HotkeyTrigger.current(
                 defaults: testDefaults,
@@ -1241,22 +1241,22 @@ final class SettingsViewModelTests: XCTestCase {
         )
     }
 
-    func testLegacyDefaultFnHandsFreeMigratesToFnSpaceWithoutChangingPushToTalk() {
+    func testLegacyDefaultFnHandsFreeMigratesToCombinedMode() {
         testDefaults.removeObject(forKey: HotkeyTrigger.pushToTalkDefaultsKey)
         HotkeyTrigger.fn.save(to: testDefaults)
 
         let vm = SettingsViewModel(defaults: testDefaults)
 
-        XCTAssertEqual(vm.hotkeyTrigger, .defaultDictation)
+        XCTAssertEqual(vm.hotkeyTrigger, .fn)
         XCTAssertEqual(vm.pushToTalkHotkeyTrigger, .defaultPushToTalk)
-        XCTAssertEqual(HotkeyTrigger.current(defaults: testDefaults), .defaultDictation)
+        XCTAssertEqual(HotkeyTrigger.current(defaults: testDefaults), .fn)
         XCTAssertEqual(
             HotkeyTrigger.current(
                 defaults: testDefaults,
                 defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey,
                 fallback: .defaultPushToTalk
             ),
-            .defaultPushToTalk
+            .fn
         )
     }
 
@@ -1292,13 +1292,23 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(vm.pushToTalkHotkeyTrigger, .defaultDictation)
     }
 
+    func testStoredMatchingDedicatedDictationHotkeysPersistAsCombinedMode() {
+        HotkeyTrigger.fn.save(to: testDefaults)
+        HotkeyTrigger.fn.save(to: testDefaults, defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey)
+
+        let vm = SettingsViewModel(defaults: testDefaults)
+
+        XCTAssertEqual(vm.hotkeyTrigger, .fn)
+        XCTAssertEqual(vm.pushToTalkHotkeyTrigger, .fn)
+    }
+
     func testHotkeyTriggerBackwardCompatibleWithLegacyString() {
         // Simulate a legacy UserDefaults value from the old TriggerKey enum
         testDefaults.removeObject(forKey: HotkeyTrigger.pushToTalkDefaultsKey)
         testDefaults.set("option", forKey: "hotkeyTrigger")
 
         let vm = SettingsViewModel(defaults: testDefaults)
-        XCTAssertEqual(vm.hotkeyTrigger, .defaultDictation)
+        XCTAssertEqual(vm.hotkeyTrigger, .option)
         XCTAssertEqual(vm.pushToTalkHotkeyTrigger, .option)
     }
 

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -137,14 +137,14 @@ See [00-vision.md](./00-vision.md) for positioning and market context.
 
 **Activation — Configurable Hotkey:**
 
-Dictation has two configurable shortcuts: push-to-talk defaults to `Fn`, and hands-free mode defaults to `Fn+Space`. The "record a shortcut" UI supports bare modifiers (Fn, Control, etc.), standalone keys (F5, Tab, etc.), modifier+key chords (Fn+Space, Cmd+9, Ctrl+Shift+D), and modifier-only chords (Command+Option, including side-specific variants like Right Command+Right Option). See ADR-009 for full details.
+Dictation has two configurable shortcuts: push-to-talk defaults to `Fn`, and hands-free mode defaults to `Fn+Space`. The "record a shortcut" UI supports bare modifiers (Fn, Control, etc.), standalone keys (F5, Tab, etc.), modifier+key chords (Fn+Space, Cmd+9, Ctrl+Shift+D), and modifier-only chords (Command+Option, including side-specific variants like Right Command+Right Option). See ADR-009 for full details. If both dictation shortcuts are set to the same trigger, MacParakeet uses the legacy combined gesture: hold for push-to-talk and double-tap for hands-free mode.
 
 | Mode | Gesture | Behavior |
 |------|---------|----------|
 | **Hands-free** | Tap the hands-free shortcut | Persistent recording. Tap the shortcut again to stop. |
 | **Press-and-hold** | Hold the push-to-talk shortcut | Hold-to-talk. Release auto-stops and pastes. |
 
-Both modes coexist with no double-tap requirement.
+New installs default to separate shortcuts, so there is no double-tap requirement. Existing or manually configured same-trigger shortcuts use double-tap for hands-free mode so the hold gesture can remain push-to-talk.
 
 **Implementation:**
 - `CGEvent` tap for system-wide key event interception
@@ -159,6 +159,7 @@ Both modes coexist with no double-tap requirement.
 - Chord validation: Escape blocked for all kinds. Modifier+key chords containing Command warn about system shortcut conflicts (Cmd+Tab, Cmd+Space, Cmd+Q/W/H/M). Fn is allowed in modifier+key chords such as Fn+Space.
 - Hands-free key-down: toggles persistent recording immediately for key and modifier+key triggers; bare modifier hands-free triggers toggle on bare release so normal modifier shortcuts are not captured.
 - Dedicated push-to-talk key-down: schedule only the startup debounce, then start hold-to-talk.
+- Combined same-trigger dictation shortcuts: one `HotkeyManager` runs double-tap-and-hold mode. Double-tap starts persistent recording, one tap while recording stops it, and hold remains push-to-talk.
 - On key-up: dedicated push-to-talk releases after startup debounce stop and process.
 - Escape is permanently reserved for cancel-dictation and cannot be assigned as hotkey
 - Requires Accessibility permission (prompted on first activation).
@@ -170,8 +171,9 @@ Both modes coexist with no double-tap requirement.
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │ 1. User activates recording:                                     │
-│    - Tap Fn+Space (hands-free persistent mode), OR               │
-│    - Hold Fn (hold-to-talk mode)                                 │
+│    - Tap the hands-free shortcut (Fn+Space by default), OR       │
+│    - Double-tap the shared shortcut in combined mode, OR         │
+│    - Hold the push-to-talk shortcut (Fn by default)              │
 ├─────────────────────────────────────────────────────────────────┤
 │ 2. Overlay appears (bottom-center pill)                          │
 │    - Recording indicator (waveform animation)                    │
@@ -182,8 +184,8 @@ Both modes coexist with no double-tap requirement.
 │    - Real-time waveform visualization in overlay                 │
 ├─────────────────────────────────────────────────────────────────┤
 │ 4. User stops recording:                                         │
-│    - Release Fn (hold-to-talk auto-stop), OR                     │
-│    - Tap Fn+Space again (hands-free mode), OR                    │
+│    - Release the push-to-talk shortcut, OR                       │
+│    - Tap the hands-free/combined shortcut again, OR              │
 │    - Press Escape (soft cancel with undo window), OR             │
 │    - Silence auto-stop (2s default, if enabled in settings)      │
 │    - If stop is requested while startup is in-flight, stop is     │

--- a/spec/09-testing.md
+++ b/spec/09-testing.md
@@ -278,7 +278,7 @@ Tests/
 
 These flows must be tested manually after any overlay or hotkey changes. Automated unit tests cover the state machine logic, but the full UX requires human verification.
 
-> **Note:** "Fn+Space" below refers to the configured hands-free shortcut, and "Fn" refers to the configured push-to-talk shortcut. Defaults are Fn+Space for hands-free and Fn for push-to-talk. Test with at least two different trigger keys.
+> **Note:** "Fn+Space" below refers to the configured hands-free shortcut, and "Fn" refers to the configured push-to-talk shortcut. Defaults are Fn+Space for hands-free and Fn for push-to-talk. When both shortcuts are set to the same trigger, double-tap starts hands-free mode and hold remains push-to-talk. Test with at least two different trigger keys.
 
 ### Happy Path
 
@@ -310,6 +310,7 @@ These flows must be tested manually after any overlay or hotkey changes. Automat
 | 10d | Single-tap modifier filtering | Ctrl → type "hello" → release Ctrl | Does NOT trigger dictation |
 | 10e | Switch back to Fn+Space | Settings → Shortcuts → Hands-free mode → select Fn+Space | Fn+Space works again, Ctrl no longer triggers |
 | 10f | Dynamic UI text | Change to Option+Space → check overlay/pill/history | All say "Option+Space" instead of "Fn+Space" |
+| 10g | Combined same-trigger mode | Set both dictation shortcuts to Fn → double-tap Fn → speak → tap Fn | Double-tap starts hands-free mode, one tap stops, and Settings shows double-tap guidance |
 
 ### State Transitions
 

--- a/spec/adr/009-custom-hotkey.md
+++ b/spec/adr/009-custom-hotkey.md
@@ -55,6 +55,7 @@ Community issue #17 requested modifier+key combos (e.g., Cmd+9) because Logitech
 7. **Modifier names stored as `[String]`** — Not raw `CGEventFlags.rawValue` (has phantom bits). Readable JSON: `{"kind":"chord","keyCode":25,"chordModifiers":["command"]}`.
 8. **HotkeyRecorderView two-phase capture** — Held modifiers show as preview (e.g. "⌘..."); pressing a key with modifiers held creates a chord; releasing all modifiers without a key press creates a bare modifier trigger.
 9. **Validation** — Chords are `.allowed` by default. Escape blocked. Cmd+Tab and Cmd+Space warned (system intercepts them).
+10. **Same-trigger dictation compatibility** — If hands-free and push-to-talk are configured to the same trigger, the app uses the legacy combined gesture: double-tap for persistent hands-free dictation and hold for push-to-talk. Separate triggers remain the default for new installs.
 
 ### Original decision preserved
 

--- a/spec/kernel/requirements.yaml
+++ b/spec/kernel/requirements.yaml
@@ -28,7 +28,7 @@ REQ-DICT-001:
   status: implemented
 
 REQ-DICT-002:
-  description: Separate hands-free tap-to-toggle and hold-to-talk shortcuts
+  description: Hands-free tap-to-toggle and hold-to-talk shortcuts, with same-trigger double-tap compatibility
   version: v0.1
   status: implemented
 

--- a/spec/kernel/traceability.md
+++ b/spec/kernel/traceability.md
@@ -9,7 +9,7 @@ This matrix traces each requirement ID from `requirements.yaml` to its implement
 | Requirement | Source Files | Test Files |
 |------------|-------------|------------|
 | REQ-DICT-001 | `MacParakeetCore/Services/Dictation/DictationService.swift`, `MacParakeetCore/DictationFlow/` | `DictationServiceTests.swift` |
-| REQ-DICT-002 | `MacParakeetCore/DictationFlow/FnKeyStateMachine.swift` | `FnKeyStateMachineTests.swift` |
+| REQ-DICT-002 | `MacParakeet/App/AppHotkeyCoordinator.swift`, `MacParakeet/Hotkey/HotkeyManager.swift`, `MacParakeet/Views/Settings/SettingsView.swift`, `MacParakeetViewModels/SettingsViewModel.swift`, `MacParakeetCore/STT/FnKeyStateMachine.swift`, `MacParakeetCore/STT/HotkeyGestureController.swift` | `AppHotkeyCoordinatorTests.swift`, `HotkeyManagerTests.swift`, `HotkeyGestureControllerTests.swift`, `FnKeyStateMachineTests.swift`, `SettingsViewModelTests.swift` |
 | REQ-DICT-003 | `MacParakeetCore/Services/System/ClipboardService.swift` | `ClipboardServiceTests.swift` |
 | REQ-TRANS-001 | `MacParakeetCore/Services/TranscriptionService.swift` | `TranscriptionServiceTests.swift` |
 | REQ-UI-001 | `MacParakeet/Views/Dictation/DictationOverlayView.swift` | (ViewModel tests) |


### PR DESCRIPTION
## Summary
- allow hands-free and push-to-talk dictation rows to use the exact same trigger
- route matching dictation triggers through one double-tap-and-hold hotkey manager
- preserve legacy single-hotkey installs as combined hold/double-tap mode
- update Settings guidance, tests, and specs for same-trigger compatibility

## Verification
- git diff --check
- swift test --filter AppHotkeyCoordinatorTests
- swift test --filter SettingsViewModelTests
- swift test --filter Hotkey
- swift test