### PR TITLE
Add dedicated Meetings workspace

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -282,6 +282,7 @@ final class AppEnvironmentConfigurer {
                 guard let self else { return }
                 self.transcriptionViewModel.presentCompletedTranscription(transcription, autoSave: true)
                 self.libraryViewModel.loadTranscriptions()
+                self.meetingsWorkspaceViewModel.refreshRecentMeetings()
                 self.mainWindowState.navigateToTranscription(from: .library)
                 callbacks.onOpenMainWindow()
             },

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -42,6 +42,7 @@ final class AppEnvironmentConfigurer {
     private let textSnippetsViewModel: TextSnippetsViewModel
     private let vocabularyBackupViewModel: VocabularyBackupViewModel
     private let libraryViewModel: TranscriptionLibraryViewModel
+    private let meetingsWorkspaceViewModel: MeetingsWorkspaceViewModel
     private let llmSettingsViewModel: LLMSettingsViewModel
     private let chatViewModel: TranscriptChatViewModel
     private let promptResultsViewModel: PromptResultsViewModel
@@ -59,6 +60,7 @@ final class AppEnvironmentConfigurer {
         textSnippetsViewModel: TextSnippetsViewModel,
         vocabularyBackupViewModel: VocabularyBackupViewModel,
         libraryViewModel: TranscriptionLibraryViewModel,
+        meetingsWorkspaceViewModel: MeetingsWorkspaceViewModel,
         llmSettingsViewModel: LLMSettingsViewModel,
         chatViewModel: TranscriptChatViewModel,
         promptResultsViewModel: PromptResultsViewModel,
@@ -74,6 +76,7 @@ final class AppEnvironmentConfigurer {
         self.textSnippetsViewModel = textSnippetsViewModel
         self.vocabularyBackupViewModel = vocabularyBackupViewModel
         self.libraryViewModel = libraryViewModel
+        self.meetingsWorkspaceViewModel = meetingsWorkspaceViewModel
         self.llmSettingsViewModel = llmSettingsViewModel
         self.chatViewModel = chatViewModel
         self.promptResultsViewModel = promptResultsViewModel
@@ -105,6 +108,7 @@ final class AppEnvironmentConfigurer {
         )
         historyViewModel.configure(dictationRepo: env.dictationRepo)
         libraryViewModel.configure(transcriptionRepo: env.transcriptionRepo)
+        meetingsWorkspaceViewModel.configure(transcriptionRepo: env.transcriptionRepo)
         settingsViewModel.configure(
             permissionService: env.permissionService,
             dictationRepo: env.dictationRepo,

--- a/Sources/MacParakeet/App/AppWindowCoordinator.swift
+++ b/Sources/MacParakeet/App/AppWindowCoordinator.swift
@@ -21,9 +21,11 @@ final class AppWindowCoordinator: NSObject, NSWindowDelegate {
     private let feedbackViewModel: FeedbackViewModel
     private let discoverViewModel: DiscoverViewModel
     private let libraryViewModel: TranscriptionLibraryViewModel
+    private let meetingsWorkspaceViewModel: MeetingsWorkspaceViewModel
     private let meetingPillViewModel: MeetingRecordingPillViewModel
     private let updaterController: SPUStandardUpdaterController
     private let onRecordMeeting: () -> Void
+    private let onRecordMeetingFromWorkspace: () -> Void
     private let onPauseToggleMeeting: (() -> Void)?
     private let onHotkeyRecordingStateChanged: (Bool) -> Void
     private let onQuit: () -> Void
@@ -47,9 +49,11 @@ final class AppWindowCoordinator: NSObject, NSWindowDelegate {
         feedbackViewModel: FeedbackViewModel,
         discoverViewModel: DiscoverViewModel,
         libraryViewModel: TranscriptionLibraryViewModel,
+        meetingsWorkspaceViewModel: MeetingsWorkspaceViewModel,
         meetingPillViewModel: MeetingRecordingPillViewModel,
         updaterController: SPUStandardUpdaterController,
         onRecordMeeting: @escaping () -> Void,
+        onRecordMeetingFromWorkspace: @escaping () -> Void,
         onPauseToggleMeeting: (() -> Void)? = nil,
         onHotkeyRecordingStateChanged: @escaping (Bool) -> Void,
         onQuit: @escaping () -> Void,
@@ -70,9 +74,11 @@ final class AppWindowCoordinator: NSObject, NSWindowDelegate {
         self.feedbackViewModel = feedbackViewModel
         self.discoverViewModel = discoverViewModel
         self.libraryViewModel = libraryViewModel
+        self.meetingsWorkspaceViewModel = meetingsWorkspaceViewModel
         self.meetingPillViewModel = meetingPillViewModel
         self.updaterController = updaterController
         self.onRecordMeeting = onRecordMeeting
+        self.onRecordMeetingFromWorkspace = onRecordMeetingFromWorkspace
         self.onPauseToggleMeeting = onPauseToggleMeeting
         self.onHotkeyRecordingStateChanged = onHotkeyRecordingStateChanged
         self.onQuit = onQuit
@@ -180,9 +186,11 @@ final class AppWindowCoordinator: NSObject, NSWindowDelegate {
             feedbackViewModel: feedbackViewModel,
             discoverViewModel: discoverViewModel,
             libraryViewModel: libraryViewModel,
+            meetingsWorkspaceViewModel: meetingsWorkspaceViewModel,
             meetingPillViewModel: meetingPillViewModel,
             updater: updaterController.updater,
             onRecordMeeting: onRecordMeeting,
+            onRecordMeetingFromWorkspace: onRecordMeetingFromWorkspace,
             onPauseToggleMeeting: onPauseToggleMeeting,
             onHotkeyRecordingStateChanged: onHotkeyRecordingStateChanged
         )

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -166,12 +166,23 @@ final class MeetingRecordingFlowCoordinator {
         }
     }
 
+    @discardableResult
+    func startRecording(
+        title: String? = nil,
+        trigger: TelemetryMeetingRecordingTrigger = .manual
+    ) -> Int? {
+        guard stateMachine.state == .idle else { return nil }
+        pendingTrigger = pendingTrigger ?? trigger
+        pendingTitle = title
+        currentMeetingOperationContext = ObservabilityOperationContext()
+        sendEvent(.startRequested)
+        return stateMachine.generation
+    }
+
     func toggleRecording(trigger: TelemetryMeetingRecordingTrigger = .manual) {
         switch stateMachine.state {
         case .idle:
-            pendingTrigger = pendingTrigger ?? trigger
-            currentMeetingOperationContext = ObservabilityOperationContext()
-            sendEvent(.startRequested)
+            startRecording(trigger: trigger)
         case .recording, .starting, .stopping:
             sendEvent(.stopRequested)
         case .checkingPermissions, .transcribing, .finishing:

--- a/Sources/MacParakeet/App/MeetingRecoveryCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecoveryCoordinator.swift
@@ -8,17 +8,20 @@ final class MeetingRecoveryCoordinator {
     private let environmentProvider: () -> AppEnvironment?
     private let settingsViewModel: SettingsViewModel
     private let libraryViewModel: TranscriptionLibraryViewModel
+    private let onRecoveredTranscriptionsChanged: () -> Void
     private let onPresentRecoveredTranscription: (Transcription) -> Void
 
     init(
         environmentProvider: @escaping () -> AppEnvironment?,
         settingsViewModel: SettingsViewModel,
         libraryViewModel: TranscriptionLibraryViewModel,
+        onRecoveredTranscriptionsChanged: @escaping () -> Void = {},
         onPresentRecoveredTranscription: @escaping (Transcription) -> Void
     ) {
         self.environmentProvider = environmentProvider
         self.settingsViewModel = settingsViewModel
         self.libraryViewModel = libraryViewModel
+        self.onRecoveredTranscriptionsChanged = onRecoveredTranscriptionsChanged
         self.onPresentRecoveredTranscription = onPresentRecoveredTranscription
     }
 
@@ -139,6 +142,7 @@ final class MeetingRecoveryCoordinator {
                 source: source
             ))
             libraryViewModel.loadTranscriptions()
+            onRecoveredTranscriptionsChanged()
             settingsViewModel.refreshPendingMeetingRecoveries()
             if let first = recovered.first {
                 onPresentRecoveredTranscription(first)

--- a/Sources/MacParakeet/App/MenuBarCoordinator.swift
+++ b/Sources/MacParakeet/App/MenuBarCoordinator.swift
@@ -241,11 +241,11 @@ final class MenuBarCoordinator: NSObject, NSMenuDelegate {
         let goMenuItem = NSMenuItem()
         let goMenu = NSMenu(title: "Go")
         goMenu.addItem(makeMenuItem(title: "Transcribe", action: #selector(showTranscribe), key: ""))
+        goMenu.addItem(makeMenuItem(title: "Library", action: #selector(showLibrary), key: ""))
+        goMenu.addItem(makeMenuItem(title: "Dictations", action: #selector(showDictations), key: ""))
         if AppFeatures.meetingRecordingEnabled {
             goMenu.addItem(makeMenuItem(title: "Meetings", action: #selector(showMeetings), key: ""))
         }
-        goMenu.addItem(makeMenuItem(title: "Library", action: #selector(showLibrary), key: ""))
-        goMenu.addItem(makeMenuItem(title: "Dictations", action: #selector(showDictations), key: ""))
         goMenu.addItem(NSMenuItem.separator())
         goMenu.addItem(makeMenuItem(title: "Vocabulary", action: #selector(showVocabulary), key: ""))
         if AppFeatures.transformsEnabled {

--- a/Sources/MacParakeet/App/MenuBarCoordinator.swift
+++ b/Sources/MacParakeet/App/MenuBarCoordinator.swift
@@ -241,6 +241,9 @@ final class MenuBarCoordinator: NSObject, NSMenuDelegate {
         let goMenuItem = NSMenuItem()
         let goMenu = NSMenu(title: "Go")
         goMenu.addItem(makeMenuItem(title: "Transcribe", action: #selector(showTranscribe), key: ""))
+        if AppFeatures.meetingRecordingEnabled {
+            goMenu.addItem(makeMenuItem(title: "Meetings", action: #selector(showMeetings), key: ""))
+        }
         goMenu.addItem(makeMenuItem(title: "Library", action: #selector(showLibrary), key: ""))
         goMenu.addItem(makeMenuItem(title: "Dictations", action: #selector(showDictations), key: ""))
         goMenu.addItem(NSMenuItem.separator())
@@ -486,6 +489,10 @@ final class MenuBarCoordinator: NSObject, NSMenuDelegate {
 
     @objc private func showTranscribe() {
         navigate(to: .transcribe)
+    }
+
+    @objc private func showMeetings() {
+        navigate(to: .meetings)
     }
 
     @objc private func showLibrary() {

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -164,6 +164,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         },
         settingsViewModel: settingsViewModel,
         libraryViewModel: libraryViewModel,
+        onRecoveredTranscriptionsChanged: { [weak self] in
+            self?.meetingsWorkspaceViewModel.refreshRecentMeetings()
+        },
         onPresentRecoveredTranscription: { [weak self] transcription in
             guard let self else { return }
             self.transcriptionViewModel.presentCompletedTranscription(transcription, autoSave: true)

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -66,6 +66,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let feedbackViewModel = FeedbackViewModel()
     private let discoverViewModel = DiscoverViewModel()
     private let libraryViewModel = TranscriptionLibraryViewModel()
+    private let meetingsLibraryViewModel = TranscriptionLibraryViewModel(scope: .meetings)
     private let llmSettingsViewModel = LLMSettingsViewModel()
     private let chatViewModel = TranscriptChatViewModel()
     private let promptResultsViewModel = PromptResultsViewModel()
@@ -76,6 +77,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// `MeetingRecordingFlowCoordinator` writes state into it; both the floating
     /// pill and the tile bind to the same instance.
     private let meetingPillViewModel = MeetingRecordingPillViewModel()
+    private lazy var meetingsWorkspaceViewModel = MeetingsWorkspaceViewModel(
+        recentMeetingsViewModel: meetingsLibraryViewModel,
+        meetingPillViewModel: meetingPillViewModel,
+        settingsViewModel: settingsViewModel,
+        llmSettingsViewModel: llmSettingsViewModel
+    )
     private let onboardingWindowController = OnboardingWindowController()
 
     private lazy var youtubeInputController = YouTubeInputPanelController(
@@ -94,6 +101,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         textSnippetsViewModel: textSnippetsViewModel,
         vocabularyBackupViewModel: vocabularyBackupViewModel,
         libraryViewModel: libraryViewModel,
+        meetingsWorkspaceViewModel: meetingsWorkspaceViewModel,
         llmSettingsViewModel: llmSettingsViewModel,
         chatViewModel: chatViewModel,
         promptResultsViewModel: promptResultsViewModel,
@@ -180,10 +188,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         feedbackViewModel: feedbackViewModel,
         discoverViewModel: discoverViewModel,
         libraryViewModel: libraryViewModel,
+        meetingsWorkspaceViewModel: meetingsWorkspaceViewModel,
         meetingPillViewModel: meetingPillViewModel,
         updaterController: updaterController,
         onRecordMeeting: { [weak self] in
             self?.toggleMeetingRecording(originatesFromWindow: true)
+        },
+        onRecordMeetingFromWorkspace: { [weak self] in
+            self?.startMeetingRecordingFromWorkspace()
         },
         onPauseToggleMeeting: { [weak self] in
             self?.meetingRecordingFlowCoordinator?.togglePause()
@@ -687,6 +699,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         meetingRecordingFlowCoordinator?.toggleRecording(trigger: trigger)
+    }
+
+    private func startMeetingRecordingFromWorkspace() {
+        guard appEnvironment != nil else { return }
+
+        if meetingRecordingFlowCoordinator?.isMeetingRecordingActive == true {
+            meetingRecordingFlowCoordinator?.toggleRecording()
+            return
+        }
+
+        meetingRecordingFlowCoordinator?.startRecording(trigger: .manual)
     }
 
     private func presentActiveMeetingQuitAlert() -> NSApplication.TerminateReply {

--- a/Sources/MacParakeet/Views/MainWindowView.swift
+++ b/Sources/MacParakeet/Views/MainWindowView.swift
@@ -144,6 +144,7 @@ struct MainWindowView: View {
                             },
                             onSelectMeeting: { transcription in
                                 transcriptionViewModel.currentTranscription = transcription
+                                state.navigateToTranscription(from: .meetings)
                             }
                         )
                     case .library:

--- a/Sources/MacParakeet/Views/MainWindowView.swift
+++ b/Sources/MacParakeet/Views/MainWindowView.swift
@@ -34,11 +34,10 @@ enum SidebarItem: String, CaseIterable, Identifiable {
     /// universal archive; Meetings is the workflow space for live/upcoming
     /// and saved meeting work.
     static var primaryItems: [SidebarItem] {
-        var items: [SidebarItem] = [.transcribe]
+        var items: [SidebarItem] = [.transcribe, .library, .dictations]
         if AppFeatures.meetingRecordingEnabled {
             items.append(.meetings)
         }
-        items.append(contentsOf: [.library, .dictations])
         return items
     }
 

--- a/Sources/MacParakeet/Views/MainWindowView.swift
+++ b/Sources/MacParakeet/Views/MainWindowView.swift
@@ -5,9 +5,9 @@ import MacParakeetViewModels
 
 enum SidebarItem: String, CaseIterable, Identifiable {
     case transcribe = "Transcribe"
-    case meetings = "Meetings"
     case library = "Library"
     case dictations = "Dictations"
+    case meetings = "Meetings"
     case transforms = "Transforms"
     case vocabulary = "Vocabulary"
     case feedback = "Feedback"

--- a/Sources/MacParakeet/Views/MainWindowView.swift
+++ b/Sources/MacParakeet/Views/MainWindowView.swift
@@ -5,6 +5,7 @@ import MacParakeetViewModels
 
 enum SidebarItem: String, CaseIterable, Identifiable {
     case transcribe = "Transcribe"
+    case meetings = "Meetings"
     case library = "Library"
     case dictations = "Dictations"
     case transforms = "Transforms"
@@ -18,6 +19,7 @@ enum SidebarItem: String, CaseIterable, Identifiable {
     var icon: String {
         switch self {
         case .transcribe: return "waveform"
+        case .meetings: return "person.2.wave.2"
         case .library: return "square.grid.2x2"
         case .dictations: return "clock.arrow.circlepath"
         case .transforms: return "wand.and.stars"
@@ -28,10 +30,17 @@ enum SidebarItem: String, CaseIterable, Identifiable {
         }
     }
 
-    /// Primary features — the core things users do. Meeting recording is
-    /// reachable from the Transcribe tab's third tile (when feature flag is
-    /// on); meeting browse lives in `Library` under the `Meetings` filter.
-    static let primaryItems: [SidebarItem] = [.transcribe, .library, .dictations]
+    /// Primary features — the core things users do. Library remains the
+    /// universal archive; Meetings is the workflow space for live/upcoming
+    /// and saved meeting work.
+    static var primaryItems: [SidebarItem] {
+        var items: [SidebarItem] = [.transcribe]
+        if AppFeatures.meetingRecordingEnabled {
+            items.append(.meetings)
+        }
+        items.append(contentsOf: [.library, .dictations])
+        return items
+    }
 
     /// Configuration and support items. Transforms (ADR-022) is inserted
     /// here at runtime when `AppFeatures.transformsEnabled == true`.
@@ -64,9 +73,11 @@ struct MainWindowView: View {
     let feedbackViewModel: FeedbackViewModel
     let discoverViewModel: DiscoverViewModel
     let libraryViewModel: TranscriptionLibraryViewModel
+    let meetingsWorkspaceViewModel: MeetingsWorkspaceViewModel
     let meetingPillViewModel: MeetingRecordingPillViewModel
     let updater: SPUUpdater
     let onRecordMeeting: () -> Void
+    let onRecordMeetingFromWorkspace: () -> Void
     let onPauseToggleMeeting: (() -> Void)?
     /// Routed to `AppHotkeyCoordinator.suspend` / `resume` while a hotkey
     /// recorder is active. Passed through to `SettingsView`.
@@ -115,6 +126,26 @@ struct MainWindowView: View {
                             onRecordMeeting: onRecordMeeting,
                             onPauseToggleMeeting: onPauseToggleMeeting,
                             onRefreshPermissions: settingsViewModel.refreshPermissions
+                        )
+                    case .meetings:
+                        MeetingsView(
+                            viewModel: meetingsWorkspaceViewModel,
+                            onRecordMeeting: {
+                                onRecordMeetingFromWorkspace()
+                            },
+                            onPauseToggleMeeting: onPauseToggleMeeting,
+                            onOpenCalendarSettings: {
+                                state.navigateToSettings(tab: .modes)
+                            },
+                            onOpenAISettings: {
+                                state.navigateToSettings(tab: .ai)
+                            },
+                            onRecoverMeetings: {
+                                settingsViewModel.requestPendingMeetingRecovery()
+                            },
+                            onSelectMeeting: { transcription in
+                                transcriptionViewModel.currentTranscription = transcription
+                            }
                         )
                     case .library:
                         if let transcription = transcriptionViewModel.currentTranscription {

--- a/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
+++ b/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
@@ -456,6 +456,7 @@ struct MeetingsView: View {
     private func calendarEmptyDetail(for mode: CalendarAutoStartMode) -> String {
         switch mode {
         case .off:
+            assertionFailure("calendarEmptyDetail should not be called when calendar reminders are off.")
             return "Calendar reminders are off."
         case .notify:
             return "Calendar reminders are on."
@@ -624,7 +625,7 @@ private struct CalendarEventRow: View {
                     }
                     if event.attendeeCount > 0 {
                         Text("·")
-                        Text("\(event.attendeeCount + 1) people")
+                        Text(peopleCountText)
                     }
                 }
                 .font(DesignSystem.Typography.caption)
@@ -634,6 +635,11 @@ private struct CalendarEventRow: View {
         }
         .padding(DesignSystem.Spacing.md)
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var peopleCountText: String {
+        let count = event.attendeeCount + 1
+        return "\(count) \(count == 1 ? "person" : "people")"
     }
 }
 

--- a/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
+++ b/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
@@ -1,3 +1,4 @@
+import EventKit
 import SwiftUI
 import MacParakeetCore
 import MacParakeetViewModels
@@ -41,6 +42,9 @@ struct MeetingsView: View {
             viewModel.refreshUpcomingEvents()
         }
         .onChange(of: viewModel.settingsViewModel.calendarExcludedIdentifiers) { _, _ in
+            viewModel.refreshUpcomingEvents()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .EKEventStoreChanged)) { _ in
             viewModel.refreshUpcomingEvents()
         }
         .alert(
@@ -349,6 +353,7 @@ struct MeetingsView: View {
                 .buttonStyle(.plain)
                 .foregroundStyle(DesignSystem.Colors.textTertiary)
                 .help("Clear search")
+                .accessibilityLabel("Clear meeting search")
             }
         }
         .padding(.horizontal, DesignSystem.Spacing.md)
@@ -741,6 +746,7 @@ private struct IntelligenceReadyRow: View {
             }
             .parakeetAction(.secondary)
             .help("Open AI Settings")
+            .accessibilityLabel("Open AI Settings")
         }
         .padding(DesignSystem.Spacing.md)
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
+++ b/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
@@ -1,0 +1,748 @@
+import SwiftUI
+import MacParakeetCore
+import MacParakeetViewModels
+
+struct MeetingsView: View {
+    @Bindable var viewModel: MeetingsWorkspaceViewModel
+
+    var onRecordMeeting: () -> Void
+    var onPauseToggleMeeting: (() -> Void)?
+    var onOpenCalendarSettings: () -> Void
+    var onOpenAISettings: () -> Void
+    var onRecoverMeetings: () -> Void
+    var onSelectMeeting: (Transcription) -> Void
+
+    @State private var audioSaveErrorMessage: String?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
+                header
+                recordingSurface
+                contentColumns
+            }
+            .padding(.horizontal, DesignSystem.Spacing.lg)
+            .padding(.top, DesignSystem.Spacing.lg)
+            .padding(.bottom, DesignSystem.Spacing.xl)
+            .frame(maxWidth: 1180, alignment: .topLeading)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(DesignSystem.Colors.contentBackground)
+        .onAppear {
+            viewModel.refreshIfNeeded()
+        }
+        .onChange(of: viewModel.settingsViewModel.calendarAutoStartMode) { _, _ in
+            viewModel.refreshUpcomingEvents()
+        }
+        .onChange(of: viewModel.settingsViewModel.calendarPermissionStatus) { _, _ in
+            viewModel.refreshUpcomingEvents()
+        }
+        .onChange(of: viewModel.settingsViewModel.meetingTriggerFilter) { _, _ in
+            viewModel.refreshUpcomingEvents()
+        }
+        .alert(
+            "Save Failed",
+            isPresented: Binding(
+                get: { audioSaveErrorMessage != nil },
+                set: { if !$0 { audioSaveErrorMessage = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) {
+                audioSaveErrorMessage = nil
+            }
+        } message: {
+            Text(audioSaveErrorMessage ?? "Unable to save meeting audio.")
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .center, spacing: DesignSystem.Spacing.md) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Meetings")
+                    .font(DesignSystem.Typography.pageTitle)
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+                Text("Upcoming, live, and saved.")
+                    .font(DesignSystem.Typography.bodySmall)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+            }
+
+            Spacer(minLength: DesignSystem.Spacing.lg)
+
+            if viewModel.recordingStatus != .ready {
+                MeetingsStatusChip(
+                    icon: headerStatusIcon,
+                    title: headerStatusTitle,
+                    tint: headerStatusTint
+                )
+            }
+        }
+    }
+
+    private var recordingSurface: some View {
+        MeetingRecordingTile(
+            viewModel: viewModel.meetingPillViewModel,
+            permissionState: meetingPermissionState,
+            onTap: onRecordMeeting,
+            onPauseToggle: onPauseToggleMeeting
+        )
+    }
+
+    private var contentColumns: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(alignment: .top, spacing: DesignSystem.Spacing.lg) {
+                VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
+                    upcomingSection
+                    recentMeetingsSection
+                }
+                .frame(minWidth: 480, maxWidth: .infinity, alignment: .topLeading)
+
+                VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
+                    attentionSection
+                    intelligenceSection
+                }
+                .frame(minWidth: 280, maxWidth: 340, alignment: .topLeading)
+            }
+
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
+                upcomingSection
+                recentMeetingsSection
+                attentionSection
+                intelligenceSection
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var upcomingSection: some View {
+        if AppFeatures.calendarEnabled {
+            MeetingsSection(title: "Upcoming", icon: "calendar.badge.clock") {
+                switch viewModel.calendarStatus {
+                case .unavailable:
+                    EmptyView()
+                case .off:
+                    MeetingsInlineState(
+                        icon: "calendar",
+                        title: "Calendar reminders are off",
+                        detail: "Open Settings to turn on meeting reminders.",
+                        actionTitle: "Open Settings",
+                        actionIcon: "gearshape",
+                        action: onOpenCalendarSettings
+                    )
+                case .permissionNeeded:
+                    MeetingsInlineState(
+                        icon: "calendar.badge.exclamationmark",
+                        title: "Calendar access needed",
+                        detail: "Open Settings to connect macOS Calendar.",
+                        actionTitle: "Open Settings",
+                        actionIcon: "gearshape",
+                        action: onOpenCalendarSettings
+                    )
+                case .permissionDenied:
+                    MeetingsInlineState(
+                        icon: "lock.shield",
+                        title: "Calendar is blocked",
+                        detail: "Re-enable Calendar access in macOS Settings.",
+                        actionTitle: "Open Settings",
+                        actionIcon: "gearshape",
+                        action: onOpenCalendarSettings
+                    )
+                case .loading:
+                    MeetingsLoadingRow(title: "Loading calendar")
+                case .error(let message):
+                    MeetingsInlineState(
+                        icon: "exclamationmark.triangle",
+                        title: "Calendar unavailable",
+                        detail: message,
+                        actionTitle: "Try Again",
+                        actionIcon: "arrow.clockwise",
+                        action: { viewModel.refreshUpcomingEvents() }
+                    )
+                case .ready(let mode):
+                    if viewModel.upcomingEvents.isEmpty {
+                        MeetingsInlineState(
+                            icon: "calendar",
+                            title: "No upcoming meetings",
+                            detail: calendarEmptyDetail(for: mode),
+                            actionTitle: "Refresh",
+                            actionIcon: "arrow.clockwise",
+                            action: { viewModel.refreshUpcomingEvents() }
+                        )
+                    } else {
+                        VStack(spacing: 0) {
+                            ForEach(viewModel.upcomingEvents) { event in
+                                CalendarEventRow(event: event)
+                                if event.id != viewModel.upcomingEvents.last?.id {
+                                    MeetingsHairline()
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var attentionSection: some View {
+        if !viewModel.attentionItems.isEmpty {
+            MeetingsSection(title: "Needs Attention", icon: "exclamationmark.circle") {
+                VStack(spacing: 0) {
+                    ForEach(viewModel.attentionItems) { item in
+                        AttentionRow(item: item) {
+                            performAttentionAction(item.action)
+                        }
+                        if item.id != viewModel.attentionItems.last?.id {
+                            MeetingsHairline()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var intelligenceSection: some View {
+        MeetingsSection(title: "Intelligence", icon: "sparkles") {
+            switch viewModel.intelligenceStatus {
+            case .setupNeeded:
+                MeetingsInlineState(
+                    icon: "sparkles",
+                    title: "AI not configured",
+                    detail: "Summaries and meeting chat stay off until you choose a provider.",
+                    actionTitle: "Set Up AI",
+                    actionIcon: "gearshape",
+                    action: onOpenAISettings
+                )
+            case .ready(let displayName, let isLocal):
+                IntelligenceReadyRow(
+                    displayName: displayName,
+                    locality: isLocal ? "Local" : "External",
+                    localityIcon: isLocal ? "lock" : "cloud",
+                    detail: isLocal
+                        ? "Meeting summaries and chat use \(displayName) on this Mac."
+                        : "\(displayName) may receive transcript text when you run AI actions.",
+                    tint: isLocal ? DesignSystem.Colors.successGreen : DesignSystem.Colors.textSecondary,
+                    onOpenSettings: onOpenAISettings
+                )
+            case .cannotConnect(let displayName, let message):
+                MeetingsInlineState(
+                    icon: "exclamationmark.triangle",
+                    title: "\(displayName) unavailable",
+                    detail: message,
+                    actionTitle: "Open AI Settings",
+                    actionIcon: "gearshape",
+                    action: onOpenAISettings
+                )
+            }
+        }
+    }
+
+    private var recentMeetingsSection: some View {
+        MeetingsSection(title: "Recent Meetings", icon: "clock.arrow.circlepath") {
+            VStack(alignment: .leading, spacing: 0) {
+                if shouldShowRecentMeetingSearch {
+                    recentMeetingSearchField
+                }
+
+                if viewModel.recentMeetingsViewModel.isLoading
+                    && viewModel.recentMeetingsViewModel.filteredTranscriptions.isEmpty {
+                    MeetingsLoadingRow(title: "Loading meetings")
+                } else if viewModel.recentMeetingsViewModel.filteredTranscriptions.isEmpty {
+                    MeetingsInlineState(
+                        icon: recentMeetingsEmptyIcon,
+                        title: recentMeetingsEmptyTitle,
+                        detail: recentMeetingsEmptyDetail,
+                        actionTitle: recentMeetingsEmptyActionTitle,
+                        actionIcon: recentMeetingsEmptyActionIcon,
+                        action: recentMeetingsEmptyAction
+                    )
+                } else {
+                    ForEach(viewModel.recentMeetingsViewModel.groupedTranscriptions, id: \.group) { section in
+                        MeetingDateGroupHeader(group: section.group)
+                        ForEach(Array(section.items.enumerated()), id: \.element.id) { idx, transcription in
+                            MeetingRowCard(
+                                transcription: transcription,
+                                searchText: viewModel.recentMeetingsViewModel.searchText,
+                                onTap: { onSelectMeeting(transcription) },
+                                menuContent: { recentMeetingMenu(for: transcription) }
+                            )
+                            if idx < section.items.count - 1 {
+                                MeetingRowHairline()
+                            }
+                        }
+                    }
+
+                    if viewModel.recentMeetingsViewModel.hasMore {
+                        HStack {
+                            Spacer()
+                            Button {
+                                viewModel.recentMeetingsViewModel.loadMoreTranscriptions()
+                            } label: {
+                                if viewModel.recentMeetingsViewModel.isLoading {
+                                    Label("Loading…", systemImage: "arrow.clockwise")
+                                } else {
+                                    Label("Load More", systemImage: "ellipsis")
+                                }
+                            }
+                            .parakeetAction(.secondary)
+                            .disabled(viewModel.recentMeetingsViewModel.isLoading)
+                            Spacer()
+                        }
+                        .padding(.vertical, DesignSystem.Spacing.md)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func recentMeetingMenu(for transcription: Transcription) -> some View {
+        Button {
+            onSelectMeeting(transcription)
+        } label: {
+            Label("Open", systemImage: "doc.text")
+        }
+
+        let audioAvailable = MeetingAudioFile.isAvailable(for: transcription)
+
+        Divider()
+
+        Button {
+            MeetingAudioActions.revealInFinder(transcription)
+        } label: {
+            Label("Show in Finder", systemImage: "folder")
+        }
+        .disabled(!audioAvailable)
+
+        Button {
+            saveMeetingAudio(transcription)
+        } label: {
+            Label("Save Audio As…", systemImage: "square.and.arrow.down")
+        }
+        .disabled(!audioAvailable)
+    }
+
+    private var recentMeetingSearchField: some View {
+        HStack(spacing: DesignSystem.Spacing.sm) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(DesignSystem.Colors.textTertiary)
+
+            TextField(
+                "Search meetings",
+                text: Binding(
+                    get: { viewModel.recentMeetingsViewModel.searchText },
+                    set: { viewModel.recentMeetingsViewModel.searchText = $0 }
+                )
+            )
+            .textFieldStyle(.plain)
+            .font(DesignSystem.Typography.bodySmall)
+
+            if !viewModel.recentMeetingsViewModel.searchText.isEmpty {
+                Button {
+                    viewModel.recentMeetingsViewModel.searchText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(DesignSystem.Colors.textTertiary)
+                .help("Clear search")
+            }
+        }
+        .padding(.horizontal, DesignSystem.Spacing.md)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(DesignSystem.Colors.surfaceElevated.opacity(0.55))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .strokeBorder(DesignSystem.Colors.border.opacity(0.55), lineWidth: 0.5)
+                )
+        )
+        .padding(.horizontal, DesignSystem.Spacing.md)
+        .padding(.top, DesignSystem.Spacing.md)
+        .padding(.bottom, DesignSystem.Spacing.sm)
+    }
+
+    private var meetingPermissionState: MeetingRecordingTile.PermissionState {
+        MeetingRecordingTile.PermissionState(
+            microphoneGranted: viewModel.settingsViewModel.microphoneGranted,
+            screenRecordingGranted: viewModel.settingsViewModel.screenRecordingGranted,
+            sourceMode: viewModel.settingsViewModel.meetingAudioSourceMode
+        )
+    }
+
+    private var headerStatusIcon: String {
+        switch viewModel.recordingStatus {
+        case .recording:
+            return "record.circle.fill"
+        case .paused:
+            return "pause.fill"
+        case .finishing, .transcribing:
+            return "waveform"
+        case .error:
+            return "exclamationmark.triangle"
+        case .ready:
+            return "checkmark.circle"
+        }
+    }
+
+    private var headerStatusTitle: String {
+        switch viewModel.recordingStatus {
+        case .ready:
+            return "Ready"
+        case .recording:
+            return "Recording \(viewModel.meetingPillViewModel.formattedElapsed)"
+        case .paused:
+            return "Paused \(viewModel.meetingPillViewModel.formattedElapsed)"
+        case .finishing:
+            return "Finishing"
+        case .transcribing:
+            return "Transcribing"
+        case .error:
+            return "Needs Attention"
+        }
+    }
+
+    private var headerStatusTint: Color {
+        switch viewModel.recordingStatus {
+        case .recording:
+            return DesignSystem.Colors.recordingRed
+        case .paused, .finishing, .transcribing:
+            return DesignSystem.Colors.warningAmber
+        case .error:
+            return DesignSystem.Colors.errorRed
+        case .ready:
+            return DesignSystem.Colors.successGreen
+        }
+    }
+
+    private var recentMeetingsSearchText: String {
+        viewModel.recentMeetingsViewModel.searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var shouldShowRecentMeetingSearch: Bool {
+        !viewModel.recentMeetingsViewModel.transcriptions.isEmpty || !recentMeetingsSearchText.isEmpty
+    }
+
+    private var recentMeetingsEmptyIcon: String {
+        recentMeetingsSearchText.isEmpty ? "waveform.badge.mic" : "magnifyingglass"
+    }
+
+    private var recentMeetingsEmptyTitle: String {
+        recentMeetingsSearchText.isEmpty ? "No meetings recorded yet" : "No matching meetings"
+    }
+
+    private var recentMeetingsEmptyDetail: String {
+        recentMeetingsSearchText.isEmpty
+            ? "Use Record Meeting above to capture system audio and transcribe locally."
+            : "Try different words or clear your search."
+    }
+
+    private var recentMeetingsEmptyActionTitle: String? {
+        recentMeetingsSearchText.isEmpty ? nil : "Clear"
+    }
+
+    private var recentMeetingsEmptyActionIcon: String? {
+        recentMeetingsSearchText.isEmpty ? nil : "xmark.circle"
+    }
+
+    private var recentMeetingsEmptyAction: (() -> Void)? {
+        guard !recentMeetingsSearchText.isEmpty else { return nil }
+        return {
+            viewModel.recentMeetingsViewModel.searchText = ""
+        }
+    }
+
+    private func calendarEmptyDetail(for mode: CalendarAutoStartMode) -> String {
+        switch mode {
+        case .off:
+            return "Calendar reminders are off."
+        case .notify:
+            return "Calendar reminders are on."
+        case .autoStart:
+            return "Calendar auto-start is on."
+        }
+    }
+
+    private func performAttentionAction(_ action: MeetingsWorkspaceViewModel.AttentionAction) {
+        switch action {
+        case .recordMeeting:
+            onRecordMeeting()
+        case .recoverMeetings:
+            onRecoverMeetings()
+        case .openCalendarSettings:
+            onOpenCalendarSettings()
+        case .openAISettings:
+            onOpenAISettings()
+        }
+    }
+
+    private func saveMeetingAudio(_ transcription: Transcription) {
+        Task { @MainActor in
+            do {
+                let outcome = try await MeetingAudioActions.runSaveAudioPanel(for: transcription)
+                switch outcome {
+                case .saved:
+                    SoundManager.shared.play(.transcriptionComplete)
+                case .cancelled:
+                    break
+                case .sourceUnavailable:
+                    audioSaveErrorMessage = "The meeting audio file is no longer available."
+                }
+            } catch {
+                audioSaveErrorMessage = error.localizedDescription
+            }
+        }
+    }
+}
+
+private struct MeetingsSection<Content: View>: View {
+    let title: String
+    let icon: String
+    @ViewBuilder var content: () -> Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            Label(title, systemImage: icon)
+                .font(DesignSystem.Typography.sectionTitle)
+                .foregroundStyle(DesignSystem.Colors.textPrimary)
+                .labelStyle(.titleAndIcon)
+                .accessibilityAddTraits(.isHeader)
+
+            VStack(alignment: .leading, spacing: 0) {
+                content()
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(DesignSystem.Colors.surface)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .strokeBorder(DesignSystem.Colors.border.opacity(0.65), lineWidth: 0.6)
+                    )
+            )
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct MeetingsStatusChip: View {
+    let icon: String
+    let title: String
+    let tint: Color
+
+    var body: some View {
+        Label(title, systemImage: icon)
+            .font(DesignSystem.Typography.caption.weight(.semibold))
+            .foregroundStyle(tint)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                Capsule()
+                    .fill(tint.opacity(0.11))
+            )
+            .overlay(
+                Capsule()
+                    .strokeBorder(tint.opacity(0.25), lineWidth: 0.6)
+            )
+            .lineLimit(1)
+    }
+}
+
+private struct MeetingsInlineState: View {
+    let icon: String
+    let title: String
+    let detail: String
+    let actionTitle: String?
+    let actionIcon: String?
+    let action: (() -> Void)?
+
+    var body: some View {
+        HStack(alignment: .center, spacing: DesignSystem.Spacing.md) {
+            Image(systemName: icon)
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(DesignSystem.Colors.textTertiary)
+                .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(DesignSystem.Typography.body.weight(.semibold))
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+                    .lineLimit(2)
+                Text(detail)
+                    .font(DesignSystem.Typography.bodySmall)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: DesignSystem.Spacing.md)
+
+            if let actionTitle, let actionIcon, let action {
+                Button(action: action) {
+                    Label(actionTitle, systemImage: actionIcon)
+                }
+                .parakeetAction(.secondary)
+                .fixedSize()
+            }
+        }
+        .padding(DesignSystem.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct MeetingsLoadingRow: View {
+    let title: String
+
+    var body: some View {
+        HStack(spacing: DesignSystem.Spacing.sm) {
+            ProgressView()
+                .controlSize(.small)
+            Text(title)
+                .font(DesignSystem.Typography.bodySmall)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+        }
+        .padding(DesignSystem.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct CalendarEventRow: View {
+    let event: CalendarEvent
+
+    var body: some View {
+        HStack(alignment: .center, spacing: DesignSystem.Spacing.md) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(event.title)
+                    .font(DesignSystem.Typography.body.weight(.semibold))
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+                    .lineLimit(1)
+                HStack(spacing: 6) {
+                    Text(event.formattedTimeRange)
+                    if let calendarName = event.calendarName, !calendarName.isEmpty {
+                        Text("·")
+                        Text(calendarName)
+                    }
+                    if event.attendeeCount > 0 {
+                        Text("·")
+                        Text("\(event.attendeeCount + 1) people")
+                    }
+                }
+                .font(DesignSystem.Typography.caption)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+                .lineLimit(1)
+            }
+        }
+        .padding(DesignSystem.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct AttentionRow: View {
+    let item: MeetingsWorkspaceViewModel.AttentionItem
+    var action: () -> Void
+
+    private var tint: Color {
+        item.severity == .required ? DesignSystem.Colors.errorRed : DesignSystem.Colors.warningAmber
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: DesignSystem.Spacing.md) {
+            Image(systemName: item.severity == .required ? "exclamationmark.triangle.fill" : "info.circle.fill")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(tint)
+                .frame(width: 20)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(item.title)
+                    .font(DesignSystem.Typography.body.weight(.semibold))
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+                    .lineLimit(2)
+                Text(item.detail)
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: DesignSystem.Spacing.sm)
+
+            Button(action: action) {
+                Label(item.actionTitle, systemImage: actionIcon)
+            }
+            .parakeetAction(.secondary)
+            .fixedSize()
+        }
+        .padding(DesignSystem.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var actionIcon: String {
+        switch item.action {
+        case .recordMeeting:
+            return "record.circle"
+        case .recoverMeetings:
+            return "tray.and.arrow.up"
+        case .openCalendarSettings, .openAISettings:
+            return "gearshape"
+        }
+    }
+}
+
+private struct IntelligenceReadyRow: View {
+    let displayName: String
+    let locality: String
+    let localityIcon: String
+    let detail: String
+    let tint: Color
+    var onOpenSettings: () -> Void
+
+    var body: some View {
+        HStack(alignment: .center, spacing: DesignSystem.Spacing.md) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 17, weight: .medium))
+                .foregroundStyle(tint)
+                .frame(width: 22)
+
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 6) {
+                    Text(displayName)
+                        .font(DesignSystem.Typography.body.weight(.semibold))
+                        .foregroundStyle(DesignSystem.Colors.textPrimary)
+                        .lineLimit(1)
+                    Text(locality)
+                        .font(DesignSystem.Typography.micro.weight(.semibold))
+                        .foregroundStyle(tint)
+                    Image(systemName: localityIcon)
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(tint)
+                }
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(Capsule().fill(tint.opacity(0.12)))
+
+                Text(detail)
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: DesignSystem.Spacing.sm)
+
+            Button(action: onOpenSettings) {
+                Image(systemName: "gearshape")
+            }
+            .parakeetAction(.secondary)
+            .help("Open AI Settings")
+        }
+        .padding(DesignSystem.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct MeetingsHairline: View {
+    var body: some View {
+        Rectangle()
+            .fill(DesignSystem.Colors.divider.opacity(0.7))
+            .frame(height: 0.5)
+            .padding(.horizontal, DesignSystem.Spacing.md)
+    }
+}

--- a/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
+++ b/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
@@ -40,6 +40,9 @@ struct MeetingsView: View {
         .onChange(of: viewModel.settingsViewModel.meetingTriggerFilter) { _, _ in
             viewModel.refreshUpcomingEvents()
         }
+        .onChange(of: viewModel.settingsViewModel.calendarExcludedIdentifiers) { _, _ in
+            viewModel.refreshUpcomingEvents()
+        }
         .alert(
             "Save Failed",
             isPresented: Binding(

--- a/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
+++ b/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
@@ -125,7 +125,7 @@ struct MeetingsView: View {
             MeetingsSection(title: "Upcoming", icon: "calendar.badge.clock") {
                 switch viewModel.calendarStatus {
                 case .unavailable:
-                    EmptyView()
+                    unavailableCalendarState
                 case .off:
                     MeetingsInlineState(
                         icon: "calendar",
@@ -187,6 +187,11 @@ struct MeetingsView: View {
                 }
             }
         }
+    }
+
+    private var unavailableCalendarState: some View {
+        assertionFailure("calendarStatus should not be unavailable when the calendar feature is enabled.")
+        return EmptyView()
     }
 
     @ViewBuilder

--- a/Sources/MacParakeetCore/Calendar/CalendarService.swift
+++ b/Sources/MacParakeetCore/Calendar/CalendarService.swift
@@ -36,7 +36,7 @@ public actor CalendarService {
 
     // MARK: - Permission
 
-    public enum PermissionStatus: Sendable {
+    public enum PermissionStatus: Sendable, Equatable {
         case notDetermined
         case granted
         case denied

--- a/Sources/MacParakeetViewModels/MeetingsWorkspaceViewModel.swift
+++ b/Sources/MacParakeetViewModels/MeetingsWorkspaceViewModel.swift
@@ -140,7 +140,7 @@ public final class MeetingsWorkspaceViewModel {
                 guard !Task.isCancelled, self.upcomingEventsGeneration == generation else { return }
                 self.upcomingEvents = Array(
                     events
-                        .filter(self.shouldShowCalendarEvent)
+                        .filter { event in self.shouldShowCalendarEvent(event) }
                         .prefix(max(0, self.upcomingEventLimit))
                 )
                 self.isLoadingUpcomingEvents = false

--- a/Sources/MacParakeetViewModels/MeetingsWorkspaceViewModel.swift
+++ b/Sources/MacParakeetViewModels/MeetingsWorkspaceViewModel.swift
@@ -106,13 +106,18 @@ public final class MeetingsWorkspaceViewModel {
 
     public func refresh() {
         hasLoadedInitialState = true
-        recentMeetingsViewModel.loadTranscriptions()
+        refreshRecentMeetings()
         refreshUpcomingEvents()
     }
 
     public func refreshIfNeeded() {
         guard !hasLoadedInitialState else { return }
         refresh()
+    }
+
+    @discardableResult
+    public func refreshRecentMeetings() -> Task<Void, Never> {
+        recentMeetingsViewModel.loadTranscriptions()
     }
 
     @discardableResult
@@ -133,15 +138,16 @@ public final class MeetingsWorkspaceViewModel {
         isLoadingUpcomingEvents = true
         calendarErrorMessage = nil
 
+        let lookAheadDays = calendarLookAheadDays
+        let eventLimit = upcomingEventLimit
         let task = Task { @MainActor [weak self, calendarService] in
             do {
-                guard let self else { return }
-                let events = try await calendarService.fetchUpcomingEvents(days: self.calendarLookAheadDays)
-                guard !Task.isCancelled, self.upcomingEventsGeneration == generation else { return }
+                let events = try await calendarService.fetchUpcomingEvents(days: lookAheadDays)
+                guard let self, !Task.isCancelled, self.upcomingEventsGeneration == generation else { return }
                 self.upcomingEvents = Array(
                     events
                         .filter { event in self.shouldShowCalendarEvent(event) }
-                        .prefix(max(0, self.upcomingEventLimit))
+                        .prefix(max(0, eventLimit))
                 )
                 self.isLoadingUpcomingEvents = false
             } catch {

--- a/Sources/MacParakeetViewModels/MeetingsWorkspaceViewModel.swift
+++ b/Sources/MacParakeetViewModels/MeetingsWorkspaceViewModel.swift
@@ -1,0 +1,275 @@
+import Foundation
+import MacParakeetCore
+
+@MainActor
+@Observable
+public final class MeetingsWorkspaceViewModel {
+    public enum RecordingStatus: Equatable {
+        case ready
+        case recording
+        case paused
+        case finishing
+        case transcribing
+        case error(String)
+    }
+
+    public enum CalendarStatus: Equatable {
+        case unavailable
+        case off
+        case permissionNeeded
+        case permissionDenied
+        case loading
+        case ready(mode: CalendarAutoStartMode)
+        case error(String)
+    }
+
+    public enum IntelligenceStatus: Equatable {
+        case setupNeeded
+        case ready(displayName: String, isLocal: Bool)
+        case cannotConnect(displayName: String, message: String)
+    }
+
+    public enum AttentionSeverity: Equatable, Sendable {
+        case recommended
+        case required
+    }
+
+    public enum AttentionAction: Equatable, Sendable {
+        case recordMeeting
+        case recoverMeetings
+        case openCalendarSettings
+        case openAISettings
+    }
+
+    public struct AttentionItem: Identifiable, Equatable, Sendable {
+        public let id: String
+        public let severity: AttentionSeverity
+        public let title: String
+        public let detail: String
+        public let actionTitle: String
+        public let action: AttentionAction
+
+        public init(
+            id: String,
+            severity: AttentionSeverity,
+            title: String,
+            detail: String,
+            actionTitle: String,
+            action: AttentionAction
+        ) {
+            self.id = id
+            self.severity = severity
+            self.title = title
+            self.detail = detail
+            self.actionTitle = actionTitle
+            self.action = action
+        }
+    }
+
+    public let recentMeetingsViewModel: TranscriptionLibraryViewModel
+    public let meetingPillViewModel: MeetingRecordingPillViewModel
+    public let settingsViewModel: SettingsViewModel
+    public let llmSettingsViewModel: LLMSettingsViewModel
+
+    public private(set) var upcomingEvents: [CalendarEvent] = []
+    public private(set) var isLoadingUpcomingEvents = false
+    public private(set) var calendarErrorMessage: String?
+    public var calendarLookAheadDays = 7
+    public var upcomingEventLimit = 4
+
+    @ObservationIgnored private let calendarService: any CalendarServicing
+    @ObservationIgnored private var upcomingEventsTask: Task<Void, Never>?
+    @ObservationIgnored private var upcomingEventsGeneration = 0
+    @ObservationIgnored private var hasLoadedInitialState = false
+
+    public init(
+        recentMeetingsViewModel: TranscriptionLibraryViewModel,
+        meetingPillViewModel: MeetingRecordingPillViewModel,
+        settingsViewModel: SettingsViewModel,
+        llmSettingsViewModel: LLMSettingsViewModel,
+        calendarService: any CalendarServicing = CalendarService.shared
+    ) {
+        self.recentMeetingsViewModel = recentMeetingsViewModel
+        self.meetingPillViewModel = meetingPillViewModel
+        self.settingsViewModel = settingsViewModel
+        self.llmSettingsViewModel = llmSettingsViewModel
+        self.calendarService = calendarService
+    }
+
+    deinit {
+        upcomingEventsTask?.cancel()
+    }
+
+    public func configure(transcriptionRepo: TranscriptionRepositoryProtocol) {
+        recentMeetingsViewModel.configure(transcriptionRepo: transcriptionRepo)
+    }
+
+    public func refresh() {
+        hasLoadedInitialState = true
+        recentMeetingsViewModel.loadTranscriptions()
+        refreshUpcomingEvents()
+    }
+
+    public func refreshIfNeeded() {
+        guard !hasLoadedInitialState else { return }
+        refresh()
+    }
+
+    @discardableResult
+    public func refreshUpcomingEvents() -> Task<Void, Never> {
+        upcomingEventsTask?.cancel()
+        upcomingEventsGeneration += 1
+        let generation = upcomingEventsGeneration
+
+        guard shouldFetchCalendarEvents else {
+            isLoadingUpcomingEvents = false
+            calendarErrorMessage = nil
+            upcomingEvents = []
+            let task = Task<Void, Never> {}
+            upcomingEventsTask = task
+            return task
+        }
+
+        isLoadingUpcomingEvents = true
+        calendarErrorMessage = nil
+
+        let task = Task { @MainActor [weak self, calendarService] in
+            do {
+                guard let self else { return }
+                let events = try await calendarService.fetchUpcomingEvents(days: self.calendarLookAheadDays)
+                guard !Task.isCancelled, self.upcomingEventsGeneration == generation else { return }
+                self.upcomingEvents = Array(
+                    events
+                        .filter(self.shouldShowCalendarEvent)
+                        .prefix(max(0, self.upcomingEventLimit))
+                )
+                self.isLoadingUpcomingEvents = false
+            } catch {
+                guard let self, !Task.isCancelled, self.upcomingEventsGeneration == generation else { return }
+                self.upcomingEvents = []
+                self.isLoadingUpcomingEvents = false
+                self.calendarErrorMessage = error.localizedDescription
+            }
+        }
+        upcomingEventsTask = task
+        return task
+    }
+
+    public var recordingStatus: RecordingStatus {
+        switch meetingPillViewModel.state {
+        case .idle, .completed:
+            return .ready
+        case .recording:
+            return .recording
+        case .paused:
+            return .paused
+        case .completing:
+            return .finishing
+        case .transcribing:
+            return .transcribing
+        case .error(let message):
+            return .error(message)
+        }
+    }
+
+    public var hasActiveRecording: Bool {
+        switch recordingStatus {
+        case .recording, .paused, .finishing, .transcribing:
+            return true
+        case .ready, .error:
+            return false
+        }
+    }
+
+    public var calendarStatus: CalendarStatus {
+        guard AppFeatures.calendarEnabled else { return .unavailable }
+        guard settingsViewModel.calendarAutoStartMode != .off else { return .off }
+
+        switch settingsViewModel.calendarPermissionStatus {
+        case .notDetermined:
+            return .permissionNeeded
+        case .denied:
+            return .permissionDenied
+        case .granted:
+            if isLoadingUpcomingEvents { return .loading }
+            if let calendarErrorMessage { return .error(calendarErrorMessage) }
+            return .ready(mode: settingsViewModel.calendarAutoStartMode)
+        }
+    }
+
+    public var intelligenceStatus: IntelligenceStatus {
+        switch llmSettingsViewModel.setupStatus {
+        case .setUpNeeded:
+            return .setupNeeded
+        case .ready(let displayName):
+            return .ready(
+                displayName: displayName,
+                isLocal: llmSettingsViewModel.isLocalConfiguration
+            )
+        case .cannotConnect(let displayName, let message):
+            return .cannotConnect(displayName: displayName, message: message)
+        }
+    }
+
+    public var attentionItems: [AttentionItem] {
+        var items: [AttentionItem] = []
+
+        if settingsViewModel.pendingMeetingRecoveryCount > 0 {
+            let count = settingsViewModel.pendingMeetingRecoveryCount
+            items.append(AttentionItem(
+                id: "meeting-recovery",
+                severity: .required,
+                title: "Interrupted recording",
+                detail: "\(count) partial recording\(count == 1 ? "" : "s") can be recovered.",
+                actionTitle: "Recover",
+                action: .recoverMeetings
+            ))
+        }
+
+        if case .error(let message) = recordingStatus {
+            items.append(AttentionItem(
+                id: "recording-error",
+                severity: .required,
+                title: "Recording stopped",
+                detail: message,
+                actionTitle: "Record Again",
+                action: .recordMeeting
+            ))
+        }
+
+        if case .cannotConnect(let displayName, let message) = intelligenceStatus {
+            items.append(AttentionItem(
+                id: "ai-unavailable",
+                severity: .recommended,
+                title: "\(displayName) unavailable",
+                detail: message,
+                actionTitle: "Open AI Settings",
+                action: .openAISettings
+            ))
+        }
+
+        return items
+    }
+
+    private var shouldFetchCalendarEvents: Bool {
+        AppFeatures.calendarEnabled
+            && settingsViewModel.calendarAutoStartMode != .off
+            && settingsViewModel.calendarPermissionStatus == .granted
+    }
+
+    private func shouldShowCalendarEvent(_ event: CalendarEvent) -> Bool {
+        if let calendarIdentifier = event.calendarIdentifier,
+           settingsViewModel.calendarExcludedIdentifiers.contains(calendarIdentifier) {
+            return false
+        }
+
+        switch settingsViewModel.meetingTriggerFilter {
+        case .withLink:
+            return event.meetUrl != nil
+        case .withParticipants:
+            return !event.participants.isEmpty
+        case .allEvents:
+            return true
+        }
+    }
+}

--- a/Tests/MacParakeetTests/App/MainWindowStateTests.swift
+++ b/Tests/MacParakeetTests/App/MainWindowStateTests.swift
@@ -52,11 +52,13 @@ final class MainWindowStateTests: XCTestCase {
         XCTAssertEqual(state.selectedItem, .meetings)
     }
 
-    func testPrimarySidebarOrdersMeetingsAfterDictations() {
-        XCTAssertEqual(
-            SidebarItem.primaryItems,
-            [.transcribe, .library, .dictations, .meetings]
-        )
+    func testPrimarySidebarOrderRespectsMeetingFeatureFlag() {
+        var expected: [SidebarItem] = [.transcribe, .library, .dictations]
+        if AppFeatures.meetingRecordingEnabled {
+            expected.append(.meetings)
+        }
+
+        XCTAssertEqual(SidebarItem.primaryItems, expected)
     }
 
     func testStartNewTranscriptionReturnsToTranscribeAndHidesProgressDetail() {

--- a/Tests/MacParakeetTests/App/MainWindowStateTests.swift
+++ b/Tests/MacParakeetTests/App/MainWindowStateTests.swift
@@ -52,6 +52,13 @@ final class MainWindowStateTests: XCTestCase {
         XCTAssertEqual(state.selectedItem, .meetings)
     }
 
+    func testPrimarySidebarOrdersMeetingsAfterDictations() {
+        XCTAssertEqual(
+            SidebarItem.primaryItems,
+            [.transcribe, .library, .dictations, .meetings]
+        )
+    }
+
     func testStartNewTranscriptionReturnsToTranscribeAndHidesProgressDetail() {
         let state = MainWindowState()
         state.selectedItem = .library

--- a/Tests/MacParakeetTests/App/MainWindowStateTests.swift
+++ b/Tests/MacParakeetTests/App/MainWindowStateTests.swift
@@ -44,6 +44,14 @@ final class MainWindowStateTests: XCTestCase {
         XCTAssertEqual(state.selectedItem, .library)
     }
 
+    func testNavigateCanSelectMeetingsWorkspace() {
+        let state = MainWindowState()
+
+        state.navigate(to: .meetings)
+
+        XCTAssertEqual(state.selectedItem, .meetings)
+    }
+
     func testStartNewTranscriptionReturnsToTranscribeAndHidesProgressDetail() {
         let state = MainWindowState()
         state.selectedItem = .library

--- a/Tests/MacParakeetTests/ViewModels/MeetingsWorkspaceViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/MeetingsWorkspaceViewModelTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+@testable import MacParakeetCore
+@testable import MacParakeetViewModels
+
+@MainActor
+final class MeetingsWorkspaceViewModelTests: XCTestCase {
+    private var defaultsSuiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        defaultsSuiteName = "MeetingsWorkspaceViewModelTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: defaultsSuiteName)
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+        defaults = nil
+        defaultsSuiteName = nil
+        super.tearDown()
+    }
+
+    func testRefreshUpcomingEventsSkipsFetchWhenCalendarModeIsOff() async {
+        let calendar = MockCalendarService()
+        calendar.stubPermissionStatus = .granted
+        calendar.stubEvents = [makeEvent(title: "Design Review", meetUrl: "https://meet.google.com/abc")]
+        let viewModel = makeViewModel(calendarMode: .off, calendarService: calendar)
+        viewModel.settingsViewModel.calendarPermissionStatus = .granted
+
+        await viewModel.refreshUpcomingEvents().value
+
+        XCTAssertEqual(calendar.fetchUpcomingEventsCallCount, 0)
+        XCTAssertTrue(viewModel.upcomingEvents.isEmpty)
+        XCTAssertEqual(viewModel.calendarStatus, .off)
+    }
+
+    func testRefreshUpcomingEventsFiltersByMeetingRulesAndExcludedCalendars() async {
+        let calendar = MockCalendarService()
+        calendar.stubPermissionStatus = .granted
+        calendar.stubEvents = [
+            makeEvent(title: "Design Review", meetUrl: "https://zoom.us/j/123", calendarIdentifier: "work"),
+            makeEvent(title: "Focus Block", meetUrl: nil, calendarIdentifier: "work"),
+            makeEvent(title: "Ignored Review", meetUrl: "https://meet.google.com/abc", calendarIdentifier: "personal")
+        ]
+        let viewModel = makeViewModel(
+            calendarMode: .notify,
+            triggerFilter: .withLink,
+            excludedCalendarIds: ["personal"],
+            calendarService: calendar
+        )
+        viewModel.settingsViewModel.calendarPermissionStatus = .granted
+
+        await viewModel.refreshUpcomingEvents().value
+
+        XCTAssertEqual(calendar.fetchUpcomingEventsCallCount, 1)
+        XCTAssertEqual(viewModel.upcomingEvents.map(\.title), ["Design Review"])
+        XCTAssertEqual(viewModel.calendarStatus, .ready(mode: .notify))
+    }
+
+    func testRecordingStatusTracksMeetingPillState() {
+        let pill = MeetingRecordingPillViewModel()
+        let viewModel = makeViewModel(meetingPillViewModel: pill)
+
+        pill.state = .recording
+        XCTAssertEqual(viewModel.recordingStatus, .recording)
+        XCTAssertTrue(viewModel.hasActiveRecording)
+
+        pill.state = .paused
+        XCTAssertEqual(viewModel.recordingStatus, .paused)
+        XCTAssertTrue(viewModel.hasActiveRecording)
+
+        pill.state = .error("capture failed")
+        XCTAssertEqual(viewModel.recordingStatus, .error("capture failed"))
+        XCTAssertFalse(viewModel.hasActiveRecording)
+    }
+
+    func testAttentionItemsDoNotDuplicateCalendarAndAISetupStates() {
+        let viewModel = makeViewModel(calendarMode: .notify)
+        viewModel.settingsViewModel.calendarPermissionStatus = .notDetermined
+
+        let ids = Set(viewModel.attentionItems.map(\.id))
+
+        XCTAssertFalse(ids.contains("calendar-permission"))
+        XCTAssertFalse(ids.contains("ai-setup"))
+        XCTAssertEqual(viewModel.calendarStatus, .permissionNeeded)
+        XCTAssertEqual(viewModel.intelligenceStatus, .setupNeeded)
+    }
+
+    private func makeViewModel(
+        calendarMode: CalendarAutoStartMode = .off,
+        triggerFilter: MeetingTriggerFilter = .withLink,
+        excludedCalendarIds: Set<String> = [],
+        meetingPillViewModel: MeetingRecordingPillViewModel? = nil,
+        calendarService: MockCalendarService = MockCalendarService()
+    ) -> MeetingsWorkspaceViewModel {
+        defaults.set(calendarMode.rawValue, forKey: CalendarAutoStartPreferences.modeKey)
+        defaults.set(triggerFilter.rawValue, forKey: CalendarAutoStartPreferences.triggerFilterKey)
+        defaults.set(Array(excludedCalendarIds), forKey: CalendarAutoStartPreferences.excludedCalendarIdsKey)
+
+        let settingsViewModel = SettingsViewModel(defaults: defaults)
+        let llmSettingsViewModel = LLMSettingsViewModel(defaults: defaults)
+        return MeetingsWorkspaceViewModel(
+            recentMeetingsViewModel: TranscriptionLibraryViewModel(scope: .meetings),
+            meetingPillViewModel: meetingPillViewModel ?? MeetingRecordingPillViewModel(),
+            settingsViewModel: settingsViewModel,
+            llmSettingsViewModel: llmSettingsViewModel,
+            calendarService: calendarService
+        )
+    }
+
+    private func makeEvent(
+        title: String,
+        meetUrl: String?,
+        calendarIdentifier: String? = nil
+    ) -> CalendarEvent {
+        CalendarEvent(
+            id: UUID().uuidString,
+            title: title,
+            startTime: Date().addingTimeInterval(3600),
+            endTime: Date().addingTimeInterval(5400),
+            meetUrl: meetUrl,
+            participants: [EventParticipant(name: "Ava")],
+            calendarName: "Work",
+            calendarIdentifier: calendarIdentifier
+        )
+    }
+}

--- a/Tests/MacParakeetTests/ViewModels/MeetingsWorkspaceViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/MeetingsWorkspaceViewModelTests.swift
@@ -32,7 +32,7 @@ final class MeetingsWorkspaceViewModelTests: XCTestCase {
 
         XCTAssertEqual(calendar.fetchUpcomingEventsCallCount, 0)
         XCTAssertTrue(viewModel.upcomingEvents.isEmpty)
-        XCTAssertEqual(viewModel.calendarStatus, .off)
+        XCTAssertEqual(viewModel.calendarStatus, AppFeatures.calendarEnabled ? .off : .unavailable)
     }
 
     func testRefreshUpcomingEventsFiltersByMeetingRulesAndExcludedCalendars() async {
@@ -53,9 +53,15 @@ final class MeetingsWorkspaceViewModelTests: XCTestCase {
 
         await viewModel.refreshUpcomingEvents().value
 
-        XCTAssertEqual(calendar.fetchUpcomingEventsCallCount, 1)
-        XCTAssertEqual(viewModel.upcomingEvents.map(\.title), ["Design Review"])
-        XCTAssertEqual(viewModel.calendarStatus, .ready(mode: .notify))
+        if AppFeatures.calendarEnabled {
+            XCTAssertEqual(calendar.fetchUpcomingEventsCallCount, 1)
+            XCTAssertEqual(viewModel.upcomingEvents.map(\.title), ["Design Review"])
+            XCTAssertEqual(viewModel.calendarStatus, .ready(mode: .notify))
+        } else {
+            XCTAssertEqual(calendar.fetchUpcomingEventsCallCount, 0)
+            XCTAssertTrue(viewModel.upcomingEvents.isEmpty)
+            XCTAssertEqual(viewModel.calendarStatus, .unavailable)
+        }
     }
 
     func testRecordingStatusTracksMeetingPillState() {
@@ -83,7 +89,7 @@ final class MeetingsWorkspaceViewModelTests: XCTestCase {
 
         XCTAssertFalse(ids.contains("calendar-permission"))
         XCTAssertFalse(ids.contains("ai-setup"))
-        XCTAssertEqual(viewModel.calendarStatus, .permissionNeeded)
+        XCTAssertEqual(viewModel.calendarStatus, AppFeatures.calendarEnabled ? .permissionNeeded : .unavailable)
         XCTAssertEqual(viewModel.intelligenceStatus, .setupNeeded)
     }
 

--- a/docs/planning/2026-05-meetings-workspace-plan.md
+++ b/docs/planning/2026-05-meetings-workspace-plan.md
@@ -1,0 +1,283 @@
+# Meetings Workspace Plan
+
+Date: 2026-05-27
+Status: Planned
+
+## Decision
+
+Build a dedicated top-level Meetings workspace while keeping meeting recordings
+visible in Library.
+
+The first foundation slice should be thin. MacParakeet already has the core
+meeting data model, capture stack, transcript artifact, chat, prompts, retained
+audio, calendar coordination, and CLI surface. The Meetings workspace should
+compose those existing capabilities into a workflow surface rather than create a
+second meeting domain model.
+
+Product framing:
+
+> Recording and transcription are local-first. Meeting intelligence is
+> provider-flexible and always user-chosen.
+
+## Goals
+
+- Make meetings a top-level product area, not only a Library filter.
+- Preserve Library as the universal archive for all transcript artifacts.
+- Keep `Transcription` as the stored meeting artifact.
+- Surface upcoming calendar meetings, current recording state, recent meetings,
+  templates/prompts, provider readiness, and attention states in one place.
+- Make it obvious when intelligence leaves the device and which provider handles
+  it.
+
+## Non-Goals
+
+- Do not introduce accounts as a requirement for recording or transcription.
+- Do not replace `Transcription` with a separate persisted meeting object.
+- Do not move all meeting logic into the app target; Core and ViewModels
+  boundaries stay intact.
+- Do not add cloud calendar OAuth in the first slice.
+- Do not make any cloud LLM provider the default.
+
+## Existing Assets
+
+Capture and transcription:
+
+- `MeetingRecordingService`
+- `MeetingRecordingFlowCoordinator`
+- `MeetingRecordingPillViewModel`
+- `MeetingRecordingPanelViewModel`
+- `MeetingRecordingPanelView`
+- live `Notes / Transcript / Ask` panel
+- dual-source meeting audio capture and retained meeting audio
+
+Saved meeting artifacts:
+
+- `Transcription.sourceType == .meeting`
+- `TranscriptionLibraryViewModel(scope: .meetings)`
+- `MeetingRowCard`
+- `MeetingDateGroupHeader`
+- `TranscriptResultView`
+- `MeetingAudioActions`
+- chat conversations through `TranscriptChatViewModel`
+- prompt outputs through `PromptResultsViewModel`
+
+Calendar:
+
+- EventKit calendar service and monitor path from ADR-017
+- `SettingsViewModel` calendar settings
+- `MeetingAutoStartCoordinator`
+- `MeetingCountdownToastController`
+- CLI `calendar upcoming`
+
+Intelligence and prompts:
+
+- `LLMSettingsViewModel`
+- `LLMService`
+- `LLMConfigStore`
+- `Prompt`, `PromptResult`, `PromptResultsViewModel`
+- `QuickPrompt`, `QuickPromptsViewModel`, `AskPromptsSheet`
+- CLI meeting and prompt commands
+
+## Build Order
+
+### Slice 1: Meetings Route Foundation
+
+Add a `Meetings` sidebar item and a dedicated `MeetingsView`, backed by a new
+`MeetingsWorkspaceViewModel`.
+
+The view model should aggregate existing sources:
+
+- current recording state from `MeetingRecordingPillViewModel`
+- recent meeting rows from `TranscriptionLibraryViewModel(scope: .meetings)`
+- calendar settings and permission state from `SettingsViewModel`
+- upcoming calendar events from the existing calendar service path
+- AI/provider readiness from `LLMSettingsViewModel` or a small read-only
+  provider-status adapter
+- attention states from recoverable meeting locks, failed transcriptions,
+  missing provider setup, and unavailable retained audio
+
+Expected files:
+
+- `Sources/MacParakeet/Views/Meetings/MeetingsView.swift`
+- `Sources/MacParakeetViewModels/MeetingsWorkspaceViewModel.swift`
+- `Sources/MacParakeet/Views/MainWindowView.swift`
+- `Sources/MacParakeet/Views/MainWindowState.swift`
+- `Sources/MacParakeet/App/AppWindowCoordinator.swift`
+- `Sources/MacParakeet/App/AppEnvironmentConfigurer.swift`
+
+Tests:
+
+- `MeetingsWorkspaceViewModelTests`
+- sidebar routing smoke if existing view tests support it
+- no full database migration tests expected for this slice
+
+### Slice 2: Meetings Home UI
+
+Build the first useful Meetings screen:
+
+- header with current meeting status and primary record action
+- `Upcoming` section with calendar events and record affordance
+- `Recording Now` section when a meeting is active
+- `Recent Meetings` section using existing meeting rows
+- `Needs Attention` section for recovery/failure states
+
+Keep the first UI dense and workflow-oriented. Avoid a marketing-style hero.
+The first viewport should show actual meeting workflow controls.
+
+### Slice 3: Meeting Intelligence Readiness
+
+Add a compact meeting intelligence setup strip:
+
+- current provider name
+- local/cloud badge
+- readiness state
+- direct action to Settings > AI
+- explicit copy when a selected provider sends transcript/notes off-device
+
+Support posture:
+
+- local/no-cloud providers remain valid
+- OpenAI API and OpenRouter remain explicit provider choices
+- local CLI/Ollama/LM Studio remain explicit provider choices
+- ChatGPT subscription can be added as an opt-in provider later, labeled
+  experimental if it depends on a non-API integration path
+
+This slice should not block recording or transcription.
+
+### Slice 4: Meeting Templates And Recipes
+
+Make meeting-specific intelligence presets discoverable.
+
+First pass should reuse prompt infrastructure:
+
+- built-in meeting prompts for summary, action items, decisions, blockers,
+  follow-ups, and risks
+- meeting-only grouping in the prompt UI
+- apply/re-run on a meeting artifact
+- preserve outputs as `PromptResult`
+
+Only add a new meeting-template table if prompt metadata cannot express the
+required UX. Prefer tagging or scoping existing prompts first.
+
+### Slice 5: Saved Meeting Detail Polish
+
+Improve the saved meeting detail flow without creating a separate detail object:
+
+- keep transcript, notes, chat, prompt results, and audio in one coherent
+  artifact view
+- make speaker information and source separation easier to scan
+- make retained audio actions visible
+- make re-run/regenerate actions clear
+- keep post-meeting chat persistent
+
+This can happen inside `TranscriptResultView` or via a meeting-specific wrapper
+that still uses the same underlying view models.
+
+### Slice 6: Optional Provider Expansion
+
+Add ChatGPT subscription support only after the provider boundary is clean.
+
+Requirements:
+
+- opt-in
+- Keychain storage for tokens
+- clear "sends transcript/notes to ChatGPT" disclosure
+- no dependency for core recording/transcription
+- good failure states for expired auth, missing session, rate limits, and
+  unsupported account state
+- no audio/transcript/notes/prompt content in telemetry
+
+## Backend And Foundation Scope
+
+Likely needed:
+
+- `MeetingsWorkspaceViewModel` aggregation layer
+- read-only provider-readiness adapter if `LLMSettingsViewModel` is too
+  UI-shaped
+- calendar upcoming-event adapter suitable for view models
+- attention-state helpers for failed/recoverable meetings
+- prompt scoping/tagging if meeting-specific presets need first-class grouping
+
+Likely not needed:
+
+- new `meetings` table
+- new calendar cache table
+- new recording service
+- new transcript storage format
+- new chat storage format
+- new prompt-result storage format
+
+Possible later backend changes:
+
+- richer meeting metadata if the workspace needs user-visible fields that do
+  not belong on `Transcription`
+- cross-meeting memory/indexing if meeting intelligence expands beyond a single
+  artifact
+- provider integration for ChatGPT subscription mode
+
+## Initial Implementation Issue
+
+Title:
+
+- Add dedicated Meetings workspace shell backed by existing meeting artifacts
+
+Acceptance criteria:
+
+- Sidebar has a `Meetings` item.
+- `Meetings` opens a dedicated workspace, not the generic Library screen.
+- Recent meetings are loaded through
+  `TranscriptionLibraryViewModel(scope: .meetings)`.
+- Active recording state is visible and can open/stop the existing meeting
+  recording flow.
+- Calendar permission/auto-start status is visible if calendar support is
+  enabled.
+- Empty state explains how to record a meeting without implying account setup.
+- Library still shows meetings under its existing filter.
+- No database migration.
+- No cloud provider required.
+
+## Follow-Up Issues
+
+### Add Meeting Intelligence Readiness And Provider Setup State
+
+Acceptance criteria:
+
+- Meetings workspace shows whether intelligence is configured.
+- It distinguishes local/no-cloud providers from external providers.
+- It links to Settings > AI.
+- It does not block recording or local transcription.
+- It contains no transcript/audio/notes content in telemetry.
+
+### Add Meeting Prompt Presets And Meeting-Specific Prompt Grouping
+
+Acceptance criteria:
+
+- Built-in meeting prompts exist for summary, action items, decisions, risks,
+  blockers, and follow-ups.
+- Prompts run against saved meetings and persist as prompt results.
+- Users can edit or hide meeting prompt presets through existing prompt
+  management patterns.
+- Live Ask quick prompts remain separate from saved-meeting prompt results
+  unless deliberately unified.
+
+## Open Questions
+
+- Should the `Meetings` sidebar item sit between `Library` and `Dictations`, or
+  directly after `Transcribe`?
+- Should active recording controls in the Meetings workspace open the floating
+  panel or embed a larger live workspace in the main window?
+- Should meeting prompt presets be a scoped view over existing prompts, or a
+  separate "meeting templates" concept?
+- What is the minimum provider status API needed for Settings > AI and Meetings
+  to share readiness without leaking UI concerns into Core?
+- Should ChatGPT subscription support be implemented before or after meeting
+  templates?
+
+## Recommendation
+
+Start with Slice 1 and Slice 2 together as the first implementation package.
+That gives the app a first-class Meetings surface with almost no risky backend
+change.
+
+Do provider expansion after the workspace has a stable place to show readiness,
+failure, and cloud/local disclosure.

--- a/docs/planning/2026-05-meetings-workspace-plan.md
+++ b/docs/planning/2026-05-meetings-workspace-plan.md
@@ -1,7 +1,7 @@
 # Meetings Workspace Plan
 
 Date: 2026-05-27
-Status: Planned
+Status: Active; foundation workspace implemented
 
 ## Decision
 

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -11,11 +11,12 @@ MacParakeet has these primary UI surfaces:
 4. **Meeting Recording Tile** -- Capture tile on the Transcribe tab; reflects live recording state
 5. **Meeting Recording Pill** -- Persistent floating pill during meeting recording (sacred geometry icon); shares state with the Transcribe tile
 6. **Meeting Recording Panel** -- Floating Notes / Transcript / Ask panel with audio levels and stop controls
-7. **Transforms Tab** -- Productized selected-text rewrite management for `Polish`, `Distill`, `Decide`, and custom Transforms
-8. **Transform Progress Pill** -- Floating progress/cancel surface while a Transform is running
-9. **Menu Bar** -- Quick access and status
-10. **Calendar Countdown Toasts** -- Implemented and enabled (`AppFeatures.calendarEnabled = true`); surface only when a user opts into calendar auto-start
-11. **Settings** -- Preferences, permissions, local speech models, and update controls; calendar controls appear once Calendar access is granted
+7. **Meetings Workspace** -- Dedicated route for upcoming, live, and saved meeting work
+8. **Transforms Tab** -- Productized selected-text rewrite management for `Polish`, `Distill`, `Decide`, and custom Transforms
+9. **Transform Progress Pill** -- Floating progress/cancel surface while a Transform is running
+10. **Menu Bar** -- Quick access and status
+11. **Calendar Countdown Toasts** -- Implemented and enabled (`AppFeatures.calendarEnabled = true`); surface only when a user opts into calendar auto-start
+12. **Settings** -- Preferences, permissions, local speech models, and update controls; calendar controls appear once Calendar access is granted
 
 Design philosophy: **Simple, native, stays out of the way.** No chrome, no clutter. The app should feel like part of macOS, not a web app in a wrapper.
 
@@ -69,12 +70,18 @@ The sidebar uses NavigationSplitView with flat items (icon + label):
 - **Transcribe** (`waveform`) -- Capture hub: YouTube card + file drop card + Meeting Recording tile
 - **Library** (`square.grid.2x2`) -- All transcriptions; filter chips switch between thumbnail grid (All/YouTube/Local/Favorites) and date-grouped list (Meetings)
 - **Dictations** (`clock.arrow.circlepath`) -- Flat history list with bottom bar player
+- **Meetings** (`person.2.wave.2`) -- Workflow space for upcoming, live, and saved meeting work; visible when `AppFeatures.meetingRecordingEnabled` is true
 - **Vocabulary** (`book.fill`) -- Processing mode, pipeline guide, custom words & snippets management
 - **Transforms** (`sparkles`) -- Saved selected-text rewrites backed by `.transform` prompt rows; visible when `AppFeatures.transformsEnabled` is true
 - **Feedback** (`bubble.left.and.text.bubble.right`) -- Bug reports, feature requests, community link
 - **Settings** (`gearshape`) -- Dictation prefs, meeting recording prefs, storage, permissions
 
-There is no dedicated Meetings tab. Meeting **capture** lives on the Transcribe tile (plus hotkey + menu bar); meeting **browse** lives under Library's Meetings filter. Reason: a separate sidebar entry was a third entry point for an action already covered by hotkey + menu bar, and meetings have no thumbnail-worthy visual asset, so the date-grouped list (preview text + speaker count) belongs in the unified Library rather than a dedicated tab.
+Meetings now has a dedicated workspace while remaining visible in Library.
+Meeting **capture** still lives on the Transcribe tile, hotkey, menu bar, and
+Meetings workspace; meeting **browse** lives both in the Meetings workspace and
+under Library's Meetings filter. Reason: Library remains the universal archive,
+while Meetings is the workflow surface for upcoming calendar context, the active
+recording state, recent meetings, recovery states, and intelligence readiness.
 
 Column width: `min: 160, ideal: 180, max: 220`. Window minimum width: 800pt.
 


### PR DESCRIPTION
## Summary
- Documents the Meetings workspace direction in `docs/planning/2026-05-meetings-workspace-plan.md`.
- Adds a first-class Meetings sidebar destination for live recording, upcoming calendar context, recent meeting records, recovery/attention states, and AI readiness.
- Keeps meetings available in Library too, and orders the primary sidebar and Go menu as Transcribe, Library, Dictations, Meetings.
- Reuses the existing meeting recording, calendar, library, recovery, and LLM setup primitives without a schema migration.
- Keeps recording control centralized in the top meeting recording tile. Upcoming calendar rows are read-only context, not per-event start buttons.
- Refreshes the scoped Meetings recent list after meeting completion and recovered recordings so it stays in sync with Library.

## Validation
- `swift test --filter MeetingsWorkspaceViewModelTests`
- `swift test --filter MainWindowStateTests`
- `swift test`
- `swift build`
- `MACPARAKEET_SKIP_WHISPERKIT=1 swift build --build-path .build-swift6-no-whisper -Xswiftc -swift-version -Xswiftc 6`
- `git diff --check` / `git diff --cached --check`
- `scripts/dev/run_app.sh` built and launched the debug app; the Meetings route was reachable from the Go menu. The smoke run exposed a duplicate active-recording affordance on calendar rows, which was removed before the final test pass.