### PR TITLE
[codex] Default Parakeet when English is preferred

### DIFF
--- a/Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift
+++ b/Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift
@@ -769,7 +769,7 @@ struct OnboardingFlowView: View {
                         VStack(alignment: .leading, spacing: 4) {
                             Text("\(recommendation.languageName) setup")
                                 .font(DesignSystem.Typography.sectionTitle)
-                            Text("Your Mac language suggests \(recommendation.languageName). MacParakeet will set up local Whisper instead of Parakeet so dictation works for this language from the first run.")
+                            Text("Your Mac language settings suggest \(recommendation.languageName). MacParakeet will set up local Whisper instead of Parakeet so dictation works for this language from the first run.")
                                 .font(DesignSystem.Typography.bodySmall)
                                 .foregroundStyle(.secondary)
                                 .fixedSize(horizontal: false, vertical: true)
@@ -1077,7 +1077,7 @@ struct OnboardingFlowView: View {
             return "Two ways to dictate — pick whichever feels natural."
         case .engine:
             if let recommendation = viewModel.whisperRecommendation {
-                return "Preparing local Whisper for \(recommendation.languageName) so dictation works for your Mac language."
+                return "Preparing local Whisper for \(recommendation.languageName) so dictation works for your Mac language settings."
             }
             return "The speech model (~465 MB) downloads once. Usually quick on broadband, longer on slower connections."
         case .done:

--- a/Sources/MacParakeetViewModels/OnboardingViewModel.swift
+++ b/Sources/MacParakeetViewModels/OnboardingViewModel.swift
@@ -890,11 +890,14 @@ public final class OnboardingViewModel {
         preferredLanguages: [String]
     ) -> WhisperOnboardingRecommendation? {
         let cjkWhisperLanguageCodes: Set<String> = ["ko", "ja", "zh", "yue"]
-        for language in preferredLanguages {
-            guard let code = SpeechEnginePreference.normalizeKnownLanguage(language),
-                  cjkWhisperLanguageCodes.contains(code) else {
-                continue
-            }
+        let normalizedLanguages = preferredLanguages.compactMap {
+            SpeechEnginePreference.normalizeKnownLanguage($0)
+        }
+        guard !normalizedLanguages.contains("en") else {
+            return nil
+        }
+
+        for code in normalizedLanguages where cjkWhisperLanguageCodes.contains(code) {
             return WhisperOnboardingRecommendation(
                 languageCode: code,
                 languageName: WhisperLanguageCatalog.displayLabel(for: code)

--- a/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
@@ -176,7 +176,7 @@ final class OnboardingViewModelTests: XCTestCase {
             "ko"
         )
         XCTAssertEqual(
-            OnboardingViewModel.recommendedWhisperLanguage(preferredLanguages: ["en-US", "ja-JP"])?.languageCode,
+            OnboardingViewModel.recommendedWhisperLanguage(preferredLanguages: ["ja-JP"])?.languageCode,
             "ja"
         )
         XCTAssertEqual(
@@ -184,6 +184,12 @@ final class OnboardingViewModelTests: XCTestCase {
             "zh"
         )
         XCTAssertNil(OnboardingViewModel.recommendedWhisperLanguage(preferredLanguages: ["en-US", "fr-FR"]))
+    }
+
+    func testWhisperOnboardingRecommendationKeepsParakeetWhenEnglishIsPreferred() {
+        XCTAssertNil(OnboardingViewModel.recommendedWhisperLanguage(preferredLanguages: ["en-US", "ja-JP"]))
+        XCTAssertNil(OnboardingViewModel.recommendedWhisperLanguage(preferredLanguages: ["ja-JP", "en-US"]))
+        XCTAssertNil(OnboardingViewModel.recommendedWhisperLanguage(preferredLanguages: ["zh-Hans-CN", "English"]))
     }
 
     func testMeetingRecordingStepCanContinueWithoutPermission() {

--- a/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
@@ -197,7 +197,7 @@ final class OnboardingViewModelTests: XCTestCase {
     func testWhisperOnboardingRecommendationKeepsParakeetWhenEnglishIsPreferred() {
         XCTAssertNil(OnboardingViewModel.recommendedWhisperLanguage(preferredLanguages: ["en-US", "ja-JP"]))
         XCTAssertNil(OnboardingViewModel.recommendedWhisperLanguage(preferredLanguages: ["ja-JP", "en-US"]))
-        XCTAssertNil(OnboardingViewModel.recommendedWhisperLanguage(preferredLanguages: ["zh-Hans-CN", "English"]))
+        XCTAssertNil(OnboardingViewModel.recommendedWhisperLanguage(preferredLanguages: ["zh-Hans-CN", "en-GB"]))
     }
 
     func testMeetingRecordingStepCanContinueWithoutPermission() {

--- a/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
@@ -183,6 +183,14 @@ final class OnboardingViewModelTests: XCTestCase {
             OnboardingViewModel.recommendedWhisperLanguage(preferredLanguages: ["zh-Hant-HK"])?.languageCode,
             "zh"
         )
+        XCTAssertEqual(
+            OnboardingViewModel.recommendedWhisperLanguage(preferredLanguages: ["zh-Hans-CN", "ja-JP"])?.languageCode,
+            "zh"
+        )
+        XCTAssertEqual(
+            OnboardingViewModel.recommendedWhisperLanguage(preferredLanguages: ["ja-JP", "zh-Hans-CN"])?.languageCode,
+            "ja"
+        )
         XCTAssertNil(OnboardingViewModel.recommendedWhisperLanguage(preferredLanguages: ["en-US", "fr-FR"]))
     }
 


### PR DESCRIPTION
## Summary

- Keep onboarding on the Parakeet path whenever English appears anywhere in macOS preferred languages.
- Only auto-recommend Whisper configured for a CJK language when no English preference is present and the preferred-language list includes Japanese, Korean, Chinese, or Cantonese.
- Tighten onboarding copy to say language settings instead of implying a single Mac language.

Fixes #415.

## Why

Issue #415 showed that a user with English (US) as their default could still be routed into Whisper configured for Chinese during onboarding when Chinese also appeared in macOS language settings. That is surprising for MacParakeet users because Parakeet should remain the default when English is available.

## Behavior examples

These arrays are macOS `Locale.preferredLanguages` values from Language & Region, ordered by language preference. They are not keyboard or input-source settings.

- `["en-US", "ja-JP"]` -> Parakeet
- `["ja-JP", "en-US"]` -> Parakeet
- `["ja-JP"]` -> Whisper configured for Japanese
- `["zh-Hans-CN", "ja-JP"]` -> Whisper configured for Chinese
- `["ja-JP", "zh-Hans-CN"]` -> Whisper configured for Japanese

English wins anywhere in the list. When English is absent, the first CJK preferred language still determines the Whisper language recommendation.

## Validation

- `swift test --filter OnboardingViewModelTests` passed: 30 tests, 0 failures.
- Full `swift test` passed earlier on this branch: 3,152 XCTest tests plus 16 Swift Testing tests, 10 documented skips, 0 failures.
- `git diff --check` is clean.
