### PR TITLE
Add polished text snippet editing

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -95,6 +95,8 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
   meeting outputs already exist before fetching result rows.
 - `llm` commands using `--provider lmstudio` now honor optional LM Studio API
   tokens via `--api-key`, `--api-key-env`, or `LM_API_TOKEN`.
+- `vocab snippets edit <id> --trigger ... --expansion ...` updates an existing
+  text snippet without deleting/recreating it.
 
 ### Changed
 

--- a/Sources/CLI/Commands/VocabSnippetsCommand.swift
+++ b/Sources/CLI/Commands/VocabSnippetsCommand.swift
@@ -9,6 +9,7 @@ struct VocabSnippetsCommand: AsyncParsableCommand {
         subcommands: [
             ListSnippets.self,
             AddSnippet.self,
+            EditSnippet.self,
             DeleteSnippet.self,
         ],
         defaultSubcommand: ListSnippets.self
@@ -84,6 +85,63 @@ struct VocabSnippetsCommand: AsyncParsableCommand {
         }
     }
 
+    struct EditSnippet: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "edit",
+            abstract: "Edit a text snippet by ID."
+        )
+
+        @Argument(help: "The UUID (or prefix) of the snippet to edit.")
+        var id: String
+
+        @Option(help: "Replacement trigger phrase. Omit to keep the existing trigger.")
+        var trigger: String?
+
+        @Option(help: "Replacement expansion text. Omit to keep the existing expansion.")
+        var expansion: String?
+
+        @Option(help: "Path to SQLite database file (defaults to the app database).")
+        var database: String?
+
+        func run() async throws {
+            guard trigger != nil || expansion != nil else {
+                throw ValidationError("Provide --trigger, --expansion, or both.")
+            }
+
+            try AppPaths.ensureDirectories()
+            let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
+            let repo = TextSnippetRepository(dbQueue: dbManager.dbQueue)
+            let snippets = try repo.fetchAll()
+            var snippet = try VocabSnippetsCommand.resolveSnippet(id: id, snippets: snippets)
+
+            if let trigger {
+                let trimmed = trigger.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty else {
+                    throw ValidationError("Trigger cannot be empty.")
+                }
+                if snippets.contains(where: {
+                    $0.id != snippet.id
+                        && $0.trigger.caseInsensitiveCompare(trimmed) == .orderedSame
+                }) {
+                    throw VocabError.duplicate("Snippet trigger '\(trimmed)' already exists.")
+                }
+                snippet.trigger = trimmed
+            }
+
+            if let expansion {
+                let processed = VocabSnippetsCommand.processedExpansion(from: expansion)
+                guard !processed.isEmpty else {
+                    throw ValidationError("Expansion cannot be empty.")
+                }
+                snippet.expansion = processed
+            }
+
+            snippet.updatedAt = Date()
+            try repo.save(snippet)
+            print("Updated: Say \"\(snippet.trigger)\" -> \(snippet.expansion)")
+        }
+    }
+
     struct DeleteSnippet: AsyncParsableCommand {
         static let configuration = CommandConfiguration(
             commandName: "delete",
@@ -101,19 +159,40 @@ struct VocabSnippetsCommand: AsyncParsableCommand {
             let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
             let repo = TextSnippetRepository(dbQueue: dbManager.dbQueue)
 
-            // Support UUID prefix matching
             let snippets = try repo.fetchAll()
-            let matches = snippets.filter { $0.id.uuidString.lowercased().hasPrefix(id.lowercased()) }
-
-            guard let snippet = matches.first else {
-                throw VocabError.notFound("No snippet matching '\(id)'")
-            }
-            guard matches.count == 1 else {
-                throw VocabError.ambiguous("Multiple snippets match '\(id)'. Be more specific.")
-            }
+            let snippet = try VocabSnippetsCommand.resolveSnippet(
+                id: id,
+                snippets: snippets,
+                minimumPrefixLength: 1
+            )
 
             _ = try repo.delete(id: snippet.id)
             print("Deleted: \"\(snippet.trigger)\"")
         }
+    }
+
+    private static func resolveSnippet(
+        id: String,
+        snippets: [TextSnippet],
+        minimumPrefixLength: Int = 4
+    ) throws -> TextSnippet {
+        let searchID = id.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard searchID.count >= minimumPrefixLength else {
+            throw ValidationError("ID prefix must be at least \(minimumPrefixLength) characters.")
+        }
+        let matches = snippets.filter { $0.id.uuidString.lowercased().hasPrefix(searchID) }
+
+        guard let snippet = matches.first else {
+            throw VocabError.notFound("No snippet matching '\(id)'")
+        }
+        guard matches.count == 1 else {
+            throw VocabError.ambiguous("Multiple snippets match '\(id)'. Be more specific.")
+        }
+        return snippet
+    }
+
+    private static func processedExpansion(from raw: String) -> String {
+        raw.trimmingCharacters(in: .whitespaces)
+            .replacingOccurrences(of: "\\n", with: "\n")
     }
 }

--- a/Sources/CLI/Commands/VocabWordsCommand.swift
+++ b/Sources/CLI/Commands/VocabWordsCommand.swift
@@ -137,11 +137,13 @@ struct VocabWordsCommand: AsyncParsableCommand {
 enum VocabError: Error, LocalizedError {
     case notFound(String)
     case ambiguous(String)
+    case duplicate(String)
 
     var errorDescription: String? {
         switch self {
         case .notFound(let msg): return msg
         case .ambiguous(let msg): return msg
+        case .duplicate(let msg): return msg
         }
     }
 }

--- a/Sources/MacParakeet/Views/Vocabulary/TextSnippetsView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/TextSnippetsView.swift
@@ -152,11 +152,22 @@ struct TextSnippetsView: View {
 
     // MARK: - Rows
 
+    @ViewBuilder
     private func snippetRow(_ snippet: TextSnippet) -> some View {
+        if viewModel.editingSnippetID == snippet.id {
+            SnippetEditRow(
+                viewModel: viewModel,
+                snippet: snippet,
+                usageHint: snippetUsageHint(snippet)
+            )
+        } else {
+            snippetDisplayRow(snippet)
+        }
+    }
+
+    private func snippetDisplayRow(_ snippet: TextSnippet) -> some View {
         let isHovered = hoveredSnippetID == snippet.id
-        let usageHint: String = snippet.useCount > 0
-            ? "Used \(snippet.useCount) time\(snippet.useCount == 1 ? "" : "s")"
-            : "Not yet used"
+        let usageHint = snippetUsageHint(snippet)
         return HStack(spacing: DesignSystem.Spacing.md) {
             Toggle("", isOn: Binding(
                 get: { snippet.isEnabled },
@@ -182,26 +193,23 @@ struct TextSnippetsView: View {
             Spacer(minLength: DesignSystem.Spacing.sm)
 
             if snippet.useCount > 0 {
-                HStack(spacing: 3) {
-                    Image(systemName: "chart.bar.fill")
-                        .font(.system(size: 9, weight: .semibold))
-                    Text("\(snippet.useCount)")
-                        .font(DesignSystem.Typography.micro.weight(.medium))
-                        .monospacedDigit()
-                }
-                .foregroundStyle(.secondary)
-                .padding(.horizontal, 7)
-                .padding(.vertical, 3)
-                .background(Capsule().fill(DesignSystem.Colors.surfaceElevated))
-                .help(usageHint)
-                .accessibilityLabel(usageHint)
+                SnippetUsageBadge(useCount: snippet.useCount, usageHint: usageHint)
             }
 
-            DeleteIconButton(
-                helpText: "Delete \(snippet.trigger)",
-                accessibilityName: "Delete \(snippet.trigger)"
-            ) {
-                viewModel.pendingDeleteSnippet = snippet
+            HStack(spacing: DesignSystem.Spacing.sm) {
+                EditIconButton(
+                    helpText: "Edit \(snippet.trigger)",
+                    accessibilityName: "Edit \(snippet.trigger)"
+                ) {
+                    viewModel.beginEditing(snippet)
+                }
+
+                DeleteIconButton(
+                    helpText: "Delete \(snippet.trigger)",
+                    accessibilityName: "Delete \(snippet.trigger)"
+                ) {
+                    viewModel.pendingDeleteSnippet = snippet
+                }
             }
         }
         .padding(.horizontal, DesignSystem.Spacing.md)
@@ -213,6 +221,12 @@ struct TextSnippetsView: View {
                 hoveredSnippetID = hovering ? snippet.id : nil
             }
         }
+    }
+
+    private func snippetUsageHint(_ snippet: TextSnippet) -> String {
+        snippet.useCount > 0
+            ? "Used \(snippet.useCount) time\(snippet.useCount == 1 ? "" : "s")"
+            : "Not yet used"
     }
 
     private var emptyState: some View {
@@ -277,5 +291,111 @@ struct TextSnippetsView: View {
         let expansionEmpty = viewModel.newExpansion.trimmingCharacters(in: .whitespaces).isEmpty
         guard !triggerEmpty && !expansionEmpty else { return }
         viewModel.addSnippet()
+    }
+}
+
+private struct SnippetEditRow: View {
+    @Bindable var viewModel: TextSnippetsViewModel
+    let snippet: TextSnippet
+    let usageHint: String
+
+    @FocusState private var triggerFocused: Bool
+    @FocusState private var expansionFocused: Bool
+
+    var body: some View {
+        HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+            Toggle("", isOn: Binding(
+                get: { snippet.isEnabled },
+                set: { _ in viewModel.toggleEnabled(snippet) }
+            ))
+            .labelsHidden()
+            .parakeetSwitch()
+            .controlSize(.small)
+            .accessibilityLabel("Enable \(snippet.trigger)")
+            .accessibilityHint("Expands during dictation to a saved phrase")
+
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+                HStack(spacing: DesignSystem.Spacing.sm) {
+                    ParakeetTextField(
+                        placeholder: "Trigger phrase",
+                        text: $viewModel.editTrigger,
+                        onSubmit: { expansionFocused = true },
+                        externalFocus: $triggerFocused
+                    )
+                    .frame(minWidth: 150)
+
+                    ParakeetTextField(
+                        placeholder: "Expansion",
+                        text: $viewModel.editExpansion,
+                        onSubmit: { viewModel.saveEditing() },
+                        externalFocus: $expansionFocused
+                    )
+                    .frame(minWidth: 220)
+                }
+
+                HStack(spacing: DesignSystem.Spacing.sm) {
+                    if let error = viewModel.editErrorMessage {
+                        Text(error)
+                            .font(DesignSystem.Typography.caption)
+                            .foregroundStyle(DesignSystem.Colors.errorRed)
+                    } else if snippet.useCount > 0 {
+                        SnippetUsageBadge(useCount: snippet.useCount, usageHint: usageHint)
+                    } else {
+                        Text(usageHint)
+                            .font(DesignSystem.Typography.caption)
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            Spacer(minLength: DesignSystem.Spacing.sm)
+
+            HStack(spacing: DesignSystem.Spacing.sm) {
+                Button("Cancel") {
+                    viewModel.cancelEditing()
+                }
+                .parakeetAction(.secondary)
+                .controlSize(.small)
+
+                Button("Save") {
+                    viewModel.saveEditing()
+                }
+                .parakeetAction(.primaryProminent)
+                .controlSize(.small)
+                .disabled(!viewModel.canSaveEditing)
+            }
+        }
+        .padding(.horizontal, DesignSystem.Spacing.md)
+        .padding(.vertical, DesignSystem.Spacing.sm + 2)
+        .background(DesignSystem.Colors.accentLight)
+        .contentShape(Rectangle())
+        .onAppear {
+            triggerFocused = true
+        }
+        .onExitCommand {
+            viewModel.cancelEditing()
+        }
+    }
+}
+
+private struct SnippetUsageBadge: View {
+    let useCount: Int
+    let usageHint: String
+
+    var body: some View {
+        HStack(spacing: 3) {
+            Image(systemName: "chart.bar.fill")
+                .font(.system(size: 9, weight: .semibold))
+            Text("\(useCount)")
+                .font(DesignSystem.Typography.micro.weight(.medium))
+                .monospacedDigit()
+        }
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 3)
+        .background(Capsule().fill(DesignSystem.Colors.surfaceElevated))
+        .help(usageHint)
+        .accessibilityLabel(usageHint)
     }
 }

--- a/Sources/MacParakeet/Views/Vocabulary/VocabularyComponents.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/VocabularyComponents.swift
@@ -187,6 +187,26 @@ struct VocabSheetHeader: View {
 
 // MARK: - Delete icon button
 
+struct EditIconButton: View {
+    let helpText: String
+    let accessibilityName: String
+    let action: () -> Void
+
+    @State private var hovered = false
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: "pencil")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(hovered ? DesignSystem.Colors.accent : .secondary)
+        }
+        .buttonStyle(.plain)
+        .onHover { hovered = $0 }
+        .help(helpText)
+        .accessibilityLabel(accessibilityName)
+    }
+}
+
 /// A trash button that rests in the secondary color and warms to red on hover,
 /// giving the destructive affordance a clear, contained signal.
 struct DeleteIconButton: View {

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -59,6 +59,7 @@ public enum TelemetryEventName: String, Sendable, CaseIterable {
     case customWordAdded = "custom_word_added"
     case customWordDeleted = "custom_word_deleted"
     case snippetAdded = "snippet_added"
+    case snippetEdited = "snippet_edited"
     case snippetDeleted = "snippet_deleted"
     case keystrokeSnippetFired = "keystroke_snippet_fired"
     case feedbackSubmitted = "feedback_submitted"
@@ -578,6 +579,7 @@ public enum TelemetryEventSpec: Sendable {
     case customWordAdded
     case customWordDeleted
     case snippetAdded
+    case snippetEdited
     case snippetDeleted
     case settingChanged(setting: TelemetrySettingName)
     case telemetryOptedOut
@@ -799,6 +801,7 @@ extension TelemetryEventSpec {
         case .customWordAdded: return .customWordAdded
         case .customWordDeleted: return .customWordDeleted
         case .snippetAdded: return .snippetAdded
+        case .snippetEdited: return .snippetEdited
         case .snippetDeleted: return .snippetDeleted
         case .settingChanged: return .settingChanged
         case .telemetryOptedOut: return .telemetryOptedOut
@@ -862,6 +865,7 @@ extension TelemetryEventSpec {
              .customWordAdded,
              .customWordDeleted,
              .snippetAdded,
+             .snippetEdited,
              .snippetDeleted,
              .telemetryOptedOut,
              .transcriptionDeleted,
@@ -1593,6 +1597,7 @@ public enum TelemetryImplementedContract {
         .customWordAdded: [],
         .customWordDeleted: [],
         .snippetAdded: [],
+        .snippetEdited: [],
         .snippetDeleted: [],
         .settingChanged: ["setting"],
         .telemetryOptedOut: [],

--- a/Sources/MacParakeetViewModels/TextSnippetsViewModel.swift
+++ b/Sources/MacParakeetViewModels/TextSnippetsViewModel.swift
@@ -9,6 +9,22 @@ public final class TextSnippetsViewModel {
     public var newTrigger: String = ""
     public var newExpansion: String = ""
     public var errorMessage: String?
+    public var editingSnippetID: UUID?
+    public var editTrigger: String = "" {
+        didSet {
+            if oldValue != editTrigger {
+                editErrorMessage = nil
+            }
+        }
+    }
+    public var editExpansion: String = "" {
+        didSet {
+            if oldValue != editExpansion {
+                editErrorMessage = nil
+            }
+        }
+    }
+    public var editErrorMessage: String?
     public var pendingDeleteSnippet: TextSnippet?
 
     private var repo: TextSnippetRepositoryProtocol?
@@ -26,6 +42,11 @@ public final class TextSnippetsViewModel {
             $0.trigger.localizedCaseInsensitiveContains(searchText)
                 || $0.expansion.localizedCaseInsensitiveContains(searchText)
         }
+    }
+
+    public var canSaveEditing: Bool {
+        !editTrigger.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !processedExpansion(from: editExpansion).isEmpty
     }
 
     public func loadSnippets() {
@@ -78,6 +99,64 @@ public final class TextSnippetsViewModel {
         }
     }
 
+    public func beginEditing(_ snippet: TextSnippet) {
+        if let editingSnippetID, editingSnippetID != snippet.id {
+            editErrorMessage = "Save or cancel the current edit first"
+            return
+        }
+        editingSnippetID = snippet.id
+        editTrigger = snippet.trigger
+        editExpansion = editableExpansion(from: snippet.expansion)
+        editErrorMessage = nil
+        errorMessage = nil
+    }
+
+    public func cancelEditing() {
+        editingSnippetID = nil
+        editTrigger = ""
+        editExpansion = ""
+        editErrorMessage = nil
+    }
+
+    public func saveEditing() {
+        guard let repo, let editingSnippetID else { return }
+        let trimmedTrigger = editTrigger.trimmingCharacters(in: .whitespacesAndNewlines)
+        let processedExpansion = processedExpansion(from: editExpansion)
+        guard !trimmedTrigger.isEmpty else {
+            editErrorMessage = "Trigger phrase is required"
+            return
+        }
+        guard !processedExpansion.isEmpty else {
+            editErrorMessage = "Expansion is required"
+            return
+        }
+
+        if snippets.contains(where: {
+            $0.id != editingSnippetID
+                && $0.trigger.caseInsensitiveCompare(trimmedTrigger) == .orderedSame
+        }) {
+            editErrorMessage = "'\(trimmedTrigger)' already exists"
+            return
+        }
+
+        do {
+            guard var snippet = try repo.fetch(id: editingSnippetID) else {
+                cancelEditing()
+                loadSnippets()
+                return
+            }
+            snippet.trigger = trimmedTrigger
+            snippet.expansion = processedExpansion
+            snippet.updatedAt = Date()
+            try repo.save(snippet)
+            Telemetry.send(.snippetEdited)
+            cancelEditing()
+            loadSnippets()
+        } catch {
+            editErrorMessage = error.localizedDescription
+        }
+    }
+
     public func confirmDelete() {
         guard let snippet = pendingDeleteSnippet else { return }
         pendingDeleteSnippet = nil
@@ -89,9 +168,21 @@ public final class TextSnippetsViewModel {
         do {
             _ = try repo.delete(id: snippet.id)
             Telemetry.send(.snippetDeleted)
+            if editingSnippetID == snippet.id {
+                cancelEditing()
+            }
             loadSnippets()
         } catch {
             errorMessage = error.localizedDescription
         }
+    }
+
+    private func processedExpansion(from raw: String) -> String {
+        raw.trimmingCharacters(in: .whitespaces)
+            .replacingOccurrences(of: "\\n", with: "\n")
+    }
+
+    private func editableExpansion(from expansion: String) -> String {
+        expansion.replacingOccurrences(of: "\n", with: "\\n")
     }
 }

--- a/Tests/CLITests/VocabCommandTests.swift
+++ b/Tests/CLITests/VocabCommandTests.swift
@@ -97,6 +97,92 @@ final class VocabCommandTests: XCTestCase {
         XCTAssertTrue(schema.json)
     }
 
+    func testVocabSnippetsEditUpdatesExistingSnippet() async throws {
+        let manager = try DatabaseManager(path: dbPath)
+        let repo = TextSnippetRepository(dbQueue: manager.dbQueue)
+        let createdAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let snippet = TextSnippet(
+            trigger: "my sig",
+            expansion: "Original",
+            isEnabled: false,
+            useCount: 4,
+            createdAt: createdAt,
+            updatedAt: createdAt
+        )
+        try repo.save(snippet)
+
+        let cmd = try VocabSnippetsCommand.EditSnippet.parse([
+            String(snippet.id.uuidString.prefix(8)),
+            "--trigger", "my signature",
+            "--expansion", "Best regards\\nDaniel",
+            "--database", dbPath,
+        ])
+        let output = try await capturingStdout {
+            try await cmd.run()
+        }
+
+        let updated = try XCTUnwrap(try repo.fetch(id: snippet.id))
+        XCTAssertTrue(output.contains("Updated: Say \"my signature\""))
+        XCTAssertEqual(updated.id, snippet.id)
+        XCTAssertEqual(updated.trigger, "my signature")
+        XCTAssertEqual(updated.expansion, "Best regards\nDaniel")
+        XCTAssertEqual(updated.isEnabled, false)
+        XCTAssertEqual(updated.useCount, 4)
+        XCTAssertEqual(updated.createdAt, createdAt)
+        XCTAssertGreaterThan(updated.updatedAt, createdAt)
+    }
+
+    func testVocabSnippetsEditRejectsShortIDPrefix() async throws {
+        let manager = try DatabaseManager(path: dbPath)
+        let repo = TextSnippetRepository(dbQueue: manager.dbQueue)
+        let snippet = TextSnippet(trigger: "my sig", expansion: "Original")
+        try repo.save(snippet)
+
+        let cmd = try VocabSnippetsCommand.EditSnippet.parse([
+            String(snippet.id.uuidString.prefix(3)),
+            "--expansion", "Updated",
+            "--database", dbPath,
+        ])
+
+        do {
+            try await cmd.run()
+            XCTFail("Expected short ID prefix to be rejected")
+        } catch is ValidationError {
+            // Expected.
+        } catch {
+            XCTFail("Expected ValidationError, got \(type(of: error))")
+        }
+    }
+
+    func testVocabSnippetsDeletePreservesLegacyShortPrefixLookup() async throws {
+        let manager = try DatabaseManager(path: dbPath)
+        let repo = TextSnippetRepository(dbQueue: manager.dbQueue)
+        let snippet = TextSnippet(
+            id: try XCTUnwrap(UUID(uuidString: "a1111111-1111-1111-1111-111111111111")),
+            trigger: "my sig",
+            expansion: "Original"
+        )
+        let other = TextSnippet(
+            id: try XCTUnwrap(UUID(uuidString: "b2222222-2222-2222-2222-222222222222")),
+            trigger: "my address",
+            expansion: "123 Main"
+        )
+        try repo.save(snippet)
+        try repo.save(other)
+
+        let cmd = try VocabSnippetsCommand.DeleteSnippet.parse([
+            "a",
+            "--database", dbPath,
+        ])
+        let output = try await capturingStdout {
+            try await cmd.run()
+        }
+
+        XCTAssertTrue(output.contains("Deleted: \"my sig\""))
+        XCTAssertNil(try repo.fetch(id: snippet.id))
+        XCTAssertNotNil(try repo.fetch(id: other.id))
+    }
+
     // MARK: - Schema
 
     func testSchemaJSONIsParseable() async throws {

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -1315,6 +1315,7 @@ final class TelemetryServiceTests: XCTestCase {
             .customWordAdded,
             .customWordDeleted,
             .snippetAdded,
+            .snippetEdited,
             .snippetDeleted,
             .promptCreated,
             .promptUpdated,

--- a/Tests/MacParakeetTests/ViewModels/TextSnippetsEditingViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TextSnippetsEditingViewModelTests.swift
@@ -1,0 +1,179 @@
+import XCTest
+@testable import MacParakeetCore
+@testable import MacParakeetViewModels
+
+@MainActor
+final class TextSnippetsEditingViewModelTests: XCTestCase {
+    var viewModel: TextSnippetsViewModel!
+    var mockRepo: MockTextSnippetRepository!
+
+    override func setUp() async throws {
+        mockRepo = MockTextSnippetRepository()
+        viewModel = TextSnippetsViewModel()
+        viewModel.configure(repo: mockRepo)
+    }
+
+    func testBeginEditingPopulatesFields() throws {
+        let snippet = TextSnippet(trigger: "my address", expansion: "123 Main St\nCity")
+        try mockRepo.save(snippet)
+        viewModel.loadSnippets()
+
+        viewModel.beginEditing(snippet)
+
+        XCTAssertEqual(viewModel.editingSnippetID, snippet.id)
+        XCTAssertEqual(viewModel.editTrigger, "my address")
+        XCTAssertEqual(viewModel.editExpansion, "123 Main St\\nCity")
+        XCTAssertNil(viewModel.editErrorMessage)
+    }
+
+    func testBeginEditingSecondSnippetPreservesActiveDraft() throws {
+        let first = TextSnippet(trigger: "my sig", expansion: "Original")
+        let second = TextSnippet(trigger: "my address", expansion: "123 Main")
+        try mockRepo.save(first)
+        try mockRepo.save(second)
+        viewModel.loadSnippets()
+
+        viewModel.beginEditing(first)
+        viewModel.editTrigger = "draft trigger"
+        viewModel.editExpansion = "Draft expansion"
+        viewModel.beginEditing(second)
+
+        XCTAssertEqual(viewModel.editingSnippetID, first.id)
+        XCTAssertEqual(viewModel.editTrigger, "draft trigger")
+        XCTAssertEqual(viewModel.editExpansion, "Draft expansion")
+        XCTAssertEqual(viewModel.editErrorMessage, "Save or cancel the current edit first")
+    }
+
+    func testSaveEditingUpdatesSnippetAndPreservesMetadata() throws {
+        let createdAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let snippet = TextSnippet(
+            trigger: "my sig",
+            expansion: "Original",
+            isEnabled: false,
+            useCount: 7,
+            action: .returnKey,
+            createdAt: createdAt,
+            updatedAt: createdAt
+        )
+        try mockRepo.save(snippet)
+        viewModel.loadSnippets()
+
+        viewModel.beginEditing(snippet)
+        viewModel.editTrigger = "my signature"
+        viewModel.editExpansion = "Best regards\\nDaniel"
+        viewModel.saveEditing()
+
+        let updated = try XCTUnwrap(mockRepo.fetch(id: snippet.id))
+        XCTAssertEqual(updated.id, snippet.id)
+        XCTAssertEqual(updated.trigger, "my signature")
+        XCTAssertEqual(updated.expansion, "Best regards\nDaniel")
+        XCTAssertEqual(updated.isEnabled, false)
+        XCTAssertEqual(updated.useCount, 7)
+        XCTAssertEqual(updated.action, .returnKey)
+        XCTAssertEqual(updated.createdAt, createdAt)
+        XCTAssertGreaterThan(updated.updatedAt, createdAt)
+        XCTAssertNil(viewModel.editingSnippetID)
+        XCTAssertEqual(viewModel.editTrigger, "")
+        XCTAssertEqual(viewModel.editExpansion, "")
+    }
+
+    func testSaveEditingAllowsUnchangedTrigger() throws {
+        let snippet = TextSnippet(trigger: "my sig", expansion: "Original")
+        try mockRepo.save(snippet)
+        viewModel.loadSnippets()
+
+        viewModel.beginEditing(snippet)
+        viewModel.editTrigger = "MY SIG"
+        viewModel.editExpansion = "Updated"
+        viewModel.saveEditing()
+
+        let updated = try XCTUnwrap(mockRepo.fetch(id: snippet.id))
+        XCTAssertEqual(updated.trigger, "MY SIG")
+        XCTAssertEqual(updated.expansion, "Updated")
+        XCTAssertNil(viewModel.editErrorMessage)
+    }
+
+    func testSaveEditingRejectsDuplicateTrigger() throws {
+        let first = TextSnippet(trigger: "my sig", expansion: "Original")
+        let second = TextSnippet(trigger: "my address", expansion: "123 Main")
+        try mockRepo.save(first)
+        try mockRepo.save(second)
+        viewModel.loadSnippets()
+
+        viewModel.beginEditing(first)
+        viewModel.editTrigger = "MY ADDRESS"
+        viewModel.editExpansion = "Updated"
+        viewModel.saveEditing()
+
+        let unchanged = try XCTUnwrap(mockRepo.fetch(id: first.id))
+        XCTAssertEqual(unchanged.trigger, "my sig")
+        XCTAssertEqual(unchanged.expansion, "Original")
+        XCTAssertEqual(viewModel.editingSnippetID, first.id)
+        XCTAssertEqual(viewModel.editErrorMessage, "'MY ADDRESS' already exists")
+    }
+
+    func testSaveEditingRejectsEmptyFields() throws {
+        let snippet = TextSnippet(trigger: "my sig", expansion: "Original")
+        try mockRepo.save(snippet)
+        viewModel.loadSnippets()
+
+        viewModel.beginEditing(snippet)
+        viewModel.editTrigger = " "
+        viewModel.saveEditing()
+        XCTAssertEqual(viewModel.editErrorMessage, "Trigger phrase is required")
+
+        viewModel.editTrigger = "my sig"
+        viewModel.editExpansion = "   "
+        viewModel.saveEditing()
+        XCTAssertEqual(viewModel.editErrorMessage, "Expansion is required")
+    }
+
+    func testSaveEditingClearsStateWhenSnippetWasDeletedExternally() throws {
+        let deleted = TextSnippet(trigger: "my sig", expansion: "Original")
+        let remaining = TextSnippet(trigger: "my address", expansion: "123 Main")
+        try mockRepo.save(deleted)
+        try mockRepo.save(remaining)
+        viewModel.loadSnippets()
+
+        viewModel.beginEditing(deleted)
+        viewModel.editTrigger = "updated sig"
+        _ = try mockRepo.delete(id: deleted.id)
+        viewModel.saveEditing()
+
+        XCTAssertNil(viewModel.editingSnippetID)
+        XCTAssertEqual(viewModel.editTrigger, "")
+        XCTAssertEqual(viewModel.editExpansion, "")
+        XCTAssertNil(viewModel.editErrorMessage)
+        XCTAssertEqual(viewModel.snippets.map(\.id), [remaining.id])
+
+        viewModel.beginEditing(remaining)
+        XCTAssertEqual(viewModel.editingSnippetID, remaining.id)
+        XCTAssertNil(viewModel.editErrorMessage)
+    }
+
+    func testCancelEditingClearsState() {
+        let snippet = TextSnippet(trigger: "my sig", expansion: "Original")
+        viewModel.beginEditing(snippet)
+        viewModel.editErrorMessage = "Error"
+
+        viewModel.cancelEditing()
+
+        XCTAssertNil(viewModel.editingSnippetID)
+        XCTAssertEqual(viewModel.editTrigger, "")
+        XCTAssertEqual(viewModel.editExpansion, "")
+        XCTAssertNil(viewModel.editErrorMessage)
+    }
+
+    func testEditingFieldChangesClearValidationError() {
+        let snippet = TextSnippet(trigger: "my sig", expansion: "Original")
+        viewModel.beginEditing(snippet)
+
+        viewModel.editErrorMessage = "Trigger phrase is required"
+        viewModel.editTrigger = "my signature"
+        XCTAssertNil(viewModel.editErrorMessage)
+
+        viewModel.editErrorMessage = "Expansion is required"
+        viewModel.editExpansion = "Updated"
+        XCTAssertNil(viewModel.editErrorMessage)
+    }
+}

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -410,6 +410,7 @@ swift run macparakeet-cli vocab words delete <ID>
 
 swift run macparakeet-cli vocab snippets list
 swift run macparakeet-cli vocab snippets add "my signature" "Best regards, Daniel"
+swift run macparakeet-cli vocab snippets edit <ID> --trigger "my signature" --expansion "Best regards, Daniel Moon"
 swift run macparakeet-cli vocab snippets delete <ID>
 ```
 

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -900,7 +900,7 @@ Important constraints:
 
 **Features:**
 - Add, edit, delete, enable/disable custom words
-- Add, delete text snippets
+- Add, edit, delete text snippets
 - Use count tracking for snippets (helps users know which are active)
 - Accessible from Settings view ("Manage Custom Words...", "Manage Text Snippets...")
 - Import/export the combined vocabulary backup (custom words + snippets) from
@@ -920,7 +920,7 @@ Important constraints:
 
 **Acceptance criteria:**
 - [x] Can add/edit/delete/toggle custom words
-- [x] Can add/delete text snippets
+- [x] Can add/edit/delete text snippets
 - [x] Use count displayed and updated for snippets
 - [x] Changes take effect immediately for next dictation
 - [x] Settings link opens management views

--- a/spec/07-text-processing.md
+++ b/spec/07-text-processing.md
@@ -156,6 +156,9 @@ macparakeet-cli vocab snippets list
 # Add a snippet (trigger is a natural phrase, not an abbreviation)
 macparakeet-cli vocab snippets add "my signature" "Best regards, David"
 
+# Edit a snippet
+macparakeet-cli vocab snippets edit <id> --trigger "my signature" --expansion "Best regards, Daniel"
+
 # Delete a snippet
 macparakeet-cli vocab snippets delete <id>
 ```


### PR DESCRIPTION
## Summary

Closes #188 by adding an inline edit workflow for saved text snippets. Users can now click the subtle pencil action on a snippet row, edit the trigger and expansion in place, then Save or Cancel without deleting and recreating the snippet.

The CLI also gets parity:

\`\`\`bash
macparakeet-cli vocab snippets edit <id> --trigger "my signature" --expansion "Best regards, Daniel"
\`\`\`

## Implementation

- Added TextSnippetsViewModel edit state, duplicate validation, stale-error clearing, and metadata-preserving saves.
- Added compact inline snippet editing UI using the existing Vocabulary sheet primitives and Parakeet button styling.
- Added a shared pencil icon action beside the existing delete action.
- Added \`vocab snippets edit\` with UUID prefix resolution, 4-character minimum prefix validation, and \`\\n\` expansion handling to match the GUI.
- Preserved legacy short-prefix behavior for \`vocab snippets delete\` so existing scripts keep working.
- Added privacy-safe \`snippet_edited\` telemetry to match snippet add/delete usage tracking.
- Updated specs, CLI docs, and CLI changelog.

## Review Follow-up

- Addressed Gemini review: CLI edit now converts \`\\n\` escape sequences to real newlines.
- Addressed Gemini review: edit ID prefix lookup rejects prefixes shorter than 4 characters and lowercases the search ID once.
- Addressed GrepTile P1: delete keeps its existing short-prefix lookup behavior instead of inheriting edit's 4-character minimum.
- Addressed GrepTile P1: stale edit state is cleared if a snippet is deleted externally while the edit row is open, so editing another snippet is not blocked.
- Addressed GrepTile P2: starting a second edit while a draft is active now preserves the current draft and shows an inline save/cancel prompt.
- Addressed GrepTile P2: successful snippet edits now emit \`snippet_edited\` telemetry with no content props.

## Validation

- [x] \`git diff --check\`
- [x] \`swift test --filter TextSnippets\`
- [x] \`swift test --filter VocabCommandTests\`
- [x] \`swift test --filter TextSnippetsEditingViewModelTests\`
- [x] \`swift test --filter TelemetryServiceTests\`
- [x] \`swift build --target MacParakeet\`
- [x] \`swift test\` — 2945 XCTest tests, 9 skipped, 0 failures; Swift Testing: 16 tests, 0 failures