### PR TITLE
Serialize Transform runs across re-triggers (AUDIT-072)

### DIFF
--- a/Sources/MacParakeet/App/TransformsCoordinator.swift
+++ b/Sources/MacParakeet/App/TransformsCoordinator.swift
@@ -34,7 +34,7 @@ final class TransformsCoordinator {
     private var registry: TransformsHotkeyRegistry?
     private var panelController: TransformSpikeProgressPanelController?
     private var executor: TransformExecutor?
-    private var inFlightTask: Task<Void, Never>?
+    private let runSerializer = TransformRunSerializer()
     private var bindingsChangedObserver: NSObjectProtocol?
 
     /// Per-run identity for stale-event guarding: if the user re-triggers a
@@ -101,8 +101,7 @@ final class TransformsCoordinator {
 
     /// Tear down event tap + in-flight work. Called from `applicationWillTerminate`.
     func stop() {
-        inFlightTask?.cancel()
-        inFlightTask = nil
+        runSerializer.cancel()
         registry?.stop()
         registry = nil
         panelController?.close()
@@ -193,13 +192,6 @@ final class TransformsCoordinator {
             return
         }
 
-        // Cancel any in-flight Transform if the user re-triggers a hotkey
-        // before the previous one finishes. ADR-022 §4 / spike pattern.
-        if let inFlightTask {
-            inFlightTask.cancel()
-            self.inFlightTask = nil
-        }
-
         let executor = TransformExecutor(llmService: llmService)
         self.executor = executor
 
@@ -211,13 +203,15 @@ final class TransformsCoordinator {
         let promptBody = prompt.content
         let runningTransformName = prompt.name
 
-        inFlightTask = Task { @MainActor [weak self] in
+        // Cancel any in-flight Transform if the user re-triggers a hotkey
+        // before the previous one finishes, and only start this run once the
+        // old one has fully wound down. The executor's replace phase ignores
+        // cancellation by design (clipboard write → target re-activation →
+        // ⌘V → restore must not abort half-pasted), so an immediate restart
+        // could capture the old run's payload off the pasteboard or read
+        // from the wrong app after a focus yank. ADR-022 §4; AUDIT-072.
+        runSerializer.replace { @MainActor [weak self] in
             guard let self else { return }
-            defer {
-                if self.activeRunID == runID {
-                    self.inFlightTask = nil
-                }
-            }
             do {
                 let result = try await Observability.withOperationContext(operationContext) {
                     try await executor.run(

--- a/Sources/MacParakeet/App/TransformsCoordinator.swift
+++ b/Sources/MacParakeet/App/TransformsCoordinator.swift
@@ -33,7 +33,6 @@ final class TransformsCoordinator {
 
     private var registry: TransformsHotkeyRegistry?
     private var panelController: TransformSpikeProgressPanelController?
-    private var executor: TransformExecutor?
     private let runSerializer = TransformRunSerializer()
     private var bindingsChangedObserver: NSObjectProtocol?
 
@@ -193,7 +192,6 @@ final class TransformsCoordinator {
         }
 
         let executor = TransformExecutor(llmService: llmService)
-        self.executor = executor
 
         let runID = UUID()
         activeRunID = runID

--- a/Sources/MacParakeetCore/Services/Transforms/TransformRunSerializer.swift
+++ b/Sources/MacParakeetCore/Services/Transforms/TransformRunSerializer.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Serializes Transform runs so at most one run body executes at a time.
+///
+/// Re-triggering a Transform cancels the previous run *and* waits for it to
+/// fully wind down before the next run's body starts. The wait matters:
+/// `TransformExecutor` deliberately ignores cancellation once its replace
+/// phase has begun (aborting between ⌘V and the clipboard restore would
+/// leave the host app half-pasted), so for a short window after cancellation
+/// the old run may still write the pasteboard, re-activate its target app,
+/// and post ⌘V. Starting the next run's selection capture during that window
+/// could capture the old run's payload off the pasteboard or read from the
+/// wrong app. (AUDIT-072, `docs/audits/2026-06-09-codebase-audit.md`.)
+@MainActor
+public final class TransformRunSerializer {
+    private var current: Task<Void, Never>?
+
+    /// Bumped on every `replace(with:)` so a finished run only clears
+    /// `current` if it hasn't already been superseded — the same generation
+    /// idiom the audio/runtime layers use against stale fire-and-forget work.
+    private var generation = 0
+
+    public init() {}
+
+    /// Cancel the in-flight run, if any, and start `body` once it has fully
+    /// wound down. A body that is superseded again before the previous run
+    /// finishes never starts at all.
+    @discardableResult
+    public func replace(with body: @escaping @MainActor () async -> Void) -> Task<Void, Never> {
+        let previous = current
+        previous?.cancel()
+        generation += 1
+        let myGeneration = generation
+        let task = Task { @MainActor [weak self] in
+            if let previous {
+                await previous.value
+            }
+            if !Task.isCancelled {
+                await body()
+            }
+            if let self, self.generation == myGeneration {
+                self.current = nil
+            }
+        }
+        current = task
+        return task
+    }
+
+    /// Cancel the in-flight run without starting a new one. The cancelled
+    /// body still winds down cooperatively on its own task.
+    public func cancel() {
+        current?.cancel()
+        current = nil
+    }
+}

--- a/Sources/MacParakeetCore/Services/Transforms/TransformRunSerializer.swift
+++ b/Sources/MacParakeetCore/Services/Transforms/TransformRunSerializer.swift
@@ -47,9 +47,12 @@ public final class TransformRunSerializer {
     }
 
     /// Cancel the in-flight run without starting a new one. The cancelled
-    /// body still winds down cooperatively on its own task.
+    /// body still winds down cooperatively on its own task, and `current`
+    /// deliberately keeps referencing it: a `replace(with:)` that follows a
+    /// `cancel()` must still wait for the cancelled run to wind down, or the
+    /// AUDIT-072 overlap returns through the cancel-then-retrigger path.
+    /// The finished task clears `current` itself via the generation guard.
     public func cancel() {
         current?.cancel()
-        current = nil
     }
 }

--- a/Tests/MacParakeetTests/Services/Transforms/TransformRunSerializerTests.swift
+++ b/Tests/MacParakeetTests/Services/Transforms/TransformRunSerializerTests.swift
@@ -1,0 +1,148 @@
+import XCTest
+@testable import MacParakeetCore
+
+/// Regression tests for AUDIT-072: a re-triggered Transform must not start
+/// its body (selection capture) until the previous run has fully wound
+/// down, because `TransformExecutor` deliberately runs its replace phase to
+/// completion after cancellation.
+final class TransformRunSerializerTests: XCTestCase {
+    /// MainActor-confined event log + gate shared between test and run bodies.
+    @MainActor
+    private final class RunLog {
+        var entries: [String] = []
+        var gateOpen = false
+        func append(_ entry: String) { entries.append(entry) }
+    }
+
+    /// Deterministic wait: yield the main actor until `condition` holds.
+    /// Bounded so a regression fails the test instead of hanging it.
+    @MainActor
+    private func yieldUntil(
+        _ condition: () -> Bool,
+        attempts: Int = 10_000
+    ) async -> Bool {
+        for _ in 0..<attempts {
+            if condition() { return true }
+            await Task.yield()
+        }
+        return condition()
+    }
+
+    @MainActor
+    func testRunsBodyWhenIdle() async {
+        let serializer = TransformRunSerializer()
+        let log = RunLog()
+
+        let task = serializer.replace { log.append("ran") }
+        await task.value
+
+        XCTAssertEqual(log.entries, ["ran"])
+    }
+
+    @MainActor
+    func testReplaceCancelsCooperativeRunningBody() async {
+        let serializer = TransformRunSerializer()
+        let log = RunLog()
+
+        let first = serializer.replace {
+            log.append("first:start")
+            while !Task.isCancelled { await Task.yield() }
+            log.append("first:cancelled")
+        }
+        let started = await yieldUntil { log.entries.contains("first:start") }
+        XCTAssertTrue(started, "first body never started")
+
+        let second = serializer.replace { log.append("second:start") }
+        await first.value
+        await second.value
+
+        XCTAssertEqual(log.entries, ["first:start", "first:cancelled", "second:start"])
+    }
+
+    /// The AUDIT-072 case: the first body simulates the executor's replace
+    /// phase, which keeps running after cancellation. The second body must
+    /// not start until the first has fully returned.
+    @MainActor
+    func testSecondBodyWaitsForCancellationResistantFirstBody() async {
+        let serializer = TransformRunSerializer()
+        let log = RunLog()
+
+        let first = serializer.replace {
+            log.append("first:start")
+            // Ignore cancellation, like pasteAndRestore's post-gate phase.
+            while !log.gateOpen { await Task.yield() }
+            log.append("first:end")
+        }
+        let started = await yieldUntil { log.entries.contains("first:start") }
+        XCTAssertTrue(started, "first body never started")
+
+        let second = serializer.replace { log.append("second:start") }
+
+        // Give an unserialized implementation ample opportunity to misbehave.
+        for _ in 0..<200 { await Task.yield() }
+        XCTAssertEqual(
+            log.entries, ["first:start"],
+            "second body must not start while the first run winds down"
+        )
+
+        log.gateOpen = true
+        await first.value
+        await second.value
+        XCTAssertEqual(log.entries, ["first:start", "first:end", "second:start"])
+    }
+
+    /// A run superseded while still queued behind its predecessor never
+    /// starts at all — only the latest trigger wins.
+    @MainActor
+    func testQueuedBodySupersededBeforeStartNeverRuns() async {
+        let serializer = TransformRunSerializer()
+        let log = RunLog()
+
+        let first = serializer.replace {
+            log.append("first:start")
+            while !log.gateOpen { await Task.yield() }
+            log.append("first:end")
+        }
+        let started = await yieldUntil { log.entries.contains("first:start") }
+        XCTAssertTrue(started, "first body never started")
+
+        let second = serializer.replace { log.append("second:start") }
+        let third = serializer.replace { log.append("third:start") }
+
+        log.gateOpen = true
+        await first.value
+        await second.value
+        await third.value
+
+        XCTAssertEqual(
+            log.entries, ["first:start", "first:end", "third:start"],
+            "a queued run superseded before starting must never run"
+        )
+    }
+
+    @MainActor
+    func testCancelPreventsQueuedBodyFromRunning() async {
+        let serializer = TransformRunSerializer()
+        let log = RunLog()
+
+        let first = serializer.replace {
+            log.append("first:start")
+            while !log.gateOpen { await Task.yield() }
+            log.append("first:end")
+        }
+        let started = await yieldUntil { log.entries.contains("first:start") }
+        XCTAssertTrue(started, "first body never started")
+
+        let second = serializer.replace { log.append("second:start") }
+        serializer.cancel()
+
+        log.gateOpen = true
+        await first.value
+        await second.value
+
+        XCTAssertFalse(
+            log.entries.contains("second:start"),
+            "a cancelled queued run must not start"
+        )
+    }
+}

--- a/Tests/MacParakeetTests/Services/Transforms/TransformRunSerializerTests.swift
+++ b/Tests/MacParakeetTests/Services/Transforms/TransformRunSerializerTests.swift
@@ -120,6 +120,39 @@ final class TransformRunSerializerTests: XCTestCase {
         )
     }
 
+    /// Gemini review (PR #475): a `replace(with:)` arriving after `cancel()`
+    /// must still wait for the cancelled run to wind down — `cancel()` must
+    /// not drop the `current` reference, or the AUDIT-072 overlap returns
+    /// through the cancel-then-retrigger path.
+    @MainActor
+    func testReplaceAfterCancelWaitsForCancelledBody() async {
+        let serializer = TransformRunSerializer()
+        let log = RunLog()
+
+        let first = serializer.replace {
+            log.append("first:start")
+            while !log.gateOpen { await Task.yield() }
+            log.append("first:end")
+        }
+        let started = await yieldUntil { log.entries.contains("first:start") }
+        XCTAssertTrue(started, "first body never started")
+
+        serializer.cancel()
+
+        let second = serializer.replace { log.append("second:start") }
+
+        for _ in 0..<200 { await Task.yield() }
+        XCTAssertEqual(
+            log.entries, ["first:start"],
+            "second body must not start while the cancelled first run winds down"
+        )
+
+        log.gateOpen = true
+        await first.value
+        await second.value
+        XCTAssertEqual(log.entries, ["first:start", "first:end", "second:start"])
+    }
+
     @MainActor
     func testCancelPreventsQueuedBodyFromRunning() async {
         let serializer = TransformRunSerializer()


### PR DESCRIPTION
## Summary

Audit finding **AUDIT-072** (`docs/audits/2026-06-09-codebase-audit.md`): `TransformExecutor` deliberately runs its replace phase to completion after cancellation (half-pasted states are worse), but `TransformsCoordinator.handleTrigger` cancelled the in-flight task and started a new executor **without awaiting the old one**. For the ~0.5–1s replace window (clipboard write → target re-activation → ⌘V → 500ms settle → restore), a re-trigger could:

- have the old run yank focus back to its target app mid-capture, and
- let the new run's clipboard-fallback capture read the **old run's payload** off the pasteboard as the "selection".

## Fix

New `TransformRunSerializer` (@MainActor, Core): `replace(with:)` cancels the previous run and starts the new body only after the previous task fully completes; a body superseded while queued never starts. The coordinator routes `handleTrigger` and `stop()` through it.

## Tests

5 new `TransformRunSerializerTests` — including a cancellation-resistant first body that mimics the replace phase (the regression case), supersede-while-queued, and cancel-queued. Deterministic main-actor yields, no sleeps. Full `swift test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)