### PR TITLE
Set time expectation in first-load speech-engine caption

### DIFF
--- a/Sources/MacParakeet/Views/Dictation/LoadingCaptionView.swift
+++ b/Sources/MacParakeet/Views/Dictation/LoadingCaptionView.swift
@@ -45,7 +45,7 @@ struct LoadingCaptionView: View {
     private var subcopy: String? {
         switch caption {
         case .preparingExtended:
-            "First-time setup — this happens once"
+            "First-time setup — may take a few minutes"
         case .preparing, .failed:
             nil
         }


### PR DESCRIPTION
## Summary
- The slow "Preparing speech engine…" state is a one-time-per-binary Apple Neural Engine compile of the Parakeet CoreML model. Verified empirically: relaunching the **same** build does **not** recompile (ANECompilerService stays at 0%, ready in ~13s), so only the first load after a new binary is slow.
- Changes the extended warmup subcopy from "First-time setup — this happens once" → **"First-time setup — may take a few minutes"** so users expect the multi-minute wait instead of suspecting a hang.
- The 4s escalation threshold (plain caption → extended caption) is unchanged.

## Why
The previous copy reassured but gave no time cue, and slightly overclaimed "once" (it recompiles after app updates too). One-line copy change.

## Test plan
- `swift build --target MacParakeet`
- Existing `DictationFlowCoordinatorLoadCaptionTests` still cover the escalation timing (no string assertion on the subcopy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)