### PR TITLE
Add Nemotron beta speech engine

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio",
       "state" : {
-        "revision" : "ce59fb14b8b8978b196f6a34282e20ea6762d164",
-        "version" : "0.14.5"
+        "revision" : "7f963cdc43ba89c5993654f1e138047d517a818d",
+        "version" : "0.15.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -8,8 +8,8 @@ let skipWhisperKit = ProcessInfo.processInfo.environment["MACPARAKEET_SKIP_WHISP
 let packageDependencies: [Package.Dependency] = [
     // GRDB for SQLite (dictation history + transcription records)
     .package(url: "https://github.com/groue/GRDB.swift", from: "7.0.0"),
-    // FluidAudio for Parakeet STT on CoreML/ANE
-    .package(url: "https://github.com/FluidInference/FluidAudio", .upToNextMinor(from: "0.14.5")),
+    // FluidAudio for Parakeet and Nemotron STT on CoreML/ANE
+    .package(url: "https://github.com/FluidInference/FluidAudio", .upToNextMinor(from: "0.15.2")),
     // ArgumentParser for CLI
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
     // Sparkle for auto-updates (non-App Store distribution)

--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -80,6 +80,19 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ## [Unreleased]
 
+### Added
+
+- `transcribe --engine` now accepts `nemotron` as an opt-in Beta local ASR
+  engine. `--engine app-default` also follows the saved Nemotron default and
+  Nemotron language hint when the GUI/CLI default is set to Nemotron.
+- `config get|set|list` now includes `nemotron-language`, with `auto`
+  clearing the stored language hint.
+- `models list`, `models select`, `models download`, `models delete`,
+  `models status`, `models warm-up`, `models repair`, and `health
+  --repair-models` understand the Nemotron model id
+  `nemotron-multilingual-1120ms`. `models select` requires the local Nemotron
+  artifact to be downloaded before persisting Nemotron as the shared default.
+
 ## [2.7.0] -- 2026-06-06
 
 ### Added

--- a/Sources/CLI/Commands/ConfigCommand.swift
+++ b/Sources/CLI/Commands/ConfigCommand.swift
@@ -23,9 +23,10 @@ struct ConfigCommand: ParsableCommand {
         Supported keys:
           telemetry                 on|off                         default: on
           processing-mode           raw|clean                       default: raw
-          speech-engine             parakeet|whisper                default: parakeet
+          speech-engine             parakeet|nemotron|whisper       default: parakeet
           parakeet-model            v3|v2 (v3=multilingual,         default: v3
                                     v2=English-only)
+          nemotron-language         auto|<Nemotron language code>   default: auto
           whisper-language          auto|<Whisper language code>    default: auto
           speaker-detection         on|off                          default: off
           save-transcription-audio  on|off                          default: on
@@ -49,6 +50,7 @@ struct ConfigCommand: ParsableCommand {
         "processing-mode",
         "speech-engine",
         "parakeet-model",
+        "nemotron-language",
         "whisper-language",
         "speaker-detection",
         "save-transcription-audio",
@@ -163,6 +165,8 @@ struct ConfigCommand: ParsableCommand {
             return SpeechEnginePreference.current(defaults: store).rawValue
         case "parakeet-model":
             return SpeechEnginePreference.parakeetModelVariant(defaults: store).rawValue
+        case "nemotron-language":
+            return SpeechEnginePreference.nemotronDefaultLanguage(defaults: store) ?? "auto"
         case "whisper-language":
             return SpeechEnginePreference.whisperDefaultLanguage(defaults: store) ?? WhisperLanguageCatalog.autoCode
         case "speaker-detection":
@@ -200,6 +204,10 @@ struct ConfigCommand: ParsableCommand {
             let variant = try parseParakeetModelVariant(value)
             SpeechEnginePreference.saveParakeetModelVariant(variant, defaults: store)
             return variant.rawValue
+        case "nemotron-language":
+            let language = try parseNemotronLanguage(value)
+            SpeechEnginePreference.saveNemotronDefaultLanguage(language, defaults: store)
+            return language ?? "auto"
         case "whisper-language":
             let language = try parseWhisperLanguage(value)
             SpeechEnginePreference.saveWhisperDefaultLanguage(language, defaults: store)
@@ -254,7 +262,7 @@ struct ConfigCommand: ParsableCommand {
     static func parseSpeechEngine(_ value: String) throws -> SpeechEnginePreference {
         let raw = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard let engine = SpeechEnginePreference(rawValue: raw) else {
-            throw ValidationError("Invalid value for speech-engine: '\(value)'. Use parakeet or whisper.")
+            throw ValidationError("Invalid value for speech-engine: '\(value)'. Use parakeet, nemotron, or whisper.")
         }
         return engine
     }
@@ -283,6 +291,18 @@ struct ConfigCommand: ParsableCommand {
         }
         guard let language = SpeechEnginePreference.normalizeLanguage(trimmed) else {
             throw ValidationError("Invalid value for whisper-language: '\(value)'. Use auto or a Whisper language code.")
+        }
+        return language
+    }
+
+    static func parseNemotronLanguage(_ value: String) throws -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lowered = trimmed.lowercased()
+        if lowered == "auto" || lowered == "auto-detect" {
+            return nil
+        }
+        guard let language = SpeechEnginePreference.normalizeNemotronLanguage(trimmed) else {
+            throw ValidationError("Invalid value for nemotron-language: '\(value)'. Use auto or a language code such as en-US, ko, or zh-CN.")
         }
         return language
     }

--- a/Sources/CLI/Commands/HealthCommand.swift
+++ b/Sources/CLI/Commands/HealthCommand.swift
@@ -125,7 +125,8 @@ struct HealthCommand: AsyncParsableCommand {
         }
 
         // 5. Local speech stack
-        let sttClient = makeParakeetSTTClient()
+        let defaults = macParakeetAppDefaults()
+        let sttClient = makeConfiguredSTTClient(defaults: defaults)
         var sttClientNeedsShutdown = true
         defer {
             if sttClientNeedsShutdown {
@@ -135,7 +136,8 @@ struct HealthCommand: AsyncParsableCommand {
         let diarizationService = DiarizationService()
         let status = await loadSpeechStackStatus(
             sttClient: sttClient,
-            diarizationService: diarizationService
+            diarizationService: diarizationService,
+            defaults: defaults
         )
         report.speechStack = SpeechStackPayload(status: status)
         if !json {
@@ -150,6 +152,7 @@ struct HealthCommand: AsyncParsableCommand {
                     attempts: repairAttempts,
                     sttClient: sttClient,
                     diarizationService: diarizationService,
+                    defaults: defaults,
                     log: { message in if !self.json { print("  \(message)") } }
                 )
                 report.repair = HealthReport.Repair(attempted: true, completed: true, error: nil)

--- a/Sources/CLI/Commands/ModelsCommand.swift
+++ b/Sources/CLI/Commands/ModelsCommand.swift
@@ -58,12 +58,7 @@ extension ModelsCommand {
             try emitJSONOrRethrow(json: json) {
                 let defaults = macParakeetAppDefaults()
                 let selection = try resolveSelectableSpeechModel(id, defaults: defaults)
-                if let whisperVariant = selection.whisperVariant,
-                   !WhisperEngine.isModelDownloaded(model: whisperVariant) {
-                    throw ValidationError(
-                        "Whisper model is not downloaded. Run `macparakeet-cli models download \(whisperModelID(for: whisperVariant))` first."
-                    )
-                }
+                try validateSelectableSpeechModelDownload(selection, defaults: defaults)
 
                 selection.engine.save(to: defaults)
                 if let whisperVariant = selection.whisperVariant {
@@ -78,7 +73,7 @@ extension ModelsCommand {
                         id: selection.engine.rawValue,
                         name: selection.engine.displayName,
                         engine: selection.engine.rawValue,
-                        variant: selection.whisperVariant,
+                        variant: selection.whisperVariant ?? selection.nemotronVariant?.rawValue,
                         size: nil,
                         installed: true,
                         selected: true,
@@ -104,7 +99,8 @@ extension ModelsCommand {
 
         func run() async throws {
             try await emitJSONOrRethrow(json: json) {
-                let sttClient = makeParakeetSTTClient()
+                let defaults = macParakeetAppDefaults()
+                let sttClient = makeConfiguredSTTClient(defaults: defaults)
                 var sttClientNeedsShutdown = true
                 defer {
                     if sttClientNeedsShutdown {
@@ -114,7 +110,8 @@ extension ModelsCommand {
                 let diarizationService = DiarizationService()
                 let status = await loadSpeechStackStatus(
                     sttClient: sttClient,
-                    diarizationService: diarizationService
+                    diarizationService: diarizationService,
+                    defaults: defaults
                 )
                 await sttClient.shutdown()
                 sttClientNeedsShutdown = false
@@ -133,7 +130,7 @@ extension ModelsCommand {
             abstract: "Download a local speech model without starting a transcription."
         )
 
-        @Argument(help: "Model identifier from `models list`, e.g. parakeet-v2, parakeet-v3, or whisper-large-v3-v20240930-turbo-632MB.")
+        @Argument(help: "Model identifier from `models list`, e.g. parakeet-v2, parakeet-v3, nemotron-multilingual-1120ms, or whisper-large-v3-v20240930-turbo-632MB.")
         var variant: String
 
         func run() async throws {
@@ -150,6 +147,22 @@ extension ModelsCommand {
                     if shouldPrint { print("Parakeet: \(message)") }
                 }
                 print("Parakeet: ready (\(parakeetVariant.modelName))")
+                return
+            }
+
+            if let nemotronVariant = nemotronDownloadVariant(from: lowered) {
+                let language = SpeechEnginePreference.nemotronDefaultLanguage(defaults: macParakeetAppDefaults())
+                print("Nemotron: downloading \(nemotronVariant.modelName)...")
+                let lastMessage = OSAllocatedUnfairLock(initialState: "")
+                try await STTRuntime.downloadNemotronModel(modelVariant: nemotronVariant, language: language) { message in
+                    let shouldPrint = lastMessage.withLock { last in
+                        guard last != message else { return false }
+                        last = message
+                        return true
+                    }
+                    if shouldPrint { print("Nemotron: \(message)") }
+                }
+                print("Nemotron: ready (\(nemotronVariant.modelName))")
                 return
             }
 
@@ -183,7 +196,8 @@ extension ModelsCommand {
 
         func run() async throws {
             let attempts = try validatedAttempts(attempts)
-            let sttClient = makeParakeetSTTClient()
+            let defaults = macParakeetAppDefaults()
+            let sttClient = makeConfiguredSTTClient(defaults: defaults)
             var sttClientNeedsShutdown = true
             defer {
                 if sttClientNeedsShutdown {
@@ -195,6 +209,7 @@ extension ModelsCommand {
                 attempts: attempts,
                 sttClient: sttClient,
                 diarizationService: diarizationService,
+                defaults: defaults,
                 log: { print($0) }
             )
             await sttClient.shutdown()
@@ -213,7 +228,8 @@ extension ModelsCommand {
 
         func run() async throws {
             let attempts = try validatedAttempts(attempts)
-            let sttClient = makeParakeetSTTClient()
+            let defaults = macParakeetAppDefaults()
+            let sttClient = makeConfiguredSTTClient(defaults: defaults)
             var sttClientNeedsShutdown = true
             defer {
                 if sttClientNeedsShutdown {
@@ -225,6 +241,7 @@ extension ModelsCommand {
                 attempts: attempts,
                 sttClient: sttClient,
                 diarizationService: diarizationService,
+                defaults: defaults,
                 log: { print($0) }
             )
             await sttClient.shutdown()
@@ -237,7 +254,7 @@ extension ModelsCommand {
             commandName: "delete",
             abstract: "Delete one downloaded speech model, freeing its disk space.",
             discussion: """
-                Removes a single model (one Parakeet build or the Whisper variant) \
+                Removes a single model (one Parakeet build, Nemotron, or the Whisper variant) \
                 while leaving every other model in place — unlike `models clear`, \
                 which wipes the whole local stack.
 
@@ -247,7 +264,7 @@ extension ModelsCommand {
                 """
         )
 
-        @Argument(help: "Model identifier from `models list`, e.g. parakeet-v2, parakeet-v3, or whisper-large-v3-v20240930-turbo-632MB.")
+        @Argument(help: "Model identifier from `models list`, e.g. parakeet-v2, parakeet-v3, nemotron-multilingual-1120ms, or whisper-large-v3-v20240930-turbo-632MB.")
         var id: String
 
         @Flag(name: .long, help: "Delete even the model currently in use (it will re-download on next use).")
@@ -276,6 +293,17 @@ extension ModelsCommand {
                     return
                 }
                 let removed = STTRuntime.deleteParakeetModel(version: variant.asrModelVersion)
+                guard removed else {
+                    throw ModelDeletionError.deleteFailed("Could not delete \(variant.modelName). It may be missing or in use by another process.")
+                }
+                print("Deleted \(target.displayName) · freed \(variant.approximateDownloadSize).")
+            case .nemotron(let variant):
+                let language = SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults)
+                guard STTClient.isNemotronModelCached(modelVariant: variant, language: language) else {
+                    print("\(variant.modelName) is not downloaded — nothing to delete.")
+                    return
+                }
+                let removed = STTRuntime.deleteNemotronModel(modelVariant: variant, language: language)
                 guard removed else {
                     throw ModelDeletionError.deleteFailed("Could not delete \(variant.modelName). It may be missing or in use by another process.")
                 }
@@ -324,31 +352,48 @@ func parakeetDownloadVariant(
     return parseParakeetSelectionVariant(lowered)
 }
 
+func nemotronDownloadVariant(from lowered: String) -> NemotronModelVariant? {
+    if lowered == SpeechEnginePreference.nemotron.rawValue {
+        return SpeechEnginePreference.defaultNemotronModelVariant
+    }
+    return parseNemotronSelectionVariant(lowered)
+}
+
 func resolveWhisperDownloadModel(_ variant: String) throws -> String {
     let normalizedInput = variant.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !normalizedInput.isEmpty else {
         throw ValidationError("Model variant cannot be empty.")
     }
     guard normalizedInput.hasPrefix("whisper-") else {
-        throw ValidationError("Unsupported model identifier '\(variant)'. Use a parakeet-v2 / parakeet-v3 or whisper-* id from `models list`.")
+        throw ValidationError("Unsupported model identifier '\(variant)'. Use a parakeet-v2, parakeet-v3, nemotron-multilingual-1120ms, or whisper-* id from `models list`.")
     }
     return WhisperEngine.normalizeModelVariant(normalizedInput)
 }
 
 struct SpeechStackPayload: Encodable {
+    let speechEngine: String
     let speechModelCached: Bool
     let speechRuntimeReady: Bool
     let speakerModelsCached: Bool
     let speakerModelsPrepared: Bool
+    let parakeetModelVariant: String
+    let parakeetModelDownloaded: Bool
+    let nemotronModelVariant: String
+    let nemotronModelDownloaded: Bool
     let whisperModelVariant: String
     let whisperModelDownloaded: Bool
     let summary: String
 
     init(status: SpeechStackStatus) {
+        self.speechEngine = status.speechEngine.rawValue
         self.speechModelCached = status.speechModelCached
         self.speechRuntimeReady = status.speechRuntimeReady
         self.speakerModelsCached = status.speakerModelsCached
         self.speakerModelsPrepared = status.speakerModelsPrepared
+        self.parakeetModelVariant = status.parakeetModelVariant.rawValue
+        self.parakeetModelDownloaded = status.parakeetModelDownloaded
+        self.nemotronModelVariant = status.nemotronModelVariant.rawValue
+        self.nemotronModelDownloaded = status.nemotronModelDownloaded
         self.whisperModelVariant = status.whisperModelVariant
         self.whisperModelDownloaded = status.whisperModelDownloaded
         self.summary = status.summary
@@ -356,10 +401,15 @@ struct SpeechStackPayload: Encodable {
 }
 
 struct SpeechStackStatus: Sendable, Equatable {
+    let speechEngine: SpeechEnginePreference
     let speechModelCached: Bool
     let speechRuntimeReady: Bool
     let speakerModelsCached: Bool
     let speakerModelsPrepared: Bool
+    let parakeetModelVariant: ParakeetModelVariant
+    let parakeetModelDownloaded: Bool
+    let nemotronModelVariant: NemotronModelVariant
+    let nemotronModelDownloaded: Bool
     let whisperModelVariant: String
     let whisperModelDownloaded: Bool
 
@@ -387,35 +437,72 @@ func validatedAttempts(_ attempts: Int) throws -> Int {
     return attempts
 }
 
-/// Builds the CLI's Parakeet-engine STT client honoring the persisted variant
-/// (`config set parakeet-model v2`), so `warm-up`/`repair`/`status` operate on
-/// the build the user selected rather than always defaulting to v3.
+/// Builds the CLI's standalone STT client from the persisted app/CLI defaults,
+/// so `warm-up`/`repair`/`status` exercise the engine the user selected.
+func makeConfiguredSTTClient(defaults: UserDefaults = macParakeetAppDefaults()) -> STTClient {
+    STTClient(
+        modelVersion: SpeechEnginePreference.parakeetModelVariant(defaults: defaults).asrModelVersion,
+        speechEngine: SpeechEnginePreference.current(defaults: defaults),
+        nemotronModelVariant: SpeechEnginePreference.defaultNemotronModelVariant,
+        whisperModelVariant: SpeechEnginePreference.whisperModelVariant(defaults: defaults)
+    )
+}
+
 func makeParakeetSTTClient(defaults: UserDefaults = macParakeetAppDefaults()) -> STTClient {
-    STTClient(modelVersion: SpeechEnginePreference.parakeetModelVariant(defaults: defaults).asrModelVersion)
+    STTClient(
+        modelVersion: SpeechEnginePreference.parakeetModelVariant(defaults: defaults).asrModelVersion,
+        speechEngine: .parakeet
+    )
 }
 
 func loadSpeechStackStatus(
     sttClient: STTClientProtocol,
     diarizationService: DiarizationServiceProtocol,
-    isSpeechModelCached: @escaping @Sendable () -> Bool = {
-        STTClient.isModelCached(
-            version: SpeechEnginePreference.parakeetModelVariant(defaults: macParakeetAppDefaults()).asrModelVersion
-        )
-    },
-    whisperModelVariant: String = SpeechEnginePreference.whisperModelVariant(defaults: macParakeetAppDefaults()),
-    isWhisperModelDownloaded: @escaping @Sendable (String) -> Bool = { WhisperEngine.isModelDownloaded(model: $0) }
+    defaults: UserDefaults = macParakeetAppDefaults(),
+    isParakeetModelCached: (@Sendable (ParakeetModelVariant) -> Bool)? = nil,
+    nemotronModelVariant: NemotronModelVariant = SpeechEnginePreference.defaultNemotronModelVariant,
+    isNemotronModelDownloaded: (@Sendable (NemotronModelVariant) -> Bool)? = nil,
+    whisperModelVariant: String? = nil,
+    isWhisperModelDownloaded: (@Sendable (String) -> Bool)? = nil
 ) async -> SpeechStackStatus {
+    let speechEngine = SpeechEnginePreference.current(defaults: defaults)
+    let parakeetModelVariant = SpeechEnginePreference.parakeetModelVariant(defaults: defaults)
+    let nemotronLanguage = SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults)
+    let whisperModelVariant = whisperModelVariant ?? SpeechEnginePreference.whisperModelVariant(defaults: defaults)
+    let parakeetDownloaded = (isParakeetModelCached ?? { variant in
+        STTClient.isModelCached(version: variant.asrModelVersion)
+    })(parakeetModelVariant)
+    let nemotronDownloaded = (isNemotronModelDownloaded ?? { variant in
+        STTClient.isNemotronModelCached(modelVariant: variant, language: nemotronLanguage)
+    })(nemotronModelVariant)
+    let whisperDownloaded = (isWhisperModelDownloaded ?? { variant in
+        WhisperEngine.isModelDownloaded(model: variant)
+    })(whisperModelVariant)
+    let activeSpeechModelCached = switch speechEngine {
+    case .parakeet:
+        parakeetDownloaded
+    case .nemotron:
+        nemotronDownloaded
+    case .whisper:
+        whisperDownloaded
+    }
+
     async let speechRuntimeReady = sttClient.isReady()
     async let speakerModelsCached = diarizationService.hasCachedModels()
     async let speakerModelsPrepared = diarizationService.isReady()
 
     return await SpeechStackStatus(
-        speechModelCached: isSpeechModelCached(),
+        speechEngine: speechEngine,
+        speechModelCached: activeSpeechModelCached,
         speechRuntimeReady: speechRuntimeReady,
         speakerModelsCached: speakerModelsCached,
         speakerModelsPrepared: speakerModelsPrepared,
+        parakeetModelVariant: parakeetModelVariant,
+        parakeetModelDownloaded: parakeetDownloaded,
+        nemotronModelVariant: nemotronModelVariant,
+        nemotronModelDownloaded: nemotronDownloaded,
         whisperModelVariant: whisperModelVariant,
-        whisperModelDownloaded: isWhisperModelDownloaded(whisperModelVariant)
+        whisperModelDownloaded: whisperDownloaded
     )
 }
 
@@ -423,10 +510,15 @@ func printSpeechStackStatus(_ status: SpeechStackStatus, includeHeader: Bool = t
     if includeHeader {
         print("Local speech stack:")
     }
-    print("  Speech model cached:   \(status.speechModelCached ? "Yes" : "No")")
+    print("  Active speech engine: \(status.speechEngine.displayName)")
+    print("  Active speech model cached: \(status.speechModelCached ? "Yes" : "No")")
     print("  Speech runtime loaded: \(status.speechRuntimeReady ? "Yes" : "No")")
     print("  Speaker models cached: \(status.speakerModelsCached ? "Yes" : "No")")
     print("  Speaker models prepared: \(status.speakerModelsPrepared ? "Yes" : "No")")
+    print("  Parakeet model variant: \(status.parakeetModelVariant.rawValue)")
+    print("  Parakeet model downloaded: \(status.parakeetModelDownloaded ? "Yes" : "No")")
+    print("  Nemotron model variant: \(status.nemotronModelVariant.rawValue)")
+    print("  Nemotron model downloaded: \(status.nemotronModelDownloaded ? "Yes" : "No")")
     print("  Whisper model variant: \(status.whisperModelVariant)")
     print("  Whisper model downloaded: \(status.whisperModelDownloaded ? "Yes" : "No")")
     print("  Status: \(status.summary)")
@@ -446,6 +538,7 @@ struct SelectableSpeechModel: Encodable, Equatable {
 struct SelectableSpeechModelSelection: Equatable {
     let engine: SpeechEnginePreference
     let whisperVariant: String?
+    var nemotronVariant: NemotronModelVariant? = nil
     /// Set when the selection targets a specific Parakeet build; `nil` leaves
     /// the persisted Parakeet variant untouched (e.g. a Whisper selection).
     var parakeetVariant: ParakeetModelVariant? = nil
@@ -453,13 +546,20 @@ struct SelectableSpeechModelSelection: Equatable {
 
 func loadSelectableSpeechModels(
     defaults: UserDefaults = macParakeetAppDefaults(),
-    isParakeetModelCached: @escaping (ParakeetModelVariant) -> Bool = {
-        STTClient.isModelCached(version: $0.asrModelVersion)
-    },
-    isWhisperModelDownloaded: @escaping (String) -> Bool = { WhisperEngine.isModelDownloaded(model: $0) }
+    isParakeetModelCached: ((ParakeetModelVariant) -> Bool)? = nil,
+    isNemotronModelDownloaded: ((NemotronModelVariant) -> Bool)? = nil,
+    isWhisperModelDownloaded: ((String) -> Bool)? = nil
 ) -> [SelectableSpeechModel] {
+    let checkParakeetModelCached = isParakeetModelCached ?? {
+        STTClient.isModelCached(version: $0.asrModelVersion)
+    }
     let currentEngine = SpeechEnginePreference.current(defaults: defaults)
     let currentParakeetVariant = SpeechEnginePreference.parakeetModelVariant(defaults: defaults)
+    let nemotronLanguage = SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults)
+    let checkNemotronModelDownloaded = isNemotronModelDownloaded ?? {
+        STTClient.isNemotronModelCached(modelVariant: $0, language: nemotronLanguage)
+    }
+    let checkWhisperModelDownloaded = isWhisperModelDownloaded ?? { WhisperEngine.isModelDownloaded(model: $0) }
     let whisperVariant = SpeechEnginePreference.whisperModelVariant(defaults: defaults)
     let whisperLanguage = SpeechEnginePreference.whisperDefaultLanguage(defaults: defaults)
 
@@ -470,20 +570,33 @@ func loadSelectableSpeechModels(
             engine: SpeechEnginePreference.parakeet.rawValue,
             variant: variant.rawValue,
             size: variant.approximateDownloadSize,
-            installed: isParakeetModelCached(variant),
+            installed: checkParakeetModelCached(variant),
             selected: currentEngine == .parakeet && currentParakeetVariant == variant,
             language: variant.isEnglishOnly ? "en" : nil
         )
     }
 
-    return parakeetModels + [
+    let nemotronModels = NemotronModelVariant.allCases.map { variant in
+        SelectableSpeechModel(
+            id: nemotronModelID(for: variant),
+            name: "\(variant.modelName) (\(variant.displayName))",
+            engine: SpeechEnginePreference.nemotron.rawValue,
+            variant: variant.rawValue,
+            size: variant.approximateDownloadSize,
+            installed: checkNemotronModelDownloaded(variant),
+            selected: currentEngine == .nemotron,
+            language: nemotronLanguage ?? "auto"
+        )
+    }
+
+    return parakeetModels + nemotronModels + [
         SelectableSpeechModel(
             id: whisperModelID(for: whisperVariant),
             name: "Whisper \(SpeechEnginePreference.friendlyVariantName(whisperVariant))",
             engine: SpeechEnginePreference.whisper.rawValue,
             variant: whisperVariant,
             size: whisperModelSizeLabel(for: whisperVariant),
-            installed: isWhisperModelDownloaded(whisperVariant),
+            installed: checkWhisperModelDownloaded(whisperVariant),
             selected: currentEngine == .whisper,
             language: whisperLanguage ?? WhisperLanguageCatalog.autoCode
         ),
@@ -514,7 +627,24 @@ func resolveSelectableSpeechModel(
         return SelectableSpeechModelSelection(
             engine: .parakeet,
             whisperVariant: nil,
+            nemotronVariant: nil,
             parakeetVariant: parakeetVariant
+        )
+    }
+
+    if lowered == "nemotron" {
+        return SelectableSpeechModelSelection(
+            engine: .nemotron,
+            whisperVariant: nil,
+            nemotronVariant: SpeechEnginePreference.defaultNemotronModelVariant
+        )
+    }
+
+    if let nemotronVariant = parseNemotronSelectionVariant(lowered) {
+        return SelectableSpeechModelSelection(
+            engine: .nemotron,
+            whisperVariant: nil,
+            nemotronVariant: nemotronVariant
         )
     }
 
@@ -545,11 +675,40 @@ func resolveSelectableSpeechModel(
     )
 }
 
+func validateSelectableSpeechModelDownload(
+    _ selection: SelectableSpeechModelSelection,
+    defaults: UserDefaults = macParakeetAppDefaults(),
+    isNemotronModelDownloaded: ((NemotronModelVariant, String?) -> Bool)? = nil,
+    isWhisperModelDownloaded: ((String) -> Bool)? = nil
+) throws {
+    if let nemotronVariant = selection.nemotronVariant {
+        let language = SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults)
+        let downloaded = (isNemotronModelDownloaded ?? { variant, language in
+            STTClient.isNemotronModelCached(modelVariant: variant, language: language)
+        })(nemotronVariant, language)
+        guard downloaded else {
+            throw ValidationError(
+                "Nemotron model is not downloaded. Run `macparakeet-cli models download \(nemotronModelID(for: nemotronVariant))` first."
+            )
+        }
+    }
+
+    if let whisperVariant = selection.whisperVariant {
+        let downloaded = (isWhisperModelDownloaded ?? { WhisperEngine.isModelDownloaded(model: $0) })(whisperVariant)
+        guard downloaded else {
+            throw ValidationError(
+                "Whisper model is not downloaded. Run `macparakeet-cli models download \(whisperModelID(for: whisperVariant))` first."
+            )
+        }
+    }
+}
+
 /// One concrete model that `models delete` can target, resolved from a
 /// `models list` id. Carries a user-facing `displayName` for messages.
 struct ModelDeletionTarget: Equatable {
     enum Kind: Equatable {
         case parakeet(ParakeetModelVariant)
+        case nemotron(NemotronModelVariant)
         /// Normalized Whisper variant id (matches the stored preference).
         case whisper(String)
     }
@@ -584,6 +743,12 @@ func resolveModelDeletionTarget(
             displayName: "\(parakeetVariant.modelName) (\(parakeetVariant.displayName))"
         )
     }
+    if let nemotronVariant = selection.nemotronVariant {
+        return ModelDeletionTarget(
+            kind: .nemotron(nemotronVariant),
+            displayName: "\(nemotronVariant.modelName) (\(nemotronVariant.displayName))"
+        )
+    }
     if let whisperVariant = selection.whisperVariant {
         return ModelDeletionTarget(
             kind: .whisper(whisperVariant),
@@ -605,6 +770,9 @@ func isModelInUse(
     switch target.kind {
     case .parakeet(let variant):
         return SpeechEnginePreference.parakeetModelVariant(defaults: defaults) == variant
+    case .nemotron(let variant):
+        return currentEngine == .nemotron
+            && variant == SpeechEnginePreference.defaultNemotronModelVariant
     case .whisper(let variant):
         return currentEngine == .whisper
             && SpeechEnginePreference.whisperModelVariant(defaults: defaults) == variant
@@ -638,8 +806,33 @@ private func parseParakeetSelectionVariant(_ lowered: String) -> ParakeetModelVa
     }
 }
 
+/// Recognizes `nemotron-multilingual-1120ms`, `nemotron:multilingual-1120ms`,
+/// and a few intent aliases. Returns nil for non-Nemotron ids.
+private func parseNemotronSelectionVariant(_ lowered: String) -> NemotronModelVariant? {
+    let normalized = lowered.replacingOccurrences(of: "_", with: "-")
+    let prefix = SpeechEnginePreference.nemotron.rawValue
+    let suffix: String
+    if normalized.hasPrefix("\(prefix):") {
+        suffix = String(normalized.dropFirst(prefix.count + 1))
+    } else if normalized.hasPrefix("\(prefix)-") {
+        suffix = String(normalized.dropFirst(prefix.count + 1))
+    } else {
+        return nil
+    }
+    switch suffix {
+    case "multilingual-1120ms", "multilingual", "multi", "beta":
+        return .multilingual1120
+    default:
+        return nil
+    }
+}
+
 func parakeetModelID(for variant: ParakeetModelVariant) -> String {
     "\(SpeechEnginePreference.parakeet.rawValue)-\(variant.rawValue)"
+}
+
+func nemotronModelID(for variant: NemotronModelVariant) -> String {
+    "\(SpeechEnginePreference.nemotron.rawValue)-\(variant.rawValue)"
 }
 
 func whisperModelID(for variant: String) -> String {
@@ -679,13 +872,15 @@ func prepareSpeechStack(
     attempts: Int,
     sttClient: STTClientProtocol,
     diarizationService: DiarizationServiceProtocol,
+    defaults: UserDefaults = macParakeetAppDefaults(),
     log: @escaping @Sendable (String) -> Void
 ) async throws {
-    log("Parakeet (STT): preparing...")
-    try await runWithRetry(attempts: attempts, label: "Parakeet (STT)", log: log) { attempt in
+    let speechLabel = "\(SpeechEnginePreference.current(defaults: defaults).displayName) (STT)"
+    log("\(speechLabel): preparing...")
+    try await runWithRetry(attempts: attempts, label: speechLabel, log: log) { attempt in
         try await sttClient.warmUp { message in
             if attempt == 1 || message.contains("%") || message == "Ready" || message.contains("Loading model") {
-                log("Parakeet (STT): \(message)")
+                log("\(speechLabel): \(message)")
             }
         }
     }
@@ -699,7 +894,8 @@ func prepareSpeechStack(
 
     let status = await loadSpeechStackStatus(
         sttClient: sttClient,
-        diarizationService: diarizationService
+        diarizationService: diarizationService,
+        defaults: defaults
     )
     log("Speech stack: \(status.summary)")
 }

--- a/Sources/CLI/Commands/ModelsCommand.swift
+++ b/Sources/CLI/Commands/ModelsCommand.swift
@@ -444,14 +444,16 @@ func makeConfiguredSTTClient(defaults: UserDefaults = macParakeetAppDefaults()) 
         modelVersion: SpeechEnginePreference.parakeetModelVariant(defaults: defaults).asrModelVersion,
         speechEngine: SpeechEnginePreference.current(defaults: defaults),
         nemotronModelVariant: SpeechEnginePreference.defaultNemotronModelVariant,
-        whisperModelVariant: SpeechEnginePreference.whisperModelVariant(defaults: defaults)
+        whisperModelVariant: SpeechEnginePreference.whisperModelVariant(defaults: defaults),
+        defaults: defaults
     )
 }
 
 func makeParakeetSTTClient(defaults: UserDefaults = macParakeetAppDefaults()) -> STTClient {
     STTClient(
         modelVersion: SpeechEnginePreference.parakeetModelVariant(defaults: defaults).asrModelVersion,
-        speechEngine: .parakeet
+        speechEngine: .parakeet,
+        defaults: defaults
     )
 }
 

--- a/Sources/CLI/Commands/ModelsCommand.swift
+++ b/Sources/CLI/Commands/ModelsCommand.swift
@@ -298,14 +298,10 @@ extension ModelsCommand {
                 }
                 print("Deleted \(target.displayName) · freed \(variant.approximateDownloadSize).")
             case .nemotron(let variant):
-                let language = SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults)
-                guard STTClient.isNemotronModelCached(modelVariant: variant, language: language) else {
+                let removed = STTRuntime.deleteNemotronModel(modelVariant: variant, language: nil)
+                guard removed else {
                     print("\(variant.modelName) is not downloaded — nothing to delete.")
                     return
-                }
-                let removed = STTRuntime.deleteNemotronModel(modelVariant: variant, language: language)
-                guard removed else {
-                    throw ModelDeletionError.deleteFailed("Could not delete \(variant.modelName). It may be missing or in use by another process.")
                 }
                 print("Deleted \(target.displayName) · freed \(variant.approximateDownloadSize).")
             case .whisper(let variant):

--- a/Sources/CLI/Commands/SpecCommand.swift
+++ b/Sources/CLI/Commands/SpecCommand.swift
@@ -164,8 +164,8 @@ private extension CLISpecCommand {
             jsonMode: "--format json",
             arguments: [.argument("input", summary: "File path, folder path, YouTube URL, or HTTP(S) media URL supported by yt-dlp.")],
             options: [
-                CLISpecParameter.option("--engine", valueName: "parakeet|whisper|app-default", summary: "Speech engine for this run."),
-                CLISpecParameter.option("--language", valueName: "CODE", summary: "Language hint for Whisper."),
+                CLISpecParameter.option("--engine", valueName: "parakeet|nemotron|whisper|app-default", summary: "Speech engine for this run."),
+                CLISpecParameter.option("--language", valueName: "CODE", summary: "Language hint for Nemotron or Whisper."),
                 CLISpecParameter.option("--speaker-detection", valueName: "app-default|on|off", summary: "Speaker detection behavior for this run."),
                 CLISpecParameter.option("--speaker-count", valueName: "N", summary: "Exact known speaker count; implies speaker detection unless explicitly disabled."),
                 CLISpecParameter.option("--speaker-min", valueName: "N", summary: "Minimum speaker count bound for diarization."),

--- a/Sources/CLI/Commands/SpecCommand.swift
+++ b/Sources/CLI/Commands/SpecCommand.swift
@@ -176,6 +176,84 @@ private extension CLISpecCommand {
             output: "Transcription result object."
         ),
         CLISpecCommand(
+            ["config", "list"],
+            summary: "List shared app/CLI configuration values.",
+            output: "Dictionary of canonical configuration keys to values."
+        ),
+        CLISpecCommand(
+            ["config", "get"],
+            summary: "Read one shared app/CLI configuration value.",
+            arguments: [.argument("key", summary: "Configuration key, such as speech-engine, parakeet-model, nemotron-language, or whisper-language.")],
+            output: "Configuration value."
+        ),
+        CLISpecCommand(
+            ["config", "set"],
+            summary: "Write one shared app/CLI configuration value.",
+            readOnly: false,
+            arguments: [
+                .argument("key", summary: "Configuration key."),
+                .argument("value", summary: "Configuration value."),
+            ],
+            output: "Written canonical configuration value."
+        ),
+        CLISpecCommand(
+            ["models", "list"],
+            summary: "List selectable local speech models.",
+            output: "Array of selectable speech model objects."
+        ),
+        CLISpecCommand(
+            ["models", "select"],
+            summary: "Set the shared app/CLI default speech model.",
+            readOnly: false,
+            arguments: [.argument("model-id", summary: "Model ID from models list.")],
+            output: "Selected speech model object."
+        ),
+        CLISpecCommand(
+            ["models", "status"],
+            summary: "Show local speech and speaker model status without forcing downloads.",
+            output: "SpeechStackPayload object."
+        ),
+        CLISpecCommand(
+            ["models", "download"],
+            summary: "Download a local speech model without selecting it.",
+            readOnly: false,
+            jsonMode: "none",
+            arguments: [.argument("model-id", summary: "Model ID from models list.")],
+            output: "Human-readable progress and completion lines."
+        ),
+        CLISpecCommand(
+            ["models", "delete"],
+            summary: "Delete one downloaded speech model.",
+            readOnly: false,
+            jsonMode: "none",
+            arguments: [.argument("model-id", summary: "Model ID from models list.")],
+            options: [CLISpecParameter.flag("--force", summary: "Delete even when the model is currently in use.")],
+            output: "Human-readable deletion confirmation or no-op line."
+        ),
+        CLISpecCommand(
+            ["models", "warm-up"],
+            summary: "Warm up the selected local speech stack.",
+            readOnly: false,
+            jsonMode: "none",
+            options: [CLISpecParameter.option("--attempts", valueName: "N", summary: "Maximum attempts.")],
+            output: "Human-readable warm-up progress."
+        ),
+        CLISpecCommand(
+            ["models", "repair"],
+            summary: "Best-effort retry for the selected local speech stack.",
+            readOnly: false,
+            jsonMode: "none",
+            options: [CLISpecParameter.option("--attempts", valueName: "N", summary: "Maximum attempts.")],
+            output: "Human-readable repair progress."
+        ),
+        CLISpecCommand(
+            ["models", "clear"],
+            summary: "Delete cached speech and speaker models.",
+            readOnly: false,
+            jsonMode: "none",
+            output: "Human-readable cache clear confirmation."
+        ),
+        CLISpecCommand(
             ["history", "transcriptions"],
             summary: "List saved file, URL, and meeting transcriptions.",
             options: [databaseOption],

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -423,7 +423,10 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
                     self.parakeetModel,
                     storedVariant: SpeechEnginePreference.parakeetModelVariant(defaults: defaults)
                 )
-                let createdSTTClient = STTClient(modelVersion: parakeetVariant.asrModelVersion)
+                let createdSTTClient = STTClient(
+                    modelVersion: parakeetVariant.asrModelVersion,
+                    defaults: defaults
+                )
                 sttClient = createdSTTClient
                 sttTranscriber = createdSTTClient
             case .nemotron:

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -30,6 +30,7 @@ enum TranscribeOutputFormat: String, ExpressibleByArgument, CaseIterable, Sendab
 enum TranscribeSpeechEngine: String, ExpressibleByArgument, CaseIterable, Sendable {
     case appDefault = "app-default"
     case parakeet
+    case nemotron
     case whisper
 }
 
@@ -78,10 +79,10 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
     @Option(help: "Processing mode: raw, clean, app-default.")
     var mode: TranscribeMode = .appDefault
 
-    @Option(help: "Speech engine: app-default, parakeet, whisper. Default: parakeet; app-default follows the saved GUI preference.")
+    @Option(help: "Speech engine: app-default, parakeet, nemotron, whisper. Default: parakeet; app-default follows the saved GUI preference.")
     var engine: TranscribeSpeechEngine = .parakeet
 
-    @Option(help: "Language hint for Whisper, as a Whisper code such as ko or en. Parakeet ignores this flag.")
+    @Option(help: "Language hint for Whisper or Nemotron, such as ko, en, or en-US. Parakeet ignores this flag.")
     var language: String?
 
     @Option(name: .long, help: "Parakeet build: app-default, v3 (multilingual), v2 (English-only). app-default follows the saved preference; ignored for Whisper.")
@@ -185,6 +186,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
         _ engine: TranscribeSpeechEngine,
         storedEngine: String?,
         storedLanguage: String?,
+        storedNemotronLanguage: String? = nil,
         explicitLanguage: String?
     ) -> SpeechEngineSelection {
         let preference: SpeechEnginePreference
@@ -192,10 +194,20 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
         switch engine {
         case .appDefault:
             preference = SpeechEnginePreference(rawValue: storedEngine ?? "") ?? .parakeet
-            language = preference == .whisper ? explicitLanguage ?? storedLanguage : nil
+            language = switch preference {
+            case .parakeet:
+                nil
+            case .nemotron:
+                explicitLanguage ?? storedNemotronLanguage
+            case .whisper:
+                explicitLanguage ?? storedLanguage
+            }
         case .parakeet:
             preference = .parakeet
             language = nil
+        case .nemotron:
+            preference = .nemotron
+            language = explicitLanguage
         case .whisper:
             preference = .whisper
             language = explicitLanguage
@@ -359,6 +371,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
         let writeToFiles = resolvedInputs.count > 1 || outputDir != nil
 
         var sttClient: STTClient?
+        var nemotronEngine: NemotronEngine?
         var whisperEngine: WhisperEngine?
         let runResult: Result<Void, Error>
         do {
@@ -375,6 +388,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
                 self.engine,
                 storedEngine: defaults.string(forKey: SpeechEnginePreference.defaultsKey),
                 storedLanguage: SpeechEnginePreference.whisperDefaultLanguage(defaults: defaults),
+                storedNemotronLanguage: SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults),
                 explicitLanguage: self.language
             )
             let resolvedSpeakerDetection = Self.resolveSpeakerDetection(
@@ -412,6 +426,10 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
                 let createdSTTClient = STTClient(modelVersion: parakeetVariant.asrModelVersion)
                 sttClient = createdSTTClient
                 sttTranscriber = createdSTTClient
+            case .nemotron:
+                let createdNemotronEngine = NemotronEngine(language: speechEngine.language)
+                nemotronEngine = createdNemotronEngine
+                sttTranscriber = createdNemotronEngine
             case .whisper:
                 let createdWhisperEngine = WhisperEngine(language: speechEngine.language)
                 whisperEngine = createdWhisperEngine
@@ -474,6 +492,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
         }
 
         await sttClient?.shutdown()
+        await nemotronEngine?.unload()
         await whisperEngine?.unload()
         try emitJSONOrRethrow(json: format == .json) {
             try runResult.get()
@@ -563,9 +582,9 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
         }
         printErr("Transcribing \(url.lastPathComponent) with \(speechEngine.engine.rawValue)...")
         if noHistory {
-            return try await service.transcribeTransient(fileURL: url)
+            return try await service.transcribeTransient(fileURL: url, onProgress: progressHandler)
         }
-        return try await service.transcribe(fileURL: url)
+        return try await service.transcribe(fileURL: url, onProgress: progressHandler)
     }
 
     /// Expand folder arguments into their supported audio files and

--- a/Sources/MacParakeet/Views/Settings/SettingsStatusRules.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsStatusRules.swift
@@ -37,7 +37,8 @@ enum SettingsStatusRules {
             return SettingsCardStatus(.recommended, label: "Preparing")
         }
 
-        if isAvailable(parakeet), isAvailable(nemotron), isAvailable(whisper) {
+        let optionalNemotronReady = nemotron == .notDownloaded || isAvailable(nemotron)
+        if isAvailable(parakeet), isAvailable(whisper), optionalNemotronReady {
             return SettingsCardStatus(.ok, label: "Ready")
         }
 

--- a/Sources/MacParakeet/Views/Settings/SettingsStatusRules.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsStatusRules.swift
@@ -14,16 +14,18 @@ enum SettingsStatusRules {
 
     static func localModelsCardStatus(
         parakeet: SettingsViewModel.LocalModelStatus,
+        nemotron: SettingsViewModel.LocalModelStatus,
         whisper: SettingsViewModel.LocalModelStatus,
         activeEngine: SpeechEnginePreference
     ) -> SettingsCardStatus? {
-        if parakeet == .failed || whisper == .failed {
+        if parakeet == .failed || nemotron == .failed || whisper == .failed {
             return SettingsCardStatus(.required, label: "Action needed")
         }
 
         let activeStatus: SettingsViewModel.LocalModelStatus
         switch activeEngine {
         case .parakeet: activeStatus = parakeet
+        case .nemotron: activeStatus = nemotron
         case .whisper: activeStatus = whisper
         }
 
@@ -35,7 +37,7 @@ enum SettingsStatusRules {
             return SettingsCardStatus(.recommended, label: "Preparing")
         }
 
-        if isAvailable(parakeet), isAvailable(whisper) {
+        if isAvailable(parakeet), isAvailable(nemotron), isAvailable(whisper) {
             return SettingsCardStatus(.ok, label: "Ready")
         }
 

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -499,11 +499,13 @@ struct SettingsView: View {
     /// variant-agnostic here.
     private enum PendingModelDeletion: Identifiable, Equatable {
         case parakeet(ParakeetModelVariant)
+        case nemotron
         case whisper
 
         var id: String {
             switch self {
             case .parakeet(let variant): "parakeet-\(variant.rawValue)"
+            case .nemotron: "nemotron"
             case .whisper: "whisper"
             }
         }
@@ -514,6 +516,7 @@ struct SettingsView: View {
     private var modelDeletionAlertTitle: String {
         switch pendingModelDeletion {
         case .parakeet(let variant): "Delete \(variant.modelName)?"
+        case .nemotron: "Delete the Nemotron model?"
         case .whisper: "Delete the Whisper model?"
         case nil: "Delete this model?"
         }
@@ -522,6 +525,9 @@ struct SettingsView: View {
     private func modelDeletionMessage(for deletion: PendingModelDeletion) -> String {
         switch deletion {
         case .parakeet(let variant):
+            return "This frees \(variant.approximateDownloadSize). You can download \(variant.modelName) again at any time."
+        case .nemotron:
+            let variant = SpeechEnginePreference.defaultNemotronModelVariant
             return "This frees \(variant.approximateDownloadSize). You can download \(variant.modelName) again at any time."
         case .whisper:
             return "This removes the configured Whisper model download from this Mac. You can download it again at any time."
@@ -532,6 +538,8 @@ struct SettingsView: View {
         switch deletion {
         case .parakeet(let variant):
             viewModel.deleteParakeetVariant(variant)
+        case .nemotron:
+            viewModel.deleteNemotronModel()
         case .whisper:
             viewModel.deleteWhisperModel()
         }
@@ -547,6 +555,8 @@ struct SettingsView: View {
 
     private func speechEngineSwitchConfirmationMessage(for engine: SpeechEnginePreference) -> String {
         switch engine {
+        case .nemotron:
+            return "Nemotron 3.5 is a Beta engine. It may take a moment to download or load, and transcript quality can vary while benchmarks are in progress. Dictation, file transcription, and meetings pause until the switch finishes."
         case .whisper:
             if viewModel.whisperHasBeenOptimized {
                 return "Whisper may take a moment to load. Dictation, file transcription, and meetings pause until the switch finishes."
@@ -1951,7 +1961,7 @@ struct SettingsView: View {
                     speechEngineSwitchBanner(title: banner.title, detail: banner.detail)
                 }
 
-                HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+                LazyVGrid(columns: engineOptionColumns, alignment: .leading, spacing: DesignSystem.Spacing.md) {
                     EngineOptionTile(
                         icon: "bolt.fill",
                         name: "Parakeet",
@@ -1967,6 +1977,23 @@ struct SettingsView: View {
                         isBusy: viewModel.speechEngineSwitching,
                         unavailableReason: engineSwitchUnavailableReason(for: .parakeet),
                         onSelect: { selectEngine(.parakeet) }
+                    )
+
+                    EngineOptionTile(
+                        icon: "sparkles",
+                        name: "Nemotron",
+                        tagline: "Frontier multilingual Beta",
+                        strengths: [
+                            "Nemotron 3.5 ASR Streaming",
+                            "Multilingual auto detection",
+                            "Runs locally on Apple Silicon"
+                        ],
+                        helpText: "Beta engine for trying Nemotron 3.5 locally. Best for users who want to compare the newest multilingual model while MacParakeet benchmarks quality and edge cases.",
+                        modelStatus: displayedNemotronModelStatus,
+                        isSelected: viewModel.speechEnginePreference == .nemotron,
+                        isBusy: viewModel.speechEngineSwitching,
+                        unavailableReason: engineSwitchUnavailableReason(for: .nemotron),
+                        onSelect: { handleNemotronTileTap() }
                     )
 
                     EngineOptionTile(
@@ -1989,6 +2016,15 @@ struct SettingsView: View {
                     )
                 }
 
+                if let banner = nemotronDownloadBannerState {
+                    EngineDownloadBanner(
+                        title: "Nemotron 3.5 Beta",
+                        subtitle: banner.subtitle,
+                        mode: banner.mode,
+                        action: { viewModel.downloadNemotronModel() }
+                    )
+                }
+
                 if let banner = whisperDownloadBannerState {
                     EngineDownloadBanner(
                         title: "Whisper Large v3 Turbo",
@@ -2005,6 +2041,10 @@ struct SettingsView: View {
                 }
             }
         }
+    }
+
+    private var engineOptionColumns: [GridItem] {
+        [GridItem(.adaptive(minimum: 260), spacing: DesignSystem.Spacing.md, alignment: .top)]
     }
 
     /// Parakeet build picker (multilingual `v3` vs English-only `v2`). Only
@@ -2177,6 +2217,18 @@ struct SettingsView: View {
                 Divider()
 
                 modelStatusRow(
+                    title: "Nemotron",
+                    detail: displayedNemotronModelStatusDetail,
+                    status: displayedNemotronModelStatus,
+                    isWorking: viewModel.nemotronDownloading,
+                    actionsDisabled: viewModel.speechEngineSwitching,
+                    primaryAction: displayedNemotronModelStatus == .preparing ? nil : nemotronPrimaryAction,
+                    overflowActions: displayedNemotronModelStatus == .preparing ? [] : nemotronOverflowActions
+                )
+
+                Divider()
+
+                modelStatusRow(
                     title: "Whisper",
                     detail: displayedWhisperModelStatusDetail,
                     status: displayedWhisperModelStatus,
@@ -2216,12 +2268,20 @@ struct SettingsView: View {
             return "Updating Parakeet model"
         }
         let target = currentSpeechEngineSwitchTarget
-        return target == .whisper ? "Preparing Whisper" : "Switching to \(target.displayName)"
+        switch target {
+        case .parakeet:
+            return "Switching to Parakeet"
+        case .nemotron:
+            return "Preparing Nemotron"
+        case .whisper:
+            return "Preparing Whisper"
+        }
     }
 
     private var enginesModelsCardStatus: SettingsCardStatus? {
         SettingsStatusRules.localModelsCardStatus(
             parakeet: displayedParakeetModelStatus,
+            nemotron: displayedNemotronModelStatus,
             whisper: displayedWhisperModelStatus,
             activeEngine: viewModel.speechEnginePreference
         )
@@ -2266,6 +2326,22 @@ struct SettingsView: View {
             return viewModel.whisperModelStatusDetail
         }
         return viewModel.speechEngineSwitchDetail ?? "Optimizing Whisper for this Mac..."
+    }
+
+    private var displayedNemotronModelStatus: SettingsViewModel.LocalModelStatus {
+        guard viewModel.speechEngineSwitching,
+              currentSpeechEngineSwitchTarget == .nemotron else {
+            return viewModel.nemotronModelStatus
+        }
+        return .preparing
+    }
+
+    private var displayedNemotronModelStatusDetail: String {
+        guard viewModel.speechEngineSwitching,
+              currentSpeechEngineSwitchTarget == .nemotron else {
+            return viewModel.nemotronModelStatusDetail
+        }
+        return viewModel.speechEngineSwitchDetail ?? "Loading Nemotron 3.5 Beta on Neural Engine..."
     }
 
     private func speechEngineSwitchBanner(title: String, detail: String) -> some View {
@@ -2346,6 +2422,23 @@ struct SettingsView: View {
         }
     }
 
+    private var nemotronDownloadBannerState: (mode: EngineDownloadBanner.Mode, subtitle: String)? {
+        guard viewModel.speechEnginePreference == .nemotron else { return nil }
+        if viewModel.nemotronDownloading {
+            return (.downloading, viewModel.nemotronModelStatusDetail)
+        }
+        switch viewModel.nemotronModelStatus {
+        case .notDownloaded:
+            return (.download, "\(SpeechEnginePreference.defaultNemotronModelVariant.approximateDownloadSize) · Beta model, downloads once and runs locally")
+        case .repairing:
+            return (.downloading, viewModel.nemotronModelStatusDetail)
+        case .failed:
+            return (.retry, viewModel.nemotronModelStatusDetail)
+        case .ready, .notLoaded, .preparing, .checking, .unknown:
+            return nil
+        }
+    }
+
     /// Pre-empts every "Whisper isn't ready" state so the user never sees
     /// a briefly-selected-then-reverted tile. Mirrors the VM's
     /// `isWhisperModelAvailable` (`ready` or `notLoaded`); for everything
@@ -2368,6 +2461,10 @@ struct SettingsView: View {
         case .checking, .unknown:
             selectEngine(.whisper)
         }
+    }
+
+    private func handleNemotronTileTap() {
+        selectEngine(.nemotron)
     }
 
     private var parakeetPrimaryAction: ModelRowAction? {
@@ -2432,6 +2529,55 @@ struct SettingsView: View {
             }
         default:
             return nil
+        }
+    }
+
+    private var nemotronPrimaryAction: ModelRowAction? {
+        switch viewModel.nemotronModelStatus {
+        case .notDownloaded:
+            return ModelRowAction(
+                label: "Download",
+                isProminent: true,
+                help: "Download Nemotron 3.5 Beta for local multilingual speech recognition."
+            ) {
+                viewModel.downloadNemotronModel()
+            }
+        case .failed:
+            return ModelRowAction(
+                label: "Retry",
+                isProminent: true,
+                help: "Try downloading the Nemotron model again."
+            ) {
+                viewModel.downloadNemotronModel()
+            }
+        default:
+            return nil
+        }
+    }
+
+    private var nemotronOverflowActions: [ModelRowAction] {
+        switch viewModel.nemotronModelStatus {
+        case .ready, .notLoaded:
+            var actions = [ModelRowAction(
+                label: "Repair…",
+                isProminent: false,
+                help: "Re-check the Nemotron files and re-download any missing model assets."
+            ) {
+                viewModel.downloadNemotronModel()
+            }]
+            if viewModel.speechEnginePreference != .nemotron {
+                actions.append(ModelRowAction(
+                    label: "Delete download…",
+                    isProminent: false,
+                    isDestructive: true,
+                    help: "Remove the Nemotron model download from this Mac."
+                ) {
+                    pendingModelDeletion = .nemotron
+                })
+            }
+            return actions
+        default:
+            return []
         }
     }
 

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -2464,7 +2464,20 @@ struct SettingsView: View {
     }
 
     private func handleNemotronTileTap() {
-        selectEngine(.nemotron)
+        switch viewModel.nemotronModelStatus {
+        case .ready, .notLoaded:
+            selectEngine(.nemotron)
+        case .notDownloaded:
+            viewModel.speechEngineError = "Download the Nemotron model from Local Models below before switching engines."
+        case .repairing:
+            viewModel.speechEngineError = "Nemotron model is downloading — switch engines once it finishes."
+        case .preparing:
+            viewModel.speechEngineError = "Nemotron is preparing for this Mac — switch engines once it finishes."
+        case .failed:
+            viewModel.speechEngineError = "Nemotron model failed to load — retry below."
+        case .checking, .unknown:
+            selectEngine(.nemotron)
+        }
     }
 
     private var parakeetPrimaryAction: ModelRowAction? {

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -679,6 +679,8 @@ struct TranscriptResultView: View {
         switch preference {
         case .parakeet:
             return "Parakeet TDT"
+        case .nemotron:
+            return "Nemotron 3.5 Beta"
         case .whisper:
             guard let variant = activeTranscription.engineVariant else {
                 return "Whisper"
@@ -2866,6 +2868,7 @@ private struct EngineOptionCard: View {
     private var iconName: String {
         switch selection.engine {
         case .parakeet: "bolt.fill"
+        case .nemotron: "sparkles"
         case .whisper: "globe"
         }
     }
@@ -2874,13 +2877,15 @@ private struct EngineOptionCard: View {
         switch selection.engine {
         case .parakeet:
             "Fast • 25 European languages, including English"
+        case .nemotron:
+            "Beta • Nemotron 3.5 multilingual streaming"
         case .whisper:
             "Broader languages • Korean, Chinese, Japanese, and more"
         }
     }
 
     private var languageDetail: String? {
-        guard selection.engine == .whisper else { return nil }
+        guard selection.engine == .whisper || selection.engine == .nemotron else { return nil }
         let language = selection.language ?? "auto-detect"
         return "Language: \(language)"
     }

--- a/Sources/MacParakeetCore/Models/Transcription.swift
+++ b/Sources/MacParakeetCore/Models/Transcription.swift
@@ -44,7 +44,8 @@ public struct Transcription: Codable, Identifiable, Sendable {
     /// summary generation (ADR-020 §3). `nil` for non-meeting transcripts
     /// and for meetings where the user took no notes.
     public var userNotes: String?
-    /// STT engine that produced this transcript (`"parakeet"` / `"whisper"`).
+    /// STT engine that produced this transcript (`"parakeet"` / `"nemotron"` /
+    /// `"whisper"`).
     /// `nil` for rows created before the v0.8 engine-attribution migration.
     public var engine: String?
     /// Engine-specific model variant id (e.g. the Whisper model id).

--- a/Sources/MacParakeetCore/STT/NemotronEngine.swift
+++ b/Sources/MacParakeetCore/STT/NemotronEngine.swift
@@ -9,12 +9,12 @@ public actor NemotronEngine: STTTranscribing {
 
     private let modelVariant: NemotronModelVariant
     private let defaultLanguage: String?
-    private let audioConverter = AudioConverter()
 
     private var sharedModels: SharedNemotronMultilingualModels?
     private var interactiveManager: StreamingNemotronMultilingualAsrManager?
     private var backgroundManager: StreamingNemotronMultilingualAsrManager?
     private var initializationTask: Task<Void, Error>?
+    private var activeLanes: Set<NemotronRuntimeLane> = []
 
     public init(
         modelVariant: NemotronModelVariant = NemotronEngine.defaultModelVariant,
@@ -43,9 +43,14 @@ public actor NemotronEngine: STTTranscribing {
         language: String?,
         onProgress: (@Sendable (Int, Int) -> Void)? = nil
     ) async throws -> STTResult {
+        let lane = route(for: job)
+        guard beginTranscription(on: lane) else {
+            throw STTError.engineBusy
+        }
+        defer { endTranscription(on: lane) }
+
         do {
             try await prepare(onProgress: nil)
-            let lane = route(for: job)
             guard let manager = manager(for: lane) else {
                 throw STTError.modelNotLoaded
             }
@@ -54,7 +59,9 @@ public actor NemotronEngine: STTTranscribing {
 
             onProgress?(0, 100)
             try Task.checkCancellation()
-            let samples = try audioConverter.resampleAudioFile(audioURL)
+            let samples = try await Task.detached(priority: .userInitiated) {
+                try AudioConverter().resampleAudioFile(audioURL)
+            }.value
             onProgress?(25, 100)
             try Task.checkCancellation()
             _ = try await manager.process(samples: samples)
@@ -117,10 +124,13 @@ public actor NemotronEngine: STTTranscribing {
     }
 
     public nonisolated static func defaultCacheRoot() -> URL {
-        FileManager.default.urls(
+        let appSupport = FileManager.default.urls(
             for: .applicationSupportDirectory,
             in: .userDomainMask
-        ).first!
+        ).first ?? FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+        return appSupport
             .appendingPathComponent("FluidAudio", isDirectory: true)
             .appendingPathComponent("Models", isDirectory: true)
             .appendingPathComponent(Repo.nemotronMultilingual.folderName, isDirectory: true)
@@ -222,6 +232,16 @@ public actor NemotronEngine: STTTranscribing {
         }
     }
 
+    private func beginTranscription(on lane: NemotronRuntimeLane) -> Bool {
+        guard !activeLanes.contains(lane) else { return false }
+        activeLanes.insert(lane)
+        return true
+    }
+
+    private func endTranscription(on lane: NemotronRuntimeLane) {
+        activeLanes.remove(lane)
+    }
+
     private nonisolated static func makeDownloadProgressHandler(
         _ onProgress: (@Sendable (String) -> Void)?
     ) -> DownloadUtils.ProgressHandler? {
@@ -316,7 +336,7 @@ public actor NemotronEngine: STTTranscribing {
     }
 }
 
-private enum NemotronRuntimeLane: Sendable {
+private enum NemotronRuntimeLane: Hashable, Sendable {
     case interactive
     case background
 }

--- a/Sources/MacParakeetCore/STT/NemotronEngine.swift
+++ b/Sources/MacParakeetCore/STT/NemotronEngine.swift
@@ -161,15 +161,95 @@ public actor NemotronEngine: STTTranscribing {
         modelVariant: NemotronModelVariant = defaultModelVariant,
         language: String? = nil
     ) -> Bool {
-        let directory = defaultVariantDirectory(modelVariant: modelVariant, language: language)
+        deleteModel(
+            modelVariant: modelVariant,
+            language: language,
+            cacheRoot: defaultCacheRoot()
+        )
+    }
+
+    @discardableResult
+    nonisolated static func deleteModel(
+        modelVariant: NemotronModelVariant = defaultModelVariant,
+        language: String? = nil,
+        cacheRoot: URL
+    ) -> Bool {
+        let trimmedLanguage = language?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let trimmedLanguage,
+              !trimmedLanguage.isEmpty,
+              trimmedLanguage.lowercased() != "auto" else {
+            return deleteModelCaches(modelVariant: modelVariant, cacheRoot: cacheRoot)
+        }
+        guard let language = SpeechEnginePreference.normalizeNemotronLanguage(trimmedLanguage) else {
+            return false
+        }
+
+        return deleteModelCache(
+            modelVariant: modelVariant,
+            language: language,
+            cacheRoot: cacheRoot
+        )
+    }
+
+    @discardableResult
+    nonisolated static func deleteModelCaches(
+        modelVariant: NemotronModelVariant = defaultModelVariant,
+        cacheRoot: URL = defaultCacheRoot()
+    ) -> Bool {
         let fileManager = FileManager.default
-        guard fileManager.fileExists(atPath: directory.path) else { return false }
+        guard fileManager.fileExists(atPath: cacheRoot.path) else { return false }
+
+        let languageDirectories = (try? fileManager.contentsOfDirectory(
+            at: cacheRoot,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        )) ?? []
+
+        var removedAny = false
+        for languageDirectory in languageDirectories {
+            let variantDirectory = languageDirectory
+                .appendingPathComponent("\(modelVariant.chunkMilliseconds)ms", isDirectory: true)
+            guard fileManager.fileExists(atPath: variantDirectory.path) else { continue }
+            do {
+                try fileManager.removeItem(at: variantDirectory)
+                removedAny = true
+            } catch {
+                return false
+            }
+            removeIfEmpty(languageDirectory, fileManager: fileManager)
+        }
+
+        removeIfEmpty(cacheRoot, fileManager: fileManager)
+        return removedAny
+    }
+
+    private nonisolated static func deleteModelCache(
+        modelVariant: NemotronModelVariant,
+        language: String,
+        cacheRoot: URL
+    ) -> Bool {
+        let languageDirectory = StreamingNemotronMultilingualAsrManager.languageDirectory(for: language)
+        let fileManager = FileManager.default
+        let targetDirectory = cacheRoot
+            .appendingPathComponent(languageDirectory, isDirectory: true)
+            .appendingPathComponent("\(modelVariant.chunkMilliseconds)ms", isDirectory: true)
+        guard fileManager.fileExists(atPath: targetDirectory.path) else { return false }
         do {
-            try fileManager.removeItem(at: directory)
+            try fileManager.removeItem(at: targetDirectory)
         } catch {
             return false
         }
-        return !fileManager.fileExists(atPath: directory.path)
+        removeIfEmpty(targetDirectory.deletingLastPathComponent(), fileManager: fileManager)
+        removeIfEmpty(cacheRoot, fileManager: fileManager)
+        return !fileManager.fileExists(atPath: targetDirectory.path)
+    }
+
+    private nonisolated static func removeIfEmpty(_ directory: URL, fileManager: FileManager) {
+        guard let children = try? fileManager.contentsOfDirectory(atPath: directory.path),
+              children.isEmpty else {
+            return
+        }
+        try? fileManager.removeItem(at: directory)
     }
 
     public nonisolated static func downloadModel(

--- a/Sources/MacParakeetCore/STT/NemotronEngine.swift
+++ b/Sources/MacParakeetCore/STT/NemotronEngine.swift
@@ -206,6 +206,7 @@ public actor NemotronEngine: STTTranscribing {
         )) ?? []
 
         var removedAny = false
+        var removalFailed = false
         for languageDirectory in languageDirectories {
             let variantDirectory = languageDirectory
                 .appendingPathComponent("\(modelVariant.chunkMilliseconds)ms", isDirectory: true)
@@ -214,13 +215,14 @@ public actor NemotronEngine: STTTranscribing {
                 try fileManager.removeItem(at: variantDirectory)
                 removedAny = true
             } catch {
-                return false
+                removalFailed = true
+                continue
             }
             removeIfEmpty(languageDirectory, fileManager: fileManager)
         }
 
         removeIfEmpty(cacheRoot, fileManager: fileManager)
-        return removedAny
+        return removedAny && !removalFailed
     }
 
     private nonisolated static func deleteModelCache(

--- a/Sources/MacParakeetCore/STT/NemotronEngine.swift
+++ b/Sources/MacParakeetCore/STT/NemotronEngine.swift
@@ -1,0 +1,330 @@
+import FluidAudio
+import Foundation
+import os
+
+public actor NemotronEngine: STTTranscribing {
+    public static let defaultModelVariant = SpeechEnginePreference.defaultNemotronModelVariant
+
+    private let logger = Logger(subsystem: "com.macparakeet.core", category: "NemotronEngine")
+
+    private let modelVariant: NemotronModelVariant
+    private let defaultLanguage: String?
+    private let audioConverter = AudioConverter()
+
+    private var sharedModels: SharedNemotronMultilingualModels?
+    private var interactiveManager: StreamingNemotronMultilingualAsrManager?
+    private var backgroundManager: StreamingNemotronMultilingualAsrManager?
+    private var initializationTask: Task<Void, Error>?
+
+    public init(
+        modelVariant: NemotronModelVariant = NemotronEngine.defaultModelVariant,
+        language: String? = nil
+    ) {
+        self.modelVariant = modelVariant
+        self.defaultLanguage = SpeechEnginePreference.normalizeNemotronLanguage(language)
+    }
+
+    public func transcribe(
+        audioPath: String,
+        job: STTJobKind,
+        onProgress: (@Sendable (Int, Int) -> Void)? = nil
+    ) async throws -> STTResult {
+        try await transcribe(
+            audioURL: URL(fileURLWithPath: audioPath),
+            job: job,
+            language: defaultLanguage,
+            onProgress: onProgress
+        )
+    }
+
+    public func transcribe(
+        audioURL: URL,
+        job: STTJobKind,
+        language: String?,
+        onProgress: (@Sendable (Int, Int) -> Void)? = nil
+    ) async throws -> STTResult {
+        do {
+            try await prepare(onProgress: nil)
+            let lane = route(for: job)
+            guard let manager = manager(for: lane) else {
+                throw STTError.modelNotLoaded
+            }
+            let requestedLanguage = SpeechEnginePreference.normalizeNemotronLanguage(language)
+            await manager.configureForMacParakeet(language: requestedLanguage)
+
+            onProgress?(0, 100)
+            try Task.checkCancellation()
+            let samples = try audioConverter.resampleAudioFile(audioURL)
+            onProgress?(25, 100)
+            try Task.checkCancellation()
+            _ = try await manager.process(samples: samples)
+            onProgress?(90, 100)
+            let text = try await manager.finish()
+            let detectedLanguage = await manager.detectedLanguage()
+            onProgress?(100, 100)
+
+            return STTResult(
+                text: text,
+                words: [],
+                language: detectedLanguage ?? requestedLanguage,
+                engine: .nemotron,
+                engineVariant: modelVariant.rawValue
+            )
+        } catch {
+            throw try Self.mapTranscriptionError(error)
+        }
+    }
+
+    public func prepare(onProgress: (@Sendable (String) -> Void)? = nil) async throws {
+        if isLoaded { return }
+
+        if let initializationTask {
+            try await initializationTask.value
+            return
+        }
+
+        let task = Task {
+            try await loadSharedModels(onProgress: onProgress)
+        }
+        initializationTask = task
+
+        do {
+            try await task.value
+            initializationTask = nil
+        } catch {
+            initializationTask = nil
+            throw try Self.mapWarmUpError(error)
+        }
+    }
+
+    public func unload() async {
+        initializationTask?.cancel()
+        _ = try? await initializationTask?.value
+        initializationTask = nil
+
+        let interactiveManager = self.interactiveManager
+        let backgroundManager = self.backgroundManager
+        self.interactiveManager = nil
+        self.backgroundManager = nil
+        self.sharedModels = nil
+
+        await interactiveManager?.cleanup()
+        await backgroundManager?.cleanup()
+    }
+
+    public func isReady() -> Bool {
+        isLoaded
+    }
+
+    public nonisolated static func defaultCacheRoot() -> URL {
+        FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first!
+            .appendingPathComponent("FluidAudio", isDirectory: true)
+            .appendingPathComponent("Models", isDirectory: true)
+            .appendingPathComponent(Repo.nemotronMultilingual.folderName, isDirectory: true)
+    }
+
+    public nonisolated static func defaultVariantDirectory(
+        modelVariant: NemotronModelVariant = defaultModelVariant,
+        language: String? = nil
+    ) -> URL {
+        let languageCode = SpeechEnginePreference.normalizeNemotronLanguage(language) ?? "auto"
+        let languageDirectory = StreamingNemotronMultilingualAsrManager.languageDirectory(for: languageCode)
+        return defaultCacheRoot()
+            .appendingPathComponent(languageDirectory, isDirectory: true)
+            .appendingPathComponent("\(modelVariant.chunkMilliseconds)ms", isDirectory: true)
+    }
+
+    public nonisolated static func isModelCached(
+        modelVariant: NemotronModelVariant = defaultModelVariant,
+        language: String? = nil
+    ) -> Bool {
+        let metadata = defaultVariantDirectory(modelVariant: modelVariant, language: language)
+            .appendingPathComponent(ModelNames.NemotronMultilingualStreaming.metadata)
+        return FileManager.default.fileExists(atPath: metadata.path)
+    }
+
+    @discardableResult
+    public nonisolated static func deleteModel(
+        modelVariant: NemotronModelVariant = defaultModelVariant,
+        language: String? = nil
+    ) -> Bool {
+        let directory = defaultVariantDirectory(modelVariant: modelVariant, language: language)
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: directory.path) else { return false }
+        do {
+            try fileManager.removeItem(at: directory)
+        } catch {
+            return false
+        }
+        return !fileManager.fileExists(atPath: directory.path)
+    }
+
+    public nonisolated static func downloadModel(
+        modelVariant: NemotronModelVariant = defaultModelVariant,
+        language: String? = nil,
+        onProgress: (@Sendable (String) -> Void)? = nil
+    ) async throws -> URL {
+        let progressHandler = makeDownloadProgressHandler(onProgress)
+        return try await StreamingNemotronMultilingualAsrManager.downloadVariant(
+            languageCode: SpeechEnginePreference.normalizeNemotronLanguage(language) ?? "auto",
+            chunkMs: modelVariant.chunkMilliseconds,
+            progressHandler: progressHandler
+        )
+    }
+
+    private var isLoaded: Bool {
+        sharedModels != nil && interactiveManager != nil && backgroundManager != nil
+    }
+
+    private func loadSharedModels(onProgress: (@Sendable (String) -> Void)?) async throws {
+        let languageCode = defaultLanguage ?? "auto"
+        let progressHandler = Self.makeDownloadProgressHandler(onProgress)
+        onProgress?("Preparing Nemotron model download...")
+        let shared = try await StreamingNemotronMultilingualAsrManager.downloadAndPreloadShared(
+            languageCode: languageCode,
+            chunkMs: modelVariant.chunkMilliseconds,
+            progressHandler: progressHandler
+        )
+
+        let loadedInteractiveManager = StreamingNemotronMultilingualAsrManager()
+        let loadedBackgroundManager = StreamingNemotronMultilingualAsrManager()
+        try await loadedInteractiveManager.loadFromShared(shared)
+        try await loadedBackgroundManager.loadFromShared(shared)
+        await loadedInteractiveManager.configureForMacParakeet(language: defaultLanguage)
+        await loadedBackgroundManager.configureForMacParakeet(language: defaultLanguage)
+
+        self.sharedModels = shared
+        self.interactiveManager = loadedInteractiveManager
+        self.backgroundManager = loadedBackgroundManager
+        logger.notice("nemotron_model_prepare_complete variant=\(self.modelVariant.rawValue, privacy: .public)")
+        AudioCaptureDiagnostics.append("nemotron_model_prepare_complete variant=\(self.modelVariant.rawValue)")
+        onProgress?("Ready")
+    }
+
+    private func manager(for lane: NemotronRuntimeLane) -> StreamingNemotronMultilingualAsrManager? {
+        switch lane {
+        case .interactive:
+            interactiveManager
+        case .background:
+            backgroundManager
+        }
+    }
+
+    private func route(for job: STTJobKind) -> NemotronRuntimeLane {
+        switch job {
+        case .dictation:
+            .interactive
+        case .meetingFinalize, .meetingLiveChunk, .fileTranscription:
+            .background
+        }
+    }
+
+    private nonisolated static func makeDownloadProgressHandler(
+        _ onProgress: (@Sendable (String) -> Void)?
+    ) -> DownloadUtils.ProgressHandler? {
+        guard let onProgress else { return nil }
+        let clock = ContinuousClock()
+        let lastProgressUpdate = OSAllocatedUnfairLock(initialState: clock.now - .seconds(1))
+        let lastProgressMessage = OSAllocatedUnfairLock(initialState: "")
+        return { progress in
+            guard let message = Self.progressMessage(from: progress) else { return }
+            let now = clock.now
+            let shouldEmit = lastProgressUpdate.withLock { lastUpdate in
+                guard lastUpdate.duration(to: now) >= .milliseconds(250) else { return false }
+                lastUpdate = now
+                return true
+            }
+            guard shouldEmit else { return }
+
+            let isNewMessage = lastProgressMessage.withLock { lastMessage in
+                guard lastMessage != message else { return false }
+                lastMessage = message
+                return true
+            }
+            guard isNewMessage else { return }
+
+            onProgress(message)
+        }
+    }
+
+    private nonisolated static func progressMessage(from progress: DownloadUtils.DownloadProgress) -> String? {
+        switch progress.phase {
+        case .listing:
+            return "Preparing Nemotron model download..."
+        case .downloading(let completedFiles, let totalFiles):
+            guard totalFiles > 0 else { return nil }
+            let percent = max(0, min(100, Int(progress.fractionCompleted * 100.0)))
+            return "Downloading Nemotron model... \(percent)% (\(completedFiles)/\(totalFiles))"
+        case .compiling:
+            return "Compiling Nemotron model..."
+        }
+    }
+
+    private nonisolated static func mapWarmUpError(_ error: Error) throws -> STTError {
+        if error is CancellationError {
+            throw error
+        }
+        if let mapped = mapCommonError(error) {
+            return mapped
+        }
+        return .engineStartFailed(error.localizedDescription)
+    }
+
+    private nonisolated static func mapTranscriptionError(_ error: Error) throws -> STTError {
+        if error is CancellationError {
+            throw error
+        }
+        if let mapped = mapCommonError(error) {
+            return mapped
+        }
+        return .transcriptionFailed(error.localizedDescription)
+    }
+
+    private nonisolated static func mapCommonError(_ error: Error) -> STTError? {
+        if let sttError = error as? STTError {
+            return sttError
+        }
+        if let asrError = error as? ASRError {
+            switch asrError {
+            case .notInitialized:
+                return .modelNotLoaded
+            case .invalidAudioData:
+                return .transcriptionFailed(asrError.localizedDescription)
+            case .modelLoadFailed, .modelCompilationFailed:
+                return .engineStartFailed(asrError.localizedDescription)
+            case .processingFailed(let message):
+                return .transcriptionFailed(message)
+            case .unsupportedPlatform(let message):
+                return .engineStartFailed(message)
+            case .streamingConversionFailed, .fileAccessFailed:
+                return .transcriptionFailed(asrError.localizedDescription)
+            }
+        }
+        if let urlError = error as? URLError {
+            switch urlError.code {
+            case .notConnectedToInternet, .networkConnectionLost, .timedOut,
+                 .cannotFindHost, .cannotConnectToHost, .dnsLookupFailed:
+                return .modelDownloadFailed
+            default:
+                return .engineStartFailed(urlError.localizedDescription)
+            }
+        }
+        return nil
+    }
+}
+
+private enum NemotronRuntimeLane: Sendable {
+    case interactive
+    case background
+}
+
+private extension StreamingNemotronMultilingualAsrManager {
+    func configureForMacParakeet(language: String?) async {
+        await reset()
+        await setLanguage(language)
+        appendTerminalPunctuation = true
+    }
+}

--- a/Sources/MacParakeetCore/STT/README.md
+++ b/Sources/MacParakeetCore/STT/README.md
@@ -2,8 +2,9 @@
 
 > One process-wide speech-to-text control plane. Parakeet (FluidAudio /
 > CoreML) is default, with v3 multilingual as the default build and v2
-> English-only as an opt-in Parakeet variant; WhisperKit is optional for
-> languages outside Parakeet's coverage.
+> English-only as an opt-in Parakeet variant; Nemotron 3.5 is an opt-in
+> Beta local multilingual engine; WhisperKit is optional for languages
+> outside Parakeet/Nemotron coverage.
 
 ## Entry point
 
@@ -18,9 +19,9 @@ to one `STTRuntime`; callers do not own model lifecycles directly.
 **Speech control plane**
 - `STTScheduler.swift` — public broker. Job admission, slot scheduling,
   engine routing, session leases for active meetings.
-- `STTRuntime.swift` — sole owner of the Parakeet `AsrManager`s and
-  the optional `WhisperEngine`. Handles warm-up, model init, cache
-  clearing, shutdown.
+- `STTRuntime.swift` — sole owner of the Parakeet `AsrManager`s, the
+  optional Beta `NemotronEngine`, and the optional `WhisperEngine`.
+  Handles warm-up, model init, cache clearing, shutdown.
 - `STTClient.swift` + `STTClientProtocol.swift` — **CLI / test
   facade only**. Each `STTClient` instantiates its own runtime and
   scheduler, bypassing the process singleton. App code must use the
@@ -31,6 +32,9 @@ to one `STTRuntime`; callers do not own model lifecycles directly.
   variant).
 - `WhisperEngine.swift` — WhisperKit wrapper conforming to the same
   shape as the Parakeet path.
+- `NemotronEngine.swift` — FluidAudio Nemotron 3.5 wrapper for the
+  Beta local multilingual engine. Uses separate interactive/background
+  managers backed by shared model weights so it fits the scheduler lanes.
 
 **Hotkey state (lives here for testability)**
 - `FnKeyStateMachine.swift` — pure state machine for legacy combined
@@ -83,10 +87,11 @@ shared slot drops the lowest-priority pending work.
 **Engine routing is per-job.** Parakeet stays default. The selected Parakeet
 build is `v3` unless the user opts into `v2` through Settings or the CLI
 (`config set parakeet-model`, `models select parakeet-v2`, or
-`transcribe --parakeet-model v2`). A subscriber can request WhisperKit globally
-(Settings) or per call (CLI `--engine whisper --language ko`). When set
-globally, dictation also routes there; when set per-job, only that job uses
-Whisper.
+`transcribe --parakeet-model v2`). A subscriber can request Nemotron or
+WhisperKit globally (Settings / `models select`) or per call (CLI
+`--engine nemotron --language ko`, `--engine whisper --language ko`). When set
+globally, dictation also routes there; when set per-job, only that job uses the
+requested engine.
 
 **Active meetings hold an engine lease.** Once a meeting recording
 starts, its engine selection is captured for the session's duration.
@@ -119,5 +124,7 @@ real events into the controller's input shape.
   dictation), start a meeting and dictate during it, kick off a
   long file transcription and confirm cancellation works mid-job.
 - For engine routing: run the CLI
+  `swift run macparakeet-cli transcribe --engine nemotron --language ja
+  /path/to/japanese.m4a` and
   `swift run macparakeet-cli transcribe --engine whisper --language ja
-  /path/to/japanese.m4a` and confirm Whisper is used.
+  /path/to/japanese.m4a`, then confirm the requested engine is used.

--- a/Sources/MacParakeetCore/STT/STTClient.swift
+++ b/Sources/MacParakeetCore/STT/STTClient.swift
@@ -10,8 +10,18 @@ import Foundation
 public actor STTClient: STTManaging, SpeechEngineRoutedTranscribing, SpeechEngineSwitching, SpeechEngineSwitchAvailabilityProviding, SpeechEngineSessionManaging {
     private let scheduler: STTScheduler
 
-    public init(modelVersion: AsrModelVersion = .v3) {
-        let runtime = STTRuntime(modelVersion: modelVersion)
+    public init(
+        modelVersion: AsrModelVersion = .v3,
+        speechEngine: SpeechEnginePreference = .parakeet,
+        nemotronModelVariant: NemotronModelVariant = SpeechEnginePreference.defaultNemotronModelVariant,
+        whisperModelVariant: String = SpeechEnginePreference.defaultWhisperModelVariant
+    ) {
+        let runtime = STTRuntime(
+            modelVersion: modelVersion,
+            speechEngine: speechEngine,
+            nemotronModelVariant: nemotronModelVariant,
+            whisperModelVariant: whisperModelVariant
+        )
         self.scheduler = STTScheduler(runtime: runtime)
     }
 
@@ -97,5 +107,12 @@ public actor STTClient: STTManaging, SpeechEngineRoutedTranscribing, SpeechEngin
 
     public nonisolated static func isModelCached(version: AsrModelVersion = .v3) -> Bool {
         STTRuntime.isModelCached(version: version)
+    }
+
+    public nonisolated static func isNemotronModelCached(
+        modelVariant: NemotronModelVariant = SpeechEnginePreference.defaultNemotronModelVariant,
+        language: String? = nil
+    ) -> Bool {
+        STTRuntime.isNemotronModelCached(modelVariant: modelVariant, language: language)
     }
 }

--- a/Sources/MacParakeetCore/STT/STTClient.swift
+++ b/Sources/MacParakeetCore/STT/STTClient.swift
@@ -14,13 +14,15 @@ public actor STTClient: STTManaging, SpeechEngineRoutedTranscribing, SpeechEngin
         modelVersion: AsrModelVersion = .v3,
         speechEngine: SpeechEnginePreference = .parakeet,
         nemotronModelVariant: NemotronModelVariant = SpeechEnginePreference.defaultNemotronModelVariant,
-        whisperModelVariant: String = SpeechEnginePreference.defaultWhisperModelVariant
+        whisperModelVariant: String = SpeechEnginePreference.defaultWhisperModelVariant,
+        defaults: UserDefaults = .standard
     ) {
         let runtime = STTRuntime(
             modelVersion: modelVersion,
             speechEngine: speechEngine,
             nemotronModelVariant: nemotronModelVariant,
-            whisperModelVariant: whisperModelVariant
+            whisperModelVariant: whisperModelVariant,
+            defaults: defaults
         )
         self.scheduler = STTScheduler(runtime: runtime)
     }

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -63,6 +63,8 @@ public actor STTRuntime: STTRuntimeProtocol {
     /// (`setParakeetModelVariant`); `ensureInitialized()` reads it when loading.
     private var modelVersion: AsrModelVersion
     private var speechEngine: SpeechEnginePreference
+    private var nemotronEngine: NemotronEngine?
+    private let nemotronModelVariant: NemotronModelVariant
     private var whisperEngine: WhisperEngine?
     private let whisperModelVariant: String
     private var activeTranscriptionCount = 0
@@ -75,10 +77,12 @@ public actor STTRuntime: STTRuntimeProtocol {
     public init(
         modelVersion: AsrModelVersion = .v3,
         speechEngine: SpeechEnginePreference = .parakeet,
+        nemotronModelVariant: NemotronModelVariant = SpeechEnginePreference.defaultNemotronModelVariant,
         whisperModelVariant: String = SpeechEnginePreference.defaultWhisperModelVariant
     ) {
         self.modelVersion = modelVersion
         self.speechEngine = speechEngine
+        self.nemotronModelVariant = nemotronModelVariant
         self.whisperModelVariant = WhisperEngine.normalizeModelVariant(whisperModelVariant)
     }
 
@@ -92,7 +96,7 @@ public actor STTRuntime: STTRuntimeProtocol {
             job: job,
             speechEngine: SpeechEngineSelection(
                 engine: speechEngine,
-                language: speechEngine == .whisper ? SpeechEnginePreference.whisperDefaultLanguage() : nil
+                language: defaultLanguage(for: speechEngine)
             ),
             onProgress: onProgress
         )
@@ -110,9 +114,35 @@ public actor STTRuntime: STTRuntimeProtocol {
         switch selection.engine {
         case .parakeet:
             return try await transcribeWithParakeet(audioPath: audioPath, job: job, onProgress: onProgress)
+        case .nemotron:
+            return try await transcribeWithNemotron(
+                audioPath: audioPath,
+                job: job,
+                language: selection.language,
+                onProgress: onProgress
+            )
         case .whisper:
             return try await transcribeWithWhisper(audioPath: audioPath, language: selection.language, onProgress: onProgress)
         }
+    }
+
+    private func transcribeWithNemotron(
+        audioPath: String,
+        job: STTJobKind,
+        language: String?,
+        onProgress: (@Sendable (Int, Int) -> Void)?
+    ) async throws -> STTResult {
+        let engine = nemotronEngine ?? NemotronEngine(
+            modelVariant: nemotronModelVariant,
+            language: SpeechEnginePreference.nemotronDefaultLanguage()
+        )
+        nemotronEngine = engine
+        return try await engine.transcribe(
+            audioURL: URL(fileURLWithPath: audioPath),
+            job: job,
+            language: language,
+            onProgress: onProgress
+        )
     }
 
     private func transcribeWithWhisper(
@@ -216,6 +246,13 @@ public actor STTRuntime: STTRuntimeProtocol {
             switch activeSpeechEngine {
             case .parakeet:
                 try await ensureInitialized()
+            case .nemotron:
+                let engine = nemotronEngine ?? NemotronEngine(
+                    modelVariant: nemotronModelVariant,
+                    language: SpeechEnginePreference.nemotronDefaultLanguage()
+                )
+                nemotronEngine = engine
+                try await engine.prepare(onProgress: onProgress)
             case .whisper:
                 let engine = whisperEngine ?? WhisperEngine(model: whisperModelVariant)
                 whisperEngine = engine
@@ -337,6 +374,9 @@ public actor STTRuntime: STTRuntimeProtocol {
     }
 
     public func isReady() async -> Bool {
+        if speechEngine == .nemotron {
+            return await nemotronEngine?.isReady() ?? false
+        }
         if speechEngine == .whisper {
             return await whisperEngine?.isReady() ?? false
         }
@@ -350,6 +390,7 @@ public actor STTRuntime: STTRuntimeProtocol {
     public func shutdown() async {
         invalidateBackgroundWarmUp()
         await unloadWhisper()
+        await unloadNemotron()
         await unloadParakeet()
         warmUpProgressHandler = nil
         setBackgroundWarmUpState(.idle)
@@ -432,11 +473,19 @@ public actor STTRuntime: STTRuntimeProtocol {
         onProgress: (@Sendable (String) -> Void)?
     ) async throws {
         var preparedWhisper: WhisperEngine?
+        var preparedNemotron: NemotronEngine?
 
         switch preference {
         case .parakeet:
             onProgress?("Loading Parakeet model on Neural Engine...")
             try await ensureInitialized()
+        case .nemotron:
+            let engine = nemotronEngine ?? NemotronEngine(
+                modelVariant: nemotronModelVariant,
+                language: SpeechEnginePreference.nemotronDefaultLanguage()
+            )
+            try await engine.prepare(onProgress: onProgress)
+            preparedNemotron = engine
         case .whisper:
             let engine = whisperEngine ?? WhisperEngine(
                 model: whisperModelVariant,
@@ -449,6 +498,9 @@ public actor STTRuntime: STTRuntimeProtocol {
         if let preparedWhisper {
             whisperEngine = preparedWhisper
         }
+        if let preparedNemotron {
+            nemotronEngine = preparedNemotron
+        }
         speechEngine = preference
         preference.save()
 
@@ -456,6 +508,9 @@ public actor STTRuntime: STTRuntimeProtocol {
         case .parakeet where preference != .parakeet:
             onProgress?("Releasing Parakeet model...")
             await unloadParakeet()
+        case .nemotron where preference != .nemotron:
+            onProgress?("Releasing Nemotron model...")
+            await unloadNemotron()
         case .whisper where preference != .whisper:
             onProgress?("Releasing Whisper model...")
             await unloadWhisper()
@@ -567,13 +622,20 @@ public actor STTRuntime: STTRuntimeProtocol {
     public func currentSpeechEngineSelection() async -> SpeechEngineSelection {
         SpeechEngineSelection(
             engine: speechEngine,
-            language: speechEngine == .whisper ? SpeechEnginePreference.whisperDefaultLanguage() : nil
+            language: defaultLanguage(for: speechEngine)
         )
     }
 
     public nonisolated static func isModelCached(version: AsrModelVersion = .v3) -> Bool {
         let cacheDir = AsrModels.defaultCacheDirectory(for: version)
         return AsrModels.modelsExist(at: cacheDir, version: version)
+    }
+
+    public nonisolated static func isNemotronModelCached(
+        modelVariant: NemotronModelVariant = SpeechEnginePreference.defaultNemotronModelVariant,
+        language: String? = nil
+    ) -> Bool {
+        NemotronEngine.isModelCached(modelVariant: modelVariant, language: language)
     }
 
     /// Deletes a single Parakeet build's files from disk, leaving the sibling
@@ -648,6 +710,40 @@ public actor STTRuntime: STTRuntimeProtocol {
         return removed
     }
 
+    public nonisolated static func downloadNemotronModel(
+        modelVariant: NemotronModelVariant = SpeechEnginePreference.defaultNemotronModelVariant,
+        language: String? = nil,
+        onProgress: (@Sendable (String) -> Void)? = nil
+    ) async throws {
+        _ = try await NemotronEngine.downloadModel(
+            modelVariant: modelVariant,
+            language: language,
+            onProgress: onProgress
+        )
+    }
+
+    @discardableResult
+    public nonisolated static func deleteNemotronModel(
+        modelVariant: NemotronModelVariant = SpeechEnginePreference.defaultNemotronModelVariant,
+        language: String? = nil
+    ) -> Bool {
+        let operationContext = Observability.childOperationContext()
+        let removed = NemotronEngine.deleteModel(modelVariant: modelVariant, language: language)
+        Telemetry.send(.modelOperation(
+            operationID: operationContext.operationID,
+            operationContext: operationContext,
+            action: .deleteModel,
+            outcome: removed ? .success : .failure,
+            stage: .delete,
+            modelKind: .nemotronSTT,
+            speechEngine: .nemotron,
+            engineVariant: modelVariant.rawValue,
+            durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
+            errorType: nil
+        ))
+        return removed
+    }
+
     private func unloadParakeet() async {
         let inFlightInitialization = cancelInitialization()
         inFlightInitialization?.cancel()
@@ -668,6 +764,12 @@ public actor STTRuntime: STTRuntimeProtocol {
     private func unloadWhisper() async {
         let engine = whisperEngine
         whisperEngine = nil
+        await engine?.unload()
+    }
+
+    private func unloadNemotron() async {
+        let engine = nemotronEngine
+        nemotronEngine = nil
         await engine?.unload()
     }
 
@@ -844,6 +946,8 @@ public actor STTRuntime: STTRuntimeProtocol {
         switch engine {
         case .parakeet:
             .parakeetSTT
+        case .nemotron:
+            .nemotronSTT
         case .whisper:
             .whisperSTT
         }
@@ -855,8 +959,21 @@ public actor STTRuntime: STTRuntimeProtocol {
             // Surface the active Parakeet build (v2/v3) so model-load telemetry
             // can measure variant adoption and impact (issues #311, #398).
             ParakeetModelVariant(asrModelVersion: modelVersion).rawValue
+        case .nemotron:
+            nemotronModelVariant.rawValue
         case .whisper:
             whisperModelVariant
+        }
+    }
+
+    private func defaultLanguage(for engine: SpeechEnginePreference) -> String? {
+        switch engine {
+        case .parakeet:
+            nil
+        case .nemotron:
+            SpeechEnginePreference.nemotronDefaultLanguage()
+        case .whisper:
+            SpeechEnginePreference.whisperDefaultLanguage()
         }
     }
 

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -64,6 +64,7 @@ public actor STTRuntime: STTRuntimeProtocol {
     private var modelVersion: AsrModelVersion
     private var speechEngine: SpeechEnginePreference
     private var nemotronEngine: NemotronEngine?
+    private var nemotronEngineLanguage: String?
     private let nemotronModelVariant: NemotronModelVariant
     private var whisperEngine: WhisperEngine?
     private let whisperModelVariant: String
@@ -135,11 +136,8 @@ public actor STTRuntime: STTRuntimeProtocol {
         language: String?,
         onProgress: (@Sendable (Int, Int) -> Void)?
     ) async throws -> STTResult {
-        let engine = nemotronEngine ?? NemotronEngine(
-            modelVariant: nemotronModelVariant,
-            language: SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults)
-        )
-        nemotronEngine = engine
+        let language = SpeechEnginePreference.normalizeNemotronLanguage(language)
+        let engine = try await ensureNemotronEngine(language: language)
         return try await engine.transcribe(
             audioURL: URL(fileURLWithPath: audioPath),
             job: job,
@@ -250,11 +248,9 @@ public actor STTRuntime: STTRuntimeProtocol {
             case .parakeet:
                 try await ensureInitialized()
             case .nemotron:
-                let engine = nemotronEngine ?? NemotronEngine(
-                    modelVariant: nemotronModelVariant,
+                let engine = try await ensureNemotronEngine(
                     language: SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults)
                 )
-                nemotronEngine = engine
                 try await engine.prepare(onProgress: onProgress)
             case .whisper:
                 let engine = whisperEngine ?? WhisperEngine(model: whisperModelVariant)
@@ -406,6 +402,7 @@ public actor STTRuntime: STTRuntimeProtocol {
         await shutdown()
         DownloadUtils.clearAllModelCaches()
         try? FileManager.default.removeItem(atPath: AppPaths.whisperModelsDir)
+        _ = Self.removeNemotronModelFiles(at: NemotronEngine.defaultCacheRoot())
         setBackgroundWarmUpState(.idle)
         Telemetry.send(.modelOperation(
             operationID: operationContext.operationID,
@@ -483,8 +480,7 @@ public actor STTRuntime: STTRuntimeProtocol {
             onProgress?("Loading Parakeet model on Neural Engine...")
             try await ensureInitialized()
         case .nemotron:
-            let engine = nemotronEngine ?? NemotronEngine(
-                modelVariant: nemotronModelVariant,
+            let engine = try await ensureNemotronEngine(
                 language: SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults)
             )
             try await engine.prepare(onProgress: onProgress)
@@ -686,6 +682,21 @@ public actor STTRuntime: STTRuntimeProtocol {
         return !fileManager.fileExists(atPath: directory.path)
     }
 
+    /// File-removal core for the full-stack `models clear` path. Nemotron keeps
+    /// language-scoped directories under one repo root, so a full clear removes
+    /// the root rather than the currently configured language leaf only.
+    @discardableResult
+    nonisolated static func removeNemotronModelFiles(at directory: URL) -> Bool {
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: directory.path) else { return false }
+        do {
+            try fileManager.removeItem(at: directory)
+        } catch {
+            return false
+        }
+        return !fileManager.fileExists(atPath: directory.path)
+    }
+
     /// Deletes a downloaded Whisper variant from disk, leaving Parakeet and the
     /// speaker models untouched. Thin telemetry-emitting wrapper over
     /// ``WhisperEngine/deleteModel(model:downloadBase:defaults:)`` so model
@@ -773,7 +784,26 @@ public actor STTRuntime: STTRuntimeProtocol {
     private func unloadNemotron() async {
         let engine = nemotronEngine
         nemotronEngine = nil
+        nemotronEngineLanguage = nil
         await engine?.unload()
+    }
+
+    private func ensureNemotronEngine(language: String?) async throws -> NemotronEngine {
+        let language = SpeechEnginePreference.normalizeNemotronLanguage(language)
+        if let nemotronEngine, nemotronEngineLanguage == language {
+            return nemotronEngine
+        }
+
+        guard activeTranscriptionCount <= 1 else {
+            throw STTError.engineBusy
+        }
+
+        let previousEngine = nemotronEngine
+        let engine = NemotronEngine(modelVariant: nemotronModelVariant, language: language)
+        nemotronEngine = engine
+        nemotronEngineLanguage = language
+        await previousEngine?.unload()
+        return engine
     }
 
     private func beginBackgroundWarmUp() -> UInt64 {

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -67,6 +67,7 @@ public actor STTRuntime: STTRuntimeProtocol {
     private let nemotronModelVariant: NemotronModelVariant
     private var whisperEngine: WhisperEngine?
     private let whisperModelVariant: String
+    private let defaults: UserDefaults
     private var activeTranscriptionCount = 0
 
     private var backgroundWarmUpState: STTWarmUpState = .idle
@@ -78,12 +79,14 @@ public actor STTRuntime: STTRuntimeProtocol {
         modelVersion: AsrModelVersion = .v3,
         speechEngine: SpeechEnginePreference = .parakeet,
         nemotronModelVariant: NemotronModelVariant = SpeechEnginePreference.defaultNemotronModelVariant,
-        whisperModelVariant: String = SpeechEnginePreference.defaultWhisperModelVariant
+        whisperModelVariant: String = SpeechEnginePreference.defaultWhisperModelVariant,
+        defaults: UserDefaults = .standard
     ) {
         self.modelVersion = modelVersion
         self.speechEngine = speechEngine
         self.nemotronModelVariant = nemotronModelVariant
         self.whisperModelVariant = WhisperEngine.normalizeModelVariant(whisperModelVariant)
+        self.defaults = defaults
     }
 
     func transcribe(
@@ -134,7 +137,7 @@ public actor STTRuntime: STTRuntimeProtocol {
     ) async throws -> STTResult {
         let engine = nemotronEngine ?? NemotronEngine(
             modelVariant: nemotronModelVariant,
-            language: SpeechEnginePreference.nemotronDefaultLanguage()
+            language: SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults)
         )
         nemotronEngine = engine
         return try await engine.transcribe(
@@ -249,7 +252,7 @@ public actor STTRuntime: STTRuntimeProtocol {
             case .nemotron:
                 let engine = nemotronEngine ?? NemotronEngine(
                     modelVariant: nemotronModelVariant,
-                    language: SpeechEnginePreference.nemotronDefaultLanguage()
+                    language: SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults)
                 )
                 nemotronEngine = engine
                 try await engine.prepare(onProgress: onProgress)
@@ -427,7 +430,7 @@ public actor STTRuntime: STTRuntimeProtocol {
         onProgress: (@Sendable (String) -> Void)?
     ) async throws {
         guard preference != speechEngine else {
-            preference.save()
+            preference.save(to: defaults)
             return
         }
 
@@ -482,14 +485,14 @@ public actor STTRuntime: STTRuntimeProtocol {
         case .nemotron:
             let engine = nemotronEngine ?? NemotronEngine(
                 modelVariant: nemotronModelVariant,
-                language: SpeechEnginePreference.nemotronDefaultLanguage()
+                language: SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults)
             )
             try await engine.prepare(onProgress: onProgress)
             preparedNemotron = engine
         case .whisper:
             let engine = whisperEngine ?? WhisperEngine(
                 model: whisperModelVariant,
-                language: SpeechEnginePreference.whisperDefaultLanguage()
+                language: SpeechEnginePreference.whisperDefaultLanguage(defaults: defaults)
             )
             try await engine.prepare(onProgress: onProgress)
             preparedWhisper = engine
@@ -502,7 +505,7 @@ public actor STTRuntime: STTRuntimeProtocol {
             nemotronEngine = preparedNemotron
         }
         speechEngine = preference
-        preference.save()
+        preference.save(to: defaults)
 
         switch previous {
         case .parakeet where preference != .parakeet:
@@ -971,9 +974,9 @@ public actor STTRuntime: STTRuntimeProtocol {
         case .parakeet:
             nil
         case .nemotron:
-            SpeechEnginePreference.nemotronDefaultLanguage()
+            SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults)
         case .whisper:
-            SpeechEnginePreference.whisperDefaultLanguage()
+            SpeechEnginePreference.whisperDefaultLanguage(defaults: defaults)
         }
     }
 

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -727,13 +727,107 @@ public actor STTRuntime: STTRuntimeProtocol {
     public nonisolated static func downloadNemotronModel(
         modelVariant: NemotronModelVariant = SpeechEnginePreference.defaultNemotronModelVariant,
         language: String? = nil,
+        emitTelemetry: Bool = true,
         onProgress: (@Sendable (String) -> Void)? = nil
     ) async throws {
-        _ = try await NemotronEngine.downloadModel(
+        try await downloadNemotronModel(
             modelVariant: modelVariant,
             language: language,
-            onProgress: onProgress
+            emitTelemetry: emitTelemetry,
+            onProgress: onProgress,
+            downloader: { modelVariant, language, onProgress in
+                try await NemotronEngine.downloadModel(
+                    modelVariant: modelVariant,
+                    language: language,
+                    onProgress: onProgress
+                )
+            }
         )
+    }
+
+    nonisolated static func downloadNemotronModel(
+        modelVariant: NemotronModelVariant = SpeechEnginePreference.defaultNemotronModelVariant,
+        language: String? = nil,
+        emitTelemetry: Bool,
+        onProgress: (@Sendable (String) -> Void)? = nil,
+        downloader: @escaping @Sendable (
+            NemotronModelVariant,
+            String?,
+            (@Sendable (String) -> Void)?
+        ) async throws -> URL
+    ) async throws {
+        let operationContext = Observability.childOperationContext()
+        if emitTelemetry {
+            Telemetry.send(.modelDownloadStarted(
+                modelKind: .nemotronSTT,
+                speechEngine: .nemotron,
+                engineVariant: modelVariant.rawValue
+            ))
+        }
+
+        do {
+            _ = try await downloader(modelVariant, language, onProgress)
+            guard emitTelemetry else { return }
+            let durationSeconds = Observability.durationSeconds(since: operationContext.startedAt)
+            Telemetry.send(.modelDownloadCompleted(
+                durationSeconds: durationSeconds,
+                modelKind: .nemotronSTT,
+                speechEngine: .nemotron,
+                engineVariant: modelVariant.rawValue
+            ))
+            Telemetry.send(.modelOperation(
+                operationID: operationContext.operationID,
+                operationContext: operationContext,
+                action: .download,
+                outcome: .success,
+                stage: .download,
+                modelKind: .nemotronSTT,
+                speechEngine: .nemotron,
+                engineVariant: modelVariant.rawValue,
+                durationSeconds: durationSeconds,
+                errorType: nil
+            ))
+        } catch is CancellationError {
+            if emitTelemetry {
+                Telemetry.send(.modelOperation(
+                    operationID: operationContext.operationID,
+                    operationContext: operationContext,
+                    action: .download,
+                    outcome: .cancelled,
+                    stage: .download,
+                    modelKind: .nemotronSTT,
+                    speechEngine: .nemotron,
+                    engineVariant: modelVariant.rawValue,
+                    durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
+                    errorType: "CancellationError"
+                ))
+            }
+            throw CancellationError()
+        } catch {
+            let errorType = TelemetryErrorClassifier.classify(error)
+            if emitTelemetry {
+                Telemetry.send(.modelDownloadFailed(
+                    errorType: errorType,
+                    errorDetail: TelemetryErrorClassifier.errorDetail(error),
+                    modelKind: .nemotronSTT,
+                    speechEngine: .nemotron,
+                    engineVariant: modelVariant.rawValue
+                ))
+                Telemetry.send(.modelOperation(
+                    operationID: operationContext.operationID,
+                    operationContext: operationContext,
+                    action: .download,
+                    outcome: .failure,
+                    stage: .download,
+                    modelKind: .nemotronSTT,
+                    speechEngine: .nemotron,
+                    engineVariant: modelVariant.rawValue,
+                    durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
+                    errorType: errorType
+                ))
+            }
+            throw error
+        }
     }
 
     @discardableResult

--- a/Sources/MacParakeetCore/STT/STTScheduler.swift
+++ b/Sources/MacParakeetCore/STT/STTScheduler.swift
@@ -161,7 +161,8 @@ public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEn
     }
 
     public func clearModelCache() async {
-        await quiesce(restoreAcceptsNewJobs: true)
+        await quiesce(restoreAcceptsNewJobs: false)
+        defer { acceptsNewJobs = true }
         await observingRuntimeTimeout(reason: "clear_model_cache") {
             await runtime.clearModelCache()
         }

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -167,6 +167,7 @@ public enum TelemetryTranscriptionStage: String, Sendable, Equatable {
 
 public enum TelemetryModelKind: String, Sendable, Equatable {
     case parakeetSTT = "parakeet_stt"
+    case nemotronSTT = "nemotron_stt"
     case whisperSTT = "whisper_stt"
     case speakerDiarization = "speaker_diarization"
     case localSpeechStack = "local_speech_stack"

--- a/Sources/MacParakeetCore/SpeechEnginePreference.swift
+++ b/Sources/MacParakeetCore/SpeechEnginePreference.swift
@@ -2,10 +2,12 @@ import Foundation
 
 public enum SpeechEnginePreference: String, CaseIterable, Codable, Sendable {
     case parakeet
+    case nemotron
     case whisper
 
     public static let defaultsKey = "speechRecognitionEngine"
     public static let parakeetModelVariantKey = "parakeetModelVariant"
+    public static let nemotronDefaultLanguageKey = "nemotronDefaultLanguage"
     public static let whisperDefaultLanguageKey = "whisperDefaultLanguage"
     public static let whisperModelVariantKey = "whisperModelVariant"
 
@@ -22,11 +24,14 @@ public enum SpeechEnginePreference: String, CaseIterable, Codable, Sendable {
     public static let whisperOptimizedVariantsKey = "whisperOptimizedVariants"
 
     public static let defaultWhisperModelVariant = "large-v3-v20240930_turbo_632MB"
+    public static let defaultNemotronModelVariant: NemotronModelVariant = .multilingual1120
 
     public var displayName: String {
         switch self {
         case .parakeet:
             "Parakeet"
+        case .nemotron:
+            "Nemotron"
         case .whisper:
             "Whisper"
         }
@@ -35,6 +40,8 @@ public enum SpeechEnginePreference: String, CaseIterable, Codable, Sendable {
     public var alternative: SpeechEnginePreference {
         switch self {
         case .parakeet:
+            .nemotron
+        case .nemotron:
             .whisper
         case .whisper:
             .parakeet
@@ -63,6 +70,18 @@ public enum SpeechEnginePreference: String, CaseIterable, Codable, Sendable {
             return
         }
         defaults.set(normalized, forKey: whisperDefaultLanguageKey)
+    }
+
+    public static func nemotronDefaultLanguage(defaults: UserDefaults = .standard) -> String? {
+        normalizeNemotronLanguage(defaults.string(forKey: nemotronDefaultLanguageKey))
+    }
+
+    public static func saveNemotronDefaultLanguage(_ language: String?, defaults: UserDefaults = .standard) {
+        guard let normalized = normalizeNemotronLanguage(language) else {
+            defaults.removeObject(forKey: nemotronDefaultLanguageKey)
+            return
+        }
+        defaults.set(normalized, forKey: nemotronDefaultLanguageKey)
     }
 
     public static func whisperModelVariant(defaults: UserDefaults = .standard) -> String {
@@ -141,6 +160,13 @@ public enum SpeechEnginePreference: String, CaseIterable, Codable, Sendable {
             return nil
         }
         return normalized
+    }
+
+    public static func normalizeNemotronLanguage(_ language: String?) -> String? {
+        guard let language else { return nil }
+        let trimmed = language.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed.lowercased() != "auto" else { return nil }
+        return trimmed.replacingOccurrences(of: "_", with: "-")
     }
 
     public static func normalizeModelVariant(_ variant: String?) -> String? {
@@ -271,21 +297,73 @@ public enum ParakeetModelVariant: String, CaseIterable, Codable, Sendable {
     }
 }
 
+/// The Nemotron 3.5 CoreML build surfaced by MacParakeet.
+///
+/// FluidAudio exposes several chunk-size tiers. MacParakeet starts with the
+/// multilingual 1120 ms tier because it keeps the Beta product surface simple
+/// while preserving the balanced quality/latency posture expected for
+/// dictation, meetings, and file transcription.
+public enum NemotronModelVariant: String, CaseIterable, Codable, Sendable {
+    case multilingual1120 = "multilingual-1120ms"
+
+    public var displayName: String {
+        switch self {
+        case .multilingual1120:
+            "Multilingual Beta"
+        }
+    }
+
+    public var modelName: String {
+        switch self {
+        case .multilingual1120:
+            "Nemotron 3.5 ASR Streaming 0.6B"
+        }
+    }
+
+    public var coverageSummary: String {
+        switch self {
+        case .multilingual1120:
+            "Fast multilingual streaming model. Beta while MacParakeet benchmarks quality and edge cases."
+        }
+    }
+
+    public var approximateDownloadSize: String { "~1.5 GB" }
+
+    public var chunkMilliseconds: Int {
+        switch self {
+        case .multilingual1120:
+            1120
+        }
+    }
+}
+
 public struct SpeechEngineSelection: Codable, Equatable, Sendable {
     public let engine: SpeechEnginePreference
     public let language: String?
 
     public init(engine: SpeechEnginePreference, language: String? = nil) {
         self.engine = engine
-        self.language = engine == .whisper ? SpeechEnginePreference.normalizeLanguage(language) : nil
+        self.language = switch engine {
+        case .parakeet:
+            nil
+        case .nemotron:
+            SpeechEnginePreference.normalizeNemotronLanguage(language)
+        case .whisper:
+            SpeechEnginePreference.normalizeLanguage(language)
+        }
     }
 
     public static func current(defaults: UserDefaults = .standard) -> SpeechEngineSelection {
         let engine = SpeechEnginePreference.current(defaults: defaults)
-        return SpeechEngineSelection(
-            engine: engine,
-            language: engine == .whisper ? SpeechEnginePreference.whisperDefaultLanguage(defaults: defaults) : nil
-        )
+        let language: String? = switch engine {
+        case .parakeet:
+            nil
+        case .nemotron:
+            SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults)
+        case .whisper:
+            SpeechEnginePreference.whisperDefaultLanguage(defaults: defaults)
+        }
+        return SpeechEngineSelection(engine: engine, language: language)
     }
 }
 

--- a/Sources/MacParakeetCore/SpeechEnginePreference.swift
+++ b/Sources/MacParakeetCore/SpeechEnginePreference.swift
@@ -166,7 +166,36 @@ public enum SpeechEnginePreference: String, CaseIterable, Codable, Sendable {
         guard let language else { return nil }
         let trimmed = language.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, trimmed.lowercased() != "auto" else { return nil }
-        return trimmed.replacingOccurrences(of: "_", with: "-")
+        let parts = trimmed.replacingOccurrences(of: "_", with: "-").split(separator: "-").map(String.init)
+        guard let primary = parts.first,
+              (2...3).contains(primary.count),
+              primary.allSatisfy(\.isLetter) else {
+            return nil
+        }
+
+        var canonicalParts = [primary.lowercased()]
+        var index = 1
+        if parts.indices.contains(index),
+           parts[index].count == 4,
+           parts[index].allSatisfy(\.isLetter) {
+            let script = parts[index].lowercased()
+            canonicalParts.append(script.prefix(1).uppercased() + String(script.dropFirst()))
+            index += 1
+        }
+        if parts.indices.contains(index) {
+            let region = parts[index]
+            if region.count == 2, region.allSatisfy(\.isLetter) {
+                canonicalParts.append(region.uppercased())
+                index += 1
+            } else if region.count == 3, region.allSatisfy(\.isNumber) {
+                canonicalParts.append(region)
+                index += 1
+            } else {
+                return nil
+            }
+        }
+        guard index == parts.count else { return nil }
+        return canonicalParts.joined(separator: "-")
     }
 
     public static func normalizeModelVariant(_ variant: String?) -> String? {

--- a/Sources/MacParakeetCore/SpeechEnginePreference.swift
+++ b/Sources/MacParakeetCore/SpeechEnginePreference.swift
@@ -40,7 +40,7 @@ public enum SpeechEnginePreference: String, CaseIterable, Codable, Sendable {
     public var alternative: SpeechEnginePreference {
         switch self {
         case .parakeet:
-            .nemotron
+            .whisper
         case .nemotron:
             .whisper
         case .whisper:

--- a/Sources/MacParakeetCore/UserDefaults+Sendable.swift
+++ b/Sources/MacParakeetCore/UserDefaults+Sendable.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+// UserDefaults is Foundation's thread-safe preference store, and MacParakeet
+// intentionally injects isolated suites across app, CLI, and test boundaries.
+extension UserDefaults: @unchecked @retroactive Sendable {}

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -1903,13 +1903,12 @@ public final class SettingsViewModel {
         guard nemotronModelStatus == .ready || nemotronModelStatus == .notLoaded else { return }
 
         let variant = SpeechEnginePreference.defaultNemotronModelVariant
-        let language = SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults)
         let deleter = deleteNemotronModelOnDisk
         modelStatusRefreshGeneration += 1
         applyNemotronDownloadedStatus(false)
         Task { @MainActor [weak self] in
             await Task.detached(priority: .userInitiated) {
-                _ = deleter(variant, language)
+                _ = deleter(variant, nil)
             }.value
             guard let self else { return }
             self.refreshModelStatus()

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -345,6 +345,12 @@ public final class SettingsViewModel {
     public var whisperModelStatus: LocalModelStatus = .unknown
     public var whisperModelStatusDetail: String = "Not checked yet."
     public var whisperDownloading = false
+    public var nemotronModelStatus: LocalModelStatus = .unknown
+    public var nemotronModelStatusDetail: String = "Not checked yet."
+    public var nemotronDownloading = false
+    public var isNemotronModelAvailable: Bool {
+        nemotronModelStatus == .ready || nemotronModelStatus == .notLoaded
+    }
     public var isWhisperModelDownloaded: Bool {
         whisperModelStatus == .ready || whisperModelStatus == .notLoaded
     }
@@ -515,7 +521,9 @@ public final class SettingsViewModel {
     private let defaults: UserDefaults
     private let youtubeDownloadsDirPath: @Sendable () -> String
     private let parakeetModelVariantCached: @Sendable (ParakeetModelVariant) -> Bool
+    private let nemotronModelVariantCached: @Sendable (NemotronModelVariant, String?) -> Bool
     private let deleteParakeetModelOnDisk: @Sendable (ParakeetModelVariant) -> Bool
+    private let deleteNemotronModelOnDisk: @Sendable (NemotronModelVariant, String?) -> Bool
     private let deleteWhisperModelOnDisk: @Sendable (String) -> Bool
     private let inputDevicesProvider: @Sendable () -> [AudioDeviceManager.InputDevice]
     private let defaultInputDeviceUIDProvider: @Sendable () -> String?
@@ -541,8 +549,14 @@ public final class SettingsViewModel {
         parakeetModelVariantCached: @escaping @Sendable (ParakeetModelVariant) -> Bool = {
             STTRuntime.isModelCached(version: $0.asrModelVersion)
         },
+        nemotronModelVariantCached: @escaping @Sendable (NemotronModelVariant, String?) -> Bool = {
+            STTRuntime.isNemotronModelCached(modelVariant: $0, language: $1)
+        },
         deleteParakeetModelOnDisk: @escaping @Sendable (ParakeetModelVariant) -> Bool = {
             STTRuntime.deleteParakeetModel(version: $0.asrModelVersion)
+        },
+        deleteNemotronModelOnDisk: @escaping @Sendable (NemotronModelVariant, String?) -> Bool = {
+            STTRuntime.deleteNemotronModel(modelVariant: $0, language: $1)
         },
         deleteWhisperModelOnDisk: @escaping @Sendable (String) -> Bool = {
             STTRuntime.deleteWhisperModel(variant: $0)
@@ -559,7 +573,9 @@ public final class SettingsViewModel {
         self.defaults = defaults
         self.youtubeDownloadsDirPath = youtubeDownloadsDirPath
         self.parakeetModelVariantCached = parakeetModelVariantCached
+        self.nemotronModelVariantCached = nemotronModelVariantCached
         self.deleteParakeetModelOnDisk = deleteParakeetModelOnDisk
+        self.deleteNemotronModelOnDisk = deleteNemotronModelOnDisk
         self.deleteWhisperModelOnDisk = deleteWhisperModelOnDisk
         self.inputDevicesProvider = inputDevicesProvider
         self.defaultInputDeviceUIDProvider = defaultInputDeviceUIDProvider
@@ -1213,18 +1229,24 @@ public final class SettingsViewModel {
         let activeEngine = speechEnginePreference
         let activeVariant = parakeetModelVariant
         let whisperModelVariant = SpeechEnginePreference.whisperModelVariant(defaults: defaults)
+        let nemotronModelVariant = SpeechEnginePreference.defaultNemotronModelVariant
+        let nemotronLanguage = SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults)
 
         let parakeetModelVariantCached = self.parakeetModelVariantCached
+        let nemotronModelVariantCached = self.nemotronModelVariantCached
 
         guard let sttClient else {
             parakeetStatus = .unknown
             parakeetStatusDetail = "Unavailable in this runtime."
+            nemotronModelStatus = .checking
+            nemotronModelStatusDetail = "Checking model state..."
             whisperModelStatus = .checking
             whisperModelStatusDetail = "Checking model state..."
             Task { @MainActor [weak self] in
                 let disk = await Task.detached(priority: .userInitiated) {
                     (
                         parakeetDownloaded: Set(ParakeetModelVariant.allCases.filter(parakeetModelVariantCached)),
+                        nemotronDownloaded: nemotronModelVariantCached(nemotronModelVariant, nemotronLanguage),
                         whisperDownloaded: WhisperEngine.isModelDownloaded(model: whisperModelVariant)
                     )
                 }.value
@@ -1235,6 +1257,7 @@ public final class SettingsViewModel {
                     return
                 }
                 self.downloadedParakeetVariants = disk.parakeetDownloaded
+                self.applyNemotronDownloadedStatus(disk.nemotronDownloaded)
                 self.applyWhisperDownloadedStatus(disk.whisperDownloaded)
             }
             return
@@ -1242,6 +1265,8 @@ public final class SettingsViewModel {
 
         parakeetStatus = .checking
         parakeetStatusDetail = "Checking model state..."
+        nemotronModelStatus = .checking
+        nemotronModelStatusDetail = "Checking model state..."
         whisperModelStatus = .checking
         whisperModelStatusDetail = "Checking model state..."
 
@@ -1260,6 +1285,7 @@ public final class SettingsViewModel {
             async let diskState = Task.detached(priority: .userInitiated) {
                 (
                     parakeetDownloaded: Set(ParakeetModelVariant.allCases.filter(parakeetModelVariantCached)),
+                    nemotronDownloaded: nemotronModelVariantCached(nemotronModelVariant, nemotronLanguage),
                     whisperDownloaded: WhisperEngine.isModelDownloaded(model: whisperModelVariant)
                 )
             }.value
@@ -1284,6 +1310,13 @@ public final class SettingsViewModel {
                 self.parakeetStatusDetail = "\(parakeetName) · Needs model setup before use."
             }
 
+            if activeEngine == .nemotron, activeEngineIsLoaded {
+                self.nemotronModelStatus = .ready
+                self.nemotronModelStatusDetail = "\(nemotronModelVariant.modelName) · Loaded in memory."
+            } else {
+                self.applyNemotronDownloadedStatus(modelDiskState.nemotronDownloaded)
+            }
+
             if activeEngine == .whisper, activeEngineIsLoaded {
                 self.whisperModelStatus = .ready
                 self.whisperModelStatusDetail = "\(self.whisperVariantFriendlyName) · Loaded in memory."
@@ -1297,6 +1330,26 @@ public final class SettingsViewModel {
         applyWhisperDownloadedStatus(
             WhisperEngine.isModelDownloaded(model: SpeechEnginePreference.whisperModelVariant(defaults: defaults))
         )
+    }
+
+    public func refreshNemotronModelStatus() {
+        applyNemotronDownloadedStatus(
+            nemotronModelVariantCached(
+                SpeechEnginePreference.defaultNemotronModelVariant,
+                SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults)
+            )
+        )
+    }
+
+    private func applyNemotronDownloadedStatus(_ isDownloaded: Bool) {
+        let variant = SpeechEnginePreference.defaultNemotronModelVariant
+        if isDownloaded {
+            nemotronModelStatus = .notLoaded
+            nemotronModelStatusDetail = "\(variant.modelName) · Installed locally, loads when selected."
+        } else {
+            nemotronModelStatus = .notDownloaded
+            nemotronModelStatusDetail = "\(variant.modelName) · Needs download before use."
+        }
     }
 
     private func applyWhisperDownloadedStatus(_ isDownloaded: Bool) {
@@ -1321,6 +1374,101 @@ public final class SettingsViewModel {
         SpeechEnginePreference.friendlyVariantName(
             SpeechEnginePreference.whisperModelVariant(defaults: defaults)
         )
+    }
+
+    public func downloadNemotronModel() {
+        guard !speechEngineSwitching else { return }
+        guard !nemotronDownloading else { return }
+        speechEngineError = nil
+        nemotronDownloading = true
+        nemotronModelStatus = .repairing
+        let modelVariant = SpeechEnginePreference.defaultNemotronModelVariant
+        let language = SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults)
+        let operationContext = Observability.childOperationContext()
+        nemotronModelStatusDetail = "Downloading \(modelVariant.modelName)..."
+        Telemetry.send(.modelDownloadStarted(
+            modelKind: .nemotronSTT,
+            speechEngine: .nemotron,
+            engineVariant: modelVariant.rawValue
+        ))
+
+        Task {
+            do {
+                try await STTRuntime.downloadNemotronModel(modelVariant: modelVariant, language: language) { message in
+                    Task { @MainActor [weak self] in
+                        self?.nemotronModelStatusDetail = message
+                    }
+                }
+                let durationSeconds = Observability.durationSeconds(since: operationContext.startedAt)
+                Telemetry.send(.modelDownloadCompleted(
+                    durationSeconds: durationSeconds,
+                    modelKind: .nemotronSTT,
+                    speechEngine: .nemotron,
+                    engineVariant: modelVariant.rawValue
+                ))
+                Telemetry.send(.modelOperation(
+                    operationID: operationContext.operationID,
+                    operationContext: operationContext,
+                    action: .download,
+                    outcome: .success,
+                    stage: .download,
+                    modelKind: .nemotronSTT,
+                    speechEngine: .nemotron,
+                    engineVariant: modelVariant.rawValue,
+                    durationSeconds: durationSeconds,
+                    errorType: nil
+                ))
+                await MainActor.run {
+                    self.nemotronDownloading = false
+                    self.refreshNemotronModelStatus()
+                }
+            } catch is CancellationError {
+                let durationSeconds = Observability.durationSeconds(since: operationContext.startedAt)
+                Telemetry.send(.modelOperation(
+                    operationID: operationContext.operationID,
+                    operationContext: operationContext,
+                    action: .download,
+                    outcome: .cancelled,
+                    stage: .download,
+                    modelKind: .nemotronSTT,
+                    speechEngine: .nemotron,
+                    engineVariant: modelVariant.rawValue,
+                    durationSeconds: durationSeconds,
+                    errorType: "CancellationError"
+                ))
+                await MainActor.run {
+                    self.nemotronDownloading = false
+                    self.refreshNemotronModelStatus()
+                }
+            } catch {
+                let durationSeconds = Observability.durationSeconds(since: operationContext.startedAt)
+                let errorType = TelemetryErrorClassifier.classify(error)
+                Telemetry.send(.modelDownloadFailed(
+                    errorType: errorType,
+                    errorDetail: TelemetryErrorClassifier.errorDetail(error),
+                    modelKind: .nemotronSTT,
+                    speechEngine: .nemotron,
+                    engineVariant: modelVariant.rawValue
+                ))
+                Telemetry.send(.modelOperation(
+                    operationID: operationContext.operationID,
+                    operationContext: operationContext,
+                    action: .download,
+                    outcome: .failure,
+                    stage: .download,
+                    modelKind: .nemotronSTT,
+                    speechEngine: .nemotron,
+                    engineVariant: modelVariant.rawValue,
+                    durationSeconds: durationSeconds,
+                    errorType: errorType
+                ))
+                await MainActor.run {
+                    self.nemotronDownloading = false
+                    self.nemotronModelStatus = .failed
+                    self.nemotronModelStatusDetail = error.localizedDescription
+                }
+            }
+        }
     }
 
     public func downloadWhisperModel() {
@@ -1432,6 +1580,25 @@ public final class SettingsViewModel {
         let previousPreference = SpeechEnginePreference.current(defaults: defaults)
         let operationContext = Observability.childOperationContext()
         let switchWasCold = SpeechEnginePreference.isColdSwitch(to: preference, defaults: defaults)
+
+        if preference == .nemotron && !isNemotronModelAvailable {
+            speechEngineError = "Download the Nemotron model before switching engines."
+            Telemetry.send(.speechEngineSwitchOperation(
+                operationID: operationContext.operationID,
+                operationContext: operationContext,
+                fromEngine: previousPreference,
+                toEngine: preference,
+                outcome: .unavailable,
+                durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
+                blockedReason: .modelNotDownloaded,
+                errorType: "model_not_downloaded",
+                wasCold: switchWasCold
+            ))
+            isApplyingSpeechEngineState = true
+            speechEnginePreference = .parakeet
+            isApplyingSpeechEngineState = false
+            return
+        }
 
         if preference == .whisper && !isWhisperModelDownloaded {
             speechEngineError = "Download the Whisper model before switching engines."
@@ -1727,6 +1894,28 @@ public final class SettingsViewModel {
         }
     }
 
+    /// Removes the downloaded Nemotron Beta model. Only offered while
+    /// Nemotron is not the active engine so the next active use has an explicit
+    /// download/setup moment instead of a surprise re-fetch.
+    public func deleteNemotronModel() {
+        guard !speechEngineSwitching, !nemotronDownloading else { return }
+        guard speechEnginePreference != .nemotron else { return }
+        guard nemotronModelStatus == .ready || nemotronModelStatus == .notLoaded else { return }
+
+        let variant = SpeechEnginePreference.defaultNemotronModelVariant
+        let language = SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults)
+        let deleter = deleteNemotronModelOnDisk
+        modelStatusRefreshGeneration += 1
+        applyNemotronDownloadedStatus(false)
+        Task { @MainActor [weak self] in
+            await Task.detached(priority: .userInitiated) {
+                _ = deleter(variant, language)
+            }.value
+            guard let self else { return }
+            self.refreshModelStatus()
+        }
+    }
+
     /// Removes the downloaded Whisper variant, freeing ~632 MB. Only callable
     /// while Parakeet is the active engine — deleting the model behind the
     /// active engine would force a silent re-download. State flips to
@@ -1797,6 +1986,8 @@ public final class SettingsViewModel {
         switch preference {
         case .parakeet:
             "Loading Parakeet model on Neural Engine..."
+        case .nemotron:
+            "Loading Nemotron 3.5 Beta on Neural Engine..."
         case .whisper:
             "Optimizing Whisper for this Mac..."
         }

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -1394,7 +1394,11 @@ public final class SettingsViewModel {
 
         Task {
             do {
-                try await STTRuntime.downloadNemotronModel(modelVariant: modelVariant, language: language) { message in
+                try await STTRuntime.downloadNemotronModel(
+                    modelVariant: modelVariant,
+                    language: language,
+                    emitTelemetry: false
+                ) { message in
                     Task { @MainActor [weak self] in
                         self?.nemotronModelStatusDetail = message
                     }

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -1595,7 +1595,7 @@ public final class SettingsViewModel {
                 wasCold: switchWasCold
             ))
             isApplyingSpeechEngineState = true
-            speechEnginePreference = .parakeet
+            speechEnginePreference = previousPreference
             isApplyingSpeechEngineState = false
             return
         }
@@ -1614,7 +1614,7 @@ public final class SettingsViewModel {
                 wasCold: switchWasCold
             ))
             isApplyingSpeechEngineState = true
-            speechEnginePreference = .parakeet
+            speechEnginePreference = previousPreference
             isApplyingSpeechEngineState = false
             return
         }

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -408,9 +408,6 @@ public final class TranscriptionViewModel {
     private func retranscriptionAlternativePreference(
         for primaryEngine: SpeechEnginePreference
     ) -> SpeechEnginePreference {
-        if primaryEngine == .parakeet, isNemotronModelDownloaded() {
-            return .nemotron
-        }
         return primaryEngine.alternative
     }
 

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -154,16 +154,23 @@ public final class TranscriptionViewModel {
     private let logger = Logger(subsystem: "com.macparakeet.viewmodels", category: "TranscriptionViewModel")
     private let defaults: UserDefaults
     private let isWhisperModelDownloaded: () -> Bool
+    private let isNemotronModelDownloaded: () -> Bool
     public var promptResultsViewModel: PromptResultsViewModel?
 
     public init(
         defaults: UserDefaults = .standard,
-        isWhisperModelDownloaded: (() -> Bool)? = nil
+        isWhisperModelDownloaded: (() -> Bool)? = nil,
+        isNemotronModelDownloaded: (() -> Bool)? = nil
     ) {
         self.defaults = defaults
         self.isWhisperModelDownloaded = isWhisperModelDownloaded ?? {
             WhisperEngine.isModelDownloaded(
                 model: SpeechEnginePreference.whisperModelVariant(defaults: defaults)
+            )
+        }
+        self.isNemotronModelDownloaded = isNemotronModelDownloaded ?? {
+            STTClient.isNemotronModelCached(
+                language: SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults)
             )
         }
     }
@@ -379,12 +386,12 @@ public final class TranscriptionViewModel {
         let alternativePreference = primaryEngine.engine.alternative
         let alternativeEngine = SpeechEngineSelection(
             engine: alternativePreference,
-            language: alternativePreference == .whisper
-                ? SpeechEnginePreference.whisperDefaultLanguage(defaults: defaults)
-                : nil
+            language: Self.retranscriptionLanguage(for: alternativePreference, defaults: defaults)
         )
         let unavailableReason: String?
-        if alternativePreference == .whisper && !isWhisperModelDownloaded() {
+        if alternativePreference == .nemotron && !isNemotronModelDownloaded() {
+            unavailableReason = "Download the Nemotron model in Settings before trying Nemotron."
+        } else if alternativePreference == .whisper && !isWhisperModelDownloaded() {
             unavailableReason = "Download the Whisper model in Settings before trying Whisper."
         } else {
             unavailableReason = nil
@@ -396,6 +403,20 @@ public final class TranscriptionViewModel {
             isAlternativeAvailable: unavailableReason == nil,
             unavailableReason: unavailableReason
         )
+    }
+
+    private static func retranscriptionLanguage(
+        for engine: SpeechEnginePreference,
+        defaults: UserDefaults
+    ) -> String? {
+        switch engine {
+        case .parakeet:
+            return nil
+        case .nemotron:
+            return SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults)
+        case .whisper:
+            return SpeechEnginePreference.whisperDefaultLanguage(defaults: defaults)
+        }
     }
 
     public func retranscribe(_ original: Transcription, speechEngineOverride: SpeechEngineSelection? = nil) {
@@ -872,6 +893,8 @@ public final class TranscriptionViewModel {
             switch engine {
             case .parakeet:
                 return "Parakeet TDT \u{00B7} Neural Engine"
+            case .nemotron:
+                return "Nemotron 3.5 Beta \u{00B7} Neural Engine"
             case .whisper:
                 let friendly = SpeechEnginePreference.friendlyVariantName(whisperVariant)
                 return "Whisper \(friendly) \u{00B7} Neural Engine"

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -383,7 +383,7 @@ public final class TranscriptionViewModel {
             primaryEngine = SpeechEngineSelection.current(defaults: defaults)
         }
 
-        let alternativePreference = primaryEngine.engine.alternative
+        let alternativePreference = retranscriptionAlternativePreference(for: primaryEngine.engine)
         let alternativeEngine = SpeechEngineSelection(
             engine: alternativePreference,
             language: Self.retranscriptionLanguage(for: alternativePreference, defaults: defaults)
@@ -403,6 +403,15 @@ public final class TranscriptionViewModel {
             isAlternativeAvailable: unavailableReason == nil,
             unavailableReason: unavailableReason
         )
+    }
+
+    private func retranscriptionAlternativePreference(
+        for primaryEngine: SpeechEnginePreference
+    ) -> SpeechEnginePreference {
+        if primaryEngine == .parakeet, isNemotronModelDownloaded() {
+            return .nemotron
+        }
+        return primaryEngine.alternative
     }
 
     private static func retranscriptionLanguage(

--- a/Tests/CLITests/ConfigCommandTests.swift
+++ b/Tests/CLITests/ConfigCommandTests.swift
@@ -31,6 +31,7 @@ final class ConfigCommandTests: XCTestCase {
             "processing-mode",
             "speech-engine",
             "parakeet-model",
+            "nemotron-language",
             "whisper-language",
             "speaker-detection",
             "save-transcription-audio",
@@ -58,6 +59,7 @@ final class ConfigCommandTests: XCTestCase {
         XCTAssertEqual(try ConfigCommand.read(key: "processing-mode", defaults: defaults), "raw")
         XCTAssertEqual(try ConfigCommand.read(key: "speech-engine", defaults: defaults), "parakeet")
         XCTAssertEqual(try ConfigCommand.read(key: "parakeet-model", defaults: defaults), "v3")
+        XCTAssertEqual(try ConfigCommand.read(key: "nemotron-language", defaults: defaults), "auto")
         XCTAssertEqual(try ConfigCommand.read(key: "whisper-language", defaults: defaults), "auto")
         XCTAssertEqual(try ConfigCommand.read(key: "speaker-detection", defaults: defaults), "off")
         XCTAssertEqual(try ConfigCommand.read(key: "save-transcription-audio", defaults: defaults), "on")
@@ -107,6 +109,12 @@ final class ConfigCommandTests: XCTestCase {
         XCTAssertEqual(try ConfigCommand.write(key: "speech-engine", value: "whisper", defaults: defaults), "whisper")
         XCTAssertEqual(defaults.string(forKey: SpeechEnginePreference.defaultsKey), SpeechEnginePreference.whisper.rawValue)
 
+        XCTAssertEqual(try ConfigCommand.write(key: "speech-engine", value: "nemotron", defaults: defaults), "nemotron")
+        XCTAssertEqual(defaults.string(forKey: SpeechEnginePreference.defaultsKey), SpeechEnginePreference.nemotron.rawValue)
+
+        XCTAssertEqual(try ConfigCommand.write(key: "nemotron-language", value: "en_US", defaults: defaults), "en-US")
+        XCTAssertEqual(defaults.string(forKey: SpeechEnginePreference.nemotronDefaultLanguageKey), "en-US")
+
         XCTAssertEqual(try ConfigCommand.write(key: "whisper-language", value: "ko", defaults: defaults), "ko")
         XCTAssertEqual(defaults.string(forKey: SpeechEnginePreference.whisperDefaultLanguageKey), "ko")
 
@@ -153,6 +161,13 @@ final class ConfigCommandTests: XCTestCase {
 
         XCTAssertEqual(try ConfigCommand.write(key: "whisper-language", value: "auto", defaults: defaults), "auto")
         XCTAssertNil(defaults.string(forKey: SpeechEnginePreference.whisperDefaultLanguageKey))
+    }
+
+    func testWriteNemotronLanguageAutoClearsStoredDefault() throws {
+        defaults.set("en-US", forKey: SpeechEnginePreference.nemotronDefaultLanguageKey)
+
+        XCTAssertEqual(try ConfigCommand.write(key: "nemotron-language", value: "auto", defaults: defaults), "auto")
+        XCTAssertNil(defaults.string(forKey: SpeechEnginePreference.nemotronDefaultLanguageKey))
     }
 
     func testWriteAcceptsAllBoolSynonyms() throws {

--- a/Tests/CLITests/ConfigCommandTests.swift
+++ b/Tests/CLITests/ConfigCommandTests.swift
@@ -170,6 +170,23 @@ final class ConfigCommandTests: XCTestCase {
         XCTAssertNil(defaults.string(forKey: SpeechEnginePreference.nemotronDefaultLanguageKey))
     }
 
+    func testWriteNemotronLanguageCanonicalizesScriptAndRegion() throws {
+        XCTAssertEqual(
+            try ConfigCommand.write(key: "nemotron-language", value: "zh_hant_tw", defaults: defaults),
+            "zh-Hant-TW"
+        )
+        XCTAssertEqual(defaults.string(forKey: SpeechEnginePreference.nemotronDefaultLanguageKey), "zh-Hant-TW")
+    }
+
+    func testWriteNemotronLanguageRejectsInvalidValue() {
+        XCTAssertThrowsError(
+            try ConfigCommand.write(key: "nemotron-language", value: "definitely-not-a-language", defaults: defaults)
+        ) { error in
+            XCTAssertTrue(error is ValidationError)
+        }
+        XCTAssertNil(defaults.string(forKey: SpeechEnginePreference.nemotronDefaultLanguageKey))
+    }
+
     func testWriteAcceptsAllBoolSynonyms() throws {
         for (synonym, expectedBool) in [
             ("on", true), ("ON", true), ("true", true), ("yes", true),

--- a/Tests/CLITests/ModelLifecycleCommandTests.swift
+++ b/Tests/CLITests/ModelLifecycleCommandTests.swift
@@ -228,6 +228,30 @@ final class ModelLifecycleCommandTests: XCTestCase {
         XCTAssertNil(nemotronDownloadVariant(from: "whisper-large-v3"))
     }
 
+    func testNemotronModelLifecycleSubcommandsParseCanonicalModelID() throws {
+        let modelID = "nemotron-multilingual-1120ms"
+
+        let download = try ModelsCommand.Download.parse([modelID])
+        XCTAssertEqual(download.variant, modelID)
+        XCTAssertEqual(nemotronDownloadVariant(from: download.variant), .multilingual1120)
+
+        let select = try ModelsCommand.Select.parse([modelID])
+        XCTAssertEqual(select.id, modelID)
+        XCTAssertEqual(
+            try resolveSelectableSpeechModel(select.id),
+            SelectableSpeechModelSelection(
+                engine: .nemotron,
+                whisperVariant: nil,
+                nemotronVariant: .multilingual1120
+            )
+        )
+
+        let delete = try ModelsCommand.Delete.parse([modelID, "--force"])
+        XCTAssertEqual(delete.id, modelID)
+        XCTAssertTrue(delete.force)
+        XCTAssertEqual(try resolveModelDeletionTarget(delete.id).kind, .nemotron(.multilingual1120))
+    }
+
     func testResolveSelectableSpeechModelRejectsUnknownID() {
         XCTAssertThrowsError(try resolveSelectableSpeechModel("tiny")) { error in
             XCTAssertTrue(error is ValidationError)

--- a/Tests/CLITests/ModelLifecycleCommandTests.swift
+++ b/Tests/CLITests/ModelLifecycleCommandTests.swift
@@ -50,10 +50,11 @@ final class ModelLifecycleCommandTests: XCTestCase {
         let models = loadSelectableSpeechModels(
             defaults: defaults,
             isParakeetModelCached: { $0 == .v3 },
+            isNemotronModelDownloaded: { $0 == .multilingual1120 },
             isWhisperModelDownloaded: { $0 == "large-v3-v20240930_turbo_632MB" }
         )
 
-        XCTAssertEqual(models.count, 3)
+        XCTAssertEqual(models.count, 4)
         XCTAssertEqual(models[0], SelectableSpeechModel(
             id: "parakeet-v3",
             name: "Parakeet TDT 0.6B v3 (Multilingual)",
@@ -75,6 +76,16 @@ final class ModelLifecycleCommandTests: XCTestCase {
             language: "en"
         ))
         XCTAssertEqual(models[2], SelectableSpeechModel(
+            id: "nemotron-multilingual-1120ms",
+            name: "Nemotron 3.5 ASR Streaming 0.6B (Multilingual Beta)",
+            engine: "nemotron",
+            variant: "multilingual-1120ms",
+            size: "~1.5 GB",
+            installed: true,
+            selected: false,
+            language: "auto"
+        ))
+        XCTAssertEqual(models[3], SelectableSpeechModel(
             id: "whisper-large-v3-v20240930-turbo-632MB",
             name: "Whisper Large v3 Turbo",
             engine: "whisper",
@@ -98,6 +109,7 @@ final class ModelLifecycleCommandTests: XCTestCase {
         let models = loadSelectableSpeechModels(
             defaults: defaults,
             isParakeetModelCached: { _ in true },
+            isNemotronModelDownloaded: { _ in false },
             isWhisperModelDownloaded: { _ in false }
         )
 
@@ -132,6 +144,30 @@ final class ModelLifecycleCommandTests: XCTestCase {
         XCTAssertEqual(
             try resolveSelectableSpeechModel("parakeet-english", defaults: defaults),
             SelectableSpeechModelSelection(engine: .parakeet, whisperVariant: nil, parakeetVariant: .v2)
+        )
+        XCTAssertEqual(
+            try resolveSelectableSpeechModel("nemotron", defaults: defaults),
+            SelectableSpeechModelSelection(
+                engine: .nemotron,
+                whisperVariant: nil,
+                nemotronVariant: .multilingual1120
+            )
+        )
+        XCTAssertEqual(
+            try resolveSelectableSpeechModel("nemotron-multilingual-1120ms", defaults: defaults),
+            SelectableSpeechModelSelection(
+                engine: .nemotron,
+                whisperVariant: nil,
+                nemotronVariant: .multilingual1120
+            )
+        )
+        XCTAssertEqual(
+            try resolveSelectableSpeechModel("nemotron:beta", defaults: defaults),
+            SelectableSpeechModelSelection(
+                engine: .nemotron,
+                whisperVariant: nil,
+                nemotronVariant: .multilingual1120
+            )
         )
         XCTAssertEqual(
             try resolveSelectableSpeechModel("whisper", defaults: defaults),
@@ -183,6 +219,15 @@ final class ModelLifecycleCommandTests: XCTestCase {
         XCTAssertNil(parakeetDownloadVariant(from: "tiny", defaults: defaults))
     }
 
+    func testNemotronDownloadVariantRecognizesNemotronIDs() {
+        XCTAssertEqual(nemotronDownloadVariant(from: "nemotron"), .multilingual1120)
+        XCTAssertEqual(nemotronDownloadVariant(from: "nemotron-multilingual-1120ms"), .multilingual1120)
+        XCTAssertEqual(nemotronDownloadVariant(from: "nemotron:beta"), .multilingual1120)
+        XCTAssertEqual(nemotronDownloadVariant(from: "nemotron_multilingual"), .multilingual1120)
+        XCTAssertNil(nemotronDownloadVariant(from: "parakeet-v3"))
+        XCTAssertNil(nemotronDownloadVariant(from: "whisper-large-v3"))
+    }
+
     func testResolveSelectableSpeechModelRejectsUnknownID() {
         XCTAssertThrowsError(try resolveSelectableSpeechModel("tiny")) { error in
             XCTAssertTrue(error is ValidationError)
@@ -196,6 +241,67 @@ final class ModelLifecycleCommandTests: XCTestCase {
         XCTAssertThrowsError(try resolveSelectableSpeechModel("whisper:")) { error in
             XCTAssertTrue(error is ValidationError)
         }
+    }
+
+    func testValidateSelectableSpeechModelDownloadRejectsMissingNemotron() throws {
+        let suiteName = "com.macparakeet.tests.cli.model-select-nemotron-missing.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        SpeechEnginePreference.saveNemotronDefaultLanguage("en_US", defaults: defaults)
+        var checkedVariant: NemotronModelVariant?
+        var checkedLanguage: String?
+        let selection = SelectableSpeechModelSelection(
+            engine: .nemotron,
+            whisperVariant: nil,
+            nemotronVariant: .multilingual1120
+        )
+
+        XCTAssertThrowsError(
+            try validateSelectableSpeechModelDownload(
+                selection,
+                defaults: defaults,
+                isNemotronModelDownloaded: { variant, language in
+                    checkedVariant = variant
+                    checkedLanguage = language
+                    return false
+                },
+                isWhisperModelDownloaded: { _ in true }
+            )
+        ) { error in
+            XCTAssertTrue(error is ValidationError)
+            XCTAssertTrue(String(describing: error).contains("models download nemotron-multilingual-1120ms"))
+        }
+        XCTAssertEqual(checkedVariant, .multilingual1120)
+        XCTAssertEqual(checkedLanguage, "en-US")
+        XCTAssertNil(defaults.string(forKey: SpeechEnginePreference.defaultsKey))
+    }
+
+    func testValidateSelectableSpeechModelDownloadAllowsDownloadedNemotron() throws {
+        let suiteName = "com.macparakeet.tests.cli.model-select-nemotron-downloaded.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let selection = SelectableSpeechModelSelection(
+            engine: .nemotron,
+            whisperVariant: nil,
+            nemotronVariant: .multilingual1120
+        )
+
+        XCTAssertNoThrow(
+            try validateSelectableSpeechModelDownload(
+                selection,
+                defaults: defaults,
+                isNemotronModelDownloaded: { variant, language in
+                    XCTAssertEqual(variant, .multilingual1120)
+                    XCTAssertNil(language)
+                    return true
+                },
+                isWhisperModelDownloaded: { _ in false }
+            )
+        )
     }
 
     // MARK: - models delete
@@ -218,6 +324,10 @@ final class ModelLifecycleCommandTests: XCTestCase {
         XCTAssertEqual(
             try resolveModelDeletionTarget("parakeet-v3", defaults: defaults).kind,
             .parakeet(.v3)
+        )
+        XCTAssertEqual(
+            try resolveModelDeletionTarget("nemotron-multilingual-1120ms", defaults: defaults).kind,
+            .nemotron(.multilingual1120)
         )
         XCTAssertEqual(
             try resolveModelDeletionTarget("whisper-large-v3-v20240930-turbo-632MB", defaults: defaults).kind,
@@ -250,6 +360,7 @@ final class ModelLifecycleCommandTests: XCTestCase {
                 defaults: defaults
             )
         )
+        XCTAssertFalse(isModelInUse(.init(kind: .nemotron(.multilingual1120), displayName: "nemotron"), defaults: defaults))
     }
 
     func testIsModelInUseProtectsWhisperAndConfiguredParakeetWhenWhisperActive() throws {
@@ -265,6 +376,22 @@ final class ModelLifecycleCommandTests: XCTestCase {
         // would load if the user switches back from Whisper.
         XCTAssertTrue(isModelInUse(.init(kind: .parakeet(.v3), displayName: "v3"), defaults: defaults))
         XCTAssertFalse(isModelInUse(.init(kind: .parakeet(.v2), displayName: "v2"), defaults: defaults))
+        XCTAssertFalse(isModelInUse(.init(kind: .nemotron(.multilingual1120), displayName: "nemotron"), defaults: defaults))
+    }
+
+    func testIsModelInUseProtectsNemotronWhenNemotronActive() throws {
+        let (defaults, suite) = try makeDeleteDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        SpeechEnginePreference.nemotron.save(to: defaults)
+
+        XCTAssertTrue(isModelInUse(.init(kind: .nemotron(.multilingual1120), displayName: "nemotron"), defaults: defaults))
+        XCTAssertFalse(
+            isModelInUse(
+                .init(kind: .whisper(SpeechEnginePreference.defaultWhisperModelVariant), displayName: "whisper"),
+                defaults: defaults
+            )
+        )
     }
 
     func testDeleteCommandParsesForceFlag() throws {
@@ -313,7 +440,9 @@ final class ModelLifecycleCommandTests: XCTestCase {
         let status = await loadSpeechStackStatus(
             sttClient: stt,
             diarizationService: diarization,
-            isSpeechModelCached: { true },
+            isParakeetModelCached: { $0 == .v3 },
+            nemotronModelVariant: .multilingual1120,
+            isNemotronModelDownloaded: { $0 == .multilingual1120 },
             whisperModelVariant: "large-v3-v20240930_turbo_632MB",
             isWhisperModelDownloaded: { $0 == "large-v3-v20240930_turbo_632MB" }
         )
@@ -321,10 +450,15 @@ final class ModelLifecycleCommandTests: XCTestCase {
         XCTAssertEqual(
             status,
             SpeechStackStatus(
+                speechEngine: .parakeet,
                 speechModelCached: true,
                 speechRuntimeReady: true,
                 speakerModelsCached: false,
                 speakerModelsPrepared: false,
+                parakeetModelVariant: .v3,
+                parakeetModelDownloaded: true,
+                nemotronModelVariant: .multilingual1120,
+                nemotronModelDownloaded: true,
                 whisperModelVariant: "large-v3-v20240930_turbo_632MB",
                 whisperModelDownloaded: true
             )

--- a/Tests/CLITests/SpecCommandTests.swift
+++ b/Tests/CLITests/SpecCommandTests.swift
@@ -18,6 +18,8 @@ final class SpecCommandTests: XCTestCase {
         let commands = try XCTUnwrap(payload["commands"] as? [[String: Any]])
         let paths = commands.compactMap { $0["path"] as? [String] }
         XCTAssertTrue(paths.contains(["meetings", "results", "add"]))
+        XCTAssertTrue(paths.contains(["config", "set"]))
+        XCTAssertTrue(paths.contains(["models", "delete"]))
         XCTAssertTrue(paths.contains(["spec"]))
 
         let writeback = try XCTUnwrap(commands.first { ($0["path"] as? [String]) == ["meetings", "results", "add"] })
@@ -38,7 +40,7 @@ final class SpecCommandTests: XCTestCase {
 
         XCTAssertEqual(
             documentedTopLevelCommands,
-            ["spec", "health", "transcribe", "history", "prompts", "meetings"],
+            ["spec", "health", "transcribe", "config", "models", "history", "prompts", "meetings"],
             "The spec catalog is a curated agent-facing surface; update this expectation when that surface changes."
         )
         for path in paths {
@@ -76,6 +78,19 @@ final class SpecCommandTests: XCTestCase {
         XCTAssertEqual(engine["valueName"] as? String, "parakeet|nemotron|whisper|app-default")
         let language = try XCTUnwrap(options.first { ($0["name"] as? String) == "--language" })
         XCTAssertEqual(language["summary"] as? String, "Language hint for Nemotron or Whisper.")
+    }
+
+    func testSpecDocumentsConfigAndModelsCommands() throws {
+        let payload = try specPayload()
+        let commands = try XCTUnwrap(payload["commands"] as? [[String: Any]])
+
+        let configSet = try XCTUnwrap(commands.first { ($0["path"] as? [String]) == ["config", "set"] })
+        XCTAssertEqual(configSet["readOnly"] as? Bool, false)
+
+        let modelsDelete = try XCTUnwrap(commands.first { ($0["path"] as? [String]) == ["models", "delete"] })
+        XCTAssertEqual(modelsDelete["readOnly"] as? Bool, false)
+        let options = try XCTUnwrap(modelsDelete["options"] as? [[String: Any]])
+        XCTAssertTrue(options.contains { ($0["name"] as? String) == "--force" })
     }
 
     private func specPayload() throws -> [String: Any] {

--- a/Tests/CLITests/SpecCommandTests.swift
+++ b/Tests/CLITests/SpecCommandTests.swift
@@ -71,6 +71,11 @@ final class SpecCommandTests: XCTestCase {
         XCTAssertTrue(optionNames.contains("--speaker-min"))
         XCTAssertTrue(optionNames.contains("--speaker-max"))
         XCTAssertTrue(optionNames.contains("--media-audio-quality"))
+
+        let engine = try XCTUnwrap(options.first { ($0["name"] as? String) == "--engine" })
+        XCTAssertEqual(engine["valueName"] as? String, "parakeet|nemotron|whisper|app-default")
+        let language = try XCTUnwrap(options.first { ($0["name"] as? String) == "--language" })
+        XCTAssertEqual(language["summary"] as? String, "Language hint for Nemotron or Whisper.")
     }
 
     private func specPayload() throws -> [String: Any] {

--- a/Tests/CLITests/TranscribeCommandTests.swift
+++ b/Tests/CLITests/TranscribeCommandTests.swift
@@ -135,6 +135,31 @@ final class TranscribeCommandTests: XCTestCase {
         XCTAssertNil(selection.language)
     }
 
+    func testResolveSpeechEngineUsesStoredNemotronLanguageForAppDefault() {
+        let selection = TranscribeCommand.resolveSpeechEngine(
+            .appDefault,
+            storedEngine: SpeechEnginePreference.nemotron.rawValue,
+            storedLanguage: "ko",
+            storedNemotronLanguage: "en_US",
+            explicitLanguage: nil
+        )
+
+        XCTAssertEqual(selection.engine, .nemotron)
+        XCTAssertEqual(selection.language, "en-US")
+    }
+
+    func testResolveSpeechEngineExplicitNemotronUsesExplicitLanguage() {
+        let selection = TranscribeCommand.resolveSpeechEngine(
+            .nemotron,
+            storedEngine: SpeechEnginePreference.whisper.rawValue,
+            storedLanguage: "ko",
+            explicitLanguage: "zh_CN"
+        )
+
+        XCTAssertEqual(selection.engine, .nemotron)
+        XCTAssertEqual(selection.language, "zh-CN")
+    }
+
     func testResolveSpeechEngineExplicitParakeetDropsLanguage() {
         let selection = TranscribeCommand.resolveSpeechEngine(
             .parakeet,
@@ -223,6 +248,17 @@ final class TranscribeCommandTests: XCTestCase {
 
         XCTAssertEqual(command.engine, .whisper)
         XCTAssertEqual(command.language, "ko")
+    }
+
+    func testParsesNemotronEngineAndLanguage() throws {
+        let command = try TranscribeCommand.parse([
+            "sample.wav",
+            "--engine", "nemotron",
+            "--language", "en-US",
+        ])
+
+        XCTAssertEqual(command.engine, .nemotron)
+        XCTAssertEqual(command.language, "en-US")
     }
 
     func testParsesAppDefaultEngineAndSpeakerDetection() throws {

--- a/Tests/MacParakeetTests/STT/ModelDeletionTests.swift
+++ b/Tests/MacParakeetTests/STT/ModelDeletionTests.swift
@@ -71,6 +71,47 @@ final class ModelDeletionTests: XCTestCase {
         XCTAssertFalse(STTRuntime.removeNemotronModelFiles(at: missing))
     }
 
+    func testDeleteNemotronModelCachesRemovesEveryLanguageForVariant() throws {
+        let repoRoot = tempRoot.appendingPathComponent("NemotronMultilingual", isDirectory: true)
+        let autoVariant = repoRoot
+            .appendingPathComponent("auto", isDirectory: true)
+            .appendingPathComponent("1120ms", isDirectory: true)
+        let japaneseVariant = repoRoot
+            .appendingPathComponent("ja", isDirectory: true)
+            .appendingPathComponent("1120ms", isDirectory: true)
+        let siblingVariant = repoRoot
+            .appendingPathComponent("ja", isDirectory: true)
+            .appendingPathComponent("80ms", isDirectory: true)
+        for dir in [autoVariant, japaneseVariant, siblingVariant] {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            try "weights".write(to: dir.appendingPathComponent("model.bin"), atomically: true, encoding: .utf8)
+        }
+
+        XCTAssertTrue(NemotronEngine.deleteModelCaches(modelVariant: .multilingual1120, cacheRoot: repoRoot))
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: autoVariant.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: japaneseVariant.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: siblingVariant.path))
+    }
+
+    func testDeleteNemotronModelWithInvalidLanguageDoesNotDeleteAllCaches() throws {
+        let repoRoot = tempRoot.appendingPathComponent("NemotronMultilingual", isDirectory: true)
+        let autoVariant = repoRoot
+            .appendingPathComponent("auto", isDirectory: true)
+            .appendingPathComponent("1120ms", isDirectory: true)
+        try FileManager.default.createDirectory(at: autoVariant, withIntermediateDirectories: true)
+        try "weights".write(to: autoVariant.appendingPathComponent("model.bin"), atomically: true, encoding: .utf8)
+
+        XCTAssertFalse(
+            NemotronEngine.deleteModel(
+                modelVariant: .multilingual1120,
+                language: "definitely-not-a-language",
+                cacheRoot: repoRoot
+            )
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: autoVariant.path))
+    }
+
     // MARK: - Whisper variant file removal
 
     func testDeleteWhisperModelRemovesFolderAndClearsOptimizedFlag() throws {

--- a/Tests/MacParakeetTests/STT/ModelDeletionTests.swift
+++ b/Tests/MacParakeetTests/STT/ModelDeletionTests.swift
@@ -47,6 +47,30 @@ final class ModelDeletionTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: v3Dir.path))
     }
 
+    // MARK: - Nemotron repo file removal
+
+    func testRemoveNemotronModelFilesDeletesWholeRepoRoot() throws {
+        let repoRoot = tempRoot.appendingPathComponent("NemotronMultilingual", isDirectory: true)
+        let autoDir = repoRoot
+            .appendingPathComponent("auto", isDirectory: true)
+            .appendingPathComponent("1120ms", isDirectory: true)
+        let japaneseDir = repoRoot
+            .appendingPathComponent("ja", isDirectory: true)
+            .appendingPathComponent("1120ms", isDirectory: true)
+        for dir in [autoDir, japaneseDir] {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            try "weights".write(to: dir.appendingPathComponent("model.bin"), atomically: true, encoding: .utf8)
+        }
+
+        XCTAssertTrue(STTRuntime.removeNemotronModelFiles(at: repoRoot))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: repoRoot.path))
+    }
+
+    func testRemoveNemotronModelFilesIsNoOpWhenAbsent() {
+        let missing = tempRoot.appendingPathComponent("missing-nemotron", isDirectory: true)
+        XCTAssertFalse(STTRuntime.removeNemotronModelFiles(at: missing))
+    }
+
     // MARK: - Whisper variant file removal
 
     func testDeleteWhisperModelRemovesFolderAndClearsOptimizedFlag() throws {

--- a/Tests/MacParakeetTests/STT/ModelDeletionTests.swift
+++ b/Tests/MacParakeetTests/STT/ModelDeletionTests.swift
@@ -112,6 +112,45 @@ final class ModelDeletionTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: autoVariant.path))
     }
 
+    func testDownloadNemotronModelEmitsRuntimeTelemetryOnSuccess() async throws {
+        let telemetry = ModelDeletionTelemetrySpy()
+        Telemetry.configure(telemetry)
+        defer { Telemetry.configure(NoOpTelemetryService()) }
+        let modelURL = tempRoot!
+
+        try await STTRuntime.downloadNemotronModel(
+            modelVariant: .multilingual1120,
+            language: "ja",
+            emitTelemetry: true,
+            downloader: { _, _, _ in
+                modelURL
+            }
+        )
+
+        let events = telemetry.snapshot()
+        XCTAssertTrue(events.containsNemotronDownloadStarted)
+        XCTAssertTrue(events.containsNemotronDownloadCompleted)
+        XCTAssertTrue(events.containsNemotronDownloadOperation(outcome: .success))
+    }
+
+    func testDownloadNemotronModelCanSuppressRuntimeTelemetryForUIOwnedFlows() async throws {
+        let telemetry = ModelDeletionTelemetrySpy()
+        Telemetry.configure(telemetry)
+        defer { Telemetry.configure(NoOpTelemetryService()) }
+        let modelURL = tempRoot!
+
+        try await STTRuntime.downloadNemotronModel(
+            modelVariant: .multilingual1120,
+            language: "ja",
+            emitTelemetry: false,
+            downloader: { _, _, _ in
+                modelURL
+            }
+        )
+
+        XCTAssertTrue(telemetry.snapshot().isEmpty)
+    }
+
     // MARK: - Whisper variant file removal
 
     func testDeleteWhisperModelRemovesFolderAndClearsOptimizedFlag() throws {
@@ -143,5 +182,86 @@ final class ModelDeletionTests: XCTestCase {
             defaults: defaults
         )
         XCTAssertFalse(removed)
+    }
+}
+
+private final class ModelDeletionTelemetrySpy: TelemetryServiceProtocol, @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [TelemetryEventSpec] = []
+
+    func send(_ event: TelemetryEventSpec) {
+        lock.lock()
+        events.append(event)
+        lock.unlock()
+    }
+
+    func sendAndFlush(_ event: TelemetryEventSpec) async -> Bool {
+        send(event)
+        return true
+    }
+
+    func clearQueue() {
+        lock.lock()
+        events.removeAll()
+        lock.unlock()
+    }
+
+    func flush() async {}
+    func flushForTermination() {}
+
+    func snapshot() -> [TelemetryEventSpec] {
+        lock.lock()
+        defer { lock.unlock() }
+        return events
+    }
+}
+
+private extension Array where Element == TelemetryEventSpec {
+    var containsNemotronDownloadStarted: Bool {
+        contains {
+            if case .modelDownloadStarted(let modelKind, let speechEngine, let engineVariant) = $0 {
+                return modelKind == .nemotronSTT
+                    && speechEngine == .nemotron
+                    && engineVariant == NemotronModelVariant.multilingual1120.rawValue
+            }
+            return false
+        }
+    }
+
+    var containsNemotronDownloadCompleted: Bool {
+        contains {
+            if case .modelDownloadCompleted(_, let modelKind, let speechEngine, let engineVariant) = $0 {
+                return modelKind == .nemotronSTT
+                    && speechEngine == .nemotron
+                    && engineVariant == NemotronModelVariant.multilingual1120.rawValue
+            }
+            return false
+        }
+    }
+
+    func containsNemotronDownloadOperation(outcome expectedOutcome: ObservabilityOutcome) -> Bool {
+        contains {
+            if case .modelOperation(
+                _,
+                _,
+                let action,
+                let outcome,
+                let stage,
+                let modelKind,
+                let speechEngine,
+                let engineVariant,
+                _,
+                let errorType
+            ) = $0 {
+                return action == .download
+                    && outcome == expectedOutcome
+                    && stage == .download
+                    && modelKind == .nemotronSTT
+                    && speechEngine == .nemotron
+                    && engineVariant == NemotronModelVariant.multilingual1120.rawValue
+                    && errorType == nil
+            }
+            return false
+        }
     }
 }

--- a/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
+++ b/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
@@ -121,6 +121,30 @@ final class STTSchedulerTests: XCTestCase {
         XCTAssertEqual(counts.shutdown, 1)
     }
 
+    func testClearModelCacheRejectsNewJobsUntilRuntimeClearCompletes() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.blockNextClearModelCache()
+        let scheduler = STTScheduler(runtimeProvider: runtime)
+
+        let clearTask = Task { await scheduler.clearModelCache() }
+        try await waitForClearModelCacheCall(runtime: runtime, count: 1)
+
+        do {
+            _ = try await scheduler.transcribe(audioPath: "during-clear", job: .dictation)
+            XCTFail("Expected new STT work to be rejected while cache clear is still running.")
+        } catch let error as STTSchedulerError {
+            XCTAssertEqual(error, .unavailable)
+        } catch {
+            XCTFail("Expected STTSchedulerError.unavailable, got \(error)")
+        }
+
+        await runtime.releaseClearModelCache()
+        _ = await clearTask.value
+
+        let result = try await scheduler.transcribe(audioPath: "after-clear", job: .dictation)
+        XCTAssertEqual(result.text, "dictation:after-clear")
+    }
+
     func testSetSpeechEngineForwardsWhenIdle() async throws {
         let runtime = MockSTTRuntime()
         let scheduler = STTScheduler(runtimeProvider: runtime)
@@ -613,6 +637,21 @@ final class STTSchedulerTests: XCTestCase {
         }
     }
 
+    private func waitForClearModelCacheCall(
+        runtime: MockSTTRuntime,
+        count: Int,
+        timeout: Duration = .seconds(2)
+    ) async throws {
+        let start = ContinuousClock.now
+        while await runtime.lifecycleCounts().clearModelCache < count {
+            if start.duration(to: .now) > timeout {
+                XCTFail("Timed out waiting for \(count) cache clears")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+    }
+
     private func value<T>(
         _ task: Task<T, any Error>,
         timeout: Duration = .seconds(1)
@@ -787,8 +826,10 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
     private var selection = SpeechEngineSelection(engine: .parakeet)
     private var ready = false
     private var shouldBlockNextSpeechEngineSwitch = false
+    private var shouldBlockNextClearModelCache = false
     private var ignoreCancellation = false
     private var speechEngineSwitchContinuation: CheckedContinuation<Void, Never>?
+    private var clearModelCacheContinuation: CheckedContinuation<Void, Never>?
 
     func transcribe(
         audioPath: String,
@@ -856,6 +897,12 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
 
     func clearModelCache() async {
         clearModelCacheCallCount += 1
+        if shouldBlockNextClearModelCache {
+            shouldBlockNextClearModelCache = false
+            await withCheckedContinuation { continuation in
+                clearModelCacheContinuation = continuation
+            }
+        }
         ready = false
     }
 
@@ -924,6 +971,15 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
         speechEngineSwitchContinuation = nil
     }
 
+    func blockNextClearModelCache() {
+        shouldBlockNextClearModelCache = true
+    }
+
+    func releaseClearModelCache() {
+        clearModelCacheContinuation?.resume()
+        clearModelCacheContinuation = nil
+    }
+
     func block(path: String) {
         blockedPaths.insert(path)
     }
@@ -948,6 +1004,7 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
             continuation.resume(throwing: CancellationError())
         }
         waitingContinuations.removeAll()
+        releaseClearModelCache()
     }
 
     private func cancelBlocked(path: String) {

--- a/Tests/MacParakeetTests/STT/SpeechEnginePreferenceTests.swift
+++ b/Tests/MacParakeetTests/STT/SpeechEnginePreferenceTests.swift
@@ -14,6 +14,27 @@ final class SpeechEnginePreferenceTests: XCTestCase {
         )
     }
 
+    func testEngineAlternativesPreserveStableParakeetToWhisperPath() {
+        XCTAssertEqual(SpeechEnginePreference.parakeet.alternative, .whisper)
+        XCTAssertEqual(SpeechEnginePreference.nemotron.alternative, .whisper)
+        XCTAssertEqual(SpeechEnginePreference.whisper.alternative, .parakeet)
+    }
+
+    func testSTTRuntimeUsesInjectedDefaultsForSpeechEngineLanguages() async {
+        let (defaults, suite) = makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        SpeechEnginePreference.saveNemotronDefaultLanguage("en_US", defaults: defaults)
+        let nemotronRuntime = STTRuntime(speechEngine: .nemotron, defaults: defaults)
+        let nemotronSelection = await nemotronRuntime.currentSpeechEngineSelection()
+        XCTAssertEqual(nemotronSelection, SpeechEngineSelection(engine: .nemotron, language: "en-US"))
+
+        SpeechEnginePreference.saveWhisperDefaultLanguage("KO_kr", defaults: defaults)
+        let whisperRuntime = STTRuntime(speechEngine: .whisper, defaults: defaults)
+        let whisperSelection = await whisperRuntime.currentSpeechEngineSelection()
+        XCTAssertEqual(whisperSelection, SpeechEngineSelection(engine: .whisper, language: "ko"))
+    }
+
     // MARK: - Whisper optimized-variant tracking
 
     private func makeIsolatedDefaults() -> (UserDefaults, String) {

--- a/Tests/MacParakeetTests/STT/SpeechEnginePreferenceTests.swift
+++ b/Tests/MacParakeetTests/STT/SpeechEnginePreferenceTests.swift
@@ -203,6 +203,15 @@ final class SpeechEnginePreferenceTests: XCTestCase {
         SpeechEnginePreference.saveNemotronDefaultLanguage("en_US", defaults: defaults)
         XCTAssertEqual(SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults), "en-US")
 
+        SpeechEnginePreference.saveNemotronDefaultLanguage("zh_hant_tw", defaults: defaults)
+        XCTAssertEqual(SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults), "zh-Hant-TW")
+
+        SpeechEnginePreference.saveNemotronDefaultLanguage("es_419", defaults: defaults)
+        XCTAssertEqual(SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults), "es-419")
+
+        SpeechEnginePreference.saveNemotronDefaultLanguage("definitely-not-a-language", defaults: defaults)
+        XCTAssertNil(SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults))
+
         SpeechEnginePreference.saveNemotronDefaultLanguage("auto", defaults: defaults)
         XCTAssertNil(SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults))
     }

--- a/Tests/MacParakeetTests/STT/SpeechEnginePreferenceTests.swift
+++ b/Tests/MacParakeetTests/STT/SpeechEnginePreferenceTests.swift
@@ -165,10 +165,32 @@ final class SpeechEnginePreferenceTests: XCTestCase {
         SpeechEnginePreference.saveWhisperModelVariant("small", defaults: defaults)
 
         XCTAssertFalse(SpeechEnginePreference.isColdSwitch(to: .parakeet, defaults: defaults))
+        XCTAssertFalse(SpeechEnginePreference.isColdSwitch(to: .nemotron, defaults: defaults))
         XCTAssertTrue(SpeechEnginePreference.isColdSwitch(to: .whisper, defaults: defaults))
 
         SpeechEnginePreference.markWhisperOptimized(variant: "small", defaults: defaults)
 
         XCTAssertFalse(SpeechEnginePreference.isColdSwitch(to: .whisper, defaults: defaults))
+    }
+
+    func testNemotronDefaultLanguageRoundTripsAndNormalizes() {
+        let (defaults, suite) = makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        XCTAssertNil(SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults))
+
+        SpeechEnginePreference.saveNemotronDefaultLanguage("en_US", defaults: defaults)
+        XCTAssertEqual(SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults), "en-US")
+
+        SpeechEnginePreference.saveNemotronDefaultLanguage("auto", defaults: defaults)
+        XCTAssertNil(SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults))
+    }
+
+    func testSpeechEngineSelectionCarriesNemotronLanguage() {
+        XCTAssertEqual(
+            SpeechEngineSelection(engine: .nemotron, language: "zh_CN"),
+            SpeechEngineSelection(engine: .nemotron, language: "zh-CN")
+        )
+        XCTAssertNil(SpeechEngineSelection(engine: .parakeet, language: "ko").language)
     }
 }

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -1368,6 +1368,56 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(event.wasCold, false)
     }
 
+    func testSpeechEngineChangeBlocksMissingNemotronModelAndRestoresPreviousEngine() async throws {
+        let switcher = MockSpeechEngineSwitcher()
+        SpeechEnginePreference.whisper.save(to: testDefaults)
+        let vm = SettingsViewModel(defaults: testDefaults)
+        vm.whisperModelStatus = .notLoaded
+        vm.nemotronModelStatus = .notDownloaded
+        vm.configure(
+            permissionService: mockPermissions,
+            dictationRepo: mockRepo,
+            entitlementsService: entitlements,
+            checkoutURL: nil,
+            speechEngineSwitcher: switcher
+        )
+
+        XCTAssertEqual(vm.speechEnginePreference, .whisper)
+
+        vm.speechEnginePreference = .nemotron
+
+        XCTAssertEqual(vm.speechEnginePreference, .whisper)
+        XCTAssertEqual(SpeechEnginePreference.current(defaults: testDefaults), .whisper)
+        XCTAssertEqual(vm.speechEngineError, "Download the Nemotron model before switching engines.")
+        let preferences = await switcher.preferences
+        XCTAssertTrue(preferences.isEmpty)
+    }
+
+    func testSpeechEngineChangeBlocksMissingWhisperModelAndRestoresPreviousEngine() async throws {
+        let switcher = MockSpeechEngineSwitcher()
+        SpeechEnginePreference.nemotron.save(to: testDefaults)
+        let vm = SettingsViewModel(defaults: testDefaults)
+        vm.nemotronModelStatus = .notLoaded
+        vm.whisperModelStatus = .notDownloaded
+        vm.configure(
+            permissionService: mockPermissions,
+            dictationRepo: mockRepo,
+            entitlementsService: entitlements,
+            checkoutURL: nil,
+            speechEngineSwitcher: switcher
+        )
+
+        XCTAssertEqual(vm.speechEnginePreference, .nemotron)
+
+        vm.speechEnginePreference = .whisper
+
+        XCTAssertEqual(vm.speechEnginePreference, .nemotron)
+        XCTAssertEqual(SpeechEnginePreference.current(defaults: testDefaults), .nemotron)
+        XCTAssertEqual(vm.speechEngineError, "Download the Whisper model before switching engines.")
+        let preferences = await switcher.preferences
+        XCTAssertTrue(preferences.isEmpty)
+    }
+
     func testParakeetModelVariantChangeCallsSwitcherAndPersistsOnSuccess() async throws {
         let switcher = MockSpeechEngineSwitcher()
         viewModel.configure(

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -1154,6 +1154,38 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(vm.parakeetStatusDetail, "Parakeet TDT 0.6B v3 · Installed locally, loads when selected.")
     }
 
+    func testRefreshModelStatusChecksNemotronCacheWithStoredLanguage() async throws {
+        SpeechEnginePreference.saveNemotronDefaultLanguage("en_US", defaults: testDefaults)
+        let recorder = NemotronCacheCheckRecorder()
+        let vm = SettingsViewModel(
+            defaults: testDefaults,
+            youtubeDownloadsDirPath: { [youtubeDownloadsTestDir] in
+                youtubeDownloadsTestDir?.path ?? AppPaths.youtubeDownloadsDir
+            },
+            parakeetModelVariantCached: { _ in true },
+            nemotronModelVariantCached: { variant, language in
+                recorder.record(variant, language)
+                return true
+            }
+        )
+        let stt = MockSTTClient()
+        await stt.setReady(false)
+
+        vm.configure(
+            permissionService: mockPermissions,
+            dictationRepo: mockRepo,
+            entitlementsService: entitlements,
+            checkoutURL: nil,
+            sttClient: stt
+        )
+
+        try await waitUntil { vm.nemotronModelStatus == .notLoaded }
+        let capturedChecks = recorder.calls
+        XCTAssertEqual(capturedChecks.first?.0, .multilingual1120)
+        XCTAssertEqual(capturedChecks.first?.1, "en-US")
+        XCTAssertEqual(vm.nemotronModelStatusDetail, "Nemotron 3.5 ASR Streaming 0.6B · Installed locally, loads when selected.")
+    }
+
     func testRepairParakeetModelUsesRetryAndEndsReady() async throws {
         let vm = SettingsViewModel(
             defaults: testDefaults,
@@ -1303,6 +1335,37 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(SpeechEnginePreference.current(defaults: testDefaults), .whisper)
         XCTAssertFalse(viewModel.speechEngineSwitching)
         XCTAssertNil(viewModel.speechEngineError)
+    }
+
+    func testSpeechEngineChangeBlocksMissingNemotronModel() async throws {
+        let telemetry = SettingsTelemetrySpy()
+        Telemetry.configure(telemetry)
+        let switcher = MockSpeechEngineSwitcher()
+        viewModel.nemotronModelStatus = .notDownloaded
+        viewModel.configure(
+            permissionService: mockPermissions,
+            dictationRepo: mockRepo,
+            entitlementsService: entitlements,
+            checkoutURL: nil,
+            speechEngineSwitcher: switcher
+        )
+
+        viewModel.speechEnginePreference = .nemotron
+
+        XCTAssertEqual(viewModel.speechEnginePreference, .parakeet)
+        XCTAssertEqual(SpeechEnginePreference.current(defaults: testDefaults), .parakeet)
+        XCTAssertEqual(viewModel.speechEngineError, "Download the Nemotron model before switching engines.")
+        XCTAssertFalse(viewModel.speechEngineSwitching)
+        let preferences = await switcher.preferences
+        XCTAssertTrue(preferences.isEmpty)
+
+        let event = try XCTUnwrap(speechEngineSwitchEvents(in: telemetry.snapshot()).last)
+        XCTAssertEqual(event.fromEngine, .parakeet)
+        XCTAssertEqual(event.toEngine, .nemotron)
+        XCTAssertEqual(event.outcome, .unavailable)
+        XCTAssertEqual(event.blockedReason, .modelNotDownloaded)
+        XCTAssertEqual(event.errorType, "model_not_downloaded")
+        XCTAssertEqual(event.wasCold, false)
     }
 
     func testParakeetModelVariantChangeCallsSwitcherAndPersistsOnSuccess() async throws {
@@ -1908,6 +1971,7 @@ final class SettingsViewModelTests: XCTestCase {
             defaults: testDefaults,
             parakeetModelVariantCached: { _ in true },
             deleteParakeetModelOnDisk: { variant in recorder.recordParakeet(variant); return true },
+            deleteNemotronModelOnDisk: { variant, language in recorder.recordNemotron(variant, language); return true },
             deleteWhisperModelOnDisk: { variant in recorder.recordWhisper(variant); return true }
         )
     }
@@ -1983,6 +2047,46 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(vm.whisperModelStatus, .notLoaded)
         XCTAssertTrue(recorder.whisperCalls.isEmpty)
     }
+
+    func testDeleteNemotronModelUsesStoredLanguageWhenParakeetActive() async throws {
+        SpeechEnginePreference.saveNemotronDefaultLanguage("en_US", defaults: testDefaults)
+        let recorder = ModelDeleteRecorder()
+        let vm = makeDeletionViewModel(engine: .parakeet, parakeetVariant: .v3, recorder: recorder)
+        vm.nemotronModelStatus = .notLoaded
+
+        vm.deleteNemotronModel()
+
+        XCTAssertEqual(vm.nemotronModelStatus, .notDownloaded)
+        try await waitUntil {
+            recorder.nemotronCalls.count == 1
+                && recorder.nemotronCalls.first?.0 == .multilingual1120
+                && recorder.nemotronCalls.first?.1 == "en-US"
+        }
+    }
+
+    func testDeleteNemotronModelRefusedWhenNemotronActive() {
+        let recorder = ModelDeleteRecorder()
+        let vm = makeDeletionViewModel(engine: .nemotron, parakeetVariant: .v3, recorder: recorder)
+        vm.nemotronModelStatus = .notLoaded
+
+        vm.deleteNemotronModel()
+
+        XCTAssertEqual(vm.nemotronModelStatus, .notLoaded)
+        XCTAssertTrue(recorder.nemotronCalls.isEmpty)
+    }
+}
+
+private final class NemotronCacheCheckRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedCalls: [(NemotronModelVariant, String?)] = []
+
+    func record(_ variant: NemotronModelVariant, _ language: String?) {
+        lock.lock(); recordedCalls.append((variant, language)); lock.unlock()
+    }
+
+    var calls: [(NemotronModelVariant, String?)] {
+        lock.lock(); defer { lock.unlock() }; return recordedCalls
+    }
 }
 
 /// Thread-safe capture for the injected on-disk deleter closures (they fire on
@@ -1990,10 +2094,15 @@ final class SettingsViewModelTests: XCTestCase {
 private final class ModelDeleteRecorder: @unchecked Sendable {
     private let lock = NSLock()
     private var parakeet: [ParakeetModelVariant] = []
+    private var nemotron: [(NemotronModelVariant, String?)] = []
     private var whisper: [String] = []
 
     func recordParakeet(_ variant: ParakeetModelVariant) {
         lock.lock(); parakeet.append(variant); lock.unlock()
+    }
+
+    func recordNemotron(_ variant: NemotronModelVariant, _ language: String?) {
+        lock.lock(); nemotron.append((variant, language)); lock.unlock()
     }
 
     func recordWhisper(_ variant: String) {
@@ -2002,6 +2111,10 @@ private final class ModelDeleteRecorder: @unchecked Sendable {
 
     var parakeetCalls: [ParakeetModelVariant] {
         lock.lock(); defer { lock.unlock() }; return parakeet
+    }
+
+    var nemotronCalls: [(NemotronModelVariant, String?)] {
+        lock.lock(); defer { lock.unlock() }; return nemotron
     }
 
     var whisperCalls: [String] {

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -2098,7 +2098,7 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertTrue(recorder.whisperCalls.isEmpty)
     }
 
-    func testDeleteNemotronModelUsesStoredLanguageWhenParakeetActive() async throws {
+    func testDeleteNemotronModelDeletesAllLanguageCachesWhenParakeetActive() async throws {
         SpeechEnginePreference.saveNemotronDefaultLanguage("en_US", defaults: testDefaults)
         let recorder = ModelDeleteRecorder()
         let vm = makeDeletionViewModel(engine: .parakeet, parakeetVariant: .v3, recorder: recorder)
@@ -2110,7 +2110,7 @@ final class SettingsViewModelTests: XCTestCase {
         try await waitUntil {
             recorder.nemotronCalls.count == 1
                 && recorder.nemotronCalls.first?.0 == .multilingual1120
-                && recorder.nemotronCalls.first?.1 == "en-US"
+                && recorder.nemotronCalls.first?.1 == nil
         }
     }
 

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -1441,13 +1441,16 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertNil(option.unavailableReason)
     }
 
-    func testRetranscriptionEngineOptionUsesNemotronForParakeetWhenDownloaded() throws {
+    func testRetranscriptionEngineOptionKeepsWhisperForParakeetWhenNemotronIsDownloaded() throws {
         let archivedMeeting = try makeArchivedMeetingRecording(
             speechEngine: SpeechEngineSelection(engine: .parakeet)
         )
         defer { try? FileManager.default.removeItem(at: archivedMeeting.folderURL) }
 
-        viewModel = TranscriptionViewModel(isNemotronModelDownloaded: { true })
+        viewModel = TranscriptionViewModel(
+            isWhisperModelDownloaded: { true },
+            isNemotronModelDownloaded: { true }
+        )
         let original = Transcription(
             id: UUID(),
             fileName: "English Meeting",
@@ -1460,7 +1463,7 @@ final class TranscriptionViewModelTests: XCTestCase {
 
         let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
 
-        XCTAssertEqual(option.alternativeEngine, SpeechEngineSelection(engine: .nemotron))
+        XCTAssertEqual(option.alternativeEngine, SpeechEngineSelection(engine: .whisper))
         XCTAssertTrue(option.isAlternativeAvailable)
         XCTAssertNil(option.unavailableReason)
     }
@@ -1498,7 +1501,11 @@ final class TranscriptionViewModelTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: suiteName) }
         SpeechEnginePreference.parakeet.save(to: defaults)
         SpeechEnginePreference.saveNemotronDefaultLanguage("en_US", defaults: defaults)
-        viewModel = TranscriptionViewModel(defaults: defaults, isNemotronModelDownloaded: { true })
+        viewModel = TranscriptionViewModel(
+            defaults: defaults,
+            isWhisperModelDownloaded: { true },
+            isNemotronModelDownloaded: { true }
+        )
 
         let tmpFile = FileManager.default.temporaryDirectory
             .appendingPathComponent("retranscribe-engine-youtube-\(UUID().uuidString).mp3")
@@ -1518,7 +1525,7 @@ final class TranscriptionViewModelTests: XCTestCase {
         let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
 
         XCTAssertEqual(option.primaryEngine, SpeechEngineSelection(engine: .parakeet))
-        XCTAssertEqual(option.alternativeEngine, SpeechEngineSelection(engine: .nemotron, language: "en-US"))
+        XCTAssertEqual(option.alternativeEngine, SpeechEngineSelection(engine: .whisper))
         XCTAssertTrue(option.isAlternativeAvailable)
         XCTAssertNil(option.unavailableReason)
     }

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -1414,13 +1414,40 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertEqual(option.alternativeEngine, SpeechEngineSelection(engine: .parakeet))
     }
 
-    func testRetranscriptionEngineOptionDisablesMissingWhisperModel() throws {
+    func testRetranscriptionEngineOptionDisablesMissingNemotronModel() throws {
         let archivedMeeting = try makeArchivedMeetingRecording(
             speechEngine: SpeechEngineSelection(engine: .parakeet)
         )
         defer { try? FileManager.default.removeItem(at: archivedMeeting.folderURL) }
 
-        viewModel = TranscriptionViewModel(isWhisperModelDownloaded: { false })
+        viewModel = TranscriptionViewModel(isNemotronModelDownloaded: { false })
+        let original = Transcription(
+            id: UUID(),
+            fileName: "English Meeting",
+            filePath: archivedMeeting.mixedURL.path,
+            durationMs: 2_000,
+            rawTranscript: "Old meeting transcript",
+            status: .completed,
+            sourceType: .meeting
+        )
+
+        let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
+
+        XCTAssertEqual(option.alternativeEngine, SpeechEngineSelection(engine: .nemotron))
+        XCTAssertFalse(option.isAlternativeAvailable)
+        XCTAssertEqual(option.unavailableReason, "Download the Nemotron model in Settings before trying Nemotron.")
+    }
+
+    func testRetranscriptionEngineOptionDisablesMissingWhisperModel() throws {
+        let archivedMeeting = try makeArchivedMeetingRecording(
+            speechEngine: SpeechEngineSelection(engine: .nemotron)
+        )
+        defer { try? FileManager.default.removeItem(at: archivedMeeting.folderURL) }
+
+        viewModel = TranscriptionViewModel(
+            isWhisperModelDownloaded: { false },
+            isNemotronModelDownloaded: { true }
+        )
         let original = Transcription(
             id: UUID(),
             fileName: "English Meeting",
@@ -1443,7 +1470,8 @@ final class TranscriptionViewModelTests: XCTestCase {
         let defaults = UserDefaults(suiteName: suiteName)!
         defer { defaults.removePersistentDomain(forName: suiteName) }
         SpeechEnginePreference.parakeet.save(to: defaults)
-        viewModel = TranscriptionViewModel(defaults: defaults, isWhisperModelDownloaded: { true })
+        SpeechEnginePreference.saveNemotronDefaultLanguage("en_US", defaults: defaults)
+        viewModel = TranscriptionViewModel(defaults: defaults, isNemotronModelDownloaded: { true })
 
         let tmpFile = FileManager.default.temporaryDirectory
             .appendingPathComponent("retranscribe-engine-youtube-\(UUID().uuidString).mp3")
@@ -1463,7 +1491,7 @@ final class TranscriptionViewModelTests: XCTestCase {
         let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
 
         XCTAssertEqual(option.primaryEngine, SpeechEngineSelection(engine: .parakeet))
-        XCTAssertEqual(option.alternativeEngine.engine, .whisper)
+        XCTAssertEqual(option.alternativeEngine, SpeechEngineSelection(engine: .nemotron, language: "en-US"))
         XCTAssertTrue(option.isAlternativeAvailable)
         XCTAssertNil(option.unavailableReason)
     }

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -1414,13 +1414,40 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertEqual(option.alternativeEngine, SpeechEngineSelection(engine: .parakeet))
     }
 
-    func testRetranscriptionEngineOptionDisablesMissingNemotronModel() throws {
+    func testRetranscriptionEngineOptionKeepsWhisperForParakeetWhenNemotronIsMissing() throws {
         let archivedMeeting = try makeArchivedMeetingRecording(
             speechEngine: SpeechEngineSelection(engine: .parakeet)
         )
         defer { try? FileManager.default.removeItem(at: archivedMeeting.folderURL) }
 
-        viewModel = TranscriptionViewModel(isNemotronModelDownloaded: { false })
+        viewModel = TranscriptionViewModel(
+            isWhisperModelDownloaded: { true },
+            isNemotronModelDownloaded: { false }
+        )
+        let original = Transcription(
+            id: UUID(),
+            fileName: "English Meeting",
+            filePath: archivedMeeting.mixedURL.path,
+            durationMs: 2_000,
+            rawTranscript: "Old meeting transcript",
+            status: .completed,
+            sourceType: .meeting
+        )
+
+        let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
+
+        XCTAssertEqual(option.alternativeEngine, SpeechEngineSelection(engine: .whisper))
+        XCTAssertTrue(option.isAlternativeAvailable)
+        XCTAssertNil(option.unavailableReason)
+    }
+
+    func testRetranscriptionEngineOptionUsesNemotronForParakeetWhenDownloaded() throws {
+        let archivedMeeting = try makeArchivedMeetingRecording(
+            speechEngine: SpeechEngineSelection(engine: .parakeet)
+        )
+        defer { try? FileManager.default.removeItem(at: archivedMeeting.folderURL) }
+
+        viewModel = TranscriptionViewModel(isNemotronModelDownloaded: { true })
         let original = Transcription(
             id: UUID(),
             fileName: "English Meeting",
@@ -1434,8 +1461,8 @@ final class TranscriptionViewModelTests: XCTestCase {
         let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
 
         XCTAssertEqual(option.alternativeEngine, SpeechEngineSelection(engine: .nemotron))
-        XCTAssertFalse(option.isAlternativeAvailable)
-        XCTAssertEqual(option.unavailableReason, "Download the Nemotron model in Settings before trying Nemotron.")
+        XCTAssertTrue(option.isAlternativeAvailable)
+        XCTAssertNil(option.unavailableReason)
     }
 
     func testRetranscriptionEngineOptionDisablesMissingWhisperModel() throws {

--- a/Tests/MacParakeetTests/Views/Settings/SettingsStatusRulesTests.swift
+++ b/Tests/MacParakeetTests/Views/Settings/SettingsStatusRulesTests.swift
@@ -26,6 +26,17 @@ final class SettingsStatusRulesTests: XCTestCase {
         XCTAssertEqual(status, SettingsCardStatus(.ok, label: "Ready"))
     }
 
+    func testLocalModelsShowsReadyWhenOptionalNemotronIsMissing() {
+        let status = SettingsStatusRules.localModelsCardStatus(
+            parakeet: .notLoaded,
+            nemotron: .notDownloaded,
+            whisper: .notLoaded,
+            activeEngine: .parakeet
+        )
+
+        XCTAssertEqual(status, SettingsCardStatus(.ok, label: "Ready"))
+    }
+
     func testLocalModelsRecommendsDownloadWhenActiveEngineIsMissing() {
         let status = SettingsStatusRules.localModelsCardStatus(
             parakeet: .notLoaded,

--- a/Tests/MacParakeetTests/Views/Settings/SettingsStatusRulesTests.swift
+++ b/Tests/MacParakeetTests/Views/Settings/SettingsStatusRulesTests.swift
@@ -7,6 +7,7 @@ final class SettingsStatusRulesTests: XCTestCase {
     func testLocalModelsDoesNotShowReadyWhenInactiveWhisperIsMissing() {
         let status = SettingsStatusRules.localModelsCardStatus(
             parakeet: .ready,
+            nemotron: .notLoaded,
             whisper: .notDownloaded,
             activeEngine: .parakeet
         )
@@ -14,9 +15,10 @@ final class SettingsStatusRulesTests: XCTestCase {
         XCTAssertNil(status)
     }
 
-    func testLocalModelsShowsReadyOnlyWhenBothEnginesAreAvailable() {
+    func testLocalModelsShowsReadyOnlyWhenAllEnginesAreAvailable() {
         let status = SettingsStatusRules.localModelsCardStatus(
             parakeet: .notLoaded,
+            nemotron: .notLoaded,
             whisper: .notLoaded,
             activeEngine: .parakeet
         )
@@ -27,6 +29,7 @@ final class SettingsStatusRulesTests: XCTestCase {
     func testLocalModelsRecommendsDownloadWhenActiveEngineIsMissing() {
         let status = SettingsStatusRules.localModelsCardStatus(
             parakeet: .notLoaded,
+            nemotron: .notLoaded,
             whisper: .notDownloaded,
             activeEngine: .whisper
         )
@@ -37,6 +40,7 @@ final class SettingsStatusRulesTests: XCTestCase {
     func testLocalModelsShowsPreparingWhenActiveEngineIsPreparing() {
         let status = SettingsStatusRules.localModelsCardStatus(
             parakeet: .notLoaded,
+            nemotron: .notLoaded,
             whisper: .preparing,
             activeEngine: .whisper
         )
@@ -47,11 +51,23 @@ final class SettingsStatusRulesTests: XCTestCase {
     func testLocalModelsRequiresActionWhenEitherEngineFailed() {
         let status = SettingsStatusRules.localModelsCardStatus(
             parakeet: .ready,
+            nemotron: .notLoaded,
             whisper: .failed,
             activeEngine: .parakeet
         )
 
         XCTAssertEqual(status, SettingsCardStatus(.required, label: "Action needed"))
+    }
+
+    func testLocalModelsRecommendsDownloadWhenActiveNemotronIsMissing() {
+        let status = SettingsStatusRules.localModelsCardStatus(
+            parakeet: .notLoaded,
+            nemotron: .notDownloaded,
+            whisper: .notLoaded,
+            activeEngine: .nemotron
+        )
+
+        XCTAssertEqual(status, SettingsCardStatus(.recommended, label: "Download recommended"))
     }
 
     func testMeetingRecordingRequiresScreenRecordingPermission() {

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -26,7 +26,7 @@ This script builds the latest debug binary, stops stale `/Applications`/`dist` a
 macparakeet-cli
 ├── transcribe <input...> [options]      Transcribe files, folders, or media URLs
 │   ├── --format text|transcript|json [--no-history]
-│   └── --engine app-default|parakeet|whisper [--language <code>]
+│   └── --engine app-default|parakeet|nemotron|whisper [--language <code>]
 │       --parakeet-model app-default|v3|v2 [--output-dir DIR]
 │       --speaker-detection app-default|on|off
 │       [--speaker-count N | --speaker-min N [--speaker-max N] | --speaker-max N]
@@ -53,7 +53,7 @@ macparakeet-cli
 │   ├── list [--json]                    List selectable speech models
 │   ├── select <model-id> [--json]       Set shared app/CLI speech default
 │   ├── status [--json]                  Show model status
-│   ├── download <model-id>              Download explicit model (Whisper)
+│   ├── download <model-id>              Download explicit speech model
 │   ├── warm-up [--attempts]             Warm up speech model
 │   ├── repair [--attempts]              Best-effort model repair
 │   └── clear                            Delete cached models
@@ -181,9 +181,20 @@ Parakeet remains the no-flag default for semver stability and ignores
 English-only opt-in. Use `--parakeet-model app-default|v3|v2` for a single run,
 or `config set parakeet-model v2` / `models select parakeet-v2` to persist it.
 Use `--engine app-default` when you want the CLI to follow the GUI's saved
-speech engine, Parakeet model, and Whisper language defaults. Use Whisper
-explicitly for languages outside Parakeet coverage after downloading the local
-Whisper model:
+speech engine, Parakeet model, and Nemotron/Whisper language defaults.
+Nemotron is an opt-in Beta engine for multilingual local ASR. Download it
+explicitly before selecting or running it:
+
+```bash
+swift run macparakeet-cli models download nemotron-multilingual-1120ms
+
+swift run macparakeet-cli transcribe "<FILE_OR_YOUTUBE_URL>" \
+  --engine nemotron \
+  --language auto
+```
+
+Use Whisper explicitly for languages outside Parakeet/Nemotron coverage after
+downloading the local Whisper model:
 
 ```bash
 swift run macparakeet-cli models download whisper-large-v3-v20240930-turbo-632MB
@@ -193,11 +204,12 @@ swift run macparakeet-cli transcribe "<FILE_OR_YOUTUBE_URL>" \
   --language ko
 ```
 
-`--language auto` or omitting `--language` lets Whisper detect the language.
-When `--engine app-default` resolves to Whisper, an explicit `--language`
-overrides the saved Whisper language for that invocation. When `--engine
-whisper` is explicit, pass `--language` explicitly if you do not want
-auto-detect; the saved Whisper language is only used by `--engine app-default`.
+`--language auto` or omitting `--language` lets Nemotron or Whisper detect the
+language. When `--engine app-default` resolves to Nemotron or Whisper, an
+explicit `--language` overrides the saved language for that invocation. When
+`--engine nemotron` or `--engine whisper` is explicit, pass `--language`
+explicitly if you do not want auto-detect; saved Nemotron/Whisper languages are
+only used by `--engine app-default`.
 
 ### Speaker Diarization
 
@@ -284,14 +296,16 @@ swift run macparakeet-cli models list --json
 swift run macparakeet-cli models select parakeet-v3
 swift run macparakeet-cli models select parakeet-v2
 swift run macparakeet-cli models download parakeet-v2
+swift run macparakeet-cli models download nemotron-multilingual-1120ms
+swift run macparakeet-cli models select nemotron-multilingual-1120ms
 swift run macparakeet-cli models select whisper-large-v3-v20240930-turbo-632MB
 ```
 
 `models list` reports the selectable speech engines MacParakeet exposes today:
-Parakeet v3, Parakeet v2, and the configured WhisperKit variant. `models select`
-writes the same shared default used by the GUI and `transcribe --engine
-app-default`; Whisper selection requires the local Whisper model to be
-downloaded first.
+Parakeet v3, Parakeet v2, Nemotron 3.5 ASR Beta, and the configured WhisperKit
+variant. `models select` writes the same shared default used by the GUI and
+`transcribe --engine app-default`; Nemotron and Whisper selection require the
+local model to be downloaded first.
 
 ## Retained Entitlements Parity
 
@@ -410,9 +424,10 @@ swift run macparakeet-cli calendar upcoming --days 7 --filter all --json
 # Non-invasive status (does not force downloads)
 swift run macparakeet-cli models status
 
-# Explicit Parakeet / Whisper downloads
+# Explicit Parakeet / Nemotron / Whisper downloads
 swift run macparakeet-cli models download parakeet-v3
 swift run macparakeet-cli models download parakeet-v2
+swift run macparakeet-cli models download nemotron-multilingual-1120ms
 swift run macparakeet-cli models download whisper-large-v3-v20240930-turbo-632MB
 
 # Warm-up (single attempt by default)
@@ -424,6 +439,7 @@ swift run macparakeet-cli models repair --attempts 5
 
 # Delete one downloaded model (frees its disk space; leaves the rest)
 swift run macparakeet-cli models delete parakeet-v2
+swift run macparakeet-cli models delete nemotron-multilingual-1120ms
 swift run macparakeet-cli models delete whisper-large-v3-v20240930-turbo-632MB
 swift run macparakeet-cli models delete parakeet-v3 --force   # override the in-use guard
 
@@ -431,12 +447,12 @@ swift run macparakeet-cli models delete parakeet-v3 --force   # override the in-
 swift run macparakeet-cli models clear
 ```
 
-`models warm-up` and `models repair` prepare the selected Parakeet build plus
-the diarization speech stack. Whisper is downloaded explicitly with
-`models download`. `models delete <id>` removes a single model — one Parakeet
-build or the Whisper variant — and protects the active model plus Parakeet's
-configured build unless `--force` is passed; `models clear` still wipes
-everything.
+`models warm-up` and `models repair` prepare the selected speech engine plus
+the diarization speech stack. Nemotron and Whisper are downloaded explicitly
+with `models download`. `models delete <id>` removes a single model - one
+Parakeet build, the Nemotron Beta model, or the Whisper variant - and protects
+the active model plus Parakeet's configured build unless `--force` is passed;
+`models clear` still wipes everything.
 
 ## Text Pipeline
 

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -54,6 +54,7 @@ macparakeet-cli
 │   ├── select <model-id> [--json]       Set shared app/CLI speech default
 │   ├── status [--json]                  Show model status
 │   ├── download <model-id>              Download explicit speech model
+│   ├── delete <model-id> [--force]      Delete one downloaded speech model
 │   ├── warm-up [--attempts]             Warm up speech model
 │   ├── repair [--attempts]              Best-effort model repair
 │   └── clear                            Delete cached models
@@ -247,6 +248,7 @@ swift run macparakeet-cli config list
 swift run macparakeet-cli config set processing-mode raw
 swift run macparakeet-cli config set speech-engine whisper
 swift run macparakeet-cli config set parakeet-model v3
+swift run macparakeet-cli config set nemotron-language auto
 swift run macparakeet-cli config set whisper-language ko
 swift run macparakeet-cli config set speaker-detection off
 swift run macparakeet-cli config set save-transcription-audio off
@@ -254,7 +256,7 @@ swift run macparakeet-cli config set youtube-audio-quality m4a
 ```
 
 Supported keys: `telemetry`, `processing-mode`, `speech-engine`,
-`parakeet-model`, `whisper-language`, `speaker-detection`,
+`parakeet-model`, `nemotron-language`, `whisper-language`, `speaker-detection`,
 `save-transcription-audio`, `youtube-audio-quality`. Underscore aliases such as
 `youtube_audio_quality` are accepted on input; JSON output uses canonical
 hyphenated keys.

--- a/docs/planning/2026-06-nemotron-stt-benchmark-report.md
+++ b/docs/planning/2026-06-nemotron-stt-benchmark-report.md
@@ -1,0 +1,161 @@
+# Nemotron 3.5 STT Benchmark Report
+
+Last updated: 2026-06-08
+Status: smoke benchmark complete; product-corpus benchmark still required before
+promoting Nemotron beyond Beta.
+
+## Scope
+
+This report compares the production MacParakeet CLI path for:
+
+- Parakeet TDT 0.6B v3
+- Nemotron 3.5 ASR Streaming 0.6B, CoreML via FluidAudio
+- Whisper Large v3 Turbo via WhisperKit
+
+The goal is decision support for the Nemotron Beta engine. This is not a final
+model-quality ranking. The current corpus is synthetic `say` audio and is good
+for integration, setup, latency, memory, and obvious transcript regressions. It
+is not enough to claim real-world accuracy or default-engine readiness.
+
+## Upstream Context
+
+NVIDIA describes `nvidia/nemotron-3.5-asr-streaming-0.6b` as a 600M parameter
+multilingual streaming ASR model released on 2026-06-04. The model card states
+support for 40 language-locales, punctuation/capitalization, automatic language
+detection, and configurable chunk sizes including 80 ms, 160 ms, 320 ms, 560 ms,
+and 1120 ms. Source:
+https://huggingface.co/nvidia/nemotron-3.5-asr-streaming-0.6b
+
+MacParakeet currently exposes the 1120 ms multilingual CoreML path as the single
+Nemotron Beta model variant.
+
+## Method
+
+Harness:
+
+```bash
+swift build -c release --product macparakeet-cli
+PHASE_LABEL=warm REPS=1 ENGINES='parakeet-v3 nemotron whisper' \
+  scripts/dev/benchmark_stt_engines.sh \
+  output/benchmarks/stt/smoke-corpus-20260608/corpus.tsv
+```
+
+Artifacts:
+
+- Warm raw TSV: `output/benchmarks/stt/stt-engine-benchmark-20260608-010344.tsv`
+- Warm summary TSV:
+  `output/benchmarks/stt/stt-engine-benchmark-20260608-010344-summary.tsv`
+- First-run setup sample:
+  `output/benchmarks/stt/stt-engine-benchmark-20260608-005353.tsv`
+- Corpus: `output/benchmarks/stt/smoke-corpus-20260608/corpus.tsv`
+
+Machine:
+
+- Apple M4 Pro
+- 48 GB RAM
+- macOS 26.5 (25F71)
+- Swift 6.3.1
+- FluidAudio 0.15.2, revision `7f963cdc43ba89c5993654f1e138047d517a818d`
+
+Metrics:
+
+- `final_wall_s`: `/usr/bin/time -lp` real time for one CLI process
+- `realtime_factor`: `final_wall_s / audio_duration_s`; lower is faster
+- `first_progress_s`: first CLI progress event, not first transcript partial
+- `peak_memory_gb`: `/usr/bin/time -lp` peak memory footprint
+- `wer`: normalized word error rate against synthetic references
+- punctuation and boundary columns are in the raw TSV
+
+Important limitation: the production CLI returns final transcripts and coarse
+progress, not streaming partial transcript text. True first partial latency and
+segment cadence still need a direct streaming probe or app live-preview
+instrumentation.
+
+## Corpus
+
+| Sample | Type | Duration | Notes |
+|---|---:|---:|---|
+| `english-short` | dictation | 6.14s | Synthetic English dictation |
+| `english-quiet` | quiet | 6.14s | Same text, -18 dB gain |
+| `mixed-language` | mixed-language | 7.55s | English plus Spanish words |
+| `english-meeting` | meeting | 9.86s | Meeting-style names and owners |
+| `english-long` | long-file | 125.56s | Repeated planning text |
+
+## Warm Results
+
+Aggregate over all five samples:
+
+| Engine | Total Wall | Overall RTF | Avg First Progress | Avg WER | Max Peak Mem |
+|---|---:|---:|---:|---:|---:|
+| Parakeet v3 | 2.42s | 0.0156 | 0.114s | 0.0399 | 0.070 GB |
+| Nemotron | 3.91s | 0.0252 | 0.056s | 0.1201 | 0.086 GB |
+| Whisper | 17.63s | 0.1136 | 0.053s | 0.0535 | 0.205 GB |
+
+Per-sample:
+
+| Engine | Sample | Wall s | RTF | WER | Peak GB |
+|---|---|---:|---:|---:|---:|
+| parakeet-v3 | english-short | 0.68 | 0.1108 | 0.0000 | 0.042 |
+| nemotron | english-short | 0.70 | 0.1140 | 0.0455 | 0.073 |
+| whisper | english-short | 2.57 | 0.4186 | 0.0000 | 0.183 |
+| parakeet-v3 | english-quiet | 0.37 | 0.0603 | 0.0000 | 0.044 |
+| nemotron | english-quiet | 0.43 | 0.0700 | 0.0455 | 0.073 |
+| whisper | english-quiet | 2.26 | 0.3681 | 0.0000 | 0.185 |
+| parakeet-v3 | mixed-language | 0.32 | 0.0424 | 0.1000 | 0.042 |
+| nemotron | mixed-language | 0.60 | 0.0795 | 0.2500 | 0.074 |
+| whisper | mixed-language | 2.33 | 0.3086 | 0.1000 | 0.184 |
+| parakeet-v3 | english-meeting | 0.32 | 0.0324 | 0.0370 | 0.041 |
+| nemotron | english-meeting | 0.53 | 0.0537 | 0.1852 | 0.073 |
+| whisper | english-meeting | 2.34 | 0.2373 | 0.1111 | 0.184 |
+| parakeet-v3 | english-long | 0.73 | 0.0058 | 0.0625 | 0.070 |
+| nemotron | english-long | 1.65 | 0.0131 | 0.0744 | 0.086 |
+| whisper | english-long | 8.13 | 0.0648 | 0.0565 | 0.205 |
+
+## First-Run Setup Sample
+
+First run on `english-short` after release build and model download:
+
+| Engine | First Run Wall | Peak Mem |
+|---|---:|---:|
+| Parakeet v3 | 19.40s | 0.065 GB |
+| Nemotron | 33.67s | 0.078 GB |
+| Whisper | 212.70s | 0.245 GB |
+
+Interpretation: these numbers include CLI process start plus model load and any
+remaining CoreML compile/optimization cost. They are useful as first-use setup
+signals, not steady-state latency.
+
+## Quality Notes
+
+- Parakeet v3 was fastest and lowest WER on this synthetic corpus.
+- Nemotron was much faster than Whisper in warm steady-state and used less peak
+  process memory, but it had weaker transcript quality on this English-heavy
+  smoke set.
+- Nemotron output often had less punctuation than Parakeet/Whisper on short
+  English samples.
+- Whisper handled the Spanish-accented mixed-language text better than the
+  other two engines in this synthetic sample, but it was much slower.
+- The meeting-style sample shows why Beta labeling matters: Nemotron merged
+  words around owner names and produced "analytics parody"; Parakeet also had
+  "release days", and Whisper also had "analytics parody".
+
+## Decision
+
+Ship Nemotron as an opt-in Beta engine, not as a default candidate.
+
+The integration is valuable because Nemotron is local, fast, and materially
+faster than Whisper in warm-path tests. The current MacParakeet smoke data does
+not justify replacing Parakeet v3 or making stronger quality claims.
+
+## Remaining Benchmark Work
+
+Before calling the benchmark side complete:
+
+- Run a real product corpus with natural speech, laptop/headset quiet input,
+  meeting audio, mixed-language speech, and a 10-30 minute file.
+- Add a direct streaming probe for true first partial latency, partial cadence,
+  and boundary clipping.
+- Run at least 3 repetitions per engine/sample after warm-up.
+- Capture Parakeet v2 where English-only speed is relevant.
+- Re-run on an 8 GB or 16 GB Apple Silicon machine if the Beta is marketed to
+  lower-memory Macs.

--- a/docs/planning/2026-06-nemotron-stt-benchmark-report.md
+++ b/docs/planning/2026-06-nemotron-stt-benchmark-report.md
@@ -46,8 +46,12 @@ Artifacts:
 - Warm summary TSV:
   `output/benchmarks/stt/stt-engine-benchmark-20260608-010344-summary.tsv`
 - First-run setup sample:
-  `output/benchmarks/stt/stt-engine-benchmark-20260608-005353.tsv`
+  `output/benchmarks/stt/logs/20260608-005353-*-english-short-1.stderr.tsv`
 - Corpus: `output/benchmarks/stt/smoke-corpus-20260608/corpus.tsv`
+
+The `output/benchmarks/...` files are local run artifacts, not tracked source
+files. The source rows and log-derived setup values used below are reproduced in
+this report so the PR carries the benchmark evidence.
 
 Machine:
 
@@ -62,7 +66,8 @@ Metrics:
 - `final_wall_s`: `/usr/bin/time -lp` real time for one CLI process
 - `realtime_factor`: `final_wall_s / audio_duration_s`; lower is faster
 - `first_progress_s`: first CLI progress event, not first transcript partial
-- `peak_memory_gb`: `/usr/bin/time -lp` peak memory footprint
+- `max_rss_bytes`: `/usr/bin/time -lp` maximum resident set size, byte-scale on macOS
+- `peak_memory_gb`: `/usr/bin/time -lp` peak memory footprint converted from bytes
 - `wer`: normalized word error rate against synthetic references
 - punctuation and boundary columns are in the raw TSV
 
@@ -111,6 +116,27 @@ Per-sample:
 | nemotron | english-long | 1.65 | 0.0131 | 0.0744 | 0.086 |
 | whisper | english-long | 8.13 | 0.0648 | 0.0565 | 0.205 |
 
+Warm summary source excerpt:
+
+```tsv
+engine_selector	sample_type	phase	n	avg_final_wall_s	avg_realtime_factor	avg_first_progress_s	avg_peak_memory_gb	avg_wer	avg_punctuation_per_100_words
+nemotron	dictation	warm	1	0.7000	0.1140	0.0750	0.0732	0.0455	4.5500
+nemotron	long-file	warm	1	1.6500	0.0131	0.0500	0.0856	0.0744	15.4100
+nemotron	meeting	warm	1	0.5300	0.0537	0.0540	0.0727	0.1852	7.6900
+nemotron	mixed-language	warm	1	0.6000	0.0795	0.0520	0.0741	0.2500	20.0000
+nemotron	quiet	warm	1	0.4300	0.0700	0.0500	0.0732	0.0455	4.5500
+parakeet-v3	dictation	warm	1	0.6800	0.1108	0.3440	0.0418	0.0000	13.6400
+parakeet-v3	long-file	warm	1	0.7300	0.0058	0.0520	0.0704	0.0625	16.0200
+parakeet-v3	meeting	warm	1	0.3200	0.0324	0.0500	0.0411	0.0370	11.1100
+parakeet-v3	mixed-language	warm	1	0.3200	0.0424	0.0510	0.0415	0.1000	15.0000
+parakeet-v3	quiet	warm	1	0.3700	0.0603	0.0750	0.0439	0.0000	13.6400
+whisper	dictation	warm	1	2.5700	0.4186	0.0650	0.1831	0.0000	13.6400
+whisper	long-file	warm	1	8.1300	0.0648	0.0490	0.2047	0.0565	13.6600
+whisper	meeting	warm	1	2.3400	0.2373	0.0500	0.1841	0.1111	11.1100
+whisper	mixed-language	warm	1	2.3300	0.3086	0.0520	0.1842	0.1000	15.0000
+whisper	quiet	warm	1	2.2600	0.3681	0.0500	0.1854	0.0000	13.6400
+```
+
 ## First-Run Setup Sample
 
 First run on `english-short` after release build and model download:
@@ -124,6 +150,25 @@ First run on `english-short` after release build and model download:
 Interpretation: these numbers include CLI process start plus model load and any
 remaining CoreML compile/optimization cost. They are useful as first-use setup
 signals, not steady-state latency.
+
+Source stderr excerpts:
+
+```text
+20260608-005353-parakeet-v3-english-short-1.stderr.tsv:
+real 19.40
+539246592 maximum resident set size
+69534728 peak memory footprint
+
+20260608-005353-nemotron-english-short-1.stderr.tsv:
+real 33.67
+651902976 maximum resident set size
+83313480 peak memory footprint
+
+20260608-005353-whisper-english-short-1.stderr.tsv:
+real 212.70
+784023552 maximum resident set size
+263537696 peak memory footprint
+```
 
 ## Quality Notes
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -396,9 +396,9 @@ app/category profile.
 | Event | Props | Question It Answers |
 |---|---|---|
 | `model_loaded` | `load_time_seconds`, `model_kind`, `speech_engine`, `engine_variant` | How long does model warmup take on different chips and engines? |
-| `model_download_started` | `model_kind`, `speech_engine`, `engine_variant` | First-run and Whisper model setup funnel by engine |
+| `model_download_started` | `model_kind`, `speech_engine`, `engine_variant` | First-run and optional-model setup funnel by engine |
 | `model_download_completed` | `duration_seconds`, `model_kind`, `speech_engine`, `engine_variant` | How long do model downloads take by engine/model? |
-| `model_download_failed` | `error_type`, `model_kind`, `speech_engine`, `engine_variant` | Are downloads failing for Parakeet setup or Whisper downloads? |
+| `model_download_failed` | `error_type`, `model_kind`, `speech_engine`, `engine_variant` | Are downloads failing for Parakeet setup or optional-model downloads? |
 | `model_operation` | `operation_id`, `workflow_id`, `parent_operation_id`, `action`, `outcome`, `stage`, `model_kind`, `speech_engine`, `engine_variant`, `duration_seconds`, `error_type` | Canonical model lifecycle event for downloads, warm-up, repairs, cache clears, and cancellations |
 | `speech_engine_switch_operation` | `operation_id`, `workflow_id`, `parent_operation_id`, `from_engine`, `to_engine`, `outcome`, `duration_seconds`, `blocked_reason`, `error_type`, `was_cold` | Why engine switches succeed, fail, cancel, or get blocked; whether Whisper switches are still paying first-use optimize cost |
 | `stt_runtime_unhealthy` | `reason` | Whether the STT runtime watchdog detects a stuck speech runtime |

--- a/plans/active/2026-06-nemotron-beta-engine-plan.md
+++ b/plans/active/2026-06-nemotron-beta-engine-plan.md
@@ -1,0 +1,353 @@
+# Nemotron Beta Engine Plan
+
+> Status: **ACTIVE PLAN**
+> Drafted: 2026-06-08
+> Branch: `plan/nemotron-benchmark`
+> Worktree: `/Users/dmoon/code/macparakeet-worktrees/nemotron-benchmark`
+> ADRs: `spec/adr/001-parakeet-stt.md`, `spec/adr/016-centralized-stt-runtime-scheduler.md`, `spec/adr/021-whisperkit-multilingual-stt.md`
+> Scope: add Nemotron 3.5 as a clean opt-in Beta speech engine, backed by side-by-side benchmarks against MacParakeet's current Parakeet v3/v2 and Whisper paths.
+
+## 1. Intent
+
+MacParakeet's default STT path is already strong: Parakeet TDT v3/v2 through
+FluidAudio CoreML on Apple Silicon, owned by one process-wide `STTRuntime` and
+scheduled through the two-slot `STTScheduler`. Newer FluidAudio releases add
+Nemotron ASR support with broader multilingual coverage and streaming-oriented
+APIs.
+
+The product goal is to let MacParakeet users try the new local frontier ASR
+engine without destabilizing the proven default path:
+
+**Ship Nemotron 3.5 as an explicit Beta engine for dictation, file
+transcription, and meetings, while Parakeet remains the default stable engine.**
+
+Benchmarks are still required, but they should shape the implementation, UX copy,
+and known tradeoffs rather than block any user-facing exposure until perfect
+proof exists. The answer must come from MacParakeet workloads, not upstream
+claims alone. Dictation, meeting live preview, meeting finalization, and file
+transcription have different latency and output-quality requirements.
+
+## 2. Product Shape
+
+Add Nemotron as a third first-class speech engine in Settings and CLI:
+
+```text
+Speech Recognition
+  Parakeet    Stable default, fastest proven local path
+  Nemotron    Beta, new local multilingual streaming ASR
+  Whisper     Broad compatibility fallback
+```
+
+Suggested user-facing card:
+
+```text
+Nemotron 3.5    Beta
+New local multilingual ASR with streaming support for around 40 languages.
+
+- Around 40 languages
+- Low-latency streaming
+- Runs locally on Apple Silicon
+- Larger download than Parakeet
+```
+
+Keep the fine print light. The Beta tag plus the single decision-help line is
+enough for the Settings card. Deeper details belong in model status, tooltips,
+or docs only when they help a user choose.
+
+Do not put Nemotron inside the existing **Parakeet Model** card. It should be a
+separate speech engine because it has different model artifacts, language-hint
+behavior, streaming/finalization tradeoffs, and maturity.
+
+## 3. Engineering Idea
+
+Integrate Nemotron as a first-class local engine, not as a parallel app-level
+speech stack.
+
+The production implementation should:
+
+- enter through `STTRuntime` and `STTScheduler`
+- preserve one shared STT control plane
+- keep dictation's interactive lane protected
+- keep meeting engine leases deterministic
+- treat batch/final and streaming/interim behavior separately
+- keep Parakeet v3 as the stable default
+- expose Nemotron as opt-in Beta in Settings and CLI
+- support model download, status, deletion, and attribution like the other local
+  engines
+
+Benchmark harness code may start standalone, but production wiring must not copy
+a separate ASR service pattern into the app.
+
+## 4. Hypotheses
+
+1. **Coverage:** Nemotron can cover more languages locally than Parakeet v3,
+   reducing the number of users who need Whisper as their first-choice engine.
+2. **Streaming:** Nemotron streaming may improve live-preview cadence for
+   non-English or mixed-language dictation, but chunk size may trade accuracy
+   for latency.
+3. **Final quality:** Batch/final Nemotron may be competitive for file
+   transcription and meeting finalization, even if streaming interim text has
+   punctuation or boundary limitations.
+4. **Operational fit:** First-load time, model size, memory, CoreML compile
+   behavior, and failure modes may be more important than headline WER.
+
+## 5. Non-Goals
+
+- Do not replace Parakeet as the default.
+- Do not fork the STT scheduler or create feature-owned STT runtimes.
+- Do not claim language or accuracy superiority from synthetic samples alone.
+- Do not ship a cloud STT fallback. This remains a local-first evaluation.
+- Do not add heavy warning copy. Use a concise Beta tag and practical model
+  details.
+
+## 6. Benchmark Dimensions
+
+Measure each engine and job class with the same audio where possible.
+
+| Dimension | Why it matters |
+|---|---|
+| Wall-clock transcription time | User-visible completion latency |
+| Realtime factor | Cross-audio-length speed comparison |
+| First partial latency | Dictation and meeting live-preview feel |
+| Segment cadence | Whether interim output feels continuous |
+| Final text quality | Shipping transcript quality |
+| Boundary integrity | Avoid clipped or duplicated words at emission boundaries |
+| Punctuation/capitalization | Whether final text can be inserted directly |
+| Language handling | Whether detected/manual language behavior is predictable |
+| Peak memory | 8 GB Mac viability and dual-engine residency risk |
+| First-load and compile time | Onboarding and model-switch experience |
+| Model download size | Storage and setup expectations |
+| Failure behavior | Whether errors map cleanly to user-facing states |
+
+## 7. Audio Corpus
+
+Use three corpus layers. Keep generated or downloaded benchmark assets out of
+the repo unless they are tiny and license-clean.
+
+### Layer A: Fast Smoke Corpus
+
+Purpose: quickly catch integration failures and estimate latency.
+
+- short English dictation, 5-10 seconds
+- longer English monologue, 45-90 seconds
+- quiet-input variant of the same English clip
+- at least one non-English clip from a Nemotron-covered language outside
+  Parakeet's best-known European lane
+
+Synthetic TTS is acceptable here because this layer checks integration and
+performance, not final product quality.
+
+### Layer B: Product Corpus
+
+Purpose: approximate real MacParakeet behavior.
+
+- natural spoken dictation with filler words and corrections
+- meeting-style two-speaker audio
+- long-form file transcription input, 10-30 minutes if practical
+- mixed-language or code-switching clip
+- quiet microphone clip representative of laptop or headset capture
+
+This layer should use real speech. Preserve transcripts as reference text when
+licenses allow.
+
+### Layer C: Regression Corpus
+
+Purpose: protect future changes once a direction is chosen.
+
+- tiny checked-in fixtures only if license-clean
+- otherwise scripts that fetch or generate deterministic samples into
+  `output/benchmarks/`
+- expected metrics stored as thresholds, not brittle exact transcripts
+
+## 8. Delivery Plan
+
+### Phase 1: Baseline Current Main
+
+Run the current `origin/main` CLI on the corpus:
+
+```bash
+MACPARAKEET_TELEMETRY=0 swift run macparakeet-cli transcribe sample.wav \
+  --engine parakeet --parakeet-model v3 --format json --no-history
+
+MACPARAKEET_TELEMETRY=0 swift run macparakeet-cli transcribe sample.wav \
+  --engine parakeet --parakeet-model v2 --format json --no-history
+```
+
+Capture:
+
+- wall time with `/usr/bin/time -lp`
+- output transcript
+- JSON engine attribution
+- peak memory
+- model warm/cold state
+
+### Phase 2: FluidAudio 0.15.x Build Check and API Inventory
+
+Create a spike branch change that bumps FluidAudio to a concrete 0.15.x release
+and verifies compilation:
+
+```bash
+swift package update FluidAudio
+swift build --target MacParakeetCore
+swift test --filter STT
+```
+
+Expected decision point:
+
+- if the existing Parakeet API remains source-compatible, continue
+- if the API breaks, document the compatibility delta before writing benchmark
+  code
+- inventory Nemotron APIs and decide which model path maps to dictation,
+  meeting live preview, meeting finalization, and file transcription
+
+### Phase 3: Standalone Nemotron Harness
+
+Add or generate a narrow benchmark harness that imports FluidAudio directly and
+does not alter production STT routing yet.
+
+The harness should exercise:
+
+- streaming Nemotron partials on incremental audio buffers
+- finalization via the model's finish/final API
+- a batch-like transcription path for complete files
+- manual language and auto language modes where supported
+
+Output should be machine-readable TSV or JSONL with:
+
+```text
+engine
+variant
+language_hint
+sample_id
+audio_duration_s
+first_partial_s
+final_wall_s
+realtime_factor
+peak_memory_bytes
+partial_count
+final_text_path
+error
+```
+
+### Phase 4: Production Integration
+
+Implement the Beta engine in the real app:
+
+- add Nemotron to `SpeechEnginePreference` or the equivalent routing model
+- add any required model variant/language-hint types
+- load/download/delete Nemotron model artifacts through `STTRuntime`
+- preserve scheduler job classes and meeting leases
+- expose CLI selection for `transcribe`, `config`, and `models`
+- add Settings card with the single Beta tag and concise model details
+- update model status, download progress, and storage-management surfaces
+- add privacy-safe telemetry attribution for engine, variant, duration, and
+  coarse failure type only
+
+### Phase 5: Side-by-Side Benchmark Report
+
+Produce a report after the implementation path is working:
+
+- Parakeet v3/v2 vs Nemotron vs Whisper where relevant
+- dictation, meeting live preview, meeting finalization, and file transcription
+- latency, realtime factor, first partial, memory, model setup, and qualitative
+  transcript notes
+- recommendation for default status, Beta copy, and follow-up fixes
+
+### Phase 6: Product Decision
+
+After real-user and benchmark feedback, choose one:
+
+1. keep Nemotron as Beta
+2. promote it for specific languages or workflows
+3. make it the default only if evidence clearly beats Parakeet for the default
+   user path
+4. remove or hide it if the model artifacts or runtime behavior are not good
+   enough
+
+## 9. Implementation Shape
+
+Production implementation should be a small extension of existing engine
+routing:
+
+- add a local enum case or variant for Nemotron based on the chosen model path
+- keep `SpeechEngineSelection` explicit and serializable
+- add language hint storage only if manual language meaningfully improves
+  output
+- load/download models inside `STTRuntime`
+- preserve `STTScheduler` admission, priority, backpressure, and meeting leases
+- attribute telemetry with engine and variant only, never transcript or audio
+  content
+- update `spec/06-stt-engine.md` and any ADR only after implementation is real
+
+## 10. Job-Class Mapping
+
+| Job kind | Implementation expectation |
+|---|---|
+| `dictation` | Needs low first-partial latency, no word clipping, predictable final insert text |
+| `meetingLiveChunk` | Can tolerate rough interim text, but must not block finalization or dictation |
+| `meetingFinalize` | Prioritizes complete punctuated transcript and stable per-source merge |
+| `fileTranscription` | Prioritizes final quality, progress, cancellation, and long-file behavior |
+
+The same selected engine should apply across dictation, file transcription, and
+meetings unless a specific model limitation forces a narrower first release.
+If streaming and final Nemotron paths differ, keep that distinction internal to
+the engine implementation rather than asking users to choose between technical
+subtypes prematurely.
+
+## 11. Quality Gates
+
+Nemotron should not ship as Beta unless it passes these gates:
+
+- current Parakeet v3/v2 behavior still passes `swift test --filter STT`
+- no regression to current CLI `transcribe --engine parakeet`
+- first partial latency is acceptable for dictation if used for dictation
+- final output does not systematically lose trailing words at segment or session
+  boundaries
+- cold setup and warm setup durations are documented
+- peak memory is measured on the same machine as the Parakeet baseline
+- unsupported-language behavior is explicit, not implicit fallback
+- model download/cache paths can be deleted from Settings/CLI model management
+- license and model notices are accounted for before distribution
+
+## 12. User-Facing Copy
+
+Keep Settings copy direct:
+
+```text
+Nemotron 3.5
+Beta
+New local multilingual ASR with streaming support for around 40 languages.
+
+Around 40 languages
+Low-latency streaming
+Runs locally on Apple Silicon
+Larger download than Parakeet
+```
+
+Avoid copy like "reversible", "try at your own risk", or long caveat blocks in
+the card. Save nuanced benchmark conclusions for release notes, docs, or a
+model-details tooltip.
+
+## 13. Open Questions
+
+- Which Nemotron path is the best MacParakeet candidate: streaming, offline, or
+  both with different job-class routing?
+- Does manual language selection materially improve quality over auto mode?
+- Does streaming output need a second finalization pass for punctuation and
+  capitalization?
+- Can one loaded Nemotron manager support the two-slot scheduler cleanly, or do
+  we need slot-scoped manager instances like current Parakeet?
+- Does FluidAudio 0.15.x preserve the current Parakeet v3/v2 API surface and
+  download behavior?
+- Are the CoreML model artifacts stable enough for public release, including
+  model cache invalidation and notices?
+
+## 14. Immediate Next Steps
+
+1. Build a small benchmark corpus under `output/benchmarks/nemotron/`.
+2. Record Parakeet v3/v2 baseline numbers on current `main`.
+3. Bump FluidAudio in this worktree and verify the existing STT tests.
+4. Add the standalone Nemotron benchmark harness.
+5. Implement the Nemotron engine behind the existing STT runtime/scheduler.
+6. Add Settings and CLI surfaces with a concise Beta tag.
+7. Produce the side-by-side benchmark report and tune the Beta copy if needed.

--- a/plans/active/2026-06-nemotron-beta-engine-plan.md
+++ b/plans/active/2026-06-nemotron-beta-engine-plan.md
@@ -7,6 +7,53 @@
 > ADRs: `spec/adr/001-parakeet-stt.md`, `spec/adr/016-centralized-stt-runtime-scheduler.md`, `spec/adr/021-whisperkit-multilingual-stt.md`
 > Scope: add Nemotron 3.5 as a clean opt-in Beta speech engine, backed by side-by-side benchmarks against MacParakeet's current Parakeet v3/v2 and Whisper paths.
 
+## Current Branch Status
+
+As of 2026-06-08 on `plan/nemotron-benchmark`:
+
+- FluidAudio is bumped to `0.15.2`; the existing Parakeet v3/v2 code path
+  builds against it.
+- `NemotronEngine` is wired through `STTRuntime` and therefore through the
+  existing `STTScheduler` lanes for dictation, file transcription, meeting live
+  chunks, and meeting finalization.
+- Settings exposes Nemotron as a separate Beta speech engine card and includes
+  model download/delete/status controls.
+- CLI support covers `transcribe --engine nemotron`, `config set
+  speech-engine nemotron`, `config set nemotron-language`, `models list`,
+  `models select`, `models download`, `models delete`, `models status`,
+  `models warm-up`, and `health --repair-models`. `models select` validates
+  that local Nemotron/Whisper artifacts are downloaded before persisting either
+  engine as the shared default.
+- Telemetry attribution uses the existing safe dimensions:
+  `speech_engine=nemotron`, `engine_variant=multilingual-1120ms`, and
+  `model_kind=nemotron_stt`. Audio, transcript text, file paths, URLs, and
+  language text remain excluded from telemetry payloads.
+- The first reproducible side-by-side harness is
+  `scripts/dev/benchmark_stt_engines.sh`. It exercises the production CLI path
+  and writes TSV, JSON, stderr timing logs, and transcripts under
+  `output/benchmarks/stt/`.
+- The first smoke benchmark report is
+  `docs/planning/2026-06-nemotron-stt-benchmark-report.md`. It compares
+  Parakeet v3, Nemotron, and Whisper on five synthetic samples and records why
+  Nemotron should remain opt-in Beta rather than replacing Parakeet.
+
+Validated so far:
+
+```bash
+swift build
+swift test --filter 'SpeechEnginePreferenceTests|TranscribeCommandTests|ConfigCommandTests|ModelLifecycleCommandTests|SettingsViewModelTests|STTSchedulerTests|SettingsStatusRulesTests'
+swift test
+bash -n scripts/dev/benchmark_stt_engines.sh
+git diff --check
+```
+
+The focused test slice passed 393 tests with 0 failures after the core,
+Settings, and CLI wiring. The full suite passed 3362 tests with 10 expected
+skips and 0 failures after the retranscription and Settings model-status
+coverage landed; the final full-suite rerun after CLI spec/docs polish and the
+missing-Nemotron Settings guard passed 3365 tests with 10 expected skips and 0
+failures.
+
 ## 1. Intent
 
 MacParakeet's default STT path is already strong: Parakeet TDT v3/v2 through
@@ -200,19 +247,29 @@ Expected decision point:
 - inventory Nemotron APIs and decide which model path maps to dictation,
   meeting live preview, meeting finalization, and file transcription
 
-### Phase 3: Standalone Nemotron Harness
+### Phase 3: Production-Path Benchmark Harness
 
-Add or generate a narrow benchmark harness that imports FluidAudio directly and
-does not alter production STT routing yet.
+The first harness should exercise the same path users exercise: the
+`macparakeet-cli transcribe` command backed by the production STT wrappers.
+This keeps the benchmark honest about model routing, audio conversion,
+progress, engine attribution, cancellation/error mapping, and CLI privacy
+defaults.
 
-The harness should exercise:
+Run shape:
 
-- streaming Nemotron partials on incremental audio buffers
-- finalization via the model's finish/final API
-- a batch-like transcription path for complete files
-- manual language and auto language modes where supported
+```bash
+swift build -c release --product macparakeet-cli
+MACPARAKEET_TELEMETRY=0 DO_NOT_TRACK=1 \
+  scripts/dev/benchmark_stt_engines.sh output/benchmarks/stt/corpus.tsv
+```
 
-Output should be machine-readable TSV or JSONL with:
+Corpus TSV columns:
+
+```text
+sample_id<TAB>path<TAB>language<TAB>sample_type<TAB>reference_path<TAB>notes
+```
+
+Output includes:
 
 ```text
 engine
@@ -220,14 +277,24 @@ variant
 language_hint
 sample_id
 audio_duration_s
+first_progress_s
 first_partial_s
 final_wall_s
 realtime_factor
 peak_memory_bytes
-partial_count
+wer
+punctuation_per_100_words
+prefix_ref_words_matched
+suffix_ref_words_matched
 final_text_path
 error
 ```
+
+The production CLI path currently emits final transcripts plus coarse progress,
+not streaming partial transcript text. Therefore this harness records
+`first_progress_s` automatically and reserves `first_partial_s` for a direct
+FluidAudio streaming probe or app live-preview instrumentation pass. Do not
+overstate `first_progress_s` as true first partial latency in the report.
 
 ### Phase 4: Production Integration
 
@@ -242,6 +309,10 @@ Implement the Beta engine in the real app:
 - update model status, download progress, and storage-management surfaces
 - add privacy-safe telemetry attribution for engine, variant, duration, and
   coarse failure type only
+
+Current branch state: complete enough for build/test validation and PR review;
+remaining work is benchmark evidence beyond the synthetic smoke corpus, final
+polish, PR review, and merge-readiness cleanup.
 
 ### Phase 5: Side-by-Side Benchmark Report
 
@@ -344,10 +415,11 @@ model-details tooltip.
 
 ## 14. Immediate Next Steps
 
-1. Build a small benchmark corpus under `output/benchmarks/nemotron/`.
-2. Record Parakeet v3/v2 baseline numbers on current `main`.
-3. Bump FluidAudio in this worktree and verify the existing STT tests.
-4. Add the standalone Nemotron benchmark harness.
-5. Implement the Nemotron engine behind the existing STT runtime/scheduler.
-6. Add Settings and CLI surfaces with a concise Beta tag.
-7. Produce the side-by-side benchmark report and tune the Beta copy if needed.
+1. Add a direct streaming/meeting-live probe if we need true first-partial and
+   segment-cadence numbers before PR merge.
+2. Run the product-corpus benchmark with real speech before making any
+   post-Beta quality claims.
+3. Tune the Beta copy if the product-corpus measurements expose a user-facing
+   caveat beyond "Beta".
+4. Open the PR with implementation/data-flow details and an ASCII diagram, then
+   drive review/CI to merge readiness.

--- a/scripts/dev/benchmark_stt_engines.sh
+++ b/scripts/dev/benchmark_stt_engines.sh
@@ -251,7 +251,7 @@ run_case() {
       --database "$DB_PATH" \
       "${args[@]}" \
       >"$json_file" \
-      2> >(while IFS= read -r line; do printf '%s\t%s\n' "$(now_seconds)" "$line"; done > "$stderr_file")
+      2> >(while IFS= read -r line || [[ -n "$line" ]]; do printf '%s\t%s\n' "$(now_seconds)" "$line"; done > "$stderr_file")
   local ec=$?
   set -e
 

--- a/scripts/dev/benchmark_stt_engines.sh
+++ b/scripts/dev/benchmark_stt_engines.sh
@@ -210,7 +210,7 @@ print("\t".join(fields))
 PY
 }
 
-echo -e "engine_selector\trun_index\tphase\tsample_id\tsample_type\tlanguage_hint\taudio_duration_s\ttranscript_duration_ms\tjson_engine\tjson_engine_variant\tjson_language\ttranscript_words\ttranscript_chars\twer\tpunctuation_per_100_words\tprefix_ref_words_matched\tsuffix_ref_words_matched\tfinal_wall_s\trealtime_factor\tfirst_progress_s\tfirst_partial_s\tmax_rss_bytes\tpeak_memory_bytes\texit_code\ttranscript_file\tjson_file\tstderr_file\terror" > "$RESULTS_TSV"
+echo -e "engine_selector\trun_index\tphase\tsample_id\tsample_type\tlanguage_hint\taudio_duration_s\ttranscript_duration_ms\tjson_engine\tjson_engine_variant\tjson_language\ttranscript_words\ttranscript_chars\twer\tpunctuation_per_100_words\tprefix_ref_words_matched\tsuffix_ref_words_matched\tfinal_wall_s\trealtime_factor\tfirst_progress_s\tfirst_partial_s\tmax_rss_kb\tpeak_memory_bytes\texit_code\ttranscript_file\tjson_file\tstderr_file\terror" > "$RESULTS_TSV"
 
 run_case() {
   local engine="$1"
@@ -262,14 +262,14 @@ run_case() {
     sleep 0.05
   done
 
-  local final_wall_s max_rss_bytes peak_memory_bytes first_progress_s
+  local final_wall_s max_rss_kb peak_memory_bytes first_progress_s
   final_wall_s="$(awk -F '\t' '$2 ~ /^real / {if (match($2, /[0-9.]+/)) print substr($2, RSTART, RLENGTH); exit}' "$stderr_file")"
-  max_rss_bytes="$(awk -F '\t' '$2 ~ /maximum resident set size/ {if (match($2, /[0-9.]+/)) print substr($2, RSTART, RLENGTH); exit}' "$stderr_file")"
+  max_rss_kb="$(awk -F '\t' '$2 ~ /maximum resident set size/ {if (match($2, /[0-9.]+/)) print substr($2, RSTART, RLENGTH); exit}' "$stderr_file")"
   peak_memory_bytes="$(awk -F '\t' '$2 ~ /peak memory footprint/ {if (match($2, /[0-9.]+/)) print substr($2, RSTART, RLENGTH); exit}' "$stderr_file")"
   first_progress_s="$(awk -v start="$start_s" -F '\t' '$2 ~ /^(Converting audio|Downloading audio|Transcribing\.\.\.|Identifying speakers|Finalizing)/ {printf "%.3f", $1 - start; exit}' "$stderr_file")"
 
   [[ -n "$final_wall_s" ]] || final_wall_s="NA"
-  [[ -n "$max_rss_bytes" ]] || max_rss_bytes="NA"
+  [[ -n "$max_rss_kb" ]] || max_rss_kb="NA"
   [[ -n "$peak_memory_bytes" ]] || peak_memory_bytes="NA"
   [[ -n "$first_progress_s" ]] || first_progress_s="NA"
 
@@ -295,7 +295,7 @@ PY
     [[ -n "$error" ]] || error="command_failed"
   fi
 
-  echo -e "$engine\t$run_index\t$phase\t$sample_id\t$sample_type\t$language\t$duration\t$transcript_duration_ms\t$json_engine\t$json_engine_variant\t$json_language\t$transcript_words\t$transcript_chars\t$wer\t$punct\t$prefix\t$suffix\t$final_wall_s\t$realtime_factor\t$first_progress_s\tNA\t$max_rss_bytes\t$peak_memory_bytes\t$ec\t$transcript_file\t$json_file\t$stderr_file\t$error" >> "$RESULTS_TSV"
+  echo -e "$engine\t$run_index\t$phase\t$sample_id\t$sample_type\t$language\t$duration\t$transcript_duration_ms\t$json_engine\t$json_engine_variant\t$json_language\t$transcript_words\t$transcript_chars\t$wer\t$punct\t$prefix\t$suffix\t$final_wall_s\t$realtime_factor\t$first_progress_s\tNA\t$max_rss_kb\t$peak_memory_bytes\t$ec\t$transcript_file\t$json_file\t$stderr_file\t$error" >> "$RESULTS_TSV"
 }
 
 while IFS=$'\t' read -r sample_id raw_path language sample_type reference_path notes; do

--- a/scripts/dev/benchmark_stt_engines.sh
+++ b/scripts/dev/benchmark_stt_engines.sh
@@ -210,7 +210,7 @@ print("\t".join(fields))
 PY
 }
 
-echo -e "engine_selector\trun_index\tphase\tsample_id\tsample_type\tlanguage_hint\taudio_duration_s\ttranscript_duration_ms\tjson_engine\tjson_engine_variant\tjson_language\ttranscript_words\ttranscript_chars\twer\tpunctuation_per_100_words\tprefix_ref_words_matched\tsuffix_ref_words_matched\tfinal_wall_s\trealtime_factor\tfirst_progress_s\tfirst_partial_s\tmax_rss_kb\tpeak_memory_bytes\texit_code\ttranscript_file\tjson_file\tstderr_file\terror" > "$RESULTS_TSV"
+echo -e "engine_selector\trun_index\tphase\tsample_id\tsample_type\tlanguage_hint\taudio_duration_s\ttranscript_duration_ms\tjson_engine\tjson_engine_variant\tjson_language\ttranscript_words\ttranscript_chars\twer\tpunctuation_per_100_words\tprefix_ref_words_matched\tsuffix_ref_words_matched\tfinal_wall_s\trealtime_factor\tfirst_progress_s\tfirst_partial_s\tmax_rss_bytes\tpeak_memory_bytes\texit_code\ttranscript_file\tjson_file\tstderr_file\terror" > "$RESULTS_TSV"
 
 run_case() {
   local engine="$1"
@@ -262,14 +262,14 @@ run_case() {
     sleep 0.05
   done
 
-  local final_wall_s max_rss_kb peak_memory_bytes first_progress_s
+  local final_wall_s max_rss_bytes peak_memory_bytes first_progress_s
   final_wall_s="$(awk -F '\t' '$2 ~ /^real / {if (match($2, /[0-9.]+/)) print substr($2, RSTART, RLENGTH); exit}' "$stderr_file")"
-  max_rss_kb="$(awk -F '\t' '$2 ~ /maximum resident set size/ {if (match($2, /[0-9.]+/)) print substr($2, RSTART, RLENGTH); exit}' "$stderr_file")"
+  max_rss_bytes="$(awk -F '\t' '$2 ~ /maximum resident set size/ {if (match($2, /[0-9.]+/)) print substr($2, RSTART, RLENGTH); exit}' "$stderr_file")"
   peak_memory_bytes="$(awk -F '\t' '$2 ~ /peak memory footprint/ {if (match($2, /[0-9.]+/)) print substr($2, RSTART, RLENGTH); exit}' "$stderr_file")"
   first_progress_s="$(awk -v start="$start_s" -F '\t' '$2 ~ /^(Converting audio|Downloading audio|Transcribing\.\.\.|Identifying speakers|Finalizing)/ {printf "%.3f", $1 - start; exit}' "$stderr_file")"
 
   [[ -n "$final_wall_s" ]] || final_wall_s="NA"
-  [[ -n "$max_rss_kb" ]] || max_rss_kb="NA"
+  [[ -n "$max_rss_bytes" ]] || max_rss_bytes="NA"
   [[ -n "$peak_memory_bytes" ]] || peak_memory_bytes="NA"
   [[ -n "$first_progress_s" ]] || first_progress_s="NA"
 
@@ -295,7 +295,7 @@ PY
     [[ -n "$error" ]] || error="command_failed"
   fi
 
-  echo -e "$engine\t$run_index\t$phase\t$sample_id\t$sample_type\t$language\t$duration\t$transcript_duration_ms\t$json_engine\t$json_engine_variant\t$json_language\t$transcript_words\t$transcript_chars\t$wer\t$punct\t$prefix\t$suffix\t$final_wall_s\t$realtime_factor\t$first_progress_s\tNA\t$max_rss_kb\t$peak_memory_bytes\t$ec\t$transcript_file\t$json_file\t$stderr_file\t$error" >> "$RESULTS_TSV"
+  echo -e "$engine\t$run_index\t$phase\t$sample_id\t$sample_type\t$language\t$duration\t$transcript_duration_ms\t$json_engine\t$json_engine_variant\t$json_language\t$transcript_words\t$transcript_chars\t$wer\t$punct\t$prefix\t$suffix\t$final_wall_s\t$realtime_factor\t$first_progress_s\tNA\t$max_rss_bytes\t$peak_memory_bytes\t$ec\t$transcript_file\t$json_file\t$stderr_file\t$error" >> "$RESULTS_TSV"
 }
 
 while IFS=$'\t' read -r sample_id raw_path language sample_type reference_path notes; do

--- a/scripts/dev/benchmark_stt_engines.sh
+++ b/scripts/dev/benchmark_stt_engines.sh
@@ -1,0 +1,390 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BIN_DEFAULT="$ROOT_DIR/.build/arm64-apple-macosx/release/macparakeet-cli"
+BIN="${BIN:-$BIN_DEFAULT}"
+OUT_DIR="${OUT_DIR:-$ROOT_DIR/output/benchmarks/stt}"
+STAMP="${STAMP:-$(date +%Y%m%d-%H%M%S)}"
+REPS="${REPS:-1}"
+ENGINES="${ENGINES:-parakeet-v3 nemotron whisper}"
+PHASE_LABEL="${PHASE_LABEL:-}"
+
+if [[ $# -ne 1 ]]; then
+  cat >&2 <<'EOF'
+usage: scripts/dev/benchmark_stt_engines.sh CORPUS_TSV
+
+CORPUS_TSV columns:
+  sample_id<TAB>path<TAB>language<TAB>sample_type<TAB>reference_path<TAB>notes
+
+language may be "auto". reference_path may be empty or "-".
+
+Environment:
+  BIN      release macparakeet-cli path
+  OUT_DIR  output directory, default output/benchmarks/stt
+  REPS     repetitions per engine/sample, default 1
+  ENGINES  space-separated selectors, default "parakeet-v3 nemotron whisper"
+  PHASE_LABEL  override phase label, e.g. cold or warm
+EOF
+  exit 1
+fi
+
+CORPUS_TSV="$1"
+
+if [[ ! -x "$BIN" ]]; then
+  echo "error: binary not found or not executable: $BIN" >&2
+  echo "hint: swift build -c release --product macparakeet-cli" >&2
+  exit 1
+fi
+
+if [[ ! -f "$CORPUS_TSV" ]]; then
+  echo "error: corpus TSV not found: $CORPUS_TSV" >&2
+  exit 1
+fi
+
+if ! [[ "$REPS" =~ ^[0-9]+$ ]] || [[ "$REPS" -lt 1 ]]; then
+  echo "error: REPS must be a positive integer (got: $REPS)" >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "error: python3 is required for JSON parsing and WER scoring" >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR/transcripts" "$OUT_DIR/json" "$OUT_DIR/logs"
+
+RESULTS_TSV="$OUT_DIR/stt-engine-benchmark-$STAMP.tsv"
+SUMMARY_TSV="$OUT_DIR/stt-engine-benchmark-$STAMP-summary.tsv"
+DB_PATH="$OUT_DIR/stt-benchmark-$STAMP.sqlite"
+
+expand_path() {
+  local value="$1"
+  case "$value" in
+    "~"/*) printf '%s/%s\n' "$HOME" "${value#~/}" ;;
+    *) printf '%s\n' "$value" ;;
+  esac
+}
+
+now_seconds() {
+  perl -MTime::HiRes=time -e 'printf "%.6f\n", time' 2>/dev/null || \
+    python3 -c 'import time; print(f"{time.time():.6f}")'
+}
+
+audio_duration_s() {
+  local path="$1"
+  if command -v ffprobe >/dev/null 2>&1; then
+    ffprobe -v error -show_entries format=duration -of default=nw=1:nk=1 "$path" 2>/dev/null | head -n1
+    return
+  fi
+  if command -v afinfo >/dev/null 2>&1; then
+    afinfo "$path" 2>/dev/null | awk -F': ' '/estimated duration/ {gsub(/ sec/, "", $2); print $2; exit}'
+    return
+  fi
+  echo "NA"
+}
+
+safe_name() {
+  printf '%s' "$1" | tr -c 'A-Za-z0-9_.-' '_'
+}
+
+engine_args() {
+  local selector="$1"
+  local language="$2"
+  case "$selector" in
+    parakeet|parakeet-v3)
+      printf '%s\n' "--engine" "parakeet" "--parakeet-model" "v3"
+      ;;
+    parakeet-v2)
+      printf '%s\n' "--engine" "parakeet" "--parakeet-model" "v2"
+      ;;
+    nemotron)
+      printf '%s\n' "--engine" "nemotron"
+      if [[ -n "$language" && "$language" != "auto" ]]; then
+        printf '%s\n' "--language" "$language"
+      fi
+      ;;
+    whisper)
+      printf '%s\n' "--engine" "whisper"
+      if [[ -n "$language" && "$language" != "auto" ]]; then
+        printf '%s\n' "--language" "$language"
+      fi
+      ;;
+    *)
+      echo "error: unsupported engine selector: $selector" >&2
+      exit 1
+      ;;
+  esac
+}
+
+analyze_result() {
+  local json_file="$1"
+  local transcript_file="$2"
+  local reference_path="$3"
+  python3 - "$json_file" "$transcript_file" "$reference_path" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+json_path = Path(sys.argv[1])
+transcript_path = Path(sys.argv[2])
+reference_arg = sys.argv[3]
+
+def empty():
+    print("\t".join(["NA"] * 10))
+
+try:
+    raw_json = json_path.read_text()
+    start = raw_json.find("{")
+    end = raw_json.rfind("}")
+    if start < 0 or end < start:
+        raise ValueError("JSON object not found")
+    data = json.loads(raw_json[start:end + 1])
+except Exception:
+    transcript_path.write_text("")
+    empty()
+    raise SystemExit(0)
+
+text = (data.get("cleanTranscript") or data.get("rawTranscript") or "").strip()
+transcript_path.write_text(text + ("\n" if text else ""))
+
+def tokens(value):
+    return re.findall(r"[\w']+", value.lower(), flags=re.UNICODE)
+
+def wer(ref, hyp):
+    r = tokens(ref)
+    h = tokens(hyp)
+    if not r:
+        return None
+    prev = list(range(len(h) + 1))
+    for i, rw in enumerate(r, start=1):
+        curr = [i]
+        for j, hw in enumerate(h, start=1):
+            cost = 0 if rw == hw else 1
+            curr.append(min(curr[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost))
+        prev = curr
+    return prev[-1] / len(r)
+
+def boundary_match(ref_words, hyp_words, from_end=False):
+    if not ref_words or not hyp_words:
+        return "NA"
+    limit = min(5, len(ref_words), len(hyp_words))
+    count = 0
+    for idx in range(limit):
+        ref_idx = -1 - idx if from_end else idx
+        hyp_idx = -1 - idx if from_end else idx
+        if ref_words[ref_idx] == hyp_words[hyp_idx]:
+            count += 1
+        else:
+            break
+    return str(count)
+
+word_count = len(tokens(text))
+punct_count = len(re.findall(r"[,.?!;:]", text))
+punct_per_100 = None if word_count == 0 else punct_count * 100.0 / word_count
+
+reference_text = None
+if reference_arg and reference_arg != "-":
+    ref_path = Path(reference_arg)
+    if ref_path.exists():
+        reference_text = ref_path.read_text()
+
+wer_value = wer(reference_text, text) if reference_text is not None else None
+ref_words = tokens(reference_text or "")
+hyp_words = tokens(text)
+
+fields = [
+    str((data.get("durationMs") or "NA")),
+    data.get("engine") or "NA",
+    data.get("engineVariant") or "NA",
+    data.get("language") or "NA",
+    str(word_count),
+    str(len(text)),
+    "NA" if wer_value is None else f"{wer_value:.4f}",
+    "NA" if punct_per_100 is None else f"{punct_per_100:.2f}",
+    boundary_match(ref_words, hyp_words, from_end=False),
+    boundary_match(ref_words, hyp_words, from_end=True),
+]
+print("\t".join(fields))
+PY
+}
+
+echo -e "engine_selector\trun_index\tphase\tsample_id\tsample_type\tlanguage_hint\taudio_duration_s\ttranscript_duration_ms\tjson_engine\tjson_engine_variant\tjson_language\ttranscript_words\ttranscript_chars\twer\tpunctuation_per_100_words\tprefix_ref_words_matched\tsuffix_ref_words_matched\tfinal_wall_s\trealtime_factor\tfirst_progress_s\tfirst_partial_s\tmax_rss_bytes\tpeak_memory_bytes\texit_code\ttranscript_file\tjson_file\tstderr_file\terror" > "$RESULTS_TSV"
+
+run_case() {
+  local engine="$1"
+  local run_index="$2"
+  local sample_id="$3"
+  local sample_path="$4"
+  local language="$5"
+  local sample_type="$6"
+  local reference_path="$7"
+
+  local phase="${PHASE_LABEL:-warm}"
+  if [[ -z "$PHASE_LABEL" && "$run_index" -eq 1 ]]; then
+    phase="cold"
+  fi
+
+  local safe_engine safe_sample
+  safe_engine="$(safe_name "$engine")"
+  safe_sample="$(safe_name "$sample_id")"
+  local json_file="$OUT_DIR/json/${STAMP}-${safe_engine}-${safe_sample}-${run_index}.json"
+  local stderr_file="$OUT_DIR/logs/${STAMP}-${safe_engine}-${safe_sample}-${run_index}.stderr.tsv"
+  local transcript_file="$OUT_DIR/transcripts/${STAMP}-${safe_engine}-${safe_sample}-${run_index}.txt"
+  local duration
+  duration="$(audio_duration_s "$sample_path")"
+
+  local args=()
+  while IFS= read -r arg; do
+    args+=("$arg")
+  done < <(engine_args "$engine" "$language")
+
+  local start_s
+  start_s="$(now_seconds)"
+  set +e
+  MACPARAKEET_TELEMETRY=0 DO_NOT_TRACK=1 \
+    /usr/bin/time -lp "$BIN" transcribe "$sample_path" \
+      --format json \
+      --no-history \
+      --speaker-detection off \
+      --database "$DB_PATH" \
+      "${args[@]}" \
+      >"$json_file" \
+      2> >(while IFS= read -r line; do printf '%s\t%s\n' "$(now_seconds)" "$line"; done > "$stderr_file")
+  local ec=$?
+  set -e
+
+  for _ in $(seq 1 100); do
+    if grep -q "peak memory footprint" "$stderr_file"; then
+      break
+    fi
+    sleep 0.05
+  done
+
+  local final_wall_s max_rss_bytes peak_memory_bytes first_progress_s
+  final_wall_s="$(awk -F '\t' '$2 ~ /^real / {if (match($2, /[0-9.]+/)) print substr($2, RSTART, RLENGTH); exit}' "$stderr_file")"
+  max_rss_bytes="$(awk -F '\t' '$2 ~ /maximum resident set size/ {if (match($2, /[0-9.]+/)) print substr($2, RSTART, RLENGTH); exit}' "$stderr_file")"
+  peak_memory_bytes="$(awk -F '\t' '$2 ~ /peak memory footprint/ {if (match($2, /[0-9.]+/)) print substr($2, RSTART, RLENGTH); exit}' "$stderr_file")"
+  first_progress_s="$(awk -v start="$start_s" -F '\t' '$2 ~ /^(Converting audio|Downloading audio|Transcribing\.\.\.|Identifying speakers|Finalizing)/ {printf "%.3f", $1 - start; exit}' "$stderr_file")"
+
+  [[ -n "$final_wall_s" ]] || final_wall_s="NA"
+  [[ -n "$max_rss_bytes" ]] || max_rss_bytes="NA"
+  [[ -n "$peak_memory_bytes" ]] || peak_memory_bytes="NA"
+  [[ -n "$first_progress_s" ]] || first_progress_s="NA"
+
+  local transcript_duration_ms json_engine json_engine_variant json_language transcript_words transcript_chars wer punct prefix suffix
+  IFS=$'\t' read -r transcript_duration_ms json_engine json_engine_variant json_language transcript_words transcript_chars wer punct prefix suffix < <(
+    analyze_result "$json_file" "$transcript_file" "$reference_path"
+  )
+
+  local realtime_factor="NA"
+  if [[ "$duration" != "NA" && "$final_wall_s" != "NA" ]]; then
+    realtime_factor="$(python3 - "$final_wall_s" "$duration" <<'PY'
+import sys
+wall = float(sys.argv[1])
+duration = float(sys.argv[2])
+print("NA" if duration <= 0 else f"{wall / duration:.4f}")
+PY
+)"
+  fi
+
+  local error="none"
+  if [[ "$ec" -ne 0 ]]; then
+    error="$(awk -F '\t' 'NF >= 2 {line=$2} END {print line}' "$stderr_file" | tr '\t' ' ' | sed 's/[[:space:]]\+/ /g')"
+    [[ -n "$error" ]] || error="command_failed"
+  fi
+
+  echo -e "$engine\t$run_index\t$phase\t$sample_id\t$sample_type\t$language\t$duration\t$transcript_duration_ms\t$json_engine\t$json_engine_variant\t$json_language\t$transcript_words\t$transcript_chars\t$wer\t$punct\t$prefix\t$suffix\t$final_wall_s\t$realtime_factor\t$first_progress_s\tNA\t$max_rss_bytes\t$peak_memory_bytes\t$ec\t$transcript_file\t$json_file\t$stderr_file\t$error" >> "$RESULTS_TSV"
+}
+
+while IFS=$'\t' read -r sample_id raw_path language sample_type reference_path notes; do
+  [[ -n "${sample_id:-}" ]] || continue
+  [[ "$sample_id" == \#* ]] && continue
+  [[ "$sample_id" == "sample_id" ]] && continue
+
+  sample_path="$(expand_path "$raw_path")"
+  reference_path="$(expand_path "${reference_path:-}")"
+  [[ -n "${language:-}" ]] || language="auto"
+  [[ -n "${sample_type:-}" ]] || sample_type="unknown"
+  [[ -n "${reference_path:-}" ]] || reference_path="-"
+
+  if [[ ! -f "$sample_path" ]]; then
+    echo "error: sample file not found for $sample_id: $sample_path" >&2
+    exit 1
+  fi
+
+  for engine in $ENGINES; do
+    for run_index in $(seq 1 "$REPS"); do
+      echo "benchmark: engine=$engine sample=$sample_id run=$run_index/$REPS" >&2
+      run_case "$engine" "$run_index" "$sample_id" "$sample_path" "$language" "$sample_type" "$reference_path"
+    done
+  done
+done < "$CORPUS_TSV"
+
+python3 - "$RESULTS_TSV" > "$SUMMARY_TSV" <<'PY'
+import csv
+import statistics
+import sys
+from collections import defaultdict
+
+path = sys.argv[1]
+rows = []
+with open(path, newline="") as handle:
+    reader = csv.DictReader(handle, delimiter="\t")
+    rows = list(reader)
+
+groups = defaultdict(list)
+for row in rows:
+    if row["exit_code"] == "0":
+        groups[(row["engine_selector"], row["sample_type"], row["phase"])].append(row)
+
+fields = [
+    "engine_selector", "sample_type", "phase", "n",
+    "avg_final_wall_s", "avg_realtime_factor",
+    "avg_first_progress_s", "avg_peak_memory_gb",
+    "avg_wer", "avg_punctuation_per_100_words",
+]
+writer = csv.DictWriter(sys.stdout, fieldnames=fields, delimiter="\t")
+writer.writeheader()
+
+def numbers(values):
+    result = []
+    for value in values:
+        if value in ("", "NA", None):
+            continue
+        try:
+            result.append(float(value))
+        except ValueError:
+            pass
+    return result
+
+for key in sorted(groups):
+    rows_for_key = groups[key]
+    wall = numbers(row["final_wall_s"] for row in rows_for_key)
+    rtf = numbers(row["realtime_factor"] for row in rows_for_key)
+    first_progress = numbers(row["first_progress_s"] for row in rows_for_key)
+    peak = numbers(row["peak_memory_bytes"] for row in rows_for_key)
+    wer = numbers(row["wer"] for row in rows_for_key)
+    punct = numbers(row["punctuation_per_100_words"] for row in rows_for_key)
+
+    def avg(values, scale=1.0):
+        return "NA" if not values else f"{statistics.fmean(values) / scale:.4f}"
+
+    writer.writerow({
+        "engine_selector": key[0],
+        "sample_type": key[1],
+        "phase": key[2],
+        "n": len(rows_for_key),
+        "avg_final_wall_s": avg(wall),
+        "avg_realtime_factor": avg(rtf),
+        "avg_first_progress_s": avg(first_progress),
+        "avg_peak_memory_gb": avg(peak, 1024 ** 3),
+        "avg_wer": avg(wer),
+        "avg_punctuation_per_100_words": avg(punct),
+    })
+PY
+
+echo "RESULTS_TSV=$RESULTS_TSV"
+echo "SUMMARY_TSV=$SUMMARY_TSV"
+echo "DB_PATH=$DB_PATH"


### PR DESCRIPTION
## Summary

Adds Nemotron 3.5 ASR Streaming 0.6B as a first-class opt-in **Beta** speech engine for MacParakeet while keeping Parakeet v3 as the stable default.

This wires Nemotron through the existing local STT control plane instead of adding a parallel speech stack:

- Settings: third Speech Recognition engine card, Beta copy, download/repair/delete/status controls, and missing-model switch guard.
- Runtime: new `NemotronEngine` behind `STTRuntime`/`STTScheduler` for dictation, file transcription, meeting live chunks, and meeting finalization.
- CLI: `transcribe --engine nemotron`, `config set nemotron-language`, `models list/select/download/delete/status/warm-up/repair`, `health --repair-models`, and updated CLI spec/changelog/docs.
- Telemetry: privacy-safe attribution only (`speech_engine=nemotron`, `engine_variant=multilingual-1120ms`, `model_kind=nemotron_stt`); no audio, transcript text, paths, URLs, or language text.
- Benchmarks: adds a production-CLI harness and first smoke report comparing Parakeet v3, Nemotron, and Whisper.

## Data / Control Flow

```text
User action
  |
  +-- Settings engine switch / CLI --engine nemotron
        |
        v
  SpeechEnginePreference(.nemotron, language hint)
        |
        v
  STTClient
        |
        v
  STTScheduler
        |
        +-- dictation --------------------> interactive lane
        |
        +-- file / meeting live / finalize -> background lane
        |
        v
  STTRuntime
        |
        v
  NemotronEngine
        |
        +-- SharedNemotronMultilingualModels
        +-- StreamingNemotronMultilingualAsrManager
        |
        v
  STTResult(engine: nemotron, engineVariant: multilingual-1120ms)
```

## Benchmark Snapshot

Smoke corpus, warm production CLI run on Apple M4 Pro:

| Engine | Total wall | Overall RTF | Avg first progress | Avg WER | Max peak memory |
|---|---:|---:|---:|---:|---:|
| Parakeet v3 | 2.42s | 0.0156 | 0.114s | 0.0399 | 0.070 GB |
| Nemotron | 3.91s | 0.0252 | 0.056s | 0.1201 | 0.086 GB |
| Whisper | 17.63s | 0.1136 | 0.053s | 0.0535 | 0.205 GB |

Decision from this first pass: expose Nemotron as opt-in Beta, not as the default. The report calls out that the current corpus is synthetic `say` audio; product-corpus benchmarking is still needed before any default-engine discussion.

## Verification

- `swift test --filter 'SpeechEnginePreferenceTests|TranscribeCommandTests|ConfigCommandTests|ModelLifecycleCommandTests|SettingsViewModelTests|STTSchedulerTests|SettingsStatusRulesTests'`
- `swift test --filter 'SpecCommandTests|ModelLifecycleCommandTests|TranscribeCommandTests|ConfigCommandTests'`
- `swift test --filter SettingsViewModelTests`
- `swift test` -> 3365 tests, 10 skipped, 0 failures
- `swift build -c release --product macparakeet-cli`
- `bash -n scripts/dev/benchmark_stt_engines.sh`
- `git diff --check`