### PR TITLE
Dictation-first onboarding (Part A): remove Meeting Recording + Calendar steps

### DIFF
--- a/Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift
+++ b/Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift
@@ -191,8 +191,6 @@ struct OnboardingFlowView: View {
         case .welcome: return "hand.wave"
         case .microphone: return "mic"
         case .accessibility: return "accessibility"
-        case .meetingRecording: return "record.circle"
-        case .calendar: return "calendar"
         case .hotkey: return "keyboard"
         case .engine: return "cpu"
         case .done: return "checkmark.circle"
@@ -207,10 +205,6 @@ struct OnboardingFlowView: View {
             return viewModel.micStatus == .granted
         case .accessibility:
             return viewModel.accessibilityGranted
-        case .meetingRecording:
-            return viewModel.screenRecordingGranted || viewModel.meetingRecordingSkipped
-        case .calendar:
-            return viewModel.calendarPermissionGranted || viewModel.calendarSkipped
         case .hotkey:
             return viewModel.step.rawValue > step.rawValue
         case .engine:
@@ -364,10 +358,6 @@ struct OnboardingFlowView: View {
                     openPrivacySettings(anchor: "Privacy_Accessibility")
                 }
             }
-        case .meetingRecording:
-            meetingRecordingStep
-        case .calendar:
-            calendarStep
         case .hotkey:
             hotkeyStep
         case .engine:
@@ -425,132 +415,6 @@ struct OnboardingFlowView: View {
     }
 
     // MARK: - Hotkey Step
-
-    private var meetingRecordingStep: some View {
-        onboardingCard {
-            VStack(alignment: .leading, spacing: 12) {
-                HStack {
-                    Text("Meeting Recording (Optional)")
-                        .font(DesignSystem.Typography.sectionTitle)
-
-                    Spacer()
-
-                    Text(viewModel.screenRecordingGranted ? "Granted" : "Not granted")
-                        .font(DesignSystem.Typography.caption)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 4)
-                        .background(
-                            Capsule().fill(
-                                viewModel.screenRecordingGranted
-                                ? DesignSystem.Colors.successGreen.opacity(0.15)
-                                : DesignSystem.Colors.warningAmber.opacity(0.15)
-                            )
-                        )
-                        .foregroundStyle(
-                            viewModel.screenRecordingGranted
-                            ? DesignSystem.Colors.successGreen
-                            : DesignSystem.Colors.warningAmber
-                        )
-                }
-
-                Text("Grant access to let MacParakeet record audio from meetings and calls.")
-                    .font(DesignSystem.Typography.bodySmall)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-
-                Text("You can skip this and enable meeting recording later from Settings.")
-                    .font(DesignSystem.Typography.bodySmall)
-                    .foregroundStyle(.secondary)
-
-                HStack(spacing: 10) {
-                    accentButton(
-                        "Enable meeting recording",
-                        disabled: viewModel.isBusy || viewModel.screenRecordingGranted
-                    ) {
-                        viewModel.requestScreenRecordingAccess()
-                    }
-
-                    Button("Skip — I'll set this up later") {
-                        viewModel.skipMeetingRecordingStep()
-                    }
-                    .parakeetAction(.secondary)
-                }
-
-                if !viewModel.screenRecordingGranted {
-                    Button("Open System Settings") {
-                        viewModel.openScreenRecordingSystemSettings()
-                    }
-                    .buttonStyle(.link)
-                }
-
-                if viewModel.showRelaunchHint {
-                    Text("If the status doesn't update, quit and reopen MacParakeet. macOS sometimes requires a restart after granting this permission.")
-                        .font(DesignSystem.Typography.caption)
-                        .foregroundStyle(.secondary)
-                        .padding(DesignSystem.Spacing.sm)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(
-                            RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
-                                .fill(DesignSystem.Colors.warningAmber.opacity(0.08))
-                        )
-                }
-            }
-            .padding(DesignSystem.Spacing.lg)
-        }
-    }
-
-    private var calendarStep: some View {
-        onboardingCard {
-            VStack(alignment: .leading, spacing: 12) {
-                HStack {
-                    Text("Calendar Meetings (Optional)")
-                        .font(DesignSystem.Typography.sectionTitle)
-                    Spacer()
-                    Text(viewModel.calendarPermissionGranted ? "Granted" : "Not granted")
-                        .font(DesignSystem.Typography.caption)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 4)
-                        .background(
-                            Capsule().fill(
-                                viewModel.calendarPermissionGranted
-                                ? DesignSystem.Colors.successGreen.opacity(0.15)
-                                : DesignSystem.Colors.warningAmber.opacity(0.15)
-                            )
-                        )
-                        .foregroundStyle(
-                            viewModel.calendarPermissionGranted
-                            ? DesignSystem.Colors.successGreen
-                            : DesignSystem.Colors.warningAmber
-                        )
-                }
-
-                Text("MacParakeet can read your macOS calendar to send a quiet notification before each scheduled meeting and, if you choose, start recording automatically.")
-                    .font(DesignSystem.Typography.bodySmall)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-
-                Text("Events are read on-device only and never uploaded. You can change the lead time, ignore specific calendars, or turn this off entirely from Settings.")
-                    .font(DesignSystem.Typography.bodySmall)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-
-                HStack(spacing: 10) {
-                    accentButton(
-                        viewModel.isBusy ? "Requesting..." : "Enable Calendar Access",
-                        disabled: viewModel.isBusy || viewModel.calendarPermissionGranted
-                    ) {
-                        viewModel.requestCalendarAccess()
-                    }
-
-                    Button("Skip — I'll set this up later") {
-                        viewModel.skipCalendarStep()
-                    }
-                    .parakeetAction(.secondary)
-                }
-            }
-            .padding(DesignSystem.Spacing.lg)
-        }
-    }
 
     @State private var tapPhase = 0
     @State private var holdPhase: CGFloat = 0
@@ -907,6 +771,11 @@ struct OnboardingFlowView: View {
                         : "\(handsFreeInstructionPhrase) to start dictating anywhere")
                     quickTip(icon: "doc.fill", text: "Drop an audio file onto the main window to transcribe")
                     quickTip(icon: "gearshape", text: "Visit Settings to customize your experience")
+                    if AppFeatures.meetingRecordingEnabled {
+                        Divider()
+                            .padding(.vertical, 4)
+                        quickTip(icon: "record.circle", text: "Recording a meeting? Click Record Meeting in the Transcribe tab.")
+                    }
                 }
                 .padding(DesignSystem.Spacing.lg)
             }
@@ -1053,8 +922,6 @@ struct OnboardingFlowView: View {
         case .welcome: return "Welcome to MacParakeet"
         case .microphone: return "Enable Microphone Access"
         case .accessibility: return "Enable Accessibility"
-        case .meetingRecording: return "Meeting Recording (Optional)"
-        case .calendar: return "Calendar Meetings (Optional)"
         case .hotkey: return "Learn the Hotkey"
         case .engine: return "Prepare Speech Model"
         case .done: return "All Set"
@@ -1069,10 +936,6 @@ struct OnboardingFlowView: View {
             return "MacParakeet needs microphone permission to record your voice."
         case .accessibility:
             return "Accessibility is required for the global hotkey and reliable paste automation."
-        case .meetingRecording:
-            return "Optional. This is only needed to capture system audio during meeting recording."
-        case .calendar:
-            return "Optional. Lets MacParakeet remind you before scheduled meetings and enable opt-in auto-start."
         case .hotkey:
             return "Two ways to dictate — pick whichever feels natural."
         case .engine:
@@ -1090,8 +953,6 @@ struct OnboardingFlowView: View {
         case .welcome: return "Continue"
         case .microphone: return "Continue"
         case .accessibility: return "Continue"
-        case .meetingRecording: return "Continue"
-        case .calendar: return "Continue"
         case .hotkey: return "Continue"
         case .engine: return "Continue"
         case .done: return "Finish"
@@ -1227,8 +1088,6 @@ struct OnboardingFlowView: View {
             return "Grant microphone access to continue."
         case .accessibility:
             return "Enable Accessibility to continue."
-        case .meetingRecording, .calendar:
-            return nil
         case .engine:
             if viewModel.whisperRecommendation != nil {
                 return "Preparing Whisper — first-time Core ML optimization can take 3-5 minutes on some Macs. Everything works offline after setup."

--- a/Sources/MacParakeetCore/AppFeatures.swift
+++ b/Sources/MacParakeetCore/AppFeatures.swift
@@ -6,21 +6,22 @@ import Foundation
 public enum AppFeatures {
     /// Meeting Recording (ADR-014). When `false`, all meeting recording entry
     /// points are hidden: Transcribe tile, menu-bar "Start Recording", global
-    /// meeting hotkey, settings card, library filter, onboarding step, and the
-    /// screen recording permission row. Data model, services, and tests remain
-    /// intact.
+    /// meeting hotkey, settings card, library filter, and the screen recording
+    /// permission row. Meeting recording sets itself up on first use via a
+    /// self-prompt (no onboarding step). Data model, services, and tests remain intact.
     public static let meetingRecordingEnabled: Bool = true
 
     /// Calendar auto-start (ADR-017). When `false`, all calendar entry points
-    /// are hidden: onboarding calendar step, Settings calendar subsection,
-    /// search-index calendar entry, and the auto-start coordinator never starts
-    /// polling. CalendarService, MeetingAutoStartCoordinator, models, and tests
-    /// remain intact — only the surfaces that would invoke them are gated.
+    /// are hidden: Settings calendar subsection, search-index calendar entry,
+    /// and the auto-start coordinator never starts polling. Calendar sets itself
+    /// up on first use from Settings (no onboarding step). CalendarService,
+    /// MeetingAutoStartCoordinator, models, and tests remain intact — only the
+    /// surfaces that would invoke them are gated.
     /// Enabled after the post-#318 reliability hardening (ADR-017 Phases 1+2):
     /// mid-flight teardown, RSVP/zero-duration guards, and reschedule re-fire.
     /// Calendar-driven auto-stop was removed by the 2026-05 amendment. Auto-
     /// start defaults to mode `.off`, so upgraders opt in explicitly via
-    /// onboarding or Settings; nothing changes for existing users until they do.
+    /// Settings; nothing changes for existing users until they do.
     public static let calendarEnabled: Bool = true
 
     /// Transforms — productized Phase 2 (ADR-022). When `true`:

--- a/Sources/MacParakeetViewModels/OnboardingViewModel.swift
+++ b/Sources/MacParakeetViewModels/OnboardingViewModel.swift
@@ -155,11 +155,11 @@ public final class OnboardingViewModel {
             let mic = await permissionService.checkMicrophonePermission()
             let ax = permissionService.checkAccessibilityPermission()
             guard !Task.isCancelled else { return }
-            await MainActor.run {
-                self.micStatus = mic
-                self.accessibilityGranted = ax
-                self.refreshTask = nil
-            }
+            // The class is @MainActor, so this Task already runs on the main
+            // actor — assign directly rather than hopping through MainActor.run.
+            self.micStatus = mic
+            self.accessibilityGranted = ax
+            self.refreshTask = nil
         }
     }
 

--- a/Sources/MacParakeetViewModels/OnboardingViewModel.swift
+++ b/Sources/MacParakeetViewModels/OnboardingViewModel.swift
@@ -55,7 +55,6 @@ public final class OnboardingViewModel {
     public private(set) var step: Step = .welcome
     public private(set) var micStatus: PermissionStatus = .notDetermined
     public private(set) var accessibilityGranted: Bool = false
-    public private(set) var calendarPermissionGranted: Bool = false
     public private(set) var engineState: EngineState = .idle
     public private(set) var whisperRecommendation: WhisperOnboardingRecommendation?
 
@@ -127,7 +126,6 @@ public final class OnboardingViewModel {
         self.defaults = defaults
         self.now = now
         self.permissionPollingInterval = permissionPollingInterval
-        self.calendarPermissionGranted = CalendarService.shared.permissionStatus == .granted
         self.whisperRecommendation = Self.recommendedWhisperLanguage(
             preferredLanguages: (preferredLanguages ?? { Locale.preferredLanguages })()
         )
@@ -149,10 +147,6 @@ public final class OnboardingViewModel {
         defaults.removeObject(forKey: Self.onboardingCompletedKey)
         step = .welcome
         engineState = .idle
-        // Re-resolve from the live calendar permission so a previously-
-        // granted user re-entering onboarding sees the correct "completed"
-        // state, not the stale value carried over from VM init.
-        calendarPermissionGranted = CalendarService.shared.permissionStatus == .granted
     }
 
     public func refresh() {
@@ -250,39 +244,6 @@ public final class OnboardingViewModel {
         if accessibilityGranted {
             Telemetry.send(.permissionGranted(permission: .accessibility))
         }
-    }
-
-    /// Trigger the EventKit permission prompt. On grant, default the user
-    /// into `.notify` mode so the feature works out of the box and request
-    /// notification authorization in the same flow — without it, macOS
-    /// silently drops every reminder we post and the user concludes the
-    /// feature is broken. We write directly to UserDefaults + post the
-    /// shared notification so a running `MeetingAutoStartCoordinator`
-    /// re-evaluates immediately.
-    public func requestCalendarAccess() {
-        isBusy = true
-        Telemetry.send(.permissionPrompted(permission: .calendar))
-        Task {
-            let granted = await CalendarService.shared.requestPermission()
-            let notificationsGranted = granted
-                ? await CalendarNotificationAuthorization.requestIfNeeded()
-                : false
-            await MainActor.run {
-                self.isBusy = false
-                self.calendarPermissionGranted = granted
-                if granted {
-                    Telemetry.send(.permissionGranted(permission: .calendar))
-                    self.applyCalendarMode(notificationsGranted ? .notify : .off)
-                } else {
-                    Telemetry.send(.permissionDenied(permission: .calendar))
-                }
-            }
-        }
-    }
-
-    private func applyCalendarMode(_ mode: CalendarAutoStartMode) {
-        defaults.set(mode.rawValue, forKey: CalendarAutoStartPreferences.modeKey)
-        NotificationCenter.default.post(name: .macParakeetCalendarSettingsDidChange, object: nil)
     }
 
     public func startPermissionPolling() {

--- a/Sources/MacParakeetViewModels/OnboardingViewModel.swift
+++ b/Sources/MacParakeetViewModels/OnboardingViewModel.swift
@@ -23,8 +23,6 @@ public final class OnboardingViewModel {
         case welcome
         case microphone
         case accessibility
-        case meetingRecording
-        case calendar
         case hotkey
         case engine
         case done
@@ -36,8 +34,6 @@ public final class OnboardingViewModel {
             case .welcome: return "Welcome"
             case .microphone: return "Microphone"
             case .accessibility: return "Accessibility"
-            case .meetingRecording: return "Meeting Recording"
-            case .calendar: return "Calendar"
             case .hotkey: return "Hotkey"
             case .engine: return "Speech Model"
             case .done: return "Ready"
@@ -60,9 +56,7 @@ public final class OnboardingViewModel {
     public private(set) var micStatus: PermissionStatus = .notDetermined
     public private(set) var accessibilityGranted: Bool = false
     public private(set) var screenRecordingGranted: Bool = false
-    public private(set) var meetingRecordingSkipped: Bool
     public private(set) var calendarPermissionGranted: Bool = false
-    public private(set) var calendarSkipped: Bool
     public private(set) var showRelaunchHint: Bool = false
     public private(set) var engineState: EngineState = .idle
     public private(set) var whisperRecommendation: WhisperOnboardingRecommendation?
@@ -105,8 +99,6 @@ public final class OnboardingViewModel {
     private let requiredWhisperSetupDiskBytes: Int64 = 2 * 1_024 * 1_024 * 1_024
 
     public nonisolated static let onboardingCompletedKey = "onboarding.completedAtISO"
-    public nonisolated static let meetingRecordingSkippedKey = "onboarding.meetingRecordingSkipped"
-    public nonisolated static let calendarSkippedKey = "onboarding.calendarSkipped"
 
     public init(
         permissionService: PermissionServiceProtocol,
@@ -143,8 +135,6 @@ public final class OnboardingViewModel {
         self.now = now
         self.permissionPollingInterval = permissionPollingInterval
         self.relaunchHintDelay = relaunchHintDelay
-        self.meetingRecordingSkipped = defaults.bool(forKey: Self.meetingRecordingSkippedKey)
-        self.calendarSkipped = defaults.bool(forKey: Self.calendarSkippedKey)
         self.calendarPermissionGranted = CalendarService.shared.permissionStatus == .granted
         self.whisperRecommendation = Self.recommendedWhisperLanguage(
             preferredLanguages: (preferredLanguages ?? { Locale.preferredLanguages })()
@@ -165,12 +155,8 @@ public final class OnboardingViewModel {
 
     public func resetOnboarding() {
         defaults.removeObject(forKey: Self.onboardingCompletedKey)
-        defaults.removeObject(forKey: Self.meetingRecordingSkippedKey)
-        defaults.removeObject(forKey: Self.calendarSkippedKey)
         step = .welcome
         engineState = .idle
-        meetingRecordingSkipped = false
-        calendarSkipped = false
         // Re-resolve from the live calendar permission so a previously-
         // granted user re-entering onboarding sees the correct "completed"
         // state, not the stale value carried over from VM init.
@@ -204,31 +190,15 @@ public final class OnboardingViewModel {
         }
     }
 
-    /// Steps the user actually sees. Hidden steps (gated by `AppFeatures`) are
-    /// filtered out so next/back/jump all walk the visible list — no flicker or
-    /// silent no-ops when flags are off. Calendar requires BOTH meeting
-    /// recording and calendar to be enabled; gating the inner flag alone lets
-    /// us hide the (untested) calendar flow without dropping meeting recording.
+    /// Steps the user actually sees in the dictation-first onboarding flow.
     public static var visibleSteps: [Step] {
-        Step.allCases.filter { step in
-            switch step {
-            case .meetingRecording:
-                return AppFeatures.meetingRecordingEnabled
-            case .calendar:
-                return AppFeatures.meetingRecordingEnabled && AppFeatures.calendarEnabled
-            default:
-                return true
-            }
-        }
+        [.welcome, .microphone, .accessibility, .hotkey, .engine, .done]
     }
 
     public func goNext() {
         let visible = Self.visibleSteps
         let currentRaw = step.rawValue
         guard let next = visible.first(where: { $0.rawValue > currentRaw }) else { return }
-        if step == .meetingRecording {
-            clearMeetingRecordingPendingState()
-        }
         step = next
         Telemetry.send(.onboardingStep(step: next.title.lowercased()))
         refresh()
@@ -238,17 +208,11 @@ public final class OnboardingViewModel {
         let visible = Self.visibleSteps
         let currentRaw = step.rawValue
         guard let prev = visible.last(where: { $0.rawValue < currentRaw }) else { return }
-        if step == .meetingRecording {
-            clearMeetingRecordingPendingState()
-        }
         step = prev
         refresh()
     }
 
     public func jump(to target: Step) {
-        if step == .meetingRecording, target != .meetingRecording {
-            clearMeetingRecordingPendingState()
-        }
         step = target
         refresh()
     }
@@ -261,10 +225,6 @@ public final class OnboardingViewModel {
             return micStatus == .granted
         case .accessibility:
             return accessibilityGranted
-        case .meetingRecording:
-            return true
-        case .calendar:
-            return true
         case .hotkey:
             return true
         case .engine:
@@ -321,13 +281,6 @@ public final class OnboardingViewModel {
         refresh()
     }
 
-    public func skipMeetingRecordingStep() {
-        meetingRecordingSkipped = true
-        defaults.set(true, forKey: Self.meetingRecordingSkippedKey)
-        clearMeetingRecordingPendingState()
-        goNext()
-    }
-
     /// Trigger the EventKit permission prompt. On grant, default the user
     /// into `.notify` mode so the feature works out of the box and request
     /// notification authorization in the same flow — without it, macOS
@@ -354,16 +307,6 @@ public final class OnboardingViewModel {
                 }
             }
         }
-    }
-
-    /// Skip the calendar onboarding step. Persists `.off` mode explicitly so
-    /// the SettingsViewModel default doesn't silently flip back to enabled
-    /// later. Symmetric to `skipMeetingRecordingStep()`.
-    public func skipCalendarStep() {
-        calendarSkipped = true
-        defaults.set(true, forKey: Self.calendarSkippedKey)
-        applyCalendarMode(.off)
-        goNext()
     }
 
     private func applyCalendarMode(_ mode: CalendarAutoStartMode) {
@@ -742,18 +685,13 @@ public final class OnboardingViewModel {
         showRelaunchHint = false
     }
 
-    private func updateMeetingRecordingRelaunchHint(now currentTime: Date) {
+    private func updateMeetingRecordingRelaunchHint(now _: Date) {
         guard !screenRecordingGranted else {
             clearMeetingRecordingPendingState()
             return
         }
 
-        guard step == .meetingRecording, let requestTime = screenRecordingGrantRequestedAt else {
-            showRelaunchHint = false
-            return
-        }
-
-        showRelaunchHint = currentTime.timeIntervalSince(requestTime) >= relaunchHintDelay
+        showRelaunchHint = false
     }
 
     private func cancelWarmUpObservation() {

--- a/Sources/MacParakeetViewModels/OnboardingViewModel.swift
+++ b/Sources/MacParakeetViewModels/OnboardingViewModel.swift
@@ -55,9 +55,7 @@ public final class OnboardingViewModel {
     public private(set) var step: Step = .welcome
     public private(set) var micStatus: PermissionStatus = .notDetermined
     public private(set) var accessibilityGranted: Bool = false
-    public private(set) var screenRecordingGranted: Bool = false
     public private(set) var calendarPermissionGranted: Bool = false
-    public private(set) var showRelaunchHint: Bool = false
     public private(set) var engineState: EngineState = .idle
     public private(set) var whisperRecommendation: WhisperOnboardingRecommendation?
 
@@ -76,7 +74,6 @@ public final class OnboardingViewModel {
     private let defaults: UserDefaults
     private let now: @Sendable () -> Date
     private let permissionPollingInterval: Duration
-    private let relaunchHintDelay: TimeInterval
     private var engineGeneration: Int = 0
     private var refreshTask: Task<Void, Never>?
     private var permissionPollingTask: Task<Void, Never>?
@@ -91,9 +88,6 @@ public final class OnboardingViewModel {
     /// this strongly suggests a stuck connection or a hung dependency.
     /// Memory: v0.4.22 stranded ~23 users for ~24h with no escape hatch.
     public static let warmUpStallTimeout: Duration = .seconds(180)
-    private var screenRecordingGrantRequestedAt: Date?
-    private var hasLoadedInitialScreenRecordingState = false
-    private var hasEmittedScreenRecordingGranted = false
     private let requiredFirstSetupDiskBytes: Int64 = 7 * 1_024 * 1_024 * 1_024
     private let requiredDiarizationSetupDiskBytes: Int64 = 512 * 1_024 * 1_024
     private let requiredWhisperSetupDiskBytes: Int64 = 2 * 1_024 * 1_024 * 1_024
@@ -114,8 +108,7 @@ public final class OnboardingViewModel {
         preferredLanguages: (@Sendable () -> [String])? = nil,
         defaults: UserDefaults = .standard,
         now: @escaping @Sendable () -> Date = { Date() },
-        permissionPollingInterval: Duration = .seconds(2),
-        relaunchHintDelay: TimeInterval = 10
+        permissionPollingInterval: Duration = .seconds(2)
     ) {
         self.permissionService = permissionService
         self.sttClient = sttClient
@@ -134,7 +127,6 @@ public final class OnboardingViewModel {
         self.defaults = defaults
         self.now = now
         self.permissionPollingInterval = permissionPollingInterval
-        self.relaunchHintDelay = relaunchHintDelay
         self.calendarPermissionGranted = CalendarService.shared.permissionStatus == .granted
         self.whisperRecommendation = Self.recommendedWhisperLanguage(
             preferredLanguages: (preferredLanguages ?? { Locale.preferredLanguages })()
@@ -161,7 +153,6 @@ public final class OnboardingViewModel {
         // granted user re-entering onboarding sees the correct "completed"
         // state, not the stale value carried over from VM init.
         calendarPermissionGranted = CalendarService.shared.permissionStatus == .granted
-        clearMeetingRecordingPendingState()
     }
 
     public func refresh() {
@@ -169,22 +160,10 @@ public final class OnboardingViewModel {
         refreshTask = Task {
             let mic = await permissionService.checkMicrophonePermission()
             let ax = permissionService.checkAccessibilityPermission()
-            let screenRecording = permissionService.checkScreenRecordingPermission()
             guard !Task.isCancelled else { return }
             await MainActor.run {
-                let previousScreenRecordingGranted = self.screenRecordingGranted
                 self.micStatus = mic
                 self.accessibilityGranted = ax
-                self.screenRecordingGranted = screenRecording
-                if self.hasLoadedInitialScreenRecordingState,
-                   !previousScreenRecordingGranted,
-                   screenRecording,
-                   !self.hasEmittedScreenRecordingGranted {
-                    self.hasEmittedScreenRecordingGranted = true
-                    Telemetry.send(.permissionGranted(permission: .screenRecording))
-                }
-                self.hasLoadedInitialScreenRecordingState = true
-                self.updateMeetingRecordingRelaunchHint(now: self.now())
                 self.refreshTask = nil
             }
         }
@@ -273,14 +252,6 @@ public final class OnboardingViewModel {
         }
     }
 
-    public func requestScreenRecordingAccess() {
-        Telemetry.send(.permissionPrompted(permission: .screenRecording))
-        screenRecordingGrantRequestedAt = now()
-        showRelaunchHint = false
-        _ = permissionService.requestScreenRecordingPermission()
-        refresh()
-    }
-
     /// Trigger the EventKit permission prompt. On grant, default the user
     /// into `.notify` mode so the feature works out of the box and request
     /// notification authorization in the same flow — without it, macOS
@@ -312,10 +283,6 @@ public final class OnboardingViewModel {
     private func applyCalendarMode(_ mode: CalendarAutoStartMode) {
         defaults.set(mode.rawValue, forKey: CalendarAutoStartPreferences.modeKey)
         NotificationCenter.default.post(name: .macParakeetCalendarSettingsDidChange, object: nil)
-    }
-
-    public func openScreenRecordingSystemSettings() {
-        permissionService.openScreenRecordingSettings()
     }
 
     public func startPermissionPolling() {
@@ -678,20 +645,6 @@ public final class OnboardingViewModel {
     public func stopObservingWarmUp() {
         cancelWarmUpObservation()
         stopPermissionPolling()
-    }
-
-    private func clearMeetingRecordingPendingState() {
-        screenRecordingGrantRequestedAt = nil
-        showRelaunchHint = false
-    }
-
-    private func updateMeetingRecordingRelaunchHint(now _: Date) {
-        guard !screenRecordingGranted else {
-            clearMeetingRecordingPendingState()
-            return
-        }
-
-        showRelaunchHint = false
     }
 
     private func cancelWarmUpObservation() {

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -434,7 +434,7 @@ public final class SettingsViewModel {
             NotificationCenter.default.post(name: .macParakeetCalendarSettingsDidChange, object: nil)
             Telemetry.send(.settingChanged(setting: .calendarAutoStartMode))
             // Enabling reminders requires notification authorization. The
-            // onboarding-grant flow asks for this in tandem with Calendar
+            // Calendar grant flow requests this in tandem with Calendar
             // access, but a user who granted Calendar earlier (or via
             // System Settings) and *now* flips the mode picker to non-`.off`
             // would otherwise hit the silent-drop path: coordinator marks
@@ -1115,11 +1115,10 @@ public final class SettingsViewModel {
         Telemetry.send(granted ? .permissionGranted(permission: .calendar) : .permissionDenied(permission: .calendar))
         if granted {
             await CalendarNotificationAuthorization.requestIfNeeded()
-            // Match the onboarding grant flow (OnboardingViewModel applies
-            // .notify on grant): a user who explicitly grants Calendar access
-            // from Settings intends to use the feature, so default them into
-            // the safe .notify mode. Only when still .off — never clobber an
-            // existing .autoStart choice.
+            // A user who explicitly grants Calendar access from Settings
+            // intends to use the feature, so default them into the safe
+            // .notify mode. Only when still .off — never clobber an existing
+            // .autoStart choice.
             if calendarAutoStartMode == .off {
                 calendarAutoStartMode = .notify
             }

--- a/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
@@ -402,6 +402,12 @@ final class OnboardingViewModelTests: XCTestCase {
         XCTAssertEqual(vm.engineState, .ready)
         let called = await stt.wasWarmUpCalled()
         XCTAssertTrue(called, "Speech model warm-up must still occur on the 6-step path")
+
+        // Once the engine is ready, the final .engine -> .done transition must
+        // complete the 6-step flow end-to-end (the last goNext() in the path).
+        XCTAssertTrue(vm.canContinueFromCurrentStep(), "engine should allow continue once ready")
+        vm.goNext()
+        XCTAssertEqual(vm.step, .done, "the .engine -> .done transition completes the 6-step flow")
     }
 
     func testEngineWarmUpUsesWhisperForCJKPreferredLanguageWhenModelIsCached() async throws {

--- a/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import os
 @testable import MacParakeetCore
 @testable import MacParakeetViewModels
 
@@ -57,6 +58,43 @@ private actor WhisperDownloadSpy {
     }
 }
 
+private final class PollingPermissionService: PermissionServiceProtocol, @unchecked Sendable {
+    private let microphoneCheckCount = OSAllocatedUnfairLock(initialState: 0)
+
+    var checkMicrophonePermissionCallCount: Int {
+        microphoneCheckCount.withLock { $0 }
+    }
+
+    func checkMicrophonePermission() async -> PermissionStatus {
+        microphoneCheckCount.withLock { $0 += 1 }
+        return .granted
+    }
+
+    func requestMicrophonePermission() async -> Bool {
+        true
+    }
+
+    func checkScreenRecordingPermission() -> Bool {
+        true
+    }
+
+    func requestScreenRecordingPermission() -> Bool {
+        true
+    }
+
+    func openMicrophoneSettings() {}
+
+    func openScreenRecordingSettings() {}
+
+    func checkAccessibilityPermission() -> Bool {
+        true
+    }
+
+    func requestAccessibilityPermission(prompt _: Bool) -> Bool {
+        true
+    }
+}
+
 @MainActor
 final class OnboardingViewModelTests: XCTestCase {
     private func waitUntil(
@@ -91,8 +129,7 @@ final class OnboardingViewModelTests: XCTestCase {
         downloadWhisperModel: OnboardingViewModel.WhisperModelDownloader? = nil,
         preferredLanguages: @escaping @Sendable () -> [String] = { ["en-US"] },
         now: @escaping @Sendable () -> Date = { Date() },
-        permissionPollingInterval: Duration = .seconds(2),
-        relaunchHintDelay: TimeInterval = 10
+        permissionPollingInterval: Duration = .seconds(2)
     ) -> OnboardingViewModel {
         OnboardingViewModel(
             permissionService: permissionService,
@@ -108,8 +145,7 @@ final class OnboardingViewModelTests: XCTestCase {
             preferredLanguages: preferredLanguages,
             defaults: defaults,
             now: now,
-            permissionPollingInterval: permissionPollingInterval,
-            relaunchHintDelay: relaunchHintDelay
+            permissionPollingInterval: permissionPollingInterval
         )
     }
 
@@ -301,36 +337,8 @@ final class OnboardingViewModelTests: XCTestCase {
         XCTAssertNil(OnboardingViewModel.recommendedWhisperLanguage(preferredLanguages: ["zh-Hans-CN", "en-GB"]))
     }
 
-    func testScreenRecordingGrantTransitionEmitsPermissionGrantedOnce() async throws {
-        let telemetry = OnboardingTelemetrySpy()
-        Telemetry.configure(telemetry)
-        defer { Telemetry.configure(NoOpTelemetryService()) }
-
-        let perms = MockPermissionService()
-        perms.screenRecordingPermissionSequence = [false, true, true]
-        let stt = MockSTTClient()
-        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
-        let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
-
-        vm.refresh()
-        try await Task.sleep(for: .milliseconds(60))
-        vm.refresh()
-        try await Task.sleep(for: .milliseconds(60))
-        vm.refresh()
-        try await Task.sleep(for: .milliseconds(60))
-
-        let grantedEvents = telemetry.snapshot().filter {
-            if case .permissionGranted(let permission) = $0 {
-                return permission == .screenRecording
-            }
-            return false
-        }
-        XCTAssertEqual(grantedEvents.count, 1)
-    }
-
     func testPermissionPollingLifecycleStopsAfterCancellation() async throws {
-        let perms = MockPermissionService()
-        perms.screenRecordingPermission = false
+        let perms = PollingPermissionService()
         let stt = MockSTTClient()
         let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
         let vm = makeViewModel(
@@ -343,17 +351,17 @@ final class OnboardingViewModelTests: XCTestCase {
         vm.startPermissionPolling()
         vm.startPermissionPolling()
         try await waitUntil(timeout: .milliseconds(500)) {
-            perms.checkScreenRecordingPermissionCallCount > 1
+            perms.checkMicrophonePermissionCallCount > 1
         }
-        let beforeStopCount = perms.checkScreenRecordingPermissionCallCount
+        let beforeStopCount = perms.checkMicrophonePermissionCallCount
         XCTAssertGreaterThan(beforeStopCount, 1)
 
         vm.stopPermissionPolling()
-        let atStopCount = perms.checkScreenRecordingPermissionCallCount
+        let atStopCount = perms.checkMicrophonePermissionCallCount
         try await Task.sleep(for: .milliseconds(100))
-        let firstSettledCount = perms.checkScreenRecordingPermissionCallCount
+        let firstSettledCount = perms.checkMicrophonePermissionCallCount
         try await Task.sleep(for: .milliseconds(100))
-        let secondSettledCount = perms.checkScreenRecordingPermissionCallCount
+        let secondSettledCount = perms.checkMicrophonePermissionCallCount
 
         // Allow at most one in-flight refresh tick to finish after cancellation.
         XCTAssertLessThanOrEqual(firstSettledCount, atStopCount + 1)

--- a/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
@@ -34,14 +34,6 @@ private final class OnboardingTelemetrySpy: TelemetryServiceProtocol, @unchecked
     }
 }
 
-private final class MutableDateBox: @unchecked Sendable {
-    var value: Date
-
-    init(_ value: Date) {
-        self.value = value
-    }
-}
-
 private actor WhisperDownloadSpy {
     private var calls: [String] = []
     var error: Error?
@@ -163,11 +155,120 @@ final class OnboardingViewModelTests: XCTestCase {
         XCTAssertTrue(vm.canContinueFromCurrentStep())
     }
 
-    func testMeetingRecordingStepOrdering() {
+    func testStepOrdering() {
         XCTAssertEqual(
             OnboardingViewModel.Step.allCases,
-            [.welcome, .microphone, .accessibility, .meetingRecording, .calendar, .hotkey, .engine, .done]
+            [.welcome, .microphone, .accessibility, .hotkey, .engine, .done]
         )
+    }
+
+    // MARK: - Six-step dictation-first flow
+
+    func testVisibleStepsIsCanonicalSixStepList() {
+        XCTAssertEqual(
+            OnboardingViewModel.visibleSteps,
+            [.welcome, .microphone, .accessibility, .hotkey, .engine, .done]
+        )
+    }
+
+    func testGoNextWalksSixSteps() async throws {
+        let perms = MockPermissionService()
+        perms.microphonePermission = .granted
+        perms.accessibilityPermission = true
+        let stt = MockSTTClient()
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+
+        let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
+        XCTAssertEqual(vm.step, .welcome)
+
+        vm.goNext()
+        XCTAssertEqual(vm.step, .microphone)
+
+        vm.goNext()
+        XCTAssertEqual(vm.step, .accessibility)
+
+        vm.goNext()
+        XCTAssertEqual(vm.step, .hotkey)
+
+        vm.goNext()
+        XCTAssertEqual(vm.step, .engine)
+
+        XCTAssertFalse(vm.canContinueFromCurrentStep())
+    }
+
+    func testGoBackWalksSixSteps() {
+        let perms = MockPermissionService()
+        let stt = MockSTTClient()
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+
+        let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
+        vm.jump(to: .done)
+
+        vm.goBack()
+        XCTAssertEqual(vm.step, .engine)
+
+        vm.goBack()
+        XCTAssertEqual(vm.step, .hotkey)
+
+        vm.goBack()
+        XCTAssertEqual(vm.step, .accessibility)
+
+        vm.goBack()
+        XCTAssertEqual(vm.step, .microphone)
+
+        vm.goBack()
+        XCTAssertEqual(vm.step, .welcome)
+
+        vm.goBack()
+        XCTAssertEqual(vm.step, .welcome)
+    }
+
+    func testCanContinueForEachStep() {
+        let perms = MockPermissionService()
+        perms.microphonePermission = .granted
+        perms.accessibilityPermission = true
+        let stt = MockSTTClient()
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+
+        let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
+
+        vm.jump(to: .welcome)
+        XCTAssertTrue(vm.canContinueFromCurrentStep(), "welcome should always allow continue")
+
+        vm.jump(to: .hotkey)
+        XCTAssertTrue(vm.canContinueFromCurrentStep(), "hotkey should always allow continue")
+
+        vm.jump(to: .done)
+        XCTAssertTrue(vm.canContinueFromCurrentStep(), "done should always allow continue")
+
+        vm.jump(to: .engine)
+        XCTAssertFalse(vm.canContinueFromCurrentStep(), "engine requires ready state")
+    }
+
+    func testExistingUsersDoNotReOnboard() {
+        let perms = MockPermissionService()
+        let stt = MockSTTClient()
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        defaults.set("2026-01-01T00:00:00Z", forKey: OnboardingViewModel.onboardingCompletedKey)
+
+        let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
+        XCTAssertTrue(vm.hasCompletedOnboarding)
+    }
+
+    func testNoMeetingRecordingOrCalendarStepsInFlow() {
+        let steps = OnboardingViewModel.visibleSteps
+        let allCases = OnboardingViewModel.Step.allCases
+
+        XCTAssertEqual(steps, allCases)
+        XCTAssertEqual(steps.count, 6)
     }
 
     func testWhisperOnboardingRecommendationDetectsCJKPreferredLanguages() {
@@ -200,58 +301,6 @@ final class OnboardingViewModelTests: XCTestCase {
         XCTAssertNil(OnboardingViewModel.recommendedWhisperLanguage(preferredLanguages: ["zh-Hans-CN", "en-GB"]))
     }
 
-    func testMeetingRecordingStepCanContinueWithoutPermission() {
-        let perms = MockPermissionService()
-        perms.screenRecordingPermission = false
-        let stt = MockSTTClient()
-        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
-
-        let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
-        vm.jump(to: .meetingRecording)
-
-        XCTAssertTrue(vm.canContinueFromCurrentStep())
-    }
-
-    func testSkipMeetingRecordingStepSetsFlagAndAdvances() {
-        let perms = MockPermissionService()
-        let stt = MockSTTClient()
-        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
-
-        let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
-        vm.jump(to: .meetingRecording)
-
-        vm.skipMeetingRecordingStep()
-
-        XCTAssertTrue(vm.meetingRecordingSkipped)
-        XCTAssertTrue(defaults.bool(forKey: OnboardingViewModel.meetingRecordingSkippedKey))
-        // Skip advances to the next *visible* step. With `calendarEnabled` on
-        // that's `.calendar`; with it off the calendar step is filtered out
-        // and the flow jumps straight to `.hotkey`.
-        let expected: OnboardingViewModel.Step = AppFeatures.calendarEnabled ? .calendar : .hotkey
-        XCTAssertEqual(vm.step, expected)
-    }
-
-    func testResetOnboardingClearsMeetingRecordingSkippedFlag() {
-        let perms = MockPermissionService()
-        let stt = MockSTTClient()
-        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
-
-        let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
-        vm.jump(to: .meetingRecording)
-        vm.skipMeetingRecordingStep()
-        XCTAssertTrue(defaults.bool(forKey: OnboardingViewModel.meetingRecordingSkippedKey))
-
-        vm.resetOnboarding()
-
-        XCTAssertFalse(vm.meetingRecordingSkipped)
-        XCTAssertNil(defaults.object(forKey: OnboardingViewModel.meetingRecordingSkippedKey))
-        XCTAssertEqual(vm.step, .welcome)
-    }
-
     func testScreenRecordingGrantTransitionEmitsPermissionGrantedOnce() async throws {
         let telemetry = OnboardingTelemetrySpy()
         Telemetry.configure(telemetry)
@@ -277,31 +326,6 @@ final class OnboardingViewModelTests: XCTestCase {
             return false
         }
         XCTAssertEqual(grantedEvents.count, 1)
-    }
-
-    func testRelaunchHintShowsAfterDelayWhenScreenRecordingStillNotGranted() async throws {
-        let perms = MockPermissionService()
-        perms.screenRecordingPermission = false
-        perms.requestScreenRecordingResult = false
-        let stt = MockSTTClient()
-        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
-        let nowBox = MutableDateBox(Date(timeIntervalSince1970: 0))
-        let vm = makeViewModel(
-            permissionService: perms,
-            sttClient: stt,
-            defaults: defaults,
-            now: { nowBox.value }
-        )
-
-        vm.jump(to: .meetingRecording)
-        vm.requestScreenRecordingAccess()
-        try await Task.sleep(for: .milliseconds(60))
-        XCTAssertFalse(vm.showRelaunchHint)
-
-        nowBox.value = nowBox.value.addingTimeInterval(11)
-        vm.refresh()
-        try await Task.sleep(for: .milliseconds(60))
-        XCTAssertTrue(vm.showRelaunchHint)
     }
 
     func testPermissionPollingLifecycleStopsAfterCancellation() async throws {
@@ -353,6 +377,23 @@ final class OnboardingViewModelTests: XCTestCase {
         let called = await stt.wasWarmUpCalled()
         XCTAssertTrue(called)
         XCTAssertTrue(vm.canContinueFromCurrentStep())
+    }
+
+    func testEngineWarmUpDownloadRemainsOnPath() async throws {
+        let perms = MockPermissionService()
+        let stt = MockSTTClient()
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+
+        let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
+        vm.jump(to: .engine)
+        vm.startEngineWarmUp()
+        try await Task.sleep(for: .milliseconds(150))
+
+        XCTAssertEqual(vm.engineState, .ready)
+        let called = await stt.wasWarmUpCalled()
+        XCTAssertTrue(called, "Speech model warm-up must still occur on the 6-step path")
     }
 
     func testEngineWarmUpUsesWhisperForCJKPreferredLanguageWhenModelIsCached() async throws {

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -112,15 +112,15 @@ See [00-vision.md](./00-vision.md) for positioning and market context.
 - Teach the core interaction model in under 60 seconds.
 - Download and warm up the right local speech stack on first run: Parakeet STT plus default-on speaker-detection assets for the normal path, or local Whisper plus speaker-detection assets when the user's macOS language is Korean, Japanese, Chinese, or Cantonese. Nemotron is opt-in after onboarding.
 
-**Flow:**
+**Flow (6 steps, dictation-first):**
 1. Welcome
 2. Microphone permission
 3. Accessibility permission
-4. Meeting recording permission (optional Screen & System Audio Recording)
-5. Calendar meetings (optional EventKit access, when `AppFeatures.calendarEnabled`)
-6. Hotkey instructions (configurable trigger + Esc)
-7. Speech stack setup (Parakeet + speaker detection by default; locale-aware Whisper setup for CJK macOS languages; Nemotron remains an explicit Beta choice after setup)
-8. Ready
+4. Hotkey instructions (configurable trigger + Esc)
+5. Speech stack setup (Parakeet + speaker detection by default; locale-aware Whisper setup for CJK macOS languages; Nemotron remains an explicit Beta choice after setup)
+6. Ready
+
+Meeting Recording and Calendar are opt-in and self-prompt on first use (see ADR-005 amendment, 2026-06-13).
 
 **Model failure recovery:**
 - Before warm-up, onboarding runs lightweight preflight checks (runtime support + first-setup disk/network readiness for both STT and any required default-on speaker-detection assets).

--- a/spec/README.md
+++ b/spec/README.md
@@ -219,9 +219,9 @@ Dictation + transcription + history + settings. Get audio in, text out, pasted i
 - [x] Plain-noun tab strip with one ambient indicator (ADR-020 §1, amended 2026-05-02): `Notes`, `Transcript`, `Ask` plus a breathing dot on Ask while `chatViewModel.isStreaming`; `ViewThatFits` collapses the dot into the tooltip at the 360px floor
 - [x] STT failure copy refinement (ADR-020): "Recording Error" → "Meeting interrupted" + Library-recovery hint wrapper around the technical detail
 
-Calendar-related code is implemented and **enabled** (`AppFeatures.calendarEnabled = true`) after the post-#318 reliability hardening. It surfaces the onboarding step, Settings subsection, search entry, reminder notifications, auto-start countdown, and coordinator polling; auto-start defaults to mode `.off`, so it is strictly opt-in:
+Calendar-related code is implemented and **enabled** (`AppFeatures.calendarEnabled = true`) after the post-#318 reliability hardening. It surfaces the Settings subsection, first-use permission prompt, search entry, reminder notifications, auto-start countdown, and coordinator polling; auto-start defaults to mode `.off`, so it is strictly opt-in:
 
-- [x] Calendar-driven reminders (ADR-017 Phase 1): EventKit integration + onboarding + settings + per-calendar include list
+- [x] Calendar-driven reminders (ADR-017 Phase 1): EventKit integration + first-use prompt + settings + per-calendar include list
 - [x] Pre-meeting macOS notifications at configurable lead time (off / 1 / 5 / 10 min)
 - [x] Auto-start countdown toast (ADR-017 Phase 2): 5s cancellable, top-right, non-activating
 - [ ] ~~Auto-stop toast at calendar event end~~ — **removed** (ADR-017 amendment, 2026-05): scheduled end times are unreliable; recordings stop manually. Activity/audio-based auto-stop is a future ADR.

--- a/spec/adr/005-onboarding-first-run.md
+++ b/spec/adr/005-onboarding-first-run.md
@@ -49,3 +49,23 @@ While onboarding is visible, permission state is polled so changes made in Syste
 
 - Inline onboarding inside the main window: rejected because the app is menu-bar-first and may never open the main window on first launch.
 - No onboarding: rejected due to permission and warm-up failures appearing as unexplained errors.
+
+## Amendment — 2026-06-13: Dictation-First Onboarding (Part A)
+
+**Decision:** Remove Meeting Recording and Calendar from the first-run onboarding flow. Onboarding is now 6 steps:
+1. Welcome
+2. Microphone permission
+3. Accessibility permission
+4. Hotkey instructions
+5. Speech stack setup
+6. Ready
+
+**Rationale:** Telemetry showed the Meeting Recording step (step 4 of 8) was the single largest onboarding drop, with ~90% of users skipping or abandoning at that step. Meeting recording and calendar are optional features; their onboarding steps added friction to the dictation-primary flow without improving activation.
+
+**Self-prompt contract:** Each removed feature sets itself up on first use:
+- Meeting recording: the Transcribe tab "Record Meeting" tile triggers the Screen & System Audio Recording permission prompt on first use (`MeetingRecordingFlowCoordinator`).
+- Calendar: the Settings calendar subsection requests EventKit access on first use (`CalendarSettingsView`).
+
+Accessibility is still granted during onboarding for all users, which also covers the meeting recording global hotkey's `CGEvent` session tap.
+
+**Part B (not yet done):** A separate planned change will move the speech-model download to start at onboarding open rather than at the Speech Model step. See `plans/active/2026-05-dictation-first-onboarding.md`.

--- a/spec/adr/005-onboarding-first-run.md
+++ b/spec/adr/005-onboarding-first-run.md
@@ -60,7 +60,7 @@ While onboarding is visible, permission state is polled so changes made in Syste
 5. Speech stack setup
 6. Ready
 
-**Rationale:** Telemetry showed the Meeting Recording step (step 4 of 8) was the single largest onboarding drop, with ~90% of users skipping or abandoning at that step. Meeting recording and calendar are optional features; their onboarding steps added friction to the dictation-primary flow without improving activation.
+**Rationale:** ~90% of users skipped the optional Screen & System Audio Recording permission at that step, and the step was the single largest onboarding drop-off (~24% of users who reached it did not continue to the core dictation setup). Meeting recording and calendar are optional features; their onboarding steps added friction to the dictation-primary flow without improving activation.
 
 **Self-prompt contract:** Each removed feature sets itself up on first use:
 - Meeting recording: the Transcribe tab "Record Meeting" tile triggers the Screen & System Audio Recording permission prompt on first use (`MeetingRecordingFlowCoordinator`).

--- a/spec/kernel/requirements.yaml
+++ b/spec/kernel/requirements.yaml
@@ -20,6 +20,7 @@
 #   LIB   - Transcription library
 #   MEET  - Meeting recording
 #   CAL   - Calendar auto-start
+#   ONB   - First-run onboarding
 #   CLI   - Public command-line surface
 #   XFORM - System-wide selected-text Transforms
 
@@ -321,7 +322,14 @@ REQ-CAL-001:
   status: implemented
 
 REQ-CAL-002:
-  description: Calendar settings and a skippable onboarding step let users grant Calendar access, choose the auto-start mode and lead time, and include specific calendars; the Meetings workspace Upcoming section additionally lets users connect Calendar inline (request access when not determined, deep-link to System Settings when blocked) and exposes inline mode (off/reminders/auto-start) and event-filter controls plus an Upcoming preview that mirrors the auto-start candidate rules (calendar rows appear in Settings search only when enabled, and the CLI exposes upcoming calendar events for headless verification)
+  description: Calendar settings and first-use connection surfaces let users grant Calendar access, choose the auto-start mode and lead time, and include specific calendars; the Meetings workspace Upcoming section additionally lets users connect Calendar inline (request access when not determined, deep-link to System Settings when blocked) and exposes inline mode (off/reminders/auto-start) and event-filter controls plus an Upcoming preview that mirrors the auto-start candidate rules (calendar rows appear in Settings search only when enabled, and the CLI exposes upcoming calendar events for headless verification)
+  version: v0.6
+  status: implemented
+
+# --- v0.6 Onboarding ---
+
+REQ-ONB-001:
+  description: Dictation-first 6-step onboarding (Welcome → Microphone → Accessibility → Hotkey → Speech Model → Ready); Meeting Recording and Calendar are opt-in, self-prompting on first use
   version: v0.6
   status: implemented
 


### PR DESCRIPTION
## What & why

Makes first-run onboarding **dictation-first** by removing the **Meeting Recording** and **Calendar** steps: **8 steps → 6** (`Welcome → Microphone → Accessibility → Hotkey → Speech Model → Ready`). A quiet discoverability line on the Ready screen keeps meeting recording visible, and both features self-prompt on first use.

**Why (telemetry, last 30 days, `0.6.x`):**
- The Meeting-Recording/Calendar block was the **single largest onboarding drop — ~24%** (vs 1–4% at adjacent steps).
- The step was **mostly skipped**: of ~1,852 sessions that reached it, **≤183 (~10%) granted Screen Recording**.
- Meetings is well-used (**872 sessions / 30d**), but that adoption is driven by the in-app **"Record Meeting" tile**, not onboarding (872 vs ≤183). So removing the step recovers the funnel at near-zero cost to meetings adoption.

Plan: `plans/active/2026-05-dictation-first-onboarding.md` (Part A).

## What's in this PR

- **Onboarding flow** (`OnboardingViewModel`, `OnboardingFlowView`): drop the `.meetingRecording` / `.calendar` `Step` cases + their step views + skip plumbing; static 6-step `visibleSteps`; all exhaustive `Step` switches updated; Ready-screen meetings line gated on `AppFeatures.meetingRecordingEnabled`.
- **Dead-code cleanup**: removed the now-unreachable screen-recording, relaunch-hint, and calendar scaffolding the deleted steps left behind in `OnboardingViewModel`. The real screen-recording/calendar permission UI lives on `SettingsViewModel` / `CalendarSettingsView` and is **untouched**.
- **Self-prompt contract preserved**: meeting recording → `MeetingRecordingFlowCoordinator` triggers the Screen & System Audio prompt on first "Record Meeting"; calendar → `CalendarSettingsView` requests EventKit access. Accessibility stays onboarded for everyone (also covers the meeting hotkey's `CGEvent` session tap).
- **Docs**: ADR-005 amendment (2026-06-13), `spec/02-features.md` F0 8→6, `spec/README.md` calendar dewording, `REQ-ONB-001` in `requirements.yaml`.
- **Tests**: +7 onboarding tests (6-step `visibleSteps`, `goNext`/`goBack` walks, per-step continue logic, explicit no-meeting/calendar regression guard); removed/updated tests tied to deleted behavior.

## Out of scope (deferred)

- **Part B** (model-download head-start at onboarding open) — separate change; soft-depends on the warm-up watchdog test (`plans/active/2026-06-onboarding-stall-watchdog-test.md`).
- **No telemetry changes** — `onboarding_step` / `onboarding_completed` already instrument the funnel; the lift is confirmed by post-ship analysis (no two-repo allowlist change).

## Verification

- `swift build` ✓
- `swift test` ✓ — **3,657 tests, 10 skipped, 0 failures**
- Scope: 8 files (4 source/test, 4 spec); **+214 / −425** (heavily subtractive).

Implemented by Codex (GPT-5.5, xhigh); reviewed by re-running build + the full suite, reading every diff, auditing the new tests, and checking scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
