### PR TITLE
Preserve side-specific modifier chords

### DIFF
--- a/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
+++ b/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
@@ -377,8 +377,8 @@ struct HotkeyRecorderView: View {
     }
 
     /// Map a modifier name + physical keyCode to a bare modifier trigger.
-    /// Generic capture preserves the legacy "either side" behavior. Side-specific capture
-    /// records the physical left/right key that was used during recording.
+    /// Generic capture preserves the legacy "either side" behavior. Standard
+    /// and side-specific capture record the physical left/right key used.
     static func bareModifierTrigger(
         for name: String,
         keyCode: UInt16,
@@ -403,13 +403,13 @@ struct HotkeyRecorderView: View {
     ) -> HotkeyTrigger? {
         let trigger: HotkeyTrigger
         switch captureMode {
-        case .standard, .generic:
+        case .generic:
             trigger = HotkeyTrigger.modifierChord(
                 components: components.map {
                     HotkeyTrigger.ModifierComponent(modifierName: $0.modifierName)
                 }
             )
-        case .sideSpecific:
+        case .standard, .sideSpecific:
             trigger = HotkeyTrigger.modifierChord(components: components)
         }
 

--- a/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
@@ -7,6 +7,7 @@ final class HotkeyManagerTests: XCTestCase {
     private let leftOptionMask = UInt64(NX_DEVICELALTKEYMASK)
     private let rightOptionMask = UInt64(NX_DEVICERALTKEYMASK)
     private let leftShiftMask = UInt64(NX_DEVICELSHIFTKEYMASK)
+    private let rightShiftMask = UInt64(NX_DEVICERSHIFTKEYMASK)
     private let leftCommandMask = UInt64(NX_DEVICELCMDKEYMASK)
     private let rightCommandMask = UInt64(NX_DEVICERCMDKEYMASK)
 
@@ -1589,6 +1590,42 @@ final class HotkeyManagerTests: XCTestCase {
                 timestampMs: 1_050
             ),
             [.cancelStartupDebounce, .cancelHoldWindow, .showReadyForSecondTap]
+        )
+    }
+
+    func testSideSpecificSameModifierChordRequiresBothRecordedSides() {
+        let trigger = HotkeyTrigger.modifierChord(
+            components: [
+                .init(modifierName: "shift", keyCode: 56),
+                .init(modifierName: "shift", keyCode: 60),
+            ]
+        )
+        let manager = HotkeyManager(trigger: trigger)
+
+        XCTAssertEqual(
+            manager.modifierChordFlagsChangedOutputsForTesting(
+                flags: sideSpecificFlags(
+                    CGEventFlags.maskShift.rawValue,
+                    leftShiftMask
+                ),
+                timestampMs: 1_000
+            ),
+            []
+        )
+
+        XCTAssertEqual(
+            manager.modifierChordFlagsChangedOutputsForTesting(
+                flags: sideSpecificFlags(
+                    CGEventFlags.maskShift.rawValue,
+                    leftShiftMask,
+                    rightShiftMask
+                ),
+                timestampMs: 1_025
+            ),
+            [
+                .scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs),
+                .scheduleHoldWindow(milliseconds: FnKeyStateMachine.defaultTapThresholdMs),
+            ]
         )
     }
 

--- a/Tests/MacParakeetTests/Views/Settings/HotkeyRecorderViewTests.swift
+++ b/Tests/MacParakeetTests/Views/Settings/HotkeyRecorderViewTests.swift
@@ -17,6 +17,19 @@ final class HotkeyRecorderViewTests: XCTestCase {
         )
     }
 
+    func testStandardBareShiftCaptureRecordsPhysicalModifierSide() {
+        let candidate = HotkeyRecorderView.bareModifierTrigger(
+            for: "shift",
+            keyCode: 60,
+            captureMode: .standard
+        )
+
+        XCTAssertEqual(
+            candidate,
+            HotkeyTrigger(kind: .modifier, modifierName: "shift", keyCode: nil, modifierKeyCode: 60)
+        )
+    }
+
     func testStandardModifierKeyChordCapturePreservesGenericChordBehavior() {
         let candidate = HotkeyRecorderView.keyChordTrigger(
             modifiers: ["command"],
@@ -25,6 +38,46 @@ final class HotkeyRecorderViewTests: XCTestCase {
         )
 
         XCTAssertEqual(candidate, .chord(modifiers: ["command"], keyCode: 8))
+    }
+
+    func testStandardModifierChordCaptureRecordsPhysicalModifierSides() {
+        let candidate = HotkeyRecorderView.modifierChordTrigger(
+            components: [
+                .init(modifierName: "option", keyCode: 58),
+                .init(modifierName: "command", keyCode: 55),
+            ],
+            captureMode: .standard
+        )
+
+        XCTAssertEqual(
+            candidate,
+            .modifierChord(
+                components: [
+                    .init(modifierName: "option", keyCode: 58),
+                    .init(modifierName: "command", keyCode: 55),
+                ]
+            )
+        )
+    }
+
+    func testStandardSameModifierChordCaptureRecordsBothPhysicalSides() {
+        let candidate = HotkeyRecorderView.modifierChordTrigger(
+            components: [
+                .init(modifierName: "shift", keyCode: 56),
+                .init(modifierName: "shift", keyCode: 60),
+            ],
+            captureMode: .standard
+        )
+
+        XCTAssertEqual(
+            candidate,
+            .modifierChord(
+                components: [
+                    .init(modifierName: "shift", keyCode: 56),
+                    .init(modifierName: "shift", keyCode: 60),
+                ]
+            )
+        )
     }
 
     func testGenericBareModifierCapturePreservesEitherSideBehavior() {

--- a/Tests/MacParakeetTests/Views/Settings/SettingsHotkeyConflictMessageTests.swift
+++ b/Tests/MacParakeetTests/Views/Settings/SettingsHotkeyConflictMessageTests.swift
@@ -57,6 +57,24 @@ final class SettingsHotkeyConflictMessageTests: XCTestCase {
         )
     }
 
+    func testDictationPeerValidationBlocksDuplicateSideSpecificShiftChord() {
+        let bothShifts = HotkeyTrigger.modifierChord(
+            components: [
+                .init(modifierName: "shift", keyCode: 56),
+                .init(modifierName: "shift", keyCode: 60),
+            ]
+        )
+
+        XCTAssertEqual(
+            SettingsDictationHotkeyConflictPolicy.validation(
+                candidate: bothShifts,
+                peer: bothShifts,
+                peerName: "push to talk"
+            ),
+            .blocked("Conflicts with push to talk (L⇧R⇧).")
+        )
+    }
+
     func testDictationPeerValidationAllowsDistinctDefaults() {
         XCTAssertNil(
             SettingsDictationHotkeyConflictPolicy.validation(


### PR DESCRIPTION
## What Changed
- Preserve physical modifier keyCodes for standard Settings `Change...` recordings when the saved hotkey is modifier-only.
- Keep explicit either-side recording behavior unchanged; generic capture still strips physical sides by design.
- Add regression coverage for:
  - standard left/right modifier-only chords such as Left Option + Left Command,
  - left-shift + right-shift capture and runtime matching,
  - duplicate dictation-hotkey validation for side-specific Shift chords.

## Root Cause
The previous side-specific hotkey runtime fix was still intact. The regression was at the recorder persistence boundary: `HotkeyRecorderView.modifierChordTrigger` treated `.standard` recording the same as `.generic`, stripping each `ModifierComponent.keyCode` before saving.

That made the recording UI appear side-specific while the saved trigger became a generic modifier chord, so Left Option + Left Command could be triggered by either left or right modifiers.

## Verification
- `git diff --check origin/main...HEAD`
- `swift test --filter Hotkey`
- Prior local validation on the same narrow diff before the unrelated PR branch update: `swift test`, `swift test --filter HotkeyRecorderViewTests`, `swift test --filter HotkeyManagerTests`, `swift test --filter SideSpecific`, `swift test --filter SettingsHotkeyConflictMessageTests`
