### PR TITLE
Follow up issue #365 model selectors and feedback screenshots

### DIFF
--- a/Sources/MacParakeet/Views/Feedback/FeedbackView.swift
+++ b/Sources/MacParakeet/Views/Feedback/FeedbackView.swift
@@ -208,7 +208,7 @@ struct FeedbackView: View {
                 }
             }
 
-            // Email + Screenshot — both optional, visually secondary, sharing
+            // Email + screenshots — both optional, visually secondary, sharing
             // the same input material so they read as a pair.
             HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
                 VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
@@ -223,33 +223,44 @@ struct FeedbackView: View {
                 .frame(maxWidth: .infinity)
 
                 VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
-                    Text("Screenshot (optional)")
+                    Text("Screenshots (optional)")
                         .font(DesignSystem.Typography.body)
                         .fontWeight(.medium)
 
-                    if let filename = viewModel.screenshotFilename {
-                        screenshotAttachedPill(filename)
-                    } else {
+                    if viewModel.screenshotAttachments.isEmpty {
                         screenshotAttachButton
+                    } else {
+                        VStack(spacing: DesignSystem.Spacing.xs) {
+                            ForEach(viewModel.screenshotAttachments) { attachment in
+                                screenshotAttachedPill(attachment)
+                            }
+                            if viewModel.canAttachMoreScreenshots {
+                                screenshotAttachButton
+                            }
+                        }
                     }
 
-                    Text(viewModel.screenshotFilename != nil
-                         ? "PNG, JPEG, TIFF, or HEIC"
-                         : "or drop an image here")
+                    Text(viewModel.screenshotAttachments.isEmpty
+                         ? "or drop images here"
+                         : "PNG, JPEG, TIFF, or HEIC. Up to 5.")
                         .font(DesignSystem.Typography.caption)
                         .foregroundStyle(.secondary)
                 }
                 .frame(maxWidth: .infinity)
                 .onDrop(of: [.image], isTargeted: $isDraggingScreenshot) { providers in
-                    guard let provider = providers.first else { return false }
-                    _ = provider.loadFileRepresentation(for: .image) { url, _, error in
-                        guard let url, error == nil else { return }
-                        let tmp = FileManager.default.temporaryDirectory
-                            .appendingPathComponent(url.lastPathComponent)
-                        try? FileManager.default.removeItem(at: tmp)
-                        try? FileManager.default.copyItem(at: url, to: tmp)
-                        Task { @MainActor in
-                            viewModel.handleScreenshotDrop(url: tmp)
+                    guard !providers.isEmpty else { return false }
+                    for provider in providers {
+                        _ = provider.loadFileRepresentation(for: .image) { url, _, error in
+                            guard let url, error == nil else { return }
+                            let tmpDirectory = FileManager.default.temporaryDirectory
+                                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+                            try? FileManager.default.createDirectory(at: tmpDirectory, withIntermediateDirectories: true)
+                            let tmp = tmpDirectory.appendingPathComponent(url.lastPathComponent)
+                            try? FileManager.default.removeItem(at: tmp)
+                            try? FileManager.default.copyItem(at: url, to: tmp)
+                            Task { @MainActor in
+                                viewModel.handleScreenshotDrop(url: tmp)
+                            }
                         }
                     }
                     return true
@@ -353,18 +364,18 @@ struct FeedbackView: View {
         .buttonStyle(.plain)
     }
 
-    private func screenshotAttachedPill(_ filename: String) -> some View {
+    private func screenshotAttachedPill(_ attachment: FeedbackScreenshotAttachment) -> some View {
         HStack(spacing: DesignSystem.Spacing.xs) {
             Image(systemName: "photo")
                 .font(.system(size: 11))
                 .foregroundStyle(.secondary)
-            Text(filename)
+            Text(attachment.filename)
                 .font(DesignSystem.Typography.caption)
                 .lineLimit(1)
                 .truncationMode(.middle)
             Spacer()
             Button {
-                viewModel.removeScreenshot()
+                viewModel.removeScreenshot(id: attachment.id)
             } label: {
                 Image(systemName: "xmark.circle.fill")
                     .font(.system(size: 13))

--- a/Sources/MacParakeet/Views/Feedback/FeedbackView.swift
+++ b/Sources/MacParakeet/Views/Feedback/FeedbackView.swift
@@ -254,11 +254,16 @@ struct FeedbackView: View {
                             guard let url, error == nil else { return }
                             let tmpDirectory = FileManager.default.temporaryDirectory
                                 .appendingPathComponent(UUID().uuidString, isDirectory: true)
-                            try? FileManager.default.createDirectory(at: tmpDirectory, withIntermediateDirectories: true)
                             let tmp = tmpDirectory.appendingPathComponent(url.lastPathComponent)
-                            try? FileManager.default.removeItem(at: tmp)
-                            try? FileManager.default.copyItem(at: url, to: tmp)
+                            do {
+                                try FileManager.default.createDirectory(at: tmpDirectory, withIntermediateDirectories: true)
+                                try FileManager.default.copyItem(at: url, to: tmp)
+                            } catch {
+                                try? FileManager.default.removeItem(at: tmpDirectory)
+                                return
+                            }
                             Task { @MainActor in
+                                defer { try? FileManager.default.removeItem(at: tmpDirectory) }
                                 viewModel.handleScreenshotDrop(url: tmp)
                             }
                         }

--- a/Sources/MacParakeetCore/Models/LLMProvider.swift
+++ b/Sources/MacParakeetCore/Models/LLMProvider.swift
@@ -72,9 +72,7 @@ public enum LLMProviderID: String, Codable, Sendable, CaseIterable {
                 defaultModelName: "gpt-5.5",
                 fallbackModels: [
                     "gpt-5.5",
-                    "gpt-5.5-pro",
                     "gpt-5.4",
-                    "gpt-5.4-pro",
                     "gpt-5.4-mini",
                     "gpt-5.4-nano",
                     "gpt-5.3-chat-latest",

--- a/Sources/MacParakeetCore/Services/FeedbackService.swift
+++ b/Sources/MacParakeetCore/Services/FeedbackService.swift
@@ -22,6 +22,7 @@ public struct FeedbackPayload: Sendable, Encodable {
     public let email: String?
     public let screenshotBase64: String?
     public let screenshotFilename: String?
+    public let screenshots: [FeedbackScreenshot]
     public let systemInfo: SystemInfo
 
     public init(
@@ -30,14 +31,37 @@ public struct FeedbackPayload: Sendable, Encodable {
         email: String?,
         screenshotBase64: String?,
         screenshotFilename: String?,
+        screenshots: [FeedbackScreenshot] = [],
         systemInfo: SystemInfo
     ) {
+        let normalizedScreenshots: [FeedbackScreenshot]
+        if screenshots.isEmpty,
+           let screenshotBase64,
+           let screenshotFilename {
+            normalizedScreenshots = [
+                FeedbackScreenshot(filename: screenshotFilename, base64: screenshotBase64),
+            ]
+        } else {
+            normalizedScreenshots = screenshots
+        }
+
         self.category = category
         self.message = message
         self.email = email
-        self.screenshotBase64 = screenshotBase64
-        self.screenshotFilename = screenshotFilename
+        self.screenshotBase64 = screenshotBase64 ?? normalizedScreenshots.first?.base64
+        self.screenshotFilename = screenshotFilename ?? normalizedScreenshots.first?.filename
+        self.screenshots = normalizedScreenshots
         self.systemInfo = systemInfo
+    }
+}
+
+public struct FeedbackScreenshot: Sendable, Encodable, Equatable {
+    public let filename: String
+    public let base64: String
+
+    public init(filename: String, base64: String) {
+        self.filename = filename
+        self.base64 = base64
     }
 }
 
@@ -102,6 +126,7 @@ public final class FeedbackService: FeedbackServiceProtocol {
             email: feedback.email,
             screenshotBase64: feedback.screenshotBase64,
             screenshotFilename: feedback.screenshotFilename,
+            screenshots: feedback.screenshots,
             systemInfo: feedback.systemInfo
         )
 

--- a/Sources/MacParakeetCore/Services/FeedbackService.swift
+++ b/Sources/MacParakeetCore/Services/FeedbackService.swift
@@ -48,8 +48,8 @@ public struct FeedbackPayload: Sendable, Encodable {
         self.category = category
         self.message = message
         self.email = email
-        self.screenshotBase64 = screenshotBase64 ?? normalizedScreenshots.first?.base64
-        self.screenshotFilename = screenshotFilename ?? normalizedScreenshots.first?.filename
+        self.screenshotBase64 = normalizedScreenshots.first?.base64 ?? screenshotBase64
+        self.screenshotFilename = normalizedScreenshots.first?.filename ?? screenshotFilename
         self.screenshots = normalizedScreenshots
         self.systemInfo = systemInfo
     }

--- a/Sources/MacParakeetCore/Services/LLM/LLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLM/LLMClient.swift
@@ -633,11 +633,12 @@ public final class LLMClient: LLMClientProtocol, Sendable {
 
         // Try OpenAI-compatible format: { "data": [{ "id": "..." }] }
         if let modelsResponse = try? JSONDecoder().decode(ModelsListResponse.self, from: data) {
-            return modelsResponse.data
+            let models = modelsResponse.data
                 .map { id in
                     // Gemini returns "models/gemini-2.5-flash" — strip prefix
                     id.id.hasPrefix("models/") ? String(id.id.dropFirst(7)) : id.id
                 }
+            return Self.filterListedModels(models, for: config)
                 .sorted()
         }
 
@@ -806,6 +807,34 @@ public final class LLMClient: LLMClientProtocol, Sendable {
             return true
         }
         return false
+    }
+
+    private static func filterListedModels(_ models: [String], for config: LLMProviderConfig) -> [String] {
+        guard config.id == .openai else { return models }
+        return models.filter(isOpenAIStreamingChatModel)
+    }
+
+    private static func isOpenAIStreamingChatModel(_ model: String) -> Bool {
+        let lowered = model.lowercased()
+        let unsupportedSubstrings = [
+            "audio",
+            "dall-e",
+            "embedding",
+            "image",
+            "moderation",
+            "realtime",
+            "sora",
+            "transcribe",
+            "tts",
+            "whisper",
+        ]
+        guard !unsupportedSubstrings.contains(where: lowered.contains) else { return false }
+        guard !lowered.hasSuffix("-pro") else { return false }
+        return lowered.hasPrefix("gpt-")
+            || lowered.hasPrefix("o1")
+            || lowered.hasPrefix("o3")
+            || lowered.hasPrefix("o4")
+            || lowered.hasPrefix("chatgpt-")
     }
 
     private static func responseFormat(from format: ChatResponseFormat?) -> OpenAIResponseFormat? {

--- a/Sources/MacParakeetCore/Services/LLM/LLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLM/LLMClient.swift
@@ -758,7 +758,7 @@ public final class LLMClient: LLMClientProtocol, Sendable {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
 
-        // OpenAI reasoning models (o1/o3/o4) reject temperature AND max_tokens.
+        // OpenAI reasoning models reject temperature AND max_tokens.
         // Newer OpenAI models (gpt-5.x) reject max_tokens but accept temperature.
         // All of them require max_completion_tokens instead of max_tokens.
         let isReasoningModel = config.id == .openai && Self.isOpenAIReasoningModel(config.modelName)
@@ -793,12 +793,11 @@ public final class LLMClient: LLMClientProtocol, Sendable {
 
     /// OpenAI reasoning models that reject temperature and max_tokens parameters.
     private static func isOpenAIReasoningModel(_ model: String) -> Bool {
-        let lowered = model.lowercased()
-        return lowered.hasPrefix("o1") || lowered.hasPrefix("o3") || lowered.hasPrefix("o4")
+        isOpenAIReasoningModelID(model.lowercased())
     }
 
     /// OpenAI models that require max_completion_tokens instead of max_tokens.
-    /// Includes reasoning models (o1/o3/o4) and newer GPT models (5.x+).
+    /// Includes reasoning models and newer GPT models (5.x+).
     private static func openAIRequiresMaxCompletionTokens(_ model: String) -> Bool {
         let lowered = model.lowercased()
         if isOpenAIReasoningModel(lowered) { return true }
@@ -832,7 +831,20 @@ public final class LLMClient: LLMClientProtocol, Sendable {
         guard !lowered.hasSuffix("-pro") else { return false }
         return lowered.hasPrefix("gpt-")
             || lowered.hasPrefix("chatgpt-")
-            || (lowered.hasPrefix("o") && lowered.dropFirst().first?.isNumber == true)
+            || isOpenAIReasoningModelID(lowered)
+    }
+
+    private static func isOpenAIReasoningModelID(_ model: String) -> Bool {
+        guard model.hasPrefix("o") else { return false }
+        let suffix = model.dropFirst()
+        guard let generation = suffix.first, generation.isNumber else { return false }
+        return hasOpenAIModelPrefix(model, prefix: "o\(generation)")
+    }
+
+    private static func hasOpenAIModelPrefix(_ model: String, prefix: String) -> Bool {
+        guard model.hasPrefix(prefix) else { return false }
+        let boundary = model.dropFirst(prefix.count).first
+        return boundary == nil || boundary == "-"
     }
 
     private static func responseFormat(from format: ChatResponseFormat?) -> OpenAIResponseFormat? {

--- a/Sources/MacParakeetCore/Services/LLM/LLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLM/LLMClient.swift
@@ -831,10 +831,8 @@ public final class LLMClient: LLMClientProtocol, Sendable {
         guard !unsupportedSubstrings.contains(where: lowered.contains) else { return false }
         guard !lowered.hasSuffix("-pro") else { return false }
         return lowered.hasPrefix("gpt-")
-            || lowered.hasPrefix("o1")
-            || lowered.hasPrefix("o3")
-            || lowered.hasPrefix("o4")
             || lowered.hasPrefix("chatgpt-")
+            || (lowered.hasPrefix("o") && lowered.dropFirst().first?.isNumber == true)
     }
 
     private static func responseFormat(from format: ChatResponseFormat?) -> OpenAIResponseFormat? {

--- a/Sources/MacParakeetViewModels/FeedbackViewModel.swift
+++ b/Sources/MacParakeetViewModels/FeedbackViewModel.swift
@@ -5,18 +5,61 @@ import MacParakeetCore
 import AppKit
 #endif
 
+public struct FeedbackScreenshotAttachment: Identifiable, Equatable, Sendable {
+    public let id: UUID
+    public let filename: String
+    public let data: Data
+
+    public init(id: UUID = UUID(), filename: String, data: Data) {
+        self.id = id
+        self.filename = filename
+        self.data = data
+    }
+}
+
 @MainActor
 @Observable
 public final class FeedbackViewModel {
     private static let maxScreenshotSizeBytes = 5 * 1024 * 1024
+    private static let maxScreenshotCount = 5
 
     // Form fields
     public var category: FeedbackCategory = .bug
     public var message: String = ""
     public var email: String = ""
-    public var screenshotData: Data?
-    public var screenshotFilename: String?
+    public var screenshotAttachments: [FeedbackScreenshotAttachment] = []
     public var showSystemInfo: Bool = false
+
+    public var screenshotData: Data? {
+        get { screenshotAttachments.first?.data }
+        set {
+            guard let newValue else {
+                screenshotAttachments = []
+                return
+            }
+            let filename = screenshotFilename ?? "screenshot.png"
+            screenshotAttachments = [FeedbackScreenshotAttachment(filename: filename, data: newValue)]
+        }
+    }
+
+    public var screenshotFilename: String? {
+        get { screenshotAttachments.first?.filename }
+        set {
+            guard let newValue else {
+                screenshotAttachments = []
+                return
+            }
+            guard let first = screenshotAttachments.first else {
+                screenshotAttachments = [FeedbackScreenshotAttachment(filename: newValue, data: Data())]
+                return
+            }
+            screenshotAttachments[0] = FeedbackScreenshotAttachment(id: first.id, filename: newValue, data: first.data)
+        }
+    }
+
+    public var canAttachMoreScreenshots: Bool {
+        screenshotAttachments.count < Self.maxScreenshotCount
+    }
 
     // Submission state
     public enum SubmissionState: Equatable {
@@ -53,56 +96,77 @@ public final class FeedbackViewModel {
         let panel = NSOpenPanel()
         panel.title = "Attach Screenshot"
         panel.allowedContentTypes = [.png, .jpeg, .tiff, .heic]
-        panel.allowsMultipleSelection = false
+        panel.allowsMultipleSelection = true
         panel.canChooseDirectories = false
 
-        guard panel.runModal() == .OK, let url = panel.url else { return }
-
-        do {
-            if let fileSize = try url.resourceValues(forKeys: [.fileSizeKey]).fileSize,
-               fileSize > Self.maxScreenshotSizeBytes {
-                submissionState = .error("Screenshot must be 5 MB or smaller.")
-                return
-            }
-
-            let data = try Data(contentsOf: url, options: .mappedIfSafe)
-            guard data.count <= Self.maxScreenshotSizeBytes else {
-                submissionState = .error("Screenshot must be 5 MB or smaller.")
-                return
-            }
-
-            screenshotData = data
-            screenshotFilename = url.lastPathComponent
-        } catch {
-            submissionState = .error("Failed to read screenshot: \(error.localizedDescription)")
-        }
+        guard panel.runModal() == .OK else { return }
+        attachScreenshots(from: panel.urls)
         #endif
     }
 
     public func handleScreenshotDrop(url: URL) {
+        attachScreenshots(from: [url])
+    }
+
+    public func removeScreenshot(id: FeedbackScreenshotAttachment.ID) {
+        screenshotAttachments.removeAll { $0.id == id }
+    }
+
+    public func removeScreenshot() {
+        screenshotAttachments = []
+    }
+
+    private func attachScreenshots(from urls: [URL]) {
+        var nextAttachments = screenshotAttachments
+        for url in urls {
+            guard nextAttachments.count < Self.maxScreenshotCount else {
+                submissionState = .error("Attach up to \(Self.maxScreenshotCount) screenshots.")
+                break
+            }
+
+            do {
+                nextAttachments.append(try readScreenshotAttachment(from: url))
+            } catch {
+                submissionState = .error(error.localizedDescription)
+                break
+            }
+        }
+        screenshotAttachments = nextAttachments
+    }
+
+    private func readScreenshotAttachment(from url: URL) throws -> FeedbackScreenshotAttachment {
         do {
             if let fileSize = try url.resourceValues(forKeys: [.fileSizeKey]).fileSize,
                fileSize > Self.maxScreenshotSizeBytes {
-                submissionState = .error("Screenshot must be 5 MB or smaller.")
-                return
+                throw ScreenshotAttachmentError.tooLarge
             }
 
             let data = try Data(contentsOf: url, options: .mappedIfSafe)
             guard data.count <= Self.maxScreenshotSizeBytes else {
-                submissionState = .error("Screenshot must be 5 MB or smaller.")
-                return
+                throw ScreenshotAttachmentError.tooLarge
             }
 
-            screenshotData = data
-            screenshotFilename = url.lastPathComponent
+            return FeedbackScreenshotAttachment(filename: url.lastPathComponent, data: data)
         } catch {
-            submissionState = .error("Failed to read screenshot: \(error.localizedDescription)")
+            if error is ScreenshotAttachmentError {
+                throw error
+            }
+            throw ScreenshotAttachmentError.readFailed(error.localizedDescription)
         }
     }
 
-    public func removeScreenshot() {
-        screenshotData = nil
-        screenshotFilename = nil
+    private enum ScreenshotAttachmentError: LocalizedError {
+        case tooLarge
+        case readFailed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .tooLarge:
+                return "Each screenshot must be 5 MB or smaller."
+            case .readFailed(let detail):
+                return "Failed to read screenshot: \(detail)"
+            }
+        }
     }
 
     // MARK: - Submit
@@ -116,15 +180,20 @@ public final class FeedbackViewModel {
         let trimmedMessage = message.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
         let operationContext = Observability.childOperationContext()
+        let screenshots = screenshotAttachments.map {
+            FeedbackScreenshot(filename: $0.filename, base64: $0.data.base64EncodedString())
+        }
 
         let payload = FeedbackPayload(
             category: category,
             message: trimmedMessage,
             email: trimmedEmail.isEmpty ? nil : trimmedEmail,
-            screenshotBase64: screenshotData?.base64EncodedString(),
-            screenshotFilename: screenshotFilename,
+            screenshotBase64: screenshots.first?.base64,
+            screenshotFilename: screenshots.first?.filename,
+            screenshots: screenshots,
             systemInfo: systemInfo
         )
+        let hasScreenshots = !payload.screenshots.isEmpty
 
         submitTask = Task { [weak self] in
             guard let self else { return }
@@ -141,7 +210,7 @@ public final class FeedbackViewModel {
                     category: payload.category.rawValue,
                     outcome: .success,
                     durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
-                    screenshotAttached: payload.screenshotBase64 != nil,
+                    screenshotAttached: hasScreenshots,
                     systemInfoIncluded: true,
                     errorType: nil
                 ))
@@ -163,7 +232,7 @@ public final class FeedbackViewModel {
                     category: payload.category.rawValue,
                     outcome: .failure,
                     durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
-                    screenshotAttached: payload.screenshotBase64 != nil,
+                    screenshotAttached: hasScreenshots,
                     systemInfoIncluded: true,
                     errorType: Observability.errorType(for: error)
                 ))
@@ -180,8 +249,7 @@ public final class FeedbackViewModel {
         category = .bug
         message = ""
         email = ""
-        screenshotData = nil
-        screenshotFilename = nil
+        screenshotAttachments = []
         showSystemInfo = false
         submissionState = .idle
     }

--- a/Sources/MacParakeetViewModels/FeedbackViewModel.swift
+++ b/Sources/MacParakeetViewModels/FeedbackViewModel.swift
@@ -39,8 +39,16 @@ public final class FeedbackViewModel {
                 pendingScreenshotFilename = nil
                 return
             }
-            let filename = screenshotFilename ?? pendingScreenshotFilename ?? "screenshot.png"
-            screenshotAttachments = [FeedbackScreenshotAttachment(filename: filename, data: newValue)]
+            if let first = screenshotAttachments.first {
+                screenshotAttachments[0] = FeedbackScreenshotAttachment(
+                    id: first.id,
+                    filename: first.filename,
+                    data: newValue
+                )
+            } else {
+                let filename = pendingScreenshotFilename ?? "screenshot.png"
+                screenshotAttachments = [FeedbackScreenshotAttachment(filename: filename, data: newValue)]
+            }
             pendingScreenshotFilename = nil
         }
     }

--- a/Sources/MacParakeetViewModels/FeedbackViewModel.swift
+++ b/Sources/MacParakeetViewModels/FeedbackViewModel.swift
@@ -29,16 +29,19 @@ public final class FeedbackViewModel {
     public var email: String = ""
     public var screenshotAttachments: [FeedbackScreenshotAttachment] = []
     public var showSystemInfo: Bool = false
+    private var pendingScreenshotFilename: String?
 
     public var screenshotData: Data? {
         get { screenshotAttachments.first?.data }
         set {
             guard let newValue else {
                 screenshotAttachments = []
+                pendingScreenshotFilename = nil
                 return
             }
-            let filename = screenshotFilename ?? "screenshot.png"
+            let filename = screenshotFilename ?? pendingScreenshotFilename ?? "screenshot.png"
             screenshotAttachments = [FeedbackScreenshotAttachment(filename: filename, data: newValue)]
+            pendingScreenshotFilename = nil
         }
     }
 
@@ -47,10 +50,11 @@ public final class FeedbackViewModel {
         set {
             guard let newValue else {
                 screenshotAttachments = []
+                pendingScreenshotFilename = nil
                 return
             }
             guard let first = screenshotAttachments.first else {
-                screenshotAttachments = [FeedbackScreenshotAttachment(filename: newValue, data: Data())]
+                pendingScreenshotFilename = newValue
                 return
             }
             screenshotAttachments[0] = FeedbackScreenshotAttachment(id: first.id, filename: newValue, data: first.data)
@@ -114,6 +118,7 @@ public final class FeedbackViewModel {
 
     public func removeScreenshot() {
         screenshotAttachments = []
+        pendingScreenshotFilename = nil
     }
 
     private func attachScreenshots(from urls: [URL]) {
@@ -141,7 +146,7 @@ public final class FeedbackViewModel {
                 throw ScreenshotAttachmentError.tooLarge
             }
 
-            let data = try Data(contentsOf: url, options: .mappedIfSafe)
+            let data = try Data(contentsOf: url)
             guard data.count <= Self.maxScreenshotSizeBytes else {
                 throw ScreenshotAttachmentError.tooLarge
             }
@@ -250,6 +255,7 @@ public final class FeedbackViewModel {
         message = ""
         email = ""
         screenshotAttachments = []
+        pendingScreenshotFilename = nil
         showSystemInfo = false
         submissionState = .idle
     }

--- a/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
@@ -522,9 +522,7 @@ public final class LLMSettingsViewModel {
             )
             return
         }
-        if !Self.usesDiscoveredModelList(providerID) {
-            resetDiscoveredModels()
-        }
+        resetDiscoveredModels()
         let apiKey = providerID.supportsAPIKey ? ((try? configStore?.loadAPIKey(for: providerID)) ?? "") : ""
         let cliConfig = providerID == .localCLI ? cliConfigStore?.load() : nil
         var nextDraft = LLMSettingsDraft.defaults(

--- a/Tests/MacParakeetTests/Models/LLMProviderDescriptorTests.swift
+++ b/Tests/MacParakeetTests/Models/LLMProviderDescriptorTests.swift
@@ -44,6 +44,8 @@ final class LLMProviderDescriptorTests: XCTestCase {
     func testCuratedFallbacksTrackCurrentHeadlineModels() {
         XCTAssertEqual(LLMProviderID.openai.defaultModelName, "gpt-5.5")
         XCTAssertTrue(LLMProviderID.openai.fallbackModels.contains("gpt-5.4-mini"))
+        XCTAssertFalse(LLMProviderID.openai.fallbackModels.contains("gpt-5.5-pro"))
+        XCTAssertFalse(LLMProviderID.openai.fallbackModels.contains("gpt-5.4-pro"))
         XCTAssertTrue(LLMProviderID.anthropic.fallbackModels.contains("claude-opus-4-7"))
         XCTAssertTrue(LLMProviderID.gemini.fallbackModels.contains("gemini-3.1-flash-lite"))
         XCTAssertTrue(LLMProviderID.openrouter.fallbackModels.contains("anthropic/claude-opus-4.7"))

--- a/Tests/MacParakeetTests/Services/FeedbackServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/FeedbackServiceTests.swift
@@ -149,6 +149,67 @@ final class FeedbackServiceTests: XCTestCase {
         XCTAssertEqual(sysInfo?["chip_type"] as? String, "Apple M1")
     }
 
+    func testSubmitFeedbackEncodesMultipleScreenshotsWithLegacyFirstScreenshotFields() async throws {
+        var capturedBody: [String: Any]?
+
+        MockURLProtocol.handler = { request in
+            var bodyData: Data?
+            if let body = request.httpBody {
+                bodyData = body
+            } else if let stream = request.httpBodyStream {
+                stream.open()
+                var buffer = [UInt8](repeating: 0, count: 65536)
+                var collected = Data()
+                while stream.hasBytesAvailable {
+                    let count = stream.read(&buffer, maxLength: buffer.count)
+                    if count > 0 { collected.append(buffer, count: count) }
+                    else { break }
+                }
+                stream.close()
+                bodyData = collected
+            }
+            if let data = bodyData {
+                capturedBody = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            }
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data("{\"success\":true}".utf8))
+        }
+
+        let payload = FeedbackPayload(
+            category: .bug,
+            message: "Screenshots attached",
+            email: nil,
+            screenshotBase64: nil,
+            screenshotFilename: nil,
+            screenshots: [
+                FeedbackScreenshot(filename: "first.png", base64: "AQI="),
+                FeedbackScreenshot(filename: "second.jpg", base64: "AwQ="),
+            ],
+            systemInfo: SystemInfo(
+                appVersion: "1.0",
+                buildNumber: "1",
+                gitCommit: "abc123",
+                buildSource: "test",
+                macOSVersion: "15.0.0",
+                chipType: "Apple M1"
+            )
+        )
+
+        try await service.submitFeedback(payload)
+
+        XCTAssertEqual(capturedBody?["screenshot_base64"] as? String, "AQI=")
+        XCTAssertEqual(capturedBody?["screenshot_filename"] as? String, "first.png")
+        let screenshots = capturedBody?["screenshots"] as? [[String: Any]]
+        XCTAssertEqual(screenshots?.count, 2)
+        XCTAssertEqual(screenshots?[0]["filename"] as? String, "first.png")
+        XCTAssertEqual(screenshots?[1]["base64"] as? String, "AwQ=")
+    }
+
     func testEmptyMessageThrowsError() async {
         let payload = FeedbackPayload(
             category: .bug,

--- a/Tests/MacParakeetTests/Services/LLM/LLMClientTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMClientTests.swift
@@ -1011,6 +1011,31 @@ final class LLMClientTests: XCTestCase {
         XCTAssertEqual(models, ["qwen3.5:4b"])
     }
 
+    func testOpenAIListModelsFiltersCatalogToStreamingChatModels() async throws {
+        MockURLProtocol.handler = { request in
+            XCTAssertEqual(request.url?.absoluteString, "https://api.openai.com/v1/models")
+            return (self.okResponse(for: request), Data("""
+            {
+              "data": [
+                {"id":"gpt-5.5"},
+                {"id":"gpt-5.5-pro"},
+                {"id":"gpt-4.1-mini"},
+                {"id":"gpt-4o-transcribe"},
+                {"id":"gpt-image-1"},
+                {"id":"text-embedding-3-large"},
+                {"id":"omni-moderation-latest"},
+                {"id":"chatgpt-4o-latest"},
+                {"id":"o4-mini"}
+              ]
+            }
+            """.utf8))
+        }
+
+        let models = try await llmClient.listModels(config: .openai(apiKey: "sk-test"))
+
+        XCTAssertEqual(models, ["chatgpt-4o-latest", "gpt-4.1-mini", "gpt-5.5", "o4-mini"])
+    }
+
     func testGeminiListModelsUsesNativeModelsEndpoint() async throws {
         var capturedRequest: URLRequest?
 

--- a/Tests/MacParakeetTests/Services/LLM/LLMClientTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMClientTests.swift
@@ -1026,6 +1026,7 @@ final class LLMClientTests: XCTestCase {
                 {"id":"omni-moderation-latest"},
                 {"id":"chatgpt-4o-latest"},
                 {"id":"o2-mini"},
+                {"id":"o10-mini"},
                 {"id":"o4-mini"}
               ]
             }

--- a/Tests/MacParakeetTests/Services/LLM/LLMClientTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMClientTests.swift
@@ -1025,6 +1025,7 @@ final class LLMClientTests: XCTestCase {
                 {"id":"text-embedding-3-large"},
                 {"id":"omni-moderation-latest"},
                 {"id":"chatgpt-4o-latest"},
+                {"id":"o2-mini"},
                 {"id":"o4-mini"}
               ]
             }
@@ -1033,7 +1034,7 @@ final class LLMClientTests: XCTestCase {
 
         let models = try await llmClient.listModels(config: .openai(apiKey: "sk-test"))
 
-        XCTAssertEqual(models, ["chatgpt-4o-latest", "gpt-4.1-mini", "gpt-5.5", "o4-mini"])
+        XCTAssertEqual(models, ["chatgpt-4o-latest", "gpt-4.1-mini", "gpt-5.5", "o2-mini", "o4-mini"])
     }
 
     func testGeminiListModelsUsesNativeModelsEndpoint() async throws {

--- a/Tests/MacParakeetTests/ViewModels/FeedbackViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/FeedbackViewModelTests.swift
@@ -41,6 +41,7 @@ final class FeedbackViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.email, "")
         XCTAssertNil(viewModel.screenshotData)
         XCTAssertNil(viewModel.screenshotFilename)
+        XCTAssertTrue(viewModel.screenshotAttachments.isEmpty)
         XCTAssertFalse(viewModel.showSystemInfo)
         XCTAssertEqual(viewModel.submissionState, .idle)
     }
@@ -150,6 +151,7 @@ final class FeedbackViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.email, "")
         XCTAssertNil(viewModel.screenshotData)
         XCTAssertNil(viewModel.screenshotFilename)
+        XCTAssertTrue(viewModel.screenshotAttachments.isEmpty)
         XCTAssertFalse(viewModel.showSystemInfo)
         XCTAssertEqual(viewModel.submissionState, .idle)
     }
@@ -172,6 +174,33 @@ final class FeedbackViewModelTests: XCTestCase {
 
         XCTAssertNil(viewModel.screenshotData)
         XCTAssertNil(viewModel.screenshotFilename)
+    }
+
+    func testSubmissionIncludesMultipleScreenshots() async throws {
+        viewModel.message = "The form needs screenshots"
+        viewModel.screenshotAttachments = [
+            FeedbackScreenshotAttachment(filename: "first.png", data: Data([0x01, 0x02])),
+            FeedbackScreenshotAttachment(filename: "second.jpg", data: Data([0x03, 0x04])),
+        ]
+
+        viewModel.submit()
+        try await Task.sleep(for: .milliseconds(100))
+
+        XCTAssertEqual(mockService.lastPayload?.screenshots.count, 2)
+        XCTAssertEqual(mockService.lastPayload?.screenshots[0].filename, "first.png")
+        XCTAssertEqual(mockService.lastPayload?.screenshots[1].filename, "second.jpg")
+        XCTAssertEqual(mockService.lastPayload?.screenshotFilename, "first.png")
+        XCTAssertEqual(mockService.lastPayload?.screenshotBase64, Data([0x01, 0x02]).base64EncodedString())
+    }
+
+    func testRemoveScreenshotByIDKeepsOtherAttachments() {
+        let first = FeedbackScreenshotAttachment(filename: "first.png", data: Data([0x01]))
+        let second = FeedbackScreenshotAttachment(filename: "second.png", data: Data([0x02]))
+        viewModel.screenshotAttachments = [first, second]
+
+        viewModel.removeScreenshot(id: first.id)
+
+        XCTAssertEqual(viewModel.screenshotAttachments, [second])
     }
 
     // MARK: - System Info

--- a/Tests/MacParakeetTests/ViewModels/FeedbackViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/FeedbackViewModelTests.swift
@@ -214,6 +214,20 @@ final class FeedbackViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.screenshotData, Data([0x01]))
     }
 
+    func testLegacyDataSetterUpdatesFirstAttachmentWithoutDroppingOthers() {
+        let first = FeedbackScreenshotAttachment(filename: "first.png", data: Data([0x01]))
+        let second = FeedbackScreenshotAttachment(filename: "second.png", data: Data([0x02]))
+        viewModel.screenshotAttachments = [first, second]
+
+        viewModel.screenshotData = Data([0x09])
+
+        XCTAssertEqual(viewModel.screenshotAttachments.count, 2)
+        XCTAssertEqual(viewModel.screenshotAttachments[0].id, first.id)
+        XCTAssertEqual(viewModel.screenshotAttachments[0].filename, "first.png")
+        XCTAssertEqual(viewModel.screenshotAttachments[0].data, Data([0x09]))
+        XCTAssertEqual(viewModel.screenshotAttachments[1], second)
+    }
+
     // MARK: - System Info
 
     func testSystemInfoReturnsCurrentInfo() {

--- a/Tests/MacParakeetTests/ViewModels/FeedbackViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/FeedbackViewModelTests.swift
@@ -203,6 +203,17 @@ final class FeedbackViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.screenshotAttachments, [second])
     }
 
+    func testLegacyFilenameSetterBeforeDataDoesNotCreateEmptyAttachment() {
+        viewModel.screenshotFilename = "later.png"
+
+        XCTAssertTrue(viewModel.screenshotAttachments.isEmpty)
+
+        viewModel.screenshotData = Data([0x01])
+
+        XCTAssertEqual(viewModel.screenshotFilename, "later.png")
+        XCTAssertEqual(viewModel.screenshotData, Data([0x01]))
+    }
+
     // MARK: - System Info
 
     func testSystemInfoReturnsCurrentInfo() {

--- a/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
@@ -510,6 +510,21 @@ final class LLMSettingsViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.modelListErrorMessage)
     }
 
+    func testSwitchingBetweenDiscoveryProvidersClearsPreviousDiscoveredModels() async throws {
+        mockClient.modelsList = ["qwen3.5:9b", "gemma3:4b"]
+        viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
+
+        viewModel.selectedProviderID = .ollama
+        try await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertEqual(viewModel.availableModels, ["qwen3.5:9b", "gemma3:4b"])
+
+        viewModel.selectedProviderID = .openai
+
+        XCTAssertEqual(viewModel.discoveredModelCount, 0)
+        XCTAssertEqual(viewModel.availableModels, LLMSettingsViewModel.suggestedModels(for: .openai))
+        XCTAssertFalse(viewModel.availableModels.contains("qwen3.5:9b"))
+    }
+
     func testSwitchingProviderLoadsStoredKey() {
         viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
 


### PR DESCRIPTION
## Summary
- Filter direct OpenAI `/models` responses to streaming chat-compatible model IDs and remove non-streaming `-pro` variants from fallback suggestions.
- Clear stale discovered model lists when switching between discovery-backed providers.
- Support up to five in-app feedback screenshots while preserving first-screenshot legacy fields for the deployed endpoint contract.

## Notes
Refs #365 and follows PR #367. The app change is backward-compatible with the currently deployed feedback endpoint: old Worker code will still receive and publish the first screenshot through `screenshot_base64` / `screenshot_filename`. The website companion PR is still needed for all screenshots to appear in generated feedback issues.

## Validation
- `swift test --filter 'LLMProviderDescriptorTests|LLMClientTests|LLMSettingsViewModelTests|FeedbackViewModelTests|FeedbackServiceTests'`
- `swift test`
- `git diff --check`
