### PR TITLE
Reserve the speech-engine session slot before suspension (AUDIT-071)

### DIFF
--- a/Sources/MacParakeetCore/STT/STTScheduler.swift
+++ b/Sources/MacParakeetCore/STT/STTScheduler.swift
@@ -256,15 +256,25 @@ public actor STTScheduler: STTManaging, SpeechEngineRoutedTranscribing, SpeechEn
     }
 
     public func beginSpeechEngineSession() async -> SpeechEngineLease {
+        // Reserve the session slot before the first suspension point. From
+        // here on, the `activeSpeechEngineSessionIDs.isEmpty` guard in
+        // setSpeechEngine / setParakeetModelVariant fails, so no engine
+        // switch can start while this method is suspended below. Inserting
+        // the ID only after reading the selection left a TOCTOU window: a
+        // switch could interleave at either await and the lease would pin a
+        // different engine than the runtime ends up on (AUDIT-071).
+        let sessionID = UUID()
+        activeSpeechEngineSessionIDs.insert(sessionID)
+
+        // Drain a switch that was already in flight when we entered; the
+        // reservation above guarantees no new one starts behind it.
         if let speechEngineSwitchTask {
             let result = await speechEngineSwitchTask.result
             if case .failure(let error) = result {
                 logger.warning("Proceeding with speech engine session after failed engine switch: \(error.localizedDescription, privacy: .public)")
             }
         }
-        let lease = SpeechEngineLease(selection: await runtime.currentSpeechEngineSelection())
-        activeSpeechEngineSessionIDs.insert(lease.id)
-        return lease
+        return SpeechEngineLease(id: sessionID, selection: await runtime.currentSpeechEngineSelection())
     }
 
     public func endSpeechEngineSession(_ lease: SpeechEngineLease) async {

--- a/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
+++ b/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
@@ -262,9 +262,14 @@ final class STTSchedulerTests: XCTestCase {
 
         await runtime.releaseSelectionRead()
         let lease = await leaseTask.value
+        XCTAssertEqual(lease.selection, SpeechEngineSelection(engine: .parakeet))
         let swaps = await runtime.parakeetModelVariantSwitches
         XCTAssertTrue(swaps.isEmpty, "No variant swap may reach the runtime mid-begin")
+
         await scheduler.endSpeechEngineSession(lease)
+        try await scheduler.setParakeetModelVariant(.v2, onProgress: nil)
+        let swapsAfterEnd = await runtime.parakeetModelVariantSwitches
+        XCTAssertEqual(swapsAfterEnd, [.v2], "Variant swap must succeed once the session is released")
     }
 
     func testSetParakeetModelVariantForwardsWhenIdle() async throws {

--- a/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
+++ b/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
@@ -208,6 +208,65 @@ final class STTSchedulerTests: XCTestCase {
         XCTAssertEqual(count, 1)
     }
 
+    /// AUDIT-071 regression: `beginSpeechEngineSession` suspends while
+    /// reading the runtime selection, *before* it used to insert the lease
+    /// ID. An engine switch arriving during that window passed the
+    /// `activeSpeechEngineSessionIDs.isEmpty` guard, so the lease could pin
+    /// a different engine than the runtime ended up on. The session slot
+    /// must now be reserved before the first suspension point.
+    func testSetSpeechEngineFailsWhileSessionBeginIsInFlight() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.blockNextSelectionRead()
+        let scheduler = STTScheduler(runtimeProvider: runtime)
+
+        let leaseTask = Task {
+            await scheduler.beginSpeechEngineSession()
+        }
+        try await waitForHeldSelectionRead(runtime: runtime, count: 1)
+
+        do {
+            try await scheduler.setSpeechEngine(.whisper)
+            XCTFail("Expected engine switch to fail while a session begin is in flight")
+        } catch let error as STTError {
+            XCTAssertEqual(error.localizedDescription, STTError.engineBusy.localizedDescription)
+        }
+
+        await runtime.releaseSelectionRead()
+        let lease = await leaseTask.value
+        XCTAssertEqual(lease.selection, SpeechEngineSelection(engine: .parakeet))
+        let switches = await runtime.setSpeechEngineCallCount
+        XCTAssertEqual(switches, 0, "No switch may reach the runtime mid-begin")
+
+        await scheduler.endSpeechEngineSession(lease)
+        try await scheduler.setSpeechEngine(.whisper)
+    }
+
+    /// Same AUDIT-071 window, via the Parakeet variant-swap path that shares
+    /// the engine-switch guard.
+    func testSetParakeetModelVariantFailsWhileSessionBeginIsInFlight() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.blockNextSelectionRead()
+        let scheduler = STTScheduler(runtimeProvider: runtime)
+
+        let leaseTask = Task {
+            await scheduler.beginSpeechEngineSession()
+        }
+        try await waitForHeldSelectionRead(runtime: runtime, count: 1)
+
+        do {
+            try await scheduler.setParakeetModelVariant(.v2, onProgress: nil)
+            XCTFail("Expected variant swap to fail while a session begin is in flight")
+        } catch let error as STTError {
+            XCTAssertEqual(error.localizedDescription, STTError.engineBusy.localizedDescription)
+        }
+
+        await runtime.releaseSelectionRead()
+        let lease = await leaseTask.value
+        let swaps = await runtime.parakeetModelVariantSwitches
+        XCTAssertTrue(swaps.isEmpty, "No variant swap may reach the runtime mid-begin")
+        await scheduler.endSpeechEngineSession(lease)
+    }
+
     func testSetParakeetModelVariantForwardsWhenIdle() async throws {
         let runtime = MockSTTRuntime()
         let scheduler = STTScheduler(runtimeProvider: runtime)
@@ -622,6 +681,21 @@ final class STTSchedulerTests: XCTestCase {
         }
     }
 
+    private func waitForHeldSelectionRead(
+        runtime: MockSTTRuntime,
+        count: Int,
+        timeout: Duration = .seconds(2)
+    ) async throws {
+        let start = ContinuousClock.now
+        while await runtime.heldSelectionReadCount < count {
+            if start.duration(to: .now) > timeout {
+                XCTFail("Timed out waiting for \(count) held selection reads")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+    }
+
     private func waitForSpeechEngineSwitch(
         runtime: MockSTTRuntime,
         count: Int,
@@ -829,6 +903,9 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
     private var shouldBlockNextClearModelCache = false
     private var ignoreCancellation = false
     private var speechEngineSwitchContinuation: CheckedContinuation<Void, Never>?
+    private var shouldBlockNextSelectionRead = false
+    private var selectionReadContinuation: CheckedContinuation<Void, Never>?
+    private(set) var heldSelectionReadCount = 0
     private var clearModelCacheContinuation: CheckedContinuation<Void, Never>?
 
     func transcribe(
@@ -955,11 +1032,27 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
     }
 
     func currentSpeechEngineSelection() async -> SpeechEngineSelection {
-        selection
+        if shouldBlockNextSelectionRead {
+            shouldBlockNextSelectionRead = false
+            heldSelectionReadCount += 1
+            await withCheckedContinuation { continuation in
+                selectionReadContinuation = continuation
+            }
+        }
+        return selection
     }
 
     func setCurrentSelection(_ selection: SpeechEngineSelection) {
         self.selection = selection
+    }
+
+    func blockNextSelectionRead() {
+        shouldBlockNextSelectionRead = true
+    }
+
+    func releaseSelectionRead() {
+        selectionReadContinuation?.resume()
+        selectionReadContinuation = nil
     }
 
     func blockNextSpeechEngineSwitch() {


### PR DESCRIPTION
## Summary

Audit finding **AUDIT-071** (`docs/audits/2026-06-09-codebase-audit.md`): `beginSpeechEngineSession()` suspended at `await runtime.currentSpeechEngineSelection()` **before** inserting the lease ID. During that suspension, `setSpeechEngine` / `setParakeetModelVariant` saw `activeSpeechEngineSessionIDs.isEmpty == true` and proceeded — an engine switch could interleave with meeting-session start, pinning the lease to engine A while the runtime ended up on engine B (wrong engine for live/final transcription + wrong crash-recovery pin). The existing line-259 drain only covered a switch *already in flight*, not one starting during the suspension.

## Fix

Reserve the session ID synchronously before the first await; build the lease with the reserved ID. From the reservation onward, both switch paths' guards correctly reject with `engineBusy`.

## Tests

Two regression tests **verified to fail against the unfixed code** — the failure output showed the exact pathology (`lease.selection == whisper` while the session began under `parakeet`, and a switch reaching the runtime mid-begin). `MockSTTRuntime` gains a blockable `currentSpeechEngineSelection` mirroring its existing block/release pattern. 33/33 `STTSchedulerTests` green; full `swift test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)