### PR TITLE
[codex] Add multi-select dictation cleanup

### DIFF
--- a/Sources/MacParakeet/Views/History/DictationHistoryView.swift
+++ b/Sources/MacParakeet/Views/History/DictationHistoryView.swift
@@ -37,20 +37,20 @@ struct DictationHistoryView: View {
         .animation(DesignSystem.Animation.contentSwap, value: viewModel.playbackError != nil)
         .animation(DesignSystem.Animation.contentSwap, value: viewModel.selectedSubTab)
         .alert(
-            "Delete Dictation?",
+            deleteAlertTitle,
             isPresented: Binding(
-                get: { viewModel.pendingDeleteDictation != nil },
-                set: { if !$0 { viewModel.pendingDeleteDictation = nil } }
+                get: { viewModel.pendingDeleteCount > 0 },
+                set: { if !$0 { viewModel.cancelPendingDelete() } }
             )
         ) {
             Button("Cancel", role: .cancel) {
-                viewModel.pendingDeleteDictation = nil
+                viewModel.cancelPendingDelete()
             }
             Button("Delete", role: .destructive) {
-                viewModel.confirmDelete()
+                viewModel.confirmPendingDelete()
             }
         } message: {
-            Text("This dictation and its audio file will be permanently deleted.")
+            Text(deleteAlertMessage)
         }
     }
 
@@ -73,7 +73,13 @@ struct DictationHistoryView: View {
         if viewModel.groupedDictations.isEmpty {
             emptyState
         } else {
-            dictationList
+            VStack(spacing: 0) {
+                if viewModel.hasSelectedDictations {
+                    selectedActionsBar
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                }
+                dictationList
+            }
         }
     }
 
@@ -134,6 +140,8 @@ struct DictationHistoryView: View {
                             searchText: viewModel.searchText,
                             isPlayingThis: viewModel.playingDictationId == dictation.id && viewModel.isPlaying,
                             isCopied: viewModel.copiedDictationId == dictation.id,
+                            isSelected: viewModel.isDictationSelected(dictation),
+                            onToggleSelection: { viewModel.toggleSelection(for: dictation) },
                             onTogglePlayback: { viewModel.togglePlayback(for: dictation) },
                             onCopy: {
                                 viewModel.copyToClipboard(dictation)
@@ -151,6 +159,46 @@ struct DictationHistoryView: View {
             }
             .padding(.bottom, DesignSystem.Spacing.md)
         }
+    }
+
+    private var selectedActionsBar: some View {
+        HStack(spacing: DesignSystem.Spacing.sm) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(DesignSystem.Colors.accent)
+
+            Text("\(viewModel.selectedDictationCount) selected")
+                .font(DesignSystem.Typography.bodySmall.weight(.medium))
+                .foregroundStyle(.primary)
+
+            Spacer(minLength: DesignSystem.Spacing.md)
+
+            Button {
+                viewModel.selectAllVisibleDictations()
+            } label: {
+                Label("Select All", systemImage: "checkmark.circle")
+            }
+            .disabled(viewModel.areAllVisibleDictationsSelected)
+            .parakeetAction(.secondary)
+
+            Button {
+                viewModel.clearSelection()
+            } label: {
+                Label("Clear", systemImage: "xmark.circle")
+            }
+            .parakeetAction(.secondary)
+
+            Button(role: .destructive) {
+                viewModel.requestDeleteSelectedDictations()
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+            .parakeetAction(.destructive)
+        }
+        .padding(.horizontal, DesignSystem.Spacing.lg)
+        .padding(.vertical, DesignSystem.Spacing.sm)
+        .background(DesignSystem.Colors.surfaceElevated)
+        .overlay(alignment: .bottom) { Divider() }
     }
 
     // MARK: - Status Bars
@@ -231,6 +279,19 @@ struct DictationHistoryView: View {
                 }
         )
     }
+
+    private var deleteAlertTitle: String {
+        let count = viewModel.pendingDeleteCount
+        return count > 1 ? "Delete \(count) Dictations?" : "Delete Dictation?"
+    }
+
+    private var deleteAlertMessage: String {
+        let count = viewModel.pendingDeleteCount
+        if count > 1 {
+            return "These dictations and their audio files will be permanently deleted."
+        }
+        return "This dictation and its audio file will be permanently deleted."
+    }
 }
 
 // MARK: - Card Row View
@@ -240,6 +301,8 @@ struct DictationCardRow: View {
     var searchText: String = ""
     var isPlayingThis: Bool = false
     var isCopied: Bool = false
+    var isSelected: Bool = false
+    var onToggleSelection: (() -> Void)?
     var onTogglePlayback: (() -> Void)?
     var onCopy: () -> Void
     var onDelete: () -> Void
@@ -251,6 +314,10 @@ struct DictationCardRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
             HStack(spacing: DesignSystem.Spacing.md) {
+                SelectionToggleButton(isSelected: isSelected) {
+                    onToggleSelection?()
+                }
+
                 SonicMandalaView(
                     data: .from(text: dictation.rawTranscript, durationMs: dictation.durationMs),
                     size: 32,
@@ -350,16 +417,14 @@ struct DictationCardRow: View {
         .scaleEffect(isPlayingThis ? 1.005 : 1.0)
         .background(
             RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
-                .fill(isPlayingThis
-                      ? DesignSystem.Colors.accent.opacity(0.06)
-                      : DesignSystem.Colors.cardBackground)
+                .fill(cardFill)
                 .cardShadow(isHovered ? DesignSystem.Shadows.cardHover : DesignSystem.Shadows.cardRest)
         )
         .overlay(
             RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
                 .strokeBorder(
-                    isPlayingThis ? DesignSystem.Colors.accent.opacity(0.24) : DesignSystem.Colors.border.opacity(0.5),
-                    lineWidth: 0.5
+                    cardStroke,
+                    lineWidth: isSelected ? 1 : 0.5
                 )
                 .allowsHitTesting(false)
         )
@@ -369,6 +434,27 @@ struct DictationCardRow: View {
             }
         }
         .animation(.easeInOut(duration: 0.15), value: isPlayingThis)
+        .animation(DesignSystem.Animation.selectionChange, value: isSelected)
+    }
+
+    private var cardFill: Color {
+        if isSelected {
+            return DesignSystem.Colors.accent.opacity(0.10)
+        }
+        if isPlayingThis {
+            return DesignSystem.Colors.accent.opacity(0.06)
+        }
+        return DesignSystem.Colors.cardBackground
+    }
+
+    private var cardStroke: Color {
+        if isSelected {
+            return DesignSystem.Colors.accent.opacity(0.45)
+        }
+        if isPlayingThis {
+            return DesignSystem.Colors.accent.opacity(0.24)
+        }
+        return DesignSystem.Colors.border.opacity(0.5)
     }
 
     // MARK: - Highlighted Transcript
@@ -413,6 +499,36 @@ struct DictationCardRow: View {
         let formatter = DateFormatter()
         formatter.timeStyle = .short
         return formatter.string(from: date)
+    }
+}
+
+// MARK: - Selection Toggle
+
+private struct SelectionToggleButton: View {
+    let isSelected: Bool
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                .font(.system(size: 16, weight: .semibold))
+                .frame(width: 28, height: 28)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(iconColor)
+        .help(isSelected ? "Deselect" : "Select")
+        .accessibilityLabel(isSelected ? "Deselect dictation" : "Select dictation")
+        .onHover { isHovered = $0 }
+    }
+
+    private var iconColor: Color {
+        if isSelected {
+            return DesignSystem.Colors.accent
+        }
+        return isHovered ? Color.primary : Color.secondary
     }
 }
 

--- a/Sources/MacParakeet/Views/History/DictationHistoryView.swift
+++ b/Sources/MacParakeet/Views/History/DictationHistoryView.swift
@@ -80,6 +80,7 @@ struct DictationHistoryView: View {
                 }
                 dictationList
             }
+            .animation(DesignSystem.Animation.contentSwap, value: viewModel.hasSelectedDictations)
         }
     }
 

--- a/Sources/MacParakeetViewModels/DictationHistoryViewModel.swift
+++ b/Sources/MacParakeetViewModels/DictationHistoryViewModel.swift
@@ -92,9 +92,60 @@ public final class DictationHistoryViewModel {
     public var playbackError: String?
     private var playbackErrorResetTask: Task<Void, Never>?
 
+    // MARK: - Selection
+
+    public var selectedDictationIDs: Set<UUID> = []
+
+    public var selectedDictationCount: Int {
+        selectedDictationIDs.count
+    }
+
+    public var hasSelectedDictations: Bool {
+        !selectedDictationIDs.isEmpty
+    }
+
+    public var areAllVisibleDictationsSelected: Bool {
+        let ids = visibleDictationIDs
+        return !ids.isEmpty && ids.isSubset(of: selectedDictationIDs)
+    }
+
     // MARK: - Delete Confirmation
 
-    public var pendingDeleteDictation: Dictation?
+    public var pendingDeleteDictation: Dictation? {
+        didSet {
+            if pendingDeleteDictation != nil {
+                pendingDeleteSelectedDictationIDs = []
+            }
+        }
+    }
+
+    public var pendingDeleteSelectedDictationIDs: Set<UUID> = [] {
+        didSet {
+            if !pendingDeleteSelectedDictationIDs.isEmpty {
+                pendingDeleteDictation = nil
+            }
+        }
+    }
+
+    public var pendingDeleteCount: Int {
+        if !pendingDeleteSelectedDictationIDs.isEmpty {
+            return pendingDeleteSelectedDictationIDs.count
+        }
+        return pendingDeleteDictation == nil ? 0 : 1
+    }
+
+    public func cancelPendingDelete() {
+        pendingDeleteDictation = nil
+        pendingDeleteSelectedDictationIDs = []
+    }
+
+    public func confirmPendingDelete() {
+        if !pendingDeleteSelectedDictationIDs.isEmpty {
+            confirmDeleteSelectedDictations()
+        } else {
+            confirmDelete()
+        }
+    }
 
     public func confirmDelete() {
         guard let dictation = pendingDeleteDictation else { return }
@@ -138,25 +189,85 @@ public final class DictationHistoryViewModel {
         groupedDictations = grouped.sorted { $0.key > $1.key }.map { (key, value) in
             (formatDateHeader(key), value.sorted { $0.createdAt > $1.createdAt })
         }
+        pruneSelectionToVisibleDictations()
 
         if shouldRefreshStats {
             refreshStats()
         }
     }
 
+    public func isDictationSelected(_ dictation: Dictation) -> Bool {
+        selectedDictationIDs.contains(dictation.id)
+    }
+
+    public func toggleSelection(for dictation: Dictation) {
+        if selectedDictationIDs.contains(dictation.id) {
+            selectedDictationIDs.remove(dictation.id)
+        } else {
+            selectedDictationIDs.insert(dictation.id)
+        }
+    }
+
+    public func selectAllVisibleDictations() {
+        selectedDictationIDs = visibleDictationIDs
+    }
+
+    public func clearSelection() {
+        selectedDictationIDs = []
+    }
+
+    public func requestDeleteSelectedDictations() {
+        let selectedVisibleIDs = selectedDictationIDs.intersection(visibleDictationIDs)
+        guard !selectedVisibleIDs.isEmpty else {
+            clearSelection()
+            return
+        }
+        pendingDeleteSelectedDictationIDs = selectedVisibleIDs
+    }
+
+    public func confirmDeleteSelectedDictations() {
+        let ids = pendingDeleteSelectedDictationIDs
+        pendingDeleteSelectedDictationIDs = []
+        guard !ids.isEmpty else { return }
+
+        let selectedDictations = groupedDictations
+            .flatMap(\.1)
+            .filter { ids.contains($0.id) }
+        deleteDictations(selectedDictations)
+    }
+
     public func deleteDictation(_ dictation: Dictation) {
         guard let repo = dictationRepo else { return }
-        if playingDictationId == dictation.id {
+        deleteDictations([dictation], using: repo)
+    }
+
+    private func deleteDictations(_ dictations: [Dictation]) {
+        guard let repo = dictationRepo else { return }
+        deleteDictations(dictations, using: repo)
+    }
+
+    private func deleteDictations(
+        _ dictations: [Dictation],
+        using repo: DictationRepositoryProtocol
+    ) {
+        guard !dictations.isEmpty else { return }
+
+        let ids = Set(dictations.map(\.id))
+        if let playingDictationId, ids.contains(playingDictationId) {
             stopPlayback()
         }
-        if let path = dictation.audioPath {
-            try? FileManager.default.removeItem(atPath: path)
-        }
-        do {
-            _ = try repo.delete(id: dictation.id)
-            Telemetry.send(.dictationDeleted)
-        } catch {
-            logger.error("Failed to delete dictation \(dictation.id): \(error.localizedDescription)")
+
+        for dictation in dictations {
+            if let path = dictation.audioPath {
+                try? FileManager.default.removeItem(atPath: path)
+            }
+            do {
+                _ = try repo.delete(id: dictation.id)
+                selectedDictationIDs.remove(dictation.id)
+                Telemetry.send(.dictationDeleted)
+            } catch {
+                logger.error("Failed to delete dictation \(dictation.id): \(error.localizedDescription)")
+            }
         }
         loadDictations()
     }
@@ -376,6 +487,15 @@ public final class DictationHistoryViewModel {
                 self.playbackCurrentTime = player.currentTime
             }
         }
+    }
+
+    private var visibleDictationIDs: Set<UUID> {
+        Set(groupedDictations.flatMap(\.1).map(\.id))
+    }
+
+    private func pruneSelectionToVisibleDictations() {
+        let ids = visibleDictationIDs
+        selectedDictationIDs = selectedDictationIDs.intersection(ids)
     }
 
     private static let dateHeaderFormatter: DateFormatter = {

--- a/Sources/MacParakeetViewModels/DictationHistoryViewModel.swift
+++ b/Sources/MacParakeetViewModels/DictationHistoryViewModel.swift
@@ -114,33 +114,33 @@ public final class DictationHistoryViewModel {
     public var pendingDeleteDictation: Dictation? {
         didSet {
             if pendingDeleteDictation != nil {
-                pendingDeleteSelectedDictationIDs = []
+                pendingDeleteSelectedDictations = []
             }
         }
     }
 
-    public var pendingDeleteSelectedDictationIDs: Set<UUID> = [] {
+    public var pendingDeleteSelectedDictations: [Dictation] = [] {
         didSet {
-            if !pendingDeleteSelectedDictationIDs.isEmpty {
+            if !pendingDeleteSelectedDictations.isEmpty {
                 pendingDeleteDictation = nil
             }
         }
     }
 
     public var pendingDeleteCount: Int {
-        if !pendingDeleteSelectedDictationIDs.isEmpty {
-            return pendingDeleteSelectedDictationIDs.count
+        if !pendingDeleteSelectedDictations.isEmpty {
+            return pendingDeleteSelectedDictations.count
         }
         return pendingDeleteDictation == nil ? 0 : 1
     }
 
     public func cancelPendingDelete() {
         pendingDeleteDictation = nil
-        pendingDeleteSelectedDictationIDs = []
+        pendingDeleteSelectedDictations = []
     }
 
     public func confirmPendingDelete() {
-        if !pendingDeleteSelectedDictationIDs.isEmpty {
+        if !pendingDeleteSelectedDictations.isEmpty {
             confirmDeleteSelectedDictations()
         } else {
             confirmDelete()
@@ -217,22 +217,18 @@ public final class DictationHistoryViewModel {
     }
 
     public func requestDeleteSelectedDictations() {
-        let selectedVisibleIDs = selectedDictationIDs.intersection(visibleDictationIDs)
-        guard !selectedVisibleIDs.isEmpty else {
+        let selectedDictations = visibleDictations.filter { selectedDictationIDs.contains($0.id) }
+        guard !selectedDictations.isEmpty else {
             clearSelection()
             return
         }
-        pendingDeleteSelectedDictationIDs = selectedVisibleIDs
+        pendingDeleteSelectedDictations = selectedDictations
     }
 
     public func confirmDeleteSelectedDictations() {
-        let ids = pendingDeleteSelectedDictationIDs
-        pendingDeleteSelectedDictationIDs = []
-        guard !ids.isEmpty else { return }
-
-        let selectedDictations = groupedDictations
-            .flatMap(\.1)
-            .filter { ids.contains($0.id) }
+        let selectedDictations = pendingDeleteSelectedDictations
+        pendingDeleteSelectedDictations = []
+        guard !selectedDictations.isEmpty else { return }
         deleteDictations(selectedDictations)
     }
 
@@ -257,19 +253,16 @@ public final class DictationHistoryViewModel {
             stopPlayback()
         }
 
-        for dictation in dictations {
-            if let path = dictation.audioPath {
-                try? FileManager.default.removeItem(atPath: path)
-            }
-            do {
-                _ = try repo.delete(id: dictation.id)
-                selectedDictationIDs.remove(dictation.id)
+        selectedDictationIDs.subtract(ids)
+        let targets = dictations.map { DeleteTarget(id: $0.id, audioPath: $0.audioPath) }
+
+        Task { [repo, targets] in
+            let deletedIDs = await Self.deleteTargets(targets, using: repo)
+            for _ in deletedIDs {
                 Telemetry.send(.dictationDeleted)
-            } catch {
-                logger.error("Failed to delete dictation \(dictation.id): \(error.localizedDescription)")
             }
+            loadDictations()
         }
-        loadDictations()
     }
 
     private func refreshStats() {
@@ -490,7 +483,11 @@ public final class DictationHistoryViewModel {
     }
 
     private var visibleDictationIDs: Set<UUID> {
-        Set(groupedDictations.flatMap(\.1).map(\.id))
+        Set(visibleDictations.map(\.id))
+    }
+
+    private var visibleDictations: [Dictation] {
+        groupedDictations.flatMap(\.1)
     }
 
     private func pruneSelectionToVisibleDictations() {
@@ -514,6 +511,35 @@ public final class DictationHistoryViewModel {
         } else {
             return Self.dateHeaderFormatter.string(from: date)
         }
+    }
+
+    private struct DeleteTarget: Sendable {
+        let id: UUID
+        let audioPath: String?
+    }
+
+    private nonisolated static func deleteTargets(
+        _ targets: [DeleteTarget],
+        using repo: DictationRepositoryProtocol
+    ) async -> [UUID] {
+        await Task.detached(priority: .userInitiated) {
+            let logger = Logger(subsystem: "com.macparakeet.viewmodels", category: "DictationHistory")
+            var deletedIDs: [UUID] = []
+
+            for target in targets {
+                if let path = target.audioPath {
+                    try? FileManager.default.removeItem(atPath: path)
+                }
+                do {
+                    _ = try repo.delete(id: target.id)
+                    deletedIDs.append(target.id)
+                } catch {
+                    logger.error("Failed to delete dictation \(target.id): \(error.localizedDescription)")
+                }
+            }
+
+            return deletedIDs
+        }.value
     }
 }
 

--- a/Tests/MacParakeetTests/ViewModels/DictationHistoryViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/DictationHistoryViewModelTests.swift
@@ -154,6 +154,85 @@ final class DictationHistoryViewModelTests: XCTestCase {
         XCTAssertTrue(mockRepo.deleteCalledWith.contains(dictation.id))
     }
 
+    func testToggleSelectionAddsAndRemovesDictation() {
+        let dictation = Dictation(durationMs: 1000, rawTranscript: "Selectable")
+        mockRepo.dictations = [dictation]
+        viewModel.configure(dictationRepo: mockRepo)
+
+        viewModel.toggleSelection(for: dictation)
+
+        XCTAssertTrue(viewModel.isDictationSelected(dictation))
+        XCTAssertEqual(viewModel.selectedDictationCount, 1)
+
+        viewModel.toggleSelection(for: dictation)
+
+        XCTAssertFalse(viewModel.isDictationSelected(dictation))
+        XCTAssertEqual(viewModel.selectedDictationCount, 0)
+    }
+
+    func testSelectAllVisibleDictationsUsesCurrentSearchResults() {
+        let matching = Dictation(durationMs: 1000, rawTranscript: "project note")
+        let hiddenBySearch = Dictation(durationMs: 1000, rawTranscript: "shopping list")
+        mockRepo.dictations = [matching, hiddenBySearch]
+        viewModel.configure(dictationRepo: mockRepo)
+
+        viewModel.searchText = "project"
+        viewModel.loadDictations(shouldRefreshStats: false)
+        viewModel.selectAllVisibleDictations()
+
+        XCTAssertEqual(viewModel.selectedDictationIDs, [matching.id])
+        XCTAssertTrue(viewModel.areAllVisibleDictationsSelected)
+    }
+
+    func testSearchReloadPrunesSelectionToVisibleDictations() {
+        let matching = Dictation(durationMs: 1000, rawTranscript: "project note")
+        let hiddenBySearch = Dictation(durationMs: 1000, rawTranscript: "shopping list")
+        mockRepo.dictations = [matching, hiddenBySearch]
+        viewModel.configure(dictationRepo: mockRepo)
+        viewModel.toggleSelection(for: matching)
+        viewModel.toggleSelection(for: hiddenBySearch)
+        XCTAssertEqual(viewModel.selectedDictationCount, 2)
+
+        viewModel.searchText = "project"
+        viewModel.loadDictations(shouldRefreshStats: false)
+
+        XCTAssertEqual(viewModel.selectedDictationIDs, [matching.id])
+    }
+
+    func testRequestDeleteSelectedDictationsQueuesSelectionConfirmation() {
+        let first = Dictation(durationMs: 1000, rawTranscript: "First")
+        let second = Dictation(durationMs: 1000, rawTranscript: "Second")
+        mockRepo.dictations = [first, second]
+        viewModel.configure(dictationRepo: mockRepo)
+        viewModel.toggleSelection(for: first)
+        viewModel.toggleSelection(for: second)
+
+        viewModel.requestDeleteSelectedDictations()
+
+        XCTAssertNil(viewModel.pendingDeleteDictation)
+        XCTAssertEqual(viewModel.pendingDeleteSelectedDictationIDs, [first.id, second.id])
+        XCTAssertEqual(viewModel.pendingDeleteCount, 2)
+    }
+
+    func testConfirmDeleteSelectedDictationsRemovesMultipleRowsAndClearsSelection() {
+        let first = Dictation(durationMs: 1000, rawTranscript: "First")
+        let second = Dictation(durationMs: 1000, rawTranscript: "Second")
+        let remaining = Dictation(durationMs: 1000, rawTranscript: "Remaining")
+        mockRepo.dictations = [first, second, remaining]
+        viewModel.configure(dictationRepo: mockRepo)
+        viewModel.toggleSelection(for: first)
+        viewModel.toggleSelection(for: second)
+        viewModel.requestDeleteSelectedDictations()
+
+        viewModel.confirmDeleteSelectedDictations()
+
+        XCTAssertEqual(Set(mockRepo.deleteCalledWith), [first.id, second.id])
+        XCTAssertEqual(viewModel.selectedDictationCount, 0)
+        XCTAssertEqual(viewModel.pendingDeleteCount, 0)
+        XCTAssertEqual(totalDictationCount(), 1)
+        XCTAssertEqual(viewModel.groupedDictations.flatMap(\.1).first?.id, remaining.id)
+    }
+
     // MARK: - Unconfigured
 
     func testLoadDictationsBeforeConfigureIsNoOp() {

--- a/Tests/MacParakeetTests/ViewModels/DictationHistoryViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/DictationHistoryViewModelTests.swift
@@ -141,7 +141,7 @@ final class DictationHistoryViewModelTests: XCTestCase {
 
     // MARK: - Delete
 
-    func testDeleteRemovesFromList() {
+    func testDeleteRemovesFromList() async {
         let dictation = Dictation(durationMs: 1000, rawTranscript: "To be deleted")
         mockRepo.dictations = [dictation]
 
@@ -149,6 +149,9 @@ final class DictationHistoryViewModelTests: XCTestCase {
         XCTAssertEqual(totalDictationCount(), 1)
 
         viewModel.deleteDictation(dictation)
+        await waitForCondition("dictation deleted") {
+            self.viewModel.groupedDictations.isEmpty
+        }
 
         XCTAssertTrue(viewModel.groupedDictations.isEmpty, "List should be empty after deletion")
         XCTAssertTrue(mockRepo.deleteCalledWith.contains(dictation.id))
@@ -210,11 +213,27 @@ final class DictationHistoryViewModelTests: XCTestCase {
         viewModel.requestDeleteSelectedDictations()
 
         XCTAssertNil(viewModel.pendingDeleteDictation)
-        XCTAssertEqual(viewModel.pendingDeleteSelectedDictationIDs, [first.id, second.id])
+        XCTAssertEqual(Set(viewModel.pendingDeleteSelectedDictations.map(\.id)), [first.id, second.id])
         XCTAssertEqual(viewModel.pendingDeleteCount, 2)
     }
 
-    func testConfirmDeleteSelectedDictationsRemovesMultipleRowsAndClearsSelection() {
+    func testPendingSelectedDeletePreservesRowsAcrossSearchReload() {
+        let matching = Dictation(durationMs: 1000, rawTranscript: "project note")
+        let hiddenBySearch = Dictation(durationMs: 1000, rawTranscript: "shopping list")
+        mockRepo.dictations = [matching, hiddenBySearch]
+        viewModel.configure(dictationRepo: mockRepo)
+        viewModel.toggleSelection(for: matching)
+        viewModel.toggleSelection(for: hiddenBySearch)
+        viewModel.requestDeleteSelectedDictations()
+
+        viewModel.searchText = "project"
+        viewModel.loadDictations(shouldRefreshStats: false)
+
+        XCTAssertEqual(Set(viewModel.pendingDeleteSelectedDictations.map(\.id)), [matching.id, hiddenBySearch.id])
+        XCTAssertEqual(viewModel.pendingDeleteCount, 2)
+    }
+
+    func testConfirmDeleteSelectedDictationsRemovesMultipleRowsAndClearsSelection() async {
         let first = Dictation(durationMs: 1000, rawTranscript: "First")
         let second = Dictation(durationMs: 1000, rawTranscript: "Second")
         let remaining = Dictation(durationMs: 1000, rawTranscript: "Remaining")
@@ -225,6 +244,9 @@ final class DictationHistoryViewModelTests: XCTestCase {
         viewModel.requestDeleteSelectedDictations()
 
         viewModel.confirmDeleteSelectedDictations()
+        await waitForCondition("selected dictations deleted") {
+            self.totalDictationCount() == 1
+        }
 
         XCTAssertEqual(Set(mockRepo.deleteCalledWith), [first.id, second.id])
         XCTAssertEqual(viewModel.selectedDictationCount, 0)
@@ -336,7 +358,7 @@ final class DictationHistoryViewModelTests: XCTestCase {
 
     // MARK: - Confirm Delete
 
-    func testConfirmDeleteRemovesDictation() {
+    func testConfirmDeleteRemovesDictation() async {
         let dictation = Dictation(durationMs: 1000, rawTranscript: "To be confirmed deleted")
         mockRepo.dictations = [dictation]
         viewModel.configure(dictationRepo: mockRepo)
@@ -345,6 +367,9 @@ final class DictationHistoryViewModelTests: XCTestCase {
         XCTAssertNotNil(viewModel.pendingDeleteDictation)
 
         viewModel.confirmDelete()
+        await waitForCondition("pending dictation deleted") {
+            self.viewModel.groupedDictations.isEmpty
+        }
 
         XCTAssertNil(viewModel.pendingDeleteDictation, "Pending should be cleared after confirm")
         XCTAssertTrue(mockRepo.deleteCalledWith.contains(dictation.id), "Should have called delete")
@@ -375,7 +400,7 @@ final class DictationHistoryViewModelTests: XCTestCase {
         XCTAssertEqual(mockRepo.statsCallCount, 1)
     }
 
-    func testStatsRefreshOnDelete() {
+    func testStatsRefreshOnDelete() async {
         let d1 = Dictation(durationMs: 1000, rawTranscript: "First dictation")
         let d2 = Dictation(durationMs: 2000, rawTranscript: "Second")
         mockRepo.dictations = [d1, d2]
@@ -384,10 +409,13 @@ final class DictationHistoryViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.stats.totalCount, 2)
 
         viewModel.deleteDictation(d1)
+        await waitForCondition("stats refreshed after delete") {
+            self.viewModel.stats.totalCount == 1
+        }
         XCTAssertEqual(viewModel.stats.totalCount, 1)
     }
 
-    func testDeleteRefreshesStatsOncePerDelete() {
+    func testDeleteRefreshesStatsOncePerDelete() async {
         let d1 = Dictation(durationMs: 1000, rawTranscript: "First")
         let d2 = Dictation(durationMs: 2000, rawTranscript: "Second")
         mockRepo.dictations = [d1, d2]
@@ -396,6 +424,9 @@ final class DictationHistoryViewModelTests: XCTestCase {
         XCTAssertEqual(mockRepo.statsCallCount, 1)
 
         viewModel.deleteDictation(d1)
+        await waitForCondition("stats call after delete") {
+            self.mockRepo.statsCallCount == 2
+        }
         XCTAssertEqual(mockRepo.statsCallCount, 2)
     }
 
@@ -482,5 +513,18 @@ final class DictationHistoryViewModelTests: XCTestCase {
 
     private func totalDictationCount() -> Int {
         viewModel.groupedDictations.reduce(0) { $0 + $1.1.count }
+    }
+
+    private func waitForCondition(
+        _ description: String,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        predicate: () -> Bool
+    ) async {
+        for _ in 0..<100 {
+            if predicate() { return }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        XCTFail("Timed out waiting for \(description)", file: file, line: line)
     }
 }

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -535,7 +535,7 @@ The app lives primarily in the menu bar. Click the icon for quick actions, or op
 
 ### F4: Dictation History
 
-**What:** Searchable, date-grouped flat list of all dictations with hover actions, bottom bar audio player, and copy/delete support.
+**What:** Searchable, date-grouped flat list of all dictations with hover actions, bottom bar audio player, and copy/delete support, including multi-select cleanup.
 
 **History view (flat list + bottom bar player):**
 
@@ -575,6 +575,7 @@ The app lives primarily in the menu bar. Click the icon for quick actions, or op
 - Context menu: Play/Pause, Copy, Download Audio, Delete
 - Keyboard shortcut: Cmd+Backspace to delete
 - Text selection enabled on transcript text
+- Multi-select cleanup bar for selecting visible dictations and deleting them together
 - Delete confirmation dialog before permanent removal
 
 **Database schema:**
@@ -624,6 +625,7 @@ Audio path is computed from ID by default. Files stored as WAV (16kHz mono). Use
 - [x] Can play audio via bottom bar player (Spotify-style progress bar)
 - [x] Can copy transcript text to clipboard (with checkmark confirmation)
 - [x] Can delete individual dictations (with confirmation dialog)
+- [x] Can select and delete multiple visible dictations together (with confirmation dialog)
 - [x] Can download audio files via three-dot menu
 - [x] Hover actions appear without layout shift (overlay pattern)
 - [x] History persists across app restarts (SQLite via GRDB)

--- a/spec/kernel/requirements.yaml
+++ b/spec/kernel/requirements.yaml
@@ -58,7 +58,7 @@ REQ-UI-003:
   status: implemented
 
 REQ-DATA-001:
-  description: Dictation history with date-grouped search and audio playback
+  description: Dictation history with date-grouped search, multi-select cleanup, and audio playback
   version: v0.1
   status: implemented
 

--- a/spec/kernel/traceability.md
+++ b/spec/kernel/traceability.md
@@ -15,7 +15,7 @@ This matrix traces each requirement ID from `requirements.yaml` to its implement
 | REQ-UI-001 | `MacParakeet/Views/Dictation/DictationOverlayView.swift` | (ViewModel tests) |
 | REQ-UI-002 | `MacParakeet/Views/Dictation/IdlePillView.swift` | (ViewModel tests) |
 | REQ-UI-003 | `MacParakeet/Views/MainWindowView.swift` | (ViewModel tests) |
-| REQ-DATA-001 | `MacParakeetCore/Database/DictationRepository.swift` | `DictationRepositoryTests.swift` |
+| REQ-DATA-001 | `MacParakeetCore/Database/DictationRepository.swift`, `MacParakeetViewModels/DictationHistoryViewModel.swift`, `MacParakeet/Views/History/DictationHistoryView.swift` | `DictationRepositoryTests.swift`, `DictationHistoryViewModelTests.swift` |
 | REQ-DATA-002 | `MacParakeetCore/Database/DatabaseManager.swift` | `DatabaseManagerTests.swift` |
 | REQ-STT-001 | `MacParakeet/App/AppEnvironment.swift`, `MacParakeetCore/STT/STTRuntime.swift`, `MacParakeetCore/STT/STTScheduler.swift`, `MacParakeetCore/STT/STTClient.swift`, `MacParakeetCore/Services/Dictation/DictationService.swift`, `MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift`, `MacParakeetCore/Services/TranscriptionService.swift`, `MacParakeetViewModels/OnboardingViewModel.swift` | `STTSchedulerTests.swift`, `STTClientTests.swift`, `DictationServiceTests.swift`, `MeetingRecordingServiceTests.swift`, `TranscriptionServiceTests.swift`, `OnboardingViewModelTests.swift` |
 | REQ-EXP-001 | `MacParakeetCore/Services/ExportService.swift` | `ExportServiceTests.swift` |


### PR DESCRIPTION
## Summary

Adds multi-select cleanup to Dictation History so users can select several visible dictations and delete them with one confirmation instead of deleting rows one at a time.

## User Flow

```text
History list
    |
    +-- select one or more visible rows
            |
            v
    selection bar appears
    [N selected] [Select All] [Clear] [Delete]
            |
            v
    confirmation dialog
            |
            v
    selected history rows and retained audio files are deleted
```

## What Changed

- Adds row selection toggles and selected-row styling in Dictation History.
- Adds a compact bulk-action bar for select all, clear, and delete.
- Keeps selection scoped to the visible history/search results, while pending delete confirmation stores row snapshots so the delete target is stable.
- Reuses the existing delete semantics for single and batch cleanup, including audio-file removal, telemetry, playback stop, and one history refresh after completion.
- Moves the disk/database delete loop off the main actor so larger cleanup actions do not block the UI.
- Updates the feature spec and traceability docs for the new cleanup behavior.

## Verification

- `swift test --filter DictationHistoryViewModelTests`
- `swift test`
- `git diff --check`

Closes #425
