### PR TITLE
Fix YouTube hotkey not showing panel from a background app

### DIFF
--- a/Sources/MacParakeet/Views/Transcription/YouTubeInputPanelController.swift
+++ b/Sources/MacParakeet/Views/Transcription/YouTubeInputPanelController.swift
@@ -77,7 +77,14 @@ final class YouTubeInputPanelController {
 
         self.panel = panel
 
-        NSApp.activate()
+        // This panel is summoned by a global hotkey, typically while another
+        // app is frontmost. The cooperative `NSApp.activate()` is routinely
+        // declined for a background app responding to a CGEvent tap, so the
+        // panel gets ordered into our own window list but is never raised above
+        // the active app — it only appears once the user manually focuses
+        // MacParakeet. Force activation so the panel reliably comes forward,
+        // matching the file-transcription flow in `MenuBarCoordinator`.
+        NSApp.activate(ignoringOtherApps: true)
         panel.makeKeyAndOrderFront(nil)
 
         installResignObserver()

--- a/Sources/MacParakeet/Views/Transcription/YouTubeInputPanelController.swift
+++ b/Sources/MacParakeet/Views/Transcription/YouTubeInputPanelController.swift
@@ -67,8 +67,10 @@ final class YouTubeInputPanelController {
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         panel.contentView = hosting
 
-        // Center horizontally, upper third vertically (Spotlight-style)
-        if let screen = NSScreen.main {
+        // Center horizontally, upper third vertically (Spotlight-style).
+        // Fall back to the first screen when there is no main screen (a rare
+        // transition state) so the panel never lands at the bottom-left origin.
+        if let screen = NSScreen.main ?? NSScreen.screens.first {
             let screenFrame = screen.visibleFrame
             let x = screenFrame.midX - panelWidth / 2
             let y = screenFrame.origin.y + screenFrame.height * 0.65 - panelHeight / 2


### PR DESCRIPTION
## Summary
The YouTube-transcription global hotkey only surfaced its Spotlight-style input panel when MacParakeet was already frontmost. Triggered from another app it did nothing ~7/10 times, then the panel appeared the instant the user manually focused MacParakeet.

## Root cause
`YouTubeInputPanelController.show()` called the cooperative `NSApp.activate()` (the macOS 14+ no-arg API) before `makeKeyAndOrderFront`. For a background/agent app responding to a global CGEvent-tap hotkey, the window server routinely declines cooperative activation (no user gesture targets the app), so the `.floating` panel was ordered into our own window list but never raised above the active app.

## Fix
Use the forceful `NSApp.activate(ignoringOtherApps: true)`, matching `MenuBarCoordinator.transcribeFileFlow()` (the file-transcription hotkey, which never had this bug). This was the **only** activation call site in the app using the cooperative no-arg variant — every other surface that comes forward (`AppWindowCoordinator`, `MeetingRecordingPanelController`, `OnboardingWindowController`, `DictationFlowCoordinator`, …) already force-activates. Also added an `NSScreen.main` → `NSScreen.screens.first` fallback so the panel never lands bottom-left if there's no main screen.

## How it regressed
The panel originally shipped with only `makeKeyAndOrderFront` (`4fa1c3e0`). A later review pass (`af4b6216`) added the cooperative `NSApp.activate()`, presumably to dodge the deprecation warning on `activate(ignoringOtherApps:)` — which is what made it unreliable from the background.

## Fresh-eye review (Codex + Gemini)
Both verdicts: merge-ready. Dispositions:
- **Applied** — `NSScreen.main` nil fallback (Gemini).
- **Refuted** — swap to `NSRunningApplication.current.activate(options: .activateIgnoringOtherApps)` to escape the deprecation: that option was *also* deprecated in macOS 14.0, so it relocates the warning rather than removing it. There is no reliable non-deprecated way to force-foreground a background agent app; the deprecated call is the correct pragmatic choice and matches 18+ sibling call sites. (Gemini independently concurred.)
- **Refuted** — move `installResignObserver()` before `makeKeyAndOrderFront` to avoid an orphaned-panel race: the install is synchronous-adjacent to `makeKeyAndOrderFront`, so the observer is always registered before any async `didResignKey` can be delivered by the run loop. The race isn't realizable, and Gemini judged the current ordering safe/preferable.
- **Deferred** — making `KeyablePanel.cancelOperation`'s Escape-dismissal explicit (vs. relying on `orderOut` → `didResignKey` → `hide()`). Pre-existing, works correctly, and out of scope for this activation fix.

## Testing
- `swift build --target MacParakeet` clean.
- No unit test: this is AppKit window-activation behavior, which the project deliberately doesn't unit-test (`spec/09-testing.md`).
- Manual: from another frontmost app (Safari/Notes), press the YouTube hotkey → panel appears on top immediately, every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
