### PR TITLE
Align coding-agent guides on a canonical release block; archive shipped plans

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,27 +13,16 @@ transcription, and meeting recording, plus productized Transforms
 for selected-text rewrites. Parakeet TDT 0.6B via FluidAudio CoreML on the
 Apple Neural Engine is the default STT family: multilingual v3 is the default,
 and English-only v2 is an opt-in Parakeet model for users who want the fastest
-English path without v3 auto-detect. WhisperKit is also available as an optional
-local multilingual engine for languages Parakeet does not cover.
+English path without v3 auto-detect. Two optional local engines extend
+coverage: Nemotron 3.5 (Beta), a fast multilingual FluidAudio streaming
+engine, and WhisperKit for languages Parakeet does not cover.
 
-**Release status:** v0.6 ships system-wide dictation, file/URL transcription
-including local-file batches, meeting recording, Parakeet v3/v2 model
-selection, optional WhisperKit multilingual STT, and productized Transforms
-(shipping to stable since v0.6.7). Calendar reminders and auto-start are
-enabled (`AppFeatures.calendarEnabled = true`, shipping since v0.6.10);
-calendar auto-start defaults to mode `.off`, so it is strictly opt-in. Calendar-
-driven auto-stop was removed (ADR-017 amendment) — recordings stop manually.
-VAD-guided meeting live-preview chunking is enabled
-(`AppFeatures.meetingVadLiveChunkingEnabled = true`, shipping since v0.6.14):
-launch-time prep fetches the Silero VAD model in the background, Parakeet
-meetings cut live-preview chunks at speech boundaries when the model is cached,
-and missing/erroring VAD falls back to the fixed 5s / 1s-overlap chunker without
-affecting the final post-stop transcript. `main` currently carries one feature
-flag ahead of the latest release tag: `AppFeatures.aiFormatterProfilesEnabled =
-true` (app-aware AI Formatter profiles with readable/toggleable smart defaults,
-enabled 2026-06-10 ahead of the next release). All other `AppFeatures` flags
-match the shipping build, and `main` otherwise differs only by untagged
-in-progress fixes.
+**Release status:** The notarized Stable DMG is the user-facing release
+channel; `main` is development. The canonical channel framing — including
+which `AppFeatures` flags differ between `main` and the latest release tag —
+lives in one place: [`CLAUDE.md`](./CLAUDE.md) → "Release Channels". Check
+there before describing release status anywhere; don't restate it in other
+docs.
 
 Free and open-source (GPL-3.0). Apple Silicon only. Requires macOS 14.2+.
 
@@ -54,6 +43,9 @@ swift build
 # Run the test suite (Swift 6 language mode)
 swift test
 
+# Focused run of one test class while iterating (full suite before merge)
+swift test --filter TextProcessingPipelineTests
+
 # Build, codesign, and launch the dev app
 scripts/dev/run_app.sh
 
@@ -65,6 +57,22 @@ swift run macparakeet-cli health
 The full test suite is deterministic and normally finishes in roughly one to
 two minutes depending on SwiftPM cache state. Run `swift test` before declaring
 code-change work complete.
+
+## Git & Worktrees
+
+This repo runs many parallel worktrees. Two rules that save real time:
+
+- **Base new branches/worktrees on `origin/main`, not local `main`** — the
+  local `main` ref is often stale here. `git fetch origin` first, then
+  `git worktree add -b my-branch ../macparakeet-worktrees/my-branch origin/main`.
+- **Build from the worktree the branch is checked out in.** Xcode/SwiftPM
+  state under `.swiftpm/` pins source paths to the worktree that created it,
+  so `xcodebuild` invoked from another checkout can silently compile the
+  wrong tree. `swift build` / `swift test` from inside the worktree are
+  always safe.
+
+More git/CI gotchas (flaky-test policy, blame across the line-ending
+renormalization): [`CLAUDE.md`](./CLAUDE.md) → "Known Pitfalls".
 
 ## Code Style
 
@@ -135,8 +143,9 @@ READMEs today: `Audio/`, `STT/`, `TextProcessing/`, `Database/`,
 |------|------|
 | App bundle | `/Applications/MacParakeet.app` |
 | Database | `~/Library/Application Support/MacParakeet/macparakeet.db` |
-| Parakeet CoreML STT models (~465 MB per build) | FluidAudio default cache |
+| Parakeet / Nemotron CoreML STT models (~465 MB per Parakeet build, ~1.5 GB Nemotron) | FluidAudio default cache, `~/Library/Application Support/FluidAudio/Models/` |
 | WhisperKit STT models | `~/Library/Application Support/MacParakeet/models/stt/whisper/` |
+| yt-dlp / FFmpeg helper binaries | `~/Library/Application Support/MacParakeet/bin/` |
 | Settings | `~/Library/Preferences/com.macparakeet.plist` |
 | Logs | `~/Library/Logs/MacParakeet/` |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,8 +71,7 @@ This repo runs many parallel worktrees. Two rules that save real time:
   wrong tree. `swift build` / `swift test` from inside the worktree are
   always safe.
 
-More git/CI gotchas (flaky-test policy, blame across the line-ending
-renormalization): [`CLAUDE.md`](./CLAUDE.md) → "Known Pitfalls".
+More git/CI gotchas (flaky-test policy, line-ending rules): [`CLAUDE.md`](./CLAUDE.md) → "Known Pitfalls".
 
 ## Code Style
 
@@ -143,7 +142,7 @@ READMEs today: `Audio/`, `STT/`, `TextProcessing/`, `Database/`,
 |------|------|
 | App bundle | `/Applications/MacParakeet.app` |
 | Database | `~/Library/Application Support/MacParakeet/macparakeet.db` |
-| Parakeet / Nemotron CoreML STT models (~465 MB per Parakeet build, ~1.5 GB Nemotron) | FluidAudio default cache, `~/Library/Application Support/FluidAudio/Models/` |
+| Parakeet / Nemotron CoreML STT models (~465 MB per Parakeet build, ~1.5 GB Nemotron) | FluidAudio default cache, `~/Library/Application Support/FluidAudio/Models/` (Parakeet: `parakeet-*/`; Nemotron: `nemotron-multilingual/`) |
 | WhisperKit STT models | `~/Library/Application Support/MacParakeet/models/stt/whisper/` |
 | yt-dlp / FFmpeg helper binaries | `~/Library/Application Support/MacParakeet/bin/` |
 | Settings | `~/Library/Preferences/com.macparakeet.plist` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,25 +14,31 @@ A **fast, private, local-first voice app** for macOS. The v0.6 release ships sys
 
 ## Release Channels
 
+> **Canonical release-status block.** This section is the single source of
+> truth for channel framing and the `main`-vs-release `AppFeatures` flag
+> delta. AGENTS.md, README.md, and other docs point here rather than
+> restating it — when a release ships or a flag flips, update this section
+> and leave the pointers alone.
+
 | Channel | Agent Assumption | Features |
 |---------|------------------|----------|
 | Stable DMG | User-facing release, recommended for normal use | Dictation, file and multi-platform video/podcast URL transcription, meeting recording, calendar auto-start (opt-in, default `.off`), productized Transforms, VAD-guided meeting live-preview chunking, opt-in instant dictation, optional Nemotron Beta and WhisperKit engines, exports, vocabulary, AI features |
-| `main` | Development | Latest stable release plus untagged in-progress fixes. One feature flag differs from the latest release tag: `AppFeatures.aiFormatterProfilesEnabled = true` on `main` (app-aware AI Formatter profiles, enabled 2026-06-10 ahead of the next release) |
+| `main` | Development | Latest stable release plus untagged in-progress fixes, plus the flag delta below |
 
-When editing public-facing docs, keep the channel framing accurate: `main`
-currently carries one flag ahead of the latest release tag —
+**Flag delta — `main` vs the latest release tag (one flag):**
 `AppFeatures.aiFormatterProfilesEnabled = true` (app-aware AI Formatter
-profiles with readable/toggleable smart defaults, REQ-LLM-004) — plus untagged
-in-progress fixes; all other `AppFeatures` flags match the shipping build.
-Transforms shipped to stable in v0.6.7, calendar
-auto-start in v0.6.10, and VAD-guided meeting live-preview chunking in v0.6.14.
-Calendar auto-start defaults to mode `.off`, so it is strictly opt-in. Calendar-
-driven auto-stop was removed (ADR-017 amendment, 2026-05) — scheduled end times
-are unreliable, so recordings are stopped manually (activity/audio-based auto-stop
-is a future ADR). VAD-guided meeting live-preview chunking is flag-on: launch-time
-background prep fetches the Silero model, Parakeet meetings use speech-boundary
-live chunks when it is cached, and all missing/error paths fall back to the fixed
-5s / 1s chunker; final meeting transcription is unchanged.
+profiles with readable/toggleable smart defaults, REQ-LLM-004; enabled
+2026-06-10, not yet in a tagged release). All other `AppFeatures` flags match
+the shipping build.
+
+Ship history for flagged features: Transforms reached stable in v0.6.7;
+calendar auto-start in v0.6.10 (defaults to mode `.off`, strictly opt-in;
+calendar-driven auto-stop was removed per the ADR-017 amendment, 2026-05 —
+scheduled end times are unreliable, so recordings stop manually); VAD-guided
+meeting live-preview chunking in v0.6.14 (launch-time background prep fetches
+the Silero model, Parakeet meetings cut live chunks at speech boundaries when
+it is cached, and all missing/error paths fall back to the fixed 5s / 1s
+chunker — final meeting transcription is unchanged).
 
 ## Quick Navigation
 
@@ -140,11 +146,17 @@ All ADRs are in `spec/adr/`. These are locked decisions -- don't second-guess th
 
 ## Current Phase
 
-**Current main branch** -- v0.6 release scope includes meeting recording, multi-platform video/podcast URL transcription (any `yt-dlp` site plus Apple Podcasts and freetext podcast search), Parakeet v3/v2 model selection, an optional Nemotron 3.5 Beta engine, optional WhisperKit multilingual STT, opt-in instant dictation (warm-mic pre-roll), and productized Transforms. Calendar auto-start/reminders are implemented and enabled (`AppFeatures.calendarEnabled = true`) after the post-#318 reliability hardening; auto-start defaults to mode `.off`, so it stays opt-in. VAD-guided meeting live-preview chunking is enabled (`AppFeatures.meetingVadLiveChunkingEnabled = true`, shipping since v0.6.14) with fixed-chunker fallback and unchanged final transcription. App-aware AI Formatter profiles are enabled on `main` (`AppFeatures.aiFormatterProfilesEnabled = true`, 2026-06-10, REQ-LLM-004): dictation formatter prompts route custom app profile → custom category profile → built-in smart default (readable + toggleable, master and per-category switches; defaults on) → fallback prompt, with routing provenance shown in dictation History; this flag has not shipped in a tagged release yet.
+**v0.6 series** — meeting recording (ADR-014/015/016/019/020), multi-platform
+video/podcast URL transcription (any `yt-dlp` site plus Apple Podcasts and
+freetext podcast search), Parakeet v3/v2 model selection, optional Nemotron
+3.5 Beta and WhisperKit engines (ADR-021), opt-in instant dictation (warm-mic
+pre-roll), app-aware AI Formatter profiles (REQ-LLM-004, `main`-only flag),
+and productized Transforms with `Polish`/`Distill`/`Decide` built-ins on
+Control-Option hotkeys (ADR-022). Calendar auto-start is ADR-017 Phases 1 + 2
+(enabled, default `.off`); Phase 3 (late-join/retro-link) remains proposed.
 
-- **v0.1–v0.5** MVP → Clean Pipeline → YouTube/Export → Polish/Launch → Data/UI/Prompts (open-source release). See the `spec/README.md` roadmap and git tags for the full per-version feature history.
-- **v0.6** Meeting Recording + Multilingual STT + Transforms -- ScreenCaptureKit system audio + raw AVAudioEngine mic capture by default, retained opt-in VPIO plumbing, fragmented MP4 source files + crash recovery (ADR-019), transcript-layer suppression, concurrent with dictation (ADR-015), centralized STT runtime + scheduler (ADR-016), VAD-guided meeting live-preview chunking with fixed fallback (flag-on, shipping since v0.6.14), sacred-geometry recording pill + Notes/Transcript/Ask meeting panel, customizable Ask quick prompts, library integration, prompt/result/chat support (ADR-014), live notepad + memo-steered summaries with `{{userNotes}}` template variable + slash commands (ADR-020), Parakeet model selection (`v3` multilingual default, `v2` English-only opt-in) across Settings/CLI, optional Nemotron 3.5 Beta and WhisperKit engine support for non-Parakeet languages, persisted speech-engine preference, Whisper/Nemotron language picker/default, CLI `transcribe --engine parakeet|nemotron|whisper --language --parakeet-model`, Whisper/Nemotron model download paths, engine pinning for active meeting sessions and crash recovery (ADR-021), multi-platform video/podcast URL transcription (any `yt-dlp` site plus Apple Podcasts iTunes resolution and freetext podcast search) with a platform-orbit hero and per-platform telemetry, opt-in instant dictation warm-mic pre-roll, and productized system-wide LLM Transforms with `Polish`, `Distill`, and `Decide` built-ins on Control-Option hotkeys (ADR-022).
-- **Calendar auto-start** -- ADR-017 Phases 1 + 2, enabled with `.off` default (see "Current main branch" above for live flag state); Phase 3 (late-join/retro-link) remains proposed.
+Live flag state and the `main`-vs-release delta: see "Release Channels" above.
+Per-version feature history: the `spec/README.md` roadmap and git tags.
 
 ## Key Patterns
 
@@ -231,66 +243,16 @@ CPU/GPU/CoreML as selected by WhisperKit: optional multilingual STT
 
 ### GUI Structure
 
-MacParakeet is a **menu bar app** with these UI surfaces:
-
-```
-Menu Bar Icon (always visible)
-    |
-    +-- Main Window (capture hub + library)
-    |   +-- Transcribe tab: video URL card, file drop card, Meeting Recording tile
-    |   +-- Library tab: file/video URL/meeting transcript browse
-    |   +-- Dictations, Vocabulary, Feedback, Settings, Discover
-    |   +-- Global transcription progress bar outside Transcribe
-    |
-    +-- Idle Pill (persistent floating indicator)
-    |   +-- Always visible when not dictating
-    |   +-- Click or hover to start dictating
-    |   +-- Hides during active dictation
-    |
-    +-- Dictation Overlay (compact dark pill)
-    |   +-- Recording state indicator
-    |   +-- Waveform visualization
-    |   +-- Cancel/stop controls
-    |
-    +-- Vocabulary Panel
-    |   +-- Processing mode (raw/clean)
-    |   +-- Pipeline guide + tips
-    |   +-- Custom words management (sheet)
-    |   +-- Text snippets management (sheet)
-    |
-    +-- Feedback Panel
-    |   +-- Category selection (bug report, feature request, other)
-    |   +-- Message form with optional email + screenshot
-    |
-    +-- Settings Window
-    |   +-- Hotkey configuration
-    |   +-- LLM provider settings
-    |   +-- Storage management
-    |   +-- Permissions
-    |   +-- Auto-update preferences
-    |
-    +-- Transcribe Tab (capture hub for all three modes)
-    |   +-- Video URL card (paste link)
-    |   +-- File drop card
-    |   +-- Meeting Recording tile (reflects live state)
-    |
-    +-- Meeting Recording Pill (floating indicator)
-    |   +-- Sacred-geometry rosette + stem
-    |   +-- Red dot + elapsed timer (on hover)
-    |   +-- Right-click: Stop / Open / Cancel
-    |   +-- Shares state with the Transcribe tile
-    |
-    +-- Library Panel
-    |   +-- Filter bar: All/Video/Local/Meetings/Favorites
-    |   +-- Thumbnail grid for All/Video/Local/Favorites
-    |   +-- Date-grouped list (Today/Yesterday/...) for Meetings filter
-    |   +-- Search and sort
-    |
-    +-- History Panel
-        +-- Dictation history with search
-        +-- Audio playback
-        +-- Re-copy / re-process
-```
+MacParakeet is a **menu bar app** (NSStatusItem, always visible). UI
+surfaces: the main window (Transcribe capture hub, Library, Dictations,
+Vocabulary, Feedback, Settings, Discover), a persistent idle pill (hidden
+during active dictation), the dictation overlay (compact dark pill with
+waveform + cancel/stop), the floating meeting-recording pill
+(sacred-geometry rosette; shares live state with the Transcribe tile via one
+long-lived `MeetingRecordingPillViewModel`), the Transforms floating
+result/progress pill, and the Settings window. Library's Meetings filter is
+a date-grouped list; the other filters (All/Video/Local/Favorites) use a
+thumbnail grid. Full surface-by-surface breakdown: `spec/04-ui-patterns.md`.
 
 View files organized by feature in `Sources/MacParakeet/Views/`:
 - `Transcription/` -- Transcribe tab, drop zone, video URL card, **Meeting Recording tile**, transcript display, export, library grid + meetings list
@@ -428,21 +390,22 @@ Plans live in `plans/` and are version-controlled. Create a plan for multi-file 
 
 ### Release a new build
 
-Full guide: `docs/distribution.md`. Quick steps:
+Follow `docs/distribution.md` — it is the authoritative step-by-step guide
+(pre-flight tests, version bump, build, sign + notarize, R2 upload, Sparkle
+`sign_update`, appcast prepend, website deploy, verify).
 
-0. **Pre-flight:** Run `swift test` (all must pass). Check current version: `curl -s "https://macparakeet.com/appcast.xml" | grep sparkle:shortVersionString`. Decide version bump -- patch (0.1.x) for fixes, minor (0.x.0) for features.
-1. **Build:** `VERSION=X.Y.Z scripts/dist/build_app_bundle.sh`
-2. **Sign + notarize:** `scripts/dist/sign_notarize.sh`
-   - After signing, smoke-test bundled helpers: `dist/MacParakeet.app/Contents/Resources/yt-dlp --version`.
-   - `yt-dlp_macos` is a PyInstaller binary. If it is signed with hardened runtime, it must have `com.apple.security.cs.disable-library-validation=true`; otherwise fresh installs can fail on first YouTube use with `[PYI:ERROR] Failed to load Python shared library ... different Team IDs`.
-3. **Upload DMG to R2:** `npx wrangler r2 object put macparakeet-downloads/MacParakeet.dmg --file dist/MacParakeet.dmg --content-type "application/x-apple-diskimage" --remote`
-4. **Verify R2 file size matches local:** `curl -sI "https://downloads.macparakeet.com/MacParakeet.dmg?ts=$(date +%s)" | grep content-length` -- must equal `stat -f%z dist/MacParakeet.dmg`
-5. **Sign for Sparkle:** `.build/artifacts/sparkle/Sparkle/bin/sign_update dist/MacParakeet.dmg`
-6. **Update appcast:** Edit `~/code/macparakeet-website/public/appcast.xml` -- **prepend** new `<item>` (keep all previous items). Include build number, version, signature, length, `pubDate` (`date -R`), release notes.
-7. **Deploy website:** `cd ~/code/macparakeet-website && git add public/appcast.xml && git commit && git push && npx astro build && npx wrangler pages deploy dist --project-name macparakeet-website --branch main`
-8. **Verify:** `curl -s "https://macparakeet.com/appcast.xml?ts=$(date +%s)" | grep sparkle:version`
+Critical invariants (full context and commands in the guide):
 
-**Critical:** The DMG uploaded to R2 must be the **exact same file** you ran `sign_update` on. If sizes don't match, Sparkle rejects the update.
+- The DMG uploaded to R2 must be the **exact same file** you ran
+  `sign_update` on. Verify the served `content-length` equals the local
+  `stat -f%z dist/MacParakeet.dmg`; if they differ, Sparkle rejects the update.
+- Appcast enclosure URLs must include `?v={BUILD_NUMBER}` cache-busting —
+  Cloudflare CDN caches R2 objects (~4h), and a stale cached DMG fails
+  Sparkle as "improperly signed".
+- Bundled `yt-dlp_macos` (PyInstaller) signed with hardened runtime needs
+  `com.apple.security.cs.disable-library-validation=true`, or fresh installs
+  fail on first YouTube use with a `[PYI:ERROR]` Team ID mismatch. Smoke-test
+  after signing: `dist/MacParakeet.app/Contents/Resources/yt-dlp --version`.
 
 ## Testing
 
@@ -459,8 +422,9 @@ See `spec/09-testing.md` for full strategy. Key points:
 ### Running Tests
 
 ```bash
-swift test              # Full deterministic suite, usually ~1-2 minutes
-swift test --parallel   # Optional parallel run when chasing wall-clock time
+swift test                                       # Full deterministic suite, usually ~1-2 minutes
+swift test --filter TextProcessingPipelineTests  # Focused run of one test class while iterating
+swift test --parallel                            # Optional parallel run when chasing wall-clock time
 ```
 
 ### AI Agent Testing Loop
@@ -505,7 +469,7 @@ open Package.swift  # Select MacParakeet scheme
 |------|------|
 | App bundle | `/Applications/MacParakeet.app` |
 | Database | `~/Library/Application Support/MacParakeet/macparakeet.db` |
-| Parakeet STT models | FluidAudio default cache (CoreML, ~465 MB per build) |
+| Parakeet / Nemotron STT models | FluidAudio default cache, `~/Library/Application Support/FluidAudio/Models/` (CoreML; ~465 MB per Parakeet build, ~1.5 GB Nemotron) |
 | Whisper STT models | `~/Library/Application Support/MacParakeet/models/stt/whisper/` |
 | yt-dlp binary | `~/Library/Application Support/MacParakeet/bin/yt-dlp` |
 | FFmpeg binary | `~/Library/Application Support/MacParakeet/bin/ffmpeg` |
@@ -568,9 +532,30 @@ Both audiences share the same command tree. Dev/auxiliary commands (e.g. `calend
 
 ---
 
-## Known Pitfalls (from OatFlow Experience)
+## Known Pitfalls (Hard-Won Lessons)
 
-These are hard-won lessons. Don't repeat them.
+These come from OatFlow experience and from working in this repo. Don't
+repeat them.
+
+### Git / Worktree Gotchas
+
+- **Base new branches/worktrees on `origin/main`, not local `main`** -- this
+  repo runs many parallel worktrees, so the local `main` ref is often stale.
+  `git fetch origin` first, then
+  `git worktree add -b my-branch ../macparakeet-worktrees/my-branch origin/main`.
+- **Build from the worktree the branch is checked out in** -- Xcode/SwiftPM
+  state under `.swiftpm/` pins source paths to the worktree that created it,
+  so `xcodebuild` invoked from another checkout can silently compile the
+  wrong tree. `swift build` / `swift test` run from inside the worktree are
+  always safe.
+- **`DictationFlowCoordinatorLoadCaptionTests` is known-flaky on CI** -- a
+  `waitUntil` races a ~60 ms transient state, so the same commit can pass and
+  fail seconds apart. Re-run the failed job; don't "fix" the test unless the
+  flake rate justifies a harness refactor.
+- **Blame across the 2026-06-11 line-ending renormalization** -- run
+  `git config blame.ignoreRevsFile .git-blame-ignore-revs` once locally so
+  repo-wide mechanical commits don't bury real history. `.gitattributes`
+  normalizes all text files to LF; don't commit CRLF.
 
 ### Swift Language Gotchas
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ All ADRs are in `spec/adr/`. These are locked decisions -- don't second-guess th
 **v0.6 series** — meeting recording (ADR-014/015/016/019/020), multi-platform
 video/podcast URL transcription (any `yt-dlp` site plus Apple Podcasts and
 freetext podcast search), Parakeet v3/v2 model selection, optional Nemotron
-3.5 Beta and WhisperKit engines (ADR-021), opt-in instant dictation (warm-mic
+3.5 Beta (ADR-001 amendment) and WhisperKit (ADR-021) engines, opt-in instant dictation (warm-mic
 pre-roll), app-aware AI Formatter profiles (REQ-LLM-004, `main`-only flag),
 and productized Transforms with `Polish`/`Distill`/`Decide` built-ins on
 Control-Option hotkeys (ADR-022). Calendar auto-start is ADR-017 Phases 1 + 2
@@ -224,7 +224,7 @@ code bypasses ADR-016's process-wide scheduler.
 **Two-chip architecture:**
 ```
 CPU:  MacParakeet app (UI, hotkeys, clipboard, history)
-ANE:  Parakeet STT (via FluidAudio/CoreML) -- dedicated ML chip
+ANE:  Parakeet / Nemotron STT (via FluidAudio/CoreML) -- dedicated ML chip
 CPU/GPU/CoreML as selected by WhisperKit: optional multilingual STT
 ```
 
@@ -469,7 +469,7 @@ open Package.swift  # Select MacParakeet scheme
 |------|------|
 | App bundle | `/Applications/MacParakeet.app` |
 | Database | `~/Library/Application Support/MacParakeet/macparakeet.db` |
-| Parakeet / Nemotron STT models | FluidAudio default cache, `~/Library/Application Support/FluidAudio/Models/` (CoreML; ~465 MB per Parakeet build, ~1.5 GB Nemotron) |
+| Parakeet / Nemotron STT models | FluidAudio default cache, `~/Library/Application Support/FluidAudio/Models/` (Parakeet: `parakeet-*/`; Nemotron: `nemotron-multilingual/`; CoreML; ~465 MB per Parakeet build, ~1.5 GB Nemotron) |
 | Whisper STT models | `~/Library/Application Support/MacParakeet/models/stt/whisper/` |
 | yt-dlp binary | `~/Library/Application Support/MacParakeet/bin/yt-dlp` |
 | FFmpeg binary | `~/Library/Application Support/MacParakeet/bin/ffmpeg` |
@@ -552,10 +552,11 @@ repeat them.
   `waitUntil` races a ~60 ms transient state, so the same commit can pass and
   fail seconds apart. Re-run the failed job; don't "fix" the test unless the
   flake rate justifies a harness refactor.
-- **Blame across the 2026-06-11 line-ending renormalization** -- run
+- **Mixed line endings flip whole files on edit** -- keep text files LF;
+  never commit CRLF. If the repo has `.git-blame-ignore-revs` (added with
+  the repo-wide LF renormalization), run
   `git config blame.ignoreRevsFile .git-blame-ignore-revs` once locally so
-  repo-wide mechanical commits don't bury real history. `.gitattributes`
-  normalizes all text files to LF; don't commit CRLF.
+  mechanical commits don't bury real history.
 
 ### Swift Language Gotchas
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-GPL--3.0-blue.svg" alt="GPL-3.0 License"></a>
   <img src="https://img.shields.io/badge/macOS-14.2%2B-000000.svg" alt="macOS 14.2+">
   <img src="https://img.shields.io/badge/Swift-6.0-F05138.svg" alt="Swift 6">
-  <img src="https://img.shields.io/badge/tests-passing-brightgreen.svg" alt="Tests passing">
+  <a href="https://github.com/moona3k/macparakeet/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/moona3k/macparakeet/ci.yml?branch=main&label=CI" alt="CI status"></a>
   <img src="https://img.shields.io/badge/Apple%20Silicon-only-333333.svg" alt="Apple Silicon only">
 </p>
 
@@ -239,6 +239,7 @@ All speech recognition runs locally. Parakeet uses the Neural Engine; optional N
 - **Discuss new work first** — For features or behavior changes, open an issue before starting a PR so we can agree on scope and product fit.
 - **Submit scoped PRs** — Once the issue direction is clear, fork, make the scoped changes, run `swift test`, and link the issue in the PR.
 - **Read the specs** — Architecture decisions and feature specs live in `spec/`
+- **Using a coding agent?** Point it at [`AGENTS.md`](AGENTS.md) — build/test commands, code style, and repo conventions for Claude Code, Codex, and friends. Deeper project context is in [`CLAUDE.md`](CLAUDE.md).
 
 ## Support
 

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -527,7 +527,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             await sttRuntime.backgroundWarmUp()
 
             // Universal VAD model availability (Phase 4.5,
-            // plans/active/2026-05-meeting-vad-guided-live-chunking.md §6).
+            // plans/completed/2026-05-meeting-vad-guided-live-chunking.md §6).
             // Runs every launch for every user so flipping the live-chunking
             // flag reaches the installed base, not just fresh installs. Kept
             // independent of the speech warm-up above: idempotent, silent-fail,

--- a/Sources/MacParakeetCore/AppFeatures.swift
+++ b/Sources/MacParakeetCore/AppFeatures.swift
@@ -38,7 +38,7 @@ public enum AppFeatures {
     public static let transformsEnabled: Bool = true
 
     /// VAD-guided meeting live chunking
-    /// (`plans/active/2026-05-meeting-vad-guided-live-chunking.md`). When
+    /// (`plans/completed/2026-05-meeting-vad-guided-live-chunking.md`). When
     /// `false`, meeting live-preview chunks use the fixed 5s / 1s-overlap
     /// `AudioChunker` path. When `true`, launch-time prep tries to cache the
     /// Silero VAD model, and cached-model Parakeet sessions cut live-preview

--- a/Sources/MacParakeetCore/Audio/MeetingVADChunkingSimulator.swift
+++ b/Sources/MacParakeetCore/Audio/MeetingVADChunkingSimulator.swift
@@ -13,7 +13,7 @@ import Foundation
 /// decoupled onto its own task": if chunking runs at N×realtime offline, a live
 /// source producing at 1×realtime can never back up the inline path, so the
 /// inline coupling is safe. See
-/// `plans/active/2026-05-meeting-vad-guided-live-chunking.md` (Phase 0).
+/// `plans/completed/2026-05-meeting-vad-guided-live-chunking.md` (Phase 0).
 ///
 /// **What it does not measure.** Live ScreenCaptureKit/AVAudioEngine capture,
 /// the real-time backpressure *dynamics*, the SwiftUI layer, or VAD-while-

--- a/Sources/MacParakeetCore/Audio/SpeechBoundaryMeetingLiveAudioChunker.swift
+++ b/Sources/MacParakeetCore/Audio/SpeechBoundaryMeetingLiveAudioChunker.swift
@@ -15,7 +15,7 @@ struct MeetingLiveChunkingDiagnostics: Sendable {
 
 /// Live-preview chunker that cuts at VAD speech boundaries instead of fixed
 /// 5-second windows. See
-/// `plans/active/2026-05-meeting-vad-guided-live-chunking.md`.
+/// `plans/completed/2026-05-meeting-vad-guided-live-chunking.md`.
 ///
 /// **Contiguous sample accounting.** Chunks tile the recording with no gaps in
 /// the audio they emit, so `lastEmittedSample` always equals the absolute

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -162,7 +162,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     /// per-construction. Production (`AppEnvironment`) wires the real
     /// `AppFeatures.meetingVadLiveChunkingEnabled`; the conservative `{ false }`
     /// default gives tests deterministic fixed chunking. See
-    /// `plans/active/2026-05-meeting-vad-guided-live-chunking.md`.
+    /// `plans/completed/2026-05-meeting-vad-guided-live-chunking.md`.
     private let isVadLiveChunkingEnabled: @Sendable () -> Bool
     private let requestedMicProcessingMode: MeetingMicProcessingMode
     private let liveChunkTranscriber: LiveChunkTranscriber
@@ -949,7 +949,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     /// byte-identical to the prior `AudioChunker` behavior. When enabled and
     /// the Silero VAD model is cached, Parakeet sessions cut both sources at
     /// speech boundaries; WhisperKit sessions and uncached VAD stay on fixed.
-    /// See `plans/active/2026-05-meeting-vad-guided-live-chunking.md` §4.
+    /// See `plans/completed/2026-05-meeting-vad-guided-live-chunking.md` §4.
     private func configureLiveChunkers(for session: Session) async {
         func useFixed(reason: String) async {
             await captureOrchestrator.configureChunkers(

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingVADModelPreparer.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingVADModelPreparer.swift
@@ -3,7 +3,7 @@ import OSLog
 
 /// Prepares the Silero VAD model used by VAD-guided meeting live chunking
 /// (`AppFeatures.meetingVadLiveChunkingEnabled`,
-/// `plans/active/2026-05-meeting-vad-guided-live-chunking.md`).
+/// `plans/completed/2026-05-meeting-vad-guided-live-chunking.md`).
 ///
 /// A deferred launch-time task fetches the model up front (see
 /// `MeetingVADLaunchPrep` + `AppDelegate.scheduleDeferredSpeechPreWarm`) so the
@@ -45,7 +45,7 @@ public struct MeetingVADModelPreparer: MeetingVADModelPreparing {
 }
 
 /// Universal launch-time VAD model availability (Phase 4.5,
-/// `plans/active/2026-05-meeting-vad-guided-live-chunking.md` §6).
+/// `plans/completed/2026-05-meeting-vad-guided-live-chunking.md` §6).
 ///
 /// The Silero model used to be fetched only during onboarding, so it reached
 /// *new installs only* — the entire installed base ran fixed chunking forever

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -108,7 +108,7 @@ public enum TelemetryEventName: String, Sendable, CaseIterable {
     case meetingRecoveryDiscarded = "meeting_recovery_discarded"
     case meetingRecoveryFailed = "meeting_recovery_failed"
     /// Universal launch-time Silero VAD model prep for VAD-guided meeting live
-    /// chunking (`plans/active/2026-05-meeting-vad-guided-live-chunking.md` §6).
+    /// chunking (`plans/completed/2026-05-meeting-vad-guided-live-chunking.md` §6).
     /// Confirms the installed base actually acquires the model once the feature
     /// is enabled — see `TelemetryVADModelPrepOutcome`. Gated on
     /// `AppFeatures.meetingVadLiveChunkingEnabled`, so it never fires in a
@@ -384,7 +384,7 @@ public enum TelemetryMeetingRecoverySource: String, Sendable, Equatable {
 }
 
 /// Outcome of a launch-time Silero VAD model prep attempt (Phase 4.5,
-/// `plans/active/2026-05-meeting-vad-guided-live-chunking.md` §6). The full
+/// `plans/completed/2026-05-meeting-vad-guided-live-chunking.md` §6). The full
 /// vocabulary is modeled here, but the launch hook only transmits the
 /// *transitions* worth seeing: `prepared` (an install just acquired the model
 /// — the field-reach signal) and `failed` (a download problem). The

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingVADLaunchPrepTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingVADLaunchPrepTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import MacParakeetCore
 
 /// Phase 4.5 — universal launch-time VAD model availability
-/// (`plans/active/2026-05-meeting-vad-guided-live-chunking.md` §6).
+/// (`plans/completed/2026-05-meeting-vad-guided-live-chunking.md` §6).
 ///
 /// These cover the flag-and-cache gate that `AppDelegate.scheduleDeferredSpeechPreWarm`
 /// rides on every launch, without driving the deferred launch timer. The prep

--- a/plans/completed/2026-05-delete-downloaded-models.md
+++ b/plans/completed/2026-05-delete-downloaded-models.md
@@ -1,6 +1,6 @@
 # Delete downloaded speech models
 
-> Status: **ACTIVE** — implemented on `feat/delete-downloaded-models`, pending PR merge.
+> Status: **IMPLEMENTED** — merged to main (`d6e9ba2fc`); archived 2026-06-12.
 
 ## Why
 

--- a/plans/completed/2026-05-issue-365-model-availability.md
+++ b/plans/completed/2026-05-issue-365-model-availability.md
@@ -1,6 +1,6 @@
 # Issue 365 Model Availability Plan
 
-> Status: PR READY
+> Status: **IMPLEMENTED** — merged to main (`1c960da63`, follow-up `9510f53a3`); archived 2026-06-12
 > Started: 2026-05-26
 > Issue: https://github.com/moona3k/macparakeet/issues/365
 > Scope: AI provider model lists in Settings, transcript chat, and prompt results.

--- a/plans/completed/2026-05-meeting-vad-guided-live-chunking.md
+++ b/plans/completed/2026-05-meeting-vad-guided-live-chunking.md
@@ -1,6 +1,6 @@
 # Meeting VAD-Guided Live Chunking
 
-> Status: ACTIVE PLAN — Phases 1–4.5 IMPLEMENTED; flag-on release candidate under validation
+> Status: **IMPLEMENTED** — shipped flag-on in v0.6.14 (`AppFeatures.meetingVadLiveChunkingEnabled = true`); archived 2026-06-12
 > Date: 2026-05-29
 > Scope: meeting live transcript chunk boundaries only.
 


### PR DESCRIPTION
## What

- **CLAUDE.md "Release Channels" is now the single canonical release-status + `AppFeatures` flag-delta block.** The duplicated channel-framing paragraph, changelog-style Current Phase narrative, 60-line GUI ASCII tree, and step-by-step release procedure collapse into pointers (`spec/README.md` roadmap, `spec/04-ui-patterns.md`, `docs/distribution.md`), keeping only load-bearing invariants inline.
- **AGENTS.md catches up with reality**: the Nemotron 3.5 Beta engine was missing entirely; the hand-copied release-status paragraph becomes a pointer to the canonical block; new Git & Worktrees section; focused-test command; Nemotron/yt-dlp/ffmpeg runtime locations.
- **New "Git / Worktree Gotchas" in Known Pitfalls**: base worktrees on `origin/main`, build from the branch's own worktree (`.swiftpm` path pinning), the known-flaky `DictationFlowCoordinatorLoadCaptionTests` re-run policy, `blame.ignoreRevsFile` after the 2026-06-11 LF renormalization.
- **`swift test --filter <TestClass>`** documented in both agent guides (previously only in spec/09).
- **README**: static "tests passing" badge replaced with the live CI workflow badge; Contributing points agent-assisted contributors at AGENTS.md.
- **Three shipped plans archived** to `plans/completed/` with merge evidence: VAD live chunking (shipped v0.6.14), issue #365 model availability (`1c960da63` + `9510f53a3`), per-model speech model delete (`d6e9ba2fc`).

## Why

Release status was hand-maintained in four places and had already drifted — AGENTS.md never mentioned Nemotron. One canonical block plus pointers ends the four-way sync burden, and hard-won worktree/CI lessons move from private agent memory into the repo where every coding agent can see them.

## Verification

- Docs-only change; no code touched (CI ignores `docs/**`, `spec/**`, `**/*.md`).
- Flag-delta claim verified against `AppFeatures.swift` on `main` vs the v0.6.22 tag (only `aiFormatterProfilesEnabled` differs).
- Nemotron cache path verified in `NemotronEngine.defaultCacheRoot()`.
- `git diff --stat` ≈ `git diff -w --stat` — no line-ending pollution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)