### PR TITLE
Harden Meetings page for release: recurring-meeting preview fix + Ask Prompts copy

### DIFF
--- a/Sources/MacParakeet/Views/MeetingRecording/AskPromptsSheet.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/AskPromptsSheet.swift
@@ -38,7 +38,7 @@ struct AskPromptsSheet: View {
                     zone(
                         title: "Pinned",
                         countSuffix: "\(viewModel.pinnedCount)",
-                        subtitle: "Your most-used questions, shown as one-tap buttons during a live meeting. The order here is the order you'll see them in.",
+                        subtitle: "Your most-used questions, shown as quick buttons during a live meeting. The order here is the order you'll see them in.",
                         rows: viewModel.allPinned,
                         pinned: true
                     )
@@ -140,7 +140,7 @@ struct AskPromptsSheet: View {
                 Text("Ask Prompts")
                     .font(DesignSystem.Typography.heroTitle)
                     .foregroundStyle(DesignSystem.Colors.textPrimary)
-                Text("Reusable questions for live meetings. Pin the ones you reach for most to keep them a single tap away — the rest stay in your library, ready when you need them.")
+                Text("Reusable questions for live meetings. Pin the ones you reach for most to keep them front and center — the rest stay in your library, ready when you need them.")
                     .font(DesignSystem.Typography.body)
                     .foregroundStyle(DesignSystem.Colors.textSecondary)
             }
@@ -228,7 +228,7 @@ struct AskPromptsSheet: View {
                 Image(systemName: pinned ? "pin.slash" : "tray")
                     .font(.system(size: 14))
                     .foregroundStyle(DesignSystem.Colors.textTertiary)
-                Text(pinned ? "No pinned questions yet. Pin one below to keep it a tap away during meetings." : "No questions yet. Add one below.")
+                Text(pinned ? "No pinned questions yet. Pin one below to keep it handy during meetings." : "No questions yet. Add one below.")
                     .font(DesignSystem.Typography.body)
                     .foregroundStyle(DesignSystem.Colors.textSecondary)
                 Spacer()
@@ -688,7 +688,7 @@ private struct CreatePromptSheet: View {
                             placeholder: "CATCH UP / CAPTURE / CHALLENGE"
                         )
                         promptField
-                        Text("New prompts start unpinned. Tap the pin icon in the list to keep one a tap away during meetings.")
+                        Text("New prompts start unpinned. Click the pin icon in the list to keep one handy during meetings.")
                             .font(DesignSystem.Typography.bodySmall)
                             .foregroundStyle(DesignSystem.Colors.textTertiary)
                     }

--- a/Sources/MacParakeet/Views/MeetingRecording/AskPromptsSheet.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/AskPromptsSheet.swift
@@ -38,7 +38,7 @@ struct AskPromptsSheet: View {
                     zone(
                         title: "Pinned",
                         countSuffix: "\(viewModel.pinnedCount)",
-                        subtitle: "Compact pills shown in the after-response strip. Order here controls strip order.",
+                        subtitle: "Your most-used questions, shown as one-tap buttons during a live meeting. The order here is the order you'll see them in.",
                         rows: viewModel.allPinned,
                         pinned: true
                     )
@@ -46,7 +46,7 @@ struct AskPromptsSheet: View {
                     zone(
                         title: "All prompts",
                         countSuffix: nil,
-                        subtitle: "Shown when the Ask tab is empty and inside the sparkle menu mid-conversation. Optional group label clusters related prompts (CATCH UP, CAPTURE, CHALLENGE).",
+                        subtitle: "Your full question library. These appear when you open Ask and in the ✨ menu while you're chatting. Add a group label to keep related questions together (CATCH UP, CAPTURE, CHALLENGE).",
                         rows: viewModel.allUnpinned,
                         pinned: false
                     )
@@ -140,7 +140,7 @@ struct AskPromptsSheet: View {
                 Text("Ask Prompts")
                     .font(DesignSystem.Typography.heroTitle)
                     .foregroundStyle(DesignSystem.Colors.textPrimary)
-                Text("One library. Pinned prompts surface as quick pills after a response; everything else shows in the empty Ask state and sparkle menu.")
+                Text("Reusable questions for live meetings. Pin the ones you reach for most to keep them a single tap away — the rest stay in your library, ready when you need them.")
                     .font(DesignSystem.Typography.body)
                     .foregroundStyle(DesignSystem.Colors.textSecondary)
             }
@@ -228,7 +228,7 @@ struct AskPromptsSheet: View {
                 Image(systemName: pinned ? "pin.slash" : "tray")
                     .font(.system(size: 14))
                     .foregroundStyle(DesignSystem.Colors.textTertiary)
-                Text(pinned ? "No pinned prompts. Pin a prompt below to surface it as a quick pill." : "No prompts. Add one below.")
+                Text(pinned ? "No pinned questions yet. Pin one below to keep it a tap away during meetings." : "No prompts. Add one below.")
                     .font(DesignSystem.Typography.body)
                     .foregroundStyle(DesignSystem.Colors.textSecondary)
                 Spacer()
@@ -688,7 +688,7 @@ private struct CreatePromptSheet: View {
                             placeholder: "CATCH UP / CAPTURE / CHALLENGE"
                         )
                         promptField
-                        Text("New prompts start unpinned. Use the pin icon in the list to surface a prompt as a quick pill.")
+                        Text("New prompts start unpinned. Tap the pin icon in the list to keep one a tap away during meetings.")
                             .font(DesignSystem.Typography.bodySmall)
                             .foregroundStyle(DesignSystem.Colors.textTertiary)
                     }

--- a/Sources/MacParakeet/Views/MeetingRecording/AskPromptsSheet.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/AskPromptsSheet.swift
@@ -228,7 +228,7 @@ struct AskPromptsSheet: View {
                 Image(systemName: pinned ? "pin.slash" : "tray")
                     .font(.system(size: 14))
                     .foregroundStyle(DesignSystem.Colors.textTertiary)
-                Text(pinned ? "No pinned questions yet. Pin one below to keep it a tap away during meetings." : "No prompts. Add one below.")
+                Text(pinned ? "No pinned questions yet. Pin one below to keep it a tap away during meetings." : "No questions yet. Add one below.")
                     .font(DesignSystem.Typography.body)
                     .foregroundStyle(DesignSystem.Colors.textSecondary)
                 Spacer()

--- a/Sources/MacParakeetViewModels/MeetingsWorkspaceViewModel.swift
+++ b/Sources/MacParakeetViewModels/MeetingsWorkspaceViewModel.swift
@@ -154,10 +154,9 @@ public final class MeetingsWorkspaceViewModel {
             do {
                 let events = try await calendarService.fetchUpcomingEvents(days: lookAheadDays)
                 guard let self, !Task.isCancelled, self.upcomingEventsGeneration == generation else { return }
-                self.upcomingEvents = Array(
-                    events
-                        .filter { event in self.shouldShowCalendarEvent(event) }
-                        .prefix(max(0, eventLimit))
+                self.upcomingEvents = Self.collapseRecurringOccurrences(
+                    events.filter { event in self.shouldShowCalendarEvent(event) },
+                    limit: eventLimit
                 )
                 self.isLoadingUpcomingEvents = false
             } catch {
@@ -318,5 +317,34 @@ public final class MeetingsWorkspaceViewModel {
         case .allEvents:
             return true
         }
+    }
+
+    /// Collapses occurrences of a recurring series down to its soonest
+    /// occurrence, then caps the list to `limit`.
+    ///
+    /// Every occurrence of a recurring series shares one `CalendarEvent.id`
+    /// (EventKit's `eventIdentifier` — see the identity note in
+    /// `CalendarEvent.swift`). Two reasons this matters here:
+    ///   1. The "Upcoming" preview should list *distinct* meetings, not the
+    ///      same daily standup four times pushing every other meeting out of a
+    ///      4-row preview.
+    ///   2. The view renders `ForEach(upcomingEvents)` keyed on `id`, so
+    ///      duplicate ids would give SwiftUI "undefined results" (collapsed or
+    ///      mis-diffed rows).
+    /// This collapse is display-only: `MeetingMonitor`/the coordinator still
+    /// act on *every* occurrence (they key on `dedupeKey`, id + start time).
+    /// Picks the soonest occurrence per id regardless of input order so the
+    /// preview never depends on the service's sort guarantee.
+    static func collapseRecurringOccurrences(_ events: [CalendarEvent], limit: Int) -> [CalendarEvent] {
+        var soonestByID: [String: CalendarEvent] = [:]
+        for event in events {
+            if let existing = soonestByID[event.id], existing.startTime <= event.startTime { continue }
+            soonestByID[event.id] = event
+        }
+        return Array(
+            soonestByID.values
+                .sorted { $0.startTime < $1.startTime }
+                .prefix(max(0, limit))
+        )
     }
 }

--- a/Tests/MacParakeetTests/ViewModels/MeetingsWorkspaceViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/MeetingsWorkspaceViewModelTests.swift
@@ -148,6 +148,43 @@ final class MeetingsWorkspaceViewModelTests: XCTestCase {
         }
     }
 
+    func testUpcomingPreviewCollapsesRecurringOccurrencesToSoonest() async {
+        // A recurring series returns one CalendarEvent per occurrence, all
+        // sharing EventKit's `eventIdentifier` (= CalendarEvent.id). The preview
+        // must collapse them to the soonest occurrence — both so the list shows
+        // distinct meetings and because ForEach keys on `id` (duplicate ids give
+        // SwiftUI undefined rendering). Coordinator behavior is unaffected; it
+        // keys on dedupeKey and still acts on every occurrence.
+        let calendar = MockCalendarService()
+        calendar.stubPermissionStatus = .granted
+        let base = Date().addingTimeInterval(3600)
+        // Deliberately unsorted, with the soonest standup in the middle, to
+        // prove the collapse picks soonest by start time, not array order.
+        calendar.stubEvents = [
+            makeEvent(title: "Standup Wed", meetUrl: "https://zoom.us/j/1", id: "standup", startTime: base.addingTimeInterval(2 * 86_400)),
+            makeEvent(title: "Standup Mon", meetUrl: "https://zoom.us/j/1", id: "standup", startTime: base),
+            makeEvent(title: "Standup Tue", meetUrl: "https://zoom.us/j/1", id: "standup", startTime: base.addingTimeInterval(86_400)),
+            makeEvent(title: "1:1", meetUrl: "https://zoom.us/j/2", id: "one-on-one", startTime: base.addingTimeInterval(3 * 86_400))
+        ]
+        let viewModel = makeViewModel(
+            calendarMode: .notify,
+            triggerFilter: .withLink,
+            calendarService: calendar
+        )
+        viewModel.settingsViewModel.calendarPermissionStatus = .granted
+
+        await viewModel.refreshUpcomingEvents().value
+
+        guard AppFeatures.calendarEnabled else {
+            XCTAssertTrue(viewModel.upcomingEvents.isEmpty)
+            return
+        }
+        // One row per series, soonest occurrence wins, ordered by start time.
+        XCTAssertEqual(viewModel.upcomingEvents.map(\.title), ["Standup Mon", "1:1"])
+        // No duplicate ids reach the id-keyed ForEach.
+        XCTAssertEqual(Set(viewModel.upcomingEvents.map(\.id)).count, viewModel.upcomingEvents.count)
+    }
+
     func testRecordingStatusTracksMeetingPillState() {
         let pill = MeetingRecordingPillViewModel()
         let viewModel = makeViewModel(meetingPillViewModel: pill)
@@ -277,15 +314,18 @@ final class MeetingsWorkspaceViewModelTests: XCTestCase {
     private func makeEvent(
         title: String,
         meetUrl: String?,
+        id: String? = nil,
+        startTime: Date? = nil,
         calendarIdentifier: String? = nil,
         userStatus: EventParticipant.ParticipantStatus? = nil,
         isAllDay: Bool = false
     ) -> CalendarEvent {
-        CalendarEvent(
-            id: UUID().uuidString,
+        let start = startTime ?? Date().addingTimeInterval(3600)
+        return CalendarEvent(
+            id: id ?? UUID().uuidString,
             title: title,
-            startTime: Date().addingTimeInterval(3600),
-            endTime: Date().addingTimeInterval(5400),
+            startTime: start,
+            endTime: start.addingTimeInterval(1800),
             meetUrl: meetUrl,
             participants: [EventParticipant(name: "Ava")],
             isAllDay: isAllDay,


### PR DESCRIPTION
Pre-release hardening of the new Meetings page. Two independent changes:

## 1. Fix recurring-meeting collapse in the Upcoming preview 🔴
`CalendarEvent.id` is EventKit's `eventIdentifier`, which is **shared across every occurrence of a recurring series** — the identity note in `CalendarEvent.swift` explicitly warns that `id` is not occurrence-unique and that occurrence-level work must key on `dedupeKey`.

The new Meetings UI renders `ForEach(viewModel.upcomingEvents)` keyed on `id` (plus an `event.id != last?.id` hairline check). A user with a **daily standup** gets multiple occurrences sharing one `id` inside the 7-day fetch window → SwiftUI duplicate-ID "undefined results" (collapsed / mis-diffed rows) in the preview. The existing test mock never caught it because every `makeEvent` got a fresh UUID.

**Fix:** `MeetingsWorkspaceViewModel` now collapses occurrences to the **soonest per series** before capping to `upcomingEventLimit` (new `collapseRecurringOccurrences` helper). Display-only — the coordinator still acts on every occurrence via `dedupeKey`. Bonus UX: the preview shows distinct meetings instead of the same standup four times. New regression test `testUpcomingPreviewCollapsesRecurringOccurrencesToSoonest`.

## 2. Audience-friendly Ask Prompts copy ✍️
Rewrote the five instruction strings in `AskPromptsSheet` to drop internal jargon ("surface as quick pills", "after-response strip", "empty Ask state", "sparkle menu", "group label clusters") for plain language. References the user-visible ✨ menu and Ask tab directly.

## Testing
- `swift test`: **3037 tests, 0 failures, 9 skipped**
- `swift build --target MacParakeet`: clean (copy is app-target only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)