### PR TITLE
fix: reduce Meetings workspace resize jank

### DIFF
--- a/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
+++ b/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
@@ -19,9 +19,6 @@ struct MeetingsView: View {
 
     private static let rightRailWidth: CGFloat = 280
     private static let twoColumnMinimumWidth: CGFloat = 1_100
-    private static let recentMeetingEstimatedRowHeight: CGFloat = 65
-    private static let recentMeetingEstimatedGroupHeaderHeight: CGFloat = 32
-    private static let recentMeetingListMaximumHeight: CGFloat = 540
 
     var body: some View {
         GeometryReader { proxy in
@@ -155,8 +152,8 @@ struct MeetingsView: View {
     private var oneColumnContent: some View {
         VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
             upcomingSection
-            recentMeetingsSection
             attentionSection
+            recentMeetingsSection
             intelligenceSection
             autoNotesSection
             meetingPromptsSection
@@ -409,7 +406,7 @@ struct MeetingsView: View {
                         action: recentMeetingsEmptyAction
                     )
                 } else {
-                    recentMeetingRowsViewport
+                    recentMeetingRows
 
                     if viewModel.recentMeetingsViewModel.hasMore {
                         HStack {
@@ -432,14 +429,6 @@ struct MeetingsView: View {
                 }
             }
         }
-    }
-
-    private var recentMeetingRowsViewport: some View {
-        ScrollView {
-            recentMeetingRows
-        }
-        .scrollIndicators(.visible)
-        .frame(height: recentMeetingRowsViewportHeight)
     }
 
     private var recentMeetingRows: some View {
@@ -546,22 +535,6 @@ struct MeetingsView: View {
 
     private var shouldShowRecentMeetingSearch: Bool {
         !viewModel.recentMeetingsViewModel.transcriptions.isEmpty || !recentMeetingsSearchText.isEmpty
-    }
-
-    private var recentMeetingRowsViewportHeight: CGFloat {
-        min(
-            recentMeetingRowsEstimatedHeight,
-            Self.recentMeetingListMaximumHeight
-        )
-    }
-
-    private var recentMeetingRowsEstimatedHeight: CGFloat {
-        let groups = viewModel.recentMeetingsViewModel.groupedTranscriptions
-        let rowCount = groups.reduce(0) { partial, group in
-            partial + group.items.count
-        }
-        return CGFloat(rowCount) * Self.recentMeetingEstimatedRowHeight
-            + CGFloat(groups.count) * Self.recentMeetingEstimatedGroupHeaderHeight
     }
 
     private var recentMeetingsEmptyIcon: String {
@@ -695,9 +668,16 @@ private struct CalendarInlineControlsRow: View {
     @ViewBuilder
     private var controlsArea: some View {
         if controlsEnabled {
-            HStack(spacing: DesignSystem.Spacing.sm) {
-                calendarModePicker
-                eventFilterPicker
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: DesignSystem.Spacing.sm) {
+                    calendarModePicker
+                    eventFilterPicker
+                }
+
+                VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+                    calendarModePicker
+                    eventFilterPicker
+                }
             }
         } else {
             connectCalendarControls

--- a/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
+++ b/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
@@ -17,20 +17,30 @@ struct MeetingsView: View {
     @State private var showingAskPromptsSheet = false
     @State private var showingPromptLibrary = false
 
+    private static let rightRailWidth: CGFloat = 280
+    private static let twoColumnMinimumWidth: CGFloat = 1_100
+    private static let recentMeetingEstimatedRowHeight: CGFloat = 65
+    private static let recentMeetingEstimatedGroupHeaderHeight: CGFloat = 32
+    private static let recentMeetingListMaximumHeight: CGFloat = 540
+
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
-                header
-                recordingSurface
-                contentColumns
+        GeometryReader { proxy in
+            ScrollView {
+                VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
+                    header
+                    recordingSurface
+                    contentColumns(
+                        usesTwoColumnLayout: proxy.size.width >= Self.twoColumnMinimumWidth
+                    )
+                }
+                .padding(.horizontal, DesignSystem.Spacing.lg)
+                .padding(.top, DesignSystem.Spacing.lg)
+                .padding(.bottom, DesignSystem.Spacing.xl)
+                .frame(maxWidth: 1180, alignment: .topLeading)
             }
-            .padding(.horizontal, DesignSystem.Spacing.lg)
-            .padding(.top, DesignSystem.Spacing.lg)
-            .padding(.bottom, DesignSystem.Spacing.xl)
-            .frame(maxWidth: 1180, alignment: .topLeading)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .background(DesignSystem.Colors.contentBackground)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .background(DesignSystem.Colors.contentBackground)
         .onAppear {
             viewModel.refreshIfNeeded()
         }
@@ -114,32 +124,42 @@ struct MeetingsView: View {
         )
     }
 
-    private var contentColumns: some View {
-        ViewThatFits(in: .horizontal) {
-            HStack(alignment: .top, spacing: DesignSystem.Spacing.lg) {
-                VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
-                    upcomingSection
-                    recentMeetingsSection
-                }
-                .frame(minWidth: 480, maxWidth: .infinity, alignment: .topLeading)
-
-                VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
-                    attentionSection
-                    intelligenceSection
-                    autoNotesSection
-                    meetingPromptsSection
-                }
-                .frame(minWidth: 280, maxWidth: 340, alignment: .topLeading)
+    private func contentColumns(usesTwoColumnLayout: Bool) -> some View {
+        Group {
+            if usesTwoColumnLayout {
+                twoColumnContent
+            } else {
+                oneColumnContent
             }
+        }
+    }
 
+    private var twoColumnContent: some View {
+        HStack(alignment: .top, spacing: DesignSystem.Spacing.lg) {
             VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
                 upcomingSection
+                recentMeetingsSection
+            }
+            .frame(minWidth: 480, maxWidth: .infinity, alignment: .topLeading)
+
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
                 attentionSection
                 intelligenceSection
                 autoNotesSection
                 meetingPromptsSection
-                recentMeetingsSection
             }
+            .frame(width: Self.rightRailWidth, alignment: .topLeading)
+        }
+    }
+
+    private var oneColumnContent: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
+            upcomingSection
+            recentMeetingsSection
+            attentionSection
+            intelligenceSection
+            autoNotesSection
+            meetingPromptsSection
         }
     }
 
@@ -389,20 +409,7 @@ struct MeetingsView: View {
                         action: recentMeetingsEmptyAction
                     )
                 } else {
-                    ForEach(viewModel.recentMeetingsViewModel.groupedTranscriptions, id: \.group) { section in
-                        MeetingDateGroupHeader(group: section.group)
-                        ForEach(Array(section.items.enumerated()), id: \.element.id) { idx, transcription in
-                            MeetingRowCard(
-                                transcription: transcription,
-                                searchText: viewModel.recentMeetingsViewModel.searchText,
-                                onTap: { onSelectMeeting(transcription) },
-                                menuContent: { recentMeetingMenu(for: transcription) }
-                            )
-                            if idx < section.items.count - 1 {
-                                MeetingRowHairline()
-                            }
-                        }
-                    }
+                    recentMeetingRowsViewport
 
                     if viewModel.recentMeetingsViewModel.hasMore {
                         HStack {
@@ -421,6 +428,33 @@ struct MeetingsView: View {
                             Spacer()
                         }
                         .padding(.vertical, DesignSystem.Spacing.md)
+                    }
+                }
+            }
+        }
+    }
+
+    private var recentMeetingRowsViewport: some View {
+        ScrollView {
+            recentMeetingRows
+        }
+        .scrollIndicators(.visible)
+        .frame(height: recentMeetingRowsViewportHeight)
+    }
+
+    private var recentMeetingRows: some View {
+        LazyVStack(alignment: .leading, spacing: 0) {
+            ForEach(viewModel.recentMeetingsViewModel.groupedTranscriptions, id: \.group) { section in
+                MeetingDateGroupHeader(group: section.group)
+                ForEach(Array(section.items.enumerated()), id: \.element.id) { idx, transcription in
+                    MeetingRowCard(
+                        transcription: transcription,
+                        searchText: viewModel.recentMeetingsViewModel.searchText,
+                        onTap: { onSelectMeeting(transcription) },
+                        menuContent: { recentMeetingMenu(for: transcription) }
+                    )
+                    if idx < section.items.count - 1 {
+                        MeetingRowHairline()
                     }
                 }
             }
@@ -512,6 +546,22 @@ struct MeetingsView: View {
 
     private var shouldShowRecentMeetingSearch: Bool {
         !viewModel.recentMeetingsViewModel.transcriptions.isEmpty || !recentMeetingsSearchText.isEmpty
+    }
+
+    private var recentMeetingRowsViewportHeight: CGFloat {
+        min(
+            recentMeetingRowsEstimatedHeight,
+            Self.recentMeetingListMaximumHeight
+        )
+    }
+
+    private var recentMeetingRowsEstimatedHeight: CGFloat {
+        let groups = viewModel.recentMeetingsViewModel.groupedTranscriptions
+        let rowCount = groups.reduce(0) { partial, group in
+            partial + group.items.count
+        }
+        return CGFloat(rowCount) * Self.recentMeetingEstimatedRowHeight
+            + CGFloat(groups.count) * Self.recentMeetingEstimatedGroupHeaderHeight
     }
 
     private var recentMeetingsEmptyIcon: String {
@@ -645,16 +695,9 @@ private struct CalendarInlineControlsRow: View {
     @ViewBuilder
     private var controlsArea: some View {
         if controlsEnabled {
-            ViewThatFits(in: .horizontal) {
-                HStack(spacing: DesignSystem.Spacing.sm) {
-                    calendarModePicker
-                    eventFilterPicker
-                }
-
-                VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
-                    calendarModePicker
-                    eventFilterPicker
-                }
+            HStack(spacing: DesignSystem.Spacing.sm) {
+                calendarModePicker
+                eventFilterPicker
             }
         } else {
             connectCalendarControls


### PR DESCRIPTION
## Summary
The Meetings workspace no longer spikes layout work while the window is resized. The page now chooses one-column vs. two-column mode from a single width threshold instead of asking SwiftUI to measure both full layouts on every resize pass.

The final layout keeps the resize fix without trading away basic usability: Recent Meetings stays in the dashboard's single outer scroll flow, required attention items stay visible above history on narrow layouts, and calendar controls keep their compact local fallback for constrained widths.

## Performance Evidence

| Scenario | Before | After |
| --- | ---: | ---: |
| Meetings resize loop | ~53-68% CPU sustained | peaked around ~11% CPU |
| Transcribe to Meetings navigation loop | visibly janky | peaked around ~3% CPU |

Sampling showed the hot path was SwiftUI layout sizing (`NSHostingView.layout` / `LayoutEngineBox.sizeThatFits`), not database, STT, or audio work.

## Test Plan
- `swift build`
- `swift test --filter MeetingsWorkspaceViewModelTests` — 14 tests, 0 failures
- `swift test` — 3,152 tests, 10 skipped, 0 failures
- `git diff --check`
- Fresh read-only review pass on the final diff for SwiftUI layout, correctness, performance, maintainability, and verification gaps
- GitHub CI `swift-test` checks passed on d8715c71

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
