### PR TITLE
Live preview: text size control, polish, and live resizing

### DIFF
--- a/Sources/MacParakeet/App/DebugDictationPreviewQA.swift
+++ b/Sources/MacParakeet/App/DebugDictationPreviewQA.swift
@@ -6,6 +6,7 @@ import MacParakeetCore
 final class DebugDictationPreviewQA {
     private static let launchArgument = "--qa-dictation-preview-overlay"
     private static let transcriptArgument = "--qa-dictation-preview-text"
+    private static let sizeArgument = "--qa-dictation-preview-size"
 
     private let arguments: [String]
     private var overlayController: DictationOverlayController?
@@ -31,6 +32,8 @@ final class DebugDictationPreviewQA {
         viewModel.recordingElapsedSeconds = 8
         viewModel.audioLevel = 0.45
         viewModel.liveTranscript = arguments.value(after: Self.transcriptArgument) ?? Self.defaultTranscript
+        viewModel.previewTextSize = arguments.value(after: Self.sizeArgument)
+            .flatMap(DictationPreviewTextSize.init(rawValue:)) ?? .medium
         viewModel.onCancel = { [weak self] in self?.hide() }
         viewModel.onStop = { [weak self] in self?.hide() }
         viewModel.startTimer()

--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -302,11 +302,12 @@ final class DictationFlowCoordinator {
         }
     }
 
-    // NOTE: no `deinit` cleanup for `formatterDidStartObserver`. This
-    // coordinator is effectively a singleton for the app's lifetime, the
-    // observer block captures `[weak self]`, and Swift 6 forbids touching
-    // `@MainActor`-isolated stored properties from a nonisolated deinit.
-    // NotificationCenter cleans up automatically when the token drops.
+    // NOTE: no `deinit` cleanup for `formatterDidStartObserver` or
+    // `previewTextSizeObserver`. This coordinator is effectively a singleton
+    // for the app's lifetime, both observer blocks capture `[weak self]`, and
+    // Swift 6 forbids touching `@MainActor`-isolated stored properties from a
+    // nonisolated deinit. NotificationCenter cleans up automatically when the
+    // tokens drop.
 
     // MARK: - Public Methods (translate to state machine events)
 

--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -238,6 +238,7 @@ final class DictationFlowCoordinator {
         self.onHistoryReload = onHistoryReload
         self.onPresentEntitlementsAlert = onPresentEntitlementsAlert
         observeFormatterNotifications()
+        observePreviewTextSizeNotifications()
     }
 
     // MARK: - AI Formatter pill transitions
@@ -280,6 +281,24 @@ final class DictationFlowCoordinator {
             vm.isHovered = false
             vm.hoverTooltip = nil
             vm.state = .formatting
+        }
+    }
+
+    /// Observer token for `.macParakeetDictationPreviewTextSizeDidChange` —
+    /// lets a size change in Settings resize the live preview mid-dictation
+    /// instead of only taking effect on the next recording.
+    private var previewTextSizeObserver: NSObjectProtocol?
+
+    private func observePreviewTextSizeNotifications() {
+        previewTextSizeObserver = NotificationCenter.default.addObserver(
+            forName: .macParakeetDictationPreviewTextSizeDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.overlayViewModel?.previewTextSize = self.runtimePreferences.dictationPreviewTextSize
+            }
         }
     }
 
@@ -443,6 +462,7 @@ final class DictationFlowCoordinator {
             vm.busyProcessingMessage = nil
             vm.processingLoadCaption = nil
             vm.liveTranscript = ""
+            vm.previewTextSize = runtimePreferences.dictationPreviewTextSize
             vm.state = .recording
             vm.startTimer()
 

--- a/Sources/MacParakeet/Views/Dictation/DictationOverlayController.swift
+++ b/Sources/MacParakeet/Views/Dictation/DictationOverlayController.swift
@@ -221,6 +221,7 @@ final class DictationOverlayViewModel {
     var busyProcessingMessage: String?
     var processingLoadCaption: ProcessingLoadCaption?
     var liveTranscript: String = ""
+    var previewTextSize: DictationPreviewTextSize = .medium
     var commandPromptText: String = "Speak your command..."
     var commandSelectedText: String = ""
 

--- a/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
+++ b/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
@@ -451,30 +451,50 @@ struct DictationOverlayView: View {
         return String(compact.suffix(180))
     }
 
+    /// Visual metrics for the live preview, keyed off the user's size choice.
+    /// Width stays fixed (the floating panel is 300pt wide and the shadow must
+    /// not clip); only the type scale, line spacing, and vertical breathing room
+    /// grow with size.
+    private var previewMetrics: (font: CGFloat, lineSpacing: CGFloat, verticalPadding: CGFloat, minHeight: CGFloat) {
+        switch viewModel.previewTextSize {
+        case .small:
+            return (13, 1, 8, 30)
+        case .medium:
+            return (16, 2, 9, 34)
+        case .large:
+            return (19, 3, 11, 40)
+        }
+    }
+
     @ViewBuilder
     private var liveTranscriptPreviewPanel: some View {
         if let liveTranscriptPreview {
+            let metrics = previewMetrics
             Text(liveTranscriptPreview)
-                .font(.system(size: 12, weight: .medium))
-                .foregroundStyle(.white.opacity(0.76))
+                .font(.system(size: metrics.font, weight: .semibold))
+                .foregroundStyle(.white.opacity(0.92))
                 .lineLimit(2)
+                .lineSpacing(metrics.lineSpacing)
                 .truncationMode(.head)
                 .multilineTextAlignment(.leading)
                 .frame(width: 252, alignment: .leading)
-                .frame(minHeight: 30, alignment: .leading)
-                .padding(.horizontal, 10)
-                .padding(.vertical, 7)
+                .frame(minHeight: metrics.minHeight, alignment: .leading)
+                .padding(.horizontal, 12)
+                .padding(.vertical, metrics.verticalPadding)
                 .background(
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .fill(DesignSystem.Colors.pillBackground.opacity(0.82))
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .fill(DesignSystem.Colors.pillBackground.opacity(0.86))
                         .overlay(
-                            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            RoundedRectangle(cornerRadius: 10, style: .continuous)
                                 .strokeBorder(DesignSystem.Colors.pillBorder.opacity(0.42), lineWidth: 0.5)
                         )
-                        .shadow(color: .black.opacity(0.22), radius: 7, y: 3)
+                        .shadow(color: .black.opacity(0.24), radius: 8, y: 3)
                 )
                 .accessibilityLabel(liveTranscriptPreview)
                 .padding(.bottom, 2)
+                // Smoothly grow/shrink the card when the size changes live
+                // (Settings picker) instead of snapping between presets.
+                .animation(.easeInOut(duration: 0.2), value: viewModel.previewTextSize)
                 .transition(.move(edge: .bottom).combined(with: .opacity).animation(.easeInOut(duration: 0.16)))
         }
     }

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -1024,10 +1024,29 @@ struct SettingsView: View {
 
                 settingsToggleRow(
                     title: "Live transcript preview",
-                    detail: "Shows a short in-progress transcript above the dictation pill while recording. Available with the Parakeet and Nemotron engines, not Whisper.",
+                    detail: "Shows a running transcript above the dictation pill as you speak. Works with the Parakeet and Nemotron engines; not yet available with Whisper.",
                     isBeta: true,
                     isOn: $viewModel.showLiveDictationPreview
                 )
+
+                if viewModel.showLiveDictationPreview {
+                    Divider()
+                    HStack(alignment: .center) {
+                        rowText(
+                            title: "Preview text size",
+                            detail: "Text size for the live preview above the dictation pill."
+                        )
+                        Spacer(minLength: DesignSystem.Spacing.md)
+                        Picker("Preview text size", selection: $viewModel.dictationPreviewTextSize) {
+                            ForEach(DictationPreviewTextSize.allCases, id: \.self) { size in
+                                Text(size.displayTitle).tag(size)
+                            }
+                        }
+                        .labelsHidden()
+                        .pickerStyle(.segmented)
+                        .frame(width: 200)
+                    }
+                }
 
                 Divider()
 
@@ -1066,6 +1085,10 @@ struct SettingsView: View {
                     isOn: $viewModel.keepDictationOnClipboard
                 )
             }
+            // Smoothly reveal/hide the "Preview text size" sub-row (and reflow
+            // the rows below it) when the preview toggle flips, instead of
+            // snapping it in.
+            .animation(.easeInOut(duration: 0.2), value: viewModel.showLiveDictationPreview)
         }
     }
 

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -1026,7 +1026,10 @@ struct SettingsView: View {
                     title: "Live transcript preview",
                     detail: "Shows a running transcript above the dictation pill as you speak. Works with the Parakeet and Nemotron engines; not yet available with Whisper.",
                     isBeta: true,
-                    isOn: $viewModel.showLiveDictationPreview
+                    // Animate via the binding so only this toggle's state change
+                    // animates the sub-row reveal/reflow — not a blanket
+                    // container animation that could catch unrelated controls.
+                    isOn: $viewModel.showLiveDictationPreview.animation(.easeInOut(duration: 0.2))
                 )
 
                 if viewModel.showLiveDictationPreview {
@@ -1085,10 +1088,6 @@ struct SettingsView: View {
                     isOn: $viewModel.keepDictationOnClipboard
                 )
             }
-            // Smoothly reveal/hide the "Preview text size" sub-row (and reflow
-            // the rows below it) when the preview toggle flips, instead of
-            // snapping it in.
-            .animation(.easeInOut(duration: 0.2), value: viewModel.showLiveDictationPreview)
         }
     }
 

--- a/Sources/MacParakeetCore/AppNotifications.swift
+++ b/Sources/MacParakeetCore/AppNotifications.swift
@@ -36,4 +36,8 @@ public extension Notification.Name {
     /// changes. The coordinator re-reads the opt-in toggle immediately so
     /// disabling it tears down observers/countdowns without waiting.
     static let macParakeetMeetingAutoStopDidChange = Notification.Name("macparakeet.meetingAutoStopDidChange")
+    /// Posted when the live transcript preview text size changes. The dictation
+    /// flow coordinator re-reads the preference and updates the on-screen
+    /// preview live, so a size change is visible mid-dictation.
+    static let macParakeetDictationPreviewTextSizeDidChange = Notification.Name("macparakeet.dictationPreviewTextSizeDidChange")
 }

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -20,6 +20,7 @@ public protocol AppRuntimePreferencesProtocol: Sendable {
     var pauseMediaDuringDictation: Bool { get }
     var instantDictationEnabled: Bool { get }
     var showLiveDictationPreview: Bool { get }
+    var dictationPreviewTextSize: DictationPreviewTextSize { get }
     var shouldKeepDictationOnClipboard: Bool { get }
     var hasCompletedFirstDictation: Bool { get }
     /// Flip the one-shot "first dictation completed" flag. Returns `true` only
@@ -67,6 +68,34 @@ public enum DictationInsertionStyle: String, CaseIterable, Hashable, Sendable, E
             return .sentence
         }
         return style
+    }
+}
+
+/// Text size for the in-progress live transcript preview shown above the
+/// dictation pill. Discrete presets keep the control glanceable; the view layer
+/// maps each case to concrete font/padding metrics so Core stays UI-free.
+public enum DictationPreviewTextSize: String, CaseIterable, Hashable, Sendable, Equatable {
+    case small
+    case medium
+    case large
+
+    public var displayTitle: String {
+        switch self {
+        case .small:
+            return "Small"
+        case .medium:
+            return "Medium"
+        case .large:
+            return "Large"
+        }
+    }
+
+    public static func current(defaults: UserDefaults = .standard) -> DictationPreviewTextSize {
+        guard let raw = defaults.string(forKey: UserDefaultsAppRuntimePreferences.dictationPreviewTextSizeKey),
+              let size = DictationPreviewTextSize(rawValue: raw) else {
+            return .medium
+        }
+        return size
     }
 }
 
@@ -210,6 +239,7 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
     public static let pauseMediaDuringDictationKey = "pauseMediaDuringDictation"
     public static let instantDictationEnabledKey = "instantDictationEnabled"
     public static let showLiveDictationPreviewKey = "showLiveDictationPreview"
+    public static let dictationPreviewTextSizeKey = "dictationPreviewTextSize"
     public static let keepDictationOnClipboardKey = "keepDictationOnClipboard"
     public static let hasCompletedFirstDictationKey = "hasCompletedFirstDictation"
     /// Play a chime (and, when backgrounded, post a banner) when a file/URL
@@ -310,6 +340,10 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
 
     public var showLiveDictationPreview: Bool {
         defaults.object(forKey: Self.showLiveDictationPreviewKey) as? Bool ?? true
+    }
+
+    public var dictationPreviewTextSize: DictationPreviewTextSize {
+        DictationPreviewTextSize.current(defaults: defaults)
     }
 
     public var shouldKeepDictationOnClipboard: Bool {

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -230,6 +230,7 @@ public final class SettingsViewModel {
             Telemetry.send(.settingChanged(setting: .liveDictationPreview))
         }
     }
+
     public var dictationPreviewTextSize: DictationPreviewTextSize {
         didSet {
             guard dictationPreviewTextSize != oldValue else { return }

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -230,6 +230,20 @@ public final class SettingsViewModel {
             Telemetry.send(.settingChanged(setting: .liveDictationPreview))
         }
     }
+    public var dictationPreviewTextSize: DictationPreviewTextSize {
+        didSet {
+            guard dictationPreviewTextSize != oldValue else { return }
+            defaults.set(
+                dictationPreviewTextSize.rawValue,
+                forKey: UserDefaultsAppRuntimePreferences.dictationPreviewTextSizeKey
+            )
+            // Let an active dictation overlay re-read the size and resize live.
+            NotificationCenter.default.post(name: .macParakeetDictationPreviewTextSizeDidChange, object: nil)
+            // Reuses the live-preview setting channel — size is part of the same
+            // feature, so no separate telemetry setting name is needed.
+            Telemetry.send(.settingChanged(setting: .liveDictationPreview))
+        }
+    }
     public var microphoneDeviceOptions: [MicrophoneDeviceOption] = []
     public var microphoneTestState: MicrophoneTestState = .idle
     public var microphoneTestLevel: Float = 0
@@ -695,6 +709,7 @@ public final class SettingsViewModel {
         showLiveDictationPreview = defaults.object(
             forKey: UserDefaultsAppRuntimePreferences.showLiveDictationPreviewKey
         ) as? Bool ?? true
+        dictationPreviewTextSize = DictationPreviewTextSize.current(defaults: defaults)
         voiceReturnEnabled = defaults.bool(forKey: UserDefaultsAppRuntimePreferences.voiceReturnEnabledKey)
         voiceReturnTrigger = defaults.string(forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggerKey) ?? "press return"
         processingMode = Self.normalizedProcessingMode(defaults.string(forKey: UserDefaultsAppRuntimePreferences.processingModeKey))

--- a/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
+++ b/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
@@ -142,6 +142,31 @@ final class AppRuntimePreferencesTests: XCTestCase {
         XCTAssertFalse(UserDefaultsAppRuntimePreferences(defaults: defaults).showLiveDictationPreview)
     }
 
+    func testDictationPreviewTextSizeDefaultsToMediumAndReadsPersistedValue() {
+        let suite = "app-runtime-prefs-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        XCTAssertEqual(UserDefaultsAppRuntimePreferences(defaults: defaults).dictationPreviewTextSize, .medium)
+
+        defaults.set(
+            DictationPreviewTextSize.large.rawValue,
+            forKey: UserDefaultsAppRuntimePreferences.dictationPreviewTextSizeKey
+        )
+
+        XCTAssertEqual(UserDefaultsAppRuntimePreferences(defaults: defaults).dictationPreviewTextSize, .large)
+    }
+
+    func testDictationPreviewTextSizeFallsBackToMediumOnUnknownRawValue() {
+        let suite = "app-runtime-prefs-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        defaults.set("gigantic", forKey: UserDefaultsAppRuntimePreferences.dictationPreviewTextSizeKey)
+
+        XCTAssertEqual(UserDefaultsAppRuntimePreferences(defaults: defaults).dictationPreviewTextSize, .medium)
+    }
+
     func testAIFormatterEnabledForDictationDefaultsToFalseAndReadsPersistedValue() {
         let suite = "app-runtime-prefs-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -324,6 +324,25 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(settings, [.liveDictationPreview, .liveDictationPreview])
     }
 
+    func testDictationPreviewTextSizeDefaultsToMediumPersistsAndEmitsTelemetry() {
+        XCTAssertEqual(viewModel.dictationPreviewTextSize, .medium)
+
+        let telemetry = SettingsTelemetrySpy()
+        Telemetry.configure(telemetry)
+
+        viewModel.dictationPreviewTextSize = .large
+
+        XCTAssertEqual(
+            testDefaults.string(forKey: UserDefaultsAppRuntimePreferences.dictationPreviewTextSizeKey),
+            DictationPreviewTextSize.large.rawValue
+        )
+        let settings = telemetry.snapshot().compactMap { event -> TelemetrySettingName? in
+            guard case .settingChanged(let setting) = event else { return nil }
+            return setting
+        }
+        XCTAssertEqual(settings, [.liveDictationPreview])
+    }
+
     func testSelectedMicrophonePersistsUIDAndClearsForSystemDefault() {
         var microphoneNotificationCount = 0
         var instantDictationNotificationCount = 0


### PR DESCRIPTION
## Summary

Follow-up polish on the live transcript preview (after #528). Makes the preview bigger and crisper by default, adds a user-adjustable size, updates it live while dictating, smooths the motion, and corrects the engine-availability copy.

## What changed

- **Preview text size setting** — a Small / Medium / Large segmented picker under the "Live transcript preview" toggle in Settings. Backed by a persisted `DictationPreviewTextSize` (default **Medium**); the view layer maps each preset to font/line-spacing/padding so Core stays UI-free.
- **Crisper default** — semibold text at higher contrast (0.92), softer card (radius 10), more padding, added line spacing. Default size goes from a flat 12pt to ~16pt.
- **Live resizing** — changing the size in Settings updates an in-progress preview immediately via `macParakeetDictationPreviewTextSizeDidChange` (the flow coordinator observes it and updates the overlay VM), not just on the next dictation.
- **Smoother motion** — the preview card animates between sizes instead of snapping; the "Preview text size" sub-row reveals/reflows smoothly when the toggle flips.
- **Copy fix** — reworded the toggle caption to be accurate: *"Shows a running transcript above the dictation pill as you speak. Works with the Parakeet and Nemotron engines; not yet available with Whisper."* The earlier draft wrongly implied Whisper is excluded because it's batch-only — but Parakeet's preview is also re-transcription; Whisper's preview path simply stays gated pending latency validation.
- Debug QA harness gained `--qa-dictation-preview-size`.

## Testing

- Full `swift test` ✅ (0 failures) and Swift 6 language-mode build (`MACPARAKEET_SKIP_WHISPERKIT=1`) ✅
- New tests: preference default/persistence/telemetry + bad-value fallback
- Manual: dev build — dictated while toggling Small/Medium/Large and confirmed live resize + smooth animation

## Notes

Size-only, system font (no typeface picker), per an explicit product decision. The size is read at recording start *and* updated live mid-dictation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)