### PR TITLE
Fix dev launcher crash under ad-hoc signing (Sparkle library validation)

### DIFF
--- a/scripts/dev/run_app.sh
+++ b/scripts/dev/run_app.sh
@@ -163,9 +163,22 @@ PLIST
 
 # Re-sign the bundle so TCC can identify the dev build consistently. Use the
 # release app entitlements so permission smoke tests exercise the same TCC
-# capability surface as the signed distribution build.
+# capability surface as the signed distribution build. Ad-hoc signatures carry
+# no Team ID, so hardened-runtime library validation would reject the
+# bundle-local Sparkle.framework at load (dyld: "code signature … not valid
+# for use in process") — disable library validation for the ad-hoc fallback
+# only; real identities keep the release entitlement surface.
+SIGN_ENTITLEMENTS="$APP_ENTITLEMENTS"
+if [[ "$CODESIGN_IDENTITY" == "-" ]]; then
+  echo "  note: no codesigning identity found; ad-hoc signing with library validation disabled"
+  SIGN_ENTITLEMENTS="$(mktemp -t macparakeet-dev-entitlements)"
+  cp "$APP_ENTITLEMENTS" "$SIGN_ENTITLEMENTS"
+  /usr/libexec/PlistBuddy -c \
+    "Add :com.apple.security.cs.disable-library-validation bool true" \
+    "$SIGN_ENTITLEMENTS"
+fi
 codesign --force --sign "$CODESIGN_IDENTITY" --options runtime \
-  --entitlements "$APP_ENTITLEMENTS" --deep "$APP_BUNDLE"
+  --entitlements "$SIGN_ENTITLEMENTS" --deep "$APP_BUNDLE"
 
 echo "[3/5] Stopping existing MacParakeet processes…"
 pkill -f "/Applications/MacParakeet.app/Contents/MacOS/MacParakeet" || true

--- a/scripts/dev/run_app.sh
+++ b/scripts/dev/run_app.sh
@@ -172,10 +172,16 @@ SIGN_ENTITLEMENTS="$APP_ENTITLEMENTS"
 if [[ "$CODESIGN_IDENTITY" == "-" ]]; then
   echo "  note: no codesigning identity found; ad-hoc signing with library validation disabled"
   SIGN_ENTITLEMENTS="$(mktemp -t macparakeet-dev-entitlements)"
+  trap 'rm -f "$SIGN_ENTITLEMENTS"' EXIT
   cp "$APP_ENTITLEMENTS" "$SIGN_ENTITLEMENTS"
+  # `Add` fails if the key ever lands in the release entitlements; fall back
+  # to `Set` so the merge stays idempotent.
   /usr/libexec/PlistBuddy -c \
     "Add :com.apple.security.cs.disable-library-validation bool true" \
-    "$SIGN_ENTITLEMENTS"
+    "$SIGN_ENTITLEMENTS" 2>/dev/null || \
+    /usr/libexec/PlistBuddy -c \
+      "Set :com.apple.security.cs.disable-library-validation true" \
+      "$SIGN_ENTITLEMENTS"
 fi
 codesign --force --sign "$CODESIGN_IDENTITY" --options runtime \
   --entitlements "$SIGN_ENTITLEMENTS" --deep "$APP_BUNDLE"


### PR DESCRIPTION
## Summary

`scripts/dev/run_app.sh` crashes the dev app at launch on any Mac without a codesigning identity in the keychain. This fixes the script's ad-hoc fallback so the dev bundle launches on cert-less machines, without touching the real-identity or release signing paths.

## Root cause

- With no identity available, `pick_codesign_identity` falls back to ad-hoc (`-`) — by design, so the bundle stays launchable without a development certificate.
- The script signs the wrapped bundle with `--options runtime`, which enables hardened-runtime **library validation**.
- Ad-hoc signatures carry no Team ID, so dyld rejects the bundle-local `Sparkle.framework` (itself re-signed ad-hoc by `--deep`) at load:

```
Termination Reason: Namespace DYLD, Code 1, Library missing
Library not loaded: @rpath/Sparkle.framework/Versions/B/Sparkle
Reason: ... code signature in '.../Contents/Frameworks/Sparkle.framework/Versions/B/Sparkle'
not valid for use in process
```

The ad-hoc path could never work once Sparkle was embedded in the dev bundle (#97); machines with an "Apple Development" identity never hit it, which is why it went unnoticed.

## Fix

When the chosen identity is ad-hoc, sign with a temp copy of the release entitlements plus `com.apple.security.cs.disable-library-validation`, and print a note about the degraded mode. Real identities keep the exact previous behavior (release entitlement surface, library validation on). `scripts/dist/sign_notarize.sh` is untouched.

## Verification

- Reproduced and verified on a cert-less Apple Silicon Mac (macOS 26.5): app crashed at launch before the fix, launches and runs cleanly after.
- CI green (the change is a dev script; CI compiles/tests as usual).
