### PR TITLE
Audit hygiene: yt-dlp argv parity, Whisper engine guard, scrub-pattern gaps (AUDIT-074/075/076/080)

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -177,7 +177,11 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 - Batch mode is **continue-on-error**: a failed input prints a `✗` line to
   stderr and is counted; the run proceeds. The process exits non-zero with a
   one-line summary (`N input(s) failed to transcribe (M succeeded).`) if any
-  input failed, and `0` when all succeed.
+  input failed, and `0` when all succeed. With `--format json`, a batch run
+  that ends with failures also emits the standard `--json` failure envelope
+  on stdout once the run completes — per-input results still go to the
+  output directory, and stdout is otherwise unused in batch mode (this
+  follows the general failure-envelope rule above; clarified per AUDIT-080).
 
 ### Unchanged (back-compat)
 

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -159,6 +159,18 @@ public actor STTRuntime: STTRuntimeProtocol {
         )
     }
 
+    /// Transcription-path engine access. `warmUp()` and
+    /// `performSpeechEngineSwitch()` intentionally construct `WhisperEngine`
+    /// inline instead. Warm-up is NOT gated on `activeTranscriptionCount`
+    /// (background warm-up fires from launch/meeting/onboarding flows while
+    /// jobs may be in flight); it stays safe because its reuse-or-construct
+    /// (`whisperEngine ?? WhisperEngine(...)`) is synchronous on this actor,
+    /// so it can never double-construct or orphan an engine mid-job. The
+    /// switch path runs under `setSpeechEngine`'s
+    /// `activeTranscriptionCount == 0` guard and stages into
+    /// `preparedWhisper` (prepare-then-commit, with a `language:` argument)
+    /// rather than committing to `whisperEngine` up front. Routing either
+    /// through this guard would change those semantics for no safety gain.
     private func ensureWhisperEngine() throws -> WhisperEngine {
         if let whisperEngine {
             return whisperEngine

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -151,13 +151,28 @@ public actor STTRuntime: STTRuntimeProtocol {
         language: String?,
         onProgress: (@Sendable (Int, Int) -> Void)?
     ) async throws -> STTResult {
-        let engine = whisperEngine ?? WhisperEngine(model: whisperModelVariant)
-        whisperEngine = engine
+        let engine = try ensureWhisperEngine()
         return try await engine.transcribe(
             audioURL: URL(fileURLWithPath: audioPath),
             language: language,
             onProgress: onProgress
         )
+    }
+
+    private func ensureWhisperEngine() throws -> WhisperEngine {
+        if let whisperEngine {
+            return whisperEngine
+        }
+        // Mirrors ensureNemotronEngine: never construct a fresh engine while
+        // another transcription may be mid-flight on the existing one. The
+        // scheduler's single background slot already serializes Whisper jobs,
+        // but the invariant shouldn't depend on the caller (AUDIT-075).
+        guard activeTranscriptionCount <= 1 else {
+            throw STTError.engineBusy
+        }
+        let engine = WhisperEngine(model: whisperModelVariant)
+        whisperEngine = engine
+        return engine
     }
 
     private func transcribeWithParakeet(

--- a/Sources/MacParakeetCore/Services/LLM/LLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLM/LLMClient.swift
@@ -1134,16 +1134,20 @@ public final class LLMClient: LLMClientProtocol, Sendable {
     static func scrubAPIKeyArtifacts(from message: String) -> String {
         let patterns: [(String, String)] = [
             // OpenAI / Anthropic / OpenRouter style keys with `sk-` or `sk-proj-` prefix.
+            // (No `%` here: the sk- alphabet never needs URL encoding.)
             (#"\bsk-[A-Za-z0-9_\-]{8,}"#, "<api-key>"),
-            // Bearer tokens (Authorization header echoes).
-            (#"\bBearer\s+[A-Za-z0-9._\-]{8,}"#, "Bearer <token>"),
+            // Bearer tokens (Authorization header echoes). `%` covers
+            // URL-encoded token echoes (`%2B`, `%3D`, ...) — AUDIT-076.
+            (#"\bBearer\s+[A-Za-z0-9._%\-]{8,}"#, "Bearer <token>"),
             // x-api-key header echoes (case-insensitive).
-            (#"(?i)\bx-api-key:\s*[A-Za-z0-9._\-]{8,}"#, "x-api-key: <token>"),
+            (#"(?i)\bx-api-key:\s*[A-Za-z0-9._%\-]{8,}"#, "x-api-key: <token>"),
             // Generic api-key / api_key / apikey query params (case-insensitive).
-            (#"(?i)\bapi[_-]?key=[A-Za-z0-9._\-]{8,}"#, "api-key=<token>"),
+            (#"(?i)\bapi[_-]?key=[A-Za-z0-9._%\-]{8,}"#, "api-key=<token>"),
             // Generic key= query param (must come last so the more specific
-            // api-key= rule wins).
-            (#"(?i)\bkey=[A-Za-z0-9._\-]{20,}"#, "key=<token>"),
+            // api-key= rule wins). 16+ chars: long enough to skip innocent
+            // `key=<word>` params, short enough to catch real keys the old
+            // 20-char floor let through (AUDIT-076).
+            (#"(?i)\bkey=[A-Za-z0-9._%\-]{16,}"#, "key=<token>"),
         ]
 
         var out = message

--- a/Sources/MacParakeetCore/Services/LLM/LLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLM/LLMClient.swift
@@ -1137,17 +1137,19 @@ public final class LLMClient: LLMClientProtocol, Sendable {
             // (No `%` here: the sk- alphabet never needs URL encoding.)
             (#"\bsk-[A-Za-z0-9_\-]{8,}"#, "<api-key>"),
             // Bearer tokens (Authorization header echoes). `%` covers
-            // URL-encoded token echoes (`%2B`, `%3D`, ...) — AUDIT-076.
-            (#"\bBearer\s+[A-Za-z0-9._%\-]{8,}"#, "Bearer <token>"),
+            // URL-encoded token echoes (`%2B`, `%3D`, ...); `+/=` covers raw
+            // Base64 tokens, whose pre-`+` prefix could otherwise dodge the
+            // length floor or leak a suffix — AUDIT-076 + PR #477 review.
+            (#"\bBearer\s+[A-Za-z0-9._%\-+=/]{8,}"#, "Bearer <token>"),
             // x-api-key header echoes (case-insensitive).
-            (#"(?i)\bx-api-key:\s*[A-Za-z0-9._%\-]{8,}"#, "x-api-key: <token>"),
+            (#"(?i)\bx-api-key:\s*[A-Za-z0-9._%\-+=/]{8,}"#, "x-api-key: <token>"),
             // Generic api-key / api_key / apikey query params (case-insensitive).
-            (#"(?i)\bapi[_-]?key=[A-Za-z0-9._%\-]{8,}"#, "api-key=<token>"),
+            (#"(?i)\bapi[_-]?key=[A-Za-z0-9._%\-+=/]{8,}"#, "api-key=<token>"),
             // Generic key= query param (must come last so the more specific
             // api-key= rule wins). 16+ chars: long enough to skip innocent
             // `key=<word>` params, short enough to catch real keys the old
             // 20-char floor let through (AUDIT-076).
-            (#"(?i)\bkey=[A-Za-z0-9._%\-]{16,}"#, "key=<token>"),
+            (#"(?i)\bkey=[A-Za-z0-9._%\-+=/]{16,}"#, "key=<token>"),
         ]
 
         var out = message

--- a/Sources/MacParakeetCore/Services/YouTubeDownloader.swift
+++ b/Sources/MacParakeetCore/Services/YouTubeDownloader.swift
@@ -194,12 +194,7 @@ public actor YouTubeDownloader {
     private func fetchMetadata(ytDlpPath: String, url: String) async throws -> VideoMetadata {
         let result = try await runYtDlp(
             ytDlpPath: ytDlpPath,
-            arguments: [
-                "--skip-download",
-                "--dump-json",
-                "--no-playlist",
-                url,
-            ],
+            arguments: Self.fetchMetadataArguments(url: url),
             captureStdout: true
         )
 
@@ -393,6 +388,20 @@ public actor YouTubeDownloader {
         for file in files where file.lastPathComponent.hasPrefix(uuid) {
             try? fm.removeItem(at: file)
         }
+    }
+
+    /// Metadata-probe invocation. Like every yt-dlp call site, options are
+    /// terminated with `--` before the URL so a (hypothetical) leading-dash
+    /// input can never be parsed as a flag — upstream URL validators already
+    /// reject such strings, but argv discipline shouldn't depend on the
+    /// caller (AUDIT-074).
+    nonisolated static func fetchMetadataArguments(url: String) -> [String] {
+        [
+            "--skip-download",
+            "--dump-json",
+            "--no-playlist",
+            "--", url,
+        ]
     }
 
     nonisolated static func downloadAudioArguments(

--- a/Tests/MacParakeetTests/Services/LLM/LLMClientTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMClientTests.swift
@@ -1504,6 +1504,31 @@ final class LLMClientTests: XCTestCase {
         XCTAssertEqual(LLMClient.scrubAPIKeyArtifacts(from: original), original)
     }
 
+    func testScrubReplacesURLEncodedBearerTokens() {
+        // AUDIT-076: URL-encoded echoes (`%2B`, `%3D`, ...) must not escape
+        // the Bearer pattern.
+        let scrubbed = LLMClient.scrubAPIKeyArtifacts(
+            from: "Forwarded: 'Authorization: Bearer abc123%2Bdef%3D456ghi789'"
+        )
+        XCTAssertFalse(scrubbed.contains("abc123%2Bdef%3D456ghi789"))
+        XCTAssertTrue(scrubbed.contains("Bearer <token>"))
+    }
+
+    func testScrubReplacesSixteenCharGenericKeyParams() {
+        // AUDIT-076: the old 20-char floor let shorter real keys through.
+        let scrubbed = LLMClient.scrubAPIKeyArtifacts(
+            from: "Bad URL: ?key=AIzaSyD4x8Q2hP0a"
+        )
+        XCTAssertFalse(scrubbed.contains("AIzaSyD4x8Q2hP0a"))
+        XCTAssertTrue(scrubbed.contains("key=<token>"))
+    }
+
+    func testScrubLeavesInnocentShortKeyParamsAlone() {
+        // Conservative floor: ordinary `key=<word>` params stay readable.
+        let original = "Lookup failed for key=transcription."
+        XCTAssertEqual(LLMClient.scrubAPIKeyArtifacts(from: original), original)
+    }
+
     func testScrubIsIdempotent() {
         let once = LLMClient.scrubAPIKeyArtifacts(from: "key: sk-abcdefghij1234567890")
         let twice = LLMClient.scrubAPIKeyArtifacts(from: once)

--- a/Tests/MacParakeetTests/Services/LLM/LLMClientTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMClientTests.swift
@@ -1514,6 +1514,26 @@ final class LLMClientTests: XCTestCase {
         XCTAssertTrue(scrubbed.contains("Bearer <token>"))
     }
 
+    func testScrubReplacesRawBase64BearerTokens() {
+        // PR #477 review: raw Base64 tokens contain `+`, `/`, `=`. A short
+        // pre-`+` prefix must not dodge the length floor, and no suffix may
+        // leak past the first special character.
+        let scrubbed = LLMClient.scrubAPIKeyArtifacts(
+            from: "Forwarded: 'Authorization: Bearer ab+cdef/g=hijklmnop'"
+        )
+        XCTAssertFalse(scrubbed.contains("ab+cdef/g=hijklmnop"))
+        XCTAssertTrue(scrubbed.contains("Bearer <token>"))
+    }
+
+    func testScrubReplacesRawBase64KeyParams() {
+        let scrubbed = LLMClient.scrubAPIKeyArtifacts(
+            from: "Bad URL: ?key=AAAbbbCCC+ddd/EE==&retry=1"
+        )
+        XCTAssertFalse(scrubbed.contains("AAAbbbCCC+ddd/EE=="))
+        XCTAssertTrue(scrubbed.contains("key=<token>"))
+        XCTAssertTrue(scrubbed.contains("&retry=1"), "scrub must stop at the next query separator")
+    }
+
     func testScrubReplacesSixteenCharGenericKeyParams() {
         // AUDIT-076: the old 20-char floor let shorter real keys through.
         let scrubbed = LLMClient.scrubAPIKeyArtifacts(

--- a/Tests/MacParakeetTests/Services/YouTubeDownloaderTests.swift
+++ b/Tests/MacParakeetTests/Services/YouTubeDownloaderTests.swift
@@ -65,6 +65,21 @@ final class YouTubeDownloaderTests: XCTestCase {
         XCTAssertNil(YouTubeDownloader.parseDownloadProgressPercent(from: "some random log line"))
     }
 
+    func testFetchMetadataArgumentsTerminateOptionsBeforeURL() {
+        // AUDIT-074: every yt-dlp call site must end options with `--` so a
+        // leading-dash input can never be parsed as a flag.
+        let args = YouTubeDownloader.fetchMetadataArguments(
+            url: "https://www.youtube.com/watch?v=abc"
+        )
+
+        XCTAssertEqual(args, [
+            "--skip-download",
+            "--dump-json",
+            "--no-playlist",
+            "--", "https://www.youtube.com/watch?v=abc",
+        ])
+    }
+
     func testDownloadAudioArgumentsUseM4ASelector() {
         let args = YouTubeDownloader.downloadAudioArguments(
             ffmpegDir: "/opt/macparakeet/bin",


### PR DESCRIPTION
## Summary

Four small hardening items from the 2026-06-09 audit (`docs/audits/2026-06-09-codebase-audit.md`), one commit per finding — same playbook as the April audit's sprint PRs. All are latent defects (unreachable today) or doc gaps; none change user-visible behavior.

- **AUDIT-074** — `fetchMetadata` was the one yt-dlp call site missing the `--` options terminator that `downloadAudioArguments` has. Upstream URL validators already reject leading-dash strings, but argv discipline shouldn't depend on the caller. Args factored into a tested `fetchMetadataArguments(url:)`.
- **AUDIT-075** — Whisper engine creation now goes through `ensureWhisperEngine()` with the same `activeTranscriptionCount` busy-guard as `ensureNemotronEngine`. The scheduler's single background slot already serializes Whisper jobs; the guard keeps the invariant local.
- **AUDIT-076** — `scrubAPIKeyArtifacts`: `%` added to the Bearer / x-api-key / api-key / key= character classes so URL-encoded token echoes (`%2B`, `%3D`) can't escape scrubbing; bare `key=` floor lowered 20 → 16 chars. False-positive guard test locks `key=<word>` params staying readable.
- **AUDIT-080** — CLI CHANGELOG batch section now documents that a failing batch run with `--format json` emits the standard failure envelope on stdout (behavior was already contract-consistent; the batch section just didn't say so).

## Tests

New: `testFetchMetadataArgumentsTerminateOptionsBeforeURL`, 3 scrub tests (URL-encoded Bearer, 16-char key=, innocent-param false-positive guard). Full `swift test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)