### PR TITLE
Block duplicate dictation hotkeys

### DIFF
--- a/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
+++ b/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
@@ -117,7 +117,7 @@ final class AppHotkeyCoordinator {
             return "Dictation Shortcuts: Disabled"
         }
         if !handsFree.isDisabled, handsFree == pushToTalk {
-            return "Dictation: Hold \(pushToTalk.displayName) / Double-tap \(handsFree.displayName)"
+            return "Dictation Shortcuts: Conflict on \(handsFree.displayName)"
         }
         if handsFree.isDisabled {
             return "Push-to-talk: Hold \(pushToTalk.displayName)"
@@ -137,18 +137,6 @@ final class AppHotkeyCoordinator {
         }
 
         if !handsFreeTrigger.isDisabled, !pushToTalkTrigger.isDisabled {
-            if handsFreeTrigger == pushToTalkTrigger {
-                return DictationHotkeyPlan(
-                    specs: [
-                        DictationHotkeyPlan.Spec(
-                            trigger: handsFreeTrigger,
-                            gestureMode: .doubleTapAndHold
-                        ),
-                    ],
-                    conflict: nil
-                )
-            }
-
             if handsFreeTrigger.overlaps(with: pushToTalkTrigger) {
                 return DictationHotkeyPlan(
                     specs: [

--- a/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
+++ b/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
@@ -116,8 +116,11 @@ final class AppHotkeyCoordinator {
         if handsFree.isDisabled && pushToTalk.isDisabled {
             return "Dictation Shortcuts: Disabled"
         }
-        if !handsFree.isDisabled, handsFree == pushToTalk {
-            return "Dictation Shortcuts: Conflict on \(handsFree.displayName)"
+        if handsFree.overlaps(with: pushToTalk) {
+            let conflictName = handsFree == pushToTalk
+                ? handsFree.displayName
+                : "\(handsFree.displayName) / \(pushToTalk.displayName)"
+            return "Dictation Shortcuts: Conflict on \(conflictName)"
         }
         if handsFree.isDisabled {
             return "Push-to-talk: Hold \(pushToTalk.displayName)"

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -21,8 +21,7 @@ enum SettingsDictationHotkeyConflictPolicy {
         peer: HotkeyTrigger,
         peerName: String
     ) -> HotkeyTrigger.ValidationResult? {
-        guard !candidate.isDisabled else { return nil }
-        guard candidate == peer || candidate.overlaps(with: peer) else { return nil }
+        guard candidate.overlaps(with: peer) else { return nil }
         return .blocked(SettingsHotkeyConflictMessage.blocked(
             conflictingWith: peerName,
             trigger: peer
@@ -32,11 +31,17 @@ enum SettingsDictationHotkeyConflictPolicy {
     static func existingConflictMessage(
         trigger: HotkeyTrigger,
         peer: HotkeyTrigger,
-        peerName: String
+        peerName: String,
+        disablesTrigger: Bool
     ) -> String? {
-        guard !trigger.isDisabled else { return nil }
-        guard trigger == peer || trigger.overlaps(with: peer) else { return nil }
-        return SettingsHotkeyConflictMessage.disabled(
+        guard trigger.overlaps(with: peer) else { return nil }
+        if disablesTrigger {
+            return SettingsHotkeyConflictMessage.disabled(
+                conflictingWith: peerName,
+                trigger: peer
+            )
+        }
+        return SettingsHotkeyConflictMessage.blocked(
             conflictingWith: peerName,
             trigger: peer
         )
@@ -1083,7 +1088,8 @@ struct SettingsView: View {
         if let conflict = SettingsDictationHotkeyConflictPolicy.existingConflictMessage(
             trigger: trigger,
             peer: viewModel.pushToTalkHotkeyTrigger,
-            peerName: "push to talk"
+            peerName: "push to talk",
+            disablesTrigger: false
         ) {
             return conflict
         }
@@ -1120,7 +1126,8 @@ struct SettingsView: View {
         if let conflict = SettingsDictationHotkeyConflictPolicy.existingConflictMessage(
             trigger: trigger,
             peer: viewModel.hotkeyTrigger,
-            peerName: "hands-free mode"
+            peerName: "hands-free mode",
+            disablesTrigger: true
         ) {
             return conflict
         }

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -15,6 +15,34 @@ enum SettingsHotkeyConflictMessage {
     }
 }
 
+enum SettingsDictationHotkeyConflictPolicy {
+    static func validation(
+        candidate: HotkeyTrigger,
+        peer: HotkeyTrigger,
+        peerName: String
+    ) -> HotkeyTrigger.ValidationResult? {
+        guard !candidate.isDisabled else { return nil }
+        guard candidate == peer || candidate.overlaps(with: peer) else { return nil }
+        return .blocked(SettingsHotkeyConflictMessage.blocked(
+            conflictingWith: peerName,
+            trigger: peer
+        ))
+    }
+
+    static func existingConflictMessage(
+        trigger: HotkeyTrigger,
+        peer: HotkeyTrigger,
+        peerName: String
+    ) -> String? {
+        guard !trigger.isDisabled else { return nil }
+        guard trigger == peer || trigger.overlaps(with: peer) else { return nil }
+        return SettingsHotkeyConflictMessage.disabled(
+            conflictingWith: peerName,
+            trigger: peer
+        )
+    }
+}
+
 struct SettingsView: View {
     @Bindable var viewModel: SettingsViewModel
     @Bindable var llmSettingsViewModel: LLMSettingsViewModel
@@ -528,12 +556,6 @@ struct SettingsView: View {
 
     // MARK: - Dictation
 
-    private var dictationShortcutsAreCombined: Bool {
-        let handsFree = viewModel.hotkeyTrigger
-        let pushToTalk = viewModel.pushToTalkHotkeyTrigger
-        return !handsFree.isDisabled && !pushToTalk.isDisabled && handsFree == pushToTalk
-    }
-
     private var dictationCard: some View {
         settingsCard(
             title: "Dictation",
@@ -568,9 +590,7 @@ struct SettingsView: View {
                 HStack(alignment: .center) {
                     rowText(
                         title: "Hands-free mode",
-                        detail: dictationShortcutsAreCombined
-                            ? "Double tap to start; tap once to stop."
-                            : "Tap to start; tap again to stop."
+                        detail: "Tap to start; tap again to stop."
                     )
                     Spacer(minLength: DesignSystem.Spacing.md)
                     VStack(alignment: .trailing, spacing: 4) {
@@ -948,12 +968,12 @@ struct SettingsView: View {
 
     private func dictationHotkeyValidation(for candidate: HotkeyTrigger) -> HotkeyTrigger.ValidationResult {
         guard !candidate.isDisabled else { return .allowed }
-        if candidate != viewModel.pushToTalkHotkeyTrigger,
-           candidate.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
-            return .blocked(SettingsHotkeyConflictMessage.blocked(
-                conflictingWith: "push to talk",
-                trigger: viewModel.pushToTalkHotkeyTrigger
-            ))
+        if let result = SettingsDictationHotkeyConflictPolicy.validation(
+            candidate: candidate,
+            peer: viewModel.pushToTalkHotkeyTrigger,
+            peerName: "push to talk"
+        ) {
+            return result
         }
         if AppFeatures.meetingRecordingEnabled,
            candidate.conflicts(with: viewModel.meetingHotkeyTrigger, selfMode: .bareModifierDictation) {
@@ -985,12 +1005,12 @@ struct SettingsView: View {
 
     private func pushToTalkHotkeyValidation(for candidate: HotkeyTrigger) -> HotkeyTrigger.ValidationResult {
         guard !candidate.isDisabled else { return .allowed }
-        if candidate != viewModel.hotkeyTrigger,
-           candidate.overlaps(with: viewModel.hotkeyTrigger) {
-            return .blocked(SettingsHotkeyConflictMessage.blocked(
-                conflictingWith: "hands-free mode",
-                trigger: viewModel.hotkeyTrigger
-            ))
+        if let result = SettingsDictationHotkeyConflictPolicy.validation(
+            candidate: candidate,
+            peer: viewModel.hotkeyTrigger,
+            peerName: "hands-free mode"
+        ) {
+            return result
         }
         if AppFeatures.meetingRecordingEnabled,
            candidate.conflicts(with: viewModel.meetingHotkeyTrigger, selfMode: .bareModifierDictation) {
@@ -1060,12 +1080,12 @@ struct SettingsView: View {
 
     private func dictationHotkeyConflictMessage(for trigger: HotkeyTrigger) -> String? {
         guard !trigger.isDisabled else { return nil }
-        if trigger != viewModel.pushToTalkHotkeyTrigger,
-           trigger.overlaps(with: viewModel.pushToTalkHotkeyTrigger) {
-            return SettingsHotkeyConflictMessage.disabled(
-                conflictingWith: "push to talk",
-                trigger: viewModel.pushToTalkHotkeyTrigger
-            )
+        if let conflict = SettingsDictationHotkeyConflictPolicy.existingConflictMessage(
+            trigger: trigger,
+            peer: viewModel.pushToTalkHotkeyTrigger,
+            peerName: "push to talk"
+        ) {
+            return conflict
         }
         if AppFeatures.meetingRecordingEnabled,
            trigger.conflicts(with: viewModel.meetingHotkeyTrigger, selfMode: .bareModifierDictation) {
@@ -1097,12 +1117,12 @@ struct SettingsView: View {
 
     private func pushToTalkHotkeyConflictMessage(for trigger: HotkeyTrigger) -> String? {
         guard !trigger.isDisabled else { return nil }
-        if trigger != viewModel.hotkeyTrigger,
-           trigger.overlaps(with: viewModel.hotkeyTrigger) {
-            return SettingsHotkeyConflictMessage.disabled(
-                conflictingWith: "hands-free mode",
-                trigger: viewModel.hotkeyTrigger
-            )
+        if let conflict = SettingsDictationHotkeyConflictPolicy.existingConflictMessage(
+            trigger: trigger,
+            peer: viewModel.hotkeyTrigger,
+            peerName: "hands-free mode"
+        ) {
+            return conflict
         }
         if AppFeatures.meetingRecordingEnabled,
            trigger.conflicts(with: viewModel.meetingHotkeyTrigger, selfMode: .bareModifierDictation) {
@@ -2283,9 +2303,9 @@ struct SettingsView: View {
                 modeShortcutRow(
                     keys: [viewModel.hotkeyTrigger.shortSymbol],
                     separator: nil,
-                    verb: dictationShortcutsAreCombined ? "Double tap" : "Tap",
+                    verb: "Tap",
                     action: "Hands-free mode",
-                    detail: dictationShortcutsAreCombined ? "Tap once to stop" : "Tap again to stop"
+                    detail: "Tap again to stop"
                 )
             }
         }

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -704,10 +704,11 @@ public final class SettingsViewModel {
             if storedHandsFree.isDisabled {
                 return (.disabled, .disabled, false, true)
             }
+            let handsFree = defaultHandsFreeTrigger(avoiding: storedHandsFree)
             return (
+                handsFree,
                 storedHandsFree,
-                storedHandsFree,
-                false,
+                handsFree != storedHandsFree,
                 true
             )
         }
@@ -717,6 +718,14 @@ public final class SettingsViewModel {
             defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey,
             fallback: .defaultPushToTalk
         )
+        if !storedHandsFree.isDisabled,
+           !pushToTalk.isDisabled,
+           storedHandsFree == pushToTalk {
+            if storedHandsFree == .defaultDictation {
+                return (storedHandsFree, .defaultPushToTalk, false, true)
+            }
+            return (defaultHandsFreeTrigger(avoiding: pushToTalk), pushToTalk, true, false)
+        }
         if !storedHandsFree.isDisabled,
            !pushToTalk.isDisabled,
            storedHandsFree != pushToTalk,

--- a/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
@@ -72,6 +72,16 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
         )
     }
 
+    func testMenuTitleDescribesOverlappingDictationTriggers() {
+        XCTAssertEqual(
+            AppHotkeyCoordinator.menuTitle(
+                handsFree: .chord(modifiers: ["control"], keyCode: 49),
+                pushToTalk: .control
+            ),
+            "Dictation Shortcuts: Conflict on Control+Space / Control"
+        )
+    }
+
     func testMenuTitleDescribesDistinctDictationTriggers() {
         XCTAssertEqual(
             AppHotkeyCoordinator.menuTitle(handsFree: .control, pushToTalk: .option),

--- a/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
@@ -68,7 +68,7 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
     func testMenuTitleDescribesSharedDictationTrigger() {
         XCTAssertEqual(
             AppHotkeyCoordinator.menuTitle(handsFree: .fn, pushToTalk: .fn),
-            "Dictation: Hold Fn / Double-tap Fn"
+            "Dictation Shortcuts: Conflict on Fn"
         )
     }
 
@@ -79,7 +79,7 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
         )
     }
 
-    func testDictationHotkeyPlanUsesCombinedModeForSharedTrigger() {
+    func testDictationHotkeyPlanKeepsHandsFreeWhenSharedTriggerWouldConflict() {
         let plan = AppHotkeyCoordinator.dictationHotkeyPlan(
             handsFree: .fn,
             pushToTalk: .fn
@@ -89,9 +89,9 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
             plan,
             AppHotkeyCoordinator.DictationHotkeyPlan(
                 specs: [
-                    .init(trigger: .fn, gestureMode: .doubleTapAndHold),
+                    .init(trigger: .fn, gestureMode: .singleTapToggle),
                 ],
-                conflict: nil
+                conflict: .init(trigger: .fn, conflicts: [.fn])
             )
         )
     }

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -1213,24 +1213,24 @@ final class SettingsViewModelTests: XCTestCase {
 
         let vm = SettingsViewModel(defaults: testDefaults)
 
-        XCTAssertEqual(vm.hotkeyTrigger, legacyTrigger)
+        XCTAssertEqual(vm.hotkeyTrigger, .defaultDictation)
         XCTAssertEqual(vm.pushToTalkHotkeyTrigger, legacyTrigger)
 
         let vm2 = SettingsViewModel(defaults: testDefaults)
-        XCTAssertEqual(vm2.hotkeyTrigger, legacyTrigger)
+        XCTAssertEqual(vm2.hotkeyTrigger, .defaultDictation)
         XCTAssertEqual(vm2.pushToTalkHotkeyTrigger, legacyTrigger)
     }
 
-    func testLegacyHotkeyOverlappingDefaultHandsFreeMigratesToCombinedMode() {
+    func testLegacyHotkeyOverlappingDefaultHandsFreeDisablesHandsFreeDuringMigration() {
         let legacyTrigger = HotkeyTrigger.fromKeyCode(49)
         testDefaults.removeObject(forKey: HotkeyTrigger.pushToTalkDefaultsKey)
         legacyTrigger.save(to: testDefaults)
 
         let vm = SettingsViewModel(defaults: testDefaults)
 
-        XCTAssertEqual(vm.hotkeyTrigger, legacyTrigger)
+        XCTAssertEqual(vm.hotkeyTrigger, .disabled)
         XCTAssertEqual(vm.pushToTalkHotkeyTrigger, legacyTrigger)
-        XCTAssertEqual(HotkeyTrigger.current(defaults: testDefaults), legacyTrigger)
+        XCTAssertEqual(HotkeyTrigger.current(defaults: testDefaults), .disabled)
         XCTAssertEqual(
             HotkeyTrigger.current(
                 defaults: testDefaults,
@@ -1260,22 +1260,22 @@ final class SettingsViewModelTests: XCTestCase {
         )
     }
 
-    func testLegacyDefaultFnHandsFreeMigratesToCombinedMode() {
+    func testLegacyDefaultFnHandsFreeMigratesToFnSpaceWithoutChangingPushToTalk() {
         testDefaults.removeObject(forKey: HotkeyTrigger.pushToTalkDefaultsKey)
         HotkeyTrigger.fn.save(to: testDefaults)
 
         let vm = SettingsViewModel(defaults: testDefaults)
 
-        XCTAssertEqual(vm.hotkeyTrigger, .fn)
+        XCTAssertEqual(vm.hotkeyTrigger, .defaultDictation)
         XCTAssertEqual(vm.pushToTalkHotkeyTrigger, .defaultPushToTalk)
-        XCTAssertEqual(HotkeyTrigger.current(defaults: testDefaults), .fn)
+        XCTAssertEqual(HotkeyTrigger.current(defaults: testDefaults), .defaultDictation)
         XCTAssertEqual(
             HotkeyTrigger.current(
                 defaults: testDefaults,
                 defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey,
                 fallback: .defaultPushToTalk
             ),
-            .fn
+            .defaultPushToTalk
         )
     }
 
@@ -1311,14 +1311,42 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(vm.pushToTalkHotkeyTrigger, .defaultDictation)
     }
 
-    func testStoredMatchingDedicatedDictationHotkeysPersistAsCombinedMode() {
+    func testStoredMatchingDedicatedDictationHotkeysRestoreHandsFreeDefault() {
         HotkeyTrigger.fn.save(to: testDefaults)
         HotkeyTrigger.fn.save(to: testDefaults, defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey)
 
         let vm = SettingsViewModel(defaults: testDefaults)
 
-        XCTAssertEqual(vm.hotkeyTrigger, .fn)
+        XCTAssertEqual(vm.hotkeyTrigger, .defaultDictation)
         XCTAssertEqual(vm.pushToTalkHotkeyTrigger, .fn)
+        XCTAssertEqual(HotkeyTrigger.current(defaults: testDefaults), .defaultDictation)
+        XCTAssertEqual(
+            HotkeyTrigger.current(
+                defaults: testDefaults,
+                defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey,
+                fallback: .defaultPushToTalk
+            ),
+            .fn
+        )
+    }
+
+    func testStoredMatchingDefaultHandsFreeHotkeysRestorePushToTalkDefault() {
+        HotkeyTrigger.defaultDictation.save(to: testDefaults)
+        HotkeyTrigger.defaultDictation.save(to: testDefaults, defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey)
+
+        let vm = SettingsViewModel(defaults: testDefaults)
+
+        XCTAssertEqual(vm.hotkeyTrigger, .defaultDictation)
+        XCTAssertEqual(vm.pushToTalkHotkeyTrigger, .defaultPushToTalk)
+        XCTAssertEqual(HotkeyTrigger.current(defaults: testDefaults), .defaultDictation)
+        XCTAssertEqual(
+            HotkeyTrigger.current(
+                defaults: testDefaults,
+                defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey,
+                fallback: .defaultPushToTalk
+            ),
+            .defaultPushToTalk
+        )
     }
 
     func testHotkeyTriggerBackwardCompatibleWithLegacyString() {
@@ -1327,7 +1355,7 @@ final class SettingsViewModelTests: XCTestCase {
         testDefaults.set("option", forKey: "hotkeyTrigger")
 
         let vm = SettingsViewModel(defaults: testDefaults)
-        XCTAssertEqual(vm.hotkeyTrigger, .option)
+        XCTAssertEqual(vm.hotkeyTrigger, .defaultDictation)
         XCTAssertEqual(vm.pushToTalkHotkeyTrigger, .option)
     }
 

--- a/Tests/MacParakeetTests/Views/Settings/SettingsHotkeyConflictMessageTests.swift
+++ b/Tests/MacParakeetTests/Views/Settings/SettingsHotkeyConflictMessageTests.swift
@@ -66,4 +66,28 @@ final class SettingsHotkeyConflictMessageTests: XCTestCase {
             )
         )
     }
+
+    func testExistingDictationPeerConflictMessageCanNameActiveTrigger() {
+        XCTAssertEqual(
+            SettingsDictationHotkeyConflictPolicy.existingConflictMessage(
+                trigger: .fn,
+                peer: .fn,
+                peerName: "push to talk",
+                disablesTrigger: false
+            ),
+            "Conflicts with push to talk (🌐 Fn)."
+        )
+    }
+
+    func testExistingDictationPeerConflictMessageCanNameDisabledTrigger() {
+        XCTAssertEqual(
+            SettingsDictationHotkeyConflictPolicy.existingConflictMessage(
+                trigger: .fn,
+                peer: .fn,
+                peerName: "hands-free mode",
+                disablesTrigger: true
+            ),
+            "Disabled — conflicts with hands-free mode (🌐 Fn)."
+        )
+    }
 }

--- a/Tests/MacParakeetTests/Views/Settings/SettingsHotkeyConflictMessageTests.swift
+++ b/Tests/MacParakeetTests/Views/Settings/SettingsHotkeyConflictMessageTests.swift
@@ -26,4 +26,44 @@ final class SettingsHotkeyConflictMessageTests: XCTestCase {
             "Conflicts with meeting recording (⇧⌘M)."
         )
     }
+
+    func testDictationPeerValidationBlocksExactDuplicate() {
+        XCTAssertEqual(
+            SettingsDictationHotkeyConflictPolicy.validation(
+                candidate: .fn,
+                peer: .fn,
+                peerName: "push to talk"
+            ),
+            .blocked("Conflicts with push to talk (🌐 Fn).")
+        )
+    }
+
+    func testDictationPeerValidationBlocksOverlappingDistinctTrigger() {
+        let rightCommand = HotkeyTrigger(
+            kind: .modifier,
+            modifierName: "command",
+            keyCode: nil,
+            modifierKeyCode: 54
+        )
+        let genericCommand = HotkeyTrigger.command
+
+        XCTAssertEqual(
+            SettingsDictationHotkeyConflictPolicy.validation(
+                candidate: rightCommand,
+                peer: genericCommand,
+                peerName: "hands-free mode"
+            ),
+            .blocked("Conflicts with hands-free mode (⌘ Command).")
+        )
+    }
+
+    func testDictationPeerValidationAllowsDistinctDefaults() {
+        XCTAssertNil(
+            SettingsDictationHotkeyConflictPolicy.validation(
+                candidate: .defaultDictation,
+                peer: .defaultPushToTalk,
+                peerName: "push to talk"
+            )
+        )
+    }
 }

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -137,14 +137,14 @@ See [00-vision.md](./00-vision.md) for positioning and market context.
 
 **Activation — Configurable Hotkey:**
 
-Dictation has two configurable shortcuts: push-to-talk defaults to `Fn`, and hands-free mode defaults to `Fn+Space`. The "record a shortcut" UI supports bare modifiers (Fn, Control, etc.), standalone keys (F5, Tab, etc.), modifier+key chords (Fn+Space, Cmd+9, Ctrl+Shift+D), and modifier-only chords (Command+Option, including side-specific variants like Right Command+Right Option). See ADR-009 for full details. If both dictation shortcuts are set to the same trigger, MacParakeet uses the legacy combined gesture: hold for push-to-talk and double-tap for hands-free mode.
+Dictation has two configurable shortcuts: push-to-talk defaults to `Fn`, and hands-free mode defaults to `Fn+Space`. The "record a shortcut" UI supports bare modifiers (Fn, Control, etc.), standalone keys (F5, Tab, etc.), modifier+key chords (Fn+Space, Cmd+9, Ctrl+Shift+D), and modifier-only chords (Command+Option, including side-specific variants like Right Command+Right Option). See ADR-009 for full details. The two dictation shortcuts must be distinct; Settings blocks assigning the same trigger to both roles.
 
 | Mode | Gesture | Behavior |
 |------|---------|----------|
 | **Hands-free** | Tap the hands-free shortcut | Persistent recording. Tap the shortcut again to stop. |
 | **Press-and-hold** | Hold the push-to-talk shortcut | Hold-to-talk. Release auto-stops and pastes. |
 
-New installs default to separate shortcuts, so there is no double-tap requirement. Existing or manually configured same-trigger shortcuts use double-tap for hands-free mode so the hold gesture can remain push-to-talk.
+Legacy single-hotkey installs are migrated to distinct shortcuts where possible: the old trigger becomes push-to-talk, while hands-free moves to the default `Fn+Space` or disables itself if that would conflict.
 
 **Implementation:**
 - `CGEvent` tap for system-wide key event interception
@@ -159,7 +159,7 @@ New installs default to separate shortcuts, so there is no double-tap requiremen
 - Chord validation: Escape blocked for all kinds. Modifier+key chords containing Command warn about system shortcut conflicts (Cmd+Tab, Cmd+Space, Cmd+Q/W/H/M). Fn is allowed in modifier+key chords such as Fn+Space.
 - Hands-free key-down: toggles persistent recording immediately for key and modifier+key triggers; bare modifier hands-free triggers toggle on bare release so normal modifier shortcuts are not captured.
 - Dedicated push-to-talk key-down: schedule only the startup debounce, then start hold-to-talk.
-- Combined same-trigger dictation shortcuts: one `HotkeyManager` runs double-tap-and-hold mode. Double-tap starts persistent recording, one tap while recording stops it, and hold remains push-to-talk.
+- Duplicate dictation shortcuts: exact same-trigger assignments are rejected in Settings and reported as conflicts at runtime instead of creating a hidden combined gesture.
 - On key-up: dedicated push-to-talk releases after startup debounce stop and process.
 - Escape is permanently reserved for cancel-dictation and cannot be assigned as hotkey
 - Requires Accessibility permission (prompted on first activation).
@@ -172,7 +172,6 @@ New installs default to separate shortcuts, so there is no double-tap requiremen
 ┌─────────────────────────────────────────────────────────────────┐
 │ 1. User activates recording:                                     │
 │    - Tap the hands-free shortcut (Fn+Space by default), OR       │
-│    - Double-tap the shared shortcut in combined mode, OR         │
 │    - Hold the push-to-talk shortcut (Fn by default)              │
 ├─────────────────────────────────────────────────────────────────┤
 │ 2. Overlay appears (bottom-center pill)                          │
@@ -185,7 +184,7 @@ New installs default to separate shortcuts, so there is no double-tap requiremen
 ├─────────────────────────────────────────────────────────────────┤
 │ 4. User stops recording:                                         │
 │    - Release the push-to-talk shortcut, OR                       │
-│    - Tap the hands-free/combined shortcut again, OR              │
+│    - Tap the hands-free shortcut again, OR                       │
 │    - Press Escape (soft cancel with undo window), OR             │
 │    - Silence auto-stop (2s default, if enabled in settings)      │
 │    - If stop is requested while startup is in-flight, stop is     │

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -137,7 +137,7 @@ See [00-vision.md](./00-vision.md) for positioning and market context.
 
 **Activation — Configurable Hotkey:**
 
-Dictation has two configurable shortcuts: push-to-talk defaults to `Fn`, and hands-free mode defaults to `Fn+Space`. The "record a shortcut" UI supports bare modifiers (Fn, Control, etc.), standalone keys (F5, Tab, etc.), modifier+key chords (Fn+Space, Cmd+9, Ctrl+Shift+D), and modifier-only chords (Command+Option, including side-specific variants like Right Command+Right Option). See ADR-009 for full details. The two dictation shortcuts must be distinct; Settings blocks assigning the same trigger to both roles.
+Dictation has two configurable shortcuts: push-to-talk defaults to `Fn`, and hands-free mode defaults to `Fn+Space`. The "record a shortcut" UI supports bare modifiers (Fn, Control, etc.), standalone keys (F5, Tab, etc.), modifier+key chords (Fn+Space, Cmd+9, Ctrl+Shift+D), and modifier-only chords (Command+Option, including side-specific variants like Right Command+Right Option). See ADR-009 for full details. The two dictation shortcuts must be distinct and non-overlapping; Settings blocks assigning conflicting triggers to both roles.
 
 | Mode | Gesture | Behavior |
 |------|---------|----------|
@@ -159,7 +159,7 @@ Legacy single-hotkey installs are migrated to distinct shortcuts where possible:
 - Chord validation: Escape blocked for all kinds. Modifier+key chords containing Command warn about system shortcut conflicts (Cmd+Tab, Cmd+Space, Cmd+Q/W/H/M). Fn is allowed in modifier+key chords such as Fn+Space.
 - Hands-free key-down: toggles persistent recording immediately for key and modifier+key triggers; bare modifier hands-free triggers toggle on bare release so normal modifier shortcuts are not captured.
 - Dedicated push-to-talk key-down: schedule only the startup debounce, then start hold-to-talk.
-- Duplicate dictation shortcuts: exact same-trigger assignments are rejected in Settings and reported as conflicts at runtime instead of creating a hidden combined gesture.
+- Duplicate or overlapping dictation shortcuts: conflicting assignments are rejected in Settings and reported at runtime instead of creating a hidden combined gesture.
 - On key-up: dedicated push-to-talk releases after startup debounce stop and process.
 - Escape is permanently reserved for cancel-dictation and cannot be assigned as hotkey
 - Requires Accessibility permission (prompted on first activation).

--- a/spec/09-testing.md
+++ b/spec/09-testing.md
@@ -278,7 +278,7 @@ Tests/
 
 These flows must be tested manually after any overlay or hotkey changes. Automated unit tests cover the state machine logic, but the full UX requires human verification.
 
-> **Note:** "Fn+Space" below refers to the configured hands-free shortcut, and "Fn" refers to the configured push-to-talk shortcut. Defaults are Fn+Space for hands-free and Fn for push-to-talk. When both shortcuts are set to the same trigger, double-tap starts hands-free mode and hold remains push-to-talk. Test with at least two different trigger keys.
+> **Note:** "Fn+Space" below refers to the configured hands-free shortcut, and "Fn" refers to the configured push-to-talk shortcut. Defaults are Fn+Space for hands-free and Fn for push-to-talk. The two dictation shortcuts must be distinct; Settings should reject assigning the same trigger to both roles. Test with at least two different trigger keys.
 
 ### Happy Path
 
@@ -310,7 +310,7 @@ These flows must be tested manually after any overlay or hotkey changes. Automat
 | 10d | Single-tap modifier filtering | Ctrl → type "hello" → release Ctrl | Does NOT trigger dictation |
 | 10e | Switch back to Fn+Space | Settings → Shortcuts → Hands-free mode → select Fn+Space | Fn+Space works again, Ctrl no longer triggers |
 | 10f | Dynamic UI text | Change to Option+Space → check overlay/pill/history | All say "Option+Space" instead of "Fn+Space" |
-| 10g | Combined same-trigger mode | Set both dictation shortcuts to Fn → double-tap Fn → speak → tap Fn | Double-tap starts hands-free mode, one tap stops, and Settings shows double-tap guidance |
+| 10g | Duplicate dictation shortcut blocked | Try setting both dictation shortcuts to Fn | Settings rejects the second assignment with a conflict message |
 
 ### State Transitions
 

--- a/spec/09-testing.md
+++ b/spec/09-testing.md
@@ -278,7 +278,7 @@ Tests/
 
 These flows must be tested manually after any overlay or hotkey changes. Automated unit tests cover the state machine logic, but the full UX requires human verification.
 
-> **Note:** "Fn+Space" below refers to the configured hands-free shortcut, and "Fn" refers to the configured push-to-talk shortcut. Defaults are Fn+Space for hands-free and Fn for push-to-talk. The two dictation shortcuts must be distinct; Settings should reject assigning the same trigger to both roles. Test with at least two different trigger keys.
+> **Note:** "Fn+Space" below refers to the configured hands-free shortcut, and "Fn" refers to the configured push-to-talk shortcut. Defaults are Fn+Space for hands-free and Fn for push-to-talk. The two dictation shortcuts must be distinct and non-overlapping; Settings should reject conflicting triggers for the two roles. Test with at least two different trigger keys.
 
 ### Happy Path
 
@@ -310,7 +310,7 @@ These flows must be tested manually after any overlay or hotkey changes. Automat
 | 10d | Single-tap modifier filtering | Ctrl → type "hello" → release Ctrl | Does NOT trigger dictation |
 | 10e | Switch back to Fn+Space | Settings → Shortcuts → Hands-free mode → select Fn+Space | Fn+Space works again, Ctrl no longer triggers |
 | 10f | Dynamic UI text | Change to Option+Space → check overlay/pill/history | All say "Option+Space" instead of "Fn+Space" |
-| 10g | Duplicate dictation shortcut blocked | Try setting both dictation shortcuts to Fn | Settings rejects the second assignment with a conflict message |
+| 10g | Conflicting dictation shortcut blocked | Try setting both dictation shortcuts to Fn, then try an overlapping pair such as Control and Control+Space | Settings rejects the second assignment with a conflict message |
 
 ### State Transitions
 

--- a/spec/adr/009-custom-hotkey.md
+++ b/spec/adr/009-custom-hotkey.md
@@ -55,7 +55,7 @@ Community issue #17 requested modifier+key combos (e.g., Cmd+9) because Logitech
 7. **Modifier names stored as `[String]`** — Not raw `CGEventFlags.rawValue` (has phantom bits). Readable JSON: `{"kind":"chord","keyCode":25,"chordModifiers":["command"]}`.
 8. **HotkeyRecorderView two-phase capture** — Held modifiers show as preview (e.g. "⌘..."); pressing a key with modifiers held creates a chord; releasing all modifiers without a key press creates a bare modifier trigger.
 9. **Validation** — Chords are `.allowed` by default. Escape blocked. Cmd+Tab and Cmd+Space warned (system intercepts them).
-10. **Distinct dictation roles** — Hands-free and push-to-talk cannot be manually assigned the exact same trigger. Settings blocks duplicate assignments, while legacy single-hotkey installs migrate to distinct shortcuts where possible.
+10. **Distinct dictation roles** — Hands-free and push-to-talk cannot be manually assigned overlapping triggers. Settings blocks conflicting assignments, while legacy single-hotkey installs migrate to distinct shortcuts where possible.
 
 ### Original decision preserved
 

--- a/spec/adr/009-custom-hotkey.md
+++ b/spec/adr/009-custom-hotkey.md
@@ -55,7 +55,7 @@ Community issue #17 requested modifier+key combos (e.g., Cmd+9) because Logitech
 7. **Modifier names stored as `[String]`** — Not raw `CGEventFlags.rawValue` (has phantom bits). Readable JSON: `{"kind":"chord","keyCode":25,"chordModifiers":["command"]}`.
 8. **HotkeyRecorderView two-phase capture** — Held modifiers show as preview (e.g. "⌘..."); pressing a key with modifiers held creates a chord; releasing all modifiers without a key press creates a bare modifier trigger.
 9. **Validation** — Chords are `.allowed` by default. Escape blocked. Cmd+Tab and Cmd+Space warned (system intercepts them).
-10. **Same-trigger dictation compatibility** — If hands-free and push-to-talk are configured to the same trigger, the app uses the legacy combined gesture: double-tap for persistent hands-free dictation and hold for push-to-talk. Separate triggers remain the default for new installs.
+10. **Distinct dictation roles** — Hands-free and push-to-talk cannot be manually assigned the exact same trigger. Settings blocks duplicate assignments, while legacy single-hotkey installs migrate to distinct shortcuts where possible.
 
 ### Original decision preserved
 

--- a/spec/kernel/requirements.yaml
+++ b/spec/kernel/requirements.yaml
@@ -28,7 +28,7 @@ REQ-DICT-001:
   status: implemented
 
 REQ-DICT-002:
-  description: Distinct hands-free tap-to-toggle and hold-to-talk shortcuts
+  description: Distinct, non-overlapping hands-free tap-to-toggle and hold-to-talk shortcuts
   version: v0.1
   status: implemented
 

--- a/spec/kernel/requirements.yaml
+++ b/spec/kernel/requirements.yaml
@@ -28,7 +28,7 @@ REQ-DICT-001:
   status: implemented
 
 REQ-DICT-002:
-  description: Hands-free tap-to-toggle and hold-to-talk shortcuts, with same-trigger double-tap compatibility
+  description: Distinct hands-free tap-to-toggle and hold-to-talk shortcuts
   version: v0.1
   status: implemented
 


### PR DESCRIPTION
## Summary
- block exact duplicate push-to-talk / hands-free dictation hotkey assignments in Settings
- remove the legacy same-trigger combined gesture path from runtime planning
- repair legacy or previously duplicated stored dictation hotkeys on Settings load
- update hotkey tests and specs to document distinct dictation shortcuts

## Validation
- git diff --check HEAD~1 HEAD
- swift test --filter Hotkey
- swift test