### PR TITLE
Add Apple Podcasts transcription as a first-class URL source

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Meeting calendar support is live in the stable DMG. MacParakeet reads upcoming m
 
 **Dictation** — Press a hotkey in any app, speak, text gets pasted. Hold for push-to-talk, or tap the hands-free shortcut to start and stop longer dictations. Works system-wide. A beta setting can pause supported Now Playing media while you dictate and resume it when capture stops.
 
-**File transcription** — Drag one or many audio/video files, drop a folder, use the multi-select picker, or paste a YouTube URL. Local-file batches run sequentially, keep finished results in the Library, and can be cancelled as a group. Full transcript with word-level timestamps, speaker labels, a completion chime/banner, and export to 7 formats (TXT, Markdown, SRT, VTT, DOCX, PDF, JSON). Assign global hotkeys to trigger File or YouTube transcription from anywhere.
+**File transcription** — Drag one or many audio/video files, drop a folder, use the multi-select picker, or paste a YouTube or Apple Podcasts link. Apple Podcasts links resolve through the iTunes lookup API to the episode's audio enclosure (no scraping), then download and transcribe locally just like a YouTube video. Local-file batches run sequentially, keep finished results in the Library, and can be cancelled as a group. Full transcript with word-level timestamps, speaker labels, a completion chime/banner, and export to 7 formats (TXT, Markdown, SRT, VTT, DOCX, PDF, JSON). Assign global hotkeys to trigger File or YouTube transcription from anywhere.
 
 **Meeting recording** — Record system audio and microphone together, see a live local transcript preview, take notes during the call, then save the finalized transcript to the library with export, prompts, and chat.
 
@@ -171,6 +171,7 @@ commands with `swift run`.
 | Database | SQLite via GRDB |
 | Auto-updates | Sparkle 2 |
 | YouTube | yt-dlp |
+| Podcasts | Apple Podcasts via iTunes lookup API + yt-dlp |
 | Platform | macOS 14.2+, Apple Silicon |
 
 ## Vocabulary
@@ -223,7 +224,7 @@ All speech recognition runs locally. Parakeet uses the Neural Engine; the option
 - **Opt-out telemetry.** Non-identifying usage analytics and crash reporting go to a self-hosted endpoint only when telemetry is enabled. No persistent IDs, no IP storage, and no transcript/audio content is transmitted. [Source code is right here](Sources/MacParakeetCore/Services/Telemetry/TelemetryService.swift) — verify it yourself.
 - **Temp files cleaned up.** Audio deleted after transcription unless you save it.
 
-**What does use the network:** AI summaries and chat connect to configured LLM providers, or to whatever service a configured CLI tool chooses to use, when you choose them. Sparkle checks for app updates. YouTube transcription downloads video via yt-dlp. Telemetry and crash reports go to our self-hosted server unless you opt out. Core dictation and transcription stay fully offline.
+**What does use the network:** AI summaries and chat connect to configured LLM providers, or to whatever service a configured CLI tool chooses to use, when you choose them. Sparkle checks for app updates. YouTube transcription downloads video via yt-dlp; Apple Podcasts links query the public iTunes lookup API to find the episode audio, then download it. Telemetry and crash reports go to our self-hosted server unless you opt out. Core dictation and transcription stay fully offline.
 
 **Note:** Builds from source also send telemetry by default. Opt out in Settings or set `MACPARAKEET_TELEMETRY_URL` to override.
 

--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -80,6 +80,17 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ## [Unreleased]
 
+### Added
+
+- `transcribe` now accepts **Apple Podcasts** links (e.g.
+  `https://podcasts.apple.com/us/podcast/<slug>/id<id>?i=<episode>`). The
+  episode is resolved through the public iTunes lookup API to its audio
+  enclosure, then downloaded and transcribed through the existing local
+  pipeline. Episode links transcribe that episode; show links transcribe the
+  latest episode. Saved transcripts carry a new `podcast` source type, and
+  `transcribe` telemetry classifies the input as `podcast` (additive — no
+  schema break).
+
 ## [2.7.0] -- 2026-06-06
 
 ### Added

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -325,6 +325,9 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
 
     static func telemetryInputKind(for input: String) -> ObservabilityInputKind {
         let trimmedInput = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        if PodcastURLValidator.isApplePodcastsURL(trimmedInput) {
+            return .podcast
+        }
         if YouTubeURLValidator.isYouTubeURL(trimmedInput) {
             return .youtube
         }
@@ -444,6 +447,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
                 },
                 shouldDiarize: { resolvedSpeakerDetection.enabled },
                 youtubeDownloader: youtubeDownloader,
+                podcastResolver: PodcastEpisodeResolver(),
                 diarizationService: diarizationService
             )
 

--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -276,6 +276,7 @@ final class AppEnvironment {
             shouldKeepDownloadedAudio: { [runtimePreferences] in runtimePreferences.shouldSaveTranscriptionAudio },
             shouldDiarize: { [runtimePreferences] in runtimePreferences.shouldDiarize },
             youtubeDownloader: youtubeDownloader,
+            podcastResolver: PodcastEpisodeResolver(),
             diarizationService: diarizationService
         )
 

--- a/Sources/MacParakeet/Views/Components/DesignSystem.swift
+++ b/Sources/MacParakeet/Views/Components/DesignSystem.swift
@@ -84,6 +84,9 @@ enum DesignSystem {
         // YouTube badge
         static let youtubeRed = Color.red
 
+        // Apple Podcasts badge
+        static let podcastPurple = Color(red: 0.55, green: 0.34, blue: 0.86)
+
         // Pill / overlay
         static let pillBackground = Color.black.opacity(0.7)
         static let pillBorder = Color.white.opacity(0.15)

--- a/Sources/MacParakeet/Views/Transcription/TranscribeView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscribeView.swift
@@ -170,18 +170,22 @@ struct TranscribeView: View {
                 .cardShadow(DesignSystem.Shadows.cardRest)
 
             VStack(spacing: DesignSystem.Spacing.md) {
-                // YouTube icon
+                // Video + podcast source glyphs
                 ZStack {
                     RoundedRectangle(cornerRadius: 14)
-                        .fill(DesignSystem.Colors.youtubeRed.opacity(0.1))
+                        .fill(DesignSystem.Colors.accent.opacity(0.1))
                         .frame(width: 56, height: 56)
 
-                    Image(systemName: "play.rectangle.fill")
-                        .font(.system(size: 24, weight: .medium))
-                        .foregroundStyle(DesignSystem.Colors.youtubeRed.opacity(0.7))
+                    HStack(spacing: 6) {
+                        Image(systemName: "play.rectangle.fill")
+                            .foregroundStyle(DesignSystem.Colors.youtubeRed.opacity(0.7))
+                        Image(systemName: "mic.fill")
+                            .foregroundStyle(DesignSystem.Colors.podcastPurple.opacity(0.85))
+                    }
+                    .font(.system(size: 20, weight: .medium))
                 }
 
-                Text("Transcribe a YouTube video")
+                Text("Transcribe a video or podcast")
                     .font(DesignSystem.Typography.pageTitle)
 
                 // URL input row
@@ -192,7 +196,7 @@ struct TranscribeView: View {
                             .foregroundStyle(viewModel.isValidURL ? DesignSystem.Colors.successGreen : .secondary)
                             .contentTransition(.symbolEffect(.replace))
 
-                        TextField("Paste a YouTube link", text: $viewModel.urlInput)
+                        TextField("Paste a YouTube or Apple Podcasts link", text: $viewModel.urlInput)
                             .textFieldStyle(.plain)
                             .font(DesignSystem.Typography.body)
                             .onSubmit {
@@ -221,7 +225,7 @@ struct TranscribeView: View {
                         .buttonStyle(.plain)
                         .help("Paste from clipboard")
                         .accessibilityLabel("Paste URL from clipboard")
-                        .accessibilityHint("Pastes clipboard text into the YouTube link field")
+                        .accessibilityHint("Pastes clipboard text into the link field")
                     }
                     .padding(.horizontal, 12)
                     .padding(.vertical, 10)
@@ -255,11 +259,11 @@ struct TranscribeView: View {
                     .buttonStyle(.plain)
                     .disabled(!viewModel.isValidURL)
                     .accessibilityLabel("Start transcription")
-                    .accessibilityHint("Starts transcribing the YouTube link")
+                    .accessibilityHint("Starts transcribing the YouTube or Apple Podcasts link")
                 }
                 .padding(.horizontal, DesignSystem.Spacing.md)
 
-                Text("Downloads from YouTube, then transcribes entirely on your Mac.")
+                Text("Downloads from YouTube or Apple Podcasts, then transcribes entirely on your Mac.")
                     .font(DesignSystem.Typography.caption)
                     .foregroundStyle(.tertiary)
             }
@@ -482,7 +486,7 @@ struct TranscribeView: View {
 
     private var pipelineSteps: [PipelineStep] {
         switch viewModel.sourceKind {
-        case .youtubeURL:
+        case .youtubeURL, .podcastURL:
             return [.download, .convert, .transcribe]
         case .localFile:
             return [.convert, .transcribe]

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -894,6 +894,8 @@ struct TranscriptResultView: View {
             return "record.circle.fill"
         case .youtube:
             return "play.rectangle.fill"
+        case .podcast:
+            return "mic.fill"
         case .file:
             return "waveform"
         }
@@ -905,6 +907,8 @@ struct TranscriptResultView: View {
             return "Meeting"
         case .youtube:
             return "YouTube"
+        case .podcast:
+            return "Podcast"
         case .file:
             return "Local"
         }
@@ -916,6 +920,8 @@ struct TranscriptResultView: View {
             return "Meeting recording"
         case .youtube:
             return "YouTube source"
+        case .podcast:
+            return "Podcast episode"
         case .file:
             return "Local file"
         }
@@ -927,6 +933,8 @@ struct TranscriptResultView: View {
             return DesignSystem.Colors.accent
         case .youtube:
             return DesignSystem.Colors.youtubeRed
+        case .podcast:
+            return DesignSystem.Colors.podcastPurple
         case .file:
             return DesignSystem.Colors.accent
         }

--- a/Sources/MacParakeet/Views/Transcription/YouTubeInputPanelController.swift
+++ b/Sources/MacParakeet/Views/Transcription/YouTubeInputPanelController.swift
@@ -25,11 +25,12 @@ final class YouTubeInputPanelController {
     func show() {
         if panel != nil { return }
 
-        // Auto-paste: if clipboard has a valid YouTube URL, use it as initial value
+        // Auto-paste: if clipboard has a valid YouTube or Apple Podcasts URL,
+        // use it as the initial value.
         var initialURL = ""
         if let clip = NSPasteboard.general.string(forType: .string)?
             .trimmingCharacters(in: .whitespacesAndNewlines),
-           YouTubeURLValidator.isYouTubeURL(clip) {
+           YouTubeURLValidator.isYouTubeURL(clip) || PodcastURLValidator.isApplePodcastsURL(clip) {
             initialURL = clip
         }
 

--- a/Sources/MacParakeet/Views/Transcription/YouTubeInputPanelView.swift
+++ b/Sources/MacParakeet/Views/Transcription/YouTubeInputPanelView.swift
@@ -26,6 +26,7 @@ struct YouTubeInputPanelView: View {
 
     private var isValidDraft: Bool {
         YouTubeURLValidator.isYouTubeURL(draft)
+            || PodcastURLValidator.isApplePodcastsURL(draft)
     }
 
     var body: some View {
@@ -34,16 +35,20 @@ struct YouTubeInputPanelView: View {
             HStack(spacing: DesignSystem.Spacing.sm) {
                 ZStack {
                     RoundedRectangle(cornerRadius: 10)
-                        .fill(DesignSystem.Colors.youtubeRed.opacity(0.1))
+                        .fill(DesignSystem.Colors.accent.opacity(0.1))
                         .frame(width: 36, height: 36)
 
-                    Image(systemName: "play.rectangle.fill")
-                        .font(.system(size: 16, weight: .medium))
-                        .foregroundStyle(DesignSystem.Colors.youtubeRed.opacity(0.7))
+                    HStack(spacing: 4) {
+                        Image(systemName: "play.rectangle.fill")
+                            .foregroundStyle(DesignSystem.Colors.youtubeRed.opacity(0.7))
+                        Image(systemName: "mic.fill")
+                            .foregroundStyle(DesignSystem.Colors.podcastPurple.opacity(0.85))
+                    }
+                    .font(.system(size: 13, weight: .medium))
                 }
                 .accessibilityHidden(true)
 
-                Text("Transcribe a YouTube video")
+                Text("Transcribe a video or podcast")
                     .font(DesignSystem.Typography.sectionTitle)
                     .accessibilityAddTraits(.isHeader)
 
@@ -58,12 +63,12 @@ struct YouTubeInputPanelView: View {
                     .contentTransition(.symbolEffect(.replace))
                     .accessibilityHidden(true)
 
-                TextField("Paste a YouTube link", text: $draft)
+                TextField("Paste a YouTube or Apple Podcasts link", text: $draft)
                     .textFieldStyle(.plain)
                     .font(DesignSystem.Typography.body)
                     .focused($isTextFieldFocused)
-                    .accessibilityLabel("YouTube URL")
-                    .accessibilityValue(isValidDraft ? "Valid YouTube URL" : "")
+                    .accessibilityLabel("YouTube or Apple Podcasts URL")
+                    .accessibilityValue(isValidDraft ? "Valid link" : "")
                     .onSubmit {
                         if isValidDraft && !viewModel.isTranscribing {
                             onTranscribe(draft)
@@ -129,7 +134,7 @@ struct YouTubeInputPanelView: View {
             .buttonStyle(.plain)
             .disabled(!isValidDraft || viewModel.isTranscribing)
             .accessibilityLabel("Start transcription")
-            .accessibilityHint("Starts transcribing the YouTube link")
+            .accessibilityHint("Starts transcribing the YouTube or Apple Podcasts link")
 
             // Footer text
             if viewModel.isTranscribing {
@@ -142,7 +147,7 @@ struct YouTubeInputPanelView: View {
                 .font(DesignSystem.Typography.caption)
                 .foregroundStyle(DesignSystem.Colors.warningAmber)
             } else {
-                Text("Downloads from YouTube, then transcribes entirely on your Mac.")
+                Text("Downloads from YouTube or Apple Podcasts, then transcribes entirely on your Mac.")
                     .font(DesignSystem.Typography.caption)
                     .foregroundStyle(.tertiary)
             }

--- a/Sources/MacParakeetCore/Models/Transcription.swift
+++ b/Sources/MacParakeetCore/Models/Transcription.swift
@@ -11,6 +11,7 @@ public struct Transcription: Codable, Identifiable, Sendable {
     public enum SourceType: String, Codable, Sendable, CaseIterable {
         case file
         case youtube
+        case podcast
         case meeting
     }
 

--- a/Sources/MacParakeetCore/Services/PodcastEpisodeResolver.swift
+++ b/Sources/MacParakeetCore/Services/PodcastEpisodeResolver.swift
@@ -1,0 +1,209 @@
+import Foundation
+import os
+
+public enum PodcastResolveError: Error, LocalizedError, Equatable {
+    case invalidURL
+    case lookupFailed(String)
+    case episodeNotFound
+    case noPlayableAudio
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            return "Not a valid Apple Podcasts link"
+        case .lookupFailed(let reason):
+            return "Could not look up the podcast: \(reason)"
+        case .episodeNotFound:
+            return "That podcast episode could not be found on Apple Podcasts"
+        case .noPlayableAudio:
+            return "No downloadable audio is published for that episode"
+        }
+    }
+}
+
+/// A resolved podcast episode: a direct audio enclosure URL plus the rich
+/// metadata an Apple Podcasts page never exposes inline. Mirrors the
+/// `DownloadResult` shape `YouTubeDownloader` returns so the transcription
+/// service can persist either with the same fields.
+public struct ResolvedPodcastEpisode: Sendable, Equatable {
+    public let audioURL: String
+    public let episodeTitle: String
+    public let showName: String?
+    public let artworkURL: String?
+    public let episodeDescription: String?
+    public let durationSeconds: Int?
+    /// `YYYY-MM-DD`, derived from the iTunes ISO-8601 release date.
+    public let releaseDate: String?
+    public let feedURL: String?
+
+    public init(
+        audioURL: String,
+        episodeTitle: String,
+        showName: String? = nil,
+        artworkURL: String? = nil,
+        episodeDescription: String? = nil,
+        durationSeconds: Int? = nil,
+        releaseDate: String? = nil,
+        feedURL: String? = nil
+    ) {
+        self.audioURL = audioURL
+        self.episodeTitle = episodeTitle
+        self.showName = showName
+        self.artworkURL = artworkURL
+        self.episodeDescription = episodeDescription
+        self.durationSeconds = durationSeconds
+        self.releaseDate = releaseDate
+        self.feedURL = feedURL
+    }
+}
+
+public protocol PodcastResolving: Sendable {
+    /// Resolve an Apple Podcasts URL to a playable episode. For an episode URL
+    /// (`?i=`) this returns that episode; for a show URL it returns the latest
+    /// published episode.
+    func resolve(url: String) async throws -> ResolvedPodcastEpisode
+}
+
+/// Resolves Apple Podcasts links to a downloadable enclosure + metadata using
+/// the public iTunes Lookup API — the same discovery path the standalone
+/// `podcast-transcribe` tool uses, ported to Swift with no third-party deps.
+///
+/// The lookup returns the episode's `episodeUrl` (the RSS `<enclosure>` URL)
+/// directly, so no XML feed parsing is needed for the common episode/show
+/// cases. The audio is then fetched through the existing media-download path.
+public actor PodcastEpisodeResolver: PodcastResolving {
+    public typealias DataFetcher = @Sendable (URL) async throws -> Data
+
+    private static let lookupBase = "https://itunes.apple.com/lookup"
+    private let logger = Logger(subsystem: "com.macparakeet.core", category: "PodcastEpisodeResolver")
+    private let dataFetcher: DataFetcher
+
+    public init(dataFetcher: DataFetcher? = nil) {
+        self.dataFetcher = dataFetcher ?? { url in
+            let (data, response) = try await URLSession.shared.data(from: url)
+            if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+                throw PodcastResolveError.lookupFailed("HTTP \(http.statusCode)")
+            }
+            return data
+        }
+    }
+
+    public func resolve(url: String) async throws -> ResolvedPodcastEpisode {
+        guard let collectionID = PodcastURLValidator.extractCollectionID(url) else {
+            throw PodcastResolveError.invalidURL
+        }
+        let episodeID = PodcastURLValidator.extractEpisodeID(url)
+        let lookupURL = try Self.lookupURL(collectionID: collectionID, episodeID: episodeID)
+
+        let data: Data
+        do {
+            data = try await dataFetcher(lookupURL)
+        } catch let error as PodcastResolveError {
+            throw error
+        } catch {
+            throw PodcastResolveError.lookupFailed(error.localizedDescription)
+        }
+
+        let response: ItunesLookupResponse
+        do {
+            response = try JSONDecoder().decode(ItunesLookupResponse.self, from: data)
+        } catch {
+            throw PodcastResolveError.lookupFailed("Unexpected response from Apple Podcasts")
+        }
+
+        guard !response.results.isEmpty else {
+            throw PodcastResolveError.episodeNotFound
+        }
+
+        // The lookup returns the show collection plus episodes (newest first).
+        // The first result carrying an `episodeUrl` is the requested episode for
+        // an episode lookup, or the latest episode for a show lookup.
+        guard let episode = response.results.first(where: { ($0.episodeUrl?.isEmpty == false) }) else {
+            throw PodcastResolveError.noPlayableAudio
+        }
+        guard let audioURL = episode.episodeUrl, !audioURL.isEmpty else {
+            throw PodcastResolveError.noPlayableAudio
+        }
+
+        let feed = response.results.compactMap(\.feedUrl).first
+
+        return ResolvedPodcastEpisode(
+            audioURL: audioURL,
+            episodeTitle: Self.firstNonEmpty(episode.trackName, episode.collectionName) ?? "Podcast episode",
+            showName: Self.firstNonEmpty(episode.collectionName),
+            artworkURL: Self.firstNonEmpty(episode.artworkUrl600, episode.artworkUrl160, episode.artworkUrl100),
+            episodeDescription: Self.firstNonEmpty(episode.description, episode.shortDescription),
+            durationSeconds: episode.trackTimeMillis.flatMap { $0 > 0 ? $0 / 1000 : nil },
+            releaseDate: Self.normalizedReleaseDate(episode.releaseDate),
+            feedURL: Self.firstNonEmpty(feed)
+        )
+    }
+
+    // MARK: - Lookup URL
+
+    static func lookupURL(collectionID: String, episodeID: String?) throws -> URL {
+        var components = URLComponents(string: lookupBase)
+        var items = [URLQueryItem(name: "entity", value: "podcastEpisode")]
+        if let episodeID {
+            // Looking up the episode's own track id returns just that episode.
+            items.insert(URLQueryItem(name: "id", value: episodeID), at: 0)
+        } else {
+            // Looking up the show id returns the show plus its recent episodes,
+            // newest first — we take the latest.
+            items.insert(URLQueryItem(name: "id", value: collectionID), at: 0)
+        }
+        components?.queryItems = items
+        guard let url = components?.url else {
+            throw PodcastResolveError.invalidURL
+        }
+        return url
+    }
+
+    // MARK: - Helpers
+
+    /// Convert an iTunes ISO-8601 timestamp (`2024-06-01T07:00:00Z`) to the
+    /// `YYYY-MM-DD` form the downloader uses for readable file naming.
+    static func normalizedReleaseDate(_ raw: String?) -> String? {
+        guard let raw = raw?.trimmingCharacters(in: .whitespacesAndNewlines), raw.count >= 10 else {
+            return nil
+        }
+        let datePart = String(raw.prefix(10))
+        let isYYYYMMDD = datePart.count == 10
+            && datePart[datePart.index(datePart.startIndex, offsetBy: 4)] == "-"
+            && datePart[datePart.index(datePart.startIndex, offsetBy: 7)] == "-"
+        return isYYYYMMDD ? datePart : nil
+    }
+
+    private static func firstNonEmpty(_ values: String?...) -> String? {
+        for value in values {
+            let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let trimmed, !trimmed.isEmpty {
+                return trimmed
+            }
+        }
+        return nil
+    }
+}
+
+// MARK: - iTunes Lookup decoding
+
+struct ItunesLookupResponse: Decodable {
+    let resultCount: Int
+    let results: [ItunesResult]
+}
+
+struct ItunesResult: Decodable {
+    let wrapperType: String?
+    let kind: String?
+    let trackName: String?
+    let collectionName: String?
+    let feedUrl: String?
+    let episodeUrl: String?
+    let artworkUrl600: String?
+    let artworkUrl160: String?
+    let artworkUrl100: String?
+    let description: String?
+    let shortDescription: String?
+    let releaseDate: String?
+    let trackTimeMillis: Int?
+}

--- a/Sources/MacParakeetCore/Services/Telemetry/Observability.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/Observability.swift
@@ -13,6 +13,7 @@ public enum ObservabilityInputKind: String, Sendable {
     case video
     case media
     case youtube
+    case podcast
     case meeting
     case unknown
 }

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -151,6 +151,7 @@ public enum TelemetryDictationCancelReason: String, Sendable, Equatable {
 public enum TelemetryTranscriptionSource: String, Sendable, Equatable {
     case file
     case youtube
+    case podcast
     case meeting
     case dragDrop = "drag_drop"
 }

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -54,6 +54,17 @@ private struct FormatterOutcome: Sendable {
     static let skipped = FormatterOutcome(text: nil, run: nil)
 }
 
+/// Metadata that pre-resolution (e.g. an Apple Podcasts iTunes lookup) supplies
+/// for a downloaded media URL. When present, these fields win over the generic
+/// metadata yt-dlp infers from a raw enclosure URL.
+private struct ResolvedMediaMetadata: Sendable {
+    let title: String?
+    let channelName: String?
+    let thumbnailURL: String?
+    let description: String?
+    let durationSeconds: Int?
+}
+
 extension TranscriptionServiceProtocol {
     public func transcribe(fileURL: URL) async throws -> Transcription {
         try await transcribe(fileURL: fileURL, source: .file, onProgress: nil)
@@ -201,6 +212,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
     private let shouldKeepDownloadedAudio: @Sendable () -> Bool
     private let shouldDiarize: @Sendable () -> Bool
     private let youtubeDownloader: YouTubeDownloading?
+    private let podcastResolver: PodcastResolving?
     private let diarizationService: DiarizationServiceProtocol?
     private let mediaMetadataExtractor: MediaMetadataExtracting
     private let thumbnailCache: ThumbnailCaching
@@ -221,6 +233,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
         shouldKeepDownloadedAudio: (@Sendable () -> Bool)? = nil,
         shouldDiarize: (@Sendable () -> Bool)? = nil,
         youtubeDownloader: YouTubeDownloading? = nil,
+        podcastResolver: PodcastResolving? = nil,
         diarizationService: DiarizationServiceProtocol? = nil,
         mediaMetadataExtractor: MediaMetadataExtracting = AVMediaMetadataExtractor(),
         thumbnailCache: ThumbnailCaching = ThumbnailCacheService.shared,
@@ -241,6 +254,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
         self.shouldKeepDownloadedAudio = shouldKeepDownloadedAudio ?? { true }
         self.shouldDiarize = shouldDiarize ?? { true }
         self.youtubeDownloader = youtubeDownloader
+        self.podcastResolver = podcastResolver
         self.diarizationService = diarizationService
         self.mediaMetadataExtractor = mediaMetadataExtractor
         self.thumbnailCache = thumbnailCache
@@ -282,6 +296,8 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
         let sourceType: Transcription.SourceType = switch source {
         case .youtube:
             .youtube
+        case .podcast:
+            .podcast
         case .meeting:
             .meeting
         case .file, .dragDrop:
@@ -564,10 +580,21 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
         persistResult: Bool,
         onProgress: (@Sendable (TranscriptionProgress) -> Void)? = nil
     ) async throws -> Transcription {
-        let mediaURL = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
+        let inputURL = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Apple Podcasts links are a first-class source: they resolve through
+        // the iTunes Lookup API to a direct enclosure URL + rich episode
+        // metadata, then flow through the same media-download path as YouTube.
+        // Every other http(s) media URL keeps the existing `.youtube` lineage
+        // (single-video download + generic-media fallback).
+        let isPodcast = PodcastURLValidator.isApplePodcastsURL(inputURL)
+        let telemetrySource: TelemetryTranscriptionSource = isPodcast ? .podcast : .youtube
+        let sourceType: Transcription.SourceType = isPodcast ? .podcast : .youtube
+        let inputKind: ObservabilityInputKind = isPodcast
+            ? .podcast
+            : (YouTubeURLValidator.isYouTubeURL(inputURL) ? .youtube : .media)
         let operation = TranscriptionOperationContext(
-            source: .youtube,
-            inputKind: YouTubeURLValidator.isYouTubeURL(mediaURL) ? .youtube : .media,
+            source: telemetrySource,
+            inputKind: inputKind,
             mediaExtension: nil,
             fileSizeBucket: nil
         )
@@ -585,6 +612,58 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
 
             try await assertCanTranscribeOrEmitPreflight(operation)
 
+            // Resolve podcasts to a playable enclosure + metadata before the
+            // shared download/transcribe body runs. yt-dlp downloads the
+            // resolved CDN audio URL just like any other direct media URL; the
+            // resolver's metadata wins over yt-dlp's generic filename info.
+            var downloadURL = inputURL
+            var metadataOverride: ResolvedMediaMetadata?
+            if isPodcast {
+                guard let resolver = podcastResolver else {
+                    sendTranscriptionOperation(
+                        operation,
+                        outcome: .unavailable,
+                        stage: .download,
+                        errorType: Self.errorType(for: PodcastResolveError.lookupFailed("resolver unavailable"))
+                    )
+                    throw PodcastResolveError.lookupFailed("Podcast resolver unavailable")
+                }
+                do {
+                    let episode = try await resolver.resolve(url: inputURL)
+                    downloadURL = episode.audioURL
+                    metadataOverride = ResolvedMediaMetadata(
+                        title: episode.episodeTitle,
+                        channelName: episode.showName,
+                        thumbnailURL: episode.artworkURL,
+                        description: episode.episodeDescription,
+                        durationSeconds: episode.durationSeconds
+                    )
+                } catch {
+                    if error is CancellationError {
+                        Telemetry.send(.transcriptionCancelled(
+                            source: telemetrySource,
+                            audioDurationSeconds: nil,
+                            stage: .download
+                        ))
+                        sendTranscriptionOperation(operation, outcome: .cancelled, stage: .download)
+                    } else {
+                        Telemetry.send(.transcriptionFailed(
+                            source: telemetrySource,
+                            stage: .download,
+                            errorType: Self.errorType(for: error),
+                            errorDetail: TelemetryErrorClassifier.errorDetail(error)
+                        ))
+                        sendTranscriptionOperation(
+                            operation,
+                            outcome: .failure,
+                            stage: .download,
+                            errorType: Self.errorType(for: error)
+                        )
+                    }
+                    throw error
+                }
+            }
+
             var unownedDownloadedAudioURL: URL?
             defer {
                 if let unownedDownloadedAudioURL {
@@ -595,13 +674,13 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
             let downloadResult: YouTubeDownloader.DownloadResult
             do {
                 onProgress?(.downloading(percent: 0))
-                downloadResult = try await downloader.download(url: mediaURL) { percent in
+                downloadResult = try await downloader.download(url: downloadURL) { percent in
                     onProgress?(.downloading(percent: percent))
                 }
             } catch {
                 if error is CancellationError {
                     Telemetry.send(.transcriptionCancelled(
-                        source: .youtube,
+                        source: telemetrySource,
                         audioDurationSeconds: nil,
                         stage: .download
                     ))
@@ -612,7 +691,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
                     )
                 } else {
                     Telemetry.send(.transcriptionFailed(
-                        source: .youtube,
+                        source: telemetrySource,
                         stage: .download,
                         errorType: Self.errorType(for: error),
                         errorDetail: TelemetryErrorClassifier.errorDetail(error)
@@ -628,19 +707,25 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
             }
             unownedDownloadedAudioURL = downloadResult.audioFileURL
             onProgress?(.downloading(percent: 100))
+            // Prefer the resolver/yt-dlp duration whichever is positive; the
+            // resolver wins for podcasts (yt-dlp rarely knows a raw URL's length).
+            let resolvedDurationSeconds = [metadataOverride?.durationSeconds, downloadResult.durationSeconds]
+                .compactMap { $0 }
+                .first { $0 > 0 }
+            let audioDurationSeconds = resolvedDurationSeconds.map(Double.init)
             do {
                 try Task.checkCancellation()
             } catch {
                 Telemetry.send(.transcriptionCancelled(
-                    source: .youtube,
-                    audioDurationSeconds: downloadResult.durationSeconds.map(Double.init),
+                    source: telemetrySource,
+                    audioDurationSeconds: audioDurationSeconds,
                     stage: .download
                 ))
                 sendTranscriptionOperation(
                     operation,
                     outcome: .cancelled,
                     stage: .download,
-                    audioDurationSeconds: downloadResult.durationSeconds.map(Double.init)
+                    audioDurationSeconds: audioDurationSeconds
                 )
                 throw error
             }
@@ -648,20 +733,21 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
                 && persistResult
             let embeddedMetadata = await mediaMetadataExtractor.metadata(for: downloadResult.audioFileURL)
             let title = Self.firstNonEmpty(
+                metadataOverride?.title,
                 downloadResult.title == "Untitled" ? nil : downloadResult.title,
                 embeddedMetadata.title,
                 downloadResult.title
             ) ?? "Untitled"
-            let durationMs = downloadResult.durationSeconds
-                .flatMap { $0 > 0 ? $0 * 1000 : nil }
+            let durationMs = resolvedDurationSeconds.map { $0 * 1000 }
                 ?? embeddedMetadata.durationMs
-            let channelName = Self.firstNonEmpty(downloadResult.channelName, embeddedMetadata.author)
-            let videoDescription = Self.firstNonEmpty(downloadResult.videoDescription, embeddedMetadata.description)
+            let channelName = Self.firstNonEmpty(metadataOverride?.channelName, downloadResult.channelName, embeddedMetadata.author)
+            let videoDescription = Self.firstNonEmpty(metadataOverride?.description, downloadResult.videoDescription, embeddedMetadata.description)
+            let thumbnailURL = Self.firstNonEmpty(metadataOverride?.thumbnailURL, downloadResult.thumbnailURL)
             let artifactMetadata = YouTubeAudioArtifactMetadata(
                 title: title,
                 artist: channelName,
                 description: videoDescription,
-                thumbnailURL: downloadResult.thumbnailURL
+                thumbnailURL: thumbnailURL
             )
 
             var transcription = Transcription(
@@ -670,11 +756,11 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
                 durationMs: durationMs,
                 language: nil,
                 status: .processing,
-                sourceURL: mediaURL,
-                thumbnailURL: downloadResult.thumbnailURL,
+                sourceURL: inputURL,
+                thumbnailURL: thumbnailURL,
                 channelName: channelName,
                 videoDescription: videoDescription,
-                sourceType: .youtube
+                sourceType: sourceType
             )
             if persistResult {
                 do {
@@ -684,25 +770,26 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
                         operation,
                         outcome: .failure,
                         stage: .persistence,
-                        audioDurationSeconds: downloadResult.durationSeconds.map(Double.init),
+                        audioDurationSeconds: audioDurationSeconds,
                         errorType: Self.errorType(for: error)
                     )
                     throw error
                 }
             }
-            if persistResult, downloadResult.thumbnailURL == nil {
+            if persistResult, thumbnailURL == nil {
                 await cacheEmbeddedArtworkIfPresent(embeddedMetadata, for: transcription.id)
             }
             if keepDownloadedAudio {
                 unownedDownloadedAudioURL = nil
             }
             Telemetry.send(.transcriptionStarted(
-                source: .youtube,
-                audioDurationSeconds: downloadResult.durationSeconds.map(Double.init)
+                source: telemetrySource,
+                audioDurationSeconds: audioDurationSeconds
             ))
 
-            // Cache YouTube thumbnail locally (non-blocking)
-            if persistResult, let thumbURL = downloadResult.thumbnailURL {
+            // Cache remote artwork locally (non-blocking) — YouTube thumbnail or
+            // Apple Podcasts episode artwork.
+            if persistResult, let thumbURL = thumbnailURL {
                 let transcriptionId = transcription.id
                 let logger = self.logger
                 let thumbnailCache = self.thumbnailCache
@@ -721,7 +808,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
             }
             let completed = try await transcribeAudio(
                 fileURL: downloadResult.audioFileURL,
-                source: .youtube,
+                source: telemetrySource,
                 sttJob: .fileTranscription,
                 transcription: &transcription,
                 operation: operation,

--- a/Sources/MacParakeetCore/Utilities/PodcastURLValidator.swift
+++ b/Sources/MacParakeetCore/Utilities/PodcastURLValidator.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Recognizes Apple Podcasts share URLs and extracts the collection (show) and
+/// episode identifiers needed to resolve a playable enclosure via the iTunes
+/// Lookup API.
+///
+/// This is the podcast analogue of `YouTubeURLValidator`. It intentionally only
+/// claims `podcasts.apple.com` links — a raw RSS feed or a direct audio URL is
+/// already handled by the generic `DownloadableMediaURLValidator` path, so the
+/// only gap a podcast surface has to fill is the Apple Podcasts page URL, whose
+/// HTML never points straight at audio.
+///
+/// Apple Podcasts URLs take the shape:
+///   https://podcasts.apple.com/us/podcast/{slug}/id{collectionID}?i={episodeID}
+/// The trailing `?i=` is present for a single episode and absent for a show
+/// (where we resolve the latest episode).
+public enum PodcastURLValidator {
+    private static let podcastHosts: Set<String> = [
+        "podcasts.apple.com",
+        "podcast.apple.com",
+    ]
+
+    /// `true` when the string is an Apple Podcasts URL we can resolve (i.e. a
+    /// recognized host carrying an `id{digits}` collection identifier).
+    public static func isApplePodcastsURL(_ string: String) -> Bool {
+        extractCollectionID(string) != nil
+    }
+
+    /// Extract the numeric collection (show) identifier from the `id{digits}`
+    /// path segment, or `nil` when the URL is not a recognized Apple Podcasts URL.
+    public static func extractCollectionID(_ string: String) -> String? {
+        guard let components = normalizedComponents(string) else { return nil }
+        for rawSegment in components.path.split(separator: "/") {
+            let segment = rawSegment.lowercased()
+            guard segment.hasPrefix("id") else { continue }
+            let digits = segment.dropFirst(2)
+            if !digits.isEmpty, digits.allSatisfy(\.isNumber) {
+                return String(digits)
+            }
+        }
+        return nil
+    }
+
+    /// Extract the numeric episode identifier from the `i=` query item, or `nil`
+    /// for a show URL that does not name a specific episode.
+    public static func extractEpisodeID(_ string: String) -> String? {
+        guard let components = normalizedComponents(string) else { return nil }
+        let value = components.queryItems?.first(where: { $0.name == "i" })?.value
+        guard let value, !value.isEmpty, value.allSatisfy(\.isNumber) else { return nil }
+        return value
+    }
+
+    // MARK: - Private
+
+    private static func normalizedComponents(_ string: String) -> URLComponents? {
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        guard !trimmed.contains(where: \.isWhitespace) else { return nil }
+
+        let normalizedInput = trimmed.contains("://") ? trimmed : "https://\(trimmed)"
+        guard let components = URLComponents(string: normalizedInput),
+              let host = components.host?.lowercased(),
+              podcastHosts.contains(host)
+        else {
+            return nil
+        }
+        return components
+    }
+}

--- a/Sources/MacParakeetCore/Utilities/TranscriptionAssetCleanup.swift
+++ b/Sources/MacParakeetCore/Utilities/TranscriptionAssetCleanup.swift
@@ -25,8 +25,10 @@ public enum TranscriptionAssetCleanup {
         guard let filePath = transcription.filePath, !filePath.isEmpty else { return }
 
         switch transcription.sourceType {
-        case .youtube:
-            try removeYouTubeFile(at: URL(fileURLWithPath: filePath), fileManager: fileManager)
+        case .youtube, .podcast:
+            // Both downloaded-media sources store their audio under the shared
+            // app-managed downloads directory; the same prefix guard applies.
+            try removeDownloadedMediaFile(at: URL(fileURLWithPath: filePath), fileManager: fileManager)
         case .meeting:
             try removeMeetingFolder(containing: URL(fileURLWithPath: filePath), fileManager: fileManager)
         case .file:
@@ -34,14 +36,14 @@ public enum TranscriptionAssetCleanup {
         }
     }
 
-    private static func removeYouTubeFile(at fileURL: URL, fileManager: FileManager) throws {
+    private static func removeDownloadedMediaFile(at fileURL: URL, fileManager: FileManager) throws {
         let downloadsRootURL = URL(fileURLWithPath: AppPaths.youtubeDownloadsDir, isDirectory: true)
             .standardizedFileURL
         let targetURL = fileURL.standardizedFileURL
 
         guard targetURL.path.hasPrefix(downloadsRootURL.path + "/") else {
             logger.warning(
-                "Refusing to remove YouTube asset outside app support: \(targetURL.path, privacy: .private)"
+                "Refusing to remove downloaded-media asset outside app support: \(targetURL.path, privacy: .private)"
             )
             return
         }

--- a/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
@@ -5,6 +5,7 @@ import os
 public enum LibraryFilter: String, CaseIterable, Sendable {
     case all = "All"
     case youtube = "YouTube"
+    case podcast = "Podcasts"
     case local = "Local"
     case meeting = "Meetings"
     case favorites = "Favorites"
@@ -234,6 +235,9 @@ public final class TranscriptionLibraryViewModel {
         case (.all, .youtube):
             sourceType = .youtube
             favoritesOnly = false
+        case (.all, .podcast):
+            sourceType = .podcast
+            favoritesOnly = false
         case (.all, .local):
             sourceType = .file
             favoritesOnly = false
@@ -249,7 +253,7 @@ public final class TranscriptionLibraryViewModel {
         case (.meetings, .favorites):
             sourceType = .meeting
             favoritesOnly = true
-        case (.meetings, .youtube), (.meetings, .local):
+        case (.meetings, .youtube), (.meetings, .podcast), (.meetings, .local):
             return nil
         }
 

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -20,6 +20,7 @@ public final class TranscriptionViewModel {
     public enum SourceKind: Sendable {
         case localFile
         case youtubeURL
+        case podcastURL
     }
 
     public enum ProgressPhase: Int, CaseIterable, Sendable {
@@ -110,6 +111,7 @@ public final class TranscriptionViewModel {
 
     public var isValidURL: Bool {
         YouTubeURLValidator.isYouTubeURL(urlInput)
+            || PodcastURLValidator.isApplePodcastsURL(urlInput)
     }
 
     public var hasConversations: Bool = false
@@ -280,16 +282,27 @@ public final class TranscriptionViewModel {
             return
         }
         let url = urlInput.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let videoID = YouTubeURLValidator.extractVideoID(url) else { return }
 
-        // Check for existing transcription of the same video
-        if let existing = try? transcriptionRepo?.fetchCompletedByVideoID(videoID) {
-            currentTranscription = existing
-            urlInput = ""
-            return
+        let source: SourceKind
+        let placeholderName: String
+        if PodcastURLValidator.isApplePodcastsURL(url) {
+            // Apple Podcasts episodes carry no stable client-side id to dedup on
+            // (the enclosure is resolved server-side), so each request runs.
+            source = .podcastURL
+            placeholderName = "Podcast episode"
+        } else {
+            guard let videoID = YouTubeURLValidator.extractVideoID(url) else { return }
+            // Check for existing transcription of the same video
+            if let existing = try? transcriptionRepo?.fetchCompletedByVideoID(videoID) {
+                currentTranscription = existing
+                urlInput = ""
+                return
+            }
+            source = .youtubeURL
+            placeholderName = "YouTube video"
         }
 
-        let taskID = beginNewTranscription(source: .youtubeURL, fileName: "YouTube video")
+        let taskID = beginNewTranscription(source: source, fileName: placeholderName)
         urlInput = ""
 
         transcriptionTask = Task { @MainActor [weak self] in
@@ -418,6 +431,8 @@ public final class TranscriptionViewModel {
             .file
         case .youtube:
             .youtube
+        case .podcast:
+            .podcast
         case .meeting:
             .meeting
         }
@@ -865,9 +880,14 @@ public final class TranscriptionViewModel {
     ) -> String? {
         switch phase {
         case .downloading:
-            return sourceKind == .youtubeURL
-                ? "Longer videos take more time to fetch"
-                : nil
+            switch sourceKind {
+            case .youtubeURL:
+                return "Longer videos take more time to fetch"
+            case .podcastURL:
+                return "Longer episodes take more time to fetch"
+            case .localFile:
+                return nil
+            }
         case .transcribing:
             switch engine {
             case .parakeet:

--- a/Tests/CLITests/CLITelemetryTests.swift
+++ b/Tests/CLITests/CLITelemetryTests.swift
@@ -217,6 +217,19 @@ final class CLITelemetryTests: XCTestCase {
         XCTAssertEqual(metadata.json, true)
     }
 
+    func testTranscribeMetadataClassifiesApplePodcastsInputKind() throws {
+        let command = try CLI.parseAsRoot([
+            "transcribe",
+            "https://podcasts.apple.com/us/podcast/the-daily/id1200361736?i=1000654321987",
+        ])
+
+        let metadata = CLITelemetry.metadata(for: command)
+
+        XCTAssertEqual(metadata.command, "transcribe")
+        XCTAssertEqual(metadata.inputKind, .podcast)
+        XCTAssertFalse(metadata.suppressEvent)
+    }
+
     func testTelemetryOutcomeTreatsSuccessfulExitCodeAsSuccess() {
         let result = Result<Void, Error>.failure(ExitCode.success)
 

--- a/Tests/MacParakeetTests/Services/PodcastEpisodeResolverTests.swift
+++ b/Tests/MacParakeetTests/Services/PodcastEpisodeResolverTests.swift
@@ -1,0 +1,147 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class PodcastEpisodeResolverTests: XCTestCase {
+
+    // MARK: - Episode lookup
+
+    func testResolvesEpisodeURLToEnclosureAndMetadata() async throws {
+        let json = """
+        {
+          "resultCount": 1,
+          "results": [
+            {
+              "wrapperType": "podcastEpisode",
+              "kind": "podcast-episode",
+              "trackName": "Episode 42: On Patience",
+              "collectionName": "The Daily",
+              "feedUrl": "https://feeds.example.com/thedaily.rss",
+              "episodeUrl": "https://cdn.example.com/audio/42.mp3",
+              "artworkUrl600": "https://art.example.com/600.jpg",
+              "artworkUrl100": "https://art.example.com/100.jpg",
+              "description": "A long-form episode description.",
+              "releaseDate": "2024-06-01T07:00:00Z",
+              "trackTimeMillis": 1830000
+            }
+          ]
+        }
+        """
+        let resolver = PodcastEpisodeResolver(dataFetcher: Self.fixtureFetcher(json))
+
+        let episode = try await resolver.resolve(
+            url: "https://podcasts.apple.com/us/podcast/the-daily/id1200361736?i=1000654321987"
+        )
+
+        XCTAssertEqual(episode.audioURL, "https://cdn.example.com/audio/42.mp3")
+        XCTAssertEqual(episode.episodeTitle, "Episode 42: On Patience")
+        XCTAssertEqual(episode.showName, "The Daily")
+        XCTAssertEqual(episode.artworkURL, "https://art.example.com/600.jpg")
+        XCTAssertEqual(episode.episodeDescription, "A long-form episode description.")
+        XCTAssertEqual(episode.durationSeconds, 1830)
+        XCTAssertEqual(episode.releaseDate, "2024-06-01")
+        XCTAssertEqual(episode.feedURL, "https://feeds.example.com/thedaily.rss")
+    }
+
+    func testShowURLPicksFirstEpisodeWithEnclosure() async throws {
+        // A show lookup returns the collection (no episodeUrl) followed by
+        // episodes newest-first; the resolver takes the latest playable one.
+        let json = """
+        {
+          "resultCount": 2,
+          "results": [
+            { "wrapperType": "track", "kind": "podcast", "collectionName": "The Show", "feedUrl": "https://feeds.example.com/show.rss" },
+            { "wrapperType": "podcastEpisode", "trackName": "Latest", "collectionName": "The Show", "episodeUrl": "https://cdn.example.com/latest.mp3", "trackTimeMillis": 600000 }
+          ]
+        }
+        """
+        let resolver = PodcastEpisodeResolver(dataFetcher: Self.fixtureFetcher(json))
+
+        let episode = try await resolver.resolve(url: "https://podcasts.apple.com/us/podcast/the-show/id555")
+
+        XCTAssertEqual(episode.audioURL, "https://cdn.example.com/latest.mp3")
+        XCTAssertEqual(episode.episodeTitle, "Latest")
+        XCTAssertEqual(episode.durationSeconds, 600)
+    }
+
+    // MARK: - Errors
+
+    func testInvalidURLThrows() async {
+        let resolver = PodcastEpisodeResolver(dataFetcher: Self.fixtureFetcher("{}"))
+        await assertThrows(PodcastResolveError.invalidURL) {
+            try await resolver.resolve(url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+        }
+    }
+
+    func testEmptyResultsThrowsEpisodeNotFound() async {
+        let resolver = PodcastEpisodeResolver(
+            dataFetcher: Self.fixtureFetcher(#"{ "resultCount": 0, "results": [] }"#)
+        )
+        await assertThrows(PodcastResolveError.episodeNotFound) {
+            try await resolver.resolve(url: "https://podcasts.apple.com/us/podcast/x/id1?i=2")
+        }
+    }
+
+    func testResultsWithoutEnclosureThrowsNoPlayableAudio() async {
+        let json = #"{ "resultCount": 1, "results": [ { "wrapperType": "track", "kind": "podcast", "collectionName": "X" } ] }"#
+        let resolver = PodcastEpisodeResolver(dataFetcher: Self.fixtureFetcher(json))
+        await assertThrows(PodcastResolveError.noPlayableAudio) {
+            try await resolver.resolve(url: "https://podcasts.apple.com/us/podcast/x/id1?i=2")
+        }
+    }
+
+    func testFetchErrorIsSurfacedAsLookupFailed() async {
+        let resolver = PodcastEpisodeResolver(dataFetcher: { _ in
+            throw PodcastResolveError.lookupFailed("HTTP 503")
+        })
+        await assertThrows(PodcastResolveError.lookupFailed("HTTP 503")) {
+            try await resolver.resolve(url: "https://podcasts.apple.com/us/podcast/x/id1?i=2")
+        }
+    }
+
+    // MARK: - Lookup URL + helpers
+
+    func testLookupURLUsesEpisodeIDWhenPresent() throws {
+        let url = try PodcastEpisodeResolver.lookupURL(collectionID: "111", episodeID: "222")
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let items = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value) })
+        XCTAssertEqual(items["id"], "222")
+        XCTAssertEqual(items["entity"], "podcastEpisode")
+    }
+
+    func testLookupURLUsesCollectionIDWhenNoEpisode() throws {
+        let url = try PodcastEpisodeResolver.lookupURL(collectionID: "111", episodeID: nil)
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let items = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value) })
+        XCTAssertEqual(items["id"], "111")
+    }
+
+    func testNormalizedReleaseDateTrimsISOTimestamp() {
+        XCTAssertEqual(PodcastEpisodeResolver.normalizedReleaseDate("2024-06-01T07:00:00Z"), "2024-06-01")
+        XCTAssertEqual(PodcastEpisodeResolver.normalizedReleaseDate("2024-12-31"), "2024-12-31")
+        XCTAssertNil(PodcastEpisodeResolver.normalizedReleaseDate("June 1, 2024"))
+        XCTAssertNil(PodcastEpisodeResolver.normalizedReleaseDate(nil))
+    }
+
+    // MARK: - Helpers
+
+    private static func fixtureFetcher(_ json: String) -> PodcastEpisodeResolver.DataFetcher {
+        let data = Data(json.utf8)
+        return { _ in data }
+    }
+
+    private func assertThrows(
+        _ expected: PodcastResolveError,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        _ body: () async throws -> Void
+    ) async {
+        do {
+            try await body()
+            XCTFail("Expected \(expected) to be thrown", file: file, line: line)
+        } catch let error as PodcastResolveError {
+            XCTAssertEqual(error, expected, file: file, line: line)
+        } catch {
+            XCTFail("Unexpected error: \(error)", file: file, line: line)
+        }
+    }
+}

--- a/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
@@ -67,6 +67,28 @@ private actor FailingYouTubeDownloader: YouTubeDownloading {
     }
 }
 
+private actor StubPodcastResolver: PodcastResolving {
+    var lastURL: String?
+    private let episode: ResolvedPodcastEpisode?
+    private let error: Error?
+
+    init(episode: ResolvedPodcastEpisode) {
+        self.episode = episode
+        self.error = nil
+    }
+
+    init(error: Error) {
+        self.episode = nil
+        self.error = error
+    }
+
+    func resolve(url: String) async throws -> ResolvedPodcastEpisode {
+        lastURL = url
+        if let error { throw error }
+        return episode!
+    }
+}
+
 private final class SaveFailingTranscriptionRepository: TranscriptionRepositoryProtocol, @unchecked Sendable {
     private let error: Error
 
@@ -886,6 +908,101 @@ final class TranscriptionServiceTests: XCTestCase {
         XCTAssertEqual(result.rawTranscript, "Downloaded transcript")
         XCTAssertEqual(fetched.sourceURL, facebookURL)
         XCTAssertEqual(fetched.sourceType, .youtube)
+    }
+
+    func testTranscribeURLResolvesApplePodcastsLinkAndPersistsPodcastSource() async throws {
+        let downloadedURL = try makeTempDownloadedAudio(fileExtension: "mp3")
+        defer { try? FileManager.default.removeItem(at: downloadedURL) }
+        let applePodcastsURL = "https://podcasts.apple.com/us/podcast/the-daily/id1200361736?i=1000654321987"
+        let enclosureURL = "https://cdn.example.com/audio/42.mp3"
+
+        // yt-dlp only sees a raw CDN URL, so its title is generic; the resolver's
+        // rich episode metadata must win in the persisted record.
+        let downloader = MockYouTubeDownloader(result: YouTubeDownloader.DownloadResult(
+            audioFileURL: downloadedURL,
+            title: "42",
+            durationSeconds: nil
+        ))
+        let resolver = StubPodcastResolver(episode: ResolvedPodcastEpisode(
+            audioURL: enclosureURL,
+            episodeTitle: "Episode 42: On Patience",
+            showName: "The Daily",
+            artworkURL: "https://art.example.com/600.jpg",
+            episodeDescription: "A long-form episode description.",
+            durationSeconds: 1830,
+            releaseDate: "2024-06-01"
+        ))
+
+        await mockSTT.configure(result: STTResult(text: "Podcast transcript"))
+
+        let service = TranscriptionService(
+            audioProcessor: mockAudio,
+            sttTranscriber: mockSTT,
+            transcriptionRepo: transcriptionRepo,
+            shouldKeepDownloadedAudio: { false },
+            youtubeDownloader: downloader,
+            podcastResolver: resolver
+        )
+
+        let result = try await service.transcribeURL(urlString: "  \(applePodcastsURL)\n")
+        let fetched = try XCTUnwrap(transcriptionRepo.fetch(id: result.id))
+
+        // The downloader receives the resolved enclosure, not the page URL.
+        let lastResolveURL = await resolver.lastURL
+        let lastDownloadURL = await downloader.lastURL
+        XCTAssertEqual(lastResolveURL, applePodcastsURL)
+        XCTAssertEqual(lastDownloadURL, enclosureURL)
+
+        XCTAssertEqual(result.sourceType, .podcast)
+        XCTAssertEqual(fetched.sourceType, .podcast)
+        XCTAssertEqual(result.sourceURL, applePodcastsURL)
+        XCTAssertEqual(result.fileName, "Episode 42: On Patience")
+        XCTAssertEqual(result.channelName, "The Daily")
+        XCTAssertEqual(result.thumbnailURL, "https://art.example.com/600.jpg")
+        XCTAssertEqual(result.videoDescription, "A long-form episode description.")
+        XCTAssertEqual(result.durationMs, 1_830_000)
+        XCTAssertEqual(result.rawTranscript, "Podcast transcript")
+    }
+
+    func testTranscribeURLEmitsPodcastSourceTelemetryOnResolveFailure() async throws {
+        let telemetry = TelemetrySpy()
+        Telemetry.configure(telemetry)
+        defer { Telemetry.configure(NoOpTelemetryService()) }
+
+        let downloader = MockYouTubeDownloader(result: YouTubeDownloader.DownloadResult(
+            audioFileURL: URL(fileURLWithPath: "/tmp/unused.mp3"),
+            title: "unused",
+            durationSeconds: nil
+        ))
+        let resolver = StubPodcastResolver(error: PodcastResolveError.episodeNotFound)
+
+        let service = TranscriptionService(
+            audioProcessor: mockAudio,
+            sttTranscriber: mockSTT,
+            transcriptionRepo: transcriptionRepo,
+            youtubeDownloader: downloader,
+            podcastResolver: resolver
+        )
+
+        do {
+            _ = try await service.transcribeURL(urlString: "https://podcasts.apple.com/us/podcast/x/id1?i=2")
+            XCTFail("Should have thrown")
+        } catch let error as PodcastResolveError {
+            XCTAssertEqual(error, .episodeNotFound)
+        }
+
+        let downloadCount = await downloader.downloadCallCount
+        XCTAssertEqual(downloadCount, 0, "Download must not run when resolution fails")
+
+        let failedEvent = telemetry.snapshot().reversed().first {
+            if case .transcriptionFailed = $0 { return true }
+            return false
+        }
+        guard case .transcriptionFailed(let source, let stage, _, _) = try XCTUnwrap(failedEvent) else {
+            return XCTFail("Expected transcription_failed telemetry")
+        }
+        XCTAssertEqual(source, .podcast)
+        XCTAssertEqual(stage, .download)
     }
 
     func testTranscribeMeetingUsesFinalizeLaneAndMergesFreshSourceTranscriptsByAlignment() async throws {

--- a/Tests/MacParakeetTests/Utilities/PodcastURLValidatorTests.swift
+++ b/Tests/MacParakeetTests/Utilities/PodcastURLValidatorTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class PodcastURLValidatorTests: XCTestCase {
+
+    // MARK: - Episode URLs
+
+    func testEpisodeURLWithCountryAndSlug() {
+        let url = "https://podcasts.apple.com/us/podcast/the-daily/id1200361736?i=1000654321987"
+        XCTAssertTrue(PodcastURLValidator.isApplePodcastsURL(url))
+        XCTAssertEqual(PodcastURLValidator.extractCollectionID(url), "1200361736")
+        XCTAssertEqual(PodcastURLValidator.extractEpisodeID(url), "1000654321987")
+    }
+
+    func testEpisodeURLWithExtraQueryItems() {
+        let url = "https://podcasts.apple.com/gb/podcast/show/id123?i=456&l=en&foo=bar"
+        XCTAssertEqual(PodcastURLValidator.extractCollectionID(url), "123")
+        XCTAssertEqual(PodcastURLValidator.extractEpisodeID(url), "456")
+    }
+
+    func testEpisodeURLWithoutWWWIsAccepted() {
+        let url = "podcasts.apple.com/us/podcast/x/id999?i=111"
+        XCTAssertTrue(PodcastURLValidator.isApplePodcastsURL(url))
+        XCTAssertEqual(PodcastURLValidator.extractCollectionID(url), "999")
+        XCTAssertEqual(PodcastURLValidator.extractEpisodeID(url), "111")
+    }
+
+    // MARK: - Show URLs (no episode id)
+
+    func testShowURLHasCollectionButNoEpisode() {
+        let url = "https://podcasts.apple.com/us/podcast/the-daily/id1200361736"
+        XCTAssertTrue(PodcastURLValidator.isApplePodcastsURL(url))
+        XCTAssertEqual(PodcastURLValidator.extractCollectionID(url), "1200361736")
+        XCTAssertNil(PodcastURLValidator.extractEpisodeID(url))
+    }
+
+    func testLeadingAndTrailingWhitespaceIsTrimmed() {
+        let url = "   https://podcasts.apple.com/us/podcast/x/id42?i=7   "
+        XCTAssertTrue(PodcastURLValidator.isApplePodcastsURL(url))
+        XCTAssertEqual(PodcastURLValidator.extractCollectionID(url), "42")
+        XCTAssertEqual(PodcastURLValidator.extractEpisodeID(url), "7")
+    }
+
+    // MARK: - Rejected inputs
+
+    func testYouTubeURLIsNotApplePodcasts() {
+        XCTAssertFalse(PodcastURLValidator.isApplePodcastsURL("https://www.youtube.com/watch?v=dQw4w9WgXcQ"))
+    }
+
+    func testGenericHostIsRejected() {
+        XCTAssertFalse(PodcastURLValidator.isApplePodcastsURL("https://overcast.fm/+abc123"))
+        XCTAssertFalse(PodcastURLValidator.isApplePodcastsURL("https://example.com/feed.mp3"))
+    }
+
+    func testApplePodcastsURLWithoutCollectionIDIsRejected() {
+        // A bare host or a browse page carries no resolvable `id{digits}`.
+        XCTAssertFalse(PodcastURLValidator.isApplePodcastsURL("https://podcasts.apple.com/us/browse"))
+        XCTAssertNil(PodcastURLValidator.extractCollectionID("https://podcasts.apple.com"))
+    }
+
+    func testNonNumericEpisodeIDIsIgnored() {
+        let url = "https://podcasts.apple.com/us/podcast/x/id42?i=not-a-number"
+        XCTAssertEqual(PodcastURLValidator.extractCollectionID(url), "42")
+        XCTAssertNil(PodcastURLValidator.extractEpisodeID(url))
+    }
+
+    func testEmptyAndWhitespaceInputsAreRejected() {
+        XCTAssertFalse(PodcastURLValidator.isApplePodcastsURL(""))
+        XCTAssertFalse(PodcastURLValidator.isApplePodcastsURL("   "))
+        XCTAssertFalse(PodcastURLValidator.isApplePodcastsURL("https://podcasts.apple.com/us/podcast/x id42"))
+    }
+}

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
@@ -82,6 +82,22 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
         XCTAssertEqual(vm.filteredTranscriptions.first?.fileName, "youtube.mp3")
     }
 
+    func testFilterPodcast() async throws {
+        try repo.save(Transcription(fileName: "local.mp3", status: .completed, sourceType: .file))
+        try repo.save(Transcription(fileName: "youtube.mp3", status: .completed, sourceURL: "https://youtube.com/watch?v=abc", sourceType: .youtube))
+        try repo.save(Transcription(
+            fileName: "episode.mp3",
+            status: .completed,
+            sourceURL: "https://podcasts.apple.com/us/podcast/x/id1?i=2",
+            sourceType: .podcast
+        ))
+
+        vm.filter = .podcast
+        await load()
+        XCTAssertEqual(vm.filteredTranscriptions.count, 1)
+        XCTAssertEqual(vm.filteredTranscriptions.first?.fileName, "episode.mp3")
+    }
+
     func testFilterLocal() async throws {
         try repo.save(Transcription(fileName: "local.mp3", status: .completed, sourceType: .file))
         try repo.save(Transcription(fileName: "meeting.mp3", status: .completed, sourceType: .meeting))

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -342,6 +342,29 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.progressHeadline, "Running speech recognition")
     }
 
+    func testApplePodcastsLinkIsValidAndRoutesToPodcastSourceKind() async throws {
+        let expectedResult = Transcription(
+            fileName: "Episode 42",
+            rawTranscript: "Podcast transcript",
+            status: .completed,
+            sourceURL: "https://podcasts.apple.com/us/podcast/the-daily/id1200361736?i=1000654321987",
+            sourceType: .podcast
+        )
+        await mockService.configure(result: expectedResult)
+        await mockService.configureURLProgress(phases: [.downloading(percent: 10), .transcribing(percent: 30)])
+        await mockService.configureURLDelay(milliseconds: 200)
+
+        viewModel.configure(transcriptionService: mockService, transcriptionRepo: mockRepo)
+        viewModel.urlInput = "https://podcasts.apple.com/us/podcast/the-daily/id1200361736?i=1000654321987"
+        XCTAssertTrue(viewModel.isValidURL)
+        viewModel.transcribeURL()
+
+        XCTAssertEqual(viewModel.sourceKind, .podcastURL)
+
+        try await waitUntil { self.viewModel.progressPhase == .transcribing }
+        XCTAssertEqual(viewModel.sourceKind, .podcastURL)
+    }
+
     // MARK: - Duplicate URL Detection
 
     func testTranscribeURLShowsExistingWhenAlreadyTranscribed() async {

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -435,6 +435,19 @@ ingestion model; the queue machinery is generic enough for a future
 playlist front-end). The CLI mirrors this — see F11 / `macparakeet-cli
 transcribe` and the CLI CHANGELOG (REQ-CLI-002).
 
+**Apple Podcasts URL transcription:** Pasting an Apple Podcasts link
+(`podcasts.apple.com/.../id<show>?i=<episode>`) resolves the episode through
+the public iTunes lookup API to its audio enclosure URL plus episode title,
+show name, artwork, description, and duration — no HTML scraping. The enclosure
+then flows through the same download → local STT path as YouTube (`yt-dlp`
+fetches the direct audio URL). An episode link transcribes that episode; a show
+link transcribes the latest episode. Saved transcripts use a dedicated
+`podcast` source type with its own Library filter and source chip, and the
+Transcribe-tab link field plus the Spotlight-style URL panel both accept
+YouTube and Apple Podcasts links. Implemented in `PodcastURLValidator`,
+`PodcastEpisodeResolver`, and the `TranscriptionService.transcribeURL` podcast
+branch.
+
 **Completion notification (v0.6 — REQ-UI-006):**
 
 When a file, YouTube, or batch transcription finishes, MacParakeet plays a


### PR DESCRIPTION
## Summary

Adds an **Apple Podcasts transcription pipeline** that mirrors the existing
YouTube URL path end to end. Paste an Apple Podcasts link into the Transcribe
tab, the URL panel, or the CLI and MacParakeet resolves the episode to its
audio enclosure, downloads it, and transcribes locally — with a first-class
`podcast` source type, Library filter, source chip, telemetry, and CLI input
kind.

The genuinely new piece is a small, dependency-free **iTunes-lookup resolver**
(`PodcastEpisodeResolver`) — Apple Podcasts page URLs don't point at audio and
yt-dlp's Apple extractor is unreliable, so the resolver turns a shareable link
into a direct enclosure URL + rich metadata (episode title, show, artwork,
description, duration). Everything downstream (download, STT, persistence,
playback, cleanup) reuses the proven YouTube machinery.

## What's included

**Core**
- `PodcastURLValidator` — recognizes `podcasts.apple.com` links, extracts the
  `id<digits>` collection id and `?i=` episode id (the analogue of
  `YouTubeURLValidator`).
- `PodcastEpisodeResolver` (+ `PodcastResolving` / `PodcastResolveError`) —
  resolves via `itunes.apple.com/lookup`. Episode links → that episode; show
  links → the latest episode. Injectable data fetcher for tests.
- `TranscriptionService.transcribeURL` branches on Apple Podcasts links:
  resolve → hand the resolved CDN URL to the existing
  `YouTubeDownloader.download(url:)` → persist as `.podcast` with the
  resolver's metadata. Source/telemetry/inputKind are generalized from
  hardcoded `.youtube`.
- New cases: `Transcription.SourceType.podcast`,
  `TelemetryTranscriptionSource.podcast`, `ObservabilityInputKind.podcast`.
  Asset cleanup handles `.podcast` (shared downloads dir, same prefix guard).

**App / ViewModels / CLI**
- `SourceKind.podcastURL`, `isValidURL` and `transcribeURL()` accept both link
  kinds; Library `Podcasts` filter; purple `Podcast` source chip.
- Transcribe-tab link card and Spotlight-style URL panel accept YouTube **and**
  Apple Podcasts links (no new app wiring — both already route through
  `urlInput`/`isValidURL`/`transcribeURL`).
- CLI `transcribe` classifies Apple Podcasts links as `inputKind: podcast`
  (additive; documented in the CLI CHANGELOG).

**Tests**
- `PodcastURLValidatorTests`, `PodcastEpisodeResolverTests` (JSON fixtures, no
  network), plus podcast cases in `TranscriptionServiceTests` (end-to-end +
  resolve-failure telemetry), `TranscriptionViewModelTests`,
  `TranscriptionLibraryViewModelTests`, and `CLITelemetryTests`.

**Docs**
- README, `spec/02-features.md`, and `Sources/CLI/CHANGELOG.md`.

## Design notes

- **Reuse over reinvention:** the resolved enclosure is a plain audio URL, so it
  flows through `YouTubeDownloader.download(url:)` (already documented as
  "download audio from any HTTP(S) media URL yt-dlp supports") — keeping the
  diff focused on the podcast-specific layer (validator, resolver, source type,
  UI). The resolver's metadata wins over yt-dlp's generic filename info.
- **Scope:** Apple Podcasts page URLs only — raw RSS/direct-audio URLs are
  already covered by the generic media path. iTunes lookup returns the
  enclosure directly, so no XML feed parsing is needed for the episode/show
  cases.

## Testing

- `MacParakeetCore`, `MacParakeetViewModels`, `CLI`, and the `MacParakeet`
  GUI target all compile cleanly with these changes.
- ⚠️ I could not execute `swift test` in my environment: it only has the
  **Command Line Tools** toolchain (no full Xcode), which ships neither
  `XCTest` nor the SwiftUI `#Preview` macro plugin, so the test target can't
  build locally (this affects the whole suite, not just the new tests). The new
  tests follow the existing patterns exactly; please run `swift test` in CI /
  Xcode to confirm. Happy to adjust anything that surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
