### PR TITLE
Surface prompt-generation failures with Retry/Dismiss; raise Local CLI timeout to 300s

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -80,6 +80,15 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ## [Unreleased]
 
+### Changed
+
+- The Local CLI provider's default timeout is now **300 seconds** (was 45).
+  Long transcripts routed through CLI agents (`claude -p`, `codex exec`)
+  regularly exceed 45 s, which killed `llm`/`prompts run` generations
+  mid-flight (#478). Stored configs still carrying the old 45 s default are
+  migrated to 300 s once on first load; any value entered after that — 45
+  included — is preserved. Connection tests remain capped at 45 s.
+
 ## [2.8.0] -- 2026-06-09
 
 ### Added

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -214,13 +214,6 @@ final class AppEnvironmentConfigurer {
             self?.transcriptionViewModel.handleGenerationCompleted(generationID, promptResultID: promptResultID)
         }
 
-        promptResultsViewModel.onGenerationFailed = { [weak self] generationID, replacingPromptResultID in
-            self?.transcriptionViewModel.handleGenerationFailed(
-                generationID,
-                replacingPromptResultID: replacingPromptResultID
-            )
-        }
-
         promptResultsViewModel.onDeletedPromptResult = { [weak self] promptResultID in
             self?.transcriptionViewModel.handlePromptResultDeleted(promptResultID)
         }

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -1392,10 +1392,14 @@ struct TranscriptResultView: View {
         case .result:
             return "sparkles"
         case .generation(let id):
-            if promptResultsViewModel.pendingGeneration(id: id)?.state == .queued {
+            switch promptResultsViewModel.pendingGeneration(id: id)?.state {
+            case .queued:
                 return "clock"
+            case .failed:
+                return "exclamationmark.triangle"
+            default:
+                return "sparkles"
             }
-            return "sparkles"
         case .chat:
             return "bubble.left.and.text.bubble.right"
         }
@@ -1524,28 +1528,40 @@ struct TranscriptResultView: View {
     private func generationPane(_ generation: PromptResultsViewModel.PendingGeneration) -> some View {
         ScrollView {
             VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
-                HStack {
-                    Spacer()
-                    Button {
-                        showingCancelGenerationAlert = generation.id
-                    } label: {
-                        HStack(spacing: DesignSystem.Spacing.xs) {
-                            Image(systemName: generation.state == .queued ? "minus.circle" : "xmark")
-                            Text(generation.state == .queued ? "Remove" : "Cancel")
-                        }
-                        .font(DesignSystem.Typography.caption)
-                    }
-                    .parakeetAction(.secondary)
-                    .controlSize(.small)
-                }
+                if case .failed(let message) = generation.state {
+                    failedGenerationCard(generation, message: message)
 
-                if generation.state == .queued {
-                    queuedGenerationCard
-                } else if generation.content.isEmpty {
-                    SummarySkeletonView()
+                    // Partial content streamed before the failure is still
+                    // worth reading; dimmed so it reads as incomplete.
+                    if !generation.content.isEmpty {
+                        MarkdownContentView(generation.content, font: DesignSystem.Typography.bodyLarge)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .opacity(0.6)
+                    }
                 } else {
-                    MarkdownContentView(generation.content, font: DesignSystem.Typography.bodyLarge)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                    HStack {
+                        Spacer()
+                        Button {
+                            showingCancelGenerationAlert = generation.id
+                        } label: {
+                            HStack(spacing: DesignSystem.Spacing.xs) {
+                                Image(systemName: generation.state == .queued ? "minus.circle" : "xmark")
+                                Text(generation.state == .queued ? "Remove" : "Cancel")
+                            }
+                            .font(DesignSystem.Typography.caption)
+                        }
+                        .parakeetAction(.secondary)
+                        .controlSize(.small)
+                    }
+
+                    if generation.state == .queued {
+                        queuedGenerationCard
+                    } else if generation.content.isEmpty {
+                        SummarySkeletonView()
+                    } else {
+                        MarkdownContentView(generation.content, font: DesignSystem.Typography.bodyLarge)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -1576,6 +1592,50 @@ struct TranscriptResultView: View {
                  ? "This will remove the prompt from the generation queue."
                  : "This will stop the AI from generating the result.")
         }
+    }
+
+    private func failedGenerationCard(
+        _ generation: PromptResultsViewModel.PendingGeneration,
+        message: String
+    ) -> some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            Label("Generation failed", systemImage: "exclamationmark.triangle.fill")
+                .font(DesignSystem.Typography.caption.weight(.semibold))
+                .foregroundStyle(DesignSystem.Colors.errorRed)
+
+            Text(message)
+                .font(DesignSystem.Typography.body)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            HStack(spacing: DesignSystem.Spacing.sm) {
+                Button {
+                    if let newID = promptResultsViewModel.retryGeneration(id: generation.id) {
+                        viewModel.selectedTab = .generation(id: newID)
+                    }
+                } label: {
+                    Label("Retry", systemImage: "arrow.clockwise")
+                }
+                .parakeetAction(.primary)
+                .controlSize(.regular)
+
+                Button("Dismiss") {
+                    let replacingID = generation.replacingPromptResultID
+                    promptResultsViewModel.cancelGeneration(id: generation.id)
+                    viewModel.selectedTab = replacingID.map { .result(id: $0) } ?? .transcript
+                }
+                .parakeetAction(.secondary)
+                .controlSize(.regular)
+            }
+            .padding(.top, DesignSystem.Spacing.xs)
+        }
+        .padding(DesignSystem.Spacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
+                .fill(DesignSystem.Colors.surfaceElevated.opacity(0.7))
+        )
     }
 
     private var queuedGenerationCard: some View {
@@ -1615,7 +1675,7 @@ struct TranscriptResultView: View {
                     currentModel: promptResultsViewModel.currentModelName,
                     displayName: promptResultsViewModel.modelDisplayName,
                     availableModels: promptResultsViewModel.availableModels,
-                    disabled: promptResultsViewModel.hasPendingGenerations,
+                    disabled: promptResultsViewModel.hasActiveGenerations,
                     onSelect: { promptResultsViewModel.selectModel($0) }
                 )
             }
@@ -1625,7 +1685,7 @@ struct TranscriptResultView: View {
                 .textFieldStyle(.roundedBorder)
                 .font(DesignSystem.Typography.body)
 
-            if promptResultsViewModel.hasPendingGenerations {
+            if promptResultsViewModel.hasActiveGenerations {
                 Text(queueStatusText)
                     .font(DesignSystem.Typography.caption)
                     .foregroundStyle(DesignSystem.Colors.textSecondary)

--- a/Sources/MacParakeetCore/Services/LLM/LocalCLIExecutor.swift
+++ b/Sources/MacParakeetCore/Services/LLM/LocalCLIExecutor.swift
@@ -9,7 +9,13 @@ public struct LocalCLIConfig: Codable, Sendable, Equatable {
     public let timeoutSeconds: Double
 
     public static let minimumTimeout: Double = 5
-    public static let defaultTimeout: Double = 45
+    /// CLI agents (`claude -p`, `codex exec`) routinely need minutes for
+    /// long-transcript generations — meeting summaries over ~1h of audio
+    /// were killed by the previous 45s default (#478).
+    public static let defaultTimeout: Double = 300
+    /// Default before 2026-06 (#478). Stored configs carrying this exact
+    /// value are migrated once to `defaultTimeout` by `LocalCLIConfigStore`.
+    public static let legacyDefaultTimeout: Double = 45
 
     public init(commandTemplate: String, timeoutSeconds: Double = Self.defaultTimeout) {
         self.commandTemplate = commandTemplate
@@ -96,6 +102,7 @@ public enum LocalCLIError: Error, LocalizedError, Sendable {
 // @unchecked Sendable: UserDefaults is internally thread-safe
 public final class LocalCLIConfigStore: @unchecked Sendable {
     private static let configKey = "local_cli_config"
+    private static let timeoutMigrationKey = "local_cli_timeout_migrated_to_300"
     private let defaults: UserDefaults
 
     public init(defaults: UserDefaults = .standard) {
@@ -103,8 +110,24 @@ public final class LocalCLIConfigStore: @unchecked Sendable {
     }
 
     public func load() -> LocalCLIConfig? {
-        guard let data = defaults.data(forKey: Self.configKey) else { return nil }
-        return try? JSONDecoder().decode(LocalCLIConfig.self, from: data)
+        // One-shot migration: every config saved before #478 carries the old
+        // 45s default (the settings UI persisted it even when untouched), so
+        // an exact 45 on first post-update load is treated as "never chosen"
+        // and bumped. The flag is set on the first load regardless, so a 45
+        // explicitly entered afterwards sticks.
+        let needsTimeoutMigration = !defaults.bool(forKey: Self.timeoutMigrationKey)
+        if needsTimeoutMigration {
+            defaults.set(true, forKey: Self.timeoutMigrationKey)
+        }
+        guard let data = defaults.data(forKey: Self.configKey),
+              let config = try? JSONDecoder().decode(LocalCLIConfig.self, from: data)
+        else { return nil }
+        guard needsTimeoutMigration,
+              config.timeoutSeconds == LocalCLIConfig.legacyDefaultTimeout
+        else { return config }
+        let migrated = LocalCLIConfig(commandTemplate: config.commandTemplate)
+        try? save(migrated)
+        return migrated
     }
 
     public func save(_ config: LocalCLIConfig) throws {
@@ -237,12 +260,23 @@ public final class LocalCLIExecutor: Sendable {
         )
     }
 
+    /// Connection tests use a trivial prompt, so a hung command should not
+    /// pin the settings UI for the full (now minutes-long) generation timeout.
+    static let testConnectionTimeoutCap: Double = 45
+
+    static func testConnectionConfig(for config: LocalCLIConfig) -> LocalCLIConfig {
+        LocalCLIConfig(
+            commandTemplate: config.commandTemplate,
+            timeoutSeconds: min(config.timeoutSeconds, testConnectionTimeoutCap)
+        )
+    }
+
     /// Quick test: runs the configured command with a minimal prompt.
     public func testConnection(config: LocalCLIConfig) async throws {
         let output = try await execute(
             systemPrompt: "You are a helpful assistant.",
             userPrompt: "Reply with OK",
-            config: config
+            config: Self.testConnectionConfig(for: config)
         )
         guard !output.isEmpty else {
             throw LocalCLIError.emptyOutput

--- a/Sources/MacParakeetViewModels/PromptResultsViewModel.swift
+++ b/Sources/MacParakeetViewModels/PromptResultsViewModel.swift
@@ -9,6 +9,18 @@ public final class PromptResultsViewModel {
         public enum State: Equatable, Sendable {
             case queued
             case streaming
+            /// Terminal: the generation errored. The entry stays in
+            /// `pendingGenerations` so its tab can show the error with
+            /// Retry/Dismiss — removing it on failure made errors look
+            /// like a silent revert to the Transcript tab (#478).
+            case failed(message: String)
+
+            public var isActive: Bool {
+                switch self {
+                case .queued, .streaming: return true
+                case .failed: return false
+                }
+            }
         }
 
         public var id: UUID
@@ -69,7 +81,6 @@ public final class PromptResultsViewModel {
     public var onModelChanged: (() -> Void)?
     public var onPromptResultsChanged: ((UUID, Bool) -> Void)?
     public var onGenerationCompleted: ((UUID, UUID) -> Void)?
-    public var onGenerationFailed: ((UUID, UUID?) -> Void)?
     public var onDeletedPromptResult: ((UUID) -> Void)?
     public var shouldMarkPromptResultUnread: ((UUID) -> Bool)?
 
@@ -103,6 +114,13 @@ public final class PromptResultsViewModel {
 
     public var hasPendingGenerations: Bool {
         !pendingGenerations.isEmpty
+    }
+
+    /// Queued or streaming — excludes failed entries, which only wait for
+    /// the user to retry or dismiss and should not block model switching
+    /// or read as in-flight work.
+    public var hasActiveGenerations: Bool {
+        pendingGenerations.contains { $0.state.isActive }
     }
 
     public var isStreaming: Bool {
@@ -190,7 +208,7 @@ public final class PromptResultsViewModel {
     }
 
     public func selectModel(_ modelName: String) {
-        guard let configStore, currentProviderID != .localCLI, !hasPendingGenerations else { return }
+        guard let configStore, currentProviderID != .localCLI, !hasActiveGenerations else { return }
         do {
             try configStore.updateModelName(modelName)
             currentModelName = modelName
@@ -265,6 +283,7 @@ public final class PromptResultsViewModel {
     public func hasPendingGeneration(promptName: String, transcriptionId: UUID) -> Bool {
         pendingGenerations.contains {
             $0.transcriptionId == transcriptionId && $0.promptName == promptName
+                && $0.state.isActive
         }
     }
 
@@ -514,16 +533,36 @@ public final class PromptResultsViewModel {
 
     private func finishFailedGeneration(id generationID: UUID, error: Error) {
         logger.error("Failed to generate prompt result error=\(error.localizedDescription, privacy: .public)")
-        let replacingPromptResultID = pendingGenerations
-            .first(where: { $0.id == generationID })?
-            .replacingPromptResultID
         if let index = pendingGenerations.firstIndex(where: { $0.id == generationID }) {
-            pendingGenerations.remove(at: index)
+            pendingGenerations[index].state = .failed(message: error.localizedDescription)
         }
         streamingTask = nil
         errorMessage = error.localizedDescription
-        onGenerationFailed?(generationID, replacingPromptResultID)
         processNextQueuedGeneration()
+    }
+
+    /// Re-enqueue a failed generation with the same inputs it was originally
+    /// captured with (transcript, notes snapshot, replace target). Returns
+    /// the new generation's ID so the caller can keep its tab selected.
+    @discardableResult
+    public func retryGeneration(id: UUID) -> UUID? {
+        guard let index = pendingGenerations.firstIndex(where: { $0.id == id }),
+              case .failed = pendingGenerations[index].state
+        else { return nil }
+        let failed = pendingGenerations.remove(at: index)
+        return enqueueGeneration(
+            transcript: failed.transcript,
+            transcriptionId: failed.transcriptionId,
+            prompt: Prompt(
+                name: failed.promptName,
+                content: failed.promptContent,
+                isBuiltIn: false,
+                sortOrder: 0
+            ),
+            extraInstructions: failed.extraInstructions,
+            userNotes: failed.userNotes,
+            replacingPromptResultID: failed.replacingPromptResultID
+        )
     }
 
     private func assembledSystemPrompt(

--- a/Sources/MacParakeetViewModels/PromptResultsViewModel.swift
+++ b/Sources/MacParakeetViewModels/PromptResultsViewModel.swift
@@ -546,7 +546,10 @@ public final class PromptResultsViewModel {
     /// the new generation's ID so the caller can keep its tab selected.
     @discardableResult
     public func retryGeneration(id: UUID) -> UUID? {
-        guard let index = pendingGenerations.firstIndex(where: { $0.id == id }),
+        // llmService gates enqueueGeneration; checking it before removal
+        // keeps the failed card (and its error) when retry can't start.
+        guard llmService != nil,
+              let index = pendingGenerations.firstIndex(where: { $0.id == id }),
               case .failed = pendingGenerations[index].state
         else { return nil }
         let failed = pendingGenerations.remove(at: index)

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -155,15 +155,6 @@ public final class TranscriptionViewModel {
         selectedTab = .result(id: promptResultID)
     }
 
-    public func handleGenerationFailed(_ generationID: UUID, replacingPromptResultID: UUID?) {
-        guard case .generation(let selectedID) = selectedTab, selectedID == generationID else { return }
-        if let replacingPromptResultID {
-            selectedTab = .result(id: replacingPromptResultID)
-        } else {
-            selectedTab = .transcript
-        }
-    }
-
     private var transcriptionService: TranscriptionServiceProtocol?
     private var transcriptionRepo: TranscriptionRepositoryProtocol?
     private var promptResultRepo: PromptResultRepositoryProtocol?

--- a/Tests/CLITests/ModelLifecycleCommandTests.swift
+++ b/Tests/CLITests/ModelLifecycleCommandTests.swift
@@ -454,16 +454,25 @@ final class ModelLifecycleCommandTests: XCTestCase {
         XCTAssertEqual(diarizationCalls, 1)
     }
 
-    func testLoadSpeechStackStatusReflectsSpeechAndSpeakerReadinessSeparately() async {
+    func testLoadSpeechStackStatusReflectsSpeechAndSpeakerReadinessSeparately() async throws {
         let stt = StubSTTClient()
         let diarization = StubDiarizationService()
         await stt.setReady(true)
         await diarization.setCachedModels(false)
         await diarization.setReady(false)
 
+        // Isolated suite: without it the status reads the live app's
+        // preferences, so the test result depends on whichever speech
+        // engine the developer's MacParakeet install has selected.
+        let suiteName = "com.macparakeet.tests.cli.models.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
         let status = await loadSpeechStackStatus(
             sttClient: stt,
             diarizationService: diarization,
+            defaults: defaults,
             isParakeetModelCached: { $0 == .v3 },
             nemotronModelVariant: .multilingual1120,
             isNemotronModelDownloaded: { $0 == .multilingual1120 },

--- a/Tests/MacParakeetTests/Services/LLM/LLMExecutionContextResolverTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMExecutionContextResolverTests.swift
@@ -35,7 +35,7 @@ final class LLMExecutionContextResolverTests: XCTestCase {
         try cliConfigStore.save(
             LocalCLIConfig(
                 commandTemplate: "codex exec --skip-git-repo-check --model gpt-5.4-mini",
-                timeoutSeconds: 45
+                timeoutSeconds: 90
             )
         )
 
@@ -50,6 +50,6 @@ final class LLMExecutionContextResolverTests: XCTestCase {
             context?.localCLIConfig?.commandTemplate,
             "codex exec --skip-git-repo-check --model gpt-5.4-mini"
         )
-        XCTAssertEqual(context?.localCLIConfig?.timeoutSeconds, 45)
+        XCTAssertEqual(context?.localCLIConfig?.timeoutSeconds, 90)
     }
 }

--- a/Tests/MacParakeetTests/Services/LLM/LocalCLIExecutorTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LocalCLIExecutorTests.swift
@@ -62,11 +62,72 @@ final class LocalCLIExecutorTests: XCTestCase {
     }
 
     func testDefaultTimeoutAndTimeoutDescription() {
-        XCTAssertEqual(LocalCLIConfig.defaultTimeout, 45)
+        XCTAssertEqual(LocalCLIConfig.defaultTimeout, 300)
+        XCTAssertEqual(LocalCLIConfig.legacyDefaultTimeout, 45)
         XCTAssertEqual(
             LocalCLIError.timeout(seconds: LocalCLIConfig.defaultTimeout).errorDescription,
-            "Timed out after 45s. Verify the command runs successfully in a terminal and is logged in if required."
+            "Timed out after 300s. Verify the command runs successfully in a terminal and is logged in if required."
         )
+    }
+
+    func testConfigStoreMigratesLegacyDefaultTimeoutOnFirstLoad() throws {
+        let defaults = UserDefaults(suiteName: "test.localcli.\(UUID().uuidString)")!
+        let store = LocalCLIConfigStore(defaults: defaults)
+
+        // Simulate a pre-#478 store: a config saved with the old 45s default,
+        // never loaded under the new version.
+        try store.save(
+            LocalCLIConfig(commandTemplate: "codex exec --skip-git-repo-check", timeoutSeconds: 45)
+        )
+
+        let migrated = store.load()
+        XCTAssertEqual(migrated?.timeoutSeconds, LocalCLIConfig.defaultTimeout)
+        XCTAssertEqual(migrated?.commandTemplate, "codex exec --skip-git-repo-check")
+
+        // The migrated value is persisted, not just returned.
+        XCTAssertEqual(store.load()?.timeoutSeconds, LocalCLIConfig.defaultTimeout)
+
+        // 45 entered after the migration is an explicit choice and sticks.
+        try store.save(
+            LocalCLIConfig(commandTemplate: "codex exec --skip-git-repo-check", timeoutSeconds: 45)
+        )
+        XCTAssertEqual(store.load()?.timeoutSeconds, 45)
+    }
+
+    func testConfigStoreDoesNotMigrateNonDefaultLegacyTimeout() throws {
+        let defaults = UserDefaults(suiteName: "test.localcli.\(UUID().uuidString)")!
+        let store = LocalCLIConfigStore(defaults: defaults)
+
+        try store.save(
+            LocalCLIConfig(commandTemplate: "claude -p --model haiku", timeoutSeconds: 60)
+        )
+
+        XCTAssertEqual(store.load()?.timeoutSeconds, 60)
+    }
+
+    func testConfigStoreEmptyLoadConsumesMigrationWindow() throws {
+        let defaults = UserDefaults(suiteName: "test.localcli.\(UUID().uuidString)")!
+        let store = LocalCLIConfigStore(defaults: defaults)
+
+        // A load with no stored config marks the store as post-#478: a 45
+        // saved afterwards was typed under the new default and is preserved.
+        XCTAssertNil(store.load())
+        try store.save(
+            LocalCLIConfig(commandTemplate: "claude -p --model haiku", timeoutSeconds: 45)
+        )
+        XCTAssertEqual(store.load()?.timeoutSeconds, 45)
+    }
+
+    func testTestConnectionConfigCapsTimeout() {
+        let slow = LocalCLIConfig(commandTemplate: "codex exec", timeoutSeconds: 300)
+        XCTAssertEqual(
+            LocalCLIExecutor.testConnectionConfig(for: slow).timeoutSeconds,
+            LocalCLIExecutor.testConnectionTimeoutCap
+        )
+
+        let fast = LocalCLIConfig(commandTemplate: "codex exec", timeoutSeconds: 10)
+        XCTAssertEqual(LocalCLIExecutor.testConnectionConfig(for: fast).timeoutSeconds, 10)
+        XCTAssertEqual(LocalCLIExecutor.testConnectionConfig(for: fast).commandTemplate, "codex exec")
     }
 
     // MARK: - Templates

--- a/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
@@ -969,7 +969,7 @@ final class LLMSettingsViewModelTests: XCTestCase {
         let defaults = UserDefaults(suiteName: "test.vm.\(UUID().uuidString)")!
         let cliStore = LocalCLIConfigStore(defaults: defaults)
         try cliStore.save(
-            LocalCLIConfig(commandTemplate: "claude -p --model haiku", timeoutSeconds: 45)
+            LocalCLIConfig(commandTemplate: "claude -p --model haiku", timeoutSeconds: 90)
         )
         mockConfigStore.config = .localCLI()
         viewModel.configure(configStore: mockConfigStore, llmClient: mockClient, cliConfigStore: cliStore)
@@ -1256,7 +1256,7 @@ final class LLMSettingsViewModelTests: XCTestCase {
         try cliStore.save(
             LocalCLIConfig(
                 commandTemplate: "claude -p --model haiku",
-                timeoutSeconds: 45
+                timeoutSeconds: 90
             )
         )
         mockConfigStore.config = .localCLI()
@@ -1266,7 +1266,7 @@ final class LLMSettingsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedProviderID, .localCLI)
         XCTAssertEqual(viewModel.commandTemplate, "claude -p --model haiku")
         XCTAssertEqual(viewModel.selectedCLITemplate, .claudeCode)
-        XCTAssertEqual(viewModel.cliTimeoutSeconds, 45)
+        XCTAssertEqual(viewModel.cliTimeoutSeconds, 90)
     }
 
     func testLocalCLICanSaveWithCommand() {

--- a/Tests/MacParakeetTests/ViewModels/PromptResultsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/PromptResultsViewModelTests.swift
@@ -130,7 +130,15 @@ final class PromptResultsViewModelTests: XCTestCase {
 
         XCTAssertTrue(promptResultRepo.saveCalls.isEmpty)
         XCTAssertTrue(viewModel.promptResults.isEmpty)
-        XCTAssertTrue(viewModel.pendingGenerations.isEmpty)
+        // The failed generation stays visible so its tab can show the error
+        // with Retry/Dismiss instead of silently disappearing (#478).
+        XCTAssertEqual(viewModel.pendingGenerations.count, 1)
+        guard case .failed(let message) = viewModel.pendingGenerations.first?.state else {
+            return XCTFail("Expected generation to be marked failed")
+        }
+        XCTAssertTrue(message.contains("empty response"))
+        XCTAssertFalse(viewModel.hasActiveGenerations)
+        XCTAssertTrue(viewModel.hasPendingGenerations)
         XCTAssertTrue(viewModel.errorMessage?.contains("empty response") == true)
     }
 
@@ -170,6 +178,11 @@ final class PromptResultsViewModelTests: XCTestCase {
         XCTAssertEqual(promptResultRepo.saveCalls.first?.promptName, "Decisions")
         XCTAssertEqual(promptResultRepo.saveCalls.first?.content, "Recovered")
         XCTAssertNil(viewModel.errorMessage)
+        // The first generation's failure must not block the queued second
+        // one, and it remains visible as a failed entry afterwards.
+        XCTAssertEqual(viewModel.pendingGenerations.count, 1)
+        XCTAssertEqual(viewModel.pendingGenerations.first?.promptName, "Action Items")
+        XCTAssertFalse(viewModel.hasActiveGenerations)
     }
 
     func testUnreadPromptResultsTrackMultipleCompletedResults() async throws {
@@ -257,7 +270,7 @@ final class PromptResultsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.promptResults.first?.id, generationID)
     }
 
-    func testRegenerateEmptyStreamKeepsExistingResultAndReportsFailedGeneration() async throws {
+    func testRegenerateEmptyStreamKeepsExistingResultAndMarksGenerationFailed() async throws {
         let transcriptionID = UUID()
         let existing = PromptResult(
             transcriptionId: transcriptionID,
@@ -274,10 +287,6 @@ final class PromptResultsViewModelTests: XCTestCase {
         )
         viewModel.loadPromptResults(transcriptionId: transcriptionID)
         llm.streamTokens = []
-        var failedGeneration: (UUID, UUID?)?
-        viewModel.onGenerationFailed = { generationID, replacingPromptResultID in
-            failedGeneration = (generationID, replacingPromptResultID)
-        }
 
         let generationID = try XCTUnwrap(viewModel.regeneratePromptResult(existing, transcript: "Transcript"))
 
@@ -290,9 +299,111 @@ final class PromptResultsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.promptResults.count, 1)
         XCTAssertEqual(viewModel.promptResults.first?.id, existing.id)
         XCTAssertEqual(viewModel.promptResults.first?.content, "Old summary")
-        XCTAssertEqual(failedGeneration?.0, generationID)
-        XCTAssertEqual(failedGeneration?.1, existing.id)
+        let failed = try XCTUnwrap(viewModel.pendingGeneration(id: generationID))
+        guard case .failed(let message) = failed.state else {
+            return XCTFail("Expected regeneration to be marked failed")
+        }
+        XCTAssertTrue(message.contains("empty response"))
+        XCTAssertEqual(failed.replacingPromptResultID, existing.id)
         XCTAssertTrue(viewModel.errorMessage?.contains("empty response") == true)
+    }
+
+    func testStreamErrorMarksGenerationFailedWithProviderMessage() async throws {
+        viewModel.configure(
+            llmService: llm,
+            promptRepo: promptRepo,
+            promptResultRepo: promptResultRepo
+        )
+        llm.errorToThrow = LLMError.cliError(
+            "Timed out after 45s. Verify the command runs successfully in a terminal and is logged in if required."
+        )
+
+        let generationID = try XCTUnwrap(
+            viewModel.generatePromptResult(transcript: "Transcript", transcriptionId: UUID())
+        )
+
+        try await Task.sleep(for: .milliseconds(200))
+
+        let failed = try XCTUnwrap(viewModel.pendingGeneration(id: generationID))
+        guard case .failed(let message) = failed.state else {
+            return XCTFail("Expected generation to be marked failed")
+        }
+        XCTAssertTrue(message.contains("Timed out after 45s"))
+        XCTAssertTrue(promptResultRepo.saveCalls.isEmpty)
+    }
+
+    func testRetryGenerationReEnqueuesFailedGenerationWithSameInputs() async throws {
+        let transcriptionID = UUID()
+        let existing = PromptResult(
+            transcriptionId: transcriptionID,
+            promptName: "General Summary",
+            promptContent: Prompt.defaultPrompt.content,
+            content: "Old summary"
+        )
+        promptResultRepo.promptResults = [existing]
+
+        viewModel.configure(
+            llmService: llm,
+            promptRepo: promptRepo,
+            promptResultRepo: promptResultRepo
+        )
+        viewModel.loadPromptResults(transcriptionId: transcriptionID)
+        llm.streamTokenBatches = [[], ["Recovered"]]
+
+        let failedID = try XCTUnwrap(viewModel.regeneratePromptResult(existing, transcript: "Transcript"))
+        try await Task.sleep(for: .milliseconds(200))
+        guard case .failed = viewModel.pendingGeneration(id: failedID)?.state else {
+            return XCTFail("Expected first attempt to fail")
+        }
+
+        let retriedID = try XCTUnwrap(viewModel.retryGeneration(id: failedID))
+        XCTAssertNotEqual(retriedID, failedID)
+        XCTAssertNil(viewModel.pendingGeneration(id: failedID))
+
+        try await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertTrue(viewModel.pendingGenerations.isEmpty)
+        XCTAssertEqual(promptResultRepo.replaceCalls.count, 1)
+        XCTAssertEqual(promptResultRepo.replaceCalls[0].deletingExistingID, existing.id)
+        XCTAssertEqual(viewModel.promptResults.first?.content, "Recovered")
+        XCTAssertNil(viewModel.errorMessage)
+    }
+
+    func testRetryGenerationIgnoresActiveGenerations() throws {
+        viewModel.configure(
+            llmService: llm,
+            promptRepo: promptRepo,
+            promptResultRepo: promptResultRepo
+        )
+        llm.streamDelayNs = 1_000_000_000
+
+        let generationID = try XCTUnwrap(
+            viewModel.generatePromptResult(transcript: "Transcript", transcriptionId: UUID())
+        )
+
+        XCTAssertNil(viewModel.retryGeneration(id: generationID))
+        XCTAssertEqual(viewModel.pendingGenerations.count, 1)
+    }
+
+    func testCancelGenerationRemovesFailedGeneration() async throws {
+        viewModel.configure(
+            llmService: llm,
+            promptRepo: promptRepo,
+            promptResultRepo: promptResultRepo
+        )
+        llm.streamTokens = []
+
+        let generationID = try XCTUnwrap(
+            viewModel.generatePromptResult(transcript: "Transcript", transcriptionId: UUID())
+        )
+        try await Task.sleep(for: .milliseconds(200))
+        guard case .failed = viewModel.pendingGeneration(id: generationID)?.state else {
+            return XCTFail("Expected generation to be marked failed")
+        }
+
+        viewModel.cancelGeneration(id: generationID)
+
+        XCTAssertTrue(viewModel.pendingGenerations.isEmpty)
     }
 
     func testDeletePromptResultRemovesResultAndKeepsRemainingPromptResults() throws {

--- a/Tests/MacParakeetTests/ViewModels/PromptResultsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/PromptResultsViewModelTests.swift
@@ -369,6 +369,34 @@ final class PromptResultsViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.errorMessage)
     }
 
+    func testRetryGenerationKeepsFailedEntryWhenLLMServiceIsGone() async throws {
+        viewModel.configure(
+            llmService: llm,
+            promptRepo: promptRepo,
+            promptResultRepo: promptResultRepo
+        )
+        llm.streamTokens = []
+
+        let generationID = try XCTUnwrap(
+            viewModel.generatePromptResult(transcript: "Transcript", transcriptionId: UUID())
+        )
+        try await Task.sleep(for: .milliseconds(200))
+        guard case .failed = viewModel.pendingGeneration(id: generationID)?.state else {
+            return XCTFail("Expected generation to be marked failed")
+        }
+
+        viewModel.configure(
+            llmService: nil,
+            promptRepo: promptRepo,
+            promptResultRepo: promptResultRepo
+        )
+
+        // Retry can't start without a service — the failed card (and its
+        // error message) must survive instead of being silently removed.
+        XCTAssertNil(viewModel.retryGeneration(id: generationID))
+        XCTAssertNotNil(viewModel.pendingGeneration(id: generationID))
+    }
+
     func testRetryGenerationIgnoresActiveGenerations() throws {
         viewModel.configure(
             llmService: llm,
@@ -500,6 +528,30 @@ final class PromptResultsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.hasPendingGenerations)
         XCTAssertEqual(viewModel.queuedGenerationCount, 0)
         XCTAssertNil(viewModel.streamingPromptResultID)
+    }
+
+    func testLoadPromptResultsClearsFailedGenerationsWhenSwitchingTranscriptions() async throws {
+        viewModel.configure(
+            llmService: llm,
+            promptRepo: promptRepo,
+            promptResultRepo: promptResultRepo
+        )
+        llm.streamTokens = []
+
+        let generationID = try XCTUnwrap(
+            viewModel.generatePromptResult(transcript: "Transcript", transcriptionId: UUID())
+        )
+        try await Task.sleep(for: .milliseconds(200))
+        guard case .failed = viewModel.pendingGeneration(id: generationID)?.state else {
+            return XCTFail("Expected generation to be marked failed")
+        }
+
+        // Failure feedback is scoped to the visit, like every other pending
+        // generation: navigating to another transcription drops it rather
+        // than resurfacing a stale error on the next visit.
+        viewModel.loadPromptResults(transcriptionId: UUID())
+
+        XCTAssertTrue(viewModel.pendingGenerations.isEmpty)
     }
 
     func testAutoGeneratePromptResultsDoesNothingWhenNoAutoRunPromptsAreEnabled() {

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -945,25 +945,6 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.hasConversations)
     }
 
-    func testFailedRegenerationRestoresOriginalResultTab() {
-        let generationID = UUID()
-        let promptResultID = UUID()
-        viewModel.selectedTab = .generation(id: generationID)
-
-        viewModel.handleGenerationFailed(generationID, replacingPromptResultID: promptResultID)
-
-        XCTAssertEqual(viewModel.selectedTab, .result(id: promptResultID))
-    }
-
-    func testFailedNewGenerationFallsBackToTranscriptTab() {
-        let generationID = UUID()
-        viewModel.selectedTab = .generation(id: generationID)
-
-        viewModel.handleGenerationFailed(generationID, replacingPromptResultID: nil)
-
-        XCTAssertEqual(viewModel.selectedTab, .transcript)
-    }
-
     // MARK: - File Drop
 
     func testHandleFileDropReturnsFalseWhenAlreadyTranscribing() {


### PR DESCRIPTION
Fixes #478.

## What broke for the user

With the **Local CLI → Codex** preset configured, generating a Summary on a 1:00:55 / 8,721-word meeting showed the streaming spinner, then silently snapped back to the Transcript tab. No error, no trace, no Summary.

Two stacked bugs:

1. **Failures were invisible.** On any generation error, the pending tab was removed, the view flipped back to Transcript, and the error text only rendered inside the Generate popover — which closed the moment Generate was clicked. The (genuinely helpful) timeout message was never seen by anyone.
2. **The Local CLI default timeout (45s) doesn't fit real workloads.** `codex exec` on the exact preset command with an 8.7k-word transcript measured ~18s *best-case* (M4 Pro, warm install, trivial content). Real meetings + reasoning effort + provider retries regularly exceed 45s, which `SIGKILL`ed the CLI mid-generation. Test Connection passes (tiny prompt), so the config looks healthy right up until the first long meeting.

## The fix

**Visible failures with Retry/Dismiss.** `PendingGeneration` gains a `.failed(message:)` state. The generation stays in place; its tab persists (warning icon) and shows a failure card with the provider's error text, a **Retry** button (re-enqueues with the same captured transcript/notes/replace-target — ADR-020 snapshot semantics preserved), and **Dismiss** (returns to the replaced result or transcript). Partial streamed content stays readable, dimmed. Failed entries don't block the queue, model switching, or prompt chips (`hasActiveGenerations` vs `hasPendingGenerations`).

**Timeout default 45s → 300s, with one-shot migration.** Every pre-existing Local CLI config carries a stored 45 because the settings UI persisted the default even when untouched. On first load under the new version, an exact 45 is migrated to 300 once (flag-keyed); any value entered afterwards — 45 included — sticks. **Test Connection stays capped at 45s** so a hung command can't pin the settings UI for five minutes.

## How it would have played out for the #478 reporter

Worst case the summary now gets 300s to finish (it measured well under that); and if anything still fails, the tab stays put and says exactly what happened — e.g. *"Timed out after 300s. Verify the command runs successfully in a terminal…"* — with a Retry button.

## Also in this PR

- `Tests/CLITests/ModelLifecycleCommandTests.swift` (separate commit): `loadSpeechStackStatus` test read the **live app's** preferences instead of an injected suite — it failed on any machine whose installed MacParakeet has a non-Parakeet engine selected. Now uses an isolated scratch suite like its sibling test.
- `Sources/CLI/CHANGELOG.md`: Unreleased note for the timeout default change (affects `llm` / `prompts run` with the Local CLI provider).

## Testing

- Full suite: **3,522 tests, 0 failures** (10 skipped, pre-existing).
- New coverage: failed-state retention + message, queue continues past a failed entry, retry re-enqueues with identical inputs (incl. regeneration replace-target), retry refuses active generations, dismiss removal, config-store migration matrix (legacy 45 migrates once + persists; post-migration 45 sticks; non-45 untouched; empty-store load consumes the migration window), test-connection cap.
- Legacy-45 fixtures in unrelated tests moved to 90 so they keep testing what they were written to test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)