### PR TITLE
Unify Meetings-page config affordances

### DIFF
--- a/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
+++ b/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
@@ -1095,54 +1095,48 @@ private struct IntelligenceReadyRow: View {
     let locality: String
     let localityIcon: String
     let detail: String?
-    /// Optional tooltip on the locality badge. External providers carry the
-    /// "transcript text may leave this Mac" disclosure here so the card stays
-    /// uncluttered while the notice remains discoverable on hover.
+    /// Optional disclosure for the locality badge. External providers carry the
+    /// "transcript text may leave this Mac" notice here — surfaced as a hover
+    /// tooltip and a VoiceOver hint — so the card stays uncluttered while the
+    /// disclosure remains available.
     let localityHelp: String?
     let tint: Color
     var onOpenSettings: () -> Void
 
     var body: some View {
-        // The Intelligence card sits in a 280–340pt column, so a labeled
-        // settings button beside the name can crowd it. Fall back to a stacked
-        // layout when the row is too narrow (mirrors CalendarInlineControlsRow).
-        ViewThatFits(in: .horizontal) {
-            HStack(alignment: .center, spacing: DesignSystem.Spacing.md) {
-                rowContent
-                Spacer(minLength: DesignSystem.Spacing.sm)
-                settingsButton
+        // The action button sits on its own trailing row (matching the Manage
+        // buttons in the AutoNotes/Live Ask cards) so a labeled button never
+        // crowds the provider name in the narrow 280–340pt column.
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+            HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+                Image(systemName: "sparkles")
+                    .font(.system(size: 17, weight: .medium))
+                    .foregroundStyle(tint)
+                    .frame(width: 22)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    localityBadge
+
+                    if let detail {
+                        Text(detail)
+                            .font(DesignSystem.Typography.caption)
+                            .foregroundStyle(DesignSystem.Colors.textSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+
+                Spacer(minLength: 0)
             }
 
-            VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
-                rowContent
-                settingsButton
-                    .frame(maxWidth: .infinity, alignment: .trailing)
+            Button(action: onOpenSettings) {
+                Label("AI Settings", systemImage: "gearshape")
             }
+            .parakeetAction(.secondary)
+            .help("Open AI Settings")
+            .frame(maxWidth: .infinity, alignment: .trailing)
         }
         .padding(DesignSystem.Spacing.md)
         .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    private var rowContent: some View {
-        HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
-            Image(systemName: "sparkles")
-                .font(.system(size: 17, weight: .medium))
-                .foregroundStyle(tint)
-                .frame(width: 22)
-
-            VStack(alignment: .leading, spacing: 6) {
-                localityBadge
-
-                if let detail {
-                    Text(detail)
-                        .font(DesignSystem.Typography.caption)
-                        .foregroundStyle(DesignSystem.Colors.textSecondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-            }
-
-            Spacer(minLength: 0)
-        }
     }
 
     private var localityBadge: some View {
@@ -1161,27 +1155,23 @@ private struct IntelligenceReadyRow: View {
         .padding(.horizontal, 6)
         .padding(.vertical, 2)
         .background(Capsule().fill(tint.opacity(0.12)))
-        .modifier(OptionalHelp(text: localityHelp))
-    }
-
-    private var settingsButton: some View {
-        Button(action: onOpenSettings) {
-            Label("AI Settings", systemImage: "gearshape")
-        }
-        .parakeetAction(.secondary)
-        .help("Open AI Settings")
-        .accessibilityLabel("Open AI Settings")
+        .modifier(LocalityDisclosure(text: localityHelp))
     }
 }
 
-/// Applies `.help(_:)` only when a tooltip string is present.
-private struct OptionalHelp: ViewModifier {
+/// Attaches the cloud-provider disclosure to the locality badge when present:
+/// a hover tooltip for pointer users and an accessibility hint for VoiceOver.
+/// No-op when `text` is nil (e.g. local providers, which need no disclosure).
+private struct LocalityDisclosure: ViewModifier {
     let text: String?
 
     @ViewBuilder
     func body(content: Content) -> some View {
         if let text {
-            content.help(text)
+            content
+                .accessibilityElement(children: .combine)
+                .help(text)
+                .accessibilityHint(text)
         } else {
             content
         }

--- a/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
+++ b/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
@@ -260,6 +260,9 @@ struct MeetingsView: View {
                     detail: isLocal
                         ? "Meeting summaries and chat use \(displayName) on this Mac."
                         : nil,
+                    localityHelp: isLocal
+                        ? nil
+                        : "\(displayName) may receive transcript text when you run AI actions.",
                     tint: isLocal ? DesignSystem.Colors.successGreen : DesignSystem.Colors.textSecondary,
                     onOpenSettings: onOpenAISettings
                 )
@@ -1092,32 +1095,43 @@ private struct IntelligenceReadyRow: View {
     let locality: String
     let localityIcon: String
     let detail: String?
+    /// Optional tooltip on the locality badge. External providers carry the
+    /// "transcript text may leave this Mac" disclosure here so the card stays
+    /// uncluttered while the notice remains discoverable on hover.
+    let localityHelp: String?
     let tint: Color
     var onOpenSettings: () -> Void
 
     var body: some View {
-        HStack(alignment: .center, spacing: DesignSystem.Spacing.md) {
+        // The Intelligence card sits in a 280–340pt column, so a labeled
+        // settings button beside the name can crowd it. Fall back to a stacked
+        // layout when the row is too narrow (mirrors CalendarInlineControlsRow).
+        ViewThatFits(in: .horizontal) {
+            HStack(alignment: .center, spacing: DesignSystem.Spacing.md) {
+                rowContent
+                Spacer(minLength: DesignSystem.Spacing.sm)
+                settingsButton
+            }
+
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+                rowContent
+                settingsButton
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+            }
+        }
+        .padding(DesignSystem.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var rowContent: some View {
+        HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
             Image(systemName: "sparkles")
                 .font(.system(size: 17, weight: .medium))
                 .foregroundStyle(tint)
                 .frame(width: 22)
 
             VStack(alignment: .leading, spacing: 6) {
-                HStack(spacing: 6) {
-                    Text(displayName)
-                        .font(DesignSystem.Typography.body.weight(.semibold))
-                        .foregroundStyle(DesignSystem.Colors.textPrimary)
-                        .lineLimit(1)
-                    Text(locality)
-                        .font(DesignSystem.Typography.micro.weight(.semibold))
-                        .foregroundStyle(tint)
-                    Image(systemName: localityIcon)
-                        .font(.system(size: 9, weight: .semibold))
-                        .foregroundStyle(tint)
-                }
-                .padding(.horizontal, 6)
-                .padding(.vertical, 2)
-                .background(Capsule().fill(tint.opacity(0.12)))
+                localityBadge
 
                 if let detail {
                     Text(detail)
@@ -1127,17 +1141,50 @@ private struct IntelligenceReadyRow: View {
                 }
             }
 
-            Spacer(minLength: DesignSystem.Spacing.sm)
-
-            Button(action: onOpenSettings) {
-                Label("AI Settings", systemImage: "gearshape")
-            }
-            .parakeetAction(.secondary)
-            .help("Open AI Settings")
-            .accessibilityLabel("Open AI Settings")
+            Spacer(minLength: 0)
         }
-        .padding(DesignSystem.Spacing.md)
-        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var localityBadge: some View {
+        HStack(spacing: 6) {
+            Text(displayName)
+                .font(DesignSystem.Typography.body.weight(.semibold))
+                .foregroundStyle(DesignSystem.Colors.textPrimary)
+                .lineLimit(1)
+            Text(locality)
+                .font(DesignSystem.Typography.micro.weight(.semibold))
+                .foregroundStyle(tint)
+            Image(systemName: localityIcon)
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(tint)
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background(Capsule().fill(tint.opacity(0.12)))
+        .modifier(OptionalHelp(text: localityHelp))
+    }
+
+    private var settingsButton: some View {
+        Button(action: onOpenSettings) {
+            Label("AI Settings", systemImage: "gearshape")
+        }
+        .parakeetAction(.secondary)
+        .help("Open AI Settings")
+        .accessibilityLabel("Open AI Settings")
+    }
+}
+
+/// Applies `.help(_:)` only when a tooltip string is present.
+private struct OptionalHelp: ViewModifier {
+    let text: String?
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if let text {
+            content.help(text)
+        } else {
+            content
+        }
     }
 }
 

--- a/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
+++ b/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
@@ -260,9 +260,6 @@ struct MeetingsView: View {
                     detail: isLocal
                         ? "Meeting summaries and chat use \(displayName) on this Mac."
                         : nil,
-                    localityHelp: isLocal
-                        ? nil
-                        : "\(displayName) may receive transcript text when you run AI actions.",
                     tint: isLocal ? DesignSystem.Colors.successGreen : DesignSystem.Colors.textSecondary,
                     onOpenSettings: onOpenAISettings
                 )
@@ -1095,45 +1092,39 @@ private struct IntelligenceReadyRow: View {
     let locality: String
     let localityIcon: String
     let detail: String?
-    /// Optional disclosure for the locality badge. External providers carry the
-    /// "transcript text may leave this Mac" notice here — surfaced as a hover
-    /// tooltip and a VoiceOver hint — so the card stays uncluttered while the
-    /// disclosure remains available.
-    let localityHelp: String?
     let tint: Color
     var onOpenSettings: () -> Void
 
     var body: some View {
-        // The action button sits on its own trailing row (matching the Manage
-        // buttons in the AutoNotes/Live Ask cards) so a labeled button never
-        // crowds the provider name in the narrow 280–340pt column.
-        VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
-            HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
-                Image(systemName: "sparkles")
-                    .font(.system(size: 17, weight: .medium))
-                    .foregroundStyle(tint)
-                    .frame(width: 22)
+        // Button beside the badge, vertically centered — matches the other
+        // Intelligence states (MeetingsInlineState). `.fixedSize()` keeps the
+        // button intact; a long provider name truncates gracefully rather than
+        // leaving a dead gap below it.
+        HStack(alignment: .center, spacing: DesignSystem.Spacing.md) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 17, weight: .medium))
+                .foregroundStyle(tint)
+                .frame(width: 22)
 
-                VStack(alignment: .leading, spacing: 6) {
-                    localityBadge
+            VStack(alignment: .leading, spacing: 6) {
+                localityBadge
 
-                    if let detail {
-                        Text(detail)
-                            .font(DesignSystem.Typography.caption)
-                            .foregroundStyle(DesignSystem.Colors.textSecondary)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
+                if let detail {
+                    Text(detail)
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
-
-                Spacer(minLength: 0)
             }
+
+            Spacer(minLength: DesignSystem.Spacing.sm)
 
             Button(action: onOpenSettings) {
                 Label("AI Settings", systemImage: "gearshape")
             }
             .parakeetAction(.secondary)
             .help("Open AI Settings")
-            .frame(maxWidth: .infinity, alignment: .trailing)
+            .fixedSize()
         }
         .padding(DesignSystem.Spacing.md)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -1155,26 +1146,6 @@ private struct IntelligenceReadyRow: View {
         .padding(.horizontal, 6)
         .padding(.vertical, 2)
         .background(Capsule().fill(tint.opacity(0.12)))
-        .modifier(LocalityDisclosure(text: localityHelp))
-    }
-}
-
-/// Attaches the cloud-provider disclosure to the locality badge when present:
-/// a hover tooltip for pointer users and an accessibility hint for VoiceOver.
-/// No-op when `text` is nil (e.g. local providers, which need no disclosure).
-private struct LocalityDisclosure: ViewModifier {
-    let text: String?
-
-    @ViewBuilder
-    func body(content: Content) -> some View {
-        if let text {
-            content
-                .accessibilityElement(children: .combine)
-                .help(text)
-                .accessibilityHint(text)
-        } else {
-            content
-        }
     }
 }
 

--- a/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
+++ b/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
@@ -259,7 +259,7 @@ struct MeetingsView: View {
                     localityIcon: isLocal ? "lock" : "cloud",
                     detail: isLocal
                         ? "Meeting summaries and chat use \(displayName) on this Mac."
-                        : "\(displayName) may receive transcript text when you run AI actions.",
+                        : nil,
                     tint: isLocal ? DesignSystem.Colors.successGreen : DesignSystem.Colors.textSecondary,
                     onOpenSettings: onOpenAISettings
                 )
@@ -1091,7 +1091,7 @@ private struct IntelligenceReadyRow: View {
     let displayName: String
     let locality: String
     let localityIcon: String
-    let detail: String
+    let detail: String?
     let tint: Color
     var onOpenSettings: () -> Void
 
@@ -1119,10 +1119,12 @@ private struct IntelligenceReadyRow: View {
                 .padding(.vertical, 2)
                 .background(Capsule().fill(tint.opacity(0.12)))
 
-                Text(detail)
-                    .font(DesignSystem.Typography.caption)
-                    .foregroundStyle(DesignSystem.Colors.textSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                if let detail {
+                    Text(detail)
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
 
             Spacer(minLength: DesignSystem.Spacing.sm)

--- a/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
+++ b/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
@@ -341,7 +341,7 @@ struct MeetingsView: View {
                 } label: {
                     Label("Manage", systemImage: "slider.horizontal.3")
                 }
-                .parakeetAction(.subtle)
+                .parakeetAction(.secondary)
             }
         }
         .padding(DesignSystem.Spacing.md)
@@ -669,9 +669,9 @@ private struct CalendarInlineControlsRow: View {
                 Spacer(minLength: DesignSystem.Spacing.sm)
 
                 Button(action: onOpenCalendarSettings) {
-                    Label("Calendars", systemImage: "slider.horizontal.3")
+                    Label("Calendar Settings", systemImage: "gearshape")
                 }
-                .parakeetAction(.subtle)
+                .parakeetAction(.secondary)
                 .help("Open Calendar Settings")
             }
 
@@ -1128,7 +1128,7 @@ private struct IntelligenceReadyRow: View {
             Spacer(minLength: DesignSystem.Spacing.sm)
 
             Button(action: onOpenSettings) {
-                Image(systemName: "gearshape")
+                Label("AI Settings", systemImage: "gearshape")
             }
             .parakeetAction(.secondary)
             .help("Open AI Settings")


### PR DESCRIPTION
Follow-up to #388. The four secondary config buttons on the Meetings page read as three unrelated treatments — and one (the AI provider gear) was a **bare icon with no label**, so there was no way to tell it opened the Settings window.

## The fix — one honest convention

| Button | Before | After |
|---|---|---|
| Calendar card | `slider` "Calendars" (`.subtle`) | `⚙ Calendar Settings` (`.secondary`) |
| Intelligence (ready) | **icon-only** `⚙` (`.secondary`) | `⚙ AI Settings` (`.secondary`), labeled, beside the badge |
| After Each Meeting | `slider` "Manage" (`.subtle`) | `slider` "Manage" (`.secondary`) |
| Live Ask | `slider` "Manage" (`.secondary`) | _unchanged — the reference_ |

- **Labeled `gearshape`** = "opens the Settings window," named so there's no surprise.
- **`slider` "Manage"** = "edits in place via a sheet." The two Manage buttons now match.
- All bordered `.secondary` — none reads as decorative.

## Intelligence card content change (intentional, not style-only)

Called out explicitly per review:

- The external/cloud provider row no longer shows the body line *"<provider> may receive transcript text when you run AI actions."* — it was redundant with the adjacent **"External ☁"** badge, and enabling an external provider already requires deliberately entering an API key (the real consent moment). This is an explicit owner decision.
- Local providers keep their visible *"…on this Mac"* reassurance line.
- The `AI Settings` button stays beside the badge (vertically centered, `.fixedSize()`), matching the other Intelligence states; a long provider name degrades via truncation rather than leaving a gap. (Earlier iterations tried `ViewThatFits` — a no-op, since a greedy `Spacer` defeats the fallback — and a bottom-row button, which left an empty void; beside-the-badge is the clean result.)

## Why a separate PR

The Calendar and Intelligence rows are pre-existing code, unrelated to the auto-notes feature in #388. Kept #388 scoped to auto-notes; this is the focused affordance-consistency pass.

## Testing

- `swift build --target MacParakeet` clean.
- View-layer change only; no logic/ViewModel/tests affected.
- Verified visually in the dev app (external + local provider states; button no longer crowds or leaves a gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)