### PR TITLE
Show Timed transcript view for raw transcripts

### DIFF
--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -1117,7 +1117,12 @@ struct TranscriptResultView: View {
 
             Spacer()
 
-            if !editingTranscript, hasCleanTranscriptText, hasTimestamps {
+            // Show whenever word timestamps exist: the Timed view renders from
+            // `wordTimestamps` and the Text view falls back to the raw transcript,
+            // so a clean (processed) transcript is not required. Gating on clean
+            // text hid the Timed view for Raw-mode transcripts despite the timing
+            // data being present.
+            if !editingTranscript, hasTimestamps {
                 Picker("Transcript view", selection: $transcriptDisplayMode) {
                     ForEach(TranscriptDisplayMode.allCases, id: \.self) { mode in
                         Text(mode.rawValue).tag(mode)

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -1117,11 +1117,8 @@ struct TranscriptResultView: View {
 
             Spacer()
 
-            // Show whenever word timestamps exist: the Timed view renders from
-            // `wordTimestamps` and the Text view falls back to the raw transcript,
-            // so a clean (processed) transcript is not required. Gating on clean
-            // text hid the Timed view for Raw-mode transcripts despite the timing
-            // data being present.
+            // Show whenever word timestamps exist: Timed renders from word data,
+            // and Text falls back to the raw transcript when clean text is absent.
             if !editingTranscript, hasTimestamps {
                 Picker("Transcript view", selection: $transcriptDisplayMode) {
                     ForEach(TranscriptDisplayMode.allCases, id: \.self) { mode in
@@ -2503,7 +2500,7 @@ struct TranscriptResultView: View {
     }
 
     private func syncTranscriptDisplayMode() {
-        transcriptDisplayMode = hasCleanTranscriptText ? .text : .timed
+        transcriptDisplayMode = (hasCleanTranscriptText || !hasTimestamps) ? .text : .timed
     }
 
     private func beginTranscriptEdit() {


### PR DESCRIPTION
## Summary

The transcript **Text / Timed** toggle was hidden whenever a transcript had no *clean* (processed) text — even though the Timed view renders purely from word timestamps, which the STT engine produces for **every** transcription regardless of processing mode. So Raw-mode transcripts (e.g. a file/URL transcription made with processing mode = Raw) could never reach the Timed view despite having the underlying word-timing data.

## Fix

- Relax the toggle's visibility gate in `TranscriptResultView` from `hasCleanTranscriptText && hasTimestamps` to just `hasTimestamps` (with a comment to keep it from drifting back).

## Why it's safe

- The Timed view already reads `wordTimestamps` directly; the Text view already falls back to the raw transcript (`cleanTranscript ?? rawTranscript`). Both render correctly without a clean transcript.
- Word timestamps are identical across processing modes (Clean only reformats text, it doesn't re-time), so there's no correctness reason to tie the Timed view to clean text.
- The gate had drifted here incidentally (`hasEditedTranscript` → `hasCleanTranscriptText` across two polish commits) with no documented rationale.
- Transcripts with no timestamps still correctly hide the toggle.

## Verification

- `swift test` — full suite green (3376 tests, 0 failures)
- Manual: a Raw-mode transcript now shows the Text / Timed toggle, and the Timed view renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
