### PR TITLE
Add opt-in feedback diagnostic log attachment

### DIFF
--- a/Sources/MacParakeet/Views/Feedback/FeedbackView.swift
+++ b/Sources/MacParakeet/Views/Feedback/FeedbackView.swift
@@ -25,6 +25,7 @@ struct FeedbackView: View {
         .background(DesignSystem.Colors.background)
         .onAppear {
             viewModel.configure(feedbackService: FeedbackService())
+            viewModel.refreshDiagnosticLogStatus()
         }
     }
 
@@ -272,6 +273,8 @@ struct FeedbackView: View {
                 }
             }
 
+            diagnosticLogOption
+
             // System info disclosure
             DisclosureGroup("System Info", isExpanded: $viewModel.showSystemInfo) {
                 Text(viewModel.systemInfo.displaySummary)
@@ -310,6 +313,92 @@ struct FeedbackView: View {
             }
             .padding(.top, DesignSystem.Spacing.xs)
         }
+    }
+
+    private var diagnosticLogOption: some View {
+        let isAvailable = viewModel.diagnosticLogIsAvailable
+
+        return VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            HStack(alignment: .top, spacing: DesignSystem.Spacing.sm) {
+                Image(systemName: "doc.text")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(viewModel.includeDiagnosticLog ? DesignSystem.Colors.accent : .secondary)
+                    .frame(width: 28, height: 28)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(
+                                viewModel.includeDiagnosticLog
+                                    ? DesignSystem.Colors.accent.opacity(0.12)
+                                    : DesignSystem.Colors.surfaceElevated
+                            )
+                    )
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Attach capture diagnostics")
+                        .font(DesignSystem.Typography.body.weight(.semibold))
+
+                    Text(viewModel.diagnosticLogFilename)
+                        .font(DesignSystem.Typography.micro.monospaced())
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(
+                            Capsule()
+                                .fill(DesignSystem.Colors.surfaceElevated)
+                        )
+
+                    Text("Use this for dictation or meeting recording issues. It attaches the log to the public report so we can inspect capture timing, buffers, silence, and device errors.")
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    Text("No audio or transcript text. You can also give this log to Claude Code, Codex, or another coding agent for debugging.")
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(.tertiary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    HStack(spacing: DesignSystem.Spacing.xs) {
+                        Image(systemName: isAvailable ? "checkmark.circle.fill" : "exclamationmark.circle")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(isAvailable ? DesignSystem.Colors.successGreen : DesignSystem.Colors.warningAmber)
+                        Text(viewModel.diagnosticLogAvailabilityDescription)
+                            .font(DesignSystem.Typography.micro)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                    .padding(.top, 2)
+                }
+
+                Spacer(minLength: DesignSystem.Spacing.sm)
+
+                Toggle("", isOn: $viewModel.includeDiagnosticLog)
+                    .labelsHidden()
+                    .toggleStyle(.switch)
+                    .tint(DesignSystem.Colors.accent)
+                    .disabled(!isAvailable)
+                    .accessibilityLabel("Attach capture diagnostics")
+                    .accessibilityHint("Includes the dictation audio diagnostics log with this feedback report")
+            }
+        }
+        .padding(DesignSystem.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
+                .fill(DesignSystem.Colors.surfaceElevated.opacity(viewModel.includeDiagnosticLog ? 0.95 : 0.65))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
+                .strokeBorder(
+                    viewModel.includeDiagnosticLog
+                        ? DesignSystem.Colors.accent.opacity(0.45)
+                        : DesignSystem.Colors.border.opacity(0.7),
+                    lineWidth: viewModel.includeDiagnosticLog ? 1 : 0.5
+                )
+        )
     }
 
     private func errorBanner(_ error: String) -> some View {

--- a/Sources/MacParakeetCore/Audio/AudioCaptureDiagnostics.swift
+++ b/Sources/MacParakeetCore/Audio/AudioCaptureDiagnostics.swift
@@ -13,6 +13,14 @@ public enum AudioCaptureDiagnostics {
     /// the 5 s heartbeat, which roughly doubles per-recording log volume.
     private static let maxLogBytes: UInt64 = 5_000_000
 
+    public static var diagnosticLogFileURL: URL {
+        diagnosticLogURL()
+    }
+
+    public static var diagnosticLogMaxBytes: UInt64 {
+        maxLogBytes
+    }
+
     /// Device identity is private: diagnostics are designed to be shared, so
     /// labels intentionally omit CoreAudio IDs, UIDs, and microphone names.
     static func deviceLabel(_ deviceID: AudioDeviceID?) -> String {

--- a/Sources/MacParakeetCore/Services/FeedbackService.swift
+++ b/Sources/MacParakeetCore/Services/FeedbackService.swift
@@ -23,6 +23,7 @@ public struct FeedbackPayload: Sendable, Encodable {
     public let screenshotBase64: String?
     public let screenshotFilename: String?
     public let screenshots: [FeedbackScreenshot]
+    public let diagnosticLog: FeedbackDiagnosticLog?
     public let systemInfo: SystemInfo
 
     public init(
@@ -32,6 +33,7 @@ public struct FeedbackPayload: Sendable, Encodable {
         screenshotBase64: String?,
         screenshotFilename: String?,
         screenshots: [FeedbackScreenshot] = [],
+        diagnosticLog: FeedbackDiagnosticLog? = nil,
         systemInfo: SystemInfo
     ) {
         let normalizedScreenshots: [FeedbackScreenshot]
@@ -51,11 +53,22 @@ public struct FeedbackPayload: Sendable, Encodable {
         self.screenshotBase64 = normalizedScreenshots.first?.base64 ?? screenshotBase64
         self.screenshotFilename = normalizedScreenshots.first?.filename ?? screenshotFilename
         self.screenshots = normalizedScreenshots
+        self.diagnosticLog = diagnosticLog
         self.systemInfo = systemInfo
     }
 }
 
 public struct FeedbackScreenshot: Sendable, Encodable, Equatable {
+    public let filename: String
+    public let base64: String
+
+    public init(filename: String, base64: String) {
+        self.filename = filename
+        self.base64 = base64
+    }
+}
+
+public struct FeedbackDiagnosticLog: Sendable, Encodable, Equatable {
     public let filename: String
     public let base64: String
 
@@ -127,6 +140,7 @@ public final class FeedbackService: FeedbackServiceProtocol {
             screenshotBase64: feedback.screenshotBase64,
             screenshotFilename: feedback.screenshotFilename,
             screenshots: feedback.screenshots,
+            diagnosticLog: feedback.diagnosticLog,
             systemInfo: feedback.systemInfo
         )
 

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -684,6 +684,7 @@ public enum TelemetryEventSpec: Sendable {
         outcome: ObservabilityOutcome,
         durationSeconds: Double,
         screenshotAttached: Bool,
+        diagnosticLogAttached: Bool,
         systemInfoIncluded: Bool,
         errorType: String?
     )
@@ -1352,6 +1353,7 @@ extension TelemetryEventSpec {
             let outcome,
             let durationSeconds,
             let screenshotAttached,
+            let diagnosticLogAttached,
             let systemInfoIncluded,
             let errorType
         ):
@@ -1363,6 +1365,7 @@ extension TelemetryEventSpec {
                 ("outcome", outcome.rawValue),
                 ("duration_seconds", Self.format(durationSeconds)),
                 ("screenshot_attached", Self.boolString(screenshotAttached)),
+                ("diagnostic_log_attached", Self.boolString(diagnosticLogAttached)),
                 ("system_info_included", Self.boolString(systemInfoIncluded)),
                 ("error_type", errorType)
             )
@@ -1657,7 +1660,7 @@ public enum TelemetryImplementedContract {
         .modelOperation: ["operation_id", "action", "outcome", "duration_seconds"],
         .speechEngineSwitchOperation: ["operation_id", "from_engine", "to_engine", "outcome", "duration_seconds", "was_cold"],
         .feedbackSubmitted: ["category"],
-        .feedbackOperation: ["operation_id", "category", "outcome", "duration_seconds", "screenshot_attached", "system_info_included"],
+        .feedbackOperation: ["operation_id", "category", "outcome", "duration_seconds", "screenshot_attached", "diagnostic_log_attached", "system_info_included"],
         .transcriptionDeleted: [],
         .dictationDeleted: [],
         .transcriptionFavorited: ["is_favorite"],

--- a/Sources/MacParakeetViewModels/FeedbackViewModel.swift
+++ b/Sources/MacParakeetViewModels/FeedbackViewModel.swift
@@ -22,13 +22,17 @@ public struct FeedbackScreenshotAttachment: Identifiable, Equatable, Sendable {
 public final class FeedbackViewModel {
     private static let maxScreenshotSizeBytes = 5 * 1024 * 1024
     private static let maxScreenshotCount = 5
+    private nonisolated static let diagnosticLogFilename = "dictation-audio.log"
 
     // Form fields
     public var category: FeedbackCategory = .bug
     public var message: String = ""
     public var email: String = ""
     public var screenshotAttachments: [FeedbackScreenshotAttachment] = []
+    public var includeDiagnosticLog: Bool = false
     public var showSystemInfo: Bool = false
+    public private(set) var diagnosticLogIsAvailable: Bool = false
+    public private(set) var diagnosticLogAvailabilityDescription: String = "Run dictation or meeting recording once to create this log."
     private var pendingScreenshotFilename: String?
 
     public var screenshotData: Data? {
@@ -92,10 +96,22 @@ public final class FeedbackViewModel {
         SystemInfo.current
     }
 
+    public var diagnosticLogURL: URL {
+        diagnosticLogURLOverride ?? AudioCaptureDiagnostics.diagnosticLogFileURL
+    }
+
+    public var diagnosticLogFilename: String {
+        Self.diagnosticLogFilename
+    }
+
+    private let diagnosticLogURLOverride: URL?
     private var feedbackService: (any FeedbackServiceProtocol)?
     private var submitTask: Task<Void, Never>?
+    private var diagnosticLogStatusTask: Task<Void, Never>?
 
-    public init() {}
+    public init(diagnosticLogURL: URL? = nil) {
+        self.diagnosticLogURLOverride = diagnosticLogURL
+    }
 
     public func configure(feedbackService: any FeedbackServiceProtocol) {
         self.feedbackService = feedbackService
@@ -182,6 +198,116 @@ public final class FeedbackViewModel {
         }
     }
 
+    // MARK: - Diagnostic Log
+
+    public func refreshDiagnosticLogStatus() {
+        diagnosticLogStatusTask?.cancel()
+
+        let diagnosticLogURL = diagnosticLogURL
+        diagnosticLogStatusTask = Task { [weak self] in
+            let status = await Self.loadDiagnosticLogStatus(diagnosticLogURL: diagnosticLogURL)
+            guard let self, !Task.isCancelled else { return }
+
+            diagnosticLogIsAvailable = status.isAvailable
+            diagnosticLogAvailabilityDescription = status.description
+            if !status.isAvailable {
+                includeDiagnosticLog = false
+            }
+            diagnosticLogStatusTask = nil
+        }
+    }
+
+    private nonisolated static func loadDiagnosticLogStatus(diagnosticLogURL: URL) async -> DiagnosticLogStatus {
+        await Task.detached(priority: .utility) {
+            guard FileManager.default.fileExists(atPath: diagnosticLogURL.path) else {
+                return DiagnosticLogStatus(
+                    isAvailable: false,
+                    description: "Run dictation or meeting recording once to create this log."
+                )
+            }
+
+            let fileSize = try? diagnosticLogURL
+                .resourceValues(forKeys: [.fileSizeKey])
+                .fileSize
+            if let fileSize, fileSize >= 0 {
+                let sizeDescription = ByteCountFormatter.string(
+                    fromByteCount: Int64(fileSize),
+                    countStyle: .file
+                )
+                return DiagnosticLogStatus(
+                    isAvailable: true,
+                    description: "\(Self.diagnosticLogFilename) · \(sizeDescription)"
+                )
+            }
+
+            return DiagnosticLogStatus(
+                isAvailable: true,
+                description: Self.diagnosticLogFilename
+            )
+        }.value
+    }
+
+    private struct DiagnosticLogStatus: Sendable {
+        let isAvailable: Bool
+        let description: String
+    }
+
+    private nonisolated static func readDiagnosticLogAttachmentIfNeeded(
+        includeDiagnosticLog: Bool,
+        diagnosticLogURL: URL
+    ) async throws -> FeedbackDiagnosticLog? {
+        guard includeDiagnosticLog else { return nil }
+
+        return try await Task.detached(priority: .userInitiated) {
+            do {
+                guard FileManager.default.fileExists(atPath: diagnosticLogURL.path) else {
+                    throw DiagnosticLogAttachmentError.missing
+                }
+
+                if let fileSize = try diagnosticLogURL.resourceValues(forKeys: [.fileSizeKey]).fileSize {
+                    guard fileSize >= 0 else {
+                        throw DiagnosticLogAttachmentError.tooLarge
+                    }
+                    if UInt64(fileSize) > AudioCaptureDiagnostics.diagnosticLogMaxBytes {
+                        throw DiagnosticLogAttachmentError.tooLarge
+                    }
+                }
+
+                let data = try Data(contentsOf: diagnosticLogURL)
+                guard UInt64(data.count) <= AudioCaptureDiagnostics.diagnosticLogMaxBytes else {
+                    throw DiagnosticLogAttachmentError.tooLarge
+                }
+
+                return FeedbackDiagnosticLog(
+                    filename: Self.diagnosticLogFilename,
+                    base64: data.base64EncodedString()
+                )
+            } catch {
+                if error is DiagnosticLogAttachmentError {
+                    throw error
+                }
+                throw DiagnosticLogAttachmentError.readFailed(error.localizedDescription)
+            }
+        }.value
+    }
+
+    private enum DiagnosticLogAttachmentError: LocalizedError {
+        case missing
+        case tooLarge
+        case readFailed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .missing:
+                return "No diagnostic log found yet."
+            case .tooLarge:
+                return "The diagnostic log is too large to attach."
+            case .readFailed(let detail):
+                return "Failed to read diagnostic log: \(detail)"
+            }
+        }
+    }
+
     // MARK: - Submit
 
     public func submit() {
@@ -190,50 +316,82 @@ public final class FeedbackViewModel {
 
         submitTask?.cancel()
         submissionState = .submitting
+
+        let shouldIncludeDiagnosticLog = includeDiagnosticLog
+        let diagnosticLogURL = diagnosticLogURL
+        let category = category
         let trimmedMessage = message.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
-        let operationContext = Observability.childOperationContext()
         let screenshots = screenshotAttachments.map {
             FeedbackScreenshot(filename: $0.filename, base64: $0.data.base64EncodedString())
         }
-
-        let payload = FeedbackPayload(
-            category: category,
-            message: trimmedMessage,
-            email: trimmedEmail.isEmpty ? nil : trimmedEmail,
-            screenshotBase64: screenshots.first?.base64,
-            screenshotFilename: screenshots.first?.filename,
-            screenshots: screenshots,
-            systemInfo: systemInfo
-        )
-        let hasScreenshots = !payload.screenshots.isEmpty
+        let systemInfo = systemInfo
 
         submitTask = Task { [weak self] in
             guard let self else { return }
             defer { submitTask = nil }
 
+            let operationContext = Observability.childOperationContext()
             do {
-                try await service.submitFeedback(payload)
+                let diagnosticLog = try await Self.readDiagnosticLogAttachmentIfNeeded(
+                    includeDiagnosticLog: shouldIncludeDiagnosticLog,
+                    diagnosticLogURL: diagnosticLogURL
+                )
                 guard !Task.isCancelled else { return }
 
-                Telemetry.send(.feedbackSubmitted(category: payload.category.rawValue))
-                Telemetry.send(.feedbackOperation(
-                    operationID: operationContext.operationID,
-                    operationContext: operationContext,
-                    category: payload.category.rawValue,
-                    outcome: .success,
-                    durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
-                    screenshotAttached: hasScreenshots,
-                    systemInfoIncluded: true,
-                    errorType: nil
-                ))
-                submissionState = .success
-                // Auto-reset after 3 seconds
-                try await Task.sleep(for: .seconds(3))
-                guard !Task.isCancelled else { return }
+                let payload = FeedbackPayload(
+                    category: category,
+                    message: trimmedMessage,
+                    email: trimmedEmail.isEmpty ? nil : trimmedEmail,
+                    screenshotBase64: screenshots.first?.base64,
+                    screenshotFilename: screenshots.first?.filename,
+                    screenshots: screenshots,
+                    diagnosticLog: diagnosticLog,
+                    systemInfo: systemInfo
+                )
+                let hasScreenshots = !payload.screenshots.isEmpty
+                let hasDiagnosticLog = payload.diagnosticLog != nil
 
-                if submissionState == .success {
-                    resetForm()
+                do {
+                    try await service.submitFeedback(payload)
+                    guard !Task.isCancelled else { return }
+
+                    Telemetry.send(.feedbackSubmitted(category: payload.category.rawValue))
+                    Telemetry.send(.feedbackOperation(
+                        operationID: operationContext.operationID,
+                        operationContext: operationContext,
+                        category: payload.category.rawValue,
+                        outcome: .success,
+                        durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
+                        screenshotAttached: hasScreenshots,
+                        diagnosticLogAttached: hasDiagnosticLog,
+                        systemInfoIncluded: true,
+                        errorType: nil
+                    ))
+                    submissionState = .success
+                    // Auto-reset after 3 seconds
+                    try await Task.sleep(for: .seconds(3))
+                    guard !Task.isCancelled else { return }
+
+                    if submissionState == .success {
+                        resetForm()
+                    }
+                } catch is CancellationError {
+                    return
+                } catch {
+                    guard !Task.isCancelled else { return }
+                    Telemetry.send(.feedbackOperation(
+                        operationID: operationContext.operationID,
+                        operationContext: operationContext,
+                        category: payload.category.rawValue,
+                        outcome: .failure,
+                        durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
+                        screenshotAttached: hasScreenshots,
+                        diagnosticLogAttached: hasDiagnosticLog,
+                        systemInfoIncluded: true,
+                        errorType: Observability.errorType(for: error)
+                    ))
+                    submissionState = .error(error.localizedDescription)
                 }
             } catch is CancellationError {
                 return
@@ -242,10 +400,11 @@ public final class FeedbackViewModel {
                 Telemetry.send(.feedbackOperation(
                     operationID: operationContext.operationID,
                     operationContext: operationContext,
-                    category: payload.category.rawValue,
+                    category: category.rawValue,
                     outcome: .failure,
                     durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
-                    screenshotAttached: hasScreenshots,
+                    screenshotAttached: !screenshots.isEmpty,
+                    diagnosticLogAttached: shouldIncludeDiagnosticLog,
                     systemInfoIncluded: true,
                     errorType: Observability.errorType(for: error)
                 ))
@@ -263,9 +422,11 @@ public final class FeedbackViewModel {
         message = ""
         email = ""
         screenshotAttachments = []
+        includeDiagnosticLog = false
         pendingScreenshotFilename = nil
         showSystemInfo = false
         submissionState = .idle
+        refreshDiagnosticLogStatus()
     }
 
     public func dismissError() {

--- a/Tests/MacParakeetTests/Services/FeedbackServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/FeedbackServiceTests.swift
@@ -210,6 +210,61 @@ final class FeedbackServiceTests: XCTestCase {
         XCTAssertEqual(screenshots?[1]["base64"] as? String, "AwQ=")
     }
 
+    func testSubmitFeedbackEncodesDiagnosticLog() async throws {
+        var capturedBody: [String: Any]?
+
+        MockURLProtocol.handler = { request in
+            var bodyData: Data?
+            if let body = request.httpBody {
+                bodyData = body
+            } else if let stream = request.httpBodyStream {
+                stream.open()
+                var buffer = [UInt8](repeating: 0, count: 65536)
+                var collected = Data()
+                while stream.hasBytesAvailable {
+                    let count = stream.read(&buffer, maxLength: buffer.count)
+                    if count > 0 { collected.append(buffer, count: count) }
+                    else { break }
+                }
+                stream.close()
+                bodyData = collected
+            }
+            if let data = bodyData {
+                capturedBody = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            }
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data("{\"success\":true}".utf8))
+        }
+
+        let payload = FeedbackPayload(
+            category: .bug,
+            message: "Diagnostics attached",
+            email: nil,
+            screenshotBase64: nil,
+            screenshotFilename: nil,
+            diagnosticLog: FeedbackDiagnosticLog(filename: "dictation-audio.log", base64: "ZGlhZw=="),
+            systemInfo: SystemInfo(
+                appVersion: "1.0",
+                buildNumber: "1",
+                gitCommit: "abc123",
+                buildSource: "test",
+                macOSVersion: "15.0.0",
+                chipType: "Apple M1"
+            )
+        )
+
+        try await service.submitFeedback(payload)
+
+        let diagnosticLog = capturedBody?["diagnostic_log"] as? [String: Any]
+        XCTAssertEqual(diagnosticLog?["filename"] as? String, "dictation-audio.log")
+        XCTAssertEqual(diagnosticLog?["base64"] as? String, "ZGlhZw==")
+    }
+
     func testEmptyMessageThrowsError() async {
         let payload = FeedbackPayload(
             category: .bug,

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -1054,6 +1054,31 @@ final class TelemetryServiceTests: XCTestCase {
         }
     }
 
+    func testFeedbackOperationSerializesAttachmentFlags() {
+        let event = TelemetryEvent(
+            spec: .feedbackOperation(
+                operationID: "op-feedback",
+                category: "bug",
+                outcome: .success,
+                durationSeconds: 0.6,
+                screenshotAttached: true,
+                diagnosticLogAttached: true,
+                systemInfoIncluded: true,
+                errorType: nil
+            ),
+            appVer: "0.6.18",
+            osVer: "26.5",
+            locale: "en-US",
+            chip: "Apple M1 Max",
+            session: "session"
+        )
+
+        XCTAssertEqual(event.event, "feedback_operation")
+        XCTAssertEqual(event.props?["screenshot_attached"], "true")
+        XCTAssertEqual(event.props?["diagnostic_log_attached"], "true")
+        XCTAssertEqual(event.props?["system_info_included"], "true")
+    }
+
     func testImplementedContractCoversEveryTypedEventName() {
         XCTAssertEqual(
             Set(TelemetryEventName.allCases),
@@ -1384,6 +1409,7 @@ final class TelemetryServiceTests: XCTestCase {
                 outcome: .success,
                 durationSeconds: 0.6,
                 screenshotAttached: false,
+                diagnosticLogAttached: false,
                 systemInfoIncluded: true,
                 errorType: nil
             ),

--- a/Tests/MacParakeetTests/ViewModels/FeedbackViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/FeedbackViewModelTests.swift
@@ -22,6 +22,37 @@ final class MockFeedbackService: FeedbackServiceProtocol, @unchecked Sendable {
     }
 }
 
+private final class FeedbackTelemetrySpy: TelemetryServiceProtocol, @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [TelemetryEventSpec] = []
+
+    func send(_ event: TelemetryEventSpec) {
+        lock.lock()
+        events.append(event)
+        lock.unlock()
+    }
+
+    func sendAndFlush(_ event: TelemetryEventSpec) async -> Bool {
+        send(event)
+        return true
+    }
+
+    func clearQueue() {
+        lock.lock()
+        events.removeAll()
+        lock.unlock()
+    }
+
+    func flush() async {}
+    func flushForTermination() {}
+
+    func snapshot() -> [TelemetryEventSpec] {
+        lock.lock()
+        defer { lock.unlock() }
+        return events
+    }
+}
+
 @MainActor
 final class FeedbackViewModelTests: XCTestCase {
     var viewModel: FeedbackViewModel!
@@ -31,6 +62,7 @@ final class FeedbackViewModelTests: XCTestCase {
         mockService = MockFeedbackService()
         viewModel = FeedbackViewModel()
         viewModel.configure(feedbackService: mockService)
+        Telemetry.configure(NoOpTelemetryService())
     }
 
     // MARK: - Initial State
@@ -42,6 +74,7 @@ final class FeedbackViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.screenshotData)
         XCTAssertNil(viewModel.screenshotFilename)
         XCTAssertTrue(viewModel.screenshotAttachments.isEmpty)
+        XCTAssertFalse(viewModel.includeDiagnosticLog)
         XCTAssertFalse(viewModel.showSystemInfo)
         XCTAssertEqual(viewModel.submissionState, .idle)
     }
@@ -141,6 +174,7 @@ final class FeedbackViewModelTests: XCTestCase {
         viewModel.email = "a@b.com"
         viewModel.screenshotData = Data([0x00])
         viewModel.screenshotFilename = "test.png"
+        viewModel.includeDiagnosticLog = true
         viewModel.showSystemInfo = true
         viewModel.submissionState = .error("something")
 
@@ -152,6 +186,7 @@ final class FeedbackViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.screenshotData)
         XCTAssertNil(viewModel.screenshotFilename)
         XCTAssertTrue(viewModel.screenshotAttachments.isEmpty)
+        XCTAssertFalse(viewModel.includeDiagnosticLog)
         XCTAssertFalse(viewModel.showSystemInfo)
         XCTAssertEqual(viewModel.submissionState, .idle)
     }
@@ -226,6 +261,159 @@ final class FeedbackViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.screenshotAttachments[0].filename, "first.png")
         XCTAssertEqual(viewModel.screenshotAttachments[0].data, Data([0x09]))
         XCTAssertEqual(viewModel.screenshotAttachments[1], second)
+    }
+
+    // MARK: - Diagnostic Log
+
+    func testRefreshDiagnosticLogStatusCachesAvailableLogDescription() async throws {
+        let logURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("available-dictation-audio-\(UUID().uuidString).log")
+        try Data("dictation_capture_stop duration_s=1.400\n".utf8).write(to: logURL)
+        defer { try? FileManager.default.removeItem(at: logURL) }
+
+        viewModel = FeedbackViewModel(diagnosticLogURL: logURL)
+
+        viewModel.refreshDiagnosticLogStatus()
+        try await Task.sleep(for: .milliseconds(100))
+
+        XCTAssertTrue(viewModel.diagnosticLogIsAvailable)
+        XCTAssertTrue(viewModel.diagnosticLogAvailabilityDescription.contains("dictation-audio.log"))
+    }
+
+    func testRefreshDiagnosticLogStatusClearsOptInWhenLogIsMissing() async throws {
+        let missingURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("missing-status-dictation-audio-\(UUID().uuidString).log")
+        viewModel = FeedbackViewModel(diagnosticLogURL: missingURL)
+        viewModel.includeDiagnosticLog = true
+
+        viewModel.refreshDiagnosticLogStatus()
+        try await Task.sleep(for: .milliseconds(100))
+
+        XCTAssertFalse(viewModel.diagnosticLogIsAvailable)
+        XCTAssertFalse(viewModel.includeDiagnosticLog)
+        XCTAssertEqual(
+            viewModel.diagnosticLogAvailabilityDescription,
+            "Run dictation or meeting recording once to create this log."
+        )
+    }
+
+    func testSubmissionIncludesDiagnosticLogWhenOptedIn() async throws {
+        let logURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dictation-audio-\(UUID().uuidString).log")
+        let logData = Data("dictation_capture_stop duration_s=1.400\n".utf8)
+        try logData.write(to: logURL)
+        defer { try? FileManager.default.removeItem(at: logURL) }
+
+        viewModel = FeedbackViewModel(diagnosticLogURL: logURL)
+        viewModel.configure(feedbackService: mockService)
+        viewModel.message = "Dictation acted weird"
+        viewModel.includeDiagnosticLog = true
+
+        viewModel.submit()
+        try await Task.sleep(for: .milliseconds(100))
+
+        XCTAssertEqual(mockService.submitCallCount, 1)
+        XCTAssertEqual(mockService.lastPayload?.diagnosticLog?.filename, "dictation-audio.log")
+        XCTAssertEqual(
+            mockService.lastPayload?.diagnosticLog?.base64,
+            logData.base64EncodedString()
+        )
+    }
+
+    func testSubmissionFailsWhenDiagnosticLogIsSelectedButMissing() async throws {
+        let missingURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("missing-dictation-audio-\(UUID().uuidString).log")
+        viewModel = FeedbackViewModel(diagnosticLogURL: missingURL)
+        viewModel.configure(feedbackService: mockService)
+        viewModel.message = "Dictation acted weird"
+        viewModel.includeDiagnosticLog = true
+
+        viewModel.submit()
+        try await Task.sleep(for: .milliseconds(100))
+
+        XCTAssertEqual(mockService.submitCallCount, 0)
+        if case .error(let message) = viewModel.submissionState {
+            XCTAssertEqual(message, "No diagnostic log found yet.")
+        } else {
+            XCTFail("Expected missing diagnostic log error, got \(viewModel.submissionState)")
+        }
+    }
+
+    func testDiagnosticLogReadFailureEmitsFeedbackOperationTelemetry() async throws {
+        let telemetry = FeedbackTelemetrySpy()
+        Telemetry.configure(telemetry)
+        defer { Telemetry.configure(NoOpTelemetryService()) }
+
+        let missingURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("missing-telemetry-dictation-audio-\(UUID().uuidString).log")
+        viewModel = FeedbackViewModel(diagnosticLogURL: missingURL)
+        viewModel.configure(feedbackService: mockService)
+        viewModel.message = "Dictation acted weird"
+        viewModel.includeDiagnosticLog = true
+
+        viewModel.submit()
+        try await Task.sleep(for: .milliseconds(100))
+
+        let operation = telemetry.snapshot().compactMap { event -> (
+            category: String,
+            outcome: ObservabilityOutcome,
+            screenshotAttached: Bool,
+            diagnosticLogAttached: Bool,
+            systemInfoIncluded: Bool,
+            errorType: String?
+        )? in
+            guard case .feedbackOperation(
+                _,
+                _,
+                let category,
+                let outcome,
+                _,
+                let screenshotAttached,
+                let diagnosticLogAttached,
+                let systemInfoIncluded,
+                let errorType
+            ) = event else {
+                return nil
+            }
+            return (
+                category,
+                outcome,
+                screenshotAttached,
+                diagnosticLogAttached,
+                systemInfoIncluded,
+                errorType
+            )
+        }.first
+
+        XCTAssertEqual(operation?.category, FeedbackCategory.bug.rawValue)
+        XCTAssertEqual(operation?.outcome, .failure)
+        XCTAssertEqual(operation?.screenshotAttached, false)
+        XCTAssertEqual(operation?.diagnosticLogAttached, true)
+        XCTAssertEqual(operation?.systemInfoIncluded, true)
+        XCTAssertNotNil(operation?.errorType)
+    }
+
+    func testSubmissionFailsWhenDiagnosticLogIsTooLarge() async throws {
+        let logURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("oversized-dictation-audio-\(UUID().uuidString).log")
+        let oversizedData = Data(count: Int(AudioCaptureDiagnostics.diagnosticLogMaxBytes) + 1)
+        try oversizedData.write(to: logURL)
+        defer { try? FileManager.default.removeItem(at: logURL) }
+
+        viewModel = FeedbackViewModel(diagnosticLogURL: logURL)
+        viewModel.configure(feedbackService: mockService)
+        viewModel.message = "Dictation acted weird"
+        viewModel.includeDiagnosticLog = true
+
+        viewModel.submit()
+        try await Task.sleep(for: .milliseconds(100))
+
+        XCTAssertEqual(mockService.submitCallCount, 0)
+        if case .error(let message) = viewModel.submissionState {
+            XCTAssertEqual(message, "The diagnostic log is too large to attach.")
+        } else {
+            XCTFail("Expected oversized diagnostic log error, got \(viewModel.submissionState)")
+        }
     }
 
     // MARK: - System Info

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -303,7 +303,7 @@ events remain useful for diarization-specific timing and failure analysis.
 | `copy_to_clipboard` | `source` (dictation, transcription, history, meeting, discover) | How do people get text out? |
 | `keystroke_snippet_fired` | — | Are keystroke action snippets being used? |
 | `feedback_submitted` | `category` (bug, featureRequest, other) | Feedback volume and sentiment split |
-| `feedback_operation` | `operation_id`, `workflow_id`, `parent_operation_id`, `category`, `outcome`, `duration_seconds`, `screenshot_attached`, `system_info_included`, `error_type` | Feedback delivery health without storing message text or email |
+| `feedback_operation` | `operation_id`, `workflow_id`, `parent_operation_id`, `category`, `outcome`, `duration_seconds`, `screenshot_attached`, `diagnostic_log_attached`, `system_info_included`, `error_type` | Feedback delivery health without storing message text, email, or diagnostic log contents |
 | `auto_save_operation` | `operation_id`, `workflow_id`, `parent_operation_id`, `scope`, `format`, `outcome`, `duration_seconds`, `error_type` | Whether transcript/meeting auto-save succeeds for configured users |
 | `transcription_deleted` | — | Are users cleaning up transcriptions? |
 | `dictation_deleted` | — | History hygiene patterns |
@@ -776,13 +776,13 @@ External AI review of the telemetry design. Each point was evaluated and accepte
   paths, URLs, API-key-looking strings, and emails before D1 insert. The app
   already sanitizes current emitted details, but the Worker should not rely on
   every future client doing the right thing.
-- **Local diagnostic export** — Build an explicit user-triggered diagnostic
-  bundle that includes recent `os.Logger` entries for MacParakeet subsystems,
-  `~/Library/Logs/MacParakeet/dictation-audio.log` status/metric lines,
-  app version/build info, and redacted runtime metadata. Do not upload
-  automatically. Do not include audio bytes, transcripts, notes, prompts, file
-  names, paths, URLs, API keys, microphone names, CoreAudio device IDs, or
-  device UIDs.
+- **Expanded local diagnostic export** — The in-app feedback form can now
+  attach `~/Library/Logs/MacParakeet/dictation-audio.log` by explicit opt-in.
+  A fuller user-triggered bundle should add recent `os.Logger` entries for
+  MacParakeet subsystems, app version/build info, and redacted runtime metadata.
+  Do not upload automatically. Do not include audio bytes, transcripts, notes,
+  prompts, file names, paths, URLs, API keys, microphone names, CoreAudio
+  device IDs, or device UIDs.
 - **Operation-event coverage gate** — For any new workflow that can succeed,
   fail, cancel, or become unavailable, require a matching wide `*_operation`
   event or a documented reason it is intentionally breadcrumb-only.

--- a/spec/08-error-handling.md
+++ b/spec/08-error-handling.md
@@ -173,10 +173,11 @@ Errors are always logged locally. If telemetry is enabled, non-identifying
 operation failures and crash reports may also be sent to MacParakeet's
 self-hosted telemetry pipeline.
 
-Diagnostic export is a follow-up, not a shipped menu action in the current code.
-The desired support path is an explicit user-triggered bundle containing recent
-MacParakeet `os.Logger` entries, `~/Library/Logs/MacParakeet/dictation-audio.log`,
-app version/build info, and redacted runtime metadata. It must not include
+The in-app feedback flow has an explicit opt-in control for attaching
+`~/Library/Logs/MacParakeet/dictation-audio.log` when users report dictation or
+meeting recording problems. A broader diagnostic bundle is still a follow-up:
+it should contain recent MacParakeet `os.Logger` entries, the audio diagnostics
+log, app version/build info, and redacted runtime metadata. It must not include
 audio, transcripts, notes, prompts, file names, file paths, URLs, API keys, or
 microphone identity (names, CoreAudio device IDs, device UIDs), and it must not
 upload automatically.


### PR DESCRIPTION
## Summary
- Add an opt-in capture diagnostics section to the in-app Feedback form.
- Send `dictation-audio.log` as a dedicated `diagnostic_log` payload only when selected.
- Keep the copy explicit: useful for dictation/meeting recording issues, no audio or transcript text, and shareable with coding agents for debugging.

<img width="1471" height="1057" alt="Screenshot 2026-06-06 at 9 23 31 PM" src="https://github.com/user-attachments/assets/e66d3443-e010-479d-b6cc-d28de9590efc" />

## Context
Reference: https://github.com/moona3k/macparakeet/issues/442#issuecomment-4640158828
Companion endpoint PR: https://github.com/moona3k/macparakeet-website/pull/16

## Verification
- `swift test --filter FeedbackViewModelTests --filter FeedbackServiceTests`
- `swift test`