### PR TITLE
Scope feedback diagnostic-log uploads to a recent window (#451)

### DIFF
--- a/Sources/MacParakeet/Views/Feedback/FeedbackView.swift
+++ b/Sources/MacParakeet/Views/Feedback/FeedbackView.swift
@@ -466,6 +466,9 @@ struct FeedbackView: View {
         }
         .toggleStyle(.checkbox)
         .tint(DesignSystem.Colors.accent)
+        // Indent to align with the main toggle's text column (icon width +
+        // the row's HStack spacing) so it reads as a sub-option.
+        .padding(.leading, 28 + DesignSystem.Spacing.sm)
         .padding(.top, 2)
         .accessibilityHint("Attaches your entire local diagnostics history instead of only the last seven days")
     }

--- a/Sources/MacParakeet/Views/Feedback/FeedbackView.swift
+++ b/Sources/MacParakeet/Views/Feedback/FeedbackView.swift
@@ -354,7 +354,7 @@ struct FeedbackView: View {
                         )
                         .help(viewModel.diagnosticLogURL.path)
 
-                    Text("Use this for dictation or meeting recording issues. It attaches the log to the public report so we can inspect capture timing, buffers, silence, and device errors.")
+                    Text(diagnosticLogScopeDescription)
                         .font(DesignSystem.Typography.caption)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
@@ -411,6 +411,9 @@ struct FeedbackView: View {
             }
 
             if isAvailable {
+                if viewModel.includeDiagnosticLog {
+                    diagnosticLogScopeToggle
+                }
                 diagnosticLogSample
             }
         }
@@ -436,6 +439,35 @@ struct FeedbackView: View {
     /// `~/Library/Logs/MacParakeet/dictation-audio.log` location on disk.
     private var diagnosticLogDisplayPath: String {
         (viewModel.diagnosticLogURL.path as NSString).abbreviatingWithTildeInPath
+    }
+
+    /// Lead copy for the attach control — accurately reflects how far back the
+    /// upload reaches so users know what they are sharing.
+    private var diagnosticLogScopeDescription: String {
+        let attached = viewModel.includeFullDiagnosticHistory
+            ? "It attaches your full local history"
+            : "It attaches the last 7 days"
+        return "Use this for dictation or meeting recording issues. \(attached) to the public report so we can inspect capture timing, buffers, silence, and device errors."
+    }
+
+    /// Advanced opt-in to send the entire local log instead of only the recent
+    /// window. Shown as a subordinate checkbox under the main switch, so it
+    /// reads as a refinement of "attach diagnostics" rather than a peer toggle.
+    private var diagnosticLogScopeToggle: some View {
+        Toggle(isOn: $viewModel.includeFullDiagnosticHistory) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Include full history")
+                    .font(DesignSystem.Typography.caption.weight(.medium))
+                Text("Off attaches only the last 7 days. Turn on to include older entries — useful for issues that are hard to reproduce.")
+                    .font(DesignSystem.Typography.micro)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .toggleStyle(.checkbox)
+        .tint(DesignSystem.Colors.accent)
+        .padding(.top, 2)
+        .accessibilityHint("Attaches your entire local diagnostics history instead of only the last seven days")
     }
 
     // A real, representative slice of `dictation-audio.log` — a full capture

--- a/Sources/MacParakeetCore/Audio/DiagnosticLogScope.swift
+++ b/Sources/MacParakeetCore/Audio/DiagnosticLogScope.swift
@@ -1,0 +1,163 @@
+import Foundation
+
+/// How much of `dictation-audio.log` a feedback upload should carry.
+///
+/// Scoping happens by *recency of whole lines* — never by editing what a line
+/// contains. The per-line content is already privacy-scrubbed when it is
+/// written (see `AudioCaptureDiagnostics`: no audio, no transcript text,
+/// device identity reduced to `present`/`none` + coarse transport). The only
+/// thing scope decides is *how far back* the attachment reaches.
+public enum DiagnosticLogScope: Sendable {
+    /// Default for feedback uploads: the recent tail of the log, bounded by a
+    /// time window plus hard size/line caps. Keeps an attachment to a public
+    /// issue small and focused on the window around the reported problem.
+    case recent
+
+    /// Advanced, user-chosen "include older diagnostics": the whole available
+    /// log, bounded only by the on-disk byte ceiling. For intermittent issues
+    /// where the relevant capture happened days ago.
+    case full
+}
+
+extension AudioCaptureDiagnostics {
+    /// Time window kept by `.recent` scope. 7 days is the issue's "never more
+    /// than a week" ceiling used directly as the default: generous enough that
+    /// a report filed days after the fact still carries the relevant capture,
+    /// while never dumping the whole multi-week on-disk history. The byte/line
+    /// caps below are safety ceilings, not the primary scoping rule — for all
+    /// but the heaviest users, the default upload is simply "the last week".
+    public static let recentUploadWindow: TimeInterval = 7 * 24 * 60 * 60
+
+    /// Safety byte ceiling for `.recent`, applied after the time window. Set
+    /// above what a week of normal use produces so it only bites pathological
+    /// volume; the most recent bytes win when it does.
+    public static let recentUploadMaxBytes = 2_000_000
+
+    /// Safety line ceiling for `.recent`, applied after the time window.
+    public static let recentUploadMaxLines = 20_000
+
+    /// Fallback kept by `.recent` when *nothing* falls inside
+    /// `recentUploadWindow` (a user whose last capture was over a week ago).
+    /// Rather than attach an empty log, keep this many trailing lines so their
+    /// most recent sessions still come through. ~500 lines covers dozens of
+    /// recent capture attempts (each is roughly 8–12 lines).
+    public static let recentUploadMinTailLines = 500
+
+    /// Returns the slice of a raw diagnostic log that should be attached to a
+    /// feedback upload for the given `scope`.
+    ///
+    /// - `.recent` keeps the tail within `recentUploadWindow`, bounded by
+    ///   `recentUploadMaxBytes` / `recentUploadMaxLines`. If the window is empty
+    ///   it falls back to the last `recentUploadMinTailLines` lines.
+    /// - `.full` keeps everything, tail-capped at `diagnosticLogMaxBytes`.
+    ///
+    /// Lines whose leading token is not a parseable ISO-8601 timestamp never
+    /// trip the time cutoff — they ride the size/line caps. A log with no
+    /// parseable timestamps at all therefore degrades cleanly to "the last
+    /// `recentUploadMaxBytes` / `recentUploadMaxLines`".
+    ///
+    /// - Parameter now: injected reference time (defaults to the current date)
+    ///   so the time window is deterministic in tests.
+    public static func scopedLogForUpload(
+        _ rawLog: String,
+        scope: DiagnosticLogScope,
+        now: Date = Date()
+    ) -> String {
+        var lines = rawLog.split(separator: "\n", omittingEmptySubsequences: false)
+        // A trailing newline yields a final empty element; it is not a line.
+        if lines.last == "" {
+            lines.removeLast()
+        }
+        guard !lines.isEmpty else { return "" }
+
+        let maxBytes: Int
+        let maxLines: Int
+        let cutoff: Date?
+        switch scope {
+        case .recent:
+            maxBytes = recentUploadMaxBytes
+            maxLines = recentUploadMaxLines
+            cutoff = now.addingTimeInterval(-recentUploadWindow)
+        case .full:
+            maxBytes = Int(diagnosticLogMaxBytes)
+            maxLines = .max
+            cutoff = nil
+        }
+
+        // Same options the writer uses (`withInternetDateTime` +
+        // `withFractionalSeconds`), with a non-fractional fallback for safety.
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let plain = ISO8601DateFormatter()
+        plain.formatOptions = [.withInternetDateTime]
+
+        // Phase 1 — the recent window (for `.full`, the whole log up to the
+        // ceiling). Stop at the first line older than the cutoff; lines without
+        // a parseable timestamp ride along and never stop the walk.
+        var kept = tail(of: lines, maxBytes: maxBytes, maxLines: maxLines) { line in
+            guard let cutoff,
+                  let timestamp = parseLogLineTimestamp(line, fractional: fractional, plain: plain)
+            else { return false }
+            return timestamp < cutoff
+        }
+
+        // Phase 2 — idle-user fallback. Nothing landed in the window, so keep
+        // the most recent lines regardless of age instead of an empty log.
+        if kept.isEmpty {
+            kept = tail(
+                of: lines,
+                maxBytes: maxBytes,
+                maxLines: min(maxLines, recentUploadMinTailLines)
+            ) { _ in false }
+        }
+
+        guard !kept.isEmpty else { return "" }
+        var result = kept.joined(separator: "\n")
+        result.append("\n")
+
+        // Hard byte-ceiling guarantee. `tail` admits its newest line
+        // unconditionally, so only a single pathologically long line can push
+        // past `maxBytes`. Real entries are short and newline-terminated, so
+        // this trim never fires in practice — it just keeps the contract
+        // ("recent uploads stay within the cap") true for any input.
+        if result.utf8.count > maxBytes {
+            result = String(decoding: Data(result.utf8).suffix(maxBytes), as: UTF8.self)
+        }
+        return result
+    }
+
+    /// Walks `lines` newest-first, keeping lines until a hard cap or `stopBefore`
+    /// halts it, and returns them in chronological order. The newest line is
+    /// always admitted (so the byte cap can be exceeded only by a single line).
+    private static func tail(
+        of lines: [Substring],
+        maxBytes: Int,
+        maxLines: Int,
+        stopBefore: (Substring) -> Bool
+    ) -> [Substring] {
+        var kept: [Substring] = []
+        var byteCount = 0
+        for line in lines.reversed() {
+            if kept.count >= maxLines { break }
+            let lineBytes = line.utf8.count + 1 // +1 for the rejoined newline
+            if !kept.isEmpty, byteCount + lineBytes > maxBytes { break }
+            if stopBefore(line) { break }
+            kept.append(line)
+            byteCount += lineBytes
+        }
+        kept.reverse()
+        return kept
+    }
+
+    /// Parses the leading ISO-8601 timestamp token of a log line, or `nil` if
+    /// the line does not start with one.
+    private static func parseLogLineTimestamp(
+        _ line: Substring,
+        fractional: ISO8601DateFormatter,
+        plain: ISO8601DateFormatter
+    ) -> Date? {
+        let token = line.firstIndex(of: " ").map { String(line[..<$0]) } ?? String(line)
+        guard !token.isEmpty else { return nil }
+        return fractional.date(from: token) ?? plain.date(from: token)
+    }
+}

--- a/Sources/MacParakeetCore/Audio/DiagnosticLogScope.swift
+++ b/Sources/MacParakeetCore/Audio/DiagnosticLogScope.swift
@@ -46,13 +46,13 @@ extension AudioCaptureDiagnostics {
     /// Returns the slice of a raw diagnostic log that should be attached to a
     /// feedback upload for the given `scope`.
     ///
-    /// - `.recent` keeps the tail within `recentUploadWindow`, bounded by
+    /// - `.recent` keeps the lines within `recentUploadWindow`, bounded by
     ///   `recentUploadMaxBytes` / `recentUploadMaxLines`. If the window is empty
     ///   it falls back to the last `recentUploadMinTailLines` lines.
     /// - `.full` keeps everything, tail-capped at `diagnosticLogMaxBytes`.
     ///
     /// Lines whose leading token is not a parseable ISO-8601 timestamp never
-    /// trip the time cutoff — they ride the size/line caps. A log with no
+    /// count as out-of-window — they ride the size/line caps. A log with no
     /// parseable timestamps at all therefore degrades cleanly to "the last
     /// `recentUploadMaxBytes` / `recentUploadMaxLines`".
     ///
@@ -63,7 +63,13 @@ extension AudioCaptureDiagnostics {
         scope: DiagnosticLogScope,
         now: Date = Date()
     ) -> String {
-        var lines = rawLog.split(separator: "\n", omittingEmptySubsequences: false)
+        // Split on LF, treating CRLF as one separator too: in Swift "\r\n" is a
+        // single Character, so a plain "\n" split would miss it and collapse a
+        // CRLF log into one line. The output is rejoined with LF.
+        var lines = rawLog.split(
+            omittingEmptySubsequences: false,
+            whereSeparator: { $0 == "\n" || $0 == "\r\n" }
+        )
         // A trailing newline yields a final empty element; it is not a line.
         if lines.last == "" {
             lines.removeLast()
@@ -92,8 +98,9 @@ extension AudioCaptureDiagnostics {
         plain.formatOptions = [.withInternetDateTime]
 
         // Phase 1 — the recent window (for `.full`, the whole log up to the
-        // ceiling). Stop at the first line older than the cutoff; lines without
-        // a parseable timestamp ride along and never stop the walk.
+        // ceiling). Lines older than the cutoff are skipped, not used to stop
+        // the walk, so a non-monotonic log (e.g. a backward clock correction)
+        // still keeps every in-window line. Lines without a timestamp ride along.
         var kept = tail(of: lines, maxBytes: maxBytes, maxLines: maxLines) { line in
             guard let cutoff,
                   let timestamp = parseLogLineTimestamp(line, fractional: fractional, plain: plain)
@@ -119,29 +126,37 @@ extension AudioCaptureDiagnostics {
         // unconditionally, so only a single pathologically long line can push
         // past `maxBytes`. Real entries are short and newline-terminated, so
         // this trim never fires in practice — it just keeps the contract
-        // ("recent uploads stay within the cap") true for any input.
+        // ("recent uploads stay within the cap") true for any input. Cut on a
+        // UTF-8 scalar boundary so we never emit replacement characters or
+        // overshoot the cap when a multi-byte sequence straddles the boundary.
         if result.utf8.count > maxBytes {
-            result = String(decoding: Data(result.utf8).suffix(maxBytes), as: UTF8.self)
+            let utf8 = result.utf8
+            var start = utf8.index(utf8.endIndex, offsetBy: -maxBytes)
+            while start < utf8.endIndex, utf8[start] & 0xC0 == 0x80 {
+                start = utf8.index(after: start)
+            }
+            result = String(decoding: utf8[start...], as: UTF8.self)
         }
         return result
     }
 
-    /// Walks `lines` newest-first, keeping lines until a hard cap or `stopBefore`
-    /// halts it, and returns them in chronological order. The newest line is
+    /// Walks `lines` newest-first, keeping lines until a hard cap halts it, and
+    /// returns them in chronological order. Lines for which `skip` returns true
+    /// are passed over without stopping the walk. The newest kept line is
     /// always admitted (so the byte cap can be exceeded only by a single line).
     private static func tail(
         of lines: [Substring],
         maxBytes: Int,
         maxLines: Int,
-        stopBefore: (Substring) -> Bool
+        skip: (Substring) -> Bool
     ) -> [Substring] {
         var kept: [Substring] = []
         var byteCount = 0
         for line in lines.reversed() {
             if kept.count >= maxLines { break }
+            if skip(line) { continue }
             let lineBytes = line.utf8.count + 1 // +1 for the rejoined newline
             if !kept.isEmpty, byteCount + lineBytes > maxBytes { break }
-            if stopBefore(line) { break }
             kept.append(line)
             byteCount += lineBytes
         }

--- a/Sources/MacParakeetCore/Audio/README.md
+++ b/Sources/MacParakeetCore/Audio/README.md
@@ -50,6 +50,11 @@ fan-out. There is exactly one instance per process, owned by
   `~/Library/Logs/MacParakeet/dictation-audio.log`. 5 MB cap;
   delete-on-overflow (not rotated). Used by every file in this
   folder and by `AppDelegate`'s boot marker.
+- `DiagnosticLogScope.swift` — `AudioCaptureDiagnostics.scopedLogForUpload`
+  trims the log to a recent window (`.recent`, the feedback default:
+  last 7 days, 2 MB / 20k-line safety ceilings, min-tail fallback) or
+  the whole file (`.full`, advanced opt-in) before a feedback upload.
+  Scopes whole lines by recency; never edits line contents.
 - `AudioChunker.swift` — actor that buffers resampled audio for
   incremental STT (live meeting transcription).
 - `MeetingLiveAudioChunking.swift`,

--- a/Sources/MacParakeetViewModels/FeedbackViewModel.swift
+++ b/Sources/MacParakeetViewModels/FeedbackViewModel.swift
@@ -29,11 +29,21 @@ public final class FeedbackViewModel {
     public var message: String = ""
     public var email: String = ""
     public var screenshotAttachments: [FeedbackScreenshotAttachment] = []
-    public var includeDiagnosticLog: Bool = false
+    public var includeDiagnosticLog: Bool = false {
+        didSet {
+            // Turning diagnostics off clears the advanced full-history opt-in,
+            // so re-enabling always starts from the privacy-preferring recent
+            // window rather than silently re-attaching the entire log.
+            if !includeDiagnosticLog {
+                includeFullDiagnosticHistory = false
+            }
+        }
+    }
     /// Advanced opt-in: attach the entire local diagnostics history instead of
     /// just the recent window. Off by default — uploads scope to the last week
     /// (see `DiagnosticLogScope.recent`). Only meaningful while
-    /// `includeDiagnosticLog` is on.
+    /// `includeDiagnosticLog` is on; cleared whenever `includeDiagnosticLog`
+    /// flips off.
     public var includeFullDiagnosticHistory: Bool = false
     public var showSystemInfo: Bool = false
     public private(set) var diagnosticLogIsAvailable: Bool = false

--- a/Sources/MacParakeetViewModels/FeedbackViewModel.swift
+++ b/Sources/MacParakeetViewModels/FeedbackViewModel.swift
@@ -30,6 +30,11 @@ public final class FeedbackViewModel {
     public var email: String = ""
     public var screenshotAttachments: [FeedbackScreenshotAttachment] = []
     public var includeDiagnosticLog: Bool = false
+    /// Advanced opt-in: attach the entire local diagnostics history instead of
+    /// just the recent window. Off by default — uploads scope to the last week
+    /// (see `DiagnosticLogScope.recent`). Only meaningful while
+    /// `includeDiagnosticLog` is on.
+    public var includeFullDiagnosticHistory: Bool = false
     public var showSystemInfo: Bool = false
     public private(set) var diagnosticLogIsAvailable: Bool = false
     public private(set) var diagnosticLogAvailabilityDescription: String = "Run dictation or meeting recording once to create this log."
@@ -254,6 +259,7 @@ public final class FeedbackViewModel {
 
     private nonisolated static func readDiagnosticLogAttachmentIfNeeded(
         includeDiagnosticLog: Bool,
+        includeFullHistory: Bool,
         diagnosticLogURL: URL
     ) async throws -> FeedbackDiagnosticLog? {
         guard includeDiagnosticLog else { return nil }
@@ -264,23 +270,20 @@ public final class FeedbackViewModel {
                     throw DiagnosticLogAttachmentError.missing
                 }
 
-                if let fileSize = try diagnosticLogURL.resourceValues(forKeys: [.fileSizeKey]).fileSize {
-                    guard fileSize >= 0 else {
-                        throw DiagnosticLogAttachmentError.tooLarge
-                    }
-                    if UInt64(fileSize) > AudioCaptureDiagnostics.diagnosticLogMaxBytes {
-                        throw DiagnosticLogAttachmentError.tooLarge
-                    }
-                }
-
                 let data = try Data(contentsOf: diagnosticLogURL)
-                guard UInt64(data.count) <= AudioCaptureDiagnostics.diagnosticLogMaxBytes else {
-                    throw DiagnosticLogAttachmentError.tooLarge
+                // Scope to a recent window by default; the on-disk file is
+                // already byte-capped, so `.full` only lifts the time window.
+                let scoped = AudioCaptureDiagnostics.scopedLogForUpload(
+                    String(decoding: data, as: UTF8.self),
+                    scope: includeFullHistory ? .full : .recent
+                )
+                guard !scoped.isEmpty else {
+                    throw DiagnosticLogAttachmentError.empty
                 }
 
                 return FeedbackDiagnosticLog(
                     filename: Self.diagnosticLogFilename,
-                    base64: data.base64EncodedString()
+                    base64: Data(scoped.utf8).base64EncodedString()
                 )
             } catch {
                 if error is DiagnosticLogAttachmentError {
@@ -293,15 +296,15 @@ public final class FeedbackViewModel {
 
     private enum DiagnosticLogAttachmentError: LocalizedError {
         case missing
-        case tooLarge
+        case empty
         case readFailed(String)
 
         var errorDescription: String? {
             switch self {
             case .missing:
                 return "No diagnostic log found yet."
-            case .tooLarge:
-                return "The diagnostic log is too large to attach."
+            case .empty:
+                return "The diagnostic log is empty."
             case .readFailed(let detail):
                 return "Failed to read diagnostic log: \(detail)"
             }
@@ -318,6 +321,7 @@ public final class FeedbackViewModel {
         submissionState = .submitting
 
         let shouldIncludeDiagnosticLog = includeDiagnosticLog
+        let shouldIncludeFullDiagnosticHistory = includeFullDiagnosticHistory
         let diagnosticLogURL = diagnosticLogURL
         let category = category
         let trimmedMessage = message.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -335,6 +339,7 @@ public final class FeedbackViewModel {
             do {
                 let diagnosticLog = try await Self.readDiagnosticLogAttachmentIfNeeded(
                     includeDiagnosticLog: shouldIncludeDiagnosticLog,
+                    includeFullHistory: shouldIncludeFullDiagnosticHistory,
                     diagnosticLogURL: diagnosticLogURL
                 )
                 guard !Task.isCancelled else { return }
@@ -423,6 +428,7 @@ public final class FeedbackViewModel {
         email = ""
         screenshotAttachments = []
         includeDiagnosticLog = false
+        includeFullDiagnosticHistory = false
         pendingScreenshotFilename = nil
         showSystemInfo = false
         submissionState = .idle

--- a/Tests/MacParakeetTests/Audio/DiagnosticLogScopeTests.swift
+++ b/Tests/MacParakeetTests/Audio/DiagnosticLogScopeTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import MacParakeetCore
 
 final class DiagnosticLogScopeTests: XCTestCase {
-    // Fixed reference time so the 72 h window is deterministic.
+    // Fixed reference time so the 7-day (168 h) window is deterministic.
     private let now = Date(timeIntervalSince1970: 1_780_000_000)
 
     private func iso(_ date: Date) -> String {
@@ -57,6 +57,40 @@ final class DiagnosticLogScopeTests: XCTestCase {
         let scoped = AudioCaptureDiagnostics.scopedLogForUpload(raw, scope: .recent, now: now)
 
         XCTAssertTrue(scoped.hasSuffix("\n"))
+    }
+
+    func testRecentHandlesCRLFLineEndings() {
+        // CRLF must split into lines (not collapse into one) so the window
+        // filter still works. Output is normalized to LF.
+        let raw = [
+            line(hoursAgo: 400, "old_crlf_event"),
+            line(hoursAgo: 1, "recent_crlf_event"),
+        ].joined(separator: "\r\n") + "\r\n"
+
+        let scoped = AudioCaptureDiagnostics.scopedLogForUpload(raw, scope: .recent, now: now)
+
+        XCTAssertTrue(scoped.contains("recent_crlf_event"))
+        XCTAssertFalse(scoped.contains("old_crlf_event"))
+        XCTAssertFalse(scoped.contains("\r"), "CRLF should be normalized to LF in the output")
+    }
+
+    func testRecentKeepsInWindowLinesDespiteOutOfOrderTimestamps() {
+        // A backward clock correction can place an old line physically after a
+        // recent one. The in-window line must survive rather than being cut off
+        // when the walk meets the stale line.
+        let raw = joined([
+            line(hoursAgo: 6, "recent_old_but_in_window"),
+            line(hoursAgo: 300, "stale_middle"),
+            line(hoursAgo: 2, "recent_new"),
+            line(hoursAgo: 1, "recent_newest"),
+        ])
+
+        let scoped = AudioCaptureDiagnostics.scopedLogForUpload(raw, scope: .recent, now: now)
+
+        XCTAssertTrue(scoped.contains("recent_newest"))
+        XCTAssertTrue(scoped.contains("recent_new"))
+        XCTAssertTrue(scoped.contains("recent_old_but_in_window"))
+        XCTAssertFalse(scoped.contains("stale_middle"))
     }
 
     // MARK: - Idle-user fallback
@@ -131,6 +165,21 @@ final class DiagnosticLogScopeTests: XCTestCase {
         let scoped = AudioCaptureDiagnostics.scopedLogForUpload(raw, scope: .recent, now: now)
 
         XCTAssertLessThanOrEqual(scoped.utf8.count, AudioCaptureDiagnostics.recentUploadMaxBytes)
+    }
+
+    func testByteCeilingHoldsForMultiByteSingleLine() {
+        // A single line of 3-byte characters whose byte length exceeds the cap:
+        // the boundary trim must stay within the cap AND not emit replacement
+        // characters from a mid-sequence cut.
+        let euros = String(
+            repeating: "€",
+            count: AudioCaptureDiagnostics.recentUploadMaxBytes / 3 + 100
+        )
+
+        let scoped = AudioCaptureDiagnostics.scopedLogForUpload(euros, scope: .recent, now: now)
+
+        XCTAssertLessThanOrEqual(scoped.utf8.count, AudioCaptureDiagnostics.recentUploadMaxBytes)
+        XCTAssertFalse(scoped.contains("\u{FFFD}"), "trim must cut on a UTF-8 boundary")
     }
 
     // MARK: - No parseable timestamps

--- a/Tests/MacParakeetTests/Audio/DiagnosticLogScopeTests.swift
+++ b/Tests/MacParakeetTests/Audio/DiagnosticLogScopeTests.swift
@@ -1,0 +1,216 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class DiagnosticLogScopeTests: XCTestCase {
+    // Fixed reference time so the 72 h window is deterministic.
+    private let now = Date(timeIntervalSince1970: 1_780_000_000)
+
+    private func iso(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: date)
+    }
+
+    /// A log line stamped `hoursAgo` before `now`, matching the writer format.
+    private func line(hoursAgo: Double, _ event: String) -> String {
+        "\(iso(now.addingTimeInterval(-hoursAgo * 3600))) \(event)"
+    }
+
+    private func joined(_ lines: [String]) -> String {
+        lines.joined(separator: "\n") + "\n"
+    }
+
+    // MARK: - Date filtering
+
+    func testRecentDropsLinesOlderThanWindow() {
+        let raw = joined([
+            line(hoursAgo: 400, "old_event_a"),
+            line(hoursAgo: 200, "old_event_b"),
+            line(hoursAgo: 2, "recent_event"),
+            line(hoursAgo: 0.1, "very_recent_event"),
+        ])
+
+        let scoped = AudioCaptureDiagnostics.scopedLogForUpload(raw, scope: .recent, now: now)
+
+        XCTAssertTrue(scoped.contains("recent_event"))
+        XCTAssertTrue(scoped.contains("very_recent_event"))
+        XCTAssertFalse(scoped.contains("old_event_a"))
+        XCTAssertFalse(scoped.contains("old_event_b"))
+    }
+
+    func testRecentKeepsLineExactlyAtWindowEdge() {
+        // A line just inside the 7-day window survives; one just outside does not.
+        let raw = joined([
+            line(hoursAgo: 168.01, "just_outside"),
+            line(hoursAgo: 167.99, "just_inside"),
+        ])
+
+        let scoped = AudioCaptureDiagnostics.scopedLogForUpload(raw, scope: .recent, now: now)
+
+        XCTAssertTrue(scoped.contains("just_inside"))
+        XCTAssertFalse(scoped.contains("just_outside"))
+    }
+
+    func testRecentKeepsTrailingNewlineSoOutputIsLineTerminated() {
+        let raw = joined([line(hoursAgo: 1, "recent_event")])
+
+        let scoped = AudioCaptureDiagnostics.scopedLogForUpload(raw, scope: .recent, now: now)
+
+        XCTAssertTrue(scoped.hasSuffix("\n"))
+    }
+
+    // MARK: - Idle-user fallback
+
+    func testRecentFallsBackToTrailingLinesWhenWindowIsEmpty() {
+        // Every line is older than the window, but there are few of them, so the
+        // fallback keeps them all rather than attaching nothing.
+        let raw = joined([
+            line(hoursAgo: 240, "stale_a"),
+            line(hoursAgo: 200, "stale_b"),
+            line(hoursAgo: 180, "stale_c"),
+        ])
+
+        let scoped = AudioCaptureDiagnostics.scopedLogForUpload(raw, scope: .recent, now: now)
+
+        XCTAssertFalse(scoped.isEmpty)
+        XCTAssertTrue(scoped.contains("stale_c"))
+        XCTAssertTrue(scoped.contains("stale_a"))
+    }
+
+    func testRecentFallbackIsCappedToMinTailLines() {
+        // All lines are stale (window empty) and there are more than the
+        // fallback floor; only the most recent floor-worth survive.
+        let total = AudioCaptureDiagnostics.recentUploadMinTailLines + 50
+        let lines = (0..<total).map { index in
+            // Oldest first; index 0 is the furthest in the past.
+            line(hoursAgo: Double(240 + (total - index)), "stale_\(index)")
+        }
+
+        let scoped = AudioCaptureDiagnostics.scopedLogForUpload(joined(lines), scope: .recent, now: now)
+        let keptLineCount = scoped.split(separator: "\n").count
+
+        XCTAssertEqual(keptLineCount, AudioCaptureDiagnostics.recentUploadMinTailLines)
+        // The newest stale line is kept; the oldest is dropped.
+        XCTAssertTrue(scoped.contains("stale_\(total - 1)"))
+        XCTAssertFalse(scoped.contains("stale_0"))
+    }
+
+    // MARK: - Size / line caps
+
+    func testRecentEnforcesLineCap() {
+        // More recent lines than the line cap allows.
+        let total = AudioCaptureDiagnostics.recentUploadMaxLines + 500
+        let lines = (0..<total).map { line(hoursAgo: 1, "recent_\($0)") }
+
+        let scoped = AudioCaptureDiagnostics.scopedLogForUpload(joined(lines), scope: .recent, now: now)
+        let keptLineCount = scoped.split(separator: "\n").count
+
+        XCTAssertLessThanOrEqual(keptLineCount, AudioCaptureDiagnostics.recentUploadMaxLines)
+        // The most recent line survives; the oldest is trimmed.
+        XCTAssertTrue(scoped.contains("recent_\(total - 1)"))
+        XCTAssertFalse(scoped.contains("recent_0"))
+    }
+
+    func testRecentEnforcesByteCap() {
+        // Each line ~1 KB of recent content; well over the 2 MB byte cap.
+        let filler = String(repeating: "x", count: 1000)
+        let lines = (0..<4000).map { line(hoursAgo: 1, "recent_\($0)_\(filler)") }
+
+        let scoped = AudioCaptureDiagnostics.scopedLogForUpload(joined(lines), scope: .recent, now: now)
+
+        XCTAssertLessThanOrEqual(scoped.utf8.count, AudioCaptureDiagnostics.recentUploadMaxBytes)
+        // The most recent content is what survives the tail trim.
+        XCTAssertTrue(scoped.contains("recent_3999"))
+        XCTAssertFalse(scoped.contains("recent_0_"))
+    }
+
+    func testByteCeilingHoldsForSinglePathologicallyLongLine() {
+        // One line, no newline, larger than the cap: still bounded.
+        let raw = String(repeating: "a", count: AudioCaptureDiagnostics.recentUploadMaxBytes * 2)
+
+        let scoped = AudioCaptureDiagnostics.scopedLogForUpload(raw, scope: .recent, now: now)
+
+        XCTAssertLessThanOrEqual(scoped.utf8.count, AudioCaptureDiagnostics.recentUploadMaxBytes)
+    }
+
+    // MARK: - No parseable timestamps
+
+    func testRecentKeepsTailWhenNoTimestampsAreParseable() {
+        // No line begins with an ISO-8601 timestamp; the time cutoff can never
+        // fire, so we degrade to keeping the tail under the caps.
+        let lines = (0..<10).map { "freeform diagnostic line \($0) words=\($0)" }
+
+        let scoped = AudioCaptureDiagnostics.scopedLogForUpload(joined(lines), scope: .recent, now: now)
+
+        XCTAssertFalse(scoped.isEmpty)
+        XCTAssertTrue(scoped.contains("freeform diagnostic line 9"))
+        XCTAssertTrue(scoped.contains("freeform diagnostic line 0"))
+    }
+
+    func testRecentKeepsNonTimestampedLinesAdjacentToRecentEntries() {
+        // A timestamp-less line interleaved with recent entries rides along.
+        let raw = joined([
+            line(hoursAgo: 400, "old_event"),
+            line(hoursAgo: 1, "recent_event"),
+            "continuation line without timestamp words=3",
+        ])
+
+        let scoped = AudioCaptureDiagnostics.scopedLogForUpload(raw, scope: .recent, now: now)
+
+        XCTAssertTrue(scoped.contains("recent_event"))
+        XCTAssertTrue(scoped.contains("continuation line without timestamp"))
+        XCTAssertFalse(scoped.contains("old_event"))
+    }
+
+    // MARK: - Full scope
+
+    func testFullScopeKeepsEntireLog() {
+        let raw = joined([
+            line(hoursAgo: 500, "ancient_event"),
+            line(hoursAgo: 100, "old_event"),
+            line(hoursAgo: 1, "recent_event"),
+        ])
+
+        let scoped = AudioCaptureDiagnostics.scopedLogForUpload(raw, scope: .full, now: now)
+
+        XCTAssertTrue(scoped.contains("ancient_event"))
+        XCTAssertTrue(scoped.contains("old_event"))
+        XCTAssertTrue(scoped.contains("recent_event"))
+    }
+
+    func testFullScopeReconstructsLogExactly() {
+        let raw = joined([
+            line(hoursAgo: 50, "event_a key=1"),
+            line(hoursAgo: 49, "event_b key=2"),
+        ])
+
+        let scoped = AudioCaptureDiagnostics.scopedLogForUpload(raw, scope: .full, now: now)
+
+        XCTAssertEqual(scoped, raw)
+    }
+
+    func testFullScopeTailCapsAtOnDiskCeiling() {
+        let ceiling = Int(AudioCaptureDiagnostics.diagnosticLogMaxBytes)
+        let filler = String(repeating: "y", count: 1000)
+        let lines = (0..<(ceiling / 1000 + 100)).map { line(hoursAgo: 1, "event_\($0)_\(filler)") }
+
+        let scoped = AudioCaptureDiagnostics.scopedLogForUpload(joined(lines), scope: .full, now: now)
+
+        XCTAssertLessThanOrEqual(scoped.utf8.count, ceiling)
+    }
+
+    // MARK: - Edge cases
+
+    func testEmptyLogProducesEmptyOutput() {
+        // A genuinely empty file yields no attachment — this is the contract the
+        // feedback view model's empty-log guard relies on.
+        XCTAssertEqual(AudioCaptureDiagnostics.scopedLogForUpload("", scope: .recent, now: now), "")
+        XCTAssertEqual(AudioCaptureDiagnostics.scopedLogForUpload("", scope: .full, now: now), "")
+    }
+
+    func testWhitespaceOnlyLogIsPreservedAsContent() {
+        // A lone blank line is content, not an empty file.
+        let scoped = AudioCaptureDiagnostics.scopedLogForUpload("\n\n", scope: .recent, now: now)
+        XCTAssertFalse(scoped.isEmpty)
+    }
+}

--- a/Tests/MacParakeetTests/ViewModels/FeedbackViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/FeedbackViewModelTests.swift
@@ -65,6 +65,15 @@ final class FeedbackViewModelTests: XCTestCase {
         Telemetry.configure(NoOpTelemetryService())
     }
 
+    /// An ISO-8601 timestamp `secondsAgo` before now, in the writer's format —
+    /// used to build diagnostic-log fixtures whose recency the scoping logic
+    /// (which uses the real `Date()`) will evaluate.
+    static func iso(secondsAgo: Double) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: Date().addingTimeInterval(-secondsAgo))
+    }
+
     // MARK: - Initial State
 
     func testDefaultState() {
@@ -175,6 +184,7 @@ final class FeedbackViewModelTests: XCTestCase {
         viewModel.screenshotData = Data([0x00])
         viewModel.screenshotFilename = "test.png"
         viewModel.includeDiagnosticLog = true
+        viewModel.includeFullDiagnosticHistory = true
         viewModel.showSystemInfo = true
         viewModel.submissionState = .error("something")
 
@@ -187,6 +197,7 @@ final class FeedbackViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.screenshotFilename)
         XCTAssertTrue(viewModel.screenshotAttachments.isEmpty)
         XCTAssertFalse(viewModel.includeDiagnosticLog)
+        XCTAssertFalse(viewModel.includeFullDiagnosticHistory)
         XCTAssertFalse(viewModel.showSystemInfo)
         XCTAssertEqual(viewModel.submissionState, .idle)
     }
@@ -393,11 +404,88 @@ final class FeedbackViewModelTests: XCTestCase {
         XCTAssertNotNil(operation?.errorType)
     }
 
-    func testSubmissionFailsWhenDiagnosticLogIsTooLarge() async throws {
+    func testSubmissionTrimsOversizedDiagnosticLogToRecentWindow() async throws {
         let logURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("oversized-dictation-audio-\(UUID().uuidString).log")
-        let oversizedData = Data(count: Int(AudioCaptureDiagnostics.diagnosticLogMaxBytes) + 1)
-        try oversizedData.write(to: logURL)
+        // A realistic, all-recent log far larger than the recent byte cap.
+        let filler = String(repeating: "x", count: 800)
+        let lines = (0..<3000).map { index in
+            "\(Self.iso(secondsAgo: Double(3000 - index))) dictation_capture_stop seq=\(index) \(filler)"
+        }
+        try Data((lines.joined(separator: "\n") + "\n").utf8).write(to: logURL)
+        defer { try? FileManager.default.removeItem(at: logURL) }
+
+        viewModel = FeedbackViewModel(diagnosticLogURL: logURL)
+        viewModel.configure(feedbackService: mockService)
+        viewModel.message = "Dictation acted weird"
+        viewModel.includeDiagnosticLog = true
+
+        viewModel.submit()
+        try await Task.sleep(for: .milliseconds(150))
+
+        // The oversized log is trimmed to the recent window, not rejected.
+        XCTAssertEqual(mockService.submitCallCount, 1)
+        let base64 = try XCTUnwrap(mockService.lastPayload?.diagnosticLog?.base64)
+        let decoded = try XCTUnwrap(Data(base64Encoded: base64))
+        XCTAssertLessThanOrEqual(decoded.count, AudioCaptureDiagnostics.recentUploadMaxBytes)
+        let text = String(decoding: decoded, as: UTF8.self)
+        XCTAssertTrue(text.contains("seq=2999"), "newest line should survive")
+        XCTAssertFalse(text.contains("seq=0 "), "oldest line should be trimmed")
+    }
+
+    func testSubmissionAttachesOnlyRecentWindowByDefault() async throws {
+        let logURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("windowed-dictation-audio-\(UUID().uuidString).log")
+        let raw = """
+        \(Self.iso(secondsAgo: 240 * 3600)) dictation_capture_stop seq=old
+        \(Self.iso(secondsAgo: 3600)) dictation_capture_stop seq=recent
+        """ + "\n"
+        try Data(raw.utf8).write(to: logURL)
+        defer { try? FileManager.default.removeItem(at: logURL) }
+
+        viewModel = FeedbackViewModel(diagnosticLogURL: logURL)
+        viewModel.configure(feedbackService: mockService)
+        viewModel.message = "Dictation acted weird"
+        viewModel.includeDiagnosticLog = true
+
+        viewModel.submit()
+        try await Task.sleep(for: .milliseconds(100))
+
+        let base64 = try XCTUnwrap(mockService.lastPayload?.diagnosticLog?.base64)
+        let text = String(decoding: try XCTUnwrap(Data(base64Encoded: base64)), as: UTF8.self)
+        XCTAssertTrue(text.contains("seq=recent"))
+        XCTAssertFalse(text.contains("seq=old"), "entries older than the window should be dropped by default")
+    }
+
+    func testSubmissionAttachesFullHistoryWhenRequested() async throws {
+        let logURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fullhistory-dictation-audio-\(UUID().uuidString).log")
+        let raw = """
+        \(Self.iso(secondsAgo: 240 * 3600)) dictation_capture_stop seq=old
+        \(Self.iso(secondsAgo: 3600)) dictation_capture_stop seq=recent
+        """ + "\n"
+        try Data(raw.utf8).write(to: logURL)
+        defer { try? FileManager.default.removeItem(at: logURL) }
+
+        viewModel = FeedbackViewModel(diagnosticLogURL: logURL)
+        viewModel.configure(feedbackService: mockService)
+        viewModel.message = "Dictation acted weird"
+        viewModel.includeDiagnosticLog = true
+        viewModel.includeFullDiagnosticHistory = true
+
+        viewModel.submit()
+        try await Task.sleep(for: .milliseconds(100))
+
+        let base64 = try XCTUnwrap(mockService.lastPayload?.diagnosticLog?.base64)
+        let text = String(decoding: try XCTUnwrap(Data(base64Encoded: base64)), as: UTF8.self)
+        XCTAssertTrue(text.contains("seq=recent"))
+        XCTAssertTrue(text.contains("seq=old"), "full history should include entries older than the window")
+    }
+
+    func testSubmissionFailsWhenDiagnosticLogIsEmpty() async throws {
+        let logURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("empty-dictation-audio-\(UUID().uuidString).log")
+        try Data().write(to: logURL)
         defer { try? FileManager.default.removeItem(at: logURL) }
 
         viewModel = FeedbackViewModel(diagnosticLogURL: logURL)
@@ -410,9 +498,9 @@ final class FeedbackViewModelTests: XCTestCase {
 
         XCTAssertEqual(mockService.submitCallCount, 0)
         if case .error(let message) = viewModel.submissionState {
-            XCTAssertEqual(message, "The diagnostic log is too large to attach.")
+            XCTAssertEqual(message, "The diagnostic log is empty.")
         } else {
-            XCTFail("Expected oversized diagnostic log error, got \(viewModel.submissionState)")
+            XCTFail("Expected empty diagnostic log error, got \(viewModel.submissionState)")
         }
     }
 

--- a/Tests/MacParakeetTests/ViewModels/FeedbackViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/FeedbackViewModelTests.swift
@@ -74,6 +74,16 @@ final class FeedbackViewModelTests: XCTestCase {
         return formatter.string(from: Date().addingTimeInterval(-secondsAgo))
     }
 
+    /// Polls until `condition` holds or `timeout` elapses, so async submission
+    /// assertions wait for the detached submit task deterministically instead
+    /// of racing a fixed delay on a loaded runner.
+    private func waitUntil(timeout: Duration = .seconds(5), _ condition: () -> Bool) async {
+        let deadline = ContinuousClock.now + timeout
+        while !condition(), ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
     // MARK: - Initial State
 
     func testDefaultState() {
@@ -421,7 +431,7 @@ final class FeedbackViewModelTests: XCTestCase {
         viewModel.includeDiagnosticLog = true
 
         viewModel.submit()
-        try await Task.sleep(for: .milliseconds(150))
+        await waitUntil { mockService.submitCallCount == 1 }
 
         // The oversized log is trimmed to the recent window, not rejected.
         XCTAssertEqual(mockService.submitCallCount, 1)
@@ -449,7 +459,7 @@ final class FeedbackViewModelTests: XCTestCase {
         viewModel.includeDiagnosticLog = true
 
         viewModel.submit()
-        try await Task.sleep(for: .milliseconds(100))
+        await waitUntil { mockService.submitCallCount == 1 }
 
         let base64 = try XCTUnwrap(mockService.lastPayload?.diagnosticLog?.base64)
         let text = String(decoding: try XCTUnwrap(Data(base64Encoded: base64)), as: UTF8.self)
@@ -474,7 +484,7 @@ final class FeedbackViewModelTests: XCTestCase {
         viewModel.includeFullDiagnosticHistory = true
 
         viewModel.submit()
-        try await Task.sleep(for: .milliseconds(100))
+        await waitUntil { mockService.submitCallCount == 1 }
 
         let base64 = try XCTUnwrap(mockService.lastPayload?.diagnosticLog?.base64)
         let text = String(decoding: try XCTUnwrap(Data(base64Encoded: base64)), as: UTF8.self)
@@ -494,7 +504,10 @@ final class FeedbackViewModelTests: XCTestCase {
         viewModel.includeDiagnosticLog = true
 
         viewModel.submit()
-        try await Task.sleep(for: .milliseconds(100))
+        await waitUntil {
+            if case .error = viewModel.submissionState { return true }
+            return false
+        }
 
         XCTAssertEqual(mockService.submitCallCount, 0)
         if case .error(let message) = viewModel.submissionState {
@@ -502,6 +515,17 @@ final class FeedbackViewModelTests: XCTestCase {
         } else {
             XCTFail("Expected empty diagnostic log error, got \(viewModel.submissionState)")
         }
+    }
+
+    func testTurningDiagnosticsOffResetsFullHistoryOptIn() {
+        viewModel.includeDiagnosticLog = true
+        viewModel.includeFullDiagnosticHistory = true
+
+        // Disabling diagnostics must clear the advanced full-history opt-in so
+        // re-enabling later starts from the privacy-preferring recent window.
+        viewModel.includeDiagnosticLog = false
+
+        XCTAssertFalse(viewModel.includeFullDiagnosticHistory)
     }
 
     // MARK: - System Info

--- a/plans/completed/scope-diagnostic-log-upload.md
+++ b/plans/completed/scope-diagnostic-log-upload.md
@@ -1,0 +1,66 @@
+# Scope diagnostic-log feedback uploads to a recent window
+
+> Status: **IMPLEMENTED** — issue #451
+
+## Problem
+
+The in-app feedback flow attaches the whole local `dictation-audio.log`
+(up to the 5 MB on-disk cap) when a user opts in. The per-line content is
+already scrubbed at write time (no audio, no transcript text, device identity
+reduced to `present`/`none` + coarse transport). The remaining concern is
+*breadth*: a full-history upload can carry weeks of behavioral cadence onto a
+public GitHub issue when support only needs the recent window around the bug.
+
+Owner steer: the behavioral metadata itself is valuable for debugging and is
+already disclosed via the opt-in + preview affordance — **do not strip per-line
+detail**, and don't filter so hard we miss key info. Since it's opt-in, lean
+generous: the single change that matters is *not dumping the whole day-1
+history* — send a generous **recent window** by default.
+
+## Approach
+
+Scope by *recency of whole lines*, never by redacting line contents.
+
+### Core (`MacParakeetCore/Audio/DiagnosticLogScope.swift`)
+
+- `enum DiagnosticLogScope { case recent, full }`
+- `AudioCaptureDiagnostics.scopedLogForUpload(_ raw: String, scope:, now:) -> String`
+  - **recent (default)**: keep the tail within the last **7 days** (the issue's
+    week ceiling, used directly as the default), with **2 MB / 20k-line** safety
+    ceilings, falling back to the last **500 lines** when the user has been idle
+    longer than a week so the attachment is never empty.
+  - **full (advanced opt-in)**: whole log, tail-capped at the on-disk ceiling
+    (`diagnosticLogMaxBytes`, 5 MB).
+  - Timestamp parse from each line's leading ISO-8601 token (shared format
+    options with the writer; fractional + non-fractional fallback). Lines with
+    no parseable timestamp never trigger the time cutoff — they ride the
+    size/line caps (covers the "no parseable timestamps" fallback).
+
+### ViewModel (`FeedbackViewModel`)
+
+- New `includeFullDiagnosticHistory: Bool = false`.
+- `readDiagnosticLogAttachmentIfNeeded` scopes via Core before base64.
+- Remove `.tooLarge` (we now trim instead of reject); add `.empty` for a
+  genuinely empty log. Reset the new flag in `resetForm`.
+
+### View (`FeedbackView`)
+
+- Light copy: the attach sentence reads "last 3 days" by default, "your full
+  local history" when full is on. Keep the existing privacy framing + preview.
+- Add a compact advanced **"Include full history"** checkbox, shown only when
+  the user has opted into attaching diagnostics.
+
+## Acceptance criteria (issue #451)
+
+- [x] Default upload no longer attaches full history — recent window only.
+- [x] Still useful for startup clipping, no-buffer, silent input, engine
+      failures, model-empty (those events land in the recent window / min-tail).
+- [x] UI copy accurately states what is attached (recent vs full) and that no
+      audio/transcript text is included.
+- [x] Tests: date filtering, size/line caps, no-timestamp fallback.
+
+## Out of scope
+
+- Per-line content/redaction changes (already done at write time).
+- New telemetry params (would be a two-repo allowlist change).
+- A broader multi-source diagnostic bundle (separate follow-up in spec/08).

--- a/plans/completed/scope-diagnostic-log-upload.md
+++ b/plans/completed/scope-diagnostic-log-upload.md
@@ -45,7 +45,7 @@ Scope by *recency of whole lines*, never by redacting line contents.
 
 ### View (`FeedbackView`)
 
-- Light copy: the attach sentence reads "last 3 days" by default, "your full
+- Light copy: the attach sentence reads "last 7 days" by default, "your full
   local history" when full is on. Keep the existing privacy framing + preview.
 - Add a compact advanced **"Include full history"** checkbox, shown only when
   the user has opted into attaching diagnostics.

--- a/spec/08-error-handling.md
+++ b/spec/08-error-handling.md
@@ -175,7 +175,15 @@ self-hosted telemetry pipeline.
 
 The in-app feedback flow has an explicit opt-in control for attaching
 `~/Library/Logs/MacParakeet/dictation-audio.log` when users report dictation or
-meeting recording problems. A broader diagnostic bundle is still a follow-up:
+meeting recording problems. The attachment is scoped to a recent window by
+default (`DiagnosticLogScope.recent`: the last 7 days, with 2 MB / 20k-line
+safety ceilings, falling back to the last few hundred lines when nothing is
+that recent) so a public issue carries the window around the bug rather than the
+full multi-week on-disk history. An advanced "Include full history" toggle lifts
+the time window to the entire on-disk log for intermittent issues. Scoping
+selects *whole lines by recency*; it never edits line contents, which are
+already privacy-scrubbed at write time.
+A broader diagnostic bundle is still a follow-up:
 it should contain recent MacParakeet `os.Logger` entries, the audio diagnostics
 log, app version/build info, and redacted runtime metadata. It must not include
 audio, transcripts, notes, prompts, file names, file paths, URLs, API keys, or


### PR DESCRIPTION
Closes #451.

## What & why

When a user opts into attaching `dictation-audio.log` to a feedback report, we currently upload the **entire** on-disk log (up to the 5 MB cap), which can span weeks. That's broader than support triage needs and broader than most people want on a public GitHub issue.

The per-line content is already privacy-scrubbed at write time (no audio, no transcript text, device identity reduced to `present`/`none` + coarse transport). So the only thing worth changing is **how far back the default attachment reaches** — not what each line contains.

This trims the default to a generous **recent window** while keeping the flow opt-in, previewed, and reversible.

## Behavior

- **Default (`.recent`):** attach the last **7 days**, with 2 MB / 20k-line safety ceilings. If the user has been idle longer than a week, fall back to the last 500 lines so the attachment is never empty.
- **Advanced (`.full`):** an **"Include full history"** checkbox (shown only once diagnostics are toggled on) attaches the whole log — for intermittent issues where the relevant capture happened a while ago.
- Scoping selects **whole lines by recency**; it never edits line contents.
- The old "log too large → reject" path is gone — an oversized log is now trimmed to the window instead of refused. A genuinely empty log surfaces a clear `.empty` error.

## UX copy

The attach card now states exactly what's shared:
- *"…It attaches the last 7 days to the public report so we can inspect capture timing, buffers, silence, and device errors."* (or *"…your full local history"* when the advanced toggle is on)
- Existing "no audio or transcript text" framing + the verbatim log preview are unchanged.

## Tests

- `DiagnosticLogScopeTests` (15): date filtering, window edge, size/line caps, single-giant-line byte ceiling, no-parseable-timestamp fallback, idle-user min-tail fallback, full-scope round-trip, empty input.
- `FeedbackViewModelTests` (new): recent-window-by-default, full-history-when-requested, oversized-log-trims (not rejects), empty-log error.
- Full `swift test` suite green.

## Acceptance criteria (#451)

- [x] Default upload no longer attaches full history.
- [x] Still useful for startup clipping / no-buffer / silent input / engine failure / model-empty reports (those land in the 7-day window or the min-tail fallback).
- [x] UI copy accurately describes what's attached and that no audio/transcript text is included.
- [x] Tests cover date filtering, size/line caps, and the no-timestamp fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)