### PR TITLE
Support shared custom dictation triggers

### DIFF
--- a/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
+++ b/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
@@ -116,8 +116,8 @@ final class AppHotkeyCoordinator {
         if handsFree.isDisabled && pushToTalk.isDisabled {
             return "Dictation Shortcuts: Disabled"
         }
-        if HotkeyTrigger.isDefaultDictationGesturePreset(handsFree: handsFree, pushToTalk: pushToTalk) {
-            return "Dictation: Hold Fn / Double-tap Fn"
+        if HotkeyTrigger.isSharedDictationGesture(handsFree: handsFree, pushToTalk: pushToTalk) {
+            return "Dictation: Hold \(pushToTalk.displayName) / Double-tap \(handsFree.displayName)"
         }
         if handsFree.overlaps(with: pushToTalk) {
             let conflictName = handsFree == pushToTalk
@@ -142,7 +142,7 @@ final class AppHotkeyCoordinator {
             return DictationHotkeyPlan(specs: [], conflict: nil)
         }
 
-        if HotkeyTrigger.isDefaultDictationGesturePreset(
+        if HotkeyTrigger.isSharedDictationGesture(
             handsFree: handsFreeTrigger,
             pushToTalk: pushToTalkTrigger
         ) {

--- a/Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift
+++ b/Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift
@@ -27,23 +27,23 @@ struct OnboardingFlowView: View {
         return current.isDisabled ? .defaultPushToTalk : current
     }
 
-    private var usesDefaultDictationGesturePreset: Bool {
-        HotkeyTrigger.isDefaultDictationGesturePreset(
+    private var usesSharedDictationGesture: Bool {
+        HotkeyTrigger.isSharedDictationGesture(
             handsFree: handsFreeDisplayTrigger,
             pushToTalk: pushToTalkDisplayTrigger
         )
     }
 
     private var handsFreeGestureTitle: String {
-        "\(usesDefaultDictationGesturePreset ? "Double-tap" : "Tap") \(handsFreeDisplayTrigger.shortSymbol)"
+        "\(usesSharedDictationGesture ? "Double-tap" : "Tap") \(handsFreeDisplayTrigger.shortSymbol)"
     }
 
     private var handsFreeInstructionPhrase: String {
-        "\(usesDefaultDictationGesturePreset ? "Double-tap" : "Tap") \(handsFreeDisplayTrigger.displayName)"
+        "\(usesSharedDictationGesture ? "Double-tap" : "Tap") \(handsFreeDisplayTrigger.displayName)"
     }
 
     private var handsFreeTryNowVerb: String {
-        usesDefaultDictationGesturePreset ? "double-tap" : "tap"
+        usesSharedDictationGesture ? "double-tap" : "tap"
     }
 
     private let windowWidth: CGFloat = 740
@@ -682,7 +682,7 @@ struct OnboardingFlowView: View {
             .opacity(reduceMotion || tapPhase == 1 ? 1.0 : 0.5)
             .animation(.easeInOut(duration: 0.15), value: tapPhase)
             .overlay(alignment: .topTrailing) {
-                if usesDefaultDictationGesturePreset {
+                if usesSharedDictationGesture {
                     Text("x2")
                         .font(DesignSystem.Typography.caption.weight(.semibold))
                         .foregroundStyle(DesignSystem.Colors.accent)
@@ -715,7 +715,7 @@ struct OnboardingFlowView: View {
     private func startAnimations() {
         guard !reduceMotion else { return }
         animationTask?.cancel()
-        let tapCount = usesDefaultDictationGesturePreset ? 2 : 1
+        let tapCount = usesSharedDictationGesture ? 2 : 1
         animationTask = Task { @MainActor in
             while !Task.isCancelled {
                 // Hands-free gesture.

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -22,7 +22,7 @@ enum SettingsDictationHotkeyConflictPolicy {
         peerName: String
     ) -> HotkeyTrigger.ValidationResult? {
         guard candidate.overlaps(with: peer) else { return nil }
-        if HotkeyTrigger.isDefaultDictationGesturePreset(handsFree: candidate, pushToTalk: peer) {
+        if HotkeyTrigger.isSharedDictationGesture(handsFree: candidate, pushToTalk: peer) {
             return nil
         }
         return .blocked(SettingsHotkeyConflictMessage.blocked(
@@ -38,7 +38,7 @@ enum SettingsDictationHotkeyConflictPolicy {
         disablesTrigger: Bool
     ) -> String? {
         guard trigger.overlaps(with: peer) else { return nil }
-        if HotkeyTrigger.isDefaultDictationGesturePreset(handsFree: trigger, pushToTalk: peer) {
+        if HotkeyTrigger.isSharedDictationGesture(handsFree: trigger, pushToTalk: peer) {
             return nil
         }
         if disablesTrigger {
@@ -2333,7 +2333,7 @@ struct SettingsView: View {
                 modeShortcutRow(
                     keys: [viewModel.hotkeyTrigger.shortSymbol],
                     separator: nil,
-                    verb: usesDefaultDictationGesturePreset ? "Double-tap" : "Tap",
+                    verb: usesSharedDictationGesture ? "Double-tap" : "Tap",
                     action: "Hands-free mode",
                     detail: "Tap again to stop"
                 )
@@ -2346,6 +2346,13 @@ struct SettingsView: View {
         )
     }
 
+    private var usesSharedDictationGesture: Bool {
+        HotkeyTrigger.isSharedDictationGesture(
+            handsFree: viewModel.hotkeyTrigger,
+            pushToTalk: viewModel.pushToTalkHotkeyTrigger
+        )
+    }
+
     private var usesDefaultDictationGesturePreset: Bool {
         HotkeyTrigger.isDefaultDictationGesturePreset(
             handsFree: viewModel.hotkeyTrigger,
@@ -2354,8 +2361,8 @@ struct SettingsView: View {
     }
 
     private var handsFreeHotkeyDetail: String {
-        if usesDefaultDictationGesturePreset {
-            return "Double-tap Fn to start; tap Fn again to stop."
+        if usesSharedDictationGesture {
+            return "Double-tap to start; tap again to stop."
         }
         return "Tap to start; tap again to stop."
     }

--- a/Sources/MacParakeetCore/STT/HotkeyTrigger.swift
+++ b/Sources/MacParakeetCore/STT/HotkeyTrigger.swift
@@ -371,6 +371,13 @@ public struct HotkeyTrigger: Sendable {
         handsFree == .defaultDictation && pushToTalk == .defaultPushToTalk
     }
 
+    public static func isSharedDictationGesture(
+        handsFree: HotkeyTrigger,
+        pushToTalk: HotkeyTrigger
+    ) -> Bool {
+        !handsFree.isDisabled && !pushToTalk.isDisabled && handsFree == pushToTalk
+    }
+
     // MARK: - Factory
 
     /// Create a trigger from a CGKeyCode.

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -730,10 +730,7 @@ public final class SettingsViewModel {
         if !storedHandsFree.isDisabled,
            !pushToTalk.isDisabled,
            storedHandsFree == pushToTalk {
-            if storedHandsFree == .defaultDictation {
-                return (storedHandsFree, .defaultPushToTalk, false, true)
-            }
-            return (defaultHandsFreeTrigger(avoiding: pushToTalk), pushToTalk, true, false)
+            return (storedHandsFree, pushToTalk, false, false)
         }
         if !storedHandsFree.isDisabled,
            !pushToTalk.isDisabled,

--- a/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
@@ -37,6 +37,15 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
         )
     }
 
+    private func rightCommandTrigger() -> HotkeyTrigger {
+        HotkeyTrigger(
+            kind: .modifier,
+            modifierName: "command",
+            keyCode: nil,
+            modifierKeyCode: 54
+        )
+    }
+
     func testSetupFileTranscriptionHotkeyReportsConflictInsteadOfSilentlyDropping() {
         let viewModel = makeViewModel()
         let conflictingTrigger = HotkeyTrigger.modifierChord(modifiers: ["command", "option"])
@@ -72,6 +81,15 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
         )
     }
 
+    func testMenuTitleDescribesSharedCustomDictationTrigger() {
+        let rightCommand = rightCommandTrigger()
+
+        XCTAssertEqual(
+            AppHotkeyCoordinator.menuTitle(handsFree: rightCommand, pushToTalk: rightCommand),
+            "Dictation: Hold Right Command / Double-tap Right Command"
+        )
+    }
+
     func testMenuTitleDescribesOverlappingDictationTriggers() {
         XCTAssertEqual(
             AppHotkeyCoordinator.menuTitle(
@@ -100,6 +118,24 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
             AppHotkeyCoordinator.DictationHotkeyPlan(
                 specs: [
                     .init(trigger: .fn, gestureMode: .doubleTapAndHold),
+                ],
+                conflict: nil
+            )
+        )
+    }
+
+    func testDictationHotkeyPlanUsesCombinedGestureForSharedRightCommand() {
+        let rightCommand = rightCommandTrigger()
+        let plan = AppHotkeyCoordinator.dictationHotkeyPlan(
+            handsFree: rightCommand,
+            pushToTalk: rightCommand
+        )
+
+        XCTAssertEqual(
+            plan,
+            AppHotkeyCoordinator.DictationHotkeyPlan(
+                specs: [
+                    .init(trigger: rightCommand, gestureMode: .doubleTapAndHold),
                 ],
                 conflict: nil
             )

--- a/Tests/MacParakeetTests/Hotkey/HotkeyTriggerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyTriggerTests.swift
@@ -403,6 +403,46 @@ final class HotkeyTriggerTests: XCTestCase {
             handsFree: .defaultDictation,
             pushToTalk: .defaultPushToTalk
         ))
+        XCTAssertTrue(HotkeyTrigger.isSharedDictationGesture(
+            handsFree: .defaultDictation,
+            pushToTalk: .defaultPushToTalk
+        ))
+    }
+
+    func testSharedDictationGestureAllowsExactCustomTrigger() {
+        let rightCommand = HotkeyTrigger(
+            kind: .modifier,
+            modifierName: "command",
+            keyCode: nil,
+            modifierKeyCode: 54
+        )
+
+        XCTAssertTrue(HotkeyTrigger.isSharedDictationGesture(
+            handsFree: rightCommand,
+            pushToTalk: rightCommand
+        ))
+    }
+
+    func testSharedDictationGestureRejectsDisabledTriggers() {
+        XCTAssertFalse(HotkeyTrigger.isSharedDictationGesture(
+            handsFree: .disabled,
+            pushToTalk: .disabled
+        ))
+    }
+
+    func testSharedDictationGestureRejectsNonExactOverlap() {
+        let rightCommand = HotkeyTrigger(
+            kind: .modifier,
+            modifierName: "command",
+            keyCode: nil,
+            modifierKeyCode: 54
+        )
+
+        XCTAssertTrue(rightCommand.overlaps(with: .command))
+        XCTAssertFalse(HotkeyTrigger.isSharedDictationGesture(
+            handsFree: rightCommand,
+            pushToTalk: .command
+        ))
     }
 
     // MARK: - Chord Validation

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -1476,7 +1476,7 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(vm.pushToTalkHotkeyTrigger, .defaultDictation)
     }
 
-    func testStoredMatchingDedicatedDictationHotkeysRestoreHandsFreeDefault() {
+    func testStoredMatchingDedicatedDictationHotkeysPreserveSharedFn() {
         HotkeyTrigger.fn.save(to: testDefaults)
         HotkeyTrigger.fn.save(to: testDefaults, defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey)
 
@@ -1492,6 +1492,31 @@ final class SettingsViewModelTests: XCTestCase {
                 fallback: .defaultPushToTalk
             ),
             .fn
+        )
+    }
+
+    func testStoredMatchingCustomDictationHotkeysPreserveSharedTrigger() {
+        let rightCommand = HotkeyTrigger(
+            kind: .modifier,
+            modifierName: "command",
+            keyCode: nil,
+            modifierKeyCode: 54
+        )
+        rightCommand.save(to: testDefaults)
+        rightCommand.save(to: testDefaults, defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey)
+
+        let vm = SettingsViewModel(defaults: testDefaults)
+
+        XCTAssertEqual(vm.hotkeyTrigger, rightCommand)
+        XCTAssertEqual(vm.pushToTalkHotkeyTrigger, rightCommand)
+        XCTAssertEqual(HotkeyTrigger.current(defaults: testDefaults), rightCommand)
+        XCTAssertEqual(
+            HotkeyTrigger.current(
+                defaults: testDefaults,
+                defaultsKey: HotkeyTrigger.pushToTalkDefaultsKey,
+                fallback: .defaultPushToTalk
+            ),
+            rightCommand
         )
     }
 

--- a/Tests/MacParakeetTests/Views/Settings/SettingsHotkeyConflictMessageTests.swift
+++ b/Tests/MacParakeetTests/Views/Settings/SettingsHotkeyConflictMessageTests.swift
@@ -38,14 +38,14 @@ final class SettingsHotkeyConflictMessageTests: XCTestCase {
         )
     }
 
-    func testDictationPeerValidationBlocksNonDefaultExactDuplicate() {
+    func testDictationPeerValidationAllowsNonDefaultExactDuplicate() {
         XCTAssertEqual(
             SettingsDictationHotkeyConflictPolicy.validation(
                 candidate: .control,
                 peer: .control,
                 peerName: "push to talk"
             ),
-            .blocked("Conflicts with push to talk (⌃ Control).")
+            nil
         )
     }
 
@@ -68,7 +68,7 @@ final class SettingsHotkeyConflictMessageTests: XCTestCase {
         )
     }
 
-    func testDictationPeerValidationBlocksDuplicateSideSpecificShiftChord() {
+    func testDictationPeerValidationAllowsDuplicateSideSpecificShiftChord() {
         let bothShifts = HotkeyTrigger.modifierChord(
             components: [
                 .init(modifierName: "shift", keyCode: 56),
@@ -82,7 +82,7 @@ final class SettingsHotkeyConflictMessageTests: XCTestCase {
                 peer: bothShifts,
                 peerName: "push to talk"
             ),
-            .blocked("Conflicts with push to talk (L⇧R⇧).")
+            nil
         )
     }
 
@@ -108,7 +108,7 @@ final class SettingsHotkeyConflictMessageTests: XCTestCase {
         )
     }
 
-    func testExistingDictationPeerConflictMessageCanNameActiveTrigger() {
+    func testExistingDictationPeerConflictMessageAllowsExactSharedTrigger() {
         XCTAssertEqual(
             SettingsDictationHotkeyConflictPolicy.existingConflictMessage(
                 trigger: .control,
@@ -116,19 +116,26 @@ final class SettingsHotkeyConflictMessageTests: XCTestCase {
                 peerName: "push to talk",
                 disablesTrigger: false
             ),
-            "Conflicts with push to talk (⌃ Control)."
+            nil
         )
     }
 
     func testExistingDictationPeerConflictMessageCanNameDisabledTrigger() {
+        let rightCommand = HotkeyTrigger(
+            kind: .modifier,
+            modifierName: "command",
+            keyCode: nil,
+            modifierKeyCode: 54
+        )
+
         XCTAssertEqual(
             SettingsDictationHotkeyConflictPolicy.existingConflictMessage(
-                trigger: .control,
-                peer: .control,
+                trigger: rightCommand,
+                peer: .command,
                 peerName: "hands-free mode",
                 disablesTrigger: true
             ),
-            "Disabled — conflicts with hands-free mode (⌃ Control)."
+            "Disabled — conflicts with hands-free mode (⌘ Command)."
         )
     }
 }

--- a/plans/active/2026-05-issue-350-shared-dictation-key.md
+++ b/plans/active/2026-05-issue-350-shared-dictation-key.md
@@ -1,0 +1,146 @@
+# Issue #350: Shared Dictation Key
+
+Status: **ACTIVE**
+Owner: Core app team
+Updated: 2026-05-24
+
+## Problem
+
+Issue #350 asks for the same single-key workflow that Fn already supports, but
+with Right Command:
+
+```text
+Hold Right Command       -> push-to-talk dictation
+Double-tap Right Command -> hands-free dictation
+Tap Right Command again  -> stop hands-free dictation
+```
+
+The user can assign Right Command to push-to-talk today, but Settings blocks
+assigning the same Right Command trigger to hands-free mode. Their workaround is
+Right Command for push-to-talk plus backtick for hands-free, but backtick is a
+typing key and correctly carries an interference warning.
+
+## Decision
+
+Support exact shared dictation triggers. If hands-free and push-to-talk are set
+to the exact same non-disabled `HotkeyTrigger`, MacParakeet treats that trigger
+as a shared dictation key and routes it through the existing combined
+hold/double-tap gesture controller.
+
+This is not a new "double-tap hotkey" trigger type. The stored trigger remains
+the physical key or chord. The gesture semantics are inferred from the two
+dictation roles sharing the exact same trigger.
+
+## Product Rule
+
+1. Exact same trigger in both dictation rows:
+   - hold -> push-to-talk
+   - double-tap -> hands-free start
+   - tap while hands-free is active -> stop
+2. Distinct triggers:
+   - push-to-talk stays hold-only
+   - hands-free stays single-tap toggle
+3. Overlapping but non-exact triggers remain conflicts:
+   - generic Command vs Right Command
+   - Right Command vs Right Command+Right Option
+   - Control vs Control+Option
+
+Exact equality matters because it keeps the mental model crisp: one physical
+trigger can own both dictation gestures, but near-overlaps still risk accidental
+activation and should stay blocked.
+
+## UX
+
+Keep the current Settings shape. Do not add a new toggle or a separate
+"double-tap" binding UI.
+
+When the two dictation rows share the exact same trigger:
+
+- Both rows show the same trigger label.
+- The hands-free row detail changes to "Double-tap to start; tap again to stop."
+- The guide panel changes from "Tap" to "Double-tap" for hands-free mode.
+- Conflict text is not shown.
+
+When the rows use distinct triggers, retain the existing copy:
+
+- push-to-talk: "Hold to dictate, release to stop."
+- hands-free: "Tap to start; tap again to stop."
+
+## Implementation Plan
+
+1. Add a shared-dictation predicate.
+   - Prefer a small helper such as
+     `HotkeyTrigger.isSharedDictationGesturePreset(handsFree:pushToTalk:)`.
+   - Return true only when both triggers are enabled and exactly equal.
+   - Keep the existing Fn helper as a compatibility/default-label convenience
+     or fold it through the generalized helper if that keeps call sites clearer.
+
+2. Update `AppHotkeyCoordinator`.
+   - Exact shared trigger -> one `DictationHotkeyPlan.Spec` using
+     `.doubleTapAndHold`.
+   - Distinct triggers -> current `.singleTapToggle` plus `.holdOnly`.
+   - Non-exact overlaps -> current conflict behavior.
+   - Update menu title so shared Right Command reads like a combined gesture,
+     not a conflict.
+
+3. Update Settings validation and conflict display.
+   - `SettingsDictationHotkeyConflictPolicy` should allow exact shared triggers.
+   - Keep blocking non-exact overlaps.
+   - Keep auxiliary hotkey conflict behavior unchanged.
+
+4. Preserve shared custom triggers on launch.
+   - `SettingsViewModel.resolveDictationHotkeyTriggers` currently migrates
+     duplicate non-Fn dictation triggers away.
+   - Change that migration so exact shared triggers such as Right Command are
+     preserved instead of replaced by the default hands-free trigger.
+   - Continue migrating ambiguous overlapping-but-not-equal pairs to a safe
+     configuration.
+
+5. Update Settings copy.
+   - Replace `usesDefaultDictationGesturePreset` usage with a generalized
+     shared-trigger check where the behavior is what matters.
+   - Keep "Double-tap Fn" label overrides only where the literal default label
+     should mention Fn.
+
+6. Amend ADR-009.
+   - Replace the Fn-only exception wording with the generalized rule:
+     hands-free and push-to-talk may share the exact same trigger, in which
+     case the shared hold/double-tap gesture applies.
+
+## Tests
+
+Add focused coverage for:
+
+1. `AppHotkeyCoordinator.dictationHotkeyPlan` returns one `.doubleTapAndHold`
+   spec for shared Right Command.
+2. The planner still reports conflicts for non-exact overlaps.
+3. Settings peer validation allows exact shared Right Command.
+4. Settings peer validation blocks generic Command vs Right Command.
+5. `SettingsViewModel.resolveDictationHotkeyTriggers` preserves stored shared
+   Right Command for both roles.
+6. Existing Fn default behavior remains unchanged.
+
+Run:
+
+```bash
+swift test --filter Hotkey
+swift test --filter SettingsViewModel
+swift test
+```
+
+## Out of Scope
+
+- No new persistent trigger kind.
+- No user-facing "double-tap mode" toggle.
+- No changes to meeting/file/YouTube/Transform hotkey semantics.
+- No broad hotkey architecture rewrite.
+
+## Acceptance Criteria
+
+- A user can set both dictation rows to Right Command.
+- The app starts one combined dictation hotkey manager for that shared trigger.
+- Hold starts push-to-talk and release stops it.
+- Double-tap starts hands-free mode.
+- A later tap stops hands-free mode.
+- Settings copy reflects the inferred double-tap behavior.
+- Non-exact overlaps remain blocked.

--- a/plans/completed/2026-05-issue-350-shared-dictation-key.md
+++ b/plans/completed/2026-05-issue-350-shared-dictation-key.md
@@ -1,6 +1,6 @@
 # Issue #350: Shared Dictation Key
 
-Status: **ACTIVE**
+Status: **COMPLETED** — implemented on 2026-05-24.
 Owner: Core app team
 Updated: 2026-05-24
 
@@ -70,7 +70,7 @@ When the rows use distinct triggers, retain the existing copy:
 
 1. Add a shared-dictation predicate.
    - Prefer a small helper such as
-     `HotkeyTrigger.isSharedDictationGesturePreset(handsFree:pushToTalk:)`.
+     `HotkeyTrigger.isSharedDictationGesture(handsFree:pushToTalk:)`.
    - Return true only when both triggers are enabled and exactly equal.
    - Keep the existing Fn helper as a compatibility/default-label convenience
      or fold it through the generalized helper if that keeps call sites clearer.

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -137,11 +137,11 @@ See [00-vision.md](./00-vision.md) for positioning and market context.
 
 **Activation — Configurable Hotkey:**
 
-Dictation defaults to a built-in shared `Fn` gesture preset: hold `Fn` for push-to-talk, or double-tap `Fn` for hands-free mode. `Fn+Fn` is not a customizable recorded hotkey; choosing restore default returns to this preset. Each dictation role can still be assigned a custom shortcut. The "record a shortcut" UI supports bare modifiers (Fn, Control, etc.), standalone keys (F5, Tab, etc.), modifier+key chords (Fn+Space, Cmd+9, Ctrl+Shift+D), and modifier-only chords (Command+Option, including side-specific variants like Right Command+Right Option). See ADR-009 for full details. Custom dictation shortcuts must be distinct and non-overlapping; Settings blocks assigning conflicting triggers to both roles.
+Dictation defaults to a built-in shared `Fn` gesture preset: hold `Fn` for push-to-talk, or double-tap `Fn` for hands-free mode. `Fn+Fn` is not a customizable recorded hotkey; choosing restore default returns to this preset. Each dictation role can still be assigned a custom shortcut. The "record a shortcut" UI supports bare modifiers (Fn, Control, etc.), standalone keys (F5, Tab, etc.), modifier+key chords (Fn+Space, Cmd+9, Ctrl+Shift+D), and modifier-only chords (Command+Option, including side-specific variants like Right Command+Right Option). See ADR-009 for full details. Custom dictation shortcuts may be distinct, or both roles may share the exact same non-disabled trigger to reuse the hold/double-tap gesture model. Settings blocks overlapping but non-identical triggers.
 
 | Mode | Gesture | Behavior |
 |------|---------|----------|
-| **Hands-free** | Double-tap Fn by default, or tap the configured hands-free shortcut | Persistent recording. Tap the shortcut again to stop. |
+| **Hands-free** | Double-tap the shared Fn/custom trigger when both dictation roles share one, or tap the configured hands-free shortcut when roles are distinct | Persistent recording. Tap the shortcut again to stop. |
 | **Press-and-hold** | Hold the push-to-talk shortcut | Hold-to-talk. Release auto-stops and pastes. |
 
 Legacy default installs using `Fn+Space` hands-free plus `Fn` push-to-talk migrate to the shared `Fn` gesture preset. Legacy single-hotkey installs are migrated to the shared default gesture when the stored trigger is `Fn`. Otherwise the old trigger becomes push-to-talk, while hands-free moves to the default `Fn` preset or disables itself if that would conflict.
@@ -159,7 +159,7 @@ Legacy default installs using `Fn+Space` hands-free plus `Fn` push-to-talk migra
 - Chord validation: Escape blocked for all kinds. Modifier+key chords containing Command warn about system shortcut conflicts (Cmd+Tab, Cmd+Space, Cmd+Q/W/H/M). Fn is allowed in modifier+key chords such as Fn+Space.
 - Hands-free key-down: toggles persistent recording immediately for key and modifier+key triggers; bare modifier hands-free triggers toggle on bare release so normal modifier shortcuts are not captured.
 - Dedicated push-to-talk key-down: schedule only the startup debounce, then start hold-to-talk.
-- Duplicate or overlapping dictation shortcuts: the built-in shared `Fn` default is allowed as a gesture preset; other conflicting assignments are rejected in Settings and reported at runtime instead of creating a hidden combined gesture.
+- Duplicate or overlapping dictation shortcuts: exact duplicate triggers are allowed and use the shared hold/double-tap gesture model; overlapping but non-identical assignments are rejected in Settings and reported at runtime instead of creating a hidden combined gesture.
 - On key-up: dedicated push-to-talk releases after startup debounce stop and process.
 - Escape is permanently reserved for cancel-dictation and cannot be assigned as hotkey
 - Requires Accessibility permission (prompted on first activation).
@@ -648,7 +648,7 @@ Audio path is computed from ID by default. Files stored as WAV (16kHz mono). Use
 |---------|---------|---------|
 | Launch at login | On / Off | Off |
 | Push-to-talk hotkey | Bare modifiers, standalone keys, modifier+key chords, and modifier-only chords with overlap checks | Fn |
-| Hands-free hotkey | Default shared Fn gesture preset; custom bare modifiers, standalone keys, modifier+key chords, and modifier-only chords with overlap checks | Fn |
+| Hands-free hotkey | Default shared Fn gesture preset; custom bare modifiers, standalone keys, modifier+key chords, and modifier-only chords; may exactly match push-to-talk for shared gesture behavior | Fn |
 | Stop mode | Auto-stop after silence / Manual | Manual |
 | Silence delay | 1s, 1.5s, 2s, 3s, 5s | 2s |
 | Save audio recordings | On / Off | On |

--- a/spec/09-testing.md
+++ b/spec/09-testing.md
@@ -278,7 +278,7 @@ Tests/
 
 These flows must be tested manually after any overlay or hotkey changes. Automated unit tests cover the state machine logic, but the full UX requires human verification.
 
-> **Note:** The default dictation preset uses `Fn` for both roles: double-tap `Fn` for hands-free, and hold `Fn` for push-to-talk. `Fn+Space` is a supported custom hands-free chord and should remain recordable. Custom dictation shortcuts must be distinct and non-overlapping; Settings should reject conflicting triggers for the two roles. Test with at least two different trigger keys.
+> **Note:** The default dictation preset uses `Fn` for both roles: double-tap `Fn` for hands-free, and hold `Fn` for push-to-talk. `Fn+Space` is a supported custom hands-free chord and should remain recordable. Custom dictation shortcuts may be distinct, or both roles may share the exact same trigger for the shared hold/double-tap gesture. Settings should reject overlapping but non-identical triggers for the two roles. Test with at least two different trigger keys.
 
 ### Happy Path
 

--- a/spec/adr/009-custom-hotkey.md
+++ b/spec/adr/009-custom-hotkey.md
@@ -55,7 +55,7 @@ Community issue #17 requested modifier+key combos (e.g., Cmd+9) because Logitech
 7. **Modifier names stored as `[String]`** — Not raw `CGEventFlags.rawValue` (has phantom bits). Readable JSON: `{"kind":"chord","keyCode":25,"chordModifiers":["command"]}`.
 8. **HotkeyRecorderView two-phase capture** — Held modifiers show as preview (e.g. "⌘..."); pressing a key with modifiers held creates a chord; releasing all modifiers without a key press creates a bare modifier trigger.
 9. **Validation** — Chords are `.allowed` by default. Escape blocked. Cmd+Tab and Cmd+Space warned (system intercepts them).
-10. **Distinct dictation roles** — Hands-free and push-to-talk cannot be manually assigned overlapping triggers. Settings blocks conflicting assignments, except for the built-in shared Fn default gesture preset. Legacy single-hotkey installs migrate to the shared default gesture when appropriate, or to distinct shortcuts where possible.
+10. **Shared dictation gestures** — Hands-free and push-to-talk may share the exact same trigger, in which case that trigger uses the combined gesture model: hold for push-to-talk, double-tap for hands-free, and tap again to stop hands-free. Settings still blocks overlapping but non-identical triggers (for example, generic Command vs Right Command, or Right Command vs Right Command+Right Option). Legacy single-hotkey installs migrate to the shared default gesture when appropriate, or to distinct shortcuts where possible.
 
 ### Original decision preserved
 


### PR DESCRIPTION
## Summary
- allow hands-free and push-to-talk to share the exact same enabled trigger
- route exact shared triggers through the existing hold/double-tap gesture controller
- update Settings/onboarding copy plus ADR/spec/testing docs for the generalized shared-trigger rule

## UX
A user can now set both dictation rows to Right Command:
- hold Right Command -> push-to-talk
- double-tap Right Command -> hands-free start
- tap Right Command again -> stop hands-free

Non-exact overlaps are still blocked, e.g. generic Command vs Right Command or Right Command vs Right Command+Right Option.

## Verification
- git diff --check
- swift test --filter Hotkey
- swift test

Related: #350
