### PR TITLE
[codex] Fix dictation stop paste focus loss

### DIFF
--- a/Sources/MacParakeet/Views/Dictation/DictationOverlayController.swift
+++ b/Sources/MacParakeet/Views/Dictation/DictationOverlayController.swift
@@ -7,10 +7,14 @@ import SwiftUI
 /// NSView overlay that detects mouse hover and position via NSTrackingArea with `.activeAlways`.
 /// Required because `.help()`, `.onHover`, and standard tracking options
 /// all fail on non-activating NSPanel. See CLAUDE.md Known Pitfalls.
-private final class MouseTrackingView: NSView {
+final class MouseTrackingView: NSView {
     var onEnter: (() -> Void)?
     var onExit: (() -> Void)?
     var onMoved: ((NSPoint) -> Void)?
+    var shouldReceiveMouseDown: ((NSPoint) -> Bool)?
+    var onClick: ((NSPoint) -> Void)?
+
+    private var mouseDownPoint: NSPoint?
 
     override func updateTrackingAreas() {
         super.updateTrackingAreas()
@@ -33,18 +37,82 @@ private final class MouseTrackingView: NSView {
         onMoved?(convert(event.locationInWindow, from: nil))
     }
 
-    // Pass all clicks through to SwiftUI content below
-    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+    override func mouseDown(with event: NSEvent) {
+        mouseDownPoint = convert(event.locationInWindow, from: nil)
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        let upPoint = convert(event.locationInWindow, from: nil)
+        if let downPoint = mouseDownPoint,
+           shouldReceiveMouseDown?(downPoint) == true,
+           shouldReceiveMouseDown?(upPoint) == true {
+            onClick?(upPoint)
+        }
+        mouseDownPoint = nil
+    }
+
+    // Only intercept clicks in the visible control regions; pass through everywhere else.
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        let localPoint = convert(point, from: superview)
+        return shouldReceiveMouseDown?(localPoint) == true ? self : nil
+    }
 }
 
-// MARK: - Clickable Non-Activating Panel
+// MARK: - Keyless Non-Activating Panel
 
-/// NSPanel subclass that allows SwiftUI buttons to receive clicks while
-/// remaining non-activating (won't steal focus on `orderFront`).
-/// Without `canBecomeKey = true`, buttons inside a `.nonactivatingPanel`
-/// are unresponsive because the panel never becomes key window.
-private final class ClickablePanel: NSPanel {
-    override var canBecomeKey: Bool { true }
+final class DictationOverlayPanel: NSPanel {
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+}
+
+enum DictationOverlayControlHitTarget: Equatable {
+    case cancel
+    case stop
+}
+
+struct DictationOverlayControlHitTesting {
+    static let pillWidth: CGFloat = 210
+    static let controlZoneWidth: CGFloat = 45
+    static let controlRowBottomPadding: CGFloat = 8
+    static let controlRowHeight: CGFloat = 36
+    static let controlRowHitSlop: CGFloat = 6
+
+    static func target(
+        at point: NSPoint,
+        in bounds: NSRect,
+        overlayState: DictationOverlayViewModel.OverlayState,
+        recordingMode: FnKeyStateMachine.RecordingMode,
+        requiresVisibleControlRow: Bool = false
+    ) -> DictationOverlayControlHitTarget? {
+        guard bounds.width >= pillWidth else {
+            return nil
+        }
+
+        guard case .recording = overlayState,
+              recordingMode == .persistent else {
+            return nil
+        }
+
+        if requiresVisibleControlRow {
+            let controlBottom = bounds.minY + controlRowBottomPadding - controlRowHitSlop
+            let controlTop = bounds.minY + controlRowBottomPadding + controlRowHeight + controlRowHitSlop
+            guard point.y >= controlBottom && point.y <= controlTop else {
+                return nil
+            }
+        }
+
+        let pillLeft = (bounds.width - pillWidth) / 2
+        let pillRight = pillLeft + pillWidth
+        let x = point.x
+
+        if x >= pillLeft && x < pillLeft + controlZoneWidth {
+            return .cancel
+        }
+        if x > pillRight - controlZoneWidth && x <= pillRight {
+            return .stop
+        }
+        return nil
+    }
 }
 
 @MainActor
@@ -85,7 +153,7 @@ final class DictationOverlayController: DictationOverlayControlling {
         let panelHeight: CGFloat = 160
         hosting.frame = NSRect(x: 0, y: 0, width: panelWidth, height: panelHeight)
 
-        let panel = ClickablePanel(
+        let panel = DictationOverlayPanel(
             contentRect: NSRect(x: 0, y: 0, width: panelWidth, height: panelHeight),
             styleMask: [.nonactivatingPanel, .borderless],
             backing: .buffered,
@@ -106,8 +174,24 @@ final class DictationOverlayController: DictationOverlayControlling {
             self?.overlayViewModel.isHovered = false
             self?.overlayViewModel.hoverTooltip = nil
         }
-        tracker.onMoved = { [weak self] point in
-            self?.updateHoverTooltip(at: point, in: hosting.bounds)
+        tracker.onMoved = { [weak self, weak tracker] point in
+            guard let tracker else { return }
+            self?.updateHoverTooltip(at: point, in: tracker.bounds)
+        }
+        tracker.shouldReceiveMouseDown = { [weak self, weak tracker] point in
+            guard let self, let tracker else { return false }
+            return self.clickHitTarget(at: point, in: tracker.bounds) != nil
+        }
+        tracker.onClick = { [weak self, weak tracker] point in
+            guard let self, let tracker else { return }
+            switch self.clickHitTarget(at: point, in: tracker.bounds) {
+            case .cancel:
+                self.overlayViewModel.onCancel?()
+            case .stop:
+                self.overlayViewModel.onStop?()
+            case nil:
+                break
+            }
         }
         hosting.addSubview(tracker)
         trackingView = tracker
@@ -132,8 +216,8 @@ final class DictationOverlayController: DictationOverlayControlling {
         trackingView = nil
     }
 
-    /// Resign key window so CGEvent paste targets the user's app, not the overlay panel.
-    /// Call this before any simulated Cmd+V when the overlay was clicked (e.g. Undo, Stop button).
+    /// Compatibility hook for paste flows that defensively clear overlay key state.
+    /// DictationOverlayPanel is keyless, so this is normally a no-op.
     func resignKeyWindow() {
         panel?.resignKey()
     }
@@ -141,22 +225,10 @@ final class DictationOverlayController: DictationOverlayControlling {
     /// Determine which element the cursor is over and update the tooltip.
     /// The pill is centered in the panel. Left zone = cancel, right zone = stop.
     private func updateHoverTooltip(at point: NSPoint, in bounds: NSRect) {
-        guard case .recording = overlayViewModel.state,
-              overlayViewModel.recordingMode == .persistent else {
-            // No hover tooltips in hold-to-talk (no buttons), ready, cancelled, processing, success, noSpeech, or error states
-            overlayViewModel.hoverTooltip = nil
-            return
-        }
-
-        let panelWidth = bounds.width
-        let pillWidth: CGFloat = 210 // approximate pill content width
-        let pillLeft = (panelWidth - pillWidth) / 2
-        let pillRight = pillLeft + pillWidth
-
-        let x = point.x
-        if x >= pillLeft && x < pillLeft + 45 {
+        switch controlHitTarget(at: point, in: bounds) {
+        case .cancel:
             overlayViewModel.hoverTooltip = "Cancel (Esc)"
-        } else if x > pillRight - 45 && x <= pillRight {
+        case .stop:
             if overlayViewModel.sessionKind == .command {
                 overlayViewModel.hoverTooltip = "Stop & apply (Fn+Control)"
             } else {
@@ -165,9 +237,28 @@ final class DictationOverlayController: DictationOverlayControlling {
                     ? "Stop & paste"
                     : "Stop & paste (\(trigger.displayName))"
             }
-        } else {
+        case nil:
             overlayViewModel.hoverTooltip = nil
         }
+    }
+
+    private func controlHitTarget(at point: NSPoint, in bounds: NSRect) -> DictationOverlayControlHitTarget? {
+        DictationOverlayControlHitTesting.target(
+            at: point,
+            in: bounds,
+            overlayState: overlayViewModel.state,
+            recordingMode: overlayViewModel.recordingMode
+        )
+    }
+
+    private func clickHitTarget(at point: NSPoint, in bounds: NSRect) -> DictationOverlayControlHitTarget? {
+        DictationOverlayControlHitTesting.target(
+            at: point,
+            in: bounds,
+            overlayState: overlayViewModel.state,
+            recordingMode: overlayViewModel.recordingMode,
+            requiresVisibleControlRow: true
+        )
     }
 
     func updateSize(width: CGFloat) {

--- a/Tests/MacParakeetTests/Views/DictationOverlayControllerTests.swift
+++ b/Tests/MacParakeetTests/Views/DictationOverlayControllerTests.swift
@@ -1,0 +1,169 @@
+import AppKit
+import XCTest
+@testable import MacParakeet
+@testable import MacParakeetCore
+
+@MainActor
+final class DictationOverlayControllerTests: XCTestCase {
+    private func mouseEvent(
+        type: NSEvent.EventType,
+        in view: NSView,
+        localPoint: NSPoint
+    ) -> NSEvent {
+        let windowPoint = view.convert(localPoint, to: nil)
+        return NSEvent.mouseEvent(
+            with: type,
+            location: windowPoint,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        )!
+    }
+
+    func testMouseTrackingViewHitTestConvertsSuperviewPointToLocalCoordinates() {
+        let parent = NSView(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+        let tracker = MouseTrackingView(frame: NSRect(x: 50, y: 60, width: 300, height: 160))
+        parent.addSubview(tracker)
+
+        var receivedPoint: NSPoint?
+        tracker.shouldReceiveMouseDown = { point in
+            receivedPoint = point
+            return true
+        }
+
+        XCTAssertIdentical(parent.hitTest(NSPoint(x: 60, y: 75)), tracker)
+        XCTAssertEqual(receivedPoint?.x, 10)
+        XCTAssertEqual(receivedPoint?.y, 15)
+    }
+
+    func testMouseTrackingViewClicksOnMouseUpWhenPressAndReleaseStayInsideControlZone() {
+        let tracker = MouseTrackingView(frame: NSRect(x: 50, y: 60, width: 300, height: 160))
+        tracker.shouldReceiveMouseDown = { point in
+            point.x >= 0 && point.x <= 100 && point.y >= 0 && point.y <= 100
+        }
+
+        var clickedPoint: NSPoint?
+        tracker.onClick = { clickedPoint = $0 }
+
+        tracker.mouseDown(with: mouseEvent(type: .leftMouseDown, in: tracker, localPoint: NSPoint(x: 20, y: 20)))
+        tracker.mouseUp(with: mouseEvent(type: .leftMouseUp, in: tracker, localPoint: NSPoint(x: 25, y: 30)))
+
+        XCTAssertEqual(clickedPoint?.x, 25)
+        XCTAssertEqual(clickedPoint?.y, 30)
+    }
+
+    func testMouseTrackingViewDoesNotClickWhenMouseUpLeavesControlZone() {
+        let tracker = MouseTrackingView(frame: NSRect(x: 50, y: 60, width: 300, height: 160))
+        tracker.shouldReceiveMouseDown = { point in
+            point.x >= 0 && point.x <= 100 && point.y >= 0 && point.y <= 100
+        }
+
+        var clickCount = 0
+        tracker.onClick = { _ in clickCount += 1 }
+
+        tracker.mouseDown(with: mouseEvent(type: .leftMouseDown, in: tracker, localPoint: NSPoint(x: 20, y: 20)))
+        tracker.mouseUp(with: mouseEvent(type: .leftMouseUp, in: tracker, localPoint: NSPoint(x: 150, y: 20)))
+
+        XCTAssertEqual(clickCount, 0)
+    }
+
+    func testDictationOverlayPanelCannotBecomeKeyOrMain() {
+        let panel = DictationOverlayPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 300, height: 160),
+            styleMask: [.nonactivatingPanel, .borderless],
+            backing: .buffered,
+            defer: true
+        )
+
+        XCTAssertFalse(panel.canBecomeKey)
+        XCTAssertFalse(panel.canBecomeMain)
+    }
+
+    func testControlHitTestingTargetsCancelAndStopZonesInVisibleControlRow() {
+        let bounds = NSRect(x: 0, y: 0, width: 300, height: 160)
+
+        XCTAssertEqual(
+            DictationOverlayControlHitTesting.target(
+                at: NSPoint(x: 50, y: 25),
+                in: bounds,
+                overlayState: .recording,
+                recordingMode: .persistent,
+                requiresVisibleControlRow: true
+            ),
+            .cancel
+        )
+        XCTAssertEqual(
+            DictationOverlayControlHitTesting.target(
+                at: NSPoint(x: 250, y: 25),
+                in: bounds,
+                overlayState: .recording,
+                recordingMode: .persistent,
+                requiresVisibleControlRow: true
+            ),
+            .stop
+        )
+        XCTAssertNil(
+            DictationOverlayControlHitTesting.target(
+                at: NSPoint(x: 150, y: 25),
+                in: bounds,
+                overlayState: .recording,
+                recordingMode: .persistent,
+                requiresVisibleControlRow: true
+            )
+        )
+    }
+
+    func testClickHitTestingIgnoresTransparentSpaceAboveVisibleControls() {
+        let bounds = NSRect(x: 0, y: 0, width: 300, height: 160)
+
+        XCTAssertNil(
+            DictationOverlayControlHitTesting.target(
+                at: NSPoint(x: 250, y: 100),
+                in: bounds,
+                overlayState: .recording,
+                recordingMode: .persistent,
+                requiresVisibleControlRow: true
+            )
+        )
+    }
+
+    func testControlHitTestingIgnoresBoundsNarrowerThanPill() {
+        XCTAssertNil(
+            DictationOverlayControlHitTesting.target(
+                at: NSPoint(x: 10, y: 25),
+                in: NSRect(x: 0, y: 0, width: 200, height: 160),
+                overlayState: .recording,
+                recordingMode: .persistent,
+                requiresVisibleControlRow: true
+            )
+        )
+    }
+
+    func testControlHitTestingIgnoresNonPersistentRecordingStates() {
+        let bounds = NSRect(x: 0, y: 0, width: 300, height: 160)
+        let stopPoint = NSPoint(x: 250, y: 25)
+
+        XCTAssertNil(
+            DictationOverlayControlHitTesting.target(
+                at: stopPoint,
+                in: bounds,
+                overlayState: .recording,
+                recordingMode: .holdToTalk,
+                requiresVisibleControlRow: true
+            )
+        )
+        XCTAssertNil(
+            DictationOverlayControlHitTesting.target(
+                at: stopPoint,
+                in: bounds,
+                overlayState: .processing,
+                recordingMode: .persistent,
+                requiresVisibleControlRow: true
+            )
+        )
+    }
+}

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -256,7 +256,7 @@ Compact dark pill, icon-only controls, positioned at bottom-center of screen (40
 **Controls:** Icon buttons only, no text labels
 **Border:** Subtle white stroke (`Color.white.opacity(0.1)`, 1px)
 
-**Hover tooltips:** AppKit-level `MouseTrackingOverlay` using `NSTrackingArea` with `.activeAlways` flag (required because the overlay is a non-activating `NSPanel`). Sits on top of the hosting view with `hitTest -> nil` for click passthrough. Zone-based detection by relative X position. Tooltips render as dark capsule positioned above the pill with 13pt medium white text. Keyboard shortcuts are highlighted only when the action has a fixed shortcut.
+**Hover tooltips:** AppKit-level `MouseTrackingOverlay` using `NSTrackingArea` with `.activeAlways` flag (required because the overlay is a non-activating `NSPanel`). Sits on top of the hosting view, passing clicks through except for the visible persistent-mode Cancel / Stop control zones. Zone-based detection by relative X position. Tooltips render as dark capsule positioned above the pill with 13pt medium white text. Keyboard shortcuts are highlighted only when the action has a fixed shortcut.
 
 | Zone | Tooltip | Shortcut Highlight |
 |------|---------|-------------------|

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -441,7 +441,7 @@ Tooltips use AppKit `NSTrackingArea` with `.activeAlways` because the pill is a 
 
 Implementation pattern:
 - `MouseTrackingOverlay` NSView layered on top of the pill
-- `hitTest` returns `nil` for click passthrough (dictation overlay) or `self` for click-to-dictate (idle pill)
+- `hitTest` passes through transparent overlay space, intercepting only visible control zones for dictation or the pill region for click-to-dictate
 - `NSTrackingArea` with `.mouseMoved` + `.activeAlways` for precise hover detection
 - Show/hide tooltip label (opacity toggle, not add/remove, to prevent resize jitter)
 - Reserve space for tooltip text in the layout at all times


### PR DESCRIPTION
## Summary
- keep the dictation overlay panel keyless so clicking Stop & paste does not disturb the user's focused input
- route persistent-mode Stop / Cancel mouse handling through AppKit hit zones instead of relying on a keyable SwiftUI button panel
- align mouse hit testing to tracker-local coordinates and fire control actions on mouse-up so drag-out cancels work
- add regression tests for keyless panel behavior, control-zone hit testing, coordinate conversion, mouse-up activation, and undersized bounds
- update the specs for the new pass-through-except-controls tracking behavior

## Root Cause
Commit `57ce8043` made the dictation overlay panel keyable so SwiftUI buttons inside the non-activating panel could receive clicks. That solved the original button clickability issue, but it meant clicking Stop & paste could make the overlay the key window before paste dispatch. The transcript still reached history, but the generated Cmd+V could miss the user's original focused input.

This keeps the original intent, clickable persistent-mode controls, while restoring the overlay's keyless contract.

## Review Feedback
- Addressed Gemini coordinate-space feedback by converting `hitTest(_:)` points to local tracking-view coordinates and evaluating closures against `tracker.bounds`.
- Addressed Gemini defensive bounds feedback by rejecting hit testing when the panel is narrower than the pill geometry.
- Addressed Greptile mouse-down semantics by moving activation to mouse-up with down/up hit guards.
- Addressed Greptile stale-comment note on `resignKeyWindow`.

## Validation
- `git diff --check`
- `swift test --filter DictationOverlayControllerTests` -> 8 tests, 0 failures
- `swift test` -> 3,002 XCTest cases, 9 skipped, 0 failures; 16 Swift Testing cases, 0 failures

Fixes #366