### PR TITLE
Gate engine switches and tag cold Whisper swaps

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -117,6 +117,7 @@ final class AppEnvironmentConfigurer {
             snippetRepo: env.snippetRepo,
             sttClient: env.sttScheduler,
             speechEngineSwitcher: env.sttScheduler,
+            speechEngineSwitchAvailabilityProvider: env.sttScheduler,
             meetingRecoveryService: env.meetingRecordingRecoveryService,
             sharedMicStream: env.sharedMicStream
         )

--- a/Sources/MacParakeet/Views/Settings/Components/EngineOptionTile.swift
+++ b/Sources/MacParakeet/Views/Settings/Components/EngineOptionTile.swift
@@ -17,6 +17,7 @@ struct EngineOptionTile: View {
     let modelStatus: SettingsViewModel.LocalModelStatus
     let isSelected: Bool
     let isBusy: Bool
+    var unavailableReason: String?
     /// When the model is downloaded but has never paid its one-time on-device
     /// optimize, the next load is slow (minutes). Splits the `.notLoaded`
     /// footer into a cold "Setup needed" vs warm "Downloaded" presentation.
@@ -60,16 +61,20 @@ struct EngineOptionTile: View {
             .contentShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius))
         }
         .buttonStyle(.plain)
-        .disabled(isBusy)
-        .help(helpText)
+        .disabled(isBusy || isUnavailable)
+        .help(unavailableReason ?? helpText)
         .onHover { hovering in
             withAnimation(DesignSystem.Animation.hoverTransition) {
                 isHovered = hovering
             }
         }
         .accessibilityLabel("\(name) engine. \(tagline).")
-        .accessibilityHint(helpText)
+        .accessibilityHint(unavailableReason ?? helpText)
         .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    private var isUnavailable: Bool {
+        !isSelected && unavailableReason != nil
     }
 
     private func handleTileTap() {
@@ -107,7 +112,11 @@ struct EngineOptionTile: View {
     }
 
     private var statusFooter: some View {
-        let info = StatusInfo.from(modelStatus, needsFirstOptimize: needsFirstOptimize)
+        let info = StatusInfo.from(
+            modelStatus,
+            needsFirstOptimize: needsFirstOptimize,
+            unavailableReason: isUnavailable ? unavailableReason : nil
+        )
         return HStack(alignment: .center, spacing: DesignSystem.Spacing.xs) {
             Circle()
                 .fill(info.color)
@@ -118,8 +127,9 @@ struct EngineOptionTile: View {
             Text(info.detail)
                 .font(DesignSystem.Typography.micro)
                 .foregroundStyle(DesignSystem.Colors.textSecondary)
-                .lineLimit(1)
+                .lineLimit(isUnavailable ? 2 : 1)
                 .truncationMode(.tail)
+                .fixedSize(horizontal: false, vertical: isUnavailable)
             Spacer(minLength: DesignSystem.Spacing.xs)
         }
         .padding(.top, DesignSystem.Spacing.xs)
@@ -128,14 +138,24 @@ struct EngineOptionTile: View {
 
     private var background: some View {
         RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
-            .fill(isSelected
-                  ? DesignSystem.Colors.accent.opacity(0.13)
-                  : DesignSystem.Colors.surfaceElevated.opacity(isHovered ? 0.7 : 0.4))
+            .fill(backgroundColor)
+    }
+
+    private var backgroundColor: Color {
+        if isSelected {
+            return DesignSystem.Colors.accent.opacity(0.13)
+        }
+        if isUnavailable {
+            return DesignSystem.Colors.surfaceElevated.opacity(0.25)
+        }
+        return DesignSystem.Colors.surfaceElevated.opacity(isHovered ? 0.7 : 0.4)
     }
 
     private var border: some View {
         let strokeColor: Color = if isSelected {
             DesignSystem.Colors.accent.opacity(0.8)
+        } else if isUnavailable {
+            DesignSystem.Colors.border.opacity(0.45)
         } else if isHovered {
             DesignSystem.Colors.accent.opacity(0.3)
         } else {
@@ -153,8 +173,16 @@ struct EngineOptionTile: View {
 
         static func from(
             _ status: SettingsViewModel.LocalModelStatus,
-            needsFirstOptimize: Bool = false
+            needsFirstOptimize: Bool = false,
+            unavailableReason: String? = nil
         ) -> StatusInfo {
+            if let unavailableReason {
+                return StatusInfo(
+                    color: DesignSystem.Colors.textSecondary,
+                    label: "Unavailable",
+                    detail: unavailableReason
+                )
+            }
             switch status {
             case .ready:
                 return StatusInfo(

--- a/Sources/MacParakeet/Views/Settings/Components/EngineOptionTile.swift
+++ b/Sources/MacParakeet/Views/Settings/Components/EngineOptionTile.swift
@@ -17,7 +17,7 @@ struct EngineOptionTile: View {
     let modelStatus: SettingsViewModel.LocalModelStatus
     let isSelected: Bool
     let isBusy: Bool
-    var unavailableReason: String?
+    let unavailableReason: String?
     /// When the model is downloaded but has never paid its one-time on-device
     /// optimize, the next load is slow (minutes). Splits the `.notLoaded`
     /// footer into a cold "Setup needed" vs warm "Downloaded" presentation.
@@ -350,6 +350,7 @@ struct EngineDownloadBanner: View {
                 modelStatus: .ready,
                 isSelected: true,
                 isBusy: false,
+                unavailableReason: nil,
                 onSelect: {}
             )
 
@@ -366,6 +367,7 @@ struct EngineDownloadBanner: View {
                 modelStatus: .notDownloaded,
                 isSelected: false,
                 isBusy: false,
+                unavailableReason: nil,
                 onSelect: {}
             )
         }

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -116,6 +116,7 @@ struct SettingsView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             viewModel.refreshPermissions()
+            viewModel.refreshSpeechEngineSwitchAvailability()
             Task { await viewModel.refreshCalendarNotificationAuthorization() }
         }
         .onAppear {
@@ -1546,6 +1547,7 @@ struct SettingsView: View {
                         modelStatus: displayedParakeetModelStatus,
                         isSelected: viewModel.speechEnginePreference == .parakeet,
                         isBusy: viewModel.speechEngineSwitching,
+                        unavailableReason: engineSwitchUnavailableReason(for: .parakeet),
                         onSelect: { selectEngine(.parakeet) }
                     )
 
@@ -1562,6 +1564,7 @@ struct SettingsView: View {
                         modelStatus: displayedWhisperModelStatus,
                         isSelected: viewModel.speechEnginePreference == .whisper,
                         isBusy: viewModel.speechEngineSwitching,
+                        unavailableReason: engineSwitchUnavailableReason(for: .whisper),
                         needsFirstOptimize: displayedWhisperModelStatus == .notLoaded
                             && !viewModel.whisperHasBeenOptimized,
                         onSelect: { handleWhisperTileTap() }
@@ -1680,6 +1683,11 @@ struct SettingsView: View {
         viewModel.speechEngineSwitchTarget ?? viewModel.speechEnginePreference
     }
 
+    private func engineSwitchUnavailableReason(for engine: SpeechEnginePreference) -> String? {
+        guard viewModel.speechEnginePreference != engine else { return nil }
+        return viewModel.speechEngineSwitchUnavailableMessage
+    }
+
     private var displayedParakeetModelStatus: SettingsViewModel.LocalModelStatus {
         guard viewModel.speechEngineSwitching,
               currentSpeechEngineSwitchTarget == .parakeet else {
@@ -1749,8 +1757,15 @@ struct SettingsView: View {
     private func selectEngine(_ engine: SpeechEnginePreference) {
         guard viewModel.speechEnginePreference != engine,
               !viewModel.speechEngineSwitching else { return }
-        withAnimation(DesignSystem.Animation.contentSwap) {
-            viewModel.speechEnginePreference = engine
+        Task { @MainActor in
+            let availability = await viewModel.refreshSpeechEngineSwitchAvailabilityNow()
+            guard availability == .available else {
+                viewModel.speechEngineError = SettingsViewModel.speechEngineSwitchUnavailableMessage(for: availability)
+                return
+            }
+            withAnimation(DesignSystem.Animation.contentSwap) {
+                viewModel.speechEnginePreference = engine
+            }
         }
     }
 

--- a/Sources/MacParakeetCore/STT/STTClient.swift
+++ b/Sources/MacParakeetCore/STT/STTClient.swift
@@ -7,7 +7,7 @@ import Foundation
 ///   bypassing the process-wide singleton that ADR-016 requires.
 ///   **App code must never instantiate this type directly.**
 ///   Use the shared ``STTScheduler`` from `AppEnvironment` instead.
-public actor STTClient: STTManaging, SpeechEngineRoutedTranscribing, SpeechEngineSwitching, SpeechEngineSessionManaging {
+public actor STTClient: STTManaging, SpeechEngineRoutedTranscribing, SpeechEngineSwitching, SpeechEngineSwitchAvailabilityProviding, SpeechEngineSessionManaging {
     private let scheduler: STTScheduler
 
     public init(modelVersion: AsrModelVersion = .v3) {
@@ -74,6 +74,10 @@ public actor STTClient: STTManaging, SpeechEngineRoutedTranscribing, SpeechEngin
         onProgress: (@Sendable (String) -> Void)?
     ) async throws {
         try await scheduler.setSpeechEngine(preference, onProgress: onProgress)
+    }
+
+    public func engineSwitchAvailability() async -> SpeechEngineSwitchAvailability {
+        await scheduler.engineSwitchAvailability()
     }
 
     public func beginSpeechEngineSession() async -> SpeechEngineLease {

--- a/Sources/MacParakeetCore/STT/STTClientProtocol.swift
+++ b/Sources/MacParakeetCore/STT/STTClientProtocol.swift
@@ -52,6 +52,18 @@ public protocol SpeechEngineSwitching: Sendable {
     ) async throws
 }
 
+public enum SpeechEngineSwitchAvailability: Sendable, Equatable {
+    case available
+    case meetingActive
+    case transcribing
+    case switchInProgress
+    case unavailable
+}
+
+public protocol SpeechEngineSwitchAvailabilityProviding: Sendable {
+    func engineSwitchAvailability() async -> SpeechEngineSwitchAvailability
+}
+
 extension SpeechEngineSwitching {
     public func setSpeechEngine(
         _ preference: SpeechEnginePreference,

--- a/Sources/MacParakeetCore/STT/STTScheduler.swift
+++ b/Sources/MacParakeetCore/STT/STTScheduler.swift
@@ -19,7 +19,7 @@ public enum STTSchedulerError: Error, LocalizedError, Equatable {
 ///
 /// Jobs execute independently per slot so dictation can remain responsive while
 /// meeting and file work share an explicitly prioritized background path.
-public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEngineSwitching, SpeechEngineSessionManaging {
+public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEngineSwitching, SpeechEngineSwitchAvailabilityProviding, SpeechEngineSessionManaging {
     private struct ScheduledJob: Sendable {
         let id: UUID
         let audioPath: String
@@ -205,6 +205,22 @@ public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEn
                 switchTask.cancel()
             }
         }
+    }
+
+    public func engineSwitchAvailability() async -> SpeechEngineSwitchAvailability {
+        if speechEngineSwitchTask != nil {
+            return .switchInProgress
+        }
+        if !activeSpeechEngineSessionIDs.isEmpty {
+            return .meetingActive
+        }
+        if hasQueuedOrRunningJobs {
+            return .transcribing
+        }
+        if !acceptsNewJobs {
+            return .unavailable
+        }
+        return .available
     }
 
     public func beginSpeechEngineSession() async -> SpeechEngineLease {

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -639,7 +639,7 @@ public enum TelemetryEventSpec: Sendable {
         durationSeconds: Double,
         blockedReason: TelemetrySpeechEngineSwitchBlockedReason?,
         errorType: String?,
-        wasCold: Bool? = nil
+        wasCold: Bool
     )
     // Lifecycle actions
     case feedbackSubmitted(category: String)
@@ -1301,7 +1301,7 @@ extension TelemetryEventSpec {
                 ("duration_seconds", Self.format(durationSeconds)),
                 ("blocked_reason", blockedReason?.rawValue),
                 ("error_type", errorType),
-                ("was_cold", wasCold.map(Self.boolString))
+                ("was_cold", Self.boolString(wasCold))
             )
         case .feedbackSubmitted(let category):
             return ["category": category]

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -182,6 +182,10 @@ public enum TelemetryModelOperationStage: String, Sendable, Equatable {
 public enum TelemetrySpeechEngineSwitchBlockedReason: String, Sendable, Equatable {
     case modelNotDownloaded = "model_not_downloaded"
     case engineBusy = "engine_busy"
+    case meetingActive = "meeting_active"
+    case transcribing
+    case switchInProgress = "switch_in_progress"
+    case unavailable
 }
 
 public enum TelemetryCopySource: String, Sendable, Equatable {
@@ -634,7 +638,8 @@ public enum TelemetryEventSpec: Sendable {
         outcome: ObservabilityOutcome,
         durationSeconds: Double,
         blockedReason: TelemetrySpeechEngineSwitchBlockedReason?,
-        errorType: String?
+        errorType: String?,
+        wasCold: Bool? = nil
     )
     // Lifecycle actions
     case feedbackSubmitted(category: String)
@@ -1283,7 +1288,8 @@ extension TelemetryEventSpec {
             let outcome,
             let durationSeconds,
             let blockedReason,
-            let errorType
+            let errorType,
+            let wasCold
         ):
             return Self.compactProps(
                 ("operation_id", operationID),
@@ -1294,7 +1300,8 @@ extension TelemetryEventSpec {
                 ("outcome", outcome.rawValue),
                 ("duration_seconds", Self.format(durationSeconds)),
                 ("blocked_reason", blockedReason?.rawValue),
-                ("error_type", errorType)
+                ("error_type", errorType),
+                ("was_cold", wasCold.map(Self.boolString))
             )
         case .feedbackSubmitted(let category):
             return ["category": category]
@@ -1605,7 +1612,7 @@ public enum TelemetryImplementedContract {
         .modelDownloadCompleted: ["duration_seconds"],
         .modelDownloadFailed: ["error_type"],
         .modelOperation: ["operation_id", "action", "outcome", "duration_seconds"],
-        .speechEngineSwitchOperation: ["operation_id", "from_engine", "to_engine", "outcome", "duration_seconds"],
+        .speechEngineSwitchOperation: ["operation_id", "from_engine", "to_engine", "outcome", "duration_seconds", "was_cold"],
         .feedbackSubmitted: ["category"],
         .feedbackOperation: ["operation_id", "category", "outcome", "duration_seconds", "screenshot_attached", "system_info_included"],
         .transcriptionDeleted: [],

--- a/Sources/MacParakeetCore/SpeechEnginePreference.swift
+++ b/Sources/MacParakeetCore/SpeechEnginePreference.swift
@@ -81,6 +81,11 @@ public enum SpeechEnginePreference: String, CaseIterable, Codable, Sendable {
         return optimized.contains(normalized)
     }
 
+    public static func isColdSwitch(to preference: SpeechEnginePreference, defaults: UserDefaults = .standard) -> Bool {
+        guard preference == .whisper else { return false }
+        return !hasOptimizedWhisper(variant: whisperModelVariant(defaults: defaults), defaults: defaults)
+    }
+
     /// Records that `variant` finished its one-time optimize on this Mac.
     /// Idempotent; call after a successful `WhisperEngine.prepare()`.
     public static func markWhisperOptimized(variant: String, defaults: UserDefaults = .standard) {

--- a/Sources/MacParakeetViewModels/OnboardingViewModel.swift
+++ b/Sources/MacParakeetViewModels/OnboardingViewModel.swift
@@ -652,11 +652,7 @@ public final class OnboardingViewModel {
 
         let previousPreference = SpeechEnginePreference.current(defaults: defaults)
         let operationContext = Observability.childOperationContext()
-        let modelVariant = SpeechEnginePreference.whisperModelVariant(defaults: defaults)
-        let switchWasCold = !SpeechEnginePreference.hasOptimizedWhisper(
-            variant: modelVariant,
-            defaults: defaults
-        )
+        let switchWasCold = SpeechEnginePreference.isColdSwitch(to: .whisper, defaults: defaults)
         engineState = .working(message: "Preparing Whisper for this Mac...", progress: nil)
 
         do {

--- a/Sources/MacParakeetViewModels/OnboardingViewModel.swift
+++ b/Sources/MacParakeetViewModels/OnboardingViewModel.swift
@@ -652,6 +652,11 @@ public final class OnboardingViewModel {
 
         let previousPreference = SpeechEnginePreference.current(defaults: defaults)
         let operationContext = Observability.childOperationContext()
+        let modelVariant = SpeechEnginePreference.whisperModelVariant(defaults: defaults)
+        let switchWasCold = !SpeechEnginePreference.hasOptimizedWhisper(
+            variant: modelVariant,
+            defaults: defaults
+        )
         engineState = .working(message: "Preparing Whisper for this Mac...", progress: nil)
 
         do {
@@ -680,7 +685,8 @@ public final class OnboardingViewModel {
                 outcome: .success,
                 durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
                 blockedReason: nil,
-                errorType: nil
+                errorType: nil,
+                wasCold: switchWasCold
             ))
         } catch {
             let errorType = TelemetryErrorClassifier.classify(error)
@@ -692,7 +698,8 @@ public final class OnboardingViewModel {
                 outcome: error is CancellationError ? .cancelled : .failure,
                 durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
                 blockedReason: Self.telemetrySpeechEngineSwitchBlockedReason(for: error),
-                errorType: errorType
+                errorType: errorType,
+                wasCold: switchWasCold
             ))
             throw error
         }

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -1276,7 +1276,7 @@ public final class SettingsViewModel {
         speechEngineError = nil
         let previousPreference = SpeechEnginePreference.current(defaults: defaults)
         let operationContext = Observability.childOperationContext()
-        let switchWasCold = Self.speechEngineSwitchWasCold(to: preference, defaults: defaults)
+        let switchWasCold = SpeechEnginePreference.isColdSwitch(to: preference, defaults: defaults)
 
         if preference == .whisper && !isWhisperModelDownloaded {
             speechEngineError = "Download the Whisper model before switching engines."
@@ -1516,17 +1516,6 @@ public final class SettingsViewModel {
         case .unavailable:
             return .unavailable
         }
-    }
-
-    private static func speechEngineSwitchWasCold(
-        to preference: SpeechEnginePreference,
-        defaults: UserDefaults
-    ) -> Bool {
-        guard preference == .whisper else { return false }
-        return !SpeechEnginePreference.hasOptimizedWhisper(
-            variant: SpeechEnginePreference.whisperModelVariant(defaults: defaults),
-            defaults: defaults
-        )
     }
 
     private static func initialSpeechEngineSwitchDetail(

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -268,6 +268,7 @@ public final class SettingsViewModel {
     public var speechEngineSwitching = false
     public var speechEngineSwitchTarget: SpeechEnginePreference?
     public var speechEngineSwitchDetail: String?
+    public var speechEngineSwitchAvailability: SpeechEngineSwitchAvailability = .available
     public var speechEngineError: String?
     public var whisperModelStatus: LocalModelStatus = .unknown
     public var whisperModelStatusDetail: String = "Not checked yet."
@@ -432,6 +433,7 @@ public final class SettingsViewModel {
     private var launchAtLoginService: LaunchAtLoginControlling?
     private var sttClient: STTClientProtocol?
     private var speechEngineSwitcher: SpeechEngineSwitching?
+    private var speechEngineSwitchAvailabilityProvider: SpeechEngineSwitchAvailabilityProviding?
     private var meetingRecoveryService: MeetingRecordingRecoveryServicing?
     private var sharedMicStream: SharedMicrophoneStream?
     private let defaults: UserDefaults
@@ -758,6 +760,7 @@ public final class SettingsViewModel {
         snippetRepo: TextSnippetRepositoryProtocol? = nil,
         sttClient: STTClientProtocol? = nil,
         speechEngineSwitcher: SpeechEngineSwitching? = nil,
+        speechEngineSwitchAvailabilityProvider: SpeechEngineSwitchAvailabilityProviding? = nil,
         meetingRecoveryService: MeetingRecordingRecoveryServicing? = nil,
         sharedMicStream: SharedMicrophoneStream? = nil
     ) {
@@ -772,6 +775,9 @@ public final class SettingsViewModel {
         self.snippetRepo = snippetRepo
         self.sttClient = sttClient
         self.speechEngineSwitcher = speechEngineSwitcher
+        self.speechEngineSwitchAvailabilityProvider = speechEngineSwitchAvailabilityProvider
+            ?? (speechEngineSwitcher as? SpeechEngineSwitchAvailabilityProviding)
+            ?? (sttClient as? SpeechEngineSwitchAvailabilityProviding)
         self.meetingRecoveryService = meetingRecoveryService
         self.sharedMicStream = sharedMicStream
         refreshLaunchAtLoginStatus()
@@ -779,6 +785,7 @@ public final class SettingsViewModel {
         refreshStats()
         refreshEntitlements()
         refreshModelStatus()
+        refreshSpeechEngineSwitchAvailability()
         refreshPendingMeetingRecoveries()
     }
 
@@ -977,12 +984,14 @@ public final class SettingsViewModel {
     public func startPermissionPolling() {
         guard permissionPollingTask == nil else { return }
         refreshPermissions()
+        refreshSpeechEngineSwitchAvailability()
         permissionPollingTask = Task { [weak self] in
             guard let self else { return }
             while !Task.isCancelled {
                 try? await Task.sleep(for: self.permissionPollingInterval)
                 guard !Task.isCancelled else { break }
                 self.refreshPermissions()
+                self.refreshSpeechEngineSwitchAvailability()
             }
         }
     }
@@ -1004,6 +1013,44 @@ public final class SettingsViewModel {
         let (count, sizeBytes) = youtubeDownloadStats()
         youtubeDownloadCount = count
         youtubeDownloadStorageMB = Double(sizeBytes) / (1024.0 * 1024.0)
+    }
+
+    public func refreshSpeechEngineSwitchAvailability() {
+        Task { @MainActor [weak self] in
+            _ = await self?.refreshSpeechEngineSwitchAvailabilityNow()
+        }
+    }
+
+    @discardableResult
+    public func refreshSpeechEngineSwitchAvailabilityNow() async -> SpeechEngineSwitchAvailability {
+        guard let speechEngineSwitchAvailabilityProvider else {
+            speechEngineSwitchAvailability = .available
+            return .available
+        }
+        let availability = await speechEngineSwitchAvailabilityProvider.engineSwitchAvailability()
+        speechEngineSwitchAvailability = availability
+        return availability
+    }
+
+    public var speechEngineSwitchUnavailableMessage: String? {
+        Self.speechEngineSwitchUnavailableMessage(for: speechEngineSwitchAvailability)
+    }
+
+    public static func speechEngineSwitchUnavailableMessage(
+        for availability: SpeechEngineSwitchAvailability
+    ) -> String? {
+        switch availability {
+        case .available:
+            return nil
+        case .meetingActive:
+            return "Stop the meeting recording to switch engines"
+        case .transcribing:
+            return "Finishing transcription — switch when it completes"
+        case .switchInProgress:
+            return "Finishing engine switch — try again in a moment"
+        case .unavailable:
+            return "Speech engine is temporarily unavailable"
+        }
     }
 
     public func refreshEntitlements() {
@@ -1229,6 +1276,7 @@ public final class SettingsViewModel {
         speechEngineError = nil
         let previousPreference = SpeechEnginePreference.current(defaults: defaults)
         let operationContext = Observability.childOperationContext()
+        let switchWasCold = Self.speechEngineSwitchWasCold(to: preference, defaults: defaults)
 
         if preference == .whisper && !isWhisperModelDownloaded {
             speechEngineError = "Download the Whisper model before switching engines."
@@ -1240,7 +1288,8 @@ public final class SettingsViewModel {
                 outcome: .unavailable,
                 durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
                 blockedReason: .modelNotDownloaded,
-                errorType: "model_not_downloaded"
+                errorType: "model_not_downloaded",
+                wasCold: switchWasCold
             ))
             isApplyingSpeechEngineState = true
             speechEnginePreference = .parakeet
@@ -1258,7 +1307,8 @@ public final class SettingsViewModel {
                 outcome: .success,
                 durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
                 blockedReason: nil,
-                errorType: nil
+                errorType: nil,
+                wasCold: switchWasCold
             ))
             return
         }
@@ -1277,6 +1327,26 @@ public final class SettingsViewModel {
                 self.speechEngineSwitchDetail = nil
                 self.refreshModelStatus()
             }
+            let availability = await self.refreshSpeechEngineSwitchAvailabilityNow()
+            guard availability == .available else {
+                let blockedReason = Self.telemetrySpeechEngineSwitchBlockedReason(for: availability)
+                self.speechEngineError = Self.speechEngineSwitchUnavailableMessage(for: availability)
+                Telemetry.send(.speechEngineSwitchOperation(
+                    operationID: operationContext.operationID,
+                    operationContext: operationContext,
+                    fromEngine: previousPreference,
+                    toEngine: preference,
+                    outcome: .unavailable,
+                    durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
+                    blockedReason: blockedReason,
+                    errorType: blockedReason?.rawValue,
+                    wasCold: switchWasCold
+                ))
+                self.isApplyingSpeechEngineState = true
+                self.speechEnginePreference = SpeechEnginePreference.current(defaults: self.defaults)
+                self.isApplyingSpeechEngineState = false
+                return
+            }
             do {
                 try await Observability.withOperationContext(operationContext) {
                     try await speechEngineSwitcher.setSpeechEngine(preference) { [weak self] message in
@@ -1294,7 +1364,8 @@ public final class SettingsViewModel {
                     outcome: .success,
                     durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
                     blockedReason: nil,
-                    errorType: nil
+                    errorType: nil,
+                    wasCold: switchWasCold
                 ))
             } catch is CancellationError {
                 Telemetry.send(.speechEngineSwitchOperation(
@@ -1305,7 +1376,8 @@ public final class SettingsViewModel {
                     outcome: .cancelled,
                     durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
                     blockedReason: nil,
-                    errorType: "CancellationError"
+                    errorType: "CancellationError",
+                    wasCold: switchWasCold
                 ))
                 self.isApplyingSpeechEngineState = true
                 self.speechEnginePreference = SpeechEnginePreference.current(defaults: self.defaults)
@@ -1321,7 +1393,8 @@ public final class SettingsViewModel {
                     outcome: .failure,
                     durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
                     blockedReason: Self.telemetrySpeechEngineSwitchBlockedReason(for: error),
-                    errorType: errorType
+                    errorType: errorType,
+                    wasCold: switchWasCold
                 ))
                 self.isApplyingSpeechEngineState = true
                 self.speechEnginePreference = SpeechEnginePreference.current(defaults: self.defaults)
@@ -1426,6 +1499,34 @@ public final class SettingsViewModel {
              .invalidResponse:
             return nil
         }
+    }
+
+    private static func telemetrySpeechEngineSwitchBlockedReason(
+        for availability: SpeechEngineSwitchAvailability
+    ) -> TelemetrySpeechEngineSwitchBlockedReason? {
+        switch availability {
+        case .available:
+            return nil
+        case .meetingActive:
+            return .meetingActive
+        case .transcribing:
+            return .transcribing
+        case .switchInProgress:
+            return .switchInProgress
+        case .unavailable:
+            return .unavailable
+        }
+    }
+
+    private static func speechEngineSwitchWasCold(
+        to preference: SpeechEnginePreference,
+        defaults: UserDefaults
+    ) -> Bool {
+        guard preference == .whisper else { return false }
+        return !SpeechEnginePreference.hasOptimizedWhisper(
+            variant: SpeechEnginePreference.whisperModelVariant(defaults: defaults),
+            defaults: defaults
+        )
     }
 
     private static func initialSpeechEngineSwitchDetail(

--- a/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
+++ b/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
@@ -184,6 +184,71 @@ final class STTSchedulerTests: XCTestCase {
         XCTAssertEqual(count, 1)
     }
 
+    func testEngineSwitchAvailabilityReportsAvailableWhenIdle() async {
+        let runtime = MockSTTRuntime()
+        let scheduler = STTScheduler(runtimeProvider: runtime)
+
+        let availability = await scheduler.engineSwitchAvailability()
+
+        XCTAssertEqual(availability, .available)
+    }
+
+    func testEngineSwitchAvailabilityReportsMeetingActiveForSessionLease() async {
+        let runtime = MockSTTRuntime()
+        let scheduler = STTScheduler(runtimeProvider: runtime)
+
+        let lease = await scheduler.beginSpeechEngineSession()
+
+        let availability = await scheduler.engineSwitchAvailability()
+        XCTAssertEqual(availability, .meetingActive)
+
+        await scheduler.endSpeechEngineSession(lease)
+    }
+
+    func testEngineSwitchAvailabilityReportsTranscribingForActiveJob() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.block(path: "active")
+        let scheduler = STTScheduler(runtimeProvider: runtime)
+
+        let activeTask = Task {
+            try await scheduler.transcribe(audioPath: "active", job: .fileTranscription)
+        }
+        try await waitForStartedPaths(runtime: runtime, count: 1)
+
+        let availability = await scheduler.engineSwitchAvailability()
+        XCTAssertEqual(availability, .transcribing)
+
+        await runtime.release(path: "active")
+        _ = try await activeTask.value
+    }
+
+    func testEngineSwitchAvailabilityReportsSwitchInProgress() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.blockNextSpeechEngineSwitch()
+        let scheduler = STTScheduler(runtimeProvider: runtime)
+
+        let switchTask = Task {
+            try await scheduler.setSpeechEngine(.whisper)
+        }
+        try await waitForSpeechEngineSwitch(runtime: runtime, count: 1)
+
+        let availability = await scheduler.engineSwitchAvailability()
+        XCTAssertEqual(availability, .switchInProgress)
+
+        await runtime.releaseSpeechEngineSwitch()
+        _ = try await switchTask.value
+    }
+
+    func testEngineSwitchAvailabilityReportsUnavailableAfterShutdown() async {
+        let runtime = MockSTTRuntime()
+        let scheduler = STTScheduler(runtimeProvider: runtime)
+
+        await scheduler.shutdown()
+
+        let availability = await scheduler.engineSwitchAvailability()
+        XCTAssertEqual(availability, .unavailable)
+    }
+
     func testSpeechEngineSessionWaitsForInFlightEngineSwitch() async throws {
         let runtime = MockSTTRuntime()
         await runtime.blockNextSpeechEngineSwitch()

--- a/Tests/MacParakeetTests/STT/SpeechEnginePreferenceTests.swift
+++ b/Tests/MacParakeetTests/STT/SpeechEnginePreferenceTests.swift
@@ -78,4 +78,18 @@ final class SpeechEnginePreferenceTests: XCTestCase {
         XCTAssertTrue(SpeechEnginePreference.hasOptimizedWhisper(variant: "large-v3-turbo", defaults: defaults))
         XCTAssertFalse(SpeechEnginePreference.hasOptimizedWhisper(variant: "small", defaults: defaults))
     }
+
+    func testColdSwitchOnlyAppliesToUnoptimizedActiveWhisperVariant() {
+        let (defaults, suite) = makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        SpeechEnginePreference.saveWhisperModelVariant("small", defaults: defaults)
+
+        XCTAssertFalse(SpeechEnginePreference.isColdSwitch(to: .parakeet, defaults: defaults))
+        XCTAssertTrue(SpeechEnginePreference.isColdSwitch(to: .whisper, defaults: defaults))
+
+        SpeechEnginePreference.markWhisperOptimized(variant: "small", defaults: defaults)
+
+        XCTAssertFalse(SpeechEnginePreference.isColdSwitch(to: .whisper, defaults: defaults))
+    }
 }

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -750,7 +750,8 @@ final class TelemetryServiceTests: XCTestCase {
                 outcome: .unavailable,
                 durationSeconds: 0.1,
                 blockedReason: .modelNotDownloaded,
-                errorType: "model_not_downloaded"
+                errorType: "model_not_downloaded",
+                wasCold: true
             ),
             appVer: "0.4.2",
             osVer: "15.3",
@@ -773,6 +774,7 @@ final class TelemetryServiceTests: XCTestCase {
         XCTAssertEqual(props["duration_seconds"], "0.1")
         XCTAssertEqual(props["blocked_reason"], "model_not_downloaded")
         XCTAssertEqual(props["error_type"], "model_not_downloaded")
+        XCTAssertEqual(props["was_cold"], "true")
     }
 
     func testOperationContextSerializesWorkflowParentAndStage() throws {
@@ -1331,7 +1333,8 @@ final class TelemetryServiceTests: XCTestCase {
                 outcome: .success,
                 durationSeconds: 1.1,
                 blockedReason: nil,
-                errorType: nil
+                errorType: nil,
+                wasCold: true
             ),
             .feedbackOperation(
                 operationID: "op-feedback",

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -1235,7 +1235,7 @@ final class SettingsViewModelTests: XCTestCase {
         let outcome: ObservabilityOutcome
         let blockedReason: TelemetrySpeechEngineSwitchBlockedReason?
         let errorType: String?
-        let wasCold: Bool?
+        let wasCold: Bool
     }
 
     private func speechEngineSwitchEvents(

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -1057,6 +1057,86 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.speechEngineError)
     }
 
+    func testRefreshSpeechEngineSwitchAvailabilityStoresProviderResult() async {
+        let provider = MockSpeechEngineSwitchAvailabilityProvider(.transcribing)
+        viewModel.configure(
+            permissionService: mockPermissions,
+            dictationRepo: mockRepo,
+            entitlementsService: entitlements,
+            checkoutURL: nil,
+            speechEngineSwitchAvailabilityProvider: provider
+        )
+
+        let availability = await viewModel.refreshSpeechEngineSwitchAvailabilityNow()
+
+        XCTAssertEqual(availability, .transcribing)
+        XCTAssertEqual(viewModel.speechEngineSwitchAvailability, .transcribing)
+        XCTAssertEqual(
+            SettingsViewModel.speechEngineSwitchUnavailableMessage(for: .transcribing),
+            "Finishing transcription — switch when it completes"
+        )
+    }
+
+    func testSpeechEngineChangeBlockedByAvailabilityShowsReasonAndTelemetry() async throws {
+        let telemetry = SettingsTelemetrySpy()
+        Telemetry.configure(telemetry)
+        let switcher = MockSpeechEngineSwitcher()
+        let provider = MockSpeechEngineSwitchAvailabilityProvider(.meetingActive)
+        viewModel.whisperModelStatus = .notLoaded
+        viewModel.configure(
+            permissionService: mockPermissions,
+            dictationRepo: mockRepo,
+            entitlementsService: entitlements,
+            checkoutURL: nil,
+            speechEngineSwitcher: switcher,
+            speechEngineSwitchAvailabilityProvider: provider
+        )
+
+        viewModel.whisperModelStatus = .notLoaded
+        viewModel.speechEnginePreference = .whisper
+        try await waitForSpeechEngineSwitchingToFinish()
+
+        XCTAssertEqual(viewModel.speechEnginePreference, .parakeet)
+        XCTAssertEqual(SpeechEnginePreference.current(defaults: testDefaults), .parakeet)
+        XCTAssertEqual(viewModel.speechEngineError, "Stop the meeting recording to switch engines")
+        let preferences = await switcher.preferences
+        XCTAssertTrue(preferences.isEmpty)
+
+        let event = try XCTUnwrap(speechEngineSwitchEvents(in: telemetry.snapshot()).last)
+        XCTAssertEqual(event.fromEngine, .parakeet)
+        XCTAssertEqual(event.toEngine, .whisper)
+        XCTAssertEqual(event.outcome, .unavailable)
+        XCTAssertEqual(event.blockedReason, .meetingActive)
+        XCTAssertEqual(event.errorType, "meeting_active")
+        XCTAssertEqual(event.wasCold, true)
+    }
+
+    func testSpeechEngineChangeTelemetryMarksColdWhisperSwitch() async throws {
+        let telemetry = SettingsTelemetrySpy()
+        Telemetry.configure(telemetry)
+        let switcher = MockSpeechEngineSwitcher()
+        viewModel.whisperModelStatus = .notLoaded
+        viewModel.configure(
+            permissionService: mockPermissions,
+            dictationRepo: mockRepo,
+            entitlementsService: entitlements,
+            checkoutURL: nil,
+            speechEngineSwitcher: switcher
+        )
+
+        viewModel.whisperModelStatus = .notLoaded
+        viewModel.speechEnginePreference = .whisper
+        try await waitForSpeechEngineSwitchingToFinish()
+
+        let event = try XCTUnwrap(speechEngineSwitchEvents(in: telemetry.snapshot()).last)
+        XCTAssertEqual(event.fromEngine, .parakeet)
+        XCTAssertEqual(event.toEngine, .whisper)
+        XCTAssertEqual(event.outcome, .success)
+        XCTAssertNil(event.blockedReason)
+        XCTAssertNil(event.errorType)
+        XCTAssertEqual(event.wasCold, true)
+    }
+
     func testSpeechEngineChangeShowsProgressAndClearsWhenDone() async throws {
         let switcher = MockSpeechEngineSwitcher(progressMessages: ["Optimizing Whisper for this Mac..."])
         await switcher.blockNextSwitch()
@@ -1146,6 +1226,43 @@ final class SettingsViewModelTests: XCTestCase {
                 return
             }
             try await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
+    private struct SpeechEngineSwitchEventSnapshot {
+        let fromEngine: SpeechEnginePreference
+        let toEngine: SpeechEnginePreference
+        let outcome: ObservabilityOutcome
+        let blockedReason: TelemetrySpeechEngineSwitchBlockedReason?
+        let errorType: String?
+        let wasCold: Bool?
+    }
+
+    private func speechEngineSwitchEvents(
+        in events: [TelemetryEventSpec]
+    ) -> [SpeechEngineSwitchEventSnapshot] {
+        events.compactMap { event in
+            guard case .speechEngineSwitchOperation(
+                operationID: _,
+                operationContext: _,
+                fromEngine: let fromEngine,
+                toEngine: let toEngine,
+                outcome: let outcome,
+                durationSeconds: _,
+                blockedReason: let blockedReason,
+                errorType: let errorType,
+                wasCold: let wasCold
+            ) = event else {
+                return nil
+            }
+            return SpeechEngineSwitchEventSnapshot(
+                fromEngine: fromEngine,
+                toEngine: toEngine,
+                outcome: outcome,
+                blockedReason: blockedReason,
+                errorType: errorType,
+                wasCold: wasCold
+            )
         }
     }
 
@@ -1355,6 +1472,22 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertFalse(vm2.saveAudioRecordings)
         XCTAssertFalse(vm2.saveTranscriptionAudio)
         XCTAssertTrue(vm2.speakerDiarization)
+    }
+}
+
+private actor MockSpeechEngineSwitchAvailabilityProvider: SpeechEngineSwitchAvailabilityProviding {
+    private var availability: SpeechEngineSwitchAvailability
+
+    init(_ availability: SpeechEngineSwitchAvailability) {
+        self.availability = availability
+    }
+
+    func setAvailability(_ availability: SpeechEngineSwitchAvailability) {
+        self.availability = availability
+    }
+
+    func engineSwitchAvailability() async -> SpeechEngineSwitchAvailability {
+        availability
     }
 }
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -354,7 +354,7 @@ events remain useful for diarization-specific timing and failure analysis.
 | `model_download_completed` | `duration_seconds`, `model_kind`, `speech_engine`, `engine_variant` | How long do model downloads take by engine/model? |
 | `model_download_failed` | `error_type`, `model_kind`, `speech_engine`, `engine_variant` | Are downloads failing for Parakeet setup or Whisper downloads? |
 | `model_operation` | `operation_id`, `workflow_id`, `parent_operation_id`, `action`, `outcome`, `stage`, `model_kind`, `speech_engine`, `engine_variant`, `duration_seconds`, `error_type` | Canonical model lifecycle event for downloads, warm-up, repairs, cache clears, and cancellations |
-| `speech_engine_switch_operation` | `operation_id`, `workflow_id`, `parent_operation_id`, `from_engine`, `to_engine`, `outcome`, `duration_seconds`, `blocked_reason`, `error_type` | Why engine switches succeed, fail, cancel, or get blocked |
+| `speech_engine_switch_operation` | `operation_id`, `workflow_id`, `parent_operation_id`, `from_engine`, `to_engine`, `outcome`, `duration_seconds`, `blocked_reason`, `error_type`, `was_cold` | Why engine switches succeed, fail, cancel, or get blocked; whether Whisper switches are still paying first-use optimize cost |
 | `stt_runtime_unhealthy` | `reason` | Whether the STT runtime watchdog detects a stuck speech runtime |
 
 ### 8. Permissions — "Is onboarding smooth?"


### PR DESCRIPTION
## Summary
- Add `STTScheduler.engineSwitchAvailability()` and expose it through the Settings view-model boundary.
- Disable inactive engine tiles with named reasons when a meeting recording, transcription job, in-flight switch, or unavailable scheduler state blocks switching.
- Add `was_cold` to `speech_engine_switch_operation`, derived from the active Whisper variant optimization flag at switch time.
- Keep Stage B background optimize/cancel work out of scope.

## Companion
- Website telemetry handling: https://github.com/moona3k/macparakeet-website/pull/11

## Merge Note
- PR #338 also touches telemetry docs/tests. If it lands first, this PR may need a small conflict resolution around `TelemetryEvent.swift`, `TelemetryServiceTests.swift`, and `docs/telemetry.md`.

## Validation
- `swift test --filter TelemetryServiceTests`
- `swift test`
- `git diff --check`
