### PR TITLE
fix(dictation): classify failed microphone capture

### DIFF
--- a/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
+++ b/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
@@ -843,6 +843,15 @@ struct DictationOverlayView: View {
     private func errorInfo(_ message: String) -> (title: String, subtitle: String) {
         let lower = message.lowercased()
 
+        if lower.contains("permission") || lower.contains("access") {
+            if lower.contains("copied to clipboard") || lower.contains("cmd+v") {
+                return ("Permission Required", "Copied to clipboard. Enable Accessibility or press Cmd+V now.")
+            }
+            return ("Permission Required", "Grant access in System Settings > Privacy & Security.")
+        }
+        if lower.contains("microphone") || lower.contains("audio input") {
+            return ("Microphone Unavailable", "Check your mic connection or select a different input.")
+        }
         if lower.contains("stt") || lower.contains("speech engine") || lower.contains("engine")
             || lower.contains("model not loaded")
             || lower.contains("failed to start") {
@@ -851,15 +860,6 @@ struct DictationOverlayView: View {
         if lower.contains("couldn't hear") || lower.contains("empty")
             || lower.contains("too short") || lower.contains("insufficient") {
             return ("No Speech Detected", "Try speaking louder or holding a bit longer.")
-        }
-        if lower.contains("microphone") || lower.contains("audio input") {
-            return ("Microphone Unavailable", "Check your mic connection or select a different input.")
-        }
-        if lower.contains("permission") || lower.contains("access") {
-            if lower.contains("copied to clipboard") || lower.contains("cmd+v") {
-                return ("Permission Required", "Copied to clipboard. Enable Accessibility or press Cmd+V now.")
-            }
-            return ("Permission Required", "Grant access in System Settings > Privacy & Security.")
         }
         if lower.contains("copied to clipboard") || lower.contains("cmd+v") {
             return ("Copied to Clipboard", "Auto-paste wasn't available. Press Cmd+V where you want the text.")

--- a/Sources/MacParakeetCore/Audio/AudioProcessor.swift
+++ b/Sources/MacParakeetCore/Audio/AudioProcessor.swift
@@ -41,6 +41,10 @@ public actor AudioProcessor: AudioProcessorProtocol {
         get async { await recorder.deviceInfo }
     }
 
+    public var lastCaptureHealth: AudioCaptureHealth? {
+        get async { await recorder.lastCaptureHealth }
+    }
+
     public func convert(fileURL: URL) async throws -> URL {
         try await converter.convert(fileURL: fileURL)
     }

--- a/Sources/MacParakeetCore/Audio/AudioProcessorProtocol.swift
+++ b/Sources/MacParakeetCore/Audio/AudioProcessorProtocol.swift
@@ -16,6 +16,89 @@ public struct DictationAudioSampleSink: Sendable {
     }
 }
 
+public enum AudioCaptureProblem: String, Sendable, Equatable {
+    case engineStartFailed = "engine_start_failed"
+    case noInputBuffers = "no_input_buffers"
+    case silentInput = "silent_input"
+
+    var userMessage: String {
+        switch self {
+        case .engineStartFailed:
+            return "Microphone failed to start. Try again."
+        case .noInputBuffers:
+            return "No microphone input detected. Check your input device and try again."
+        case .silentInput:
+            return "No microphone signal detected. Check your input device and try again."
+        }
+    }
+}
+
+public struct AudioCaptureHealth: Sendable, Equatable {
+    public static let noBufferMinimumWallDurationSeconds: Double = 2.0
+    public static let silentInputMinimumAudioDurationSeconds: Double = 2.0
+    public static let silentInputMaximumLevel: Float = 0.02
+
+    public let sampleCount: Int
+    public let audioDurationSeconds: Double
+    public let wallDurationSeconds: Double
+    public let fileBytes: UInt64?
+    public let inputBufferCount: Int
+    public let outputBufferCount: Int
+    public let inputFrameCount: Int
+    public let maxRMS: Float
+    public let maxAudioLevel: Float
+    public let nonSilentBufferCount: Int
+    public let missingFloatChannelDataBufferCount: Int
+    public let invalidFormatBufferCount: Int
+    public let noBufferTimeoutFired: Bool
+
+    public init(
+        sampleCount: Int,
+        audioDurationSeconds: Double,
+        wallDurationSeconds: Double,
+        fileBytes: UInt64?,
+        inputBufferCount: Int,
+        outputBufferCount: Int,
+        inputFrameCount: Int,
+        maxRMS: Float,
+        maxAudioLevel: Float,
+        nonSilentBufferCount: Int,
+        missingFloatChannelDataBufferCount: Int,
+        invalidFormatBufferCount: Int,
+        noBufferTimeoutFired: Bool
+    ) {
+        self.sampleCount = sampleCount
+        self.audioDurationSeconds = audioDurationSeconds
+        self.wallDurationSeconds = wallDurationSeconds
+        self.fileBytes = fileBytes
+        self.inputBufferCount = inputBufferCount
+        self.outputBufferCount = outputBufferCount
+        self.inputFrameCount = inputFrameCount
+        self.maxRMS = maxRMS
+        self.maxAudioLevel = maxAudioLevel
+        self.nonSilentBufferCount = nonSilentBufferCount
+        self.missingFloatChannelDataBufferCount = missingFloatChannelDataBufferCount
+        self.invalidFormatBufferCount = invalidFormatBufferCount
+        self.noBufferTimeoutFired = noBufferTimeoutFired
+    }
+
+    public var terminalProblem: AudioCaptureProblem? {
+        if noBufferTimeoutFired ||
+            (inputBufferCount == 0 && wallDurationSeconds >= Self.noBufferMinimumWallDurationSeconds) {
+            return .noInputBuffers
+        }
+
+        if inputBufferCount > 0,
+           audioDurationSeconds >= Self.silentInputMinimumAudioDurationSeconds,
+           nonSilentBufferCount == 0,
+           maxAudioLevel < Self.silentInputMaximumLevel {
+            return .silentInput
+        }
+
+        return nil
+    }
+}
+
 public protocol AudioProcessorProtocol: Sendable {
     /// Convert an audio/video file to 16kHz mono WAV for STT processing
     func convert(fileURL: URL) async throws -> URL
@@ -39,6 +122,9 @@ public protocol AudioProcessorProtocol: Sendable {
     /// Device info from the most recent recording (name, transport, format, fallback status).
     var recordingDeviceInfo: RecordingDeviceInfo? { get async }
 
+    /// Health metrics from the most recently stopped capture, if available.
+    var lastCaptureHealth: AudioCaptureHealth? { get async }
+
     /// Discard the instant-dictation pre-roll from the active capture (no-op
     /// when idle or when no pre-roll was prepended). Called when system media
     /// was confirmed playing at dictation start, so the pre-roll is known to
@@ -54,6 +140,10 @@ public extension AudioProcessorProtocol {
     /// Capture-only implementations (file converters, test doubles) have no
     /// pre-roll; discarding is a no-op unless a conformer opts in.
     func discardPreRollForActiveCapture() async {}
+
+    var lastCaptureHealth: AudioCaptureHealth? {
+        get async { nil }
+    }
 }
 
 public enum AudioProcessorError: Error, LocalizedError {
@@ -64,6 +154,7 @@ public enum AudioProcessorError: Error, LocalizedError {
     case unsupportedFormat(String)
     case fileTooLarge(String)
     case insufficientSamples
+    case inputUnavailable(AudioCaptureProblem)
 
     public var errorDescription: String? {
         switch self {
@@ -74,6 +165,7 @@ public enum AudioProcessorError: Error, LocalizedError {
         case .unsupportedFormat(let format): return "Unsupported audio format: \(format)"
         case .fileTooLarge(let info): return "File too large: \(info)"
         case .insufficientSamples: return "Recording too short"
+        case .inputUnavailable(let problem): return problem.userMessage
         }
     }
 }

--- a/Sources/MacParakeetCore/Audio/AudioRecorder.swift
+++ b/Sources/MacParakeetCore/Audio/AudioRecorder.swift
@@ -31,6 +31,7 @@ private struct RecordingRuntimeMetrics: Sendable {
     var nonSilentBufferCount: Int = 0
     var missingFloatChannelDataBufferCount: Int = 0
     var invalidFormatBufferCount: Int = 0
+    var noBufferTimeoutFired: Bool = false
 }
 
 private struct DictationPreRollRingBuffer: Sendable {
@@ -100,8 +101,8 @@ private struct UncheckedSendableFloatSamples: @unchecked Sendable {
 /// fires once if no buffer has been delivered within
 /// `firstBufferTimeoutSeconds` after `dictation_capture_engine_started`; the
 /// heartbeat repeats every `heartbeatIntervalSeconds` while the recording is
-/// active. Both are log-only and generation-guarded, so stale delayed closures
-/// bail out after `stop()` or the next recording starts. See
+/// active. Both are generation-guarded, so stale delayed closures bail out
+/// after `stop()` or the next recording starts. See
 /// `journal/2026-05-03-dictation-silent-stall.md`.
 private struct CaptureDiagnosticsTimers {
     /// Generation that delivered its first buffer. This may be set before
@@ -194,6 +195,8 @@ public actor AudioRecorder {
     private var liveSampleSink: DictationAudioSampleSink?
     private var recording = false
     private var starting = false
+    private var recordingStartedAt: TimeInterval?
+    private var _lastCaptureHealth: AudioCaptureHealth?
     /// Frames of instant-dictation pre-roll prepended to the current
     /// recording's WAV. Reset at every `start()` entry; read by `stop()` to
     /// trim the file head when `discardPreRollRequested` is set.
@@ -216,6 +219,7 @@ public actor AudioRecorder {
 
     private static let outputSampleRate = ASRConstants.sampleRate
     private static let preRollPrependSamples = Int(Double(outputSampleRate) * 0.45)
+    private static let maxStartAttempts = 2
 
     /// Minimum samples before sending to STT. Mirrors FluidAudio's ASR guard,
     /// currently 0.3 seconds at 16 kHz.
@@ -262,6 +266,10 @@ public actor AudioRecorder {
     /// telemetry treats `nil` as "device unknown".
     public var deviceInfo: RecordingDeviceInfo? {
         nil
+    }
+
+    public var lastCaptureHealth: AudioCaptureHealth? {
+        _lastCaptureHealth
     }
 
     public func setInstantDictationEnabled(_ enabled: Bool) async {
@@ -341,7 +349,7 @@ public actor AudioRecorder {
 
     /// Subscribe to the shared microphone stream and start writing converted
     /// buffers to a temp WAV file. Returns once the subscription is owned and
-    /// the watchdog is armed.
+    /// the first real input buffer has arrived.
     public func start() async throws {
         try await start(sampleSink: nil)
     }
@@ -404,6 +412,7 @@ public actor AudioRecorder {
         self.firstBufferLogged.withLock { $0 = false }
         self.runtimeMetrics.withLock { $0 = RecordingRuntimeMetrics() }
         self.sampleCounter.withLock { $0 = 0 }
+        self._lastCaptureHealth = nil
         // This synchronous section has no suspension points, so a discard
         // request for *this* session cannot interleave before the reset; one
         // arriving for a previous aborted session is correctly cleared here.
@@ -430,14 +439,7 @@ public actor AudioRecorder {
                 sampleSink?.onSamples(preRollSamples)
             }
         } catch {
-            try? FileManager.default.removeItem(at: url)
-            if instantDictationEnabled {
-                let hasWarmSubscriber = warmSubscriberToken != nil
-                preRollCaptureGeneration.withLock { $0 += 1 }
-                preRollConverterCache.reset()
-                preRollBuffer.withLock { $0.clear() }
-                preRollAcceptingSamples.withLock { $0 = hasWarmSubscriber }
-            }
+            cleanupAfterFailedStart(url: url)
             throw error
         }
 
@@ -486,7 +488,7 @@ public actor AudioRecorder {
                 self.runtimeMetrics.withLock { metrics in
                     metrics.maxRMS = max(metrics.maxRMS, rmsValue)
                     metrics.maxAudioLevel = max(metrics.maxAudioLevel, normalizedValue)
-                    if normalizedValue >= 0.02 {
+                    if normalizedValue >= AudioCaptureHealth.silentInputMaximumLevel {
                         metrics.nonSilentBufferCount += 1
                     }
                 }
@@ -578,7 +580,8 @@ public actor AudioRecorder {
         let deathHandler: SharedMicrophoneStream.EngineDeathHandler = { [weak self] in
             // Engine death = recording is dead. Bump the generation so any
             // in-flight buffer handlers bail. The next caller of `stop()`
-            // will surface `insufficientSamples` if no audio was captured.
+            // will surface capture health or `insufficientSamples` if no
+            // usable audio was captured.
             self?.sessionGeneration.withLock { $0 += 1 }
         }
 
@@ -587,25 +590,52 @@ public actor AudioRecorder {
         )
 
         let token: SharedMicrophoneStream.SubscriberToken
-        do {
-            token = try await sharedStream.subscribe(
-                wantsVPIO: false,
-                onEngineDeath: deathHandler,
-                handler: bufferHandler
-            )
-        } catch {
-            try? FileManager.default.removeItem(at: url)
-            if instantDictationEnabled {
-                let hasWarmSubscriber = warmSubscriberToken != nil
-                preRollCaptureGeneration.withLock { $0 += 1 }
-                preRollConverterCache.reset()
-                preRollBuffer.withLock { $0.clear() }
-                preRollAcceptingSamples.withLock { $0 = hasWarmSubscriber }
+        var subscribeAttempt = 1
+        while true {
+            do {
+                token = try await sharedStream.subscribe(
+                    wantsVPIO: false,
+                    onEngineDeath: deathHandler,
+                    handler: bufferHandler
+                )
+                break
+            } catch {
+                if error is CancellationError {
+                    cleanupAfterFailedStart(url: url)
+                    throw error
+                }
+
+                let startWasCancelled = preSubscribeGeneration != self.sessionGeneration.withLock { $0 }
+                    || !self.starting
+                    || self.startCallGeneration != myStartCallGeneration
+                if startWasCancelled {
+                    cleanupAfterFailedStart(url: url)
+                    AudioCaptureDiagnostics.append(
+                        "dictation_capture_start_aborted reason=\"interrupted_during_subscribe\""
+                    )
+                    throw AudioProcessorError.recordingFailed("interrupted during subscribe")
+                }
+
+                if subscribeAttempt < Self.maxStartAttempts, Self.isRetryableStartError(error) {
+                    AudioCaptureDiagnostics.append(
+                        "dictation_capture_start_retry attempt=\(subscribeAttempt + 1) reason=engine_start_failed \(AudioCaptureDiagnostics.errorFields(error))"
+                    )
+                    subscribeAttempt += 1
+                    do {
+                        try await Task.sleep(for: .milliseconds(100))
+                    } catch {
+                        cleanupAfterFailedStart(url: url)
+                        throw error
+                    }
+                    continue
+                }
+
+                cleanupAfterFailedStart(url: url)
+                AudioCaptureDiagnostics.append(
+                    "dictation_capture_start_failed \(AudioCaptureDiagnostics.errorFields(error))"
+                )
+                throw AudioProcessorError.inputUnavailable(.engineStartFailed)
             }
-            AudioCaptureDiagnostics.append(
-                "dictation_capture_start_failed \(AudioCaptureDiagnostics.errorFields(error))"
-            )
-            throw AudioProcessorError.recordingFailed(error.localizedDescription)
         }
 
         // Actor-reentrancy guard. While we awaited subscribe, another
@@ -623,14 +653,7 @@ public actor AudioRecorder {
         if lostRace {
             let stream = sharedStream
             Task { await stream.unsubscribe(token) }
-            try? FileManager.default.removeItem(at: url)
-            if instantDictationEnabled {
-                let hasWarmSubscriber = warmSubscriberToken != nil
-                preRollCaptureGeneration.withLock { $0 += 1 }
-                preRollConverterCache.reset()
-                preRollBuffer.withLock { $0.clear() }
-                preRollAcceptingSamples.withLock { $0 = hasWarmSubscriber }
-            }
+            cleanupAfterFailedStart(url: url)
             AudioCaptureDiagnostics.append(
                 "dictation_capture_start_aborted reason=\"interrupted_during_subscribe\""
             )
@@ -640,6 +663,7 @@ public actor AudioRecorder {
         self.audioFile = file
         self.outputURL = url
         self.recording = true
+        self.recordingStartedAt = ProcessInfo.processInfo.systemUptime
         self.sharedSubscriberToken = token
         self.liveSampleSink = sampleSink
         didClaimSampleSink = true
@@ -655,12 +679,25 @@ public actor AudioRecorder {
             "dictation_capture_started"
         )
 
-        // Diagnostic instrumentation. Strictly log-only — these timers fire
-        // observability events and never abort the recording. Treating the
-        // tap-silence condition as "the user's recording is over" would mask
-        // a regression behind a friendlier error message; we want to surface
-        // the regression instead. See journal/2026-05-03-dictation-silent-stall.md.
+        // Diagnostic instrumentation plus first-buffer readiness. The delayed
+        // log still records the stall shape, while start() now refuses to
+        // report a healthy recording until a usable first buffer arrives.
         armCaptureDiagnostics(generation: tapGeneration)
+
+        let firstBufferArrived = await waitForFirstBuffer(
+            generation: tapGeneration,
+            timeoutSeconds: Self.firstBufferTimeoutSeconds
+        )
+        if !firstBufferArrived {
+            await abortStartedCapture(
+                token: token,
+                url: url,
+                generation: tapGeneration,
+                reason: "no_first_buffer"
+            )
+            try Task.checkCancellation()
+            throw AudioProcessorError.inputUnavailable(.noInputBuffers)
+        }
     }
 
     /// Discard the instant-dictation pre-roll from the in-flight recording.
@@ -675,9 +712,9 @@ public actor AudioRecorder {
     }
 
     /// Stop recording and return the path to the recorded WAV file.
-    /// Throws `insufficientSamples` if the recording is shorter than the STT
-    /// minimum — measured after any pre-roll discard, so a capture that is
-    /// effectively media-only dismisses silently instead of transcribing it.
+    /// Throws when the capture is unavailable or shorter than the STT minimum.
+    /// The length gate is measured after any pre-roll discard, so a capture
+    /// that is effectively media-only dismisses instead of transcribing it.
     public func stop() async throws -> URL {
         if starting, !recording {
             // `start()` awaits the stream subscription. A stop/cancel during
@@ -696,11 +733,10 @@ public actor AudioRecorder {
 
         var unsubscribeTask: Task<Void, Never>?
         if let token = sharedSubscriberToken {
-            // Fire-and-forget on the happy path so stop() never waits on the
-            // stream's engine queue, which serializes the unsubscribe behind
-            // any pending operations. The pre-roll discard path below awaits
-            // this task — that is what releases the tap's retain on the
-            // writer AVAudioFile, finalizing the WAV before it is re-read.
+            // Unsubscribe asynchronously after the synchronous state handoff.
+            // We still await it below before returning the URL, because the tap
+            // closure owns the writer AVAudioFile and releasing it finalizes
+            // the WAV for immediate STT or test reads.
             let stream = sharedStream
             unsubscribeTask = Task { await stream.unsubscribe(token) }
             sharedSubscriberToken = nil
@@ -714,6 +750,8 @@ public actor AudioRecorder {
         }
         audioFile = nil
         recording = false
+        let startedAt = recordingStartedAt
+        recordingStartedAt = nil
         let sampleSink = liveSampleSink
         liveSampleSink = nil
         atomicAudioLevel.withLock { $0 = 0.0 }
@@ -744,18 +782,46 @@ public actor AudioRecorder {
             throw AudioProcessorError.recordingFailed("No output file")
         }
 
+        await unsubscribeTask?.value
+        sharedProcessingQueue.sync {}
+
         let sampleCount = sampleCounter.withLock { $0 }
         let metrics = runtimeMetrics.withLock { $0 }
         let fileBytes = Self.fileSizeBytes(at: url)
-        let duration = Double(sampleCount) / Double(Self.outputSampleRate)
+        // Length and silence gates use the post-discard count: a capture whose
+        // remainder is below the STT floor, or sustained silence, should be
+        // judged on the audio that will actually be transcribed.
+        let effectiveSampleCount = max(0, sampleCount - discardFrames)
+        let duration = Double(effectiveSampleCount) / Double(Self.outputSampleRate)
+        let wallDuration = startedAt.map { ProcessInfo.processInfo.systemUptime - $0 } ?? duration
+        let health = AudioCaptureHealth(
+            sampleCount: effectiveSampleCount,
+            audioDurationSeconds: duration,
+            wallDurationSeconds: wallDuration,
+            fileBytes: fileBytes,
+            inputBufferCount: metrics.inputBufferCount,
+            outputBufferCount: metrics.outputBufferCount,
+            inputFrameCount: metrics.inputFrameCount,
+            maxRMS: metrics.maxRMS,
+            maxAudioLevel: metrics.maxAudioLevel,
+            nonSilentBufferCount: metrics.nonSilentBufferCount,
+            missingFloatChannelDataBufferCount: metrics.missingFloatChannelDataBufferCount,
+            invalidFormatBufferCount: metrics.invalidFormatBufferCount,
+            noBufferTimeoutFired: metrics.noBufferTimeoutFired
+        )
+        _lastCaptureHealth = health
         logger.debug("stop sampleCount=\(sampleCount, privacy: .public)")
         AudioCaptureDiagnostics.append(
-            "dictation_capture_stop sample_count=\(sampleCount) duration_s=\(String(format: "%.3f", duration)) file_bytes=\(fileBytes.map(String.init) ?? "unknown") input_buffers=\(metrics.inputBufferCount) output_buffers=\(metrics.outputBufferCount) input_frames=\(metrics.inputFrameCount) max_rms=\(String(format: "%.6f", metrics.maxRMS)) max_level=\(String(format: "%.3f", metrics.maxAudioLevel)) non_silent_buffers=\(metrics.nonSilentBufferCount) missing_float_buffers=\(metrics.missingFloatChannelDataBufferCount) invalid_format_buffers=\(metrics.invalidFormatBufferCount)"
+            "dictation_capture_stop sample_count=\(sampleCount) effective_sample_count=\(effectiveSampleCount) duration_s=\(String(format: "%.3f", duration)) wall_duration_s=\(String(format: "%.3f", wallDuration)) file_bytes=\(fileBytes.map(String.init) ?? "unknown") input_buffers=\(metrics.inputBufferCount) output_buffers=\(metrics.outputBufferCount) input_frames=\(metrics.inputFrameCount) max_rms=\(String(format: "%.6f", metrics.maxRMS)) max_level=\(String(format: "%.3f", metrics.maxAudioLevel)) non_silent_buffers=\(metrics.nonSilentBufferCount) missing_float_buffers=\(metrics.missingFloatChannelDataBufferCount) invalid_format_buffers=\(metrics.invalidFormatBufferCount) no_buffer_timeout=\(metrics.noBufferTimeoutFired)"
         )
-        // Length gate uses the post-discard count: a capture whose remainder
-        // is below the STT floor would otherwise transcribe nothing but the
-        // discarded media audio.
-        let effectiveSampleCount = sampleCount - discardFrames
+        if let problem = health.terminalProblem {
+            try? FileManager.default.removeItem(at: url)
+            AudioCaptureDiagnostics.append(
+                "dictation_capture_unavailable problem=\(problem.rawValue) sample_count=\(effectiveSampleCount) input_buffers=\(metrics.inputBufferCount) non_silent_buffers=\(metrics.nonSilentBufferCount) max_level=\(String(format: "%.3f", metrics.maxAudioLevel))"
+            )
+            sampleSink?.onCancel()
+            throw AudioProcessorError.inputUnavailable(problem)
+        }
         guard effectiveSampleCount >= Self.minimumSamples else {
             // Clean up the too-short file
             try? FileManager.default.removeItem(at: url)
@@ -769,16 +835,8 @@ public actor AudioRecorder {
         sampleSink?.onFinish()
 
         if discardFrames > 0 {
-            // Releasing the subscriber drops the tap's retain on the writer
-            // AVAudioFile (the handler closure holds it); draining the
-            // processing queue afterwards releases the copies held by any
-            // already-enqueued blocks. Only then is the WAV finalized on disk
-            // and safe to re-read. Suspending here is safe: every piece of
-            // per-session actor state was reset above, and this path touches
-            // only locals — a reentrant start() begins a fresh session
-            // against a different file.
-            await unsubscribeTask?.value
-            sharedProcessingQueue.sync {}
+            // The file was finalized above, so it is safe to rewrite it in
+            // place before handing it to STT.
             do {
                 try Self.removeLeadingFrames(discardFrames, fromWAVAt: url)
                 let duration = Double(discardFrames) / Double(Self.outputSampleRate)
@@ -851,6 +909,84 @@ public actor AudioRecorder {
     private func logTapError(_ message: String) {
         logger.warning("audio_tap \(message, privacy: .public)")
         AudioCaptureDiagnostics.append("dictation_capture_tap_error \(message)")
+    }
+
+    private func cleanupAfterFailedStart(url: URL) {
+        try? FileManager.default.removeItem(at: url)
+        if instantDictationEnabled {
+            let hasWarmSubscriber = warmSubscriberToken != nil
+            preRollCaptureGeneration.withLock { $0 += 1 }
+            preRollConverterCache.reset()
+            preRollBuffer.withLock { $0.clear() }
+            preRollAcceptingSamples.withLock { $0 = hasWarmSubscriber }
+        }
+    }
+
+    private static func isRetryableStartError(_ error: Error) -> Bool {
+        if case SharedMicrophoneStream.SubscribeError.engineStartFailed = error {
+            return true
+        }
+        return false
+    }
+
+    private func waitForFirstBuffer(
+        generation: Int,
+        timeoutSeconds: TimeInterval
+    ) async -> Bool {
+        let deadline = ProcessInfo.processInfo.systemUptime + timeoutSeconds
+        while ProcessInfo.processInfo.systemUptime < deadline {
+            if Task.isCancelled {
+                return false
+            }
+            if captureDiagnosticsTimers.withLock({ $0.firstBufferSeenGeneration == generation }) {
+                return true
+            }
+            if sessionGeneration.withLock({ $0 }) != generation || !recording {
+                return false
+            }
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+        return captureDiagnosticsTimers.withLock { $0.firstBufferSeenGeneration == generation }
+    }
+
+    private func abortStartedCapture(
+        token: SharedMicrophoneStream.SubscriberToken,
+        url: URL,
+        generation: Int,
+        reason: String
+    ) async {
+        let generationStillActive = sessionGeneration.withLock { $0 } == generation
+        let recorderStillOwnsToken = sharedSubscriberToken == token && recording
+        guard generationStillActive || recorderStillOwnsToken else { return }
+
+        sharedSubscriberToken = nil
+        audioFile = nil
+        outputURL = nil
+        recording = false
+        recordingStartedAt = nil
+        let sampleSink = liveSampleSink
+        liveSampleSink = nil
+        atomicAudioLevel.withLock { $0 = 0.0 }
+        preRollCaptureGeneration.withLock { $0 += 1 }
+        preRollConverterCache.reset()
+        preRollBuffer.withLock { $0.clear() }
+        if instantDictationEnabled {
+            let hasWarmSubscriber = warmSubscriberToken != nil
+            preRollAcceptingSamples.withLock { $0 = hasWarmSubscriber }
+            if warmSubscriberToken == nil {
+                Task { await self.startWarmCaptureIfNeeded() }
+            }
+        }
+        sessionGeneration.withLock { $0 += 1 }
+        disarmCaptureDiagnostics()
+        sharedProcessingQueue.sync {}
+
+        AudioCaptureDiagnostics.append(
+            "dictation_capture_start_failed reason=\(reason)"
+        )
+        sampleSink?.onCancel()
+        await sharedStream.unsubscribe(token)
+        try? FileManager.default.removeItem(at: url)
     }
 
     private func writePreRollSamples(
@@ -1038,10 +1174,11 @@ public actor AudioRecorder {
         )!
     )
 
-    // MARK: - Capture diagnostics (log-only)
+    // MARK: - Capture diagnostics
 
-    /// Arm the first-buffer timeout and recording heartbeat. Both are
-    /// log-only; firing them does not affect the recording.
+    /// Arm the first-buffer timeout and recording heartbeat. The first-buffer
+    /// timer records the no-buffer health bit; `start()` owns the user-facing
+    /// readiness gate. Heartbeats remain log-only.
     ///
     /// `armedGeneration` (captured by both closures) is the value of
     /// `sessionGeneration` at the moment `start()` succeeded. If the closure
@@ -1080,6 +1217,7 @@ public actor AudioRecorder {
             }
             guard shouldFire else { return }
             guard self.sessionGeneration.withLock({ $0 }) == armedGeneration else { return }
+            self.runtimeMetrics.withLock { $0.noBufferTimeoutFired = true }
             let isRunning = stream.diagnostics.engineRunning
             let defaultInput = AudioCaptureDiagnostics.defaultInputDeviceSummary()
             AudioCaptureDiagnostics.append(

--- a/Sources/MacParakeetCore/Audio/README.md
+++ b/Sources/MacParakeetCore/Audio/README.md
@@ -40,7 +40,10 @@ owned by `AppEnvironment`.
   see "What to know" below). When the Pause Media round-trip confirms media was
   playing at press time, `discardPreRollForActiveRecording()` marks
   the session and `stop()` trims the prepended pre-roll from the WAV —
-  pre-press media audio that no pause can silence (issue #474).
+  pre-press media audio that no pause can silence (issue #474). Active
+  dictation start now waits for the first real input buffer; if the shared
+  engine starts but delivers none within the watchdog window, start aborts with
+  a microphone-input error instead of handing an empty WAV to STT.
 - `MicrophoneCapture.swift` — meeting microphone capture. Subscribes
   with `wantsVPIO: false` by default via `MeetingMicProcessingMode.raw`.
   VPIO modes remain available for explicit experiments, with raw fallback
@@ -196,13 +199,14 @@ debounce (0.5 s in `AppEnvironment`, 0 = disabled for direct
 constructions) keyed by a supersession generation; superseded or
 cancelled sleepers exit before touching any engine or pre-roll state.
 
-**Diagnostic logging is observability-only.** The first-buffer
-watchdog and recording heartbeat in `AudioRecorder` log to
-`dictation-audio.log` but **never** abort the recording. PR #210
-shipped this deliberately; converting any of those signals into a
-user-facing error would mask a regression as a fact of life.
-Telemetry counters can be added separately, but the log path stays
-non-disruptive.
+**Diagnostics stay narrow.** The recording heartbeat in `AudioRecorder`
+remains observability-only. The first-buffer watchdog is now also a
+startup readiness signal: `start()` does not report a healthy recording until
+at least one microphone buffer arrives, and a no-buffer start aborts with a
+microphone-input error. Sustained silent input is classified at `stop()` using
+the capture-health snapshot before STT runs. Keep mid-session heartbeat logs
+non-disruptive; they are still there to diagnose stalls without inventing a
+second recovery path.
 
 **The configuration-change observer self-heals (four-gated restart).** When
 `AVAudioEngine` stops itself after an `AVAudioEngineConfigurationChange`

--- a/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
+++ b/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
@@ -424,6 +424,8 @@ public actor DictationService: DictationServiceProtocol {
 
         do {
             let audioURL = try await audioProcessor.stopCapture()
+            let captureHealth = await audioProcessor.lastCaptureHealth
+            try rejectUnavailableCaptureIfNeeded(captureHealth, audioURL: audioURL)
             let device = await audioProcessor.recordingDeviceInfo
             await cancelDisplayPreview(sessionID: currentSession, clearText: false)
             _ = await finishLiveDictationTranscription(sessionID: currentSession)
@@ -634,8 +636,10 @@ public actor DictationService: DictationServiceProtocol {
 
         let currentSession = activeSessionID
         let formatterContext = currentAIFormatterFinishContext ?? currentAIFormatterStartContext
+        let captureHealth = await audioProcessor.lastCaptureHealth
         _state = .processing
         do {
+            try rejectUnavailableCaptureIfNeeded(captureHealth, audioURL: audioURL)
             let result = try await withCurrentObservabilityContextIfAny {
                 try await processCapturedAudio(audioURL: audioURL, formatterContext: formatterContext)
             }
@@ -740,6 +744,21 @@ public actor DictationService: DictationServiceProtocol {
         return try await Observability.withOperationContext(operationContext) {
             try await operation()
         }
+    }
+
+    private func rejectUnavailableCaptureIfNeeded(
+        _ captureHealth: AudioCaptureHealth?,
+        audioURL: URL
+    ) throws {
+        guard let captureHealth, let problem = captureHealth.terminalProblem else {
+            return
+        }
+        logger.warning("dictation_capture_unavailable problem=\(problem.rawValue, privacy: .public)")
+        AudioCaptureDiagnostics.append(
+            "dictation_transcribe_skipped problem=\(problem.rawValue) input_buffers=\(captureHealth.inputBufferCount) non_silent_buffers=\(captureHealth.nonSilentBufferCount) max_level=\(String(format: "%.3f", captureHealth.maxAudioLevel))"
+        )
+        try? FileManager.default.removeItem(at: audioURL)
+        throw AudioProcessorError.inputUnavailable(problem)
     }
 
     private func beginLiveDictationTranscriptionIfAvailable(

--- a/Tests/MacParakeetTests/Audio/AudioRecorderFormatChangeTests.swift
+++ b/Tests/MacParakeetTests/Audio/AudioRecorderFormatChangeTests.swift
@@ -44,8 +44,12 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
             permissionProvider: { true }
         )
 
-        try await recorder.start()
-        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 4_800))
+        try await startRecorder(
+            recorder,
+            stream: stream,
+            platform: platform,
+            firstBuffer: try makeMonoFloatBuffer(frameCount: 4_800)
+        )
 
         let url = try await recorder.stop()
         XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
@@ -60,8 +64,12 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
             permissionProvider: { true }
         )
 
-        try await recorder.start()
-        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 4_799))
+        try await startRecorder(
+            recorder,
+            stream: stream,
+            platform: platform,
+            firstBuffer: try makeMonoFloatBuffer(frameCount: 4_799)
+        )
 
         do {
             _ = try await recorder.stop()
@@ -87,8 +95,13 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
             onCancel: { spy.recordCancel() }
         )
 
-        try await recorder.start(sampleSink: sink)
-        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 4_800))
+        try await startRecorder(
+            recorder,
+            stream: stream,
+            platform: platform,
+            firstBuffer: try makeMonoFloatBuffer(frameCount: 4_800),
+            sampleSink: sink
+        )
 
         let url = try await recorder.stop()
         defer { try? FileManager.default.removeItem(at: url) }
@@ -111,8 +124,13 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
             onCancel: { spy.recordCancel() }
         )
 
-        try await recorder.start(sampleSink: sink)
-        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 4_799))
+        try await startRecorder(
+            recorder,
+            stream: stream,
+            platform: platform,
+            firstBuffer: try makeMonoFloatBuffer(frameCount: 4_799),
+            sampleSink: sink
+        )
 
         do {
             _ = try await recorder.stop()
@@ -125,6 +143,117 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
 
         XCTAssertEqual(spy.counts.cancel, 1, "a cancelled capture should cancel the sample sink")
         XCTAssertEqual(spy.counts.finish, 0, "a cancelled capture must not finish the sample sink")
+    }
+
+    func testSharedModeStartRetriesTransientEngineStartFailure() async throws {
+        let platform = AudioRecorderBlockingPlatform()
+        platform.enqueueConfigureAndStartErrors([TestMicrophoneStartError.coreAudio10868])
+        let stream = SharedMicrophoneStream(platform: platform, bufferSize: 1024)
+        let recorder = AudioRecorder(
+            sharedStream: stream,
+            permissionProvider: { true }
+        )
+
+        let startTask = Task { try await recorder.start() }
+        let retriedAndRunning = await pollUntil(timeout: .seconds(2)) {
+            platform.configureAndStartCallCount >= 2 && platform.isEngineRunning
+        }
+        XCTAssertTrue(retriedAndRunning, "expected recorder to retry once and restart the mock engine")
+
+        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 4_800))
+        try await startTask.value
+
+        XCTAssertEqual(platform.configureAndStartCallCount, 2)
+        let url = try await recorder.stop()
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    func testSharedModeStartFailsWhenFirstBufferNeverArrives() async throws {
+        let platform = AudioRecorderBlockingPlatform()
+        let stream = SharedMicrophoneStream(platform: platform, bufferSize: 1024)
+        let recorder = AudioRecorder(
+            sharedStream: stream,
+            permissionProvider: { true }
+        )
+
+        do {
+            try await recorder.start()
+            XCTFail("start() should fail when the shared stream never delivers a first buffer")
+        } catch AudioProcessorError.inputUnavailable(let problem) {
+            XCTAssertEqual(problem, .noInputBuffers)
+        } catch {
+            XCTFail("Unexpected start error: \(error)")
+        }
+
+        let isRecording = await recorder.isRecording
+        XCTAssertFalse(isRecording)
+        XCTAssertEqual(stream.diagnostics.subscriberCount, 0)
+        XCTAssertFalse(stream.diagnostics.engineRunning)
+    }
+
+    func testSharedModeStopDuringFirstBufferWaitCleansUpRecorder() async throws {
+        let platform = AudioRecorderBlockingPlatform()
+        let stream = SharedMicrophoneStream(platform: platform, bufferSize: 1024)
+        let recorder = AudioRecorder(
+            sharedStream: stream,
+            permissionProvider: { true }
+        )
+
+        let startTask = Task { try await recorder.start() }
+        let waitingForFirstBuffer = await pollUntil(timeout: .seconds(2)) {
+            stream.diagnostics.activeSubscriberCount == 1 && stream.diagnostics.engineRunning
+        }
+        XCTAssertTrue(waitingForFirstBuffer, "expected start() to own a subscriber before first-buffer gate")
+
+        do {
+            _ = try await recorder.stop()
+            XCTFail("stop() should reject a zero-sample capture")
+        } catch AudioProcessorError.insufficientSamples {
+            // Expected.
+        } catch {
+            XCTFail("Unexpected stop error: \(error)")
+        }
+
+        do {
+            try await startTask.value
+            XCTFail("start() should fail after stop invalidates the first-buffer wait")
+        } catch AudioProcessorError.inputUnavailable(let problem) {
+            XCTAssertEqual(problem, .noInputBuffers)
+        } catch {
+            XCTFail("Unexpected start error: \(error)")
+        }
+
+        let isRecording = await recorder.isRecording
+        XCTAssertFalse(isRecording)
+        let drained = await pollUntil(timeout: .seconds(2)) {
+            stream.diagnostics.subscriberCount == 0 && !stream.diagnostics.engineRunning
+        }
+        XCTAssertTrue(drained, "expected stop() to unsubscribe the pending first-buffer capture")
+    }
+
+    func testSharedModeStopFailsSilentLongCaptureBeforeSTT() async throws {
+        let platform = AudioRecorderBlockingPlatform()
+        let stream = SharedMicrophoneStream(platform: platform, bufferSize: 1024)
+        let recorder = AudioRecorder(
+            sharedStream: stream,
+            permissionProvider: { true }
+        )
+
+        try await startRecorder(
+            recorder,
+            stream: stream,
+            platform: platform,
+            firstBuffer: try makeMonoFloatBuffer(frameCount: 32_000, sampleValue: 0)
+        )
+
+        do {
+            _ = try await recorder.stop()
+            XCTFail("stop() should classify a sustained zero-signal capture as unavailable input")
+        } catch AudioProcessorError.inputUnavailable(let problem) {
+            XCTAssertEqual(problem, .silentInput)
+        } catch {
+            XCTFail("Unexpected stop error: \(error)")
+        }
     }
 
     func testInstantDictationPrependsWarmPreRoll() async throws {
@@ -142,8 +271,12 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
         platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 8_000, sampleValue: 0.6))
         try await Task.sleep(for: .milliseconds(50))
 
-        try await recorder.start()
-        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.2))
+        try await startRecorder(
+            recorder,
+            stream: stream,
+            platform: platform,
+            firstBuffer: try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.2)
+        )
 
         let url = try await recorder.stop()
         defer { try? FileManager.default.removeItem(at: url) }
@@ -170,8 +303,12 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
         await recorder.setInstantDictationEnabled(true)
         platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 8_000, sampleValue: 0.8))
 
-        try await recorder.start()
-        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.2))
+        try await startRecorder(
+            recorder,
+            stream: stream,
+            platform: platform,
+            firstBuffer: try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.2)
+        )
 
         let url = try await recorder.stop()
         defer { try? FileManager.default.removeItem(at: url) }
@@ -197,13 +334,21 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
         platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 8_000, sampleValue: 0.7))
         try await Task.sleep(for: .milliseconds(50))
 
-        try await recorder.start()
-        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.3))
+        try await startRecorder(
+            recorder,
+            stream: stream,
+            platform: platform,
+            firstBuffer: try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.3)
+        )
         let firstURL = try await recorder.stop()
         try? FileManager.default.removeItem(at: firstURL)
 
-        try await recorder.start()
-        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.4))
+        try await startRecorder(
+            recorder,
+            stream: stream,
+            platform: platform,
+            firstBuffer: try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.4)
+        )
         let secondURL = try await recorder.stop()
         defer { try? FileManager.default.removeItem(at: secondURL) }
 
@@ -299,8 +444,12 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
         platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 8_000, sampleValue: 0.5))
         try await Task.sleep(for: .milliseconds(50))
 
-        try await recorder.start()
-        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.2))
+        try await startRecorder(
+            recorder,
+            stream: stream,
+            platform: platform,
+            firstBuffer: try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.2)
+        )
 
         let url = try await recorder.stop()
         defer { try? FileManager.default.removeItem(at: url) }
@@ -346,8 +495,12 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
         }
         XCTAssertTrue(restarted, "warm capture should restart once only the passive subscriber remains")
 
-        try await recorder.start()
-        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.2))
+        try await startRecorder(
+            recorder,
+            stream: stream,
+            platform: platform,
+            firstBuffer: try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.2)
+        )
         let url = try await recorder.stop()
         defer { try? FileManager.default.removeItem(at: url) }
 
@@ -369,8 +522,12 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
         )
 
         await recorder.setInstantDictationEnabled(true)
-        try await recorder.start()
-        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.3))
+        try await startRecorder(
+            recorder,
+            stream: stream,
+            platform: platform,
+            firstBuffer: try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.3)
+        )
 
         await recorder.refreshInstantDictationWarmCapture()
 
@@ -523,6 +680,12 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
             XCTFail("Unexpected start #1 error: \(error)")
         }
 
+        let readyForFirstBuffer = await pollUntil(timeout: .seconds(2)) {
+            stream.diagnostics.activeSubscriberCount >= 1 && stream.diagnostics.engineRunning
+        }
+        XCTAssertTrue(readyForFirstBuffer, "expected start #2 to hold a subscriber before first-buffer gate")
+        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 4_800))
+
         do {
             try await task2.value
         } catch {
@@ -540,9 +703,9 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
         XCTAssertTrue(drained, "expected exactly one remaining subscriber after #1 unsubscribed")
         XCTAssertTrue(stream.diagnostics.engineRunning)
 
-        // Cleanup stop() throws `insufficientSamples` because the mock platform
-        // never delivers buffers — expected here and unrelated to the race.
-        _ = try? await recorder.stop()
+        if let cleanupURL = try? await recorder.stop() {
+            try? FileManager.default.removeItem(at: cleanupURL)
+        }
     }
 
     // MARK: - Pre-roll discard (issue #474)
@@ -559,8 +722,12 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
         platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 8_000, sampleValue: 0.6))
         try await Task.sleep(for: .milliseconds(50))
 
-        try await recorder.start()
-        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.2))
+        try await startRecorder(
+            recorder,
+            stream: stream,
+            platform: platform,
+            firstBuffer: try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.2)
+        )
         await recorder.discardPreRollForActiveRecording()
 
         let url = try await recorder.stop()
@@ -590,8 +757,12 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
         // Total = 7,200 pre-roll + 3,200 live ≥ the 4,800 floor, but the
         // post-discard remainder (3,200) is below it: without the discard
         // this capture would transcribe nothing but the paused media audio.
-        try await recorder.start()
-        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 3_200, sampleValue: 0.2))
+        try await startRecorder(
+            recorder,
+            stream: stream,
+            platform: platform,
+            firstBuffer: try makeMonoFloatBuffer(frameCount: 3_200, sampleValue: 0.2)
+        )
         await recorder.discardPreRollForActiveRecording()
 
         do {
@@ -621,8 +792,12 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
         // Idle request must be dropped, not pre-armed for the next session.
         await recorder.discardPreRollForActiveRecording()
 
-        try await recorder.start()
-        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.2))
+        try await startRecorder(
+            recorder,
+            stream: stream,
+            platform: platform,
+            firstBuffer: try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.2)
+        )
 
         let url = try await recorder.stop()
         defer { try? FileManager.default.removeItem(at: url) }
@@ -647,8 +822,12 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
         platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 8_000, sampleValue: 0.6))
         try await Task.sleep(for: .milliseconds(50))
 
-        try await recorder.start()
-        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.2))
+        try await startRecorder(
+            recorder,
+            stream: stream,
+            platform: platform,
+            firstBuffer: try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.2)
+        )
         await recorder.discardPreRollForActiveRecording()
         let firstURL = try await recorder.stop()
         try? FileManager.default.removeItem(at: firstURL)
@@ -656,8 +835,12 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
         platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 8_000, sampleValue: 0.7))
         try await Task.sleep(for: .milliseconds(50))
 
-        try await recorder.start()
-        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.2))
+        try await startRecorder(
+            recorder,
+            stream: stream,
+            platform: platform,
+            firstBuffer: try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.2)
+        )
         let secondURL = try await recorder.stop()
         defer { try? FileManager.default.removeItem(at: secondURL) }
 
@@ -677,8 +860,12 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
             permissionProvider: { true }
         )
 
-        try await recorder.start()
-        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.3))
+        try await startRecorder(
+            recorder,
+            stream: stream,
+            platform: platform,
+            firstBuffer: try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.3)
+        )
         await recorder.discardPreRollForActiveRecording()
 
         let url = try await recorder.stop()
@@ -705,8 +892,12 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
         XCTAssertEqual(stream.diagnostics.subscriberCount, 0)
 
         // Dictation itself still works — cold start, no pre-roll.
-        try await recorder.start()
-        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.2))
+        try await startRecorder(
+            recorder,
+            stream: stream,
+            platform: platform,
+            firstBuffer: try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.2)
+        )
         let url = try await recorder.stop()
         defer { try? FileManager.default.removeItem(at: url) }
 
@@ -877,6 +1068,34 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
         await recorder.setInstantDictationEnabled(false)
     }
 
+    private func startRecorder(
+        _ recorder: AudioRecorder,
+        stream: SharedMicrophoneStream,
+        platform: AudioRecorderBlockingPlatform,
+        firstBuffer: AVAudioPCMBuffer,
+        sampleSink: DictationAudioSampleSink? = nil,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        let startTask = Task {
+            try await recorder.start(sampleSink: sampleSink)
+        }
+        let readyForFirstBuffer = await pollUntil(timeout: .seconds(2)) {
+            stream.diagnostics.activeSubscriberCount >= 1 && stream.diagnostics.engineRunning
+        }
+        XCTAssertTrue(
+            readyForFirstBuffer,
+            "expected mock platform to start before delivering first buffer",
+            file: file,
+            line: line
+        )
+        if !readyForFirstBuffer {
+            startTask.cancel()
+        }
+        platform.deliverBuffer(firstBuffer)
+        try await startTask.value
+    }
+
     private func pollUntil(
         timeout: Duration,
         condition: @Sendable () -> Bool
@@ -943,6 +1162,14 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
     }
 }
 
+private enum TestMicrophoneStartError: Error, LocalizedError {
+    case coreAudio10868
+
+    var errorDescription: String? {
+        "The operation couldn't be completed. (com.apple.coreaudio.avfaudio error -10868.)"
+    }
+}
+
 private final class AudioRecorderBlockingPlatform: MicrophoneEnginePlatform, @unchecked Sendable {
     private let lock = NSLock()
     private let hookLock = NSLock()
@@ -950,6 +1177,7 @@ private final class AudioRecorderBlockingPlatform: MicrophoneEnginePlatform, @un
     private var _configureAndStartCallCount = 0
     private var _tapHandler: (@Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void)?
     private var _configureAndStartHook: (@Sendable () -> Void)?
+    private var _configureAndStartErrors: [Error] = []
 
     var configureAndStartHook: (@Sendable () -> Void)? {
         get { hookLock.withLock { _configureAndStartHook } }
@@ -968,14 +1196,28 @@ private final class AudioRecorderBlockingPlatform: MicrophoneEnginePlatform, @un
         AVAudioFormat(standardFormatWithSampleRate: 48_000, channels: 1)
     }
 
+    func enqueueConfigureAndStartErrors(_ errors: [Error]) {
+        lock.withLock {
+            _configureAndStartErrors.append(contentsOf: errors)
+        }
+    }
+
     func configureAndStart(
         vpioEnabled: Bool,
         bufferSize: AVAudioFrameCount,
         tapHandler: @escaping @Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void
     ) throws {
+        let queuedError = lock.withLock { () -> Error? in
+            _configureAndStartCallCount += 1
+            guard !_configureAndStartErrors.isEmpty else { return nil }
+            return _configureAndStartErrors.removeFirst()
+        }
+        if let queuedError {
+            throw queuedError
+        }
+
         configureAndStartHook?()
         lock.withLock {
-            _configureAndStartCallCount += 1
             _isRunning = true
             _tapHandler = tapHandler
         }

--- a/Tests/MacParakeetTests/Audio/MockAudioProcessor.swift
+++ b/Tests/MacParakeetTests/Audio/MockAudioProcessor.swift
@@ -6,6 +6,7 @@ public actor MockAudioProcessor: AudioProcessorProtocol {
     public var convertError: Error?
     public var captureResult: URL?
     public var captureError: Error?
+    public var captureHealth: AudioCaptureHealth?
     private var _audioLevel: Float = 0.0
     private var _isRecording = false
     private var startCaptureDelayMs: UInt64 = 0
@@ -26,6 +27,10 @@ public actor MockAudioProcessor: AudioProcessorProtocol {
     public func configure(captureResult: URL) {
         self.captureResult = captureResult
         self.captureError = nil
+    }
+
+    public func configure(lastCaptureHealth: AudioCaptureHealth?) {
+        self.captureHealth = lastCaptureHealth
     }
 
     public func configureConvertError(_ error: Error) {
@@ -54,6 +59,10 @@ public actor MockAudioProcessor: AudioProcessorProtocol {
 
     public var recordingDeviceInfo: RecordingDeviceInfo? {
         nil
+    }
+
+    public var lastCaptureHealth: AudioCaptureHealth? {
+        captureHealth
     }
 
     public func convert(fileURL: URL) async throws -> URL {

--- a/Tests/MacParakeetTests/Services/Dictation/DictationServiceErrorTests.swift
+++ b/Tests/MacParakeetTests/Services/Dictation/DictationServiceErrorTests.swift
@@ -32,6 +32,9 @@ final class DictationServiceErrorTests: XCTestCase {
             (.unsupportedFormat("xyz"), "Unsupported audio format: xyz"),
             (.fileTooLarge("2GB"), "File too large: 2GB"),
             (.insufficientSamples, "Recording too short"),
+            (.inputUnavailable(.engineStartFailed), "Microphone failed to start. Try again."),
+            (.inputUnavailable(.noInputBuffers), "No microphone input detected. Check your input device and try again."),
+            (.inputUnavailable(.silentInput), "No microphone signal detected. Check your input device and try again."),
         ]
 
         for (error, expected) in errors {

--- a/Tests/MacParakeetTests/Services/Dictation/DictationServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/Dictation/DictationServiceTests.swift
@@ -310,6 +310,99 @@ final class DictationServiceTests: XCTestCase {
         XCTAssertEqual(operation["language"], "ko")
     }
 
+    func testSilentCaptureHealthFailsBeforeSTTAndEmitsFailureTelemetry() async throws {
+        let telemetry = DictationTelemetrySpy()
+        Telemetry.configure(telemetry)
+
+        let audioURL = try makeTemporaryAudioURL()
+        await mockAudio.configure(captureResult: audioURL)
+        await mockAudio.configure(lastCaptureHealth: AudioCaptureHealth(
+            sampleCount: 32_000,
+            audioDurationSeconds: 2,
+            wallDurationSeconds: 2,
+            fileBytes: 128_000,
+            inputBufferCount: 20,
+            outputBufferCount: 20,
+            inputFrameCount: 96_000,
+            maxRMS: 0,
+            maxAudioLevel: 0,
+            nonSilentBufferCount: 0,
+            missingFloatChannelDataBufferCount: 0,
+            invalidFormatBufferCount: 0,
+            noBufferTimeoutFired: false
+        ))
+        await mockSTT.configure(result: STTResult(text: "should not transcribe"))
+
+        try await service.startRecording(context: DictationTelemetryContext(trigger: .hotkey, mode: .persistent))
+        do {
+            _ = try await service.stopRecording()
+            XCTFail("Expected silent capture health to fail before STT")
+        } catch AudioProcessorError.inputUnavailable(let problem) {
+            XCTAssertEqual(problem, .silentInput)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        let transcribeCallCount = await mockSTT.transcribeCallCount
+        XCTAssertEqual(transcribeCallCount, 0)
+        let events = telemetry.snapshot()
+        XCTAssertFalse(events.contains { event in
+            if case .dictationEmpty = event { return true }
+            return false
+        })
+        XCTAssertTrue(events.contains { event in
+            if case .dictationFailed = event { return true }
+            return false
+        })
+
+        let operation = try XCTUnwrap(dictationOperationProps(in: events).last)
+        XCTAssertEqual(operation["outcome"], "failure")
+        XCTAssertEqual(operation["error_type"], "AudioProcessorError.inputUnavailable")
+        XCTAssertEqual(operation["trigger"], "hotkey")
+        XCTAssertEqual(operation["mode"], "persistent")
+    }
+
+    func testNoBufferCaptureFailureEmitsFailureTelemetry() async throws {
+        let telemetry = DictationTelemetrySpy()
+        Telemetry.configure(telemetry)
+
+        await mockAudio.configure(lastCaptureHealth: AudioCaptureHealth(
+            sampleCount: 0,
+            audioDurationSeconds: 0,
+            wallDurationSeconds: 3,
+            fileBytes: 4_096,
+            inputBufferCount: 0,
+            outputBufferCount: 0,
+            inputFrameCount: 0,
+            maxRMS: 0,
+            maxAudioLevel: 0,
+            nonSilentBufferCount: 0,
+            missingFloatChannelDataBufferCount: 0,
+            invalidFormatBufferCount: 0,
+            noBufferTimeoutFired: true
+        ))
+
+        try await service.startRecording(context: DictationTelemetryContext(trigger: .hotkey, mode: .hold))
+        await mockAudio.configureCaptureError(AudioProcessorError.inputUnavailable(.noInputBuffers))
+        do {
+            _ = try await service.stopRecording()
+            XCTFail("Expected no-buffer capture to fail")
+        } catch AudioProcessorError.inputUnavailable(let problem) {
+            XCTAssertEqual(problem, .noInputBuffers)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        let events = telemetry.snapshot()
+        XCTAssertFalse(events.contains { event in
+            if case .dictationEmpty = event { return true }
+            return false
+        })
+        let operation = try XCTUnwrap(dictationOperationProps(in: events).last)
+        XCTAssertEqual(operation["outcome"], "failure")
+        XCTAssertEqual(operation["error_type"], "AudioProcessorError.inputUnavailable")
+    }
+
     func testStopRecordingUsesRecordedFileEvenWhenLiveFinalIsAvailable() async throws {
         service = DictationService(
             audioProcessor: mockAudio,
@@ -1336,6 +1429,13 @@ final class DictationServiceTests: XCTestCase {
             try? await Task.sleep(for: .milliseconds(10))
         }
         return await condition()
+    }
+
+    private func makeTemporaryAudioURL() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString).wav")
+        try Data([0]).write(to: url)
+        return url
     }
 
     private func allTelemetryProps(in events: [TelemetryEventSpec]) -> [[String: String]] {

--- a/Tests/MacParakeetTests/Services/Telemetry/TelemetryErrorClassifierTests.swift
+++ b/Tests/MacParakeetTests/Services/Telemetry/TelemetryErrorClassifierTests.swift
@@ -17,6 +17,8 @@ struct TelemetryErrorClassifierTests {
             == "AudioProcessorError.recordingFailed")
         #expect(TelemetryErrorClassifier.classify(AudioProcessorError.conversionFailed("test"))
             == "AudioProcessorError.conversionFailed")
+        #expect(TelemetryErrorClassifier.classify(AudioProcessorError.inputUnavailable(.noInputBuffers))
+            == "AudioProcessorError.inputUnavailable")
     }
 
     @Test("classifies STTError cases with case name")


### PR DESCRIPTION
## Summary
Dictation now fails fast when the microphone capture itself is unavailable instead of letting a dead or silent stream fall through to STT as a misleading no-speech result.

Before this, a user could start dictation, speak for minutes, and only find out at stop time that MacParakeet had no usable audio. The app already tracked buffer and signal-health metrics, but that state was dropped at the recorder boundary, so dictation could not distinguish hard engine-start failure, no buffers, silent buffers, and genuine empty speech.

## Root Cause
`AudioRecorder` treated a successful shared-stream subscription as capture success. That contract was too weak: subscribed does not mean usable audio.

## Fix
- Require the first usable buffer before `AudioRecorder.start()` reports success.
- Retry one transient shared-engine start failure before surfacing unavailable input.
- Expose `AudioCaptureHealth` through `AudioProcessorProtocol` so dictation can classify no-buffer and silent-input captures before STT.
- Emit capture-failure telemetry instead of no-speech telemetry for these paths.
- Cover no-buffer, retry, silent-capture, stop-during-first-buffer-wait, and dictation telemetry regressions.

## Related Issues
- Addresses #432 at the app-level capture contract: a recording can no longer be considered successfully started without a first buffer, and unusable capture is classified as microphone-input failure.
- Partially addresses #435 by replacing the misleading “more audio needed” path for unusable capture. The separate request for an audible in-recording warning remains follow-up work.

## Verification
- `swift test --filter DictationServiceTests/testSilentCaptureHealthFailsBeforeSTTAndEmitsFailureTelemetry`
- `swift test --filter AudioRecorderFormatChangeTests`
- `swift test --filter DictationServiceTests`
- `swift test --filter TelemetryErrorClassifierTests`
- `swift test --filter DictationServiceErrorTests`
- `swift test --filter AudioFileConverterTests/testAudioProcessorErrorDescriptions`
- `swift test --filter Audio`
- `MACPARAKEET_HARDWARE_TESTS=1 swift test --filter MicrophoneEngineRealPlatformTests`
- `swift test` — 3,259 XCTest tests, 10 skipped, 0 failures; 16 Swift Testing tests, 0 failures
- `git diff --check`

## Scope Note
This does not claim to fix every lower-level macOS/CoreAudio/device-routing trigger such as CoreAudio `-10868`. It fixes MacParakeet's product-level failure mode by detecting, retrying where appropriate, classifying, and reporting unusable capture instead of presenting it as STT/no-speech failure.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
