### PR TITLE
Add meeting microphone mute control

### DIFF
--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -58,6 +58,7 @@ final class MeetingRecordingFlowCoordinator {
     private var panelViewModel: MeetingRecordingPanelViewModel?
     private var actionTask: Task<Void, Never>?
     private var pauseToggleTask: Task<Void, Never>?
+    private var microphoneMuteToggleTask: Task<Void, Never>?
     private var autoDismissTask: Task<Void, Never>?
     private var pillPollingTask: Task<Void, Never>?
     private var transcriptObservationTask: Task<Void, Never>?
@@ -150,6 +151,18 @@ final class MeetingRecordingFlowCoordinator {
             guard self.pillViewModel.canTogglePause else { return }
             self.pillViewModel.state = wantPause ? .paused : .recording
             self.panelViewModel?.isPaused = wantPause
+        }
+    }
+
+    func toggleMicrophoneMute() {
+        guard panelViewModel?.canToggleMicrophoneMute == true else { return }
+        let wantMuted = !(panelViewModel?.isMicrophoneMuted ?? false)
+        microphoneMuteToggleTask?.cancel()
+        microphoneMuteToggleTask = Task { @MainActor [meetingRecordingService, weak self] in
+            let microphoneMuteState = await meetingRecordingService.setMicrophoneMuted(wantMuted)
+            guard !Task.isCancelled, let self else { return }
+            self.panelViewModel?.isMicrophoneMuted = microphoneMuteState.isMuted
+            self.panelViewModel?.canToggleMicrophoneMute = microphoneMuteState.canMute
         }
     }
 
@@ -333,10 +346,13 @@ final class MeetingRecordingFlowCoordinator {
             panelVM.micLevel = 0
             panelVM.systemLevel = 0
             panelVM.isPaused = false
+            panelVM.isMicrophoneMuted = false
+            panelVM.canToggleMicrophoneMute = (pendingAudioSourceMode ?? meetingAudioSourceModeProvider()).capturesMicrophone
             panelVM.updateLiveTranscriptStatus(.startingAudio)
             panelVM.updatePreviewLines([], isTranscriptionLagging: false)
             panelVM.onStop = { [weak self] in self?.toggleRecording() }
             panelVM.onPauseToggle = { [weak self] in self?.togglePause() }
+            panelVM.onMicrophoneMuteToggle = { [weak self] in self?.toggleMicrophoneMute() }
             panelVM.onClose = { [weak self] in self?.hideMeetingPanel() }
             // Configure live Ask: in-memory mode (no transcriptionId/conversationRepo).
             // Promotion to a persisted ChatConversation happens in .navigateToTranscription.
@@ -592,6 +608,8 @@ final class MeetingRecordingFlowCoordinator {
             stopSpeechWarmUpObservation()
             pauseToggleTask?.cancel()
             pauseToggleTask = nil
+            microphoneMuteToggleTask?.cancel()
+            microphoneMuteToggleTask = nil
             pillController?.hide()
             pillController = nil
             // Pill view model is long-lived (also drives the Transcribe-tab
@@ -710,6 +728,7 @@ final class MeetingRecordingFlowCoordinator {
                 let systemLevel = await meetingRecordingService.systemLevel
                 let elapsedSeconds = await meetingRecordingService.elapsedSeconds
                 let captureMode = await meetingRecordingService.captureMode
+                let microphoneMuteState = await meetingRecordingService.microphoneMuteState
 
                 guard !Task.isCancelled else { break }
                 pillViewModel.micLevel = micLevel
@@ -718,6 +737,8 @@ final class MeetingRecordingFlowCoordinator {
                 panelViewModel?.elapsedSeconds = elapsedSeconds
                 panelViewModel?.micLevel = micLevel
                 panelViewModel?.systemLevel = systemLevel
+                panelViewModel?.isMicrophoneMuted = microphoneMuteState.isMuted
+                panelViewModel?.canToggleMicrophoneMute = microphoneMuteState.canMute
                 // Pause/resume reconciliation (issue #235). The user-facing
                 // toggle does an optimistic flip; this poll is the
                 // authoritative source if the optimistic flip diverged from

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelView.swift
@@ -231,6 +231,12 @@ struct MeetingRecordingPanelView: View {
                         .foregroundStyle(DesignSystem.Colors.textTertiary.opacity(0.8))
                 }
 
+                if viewModel.canToggleMicrophoneMute {
+                    MeetingMicrophoneMuteButton(isMuted: viewModel.isMicrophoneMuted) {
+                        viewModel.onMicrophoneMuteToggle?()
+                    }
+                }
+
                 if viewModel.canTogglePause {
                     PauseResumeButton(isPaused: viewModel.isPaused) {
                         viewModel.onPauseToggle?()

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingStopButton.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingStopButton.swift
@@ -106,6 +106,73 @@ struct StopRecordingButton: View {
     }
 }
 
+// MARK: - Microphone Mute Button
+
+/// Meeting-local microphone mute. System audio keeps recording, so this is
+/// intentionally separate from pause.
+struct MeetingMicrophoneMuteButton: View {
+    var isMuted: Bool
+    var onToggle: () -> Void
+
+    @State private var isHovered = false
+
+    private static let trackHeight: CGFloat = 31
+
+    private var activeColor: Color {
+        isMuted ? DesignSystem.Colors.errorRed : DesignSystem.Colors.accent
+    }
+
+    var body: some View {
+        Button(action: onToggle) {
+            Image(systemName: isMuted ? "mic.slash.fill" : "mic.fill")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(
+                    isHovered || isMuted
+                        ? activeColor
+                        : DesignSystem.Colors.textSecondary
+                )
+                .frame(width: 13, height: 13)
+                .padding(9)
+                .background(
+                    Circle()
+                        .fill((isHovered || isMuted)
+                            ? activeColor.opacity(isMuted ? 0.18 : 0.12)
+                            : DesignSystem.Colors.surfaceElevated.opacity(0.6)
+                        )
+                        .overlay(
+                            Circle()
+                                .stroke(
+                                    (isHovered || isMuted)
+                                        ? activeColor.opacity(0.32)
+                                        : .clear,
+                                    lineWidth: 0.5
+                                )
+                        )
+                )
+                .shadow(
+                    color: isHovered
+                        ? activeColor.opacity(0.22)
+                        : .clear,
+                    radius: 6
+                )
+                .scaleEffect(isHovered ? 1.08 : 1.0)
+                .animation(.easeOut(duration: 0.15), value: isHovered)
+                .contentTransition(.symbolEffect(.replace))
+        }
+        .buttonStyle(.plain)
+        .frame(height: Self.trackHeight)
+        .accessibilityLabel(isMuted ? "Unmute meeting microphone" : "Mute meeting microphone")
+        .help(
+            isMuted
+                ? "Unmute meeting microphone"
+                : "Mute your microphone in this recording — system audio keeps recording"
+        )
+        .onHover { hovering in
+            isHovered = hovering
+        }
+    }
+}
+
 // MARK: - Pause / Resume Button
 
 /// Pill-shaped pause/resume toggle for the meeting panel header (issue #235).

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -22,6 +22,16 @@ public enum CaptureMode: Sendable, Equatable {
     case stopped
 }
 
+public struct MeetingMicrophoneMuteState: Sendable, Equatable {
+    public let isMuted: Bool
+    public let canMute: Bool
+
+    public init(isMuted: Bool, canMute: Bool) {
+        self.isMuted = isMuted
+        self.canMute = canMute
+    }
+}
+
 public protocol MeetingRecordingServiceProtocol: Sendable {
     /// `title` lets callers (e.g., the calendar auto-start path) pre-name
     /// the recording. `nil` or whitespace-only falls back to the default
@@ -44,6 +54,10 @@ public protocol MeetingRecordingServiceProtocol: Sendable {
     /// Resume a paused recording. No-op when no session is active or when
     /// not currently paused.
     func resumeRecording() async
+    /// Mute or unmute the meeting microphone source without pausing system
+    /// audio capture. No-op for system-only recordings.
+    @discardableResult
+    func setMicrophoneMuted(_ muted: Bool) async -> MeetingMicrophoneMuteState
     /// Persist the user's in-flight notepad text to the recording's lock file
     /// without changing the recording state. Called by the notes view model on
     /// every idle-debounce fire (ADR-020 §8). All `recording.lock` writes are
@@ -56,6 +70,9 @@ public protocol MeetingRecordingServiceProtocol: Sendable {
     var systemLevel: Float { get async }
     var elapsedSeconds: Int { get async }
     var captureMode: CaptureMode { get async }
+    var isMicrophoneMuted: Bool { get async }
+    var canMuteMicrophone: Bool { get async }
+    var microphoneMuteState: MeetingMicrophoneMuteState { get async }
     var transcriptUpdates: AsyncStream<MeetingTranscriptUpdate> { get async }
 }
 
@@ -153,6 +170,13 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     private var pausedHostTime: UInt64?
     private var completedPauseHostTimeRanges: [HostTimeRange] = []
     private var accumulatedPausedDuration: TimeInterval = 0
+    /// Meeting-local microphone mute. We keep the OS mic stream alive and
+    /// write silence into the mic source file while muted so the mic and
+    /// system tracks stay time-aligned for the final mix.
+    private var microphoneMuted = false
+    private var microphoneMutedHostTime: UInt64?
+    private var completedMicrophoneMuteHostTimeRanges: [HostTimeRange] = []
+    private var reusableMicrophoneSilentBuffer: AVAudioPCMBuffer?
     /// In-flight notes text for the current session. Mutated by `updateNotes`
     /// on each VM debounce; read at finalize time and surfaced via
     /// `MeetingRecordingOutput.userNotes`. `nil` when no notes have been
@@ -202,6 +226,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     private static let syncLagEmaAlpha: Double = 0.2
     private static let syncLagLogBucketMs: Int = 20
     private static let syncLagWarningThresholdMs: Double = 120
+    private static let completedHostTimeRangeLimit = 512
 
     private static func currentAudioHostTime() -> UInt64 {
         AVAudioTime.hostTime(forSeconds: ProcessInfo.processInfo.systemUptime)
@@ -276,6 +301,21 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             return .stopped
         }
         return paused ? .paused : .full
+    }
+
+    public var isMicrophoneMuted: Bool {
+        microphoneMuted
+    }
+
+    public var canMuteMicrophone: Bool {
+        currentSession != nil
+            && !captureFailed
+            && captureHealthMetrics.sourceMode?.capturesMicrophone == true
+    }
+
+    public var microphoneMuteState: MeetingMicrophoneMuteState {
+        let canMute = canMuteMicrophone
+        return MeetingMicrophoneMuteState(isMuted: canMute && microphoneMuted, canMute: canMute)
     }
 
     /// Wallclock-since-start minus all pause time (completed + ongoing).
@@ -703,6 +743,31 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         )
     }
 
+    @discardableResult
+    public func setMicrophoneMuted(_ muted: Bool) async -> MeetingMicrophoneMuteState {
+        guard canMuteMicrophone, microphoneMuted != muted else { return microphoneMuteState }
+
+        microphoneMuted = muted
+        if muted {
+            microphoneMutedHostTime = Self.currentAudioHostTime()
+            latestLevels.microphone = 0
+            recentProcessedMicRms = 0
+        } else {
+            if let microphoneMutedHostTime {
+                appendCompletedMicrophoneMuteHostTimeRange(
+                    start: microphoneMutedHostTime,
+                    end: Self.currentAudioHostTime()
+                )
+            }
+            microphoneMutedHostTime = nil
+        }
+
+        AudioCaptureDiagnostics.append(
+            "meeting_microphone_\(muted ? "muted" : "unmuted") session=\(currentSession?.id.uuidString ?? "nil")"
+        )
+        return microphoneMuteState
+    }
+
     public func cancelRecording() async {
         guard let session = currentSession else { return }
 
@@ -778,11 +843,22 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             let handling = captureBufferHandling(time: time)
             guard handling != .drop else { return }
             do {
+                let muted = isMicrophoneMuted(at: time)
+                let recordingBuffer: AVAudioPCMBuffer
+                if muted {
+                    guard let silentBuffer = silentMicrophoneBufferLike(buffer) else {
+                        await failCapture(MeetingAudioError.captureRuntimeFailure("Failed to create muted microphone buffer"))
+                        return
+                    }
+                    recordingBuffer = silentBuffer
+                } else {
+                    recordingBuffer = buffer
+                }
                 recordCaptureMetrics(for: .microphone, time: time)
-                try writer?.write(buffer, source: .microphone)
+                try writer?.write(recordingBuffer, source: .microphone)
                 if handling == .recordAndProcess {
-                    latestLevels.microphone = buffer.rmsLevel
-                    if let samples = AudioChunker.extractAndResample(from: buffer) {
+                    latestLevels.microphone = muted ? 0 : recordingBuffer.rmsLevel
+                    if let samples = AudioChunker.extractAndResample(from: recordingBuffer) {
                         await ingestResampledSamples(
                             samples,
                             source: .microphone,
@@ -844,6 +920,9 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     private func failCapture(_ error: Error) async {
         captureFailed = true
         latestLevels = MeetingAudioLevels()
+        microphoneMuted = false
+        microphoneMutedHostTime = nil
+        completedMicrophoneMuteHostTimeRanges = []
         logger.error("meeting_capture_failed error_type=\(AudioCaptureDiagnostics.errorType(error), privacy: .public) error_detail=\(error.localizedDescription, privacy: .private)")
         await audioCaptureService.stop()
     }
@@ -1005,7 +1084,47 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
 
     private func appendCompletedPauseHostTimeRange(start: UInt64, end: UInt64) {
         guard end > start else { return }
-        completedPauseHostTimeRanges.append(HostTimeRange(start: start, end: end))
+        appendBoundedCompletedHostTimeRange(
+            start: start,
+            end: end,
+            to: &completedPauseHostTimeRanges
+        )
+    }
+
+    private func appendCompletedMicrophoneMuteHostTimeRange(start: UInt64, end: UInt64) {
+        guard end > start else { return }
+        appendBoundedCompletedHostTimeRange(
+            start: start,
+            end: end,
+            to: &completedMicrophoneMuteHostTimeRanges
+        )
+    }
+
+    private func appendBoundedCompletedHostTimeRange(
+        start: UInt64,
+        end: UInt64,
+        to ranges: inout [HostTimeRange]
+    ) {
+        ranges.append(HostTimeRange(start: start, end: end))
+        let overflowCount = ranges.count - Self.completedHostTimeRangeLimit
+        if overflowCount > 0 {
+            ranges.removeFirst(overflowCount)
+        }
+    }
+
+    private func isMicrophoneMuted(at time: AVAudioTime) -> Bool {
+        guard time.isHostTimeValid else { return microphoneMuted }
+
+        let hostTime = time.hostTime
+        if completedMicrophoneMuteHostTimeRanges.contains(where: { $0.contains(hostTime) }) {
+            return true
+        }
+
+        if let microphoneMutedHostTime {
+            return hostTime >= microphoneMutedHostTime
+        }
+
+        return false
     }
 
     private func existingSourceURLs(for session: Session) throws -> [URL] {
@@ -1273,6 +1392,10 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         pausedHostTime = nil
         completedPauseHostTimeRanges = []
         accumulatedPausedDuration = 0
+        microphoneMuted = false
+        microphoneMutedHostTime = nil
+        completedMicrophoneMuteHostTimeRanges = []
+        reusableMicrophoneSilentBuffer = nil
         micConditioner = PassthroughMicConditioner()
         latestLevels = MeetingAudioLevels()
         sourceCaptureMetrics = [:]
@@ -1305,5 +1428,34 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         formatter.dateStyle = .medium
         formatter.timeStyle = .short
         return "Meeting \(formatter.string(from: date))"
+    }
+
+    private func silentMicrophoneBufferLike(_ buffer: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {
+        if let cached = reusableMicrophoneSilentBuffer,
+           cached.format.isEqual(buffer.format),
+           cached.frameCapacity >= buffer.frameLength {
+            cached.frameLength = buffer.frameLength
+            Self.zeroPCMBuffer(cached)
+            return cached
+        }
+
+        guard let silent = AVAudioPCMBuffer(
+            pcmFormat: buffer.format,
+            frameCapacity: buffer.frameLength
+        ) else {
+            return nil
+        }
+        silent.frameLength = buffer.frameLength
+        Self.zeroPCMBuffer(silent)
+        reusableMicrophoneSilentBuffer = silent
+        return silent
+    }
+
+    private static func zeroPCMBuffer(_ buffer: AVAudioPCMBuffer) {
+        for audioBuffer in UnsafeMutableAudioBufferListPointer(buffer.mutableAudioBufferList) {
+            if let data = audioBuffer.mData {
+                memset(data, 0, Int(audioBuffer.mDataByteSize))
+            }
+        }
     }
 }

--- a/Sources/MacParakeetViewModels/MeetingRecordingPanelViewModel.swift
+++ b/Sources/MacParakeetViewModels/MeetingRecordingPanelViewModel.swift
@@ -43,6 +43,9 @@ public final class MeetingRecordingPanelViewModel {
     /// Mirrors `MeetingRecordingService.isPaused`, set by the flow
     /// coordinator's polling task.
     public var isPaused: Bool = false
+    /// Meeting-local mic mute. Unlike pause, system audio keeps recording.
+    public var isMicrophoneMuted: Bool = false
+    public var canToggleMicrophoneMute: Bool = false
     public var previewLines: [MeetingRecordingPreviewLine] = []
     public var isTranscriptionLagging: Bool = false
     public private(set) var liveTranscriptStatus: LiveTranscriptStatus = .listening
@@ -55,6 +58,7 @@ public final class MeetingRecordingPanelViewModel {
     public let quickPromptsViewModel: QuickPromptsViewModel = QuickPromptsViewModel()
     public var onStop: (() -> Void)?
     public var onPauseToggle: (() -> Void)?
+    public var onMicrophoneMuteToggle: (() -> Void)?
     public var onClose: (() -> Void)?
 
     private var copiedResetTask: Task<Void, Never>?
@@ -139,6 +143,8 @@ public final class MeetingRecordingPanelViewModel {
         micLevel = 0
         systemLevel = 0
         isPaused = false
+        isMicrophoneMuted = false
+        canToggleMicrophoneMute = false
         previewLines = []
         previewLineWordCounts = []
         wordCount = 0

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
@@ -1321,6 +1321,168 @@ final class MeetingRecordingServiceTests: XCTestCase {
         XCTAssertFalse(isPaused)
     }
 
+    func testMicrophoneMuteWritesSilenceAndKeepsSystemAudioLive() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let audioConverter = MockMeetingAudioFileConverter()
+        let sttClient = CountingMeetingSTTClient()
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: audioConverter,
+            sttTranscriber: sttClient,
+            lockFileStore: RecordingLockFileStore()
+        )
+
+        try await service.startRecording()
+        let muteState = await service.setMicrophoneMuted(true)
+        XCTAssertEqual(muteState, MeetingMicrophoneMuteState(isMuted: true, canMute: true))
+
+        let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.5))
+        let systemBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.5))
+        await captureService.yield(.microphoneBuffer(
+            microphoneBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: ProcessInfo.processInfo.systemUptime + 0.1))
+        ))
+        await captureService.yield(.systemBuffer(
+            systemBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: ProcessInfo.processInfo.systemUptime + 0.1))
+        ))
+        try await Task.sleep(for: .milliseconds(80))
+
+        let micLevel = await service.micLevel
+        let systemLevel = await service.systemLevel
+        XCTAssertEqual(micLevel, 0)
+        XCTAssertGreaterThan(systemLevel, 0)
+
+        let output = try await service.stopRecording()
+        defer { try? FileManager.default.removeItem(at: output.folderURL) }
+
+        XCTAssertGreaterThan(output.sourceAlignment.microphone?.writtenFrameCount ?? 0, 0)
+        XCTAssertGreaterThan(output.sourceAlignment.system?.writtenFrameCount ?? 0, 0)
+        let counts = await sttClient.callCounts
+        XCTAssertEqual(counts.microphone, 0)
+        XCTAssertGreaterThanOrEqual(counts.system, 1)
+
+        await service.completeTranscription(for: output)
+    }
+
+    func testMicrophoneMutePreservesQueuedPreMuteAudioByHostTime() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let sttClient = CountingMeetingSTTClient()
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: MockMeetingAudioFileConverter(),
+            sttTranscriber: sttClient,
+            lockFileStore: RecordingLockFileStore()
+        )
+
+        try await service.startRecording()
+        let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.25))
+        let preMuteHostTime = AVAudioTime.hostTime(
+            forSeconds: max(0, ProcessInfo.processInfo.systemUptime - 1)
+        )
+        await captureService.yield(.microphoneBuffer(
+            microphoneBuffer,
+            AVAudioTime(hostTime: preMuteHostTime)
+        ))
+
+        await service.setMicrophoneMuted(true)
+
+        let output = try await service.stopRecording()
+        defer { try? FileManager.default.removeItem(at: output.folderURL) }
+
+        XCTAssertEqual(output.sourceAlignment.microphone?.firstHostTime, preMuteHostTime)
+        let counts = await sttClient.callCounts
+        XCTAssertGreaterThanOrEqual(counts.microphone, 1)
+
+        await service.completeTranscription(for: output)
+    }
+
+    func testMicrophoneMuteUnmuteAllowsLaterMicAudio() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let sttClient = CountingMeetingSTTClient()
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: MockMeetingAudioFileConverter(),
+            sttTranscriber: sttClient,
+            lockFileStore: RecordingLockFileStore()
+        )
+
+        try await service.startRecording()
+        await service.setMicrophoneMuted(true)
+
+        let mutedBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.5))
+        await captureService.yield(.microphoneBuffer(
+            mutedBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: ProcessInfo.processInfo.systemUptime + 0.1))
+        ))
+        try await Task.sleep(for: .milliseconds(20))
+
+        await service.setMicrophoneMuted(false)
+
+        let unmutedBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.25))
+        await captureService.yield(.microphoneBuffer(
+            unmutedBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: ProcessInfo.processInfo.systemUptime + 0.3))
+        ))
+        try await Task.sleep(for: .milliseconds(80))
+
+        let output = try await service.stopRecording()
+        defer { try? FileManager.default.removeItem(at: output.folderURL) }
+
+        let counts = await sttClient.callCounts
+        XCTAssertGreaterThanOrEqual(counts.microphone, 1)
+
+        await service.completeTranscription(for: output)
+    }
+
+    func testMicrophoneMuteIsUnavailableForSystemOnlyRecordings() async throws {
+        let captureService = MockMeetingAudioCaptureService(
+            startReport: MeetingAudioCaptureStartReport(sourceMode: .systemOnly)
+        )
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: MockMeetingAudioFileConverter(),
+            sttTranscriber: CountingMeetingSTTClient(),
+            lockFileStore: RecordingLockFileStore()
+        )
+
+        try await service.startRecording(sourceMode: .systemOnly)
+        defer {
+            Task { await service.cancelRecording() }
+        }
+
+        let canMute = await service.canMuteMicrophone
+        XCTAssertFalse(canMute)
+        let muteState = await service.setMicrophoneMuted(true)
+        XCTAssertEqual(muteState, MeetingMicrophoneMuteState(isMuted: false, canMute: false))
+        let isMuted = await service.isMicrophoneMuted
+        XCTAssertFalse(isMuted)
+    }
+
+    func testMicrophoneMuteStateClearsAfterCaptureFailure() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: MockMeetingAudioFileConverter(),
+            sttTranscriber: CountingMeetingSTTClient(),
+            lockFileStore: RecordingLockFileStore()
+        )
+
+        try await service.startRecording()
+        let mutedState = await service.setMicrophoneMuted(true)
+        XCTAssertEqual(mutedState, MeetingMicrophoneMuteState(isMuted: true, canMute: true))
+
+        await captureService.yield(.error(.captureRuntimeFailure("simulated runtime failure")))
+        try await Task.sleep(for: .milliseconds(50))
+
+        let failedState = await service.microphoneMuteState
+        XCTAssertEqual(failedState, MeetingMicrophoneMuteState(isMuted: false, canMute: false))
+        let setStateAfterFailure = await service.setMicrophoneMuted(false)
+        XCTAssertEqual(setStateAfterFailure, MeetingMicrophoneMuteState(isMuted: false, canMute: false))
+
+        await service.cancelRecording()
+    }
+
     func testPauseAndResumeAreNoOpsWhenNotRecording() async throws {
         let captureService = MockMeetingAudioCaptureService()
         let service = MeetingRecordingService(

--- a/Tests/MacParakeetTests/ViewModels/MeetingRecordingPanelViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/MeetingRecordingPanelViewModelTests.swift
@@ -182,6 +182,8 @@ final class MeetingRecordingPanelViewModelTests: XCTestCase {
         let viewModel = MeetingRecordingPanelViewModel()
         viewModel.state = .recording
         viewModel.elapsedSeconds = 42
+        viewModel.isMicrophoneMuted = true
+        viewModel.canToggleMicrophoneMute = true
         viewModel.updatePreviewLines(
             [
                 MeetingRecordingPreviewLine(
@@ -202,6 +204,8 @@ final class MeetingRecordingPanelViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.elapsedSeconds, 0)
         XCTAssertEqual(viewModel.micLevel, 0)
         XCTAssertEqual(viewModel.systemLevel, 0)
+        XCTAssertFalse(viewModel.isMicrophoneMuted)
+        XCTAssertFalse(viewModel.canToggleMicrophoneMute)
         XCTAssertTrue(viewModel.previewLines.isEmpty)
         XCTAssertFalse(viewModel.isTranscriptionLagging)
         XCTAssertEqual(viewModel.liveTranscriptStatus, .listening)


### PR DESCRIPTION
## Summary
- Add a meeting-recording microphone mute toggle to the floating recording panel when the selected meeting source captures microphone audio.
- Route the toggle through MeetingRecordingFlowCoordinator and MeetingRecordingService so system audio keeps recording while local mic audio is written as silence.
- Keep dictation behavior unchanged; this is meeting recording only.

## Review Notes
- Muted mic buffers are written as silence instead of dropped so dual-source timing/alignment remains stable for the final mix.
- If the silent buffer cannot be created, capture fails instead of falling back to writing real mic audio.
- System-only meeting recordings hide/no-op the microphone mute control.

## Verification
- swift test --filter MeetingRecordingServiceTests/testMicrophoneMute
- swift test --filter MeetingRecordingPanelViewModelTests
- swift test

Refs #309