### PR TITLE
Reuse one MeetingVADService across meetings; record Phase 0 results

### DIFF
--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -200,6 +200,11 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     private var processingTask: Task<Void, Never>?
     private var captureOrchestrator = CaptureOrchestrator()
     private var micConditioner: any MicConditioning = PassthroughMicConditioner()
+    /// Reused across meetings so the Silero VAD model (CoreML) is loaded at most
+    /// once per app session instead of at every meeting start. Only set when the
+    /// model is cached; stays nil (and is re-checked cheaply each meeting) until
+    /// then. See `configureLiveChunkers`.
+    private var sharedVADService: MeetingVADService?
     private var transcriptAssembler = MeetingTranscriptAssembler()
     private var isTranscriptionLagging = false
     private var captureFailed = false
@@ -953,7 +958,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             await useFixed(reason: "non_parakeet_engine")
             return
         }
-        guard let vad = await MeetingVADService.makeIfModelCached() else {
+        guard let vad = await liveVADService() else {
             await useFixed(reason: "vad_unavailable")
             return
         }
@@ -963,6 +968,16 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             system: SpeechBoundaryMeetingLiveAudioChunker(vad: vad)
         )
         AudioCaptureDiagnostics.append("meeting_live_chunking_mode mode=vad reason=started")
+    }
+
+    /// The shared VAD service, loaded lazily once per app session. Returns nil
+    /// when the model is not cached — cheap to re-check (a file-existence test),
+    /// so a later session can still pick it up after onboarding fetches it.
+    private func liveVADService() async -> MeetingVADService? {
+        if let sharedVADService { return sharedVADService }
+        guard let service = await MeetingVADService.makeIfModelCached() else { return nil }
+        sharedVADService = service
+        return service
     }
 
     private func ingestResampledSamples(

--- a/plans/active/2026-05-meeting-vad-guided-live-chunking.md
+++ b/plans/active/2026-05-meeting-vad-guided-live-chunking.md
@@ -47,24 +47,38 @@ live chunking via `FixedMeetingLiveAudioChunker`, byte-identical to
     speech-end, 0 force-emits, 0 VAD errors, no fallback. Confirms the live path
     is correct against the real model, not just the fake-VAD unit tests.
 
-**Not yet done (need hardware / live meetings):**
-- **Phase 0** — `.cpuOnly` vs `.cpuAndNeuralEngine` benchmark + live-latency
-  measurement. The service currently defaults to `.cpuOnly`. (The
-  cached-only-vs-prepare-during-onboarding decision is now settled: prepare
-  during onboarding, flag-gated — see "Model prep" above.)
-- **Phase 5** — real-meeting threshold tuning and the default-on decision; only
-  then update `spec/05-audio-pipeline.md` / `spec/09-testing.md`.
+**Phase 0 — DONE (2026-05-29, via `meeting-vad-sim` on a real 104-min meeting):**
+Replayed both captured streams of a real meeting through the live path.
+- **Mic stream** (6274s): VAD ran at **1553× realtime**, per-ingest p99=0.20ms /
+  max=4.2ms, **0 VAD errors**, no fallback. 436 speech-aligned chunks (variable
+  2–10s) vs 1569 rigid 5s fixed chunks. Diagnostics: 226 speech-end cuts, 256
+  10s-cap force-emits, 289 dropped-silence windows.
+- **System stream** (6238s, mostly silent): VAD ran at **1357× realtime**,
+  max=11.6ms, **0 errors**; emitted only 8 chunks and dropped 618 silence
+  windows (fixed would have produced ~1247 mostly-silent chunks) — a real
+  efficiency win on system audio.
+- **Verdict:** at >1300× realtime a live 1×-realtime source cannot back up the
+  queue, so **VAD inference runs inline in the capture task** (no decoupled task
+  needed — settles the #387 open architecture question). `.cpuOnly` confirmed
+  sufficient; the `.cpuAndNeuralEngine` comparison is unnecessary given the
+  headroom.
 
-**Review findings deferred to enablement (multi-AI convergence on PR #387):**
-- **Reuse the `VadManager` across sessions.** `makeIfModelCached` loads the
-  CoreML model on every `startRecording()`. Harmless while the flag is off (no
-  model on disk), but once the model is cached (follow-up model-prep PR) this
-  adds a synchronous load to each meeting start — cache one `MeetingVADService`
-  on `MeetingRecordingService` and reuse it.
+**Done — reuse the `VadManager` across sessions** (was a deferred review item):
+`MeetingRecordingService` now caches one `MeetingVADService` (`sharedVADService`,
+loaded lazily via `liveVADService()`), so the CoreML model loads at most once per
+app session instead of at every meeting start. Re-checks cheaply (file-existence)
+while still nil, so a later session picks it up after onboarding fetches the model.
+
+**Not yet done:**
+- **Phase 5** — subjective live-preview feel on a real call (eyeball the cadence)
+  and the default-on decision; only then update `spec/05-audio-pipeline.md` /
+  `spec/09-testing.md`. The sim data above strongly supports it (speech-aligned,
+  0 errors over 104 min × 2 streams), but the on-screen feel is still unverified.
 - **Sub-minimum speech-end then prolonged silence.** A <2.0s utterance keeps
   `sawSpeechSinceLastEmit` set, so a following long silence force-emits a mostly
   silent 10s chunk to live STT. Bounded and not data-loss (timestamps stay
-  correct), but a Phase 5 tuning target.
+  correct); the 256 mic force-emits above are mostly this + long monologue. A
+  Phase 5 tuning target, not a blocker.
 
 ## Problem
 


### PR DESCRIPTION
## Summary

Follow-up to #387/#390. Two things, both keeping the feature **dark** (flag unchanged):

1. **Reuse fix** (the deferred review item): `MeetingRecordingService` now caches one `MeetingVADService` (`sharedVADService`, lazy via `liveVADService()`) instead of loading the Silero CoreML model at *every* meeting start. Loads at most once per app session; re-checks cheaply while the model is absent so a later session picks it up after onboarding fetches it.
2. **Phase 0 — settled** using the new `meeting-vad-sim` CLI on a **real 104-minute meeting** (both captured streams):

| Stream | Realtime | per-ingest p99/max | Errors | Chunks (VAD vs fixed) |
|---|---|---|---|---|
| Mic (6274s) | **1553×** | 0.20ms / 4.2ms | 0 | 436 speech-aligned vs 1569 |
| System (6238s, mostly silent) | **1357×** | — / 11.6ms | 0 | 8 (618 silence dropped) vs ~1247 |

**Verdict:** at >1300× realtime a live 1× source can't back up the queue → VAD runs **inline in the capture task** (no decoupled task needed; settles the #387 architecture question). `.cpuOnly` confirmed sufficient. Zero VAD errors over 104 min across both streams.

## Validation

`swift build` clean; `swift test` green (3074 XCTest, 0 failures). 53 MeetingRecordingService tests pass. The reuse path is also exercised end-to-end by `meeting-vad-sim` on real audio.

## Still dark

Flag stays `false`. Only Phase 5 remains before default-on: eyeballing the live-preview *feel* on a real call (the sim data strongly supports it, but on-screen cadence is unverified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)