### PR TITLE
Discard instant-dictation pre-roll when media pause confirms playback (#474)

### DIFF
--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -889,8 +889,21 @@ final class DictationFlowCoordinator {
                 // capture start, or its out-of-process now-playing lookup
                 // clips the first words of the dictation. The coordinator's
                 // generation guard keeps resume correct if capture ends before
-                // the pause settles.
-                self.mediaPauseCoordinator.requestPauseBeforeDictationCapture()
+                // the pause settles. When the round-trip confirms media was
+                // playing, the instant-dictation pre-roll is pre-press media
+                // audio that no pause can silence — discard it (issue #474).
+                // Best-effort by design: if the round-trip settles after the
+                // capture stopped, the session guard drops the request.
+                self.mediaPauseCoordinator.requestPauseBeforeDictationCapture(
+                    onMediaPaused: { [weak self] in
+                        guard let self else { return }
+                        Task {
+                            await self.serviceSession.discardPreRollForActiveCapture(
+                                sessionID: sessionID
+                            )
+                        }
+                    }
+                )
                 try Task.checkCancellation()
                 try await self.serviceSession.startRecording(
                     sessionID: sessionID,

--- a/Sources/MacParakeet/App/DictationMediaPauseCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationMediaPauseCoordinator.swift
@@ -5,9 +5,20 @@ import OSLog
 
 @MainActor
 protocol DictationMediaPauseCoordinating: AnyObject {
-    func requestPauseBeforeDictationCapture()
+    /// `onMediaPaused` fires (on the MainActor) when the now-playing
+    /// round-trip confirms media was playing and the pause command was sent —
+    /// and only while this capture's pause request is still current. Callers
+    /// use it to discard the instant-dictation pre-roll, which by then is
+    /// known to contain pre-press media audio (issue #474).
+    func requestPauseBeforeDictationCapture(onMediaPaused: (@MainActor () -> Void)?)
     func resumeAfterDictationCapture() async
     func resumeForTermination()
+}
+
+extension DictationMediaPauseCoordinating {
+    func requestPauseBeforeDictationCapture() {
+        requestPauseBeforeDictationCapture(onMediaPaused: nil)
+    }
 }
 
 @MainActor
@@ -50,7 +61,7 @@ final class DictationMediaPauseCoordinator: DictationMediaPauseCoordinating {
     /// round-trip that previously front-loaded hundreds of milliseconds onto
     /// every dictation press and clipped the first words — runs in the
     /// detached child task, concurrently with audio capture start.
-    func requestPauseBeforeDictationCapture() {
+    func requestPauseBeforeDictationCapture(onMediaPaused: (@MainActor () -> Void)?) {
         generation += 1
         let pauseGeneration = generation
 
@@ -69,6 +80,7 @@ final class DictationMediaPauseCoordinator: DictationMediaPauseCoordinating {
 
         guard !isMeetingRecordingActive() else {
             Self.logger.notice("media_pause_skipped reason=meeting_active")
+            AudioCaptureDiagnostics.append("media_pause_skipped reason=meeting_active")
             return
         }
 
@@ -82,12 +94,15 @@ final class DictationMediaPauseCoordinator: DictationMediaPauseCoordinating {
             // cancelled) while the round-trip was in flight: release the token
             // instead of arming a pause nobody will resume. The generation
             // check is the authoritative guard; the cancellation check is a
-            // best-effort fast path.
+            // best-effort fast path. `onMediaPaused` must not fire here: this
+            // capture is over, and discarding pre-roll now could hit a newer
+            // session that this request knows nothing about.
             guard !Task.isCancelled, self.generation == pauseGeneration else {
                 await self.mediaController.resume(token)
                 return
             }
             self.activeToken = token
+            onMediaPaused?()
         }
     }
 
@@ -116,7 +131,7 @@ final class DictationMediaPauseCoordinator: DictationMediaPauseCoordinating {
 
 @MainActor
 final class NoOpDictationMediaPauseCoordinator: DictationMediaPauseCoordinating {
-    func requestPauseBeforeDictationCapture() {}
+    func requestPauseBeforeDictationCapture(onMediaPaused: (@MainActor () -> Void)?) {}
     func resumeAfterDictationCapture() async {}
     func resumeForTermination() {}
 }

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -1004,7 +1004,7 @@ struct SettingsView: View {
 
                 settingsToggleRow(
                     title: "Pause media while dictating",
-                    detail: "Pauses playing media during dictation and resumes it when capture stops.",
+                    detail: "Pauses playing media during dictation and resumes it when capture stops. On speakers, a moment of media sound can reach the mic before the pause lands — speak as you press, or use headphones.",
                     isBeta: true,
                     isOn: $viewModel.pauseMediaDuringDictation
                 )

--- a/Sources/MacParakeetCore/Audio/AudioProcessor.swift
+++ b/Sources/MacParakeetCore/Audio/AudioProcessor.swift
@@ -45,6 +45,10 @@ public actor AudioProcessor: AudioProcessorProtocol {
         try await recorder.stop()
     }
 
+    public func discardPreRollForActiveCapture() async {
+        await recorder.discardPreRollForActiveRecording()
+    }
+
     public func setInstantDictationEnabled(_ enabled: Bool) async {
         await recorder.setInstantDictationEnabled(enabled)
     }

--- a/Sources/MacParakeetCore/Audio/AudioProcessorProtocol.swift
+++ b/Sources/MacParakeetCore/Audio/AudioProcessorProtocol.swift
@@ -18,6 +18,18 @@ public protocol AudioProcessorProtocol: Sendable {
 
     /// Device info from the most recent recording (name, transport, format, fallback status).
     var recordingDeviceInfo: RecordingDeviceInfo? { get async }
+
+    /// Discard the instant-dictation pre-roll from the active capture (no-op
+    /// when idle or when no pre-roll was prepended). Called when system media
+    /// was confirmed playing at dictation start, so the pre-roll is known to
+    /// be pre-press media audio (issue #474).
+    func discardPreRollForActiveCapture() async
+}
+
+public extension AudioProcessorProtocol {
+    /// Capture-only implementations (file converters, test doubles) have no
+    /// pre-roll; discarding is a no-op unless a conformer opts in.
+    func discardPreRollForActiveCapture() async {}
 }
 
 public enum AudioProcessorError: Error, LocalizedError {

--- a/Sources/MacParakeetCore/Audio/AudioRecorder.swift
+++ b/Sources/MacParakeetCore/Audio/AudioRecorder.swift
@@ -743,9 +743,13 @@ public actor AudioRecorder {
         to destinationURL: URL
     ) throws {
         let source = try AVAudioFile(forReading: sourceURL)
+        // fileFormat, not processingFormat: the copy must preserve the
+        // on-disk format. Identical for today's Float32 mono WAVs, but
+        // processingFormat would silently reformat the copy if the recording
+        // format ever changed (e.g. Int16).
         let writer = try AVAudioFile(
             forWriting: destinationURL,
-            settings: source.processingFormat.settings
+            settings: source.fileFormat.settings
         )
         source.framePosition = AVAudioFramePosition(frames)
         var remaining = max(0, source.length - AVAudioFramePosition(frames))

--- a/Sources/MacParakeetCore/Audio/AudioRecorder.swift
+++ b/Sources/MacParakeetCore/Audio/AudioRecorder.swift
@@ -174,6 +174,17 @@ public actor AudioRecorder {
     private var outputURL: URL?
     private var recording = false
     private var starting = false
+    /// Frames of instant-dictation pre-roll prepended to the current
+    /// recording's WAV. Reset at every `start()` entry; read by `stop()` to
+    /// trim the file head when `discardPreRollRequested` is set.
+    private var preRollFramesWritten = 0
+    /// Set via `discardPreRollForActiveRecording()` when system media was
+    /// confirmed playing at dictation start — the pre-roll is then known to
+    /// be pre-press media audio that no media pause can silence (issue #474).
+    /// Best-effort: requests that arrive outside an active/starting session
+    /// are dropped, and `start()` resets the flag so a stale request can
+    /// never trim a later session's pre-roll.
+    private var discardPreRollRequested = false
     /// Bumped on every `start()` entry that passes the entry guard. Each call
     /// captures its value as `myStartCallGeneration`; the `defer` only clears
     /// `starting` if no newer call has claimed the slot. Without this, an
@@ -333,6 +344,11 @@ public actor AudioRecorder {
         self.firstBufferLogged.withLock { $0 = false }
         self.runtimeMetrics.withLock { $0 = RecordingRuntimeMetrics() }
         self.sampleCounter.withLock { $0 = 0 }
+        // This synchronous section has no suspension points, so a discard
+        // request for *this* session cannot interleave before the reset; one
+        // arriving for a previous aborted session is correctly cleared here.
+        self.preRollFramesWritten = 0
+        self.discardPreRollRequested = false
         self.preRollAcceptingSamples.withLock { $0 = false }
         self.sharedProcessingQueue.sync {}
         self.preRollCaptureGeneration.withLock { $0 += 1 }
@@ -573,9 +589,22 @@ public actor AudioRecorder {
         armCaptureDiagnostics(generation: tapGeneration)
     }
 
+    /// Discard the instant-dictation pre-roll from the in-flight recording.
+    /// Called when system media was confirmed playing at dictation start: the
+    /// pre-roll is then pre-press media audio that no media pause can silence,
+    /// and `stop()` trims it from the WAV before transcription (issue #474).
+    /// Requests outside an active/starting session are dropped — best-effort
+    /// by design; a missed request only keeps the original bleed window.
+    public func discardPreRollForActiveRecording() {
+        guard recording || starting else { return }
+        discardPreRollRequested = true
+    }
+
     /// Stop recording and return the path to the recorded WAV file.
-    /// Throws `insufficientSamples` if the recording is shorter than the STT minimum.
-    public func stop() throws -> URL {
+    /// Throws `insufficientSamples` if the recording is shorter than the STT
+    /// minimum — measured after any pre-roll discard, so a capture that is
+    /// effectively media-only dismisses silently instead of transcribing it.
+    public func stop() async throws -> URL {
         if starting, !recording {
             // `start()` awaits the stream subscription. A stop/cancel during
             // that await must invalidate the pending tap generation so the
@@ -591,12 +620,15 @@ public actor AudioRecorder {
             throw AudioProcessorError.recordingFailed("Not recording")
         }
 
+        var unsubscribeTask: Task<Void, Never>?
         if let token = sharedSubscriberToken {
-            // Fire-and-forget so stop() stays synchronous. The stream's
-            // engine queue serializes the unsubscribe behind any pending
-            // operations.
+            // Fire-and-forget on the happy path so stop() never waits on the
+            // stream's engine queue, which serializes the unsubscribe behind
+            // any pending operations. The pre-roll discard path below awaits
+            // this task — that is what releases the tap's retain on the
+            // writer AVAudioFile, finalizing the WAV before it is re-read.
             let stream = sharedStream
-            Task { await stream.unsubscribe(token) }
+            unsubscribeTask = Task { await stream.unsubscribe(token) }
             sharedSubscriberToken = nil
             // Conversion and file writes run on this serial queue instead of
             // the shared audio tap. Drain already-enqueued work so stop()
@@ -612,6 +644,14 @@ public actor AudioRecorder {
         preRollCaptureGeneration.withLock { $0 += 1 }
         preRollConverterCache.reset()
         preRollBuffer.withLock { $0.clear() }
+        // Snapshot + reset the discard state while still in the synchronous
+        // section: the trim below suspends, and a reentrant start() must see
+        // clean per-session state.
+        let discardFrames = (discardPreRollRequested && preRollFramesWritten > 0)
+            ? preRollFramesWritten
+            : 0
+        preRollFramesWritten = 0
+        discardPreRollRequested = false
         if instantDictationEnabled {
             let hasWarmSubscriber = warmSubscriberToken != nil
             preRollAcceptingSamples.withLock { $0 = hasWarmSubscriber }
@@ -635,16 +675,94 @@ public actor AudioRecorder {
         AudioCaptureDiagnostics.append(
             "dictation_capture_stop sample_count=\(sampleCount) duration_s=\(String(format: "%.3f", duration)) file_bytes=\(fileBytes.map(String.init) ?? "unknown") input_buffers=\(metrics.inputBufferCount) output_buffers=\(metrics.outputBufferCount) input_frames=\(metrics.inputFrameCount) max_rms=\(String(format: "%.6f", metrics.maxRMS)) max_level=\(String(format: "%.3f", metrics.maxAudioLevel)) non_silent_buffers=\(metrics.nonSilentBufferCount) missing_float_buffers=\(metrics.missingFloatChannelDataBufferCount) invalid_format_buffers=\(metrics.invalidFormatBufferCount)"
         )
-        guard sampleCount >= Self.minimumSamples else {
+        // Length gate uses the post-discard count: a capture whose remainder
+        // is below the STT floor would otherwise transcribe nothing but the
+        // discarded media audio.
+        let effectiveSampleCount = sampleCount - discardFrames
+        guard effectiveSampleCount >= Self.minimumSamples else {
             // Clean up the too-short file
             try? FileManager.default.removeItem(at: url)
+            let discardField = discardFrames > 0 ? " discarded_preroll_frames=\(discardFrames)" : ""
             AudioCaptureDiagnostics.append(
-                "dictation_capture_insufficient sample_count=\(sampleCount) required=\(Self.minimumSamples)"
+                "dictation_capture_insufficient sample_count=\(effectiveSampleCount) required=\(Self.minimumSamples)\(discardField)"
             )
             throw AudioProcessorError.insufficientSamples
         }
 
+        if discardFrames > 0 {
+            // Releasing the subscriber drops the tap's retain on the writer
+            // AVAudioFile (the handler closure holds it); draining the
+            // processing queue afterwards releases the copies held by any
+            // already-enqueued blocks. Only then is the WAV finalized on disk
+            // and safe to re-read. Suspending here is safe: every piece of
+            // per-session actor state was reset above, and this path touches
+            // only locals — a reentrant start() begins a fresh session
+            // against a different file.
+            await unsubscribeTask?.value
+            sharedProcessingQueue.sync {}
+            do {
+                try Self.removeLeadingFrames(discardFrames, fromWAVAt: url)
+                let duration = Double(discardFrames) / Double(Self.outputSampleRate)
+                AudioCaptureDiagnostics.append(
+                    "dictation_capture_preroll_discarded reason=media_paused sample_count=\(discardFrames) duration_s=\(String(format: "%.3f", duration))"
+                )
+            } catch {
+                // Degrade to the pre-fix behavior (pre-roll bleed) rather
+                // than lose the user's dictation.
+                AudioCaptureDiagnostics.append(
+                    "dictation_capture_preroll_discard_failed \(AudioCaptureDiagnostics.errorFields(error))"
+                )
+            }
+        }
+
         return url
+    }
+
+    /// Rewrite the WAV at `url` without its first `frames` frames. Used by
+    /// `stop()` to drop a media-contaminated instant-dictation pre-roll. The
+    /// rewrite goes through a sibling temp file plus an atomic replace so a
+    /// failure at any point leaves the original file intact.
+    private static func removeLeadingFrames(_ frames: Int, fromWAVAt url: URL) throws {
+        let tempURL = url.deletingLastPathComponent()
+            .appendingPathComponent("\(UUID().uuidString).wav")
+        do {
+            try writeCopy(of: url, skippingLeadingFrames: frames, to: tempURL)
+        } catch {
+            try? FileManager.default.removeItem(at: tempURL)
+            throw error
+        }
+        _ = try FileManager.default.replaceItemAt(url, withItemAt: tempURL)
+    }
+
+    /// Separate function so the writer `AVAudioFile`'s last strong reference
+    /// is provably gone when it returns — dealloc finalizes the WAV header,
+    /// which must happen before `removeLeadingFrames` swaps the file in.
+    private static func writeCopy(
+        of sourceURL: URL,
+        skippingLeadingFrames frames: Int,
+        to destinationURL: URL
+    ) throws {
+        let source = try AVAudioFile(forReading: sourceURL)
+        let writer = try AVAudioFile(
+            forWriting: destinationURL,
+            settings: source.processingFormat.settings
+        )
+        source.framePosition = AVAudioFramePosition(frames)
+        var remaining = max(0, source.length - AVAudioFramePosition(frames))
+        let chunkFrames: AVAudioFrameCount = 16_384
+        while remaining > 0 {
+            let count = AVAudioFrameCount(min(AVAudioFramePosition(chunkFrames), remaining))
+            guard let buffer = AVAudioPCMBuffer(
+                pcmFormat: source.processingFormat,
+                frameCapacity: count
+            ) else {
+                throw AudioProcessorError.recordingFailed("Failed to allocate pre-roll trim buffer")
+            }
+            try source.read(into: buffer, frameCount: count)
+            guard buffer.frameLength > 0 else { break }
+            try writer.write(from: buffer)
+            remaining -= AVAudioFramePosition(buffer.frameLength)
+        }
     }
 
     private func logTapError(_ message: String) {
@@ -673,6 +791,7 @@ public actor AudioRecorder {
             }
         }
         try file.write(from: buffer)
+        preRollFramesWritten = samples.count
         sampleCounter.withLock { $0 += samples.count }
         runtimeMetrics.withLock { $0.outputBufferCount += 1 }
         let duration = Double(samples.count) / Double(Self.outputSampleRate)

--- a/Sources/MacParakeetCore/Audio/README.md
+++ b/Sources/MacParakeetCore/Audio/README.md
@@ -32,7 +32,10 @@ owned by `AppEnvironment`.
   Dictation keeps a passive warm subscriber attached while idle,
   stores a 1-second RAM-only 16 kHz mono ring buffer, and prepends up
   to 0.45 seconds when the user starts dictation. It does not run STT
-  while idle.
+  while idle. When the Pause Media round-trip confirms media was
+  playing at press time, `discardPreRollForActiveRecording()` marks
+  the session and `stop()` trims the prepended pre-roll from the WAV —
+  pre-press media audio that no pause can silence (issue #474).
 - `MicrophoneCapture.swift` — meeting microphone capture. Subscribes
   with `wantsVPIO: false` by default via `MeetingMicProcessingMode.raw`.
   VPIO modes remain available for explicit experiments, with raw fallback
@@ -54,7 +57,11 @@ owned by `AppEnvironment`.
 - `AudioCaptureDiagnostics.swift` — public `append(_:)` to
   `~/Library/Logs/MacParakeet/dictation-audio.log`. 5 MB cap;
   delete-on-overflow (not rotated). Used by every file in this
-  folder and by `AppDelegate`'s boot marker.
+  folder, by `AppDelegate`'s boot marker, and by the dictation
+  media-pause path (`SystemMediaController` +
+  `DictationMediaPauseCoordinator` mirror their `media_pause_*` /
+  `media_resume_*` outcomes here so uploaded logs show the
+  press→pause window next to the capture timeline; issue #474).
 - `DiagnosticLogScope.swift` — `AudioCaptureDiagnostics.scopedLogForUpload`
   trims the log to a recent window (`.recent`, the feedback default:
   last 7 days, 2 MB / 20k-line safety ceilings, min-tail fallback) or

--- a/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
+++ b/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
@@ -439,6 +439,27 @@ public actor DictationService: DictationServiceProtocol {
         }
     }
 
+    /// Discard the instant-dictation pre-roll from the active capture because
+    /// system media was confirmed playing at press time — the pre-roll is
+    /// pre-press media audio that no pause can silence (issue #474).
+    /// Best-effort: a stale session ID or a capture that already stopped
+    /// keeps its pre-roll, which only re-opens the original bleed window.
+    public func discardPreRollForActiveCapture(sessionID: Int?) async {
+        if let sessionID, sessionID != activeSessionID {
+            logger.notice(
+                "discardPreRoll ignored stale session requested=\(sessionID) active=\(self.activeSessionID)"
+            )
+            return
+        }
+        guard case .recording = _state else {
+            logger.notice(
+                "discardPreRoll ignored state=\(self.debugStateLabel(self._state), privacy: .public)"
+            )
+            return
+        }
+        await audioProcessor.discardPreRollForActiveCapture()
+    }
+
     public func cancelRecording(reason: TelemetryDictationCancelReason? = nil) async {
         await cancelRecording(reason: reason, sessionID: nil)
     }

--- a/Sources/MacParakeetCore/Services/Dictation/DictationServiceSession.swift
+++ b/Sources/MacParakeetCore/Services/Dictation/DictationServiceSession.swift
@@ -68,6 +68,13 @@ public final class DictationServiceSession {
         await service.cancelRecording(reason: reason, sessionID: sessionID)
     }
 
+    /// Discard the instant-dictation pre-roll from the named session's capture
+    /// because system media was confirmed playing at press time (issue #474).
+    /// Best-effort: stale session IDs and non-recording states are ignored.
+    public func discardPreRollForActiveCapture(sessionID: Int) async {
+        await service.discardPreRollForActiveCapture(sessionID: sessionID)
+    }
+
     public func confirmCancel(sessionID: Int) async {
         await service.confirmCancel(sessionID: sessionID)
     }

--- a/Sources/MacParakeetCore/Services/System/SystemMediaController.swift
+++ b/Sources/MacParakeetCore/Services/System/SystemMediaController.swift
@@ -51,27 +51,52 @@ public final class SystemMediaController: SystemMediaControlling, @unchecked Sen
     }
 
     public func pauseIfPlaying() async -> MediaPauseToken? {
-        guard let snapshot = await snapshotProvider() else {
+        // Mirrored into dictation-audio.log (issue #474): the delta between
+        // `dictation_capture_start` and `media_pause_sent` line timestamps is
+        // the window where playing media bleeds into the capture, and
+        // `snapshot_ms` shows how much of it the now-playing helper costs.
+        // Identity fields (pid/bundle) stay out — the log is user-shareable.
+        let clock = ContinuousClock()
+        let snapshotStart = clock.now
+        let snapshot = await snapshotProvider()
+        let snapshotMs = Int(((clock.now - snapshotStart) / .milliseconds(1)).rounded())
+
+        guard let snapshot else {
             Self.logger.notice("media_pause_skipped reason=snapshot_unavailable")
+            AudioCaptureDiagnostics.append(
+                "media_pause_skipped reason=snapshot_unavailable snapshot_ms=\(snapshotMs)"
+            )
             return nil
         }
 
         guard snapshot.isPlaying else {
             Self.logger.notice("media_pause_skipped reason=no_playing_session")
+            AudioCaptureDiagnostics.append(
+                "media_pause_skipped reason=no_playing_session snapshot_ms=\(snapshotMs)"
+            )
             return nil
         }
 
         guard snapshot.hasIdentity else {
             Self.logger.notice("media_pause_skipped reason=session_identity_unavailable")
+            AudioCaptureDiagnostics.append(
+                "media_pause_skipped reason=session_identity_unavailable snapshot_ms=\(snapshotMs)"
+            )
             return nil
         }
 
         guard commandSender(Command.pause) else {
             Self.logger.error("media_pause_failed bucket=send_command_failed")
+            AudioCaptureDiagnostics.append(
+                "media_pause_failed bucket=send_command_failed snapshot_ms=\(snapshotMs)"
+            )
             return nil
         }
 
         Self.logger.notice("media_pause_sent source=now_playing_helper")
+        AudioCaptureDiagnostics.append(
+            "media_pause_sent snapshot_ms=\(snapshotMs)"
+        )
         return MediaPauseToken(
             processIdentifier: snapshot.processIdentifier,
             bundleIdentifier: snapshot.bundleIdentifier
@@ -81,25 +106,30 @@ public final class SystemMediaController: SystemMediaControlling, @unchecked Sen
     public func resume(_ token: MediaPauseToken) async {
         guard let snapshot = await snapshotProvider() else {
             Self.logger.notice("media_resume_skipped reason=snapshot_unavailable")
+            AudioCaptureDiagnostics.append("media_resume_skipped reason=snapshot_unavailable")
             return
         }
 
         if snapshot.isPlaying {
             Self.logger.notice("media_resume_skipped reason=already_playing")
+            AudioCaptureDiagnostics.append("media_resume_skipped reason=already_playing")
             return
         }
 
         guard snapshot.matches(token) else {
             Self.logger.notice("media_resume_skipped reason=now_playing_changed")
+            AudioCaptureDiagnostics.append("media_resume_skipped reason=now_playing_changed")
             return
         }
 
         guard commandSender(Command.play) else {
             Self.logger.error("media_resume_failed bucket=send_command_failed")
+            AudioCaptureDiagnostics.append("media_resume_failed bucket=send_command_failed")
             return
         }
 
         Self.logger.notice("media_resume_sent source=now_playing_helper")
+        AudioCaptureDiagnostics.append("media_resume_sent")
     }
 }
 

--- a/Tests/MacParakeetTests/Audio/AudioRecorderFormatChangeTests.swift
+++ b/Tests/MacParakeetTests/Audio/AudioRecorderFormatChangeTests.swift
@@ -491,6 +491,150 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
         _ = try? await recorder.stop()
     }
 
+    // MARK: - Pre-roll discard (issue #474)
+
+    func testDiscardPreRollRemovesPrependedSamplesFromFinalWAV() async throws {
+        let platform = AudioRecorderBlockingPlatform()
+        let stream = SharedMicrophoneStream(platform: platform, bufferSize: 1024)
+        let recorder = AudioRecorder(
+            sharedStream: stream,
+            permissionProvider: { true }
+        )
+
+        await recorder.setInstantDictationEnabled(true)
+        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 8_000, sampleValue: 0.6))
+        try await Task.sleep(for: .milliseconds(50))
+
+        try await recorder.start()
+        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.2))
+        await recorder.discardPreRollForActiveRecording()
+
+        let url = try await recorder.stop()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let samples = try readFloatSamples(from: url)
+        XCTAssertEqual(samples.count, 4_800)
+        XCTAssertEqual(try XCTUnwrap(samples.first), 0.2, accuracy: 0.0001)
+        XCTAssertEqual(try XCTUnwrap(samples.last), 0.2, accuracy: 0.0001)
+        XCTAssertFalse(samples.contains { abs($0 - 0.6) < 0.0001 })
+
+        await recorder.setInstantDictationEnabled(false)
+    }
+
+    func testDiscardPreRollMakesMediaOnlyCaptureInsufficient() async throws {
+        let platform = AudioRecorderBlockingPlatform()
+        let stream = SharedMicrophoneStream(platform: platform, bufferSize: 1024)
+        let recorder = AudioRecorder(
+            sharedStream: stream,
+            permissionProvider: { true }
+        )
+
+        await recorder.setInstantDictationEnabled(true)
+        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 8_000, sampleValue: 0.6))
+        try await Task.sleep(for: .milliseconds(50))
+
+        // Total = 7,200 pre-roll + 3,200 live ≥ the 4,800 floor, but the
+        // post-discard remainder (3,200) is below it: without the discard
+        // this capture would transcribe nothing but the paused media audio.
+        try await recorder.start()
+        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 3_200, sampleValue: 0.2))
+        await recorder.discardPreRollForActiveRecording()
+
+        do {
+            _ = try await recorder.stop()
+            XCTFail("stop() should report insufficient samples once the pre-roll is discarded")
+        } catch AudioProcessorError.insufficientSamples {
+            // Expected.
+        } catch {
+            XCTFail("Unexpected stop error: \(error)")
+        }
+
+        await recorder.setInstantDictationEnabled(false)
+    }
+
+    func testDiscardPreRollRequestIgnoredWhenIdle() async throws {
+        let platform = AudioRecorderBlockingPlatform()
+        let stream = SharedMicrophoneStream(platform: platform, bufferSize: 1024)
+        let recorder = AudioRecorder(
+            sharedStream: stream,
+            permissionProvider: { true }
+        )
+
+        await recorder.setInstantDictationEnabled(true)
+        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 8_000, sampleValue: 0.6))
+        try await Task.sleep(for: .milliseconds(50))
+
+        // Idle request must be dropped, not pre-armed for the next session.
+        await recorder.discardPreRollForActiveRecording()
+
+        try await recorder.start()
+        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.2))
+
+        let url = try await recorder.stop()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let samples = try readFloatSamples(from: url)
+        XCTAssertEqual(samples.count, 12_000)
+        XCTAssertEqual(samples[0], 0.6, accuracy: 0.0001)
+        XCTAssertEqual(samples[7_200], 0.2, accuracy: 0.0001)
+
+        await recorder.setInstantDictationEnabled(false)
+    }
+
+    func testDiscardPreRollStateDoesNotLeakIntoNextRecording() async throws {
+        let platform = AudioRecorderBlockingPlatform()
+        let stream = SharedMicrophoneStream(platform: platform, bufferSize: 1024)
+        let recorder = AudioRecorder(
+            sharedStream: stream,
+            permissionProvider: { true }
+        )
+
+        await recorder.setInstantDictationEnabled(true)
+        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 8_000, sampleValue: 0.6))
+        try await Task.sleep(for: .milliseconds(50))
+
+        try await recorder.start()
+        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.2))
+        await recorder.discardPreRollForActiveRecording()
+        let firstURL = try await recorder.stop()
+        try? FileManager.default.removeItem(at: firstURL)
+
+        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 8_000, sampleValue: 0.7))
+        try await Task.sleep(for: .milliseconds(50))
+
+        try await recorder.start()
+        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.2))
+        let secondURL = try await recorder.stop()
+        defer { try? FileManager.default.removeItem(at: secondURL) }
+
+        let samples = try readFloatSamples(from: secondURL)
+        XCTAssertEqual(samples.count, 12_000)
+        XCTAssertEqual(samples[0], 0.7, accuracy: 0.0001)
+        XCTAssertEqual(samples[7_200], 0.2, accuracy: 0.0001)
+
+        await recorder.setInstantDictationEnabled(false)
+    }
+
+    func testDiscardPreRollWithoutInstantDictationIsNoOp() async throws {
+        let platform = AudioRecorderBlockingPlatform()
+        let stream = SharedMicrophoneStream(platform: platform, bufferSize: 1024)
+        let recorder = AudioRecorder(
+            sharedStream: stream,
+            permissionProvider: { true }
+        )
+
+        try await recorder.start()
+        platform.deliverBuffer(try makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.3))
+        await recorder.discardPreRollForActiveRecording()
+
+        let url = try await recorder.stop()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let samples = try readFloatSamples(from: url)
+        XCTAssertEqual(samples.count, 4_800)
+        XCTAssertEqual(try XCTUnwrap(samples.first), 0.3, accuracy: 0.0001)
+    }
+
     private func pollUntil(
         timeout: Duration,
         condition: @Sendable () -> Bool

--- a/Tests/MacParakeetTests/Audio/MockAudioProcessor.swift
+++ b/Tests/MacParakeetTests/Audio/MockAudioProcessor.swift
@@ -78,4 +78,10 @@ public actor MockAudioProcessor: AudioProcessorProtocol {
         if let error = captureError { throw error }
         return captureResult ?? URL(fileURLWithPath: "/tmp/recording.wav")
     }
+
+    public var discardPreRollCallCount = 0
+
+    public func discardPreRollForActiveCapture() async {
+        discardPreRollCallCount += 1
+    }
 }

--- a/Tests/MacParakeetTests/DictationFlow/DictationMediaPauseCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationMediaPauseCoordinatorTests.swift
@@ -222,6 +222,63 @@ final class DictationMediaPauseCoordinatorTests: XCTestCase {
         XCTAssertEqual(snapshot.resumeTokens, [token])
     }
 
+    func testOnMediaPausedFiresOnceWhenTokenAcquired() async {
+        settings.pauseMediaDuringDictation = true
+        let token = MediaPauseToken(processIdentifier: 11)
+        let media = FakeSystemMediaController(pauseBehavior: .immediate(token))
+        let coordinator = makeCoordinator(media: media)
+
+        var mediaPausedCallbacks = 0
+        coordinator.requestPauseBeforeDictationCapture(onMediaPaused: {
+            mediaPausedCallbacks += 1
+        })
+        await coordinator.pauseTask?.value
+
+        XCTAssertEqual(mediaPausedCallbacks, 1)
+        await coordinator.resumeAfterDictationCapture()
+    }
+
+    func testOnMediaPausedNotFiredWhenNothingPlaying() async {
+        settings.pauseMediaDuringDictation = true
+        let media = FakeSystemMediaController(pauseBehavior: .immediate(nil))
+        let coordinator = makeCoordinator(media: media)
+
+        var mediaPausedCallbacks = 0
+        coordinator.requestPauseBeforeDictationCapture(onMediaPaused: {
+            mediaPausedCallbacks += 1
+        })
+        await coordinator.pauseTask?.value
+
+        XCTAssertEqual(mediaPausedCallbacks, 0)
+    }
+
+    /// A late-arriving token from a capture that already ended must be
+    /// released without firing `onMediaPaused` — a discard fired here could
+    /// hit a newer session this request knows nothing about.
+    func testOnMediaPausedNotFiredWhenCaptureEndsBeforePauseCompletes() async {
+        settings.pauseMediaDuringDictation = true
+        let token = MediaPauseToken(processIdentifier: 22)
+        let media = FakeSystemMediaController(pauseBehavior: .deferred)
+        let coordinator = makeCoordinator(media: media)
+        let pauseStarted = expectation(description: "pause request started")
+        media.setPauseStartedHandler {
+            pauseStarted.fulfill()
+        }
+
+        var mediaPausedCallbacks = 0
+        coordinator.requestPauseBeforeDictationCapture(onMediaPaused: {
+            mediaPausedCallbacks += 1
+        })
+        await fulfillment(of: [pauseStarted], timeout: 1)
+
+        await coordinator.resumeAfterDictationCapture()
+        media.completeDeferredPause(with: token)
+        await coordinator.pauseTask?.value
+
+        XCTAssertEqual(mediaPausedCallbacks, 0)
+        XCTAssertEqual(media.snapshot().resumeTokens, [token])
+    }
+
     func testTerminationResumesActiveToken() async throws {
         settings.pauseMediaDuringDictation = true
         let token = MediaPauseToken(processIdentifier: 303)

--- a/Tests/MacParakeetTests/Services/Dictation/DictationServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/Dictation/DictationServiceTests.swift
@@ -77,6 +77,31 @@ final class DictationServiceTests: XCTestCase {
         }
     }
 
+    func testDiscardPreRollForwardsToAudioProcessorWhileRecording() async throws {
+        try await service.startRecording()
+
+        await service.discardPreRollForActiveCapture(sessionID: nil)
+
+        let callCount = await mockAudio.discardPreRollCallCount
+        XCTAssertEqual(callCount, 1)
+    }
+
+    func testDiscardPreRollIgnoresStaleSession() async throws {
+        try await service.startRecording(context: DictationTelemetryContext(), sessionID: 7)
+
+        await service.discardPreRollForActiveCapture(sessionID: 6)
+
+        let callCount = await mockAudio.discardPreRollCallCount
+        XCTAssertEqual(callCount, 0)
+    }
+
+    func testDiscardPreRollIgnoredWhenNotRecording() async {
+        await service.discardPreRollForActiveCapture(sessionID: nil)
+
+        let callCount = await mockAudio.discardPreRollCallCount
+        XCTAssertEqual(callCount, 0)
+    }
+
     func testStartFailureUsesRequestedTelemetryContextForOperation() async throws {
         let telemetry = DictationTelemetrySpy()
         Telemetry.configure(telemetry)

--- a/plans/active/2026-05-dictation-media-pause.md
+++ b/plans/active/2026-05-dictation-media-pause.md
@@ -2,8 +2,14 @@
 
 Status: **ACTIVE**
 Owner: Core app team
-Updated: 2026-05-24
+Updated: 2026-06-10
 Related: [GitHub issue #351](https://github.com/moona3k/macparakeet/issues/351)
+
+> **Interaction with Instant Dictation (issue #474):** with both features on
+> and media playing through speakers, the pre-roll plus the pause-IPC latency
+> put media audio at the head of the transcript. Mechanism, fix tiers, and the
+> implemented mitigation (diagnostics + pre-roll discard on confirmed pause)
+> live in `2026-06-issue-474-instant-dictation-media-pause-bleed.md`.
 
 ## Decision
 

--- a/plans/active/2026-06-issue-474-instant-dictation-media-pause-bleed.md
+++ b/plans/active/2026-06-issue-474-instant-dictation-media-pause-bleed.md
@@ -1,0 +1,331 @@
+# Issue #474 — Instant Dictation × Pause Media: media audio bleeds into transcript head
+
+> Status: **ACTIVE** (Tiers 0 + 1 implemented 2026-06-10; Tier 2 deferred)
+> Date: 2026-06-09 (tiering 2026-06-10; implementation 2026-06-10)
+> Issue: https://github.com/moona3k/macparakeet/issues/474
+> Investigated by: Claude (full code + diagnostic-log review, 2026-06-09)
+> Decision (owner, 2026-06-10): proceed with **Tier 0 + Tier 1**; Tier 2
+> stays deferred pending instrumentation data and a second report.
+>
+> **Implemented (2026-06-10):**
+> - Tier 0a — `media_pause_*` / `media_resume_*` outcomes (+ `snapshot_ms`)
+>   mirrored into `dictation-audio.log` from `SystemMediaController` and the
+>   `meeting_active` skip from `DictationMediaPauseCoordinator`. Window 2 is
+>   now measurable in uploaded logs as
+>   `timestamp(media_pause_sent) − timestamp(dictation_capture_start)`.
+> - Tier 0b — speakers caveat added to the Pause Media settings caption.
+> - Tier 1 — `onMediaPaused` callback on the pause coordinator →
+>   `DictationServiceSession.discardPreRollForActiveCapture(sessionID:)` →
+>   `AudioRecorder.discardPreRollForActiveRecording()`; `stop()` trims the
+>   prepended pre-roll from the WAV (atomic temp-file rewrite) and applies
+>   the minimum-sample gate to the post-trim count. Best-effort semantics as
+>   designed. Log lines: `dictation_capture_preroll_discarded`,
+>   `dictation_capture_preroll_discard_failed`,
+>   `discarded_preroll_frames` on insufficient captures.
+> - Remaining for a future agent: Tier 2 (see revisit criteria below) and
+>   archiving this plan once Tier 2 is either built or formally rejected.
+
+## TL;DR for the implementing agent
+
+Valid bug, mechanism fully confirmed in code. With **Instant Dictation**
+(`instantDictationEnabled`) and **Pause Media** (`pauseMediaDuringDictation`)
+both on — both opt-in, default `false` — and media playing through
+**speakers**, the head of the dictation WAV contains media audio that the ASR
+engine faithfully transcribes. Two windows produce the bleed, both by design:
+
+1. **Pre-roll window (0.45 s, entirely pre-press)** — Instant Dictation
+   prepends the last 0.45 s of the warm-mic ring buffer, i.e. audio recorded
+   *before* the hotkey press. No pause, however fast, can silence audio that
+   already happened.
+2. **Pause-latency window (~0.3–1.5 s, post-press)** — the media-pause IPC is
+   deliberately fire-and-forget (PR #384) and is slow by construction: an
+   osascript subprocess snapshots now-playing state (1.25 s timeout) *before*
+   the pause command is sent. The warm engine meanwhile delivers its first
+   live buffer in as little as 7 ms.
+
+There is **no AEC** in the dictation path (raw capture, `wantsVPIO: false`),
+so speaker output enters the mic at full level. Headphone users can never hit
+this.
+
+**Recommended path (2026-06-10): Tier 0 (guidance + instrumentation) and
+Tier 1 (drop pre-roll when media was confirmed playing) now; Tier 2 (warm
+now-playing snapshot) explicitly deferred pending instrumentation data and a
+second report.** Do NOT make the two toggles mutually exclusive — the
+conflict is speakers-only, not inherent to the feature pair. See "Fix tiers"
+below for the full reasoning and the traps.
+
+## The report
+
+Filed via in-app feedback (moonpi-bot) on v0.6.22 (build 20260609180743,
+commit `92c3dfdfbade`), macOS 26.5.1, M1 Max. Reporter is the same engaged
+user ("Mustard") behind #383, #421, and #450 — their reports already drove
+two fixes in this exact area. They enabled Instant Dictation for the first
+time ~1 h before filing (first-ever `dictation_warm_capture_started` in their
+log at 18:53 UTC; issue filed 19:54 UTC).
+
+Reporter's observations, all consistent with the confirmed mechanism:
+
+- Bleed is **content-dependent**: happens when the media has voice-like audio
+  at press time; clean when the media is in a natural pause.
+- **Speak immediately → clean** (near-field voice dominates the SNR).
+- **Press, wait for media to pause, then speak → dirty** (the head of the WAV
+  is pure media speech followed by a silence gap — maximally transcribable).
+- Reporter hypothesized "VAD is picking up the voice-like media audio."
+  **Mostly right, one detail wrong:** there is no VAD anywhere in the
+  dictation path. The entire WAV (pre-roll + live) goes to Parakeet/Nemotron;
+  the engine transcribes whatever speech is in it. VAD exists only in meeting
+  live-preview chunking. Correct this gently if replying on the issue.
+
+Cruel irony worth understanding: the Pause Media feature *trains* the exact
+timing that maximizes the bleed — it teaches users to wait for silence before
+speaking, which hands the pipeline a clean run of media-only speech.
+
+## Confirmed mechanism, with code references
+
+Press-time sequence (`DictationFlowCoordinator.startRecordingTask`,
+`Sources/MacParakeet/App/DictationFlowCoordinator.swift:878-901`):
+
+1. `mediaPauseCoordinator.requestPauseBeforeDictationCapture()` — explicitly
+   fire-and-forget (`DictationFlowCoordinator.swift:888-893`; comment explains
+   why: awaiting the round-trip clipped first words — that was issue #383 →
+   PR #384 "Decouple media pause from dictation capture start", `b25eb0a47`).
+2. `serviceSession.startRecording(...)` → `AudioRecorder.start()`.
+
+The pause path (`Sources/MacParakeet/App/DictationMediaPauseCoordinator.swift:53-91`
+→ `Sources/MacParakeetCore/Services/System/SystemMediaController.swift:53-79`):
+
+- `pauseIfPlaying()` first runs `OsaScriptNowPlayingSnapshotReader.snapshot()`
+  — spawns `/usr/bin/osascript -l JavaScript` which loads the private
+  MediaRemote framework and reads `MRNowPlayingRequest`
+  (`SystemMediaController.swift:132-210`, timeout 1.25 s). The osascript
+  subprocess exists because Apple-signed `osascript` carries the MediaRemote
+  entitlements the app lacks on modern macOS — **do not** "optimize" the
+  snapshot into an in-process call without re-checking entitlement reality.
+- Only after the snapshot returns does it send pause via in-process
+  `MRMediaRemoteSendCommand` (`MediaRemoteCommandSender`, `:242-291`).
+- Then the media app reacts (some players fade out over 100–500 ms), plus
+  output-device latency.
+
+The capture path (`Sources/MacParakeetCore/Audio/AudioRecorder.swift`):
+
+- `preRollPrependSamples = 0.45 s` at 16 kHz (`AudioRecorder.swift:187`).
+- `start()` snapshots the ring's suffix and writes it to the WAV head
+  (`AudioRecorder.swift:340-350`) before the live tap appends.
+- The warm subscriber keeps the engine hot; first live buffer arrives in
+  ~7–100 ms (vs ~250 ms cold).
+- Capture is raw: `wantsVPIO: false`, so no echo cancellation. With built-in
+  mic + built-in speakers (the reporter's setup per the log), bleed is
+  acoustic and unavoidable at the capture layer.
+
+Net result with media on speakers: WAV head = 0.45 s pre-press media
++ ~0.3–1.5 s post-press media-until-silence + user speech.
+
+Tail bleed is **not** possible: resume runs after capture stop
+(`resumeAfterDictationCapture`).
+
+Note: window 2 exists **even without Instant Dictation** — cold capture
+(~250 ms to first buffer) still beats the osascript round-trip, so plain
+Pause-Media-on-speakers has always had a smaller version of this. Pre-roll
+made the bleed guaranteed and visible.
+
+## Evidence from the uploaded diagnostic log
+
+`diagnostics/1781034873191-dictation-audio.log` (committed `8822ccfc3`,
+trimmed `978dc1d97`):
+
+- Line 26071: `2026-06-09T18:53:13.067Z dictation_warm_capture_started
+  preroll_s=0.450` — first warm capture ever for this user (only `warm` line
+  in 26 631 lines).
+- Lines 26073/26084/26094/…: `dictation_capture_preroll_prepend
+  sample_count=7200 duration_s=0.450` on every press — ring always full.
+- Throughout: `vpio=false`, `transport=built-in` (raw capture, built-in mic).
+- Warm-start latency: `engine_started` 19:02:32.291 → `first_buffer`
+  19:02:32.298 (7 ms). Cold sessions earlier in the log: ~150 ms engine start
+  + ~100 ms first buffer.
+- **Gap:** media-pause events (`media_pause_skipped/sent/failed`,
+  `media_resume_*`) go to OSLog only (`Logger`, categories
+  `DictationMediaPause` and `SystemMediaController`) — they never appear in
+  `dictation-audio.log`, so uploaded diagnostics cannot quantify the pause
+  window. No telemetry events exist for media pause either
+  (grep `TelemetryEvent.swift` — nothing).
+
+## Why pre-roll exists (don't "fix" by deleting it)
+
+Commit `07d16a327` / PR #418, motivated by issue #414 (Hex-style hot mic):
+users begin speaking at/before the press and lose the first syllable. Issue
+#450's test data shows it plainly — "one two three four five six seven eight"
+spoken at press transcribed as "Four five six seven eight" on the cold path.
+The 1 s ring / 0.45 s prepend numbers were lifted from Hex's design. ADR-015
+amendment covers the passive warm subscriber (`blocksVPIOPromotion=false`).
+
+The design-tension triangle, for orientation:
+
+- Gate capture on pause → clipped first words (#383).
+- Don't gate (PR #384) → post-press bleed window.
+- Add pre-roll (#418) → guaranteed pre-press bleed window.
+
+You cannot satisfy "no first-word loss" and "no media bleed" simultaneously
+without either AEC or knowledge-based suppression. Neither the media-pause
+plan (`plans/active/2026-05-dictation-media-pause.md`) nor the 2026-06-09
+audit analyzed this interaction — it's a genuinely new finding.
+
+## Severity
+
+P3. Opt-in × opt-in × speakers-only, so small blast radius — but it is a
+*wrong text inserted into the user's document* defect, which costs more trust
+than missing text. Reporter is technical, repeat, and high-signal.
+
+## Fix tiers (assessed 2026-06-10)
+
+Framing question the owner asked: *fixable, or just recommend not combining
+the features?* Answer: **mostly fixable, and "don't combine" is the wrong
+rec.** The conflict is conditional, not inherent — on **headphones** both
+features work together perfectly (no acoustic path from media to mic). The
+incompatibility is specifically *speakers + wait-to-speak*. Do **not** make
+the toggles mutually exclusive in the UI; that punishes headphone users who
+legitimately want both. The honest guidance is "with speakers, speak as you
+press — or use headphones."
+
+**Tier 0 — guidance + instrumentation (free; do now).**
+- Reply on #474: confirm the mechanism, credit the hypothesis, correct the
+  VAD detail (no VAD in the dictation path — the whole WAV is transcribed),
+  give the speakers guidance above.
+- Settings caption note on one or both toggles ("with speakers, media speech
+  may appear at the start of the transcript; use headphones or speak right
+  away").
+- Instrumentation: mirror `media_pause_requested` / `media_pause_sent` /
+  `media_pause_skipped` (+ ms-since-press) into
+  `AudioCaptureDiagnostics.append(...)` so uploaded logs quantify the real
+  pause window in the wild. Optionally a telemetry counter (remember:
+  telemetry allowlist is a two-repo change — Worker `ALLOWED_EVENTS` in
+  macparakeet-website).
+
+**Tier 1 — drop pre-roll when media was confirmed playing (cheap; do now;
+~halves the bleed).**
+When `pauseIfPlaying()` confirms media *was* playing at press, exclude the
+0.45 s pre-roll from transcription. No new IPC, no polling: the confirmation
+arrives ~300 ms into capture and transcription only happens at stop, so the
+decision is always available in time. This is principled, not a hack — for
+the wait-to-speak user the pre-roll is *pure media* (their voice cannot be in
+it), so dropping it is a pure win; for the speak-over-media user the pre-roll
+was contaminated anyway.
+Implementation notes:
+- Pre-roll is already written to the WAV head at `start()`. Either remember
+  the pre-roll byte/frame count and skip it at transcribe time, or restructure
+  to decide inclusion at stop. The trim decision naturally lives where the
+  dictation service hands the WAV to the scheduler.
+- Wiring crosses targets: `DictationMediaPauseCoordinator` (app target,
+  MainActor) learns "media was playing"; `AudioRecorder` (Core, actor) owns
+  the WAV. Capture "media_was_playing_at_press" as a fact **independent of
+  token retention** — for very short dictations the token can be acquired and
+  immediately resumed by the generation guard, but the playing-at-press fact
+  still holds and must still trigger the pre-roll drop.
+- Caveat to set expectations: Tier 1 alone kills only window 1. The
+  ~0.3–1.5 s pause-latency window still bleeds, so the reporter's
+  wait-to-speak symptom shrinks but does not vanish.
+
+**Tier 2 — warm/cached now-playing snapshot (real fix for window 2;
+DEFERRED).**
+Keep a cached now-playing snapshot while pause-media is enabled so the press
+path can send `MRMediaRemoteSendCommand(pause)` within milliseconds and build
+the resume token from the cache. Combined with Tier 1, residual bleed shrinks
+to maybe a stray word during the media app's own fade-out.
+Why deferred (decision context, 2026-06-10):
+- The cache requires **idle osascript polling** — the app cannot read
+  now-playing state in-process (entitlement gap; that is why osascript exists
+  here at all), and one-shot osascript can't push notifications. Periodic
+  subprocess spawns + battery cost to serve an opt-in × opt-in niche, on the
+  strength of one report. Complexity ahead of evidence.
+- Not provably zero even then: media-app fade-out (~100–500 ms in some
+  players) and snapshot staleness leave a residual.
+- Revisit when Tier 0 instrumentation shows real-world pause latency
+  (is window 2 ~300 ms or ~1.5 s?) **and** a second report exists.
+- Staleness analysis if/when built: poll-every-~5 s is tolerable. Stale
+  "playing" (user manually paused seconds ago) → redundant pause command
+  (pause is not a toggle; harmless) + unnecessary pre-roll drop (minor).
+  Stale "not playing" (media started seconds before press) → fall back to
+  today's behavior. Neither corrupts resume correctness if the token is still
+  built from a confirmed snapshot.
+
+⚠ **Trap — do not do "optimistic pause, snapshot after":** pausing first
+poisons the snapshot needed for a sound resume token. The post-pause snapshot
+reads `isPlaying=false`, you cannot distinguish "we paused it" from "user had
+paused it," and either media gets stuck paused (no token) or you wrongly
+auto-resume something the user paused themselves. The snapshot-first ordering
+in `pauseIfPlaying()` is load-bearing; the only sound speedup is making the
+snapshot *already available* at press time (Tier 2), not reordering it.
+
+**Tier 3 — AEC / VPIO: rejected (provably-zero requires this; not worth it).**
+VPIO is deliberately not the dictation default (PR #189 duplex-channel
+regression, call-safety; see `Sources/MacParakeetCore/Audio/README.md` — VPIO
+is sticky process-wide once engaged). The neural echo-suppression plan
+(`plans/active/2026-05-meeting-neural-echo-suppression.md`) is meeting-scoped
+and needs a far-end system-audio reference; dictation doesn't capture system
+audio and shouldn't (it would drag Screen Recording permission into the
+dictation flow — onboarding funnel data already shows a −21 pt cliff at the
+screen-recording step).
+
+**Also rejected — timestamp-based head trimming.**
+Dropping ASR words whose timestamps predate the estimated pause-effective
+moment is heuristic, risks eating real first words (the speak-immediately
+user's speech lives inside window 2 — there is no reliable discriminator
+between their voice and media speech without diarization), and violates
+"Simplicity is the product."
+
+## Implementation notes / constraints for the fix
+
+- `AudioRecorder` pre-roll state is guarded by per-call/lifecycle
+  **generation counters** (`preRollCaptureGeneration`,
+  `warmCaptureLifecycleGeneration`, `startCallGeneration`) — read the long
+  comments in `AudioRecorder.swift:160-300` and the Audio README before
+  touching start/stop/refresh ordering. Audit item R-6 already covers a
+  benign warm-retry race; don't reintroduce a real one.
+- Tap closures run on the audio render thread: no allocation, no actor hops
+  (`OSAllocatedUnfairLock` fields only).
+- `DictationMediaPauseCoordinator` has its own generation guard so a fast
+  capture-stop correctly releases an in-flight pause token. A cached-snapshot
+  redesign must preserve that resume correctness (tests exist:
+  `pauseTask` is `private(set)` specifically so tests can await the IPC).
+- Settings keys: `pauseMediaDuringDictation`, `instantDictationEnabled`
+  (`AppRuntimePreferences.swift:197-198`), both default `false`. Both rows
+  show Beta badges in `SettingsView`.
+- Meeting recordings already skip media pause
+  (`media_pause_skipped reason=meeting_active`).
+- Relevant tests to extend: `DictationMediaPauseCoordinator` tests,
+  `AudioRecorderFormatChangeTests`, `SharedMicrophoneStreamTests`.
+  Run `swift test --filter Audio` then full `swift test`.
+
+## Verification / repro guidance
+
+Repro (needs speakers, not headphones): enable both toggles, play a video
+with continuous dialogue at moderate volume on built-in speakers, press the
+dictation hotkey, **wait** for the media to pause, then speak. Expect the
+video's dialogue at the transcript head. Control: same flow but speak
+immediately → mostly clean; same flow on headphones → always clean.
+
+After a fix, the uploaded-log signature to look for (post-instrumentation):
+`dictation_capture_start` → `media_pause_sent` delta in the tens of ms, and
+no `dictation_capture_preroll_prepend` (or a trimmed one) when media was
+playing.
+
+## Suggested sequencing
+
+1. **Tier 0a:** land instrumentation (`media_pause_*` lines into
+   `AudioCaptureDiagnostics` with ms-since-press) — independently shippable,
+   improves every future report of this class.
+2. **Tier 0b:** reply on #474 — confirm the mechanism, credit the hypothesis,
+   correct the VAD detail, give the speakers/speak-promptly/headphones
+   guidance, link this plan. Add the settings caption note.
+3. **Tier 1:** drop pre-roll from transcription when media was confirmed
+   playing at press. Behind the existing settings, no new flags. Tests:
+   the cross-target "media_was_playing_at_press" plumbing, the
+   short-dictation case where the token is acquired-then-immediately-resumed,
+   and pre-roll inclusion unchanged when media was not playing / pause-media
+   is off.
+4. **Stop here.** Tier 2 only when instrumentation shows window 2 is large in
+   the wild AND a second report arrives. If/when built: warm snapshot cache,
+   tests for the optimistic-pause trap and staleness cases.
+5. On completion of Tiers 0–1: update
+   `plans/active/2026-05-dictation-media-pause.md` (or fold it into this doc)
+   and the Audio README's Instant Dictation paragraph with the interaction
+   note; archive completed plans to `plans/completed/`.

--- a/spec/05-audio-pipeline.md
+++ b/spec/05-audio-pipeline.md
@@ -20,6 +20,7 @@ Mic Input → SharedMicrophoneStream tap → temp WAV → selected local STT eng
 - **Minimum sample threshold**: 4,800 samples (0.3 seconds at 16kHz) required before sending to STT, mirroring FluidAudio's ASR guard. Header-only and near-empty recordings are rejected before they reach the speech engine.
 - Dictation always extracts channel 0 before conversion so VPIO duplex layouts produce the post-AEC mono stream instead of channel-mixed reference audio.
 - **Instant Dictation**: default-off setting that keeps a passive shared-stream subscriber attached while idle, stores a bounded 1-second RAM-only ring at 16kHz mono, and prepends up to 0.45 seconds to the next dictation WAV. macOS shows the microphone indicator while this is enabled. No STT or transcript processing runs while idle.
+- **Pre-roll discard on confirmed media pause (issue #474)**: when the Pause Media round-trip confirms system media was playing at press time, `stop()` trims the prepended pre-roll from the WAV before transcription — it is pre-press audio that no pause can silence, so on speakers it would put the media's speech at the head of the transcript. The minimum-sample threshold then applies to the post-trim count, so an effectively media-only capture dismisses silently. Best-effort: a pause confirmation that settles after capture stops keeps the pre-roll.
 - Dictation does not use the meeting crash-recovery lock-file pipeline. The current implementation writes a temp WAV and either moves it into retained storage or deletes it after processing.
 
 ### Storage


### PR DESCRIPTION
Fixes the Instant Dictation × Pause Media interaction reported in #474: with both features enabled and media playing through speakers, video/podcast speech appeared at the head of transcripts.

## Root cause

Two windows put media audio at the head of the capture, plus no AEC to keep it out of the mic:

1. **Pre-roll window (0.45s, pre-press)** — Instant Dictation prepends the last 0.45s of the warm-mic ring, audio recorded *before* the hotkey press. No pause, however fast, can silence audio that already happened.
2. **Pause-latency window (~0.3–1.5s, post-press)** — the media-pause IPC is deliberately fire-and-forget (#383/#384, so it never clips first words), and is slow by construction: an osascript now-playing snapshot (1.25s timeout) runs before the pause command. The warm engine meanwhile delivers its first buffer in as little as 7ms.

Dictation capture is raw (`wantsVPIO: false`), so on speakers the media enters the mic at full level. The full investigation, fix tiers, and the deferred Tier 2 (warm now-playing snapshot) live in `plans/active/2026-06-issue-474-instant-dictation-media-pause-bleed.md`.

## What this PR does

**Tier 1 — discard the pre-roll when media was confirmed playing (kills window 1).**
When the pause round-trip confirms media was playing, the coordinator's new `onMediaPaused` callback routes `DictationServiceSession.discardPreRollForActiveCapture(sessionID:)` → `AudioRecorder.discardPreRollForActiveRecording()`. At `stop()`, the prepended pre-roll is trimmed from the WAV via an atomic temp-file rewrite (performed after the subscriber teardown deterministically releases the writer `AVAudioFile`). The minimum-sample gate applies to the post-trim count, so an effectively media-only capture dismisses silently instead of transcribing the paused media. This is principled, not lossy: for the wait-to-speak user the pre-roll is pure media (their voice cannot be in it); for the speak-over-media user it was contaminated anyway.

Best-effort by design, guarded at every layer: the callback fires only while the pause request is still current (generation guard — never on the late-token release path), the service drops stale session IDs and non-recording states, and the recorder drops idle requests and resets the flag at every `start()`. A pause confirmation that settles after capture stops keeps the pre-roll — re-opening only the original bleed window, never corrupting a newer session.

**Tier 0 — make window 2 measurable + set expectations.**
`SystemMediaController` mirrors `media_pause_*` / `media_resume_*` outcomes (+ `snapshot_ms`) into `dictation-audio.log`, and the coordinator mirrors the `meeting_active` skip. The press→pause window is now readable in uploaded diagnostics as `timestamp(media_pause_sent) − timestamp(dictation_capture_start)` — the data needed to decide whether Tier 2 (warm now-playing snapshot) is worth its idle-polling cost. The Pause Media settings caption now states the speakers caveat.

## Tests

- Recorder: pre-roll trimmed from the final WAV; media-only remainder → `insufficientSamples`; idle requests dropped; no state leak into the next session; no-op without Instant Dictation (5 new cases).
- Coordinator: `onMediaPaused` fires once on token acquisition; not when nothing was playing; not when capture ends before the round-trip settles (3 new cases).
- Service: forwarding for the active session; stale session and non-recording states ignored (3 new cases).
- Full suite: 3535 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)