### PR TITLE
refactor(settings): focus Capture tab around workflows

### DIFF
--- a/Sources/MacParakeet/Views/MainWindowState.swift
+++ b/Sources/MacParakeet/Views/MainWindowState.swift
@@ -7,12 +7,14 @@ import MacParakeetViewModels
 final class MainWindowState {
     var selectedItem: SidebarItem = .transcribe
     var requestedSettingsTab: SettingsTab?
+    var requestedSettingsAnchor: String?
     var requestedSettingsTabRevision = 0
     var showingProgressDetail = false
 
-    func navigateToSettings(tab: SettingsTab? = nil) {
+    func navigateToSettings(tab: SettingsTab? = nil, anchor: String? = nil) {
         requestedSettingsTab = tab
-        if tab != nil {
+        requestedSettingsAnchor = anchor
+        if tab != nil || anchor != nil {
             requestedSettingsTabRevision += 1
         }
         selectedItem = .settings
@@ -35,6 +37,7 @@ final class MainWindowState {
 
     func consumeRequestedSettingsTab() {
         requestedSettingsTab = nil
+        requestedSettingsAnchor = nil
     }
 
     /// Transforms tab — pending sheet state (ADR-022). When non-nil the

--- a/Sources/MacParakeet/Views/MainWindowView.swift
+++ b/Sources/MacParakeet/Views/MainWindowView.swift
@@ -135,7 +135,7 @@ struct MainWindowView: View {
                             },
                             onPauseToggleMeeting: onPauseToggleMeeting,
                             onOpenCalendarSettings: {
-                                state.navigateToSettings(tab: .modes)
+                                state.navigateToSettings(tab: .capture, anchor: "meeting")
                             },
                             onOpenAISettings: {
                                 state.navigateToSettings(tab: .ai)
@@ -259,6 +259,7 @@ struct MainWindowView: View {
                             updater: updater,
                             transformHotkeys: transformsViewModel.transforms,
                             requestedTab: state.requestedSettingsTab,
+                            requestedAnchor: state.requestedSettingsAnchor,
                             requestedTabRevision: state.requestedSettingsTabRevision,
                             onRequestedTabConsumed: {
                                 state.consumeRequestedSettingsTab()

--- a/Sources/MacParakeet/Views/Settings/Components/SettingsTabBar.swift
+++ b/Sources/MacParakeet/Views/Settings/Components/SettingsTabBar.swift
@@ -115,8 +115,8 @@ enum SettingsTabMetadata {
 
     static func `for`(_ tab: SettingsTab) -> Info {
         switch tab {
-        case .modes:
-            return Info(title: "Modes", systemImage: "rectangle.3.group", keyboardShortcut: "1", shortcutDigit: "1")
+        case .capture:
+            return Info(title: "Capture", systemImage: "waveform", keyboardShortcut: "1", shortcutDigit: "1")
         case .engine:
             return Info(title: "Engine", systemImage: "cpu", keyboardShortcut: "2", shortcutDigit: "2")
         case .ai:
@@ -128,7 +128,7 @@ enum SettingsTabMetadata {
 }
 
 #Preview("Light — clean", traits: .fixedLayout(width: 640, height: 120)) {
-    @Previewable @State var tab: SettingsTab = .modes
+    @Previewable @State var tab: SettingsTab = .capture
 
     return SettingsTabBar(activeTab: $tab, tabBadges: [:])
         .padding()
@@ -142,7 +142,7 @@ enum SettingsTabMetadata {
     return SettingsTabBar(
         activeTab: $tab,
         tabBadges: [
-            .modes: .recommended,
+            .capture: .recommended,
             .engine: .required,
             .system: .recommended
         ]
@@ -158,7 +158,7 @@ enum SettingsTabMetadata {
     return SettingsTabBar(
         activeTab: $tab,
         tabBadges: [
-            .modes: .recommended,
+            .capture: .recommended,
             .engine: .required
         ]
     )

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -111,12 +111,47 @@ enum SettingsDictationHotkeyDisplay {
     }
 }
 
+private extension SettingsCaptureWorkflow {
+    var title: LocalizedStringKey {
+        switch self {
+        case .dictation: "Dictation"
+        case .transcription: "Transcription"
+        case .meetings: "Meetings"
+        }
+    }
+
+    var eyebrow: LocalizedStringKey {
+        switch self {
+        case .dictation: "Anywhere"
+        case .transcription: "Files & URLs"
+        case .meetings: "Calls"
+        }
+    }
+
+    var detail: LocalizedStringKey {
+        switch self {
+        case .dictation: "Hotkeys, overlay, silence, and paste behavior."
+        case .transcription: "File, YouTube, speaker, notification, and save options."
+        case .meetings: "System audio, recovery, auto-save, and calendar setup."
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .dictation: "waveform"
+        case .transcription: "doc.text"
+        case .meetings: "record.circle"
+        }
+    }
+}
+
 struct SettingsView: View {
     @Bindable var viewModel: SettingsViewModel
     @Bindable var llmSettingsViewModel: LLMSettingsViewModel
     let updater: SPUUpdater
     let transformHotkeys: [Prompt]
     let requestedTab: SettingsTab?
+    let requestedAnchor: String?
     let requestedTabRevision: Int
     let onRequestedTabConsumed: () -> Void
     /// Fired by each `HotkeyRecorderView` when it starts/stops capturing
@@ -147,6 +182,7 @@ struct SettingsView: View {
         updater: SPUUpdater,
         transformHotkeys: [Prompt] = [],
         requestedTab: SettingsTab? = nil,
+        requestedAnchor: String? = nil,
         requestedTabRevision: Int = 0,
         onRequestedTabConsumed: @escaping () -> Void = {},
         onHotkeyRecordingStateChanged: @escaping (Bool) -> Void
@@ -156,6 +192,7 @@ struct SettingsView: View {
         self.updater = updater
         self.transformHotkeys = transformHotkeys
         self.requestedTab = requestedTab
+        self.requestedAnchor = requestedAnchor
         self.requestedTabRevision = requestedTabRevision
         self.onRequestedTabConsumed = onRequestedTabConsumed
         self.onHotkeyRecordingStateChanged = onHotkeyRecordingStateChanged
@@ -187,8 +224,8 @@ struct SettingsView: View {
                     )
                 } else {
                     switch rootViewModel.activeTab {
-                    case .modes:
-                        modesTabContent
+                    case .capture:
+                        captureTabContent
                     case .engine:
                         engineTabContent
                     case .ai:
@@ -219,13 +256,14 @@ struct SettingsView: View {
             Task { await viewModel.refreshCalendarNotificationAuthorization() }
         }
         .onAppear {
-            if requestedTab != nil {
+            if requestedTab != nil || requestedAnchor != nil {
+                openRequestedSettingsDestination(tab: requestedTab, anchor: requestedAnchor)
                 onRequestedTabConsumed()
             }
         }
         .onChange(of: requestedTabRevision) { _, _ in
-            if let requestedTab {
-                rootViewModel.open(tab: requestedTab)
+            if requestedTab != nil || requestedAnchor != nil {
+                openRequestedSettingsDestination(tab: requestedTab, anchor: requestedAnchor)
                 onRequestedTabConsumed()
             }
         }
@@ -284,16 +322,16 @@ struct SettingsView: View {
     private var tabBadges: [SettingsTab: SettingsStatusChip.Status] {
         var badges: [SettingsTab: SettingsStatusChip.Status] = [:]
 
-        var modesStatuses: [SettingsCardStatus?] = [
+        var captureStatuses: [SettingsCardStatus?] = [
             viewModel.microphoneGranted
                 ? SettingsCardStatus(.ok, label: "Granted")
                 : SettingsCardStatus(.required, label: "Permission required")
         ]
         if AppFeatures.meetingRecordingEnabled {
-            modesStatuses.append(meetingRecordingCardStatus)
+            captureStatuses.append(meetingRecordingCardStatus)
         }
-        if let badge = Self.attentionBadge(for: modesStatuses) {
-            badges[.modes] = badge
+        if let badge = Self.attentionBadge(for: captureStatuses) {
+            badges[.capture] = badge
         }
 
         if let badge = Self.attentionBadge(for: [
@@ -332,9 +370,50 @@ struct SettingsView: View {
     /// 3. Clear the search query — this also drops `isSearching` to
     ///    false. SwiftUI batches these so the user perceives one swap.
     private func handleSearchResultTap(_ entry: SettingsSearchEntry) {
-        pendingScrollTarget = entry.cardAnchor
+        if entry.tab == .capture, let section = captureSection(for: entry.cardAnchor) {
+            rootViewModel.activeCaptureWorkflow = section
+        }
+        pendingScrollTarget = normalizedScrollAnchor(for: entry.cardAnchor, tab: entry.tab)
         rootViewModel.activeTab = entry.tab
         rootViewModel.clearSearch()
+    }
+
+    private func openRequestedSettingsDestination(tab: SettingsTab?, anchor: String?) {
+        let destinationTab = tab ?? rootViewModel.activeTab
+        if destinationTab == .capture, let anchor, let section = captureSection(for: anchor) {
+            rootViewModel.activeCaptureWorkflow = section
+        }
+        if let anchor {
+            pendingScrollTarget = normalizedScrollAnchor(for: anchor, tab: destinationTab)
+        }
+        rootViewModel.open(tab: destinationTab)
+    }
+
+    private func normalizedScrollAnchor(for anchor: String, tab: SettingsTab) -> String {
+        guard tab == .capture, let section = captureSection(for: anchor) else {
+            return anchor
+        }
+        switch section {
+        case .dictation:
+            return "dictation"
+        case .transcription:
+            return "transcription"
+        case .meetings:
+            return "meeting"
+        }
+    }
+
+    private func captureSection(for anchor: String) -> SettingsCaptureWorkflow? {
+        if anchor.hasPrefix("dictation") {
+            return .dictation
+        }
+        if anchor.hasPrefix("transcription") {
+            return .transcription
+        }
+        if anchor.hasPrefix("meeting") {
+            return AppFeatures.meetingRecordingEnabled ? .meetings : nil
+        }
+        return nil
     }
 
     /// Hidden button that registers ⌘F as a focus shortcut. Lives in a
@@ -350,21 +429,27 @@ struct SettingsView: View {
         .accessibilityHidden(true)
     }
 
-    /// Modes tab — daily-ops config for the three product modes, plus the
-    /// Audio Input prerequisite that gates them. The legacy `headerCard`
-    /// "Workspace Controls" was eliminated (its stat chips are redundant
-    /// with Storage / Permissions / per-mode chips). The legacy `generalCard`
-    /// was split: "Show idle pill" lives on the Dictation card now;
-    /// Launch at Login + Menu Bar Only moved to the System Startup card.
-    /// The Calendar card was folded into Meeting Recording.
-    private var modesTabContent: some View {
+    /// Capture tab — daily-ops config for the three product workflows. The
+    /// shared microphone strip stays above the workflow picker because input is
+    /// a capture prerequisite, not a fourth mode.
+    private var captureTabContent: some View {
         scrollableTabBody {
-            audioInputCard.id("audio.input")
-            dictationCard.id("dictation")
-            transcriptionCard.id("transcription")
-            if AppFeatures.meetingRecordingEnabled {
-                meetingRecordingCard.id("meeting")
+            captureMicrophoneStrip.id("audio.input")
+            captureWorkflowSwitcher
+
+            Group {
+                switch displayedCaptureWorkflow {
+                case .dictation:
+                    dictationCard.id("dictation")
+                case .transcription:
+                    transcriptionCard.id("transcription")
+                case .meetings:
+                    if AppFeatures.meetingRecordingEnabled {
+                        meetingRecordingCard.id("meeting")
+                    }
+                }
             }
+            .animation(DesignSystem.Animation.contentSwap, value: rootViewModel.activeCaptureWorkflow)
         }
     }
 
@@ -538,84 +623,199 @@ struct SettingsView: View {
         }
     }
 
-    // MARK: - Audio Input
+    // MARK: - Capture
 
-    private var audioInputCard: some View {
-        SettingsCard(
-            title: "Audio Input",
-            subtitle: "Choose the microphone used for dictation and meetings.",
-            icon: "mic",
-            status: viewModel.microphoneGranted
-                ? SettingsCardStatus(.ok, label: "Granted")
-                : SettingsCardStatus(.required, label: "Permission required")
-        ) {
-            VStack(spacing: DesignSystem.Spacing.md) {
-                HStack(alignment: .center) {
-                    rowText(
-                        title: "Microphone",
-                        detail: viewModel.selectedMicrophoneStatusText
+    private var availableCaptureSections: [SettingsCaptureWorkflow] {
+        SettingsCaptureWorkflow.allCases.filter { section in
+            section != .meetings || AppFeatures.meetingRecordingEnabled
+        }
+    }
+
+    private var displayedCaptureWorkflow: SettingsCaptureWorkflow {
+        if availableCaptureSections.contains(rootViewModel.activeCaptureWorkflow) {
+            return rootViewModel.activeCaptureWorkflow
+        }
+        return .dictation
+    }
+
+    private var captureMicrophoneStrip: some View {
+        VStack(spacing: DesignSystem.Spacing.md) {
+            HStack(alignment: .center, spacing: DesignSystem.Spacing.md) {
+                Image(systemName: "mic")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(DesignSystem.Colors.accent)
+                    .frame(width: 30, height: 30)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(DesignSystem.Colors.accent.opacity(0.12))
                     )
-                    Spacer(minLength: DesignSystem.Spacing.md)
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 2) {
                     HStack(spacing: DesignSystem.Spacing.sm) {
-                        Picker("Microphone", selection: $viewModel.selectedMicrophoneDeviceUID) {
-                            Text("System Default").tag(SettingsViewModel.systemDefaultMicrophoneSelection)
-                            ForEach(viewModel.microphoneDeviceOptions) { device in
-                                Text(device.displayName).tag(device.uid)
-                                    .disabled(!device.isAvailable)
-                            }
-                        }
-                        .labelsHidden()
-                        .frame(minWidth: 220, idealWidth: 260, maxWidth: 320)
-
-                        Button {
-                            viewModel.refreshMicrophoneDevices()
-                        } label: {
-                            Image(systemName: "arrow.clockwise")
-                        }
-                        .parakeetAction(.secondary)
-                        .help("Refresh microphones")
-                        .accessibilityLabel("Refresh microphones")
-                    }
-                }
-
-                Divider()
-
-                HStack(alignment: .center, spacing: DesignSystem.Spacing.md) {
-                    microphoneTestStatus
-                    Spacer(minLength: DesignSystem.Spacing.md)
-                    Button {
-                        switch viewModel.microphoneTestState {
-                        case .testing:
-                            viewModel.cancelMicrophoneTest()
-                        default:
-                            viewModel.testSelectedMicrophone()
-                        }
-                    } label: {
-                        Label(
-                            viewModel.microphoneTestState == .testing ? "Stop Test" : "Test Input",
-                            systemImage: viewModel.microphoneTestState == .testing ? "stop.fill" : "waveform"
+                        Text("Microphone")
+                            .font(DesignSystem.Typography.body.weight(.semibold))
+                        SettingsStatusChip(
+                            status: viewModel.microphoneGranted ? .ok : .required,
+                            label: viewModel.microphoneGranted ? "Granted" : "Permission required"
                         )
                     }
-                    .parakeetAction(.primaryProminent)
-                    .disabled(!viewModel.microphoneGranted && viewModel.microphoneTestState != .testing)
+                    Text(viewModel.selectedMicrophoneStatusText)
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+                .layoutPriority(1)
+
+                Spacer(minLength: DesignSystem.Spacing.md)
+
+                HStack(spacing: DesignSystem.Spacing.sm) {
+                    Picker("Microphone", selection: $viewModel.selectedMicrophoneDeviceUID) {
+                        Text("System Default").tag(SettingsViewModel.systemDefaultMicrophoneSelection)
+                        ForEach(viewModel.microphoneDeviceOptions) { device in
+                            Text(device.displayName).tag(device.uid)
+                                .disabled(!device.isAvailable)
+                        }
+                    }
+                    .labelsHidden()
+                    .frame(minWidth: 160, idealWidth: 220, maxWidth: 280)
+
+                    Button {
+                        viewModel.refreshMicrophoneDevices()
+                    } label: {
+                        Image(systemName: "arrow.clockwise")
+                    }
+                    .parakeetAction(.secondary)
+                    .help("Refresh microphones")
+                    .accessibilityLabel("Refresh microphones")
+                }
+            }
+
+            Divider()
+
+            HStack(alignment: .center, spacing: DesignSystem.Spacing.md) {
+                HStack(spacing: DesignSystem.Spacing.sm) {
+                    microphoneLevelMeter(level: viewModel.microphoneTestLevel)
+                    Text(microphoneTestTitle)
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(microphoneTestDetailColor)
+                        .lineLimit(1)
+                        .frame(minWidth: 82, alignment: .leading)
+                }
+
+                Spacer()
+
+                Button {
+                    switch viewModel.microphoneTestState {
+                    case .testing:
+                        viewModel.cancelMicrophoneTest()
+                    default:
+                        viewModel.testSelectedMicrophone()
+                    }
+                } label: {
+                    Label(
+                        viewModel.microphoneTestState == .testing ? "Stop" : "Test Input",
+                        systemImage: viewModel.microphoneTestState == .testing ? "stop.fill" : "waveform"
+                    )
+                }
+                .parakeetAction(.primaryProminent)
+                .disabled(!viewModel.microphoneGranted && viewModel.microphoneTestState != .testing)
+                .help(microphoneTestDetail)
+            }
+        }
+        .padding(.horizontal, DesignSystem.Spacing.lg)
+        .padding(.vertical, DesignSystem.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
+                .fill(DesignSystem.Colors.cardBackground)
+                .cardShadow(DesignSystem.Shadows.cardRest)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
+                .strokeBorder(DesignSystem.Colors.border.opacity(0.6), lineWidth: 0.5)
+        )
+    }
+
+    private var captureWorkflowSwitcher: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            Text("Capture workflow")
+                .font(DesignSystem.Typography.caption.weight(.semibold))
+                .textCase(.uppercase)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: DesignSystem.Spacing.sm) {
+                ForEach(availableCaptureSections) { section in
+                    captureWorkflowButton(section)
                 }
             }
         }
+        .id("capture.workflow")
     }
 
-    private var microphoneTestStatus: some View {
-        HStack(spacing: DesignSystem.Spacing.sm) {
-            microphoneLevelMeter(level: viewModel.microphoneTestLevel)
-            VStack(alignment: .leading, spacing: 2) {
-                Text(microphoneTestTitle)
-                    .font(DesignSystem.Typography.body)
-                Text(microphoneTestDetail)
+    private func captureWorkflowButton(_ section: SettingsCaptureWorkflow) -> some View {
+        let isActive = section == displayedCaptureWorkflow
+        return Button {
+            rootViewModel.activeCaptureWorkflow = section
+        } label: {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+                HStack(alignment: .center, spacing: DesignSystem.Spacing.sm) {
+                    Image(systemName: section.systemImage)
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(isActive ? DesignSystem.Colors.accent : DesignSystem.Colors.textSecondary)
+                        .frame(width: 28, height: 28)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(isActive ? DesignSystem.Colors.accent.opacity(0.14) : DesignSystem.Colors.surfaceElevated)
+                        )
+
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(section.eyebrow)
+                            .font(DesignSystem.Typography.micro.weight(.semibold))
+                            .foregroundStyle(isActive ? DesignSystem.Colors.accent : DesignSystem.Colors.textTertiary)
+                        Text(section.title)
+                            .font(DesignSystem.Typography.body.weight(.semibold))
+                            .foregroundStyle(DesignSystem.Colors.textPrimary)
+                    }
+
+                    Spacer(minLength: DesignSystem.Spacing.sm)
+
+                    if isActive {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(DesignSystem.Colors.accent)
+                    }
+                }
+
+                Text(section.detail)
                     .font(DesignSystem.Typography.caption)
-                    .foregroundStyle(microphoneTestDetailColor)
+                    .foregroundStyle(.secondary)
                     .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
             }
+            .padding(DesignSystem.Spacing.md)
+            .frame(maxWidth: .infinity, minHeight: 94, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
+                    .fill(isActive ? DesignSystem.Colors.accentLight : DesignSystem.Colors.cardBackground)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
+                    .strokeBorder(
+                        isActive ? DesignSystem.Colors.accent.opacity(0.75) : DesignSystem.Colors.border.opacity(0.55),
+                        lineWidth: isActive ? 1 : 0.5
+                    )
+            )
+            .contentShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius))
         }
+        .buttonStyle(.plain)
+        .accessibilityLabel(section.title)
+        .accessibilityHint(section.detail)
+        .accessibilityAddTraits(isActive ? .isSelected : [])
     }
+
+    // MARK: - Microphone Helpers
 
     private var microphoneTestTitle: String {
         switch viewModel.microphoneTestState {

--- a/Sources/MacParakeetViewModels/SettingsRootViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsRootViewModel.swift
@@ -1,18 +1,31 @@
 import Foundation
 
+public enum SettingsCaptureWorkflow: String, CaseIterable, Identifiable, Sendable {
+    case dictation
+    case transcription
+    case meetings
+
+    public var id: String { rawValue }
+
+    public static let `default`: SettingsCaptureWorkflow = .dictation
+}
+
 /// Coordinator view-model for the tabbed Settings panel.
 ///
 /// Owns purely-UI state that spans tabs:
 /// - `activeTab` — currently visible tab; persisted across launches via
 ///   UserDefaults so a user who lives in System (e.g. while auditing
 ///   permissions) returns there on next launch.
+/// - `activeCaptureWorkflow` — currently selected workflow inside the Capture
+///   tab; persisted so reopening Settings keeps the user's place.
 /// - `searchQuery` — top-of-panel search text; non-empty switches the panel
 ///   into flat-results mode.
 ///
-/// Intentionally **does not** own per-tab state. Sub-VMs (`Modes`, `Engine`,
-/// `AI`, `System`) will be wired in subsequent commits and addressed by the
-/// parent view, not stored here. Keeping this VM small is the explicit
-/// remedy for the 1,265-line god-object pattern that motivated the split.
+/// Intentionally does not own settings forms or service state. Sub-VMs
+/// (`Capture`, `Engine`, `AI`, `System`) will be wired in subsequent commits
+/// and addressed by the parent view, not stored here. Keeping this VM small is
+/// the explicit remedy for the 1,265-line god-object pattern that motivated
+/// the split.
 @MainActor
 @Observable
 public final class SettingsRootViewModel {
@@ -20,6 +33,7 @@ public final class SettingsRootViewModel {
     /// because it is a UI-only preference and does not belong in the runtime
     /// preferences contract consumed by Core services.
     public static let lastViewedTabKey = "settings.lastViewedTab"
+    public static let lastCaptureWorkflowKey = "settings.capture.lastWorkflow"
 
     public var activeTab: SettingsTab {
         didSet {
@@ -29,6 +43,13 @@ public final class SettingsRootViewModel {
     }
 
     public var searchQuery: String = ""
+
+    public var activeCaptureWorkflow: SettingsCaptureWorkflow {
+        didSet {
+            guard activeCaptureWorkflow != oldValue else { return }
+            defaults.set(activeCaptureWorkflow.rawValue, forKey: Self.lastCaptureWorkflowKey)
+        }
+    }
 
     /// `true` when the user has typed something into the search field. The
     /// view collapses the tab layout into flat results in this state.
@@ -44,6 +65,12 @@ public final class SettingsRootViewModel {
 
     public init(defaults: UserDefaults = .standard, initialTab: SettingsTab? = nil) {
         self.defaults = defaults
+        if let raw = defaults.string(forKey: Self.lastCaptureWorkflowKey),
+           let restored = SettingsCaptureWorkflow(rawValue: raw) {
+            self.activeCaptureWorkflow = restored
+        } else {
+            self.activeCaptureWorkflow = .default
+        }
         if let initialTab {
             self.activeTab = initialTab
             defaults.set(initialTab.rawValue, forKey: Self.lastViewedTabKey)

--- a/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
+++ b/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
@@ -119,10 +119,10 @@ public enum SettingsSearchIndex {
     /// by `entries.filter(...)`, and tests assert that the filter is
     /// stable in index order.
     private static let allEntries: [SettingsSearchEntry] = [
-        // MARK: Modes
+        // MARK: Capture
         SettingsSearchEntry(
             id: "audio.input",
-            tab: .modes,
+            tab: .capture,
             title: "Audio Input",
             subtitle: "Choose the microphone used for dictation and meetings.",
             keywords: ["microphone", "mic", "input device", "audio device"],
@@ -130,7 +130,7 @@ public enum SettingsSearchIndex {
         ),
         SettingsSearchEntry(
             id: "dictation",
-            tab: .modes,
+            tab: .capture,
             title: "Dictation",
             subtitle: "Hotkey, silence detection, and overlay behavior.",
             keywords: ["hotkey", "fn key", "shortcut", "voice", "dictate", "talk", "press to talk"],
@@ -138,7 +138,7 @@ public enum SettingsSearchIndex {
         ),
         SettingsSearchEntry(
             id: "dictation.idle.pill",
-            tab: .modes,
+            tab: .capture,
             title: "Show idle pill at all times",
             subtitle: "in Dictation",
             keywords: ["pill", "indicator", "always visible", "menu bar", "floating"],
@@ -146,7 +146,7 @@ public enum SettingsSearchIndex {
         ),
         SettingsSearchEntry(
             id: "dictation.keep.clipboard",
-            tab: .modes,
+            tab: .capture,
             title: "Keep dictation on clipboard",
             subtitle: "in Dictation",
             keywords: ["clipboard", "copy", "paste", "cmd v", "command v", "transcript", "retain", "remote"],
@@ -154,7 +154,7 @@ public enum SettingsSearchIndex {
         ),
         SettingsSearchEntry(
             id: "transcription",
-            tab: .modes,
+            tab: .capture,
             title: "Transcription",
             subtitle: "How file and YouTube transcription behaves.",
             keywords: ["file", "youtube", "drag drop", "audio file", "video file", "transcribe"],
@@ -162,7 +162,7 @@ public enum SettingsSearchIndex {
         ),
         SettingsSearchEntry(
             id: "transcription.hotkey.file",
-            tab: .modes,
+            tab: .capture,
             title: "File transcription hotkey",
             subtitle: "in Transcription",
             keywords: ["hotkey", "shortcut", "file", "drag drop", "audio file", "video file"],
@@ -170,7 +170,7 @@ public enum SettingsSearchIndex {
         ),
         SettingsSearchEntry(
             id: "transcription.hotkey.youtube",
-            tab: .modes,
+            tab: .capture,
             title: "YouTube transcription hotkey",
             subtitle: "in Transcription",
             keywords: ["hotkey", "shortcut", "youtube", "url", "video"],
@@ -178,7 +178,7 @@ public enum SettingsSearchIndex {
         ),
         SettingsSearchEntry(
             id: "transcription.youtube.audio.quality",
-            tab: .modes,
+            tab: .capture,
             title: "YouTube audio quality",
             subtitle: "in Transcription",
             keywords: ["youtube", "audio", "quality", "m4a", "best available", "opus", "webm"],
@@ -186,7 +186,7 @@ public enum SettingsSearchIndex {
         ),
         SettingsSearchEntry(
             id: "transcription.diarization",
-            tab: .modes,
+            tab: .capture,
             title: "Speaker detection",
             subtitle: "in Transcription",
             keywords: ["speaker", "diarization", "pyannote", "who said what", "speakers"],
@@ -194,7 +194,7 @@ public enum SettingsSearchIndex {
         ),
         SettingsSearchEntry(
             id: "transcription.completion.notification",
-            tab: .modes,
+            tab: .capture,
             title: "Notify when transcription finishes",
             subtitle: "in Transcription",
             keywords: ["notification", "notify", "sound", "chime", "alert", "banner", "done", "finished", "complete", "batch"],
@@ -202,7 +202,7 @@ public enum SettingsSearchIndex {
         ),
         SettingsSearchEntry(
             id: "transcription.autosave",
-            tab: .modes,
+            tab: .capture,
             title: "Auto-save transcripts to disk",
             subtitle: "in Transcription",
             keywords: ["auto save", "autosave", "export", "save", "disk", "folder", "file"],
@@ -210,7 +210,7 @@ public enum SettingsSearchIndex {
         ),
         SettingsSearchEntry(
             id: "meeting",
-            tab: .modes,
+            tab: .capture,
             title: "Meeting Recording",
             subtitle: "Dedicated controls for meeting audio capture.",
             keywords: ["meeting", "system audio", "screen recording", "meeting capture", "core audio taps"],
@@ -218,7 +218,7 @@ public enum SettingsSearchIndex {
         ),
         SettingsSearchEntry(
             id: "meeting.calendar",
-            tab: .modes,
+            tab: .capture,
             title: "Calendar",
             subtitle: "in Meeting Recording",
             keywords: ["calendar", "auto start", "auto-start", "reminders", "events", "ics"],

--- a/Sources/MacParakeetViewModels/SettingsTab.swift
+++ b/Sources/MacParakeetViewModels/SettingsTab.swift
@@ -3,11 +3,12 @@ import Foundation
 /// Top-level Settings information architecture.
 ///
 /// The four-tab IA decomposes a previously single-scroll Settings panel into
-/// destination-shaped buckets. Order is `Modes / Engine / AI / System` —
-/// daily-ops first, infrastructure-toward-the-back. See
-/// `plans/active/2026-04-settings-ia-overhaul.md` for the IA rationale.
+/// destination-shaped buckets. Order is `Capture / Engine / AI / System` —
+/// daily-ops first, infrastructure-toward-the-back. The `capture` case keeps
+/// the old raw value so users who last opened the previous Modes tab return to
+/// the same daily-ops surface after the rename.
 public enum SettingsTab: String, CaseIterable, Codable, Sendable, Identifiable {
-    case modes
+    case capture = "modes"
     case engine
     case ai
     case system
@@ -15,6 +16,6 @@ public enum SettingsTab: String, CaseIterable, Codable, Sendable, Identifiable {
     public var id: String { rawValue }
 
     /// The default tab shown on first launch and when no last-viewed tab is
-    /// persisted. Modes is the daily-ops surface; users return there most often.
-    public static let `default`: SettingsTab = .modes
+    /// persisted. Capture is the daily-ops surface; users return there most often.
+    public static let `default`: SettingsTab = .capture
 }

--- a/Tests/MacParakeetTests/App/MainWindowStateTests.swift
+++ b/Tests/MacParakeetTests/App/MainWindowStateTests.swift
@@ -12,6 +12,18 @@ final class MainWindowStateTests: XCTestCase {
 
         XCTAssertEqual(state.selectedItem, .settings)
         XCTAssertEqual(state.requestedSettingsTab, .ai)
+        XCTAssertNil(state.requestedSettingsAnchor)
+        XCTAssertEqual(state.requestedSettingsTabRevision, 1)
+    }
+
+    func testNavigateToSettingsCanRequestAnchor() {
+        let state = MainWindowState()
+
+        state.navigateToSettings(tab: .capture, anchor: "meeting")
+
+        XCTAssertEqual(state.selectedItem, .settings)
+        XCTAssertEqual(state.requestedSettingsTab, .capture)
+        XCTAssertEqual(state.requestedSettingsAnchor, "meeting")
         XCTAssertEqual(state.requestedSettingsTabRevision, 1)
     }
 
@@ -32,6 +44,7 @@ final class MainWindowStateTests: XCTestCase {
         state.consumeRequestedSettingsTab()
 
         XCTAssertNil(state.requestedSettingsTab)
+        XCTAssertNil(state.requestedSettingsAnchor)
         XCTAssertEqual(state.requestedSettingsTabRevision, 1)
         XCTAssertEqual(state.selectedItem, .settings)
     }

--- a/Tests/MacParakeetTests/ViewModels/SettingsRootViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsRootViewModelTests.swift
@@ -22,9 +22,10 @@ final class SettingsRootViewModelTests: XCTestCase {
         super.tearDown()
     }
 
-    func testDefaultsToModesTabOnFirstLaunch() {
+    func testDefaultsToCaptureTabOnFirstLaunch() {
         let vm = SettingsRootViewModel(defaults: defaults)
-        XCTAssertEqual(vm.activeTab, .modes)
+        XCTAssertEqual(vm.activeTab, .capture)
+        XCTAssertEqual(vm.activeCaptureWorkflow, .dictation)
         XCTAssertEqual(vm.searchQuery, "")
         XCTAssertFalse(vm.isSearching)
     }
@@ -55,6 +56,30 @@ final class SettingsRootViewModelTests: XCTestCase {
             let reader = SettingsRootViewModel(defaults: defaults)
             XCTAssertEqual(reader.activeTab, tab, "Tab \(tab.rawValue) should round-trip")
         }
+    }
+
+    func testActiveCaptureWorkflowPersistsAcrossInstances() {
+        let first = SettingsRootViewModel(defaults: defaults)
+        first.activeCaptureWorkflow = .meetings
+
+        let second = SettingsRootViewModel(defaults: defaults)
+        XCTAssertEqual(second.activeCaptureWorkflow, .meetings)
+    }
+
+    func testEachCaptureWorkflowRoundTripsThroughPersistence() {
+        for workflow in SettingsCaptureWorkflow.allCases {
+            let writer = SettingsRootViewModel(defaults: defaults)
+            writer.activeCaptureWorkflow = workflow
+
+            let reader = SettingsRootViewModel(defaults: defaults)
+            XCTAssertEqual(reader.activeCaptureWorkflow, workflow, "Workflow \(workflow.rawValue) should round-trip")
+        }
+    }
+
+    func testCorruptedPersistedCaptureWorkflowFallsBackToDefault() {
+        defaults.set("not-a-real-workflow", forKey: SettingsRootViewModel.lastCaptureWorkflowKey)
+        let vm = SettingsRootViewModel(defaults: defaults)
+        XCTAssertEqual(vm.activeCaptureWorkflow, .default)
     }
 
     func testCorruptedPersistedTabFallsBackToDefault() {
@@ -109,10 +134,18 @@ final class SettingsRootViewModelTests: XCTestCase {
         // UserDefaults writes directly, but we can confirm setting the same
         // value doesn't somehow change behavior.
         let vm = SettingsRootViewModel(defaults: defaults)
-        vm.activeTab = .modes
-        XCTAssertEqual(vm.activeTab, .modes)
+        vm.activeTab = .capture
+        XCTAssertEqual(vm.activeTab, .capture)
 
-        vm.activeTab = .modes
-        XCTAssertEqual(vm.activeTab, .modes)
+        vm.activeTab = .capture
+        XCTAssertEqual(vm.activeTab, .capture)
+    }
+
+    func testLegacyModesRawValueRestoresCaptureTab() {
+        defaults.set("modes", forKey: SettingsRootViewModel.lastViewedTabKey)
+
+        let vm = SettingsRootViewModel(defaults: defaults)
+
+        XCTAssertEqual(vm.activeTab, .capture)
     }
 }


### PR DESCRIPTION
## Summary
Settings now opens on a Capture surface that separates shared microphone setup from workflow-specific Dictation, Transcription, and Meetings controls. The old `modes` persisted value is preserved, so existing users still return to the same daily-ops destination after the rename.

The Capture screen keeps only one workflow card visible at a time, reducing the long mixed scroll while keeping search and deep links working: capture search results reveal the right workflow before scrolling, and the Meetings workspace jumps directly to Capture > Meetings. The selected Capture workflow is now persisted too, so reopening Settings keeps the user's last Dictation, Transcription, or Meetings section.

## Validation
- `git diff --check`
- `MACPARAKEET_SKIP_WHISPERKIT=1 swift build --build-path .build-swift6-no-whisper -Xswiftc -swift-version -Xswiftc 6`
- `swift test --filter SettingsRootViewModelTests --filter SettingsSearchIndexTests --filter MainWindowStateTests` (41 selected tests, 0 failures)
- `swift test` (3187 XCTest tests, 10 skipped, 0 failures; 16 Swift Testing tests, 0 failures)
- `scripts/dev/run_app.sh` launched `MacParakeet-Dev.app` from commit `cff3b85b09a1`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
