### PR TITLE
Hide app-aware AI formatter profiles for release

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -183,10 +183,17 @@ final class AppEnvironment {
         let aiFormatterPromptClosure: @Sendable () -> String = { [runtimePreferences] in
             runtimePreferences.aiFormatterPrompt
         }
-        let aiFormatterPromptResolver = AIFormatterProfilePromptResolver(
-            profileRepository: aiFormatterProfileRepo,
-            globalPromptTemplate: aiFormatterPromptClosure
-        )
+        let aiFormatterPromptResolver: any AIFormatterPromptResolving
+        if AppFeatures.aiFormatterProfilesEnabled {
+            aiFormatterPromptResolver = AIFormatterProfilePromptResolver(
+                profileRepository: aiFormatterProfileRepo,
+                globalPromptTemplate: aiFormatterPromptClosure
+            )
+        } else {
+            aiFormatterPromptResolver = AIFormatterGlobalPromptResolver(
+                promptTemplate: aiFormatterPromptClosure
+            )
+        }
 
         llmClient = RoutingLLMClient()
         llmConfigStore = LLMConfigStore()

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -152,7 +152,7 @@ final class AppEnvironmentConfigurer {
         llmSettingsViewModel.configure(
             configStore: env.llmConfigStore,
             llmClient: env.llmClient,
-            aiFormatterProfileRepo: env.aiFormatterProfileRepo
+            aiFormatterProfileRepo: AppFeatures.aiFormatterProfilesEnabled ? env.aiFormatterProfileRepo : nil
         )
 
         settingsViewModel.onDictationStateChanged = { [weak self] in

--- a/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
@@ -409,10 +409,12 @@ struct LLMSettingsView: View {
                 }
             }
 
-            Divider()
+            if AppFeatures.aiFormatterProfilesEnabled {
+                Divider()
 
-            aiFormatterProfilesSection
-                .id("ai.formatter")
+                aiFormatterProfilesSection
+                    .id("ai.formatter")
+            }
         }
     }
 

--- a/Sources/MacParakeetCore/AppFeatures.swift
+++ b/Sources/MacParakeetCore/AppFeatures.swift
@@ -50,4 +50,10 @@ public enum AppFeatures {
     /// clean inline performance and Phase 4.5 made model prep universal. Keep
     /// `vad_model_prep` allowlisted and deployed before shipping flag-on builds.
     public static let meetingVadLiveChunkingEnabled: Bool = true
+
+    /// App-aware AI Formatter profiles. When `false`, profile management is
+    /// hidden from Settings/search and dictation uses only the global formatter
+    /// prompt. The profile table and repository still migrate so enabling this
+    /// later does not require a data-model catch-up release.
+    public static let aiFormatterProfilesEnabled: Bool = false
 }

--- a/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
+++ b/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
@@ -73,9 +73,9 @@ public struct SettingsSearchEntry: Identifiable, Hashable, Sendable {
 /// Anchor drift is currently caught by manual review — the index and
 /// the view are coupled by string convention, not by a compiler check.
 ///
-/// **Feature flags:** entries pointing at meeting-recording surfaces
-/// are filtered out when `AppFeatures.meetingRecordingEnabled` is
-/// `false`, so search never lands on a card or row that won't render.
+/// **Feature flags:** entries pointing at gated surfaces are filtered out
+/// when their `AppFeatures` flag is `false`, so search never lands on a
+/// card or row that won't render.
 public enum SettingsSearchIndex {
     /// Ids whose destination card or row is gated on
     /// `AppFeatures.meetingRecordingEnabled`. When the flag is off these
@@ -94,6 +94,13 @@ public enum SettingsSearchIndex {
         "meeting.calendar"
     ]
 
+    /// Ids gated on `AppFeatures.aiFormatterProfilesEnabled`. The global AI
+    /// Formatter prompt remains visible via `ai.provider`; only app/category
+    /// profile management is hidden by this gate.
+    private static let aiFormatterProfileGatedIds: Set<String> = [
+        "ai.formatter"
+    ]
+
     public static let entries: [SettingsSearchEntry] = {
         var result = allEntries
         if !AppFeatures.meetingRecordingEnabled {
@@ -101,6 +108,9 @@ public enum SettingsSearchIndex {
         }
         if !AppFeatures.calendarEnabled {
             result = result.filter { !calendarGatedIds.contains($0.id) }
+        }
+        if !AppFeatures.aiFormatterProfilesEnabled {
+            result = result.filter { !aiFormatterProfileGatedIds.contains($0.id) }
         }
         return result
     }()

--- a/Tests/MacParakeetTests/ViewModels/SettingsSearchIndexTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsSearchIndexTests.swift
@@ -107,8 +107,12 @@ final class SettingsSearchIndexTests: XCTestCase {
     }
 
     func testAIFormatterSearchEntryUsesFormatterAnchor() throws {
-        let entry = try XCTUnwrap(SettingsSearchIndex.entries.first { $0.id == "ai.formatter" })
-        XCTAssertEqual(entry.cardAnchor, "ai.formatter")
+        let entry = SettingsSearchIndex.entries.first { $0.id == "ai.formatter" }
+        if AppFeatures.aiFormatterProfilesEnabled {
+            XCTAssertEqual(try XCTUnwrap(entry).cardAnchor, "ai.formatter")
+        } else {
+            XCTAssertNil(entry)
+        }
     }
 
     func testEveryTabHasAtLeastOneEntry() {


### PR DESCRIPTION
## Summary
- add a release-off `AppFeatures.aiFormatterProfilesEnabled` flag
- hide AI Formatter profile management from Settings and Settings search while the flag is false
- route dictation through the global AI Formatter prompt resolver while profiles are hidden
- keep profile migrations/repository/tests intact so the feature can be re-enabled later without schema catch-up

## Testing
- `swift test --filter 'SettingsSearchIndexTests|LLMSettingsViewModelTests|DictationServiceTests|AIFormatterProfile'`\n- `swift test --filter MicrophoneCaptureTests`\n- `swift test`\n\nFull suite result: 3182 XCTest tests, 10 expected skips, 0 failures; 16 Swift Testing tests, 0 failures.