### PR TITLE
Support yt-dlp media URLs in CLI transcribe

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -87,6 +87,13 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
   `--speaker-max <n>` for a range. These flags imply speaker detection when
   `--speaker-detection` is left at `app-default`, and they are rejected with
   `--speaker-detection off` or `--no-diarize`.
+- `transcribe` now accepts any explicit `http://` or `https://` media URL that
+  `yt-dlp` can download, including non-YouTube sites such as Facebook Reels,
+  before passing the downloaded audio/video through the local transcription
+  pipeline.
+- `transcribe --media-audio-quality app-default|m4a|best-available` is the new
+  canonical spelling for downloaded media quality. The older
+  `--youtube-audio-quality` spelling remains accepted as a compatibility alias.
 
 ## [2.6.0] -- 2026-05-31
 

--- a/Sources/CLI/Commands/HealthCommand.swift
+++ b/Sources/CLI/Commands/HealthCommand.swift
@@ -197,7 +197,7 @@ struct HealthCommand: AsyncParsableCommand {
             ytDlp = .init(
                 status: "missing",
                 path: nil,
-                error: "Run `macparakeet-cli health --repair-binaries` or transcribe a YouTube URL to install yt-dlp."
+                error: "Run `macparakeet-cli health --repair-binaries` or transcribe a media URL to install yt-dlp."
             )
         }
         report.ytDlp = ytDlp

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -53,7 +53,7 @@ struct ResolvedSpeakerDetection: Equatable, Sendable {
 struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
     static let configuration = CommandConfiguration(
         commandName: "transcribe",
-        abstract: "Transcribe an audio/video file or YouTube URL.",
+        abstract: "Transcribe an audio/video file or media URL.",
         discussion: """
         Telemetry: the root CLI runner emits one privacy-safe `cli_operation` \
         event per invocation; `transcribe` adds allowlisted input/output metadata \
@@ -66,7 +66,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
         """
     )
 
-    @Argument(help: "One or more audio/video file paths, folders, or YouTube URLs. Multiple inputs (or --output-dir) transcribe in sequence, writing one file each.")
+    @Argument(help: "One or more audio/video file paths, folders, YouTube URLs, or HTTP(S) media URLs supported by yt-dlp. Multiple inputs (or --output-dir) transcribe in sequence, writing one file each.")
     var inputs: [String]
 
     @Option(name: .long, help: "Directory to write one transcript per input. Implies batch mode; created if missing. When omitted with multiple inputs, the current directory is used.")
@@ -87,11 +87,14 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
     @Option(name: .long, help: "Parakeet build: app-default, v3 (multilingual), v2 (English-only). app-default follows the saved preference; ignored for Whisper.")
     var parakeetModel: TranscribeParakeetModel = .appDefault
 
-    @Option(help: "Downloaded YouTube audio retention: app-default, keep, delete.")
+    @Option(help: "Downloaded media retention: app-default, keep, delete.")
     var downloadedAudio: DownloadedAudioPolicy = .appDefault
 
-    @Option(help: "YouTube audio quality: app-default, m4a, best-available.")
-    var youtubeAudioQuality: YouTubeAudioQualityOption = .appDefault
+    @Option(name: .customLong("media-audio-quality"), help: "Downloaded media audio quality: app-default, m4a, best-available.")
+    var mediaAudioQuality: YouTubeAudioQualityOption?
+
+    @Option(name: .customLong("youtube-audio-quality"), help: .hidden)
+    var legacyYouTubeAudioQuality: YouTubeAudioQualityOption?
 
     @Option(help: "Path to SQLite database file (defaults to the app database).")
     var database: String?
@@ -114,7 +117,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
     @Flag(help: "Run retained entitlement checks before transcribing. Current free builds remain unlocked.")
     var enforceEntitlements: Bool = false
 
-    @Flag(name: .long, help: "Do not save the completed transcription to MacParakeet history. YouTube audio is temporary.")
+    @Flag(name: .long, help: "Do not save the completed transcription to MacParakeet history. Downloaded media is temporary.")
     var noHistory: Bool = false
 
     var cliTelemetryMetadata: CLITelemetry.OperationMetadata {
@@ -126,12 +129,19 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
         )
     }
 
+    var effectiveMediaAudioQuality: YouTubeAudioQualityOption {
+        mediaAudioQuality ?? legacyYouTubeAudioQuality ?? .appDefault
+    }
+
     func validate() throws {
         if inputs.isEmpty {
-            throw ValidationError("Provide at least one file path, folder, or YouTube URL to transcribe.")
+            throw ValidationError("Provide at least one file path, folder, or media URL to transcribe.")
         }
         if noHistory && downloadedAudio == .keep {
             throw ValidationError("--no-history cannot be combined with --downloaded-audio keep.")
+        }
+        if mediaAudioQuality != nil && legacyYouTubeAudioQuality != nil {
+            throw ValidationError("--media-audio-quality and --youtube-audio-quality cannot be combined.")
         }
         try Self.validateSpeakerConstraintOptions(
             speakerDetection: speakerDetection,
@@ -153,7 +163,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
         }
     }
 
-    static func resolveYouTubeAudioQuality(
+    static func resolveMediaAudioQuality(
         _ quality: YouTubeAudioQualityOption,
         storedQuality: String?
     ) -> YouTubeAudioQuality {
@@ -318,7 +328,25 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
         if YouTubeURLValidator.isYouTubeURL(trimmedInput) {
             return .youtube
         }
+        if DownloadableMediaURLValidator.isDownloadableMediaURL(trimmedInput) {
+            return .media
+        }
         return Observability.inputKind(for: Self.localFileURL(for: trimmedInput)) ?? .unknown
+    }
+
+    static func isDownloadableURLInput(_ input: String) -> Bool {
+        downloadableURLInput(input) != nil
+    }
+
+    static func downloadableURLInput(_ input: String) -> String? {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        guard YouTubeURLValidator.isYouTubeURL(trimmed)
+            || DownloadableMediaURLValidator.isDownloadableMediaURL(trimmed)
+        else {
+            return nil
+        }
+        return trimmed
     }
 
     func run() async throws {
@@ -361,8 +389,8 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
                 self.mode,
                 storedMode: defaults.string(forKey: UserDefaultsAppRuntimePreferences.processingModeKey)
             )
-            let resolvedYouTubeAudioQuality = Self.resolveYouTubeAudioQuality(
-                self.youtubeAudioQuality,
+            let resolvedMediaAudioQuality = Self.resolveMediaAudioQuality(
+                self.effectiveMediaAudioQuality,
                 storedQuality: defaults.string(forKey: UserDefaultsAppRuntimePreferences.youtubeAudioQualityKey)
             )
             let configuredShouldKeepDownloadedAudio: Bool = switch self.downloadedAudio {
@@ -391,7 +419,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
             }
             let audioProcessor = AudioProcessor()
             let youtubeDownloader = YouTubeDownloader(audioQuality: {
-                resolvedYouTubeAudioQuality
+                resolvedMediaAudioQuality
             })
             let entitlementsService = enforceEntitlements ? makeEntitlementsService() : nil
 
@@ -490,7 +518,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
         }
     }
 
-    /// Transcribe a single resolved input (YouTube URL or local file) and
+    /// Transcribe a single resolved input (media URL or local file) and
     /// return the record. Progress is reported on stderr; this throws on
     /// missing/unsupported files or transcription errors so callers can either
     /// surface it (single mode) or count and continue (batch mode).
@@ -518,11 +546,11 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
             }
         }
 
-        if YouTubeURLValidator.isYouTubeURL(input) {
+        if let mediaURL = Self.downloadableURLInput(input) {
             if noHistory {
-                return try await service.transcribeURLTransient(urlString: input, onProgress: progressHandler)
+                return try await service.transcribeURLTransient(urlString: mediaURL, onProgress: progressHandler)
             }
-            return try await service.transcribeURL(urlString: input, onProgress: progressHandler)
+            return try await service.transcribeURL(urlString: mediaURL, onProgress: progressHandler)
         }
 
         let url = Self.localFileURL(for: input)
@@ -541,15 +569,15 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
     }
 
     /// Expand folder arguments into their supported audio files and
-    /// de-duplicate while preserving order. YouTube URLs and individual file
+    /// de-duplicate while preserving order. Media URLs and individual file
     /// paths pass through unchanged (existence/support is checked per file in
     /// `transcribeOne`).
     static func expandInputs(_ inputs: [String]) -> [String] {
         var result: [String] = []
         var seen: Set<String> = []
         for input in inputs {
-            if YouTubeURLValidator.isYouTubeURL(input) {
-                if seen.insert(input).inserted { result.append(input) }
+            if let mediaURL = Self.downloadableURLInput(input) {
+                if seen.insert(mediaURL).inserted { result.append(mediaURL) }
                 continue
             }
             let url = localFileURL(for: input).standardizedFileURL
@@ -575,7 +603,18 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
     }
 
     static func displayName(for input: String) -> String {
-        YouTubeURLValidator.isYouTubeURL(input) ? input : localFileURL(for: input).lastPathComponent
+        if let mediaURL = Self.downloadableURLInput(input) {
+            return displayNameForMediaURL(mediaURL)
+        }
+        return localFileURL(for: input).lastPathComponent
+    }
+
+    static func displayNameForMediaURL(_ mediaURL: String) -> String {
+        let trimmed = mediaURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let queryOrFragmentIndex = trimmed.firstIndex(where: { $0 == "?" || $0 == "#" }) else {
+            return trimmed
+        }
+        return String(trimmed[..<queryOrFragmentIndex])
     }
 
     /// Write one transcript file for `t` into `dir`, named after the source and

--- a/Sources/MacParakeetCore/Services/Telemetry/Observability.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/Observability.swift
@@ -11,6 +11,7 @@ public enum ObservabilityOutcome: String, Sendable {
 public enum ObservabilityInputKind: String, Sendable {
     case audio
     case video
+    case media
     case youtube
     case meeting
     case unknown

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -564,9 +564,10 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
         persistResult: Bool,
         onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
     ) async throws -> Transcription {
+        let mediaURL = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
         let operation = TranscriptionOperationContext(
             source: .youtube,
-            inputKind: .youtube,
+            inputKind: YouTubeURLValidator.isYouTubeURL(mediaURL) ? .youtube : .media,
             mediaExtension: nil,
             fileSizeBucket: nil
         )
@@ -594,7 +595,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
             let downloadResult: YouTubeDownloader.DownloadResult
             do {
                 onProgress?(.downloading(percent: 0))
-                downloadResult = try await downloader.download(url: urlString) { percent in
+                downloadResult = try await downloader.download(url: mediaURL) { percent in
                     onProgress?(.downloading(percent: percent))
                 }
             } catch {
@@ -669,7 +670,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
                 durationMs: durationMs,
                 language: nil,
                 status: .processing,
-                sourceURL: urlString,
+                sourceURL: mediaURL,
                 thumbnailURL: downloadResult.thumbnailURL,
                 channelName: channelName,
                 videoDescription: videoDescription,

--- a/Sources/MacParakeetCore/Services/YouTubeDownloader.swift
+++ b/Sources/MacParakeetCore/Services/YouTubeDownloader.swift
@@ -10,8 +10,8 @@ public enum YouTubeDownloadError: Error, LocalizedError {
 
     public var errorDescription: String? {
         switch self {
-        case .invalidURL: return "Not a valid YouTube URL"
-        case .videoNotFound: return "Video not found or is private"
+        case .invalidURL: return "Not a valid media URL"
+        case .videoNotFound: return "Video not found, private, or unavailable"
         case .downloadFailed(let reason): return "Download failed: \(reason)"
         case .ytDlpNotFound: return "yt-dlp not found. Run the app once to install dependencies."
         case .timedOut: return "Download timed out — the connection may have stalled"
@@ -85,20 +85,21 @@ public actor YouTubeDownloader {
         self.audioQuality = audioQuality
     }
 
-    /// Download audio from a YouTube URL.
+    /// Download audio from any HTTP(S) media URL that yt-dlp supports.
     public func download(url: String, onProgress: (@Sendable (Int) -> Void)? = nil) async throws -> DownloadResult {
-        guard YouTubeURLValidator.isYouTubeURL(url) else {
+        let mediaURL = url.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard Self.isSupportedMediaURL(mediaURL) else {
             throw YouTubeDownloadError.invalidURL
         }
 
         let ytDlpPath = try await resolveYtDlpPath()
         do {
-            return try await download(url: url, ytDlpPath: ytDlpPath, onProgress: onProgress)
+            return try await download(url: mediaURL, ytDlpPath: ytDlpPath, onProgress: onProgress)
         } catch {
             let originalError = error
             if Self.isPyInstallerLibraryValidationError(error) {
                 let repairedPath = try await binaryBootstrap.reinstallYtDlpFromBundledSeedOrDownload()
-                return try await download(url: url, ytDlpPath: repairedPath, onProgress: onProgress)
+                return try await download(url: mediaURL, ytDlpPath: repairedPath, onProgress: onProgress)
             }
 
             guard Self.shouldRetryWithFreshYtDlp(error) else {
@@ -111,8 +112,13 @@ public actor YouTubeDownloader {
             } catch {
                 throw originalError
             }
-            return try await download(url: url, ytDlpPath: freshPath, onProgress: onProgress)
+            return try await download(url: mediaURL, ytDlpPath: freshPath, onProgress: onProgress)
         }
+    }
+
+    nonisolated static func isSupportedMediaURL(_ url: String) -> Bool {
+        YouTubeURLValidator.isYouTubeURL(url)
+            || DownloadableMediaURLValidator.isDownloadableMediaURL(url)
     }
 
     // MARK: - Private
@@ -707,7 +713,7 @@ public actor YouTubeDownloader {
 
         let normalized = trimmed.lowercased()
         if normalized.contains("no supported javascript runtime could be found") {
-            return "No supported JavaScript runtime found for YouTube extraction. Install Node.js (recommended) or Deno and retry."
+            return "No supported JavaScript runtime found for media extraction. Install Node.js (recommended) or Deno and retry."
         }
 
         if normalized.contains("ffmpeg") && normalized.contains("not found") {

--- a/Sources/MacParakeetCore/Utilities/DownloadableMediaURLValidator.swift
+++ b/Sources/MacParakeetCore/Utilities/DownloadableMediaURLValidator.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public enum DownloadableMediaURLValidator {
+    /// This intentionally overlaps with YouTube URLs. Callers that need to
+    /// distinguish YouTube telemetry/routing should check `YouTubeURLValidator`
+    /// first, then fall back to this generic HTTP(S) media URL check.
+    public static func isDownloadableMediaURL(_ string: String) -> Bool {
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        guard !trimmed.contains(where: \.isWhitespace) else { return false }
+
+        let lowercased = trimmed.lowercased()
+        guard lowercased.hasPrefix("http://") || lowercased.hasPrefix("https://") else { return false }
+        guard let separatorRange = trimmed.range(of: "://") else { return false }
+
+        let afterScheme = trimmed[separatorRange.upperBound...]
+        guard !afterScheme.isEmpty && !afterScheme.hasPrefix("/") else { return false }
+
+        let hostEnd = afterScheme.firstIndex { character in
+            character == "/" || character == "?" || character == "#"
+        } ?? afterScheme.endIndex
+        guard !afterScheme[..<hostEnd].isEmpty else { return false }
+
+        return true
+    }
+}

--- a/Tests/CLITests/CLITelemetryTests.swift
+++ b/Tests/CLITests/CLITelemetryTests.swift
@@ -201,6 +201,22 @@ final class CLITelemetryTests: XCTestCase {
         XCTAssertFalse(metadata.suppressEvent)
     }
 
+    func testTranscribeMetadataUsesMediaInputKindForGenericURL() throws {
+        let command = try CLI.parseAsRoot([
+            "transcribe",
+            "https://www.facebook.com/reel/1998924354042801",
+            "--format",
+            "json",
+        ])
+
+        let metadata = CLITelemetry.metadata(for: command)
+
+        XCTAssertEqual(metadata.command, "transcribe")
+        XCTAssertEqual(metadata.inputKind, .media)
+        XCTAssertEqual(metadata.outputFormat, "json")
+        XCTAssertEqual(metadata.json, true)
+    }
+
     func testTelemetryOutcomeTreatsSuccessfulExitCodeAsSuccess() {
         let result = Result<Void, Error>.failure(ExitCode.success)
 

--- a/Tests/CLITests/TranscribeCommandTests.swift
+++ b/Tests/CLITests/TranscribeCommandTests.swift
@@ -46,26 +46,26 @@ final class TranscribeCommandTests: XCTestCase {
         )
     }
 
-    func testResolveYouTubeAudioQualityUsesM4AForAppDefaultWhenUnset() {
-        let quality = TranscribeCommand.resolveYouTubeAudioQuality(.appDefault, storedQuality: nil)
+    func testResolveMediaAudioQualityUsesM4AForAppDefaultWhenUnset() {
+        let quality = TranscribeCommand.resolveMediaAudioQuality(.appDefault, storedQuality: nil)
         XCTAssertEqual(quality, .m4a)
     }
 
-    func testResolveYouTubeAudioQualityUsesM4AForAppDefaultWhenStoredQualityInvalid() {
-        let quality = TranscribeCommand.resolveYouTubeAudioQuality(.appDefault, storedQuality: "not-a-quality")
+    func testResolveMediaAudioQualityUsesM4AForAppDefaultWhenStoredQualityInvalid() {
+        let quality = TranscribeCommand.resolveMediaAudioQuality(.appDefault, storedQuality: "not-a-quality")
         XCTAssertEqual(quality, .m4a)
     }
 
-    func testResolveYouTubeAudioQualityUsesStoredQualityForAppDefaultWhenValid() {
-        let quality = TranscribeCommand.resolveYouTubeAudioQuality(
+    func testResolveMediaAudioQualityUsesStoredQualityForAppDefaultWhenValid() {
+        let quality = TranscribeCommand.resolveMediaAudioQuality(
             .appDefault,
             storedQuality: YouTubeAudioQuality.bestAvailable.rawValue
         )
         XCTAssertEqual(quality, .bestAvailable)
     }
 
-    func testResolveYouTubeAudioQualityRespectsExplicitQuality() {
-        let quality = TranscribeCommand.resolveYouTubeAudioQuality(
+    func testResolveMediaAudioQualityRespectsExplicitQuality() {
+        let quality = TranscribeCommand.resolveMediaAudioQuality(
             .bestAvailable,
             storedQuality: YouTubeAudioQuality.m4a.rawValue
         )
@@ -311,13 +311,32 @@ final class TranscribeCommandTests: XCTestCase {
         }
     }
 
-    func testParsesYouTubeAudioQuality() throws {
+    func testParsesMediaAudioQuality() throws {
+        let command = try TranscribeCommand.parse([
+            "https://www.youtube.com/watch?v=abc",
+            "--media-audio-quality", "best-available",
+        ])
+
+        XCTAssertEqual(command.effectiveMediaAudioQuality, .bestAvailable)
+    }
+
+    func testParsesLegacyYouTubeAudioQualityAlias() throws {
         let command = try TranscribeCommand.parse([
             "https://www.youtube.com/watch?v=abc",
             "--youtube-audio-quality", "best-available",
         ])
 
-        XCTAssertEqual(command.youtubeAudioQuality, .bestAvailable)
+        XCTAssertEqual(command.effectiveMediaAudioQuality, .bestAvailable)
+    }
+
+    func testRejectsMediaAndLegacyAudioQualityTogether() throws {
+        XCTAssertThrowsError(try TranscribeCommand.parse([
+            "https://www.youtube.com/watch?v=abc",
+            "--media-audio-quality", "m4a",
+            "--youtube-audio-quality", "best-available",
+        ])) { error in
+            XCTAssertTrue(String(describing: error).contains("cannot be combined"))
+        }
     }
 
     func testParsesTranscriptFormatAndNoHistory() throws {
@@ -346,7 +365,7 @@ final class TranscribeCommandTests: XCTestCase {
         XCTAssertEqual(command.engine, .parakeet)
         XCTAssertNil(command.language)
         XCTAssertEqual(command.speakerDetection, .appDefault)
-        XCTAssertEqual(command.youtubeAudioQuality, .appDefault)
+        XCTAssertEqual(command.effectiveMediaAudioQuality, .appDefault)
     }
 
     func testLocalFileURLExpandsTilde() {
@@ -354,6 +373,27 @@ final class TranscribeCommandTests: XCTestCase {
         XCTAssertEqual(
             url.path,
             FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("sample.wav").path
+        )
+    }
+
+    func testTelemetryInputKindUsesMediaForNonYouTubeURL() {
+        XCTAssertEqual(
+            TranscribeCommand.telemetryInputKind(for: "https://www.facebook.com/reel/1998924354042801"),
+            .media
+        )
+    }
+
+    func testDownloadableURLInputAcceptsGenericHTTPURL() {
+        XCTAssertTrue(TranscribeCommand.isDownloadableURLInput(
+            "https://www.facebook.com/reel/1998924354042801"
+        ))
+        XCTAssertFalse(TranscribeCommand.isDownloadableURLInput("/tmp/video.mp4"))
+    }
+
+    func testDownloadableURLInputTrimsPastedMediaURL() {
+        XCTAssertEqual(
+            TranscribeCommand.downloadableURLInput("  https://www.facebook.com/reel/1998924354042801\n"),
+            "https://www.facebook.com/reel/1998924354042801"
         )
     }
 
@@ -444,15 +484,29 @@ final class TranscribeCommandTests: XCTestCase {
             try Data("x".utf8).write(to: dir.appendingPathComponent(name))
         }
         let youtube = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        let facebook = "https://www.facebook.com/reel/1998924354042801"
 
-        let resolved = TranscribeCommand.expandInputs([dir.path, youtube, youtube])
+        let resolved = TranscribeCommand.expandInputs([dir.path, youtube, facebook, facebook, youtube])
 
         // Folder expands to its supported files (name-sorted), txt excluded,
-        // YouTube URL passes through once.
-        XCTAssertEqual(resolved.count, 3)
+        // media URLs pass through once.
+        XCTAssertEqual(resolved.count, 4)
         XCTAssertTrue(resolved[0].hasSuffix("lecture01.m4a"))
         XCTAssertTrue(resolved[1].hasSuffix("lecture02.mp3"))
-        XCTAssertEqual(resolved.last, youtube)
+        XCTAssertEqual(resolved[2], youtube)
+        XCTAssertEqual(resolved[3], facebook)
+    }
+
+    func testDisplayNameKeepsGenericMediaURLReadable() {
+        let facebook = "https://www.facebook.com/reel/1998924354042801"
+        XCTAssertEqual(TranscribeCommand.displayName(for: facebook), facebook)
+    }
+
+    func testDisplayNameStripsMediaURLQueryAndFragment() {
+        XCTAssertEqual(
+            TranscribeCommand.displayName(for: "https://example.com/watch/video.mp4?token=secret#section"),
+            "https://example.com/watch/video.mp4"
+        )
     }
 
     func testExpandInputsDeduplicatesStandardizedLooseFilesAgainstFolders() throws {

--- a/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
@@ -855,6 +855,39 @@ final class TranscriptionServiceTests: XCTestCase {
         XCTAssertEqual(metadata.thumbnailURL, "https://img.example/thumb.jpg")
     }
 
+    func testTranscribeURLAcceptsGenericMediaURLThroughDownloader() async throws {
+        let downloadedURL = try makeTempDownloadedAudio()
+        defer { try? FileManager.default.removeItem(at: downloadedURL) }
+        let facebookURL = "https://www.facebook.com/reel/1998924354042801"
+
+        let downloader = MockYouTubeDownloader(result: YouTubeDownloader.DownloadResult(
+            audioFileURL: downloadedURL,
+            title: "Facebook Reel",
+            durationSeconds: 85
+        ))
+
+        await mockSTT.configure(result: STTResult(text: "Downloaded transcript"))
+
+        let service = TranscriptionService(
+            audioProcessor: mockAudio,
+            sttTranscriber: mockSTT,
+            transcriptionRepo: transcriptionRepo,
+            shouldKeepDownloadedAudio: { false },
+            youtubeDownloader: downloader
+        )
+
+        let result = try await service.transcribeURL(urlString: "  \(facebookURL)\n")
+        let fetched = try XCTUnwrap(transcriptionRepo.fetch(id: result.id))
+        let lastDownloadURL = await downloader.lastURL
+
+        XCTAssertEqual(lastDownloadURL, facebookURL)
+        XCTAssertEqual(result.sourceURL, facebookURL)
+        XCTAssertEqual(result.fileName, "Facebook Reel")
+        XCTAssertEqual(result.rawTranscript, "Downloaded transcript")
+        XCTAssertEqual(fetched.sourceURL, facebookURL)
+        XCTAssertEqual(fetched.sourceType, .youtube)
+    }
+
     func testTranscribeMeetingUsesFinalizeLaneAndMergesFreshSourceTranscriptsByAlignment() async throws {
         let telemetry = TelemetrySpy()
         Telemetry.configure(telemetry)

--- a/Tests/MacParakeetTests/Services/YouTubeDownloaderTests.swift
+++ b/Tests/MacParakeetTests/Services/YouTubeDownloaderTests.swift
@@ -32,6 +32,23 @@ final class YouTubeDownloaderTests: XCTestCase {
         }
     }
 
+    func testSupportedMediaURLAcceptsFacebookReel() {
+        XCTAssertTrue(YouTubeDownloader.isSupportedMediaURL(
+            "https://www.facebook.com/reel/1998924354042801"
+        ))
+    }
+
+    func testSupportedMediaURLPreservesSchemalessYouTubeCompatibility() {
+        XCTAssertTrue(YouTubeDownloader.isSupportedMediaURL(
+            "youtube.com/watch?v=dQw4w9WgXcQ"
+        ))
+    }
+
+    func testSupportedMediaURLRejectsNonHTTPInput() {
+        XCTAssertFalse(YouTubeDownloader.isSupportedMediaURL("ftp://example.com/video.mp4"))
+        XCTAssertFalse(YouTubeDownloader.isSupportedMediaURL("/tmp/video.mp4"))
+    }
+
     func testParseDownloadProgressPercentParsesYtDlpLine() {
         XCTAssertEqual(
             YouTubeDownloader.parseDownloadProgressPercent(from: "[download]  42.3% of ~12.34MiB at 1.23MiB/s ETA 00:07"),

--- a/Tests/MacParakeetTests/Utilities/DownloadableMediaURLValidatorTests.swift
+++ b/Tests/MacParakeetTests/Utilities/DownloadableMediaURLValidatorTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class DownloadableMediaURLValidatorTests: XCTestCase {
+    func testAcceptsHTTPSMediaURL() {
+        XCTAssertTrue(DownloadableMediaURLValidator.isDownloadableMediaURL(
+            "https://www.facebook.com/reel/1998924354042801"
+        ))
+    }
+
+    func testAcceptsHTTPMediaURL() {
+        XCTAssertTrue(DownloadableMediaURLValidator.isDownloadableMediaURL(
+            "http://example.com/video.mp4"
+        ))
+    }
+
+    func testAcceptsLenientHTTPURLWithUnencodedQueryCharacters() {
+        XCTAssertTrue(DownloadableMediaURLValidator.isDownloadableMediaURL(
+            "https://example.com/watch?metadata={abc}"
+        ))
+    }
+
+    func testTrimsOuterWhitespace() {
+        XCTAssertTrue(DownloadableMediaURLValidator.isDownloadableMediaURL(
+            "  https://example.com/video.mp4\n"
+        ))
+    }
+
+    func testRejectsLocalFilesAndUnsupportedSchemes() {
+        XCTAssertFalse(DownloadableMediaURLValidator.isDownloadableMediaURL("/tmp/video.mp4"))
+        XCTAssertFalse(DownloadableMediaURLValidator.isDownloadableMediaURL("video.mp4"))
+        XCTAssertFalse(DownloadableMediaURLValidator.isDownloadableMediaURL("ftp://example.com/video.mp4"))
+        XCTAssertFalse(DownloadableMediaURLValidator.isDownloadableMediaURL("https://"))
+        XCTAssertFalse(DownloadableMediaURLValidator.isDownloadableMediaURL("https:///video.mp4"))
+        XCTAssertFalse(DownloadableMediaURLValidator.isDownloadableMediaURL("https://?id=1"))
+    }
+
+    func testRejectsWhitespaceBearingInput() {
+        XCTAssertFalse(DownloadableMediaURLValidator.isDownloadableMediaURL(
+            "https://example.com/video one.mp4"
+        ))
+    }
+}

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -24,7 +24,7 @@ This script builds the latest debug binary, stops stale `/Applications`/`dist` a
 
 ```
 macparakeet-cli
-├── transcribe <input...> [options]      Transcribe files, folders, or YouTube URLs
+├── transcribe <input...> [options]      Transcribe files, folders, or media URLs
 │   ├── --format text|transcript|json [--no-history]
 │   └── --engine app-default|parakeet|whisper [--language <code>]
 │       --parakeet-model app-default|v3|v2 [--output-dir DIR]
@@ -134,7 +134,7 @@ detection setting; the explicit flag below keeps the behavior visible in test
 commands.
 
 ```bash
-swift run macparakeet-cli transcribe "<FILE_OR_YOUTUBE_URL>" \
+swift run macparakeet-cli transcribe "<FILE_OR_MEDIA_URL>" \
   --engine app-default \
   --parakeet-model app-default \
   --speaker-detection app-default \
@@ -148,7 +148,7 @@ swift run macparakeet-cli transcribe "<FILE_OR_YOUTUBE_URL>" \
 Explicitly pins behavior.
 
 ```bash
-swift run macparakeet-cli transcribe "<FILE_OR_YOUTUBE_URL>" \
+swift run macparakeet-cli transcribe "<FILE_OR_MEDIA_URL>" \
   --engine parakeet \
   --parakeet-model v3 \
   --speaker-detection off \
@@ -160,7 +160,7 @@ swift run macparakeet-cli transcribe "<FILE_OR_YOUTUBE_URL>" \
 Or clean mode with retained downloads:
 
 ```bash
-swift run macparakeet-cli transcribe "<FILE_OR_YOUTUBE_URL>" \
+swift run macparakeet-cli transcribe "<FILE_OR_MEDIA_URL>" \
   --engine parakeet \
   --parakeet-model v3 \
   --speaker-detection on \
@@ -377,7 +377,7 @@ swift run macparakeet-cli health --repair-binaries
 managed or app-bundled `yt-dlp`, but it does not install or update helper
 binaries. `health --repair-binaries` explicitly fetches the latest managed
 `yt-dlp` copy. App-bundled CLI installs include a signed `yt-dlp` seed so
-YouTube URL transcription works without a first-use helper download.
+media URL transcription works without a first-use helper download.
 
 ## Meetings
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -109,7 +109,7 @@ deriving it from the event name when older clients do not send the field.
 - Transcription text content
 - Custom word or snippet values
 - File names or paths
-- YouTube URLs
+- YouTube/media URLs
 - LLM prompts or responses
 - AI Formatter profile names, profile ids, profile prompts, or match kinds
 - Exact app bundle identifiers or app display names
@@ -260,7 +260,7 @@ catalog.
 | `transcription_completed` | `source`, `audio_duration_seconds`, `processing_seconds`, `word_count`, `speaker_count`, `diarization_requested`, `diarization_applied`, `speech_engine`, `engine_variant`, `language` | Real-world performance, speaker-label coverage, language coverage, and STT engine adoption across file, YouTube, and meeting pipelines |
 | `transcription_cancelled` | `source`, `audio_duration_seconds`, `stage` (download, audio_conversion, stt, diarization, post_processing) | Where do users abandon jobs? |
 | `transcription_failed` | `source`, `stage`, `error_type` | What's breaking, and in which pipeline stage? |
-| `transcription_operation` | `operation_id`, `workflow_id`, `parent_operation_id`, `outcome`, `source`, `stage`, `duration_seconds`, `audio_duration_seconds`, `processing_seconds`, `word_count`, `speaker_count`, `diarization_requested`, `diarization_applied`, `input_kind`, `media_extension`, `file_size_bucket`, `speech_engine`, `engine_variant`, `language`, `error_type` | One wide outcome event per file, YouTube, or meeting transcription |
+| `transcription_operation` | `operation_id`, `workflow_id`, `parent_operation_id`, `outcome`, `source`, `stage`, `duration_seconds`, `audio_duration_seconds`, `processing_seconds`, `word_count`, `speaker_count`, `diarization_requested`, `diarization_applied`, `input_kind`, `media_extension`, `file_size_bucket`, `speech_engine`, `engine_variant`, `language`, `error_type` | One wide outcome event per file, media URL, or meeting transcription |
 
 `transcription_operation` is the broad product-health outcome event. Its
 `stage` values are `preflight`, `download`, `audio_conversion`, `stt`,

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -56,9 +56,10 @@ sitting at a keyboard, it lives in the .app.
   per-minute charges.
 - **Audio + video file transcription** -- accepts MP3 / WAV / MP4 / MOV /
   WebM / etc. via the bundled FFmpeg.
-- **YouTube transcription** via yt-dlp. The standalone Homebrew install uses
+- **Media URL transcription** via yt-dlp, including YouTube and other public
+  media URLs supported by yt-dlp. The standalone Homebrew install uses
   Homebrew's `yt-dlp`; the app bundle can seed a signed helper into
-  MacParakeet's Application Support folder before first YouTube use.
+  MacParakeet's Application Support folder before first media URL use.
 - **Persistent SQLite memory layer** -- everything transcribed is queryable
   later: dictation history, transcriptions, prompt outputs.
 - **Shared app/CLI preferences** -- agents can set speech engine, processing
@@ -194,7 +195,7 @@ macparakeet-cli transcribe /path/to/audio.mp3 \
   --speaker-detection app-default \
   --mode app-default \
   --downloaded-audio app-default \
-  --youtube-audio-quality app-default \
+  --media-audio-quality app-default \
   --format json
 ```
 
@@ -229,10 +230,10 @@ macparakeet-cli config set youtube-audio-quality m4a
 is passed. The saved Whisper language is used when `--engine app-default`
 resolves to Whisper.
 
-### Transcribe a YouTube video
+### Transcribe a media URL
 
 ```bash
-macparakeet-cli transcribe "https://www.youtube.com/watch?v=..." --format json
+macparakeet-cli transcribe "https://www.facebook.com/reel/..." --format json
 ```
 
 ### Look up past transcriptions
@@ -379,27 +380,27 @@ macparakeet-cli health --json
 If it fails, report the `errorType`/message and stop. Do not guess that models,
 FFmpeg, yt-dlp, or the database are ready. App-bundled CLI installs should
 already have a signed yt-dlp helper seed; if `yt-dlp` is still missing and the
-user wants YouTube transcription, run
+user wants media URL transcription, run
 `macparakeet-cli health --repair-binaries` before retrying.
 
 ## Core Commands
 
 ```bash
 macparakeet-cli spec --json
-macparakeet-cli transcribe "<path-or-youtube-url>" --format json
-macparakeet-cli transcribe "<path-or-youtube-url>" --format transcript --no-history
+macparakeet-cli transcribe "<path-or-media-url>" --format json
+macparakeet-cli transcribe "<path-or-media-url>" --format transcript --no-history
 macparakeet-cli models download whisper-large-v3-v20240930-turbo-632MB
 macparakeet-cli models list --json
 macparakeet-cli models select parakeet-v3 --json
 macparakeet-cli config set parakeet-model v3 --json
-macparakeet-cli transcribe "<path-or-youtube-url>" --engine whisper --language ko --format json
-macparakeet-cli transcribe "<path-or-youtube-url>" \
+macparakeet-cli transcribe "<path-or-media-url>" --engine whisper --language ko --format json
+macparakeet-cli transcribe "<path-or-media-url>" \
   --engine app-default \
   --parakeet-model app-default \
   --speaker-detection app-default \
   --mode app-default \
   --downloaded-audio app-default \
-  --youtube-audio-quality app-default \
+  --media-audio-quality app-default \
   --format json
 macparakeet-cli config list --json
 macparakeet-cli config set speech-engine parakeet --json
@@ -441,7 +442,7 @@ macparakeet-cli prompts run "<prompt-name>" \
 - Use the full app-default group (`--engine app-default`,
   `--parakeet-model app-default`, `--speaker-detection app-default`,
   `--mode app-default`, `--downloaded-audio app-default`, and
-  `--youtube-audio-quality app-default`) when you are intentionally checking
+  `--media-audio-quality app-default`) when you are intentionally checking
   GUI-default behavior. Pin explicit flags for reproducible agent tests.
 - `config get speaker-detection` reports the saved app-default value. Bare
   `transcribe` and `--speaker-detection app-default` use that value; pass
@@ -477,7 +478,7 @@ macparakeet-cli prompts run "<prompt-name>" \
   produce a `.ambiguous` error; missing records produce `.notFound`.
 - **Privacy:** STT and database access never touch the network. Network
   egress paths are: explicit helper repair (`health --repair-binaries`),
-  YouTube downloads (yt-dlp), optional LLM provider calls (only when
+  media URL downloads (yt-dlp), optional LLM provider calls (only when
   `prompts run` or `llm` targets a hosted provider, or when a configured
   Local CLI command contacts its own service), Sparkle update checks (app,
   not CLI), and a single privacy-safe

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -38,14 +38,14 @@ description: Local speech-to-text, transcription, and prompt automation
              on Apple Silicon. Powered by Parakeet TDT on the Neural Engine.
 when_to_use:
   - User wants to transcribe a local audio/video file.
-  - User wants to transcribe a YouTube URL.
+  - User wants to transcribe a media URL.
   - User asks "what was said in <past meeting / dictation>?"
   - User asks for action items / summary from a recorded transcript.
 commands:
   spec: macparakeet-cli spec --json
   health: macparakeet-cli health --json
   transcribe_file: macparakeet-cli transcribe "{path}" --format json
-  transcribe_youtube: macparakeet-cli transcribe "{url}" --format json
+  transcribe_media_url: macparakeet-cli transcribe "{url}" --format json
   transcribe_app_defaults: |
     macparakeet-cli transcribe "{path}" \
       --engine app-default \

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -17,7 +17,7 @@ Local speech-to-text and transcription for an OpenClaw agent running on Apple
 Silicon. Wraps `macparakeet-cli` so an OpenClaw skill can:
 
 - Transcribe a local audio/video file.
-- Transcribe a YouTube URL.
+- Transcribe a media URL.
 - Search the user's prior dictation/transcription history.
 - Inspect meeting recordings and store external meeting results.
 - Run a prompt against a transcription (action items, summary, etc.).
@@ -47,7 +47,7 @@ If MacParakeet.app is already installed, the bundled CLI is also available at
 | Health probe (run at skill init) | `macparakeet-cli health --json` |
 | Discover core contract | `macparakeet-cli spec --json` |
 | Transcribe a file | `macparakeet-cli transcribe <path> --format json` |
-| Transcribe a YouTube URL | `macparakeet-cli transcribe <url> --format json` |
+| Transcribe a media URL | `macparakeet-cli transcribe <url> --format json` |
 | Use GUI/default preferences | `macparakeet-cli transcribe <path> --engine app-default --parakeet-model app-default --speaker-detection app-default --mode app-default --downloaded-audio app-default --youtube-audio-quality app-default --format json` |
 | Inspect/select speech models | `macparakeet-cli models list --json` / `macparakeet-cli models select parakeet-v3 --json` / `macparakeet-cli models select parakeet-v2 --json` |
 | Configure shared defaults | `macparakeet-cli config set speaker-detection off --json`; `macparakeet-cli config set parakeet-model v3 --json` |


### PR DESCRIPTION
## Summary
- expands `macparakeet-cli transcribe` URL handling from YouTube-only to explicit HTTP(S) media URLs that `yt-dlp` can download
- routes non-YouTube URLs through the existing downloader/transcription pipeline, with `input_kind=media` telemetry and no raw URL telemetry leakage
- updates CLI help, health guidance, integration docs, and tests around Facebook Reel/generic media URL handling

## Notes
- Keeps the existing `YouTubeDownloader` type name and persisted `.youtube` source bucket for downloaded URL records to avoid a broader DB/UI migration.
- Normalizes pasted media URLs before calling `yt-dlp`, so surrounding whitespace does not get passed into the downloader.

## Validation
- `git diff --check origin/main...HEAD`
- `swift test --filter 'TranscribeCommandTests|CLITelemetryTests|DownloadableMediaURLValidatorTests|YouTubeDownloaderTests|TranscriptionServiceTests'`
- `swift test` after rebasing onto `origin/main` — 3232 XCTest tests, 10 skipped hardware tests, 0 failures; 16 Swift Testing tests, 0 failures
- Live CLI smoke: `https://www.facebook.com/reel/2354349765033561` downloaded and produced a non-empty transcript
