### PR TITLE
Fix transform capture for terminals and read-only surfaces

### DIFF
--- a/Sources/MacParakeetCore/Services/System/SelectionCaptureService.swift
+++ b/Sources/MacParakeetCore/Services/System/SelectionCaptureService.swift
@@ -38,7 +38,9 @@ public enum SelectionCaptureResult: @unchecked Sendable {
 
     /// True when this result came from the pre-existing clipboard fallback
     /// (Cmd+C produced no new selection, but there was already text on the
-    /// clipboard). Used in logging / diagnostics.
+    /// clipboard). The capture never wrote to the pasteboard in this case, so
+    /// the abandoned-restore path uses this to skip an otherwise-spurious
+    /// clipboard write. Also surfaced in logging / diagnostics.
     public var isPreExistingClipboardFallback: Bool {
         guard case .clipboard(_, let snapshot, _) = self else { return false }
         return snapshot.temporaryChangeCount == snapshot.originalChangeCount
@@ -243,6 +245,13 @@ public actor SelectionCaptureService {
     func restoreClipboardCaptureIfCurrent(_ result: SelectionCaptureResult) async {
         guard case .clipboard(_, let snapshot, _) = result else { return }
 
+        // A pre-existing clipboard fallback never hijacked the pasteboard — it
+        // read text the user had already copied. There is nothing to restore,
+        // and writing the same content back would bump the change count and
+        // fire spurious clipboard-manager "new item" events for a duplicate of
+        // the user's own text. Skip it entirely.
+        if result.isPreExistingClipboardFallback { return }
+
         guard let temporaryChangeCount = snapshot.temporaryChangeCount else {
             await restoreSnapshotOnMain(snapshot)
             return
@@ -302,15 +311,15 @@ public actor SelectionCaptureService {
         //
         // Fall back to whatever text is already on the clipboard: the user may
         // have manually Cmd+C'd from a read-only surface (terminal scrollback,
-        // PDF, browser) before pressing the transform hotkey. Use the snapshot's
-        // own originalChangeCount as the temporaryChangeCount so that
-        // `restoreClipboardCaptureIfCurrent` correctly skips restoration if the
-        // user copies something new during the LLM phase.
-        if let preExistingText = snapshot.items?
-            .compactMap({ $0.string(forType: .string) })
-            .first(where: { !$0.isEmpty }) {
+        // PDF, browser) before pressing the transform hotkey. Tag the snapshot
+        // with `temporaryChangeCount == originalChangeCount` so downstream code
+        // knows this capture never hijacked the clipboard: the abandoned-restore
+        // path skips it (`isPreExistingClipboardFallback`), and the success-path
+        // restore treats the saved snapshot as the user's own pre-existing
+        // content to put back after the paste.
+        if let preExistingText = await preExistingClipboardTextOnMain(snapshot) {
             logger.notice(
-                "transforms: clipboard-hijack timed out; using pre-existing clipboard text len=\(preExistingText.count, privacy: .public) target=\(target?.bundleIdentifier ?? "none", privacy: .public)"
+                "transforms-spike: clipboard-hijack timed out; using pre-existing clipboard text len=\(preExistingText.count, privacy: .public) target=\(target?.bundleIdentifier ?? "none", privacy: .public)"
             )
             return .clipboard(
                 text: preExistingText,
@@ -320,7 +329,7 @@ public actor SelectionCaptureService {
         }
 
         logger.notice(
-            "transforms: clipboard-hijack timed out with no selection and empty clipboard target=\(target?.bundleIdentifier ?? "none", privacy: .public)"
+            "transforms-spike: clipboard-hijack timed out with no selection and empty clipboard target=\(target?.bundleIdentifier ?? "none", privacy: .public)"
         )
         return .empty
     }
@@ -343,6 +352,17 @@ public actor SelectionCaptureService {
     @MainActor
     private func currentStringOnMain() -> String? {
         backend.currentPasteboardString()
+    }
+
+    /// Read the first non-empty string from a captured snapshot's items.
+    /// `NSPasteboardItem` is an AppKit type and is not thread-safe, so this
+    /// access must happen on the main actor — never from the service's own
+    /// cooperative executor.
+    @MainActor
+    private func preExistingClipboardTextOnMain(_ snapshot: PasteboardSnapshot) -> String? {
+        snapshot.items?
+            .compactMap { $0.string(forType: .string) }
+            .first { !$0.isEmpty }
     }
 
     @MainActor

--- a/Sources/MacParakeetCore/Services/System/SelectionCaptureService.swift
+++ b/Sources/MacParakeetCore/Services/System/SelectionCaptureService.swift
@@ -36,6 +36,14 @@ public enum SelectionCaptureResult: @unchecked Sendable {
         }
     }
 
+    /// True when this result came from the pre-existing clipboard fallback
+    /// (Cmd+C produced no new selection, but there was already text on the
+    /// clipboard). Used in logging / diagnostics.
+    public var isPreExistingClipboardFallback: Bool {
+        guard case .clipboard(_, let snapshot, _) = self else { return false }
+        return snapshot.temporaryChangeCount == snapshot.originalChangeCount
+    }
+
     public var target: SelectionCaptureTarget? {
         switch self {
         case .ax(_, _, let target), .clipboard(_, _, let target):
@@ -287,8 +295,33 @@ public actor SelectionCaptureService {
             try? await Task.sleep(nanoseconds: pollIntervalNanos)
         }
 
-        // No change count delta — selection was empty. Pasteboard wasn't
-        // touched (Cmd+C with no selection is a no-op) so nothing to restore.
+        // No change count delta — Cmd+C with no selection is a no-op in the
+        // target app. Common in terminals running interactive TUI apps (e.g.
+        // Claude Code) where the application intercepts mouse events, leaving
+        // the terminal with no text selection even after a click-drag.
+        //
+        // Fall back to whatever text is already on the clipboard: the user may
+        // have manually Cmd+C'd from a read-only surface (terminal scrollback,
+        // PDF, browser) before pressing the transform hotkey. Use the snapshot's
+        // own originalChangeCount as the temporaryChangeCount so that
+        // `restoreClipboardCaptureIfCurrent` correctly skips restoration if the
+        // user copies something new during the LLM phase.
+        if let preExistingText = snapshot.items?
+            .compactMap({ $0.string(forType: .string) })
+            .first(where: { !$0.isEmpty }) {
+            logger.notice(
+                "transforms: clipboard-hijack timed out; using pre-existing clipboard text len=\(preExistingText.count, privacy: .public) target=\(target?.bundleIdentifier ?? "none", privacy: .public)"
+            )
+            return .clipboard(
+                text: preExistingText,
+                savedClipboard: snapshot.withTemporaryChangeCount(snapshot.originalChangeCount),
+                target: target
+            )
+        }
+
+        logger.notice(
+            "transforms: clipboard-hijack timed out with no selection and empty clipboard target=\(target?.bundleIdentifier ?? "none", privacy: .public)"
+        )
         return .empty
     }
 

--- a/Tests/MacParakeetTests/Services/System/SelectionCaptureServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/System/SelectionCaptureServiceTests.swift
@@ -69,14 +69,16 @@ final class SelectionCaptureServiceTests: XCTestCase {
         }
     }
 
-    func testCaptureReturnsEmptyWhenClipboardDidNotChange() async {
+    func testCaptureReturnsEmptyWhenClipboardDidNotChangeAndNoPriorContent() async {
+        // No change count AND no pre-existing clipboard text → still .empty.
         let backend = FakeSelectionCaptureBackend(
             isTrusted: true,
             focusedElement: AXUIElementCreateSystemWide(),
             selectedText: nil,
             initialChangeCount: 5,
+            snapshotItems: nil,         // nothing on clipboard
             pasteboardAfterCmdC: "ignored",
-            changeCountAfterCmdC: 5  // No change
+            changeCountAfterCmdC: 5     // No change
         )
         let service = SelectionCaptureService(
             backend: backend,
@@ -92,6 +94,71 @@ final class SelectionCaptureServiceTests: XCTestCase {
         default:
             XCTFail("Expected .empty, got \(result.pathTag)")
         }
+    }
+
+    /// Terminal / read-only surface workflow: the user manually Cmd+C'd text
+    /// before triggering the transform. The synthesized Cmd+C produces no new
+    /// clipboard write (nothing selected in the terminal), so the hijack times
+    /// out — but pre-existing clipboard text should be used as a fallback.
+    func testCaptureFallsBackToPreExistingClipboardWhenHijackTimesOut() async {
+        let existingItem = NSPasteboardItem()
+        existingItem.setString("pre-existing clipboard text", forType: .string)
+        let backend = FakeSelectionCaptureBackend(
+            isTrusted: true,
+            focusedElement: AXUIElementCreateSystemWide(),
+            selectedText: nil,
+            initialChangeCount: 7,
+            snapshotItems: [existingItem],
+            pasteboardAfterCmdC: nil,
+            changeCountAfterCmdC: 7     // No change — nothing was selected
+        )
+        let service = SelectionCaptureService(
+            backend: backend,
+            clipboardPollTimeout: .milliseconds(60),
+            pollIntervalNanos: 1_000_000
+        )
+
+        let result = await service.captureSelection()
+
+        switch result {
+        case .clipboard(let text, let snapshot, _):
+            XCTAssertEqual(text, "pre-existing clipboard text")
+            XCTAssertEqual(snapshot.originalChangeCount, 7)
+            // temporaryChangeCount equals originalChangeCount for the pre-existing
+            // fallback — this tells restoreClipboardCaptureIfCurrent to skip
+            // restoration if the user copied something new during the LLM phase.
+            XCTAssertEqual(snapshot.temporaryChangeCount, 7)
+        default:
+            XCTFail("Expected .clipboard with pre-existing text, got \(result.pathTag)")
+        }
+    }
+
+    /// Abandoning a pre-existing clipboard capture should not clobber a
+    /// subsequent user copy (changeCount moved while LLM was running).
+    func testAbandonedPreExistingCapturePreservesSubsequentUserCopy() async {
+        let existingItem = NSPasteboardItem()
+        existingItem.setString("old clipboard text", forType: .string)
+        let backend = FakeSelectionCaptureBackend(
+            isTrusted: true,
+            focusedElement: AXUIElementCreateSystemWide(),
+            selectedText: nil,
+            initialChangeCount: 3,
+            snapshotItems: [existingItem],
+            pasteboardAfterCmdC: nil,
+            changeCountAfterCmdC: 3
+        )
+        let service = SelectionCaptureService(
+            backend: backend,
+            clipboardPollTimeout: .milliseconds(60),
+            pollIntervalNanos: 1_000_000
+        )
+
+        let result = await service.captureSelection()
+        // Simulate the user copying something new during the LLM phase.
+        backend.setChangeCountForTesting(4)
+        await service.restoreClipboardCaptureIfCurrent(result)
+
+        XCTAssertEqual(backend.restoreCount(), 0, "User clipboard write after capture must not be clobbered")
     }
 
     func testCaptureSnapshotIsCarriedForRestore() async {

--- a/Tests/MacParakeetTests/Services/System/SelectionCaptureServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/System/SelectionCaptureServiceTests.swift
@@ -133,6 +133,37 @@ final class SelectionCaptureServiceTests: XCTestCase {
         }
     }
 
+    /// Regression: abandoning a pre-existing clipboard fallback when the user
+    /// has NOT copied anything new must not touch the pasteboard. The capture
+    /// never hijacked the clipboard (it read text the user already had), so a
+    /// restore would be a spurious `clearContents()` + `writeObjects()` that
+    /// bumps the change count and fires clipboard-manager "new item" events for
+    /// a duplicate of the user's own text.
+    func testAbandonedPreExistingCaptureSkipsRestoreWhenClipboardUnchanged() async {
+        let existingItem = NSPasteboardItem()
+        existingItem.setString("pre-existing text", forType: .string)
+        let backend = FakeSelectionCaptureBackend(
+            isTrusted: true,
+            focusedElement: AXUIElementCreateSystemWide(),
+            selectedText: nil,
+            initialChangeCount: 9,
+            snapshotItems: [existingItem],
+            pasteboardAfterCmdC: nil,
+            changeCountAfterCmdC: 9     // No change — pre-existing fallback
+        )
+        let service = SelectionCaptureService(
+            backend: backend,
+            clipboardPollTimeout: .milliseconds(60),
+            pollIntervalNanos: 1_000_000
+        )
+
+        let result = await service.captureSelection()
+        // Abandon with NO subsequent user copy (change count still 9).
+        await service.restoreClipboardCaptureIfCurrent(result)
+
+        XCTAssertEqual(backend.restoreCount(), 0, "Pre-existing fallback never hijacked the clipboard — restoring would spuriously bump the change count")
+    }
+
     /// Abandoning a pre-existing clipboard capture should not clobber a
     /// subsequent user copy (changeCount moved while LLM was running).
     func testAbandonedPreExistingCapturePreservesSubsequentUserCopy() async {


### PR DESCRIPTION
## Problem

`TransformsCoordinator` uses `replacementMode: .pasteIntoCurrentFocus` specifically so that "read-only selections (browser text, terminal scrollback, PDFs) can still feed a paste-ready result into the user's active input." In practice, this was completely broken for terminals.

Terminals running interactive TUI apps (Claude Code, vim, etc.) operate in **application mode**: mouse events are forwarded to the running process, not to the terminal's selection mechanism. So a click-drag never establishes a text selection in the terminal. When MacParakeet posts the synthesized Cmd+C, there's nothing selected, the pasteboard change count never moves, and after 500ms the capture returns `.empty` → **"No selection — select text first"** every time.

The natural workaround — manually Cmd+C the terminal text first, then press the transform hotkey — also failed, because `clipboardHijack()` only looked for a *new* clipboard write (change count delta), never considering pre-existing clipboard content.

## Fix

After the 500ms poll loop exits with no change count delta, check the pre-capture snapshot for existing text. If found, return it as a `.clipboard` capture:

```swift
// timeout path — was just: return .empty
if let preExistingText = snapshot.items?
    .compactMap({ $0.string(forType: .string) })
    .first(where: { !$0.isEmpty }) {
    return .clipboard(
        text: preExistingText,
        savedClipboard: snapshot.withTemporaryChangeCount(snapshot.originalChangeCount),
        target: target
    )
}
return .empty
```

The `temporaryChangeCount = originalChangeCount` sentinel marks a capture that **never hijacked the clipboard** — it read text the user had already copied. The abandoned-restore path (`restoreClipboardCaptureIfCurrent`) skips it entirely via `isPreExistingClipboardFallback`, so a cancel/LLM-error leaves the clipboard untouched (no `clearContents()`/`writeObjects()`, no change-count bump, no clipboard-manager noise). The success path is unaffected: `SelectionReplacementService` genuinely writes the transform result and then restores the saved snapshot, which is a legitimate restore.

> **Review update (commit `ed7e78a`):** wired `isPreExistingClipboardFallback` into the abandoned-restore early-return (Greptile P1 — the original commit performed a spurious clipboard write here), and moved the `NSPasteboardItem.string(forType:)` read onto a `@MainActor` helper (Gemini — off-actor AppKit access). Log prefixes aligned to `transforms-spike:`.

**Workflow this enables:**
1. Select text in terminal → **Cmd+C**
2. Press transform hotkey (⌥2 for Distill, etc.)
3. Transform runs on the copied text, result pasted into current focus

## Tests

- `testCaptureFallsBackToPreExistingClipboardWhenHijackTimesOut` — hijack timeout with pre-existing clipboard text → `.clipboard` with `temporaryChangeCount == originalChangeCount`
- `testAbandonedPreExistingCapturePreservesSubsequentUserCopy` — user copies something new during LLM phase → restore skipped ✓
- `testCaptureReturnsEmptyWhenClipboardDidNotChangeAndNoPriorContent` — timeout AND empty clipboard → still `.empty` ✓ (renamed from `testCaptureReturnsEmptyWhenClipboardDidNotChange` for clarity)

All 9 `SelectionCaptureServiceTests` pass.

## Scope

Purely additive to the timeout path. The normal clipboard hijack path (Cmd+C fires, change count moves, text found → success) is unchanged. The "change count moved but no text" path (image/file copy) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
