### PR TITLE
Make meeting tests independent of the VAD live-chunking flag

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -104,7 +104,10 @@ final class AppEnvironment {
                 sourceModeProvider: meetingAudioSourceModeProvider,
                 sharedMicStream: sharedMicStream
             ),
-            sttTranscriber: sttScheduler
+            sttTranscriber: sttScheduler,
+            // Wire the real feature flag here (the service defaults to fixed
+            // chunking so tests stay deterministic regardless of the flag).
+            isVadLiveChunkingEnabled: { AppFeatures.meetingVadLiveChunkingEnabled }
         )
         clipboardService = ClipboardService()
         systemMediaController = SystemMediaController()

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -157,6 +157,15 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     private let audioCaptureService: any MeetingAudioCapturing
     private let audioConverter: any AudioFileConverting
     private let fileManager: FileManager
+    /// Whether VAD-guided live chunking is enabled for this service. Injected
+    /// rather than read from `AppFeatures` directly so the decision is testable:
+    /// tests get deterministic fixed chunking via the conservative `{ false }`
+    /// default, while production (`AppEnvironment`) wires the real
+    /// `AppFeatures.meetingVadLiveChunkingEnabled`. This keeps the meeting test
+    /// suite green regardless of the global flag (synthetic test tones produce
+    /// no VAD chunks, so flag-on would otherwise break every chunk-dependent
+    /// test) — see `plans/active/2026-05-meeting-vad-guided-live-chunking.md`.
+    private let isVadLiveChunkingEnabled: @Sendable () -> Bool
     private let requestedMicProcessingMode: MeetingMicProcessingMode
     private let liveChunkTranscriber: LiveChunkTranscriber
     private let lockFileStore: MeetingRecordingLockFileStoring
@@ -244,6 +253,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         sttTranscriber: STTTranscribing,
         lockFileStore: MeetingRecordingLockFileStoring = MeetingRecordingLockFileStore(),
         fileManager: FileManager = .default,
+        isVadLiveChunkingEnabled: @escaping @Sendable () -> Bool = { false },
         echoSuppressionConfiguration: MeetingEchoSuppressionConfiguration = .fromEnvironment()
     ) {
         self.init(
@@ -253,6 +263,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             sttTranscriber: sttTranscriber,
             lockFileStore: lockFileStore,
             fileManager: fileManager,
+            isVadLiveChunkingEnabled: isVadLiveChunkingEnabled,
             micConditionerFactory: {
                 MeetingEchoSuppressionFactory.makeConditioner(
                     configuration: echoSuppressionConfiguration
@@ -268,6 +279,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         sttTranscriber: STTTranscribing,
         lockFileStore: MeetingRecordingLockFileStoring = MeetingRecordingLockFileStore(),
         fileManager: FileManager = .default,
+        isVadLiveChunkingEnabled: @escaping @Sendable () -> Bool = { false },
         micConditionerFactory: @escaping @Sendable () -> any MicConditioning
     ) {
         self.requestedMicProcessingMode = micProcessingMode
@@ -275,6 +287,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         self.audioConverter = audioConverter
         self.lockFileStore = lockFileStore
         self.fileManager = fileManager
+        self.isVadLiveChunkingEnabled = isVadLiveChunkingEnabled
         self.micConditionerFactory = micConditionerFactory
         self.liveChunkTranscriber = LiveChunkTranscriber(sttTranscriber: sttTranscriber)
         self.speechEngineSessionManager = sttTranscriber as? any SpeechEngineSessionManaging
@@ -950,7 +963,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             )
         }
 
-        guard AppFeatures.meetingVadLiveChunkingEnabled else {
+        guard isVadLiveChunkingEnabled() else {
             await useFixed(reason: "feature_disabled")
             return
         }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -157,14 +157,12 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     private let audioCaptureService: any MeetingAudioCapturing
     private let audioConverter: any AudioFileConverting
     private let fileManager: FileManager
-    /// Whether VAD-guided live chunking is enabled for this service. Injected
-    /// rather than read from `AppFeatures` directly so the decision is testable:
-    /// tests get deterministic fixed chunking via the conservative `{ false }`
-    /// default, while production (`AppEnvironment`) wires the real
-    /// `AppFeatures.meetingVadLiveChunkingEnabled`. This keeps the meeting test
-    /// suite green regardless of the global flag (synthetic test tones produce
-    /// no VAD chunks, so flag-on would otherwise break every chunk-dependent
-    /// test) — see `plans/active/2026-05-meeting-vad-guided-live-chunking.md`.
+    /// Whether VAD-guided live chunking is enabled, injected (rather than read
+    /// from `AppFeatures` directly) so the decision is testable and overridable
+    /// per-construction. Production (`AppEnvironment`) wires the real
+    /// `AppFeatures.meetingVadLiveChunkingEnabled`; the conservative `{ false }`
+    /// default gives tests deterministic fixed chunking. See
+    /// `plans/active/2026-05-meeting-vad-guided-live-chunking.md`.
     private let isVadLiveChunkingEnabled: @Sendable () -> Bool
     private let requestedMicProcessingMode: MeetingMicProcessingMode
     private let liveChunkTranscriber: LiveChunkTranscriber
@@ -959,7 +957,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
                 system: FixedMeetingLiveAudioChunker()
             )
             AudioCaptureDiagnostics.append(
-                "meeting_live_chunking_mode mode=fixed reason=\(reason)"
+                "meeting_live_chunking_mode session=\(session.id.uuidString) mode=fixed reason=\(reason)"
             )
         }
 
@@ -980,7 +978,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             microphone: SpeechBoundaryMeetingLiveAudioChunker(vad: vad),
             system: SpeechBoundaryMeetingLiveAudioChunker(vad: vad)
         )
-        AudioCaptureDiagnostics.append("meeting_live_chunking_mode mode=vad reason=started")
+        AudioCaptureDiagnostics.append("meeting_live_chunking_mode session=\(session.id.uuidString) mode=vad reason=started")
     }
 
     /// The shared VAD service, loaded lazily once per app session. Returns nil

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
@@ -326,6 +326,46 @@ final class MeetingRecordingServiceTests: XCTestCase {
         try? FileManager.default.removeItem(at: output.folderURL)
     }
 
+    /// PR #395's mechanism: the injected `isVadLiveChunkingEnabled` closure is
+    /// consulted in `configureLiveChunkers`. The sibling tests all exercise the
+    /// default `{ false }` path (→ `feature_disabled` → fixed chunker); this is
+    /// the one test that proves `{ true }` flips the first guard. It asserts
+    /// only the durable invariant — the decision is NOT `feature_disabled` —
+    /// because the downstream reason (`non_parakeet_engine` / `vad_unavailable`
+    /// / `mode=vad reason=started`) depends on the session engine and whether
+    /// the Silero model happens to be cached on the machine. The full
+    /// VAD-chunker install path is covered by
+    /// `SpeechBoundaryMeetingLiveAudioChunkerTests`.
+    func testRecordingWithVadEnabledConsultsInjectedFlag() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: MockMeetingAudioFileConverter(),
+            sttTranscriber: CountingMeetingSTTClient(),
+            isVadLiveChunkingEnabled: { true }
+        )
+
+        try await service.startRecording()
+        let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 16_000, sampleValue: 0.25))
+        await captureService.yield(.microphoneBuffer(
+            microphoneBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
+        ))
+        let output = try await service.stopRecording()
+        defer { try? FileManager.default.removeItem(at: output.folderURL) }
+
+        let log = try String(contentsOf: AudioCaptureDiagnostics.diagnosticLogURL(), encoding: .utf8)
+        let modeLine = try XCTUnwrap(
+            log.split(whereSeparator: \.isNewline)
+                .last { $0.contains("meeting_live_chunking_mode session=\(output.sessionID.uuidString)") },
+            "expected a chunking-mode decision logged for this session"
+        )
+        XCTAssertFalse(
+            modeLine.contains("reason=feature_disabled"),
+            "flag-on recording must consult the injected closure, not short-circuit on feature_disabled"
+        )
+    }
+
     func testStopRecordingReturnsOutputAndKeepsLockWhenMixFails() async throws {
         let captureService = MockMeetingAudioCaptureService()
         let lockStore = RecordingLockFileStore()


### PR DESCRIPTION
## Summary

Unblocks flipping `AppFeatures.meetingVadLiveChunkingEnabled` to `true` (shipping VAD-guided meeting live chunking). Today, flipping it turns the **entire `MeetingRecordingServiceTests` suite red** — this PR makes the meeting tests independent of the global flag so the flip is a clean, green change.

## The blocker

`MeetingRecordingServiceTests` (53 tests) feed synthetic **constant-amplitude tones** and assert fixed-chunking behavior — emitted chunk ranges, live-chunk transcription events. The chunker choice is decided by the global flag:

```
MeetingRecordingService.configureLiveChunkers:  guard AppFeatures.meetingVadLiveChunkingEnabled else { …fixed… }
```

VAD correctly classifies a constant DC tone as **non-speech**, so with the flag ON the speech-boundary chunker emits nothing → chunk-asserting tests fail (`XCTUnwrap(ranges[.microphone])` → nil) and chunk-waiting tests stall on never-fulfilled expectations. (Confirmed by stack sampling: the main thread parked in `XCTWaiter waitForExpectations`, cooperative pool idle.)

## The fix — dependency inversion (zero test edits)

Reading a global compile-time flag for behavior the tests assert on is the real defect. Inject the decision instead:

- `MeetingRecordingService` gains `isVadLiveChunkingEnabled: @Sendable () -> Bool`, defaulting to the conservative `{ false }` (fixed chunking).
- `configureLiveChunkers` consults the injected closure.
- `AppEnvironment` (the one production construction) wires the real flag: `isVadLiveChunkingEnabled: { AppFeatures.meetingVadLiveChunkingEnabled }`.

Production behavior is unchanged. The ~53 meeting tests inherit deterministic fixed chunking via the default — **no test edits** — so the suite is green regardless of the flag. The VAD chunker itself remains covered by `SpeechBoundaryMeetingLiveAudioChunkerTests` (fake VAD) and `MeetingVADChunkingSimulatorTests`.

## Validation

- **Full `swift test` with the flag ON: 0 failures** (incl. `MeetingRecordingServiceTests` — 53/53, ~5s; previously hung 12+ min). This is the proof the flag can now flip safely.
- Full `swift test` with the flag OFF (committed config / CI): green, behavior unchanged.

The flag stays `false` in this PR — this is the test-compatibility prerequisite, not the enablement flip (that remains the separate `flip/meeting-vad-default-on` change). This PR makes that flip green.

## Out of scope — the other (non-blocking) issue

There's a separate test-isolation defect: `MeetingRecordingService` writes to the **real** `AppPaths.meetingRecordingsDir` in tests (no temp-dir seam), so two concurrent `swift test` runs (e.g. across worktrees) deadlock on the shared directory, and runs leave folders behind. It does **not** block CI or the flag flip (single run per CI runner), so it's left for a focused follow-up rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
