### PR TITLE
Expose Parakeet v2 (English-only) model selection (#311, #398)

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -80,6 +80,40 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ## [Unreleased]
 
+## [2.5.0] -- 2026-05-30
+
+### Added
+
+- Parakeet now exposes both model builds: the multilingual `v3` (default) and
+  the English-only `v2`. v2 is a touch faster on English and never mis-detects
+  English speech as another language (the v3 auto-detect failure behind issues
+  #311 and #398).
+- `config set parakeet-model v3|v2` (also `multilingual`/`english` aliases) and
+  `config get parakeet-model` persist the shared GUI/CLI Parakeet build
+  preference. Listed in `config list`.
+- `transcribe --parakeet-model app-default|v3|v2` overrides the Parakeet build
+  for a single run; `app-default` follows the saved preference. Ignored for
+  Whisper.
+- `models list` now lists both Parakeet builds (`parakeet-v3`, `parakeet-v2`)
+  with their per-build install state and approximate size. `models select
+  parakeet-v2` (also `parakeet:v2` / `parakeet-english`) persists the build.
+  `models warm-up` / `repair` / `status` now operate on the selected build
+  instead of always defaulting to v3.
+- `models download parakeet-v2` / `parakeet-v3` (and bare `parakeet` for the
+  selected build) pre-fetches a Parakeet build without selecting it, alongside
+  the existing `whisper-*` download path.
+
+### Changed
+
+- `models list` now returns **two** Parakeet rows (`parakeet-v3`, `parakeet-v2`)
+  instead of one. Callers that assumed a single Parakeet entry, or that read the
+  Parakeet id as the literal `"parakeet"`, should switch to selecting by the
+  `selected` flag / the new ids. The bare `parakeet` id still works in
+  `models select` (keeps the persisted build). JSON field names and types are
+  unchanged.
+- `models list` Parakeet `size` now reports the real ~465 MB per-build download
+  footprint (previously an inaccurate "6 GB" placeholder).
+
 ## [2.4.0] -- 2026-05-29
 
 ### Added

--- a/Sources/CLI/Commands/ConfigCommand.swift
+++ b/Sources/CLI/Commands/ConfigCommand.swift
@@ -24,6 +24,8 @@ struct ConfigCommand: ParsableCommand {
           telemetry                 on|off                         default: on
           processing-mode           raw|clean                       default: raw
           speech-engine             parakeet|whisper                default: parakeet
+          parakeet-model            v3|v2 (v3=multilingual,         default: v3
+                                    v2=English-only)
           whisper-language          auto|<Whisper language code>    default: auto
           speaker-detection         on|off                          default: off
           save-transcription-audio  on|off                          default: on
@@ -46,6 +48,7 @@ struct ConfigCommand: ParsableCommand {
         "telemetry",
         "processing-mode",
         "speech-engine",
+        "parakeet-model",
         "whisper-language",
         "speaker-detection",
         "save-transcription-audio",
@@ -158,6 +161,8 @@ struct ConfigCommand: ParsableCommand {
             return (Dictation.ProcessingMode(rawValue: raw ?? Dictation.ProcessingMode.raw.rawValue) ?? .raw).rawValue
         case "speech-engine":
             return SpeechEnginePreference.current(defaults: store).rawValue
+        case "parakeet-model":
+            return SpeechEnginePreference.parakeetModelVariant(defaults: store).rawValue
         case "whisper-language":
             return SpeechEnginePreference.whisperDefaultLanguage(defaults: store) ?? WhisperLanguageCatalog.autoCode
         case "speaker-detection":
@@ -191,6 +196,10 @@ struct ConfigCommand: ParsableCommand {
             let engine = try parseSpeechEngine(value)
             engine.save(to: store)
             return engine.rawValue
+        case "parakeet-model":
+            let variant = try parseParakeetModelVariant(value)
+            SpeechEnginePreference.saveParakeetModelVariant(variant, defaults: store)
+            return variant.rawValue
         case "whisper-language":
             let language = try parseWhisperLanguage(value)
             SpeechEnginePreference.saveWhisperDefaultLanguage(language, defaults: store)
@@ -248,6 +257,22 @@ struct ConfigCommand: ParsableCommand {
             throw ValidationError("Invalid value for speech-engine: '\(value)'. Use parakeet or whisper.")
         }
         return engine
+    }
+
+    /// Accepts the canonical `v3`/`v2` ids plus the friendlier
+    /// `multilingual`/`english` aliases so users can express intent either way.
+    static func parseParakeetModelVariant(_ value: String) throws -> ParakeetModelVariant {
+        let raw = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "_", with: "-")
+        switch raw {
+        case "v3", "multilingual", "multi":
+            return .v3
+        case "v2", "english", "english-only", "en":
+            return .v2
+        default:
+            throw ValidationError("Invalid value for parakeet-model: '\(value)'. Use v3 (multilingual) or v2 (English-only).")
+        }
     }
 
     static func parseWhisperLanguage(_ value: String) throws -> String? {

--- a/Sources/CLI/Commands/HealthCommand.swift
+++ b/Sources/CLI/Commands/HealthCommand.swift
@@ -125,7 +125,7 @@ struct HealthCommand: AsyncParsableCommand {
         }
 
         // 5. Local speech stack
-        let sttClient = STTClient()
+        let sttClient = makeParakeetSTTClient()
         var sttClientNeedsShutdown = true
         defer {
             if sttClientNeedsShutdown {

--- a/Sources/CLI/Commands/ModelsCommand.swift
+++ b/Sources/CLI/Commands/ModelsCommand.swift
@@ -68,6 +68,9 @@ extension ModelsCommand {
                 if let whisperVariant = selection.whisperVariant {
                     SpeechEnginePreference.saveWhisperModelVariant(whisperVariant, defaults: defaults)
                 }
+                if let parakeetVariant = selection.parakeetVariant {
+                    SpeechEnginePreference.saveParakeetModelVariant(parakeetVariant, defaults: defaults)
+                }
 
                 let selected = loadSelectableSpeechModels(defaults: defaults).first { $0.selected }
                     ?? SelectableSpeechModel(
@@ -100,7 +103,7 @@ extension ModelsCommand {
 
         func run() async throws {
             try await emitJSONOrRethrow(json: json) {
-                let sttClient = STTClient()
+                let sttClient = makeParakeetSTTClient()
                 var sttClientNeedsShutdown = true
                 defer {
                     if sttClientNeedsShutdown {
@@ -129,10 +132,26 @@ extension ModelsCommand {
             abstract: "Download a local speech model without starting a transcription."
         )
 
-        @Argument(help: "Model identifier. Use whisper-large-v3-v20240930-turbo-632MB for Whisper.")
+        @Argument(help: "Model identifier from `models list`, e.g. parakeet-v2, parakeet-v3, or whisper-large-v3-v20240930-turbo-632MB.")
         var variant: String
 
         func run() async throws {
+            let lowered = variant.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            if let parakeetVariant = parakeetDownloadVariant(from: lowered) {
+                print("Parakeet: downloading \(parakeetVariant.modelName)...")
+                let lastMessage = OSAllocatedUnfairLock(initialState: "")
+                try await STTRuntime.downloadParakeetModel(version: parakeetVariant.asrModelVersion) { message in
+                    let shouldPrint = lastMessage.withLock { last in
+                        guard last != message else { return false }
+                        last = message
+                        return true
+                    }
+                    if shouldPrint { print("Parakeet: \(message)") }
+                }
+                print("Parakeet: ready (\(parakeetVariant.modelName))")
+                return
+            }
+
             let model = try resolveWhisperDownloadModel(variant)
             print("Whisper: downloading \(model)...")
             let lastPercent = OSAllocatedUnfairLock(initialState: -1)
@@ -163,7 +182,7 @@ extension ModelsCommand {
 
         func run() async throws {
             let attempts = try validatedAttempts(attempts)
-            let sttClient = STTClient()
+            let sttClient = makeParakeetSTTClient()
             var sttClientNeedsShutdown = true
             defer {
                 if sttClientNeedsShutdown {
@@ -193,7 +212,7 @@ extension ModelsCommand {
 
         func run() async throws {
             let attempts = try validatedAttempts(attempts)
-            let sttClient = STTClient()
+            let sttClient = makeParakeetSTTClient()
             var sttClientNeedsShutdown = true
             defer {
                 if sttClientNeedsShutdown {
@@ -219,7 +238,7 @@ extension ModelsCommand {
         )
 
         func run() async throws {
-            let sttClient = STTClient()
+            let sttClient = makeParakeetSTTClient()
             await sttClient.clearModelCache()
             DiarizationService.clearModelCache()
             try? FileManager.default.removeItem(atPath: AppPaths.whisperModelsDir)
@@ -228,13 +247,26 @@ extension ModelsCommand {
     }
 }
 
+/// Recognizes the Parakeet ids surfaced by `models list` (`parakeet-v3`,
+/// `parakeet-v2`), the bare `parakeet` (current build), and the `:`/alias
+/// spellings. Returns nil for non-Parakeet ids so Whisper parsing runs.
+func parakeetDownloadVariant(
+    from lowered: String,
+    defaults: UserDefaults = macParakeetAppDefaults()
+) -> ParakeetModelVariant? {
+    if lowered == SpeechEnginePreference.parakeet.rawValue {
+        return SpeechEnginePreference.parakeetModelVariant(defaults: defaults)
+    }
+    return parseParakeetSelectionVariant(lowered)
+}
+
 func resolveWhisperDownloadModel(_ variant: String) throws -> String {
     let normalizedInput = variant.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !normalizedInput.isEmpty else {
         throw ValidationError("Model variant cannot be empty.")
     }
     guard normalizedInput.hasPrefix("whisper-") else {
-        throw ValidationError("Only whisper-* model identifiers are supported by models download.")
+        throw ValidationError("Unsupported model identifier '\(variant)'. Use a parakeet-v2 / parakeet-v3 or whisper-* id from `models list`.")
     }
     return WhisperEngine.normalizeModelVariant(normalizedInput)
 }
@@ -291,10 +323,21 @@ func validatedAttempts(_ attempts: Int) throws -> Int {
     return attempts
 }
 
+/// Builds the CLI's Parakeet-engine STT client honoring the persisted variant
+/// (`config set parakeet-model v2`), so `warm-up`/`repair`/`status` operate on
+/// the build the user selected rather than always defaulting to v3.
+func makeParakeetSTTClient(defaults: UserDefaults = macParakeetAppDefaults()) -> STTClient {
+    STTClient(modelVersion: SpeechEnginePreference.parakeetModelVariant(defaults: defaults).asrModelVersion)
+}
+
 func loadSpeechStackStatus(
     sttClient: STTClientProtocol,
     diarizationService: DiarizationServiceProtocol,
-    isSpeechModelCached: @escaping @Sendable () -> Bool = { STTClient.isModelCached() },
+    isSpeechModelCached: @escaping @Sendable () -> Bool = {
+        STTClient.isModelCached(
+            version: SpeechEnginePreference.parakeetModelVariant(defaults: macParakeetAppDefaults()).asrModelVersion
+        )
+    },
     whisperModelVariant: String = SpeechEnginePreference.whisperModelVariant(defaults: macParakeetAppDefaults()),
     isWhisperModelDownloaded: @escaping @Sendable (String) -> Bool = { WhisperEngine.isModelDownloaded(model: $0) }
 ) async -> SpeechStackStatus {
@@ -339,28 +382,37 @@ struct SelectableSpeechModel: Encodable, Equatable {
 struct SelectableSpeechModelSelection: Equatable {
     let engine: SpeechEnginePreference
     let whisperVariant: String?
+    /// Set when the selection targets a specific Parakeet build; `nil` leaves
+    /// the persisted Parakeet variant untouched (e.g. a Whisper selection).
+    var parakeetVariant: ParakeetModelVariant? = nil
 }
 
 func loadSelectableSpeechModels(
     defaults: UserDefaults = macParakeetAppDefaults(),
-    isParakeetModelCached: @escaping () -> Bool = { STTClient.isModelCached() },
+    isParakeetModelCached: @escaping (ParakeetModelVariant) -> Bool = {
+        STTClient.isModelCached(version: $0.asrModelVersion)
+    },
     isWhisperModelDownloaded: @escaping (String) -> Bool = { WhisperEngine.isModelDownloaded(model: $0) }
 ) -> [SelectableSpeechModel] {
     let currentEngine = SpeechEnginePreference.current(defaults: defaults)
+    let currentParakeetVariant = SpeechEnginePreference.parakeetModelVariant(defaults: defaults)
     let whisperVariant = SpeechEnginePreference.whisperModelVariant(defaults: defaults)
     let whisperLanguage = SpeechEnginePreference.whisperDefaultLanguage(defaults: defaults)
 
-    return [
+    let parakeetModels = ParakeetModelVariant.allCases.map { variant in
         SelectableSpeechModel(
-            id: SpeechEnginePreference.parakeet.rawValue,
-            name: "Parakeet TDT 0.6B v3",
+            id: parakeetModelID(for: variant),
+            name: "\(variant.modelName) (\(variant.displayName))",
             engine: SpeechEnginePreference.parakeet.rawValue,
-            variant: nil,
-            size: "6 GB",
-            installed: isParakeetModelCached(),
-            selected: currentEngine == .parakeet,
-            language: nil
-        ),
+            variant: variant.rawValue,
+            size: variant.approximateDownloadSize,
+            installed: isParakeetModelCached(variant),
+            selected: currentEngine == .parakeet && currentParakeetVariant == variant,
+            language: variant.isEnglishOnly ? "en" : nil
+        )
+    }
+
+    return parakeetModels + [
         SelectableSpeechModel(
             id: whisperModelID(for: whisperVariant),
             name: "Whisper \(SpeechEnginePreference.friendlyVariantName(whisperVariant))",
@@ -384,8 +436,22 @@ func resolveSelectableSpeechModel(
         throw ValidationError("Model ID cannot be empty.")
     }
 
+    // Bare "parakeet" keeps the persisted variant; "parakeet-v2" / "parakeet:v3"
+    // / "parakeet-english" target a specific build.
     if lowered == SpeechEnginePreference.parakeet.rawValue {
-        return SelectableSpeechModelSelection(engine: .parakeet, whisperVariant: nil)
+        return SelectableSpeechModelSelection(
+            engine: .parakeet,
+            whisperVariant: nil,
+            parakeetVariant: SpeechEnginePreference.parakeetModelVariant(defaults: defaults)
+        )
+    }
+
+    if let parakeetVariant = parseParakeetSelectionVariant(lowered) {
+        return SelectableSpeechModelSelection(
+            engine: .parakeet,
+            whisperVariant: nil,
+            parakeetVariant: parakeetVariant
+        )
     }
 
     if lowered == "whisper" {
@@ -413,6 +479,33 @@ func resolveSelectableSpeechModel(
         engine: .whisper,
         whisperVariant: WhisperEngine.normalizeModelVariant(variantInput)
     )
+}
+
+/// Recognizes `parakeet-v2`, `parakeet:v3`, `parakeet-english`,
+/// `parakeet-multilingual`, etc. Returns `nil` when `id` isn't a Parakeet
+/// variant selector so the caller can fall through to Whisper parsing.
+private func parseParakeetSelectionVariant(_ lowered: String) -> ParakeetModelVariant? {
+    let prefix = SpeechEnginePreference.parakeet.rawValue
+    let suffix: String
+    if lowered.hasPrefix("\(prefix):") {
+        suffix = String(lowered.dropFirst(prefix.count + 1))
+    } else if lowered.hasPrefix("\(prefix)-") {
+        suffix = String(lowered.dropFirst(prefix.count + 1))
+    } else {
+        return nil
+    }
+    switch suffix {
+    case "v3", "multilingual", "multi":
+        return .v3
+    case "v2", "english", "english-only", "en":
+        return .v2
+    default:
+        return nil
+    }
+}
+
+func parakeetModelID(for variant: ParakeetModelVariant) -> String {
+    "\(SpeechEnginePreference.parakeet.rawValue)-\(variant.rawValue)"
 }
 
 func whisperModelID(for variant: String) -> String {

--- a/Sources/CLI/Commands/ModelsCommand.swift
+++ b/Sources/CLI/Commands/ModelsCommand.swift
@@ -485,12 +485,16 @@ func resolveSelectableSpeechModel(
 /// `parakeet-multilingual`, etc. Returns `nil` when `id` isn't a Parakeet
 /// variant selector so the caller can fall through to Whisper parsing.
 private func parseParakeetSelectionVariant(_ lowered: String) -> ParakeetModelVariant? {
+    // Normalize underscores to hyphens so `parakeet_v2` / `parakeet_english`
+    // resolve the same as their hyphenated forms — matching how
+    // `ConfigCommand.parseParakeetModelVariant` canonicalizes the setting.
+    let normalized = lowered.replacingOccurrences(of: "_", with: "-")
     let prefix = SpeechEnginePreference.parakeet.rawValue
     let suffix: String
-    if lowered.hasPrefix("\(prefix):") {
-        suffix = String(lowered.dropFirst(prefix.count + 1))
-    } else if lowered.hasPrefix("\(prefix)-") {
-        suffix = String(lowered.dropFirst(prefix.count + 1))
+    if normalized.hasPrefix("\(prefix):") {
+        suffix = String(normalized.dropFirst(prefix.count + 1))
+    } else if normalized.hasPrefix("\(prefix)-") {
+        suffix = String(normalized.dropFirst(prefix.count + 1))
     } else {
         return nil
     }

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -33,6 +33,12 @@ enum TranscribeSpeechEngine: String, ExpressibleByArgument, CaseIterable, Sendab
     case whisper
 }
 
+enum TranscribeParakeetModel: String, ExpressibleByArgument, CaseIterable, Sendable {
+    case appDefault = "app-default"
+    case v3
+    case v2
+}
+
 enum SpeakerDetectionOption: String, ExpressibleByArgument, CaseIterable, Sendable {
     case appDefault = "app-default"
     case on
@@ -69,6 +75,9 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
 
     @Option(help: "Language hint for Whisper, as a Whisper code such as ko or en. Parakeet ignores this flag.")
     var language: String?
+
+    @Option(name: .long, help: "Parakeet build: app-default, v3 (multilingual), v2 (English-only). app-default follows the saved preference; ignored for Whisper.")
+    var parakeetModel: TranscribeParakeetModel = .appDefault
 
     @Option(help: "Downloaded YouTube audio retention: app-default, keep, delete.")
     var downloadedAudio: DownloadedAudioPolicy = .appDefault
@@ -157,6 +166,20 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
         return SpeechEngineSelection(engine: preference, language: language)
     }
 
+    static func resolveParakeetModelVariant(
+        _ option: TranscribeParakeetModel,
+        storedVariant: ParakeetModelVariant
+    ) -> ParakeetModelVariant {
+        switch option {
+        case .appDefault:
+            return storedVariant
+        case .v3:
+            return .v3
+        case .v2:
+            return .v2
+        }
+    }
+
     static func resolveSpeakerDetection(
         _ option: SpeakerDetectionOption,
         storedEnabled: Bool?,
@@ -229,7 +252,11 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
             let sttTranscriber: STTTranscribing
             switch speechEngine.engine {
             case .parakeet:
-                let createdSTTClient = STTClient()
+                let parakeetVariant = Self.resolveParakeetModelVariant(
+                    self.parakeetModel,
+                    storedVariant: SpeechEnginePreference.parakeetModelVariant(defaults: defaults)
+                )
+                let createdSTTClient = STTClient(modelVersion: parakeetVariant.asrModelVersion)
                 sttClient = createdSTTClient
                 sttTranscriber = createdSTTClient
             case .whisper:

--- a/Sources/CLI/MacParakeetCLI.swift
+++ b/Sources/CLI/MacParakeetCLI.swift
@@ -8,7 +8,7 @@ struct CLI: AsyncParsableCommand {
     /// distinguishable from synthesized Bundle.main values (the bare executable
     /// has no Info.plist and macOS otherwise reports an SDK marker like "16.0").
     /// Bump in lockstep with `Sources/CLI/CHANGELOG.md`.
-    static let cliVersion = "2.4.0"
+    static let cliVersion = "2.5.0"
 
     static let configuration = CommandConfiguration(
         commandName: "macparakeet-cli",

--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -73,6 +73,7 @@ final class AppEnvironment {
         }
 
         sttRuntime = STTRuntime(
+            modelVersion: SpeechEnginePreference.parakeetModelVariant().asrModelVersion,
             speechEngine: SpeechEnginePreference.current(),
             whisperModelVariant: SpeechEnginePreference.whisperModelVariant()
         )

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -369,15 +369,21 @@ struct SettingsView: View {
     /// so each surface owns one decision the user makes:
     ///
     /// 1. `engineSelectorCard` — which engine? (Parakeet vs Whisper)
-    /// 2. `engineLanguageCard` — which language? (Whisper only — Parakeet
+    /// 2. `engineParakeetModelCard` — which Parakeet build? (Parakeet only —
+    ///    multilingual `v3` vs English-only `v2`)
+    /// 3. `engineLanguageCard` — which language? (Whisper only — Parakeet
     ///    auto-detects from its 25 supported European languages)
-    /// 3. `enginesModelsCard` — what's the local model state?
+    /// 4. `enginesModelsCard` — what's the local model state?
+    ///
+    /// Cards 2 and 3 are mutually exclusive (one per engine), so exactly one
+    /// contextual config card sits between the selector and the models card.
     ///
     /// Sub-VM split (`EngineSettingsViewModel`) lands in a later commit;
     /// the cards keep reading from `viewModel` for now.
     private var engineTabContent: some View {
         scrollableTabBody {
             engineSelectorCard.id("engine.selector")
+            engineParakeetModelCard.id("engine.parakeetModel")
             engineLanguageCard.id("engine.language")
             enginesModelsCard.id("engine.models")
         }
@@ -1725,6 +1731,110 @@ struct SettingsView: View {
         }
     }
 
+    /// Parakeet build picker (multilingual `v3` vs English-only `v2`). Only
+    /// shown when Parakeet is the active engine — symmetric to the Whisper
+    /// Language card. English-only fixes the v3 auto-detect mis-firing English
+    /// as another language (issues #311, #398).
+    @ViewBuilder
+    private var engineParakeetModelCard: some View {
+        if viewModel.speechEnginePreference == .parakeet {
+            SettingsCard(
+                title: "Parakeet Model",
+                subtitle: "Pick how Parakeet handles language. English-only is a touch faster and never mistakes English for another language.",
+                icon: "character.book.closed"
+            ) {
+                VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
+                    parakeetModelOptionRow(.v3)
+                    Divider()
+                    parakeetModelOptionRow(.v2)
+                }
+            }
+            .transition(.opacity)
+        }
+    }
+
+    private func parakeetModelOptionRow(_ variant: ParakeetModelVariant) -> some View {
+        let isSelected = viewModel.parakeetModelVariant == variant
+        let isDownloaded = viewModel.downloadedParakeetVariants.contains(variant)
+        return Button {
+            selectParakeetModelVariant(variant)
+        } label: {
+            HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+                Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
+                    .font(.system(size: 16, weight: .regular))
+                    .foregroundStyle(isSelected ? DesignSystem.Colors.accent : DesignSystem.Colors.textSecondary)
+                    .accessibilityHidden(true)
+                    .padding(.top, 1)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    HStack(spacing: DesignSystem.Spacing.sm) {
+                        Text(variant.displayName)
+                            .font(DesignSystem.Typography.body.weight(.medium))
+                            .foregroundStyle(DesignSystem.Colors.textPrimary)
+                        parakeetVariantStatusBadge(isDownloaded: isDownloaded, size: variant.approximateDownloadSize)
+                    }
+                    Text(variant.coverageSummary)
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 0)
+            }
+            .padding(.vertical, DesignSystem.Spacing.xs)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(viewModel.speechEngineSwitching)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(variant.displayName). \(variant.coverageSummary)")
+        // `.combine` can drop the wrapping Button's role, so assert it explicitly
+        // alongside the selected state for VoiceOver.
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : [.isButton])
+    }
+
+    /// Compact trailing badge: green "Downloaded" when present, amber size hint
+    /// with a download glyph when the build hasn't been fetched yet.
+    @ViewBuilder
+    private func parakeetVariantStatusBadge(isDownloaded: Bool, size: String) -> some View {
+        if isDownloaded {
+            HStack(spacing: 4) {
+                Circle()
+                    .fill(DesignSystem.Colors.successGreen)
+                    .frame(width: 6, height: 6)
+                Text("Downloaded")
+                    .font(DesignSystem.Typography.micro.weight(.medium))
+                    .foregroundStyle(DesignSystem.Colors.successGreen)
+            }
+        } else {
+            HStack(spacing: 4) {
+                Image(systemName: "arrow.down.circle")
+                    .font(.system(size: 10, weight: .semibold))
+                Text("\(size) · downloads on first use")
+                    .font(DesignSystem.Typography.micro.weight(.medium))
+            }
+            .foregroundStyle(DesignSystem.Colors.warningAmber)
+        }
+    }
+
+    /// Mirrors `selectEngine`: pre-checks switch availability so the radio never
+    /// flips then reverts. The VM setter (`applyParakeetModelVariantChange`)
+    /// drives the actual reload + persistence.
+    private func selectParakeetModelVariant(_ variant: ParakeetModelVariant) {
+        guard viewModel.parakeetModelVariant != variant,
+              !viewModel.speechEngineSwitching else { return }
+        Task { @MainActor in
+            let availability = await viewModel.refreshSpeechEngineSwitchAvailabilityNow()
+            guard availability == .available else {
+                viewModel.speechEngineError = SettingsViewModel.speechEngineSwitchUnavailableMessage(for: availability)
+                return
+            }
+            withAnimation(DesignSystem.Animation.contentSwap) {
+                viewModel.parakeetModelVariant = variant
+            }
+        }
+    }
+
     @ViewBuilder
     private var engineLanguageCard: some View {
         if viewModel.speechEnginePreference == .whisper {
@@ -1786,9 +1896,7 @@ struct SettingsView: View {
 
     private var engineSelectorCardStatus: SettingsCardStatus? {
         if viewModel.speechEngineSwitching {
-            let target = currentSpeechEngineSwitchTarget
-            let label = target == .whisper ? "Preparing Whisper" : "Switching to \(target.displayName)"
-            return SettingsCardStatus(.recommended, label: label)
+            return SettingsCardStatus(.recommended, label: speechEngineSwitchTitle)
         }
         if viewModel.speechEngineError != nil {
             return SettingsCardStatus(.required, label: "Action needed")
@@ -1798,13 +1906,22 @@ struct SettingsView: View {
 
     private var speechEngineSwitchBannerState: (title: String, detail: String)? {
         guard viewModel.speechEngineSwitching else { return nil }
-        let target = currentSpeechEngineSwitchTarget
         let phase = viewModel.speechEngineSwitchDetail ?? "Preparing speech engine..."
-        let title = target == .whisper ? "Preparing Whisper" : "Switching to \(target.displayName)"
         return (
-            title,
+            speechEngineSwitchTitle,
             "\(phase) Dictation, file transcription, and meetings pause until this finishes."
         )
+    }
+
+    /// Title for the switch banner / status chip. A Parakeet *build* swap
+    /// (v3 ↔ v2) keeps the engine on Parakeet, so "Switching to Parakeet" would
+    /// be wrong — show "Updating Parakeet model" instead.
+    private var speechEngineSwitchTitle: String {
+        if viewModel.isParakeetVariantSwitch {
+            return "Updating Parakeet model"
+        }
+        let target = currentSpeechEngineSwitchTarget
+        return target == .whisper ? "Preparing Whisper" : "Switching to \(target.displayName)"
     }
 
     private var enginesModelsCardStatus: SettingsCardStatus? {

--- a/Sources/MacParakeetCore/STT/ParakeetModelVariant+ASR.swift
+++ b/Sources/MacParakeetCore/STT/ParakeetModelVariant+ASR.swift
@@ -1,0 +1,24 @@
+import FluidAudio
+
+/// Bridges the Foundation-only ``ParakeetModelVariant`` preference to the
+/// FluidAudio `AsrModelVersion` the runtime actually loads. Kept in the STT
+/// layer so `SpeechEnginePreference.swift` never has to import CoreML/FluidAudio.
+extension ParakeetModelVariant {
+    public var asrModelVersion: AsrModelVersion {
+        switch self {
+        case .v3: .v3
+        case .v2: .v2
+        }
+    }
+
+    /// Maps a loaded FluidAudio version back to the user-facing variant.
+    /// Any non-`v2` version collapses to `.v3` — MacParakeet only exposes the
+    /// v2/v3 pair, so the specialized CJK builds (if ever loaded) read as the
+    /// multilingual default rather than crashing an exhaustive switch.
+    public init(asrModelVersion: AsrModelVersion) {
+        switch asrModelVersion {
+        case .v2: self = .v2
+        default: self = .v3
+        }
+    }
+}

--- a/Sources/MacParakeetCore/STT/STTClient.swift
+++ b/Sources/MacParakeetCore/STT/STTClient.swift
@@ -76,6 +76,13 @@ public actor STTClient: STTManaging, SpeechEngineRoutedTranscribing, SpeechEngin
         try await scheduler.setSpeechEngine(preference, onProgress: onProgress)
     }
 
+    public func setParakeetModelVariant(
+        _ variant: ParakeetModelVariant,
+        onProgress: (@Sendable (String) -> Void)?
+    ) async throws {
+        try await scheduler.setParakeetModelVariant(variant, onProgress: onProgress)
+    }
+
     public func engineSwitchAvailability() async -> SpeechEngineSwitchAvailability {
         await scheduler.engineSwitchAvailability()
     }

--- a/Sources/MacParakeetCore/STT/STTClientProtocol.swift
+++ b/Sources/MacParakeetCore/STT/STTClientProtocol.swift
@@ -50,6 +50,14 @@ public protocol SpeechEngineSwitching: Sendable {
         _ preference: SpeechEnginePreference,
         onProgress: (@Sendable (String) -> Void)?
     ) async throws
+    /// Switches the active Parakeet build (multilingual `v3` ↔ English-only
+    /// `v2`). Like an engine switch, this may download the target and reloads
+    /// the runtime when Parakeet is active; see
+    /// ``STTRuntime/setParakeetModelVariant(_:onProgress:)``.
+    func setParakeetModelVariant(
+        _ variant: ParakeetModelVariant,
+        onProgress: (@Sendable (String) -> Void)?
+    ) async throws
 }
 
 public enum SpeechEngineSwitchAvailability: Sendable, Equatable {

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -26,6 +26,10 @@ protocol STTRuntimeProtocol: Sendable {
         _ preference: SpeechEnginePreference,
         onProgress: (@Sendable (String) -> Void)?
     ) async throws
+    func setParakeetModelVariant(
+        _ variant: ParakeetModelVariant,
+        onProgress: (@Sendable (String) -> Void)?
+    ) async throws
     func currentSpeechEngineSelection() async -> SpeechEngineSelection
 }
 
@@ -54,7 +58,10 @@ public actor STTRuntime: STTRuntimeProtocol {
     private var initializationTask: Task<Void, Error>?
     private var initializationGeneration: UInt64 = 0
     private var warmUpProgressHandler: (@Sendable (String) -> Void)?
-    private let modelVersion: AsrModelVersion
+    /// The active Parakeet build. Mutable because the user can switch between
+    /// the multilingual `v3` and English-only `v2` variants at runtime
+    /// (`setParakeetModelVariant`); `ensureInitialized()` reads it when loading.
+    private var modelVersion: AsrModelVersion
     private var speechEngine: SpeechEnginePreference
     private var whisperEngine: WhisperEngine?
     private let whisperModelVariant: String
@@ -169,15 +176,19 @@ public actor STTRuntime: STTRuntimeProtocol {
             let result = try await manager.transcribe(audioURL, decoderState: &decoderState)
             let words = Self.mergeTokenTimingsIntoWords(result.tokenTimings)
             onProgress?(100, 100)
-            // MacParakeet exposes Parakeet TDT 0.6B-v3 as an English-only engine
-            // — there is no user-facing Parakeet language selector even though
-            // the model itself supports 25 European languages. Attributing
-            // "en" here lets the telemetry `language` field reflect what the
-            // engine actually produced in this app's configuration. If the
-            // app ever exposes Parakeet's multilingual modes, this attribution
-            // needs to consult the user's selection (or per-segment detection)
-            // instead of hard-coding the code.
-            return STTResult(text: result.text, words: words, language: "en", engine: .parakeet, engineVariant: nil)
+            // Telemetry `language` is attributed "en": MacParakeet positions
+            // Parakeet as English-first (v2 is English-only; v3 multilingual is
+            // not surfaced via a Parakeet language picker), so this reflects the
+            // app's configuration rather than per-segment detection. The
+            // `engineVariant` carries the active build (v2/v3) so adoption and
+            // impact can be measured without exposing transcript content.
+            return STTResult(
+                text: result.text,
+                words: words,
+                language: "en",
+                engine: .parakeet,
+                engineVariant: ParakeetModelVariant(asrModelVersion: modelVersion).rawValue
+            )
         } catch {
             throw try Self.mapTranscriptionError(error)
         }
@@ -454,6 +465,96 @@ public actor STTRuntime: STTRuntimeProtocol {
         onProgress?("\(preference.displayName) is ready")
     }
 
+    /// Switches the active Parakeet build between the multilingual `v3` and the
+    /// English-only `v2` variant. Symmetric to ``setSpeechEngine(_:onProgress:)``:
+    /// it downloads the target first (so the current model keeps serving until
+    /// the slow fetch finishes), then swaps the loaded managers in place. When
+    /// the target is already cached the download is a cheap no-op, so flipping
+    /// between two installed variants is near-instant.
+    ///
+    /// If Parakeet isn't the active engine there is nothing loaded to swap, so
+    /// the new version is simply recorded and takes effect the next time
+    /// Parakeet loads.
+    public func setParakeetModelVariant(
+        _ variant: ParakeetModelVariant,
+        onProgress: (@Sendable (String) -> Void)?
+    ) async throws {
+        let targetVersion = variant.asrModelVersion
+        guard targetVersion != modelVersion else { return }
+
+        guard initializationTask == nil, activeTranscriptionCount == 0 else {
+            throw STTError.engineBusy
+        }
+
+        let previousVersion = modelVersion
+        let startedAt = Date()
+        logger.notice("parakeet_variant_switch_start to=\(variant.rawValue, privacy: .public) engine=\(self.speechEngine.rawValue, privacy: .public)")
+        AudioCaptureDiagnostics.append(
+            "parakeet_variant_switch_start to=\(variant.rawValue) engine=\(self.speechEngine.rawValue)"
+        )
+
+        guard speechEngine == .parakeet else {
+            // Inactive engine: record the choice; it loads on the next Parakeet use.
+            modelVersion = targetVersion
+            logger.notice("parakeet_variant_switch_deferred to=\(variant.rawValue, privacy: .public) reason=engine_inactive")
+            AudioCaptureDiagnostics.append("parakeet_variant_switch_deferred to=\(variant.rawValue) reason=engine_inactive")
+            return
+        }
+
+        invalidateBackgroundWarmUp()
+        setBackgroundWarmUpState(.idle)
+
+        do {
+            onProgress?("Preparing \(variant.modelName)...")
+            try await downloadParakeetModels(version: targetVersion, onProgress: onProgress)
+
+            onProgress?("Loading \(variant.modelName) on Neural Engine...")
+            await unloadParakeet()
+            modelVersion = targetVersion
+            try await ensureInitialized()
+
+            onProgress?("\(variant.modelName) is ready")
+            let duration = Observability.durationSeconds(since: startedAt)
+            logger.notice("parakeet_variant_switch_complete to=\(variant.rawValue, privacy: .public) duration_s=\(duration, privacy: .public)")
+            AudioCaptureDiagnostics.append(
+                "parakeet_variant_switch_complete to=\(variant.rawValue) duration_s=\(Self.formatSeconds(duration))"
+            )
+        } catch {
+            // Restore the previous version so the in-memory runtime matches the
+            // persisted preference (the caller only saves on success); the next
+            // transcribe reloads `previousVersion` from cache.
+            modelVersion = previousVersion
+            let duration = Observability.durationSeconds(since: startedAt)
+            logger.error("parakeet_variant_switch_failed to=\(variant.rawValue, privacy: .public) duration_s=\(duration, privacy: .public) error_type=\(AudioCaptureDiagnostics.errorType(error), privacy: .public) error_detail=\(error.localizedDescription, privacy: .private)")
+            AudioCaptureDiagnostics.append(
+                "parakeet_variant_switch_failed to=\(variant.rawValue) duration_s=\(Self.formatSeconds(duration)) \(AudioCaptureDiagnostics.errorFields(error))"
+            )
+            throw error
+        }
+    }
+
+    /// Pre-fetches a Parakeet build to disk without loading it, reusing the
+    /// throttled progress→message bridge. Returns immediately when the model is
+    /// already cached (`AsrModels.download` validates and no-ops).
+    private func downloadParakeetModels(
+        version: AsrModelVersion,
+        onProgress: (@Sendable (String) -> Void)?
+    ) async throws {
+        try await Self.downloadParakeetModel(version: version, onProgress: onProgress)
+    }
+
+    /// Downloads a Parakeet build to its version-specific cache without loading
+    /// it (no runtime spin-up). Cached builds are a cheap validate-and-return.
+    /// Exposed for the CLI's `models download parakeet-v2|v3` path so a build can
+    /// be pre-fetched headlessly without selecting it.
+    public nonisolated static func downloadParakeetModel(
+        version: AsrModelVersion,
+        onProgress: (@Sendable (String) -> Void)? = nil
+    ) async throws {
+        let progressHandler = makeDownloadProgressHandler(onProgress)
+        _ = try await AsrModels.download(version: version, progressHandler: progressHandler)
+    }
+
     public func currentSpeechEngineSelection() async -> SpeechEngineSelection {
         SpeechEngineSelection(
             engine: speechEngine,
@@ -543,38 +644,9 @@ public actor STTRuntime: STTRuntimeProtocol {
         let version = modelVersion
         let warmUpProgressHandler = self.warmUpProgressHandler
         let task = Task {
-            let clock = ContinuousClock()
-            let lastProgressUpdate = OSAllocatedUnfairLock(initialState: clock.now - .seconds(1))
-            let lastProgressMessage = OSAllocatedUnfairLock(initialState: "")
             var interactiveManager: AsrManager?
             var backgroundManager: AsrManager?
-            let progressHandler: DownloadUtils.ProgressHandler?
-            if let warmUpProgressHandler {
-                let progressCallback: @Sendable (String) -> Void = warmUpProgressHandler
-                progressHandler = { progress in
-                    guard let message = Self.warmUpProgressMessage(from: progress) else { return }
-                    let now = clock.now
-                    let shouldEmit = lastProgressUpdate.withLock { lastUpdate in
-                        guard lastUpdate.duration(to: now) >= .milliseconds(250) else {
-                            return false
-                        }
-                        lastUpdate = now
-                        return true
-                    }
-                    guard shouldEmit else { return }
-
-                    let isNewMessage = lastProgressMessage.withLock { lastMessage in
-                        guard lastMessage != message else { return false }
-                        lastMessage = message
-                        return true
-                    }
-                    guard isNewMessage else { return }
-
-                    progressCallback(message)
-                }
-            } else {
-                progressHandler = nil
-            }
+            let progressHandler = Self.makeDownloadProgressHandler(warmUpProgressHandler)
 
             let downloadedModels = try await AsrModels.downloadAndLoad(
                 version: version,
@@ -699,7 +771,9 @@ public actor STTRuntime: STTRuntimeProtocol {
     private func telemetryEngineVariant(for engine: SpeechEnginePreference) -> String? {
         switch engine {
         case .parakeet:
-            nil
+            // Surface the active Parakeet build (v2/v3) so model-load telemetry
+            // can measure variant adoption and impact (issues #311, #398).
+            ParakeetModelVariant(asrModelVersion: modelVersion).rawValue
         case .whisper:
             whisperModelVariant
         }
@@ -766,6 +840,38 @@ public actor STTRuntime: STTRuntimeProtocol {
         }
 
         return nil
+    }
+
+    /// Builds a download progress handler that throttles to ≤1 update / 250 ms
+    /// and suppresses repeated identical messages, translating raw
+    /// `DownloadProgress` into a user-facing string. Shared by initial warm-up
+    /// loading and the Parakeet variant pre-download so both report identically.
+    private nonisolated static func makeDownloadProgressHandler(
+        _ onProgress: (@Sendable (String) -> Void)?
+    ) -> DownloadUtils.ProgressHandler? {
+        guard let onProgress else { return nil }
+        let clock = ContinuousClock()
+        let lastProgressUpdate = OSAllocatedUnfairLock(initialState: clock.now - .seconds(1))
+        let lastProgressMessage = OSAllocatedUnfairLock(initialState: "")
+        return { progress in
+            guard let message = Self.warmUpProgressMessage(from: progress) else { return }
+            let now = clock.now
+            let shouldEmit = lastProgressUpdate.withLock { lastUpdate in
+                guard lastUpdate.duration(to: now) >= .milliseconds(250) else { return false }
+                lastUpdate = now
+                return true
+            }
+            guard shouldEmit else { return }
+
+            let isNewMessage = lastProgressMessage.withLock { lastMessage in
+                guard lastMessage != message else { return false }
+                lastMessage = message
+                return true
+            }
+            guard isNewMessage else { return }
+
+            onProgress(message)
+        }
     }
 
     private nonisolated static func warmUpProgressMessage(from progress: DownloadUtils.DownloadProgress) -> String? {

--- a/Sources/MacParakeetCore/STT/STTScheduler.swift
+++ b/Sources/MacParakeetCore/STT/STTScheduler.swift
@@ -207,6 +207,37 @@ public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEn
         }
     }
 
+    public func setParakeetModelVariant(
+        _ variant: ParakeetModelVariant,
+        onProgress: (@Sendable (String) -> Void)?
+    ) async throws {
+        // Shares the engine-switch guard + task slot: a variant swap reloads the
+        // model and must not race transcription, meetings, or an engine switch.
+        guard acceptsNewJobs,
+              activeSpeechEngineSessionIDs.isEmpty,
+              !hasQueuedOrRunningJobs,
+              speechEngineSwitchTask == nil else {
+            throw STTError.engineBusy
+        }
+
+        acceptsNewJobs = false
+        let switchTask = Task {
+            try await runtime.setParakeetModelVariant(variant, onProgress: onProgress)
+        }
+        speechEngineSwitchTask = switchTask
+        defer {
+            speechEngineSwitchTask = nil
+            acceptsNewJobs = true
+        }
+        try await observingRuntimeTimeoutThrowing(reason: "set_parakeet_model_variant") {
+            try await withTaskCancellationHandler {
+                try await switchTask.value
+            } onCancel: {
+                switchTask.cancel()
+            }
+        }
+    }
+
     public func engineSwitchAvailability() async -> SpeechEngineSwitchAvailability {
         if speechEngineSwitchTask != nil {
             return .switchInProgress

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -398,6 +398,7 @@ public enum TelemetrySettingName: String, Sendable, Equatable {
     case saveTranscriptionAudio = "save_transcription_audio"
     case youtubeAudioQuality = "youtube_audio_quality"
     case speakerDiarization = "speaker_diarization"
+    case parakeetModelVariant = "parakeet_model_variant"
     case whisperDefaultLanguage = "whisper_default_language"
     case autoSave = "auto_save"
     case meetingAutoSave = "meeting_auto_save"

--- a/Sources/MacParakeetCore/SpeechEnginePreference.swift
+++ b/Sources/MacParakeetCore/SpeechEnginePreference.swift
@@ -5,8 +5,13 @@ public enum SpeechEnginePreference: String, CaseIterable, Codable, Sendable {
     case whisper
 
     public static let defaultsKey = "speechRecognitionEngine"
+    public static let parakeetModelVariantKey = "parakeetModelVariant"
     public static let whisperDefaultLanguageKey = "whisperDefaultLanguage"
     public static let whisperModelVariantKey = "whisperModelVariant"
+
+    /// New users stay on the multilingual `v3` build — it "works for everyone".
+    /// `v2` (English-only) is surfaced as a clearly-labeled opt-in.
+    public static let defaultParakeetModelVariant: ParakeetModelVariant = .v3
 
     /// Variants whose one-time CoreML compile/ANE specialization has already
     /// completed on this Mac. The first load of a Whisper variant pays a
@@ -71,6 +76,21 @@ public enum SpeechEnginePreference: String, CaseIterable, Codable, Sendable {
             return
         }
         defaults.set(normalized, forKey: whisperModelVariantKey)
+    }
+
+    /// The persisted Parakeet model variant, defaulting to multilingual `v3`.
+    /// Backed by a validated enum so the stored value can never drift to an
+    /// unsupported model id.
+    public static func parakeetModelVariant(defaults: UserDefaults = .standard) -> ParakeetModelVariant {
+        guard let raw = defaults.string(forKey: parakeetModelVariantKey),
+              let variant = ParakeetModelVariant(rawValue: raw) else {
+            return defaultParakeetModelVariant
+        }
+        return variant
+    }
+
+    public static func saveParakeetModelVariant(_ variant: ParakeetModelVariant, defaults: UserDefaults = .standard) {
+        defaults.set(variant.rawValue, forKey: parakeetModelVariantKey)
     }
 
     /// Whether `variant` has already paid its one-time on-device optimize, so
@@ -177,6 +197,62 @@ public enum SpeechEnginePreference: String, CaseIterable, Codable, Sendable {
         }
 
         return true
+    }
+}
+
+/// Which Parakeet TDT 0.6B build powers on-device transcription.
+///
+/// FluidAudio ships two peer Parakeet TDT 0.6B bundles. `v3` is multilingual
+/// (English + 24 other European languages) and is the default; `v2` is an
+/// English-only build that runs a touch faster on English and — crucially —
+/// cannot mis-detect English speech as another language, which `v3`'s
+/// auto-detection occasionally does (issues #311, #398).
+///
+/// The FluidAudio `AsrModelVersion` bridge lives in the STT layer
+/// (`ParakeetModelVariant+ASR.swift`) so this preference type stays
+/// Foundation-only and decoupled from CoreML.
+public enum ParakeetModelVariant: String, CaseIterable, Codable, Sendable {
+    case v3
+    case v2
+
+    /// Short label for the variant's language posture (Settings tile heading).
+    public var displayName: String {
+        switch self {
+        case .v3: "Multilingual"
+        case .v2: "English only"
+        }
+    }
+
+    /// Marketing-grade model identifier (Local Models row, `models list`).
+    public var modelName: String {
+        switch self {
+        case .v3: "Parakeet TDT 0.6B v3"
+        case .v2: "Parakeet TDT 0.6B v2"
+        }
+    }
+
+    /// One-line description of what the variant is best for.
+    public var coverageSummary: String {
+        switch self {
+        case .v3:
+            "English plus 24 European languages. Best for mixed or non-English speech."
+        case .v2:
+            "English only. A touch faster, and never mis-hears English as another language."
+        }
+    }
+
+    /// Approximate on-disk download footprint. Both builds land near ~465 MB
+    /// (v3 int8 encoder ≈ 461 MB measured; v2 ≈ 465 MB). Kept deliberately
+    /// rounded so the copy doesn't read as falsely precise.
+    public var approximateDownloadSize: String { "~465 MB" }
+
+    public var isEnglishOnly: Bool { self == .v2 }
+
+    public var alternative: ParakeetModelVariant {
+        switch self {
+        case .v3: .v2
+        case .v2: .v3
+        }
     }
 }
 

--- a/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
+++ b/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
@@ -230,6 +230,21 @@ public enum SettingsSearchIndex {
             cardAnchor: "engine.selector"
         ),
         SettingsSearchEntry(
+            id: "engine.parakeetModel",
+            tab: .engine,
+            title: "Parakeet Model",
+            subtitle: "Available when Parakeet is the active engine.",
+            keywords: [
+                "parakeet", "v2", "v3", "english only", "english-only", "multilingual",
+                "faster parakeet", "speed", "low latency", "language", "model", "variant"
+            ],
+            // Anchored to the engine selector for the same reason as the
+            // Whisper Language entry: the Parakeet Model card only renders
+            // when Parakeet is active, so landing on the always-present
+            // selector keeps the search result from jumping to a hidden anchor.
+            cardAnchor: "engine.selector"
+        ),
+        SettingsSearchEntry(
             id: "engine.models",
             tab: .engine,
             title: "Local Models",

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -284,6 +284,15 @@ public final class SettingsViewModel {
             applySpeechEngineChange(speechEnginePreference)
         }
     }
+    /// Which Parakeet build (multilingual `v3` vs English-only `v2`) is active.
+    /// Changing it live-reloads the model when Parakeet is the selected engine
+    /// (downloading the target on first use); see `applyParakeetModelVariantChange`.
+    public var parakeetModelVariant: ParakeetModelVariant {
+        didSet {
+            guard !isApplyingParakeetVariantState else { return }
+            applyParakeetModelVariantChange(parakeetModelVariant)
+        }
+    }
     public var whisperDefaultLanguage: String {
         didSet {
             SpeechEnginePreference.saveWhisperDefaultLanguage(whisperDefaultLanguage, defaults: defaults)
@@ -293,6 +302,11 @@ public final class SettingsViewModel {
     public var speechEngineSwitching = false
     public var speechEngineSwitchTarget: SpeechEnginePreference?
     public var speechEngineSwitchDetail: String?
+    /// True while a Parakeet *build* swap (v3 ↔ v2) is in flight, as opposed to
+    /// an engine switch. Both set `speechEngineSwitchTarget = .parakeet`, so the
+    /// banner needs this to avoid the misleading "Switching to Parakeet" copy
+    /// when the user is already on Parakeet and only changing the build.
+    public var isParakeetVariantSwitch = false
     public var speechEngineSwitchAvailability: SpeechEngineSwitchAvailability = .available
     public var speechEngineError: String?
     public var whisperModelStatus: LocalModelStatus = .unknown
@@ -438,6 +452,10 @@ public final class SettingsViewModel {
     public var parakeetStatus: LocalModelStatus = .unknown
     public var parakeetStatusDetail: String = "Not checked yet."
     public var parakeetRepairing = false
+    /// Which Parakeet builds are present on disk. Drives the per-variant
+    /// download badges in the Parakeet Model card; refreshed in
+    /// `refreshModelStatus()`.
+    public var downloadedParakeetVariants: Set<ParakeetModelVariant> = []
 
     // Licensing / entitlements
     public var entitlementsSummary: String = ""
@@ -463,12 +481,13 @@ public final class SettingsViewModel {
     private var sharedMicStream: SharedMicrophoneStream?
     private let defaults: UserDefaults
     private let youtubeDownloadsDirPath: @Sendable () -> String
-    private let isSpeechModelCached: @Sendable () -> Bool
+    private let parakeetModelVariantCached: @Sendable (ParakeetModelVariant) -> Bool
     private let inputDevicesProvider: @Sendable () -> [AudioDeviceManager.InputDevice]
     private let defaultInputDeviceUIDProvider: @Sendable () -> String?
     private let permissionPollingInterval: Duration
     private var isApplyingLaunchAtLoginState = false
     private var isApplyingSpeechEngineState = false
+    private var isApplyingParakeetVariantState = false
     private var modelStatusRefreshGeneration = 0
     // `deinit` is nonisolated even though this type is `@MainActor`.
     // These handles are only mutated on the main actor during the view
@@ -484,7 +503,9 @@ public final class SettingsViewModel {
     public init(
         defaults: UserDefaults = .standard,
         youtubeDownloadsDirPath: @escaping @Sendable () -> String = { AppPaths.youtubeDownloadsDir },
-        isSpeechModelCached: @escaping @Sendable () -> Bool = { STTRuntime.isModelCached() },
+        parakeetModelVariantCached: @escaping @Sendable (ParakeetModelVariant) -> Bool = {
+            STTRuntime.isModelCached(version: $0.asrModelVersion)
+        },
         inputDevicesProvider: @escaping @Sendable () -> [AudioDeviceManager.InputDevice] = {
             AudioDeviceManager.inputDevices()
         },
@@ -496,7 +517,7 @@ public final class SettingsViewModel {
         AutoSaveService.migrateLegacyMeetingSettingsIfNeeded(defaults: defaults)
         self.defaults = defaults
         self.youtubeDownloadsDirPath = youtubeDownloadsDirPath
-        self.isSpeechModelCached = isSpeechModelCached
+        self.parakeetModelVariantCached = parakeetModelVariantCached
         self.inputDevicesProvider = inputDevicesProvider
         self.defaultInputDeviceUIDProvider = defaultInputDeviceUIDProvider
         self.permissionPollingInterval = permissionPollingInterval
@@ -545,6 +566,7 @@ public final class SettingsViewModel {
         youtubeAudioQuality = YouTubeAudioQuality.current(defaults: defaults)
         speakerDiarization = defaults.object(forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey) as? Bool ?? false
         speechEnginePreference = SpeechEnginePreference.current(defaults: defaults)
+        parakeetModelVariant = SpeechEnginePreference.parakeetModelVariant(defaults: defaults)
         whisperDefaultLanguage = SpeechEnginePreference.whisperDefaultLanguage(defaults: defaults) ?? "auto"
         // Ensure auto-save folders are configured before reading paths.
         // Idempotent: existing user-chosen folders are preserved; only
@@ -1117,19 +1139,25 @@ public final class SettingsViewModel {
         let refreshGeneration = modelStatusRefreshGeneration
         let whisperModelVariant = SpeechEnginePreference.whisperModelVariant(defaults: defaults)
 
+        let parakeetModelVariantCached = self.parakeetModelVariantCached
+
         guard let sttClient else {
             parakeetStatus = .unknown
             parakeetStatusDetail = "Unavailable in this runtime."
             whisperModelStatus = .checking
             whisperModelStatusDetail = "Checking model state..."
             Task { @MainActor [weak self] in
-                let whisperDownloaded = await Task.detached(priority: .userInitiated) {
-                    WhisperEngine.isModelDownloaded(model: whisperModelVariant)
+                let disk = await Task.detached(priority: .userInitiated) {
+                    (
+                        parakeetDownloaded: Set(ParakeetModelVariant.allCases.filter(parakeetModelVariantCached)),
+                        whisperDownloaded: WhisperEngine.isModelDownloaded(model: whisperModelVariant)
+                    )
                 }.value
                 guard let self, self.modelStatusRefreshGeneration == refreshGeneration else {
                     return
                 }
-                self.applyWhisperDownloadedStatus(whisperDownloaded)
+                self.downloadedParakeetVariants = disk.parakeetDownloaded
+                self.applyWhisperDownloadedStatus(disk.whisperDownloaded)
             }
             return
         }
@@ -1150,31 +1178,34 @@ public final class SettingsViewModel {
             // Snapshot the engine before the await so a mid-suspension toggle
             // can't pair the new preference with the old engine's readiness.
             let activeEngine = self.speechEnginePreference
-            let isSpeechModelCached = self.isSpeechModelCached
+            let activeVariant = self.parakeetModelVariant
 
             async let activeEngineLoaded = sttClient.isReady()
             async let diskState = Task.detached(priority: .userInitiated) {
                 (
-                    parakeetCached: isSpeechModelCached(),
+                    parakeetDownloaded: Set(ParakeetModelVariant.allCases.filter(parakeetModelVariantCached)),
                     whisperDownloaded: WhisperEngine.isModelDownloaded(model: whisperModelVariant)
                 )
             }.value
 
             let (activeEngineIsLoaded, modelDiskState) = await (activeEngineLoaded, diskState)
             guard self.modelStatusRefreshGeneration == refreshGeneration,
-                  self.speechEnginePreference == activeEngine else {
+                  self.speechEnginePreference == activeEngine,
+                  self.parakeetModelVariant == activeVariant else {
                 return
             }
 
+            self.downloadedParakeetVariants = modelDiskState.parakeetDownloaded
+            let parakeetName = activeVariant.modelName
             if activeEngine == .parakeet, activeEngineIsLoaded {
                 self.parakeetStatus = .ready
-                self.parakeetStatusDetail = "Parakeet TDT 0.6B v3 · Loaded on Neural Engine."
-            } else if modelDiskState.parakeetCached {
+                self.parakeetStatusDetail = "\(parakeetName) · Loaded on Neural Engine."
+            } else if modelDiskState.parakeetDownloaded.contains(activeVariant) {
                 self.parakeetStatus = .notLoaded
-                self.parakeetStatusDetail = "Parakeet TDT 0.6B v3 · Installed locally, loads when selected."
+                self.parakeetStatusDetail = "\(parakeetName) · Installed locally, loads when selected."
             } else {
                 self.parakeetStatus = .notDownloaded
-                self.parakeetStatusDetail = "Parakeet TDT 0.6B v3 · Needs model setup before use."
+                self.parakeetStatusDetail = "\(parakeetName) · Needs model setup before use."
             }
 
             if activeEngine == .whisper, activeEngineIsLoaded {
@@ -1449,6 +1480,66 @@ public final class SettingsViewModel {
                 self.isApplyingSpeechEngineState = false
             }
         }
+    }
+
+    /// Applies a Parakeet variant toggle (multilingual `v3` ↔ English-only
+    /// `v2`). Mirrors `applySpeechEngineChange`: validates switch availability,
+    /// drives the shared switch banner, persists only after the runtime reload
+    /// succeeds, and reverts the published value on block/cancel/failure.
+    private func applyParakeetModelVariantChange(_ variant: ParakeetModelVariant) {
+        speechEngineError = nil
+        let previousVariant = SpeechEnginePreference.parakeetModelVariant(defaults: defaults)
+        guard variant != previousVariant else { return }
+
+        guard let speechEngineSwitcher else {
+            // No runtime wired (previews/tests): just persist the choice.
+            SpeechEnginePreference.saveParakeetModelVariant(variant, defaults: defaults)
+            Telemetry.send(.settingChanged(setting: .parakeetModelVariant))
+            return
+        }
+
+        speechEngineSwitching = true
+        speechEngineSwitchTarget = .parakeet
+        isParakeetVariantSwitch = true
+        speechEngineSwitchDetail = "Preparing \(variant.modelName)..."
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer {
+                self.speechEngineSwitching = false
+                self.speechEngineSwitchTarget = nil
+                self.isParakeetVariantSwitch = false
+                self.speechEngineSwitchDetail = nil
+                self.refreshModelStatus()
+            }
+            let availability = await self.refreshSpeechEngineSwitchAvailabilityNow()
+            guard availability == .available else {
+                self.speechEngineError = Self.speechEngineSwitchUnavailableMessage(for: availability)
+                self.revertParakeetModelVariant()
+                return
+            }
+            do {
+                try await speechEngineSwitcher.setParakeetModelVariant(variant) { [weak self] message in
+                    Task { @MainActor [weak self] in
+                        self?.speechEngineSwitchDetail = message
+                    }
+                }
+                SpeechEnginePreference.saveParakeetModelVariant(variant, defaults: self.defaults)
+                Telemetry.send(.settingChanged(setting: .parakeetModelVariant))
+            } catch is CancellationError {
+                self.revertParakeetModelVariant()
+            } catch {
+                self.speechEngineError = error.localizedDescription
+                self.revertParakeetModelVariant()
+            }
+        }
+    }
+
+    /// Snaps the published variant back to the persisted value without
+    /// re-triggering a switch (the `isApplyingParakeetVariantState` guard).
+    private func revertParakeetModelVariant() {
+        isApplyingParakeetVariantState = true
+        parakeetModelVariant = SpeechEnginePreference.parakeetModelVariant(defaults: defaults)
+        isApplyingParakeetVariantState = false
     }
 
     public func repairParakeetModel() {

--- a/Tests/CLITests/ConfigCommandTests.swift
+++ b/Tests/CLITests/ConfigCommandTests.swift
@@ -30,6 +30,7 @@ final class ConfigCommandTests: XCTestCase {
             "telemetry",
             "processing-mode",
             "speech-engine",
+            "parakeet-model",
             "whisper-language",
             "speaker-detection",
             "save-transcription-audio",
@@ -56,6 +57,7 @@ final class ConfigCommandTests: XCTestCase {
     func testReadAgentDefaultsReflectGUIFallbacks() throws {
         XCTAssertEqual(try ConfigCommand.read(key: "processing-mode", defaults: defaults), "raw")
         XCTAssertEqual(try ConfigCommand.read(key: "speech-engine", defaults: defaults), "parakeet")
+        XCTAssertEqual(try ConfigCommand.read(key: "parakeet-model", defaults: defaults), "v3")
         XCTAssertEqual(try ConfigCommand.read(key: "whisper-language", defaults: defaults), "auto")
         XCTAssertEqual(try ConfigCommand.read(key: "speaker-detection", defaults: defaults), "off")
         XCTAssertEqual(try ConfigCommand.read(key: "save-transcription-audio", defaults: defaults), "on")
@@ -124,6 +126,26 @@ final class ConfigCommandTests: XCTestCase {
     func testWriteCanonicalizesUnderscoreKeys() throws {
         XCTAssertEqual(try ConfigCommand.write(key: "speaker_detection", value: "on", defaults: defaults), "on")
         XCTAssertEqual(defaults.object(forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey) as? Bool, true)
+    }
+
+    func testWriteParakeetModelPersistsAndCanonicalizesAliases() throws {
+        XCTAssertEqual(try ConfigCommand.write(key: "parakeet-model", value: "v2", defaults: defaults), "v2")
+        XCTAssertEqual(SpeechEnginePreference.parakeetModelVariant(defaults: defaults), .v2)
+
+        // Friendly aliases canonicalize to the v3/v2 ids.
+        XCTAssertEqual(try ConfigCommand.write(key: "parakeet-model", value: "english", defaults: defaults), "v2")
+        XCTAssertEqual(try ConfigCommand.write(key: "parakeet-model", value: "multilingual", defaults: defaults), "v3")
+        XCTAssertEqual(SpeechEnginePreference.parakeetModelVariant(defaults: defaults), .v3)
+
+        // Underscore-aliased key resolves too.
+        XCTAssertEqual(try ConfigCommand.write(key: "parakeet_model", value: "v2", defaults: defaults), "v2")
+        XCTAssertEqual(try ConfigCommand.read(key: "parakeet-model", defaults: defaults), "v2")
+    }
+
+    func testWriteParakeetModelRejectsInvalidValue() {
+        XCTAssertThrowsError(try ConfigCommand.write(key: "parakeet-model", value: "v9", defaults: defaults)) { error in
+            XCTAssertTrue(error is ValidationError)
+        }
     }
 
     func testWriteWhisperLanguageAutoClearsStoredDefault() throws {

--- a/Tests/CLITests/ModelLifecycleCommandTests.swift
+++ b/Tests/CLITests/ModelLifecycleCommandTests.swift
@@ -172,6 +172,9 @@ final class ModelLifecycleCommandTests: XCTestCase {
         XCTAssertEqual(parakeetDownloadVariant(from: "parakeet-v2", defaults: defaults), .v2)
         XCTAssertEqual(parakeetDownloadVariant(from: "parakeet:v3", defaults: defaults), .v3)
         XCTAssertEqual(parakeetDownloadVariant(from: "parakeet-english", defaults: defaults), .v2)
+        // Underscore spellings normalize to hyphens, matching `config set`.
+        XCTAssertEqual(parakeetDownloadVariant(from: "parakeet_v2", defaults: defaults), .v2)
+        XCTAssertEqual(parakeetDownloadVariant(from: "parakeet_english", defaults: defaults), .v2)
         // Bare "parakeet" resolves to the persisted build.
         SpeechEnginePreference.saveParakeetModelVariant(.v2, defaults: defaults)
         XCTAssertEqual(parakeetDownloadVariant(from: "parakeet", defaults: defaults), .v2)

--- a/Tests/CLITests/ModelLifecycleCommandTests.swift
+++ b/Tests/CLITests/ModelLifecycleCommandTests.swift
@@ -49,22 +49,32 @@ final class ModelLifecycleCommandTests: XCTestCase {
 
         let models = loadSelectableSpeechModels(
             defaults: defaults,
-            isParakeetModelCached: { false },
+            isParakeetModelCached: { $0 == .v3 },
             isWhisperModelDownloaded: { $0 == "large-v3-v20240930_turbo_632MB" }
         )
 
-        XCTAssertEqual(models.count, 2)
+        XCTAssertEqual(models.count, 3)
         XCTAssertEqual(models[0], SelectableSpeechModel(
-            id: "parakeet",
-            name: "Parakeet TDT 0.6B v3",
+            id: "parakeet-v3",
+            name: "Parakeet TDT 0.6B v3 (Multilingual)",
             engine: "parakeet",
-            variant: nil,
-            size: "6 GB",
-            installed: false,
+            variant: "v3",
+            size: "~465 MB",
+            installed: true,
             selected: false,
             language: nil
         ))
         XCTAssertEqual(models[1], SelectableSpeechModel(
+            id: "parakeet-v2",
+            name: "Parakeet TDT 0.6B v2 (English only)",
+            engine: "parakeet",
+            variant: "v2",
+            size: "~465 MB",
+            installed: false,
+            selected: false,
+            language: "en"
+        ))
+        XCTAssertEqual(models[2], SelectableSpeechModel(
             id: "whisper-large-v3-v20240930-turbo-632MB",
             name: "Whisper Large v3 Turbo",
             engine: "whisper",
@@ -74,6 +84,27 @@ final class ModelLifecycleCommandTests: XCTestCase {
             selected: true,
             language: "ko"
         ))
+    }
+
+    func testLoadSelectableSpeechModelsMarksSelectedParakeetVariant() throws {
+        let suiteName = "com.macparakeet.tests.cli.model-list-parakeet.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        SpeechEnginePreference.parakeet.save(to: defaults)
+        SpeechEnginePreference.saveParakeetModelVariant(.v2, defaults: defaults)
+
+        let models = loadSelectableSpeechModels(
+            defaults: defaults,
+            isParakeetModelCached: { _ in true },
+            isWhisperModelDownloaded: { _ in false }
+        )
+
+        let v3 = try XCTUnwrap(models.first { $0.id == "parakeet-v3" })
+        let v2 = try XCTUnwrap(models.first { $0.id == "parakeet-v2" })
+        XCTAssertFalse(v3.selected, "Multilingual build should not be marked selected")
+        XCTAssertTrue(v2.selected, "English-only build is the persisted Parakeet variant")
     }
 
     func testResolveSelectableSpeechModelAcceptsEngineAndWhisperIDs() throws {
@@ -88,7 +119,19 @@ final class ModelLifecycleCommandTests: XCTestCase {
 
         XCTAssertEqual(
             try resolveSelectableSpeechModel("parakeet", defaults: defaults),
-            SelectableSpeechModelSelection(engine: .parakeet, whisperVariant: nil)
+            SelectableSpeechModelSelection(engine: .parakeet, whisperVariant: nil, parakeetVariant: .v3)
+        )
+        XCTAssertEqual(
+            try resolveSelectableSpeechModel("parakeet-v2", defaults: defaults),
+            SelectableSpeechModelSelection(engine: .parakeet, whisperVariant: nil, parakeetVariant: .v2)
+        )
+        XCTAssertEqual(
+            try resolveSelectableSpeechModel("parakeet:v3", defaults: defaults),
+            SelectableSpeechModelSelection(engine: .parakeet, whisperVariant: nil, parakeetVariant: .v3)
+        )
+        XCTAssertEqual(
+            try resolveSelectableSpeechModel("parakeet-english", defaults: defaults),
+            SelectableSpeechModelSelection(engine: .parakeet, whisperVariant: nil, parakeetVariant: .v2)
         )
         XCTAssertEqual(
             try resolveSelectableSpeechModel("whisper", defaults: defaults),
@@ -118,6 +161,23 @@ final class ModelLifecycleCommandTests: XCTestCase {
                 whisperVariant: "large-v3-v20240930_turbo_632MB"
             )
         )
+    }
+
+    func testParakeetDownloadVariantRecognizesParakeetIDs() throws {
+        let suiteName = "com.macparakeet.tests.cli.parakeet-download.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        XCTAssertEqual(parakeetDownloadVariant(from: "parakeet-v2", defaults: defaults), .v2)
+        XCTAssertEqual(parakeetDownloadVariant(from: "parakeet:v3", defaults: defaults), .v3)
+        XCTAssertEqual(parakeetDownloadVariant(from: "parakeet-english", defaults: defaults), .v2)
+        // Bare "parakeet" resolves to the persisted build.
+        SpeechEnginePreference.saveParakeetModelVariant(.v2, defaults: defaults)
+        XCTAssertEqual(parakeetDownloadVariant(from: "parakeet", defaults: defaults), .v2)
+        // Non-Parakeet ids fall through (nil) so Whisper parsing runs.
+        XCTAssertNil(parakeetDownloadVariant(from: "whisper-large-v3", defaults: defaults))
+        XCTAssertNil(parakeetDownloadVariant(from: "tiny", defaults: defaults))
     }
 
     func testResolveSelectableSpeechModelRejectsUnknownID() {

--- a/Tests/CLITests/TranscribeCommandTests.swift
+++ b/Tests/CLITests/TranscribeCommandTests.swift
@@ -24,6 +24,28 @@ final class TranscribeCommandTests: XCTestCase {
         XCTAssertEqual(mode, .clean)
     }
 
+    func testResolveParakeetModelVariantFollowsStoredForAppDefault() {
+        XCTAssertEqual(
+            TranscribeCommand.resolveParakeetModelVariant(.appDefault, storedVariant: .v2),
+            .v2
+        )
+        XCTAssertEqual(
+            TranscribeCommand.resolveParakeetModelVariant(.appDefault, storedVariant: .v3),
+            .v3
+        )
+    }
+
+    func testResolveParakeetModelVariantRespectsExplicitOverride() {
+        XCTAssertEqual(
+            TranscribeCommand.resolveParakeetModelVariant(.v2, storedVariant: .v3),
+            .v2
+        )
+        XCTAssertEqual(
+            TranscribeCommand.resolveParakeetModelVariant(.v3, storedVariant: .v2),
+            .v3
+        )
+    }
+
     func testResolveYouTubeAudioQualityUsesM4AForAppDefaultWhenUnset() {
         let quality = TranscribeCommand.resolveYouTubeAudioQuality(.appDefault, storedQuality: nil)
         XCTAssertEqual(quality, .m4a)

--- a/Tests/MacParakeetTests/STT/MockSTTClient.swift
+++ b/Tests/MacParakeetTests/STT/MockSTTClient.swift
@@ -20,6 +20,8 @@ public actor MockSTTClient: STTClientProtocol, SpeechEngineRoutedTranscribing, S
     public var speechEngineSwitches: [SpeechEnginePreference] = []
     public var speechEngineSwitchError: Error?
     public var speechEngineSwitchProgressMessages: [String] = []
+    public var parakeetModelVariantSwitches: [ParakeetModelVariant] = []
+    public var parakeetModelVariantSwitchError: Error?
     private var warmUpState: STTWarmUpState = .idle
     private var warmUpObservers: [UUID: AsyncStream<STTWarmUpState>.Continuation] = [:]
     private var backgroundWarmUpTask: Task<Void, Never>?
@@ -211,6 +213,18 @@ public actor MockSTTClient: STTClientProtocol, SpeechEngineRoutedTranscribing, S
         speechEngineSwitchProgressMessages.append("Preparing \(preference.displayName)...")
         if let speechEngineSwitchError {
             throw speechEngineSwitchError
+        }
+        ready = true
+    }
+
+    public func setParakeetModelVariant(
+        _ variant: ParakeetModelVariant,
+        onProgress: (@Sendable (String) -> Void)?
+    ) async throws {
+        parakeetModelVariantSwitches.append(variant)
+        onProgress?("Preparing \(variant.modelName)...")
+        if let parakeetModelVariantSwitchError {
+            throw parakeetModelVariantSwitchError
         }
         ready = true
     }

--- a/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
+++ b/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
@@ -184,6 +184,59 @@ final class STTSchedulerTests: XCTestCase {
         XCTAssertEqual(count, 1)
     }
 
+    func testSetParakeetModelVariantForwardsWhenIdle() async throws {
+        let runtime = MockSTTRuntime()
+        let scheduler = STTScheduler(runtimeProvider: runtime)
+        let progressMessages = LockedStringRecorder()
+
+        try await scheduler.setParakeetModelVariant(.v2) { message in
+            progressMessages.record(message)
+        }
+
+        let variants = await runtime.parakeetModelVariantSwitches
+        XCTAssertEqual(variants, [.v2])
+        XCTAssertEqual(progressMessages.values, ["Mock loading Parakeet TDT 0.6B v2"])
+    }
+
+    func testSetParakeetModelVariantFailsWhileJobIsRunning() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.block(path: "active")
+        let scheduler = STTScheduler(runtimeProvider: runtime)
+
+        let activeTask = Task {
+            try await scheduler.transcribe(audioPath: "active", job: .fileTranscription)
+        }
+        try await waitForStartedPaths(runtime: runtime, count: 1)
+
+        do {
+            try await scheduler.setParakeetModelVariant(.v2, onProgress: nil)
+            XCTFail("Expected variant switch to fail while STT job is running")
+        } catch let error as STTError {
+            XCTAssertEqual(error.localizedDescription, STTError.engineBusy.localizedDescription)
+        }
+
+        await runtime.release(path: "active")
+        _ = try await activeTask.value
+    }
+
+    func testSetParakeetModelVariantFailsWhileSessionLeaseIsActive() async throws {
+        let runtime = MockSTTRuntime()
+        let scheduler = STTScheduler(runtimeProvider: runtime)
+
+        let lease = await scheduler.beginSpeechEngineSession()
+        do {
+            try await scheduler.setParakeetModelVariant(.v2, onProgress: nil)
+            XCTFail("Expected variant switch to fail while a speech engine session is active")
+        } catch let error as STTError {
+            XCTAssertEqual(error.localizedDescription, STTError.engineBusy.localizedDescription)
+        }
+
+        await scheduler.endSpeechEngineSession(lease)
+        try await scheduler.setParakeetModelVariant(.v2, onProgress: nil)
+        let variants = await runtime.parakeetModelVariantSwitches
+        XCTAssertEqual(variants, [.v2])
+    }
+
     func testEngineSwitchAvailabilityReportsAvailableWhenIdle() async {
         let runtime = MockSTTRuntime()
         let scheduler = STTScheduler(runtimeProvider: runtime)
@@ -730,6 +783,7 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
     private(set) var shutdownCallCount = 0
     private(set) var setSpeechEngineCallCount = 0
     private(set) var usedSpeechEngineProgressOverload = false
+    private(set) var parakeetModelVariantSwitches: [ParakeetModelVariant] = []
     private var selection = SpeechEngineSelection(engine: .parakeet)
     private var ready = false
     private var shouldBlockNextSpeechEngineSwitch = false
@@ -831,6 +885,26 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
         usedSpeechEngineProgressOverload = true
         onProgress?("Mock loading \(preference.displayName)")
         try await setSpeechEngine(preference)
+    }
+
+    func setParakeetModelVariant(
+        _ variant: ParakeetModelVariant,
+        onProgress: (@Sendable (String) -> Void)?
+    ) async throws {
+        parakeetModelVariantSwitches.append(variant)
+        onProgress?("Mock loading \(variant.modelName)")
+        if shouldBlockNextSpeechEngineSwitch {
+            shouldBlockNextSpeechEngineSwitch = false
+            await withTaskCancellationHandler {
+                await withCheckedContinuation { continuation in
+                    speechEngineSwitchContinuation = continuation
+                }
+            } onCancel: {
+                Task { await self.releaseSpeechEngineSwitch() }
+            }
+            try Task.checkCancellation()
+        }
+        selection = SpeechEngineSelection(engine: .parakeet)
     }
 
     func currentSpeechEngineSelection() async -> SpeechEngineSelection {

--- a/Tests/MacParakeetTests/STT/SpeechEnginePreferenceTests.swift
+++ b/Tests/MacParakeetTests/STT/SpeechEnginePreferenceTests.swift
@@ -79,6 +79,51 @@ final class SpeechEnginePreferenceTests: XCTestCase {
         XCTAssertFalse(SpeechEnginePreference.hasOptimizedWhisper(variant: "small", defaults: defaults))
     }
 
+    // MARK: - Parakeet model variant
+
+    func testParakeetModelVariantDefaultsToMultilingualV3() {
+        let (defaults, suite) = makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        XCTAssertEqual(SpeechEnginePreference.parakeetModelVariant(defaults: defaults), .v3)
+    }
+
+    func testParakeetModelVariantRoundTrips() {
+        let (defaults, suite) = makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        SpeechEnginePreference.saveParakeetModelVariant(.v2, defaults: defaults)
+        XCTAssertEqual(SpeechEnginePreference.parakeetModelVariant(defaults: defaults), .v2)
+
+        SpeechEnginePreference.saveParakeetModelVariant(.v3, defaults: defaults)
+        XCTAssertEqual(SpeechEnginePreference.parakeetModelVariant(defaults: defaults), .v3)
+    }
+
+    func testParakeetModelVariantFallsBackOnCorruptValue() {
+        let (defaults, suite) = makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        defaults.set("nonsense", forKey: SpeechEnginePreference.parakeetModelVariantKey)
+        XCTAssertEqual(SpeechEnginePreference.parakeetModelVariant(defaults: defaults), .v3)
+    }
+
+    func testParakeetModelVariantBridgesToAsrModelVersion() {
+        XCTAssertEqual(ParakeetModelVariant.v3.asrModelVersion, .v3)
+        XCTAssertEqual(ParakeetModelVariant.v2.asrModelVersion, .v2)
+        XCTAssertEqual(ParakeetModelVariant(asrModelVersion: .v2), .v2)
+        XCTAssertEqual(ParakeetModelVariant(asrModelVersion: .v3), .v3)
+        // Specialized CJK builds collapse to the multilingual default rather
+        // than crashing an exhaustive switch.
+        XCTAssertEqual(ParakeetModelVariant(asrModelVersion: .tdtJa), .v3)
+    }
+
+    func testParakeetModelVariantEnglishOnlyFlag() {
+        XCTAssertTrue(ParakeetModelVariant.v2.isEnglishOnly)
+        XCTAssertFalse(ParakeetModelVariant.v3.isEnglishOnly)
+        XCTAssertEqual(ParakeetModelVariant.v3.alternative, .v2)
+        XCTAssertEqual(ParakeetModelVariant.v2.alternative, .v3)
+    }
+
     func testColdSwitchOnlyAppliesToUnoptimizedActiveWhisperVariant() {
         let (defaults, suite) = makeIsolatedDefaults()
         defer { defaults.removePersistentDomain(forName: suite) }

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -1006,7 +1006,7 @@ final class SettingsViewModelTests: XCTestCase {
             youtubeDownloadsDirPath: { [youtubeDownloadsTestDir] in
                 youtubeDownloadsTestDir?.path ?? AppPaths.youtubeDownloadsDir
             },
-            isSpeechModelCached: { false }
+            parakeetModelVariantCached: { _ in false }
         )
         let stt = MockSTTClient()
         await stt.setReady(false)
@@ -1030,7 +1030,7 @@ final class SettingsViewModelTests: XCTestCase {
             youtubeDownloadsDirPath: { [youtubeDownloadsTestDir] in
                 youtubeDownloadsTestDir?.path ?? AppPaths.youtubeDownloadsDir
             },
-            isSpeechModelCached: { true }
+            parakeetModelVariantCached: { _ in true }
         )
         let stt = MockSTTClient()
         await stt.setReady(true)
@@ -1055,7 +1055,7 @@ final class SettingsViewModelTests: XCTestCase {
             youtubeDownloadsDirPath: { [youtubeDownloadsTestDir] in
                 youtubeDownloadsTestDir?.path ?? AppPaths.youtubeDownloadsDir
             },
-            isSpeechModelCached: { true }
+            parakeetModelVariantCached: { _ in true }
         )
         let stt = MockSTTClient()
         await stt.setReady(false)
@@ -1115,6 +1115,73 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(SpeechEnginePreference.current(defaults: testDefaults), .whisper)
         XCTAssertFalse(viewModel.speechEngineSwitching)
         XCTAssertNil(viewModel.speechEngineError)
+    }
+
+    func testParakeetModelVariantChangeCallsSwitcherAndPersistsOnSuccess() async throws {
+        let switcher = MockSpeechEngineSwitcher()
+        viewModel.configure(
+            permissionService: mockPermissions,
+            dictationRepo: mockRepo,
+            entitlementsService: entitlements,
+            checkoutURL: nil,
+            speechEngineSwitcher: switcher
+        )
+
+        XCTAssertEqual(viewModel.parakeetModelVariant, .v3)
+        viewModel.parakeetModelVariant = .v2
+        try await waitForSpeechEngineSwitchingToFinish()
+
+        let variants = await switcher.parakeetVariants
+        XCTAssertEqual(variants, [.v2])
+        XCTAssertEqual(SpeechEnginePreference.parakeetModelVariant(defaults: testDefaults), .v2)
+        XCTAssertFalse(viewModel.speechEngineSwitching)
+        XCTAssertNil(viewModel.speechEngineError)
+    }
+
+    func testParakeetModelVariantChangeBlockedByAvailabilityRevertsWithoutPersisting() async throws {
+        let switcher = MockSpeechEngineSwitcher()
+        let provider = MockSpeechEngineSwitchAvailabilityProvider(.meetingActive)
+        viewModel.configure(
+            permissionService: mockPermissions,
+            dictationRepo: mockRepo,
+            entitlementsService: entitlements,
+            checkoutURL: nil,
+            speechEngineSwitcher: switcher,
+            speechEngineSwitchAvailabilityProvider: provider
+        )
+
+        viewModel.parakeetModelVariant = .v2
+        try await waitForSpeechEngineSwitchingToFinish()
+
+        XCTAssertEqual(viewModel.parakeetModelVariant, .v3)
+        XCTAssertEqual(SpeechEnginePreference.parakeetModelVariant(defaults: testDefaults), .v3)
+        XCTAssertEqual(viewModel.speechEngineError, "Stop the meeting recording to switch engines")
+        let variants = await switcher.parakeetVariants
+        XCTAssertTrue(variants.isEmpty)
+    }
+
+    func testParakeetModelVariantChangeRevertsWhenSwitcherFails() async throws {
+        let switcher = MockSpeechEngineSwitcher(error: STTError.engineBusy)
+        viewModel.configure(
+            permissionService: mockPermissions,
+            dictationRepo: mockRepo,
+            entitlementsService: entitlements,
+            checkoutURL: nil,
+            speechEngineSwitcher: switcher
+        )
+
+        viewModel.parakeetModelVariant = .v2
+        try await waitForSpeechEngineSwitchingToFinish()
+
+        // The switch was attempted but failed, so the choice is NOT persisted
+        // and the published value snaps back to the previous build.
+        let variants = await switcher.parakeetVariants
+        XCTAssertEqual(variants, [.v2])
+        XCTAssertEqual(viewModel.parakeetModelVariant, .v3)
+        XCTAssertEqual(SpeechEnginePreference.parakeetModelVariant(defaults: testDefaults), .v3)
+        XCTAssertEqual(viewModel.speechEngineError, STTError.engineBusy.localizedDescription)
+        XCTAssertFalse(viewModel.speechEngineSwitching)
+        XCTAssertFalse(viewModel.isParakeetVariantSwitch)
     }
 
     func testRefreshSpeechEngineSwitchAvailabilityStoresProviderResult() async {
@@ -1658,6 +1725,7 @@ private actor MockSpeechEngineSwitcher: SpeechEngineSwitching {
     private let error: Error?
     private let progressMessages: [String]
     private(set) var preferences: [SpeechEnginePreference] = []
+    private(set) var parakeetVariants: [ParakeetModelVariant] = []
     private var shouldBlockNextSwitch = false
     private var switchContinuation: CheckedContinuation<Void, Never>?
     private var releaseRequested = false
@@ -1676,6 +1744,30 @@ private actor MockSpeechEngineSwitcher: SpeechEngineSwitching {
         onProgress: (@Sendable (String) -> Void)?
     ) async throws {
         preferences.append(preference)
+        for message in progressMessages {
+            onProgress?(message)
+        }
+        if shouldBlockNextSwitch {
+            shouldBlockNextSwitch = false
+            await withCheckedContinuation { continuation in
+                if releaseRequested {
+                    releaseRequested = false
+                    continuation.resume()
+                } else {
+                    switchContinuation = continuation
+                }
+            }
+        }
+        if let error {
+            throw error
+        }
+    }
+
+    func setParakeetModelVariant(
+        _ variant: ParakeetModelVariant,
+        onProgress: (@Sendable (String) -> Void)?
+    ) async throws {
+        parakeetVariants.append(variant)
         for message in progressMessages {
             onProgress?(message)
         }

--- a/spec/06-stt-engine.md
+++ b/spec/06-stt-engine.md
@@ -17,11 +17,25 @@ MacParakeet's default speech engine is Parakeet TDT 0.6B-v3 via FluidAudio CoreM
 | Word Error Rate | ~2.5% (v3 multilingual) / ~2.1% (v2 English-only) |
 | Speed | ~155x realtime on Apple Silicon |
 | Peak working RAM | ~66 MB per active Parakeet inference slot (~130 MB with custom vocabulary boosting) |
-| Model download | ~6 GB CoreML bundle (one-time, during onboarding) |
+| Model download | ~465 MB CoreML bundle per build (one-time; v2 and v3 cache independently) |
 | Output | Word-level timestamps with per-word confidence scores |
 | Input format | 16kHz mono Float32 samples (FluidAudio's AudioConverter handles resampling) |
 | Languages | v3: 25 European languages; v2: English only |
 | Decoding | Optimized CTC/TDT decoding (FluidAudio implementation) |
+
+#### Parakeet model variant (v2 / v3)
+
+FluidAudio ships two peer Parakeet TDT 0.6B builds, both exposed to the user:
+
+| Variant | `ParakeetModelVariant` | Languages | Notes |
+|---------|------------------------|-----------|-------|
+| Multilingual (default) | `.v3` | English + 24 European | "Works for everyone"; the new-user default. |
+| English-only | `.v2` | English only | A touch faster on English; cannot mis-detect English as another language (issues #311, #398). |
+
+- **Preference:** persisted as a validated enum under `SpeechEnginePreference.parakeetModelVariantKey` (default `.v3`). The `ParakeetModelVariant → AsrModelVersion` bridge lives in `STT/ParakeetModelVariant+ASR.swift` so the preference type stays Foundation-only.
+- **Runtime switching:** `STTScheduler.setParakeetModelVariant(_:onProgress:)` reloads the active Parakeet model in place when Parakeet is selected — downloading the target build first so the current model keeps serving until the swap. It shares the engine-switch guard, so it is blocked while transcription, a meeting lease, or an engine switch is in flight. Both builds cache independently (`AsrModels.defaultCacheDirectory(for:)`), so flipping between two installed builds is near-instant.
+- **GUI:** the *Parakeet Model* card under Settings → Engine (shown only when Parakeet is the active engine, symmetric to the Whisper Language card).
+- **CLI:** `config set parakeet-model v3|v2` (aliases `multilingual`/`english`), `transcribe --parakeet-model app-default|v3|v2`, and the `parakeet-v3` / `parakeet-v2` ids in `models list` / `models select`.
 
 ### WhisperKit Optional Engine
 
@@ -237,7 +251,7 @@ The GUI uses the persisted `speechRecognitionEngine` preference; the CLI can ove
 
 - **Lazy init**: The shared runtime owner is not loaded at app launch; loaded on first STT request or warm-up
 - **Keep loaded**: Once initialized, the runtime keeps its currently loaded managers ready for subsequent requests
-- **Warm-up during onboarding**: Prepare Parakeet models (~6 GB) + CoreML compilation (~3.4s first time) on the default path; for Korean, Japanese, Chinese, or Cantonese macOS languages, onboarding prepares Whisper instead and stores the matching Whisper language hint locally
+- **Warm-up during onboarding**: Prepare the default Parakeet build (~465 MB) + CoreML compilation (~3.4s first time) on the default path; for Korean, Japanese, Chinese, or Cantonese macOS languages, onboarding prepares Whisper instead and stores the matching Whisper language hint locally
 - **Graceful shutdown**: The shared runtime is released when the app quits
 - **Single owner**: Warm-up, readiness, shutdown, and cache clear happen once at the runtime layer
 - **Cancellation-safe init**: Shutdown/cache clear cancel in-flight initialization and wait for loaded managers to clean themselves up before returning
@@ -320,17 +334,15 @@ Saved meeting retranscription from the library:
 
 ### Parakeet CoreML Model Bundle
 
-The CoreML model for `parakeet-tdt-0.6b-v3-coreml` is **~6 GB** on HuggingFace. Larger than the MLX weights (~2.5 GB) because CoreML stores pre-compiled, hardware-optimized model graphs for the ANE:
+The `parakeet-tdt-0.6b-*-coreml` HuggingFace repos host several precision/encoder variants, but MacParakeet only fetches the components it loads (the int8 encoder for v3), so the **actual download is ~465 MB per build**. v2 and v3 cache independently, so a user who installs both pays the ~465 MB once each:
 
 | Component | Format |
 |-----------|--------|
-| ParakeetEncoder_15s | `.mlmodelc` |
-| ParakeetDecoder | `.mlmodelc` |
-| RNNTJoint | `.mlmodelc` |
+| ParakeetEncoder (int8 for v3) | `.mlmodelc` |
+| Decoder | `.mlmodelc` |
+| JointDecision (v3: `JointDecisionv3`) | `.mlmodelc` |
 | Preprocessor | `.mlmodelc` |
-| Melspectrogram_15s | `.mlpackage` |
-| MelEncoder | `.mlmodelc` |
-| Vocab files | `.json` |
+| Vocab file (`parakeet_vocab.json`) | `.json` |
 
 ### Parakeet Download Mechanism
 
@@ -354,7 +366,7 @@ The normalized Whisper variant is stored without the leading `whisper-` prefix i
 During onboarding:
 
 1. Use local macOS preferred languages to choose the initial speech setup path.
-2. Default path: download Parakeet CoreML models (~6 GB) with progress indication.
+2. Default path: download the default Parakeet CoreML build (~465 MB) with progress indication.
 3. CJK path: download the default Whisper model (~632 MB), save the canonical Whisper language hint (`ko`, `ja`, `zh`, or `yue`), and switch the app default engine to Whisper through the scheduler.
 4. If speaker detection is enabled, prepare diarization assets (~130 MB) on the separate diarization service path.
 5. Warm the selected runtime path enough to verify the chosen engine works.


### PR DESCRIPTION
Closes #311. Addresses #398.

## What & why

Exposes a user-selectable Parakeet build — **multilingual `v3` (default)** vs **English-only `v2`** — across the STT runtime, Settings, and the CLI.

- **#398**: v3 auto-detects language and sometimes hallucinates clear English speech into another language. v2 is English-only, so it *can't* mis-detect — a strict, reliable lock for English-first users.
- **#311**: closes the asymmetry where Whisper was configurable but Parakeet (the core, fastest engine) was hard-pinned to v3. v2 is also a touch faster on English-only workloads.

Default stays `v3` ("works for everyone"); `v2` is an opt-in, clearly labeled "English only".

## UX

A contextual **Parakeet Model** card under Settings → Engine, shown only when Parakeet is the active engine — symmetric to the existing Whisper Language card. Two radio rows (Multilingual / English only) with per-build download status. Switching reloads the active model live (downloading the target first so the current model keeps serving), reusing the engine-switch banner + busy guards.

```
Settings → Engine
  ┌ Speech Recognition ──────────────┐   (Parakeet ◉ / Whisper ○)
  ┌ Parakeet Model ──────────────────┐   ← new, only when Parakeet active
  │ ◉ Multilingual         Downloaded │
  │   English + 24 European languages │
  │ ○ English only   ~465 MB · 1st use│
  │   Faster, never mis-hears English │
  └───────────────────────────────────┘
```

## CLI (semver 2.4.0 → 2.5.0, additive)

- `config set parakeet-model v3|v2` (aliases `multilingual`/`english`), `config get`, `config list`
- `transcribe --parakeet-model app-default|v3|v2`
- `models list` lists both builds; `models select parakeet-v2`; `models download parakeet-v2|v3`
- All CLI `STTClient()` paths (`transcribe`, `models warm-up/repair/status`, `health`) honor the stored build

See `Sources/CLI/CHANGELOG.md` for the contract callout (`models list` now returns two Parakeet rows; `size` corrected from a stale "6 GB" to the real ~465 MB).

## Architecture

- New Foundation-only `ParakeetModelVariant` enum + persistence on `SpeechEnginePreference`; FluidAudio `AsrModelVersion` bridge isolated in `STT/ParakeetModelVariant+ASR.swift`.
- `STTRuntime.setParakeetModelVariant` reloads in place (download → unload → re-init, restore-on-failure); routed through `STTScheduler` reusing the switch-task guard so a build swap is serialized against dictation/meeting/file work and engine switches (ADR-016 / ADR-021).
- Telemetry: `engineVariant` now carries the active Parakeet build on load/operation/transcription events; `settingChanged(parakeet_model_variant)` on toggle. No telemetry allowlist change required.

## Testing & review

- Full suite green: **3110 tests, 0 failures** (9 skipped). New tests: preference round-trip + AsrModelVersion bridge, scheduler busy-guard + forwarding, VM switch/block/revert, CLI config/models/transcribe parsing.
- FluidAudio v0.14.5 API + official docs verified (v2 = English-only, v3 = multilingual; `AsrModels.download(version:)` pre-fetches and no-ops when cached).
- Reviewed by three independent agents (Codex, Gemini, fresh-eye). No P0/P1 correctness bugs; converging polish items (banner copy during a build swap, CHANGELOG contract callout, `.isButton` a11y trait, `models download parakeet-*`, variant telemetry, error-path test) all addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
