### PR TITLE
Fix first-word clipping: decouple media pause from dictation capture start (#383)

### DIFF
--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -865,7 +865,12 @@ final class DictationFlowCoordinator {
         recordingTask = Task { @MainActor in
             do {
                 try Task.checkCancellation()
-                await self.mediaPauseCoordinator.pauseBeforeDictationCapture()
+                // Fire-and-forget: the media-pause round-trip must not gate
+                // capture start, or its out-of-process now-playing lookup
+                // clips the first words of the dictation. The coordinator's
+                // generation guard keeps resume correct if capture ends before
+                // the pause settles.
+                self.mediaPauseCoordinator.requestPauseBeforeDictationCapture()
                 try Task.checkCancellation()
                 try await self.serviceSession.startRecording(
                     sessionID: sessionID,

--- a/Sources/MacParakeet/App/DictationMediaPauseCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationMediaPauseCoordinator.swift
@@ -5,7 +5,7 @@ import OSLog
 
 @MainActor
 protocol DictationMediaPauseCoordinating: AnyObject {
-    func pauseBeforeDictationCapture() async
+    func requestPauseBeforeDictationCapture()
     func resumeAfterDictationCapture() async
     func resumeForTermination()
 }
@@ -22,6 +22,10 @@ final class DictationMediaPauseCoordinator: DictationMediaPauseCoordinating {
 
     private var activeToken: MediaPauseToken?
     private var generation = 0
+    /// In-flight media-pause round-trip. Tracked so it never gates capture
+    /// start, and so tests can deterministically await the IPC. `private(set)`
+    /// keeps it readable from `@testable` tests without external mutation.
+    private(set) var pauseTask: Task<Void, Never>?
 
     init(
         settingsViewModel: SettingsViewModel,
@@ -33,9 +37,28 @@ final class DictationMediaPauseCoordinator: DictationMediaPauseCoordinating {
         self.isMeetingRecordingActive = isMeetingRecordingActive
     }
 
-    func pauseBeforeDictationCapture() async {
+    /// Kick off media pause without blocking the caller.
+    ///
+    /// The generation claim and the cheap, synchronous guards run on the
+    /// current MainActor turn, so a subsequent `resumeAfterDictationCapture()`
+    /// (which also bumps `generation` synchronously) is always correctly
+    /// ordered against this request: if capture ends before the pause IPC
+    /// settles, the in-flight task sees the generation change and resumes the
+    /// token it acquired instead of leaving media stuck paused.
+    ///
+    /// Only the now-playing snapshot + pause command — an out-of-process
+    /// round-trip that previously front-loaded hundreds of milliseconds onto
+    /// every dictation press and clipped the first words — runs in the
+    /// detached child task, concurrently with audio capture start.
+    func requestPauseBeforeDictationCapture() {
         generation += 1
         let pauseGeneration = generation
+
+        // Abandon any still-in-flight pause from a previous request. The
+        // generation bump above already invalidates it; cancelling also lets
+        // it short-circuit before spawning the round-trip if it hasn't started.
+        pauseTask?.cancel()
+        pauseTask = nil
 
         guard activeToken == nil else { return }
 
@@ -49,18 +72,28 @@ final class DictationMediaPauseCoordinator: DictationMediaPauseCoordinating {
             return
         }
 
-        guard let token = await mediaController.pauseIfPlaying() else { return }
-
-        guard generation == pauseGeneration else {
-            await mediaController.resume(token)
-            return
+        pauseTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            // Capture already ended before this task even ran — skip the
+            // round-trip entirely; nothing was paused, so nothing to resume.
+            guard !Task.isCancelled else { return }
+            guard let token = await self.mediaController.pauseIfPlaying() else { return }
+            // Capture ended (cancel/resume bumped generation, or this task was
+            // cancelled) while the round-trip was in flight: release the token
+            // instead of arming a pause nobody will resume. The generation
+            // check is the authoritative guard; the cancellation check is a
+            // best-effort fast path.
+            guard !Task.isCancelled, self.generation == pauseGeneration else {
+                await self.mediaController.resume(token)
+                return
+            }
+            self.activeToken = token
         }
-
-        activeToken = token
     }
 
     func resumeAfterDictationCapture() async {
         generation += 1
+        pauseTask?.cancel()
         guard let token = activeToken else { return }
         activeToken = nil
         await mediaController.resume(token)
@@ -68,6 +101,7 @@ final class DictationMediaPauseCoordinator: DictationMediaPauseCoordinating {
 
     func resumeForTermination() {
         generation += 1
+        pauseTask?.cancel()
         guard let token = activeToken else { return }
         activeToken = nil
         let mediaController = mediaController
@@ -82,7 +116,7 @@ final class DictationMediaPauseCoordinator: DictationMediaPauseCoordinating {
 
 @MainActor
 final class NoOpDictationMediaPauseCoordinator: DictationMediaPauseCoordinating {
-    func pauseBeforeDictationCapture() async {}
+    func requestPauseBeforeDictationCapture() {}
     func resumeAfterDictationCapture() async {}
     func resumeForTermination() {}
 }

--- a/Tests/MacParakeetTests/DictationFlow/DictationMediaPauseCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationMediaPauseCoordinatorTests.swift
@@ -112,7 +112,8 @@ final class DictationMediaPauseCoordinatorTests: XCTestCase {
         let media = FakeSystemMediaController(pauseBehavior: .immediate(token))
         let coordinator = makeCoordinator(media: media)
 
-        await coordinator.pauseBeforeDictationCapture()
+        coordinator.requestPauseBeforeDictationCapture()
+        await coordinator.pauseTask?.value
         await coordinator.resumeAfterDictationCapture()
 
         let snapshot = media.snapshot()
@@ -126,7 +127,8 @@ final class DictationMediaPauseCoordinatorTests: XCTestCase {
         let media = FakeSystemMediaController(pauseBehavior: .immediate(token))
         let coordinator = makeCoordinator(media: media, isMeetingRecordingActive: true)
 
-        await coordinator.pauseBeforeDictationCapture()
+        coordinator.requestPauseBeforeDictationCapture()
+        await coordinator.pauseTask?.value
         await coordinator.resumeAfterDictationCapture()
 
         let snapshot = media.snapshot()
@@ -140,8 +142,10 @@ final class DictationMediaPauseCoordinatorTests: XCTestCase {
         let media = FakeSystemMediaController(pauseBehavior: .immediate(token))
         let coordinator = makeCoordinator(media: media)
 
-        await coordinator.pauseBeforeDictationCapture()
-        await coordinator.pauseBeforeDictationCapture()
+        coordinator.requestPauseBeforeDictationCapture()
+        await coordinator.pauseTask?.value
+        coordinator.requestPauseBeforeDictationCapture()
+        await coordinator.pauseTask?.value
         await coordinator.resumeAfterDictationCapture()
         await coordinator.resumeAfterDictationCapture()
 
@@ -155,12 +159,43 @@ final class DictationMediaPauseCoordinatorTests: XCTestCase {
         let media = FakeSystemMediaController(pauseBehavior: .immediate(nil))
         let coordinator = makeCoordinator(media: media)
 
-        await coordinator.pauseBeforeDictationCapture()
+        coordinator.requestPauseBeforeDictationCapture()
+        await coordinator.pauseTask?.value
         await coordinator.resumeAfterDictationCapture()
 
         let snapshot = media.snapshot()
         XCTAssertEqual(snapshot.pauseCallCount, 1)
         XCTAssertEqual(snapshot.resumeTokens, [])
+    }
+
+    /// The fix: `requestPauseBeforeDictationCapture()` must return without
+    /// waiting on the (potentially slow) now-playing round-trip, so audio
+    /// capture starts immediately and the first words are never clipped.
+    func testRequestPauseDoesNotBlockOnMediaRoundTrip() async {
+        settings.pauseMediaDuringDictation = true
+        let token = MediaPauseToken(processIdentifier: 1)
+        let media = FakeSystemMediaController(pauseBehavior: .deferred)
+        let coordinator = makeCoordinator(media: media)
+        let pauseStarted = expectation(description: "pause request started")
+        media.setPauseStartedHandler {
+            pauseStarted.fulfill()
+        }
+
+        // Synchronous: returns even though the media round-trip is still in
+        // flight (it never resolves until completeDeferredPause below).
+        coordinator.requestPauseBeforeDictationCapture()
+        await fulfillment(of: [pauseStarted], timeout: 1)
+
+        // Clean up the in-flight pause so the task settles deterministically.
+        await coordinator.resumeAfterDictationCapture()
+        media.completeDeferredPause(with: token)
+        await coordinator.pauseTask?.value
+
+        // The round-trip ran once and its late-arriving token was resumed,
+        // never left paused.
+        let snapshot = media.snapshot()
+        XCTAssertEqual(snapshot.pauseCallCount, 1)
+        XCTAssertEqual(snapshot.resumeTokens, [token])
     }
 
     func testLatePauseTokenIsReleasedIfCaptureEndsBeforePauseCompletes() async {
@@ -173,15 +208,15 @@ final class DictationMediaPauseCoordinatorTests: XCTestCase {
             pauseStarted.fulfill()
         }
 
-        let pauseTask = Task {
-            await coordinator.pauseBeforeDictationCapture()
-        }
+        coordinator.requestPauseBeforeDictationCapture()
         await fulfillment(of: [pauseStarted], timeout: 1)
 
+        // Capture ends (resume) before the pause round-trip settles.
         await coordinator.resumeAfterDictationCapture()
         media.completeDeferredPause(with: token)
-        await pauseTask.value
+        await coordinator.pauseTask?.value
 
+        // The late-arriving pause token must be resumed, not left stuck paused.
         let snapshot = media.snapshot()
         XCTAssertEqual(snapshot.pauseCallCount, 1)
         XCTAssertEqual(snapshot.resumeTokens, [token])
@@ -193,7 +228,8 @@ final class DictationMediaPauseCoordinatorTests: XCTestCase {
         let media = FakeSystemMediaController(pauseBehavior: .immediate(token))
         let coordinator = makeCoordinator(media: media)
 
-        await coordinator.pauseBeforeDictationCapture()
+        coordinator.requestPauseBeforeDictationCapture()
+        await coordinator.pauseTask?.value
         coordinator.resumeForTermination()
 
         try await waitUntil {


### PR DESCRIPTION
## Summary

Fixes #383 — with **Pause media during dictation** enabled, push-to-talk clipped the first 1–3 words unless the user deliberately paused after pressing the hotkey.

The reporter (Mustard, v0.6.13, M1 Max) suspected the Anthropic API key he'd just added changed the press-time decision path. His instinct that *something at press time adds latency* was right, but the culprit is the **media-pause now-playing lookup**, not the API key — the dictation start path never reads LLM/API/keychain state. The two changes coincided in the same setup session.

## Root cause

`DictationMediaPauseCoordinator.pauseBeforeDictationCapture()` was `await`ed in `DictationFlowCoordinator.startRecordingTask` **before** `serviceSession.startRecording()`. Its now-playing snapshot reader spawns `/usr/bin/osascript` (JXA → MediaRemote) with a **1.25s ceiling** (`SystemMediaController`), so hundreds of ms of out-of-process round-trip sat directly in front of `audioProcessor.startCapture()`. Speech during that window was lost — exactly the reported 1–3 words, and exactly why pausing-after-press masks it.

## Fix

Pausing media is logically independent of starting the mic, so it must never gate capture:

- `pauseBeforeDictationCapture() async` → synchronous, fire-and-forget `requestPauseBeforeDictationCapture()`.
- The `generation` claim + cheap guards (setting off / meeting active / token held) stay **synchronous** on the MainActor turn.
- Only the now-playing snapshot + pause command run in a detached child task, concurrently with capture start.
- `startRecordingTask` drops the `await`, so the mic tap goes live immediately.

### Why the obvious one-liner is wrong

Naively dropping the `await` (whole method in a fresh `Task`) defers the generation claim. On a quick press-release, `resumeAfterDictationCapture()` could run first and no-op, then the pause task acquires a token and **leaves media stuck paused**. Keeping the claim synchronous guarantees resume is always ordered after it; the in-flight task then sees the generation change and resumes the token it acquired.

## Tests

- **New** `testRequestPauseDoesNotBlockOnMediaRoundTrip` — request returns while the media round-trip is still pending (the decoupling guarantee).
- `testLatePauseTokenIsReleasedIfCaptureEndsBeforePauseCompletes` — preserved race coverage: capture ending before pause settles must resume, not strand, the token.
- Existing pause/resume/meeting/termination cases updated to the sync API.
- Full suite: **3020 XCTests, 0 failures** (9 skipped) + Swift Testing suites green.

## Follow-up (not in this PR)

The residual bleed window (media audible into the mic until pause settles) is inherent to starting capture before media is paused. The real cure is replacing the `osascript` spawn with a fast in-process MediaRemote snapshot — worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)