### PR TITLE
Add per-model delete for downloaded speech models

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -88,9 +88,10 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
   (`parakeet-v2` / `parakeet-v3`) or the Whisper variant (`whisper-*`) — freeing
   its disk space while leaving every other model in place. Contrast with
   `models clear`, which still wipes the whole local speech/speaker stack.
-- The model currently in use (the active engine's selected build) is protected:
-  `models delete` refuses it with a validation error (exit `2`) so a delete
-  can't silently force a re-download. Pass `--force` to delete it anyway.
+- The active model is protected, and Parakeet's configured build is protected
+  even while Whisper is active: `models delete` refuses it with a validation
+  error (exit `2`) so a delete can't silently force a re-download. Pass
+  `--force` to delete it anyway.
 - Deleting a model that isn't downloaded is a no-op that prints a short note and
   exits `0`.
 

--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -80,6 +80,20 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ## [Unreleased]
 
+## [2.6.0] -- 2026-05-31
+
+### Added
+
+- `models delete <id>` removes a single downloaded model — one Parakeet build
+  (`parakeet-v2` / `parakeet-v3`) or the Whisper variant (`whisper-*`) — freeing
+  its disk space while leaving every other model in place. Contrast with
+  `models clear`, which still wipes the whole local speech/speaker stack.
+- The model currently in use (the active engine's selected build) is protected:
+  `models delete` refuses it with a validation error (exit `2`) so a delete
+  can't silently force a re-download. Pass `--force` to delete it anyway.
+- Deleting a model that isn't downloaded is a no-op that prints a short note and
+  exits `0`.
+
 ## [2.5.0] -- 2026-05-30
 
 ### Added

--- a/Sources/CLI/Commands/ModelsCommand.swift
+++ b/Sources/CLI/Commands/ModelsCommand.swift
@@ -277,7 +277,7 @@ extension ModelsCommand {
                 }
                 let removed = STTRuntime.deleteParakeetModel(version: variant.asrModelVersion)
                 guard removed else {
-                    throw ValidationError("Could not delete \(variant.modelName). It may be missing or in use by another process.")
+                    throw ModelDeletionError.deleteFailed("Could not delete \(variant.modelName). It may be missing or in use by another process.")
                 }
                 print("Deleted \(target.displayName) · freed \(variant.approximateDownloadSize).")
             case .whisper(let variant):
@@ -287,7 +287,7 @@ extension ModelsCommand {
                 }
                 let removed = STTRuntime.deleteWhisperModel(variant: variant, defaults: defaults)
                 guard removed else {
-                    throw ValidationError("Could not delete Whisper \(SpeechEnginePreference.friendlyVariantName(variant)). It may be missing or in use by another process.")
+                    throw ModelDeletionError.deleteFailed("Could not delete Whisper \(SpeechEnginePreference.friendlyVariantName(variant)). It may be missing or in use by another process.")
                 }
                 let freed = whisperModelSizeLabel(for: variant).map { " · freed \($0)" } ?? ""
                 print("Deleted \(target.displayName)\(freed).")
@@ -556,6 +556,17 @@ struct ModelDeletionTarget: Equatable {
 
     let kind: Kind
     let displayName: String
+}
+
+enum ModelDeletionError: Error, Equatable, LocalizedError {
+    case deleteFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .deleteFailed(let message):
+            return message
+        }
+    }
 }
 
 /// Maps a `models list` id (`parakeet-v2`, `whisper-…`, bare `parakeet` /

--- a/Sources/CLI/Commands/ModelsCommand.swift
+++ b/Sources/CLI/Commands/ModelsCommand.swift
@@ -266,9 +266,7 @@ extension ModelsCommand {
                 }
                 // --force overrides the guard; make the consequence explicit since
                 // there's no interactive confirmation on the CLI.
-                FileHandle.standardError.write(
-                    Data("Warning: deleting \(target.displayName), the model currently in use. It will re-download on next use.\n".utf8)
-                )
+                printErr("Warning: deleting \(target.displayName), the model currently in use. It will re-download on next use.")
             }
 
             switch target.kind {

--- a/Sources/CLI/Commands/ModelsCommand.swift
+++ b/Sources/CLI/Commands/ModelsCommand.swift
@@ -582,9 +582,10 @@ func resolveModelDeletionTarget(
     throw ValidationError("Unknown model ID: '\(id)'. Run `macparakeet-cli models list` for valid IDs.")
 }
 
-/// Whether `target` is the model the active engine would load right now.
-/// Deleting it would force a silent re-download, so `models delete` protects it
-/// unless `--force` is passed.
+/// Whether `target` is protected from deletion without `--force`. The selected
+/// Parakeet build is protected even while Whisper is active because it is the
+/// build Parakeet would load after a switch; Whisper's single surfaced variant
+/// is protected only while Whisper is active.
 func isModelInUse(
     _ target: ModelDeletionTarget,
     defaults: UserDefaults = macParakeetAppDefaults()
@@ -592,8 +593,7 @@ func isModelInUse(
     let currentEngine = SpeechEnginePreference.current(defaults: defaults)
     switch target.kind {
     case .parakeet(let variant):
-        return currentEngine == .parakeet
-            && SpeechEnginePreference.parakeetModelVariant(defaults: defaults) == variant
+        return SpeechEnginePreference.parakeetModelVariant(defaults: defaults) == variant
     case .whisper(let variant):
         return currentEngine == .whisper
             && SpeechEnginePreference.whisperModelVariant(defaults: defaults) == variant

--- a/Sources/CLI/Commands/ModelsCommand.swift
+++ b/Sources/CLI/Commands/ModelsCommand.swift
@@ -14,6 +14,7 @@ struct ModelsCommand: AsyncParsableCommand {
             Download.self,
             WarmUp.self,
             Repair.self,
+            Delete.self,
             Clear.self,
         ]
     )
@@ -228,6 +229,71 @@ extension ModelsCommand {
             )
             await sttClient.shutdown()
             sttClientNeedsShutdown = false
+        }
+    }
+
+    struct Delete: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "delete",
+            abstract: "Delete one downloaded speech model, freeing its disk space.",
+            discussion: """
+                Removes a single model (one Parakeet build or the Whisper variant) \
+                while leaving every other model in place — unlike `models clear`, \
+                which wipes the whole local stack.
+
+                The model currently in use is protected: deleting it would force a \
+                silent re-download on the next transcription. Switch models first, \
+                or pass --force to delete it anyway.
+                """
+        )
+
+        @Argument(help: "Model identifier from `models list`, e.g. parakeet-v2, parakeet-v3, or whisper-large-v3-v20240930-turbo-632MB.")
+        var id: String
+
+        @Flag(name: .long, help: "Delete even the model currently in use (it will re-download on next use).")
+        var force: Bool = false
+
+        func run() async throws {
+            let defaults = macParakeetAppDefaults()
+            let target = try resolveModelDeletionTarget(id, defaults: defaults)
+
+            if isModelInUse(target, defaults: defaults) {
+                guard force else {
+                    throw ValidationError(
+                        "\(target.displayName) is the model currently in use. Switch to another model first, "
+                            + "or pass --force to delete it anyway (it re-downloads on next use)."
+                    )
+                }
+                // --force overrides the guard; make the consequence explicit since
+                // there's no interactive confirmation on the CLI.
+                FileHandle.standardError.write(
+                    Data("Warning: deleting \(target.displayName), the model currently in use. It will re-download on next use.\n".utf8)
+                )
+            }
+
+            switch target.kind {
+            case .parakeet(let variant):
+                guard STTClient.isModelCached(version: variant.asrModelVersion) else {
+                    print("\(variant.modelName) is not downloaded — nothing to delete.")
+                    return
+                }
+                let removed = STTRuntime.deleteParakeetModel(version: variant.asrModelVersion)
+                guard removed else {
+                    throw ValidationError("Could not delete \(variant.modelName). It may be missing or in use by another process.")
+                }
+                print("Deleted \(target.displayName) · freed \(variant.approximateDownloadSize).")
+            case .whisper(let variant):
+                guard WhisperEngine.isModelDownloaded(model: variant) else {
+                    print("Whisper \(SpeechEnginePreference.friendlyVariantName(variant)) is not downloaded — nothing to delete.")
+                    return
+                }
+                let removed = STTRuntime.deleteWhisperModel(variant: variant, defaults: defaults)
+                guard removed else {
+                    throw ValidationError("Could not delete Whisper \(SpeechEnginePreference.friendlyVariantName(variant)). It may be missing or in use by another process.")
+                }
+                let freed = whisperModelSizeLabel(for: variant).map { " · freed \($0)" } ?? ""
+                print("Deleted \(target.displayName)\(freed).")
+            }
         }
     }
 
@@ -479,6 +545,61 @@ func resolveSelectableSpeechModel(
         engine: .whisper,
         whisperVariant: WhisperEngine.normalizeModelVariant(variantInput)
     )
+}
+
+/// One concrete model that `models delete` can target, resolved from a
+/// `models list` id. Carries a user-facing `displayName` for messages.
+struct ModelDeletionTarget: Equatable {
+    enum Kind: Equatable {
+        case parakeet(ParakeetModelVariant)
+        /// Normalized Whisper variant id (matches the stored preference).
+        case whisper(String)
+    }
+
+    let kind: Kind
+    let displayName: String
+}
+
+/// Maps a `models list` id (`parakeet-v2`, `whisper-…`, bare `parakeet` /
+/// `whisper`) to a single deletable model, reusing the selection parser so the
+/// delete and select grammars never drift. Throws `ValidationError` on an
+/// unknown id.
+func resolveModelDeletionTarget(
+    _ id: String,
+    defaults: UserDefaults = macParakeetAppDefaults()
+) throws -> ModelDeletionTarget {
+    let selection = try resolveSelectableSpeechModel(id, defaults: defaults)
+    if let parakeetVariant = selection.parakeetVariant {
+        return ModelDeletionTarget(
+            kind: .parakeet(parakeetVariant),
+            displayName: "\(parakeetVariant.modelName) (\(parakeetVariant.displayName))"
+        )
+    }
+    if let whisperVariant = selection.whisperVariant {
+        return ModelDeletionTarget(
+            kind: .whisper(whisperVariant),
+            displayName: "Whisper \(SpeechEnginePreference.friendlyVariantName(whisperVariant))"
+        )
+    }
+    throw ValidationError("Unknown model ID: '\(id)'. Run `macparakeet-cli models list` for valid IDs.")
+}
+
+/// Whether `target` is the model the active engine would load right now.
+/// Deleting it would force a silent re-download, so `models delete` protects it
+/// unless `--force` is passed.
+func isModelInUse(
+    _ target: ModelDeletionTarget,
+    defaults: UserDefaults = macParakeetAppDefaults()
+) -> Bool {
+    let currentEngine = SpeechEnginePreference.current(defaults: defaults)
+    switch target.kind {
+    case .parakeet(let variant):
+        return currentEngine == .parakeet
+            && SpeechEnginePreference.parakeetModelVariant(defaults: defaults) == variant
+    case .whisper(let variant):
+        return currentEngine == .whisper
+            && SpeechEnginePreference.whisperModelVariant(defaults: defaults) == variant
+    }
 }
 
 /// Recognizes `parakeet-v2`, `parakeet:v3`, `parakeet-english`,

--- a/Sources/CLI/MacParakeetCLI.swift
+++ b/Sources/CLI/MacParakeetCLI.swift
@@ -8,7 +8,7 @@ struct CLI: AsyncParsableCommand {
     /// distinguishable from synthesized Bundle.main values (the bare executable
     /// has no Info.plist and macOS otherwise reports an SDK marker like "16.0").
     /// Bump in lockstep with `Sources/CLI/CHANGELOG.md`.
-    static let cliVersion = "2.5.0"
+    static let cliVersion = "2.6.0"
 
     static let configuration = CommandConfiguration(
         commandName: "macparakeet-cli",

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -2271,7 +2271,7 @@ struct SettingsView: View {
     }
 
     fileprivate struct ModelRowAction: Identifiable {
-        let id = UUID()
+        var id: String { label }
         let label: String
         let isProminent: Bool
         let isDestructive: Bool

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -406,7 +406,9 @@ struct SettingsView: View {
     }
 
     /// A downloaded model awaiting delete confirmation. `parakeet` carries the
-    /// specific build; Whisper has a single variant so it needs no payload.
+    /// specific build; Whisper deletion follows the configured Whisper variant
+    /// from `SettingsViewModel.deleteWhisperModel()`, so the alert copy stays
+    /// variant-agnostic here.
     private enum PendingModelDeletion: Identifiable, Equatable {
         case parakeet(ParakeetModelVariant)
         case whisper
@@ -434,7 +436,7 @@ struct SettingsView: View {
         case .parakeet(let variant):
             return "This frees \(variant.approximateDownloadSize). You can download \(variant.modelName) again at any time."
         case .whisper:
-            return "This frees about 632 MB. You can download the Whisper model again at any time."
+            return "This removes the configured Whisper model download from this Mac. You can download it again at any time."
         }
     }
 
@@ -2248,7 +2250,7 @@ struct SettingsView: View {
                     label: "Delete download…",
                     isProminent: false,
                     isDestructive: true,
-                    help: "Remove the downloaded Whisper model from this Mac to free disk space."
+                    help: "Remove the configured Whisper model download from this Mac."
                 ) {
                     pendingModelDeletion = .whisper
                 })

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -1867,25 +1867,14 @@ struct SettingsView: View {
             .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : [.isButton])
 
             if canDelete {
-                Menu {
-                    Button(role: .destructive) {
-                        pendingModelDeletion = .parakeet(variant)
-                    } label: {
-                        Text("Delete download")
-                    }
-                    .help("Remove this Parakeet build to free \(variant.approximateDownloadSize).")
-                } label: {
-                    Image(systemName: "ellipsis")
-                        .font(.system(size: 13, weight: .semibold))
-                        .frame(width: 22, height: 22)
+                ModelDeleteIconButton(
+                    helpText: "Remove this Parakeet build to free \(variant.approximateDownloadSize).",
+                    accessibilityLabel: "Delete \(variant.modelName) download"
+                ) {
+                    pendingModelDeletion = .parakeet(variant)
                 }
-                .menuStyle(.borderlessButton)
-                .menuIndicator(.hidden)
-                .fixedSize()
                 .padding(.top, 1)
                 .disabled(viewModel.speechEngineSwitching)
-                .help("More actions for \(variant.modelName)")
-                .accessibilityLabel("More actions for \(variant.modelName)")
             }
         }
     }
@@ -2290,6 +2279,32 @@ struct SettingsView: View {
             self.isDestructive = isDestructive
             self.help = help
             self.run = run
+        }
+    }
+
+    private struct ModelDeleteIconButton: View {
+        let helpText: String
+        let accessibilityLabel: String
+        let action: () -> Void
+
+        @State private var isHovered = false
+
+        var body: some View {
+            Button(role: .destructive, action: action) {
+                Image(systemName: "trash")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(isHovered ? DesignSystem.Colors.errorRed : DesignSystem.Colors.textTertiary)
+                    .frame(width: 26, height: 24)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(isHovered ? DesignSystem.Colors.errorRed.opacity(0.10) : .clear)
+                    )
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .onHover { isHovered = $0 }
+            .help(helpText)
+            .accessibilityLabel(accessibilityLabel)
         }
     }
 

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -137,6 +137,9 @@ struct SettingsView: View {
     @State private var automaticallyChecksForUpdates: Bool
     @State private var automaticallyDownloadsUpdates: Bool
     @State private var copiedBuildIdentity = false
+    /// Which downloaded model a destructive confirmation is pending for. Drives
+    /// the shared delete-confirmation alert on the Engine tab.
+    @State private var pendingModelDeletion: PendingModelDeletion?
 
     init(
         viewModel: SettingsViewModel,
@@ -387,6 +390,62 @@ struct SettingsView: View {
             engineLanguageCard.id("engine.language")
             enginesModelsCard.id("engine.models")
         }
+        .alert(
+            modelDeletionAlertTitle,
+            isPresented: Binding(
+                get: { pendingModelDeletion != nil },
+                set: { if !$0 { pendingModelDeletion = nil } }
+            ),
+            presenting: pendingModelDeletion
+        ) { deletion in
+            Button("Cancel", role: .cancel) { pendingModelDeletion = nil }
+            Button("Delete", role: .destructive) { performModelDeletion(deletion) }
+        } message: { deletion in
+            Text(modelDeletionMessage(for: deletion))
+        }
+    }
+
+    /// A downloaded model awaiting delete confirmation. `parakeet` carries the
+    /// specific build; Whisper has a single variant so it needs no payload.
+    private enum PendingModelDeletion: Identifiable, Equatable {
+        case parakeet(ParakeetModelVariant)
+        case whisper
+
+        var id: String {
+            switch self {
+            case .parakeet(let variant): "parakeet-\(variant.rawValue)"
+            case .whisper: "whisper"
+            }
+        }
+    }
+
+    /// Names the model in the alert title; falls back to a generic title once
+    /// the alert is dismissed and `pendingModelDeletion` is nil.
+    private var modelDeletionAlertTitle: String {
+        switch pendingModelDeletion {
+        case .parakeet(let variant): "Delete \(variant.modelName)?"
+        case .whisper: "Delete the Whisper model?"
+        case nil: "Delete this model?"
+        }
+    }
+
+    private func modelDeletionMessage(for deletion: PendingModelDeletion) -> String {
+        switch deletion {
+        case .parakeet(let variant):
+            return "This frees \(variant.approximateDownloadSize). You can download \(variant.modelName) again at any time."
+        case .whisper:
+            return "This frees about 632 MB. You can download the Whisper model again at any time."
+        }
+    }
+
+    private func performModelDeletion(_ deletion: PendingModelDeletion) {
+        switch deletion {
+        case .parakeet(let variant):
+            viewModel.deleteParakeetVariant(variant)
+        case .whisper:
+            viewModel.deleteWhisperModel()
+        }
+        pendingModelDeletion = nil
     }
 
     /// AI tab — optional setup for summaries, chat, prompt actions, and Ask.
@@ -1767,42 +1826,68 @@ struct SettingsView: View {
         let downloadStatusLabel = isDownloaded
             ? "Downloaded."
             : "\(variant.approximateDownloadSize), downloads on first use."
+        // The selected build is the one Parakeet loads, so it's protected; only
+        // the other, already-downloaded build can be removed from here.
+        let canDelete = isDownloaded && !isSelected
 
-        return Button {
-            selectParakeetModelVariant(variant)
-        } label: {
-            HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
-                Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
-                    .font(.system(size: 16, weight: .regular))
-                    .foregroundStyle(isSelected ? DesignSystem.Colors.accent : DesignSystem.Colors.textSecondary)
-                    .accessibilityHidden(true)
-                    .padding(.top, 1)
+        return HStack(alignment: .top, spacing: DesignSystem.Spacing.sm) {
+            Button {
+                selectParakeetModelVariant(variant)
+            } label: {
+                HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+                    Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
+                        .font(.system(size: 16, weight: .regular))
+                        .foregroundStyle(isSelected ? DesignSystem.Colors.accent : DesignSystem.Colors.textSecondary)
+                        .accessibilityHidden(true)
+                        .padding(.top, 1)
 
-                VStack(alignment: .leading, spacing: 3) {
-                    HStack(spacing: DesignSystem.Spacing.sm) {
-                        Text(variant.modelName)
-                            .font(DesignSystem.Typography.body.weight(.medium))
-                            .foregroundStyle(DesignSystem.Colors.textPrimary)
-                        parakeetVariantStatusBadge(isDownloaded: isDownloaded, size: variant.approximateDownloadSize)
+                    VStack(alignment: .leading, spacing: 3) {
+                        HStack(spacing: DesignSystem.Spacing.sm) {
+                            Text(variant.modelName)
+                                .font(DesignSystem.Typography.body.weight(.medium))
+                                .foregroundStyle(DesignSystem.Colors.textPrimary)
+                            parakeetVariantStatusBadge(isDownloaded: isDownloaded, size: variant.approximateDownloadSize)
+                        }
+                        Text(variant.coverageSummary)
+                            .font(DesignSystem.Typography.caption)
+                            .foregroundStyle(DesignSystem.Colors.textSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
-                    Text(variant.coverageSummary)
-                        .font(DesignSystem.Typography.caption)
-                        .foregroundStyle(DesignSystem.Colors.textSecondary)
-                        .fixedSize(horizontal: false, vertical: true)
                 }
-
-                Spacer(minLength: 0)
+                .padding(.vertical, DesignSystem.Spacing.xs)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
             }
-            .padding(.vertical, DesignSystem.Spacing.xs)
-            .contentShape(Rectangle())
+            .buttonStyle(.plain)
+            .disabled(viewModel.speechEngineSwitching)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("\(variant.modelName). \(variant.displayName). \(variant.coverageSummary) \(downloadStatusLabel)")
+            // `.combine` can drop the wrapping Button's role, so assert it explicitly
+            // alongside the selected state for VoiceOver.
+            .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : [.isButton])
+
+            if canDelete {
+                Menu {
+                    Button(role: .destructive) {
+                        pendingModelDeletion = .parakeet(variant)
+                    } label: {
+                        Text("Delete download")
+                    }
+                    .help("Remove this Parakeet build to free \(variant.approximateDownloadSize).")
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .font(.system(size: 13, weight: .semibold))
+                        .frame(width: 22, height: 22)
+                }
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .fixedSize()
+                .padding(.top, 1)
+                .disabled(viewModel.speechEngineSwitching)
+                .help("More actions for \(variant.modelName)")
+                .accessibilityLabel("More actions for \(variant.modelName)")
+            }
         }
-        .buttonStyle(.plain)
-        .disabled(viewModel.speechEngineSwitching)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(variant.modelName). \(variant.displayName). \(variant.coverageSummary) \(downloadStatusLabel)")
-        // `.combine` can drop the wrapping Button's role, so assert it explicitly
-        // alongside the selected state for VoiceOver.
-        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : [.isButton])
     }
 
     /// Compact trailing badge: green "Downloaded" when present, amber size hint
@@ -1888,7 +1973,7 @@ struct SettingsView: View {
                     isWorking: viewModel.parakeetRepairing,
                     actionsDisabled: viewModel.speechEngineSwitching,
                     primaryAction: displayedParakeetModelStatus == .preparing ? nil : parakeetPrimaryAction,
-                    overflowAction: displayedParakeetModelStatus == .preparing ? nil : parakeetOverflowAction
+                    overflowActions: displayedParakeetModelStatus == .preparing ? [] : parakeetOverflowActions
                 )
 
                 Divider()
@@ -1900,7 +1985,7 @@ struct SettingsView: View {
                     isWorking: viewModel.whisperDownloading,
                     actionsDisabled: viewModel.speechEngineSwitching,
                     primaryAction: displayedWhisperModelStatus == .preparing ? nil : whisperPrimaryAction,
-                    overflowAction: displayedWhisperModelStatus == .preparing ? nil : whisperOverflowAction
+                    overflowActions: displayedWhisperModelStatus == .preparing ? [] : whisperOverflowActions
                 )
             }
         }
@@ -2110,18 +2195,22 @@ struct SettingsView: View {
         }
     }
 
-    private var parakeetOverflowAction: ModelRowAction? {
+    /// Parakeet's Local Models overflow keeps just "Repair…". Per-build delete
+    /// lives in the Parakeet Model card, where each build is listed with its own
+    /// download badge — that's the unambiguous place to remove the build you're
+    /// not using (this row represents whichever build is active).
+    private var parakeetOverflowActions: [ModelRowAction] {
         switch viewModel.parakeetStatus {
         case .ready, .notLoaded:
-            return ModelRowAction(
+            return [ModelRowAction(
                 label: "Repair…",
                 isProminent: false,
                 help: "Re-validate the Parakeet files and load the model again."
             ) {
                 viewModel.repairParakeetModel()
-            }
+            }]
         default:
-            return nil
+            return []
         }
     }
 
@@ -2148,7 +2237,7 @@ struct SettingsView: View {
         }
     }
 
-    private var whisperOverflowAction: ModelRowAction? {
+    private var whisperOverflowActions: [ModelRowAction] {
         switch viewModel.whisperModelStatus {
         case .ready, .notLoaded:
             // Symmetric with Parakeet's "Repair…" — both engines surface the
@@ -2156,27 +2245,49 @@ struct SettingsView: View {
             // (which downloads if files are missing); Whisper re-runs the
             // download (no-op via HuggingFace cache when files are intact).
             // The user shouldn't have to reason about that asymmetry.
-            return ModelRowAction(
+            var actions = [ModelRowAction(
                 label: "Repair…",
                 isProminent: false,
                 help: "Re-check the Whisper files and re-download any missing model assets."
             ) {
                 viewModel.downloadWhisperModel()
+            }]
+            // Offer delete only when Whisper isn't the active engine — deleting
+            // the in-use model would force a silent re-download next time.
+            if viewModel.speechEnginePreference != .whisper {
+                actions.append(ModelRowAction(
+                    label: "Delete download…",
+                    isProminent: false,
+                    isDestructive: true,
+                    help: "Remove the downloaded Whisper model from this Mac to free disk space."
+                ) {
+                    pendingModelDeletion = .whisper
+                })
             }
+            return actions
         default:
-            return nil
+            return []
         }
     }
 
-    fileprivate struct ModelRowAction {
+    fileprivate struct ModelRowAction: Identifiable {
+        let id = UUID()
         let label: String
         let isProminent: Bool
+        let isDestructive: Bool
         let help: String?
         let run: () -> Void
 
-        init(label: String, isProminent: Bool, help: String? = nil, run: @escaping () -> Void) {
+        init(
+            label: String,
+            isProminent: Bool,
+            isDestructive: Bool = false,
+            help: String? = nil,
+            run: @escaping () -> Void
+        ) {
             self.label = label
             self.isProminent = isProminent
+            self.isDestructive = isDestructive
             self.help = help
             self.run = run
         }
@@ -2463,7 +2574,7 @@ struct SettingsView: View {
         isWorking: Bool,
         actionsDisabled: Bool = false,
         primaryAction: ModelRowAction?,
-        overflowAction: ModelRowAction?
+        overflowActions: [ModelRowAction]
     ) -> some View {
         HStack(alignment: .center, spacing: DesignSystem.Spacing.md) {
             VStack(alignment: .leading, spacing: 2) {
@@ -2487,15 +2598,19 @@ struct SettingsView: View {
                             isWorking: isWorking,
                             actionsDisabled: actionsDisabled
                         )
-                    } else if let overflow = overflowAction,
+                    } else if !overflowActions.isEmpty,
                               !actionsDisabled,
                               !isWorking,
                               status != .checking,
                               status != .repairing,
                               status != .preparing {
                         Menu {
-                            Button(overflow.label, action: overflow.run)
-                                .help(overflow.help ?? overflow.label)
+                            ForEach(overflowActions) { action in
+                                Button(role: action.isDestructive ? .destructive : nil, action: action.run) {
+                                    Text(action.label)
+                                }
+                                .help(action.help ?? action.label)
+                            }
                         } label: {
                             Image(systemName: "ellipsis")
                                 .font(.system(size: 13, weight: .semibold))
@@ -2504,7 +2619,7 @@ struct SettingsView: View {
                         .menuStyle(.borderlessButton)
                         .menuIndicator(.hidden)
                         .fixedSize()
-                        .help(overflow.help ?? "More actions")
+                        .help(overflowActions.count == 1 ? (overflowActions[0].help ?? "More actions") : "More actions")
                         .accessibilityLabel("More actions")
                     } else if isWorking || status == .checking || status == .repairing || status == .preparing {
                         ProgressView()

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -576,6 +576,78 @@ public actor STTRuntime: STTRuntimeProtocol {
         return AsrModels.modelsExist(at: cacheDir, version: version)
     }
 
+    /// Deletes a single Parakeet build's files from disk, leaving the sibling
+    /// build (and every other model) untouched. Each FluidAudio version caches
+    /// into its own leaf directory under `…/FluidAudio/Models`, so removing one
+    /// can't strand the other. Returns `true` when files were present and are
+    /// now gone; a no-op `false` when the build wasn't cached.
+    ///
+    /// Pure file work — callers must not delete the build currently loaded by
+    /// the active engine (the app and CLI guard this). Mirrors
+    /// ``downloadParakeetModel(version:onProgress:)`` so a build can be removed
+    /// headlessly without touching the runtime.
+    @discardableResult
+    public nonisolated static func deleteParakeetModel(version: AsrModelVersion) -> Bool {
+        let operationContext = Observability.childOperationContext()
+        let removed = removeParakeetModelFiles(at: AsrModels.defaultCacheDirectory(for: version))
+        Telemetry.send(.modelOperation(
+            operationID: operationContext.operationID,
+            operationContext: operationContext,
+            action: .deleteModel,
+            outcome: removed ? .success : .failure,
+            stage: .delete,
+            modelKind: .parakeetSTT,
+            speechEngine: .parakeet,
+            engineVariant: ParakeetModelVariant(asrModelVersion: version).rawValue,
+            durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
+            errorType: nil
+        ))
+        return removed
+    }
+
+    /// File-removal core of ``deleteParakeetModel(version:)``, split out so the
+    /// directory resolution can be exercised against a temp dir in tests without
+    /// emitting telemetry. Returns `true` only when the directory existed and is
+    /// gone afterward.
+    @discardableResult
+    nonisolated static func removeParakeetModelFiles(at directory: URL) -> Bool {
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: directory.path) else { return false }
+        do {
+            try fileManager.removeItem(at: directory)
+        } catch {
+            return false
+        }
+        return !fileManager.fileExists(atPath: directory.path)
+    }
+
+    /// Deletes a downloaded Whisper variant from disk, leaving Parakeet and the
+    /// speaker models untouched. Thin telemetry-emitting wrapper over
+    /// ``WhisperEngine/deleteModel(model:downloadBase:defaults:)`` so model
+    /// deletions report through the same `model_operation` channel as Parakeet.
+    /// Pure-file deletion (and its unit tests) lives on `WhisperEngine`.
+    @discardableResult
+    public nonisolated static func deleteWhisperModel(
+        variant: String = SpeechEnginePreference.defaultWhisperModelVariant,
+        defaults: UserDefaults = .standard
+    ) -> Bool {
+        let operationContext = Observability.childOperationContext()
+        let removed = WhisperEngine.deleteModel(model: variant, defaults: defaults)
+        Telemetry.send(.modelOperation(
+            operationID: operationContext.operationID,
+            operationContext: operationContext,
+            action: .deleteModel,
+            outcome: removed ? .success : .failure,
+            stage: .delete,
+            modelKind: .whisperSTT,
+            speechEngine: .whisper,
+            engineVariant: SpeechEnginePreference.normalizeModelVariant(variant) ?? variant,
+            durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
+            errorType: nil
+        ))
+        return removed
+    }
+
     private func unloadParakeet() async {
         let inFlightInitialization = cancelInitialization()
         inFlightInitialization?.cancel()

--- a/Sources/MacParakeetCore/STT/WhisperEngine.swift
+++ b/Sources/MacParakeetCore/STT/WhisperEngine.swift
@@ -213,8 +213,11 @@ public actor WhisperEngine: STTTranscribing {
         } catch {
             return false
         }
-        SpeechEnginePreference.clearWhisperOptimized(variant: model, defaults: defaults)
-        return localModelFolder(model: model, downloadBase: downloadBase) == nil
+        let removed = localModelFolder(model: model, downloadBase: downloadBase) == nil
+        if removed {
+            SpeechEnginePreference.clearWhisperOptimized(variant: model, defaults: defaults)
+        }
+        return removed
     }
 
     public func transcribe(

--- a/Sources/MacParakeetCore/STT/WhisperEngine.swift
+++ b/Sources/MacParakeetCore/STT/WhisperEngine.swift
@@ -195,6 +195,28 @@ public actor WhisperEngine: STTTranscribing {
         }
     }
 
+    /// Removes a downloaded Whisper variant from disk and forgets its optimized
+    /// flag so a later re-download honestly reports the cold-start cost. A
+    /// no-op (returns `false`) when the variant isn't present. Pure file work —
+    /// callers are responsible for not deleting the engine currently in use.
+    @discardableResult
+    public static func deleteModel(
+        model: String = WhisperEngine.defaultModelVariant,
+        downloadBase: URL = WhisperEngine.defaultDownloadBase,
+        defaults: UserDefaults = .standard
+    ) -> Bool {
+        guard let folder = localModelFolder(model: model, downloadBase: downloadBase) else {
+            return false
+        }
+        do {
+            try FileManager.default.removeItem(at: folder)
+        } catch {
+            return false
+        }
+        SpeechEnginePreference.clearWhisperOptimized(variant: model, defaults: defaults)
+        return localModelFolder(model: model, downloadBase: downloadBase) == nil
+    }
+
     public func transcribe(
         audioPath: String,
         job: STTJobKind,

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -177,6 +177,9 @@ public enum TelemetryModelOperationAction: String, Sendable, Equatable {
     case warmUp = "warm_up"
     case repair
     case clearCache = "clear_cache"
+    /// Removing a single model from disk (one Parakeet build or the Whisper
+    /// variant), as opposed to `clearCache` which wipes the whole local stack.
+    case deleteModel = "delete_model"
 }
 
 public enum TelemetryModelOperationStage: String, Sendable, Equatable {
@@ -185,6 +188,7 @@ public enum TelemetryModelOperationStage: String, Sendable, Equatable {
     case load
     case warmUp = "warm_up"
     case clearCache = "clear_cache"
+    case delete
 }
 
 public enum TelemetrySpeechEngineSwitchBlockedReason: String, Sendable, Equatable {

--- a/Sources/MacParakeetCore/SpeechEnginePreference.swift
+++ b/Sources/MacParakeetCore/SpeechEnginePreference.swift
@@ -116,6 +116,21 @@ public enum SpeechEnginePreference: String, CaseIterable, Codable, Sendable {
         defaults.set(optimized, forKey: whisperOptimizedVariantsKey)
     }
 
+    /// Forgets that `variant` was optimized. Call after deleting the model from
+    /// disk so a later re-download honestly reports the cold "first switch takes
+    /// a few minutes" state instead of promising an instant load. Idempotent.
+    public static func clearWhisperOptimized(variant: String, defaults: UserDefaults = .standard) {
+        guard let normalized = normalizeModelVariant(variant) else { return }
+        let optimized = defaults.stringArray(forKey: whisperOptimizedVariantsKey) ?? []
+        guard optimized.contains(normalized) else { return }
+        let remaining = optimized.filter { $0 != normalized }
+        if remaining.isEmpty {
+            defaults.removeObject(forKey: whisperOptimizedVariantsKey)
+        } else {
+            defaults.set(remaining, forKey: whisperOptimizedVariantsKey)
+        }
+    }
+
     public static func normalizeLanguage(_ language: String?) -> String? {
         WhisperLanguageCatalog.canonicalCode(for: language)
     }

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -1648,20 +1648,16 @@ public final class SettingsViewModel {
         }
     }
 
-    /// Removes a downloaded Parakeet build, freeing ~465 MB. The build the
-    /// active engine would load is protected — the UI only offers delete for
-    /// the other, downloaded build, and the guards here enforce that even if a
-    /// stale tap slips through. The "Downloaded" badge drops immediately; a
-    /// disk refresh then confirms.
+    /// Removes a downloaded Parakeet build, freeing ~465 MB. The selected
+    /// Parakeet build is protected — the UI only offers delete for the other,
+    /// downloaded build, and the guards here enforce that even if a stale tap
+    /// slips through. The "Downloaded" badge drops immediately; a disk refresh
+    /// then confirms.
     public func deleteParakeetVariant(_ variant: ParakeetModelVariant) {
         guard !speechEngineSwitching else { return }
-        // Never delete the build the active engine would load — it would force
-        // a silent re-download on the next dictation. Meeting-active state needs
-        // no separate guard: a meeting pins the variant chosen at its start, and
-        // variant switches are blocked while a meeting runs, so the active build
-        // can't change mid-meeting. Only the dormant, non-selected build is ever
-        // deletable here, and removing files for a build that isn't loaded is safe.
-        guard !(speechEnginePreference == .parakeet && parakeetModelVariant == variant) else { return }
+        // Never delete the selected Parakeet build. Even while Whisper is the
+        // active engine, this is the build Parakeet would load after a switch.
+        guard parakeetModelVariant != variant else { return }
         guard downloadedParakeetVariants.contains(variant) else { return }
 
         // Invalidate any in-flight status refresh so it can't re-add the badge

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -493,6 +493,8 @@ public final class SettingsViewModel {
     private let defaults: UserDefaults
     private let youtubeDownloadsDirPath: @Sendable () -> String
     private let parakeetModelVariantCached: @Sendable (ParakeetModelVariant) -> Bool
+    private let deleteParakeetModelOnDisk: @Sendable (ParakeetModelVariant) -> Bool
+    private let deleteWhisperModelOnDisk: @Sendable (String) -> Bool
     private let inputDevicesProvider: @Sendable () -> [AudioDeviceManager.InputDevice]
     private let defaultInputDeviceUIDProvider: @Sendable () -> String?
     private let permissionPollingInterval: Duration
@@ -517,6 +519,12 @@ public final class SettingsViewModel {
         parakeetModelVariantCached: @escaping @Sendable (ParakeetModelVariant) -> Bool = {
             STTRuntime.isModelCached(version: $0.asrModelVersion)
         },
+        deleteParakeetModelOnDisk: @escaping @Sendable (ParakeetModelVariant) -> Bool = {
+            STTRuntime.deleteParakeetModel(version: $0.asrModelVersion)
+        },
+        deleteWhisperModelOnDisk: @escaping @Sendable (String) -> Bool = {
+            STTRuntime.deleteWhisperModel(variant: $0)
+        },
         inputDevicesProvider: @escaping @Sendable () -> [AudioDeviceManager.InputDevice] = {
             AudioDeviceManager.inputDevices()
         },
@@ -529,6 +537,8 @@ public final class SettingsViewModel {
         self.defaults = defaults
         self.youtubeDownloadsDirPath = youtubeDownloadsDirPath
         self.parakeetModelVariantCached = parakeetModelVariantCached
+        self.deleteParakeetModelOnDisk = deleteParakeetModelOnDisk
+        self.deleteWhisperModelOnDisk = deleteWhisperModelOnDisk
         self.inputDevicesProvider = inputDevicesProvider
         self.defaultInputDeviceUIDProvider = defaultInputDeviceUIDProvider
         self.permissionPollingInterval = permissionPollingInterval
@@ -1635,6 +1645,68 @@ public final class SettingsViewModel {
                     self.parakeetStatusDetail = error.localizedDescription
                 }
             }
+        }
+    }
+
+    /// Removes a downloaded Parakeet build, freeing ~465 MB. The build the
+    /// active engine would load is protected — the UI only offers delete for
+    /// the other, downloaded build, and the guards here enforce that even if a
+    /// stale tap slips through. The "Downloaded" badge drops immediately; a
+    /// disk refresh then confirms.
+    public func deleteParakeetVariant(_ variant: ParakeetModelVariant) {
+        guard !speechEngineSwitching else { return }
+        // Never delete the build the active engine would load — it would force
+        // a silent re-download on the next dictation. Meeting-active state needs
+        // no separate guard: a meeting pins the variant chosen at its start, and
+        // variant switches are blocked while a meeting runs, so the active build
+        // can't change mid-meeting. Only the dormant, non-selected build is ever
+        // deletable here, and removing files for a build that isn't loaded is safe.
+        guard !(speechEnginePreference == .parakeet && parakeetModelVariant == variant) else { return }
+        guard downloadedParakeetVariants.contains(variant) else { return }
+
+        // Invalidate any in-flight status refresh so it can't re-add the badge
+        // we're about to drop (the files linger on disk until the detached
+        // delete runs).
+        modelStatusRefreshGeneration += 1
+        // Optimistic: drop the badge now so the row can't be tapped twice; the
+        // refresh below reconciles against disk.
+        downloadedParakeetVariants.remove(variant)
+
+        let deleter = deleteParakeetModelOnDisk
+        Task { @MainActor [weak self] in
+            await Task.detached(priority: .userInitiated) {
+                _ = deleter(variant)
+            }.value
+            guard let self else { return }
+            self.refreshModelStatus()
+        }
+    }
+
+    /// Removes the downloaded Whisper variant, freeing ~632 MB. Only callable
+    /// while Parakeet is the active engine — deleting the model behind the
+    /// active engine would force a silent re-download. State flips to
+    /// "Not Downloaded" immediately; a disk refresh then confirms.
+    public func deleteWhisperModel() {
+        guard !speechEngineSwitching, !whisperDownloading else { return }
+        // Protect the in-use engine's model.
+        guard speechEnginePreference != .whisper else { return }
+        guard isWhisperModelDownloaded else { return }
+
+        let variant = SpeechEnginePreference.whisperModelVariant(defaults: defaults)
+        let deleter = deleteWhisperModelOnDisk
+        // Invalidate any in-flight status refresh so it can't flip the badge
+        // back to "Installed" (the file lingers until the detached delete runs)
+        // and re-expose the delete action for a ghost second tap.
+        modelStatusRefreshGeneration += 1
+        // Optimistic: render the not-downloaded state now so the delete action
+        // disappears before the async file work finishes.
+        applyWhisperDownloadedStatus(false)
+        Task { @MainActor [weak self] in
+            await Task.detached(priority: .userInitiated) {
+                _ = deleter(variant)
+            }.value
+            guard let self else { return }
+            self.refreshModelStatus()
         }
     }
 

--- a/Tests/CLITests/ModelLifecycleCommandTests.swift
+++ b/Tests/CLITests/ModelLifecycleCommandTests.swift
@@ -276,6 +276,11 @@ final class ModelLifecycleCommandTests: XCTestCase {
         XCTAssertTrue(forced.force)
     }
 
+    func testDeleteFailureIsRuntimeFailure() {
+        let error = ModelDeletionError.deleteFailed("Could not delete Parakeet v2.")
+        XCTAssertEqual(CLI.normalizedExitCode(for: error), .failure)
+    }
+
     func testWarmUpRetriesConfiguredAttempts() async {
         let stt = StubSTTClient()
         let diarization = StubDiarizationService()

--- a/Tests/CLITests/ModelLifecycleCommandTests.swift
+++ b/Tests/CLITests/ModelLifecycleCommandTests.swift
@@ -234,7 +234,7 @@ final class ModelLifecycleCommandTests: XCTestCase {
         }
     }
 
-    func testIsModelInUseProtectsActiveParakeetBuildOnly() throws {
+    func testIsModelInUseProtectsConfiguredParakeetBuild() throws {
         let (defaults, suite) = try makeDeleteDefaults()
         defer { defaults.removePersistentDomain(forName: suite) }
 
@@ -252,16 +252,19 @@ final class ModelLifecycleCommandTests: XCTestCase {
         )
     }
 
-    func testIsModelInUseProtectsWhisperWhenActive() throws {
+    func testIsModelInUseProtectsWhisperAndConfiguredParakeetWhenWhisperActive() throws {
         let (defaults, suite) = try makeDeleteDefaults()
         defer { defaults.removePersistentDomain(forName: suite) }
 
         SpeechEnginePreference.whisper.save(to: defaults)
+        SpeechEnginePreference.saveParakeetModelVariant(.v3, defaults: defaults)
         let variant = SpeechEnginePreference.whisperModelVariant(defaults: defaults)
 
         XCTAssertTrue(isModelInUse(.init(kind: .whisper(variant), displayName: "whisper"), defaults: defaults))
-        // Parakeet builds aren't in use while Whisper is the active engine.
-        XCTAssertFalse(isModelInUse(.init(kind: .parakeet(.v3), displayName: "v3"), defaults: defaults))
+        // Parakeet's configured build is protected too: it is what Parakeet
+        // would load if the user switches back from Whisper.
+        XCTAssertTrue(isModelInUse(.init(kind: .parakeet(.v3), displayName: "v3"), defaults: defaults))
+        XCTAssertFalse(isModelInUse(.init(kind: .parakeet(.v2), displayName: "v2"), defaults: defaults))
     }
 
     func testDeleteCommandParsesForceFlag() throws {

--- a/Tests/CLITests/ModelLifecycleCommandTests.swift
+++ b/Tests/CLITests/ModelLifecycleCommandTests.swift
@@ -198,6 +198,81 @@ final class ModelLifecycleCommandTests: XCTestCase {
         }
     }
 
+    // MARK: - models delete
+
+    private func makeDeleteDefaults() throws -> (UserDefaults, String) {
+        let suite = "test.ModelsDelete.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        return (defaults, suite)
+    }
+
+    func testResolveModelDeletionTargetMapsParakeetAndWhisperIDs() throws {
+        let (defaults, suite) = try makeDeleteDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        XCTAssertEqual(
+            try resolveModelDeletionTarget("parakeet-v2", defaults: defaults).kind,
+            .parakeet(.v2)
+        )
+        XCTAssertEqual(
+            try resolveModelDeletionTarget("parakeet-v3", defaults: defaults).kind,
+            .parakeet(.v3)
+        )
+        XCTAssertEqual(
+            try resolveModelDeletionTarget("whisper-large-v3-v20240930-turbo-632MB", defaults: defaults).kind,
+            .whisper("large-v3-v20240930_turbo_632MB")
+        )
+    }
+
+    func testResolveModelDeletionTargetRejectsUnknownID() throws {
+        let (defaults, suite) = try makeDeleteDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        XCTAssertThrowsError(try resolveModelDeletionTarget("tiny", defaults: defaults)) { error in
+            XCTAssertTrue(error is ValidationError)
+        }
+    }
+
+    func testIsModelInUseProtectsActiveParakeetBuildOnly() throws {
+        let (defaults, suite) = try makeDeleteDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        SpeechEnginePreference.parakeet.save(to: defaults)
+        SpeechEnginePreference.saveParakeetModelVariant(.v3, defaults: defaults)
+
+        XCTAssertTrue(isModelInUse(.init(kind: .parakeet(.v3), displayName: "v3"), defaults: defaults))
+        XCTAssertFalse(isModelInUse(.init(kind: .parakeet(.v2), displayName: "v2"), defaults: defaults))
+        // Parakeet is active, so Whisper is never the in-use model.
+        XCTAssertFalse(
+            isModelInUse(
+                .init(kind: .whisper(SpeechEnginePreference.defaultWhisperModelVariant), displayName: "whisper"),
+                defaults: defaults
+            )
+        )
+    }
+
+    func testIsModelInUseProtectsWhisperWhenActive() throws {
+        let (defaults, suite) = try makeDeleteDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        SpeechEnginePreference.whisper.save(to: defaults)
+        let variant = SpeechEnginePreference.whisperModelVariant(defaults: defaults)
+
+        XCTAssertTrue(isModelInUse(.init(kind: .whisper(variant), displayName: "whisper"), defaults: defaults))
+        // Parakeet builds aren't in use while Whisper is the active engine.
+        XCTAssertFalse(isModelInUse(.init(kind: .parakeet(.v3), displayName: "v3"), defaults: defaults))
+    }
+
+    func testDeleteCommandParsesForceFlag() throws {
+        let plain = try ModelsCommand.Delete.parse(["parakeet-v2"])
+        XCTAssertEqual(plain.id, "parakeet-v2")
+        XCTAssertFalse(plain.force)
+
+        let forced = try ModelsCommand.Delete.parse(["parakeet-v2", "--force"])
+        XCTAssertTrue(forced.force)
+    }
+
     func testWarmUpRetriesConfiguredAttempts() async {
         let stt = StubSTTClient()
         let diarization = StubDiarizationService()

--- a/Tests/MacParakeetTests/STT/ModelDeletionTests.swift
+++ b/Tests/MacParakeetTests/STT/ModelDeletionTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import MacParakeetCore
+
+/// Covers the pure file-removal cores behind per-model delete. The telemetry
+/// wrappers (`STTRuntime.deleteParakeetModel` / `deleteWhisperModel`) resolve
+/// the real cache paths, so they're exercised through these injectable pieces
+/// against temp directories rather than the live FluidAudio cache.
+final class ModelDeletionTests: XCTestCase {
+    private var tempRoot: URL!
+
+    override func setUpWithError() throws {
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ModelDeletionTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
+    }
+
+    // MARK: - Parakeet build file removal
+
+    func testRemoveParakeetModelFilesDeletesPopulatedDirectory() throws {
+        let modelDir = tempRoot.appendingPathComponent("parakeet-tdt-0.6b-v2-coreml", isDirectory: true)
+        try FileManager.default.createDirectory(at: modelDir, withIntermediateDirectories: true)
+        try "model".write(to: modelDir.appendingPathComponent("Decoder.mlmodelc"), atomically: true, encoding: .utf8)
+
+        XCTAssertTrue(STTRuntime.removeParakeetModelFiles(at: modelDir))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: modelDir.path))
+    }
+
+    func testRemoveParakeetModelFilesIsNoOpWhenAbsent() {
+        let missing = tempRoot.appendingPathComponent("does-not-exist", isDirectory: true)
+        XCTAssertFalse(STTRuntime.removeParakeetModelFiles(at: missing))
+    }
+
+    func testRemoveParakeetModelFilesLeavesSiblingBuildIntact() throws {
+        let v2Dir = tempRoot.appendingPathComponent("parakeet-tdt-0.6b-v2-coreml", isDirectory: true)
+        let v3Dir = tempRoot.appendingPathComponent("parakeet-tdt-0.6b-v3-coreml", isDirectory: true)
+        for dir in [v2Dir, v3Dir] {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            try "x".write(to: dir.appendingPathComponent("Decoder.mlmodelc"), atomically: true, encoding: .utf8)
+        }
+
+        XCTAssertTrue(STTRuntime.removeParakeetModelFiles(at: v2Dir))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: v2Dir.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: v3Dir.path))
+    }
+
+    // MARK: - Whisper variant file removal
+
+    func testDeleteWhisperModelRemovesFolderAndClearsOptimizedFlag() throws {
+        let suite = "test.ModelDeletion.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let variant = SpeechEnginePreference.defaultWhisperModelVariant
+        let folder = tempRoot.appendingPathComponent(variant, isDirectory: true)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        try "weights".write(to: folder.appendingPathComponent("model.bin"), atomically: true, encoding: .utf8)
+        SpeechEnginePreference.markWhisperOptimized(variant: variant, defaults: defaults)
+
+        let removed = WhisperEngine.deleteModel(model: variant, downloadBase: tempRoot, defaults: defaults)
+
+        XCTAssertTrue(removed)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: folder.path))
+        XCTAssertFalse(SpeechEnginePreference.hasOptimizedWhisper(variant: variant, defaults: defaults))
+    }
+
+    func testDeleteWhisperModelIsNoOpWhenNotDownloaded() throws {
+        let suite = "test.ModelDeletion.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let removed = WhisperEngine.deleteModel(
+            model: SpeechEnginePreference.defaultWhisperModelVariant,
+            downloadBase: tempRoot,
+            defaults: defaults
+        )
+        XCTAssertFalse(removed)
+    }
+}

--- a/Tests/MacParakeetTests/STT/SpeechEnginePreferenceTests.swift
+++ b/Tests/MacParakeetTests/STT/SpeechEnginePreferenceTests.swift
@@ -79,6 +79,40 @@ final class SpeechEnginePreferenceTests: XCTestCase {
         XCTAssertFalse(SpeechEnginePreference.hasOptimizedWhisper(variant: "small", defaults: defaults))
     }
 
+    func testClearWhisperOptimizedForgetsVariant() {
+        let (defaults, suite) = makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let variant = SpeechEnginePreference.defaultWhisperModelVariant
+        SpeechEnginePreference.markWhisperOptimized(variant: variant, defaults: defaults)
+        XCTAssertTrue(SpeechEnginePreference.hasOptimizedWhisper(variant: variant, defaults: defaults))
+
+        SpeechEnginePreference.clearWhisperOptimized(variant: variant, defaults: defaults)
+        XCTAssertFalse(SpeechEnginePreference.hasOptimizedWhisper(variant: variant, defaults: defaults))
+    }
+
+    func testClearWhisperOptimizedLeavesOtherVariantsIntact() {
+        let (defaults, suite) = makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        SpeechEnginePreference.markWhisperOptimized(variant: "large-v3-turbo", defaults: defaults)
+        SpeechEnginePreference.markWhisperOptimized(variant: "small", defaults: defaults)
+
+        SpeechEnginePreference.clearWhisperOptimized(variant: "large-v3-turbo", defaults: defaults)
+
+        XCTAssertFalse(SpeechEnginePreference.hasOptimizedWhisper(variant: "large-v3-turbo", defaults: defaults))
+        XCTAssertTrue(SpeechEnginePreference.hasOptimizedWhisper(variant: "small", defaults: defaults))
+    }
+
+    func testClearWhisperOptimizedIsIdempotentWhenAbsent() {
+        let (defaults, suite) = makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        // No-op when nothing was marked — must not crash or leave stray keys.
+        SpeechEnginePreference.clearWhisperOptimized(variant: "small", defaults: defaults)
+        XCTAssertNil(defaults.stringArray(forKey: SpeechEnginePreference.whisperOptimizedVariantsKey))
+    }
+
     // MARK: - Parakeet model variant
 
     func testParakeetModelVariantDefaultsToMultilingualV3() {

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -1748,6 +1748,17 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertTrue(recorder.parakeetCalls.isEmpty)
     }
 
+    func testDeleteParakeetVariantRefusesSelectedBuildWhenWhisperActive() {
+        let recorder = ModelDeleteRecorder()
+        let vm = makeDeletionViewModel(engine: .whisper, parakeetVariant: .v3, recorder: recorder)
+        vm.downloadedParakeetVariants = [.v3, .v2]
+
+        vm.deleteParakeetVariant(.v3)
+
+        XCTAssertTrue(vm.downloadedParakeetVariants.contains(.v3))
+        XCTAssertTrue(recorder.parakeetCalls.isEmpty)
+    }
+
     func testDeleteParakeetVariantIgnoredWhileSwitching() {
         let recorder = ModelDeleteRecorder()
         let vm = makeDeletionViewModel(engine: .parakeet, parakeetVariant: .v3, recorder: recorder)

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -1703,6 +1703,111 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertFalse(vm2.saveTranscriptionAudio)
         XCTAssertTrue(vm2.speakerDiarization)
     }
+
+    // MARK: - Model deletion
+
+    /// Builds a VM whose engine/variant are pinned via pre-seeded defaults (so
+    /// init reads them without firing didSet side effects) and whose on-disk
+    /// deletes are captured by `recorder` instead of touching the real cache.
+    private func makeDeletionViewModel(
+        engine: SpeechEnginePreference,
+        parakeetVariant: ParakeetModelVariant,
+        recorder: ModelDeleteRecorder
+    ) -> SettingsViewModel {
+        engine.save(to: testDefaults)
+        SpeechEnginePreference.saveParakeetModelVariant(parakeetVariant, defaults: testDefaults)
+        return SettingsViewModel(
+            defaults: testDefaults,
+            parakeetModelVariantCached: { _ in true },
+            deleteParakeetModelOnDisk: { variant in recorder.recordParakeet(variant); return true },
+            deleteWhisperModelOnDisk: { variant in recorder.recordWhisper(variant); return true }
+        )
+    }
+
+    func testDeleteParakeetVariantRemovesUnusedBuild() async throws {
+        let recorder = ModelDeleteRecorder()
+        let vm = makeDeletionViewModel(engine: .parakeet, parakeetVariant: .v3, recorder: recorder)
+        vm.downloadedParakeetVariants = [.v3, .v2]
+
+        vm.deleteParakeetVariant(.v2)
+
+        // Badge drops synchronously; the disk delete lands on a detached task.
+        XCTAssertFalse(vm.downloadedParakeetVariants.contains(.v2))
+        try await waitUntil { recorder.parakeetCalls == [.v2] }
+    }
+
+    func testDeleteParakeetVariantRefusesActiveBuild() {
+        let recorder = ModelDeleteRecorder()
+        let vm = makeDeletionViewModel(engine: .parakeet, parakeetVariant: .v3, recorder: recorder)
+        vm.downloadedParakeetVariants = [.v3, .v2]
+
+        // v3 is the active build — deleting it would force a re-download.
+        vm.deleteParakeetVariant(.v3)
+
+        XCTAssertTrue(vm.downloadedParakeetVariants.contains(.v3))
+        XCTAssertTrue(recorder.parakeetCalls.isEmpty)
+    }
+
+    func testDeleteParakeetVariantIgnoredWhileSwitching() {
+        let recorder = ModelDeleteRecorder()
+        let vm = makeDeletionViewModel(engine: .parakeet, parakeetVariant: .v3, recorder: recorder)
+        vm.downloadedParakeetVariants = [.v3, .v2]
+        vm.speechEngineSwitching = true
+
+        vm.deleteParakeetVariant(.v2)
+
+        XCTAssertTrue(vm.downloadedParakeetVariants.contains(.v2))
+        XCTAssertTrue(recorder.parakeetCalls.isEmpty)
+    }
+
+    func testDeleteWhisperModelRemovesDownloadWhenParakeetActive() async throws {
+        let recorder = ModelDeleteRecorder()
+        let vm = makeDeletionViewModel(engine: .parakeet, parakeetVariant: .v3, recorder: recorder)
+        vm.whisperModelStatus = .notLoaded
+
+        vm.deleteWhisperModel()
+
+        // Status flips to not-downloaded immediately; delete runs in the background.
+        XCTAssertEqual(vm.whisperModelStatus, .notDownloaded)
+        try await waitUntil {
+            recorder.whisperCalls == [SpeechEnginePreference.whisperModelVariant(defaults: self.testDefaults)]
+        }
+    }
+
+    func testDeleteWhisperModelRefusedWhenWhisperActive() {
+        let recorder = ModelDeleteRecorder()
+        let vm = makeDeletionViewModel(engine: .whisper, parakeetVariant: .v3, recorder: recorder)
+        vm.whisperModelStatus = .notLoaded
+
+        vm.deleteWhisperModel()
+
+        XCTAssertEqual(vm.whisperModelStatus, .notLoaded)
+        XCTAssertTrue(recorder.whisperCalls.isEmpty)
+    }
+}
+
+/// Thread-safe capture for the injected on-disk deleter closures (they fire on
+/// a detached task, so reads/writes are lock-guarded).
+private final class ModelDeleteRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var parakeet: [ParakeetModelVariant] = []
+    private var whisper: [String] = []
+
+    func recordParakeet(_ variant: ParakeetModelVariant) {
+        lock.lock(); parakeet.append(variant); lock.unlock()
+    }
+
+    func recordWhisper(_ variant: String) {
+        lock.lock(); whisper.append(variant); lock.unlock()
+    }
+
+    var parakeetCalls: [ParakeetModelVariant] {
+        lock.lock(); defer { lock.unlock() }; return parakeet
+    }
+
+    var whisperCalls: [String] {
+        lock.lock(); defer { lock.unlock() }; return whisper
+    }
 }
 
 private actor MockSpeechEngineSwitchAvailabilityProvider: SpeechEngineSwitchAvailabilityProviding {

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -412,13 +412,20 @@ swift run macparakeet-cli models warm-up
 swift run macparakeet-cli models repair
 swift run macparakeet-cli models repair --attempts 5
 
-# Delete cached models
+# Delete one downloaded model (frees its disk space; leaves the rest)
+swift run macparakeet-cli models delete parakeet-v2
+swift run macparakeet-cli models delete whisper-large-v3-v20240930-turbo-632MB
+swift run macparakeet-cli models delete parakeet-v3 --force   # override the in-use guard
+
+# Delete the entire cached speech + speaker stack
 swift run macparakeet-cli models clear
 ```
 
 `models warm-up` and `models repair` prepare the selected Parakeet build plus
 the diarization speech stack. Whisper is downloaded explicitly with
-`models download`.
+`models download`. `models delete <id>` removes a single model — one Parakeet
+build or the Whisper variant — and protects the model currently in use unless
+`--force` is passed; `models clear` still wipes everything.
 
 ## Text Pipeline
 

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -424,8 +424,9 @@ swift run macparakeet-cli models clear
 `models warm-up` and `models repair` prepare the selected Parakeet build plus
 the diarization speech stack. Whisper is downloaded explicitly with
 `models download`. `models delete <id>` removes a single model — one Parakeet
-build or the Whisper variant — and protects the model currently in use unless
-`--force` is passed; `models clear` still wipes everything.
+build or the Whisper variant — and protects the active model plus Parakeet's
+configured build unless `--force` is passed; `models clear` still wipes
+everything.
 
 ## Text Pipeline
 

--- a/plans/active/2026-05-delete-downloaded-models.md
+++ b/plans/active/2026-05-delete-downloaded-models.md
@@ -1,0 +1,67 @@
+# Delete downloaded speech models
+
+> Status: **ACTIVE** — implemented on `feat/delete-downloaded-models`, pending PR merge.
+
+## Why
+
+Issue #311 follow-up (Du7chManiac): after we exposed Parakeet v2 alongside v3,
+users who tried both builds have ~465 MB stranded on disk with no way to reclaim
+it short of `models clear`, which nukes *everything* (including the build they
+use, forcing a re-download). Whisper (~632 MB) has the same problem once a user
+switches back to Parakeet. Per-model delete is table stakes for local-model apps
+(MacWhisper, LM Studio, Ollama, Superwhisper, VoiceInk all have it).
+
+## Scope
+
+In scope: delete one downloaded model at a time — either Parakeet build, or the
+Whisper variant — from the GUI and CLI, protecting the model currently in use.
+
+Out of scope: changing selection/download flows, multi-Whisper-variant UI,
+on-disk size measurement (we keep the existing approximate size copy), and any
+change to `models clear`.
+
+## Invariants
+
+- The model the active engine would load is never deletable without `--force`
+  (CLI) and is never offered in the GUI — deleting it would silently force a
+  re-download.
+- Deleting one Parakeet build never touches the sibling build (independent
+  cache dirs) or the diarization / Whisper models.
+- `models clear` behaviour is unchanged.
+
+## Design
+
+**Placement (chosen with owner):** in-context, reusing shipped patterns.
+- Parakeet: a `⋯` menu on each *downloaded, non-selected* build row in the
+  existing **Parakeet Model** card (where each build already shows a "Downloaded"
+  badge + size). The selected build has no menu.
+- Whisper: a "Delete download…" item added to the existing `⋯` overflow on the
+  **Local Models** Whisper row, shown only when Whisper is not the active engine.
+- Shared destructive confirmation `.alert` on the Engine tab.
+
+## Layers
+
+- **Core** (`MacParakeetCore`)
+  - `STTRuntime.deleteParakeetModel(version:)` → removes the leaf cache dir
+    `AsrModels.defaultCacheDirectory(for:)`; emits `model_operation`/`delete_model`
+    telemetry. Pure `removeParakeetModelFiles(at:)` underneath for tests.
+  - `WhisperEngine.deleteModel(model:downloadBase:defaults:)` → removes the
+    variant folder + clears the optimized flag (pure, injectable).
+  - `STTRuntime.deleteWhisperModel(variant:defaults:)` → telemetry wrapper.
+  - `SpeechEnginePreference.clearWhisperOptimized(variant:)`.
+  - `TelemetryModelOperationAction.deleteModel` + `.stage.delete` (prop value on
+    the already-allowlisted `model_operation` event — no website change).
+- **CLI**: `models delete <id> [--force]`; testable `resolveModelDeletionTarget`
+  + `isModelInUse`. CLI bumped to 2.6.0.
+- **ViewModels**: `SettingsViewModel.deleteParakeetVariant(_:)` /
+  `deleteWhisperModel()` with in-use + switching guards, optimistic state, and a
+  disk refresh. Deleters injected as closures for tests.
+- **GUI**: per-build `⋯` in the Parakeet Model card; multi-action overflow on the
+  Local Models rows; shared confirmation alert.
+
+## Tests
+
+- Core: Parakeet file removal (incl. sibling-intact), Whisper folder removal +
+  optimized-flag clearing + no-op, `clearWhisperOptimized`.
+- VM: delete dispatch + active-build / active-engine / switching guards.
+- CLI: id resolution, in-use guard for both engines, `--force` parsing.

--- a/plans/active/2026-05-delete-downloaded-models.md
+++ b/plans/active/2026-05-delete-downloaded-models.md
@@ -22,9 +22,9 @@ change to `models clear`.
 
 ## Invariants
 
-- The model the active engine would load is never deletable without `--force`
-  (CLI) and is never offered in the GUI — deleting it would silently force a
-  re-download.
+- The active model and Parakeet's configured build are never deletable without
+  `--force` (CLI) and are never offered in the GUI — deleting either would
+  silently force a re-download after current or future engine use.
 - Deleting one Parakeet build never touches the sibling build (independent
   cache dirs) or the diarization / Whisper models.
 - `models clear` behaviour is unchanged.


### PR DESCRIPTION
## Summary

Adds the ability to **delete a single downloaded speech model** — one Parakeet build (v2/v3) or the Whisper variant — from both Settings and the CLI, instead of only the all-or-nothing `models clear`.

Direct response to the feedback on #311 (Du7chManiac): *"Could you also allow deleting the model we are not using?"* After we exposed Parakeet v2 alongside v3, a user who tries both builds strands ~465 MB on disk with no way to reclaim it short of `models clear`, which wipes **everything** — including the build still in use, forcing a re-download. Whisper (~632 MB) has the same problem once a user switches back to Parakeet.

Per-model delete is table stakes for local-model apps (MacWhisper, LM Studio, Ollama, Superwhisper, VoiceInk all have it).

## UX (chosen with owner: in-context + protect the in-use model)

- **Parakeet Model card** — a `⋯` menu appears on each *downloaded, non-selected* build row → **Delete download**. The selected (in-use) build has no menu.
- **Local Models card** — the Whisper row's overflow gains **Delete download…**, shown only when Whisper isn't the active engine.
- One shared destructive **confirmation alert** on the Engine tab (native `.alert`, matching the Reset & Cleanup pattern).
- **CLI**: `macparakeet-cli models delete <id> [--force]`, symmetric with `models download`.

**The model currently in use is protected on every surface** — the GUI hides it, the ViewModel guards it, and the CLI refuses it (exit `2`) unless `--force` (which prints a warning). A delete can never silently force a re-download.

## Implementation

| Layer | Change |
|-------|--------|
| Core | `STTRuntime.deleteParakeetModel(version:)` removes only that build's leaf cache dir (sibling untouched); `WhisperEngine.deleteModel` removes the variant folder + clears its optimized flag; `STTRuntime.deleteWhisperModel` telemetry wrapper; `SpeechEnginePreference.clearWhisperOptimized`. New `model_operation` action `delete_model` (a **prop value** on an already-allowlisted event — no website change). |
| CLI | `models delete` subcommand + testable `resolveModelDeletionTarget` / `isModelInUse`; version → 2.6.0; CHANGELOG entry. |
| ViewModels | `SettingsViewModel.deleteParakeetVariant(_:)` / `deleteWhisperModel()` with in-use + switching guards, optimistic state, refresh-generation bump to drop stale in-flight refreshes, and injected deleter closures for tests. |
| GUI | Per-build `⋯` in the Parakeet Model card; multi-action overflow on Local Models rows; shared confirmation alert. |

## Testing

- `swift test` — **full suite green** (0 failures).
- New/updated tests: core file removal incl. sibling-intact + Whisper folder removal + optimized-flag clearing (`ModelDeletionTests`, `SpeechEnginePreferenceTests`); ViewModel delete dispatch + active-build / active-engine / switching guards (`SettingsViewModelTests`); CLI id resolution, in-use guard for both engines, `--force` parsing (`ModelLifecycleCommandTests`).
- CLI smoke-tested manually: in-use guard refuses the active build (and leaves it installed), unknown id errors, `--help` reads cleanly.
- Independent structural review (Codex) of the diff: in-use guard airtight across all three surfaces, no Swift 6 concurrency issues, cache-path scoping correct, telemetry allowlist unaffected. Its two functional suggestions (CLI `--force` warning; bump refresh generation to avoid a ghost double-tap) are applied in this branch.

> Note: verified via build + full test suite + structural review. A quick manual glance at the Engine settings (Parakeet `⋯` on the unused build, Whisper overflow → Delete) is recommended before merge.

Closes the delete request on #311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
