### PR TITLE
Meeting VAD-guided live chunking (Phases 1–4, flag-off)

### DIFF
--- a/Sources/MacParakeetCore/AppFeatures.swift
+++ b/Sources/MacParakeetCore/AppFeatures.swift
@@ -44,4 +44,17 @@ public enum AppFeatures {
     /// Enabled once the website telemetry allowlist accepts
     /// `transform_executed` / `transform_failed` (ADR-022 §9).
     public static let transformsEnabled: Bool = true
+
+    /// VAD-guided meeting live chunking
+    /// (`plans/active/2026-05-meeting-vad-guided-live-chunking.md`). When
+    /// `false` (current production behavior), meeting live-preview chunks use
+    /// the fixed 5s / 1s-overlap `AudioChunker` path. When `true` and the Silero
+    /// VAD model is already cached, live preview cuts at speech boundaries for
+    /// Parakeet sessions; each source independently falls back to fixed chunking
+    /// when VAD is unavailable or errors repeatedly. The final saved transcript
+    /// (post-stop full-file STT) is unaffected either way.
+    ///
+    /// Default-off pending Phase 0 (compute-unit benchmark) and Phase 5
+    /// (real-meeting threshold tuning) in the plan.
+    public static let meetingVadLiveChunkingEnabled: Bool = false
 }

--- a/Sources/MacParakeetCore/Audio/MeetingLiveAudioChunking.swift
+++ b/Sources/MacParakeetCore/Audio/MeetingLiveAudioChunking.swift
@@ -1,37 +1,5 @@
 import Foundation
 
-/// Diagnostics for a single live-chunking source (microphone or system).
-///
-/// Private observability only — never surfaced as user-facing text. Lets the
-/// app answer "did this session use VAD or fixed fallback, and why" without
-/// logging transcript content or audio. See
-/// `plans/active/2026-05-meeting-vad-guided-live-chunking.md` §5.
-struct MeetingLiveChunkingDiagnostics: Sendable, Equatable {
-    enum Mode: String, Sendable {
-        case fixed
-        case vad
-    }
-
-    var mode: Mode
-    /// `true` once a VAD-mode chunker has degraded to fixed-window emits after
-    /// repeated streaming errors.
-    var fellBackToFixed: Bool = false
-    var chunksEmitted: Int = 0
-    var speechStartEvents: Int = 0
-    var speechEndEvents: Int = 0
-    /// Max-duration force emits (no speech-end arrived before the cap).
-    var forceEmits: Int = 0
-    /// Windows of detected silence discarded without emitting a chunk.
-    var droppedSilenceWindows: Int = 0
-    var vadErrors: Int = 0
-    /// Most recent VAD speech probability, for tuning visibility only.
-    var recentProbability: Float = 0
-
-    init(mode: Mode) {
-        self.mode = mode
-    }
-}
-
 /// MacParakeet-owned abstraction over meeting live-preview chunking, so product
 /// code (`CaptureOrchestrator`) depends on one shape regardless of whether the
 /// underlying strategy is fixed 5s windows or VAD speech boundaries.
@@ -43,34 +11,28 @@ protocol MeetingLiveAudioChunking: Sendable {
     func addSamples(_ samples: [Float]) async -> [AudioChunker.AudioChunk]
     func flush() async -> AudioChunker.AudioChunk?
     func reset() async
-    var diagnostics: MeetingLiveChunkingDiagnostics { get async }
 }
 
 /// Thin adapter that preserves the current fixed 5s / 1s-overlap behavior by
 /// delegating to `AudioChunker`. This is the fallback path and the default
-/// production behavior; it must stay byte-identical to `AudioChunker`.
+/// production behavior; it stays byte-identical to `AudioChunker`.
 actor FixedMeetingLiveAudioChunker: MeetingLiveAudioChunking {
     private let chunker = AudioChunker()
-    private var diag = MeetingLiveChunkingDiagnostics(mode: .fixed)
 
     init() {}
 
     func addSamples(_ samples: [Float]) async -> [AudioChunker.AudioChunk] {
-        guard let chunk = await chunker.addSamples(samples) else { return [] }
-        diag.chunksEmitted += 1
-        return [chunk]
+        if let chunk = await chunker.addSamples(samples) {
+            return [chunk]
+        }
+        return []
     }
 
     func flush() async -> AudioChunker.AudioChunk? {
-        guard let chunk = await chunker.flush() else { return nil }
-        diag.chunksEmitted += 1
-        return chunk
+        await chunker.flush()
     }
 
     func reset() async {
         await chunker.reset()
-        diag = MeetingLiveChunkingDiagnostics(mode: .fixed)
     }
-
-    var diagnostics: MeetingLiveChunkingDiagnostics { diag }
 }

--- a/Sources/MacParakeetCore/Audio/MeetingLiveAudioChunking.swift
+++ b/Sources/MacParakeetCore/Audio/MeetingLiveAudioChunking.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Diagnostics for a single live-chunking source (microphone or system).
+///
+/// Private observability only — never surfaced as user-facing text. Lets the
+/// app answer "did this session use VAD or fixed fallback, and why" without
+/// logging transcript content or audio. See
+/// `plans/active/2026-05-meeting-vad-guided-live-chunking.md` §5.
+struct MeetingLiveChunkingDiagnostics: Sendable, Equatable {
+    enum Mode: String, Sendable {
+        case fixed
+        case vad
+    }
+
+    var mode: Mode
+    /// `true` once a VAD-mode chunker has degraded to fixed-window emits after
+    /// repeated streaming errors.
+    var fellBackToFixed: Bool = false
+    var chunksEmitted: Int = 0
+    var speechStartEvents: Int = 0
+    var speechEndEvents: Int = 0
+    /// Max-duration force emits (no speech-end arrived before the cap).
+    var forceEmits: Int = 0
+    /// Windows of detected silence discarded without emitting a chunk.
+    var droppedSilenceWindows: Int = 0
+    var vadErrors: Int = 0
+    /// Most recent VAD speech probability, for tuning visibility only.
+    var recentProbability: Float = 0
+
+    init(mode: Mode) {
+        self.mode = mode
+    }
+}
+
+/// MacParakeet-owned abstraction over meeting live-preview chunking, so product
+/// code (`CaptureOrchestrator`) depends on one shape regardless of whether the
+/// underlying strategy is fixed 5s windows or VAD speech boundaries.
+///
+/// `addSamples` returns an array because a boundary-driven chunker can emit
+/// zero, one, or several chunks for a single ingest; the fixed adapter simply
+/// returns at most one.
+protocol MeetingLiveAudioChunking: Sendable {
+    func addSamples(_ samples: [Float]) async -> [AudioChunker.AudioChunk]
+    func flush() async -> AudioChunker.AudioChunk?
+    func reset() async
+    var diagnostics: MeetingLiveChunkingDiagnostics { get async }
+}
+
+/// Thin adapter that preserves the current fixed 5s / 1s-overlap behavior by
+/// delegating to `AudioChunker`. This is the fallback path and the default
+/// production behavior; it must stay byte-identical to `AudioChunker`.
+actor FixedMeetingLiveAudioChunker: MeetingLiveAudioChunking {
+    private let chunker = AudioChunker()
+    private var diag = MeetingLiveChunkingDiagnostics(mode: .fixed)
+
+    init() {}
+
+    func addSamples(_ samples: [Float]) async -> [AudioChunker.AudioChunk] {
+        guard let chunk = await chunker.addSamples(samples) else { return [] }
+        diag.chunksEmitted += 1
+        return [chunk]
+    }
+
+    func flush() async -> AudioChunker.AudioChunk? {
+        guard let chunk = await chunker.flush() else { return nil }
+        diag.chunksEmitted += 1
+        return chunk
+    }
+
+    func reset() async {
+        await chunker.reset()
+        diag = MeetingLiveChunkingDiagnostics(mode: .fixed)
+    }
+
+    var diagnostics: MeetingLiveChunkingDiagnostics { diag }
+}

--- a/Sources/MacParakeetCore/Audio/SpeechBoundaryMeetingLiveAudioChunker.swift
+++ b/Sources/MacParakeetCore/Audio/SpeechBoundaryMeetingLiveAudioChunker.swift
@@ -1,0 +1,253 @@
+import Foundation
+import OSLog
+
+/// Live-preview chunker that cuts at VAD speech boundaries instead of fixed
+/// 5-second windows. See
+/// `plans/active/2026-05-meeting-vad-guided-live-chunking.md`.
+///
+/// **Contiguous sample accounting.** Chunks tile the recording with no gaps in
+/// the audio they emit, so `lastEmittedSample` always equals the absolute
+/// sample index of `buffer[0]`, and therefore `chunk.startMs` always equals the
+/// true absolute position of the chunk's first sample.
+/// `MeetingTranscriptAssembler` dedups live words by absolute `endMs`, so a
+/// `startMs` that understated the position would silently drop early words from
+/// the preview. Contiguous accounting makes that impossible.
+///
+/// Silence between utterances becomes leading silence of the next chunk (minor
+/// STT cost, no correctness cost). The only deliberate overlap is a short tail
+/// re-fed after a forced (max-duration) cut, because that cut lands mid-word;
+/// the assembler's dedup harmlessly discards the duplicated tail words.
+///
+/// This type does not depend on FluidAudio — it round-trips the opaque
+/// `MeetingVADStreamState` through a `MeetingVoiceActivityDetecting`.
+actor SpeechBoundaryMeetingLiveAudioChunker: MeetingLiveAudioChunking {
+    private static let sampleRate = 16_000
+    /// `VadManager.chunkSize` — VAD streaming state advances by the sample count
+    /// passed, so windows must be exactly this size to keep the boundary
+    /// timeline aligned.
+    private static let vadWindow = 4_096
+    /// Degraded-fallback fixed cadence, identical to `AudioChunker`.
+    private static let fixedWindow = 5 * sampleRate
+    private static let fixedOverlap = 1 * sampleRate
+    private static let fixedFlushMinimum = 8_000
+    private static let maxConsecutiveVADErrors = 3
+
+    private let vad: any MeetingVoiceActivityDetecting
+    private let config: MeetingVADConfig
+    private let minChunkSamples: Int
+    private let maxChunkSamples: Int
+    private let forceEmitTailOverlap: Int
+    private let flushMinSamples: Int
+
+    /// Samples from `lastEmittedSample` up to `totalSamplesSeen`; the audio a
+    /// future chunk will be cut from. `buffer[0]` is absolute `lastEmittedSample`.
+    private var buffer: [Float] = []
+    /// Samples appended but not yet sliced into a VAD window (< `vadWindow`).
+    private var pendingVAD: [Float] = []
+    private var totalSamplesSeen = 0
+    private var lastEmittedSample = 0
+    private var sawSpeechSinceLastEmit = false
+    private var vadState: MeetingVADStreamState?
+    private var consecutiveVADErrors = 0
+    private var fellBackToFixed = false
+    private var diag = MeetingLiveChunkingDiagnostics(mode: .vad)
+
+    private let logger = Logger(subsystem: "com.macparakeet.core", category: "SpeechBoundaryChunker")
+
+    init(
+        vad: any MeetingVoiceActivityDetecting,
+        config: MeetingVADConfig = .default,
+        minChunkSeconds: Double = 2.0,
+        maxChunkSeconds: Double = 10.0,
+        forceEmitTailOverlapSeconds: Double = 0.25,
+        flushMinimumSeconds: Double = 0.5
+    ) {
+        self.vad = vad
+        self.config = config
+        self.minChunkSamples = Int(minChunkSeconds * Double(Self.sampleRate))
+        self.maxChunkSamples = Int(maxChunkSeconds * Double(Self.sampleRate))
+        self.forceEmitTailOverlap = Int(forceEmitTailOverlapSeconds * Double(Self.sampleRate))
+        self.flushMinSamples = Int(flushMinimumSeconds * Double(Self.sampleRate))
+    }
+
+    var diagnostics: MeetingLiveChunkingDiagnostics { diag }
+
+    func reset() async {
+        buffer = []
+        pendingVAD = []
+        totalSamplesSeen = 0
+        lastEmittedSample = 0
+        sawSpeechSinceLastEmit = false
+        vadState = nil
+        consecutiveVADErrors = 0
+        fellBackToFixed = false
+        diag = MeetingLiveChunkingDiagnostics(mode: .vad)
+    }
+
+    func addSamples(_ samples: [Float]) async -> [AudioChunker.AudioChunk] {
+        guard !samples.isEmpty else { return [] }
+        buffer.append(contentsOf: samples)
+        totalSamplesSeen += samples.count
+
+        if fellBackToFixed {
+            return drainFixed()
+        }
+
+        pendingVAD.append(contentsOf: samples)
+        if vadState == nil {
+            vadState = await vad.makeStreamState()
+        }
+
+        var emitted: [AudioChunker.AudioChunk] = []
+        while pendingVAD.count >= Self.vadWindow {
+            let window = Array(pendingVAD.prefix(Self.vadWindow))
+            pendingVAD.removeFirst(Self.vadWindow)
+            await process(window: window, into: &emitted)
+            if fellBackToFixed {
+                emitted.append(contentsOf: drainFixed())
+                return emitted
+            }
+            if let forced = maybeForceEmitOrDropSilence() {
+                emitted.append(forced)
+            }
+        }
+        // A large single ingest can leave the buffer past the cap even after the
+        // VAD windows are drained; keep emitting until it is bounded again.
+        while let forced = maybeForceEmitOrDropSilence() {
+            emitted.append(forced)
+        }
+        return emitted
+    }
+
+    func flush() async -> AudioChunker.AudioChunk? {
+        if fellBackToFixed {
+            return flushFixed()
+        }
+
+        // Best-effort: feed the sub-window tail so a speech segment that began in
+        // the final < 256 ms before stop can still be recognized as speech.
+        if !pendingVAD.isEmpty, let state = vadState {
+            if let result = try? await vad.processStreamingChunk(pendingVAD, state: state, config: config) {
+                vadState = result.state
+                diag.recentProbability = result.probability
+                if case .speechStart = result.event {
+                    sawSpeechSinceLastEmit = true
+                    diag.speechStartEvents += 1
+                }
+            }
+            pendingVAD.removeAll()
+        }
+
+        guard sawSpeechSinceLastEmit, buffer.count >= flushMinSamples else {
+            return nil
+        }
+        return makeChunk(length: buffer.count, tailOverlap: 0)
+    }
+
+    // MARK: - VAD streaming
+
+    private func process(
+        window: [Float],
+        into emitted: inout [AudioChunker.AudioChunk]
+    ) async {
+        guard let state = vadState else { return }
+        do {
+            let result = try await vad.processStreamingChunk(window, state: state, config: config)
+            vadState = result.state
+            consecutiveVADErrors = 0
+            diag.recentProbability = result.probability
+
+            switch result.event {
+            case .speechStart:
+                sawSpeechSinceLastEmit = true
+                diag.speechStartEvents += 1
+            case .speechEnd(let sampleIndex):
+                diag.speechEndEvents += 1
+                if let chunk = emitAtSpeechEnd(cutSample: sampleIndex) {
+                    emitted.append(chunk)
+                }
+            case .none:
+                break
+            }
+        } catch {
+            diag.vadErrors += 1
+            consecutiveVADErrors += 1
+            logger.error(
+                "meeting_vad_stream_error consecutive=\(self.consecutiveVADErrors) error=\(error.localizedDescription, privacy: .public)"
+            )
+            if consecutiveVADErrors >= Self.maxConsecutiveVADErrors {
+                fellBackToFixed = true
+                diag.fellBackToFixed = true
+                logger.notice("meeting_vad_fallback_to_fixed source diagnostics will report mode=vad reason=vad_error")
+            }
+        }
+    }
+
+    /// Emit `[lastEmittedSample, cutSample)` when a speech segment ends. The cut
+    /// is retroactive, so it can land before the current ingest position; we
+    /// skip cuts that are too early or that would produce a sub-minimum chunk
+    /// and let the next `speechEnd` extend the segment.
+    private func emitAtSpeechEnd(cutSample: Int) -> AudioChunker.AudioChunk? {
+        guard sawSpeechSinceLastEmit else { return nil }
+        let length = cutSample - lastEmittedSample
+        guard length >= minChunkSamples, length <= buffer.count else { return nil }
+        let chunk = makeChunk(length: length, tailOverlap: 0)
+        sawSpeechSinceLastEmit = false
+        return chunk
+    }
+
+    /// When the buffer reaches the max-duration cap: force a cut (keeping a tail
+    /// overlap for STT context) if speech was detected, otherwise discard the
+    /// silence down to a small context window so memory and latency stay bounded.
+    private func maybeForceEmitOrDropSilence() -> AudioChunker.AudioChunk? {
+        guard buffer.count >= maxChunkSamples else { return nil }
+
+        guard sawSpeechSinceLastEmit else {
+            let drop = buffer.count - Self.vadWindow
+            if drop > 0 {
+                buffer.removeFirst(drop)
+                lastEmittedSample += drop
+                diag.droppedSilenceWindows += 1
+            }
+            return nil
+        }
+
+        diag.forceEmits += 1
+        return makeChunk(length: maxChunkSamples, tailOverlap: forceEmitTailOverlap)
+    }
+
+    /// Emit `buffer[0..<length]`, then advance by `length - tailOverlap`,
+    /// retaining the tail so the next chunk re-includes it. Timestamps come
+    /// strictly from sample counters (no wall clock).
+    private func makeChunk(length: Int, tailOverlap: Int) -> AudioChunker.AudioChunk {
+        let startMs = lastEmittedSample * 1000 / Self.sampleRate
+        let endMs = (lastEmittedSample + length) * 1000 / Self.sampleRate
+        let samples = Array(buffer.prefix(length))
+
+        let advance = max(0, length - tailOverlap)
+        buffer.removeFirst(min(advance, buffer.count))
+        lastEmittedSample += advance
+        diag.chunksEmitted += 1
+
+        return AudioChunker.AudioChunk(samples: samples, startMs: startMs, endMs: endMs)
+    }
+
+    // MARK: - Degraded fixed fallback (shares the absolute sample counters so
+    // timestamps stay monotonic across the switch).
+
+    private func drainFixed() -> [AudioChunker.AudioChunk] {
+        var out: [AudioChunker.AudioChunk] = []
+        while buffer.count >= Self.fixedWindow {
+            out.append(makeChunk(length: Self.fixedWindow, tailOverlap: Self.fixedOverlap))
+        }
+        return out
+    }
+
+    private func flushFixed() -> AudioChunker.AudioChunk? {
+        guard buffer.count >= Self.fixedFlushMinimum else {
+            buffer = []
+            return nil
+        }
+        return makeChunk(length: buffer.count, tailOverlap: 0)
+    }
+}

--- a/Sources/MacParakeetCore/Audio/SpeechBoundaryMeetingLiveAudioChunker.swift
+++ b/Sources/MacParakeetCore/Audio/SpeechBoundaryMeetingLiveAudioChunker.swift
@@ -13,6 +13,13 @@ import OSLog
 /// `startMs` that understated the position would silently drop early words from
 /// the preview. Contiguous accounting makes that impossible.
 ///
+/// **Lockstep buffering.** Incoming samples are staged in `pendingVAD` and only
+/// moved into the emittable `buffer` once they have been fed to VAD in exact
+/// `VadManager.chunkSize` windows. So `buffer` only ever holds *VAD-examined*
+/// audio, and the force-emit / silence-drop decisions (which key off
+/// `buffer.count`) can never act on samples VAD has not analyzed — even for an
+/// arbitrarily large single ingest.
+///
 /// Silence between utterances becomes leading silence of the next chunk (minor
 /// STT cost, no correctness cost). The only deliberate overlap is a short tail
 /// re-fed after a forced (max-duration) cut, because that cut lands mid-word;
@@ -39,12 +46,14 @@ actor SpeechBoundaryMeetingLiveAudioChunker: MeetingLiveAudioChunking {
     private let forceEmitTailOverlap: Int
     private let flushMinSamples: Int
 
-    /// Samples from `lastEmittedSample` up to `totalSamplesSeen`; the audio a
-    /// future chunk will be cut from. `buffer[0]` is absolute `lastEmittedSample`.
+    /// VAD-examined samples from `lastEmittedSample` up to the VAD frontier; the
+    /// audio a future chunk will be cut from. `buffer[0]` is absolute
+    /// `lastEmittedSample`, and `lastEmittedSample + buffer.count` is exactly the
+    /// number of samples fed to VAD so far (minus what was emitted/dropped).
     private var buffer: [Float] = []
-    /// Samples appended but not yet sliced into a VAD window (< `vadWindow`).
+    /// Samples received but not yet sliced into a VAD window (< `vadWindow`).
+    /// Not yet in `buffer`, so never counted by force-emit/silence-drop.
     private var pendingVAD: [Float] = []
-    private var totalSamplesSeen = 0
     private var lastEmittedSample = 0
     private var sawSpeechSinceLastEmit = false
     private var vadState: MeetingVADStreamState?
@@ -75,7 +84,6 @@ actor SpeechBoundaryMeetingLiveAudioChunker: MeetingLiveAudioChunking {
     func reset() async {
         buffer = []
         pendingVAD = []
-        totalSamplesSeen = 0
         lastEmittedSample = 0
         sawSpeechSinceLastEmit = false
         vadState = nil
@@ -86,10 +94,9 @@ actor SpeechBoundaryMeetingLiveAudioChunker: MeetingLiveAudioChunking {
 
     func addSamples(_ samples: [Float]) async -> [AudioChunker.AudioChunk] {
         guard !samples.isEmpty else { return [] }
-        buffer.append(contentsOf: samples)
-        totalSamplesSeen += samples.count
 
         if fellBackToFixed {
+            buffer.append(contentsOf: samples)
             return drainFixed()
         }
 
@@ -102,19 +109,23 @@ actor SpeechBoundaryMeetingLiveAudioChunker: MeetingLiveAudioChunking {
         while pendingVAD.count >= Self.vadWindow {
             let window = Array(pendingVAD.prefix(Self.vadWindow))
             pendingVAD.removeFirst(Self.vadWindow)
+            // Move the window into the emittable buffer *before* processing, so a
+            // speech-end cut from this window has its audio available, and so the
+            // VAD frontier (lastEmittedSample + buffer.count) stays exact.
+            buffer.append(contentsOf: window)
             await process(window: window, into: &emitted)
+
             if fellBackToFixed {
+                // Stage drains into the buffer so the fixed fallback emits the
+                // complete audio; the staged samples are already accounted for.
+                buffer.append(contentsOf: pendingVAD)
+                pendingVAD.removeAll()
                 emitted.append(contentsOf: drainFixed())
                 return emitted
             }
             if let forced = maybeForceEmitOrDropSilence() {
                 emitted.append(forced)
             }
-        }
-        // A large single ingest can leave the buffer past the cap even after the
-        // VAD windows are drained; keep emitting until it is bounded again.
-        while let forced = maybeForceEmitOrDropSilence() {
-            emitted.append(forced)
         }
         return emitted
     }
@@ -124,18 +135,32 @@ actor SpeechBoundaryMeetingLiveAudioChunker: MeetingLiveAudioChunking {
             return flushFixed()
         }
 
-        // Best-effort: feed the sub-window tail so a speech segment that began in
-        // the final < 256 ms before stop can still be recognized as speech.
+        // Feed the sub-window tail so a clean speech end (or start) in the final
+        // < 256 ms before stop is still recognized. The tail audio joins the
+        // emittable buffer first so any speech-end cut has it available.
         if !pendingVAD.isEmpty, let state = vadState {
-            if let result = try? await vad.processStreamingChunk(pendingVAD, state: state, config: config) {
+            let tail = pendingVAD
+            pendingVAD.removeAll()
+            buffer.append(contentsOf: tail)
+            if let result = try? await vad.processStreamingChunk(tail, state: state, config: config) {
                 vadState = result.state
                 diag.recentProbability = result.probability
-                if case .speechStart = result.event {
+                switch result.event {
+                case .speechStart:
                     sawSpeechSinceLastEmit = true
                     diag.speechStartEvents += 1
+                case .speechEnd(let cutSample):
+                    diag.speechEndEvents += 1
+                    // Trim trailing silence at the VAD-confirmed boundary. If the
+                    // cut is sub-minimum we fall through and emit the whole spoken
+                    // tail below (flush accepts shorter tails than streaming does).
+                    if let chunk = emitAtSpeechEnd(cutSample: cutSample) {
+                        return chunk
+                    }
+                case .none:
+                    break
                 }
             }
-            pendingVAD.removeAll()
         }
 
         guard sawSpeechSinceLastEmit, buffer.count >= flushMinSamples else {
@@ -161,9 +186,9 @@ actor SpeechBoundaryMeetingLiveAudioChunker: MeetingLiveAudioChunking {
             case .speechStart:
                 sawSpeechSinceLastEmit = true
                 diag.speechStartEvents += 1
-            case .speechEnd(let sampleIndex):
+            case .speechEnd(let cutSample):
                 diag.speechEndEvents += 1
-                if let chunk = emitAtSpeechEnd(cutSample: sampleIndex) {
+                if let chunk = emitAtSpeechEnd(cutSample: cutSample) {
                     emitted.append(chunk)
                 }
             case .none:
@@ -178,15 +203,15 @@ actor SpeechBoundaryMeetingLiveAudioChunker: MeetingLiveAudioChunking {
             if consecutiveVADErrors >= Self.maxConsecutiveVADErrors {
                 fellBackToFixed = true
                 diag.fellBackToFixed = true
-                logger.notice("meeting_vad_fallback_to_fixed source diagnostics will report mode=vad reason=vad_error")
+                logger.notice("meeting_vad_fallback_to_fixed reason=vad_error")
             }
         }
     }
 
     /// Emit `[lastEmittedSample, cutSample)` when a speech segment ends. The cut
-    /// is retroactive, so it can land before the current ingest position; we
-    /// skip cuts that are too early or that would produce a sub-minimum chunk
-    /// and let the next `speechEnd` extend the segment.
+    /// is retroactive (absolute, from VAD's stream start), so it can land before
+    /// the current ingest position; we skip cuts that are too early or that would
+    /// produce a sub-minimum chunk and let the next `speechEnd` extend the segment.
     private func emitAtSpeechEnd(cutSample: Int) -> AudioChunker.AudioChunk? {
         guard sawSpeechSinceLastEmit else { return nil }
         let length = cutSample - lastEmittedSample
@@ -199,6 +224,7 @@ actor SpeechBoundaryMeetingLiveAudioChunker: MeetingLiveAudioChunking {
     /// When the buffer reaches the max-duration cap: force a cut (keeping a tail
     /// overlap for STT context) if speech was detected, otherwise discard the
     /// silence down to a small context window so memory and latency stay bounded.
+    /// Operates only on VAD-examined audio (see lockstep buffering note).
     private func maybeForceEmitOrDropSilence() -> AudioChunker.AudioChunk? {
         guard buffer.count >= maxChunkSamples else { return nil }
 

--- a/Sources/MacParakeetCore/Audio/SpeechBoundaryMeetingLiveAudioChunker.swift
+++ b/Sources/MacParakeetCore/Audio/SpeechBoundaryMeetingLiveAudioChunker.swift
@@ -1,6 +1,18 @@
 import Foundation
 import OSLog
 
+/// Counters exposed for unit-test observation of the chunker's state machine
+/// (silence drops, force emits, fallback). Not user-facing; carries no
+/// transcript or audio. A natural hook for Phase 5 telemetry if it lands.
+struct MeetingLiveChunkingDiagnostics: Sendable {
+    var chunksEmitted = 0
+    var speechEndEvents = 0
+    var forceEmits = 0
+    var droppedSilenceWindows = 0
+    var vadErrors = 0
+    var fellBackToFixed = false
+}
+
 /// Live-preview chunker that cuts at VAD speech boundaries instead of fixed
 /// 5-second windows. See
 /// `plans/active/2026-05-meeting-vad-guided-live-chunking.md`.
@@ -25,6 +37,10 @@ import OSLog
 /// re-fed after a forced (max-duration) cut, because that cut lands mid-word;
 /// the assembler's dedup harmlessly discards the duplicated tail words.
 ///
+/// **Concurrency.** Methods mutate shared buffers across `await` points, so the
+/// owner must call them serially. `CaptureOrchestrator` (the only caller) is an
+/// actor that drives `addSamples`/`flush`/`reset` one at a time, satisfying this.
+///
 /// This type does not depend on FluidAudio — it round-trips the opaque
 /// `MeetingVADStreamState` through a `MeetingVoiceActivityDetecting`.
 actor SpeechBoundaryMeetingLiveAudioChunker: MeetingLiveAudioChunking {
@@ -33,6 +49,10 @@ actor SpeechBoundaryMeetingLiveAudioChunker: MeetingLiveAudioChunking {
     /// passed, so windows must be exactly this size to keep the boundary
     /// timeline aligned.
     private static let vadWindow = 4_096
+    private static let minChunkSamples = 2 * sampleRate          // 2.0s
+    private static let maxChunkSamples = 10 * sampleRate         // 10.0s
+    private static let forceEmitTailOverlap = sampleRate / 4     // 0.25s
+    private static let flushMinSamples = sampleRate / 2          // 0.5s
     /// Degraded-fallback fixed cadence, identical to `AudioChunker`.
     private static let fixedWindow = 5 * sampleRate
     private static let fixedOverlap = 1 * sampleRate
@@ -41,10 +61,6 @@ actor SpeechBoundaryMeetingLiveAudioChunker: MeetingLiveAudioChunking {
 
     private let vad: any MeetingVoiceActivityDetecting
     private let config: MeetingVADConfig
-    private let minChunkSamples: Int
-    private let maxChunkSamples: Int
-    private let forceEmitTailOverlap: Int
-    private let flushMinSamples: Int
 
     /// VAD-examined samples from `lastEmittedSample` up to the VAD frontier; the
     /// audio a future chunk will be cut from. `buffer[0]` is absolute
@@ -59,24 +75,13 @@ actor SpeechBoundaryMeetingLiveAudioChunker: MeetingLiveAudioChunking {
     private var vadState: MeetingVADStreamState?
     private var consecutiveVADErrors = 0
     private var fellBackToFixed = false
-    private var diag = MeetingLiveChunkingDiagnostics(mode: .vad)
+    private var diag = MeetingLiveChunkingDiagnostics()
 
     private let logger = Logger(subsystem: "com.macparakeet.core", category: "SpeechBoundaryChunker")
 
-    init(
-        vad: any MeetingVoiceActivityDetecting,
-        config: MeetingVADConfig = .default,
-        minChunkSeconds: Double = 2.0,
-        maxChunkSeconds: Double = 10.0,
-        forceEmitTailOverlapSeconds: Double = 0.25,
-        flushMinimumSeconds: Double = 0.5
-    ) {
+    init(vad: any MeetingVoiceActivityDetecting, config: MeetingVADConfig = .default) {
         self.vad = vad
         self.config = config
-        self.minChunkSamples = Int(minChunkSeconds * Double(Self.sampleRate))
-        self.maxChunkSamples = Int(maxChunkSeconds * Double(Self.sampleRate))
-        self.forceEmitTailOverlap = Int(forceEmitTailOverlapSeconds * Double(Self.sampleRate))
-        self.flushMinSamples = Int(flushMinimumSeconds * Double(Self.sampleRate))
     }
 
     var diagnostics: MeetingLiveChunkingDiagnostics { diag }
@@ -89,7 +94,7 @@ actor SpeechBoundaryMeetingLiveAudioChunker: MeetingLiveAudioChunking {
         vadState = nil
         consecutiveVADErrors = 0
         fellBackToFixed = false
-        diag = MeetingLiveChunkingDiagnostics(mode: .vad)
+        diag = MeetingLiveChunkingDiagnostics()
     }
 
     func addSamples(_ samples: [Float]) async -> [AudioChunker.AudioChunk] {
@@ -144,11 +149,9 @@ actor SpeechBoundaryMeetingLiveAudioChunker: MeetingLiveAudioChunking {
             buffer.append(contentsOf: tail)
             if let result = try? await vad.processStreamingChunk(tail, state: state, config: config) {
                 vadState = result.state
-                diag.recentProbability = result.probability
                 switch result.event {
                 case .speechStart:
                     sawSpeechSinceLastEmit = true
-                    diag.speechStartEvents += 1
                 case .speechEnd(let cutSample):
                     diag.speechEndEvents += 1
                     // Trim trailing silence at the VAD-confirmed boundary. If the
@@ -163,7 +166,7 @@ actor SpeechBoundaryMeetingLiveAudioChunker: MeetingLiveAudioChunking {
             }
         }
 
-        guard sawSpeechSinceLastEmit, buffer.count >= flushMinSamples else {
+        guard sawSpeechSinceLastEmit, buffer.count >= Self.flushMinSamples else {
             return nil
         }
         return makeChunk(length: buffer.count, tailOverlap: 0)
@@ -180,12 +183,10 @@ actor SpeechBoundaryMeetingLiveAudioChunker: MeetingLiveAudioChunking {
             let result = try await vad.processStreamingChunk(window, state: state, config: config)
             vadState = result.state
             consecutiveVADErrors = 0
-            diag.recentProbability = result.probability
 
             switch result.event {
             case .speechStart:
                 sawSpeechSinceLastEmit = true
-                diag.speechStartEvents += 1
             case .speechEnd(let cutSample):
                 diag.speechEndEvents += 1
                 if let chunk = emitAtSpeechEnd(cutSample: cutSample) {
@@ -210,12 +211,20 @@ actor SpeechBoundaryMeetingLiveAudioChunker: MeetingLiveAudioChunking {
 
     /// Emit `[lastEmittedSample, cutSample)` when a speech segment ends. The cut
     /// is retroactive (absolute, from VAD's stream start), so it can land before
-    /// the current ingest position; we skip cuts that are too early or that would
-    /// produce a sub-minimum chunk and let the next `speechEnd` extend the segment.
+    /// the current ingest position.
     private func emitAtSpeechEnd(cutSample: Int) -> AudioChunker.AudioChunk? {
         guard sawSpeechSinceLastEmit else { return nil }
         let length = cutSample - lastEmittedSample
-        guard length >= minChunkSamples, length <= buffer.count else { return nil }
+        if length <= 0 {
+            // Boundary lands at/behind what we already emitted (e.g. a force-emit
+            // advanced past where speech actually ended). Speech is over, so clear
+            // the flag — otherwise trailing silence would never be dropped and
+            // we'd force-emit silence every max-duration window.
+            sawSpeechSinceLastEmit = false
+            return nil
+        }
+        // Sub-minimum: keep buffering and let the next speechEnd extend the segment.
+        guard length >= Self.minChunkSamples, length <= buffer.count else { return nil }
         let chunk = makeChunk(length: length, tailOverlap: 0)
         sawSpeechSinceLastEmit = false
         return chunk
@@ -226,7 +235,7 @@ actor SpeechBoundaryMeetingLiveAudioChunker: MeetingLiveAudioChunking {
     /// silence down to a small context window so memory and latency stay bounded.
     /// Operates only on VAD-examined audio (see lockstep buffering note).
     private func maybeForceEmitOrDropSilence() -> AudioChunker.AudioChunk? {
-        guard buffer.count >= maxChunkSamples else { return nil }
+        guard buffer.count >= Self.maxChunkSamples else { return nil }
 
         guard sawSpeechSinceLastEmit else {
             let drop = buffer.count - Self.vadWindow
@@ -239,7 +248,7 @@ actor SpeechBoundaryMeetingLiveAudioChunker: MeetingLiveAudioChunking {
         }
 
         diag.forceEmits += 1
-        return makeChunk(length: maxChunkSamples, tailOverlap: forceEmitTailOverlap)
+        return makeChunk(length: Self.maxChunkSamples, tailOverlap: Self.forceEmitTailOverlap)
     }
 
     /// Emit `buffer[0..<length]`, then advance by `length - tailOverlap`,
@@ -271,6 +280,10 @@ actor SpeechBoundaryMeetingLiveAudioChunker: MeetingLiveAudioChunking {
 
     private func flushFixed() -> AudioChunker.AudioChunk? {
         guard buffer.count >= Self.fixedFlushMinimum else {
+            // Discard the sub-minimum tail but keep the sample counter consistent
+            // with the discarded audio, so the invariant holds if the instance is
+            // ever reused without reset().
+            lastEmittedSample += buffer.count
             buffer = []
             return nil
         }

--- a/Sources/MacParakeetCore/Services/Capture/CaptureOrchestrator.swift
+++ b/Sources/MacParakeetCore/Services/Capture/CaptureOrchestrator.swift
@@ -19,8 +19,19 @@ struct CaptureOrchestratorOutput: Sendable {
 
 actor CaptureOrchestrator {
     private var pairJoiner = MeetingAudioPairJoiner()
-    private var microphoneChunker = AudioChunker()
-    private var systemChunker = AudioChunker()
+    private var microphoneChunker: any MeetingLiveAudioChunking = FixedMeetingLiveAudioChunker()
+    private var systemChunker: any MeetingLiveAudioChunking = FixedMeetingLiveAudioChunker()
+
+    /// Swap in the per-source chunkers for the next recording. Sources are
+    /// independent so one can use VAD while the other falls back to fixed.
+    /// Call before `reset()` at session start; defaults to fixed chunkers.
+    func configureChunkers(
+        microphone: any MeetingLiveAudioChunking,
+        system: any MeetingLiveAudioChunking
+    ) {
+        microphoneChunker = microphone
+        systemChunker = system
+    }
 
     func reset() async {
         pairJoiner.reset()
@@ -86,11 +97,11 @@ actor CaptureOrchestrator {
                 micSamples = pair.microphoneSamples
             }
 
-            if let micChunk = await microphoneChunker.addSamples(micSamples) {
+            for micChunk in await microphoneChunker.addSamples(micSamples) {
                 output.chunks.append(CaptureOrchestratorChunk(source: .microphone, chunk: micChunk))
             }
 
-            if let systemChunk = await systemChunker.addSamples(pair.systemSamples) {
+            for systemChunk in await systemChunker.addSamples(pair.systemSamples) {
                 output.chunks.append(CaptureOrchestratorChunk(source: .system, chunk: systemChunk))
             }
 

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -399,6 +399,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             let events = await audioCaptureService.events
             try await validateStartStillCurrent(session)
             self.latestLevels = MeetingAudioLevels()
+            await configureLiveChunkers(for: session)
             await captureOrchestrator.reset()
             try await validateStartStillCurrent(session)
             micConditioner = micConditionerFactory()
@@ -925,6 +926,43 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         completedMicrophoneMuteHostTimeRanges = []
         logger.error("meeting_capture_failed error_type=\(AudioCaptureDiagnostics.errorType(error), privacy: .public) error_detail=\(error.localizedDescription, privacy: .private)")
         await audioCaptureService.stop()
+    }
+
+    /// Pick the live-preview chunking strategy for this session and install it
+    /// on the orchestrator. Production default (flag off) is fixed 5s chunking,
+    /// byte-identical to the prior behavior. When enabled and the Silero VAD
+    /// model is already cached, both sources cut at speech boundaries for
+    /// Parakeet sessions; WhisperKit sessions and uncached VAD stay on fixed.
+    /// See `plans/active/2026-05-meeting-vad-guided-live-chunking.md` §4.
+    private func configureLiveChunkers(for session: Session) async {
+        func useFixed(reason: String) async {
+            await captureOrchestrator.configureChunkers(
+                microphone: FixedMeetingLiveAudioChunker(),
+                system: FixedMeetingLiveAudioChunker()
+            )
+            AudioCaptureDiagnostics.append(
+                "meeting_live_chunking_mode mode=fixed reason=\(reason)"
+            )
+        }
+
+        guard AppFeatures.meetingVadLiveChunkingEnabled else {
+            await useFixed(reason: "feature_disabled")
+            return
+        }
+        guard session.speechEngine.engine == .parakeet else {
+            await useFixed(reason: "non_parakeet_engine")
+            return
+        }
+        guard let vad = await MeetingVADService.makeIfModelCached() else {
+            await useFixed(reason: "vad_unavailable")
+            return
+        }
+
+        await captureOrchestrator.configureChunkers(
+            microphone: SpeechBoundaryMeetingLiveAudioChunker(vad: vad),
+            system: SpeechBoundaryMeetingLiveAudioChunker(vad: vad)
+        )
+        AudioCaptureDiagnostics.append("meeting_live_chunking_mode mode=vad reason=started")
     }
 
     private func ingestResampledSamples(

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingVADService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingVADService.swift
@@ -1,0 +1,162 @@
+@preconcurrency import CoreML
+import FluidAudio
+import Foundation
+import OSLog
+
+/// A speech boundary emitted by streaming VAD. `sampleIndex` is **retroactive**:
+/// it points back to where speech started/ended (minus padding) in the VAD
+/// stream's own absolute sample coordinate, not the current ingest position.
+enum MeetingVADEvent: Sendable {
+    case speechStart(sampleIndex: Int)
+    case speechEnd(sampleIndex: Int)
+}
+
+/// Opaque, adapter-owned streaming VAD state. Product code round-trips this
+/// without depending on FluidAudio's `VadStreamState`. The FluidAudio-backed
+/// storage is internal; a `nil` `fluidState` is the starting state used by test
+/// doubles that drive the state machine directly.
+struct MeetingVADStreamState: Sendable {
+    var fluidState: VadStreamState?
+
+    init(fluidState: VadStreamState? = nil) {
+        self.fluidState = fluidState
+    }
+}
+
+struct MeetingVADResult: Sendable {
+    let state: MeetingVADStreamState
+    let event: MeetingVADEvent?
+    let probability: Float
+}
+
+/// MacParakeet-owned VAD config. Mirrors only the knobs that actually affect
+/// FluidAudio's **streaming** state machine (verified in
+/// `VadManager+Streaming.swift`): silence-before-end, retroactive padding, and
+/// optional hysteresis override. `minSpeechDuration` / `maxSpeechDuration` /
+/// `silenceThresholdForSplit` are inert in streaming mode, so they are
+/// deliberately absent here. Min/max chunk bounds live in the chunker, not VAD.
+struct MeetingVADConfig: Sendable {
+    /// Silence that must elapse before a `speechEnd` fires.
+    var minSilenceDuration: TimeInterval = 0.50
+    /// Padding folded into the retroactive boundary index.
+    var speechPadding: TimeInterval = 0.15
+    /// Optional explicit negative (exit) threshold. `nil` derives it from the
+    /// model's default threshold minus `negativeThresholdOffset`.
+    var negativeThreshold: Float?
+    var negativeThresholdOffset: Float = 0.15
+
+    static let `default` = MeetingVADConfig()
+}
+
+/// Streaming voice-activity detection, MacParakeet-facing. One conforming
+/// instance can serve multiple sources concurrently because all per-stream
+/// state is carried in the `MeetingVADStreamState` value the caller threads
+/// through `processStreamingChunk`.
+protocol MeetingVoiceActivityDetecting: Sendable {
+    func makeStreamState() async -> MeetingVADStreamState
+    func processStreamingChunk(
+        _ samples: [Float],
+        state: MeetingVADStreamState,
+        config: MeetingVADConfig
+    ) async throws -> MeetingVADResult
+}
+
+/// FluidAudio-backed VAD adapter. Owns a single `VadManager` (one CoreML model
+/// load) and exposes only MacParakeet types. The same instance backs both the
+/// microphone and system chunkers; each chunker keeps its own stream state.
+actor MeetingVADService: MeetingVoiceActivityDetecting {
+    private let manager: VadManager
+
+    init(manager: VadManager) {
+        self.manager = manager
+    }
+
+    /// Build a service **only if the VAD model is already cached on disk**.
+    /// Never downloads, so it cannot add hidden meeting-start latency or block
+    /// on the network. Returns `nil` when the model is absent or fails to load,
+    /// so callers fall back to fixed chunking for the session.
+    ///
+    /// `computeUnits` defaults to `.cpuOnly` to avoid Neural Engine contention
+    /// with Parakeet during live transcription (Phase 0 benchmark may revisit).
+    static func makeIfModelCached(
+        computeUnits: MLComputeUnits = .cpuOnly
+    ) async -> MeetingVADService? {
+        let logger = Logger(subsystem: "com.macparakeet.core", category: "MeetingVADService")
+        guard isModelCached() else {
+            logger.info("meeting_vad_model_uncached — falling back to fixed live chunking")
+            return nil
+        }
+        do {
+            let manager = try await VadManager(config: VadConfig(computeUnits: computeUnits))
+            guard await manager.isAvailable else {
+                logger.error("meeting_vad_init_unavailable — model loaded but not available")
+                return nil
+            }
+            return MeetingVADService(manager: manager)
+        } catch {
+            logger.error("meeting_vad_init_failed error=\(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+    }
+
+    /// `true` when every required Silero VAD model file already exists in the
+    /// shared FluidAudio model cache.
+    static func isModelCached() -> Bool {
+        let directory = MLModelConfigurationUtils.defaultModelsDirectory(for: .vad)
+        return ModelNames.VAD.requiredModels.allSatisfy { modelName in
+            FileManager.default.fileExists(
+                atPath: directory.appendingPathComponent(modelName, isDirectory: false).path
+            )
+        }
+    }
+
+    func makeStreamState() async -> MeetingVADStreamState {
+        MeetingVADStreamState(fluidState: await manager.makeStreamState())
+    }
+
+    func processStreamingChunk(
+        _ samples: [Float],
+        state: MeetingVADStreamState,
+        config: MeetingVADConfig
+    ) async throws -> MeetingVADResult {
+        let fluidState: VadStreamState
+        if let existing = state.fluidState {
+            fluidState = existing
+        } else {
+            fluidState = await manager.makeStreamState()
+        }
+        let result = try await manager.processStreamingChunk(
+            samples,
+            state: fluidState,
+            config: config.fluidConfig
+        )
+        return MeetingVADResult(
+            state: MeetingVADStreamState(fluidState: result.state),
+            event: result.event.map(Self.mapEvent),
+            probability: result.probability
+        )
+    }
+
+    private static func mapEvent(_ event: VadStreamEvent) -> MeetingVADEvent {
+        switch event.kind {
+        case .speechStart:
+            return .speechStart(sampleIndex: event.sampleIndex)
+        case .speechEnd:
+            return .speechEnd(sampleIndex: event.sampleIndex)
+        }
+    }
+}
+
+extension MeetingVADConfig {
+    /// Map to FluidAudio's `VadSegmentationConfig`, carrying only the
+    /// streaming-relevant knobs and leaving the inert segmentation fields at
+    /// their defaults.
+    var fluidConfig: VadSegmentationConfig {
+        VadSegmentationConfig(
+            minSilenceDuration: minSilenceDuration,
+            speechPadding: speechPadding,
+            negativeThreshold: negativeThreshold,
+            negativeThresholdOffset: negativeThresholdOffset
+        )
+    }
+}

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingVADService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingVADService.swift
@@ -14,13 +14,16 @@ enum MeetingVADEvent: Sendable {
 }
 
 /// Opaque, adapter-owned streaming VAD state. Product code round-trips this
-/// without depending on FluidAudio's `VadStreamState`. The FluidAudio-backed
-/// storage is internal; a `nil` `fluidState` is the starting state used by test
-/// doubles that drive the state machine directly.
+/// without depending on FluidAudio's `VadStreamState`; the FluidAudio-backed
+/// storage is internal. The no-argument init produces a fresh stream state.
 struct MeetingVADStreamState: Sendable {
-    var fluidState: VadStreamState?
+    var fluidState: VadStreamState
 
-    init(fluidState: VadStreamState? = nil) {
+    init() {
+        self.fluidState = VadStreamState()
+    }
+
+    init(fluidState: VadStreamState) {
         self.fluidState = fluidState
     }
 }
@@ -28,24 +31,20 @@ struct MeetingVADStreamState: Sendable {
 struct MeetingVADResult: Sendable {
     let state: MeetingVADStreamState
     let event: MeetingVADEvent?
-    let probability: Float
 }
 
 /// MacParakeet-owned VAD config. Mirrors only the knobs that actually affect
 /// FluidAudio's **streaming** state machine (verified in
-/// `VadManager+Streaming.swift`): silence-before-end, retroactive padding, and
-/// optional hysteresis override. `minSpeechDuration` / `maxSpeechDuration` /
-/// `silenceThresholdForSplit` are inert in streaming mode, so they are
-/// deliberately absent here. Min/max chunk bounds live in the chunker, not VAD.
+/// `VadManager+Streaming.swift`): silence-before-end and retroactive padding.
+/// `minSpeechDuration` / `maxSpeechDuration` / `silenceThresholdForSplit` are
+/// inert in streaming mode, so they are deliberately absent. Min/max chunk
+/// bounds live in the chunker, not VAD. The two values below are deliberate
+/// non-defaults tuned for live-meeting feel (FluidAudio defaults 0.75 / 0.10).
 struct MeetingVADConfig: Sendable {
     /// Silence that must elapse before a `speechEnd` fires.
     var minSilenceDuration: TimeInterval = 0.50
     /// Padding folded into the retroactive boundary index.
     var speechPadding: TimeInterval = 0.15
-    /// Optional explicit negative (exit) threshold. `nil` derives it from the
-    /// model's default threshold minus `negativeThresholdOffset`.
-    var negativeThreshold: Float?
-    var negativeThresholdOffset: Float = 0.15
 
     static let `default` = MeetingVADConfig()
 }
@@ -121,21 +120,14 @@ actor MeetingVADService: MeetingVoiceActivityDetecting {
         state: MeetingVADStreamState,
         config: MeetingVADConfig
     ) async throws -> MeetingVADResult {
-        let fluidState: VadStreamState
-        if let existing = state.fluidState {
-            fluidState = existing
-        } else {
-            fluidState = await manager.makeStreamState()
-        }
         let result = try await manager.processStreamingChunk(
             samples,
-            state: fluidState,
+            state: state.fluidState,
             config: config.fluidConfig
         )
         return MeetingVADResult(
             state: MeetingVADStreamState(fluidState: result.state),
-            event: result.event.map(Self.mapEvent),
-            probability: result.probability
+            event: result.event.map(Self.mapEvent)
         )
     }
 
@@ -156,9 +148,7 @@ extension MeetingVADConfig {
     var fluidConfig: VadSegmentationConfig {
         VadSegmentationConfig(
             minSilenceDuration: minSilenceDuration,
-            speechPadding: speechPadding,
-            negativeThreshold: negativeThreshold,
-            negativeThresholdOffset: negativeThresholdOffset
+            speechPadding: speechPadding
         )
     }
 }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingVADService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingVADService.swift
@@ -3,11 +3,13 @@ import FluidAudio
 import Foundation
 import OSLog
 
-/// A speech boundary emitted by streaming VAD. `sampleIndex` is **retroactive**:
-/// it points back to where speech started/ended (minus padding) in the VAD
-/// stream's own absolute sample coordinate, not the current ingest position.
+/// A speech boundary emitted by streaming VAD. The `speechEnd` `sampleIndex` is
+/// **retroactive**: it points back to where speech ended (minus padding) in the
+/// VAD stream's own absolute sample coordinate, not the current ingest position.
+/// `speechStart` carries no index — the chunker only needs to know that speech
+/// began since the last emit, and uses `speechEnd` as the cut point.
 enum MeetingVADEvent: Sendable {
-    case speechStart(sampleIndex: Int)
+    case speechStart
     case speechEnd(sampleIndex: Int)
 }
 
@@ -140,7 +142,7 @@ actor MeetingVADService: MeetingVoiceActivityDetecting {
     private static func mapEvent(_ event: VadStreamEvent) -> MeetingVADEvent {
         switch event.kind {
         case .speechStart:
-            return .speechStart(sampleIndex: event.sampleIndex)
+            return .speechStart
         case .speechEnd:
             return .speechEnd(sampleIndex: event.sampleIndex)
         }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingVADService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingVADService.swift
@@ -49,10 +49,14 @@ struct MeetingVADConfig: Sendable {
     static let `default` = MeetingVADConfig()
 }
 
-/// Streaming voice-activity detection, MacParakeet-facing. One conforming
-/// instance can serve multiple sources concurrently because all per-stream
-/// state is carried in the `MeetingVADStreamState` value the caller threads
-/// through `processStreamingChunk`.
+/// Streaming voice-activity detection, MacParakeet-facing. Per-stream state is
+/// carried in the `MeetingVADStreamState` value the caller threads through
+/// `processStreamingChunk`, so one instance can back several sources (mic +
+/// system). Callers must invoke it **serially**, though: the FluidAudio-backed
+/// implementation shares a pooled ANE buffer inside `VadManager`, so it is not
+/// safe to call truly concurrently (e.g. from a `TaskGroup`). The actor hop plus
+/// `CaptureOrchestrator`'s sequential mic-then-system calls provide that
+/// serialization.
 protocol MeetingVoiceActivityDetecting: Sendable {
     func makeStreamState() async -> MeetingVADStreamState
     func processStreamingChunk(

--- a/Tests/MacParakeetTests/Audio/FixedMeetingLiveAudioChunkerTests.swift
+++ b/Tests/MacParakeetTests/Audio/FixedMeetingLiveAudioChunkerTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import MacParakeetCore
+
+/// The fixed adapter is the production default and fallback path; it must stay
+/// byte-identical to `AudioChunker`.
+final class FixedMeetingLiveAudioChunkerTests: XCTestCase {
+    func testMatchesAudioChunkerForSteadyStream() async {
+        let adapter = FixedMeetingLiveAudioChunker()
+        let reference = AudioChunker()
+
+        // Feed several 8 000-sample batches (0.5s each) and compare emissions.
+        var adapterChunks: [AudioChunker.AudioChunk] = []
+        var referenceChunks: [AudioChunker.AudioChunk] = []
+        for _ in 0..<30 {
+            let batch = [Float](repeating: 0.2, count: 8_000)
+            adapterChunks += await adapter.addSamples(batch)
+            if let chunk = await reference.addSamples(batch) {
+                referenceChunks.append(chunk)
+            }
+        }
+
+        XCTAssertEqual(adapterChunks.count, referenceChunks.count)
+        XCTAssertFalse(adapterChunks.isEmpty)
+        for (lhs, rhs) in zip(adapterChunks, referenceChunks) {
+            XCTAssertEqual(lhs.startMs, rhs.startMs)
+            XCTAssertEqual(lhs.endMs, rhs.endMs)
+            XCTAssertEqual(lhs.samples, rhs.samples)
+        }
+    }
+
+    func testFlushMatchesAudioChunker() async {
+        let adapter = FixedMeetingLiveAudioChunker()
+        let reference = AudioChunker()
+
+        let batch = [Float](repeating: 0.3, count: 20_000)  // > minimum, < chunk
+        _ = await adapter.addSamples(batch)
+        _ = await reference.addSamples(batch)
+
+        let adapterFlush = await adapter.flush()
+        let referenceFlush = await reference.flush()
+
+        XCTAssertEqual(adapterFlush?.startMs, referenceFlush?.startMs)
+        XCTAssertEqual(adapterFlush?.endMs, referenceFlush?.endMs)
+        XCTAssertEqual(adapterFlush?.samples, referenceFlush?.samples)
+    }
+
+    func testResetClearsState() async {
+        let adapter = FixedMeetingLiveAudioChunker()
+        _ = await adapter.addSamples([Float](repeating: 0.1, count: 80_000))
+        await adapter.reset()
+
+        let diag = await adapter.diagnostics
+        XCTAssertEqual(diag.mode, .fixed)
+        XCTAssertEqual(diag.chunksEmitted, 0)
+
+        // After reset the timeline restarts at 0.
+        let chunks = await adapter.addSamples([Float](repeating: 0.1, count: 80_000))
+        XCTAssertEqual(chunks.first?.startMs, 0)
+    }
+}

--- a/Tests/MacParakeetTests/Audio/FixedMeetingLiveAudioChunkerTests.swift
+++ b/Tests/MacParakeetTests/Audio/FixedMeetingLiveAudioChunkerTests.swift
@@ -49,10 +49,6 @@ final class FixedMeetingLiveAudioChunkerTests: XCTestCase {
         _ = await adapter.addSamples([Float](repeating: 0.1, count: 80_000))
         await adapter.reset()
 
-        let diag = await adapter.diagnostics
-        XCTAssertEqual(diag.mode, .fixed)
-        XCTAssertEqual(diag.chunksEmitted, 0)
-
         // After reset the timeline restarts at 0.
         let chunks = await adapter.addSamples([Float](repeating: 0.1, count: 80_000))
         XCTAssertEqual(chunks.first?.startMs, 0)

--- a/Tests/MacParakeetTests/Audio/SpeechBoundaryMeetingLiveAudioChunkerTests.swift
+++ b/Tests/MacParakeetTests/Audio/SpeechBoundaryMeetingLiveAudioChunkerTests.swift
@@ -240,6 +240,28 @@ final class SpeechBoundaryMeetingLiveAudioChunkerTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(diag.droppedSilenceWindows, 1)
     }
 
+    func testStaleRetroactiveSpeechEndDropsTrailingSilenceInsteadOfForcing() async {
+        // speechStart, continuous speech to a 10s force-emit (window 40), then a
+        // speechEnd whose retroactive index (150 000) lands BEFORE the
+        // post-force-emit lastEmittedSample (156 000). The stale cut must clear
+        // the speech flag so the trailing silence is DROPPED — not force-emitted
+        // as a silence chunk every 10s.
+        let vad = FakeMeetingVAD(events: [
+            1: .speechStart,
+            41: .speechEnd(sampleIndex: 150_000),
+        ])
+        let chunker = SpeechBoundaryMeetingLiveAudioChunker(vad: vad)
+
+        // 40 windows force-emit once; window 41 delivers the stale end; the rest
+        // is silence that should reach the max cap (~window 78) and be dropped.
+        let chunks = await feed(chunker, windows: 78)
+
+        XCTAssertEqual(chunks.count, 1, "only the single force-emit should be emitted")
+        let diag = await chunker.diagnostics
+        XCTAssertEqual(diag.forceEmits, 1, "a stale end must not leave the speech flag set (which would force-emit silence)")
+        XCTAssertGreaterThanOrEqual(diag.droppedSilenceWindows, 1, "post-speech silence should be dropped")
+    }
+
     func testFlushTrimsTrailingSilenceAtSpeechEndBoundary() async {
         // Speech for 10 windows, then a clean speech-end inside the final partial
         // (< 256 ms) tail fed at flush. flush() must cut at the VAD boundary
@@ -285,7 +307,6 @@ private enum FakeVADError: Error {
 /// throws on `failCalls`. State is ignored (the chunker round-trips it).
 private actor FakeMeetingVAD: MeetingVoiceActivityDetecting {
     private var callIndex = 0
-    private var processed = 0
     private let events: [Int: MeetingVADEvent]
     private let failCalls: Set<Int>
 
@@ -304,15 +325,9 @@ private actor FakeMeetingVAD: MeetingVoiceActivityDetecting {
         config: MeetingVADConfig
     ) throws -> MeetingVADResult {
         callIndex += 1
-        processed += samples.count
         if failCalls.contains(callIndex) {
             throw FakeVADError.boom
         }
-        let event = events[callIndex]
-        let probability: Float = {
-            if case .speechStart = event { return 1.0 }
-            return 0.0
-        }()
-        return MeetingVADResult(state: state, event: event, probability: probability)
+        return MeetingVADResult(state: state, event: events[callIndex])
     }
 }

--- a/Tests/MacParakeetTests/Audio/SpeechBoundaryMeetingLiveAudioChunkerTests.swift
+++ b/Tests/MacParakeetTests/Audio/SpeechBoundaryMeetingLiveAudioChunkerTests.swift
@@ -14,7 +14,7 @@ final class SpeechBoundaryMeetingLiveAudioChunkerTests: XCTestCase {
     func testSpeechEndAfterMinimumEmitsOneContiguousChunk() async {
         // speechStart at the first window, speechEnd at the 10th (40 960 samples).
         let vad = FakeMeetingVAD(events: [
-            1: .speechStart(sampleIndex: 0),
+            1: .speechStart,
             10: .speechEnd(sampleIndex: 40_960),
         ])
         let chunker = SpeechBoundaryMeetingLiveAudioChunker(vad: vad)
@@ -32,7 +32,7 @@ final class SpeechBoundaryMeetingLiveAudioChunkerTests: XCTestCase {
         // First speech-end lands at 16 000 samples (1.0s < 2.0s min) and must be
         // skipped; the next end at 40 960 emits a single chunk covering both.
         let vad = FakeMeetingVAD(events: [
-            1: .speechStart(sampleIndex: 0),
+            1: .speechStart,
             4: .speechEnd(sampleIndex: 16_000),
             10: .speechEnd(sampleIndex: 40_960),
         ])
@@ -48,9 +48,9 @@ final class SpeechBoundaryMeetingLiveAudioChunkerTests: XCTestCase {
     func testConsecutiveSpeechEndsAreContiguous() async {
         // Two valid speech segments: ends at 40 960 and 81 920.
         let vad = FakeMeetingVAD(events: [
-            1: .speechStart(sampleIndex: 0),
+            1: .speechStart,
             10: .speechEnd(sampleIndex: 40_960),
-            11: .speechStart(sampleIndex: 40_960),
+            11: .speechStart,
             20: .speechEnd(sampleIndex: 81_920),
         ])
         let chunker = SpeechBoundaryMeetingLiveAudioChunker(vad: vad)
@@ -94,7 +94,7 @@ final class SpeechBoundaryMeetingLiveAudioChunkerTests: XCTestCase {
 
     func testForceEmitAtMaxDurationKeepsTailOverlap() async {
         // speechStart, then a long monologue with no speech-end.
-        let vad = FakeMeetingVAD(events: [1: .speechStart(sampleIndex: 0)])
+        let vad = FakeMeetingVAD(events: [1: .speechStart])
         let chunker = SpeechBoundaryMeetingLiveAudioChunker(vad: vad)
 
         // 40 windows = 163 840 samples; force-emit fires once buffer ≥ 160 000.
@@ -123,7 +123,7 @@ final class SpeechBoundaryMeetingLiveAudioChunkerTests: XCTestCase {
     // MARK: - flush
 
     func testFlushEmitsSpokenTail() async {
-        let vad = FakeMeetingVAD(events: [1: .speechStart(sampleIndex: 0)])
+        let vad = FakeMeetingVAD(events: [1: .speechStart])
         let chunker = SpeechBoundaryMeetingLiveAudioChunker(vad: vad)
 
         _ = await feed(chunker, windows: 5)  // 20 480 samples, no end event
@@ -146,7 +146,7 @@ final class SpeechBoundaryMeetingLiveAudioChunkerTests: XCTestCase {
     }
 
     func testFlushDropsTinyTail() async {
-        let vad = FakeMeetingVAD(events: [1: .speechStart(sampleIndex: 0)])
+        let vad = FakeMeetingVAD(events: [1: .speechStart])
         let chunker = SpeechBoundaryMeetingLiveAudioChunker(vad: vad)
 
         _ = await feed(chunker, windows: 1)  // 4 096 < 8 000 flush minimum
@@ -159,7 +159,7 @@ final class SpeechBoundaryMeetingLiveAudioChunkerTests: XCTestCase {
 
     func testResetRestartsTimelineAtZero() async {
         let vad = FakeMeetingVAD(events: [
-            1: .speechStart(sampleIndex: 0),
+            1: .speechStart,
             10: .speechEnd(sampleIndex: 40_960),
         ])
         let chunker = SpeechBoundaryMeetingLiveAudioChunker(vad: vad)
@@ -201,7 +201,7 @@ final class SpeechBoundaryMeetingLiveAudioChunkerTests: XCTestCase {
     func testTransientVADErrorDoesNotTriggerFallback() async {
         let vad = FakeMeetingVAD(
             events: [
-                1: .speechStart(sampleIndex: 0),
+                1: .speechStart,
                 10: .speechEnd(sampleIndex: 40_960),
             ],
             failCalls: [2]  // single transient error, recovers on call 3
@@ -215,6 +215,48 @@ final class SpeechBoundaryMeetingLiveAudioChunkerTests: XCTestCase {
         XCTAssertEqual(diag.vadErrors, 1)
         XCTAssertEqual(chunks.count, 1)
         XCTAssertEqual(chunks[0].samples.count, 40_960)
+    }
+
+    // MARK: - lockstep buffering (regression: large ingest must not drop unexamined speech)
+
+    func testLargeSingleIngestDropsLeadingSilenceButKeepsLaterSpeech() async {
+        // One giant ingest (45 windows) where VAD only detects speech at window
+        // 41. Because the emittable buffer only ever holds VAD-examined audio,
+        // the leading silence (windows 1–39) is dropped, window 40 is retained as
+        // context, and the speech (windows 41–45) is preserved — never discarded
+        // ahead of the VAD read head.
+        let vad = FakeMeetingVAD(events: [41: .speechStart])
+        let chunker = SpeechBoundaryMeetingLiveAudioChunker(vad: vad)
+
+        let emitted = await chunker.addSamples([Float](repeating: 0.1, count: 45 * window))
+        XCTAssertTrue(emitted.isEmpty, "speech only just started; nothing to emit yet")
+
+        let tail = await chunker.flush()
+        XCTAssertEqual(tail?.samples.count, 24_576, "speech audio must survive the silence drop")
+        XCTAssertEqual(tail?.startMs, 9_984, "leading silence (windows 1–39) should be dropped")
+        XCTAssertEqual(tail?.endMs, 11_520)
+
+        let diag = await chunker.diagnostics
+        XCTAssertGreaterThanOrEqual(diag.droppedSilenceWindows, 1)
+    }
+
+    func testFlushTrimsTrailingSilenceAtSpeechEndBoundary() async {
+        // Speech for 10 windows, then a clean speech-end inside the final partial
+        // (< 256 ms) tail fed at flush. flush() must cut at the VAD boundary
+        // rather than emit the trailing silence after it.
+        let vad = FakeMeetingVAD(events: [
+            1: .speechStart,
+            11: .speechEnd(sampleIndex: 40_960),  // fires when the tail is fed at flush
+        ])
+        let chunker = SpeechBoundaryMeetingLiveAudioChunker(vad: vad)
+
+        let emitted = await chunker.addSamples([Float](repeating: 0.1, count: 10 * window + 2_000))
+        XCTAssertTrue(emitted.isEmpty)
+
+        let tail = await chunker.flush()
+        XCTAssertEqual(tail?.samples.count, 40_960, "trailing silence past the speech-end must be trimmed")
+        XCTAssertEqual(tail?.startMs, 0)
+        XCTAssertEqual(tail?.endMs, 2_560)
     }
 
     // MARK: - helpers

--- a/Tests/MacParakeetTests/Audio/SpeechBoundaryMeetingLiveAudioChunkerTests.swift
+++ b/Tests/MacParakeetTests/Audio/SpeechBoundaryMeetingLiveAudioChunkerTests.swift
@@ -1,0 +1,276 @@
+import XCTest
+@testable import MacParakeetCore
+
+/// Deterministic state-machine coverage for the VAD speech-boundary chunker,
+/// driven by a scripted fake VAD so no FluidAudio models are loaded.
+final class SpeechBoundaryMeetingLiveAudioChunkerTests: XCTestCase {
+    private let window = 4_096
+    private let minChunkSamples = 32_000   // 2.0s
+    private let maxChunkSamples = 160_000  // 10.0s
+    private let flushMinSamples = 8_000    // 0.5s
+
+    // MARK: - speech-end emits
+
+    func testSpeechEndAfterMinimumEmitsOneContiguousChunk() async {
+        // speechStart at the first window, speechEnd at the 10th (40 960 samples).
+        let vad = FakeMeetingVAD(events: [
+            1: .speechStart(sampleIndex: 0),
+            10: .speechEnd(sampleIndex: 40_960),
+        ])
+        let chunker = SpeechBoundaryMeetingLiveAudioChunker(vad: vad)
+
+        let chunks = await feed(chunker, windows: 10)
+
+        XCTAssertEqual(chunks.count, 1)
+        let chunk = chunks[0]
+        XCTAssertEqual(chunk.samples.count, 40_960)
+        XCTAssertEqual(chunk.startMs, 0)
+        XCTAssertEqual(chunk.endMs, 2_560)
+    }
+
+    func testSubMinimumSpeechEndIsNotEmittedButExtendedByNextEnd() async {
+        // First speech-end lands at 16 000 samples (1.0s < 2.0s min) and must be
+        // skipped; the next end at 40 960 emits a single chunk covering both.
+        let vad = FakeMeetingVAD(events: [
+            1: .speechStart(sampleIndex: 0),
+            4: .speechEnd(sampleIndex: 16_000),
+            10: .speechEnd(sampleIndex: 40_960),
+        ])
+        let chunker = SpeechBoundaryMeetingLiveAudioChunker(vad: vad)
+
+        let chunks = await feed(chunker, windows: 10)
+
+        XCTAssertEqual(chunks.count, 1, "sub-minimum end must not emit on its own")
+        XCTAssertEqual(chunks[0].samples.count, 40_960)
+        XCTAssertEqual(chunks[0].startMs, 0)
+    }
+
+    func testConsecutiveSpeechEndsAreContiguous() async {
+        // Two valid speech segments: ends at 40 960 and 81 920.
+        let vad = FakeMeetingVAD(events: [
+            1: .speechStart(sampleIndex: 0),
+            10: .speechEnd(sampleIndex: 40_960),
+            11: .speechStart(sampleIndex: 40_960),
+            20: .speechEnd(sampleIndex: 81_920),
+        ])
+        let chunker = SpeechBoundaryMeetingLiveAudioChunker(vad: vad)
+
+        let chunks = await feed(chunker, windows: 20)
+
+        XCTAssertEqual(chunks.count, 2)
+        XCTAssertEqual(chunks[0].startMs, 0)
+        XCTAssertEqual(chunks[0].endMs, 2_560)
+        // Contiguous accounting: the second chunk begins exactly where the first ended.
+        XCTAssertEqual(chunks[1].startMs, chunks[0].endMs)
+        XCTAssertEqual(chunks[1].startMs, 2_560)
+        XCTAssertEqual(chunks[1].endMs, 5_120)
+    }
+
+    // MARK: - silence handling
+
+    func testSilenceOnlyInputEmitsNothing() async {
+        let vad = FakeMeetingVAD()  // never reports speech
+        let chunker = SpeechBoundaryMeetingLiveAudioChunker(vad: vad)
+
+        let chunks = await feed(chunker, windows: 6)  // ~1.5s, below max
+
+        XCTAssertTrue(chunks.isEmpty)
+    }
+
+    func testProlongedSilenceIsDiscardedNotEmitted() async {
+        let vad = FakeMeetingVAD()  // never reports speech
+        let chunker = SpeechBoundaryMeetingLiveAudioChunker(vad: vad)
+
+        // 45 windows = 184 320 samples, well past the 160 000 max.
+        let chunks = await feed(chunker, windows: 45)
+
+        XCTAssertTrue(chunks.isEmpty, "silence must never be emitted as a chunk")
+        let diag = await chunker.diagnostics
+        XCTAssertGreaterThanOrEqual(diag.droppedSilenceWindows, 1)
+        XCTAssertEqual(diag.forceEmits, 0)
+    }
+
+    // MARK: - max-duration force emit
+
+    func testForceEmitAtMaxDurationKeepsTailOverlap() async {
+        // speechStart, then a long monologue with no speech-end.
+        let vad = FakeMeetingVAD(events: [1: .speechStart(sampleIndex: 0)])
+        let chunker = SpeechBoundaryMeetingLiveAudioChunker(vad: vad)
+
+        // 40 windows = 163 840 samples; force-emit fires once buffer ≥ 160 000.
+        let chunks = await feed(chunker, windows: 40)
+
+        XCTAssertEqual(chunks.count, 1)
+        XCTAssertEqual(chunks[0].samples.count, maxChunkSamples)
+        XCTAssertEqual(chunks[0].startMs, 0)
+        XCTAssertEqual(chunks[0].endMs, 10_000)
+
+        let diag = await chunker.diagnostics
+        XCTAssertEqual(diag.forceEmits, 1)
+
+        // The retained 250ms tail means the next chunk re-includes it: feed
+        // another long stretch and confirm the next chunk starts before the
+        // previous end (deliberate overlap the assembler dedups).
+        let more = await feed(chunker, windows: 40)
+        if let next = more.first {
+            XCTAssertLessThan(next.startMs, 10_000, "force-emit tail overlap should re-feed audio")
+            XCTAssertEqual(next.startMs, (maxChunkSamples - 4_000) * 1000 / 16_000)
+        } else {
+            XCTFail("expected a second force-emit after another long stretch")
+        }
+    }
+
+    // MARK: - flush
+
+    func testFlushEmitsSpokenTail() async {
+        let vad = FakeMeetingVAD(events: [1: .speechStart(sampleIndex: 0)])
+        let chunker = SpeechBoundaryMeetingLiveAudioChunker(vad: vad)
+
+        _ = await feed(chunker, windows: 5)  // 20 480 samples, no end event
+        let tail = await chunker.flush()
+
+        XCTAssertNotNil(tail)
+        XCTAssertEqual(tail?.samples.count, 20_480)
+        XCTAssertEqual(tail?.startMs, 0)
+        XCTAssertEqual(tail?.endMs, 1_280)
+    }
+
+    func testFlushDropsSilentTail() async {
+        let vad = FakeMeetingVAD()  // no speech
+        let chunker = SpeechBoundaryMeetingLiveAudioChunker(vad: vad)
+
+        _ = await feed(chunker, windows: 5)
+        let tail = await chunker.flush()
+
+        XCTAssertNil(tail, "a tail with no detected speech must be dropped")
+    }
+
+    func testFlushDropsTinyTail() async {
+        let vad = FakeMeetingVAD(events: [1: .speechStart(sampleIndex: 0)])
+        let chunker = SpeechBoundaryMeetingLiveAudioChunker(vad: vad)
+
+        _ = await feed(chunker, windows: 1)  // 4 096 < 8 000 flush minimum
+        let tail = await chunker.flush()
+
+        XCTAssertNil(tail, "a sub-0.5s tail must be dropped")
+    }
+
+    // MARK: - reset
+
+    func testResetRestartsTimelineAtZero() async {
+        let vad = FakeMeetingVAD(events: [
+            1: .speechStart(sampleIndex: 0),
+            10: .speechEnd(sampleIndex: 40_960),
+        ])
+        let chunker = SpeechBoundaryMeetingLiveAudioChunker(vad: vad)
+
+        _ = await feed(chunker, windows: 10)
+        await chunker.reset()
+
+        let after = await chunker.flush()
+        XCTAssertNil(after, "reset should clear the buffer")
+
+        let diag = await chunker.diagnostics
+        XCTAssertEqual(diag.chunksEmitted, 0)
+        XCTAssertEqual(diag.speechEndEvents, 0)
+    }
+
+    // MARK: - fallback
+
+    func testRepeatedVADErrorsFallBackToFixedChunking() async {
+        let vad = FakeMeetingVAD(failCalls: [1, 2, 3])
+        let chunker = SpeechBoundaryMeetingLiveAudioChunker(vad: vad)
+
+        // Feed enough to cross the fixed 5s window after fallback.
+        let chunks = await feed(chunker, windows: 25)
+
+        let diag = await chunker.diagnostics
+        XCTAssertTrue(diag.fellBackToFixed)
+        XCTAssertGreaterThanOrEqual(diag.vadErrors, 3)
+        XCTAssertFalse(chunks.isEmpty, "fixed fallback should still emit live chunks")
+        // First fixed chunk mirrors AudioChunker: 80 000 samples starting at 0.
+        XCTAssertEqual(chunks[0].samples.count, 80_000)
+        XCTAssertEqual(chunks[0].startMs, 0)
+        XCTAssertEqual(chunks[0].endMs, 5_000)
+        // Timestamps stay monotonic across the switch.
+        for (lhs, rhs) in zip(chunks, chunks.dropFirst()) {
+            XCTAssertLessThanOrEqual(lhs.startMs, rhs.startMs)
+        }
+    }
+
+    func testTransientVADErrorDoesNotTriggerFallback() async {
+        let vad = FakeMeetingVAD(
+            events: [
+                1: .speechStart(sampleIndex: 0),
+                10: .speechEnd(sampleIndex: 40_960),
+            ],
+            failCalls: [2]  // single transient error, recovers on call 3
+        )
+        let chunker = SpeechBoundaryMeetingLiveAudioChunker(vad: vad)
+
+        let chunks = await feed(chunker, windows: 10)
+
+        let diag = await chunker.diagnostics
+        XCTAssertFalse(diag.fellBackToFixed)
+        XCTAssertEqual(diag.vadErrors, 1)
+        XCTAssertEqual(chunks.count, 1)
+        XCTAssertEqual(chunks[0].samples.count, 40_960)
+    }
+
+    // MARK: - helpers
+
+    /// Feed `windows` of exactly 4 096 samples, mirroring the production cadence
+    /// where each ingest is roughly one VAD window. Returns all emitted chunks.
+    @discardableResult
+    private func feed(
+        _ chunker: SpeechBoundaryMeetingLiveAudioChunker,
+        windows: Int,
+        value: Float = 0.1
+    ) async -> [AudioChunker.AudioChunk] {
+        var all: [AudioChunker.AudioChunk] = []
+        for _ in 0..<windows {
+            all += await chunker.addSamples([Float](repeating: value, count: window))
+        }
+        return all
+    }
+}
+
+private enum FakeVADError: Error {
+    case boom
+}
+
+/// Scripted VAD: emits the programmed event for a given 1-based call index, and
+/// throws on `failCalls`. State is ignored (the chunker round-trips it).
+private actor FakeMeetingVAD: MeetingVoiceActivityDetecting {
+    private var callIndex = 0
+    private var processed = 0
+    private let events: [Int: MeetingVADEvent]
+    private let failCalls: Set<Int>
+
+    init(events: [Int: MeetingVADEvent] = [:], failCalls: Set<Int> = []) {
+        self.events = events
+        self.failCalls = failCalls
+    }
+
+    func makeStreamState() -> MeetingVADStreamState {
+        MeetingVADStreamState()
+    }
+
+    func processStreamingChunk(
+        _ samples: [Float],
+        state: MeetingVADStreamState,
+        config: MeetingVADConfig
+    ) throws -> MeetingVADResult {
+        callIndex += 1
+        processed += samples.count
+        if failCalls.contains(callIndex) {
+            throw FakeVADError.boom
+        }
+        let event = events[callIndex]
+        let probability: Float = {
+            if case .speechStart = event { return 1.0 }
+            return 0.0
+        }()
+        return MeetingVADResult(state: state, event: event, probability: probability)
+    }
+}

--- a/plans/active/2026-05-meeting-vad-guided-live-chunking.md
+++ b/plans/active/2026-05-meeting-vad-guided-live-chunking.md
@@ -36,6 +36,17 @@ live chunking via `FixedMeetingLiveAudioChunker`, byte-identical to
 - **Phase 5** — real-meeting threshold tuning and the default-on decision; only
   then update `spec/05-audio-pipeline.md` / `spec/09-testing.md`.
 
+**Review findings deferred to enablement (multi-AI convergence on PR #387):**
+- **Reuse the `VadManager` across sessions.** `makeIfModelCached` loads the
+  CoreML model on every `startRecording()`. Harmless while the flag is off (no
+  model on disk), but once the model is cached (follow-up model-prep PR) this
+  adds a synchronous load to each meeting start — cache one `MeetingVADService`
+  on `MeetingRecordingService` and reuse it.
+- **Sub-minimum speech-end then prolonged silence.** A <2.0s utterance keeps
+  `sawSpeechSinceLastEmit` set, so a following long silence force-emits a mostly
+  silent 10s chunk to live STT. Bounded and not data-loss (timestamps stay
+  correct), but a Phase 5 tuning target.
+
 ## Problem
 
 Meeting recording currently feeds the live transcript preview with fixed

--- a/plans/active/2026-05-meeting-vad-guided-live-chunking.md
+++ b/plans/active/2026-05-meeting-vad-guided-live-chunking.md
@@ -1,8 +1,40 @@
 # Meeting VAD-Guided Live Chunking
 
-> Status: ACTIVE PLAN
+> Status: ACTIVE PLAN — Phases 1–4 IMPLEMENTED (flag-off)
 > Date: 2026-05-29
 > Scope: meeting live transcript chunk boundaries only.
+
+## Implementation Status (2026-05-28)
+
+Phases 1–4 are implemented behind `AppFeatures.meetingVadLiveChunkingEnabled`,
+which defaults to **`false`** — production behavior is unchanged (fixed 5s / 1s
+live chunking via `FixedMeetingLiveAudioChunker`, byte-identical to
+`AudioChunker`). The VAD path is exercisable in dev builds and fully unit-tested.
+
+- **Phase 1** — `MeetingLiveAudioChunking` protocol + `MeetingLiveChunkingDiagnostics`
+  + `FixedMeetingLiveAudioChunker`; `CaptureOrchestrator` now depends on the
+  abstraction. (`Sources/MacParakeetCore/Audio/MeetingLiveAudioChunking.swift`)
+- **Phase 2** — `SpeechBoundaryMeetingLiveAudioChunker` actor with contiguous
+  sample accounting, speech-end cuts, chunker-owned 2.0s/10.0s bounds,
+  force-emit tail overlap, flush, reset, and degraded fixed-fallback on repeated
+  VAD errors. Deterministic tests via a fake VAD (no FluidAudio models loaded).
+  (`.../Audio/SpeechBoundaryMeetingLiveAudioChunker.swift`,
+  `Tests/.../Audio/SpeechBoundaryMeetingLiveAudioChunkerTests.swift`)
+- **Phase 3** — `MeetingVADService` (FluidAudio `VadManager` adapter) with
+  cached-only, non-blocking init (`makeIfModelCached`, `.cpuOnly` default) and
+  MacParakeet-owned `MeetingVoiceActivityDetecting` / `MeetingVAD*` types.
+  (`.../Services/MeetingRecording/MeetingVADService.swift`)
+- **Phase 4** — flag + `MeetingRecordingService.configureLiveChunkers(for:)`
+  picks fixed vs speech-boundary per session (VAD only for cached-model Parakeet
+  sessions; per-source fixed fallback otherwise), with `meeting_live_chunking_mode`
+  diagnostics.
+
+**Not yet done (need hardware / live meetings):**
+- **Phase 0** — `.cpuOnly` vs `.cpuAndNeuralEngine` benchmark + live-latency
+  measurement, and the cached-only-vs-prepare-during-onboarding decision. The
+  service currently defaults to `.cpuOnly`, cached-only.
+- **Phase 5** — real-meeting threshold tuning and the default-on decision; only
+  then update `spec/05-audio-pipeline.md` / `spec/09-testing.md`.
 
 ## Problem
 

--- a/plans/active/2026-05-meeting-vad-guided-live-chunking.md
+++ b/plans/active/2026-05-meeting-vad-guided-live-chunking.md
@@ -1,0 +1,463 @@
+# Meeting VAD-Guided Live Chunking
+
+> Status: ACTIVE PLAN
+> Date: 2026-05-29
+> Scope: meeting live transcript chunk boundaries only.
+
+## Problem
+
+Meeting recording currently feeds the live transcript preview with fixed
+`AudioChunker` windows: 5 seconds of audio with 1 second of overlap. This is
+simple and robust, but fixed windows can split active speech in the middle of a
+sentence, enqueue silence-heavy chunks, and make the live preview feel choppier
+than the final transcript.
+
+The final transcript path is already safer than the live preview path:
+MacParakeet re-transcribes retained `microphone.m4a` and `system.m4a` source
+files after recording stops, then merges those source-aware results by persisted
+alignment. This plan must not change that final path.
+
+## Goals
+
+- Cut meeting live-preview chunks at speech boundaries when VAD is available.
+- Keep fixed 5s chunking as the fallback path.
+- Preserve sample-time chunk timestamps and pause/resume monotonicity.
+- Keep microphone and system chunkers source-specific and alignment-safe.
+- Reduce live STT work on silence-heavy windows.
+- Improve live transcript coherence without changing retained audio, final STT,
+  or meeting storage.
+- Make VAD availability, fallback, and chunk boundary reasons visible in
+  diagnostics.
+
+## Non-Goals
+
+- No final transcript repair, coverage audit, or VAD-based mutation of saved
+  transcripts.
+- No change to `TranscriptionService.transcribeMeetingAudio`.
+- No change to retained source files: `microphone.m4a`, `system.m4a`, and
+  `meeting.m4a` remain as they are.
+- No user-facing setting in the first implementation.
+- No re-enable of VPIO, Core Audio process taps, or capture teardown on pause.
+- No direct feature ownership of FluidAudio APIs outside a small adapter.
+
+## Verified Current State
+
+- `AudioChunker` is the current live-preview chunker. It emits one 5s chunk once
+  80,000 samples are buffered at 16 kHz, retains 16,000 samples of overlap, and
+  drops tails shorter than 8,000 samples.
+- `CaptureOrchestrator` owns the live path's join, conditioning, and per-source
+  chunkers. It feeds both mic and system chunkers on every joined pair so
+  sample-position counters stay lockstep even when one source is silence-padded.
+- Pause/resume intentionally does not reset `CaptureOrchestrator` or
+  `AudioChunker`; resetting would zero `totalSamplesProcessed` and cause
+  post-resume live chunks to be filtered as duplicates.
+- `LiveChunkTranscriber` accepts `AudioChunker.AudioChunk`, writes a temporary
+  16 kHz WAV, routes through the meeting's captured speech engine, and reports
+  ordered results or backpressure drops.
+- FluidAudio 0.14.5 is pinned in `Package.resolved` and exposes:
+  - `VadManager.sampleRate == 16000`
+  - `VadManager.chunkSize == 4096` samples, or 256 ms (model input is 4096 new
+    samples + 64-sample context = 4160; the manager pads/truncates internally if
+    you hand it a different size, but the streaming state advances by the count
+    you pass, so feeding non-`chunkSize` windows desyncs the timeline)
+  - `VadManager.makeStreamState()`
+  - `VadManager.processStreamingChunk(_:state:config:returnSeconds:timeResolution:)`
+  - `VadStreamEvent(kind:sampleIndex:time:)` — the boundary `sampleIndex` is
+    **retroactive** (points back to where speech started/ended, minus padding),
+    not the current ingest position
+  - `VadSegmentationConfig` exists with min speech, min silence, max speech,
+    padding, and hysteresis thresholds, **but the streaming state machine only
+    reads `speechPadding`, `minSilenceDuration`, and the
+    `negativeThreshold`/`negativeThresholdOffset` hysteresis** (verified in
+    `VadManager+Streaming.swift:40-91`). `maxSpeechDuration`, `minSpeechDuration`,
+    and `silenceThresholdForSplit` are **inert in streaming mode** — they only
+    affect the batch `segmentSpeech` path. Streaming `speechEnd` fires *only* on
+    real silence; FluidAudio never force-splits a long monologue.
+- MacParakeet currently prepares ASR and diarization assets, but there is no
+  MacParakeet-owned VAD service or VAD model readiness surface.
+
+## Design
+
+### 1. Add a MacParakeet-owned live chunking abstraction
+
+Keep product code independent of any one VAD implementation:
+
+```swift
+protocol MeetingLiveAudioChunking: Sendable {
+    func addSamples(_ samples: [Float]) async -> [AudioChunker.AudioChunk]
+    func flush() async -> AudioChunker.AudioChunk?
+    func reset() async
+    var diagnostics: MeetingLiveChunkingDiagnostics { get async }
+}
+```
+
+The existing fixed-window behavior becomes `FixedMeetingLiveAudioChunker`, a
+thin adapter around `AudioChunker`. This keeps the fallback path testable and
+lets `CaptureOrchestrator` depend on one shape.
+
+`addSamples` returns an array, not an optional single chunk. The current path
+usually emits at most one chunk per ingest, but a boundary-driven chunker should
+not bake that assumption into the abstraction.
+
+### 2. Add a speech-boundary chunker
+
+Introduce `SpeechBoundaryMeetingLiveAudioChunker`, an actor that maintains:
+
+- `totalSamplesSeen`
+- `lastEmittedSample`
+- buffered 16 kHz samples
+- pending VAD input samples
+- current `VadStreamState`
+- recent VAD probabilities for diagnostics only
+- fallback/error counters
+
+VAD input must be fed in exact `VadManager.chunkSize` (4096-sample) windows. Do
+not pass arbitrary buffer sizes to `processStreamingChunk`, because FluidAudio
+pads or truncates model input internally while the streaming state advances by
+the caller-provided sample count — mismatched sizes desync the boundary
+timeline. Buffer incoming samples and feed them in exact 4096-sample slices,
+holding the remainder for the next ingest.
+
+**The chunker — not FluidAudio — owns the min and max chunk bounds.** As noted
+in Verified Current State, the streaming state machine ignores
+`maxSpeechDuration`/`minSpeechDuration`/`silenceThresholdForSplit`. So the
+config below only carries the knobs that actually affect streaming, and the
+2.0s minimum and 10.0s maximum are enforced by the chunker's own sample
+counters.
+
+Initial live config (only streaming-relevant knobs):
+
+```swift
+VadSegmentationConfig(
+    minSilenceDuration: 0.50,   // silence before a speechEnd fires
+    speechPadding: 0.15         // padding folded into the retroactive boundary index
+    // negativeThreshold / negativeThresholdOffset: tune in Phase 5 for sensitivity
+)
+// NOTE: minSpeechDuration, maxSpeechDuration, and silenceThresholdForSplit are
+// INERT in streaming mode. Do not rely on them — the chunker enforces min/max.
+```
+
+Initial chunking policy (enforced by the chunker):
+
+- **Contiguous sample accounting (v1).** Chunks tile the recording with no gaps:
+  each emitted chunk's audio is exactly the buffered slice
+  `[lastEmittedSample, cutSample)`, and `lastEmittedSample` advances to
+  `cutSample` on every emit. Silence between utterances becomes leading silence
+  of the next chunk (minor STT cost, no correctness cost). Do **not** excise
+  silence from the timeline — see the timestamp note below for why.
+- **Cut at the retroactive `speechEnd` sample.** When a `speechEnd` event
+  arrives, the cut point is `event.sampleIndex` (which points into the past),
+  not the current ingest position. Emit `[lastEmittedSample, event.sampleIndex)`
+  and retain the samples after it for the next chunk.
+- Do not emit silence-only output: if no `speechEnd` has arrived and the buffer
+  since `lastEmittedSample` is all silence, keep buffering rather than emitting.
+- Do not emit a speech-end chunk shorter than 2.0 seconds unless `flush()` is
+  called at stop; keep buffering and let the next `speechEnd` extend it.
+- Force emit at 10.0 seconds (chunker sample counter, the *only* max mechanism)
+  even if no `speechEnd` has arrived, to keep live preview latency bounded.
+- Keep a small tail overlap, initially 250 ms, when force-emitting long speech
+  (a forced cut lands mid-word, so re-feed the tail; speech-end cuts land in
+  silence and need no overlap).
+- On `flush()`, emit any remaining chunk with at least 0.5 seconds of audio and
+  detected speech; otherwise drop it.
+
+The chunk timestamps must be derived from sample counters. Under contiguous
+accounting the first sample of each chunk is exactly `lastEmittedSample`:
+
+```text
+startMs = lastEmittedSample * 1000 / 16000     // == first sample of THIS chunk
+endMs   = cutSample          * 1000 / 16000
+```
+
+No wall-clock `Date` or `hostTime` should be used for chunk timestamps.
+
+> **Why contiguous accounting matters.** `MeetingTranscriptAssembler` places
+> words at `chunk.startMs + wordRelativeMs` and dedups by absolute `endMs`
+> (`MeetingTranscriptAssembler.swift:60-73`). It is overlap-agnostic, so
+> variable/zero overlap is safe — *but only if `chunk.startMs` equals the true
+> absolute position of the chunk's first sample.* If the chunker skipped silence
+> gaps and still computed `startMs = lastEmittedSample`, it would understate the
+> position and the new chunk's early words could land at `endMs <= cutoff` and be
+> **silently dropped** from the live preview. Contiguous accounting keeps
+> `startMs = lastEmittedSample` correct and avoids that bug.
+
+### 3. Add a VAD service adapter
+
+Add a small actor in Core, for example `MeetingVADService`, that owns
+`VadManager` lifecycle behind a MacParakeet-owned protocol. The product-facing
+types should not expose FluidAudio's `VadStreamState` or `VadStreamResult`
+directly:
+
+```swift
+struct MeetingVADStreamState: Sendable { /* adapter-owned storage */ }
+
+struct MeetingVADResult: Sendable {
+    let state: MeetingVADStreamState
+    let event: MeetingVADEvent?
+    let probability: Float
+}
+
+enum MeetingVADEvent: Sendable {
+    case speechStart(sampleIndex: Int)
+    case speechEnd(sampleIndex: Int)
+}
+
+protocol MeetingVoiceActivityDetecting: Sendable {
+    func makeStreamState() async -> MeetingVADStreamState
+    func processStreamingChunk(
+        _ samples: [Float],
+        state: MeetingVADStreamState,
+        config: MeetingVADConfig
+    ) async throws -> MeetingVADResult
+}
+```
+
+`MeetingVADConfig` should mirror only the knobs that actually affect streaming
+(`minSilenceDuration`, `speechPadding`, and optionally `negativeThreshold` /
+`negativeThresholdOffset` for sensitivity tuning). The FluidAudio adapter maps
+those to `VadSegmentationConfig` and leaves the inert segmentation knobs at
+their defaults. The min/max chunk bounds are **not** VAD config — they live in
+`SpeechBoundaryMeetingLiveAudioChunker` as sample counters.
+
+The first implementation should be conservative:
+
+- Use VAD only when the VAD model is already available or can initialize quickly.
+- If VAD initialization fails, fall back to fixed chunking for the session.
+- If streaming VAD fails repeatedly during a session, fall back to fixed chunking
+  for that source and record diagnostics.
+- Do not block meeting start on VAD model download.
+
+Compute-unit choice must be benchmarked before enabling by default. VAD is small
+but runs frequently; the plan should compare `.cpuOnly` and
+`.cpuAndNeuralEngine` against live STT latency. Prefer CPU-only if it is fast
+enough and avoids ANE contention with Parakeet.
+
+### 4. Integrate through `CaptureOrchestrator`
+
+Replace the two concrete `AudioChunker` fields with two
+`MeetingLiveAudioChunking` instances:
+
+```swift
+private var microphoneChunker: any MeetingLiveAudioChunking
+private var systemChunker: any MeetingLiveAudioChunking
+```
+
+The orchestrator must preserve existing invariants:
+
+- every drained `MeetingAudioPair` feeds both chunkers
+- silence-padded absent sources still advance the corresponding chunker
+- mic conditioning happens before microphone chunking
+- system audio chunking remains source-specific
+- `reset()` resets pair joiner and both chunkers
+- `flushChunkers()` flushes both sources
+
+The active echo-suppression plan wants cleaned mic samples to drive live mic
+VAD/STT. This plan should integrate at the same seam: the microphone chunker
+receives the already-conditioned mic samples from `MicConditioning`.
+
+> **Sequencing dependency.** Three active plans touch the
+> `CaptureOrchestrator.ingest` mic-conditioning seam: this one,
+> `2026-05-meeting-neural-echo-suppression.md`, and
+> `2026-05-silent-buffer-fallback.md`. VAD consumes the *post-conditioning* mic
+> stream, so it is compatible with echo suppression, but the two should not
+> refactor `ingest` simultaneously. Land (or branch from) the echo-suppression
+> conditioner change first, then tap its output here. Coordinate before parallel
+> implementation.
+
+### 5. Diagnostics
+
+Add private diagnostics, not user-visible text, for:
+
+```text
+meeting_live_chunking_mode source=microphone mode=vad|fixed reason=started|fallback|vad_unavailable|vad_error
+meeting_live_chunk_boundary source=system mode=vad reason=speech_end|max_duration|flush start_ms=<n> end_ms=<n> duration_ms=<n>
+meeting_live_vad_stats source=microphone chunks_processed=<n> speech_start=<n> speech_end=<n> force_emit=<n> dropped_silence=<n> fallback=<bool>
+```
+
+Do not log transcript text, audio paths, device names, model paths, or raw
+sample values.
+
+Telemetry should wait until the diagnostic shape is proven useful. If telemetry
+is added later, keep it aggregated and privacy-safe.
+
+## Rollout Phases
+
+### Phase 0: Benchmark and API spike
+
+- Confirm `VadManager` initialization behavior when VAD assets are absent.
+- Benchmark streaming VAD with `.cpuOnly` and `.cpuAndNeuralEngine`.
+- Measure added live-preview latency while a meeting live chunk is also being
+  transcribed.
+- Decide whether first release is cached-only VAD or prepares VAD assets during
+  onboarding/model repair.
+
+Exit criteria:
+
+- documented compute-unit choice
+- documented model-readiness behavior
+- no plan to block meeting start on VAD download
+
+### Phase 1: Abstraction and fixed adapter
+
+- Add `MeetingLiveAudioChunking`.
+- Wrap current `AudioChunker` as `FixedMeetingLiveAudioChunker`.
+- Update `CaptureOrchestrator` to use the abstraction with fixed mode only.
+- Keep behavior identical to current fixed 5s chunking.
+
+Exit criteria:
+
+- existing `AudioChunkerTests`, `CaptureOrchestratorTests`, and
+  meeting-recording tests still pass
+- no live chunk timing behavior changes yet
+
+### Phase 2: Speech-boundary chunker with fake VAD
+
+- Implement `SpeechBoundaryMeetingLiveAudioChunker` against a fake
+  `MeetingVoiceActivityDetecting` test double.
+- Cover speech start/end, silence-only input, max-duration force emits, flush,
+  reset, VAD errors, and overlap.
+- Verify timestamps stay sample-counter-derived and monotonic.
+
+Exit criteria:
+
+- deterministic unit tests cover the boundary state machine without loading
+  FluidAudio models
+- no dependency on wall-clock timers
+
+### Phase 3: FluidAudio VAD adapter
+
+- Add `MeetingVADService` backed by `VadManager`.
+- Add cached/available checks or a nonblocking initialization strategy.
+- Add per-session fallback to fixed chunking when VAD is unavailable.
+- Keep VAD model lifecycle separate from `STTScheduler`; do not instantiate a
+  second STT runtime or bypass ADR-016.
+
+Exit criteria:
+
+- VAD unavailable path starts meetings normally
+- VAD errors do not fail capture
+- diagnostics clearly show fixed fallback
+
+### Phase 4: Orchestrator integration behind a feature flag
+
+- Add an internal feature flag, for example
+  `AppFeatures.meetingVadLiveChunkingEnabled`.
+- When disabled, construct fixed chunkers.
+- When enabled and VAD is available, construct speech-boundary chunkers.
+- Keep source-specific mode decisions, so one source can fall back without
+  forcing the other source to fall back.
+
+Exit criteria:
+
+- fixed mode remains current production behavior
+- VAD mode is exercisable in dev builds and tests
+- pause/resume and source-alignment tests pass in both modes
+
+### Phase 5: Release hardening
+
+- Tune thresholds with real meetings and synthetic fixtures.
+- Decide whether to enable by default.
+- If default-on, document fallback behavior in `spec/05-audio-pipeline.md`.
+- Update `spec/09-testing.md` with VAD live chunk test coverage.
+
+Exit criteria:
+
+- full `swift test`
+- `git diff --check`
+- dev app smoke:
+  - start meeting
+  - verify live transcript appears after natural pauses
+  - pause/resume
+  - dictate during meeting
+  - stop meeting and verify final transcript still uses source-file STT
+- real call smoke on Zoom or Google Meet
+
+## Test Plan
+
+### Unit Tests
+
+- Fixed adapter preserves current 5s/1s-overlap behavior.
+- Speech-boundary chunker does not emit silence-only chunks.
+- Speech-boundary chunker emits on speech end after minimum duration.
+- Speech-boundary chunker does not emit sub-minimum fragments during normal
+  streaming.
+- Speech-boundary chunker force-emits at max duration.
+- Force-emitted long speech keeps bounded overlap and monotonic timestamps.
+- `flush()` emits a valid spoken tail and drops a silent/tiny tail.
+- `reset()` clears buffer, stream state, and counters.
+- VAD failure switches to fixed fallback without throwing out of the live
+  capture path.
+- Returned chunk `startMs`/`endMs` are sample-counter-based.
+
+### Orchestrator Tests
+
+- Both sources remain lockstep during paired input.
+- Mic-only stretches still advance the system chunker with silence padding.
+- System-only stretches still advance the mic chunker with silence padding.
+- Mic conditioning output feeds the microphone VAD chunker.
+- `flushPendingPairs` and `flushChunkers` preserve final live tail behavior.
+- Pause/resume does not reset chunk timestamps.
+
+### Meeting Service Tests
+
+- VAD chunk mode enqueues fewer or equal silence-only live chunks than fixed
+  mode.
+- Low-signal and system-dominant mic chunk drops still apply after VAD chunking.
+- Backpressure drops remain nonfatal.
+- Stop cancels or drains pending live chunk tasks as today.
+- Final transcription path is unchanged.
+
+### Manual Validation
+
+- Quiet room, local monologue.
+- Remote-only meeting audio.
+- Double-talk: local speaker talks over remote speaker.
+- Long monologue over 60 seconds.
+- Long silence between remarks.
+- Pause/resume during an unfinished speech segment.
+- Dictation during active meeting.
+- VAD model absent or deleted before meeting start.
+- Output-device switch during meeting remains nonfatal.
+
+## Acceptance Criteria
+
+- With VAD enabled and available, live chunks are emitted due to speech end,
+  max duration, or stop flush; not solely every fixed 5 seconds.
+- With VAD unavailable, live chunking falls back to the existing fixed behavior
+  and the meeting still starts.
+- Final saved transcript, retained audio files, source alignment, crash
+  recovery, and export artifacts are unchanged by this plan.
+- Chunk timestamps remain monotonic across pause/resume.
+- Live transcript preview does not regress under STT backpressure.
+- Diagnostics can answer whether a session used VAD, fixed fallback, or changed
+  modes mid-session.
+
+## Risks
+
+- VAD model initialization could add hidden meeting-start latency.
+  Mitigation: cached-only or nonblocking initialization in the first release.
+- VAD inference could contend with Parakeet on ANE.
+  Mitigation: benchmark compute units and prefer CPU-only if acceptable.
+- VAD false negatives could delay live preview.
+  Mitigation: max-duration force emit and fixed fallback after repeated errors.
+- System audio can include non-speech sounds.
+  Mitigation: low-signal filtering remains; final STT remains authoritative.
+- Variable chunk lengths are largely safe: `MeetingTranscriptAssembler` is
+  overlap-agnostic (placement + dedup are absolute-timestamp-based,
+  `MeetingTranscriptAssembler.swift:60-73`). The real, narrow risk is a
+  `startMs` that does not equal the chunk's true first-sample position, which
+  drops words below the dedup cutoff.
+  Mitigation: contiguous sample accounting (Design §2) guarantees
+  `startMs == lastEmittedSample`; add a test asserting no live words are dropped
+  across a speech-end cut and across a force-emit overlap.
+
+## Open Questions
+
+- Should VAD assets be prepared during onboarding/model repair, or should the
+  first release use VAD only when the model already exists?
+- What initial max-duration gives the best live feel: 8s, 10s, or 14s?
+- Should microphone and system sources use the same VAD thresholds?
+- Should VAD mode be enabled only for Parakeet live chunks first, or also when a
+  meeting is pinned to WhisperKit?
+- Once echo suppression ships, should VAD fall back to raw mic or fixed chunks
+  if the cleaned mic stream is unavailable?


### PR DESCRIPTION
## Summary

Implements VAD speech-boundary chunking for the meeting **live transcript preview**, behind `AppFeatures.meetingVadLiveChunkingEnabled` (defaults **off**). Cuts the live preview on natural pauses instead of arbitrary fixed 5s windows — a pattern learned from Muesli's `StreamingVadController`. The authoritative **final** transcript (post-stop full-file STT), retained audio, source alignment, crash recovery, and exports are all untouched.

Plan: `plans/active/2026-05-meeting-vad-guided-live-chunking.md` (Phases 1–4 of 0–5).

## What's in this PR

| Phase | Delivered |
|-------|-----------|
| 1 | `MeetingLiveAudioChunking` protocol + `FixedMeetingLiveAudioChunker` (byte-identical to `AudioChunker`); `CaptureOrchestrator` depends on the abstraction |
| 2 | `SpeechBoundaryMeetingLiveAudioChunker` actor + deterministic fake-VAD unit tests |
| 3 | `MeetingVADService` — FluidAudio `VadManager` adapter, cached-only / non-blocking init, `.cpuOnly` default |
| 4 | Feature flag + `MeetingRecordingService.configureLiveChunkers(for:)` per-session selection + diagnostics |

## Why it's safe to merge

- **Flag defaults off** → production live chunking is the existing fixed 5s/1s path. A test asserts the fixed adapter is byte-identical to `AudioChunker`.
- **VAD never blocks meeting start**: `makeIfModelCached()` only initializes when the Silero model is already on disk; never downloads.
- **Per-source fallback**: VAD is used only for cached-model Parakeet sessions; each source independently degrades to fixed chunking on repeated VAD errors, preserving monotonic timestamps.
- **Contiguous sample accounting** guarantees `chunk.startMs` equals the chunk's true absolute first-sample position — the invariant `MeetingTranscriptAssembler` needs to avoid silently dropping live words. An independent review traced this through every mutation path (speech-end, force-emit overlap, silence drop, flush, fallback, reset) with no findings.

## Validation

- `swift build` clean; `swift test` green: **3052 XCTest, 0 failures**, 9 skipped, plus Swift Testing suites.
- 15 new tests (12 speech-boundary state-machine + 3 fixed-adapter equivalence).
- Existing `CaptureOrchestratorTests` / `AudioChunkerTests` unchanged and green.

## Not in this PR (need hardware / live meetings)

- **Phase 0** — benchmark `.cpuOnly` vs `.cpuAndNeuralEngine` + live-latency under concurrent STT; decide cached-only vs prepare-during-onboarding. (Currently `.cpuOnly`, cached-only.)
- **Phase 5** — real-meeting threshold tuning + the default-on decision; only then update `spec/05-audio-pipeline.md` / `spec/09-testing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)