### PR TITLE
settings: make dictation AI formatting opt-in (#408)

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -180,6 +180,14 @@ final class AppEnvironment {
             runtimePreferences.aiFormatterEnabled
         }
 
+        // Dictation gates the AI Formatter on BOTH the global switch and the
+        // dictation-specific switch, so users can keep AI formatting for
+        // file/meeting transcripts (which use `aiFormatterEnabledClosure`) while
+        // keeping live dictation fast. See issue #408.
+        let dictationAIFormatterEnabledClosure: @Sendable () -> Bool = { [runtimePreferences] in
+            runtimePreferences.aiFormatterEnabled && runtimePreferences.aiFormatterEnabledForDictation
+        }
+
         let aiFormatterPromptClosure: @Sendable () -> String = { [runtimePreferences] in
             runtimePreferences.aiFormatterPrompt
         }
@@ -218,7 +226,7 @@ final class AppEnvironment {
             processingMode: processingModeClosure,
             llmService: llmService,
             llmRunRepo: llmRunRepo,
-            shouldUseAIFormatter: aiFormatterEnabledClosure,
+            shouldUseAIFormatter: dictationAIFormatterEnabledClosure,
             aiFormatterPromptResolver: aiFormatterPromptResolver,
             markFirstDictationCompleted: { [runtimePreferences] in
                 // Fire the activation milestone exactly once, the first time a

--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -283,7 +283,7 @@ final class AppEnvironment {
         derivedFieldsBackfill.runInBackground()
     }
 
-    private static func enableAIFormatterByDefaultWhenLLMConfigured(
+    nonisolated static func enableAIFormatterByDefaultWhenLLMConfigured(
         defaults: UserDefaults,
         configStore: LLMConfigStoreProtocol
     ) {

--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -67,7 +67,7 @@ final class AppEnvironment {
 
         // Services
         let llmConfigStore = LLMConfigStore()
-        Self.enableAIFormatterByDefaultWhenLLMConfigured(
+        Self.syncAIFormatterAvailabilityWithLLMConfiguration(
             defaults: .standard,
             configStore: llmConfigStore
         )
@@ -283,14 +283,35 @@ final class AppEnvironment {
         derivedFieldsBackfill.runInBackground()
     }
 
-    nonisolated static func enableAIFormatterByDefaultWhenLLMConfigured(
+    nonisolated static func syncAIFormatterAvailabilityWithLLMConfiguration(
         defaults: UserDefaults,
         configStore: LLMConfigStoreProtocol
     ) {
-        guard defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey) == nil else {
+        let config: LLMProviderConfig?
+        do {
+            config = try configStore.loadConfig()
+        } catch {
             return
         }
-        guard (try? configStore.loadConfig()) != nil else { return }
-        defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey)
+        let hasDictationRoutingPreference = defaults.object(
+            forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey
+        ) != nil
+        if config != nil {
+            let legacyFormatterWasEnabled = defaults.object(
+                forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey
+            ) as? Bool == true
+            if !hasDictationRoutingPreference {
+                defaults.set(
+                    legacyFormatterWasEnabled,
+                    forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey
+                )
+            }
+            defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey)
+        } else {
+            defaults.removeObject(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey)
+            if !hasDictationRoutingPreference {
+                defaults.set(false, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey)
+            }
+        }
     }
 }

--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -66,6 +66,11 @@ final class AppEnvironment {
         quickPromptRepo = QuickPromptRepository(dbQueue: databaseManager.dbQueue)
 
         // Services
+        let llmConfigStore = LLMConfigStore()
+        Self.enableAIFormatterByDefaultWhenLLMConfigured(
+            defaults: .standard,
+            configStore: llmConfigStore
+        )
         let runtimePreferences = UserDefaultsAppRuntimePreferences()
         self.runtimePreferences = runtimePreferences
         let selectedInputDeviceUIDProvider: @Sendable () -> String? = { [runtimePreferences] in
@@ -204,7 +209,7 @@ final class AppEnvironment {
         }
 
         llmClient = RoutingLLMClient()
-        llmConfigStore = LLMConfigStore()
+        self.llmConfigStore = llmConfigStore
         llmService = LLMService(
             client: llmClient,
             contextResolver: StoredLLMExecutionContextResolver(
@@ -276,5 +281,16 @@ final class AppEnvironment {
 
         derivedFieldsBackfill = DerivedFieldsBackfillService(dbQueue: databaseManager.dbQueue)
         derivedFieldsBackfill.runInBackground()
+    }
+
+    private static func enableAIFormatterByDefaultWhenLLMConfigured(
+        defaults: UserDefaults,
+        configStore: LLMConfigStoreProtocol
+    ) {
+        guard defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey) == nil else {
+            return
+        }
+        guard (try? configStore.loadConfig()) != nil else { return }
+        defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey)
     }
 }

--- a/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
@@ -341,35 +341,27 @@ struct LLMSettingsView: View {
     private var aiFormatterSection: some View {
         VStack(spacing: DesignSystem.Spacing.md) {
             VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
-                HStack(alignment: .center, spacing: DesignSystem.Spacing.md) {
-                    VStack(alignment: .leading, spacing: 3) {
-                        HStack(spacing: 7) {
-                            Text("AI Formatter")
-                                .font(DesignSystem.Typography.body.weight(.semibold))
-                            Text("Final step")
-                                .font(DesignSystem.Typography.micro.weight(.semibold))
-                                .foregroundStyle(DesignSystem.Colors.accentDark)
-                                .padding(.horizontal, 7)
-                                .padding(.vertical, 3)
-                                .background(
-                                    Capsule()
-                                        .fill(DesignSystem.Colors.accent.opacity(0.12))
-                                )
-                        }
-                        Text("Formats file and meeting transcripts with app-aware smart defaults after the usual cleanup step.")
-                            .font(DesignSystem.Typography.caption)
-                            .foregroundStyle(.secondary)
-                            .fixedSize(horizontal: false, vertical: true)
+                VStack(alignment: .leading, spacing: 3) {
+                    HStack(spacing: 7) {
+                        Text("AI Formatter")
+                            .font(DesignSystem.Typography.body.weight(.semibold))
+                        Text("Final step")
+                            .font(DesignSystem.Typography.micro.weight(.semibold))
+                            .foregroundStyle(DesignSystem.Colors.accentDark)
+                            .padding(.horizontal, 7)
+                            .padding(.vertical, 3)
+                            .background(
+                                Capsule()
+                                    .fill(DesignSystem.Colors.accent.opacity(0.12))
+                            )
                     }
-                    Spacer(minLength: DesignSystem.Spacing.md)
-                    AIFormatterActivationToggle(
-                        isOn: $viewModel.aiFormatterEnabled,
-                        isAvailable: viewModel.canToggleAIFormatter,
-                        disabledReason: viewModel.aiFormatterDisabledReason
-                    )
+                    Text("Uses the saved LLM provider for file and meeting transcripts after the usual cleanup step.")
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
 
-                if let disabledReason = viewModel.aiFormatterDisabledReason {
+                if let disabledReason = viewModel.aiFormatterUnavailableReason {
                     HStack(spacing: 6) {
                         Image(systemName: "info.circle.fill")
                             .font(.system(size: 11, weight: .semibold))
@@ -381,7 +373,7 @@ struct LLMSettingsView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
-                if viewModel.aiFormatterEnabled {
+                if viewModel.isAIFormatterAvailable {
                     Divider()
                     Toggle(isOn: $viewModel.aiFormatterEnabledForDictation) {
                         VStack(alignment: .leading, spacing: 3) {
@@ -493,7 +485,7 @@ struct LLMSettingsView: View {
                             .font(.system(.body, design: .monospaced))
                             .scrollContentBackground(.hidden)
                             .padding(6)
-                            .disabled(!viewModel.canToggleAIFormatter)
+                            .disabled(!viewModel.isAIFormatterAvailable)
                     }
                     .frame(width: 380)
                     .frame(minHeight: 220)
@@ -1355,133 +1347,5 @@ struct LLMSettingsView: View {
                     .lineLimit(2)
             }
         }
-    }
-}
-
-private struct AIFormatterActivationToggle: View {
-    @Binding var isOn: Bool
-    let isAvailable: Bool
-    let disabledReason: String?
-
-    var body: some View {
-        Toggle("AI Formatter", isOn: $isOn)
-            .labelsHidden()
-            .toggleStyle(AIFormatterActivationToggleStyle())
-            .disabled(!isAvailable)
-            .help(disabledReason ?? "Run AI formatting after the standard cleanup step.")
-            .accessibilityLabel("AI Formatter")
-            .accessibilityValue(isOn ? "Enabled" : "Disabled")
-            .accessibilityHint(disabledReason ?? "Runs after local transcription cleanup as the final output step.")
-    }
-}
-
-private struct AIFormatterActivationToggleStyle: ToggleStyle {
-    @Environment(\.isEnabled) private var isEnabled
-
-    func makeBody(configuration: Configuration) -> some View {
-        Button {
-            withAnimation(.spring(response: 0.22, dampingFraction: 0.82)) {
-                configuration.isOn.toggle()
-            }
-        } label: {
-            HStack(spacing: 10) {
-                Image(systemName: configuration.isOn ? "sparkles" : "wand.and.stars")
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(iconTint(isOn: configuration.isOn))
-                    .frame(width: 24, height: 24)
-                    .background(
-                        Circle()
-                            .fill(iconBackground(isOn: configuration.isOn))
-                    )
-                    .accessibilityHidden(true)
-
-                Text(labelText(isOn: configuration.isOn))
-                    .font(DesignSystem.Typography.caption.weight(.semibold))
-                    .foregroundStyle(labelTint(isOn: configuration.isOn))
-                    .lineLimit(1)
-
-                Spacer(minLength: 4)
-
-                switchTrack(isOn: configuration.isOn)
-            }
-            .padding(.leading, 8)
-            .padding(.trailing, 10)
-            .padding(.vertical, 6)
-            .frame(width: 164, height: 38)
-            .background(
-                RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
-                    .fill(controlBackground(isOn: configuration.isOn))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
-                    .strokeBorder(controlBorder(isOn: configuration.isOn), lineWidth: 1)
-            )
-            .contentShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius))
-        }
-        .buttonStyle(.plain)
-    }
-
-    private func switchTrack(isOn: Bool) -> some View {
-        ZStack(alignment: isOn ? .trailing : .leading) {
-            Capsule()
-                .fill(trackBackground(isOn: isOn))
-                .overlay(
-                    Capsule()
-                        .strokeBorder(trackBorder(isOn: isOn), lineWidth: 1)
-                )
-
-            Circle()
-                .fill(knobFill(isOn: isOn))
-                .frame(width: 14, height: 14)
-                .padding(2)
-                .shadow(color: .black.opacity(isOn && isEnabled ? 0.18 : 0), radius: 2, y: 1)
-        }
-        .frame(width: 34, height: 18)
-        .accessibilityHidden(true)
-    }
-
-    private func labelText(isOn: Bool) -> String {
-        guard isEnabled else { return "Unavailable" }
-        return isOn ? "Enabled" : "Enable"
-    }
-
-    private func iconTint(isOn: Bool) -> Color {
-        if !isEnabled { return DesignSystem.Colors.textTertiary }
-        return isOn ? DesignSystem.Colors.onAccent : DesignSystem.Colors.accent
-    }
-
-    private func iconBackground(isOn: Bool) -> Color {
-        if !isEnabled { return DesignSystem.Colors.surfaceElevated.opacity(0.75) }
-        return isOn ? DesignSystem.Colors.accent : DesignSystem.Colors.accent.opacity(0.12)
-    }
-
-    private func labelTint(isOn: Bool) -> Color {
-        if !isEnabled { return DesignSystem.Colors.textTertiary }
-        return isOn ? DesignSystem.Colors.accentDark : DesignSystem.Colors.textSecondary
-    }
-
-    private func controlBackground(isOn: Bool) -> Color {
-        if !isEnabled { return DesignSystem.Colors.surfaceElevated.opacity(0.45) }
-        return isOn ? DesignSystem.Colors.accentLight : DesignSystem.Colors.surfaceElevated
-    }
-
-    private func controlBorder(isOn: Bool) -> Color {
-        if !isEnabled { return DesignSystem.Colors.border.opacity(0.45) }
-        return isOn ? DesignSystem.Colors.accent.opacity(0.45) : DesignSystem.Colors.border.opacity(0.75)
-    }
-
-    private func trackBackground(isOn: Bool) -> Color {
-        if !isEnabled { return DesignSystem.Colors.border.opacity(0.35) }
-        return isOn ? DesignSystem.Colors.accent : DesignSystem.Colors.border.opacity(0.35)
-    }
-
-    private func trackBorder(isOn: Bool) -> Color {
-        if !isEnabled { return Color.clear }
-        return isOn ? DesignSystem.Colors.accent.opacity(0.35) : DesignSystem.Colors.border.opacity(0.75)
-    }
-
-    private func knobFill(isOn: Bool) -> Color {
-        if !isEnabled { return DesignSystem.Colors.textTertiary.opacity(0.55) }
-        return isOn ? DesignSystem.Colors.onAccent : DesignSystem.Colors.textSecondary
     }
 }

--- a/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
@@ -380,6 +380,22 @@ struct LLMSettingsView: View {
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
+
+                if viewModel.aiFormatterEnabled {
+                    Divider()
+                    Toggle(isOn: $viewModel.aiFormatterEnabledForDictation) {
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text("Apply to dictation")
+                                .font(DesignSystem.Typography.body.weight(.medium))
+                            Text("Run the AI Formatter on live dictation. Turn off to keep dictation fast — file and meeting transcripts are still formatted.")
+                                .font(DesignSystem.Typography.caption)
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                    .toggleStyle(.switch)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
             }
 
             if AppFeatures.aiFormatterProfilesEnabled {

--- a/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
@@ -356,7 +356,7 @@ struct LLMSettingsView: View {
                                         .fill(DesignSystem.Colors.accent.opacity(0.12))
                                 )
                         }
-                        Text("Formats dictation with app-aware smart defaults after the usual cleanup step.")
+                        Text("Formats file and meeting transcripts with app-aware smart defaults after the usual cleanup step.")
                             .font(DesignSystem.Typography.caption)
                             .foregroundStyle(.secondary)
                             .fixedSize(horizontal: false, vertical: true)
@@ -385,9 +385,9 @@ struct LLMSettingsView: View {
                     Divider()
                     Toggle(isOn: $viewModel.aiFormatterEnabledForDictation) {
                         VStack(alignment: .leading, spacing: 3) {
-                            Text("Apply to dictation")
+                            Text("Also use for dictation")
                                 .font(DesignSystem.Typography.body.weight(.medium))
-                            Text("Run the AI Formatter on live dictation. Turn off to keep dictation fast — file and meeting transcripts are still formatted.")
+                            Text("Run the AI Formatter on live dictation too. This can add latency on short utterances.")
                                 .font(DesignSystem.Typography.caption)
                                 .foregroundStyle(.secondary)
                                 .fixedSize(horizontal: false, vertical: true)

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -9,6 +9,7 @@ public protocol AppRuntimePreferencesProtocol: Sendable {
     var youtubeAudioQuality: YouTubeAudioQuality { get }
     var shouldDiarize: Bool { get }
     var aiFormatterEnabled: Bool { get }
+    var aiFormatterEnabledForDictation: Bool { get }
     var aiFormatterPrompt: String { get }
     var selectedMicrophoneDeviceUID: String? { get }
     var meetingAudioSourceMode: MeetingAudioSourceMode { get }
@@ -111,6 +112,7 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
     public static let youtubeAudioQualityKey = "youtubeAudioQuality"
     public static let speakerDiarizationKey = "speakerDiarization"
     public static let aiFormatterEnabledKey = "aiFormatterEnabled"
+    public static let aiFormatterEnabledForDictationKey = "aiFormatterEnabledForDictation"
     public static let aiFormatterPromptKey = "aiFormatterPrompt"
     public static let selectedMicrophoneDeviceUIDKey = "selectedMicrophoneDeviceUID"
     public static let meetingAudioSourceModeKey = "meetingAudioSourceMode"
@@ -161,6 +163,16 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
 
     public var aiFormatterEnabled: Bool {
         defaults.object(forKey: Self.aiFormatterEnabledKey) as? Bool ?? false
+    }
+
+    /// Whether the AI Formatter also runs on live dictation. Independent of the
+    /// global `aiFormatterEnabled` switch so users can keep AI formatting for
+    /// long-form file/meeting transcripts while keeping dictation low-latency
+    /// (the LLM round-trip is the dominant cost on short utterances). Defaults
+    /// to `true`, preserving the prior behavior where dictation followed the
+    /// global toggle. The dictation gate is the logical AND of both flags.
+    public var aiFormatterEnabledForDictation: Bool {
+        defaults.object(forKey: Self.aiFormatterEnabledForDictationKey) as? Bool ?? true
     }
 
     public var aiFormatterPrompt: String {

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -169,10 +169,9 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
     /// global `aiFormatterEnabled` switch so users can keep AI formatting for
     /// long-form file/meeting transcripts while keeping dictation low-latency
     /// (the LLM round-trip is the dominant cost on short utterances). Defaults
-    /// to `true`, preserving the prior behavior where dictation followed the
-    /// global toggle. The dictation gate is the logical AND of both flags.
+    /// to `false`; the dictation gate is the logical AND of both flags.
     public var aiFormatterEnabledForDictation: Bool {
-        defaults.object(forKey: Self.aiFormatterEnabledForDictationKey) as? Bool ?? true
+        defaults.object(forKey: Self.aiFormatterEnabledForDictationKey) as? Bool ?? false
     }
 
     public var aiFormatterPrompt: String {

--- a/Sources/MacParakeetViewModels/LLMSettingsDraft.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsDraft.swift
@@ -36,7 +36,6 @@ public struct LLMSettingsDraft: Equatable, Sendable {
     public var commandTemplate: String
     public var selectedCLITemplate: LocalCLITemplate?
     public var cliTimeoutSeconds: Double
-    public var aiFormatterEnabled: Bool
     public var aiFormatterPrompt: String
 
     public init(
@@ -49,7 +48,6 @@ public struct LLMSettingsDraft: Equatable, Sendable {
         commandTemplate: String = "",
         selectedCLITemplate: LocalCLITemplate? = nil,
         cliTimeoutSeconds: Double = LocalCLIConfig.defaultTimeout,
-        aiFormatterEnabled: Bool = false,
         aiFormatterPrompt: String = AIFormatter.defaultPromptTemplate
     ) {
         self.providerID = providerID
@@ -61,7 +59,6 @@ public struct LLMSettingsDraft: Equatable, Sendable {
         self.commandTemplate = commandTemplate
         self.selectedCLITemplate = selectedCLITemplate
         self.cliTimeoutSeconds = max(LocalCLIConfig.minimumTimeout, cliTimeoutSeconds)
-        self.aiFormatterEnabled = aiFormatterEnabled
         self.aiFormatterPrompt = AIFormatter.normalizedPromptTemplate(aiFormatterPrompt)
     }
 
@@ -192,7 +189,6 @@ public struct LLMSettingsDraft: Equatable, Sendable {
         apiKey: String = "",
         defaultModelName: String = "",
         cliConfig: LocalCLIConfig? = nil,
-        aiFormatterEnabled: Bool = false,
         aiFormatterPrompt: String = AIFormatter.defaultPromptTemplate
     ) -> Self {
         let selectedCLITemplate = cliConfig.map { LocalCLITemplate.inferredTemplate(for: $0.commandTemplate) } ?? nil
@@ -206,7 +202,6 @@ public struct LLMSettingsDraft: Equatable, Sendable {
             commandTemplate: cliConfig?.commandTemplate ?? "",
             selectedCLITemplate: selectedCLITemplate,
             cliTimeoutSeconds: cliConfig?.timeoutSeconds ?? LocalCLIConfig.defaultTimeout,
-            aiFormatterEnabled: aiFormatterEnabled,
             aiFormatterPrompt: aiFormatterPrompt
         )
     }
@@ -217,7 +212,6 @@ public struct LLMSettingsDraft: Equatable, Sendable {
         defaultModelName: String,
         defaultBaseURL: String,
         cliConfig: LocalCLIConfig? = nil,
-        aiFormatterEnabled: Bool = false,
         aiFormatterPrompt: String = AIFormatter.defaultPromptTemplate
     ) -> Self {
         let isSuggestedModel = suggestedModels.contains(config.modelName)
@@ -232,7 +226,6 @@ public struct LLMSettingsDraft: Equatable, Sendable {
             commandTemplate: cliConfig?.commandTemplate ?? "",
             selectedCLITemplate: selectedCLITemplate,
             cliTimeoutSeconds: cliConfig?.timeoutSeconds ?? LocalCLIConfig.defaultTimeout,
-            aiFormatterEnabled: aiFormatterEnabled,
             aiFormatterPrompt: aiFormatterPrompt
         )
     }

--- a/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
@@ -366,8 +366,8 @@ public final class LLMSettingsViewModel {
     /// the draft. It persists immediately through the injected `defaults` — the
     /// same store the rest of this view model uses, and the same eager-write
     /// behavior `aiFormatterEnabled` already has via
-    /// `persistAIFormatterDraftIfNeeded`. Default `true` preserves prior
-    /// behavior; `clearConfiguration()` resets it. See issue #408.
+    /// `persistAIFormatterDraftIfNeeded`. Default `false` keeps live dictation
+    /// low-latency unless the user opts in. See issue #408.
     public var aiFormatterEnabledForDictation: Bool {
         didSet {
             guard aiFormatterEnabledForDictation != oldValue else { return }
@@ -500,11 +500,15 @@ public final class LLMSettingsViewModel {
                 try cliConfigStore?.save(cliConfig)
             }
 
-            let normalizedFormatterPrompt = persistAIFormatterPreferences(from: draft)
-            if draft.aiFormatterPrompt != normalizedFormatterPrompt || draft.aiFormatterEnabled != aiFormatterEnabled {
+            let formatterPersistence = persistAIFormatterPreferences(
+                from: draft,
+                defaultEnabledWhenUnset: Self.storedAIFormatterEnabledPreference(from: defaults) == nil
+            )
+            if draft.aiFormatterPrompt != formatterPersistence.prompt
+                || draft.aiFormatterEnabled != formatterPersistence.enabled {
                 var normalizedDraft = draft
-                normalizedDraft.aiFormatterEnabled = aiFormatterEnabled
-                normalizedDraft.aiFormatterPrompt = normalizedFormatterPrompt
+                normalizedDraft.aiFormatterEnabled = formatterPersistence.enabled
+                normalizedDraft.aiFormatterPrompt = formatterPersistence.prompt
                 draft = normalizedDraft
             }
 
@@ -570,11 +574,12 @@ public final class LLMSettingsViewModel {
         } else {
             apiKey = ""
         }
-        defaults.set(false, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey)
+        defaults.removeObject(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey)
         defaults.set(AIFormatter.defaultPromptTemplate, forKey: UserDefaultsAppRuntimePreferences.aiFormatterPromptKey)
         // Restore the dictation routing preference to its default so a config
         // clear returns the formatter to a fully predictable state.
-        aiFormatterEnabledForDictation = true
+        defaults.set(false, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey)
+        aiFormatterEnabledForDictation = false
         draft = .defaults(
             for: currentProvider,
             apiKey: apiKey,
@@ -951,7 +956,7 @@ public final class LLMSettingsViewModel {
             defaultModelName: Self.defaultModelName(for: config.id),
             defaultBaseURL: Self.defaultBaseURL(for: config.id),
             cliConfig: cliConfig,
-            aiFormatterEnabled: Self.loadStoredAIFormatterEnabled(from: defaults),
+            aiFormatterEnabled: Self.loadStoredAIFormatterEnabled(from: defaults, defaultValue: true),
             aiFormatterPrompt: Self.loadStoredAIFormatterPrompt(from: defaults)
         )
         if Self.usesDiscoveredModelList(config.id) {
@@ -1085,30 +1090,41 @@ public final class LLMSettingsViewModel {
         providerID.supportsModelListing
     }
 
-    private func persistAIFormatterPreferences(from draft: LLMSettingsDraft) -> String {
-        let enabled = draft.providerID != nil && draft.aiFormatterEnabled
+    private func persistAIFormatterPreferences(
+        from draft: LLMSettingsDraft,
+        defaultEnabledWhenUnset: Bool = false
+    ) -> (enabled: Bool, prompt: String) {
+        let preferredEnabled = defaultEnabledWhenUnset ? true : draft.aiFormatterEnabled
+        let enabled = draft.providerID != nil && preferredEnabled
         let normalizedPrompt = draft.normalizedAIFormatterPrompt
         defaults.set(enabled, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey)
         defaults.set(normalizedPrompt, forKey: UserDefaultsAppRuntimePreferences.aiFormatterPromptKey)
-        return normalizedPrompt
+        return (enabled, normalizedPrompt)
     }
 
     private func persistAIFormatterDraftIfNeeded() {
         guard canToggleAIFormatter else { return }
-        let normalizedPrompt = persistAIFormatterPreferences(from: draft)
-        if draft.aiFormatterPrompt != normalizedPrompt {
+        let formatterPersistence = persistAIFormatterPreferences(from: draft)
+        if draft.aiFormatterPrompt != formatterPersistence.prompt {
             var normalizedDraft = draft
-            normalizedDraft.aiFormatterPrompt = normalizedPrompt
+            normalizedDraft.aiFormatterPrompt = formatterPersistence.prompt
             updateDraft(normalizedDraft)
         }
     }
 
-    private static func loadStoredAIFormatterEnabled(from defaults: UserDefaults) -> Bool {
-        defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey) as? Bool ?? false
+    private static func storedAIFormatterEnabledPreference(from defaults: UserDefaults) -> Bool? {
+        defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey) as? Bool
+    }
+
+    private static func loadStoredAIFormatterEnabled(
+        from defaults: UserDefaults,
+        defaultValue: Bool = false
+    ) -> Bool {
+        storedAIFormatterEnabledPreference(from: defaults) ?? defaultValue
     }
 
     private static func loadStoredAIFormatterEnabledForDictation(from defaults: UserDefaults) -> Bool {
-        defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey) as? Bool ?? true
+        defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey) as? Bool ?? false
     }
 
     private static func loadStoredAIFormatterPrompt(from defaults: UserDefaults) -> String {

--- a/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
@@ -360,6 +360,24 @@ public final class LLMSettingsViewModel {
         }
     }
 
+    /// Whether the AI Formatter also runs on live dictation. Unlike
+    /// `aiFormatterEnabled`, this is a routing preference rather than part of the
+    /// saved provider config, so it lives directly on the view model instead of
+    /// the draft. It persists immediately through the injected `defaults` — the
+    /// same store the rest of this view model uses, and the same eager-write
+    /// behavior `aiFormatterEnabled` already has via
+    /// `persistAIFormatterDraftIfNeeded`. Default `true` preserves prior
+    /// behavior; `clearConfiguration()` resets it. See issue #408.
+    public var aiFormatterEnabledForDictation: Bool {
+        didSet {
+            guard aiFormatterEnabledForDictation != oldValue else { return }
+            defaults.set(
+                aiFormatterEnabledForDictation,
+                forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey
+            )
+        }
+    }
+
     public var canToggleAIFormatter: Bool {
         draft.providerID != nil && draft.providerID == savedProviderID
     }
@@ -441,6 +459,7 @@ public final class LLMSettingsViewModel {
 
     public init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
+        self.aiFormatterEnabledForDictation = Self.loadStoredAIFormatterEnabledForDictation(from: defaults)
         self.draft = LLMSettingsDraft(
             aiFormatterEnabled: false,
             aiFormatterPrompt: Self.loadStoredAIFormatterPrompt(from: defaults)
@@ -553,6 +572,9 @@ public final class LLMSettingsViewModel {
         }
         defaults.set(false, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey)
         defaults.set(AIFormatter.defaultPromptTemplate, forKey: UserDefaultsAppRuntimePreferences.aiFormatterPromptKey)
+        // Restore the dictation routing preference to its default so a config
+        // clear returns the formatter to a fully predictable state.
+        aiFormatterEnabledForDictation = true
         draft = .defaults(
             for: currentProvider,
             apiKey: apiKey,
@@ -1083,6 +1105,10 @@ public final class LLMSettingsViewModel {
 
     private static func loadStoredAIFormatterEnabled(from defaults: UserDefaults) -> Bool {
         defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey) as? Bool ?? false
+    }
+
+    private static func loadStoredAIFormatterEnabledForDictation(from defaults: UserDefaults) -> Bool {
+        defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey) as? Bool ?? true
     }
 
     private static func loadStoredAIFormatterPrompt(from defaults: UserDefaults) -> String {

--- a/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
@@ -341,13 +341,7 @@ public final class LLMSettingsViewModel {
     }
 
     public var aiFormatterEnabled: Bool {
-        get { draft.providerID != nil && draft.aiFormatterEnabled }
-        set {
-            var nextDraft = draft
-            nextDraft.aiFormatterEnabled = canToggleAIFormatter ? newValue : false
-            updateDraft(nextDraft)
-            persistAIFormatterDraftIfNeeded()
-        }
+        isAIFormatterAvailable
     }
 
     public var aiFormatterPrompt: String {
@@ -360,14 +354,11 @@ public final class LLMSettingsViewModel {
         }
     }
 
-    /// Whether the AI Formatter also runs on live dictation. Unlike
-    /// `aiFormatterEnabled`, this is a routing preference rather than part of the
-    /// saved provider config, so it lives directly on the view model instead of
-    /// the draft. It persists immediately through the injected `defaults` — the
-    /// same store the rest of this view model uses, and the same eager-write
-    /// behavior `aiFormatterEnabled` already has via
-    /// `persistAIFormatterDraftIfNeeded`. Default `false` keeps live dictation
-    /// low-latency unless the user opts in. See issue #408.
+    /// Whether the AI Formatter also runs on live dictation. Transcript and
+    /// meeting formatter availability follows the saved provider config;
+    /// dictation is the latency-sensitive opt-in path. The value persists
+    /// immediately through the injected `defaults` store. Default `false` keeps
+    /// live dictation low-latency unless the user opts in. See issue #408.
     public var aiFormatterEnabledForDictation: Bool {
         didSet {
             guard aiFormatterEnabledForDictation != oldValue else { return }
@@ -378,12 +369,8 @@ public final class LLMSettingsViewModel {
         }
     }
 
-    public var canToggleAIFormatter: Bool {
+    public var isAIFormatterAvailable: Bool {
         draft.providerID != nil && draft.providerID == savedProviderID
-    }
-
-    public var aiFormatterStatusText: String {
-        aiFormatterEnabled ? "Enabled" : "Disabled"
     }
 
     public var aiFormatterPromptModeText: String {
@@ -392,15 +379,15 @@ public final class LLMSettingsViewModel {
             : "Custom prompt"
     }
 
-    public var aiFormatterDisabledReason: String? {
+    public var aiFormatterUnavailableReason: String? {
         if draft.providerID == nil {
             return "Set up AI to enable the formatter."
         }
         if !isConfigured {
-            return "Save your AI setup first. Formatter changes apply immediately after that."
+            return "Save your AI setup first."
         }
         if draft.providerID != savedProviderID {
-            return "Save this AI option first. Formatter changes apply immediately after that."
+            return "Save this AI option first."
         }
         return nil
     }
@@ -461,7 +448,6 @@ public final class LLMSettingsViewModel {
         self.defaults = defaults
         self.aiFormatterEnabledForDictation = Self.loadStoredAIFormatterEnabledForDictation(from: defaults)
         self.draft = LLMSettingsDraft(
-            aiFormatterEnabled: false,
             aiFormatterPrompt: Self.loadStoredAIFormatterPrompt(from: defaults)
         )
     }
@@ -500,15 +486,10 @@ public final class LLMSettingsViewModel {
                 try cliConfigStore?.save(cliConfig)
             }
 
-            let formatterPersistence = persistAIFormatterPreferences(
-                from: draft,
-                defaultEnabledWhenUnset: Self.storedAIFormatterEnabledPreference(from: defaults) == nil
-            )
-            if draft.aiFormatterPrompt != formatterPersistence.prompt
-                || draft.aiFormatterEnabled != formatterPersistence.enabled {
+            let persistedPrompt = persistAIFormatterPreferences(from: draft)
+            if draft.aiFormatterPrompt != persistedPrompt {
                 var normalizedDraft = draft
-                normalizedDraft.aiFormatterEnabled = formatterPersistence.enabled
-                normalizedDraft.aiFormatterPrompt = formatterPersistence.prompt
+                normalizedDraft.aiFormatterPrompt = persistedPrompt
                 draft = normalizedDraft
             }
 
@@ -578,14 +559,12 @@ public final class LLMSettingsViewModel {
         defaults.set(AIFormatter.defaultPromptTemplate, forKey: UserDefaultsAppRuntimePreferences.aiFormatterPromptKey)
         // Restore the dictation routing preference to its default so a config
         // clear returns the formatter to a fully predictable state.
-        defaults.set(false, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey)
         aiFormatterEnabledForDictation = false
         draft = .defaults(
             for: currentProvider,
             apiKey: apiKey,
             defaultModelName: defaultModelNameAfterClearing(currentProvider),
             cliConfig: preservedCLIConfig,
-            aiFormatterEnabled: false,
             aiFormatterPrompt: AIFormatter.defaultPromptTemplate
         )
         if currentProvider == .lmstudio {
@@ -906,12 +885,10 @@ public final class LLMSettingsViewModel {
     private func applyProviderChange(to providerID: LLMProviderID?) {
         guard draft.providerID != providerID else { return }
         let formatterPrompt = draft.aiFormatterPrompt
-        let formatterEnabled = providerID == nil ? false : draft.aiFormatterEnabled
         guard let providerID else {
             resetDiscoveredModels()
             updateDraft(
                 LLMSettingsDraft(
-                    aiFormatterEnabled: false,
                     aiFormatterPrompt: formatterPrompt
                 )
             )
@@ -925,7 +902,6 @@ public final class LLMSettingsViewModel {
             apiKey: apiKey,
             defaultModelName: Self.defaultModelName(for: providerID),
             cliConfig: cliConfig,
-            aiFormatterEnabled: formatterEnabled,
             aiFormatterPrompt: formatterPrompt
         )
         // Auto-switch to custom model input when provider has no fallback list.
@@ -941,7 +917,6 @@ public final class LLMSettingsViewModel {
     private func loadExistingConfig() {
         guard let configStore, let config = try? configStore.loadConfig() else {
             draft = LLMSettingsDraft(
-                aiFormatterEnabled: false,
                 aiFormatterPrompt: Self.loadStoredAIFormatterPrompt(from: defaults)
             )
             resetDiscoveredModels()
@@ -956,7 +931,6 @@ public final class LLMSettingsViewModel {
             defaultModelName: Self.defaultModelName(for: config.id),
             defaultBaseURL: Self.defaultBaseURL(for: config.id),
             cliConfig: cliConfig,
-            aiFormatterEnabled: Self.loadStoredAIFormatterEnabled(from: defaults, defaultValue: true),
             aiFormatterPrompt: Self.loadStoredAIFormatterPrompt(from: defaults)
         )
         if Self.usesDiscoveredModelList(config.id) {
@@ -1090,37 +1064,28 @@ public final class LLMSettingsViewModel {
         providerID.supportsModelListing
     }
 
-    private func persistAIFormatterPreferences(
-        from draft: LLMSettingsDraft,
-        defaultEnabledWhenUnset: Bool = false
-    ) -> (enabled: Bool, prompt: String) {
-        let preferredEnabled = defaultEnabledWhenUnset ? true : draft.aiFormatterEnabled
-        let enabled = draft.providerID != nil && preferredEnabled
+    private func persistAIFormatterPreferences(from draft: LLMSettingsDraft) -> String {
+        let enabled = draft.providerID != nil
         let normalizedPrompt = draft.normalizedAIFormatterPrompt
         defaults.set(enabled, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey)
         defaults.set(normalizedPrompt, forKey: UserDefaultsAppRuntimePreferences.aiFormatterPromptKey)
-        return (enabled, normalizedPrompt)
+        if defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey) == nil {
+            defaults.set(
+                aiFormatterEnabledForDictation,
+                forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey
+            )
+        }
+        return normalizedPrompt
     }
 
     private func persistAIFormatterDraftIfNeeded() {
-        guard canToggleAIFormatter else { return }
-        let formatterPersistence = persistAIFormatterPreferences(from: draft)
-        if draft.aiFormatterPrompt != formatterPersistence.prompt {
+        guard isAIFormatterAvailable else { return }
+        let persistedPrompt = persistAIFormatterPreferences(from: draft)
+        if draft.aiFormatterPrompt != persistedPrompt {
             var normalizedDraft = draft
-            normalizedDraft.aiFormatterPrompt = formatterPersistence.prompt
+            normalizedDraft.aiFormatterPrompt = persistedPrompt
             updateDraft(normalizedDraft)
         }
-    }
-
-    private static func storedAIFormatterEnabledPreference(from defaults: UserDefaults) -> Bool? {
-        defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey) as? Bool
-    }
-
-    private static func loadStoredAIFormatterEnabled(
-        from defaults: UserDefaults,
-        defaultValue: Bool = false
-    ) -> Bool {
-        storedAIFormatterEnabledPreference(from: defaults) ?? defaultValue
     }
 
     private static func loadStoredAIFormatterEnabledForDictation(from defaults: UserDefaults) -> Bool {

--- a/Tests/MacParakeetTests/App/AppEnvironmentTests.swift
+++ b/Tests/MacParakeetTests/App/AppEnvironmentTests.swift
@@ -3,13 +3,13 @@ import MacParakeetCore
 import XCTest
 
 final class AppEnvironmentTests: XCTestCase {
-    func testEnableAIFormatterByDefaultWhenLLMConfiguredWritesTrueWhenPreferenceUnset() {
+    func testSyncAIFormatterAvailabilityWritesTrueWhenProviderExists() {
         let (suiteName, defaults) = makeDefaults()
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let configStore = MockLLMConfigStore()
         configStore.config = .openai(apiKey: "sk-test")
 
-        AppEnvironment.enableAIFormatterByDefaultWhenLLMConfigured(
+        AppEnvironment.syncAIFormatterAvailabilityWithLLMConfiguration(
             defaults: defaults,
             configStore: configStore
         )
@@ -18,37 +18,146 @@ final class AppEnvironmentTests: XCTestCase {
             defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey) as? Bool,
             true
         )
+        XCTAssertEqual(
+            defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey) as? Bool,
+            false
+        )
     }
 
-    func testEnableAIFormatterByDefaultWhenLLMConfiguredPreservesExplicitFalse() {
+    func testSyncAIFormatterAvailabilityOverwritesLegacyExplicitFalseWhenProviderExists() {
         let (suiteName, defaults) = makeDefaults()
         defer { defaults.removePersistentDomain(forName: suiteName) }
         defaults.set(false, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey)
         let configStore = MockLLMConfigStore()
         configStore.config = .openai(apiKey: "sk-test")
 
-        AppEnvironment.enableAIFormatterByDefaultWhenLLMConfigured(
+        AppEnvironment.syncAIFormatterAvailabilityWithLLMConfiguration(
             defaults: defaults,
             configStore: configStore
         )
 
         XCTAssertEqual(
             defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey) as? Bool,
+            true
+        )
+        XCTAssertEqual(
+            defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey) as? Bool,
             false
         )
     }
 
-    func testEnableAIFormatterByDefaultWhenLLMConfiguredLeavesPreferenceUnsetWithoutProvider() {
+    func testSyncAIFormatterAvailabilityDoesNotMigrateLegacyExplicitFalseOnSecondRun() {
+        let (suiteName, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(false, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey)
+        let configStore = MockLLMConfigStore()
+        configStore.config = .openai(apiKey: "sk-test")
+
+        AppEnvironment.syncAIFormatterAvailabilityWithLLMConfiguration(
+            defaults: defaults,
+            configStore: configStore
+        )
+        AppEnvironment.syncAIFormatterAvailabilityWithLLMConfiguration(
+            defaults: defaults,
+            configStore: configStore
+        )
+
+        XCTAssertEqual(
+            defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey) as? Bool,
+            true
+        )
+        XCTAssertEqual(
+            defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey) as? Bool,
+            false
+        )
+    }
+
+    func testSyncAIFormatterAvailabilityDoesNotMigrateNewProviderOnSecondRun() {
         let (suiteName, defaults) = makeDefaults()
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let configStore = MockLLMConfigStore()
+        configStore.config = .openai(apiKey: "sk-test")
 
-        AppEnvironment.enableAIFormatterByDefaultWhenLLMConfigured(
+        AppEnvironment.syncAIFormatterAvailabilityWithLLMConfiguration(
+            defaults: defaults,
+            configStore: configStore
+        )
+        AppEnvironment.syncAIFormatterAvailabilityWithLLMConfiguration(
+            defaults: defaults,
+            configStore: configStore
+        )
+
+        XCTAssertEqual(
+            defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey) as? Bool,
+            true
+        )
+        XCTAssertEqual(
+            defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey) as? Bool,
+            false
+        )
+    }
+
+    func testSyncAIFormatterAvailabilityMigratesLegacyExplicitTrueToDictationPreference() {
+        let (suiteName, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey)
+        let configStore = MockLLMConfigStore()
+        configStore.config = .openai(apiKey: "sk-test")
+
+        AppEnvironment.syncAIFormatterAvailabilityWithLLMConfiguration(
+            defaults: defaults,
+            configStore: configStore
+        )
+
+        XCTAssertEqual(
+            defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey) as? Bool,
+            true
+        )
+        XCTAssertEqual(
+            defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey) as? Bool,
+            true
+        )
+    }
+
+    func testSyncAIFormatterAvailabilityPreservesExistingDictationPreference() {
+        let (suiteName, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey)
+        defaults.set(false, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey)
+        let configStore = MockLLMConfigStore()
+        configStore.config = .openai(apiKey: "sk-test")
+
+        AppEnvironment.syncAIFormatterAvailabilityWithLLMConfiguration(
+            defaults: defaults,
+            configStore: configStore
+        )
+
+        XCTAssertEqual(
+            defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey) as? Bool,
+            true
+        )
+        XCTAssertEqual(
+            defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey) as? Bool,
+            false
+        )
+    }
+
+    func testSyncAIFormatterAvailabilityRemovesPreferenceWithoutProvider() {
+        let (suiteName, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey)
+        let configStore = MockLLMConfigStore()
+
+        AppEnvironment.syncAIFormatterAvailabilityWithLLMConfiguration(
             defaults: defaults,
             configStore: configStore
         )
 
         XCTAssertNil(defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey))
+        XCTAssertEqual(
+            defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey) as? Bool,
+            false
+        )
     }
 
     private func makeDefaults() -> (suiteName: String, defaults: UserDefaults) {

--- a/Tests/MacParakeetTests/App/AppEnvironmentTests.swift
+++ b/Tests/MacParakeetTests/App/AppEnvironmentTests.swift
@@ -1,0 +1,60 @@
+import MacParakeetCore
+@testable import MacParakeet
+import XCTest
+
+final class AppEnvironmentTests: XCTestCase {
+    func testEnableAIFormatterByDefaultWhenLLMConfiguredWritesTrueWhenPreferenceUnset() {
+        let (suiteName, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let configStore = MockLLMConfigStore()
+        configStore.config = .openai(apiKey: "sk-test")
+
+        AppEnvironment.enableAIFormatterByDefaultWhenLLMConfigured(
+            defaults: defaults,
+            configStore: configStore
+        )
+
+        XCTAssertEqual(
+            defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey) as? Bool,
+            true
+        )
+    }
+
+    func testEnableAIFormatterByDefaultWhenLLMConfiguredPreservesExplicitFalse() {
+        let (suiteName, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(false, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey)
+        let configStore = MockLLMConfigStore()
+        configStore.config = .openai(apiKey: "sk-test")
+
+        AppEnvironment.enableAIFormatterByDefaultWhenLLMConfigured(
+            defaults: defaults,
+            configStore: configStore
+        )
+
+        XCTAssertEqual(
+            defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey) as? Bool,
+            false
+        )
+    }
+
+    func testEnableAIFormatterByDefaultWhenLLMConfiguredLeavesPreferenceUnsetWithoutProvider() {
+        let (suiteName, defaults) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let configStore = MockLLMConfigStore()
+
+        AppEnvironment.enableAIFormatterByDefaultWhenLLMConfigured(
+            defaults: defaults,
+            configStore: configStore
+        )
+
+        XCTAssertNil(defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey))
+    }
+
+    private func makeDefaults() -> (suiteName: String, defaults: UserDefaults) {
+        let suiteName = "AppEnvironmentTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return (suiteName, defaults)
+    }
+}

--- a/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
+++ b/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
@@ -87,18 +87,16 @@ final class AppRuntimePreferencesTests: XCTestCase {
         XCTAssertTrue(UserDefaultsAppRuntimePreferences(defaults: defaults).pauseMediaDuringDictation)
     }
 
-    func testAIFormatterEnabledForDictationDefaultsToTrueAndReadsPersistedValue() {
+    func testAIFormatterEnabledForDictationDefaultsToFalseAndReadsPersistedValue() {
         let suite = "app-runtime-prefs-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
         defer { defaults.removePersistentDomain(forName: suite) }
 
-        // Defaults to true so existing installs keep formatting dictation as
-        // before — opting dictation out is an explicit user choice (issue #408).
-        XCTAssertTrue(UserDefaultsAppRuntimePreferences(defaults: defaults).aiFormatterEnabledForDictation)
-
-        defaults.set(false, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey)
-
         XCTAssertFalse(UserDefaultsAppRuntimePreferences(defaults: defaults).aiFormatterEnabledForDictation)
+
+        defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey)
+
+        XCTAssertTrue(UserDefaultsAppRuntimePreferences(defaults: defaults).aiFormatterEnabledForDictation)
     }
 
     /// Models the gate the composition root installs on the dictation path: the

--- a/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
+++ b/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
@@ -86,4 +86,39 @@ final class AppRuntimePreferencesTests: XCTestCase {
 
         XCTAssertTrue(UserDefaultsAppRuntimePreferences(defaults: defaults).pauseMediaDuringDictation)
     }
+
+    func testAIFormatterEnabledForDictationDefaultsToTrueAndReadsPersistedValue() {
+        let suite = "app-runtime-prefs-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        // Defaults to true so existing installs keep formatting dictation as
+        // before — opting dictation out is an explicit user choice (issue #408).
+        XCTAssertTrue(UserDefaultsAppRuntimePreferences(defaults: defaults).aiFormatterEnabledForDictation)
+
+        defaults.set(false, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey)
+
+        XCTAssertFalse(UserDefaultsAppRuntimePreferences(defaults: defaults).aiFormatterEnabledForDictation)
+    }
+
+    /// Models the gate the composition root installs on the dictation path: the
+    /// AI Formatter runs on dictation only when the global switch AND the
+    /// dictation-specific switch are both on, while the file/meeting path keys
+    /// off the global switch alone.
+    func testDictationFormatterGateIsConjunctionOfGlobalAndDictationFlags() {
+        func dictationGate(global: Bool, dictation: Bool) -> Bool {
+            let suite = "app-runtime-prefs-\(UUID().uuidString)"
+            let defaults = UserDefaults(suiteName: suite)!
+            defer { defaults.removePersistentDomain(forName: suite) }
+            defaults.set(global, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey)
+            defaults.set(dictation, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey)
+            let prefs = UserDefaultsAppRuntimePreferences(defaults: defaults)
+            return prefs.aiFormatterEnabled && prefs.aiFormatterEnabledForDictation
+        }
+
+        XCTAssertTrue(dictationGate(global: true, dictation: true))
+        XCTAssertFalse(dictationGate(global: true, dictation: false))
+        XCTAssertFalse(dictationGate(global: false, dictation: true))
+        XCTAssertFalse(dictationGate(global: false, dictation: false))
+    }
 }

--- a/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
@@ -92,7 +92,6 @@ final class LLMSettingsViewModelTests: XCTestCase {
         )
     }
 
-
     func testSetupStatusReadyUsesSavedProviderDisplayName() {
         mockConfigStore.config = .lmstudio(model: "local-model")
         viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
@@ -772,12 +771,11 @@ final class LLMSettingsViewModelTests: XCTestCase {
     func testSelectingNoneDisablesAIFormatter() {
         viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
         viewModel.selectedProviderID = .openai
-        viewModel.aiFormatterEnabled = true
 
         viewModel.selectedProviderID = nil
 
         XCTAssertFalse(viewModel.aiFormatterEnabled)
-        XCTAssertFalse(viewModel.canToggleAIFormatter)
+        XCTAssertFalse(viewModel.isAIFormatterAvailable)
     }
 
     func testNoneProviderReturnsEmptyModels() {
@@ -997,7 +995,6 @@ final class LLMSettingsViewModelTests: XCTestCase {
         viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
         viewModel.selectedProviderID = .openai
         viewModel.apiKeyInput = "sk-test"
-        viewModel.aiFormatterEnabled = true
         viewModel.aiFormatterPrompt = "Rewrite this carefully:\n\(AIFormatter.transcriptPlaceholder)"
 
         viewModel.saveConfiguration()
@@ -1020,10 +1017,14 @@ final class LLMSettingsViewModelTests: XCTestCase {
             defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey) as? Bool,
             true
         )
+        XCTAssertEqual(
+            defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey) as? Bool,
+            false
+        )
         XCTAssertTrue(viewModel.aiFormatterEnabled)
     }
 
-    func testSavePreservesExplicitAIFormatterDisabledPreference() {
+    func testSaveEnablesAIFormatterWhenLegacyPreferenceWasFalse() {
         defaults.set(false, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey)
         viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
         viewModel.selectedProviderID = .openai
@@ -1033,9 +1034,13 @@ final class LLMSettingsViewModelTests: XCTestCase {
 
         XCTAssertEqual(
             defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey) as? Bool,
+            true
+        )
+        XCTAssertEqual(
+            defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey) as? Bool,
             false
         )
-        XCTAssertFalse(viewModel.aiFormatterEnabled)
+        XCTAssertTrue(viewModel.aiFormatterEnabled)
     }
 
     func testFieldChangeResetsSaveState() {
@@ -1079,25 +1084,21 @@ final class LLMSettingsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.aiFormatterPrompt, AIFormatter.defaultPromptTemplate)
     }
 
-    func testAIFormatterStaysDisabledUntilProviderIsSaved() {
+    func testAIFormatterUnavailableUntilProviderIsSaved() {
         viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
         viewModel.selectedProviderID = .openai
 
-        XCTAssertFalse(viewModel.canToggleAIFormatter)
-
-        viewModel.aiFormatterEnabled = true
-
+        XCTAssertFalse(viewModel.isAIFormatterAvailable)
         XCTAssertFalse(viewModel.aiFormatterEnabled)
         XCTAssertNil(defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey))
     }
 
-    func testAIFormatterTogglePersistsImmediatelyWhenConfigured() {
+    func testAIFormatterPromptPersistsImmediatelyWhenConfigured() {
         mockConfigStore.config = .openai(apiKey: "sk-test")
         viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
 
-        XCTAssertTrue(viewModel.canToggleAIFormatter)
+        XCTAssertTrue(viewModel.isAIFormatterAvailable)
 
-        viewModel.aiFormatterEnabled = true
         viewModel.aiFormatterPrompt = "Rewrite:\n\(AIFormatter.transcriptPlaceholder)"
 
         XCTAssertTrue(defaults.bool(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey))

--- a/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
@@ -46,39 +46,49 @@ final class LLMSettingsViewModelTests: XCTestCase {
 
     // MARK: - AI Formatter: dictation routing toggle (#408)
 
-    func testAIFormatterEnabledForDictationDefaultsToTrue() {
-        XCTAssertTrue(viewModel.aiFormatterEnabledForDictation)
+    func testAIFormatterEnabledForDictationDefaultsToFalse() {
+        XCTAssertFalse(viewModel.aiFormatterEnabledForDictation)
     }
 
     func testAIFormatterEnabledForDictationPersistsThroughInjectedDefaults() {
-        viewModel.aiFormatterEnabledForDictation = false
-        XCTAssertFalse(
-            defaults.bool(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey)
-        )
+        let key = UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey
+        let standard = UserDefaults.standard
+        let priorStandardValue = standard.object(forKey: key)
+        standard.set(false, forKey: key)
+        defer {
+            if let priorStandardValue {
+                standard.set(priorStandardValue, forKey: key)
+            } else {
+                standard.removeObject(forKey: key)
+            }
+        }
+
+        viewModel.aiFormatterEnabledForDictation = true
+
+        XCTAssertEqual(defaults.object(forKey: key) as? Bool, true)
         // The view model uses the injected store, not UserDefaults.standard.
-        XCTAssertFalse(
-            UserDefaults.standard.object(
-                forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey
-            ) as? Bool ?? false
-        )
+        XCTAssertEqual(standard.object(forKey: key) as? Bool, false)
     }
 
     func testAIFormatterEnabledForDictationLoadsStoredValueOnInit() {
-        defaults.set(false, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey)
+        defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey)
         let reloaded = LLMSettingsViewModel(defaults: defaults)
-        XCTAssertFalse(reloaded.aiFormatterEnabledForDictation)
+        XCTAssertTrue(reloaded.aiFormatterEnabledForDictation)
     }
 
     func testClearConfigurationRestoresDictationRoutingDefault() {
         mockConfigStore.config = .lmstudio(model: "local-model")
         viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
-        viewModel.aiFormatterEnabledForDictation = false
+        viewModel.aiFormatterEnabledForDictation = true
 
         viewModel.clearConfiguration()
 
-        XCTAssertTrue(viewModel.aiFormatterEnabledForDictation)
-        XCTAssertTrue(
-            defaults.bool(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey)
+        XCTAssertFalse(viewModel.aiFormatterEnabledForDictation)
+        XCTAssertEqual(
+            defaults.object(
+                forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey
+            ) as? Bool,
+            false
         )
     }
 
@@ -234,6 +244,15 @@ final class LLMSettingsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.useCustomModel)
     }
 
+    func testLoadsExistingConfigEnablesAIFormatterByDefaultWhenPreferenceUnset() {
+        mockConfigStore.config = .openai(apiKey: "sk-existing", model: "gpt-4.1")
+
+        viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
+
+        XCTAssertTrue(viewModel.aiFormatterEnabled)
+        XCTAssertNil(defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey))
+    }
+
     func testLoadsExistingConfigWithCustomModel() {
         mockConfigStore.config = .openai(apiKey: "sk-existing", model: "gpt-4")
 
@@ -292,7 +311,8 @@ final class LLMSettingsViewModelTests: XCTestCase {
 
         viewModel.clearConfiguration()
 
-        XCTAssertFalse(defaults.bool(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey))
+        XCTAssertNil(defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey))
+        XCTAssertFalse(UserDefaultsAppRuntimePreferences(defaults: defaults).aiFormatterEnabled)
         XCTAssertEqual(
             defaults.string(forKey: UserDefaultsAppRuntimePreferences.aiFormatterPromptKey),
             AIFormatter.defaultPromptTemplate
@@ -987,6 +1007,35 @@ final class LLMSettingsViewModelTests: XCTestCase {
             defaults.string(forKey: UserDefaultsAppRuntimePreferences.aiFormatterPromptKey),
             "Rewrite this carefully:\n\(AIFormatter.transcriptPlaceholder)"
         )
+    }
+
+    func testSaveEnablesAIFormatterByDefaultForNewProviderConfiguration() {
+        viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
+        viewModel.selectedProviderID = .openai
+        viewModel.apiKeyInput = "sk-test"
+
+        viewModel.saveConfiguration()
+
+        XCTAssertEqual(
+            defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey) as? Bool,
+            true
+        )
+        XCTAssertTrue(viewModel.aiFormatterEnabled)
+    }
+
+    func testSavePreservesExplicitAIFormatterDisabledPreference() {
+        defaults.set(false, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey)
+        viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
+        viewModel.selectedProviderID = .openai
+        viewModel.apiKeyInput = "sk-test"
+
+        viewModel.saveConfiguration()
+
+        XCTAssertEqual(
+            defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey) as? Bool,
+            false
+        )
+        XCTAssertFalse(viewModel.aiFormatterEnabled)
     }
 
     func testFieldChangeResetsSaveState() {

--- a/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
@@ -44,6 +44,45 @@ final class LLMSettingsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.aiFormatterPromptModeText, "Default prompt")
     }
 
+    // MARK: - AI Formatter: dictation routing toggle (#408)
+
+    func testAIFormatterEnabledForDictationDefaultsToTrue() {
+        XCTAssertTrue(viewModel.aiFormatterEnabledForDictation)
+    }
+
+    func testAIFormatterEnabledForDictationPersistsThroughInjectedDefaults() {
+        viewModel.aiFormatterEnabledForDictation = false
+        XCTAssertFalse(
+            defaults.bool(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey)
+        )
+        // The view model uses the injected store, not UserDefaults.standard.
+        XCTAssertFalse(
+            UserDefaults.standard.object(
+                forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey
+            ) as? Bool ?? false
+        )
+    }
+
+    func testAIFormatterEnabledForDictationLoadsStoredValueOnInit() {
+        defaults.set(false, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey)
+        let reloaded = LLMSettingsViewModel(defaults: defaults)
+        XCTAssertFalse(reloaded.aiFormatterEnabledForDictation)
+    }
+
+    func testClearConfigurationRestoresDictationRoutingDefault() {
+        mockConfigStore.config = .lmstudio(model: "local-model")
+        viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
+        viewModel.aiFormatterEnabledForDictation = false
+
+        viewModel.clearConfiguration()
+
+        XCTAssertTrue(viewModel.aiFormatterEnabledForDictation)
+        XCTAssertTrue(
+            defaults.bool(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey)
+        )
+    }
+
+
     func testSetupStatusReadyUsesSavedProviderDisplayName() {
         mockConfigStore.config = .lmstudio(model: "local-model")
         viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)


### PR DESCRIPTION
> Related issue: #408 — separate Dictation/Transform AI from Meeting AI. This PR is the focused first step: Dictation gets its own AI formatting opt-in while Transcription and Meetings AI features follow whether an LLM provider is configured.

## Summary

Makes Dictation the only explicit AI Formatter toggle. Once an LLM provider/API key is configured, AI-backed Transcription and Meetings features are available by default with no separate user-facing global gate.

- File/meeting transcript formatting uses the saved provider configuration as the availability gate.
- Dictation gates AI formatting on `aiFormatterEnabled && aiFormatterEnabledForDictation`.
- New users and legacy users who had the old formatter disabled are sealed to dictation-off, including across repeated launches.
- Legacy users who explicitly had the old AI Formatter enabled migrate once to `aiFormatterEnabledForDictation = true`, preserving their existing dictation behavior.
- Clearing the LLM configuration removes the internal formatter availability flag and resets dictation routing to off.
- Settings now shows only the dictation opt-in toggle in the AI Formatter section.

## Why

Entering an LLM provider/API key is the user's permission for AI features in Transcription and Meetings, such as transcript chat, summaries, and custom prompts. Dictation is different because it is latency-sensitive: short utterances can feel noticeably slower when every paste waits for an LLM response. This keeps provider setup simple while leaving dictation AI formatting under a dedicated opt-in toggle.

## Implementation

- `Sources/MacParakeetCore/AppRuntimePreferences.swift` — adds `aiFormatterEnabledForDictation`, defaulting to `false`.
- `Sources/MacParakeet/App/AppEnvironment.swift` — syncs the internal formatter availability flag from saved provider configuration and seals the new dictation preference so migration is idempotent.
- `Sources/MacParakeetViewModels/LLMSettingsViewModel.swift` — derives formatter availability from saved provider state, persists prompt/settings through injected defaults, and seals dictation-off on new provider saves when no dictation preference exists.
- `Sources/MacParakeetViewModels/LLMSettingsDraft.swift` — removes the dead draft-level global formatter toggle.
- `Sources/MacParakeet/Views/Settings/LLMSettingsView.swift` — removes the global activation control and shows only the Dictation opt-in toggle.
- Tests cover runtime preference conjunction, settings save/clear behavior, provider defaulting, one-time legacy migration, and second-launch idempotency.

## Testing

- `git diff --check`
- `swift test --filter AppEnvironmentTests --build-path /Users/dmoon/code/macparakeet/.build --skip-update` — 7/7 pass.
- `swift test --filter LLMSettingsViewModelTests --build-path /Users/dmoon/code/macparakeet/.build --skip-update` — 101/101 pass.
- `swift test --build-path /Users/dmoon/code/macparakeet/.build --skip-update` — 3,235 XCTest tests pass, 10 skipped; 16 Swift Testing tests pass.

## Review

Local review, Gemini, and Claude converged on the final behavior. The only substantive external finding was a migration idempotency bug; this branch now seals the dictation preference on first sync/save and includes regression tests for the second-launch cases.