### PR TITLE
Universal launch-time VAD model prep (Phase 4.5, flag-gated)

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -27,7 +27,10 @@ final class AppEnvironment {
     let youtubeDownloader: YouTubeDownloader
     let diarizationService: DiarizationService
     /// Stateless; fetches the Silero VAD model for VAD-guided meeting live
-    /// chunking during onboarding when `AppFeatures.meetingVadLiveChunkingEnabled`.
+    /// chunking. Consumed by `AppDelegate.scheduleDeferredSpeechPreWarm` on every
+    /// launch (gated on `AppFeatures.meetingVadLiveChunkingEnabled`) so the
+    /// installed base — not just fresh installs — acquires the model. See
+    /// `MeetingVADLaunchPrep` and the VAD plan §6 (Phase 4.5).
     let meetingVADModelPreparer: any MeetingVADModelPreparing = MeetingVADModelPreparer()
     let clipboardService: ClipboardService
     let systemMediaController: SystemMediaController

--- a/Sources/MacParakeet/App/OnboardingCoordinator.swift
+++ b/Sources/MacParakeet/App/OnboardingCoordinator.swift
@@ -44,7 +44,6 @@ final class OnboardingCoordinator {
                 permissionService: environment.permissionService,
                 sttClient: environment.sttScheduler,
                 diarizationService: environment.diarizationService,
-                meetingVADModelPreparer: environment.meetingVADModelPreparer,
                 entitlementsService: environment.entitlementsService
             )
         }
@@ -56,7 +55,6 @@ final class OnboardingCoordinator {
             permissionService: environment.permissionService,
             sttClient: environment.sttScheduler,
             diarizationService: environment.diarizationService,
-            meetingVADModelPreparer: environment.meetingVADModelPreparer,
             entitlementsService: environment.entitlementsService
         )
     }
@@ -70,14 +68,12 @@ final class OnboardingCoordinator {
         permissionService: PermissionServiceProtocol,
         sttClient: STTClientProtocol,
         diarizationService: DiarizationServiceProtocol?,
-        meetingVADModelPreparer: any MeetingVADModelPreparing,
         entitlementsService: EntitlementsService
     ) {
         onboardingWindowController.show(
             permissionService: permissionService,
             sttClient: sttClient,
             diarizationService: diarizationService,
-            meetingVADModelPreparer: meetingVADModelPreparer,
             onFinish: { [weak self] in
                 self?.reopenOnNextActivate = false
                 self?.onRefreshHotkeys()

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -540,14 +540,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             )
             // Only surface the transitions worth seeing. `alreadyCached`
             // (steady state) and `disabled` are silent to avoid per-launch
-            // telemetry spam; a cancelled-mid-download outcome is dropped too.
-            guard !Task.isCancelled else { return }
+            // telemetry spam; `cancelled` (app quit mid-download) is dropped
+            // because `run` already treats cancellation as non-failure. No
+            // post-call `Task.isCancelled` guard here: once `run` has returned
+            // a terminal outcome the work genuinely completed, so a late
+            // cancellation shouldn't drop the one event we care about
+            // (`prepared` — proof the installed base acquired the model).
             switch prepOutcome {
             case .prepared:
                 Telemetry.send(.vadModelPrep(outcome: .prepared))
             case .failed:
                 Telemetry.send(.vadModelPrep(outcome: .failed))
-            case .alreadyCached, .disabled:
+            case .alreadyCached, .disabled, .cancelled:
                 break
             }
         }

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -511,10 +511,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func scheduleDeferredSpeechPreWarm(environment env: AppEnvironment) {
         guard speechPreWarmTask == nil else { return }
         let sttRuntime = env.sttRuntime
+        let vadModelPreparer = env.meetingVADModelPreparer
         let deferralMs = preWarmDeferralMs
         let onboardingCompletedKey = OnboardingViewModel.onboardingCompletedKey
 
-        speechPreWarmTask = Task(priority: .utility) { @MainActor [weak self, sttRuntime] in
+        speechPreWarmTask = Task(priority: .utility) { @MainActor [weak self, sttRuntime, vadModelPreparer] in
             defer {
                 self?.speechPreWarmTask = nil
             }
@@ -524,6 +525,31 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             let onboardingDone = UserDefaults.standard.string(forKey: onboardingCompletedKey) != nil
             guard onboardingDone else { return }
             await sttRuntime.backgroundWarmUp()
+
+            // Universal VAD model availability (Phase 4.5,
+            // plans/active/2026-05-meeting-vad-guided-live-chunking.md §6).
+            // Runs every launch for every user so flipping the live-chunking
+            // flag reaches the installed base, not just fresh installs. Kept
+            // independent of the speech warm-up above: idempotent, silent-fail,
+            // and the meeting path falls back to fixed chunking if it never
+            // succeeds. No-op when the flag is off.
+            guard !Task.isCancelled else { return }
+            let prepOutcome = await MeetingVADLaunchPrep.run(
+                featureEnabled: AppFeatures.meetingVadLiveChunkingEnabled,
+                preparer: vadModelPreparer
+            )
+            // Only surface the transitions worth seeing. `alreadyCached`
+            // (steady state) and `disabled` are silent to avoid per-launch
+            // telemetry spam; a cancelled-mid-download outcome is dropped too.
+            guard !Task.isCancelled else { return }
+            switch prepOutcome {
+            case .prepared:
+                Telemetry.send(.vadModelPrep(outcome: .prepared))
+            case .failed:
+                Telemetry.send(.vadModelPrep(outcome: .failed))
+            case .alreadyCached, .disabled:
+                break
+            }
         }
     }
 

--- a/Sources/MacParakeet/Onboarding/OnboardingWindowController.swift
+++ b/Sources/MacParakeet/Onboarding/OnboardingWindowController.swift
@@ -16,7 +16,6 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
         permissionService: PermissionServiceProtocol,
         sttClient: STTClientProtocol,
         diarizationService: DiarizationServiceProtocol? = nil,
-        meetingVADModelPreparer: (any MeetingVADModelPreparing)? = nil,
         onFinish: @escaping () -> Void,
         onHotkeyPreviewArm: @escaping () -> Void = {},
         onHotkeyPreviewDisarm: @escaping () -> Void = {},
@@ -33,8 +32,7 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
         let vm = OnboardingViewModel(
             permissionService: permissionService,
             sttClient: sttClient,
-            diarizationService: diarizationService,
-            meetingVADModelPreparer: meetingVADModelPreparer
+            diarizationService: diarizationService
         )
         viewModel = vm
         // Retained so the rehearsal taps/overlay are torn down if the window

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingVADModelPreparer.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingVADModelPreparer.swift
@@ -57,9 +57,10 @@ public struct MeetingVADModelPreparer: MeetingVADModelPreparing {
 /// This is the flag-and-cache gate factored out of `AppDelegate` so the
 /// decision is unit-testable without driving the deferred launch timer.
 public enum MeetingVADLaunchPrep {
-    /// Outcome of a single launch-prep attempt. `disabled` (feature off) and
-    /// `alreadyCached` (steady state) are silent — only `prepared` / `failed`
-    /// are worth a telemetry event. See `TelemetryVADModelPrepOutcome`.
+    /// Outcome of a single launch-prep attempt. `disabled` (feature off),
+    /// `alreadyCached` (steady state), and `cancelled` (app quit mid-download)
+    /// are silent — only `prepared` / `failed` are worth a telemetry event.
+    /// See `TelemetryVADModelPrepOutcome`.
     public enum Outcome: Sendable, Equatable {
         /// Feature flag is off — prep was not attempted.
         case disabled
@@ -70,6 +71,10 @@ public enum MeetingVADLaunchPrep {
         /// Download/compile failed; swallowed. The meeting path falls back to
         /// fixed chunking and the next launch retries (natural backoff).
         case failed
+        /// The launch task was cancelled mid-download (e.g. app quit). Distinct
+        /// from `.failed` so a normal-shutdown cancellation never emits a
+        /// spurious failure telemetry event. The next launch retries.
+        case cancelled
     }
 
     private static let logger = Logger(subsystem: "com.macparakeet.core", category: "MeetingVADLaunchPrep")
@@ -89,6 +94,15 @@ public enum MeetingVADLaunchPrep {
             logger.info("vad_model_launch_prep prepared")
             return .prepared
         } catch {
+            // Cancellation (the deferred launch task is cancelled on app quit)
+            // must not be reported as a failure. `Task.isCancelled` is the
+            // ground truth — a cancelled in-flight `URLSession` download
+            // surfaces as `URLError(.cancelled)`, not `CancellationError`, so
+            // matching the error type alone would miss the common case.
+            if Task.isCancelled || error is CancellationError {
+                logger.info("vad_model_launch_prep cancelled")
+                return .cancelled
+            }
             logger.error("vad_model_launch_prep failed error=\(error.localizedDescription, privacy: .public)")
             return .failed
         }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingVADModelPreparer.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingVADModelPreparer.swift
@@ -1,13 +1,14 @@
 import Foundation
+import OSLog
 
 /// Prepares the Silero VAD model used by VAD-guided meeting live chunking
 /// (`AppFeatures.meetingVadLiveChunkingEnabled`,
 /// `plans/active/2026-05-meeting-vad-guided-live-chunking.md`).
 ///
-/// Onboarding fetches the model up front so the runtime path
-/// (`MeetingVADService.makeIfModelCached`) stays download-free and never adds
-/// latency at meeting start. Mirrors `DiarizationServiceProtocol` model prep so
-/// the onboarding warm-up treats both optional model stacks the same way.
+/// A deferred launch-time task fetches the model up front (see
+/// `MeetingVADLaunchPrep` + `AppDelegate.scheduleDeferredSpeechPreWarm`) so the
+/// runtime path (`MeetingVADService.makeIfModelCached`) stays download-free and
+/// never adds latency at meeting start.
 public protocol MeetingVADModelPreparing: Sendable {
     /// `true` when every required Silero VAD model file is already cached.
     func isModelReady() async -> Bool
@@ -40,6 +41,57 @@ public struct MeetingVADModelPreparer: MeetingVADModelPreparing {
         onProgress?("Downloading voice-activity model...")
         try await MeetingVADService.downloadModel()
         onProgress?("Voice-activity model ready")
+    }
+}
+
+/// Universal launch-time VAD model availability (Phase 4.5,
+/// `plans/active/2026-05-meeting-vad-guided-live-chunking.md` §6).
+///
+/// The Silero model used to be fetched only during onboarding, so it reached
+/// *new installs only* — the entire installed base ran fixed chunking forever
+/// because the runtime (`MeetingVADService.makeIfModelCached`) never downloads.
+/// `AppDelegate.scheduleDeferredSpeechPreWarm` now runs this on every launch
+/// for every user (after the speech warm-up), so flipping
+/// `meetingVadLiveChunkingEnabled` actually lights VAD up for everyone.
+///
+/// This is the flag-and-cache gate factored out of `AppDelegate` so the
+/// decision is unit-testable without driving the deferred launch timer.
+public enum MeetingVADLaunchPrep {
+    /// Outcome of a single launch-prep attempt. `disabled` (feature off) and
+    /// `alreadyCached` (steady state) are silent — only `prepared` / `failed`
+    /// are worth a telemetry event. See `TelemetryVADModelPrepOutcome`.
+    public enum Outcome: Sendable, Equatable {
+        /// Feature flag is off — prep was not attempted.
+        case disabled
+        /// Model already on disk — nothing to do.
+        case alreadyCached
+        /// Model was just downloaded + compiled this launch.
+        case prepared
+        /// Download/compile failed; swallowed. The meeting path falls back to
+        /// fixed chunking and the next launch retries (natural backoff).
+        case failed
+    }
+
+    private static let logger = Logger(subsystem: "com.macparakeet.core", category: "MeetingVADLaunchPrep")
+
+    /// Idempotent, never-throwing launch-time prep. Skips when the feature is
+    /// off or the model is already cached; otherwise downloads it. A failure is
+    /// logged and swallowed (returns `.failed`) — VAD live chunking is an
+    /// optional enhancement, never a launch blocker.
+    public static func run(
+        featureEnabled: Bool,
+        preparer: any MeetingVADModelPreparing
+    ) async -> Outcome {
+        guard featureEnabled else { return .disabled }
+        if await preparer.isModelReady() { return .alreadyCached }
+        do {
+            try await preparer.prepareModel()
+            logger.info("vad_model_launch_prep prepared")
+            return .prepared
+        } catch {
+            logger.error("vad_model_launch_prep failed error=\(error.localizedDescription, privacy: .public)")
+            return .failed
+        }
     }
 }
 

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -107,6 +107,13 @@ public enum TelemetryEventName: String, Sendable, CaseIterable {
     case meetingRecoveryCompleted = "meeting_recovery_completed"
     case meetingRecoveryDiscarded = "meeting_recovery_discarded"
     case meetingRecoveryFailed = "meeting_recovery_failed"
+    /// Universal launch-time Silero VAD model prep for VAD-guided meeting live
+    /// chunking (`plans/active/2026-05-meeting-vad-guided-live-chunking.md` §6).
+    /// Confirms the installed base actually acquires the model once the feature
+    /// is enabled — see `TelemetryVADModelPrepOutcome`. Gated on
+    /// `AppFeatures.meetingVadLiveChunkingEnabled`, so it never fires in a
+    /// flag-off build.
+    case vadModelPrep = "vad_model_prep"
     // Calendar auto-start (ADR-017)
     case calendarReminderShown = "calendar_reminder_shown"
     case calendarAutoStartTriggered = "calendar_auto_start_triggered"
@@ -332,6 +339,20 @@ public enum TelemetryMeetingOperationStage: String, Sendable, Equatable {
 public enum TelemetryMeetingRecoverySource: String, Sendable, Equatable {
     case launch
     case settings
+}
+
+/// Outcome of a launch-time Silero VAD model prep attempt (Phase 4.5,
+/// `plans/active/2026-05-meeting-vad-guided-live-chunking.md` §6). The full
+/// vocabulary is modeled here, but the launch hook only transmits the
+/// *transitions* worth seeing: `prepared` (an install just acquired the model
+/// — the field-reach signal) and `failed` (a download problem). The
+/// steady-state `alreadyCached` is intentionally NOT emitted on every launch to
+/// avoid per-launch telemetry spam; cumulative `prepared` counts already
+/// approximate how much of the installed base has the model.
+public enum TelemetryVADModelPrepOutcome: String, Sendable, Equatable {
+    case alreadyCached = "already_cached"
+    case prepared
+    case failed
 }
 
 public enum TelemetryPermission: String, Sendable, Equatable {
@@ -701,6 +722,9 @@ public enum TelemetryEventSpec: Sendable {
         errorType: String,
         errorDetail: String? = nil
     )
+    /// Launch-time VAD model prep outcome (Phase 4.5). Only `.prepared` /
+    /// `.failed` are ever sent — see `TelemetryVADModelPrepOutcome`.
+    case vadModelPrep(outcome: TelemetryVADModelPrepOutcome)
     // Calendar auto-start (ADR-017). Mode is "notify" / "auto_start" — `.off`
     // never produces an event because the coordinator short-circuits.
     case calendarReminderShown(mode: String, leadMinutes: Int, hasMeetUrl: Bool)
@@ -848,6 +872,7 @@ extension TelemetryEventSpec {
         case .meetingRecoveryCompleted: return .meetingRecoveryCompleted
         case .meetingRecoveryDiscarded: return .meetingRecoveryDiscarded
         case .meetingRecoveryFailed: return .meetingRecoveryFailed
+        case .vadModelPrep: return .vadModelPrep
         case .calendarReminderShown: return .calendarReminderShown
         case .calendarAutoStartTriggered: return .calendarAutoStartTriggered
         case .calendarAutoStartCancelled: return .calendarAutoStartCancelled
@@ -1413,6 +1438,8 @@ extension TelemetryEventSpec {
             ]
             if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
             return props
+        case .vadModelPrep(let outcome):
+            return ["outcome": outcome.rawValue]
         case .calendarReminderShown(let mode, let leadMinutes, let hasMeetUrl):
             return [
                 "mode": mode,
@@ -1644,6 +1671,7 @@ public enum TelemetryImplementedContract {
         .meetingRecoveryCompleted: ["count", "duration_seconds", "source"],
         .meetingRecoveryDiscarded: ["count", "source"],
         .meetingRecoveryFailed: ["count", "source", "error_type"],
+        .vadModelPrep: ["outcome"],
         .calendarReminderShown: ["mode", "lead_minutes", "has_meet_url"],
         .calendarAutoStartTriggered: ["lead_seconds", "has_meet_url"],
         .calendarAutoStartCancelled: ["reason"],

--- a/Sources/MacParakeetViewModels/OnboardingViewModel.swift
+++ b/Sources/MacParakeetViewModels/OnboardingViewModel.swift
@@ -73,8 +73,6 @@ public final class OnboardingViewModel {
     private let sttClient: STTClientProtocol
     private let speechEngineSwitcher: SpeechEngineSwitching?
     private let diarizationService: DiarizationServiceProtocol?
-    private let meetingVADModelPreparer: MeetingVADModelPreparing?
-    private let isMeetingVADLiveChunkingEnabled: @Sendable () -> Bool
     private let isRuntimeSupported: @Sendable () -> Bool
     private let availableDiskBytes: @Sendable () -> Int64?
     private let isNetworkReachable: @Sendable () async -> Bool
@@ -115,8 +113,6 @@ public final class OnboardingViewModel {
         sttClient: STTClientProtocol,
         speechEngineSwitcher: SpeechEngineSwitching? = nil,
         diarizationService: DiarizationServiceProtocol? = nil,
-        meetingVADModelPreparer: MeetingVADModelPreparing? = nil,
-        isMeetingVADLiveChunkingEnabled: (@Sendable () -> Bool)? = nil,
         isRuntimeSupported: (@Sendable () -> Bool)? = nil,
         availableDiskBytes: (@Sendable () -> Int64?)? = nil,
         isNetworkReachable: (@Sendable () async -> Bool)? = nil,
@@ -133,9 +129,6 @@ public final class OnboardingViewModel {
         self.sttClient = sttClient
         self.speechEngineSwitcher = speechEngineSwitcher ?? (sttClient as? SpeechEngineSwitching)
         self.diarizationService = diarizationService
-        self.meetingVADModelPreparer = meetingVADModelPreparer
-        self.isMeetingVADLiveChunkingEnabled = isMeetingVADLiveChunkingEnabled
-            ?? { AppFeatures.meetingVadLiveChunkingEnabled }
         self.isRuntimeSupported = isRuntimeSupported ?? { Self.defaultRuntimeSupportedCheck() }
         self.availableDiskBytes = availableDiskBytes ?? { Self.defaultAvailableDiskBytes() }
         self.isNetworkReachable = isNetworkReachable ?? { await Self.defaultNetworkReachabilityCheck() }
@@ -484,7 +477,6 @@ public final class OnboardingViewModel {
                     ))
                     do {
                         try await self.prepareDiarizationModelsIfNeeded(generation: generation)
-                        try await self.prepareMeetingVADModelIfNeeded(generation: generation)
                     } catch is CancellationError {
                         break observationLoop
                     } catch {
@@ -731,41 +723,6 @@ public final class OnboardingViewModel {
             throw error
         }
     }
-
-    /// Fetch the Silero VAD model used by VAD-guided meeting live chunking, but
-    /// only when the feature is enabled (`AppFeatures.meetingVadLiveChunkingEnabled`).
-    /// Runs on the Parakeet warm-up path only — VAD live chunking is gated to
-    /// Parakeet sessions, so a Whisper session would never use the model.
-    ///
-    /// VAD live chunking is an optional enhancement: the meeting path falls back
-    /// to fixed chunking when the model is absent. So a download failure here is
-    /// logged and swallowed rather than failing the speech-engine warm-up.
-    /// Cancellation is still propagated so a torn-down warm-up exits cleanly.
-    private func prepareMeetingVADModelIfNeeded(generation: Int) async throws {
-        guard isMeetingVADLiveChunkingEnabled() else { return }
-        guard let meetingVADModelPreparer else { return }
-        guard await meetingVADModelPreparer.isModelReady() == false else { return }
-
-        engineState = .working(message: "Voice-activity model: downloading...", progress: nil)
-        do {
-            try await meetingVADModelPreparer.prepareModel(onProgress: { [weak self] message in
-                Task { @MainActor [weak self] in
-                    guard let self, self.engineGeneration == generation else { return }
-                    self.engineState = .working(message: "Voice-activity model: \(message)", progress: nil)
-                }
-            })
-        } catch is CancellationError {
-            throw CancellationError()
-        } catch {
-            logger.error("meeting_vad_model_prep_failed error=\(error.localizedDescription, privacy: .public)")
-            Telemetry.send(.errorOccurred(
-                domain: "meeting_vad",
-                code: "model_prep_failed",
-                description: TelemetryErrorClassifier.errorDetail(error)
-            ))
-        }
-    }
-
 
     public func retryEngineWarmUp() {
         cancelWarmUpObservation()

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingVADLaunchPrepTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingVADLaunchPrepTests.swift
@@ -60,4 +60,20 @@ final class MeetingVADLaunchPrepTests: XCTestCase {
         let called = await preparer.prepareModelCalled
         XCTAssertTrue(called)
     }
+
+    /// Cancellation (the deferred launch task is cancelled on app quit) must be
+    /// reported as `.cancelled`, never `.failed` — the AppDelegate caller drops
+    /// `.cancelled` silently, so this is what prevents a spurious
+    /// `vad_model_prep failed` telemetry event on every quit-mid-download.
+    func testReportsCancelledRatherThanFailedOnCancellation() async {
+        let preparer = MockMeetingVADModelPreparer()
+        await preparer.configureCached(false)
+        await preparer.configurePrepareModel(error: CancellationError())
+
+        let outcome = await MeetingVADLaunchPrep.run(featureEnabled: true, preparer: preparer)
+
+        XCTAssertEqual(outcome, .cancelled)
+        let called = await preparer.prepareModelCalled
+        XCTAssertTrue(called)
+    }
 }

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingVADLaunchPrepTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingVADLaunchPrepTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import MacParakeetCore
+
+/// Phase 4.5 — universal launch-time VAD model availability
+/// (`plans/active/2026-05-meeting-vad-guided-live-chunking.md` §6).
+///
+/// These cover the flag-and-cache gate that `AppDelegate.scheduleDeferredSpeechPreWarm`
+/// rides on every launch, without driving the deferred launch timer. The prep
+/// must be a no-op when the feature is off or the model is already cached, must
+/// download when enabled + uncached, and must never throw — a download failure
+/// is swallowed so the meeting path falls back to fixed chunking.
+final class MeetingVADLaunchPrepTests: XCTestCase {
+    private enum FakeVADPrepError: Error { case boom }
+
+    func testReturnsDisabledAndSkipsPrepWhenFeatureOff() async {
+        let preparer = MockMeetingVADModelPreparer()
+        await preparer.configureCached(false)
+
+        let outcome = await MeetingVADLaunchPrep.run(featureEnabled: false, preparer: preparer)
+
+        XCTAssertEqual(outcome, .disabled)
+        let called = await preparer.prepareModelCalled
+        XCTAssertFalse(called, "feature-off launch must not fetch the VAD model")
+    }
+
+    func testReturnsAlreadyCachedAndSkipsPrepWhenModelReady() async {
+        let preparer = MockMeetingVADModelPreparer()
+        await preparer.configureCached(true)
+
+        let outcome = await MeetingVADLaunchPrep.run(featureEnabled: true, preparer: preparer)
+
+        XCTAssertEqual(outcome, .alreadyCached)
+        let called = await preparer.prepareModelCalled
+        XCTAssertFalse(called, "already-cached model must not be re-fetched")
+    }
+
+    func testPreparesWhenEnabledAndUncached() async {
+        let preparer = MockMeetingVADModelPreparer()
+        await preparer.configureCached(false)
+
+        let outcome = await MeetingVADLaunchPrep.run(featureEnabled: true, preparer: preparer)
+
+        XCTAssertEqual(outcome, .prepared)
+        let called = await preparer.prepareModelCalled
+        XCTAssertTrue(called, "enabled + uncached must fetch the VAD model")
+        let ready = await preparer.isModelReady()
+        XCTAssertTrue(ready, "a successful prep must leave the model cached")
+    }
+
+    func testSwallowsFailureAndReturnsFailed() async {
+        let preparer = MockMeetingVADModelPreparer()
+        await preparer.configureCached(false)
+        await preparer.configurePrepareModel(error: FakeVADPrepError.boom)
+
+        // Must not throw out of `run` — VAD prep is optional and never a launch
+        // blocker.
+        let outcome = await MeetingVADLaunchPrep.run(featureEnabled: true, preparer: preparer)
+
+        XCTAssertEqual(outcome, .failed)
+        let called = await preparer.prepareModelCalled
+        XCTAssertTrue(called)
+    }
+}

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -1033,6 +1033,27 @@ final class TelemetryServiceTests: XCTestCase {
         XCTAssertEqual(Set(event.props?.keys ?? Dictionary<String, String>().keys), ["activation_window"])
     }
 
+    func testVADModelPrepSerializesOutcome() {
+        let cases: [(TelemetryVADModelPrepOutcome, String)] = [
+            (.prepared, "prepared"),
+            (.failed, "failed"),
+            (.alreadyCached, "already_cached"),
+        ]
+        for (outcome, expected) in cases {
+            let event = TelemetryEvent(
+                spec: .vadModelPrep(outcome: outcome),
+                appVer: "0.6.9",
+                osVer: "15.4",
+                locale: "en-US",
+                chip: "Apple M4",
+                session: "session"
+            )
+            XCTAssertEqual(event.event, "vad_model_prep")
+            XCTAssertEqual(event.props?["outcome"], expected)
+            XCTAssertEqual(Set(event.props?.keys ?? Dictionary<String, String>().keys), ["outcome"])
+        }
+    }
+
     func testImplementedContractCoversEveryTypedEventName() {
         XCTAssertEqual(
             Set(TelemetryEventName.allCases),
@@ -1391,6 +1412,7 @@ final class TelemetryServiceTests: XCTestCase {
             .meetingRecoveryCompleted(count: 1, durationSeconds: 4.2, source: .launch),
             .meetingRecoveryDiscarded(count: 1, source: .settings),
             .meetingRecoveryFailed(count: 1, source: .settings, errorType: "no_audio"),
+            .vadModelPrep(outcome: .prepared),
             .errorOccurred(domain: "STTError", code: "engineFailed", description: "test"),
             .crashOccurred(
                 crashType: "signal", signal: "11", name: "SIGSEGV",

--- a/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
@@ -2,10 +2,6 @@ import XCTest
 @testable import MacParakeetCore
 @testable import MacParakeetViewModels
 
-private enum FakeVADPrepError: Error {
-    case boom
-}
-
 private final class OnboardingTelemetrySpy: TelemetryServiceProtocol, @unchecked Sendable {
     private let lock = NSLock()
     private var events: [TelemetryEventSpec] = []
@@ -94,8 +90,6 @@ final class OnboardingViewModelTests: XCTestCase {
         sttClient: STTClientProtocol,
         speechEngineSwitcher: SpeechEngineSwitching? = nil,
         diarizationService: DiarizationServiceProtocol? = nil,
-        meetingVADModelPreparer: MeetingVADModelPreparing? = nil,
-        isMeetingVADLiveChunkingEnabled: @escaping @Sendable () -> Bool = { false },
         defaults: UserDefaults,
         isRuntimeSupported: @escaping @Sendable () -> Bool = { true },
         availableDiskBytes: @escaping @Sendable () -> Int64? = { 20 * 1_024 * 1_024 * 1_024 },
@@ -113,8 +107,6 @@ final class OnboardingViewModelTests: XCTestCase {
             sttClient: sttClient,
             speechEngineSwitcher: speechEngineSwitcher,
             diarizationService: diarizationService,
-            meetingVADModelPreparer: meetingVADModelPreparer,
-            isMeetingVADLiveChunkingEnabled: isMeetingVADLiveChunkingEnabled,
             isRuntimeSupported: isRuntimeSupported,
             availableDiskBytes: availableDiskBytes,
             isNetworkReachable: isNetworkReachable,
@@ -347,115 +339,6 @@ final class OnboardingViewModelTests: XCTestCase {
         let called = await stt.wasWarmUpCalled()
         XCTAssertTrue(called)
         XCTAssertTrue(vm.canContinueFromCurrentStep())
-    }
-
-    // MARK: - Meeting VAD model prep (VAD-guided live chunking)
-
-    func testEngineWarmUpPreparesMeetingVADModelWhenEnabledAndUncached() async throws {
-        let perms = MockPermissionService()
-        let stt = MockSTTClient()
-        let vadPreparer = MockMeetingVADModelPreparer()
-        await vadPreparer.configureCached(false)
-        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
-
-        let vm = makeViewModel(
-            permissionService: perms,
-            sttClient: stt,
-            meetingVADModelPreparer: vadPreparer,
-            isMeetingVADLiveChunkingEnabled: { true },
-            defaults: defaults
-        )
-        vm.jump(to: .engine)
-
-        vm.startEngineWarmUp()
-        try await Task.sleep(for: .milliseconds(160))
-
-        let prepared = await vadPreparer.prepareModelCalled
-        XCTAssertTrue(prepared, "VAD model should be fetched on the Parakeet warm-up path when enabled and uncached")
-        XCTAssertEqual(vm.engineState, .ready)
-    }
-
-    func testEngineWarmUpSkipsMeetingVADModelWhenFlagDisabled() async throws {
-        let perms = MockPermissionService()
-        let stt = MockSTTClient()
-        let vadPreparer = MockMeetingVADModelPreparer()
-        await vadPreparer.configureCached(false)
-        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
-
-        let vm = makeViewModel(
-            permissionService: perms,
-            sttClient: stt,
-            meetingVADModelPreparer: vadPreparer,
-            isMeetingVADLiveChunkingEnabled: { false },
-            defaults: defaults
-        )
-        vm.jump(to: .engine)
-
-        vm.startEngineWarmUp()
-        try await Task.sleep(for: .milliseconds(160))
-
-        let prepared = await vadPreparer.prepareModelCalled
-        XCTAssertFalse(prepared, "disabled feature must not fetch the VAD model")
-        XCTAssertEqual(vm.engineState, .ready)
-    }
-
-    func testEngineWarmUpSkipsMeetingVADModelWhenAlreadyCached() async throws {
-        let perms = MockPermissionService()
-        let stt = MockSTTClient()
-        let vadPreparer = MockMeetingVADModelPreparer()
-        await vadPreparer.configureCached(true)  // already on disk
-        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
-
-        let vm = makeViewModel(
-            permissionService: perms,
-            sttClient: stt,
-            meetingVADModelPreparer: vadPreparer,
-            isMeetingVADLiveChunkingEnabled: { true },
-            defaults: defaults
-        )
-        vm.jump(to: .engine)
-
-        vm.startEngineWarmUp()
-        try await Task.sleep(for: .milliseconds(160))
-
-        let prepared = await vadPreparer.prepareModelCalled
-        XCTAssertFalse(prepared, "already-cached model must not be re-fetched")
-        XCTAssertEqual(vm.engineState, .ready)
-    }
-
-    func testMeetingVADModelPrepFailureDoesNotFailWarmUp() async throws {
-        let perms = MockPermissionService()
-        let stt = MockSTTClient()
-        let vadPreparer = MockMeetingVADModelPreparer()
-        await vadPreparer.configureCached(false)
-        await vadPreparer.configurePrepareModel(error: FakeVADPrepError.boom)
-        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
-
-        let vm = makeViewModel(
-            permissionService: perms,
-            sttClient: stt,
-            meetingVADModelPreparer: vadPreparer,
-            isMeetingVADLiveChunkingEnabled: { true },
-            defaults: defaults
-        )
-        vm.jump(to: .engine)
-
-        vm.startEngineWarmUp()
-        try await Task.sleep(for: .milliseconds(160))
-
-        let prepared = await vadPreparer.prepareModelCalled
-        XCTAssertTrue(prepared)
-        // VAD live chunking is optional — a download failure must not block the
-        // speech engine, so warm-up still completes.
-        XCTAssertEqual(vm.engineState, .ready)
     }
 
     func testEngineWarmUpUsesWhisperForCJKPreferredLanguageWhenModelIsCached() async throws {

--- a/plans/active/2026-05-meeting-vad-guided-live-chunking.md
+++ b/plans/active/2026-05-meeting-vad-guided-live-chunking.md
@@ -1,6 +1,6 @@
 # Meeting VAD-Guided Live Chunking
 
-> Status: ACTIVE PLAN — Phases 1–4 IMPLEMENTED (flag-off)
+> Status: ACTIVE PLAN — Phases 1–4.5 IMPLEMENTED (flag-off)
 > Date: 2026-05-29
 > Scope: meeting live transcript chunk boundaries only.
 
@@ -28,14 +28,29 @@ live chunking via `FixedMeetingLiveAudioChunker`, byte-identical to
   picks fixed vs speech-boundary per session (VAD only for cached-model Parakeet
   sessions; per-source fixed fallback otherwise), with `meeting_live_chunking_mode`
   diagnostics.
-- **Model prep** — `MeetingVADModelPreparer` + `MeetingVADService.downloadModel`
-  fetch the Silero VAD model during the onboarding speech-engine warm-up, **only
-  when `meetingVadLiveChunkingEnabled` is true** and on the Parakeet path (VAD is
-  gated to Parakeet sessions). Failure is logged + swallowed (warm-up still
-  completes; runtime falls back to fixed). This makes the flag meaningfully
-  flippable: flip → relaunch → model fetched → `makeIfModelCached()` starts
-  succeeding. (`.../Services/MeetingRecording/MeetingVADModelPreparer.swift`,
-  `OnboardingViewModel.prepareMeetingVADModelIfNeeded`)
+- **Model prep (Phase 4.5 — universal launch-time prep, IMPLEMENTED).**
+  `MeetingVADModelPreparer` + `MeetingVADService.downloadModel` fetch the Silero
+  VAD model, **only when `meetingVadLiveChunkingEnabled` is true**. The fetch now
+  rides `AppDelegate.scheduleDeferredSpeechPreWarm` — the existing 1.5s-deferred,
+  `.utility`, single-flight launch task that runs on **every launch for every
+  user** — via the testable `MeetingVADLaunchPrep.run(featureEnabled:preparer:)`
+  gate. So flipping the flag reaches the **whole installed base**, not just fresh
+  installs, which is what makes default-on meaningful. The prep is idempotent
+  (no-ops when `isModelReady()`), independent of the speech warm-up's own
+  try/catch, and silent-fail: a download failure is logged + swallowed, the
+  runtime falls back to fixed chunking, and the next launch retries (natural
+  per-launch backoff). The **onboarding-only prep
+  (`OnboardingViewModel.prepareMeetingVADModelIfNeeded`) and its injection through
+  `OnboardingCoordinator` / `OnboardingWindowController` were deleted** — one prep
+  path, and VAD is fully detached from `2026-05-dictation-first-onboarding.md`.
+  (`.../Services/MeetingRecording/MeetingVADModelPreparer.swift`,
+  `AppDelegate.scheduleDeferredSpeechPreWarm`)
+  - **Telemetry:** `vad_model_prep` outcome event (`prepared` / `failed` only;
+    `already_cached` and feature-off are silent to avoid per-launch spam).
+    Two-repo allowlist: `"vad_model_prep"` added to `ALLOWED_EVENTS` in the
+    website's `functions/api/telemetry.ts` — **must deploy the website before the
+    flag-flip build ships** or the Worker rejects the whole batch. (No production
+    risk while the flag is off: the event never fires.)
   - **Verified end-to-end (2026-05-28, headless):** `downloadModel()` fetches the
     Silero model to `Models/silero-vad/` (the `repo.folderName` path the pinned
     FluidAudio `VadManager` actually loads from — `isModelCached()` uses the same
@@ -380,6 +395,71 @@ sample values.
 Telemetry should wait until the diagnostic shape is proven useful. If telemetry
 is added later, keep it aggregated and privacy-safe.
 
+### 6. Universal VAD model availability (launch-time background prep)
+
+**This is the gating enablement work — without it, turning VAD on reaches almost
+no one.**
+
+**The gap.** Today the Silero model is fetched *only* during the onboarding
+speech-engine warm-up (`OnboardingViewModel.prepareMeetingVADModelIfNeeded`, see
+Implementation Status). Onboarding runs once and never again — the coordinator
+gates on `onboarding.completedAtISO`. So the model reaches **new installs only**.
+Every already-onboarded user — essentially the entire installed base — never
+acquires it, and the runtime (`makeIfModelCached`, which *never* downloads by
+design) silently falls back to fixed chunking for them. Flipping
+`meetingVadLiveChunkingEnabled` on today would light VAD up for ~nobody who
+matters. The plan's own "flip → relaunch → model fetched" claim (Implementation
+Status) is only true for users who re-run onboarding.
+
+**Decision.** Prep the model in the **background on every launch, for all users**,
+whenever the feature is on and the model is missing. The model is tiny (verified
+~1.7s end-to-end, single-digit MB), so prepping it for users who never record a
+meeting costs essentially nothing — one universal path beats scoping to meeting
+users. This *subsumes* the onboarding-only prep.
+
+**Integration — ride the existing deferred warm-up.**
+`AppDelegate.scheduleDeferredSpeechPreWarm` (`AppDelegate.swift:511`) already runs
+on every launch for every user: deferred 1.5s, `Task(priority: .utility)`,
+single-flight. Append VAD prep to that task, after `sttRuntime.backgroundWarmUp()`:
+
+```swift
+// inside the existing deferred .utility task, after speech warm-up
+if AppFeatures.meetingVadLiveChunkingEnabled,
+   await environment.meetingVADModelPreparer.isModelReady() == false {
+    do { try await environment.meetingVADModelPreparer.prepareModel() }
+    catch { /* log + swallow; runtime falls back to fixed; retry next launch */ }
+}
+```
+
+- **Own `try/catch`, independent of the speech warm-up**, so neither blocks the
+  other.
+- `prepareModel()` is **idempotent** (`MeetingVADModelPreparer` no-ops when
+  `isModelCached()`), so the call is free once the model is present.
+- **Silent-fail → fixed fallback** (the runtime already does this); a failed prep
+  just retries on the next launch — natural per-launch backoff, no within-session
+  hammering.
+
+**Delete the onboarding-only prep.** Once launch prep covers everyone, remove
+`OnboardingViewModel.prepareMeetingVADModelIfNeeded` (call site `:487`) and the
+`meetingVADModelPreparer` injection through `OnboardingCoordinator` /
+`OnboardingWindowController` / the onboarding ViewModel. One prep path instead of
+two; also fully detaches VAD from the dictation-first onboarding plan
+(`2026-05-dictation-first-onboarding.md`). (Leave `AppEnvironment`'s
+`meetingVADModelPreparer` — the launch hook now consumes it.)
+
+**Telemetry (recommended).** The whole point is reaching a population that's
+invisible by default, so instrument prep outcome to confirm field reach: a
+`vad_model_prep` event with an outcome (`already_cached` | `prepared` | `failed`).
+That is the difference between *believing* existing users got VAD and *seeing*
+that they did. **Two-repo change** — also add the event name to `ALLOWED_EVENTS`
+in `macparakeet-website/functions/api/telemetry.ts` and deploy that **before** the
+build ships, or the Worker rejects the whole batch.
+
+**Network-awareness (optional, low priority).** A careful implementation skips the
+silent download on metered / Low Data Mode connections (`NWPathMonitor.isExpensive`
+/ `isConstrained`) and retries when unconstrained. For a ~couple-MB, ~1.7s model
+this is nice-to-have, not a blocker — acceptable to defer past first enablement.
+
 ## Rollout Phases
 
 ### Phase 0: Benchmark and API spike
@@ -453,6 +533,38 @@ Exit criteria:
 - VAD mode is exercisable in dev builds and tests
 - pause/resume and source-alignment tests pass in both modes
 
+### Phase 4.5: Universal VAD model availability (prerequisite for default-on) — IMPLEMENTED
+
+The single most impactful piece — default-on without it reaches only fresh
+installs. Implements **Design §6**.
+
+- ✅ Idempotent VAD model prep appended to
+  `AppDelegate.scheduleDeferredSpeechPreWarm` (after the speech warm-up), gated
+  on `meetingVadLiveChunkingEnabled && !isModelReady()` via the testable
+  `MeetingVADLaunchPrep.run(featureEnabled:preparer:)`, in its own swallowing
+  path (never throws out of the launch task).
+- ✅ Onboarding-only prep deleted
+  (`OnboardingViewModel.prepareMeetingVADModelIfNeeded`, the
+  `meetingVADModelPreparer` / `isMeetingVADLiveChunkingEnabled` ViewModel inputs,
+  and the injection through `OnboardingCoordinator` / `OnboardingWindowController`).
+  `AppEnvironment.meetingVADModelPreparer` retained — the launch hook consumes it.
+- ✅ `vad_model_prep` telemetry outcome event (`prepared` / `failed`) +
+  `"vad_model_prep"` added to the website `ALLOWED_EVENTS`. Deploy the website
+  before the flag-flip build ships.
+
+Exit criteria:
+
+- ✅ full `swift test` — unit-tested via `MeetingVADLaunchPrepTests` (disabled /
+  already-cached / prepared / failed-is-swallowed) and `TelemetryServiceTests`
+  (outcome serialization + contract coverage). The flag-and-cache gate is tested
+  without driving the launch timer.
+- ⏳ dev smoke (manual, do at Phase 5 enablement): with the flag on and the model
+  cache deleted, relaunch → the model is fetched in the background within
+  seconds, then `isModelCached()` is true and a meeting uses VAD
+  (`meeting_live_chunking_mode … mode=vad`).
+- ⏳ offline relaunch → prep fails silently, meeting still starts on fixed
+  chunking, next online relaunch fetches it.
+
 ### Phase 5: Release hardening
 
 - Tune thresholds with real meetings and synthetic fixtures.
@@ -507,6 +619,16 @@ Exit criteria:
 - Stop cancels or drains pending live chunk tasks as today.
 - Final transcription path is unchanged.
 
+### Model Prep (Phase 4.5)
+
+- Launch prep no-ops when the model is already cached (`isModelReady() == true`
+  → `prepareModel` not called). Use `MockMeetingVADModelPreparer`.
+- Launch prep is skipped entirely when `meetingVadLiveChunkingEnabled` is false.
+- A failing `prepareModel` is swallowed (no throw escapes the launch task) and
+  leaves the app able to start a meeting on fixed chunking.
+- Factor the flag-and-cache gate into a small testable function so the decision is
+  unit-tested without driving `AppDelegate`.
+
 ### Manual Validation
 
 - Quiet room, local monologue.
@@ -553,8 +675,11 @@ Exit criteria:
 
 ## Open Questions
 
-- Should VAD assets be prepared during onboarding/model repair, or should the
-  first release use VAD only when the model already exists?
+- ~~Should VAD assets be prepared during onboarding/model repair, or should the
+  first release use VAD only when the model already exists?~~ **RESOLVED** —
+  neither. Prep in the background on **every launch for all users** (flag-on +
+  uncached), riding `scheduleDeferredSpeechPreWarm`; onboarding-only prep strands
+  the installed base. See **Design §6** / **Phase 4.5**.
 - What initial max-duration gives the best live feel: 8s, 10s, or 14s?
 - Should microphone and system sources use the same VAD thresholds?
 - Should VAD mode be enabled only for Parakeet live chunks first, or also when a


### PR DESCRIPTION
## Summary

Makes the Silero VAD model available to the **entire installed base**, not just fresh installs, so VAD-guided meeting live chunking actually lights up for real users once the feature is enabled. This is **Phase 4.5** of `plans/active/2026-05-meeting-vad-guided-live-chunking.md` (§6).

**The gap it closes:** PR #390 fetched the VAD model only during onboarding, which never re-runs for already-onboarded users — so the model reached *new installs only*, and the runtime (`MeetingVADService.makeIfModelCached`, which never downloads) silently ran fixed chunking for everyone else. Flipping the flag today would have lit VAD up for ~nobody.

## What this does

- **`MeetingVADLaunchPrep.run(featureEnabled:preparer:)`** — idempotent, never-throwing launch-time prep. No-ops when the feature is off or the model is already cached; downloads otherwise; swallows failures (`.failed` → runtime falls back to fixed chunking, next launch retries). This is the flag-and-cache gate factored out of `AppDelegate` so it's unit-testable without driving the launch timer.
- **Wired into `AppDelegate.scheduleDeferredSpeechPreWarm`** — the existing 1.5s-deferred, `.utility`, single-flight launch task that already runs every launch for every user — after the speech warm-up, in its own path (independent of STT warm-up success/failure).
- **Deletes the onboarding-only prep** (`OnboardingViewModel.prepareMeetingVADModelIfNeeded` + the `meetingVADModelPreparer` / `isMeetingVADLiveChunkingEnabled` ViewModel inputs + the injection through `OnboardingCoordinator` / `OnboardingWindowController`). One prep path. `AppEnvironment.meetingVADModelPreparer` is retained — the launch hook consumes it now.
- **`vad_model_prep` telemetry** (`prepared` / `failed` only — `already_cached` and feature-off are silent to avoid per-launch spam) so the model's reach into the installed base is observable.

## The flag stays `false`

This is the model-availability **prerequisite** (Phase 4.5), not the enablement flip. `AppFeatures.meetingVadLiveChunkingEnabled` remains `false`; flipping it on is a later, separate 1-line PR after Phase 5 (real-call eyeball + hardening). With the flag off, `MeetingVADLaunchPrep.run` returns `.disabled` and the telemetry event never fires — **zero production behavior change** from this PR.

## ⚠️ Two-repo prerequisite before the flag flips

The `vad_model_prep` event name must be added to `ALLOWED_EVENTS` in the website's `functions/api/telemetry.ts` **and deployed** before any build ships with the flag on, or the Worker rejects the whole batch. The allowlist edit is prepared locally in `macparakeet-website`; it needs push + deploy as part of the eventual flip. No urgency while the flag is off (the event can't fire).

## Validation

- Full `swift test` at the committed flag-off config: **0 failures, exit 0** (all suites, incl. `MeetingRecordingServiceTests`, `MeetingVADLaunchPrepTests`, `OnboardingViewModelTests`, `TelemetryServiceTests`, + swift-testing).
- New `MeetingVADLaunchPrepTests`: disabled / already-cached / prepared / failure-swallowed.
- `TelemetryServiceTests`: outcome serialization + the typed-event contract coverage.

## Heads-up (out of scope for this PR) — what actually blocks the flag flip

While verifying, I confirmed the real Phase-5 blockers (neither caused by this PR):

1. **Flipping `meetingVadLiveChunkingEnabled = true` breaks the committed meeting test suite.** `MeetingRecordingServiceTests` feeds synthetic *constant-amplitude tones* and asserts fixed-chunking output; VAD correctly classifies a constant DC tone as non-speech, so the chunker emits nothing and assertions like `XCTUnwrap(ranges[.microphone])` fail. ~47 tone-feeding sites across 53 tests, none VAD-aware — they need reworking to realistic/VAD-triggering audio before the flag can flip.
2. **Test-isolation defect:** `MeetingRecordingService` writes to the **real** `AppPaths.meetingRecordingsDir` in tests (no temp-dir override) — hence hundreds of leftover folders + stale `recording.lock`s in `~/Library/Application Support/MacParakeet/meeting-recordings/`. Two concurrent `swift test` runs deadlock on that shared dir (this is what caused the intermittent full-suite "hang" during review — a cross-process file-lock contention, not a code deadlock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
