### PR TITLE
Harden meeting echo suppression: frame carry, reference delay, simultaneous-echo transcript rule

### DIFF
--- a/Sources/MacParakeetCore/Audio/MicrophoneEnginePlatform.swift
+++ b/Sources/MacParakeetCore/Audio/MicrophoneEnginePlatform.swift
@@ -46,6 +46,8 @@ public protocol MicrophoneEnginePlatform: AnyObject, Sendable {
 /// engine-lifecycle invariants from `MicrophoneCapture` (PR #186):
 ///
 /// - VPIO ducking is suppressed so other apps' audio isn't ~50% attenuated.
+/// - VPIO AGC is disabled so it cannot write the shared hardware input gain
+///   that other apps capturing the same mic (a live Zoom call) inherit.
 /// - The engine is destroyed and recreated on stop so coreaudiod releases
 ///   the VPAU aggregate device. A long-lived engine keeps the VPAU alive
 ///   indefinitely, which inherits the duplex layout into other engines.
@@ -326,6 +328,20 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
                 let errorType = AudioCaptureDiagnostics.errorType(error)
                 logger.debug(
                     "shared_mic_engine_ducking_config_failed error_type=\(errorType, privacy: .public) error_detail=\(error.localizedDescription, privacy: .private)"
+                )
+            }
+            do {
+                // VPIO's AGC can write the shared hardware input gain of the
+                // physical device, which every other app capturing the same
+                // mic (e.g. a live Zoom call) inherits. Keep the experimental
+                // VPIO path's side effects inside this process.
+                try catchingObjCException {
+                    inputNode.isVoiceProcessingAGCEnabled = false
+                }
+            } catch {
+                let errorType = AudioCaptureDiagnostics.errorType(error)
+                logger.debug(
+                    "shared_mic_engine_agc_config_failed error_type=\(errorType, privacy: .public) error_detail=\(error.localizedDescription, privacy: .private)"
                 )
             }
         }

--- a/Sources/MacParakeetCore/Services/Capture/CaptureOrchestrator.swift
+++ b/Sources/MacParakeetCore/Services/Capture/CaptureOrchestrator.swift
@@ -56,7 +56,14 @@ actor CaptureOrchestrator {
         micConditioner: any MicConditioning
     ) async -> CaptureOrchestratorOutput {
         let pairs = pairJoiner.flushRemainingPairs()
-        return await processPairs(pairs, micConditioner: micConditioner)
+        var output = await processPairs(pairs, micConditioner: micConditioner)
+        let heldSamples = micConditioner.flush()
+        if !heldSamples.isEmpty {
+            for micChunk in await microphoneChunker.addSamples(heldSamples) {
+                output.chunks.append(CaptureOrchestratorChunk(source: .microphone, chunk: micChunk))
+            }
+        }
+        return output
     }
 
     func flushChunkers() async -> [CaptureOrchestratorChunk] {
@@ -94,7 +101,13 @@ actor CaptureOrchestrator {
                 processedMicrophoneRms = chunkRms(for: processedMic)
                 micSamples = processedMic
             } else {
-                micSamples = pair.microphoneSamples
+                // Synthetic silence bypasses the conditioner; drain any
+                // samples it is holding first so they cannot land behind
+                // this pair's zeros out of order.
+                let heldSamples = micConditioner.flush()
+                micSamples = heldSamples.isEmpty
+                    ? pair.microphoneSamples
+                    : heldSamples + pair.microphoneSamples
             }
 
             for micChunk in await microphoneChunker.addSamples(micSamples) {

--- a/Sources/MacParakeetCore/Services/Capture/MeetingEchoSuppressionRuntime.swift
+++ b/Sources/MacParakeetCore/Services/Capture/MeetingEchoSuppressionRuntime.swift
@@ -16,9 +16,11 @@ public struct MeetingEchoSuppressionConfiguration: Sendable, Equatable {
     public static let modelSHA256EnvironmentKey = "MACPARAKEET_MEETING_ECHO_MODEL_SHA256"
     public static let frameSizeEnvironmentKey = "MACPARAKEET_MEETING_ECHO_FRAME_SIZE"
     public static let sampleRateEnvironmentKey = "MACPARAKEET_MEETING_ECHO_SAMPLE_RATE"
+    public static let referenceDelayMsEnvironmentKey = "MACPARAKEET_MEETING_ECHO_REFERENCE_DELAY_MS"
 
     public static let defaultSampleRate = 16_000
     public static let defaultFrameSize = 256
+    public static let defaultReferenceDelayMs = 0
 
     public var mode: MeetingEchoSuppressionMode
     public var libraryURL: URL?
@@ -26,6 +28,10 @@ public struct MeetingEchoSuppressionConfiguration: Sendable, Equatable {
     public var modelSHA256: String?
     public var sampleRate: Int
     public var frameSize: Int
+    /// How far behind the microphone the system-audio reference is read, in
+    /// milliseconds, approximating the output + acoustic + input echo-path
+    /// latency. 0 reads the reference at the microphone's own position.
+    public var referenceDelayMs: Int
 
     public init(
         mode: MeetingEchoSuppressionMode = .automatic,
@@ -33,7 +39,8 @@ public struct MeetingEchoSuppressionConfiguration: Sendable, Equatable {
         modelURL: URL? = nil,
         modelSHA256: String? = nil,
         sampleRate: Int = Self.defaultSampleRate,
-        frameSize: Int = Self.defaultFrameSize
+        frameSize: Int = Self.defaultFrameSize,
+        referenceDelayMs: Int = Self.defaultReferenceDelayMs
     ) {
         self.mode = mode
         self.libraryURL = libraryURL
@@ -41,6 +48,7 @@ public struct MeetingEchoSuppressionConfiguration: Sendable, Equatable {
         self.modelSHA256 = modelSHA256
         self.sampleRate = max(1, sampleRate)
         self.frameSize = max(1, frameSize)
+        self.referenceDelayMs = max(0, referenceDelayMs)
     }
 
     public static func fromEnvironment(
@@ -61,6 +69,8 @@ public struct MeetingEchoSuppressionConfiguration: Sendable, Equatable {
             .flatMap(Self.integerValue(from:)) ?? defaultSampleRate
         let frameSize = environment[frameSizeEnvironmentKey]
             .flatMap(Self.integerValue(from:)) ?? defaultFrameSize
+        let referenceDelayMs = environment[referenceDelayMsEnvironmentKey]
+            .flatMap(Self.integerValue(from:)) ?? defaultReferenceDelayMs
 
         return MeetingEchoSuppressionConfiguration(
             mode: mode,
@@ -68,7 +78,8 @@ public struct MeetingEchoSuppressionConfiguration: Sendable, Equatable {
             modelURL: modelURL,
             modelSHA256: modelSHA256,
             sampleRate: sampleRate,
-            frameSize: frameSize
+            frameSize: frameSize,
+            referenceDelayMs: referenceDelayMs
         )
     }
 
@@ -232,7 +243,13 @@ enum MeetingEchoSuppressionFactory {
                 sampleRate: configuration.sampleRate,
                 frameSize: configuration.frameSize
             )
-            return StreamingMeetingEchoSuppressor(processor: processor)
+            // The processor may report its own sample rate, so the ms→samples
+            // conversion happens here rather than in the configuration.
+            let referenceDelaySamples = configuration.referenceDelayMs * processor.sampleRate / 1_000
+            return StreamingMeetingEchoSuppressor(
+                processor: processor,
+                referenceDelaySamples: referenceDelaySamples
+            )
         } catch {
             return unavailableDynamicConditioner(reason: "load_failed", error: error)
         }

--- a/Sources/MacParakeetCore/Services/Capture/MicConditioner.swift
+++ b/Sources/MacParakeetCore/Services/Capture/MicConditioner.swift
@@ -40,12 +40,19 @@ protocol MeetingEchoSuppressing: AnyObject, Sendable {
 protocol MicConditioning: AnyObject, Sendable {
     var diagnostics: MeetingEchoSuppressionDiagnostics { get }
     func condition(microphone: [Float], speaker: [Float], hasSpeakerReference: Bool) -> [Float]
+    /// Drain any microphone samples held back by internal framing, raw.
+    /// Stateless conditioners hold nothing and return `[]` (the default).
+    func flush() -> [Float]
     func reset()
 }
 
 extension MicConditioning {
     func condition(microphone: [Float], speaker: [Float]) -> [Float] {
         condition(microphone: microphone, speaker: speaker, hasSpeakerReference: !speaker.isEmpty)
+    }
+
+    func flush() -> [Float] {
+        []
     }
 }
 
@@ -87,10 +94,31 @@ final class PassthroughMicConditioner: MicConditioning, @unchecked Sendable {
     }
 }
 
+/// Streams microphone batches through a frame-based echo processor.
+///
+/// Incoming batches rarely align with the processor's hop size, so samples
+/// that do not yet fill a frame are carried across `condition` calls instead
+/// of leaking through raw — the processor's streaming state requires
+/// contiguous frames. Reference (speaker) samples are appended in lockstep
+/// with microphone samples and retained `referenceDelaySamples` longer, so a
+/// frame at stream position `p` is cancelled against reference audio from
+/// `p - referenceDelaySamples` (the echo path is causal: speaker audio leaks
+/// into the mic only after output + acoustic + input latency).
 final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable {
     private let processor: any MeetingEchoSuppressing
+    private let referenceDelaySamples: Int
     private let lock = NSLock()
     private var diagnosticsStorage: MeetingEchoSuppressionDiagnostics
+
+    // `pendingMicrophone[0]` sits at absolute stream position
+    // `microphonePosition`; `referenceHistory[0]` at `referencePosition`.
+    // Invariant: referencePosition + referenceHistory.count ==
+    // microphonePosition + pendingMicrophone.count.
+    private var pendingMicrophone: [Float] = []
+    private var referenceHistory: [Float] = []
+    private var referenceValidity: [Bool] = []
+    private var microphonePosition = 0
+    private var referencePosition = 0
 
     var diagnostics: MeetingEchoSuppressionDiagnostics {
         lock.lock()
@@ -98,8 +126,9 @@ final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable
         return diagnosticsStorage
     }
 
-    init(processor: any MeetingEchoSuppressing) {
+    init(processor: any MeetingEchoSuppressing, referenceDelaySamples: Int = 0) {
         self.processor = processor
+        self.referenceDelaySamples = max(0, referenceDelaySamples)
         self.diagnosticsStorage = MeetingEchoSuppressionDiagnostics(
             processorName: processor.name,
             loaded: true,
@@ -116,23 +145,76 @@ final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable
     func condition(microphone: [Float], speaker: [Float], hasSpeakerReference: Bool) -> [Float] {
         guard !microphone.isEmpty else { return [] }
 
+        lock.lock()
+        defer { lock.unlock() }
+
+        pendingMicrophone.append(contentsOf: microphone)
+        for index in 0..<microphone.count {
+            let hasSample = hasSpeakerReference && index < speaker.count
+            referenceHistory.append(hasSample ? speaker[index] : 0)
+            referenceValidity.append(hasSample)
+        }
+
+        return drainProcessableFramesLocked()
+    }
+
+    func flush() -> [Float] {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard !pendingMicrophone.isEmpty else { return [] }
+        let tail = pendingMicrophone
+        diagnosticsStorage.rawFallbackFrames += 1
+        advanceConsumedLocked(by: tail.count)
+        return tail
+    }
+
+    func reset() {
+        lock.lock()
+        defer { lock.unlock() }
+        processor.reset()
+        pendingMicrophone.removeAll()
+        referenceHistory.removeAll()
+        referenceValidity.removeAll()
+        microphonePosition = 0
+        referencePosition = 0
+        diagnosticsStorage = MeetingEchoSuppressionDiagnostics(
+            processorName: processor.name,
+            loaded: true,
+            micFrames: 0,
+            processedFrames: 0,
+            rawFallbackFrames: 0,
+            fullReferenceFrames: 0,
+            partialReferenceFrames: 0,
+            missingReferenceFrames: 0,
+            processingFailures: 0
+        )
+    }
+
+    private enum ReferenceQuality {
+        case full
+        case partial
+        case missing
+    }
+
+    private func drainProcessableFramesLocked() -> [Float] {
         let frameSize = max(processor.frameSize, 1)
+        guard pendingMicrophone.count >= frameSize else { return [] }
+
         var output: [Float] = []
-        output.reserveCapacity(microphone.count)
+        output.reserveCapacity(pendingMicrophone.count)
         var micFrame = [Float](repeating: 0, count: frameSize)
         var referenceFrame = [Float](repeating: 0, count: frameSize)
         var processedFrame = [Float](repeating: 0, count: frameSize)
+        var consumed = 0
 
-        lock.lock()
-        defer { lock.unlock() }
-        var cursor = 0
-        while cursor + frameSize <= microphone.count {
-            copyFrame(from: microphone, start: cursor, into: &micFrame)
-            let referenceQuality = fillReferenceFrame(
+        while consumed + frameSize <= pendingMicrophone.count {
+            for offset in 0..<frameSize {
+                micFrame[offset] = pendingMicrophone[consumed + offset]
+            }
+            let referenceQuality = fillReferenceFrameLocked(
                 &referenceFrame,
-                speaker: speaker,
-                start: cursor,
-                hasSpeakerReference: hasSpeakerReference
+                frameStartPosition: microphonePosition + consumed
             )
 
             diagnosticsStorage.micFrames += 1
@@ -165,79 +247,44 @@ final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable
                 diagnosticsStorage.processingFailures += 1
             }
 
-            cursor += frameSize
+            consumed += frameSize
         }
 
-        if cursor < microphone.count {
-            output.append(contentsOf: microphone[cursor...])
-            diagnosticsStorage.rawFallbackFrames += 1
-        }
-
+        advanceConsumedLocked(by: consumed)
         return output
     }
 
-    func reset() {
-        lock.lock()
-        defer { lock.unlock() }
-        processor.reset()
-        diagnosticsStorage = MeetingEchoSuppressionDiagnostics(
-            processorName: processor.name,
-            loaded: true,
-            micFrames: 0,
-            processedFrames: 0,
-            rawFallbackFrames: 0,
-            fullReferenceFrames: 0,
-            partialReferenceFrames: 0,
-            missingReferenceFrames: 0,
-            processingFailures: 0
-        )
-    }
-
-    private enum ReferenceQuality {
-        case full
-        case partial
-        case missing
-    }
-
-    private func copyFrame(
-        from samples: [Float],
-        start: Int,
-        into frame: inout [Float]
-    ) {
-        for offset in frame.indices {
-            frame[offset] = samples[start + offset]
-        }
-    }
-
-    private func fillReferenceFrame(
+    private func fillReferenceFrameLocked(
         _ frame: inout [Float],
-        speaker: [Float],
-        start: Int,
-        hasSpeakerReference: Bool
+        frameStartPosition: Int
     ) -> ReferenceQuality {
-        for index in frame.indices {
-            frame[index] = 0
-        }
-
-        guard hasSpeakerReference, !speaker.isEmpty, start < speaker.count else {
-            return .missing
-        }
-
-        if start + frame.count <= speaker.count {
-            for offset in frame.indices {
-                frame[offset] = speaker[start + offset]
+        var validCount = 0
+        for offset in frame.indices {
+            let absolute = frameStartPosition + offset - referenceDelaySamples
+            let index = absolute - referencePosition
+            if index >= 0, index < referenceHistory.count, referenceValidity[index] {
+                frame[offset] = referenceHistory[index]
+                validCount += 1
+            } else {
+                frame[offset] = 0
             }
-            return .full
         }
 
-        let available = speaker.count - start
-        guard available > 0 else {
-            return .missing
-        }
+        if validCount == frame.count { return .full }
+        return validCount == 0 ? .missing : .partial
+    }
 
-        for offset in 0..<available {
-            frame[offset] = speaker[start + offset]
+    private func advanceConsumedLocked(by consumed: Int) {
+        guard consumed > 0 else { return }
+        pendingMicrophone.removeFirst(consumed)
+        microphonePosition += consumed
+
+        let keepFrom = microphonePosition - referenceDelaySamples
+        let dropCount = min(max(0, keepFrom - referencePosition), referenceHistory.count)
+        if dropCount > 0 {
+            referenceHistory.removeFirst(dropCount)
+            referenceValidity.removeFirst(dropCount)
+            referencePosition += dropCount
         }
-        return .partial
     }
 }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingTranscriptNoiseFilter.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingTranscriptNoiseFilter.swift
@@ -30,6 +30,9 @@ struct MeetingTranscriptNoiseFilter {
     private static let duplicateMaxWords = 10
     private static let duplicateLowConfidenceThreshold = 0.65
     private static let duplicateShortConfidenceThreshold = 0.80
+    private static let simultaneousEchoMinWords = 5
+    private static let simultaneousEchoSimilarity = 0.8
+    private static let fuzzyTokenMinLength = 4
     private static let allowedTokenCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "'"))
 
     static func cleanFinalMicrophoneWords(
@@ -49,6 +52,11 @@ struct MeetingTranscriptNoiseFilter {
             }
 
             if isObviousSystemDuplicate(microphoneRun: run.words, systemTokenWords: systemTokenWords) {
+                indexesToDrop.formUnion(run.indexes)
+                continue
+            }
+
+            if isSimultaneousSystemEcho(microphoneRun: run.words, systemTokenWords: systemTokenWords) {
                 indexesToDrop.formUnion(run.indexes)
             }
         }
@@ -122,6 +130,103 @@ struct MeetingTranscriptNoiseFilter {
         }
 
         return false
+    }
+
+    /// A microphone run that repeats the remote speaker's words *while the
+    /// remote speaker is saying them* is acoustic echo by construction — a
+    /// person cannot utter the same multi-word sequence simultaneously with
+    /// the far end. This rule is deliberately confidence-independent: loud
+    /// speaker playback transcribes confidently, which is exactly the echo
+    /// the confidence-gated duplicate rule misses. Precision comes from the
+    /// length floor, the simultaneity window, and the in-order match ratio.
+    private static func isSimultaneousSystemEcho(
+        microphoneRun: [WordTimestamp],
+        systemTokenWords: [(token: String, word: WordTimestamp)]
+    ) -> Bool {
+        let micTokens = normalizedTokens(microphoneRun)
+        guard micTokens.count >= simultaneousEchoMinWords,
+              let runStart = microphoneRun.first?.startMs,
+              let runEnd = microphoneRun.last?.endMs
+        else { return false }
+
+        let windowStart = runStart - duplicateTimingToleranceMs
+        let windowEnd = runEnd + duplicateTimingToleranceMs
+        let simultaneousTokens = systemTokenWords
+            .filter { $0.word.endMs >= windowStart && $0.word.startMs <= windowEnd }
+            .map(\.token)
+
+        let requiredMatches = Int((Double(micTokens.count) * simultaneousEchoSimilarity).rounded(.up))
+        guard simultaneousTokens.count >= requiredMatches else { return false }
+
+        return fuzzyLongestCommonSubsequence(micTokens, simultaneousTokens) >= requiredMatches
+    }
+
+    /// Length of the longest common subsequence under fuzzy token equality,
+    /// so a single inserted/dropped/respelled word ("number"/"numbers")
+    /// cannot defeat the match the way positional comparison would.
+    private static func fuzzyLongestCommonSubsequence(
+        _ micTokens: [String],
+        _ systemTokens: [String]
+    ) -> Int {
+        guard !micTokens.isEmpty, !systemTokens.isEmpty else { return 0 }
+
+        var previous = [Int](repeating: 0, count: systemTokens.count + 1)
+        var current = previous
+        for micToken in micTokens {
+            for (index, systemToken) in systemTokens.enumerated() {
+                if tokensRoughlyMatch(micToken, systemToken) {
+                    current[index + 1] = previous[index] + 1
+                } else {
+                    current[index + 1] = max(previous[index + 1], current[index])
+                }
+            }
+            previous = current
+        }
+        return previous[systemTokens.count]
+    }
+
+    private static func tokensRoughlyMatch(_ lhs: String, _ rhs: String) -> Bool {
+        if lhs == rhs { return true }
+        guard lhs.count >= fuzzyTokenMinLength, rhs.count >= fuzzyTokenMinLength else { return false }
+        return editDistanceIsAtMostOne(lhs, rhs)
+    }
+
+    private static func editDistanceIsAtMostOne(_ lhs: String, _ rhs: String) -> Bool {
+        let shorter: [Character]
+        let longer: [Character]
+        if lhs.count <= rhs.count {
+            shorter = Array(lhs)
+            longer = Array(rhs)
+        } else {
+            shorter = Array(rhs)
+            longer = Array(lhs)
+        }
+        guard longer.count - shorter.count <= 1 else { return false }
+
+        if shorter.count == longer.count {
+            var mismatches = 0
+            for index in shorter.indices where shorter[index] != longer[index] {
+                mismatches += 1
+                if mismatches > 1 { return false }
+            }
+            return true
+        }
+
+        var shortIndex = 0
+        var longIndex = 0
+        var skipped = false
+        while shortIndex < shorter.count {
+            if shorter[shortIndex] == longer[longIndex] {
+                shortIndex += 1
+                longIndex += 1
+            } else if skipped {
+                return false
+            } else {
+                skipped = true
+                longIndex += 1
+            }
+        }
+        return true
     }
 
     private static func rangesOverlapWithTolerance(

--- a/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressionRuntimeTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressionRuntimeTests.swift
@@ -10,6 +10,7 @@ final class MeetingEchoSuppressionRuntimeTests: XCTestCase {
             MeetingEchoSuppressionConfiguration.modelSHA256EnvironmentKey: " ABC123 ",
             MeetingEchoSuppressionConfiguration.sampleRateEnvironmentKey: " 48000 ",
             MeetingEchoSuppressionConfiguration.frameSizeEnvironmentKey: " 256 ",
+            MeetingEchoSuppressionConfiguration.referenceDelayMsEnvironmentKey: " 120 ",
         ])
 
         XCTAssertEqual(configuration.mode, .dynamicLibrary)
@@ -18,6 +19,15 @@ final class MeetingEchoSuppressionRuntimeTests: XCTestCase {
         XCTAssertEqual(configuration.modelSHA256, "abc123")
         XCTAssertEqual(configuration.sampleRate, 48_000)
         XCTAssertEqual(configuration.frameSize, 256)
+        XCTAssertEqual(configuration.referenceDelayMs, 120)
+    }
+
+    func testReferenceDelayDefaultsToZeroAndClampsNegative() {
+        XCTAssertEqual(MeetingEchoSuppressionConfiguration().referenceDelayMs, 0)
+        XCTAssertEqual(
+            MeetingEchoSuppressionConfiguration(referenceDelayMs: -50).referenceDelayMs,
+            0
+        )
     }
 
     func testDefaultFrameSizeMatchesLocalVQEHopLengthFallback() {

--- a/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressorTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressorTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import MacParakeetCore
 
 final class MeetingEchoSuppressorTests: XCTestCase {
-    func testProcessesFullReferenceFramesAndPreservesSampleCount() {
+    func testProcessesFullReferenceFramesAndHoldsTailForNextCall() {
         let processor = SubtractingEchoProcessor(frameSize: 4)
         let suppressor = StreamingMeetingEchoSuppressor(processor: processor)
 
@@ -12,9 +12,8 @@ final class MeetingEchoSuppressorTests: XCTestCase {
             hasSpeakerReference: true
         )
 
-        XCTAssertEqual(output.count, 5)
-        XCTAssertEqual(output.prefix(4).map { rounded($0) }, [0.4, 0.3, 0.1, 0.0])
-        XCTAssertEqual(output.last, 0.9, "tail samples that do not fill a processor frame pass through raw")
+        XCTAssertEqual(output.count, 4, "tail samples that do not fill a processor frame are held, not emitted raw")
+        XCTAssertEqual(output.map { rounded($0) }, [0.4, 0.3, 0.1, 0.0])
         XCTAssertEqual(
             suppressor.diagnostics,
             MeetingEchoSuppressionDiagnostics(
@@ -22,13 +21,100 @@ final class MeetingEchoSuppressorTests: XCTestCase {
                 loaded: true,
                 micFrames: 1,
                 processedFrames: 1,
-                rawFallbackFrames: 1,
+                rawFallbackFrames: 0,
                 fullReferenceFrames: 1,
                 partialReferenceFrames: 0,
                 missingReferenceFrames: 0,
                 processingFailures: 0
             )
         )
+    }
+
+    func testHeldTailJoinsNextCallIntoContiguousFrames() {
+        let processor = RecordingEchoProcessor(frameSize: 4)
+        let suppressor = StreamingMeetingEchoSuppressor(processor: processor)
+
+        let first = suppressor.condition(
+            microphone: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6],
+            speaker: [1.1, 1.2, 1.3, 1.4, 1.5, 1.6],
+            hasSpeakerReference: true
+        )
+        let second = suppressor.condition(
+            microphone: [0.7, 0.8],
+            speaker: [1.7, 1.8],
+            hasSpeakerReference: true
+        )
+
+        XCTAssertEqual(first, [0.1, 0.2, 0.3, 0.4])
+        XCTAssertEqual(second, [0.5, 0.6, 0.7, 0.8], "second frame must start with the carried tail")
+        XCTAssertEqual(processor.microphones, [[0.1, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8]])
+        XCTAssertEqual(
+            processor.references,
+            [[1.1, 1.2, 1.3, 1.4], [1.5, 1.6, 1.7, 1.8]],
+            "reference samples must stay aligned with carried microphone samples across calls"
+        )
+        XCTAssertEqual(suppressor.diagnostics.rawFallbackFrames, 0)
+    }
+
+    func testProcessedStreamIsInvariantToBatchSize() {
+        let microphone: [Float] = (0..<23).map { Float($0) / 100 }
+        let speaker: [Float] = (0..<23).map { Float($0) / 200 }
+
+        let single = StreamingMeetingEchoSuppressor(processor: SubtractingEchoProcessor(frameSize: 4))
+        var singleOutput = single.condition(microphone: microphone, speaker: speaker, hasSpeakerReference: true)
+        singleOutput += single.flush()
+
+        let batched = StreamingMeetingEchoSuppressor(processor: SubtractingEchoProcessor(frameSize: 4))
+        var batchedOutput: [Float] = []
+        var cursor = 0
+        for batchSize in [3, 7, 1, 5, 4, 2, 1] {
+            let next = min(cursor + batchSize, microphone.count)
+            batchedOutput += batched.condition(
+                microphone: Array(microphone[cursor..<next]),
+                speaker: Array(speaker[cursor..<next]),
+                hasSpeakerReference: true
+            )
+            cursor = next
+        }
+        batchedOutput += batched.flush()
+
+        XCTAssertEqual(cursor, microphone.count)
+        XCTAssertEqual(batchedOutput, singleOutput, "splitting the stream into batches must not change the output")
+    }
+
+    func testReferenceDelayReadsOlderSpeakerSamples() {
+        let processor = RecordingEchoProcessor(frameSize: 4)
+        let suppressor = StreamingMeetingEchoSuppressor(processor: processor, referenceDelaySamples: 2)
+
+        _ = suppressor.condition(
+            microphone: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8],
+            speaker: [1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8],
+            hasSpeakerReference: true
+        )
+
+        XCTAssertEqual(
+            processor.references,
+            [[0, 0, 1.1, 1.2], [1.3, 1.4, 1.5, 1.6]],
+            "frame at position p must read reference from p - delay, zero-filled before stream start"
+        )
+        XCTAssertEqual(suppressor.diagnostics.partialReferenceFrames, 1)
+        XCTAssertEqual(suppressor.diagnostics.fullReferenceFrames, 1)
+    }
+
+    func testFlushDrainsHeldTailRaw() {
+        let processor = SubtractingEchoProcessor(frameSize: 4)
+        let suppressor = StreamingMeetingEchoSuppressor(processor: processor)
+
+        _ = suppressor.condition(
+            microphone: [0.5, 0.4, 0.3, 0.2, 0.9],
+            speaker: [0.1, 0.1, 0.2, 0.2, 0.8],
+            hasSpeakerReference: true
+        )
+        let tail = suppressor.flush()
+
+        XCTAssertEqual(tail, [0.9], "flush returns held samples unprocessed")
+        XCTAssertEqual(suppressor.diagnostics.rawFallbackFrames, 1)
+        XCTAssertEqual(suppressor.flush(), [], "second flush has nothing left to drain")
     }
 
     func testMissingReferenceUsesZeroReferenceAndIncrementsDiagnostics() {
@@ -76,20 +162,30 @@ final class MeetingEchoSuppressorTests: XCTestCase {
         XCTAssertEqual(suppressor.diagnostics.processingFailures, 1)
     }
 
-    func testResetClearsProcessorAndDiagnostics() {
+    func testResetClearsProcessorDiagnosticsAndCarriedSamples() {
         let processor = RecordingEchoProcessor(frameSize: 4)
         let suppressor = StreamingMeetingEchoSuppressor(processor: processor)
 
         _ = suppressor.condition(
-            microphone: [0.5, 0.4, 0.3, 0.2],
-            speaker: [0.1, 0.1, 0.1, 0.1],
+            microphone: [0.5, 0.4, 0.3, 0.2, 0.9],
+            speaker: [0.1, 0.1, 0.1, 0.1, 0.1],
             hasSpeakerReference: true
         )
         suppressor.reset()
+        _ = suppressor.condition(
+            microphone: [0.6, 0.7, 0.8, 0.9],
+            speaker: [0.2, 0.2, 0.2, 0.2],
+            hasSpeakerReference: true
+        )
 
         XCTAssertEqual(processor.resetCount, 1)
-        XCTAssertEqual(suppressor.diagnostics.processedFrames, 0)
-        XCTAssertEqual(suppressor.diagnostics.fullReferenceFrames, 0)
+        XCTAssertEqual(
+            processor.microphones.last,
+            [0.6, 0.7, 0.8, 0.9],
+            "samples held before reset must not leak into post-reset frames"
+        )
+        XCTAssertEqual(suppressor.diagnostics.micFrames, 1)
+        XCTAssertEqual(suppressor.flush(), [])
     }
 
     private func rounded(_ value: Float) -> Float {
@@ -119,6 +215,7 @@ private final class RecordingEchoProcessor: MeetingEchoSuppressing, @unchecked S
     let name = "recording-test"
     let sampleRate = 16_000
     let frameSize: Int
+    private(set) var microphones: [[Float]] = []
     private(set) var references: [[Float]] = []
     private(set) var resetCount = 0
 
@@ -128,10 +225,12 @@ private final class RecordingEchoProcessor: MeetingEchoSuppressing, @unchecked S
 
     func reset() {
         resetCount += 1
+        microphones.removeAll()
         references.removeAll()
     }
 
     func processFrame(microphone: [Float], reference: [Float], output: inout [Float]) throws {
+        microphones.append(microphone)
         references.append(reference)
         for index in output.indices {
             output[index] = microphone[index]

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingTranscriptNoiseFilterTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingTranscriptNoiseFilterTests.swift
@@ -101,4 +101,133 @@ final class MeetingTranscriptNoiseFilterTests: XCTestCase {
             ["system", "microphone", "system", "system", "microphone", "microphone", "system", "microphone"]
         )
     }
+
+    /// Loud speaker playback transcribes confidently, so echo of a long
+    /// remote utterance sails past the confidence-gated duplicate rule. A
+    /// ≥5-word run matching the remote speaker's simultaneous words (with
+    /// minor STT spelling variance) is echo regardless of confidence.
+    func testFinalizeDropsLongHighConfidenceSimultaneousEcho() {
+        let finalized = MeetingTranscriptFinalizer.finalize(sourceTranscripts: [
+            .init(
+                source: .microphone,
+                result: STTResult(
+                    text: "Let's finalize the budget numbers tomorrow",
+                    words: [
+                        TimestampedWord(word: "Let's", startMs: 200, endMs: 480, confidence: 0.92),
+                        TimestampedWord(word: "finalize", startMs: 500, endMs: 900, confidence: 0.91),
+                        TimestampedWord(word: "the", startMs: 920, endMs: 1_040, confidence: 0.93),
+                        TimestampedWord(word: "budget", startMs: 1_060, endMs: 1_400, confidence: 0.90),
+                        TimestampedWord(word: "numbers", startMs: 1_420, endMs: 1_780, confidence: 0.88),
+                        TimestampedWord(word: "tomorrow", startMs: 1_800, endMs: 2_300, confidence: 0.92),
+                    ]
+                ),
+                startOffsetMs: 0
+            ),
+            .init(
+                source: .system,
+                result: STTResult(
+                    text: "Let's finalize the budget number tomorrow",
+                    words: [
+                        TimestampedWord(word: "Let's", startMs: 0, endMs: 280, confidence: 0.95),
+                        TimestampedWord(word: "finalize", startMs: 300, endMs: 700, confidence: 0.95),
+                        TimestampedWord(word: "the", startMs: 720, endMs: 840, confidence: 0.95),
+                        TimestampedWord(word: "budget", startMs: 860, endMs: 1_200, confidence: 0.95),
+                        TimestampedWord(word: "number", startMs: 1_220, endMs: 1_580, confidence: 0.95),
+                        TimestampedWord(word: "tomorrow", startMs: 1_600, endMs: 2_100, confidence: 0.95),
+                    ]
+                ),
+                startOffsetMs: 0
+            ),
+        ])
+
+        XCTAssertEqual(finalized.words.map(\.speakerId), Array(repeating: "system", count: 6))
+        XCTAssertEqual(finalized.rawTranscript, "Let's finalize the budget number tomorrow")
+    }
+
+    /// The same phrase repeated by the user AFTER the remote speaker finished
+    /// is genuine speech (agreement, read-back), not echo — the simultaneity
+    /// window must not reach it.
+    func testFinalizePreservesDelayedRepetitionOfSystemPhrase() {
+        let finalized = MeetingTranscriptFinalizer.finalize(sourceTranscripts: [
+            .init(
+                source: .microphone,
+                result: STTResult(
+                    text: "we ship the release on Friday",
+                    words: [
+                        TimestampedWord(word: "we", startMs: 4_000, endMs: 4_150, confidence: 0.92),
+                        TimestampedWord(word: "ship", startMs: 4_170, endMs: 4_400, confidence: 0.91),
+                        TimestampedWord(word: "the", startMs: 4_420, endMs: 4_520, confidence: 0.93),
+                        TimestampedWord(word: "release", startMs: 4_540, endMs: 4_900, confidence: 0.90),
+                        TimestampedWord(word: "on", startMs: 4_920, endMs: 5_000, confidence: 0.92),
+                        TimestampedWord(word: "Friday", startMs: 5_020, endMs: 5_400, confidence: 0.94),
+                    ]
+                ),
+                startOffsetMs: 0
+            ),
+            .init(
+                source: .system,
+                result: STTResult(
+                    text: "we ship the release on Friday",
+                    words: [
+                        TimestampedWord(word: "we", startMs: 0, endMs: 150, confidence: 0.95),
+                        TimestampedWord(word: "ship", startMs: 170, endMs: 400, confidence: 0.95),
+                        TimestampedWord(word: "the", startMs: 420, endMs: 520, confidence: 0.95),
+                        TimestampedWord(word: "release", startMs: 540, endMs: 900, confidence: 0.95),
+                        TimestampedWord(word: "on", startMs: 920, endMs: 1_000, confidence: 0.95),
+                        TimestampedWord(word: "Friday", startMs: 1_020, endMs: 1_400, confidence: 0.95),
+                    ]
+                ),
+                startOffsetMs: 0
+            ),
+        ])
+
+        XCTAssertEqual(
+            finalized.words.filter { $0.speakerId == "microphone" }.count,
+            6,
+            "a repetition that starts seconds after the remote phrase ended is not simultaneous echo"
+        )
+    }
+
+    func testFinalizePreservesSimultaneousDifferentSpeech() {
+        let finalized = MeetingTranscriptFinalizer.finalize(sourceTranscripts: [
+            .init(
+                source: .microphone,
+                result: STTResult(
+                    text: "I think we should wait until Monday",
+                    words: [
+                        TimestampedWord(word: "I", startMs: 100, endMs: 180, confidence: 0.92),
+                        TimestampedWord(word: "think", startMs: 200, endMs: 450, confidence: 0.91),
+                        TimestampedWord(word: "we", startMs: 470, endMs: 580, confidence: 0.93),
+                        TimestampedWord(word: "should", startMs: 600, endMs: 850, confidence: 0.90),
+                        TimestampedWord(word: "wait", startMs: 870, endMs: 1_100, confidence: 0.92),
+                        TimestampedWord(word: "until", startMs: 1_120, endMs: 1_350, confidence: 0.91),
+                        TimestampedWord(word: "Monday", startMs: 1_370, endMs: 1_750, confidence: 0.94),
+                    ]
+                ),
+                startOffsetMs: 0
+            ),
+            .init(
+                source: .system,
+                result: STTResult(
+                    text: "the deployment pipeline finished without any errors",
+                    words: [
+                        TimestampedWord(word: "the", startMs: 0, endMs: 120, confidence: 0.95),
+                        TimestampedWord(word: "deployment", startMs: 140, endMs: 560, confidence: 0.95),
+                        TimestampedWord(word: "pipeline", startMs: 580, endMs: 950, confidence: 0.95),
+                        TimestampedWord(word: "finished", startMs: 970, endMs: 1_300, confidence: 0.95),
+                        TimestampedWord(word: "without", startMs: 1_320, endMs: 1_600, confidence: 0.95),
+                        TimestampedWord(word: "any", startMs: 1_620, endMs: 1_750, confidence: 0.95),
+                        TimestampedWord(word: "errors", startMs: 1_770, endMs: 2_100, confidence: 0.95),
+                    ]
+                ),
+                startOffsetMs: 0
+            ),
+        ])
+
+        XCTAssertEqual(
+            finalized.words.filter { $0.speakerId == "microphone" }.count,
+            7,
+            "cross-talk with different words must never be treated as echo"
+        )
+    }
 }

--- a/plans/active/2026-05-meeting-neural-echo-suppression.md
+++ b/plans/active/2026-05-meeting-neural-echo-suppression.md
@@ -2,7 +2,39 @@
 
 > Status: ACTIVE PLAN
 > Date: 2026-05-22
+> Updated: 2026-06-10
 > Scope: meeting recording microphone cleanup, source separation, and release packaging.
+
+## Progress (2026-06-10, issue #480)
+
+Phase 1's streaming-coordinator defects are fixed and the transcript-layer
+safety net is hardened; the LocalVQE validation experiment is unblocked:
+
+- `StreamingMeetingEchoSuppressor` now carries partial frames across
+  `condition` calls (the pending-mic-frame queue this plan specified). Before,
+  every batch leaked an unprocessed raw tail (batches are not hop-size
+  multiples) and fed the stateful processor discontiguous frames — any live
+  test would have under-reported the model's real quality.
+- Reference delay is implemented: a reference-history ring serves the frame at
+  stream position `p` reference audio from `p - delay`, configured via
+  `MACPARAKEET_MEETING_ECHO_REFERENCE_DELAY_MS` (default 0). This is the
+  "configured reference offset" step; the cross-correlation estimator remains
+  future work if live tests show residual delay mismatch.
+- `MicConditioning.flush()` drains held samples; `CaptureOrchestrator` drains
+  before synthetic-silence pairs (ordering) and on pending-pair flush.
+- `MeetingTranscriptNoiseFilter` gained a confidence-independent
+  simultaneous-echo rule (>=5-word mic runs fuzzy-matching >=80% of the remote
+  speaker's simultaneous words are dropped) — the final-transcript fix for
+  high-confidence echo that the existing low-confidence rule missed.
+- VPIO experiment plumbing now sets `isVoiceProcessingAGCEnabled = false`
+  (macOS 14+): VPIO AGC can write the shared hardware input gain other apps
+  inherit, the likely mechanism behind the 2026-05-14 "muffled outgoing mic"
+  finding. Raw capture remains the shipped default; this only de-risks future
+  experiments.
+
+Next: obtain/build the LocalVQE assets, run the env-gated two-party
+speaker-call validation (Phase 5's "real two-party call validation"), then
+decide Phase 4 (cleaned final artifact) and release packaging.
 
 ## Problem
 

--- a/spec/adr/014-meeting-recording.md
+++ b/spec/adr/014-meeting-recording.md
@@ -8,6 +8,7 @@
 > Amended: 2026-05-09 (pause/resume for active recordings — [issue #235](https://github.com/moona3k/macparakeet/issues/235))
 > Amended: 2026-05-14 (ship raw meeting mic capture by default after live-call testing showed VPIO can muffle the user's outgoing mic for other participants)
 > Amended: 2026-05-29 (permission timing clarification: Screen & System Audio Recording can be granted from the optional onboarding step or requested on first meeting use; denied/missing permission still blocks recording)
+> Amended: 2026-06-10 (echo hardening for [issue #480](https://github.com/moona3k/macparakeet/issues/480): confidence-independent simultaneous-echo rule in the final transcript filter, streaming AEC frame carry + reference-delay knob, VPIO experiments now disable AGC)
 
 ## Context
 
@@ -102,7 +103,7 @@ Keeping mic and system audio as separate streams enables source-aware attributio
 
 The meeting service captures the active `SpeechEngineSelection` at start and persists it in the session metadata/lock file. Live preview, final transcription, retranscription of archived source files, and crash recovery use that captured selection. Settings cannot switch engines while the meeting's speech-engine lease is active.
 
-### 9. Meeting mic echo mitigation (v0.6 hardening)
+### 10. Meeting mic echo mitigation (v0.6 hardening)
 
 To reduce phantom "Me" fragments when users are on speakers:
 
@@ -111,6 +112,8 @@ To reduce phantom "Me" fragments when users are on speakers:
 - A short-window dominant-system guard remains in place for live mic chunk enqueue when recent system energy strongly dominates mic energy.
 - The guard affects live mic chunk transcription only; mic audio is still stored and included in the finalized meeting artifact.
 - Joiner queue overflow and sync-lag telemetry are logged for long-session observability.
+- The final transcript filter (`MeetingTranscriptNoiseFilter`) drops mic runs of >=5 words whose tokens fuzzy-match the remote speaker's *simultaneous* system words (>=80% in-order match within a +/-600 ms window), regardless of confidence — a person cannot utter the same multi-word sequence at the same time as the far end, so such runs are acoustic echo by construction (2026-06-10, issue #480). Short runs keep the conservative confidence-gated rule.
+- The opt-in experimental `StreamingMeetingEchoSuppressor` carries partial frames across batches (contiguous frames for stateful processors, no raw-tail leak) and supports an env-configured reference delay (`MACPARAKEET_MEETING_ECHO_REFERENCE_DELAY_MS`) approximating the echo-path latency (2026-06-10).
 - Dictation capture remains raw and unchanged (ADR-015 isolation still applies).
 
 ## Rationale


### PR DESCRIPTION
Addresses #480 — on speakers, the remote participant's voice bleeds acoustically into the mic and lands in the final transcript as phantom "Me" text.

## What this PR does

**1. Final-transcript fix (user-visible now): confidence-independent simultaneous-echo rule.**
`MeetingTranscriptNoiseFilter`'s existing duplicate rule only drops mic runs ≤10 words with *low* confidence and *exact* token equality — but loud speaker playback transcribes long and confident, which is exactly what #480's reporter sees. New rule: a mic run of ≥5 words whose tokens fuzzy-match (edit distance ≤1 on tokens ≥4 chars) ≥80% in-order (LCS) of the remote speaker's **simultaneous** system words (±600 ms window) is dropped regardless of confidence — a person cannot utter the same multi-word sequence at the same time as the far end, so such runs are acoustic echo by construction. Precision guards: 5-word floor (short genuine overlaps like "Can you hear me" untouched), simultaneity window (delayed repetition/read-back preserved), in-order match ratio (cross-talk with different words preserved). Each has a test.

**2. Streaming AEC correctness fixes (unblocks the LocalVQE validation).**
`StreamingMeetingEchoSuppressor` framed each batch independently: every `condition()` call leaked an unprocessed sub-frame tail raw (batches are never hop-size multiples) and fed the stateful processor discontiguous frames — any live model test would have under-reported quality. Now: pending samples carry across calls (batch-size-invariance test), reference history is retained and read at `p - delay` via the new `MACPARAKEET_MEETING_ECHO_REFERENCE_DELAY_MS` knob (default 0, no behavior change), and `MicConditioning.flush()` drains held samples with ordering preserved around synthetic-silence pairs in `CaptureOrchestrator`.

**3. VPIO experiment hardening (from the #480 investigation).**
The opt-in VPIO path now sets `isVoiceProcessingAGCEnabled = false` (macOS 14+). VPIO's AGC can write the physical device's shared hardware input gain, which other apps capturing the same mic (a live Zoom call) inherit — the likely mechanism behind the 2026-05-14 "muffled outgoing mic" finding (Apple Forums 733733/751100, corroborating reports). Raw capture remains the shipped default; this only de-risks future experiments.

## What this PR does not do

No change to shipped capture defaults, no localvqe assets bundled, no cleaned final artifact yet — that's the env-gated speaker-call validation + Phase 4 of `plans/active/2026-05-meeting-neural-echo-suppression.md` (progress log updated in this PR).

## Validation

- `swift test` full suite green (exit 0)
- Focused: suppressor 9/9 (incl. batch-size invariance, reference delay, flush, reset-clears-carry), runtime config, orchestrator, engine platform, shared stream, noise filter 6/6 (incl. three precision cases)
- `git diff --check` clean

ADR-014 amended (§9→§10 duplicate-number fix + 2026-06-10 amendment line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)