### PR TITLE
Self-heal the shared mic engine after AVAudioEngineConfigurationChange

### DIFF
--- a/Sources/MacParakeetCore/Audio/MicrophoneEnginePlatform.swift
+++ b/Sources/MacParakeetCore/Audio/MicrophoneEnginePlatform.swift
@@ -91,16 +91,21 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
     private var defaultInputChangeObserver: AudioObjectPropertyListenerBlock?
     /// Parameters from the most recent successful start. Used by the
     /// configuration-change observer to re-run the exact same start sequence
-    /// during self-healing recovery. Cleared in `stopEngine()` — including
-    /// when the platform is already stopped — so a stale tap-handler closure
-    /// is never retained after an explicit stop. Never cleared by teardown /
-    /// reset / engine-replace helpers (they are part of the recovery path).
+    /// during self-healing recovery. Cleared at the start of each configure
+    /// attempt and in `stopEngine()` — including when the platform is already
+    /// stopped — so a stale tap-handler closure is never retained after a
+    /// failed start or explicit stop. Never cleared by teardown / reset /
+    /// engine-replace helpers (they are part of the recovery path).
     private struct StartRequest {
         let vpioEnabled: Bool
         let bufferSize: AVAudioFrameCount
         let tapHandler: @Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void
     }
     private var lastStartRequestLocked: StartRequest?
+
+    deinit {
+        tearDownLocked()
+    }
 
     private static func nowNanos() -> UInt64 {
         DispatchTime.now().uptimeNanoseconds
@@ -209,6 +214,7 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
         bufferSize: AVAudioFrameCount,
         tapHandler: @escaping @Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void
     ) throws {
+        lastStartRequestLocked = nil
         // VPIO toggle requires a stop → setVoiceProcessingEnabled → start
         // sequence; the engine cannot be reconfigured while running.
         if running {

--- a/Sources/MacParakeetCore/Audio/MicrophoneEnginePlatform.swift
+++ b/Sources/MacParakeetCore/Audio/MicrophoneEnginePlatform.swift
@@ -82,13 +82,25 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
     /// Token for the `AVAudioEngine.configurationChangeNotification` observer
     /// installed on the current `audioEngine` instance. Cleared on
     /// `tearDown` / `resetEngine` / `replaceEngineAfterFailure` so the
-    /// next instance gets its own observer. Recorded here purely to
-    /// surface the signal in `dictation-audio.log` — Core Audio sends
-    /// this when the input chain reconfigures (default-input change,
-    /// format change, sample-rate change), which is the most likely
+    /// next instance gets its own observer. Drives both diagnostic logging
+    /// and self-healing restart via `recoverFromConfigurationChangeLocked` —
+    /// Core Audio sends this when the input chain reconfigures (default-input
+    /// change, format change, sample-rate change), which is the most likely
     /// trigger for the silent tap-stall under investigation.
     private var configurationChangeObserver: NSObjectProtocol?
     private var defaultInputChangeObserver: AudioObjectPropertyListenerBlock?
+    /// Parameters from the most recent successful start. Used by the
+    /// configuration-change observer to re-run the exact same start sequence
+    /// during self-healing recovery. Cleared in `stopEngine()` — including
+    /// when the platform is already stopped — so a stale tap-handler closure
+    /// is never retained after an explicit stop. Never cleared by teardown /
+    /// reset / engine-replace helpers (they are part of the recovery path).
+    private struct StartRequest {
+        let vpioEnabled: Bool
+        let bufferSize: AVAudioFrameCount
+        let tapHandler: @Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void
+    }
+    private var lastStartRequestLocked: StartRequest?
 
     private static func nowNanos() -> UInt64 {
         DispatchTime.now().uptimeNanoseconds
@@ -165,92 +177,20 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
         tapHandler: @escaping @Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void
     ) throws {
         try queue.sync {
-            // VPIO toggle requires a stop → setVoiceProcessingEnabled → start
-            // sequence; the engine cannot be reconfigured while running.
-            if running {
-                tearDownLocked()
-            }
-
-            let attempts = deviceAttemptsBuilder?() ?? []
-            if attempts.isEmpty {
-                // No device chain — use whatever the engine's input node picks.
-                try startConfiguredEngineLocked(
-                    vpioEnabled: vpioEnabled,
-                    bufferSize: bufferSize,
-                    tapHandler: tapHandler
-                )
-                lastSucceededAttemptLocked = nil
-                return
-            }
-
-            var lastError: Error?
-            for attempt in attempts {
-                let transport = AudioCaptureDiagnostics.deviceTransportLabel(attempt.deviceID)
-                let deviceLabel = AudioCaptureDiagnostics.deviceLabel(attempt.deviceID)
-                var setDeviceMilliseconds = "0.000"
-                if let deviceID = attempt.explicitDeviceID {
-                    let setDeviceStartedAt = Self.nowNanos()
-                    let didSetDevice = inputDeviceSetter(deviceID, audioEngine)
-                    let setDeviceEndedAt = Self.nowNanos()
-                    setDeviceMilliseconds = Self.elapsedMilliseconds(
-                        from: setDeviceStartedAt,
-                        to: setDeviceEndedAt
-                    )
-                    guard didSetDevice else {
-                        logger.warning(
-                            "shared_mic_engine_input_device_set_failed source=\(attempt.source.logValue, privacy: .public) transport=\(transport, privacy: .public)"
-                        )
-                        AudioCaptureDiagnostics.append(
-                            "shared_mic_engine_input_device_set_failed source=\(attempt.source.logValue) device=\(deviceLabel) transport=\(transport) set_device_ms=\(setDeviceMilliseconds)"
-                        )
-                        if lastError == nil {
-                            lastError = AVAudioEngineMicrophonePlatformError.deviceSetFailed(attempt)
-                        }
-                        resetEngineLocked()
-                        continue
-                    }
-                }
-
-                do {
-                    let startEngineStartedAt = Self.nowNanos()
-                    try startConfiguredEngineLocked(
-                        vpioEnabled: vpioEnabled,
-                        bufferSize: bufferSize,
-                        tapHandler: tapHandler
-                    )
-                    let startEngineEndedAt = Self.nowNanos()
-                    let startEngineMilliseconds = Self.elapsedMilliseconds(
-                        from: startEngineStartedAt,
-                        to: startEngineEndedAt
-                    )
-                    lastSucceededAttemptLocked = attempt
-                    logger.info(
-                        "shared_mic_engine_input_device_started source=\(attempt.source.logValue, privacy: .public) transport=\(transport, privacy: .public) vpio=\(vpioEnabled, privacy: .public)"
-                    )
-                    AudioCaptureDiagnostics.append(
-                        "shared_mic_engine_input_device_started source=\(attempt.source.logValue) device=\(deviceLabel) transport=\(transport) vpio=\(vpioEnabled) set_device_ms=\(setDeviceMilliseconds) start_engine_ms=\(startEngineMilliseconds)"
-                    )
-                    return
-                } catch {
-                    lastError = error
-                    let errorType = AudioCaptureDiagnostics.errorType(error)
-                    logger.warning(
-                        "shared_mic_engine_input_device_start_failed source=\(attempt.source.logValue, privacy: .public) transport=\(transport, privacy: .public) error_type=\(errorType, privacy: .public) error_detail=\(error.localizedDescription, privacy: .private)"
-                    )
-                    AudioCaptureDiagnostics.append(
-                        "shared_mic_engine_input_device_start_failed source=\(attempt.source.logValue) device=\(deviceLabel) transport=\(transport) set_device_ms=\(setDeviceMilliseconds) \(AudioCaptureDiagnostics.errorFields(error))"
-                    )
-                    // startConfiguredEngineLocked already replaces the engine on
-                    // failure, so nothing more to reset here.
-                }
-            }
-
-            throw lastError ?? AVAudioEngineMicrophonePlatformError.noDeviceAvailable
+            try configureAndStartLocked(
+                vpioEnabled: vpioEnabled,
+                bufferSize: bufferSize,
+                tapHandler: tapHandler
+            )
         }
     }
 
     public func stopEngine() {
         queue.sync {
+            // Clear the stored start request unconditionally so the tap-handler
+            // closure is never retained past an explicit stop, even when the
+            // platform is already stopped.
+            lastStartRequestLocked = nil
             guard running else { return }
             tearDownLocked()
             logger.info("shared_mic_engine_stopped")
@@ -259,6 +199,108 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
     }
 
     // MARK: - Internals (queue-held)
+
+    /// Queue-held body of `configureAndStart`. Extracted so that
+    /// `recoverFromConfigurationChangeLocked` (already on the platform queue)
+    /// can re-run the full start sequence — including the device-fallback
+    /// chain — without deadlocking.
+    private func configureAndStartLocked(
+        vpioEnabled: Bool,
+        bufferSize: AVAudioFrameCount,
+        tapHandler: @escaping @Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void
+    ) throws {
+        // VPIO toggle requires a stop → setVoiceProcessingEnabled → start
+        // sequence; the engine cannot be reconfigured while running.
+        if running {
+            tearDownLocked()
+        }
+
+        let attempts = deviceAttemptsBuilder?() ?? []
+        if attempts.isEmpty {
+            // No device chain — use whatever the engine's input node picks.
+            try startConfiguredEngineLocked(
+                vpioEnabled: vpioEnabled,
+                bufferSize: bufferSize,
+                tapHandler: tapHandler
+            )
+            lastSucceededAttemptLocked = nil
+            lastStartRequestLocked = StartRequest(
+                vpioEnabled: vpioEnabled,
+                bufferSize: bufferSize,
+                tapHandler: tapHandler
+            )
+            return
+        }
+
+        var lastError: Error?
+        for attempt in attempts {
+            let transport = AudioCaptureDiagnostics.deviceTransportLabel(attempt.deviceID)
+            let deviceLabel = AudioCaptureDiagnostics.deviceLabel(attempt.deviceID)
+            var setDeviceMilliseconds = "0.000"
+            if let deviceID = attempt.explicitDeviceID {
+                let setDeviceStartedAt = Self.nowNanos()
+                let didSetDevice = inputDeviceSetter(deviceID, audioEngine)
+                let setDeviceEndedAt = Self.nowNanos()
+                setDeviceMilliseconds = Self.elapsedMilliseconds(
+                    from: setDeviceStartedAt,
+                    to: setDeviceEndedAt
+                )
+                guard didSetDevice else {
+                    logger.warning(
+                        "shared_mic_engine_input_device_set_failed source=\(attempt.source.logValue, privacy: .public) transport=\(transport, privacy: .public)"
+                    )
+                    AudioCaptureDiagnostics.append(
+                        "shared_mic_engine_input_device_set_failed source=\(attempt.source.logValue) device=\(deviceLabel) transport=\(transport) set_device_ms=\(setDeviceMilliseconds)"
+                    )
+                    if lastError == nil {
+                        lastError = AVAudioEngineMicrophonePlatformError.deviceSetFailed(attempt)
+                    }
+                    resetEngineLocked()
+                    continue
+                }
+            }
+
+            do {
+                let startEngineStartedAt = Self.nowNanos()
+                try startConfiguredEngineLocked(
+                    vpioEnabled: vpioEnabled,
+                    bufferSize: bufferSize,
+                    tapHandler: tapHandler
+                )
+                let startEngineEndedAt = Self.nowNanos()
+                let startEngineMilliseconds = Self.elapsedMilliseconds(
+                    from: startEngineStartedAt,
+                    to: startEngineEndedAt
+                )
+                lastSucceededAttemptLocked = attempt
+                lastStartRequestLocked = StartRequest(
+                    vpioEnabled: vpioEnabled,
+                    bufferSize: bufferSize,
+                    tapHandler: tapHandler
+                )
+                logger.info(
+                    "shared_mic_engine_input_device_started source=\(attempt.source.logValue, privacy: .public) transport=\(transport, privacy: .public) vpio=\(vpioEnabled, privacy: .public)"
+                )
+                AudioCaptureDiagnostics.append(
+                    "shared_mic_engine_input_device_started source=\(attempt.source.logValue) device=\(deviceLabel) transport=\(transport) vpio=\(vpioEnabled) set_device_ms=\(setDeviceMilliseconds) start_engine_ms=\(startEngineMilliseconds)"
+                )
+                return
+            } catch {
+                lastError = error
+                let errorType = AudioCaptureDiagnostics.errorType(error)
+                logger.warning(
+                    "shared_mic_engine_input_device_start_failed source=\(attempt.source.logValue, privacy: .public) transport=\(transport, privacy: .public) error_type=\(errorType, privacy: .public) error_detail=\(error.localizedDescription, privacy: .private)"
+                )
+                AudioCaptureDiagnostics.append(
+                    "shared_mic_engine_input_device_start_failed source=\(attempt.source.logValue) device=\(deviceLabel) transport=\(transport) set_device_ms=\(setDeviceMilliseconds) \(AudioCaptureDiagnostics.errorFields(error))"
+                )
+                // startConfiguredEngineLocked already replaces the engine on
+                // failure, so nothing more to reset here.
+            }
+        }
+
+        throw lastError ?? AVAudioEngineMicrophonePlatformError.noDeviceAvailable
+    }
 
     private func startConfiguredEngineLocked(
         vpioEnabled: Bool,
@@ -478,12 +520,18 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
 
     /// Observe `AVAudioEngine.configurationChangeNotification` on the
     /// current `audioEngine` and log every fire to `dictation-audio.log`.
-    /// Core Audio posts this when the engine's input chain is renegotiated
-    /// out from under us — default-input device change, sample-rate
-    /// change, exclusive-access takeover by another process. Without
-    /// observing it, those events are invisible in our logs and the
-    /// silent tap-stall they can leave behind has no signature beyond
-    /// "buffers stopped arriving."
+    /// After logging, calls `recoverFromConfigurationChangeLocked` to attempt
+    /// a self-healing restart when all four gates pass:
+    /// (1) `running == true`, (2) the notification belongs to the current
+    /// engine instance, (3) `AVAudioEngine.isRunning == false`, and
+    /// (4) the original start parameters are known.
+    ///
+    /// Core Audio posts `AVAudioEngineConfigurationChange` when the engine's
+    /// input chain is renegotiated out from under us — default-input device
+    /// change, sample-rate change, exclusive-access takeover by another
+    /// process. The Apple-documented contract for this notification is that
+    /// the client restarts the engine; this observer fulfils that contract
+    /// while the watchdog/heartbeat in `AudioRecorder` remain log-only.
     private func installConfigurationChangeObserverLocked() {
         let token = NotificationCenter.default.addObserver(
             forName: .AVAudioEngineConfigurationChange,
@@ -495,18 +543,21 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
             self.queue.async { [weak self, engineBox] in
                 guard let self else { return }
                 let format = engineBox.inputFormat()
+                let engineIsRunning = engineBox.isEngineRunning()
                 let snapshot = (
                     sr: format?.sampleRate ?? 0,
                     ch: format?.channelCount ?? 0,
-                    isRunning: self.running
+                    isRunning: self.running,
+                    engineIsRunning: engineIsRunning
                 )
                 let defaultInput = AudioCaptureDiagnostics.defaultInputDeviceSummary()
                 AudioCaptureDiagnostics.append(
-                    "shared_mic_engine_configuration_changed sr=\(snapshot.sr) ch=\(snapshot.ch) isRunning=\(snapshot.isRunning) \(defaultInput)"
+                    "shared_mic_engine_configuration_changed sr=\(snapshot.sr) ch=\(snapshot.ch) isRunning=\(snapshot.isRunning) engine_is_running=\(snapshot.engineIsRunning) \(defaultInput)"
                 )
                 self.logger.info(
-                    "shared_mic_engine_configuration_changed sr=\(snapshot.sr, privacy: .public) ch=\(snapshot.ch, privacy: .public) isRunning=\(snapshot.isRunning, privacy: .public)"
+                    "shared_mic_engine_configuration_changed sr=\(snapshot.sr, privacy: .public) ch=\(snapshot.ch, privacy: .public) isRunning=\(snapshot.isRunning, privacy: .public) engine_is_running=\(snapshot.engineIsRunning, privacy: .public)"
                 )
+                self.recoverFromConfigurationChangeLocked(engineBox: engineBox)
             }
         }
         configurationChangeObserver = token
@@ -516,6 +567,52 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
         if let token = configurationChangeObserver {
             NotificationCenter.default.removeObserver(token)
             configurationChangeObserver = nil
+        }
+    }
+
+    /// Attempts to restart capture after an `AVAudioEngineConfigurationChange`
+    /// notification. All four gates must be satisfied:
+    /// 1. `running == true` — an explicit stop wins and suppresses recovery.
+    /// 2. `engineBox.wraps(audioEngine)` — the notification belongs to the
+    ///    current engine instance; stale events for a replaced engine are
+    ///    discarded.
+    /// 3. `engineBox.isEngineRunning() == false` — the engine actually
+    ///    stopped; benign notifications around a healthy start are no-ops.
+    /// 4. `lastStartRequestLocked != nil` — we have the parameters to replay.
+    ///
+    /// On success the engine is restarted with the original parameters.
+    /// On failure `running` is left `false` (the start helpers guarantee
+    /// this); a failed recovery does NOT retry — the next explicit
+    /// `configureAndStart` resets everything.
+    ///
+    /// Loop safety: the observer is registered with `object: audioEngine` and
+    /// removed on every teardown. Recovery replaces the engine, installing a
+    /// fresh observer on the new instance. A failed recovery leaves
+    /// `running == false`, which gates further attempts.
+    private func recoverFromConfigurationChangeLocked(engineBox: UncheckedSendableAudioEngine) {
+        guard running else { return }
+        guard engineBox.wraps(audioEngine) else { return }
+        guard !engineBox.isEngineRunning() else { return }
+        guard let request = lastStartRequestLocked else { return }
+
+        AudioCaptureDiagnostics.append("shared_mic_engine_config_change_recovery_attempt")
+        logger.info("shared_mic_engine_config_change_recovery_attempt")
+
+        do {
+            try configureAndStartLocked(
+                vpioEnabled: request.vpioEnabled,
+                bufferSize: request.bufferSize,
+                tapHandler: request.tapHandler
+            )
+            AudioCaptureDiagnostics.append("shared_mic_engine_config_change_recovery_succeeded")
+            logger.info("shared_mic_engine_config_change_recovery_succeeded")
+        } catch {
+            AudioCaptureDiagnostics.append(
+                "shared_mic_engine_config_change_recovery_failed \(AudioCaptureDiagnostics.errorFields(error))"
+            )
+            logger.error(
+                "shared_mic_engine_config_change_recovery_failed error_type=\(AudioCaptureDiagnostics.errorType(error), privacy: .public) error_detail=\(error.localizedDescription, privacy: .private)"
+            )
         }
     }
 

--- a/Sources/MacParakeetCore/Audio/README.md
+++ b/Sources/MacParakeetCore/Audio/README.md
@@ -21,7 +21,10 @@ owned by `AppEnvironment`.
 - `MicrophoneEnginePlatform.swift` — `AVAudioEngine` wrapper. Device
   fallback chain, VPIO toggle, tap install, engine recreation on
   every teardown (so coreaudiod releases the VPAU aggregate
-  device), `AVAudioEngineConfigurationChangeNotification` observer.
+  device), `AVAudioEngineConfigurationChangeNotification` observer,
+  configuration-change self-healing (four-gated restart on HAL
+  reconfiguration — the Apple-documented contract for
+  `AVAudioEngineConfigurationChange` clients).
 
 **Mic consumers (each subscribes to the shared stream)**
 - `AudioRecorder.swift` — dictation capture.
@@ -189,6 +192,25 @@ shipped this deliberately; converting any of those signals into a
 user-facing error would mask a regression as a fact of life.
 Telemetry counters can be added separately, but the log path stays
 non-disruptive.
+
+**The configuration-change observer self-heals (four-gated restart).** When
+`AVAudioEngine` stops itself after an `AVAudioEngineConfigurationChange`
+notification (default-input change, format change, sample-rate change), the
+observer in `MicrophoneEnginePlatform` attempts a self-healing restart — this
+is the Apple-documented client contract for that notification, not a
+diagnostic-turned-error. Recovery runs only when all four gates pass:
+(1) `running == true` (explicit stop wins), (2) the notification belongs to
+the current engine instance (stale events for replaced engines are discarded),
+(3) `AVAudioEngine.isRunning == false` (benign notifications around a healthy
+start are no-ops), and (4) the original start parameters are known. The
+watchdog and heartbeat in `AudioRecorder` remain log-only; only the
+configuration-change path self-heals. Three new log events mark the recovery
+flow: `shared_mic_engine_config_change_recovery_attempt`,
+`shared_mic_engine_config_change_recovery_succeeded`, and
+`shared_mic_engine_config_change_recovery_failed`. The
+`shared_mic_engine_configuration_changed` line now includes an
+`engine_is_running=` field (actual `AVAudioEngine.isRunning`) alongside the
+existing `isRunning=` (platform `running` flag).
 
 `MicrophoneEnginePlatform` also logs per-phase engine-start timings
 (`shared_mic_engine_start_timing`) so a slow first-buffer report can be split

--- a/Sources/MacParakeetCore/Audio/UncheckedSendableAudioPCMBuffer.swift
+++ b/Sources/MacParakeetCore/Audio/UncheckedSendableAudioPCMBuffer.swift
@@ -46,4 +46,14 @@ final class UncheckedSendableAudioEngine: @unchecked Sendable {
             engine.inputNode.outputFormat(forBus: 0)
         }
     }
+
+    /// ObjC-exception-safe read of the engine's running state.
+    func isEngineRunning() -> Bool {
+        (try? catchingObjCException { engine.isRunning }) ?? false
+    }
+
+    /// Returns true if this box wraps the given engine instance (identity check).
+    func wraps(_ other: AVAudioEngine) -> Bool {
+        engine === other
+    }
 }

--- a/Tests/MacParakeetTests/Audio/MicrophoneEnginePlatformConfigChangeRecoveryTests.swift
+++ b/Tests/MacParakeetTests/Audio/MicrophoneEnginePlatformConfigChangeRecoveryTests.swift
@@ -1,0 +1,214 @@
+import AVFoundation
+import os
+import XCTest
+@testable import MacParakeetCore
+
+/// Tests for `AVAudioEngineMicrophonePlatform`'s self-healing behaviour when
+/// `AVAudioEngine` stops itself after an `AVAudioEngineConfigurationChange`
+/// notification (default-input change, sample-rate change, etc.).
+///
+/// These tests use the internal `engineStarter` seam so no real audio hardware
+/// is needed. A never-actually-started `AVAudioEngine` reports
+/// `isRunning == false` — the same signature a HAL reconfiguration leaves on a
+/// live engine — so the four recovery gates are exercisable without hardware.
+///
+/// Queue-ordering guarantee exploited by the "no recovery" assertions: the
+/// configuration-change observer posts its work to `queue.async`. The public
+/// `isEngineRunning` accessor calls `queue.sync { running }`. Because
+/// `queue.async` enqueues before the subsequent `queue.sync` executes, reading
+/// `isEngineRunning` after posting a notification is a reliable "flush"
+/// — the async recovery block is guaranteed to have run before the sync read
+/// returns.
+final class MicrophoneEnginePlatformConfigChangeRecoveryTests: XCTestCase {
+
+    // MARK: - Test 1
+
+    /// Starting the engine and then posting a configuration-change notification
+    /// for the live engine causes the starter to be invoked a second time with
+    /// the ORIGINAL vpio/bufferSize parameters and a DIFFERENT (freshly created)
+    /// engine instance, and leaves the platform running.
+    func testConfigurationChangeWhileRunningRestartsEngine() throws {
+        // Arrange: capture each engine instance and the call parameters.
+        let enginesLock = OSAllocatedUnfairLock(initialState: [AVAudioEngine]())
+        let vpioLock = OSAllocatedUnfairLock(initialState: [Bool]())
+        let bufferSizeLock = OSAllocatedUnfairLock(initialState: [AVAudioFrameCount]())
+        let recoveryExpectation = expectation(description: "engineStarter invoked for recovery")
+
+        let platform = AVAudioEngineMicrophonePlatform(
+            engineStarter: { engine, vpio, bufferSize, _ in
+                let engines = enginesLock.withLock { engines -> [AVAudioEngine] in
+                    engines.append(engine)
+                    return engines
+                }
+                vpioLock.withLock { arr in arr.append(vpio) }
+                bufferSizeLock.withLock { arr in arr.append(bufferSize) }
+                if engines.count == 2 {
+                    recoveryExpectation.fulfill()
+                }
+            }
+        )
+        defer { platform.stopEngine() }
+
+        // Act: first start.
+        try platform.configureAndStart(vpioEnabled: true, bufferSize: 512, tapHandler: { _, _ in })
+
+        let capturedEngines = enginesLock.withLock { engines in engines }
+        XCTAssertEqual(capturedEngines.count, 1, "engineStarter should have been called once after first start")
+        let firstEngine = capturedEngines[0]
+
+        // Post the configuration-change notification for the live engine.
+        // A never-started AVAudioEngine has isRunning == false, which
+        // satisfies gate 3 of the four-gate check without real hardware.
+        NotificationCenter.default.post(
+            name: .AVAudioEngineConfigurationChange,
+            object: firstEngine
+        )
+
+        // Wait for the recovery queue block to run and invoke the starter a
+        // second time.
+        wait(for: [recoveryExpectation], timeout: 2.0)
+
+        // Assert: exactly 2 starter invocations.
+        let engines = enginesLock.withLock { arr in arr }
+        XCTAssertEqual(engines.count, 2, "starter should be invoked exactly twice (initial + recovery)")
+
+        // The second invocation must use a DIFFERENT engine instance
+        // (tearDownLocked replaced it during the recovery path).
+        XCTAssertFalse(
+            engines[0] === engines[1],
+            "recovery must use a fresh engine instance, not the stalled one"
+        )
+
+        // Parameters must match the original configureAndStart call (VPIO stickiness).
+        let capturedVpio = vpioLock.withLock { arr in arr }
+        XCTAssertEqual(capturedVpio, [true, true], "recovery must replay the original vpioEnabled")
+
+        let capturedBufferSizes = bufferSizeLock.withLock { arr in arr }
+        XCTAssertEqual(
+            capturedBufferSizes,
+            [512, 512],
+            "recovery must replay the original bufferSize"
+        )
+
+        // Platform must be running after successful recovery.
+        XCTAssertTrue(platform.isEngineRunning, "platform should report running after recovery")
+    }
+
+    // MARK: - Test 2
+
+    /// After an explicit `stopEngine()`, posting a configuration-change
+    /// notification must NOT trigger any additional starter invocation, and the
+    /// platform must remain stopped.
+    func testConfigurationChangeAfterStopEngineDoesNotRestart() throws {
+        // Arrange: count starter invocations.
+        let invocationLock = OSAllocatedUnfairLock(initialState: 0)
+
+        let platform = AVAudioEngineMicrophonePlatform(
+            engineStarter: { _, _, _, _ in
+                invocationLock.withLock { count in count += 1 }
+            }
+        )
+
+        // Start then stop.
+        try platform.configureAndStart(vpioEnabled: false, bufferSize: 1024, tapHandler: { _, _ in })
+        XCTAssertEqual(invocationLock.withLock { count in count }, 1)
+        platform.stopEngine()
+        XCTAssertFalse(platform.isEngineRunning)
+
+        // Post a notification for an arbitrary engine.  The configuration-change
+        // observer is registered with `object: audioEngine` and removed on
+        // teardown, so the production notification will not route to the
+        // platform's handler. We additionally post for a fresh engine to confirm
+        // the gate-1 check (`running == false`) also suppresses any stale
+        // queue.async blocks.
+        let staleEngine = AVAudioEngine()
+        NotificationCenter.default.post(
+            name: .AVAudioEngineConfigurationChange,
+            object: staleEngine
+        )
+
+        // `isEngineRunning` calls `queue.sync { running }`.  Because the
+        // notification handler enqueues work via `queue.async`, the sync read
+        // is guaranteed to happen AFTER any queued recovery block — so this
+        // single call flushes the queue without a sleep.
+        XCTAssertFalse(platform.isEngineRunning, "platform must remain stopped after explicit stop")
+        XCTAssertEqual(
+            invocationLock.withLock { count in count },
+            1,
+            "starter must be called exactly once (initial start only)"
+        )
+    }
+
+    // MARK: - Test 3
+
+    /// When the recovery attempt itself throws, the platform is left with
+    /// `running == false`. A subsequent notification post must NOT trigger
+    /// another attempt (no retry loop), and exactly 2 starter invocations
+    /// occur in total.
+    func testFailedRecoveryLeavesEngineStopped() throws {
+        // Arrange: capture engine instances and count invocations.
+        let enginesLock = OSAllocatedUnfairLock(initialState: [AVAudioEngine]())
+        let invocationLock = OSAllocatedUnfairLock(initialState: 0)
+
+        let firstStartExpectation = expectation(description: "first engineStarter call succeeds")
+        let recoveryAttemptExpectation = expectation(description: "second engineStarter call (recovery throws)")
+        // Inverted: must NOT be fulfilled by a third call.
+        let noThirdCallExpectation = expectation(description: "third engineStarter call must not happen")
+        noThirdCallExpectation.isInverted = true
+
+        let platform = AVAudioEngineMicrophonePlatform(
+            engineStarter: { engine, _, _, _ in
+                let count = invocationLock.withLock { c -> Int in
+                    c += 1
+                    return c
+                }
+                enginesLock.withLock { arr in arr.append(engine) }
+                switch count {
+                case 1:
+                    firstStartExpectation.fulfill()
+                case 2:
+                    recoveryAttemptExpectation.fulfill()
+                    throw AVAudioEngineMicrophonePlatformError.noDeviceAvailable
+                default:
+                    noThirdCallExpectation.fulfill()
+                }
+            }
+        )
+        defer { platform.stopEngine() }
+
+        // Act: first start succeeds.
+        try platform.configureAndStart(vpioEnabled: false, bufferSize: 256, tapHandler: { _, _ in })
+        wait(for: [firstStartExpectation], timeout: 1.0)
+
+        let firstEngine = enginesLock.withLock { arr in arr }[0]
+
+        // Post the notification for the live engine — triggers recovery (call 2, throws).
+        NotificationCenter.default.post(
+            name: .AVAudioEngineConfigurationChange,
+            object: firstEngine
+        )
+        wait(for: [recoveryAttemptExpectation], timeout: 2.0)
+
+        // Platform must be stopped (recovery failed).
+        XCTAssertFalse(platform.isEngineRunning, "failed recovery must leave platform stopped")
+        XCTAssertEqual(invocationLock.withLock { c in c }, 2, "exactly 2 starter invocations total")
+
+        // Post again — running == false so gate 1 suppresses any further attempt.
+        // The previously-registered observer was also removed when tearDownLocked
+        // ran during the failed recovery, so the production object-match gate
+        // additionally suppresses it.
+        NotificationCenter.default.post(
+            name: .AVAudioEngineConfigurationChange,
+            object: firstEngine
+        )
+        // Flush the queue by reading isEngineRunning (queue.sync).
+        _ = platform.isEngineRunning
+        // Short wait for the inverted expectation to confirm no third call.
+        wait(for: [noThirdCallExpectation], timeout: 0.3)
+        XCTAssertEqual(
+            invocationLock.withLock { c in c },
+            2,
+            "still exactly 2 invocations after second notification"
+        )
+    }
+}

--- a/plans/active/2026-05-dictation-stall-integration-tests.md
+++ b/plans/active/2026-05-dictation-stall-integration-tests.md
@@ -5,6 +5,28 @@
 > Branch: `test/dictation-stall-integration`
 > Related: `journal/2026-05-03-dictation-silent-stall.md`, ADR-015, PR #189 (shared-mic-engine), PR #210 (diagnostic package)
 
+## Status (2026-06-12): root cause confirmed, recovery implemented
+
+Issue #499 (field report with an opt-in diagnostic log: 87 zero-sample
+captures, 380 `shared_mic_engine_configuration_changed` events across 480
+starts) confirmed hypothesis 1 from the list below: **HAL configuration
+change mid-session**. `AVAudioEngine` stops itself when the input chain
+reconfigures and posts `AVAudioEngineConfigurationChange`; the PR #210
+observer was log-only, so nothing restarted the engine and the platform's
+`running` flag stayed `true` over a dead graph.
+
+The fix (branch `fix/mic-config-change-recovery`) makes
+`AVAudioEngineMicrophonePlatform` self-heal: it replays the last successful
+start request when a configuration-change notification arrives for the
+current engine instance and the engine has actually stopped. The
+`shared_mic_engine_configuration_changed` log line now carries
+`engine_is_running=` (actual `AVAudioEngine.isRunning`) alongside the
+platform-flag `isRunning=`, closing the instrumentation gap called out
+below. Regression tests:
+`Tests/MacParakeetTests/Audio/MicrophoneEnginePlatformConfigChangeRecoveryTests.swift`.
+The Tier-4 HAL-mutation test is now expected to pass *because of* recovery
+on machines where the default-input mutation is observable.
+
 ## Status (2026-05-04, amended 2026-05-27)
 
 - **Tier 1 shipped + expanded** — 9 tests in `Tests/MacParakeetTests/Audio/MicrophoneEngineRealPlatformTests.swift`. Run the normal hardware subset with `MACPARAKEET_HARDWARE_TESTS=1`.


### PR DESCRIPTION
Fixes #499

## The bug

When macOS reconfigures the input hardware chain — default-input device change, USB unplug, Bluetooth HFP/SCO profile flap, sample-rate change — `AVAudioEngine` **stops itself** and posts `AVAudioEngineConfigurationChange`. The documented AVFoundation contract is that the client restarts the engine after this notification. Our observer (shipped log-only in PR #210's diagnostic package) never did, so:

- the platform's `running` flag stayed `true` over a dead graph,
- the tap stayed installed and buffers silently stopped,
- the only recovery was the user manually stopping and restarting capture.

The reporter's opt-in diagnostic log confirms the signature at scale: **87 zero-sample captures**, 380 `shared_mic_engine_configuration_changed` events across 480 starts. Every failed capture shows `engine_started → configuration_changed → no first buffer`, while successful captures show the same config-change line followed ~100 ms later by `first_buffer`. A contributing observability bug hid the smoking gun: the log line reported `isRunning=` from the platform's own flag (always `true` during a stall), not from `AVAudioEngine.isRunning`.

This closes the investigation open since 2026-05-03 (`plans/active/2026-05-dictation-stall-integration-tests.md` hypothesis 1: HAL configuration change mid-session).

## The fix

All changes live in `AVAudioEngineMicrophonePlatform` (plus two small additions to `UncheckedSendableAudioEngine`), so both shared-mic consumers — dictation and meeting mic — are covered without touching `SharedMicrophoneStream`'s state machine.

1. **Remember the last start request.** `StartRequest` (vpio, buffer size, tap handler) stored on every successful start; cleared only on explicit `stopEngine()` so recovery can never revive an engine the caller intentionally stopped.
2. **Extract `configureAndStartLocked`.** The recovery path already runs on the platform queue; the extraction lets it re-run the full start sequence — including the device-fallback chain (selected → systemDefault → builtIn) — without deadlocking. Because the attempt list is rebuilt at call time, recovery lands on whatever input is *now* correct (fixes the "unplugged the USB mic and the built-in wasn't picked up" case).
3. **Recover in the configuration-change observer**, gated on ALL of:
   - `running == true` — an explicit stop wins;
   - the notification belongs to the **current** engine instance — stale events for replaced engines are discarded;
   - `engine.isRunning == false` — benign notifications around a healthy start are no-ops;
   - a stored start request exists.

   Loop safety is structural: the observer is registered with `object: audioEngine` and removed on every teardown; recovery replaces the engine (fresh observer on the new instance); a failed recovery leaves `running == false`, which gates further attempts until the next explicit start.
4. **Log the real engine state.** `shared_mic_engine_configuration_changed` now carries `engine_is_running=` (actual) alongside `isRunning=` (platform flag), so future field logs distinguish HAL route churn from a dead engine at a glance. Recovery outcomes log as `shared_mic_engine_config_change_recovery_attempt/_succeeded/_failed`.

**PR #210 policy note:** the watchdog and heartbeat remain observability-only. This converts an OS lifecycle event into the restart Apple's contract asks for — not a diagnostic signal into a user-facing error.

## Tests

New `MicrophoneEnginePlatformConfigChangeRecoveryTests` (3 tests) via the internal `engineStarter` seam — a never-started `AVAudioEngine` reports `isRunning == false`, the same signature a HAL reconfiguration leaves on a real engine, so no hardware is needed:

- `testConfigurationChangeWhileRunningRestartsEngine` — recovery restarts once, with the original parameters, on a fresh engine instance.
- `testConfigurationChangeAfterStopEngineDoesNotRestart` — explicit stop wins; the notification is inert.
- `testFailedRecoveryLeavesEngineStopped` — a throwing restart leaves `running == false` with no retry loop.

Results: new tests 3/3; `swift test --filter Audio` 232/232; full `swift test` green (~3.6k tests, 10 hardware-gated skips, 0 failures). The Tier-4 HAL-mutation hardware test is now expected to pass *because of* recovery on machines where the default-input mutation is observable.

Manual verification for anyone with the repro: start dictation, switch the default input in System Settings (or unplug a USB mic) mid-recording — the level meter should resume within ~0.5 s and the log should show `configuration_changed … engine_is_running=false → recovery_attempt → recovery_succeeded`.

## Known limitations (deliberate scope, from the issue + adversarial review)

- **If every device attempt fails during recovery**, the engine stays down until the next explicit start — the same end state as today, but now explicitly logged. Wiring the failure into `SharedMicrophoneStream.onEngineDeath` so subscribers can surface a stall UI is a natural follow-up.
- **A recovery can transiently restart the idle Instant Dictation warm hold onto a Bluetooth input.** The #481 debounced refresh (triggered by the same default-input event) drops the warm hold within ~0.5 s, bounding the HFP pin to under a second. Suppressing recovery for passive-only subscribers would require the platform to know subscriber composition — a layering violation not worth taking for this window.

## Process

Issue analysis validated against the field log and codebase; implementation by Codex (GPT-5.5, xhigh reasoning) from a reviewed spec; adversarial review by a second independent Codex session (cleared deadlock, recovery-storm, VPIO-race, and test-determinism attack surfaces; surfaced the two limitations above); tests verified independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
