### PR TITLE
Fix Fn stop after pill-started dictation

### DIFF
--- a/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
+++ b/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
@@ -409,27 +409,14 @@ final class AppHotkeyCoordinator {
         _ activeMode: FnKeyStateMachine.RecordingMode?,
         for gestureMode: HotkeyGestureController.Mode
     ) -> FnKeyStateMachine.RecordingMode? {
-        guard let activeMode else { return nil }
-        switch (activeMode, gestureMode) {
-        case (.persistent, .singleTapToggle),
-             (.persistent, .doubleTapOnly),
-             (.persistent, .doubleTapAndHold),
-             (.holdToTalk, .holdOnly),
-             (.holdToTalk, .doubleTapAndHold):
-            return activeMode
-        case (.persistent, .holdOnly),
-             (.holdToTalk, .singleTapToggle),
-             (.holdToTalk, .doubleTapOnly):
-            return nil
-        }
+        HotkeyManager.resumeMode(activeMode, for: gestureMode)
     }
 
     static func shouldSuppressPeer(
         _ activeMode: FnKeyStateMachine.RecordingMode?,
         for gestureMode: HotkeyGestureController.Mode
     ) -> Bool {
-        guard activeMode != nil else { return false }
-        return resumeMode(activeMode, for: gestureMode) == nil
+        HotkeyManager.shouldSuppressPeer(activeMode, for: gestureMode)
     }
 
     func refreshAllHotkeys() {

--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -643,6 +643,9 @@ final class DictationFlowCoordinator {
             }
             onMenuBarIconUpdate(iconState)
 
+        case .syncHotkeyRecordingMode(let mode):
+            hotkeyManagers.forEach { $0.syncRecordingMode(mode) }
+
         case .resetHotkeyStateMachine:
             hotkeyManagers.forEach { $0.resetToIdle() }
 

--- a/Sources/MacParakeet/Hotkey/HotkeyManager.swift
+++ b/Sources/MacParakeet/Hotkey/HotkeyManager.swift
@@ -729,9 +729,44 @@ public final class HotkeyManager {
         activeRecordingMode = mode
     }
 
+    public func syncRecordingMode(_ mode: FnKeyStateMachine.RecordingMode) {
+        if let resumeMode = Self.resumeMode(mode, for: gestureMode) {
+            resumeRecording(mode: resumeMode)
+        } else {
+            suppressUntilReset()
+        }
+    }
+
     /// Reset state machine to idle (e.g., after cancel countdown expires).
     public func resetToIdle(flags: CGEventFlags? = nil) {
         resetGestureState(flags: flags, triggerKeyPressed: false)
+    }
+
+    static func resumeMode(
+        _ activeMode: FnKeyStateMachine.RecordingMode?,
+        for gestureMode: HotkeyGestureController.Mode
+    ) -> FnKeyStateMachine.RecordingMode? {
+        guard let activeMode else { return nil }
+        switch (activeMode, gestureMode) {
+        case (.persistent, .singleTapToggle),
+             (.persistent, .doubleTapOnly),
+             (.persistent, .doubleTapAndHold),
+             (.holdToTalk, .holdOnly),
+             (.holdToTalk, .doubleTapAndHold):
+            return activeMode
+        case (.persistent, .holdOnly),
+             (.holdToTalk, .singleTapToggle),
+             (.holdToTalk, .doubleTapOnly):
+            return nil
+        }
+    }
+
+    static func shouldSuppressPeer(
+        _ activeMode: FnKeyStateMachine.RecordingMode?,
+        for gestureMode: HotkeyGestureController.Mode
+    ) -> Bool {
+        guard activeMode != nil else { return false }
+        return resumeMode(activeMode, for: gestureMode) == nil
     }
 
     @discardableResult

--- a/Sources/MacParakeetCore/DictationFlow/DictationFlowStateMachine.swift
+++ b/Sources/MacParakeetCore/DictationFlow/DictationFlowStateMachine.swift
@@ -124,6 +124,7 @@ public enum DictationFlowEffect: Equatable, Sendable {
 
     // App integration
     case updateMenuBar(DictationFlowMenuBarState)
+    case syncHotkeyRecordingMode(mode: FnKeyStateMachine.RecordingMode)
     case resetHotkeyStateMachine
     case notifyHotkeyCancelledByUI
     case presentEntitlementsAlert
@@ -234,7 +235,7 @@ public struct DictationFlowStateMachine: Sendable, Equatable {
         case (.startingService(let mode), .recordingStarted(let gen)):
             guard gen == generation else { return [] }
             state = .recording(mode: mode)
-            return []
+            return [.syncHotkeyRecordingMode(mode: mode)]
 
         case (.startingService, .startFailed(let gen, let message)):
             guard gen == generation else { return [] }

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorTests.swift
@@ -5,6 +5,26 @@ import XCTest
 
 @MainActor
 final class DictationFlowCoordinatorTests: XCTestCase {
+    func testPillStartedPersistentRecordingSyncsFnHotkeyToStop() async throws {
+        let harness = try await makeRecordingHarness()
+        let fnManager = HotkeyManager(trigger: .fn)
+        harness.coordinator.hotkeyManagers = [fnManager]
+
+        harness.coordinator.startDictation(mode: .persistent, trigger: .pillClick)
+
+        let started = await waitUntil { self.isRecording(harness.coordinator.overlayStateForTesting) }
+        XCTAssertTrue(started)
+        XCTAssertEqual(
+            fnManager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_000
+            ),
+            [.stopRecording]
+        )
+
+        harness.coordinator.cancelDictation()
+    }
+
     func testSuccessfulMicPermissionRequestDismissesStaleStartFailure() async throws {
         let harness = try await makeMicPermissionHarness(
             microphonePermission: .notDetermined,
@@ -192,12 +212,12 @@ final class DictationFlowCoordinatorTests: XCTestCase {
             dictationRepo: repo
         )
 
-        let settingsDefaults = UserDefaults(suiteName: "mic-permission-settings-\(UUID().uuidString)")!
+        let settingsDefaults = makeTestDefaults(prefix: "mic-permission-settings")
         settingsDefaults.set(false, forKey: UserDefaultsAppRuntimePreferences.showIdlePillKey)
         let settings = SettingsViewModel(defaults: settingsDefaults)
 
         let preferences = UserDefaultsAppRuntimePreferences(
-            defaults: UserDefaults(suiteName: "mic-permission-preferences-\(UUID().uuidString)")!
+            defaults: makeTestDefaults(prefix: "mic-permission-preferences")
         )
         let entitlements = EntitlementsService(
             config: LicensingConfig(checkoutURL: nil, expectedVariantID: nil),
@@ -230,6 +250,57 @@ final class DictationFlowCoordinatorTests: XCTestCase {
         )
     }
 
+    private func makeRecordingHarness() async throws -> RecordingHarness {
+        let dbManager = try DatabaseManager()
+        let audio = MockAudioProcessor()
+        let stt = MockSTTClient()
+        let repo = DictationRepository(dbQueue: dbManager.dbQueue)
+        let service = DictationService(
+            audioProcessor: audio,
+            sttTranscriber: stt,
+            dictationRepo: repo
+        )
+
+        let settingsDefaults = makeTestDefaults(prefix: "recording-settings")
+        settingsDefaults.set(false, forKey: UserDefaultsAppRuntimePreferences.showIdlePillKey)
+        let settings = SettingsViewModel(defaults: settingsDefaults)
+        let preferences = UserDefaultsAppRuntimePreferences(
+            defaults: makeTestDefaults(prefix: "recording-preferences")
+        )
+        let entitlements = EntitlementsService(
+            config: LicensingConfig(checkoutURL: nil, expectedVariantID: nil),
+            store: InMemoryKeyValueStore(),
+            api: StubLicenseAPI()
+        )
+
+        let coordinator = DictationFlowCoordinator(
+            dictationService: service,
+            clipboardService: MockClipboardService(),
+            entitlementsService: entitlements,
+            dictationRepo: repo,
+            settingsViewModel: settings,
+            sttRuntime: AlwaysReadySTTReadinessChecker(),
+            runtimePreferences: preferences,
+            permissionService: MockPermissionService(),
+            overlayControllerFactory: { MicPermissionSpyDictationOverlayController(viewModel: $0) },
+            onMenuBarIconUpdate: { _ in },
+            onHistoryReload: {},
+            onPresentEntitlementsAlert: { _ in }
+        )
+
+        return RecordingHarness(coordinator: coordinator)
+    }
+
+    private func makeTestDefaults(prefix: String) -> UserDefaults {
+        let suiteName = "\(prefix)-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        addTeardownBlock {
+            UserDefaults(suiteName: suiteName)?.removePersistentDomain(forName: suiteName)
+        }
+        return defaults
+    }
+
     private func waitUntil(
         timeoutMs: UInt64 = 1200,
         condition: @escaping @MainActor () -> Bool
@@ -242,10 +313,20 @@ final class DictationFlowCoordinatorTests: XCTestCase {
         return condition()
     }
 
+    private func isRecording(_ state: DictationOverlayViewModel.OverlayState?) -> Bool {
+        guard let state else { return false }
+        if case .recording = state { return true }
+        return false
+    }
+
     private struct MicPermissionHarness {
         let coordinator: DictationFlowCoordinator
         let audio: MockAudioProcessor
         let permissionService: MockPermissionService
+    }
+
+    private struct RecordingHarness {
+        let coordinator: DictationFlowCoordinator
     }
 }
 

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowStateMachineTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowStateMachineTests.swift
@@ -269,7 +269,7 @@ final class DictationFlowStateMachineTests: XCTestCase {
 
         let effects = m.handle(.recordingStarted(generation: gen))
         XCTAssertEqual(m.state, .recording(mode: .holdToTalk))
-        XCTAssertTrue(effects.isEmpty) // audio level loop starts externally
+        XCTAssertEqual(effects, [.syncHotkeyRecordingMode(mode: .holdToTalk)])
     }
 
     func testStartingServiceStartFailed() {

--- a/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
@@ -701,6 +701,44 @@ final class HotkeyManagerTests: XCTestCase {
         )
     }
 
+    func testSyncedPersistentRecordingFromExternalSurfaceMakesFnPressStop() {
+        let manager = HotkeyManager(trigger: .fn)
+
+        manager.syncRecordingMode(.persistent)
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_000
+            ),
+            [.stopRecording]
+        )
+    }
+
+    func testSyncedPersistentRecordingSuppressesHoldOnlyPeerUntilReset() {
+        let manager = HotkeyManager(trigger: .option, gestureMode: .holdOnly)
+
+        manager.syncRecordingMode(.persistent)
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskAlternate],
+                timestampMs: 1_000
+            ),
+            []
+        )
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [])
+
+        manager.resetToIdle(flags: [])
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskAlternate],
+                timestampMs: 2_000
+            ),
+            [.scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs)]
+        )
+    }
+
     func testChordTriggerKeyUpPassesThroughWhenChordWasNotHandled() {
         let trigger = HotkeyTrigger.chord(modifiers: ["control", "shift"], keyCode: 15)
         let manager = HotkeyManager(trigger: trigger)


### PR DESCRIPTION
## Summary
- sync hotkey managers when dictation reaches recording from non-hotkey surfaces
- centralize active-mode compatibility policy in HotkeyManager so rebuild-time and runtime sync use the same rules
- add regression coverage for pill click start followed by Fn stop

Fixes #379

## Root Cause
Pill/menu starts drove DictationFlowCoordinator directly, so the service entered recording while Fn HotkeyManager stayed internally idle. Pressing Fn was treated as a new start gesture while the flow was already recording, which hit the existing rapid-restart/cancel path instead of stopping the current capture.

## Tests
- swift test --filter DictationFlowCoordinatorTests/testPillStartedPersistentRecordingSyncsFnHotkeyToStop --filter DictationFlowStateMachineTests/testStartingServiceRecordingStarted --filter HotkeyManagerTests/testSyncedPersistentRecording --filter AppHotkeyCoordinatorTests/testResumeModeMatchesActiveDictationRole
- swift test --filter HotkeyManagerTests --filter DictationFlowCoordinatorTests --filter DictationFlowStateMachineTests --filter AppHotkeyCoordinatorTests
- git diff --check
- swift test