### PR TITLE
Broaden CLI telemetry observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The [notarized DMG](https://downloads.macparakeet.com/MacParakeet.dmg) is the st
 | Stable DMG | Recommended for normal use | Dictation, file/video/YouTube transcription, meeting recording, optional WhisperKit, exports, vocabulary, AI features |
 | `main` branch | Development | v0.6 release scope plus productized Transforms and calendar auto-start (`AppFeatures.calendarEnabled = true`); calendar auto-start defaults to opt-in `.off` |
 
-Calendar reminders, auto-start, and auto-stop are implemented and enabled on `main`; calendar auto-start defaults to mode `.off`, so it stays opt-in until a user turns it on.
+Calendar reminders and auto-start are implemented and enabled on `main`; calendar auto-start defaults to mode `.off`, so it stays opt-in until a user turns it on. Calendar-driven auto-stop was removed by ADR-017; recordings stop manually.
 
 ## What it does
 

--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -94,6 +94,11 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ### Changed
 
+- CLI telemetry now lives in the root runner instead of the `transcribe`
+  command, so every successfully parsed command emits one privacy-safe
+  `cli_operation` event. `transcribe` keeps its extra coarse input/output
+  metadata; other commands report only command path, outcome, duration, exit
+  code, and error type.
 - `transcribe` now defaults `--speaker-detection` to `app-default`, so bare
   CLI transcription follows the saved GUI/CLI speaker-detection preference.
   Use `--speaker-detection on` to force diarization for one run, or

--- a/Sources/CLI/Commands/CLIHelpers.swift
+++ b/Sources/CLI/Commands/CLIHelpers.swift
@@ -5,6 +5,11 @@ import MacParakeetCore
 let macParakeetAppDefaultsSuiteName = "com.macparakeet.MacParakeet"
 let cliValidationMisuseExitCode = ExitCode(2)
 
+struct CLIJSONEnvelopeExit: Error {
+    let exitCode: ExitCode
+    let originalError: Error
+}
+
 func macParakeetAppDefaults() -> UserDefaults {
     UserDefaults(suiteName: macParakeetAppDefaultsSuiteName) ?? .standard
 }
@@ -393,13 +398,13 @@ private func rethrowWithOptionalJSONEnvelope(_ error: Error, json: Bool) throws 
     let envelope = CLIErrorEnvelope(error: error)
     try? printJSON(envelope)
     if error is ValidationError || error is CLIInputError {
-        throw cliValidationMisuseExitCode
+        throw CLIJSONEnvelopeExit(exitCode: cliValidationMisuseExitCode, originalError: error)
     }
     if let transforms = error as? CLITransformsError, transforms.isValidationMisuse {
-        throw cliValidationMisuseExitCode
+        throw CLIJSONEnvelopeExit(exitCode: cliValidationMisuseExitCode, originalError: error)
     }
     if let history = error as? CLITransformHistoryError, case .invalidPrefix = history {
-        throw cliValidationMisuseExitCode
+        throw CLIJSONEnvelopeExit(exitCode: cliValidationMisuseExitCode, originalError: error)
     }
-    throw ExitCode.failure
+    throw CLIJSONEnvelopeExit(exitCode: .failure, originalError: error)
 }

--- a/Sources/CLI/Commands/CLITelemetry.swift
+++ b/Sources/CLI/Commands/CLITelemetry.swift
@@ -171,10 +171,11 @@ enum CLITelemetry {
             return provider.cliTelemetryMetadata
         }
 
-        let path = commandPath(for: type(of: command)) ?? [
-            type(of: command).configuration.commandName ?? String(describing: type(of: command))
+        let commandType = type(of: command)
+        let path = commandPath(for: commandType) ?? [
+            commandType.configuration.commandName ?? String(describing: commandType)
         ]
-        let commandName = path.first ?? "unknown"
+        let commandName = path[0]
         let subcommand = path.dropFirst().isEmpty ? nil : path.dropFirst().joined(separator: " ")
         return OperationMetadata(command: commandName, subcommand: subcommand)
     }
@@ -229,13 +230,13 @@ enum CLITelemetry {
     }
 }
 
-private extension Result where Success == Void, Failure == Error {
+extension Result where Success == Void, Failure == Error {
     var cliTelemetryOutcome: ObservabilityOutcome {
         switch self {
         case .success:
             return .success
-        case .failure:
-            return .failure
+        case .failure(let error):
+            return CLI.normalizedExitCode(for: error).isSuccess ? .success : .failure
         }
     }
 

--- a/Sources/CLI/Commands/CLITelemetry.swift
+++ b/Sources/CLI/Commands/CLITelemetry.swift
@@ -1,7 +1,37 @@
+import ArgumentParser
 import Foundation
 import MacParakeetCore
 
+protocol CLITelemetryMetadataProviding {
+    var cliTelemetryMetadata: CLITelemetry.OperationMetadata { get }
+}
+
 enum CLITelemetry {
+    struct OperationMetadata: Equatable, Sendable {
+        var command: String
+        var subcommand: String?
+        var inputKind: ObservabilityInputKind?
+        var outputFormat: String?
+        var json: Bool?
+        var suppressEvent: Bool
+
+        init(
+            command: String,
+            subcommand: String? = nil,
+            inputKind: ObservabilityInputKind? = nil,
+            outputFormat: String? = nil,
+            json: Bool? = nil,
+            suppressEvent: Bool = false
+        ) {
+            self.command = command
+            self.subcommand = subcommand
+            self.inputKind = inputKind
+            self.outputFormat = outputFormat
+            self.json = json
+            self.suppressEvent = suppressEvent
+        }
+    }
+
     /// Outcome of evaluating env-var overrides for CLI telemetry. Resolved before
     /// the user's persisted UserDefaults preference is consulted.
     enum EnvOverride: Equatable {
@@ -92,6 +122,83 @@ enum CLITelemetry {
         return false
     }
 
+    static func runInstrumented(_ command: inout ParsableCommand) async throws {
+        let metadata = metadata(for: command)
+        if metadata.suppressEvent {
+            Telemetry.configure(NoOpTelemetryService())
+        } else {
+            configureIfNeeded()
+        }
+        let operationContext = ObservabilityOperationContext()
+        let operationID = operationContext.operationID
+        let startedAt = operationContext.startedAt
+        let result: Result<Void, Error>
+
+        do {
+            try await Observability.withOperationContext(operationContext) {
+                if var asyncCommand = command as? AsyncParsableCommand {
+                    try await asyncCommand.run()
+                } else {
+                    try command.run()
+                }
+            }
+            result = .success(())
+        } catch {
+            result = .failure(error)
+        }
+
+        if !metadata.suppressEvent {
+            await sendOperationAndFlush(
+                operationID: operationID,
+                operationContext: operationContext,
+                command: metadata.command,
+                subcommand: metadata.subcommand,
+                outcome: result.cliTelemetryOutcome,
+                startedAt: startedAt,
+                inputKind: metadata.inputKind,
+                outputFormat: metadata.outputFormat,
+                json: metadata.json,
+                exitCode: result.cliTelemetryExitCode,
+                errorType: result.cliTelemetryErrorType
+            )
+        }
+
+        try result.get()
+    }
+
+    static func metadata(for command: ParsableCommand) -> OperationMetadata {
+        if let provider = command as? CLITelemetryMetadataProviding {
+            return provider.cliTelemetryMetadata
+        }
+
+        let path = commandPath(for: type(of: command)) ?? [
+            type(of: command).configuration.commandName ?? String(describing: type(of: command))
+        ]
+        let commandName = path.first ?? "unknown"
+        let subcommand = path.dropFirst().isEmpty ? nil : path.dropFirst().joined(separator: " ")
+        return OperationMetadata(command: commandName, subcommand: subcommand)
+    }
+
+    private static func commandPath(for target: ParsableCommand.Type) -> [String]? {
+        commandPath(through: CLI.configuration.subcommands, target: target)
+    }
+
+    private static func commandPath(
+        through commandTypes: [ParsableCommand.Type],
+        target: ParsableCommand.Type
+    ) -> [String]? {
+        for commandType in commandTypes {
+            let name = commandType.configuration.commandName ?? String(describing: commandType)
+            if commandType == target {
+                return [name]
+            }
+            if let childPath = commandPath(through: commandType.configuration.subcommands, target: target) {
+                return [name] + childPath
+            }
+        }
+        return nil
+    }
+
     static func sendOperationAndFlush(
         operationID: String,
         operationContext: ObservabilityOperationContext? = nil,
@@ -119,5 +226,37 @@ enum CLITelemetry {
             errorType: errorType
         ))
         await Telemetry.flush()
+    }
+}
+
+private extension Result where Success == Void, Failure == Error {
+    var cliTelemetryOutcome: ObservabilityOutcome {
+        switch self {
+        case .success:
+            return .success
+        case .failure:
+            return .failure
+        }
+    }
+
+    var cliTelemetryExitCode: Int {
+        switch self {
+        case .success:
+            return 0
+        case .failure(let error):
+            return Int(CLI.normalizedExitCode(for: error).rawValue)
+        }
+    }
+
+    var cliTelemetryErrorType: String? {
+        switch self {
+        case .success:
+            return nil
+        case .failure(let error):
+            if let jsonExit = error as? CLIJSONEnvelopeExit {
+                return CLIErrorType.key(for: jsonExit.originalError)
+            }
+            return CLIErrorType.key(for: error)
+        }
     }
 }

--- a/Sources/CLI/Commands/ConfigCommand.swift
+++ b/Sources/CLI/Commands/ConfigCommand.swift
@@ -92,8 +92,8 @@ struct ConfigCommand: ParsableCommand {
 
         var cliTelemetryMetadata: CLITelemetry.OperationMetadata {
             CLITelemetry.OperationMetadata(
-                command: "config",
-                subcommand: "set",
+                command: ConfigCommand.configuration.commandName ?? "config",
+                subcommand: Self.configuration.commandName ?? "set",
                 json: json,
                 suppressEvent: Self.suppressesTelemetryEvent(key: key, value: value)
             )

--- a/Sources/CLI/Commands/ConfigCommand.swift
+++ b/Sources/CLI/Commands/ConfigCommand.swift
@@ -75,7 +75,7 @@ struct ConfigCommand: ParsableCommand {
         }
     }
 
-    struct SetCommand: ParsableCommand {
+    struct SetCommand: ParsableCommand, CLITelemetryMetadataProviding {
         static let configuration = CommandConfiguration(
             commandName: "set",
             abstract: "Write a configuration value."
@@ -90,12 +90,26 @@ struct ConfigCommand: ParsableCommand {
         @Flag(name: .long, help: "Emit JSON instead of plain text.")
         var json: Bool = false
 
+        var cliTelemetryMetadata: CLITelemetry.OperationMetadata {
+            CLITelemetry.OperationMetadata(
+                command: "config",
+                subcommand: "set",
+                json: json,
+                suppressEvent: Self.suppressesTelemetryEvent(key: key, value: value)
+            )
+        }
+
         func run() throws {
             try emitJSONOrRethrow(json: json) {
                 let canonicalKey = try ConfigCommand.canonicalKey(key)
                 let written = try ConfigCommand.write(key: canonicalKey, value: value)
                 try printResult(key: canonicalKey, value: written, json: json)
             }
+        }
+
+        static func suppressesTelemetryEvent(key: String, value: String) -> Bool {
+            (try? ConfigCommand.canonicalKey(key)) == "telemetry"
+                && (try? ConfigCommand.parseBool(value, key: key)) == false
         }
     }
 

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -39,15 +39,15 @@ enum SpeakerDetectionOption: String, ExpressibleByArgument, CaseIterable, Sendab
     case off
 }
 
-struct TranscribeCommand: AsyncParsableCommand {
+struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
     static let configuration = CommandConfiguration(
         commandName: "transcribe",
         abstract: "Transcribe an audio/video file or YouTube URL.",
         discussion: """
-        Telemetry: emits one privacy-safe `cli_operation` event per invocation with \
-        allowlisted invocation metadata (command, outcome, duration, input_kind, \
-        output_format, json, exit_code, error_type). It never includes the path, \
-        URL, transcript, language value, or user content. Disable with \
+        Telemetry: the root CLI runner emits one privacy-safe `cli_operation` \
+        event per invocation; `transcribe` adds allowlisted input/output metadata \
+        (input_kind, output_format, json). It never includes the path, URL, \
+        transcript, language value, or user content. Disable with \
         `MACPARAKEET_TELEMETRY=0`, `DO_NOT_TRACK=1`, the persistent \
         `macparakeet-cli config set telemetry off`, or the GUI Settings toggle. \
         Auto-disabled in CI (CI/GITHUB_ACTIONS/etc.). See \
@@ -90,6 +90,15 @@ struct TranscribeCommand: AsyncParsableCommand {
 
     @Flag(name: .long, help: "Do not save the completed transcription to MacParakeet history. YouTube audio is temporary.")
     var noHistory: Bool = false
+
+    var cliTelemetryMetadata: CLITelemetry.OperationMetadata {
+        CLITelemetry.OperationMetadata(
+            command: "transcribe",
+            inputKind: Self.telemetryInputKind(for: input),
+            outputFormat: format.rawValue,
+            json: format == .json
+        )
+    }
 
     func validate() throws {
         if noHistory && downloadedAudio == .keep {
@@ -168,159 +177,158 @@ struct TranscribeCommand: AsyncParsableCommand {
         URL(fileURLWithPath: expandTilde(input))
     }
 
-    func run() async throws {
-        CLITelemetry.configureIfNeeded()
-        let cliOperationContext = ObservabilityOperationContext()
-        let cliOperationID = cliOperationContext.operationID
-        let cliStartedAt = cliOperationContext.startedAt
+    static func telemetryInputKind(for input: String) -> ObservabilityInputKind {
         let trimmedInput = input.trimmingCharacters(in: .whitespacesAndNewlines)
-        let inputKind: ObservabilityInputKind = YouTubeURLValidator.isYouTubeURL(trimmedInput)
-            ? .youtube
-            : (Observability.inputKind(for: Self.localFileURL(for: trimmedInput)) ?? .unknown)
+        if YouTubeURLValidator.isYouTubeURL(trimmedInput) {
+            return .youtube
+        }
+        return Observability.inputKind(for: Self.localFileURL(for: trimmedInput)) ?? .unknown
+    }
+
+    func run() async throws {
+        let trimmedInput = input.trimmingCharacters(in: .whitespacesAndNewlines)
 
         var sttClient: STTClient?
         var whisperEngine: WhisperEngine?
         let runResult: Result<Void, Error>
         do {
-            try await Observability.withOperationContext(cliOperationContext) {
-                try AppPaths.ensureDirectories()
-                let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
-                let transcriptionRepo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
-                let customWordRepo = CustomWordRepository(dbQueue: dbManager.dbQueue)
-                let snippetRepo = TextSnippetRepository(dbQueue: dbManager.dbQueue)
-                let defaults = macParakeetAppDefaults()
-                let speechEngine = Self.resolveSpeechEngine(
-                    self.engine,
-                    storedEngine: defaults.string(forKey: SpeechEnginePreference.defaultsKey),
-                    storedLanguage: SpeechEnginePreference.whisperDefaultLanguage(defaults: defaults),
-                    explicitLanguage: self.language
-                )
-                let speakerDetectionEnabled = Self.resolveSpeakerDetection(
-                    self.speakerDetection,
-                    storedEnabled: defaults.object(forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey) as? Bool,
-                    noDiarize: self.noDiarize
-                )
-                let processingMode = Self.resolveProcessingMode(
-                    self.mode,
-                    storedMode: defaults.string(forKey: UserDefaultsAppRuntimePreferences.processingModeKey)
-                )
-                let resolvedYouTubeAudioQuality = Self.resolveYouTubeAudioQuality(
-                    self.youtubeAudioQuality,
-                    storedQuality: defaults.string(forKey: UserDefaultsAppRuntimePreferences.youtubeAudioQualityKey)
-                )
-                let configuredShouldKeepDownloadedAudio: Bool = switch self.downloadedAudio {
-                case .keep:
-                    true
-                case .delete:
-                    false
-                case .appDefault:
-                    defaults.object(forKey: UserDefaultsAppRuntimePreferences.saveTranscriptionAudioKey) as? Bool ?? true
-                }
-                let shouldKeepDownloadedAudio = self.noHistory ? false : configuredShouldKeepDownloadedAudio
-                let sttTranscriber: STTTranscribing
-                switch speechEngine.engine {
-                case .parakeet:
-                    let createdSTTClient = STTClient()
-                    sttClient = createdSTTClient
-                    sttTranscriber = createdSTTClient
-                case .whisper:
-                    let createdWhisperEngine = WhisperEngine(language: speechEngine.language)
-                    whisperEngine = createdWhisperEngine
-                    sttTranscriber = createdWhisperEngine
-                }
-                let audioProcessor = AudioProcessor()
-                let youtubeDownloader = YouTubeDownloader(audioQuality: {
-                    resolvedYouTubeAudioQuality
-                })
-                let entitlementsService = enforceEntitlements ? makeEntitlementsService() : nil
+            try AppPaths.ensureDirectories()
+            let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
+            let transcriptionRepo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
+            let customWordRepo = CustomWordRepository(dbQueue: dbManager.dbQueue)
+            let snippetRepo = TextSnippetRepository(dbQueue: dbManager.dbQueue)
+            let defaults = macParakeetAppDefaults()
+            let speechEngine = Self.resolveSpeechEngine(
+                self.engine,
+                storedEngine: defaults.string(forKey: SpeechEnginePreference.defaultsKey),
+                storedLanguage: SpeechEnginePreference.whisperDefaultLanguage(defaults: defaults),
+                explicitLanguage: self.language
+            )
+            let speakerDetectionEnabled = Self.resolveSpeakerDetection(
+                self.speakerDetection,
+                storedEnabled: defaults.object(forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey) as? Bool,
+                noDiarize: self.noDiarize
+            )
+            let processingMode = Self.resolveProcessingMode(
+                self.mode,
+                storedMode: defaults.string(forKey: UserDefaultsAppRuntimePreferences.processingModeKey)
+            )
+            let resolvedYouTubeAudioQuality = Self.resolveYouTubeAudioQuality(
+                self.youtubeAudioQuality,
+                storedQuality: defaults.string(forKey: UserDefaultsAppRuntimePreferences.youtubeAudioQualityKey)
+            )
+            let configuredShouldKeepDownloadedAudio: Bool = switch self.downloadedAudio {
+            case .keep:
+                true
+            case .delete:
+                false
+            case .appDefault:
+                defaults.object(forKey: UserDefaultsAppRuntimePreferences.saveTranscriptionAudioKey) as? Bool ?? true
+            }
+            let shouldKeepDownloadedAudio = self.noHistory ? false : configuredShouldKeepDownloadedAudio
+            let sttTranscriber: STTTranscribing
+            switch speechEngine.engine {
+            case .parakeet:
+                let createdSTTClient = STTClient()
+                sttClient = createdSTTClient
+                sttTranscriber = createdSTTClient
+            case .whisper:
+                let createdWhisperEngine = WhisperEngine(language: speechEngine.language)
+                whisperEngine = createdWhisperEngine
+                sttTranscriber = createdWhisperEngine
+            }
+            let audioProcessor = AudioProcessor()
+            let youtubeDownloader = YouTubeDownloader(audioQuality: {
+                resolvedYouTubeAudioQuality
+            })
+            let entitlementsService = enforceEntitlements ? makeEntitlementsService() : nil
 
-                if let entitlementsService {
-                    await entitlementsService.bootstrapTrialIfNeeded()
-                    await entitlementsService.refreshValidationIfNeeded()
-                }
+            if let entitlementsService {
+                await entitlementsService.bootstrapTrialIfNeeded()
+                await entitlementsService.refreshValidationIfNeeded()
+            }
 
-                let diarizationService: DiarizationService? = speakerDetectionEnabled ? DiarizationService() : nil
-                let service = TranscriptionService(
-                    audioProcessor: audioProcessor,
-                    sttTranscriber: sttTranscriber,
-                    transcriptionRepo: transcriptionRepo,
-                    entitlements: entitlementsService,
-                    customWordRepo: customWordRepo,
-                    snippetRepo: snippetRepo,
-                    processingMode: {
-                        processingMode
-                    },
-                    shouldKeepDownloadedAudio: {
-                        shouldKeepDownloadedAudio
-                    },
-                    shouldDiarize: { speakerDetectionEnabled },
-                    youtubeDownloader: youtubeDownloader,
-                    diarizationService: diarizationService
-                )
+            let diarizationService: DiarizationService? = speakerDetectionEnabled ? DiarizationService() : nil
+            let service = TranscriptionService(
+                audioProcessor: audioProcessor,
+                sttTranscriber: sttTranscriber,
+                transcriptionRepo: transcriptionRepo,
+                entitlements: entitlementsService,
+                customWordRepo: customWordRepo,
+                snippetRepo: snippetRepo,
+                processingMode: {
+                    processingMode
+                },
+                shouldKeepDownloadedAudio: {
+                    shouldKeepDownloadedAudio
+                },
+                shouldDiarize: { speakerDetectionEnabled },
+                youtubeDownloader: youtubeDownloader,
+                diarizationService: diarizationService
+            )
 
-                let result: Transcription
+            let result: Transcription
 
-                if YouTubeURLValidator.isYouTubeURL(trimmedInput) {
-                    let lastProgressLine = OSAllocatedUnfairLock(initialState: "")
-                    @Sendable func printProgressLine(_ line: String) {
-                        let shouldPrint = lastProgressLine.withLock { lastLine in
-                            guard lastLine != line else { return false }
-                            lastLine = line
-                            return true
-                        }
-                        if shouldPrint {
-                            printErr(line)
-                        }
+            if YouTubeURLValidator.isYouTubeURL(trimmedInput) {
+                let lastProgressLine = OSAllocatedUnfairLock(initialState: "")
+                @Sendable func printProgressLine(_ line: String) {
+                    let shouldPrint = lastProgressLine.withLock { lastLine in
+                        guard lastLine != line else { return false }
+                        lastLine = line
+                        return true
                     }
+                    if shouldPrint {
+                        printErr(line)
+                    }
+                }
 
-                    let progressHandler: @Sendable (TranscriptionProgress) -> Void = { progress in
-                        switch progress {
-                        case .converting: printProgressLine("Converting audio...")
-                        case .downloading(let pct): printProgressLine("Downloading audio... \(pct)%")
-                        case .transcribing(let pct): printProgressLine("Transcribing... \(pct)%")
-                        case .identifyingSpeakers: printProgressLine("Identifying speakers...")
-                        case .finalizing: printProgressLine("Finalizing...")
-                        }
+                let progressHandler: @Sendable (TranscriptionProgress) -> Void = { progress in
+                    switch progress {
+                    case .converting: printProgressLine("Converting audio...")
+                    case .downloading(let pct): printProgressLine("Downloading audio... \(pct)%")
+                    case .transcribing(let pct): printProgressLine("Transcribing... \(pct)%")
+                    case .identifyingSpeakers: printProgressLine("Identifying speakers...")
+                    case .finalizing: printProgressLine("Finalizing...")
                     }
-                    if self.noHistory {
-                        result = try await service.transcribeURLTransient(
-                            urlString: trimmedInput,
-                            onProgress: progressHandler
-                        )
-                    } else {
-                        result = try await service.transcribeURL(
-                            urlString: trimmedInput,
-                            onProgress: progressHandler
-                        )
-                    }
+                }
+                if self.noHistory {
+                    result = try await service.transcribeURLTransient(
+                        urlString: trimmedInput,
+                        onProgress: progressHandler
+                    )
                 } else {
-                    let url = Self.localFileURL(for: trimmedInput)
+                    result = try await service.transcribeURL(
+                        urlString: trimmedInput,
+                        onProgress: progressHandler
+                    )
+                }
+            } else {
+                let url = Self.localFileURL(for: trimmedInput)
 
-                    guard FileManager.default.fileExists(atPath: url.path) else {
-                        throw CLIError.fileNotFound(url.path)
-                    }
-
-                    let ext = url.pathExtension.lowercased()
-                    guard AudioFileConverter.supportedExtensions.contains(ext) else {
-                        throw CLIError.unsupportedFormat(ext)
-                    }
-
-                    printErr("Transcribing \(url.lastPathComponent) with \(speechEngine.engine.rawValue)...")
-                    if self.noHistory {
-                        result = try await service.transcribeTransient(fileURL: url)
-                    } else {
-                        result = try await service.transcribe(fileURL: url)
-                    }
+                guard FileManager.default.fileExists(atPath: url.path) else {
+                    throw CLIError.fileNotFound(url.path)
                 }
 
-                switch format {
-                case .json:
-                    try printJSON(result)
-                case .transcript:
-                    printTranscript(result)
-                case .text:
-                    printText(result)
+                let ext = url.pathExtension.lowercased()
+                guard AudioFileConverter.supportedExtensions.contains(ext) else {
+                    throw CLIError.unsupportedFormat(ext)
                 }
+
+                printErr("Transcribing \(url.lastPathComponent) with \(speechEngine.engine.rawValue)...")
+                if self.noHistory {
+                    result = try await service.transcribeTransient(fileURL: url)
+                } else {
+                    result = try await service.transcribe(fileURL: url)
+                }
+            }
+
+            switch format {
+            case .json:
+                try printJSON(result)
+            case .transcript:
+                printTranscript(result)
+            case .text:
+                printText(result)
             }
             runResult = .success(())
         } catch {
@@ -329,31 +337,6 @@ struct TranscribeCommand: AsyncParsableCommand {
 
         await sttClient?.shutdown()
         await whisperEngine?.unload()
-        let cliOutcome: ObservabilityOutcome
-        let exitCode: Int
-        let errorType: String?
-        switch runResult {
-        case .success:
-            cliOutcome = .success
-            exitCode = 0
-            errorType = nil
-        case .failure(let error):
-            cliOutcome = .failure
-            exitCode = 1
-            errorType = Observability.errorType(for: error)
-        }
-        await CLITelemetry.sendOperationAndFlush(
-            operationID: cliOperationID,
-            operationContext: cliOperationContext,
-            command: "transcribe",
-            outcome: cliOutcome,
-            startedAt: cliStartedAt,
-            inputKind: inputKind,
-            outputFormat: format.rawValue,
-            json: format == .json,
-            exitCode: exitCode,
-            errorType: errorType
-        )
         try emitJSONOrRethrow(json: format == .json) {
             try runResult.get()
         }

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -93,7 +93,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
 
     var cliTelemetryMetadata: CLITelemetry.OperationMetadata {
         CLITelemetry.OperationMetadata(
-            command: "transcribe",
+            command: Self.configuration.commandName ?? "transcribe",
             inputKind: Self.telemetryInputKind(for: input),
             outputFormat: format.rawValue,
             json: format == .json

--- a/Sources/CLI/MacParakeetCLI.swift
+++ b/Sources/CLI/MacParakeetCLI.swift
@@ -42,17 +42,16 @@ struct CLI: AsyncParsableCommand {
     static func main(_ arguments: [String]?) async {
         do {
             var command = try parseAsRoot(arguments)
-            if var asyncCommand = command as? AsyncParsableCommand {
-                try await asyncCommand.run()
-            } else {
-                try command.run()
-            }
+            try await CLITelemetry.runInstrumented(&command)
         } catch {
             exitWithNormalizedError(error)
         }
     }
 
     static func normalizedExitCode(for error: Error) -> ExitCode {
+        if let jsonExit = error as? CLIJSONEnvelopeExit {
+            return jsonExit.exitCode
+        }
         if let exitCode = error as? ExitCode {
             return normalizedExitCode(for: exitCode)
         }
@@ -65,6 +64,9 @@ struct CLI: AsyncParsableCommand {
 
     private static func exitWithNormalizedError(_ error: Error) -> Never {
         let exitCode = normalizedExitCode(for: error)
+        if error is CLIJSONEnvelopeExit {
+            Darwin.exit(exitCode.rawValue)
+        }
         let message = fullMessage(for: error)
         if !message.isEmpty {
             if exitCode.isSuccess {

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -270,28 +270,35 @@ final class MeetingRecordingFlowCoordinator {
                 let sourceMode = meetingAudioSourceModeProvider()
                 self.pendingAudioSourceMode = sourceMode
                 let microphoneGranted: Bool
+                let microphonePrompted: Bool
                 if sourceMode.capturesMicrophone {
                     let microphoneStatus = await permissionService.checkMicrophonePermission()
                     switch microphoneStatus {
                     case .granted:
                         microphoneGranted = true
+                        microphonePrompted = false
                     case .denied:
                         microphoneGranted = false
+                        microphonePrompted = false
                     case .notDetermined:
                         Telemetry.send(.permissionPrompted(permission: .microphone))
+                        microphonePrompted = true
                         microphoneGranted = await permissionService.requestMicrophonePermission()
                     }
                 } else {
                     microphoneGranted = true
+                    microphonePrompted = false
                 }
 
                 if !microphoneGranted {
-                    Telemetry.send(.permissionDenied(permission: .microphone))
+                    if microphonePrompted {
+                        Telemetry.send(.permissionDenied(permission: .microphone))
+                    }
                     self.clearPendingStartContext(failureReason: "permission_denied")
                     self.sendEvent(.permissionsDenied(generation: gen, reason: .microphone))
                     return
                 }
-                if sourceMode.capturesMicrophone {
+                if microphonePrompted {
                     Telemetry.send(.permissionGranted(permission: .microphone))
                 }
 
@@ -306,7 +313,9 @@ final class MeetingRecordingFlowCoordinator {
                     self.sendEvent(.permissionsDenied(generation: gen, reason: .screenRecording))
                     return
                 }
-                Telemetry.send(.permissionGranted(permission: .screenRecording))
+                if !existingScreenGrant {
+                    Telemetry.send(.permissionGranted(permission: .screenRecording))
+                }
                 self.sendEvent(.permissionsGranted(generation: gen))
             }
 

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -392,6 +392,8 @@ public enum TelemetrySettingName: String, Sendable, Equatable {
 }
 
 public enum TelemetryEventSpec: Sendable {
+    static let maxCrashStackTraceCharacters = 1024
+
     case appLaunched
     case appQuit(sessionDurationSeconds: Double)
     case dictationStarted(trigger: TelemetryDictationTrigger?, mode: TelemetryDictationMode?)
@@ -1438,7 +1440,7 @@ extension TelemetryEventSpec {
                 ("uuid", uuid),
                 ("slide", slide),
                 ("reason", reason.map { String($0.prefix(512)) }),
-                ("stack_trace", String(stackTrace.prefix(2048)))
+                ("stack_trace", String(stackTrace.prefix(Self.maxCrashStackTraceCharacters)))
             )
         case .cliOperation(
             let operationID,

--- a/Tests/CLITests/CLITelemetryTests.swift
+++ b/Tests/CLITests/CLITelemetryTests.swift
@@ -1,3 +1,4 @@
+import ArgumentParser
 import XCTest
 @testable import CLI
 @testable import MacParakeetCore
@@ -198,5 +199,12 @@ final class CLITelemetryTests: XCTestCase {
         XCTAssertEqual(metadata.outputFormat, "json")
         XCTAssertEqual(metadata.json, true)
         XCTAssertFalse(metadata.suppressEvent)
+    }
+
+    func testTelemetryOutcomeTreatsSuccessfulExitCodeAsSuccess() {
+        let result = Result<Void, Error>.failure(ExitCode.success)
+
+        XCTAssertEqual(result.cliTelemetryOutcome, .success)
+        XCTAssertEqual(result.cliTelemetryExitCode, 0)
     }
 }

--- a/Tests/CLITests/CLITelemetryTests.swift
+++ b/Tests/CLITests/CLITelemetryTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import CLI
+@testable import MacParakeetCore
 
 final class CLITelemetryTests: XCTestCase {
 
@@ -154,5 +155,48 @@ final class CLITelemetryTests: XCTestCase {
         XCTAssertTrue(
             CLITelemetry.isCIEnvironment(env: ["JENKINS_URL": "https://ci.example.com/"])
         )
+    }
+
+    // MARK: - operation metadata
+
+    func testMetadataUsesCanonicalNestedCommandPath() throws {
+        let command = try CLI.parseAsRoot(["config", "set", "telemetry", "off"])
+
+        let metadata = CLITelemetry.metadata(for: command)
+
+        XCTAssertEqual(metadata.command, "config")
+        XCTAssertEqual(metadata.subcommand, "set")
+        XCTAssertNil(metadata.inputKind)
+        XCTAssertNil(metadata.outputFormat)
+        XCTAssertEqual(metadata.json, false)
+        XCTAssertTrue(metadata.suppressEvent)
+    }
+
+    func testConfigSetTelemetryOnDoesNotSuppressTelemetryEvent() throws {
+        let command = try CLI.parseAsRoot(["config", "set", "telemetry", "on"])
+
+        let metadata = CLITelemetry.metadata(for: command)
+
+        XCTAssertEqual(metadata.command, "config")
+        XCTAssertEqual(metadata.subcommand, "set")
+        XCTAssertFalse(metadata.suppressEvent)
+    }
+
+    func testTranscribeMetadataKeepsPrivacySafeInputKindAndOutputFormat() throws {
+        let command = try CLI.parseAsRoot([
+            "transcribe",
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            "--format",
+            "json",
+        ])
+
+        let metadata = CLITelemetry.metadata(for: command)
+
+        XCTAssertEqual(metadata.command, "transcribe")
+        XCTAssertNil(metadata.subcommand)
+        XCTAssertEqual(metadata.inputKind, .youtube)
+        XCTAssertEqual(metadata.outputFormat, "json")
+        XCTAssertEqual(metadata.json, true)
+        XCTAssertFalse(metadata.suppressEvent)
     }
 }

--- a/Tests/CLITests/ExportCommandTests.swift
+++ b/Tests/CLITests/ExportCommandTests.swift
@@ -72,8 +72,9 @@ final class ExportCommandTests: XCTestCase {
             }
         }
 
-        let exit = try XCTUnwrap(thrownError as? ExitCode)
-        XCTAssertEqual(exit, .failure)
+        let error = try XCTUnwrap(thrownError)
+        XCTAssertTrue(error is CLIJSONEnvelopeExit)
+        XCTAssertEqual(CLI.normalizedExitCode(for: error), .failure)
         let object = try XCTUnwrap(
             JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any]
         )

--- a/Tests/CLITests/LLMJSONOutputTests.swift
+++ b/Tests/CLITests/LLMJSONOutputTests.swift
@@ -177,8 +177,9 @@ final class LLMJSONOutputTests: XCTestCase {
             }
         }
 
-        let exit = try XCTUnwrap(thrownError as? ExitCode)
-        XCTAssertEqual(exit, .failure)
+        let error = try XCTUnwrap(thrownError)
+        XCTAssertTrue(error is CLIJSONEnvelopeExit)
+        XCTAssertEqual(CLI.normalizedExitCode(for: error), .failure)
 
         let object = try XCTUnwrap(
             JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any]
@@ -200,8 +201,9 @@ final class LLMJSONOutputTests: XCTestCase {
             }
         }
 
-        let exit = try XCTUnwrap(thrownError as? ExitCode)
-        XCTAssertEqual(exit.rawValue, 2)
+        let error = try XCTUnwrap(thrownError)
+        XCTAssertTrue(error is CLIJSONEnvelopeExit)
+        XCTAssertEqual(CLI.normalizedExitCode(for: error), cliValidationMisuseExitCode)
 
         let object = try XCTUnwrap(
             JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any]

--- a/Tests/CLITests/TranscribeCommandTests.swift
+++ b/Tests/CLITests/TranscribeCommandTests.swift
@@ -246,8 +246,9 @@ final class TranscribeCommandTests: XCTestCase {
             }
         }
 
-        let exit = try XCTUnwrap(thrownError as? ExitCode)
-        XCTAssertEqual(exit, .failure)
+        let error = try XCTUnwrap(thrownError)
+        XCTAssertTrue(error is CLIJSONEnvelopeExit)
+        XCTAssertEqual(CLI.normalizedExitCode(for: error), .failure)
         let object = try XCTUnwrap(
             JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any]
         )

--- a/Tests/CLITests/TransformsCommandTests.swift
+++ b/Tests/CLITests/TransformsCommandTests.swift
@@ -157,8 +157,9 @@ final class TransformsCommandTests: XCTestCase {
             }
         }
 
-        let exit = try XCTUnwrap(thrownError as? ExitCode)
-        XCTAssertEqual(exit.rawValue, 2)
+        let error = try XCTUnwrap(thrownError)
+        XCTAssertTrue(error is CLIJSONEnvelopeExit)
+        XCTAssertEqual(CLI.normalizedExitCode(for: error), cliValidationMisuseExitCode)
 
         let object = try XCTUnwrap(
             JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any]
@@ -189,8 +190,9 @@ final class TransformsCommandTests: XCTestCase {
             }
         }
 
-        let exit = try XCTUnwrap(thrownError as? ExitCode)
-        XCTAssertEqual(exit.rawValue, 1)
+        let error = try XCTUnwrap(thrownError)
+        XCTAssertTrue(error is CLIJSONEnvelopeExit)
+        XCTAssertEqual(CLI.normalizedExitCode(for: error), .failure)
 
         let object = try XCTUnwrap(
             JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any]
@@ -831,8 +833,9 @@ final class TransformsCommandTests: XCTestCase {
             }
         }
 
-        let exit = try XCTUnwrap(thrownError as? ExitCode)
-        XCTAssertEqual(exit.rawValue, 2)
+        let error = try XCTUnwrap(thrownError)
+        XCTAssertTrue(error is CLIJSONEnvelopeExit)
+        XCTAssertEqual(CLI.normalizedExitCode(for: error), cliValidationMisuseExitCode)
 
         let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any])
         XCTAssertEqual(object["ok"] as? Bool, false)
@@ -863,8 +866,9 @@ final class TransformsCommandTests: XCTestCase {
             }
         }
 
-        let exit = try XCTUnwrap(thrownError as? ExitCode)
-        XCTAssertEqual(exit, .failure)
+        let error = try XCTUnwrap(thrownError)
+        XCTAssertTrue(error is CLIJSONEnvelopeExit)
+        XCTAssertEqual(CLI.normalizedExitCode(for: error), .failure)
 
         let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any])
         XCTAssertEqual(object["ok"] as? Bool, false)

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -1169,6 +1169,26 @@ final class TelemetryServiceTests: XCTestCase {
         XCTAssertFalse(AppPreferences.isTelemetryEnabled(defaults: defaults))
     }
 
+    func testCrashOccurredStackTracePropFitsTelemetryIngestLimit() {
+        let stackTrace = String(repeating: "A", count: TelemetryEventSpec.maxCrashStackTraceCharacters + 500)
+
+        let event = TelemetryEventSpec.crashOccurred(
+            crashType: "signal",
+            signal: "11",
+            name: "SIGSEGV",
+            crashTimestamp: "1711900000",
+            crashAppVer: "0.5.1",
+            crashOsVer: "15.3.1",
+            uuid: "A1B2C3D4",
+            slide: "0x100000",
+            reason: nil,
+            stackTrace: stackTrace
+        )
+
+        let props = event.props ?? [:]
+        XCTAssertEqual(props["stack_trace"]?.count, TelemetryEventSpec.maxCrashStackTraceCharacters)
+    }
+
     private func sampleEvents() -> [TelemetryEventSpec] {
         [
             .appLaunched,

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -110,9 +110,10 @@ scripts; the alias remains documented here only while the CLI still exposes it.
 > a few newer meeting-note commands also accept `--json` for agent workflows.
 
 > **Telemetry convention**: CLI telemetry uses the same opt-out preference as
-> the GUI and does not change stdout/stderr contracts. `transcribe` emits a
-> privacy-safe `cli_operation` event with command, outcome, duration, output
-> format, coarse input kind, exit code, and low-cardinality error type. Disable
+> the GUI and does not change stdout/stderr contracts. After argument parsing
+> succeeds, the root runner emits one privacy-safe `cli_operation` event with
+> command, subcommand, outcome, duration, exit code, and low-cardinality error
+> type. `transcribe` also includes coarse input kind and output format. Disable
 > with `MACPARAKEET_TELEMETRY=0`, `DO_NOT_TRACK=1`, or
 > `macparakeet-cli config set telemetry off`.
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -378,8 +378,9 @@ events remain useful for diarization-specific timing and failure analysis.
 |---|---|---|
 | `cli_operation` | `operation_id`, `workflow_id`, `parent_operation_id`, `command`, `subcommand`, `outcome`, `duration_seconds`, `input_kind`, `output_format`, `json`, `exit_code`, `error_type` | Which CLI workflows are used by scripts/agents, and where they fail |
 
-CLI telemetry is initialized by `macparakeet-cli transcribe` and uses the same
-app preference as the GUI. Override resolution order (first match wins):
+CLI telemetry is initialized once by the root `macparakeet-cli` runner after
+argument parsing succeeds and uses the same app preference as the GUI. Override
+resolution order (first match wins):
 
 1. `MACPARAKEET_TELEMETRY=0/false/no/off` → force-off for this process
 2. `MACPARAKEET_TELEMETRY=1/true/yes/on` → force-on for this process

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -451,7 +451,7 @@ macparakeet-cli prompts run "<prompt-name>" \
   `prompts run` or `llm` targets a hosted provider, or when a configured
   Local CLI command contacts its own service), Sparkle update checks (app,
   not CLI), and a single privacy-safe
-  `cli_operation` event per `transcribe` invocation, posted to the self-hosted
+  `cli_operation` event per successfully parsed CLI invocation, posted to the self-hosted
   endpoint at `https://macparakeet.com/api/telemetry`. The telemetry event
   ships only allowlisted invocation metadata (`operation_id`, `workflow_id`,
   `parent_operation_id`, `command`, `subcommand`, `outcome`,


### PR DESCRIPTION
## Summary

- move CLI telemetry emission into the root runner so every successfully parsed command emits one privacy-safe `cli_operation` wide event
- keep `transcribe` metadata coarse (`input_kind`, `output_format`, `json`) and avoid paths, URLs, transcripts, language values, or user content
- preserve JSON-mode stdout/exit-code behavior while wrapping failures so telemetry can classify the original error
- suppress telemetry for `macparakeet-cli config set telemetry off`
- tighten meeting permission funnel semantics so already-granted permissions do not count as fresh grants
- cap crash stack traces to the telemetry ingest prop limit and refresh docs for current calendar/manual-stop behavior

## Fresh-eye review

Found and fixed one privacy semantics issue before opening: with root-level CLI instrumentation, the telemetry opt-out command itself could have emitted if telemetry was previously enabled. `ConfigCommand.SetCommand` now marks `telemetry off` as suppressed, configures a no-op telemetry service for that invocation, and the behavior is pinned in `CLITelemetryTests`.

No remaining blockers found in the reviewed diff. The remaining production telemetry ATTENTION signals are pre-existing runtime signals, not introduced by this change.

## Verification

- `swift test --filter CLITelemetryTests`
- `swift test` (2,904 tests, 9 skipped, 0 failures)
- `git diff --check`
