### PR TITLE
Fix dictation hotkey defaults and recorder persistence

### DIFF
--- a/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
+++ b/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
@@ -116,6 +116,9 @@ final class AppHotkeyCoordinator {
         if handsFree.isDisabled && pushToTalk.isDisabled {
             return "Dictation Shortcuts: Disabled"
         }
+        if HotkeyTrigger.isDefaultDictationGesturePreset(handsFree: handsFree, pushToTalk: pushToTalk) {
+            return "Dictation: Hold Fn / Tap Fn"
+        }
         if handsFree.overlaps(with: pushToTalk) {
             let conflictName = handsFree == pushToTalk
                 ? handsFree.displayName
@@ -137,6 +140,21 @@ final class AppHotkeyCoordinator {
     ) -> DictationHotkeyPlan {
         guard !handsFreeTrigger.isDisabled || !pushToTalkTrigger.isDisabled else {
             return DictationHotkeyPlan(specs: [], conflict: nil)
+        }
+
+        if HotkeyTrigger.isDefaultDictationGesturePreset(
+            handsFree: handsFreeTrigger,
+            pushToTalk: pushToTalkTrigger
+        ) {
+            return DictationHotkeyPlan(
+                specs: [
+                    DictationHotkeyPlan.Spec(
+                        trigger: handsFreeTrigger,
+                        gestureMode: .doubleTapAndHold
+                    ),
+                ],
+                conflict: nil
+            )
         }
 
         if !handsFreeTrigger.isDisabled, !pushToTalkTrigger.isDisabled {

--- a/Sources/MacParakeet/Onboarding/OnboardingHotkeyPreviewController.swift
+++ b/Sources/MacParakeet/Onboarding/OnboardingHotkeyPreviewController.swift
@@ -103,7 +103,7 @@ final class OnboardingHotkeyPreviewController {
     }
 
     /// Mirror the production app: once one trigger fires, suppress the peer
-    /// trigger until reset so a held `fn` can't also fire an `fn+Space` toggle.
+    /// trigger until reset so overlapping custom triggers cannot double-fire.
     private func suppressPeers(of active: HotkeyManager) {
         for manager in managers where manager !== active {
             manager.suppressUntilReset()

--- a/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
+++ b/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
@@ -181,7 +181,10 @@ struct HotkeyRecorderView: View {
                 }
 
                 // Check if chord modifiers are held. Caps Lock remains excluded.
-                let heldModifiers = chordModifiersFromFlags(event.modifierFlags)
+                let heldModifiers = Self.chordModifierNames(
+                    flags: event.modifierFlags,
+                    pendingComponents: pendingModifierComponents
+                )
 
                 if !heldModifiers.isEmpty {
                     // Chord: modifier(s) + key
@@ -310,13 +313,22 @@ struct HotkeyRecorderView: View {
     /// Extract chord-eligible modifier names from NSEvent modifier flags.
     /// Caps Lock is intentionally excluded.
     private func chordModifiersFromFlags(_ flags: NSEvent.ModifierFlags) -> [String] {
-        var modifiers: [String] = []
-        if flags.contains(.control) { modifiers.append("control") }
-        if flags.contains(.option) { modifiers.append("option") }
-        if flags.contains(.shift) { modifiers.append("shift") }
-        if flags.contains(.command) { modifiers.append("command") }
-        if flags.contains(.function) { modifiers.append("fn") }
-        return modifiers
+        Self.chordModifierNames(flags: flags, pendingComponents: [])
+    }
+
+    static func chordModifierNames(
+        flags: NSEvent.ModifierFlags,
+        pendingComponents: [HotkeyTrigger.ModifierComponent]
+    ) -> [String] {
+        let order = ["fn", "control", "option", "shift", "command"]
+        var names: Set<String> = []
+        if flags.contains(.function) { names.insert("fn") }
+        if flags.contains(.control) { names.insert("control") }
+        if flags.contains(.option) { names.insert("option") }
+        if flags.contains(.shift) { names.insert("shift") }
+        if flags.contains(.command) { names.insert("command") }
+        names.formUnion(pendingComponents.map(\.modifierName))
+        return order.filter { names.contains($0) }
     }
 
     private func modifierComponentsAfterFlagsChanged(

--- a/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
+++ b/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
@@ -377,8 +377,8 @@ struct HotkeyRecorderView: View {
     }
 
     /// Map a modifier name + physical keyCode to a bare modifier trigger.
-    /// Generic capture preserves the legacy "either side" behavior. Side-specific capture
-    /// records the physical left/right key that was used during recording.
+    /// Generic capture preserves the legacy "either side" behavior. Standard
+    /// and side-specific capture record the physical left/right key used.
     static func bareModifierTrigger(
         for name: String,
         keyCode: UInt16,
@@ -403,13 +403,13 @@ struct HotkeyRecorderView: View {
     ) -> HotkeyTrigger? {
         let trigger: HotkeyTrigger
         switch captureMode {
-        case .standard, .generic:
+        case .generic:
             trigger = HotkeyTrigger.modifierChord(
                 components: components.map {
                     HotkeyTrigger.ModifierComponent(modifierName: $0.modifierName)
                 }
             )
-        case .sideSpecific:
+        case .standard, .sideSpecific:
             trigger = HotkeyTrigger.modifierChord(components: components)
         }
 

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -22,6 +22,9 @@ enum SettingsDictationHotkeyConflictPolicy {
         peerName: String
     ) -> HotkeyTrigger.ValidationResult? {
         guard candidate.overlaps(with: peer) else { return nil }
+        if HotkeyTrigger.isDefaultDictationGesturePreset(handsFree: candidate, pushToTalk: peer) {
+            return nil
+        }
         return .blocked(SettingsHotkeyConflictMessage.blocked(
             conflictingWith: peerName,
             trigger: peer
@@ -35,6 +38,9 @@ enum SettingsDictationHotkeyConflictPolicy {
         disablesTrigger: Bool
     ) -> String? {
         guard trigger.overlaps(with: peer) else { return nil }
+        if HotkeyTrigger.isDefaultDictationGesturePreset(handsFree: trigger, pushToTalk: peer) {
+            return nil
+        }
         if disablesTrigger {
             return SettingsHotkeyConflictMessage.disabled(
                 conflictingWith: peerName,

--- a/Sources/MacParakeetCore/STT/HotkeyTrigger.swift
+++ b/Sources/MacParakeetCore/STT/HotkeyTrigger.swift
@@ -359,9 +359,17 @@ public struct HotkeyTrigger: Sendable {
 
     // MARK: - Default Triggers
 
-    public static let defaultDictation: HotkeyTrigger = .chord(modifiers: ["fn"], keyCode: 49)
+    public static let fnSpace: HotkeyTrigger = .chord(modifiers: ["fn"], keyCode: 49)
+    public static let defaultDictation: HotkeyTrigger = .fn
     public static let defaultPushToTalk: HotkeyTrigger = .fn
     public static let defaultMeetingRecording: HotkeyTrigger = .chord(modifiers: ["command", "shift"], keyCode: 46)
+
+    public static func isDefaultDictationGesturePreset(
+        handsFree: HotkeyTrigger,
+        pushToTalk: HotkeyTrigger
+    ) -> Bool {
+        handsFree == .defaultDictation && pushToTalk == .defaultPushToTalk
+    }
 
     // MARK: - Factory
 

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -706,6 +706,9 @@ public final class SettingsViewModel {
             if storedHandsFree.isDisabled {
                 return (.disabled, .disabled, false, true)
             }
+            if storedHandsFree == .fnSpace {
+                return (.defaultDictation, .defaultPushToTalk, true, true)
+            }
             let handsFree = defaultHandsFreeTrigger(avoiding: storedHandsFree)
             return (
                 handsFree,
@@ -720,6 +723,10 @@ public final class SettingsViewModel {
             defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey,
             fallback: .defaultPushToTalk
         )
+        if storedHandsFree == .fnSpace,
+           pushToTalk == .defaultPushToTalk {
+            return (.defaultDictation, .defaultPushToTalk, true, false)
+        }
         if !storedHandsFree.isDisabled,
            !pushToTalk.isDisabled,
            storedHandsFree == pushToTalk {

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -738,6 +738,9 @@ public final class SettingsViewModel {
     }
 
     private static func defaultHandsFreeTrigger(avoiding pushToTalk: HotkeyTrigger) -> HotkeyTrigger {
+        if pushToTalk == .defaultPushToTalk {
+            return .defaultDictation
+        }
         guard !pushToTalk.isDisabled,
               HotkeyTrigger.defaultDictation.overlaps(with: pushToTalk) else {
             return .defaultDictation

--- a/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
@@ -68,7 +68,7 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
     func testMenuTitleDescribesSharedDictationTrigger() {
         XCTAssertEqual(
             AppHotkeyCoordinator.menuTitle(handsFree: .fn, pushToTalk: .fn),
-            "Dictation Shortcuts: Conflict on Fn"
+            "Dictation: Hold Fn / Tap Fn"
         )
     }
 
@@ -89,7 +89,7 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
         )
     }
 
-    func testDictationHotkeyPlanKeepsHandsFreeWhenSharedTriggerWouldConflict() {
+    func testDictationHotkeyPlanUsesCombinedDefaultGestureForFnPair() {
         let plan = AppHotkeyCoordinator.dictationHotkeyPlan(
             handsFree: .fn,
             pushToTalk: .fn
@@ -99,9 +99,9 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
             plan,
             AppHotkeyCoordinator.DictationHotkeyPlan(
                 specs: [
-                    .init(trigger: .fn, gestureMode: .singleTapToggle),
+                    .init(trigger: .fn, gestureMode: .doubleTapAndHold),
                 ],
-                conflict: .init(trigger: .fn, conflicts: [.fn])
+                conflict: nil
             )
         )
     }
@@ -124,7 +124,7 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
         )
     }
 
-    func testDictationHotkeyPlanUsesSeparateManagersForDefaults() {
+    func testDictationHotkeyPlanUsesCombinedManagerForDefaults() {
         let plan = AppHotkeyCoordinator.dictationHotkeyPlan(
             handsFree: .defaultDictation,
             pushToTalk: .defaultPushToTalk
@@ -134,12 +134,7 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
             plan,
             AppHotkeyCoordinator.DictationHotkeyPlan(
                 specs: [
-                    .init(trigger: .defaultDictation, gestureMode: .singleTapToggle),
-                    .init(
-                        trigger: .defaultPushToTalk,
-                        gestureMode: .holdOnly,
-                        startupDebounceMs: FnKeyStateMachine.defaultTapThresholdMs
-                    ),
+                    .init(trigger: .defaultDictation, gestureMode: .doubleTapAndHold),
                 ],
                 conflict: nil
             )

--- a/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
@@ -328,7 +328,7 @@ final class HotkeyManagerTests: XCTestCase {
     }
 
     func testSingleTapToggleGestureModeWorksForFnSpaceChord() {
-        let trigger = HotkeyTrigger.defaultDictation
+        let trigger = HotkeyTrigger.fnSpace
         let manager = HotkeyManager(trigger: trigger, gestureMode: .singleTapToggle)
 
         let firstDown = manager.chordEventDecisionForTesting(
@@ -365,7 +365,7 @@ final class HotkeyManagerTests: XCTestCase {
             gestureMode: .holdOnly,
             startupDebounceMs: FnKeyStateMachine.defaultTapThresholdMs
         )
-        let handsFree = HotkeyManager(trigger: .defaultDictation, gestureMode: .singleTapToggle)
+        let handsFree = HotkeyManager(trigger: .fnSpace, gestureMode: .singleTapToggle)
 
         XCTAssertEqual(
             pushToTalk.modifierFlagsChangedOutputsForTesting(
@@ -387,7 +387,7 @@ final class HotkeyManagerTests: XCTestCase {
         let handsFreeStart = handsFree.chordEventDecisionForTesting(
             type: .keyDown,
             keyCode: 49,
-            flags: HotkeyTrigger.defaultDictation.chordEventFlags,
+            flags: HotkeyTrigger.fnSpace.chordEventFlags,
             timestampMs: 1_200
         )
         XCTAssertEqual(handsFreeStart.outputs, [.startRecording(mode: .persistent)])

--- a/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
@@ -7,6 +7,7 @@ final class HotkeyManagerTests: XCTestCase {
     private let leftOptionMask = UInt64(NX_DEVICELALTKEYMASK)
     private let rightOptionMask = UInt64(NX_DEVICERALTKEYMASK)
     private let leftShiftMask = UInt64(NX_DEVICELSHIFTKEYMASK)
+    private let rightShiftMask = UInt64(NX_DEVICERSHIFTKEYMASK)
     private let leftCommandMask = UInt64(NX_DEVICELCMDKEYMASK)
     private let rightCommandMask = UInt64(NX_DEVICERCMDKEYMASK)
 
@@ -1589,6 +1590,42 @@ final class HotkeyManagerTests: XCTestCase {
                 timestampMs: 1_050
             ),
             [.cancelStartupDebounce, .cancelHoldWindow, .showReadyForSecondTap]
+        )
+    }
+
+    func testSideSpecificSameModifierChordRequiresBothRecordedSides() {
+        let trigger = HotkeyTrigger.modifierChord(
+            components: [
+                .init(modifierName: "shift", keyCode: 56),
+                .init(modifierName: "shift", keyCode: 60),
+            ]
+        )
+        let manager = HotkeyManager(trigger: trigger)
+
+        XCTAssertEqual(
+            manager.modifierChordFlagsChangedOutputsForTesting(
+                flags: sideSpecificFlags(
+                    CGEventFlags.maskShift.rawValue,
+                    leftShiftMask
+                ),
+                timestampMs: 1_000
+            ),
+            []
+        )
+
+        XCTAssertEqual(
+            manager.modifierChordFlagsChangedOutputsForTesting(
+                flags: sideSpecificFlags(
+                    CGEventFlags.maskShift.rawValue,
+                    leftShiftMask,
+                    rightShiftMask
+                ),
+                timestampMs: 1_025
+            ),
+            [
+                .scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs),
+                .scheduleHoldWindow(milliseconds: FnKeyStateMachine.defaultTapThresholdMs),
+            ]
         )
     }
 

--- a/Tests/MacParakeetTests/Hotkey/HotkeyTriggerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyTriggerTests.swift
@@ -387,18 +387,22 @@ final class HotkeyTriggerTests: XCTestCase {
     }
 
     func testFnSpaceChordDisplayAndFlags() {
-        let trigger = HotkeyTrigger.defaultDictation
+        let trigger = HotkeyTrigger.fnSpace
 
-        XCTAssertEqual(trigger, .chord(modifiers: ["fn"], keyCode: 49))
         XCTAssertEqual(trigger.displayName, "Fn+Space")
         XCTAssertEqual(trigger.shortSymbol, "fn+Space")
         XCTAssertEqual(trigger.chordEventFlags, 0x00800000)
         XCTAssertEqual(trigger.validation, .allowed)
     }
 
-    func testDefaultHandsFreeAndPushToTalkDoNotOverlap() {
-        XCTAssertFalse(HotkeyTrigger.defaultDictation.overlaps(with: .defaultPushToTalk))
-        XCTAssertFalse(HotkeyTrigger.defaultPushToTalk.overlaps(with: .defaultDictation))
+    func testDefaultHandsFreeAndPushToTalkUseCombinedFnGesturePreset() {
+        XCTAssertEqual(HotkeyTrigger.defaultDictation, .fn)
+        XCTAssertEqual(HotkeyTrigger.defaultPushToTalk, .fn)
+        XCTAssertTrue(HotkeyTrigger.defaultDictation.overlaps(with: .defaultPushToTalk))
+        XCTAssertTrue(HotkeyTrigger.isDefaultDictationGesturePreset(
+            handsFree: .defaultDictation,
+            pushToTalk: .defaultPushToTalk
+        ))
     }
 
     // MARK: - Chord Validation

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -1358,6 +1358,54 @@ final class SettingsViewModelTests: XCTestCase {
         )
     }
 
+    func testLegacyFnSpaceDefaultPairMigratesToCombinedDefaultGesture() {
+        HotkeyTrigger.fnSpace.save(to: testDefaults)
+        HotkeyTrigger.defaultPushToTalk.save(to: testDefaults, defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey)
+
+        let vm = SettingsViewModel(defaults: testDefaults)
+
+        XCTAssertEqual(vm.hotkeyTrigger, .defaultDictation)
+        XCTAssertEqual(vm.pushToTalkHotkeyTrigger, .defaultPushToTalk)
+        XCTAssertEqual(HotkeyTrigger.current(defaults: testDefaults), .defaultDictation)
+        XCTAssertEqual(
+            HotkeyTrigger.current(
+                defaults: testDefaults,
+                defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey,
+                fallback: .defaultPushToTalk
+            ),
+            .defaultPushToTalk
+        )
+    }
+
+    func testLegacyFnSpaceDefaultWithoutDedicatedPushToTalkMigratesToCombinedDefaultGesture() {
+        testDefaults.removeObject(forKey: HotkeyTrigger.pushToTalkDefaultsKey)
+        HotkeyTrigger.fnSpace.save(to: testDefaults)
+
+        let vm = SettingsViewModel(defaults: testDefaults)
+
+        XCTAssertEqual(vm.hotkeyTrigger, .defaultDictation)
+        XCTAssertEqual(vm.pushToTalkHotkeyTrigger, .defaultPushToTalk)
+        XCTAssertEqual(HotkeyTrigger.current(defaults: testDefaults), .defaultDictation)
+        XCTAssertEqual(
+            HotkeyTrigger.current(
+                defaults: testDefaults,
+                defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey,
+                fallback: .defaultPushToTalk
+            ),
+            .defaultPushToTalk
+        )
+    }
+
+    func testStoredFnSpaceHandsFreePersistsWhenDedicatedPushToTalkIsCustom() {
+        HotkeyTrigger.fnSpace.save(to: testDefaults)
+        HotkeyTrigger.control.save(to: testDefaults, defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey)
+
+        let vm = SettingsViewModel(defaults: testDefaults)
+
+        XCTAssertEqual(vm.hotkeyTrigger, .fnSpace)
+        XCTAssertEqual(vm.pushToTalkHotkeyTrigger, .control)
+    }
+
     func testMissingHandsFreeKeyUsesCombinedDefaultWhenDedicatedPushToTalkIsDefault() {
         testDefaults.removeObject(forKey: HotkeyTrigger.defaultsKey)
         HotkeyTrigger.defaultDictation.save(to: testDefaults, defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey)

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -1268,7 +1268,7 @@ final class SettingsViewModelTests: XCTestCase {
 
     // MARK: - Hotkey Trigger
 
-    func testHotkeyTriggerDefaultsToFnSpace() {
+    func testHotkeyTriggerDefaultsToFn() {
         XCTAssertEqual(viewModel.hotkeyTrigger, .defaultDictation)
     }
 
@@ -1338,16 +1338,16 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(vm2.pushToTalkHotkeyTrigger, legacyTrigger)
     }
 
-    func testLegacyHotkeyOverlappingDefaultHandsFreeDisablesHandsFreeDuringMigration() {
-        let legacyTrigger = HotkeyTrigger.fromKeyCode(49)
+    func testLegacyFnHotkeyMigratesToCombinedDefaultGesture() {
+        let legacyTrigger = HotkeyTrigger.fn
         testDefaults.removeObject(forKey: HotkeyTrigger.pushToTalkDefaultsKey)
         legacyTrigger.save(to: testDefaults)
 
         let vm = SettingsViewModel(defaults: testDefaults)
 
-        XCTAssertEqual(vm.hotkeyTrigger, .disabled)
+        XCTAssertEqual(vm.hotkeyTrigger, .defaultDictation)
         XCTAssertEqual(vm.pushToTalkHotkeyTrigger, legacyTrigger)
-        XCTAssertEqual(HotkeyTrigger.current(defaults: testDefaults), .disabled)
+        XCTAssertEqual(HotkeyTrigger.current(defaults: testDefaults), .defaultDictation)
         XCTAssertEqual(
             HotkeyTrigger.current(
                 defaults: testDefaults,
@@ -1358,15 +1358,15 @@ final class SettingsViewModelTests: XCTestCase {
         )
     }
 
-    func testMissingHandsFreeKeyAvoidsExistingDedicatedPushToTalkDuringDefaultMigration() {
+    func testMissingHandsFreeKeyUsesCombinedDefaultWhenDedicatedPushToTalkIsDefault() {
         testDefaults.removeObject(forKey: HotkeyTrigger.defaultsKey)
         HotkeyTrigger.defaultDictation.save(to: testDefaults, defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey)
 
         let vm = SettingsViewModel(defaults: testDefaults)
 
-        XCTAssertEqual(vm.hotkeyTrigger, .disabled)
+        XCTAssertEqual(vm.hotkeyTrigger, .defaultDictation)
         XCTAssertEqual(vm.pushToTalkHotkeyTrigger, .defaultDictation)
-        XCTAssertEqual(HotkeyTrigger.current(defaults: testDefaults), .disabled)
+        XCTAssertEqual(HotkeyTrigger.current(defaults: testDefaults), .defaultDictation)
         XCTAssertEqual(
             HotkeyTrigger.current(
                 defaults: testDefaults,
@@ -1377,7 +1377,7 @@ final class SettingsViewModelTests: XCTestCase {
         )
     }
 
-    func testLegacyDefaultFnHandsFreeMigratesToFnSpaceWithoutChangingPushToTalk() {
+    func testLegacyDefaultFnHandsFreeMigratesToCombinedDefaultGesture() {
         testDefaults.removeObject(forKey: HotkeyTrigger.pushToTalkDefaultsKey)
         HotkeyTrigger.fn.save(to: testDefaults)
 
@@ -1418,7 +1418,7 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(vm.pushToTalkHotkeyTrigger, dedicatedTrigger)
     }
 
-    func testStoredFnHandsFreePersistsWhenDedicatedPushToTalkUsesFnSpace() {
+    func testStoredFnHandsFreePersistsWhenDedicatedPushToTalkUsesDefaultFn() {
         HotkeyTrigger.fn.save(to: testDefaults)
         HotkeyTrigger.defaultDictation.save(to: testDefaults, defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey)
 

--- a/Tests/MacParakeetTests/Views/Settings/HotkeyRecorderViewTests.swift
+++ b/Tests/MacParakeetTests/Views/Settings/HotkeyRecorderViewTests.swift
@@ -170,7 +170,21 @@ final class HotkeyRecorderViewTests: XCTestCase {
             captureMode: .generic
         )
 
-        XCTAssertEqual(candidate, .defaultDictation)
+        XCTAssertEqual(candidate, .fnSpace)
+    }
+
+    func testKeyChordCaptureUsesPendingFnWhenKeyDownFlagsOmitFunction() {
+        let modifiers = HotkeyRecorderView.chordModifierNames(
+            flags: [],
+            pendingComponents: [.init(modifierName: "fn")]
+        )
+        let candidate = HotkeyRecorderView.keyChordTrigger(
+            modifiers: modifiers,
+            keyCode: 49,
+            captureMode: .standard
+        )
+
+        XCTAssertEqual(candidate, .fnSpace)
     }
 
     func testBareFnCaptureRemainsSupported() {

--- a/Tests/MacParakeetTests/Views/Settings/HotkeyRecorderViewTests.swift
+++ b/Tests/MacParakeetTests/Views/Settings/HotkeyRecorderViewTests.swift
@@ -17,6 +17,19 @@ final class HotkeyRecorderViewTests: XCTestCase {
         )
     }
 
+    func testStandardBareShiftCaptureRecordsPhysicalModifierSide() {
+        let candidate = HotkeyRecorderView.bareModifierTrigger(
+            for: "shift",
+            keyCode: 60,
+            captureMode: .standard
+        )
+
+        XCTAssertEqual(
+            candidate,
+            HotkeyTrigger(kind: .modifier, modifierName: "shift", keyCode: nil, modifierKeyCode: 60)
+        )
+    }
+
     func testStandardModifierKeyChordCapturePreservesGenericChordBehavior() {
         let candidate = HotkeyRecorderView.keyChordTrigger(
             modifiers: ["command"],
@@ -25,6 +38,46 @@ final class HotkeyRecorderViewTests: XCTestCase {
         )
 
         XCTAssertEqual(candidate, .chord(modifiers: ["command"], keyCode: 8))
+    }
+
+    func testStandardModifierChordCaptureRecordsPhysicalModifierSides() {
+        let candidate = HotkeyRecorderView.modifierChordTrigger(
+            components: [
+                .init(modifierName: "option", keyCode: 58),
+                .init(modifierName: "command", keyCode: 55),
+            ],
+            captureMode: .standard
+        )
+
+        XCTAssertEqual(
+            candidate,
+            .modifierChord(
+                components: [
+                    .init(modifierName: "option", keyCode: 58),
+                    .init(modifierName: "command", keyCode: 55),
+                ]
+            )
+        )
+    }
+
+    func testStandardSameModifierChordCaptureRecordsBothPhysicalSides() {
+        let candidate = HotkeyRecorderView.modifierChordTrigger(
+            components: [
+                .init(modifierName: "shift", keyCode: 56),
+                .init(modifierName: "shift", keyCode: 60),
+            ],
+            captureMode: .standard
+        )
+
+        XCTAssertEqual(
+            candidate,
+            .modifierChord(
+                components: [
+                    .init(modifierName: "shift", keyCode: 56),
+                    .init(modifierName: "shift", keyCode: 60),
+                ]
+            )
+        )
     }
 
     func testGenericBareModifierCapturePreservesEitherSideBehavior() {

--- a/Tests/MacParakeetTests/Views/Settings/SettingsHotkeyConflictMessageTests.swift
+++ b/Tests/MacParakeetTests/Views/Settings/SettingsHotkeyConflictMessageTests.swift
@@ -27,14 +27,25 @@ final class SettingsHotkeyConflictMessageTests: XCTestCase {
         )
     }
 
-    func testDictationPeerValidationBlocksExactDuplicate() {
+    func testDictationPeerValidationAllowsDefaultFnGesturePreset() {
         XCTAssertEqual(
             SettingsDictationHotkeyConflictPolicy.validation(
                 candidate: .fn,
                 peer: .fn,
                 peerName: "push to talk"
             ),
-            .blocked("Conflicts with push to talk (🌐 Fn).")
+            nil
+        )
+    }
+
+    func testDictationPeerValidationBlocksNonDefaultExactDuplicate() {
+        XCTAssertEqual(
+            SettingsDictationHotkeyConflictPolicy.validation(
+                candidate: .control,
+                peer: .control,
+                peerName: "push to talk"
+            ),
+            .blocked("Conflicts with push to talk (⌃ Control).")
         )
     }
 
@@ -85,7 +96,7 @@ final class SettingsHotkeyConflictMessageTests: XCTestCase {
         )
     }
 
-    func testExistingDictationPeerConflictMessageCanNameActiveTrigger() {
+    func testExistingDictationPeerConflictMessageAllowsDefaultFnGesturePreset() {
         XCTAssertEqual(
             SettingsDictationHotkeyConflictPolicy.existingConflictMessage(
                 trigger: .fn,
@@ -93,19 +104,31 @@ final class SettingsHotkeyConflictMessageTests: XCTestCase {
                 peerName: "push to talk",
                 disablesTrigger: false
             ),
-            "Conflicts with push to talk (🌐 Fn)."
+            nil
+        )
+    }
+
+    func testExistingDictationPeerConflictMessageCanNameActiveTrigger() {
+        XCTAssertEqual(
+            SettingsDictationHotkeyConflictPolicy.existingConflictMessage(
+                trigger: .control,
+                peer: .control,
+                peerName: "push to talk",
+                disablesTrigger: false
+            ),
+            "Conflicts with push to talk (⌃ Control)."
         )
     }
 
     func testExistingDictationPeerConflictMessageCanNameDisabledTrigger() {
         XCTAssertEqual(
             SettingsDictationHotkeyConflictPolicy.existingConflictMessage(
-                trigger: .fn,
-                peer: .fn,
+                trigger: .control,
+                peer: .control,
                 peerName: "hands-free mode",
                 disablesTrigger: true
             ),
-            "Disabled — conflicts with hands-free mode (🌐 Fn)."
+            "Disabled — conflicts with hands-free mode (⌃ Control)."
         )
     }
 }

--- a/Tests/MacParakeetTests/Views/Settings/SettingsHotkeyConflictMessageTests.swift
+++ b/Tests/MacParakeetTests/Views/Settings/SettingsHotkeyConflictMessageTests.swift
@@ -57,6 +57,24 @@ final class SettingsHotkeyConflictMessageTests: XCTestCase {
         )
     }
 
+    func testDictationPeerValidationBlocksDuplicateSideSpecificShiftChord() {
+        let bothShifts = HotkeyTrigger.modifierChord(
+            components: [
+                .init(modifierName: "shift", keyCode: 56),
+                .init(modifierName: "shift", keyCode: 60),
+            ]
+        )
+
+        XCTAssertEqual(
+            SettingsDictationHotkeyConflictPolicy.validation(
+                candidate: bothShifts,
+                peer: bothShifts,
+                peerName: "push to talk"
+            ),
+            .blocked("Conflicts with push to talk (L⇧R⇧).")
+        )
+    }
+
     func testDictationPeerValidationAllowsDistinctDefaults() {
         XCTAssertNil(
             SettingsDictationHotkeyConflictPolicy.validation(

--- a/docs/design-overhaul.md
+++ b/docs/design-overhaul.md
@@ -554,7 +554,7 @@ Every empty state is a **personality moment**:
 
 | Empty State | Copy | Visual |
 |-------------|------|--------|
-| No dictations | "Your voice, captured. Tap Fn+Space to start." | Large warm merkaba, gentle pulse |
+| No dictations | "Your voice, captured. Tap Fn to start." | Large warm merkaba, gentle pulse |
 | No transcriptions | "Drop a file and watch the magic happen." | Merkaba with subtle upward particle drift |
 | Search no results | "Nothing matched. Try different words?" | Merkaba at low opacity, still |
 | Error | "Hmm, something went wrong." + actionable detail | Warm error card, not stark red |

--- a/spec/00-vision.md
+++ b/spec/00-vision.md
@@ -30,7 +30,7 @@
 
 Three capture modes plus one optional selected-text AI utility. That is the product:
 
-1. **Dictate anywhere** -- Tap Fn+Space for hands-free dictation, or hold Fn for push-to-talk. Text appears where your cursor is.
+1. **Dictate anywhere** -- Double-tap Fn for hands-free dictation, or hold Fn for push-to-talk. Text appears where your cursor is.
 2. **Drop a file** -- Drag audio/video in. Get a transcript out.
 3. **Record a meeting** -- Capture system audio + mic, get a transcript when you stop.
 4. **Transform selected text** -- Press a bound Transform hotkey to rewrite selected text through your configured LLM provider.
@@ -81,7 +81,7 @@ This is not privacy theater ("your data is encrypted in transit"). This is priva
 
 MacWhisper has 50+ features. MacParakeet has three capture modes plus Transforms.
 
-- **Dictate** -- Tap Fn+Space or hold Fn, speak, and text appears at cursor. Works in any app.
+- **Dictate** -- Double-tap Fn or hold Fn, speak, and text appears at cursor. Works in any app.
 - **Transcribe** -- Drop a file, get text out. Audio, video, YouTube links.
 - **Record** -- Capture a meeting (system audio + mic), get a transcript.
 - **Transform** -- Select text anywhere, press a bound hotkey, rewrite it through your configured LLM provider.
@@ -136,9 +136,9 @@ That does not mean monetization is permanently forbidden. GPL permits charging f
 +-----------------------------------------------------------------------+
 |  Any app. Any text field. Any time.                                   |
 |                                                                       |
-|  1. Hold Fn for push-to-talk or tap Fn+Space for hands-free           |
+|  1. Hold Fn for push-to-talk or double-tap Fn for hands-free          |
 |  2. Speak naturally                                                   |
-|  3. Release Fn, or tap Fn+Space again                                 |
+|  3. Release Fn, or tap Fn again                                       |
 |  4. Clean text appears at cursor in <500ms                            |
 |                                                                       |
 |  +-----------------------------------------+                          |

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -144,7 +144,7 @@ Dictation defaults to a built-in shared `Fn` gesture preset: hold `Fn` for push-
 | **Hands-free** | Double-tap Fn by default, or tap the configured hands-free shortcut | Persistent recording. Tap the shortcut again to stop. |
 | **Press-and-hold** | Hold the push-to-talk shortcut | Hold-to-talk. Release auto-stops and pastes. |
 
-Legacy single-hotkey installs are migrated to the shared default gesture when the stored trigger is `Fn`. Otherwise the old trigger becomes push-to-talk, while hands-free moves to the default `Fn` preset or disables itself if that would conflict.
+Legacy default installs using `Fn+Space` hands-free plus `Fn` push-to-talk migrate to the shared `Fn` gesture preset. Legacy single-hotkey installs are migrated to the shared default gesture when the stored trigger is `Fn`. Otherwise the old trigger becomes push-to-talk, while hands-free moves to the default `Fn` preset or disables itself if that would conflict.
 
 **Implementation:**
 - `CGEvent` tap for system-wide key event interception

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -16,7 +16,7 @@ See [00-vision.md](./00-vision.md) for positioning and market context.
 │  v0.1 - "Core" (MVP)                                            │
 │  "Dictation + Transcription — fast, private, done"              │
 ├─────────────────────────────────────────────────────────────────┤
-│  • System-wide dictation (Fn hold + Fn+Space hands-free)        │
+│  • System-wide dictation (hold Fn + double-tap Fn hands-free)   │
 │  • Persistent idle pill (always-visible click-to-dictate pill)  │
 │  • File transcription (drag-and-drop audio/video)               │
 │  • Menu bar app with main window                                │
@@ -137,14 +137,14 @@ See [00-vision.md](./00-vision.md) for positioning and market context.
 
 **Activation — Configurable Hotkey:**
 
-Dictation has two configurable shortcuts: push-to-talk defaults to `Fn`, and hands-free mode defaults to `Fn+Space`. The "record a shortcut" UI supports bare modifiers (Fn, Control, etc.), standalone keys (F5, Tab, etc.), modifier+key chords (Fn+Space, Cmd+9, Ctrl+Shift+D), and modifier-only chords (Command+Option, including side-specific variants like Right Command+Right Option). See ADR-009 for full details. The two dictation shortcuts must be distinct and non-overlapping; Settings blocks assigning conflicting triggers to both roles.
+Dictation defaults to a built-in shared `Fn` gesture preset: hold `Fn` for push-to-talk, or double-tap `Fn` for hands-free mode. `Fn+Fn` is not a customizable recorded hotkey; choosing restore default returns to this preset. Each dictation role can still be assigned a custom shortcut. The "record a shortcut" UI supports bare modifiers (Fn, Control, etc.), standalone keys (F5, Tab, etc.), modifier+key chords (Fn+Space, Cmd+9, Ctrl+Shift+D), and modifier-only chords (Command+Option, including side-specific variants like Right Command+Right Option). See ADR-009 for full details. Custom dictation shortcuts must be distinct and non-overlapping; Settings blocks assigning conflicting triggers to both roles.
 
 | Mode | Gesture | Behavior |
 |------|---------|----------|
-| **Hands-free** | Tap the hands-free shortcut | Persistent recording. Tap the shortcut again to stop. |
+| **Hands-free** | Double-tap Fn by default, or tap the configured hands-free shortcut | Persistent recording. Tap the shortcut again to stop. |
 | **Press-and-hold** | Hold the push-to-talk shortcut | Hold-to-talk. Release auto-stops and pastes. |
 
-Legacy single-hotkey installs are migrated to distinct shortcuts where possible: the old trigger becomes push-to-talk, while hands-free moves to the default `Fn+Space` or disables itself if that would conflict.
+Legacy single-hotkey installs are migrated to the shared default gesture when the stored trigger is `Fn`. Otherwise the old trigger becomes push-to-talk, while hands-free moves to the default `Fn` preset or disables itself if that would conflict.
 
 **Implementation:**
 - `CGEvent` tap for system-wide key event interception
@@ -159,7 +159,7 @@ Legacy single-hotkey installs are migrated to distinct shortcuts where possible:
 - Chord validation: Escape blocked for all kinds. Modifier+key chords containing Command warn about system shortcut conflicts (Cmd+Tab, Cmd+Space, Cmd+Q/W/H/M). Fn is allowed in modifier+key chords such as Fn+Space.
 - Hands-free key-down: toggles persistent recording immediately for key and modifier+key triggers; bare modifier hands-free triggers toggle on bare release so normal modifier shortcuts are not captured.
 - Dedicated push-to-talk key-down: schedule only the startup debounce, then start hold-to-talk.
-- Duplicate or overlapping dictation shortcuts: conflicting assignments are rejected in Settings and reported at runtime instead of creating a hidden combined gesture.
+- Duplicate or overlapping dictation shortcuts: the built-in shared `Fn` default is allowed as a gesture preset; other conflicting assignments are rejected in Settings and reported at runtime instead of creating a hidden combined gesture.
 - On key-up: dedicated push-to-talk releases after startup debounce stop and process.
 - Escape is permanently reserved for cancel-dictation and cannot be assigned as hotkey
 - Requires Accessibility permission (prompted on first activation).
@@ -171,7 +171,7 @@ Legacy single-hotkey installs are migrated to distinct shortcuts where possible:
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │ 1. User activates recording:                                     │
-│    - Tap the hands-free shortcut (Fn+Space by default), OR       │
+│    - Double-tap Fn, or tap the configured hands-free shortcut, OR│
 │    - Hold the push-to-talk shortcut (Fn by default)              │
 ├─────────────────────────────────────────────────────────────────┤
 │ 2. Overlay appears (bottom-center pill)                          │
@@ -445,7 +445,7 @@ The app lives primarily in the menu bar. Click the icon for quick actions, or op
 ┌────────────────────────────┐
 │ 🎙 MacParakeet              │
 ├────────────────────────────┤
-│ Start Dictation  Fn+Space   │
+│ Start Dictation  Hold/Tap Fn│
 │ Open Window            ⌘O   │
 ├────────────────────────────┤
 │ Recent Files            ►   │
@@ -609,7 +609,7 @@ Audio path is computed from ID by default. Files stored as WAV (16kHz mono). Use
 │ DICTATION                                                        │
 │ ┌──────────────────────────────────────────────────────────────┐ │
 │ │ Push to talk: [fn Fn   Change...]                          │ │
-│ │ Hands-free:  [fn+Space Change...]                          │ │
+│ │ Hands-free:  [fn Fn   Change...]                          │ │
 │ │                                                              │ │
 │ │ Stop mode:                                                   │ │
 │ │   ( ) Auto-stop after silence     Delay: [2 sec ▾]          │ │
@@ -648,7 +648,7 @@ Audio path is computed from ID by default. Files stored as WAV (16kHz mono). Use
 |---------|---------|---------|
 | Launch at login | On / Off | Off |
 | Push-to-talk hotkey | Bare modifiers, standalone keys, modifier+key chords, and modifier-only chords with overlap checks | Fn |
-| Hands-free hotkey | Bare modifiers, standalone keys, modifier+key chords, and modifier-only chords with overlap checks | Fn+Space |
+| Hands-free hotkey | Default shared Fn gesture preset; custom bare modifiers, standalone keys, modifier+key chords, and modifier-only chords with overlap checks | Fn |
 | Stop mode | Auto-stop after silence / Manual | Manual |
 | Silence delay | 1s, 1.5s, 2s, 3s, 5s | 2s |
 | Save audio recordings | On / Off | On |

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -223,7 +223,7 @@ Persistent floating pill at the bottom-center of the screen, always visible when
 
 ```
   ╭────────────────────────────────────────────╮
-  │  Click, tap fn+Space or hold fn to dictate │  ← tooltip bubble
+  │  Click, tap fn or hold fn to dictate       │  ← tooltip bubble
   ╰────────────────────────────────────────────╯
 ┌──────────────────────────────────────────┐
 │    ╭──────────────────────────────╮      │
@@ -233,7 +233,7 @@ Persistent floating pill at the bottom-center of the screen, always visible when
 
 - 148×30pt expanded dark capsule (black 85%)
 - 12 small dots (3pt, white 25%) inside pill
-- Tooltip bubble above: "Click, tap fn+Space or hold fn to dictate"
+- Tooltip bubble above: "Click, tap fn or hold fn to dictate"
   - Shortcut tokens in pink (0.85, 0.55, 0.75)
   - Dark capsule background (black 90%) with white 10% stroke
 ```
@@ -747,7 +747,7 @@ Settings open in the content area when "Settings" is selected in the sidebar. Th
 │  Push to talk                [fn Fn        ▾]          │
 │  (Hold to dictate, release to stop)                       │
 │                                                           │
-│  Hands-free mode             [fn+Space    ▾]          │
+│  Hands-free mode             [fn          ▾]          │
 │  (Tap to start, tap again to stop)                       │
 │                                                           │
 │  Silence threshold            [──●──────── 2.0s]        │

--- a/spec/09-testing.md
+++ b/spec/09-testing.md
@@ -278,27 +278,27 @@ Tests/
 
 These flows must be tested manually after any overlay or hotkey changes. Automated unit tests cover the state machine logic, but the full UX requires human verification.
 
-> **Note:** "Fn+Space" below refers to the configured hands-free shortcut, and "Fn" refers to the configured push-to-talk shortcut. Defaults are Fn+Space for hands-free and Fn for push-to-talk. The two dictation shortcuts must be distinct and non-overlapping; Settings should reject conflicting triggers for the two roles. Test with at least two different trigger keys.
+> **Note:** The default dictation preset uses `Fn` for both roles: double-tap `Fn` for hands-free, and hold `Fn` for push-to-talk. `Fn+Space` is a supported custom hands-free chord and should remain recordable. Custom dictation shortcuts must be distinct and non-overlapping; Settings should reject conflicting triggers for the two roles. Test with at least two different trigger keys.
 
 ### Happy Path
 
 | # | Flow | Steps | Expected |
 |---|------|-------|----------|
-| 1 | Persistent recording | Fn+Space → speak → Fn+Space | Pill appears → waveform animates → checkmark → text pasted |
+| 1 | Persistent recording | Double-tap Fn → speak → tap Fn | Pill appears → waveform animates → checkmark → text pasted |
 | 2 | Hold-to-talk | Hold Fn (>400ms) → speak → release Fn | Pill appears → waveform → checkmark → text pasted |
 
 ### Cancel & Undo Flows
 
 | # | Flow | Steps | Expected |
 |---|------|-------|----------|
-| 3 | Cancel via Esc | Fn+Space → Esc | Pill shows countdown ring (5s) → auto-dismiss |
-| 4 | Cancel via X button | Fn+Space → click X | Same as Esc cancel — countdown → auto-dismiss |
-| 5 | Undo after Esc cancel | Fn+Space → Esc → click Undo | Recording restarts, pill shows waveform again |
-| 6 | Undo after X cancel | Fn+Space → click X → click Undo | Recording restarts, pill shows waveform again |
-| 7 | **Hands-free after undo** | Fn+Space → cancel → Undo → Fn+Space | Recording stops, checkmark, text pasted |
-| 8 | **New hands-free recording after undo** | Fn+Space → cancel → Undo → Fn+Space → Fn+Space | New recording starts |
-| 9 | Hands-free blocked during cancel | Fn+Space → Esc → Fn+Space (during countdown) | Nothing happens — shortcut is blocked |
-| 10 | Cancel countdown expires | Fn+Space → Esc → wait 5s | Pill auto-dismisses, Fn+Space works again |
+| 3 | Cancel via Esc | Double-tap Fn → Esc | Pill shows countdown ring (5s) → auto-dismiss |
+| 4 | Cancel via X button | Double-tap Fn → click X | Same as Esc cancel — countdown → auto-dismiss |
+| 5 | Undo after Esc cancel | Double-tap Fn → Esc → click Undo | Recording restarts, pill shows waveform again |
+| 6 | Undo after X cancel | Double-tap Fn → click X → click Undo | Recording restarts, pill shows waveform again |
+| 7 | **Hands-free after undo** | Double-tap Fn → cancel → Undo → tap Fn | Recording stops, checkmark, text pasted |
+| 8 | **New hands-free recording after undo** | Double-tap Fn → cancel → Undo → tap Fn → double-tap Fn | New recording starts |
+| 9 | Hands-free blocked during cancel | Double-tap Fn → Esc → Fn (during countdown) | Nothing happens — shortcut is blocked |
+| 10 | Cancel countdown expires | Double-tap Fn → Esc → wait 5s | Pill auto-dismisses, Fn works again |
 
 ### Configurable Hotkey
 
@@ -308,18 +308,18 @@ These flows must be tested manually after any overlay or hotkey changes. Automat
 | 10b | New trigger works | Ctrl+Space → speak → Ctrl+Space | Recording starts/stops with new shortcut |
 | 10c | Bare-tap filtering | Hold Ctrl → press C → release Ctrl | Does NOT trigger dictation (keyboard shortcut) |
 | 10d | Single-tap modifier filtering | Ctrl → type "hello" → release Ctrl | Does NOT trigger dictation |
-| 10e | Switch back to Fn+Space | Settings → Shortcuts → Hands-free mode → select Fn+Space | Fn+Space works again, Ctrl no longer triggers |
-| 10f | Dynamic UI text | Change to Option+Space → check overlay/pill/history | All say "Option+Space" instead of "Fn+Space" |
-| 10g | Conflicting dictation shortcut blocked | Try setting both dictation shortcuts to Fn, then try an overlapping pair such as Control and Control+Space | Settings rejects the second assignment with a conflict message |
+| 10e | Record Fn+Space custom chord | Settings → Shortcuts → Hands-free mode → record Fn+Space | Fn+Space works, Ctrl no longer triggers |
+| 10f | Dynamic UI text | Change to Option+Space → check overlay/pill/history | All say "Option+Space" instead of "Fn" |
+| 10g | Conflicting custom dictation shortcut blocked | Restore default so both roles use Fn, then try an overlapping custom pair such as Control and Control+Space | Default Fn preset is accepted; Settings rejects the custom conflict with a conflict message |
 
 ### State Transitions
 
 | # | Flow | Steps | Expected |
 |---|------|-------|----------|
-| 11 | Recording → Processing | Fn+Space → speak → Fn+Space | Pill smoothly transitions from waveform to spinner |
+| 11 | Recording → Processing | Double-tap Fn → speak → tap Fn | Pill smoothly transitions from waveform to spinner |
 | 12 | Processing → Success | (after transcription completes) | Animated checkmark appears, then text pastes |
 | 13 | Error display | (trigger STT error) | Error card (rounded rect, icon, title+subtitle, dismiss button) |
-| 13a | Delayed first-stop race | Fn+Space, then immediately Fn+Space while first start is still spinning up | Stop is deferred, then processing/paste completes once recording is active (no silent drop) |
+| 13a | Delayed first-stop race | Double-tap Fn, then immediately tap Fn while first start is still spinning up | Stop is deferred, then processing/paste completes once recording is active (no silent drop) |
 
 ### Hover Tooltips
 

--- a/spec/adr/009-custom-hotkey.md
+++ b/spec/adr/009-custom-hotkey.md
@@ -50,12 +50,12 @@ Community issue #17 requested modifier+key combos (e.g., Cmd+9) because Logitech
 2. **Release-any-part stops** — For hold-to-talk with Cmd+9, releasing either Cmd or 9 ends dictation.
 3. **Key swallowed, modifiers passed** — The trigger key event is swallowed; modifier flag changes pass through to the active app.
 4. **Required modifiers must be present** — Mask to 5 relevant bits (fn⌃⌥⇧⌘) before comparing. Caps Lock, NumPad, etc. are stripped.
-5. **Fn allowed in key chords** — Fn+Space is the default hands-free dictation shortcut. Bare Fn remains available for push-to-talk.
+5. **Fn allowed in key chords** — Fn+Space is supported as a custom hands-free dictation shortcut. The default dictation behavior is a shared bare-Fn gesture preset: double-tap Fn for hands-free and hold Fn for push-to-talk.
 6. **FnKeyStateMachine unchanged** — Key-agnostic. Chords generate role-specific down/up signals, including hands-free single-tap toggle and hold-to-talk.
 7. **Modifier names stored as `[String]`** — Not raw `CGEventFlags.rawValue` (has phantom bits). Readable JSON: `{"kind":"chord","keyCode":25,"chordModifiers":["command"]}`.
 8. **HotkeyRecorderView two-phase capture** — Held modifiers show as preview (e.g. "⌘..."); pressing a key with modifiers held creates a chord; releasing all modifiers without a key press creates a bare modifier trigger.
 9. **Validation** — Chords are `.allowed` by default. Escape blocked. Cmd+Tab and Cmd+Space warned (system intercepts them).
-10. **Distinct dictation roles** — Hands-free and push-to-talk cannot be manually assigned overlapping triggers. Settings blocks conflicting assignments, while legacy single-hotkey installs migrate to distinct shortcuts where possible.
+10. **Distinct dictation roles** — Hands-free and push-to-talk cannot be manually assigned overlapping triggers. Settings blocks conflicting assignments, except for the built-in shared Fn default gesture preset. Legacy single-hotkey installs migrate to the shared default gesture when appropriate, or to distinct shortcuts where possible.
 
 ### Original decision preserved
 


### PR DESCRIPTION
## What Changed
- Preserve physical modifier keyCodes for standard Settings `Change...` recordings when the saved hotkey is modifier-only.
- Make the default dictation preset a shared `Fn` gesture: double-tap `Fn` for hands-free and hold `Fn` for push-to-talk.
- Migrate legacy default installs from `Fn+Space` hands-free plus `Fn` push-to-talk to the shared `Fn` gesture preset, while preserving explicit `Fn+Space` customizations when push-to-talk is custom.
- Keep `Fn+Space` available as a custom hands-free chord and fix recording it when macOS omits the function flag on Space keyDown.
- Allow only the built-in shared `Fn` default to overlap; custom overlapping dictation shortcuts remain blocked.
- Update hotkey specs, ADR notes, and manual QA for the new default preset.

## Root Cause
There were two hotkey modeling issues.

First, the standard modifier-chord recorder displayed physical left/right modifiers while recording, but persisted modifier-only chords without keyCodes. That made recordings like Left Option + Left Command behave as generic Option + Command at runtime.

Second, dictation defaults still modeled hands-free as `Fn+Space` even though the product default gesture is `Fn+Fn`. `Fn+Fn` should not be a customizable chord; it should be the built-in default gesture preset users can return to via restore default. Existing installs that had the old default pair persisted also needed migration so they do not remain stranded on `Fn+Space`. Separately, `Fn+Space` recording failed because the recorder only trusted keyDown modifier flags, and macOS can omit `.function` even after the recorder has observed Fn in pending modifier state.

## Verification
- `git diff --check`
- `swift test --filter HotkeyRecorderViewTests`
- `swift test --filter HotkeyManagerTests`
- `swift test --filter SideSpecific`
- `swift test --filter Hotkey`
- `swift test --filter SettingsHotkeyConflictMessageTests`
- `swift test --filter SettingsViewModelTests/testLegacyFnSpace --filter SettingsViewModelTests/testStoredFnSpaceHandsFreePersistsWhenDedicatedPushToTalkIsCustom --filter Hotkey`
- `swift test`
