### PR TITLE
Implement meeting camera activity collector

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ profiles with readable/toggleable smart defaults, REQ-LLM-004; enabled
 that are not user-visible until validation flips them: `AppFeatures.meetingAutoStopEnabled = false`
 (ADR-023 activity-based meeting auto-stop, implemented 2026-06-14 behind its
 own opt-in setting), `AppFeatures.meetingActivityDetectionEnabled = false`
-(ADR-024 Phases A+B process-audio/camera attribution + pure detector
+(ADR-024 Phases A+B process-audio attribution + camera activity + pure detector
 foundation; no runtime coordinator/UI yet). Reliability kill-switch on `main`:
 `AppFeatures.meetingCaptureReliabilityEnabled = true` (ADR-025 Phase A
 mic-health telemetry watchdog; default-on, no UI/recording behavior change).
@@ -149,7 +149,7 @@ All ADRs are in `spec/adr/`. These are locked decisions -- don't second-guess th
 | ADR-021 | WhisperKit as optional multilingual STT engine (implemented) | `spec/adr/021-whisperkit-multilingual-stt.md` |
 | ADR-022 | Transforms — system-wide LLM rewrites on selected text (Phase 2 productized; enabled, shipping since v0.6.7) | `spec/adr/022-transforms-system-wide-rewrite.md` |
 | ADR-023 | Activity-based meeting auto-stop (silence + app-quit signals + veto countdown; Phases A+B implemented behind default-off flag, Phase C deferred to ADR-024 attribution) | `spec/adr/023-activity-based-meeting-auto-stop.md` |
-| ADR-024 | Activity-based meeting detection (Phases A+B per-process audio + camera attribution with pure detector implemented behind default-off flag; coordinator/prompt phases proposed) | `spec/adr/024-activity-based-meeting-detection.md` |
+| ADR-024 | Activity-based meeting detection (Phases A+B per-process audio attribution + camera activity with pure detector implemented behind default-off flag; coordinator/prompt phases proposed) | `spec/adr/024-activity-based-meeting-detection.md` |
 | ADR-025 | Meeting capture reliability — mic-health watchdog + post-stop coverage repair (Phase A mic-health telemetry watchdog implemented behind default-on kill-switch; warning UI + repair proposed) | `spec/adr/025-meeting-capture-reliability.md` |
 
 > Historical/dormant ADRs (still in `spec/adr/`, kept for context): ADR-003 (one-time purchase pricing), ADR-006 (trial + license activation), ADR-008 (local LLM runtime). Current public builds are free/GPL-3.0 and unlocked. The old LemonSqueezy/trial entitlement plumbing is intentionally retained as future-option code for GPL-compatible official paid distribution/support; do not remove it as dead code without explicit owner direction and an ADR/spec update.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,8 @@ profiles with readable/toggleable smart defaults, REQ-LLM-004; enabled
 that are not user-visible until validation flips them: `AppFeatures.meetingAutoStopEnabled = false`
 (ADR-023 activity-based meeting auto-stop, implemented 2026-06-14 behind its
 own opt-in setting), `AppFeatures.meetingActivityDetectionEnabled = false`
-(ADR-024 Phase A process-audio attribution + pure detector foundation; no
-runtime coordinator/UI yet). Reliability kill-switch on `main`:
+(ADR-024 Phases A+B process-audio/camera attribution + pure detector
+foundation; no runtime coordinator/UI yet). Reliability kill-switch on `main`:
 `AppFeatures.meetingCaptureReliabilityEnabled = true` (ADR-025 Phase A
 mic-health telemetry watchdog; default-on, no UI/recording behavior change).
 All other `AppFeatures` flags match the shipping build.
@@ -149,7 +149,7 @@ All ADRs are in `spec/adr/`. These are locked decisions -- don't second-guess th
 | ADR-021 | WhisperKit as optional multilingual STT engine (implemented) | `spec/adr/021-whisperkit-multilingual-stt.md` |
 | ADR-022 | Transforms — system-wide LLM rewrites on selected text (Phase 2 productized; enabled, shipping since v0.6.7) | `spec/adr/022-transforms-system-wide-rewrite.md` |
 | ADR-023 | Activity-based meeting auto-stop (silence + app-quit signals + veto countdown; Phases A+B implemented behind default-off flag, Phase C deferred to ADR-024 attribution) | `spec/adr/023-activity-based-meeting-auto-stop.md` |
-| ADR-024 | Activity-based meeting detection (Phase A per-process audio attribution + pure detector implemented behind default-off flag; camera/coordinator/prompt phases proposed) | `spec/adr/024-activity-based-meeting-detection.md` |
+| ADR-024 | Activity-based meeting detection (Phases A+B per-process audio + camera attribution with pure detector implemented behind default-off flag; coordinator/prompt phases proposed) | `spec/adr/024-activity-based-meeting-detection.md` |
 | ADR-025 | Meeting capture reliability — mic-health watchdog + post-stop coverage repair (Phase A mic-health telemetry watchdog implemented behind default-on kill-switch; warning UI + repair proposed) | `spec/adr/025-meeting-capture-reliability.md` |
 
 > Historical/dormant ADRs (still in `spec/adr/`, kept for context): ADR-003 (one-time purchase pricing), ADR-006 (trial + license activation), ADR-008 (local LLM runtime). Current public builds are free/GPL-3.0 and unlocked. The old LemonSqueezy/trial entitlement plumbing is intentionally retained as future-option code for GPL-compatible official paid distribution/support; do not remove it as dead code without explicit owner direction and an ADR/spec update.
@@ -162,8 +162,8 @@ freetext podcast search), Parakeet v3/v2 model selection, optional Nemotron
 3.5 Beta (ADR-001 amendment) and WhisperKit (ADR-021) engines, opt-in instant dictation (warm-mic
 pre-roll), app-aware AI Formatter profiles (REQ-LLM-004, `main`-only flag),
 default-off activity-based meeting auto-stop (ADR-023, `main` validation flag),
-default-off activity-based meeting detection foundation (ADR-024 Phase A, no
-runtime coordinator/UI yet),
+default-off activity-based meeting detection foundation (ADR-024 Phases A+B,
+no runtime coordinator/UI yet),
 meeting mic-health telemetry watchdog (ADR-025 Phase A, default-on kill-switch),
 and productized Transforms with `Polish`/`Distill`/`Decide` built-ins on
 Control-Option hotkeys (ADR-022). Calendar auto-start is ADR-017 Phases 1 + 2

--- a/Sources/MacParakeetCore/MeetingDetection/CameraActivityCollector.swift
+++ b/Sources/MacParakeetCore/MeetingDetection/CameraActivityCollector.swift
@@ -17,21 +17,38 @@ public final class CameraActivityCollector: @unchecked Sendable {
     private var stateHandler: StateHandler?
     private var deviceListListener: CMIOObjectPropertyListenerBlock?
     private var deviceListeners: [DeviceListener] = []
+    private var lifecycleGeneration: UInt64 = 0
 
     public init() {}
 
+    deinit {
+        stop()
+    }
+
     public func start(handler: @escaping StateHandler) {
-        let currentDeviceIDs = Self.deviceIDs()
-        lock.withLock {
-            stateHandler = handler
-            installDeviceListListenerLocked()
-            refreshDeviceListenersLocked(deviceIDs: currentDeviceIDs)
+        let generation = lock.withLock {
+            lifecycleGeneration &+= 1
+            return lifecycleGeneration
         }
-        emitCurrentState()
+
+        listenerQueue.async { [weak self] in
+            guard let self else { return }
+
+            self.lock.withLock {
+                guard self.lifecycleGeneration == generation else { return }
+
+                self.stateHandler = handler
+                self.installDeviceListListenerLocked()
+                self.refreshDeviceListenersLocked(deviceIDs: Self.deviceIDs())
+            }
+
+            self.emitCurrentState(generation: generation)
+        }
     }
 
     public func stop() {
         lock.withLock {
+            lifecycleGeneration &+= 1
             removeDeviceListenersLocked()
             removeDeviceListListenerLocked()
             stateHandler = nil
@@ -58,9 +75,14 @@ public final class CameraActivityCollector: @unchecked Sendable {
         emitCurrentState()
     }
 
-    private func emitCurrentState() {
+    private func emitCurrentState(generation: UInt64? = nil) {
         let isRunning = cameraRunning()
-        let handler = lock.withLock { stateHandler }
+        let handler: StateHandler? = lock.withLock {
+            guard generation == nil || lifecycleGeneration == generation else {
+                return nil
+            }
+            return stateHandler
+        }
         handler?(isRunning)
     }
 
@@ -109,7 +131,10 @@ public final class CameraActivityCollector: @unchecked Sendable {
             self?.emitCurrentState()
         }
         let status = CMIOObjectAddPropertyListenerBlock(deviceID, &address, listenerQueue, block)
-        guard status == noErr else { return }
+        guard status == noErr else {
+            logger.debug("camera_device_listener_failed deviceID=\(deviceID) status=\(status)")
+            return
+        }
         deviceListeners.append(DeviceListener(deviceID: deviceID, block: block))
     }
 

--- a/Sources/MacParakeetCore/MeetingDetection/CameraActivityCollector.swift
+++ b/Sources/MacParakeetCore/MeetingDetection/CameraActivityCollector.swift
@@ -1,0 +1,188 @@
+import CoreMediaIO
+import Foundation
+import OSLog
+
+public final class CameraActivityCollector: @unchecked Sendable {
+    public typealias StateHandler = @Sendable (Bool) -> Void
+
+    private struct DeviceListener {
+        let deviceID: CMIOObjectID
+        let block: CMIOObjectPropertyListenerBlock
+    }
+
+    private let logger = Logger(subsystem: "com.macparakeet.core", category: "CameraActivityCollector")
+    private let lock = NSLock()
+    private let listenerQueue = DispatchQueue(label: "com.macparakeet.camera-activity")
+
+    private var stateHandler: StateHandler?
+    private var deviceListListener: CMIOObjectPropertyListenerBlock?
+    private var deviceListeners: [DeviceListener] = []
+
+    public init() {}
+
+    public func start(handler: @escaping StateHandler) {
+        let currentDeviceIDs = Self.deviceIDs()
+        lock.withLock {
+            stateHandler = handler
+            installDeviceListListenerLocked()
+            refreshDeviceListenersLocked(deviceIDs: currentDeviceIDs)
+        }
+        emitCurrentState()
+    }
+
+    public func stop() {
+        lock.withLock {
+            removeDeviceListenersLocked()
+            removeDeviceListListenerLocked()
+            stateHandler = nil
+        }
+    }
+
+    public func cameraRunning() -> Bool {
+        Self.currentCameraRunning()
+    }
+
+    public static func currentCameraRunning() -> Bool {
+        cameraRunning(deviceStates: deviceIDs().map(deviceRunningSomewhere))
+    }
+
+    public static func cameraRunning(deviceStates: [Bool]) -> Bool {
+        deviceStates.contains(true)
+    }
+
+    private func handleDeviceListChanged() {
+        let currentDeviceIDs = Self.deviceIDs()
+        lock.withLock {
+            refreshDeviceListenersLocked(deviceIDs: currentDeviceIDs)
+        }
+        emitCurrentState()
+    }
+
+    private func emitCurrentState() {
+        let isRunning = cameraRunning()
+        let handler = lock.withLock { stateHandler }
+        handler?(isRunning)
+    }
+
+    private func installDeviceListListenerLocked() {
+        guard deviceListListener == nil else { return }
+        var address = Self.address(selector: kCMIOHardwarePropertyDevices)
+        let block: CMIOObjectPropertyListenerBlock = { [weak self] _, _ in
+            self?.handleDeviceListChanged()
+        }
+        let status = CMIOObjectAddPropertyListenerBlock(
+            CMIOObjectID(kCMIOObjectSystemObject),
+            &address,
+            listenerQueue,
+            block
+        )
+        guard status == noErr else {
+            logger.debug("camera_device_list_listener_failed status=\(status)")
+            return
+        }
+        deviceListListener = block
+    }
+
+    private func removeDeviceListListenerLocked() {
+        guard let block = deviceListListener else { return }
+        var address = Self.address(selector: kCMIOHardwarePropertyDevices)
+        CMIOObjectRemovePropertyListenerBlock(
+            CMIOObjectID(kCMIOObjectSystemObject),
+            &address,
+            listenerQueue,
+            block
+        )
+        deviceListListener = nil
+    }
+
+    private func refreshDeviceListenersLocked(deviceIDs: [CMIOObjectID]) {
+        removeDeviceListenersLocked()
+
+        for deviceID in deviceIDs {
+            installDeviceListenerLocked(deviceID: deviceID)
+        }
+    }
+
+    private func installDeviceListenerLocked(deviceID: CMIOObjectID) {
+        var address = Self.address(selector: kCMIODevicePropertyDeviceIsRunningSomewhere)
+        let block: CMIOObjectPropertyListenerBlock = { [weak self] _, _ in
+            self?.emitCurrentState()
+        }
+        let status = CMIOObjectAddPropertyListenerBlock(deviceID, &address, listenerQueue, block)
+        guard status == noErr else { return }
+        deviceListeners.append(DeviceListener(deviceID: deviceID, block: block))
+    }
+
+    private func removeDeviceListenersLocked() {
+        for listener in deviceListeners {
+            var address = Self.address(selector: kCMIODevicePropertyDeviceIsRunningSomewhere)
+            CMIOObjectRemovePropertyListenerBlock(
+                listener.deviceID,
+                &address,
+                listenerQueue,
+                listener.block
+            )
+        }
+        deviceListeners.removeAll()
+    }
+
+    private static func deviceIDs() -> [CMIOObjectID] {
+        var address = address(selector: kCMIOHardwarePropertyDevices)
+        var dataSize: UInt32 = 0
+        var status = CMIOObjectGetPropertyDataSize(
+            CMIOObjectID(kCMIOObjectSystemObject),
+            &address,
+            0,
+            nil,
+            &dataSize
+        )
+        guard status == noErr, dataSize > 0 else { return [] }
+
+        let count = Int(dataSize) / MemoryLayout<CMIOObjectID>.size
+        guard count > 0 else { return [] }
+
+        var deviceIDs = [CMIOObjectID](repeating: 0, count: count)
+        var dataUsed: UInt32 = 0
+        status = deviceIDs.withUnsafeMutableBufferPointer { buffer in
+            guard let baseAddress = buffer.baseAddress else { return noErr }
+            return CMIOObjectGetPropertyData(
+                CMIOObjectID(kCMIOObjectSystemObject),
+                &address,
+                0,
+                nil,
+                dataSize,
+                &dataUsed,
+                baseAddress
+            )
+        }
+        guard status == noErr else { return [] }
+
+        let usedCount = min(count, Int(dataUsed) / MemoryLayout<CMIOObjectID>.size)
+        return Array(deviceIDs.prefix(usedCount)).filter { $0 != kCMIOObjectUnknown }
+    }
+
+    private static func deviceRunningSomewhere(deviceID: CMIOObjectID) -> Bool {
+        var address = address(selector: kCMIODevicePropertyDeviceIsRunningSomewhere)
+        var value: UInt32 = 0
+        var dataUsed: UInt32 = 0
+        let status = CMIOObjectGetPropertyData(
+            deviceID,
+            &address,
+            0,
+            nil,
+            UInt32(MemoryLayout<UInt32>.size),
+            &dataUsed,
+            &value
+        )
+        guard status == noErr, dataUsed == UInt32(MemoryLayout<UInt32>.size) else { return false }
+        return value != 0
+    }
+
+    private static func address(selector: Int) -> CMIOObjectPropertyAddress {
+        CMIOObjectPropertyAddress(
+            mSelector: CMIOObjectPropertySelector(selector),
+            mScope: CMIOObjectPropertyScope(kCMIOObjectPropertyScopeGlobal),
+            mElement: CMIOObjectPropertyElement(kCMIOObjectPropertyElementMain)
+        )
+    }
+}

--- a/Sources/MacParakeetCore/MeetingDetection/CameraActivityCollector.swift
+++ b/Sources/MacParakeetCore/MeetingDetection/CameraActivityCollector.swift
@@ -68,11 +68,23 @@ public final class CameraActivityCollector: @unchecked Sendable {
     }
 
     private func handleDeviceListChanged() {
-        let currentDeviceIDs = Self.deviceIDs()
-        lock.withLock {
-            refreshDeviceListenersLocked(deviceIDs: currentDeviceIDs)
+        let generation: UInt64? = lock.withLock {
+            guard stateHandler != nil else { return nil }
+            return lifecycleGeneration
         }
-        emitCurrentState()
+        guard let generation else { return }
+
+        let currentDeviceIDs = Self.deviceIDs()
+        let shouldEmit = lock.withLock {
+            guard lifecycleGeneration == generation, stateHandler != nil else {
+                return false
+            }
+            refreshDeviceListenersLocked(deviceIDs: currentDeviceIDs)
+            return true
+        }
+        if shouldEmit {
+            emitCurrentState(generation: generation)
+        }
     }
 
     private func emitCurrentState(generation: UInt64? = nil) {

--- a/Tests/MacParakeetTests/MeetingDetection/MeetingActivityDetectorTests.swift
+++ b/Tests/MacParakeetTests/MeetingDetection/MeetingActivityDetectorTests.swift
@@ -187,6 +187,26 @@ final class MeetingActivityDetectorTests: XCTestCase {
         XCTAssertEqual(result, [])
     }
 
+    func testMicAndCameraWithSelfFilteredAudioDoesNotTrigger() {
+        let processes = [
+            AudioProcessActivity(pid: 100, bundleID: "com.macparakeet", isRunningInput: true, isRunningOutput: false),
+        ]
+        let filtered = AudioProcessActivityCollector.filterSelf(
+            processes: processes,
+            selfProcessID: 100,
+            selfBundleID: "com.macparakeet"
+        )
+
+        let result = evaluate(
+            signal: ActivitySignalSnapshot(
+                audio: ProcessAudioSnapshot(processes: filtered),
+                cameraRunning: true
+            )
+        )
+
+        XCTAssertEqual(result, [])
+    }
+
     func testSuppressedIdentityDoesNotPromptUntilCooldownExpires() {
         let identity = MeetingIdentity(source: .app, app: .zoom)
         let signal = snapshot(input: [.zoom])
@@ -233,6 +253,12 @@ final class MeetingActivityDetectorTests: XCTestCase {
         )
 
         XCTAssertEqual(filtered, [activity(.teams, pid: 200, input: true)])
+    }
+
+    func testCameraCollectorAggregatesAnyRunningDevice() {
+        XCTAssertFalse(CameraActivityCollector.cameraRunning(deviceStates: []))
+        XCTAssertFalse(CameraActivityCollector.cameraRunning(deviceStates: [false, false]))
+        XCTAssertTrue(CameraActivityCollector.cameraRunning(deviceStates: [false, true, false]))
     }
 
     private func evaluate(

--- a/plans/active/2026-06-14-meeting-activity-detection.md
+++ b/plans/active/2026-06-14-meeting-activity-detection.md
@@ -1,6 +1,6 @@
 # Activity-Based Meeting Detection
 
-**Status:** IN PROGRESS — Phase A implemented 2026-06-14 behind
+**Status:** IN PROGRESS — Phases A+B implemented 2026-06-14 behind
 `AppFeatures.meetingActivityDetectionEnabled = false`. No user-visible behavior
 ships until later phases add coordinator/UI wiring and the flag is validated.
 **Date:** 2026-06-14
@@ -9,7 +9,7 @@ implements). Related: ADR-002 (local-first), ADR-014 (meeting recording),
 ADR-015 (concurrent dictation/meeting), ADR-017 (calendar auto-start — the
 coordinator/pure-evaluator pattern to mirror), ADR-023 (activity-based
 auto-stop — consumes the same signal layer this plan builds).
-**Requirement:** REQ-MEET-016 (v0.7, Phase A foundation implemented).
+**Requirement:** REQ-MEET-016 (v0.7, Phases A+B foundation implemented).
 
 ## What this plan closes out
 
@@ -101,7 +101,7 @@ structure (tiers, self-exclusion, dwell, suppression) is in place and tested.
 fabricated snapshots. Collector compiles and excludes self. No user-visible
 change (flag off, no coordinator).
 
-### Phase B — Camera collector + full fusion rule + self-exclusion across signals
+### Phase B — Camera collector + full fusion rule + self-exclusion across signals — implemented 2026-06-14
 
 | File | Change |
 |------|--------|

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -1772,7 +1772,7 @@ authoritative transcript and is unchanged by this live-preview strategy.
 
 ## v0.7 Features (Meeting Reliability & Detection)
 
-> Status: **MIXED** — F44 / ADR-023 auto-stop Phases A+B are implemented behind a default-off flag. F45 / ADR-024 detection Phase A is implemented behind a default-off flag with no UI/coordinator wiring. F46 / ADR-025 reliability Phase A is implemented behind a default-on kill-switch with telemetry only. Remaining ADR-024 and ADR-025 phases remain proposed. User-visible meeting automation stays opt-in / flag-gated.
+> Status: **MIXED** — F44 / ADR-023 auto-stop Phases A+B are implemented behind a default-off flag. F45 / ADR-024 detection Phases A+B are implemented behind a default-off flag with no UI/coordinator wiring. F46 / ADR-025 reliability Phase A is implemented behind a default-on kill-switch with telemetry only. Remaining ADR-024 and ADR-025 phases remain proposed. User-visible meeting automation stays opt-in / flag-gated.
 
 ### F44: Activity-Based Meeting Auto-Stop
 
@@ -1782,9 +1782,9 @@ authoritative transcript and is unchanged by this live-preview strategy.
 
 ### F45: Activity-Based Meeting Detection
 
-> Status: **PARTIAL IMPLEMENTATION** — ADR-024 Phase A implements the CoreAudio process attribution collector, shared signal snapshot types, trust-tiered app registry, detection mode, and pure detector tests behind `AppFeatures.meetingActivityDetectionEnabled = false`. Camera collection, coordinator/UI wiring, prompt/auto-start telemetry, and ADR-023 auto-stop attribution remain proposed.
+> Status: **PARTIAL IMPLEMENTATION** — ADR-024 Phases A+B implement the CoreAudio process attribution collector, CoreMediaIO camera activity collector, shared signal snapshot types, trust-tiered app registry, detection mode, and pure detector tests behind `AppFeatures.meetingActivityDetectionEnabled = false`. Coordinator/UI wiring, prompt/auto-start telemetry, and ADR-023 auto-stop attribution remain proposed.
 
-**What:** Recognize an *unscheduled* live meeting from metadata-only on-device signals — per-process CoreAudio audio attribution (which app holds the mic, never the audio itself), CoreMediaIO camera activity, and a recognized conferencing-app/URL registry — fused conservatively so camera alone (e.g. Photo Booth) never triggers, with the app's own capture excluded from the signals. Phase A ships the metadata-only audio attribution and pure policy foundation only; it does not start observers at runtime or show prompts while the flag remains off. Later phases offer to record ("Record this meeting?"), with opt-in auto-start as a separate mode. Extends ADR-017's calendar-only trigger to ad-hoc calls and someone-else's invites. Metadata-only / local-first, opt-in, default off, gated by `AppFeatures.meetingActivityDetectionEnabled`. The same signal layer feeds F44 auto-stop.
+**What:** Recognize an *unscheduled* live meeting from metadata-only on-device signals — per-process CoreAudio audio attribution (which app holds the mic, never the audio itself), CoreMediaIO camera activity, and a recognized conferencing-app/URL registry — fused conservatively so camera alone (e.g. Photo Booth) never triggers, with the app's own capture excluded from the signals. Phases A+B ship the metadata-only collectors and pure policy foundation only; they do not start observers at runtime or show prompts while the flag remains off. Later phases offer to record ("Record this meeting?"), with opt-in auto-start as a separate mode. Extends ADR-017's calendar-only trigger to ad-hoc calls and someone-else's invites. Metadata-only / local-first, opt-in, default off, gated by `AppFeatures.meetingActivityDetectionEnabled`. The same signal layer feeds F44 auto-stop.
 
 ### F46: Meeting Capture Reliability — Mic-Health Watchdog + Coverage Repair
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -77,7 +77,7 @@ All ADRs live in `spec/adr/`. These are locked -- they record decisions already 
 | [ADR-021](adr/021-whisperkit-multilingual-stt.md) | WhisperKit as optional multilingual STT engine |
 | [ADR-022](adr/022-transforms-system-wide-rewrite.md) | Transforms — system-wide LLM rewrites on selected text (implemented 2026-05-13) |
 | [ADR-023](adr/023-activity-based-meeting-auto-stop.md) | Activity-based meeting auto-stop (silence + app-quit signals, veto countdown; Phases A+B implemented behind default-off flag — replaces withdrawn ADR-017 calendar auto-stop) |
-| [ADR-024](adr/024-activity-based-meeting-detection.md) | Activity-based meeting detection (Phase A process-audio collector + pure detector implemented behind default-off flag; camera/coordinator/prompt phases proposed) |
+| [ADR-024](adr/024-activity-based-meeting-detection.md) | Activity-based meeting detection (Phases A+B process-audio/camera collectors + pure detector implemented behind default-off flag; coordinator/prompt phases proposed) |
 | [ADR-025](adr/025-meeting-capture-reliability.md) | Meeting capture reliability — mic-health watchdog + post-stop coverage repair (Phase A mic-health telemetry watchdog implemented; warning UI + repair proposed) |
 
 ## Version Roadmap
@@ -90,7 +90,7 @@ All ADRs live in `spec/adr/`. These are locked -- they record decisions already 
 | v0.4 | Polish & Launch | Diarization, custom hotkey, non-blocking progress, direct distribution | **Implemented** |
 | v0.5 | Data, UI & Prompts | Private dictation, favorites, video player, split-pane detail, library grid, prompt library, multi-summary | **Implemented** |
 | v0.6 | Meeting Recording + Multilingual STT + Transforms | System audio + mic capture, concurrent with dictation, local transcription, VAD-guided live-preview chunking, library integration, optional Nemotron Beta and WhisperKit engines, system-wide selected-text rewrites, calendar auto-start | **Implemented** |
-| v0.7 | Post-v0.6 polish | Activity-based auto-stop (ADR-023 implemented behind default-off flag), meeting reliability (ADR-025 Phase A implemented behind default-on kill-switch), and activity-based detection (ADR-024 Phase A implemented behind default-off flag), plus other follow-up polish | **Planned** |
+| v0.7 | Post-v0.6 polish | Activity-based auto-stop (ADR-023 implemented behind default-off flag), meeting reliability (ADR-025 Phase A implemented behind default-on kill-switch), and activity-based detection (ADR-024 Phases A+B implemented behind default-off flag), plus other follow-up polish | **Planned** |
 
 ## Version Progress
 

--- a/spec/adr/024-activity-based-meeting-detection.md
+++ b/spec/adr/024-activity-based-meeting-detection.md
@@ -1,17 +1,18 @@
 # ADR-024: Activity-Based Meeting Detection
 
-> Status: **PARTIAL IMPLEMENTATION** — Phase A ships the default-off CoreAudio
-> process attribution collector, shared activity snapshot types, app registry,
-> detection mode, and pure detector tests. Camera collection, coordinator/UI
-> wiring, prompt/auto-start telemetry, and ADR-023 auto-stop attribution remain
-> proposed until later phases flip `AppFeatures.meetingActivityDetectionEnabled`.
+> Status: **PARTIAL IMPLEMENTATION** — Phases A+B ship the default-off CoreAudio
+> process attribution collector, CoreMediaIO camera activity collector, shared
+> activity snapshot types, app registry, detection mode, and pure detector tests.
+> Coordinator/UI wiring, prompt/auto-start telemetry, and ADR-023 auto-stop
+> attribution remain proposed until later phases flip
+> `AppFeatures.meetingActivityDetectionEnabled`.
 > Default off / opt-in.
 > Date: 2026-06-14
 > Related: ADR-002 (local-first), ADR-014 (meeting recording), ADR-015
 > (concurrent dictation/meeting), ADR-017 (calendar auto-start), ADR-023
 > (activity-based meeting auto-stop — authored in parallel; consumes the same
 > activity-signal layer this ADR builds).
-> Requirement: REQ-MEET-016 (v0.7, Phase A foundation implemented).
+> Requirement: REQ-MEET-016 (v0.7, Phases A+B foundation implemented).
 
 ## Context
 

--- a/spec/kernel/requirements.yaml
+++ b/spec/kernel/requirements.yaml
@@ -372,7 +372,7 @@ REQ-MEET-015:
   status: implemented
 
 REQ-MEET-016:
-  description: Activity-based meeting detection recognizes an unscheduled live meeting from metadata-only on-device signals (per-process CoreAudio audio attribution, CoreMediaIO camera activity, recognized conferencing-app/URL registry) fused so camera alone never triggers, with self-attribution exclusion and a stabilization + decline-cooldown prompt state machine, and offers to record (opt-in auto-start as a separate mode); Phase A implements the default-off process-audio attribution collector, shared signal snapshot, trust-tiered app registry, detection mode, and pure detector tests while camera collection, coordinator/UI wiring, prompt telemetry, and auto-stop attribution remain deferred; opt-in, default off, metadata-only/local-first, gated by AppFeatures.meetingActivityDetectionEnabled (ADR-024)
+  description: Activity-based meeting detection recognizes an unscheduled live meeting from metadata-only on-device signals (per-process CoreAudio audio attribution, CoreMediaIO camera activity, recognized conferencing-app/URL registry) fused so camera alone never triggers, with self-attribution exclusion and a stabilization + decline-cooldown prompt state machine, and offers to record (opt-in auto-start as a separate mode); Phases A+B implement the default-off process-audio attribution collector, CoreMediaIO camera activity collector, shared signal snapshot, trust-tiered app registry, detection mode, and pure detector tests while coordinator/UI wiring, prompt telemetry, and auto-stop attribution remain deferred; opt-in, default off, metadata-only/local-first, gated by AppFeatures.meetingActivityDetectionEnabled (ADR-024)
   version: v0.7
   status: active
 


### PR DESCRIPTION
## What & why

Adds the **camera signal** to the detection foundation (#524). A running camera *plus* mic activity strengthens "this is a meeting" — but **camera alone never triggers** a meeting (so Photo Booth, QuickTime, or a preview window can't masquerade as one). Still no UI; same default-off `AppFeatures.meetingActivityDetectionEnabled` flag.

## How it works

```
CoreMediaIO devices ─▶ CameraActivityCollector ─ any device running? ─▶ cameraRunning: Bool
   (hotplug-aware,        (fail-closed reads, async start,                  │
    per-device listeners)  teardown on stop()/deinit)                       ▼
                                                          MeetingActivityDetector fusion
                                                          mic + camera ⇒ meeting ✓
                                                          camera only  ⇒ rejected ✗
```

The collector tracks `kCMIODevicePropertyDeviceIsRunningSomewhere` across all camera devices, reacts to hotplug via a device-list listener, and reads fail-closed (any CoreMediaIO error ⇒ "not running"). The detector keeps the **conservative fusion**: a meeting needs mic input; camera only ever *reinforces* it.

## What changed

- `CameraActivityCollector` — CoreMediaIO wrapper: device-list + per-device listeners, fail-closed snapshots, async non-blocking startup (with a lifecycle-generation guard), listeners torn down in `stop()` **and** `deinit`, debug logging on listener-registration failure.
- Detector tests for the fusion matrix: camera-alone rejection, mic+camera unknown-app detection, self-filtered mic rejection, multi-device aggregation.
- ADR-024 / requirements / roadmap / `CLAUDE.md` updated to mark Phases A+B implemented (coordinator/UI wiring + prompt telemetry remain deferred).

## Rollout

- Default-off, **no runtime consumer yet** — zero blast radius. No telemetry events → no website allowlist change needed.

## Stack (top of stack — merge bottom-up)

```
main
└─ #522 auto-stop   (ADR-023)
   └─ #523 mic-health (ADR-025 A)
      └─ #524 detection (ADR-024 A)
         └─ #525 camera  (ADR-024 B)  ◀── this PR
```

> Built on #524's foundation; the merge driver rebases this onto the merged Phase A (reconciling the `recognizedMeetingURLBundleIDs` rename + shared detector tests) before merge.

## Validation

- Full `swift test` suite green.
- Focused: `MeetingActivityDetectorTests`, `SpecCommandTests`.
