### PR TITLE
Expose meeting result availability in CLI

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -90,8 +90,9 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
   CLI. `add` stores externally generated output as a `PromptResult` without
   invoking an LLM, preserving the meeting transcript as the canonical object.
 - `meetings list --json`, `meetings show --json`, and `meetings export --format json`
-  now include `hasPromptResults` and `promptResultCount`, so agents can tell
-  whether structured meeting outputs already exist before fetching result rows.
+  now include `hasPromptResults` and `promptResultCount`, and Markdown exports
+  include the same count in metadata, so agents can tell whether structured
+  meeting outputs already exist before fetching result rows.
 - `llm` commands using `--provider lmstudio` now honor optional LM Studio API
   tokens via `--api-key`, `--api-key-env`, or `LM_API_TOKEN`.
 

--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -89,6 +89,9 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 - `meetings results list|add` exposes saved meeting PromptResults through the
   CLI. `add` stores externally generated output as a `PromptResult` without
   invoking an LLM, preserving the meeting transcript as the canonical object.
+- `meetings list --json`, `meetings show --json`, and `meetings export --format json`
+  now include `hasPromptResults` and `promptResultCount`, so agents can tell
+  whether structured meeting outputs already exist before fetching result rows.
 - `llm` commands using `--provider lmstudio` now honor optional LM Studio API
   tokens via `--api-key`, `--api-key-env`, or `LM_API_TOKEN`.
 

--- a/Sources/CLI/Commands/MeetingsCommand.swift
+++ b/Sources/CLI/Commands/MeetingsCommand.swift
@@ -43,24 +43,27 @@ struct MeetingsCommand: AsyncParsableCommand {
                     limit: limit,
                     includeProcessing: true
                 )).items
-                    .map { transcription in
-                        MeetingListItem(
-                            transcription,
-                            promptResultCount: try repositories.promptResults.count(transcriptionId: transcription.id)
-                        )
-                    }
+                let promptResultCounts = try repositories.promptResults.counts(
+                    transcriptionIds: meetings.map(\.id)
+                )
+                let items = meetings.map { transcription in
+                    MeetingListItem(
+                        transcription,
+                        promptResultCount: promptResultCounts[transcription.id] ?? 0
+                    )
+                }
 
                 if json {
-                    try printJSON(meetings)
+                    try printJSON(items)
                     return
                 }
 
-                guard !meetings.isEmpty else {
+                guard !items.isEmpty else {
                     print("No meetings found.")
                     return
                 }
 
-                for meeting in meetings {
+                for meeting in items {
                     let duration = meeting.durationMs.map(formatDuration) ?? "--"
                     let notes = meeting.hasNotes ? "notes" : "no notes"
                     let results = meeting.promptResultCount == 1 ? "1 result" : "\(meeting.promptResultCount) results"
@@ -621,7 +624,7 @@ private struct MeetingPromptResultRecord: Encodable {
 
 private struct MeetingResultRepositories {
     let transcriptions: TranscriptionRepository
-    let promptResults: PromptResultRepository
+    let promptResults: PromptResultRepositoryProtocol
 }
 
 private func makeDatabaseManager(database: String?) throws -> DatabaseManager {
@@ -725,7 +728,7 @@ private func exportContent(
 ) throws -> String {
     switch format {
     case .md:
-        return markdownExport(for: transcription)
+        return markdownExport(for: transcription, promptResultCount: promptResultCount)
     case .json:
         let data = try cliJSONEncoder.encode(MeetingRecord(
             transcription,
@@ -735,7 +738,7 @@ private func exportContent(
     }
 }
 
-private func markdownExport(for transcription: Transcription) -> String {
+private func markdownExport(for transcription: Transcription, promptResultCount: Int) -> String {
     var sections: [String] = []
     sections.append("# \(transcription.fileName)")
     sections.append("""
@@ -743,6 +746,7 @@ private func markdownExport(for transcription: Transcription) -> String {
     - Created: \(ISO8601DateFormatter().string(from: transcription.createdAt))
     - Duration: \(transcription.durationMs.map(formatDuration) ?? "--")
     - Status: \(transcription.status.rawValue)
+    - Prompt results: \(promptResultCount)
     """)
 
     if let notes = normalizedNotes(transcription.userNotes) {

--- a/Sources/CLI/Commands/MeetingsCommand.swift
+++ b/Sources/CLI/Commands/MeetingsCommand.swift
@@ -37,13 +37,18 @@ struct MeetingsCommand: AsyncParsableCommand {
 
         func run() async throws {
             try emitJSONOrRethrow(json: json) {
-                let repo = try makeTranscriptionRepository(database: database)
-                let meetings = try repo.fetchLibraryPage(query: TranscriptionLibraryQuery(
+                let repositories = try makeMeetingResultRepositories(database: database)
+                let meetings = try repositories.transcriptions.fetchLibraryPage(query: TranscriptionLibraryQuery(
                     sourceType: .meeting,
                     limit: limit,
                     includeProcessing: true
                 )).items
-                    .map(MeetingListItem.init)
+                    .map { transcription in
+                        MeetingListItem(
+                            transcription,
+                            promptResultCount: try repositories.promptResults.count(transcriptionId: transcription.id)
+                        )
+                    }
 
                 if json {
                     try printJSON(meetings)
@@ -58,7 +63,8 @@ struct MeetingsCommand: AsyncParsableCommand {
                 for meeting in meetings {
                     let duration = meeting.durationMs.map(formatDuration) ?? "--"
                     let notes = meeting.hasNotes ? "notes" : "no notes"
-                    print("[\(formatDate(meeting.createdAt))] \(meeting.title) (\(duration)) [\(meeting.status)] [\(notes)]  (\(meeting.shortID))")
+                    let results = meeting.promptResultCount == 1 ? "1 result" : "\(meeting.promptResultCount) results"
+                    print("[\(formatDate(meeting.createdAt))] \(meeting.title) (\(duration)) [\(meeting.status)] [\(notes)] [\(results)]  (\(meeting.shortID))")
                 }
             }
         }
@@ -81,9 +87,12 @@ struct MeetingsCommand: AsyncParsableCommand {
 
         func run() async throws {
             try emitJSONOrRethrow(json: json) {
-                let repo = try makeTranscriptionRepository(database: database)
-                let transcription = try findMeeting(idOrName: meeting, repo: repo)
-                let record = MeetingRecord(transcription)
+                let repositories = try makeMeetingResultRepositories(database: database)
+                let transcription = try findMeeting(idOrName: meeting, repo: repositories.transcriptions)
+                let record = MeetingRecord(
+                    transcription,
+                    promptResultCount: try repositories.promptResults.count(transcriptionId: transcription.id)
+                )
 
                 if json {
                     try printJSON(record)
@@ -424,9 +433,13 @@ struct MeetingsCommand: AsyncParsableCommand {
 
         func run() async throws {
             try emitJSONOrRethrow(json: stdout && format == .json) {
-                let repo = try makeTranscriptionRepository(database: database)
-                let transcription = try findMeeting(idOrName: meeting, repo: repo)
-                let content = try exportContent(for: transcription, format: format)
+                let repositories = try makeMeetingResultRepositories(database: database)
+                let transcription = try findMeeting(idOrName: meeting, repo: repositories.transcriptions)
+                let content = try exportContent(
+                    for: transcription,
+                    format: format,
+                    promptResultCount: try repositories.promptResults.count(transcriptionId: transcription.id)
+                )
 
                 if stdout {
                     print(content)
@@ -470,10 +483,12 @@ private struct MeetingListItem: Encodable {
     let isFavorite: Bool
     let hasNotes: Bool
     let notesPreview: String?
+    let hasPromptResults: Bool
+    let promptResultCount: Int
     let hasTranscript: Bool
     let transcriptPreview: String?
 
-    init(_ transcription: Transcription) {
+    init(_ transcription: Transcription, promptResultCount: Int = 0) {
         id = transcription.id
         shortID = String(transcription.id.uuidString.prefix(8))
         title = transcription.fileName
@@ -484,6 +499,8 @@ private struct MeetingListItem: Encodable {
         isFavorite = transcription.isFavorite
         hasNotes = normalizedNotes(transcription.userNotes) != nil
         notesPreview = preview(transcription.userNotes)
+        self.promptResultCount = promptResultCount
+        hasPromptResults = promptResultCount > 0
         let transcript = preferredTranscriptText(transcription)
         hasTranscript = !transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         transcriptPreview = preview(transcript)
@@ -503,6 +520,8 @@ private struct MeetingRecord: Encodable {
     let recoveredFromCrash: Bool
     let isTranscriptEdited: Bool
     let notes: String?
+    let hasPromptResults: Bool
+    let promptResultCount: Int
     let rawTranscript: String?
     let cleanTranscript: String?
     let transcript: String
@@ -511,7 +530,7 @@ private struct MeetingRecord: Encodable {
     let speakers: [SpeakerInfo]?
     let diarizationSegments: [DiarizationSegmentRecord]?
 
-    init(_ transcription: Transcription) {
+    init(_ transcription: Transcription, promptResultCount: Int = 0) {
         id = transcription.id
         shortID = String(transcription.id.uuidString.prefix(8))
         title = transcription.fileName
@@ -524,6 +543,8 @@ private struct MeetingRecord: Encodable {
         recoveredFromCrash = transcription.recoveredFromCrash
         isTranscriptEdited = transcription.isTranscriptEdited
         notes = transcription.userNotes
+        self.promptResultCount = promptResultCount
+        hasPromptResults = promptResultCount > 0
         rawTranscript = transcription.rawTranscript
         cleanTranscript = transcription.cleanTranscript
         transcript = preferredTranscriptText(transcription)
@@ -697,12 +718,19 @@ private func emitNotesUpdate(_ record: MeetingNotesRecord, json: Bool) throws {
     }
 }
 
-private func exportContent(for transcription: Transcription, format: MeetingExportFormat) throws -> String {
+private func exportContent(
+    for transcription: Transcription,
+    format: MeetingExportFormat,
+    promptResultCount: Int
+) throws -> String {
     switch format {
     case .md:
         return markdownExport(for: transcription)
     case .json:
-        let data = try cliJSONEncoder.encode(MeetingRecord(transcription))
+        let data = try cliJSONEncoder.encode(MeetingRecord(
+            transcription,
+            promptResultCount: promptResultCount
+        ))
         return String(data: data, encoding: .utf8) ?? "{}"
     }
 }
@@ -735,6 +763,7 @@ private func printMeetingRecord(_ record: MeetingRecord) {
     print("Created: \(formatDate(record.createdAt))")
     print("Duration: \(record.durationMs.map(formatDuration) ?? "--")")
     print("Status: \(record.status.rawValue)")
+    print("Prompt results: \(record.promptResultCount)")
     if let filePath = record.filePath {
         print("Audio: \(filePath)")
     }

--- a/Sources/CLI/Commands/SpecCommand.swift
+++ b/Sources/CLI/Commands/SpecCommand.swift
@@ -205,14 +205,14 @@ private extension CLISpecCommand {
             ["meetings", "list"],
             summary: "List recent meeting recordings.",
             options: [databaseOption],
-            output: "Array of meeting list objects."
+            output: "Array of meeting list objects with transcript, notes, and prompt-result availability."
         ),
         CLISpecCommand(
             ["meetings", "show"],
             summary: "Show one meeting artifact.",
             arguments: [.argument("meeting", summary: "Meeting UUID, UUID prefix, or exact title.")],
             options: [databaseOption],
-            output: "MeetingRecord object."
+            output: "MeetingRecord object with transcript, notes, and prompt-result count."
         ),
         CLISpecCommand(
             ["meetings", "transcript"],
@@ -269,7 +269,7 @@ private extension CLISpecCommand {
                 CLISpecParameter.flag("--stdout", summary: "Print export content to stdout."),
                 databaseOption,
             ],
-            output: "Markdown text or MeetingRecord JSON."
+            output: "Markdown text or MeetingRecord JSON with prompt-result count."
         ),
     ]
 }

--- a/Sources/MacParakeetCore/Database/PromptResultRepository.swift
+++ b/Sources/MacParakeetCore/Database/PromptResultRepository.swift
@@ -71,4 +71,12 @@ public final class PromptResultRepository: PromptResultRepositoryProtocol {
                 .isEmpty(db)
         }
     }
+
+    public func count(transcriptionId: UUID) throws -> Int {
+        try dbQueue.read { db in
+            try PromptResult
+                .filter(PromptResult.Columns.transcriptionId == transcriptionId)
+                .fetchCount(db)
+        }
+    }
 }

--- a/Sources/MacParakeetCore/Database/PromptResultRepository.swift
+++ b/Sources/MacParakeetCore/Database/PromptResultRepository.swift
@@ -8,6 +8,8 @@ public protocol PromptResultRepositoryProtocol: Sendable {
     func delete(id: UUID) throws -> Bool
     func deleteAll(transcriptionId: UUID) throws
     func hasPromptResults(transcriptionId: UUID) throws -> Bool
+    func count(transcriptionId: UUID) throws -> Int
+    func counts(transcriptionIds: [UUID]) throws -> [UUID: Int]
 }
 
 public extension PromptResultRepositoryProtocol {
@@ -16,6 +18,14 @@ public extension PromptResultRepositoryProtocol {
         if let deletingExistingID, deletingExistingID != promptResult.id {
             _ = try delete(id: deletingExistingID)
         }
+    }
+
+    func counts(transcriptionIds: [UUID]) throws -> [UUID: Int] {
+        var counts: [UUID: Int] = [:]
+        for transcriptionId in Set(transcriptionIds) {
+            counts[transcriptionId] = try count(transcriptionId: transcriptionId)
+        }
+        return counts
     }
 }
 
@@ -77,6 +87,31 @@ public final class PromptResultRepository: PromptResultRepositoryProtocol {
             try PromptResult
                 .filter(PromptResult.Columns.transcriptionId == transcriptionId)
                 .fetchCount(db)
+        }
+    }
+
+    public func counts(transcriptionIds: [UUID]) throws -> [UUID: Int] {
+        let ids = Array(Set(transcriptionIds))
+        guard !ids.isEmpty else { return [:] }
+
+        return try dbQueue.read { db in
+            let placeholders = Array(repeating: "?", count: ids.count).joined(separator: ", ")
+            let rows = try Row.fetchAll(
+                db,
+                sql: """
+                    SELECT transcriptionId, COUNT(*) AS count
+                    FROM summaries
+                    WHERE transcriptionId IN (\(placeholders))
+                    GROUP BY transcriptionId
+                    """,
+                arguments: StatementArguments(ids)
+            )
+
+            return rows.reduce(into: [:]) { result, row in
+                let transcriptionId: UUID = row["transcriptionId"]
+                let count: Int = row["count"]
+                result[transcriptionId] = count
+            }
         }
     }
 }

--- a/Tests/CLITests/MeetingsCommandTests.swift
+++ b/Tests/CLITests/MeetingsCommandTests.swift
@@ -112,6 +112,70 @@ final class MeetingsCommandTests: XCTestCase {
         XCTAssertEqual(saved[0].userNotesSnapshot, "Manual note")
     }
 
+    func testListAndShowExposePromptResultAvailability() async throws {
+        let dbURL = temporaryDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: dbURL) }
+        let db = try DatabaseManager(path: dbURL.path)
+        let transcriptionRepo = TranscriptionRepository(dbQueue: db.dbQueue)
+        let resultRepo = PromptResultRepository(dbQueue: db.dbQueue)
+        let meeting = Transcription(
+            fileName: "Agent Review",
+            rawTranscript: "We agreed to keep the CLI contract explicit.",
+            status: .completed,
+            sourceType: .meeting
+        )
+        try transcriptionRepo.save(meeting)
+        try resultRepo.save(PromptResult(
+            transcriptionId: meeting.id,
+            promptName: "Executive Summary",
+            promptContent: "Summarize the meeting.",
+            content: "Keep the CLI contract explicit."
+        ))
+
+        let listCommand = try MeetingsCommand.ListSubcommand.parse([
+            "--json",
+            "--database", dbURL.path,
+        ])
+        let listOutput = try await captureStandardOutput {
+            try await listCommand.run()
+        }
+        let listPayload = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(listOutput.utf8)) as? [[String: Any]]
+        )
+        let listItem = try XCTUnwrap(listPayload.first)
+        XCTAssertEqual(listItem["hasPromptResults"] as? Bool, true)
+        XCTAssertEqual(listItem["promptResultCount"] as? Int, 1)
+
+        let showCommand = try MeetingsCommand.ShowSubcommand.parse([
+            meeting.id.uuidString,
+            "--json",
+            "--database", dbURL.path,
+        ])
+        let showOutput = try await captureStandardOutput {
+            try await showCommand.run()
+        }
+        let showPayload = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(showOutput.utf8)) as? [String: Any]
+        )
+        XCTAssertEqual(showPayload["hasPromptResults"] as? Bool, true)
+        XCTAssertEqual(showPayload["promptResultCount"] as? Int, 1)
+
+        let exportCommand = try MeetingsCommand.ExportSubcommand.parse([
+            meeting.id.uuidString,
+            "--format", "json",
+            "--stdout",
+            "--database", dbURL.path,
+        ])
+        let exportOutput = try await captureStandardOutput {
+            try await exportCommand.run()
+        }
+        let exportPayload = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(exportOutput.utf8)) as? [String: Any]
+        )
+        XCTAssertEqual(exportPayload["hasPromptResults"] as? Bool, true)
+        XCTAssertEqual(exportPayload["promptResultCount"] as? Int, 1)
+    }
+
     func testFormatRawValues() {
         XCTAssertEqual(MeetingTranscriptFormat(rawValue: "text"), .text)
         XCTAssertEqual(MeetingTranscriptFormat(rawValue: "json"), .json)

--- a/Tests/CLITests/MeetingsCommandTests.swift
+++ b/Tests/CLITests/MeetingsCommandTests.swift
@@ -112,7 +112,7 @@ final class MeetingsCommandTests: XCTestCase {
         XCTAssertEqual(saved[0].userNotesSnapshot, "Manual note")
     }
 
-    func testListAndShowExposePromptResultAvailability() async throws {
+    func testMeetingSurfacesExposePromptResultAvailability() async throws {
         let dbURL = temporaryDatabaseURL()
         defer { try? FileManager.default.removeItem(at: dbURL) }
         let db = try DatabaseManager(path: dbURL.path)
@@ -174,6 +174,17 @@ final class MeetingsCommandTests: XCTestCase {
         )
         XCTAssertEqual(exportPayload["hasPromptResults"] as? Bool, true)
         XCTAssertEqual(exportPayload["promptResultCount"] as? Int, 1)
+
+        let markdownExportCommand = try MeetingsCommand.ExportSubcommand.parse([
+            meeting.id.uuidString,
+            "--format", "md",
+            "--stdout",
+            "--database", dbURL.path,
+        ])
+        let markdownExportOutput = try await captureStandardOutput {
+            try await markdownExportCommand.run()
+        }
+        XCTAssertTrue(markdownExportOutput.contains("- Prompt results: 1"))
     }
 
     func testFormatRawValues() {

--- a/Tests/MacParakeetTests/Database/PromptResultRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/PromptResultRepositoryTests.swift
@@ -62,6 +62,7 @@ final class PromptResultRepositoryTests: XCTestCase {
         )
 
         XCTAssertEqual(try repo.fetchAll(transcriptionId: transcription.id).count, 2)
+        XCTAssertEqual(try repo.count(transcriptionId: transcription.id), 2)
         XCTAssertTrue(try repo.hasPromptResults(transcriptionId: transcription.id))
     }
 
@@ -117,5 +118,6 @@ final class PromptResultRepositoryTests: XCTestCase {
         _ = try transcriptionRepo.delete(id: transcription.id)
 
         XCTAssertFalse(try repo.hasPromptResults(transcriptionId: transcription.id))
+        XCTAssertEqual(try repo.count(transcriptionId: transcription.id), 0)
     }
 }

--- a/Tests/MacParakeetTests/Database/PromptResultRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/PromptResultRepositoryTests.swift
@@ -63,6 +63,7 @@ final class PromptResultRepositoryTests: XCTestCase {
 
         XCTAssertEqual(try repo.fetchAll(transcriptionId: transcription.id).count, 2)
         XCTAssertEqual(try repo.count(transcriptionId: transcription.id), 2)
+        XCTAssertEqual(try repo.counts(transcriptionIds: [transcription.id])[transcription.id], 2)
         XCTAssertTrue(try repo.hasPromptResults(transcriptionId: transcription.id))
     }
 
@@ -119,5 +120,6 @@ final class PromptResultRepositoryTests: XCTestCase {
 
         XCTAssertFalse(try repo.hasPromptResults(transcriptionId: transcription.id))
         XCTAssertEqual(try repo.count(transcriptionId: transcription.id), 0)
+        XCTAssertEqual(try repo.counts(transcriptionIds: [transcription.id])[transcription.id] ?? 0, 0)
     }
 }

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -877,6 +877,10 @@ final class MockPromptResultRepository: PromptResultRepositoryProtocol, @uncheck
     func hasPromptResults(transcriptionId: UUID) throws -> Bool {
         promptResults.contains { $0.transcriptionId == transcriptionId }
     }
+
+    func count(transcriptionId: UUID) throws -> Int {
+        promptResults.filter { $0.transcriptionId == transcriptionId }.count
+    }
 }
 
 // MARK: - MockChatConversationRepository


### PR DESCRIPTION
## Summary
- Add `hasPromptResults` and `promptResultCount` to meeting list/show/export JSON.
- Show prompt-result counts in human meeting list/show output.
- Add repository count coverage plus CLI spec and changelog updates.

## Tests
- `swift test --filter MeetingsCommandTests`
- `swift test --filter PromptResultRepositoryTests`
- `swift test --filter SpecCommandTests`
- `git diff --check`
- `swift test`