### PR TITLE
Add rich transcript context for AI

### DIFF
--- a/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
@@ -166,6 +166,10 @@ struct LLMSettingsView: View {
 
             Divider()
 
+            transcriptAIContextSection
+
+            Divider()
+
             aiFormatterSection
         }
     }
@@ -335,6 +339,51 @@ struct LLMSettingsView: View {
                     .frame(width: 220, alignment: .leading)
             }
         }
+    }
+
+    private var transcriptAIContextSection: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Transcript context for AI")
+                        .font(DesignSystem.Typography.body.weight(.semibold))
+                    Text("Controls what summaries, transcript chat, and Meeting Ask send to your AI provider.")
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: DesignSystem.Spacing.md)
+
+                Picker("Transcript context for AI", selection: $viewModel.transcriptAIContextMode) {
+                    ForEach(TranscriptAIContextMode.allCases) { mode in
+                        Text(mode.displayTitle).tag(mode)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.segmented)
+                .frame(width: 300)
+            }
+
+            Text(viewModel.transcriptAIContextMode.detail)
+                .font(DesignSystem.Typography.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if viewModel.transcriptAIContextMode == .richTranscript {
+                HStack(alignment: .top, spacing: 6) {
+                    Image(systemName: "info.circle.fill")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    Text("Speaker labels are a rough reference from audio-source separation and diarization, not a high-accuracy identification of who said each line.")
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .id("ai.transcriptContext")
     }
 
     @ViewBuilder

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -69,6 +69,9 @@ struct TranscriptResultView: View {
     var onRetranscribe: ((Transcription, SpeechEngineSelection?) -> Void)?
     var onSetUpAI: (() -> Void)?
 
+    @AppStorage(UserDefaultsAppRuntimePreferences.transcriptAIContextModeKey)
+    private var transcriptAIContextModeRaw = TranscriptAIContextMode.richTranscript.rawValue
+
     @State private var backHovered = false
     @State private var headerExpanded = false
     @State private var speakerOverviewExpanded = false
@@ -158,7 +161,7 @@ struct TranscriptResultView: View {
             syncTranscriptDisplayMode()
             promptResultsViewModel.loadVisiblePrompts()
             promptResultsViewModel.loadPromptResults(transcriptionId: transcription.id)
-            let text = viewModel.currentTranscription?.cleanTranscript ?? viewModel.currentTranscription?.rawTranscript ?? ""
+            let text = currentAIContextText
             chatViewModel.loadTranscript(text, transcriptionId: viewModel.currentTranscription?.id)
             // Feed the user's typed meeting notes (if any) into chat alongside
             // the transcript. The closure is re-evaluated on every chat-send so
@@ -201,7 +204,7 @@ struct TranscriptResultView: View {
             viewModel.loadPersistedContent()
             syncTranscriptDisplayMode()
             promptResultsViewModel.loadPromptResults(transcriptionId: transcription.id)
-            let text = viewModel.currentTranscription?.cleanTranscript ?? viewModel.currentTranscription?.rawTranscript ?? ""
+            let text = currentAIContextText
             chatViewModel.loadTranscript(text, transcriptionId: viewModel.currentTranscription?.id)
         }
         .onChange(of: activeTranscription.speakers) {
@@ -212,6 +215,9 @@ struct TranscriptResultView: View {
         }
         .onChange(of: activeTranscription.diarizationSegments) {
             rebuildSegmentCache()
+        }
+        .onChange(of: transcriptAIContextModeRaw) {
+            chatViewModel.loadTranscript(currentAIContextText, transcriptionId: viewModel.currentTranscription?.id)
         }
         .onChange(of: viewModel.selectedTab) {
             if case .result(let id) = viewModel.selectedTab {
@@ -624,6 +630,17 @@ struct TranscriptResultView: View {
 
     private var transcriptText: String {
         activeTranscription.cleanTranscript ?? activeTranscription.rawTranscript ?? ""
+    }
+
+    private var currentAIContextMode: TranscriptAIContextMode {
+        TranscriptAIContextMode(rawValue: transcriptAIContextModeRaw) ?? .richTranscript
+    }
+
+    private var currentAIContextText: String {
+        TranscriptAIContextFormatter.format(
+            transcription: activeTranscription,
+            mode: currentAIContextMode
+        )
     }
 
     private var rawTranscriptText: String {
@@ -1428,7 +1445,7 @@ struct TranscriptResultView: View {
                         Spacer()
 
                         Button {
-                            if let generationID = promptResultsViewModel.regeneratePromptResult(promptResult, transcript: transcriptText) {
+                            if let generationID = promptResultsViewModel.regeneratePromptResult(promptResult, transcript: currentAIContextText) {
                                 viewModel.selectedTab = .generation(id: generationID)
                             }
                         } label: {
@@ -1645,7 +1662,7 @@ struct TranscriptResultView: View {
                 Button {
                     showGeneratePopover = false
                     if let generationID = promptResultsViewModel.generatePromptResult(
-                        transcript: transcriptText,
+                        transcript: currentAIContextText,
                         transcriptionId: transcription.id
                     ) {
                         viewModel.selectedTab = .generation(id: generationID)
@@ -2522,10 +2539,7 @@ struct TranscriptResultView: View {
             return
         }
 
-        let updatedText = viewModel.currentTranscription?.cleanTranscript
-            ?? viewModel.currentTranscription?.rawTranscript
-            ?? trimmed
-        chatViewModel.loadTranscript(updatedText, transcriptionId: viewModel.currentTranscription?.id)
+        chatViewModel.loadTranscript(currentAIContextText, transcriptionId: viewModel.currentTranscription?.id)
         transcriptDraft = ""
         transcriptEditError = nil
         editingTranscript = false
@@ -2536,8 +2550,7 @@ struct TranscriptResultView: View {
 
     private func revertTranscriptEdit() {
         guard viewModel.revertCurrentTranscriptToOriginal() else { return }
-        let originalText = viewModel.currentTranscription?.rawTranscript ?? rawTranscriptText
-        chatViewModel.loadTranscript(originalText, transcriptionId: viewModel.currentTranscription?.id)
+        chatViewModel.loadTranscript(currentAIContextText, transcriptionId: viewModel.currentTranscription?.id)
         transcriptDraft = ""
         transcriptEditError = nil
         editingTranscript = false

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -11,6 +11,7 @@ public protocol AppRuntimePreferencesProtocol: Sendable {
     var aiFormatterEnabled: Bool { get }
     var aiFormatterEnabledForDictation: Bool { get }
     var aiFormatterPrompt: String { get }
+    var transcriptAIContextMode: TranscriptAIContextMode { get }
     var selectedMicrophoneDeviceUID: String? { get }
     var meetingAudioSourceMode: MeetingAudioSourceMode { get }
     var pauseMediaDuringDictation: Bool { get }
@@ -22,6 +23,39 @@ public protocol AppRuntimePreferencesProtocol: Sendable {
     /// subsequent call.
     @discardableResult
     func markFirstDictationCompleted() -> Bool
+}
+
+public enum TranscriptAIContextMode: String, CaseIterable, Codable, Identifiable, Sendable, Equatable {
+    case richTranscript = "rich_transcript"
+    case plainTranscript = "plain_transcript"
+
+    public var id: String { rawValue }
+
+    public var displayTitle: String {
+        switch self {
+        case .richTranscript:
+            return "Rich transcript"
+        case .plainTranscript:
+            return "Plain transcript"
+        }
+    }
+
+    public var detail: String {
+        switch self {
+        case .richTranscript:
+            return "Use timestamps and available speaker labels when the transcript has them."
+        case .plainTranscript:
+            return "Use the transcript text without timing or speaker labels."
+        }
+    }
+
+    public static func current(defaults: UserDefaults = .standard) -> TranscriptAIContextMode {
+        guard let raw = defaults.string(forKey: UserDefaultsAppRuntimePreferences.transcriptAIContextModeKey),
+              let mode = TranscriptAIContextMode(rawValue: raw) else {
+            return .richTranscript
+        }
+        return mode
+    }
 }
 
 public enum YouTubeAudioQuality: String, CaseIterable, Hashable, Sendable, Equatable {
@@ -114,6 +148,7 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
     public static let aiFormatterEnabledKey = "aiFormatterEnabled"
     public static let aiFormatterEnabledForDictationKey = "aiFormatterEnabledForDictation"
     public static let aiFormatterPromptKey = "aiFormatterPrompt"
+    public static let transcriptAIContextModeKey = "transcriptAIContextMode"
     public static let selectedMicrophoneDeviceUIDKey = "selectedMicrophoneDeviceUID"
     public static let meetingAudioSourceModeKey = "meetingAudioSourceMode"
     public static let pauseMediaDuringDictationKey = "pauseMediaDuringDictation"
@@ -177,6 +212,10 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
     public var aiFormatterPrompt: String {
         let prompt = defaults.string(forKey: Self.aiFormatterPromptKey) ?? ""
         return AIFormatter.normalizedPromptTemplate(prompt)
+    }
+
+    public var transcriptAIContextMode: TranscriptAIContextMode {
+        TranscriptAIContextMode.current(defaults: defaults)
     }
 
     public var selectedMicrophoneDeviceUID: String? {

--- a/Sources/MacParakeetCore/Services/ExportService.swift
+++ b/Sources/MacParakeetCore/Services/ExportService.swift
@@ -345,65 +345,13 @@ public final class ExportService: ExportServiceProtocol, Sendable {
 
     // MARK: - Subtitle Cue Building
 
-    public struct SubtitleCue: Sendable {
-        public let startMs: Int
-        public let endMs: Int
-        public let text: String
-        public let speakerId: String?
-    }
+    public typealias SubtitleCue = TranscriptCue
 
     /// Groups word timestamps into subtitle cues suitable for SRT/VTT and overlay display.
     /// Rules: max ~12 words per cue, break on sentence-ending punctuation,
     /// break on long pauses (>800ms), max ~7 seconds per cue, break on speaker change.
     public func buildSubtitleCues(from words: [WordTimestamp]) -> [SubtitleCue] {
-        guard !words.isEmpty else { return [] }
-
-        var cues: [SubtitleCue] = []
-        var currentWords: [String] = []
-        var cueStartMs = words[0].startMs
-        var cueEndMs = words[0].endMs
-        var cueSpeakerId = words[0].speakerId
-
-        for (i, word) in words.enumerated() {
-            // Break on speaker change before adding the word
-            let speakerChanged = !currentWords.isEmpty && word.speakerId != cueSpeakerId
-            if speakerChanged {
-                cues.append(SubtitleCue(
-                    startMs: cueStartMs,
-                    endMs: cueEndMs,
-                    text: currentWords.joined(separator: " "),
-                    speakerId: cueSpeakerId
-                ))
-                currentWords = []
-                cueStartMs = word.startMs
-                cueSpeakerId = word.speakerId
-            }
-
-            currentWords.append(word.word)
-            cueEndMs = word.endMs
-
-            let isLast = i == words.count - 1
-            let endsWithPunctuation = word.word.last.map { ".!?".contains($0) } ?? false
-            let hasLongGap = !isLast && (words[i + 1].startMs - word.endMs) > 800
-            let tooManyWords = currentWords.count >= 12
-            let tooLong = (cueEndMs - cueStartMs) > 7000
-
-            if isLast || (endsWithPunctuation && currentWords.count >= 2) || hasLongGap || tooManyWords || tooLong {
-                cues.append(SubtitleCue(
-                    startMs: cueStartMs,
-                    endMs: cueEndMs,
-                    text: currentWords.joined(separator: " "),
-                    speakerId: cueSpeakerId
-                ))
-                currentWords = []
-                if !isLast {
-                    cueStartMs = words[i + 1].startMs
-                    cueSpeakerId = words[i + 1].speakerId
-                }
-            }
-        }
-
-        return cues
+        TranscriptCueBuilder.build(from: words)
     }
 
     /// Resolve a speakerId to a display label using the speakers mapping.

--- a/Sources/MacParakeetCore/TextProcessing/TranscriptAIContextFormatter.swift
+++ b/Sources/MacParakeetCore/TextProcessing/TranscriptAIContextFormatter.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+public enum TranscriptAIContextFormatter {
+    public static func format(
+        transcription: Transcription,
+        mode: TranscriptAIContextMode = .richTranscript
+    ) -> String {
+        switch mode {
+        case .plainTranscript:
+            return preferredText(transcription)
+        case .richTranscript:
+            return richText(transcription) ?? preferredText(transcription)
+        }
+    }
+
+    private static func preferredText(_ transcription: Transcription) -> String {
+        (transcription.cleanTranscript ?? transcription.rawTranscript ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func editedTranscriptText(_ transcription: Transcription) -> String? {
+        guard transcription.isTranscriptEdited,
+              let text = transcription.cleanTranscript?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !text.isEmpty
+        else {
+            return nil
+        }
+        return text
+    }
+
+    private static func richText(_ transcription: Transcription) -> String? {
+        if let edited = editedTranscriptText(transcription) {
+            return edited
+        }
+
+        guard let words = transcription.wordTimestamps, !words.isEmpty else {
+            return nil
+        }
+
+        let cues = TranscriptCueBuilder.build(from: words)
+        guard !cues.isEmpty else { return nil }
+
+        return cues.map { cue in
+            let timestamp = "[\(readableTimestamp(ms: cue.startMs))]"
+            if let label = speakerLabel(for: cue.speakerId, in: transcription.speakers) {
+                return "\(timestamp) \(label): \(cue.text)"
+            }
+            return "\(timestamp) \(cue.text)"
+        }
+        .joined(separator: "\n")
+    }
+
+    private static func speakerLabel(for speakerId: String?, in speakers: [SpeakerInfo]?) -> String? {
+        guard let speakerId else { return nil }
+        guard let speakers, !speakers.isEmpty else { return speakerId }
+        return speakers.first(where: { $0.id == speakerId })?.label ?? speakerId
+    }
+
+    private static func readableTimestamp(ms: Int) -> String {
+        let totalSeconds = max(0, ms) / 1000
+        let hours = totalSeconds / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        let seconds = totalSeconds % 60
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, seconds)
+        }
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+}

--- a/Sources/MacParakeetCore/TextProcessing/TranscriptCueBuilder.swift
+++ b/Sources/MacParakeetCore/TextProcessing/TranscriptCueBuilder.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+public struct TranscriptCue: Sendable, Equatable {
+    public let startMs: Int
+    public let endMs: Int
+    public let text: String
+    public let speakerId: String?
+
+    public init(startMs: Int, endMs: Int, text: String, speakerId: String?) {
+        self.startMs = startMs
+        self.endMs = endMs
+        self.text = text
+        self.speakerId = speakerId
+    }
+}
+
+public enum TranscriptCueBuilder {
+    /// Groups word timestamps into compact cues suitable for subtitles,
+    /// playback overlays, and AI context.
+    public static func build(from words: [WordTimestamp]) -> [TranscriptCue] {
+        guard !words.isEmpty else { return [] }
+
+        var cues: [TranscriptCue] = []
+        var currentWords: [String] = []
+        var cueStartMs = words[0].startMs
+        var cueEndMs = words[0].endMs
+        var cueSpeakerId = words[0].speakerId
+
+        for (index, word) in words.enumerated() {
+            let speakerChanged = !currentWords.isEmpty && word.speakerId != cueSpeakerId
+            if speakerChanged {
+                cues.append(TranscriptCue(
+                    startMs: cueStartMs,
+                    endMs: cueEndMs,
+                    text: currentWords.joined(separator: " "),
+                    speakerId: cueSpeakerId
+                ))
+                currentWords = []
+                cueStartMs = word.startMs
+                cueSpeakerId = word.speakerId
+            }
+
+            currentWords.append(word.word)
+            cueEndMs = word.endMs
+
+            let isLast = index == words.count - 1
+            let endsWithPunctuation = word.word.last.map { ".!?".contains($0) } ?? false
+            let hasLongGap = !isLast && (words[index + 1].startMs - word.endMs) > 800
+            let tooManyWords = currentWords.count >= 12
+            let tooLong = (cueEndMs - cueStartMs) > 7000
+
+            if isLast || (endsWithPunctuation && currentWords.count >= 2) || hasLongGap || tooManyWords || tooLong {
+                cues.append(TranscriptCue(
+                    startMs: cueStartMs,
+                    endMs: cueEndMs,
+                    text: currentWords.joined(separator: " "),
+                    speakerId: cueSpeakerId
+                ))
+                currentWords = []
+                if !isLast {
+                    cueStartMs = words[index + 1].startMs
+                    cueSpeakerId = words[index + 1].speakerId
+                }
+            }
+        }
+
+        return cues
+    }
+}

--- a/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
@@ -369,6 +369,16 @@ public final class LLMSettingsViewModel {
         }
     }
 
+    public var transcriptAIContextMode: TranscriptAIContextMode {
+        didSet {
+            guard transcriptAIContextMode != oldValue else { return }
+            defaults.set(
+                transcriptAIContextMode.rawValue,
+                forKey: UserDefaultsAppRuntimePreferences.transcriptAIContextModeKey
+            )
+        }
+    }
+
     public var isAIFormatterAvailable: Bool {
         draft.providerID != nil && draft.providerID == savedProviderID
     }
@@ -447,6 +457,7 @@ public final class LLMSettingsViewModel {
     public init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
         self.aiFormatterEnabledForDictation = Self.loadStoredAIFormatterEnabledForDictation(from: defaults)
+        self.transcriptAIContextMode = TranscriptAIContextMode.current(defaults: defaults)
         self.draft = LLMSettingsDraft(
             aiFormatterPrompt: Self.loadStoredAIFormatterPrompt(from: defaults)
         )

--- a/Sources/MacParakeetViewModels/MeetingRecordingPanelViewModel.swift
+++ b/Sources/MacParakeetViewModels/MeetingRecordingPanelViewModel.swift
@@ -63,8 +63,14 @@ public final class MeetingRecordingPanelViewModel {
 
     private var copiedResetTask: Task<Void, Never>?
     private var previewLineWordCounts: [Int] = []
+    private let transcriptAIContextModeProvider: @MainActor () -> TranscriptAIContextMode
 
-    public init() {
+    public init(
+        transcriptAIContextModeProvider: @escaping @MainActor () -> TranscriptAIContextMode = {
+            TranscriptAIContextMode.current()
+        }
+    ) {
+        self.transcriptAIContextModeProvider = transcriptAIContextModeProvider
         // Mark the chat VM as the live in-meeting Ask surface so
         // `llm_chat_used` telemetry distinguishes Ask chat from
         // post-transcription transcript chat. Without this the two sources
@@ -116,7 +122,8 @@ public final class MeetingRecordingPanelViewModel {
                 liveTranscriptStatus = .live
             }
             // Keep the live Ask tab fed with the latest transcript without disturbing
-            // chat history. Bracketed timestamps stripped — LLMs do better without them.
+            // chat history. The transcript AI context preference decides whether
+            // future sends use rich timestamp/speaker context or plain text.
             chatViewModel.updateTranscriptText(chatTranscript)
         }
         self.isTranscriptionLagging = isTranscriptionLagging
@@ -126,9 +133,13 @@ public final class MeetingRecordingPanelViewModel {
         previewLines.map { "[\($0.timestamp)] \($0.speakerLabel): \($0.text)" }.joined(separator: "\n")
     }
 
-    /// Cleaner transcript shape for LLM consumption: speaker label + text, no timestamps.
     public var chatTranscript: String {
-        previewLines.map { "\($0.speakerLabel): \($0.text)" }.joined(separator: "\n")
+        switch transcriptAIContextModeProvider() {
+        case .richTranscript:
+            return transcriptText
+        case .plainTranscript:
+            return previewLines.map(\.text).joined(separator: "\n")
+        }
     }
 
     public var canCopy: Bool {

--- a/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
+++ b/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
@@ -285,6 +285,18 @@ public enum SettingsSearchIndex {
             cardAnchor: "ai.provider"
         ),
         SettingsSearchEntry(
+            id: "ai.transcriptContext",
+            tab: .ai,
+            title: "Transcript Context for AI",
+            subtitle: "Rich or plain transcript context for summaries, chat, and Meeting Ask.",
+            keywords: [
+                "meeting ai", "meeting context", "transcript context", "rich transcript",
+                "plain transcript", "speaker labels", "speaker diarization", "timestamps",
+                "summary context", "chat context", "ask context"
+            ],
+            cardAnchor: "ai.transcriptContext"
+        ),
+        SettingsSearchEntry(
             id: "ai.formatter",
             tab: .ai,
             title: "AI Formatter",

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -168,6 +168,13 @@ public final class TranscriptionViewModel {
         }
     }
 
+    private func aiContextText(for transcription: Transcription) -> String {
+        TranscriptAIContextFormatter.format(
+            transcription: transcription,
+            mode: TranscriptAIContextMode.current(defaults: defaults)
+        )
+    }
+
     public func configure(
         transcriptionService: TranscriptionServiceProtocol,
         transcriptionRepo: TranscriptionRepositoryProtocol,
@@ -715,7 +722,7 @@ public final class TranscriptionViewModel {
             autoSaveIfEnabled(transcription)
         }
         guard runAutoPrompts else { return }
-        let text = transcription.cleanTranscript ?? transcription.rawTranscript ?? ""
+        let text = aiContextText(for: transcription)
         promptResultsViewModel?.autoGeneratePromptResults(
             transcript: text,
             transcriptionId: transcription.id,

--- a/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
+++ b/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
@@ -99,6 +99,25 @@ final class AppRuntimePreferencesTests: XCTestCase {
         XCTAssertTrue(UserDefaultsAppRuntimePreferences(defaults: defaults).aiFormatterEnabledForDictation)
     }
 
+    func testTranscriptAIContextModeDefaultsToRichAndReadsPersistedValue() {
+        let suite = "app-runtime-prefs-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        XCTAssertEqual(UserDefaultsAppRuntimePreferences(defaults: defaults).transcriptAIContextMode, .richTranscript)
+
+        defaults.set(
+            TranscriptAIContextMode.plainTranscript.rawValue,
+            forKey: UserDefaultsAppRuntimePreferences.transcriptAIContextModeKey
+        )
+
+        XCTAssertEqual(UserDefaultsAppRuntimePreferences(defaults: defaults).transcriptAIContextMode, .plainTranscript)
+
+        defaults.set("not-a-mode", forKey: UserDefaultsAppRuntimePreferences.transcriptAIContextModeKey)
+
+        XCTAssertEqual(UserDefaultsAppRuntimePreferences(defaults: defaults).transcriptAIContextMode, .richTranscript)
+    }
+
     /// Models the gate the composition root installs on the dictation path: the
     /// AI Formatter runs on dictation only when the global switch AND the
     /// dictation-specific switch are both on, while the file/meeting path keys

--- a/Tests/MacParakeetTests/TextProcessing/TranscriptAIContextFormatterTests.swift
+++ b/Tests/MacParakeetTests/TextProcessing/TranscriptAIContextFormatterTests.swift
@@ -1,0 +1,118 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class TranscriptAIContextFormatterTests: XCTestCase {
+    func testRichTranscriptIncludesTimestampsAndSpeakerLabels() {
+        let transcription = Transcription(
+            fileName: "meeting.wav",
+            rawTranscript: "Hello there. Thanks.",
+            cleanTranscript: "Hello there. Thanks.",
+            wordTimestamps: [
+                WordTimestamp(word: "Hello", startMs: 0, endMs: 400, confidence: 0.99, speakerId: "microphone"),
+                WordTimestamp(word: "there.", startMs: 450, endMs: 900, confidence: 0.98, speakerId: "microphone"),
+                WordTimestamp(word: "Thanks.", startMs: 2_000, endMs: 2_400, confidence: 0.97, speakerId: "system")
+            ],
+            speakers: [
+                SpeakerInfo(id: "microphone", label: "Me"),
+                SpeakerInfo(id: "system", label: "Others")
+            ],
+            status: .completed,
+            sourceType: .meeting
+        )
+
+        let formatted = TranscriptAIContextFormatter.format(
+            transcription: transcription,
+            mode: .richTranscript
+        )
+
+        XCTAssertEqual(
+            formatted,
+            """
+            [0:00] Me: Hello there.
+            [0:02] Others: Thanks.
+            """
+        )
+    }
+
+    func testRichTranscriptFallsBackToSpeakerIdWhenSpeakerMapIsMissing() {
+        let transcription = Transcription(
+            fileName: "meeting.wav",
+            rawTranscript: "Hello there.",
+            cleanTranscript: "Hello there.",
+            wordTimestamps: [
+                WordTimestamp(word: "Hello", startMs: 0, endMs: 400, confidence: 0.99, speakerId: "microphone"),
+                WordTimestamp(word: "there.", startMs: 450, endMs: 900, confidence: 0.98, speakerId: "microphone")
+            ],
+            speakers: nil,
+            status: .completed,
+            sourceType: .meeting
+        )
+
+        let formatted = TranscriptAIContextFormatter.format(
+            transcription: transcription,
+            mode: .richTranscript
+        )
+
+        XCTAssertEqual(formatted, "[0:00] microphone: Hello there.")
+    }
+
+    func testPlainTranscriptUsesCleanTextWithoutTimingOrSpeakerLabels() {
+        let transcription = Transcription(
+            fileName: "meeting.wav",
+            rawTranscript: "raw",
+            cleanTranscript: "  Clean transcript\n",
+            wordTimestamps: [
+                WordTimestamp(word: "Clean", startMs: 0, endMs: 200, confidence: 0.9, speakerId: "speaker-1")
+            ],
+            speakers: [SpeakerInfo(id: "speaker-1", label: "Speaker 1")],
+            status: .completed,
+            sourceType: .meeting
+        )
+
+        let formatted = TranscriptAIContextFormatter.format(
+            transcription: transcription,
+            mode: .plainTranscript
+        )
+
+        XCTAssertEqual(formatted, "Clean transcript")
+    }
+
+    func testRichTranscriptFallsBackToPreferredTextWhenNoTimestampsExist() {
+        let transcription = Transcription(
+            fileName: "audio.wav",
+            rawTranscript: "  Raw fallback\n",
+            cleanTranscript: nil,
+            wordTimestamps: nil,
+            status: .completed
+        )
+
+        let formatted = TranscriptAIContextFormatter.format(
+            transcription: transcription,
+            mode: .richTranscript
+        )
+
+        XCTAssertEqual(formatted, "Raw fallback")
+    }
+
+    func testEditedTranscriptUsesEditedTextEvenInRichMode() {
+        let transcription = Transcription(
+            fileName: "meeting.wav",
+            rawTranscript: "Old raw",
+            cleanTranscript: "Edited transcript",
+            wordTimestamps: [
+                WordTimestamp(word: "Old", startMs: 0, endMs: 300, confidence: 0.9, speakerId: "speaker-1")
+            ],
+            speakers: [SpeakerInfo(id: "speaker-1", label: "Speaker 1")],
+            status: .completed,
+            sourceType: .meeting,
+            isTranscriptEdited: true
+        )
+
+        let formatted = TranscriptAIContextFormatter.format(
+            transcription: transcription,
+            mode: .richTranscript
+        )
+
+        XCTAssertEqual(formatted, "Edited transcript")
+    }
+}

--- a/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
@@ -42,6 +42,7 @@ final class LLMSettingsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.aiFormatterEnabled)
         XCTAssertEqual(viewModel.aiFormatterPrompt, AIFormatter.defaultPromptTemplate)
         XCTAssertEqual(viewModel.aiFormatterPromptModeText, "Default prompt")
+        XCTAssertEqual(viewModel.transcriptAIContextMode, .richTranscript)
     }
 
     // MARK: - AI Formatter: dictation routing toggle (#408)
@@ -52,28 +53,26 @@ final class LLMSettingsViewModelTests: XCTestCase {
 
     func testAIFormatterEnabledForDictationPersistsThroughInjectedDefaults() {
         let key = UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey
-        let standard = UserDefaults.standard
-        let priorStandardValue = standard.object(forKey: key)
-        standard.set(false, forKey: key)
-        defer {
-            if let priorStandardValue {
-                standard.set(priorStandardValue, forKey: key)
-            } else {
-                standard.removeObject(forKey: key)
-            }
-        }
 
         viewModel.aiFormatterEnabledForDictation = true
 
         XCTAssertEqual(defaults.object(forKey: key) as? Bool, true)
-        // The view model uses the injected store, not UserDefaults.standard.
-        XCTAssertEqual(standard.object(forKey: key) as? Bool, false)
+        XCTAssertTrue(LLMSettingsViewModel(defaults: defaults).aiFormatterEnabledForDictation)
     }
 
     func testAIFormatterEnabledForDictationLoadsStoredValueOnInit() {
         defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey)
         let reloaded = LLMSettingsViewModel(defaults: defaults)
         XCTAssertTrue(reloaded.aiFormatterEnabledForDictation)
+    }
+
+    func testTranscriptAIContextModePersistsThroughInjectedDefaults() {
+        let key = UserDefaultsAppRuntimePreferences.transcriptAIContextModeKey
+
+        viewModel.transcriptAIContextMode = .plainTranscript
+
+        XCTAssertEqual(defaults.string(forKey: key), TranscriptAIContextMode.plainTranscript.rawValue)
+        XCTAssertEqual(LLMSettingsViewModel(defaults: defaults).transcriptAIContextMode, .plainTranscript)
     }
 
     func testClearConfigurationRestoresDictationRoutingDefault() {

--- a/Tests/MacParakeetTests/ViewModels/MeetingRecordingPanelViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/MeetingRecordingPanelViewModelTests.swift
@@ -80,6 +80,66 @@ final class MeetingRecordingPanelViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.wordCount, 7)
     }
 
+    func testChatTranscriptCanUseRichPreviewContext() {
+        let viewModel = MeetingRecordingPanelViewModel(
+            transcriptAIContextModeProvider: { .richTranscript }
+        )
+        viewModel.updatePreviewLines([
+            MeetingRecordingPreviewLine(
+                id: "1",
+                timestamp: "0:05",
+                speakerLabel: "Me",
+                text: "Testing the meeting panel",
+                source: .microphone
+            ),
+            MeetingRecordingPreviewLine(
+                id: "2",
+                timestamp: "0:08",
+                speakerLabel: "Others",
+                text: "Reply from the call",
+                source: .system
+            )
+        ])
+
+        XCTAssertEqual(
+            viewModel.chatTranscript,
+            """
+            [0:05] Me: Testing the meeting panel
+            [0:08] Others: Reply from the call
+            """
+        )
+    }
+
+    func testChatTranscriptCanUsePlainPreviewContext() {
+        let viewModel = MeetingRecordingPanelViewModel(
+            transcriptAIContextModeProvider: { .plainTranscript }
+        )
+        viewModel.updatePreviewLines([
+            MeetingRecordingPreviewLine(
+                id: "1",
+                timestamp: "0:05",
+                speakerLabel: "Me",
+                text: "Testing the meeting panel",
+                source: .microphone
+            ),
+            MeetingRecordingPreviewLine(
+                id: "2",
+                timestamp: "0:08",
+                speakerLabel: "Others",
+                text: "Reply from the call",
+                source: .system
+            )
+        ])
+
+        XCTAssertEqual(
+            viewModel.chatTranscript,
+            """
+            Testing the meeting panel
+            Reply from the call
+            """
+        )
+    }
+
     func testTranscribingAndErrorStatesUpdateStatusSurface() {
         let viewModel = MeetingRecordingPanelViewModel()
 

--- a/Tests/MacParakeetTests/ViewModels/SettingsSearchIndexTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsSearchIndexTests.swift
@@ -115,6 +115,16 @@ final class SettingsSearchIndexTests: XCTestCase {
         }
     }
 
+    func testTranscriptAIContextQueriesFindTranscriptContextEntry() throws {
+        let entry = try XCTUnwrap(SettingsSearchIndex.entries.first { $0.id == "ai.transcriptContext" })
+        XCTAssertEqual(entry.cardAnchor, "ai.transcriptContext")
+
+        for query in ["rich transcript", "plain transcript", "speaker labels", "diarization", "meeting context"] {
+            let ids = Set(SettingsSearchIndex.matches(query).map(\.id))
+            XCTAssertTrue(ids.contains("ai.transcriptContext"), "Query \(query) should find Transcript Context for AI")
+        }
+    }
+
     func testAIFormatterSmartDefaultsQueriesFindFormatterEntry() {
         for query in ["smart defaults", "fallback prompt"] {
             let ids = Set(SettingsSearchIndex.matches(query).map(\.id))

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -1725,6 +1725,106 @@ final class TranscriptionViewModelTests: XCTestCase {
                              "Fresh transcribe must still fire auto-run prompts")
     }
 
+    func testAutoRunPromptsUseRichTranscriptContextByDefault() {
+        let suite = "test.transcription.context.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        viewModel = TranscriptionViewModel(defaults: defaults)
+
+        let llm = MockLLMService()
+        llm.streamDelayNs = 1_000_000_000
+        let promptRepo = MockPromptRepository()
+        promptRepo.prompts = Prompt.builtInPrompts()
+        let promptResultsVM = PromptResultsViewModel()
+        promptResultsVM.configure(
+            llmService: llm,
+            promptRepo: promptRepo,
+            promptResultRepo: mockPromptResultRepo
+        )
+        viewModel.configure(
+            transcriptionService: mockService,
+            transcriptionRepo: mockRepo,
+            llmService: llm,
+            promptResultRepo: mockPromptResultRepo,
+            promptResultsViewModel: promptResultsVM
+        )
+        let transcription = Transcription(
+            fileName: "meeting.wav",
+            rawTranscript: "Hello there. Thanks.",
+            cleanTranscript: "Hello there. Thanks.",
+            wordTimestamps: [
+                WordTimestamp(word: "Hello", startMs: 0, endMs: 400, confidence: 0.99, speakerId: "microphone"),
+                WordTimestamp(word: "there.", startMs: 450, endMs: 900, confidence: 0.98, speakerId: "microphone"),
+                WordTimestamp(word: "Thanks.", startMs: 2_000, endMs: 2_400, confidence: 0.97, speakerId: "system")
+            ],
+            speakers: [
+                SpeakerInfo(id: "microphone", label: "Me"),
+                SpeakerInfo(id: "system", label: "Others")
+            ],
+            status: .completed,
+            sourceType: .meeting
+        )
+
+        viewModel.presentCompletedTranscription(transcription, autoSave: false)
+
+        XCTAssertEqual(
+            promptResultsVM.pendingGenerations.first?.transcript,
+            """
+            [0:00] Me: Hello there.
+            [0:02] Others: Thanks.
+            """
+        )
+    }
+
+    func testAutoRunPromptsUsePlainTranscriptContextWhenConfigured() {
+        let suite = "test.transcription.context.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set(
+            TranscriptAIContextMode.plainTranscript.rawValue,
+            forKey: UserDefaultsAppRuntimePreferences.transcriptAIContextModeKey
+        )
+        viewModel = TranscriptionViewModel(defaults: defaults)
+
+        let llm = MockLLMService()
+        llm.streamDelayNs = 1_000_000_000
+        let promptRepo = MockPromptRepository()
+        promptRepo.prompts = Prompt.builtInPrompts()
+        let promptResultsVM = PromptResultsViewModel()
+        promptResultsVM.configure(
+            llmService: llm,
+            promptRepo: promptRepo,
+            promptResultRepo: mockPromptResultRepo
+        )
+        viewModel.configure(
+            transcriptionService: mockService,
+            transcriptionRepo: mockRepo,
+            llmService: llm,
+            promptResultRepo: mockPromptResultRepo,
+            promptResultsViewModel: promptResultsVM
+        )
+        let transcription = Transcription(
+            fileName: "meeting.wav",
+            rawTranscript: "Hello there. Thanks.",
+            cleanTranscript: "Hello there. Thanks.",
+            wordTimestamps: [
+                WordTimestamp(word: "Hello", startMs: 0, endMs: 400, confidence: 0.99, speakerId: "microphone"),
+                WordTimestamp(word: "there.", startMs: 450, endMs: 900, confidence: 0.98, speakerId: "microphone"),
+                WordTimestamp(word: "Thanks.", startMs: 2_000, endMs: 2_400, confidence: 0.97, speakerId: "system")
+            ],
+            speakers: [
+                SpeakerInfo(id: "microphone", label: "Me"),
+                SpeakerInfo(id: "system", label: "Others")
+            ],
+            status: .completed,
+            sourceType: .meeting
+        )
+
+        viewModel.presentCompletedTranscription(transcription, autoSave: false)
+
+        XCTAssertEqual(promptResultsVM.pendingGenerations.first?.transcript, "Hello there. Thanks.")
+    }
+
     func testRetranscribeFailureLeavesOriginalIntact() async throws {
         let tmpFile = FileManager.default.temporaryDirectory.appendingPathComponent("retranscribe-fail-test.mp3")
         FileManager.default.createFile(atPath: tmpFile.path, contents: Data([0]))

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -612,6 +612,8 @@ final class MockLLMService: LLMServiceProtocol, @unchecked Sendable {
     var chatCallCount = 0
     var formatTranscriptCallCount = 0
     var lastChatQuestion: String?
+    var lastSummaryTranscript: String?
+    var lastChatTranscript: String?
     var lastChatHistory: [ChatMessage]?
     var lastChatUserNotes: String?
     var lastChatSource: TelemetryChatSource?
@@ -623,6 +625,7 @@ final class MockLLMService: LLMServiceProtocol, @unchecked Sendable {
 
     func generatePromptResult(transcript: String, systemPrompt: String?) async throws -> String {
         summarizeCallCount += 1
+        lastSummaryTranscript = transcript
         lastSummarySystemPrompt = systemPrompt
         if let error = errorToThrow { throw error }
         return summarizeResult
@@ -630,6 +633,9 @@ final class MockLLMService: LLMServiceProtocol, @unchecked Sendable {
 
     func chat(question: String, transcript: String, userNotes: String?, history: [ChatMessage], source: TelemetryChatSource) async throws -> String {
         chatCallCount += 1
+        lastChatQuestion = question
+        lastChatTranscript = transcript
+        lastChatHistory = history
         lastChatUserNotes = userNotes
         lastChatSource = source
         if let error = errorToThrow { throw error }
@@ -702,6 +708,7 @@ final class MockLLMService: LLMServiceProtocol, @unchecked Sendable {
 
     func generatePromptResultStream(transcript: String, systemPrompt: String?) -> AsyncThrowingStream<String, Error> {
         summarizeCallCount += 1
+        lastSummaryTranscript = transcript
         lastSummarySystemPrompt = systemPrompt
         let tokens: [String]
         if streamTokenBatches.isEmpty {
@@ -733,6 +740,7 @@ final class MockLLMService: LLMServiceProtocol, @unchecked Sendable {
     func chatStream(question: String, transcript: String, userNotes: String?, history: [ChatMessage], source: TelemetryChatSource) -> AsyncThrowingStream<String, Error> {
         chatCallCount += 1
         lastChatQuestion = question
+        lastChatTranscript = transcript
         lastChatHistory = history
         lastChatUserNotes = userNotes
         lastChatSource = source


### PR DESCRIPTION
## Summary
- Adds a new AI setting: Rich transcript (default) or Plain transcript.
- Rich transcript sends timestamps and available speaker labels to summaries, transcript chat, and live Meeting Ask.
- Plain transcript keeps the older flat-text behavior for users who do not want timing or speaker context sent to their AI provider.

## Why
Meeting transcripts already preserve timing and rough speaker labels in the transcript/export UI, but AI summaries and chat were receiving only flat text. That made meeting summaries, action items, and follow-up questions lose useful context.

## How it works

```text
Meeting or transcript with word timestamps
        |
        v
TranscriptCueBuilder
        |
        +--> Rich transcript: [0:05] Me: ...
        |
        +--> Plain transcript: flat transcript text
        |
        v
Summaries, transcript chat, and Meeting Ask
```

## Notes
- Speaker labels are a rough reference from audio-source separation and diarization; they are not a high-accuracy identification of who said each line.
- Edited transcripts use the edited text so AI does not receive stale timestamp/speaker alignment.

## Verification
- `swift test --filter 'LLMSettingsViewModelTests/testAIFormatterEnabledForDictationPersistsThroughInjectedDefaults|LLMSettingsViewModelTests/testTranscriptAIContextModePersistsThroughInjectedDefaults|MeetingRecordingPanelViewModelTests/testChatTranscriptCanUseRichPreviewContext|MeetingRecordingPanelViewModelTests/testChatTranscriptCanUsePlainPreviewContext'`
- `swift test`

Fixes #431
Fixes #393
