### PR TITLE
[codex] Pin system default microphone before implicit fallback

### DIFF
--- a/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
+++ b/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
@@ -90,7 +90,9 @@ public func meetingInputDeviceAttempts(
     }
 
     let defaultDeviceID = defaultInputDevice()
-    if let defaultDeviceID {
+    if selectedUID == nil, let defaultDeviceID {
+        appendExplicit(.systemDefault, deviceID: defaultDeviceID)
+    } else if let defaultDeviceID {
         seenDeviceIDs.insert(defaultDeviceID)
     }
     attempts.append(.implicitSystemDefault(resolvedDeviceID: defaultDeviceID))

--- a/Sources/MacParakeetCore/Audio/MicrophoneEnginePlatform.swift
+++ b/Sources/MacParakeetCore/Audio/MicrophoneEnginePlatform.swift
@@ -50,9 +50,9 @@ public protocol MicrophoneEnginePlatform: AnyObject, Sendable {
 ///   the VPAU aggregate device. A long-lived engine keeps the VPAU alive
 ///   indefinitely, which inherits the duplex layout into other engines.
 /// - When configured with a `deviceAttemptsBuilder`, each `configureAndStart`
-///   walks the resolved attempt list (selected → implicit systemDefault →
-///   builtIn) and recreates the engine on every failed attempt before trying
-///   the next — the same fallback shape `MicrophoneCapture` uses today.
+///   walks the resolved attempt list (selected → explicit systemDefault when
+///   System Default is selected → implicit systemDefault → builtIn) and
+///   recreates the engine on every failed attempt before trying the next.
 public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @unchecked Sendable {
     public typealias DeviceAttemptsBuilder = @Sendable () -> [MeetingInputDeviceAttempt]
     public typealias InputDeviceSetter = @Sendable (AudioDeviceID, AVAudioEngine) -> Bool

--- a/Tests/MacParakeetTests/Audio/MicrophoneCaptureTests.swift
+++ b/Tests/MacParakeetTests/Audio/MicrophoneCaptureTests.swift
@@ -346,6 +346,28 @@ final class MicrophoneCaptureTests: XCTestCase {
         )
     }
 
+    func testSystemDefaultSelectionPinsResolvedDefaultBeforeImplicitFallback() {
+        let attempts = meetingInputDeviceAttempts(
+            selectedUID: nil,
+            selectedInputDeviceID: { _ in nil },
+            defaultInputDevice: { AudioDeviceID(20) },
+            builtInMicrophone: { AudioDeviceID(30) }
+        )
+
+        XCTAssertEqual(
+            attempts,
+            [
+                MeetingInputDeviceAttempt(source: .systemDefault, deviceID: 20),
+                .implicitSystemDefault(resolvedDeviceID: 20),
+                MeetingInputDeviceAttempt(source: .builtIn, deviceID: 30),
+            ]
+        )
+        XCTAssertFalse(attempts[0].usesImplicitSystemDefault)
+        XCTAssertTrue(attempts[1].usesImplicitSystemDefault)
+        XCTAssertEqual(attempts[0].explicitDeviceID, 20)
+        XCTAssertNil(attempts[1].explicitDeviceID)
+    }
+
     func testInputDeviceAttemptsDeduplicateDefaultAndBuiltIn() {
         let attempts = meetingInputDeviceAttempts(
             selectedUID: nil,
@@ -357,6 +379,7 @@ final class MicrophoneCaptureTests: XCTestCase {
         XCTAssertEqual(
             attempts,
             [
+                MeetingInputDeviceAttempt(source: .systemDefault, deviceID: 30),
                 .implicitSystemDefault(resolvedDeviceID: 30),
             ]
         )
@@ -432,6 +455,33 @@ final class MicrophoneCaptureTests: XCTestCase {
         defer { platform.stopEngine() }
 
         XCTAssertEqual(recorder.deviceIDs, [10])
+        XCTAssertEqual(platform.lastSucceededAttempt, .implicitSystemDefault(resolvedDeviceID: 20))
+    }
+
+    func testPlatformFallsBackToImplicitSystemDefaultWhenExplicitDefaultSetFails() throws {
+        let recorder = MicrophoneCaptureInputDeviceSetterRecorder()
+        let platform = AVAudioEngineMicrophonePlatform(
+            deviceAttemptsBuilder: {
+                [
+                    MeetingInputDeviceAttempt(source: .systemDefault, deviceID: 20),
+                    .implicitSystemDefault(resolvedDeviceID: 20),
+                ]
+            },
+            inputDeviceSetter: { deviceID, _ in
+                recorder.record(deviceID)
+                return false
+            },
+            engineStarter: { _, _, _, _ in }
+        )
+
+        try platform.configureAndStart(
+            vpioEnabled: false,
+            bufferSize: 1024,
+            tapHandler: { _, _ in }
+        )
+        defer { platform.stopEngine() }
+
+        XCTAssertEqual(recorder.deviceIDs, [20])
         XCTAssertEqual(platform.lastSucceededAttempt, .implicitSystemDefault(resolvedDeviceID: 20))
     }
 

--- a/Tests/MacParakeetTests/Audio/MicrophoneCaptureTests.swift
+++ b/Tests/MacParakeetTests/Audio/MicrophoneCaptureTests.swift
@@ -485,6 +485,40 @@ final class MicrophoneCaptureTests: XCTestCase {
         XCTAssertEqual(platform.lastSucceededAttempt, .implicitSystemDefault(resolvedDeviceID: 20))
     }
 
+    func testPlatformFallsBackToImplicitSystemDefaultWhenExplicitDefaultStartFails() throws {
+        let recorder = MicrophoneCaptureInputDeviceSetterRecorder()
+        let startAttempts = MicrophoneCaptureTestCounter()
+        let platform = AVAudioEngineMicrophonePlatform(
+            deviceAttemptsBuilder: {
+                [
+                    MeetingInputDeviceAttempt(source: .systemDefault, deviceID: 20),
+                    .implicitSystemDefault(resolvedDeviceID: 20),
+                ]
+            },
+            inputDeviceSetter: { deviceID, _ in
+                recorder.record(deviceID)
+                return true
+            },
+            engineStarter: { _, _, _, _ in
+                startAttempts.increment()
+                if startAttempts.value == 1 {
+                    throw MicrophoneCaptureMockError.simulatedFailure
+                }
+            }
+        )
+
+        try platform.configureAndStart(
+            vpioEnabled: false,
+            bufferSize: 1024,
+            tapHandler: { _, _ in }
+        )
+        defer { platform.stopEngine() }
+
+        XCTAssertEqual(recorder.deviceIDs, [20])
+        XCTAssertEqual(startAttempts.value, 2)
+        XCTAssertEqual(platform.lastSucceededAttempt, .implicitSystemDefault(resolvedDeviceID: 20))
+    }
+
     private func makeSharedTestBuffer() -> AVAudioPCMBuffer {
         let format = AVAudioFormat(standardFormatWithSampleRate: 16_000, channels: 1)!
         let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 256)!


### PR DESCRIPTION

## Summary

Fixes #409.

MacParakeet System Default microphone selection was using AVAudioEngine implicit default routing. With Bluetooth headphones connected as output, macOS can route capture through the headset input and put the headphones into low-quality HFP/HSP call mode, even when the macOS default input is the built-in microphone.

This changes only the actual System Default case: when CoreAudio reports a concrete default input device, try that device explicitly first, then retain the existing implicit system-default fallback. Explicit user-selected microphones, missing selected-device fallback, and no-default-device behavior stay unchanged.

## Why this is low risk

- Explicit selected microphone behavior is unchanged.
- Missing selected microphone fallback behavior is unchanged.
- If explicitly setting the resolved default fails, capture falls back to the old implicit path.
- If CoreAudio does not report a default input, capture still uses the old implicit path.
- The prior implicit fallback remains in place for compatibility with devices that motivated the original implicit-default behavior.

## Validation

- `swift test --filter MicrophoneCaptureTests`
- `swift test --filter SharedMicrophoneStreamTests`
- `swift test` - 3150 XCTest tests + 16 Swift Testing tests passed, 10 skipped, 0 failures

## Field verification needed

Ask the affected user to test Bluetooth headphones as output, macOS input set to MacBook Pro Microphone, and MacParakeet microphone set to System Default. Expected result: MacParakeet records from the resolved default input without pushing Bluetooth headphones into call-mode audio. If explicit default routing fails on their setup, the existing implicit fallback should preserve capture instead of hard failing.
