### PR TITLE
Clarify shared Fn hands-free default copy

### DIFF
--- a/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
+++ b/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
@@ -117,7 +117,7 @@ final class AppHotkeyCoordinator {
             return "Dictation Shortcuts: Disabled"
         }
         if HotkeyTrigger.isDefaultDictationGesturePreset(handsFree: handsFree, pushToTalk: pushToTalk) {
-            return "Dictation: Hold Fn / Tap Fn"
+            return "Dictation: Hold Fn / Double-tap Fn"
         }
         if handsFree.overlaps(with: pushToTalk) {
             let conflictName = handsFree == pushToTalk

--- a/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
+++ b/Sources/MacParakeet/Views/Settings/HotkeyRecorderView.swift
@@ -16,6 +16,8 @@ struct HotkeyRecorderView: View {
 
     @Binding var trigger: HotkeyTrigger
     var defaultTrigger: HotkeyTrigger = .fn
+    var displayLabelOverride: String? = nil
+    var defaultLabelOverride: String? = nil
     var additionalValidation: ((HotkeyTrigger) -> HotkeyTrigger.ValidationResult)? = nil
     /// Called with `true` when the user enters recording mode (just before
     /// the local NSEvent monitor is attached) and `false` when the matching
@@ -64,7 +66,7 @@ struct HotkeyRecorderView: View {
                     .font(DesignSystem.Typography.body)
                     .foregroundStyle(.secondary)
             } else {
-                Text(trigger.formattedLabel)
+                Text(displayLabelOverride ?? trigger.formattedLabel)
                     .font(DesignSystem.Typography.body)
                     .foregroundStyle(.primary)
             }
@@ -85,7 +87,7 @@ struct HotkeyRecorderView: View {
                     Divider()
                 }
 
-                Button("Reset to Default (\(Self.resetLabel(for: defaultTrigger)))") {
+                Button("Reset to Default (\(defaultLabelOverride ?? Self.resetLabel(for: defaultTrigger)))") {
                     resetToDefault()
                 }
                 .disabled(trigger == defaultTrigger)

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -602,13 +602,15 @@ struct SettingsView: View {
                 HStack(alignment: .center) {
                     rowText(
                         title: "Hands-free mode",
-                        detail: "Tap to start; tap again to stop."
+                        detail: handsFreeHotkeyDetail
                     )
                     Spacer(minLength: DesignSystem.Spacing.md)
                     VStack(alignment: .trailing, spacing: 4) {
                         HotkeyRecorderView(
                             trigger: $viewModel.hotkeyTrigger,
                             defaultTrigger: .defaultDictation,
+                            displayLabelOverride: handsFreeHotkeyDisplayLabelOverride,
+                            defaultLabelOverride: handsFreeHotkeyDefaultLabelOverride,
                             additionalValidation: { candidate in
                                 dictationHotkeyValidation(for: candidate)
                             },
@@ -2331,7 +2333,7 @@ struct SettingsView: View {
                 modeShortcutRow(
                     keys: [viewModel.hotkeyTrigger.shortSymbol],
                     separator: nil,
-                    verb: "Tap",
+                    verb: usesDefaultDictationGesturePreset ? "Double-tap" : "Tap",
                     action: "Hands-free mode",
                     detail: "Tap again to stop"
                 )
@@ -2342,6 +2344,31 @@ struct SettingsView: View {
             RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
                 .fill(DesignSystem.Colors.surfaceElevated)
         )
+    }
+
+    private var usesDefaultDictationGesturePreset: Bool {
+        HotkeyTrigger.isDefaultDictationGesturePreset(
+            handsFree: viewModel.hotkeyTrigger,
+            pushToTalk: viewModel.pushToTalkHotkeyTrigger
+        )
+    }
+
+    private var handsFreeHotkeyDetail: String {
+        if usesDefaultDictationGesturePreset {
+            return "Double-tap Fn to start; tap Fn again to stop."
+        }
+        return "Tap to start; tap again to stop."
+    }
+
+    private var handsFreeHotkeyDisplayLabelOverride: String? {
+        usesDefaultDictationGesturePreset ? "Double-tap Fn" : nil
+    }
+
+    private var handsFreeHotkeyDefaultLabelOverride: String? {
+        HotkeyTrigger.isDefaultDictationGesturePreset(
+            handsFree: .defaultDictation,
+            pushToTalk: viewModel.pushToTalkHotkeyTrigger
+        ) ? "Double-tap Fn" : nil
     }
 
     private func modeShortcutRow(

--- a/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
@@ -68,7 +68,7 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
     func testMenuTitleDescribesSharedDictationTrigger() {
         XCTAssertEqual(
             AppHotkeyCoordinator.menuTitle(handsFree: .fn, pushToTalk: .fn),
-            "Dictation: Hold Fn / Tap Fn"
+            "Dictation: Hold Fn / Double-tap Fn"
         )
     }
 


### PR DESCRIPTION
## Summary
- Show the default hands-free Fn shortcut as `Double-tap Fn` when push-to-talk and hands-free share the default Fn gesture preset.
- Keep custom hands-free shortcuts on the normal single-tap copy.
- Update the menu-bar title for the shared default to `Hold Fn / Double-tap Fn`.

## Root cause
The effective default behavior was already correct: `Fn` + `Fn` is collapsed into one double-tap-and-hold dictation manager. Settings was still rendering the raw stored hands-free trigger, so it looked like an accidental duplicate and described the hands-free side as `Tap`.

## Verification
- `git diff --check`
- `swift test --filter Hotkey`
- `swift test`