### PR TITLE
Revert system default microphone pinning

### DIFF
--- a/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
+++ b/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
@@ -90,9 +90,7 @@ public func meetingInputDeviceAttempts(
     }
 
     let defaultDeviceID = defaultInputDevice()
-    if selectedUID == nil, let defaultDeviceID {
-        appendExplicit(.systemDefault, deviceID: defaultDeviceID)
-    } else if let defaultDeviceID {
+    if let defaultDeviceID {
         seenDeviceIDs.insert(defaultDeviceID)
     }
     attempts.append(.implicitSystemDefault(resolvedDeviceID: defaultDeviceID))

--- a/Sources/MacParakeetCore/Audio/MicrophoneEnginePlatform.swift
+++ b/Sources/MacParakeetCore/Audio/MicrophoneEnginePlatform.swift
@@ -50,9 +50,9 @@ public protocol MicrophoneEnginePlatform: AnyObject, Sendable {
 ///   the VPAU aggregate device. A long-lived engine keeps the VPAU alive
 ///   indefinitely, which inherits the duplex layout into other engines.
 /// - When configured with a `deviceAttemptsBuilder`, each `configureAndStart`
-///   walks the resolved attempt list (selected → explicit systemDefault when
-///   System Default is selected → implicit systemDefault → builtIn) and
-///   recreates the engine on every failed attempt before trying the next.
+///   walks the resolved attempt list (selected → implicit systemDefault →
+///   builtIn) and recreates the engine on every failed attempt before trying
+///   the next — the same fallback shape `MicrophoneCapture` uses today.
 public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @unchecked Sendable {
     public typealias DeviceAttemptsBuilder = @Sendable () -> [MeetingInputDeviceAttempt]
     public typealias InputDeviceSetter = @Sendable (AudioDeviceID, AVAudioEngine) -> Bool

--- a/Tests/MacParakeetTests/Audio/MicrophoneCaptureTests.swift
+++ b/Tests/MacParakeetTests/Audio/MicrophoneCaptureTests.swift
@@ -346,28 +346,6 @@ final class MicrophoneCaptureTests: XCTestCase {
         )
     }
 
-    func testSystemDefaultSelectionPinsResolvedDefaultBeforeImplicitFallback() {
-        let attempts = meetingInputDeviceAttempts(
-            selectedUID: nil,
-            selectedInputDeviceID: { _ in nil },
-            defaultInputDevice: { AudioDeviceID(20) },
-            builtInMicrophone: { AudioDeviceID(30) }
-        )
-
-        XCTAssertEqual(
-            attempts,
-            [
-                MeetingInputDeviceAttempt(source: .systemDefault, deviceID: 20),
-                .implicitSystemDefault(resolvedDeviceID: 20),
-                MeetingInputDeviceAttempt(source: .builtIn, deviceID: 30),
-            ]
-        )
-        XCTAssertFalse(attempts[0].usesImplicitSystemDefault)
-        XCTAssertTrue(attempts[1].usesImplicitSystemDefault)
-        XCTAssertEqual(attempts[0].explicitDeviceID, 20)
-        XCTAssertNil(attempts[1].explicitDeviceID)
-    }
-
     func testInputDeviceAttemptsDeduplicateDefaultAndBuiltIn() {
         let attempts = meetingInputDeviceAttempts(
             selectedUID: nil,
@@ -379,7 +357,6 @@ final class MicrophoneCaptureTests: XCTestCase {
         XCTAssertEqual(
             attempts,
             [
-                MeetingInputDeviceAttempt(source: .systemDefault, deviceID: 30),
                 .implicitSystemDefault(resolvedDeviceID: 30),
             ]
         )
@@ -455,67 +432,6 @@ final class MicrophoneCaptureTests: XCTestCase {
         defer { platform.stopEngine() }
 
         XCTAssertEqual(recorder.deviceIDs, [10])
-        XCTAssertEqual(platform.lastSucceededAttempt, .implicitSystemDefault(resolvedDeviceID: 20))
-    }
-
-    func testPlatformFallsBackToImplicitSystemDefaultWhenExplicitDefaultSetFails() throws {
-        let recorder = MicrophoneCaptureInputDeviceSetterRecorder()
-        let platform = AVAudioEngineMicrophonePlatform(
-            deviceAttemptsBuilder: {
-                [
-                    MeetingInputDeviceAttempt(source: .systemDefault, deviceID: 20),
-                    .implicitSystemDefault(resolvedDeviceID: 20),
-                ]
-            },
-            inputDeviceSetter: { deviceID, _ in
-                recorder.record(deviceID)
-                return false
-            },
-            engineStarter: { _, _, _, _ in }
-        )
-
-        try platform.configureAndStart(
-            vpioEnabled: false,
-            bufferSize: 1024,
-            tapHandler: { _, _ in }
-        )
-        defer { platform.stopEngine() }
-
-        XCTAssertEqual(recorder.deviceIDs, [20])
-        XCTAssertEqual(platform.lastSucceededAttempt, .implicitSystemDefault(resolvedDeviceID: 20))
-    }
-
-    func testPlatformFallsBackToImplicitSystemDefaultWhenExplicitDefaultStartFails() throws {
-        let recorder = MicrophoneCaptureInputDeviceSetterRecorder()
-        let startAttempts = MicrophoneCaptureTestCounter()
-        let platform = AVAudioEngineMicrophonePlatform(
-            deviceAttemptsBuilder: {
-                [
-                    MeetingInputDeviceAttempt(source: .systemDefault, deviceID: 20),
-                    .implicitSystemDefault(resolvedDeviceID: 20),
-                ]
-            },
-            inputDeviceSetter: { deviceID, _ in
-                recorder.record(deviceID)
-                return true
-            },
-            engineStarter: { _, _, _, _ in
-                startAttempts.increment()
-                if startAttempts.value == 1 {
-                    throw MicrophoneCaptureMockError.simulatedFailure
-                }
-            }
-        )
-
-        try platform.configureAndStart(
-            vpioEnabled: false,
-            bufferSize: 1024,
-            tapHandler: { _, _ in }
-        )
-        defer { platform.stopEngine() }
-
-        XCTAssertEqual(recorder.deviceIDs, [20])
-        XCTAssertEqual(startAttempts.value, 2)
         XCTAssertEqual(platform.lastSucceededAttempt, .implicitSystemDefault(resolvedDeviceID: 20))
     }
 


### PR DESCRIPTION
## Summary
- Reverts 20f4daac ("Pin system default microphone before implicit fallback")
- Restores implicit system-default microphone routing for no-selected-device captures
- Removes the v0.6.17-specific test expectations that pinned the current system default device

Fixes #421

## Testing
- swift test --filter MicrophoneCaptureTests
- swift test