### PR TITLE
Fix calendar permission entitlement

### DIFF
--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -127,6 +127,10 @@ Before building, verify the codebase is ready:
 # All tests must pass
 swift test
 
+# Distribution privacy/entitlement guard runs after signing, but this source
+# file is the expected entitlement surface for the final app.
+plutil -p scripts/dist/MacParakeet.entitlements
+
 # Check currently deployed version
 curl -s "https://macparakeet.com/appcast.xml" | grep -E "sparkle:version|sparkle:shortVersionString"
 ```
@@ -500,6 +504,19 @@ These are set automatically by `build_app_bundle.sh`:
 |-----|-------|
 | `SUFeedURL` | `https://macparakeet.com/appcast.xml` |
 | `SUPublicEDKey` | `2aqRU0Agz+xxZwt0kLybmKz/SAvZUsyn+z9fU0I6ynY=` |
+
+### Privacy Strings and Entitlements
+
+Permission prompts require both the appropriate `Info.plist` usage string and
+the matching signed app entitlement when macOS gates access through TCC. The
+release signing script runs `scripts/dist/verify_app_privacy_surface.sh` after
+codesigning to catch drift before notarization.
+
+| Capability | Info.plist key | Entitlement |
+|------------|----------------|-------------|
+| Microphone input | `NSMicrophoneUsageDescription` | `com.apple.security.device.audio-input` |
+| System audio capture | `NSAudioCaptureUsageDescription` | macOS TCC prompt, no app entitlement |
+| Calendar event read access | `NSCalendarsFullAccessUsageDescription` | `com.apple.security.personal-information.calendars` |
 
 ### Settings UI
 

--- a/plans/completed/2026-05-issue-368-calendar-entitlement.md
+++ b/plans/completed/2026-05-issue-368-calendar-entitlement.md
@@ -1,0 +1,80 @@
+# Issue #368 Calendar Permission Root Cause
+
+## Summary
+
+Issue #368 reports that Calendar access cannot be connected from either
+Settings or onboarding in MacParakeet 0.6.11 (`d42138a00cdc`). The CleanShot
+evidence shows the Calendar button briefly entering its requesting state and
+then returning to "Grant Calendar Access" without a macOS prompt or blocked
+permission recovery state.
+
+The root cause is the signed release app's missing Calendar entitlement:
+`com.apple.security.personal-information.calendars`.
+
+## Evidence
+
+- The reported build is the shipped Developer ID app:
+  `CFBundleIdentifier=com.macparakeet.MacParakeet`,
+  `CFBundleShortVersionString=0.6.11`,
+  `CFBundleVersion=20260524210220`,
+  `MacParakeetGitCommit=d42138a00cdc`.
+- The shipped app bundle includes `NSCalendarsFullAccessUsageDescription`, so
+  this is not an Info.plist usage-string omission.
+- The shipped app entitlements include only:
+  `com.apple.security.device.audio-input` and
+  `com.apple.security.network.client`.
+- The user's visible behavior matches EventKit returning failure before TCC
+  records a decision: the UI awaits `CalendarService.requestPermission()`, gets
+  `false`, re-reads `.notDetermined`, and renders the same grant button again.
+- Local TCC inspection on the matching installed app showed no
+  `kTCCServiceCalendar` row for `com.macparakeet.MacParakeet`, consistent with
+  no first-time Calendar prompt being presented or recorded.
+
+## Official Docs Check
+
+Apple's EventKit docs say apps must request access through `EKEventStore`
+before reading calendar data, and full access is the required access level for
+reading events. Apple's Info.plist docs require
+`NSCalendarsFullAccessUsageDescription` for full calendar access. Apple's
+Calendar entitlement docs define
+`com.apple.security.personal-information.calendars` as the entitlement that
+allows read-write access to the user's calendar and instruct developers to add
+that entitlement when enabling App Sandbox or Hardened Runtime capabilities.
+
+MacParakeet uses Developer ID hardened-runtime signing in
+`scripts/dist/sign_notarize.sh`, so the final app needs both:
+
+- `NSCalendarsFullAccessUsageDescription` in `Info.plist`
+- `com.apple.security.personal-information.calendars = true` in the signed app
+  entitlements
+
+## Why Local Testing Missed It
+
+Most local calendar testing exercised the dev bundle (`com.macparakeet.dev`)
+or an already-granted TCC identity. That path did not force a fresh first-time
+Calendar prompt for the signed release bundle identity. The dev run script also
+did not explicitly sign with the release entitlement file, so dev smoke testing
+was not a strong parity check for the final Developer ID app.
+
+## Fix
+
+- Add `com.apple.security.personal-information.calendars` to
+  `scripts/dist/MacParakeet.entitlements`.
+- Sign the dev app with the same entitlement file so local calendar permission
+  smoke tests exercise the same capability surface as release.
+- Add `scripts/dist/verify_app_privacy_surface.sh` and run it from
+  `scripts/dist/sign_notarize.sh` after codesigning. The verifier checks the
+  microphone, system-audio, and calendar privacy strings plus the app
+  entitlements needed by TCC.
+
+## Regression Guard
+
+Before notarization, `scripts/dist/sign_notarize.sh` now fails if the signed app
+is missing:
+
+- `NSMicrophoneUsageDescription`
+- `NSAudioCaptureUsageDescription`
+- `NSCalendarsFullAccessUsageDescription`
+- `com.apple.security.device.audio-input`
+- `com.apple.security.personal-information.calendars`
+- `com.apple.security.network.client`

--- a/scripts/dev/run_app.sh
+++ b/scripts/dev/run_app.sh
@@ -41,6 +41,7 @@ pick_codesign_identity() {
 }
 
 CODESIGN_IDENTITY="$(pick_codesign_identity)"
+APP_ENTITLEMENTS="$ROOT_DIR/scripts/dist/MacParakeet.entitlements"
 
 sync_frameworks_into_bundle() {
   local source_dir="$1"
@@ -160,8 +161,11 @@ cat > "$APP_BUNDLE/Contents/Info.plist" << 'PLIST'
 </plist>
 PLIST
 
-# Re-sign the bundle so TCC can identify the dev build consistently.
-codesign --force --sign "$CODESIGN_IDENTITY" --deep "$APP_BUNDLE"
+# Re-sign the bundle so TCC can identify the dev build consistently. Use the
+# release app entitlements so permission smoke tests exercise the same TCC
+# capability surface as the signed distribution build.
+codesign --force --sign "$CODESIGN_IDENTITY" --options runtime \
+  --entitlements "$APP_ENTITLEMENTS" --deep "$APP_BUNDLE"
 
 echo "[3/5] Stopping existing MacParakeet processes…"
 pkill -f "/Applications/MacParakeet.app/Contents/MacOS/MacParakeet" || true

--- a/scripts/dist/MacParakeet.entitlements
+++ b/scripts/dist/MacParakeet.entitlements
@@ -4,6 +4,8 @@
 <dict>
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
+	<key>com.apple.security.personal-information.calendars</key>
+	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 </dict>

--- a/scripts/dist/sign_notarize.sh
+++ b/scripts/dist/sign_notarize.sh
@@ -163,6 +163,7 @@ codesign --force --sign "$SIGN_IDENTITY" --options runtime --timestamp \
 
 echo "[4/8] Verifying signature…"
 codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+"$ROOT_DIR/scripts/dist/verify_app_privacy_surface.sh" "$APP_PATH"
 VERIFY_CODE_SIGNATURES=1 "$ROOT_DIR/scripts/dist/verify_meeting_echo_assets.sh" "$APP_PATH"
 
 ZIP_PATH="$DIST_DIR/${APP_NAME}.app.zip"

--- a/scripts/dist/verify_app_privacy_surface.sh
+++ b/scripts/dist/verify_app_privacy_surface.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_PATH="${1:-dist/MacParakeet.app}"
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+if [[ ! -d "$APP_PATH" ]]; then
+  fail "Missing app bundle: $APP_PATH"
+fi
+
+INFO_PLIST="$APP_PATH/Contents/Info.plist"
+if [[ ! -f "$INFO_PLIST" ]]; then
+  fail "Missing Info.plist: $INFO_PLIST"
+fi
+
+require_info_string() {
+  local key="$1"
+  local value
+  value="$(/usr/libexec/PlistBuddy -c "Print :$key" "$INFO_PLIST" 2>/dev/null || true)"
+  if [[ -z "$value" ]]; then
+    fail "Missing Info.plist privacy string: $key"
+  fi
+}
+
+ENTITLEMENTS_PLIST="$(mktemp)"
+CODESIGN_ERR="$(mktemp)"
+trap 'rm -f "$ENTITLEMENTS_PLIST" "$CODESIGN_ERR"' EXIT
+
+if ! codesign -d --xml --entitlements - "$APP_PATH" >"$ENTITLEMENTS_PLIST" 2>"$CODESIGN_ERR"; then
+  cat "$CODESIGN_ERR" >&2
+  fail "Could not read codesign entitlements for: $APP_PATH"
+fi
+
+require_entitlement_true() {
+  local key="$1"
+  local value
+  value="$(/usr/libexec/PlistBuddy -c "Print :$key" "$ENTITLEMENTS_PLIST" 2>/dev/null || true)"
+  if [[ "$value" != "true" ]]; then
+    fail "Missing true app entitlement: $key"
+  fi
+}
+
+require_info_string "NSMicrophoneUsageDescription"
+require_info_string "NSAudioCaptureUsageDescription"
+require_info_string "NSCalendarsFullAccessUsageDescription"
+
+require_entitlement_true "com.apple.security.device.audio-input"
+require_entitlement_true "com.apple.security.personal-information.calendars"
+require_entitlement_true "com.apple.security.network.client"
+
+echo "Verified app privacy surface: $APP_PATH"

--- a/spec/03-architecture.md
+++ b/spec/03-architecture.md
@@ -1098,6 +1098,7 @@ Dictation ready
 | Microphone | Dictation, onboarding mic test, meeting recording mic capture | Requested on first dictation/meeting use |
 | Accessibility | Global hotkey paste simulation | Requested on first dictation use |
 | Screen & System Audio Recording | ScreenCaptureKit system-audio capture for meeting recording | Requested on first meeting recording attempt; recording stays blocked until granted |
+| Calendar | Calendar reminders and optional meeting auto-start | Requested from onboarding or Settings calendar controls |
 
 ### Sandboxing (App Store)
 
@@ -1106,6 +1107,7 @@ For App Store distribution, the app needs:
 | Entitlement | Required For |
 |-------------|-------------|
 | `com.apple.security.device.audio-input` | Microphone access |
+| `com.apple.security.personal-information.calendars` | Calendar event access |
 | `com.apple.security.temporary-exception.apple-events` | Accessibility (paste simulation) |
 | `com.apple.security.files.user-selected.read-write` | File drag-and-drop |
 | `com.apple.security.files.downloads.read-write` | Export to Downloads |


### PR DESCRIPTION
## Summary

Fixes the release Calendar permission path for issue #368.

The shipped 0.6.11 app had `NSCalendarsFullAccessUsageDescription`, but its signed app entitlements did not include `com.apple.security.personal-information.calendars`. EventKit could therefore return failure before macOS recorded a Calendar TCC decision, leaving Settings/onboarding to fall back to the same "Grant Calendar Access" state.

## What Changed

- Add the Calendar personal-information entitlement to the app entitlement file.
- Sign the dev app with the release entitlement file so local permission smoke tests match the distribution capability surface.
- Add a release signing guard that verifies required privacy strings and signed app entitlements before notarization.
- Document the root cause and update distribution/spec entitlement notes.

Closes #368.

## Reference Check

- Apple's EventKit guidance requires the Calendar privacy string for full-access requests, and macOS Calendar access under sandbox/hardened-runtime signing requires `com.apple.security.personal-information.calendars`.
- Open-source references checked: Anarlog/Char, legacy Hyprnote, Muesli, Galopen, and Calendr. The comparable EventKit apps pair `requestFullAccessToEvents`/full-access Calendar reads with either an explicit Calendar entitlement or Xcode's Calendar resource-access build setting.
- MacParakeet now matches that packaging pattern and adds a stronger signed-bundle verifier than the references reviewed.

## Review Comments

- Gemini verifier feedback addressed in 3d289a7a by switching to `codesign -d --xml --entitlements -`.
- Greptile stderr feedback addressed in 3d289a7a by preserving `codesign` stderr separately on failure.
- Both inline review threads have been replied to and are resolved/outdated.

## Validation

- `git diff --check origin/main...HEAD`
- `bash -n scripts/dist/verify_app_privacy_surface.sh scripts/dist/sign_notarize.sh scripts/dev/run_app.sh`
- `scripts/dist/verify_app_privacy_surface.sh /Applications/MacParakeet.app` fails on 0.6.11 with missing Calendar entitlement, as expected.
- Ad-hoc signed fixture with `scripts/dist/MacParakeet.entitlements` passes `scripts/dist/verify_app_privacy_surface.sh`.
- `SKIP_NOTARIZE=1 CREATE_DMG=0 scripts/dist/sign_notarize.sh`
- `swift test --filter Calendar`
- `swift test` (3013 XCTest tests, 9 skipped hardware tests, 0 failures; 16 Swift Testing tests, 0 failures)