### PR TITLE
docs: point Homebrew app install at the official cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,12 @@ The DMG is the stable release.
 **Mac app (Homebrew cask):**
 
 ```bash
-brew install --cask moona3k/tap/macparakeet
+brew install --cask macparakeet
 ```
 
-The cask installs the same notarized DMG as the direct download. In-app updates
-continue through Sparkle.
+This is the official [`homebrew/cask`](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/m/macparakeet.rb)
+entry — no tap required. It installs the same notarized DMG as the direct
+download, and in-app updates continue through Sparkle.
 
 **Standalone CLI (Homebrew):**
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -249,10 +249,13 @@ curl -s "https://macparakeet.com/appcast.xml?ts=$(date +%s)" | grep "sparkle:ver
 1. Confirm R2 file size matches appcast `length`
 2. Confirm appcast `sparkle:version` is newer than the installed app's build number
 3. Launch the app → "Check for Updates..." from the menu bar → should find and validate the update
-4. Confirm the GitHub release has a versioned DMG asset named
-   `MacParakeet-X.Y.Z.dmg`. The official Homebrew cask URL is versioned as
-   `MacParakeet-#{version}.dmg`, and BrewTestBot cannot autobump the cask until
-   that GitHub asset URL exists.
+4. Confirm the GitHub release `vX.Y.Z` includes an asset named **exactly**
+   `MacParakeet.dmg`. The official Homebrew cask fetches
+   `…/releases/download/v#{version}/MacParakeet.dmg` — the version lives in the
+   tag path, **not** the filename. BrewTestBot cannot autobump the cask until
+   that plain-named asset exists on the new tag. (Attaching only a
+   `MacParakeet-X.Y.Z.dmg` is not enough; v0.6.20 shipped without the plain
+   `MacParakeet.dmg` and the cask could not bump to it.)
 
 ## Standalone CLI Homebrew release
 

--- a/docs/marketing.md
+++ b/docs/marketing.md
@@ -184,7 +184,7 @@ MacParakeet is the only Mac voice app that captures meetings (system audio + mic
 
 - **Primary URL:** `macparakeet.com`
 - **GitHub:** `github.com/moona3k/macparakeet`
-- **Future Homebrew (when shipped):** `brew install --cask macparakeet`
+- **Homebrew (official cask, live since 2026-06-06):** `brew install --cask macparakeet`
 - **Never use:** "Get started today," "Try it free," "Sign up." There is no signup. The app downloads and runs.
 
 ## Production Stack


### PR DESCRIPTION
The app cask graduated to the official `homebrew/cask` (autobumped), but our
docs still sent users to the personal tap and still called official Homebrew
"future". Companion to the tap cleanup in moona3k/homebrew-tap#1.

```
 App  →  brew install --cask macparakeet          (official cask, no tap)
 CLI  →  brew install moona3k/tap/macparakeet-cli  (tap — unchanged)
```

### Changes
- **`README.md`** — app install is now `brew install --cask macparakeet`
  (official, no tap). The **CLI** install stays on the tap — precompiled
  binaries can't go in homebrew-core.
- **`docs/marketing.md`** — drop "Future Homebrew (when shipped)"; it's live.
- **`docs/distribution.md`** — fix a release landmine: the cask fetches
  `…/releases/download/v#{version}/MacParakeet.dmg` (version in the **tag
  path**, constant filename), **not** `MacParakeet-X.Y.Z.dmg`. Each release
  must attach a plain `MacParakeet.dmg` or BrewTestBot autobump silently breaks
  — as it did on `v0.6.20`.

Docs-only — no code or tests touched.

Refs moona3k/macparakeet#500
