### PR TITLE
Expose live Ask prompts in Meetings

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -108,7 +108,10 @@ final class AppEnvironmentConfigurer {
         )
         historyViewModel.configure(dictationRepo: env.dictationRepo)
         libraryViewModel.configure(transcriptionRepo: env.transcriptionRepo)
-        meetingsWorkspaceViewModel.configure(transcriptionRepo: env.transcriptionRepo)
+        meetingsWorkspaceViewModel.configure(
+            transcriptionRepo: env.transcriptionRepo,
+            quickPromptRepo: env.quickPromptRepo
+        )
         settingsViewModel.configure(
             permissionService: env.permissionService,
             dictationRepo: env.dictationRepo,

--- a/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
+++ b/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
@@ -14,6 +14,7 @@ struct MeetingsView: View {
     var onSelectMeeting: (Transcription) -> Void
 
     @State private var audioSaveErrorMessage: String?
+    @State private var showingAskPromptsSheet = false
 
     var body: some View {
         ScrollView {
@@ -59,6 +60,13 @@ struct MeetingsView: View {
             }
         } message: {
             Text(audioSaveErrorMessage ?? "Unable to save meeting audio.")
+        }
+        .sheet(isPresented: $showingAskPromptsSheet, onDismiss: {
+            viewModel.quickPromptsViewModel.cancelCreating()
+            viewModel.quickPromptsViewModel.editingPrompt = nil
+            viewModel.refreshQuickPrompts()
+        }) {
+            AskPromptsSheet(viewModel: viewModel.quickPromptsViewModel)
         }
     }
 
@@ -106,6 +114,7 @@ struct MeetingsView: View {
                 VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
                     attentionSection
                     intelligenceSection
+                    meetingPromptsSection
                 }
                 .frame(minWidth: 280, maxWidth: 340, alignment: .topLeading)
             }
@@ -115,6 +124,7 @@ struct MeetingsView: View {
                 recentMeetingsSection
                 attentionSection
                 intelligenceSection
+                meetingPromptsSection
             }
         }
     }
@@ -245,6 +255,22 @@ struct MeetingsView: View {
                     action: onOpenAISettings
                 )
             }
+        }
+    }
+
+    private var meetingPromptsSection: some View {
+        MeetingsSection(title: "Meeting Prompts", icon: "text.bubble") {
+            LiveAskPromptRow(
+                pinnedCount: viewModel.liveAskPromptVisiblePinnedCount,
+                previewPrompts: viewModel.liveAskPromptPreviewPrompts,
+                onManage: {
+                    showingAskPromptsSheet = true
+                },
+                onCreate: {
+                    viewModel.quickPromptsViewModel.startCreating()
+                    showingAskPromptsSheet = true
+                }
+            )
         }
     }
 
@@ -755,6 +781,104 @@ private struct IntelligenceReadyRow: View {
         }
         .padding(DesignSystem.Spacing.md)
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct LiveAskPromptRow: View {
+    let pinnedCount: Int
+    let previewPrompts: [QuickPrompt]
+    var onManage: () -> Void
+    var onCreate: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+            HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+                Image(systemName: "quote.bubble")
+                    .font(.system(size: 17, weight: .medium))
+                    .foregroundStyle(DesignSystem.Colors.accent)
+                    .frame(width: 22)
+
+                VStack(alignment: .leading, spacing: 5) {
+                    HStack(alignment: .firstTextBaseline, spacing: 7) {
+                        Text("Live Ask")
+                            .font(DesignSystem.Typography.body.weight(.semibold))
+                            .foregroundStyle(DesignSystem.Colors.textPrimary)
+
+                        if pinnedCount > 0 {
+                            Text("\(pinnedCount) pinned")
+                                .font(DesignSystem.Typography.micro.weight(.semibold))
+                                .foregroundStyle(DesignSystem.Colors.accent)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(Capsule().fill(DesignSystem.Colors.accent.opacity(0.12)))
+                        }
+                    }
+
+                    Text("Quick prompts available while a meeting is live.")
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: DesignSystem.Spacing.sm)
+            }
+
+            promptPreview
+
+            HStack(spacing: DesignSystem.Spacing.sm) {
+                Button(action: onManage) {
+                    Label("Manage", systemImage: "slider.horizontal.3")
+                }
+                .parakeetAction(.secondary)
+
+                Button(action: onCreate) {
+                    Label("New", systemImage: "plus")
+                }
+                .parakeetAction(.subtle)
+
+                Spacer(minLength: 0)
+            }
+        }
+        .padding(DesignSystem.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private var promptPreview: some View {
+        if previewPrompts.isEmpty {
+            Text("No pinned prompts yet.")
+                .font(DesignSystem.Typography.caption)
+                .foregroundStyle(DesignSystem.Colors.textTertiary)
+        } else {
+            HStack(spacing: 6) {
+                ForEach(previewPrompts) { prompt in
+                    Text(prompt.label)
+                        .font(DesignSystem.Typography.micro.weight(.medium))
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .frame(maxWidth: 92, alignment: .leading)
+                        .padding(.horizontal, 7)
+                        .padding(.vertical, 4)
+                        .background(
+                            Capsule()
+                                .fill(DesignSystem.Colors.surfaceElevated.opacity(0.72))
+                        )
+                        .overlay(
+                            Capsule()
+                                .strokeBorder(DesignSystem.Colors.border.opacity(0.5), lineWidth: 0.5)
+                        )
+                }
+
+                if pinnedCount > previewPrompts.count {
+                    Text("+\(pinnedCount - previewPrompts.count)")
+                        .font(DesignSystem.Typography.micro.weight(.semibold))
+                        .foregroundStyle(DesignSystem.Colors.textTertiary)
+                        .fixedSize()
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
     }
 }
 

--- a/Sources/MacParakeetViewModels/MeetingsWorkspaceViewModel.swift
+++ b/Sources/MacParakeetViewModels/MeetingsWorkspaceViewModel.swift
@@ -70,6 +70,7 @@ public final class MeetingsWorkspaceViewModel {
     public let meetingPillViewModel: MeetingRecordingPillViewModel
     public let settingsViewModel: SettingsViewModel
     public let llmSettingsViewModel: LLMSettingsViewModel
+    public let quickPromptsViewModel: QuickPromptsViewModel
 
     public private(set) var upcomingEvents: [CalendarEvent] = []
     public private(set) var isLoadingUpcomingEvents = false
@@ -87,12 +88,14 @@ public final class MeetingsWorkspaceViewModel {
         meetingPillViewModel: MeetingRecordingPillViewModel,
         settingsViewModel: SettingsViewModel,
         llmSettingsViewModel: LLMSettingsViewModel,
+        quickPromptsViewModel: QuickPromptsViewModel? = nil,
         calendarService: any CalendarServicing = CalendarService.shared
     ) {
         self.recentMeetingsViewModel = recentMeetingsViewModel
         self.meetingPillViewModel = meetingPillViewModel
         self.settingsViewModel = settingsViewModel
         self.llmSettingsViewModel = llmSettingsViewModel
+        self.quickPromptsViewModel = quickPromptsViewModel ?? QuickPromptsViewModel()
         self.calendarService = calendarService
     }
 
@@ -100,14 +103,21 @@ public final class MeetingsWorkspaceViewModel {
         upcomingEventsTask?.cancel()
     }
 
-    public func configure(transcriptionRepo: TranscriptionRepositoryProtocol) {
+    public func configure(
+        transcriptionRepo: TranscriptionRepositoryProtocol,
+        quickPromptRepo: QuickPromptRepositoryProtocol? = nil
+    ) {
         recentMeetingsViewModel.configure(transcriptionRepo: transcriptionRepo)
+        if let quickPromptRepo {
+            quickPromptsViewModel.configure(repo: quickPromptRepo)
+        }
     }
 
     public func refresh() {
         hasLoadedInitialState = true
         refreshRecentMeetings()
         refreshUpcomingEvents()
+        refreshQuickPrompts()
     }
 
     public func refreshIfNeeded() {
@@ -159,6 +169,18 @@ public final class MeetingsWorkspaceViewModel {
         }
         upcomingEventsTask = task
         return task
+    }
+
+    public func refreshQuickPrompts() {
+        quickPromptsViewModel.refresh()
+    }
+
+    public var liveAskPromptVisiblePinnedCount: Int {
+        quickPromptsViewModel.visiblePinned.count
+    }
+
+    public var liveAskPromptPreviewPrompts: [QuickPrompt] {
+        Array(quickPromptsViewModel.visiblePinned.prefix(2))
     }
 
     public var recordingStatus: RecordingStatus {

--- a/Tests/MacParakeetTests/ViewModels/MeetingsWorkspaceViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/MeetingsWorkspaceViewModelTests.swift
@@ -93,6 +93,81 @@ final class MeetingsWorkspaceViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.intelligenceStatus, .setupNeeded)
     }
 
+    func testConfigureLoadsLiveAskPromptPreview() throws {
+        let manager = try DatabaseManager()
+        let quickPromptRepo = QuickPromptRepository(dbQueue: manager.dbQueue)
+        let transcriptionRepo = TranscriptionRepository(dbQueue: manager.dbQueue)
+        let viewModel = makeViewModel()
+
+        viewModel.configure(
+            transcriptionRepo: transcriptionRepo,
+            quickPromptRepo: quickPromptRepo
+        )
+
+        XCTAssertEqual(
+            viewModel.quickPromptsViewModel.pinnedCount,
+            QuickPrompt.builtInPrompts().filter(\.isPinned).count
+        )
+        XCTAssertEqual(
+            viewModel.liveAskPromptVisiblePinnedCount,
+            viewModel.quickPromptsViewModel.visiblePinned.count
+        )
+        XCTAssertEqual(
+            viewModel.liveAskPromptPreviewPrompts.map(\.label),
+            viewModel.quickPromptsViewModel.visiblePinned.prefix(2).map(\.label)
+        )
+    }
+
+    func testRefreshQuickPromptsIsSafeBeforeRepositoryConfiguration() {
+        let viewModel = makeViewModel()
+
+        viewModel.refreshQuickPrompts()
+
+        XCTAssertTrue(viewModel.liveAskPromptPreviewPrompts.isEmpty)
+        XCTAssertEqual(viewModel.liveAskPromptVisiblePinnedCount, 0)
+        XCTAssertEqual(viewModel.quickPromptsViewModel.pinnedCount, 0)
+    }
+
+    func testLiveAskPromptPreviewIsEmptyWhenNoPromptsArePinned() throws {
+        let manager = try DatabaseManager()
+        let quickPromptRepo = QuickPromptRepository(dbQueue: manager.dbQueue)
+        let transcriptionRepo = TranscriptionRepository(dbQueue: manager.dbQueue)
+        let viewModel = makeViewModel()
+        viewModel.configure(
+            transcriptionRepo: transcriptionRepo,
+            quickPromptRepo: quickPromptRepo
+        )
+
+        for prompt in viewModel.quickPromptsViewModel.allPinned {
+            try quickPromptRepo.setPinned(id: prompt.id, isPinned: false)
+        }
+        viewModel.refreshQuickPrompts()
+
+        XCTAssertTrue(viewModel.liveAskPromptPreviewPrompts.isEmpty)
+        XCTAssertEqual(viewModel.liveAskPromptVisiblePinnedCount, 0)
+        XCTAssertEqual(viewModel.quickPromptsViewModel.pinnedCount, 0)
+    }
+
+    func testLiveAskPromptCountTracksVisiblePinnedPromptsAfterHiding() throws {
+        let manager = try DatabaseManager()
+        let quickPromptRepo = QuickPromptRepository(dbQueue: manager.dbQueue)
+        let transcriptionRepo = TranscriptionRepository(dbQueue: manager.dbQueue)
+        let viewModel = makeViewModel()
+        viewModel.configure(
+            transcriptionRepo: transcriptionRepo,
+            quickPromptRepo: quickPromptRepo
+        )
+
+        for prompt in viewModel.quickPromptsViewModel.visiblePinned {
+            try quickPromptRepo.toggleVisibility(id: prompt.id)
+        }
+        viewModel.refreshQuickPrompts()
+
+        XCTAssertTrue(viewModel.liveAskPromptPreviewPrompts.isEmpty)
+        XCTAssertEqual(viewModel.liveAskPromptVisiblePinnedCount, 0)
+        XCTAssertEqual(viewModel.quickPromptsViewModel.pinnedCount, 0)
+    }
+
     private func makeViewModel(
         calendarMode: CalendarAutoStartMode = .off,
         triggerFilter: MeetingTriggerFilter = .withLink,

--- a/docs/planning/2026-05-meeting-prompts-workspace-plan.md
+++ b/docs/planning/2026-05-meeting-prompts-workspace-plan.md
@@ -1,0 +1,190 @@
+# Meeting Prompts Workspace Plan
+
+Date: 2026-05-27
+Status: Active; Slice 1 implemented in `feat/meeting-prompts-workspace`
+
+## Decision
+
+Expose meeting prompt configuration from the dedicated Meetings workspace while
+keeping detailed editing in the existing prompt sheets.
+
+The Meetings page should become the control surface for meeting intelligence,
+not a second settings page and not a duplicate prompt library. The first slice
+should bridge to the existing live Ask quick prompts. Later slices can add
+meeting-scoped post-recording recipes that run against saved meeting artifacts.
+
+User-facing naming:
+
+- `Meeting Prompts` for the Meetings-page section.
+- `Live Ask` for the current `QuickPrompt` pills used in the live meeting Ask
+  tab.
+- `After Recording` or `Meeting Recipes` for saved-meeting prompt outputs backed
+  by `Prompt` and `PromptResult`.
+
+## Goals
+
+- Make prompt configuration discoverable before a meeting starts.
+- Keep the Meetings page workflow-oriented: upcoming, live, saved, attention,
+  intelligence readiness, and prompt controls.
+- Reuse the existing `AskPromptsSheet` for detailed live Ask prompt management.
+- Preserve the distinction between live Ask quick prompts and saved-meeting
+  prompt results.
+- Keep provider configuration in Settings > AI.
+- Preserve the privacy boundary: audio and transcription remain local-first;
+  transcript and notes are sent only when the user invokes provider-backed
+  intelligence.
+
+## Non-Goals
+
+- Do not build a full prompt admin page inside Meetings.
+- Do not replace `AskPromptsSheet`.
+- Do not merge `QuickPrompt` and `Prompt` into one model.
+- Do not introduce a new `meetings` table.
+- Do not add provider/model setup controls inside Meetings beyond readiness and
+  links to Settings > AI.
+- Do not auto-run meeting recipes on file, YouTube, or dictation artifacts.
+
+## Product Shape
+
+### Slice 1: Live Ask Prompt Bridge
+
+Add a compact `Meeting Prompts` section to the Meetings workspace right column.
+
+The section should show:
+
+- `Live Ask` title and short explanation.
+- Pinned prompt count.
+- Top pinned prompt labels, capped visually to keep the card scannable.
+- A `Manage` action that opens the existing `AskPromptsSheet`.
+- A `New` action that opens the same sheet in create mode.
+- An empty state if the quick-prompt repository is not configured yet or all
+  prompts are hidden.
+
+This slice should not add schema, prompt-result generation, or auto-run
+behavior. It is a discoverability bridge.
+
+### Slice 2: Meeting Recipe Defaults
+
+Add saved-meeting recipes backed by the existing prompt-result architecture:
+
+- Summary
+- Action Items
+- Decisions
+- Risks / Blockers
+- Follow-up Email
+
+Recipes should run against `Transcription.sourceType == .meeting` artifacts and
+persist as `PromptResult`. They should be source-scoped so meeting-specific
+prompts never show up as generic file/YouTube actions by accident.
+
+If the current `Prompt` metadata cannot express source scoping and display
+order, add the smallest durable metadata surface needed. Prefer extending prompt
+metadata over creating a new table unless the prompt model cannot carry the
+contract cleanly.
+
+### Slice 3: Saved Meeting Detail Integration
+
+Surface the same recipes on saved meeting detail:
+
+- Run
+- Regenerate
+- View Result
+- Copy/export result where existing prompt-result surfaces already support it
+
+The detail view should stay artifact-centered: transcript, notes, chat, prompt
+results, and retained audio belong together. The full editor still opens in a
+sheet.
+
+### Slice 4: Auto-Run Preferences
+
+After meeting-scoped recipes exist, add opt-in auto-run behavior:
+
+- Per-recipe enable/disable.
+- Optional "run after transcription completes" toggle.
+- Clear provider disclosure for external providers.
+- No auto-run for non-meeting sources.
+
+Default should be conservative until product usage says otherwise. A safe first
+default is all auto-run off, with one-click manual run.
+
+## Architecture Boundary
+
+Live Ask:
+
+- Model: `QuickPrompt`
+- View model: `QuickPromptsViewModel`
+- UI: `AskPromptsSheet`, `LiveAskPaneView`
+- Storage: `quick_prompts`
+- Use case: in-flight meeting chat starter and follow-up pills
+
+Saved meeting recipes:
+
+- Model: `Prompt`
+- Result model: `PromptResult`
+- View model: `PromptResultsViewModel`
+- UI: `TranscriptResultView` and future compact Meetings-page rows
+- Storage: existing prompt and prompt-result tables
+- Use case: post-meeting structured outputs
+
+The plan intentionally keeps these models separate because their lifecycles and
+UX contracts are different.
+
+## Implementation Notes
+
+Slice 1 implementation:
+
+- `MeetingsWorkspaceViewModel`
+  - Owns or receives a `QuickPromptsViewModel`.
+  - Exposes a small preview projection so the view avoids prompt filtering
+    logic.
+  - Refresh quick prompts when the Meetings page appears and when the sheet
+    closes.
+- `AppEnvironmentConfigurer`
+  - Configure that quick-prompt view model with `env.quickPromptRepo`.
+- `MeetingsView`
+  - Add a `Meeting Prompts` section to the right column, below intelligence or
+    near it.
+  - Present `AskPromptsSheet`.
+  - Start create mode before presenting the sheet when the user taps `New`.
+
+Slice 2 and later likely need source-scoped prompt metadata and tests. Do not
+start auto-run until source scoping is explicit.
+
+## Acceptance Criteria
+
+- Meetings page exposes `Meeting Prompts`.
+- Users can manage live Ask quick prompts from Meetings without opening a live
+  meeting panel first.
+- Users can create a new live Ask quick prompt from Meetings.
+- The existing Ask tab prompt manager remains the detailed editing surface.
+- The first slice adds no database migration.
+- The UI stays compact on the right column and stacks cleanly in the narrow
+  layout.
+- External-provider copy remains in the existing Intelligence section; the
+  prompt card does not imply local-only LLM processing.
+- No telemetry includes prompt text, transcript text, notes, or audio.
+
+## Review Risks
+
+- Avoid presenting pinned prompts as post-meeting recipes; they are live Ask
+  controls only.
+- Avoid a settings-page feel by limiting the card to summary state and two
+  actions.
+- Ensure the Meetings page refreshes after sheet dismissal.
+- Ensure `New` starts the create flow inside the sheet without skipping the
+  existing validation and save logic.
+- Ensure the view model can exist before environment configuration without
+  crashing; show a quiet empty state until the repository is available.
+
+## Open Questions
+
+- Should the first `New` prompt from Meetings default to pinned or remain
+  unpinned like the existing sheet? Current implementation should preserve the
+  existing unpinned default unless the product explicitly changes that contract.
+- Should meeting recipes auto-run by default after transcription, or should all
+  be manual first? Recommendation: manual first.
+- Should recipe preferences live on `Prompt` metadata or in a separate
+  preference store? Decide during Slice 2 after inspecting current prompt model
+  constraints.
+- Should `Summary` remain global or become source-scoped once meeting recipes
+  exist? Decide before auto-run.


### PR DESCRIPTION
## Summary

- Add a Meetings-page plan for prompt configuration and future meeting recipe slices.
- Expose Live Ask quick prompts from the Meetings workspace with a compact Meeting Prompts card.
- Reuse the existing AskPromptsSheet for Manage/New instead of adding a second prompt editor.
- Wire QuickPromptsViewModel into MeetingsWorkspaceViewModel and cover the new preview behavior with tests.

## Validation

- `swift test --filter MeetingsWorkspaceViewModelTests`
- `swift test`
- `git diff --check`

## Review Notes

- No schema migration in this slice.
- The Meetings card previews only visible pinned Live Ask prompts and caps chips for the narrow right column.
- Post-recording meeting recipes remain documented as a later slice, with source scoping required before auto-run behavior.