### PR TITLE
Implement meeting mic-health watchdog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,10 @@ profiles with readable/toggleable smart defaults, REQ-LLM-004; enabled
 2026-06-10, not yet in a tagged release). Staged default-off flags on `main`
 that are not user-visible until validation flips them: `AppFeatures.meetingAutoStopEnabled = false`
 (ADR-023 activity-based meeting auto-stop, implemented 2026-06-14 behind its
-own opt-in setting). All other `AppFeatures` flags match the shipping build.
+own opt-in setting). Reliability kill-switch on `main`:
+`AppFeatures.meetingCaptureReliabilityEnabled = true` (ADR-025 Phase A
+mic-health telemetry watchdog; default-on, no UI/recording behavior change).
+All other `AppFeatures` flags match the shipping build.
 
 Ship history for flagged features: Transforms reached stable in v0.6.7;
 calendar auto-start in v0.6.10 (defaults to mode `.off`, strictly opt-in;
@@ -145,7 +148,7 @@ All ADRs are in `spec/adr/`. These are locked decisions -- don't second-guess th
 | ADR-022 | Transforms — system-wide LLM rewrites on selected text (Phase 2 productized; enabled, shipping since v0.6.7) | `spec/adr/022-transforms-system-wide-rewrite.md` |
 | ADR-023 | Activity-based meeting auto-stop (silence + app-quit signals + veto countdown; Phases A+B implemented behind default-off flag, Phase C deferred to ADR-024 attribution) | `spec/adr/023-activity-based-meeting-auto-stop.md` |
 | ADR-024 | Activity-based meeting detection (per-process audio attribution + camera + app signal fusion; proposed) | `spec/adr/024-activity-based-meeting-detection.md` |
-| ADR-025 | Meeting capture reliability — mic-health watchdog + post-stop coverage repair (proposed) | `spec/adr/025-meeting-capture-reliability.md` |
+| ADR-025 | Meeting capture reliability — mic-health watchdog + post-stop coverage repair (Phase A mic-health telemetry watchdog implemented behind default-on kill-switch; warning UI + repair proposed) | `spec/adr/025-meeting-capture-reliability.md` |
 
 > Historical/dormant ADRs (still in `spec/adr/`, kept for context): ADR-003 (one-time purchase pricing), ADR-006 (trial + license activation), ADR-008 (local LLM runtime). Current public builds are free/GPL-3.0 and unlocked. The old LemonSqueezy/trial entitlement plumbing is intentionally retained as future-option code for GPL-compatible official paid distribution/support; do not remove it as dead code without explicit owner direction and an ADR/spec update.
 
@@ -157,6 +160,7 @@ freetext podcast search), Parakeet v3/v2 model selection, optional Nemotron
 3.5 Beta (ADR-001 amendment) and WhisperKit (ADR-021) engines, opt-in instant dictation (warm-mic
 pre-roll), app-aware AI Formatter profiles (REQ-LLM-004, `main`-only flag),
 default-off activity-based meeting auto-stop (ADR-023, `main` validation flag),
+meeting mic-health telemetry watchdog (ADR-025 Phase A, default-on kill-switch),
 and productized Transforms with `Polish`/`Distill`/`Decide` built-ins on
 Control-Option hotkeys (ADR-022). Calendar auto-start is ADR-017 Phases 1 + 2
 (enabled, default `.off`); Phase 3 (late-join/retro-link) remains proposed.

--- a/Sources/MacParakeetCore/AppFeatures.swift
+++ b/Sources/MacParakeetCore/AppFeatures.swift
@@ -30,6 +30,14 @@ public enum AppFeatures {
     /// active. Default off until field validation proves the trust posture.
     public static let meetingAutoStopEnabled: Bool = false
 
+    /// Meeting capture reliability watchdog (ADR-025 Phase A). When `true`,
+    /// meeting capture observes metadata-only microphone/system buffer liveness
+    /// and emits `mic_stall_detected` telemetry for confirmed mic-health
+    /// stalls. This does not stop, truncate, repair, or discard recordings.
+    /// Keep this default-on reliability path behind a kill switch while repair
+    /// phases are still being validated.
+    public static let meetingCaptureReliabilityEnabled: Bool = true
+
     /// Transforms — productized Phase 2 (ADR-022). When `true`:
     /// - the Transforms tab appears in the main sidebar
     /// - `TransformsHotkeyRegistry` installs its event tap on launch

--- a/Sources/MacParakeetCore/Audio/MeetingAudioCaptureService.swift
+++ b/Sources/MacParakeetCore/Audio/MeetingAudioCaptureService.swift
@@ -410,6 +410,8 @@ private final class MeetingMicHealthTelemetryObserver: @unchecked Sendable {
 
         for event in events {
             guard case let .stallSuspected(signature, elapsedMs) = event else {
+                // ADR-025 Phase A emits only detection telemetry; warning and recovery
+                // surfaces consume `.recovered` in later phases.
                 continue
             }
             Telemetry.send(.micStallDetected(signature: .init(signature), elapsedMs: elapsedMs))

--- a/Sources/MacParakeetCore/Audio/MeetingAudioCaptureService.swift
+++ b/Sources/MacParakeetCore/Audio/MeetingAudioCaptureService.swift
@@ -59,6 +59,7 @@ public actor MeetingAudioCaptureService {
     private let micProcessingMode: MeetingMicProcessingMode
     private let sourceModeProvider: @Sendable () -> MeetingAudioSourceMode
     private let eventSink = EventSink()
+    private let micHealthObserver: MeetingMicHealthTelemetryObserver
 
     private var systemAudioCapture: (any MeetingSystemAudioCapturing)?
     private var isCapturing = false
@@ -74,6 +75,7 @@ public actor MeetingAudioCaptureService {
         self.microphoneCapture = MicrophoneCapture(sharedStream: sharedMicStream)
         self.micProcessingMode = micProcessingMode
         self.sourceModeProvider = sourceModeProvider
+        self.micHealthObserver = MeetingMicHealthTelemetryObserver()
         self.systemAudioCaptureFactory = {
             guard #available(macOS 14.2, *) else {
                 throw MeetingAudioError.unsupportedPlatform
@@ -86,24 +88,40 @@ public actor MeetingAudioCaptureService {
         microphoneCaptureFactory: @escaping MeetingMicrophoneCaptureFactory,
         systemAudioCaptureFactory: @escaping @Sendable () throws -> any MeetingSystemAudioCapturing,
         micProcessingMode: MeetingMicProcessingMode = .raw,
-        sourceModeProvider: @escaping @Sendable () -> MeetingAudioSourceMode = { .microphoneAndSystem }
+        sourceModeProvider: @escaping @Sendable () -> MeetingAudioSourceMode = { .microphoneAndSystem },
+        micHealthConfig: MeetingMicHealthMonitor.Config = .default,
+        micHealthNowProvider: @escaping @Sendable () -> Date = { Date() },
+        micHealthFeatureEnabled: Bool = AppFeatures.meetingCaptureReliabilityEnabled
     ) {
         self.microphoneCapture = microphoneCaptureFactory()
         self.systemAudioCaptureFactory = systemAudioCaptureFactory
         self.micProcessingMode = micProcessingMode
         self.sourceModeProvider = sourceModeProvider
+        self.micHealthObserver = MeetingMicHealthTelemetryObserver(
+            config: micHealthConfig,
+            nowProvider: micHealthNowProvider,
+            featureEnabled: micHealthFeatureEnabled
+        )
     }
 
     init(
         microphoneCapture: any MeetingMicrophoneCapturing,
         systemAudioCaptureFactory: @escaping @Sendable () throws -> any MeetingSystemAudioCapturing,
         micProcessingMode: MeetingMicProcessingMode = .raw,
-        sourceModeProvider: @escaping @Sendable () -> MeetingAudioSourceMode = { .microphoneAndSystem }
+        sourceModeProvider: @escaping @Sendable () -> MeetingAudioSourceMode = { .microphoneAndSystem },
+        micHealthConfig: MeetingMicHealthMonitor.Config = .default,
+        micHealthNowProvider: @escaping @Sendable () -> Date = { Date() },
+        micHealthFeatureEnabled: Bool = AppFeatures.meetingCaptureReliabilityEnabled
     ) {
         self.microphoneCapture = microphoneCapture
         self.systemAudioCaptureFactory = systemAudioCaptureFactory
         self.micProcessingMode = micProcessingMode
         self.sourceModeProvider = sourceModeProvider
+        self.micHealthObserver = MeetingMicHealthTelemetryObserver(
+            config: micHealthConfig,
+            nowProvider: micHealthNowProvider,
+            featureEnabled: micHealthFeatureEnabled
+        )
     }
 
     public var events: AsyncStream<MeetingAudioCaptureEvent> {
@@ -139,6 +157,7 @@ public actor MeetingAudioCaptureService {
         let systemCapture = try systemAudioCaptureFactory()
         let sourceMode = sourceModeOverride ?? sourceModeProvider()
         eventSink.setHandler(handler)
+        micHealthObserver.start(observing: sourceMode.capturesMicrophone)
         var microphoneStartReport: MeetingMicrophoneCaptureStartReport?
         var attemptedMicrophoneStart = false
         let systemAudioFailureEvent: @Sendable (MeetingAudioError) -> MeetingAudioCaptureEvent = { error in
@@ -165,6 +184,7 @@ public actor MeetingAudioCaptureService {
                             )
                             return
                         }
+                        self?.micHealthObserver.observeMicrophoneBuffer(copy)
                         self?.eventSink.emit(.microphoneBuffer(copy, time))
                     },
                     onStall: { [weak self] error in
@@ -187,6 +207,7 @@ public actor MeetingAudioCaptureService {
                         )
                         return
                     }
+                    self?.micHealthObserver.observeSystemBuffer(copy)
                     self?.eventSink.emit(.systemBuffer(copy, time))
                 },
                 onStall: { [weak self] error in
@@ -200,6 +221,7 @@ public actor MeetingAudioCaptureService {
             await systemCapture.stop()
             finishEventStream()
             eventSink.setHandler(nil)
+            micHealthObserver.stop()
             throw error
         }
 
@@ -225,6 +247,7 @@ public actor MeetingAudioCaptureService {
         eventContinuation?.finish()
         finishEventStream()
         eventSink.setHandler(nil)
+        micHealthObserver.stop()
         logger.info("Meeting audio capture stopped")
     }
 
@@ -325,6 +348,72 @@ private final class EventSink: @unchecked Sendable {
     func emit(_ event: MeetingAudioCaptureEvent) {
         let currentHandler = lock.withLock { handler }
         currentHandler?(event)
+    }
+}
+
+private final class MeetingMicHealthTelemetryObserver: @unchecked Sendable {
+    private let lock = NSLock()
+    private let config: MeetingMicHealthMonitor.Config
+    private let nowProvider: @Sendable () -> Date
+    private let featureEnabled: Bool
+    private var monitor: MeetingMicHealthMonitor
+    private var isObserving = false
+
+    init(
+        config: MeetingMicHealthMonitor.Config = .default,
+        nowProvider: @escaping @Sendable () -> Date = { Date() },
+        featureEnabled: Bool = AppFeatures.meetingCaptureReliabilityEnabled
+    ) {
+        self.config = config
+        self.nowProvider = nowProvider
+        self.featureEnabled = featureEnabled
+        self.monitor = MeetingMicHealthMonitor(config: config)
+    }
+
+    func start(observing sourceIncludesMicrophone: Bool) {
+        lock.withLock {
+            monitor = MeetingMicHealthMonitor(config: config)
+            isObserving = featureEnabled && sourceIncludesMicrophone
+        }
+    }
+
+    func stop() {
+        lock.withLock {
+            monitor.reset()
+            isObserving = false
+        }
+    }
+
+    func observeMicrophoneBuffer(_ buffer: AVAudioPCMBuffer) {
+        observe(
+            micSignal: .init(isNonSilent: buffer.rmsLevel >= config.nonSilentLevelThreshold),
+            systemSignal: nil
+        )
+    }
+
+    func observeSystemBuffer(_ buffer: AVAudioPCMBuffer) {
+        observe(
+            micSignal: nil,
+            systemSignal: .init(isNonSilent: buffer.rmsLevel >= config.nonSilentLevelThreshold)
+        )
+    }
+
+    private func observe(
+        micSignal: MeetingMicHealthMonitor.AudioSignal?,
+        systemSignal: MeetingMicHealthMonitor.AudioSignal?
+    ) {
+        let now = nowProvider()
+        let events = lock.withLock {
+            guard isObserving else { return [MeetingMicHealthMonitor.HealthEvent]() }
+            return monitor.ingest(micSignal: micSignal, systemSignal: systemSignal, now: now)
+        }
+
+        for event in events {
+            guard case let .stallSuspected(signature, elapsedMs) = event else {
+                continue
+            }
+            Telemetry.send(.micStallDetected(signature: .init(signature), elapsedMs: elapsedMs))
+        }
     }
 }
 

--- a/Sources/MacParakeetCore/Audio/MeetingAudioCaptureService.swift
+++ b/Sources/MacParakeetCore/Audio/MeetingAudioCaptureService.swift
@@ -385,6 +385,7 @@ private final class MeetingMicHealthTelemetryObserver: @unchecked Sendable {
     }
 
     func observeMicrophoneBuffer(_ buffer: AVAudioPCMBuffer) {
+        guard shouldObserve else { return }
         observe(
             micSignal: .init(isNonSilent: buffer.rmsLevel >= config.nonSilentLevelThreshold),
             systemSignal: nil
@@ -392,10 +393,15 @@ private final class MeetingMicHealthTelemetryObserver: @unchecked Sendable {
     }
 
     func observeSystemBuffer(_ buffer: AVAudioPCMBuffer) {
+        guard shouldObserve else { return }
         observe(
             micSignal: nil,
             systemSignal: .init(isNonSilent: buffer.rmsLevel >= config.nonSilentLevelThreshold)
         )
+    }
+
+    private var shouldObserve: Bool {
+        lock.withLock { isObserving }
     }
 
     private func observe(

--- a/Sources/MacParakeetCore/Audio/MeetingMicHealthMonitor.swift
+++ b/Sources/MacParakeetCore/Audio/MeetingMicHealthMonitor.swift
@@ -4,15 +4,18 @@ public struct MeetingMicHealthMonitor: Sendable {
     public struct Config: Sendable, Equatable {
         public var systemActiveConfirmationSeconds: TimeInterval
         public var micGapSeconds: TimeInterval
+        public var systemGapSeconds: TimeInterval
         public var nonSilentLevelThreshold: Float
 
         public init(
             systemActiveConfirmationSeconds: TimeInterval = 3.0,
             micGapSeconds: TimeInterval = 1.0,
+            systemGapSeconds: TimeInterval = 2.0,
             nonSilentLevelThreshold: Float = 0.02
         ) {
             self.systemActiveConfirmationSeconds = systemActiveConfirmationSeconds
             self.micGapSeconds = micGapSeconds
+            self.systemGapSeconds = systemGapSeconds
             self.nonSilentLevelThreshold = nonSilentLevelThreshold
         }
 
@@ -41,6 +44,7 @@ public struct MeetingMicHealthMonitor: Sendable {
     private let config: Config
     private var systemActiveStartedAt: Date?
     private var lastMicBufferAt: Date?
+    private var lastSystemBufferAt: Date?
     private var silentMicStartedAt: Date?
     private var lastMicWasNonSilent = false
     private var activeStallSignature: StallSignature?
@@ -52,6 +56,7 @@ public struct MeetingMicHealthMonitor: Sendable {
     public mutating func reset() {
         systemActiveStartedAt = nil
         lastMicBufferAt = nil
+        lastSystemBufferAt = nil
         silentMicStartedAt = nil
         lastMicWasNonSilent = false
         activeStallSignature = nil
@@ -64,7 +69,10 @@ public struct MeetingMicHealthMonitor: Sendable {
     ) -> [HealthEvent] {
         var events: [HealthEvent] = []
 
+        expireSystemActivityIfStale(now: now)
+
         if let systemSignal {
+            lastSystemBufferAt = now
             if systemSignal.isNonSilent {
                 if systemActiveStartedAt == nil {
                     systemActiveStartedAt = now
@@ -118,13 +126,27 @@ public struct MeetingMicHealthMonitor: Sendable {
         return nil
     }
 
+    private mutating func expireSystemActivityIfStale(now: Date) {
+        guard let lastSystemBufferAt,
+              now.timeIntervalSince(lastSystemBufferAt) >= config.systemGapSeconds
+        else {
+            return
+        }
+        systemActiveStartedAt = nil
+    }
+
     private func elapsedMs(for signature: StallSignature, now: Date) -> Int {
         let start: Date
         switch signature {
         case .micMissing:
             start = systemActiveStartedAt ?? now
         case .micSilent:
-            start = silentMicStartedAt ?? lastMicBufferAt ?? systemActiveStartedAt ?? now
+            let silenceStartedAt = silentMicStartedAt ?? lastMicBufferAt ?? systemActiveStartedAt ?? now
+            if let systemActiveStartedAt, silenceStartedAt < systemActiveStartedAt {
+                start = systemActiveStartedAt
+            } else {
+                start = silenceStartedAt
+            }
         case .micGap:
             start = lastMicBufferAt ?? systemActiveStartedAt ?? now
         }

--- a/Sources/MacParakeetCore/Audio/MeetingMicHealthMonitor.swift
+++ b/Sources/MacParakeetCore/Audio/MeetingMicHealthMonitor.swift
@@ -142,14 +142,18 @@ public struct MeetingMicHealthMonitor: Sendable {
             start = systemActiveStartedAt ?? now
         case .micSilent:
             let silenceStartedAt = silentMicStartedAt ?? lastMicBufferAt ?? systemActiveStartedAt ?? now
-            if let systemActiveStartedAt, silenceStartedAt < systemActiveStartedAt {
-                start = systemActiveStartedAt
-            } else {
-                start = silenceStartedAt
-            }
+            start = boundedBySystemActivity(silenceStartedAt)
         case .micGap:
-            start = lastMicBufferAt ?? systemActiveStartedAt ?? now
+            let gapStartedAt = lastMicBufferAt ?? systemActiveStartedAt ?? now
+            start = boundedBySystemActivity(gapStartedAt)
         }
         return max(0, Int((now.timeIntervalSince(start) * 1_000).rounded()))
+    }
+
+    private func boundedBySystemActivity(_ date: Date) -> Date {
+        guard let systemActiveStartedAt, date < systemActiveStartedAt else {
+            return date
+        }
+        return systemActiveStartedAt
     }
 }

--- a/Sources/MacParakeetCore/Audio/MeetingMicHealthMonitor.swift
+++ b/Sources/MacParakeetCore/Audio/MeetingMicHealthMonitor.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+public struct MeetingMicHealthMonitor: Sendable {
+    public struct Config: Sendable, Equatable {
+        public var systemActiveConfirmationSeconds: TimeInterval
+        public var micGapSeconds: TimeInterval
+        public var nonSilentLevelThreshold: Float
+
+        public init(
+            systemActiveConfirmationSeconds: TimeInterval = 3.0,
+            micGapSeconds: TimeInterval = 1.0,
+            nonSilentLevelThreshold: Float = 0.02
+        ) {
+            self.systemActiveConfirmationSeconds = systemActiveConfirmationSeconds
+            self.micGapSeconds = micGapSeconds
+            self.nonSilentLevelThreshold = nonSilentLevelThreshold
+        }
+
+        public static let `default` = Config()
+    }
+
+    public struct AudioSignal: Sendable, Equatable {
+        public var isNonSilent: Bool
+
+        public init(isNonSilent: Bool) {
+            self.isNonSilent = isNonSilent
+        }
+    }
+
+    public enum StallSignature: String, Sendable, Equatable {
+        case micMissing = "mic_missing"
+        case micSilent = "mic_silent"
+        case micGap = "mic_gap"
+    }
+
+    public enum HealthEvent: Sendable, Equatable {
+        case stallSuspected(signature: StallSignature, elapsedMs: Int)
+        case recovered
+    }
+
+    private let config: Config
+    private var systemActiveStartedAt: Date?
+    private var lastMicBufferAt: Date?
+    private var silentMicStartedAt: Date?
+    private var lastMicWasNonSilent = false
+    private var activeStallSignature: StallSignature?
+
+    public init(config: Config = .default) {
+        self.config = config
+    }
+
+    public mutating func reset() {
+        systemActiveStartedAt = nil
+        lastMicBufferAt = nil
+        silentMicStartedAt = nil
+        lastMicWasNonSilent = false
+        activeStallSignature = nil
+    }
+
+    public mutating func ingest(
+        micSignal: AudioSignal? = nil,
+        systemSignal: AudioSignal? = nil,
+        now: Date
+    ) -> [HealthEvent] {
+        var events: [HealthEvent] = []
+
+        if let systemSignal {
+            if systemSignal.isNonSilent {
+                if systemActiveStartedAt == nil {
+                    systemActiveStartedAt = now
+                }
+            } else {
+                systemActiveStartedAt = nil
+            }
+        }
+
+        if let micSignal {
+            lastMicBufferAt = now
+            lastMicWasNonSilent = micSignal.isNonSilent
+
+            if micSignal.isNonSilent {
+                silentMicStartedAt = nil
+                if activeStallSignature != nil {
+                    activeStallSignature = nil
+                    events.append(.recovered)
+                }
+            } else if silentMicStartedAt == nil {
+                silentMicStartedAt = now
+            }
+        }
+
+        guard activeStallSignature == nil,
+              let systemActiveStartedAt,
+              now.timeIntervalSince(systemActiveStartedAt) >= config.systemActiveConfirmationSeconds,
+              let signature = currentSignature(now: now)
+        else {
+            return events
+        }
+
+        activeStallSignature = signature
+        events.append(.stallSuspected(signature: signature, elapsedMs: elapsedMs(for: signature, now: now)))
+        return events
+    }
+
+    private func currentSignature(now: Date) -> StallSignature? {
+        guard let lastMicBufferAt else {
+            return .micMissing
+        }
+
+        if now.timeIntervalSince(lastMicBufferAt) >= config.micGapSeconds {
+            return .micGap
+        }
+
+        if !lastMicWasNonSilent {
+            return .micSilent
+        }
+
+        return nil
+    }
+
+    private func elapsedMs(for signature: StallSignature, now: Date) -> Int {
+        let start: Date
+        switch signature {
+        case .micMissing:
+            start = systemActiveStartedAt ?? now
+        case .micSilent:
+            start = silentMicStartedAt ?? lastMicBufferAt ?? systemActiveStartedAt ?? now
+        case .micGap:
+            start = lastMicBufferAt ?? systemActiveStartedAt ?? now
+        }
+        return max(0, Int((now.timeIntervalSince(start) * 1_000).rounded()))
+    }
+}

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -110,6 +110,7 @@ public enum TelemetryEventName: String, Sendable, CaseIterable {
     case meetingAutoStopProposed = "meeting_auto_stop_proposed"
     case meetingAutoStopConfirmed = "meeting_auto_stop_confirmed"
     case meetingAutoStopVetoed = "meeting_auto_stop_vetoed"
+    case micStallDetected = "mic_stall_detected"
     /// Universal launch-time Silero VAD model prep for VAD-guided meeting live
     /// chunking (`plans/completed/2026-05-meeting-vad-guided-live-chunking.md` §6).
     /// Confirms the installed base actually acquires the model once the feature
@@ -394,6 +395,23 @@ public enum TelemetryMeetingOperationTrigger: String, Sendable, Equatable {
 public enum TelemetryMeetingAutoStopReason: String, Sendable, Equatable {
     case meetingAppClosed = "meeting_app_closed"
     case prolongedSilence = "prolonged_silence"
+}
+
+public enum TelemetryMicStallSignature: String, Sendable, Equatable {
+    case micMissing = "mic_missing"
+    case micSilent = "mic_silent"
+    case micGap = "mic_gap"
+
+    public init(_ signature: MeetingMicHealthMonitor.StallSignature) {
+        switch signature {
+        case .micMissing:
+            self = .micMissing
+        case .micSilent:
+            self = .micSilent
+        case .micGap:
+            self = .micGap
+        }
+    }
 }
 
 public enum TelemetryMeetingOperationStage: String, Sendable, Equatable {
@@ -805,6 +823,7 @@ public enum TelemetryEventSpec: Sendable {
     case meetingAutoStopProposed(reason: TelemetryMeetingAutoStopReason)
     case meetingAutoStopConfirmed(reason: TelemetryMeetingAutoStopReason)
     case meetingAutoStopVetoed(reason: TelemetryMeetingAutoStopReason)
+    case micStallDetected(signature: TelemetryMicStallSignature, elapsedMs: Int)
     /// Launch-time VAD model prep outcome (Phase 4.5). Only `.prepared` /
     /// `.failed` are ever sent — see `TelemetryVADModelPrepOutcome`.
     case vadModelPrep(outcome: TelemetryVADModelPrepOutcome)
@@ -958,6 +977,7 @@ extension TelemetryEventSpec {
         case .meetingAutoStopProposed: return .meetingAutoStopProposed
         case .meetingAutoStopConfirmed: return .meetingAutoStopConfirmed
         case .meetingAutoStopVetoed: return .meetingAutoStopVetoed
+        case .micStallDetected: return .micStallDetected
         case .vadModelPrep: return .vadModelPrep
         case .calendarReminderShown: return .calendarReminderShown
         case .calendarAutoStartTriggered: return .calendarAutoStartTriggered
@@ -1532,6 +1552,11 @@ extension TelemetryEventSpec {
              .meetingAutoStopConfirmed(let reason),
              .meetingAutoStopVetoed(let reason):
             return ["reason": reason.rawValue]
+        case .micStallDetected(let signature, let elapsedMs):
+            return [
+                "signature": signature.rawValue,
+                "elapsed_ms": "\(max(0, elapsedMs))",
+            ]
         case .vadModelPrep(let outcome):
             return ["outcome": outcome.rawValue]
         case .calendarReminderShown(let mode, let leadMinutes, let hasMeetUrl):
@@ -1775,6 +1800,7 @@ public enum TelemetryImplementedContract {
         .meetingAutoStopProposed: ["reason"],
         .meetingAutoStopConfirmed: ["reason"],
         .meetingAutoStopVetoed: ["reason"],
+        .micStallDetected: ["signature", "elapsed_ms"],
         .vadModelPrep: ["outcome"],
         .calendarReminderShown: ["mode", "lead_minutes", "has_meet_url"],
         .calendarAutoStartTriggered: ["lead_seconds", "has_meet_url"],

--- a/Tests/MacParakeetTests/Audio/MeetingAudioCaptureServiceTests.swift
+++ b/Tests/MacParakeetTests/Audio/MeetingAudioCaptureServiceTests.swift
@@ -17,6 +17,54 @@ private final class FactoryInvocationBox: @unchecked Sendable {
     }
 }
 
+private final class MutableDateProvider: @unchecked Sendable {
+    private let lock = NSLock()
+    private var current: Date
+
+    init(_ current: Date) {
+        self.current = current
+    }
+
+    func value() -> Date {
+        lock.withLock { current }
+    }
+
+    func advance(by seconds: TimeInterval) {
+        lock.withLock {
+            current = current.addingTimeInterval(seconds)
+        }
+    }
+}
+
+private final class MeetingAudioTelemetrySpy: TelemetryServiceProtocol, @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [TelemetryEventSpec] = []
+
+    func send(_ event: TelemetryEventSpec) {
+        lock.withLock {
+            events.append(event)
+        }
+    }
+
+    func sendAndFlush(_ event: TelemetryEventSpec) async -> Bool {
+        send(event)
+        return true
+    }
+
+    func clearQueue() {
+        lock.withLock {
+            events.removeAll()
+        }
+    }
+
+    func flush() async {}
+    func flushForTermination() {}
+
+    func snapshot() -> [TelemetryEventSpec] {
+        lock.withLock { events }
+    }
+}
+
 final class MeetingAudioCaptureServiceTests: XCTestCase {
     func testFactoryInitUsesInjectedMicrophoneFactory() {
         let microphone = MockMeetingMicrophoneCapture()
@@ -165,6 +213,90 @@ final class MeetingAudioCaptureServiceTests: XCTestCase {
             try await Task.sleep(for: .milliseconds(10))
         }
         XCTFail("Timed out waiting for system-only capture events")
+    }
+
+    func testMicHealthTelemetryReportsMissingMicOnce() async throws {
+        let microphone = MockMeetingMicrophoneCapture()
+        let systemCapture = MockMeetingSystemAudioCapture()
+        let telemetry = MeetingAudioTelemetrySpy()
+        Telemetry.configure(telemetry)
+        defer { Telemetry.configure(NoOpTelemetryService()) }
+
+        let now = MutableDateProvider(Date(timeIntervalSince1970: 1_800_000_000))
+        let service = MeetingAudioCaptureService(
+            microphoneCapture: microphone,
+            systemAudioCaptureFactory: { systemCapture },
+            micHealthConfig: .init(systemActiveConfirmationSeconds: 0),
+            micHealthNowProvider: { now.value() }
+        )
+
+        _ = try await service.start()
+        defer { Task { await service.stop() } }
+
+        let buffer = try XCTUnwrap(makeInterleavedFloatStereoBuffer(
+            sampleRate: 48_000,
+            samples: [0.25, 0.25, 0.25, 0.25]
+        ))
+        systemCapture.emit(buffer: buffer, time: AVAudioTime(hostTime: 1))
+        now.advance(by: 5)
+        systemCapture.emit(buffer: buffer, time: AVAudioTime(hostTime: 2))
+
+        let events = telemetry.snapshot().filter { $0.name == .micStallDetected }
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?.props?["signature"], "mic_missing")
+        XCTAssertEqual(events.first?.props?["elapsed_ms"], "0")
+    }
+
+    func testMicHealthTelemetryDoesNotRunInSystemOnlyMode() async throws {
+        let microphone = MockMeetingMicrophoneCapture()
+        let systemCapture = MockMeetingSystemAudioCapture()
+        let telemetry = MeetingAudioTelemetrySpy()
+        Telemetry.configure(telemetry)
+        defer { Telemetry.configure(NoOpTelemetryService()) }
+
+        let service = MeetingAudioCaptureService(
+            microphoneCapture: microphone,
+            systemAudioCaptureFactory: { systemCapture },
+            sourceModeProvider: { .systemOnly },
+            micHealthConfig: .init(systemActiveConfirmationSeconds: 0)
+        )
+
+        _ = try await service.start()
+        defer { Task { await service.stop() } }
+
+        let buffer = try XCTUnwrap(makeInterleavedFloatStereoBuffer(
+            sampleRate: 48_000,
+            samples: [0.25, 0.25, 0.25, 0.25]
+        ))
+        systemCapture.emit(buffer: buffer, time: AVAudioTime(hostTime: 1))
+
+        XCTAssertFalse(telemetry.snapshot().contains { $0.name == .micStallDetected })
+    }
+
+    func testMicHealthTelemetryRespectsKillSwitch() async throws {
+        let microphone = MockMeetingMicrophoneCapture()
+        let systemCapture = MockMeetingSystemAudioCapture()
+        let telemetry = MeetingAudioTelemetrySpy()
+        Telemetry.configure(telemetry)
+        defer { Telemetry.configure(NoOpTelemetryService()) }
+
+        let service = MeetingAudioCaptureService(
+            microphoneCapture: microphone,
+            systemAudioCaptureFactory: { systemCapture },
+            micHealthConfig: .init(systemActiveConfirmationSeconds: 0),
+            micHealthFeatureEnabled: false
+        )
+
+        _ = try await service.start()
+        defer { Task { await service.stop() } }
+
+        let buffer = try XCTUnwrap(makeInterleavedFloatStereoBuffer(
+            sampleRate: 48_000,
+            samples: [0.25, 0.25, 0.25, 0.25]
+        ))
+        systemCapture.emit(buffer: buffer, time: AVAudioTime(hostTime: 1))
+
+        XCTAssertFalse(telemetry.snapshot().contains { $0.name == .micStallDetected })
     }
 
     func testEmitsRuntimeErrorEventWhenMicrophoneStalls() async throws {

--- a/Tests/MacParakeetTests/Audio/MeetingMicHealthMonitorTests.swift
+++ b/Tests/MacParakeetTests/Audio/MeetingMicHealthMonitorTests.swift
@@ -1,0 +1,132 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class MeetingMicHealthMonitorTests: XCTestCase {
+    private let start = Date(timeIntervalSince1970: 1_800_000_000)
+
+    func testMicMissingRequiresContinuousSystemConfirmation() {
+        var monitor = MeetingMicHealthMonitor(config: .init(systemActiveConfirmationSeconds: 3.0))
+
+        XCTAssertEqual(
+            monitor.ingest(systemSignal: .init(isNonSilent: true), now: start),
+            []
+        )
+        XCTAssertEqual(
+            monitor.ingest(systemSignal: .init(isNonSilent: true), now: start.addingTimeInterval(2.9)),
+            []
+        )
+
+        XCTAssertEqual(
+            monitor.ingest(systemSignal: .init(isNonSilent: true), now: start.addingTimeInterval(3.0)),
+            [.stallSuspected(signature: .micMissing, elapsedMs: 3_000)]
+        )
+    }
+
+    func testSystemSilenceResetsConfirmationWindow() {
+        var monitor = MeetingMicHealthMonitor(config: .init(systemActiveConfirmationSeconds: 3.0))
+
+        XCTAssertEqual(monitor.ingest(systemSignal: .init(isNonSilent: true), now: start), [])
+        XCTAssertEqual(
+            monitor.ingest(systemSignal: .init(isNonSilent: false), now: start.addingTimeInterval(2.5)),
+            []
+        )
+        XCTAssertEqual(
+            monitor.ingest(systemSignal: .init(isNonSilent: true), now: start.addingTimeInterval(5.0)),
+            []
+        )
+        XCTAssertEqual(
+            monitor.ingest(systemSignal: .init(isNonSilent: true), now: start.addingTimeInterval(7.9)),
+            []
+        )
+        XCTAssertEqual(
+            monitor.ingest(systemSignal: .init(isNonSilent: true), now: start.addingTimeInterval(8.0)),
+            [.stallSuspected(signature: .micMissing, elapsedMs: 3_000)]
+        )
+    }
+
+    func testMicSilentFiresWhileSilentMicBuffersContinueArriving() {
+        var monitor = MeetingMicHealthMonitor(config: .init(systemActiveConfirmationSeconds: 3.0))
+
+        for offset in [0.0, 1.0, 2.0] {
+            XCTAssertEqual(
+                monitor.ingest(
+                    micSignal: .init(isNonSilent: false),
+                    systemSignal: .init(isNonSilent: true),
+                    now: start.addingTimeInterval(offset)
+                ),
+                []
+            )
+        }
+
+        XCTAssertEqual(
+            monitor.ingest(
+                micSignal: .init(isNonSilent: false),
+                systemSignal: .init(isNonSilent: true),
+                now: start.addingTimeInterval(3.0)
+            ),
+            [.stallSuspected(signature: .micSilent, elapsedMs: 3_000)]
+        )
+    }
+
+    func testMicGapFiresAtBoundaryAfterLastMicBuffer() {
+        var monitor = MeetingMicHealthMonitor(config: .init(
+            systemActiveConfirmationSeconds: 0,
+            micGapSeconds: 1.0
+        ))
+
+        XCTAssertEqual(
+            monitor.ingest(
+                micSignal: .init(isNonSilent: true),
+                systemSignal: .init(isNonSilent: true),
+                now: start
+            ),
+            []
+        )
+        XCTAssertEqual(
+            monitor.ingest(systemSignal: .init(isNonSilent: true), now: start.addingTimeInterval(0.99)),
+            []
+        )
+        XCTAssertEqual(
+            monitor.ingest(systemSignal: .init(isNonSilent: true), now: start.addingTimeInterval(1.0)),
+            [.stallSuspected(signature: .micGap, elapsedMs: 1_000)]
+        )
+    }
+
+    func testEmitsOneStallUntilMicRecovers() {
+        var monitor = MeetingMicHealthMonitor(config: .init(systemActiveConfirmationSeconds: 0))
+
+        XCTAssertEqual(
+            monitor.ingest(systemSignal: .init(isNonSilent: true), now: start),
+            [.stallSuspected(signature: .micMissing, elapsedMs: 0)]
+        )
+        XCTAssertEqual(
+            monitor.ingest(systemSignal: .init(isNonSilent: true), now: start.addingTimeInterval(10)),
+            []
+        )
+        XCTAssertEqual(
+            monitor.ingest(micSignal: .init(isNonSilent: true), now: start.addingTimeInterval(10.1)),
+            [.recovered]
+        )
+        XCTAssertEqual(
+            monitor.ingest(systemSignal: .init(isNonSilent: true), now: start.addingTimeInterval(11.2)),
+            [.stallSuspected(signature: .micGap, elapsedMs: 1_100)]
+        )
+    }
+
+    func testSilentSystemAudioDoesNotTripWatchdog() {
+        var monitor = MeetingMicHealthMonitor(config: .init(systemActiveConfirmationSeconds: 0))
+
+        XCTAssertEqual(
+            monitor.ingest(
+                micSignal: .init(isNonSilent: false),
+                systemSignal: .init(isNonSilent: false),
+                now: start
+            ),
+            []
+        )
+        XCTAssertEqual(
+            monitor.ingest(micSignal: .init(isNonSilent: false), now: start.addingTimeInterval(5)),
+            []
+        )
+    }
+}

--- a/Tests/MacParakeetTests/Audio/MeetingMicHealthMonitorTests.swift
+++ b/Tests/MacParakeetTests/Audio/MeetingMicHealthMonitorTests.swift
@@ -141,6 +141,27 @@ final class MeetingMicHealthMonitorTests: XCTestCase {
         )
     }
 
+    func testMicGapElapsedStartsAtSystemConfirmationWindow() {
+        var monitor = MeetingMicHealthMonitor(config: .init(
+            systemActiveConfirmationSeconds: 3.0,
+            micGapSeconds: 1.0
+        ))
+
+        XCTAssertEqual(monitor.ingest(micSignal: .init(isNonSilent: true), now: start), [])
+
+        for offset in [10.0, 11.0, 12.0] {
+            XCTAssertEqual(
+                monitor.ingest(systemSignal: .init(isNonSilent: true), now: start.addingTimeInterval(offset)),
+                []
+            )
+        }
+
+        XCTAssertEqual(
+            monitor.ingest(systemSignal: .init(isNonSilent: true), now: start.addingTimeInterval(13.0)),
+            [.stallSuspected(signature: .micGap, elapsedMs: 3_000)]
+        )
+    }
+
     func testMicGapFiresAtBoundaryAfterLastMicBuffer() {
         var monitor = MeetingMicHealthMonitor(config: .init(
             systemActiveConfirmationSeconds: 0,

--- a/Tests/MacParakeetTests/Audio/MeetingMicHealthMonitorTests.swift
+++ b/Tests/MacParakeetTests/Audio/MeetingMicHealthMonitorTests.swift
@@ -5,7 +5,10 @@ final class MeetingMicHealthMonitorTests: XCTestCase {
     private let start = Date(timeIntervalSince1970: 1_800_000_000)
 
     func testMicMissingRequiresContinuousSystemConfirmation() {
-        var monitor = MeetingMicHealthMonitor(config: .init(systemActiveConfirmationSeconds: 3.0))
+        var monitor = MeetingMicHealthMonitor(config: .init(
+            systemActiveConfirmationSeconds: 3.0,
+            systemGapSeconds: 4.0
+        ))
 
         XCTAssertEqual(
             monitor.ingest(systemSignal: .init(isNonSilent: true), now: start),
@@ -23,7 +26,10 @@ final class MeetingMicHealthMonitorTests: XCTestCase {
     }
 
     func testSystemSilenceResetsConfirmationWindow() {
-        var monitor = MeetingMicHealthMonitor(config: .init(systemActiveConfirmationSeconds: 3.0))
+        var monitor = MeetingMicHealthMonitor(config: .init(
+            systemActiveConfirmationSeconds: 3.0,
+            systemGapSeconds: 4.0
+        ))
 
         XCTAssertEqual(monitor.ingest(systemSignal: .init(isNonSilent: true), now: start), [])
         XCTAssertEqual(
@@ -41,6 +47,44 @@ final class MeetingMicHealthMonitorTests: XCTestCase {
         XCTAssertEqual(
             monitor.ingest(systemSignal: .init(isNonSilent: true), now: start.addingTimeInterval(8.0)),
             [.stallSuspected(signature: .micMissing, elapsedMs: 3_000)]
+        )
+    }
+
+    func testSystemAudioGapResetsConfirmationWindow() {
+        var monitor = MeetingMicHealthMonitor(config: .init(
+            systemActiveConfirmationSeconds: 3.0,
+            systemGapSeconds: 2.0
+        ))
+
+        XCTAssertEqual(monitor.ingest(systemSignal: .init(isNonSilent: true), now: start), [])
+        XCTAssertEqual(
+            monitor.ingest(systemSignal: .init(isNonSilent: true), now: start.addingTimeInterval(2.5)),
+            []
+        )
+        XCTAssertEqual(
+            monitor.ingest(systemSignal: .init(isNonSilent: true), now: start.addingTimeInterval(3.5)),
+            []
+        )
+        XCTAssertEqual(
+            monitor.ingest(systemSignal: .init(isNonSilent: true), now: start.addingTimeInterval(4.5)),
+            []
+        )
+        XCTAssertEqual(
+            monitor.ingest(systemSignal: .init(isNonSilent: true), now: start.addingTimeInterval(5.5)),
+            [.stallSuspected(signature: .micMissing, elapsedMs: 3_000)]
+        )
+    }
+
+    func testSystemAudioGapPreventsSilentMicFalsePositive() {
+        var monitor = MeetingMicHealthMonitor(config: .init(
+            systemActiveConfirmationSeconds: 3.0,
+            systemGapSeconds: 2.0
+        ))
+
+        XCTAssertEqual(monitor.ingest(systemSignal: .init(isNonSilent: true), now: start), [])
+        XCTAssertEqual(
+            monitor.ingest(micSignal: .init(isNonSilent: false), now: start.addingTimeInterval(2.5)),
+            []
         )
     }
 
@@ -63,6 +107,35 @@ final class MeetingMicHealthMonitorTests: XCTestCase {
                 micSignal: .init(isNonSilent: false),
                 systemSignal: .init(isNonSilent: true),
                 now: start.addingTimeInterval(3.0)
+            ),
+            [.stallSuspected(signature: .micSilent, elapsedMs: 3_000)]
+        )
+    }
+
+    func testMicSilentElapsedStartsAtSystemConfirmationWindow() {
+        var monitor = MeetingMicHealthMonitor(config: .init(
+            systemActiveConfirmationSeconds: 3.0,
+            micGapSeconds: 10.0
+        ))
+
+        XCTAssertEqual(monitor.ingest(micSignal: .init(isNonSilent: false), now: start), [])
+
+        for offset in [10.0, 11.0, 12.0] {
+            XCTAssertEqual(
+                monitor.ingest(
+                    micSignal: .init(isNonSilent: false),
+                    systemSignal: .init(isNonSilent: true),
+                    now: start.addingTimeInterval(offset)
+                ),
+                []
+            )
+        }
+
+        XCTAssertEqual(
+            monitor.ingest(
+                micSignal: .init(isNonSilent: false),
+                systemSignal: .init(isNonSilent: true),
+                now: start.addingTimeInterval(13.0)
             ),
             [.stallSuspected(signature: .micSilent, elapsedMs: 3_000)]
         )

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -1154,6 +1154,22 @@ final class TelemetryServiceTests: XCTestCase {
         }
     }
 
+    func testMicStallDetectedSerializesSignatureAndElapsedTime() {
+        let event = TelemetryEvent(
+            spec: .micStallDetected(signature: .micSilent, elapsedMs: 3_250),
+            appVer: "0.6.9",
+            osVer: "15.4",
+            locale: "en-US",
+            chip: "Apple M4",
+            session: "session"
+        )
+
+        XCTAssertEqual(event.event, "mic_stall_detected")
+        XCTAssertEqual(event.props?["signature"], "mic_silent")
+        XCTAssertEqual(event.props?["elapsed_ms"], "3250")
+        XCTAssertEqual(Set(event.props?.keys ?? Dictionary<String, String>().keys), ["signature", "elapsed_ms"])
+    }
+
     func testFeedbackOperationSerializesAttachmentFlags() {
         let event = TelemetryEvent(
             spec: .feedbackOperation(
@@ -1541,6 +1557,7 @@ final class TelemetryServiceTests: XCTestCase {
             .meetingAutoStopProposed(reason: .meetingAppClosed),
             .meetingAutoStopConfirmed(reason: .meetingAppClosed),
             .meetingAutoStopVetoed(reason: .prolongedSilence),
+            .micStallDetected(signature: .micMissing, elapsedMs: 3_000),
             .vadModelPrep(outcome: .prepared),
             .errorOccurred(domain: "STTError", code: "engineFailed", description: "test"),
             .crashOccurred(

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -411,6 +411,16 @@ does not use `auto_stop` because auto-stop only affects the stop/finalize path.
 | `meeting_auto_stop_confirmed` | `reason` (`meeting_app_closed`, `prolonged_silence`) | How often the countdown completed and stopped through the normal finalize path |
 | `meeting_auto_stop_vetoed` | `reason` (`meeting_app_closed`, `prolonged_silence`) | Which signals users overrode with "Keep recording" |
 
+### 5d. Meeting Capture Reliability — "Does the mic-health watchdog catch silent stalls?"
+
+> ADR-025 Phase A is implemented behind
+> `AppFeatures.meetingCaptureReliabilityEnabled = true`. It is detection-only:
+> no audio/transcript content, no UI yet, and no recording behavior change.
+
+| Event | Props | Question It Answers |
+|---|---|---|
+| `mic_stall_detected` | `signature` (`mic_missing`, `mic_silent`, `mic_gap`), `elapsed_ms` | Which confirmed mic-health failure pattern occurred while system audio was active, and how long the coarse stall signal had persisted |
+
 ### 6. Licensing — "Is the business working?"
 
 > Note: App is now free/GPL-3.0. The licensing enum cases are intentionally

--- a/plans/active/2026-06-14-meeting-mic-reliability.md
+++ b/plans/active/2026-06-14-meeting-mic-reliability.md
@@ -1,9 +1,9 @@
 # Meeting capture reliability — mic-health watchdog + post-stop coverage repair
 
-**Status:** PROPOSED — not started. All phases unimplemented.
+**Status:** IN PROGRESS — Phase A implemented 2026-06-14 (detection-only mic-health telemetry); warning UI and coverage repair remain unimplemented.
 **Date:** 2026-06-14
 **ADRs:** ADR-025 (meeting capture reliability), ADR-014 (meeting recording), ADR-015 (concurrent dictation/meeting), ADR-016 (centralized STT runtime + two-slot scheduler), ADR-019 (crash-resilient meeting recording)
-**Requirements:** REQ-MEET-017 (mic-health watchdog), REQ-MEET-018 (post-stop coverage-based transcript repair) — v0.7, proposed
+**Requirements:** REQ-MEET-017 (mic-health watchdog) — Phase A implemented; REQ-MEET-018 (post-stop coverage-based transcript repair) — proposed
 **Sibling work:** `plans/active/2026-05-dictation-stall-integration-tests.md`, `plans/active/2026-06-onboarding-stall-watchdog-test.md` — this is the meeting-side counterpart to the dictation silent-stall hardening; stay consistent, don't duplicate.
 
 ## What this plan closes out
@@ -50,7 +50,7 @@ REQ-MEET-013 says VAD-guided live chunking leaves "final post-stop transcription
 
 ## Phased rollout
 
-### Phase A — Mic-health detection core (detection-only)
+### Phase A — Mic-health detection core (detection-only) — implemented 2026-06-14
 
 Pure monitor + signals wiring + telemetry. **No UI, no recovery.** Instrumentation-only, to confirm the stall signature in the field before acting on it — mirroring PR #210's passive-instrumentation-first discipline on the dictation side.
 
@@ -138,14 +138,14 @@ The completeness-repair stage. Pure planner + offline VAD + selective re-transcr
 ## Done criteria
 
 - [ ] `MeetingMicHealthMonitor` + `MeetingTranscriptCoverageRepair` are pure, table-tested, and pass in the normal suite
-- [ ] Mic stall (system active) emits one correctly-tagged `mic_stall_detected`; genuine quiet emits nothing
+- [x] Mic stall (system active) emits one correctly-tagged `mic_stall_detected`; genuine quiet emits nothing
 - [ ] Confirmed stall shows the gentle non-blocking warning on panel + pill; recording continues
 - [ ] Selective repair re-transcribes only uncovered gaps on the background slot; healthy meetings stay `.accept` and byte-identical
 - [ ] Full-fallback tier handles systemic failure; crash-recovered sessions get coverage repair
 - [ ] Original live transcript + retained `.m4a` never destroyed by repair
 - [ ] Both telemetry events mirrored in `macparakeet-website/functions/api/telemetry.ts` and deployed before flag-on
-- [ ] REQ-MEET-013 wording narrowed; REQ-MEET-017/018 status updated by the coordinator
-- [ ] `swift test` exits 0; docs/spec progress updated (`spec/README.md`, `spec/02-features.md`)
+- [x] REQ-MEET-017 Phase A status updated by the coordinator; REQ-MEET-013 narrowing and REQ-MEET-018 status remain for Phase C
+- [x] `swift test` exits 0; docs/spec progress updated (`spec/README.md`, `spec/02-features.md`)
 - [ ] Plan archived to `plans/completed/` on completion
 
 ## Open questions

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -1772,7 +1772,7 @@ authoritative transcript and is unchanged by this live-preview strategy.
 
 ## v0.7 Features (Meeting Reliability & Detection)
 
-> Status: **MIXED** — F44 / ADR-023 auto-stop Phases A+B are implemented behind a default-off flag. F45 / ADR-024 detection and F46 / ADR-025 reliability remain proposed. Each ships opt-in / flag-gated; nothing changes for existing users until a tagged release enables it.
+> Status: **MIXED** — F44 / ADR-023 auto-stop Phases A+B are implemented behind a default-off flag. F46 / ADR-025 reliability Phase A is implemented behind a default-on kill-switch with telemetry only. F45 / ADR-024 detection and the remaining ADR-025 warning/repair phases remain proposed. User-visible meeting automation stays opt-in / flag-gated.
 
 ### F44: Activity-Based Meeting Auto-Stop
 
@@ -1788,9 +1788,9 @@ authoritative transcript and is unchanged by this live-preview strategy.
 
 ### F46: Meeting Capture Reliability — Mic-Health Watchdog + Coverage Repair
 
-> Status: **PROPOSAL** — ADR-025, REQ-MEET-017 / REQ-MEET-018.
+> Status: **PARTIAL IMPLEMENTATION** — ADR-025 Phase A implements REQ-MEET-017 detection-only telemetry behind `AppFeatures.meetingCaptureReliabilityEnabled = true`. Warning UI, live recovery, and REQ-MEET-018 coverage repair remain proposed.
 
-**What:** Two hardening measures for meeting capture. (1) A **mic-health watchdog** treats the system-audio stream as the liveness oracle: if "Others" are clearly talking but the microphone delivers nothing / all-zero / a stalled gap, it surfaces a gentle "may be missing your side" warning plus telemetry (detection-first; auto-recovery deferred behind a confirmed-signature gate, consistent with the dictation silent-stall work). (2) A **post-stop coverage repair** runs an offline VAD pass over the retained audio, measures how much detected speech the live transcript covered, and re-transcribes only the missed regions on the ADR-016 background slot — turning live preview from "best-effort, lossy on drop" into a guaranteed-complete final transcript. Refines REQ-MEET-013 (adds a completeness stage; per-chunk transcription is unchanged).
+**What:** Two hardening measures for meeting capture. (1) A **mic-health watchdog** treats the system-audio stream as the liveness oracle: if "Others" are clearly talking but the microphone delivers nothing / all-zero / a stalled gap, Phase A emits privacy-safe `mic_stall_detected` telemetry exactly once per confirmed stall and does not change recording behavior; the gentle "may be missing your side" warning and auto-recovery remain deferred behind confirmed field signatures. (2) A **post-stop coverage repair** runs an offline VAD pass over the retained audio, measures how much detected speech the live transcript covered, and re-transcribes only the missed regions on the ADR-016 background slot — turning live preview from "best-effort, lossy on drop" into a guaranteed-complete final transcript. Refines REQ-MEET-013 (adds a completeness stage; per-chunk transcription is unchanged).
 
 ---
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -78,7 +78,7 @@ All ADRs live in `spec/adr/`. These are locked -- they record decisions already 
 | [ADR-022](adr/022-transforms-system-wide-rewrite.md) | Transforms — system-wide LLM rewrites on selected text (implemented 2026-05-13) |
 | [ADR-023](adr/023-activity-based-meeting-auto-stop.md) | Activity-based meeting auto-stop (silence + app-quit signals, veto countdown; Phases A+B implemented behind default-off flag — replaces withdrawn ADR-017 calendar auto-stop) |
 | [ADR-024](adr/024-activity-based-meeting-detection.md) | Activity-based meeting detection (per-process audio + camera + app signal fusion; proposed) |
-| [ADR-025](adr/025-meeting-capture-reliability.md) | Meeting capture reliability — mic-health watchdog + post-stop coverage repair (proposed) |
+| [ADR-025](adr/025-meeting-capture-reliability.md) | Meeting capture reliability — mic-health watchdog + post-stop coverage repair (Phase A mic-health telemetry watchdog implemented; warning UI + repair proposed) |
 
 ## Version Roadmap
 

--- a/spec/adr/025-meeting-capture-reliability.md
+++ b/spec/adr/025-meeting-capture-reliability.md
@@ -1,9 +1,9 @@
 # ADR-025: Meeting capture reliability — mic-health watchdog + post-stop coverage repair
 
-> Status: **PROPOSAL**
+> Status: **PARTIAL IMPLEMENTATION** — Phase A mic-health detection telemetry implemented behind default-on `AppFeatures.meetingCaptureReliabilityEnabled`; warning UI, live recovery, and coverage repair remain proposed.
 > Date: 2026-06-14
 > Related: ADR-014 (meeting recording via ScreenCaptureKit system audio), ADR-015 (concurrent dictation/meeting), ADR-016 (centralized STT runtime + two-slot scheduler), ADR-019 (crash-resilient meeting recording)
-> Requirements: REQ-MEET-017 (mic-health watchdog), REQ-MEET-018 (post-stop coverage-based transcript repair) — v0.7, proposed
+> Requirements: REQ-MEET-017 Phase A implemented; REQ-MEET-018 proposed
 
 ## Context
 
@@ -386,7 +386,7 @@ Add the new `TelemetryEventName` cases in
 Each phase is independently shippable and additive. Earlier phases
 deliver value without later ones.
 
-1. **Phase A — Mic-health detection core (detection-only).** Pure
+1. **Phase A — Mic-health detection core (detection-only; implemented 2026-06-14).** Pure
    `MeetingMicHealthMonitor` with the three signatures + ~3 s
    confirmation gate, table tests, and the `MeetingAudioCaptureService`
    wiring that feeds liveness signals. Emits `mic_stall_detected`

--- a/spec/kernel/requirements.yaml
+++ b/spec/kernel/requirements.yaml
@@ -377,9 +377,9 @@ REQ-MEET-016:
   status: proposed
 
 REQ-MEET-017:
-  description: Meeting mic-health watchdog treats the system-audio stream as the liveness oracle and detects a stalled, all-zero, or missing microphone (three signatures) after a short confirmation window, surfacing a non-blocking warning plus telemetry; detection-first with auto-recovery deferred behind a confirmed-signature gate (ADR-025)
+  description: Meeting mic-health watchdog treats the system-audio stream as the liveness oracle and detects a stalled, all-zero, or missing microphone (three signatures) after a short confirmation window, emitting privacy-safe telemetry once per confirmed stall behind AppFeatures.meetingCaptureReliabilityEnabled; warning UI and auto-recovery remain deferred behind confirmed field signatures (ADR-025 Phase A)
   version: v0.7
-  status: proposed
+  status: implemented
 
 REQ-MEET-018:
   description: Post-stop meeting transcript coverage repair runs an offline VAD pass over the retained audio, measures live-transcript speech coverage, and re-transcribes only missed speech regions on the ADR-016 background slot (accept → selective-repair → full-fallback ladder), adding a completeness stage without changing per-chunk transcription (refines REQ-MEET-013, ADR-025)


### PR DESCRIPTION
## Summary
- Adds ADR-025 Phase A: a detection-only meeting mic-health watchdog.
- Emits one privacy-safe `mic_stall_detected` event when system audio is active but the mic is missing, silent, or stalled.
- Keeps recording behavior unchanged: no UI warning, no auto-recovery, no stop/finalize/repair changes.

## Scope Notes
- The monitor is pure and deterministic; capture services feed copied mic/system buffer liveness only.
- Timing is bounded to continuous system-audio activity, and stale system-audio streams stand down to avoid false mic stalls.
- The default-on kill switch is `AppFeatures.meetingCaptureReliabilityEnabled`.
- Paired telemetry Worker allowlist: moona3k/macparakeet-website#18.

## Validation
- `git diff --check`
- `swift test`
- `swift test --filter MeetingMicHealthMonitorTests`
- `swift test --filter 'MeetingAudioCaptureServiceTests|TelemetryServiceTests'`
- `MACPARAKEET_SKIP_WHISPERKIT=1 swift build --build-path .build-swift6-no-whisper -Xswiftc -swift-version -Xswiftc 6`
- `swift build -Xswiftc -warn-concurrency`
