### PR TITLE
Gate dictation multi-select behind an explicit bulk mode

### DIFF
--- a/Sources/MacParakeet/Views/History/DictationHistoryView.swift
+++ b/Sources/MacParakeet/Views/History/DictationHistoryView.swift
@@ -58,14 +58,6 @@ struct DictationHistoryView: View {
         } message: {
             Text(deleteAlertMessage)
         }
-        .onDisappear {
-            // The view model is a process-lifetime singleton and the Dictations
-            // tab is conditionally mounted, so bulk-selection state would
-            // otherwise survive navigating to another section and back. Tear it
-            // down on the way out so the user always returns to ordinary
-            // browsing.
-            viewModel.exitBulkSelection()
-        }
     }
 
     // MARK: - Sub-tab Picker

--- a/Sources/MacParakeet/Views/History/DictationHistoryView.swift
+++ b/Sources/MacParakeet/Views/History/DictationHistoryView.swift
@@ -58,6 +58,14 @@ struct DictationHistoryView: View {
         } message: {
             Text(deleteAlertMessage)
         }
+        .onDisappear {
+            // The view model is a process-lifetime singleton and the Dictations
+            // tab is conditionally mounted, so bulk-selection state would
+            // otherwise survive navigating to another section and back. Tear it
+            // down on the way out so the user always returns to ordinary
+            // browsing.
+            viewModel.exitBulkSelection()
+        }
     }
 
     // MARK: - Sub-tab Picker
@@ -80,13 +88,13 @@ struct DictationHistoryView: View {
             emptyState
         } else {
             VStack(spacing: 0) {
-                if viewModel.hasSelectedDictations {
+                if viewModel.isBulkSelectionModeEnabled {
                     selectedActionsBar
                         .transition(.move(edge: .top).combined(with: .opacity))
                 }
                 dictationList
             }
-            .animation(DesignSystem.Animation.contentSwap, value: viewModel.hasSelectedDictations)
+            .animation(DesignSystem.Animation.contentSwap, value: viewModel.isBulkSelectionModeEnabled)
         }
     }
 
@@ -148,6 +156,7 @@ struct DictationHistoryView: View {
                             isPlayingThis: viewModel.playingDictationId == dictation.id && viewModel.isPlaying,
                             isCopied: viewModel.copiedDictationId == dictation.id,
                             isSelected: viewModel.isDictationSelected(dictation),
+                            showsSelectionControls: viewModel.isBulkSelectionModeEnabled,
                             onToggleSelection: { viewModel.toggleSelection(for: dictation) },
                             onTogglePlayback: { viewModel.togglePlayback(for: dictation) },
                             onCopy: {
@@ -157,7 +166,8 @@ struct DictationHistoryView: View {
                                 viewModel.pendingDeleteDictation = dictation
                             },
                             onDownloadAudio: { viewModel.downloadAudio(for: dictation) },
-                            onToggleAIEdit: { viewModel.toggleDisplayRawTranscript(for: dictation) }
+                            onToggleAIEdit: { viewModel.toggleDisplayRawTranscript(for: dictation) },
+                            onBeginBulkSelection: { viewModel.beginBulkSelection(startingWith: dictation) }
                         )
                         .padding(.horizontal, DesignSystem.Spacing.lg)
                         .padding(.bottom, DesignSystem.Spacing.sm)
@@ -181,6 +191,13 @@ struct DictationHistoryView: View {
             Spacer(minLength: DesignSystem.Spacing.md)
 
             Button {
+                viewModel.exitBulkSelection()
+            } label: {
+                Text("Cancel")
+            }
+            .parakeetAction(.subtle)
+
+            Button {
                 viewModel.selectAllVisibleDictations()
             } label: {
                 Label("Select All", systemImage: "checkmark.circle")
@@ -193,6 +210,7 @@ struct DictationHistoryView: View {
             } label: {
                 Label("Clear", systemImage: "xmark.circle")
             }
+            .disabled(!viewModel.hasSelectedDictations)
             .parakeetAction(.secondary)
 
             Button(role: .destructive) {
@@ -200,6 +218,7 @@ struct DictationHistoryView: View {
             } label: {
                 Label("Delete", systemImage: "trash")
             }
+            .disabled(!viewModel.hasSelectedDictations)
             .parakeetAction(.destructive)
         }
         .padding(.horizontal, DesignSystem.Spacing.lg)
@@ -313,20 +332,27 @@ struct DictationCardRow: View {
     var isPlayingThis: Bool = false
     var isCopied: Bool = false
     var isSelected: Bool = false
+    /// Whether the leading per-row selection circle is shown. Only true while
+    /// the History list is in bulk-selection mode; hidden during ordinary
+    /// browsing so a row doesn't look like a selection target.
+    var showsSelectionControls: Bool = false
     var onToggleSelection: (() -> Void)?
     var onTogglePlayback: (() -> Void)?
     var onCopy: () -> Void
     var onDelete: () -> Void
     var onDownloadAudio: (() -> Void)?
     var onToggleAIEdit: (() -> Void)?
+    var onBeginBulkSelection: (() -> Void)?
 
     @State private var isHovered = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
             HStack(spacing: DesignSystem.Spacing.md) {
-                SelectionToggleButton(isSelected: isSelected) {
-                    onToggleSelection?()
+                if showsSelectionControls {
+                    SelectionToggleButton(isSelected: isSelected) {
+                        onToggleSelection?()
+                    }
                 }
 
                 SonicMandalaView(
@@ -409,9 +435,11 @@ struct DictationCardRow: View {
                         hasAudio: dictation.audioPath != nil,
                         hasAIEdit: dictation.hasAIEdit && onToggleAIEdit != nil,
                         isShowingRaw: dictation.displayRawTranscript,
+                        showsBulkSelectionEntry: !showsSelectionControls && onBeginBulkSelection != nil,
                         onDownloadAudio: { onDownloadAudio?() },
                         onDelete: { onDelete() },
-                        onToggleAIEdit: onToggleAIEdit
+                        onToggleAIEdit: onToggleAIEdit,
+                        onBeginBulkSelection: { onBeginBulkSelection?() }
                     )
                 }
             }
@@ -575,9 +603,11 @@ private struct CardMenuButton: View {
     let hasAudio: Bool
     let hasAIEdit: Bool
     let isShowingRaw: Bool
+    let showsBulkSelectionEntry: Bool
     let onDownloadAudio: () -> Void
     let onDelete: () -> Void
     let onToggleAIEdit: (() -> Void)?
+    let onBeginBulkSelection: () -> Void
 
     var body: some View {
         CardActionButton(icon: "ellipsis", color: .secondary) {
@@ -600,6 +630,13 @@ private struct CardMenuButton: View {
             let title = isShowingRaw ? "Re-apply AI edit" : "Undo AI edit"
             let icon = isShowingRaw ? "wand.and.stars" : "arrow.uturn.backward"
             menu.addItem(CallbackMenuItem(title: title, icon: icon, action: onToggleAIEdit))
+        }
+
+        // Neutral entry into bulk-selection mode. Hidden once the user is
+        // already in bulk mode (it would be redundant). Named to read as a
+        // non-destructive selection gesture, not a delete.
+        if showsBulkSelectionEntry {
+            menu.addItem(CallbackMenuItem(title: "Select Multiple…", icon: "checklist", action: onBeginBulkSelection))
         }
 
         if !menu.items.isEmpty {

--- a/Sources/MacParakeet/Views/MainWindowView.swift
+++ b/Sources/MacParakeet/Views/MainWindowView.swift
@@ -298,6 +298,17 @@ struct MainWindowView: View {
                 state.selectedItem = .library
             }
         }
+        .onChange(of: state.selectedItem) { _, newItem in
+            // Bulk-selection mode is a History-only affordance living on a
+            // process-lifetime singleton, so tear it down at the navigation
+            // boundary when the user leaves the Dictations section. Handled here
+            // rather than via `DictationHistoryView.onDisappear`, which can fire
+            // on transient macOS view-lifecycle events and reset an active
+            // selection mid-browse.
+            if newItem != .dictations {
+                historyViewModel.exitBulkSelection()
+            }
+        }
     }
 
     /// Show the global bottom bar when transcribing on any tab except Transcribe (which has its own detailed view)

--- a/Sources/MacParakeetViewModels/DictationHistoryViewModel.swift
+++ b/Sources/MacParakeetViewModels/DictationHistoryViewModel.swift
@@ -258,10 +258,12 @@ public final class DictationHistoryViewModel {
         let selectedDictations = pendingDeleteSelectedDictations
         pendingDeleteSelectedDictations = []
         guard !selectedDictations.isEmpty else { return }
-        // A confirmed bulk delete is a deliberate end to the bulk workflow, so
-        // exit the mode and return the list to ordinary browsing. The selected
-        // IDs are cleared by `deleteDictations` as it prunes the deleted rows.
-        isBulkSelectionModeEnabled = false
+        // A confirmed bulk delete is a deliberate end to the bulk workflow. Tear
+        // the mode down through the single exit path so the cleanup is explicit
+        // and self-contained — `exitBulkSelection` clears the live selection
+        // unconditionally, while the rows to delete are held in the local
+        // snapshot, so deletion is unaffected.
+        exitBulkSelection()
         deleteDictations(selectedDictations)
     }
 

--- a/Sources/MacParakeetViewModels/DictationHistoryViewModel.swift
+++ b/Sources/MacParakeetViewModels/DictationHistoryViewModel.swift
@@ -59,6 +59,13 @@ public final class DictationHistoryViewModel {
 
     public var selectedSubTab: SubTab = .history {
         didSet {
+            // Selection is a History-only affordance; leaving the History
+            // sub-tab tears down any active bulk-selection mode. Keyed off
+            // "not History" rather than "== .stats" so a future third sub-tab
+            // can't silently strand the user in bulk mode.
+            if selectedSubTab != .history {
+                exitBulkSelection()
+            }
             if selectedSubTab == .stats {
                 refreshStatsTabData()
             }
@@ -95,6 +102,13 @@ public final class DictationHistoryViewModel {
     // MARK: - Selection
 
     public var selectedDictationIDs: Set<UUID> = []
+
+    /// When true, the History list shows per-row selection controls and the
+    /// bulk action bar. Bulk selection is a deliberate mode the user enters
+    /// from a row's ellipsis menu — selection chrome stays hidden during
+    /// ordinary browsing. Exited on confirmed bulk delete, Cancel, leaving the
+    /// History sub-tab, or leaving the Dictations section.
+    public var isBulkSelectionModeEnabled = false
 
     public var selectedDictationCount: Int {
         selectedDictationIDs.count
@@ -212,7 +226,22 @@ public final class DictationHistoryViewModel {
         selectedDictationIDs = visibleDictationIDs
     }
 
+    /// Empty the selection without leaving bulk mode, so the user can clear and
+    /// reselect without reopening the menu. Distinct from `exitBulkSelection()`,
+    /// which also tears down the mode.
     public func clearSelection() {
+        selectedDictationIDs = []
+    }
+
+    /// Enter bulk-selection mode, preselecting the row the user invoked it from.
+    public func beginBulkSelection(startingWith dictation: Dictation) {
+        isBulkSelectionModeEnabled = true
+        selectedDictationIDs.insert(dictation.id)
+    }
+
+    /// Leave bulk-selection mode and drop any selection.
+    public func exitBulkSelection() {
+        isBulkSelectionModeEnabled = false
         selectedDictationIDs = []
     }
 
@@ -229,6 +258,10 @@ public final class DictationHistoryViewModel {
         let selectedDictations = pendingDeleteSelectedDictations
         pendingDeleteSelectedDictations = []
         guard !selectedDictations.isEmpty else { return }
+        // A confirmed bulk delete is a deliberate end to the bulk workflow, so
+        // exit the mode and return the list to ordinary browsing. The selected
+        // IDs are cleared by `deleteDictations` as it prunes the deleted rows.
+        isBulkSelectionModeEnabled = false
         deleteDictations(selectedDictations)
     }
 

--- a/Tests/MacParakeetTests/ViewModels/DictationHistoryViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/DictationHistoryViewModelTests.swift
@@ -255,6 +255,108 @@ final class DictationHistoryViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.groupedDictations.flatMap(\.1).first?.id, remaining.id)
     }
 
+    // MARK: - Bulk Selection Mode
+
+    func testBeginBulkSelectionEnablesModeAndPreselectsStartingDictation() {
+        let dictation = Dictation(durationMs: 1000, rawTranscript: "Start here")
+        mockRepo.dictations = [dictation]
+        viewModel.configure(dictationRepo: mockRepo)
+
+        viewModel.beginBulkSelection(startingWith: dictation)
+
+        XCTAssertTrue(viewModel.isBulkSelectionModeEnabled)
+        XCTAssertEqual(viewModel.selectedDictationCount, 1)
+        XCTAssertTrue(viewModel.isDictationSelected(dictation))
+    }
+
+    func testExitBulkSelectionClearsModeAndSelection() {
+        let dictation = Dictation(durationMs: 1000, rawTranscript: "Start here")
+        mockRepo.dictations = [dictation]
+        viewModel.configure(dictationRepo: mockRepo)
+        viewModel.beginBulkSelection(startingWith: dictation)
+
+        viewModel.exitBulkSelection()
+
+        XCTAssertFalse(viewModel.isBulkSelectionModeEnabled)
+        XCTAssertTrue(viewModel.selectedDictationIDs.isEmpty)
+    }
+
+    func testClearSelectionKeepsBulkSelectionModeActive() {
+        let first = Dictation(durationMs: 1000, rawTranscript: "First")
+        let second = Dictation(durationMs: 1000, rawTranscript: "Second")
+        mockRepo.dictations = [first, second]
+        viewModel.configure(dictationRepo: mockRepo)
+        viewModel.beginBulkSelection(startingWith: first)
+        viewModel.toggleSelection(for: second)
+        XCTAssertEqual(viewModel.selectedDictationCount, 2)
+
+        viewModel.clearSelection()
+
+        XCTAssertEqual(viewModel.selectedDictationCount, 0)
+        XCTAssertTrue(viewModel.isBulkSelectionModeEnabled, "Clear deselects without leaving bulk mode")
+    }
+
+    func testCancelPendingSelectedDeletePreservesBulkSelectionMode() {
+        let first = Dictation(durationMs: 1000, rawTranscript: "First")
+        let second = Dictation(durationMs: 1000, rawTranscript: "Second")
+        mockRepo.dictations = [first, second]
+        viewModel.configure(dictationRepo: mockRepo)
+        viewModel.beginBulkSelection(startingWith: first)
+        viewModel.toggleSelection(for: second)
+        viewModel.requestDeleteSelectedDictations()
+        XCTAssertEqual(viewModel.pendingDeleteCount, 2)
+
+        viewModel.cancelPendingDelete()
+
+        XCTAssertTrue(viewModel.isBulkSelectionModeEnabled, "Canceling the alert keeps bulk mode")
+        XCTAssertEqual(viewModel.selectedDictationCount, 2, "Canceling keeps the selection for further editing")
+        XCTAssertEqual(viewModel.pendingDeleteCount, 0)
+    }
+
+    func testConfirmDeleteSelectedDictationsExitsBulkSelectionMode() {
+        let first = Dictation(durationMs: 1000, rawTranscript: "First")
+        let second = Dictation(durationMs: 1000, rawTranscript: "Second")
+        mockRepo.dictations = [first, second]
+        viewModel.configure(dictationRepo: mockRepo)
+        viewModel.beginBulkSelection(startingWith: first)
+        viewModel.toggleSelection(for: second)
+        viewModel.requestDeleteSelectedDictations()
+
+        viewModel.confirmDeleteSelectedDictations()
+
+        // Mode flips synchronously on confirm, before the async delete pipeline
+        // runs, so we assert it without awaiting the list update.
+        XCTAssertFalse(viewModel.isBulkSelectionModeEnabled, "Confirmed bulk delete leaves bulk mode")
+    }
+
+    func testSingleRowDeleteFromMenuKeepsBulkSelectionMode() {
+        let first = Dictation(durationMs: 1000, rawTranscript: "First")
+        let second = Dictation(durationMs: 1000, rawTranscript: "Second")
+        mockRepo.dictations = [first, second]
+        viewModel.configure(dictationRepo: mockRepo)
+        viewModel.beginBulkSelection(startingWith: first)
+
+        // A per-row "Delete" from the ellipsis menu routes through the single
+        // pending-delete path, which intentionally stays in bulk mode.
+        viewModel.pendingDeleteDictation = second
+        viewModel.confirmPendingDelete()
+
+        XCTAssertTrue(viewModel.isBulkSelectionModeEnabled, "Single-row delete does not exit bulk mode")
+    }
+
+    func testSwitchingToStatsExitsBulkSelectionMode() {
+        let dictation = Dictation(durationMs: 1000, rawTranscript: "Start here")
+        mockRepo.dictations = [dictation]
+        viewModel.configure(dictationRepo: mockRepo)
+        viewModel.beginBulkSelection(startingWith: dictation)
+        XCTAssertTrue(viewModel.isBulkSelectionModeEnabled)
+
+        viewModel.selectedSubTab = .stats
+
+        XCTAssertFalse(viewModel.isBulkSelectionModeEnabled, "Selection is a History-only affordance")
+        XCTAssertEqual(viewModel.selectedDictationCount, 0)
+    }
+
     // MARK: - Unconfigured
 
     func testLoadDictationsBeforeConfigureIsNoOp() {

--- a/docs/plans/2026-06-06-001-dictation-bulk-select-mode-handoff.md
+++ b/docs/plans/2026-06-06-001-dictation-bulk-select-mode-handoff.md
@@ -1,0 +1,362 @@
+---
+title: "fix: Gate dictation multi-select behind bulk mode"
+type: fix
+status: active
+date: 2026-06-06
+origin: "Issue #425 / PR #445 product review"
+---
+
+# Dictation Bulk-Select Mode Handoff
+
+## Context
+
+Current `main` includes PR #445, `[codex] Add multi-select dictation cleanup`,
+which implemented issue #425: "Allow multi-select when cleaning up dictations."
+The mechanics are sound: selected IDs are tracked in
+`DictationHistoryViewModel`, pending multi-delete stores `Dictation` snapshots,
+delete work runs off the main actor, and tests cover selection, pruning,
+snapshot stability, and batch delete.
+
+The product review found a UX mismatch. The current UI always renders a radio-
+style selection circle on every dictation row. That makes ordinary history
+browsing feel like a selection workflow, even though bulk selection is only
+needed for cleanup.
+
+Desired product direction: selection controls should be hidden by default.
+Users should enter a deliberate bulk-selection mode from the row ellipsis menu,
+then select/delete multiple dictations from that mode.
+
+## Current Evidence
+
+- Current branch during review: `main` at `5e0b7ad2`.
+- Merged PR: https://github.com/moona3k/macparakeet/pull/445
+- Source issue: https://github.com/moona3k/macparakeet/issues/425
+- Post-merge follow-up: `3a344c45` fixed alert-copy flicker and the fragile
+  async test helper.
+- Verification already run after review:
+  - `swift test --filter DictationHistoryViewModelTests`
+  - `swift test`
+- Full-suite result: 3306 XCTest tests, 10 hardware-gated skips, 0 failures,
+  plus 16 Swift Testing tests passed.
+
+## Problem
+
+The implementation currently has selection state but no explicit selection
+mode:
+
+- `Sources/MacParakeetViewModels/DictationHistoryViewModel.swift`
+  - `selectedDictationIDs` is the only mode signal.
+  - `hasSelectedDictations` controls whether the selected-actions bar appears.
+- `Sources/MacParakeet/Views/History/DictationHistoryView.swift`
+  - `SelectionToggleButton` is always rendered in `DictationCardRow`.
+  - The selected-actions bar appears only after a row has already been selected.
+  - `CardMenuButton` only exposes row actions: export audio, AI edit toggle,
+    and delete.
+
+This is technically coherent, but it overexposes bulk-cleanup UI in the default
+history view.
+
+## Lifecycle Constraint (important)
+
+`historyViewModel` is a **process-lifetime singleton** owned by `AppDelegate`
+(`Sources/MacParakeet/AppDelegate.swift`), and the Dictations tab is mounted
+conditionally — `case .dictations: DictationHistoryView(viewModel: historyViewModel)`
+in `MainWindowView.swift`. There is no `onAppear`/`loadDictations` reset when the
+view re-appears.
+
+Consequence: any "selection mode" state on the view model survives the user
+navigating away from the Dictations section entirely (to Settings, Transcribe,
+etc.) and back. So bulk mode must be exited on **two** boundaries, not one:
+the History↔Stats sub-tab switch *and* leaving the Dictations section. Missing
+the second leaves the user staring at a stale bulk-selection view on return.
+
+## Desired Behavior
+
+Default history browsing:
+
+- No selection circles on rows.
+- Existing row actions remain: play, copy, ellipsis menu.
+- Single-row delete remains available from the ellipsis menu.
+
+Entering bulk mode:
+
+- The row ellipsis menu gets a neutral item: `Select Multiple...`.
+- Choosing it enters bulk-selection mode and preselects that row.
+- Only in bulk-selection mode do row selection circles render.
+- The selected-actions bar renders because bulk mode is active, not because the
+  selected count is nonzero.
+- Once in bulk mode, the per-row `Select Multiple...` item is hidden (it is
+  redundant). Single-row delete / export / AI-edit toggle remain available.
+
+Bulk mode action bar:
+
+- Shows `N selected`.
+- Includes `Select All`, `Clear`, `Cancel`, and destructive `Delete`.
+- `Delete` is disabled when `N == 0`.
+- `Clear` is disabled when `N == 0`.
+- `Cancel` exits bulk mode and clears selection.
+- `Delete` uses the existing confirmation dialog and existing delete semantics.
+
+Leaving bulk mode (all four paths):
+
+- Confirmed delete exits bulk mode and clears selected IDs.
+- Canceling the delete confirmation keeps bulk mode and the current selection,
+  so the user can adjust the selection.
+- Switching from the History sub-tab to Stats exits bulk mode and clears
+  selection.
+- Navigating away from the Dictations section exits bulk mode and clears
+  selection (see Lifecycle Constraint).
+
+## Recommended Implementation
+
+### Unit 1 - Add Explicit Selection Mode to the View Model
+
+File:
+
+- `Sources/MacParakeetViewModels/DictationHistoryViewModel.swift`
+
+Add explicit state:
+
+- `public var isBulkSelectionModeEnabled = false`
+
+Add methods, keeping names local-style and small:
+
+- `beginBulkSelection(startingWith dictation: Dictation)`
+  - Sets `isBulkSelectionModeEnabled = true`.
+  - Inserts the starting row ID into `selectedDictationIDs`.
+- `exitBulkSelection()`
+  - Sets `isBulkSelectionModeEnabled = false`.
+  - Clears `selectedDictationIDs`.
+
+Leave `clearSelection()` exactly as-is — it empties `selectedDictationIDs` and
+must **not** touch mode (so the bulk bar's `Clear` deselects without exiting).
+`exitBulkSelection()` is the separate "leave the mode" path. Do not overload
+`clearSelection`.
+
+Reuse `hasSelectedDictations` for the bar's disabled states; do not add a new
+`canDelete...` computed property — it would just duplicate `hasSelectedDictations`.
+
+Adjust delete flow:
+
+- `requestDeleteSelectedDictations()` keeps its snapshot behavior.
+- `confirmDeleteSelectedDictations()` exits bulk mode after the empty-guard
+  passes (only when a delete actually happens):
+
+  ```swift
+  public func confirmDeleteSelectedDictations() {
+      let selectedDictations = pendingDeleteSelectedDictations
+      pendingDeleteSelectedDictations = []
+      guard !selectedDictations.isEmpty else { return }
+      isBulkSelectionModeEnabled = false      // <- exit only on real delete
+      deleteDictations(selectedDictations)
+  }
+  ```
+
+  The mode flip is synchronous; selection is cleared by the existing
+  `selectedDictationIDs.subtract(ids)` in the delete path.
+- `cancelPendingDelete()` must NOT exit bulk mode and must NOT clear
+  `selectedDictationIDs` (it already only clears the pending snapshot) — canceling
+  an alert should let the user keep editing the selection. No change needed there.
+
+Adjust tab behavior:
+
+- In the `selectedSubTab` `didSet`, exit bulk selection whenever the tab is no
+  longer History (`selectedSubTab != .history`), not specifically `== .stats`.
+  Selection is a History-only affordance, and keying off "not History" is robust
+  to a future third sub-tab.
+
+Keep existing safeguards:
+
+- Do not remove `pendingDeleteSelectedDictations` snapshot behavior.
+- Do not move disk/database delete work back onto the main actor.
+- Do not regress playback stop when deleting the currently playing dictation.
+
+No telemetry event is added for entering bulk mode or bulk delete. This is
+deliberate scoping: a new `TelemetryEventName` case requires a companion
+allowlist update in the website Worker (which rejects the whole batch on unknown
+events), and the existing per-row delete already emits `dictationDeleted`. A
+usage-signal event can be a follow-up if needed.
+
+### Unit 2 - Hide Row Selectors Until Bulk Mode
+
+File:
+
+- `Sources/MacParakeet/Views/History/DictationHistoryView.swift`
+
+At the call site for `DictationCardRow`, pass a new flag:
+
+- `showsSelectionControls: viewModel.isBulkSelectionModeEnabled`
+
+In `DictationCardRow`:
+
+- Add `var showsSelectionControls: Bool = false` (default keeps the type usable
+  without the flag).
+- Render `SelectionToggleButton` only when `showsSelectionControls` is true.
+- When false, row content starts where it did before PR #445: mandala,
+  timestamp metadata, actions, transcript.
+- Selected-row tint/stroke (`cardFill`/`cardStroke`) key off `isSelected` and are
+  automatically inert outside bulk mode (exiting clears selection), so no extra
+  guard is required there.
+
+### Unit 3 - Add Bulk Entry to the Ellipsis Menu
+
+File:
+
+- `Sources/MacParakeet/Views/History/DictationHistoryView.swift`
+
+Extend `CardMenuButton`:
+
+- Add `showsBulkSelectionEntry: Bool` and `onBeginBulkSelection: () -> Void`.
+- Add a neutral menu item named `Select Multiple...`, shown only when
+  `showsBulkSelectionEntry` is true (i.e. not already in bulk mode).
+- Use a non-destructive icon such as `checklist`.
+- The menu action only enters mode and preselects the row. It does not delete.
+
+In `DictationCardRow`, pass `showsBulkSelectionEntry: !showsSelectionControls`
+and forward an `onBeginBulkSelection` closure (call site wires it to
+`viewModel.beginBulkSelection(startingWith: dictation)`).
+
+Recommended menu order:
+
+1. Row-specific non-destructive actions (`Export Audio`, `Undo AI edit` /
+   `Re-apply AI edit`).
+2. `Select Multiple...` (only when not in bulk mode).
+3. Separator.
+4. Destructive `Delete`.
+
+Avoid naming the menu item `Bulk Delete...`: it sounds destructive, but the
+first action only enters selection mode.
+
+### Unit 4 - Make the Action Bar Mode-Based
+
+File:
+
+- `Sources/MacParakeet/Views/History/DictationHistoryView.swift`
+
+Change the action bar condition:
+
+- From `if viewModel.hasSelectedDictations`
+- To `if viewModel.isBulkSelectionModeEnabled`
+
+Also retarget the bar's appear/disappear animation trigger (the
+`.animation(..., value:)` modifier on the History content `VStack`) from
+`viewModel.hasSelectedDictations` to `viewModel.isBulkSelectionModeEnabled`, so
+the bar animates on mode enter/exit (e.g. Cancel after the user has cleared all
+rows, where `hasSelectedDictations` would not change).
+
+Update the bar actions:
+
+- `Select All`: calls `selectAllVisibleDictations()`, disabled when all visible
+  rows are already selected (unchanged).
+- `Clear`: calls `clearSelection()`, disabled when no selected rows.
+- `Cancel`: calls `exitBulkSelection()` (subtle/low-emphasis styling).
+- `Delete`: calls `requestDeleteSelectedDictations()`, disabled when no
+  selected rows.
+
+Keep the selected count visible even at zero, because a zero-selection state is
+valid while the user is in bulk mode and has cleared all rows.
+
+### Unit 5 - Exit Bulk Mode When Leaving the Dictations Section
+
+File:
+
+- `Sources/MacParakeet/Views/History/DictationHistoryView.swift`
+
+Add `.onDisappear { viewModel.exitBulkSelection() }` to the top-level body of
+`DictationHistoryView`. Because the view model is a long-lived singleton and the
+Dictations tab is conditionally mounted (see Lifecycle Constraint), this is the
+hook that fires when the user navigates to another top-level section. Verify in
+the manual smoke test that switching top-level sections clears bulk mode on
+return. (This also retroactively fixes the pre-existing wart where a raw
+selection from PR #445 survived top-level navigation.)
+
+### Unit 6 - Tests
+
+File:
+
+- `Tests/MacParakeetTests/ViewModels/DictationHistoryViewModelTests.swift`
+
+Add focused tests (the mode flips are synchronous, so these assert directly
+without `await` except where the async delete pipeline is involved):
+
+- `testBeginBulkSelectionEnablesModeAndPreselectsStartingDictation`
+  - Mode is enabled and selected count is 1 with the starting row's ID.
+- `testExitBulkSelectionClearsModeAndSelection`
+  - Mode false and selected IDs empty.
+- `testClearSelectionKeepsBulkSelectionModeActive`
+  - Supports the user clearing and reselecting without reopening the menu.
+- `testCancelPendingSelectedDeletePreservesBulkSelectionMode`
+  - User cancels confirmation, keeps mode and the existing selection.
+- `testConfirmDeleteSelectedDictationsExitsBulkSelectionMode`
+  - Mode flips false synchronously on confirm (assert before the async delete
+    resolves).
+- `testSingleRowDeleteFromMenuKeepsBulkSelectionMode`
+  - A per-row pending delete (`pendingDeleteDictation` + `confirmDelete()`) inside
+    bulk mode does not exit the mode.
+- `testSwitchingToStatsExitsBulkSelectionMode`
+  - Selection UI is History-only.
+
+Existing tests to preserve:
+
+- Selection toggling.
+- Select-all uses current visible/search results.
+- Search reload prunes selected IDs.
+- Pending selected delete stores row snapshots across search reload.
+- Batch delete removes multiple rows and clears selection.
+- Deleting the playing dictation stops playback.
+
+## Acceptance Criteria
+
+- Default History list has no left-side selection circles.
+- Opening a row ellipsis menu exposes `Select Multiple...`.
+- Choosing `Select Multiple...` shows row selection circles, preselects that
+  row, and shows the bulk action bar.
+- In bulk mode, the per-row ellipsis no longer offers `Select Multiple...`.
+- Bulk delete still requires the existing confirmation dialog.
+- Canceling the delete confirmation preserves bulk mode and selection.
+- Confirming delete exits bulk mode after deletion is accepted.
+- Switching to the Stats sub-tab exits bulk mode.
+- Navigating away from the Dictations section and back shows the default
+  (non-selection) view.
+- Single-row delete from the ellipsis menu still works.
+- Audio export, copy, playback, and AI edit toggle behavior do not regress.
+
+## Verification
+
+Run:
+
+```bash
+swift test --filter DictationHistoryViewModelTests
+swift test
+git diff --check
+```
+
+Manual smoke with the app is recommended because this is a visual/interaction
+polish change:
+
+```bash
+scripts/dev/run_app.sh
+```
+
+Smoke steps:
+
+1. Open Dictations history.
+2. Confirm default rows have no selection circles.
+3. Open a row ellipsis menu and choose `Select Multiple...`.
+4. Confirm the chosen row is selected and selection circles appear.
+5. Confirm the ellipsis menu no longer shows `Select Multiple...` while in mode.
+6. Select/deselect several rows.
+7. Clear selection and confirm bulk mode remains active (bar still visible,
+   `0 selected`, Delete/Clear disabled).
+8. Cancel bulk mode and confirm circles disappear.
+9. Re-enter bulk mode, switch to Stats and back — confirm bulk mode is gone.
+10. Re-enter bulk mode, navigate to Settings and back to Dictations — confirm
+    bulk mode is gone.
+11. Re-enter bulk mode and delete multiple rows through confirmation.
+
+## Suggested Skills For Next Agent
+
+- `compound-engineering:ce-work` for implementation.
+- `compound-engineering:ce-code-review` after the change.
+- `browser-use` or app screenshot tooling only if visual verification is needed
+  beyond `scripts/dev/run_app.sh`.

--- a/docs/plans/2026-06-06-001-dictation-bulk-select-mode-handoff.md
+++ b/docs/plans/2026-06-06-001-dictation-bulk-select-mode-handoff.md
@@ -260,15 +260,20 @@ valid while the user is in bulk mode and has cleared all rows.
 
 File:
 
-- `Sources/MacParakeet/Views/History/DictationHistoryView.swift`
+- `Sources/MacParakeet/Views/MainWindowView.swift`
 
-Add `.onDisappear { viewModel.exitBulkSelection() }` to the top-level body of
-`DictationHistoryView`. Because the view model is a long-lived singleton and the
-Dictations tab is conditionally mounted (see Lifecycle Constraint), this is the
-hook that fires when the user navigates to another top-level section. Verify in
-the manual smoke test that switching top-level sections clears bulk mode on
-return. (This also retroactively fixes the pre-existing wart where a raw
-selection from PR #445 survived top-level navigation.)
+Add `.onChange(of: state.selectedItem)` to the `MainWindowView` body, calling
+`historyViewModel.exitBulkSelection()` whenever `newItem != .dictations`. Because
+the view model is a long-lived singleton and the Dictations tab is conditionally
+mounted (see Lifecycle Constraint), bulk mode would otherwise survive navigating
+to another top-level section and back.
+
+Handle this at the navigation boundary in the parent rather than via
+`DictationHistoryView.onDisappear`: on macOS, `onDisappear` can fire during
+transient view-lifecycle events (window resize, parent re-render) and reset an
+active selection while the user is still browsing. `onChange(of: selectedItem)`
+fires only on actual navigation. (This also retroactively fixes the pre-existing
+wart where a raw selection from PR #445 survived top-level navigation.)
 
 ### Unit 6 - Tests
 

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -568,14 +568,14 @@ The app lives primarily in the menu bar. Click the icon for quick actions, or op
 - Full-width flat chronological list (no split pane, no detail view)
 - Grouped by date (Today, Yesterday, specific dates)
 - Each entry shows: time, duration, full transcript text (no line limit)
-- Hover actions: Play/Pause, Copy (with checkmark confirmation), three-dot menu (Download Audio, Delete)
+- Hover actions: Play/Pause, Copy (with checkmark confirmation), three-dot menu (Download Audio, Select Multiple…, Delete)
 - Currently-playing row has subtle accent tint background
 - Bottom bar audio player (Spotify-style): play/pause, transcript snippet, progress bar, time, close
 - Search bar filters by transcript content (substring match, case-insensitive)
 - Context menu: Play/Pause, Copy, Download Audio, Delete
 - Keyboard shortcut: Cmd+Backspace to delete
 - Text selection enabled on transcript text
-- Multi-select cleanup bar for selecting visible dictations and deleting them together
+- Multi-select cleanup is an explicit bulk-selection mode: hidden during ordinary browsing, entered via the row three-dot menu's `Select Multiple…` (which preselects that row), surfacing per-row selection circles and a bulk action bar (Cancel, Select All, Clear, Delete). The mode exits on confirmed bulk delete, Cancel, switching to the Stats sub-tab, or leaving the Dictations section.
 - Delete confirmation dialog before permanent removal
 
 **Database schema:**


### PR DESCRIPTION
## Summary

Follow-up to PR #445 / issue #425 product review. Dictation history no longer shows a radio-style selection circle on every row during ordinary browsing. Bulk selection is now a **deliberate mode** the user enters from a row's ellipsis menu.

### Behavior
- **Default browse:** no selection circles; play / copy / ellipsis only; single-row delete still in the ellipsis menu.
- **Enter bulk mode:** ellipsis → `Select Multiple…` enters mode and preselects that row. Circles + the action bar appear. The `Select Multiple…` item hides once already in bulk mode.
- **Action bar (mode-based, not count-based):** `N selected` · `Cancel` · `Select All` · `Clear` · `Delete`. `Clear`/`Delete` disable at zero selection; the count stays visible at zero.
- **Leaving bulk mode (all four paths):** confirmed bulk delete exits; canceling the delete confirmation keeps mode + selection; switching to the Stats sub-tab exits; **navigating away from the Dictations section exits** (the view model is a process-lifetime singleton, so this is handled via `onDisappear`).

### Why `onDisappear`
`historyViewModel` is owned by `AppDelegate` for the app's lifetime and the Dictations tab is conditionally mounted, so without an explicit teardown bulk mode would survive navigating to Settings/Transcribe and back. This also retroactively fixes the pre-existing wart where a raw selection from #445 persisted across top-level navigation.

## Testing
- `swift build` — clean.
- `swift test` — **3313 XCTest, 10 skipped, 0 failures** (+7 new), plus 16 Swift Testing.
- New tests cover enter / exit / clear-keeps-mode / cancel-preserves / confirm-exits / single-row-delete-keeps-mode / tab-switch-exits.
- `git diff --check` clean.

Manual smoke (visual/interaction polish) recommended via `scripts/dev/run_app.sh` — steps are in the plan doc.

## Notes
- No telemetry event added for entering bulk mode (deliberate scoping — a new `TelemetryEventName` case requires a companion website-Worker allowlist change; per-row `dictationDeleted` already fires).
- Plan doc `docs/plans/2026-06-06-001-dictation-bulk-select-mode-handoff.md` hardened to match the implemented design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)