### PR TITLE
Prepare Silero VAD model during onboarding for live chunking

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -26,6 +26,9 @@ final class AppEnvironment {
     let transcriptionService: TranscriptionService
     let youtubeDownloader: YouTubeDownloader
     let diarizationService: DiarizationService
+    /// Stateless; fetches the Silero VAD model for VAD-guided meeting live
+    /// chunking during onboarding when `AppFeatures.meetingVadLiveChunkingEnabled`.
+    let meetingVADModelPreparer: any MeetingVADModelPreparing = MeetingVADModelPreparer()
     let clipboardService: ClipboardService
     let systemMediaController: SystemMediaController
     let exportService: ExportService

--- a/Sources/MacParakeet/App/OnboardingCoordinator.swift
+++ b/Sources/MacParakeet/App/OnboardingCoordinator.swift
@@ -44,6 +44,7 @@ final class OnboardingCoordinator {
                 permissionService: environment.permissionService,
                 sttClient: environment.sttScheduler,
                 diarizationService: environment.diarizationService,
+                meetingVADModelPreparer: environment.meetingVADModelPreparer,
                 entitlementsService: environment.entitlementsService
             )
         }
@@ -55,6 +56,7 @@ final class OnboardingCoordinator {
             permissionService: environment.permissionService,
             sttClient: environment.sttScheduler,
             diarizationService: environment.diarizationService,
+            meetingVADModelPreparer: environment.meetingVADModelPreparer,
             entitlementsService: environment.entitlementsService
         )
     }
@@ -68,12 +70,14 @@ final class OnboardingCoordinator {
         permissionService: PermissionServiceProtocol,
         sttClient: STTClientProtocol,
         diarizationService: DiarizationServiceProtocol?,
+        meetingVADModelPreparer: any MeetingVADModelPreparing,
         entitlementsService: EntitlementsService
     ) {
         onboardingWindowController.show(
             permissionService: permissionService,
             sttClient: sttClient,
             diarizationService: diarizationService,
+            meetingVADModelPreparer: meetingVADModelPreparer,
             onFinish: { [weak self] in
                 self?.reopenOnNextActivate = false
                 self?.onRefreshHotkeys()

--- a/Sources/MacParakeet/Onboarding/OnboardingWindowController.swift
+++ b/Sources/MacParakeet/Onboarding/OnboardingWindowController.swift
@@ -16,6 +16,7 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
         permissionService: PermissionServiceProtocol,
         sttClient: STTClientProtocol,
         diarizationService: DiarizationServiceProtocol? = nil,
+        meetingVADModelPreparer: (any MeetingVADModelPreparing)? = nil,
         onFinish: @escaping () -> Void,
         onHotkeyPreviewArm: @escaping () -> Void = {},
         onHotkeyPreviewDisarm: @escaping () -> Void = {},
@@ -32,7 +33,8 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
         let vm = OnboardingViewModel(
             permissionService: permissionService,
             sttClient: sttClient,
-            diarizationService: diarizationService
+            diarizationService: diarizationService,
+            meetingVADModelPreparer: meetingVADModelPreparer
         )
         viewModel = vm
         // Retained so the rehearsal taps/overlay are torn down if the window

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingVADModelPreparer.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingVADModelPreparer.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Prepares the Silero VAD model used by VAD-guided meeting live chunking
+/// (`AppFeatures.meetingVadLiveChunkingEnabled`,
+/// `plans/active/2026-05-meeting-vad-guided-live-chunking.md`).
+///
+/// Onboarding fetches the model up front so the runtime path
+/// (`MeetingVADService.makeIfModelCached`) stays download-free and never adds
+/// latency at meeting start. Mirrors `DiarizationServiceProtocol` model prep so
+/// the onboarding warm-up treats both optional model stacks the same way.
+public protocol MeetingVADModelPreparing: Sendable {
+    /// `true` when every required Silero VAD model file is already cached.
+    func isModelReady() async -> Bool
+    /// Download + compile the Silero VAD model if it is not already cached;
+    /// no-ops when it is. `onProgress` receives coarse status strings.
+    func prepareModel(onProgress: (@Sendable (String) -> Void)?) async throws
+}
+
+extension MeetingVADModelPreparing {
+    public func prepareModel() async throws {
+        try await prepareModel(onProgress: nil)
+    }
+}
+
+/// FluidAudio-backed preparer. Reuses `MeetingVADService`'s cache check and the
+/// same `.cpuOnly` load path, so a successful prep guarantees a later
+/// `makeIfModelCached()` hit.
+public struct MeetingVADModelPreparer: MeetingVADModelPreparing {
+    public init() {}
+
+    public func isModelReady() async -> Bool {
+        MeetingVADService.isModelCached()
+    }
+
+    public func prepareModel(onProgress: (@Sendable (String) -> Void)?) async throws {
+        if MeetingVADService.isModelCached() {
+            onProgress?("Voice-activity model ready")
+            return
+        }
+        onProgress?("Downloading voice-activity model...")
+        try await MeetingVADService.downloadModel()
+        onProgress?("Voice-activity model ready")
+    }
+}
+
+/// Test double. `prepareModel` records the call and flips the cached flag so a
+/// follow-up `isModelReady()` reflects the prepared state.
+public actor MockMeetingVADModelPreparer: MeetingVADModelPreparing {
+    public var prepareModelCalled = false
+    public var prepareModelError: Error?
+    public var cached = false
+
+    public init() {}
+
+    public func configureCached(_ cached: Bool) {
+        self.cached = cached
+    }
+
+    public func configurePrepareModel(error: Error?) {
+        self.prepareModelError = error
+    }
+
+    public func isModelReady() async -> Bool {
+        cached
+    }
+
+    public func prepareModel(onProgress: (@Sendable (String) -> Void)?) async throws {
+        prepareModelCalled = true
+        if let error = prepareModelError { throw error }
+        cached = true
+    }
+}

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingVADService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingVADService.swift
@@ -115,6 +115,16 @@ actor MeetingVADService: MeetingVoiceActivityDetecting {
         }
     }
 
+    /// Download + compile the Silero VAD model if it is not already cached, then
+    /// discard the loaded manager. `MeetingVADModelPreparer` (onboarding model
+    /// prep) calls this so the runtime `makeIfModelCached` path stays
+    /// download-free. Uses the same `.cpuOnly` load path as the runtime; throws
+    /// on download/compile failure. FluidAudio's `VadManager` init handles the
+    /// cached-or-download decision internally.
+    static func downloadModel(computeUnits: MLComputeUnits = .cpuOnly) async throws {
+        _ = try await VadManager(config: VadConfig(computeUnits: computeUnits))
+    }
+
     func makeStreamState() async -> MeetingVADStreamState {
         MeetingVADStreamState(fluidState: await manager.makeStreamState())
     }

--- a/Sources/MacParakeetViewModels/OnboardingViewModel.swift
+++ b/Sources/MacParakeetViewModels/OnboardingViewModel.swift
@@ -73,6 +73,8 @@ public final class OnboardingViewModel {
     private let sttClient: STTClientProtocol
     private let speechEngineSwitcher: SpeechEngineSwitching?
     private let diarizationService: DiarizationServiceProtocol?
+    private let meetingVADModelPreparer: MeetingVADModelPreparing?
+    private let isMeetingVADLiveChunkingEnabled: @Sendable () -> Bool
     private let isRuntimeSupported: @Sendable () -> Bool
     private let availableDiskBytes: @Sendable () -> Int64?
     private let isNetworkReachable: @Sendable () async -> Bool
@@ -113,6 +115,8 @@ public final class OnboardingViewModel {
         sttClient: STTClientProtocol,
         speechEngineSwitcher: SpeechEngineSwitching? = nil,
         diarizationService: DiarizationServiceProtocol? = nil,
+        meetingVADModelPreparer: MeetingVADModelPreparing? = nil,
+        isMeetingVADLiveChunkingEnabled: (@Sendable () -> Bool)? = nil,
         isRuntimeSupported: (@Sendable () -> Bool)? = nil,
         availableDiskBytes: (@Sendable () -> Int64?)? = nil,
         isNetworkReachable: (@Sendable () async -> Bool)? = nil,
@@ -129,6 +133,9 @@ public final class OnboardingViewModel {
         self.sttClient = sttClient
         self.speechEngineSwitcher = speechEngineSwitcher ?? (sttClient as? SpeechEngineSwitching)
         self.diarizationService = diarizationService
+        self.meetingVADModelPreparer = meetingVADModelPreparer
+        self.isMeetingVADLiveChunkingEnabled = isMeetingVADLiveChunkingEnabled
+            ?? { AppFeatures.meetingVadLiveChunkingEnabled }
         self.isRuntimeSupported = isRuntimeSupported ?? { Self.defaultRuntimeSupportedCheck() }
         self.availableDiskBytes = availableDiskBytes ?? { Self.defaultAvailableDiskBytes() }
         self.isNetworkReachable = isNetworkReachable ?? { await Self.defaultNetworkReachabilityCheck() }
@@ -477,6 +484,7 @@ public final class OnboardingViewModel {
                     ))
                     do {
                         try await self.prepareDiarizationModelsIfNeeded(generation: generation)
+                        try await self.prepareMeetingVADModelIfNeeded(generation: generation)
                     } catch is CancellationError {
                         break observationLoop
                     } catch {
@@ -721,6 +729,40 @@ public final class OnboardingViewModel {
                 description: TelemetryErrorClassifier.errorDetail(error)
             ))
             throw error
+        }
+    }
+
+    /// Fetch the Silero VAD model used by VAD-guided meeting live chunking, but
+    /// only when the feature is enabled (`AppFeatures.meetingVadLiveChunkingEnabled`).
+    /// Runs on the Parakeet warm-up path only — VAD live chunking is gated to
+    /// Parakeet sessions, so a Whisper session would never use the model.
+    ///
+    /// VAD live chunking is an optional enhancement: the meeting path falls back
+    /// to fixed chunking when the model is absent. So a download failure here is
+    /// logged and swallowed rather than failing the speech-engine warm-up.
+    /// Cancellation is still propagated so a torn-down warm-up exits cleanly.
+    private func prepareMeetingVADModelIfNeeded(generation: Int) async throws {
+        guard isMeetingVADLiveChunkingEnabled() else { return }
+        guard let meetingVADModelPreparer else { return }
+        guard await meetingVADModelPreparer.isModelReady() == false else { return }
+
+        engineState = .working(message: "Voice-activity model: downloading...", progress: nil)
+        do {
+            try await meetingVADModelPreparer.prepareModel(onProgress: { [weak self] message in
+                Task { @MainActor [weak self] in
+                    guard let self, self.engineGeneration == generation else { return }
+                    self.engineState = .working(message: "Voice-activity model: \(message)", progress: nil)
+                }
+            })
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            logger.error("meeting_vad_model_prep_failed error=\(error.localizedDescription, privacy: .public)")
+            Telemetry.send(.errorOccurred(
+                domain: "meeting_vad",
+                code: "model_prep_failed",
+                description: TelemetryErrorClassifier.errorDetail(error)
+            ))
         }
     }
 

--- a/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
@@ -2,6 +2,10 @@ import XCTest
 @testable import MacParakeetCore
 @testable import MacParakeetViewModels
 
+private enum FakeVADPrepError: Error {
+    case boom
+}
+
 private final class OnboardingTelemetrySpy: TelemetryServiceProtocol, @unchecked Sendable {
     private let lock = NSLock()
     private var events: [TelemetryEventSpec] = []
@@ -90,6 +94,8 @@ final class OnboardingViewModelTests: XCTestCase {
         sttClient: STTClientProtocol,
         speechEngineSwitcher: SpeechEngineSwitching? = nil,
         diarizationService: DiarizationServiceProtocol? = nil,
+        meetingVADModelPreparer: MeetingVADModelPreparing? = nil,
+        isMeetingVADLiveChunkingEnabled: @escaping @Sendable () -> Bool = { false },
         defaults: UserDefaults,
         isRuntimeSupported: @escaping @Sendable () -> Bool = { true },
         availableDiskBytes: @escaping @Sendable () -> Int64? = { 20 * 1_024 * 1_024 * 1_024 },
@@ -107,6 +113,8 @@ final class OnboardingViewModelTests: XCTestCase {
             sttClient: sttClient,
             speechEngineSwitcher: speechEngineSwitcher,
             diarizationService: diarizationService,
+            meetingVADModelPreparer: meetingVADModelPreparer,
+            isMeetingVADLiveChunkingEnabled: isMeetingVADLiveChunkingEnabled,
             isRuntimeSupported: isRuntimeSupported,
             availableDiskBytes: availableDiskBytes,
             isNetworkReachable: isNetworkReachable,
@@ -339,6 +347,115 @@ final class OnboardingViewModelTests: XCTestCase {
         let called = await stt.wasWarmUpCalled()
         XCTAssertTrue(called)
         XCTAssertTrue(vm.canContinueFromCurrentStep())
+    }
+
+    // MARK: - Meeting VAD model prep (VAD-guided live chunking)
+
+    func testEngineWarmUpPreparesMeetingVADModelWhenEnabledAndUncached() async throws {
+        let perms = MockPermissionService()
+        let stt = MockSTTClient()
+        let vadPreparer = MockMeetingVADModelPreparer()
+        await vadPreparer.configureCached(false)
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+
+        let vm = makeViewModel(
+            permissionService: perms,
+            sttClient: stt,
+            meetingVADModelPreparer: vadPreparer,
+            isMeetingVADLiveChunkingEnabled: { true },
+            defaults: defaults
+        )
+        vm.jump(to: .engine)
+
+        vm.startEngineWarmUp()
+        try await Task.sleep(for: .milliseconds(160))
+
+        let prepared = await vadPreparer.prepareModelCalled
+        XCTAssertTrue(prepared, "VAD model should be fetched on the Parakeet warm-up path when enabled and uncached")
+        XCTAssertEqual(vm.engineState, .ready)
+    }
+
+    func testEngineWarmUpSkipsMeetingVADModelWhenFlagDisabled() async throws {
+        let perms = MockPermissionService()
+        let stt = MockSTTClient()
+        let vadPreparer = MockMeetingVADModelPreparer()
+        await vadPreparer.configureCached(false)
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+
+        let vm = makeViewModel(
+            permissionService: perms,
+            sttClient: stt,
+            meetingVADModelPreparer: vadPreparer,
+            isMeetingVADLiveChunkingEnabled: { false },
+            defaults: defaults
+        )
+        vm.jump(to: .engine)
+
+        vm.startEngineWarmUp()
+        try await Task.sleep(for: .milliseconds(160))
+
+        let prepared = await vadPreparer.prepareModelCalled
+        XCTAssertFalse(prepared, "disabled feature must not fetch the VAD model")
+        XCTAssertEqual(vm.engineState, .ready)
+    }
+
+    func testEngineWarmUpSkipsMeetingVADModelWhenAlreadyCached() async throws {
+        let perms = MockPermissionService()
+        let stt = MockSTTClient()
+        let vadPreparer = MockMeetingVADModelPreparer()
+        await vadPreparer.configureCached(true)  // already on disk
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+
+        let vm = makeViewModel(
+            permissionService: perms,
+            sttClient: stt,
+            meetingVADModelPreparer: vadPreparer,
+            isMeetingVADLiveChunkingEnabled: { true },
+            defaults: defaults
+        )
+        vm.jump(to: .engine)
+
+        vm.startEngineWarmUp()
+        try await Task.sleep(for: .milliseconds(160))
+
+        let prepared = await vadPreparer.prepareModelCalled
+        XCTAssertFalse(prepared, "already-cached model must not be re-fetched")
+        XCTAssertEqual(vm.engineState, .ready)
+    }
+
+    func testMeetingVADModelPrepFailureDoesNotFailWarmUp() async throws {
+        let perms = MockPermissionService()
+        let stt = MockSTTClient()
+        let vadPreparer = MockMeetingVADModelPreparer()
+        await vadPreparer.configureCached(false)
+        await vadPreparer.configurePrepareModel(error: FakeVADPrepError.boom)
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+
+        let vm = makeViewModel(
+            permissionService: perms,
+            sttClient: stt,
+            meetingVADModelPreparer: vadPreparer,
+            isMeetingVADLiveChunkingEnabled: { true },
+            defaults: defaults
+        )
+        vm.jump(to: .engine)
+
+        vm.startEngineWarmUp()
+        try await Task.sleep(for: .milliseconds(160))
+
+        let prepared = await vadPreparer.prepareModelCalled
+        XCTAssertTrue(prepared)
+        // VAD live chunking is optional — a download failure must not block the
+        // speech engine, so warm-up still completes.
+        XCTAssertEqual(vm.engineState, .ready)
     }
 
     func testEngineWarmUpUsesWhisperForCJKPreferredLanguageWhenModelIsCached() async throws {

--- a/plans/active/2026-05-meeting-vad-guided-live-chunking.md
+++ b/plans/active/2026-05-meeting-vad-guided-live-chunking.md
@@ -36,6 +36,16 @@ live chunking via `FixedMeetingLiveAudioChunker`, byte-identical to
   flippable: flip → relaunch → model fetched → `makeIfModelCached()` starts
   succeeding. (`.../Services/MeetingRecording/MeetingVADModelPreparer.swift`,
   `OnboardingViewModel.prepareMeetingVADModelIfNeeded`)
+  - **Verified end-to-end (2026-05-28, headless):** `downloadModel()` fetches the
+    Silero model to `Models/silero-vad/` (the `repo.folderName` path the pinned
+    FluidAudio `VadManager` actually loads from — `isModelCached()` uses the same
+    path, so they agree; an older `silero-vad-coreml/` cache dir from a prior
+    FluidAudio version is unrelated) in ~1.7s, after which `isModelCached()`
+    flips true. Driving the **real** Silero model through
+    `SpeechBoundaryMeetingLiveAudioChunker` with synthesized speech (two
+    sentences split by a 1.5s pause) cut at the pause: 2 contiguous chunks, 1
+    speech-end, 0 force-emits, 0 VAD errors, no fallback. Confirms the live path
+    is correct against the real model, not just the fake-VAD unit tests.
 
 **Not yet done (need hardware / live meetings):**
 - **Phase 0** — `.cpuOnly` vs `.cpuAndNeuralEngine` benchmark + live-latency

--- a/plans/active/2026-05-meeting-vad-guided-live-chunking.md
+++ b/plans/active/2026-05-meeting-vad-guided-live-chunking.md
@@ -28,11 +28,20 @@ live chunking via `FixedMeetingLiveAudioChunker`, byte-identical to
   picks fixed vs speech-boundary per session (VAD only for cached-model Parakeet
   sessions; per-source fixed fallback otherwise), with `meeting_live_chunking_mode`
   diagnostics.
+- **Model prep** — `MeetingVADModelPreparer` + `MeetingVADService.downloadModel`
+  fetch the Silero VAD model during the onboarding speech-engine warm-up, **only
+  when `meetingVadLiveChunkingEnabled` is true** and on the Parakeet path (VAD is
+  gated to Parakeet sessions). Failure is logged + swallowed (warm-up still
+  completes; runtime falls back to fixed). This makes the flag meaningfully
+  flippable: flip → relaunch → model fetched → `makeIfModelCached()` starts
+  succeeding. (`.../Services/MeetingRecording/MeetingVADModelPreparer.swift`,
+  `OnboardingViewModel.prepareMeetingVADModelIfNeeded`)
 
 **Not yet done (need hardware / live meetings):**
 - **Phase 0** — `.cpuOnly` vs `.cpuAndNeuralEngine` benchmark + live-latency
-  measurement, and the cached-only-vs-prepare-during-onboarding decision. The
-  service currently defaults to `.cpuOnly`, cached-only.
+  measurement. The service currently defaults to `.cpuOnly`. (The
+  cached-only-vs-prepare-during-onboarding decision is now settled: prepare
+  during onboarding, flag-gated — see "Model prep" above.)
 - **Phase 5** — real-meeting threshold tuning and the default-on decision; only
   then update `spec/05-audio-pipeline.md` / `spec/09-testing.md`.
 


### PR DESCRIPTION
## Summary

Follow-up to #387 (VAD-guided meeting live chunking, merged dark behind `AppFeatures.meetingVadLiveChunkingEnabled`). Until now nothing fetched the Silero VAD model, so flipping the flag was a no-op — `MeetingVADService.makeIfModelCached()` always missed and the meeting path stayed on fixed chunking. This wires the model download into the onboarding speech-engine warm-up so the flag becomes **meaningfully flippable**: flip → relaunch → warm-up fetches the model → live meetings cut at speech boundaries.

## What's here

- **`MeetingVADModelPreparing` + `MeetingVADModelPreparer`** (Core), mirroring `DiarizationServiceProtocol` model prep. `MeetingVADService.downloadModel()` triggers FluidAudio's cached-or-download `VadManager` load and discards it, keeping the runtime `makeIfModelCached` path download-free.
- **`OnboardingViewModel.prepareMeetingVADModelIfNeeded`** runs in the Parakeet warm-up `.ready` branch (right after diarization prep), **flag-gated** (injected as a closure so it's testable without flipping the global). The Whisper/CJK path is untouched — VAD is gated to Parakeet sessions.
- Threaded `meetingVADModelPreparer` through AppEnvironment → OnboardingCoordinator → OnboardingWindowController → OnboardingViewModel.

## Design notes

- **Optional, never fatal.** A download failure is logged + `errorOccurred` telemetry (domain `meeting_vad`) and **swallowed** — the speech-engine warm-up still reaches `.ready` (the meeting path falls back to fixed chunking). Cancellation still propagates. Diarization, being core, throws instead.
- Reuses the existing `errorOccurred` event → no telemetry allowlist change.

## Validation

- `swift build` clean; `swift test` green (3074 XCTest, 0 failures, 9 skipped; Swift Testing suites pass).
- 4 new onboarding tests: prep runs when enabled + uncached; skipped when disabled; skipped when already cached; prep failure does not fail warm-up.
- Independent wiring review (gating, error-swallow, threading) clean.

## Still dark

Flag stays `false`. Remaining before default-on: Phase 0 (`.cpuOnly` vs ANE benchmark + live latency) and Phase 5 (real-meeting threshold tuning) — both need on-device testing, which this PR unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)