### PR TITLE
Add CLI speaker diarization constraints

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -80,6 +80,14 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ## [Unreleased]
 
+### Added
+
+- `transcribe` now accepts per-run speaker-count constraints for diarization:
+  `--speaker-count <n>` for an exact known count and `--speaker-min <n>` /
+  `--speaker-max <n>` for a range. These flags imply speaker detection when
+  `--speaker-detection` is left at `app-default`, and they are rejected with
+  `--speaker-detection off` or `--no-diarize`.
+
 ## [2.6.0] -- 2026-05-31
 
 ### Added

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -45,6 +45,11 @@ enum SpeakerDetectionOption: String, ExpressibleByArgument, CaseIterable, Sendab
     case off
 }
 
+struct ResolvedSpeakerDetection: Equatable, Sendable {
+    let enabled: Bool
+    let constraint: SpeakerDiarizationConstraint?
+}
+
 struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
     static let configuration = CommandConfiguration(
         commandName: "transcribe",
@@ -94,6 +99,15 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
     @Option(name: .long, help: "Speaker detection: app-default, on, off. Default: app-default, which follows the saved GUI/CLI preference.")
     var speakerDetection: SpeakerDetectionOption = .appDefault
 
+    @Option(name: .long, help: "Exact speaker count for this run. Mutually exclusive with --speaker-min/--speaker-max; implies speaker detection for app-default.")
+    var speakerCount: Int?
+
+    @Option(name: .long, help: "Minimum speaker count for this run. Can be combined with --speaker-max; implies speaker detection for app-default.")
+    var speakerMin: Int?
+
+    @Option(name: .long, help: "Maximum speaker count for this run. Can be combined with --speaker-min; implies speaker detection for app-default.")
+    var speakerMax: Int?
+
     @Flag(help: "Compatibility alias for --speaker-detection off.")
     var noDiarize: Bool = false
 
@@ -119,6 +133,13 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
         if noHistory && downloadedAudio == .keep {
             throw ValidationError("--no-history cannot be combined with --downloaded-audio keep.")
         }
+        try Self.validateSpeakerConstraintOptions(
+            speakerDetection: speakerDetection,
+            noDiarize: noDiarize,
+            speakerCount: speakerCount,
+            speakerMin: speakerMin,
+            speakerMax: speakerMax
+        )
     }
 
     static func resolveProcessingMode(_ mode: TranscribeMode, storedMode: String?) -> Dictation.ProcessingMode {
@@ -191,15 +212,101 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
         storedEnabled: Bool?,
         noDiarize: Bool
     ) -> Bool {
-        if noDiarize { return false }
+        resolveSpeakerDetection(
+            option,
+            storedEnabled: storedEnabled,
+            noDiarize: noDiarize,
+            speakerCount: nil,
+            speakerMin: nil,
+            speakerMax: nil
+        ).enabled
+    }
+
+    static func resolveSpeakerDetection(
+        _ option: SpeakerDetectionOption,
+        storedEnabled: Bool?,
+        noDiarize: Bool,
+        speakerCount: Int?,
+        speakerMin: Int?,
+        speakerMax: Int?
+    ) -> ResolvedSpeakerDetection {
+        if noDiarize { return ResolvedSpeakerDetection(enabled: false, constraint: nil) }
+
+        let constraint = speakerConstraint(
+            speakerCount: speakerCount,
+            speakerMin: speakerMin,
+            speakerMax: speakerMax
+        )
+
         switch option {
         case .appDefault:
-            return storedEnabled ?? false
+            return ResolvedSpeakerDetection(
+                enabled: constraint != nil || (storedEnabled ?? false),
+                constraint: constraint
+            )
         case .on:
-            return true
+            return ResolvedSpeakerDetection(enabled: true, constraint: constraint)
         case .off:
-            return false
+            return ResolvedSpeakerDetection(enabled: false, constraint: nil)
         }
+    }
+
+    static func validateSpeakerConstraintOptions(
+        speakerDetection: SpeakerDetectionOption,
+        noDiarize: Bool,
+        speakerCount: Int?,
+        speakerMin: Int?,
+        speakerMax: Int?
+    ) throws {
+        let hasConstraint = speakerCount != nil || speakerMin != nil || speakerMax != nil
+        guard hasConstraint else { return }
+
+        if noDiarize {
+            throw ValidationError("--no-diarize cannot be combined with speaker count constraints.")
+        }
+        if speakerDetection == .off {
+            throw ValidationError("--speaker-detection off cannot be combined with speaker count constraints.")
+        }
+        if let speakerCount, speakerCount < 1 {
+            throw ValidationError("--speaker-count must be at least 1.")
+        }
+        if let speakerMin, speakerMin < 1 {
+            throw ValidationError("--speaker-min must be at least 1.")
+        }
+        if let speakerMax, speakerMax < 1 {
+            throw ValidationError("--speaker-max must be at least 1.")
+        }
+        if speakerCount != nil && (speakerMin != nil || speakerMax != nil) {
+            throw ValidationError("--speaker-count cannot be combined with --speaker-min or --speaker-max.")
+        }
+        if let speakerMin, let speakerMax, speakerMin > speakerMax {
+            throw ValidationError("--speaker-min cannot be greater than --speaker-max.")
+        }
+    }
+
+    static func speakerConstraint(
+        speakerCount: Int?,
+        speakerMin: Int?,
+        speakerMax: Int?
+    ) -> SpeakerDiarizationConstraint? {
+        if let speakerCount {
+            return .exact(speakerCount)
+        }
+        guard speakerMin != nil || speakerMax != nil else { return nil }
+        if let speakerMin, let speakerMax, speakerMin == speakerMax {
+            return .exact(speakerMin)
+        }
+        return .range(min: speakerMin, max: speakerMax)
+    }
+
+    static func makeDiarizationService(
+        for speakerDetection: ResolvedSpeakerDetection
+    ) -> DiarizationService? {
+        guard speakerDetection.enabled else { return nil }
+        guard let constraint = speakerDetection.constraint else {
+            return DiarizationService()
+        }
+        return DiarizationService(speakerConstraint: constraint)
     }
 
     static func localFileURL(for input: String) -> URL {
@@ -242,10 +349,13 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
                 storedLanguage: SpeechEnginePreference.whisperDefaultLanguage(defaults: defaults),
                 explicitLanguage: self.language
             )
-            let speakerDetectionEnabled = Self.resolveSpeakerDetection(
+            let resolvedSpeakerDetection = Self.resolveSpeakerDetection(
                 self.speakerDetection,
                 storedEnabled: defaults.object(forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey) as? Bool,
-                noDiarize: self.noDiarize
+                noDiarize: self.noDiarize,
+                speakerCount: self.speakerCount,
+                speakerMin: self.speakerMin,
+                speakerMax: self.speakerMax
             )
             let processingMode = Self.resolveProcessingMode(
                 self.mode,
@@ -290,7 +400,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
                 await entitlementsService.refreshValidationIfNeeded()
             }
 
-            let diarizationService: DiarizationService? = speakerDetectionEnabled ? DiarizationService() : nil
+            let diarizationService = Self.makeDiarizationService(for: resolvedSpeakerDetection)
             let service = TranscriptionService(
                 audioProcessor: audioProcessor,
                 sttTranscriber: sttTranscriber,
@@ -304,7 +414,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
                 shouldKeepDownloadedAudio: {
                     shouldKeepDownloadedAudio
                 },
-                shouldDiarize: { speakerDetectionEnabled },
+                shouldDiarize: { resolvedSpeakerDetection.enabled },
                 youtubeDownloader: youtubeDownloader,
                 diarizationService: diarizationService
             )

--- a/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
@@ -25,6 +25,11 @@ public struct SpeakerSegment: Sendable {
     }
 }
 
+public enum SpeakerDiarizationConstraint: Equatable, Sendable {
+    case exact(Int)
+    case range(min: Int?, max: Int?)
+}
+
 public protocol DiarizationServiceProtocol: Sendable {
     func diarize(audioURL: URL) async throws -> MacParakeetDiarizationResult
     func prepareModels(onProgress: (@Sendable (String) -> Void)?) async throws
@@ -72,6 +77,16 @@ public actor DiarizationService: DiarizationServiceProtocol {
         self.init(
             manager: OfflineDiarizerManager(config: config),
             modelsDirectory: modelsDirectory ?? OfflineDiarizerModels.defaultModelsDirectory()
+        )
+    }
+
+    public init(
+        speakerConstraint: SpeakerDiarizationConstraint,
+        modelsDirectory: URL? = nil
+    ) {
+        self.init(
+            config: Self.offlineConfig(speakerConstraint: speakerConstraint),
+            modelsDirectory: modelsDirectory
         )
     }
 
@@ -174,6 +189,20 @@ public actor DiarizationService: DiarizationServiceProtocol {
 
     nonisolated static func requiredModelNames() -> [String] {
         Array(ModelNames.OfflineDiarizer.requiredModels)
+    }
+
+    nonisolated static func offlineConfig(
+        speakerConstraint: SpeakerDiarizationConstraint?
+    ) -> OfflineDiarizerConfig {
+        let config = OfflineDiarizerConfig.default
+        guard let speakerConstraint else { return config }
+
+        switch speakerConstraint {
+        case .exact(let count):
+            return config.withSpeakers(exactly: count)
+        case .range(let min, let max):
+            return config.withSpeakers(min: min, max: max)
+        }
     }
 }
 

--- a/Tests/CLITests/TranscribeCommandTests.swift
+++ b/Tests/CLITests/TranscribeCommandTests.swift
@@ -158,6 +158,62 @@ final class TranscribeCommandTests: XCTestCase {
         XCTAssertFalse(TranscribeCommand.resolveSpeakerDetection(.on, storedEnabled: true, noDiarize: true))
     }
 
+    func testResolveSpeakerDetectionConstraintsImplyDetectionForAppDefault() {
+        let resolved = TranscribeCommand.resolveSpeakerDetection(
+            .appDefault,
+            storedEnabled: false,
+            noDiarize: false,
+            speakerCount: 2,
+            speakerMin: nil,
+            speakerMax: nil
+        )
+
+        XCTAssertTrue(resolved.enabled)
+        XCTAssertEqual(resolved.constraint, .exact(2))
+    }
+
+    func testResolveSpeakerDetectionRangeConstraint() {
+        let resolved = TranscribeCommand.resolveSpeakerDetection(
+            .on,
+            storedEnabled: false,
+            noDiarize: false,
+            speakerCount: nil,
+            speakerMin: 2,
+            speakerMax: 4
+        )
+
+        XCTAssertTrue(resolved.enabled)
+        XCTAssertEqual(resolved.constraint, .range(min: 2, max: 4))
+    }
+
+    func testResolveSpeakerDetectionEqualRangeNormalizesToExactConstraint() {
+        let resolved = TranscribeCommand.resolveSpeakerDetection(
+            .on,
+            storedEnabled: false,
+            noDiarize: false,
+            speakerCount: nil,
+            speakerMin: 2,
+            speakerMax: 2
+        )
+
+        XCTAssertTrue(resolved.enabled)
+        XCTAssertEqual(resolved.constraint, .exact(2))
+    }
+
+    func testResolveSpeakerDetectionSupportsOneSidedRangeConstraint() {
+        let resolved = TranscribeCommand.resolveSpeakerDetection(
+            .appDefault,
+            storedEnabled: false,
+            noDiarize: false,
+            speakerCount: nil,
+            speakerMin: nil,
+            speakerMax: 4
+        )
+
+        XCTAssertTrue(resolved.enabled)
+        XCTAssertEqual(resolved.constraint, .range(min: nil, max: 4))
+    }
+
     func testParsesWhisperEngineAndLanguage() throws {
         let command = try TranscribeCommand.parse([
             "sample.wav",
@@ -178,6 +234,81 @@ final class TranscribeCommandTests: XCTestCase {
 
         XCTAssertEqual(command.engine, .appDefault)
         XCTAssertEqual(command.speakerDetection, .appDefault)
+    }
+
+    func testParsesSpeakerConstraintFlags() throws {
+        let exact = try TranscribeCommand.parse([
+            "sample.wav",
+            "--speaker-count", "2",
+        ])
+        XCTAssertEqual(exact.speakerCount, 2)
+
+        let range = try TranscribeCommand.parse([
+            "sample.wav",
+            "--speaker-min", "2",
+            "--speaker-max", "4",
+        ])
+        XCTAssertEqual(range.speakerMin, 2)
+        XCTAssertEqual(range.speakerMax, 4)
+    }
+
+    func testSpeakerConstraintFlagsRejectExplicitDisable() throws {
+        XCTAssertThrowsError(try TranscribeCommand.parse([
+            "sample.wav",
+            "--speaker-detection", "off",
+            "--speaker-count", "2",
+        ])) { error in
+            XCTAssertTrue(String(describing: error).contains("--speaker-detection off cannot be combined"))
+        }
+
+        XCTAssertThrowsError(try TranscribeCommand.parse([
+            "sample.wav",
+            "--no-diarize",
+            "--speaker-min", "2",
+        ])) { error in
+            XCTAssertTrue(String(describing: error).contains("--no-diarize cannot be combined"))
+        }
+    }
+
+    func testSpeakerConstraintFlagsValidateRangeShape() throws {
+        XCTAssertThrowsError(try TranscribeCommand.parse([
+            "sample.wav",
+            "--speaker-count", "2",
+            "--speaker-max", "4",
+        ])) { error in
+            XCTAssertTrue(String(describing: error).contains("--speaker-count cannot be combined"))
+        }
+
+        XCTAssertThrowsError(try TranscribeCommand.parse([
+            "sample.wav",
+            "--speaker-min", "5",
+            "--speaker-max", "4",
+        ])) { error in
+            XCTAssertTrue(String(describing: error).contains("--speaker-min cannot be greater"))
+        }
+    }
+
+    func testSpeakerConstraintFlagsRejectNonpositiveValues() throws {
+        XCTAssertThrowsError(try TranscribeCommand.parse([
+            "sample.wav",
+            "--speaker-count", "0",
+        ])) { error in
+            XCTAssertTrue(String(describing: error).contains("--speaker-count must be at least 1"))
+        }
+
+        XCTAssertThrowsError(try TranscribeCommand.parse([
+            "sample.wav",
+            "--speaker-min=-1",
+        ])) { error in
+            XCTAssertTrue(String(describing: error).contains("--speaker-min must be at least 1"))
+        }
+
+        XCTAssertThrowsError(try TranscribeCommand.parse([
+            "sample.wav",
+            "--speaker-max", "0",
+        ])) { error in
+            XCTAssertTrue(String(describing: error).contains("--speaker-max must be at least 1"))
+        }
     }
 
     func testParsesYouTubeAudioQuality() throws {

--- a/Tests/MacParakeetTests/Services/Diarization/DiarizationServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/DiarizationServiceTests.swift
@@ -92,6 +92,38 @@ final class DiarizationServiceTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: repoDirectory.path))
     }
 
+    func testOfflineConfigAppliesExactSpeakerConstraint() {
+        let config = DiarizationService.offlineConfig(speakerConstraint: .exact(2))
+
+        XCTAssertEqual(config.clustering.numSpeakers, 2)
+        XCTAssertNil(config.clustering.minSpeakers)
+        XCTAssertNil(config.clustering.maxSpeakers)
+    }
+
+    func testOfflineConfigAppliesSpeakerRangeConstraint() {
+        let config = DiarizationService.offlineConfig(speakerConstraint: .range(min: 2, max: 4))
+
+        XCTAssertNil(config.clustering.numSpeakers)
+        XCTAssertEqual(config.clustering.minSpeakers, 2)
+        XCTAssertEqual(config.clustering.maxSpeakers, 4)
+    }
+
+    func testOfflineConfigAppliesMinimumSpeakerRangeConstraint() {
+        let config = DiarizationService.offlineConfig(speakerConstraint: .range(min: 2, max: nil))
+
+        XCTAssertNil(config.clustering.numSpeakers)
+        XCTAssertEqual(config.clustering.minSpeakers, 2)
+        XCTAssertNil(config.clustering.maxSpeakers)
+    }
+
+    func testOfflineConfigAppliesMaximumSpeakerRangeConstraint() {
+        let config = DiarizationService.offlineConfig(speakerConstraint: .range(min: nil, max: 4))
+
+        XCTAssertNil(config.clustering.numSpeakers)
+        XCTAssertNil(config.clustering.minSpeakers)
+        XCTAssertEqual(config.clustering.maxSpeakers, 4)
+    }
+
     func testDiarizePreparesModelsUsingCustomDirectoryBeforeColdStartInference() async throws {
         let customDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -29,6 +29,7 @@ macparakeet-cli
 │   └── --engine app-default|parakeet|whisper [--language <code>]
 │       --parakeet-model app-default|v3|v2 [--output-dir DIR]
 │       --speaker-detection app-default|on|off
+│       [--speaker-count N | --speaker-min N [--speaker-max N] | --speaker-max N]
 │       --youtube-audio-quality app-default|m4a|best-available
 ├── history                              View and manage history
 │   ├── dictations [--limit] [--json]    List recent dictations (default)
@@ -206,9 +207,18 @@ the explicit option, or use the legacy alias to force it off:
 
 ```bash
 swift run macparakeet-cli transcribe "<FILE>" --speaker-detection on
+swift run macparakeet-cli transcribe "<FILE>" --speaker-count 2
+swift run macparakeet-cli transcribe "<FILE>" --speaker-min 2 --speaker-max 4
 swift run macparakeet-cli transcribe "<FILE>" --speaker-detection off
 swift run macparakeet-cli transcribe "<FILE>" --no-diarize
 ```
+
+`--speaker-count`, `--speaker-min`, and `--speaker-max` are per-run
+constraints. They imply speaker detection when `--speaker-detection` is left at
+`app-default`, and they cannot be combined with `--speaker-detection off` or
+`--no-diarize`. Use `--speaker-count` for an exact count, or `--speaker-min`
+and/or `--speaker-max` for bounds; values must be positive, and
+`--speaker-min` cannot exceed `--speaker-max`.
 
 `config get speaker-detection` reports the saved app-default value used by
 bare `transcribe` and by `--speaker-detection app-default`.

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -198,6 +198,19 @@ macparakeet-cli transcribe /path/to/audio.mp3 \
   --format json
 ```
 
+For a specific file or recording where the speaker count is known, constrain
+speaker detection per run instead of changing the saved default:
+
+```bash
+macparakeet-cli transcribe /path/to/interview.mp3 --speaker-count 2 --format json
+macparakeet-cli transcribe /path/to/panel.mp3 --speaker-min 2 --speaker-max 4 --format json
+```
+
+Those constraint flags imply speaker detection when `--speaker-detection` is
+left at `app-default`; they are rejected with `--speaker-detection off` or
+`--no-diarize`. Use `--speaker-count` for an exact count, or `--speaker-min`
+and/or `--speaker-max` for bounds.
+
 Agents can also set those shared defaults without opening the GUI. Treat this
 as pre-run setup: a running GUI may cache some settings until relaunch or an
 in-app change.
@@ -432,7 +445,9 @@ macparakeet-cli prompts run "<prompt-name>" \
   GUI-default behavior. Pin explicit flags for reproducible agent tests.
 - `config get speaker-detection` reports the saved app-default value. Bare
   `transcribe` and `--speaker-detection app-default` use that value; pass
-  `--speaker-detection on` or `off` to override it for one run.
+  `--speaker-detection on` or `off` to override it for one run. For known
+  speaker counts, use per-run `--speaker-count`, `--speaker-min`, or
+  `--speaker-max` instead of mutating the saved default.
 ````
 
 ## Conventions


### PR DESCRIPTION
## Summary

- add per-run CLI speaker diarization constraints: `--speaker-count`, `--speaker-min`, and `--speaker-max`
- pass exact/ranged constraints into FluidAudio offline diarization without adding a saved GUI/default setting
- validate conflicting and nonpositive speaker flags, and document the per-run behavior for agent integrations

Refs #106.

## Validation

- `git diff --check`
- `swift test --filter TranscribeCommandTests`
- `swift test --filter DiarizationServiceTests`
- `swift test` (3216 XCTest tests, 10 expected hardware skips; 16 Swift Testing tests)
