### PR TITLE
Confirm speech engine switches in Settings

### DIFF
--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -472,6 +472,25 @@ struct SettingsView: View {
         } message: { deletion in
             Text(modelDeletionMessage(for: deletion))
         }
+        .alert(
+            speechEngineSwitchConfirmationTitle,
+            isPresented: Binding(
+                get: { viewModel.pendingSpeechEngineSwitchConfirmation != nil },
+                set: { if !$0 { viewModel.cancelPendingSpeechEngineSwitchConfirmation() } }
+            ),
+            presenting: viewModel.pendingSpeechEngineSwitchConfirmation
+        ) { engine in
+            Button("Cancel", role: .cancel) {
+                viewModel.cancelPendingSpeechEngineSwitchConfirmation()
+            }
+            Button("Switch to \(engine.displayName)") {
+                withAnimation(DesignSystem.Animation.contentSwap) {
+                    viewModel.confirmPendingSpeechEngineSwitch()
+                }
+            }
+        } message: { engine in
+            Text(speechEngineSwitchConfirmationMessage(for: engine))
+        }
     }
 
     /// A downloaded model awaiting delete confirmation. `parakeet` carries the
@@ -517,6 +536,25 @@ struct SettingsView: View {
             viewModel.deleteWhisperModel()
         }
         pendingModelDeletion = nil
+    }
+
+    private var speechEngineSwitchConfirmationTitle: String {
+        guard let engine = viewModel.pendingSpeechEngineSwitchConfirmation else {
+            return "Switch speech engine?"
+        }
+        return "Switch to \(engine.displayName)?"
+    }
+
+    private func speechEngineSwitchConfirmationMessage(for engine: SpeechEnginePreference) -> String {
+        switch engine {
+        case .whisper:
+            if viewModel.whisperHasBeenOptimized {
+                return "Whisper may take a moment to load. Dictation, file transcription, and meetings pause until the switch finishes."
+            }
+            return "Preparing Whisper can take several minutes the first time while Core ML optimizes it for this Mac. Dictation, file transcription, and meetings pause until the switch finishes."
+        case .parakeet:
+            return "Switching back to Parakeet reloads the speech engine. Dictation, file transcription, and meetings pause until the switch finishes."
+        }
     }
 
     /// AI tab — optional setup for summaries, chat, prompt actions, and Ask.
@@ -2251,13 +2289,13 @@ struct SettingsView: View {
         .accessibilityElement(children: .combine)
     }
 
-    /// Routes a tile click through `speechEnginePreference`. The VM's setter
-    /// validates (e.g. would revert if Whisper isn't downloaded), but we
-    /// pre-empt that case in `handleWhisperTileTap` so the user never sees
-    /// the briefly-selected-then-reverted state.
+    /// Routes a tile click through a confirmation step. The VM's eventual
+    /// setter still validates and performs the actual switch, but the first tap
+    /// no longer starts a potentially multi-minute engine reload by surprise.
     private func selectEngine(_ engine: SpeechEnginePreference) {
         guard viewModel.speechEnginePreference != engine,
-              !viewModel.speechEngineSwitching else { return }
+              !viewModel.speechEngineSwitching,
+              viewModel.pendingSpeechEngineSwitchConfirmation == nil else { return }
         Task { @MainActor in
             let availability = await viewModel.refreshSpeechEngineSwitchAvailabilityNow()
             guard availability == .available else {
@@ -2265,7 +2303,7 @@ struct SettingsView: View {
                 return
             }
             withAnimation(DesignSystem.Animation.contentSwap) {
-                viewModel.speechEnginePreference = engine
+                viewModel.requestSpeechEngineSwitchConfirmation(to: engine)
             }
         }
     }

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -313,6 +313,7 @@ public final class SettingsViewModel {
     public var speechEngineSwitching = false
     public var speechEngineSwitchTarget: SpeechEnginePreference?
     public var speechEngineSwitchDetail: String?
+    public var pendingSpeechEngineSwitchConfirmation: SpeechEnginePreference?
     /// True while a Parakeet *build* swap (v3 ↔ v2) is in flight, as opposed to
     /// an engine switch. Both set `speechEngineSwitchTarget = .parakeet`, so the
     /// banner needs this to avoid the misleading "Switching to Parakeet" copy
@@ -1145,6 +1146,29 @@ public final class SettingsViewModel {
         case .unavailable:
             return "Speech engine is temporarily unavailable"
         }
+    }
+
+    public func requestSpeechEngineSwitchConfirmation(to preference: SpeechEnginePreference) {
+        guard preference != speechEnginePreference,
+              !speechEngineSwitching,
+              pendingSpeechEngineSwitchConfirmation == nil else { return }
+        speechEngineError = nil
+        pendingSpeechEngineSwitchConfirmation = preference
+    }
+
+    public func cancelPendingSpeechEngineSwitchConfirmation() {
+        pendingSpeechEngineSwitchConfirmation = nil
+    }
+
+    public func confirmPendingSpeechEngineSwitch() {
+        guard let preference = pendingSpeechEngineSwitchConfirmation else { return }
+        pendingSpeechEngineSwitchConfirmation = nil
+        guard preference != speechEnginePreference else { return }
+        guard !speechEngineSwitching else {
+            speechEngineError = Self.speechEngineSwitchUnavailableMessage(for: .switchInProgress)
+            return
+        }
+        speechEnginePreference = preference
     }
 
     public func refreshEntitlements() {

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -1095,6 +1095,89 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(settings, [.whisperDefaultLanguage, .whisperDefaultLanguage])
     }
 
+    func testSpeechEngineSwitchConfirmationDefersChangeUntilConfirm() async throws {
+        let switcher = MockSpeechEngineSwitcher()
+        viewModel.whisperModelStatus = .notLoaded
+        viewModel.configure(
+            permissionService: mockPermissions,
+            dictationRepo: mockRepo,
+            entitlementsService: entitlements,
+            checkoutURL: nil,
+            speechEngineSwitcher: switcher
+        )
+
+        viewModel.whisperModelStatus = .notLoaded
+        viewModel.requestSpeechEngineSwitchConfirmation(to: .whisper)
+
+        XCTAssertEqual(viewModel.pendingSpeechEngineSwitchConfirmation, .whisper)
+        XCTAssertEqual(viewModel.speechEnginePreference, .parakeet)
+        XCTAssertEqual(SpeechEnginePreference.current(defaults: testDefaults), .parakeet)
+        let preferencesBeforeConfirm = await switcher.preferences
+        XCTAssertTrue(preferencesBeforeConfirm.isEmpty)
+
+        viewModel.confirmPendingSpeechEngineSwitch()
+        try await waitForSpeechEngineSwitchingToFinish()
+
+        XCTAssertNil(viewModel.pendingSpeechEngineSwitchConfirmation)
+        let preferencesAfterConfirm = await switcher.preferences
+        XCTAssertEqual(preferencesAfterConfirm, [.whisper])
+        XCTAssertEqual(viewModel.speechEnginePreference, .whisper)
+        XCTAssertEqual(SpeechEnginePreference.current(defaults: testDefaults), .whisper)
+    }
+
+    func testSpeechEngineSwitchConfirmationCancelLeavesEngineUnchanged() async throws {
+        let switcher = MockSpeechEngineSwitcher()
+        viewModel.whisperModelStatus = .notLoaded
+        viewModel.configure(
+            permissionService: mockPermissions,
+            dictationRepo: mockRepo,
+            entitlementsService: entitlements,
+            checkoutURL: nil,
+            speechEngineSwitcher: switcher
+        )
+
+        viewModel.whisperModelStatus = .notLoaded
+        viewModel.requestSpeechEngineSwitchConfirmation(to: .whisper)
+        viewModel.cancelPendingSpeechEngineSwitchConfirmation()
+        try await waitForSpeechEngineSwitchingToFinish()
+
+        XCTAssertNil(viewModel.pendingSpeechEngineSwitchConfirmation)
+        XCTAssertEqual(viewModel.speechEnginePreference, .parakeet)
+        XCTAssertEqual(SpeechEnginePreference.current(defaults: testDefaults), .parakeet)
+        let preferences = await switcher.preferences
+        XCTAssertTrue(preferences.isEmpty)
+    }
+
+    func testSpeechEngineSwitchConfirmationIgnoresRequestsWhilePending() {
+        viewModel.requestSpeechEngineSwitchConfirmation(to: .whisper)
+        viewModel.speechEngineError = "Existing error"
+        viewModel.requestSpeechEngineSwitchConfirmation(to: .whisper)
+
+        XCTAssertEqual(viewModel.pendingSpeechEngineSwitchConfirmation, .whisper)
+        XCTAssertEqual(viewModel.speechEngineError, "Existing error")
+    }
+
+    func testSpeechEngineSwitchConfirmationIgnoresCurrentEngine() {
+        viewModel.requestSpeechEngineSwitchConfirmation(to: .parakeet)
+
+        XCTAssertNil(viewModel.pendingSpeechEngineSwitchConfirmation)
+        XCTAssertEqual(viewModel.speechEnginePreference, .parakeet)
+    }
+
+    func testConfirmPendingSpeechEngineSwitchShowsErrorWhenSwitchStartsFirst() {
+        viewModel.requestSpeechEngineSwitchConfirmation(to: .whisper)
+        viewModel.speechEngineSwitching = true
+
+        viewModel.confirmPendingSpeechEngineSwitch()
+
+        XCTAssertNil(viewModel.pendingSpeechEngineSwitchConfirmation)
+        XCTAssertEqual(viewModel.speechEnginePreference, .parakeet)
+        XCTAssertEqual(
+            viewModel.speechEngineError,
+            SettingsViewModel.speechEngineSwitchUnavailableMessage(for: .switchInProgress)
+        )
+    }
+
     func testSpeechEngineChangeCallsSwitcherAndPersistsOnSuccess() async throws {
         let switcher = MockSpeechEngineSwitcher()
         viewModel.whisperModelStatus = .notLoaded


### PR DESCRIPTION
## Summary
- Adds a confirmation alert before switching between Parakeet and Whisper from Settings > Engine.
- Keeps the existing availability checks and switch/progress flow after confirmation.
- Warns that first-time Whisper preparation can take several minutes and pauses dictation, file transcription, and meetings.

## Verification
- swift test --filter SettingsViewModelTests
- swift test
- scripts/dev/run_app.sh

## Notes
- Parakeet v2/v3 model selection still behaves as before; this confirmation is only for engine swaps.