### PR TITLE
Add export_failed telemetry so export errors are visible

### DIFF
--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
@@ -80,7 +80,8 @@ enum TranscriptResultActions {
         } catch {
             Telemetry.send(.exportFailed(
                 format: format.rawValue,
-                errorType: TelemetryErrorClassifier.classify(error)
+                errorType: TelemetryErrorClassifier.classify(error),
+                errorDetail: TelemetryErrorClassifier.errorDetail(error)
             ))
             throw error
         }
@@ -112,7 +113,8 @@ enum TranscriptResultActions {
         } catch {
             Telemetry.send(.exportFailed(
                 format: format.rawValue,
-                errorType: TelemetryErrorClassifier.classify(error)
+                errorType: TelemetryErrorClassifier.classify(error),
+                errorDetail: TelemetryErrorClassifier.errorDetail(error)
             ))
             throw error
         }

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
@@ -61,21 +61,29 @@ enum TranscriptResultActions {
         source: Transcription,
         format: TranscriptExportFormat
     ) throws -> URL {
-        let baseStem = TranscriptSegmenter.sanitizedExportStem(from: source.fileName)
-        let promptNameSafe = promptResult.promptName
-            .lowercased()
-            .components(separatedBy: CharacterSet.alphanumerics.inverted)
-            .filter { !$0.isEmpty }
-            .joined(separator: "-")
-        let promptComponent = promptNameSafe.isEmpty ? "result" : promptNameSafe
-        let stem = "\(baseStem)-\(promptComponent)"
+        do {
+            let baseStem = TranscriptSegmenter.sanitizedExportStem(from: source.fileName)
+            let promptNameSafe = promptResult.promptName
+                .lowercased()
+                .components(separatedBy: CharacterSet.alphanumerics.inverted)
+                .filter { !$0.isEmpty }
+                .joined(separator: "-")
+            let promptComponent = promptNameSafe.isEmpty ? "result" : promptNameSafe
+            let stem = "\(baseStem)-\(promptComponent)"
 
-        let downloadsURL = try downloadsDirectory()
-        let fileURL = nextAvailableURL(in: downloadsURL, stem: stem, format: format)
+            let downloadsURL = try downloadsDirectory()
+            let fileURL = nextAvailableURL(in: downloadsURL, stem: stem, format: format)
 
-        try promptResult.content.write(to: fileURL, atomically: true, encoding: .utf8)
-        Telemetry.send(.exportUsed(format: format.rawValue))
-        return fileURL
+            try promptResult.content.write(to: fileURL, atomically: true, encoding: .utf8)
+            Telemetry.send(.exportUsed(format: format.rawValue))
+            return fileURL
+        } catch {
+            Telemetry.send(.exportFailed(
+                format: format.rawValue,
+                errorType: TelemetryErrorClassifier.classify(error)
+            ))
+            throw error
+        }
     }
 
     static func exportTranscriptToDownloads(
@@ -83,23 +91,31 @@ enum TranscriptResultActions {
         format: TranscriptExportFormat,
         options: TranscriptExportOptions = .default
     ) throws -> URL {
-        let stem = TranscriptSegmenter.sanitizedExportStem(from: transcription.fileName)
-        let downloadsURL = try downloadsDirectory()
-        let fileURL = nextAvailableURL(in: downloadsURL, stem: stem, format: format)
-        let exportService = ExportService()
+        do {
+            let stem = TranscriptSegmenter.sanitizedExportStem(from: transcription.fileName)
+            let downloadsURL = try downloadsDirectory()
+            let fileURL = nextAvailableURL(in: downloadsURL, stem: stem, format: format)
+            let exportService = ExportService()
 
-        switch format {
-        case .txt: try exportService.exportToTxt(transcription: transcription, url: fileURL, options: options)
-        case .md: try exportService.exportToMarkdown(transcription: transcription, url: fileURL, options: options)
-        case .srt: try exportService.exportToSRT(transcription: transcription, url: fileURL)
-        case .vtt: try exportService.exportToVTT(transcription: transcription, url: fileURL)
-        case .docx: try exportService.exportToDocx(transcription: transcription, url: fileURL)
-        case .pdf: try exportService.exportToPDF(transcription: transcription, url: fileURL)
-        case .json: try exportService.exportToJSON(transcription: transcription, url: fileURL)
+            switch format {
+            case .txt: try exportService.exportToTxt(transcription: transcription, url: fileURL, options: options)
+            case .md: try exportService.exportToMarkdown(transcription: transcription, url: fileURL, options: options)
+            case .srt: try exportService.exportToSRT(transcription: transcription, url: fileURL)
+            case .vtt: try exportService.exportToVTT(transcription: transcription, url: fileURL)
+            case .docx: try exportService.exportToDocx(transcription: transcription, url: fileURL)
+            case .pdf: try exportService.exportToPDF(transcription: transcription, url: fileURL)
+            case .json: try exportService.exportToJSON(transcription: transcription, url: fileURL)
+            }
+
+            Telemetry.send(.exportUsed(format: format.rawValue))
+            return fileURL
+        } catch {
+            Telemetry.send(.exportFailed(
+                format: format.rawValue,
+                errorType: TelemetryErrorClassifier.classify(error)
+            ))
+            throw error
         }
-
-        Telemetry.send(.exportUsed(format: format.rawValue))
-        return fileURL
     }
 
     private static func downloadsDirectory() throws -> URL {

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -26,6 +26,7 @@ public enum TelemetryEventName: String, Sendable, CaseIterable {
     case diarizationCompleted = "diarization_completed"
     case diarizationFailed = "diarization_failed"
     case exportUsed = "export_used"
+    case exportFailed = "export_failed"
     case llmPromptResultUsed = "llm_prompt_result_used"
     case llmPromptResultFailed = "llm_prompt_result_failed"
     case llmChatUsed = "llm_chat_used"
@@ -607,6 +608,7 @@ public enum TelemetryEventSpec: Sendable {
     case diarizationCompleted(source: TelemetryTranscriptionSource, speakerCount: Int, durationSeconds: Double)
     case diarizationFailed(source: TelemetryTranscriptionSource, errorType: String, errorDetail: String? = nil)
     case exportUsed(format: String)
+    case exportFailed(format: String, errorType: String, errorDetail: String? = nil)
     case llmPromptResultUsed(provider: String)
     case llmPromptResultFailed(provider: String, errorType: String, errorDetail: String? = nil)
     case llmChatUsed(provider: String, source: TelemetryChatSource, messageCount: Int)
@@ -907,6 +909,7 @@ extension TelemetryEventSpec {
         case .diarizationCompleted: return .diarizationCompleted
         case .diarizationFailed: return .diarizationFailed
         case .exportUsed: return .exportUsed
+        case .exportFailed: return .exportFailed
         case .llmPromptResultUsed: return .llmPromptResultUsed
         case .llmPromptResultFailed: return .llmPromptResultFailed
         case .llmChatUsed: return .llmChatUsed
@@ -1204,6 +1207,10 @@ extension TelemetryEventSpec {
             return props
         case .exportUsed(let format):
             return ["format": format]
+        case .exportFailed(let format, let errorType, let errorDetail):
+            var props = ["format": format, "error_type": errorType]
+            if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
+            return props
         case .llmPromptResultUsed(let provider):
             return ["provider": provider]
         case .llmPromptResultFailed(let provider, let errorType, let errorDetail):
@@ -1730,6 +1737,7 @@ public enum TelemetryImplementedContract {
         .diarizationCompleted: ["source", "speaker_count"],
         .diarizationFailed: ["source", "error_type"],
         .exportUsed: ["format"],
+        .exportFailed: ["format", "error_type"],
         .llmPromptResultUsed: ["provider"],
         .llmPromptResultFailed: ["provider", "error_type"],
         .llmChatUsed: ["provider", "source", "message_count"],

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -389,6 +389,7 @@ final class TelemetryServiceTests: XCTestCase {
             .dictationFailed(errorType: "runtime", errorDetail: rawDetail),
             .transcriptionFailed(source: .file, stage: .stt, errorType: "runtime", errorDetail: rawDetail),
             .diarizationFailed(source: .meeting, errorType: "runtime", errorDetail: rawDetail),
+            .exportFailed(format: "pdf", errorType: "runtime", errorDetail: rawDetail),
             .llmPromptResultFailed(provider: "openai", errorType: "provider", errorDetail: rawDetail),
             .llmChatFailed(provider: "openai", source: .transcriptChat, errorType: "provider", errorDetail: rawDetail),
             .llmTransformFailed(provider: "openai", errorType: "provider", errorDetail: rawDetail),

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -1404,6 +1404,7 @@ final class TelemetryServiceTests: XCTestCase {
                 errorType: nil
             ),
             .exportUsed(format: "txt"),
+            .exportFailed(format: "pdf", errorType: "disk_full"),
             .llmPromptResultUsed(provider: "openai"),
             .llmPromptResultFailed(provider: "openai", errorType: "auth"),
             .llmChatUsed(provider: "openai", source: .transcriptChat, messageCount: 3),

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -300,6 +300,7 @@ events remain useful for diarization-specific timing and failure analysis.
 | Event | Props | Question It Answers |
 |---|---|---|
 | `export_used` | `format` (txt, md, srt, vtt, docx, pdf, json) | Which export formats matter? |
+| `export_failed` | `format`, `error_type` | Which export formats fail and why (disk full, permissions, docx/pdf encode)? Pairs with `export_used` for a per-format success rate. |
 | `llm_prompt_result_used` | `provider` | Are prompt-library results and generated summaries being used? Which providers matter? |
 | `llm_prompt_result_failed` | `provider`, `error_type` | Failure rates for prompt-library result generation per provider |
 | `llm_chat_used` | `provider`, `source` (`meeting_ask`, `transcript_chat`), `message_count` | Do people chat with transcripts? Live meeting Ask is separable from post-transcription chat. |


### PR DESCRIPTION
## Why
From the 2026-06-14 telemetry audit: `export_used` only fires *after* a successful write, so export failures (disk full, permissions, docx/pdf encode errors) across all 7 formats were **invisible** — a gap in the operation-coverage gate.

## What
- New `export_failed` event (`format` + sanitized `error_type`).
- Both `TranscriptResultActions` export paths wrap their work in `do/catch`, emit `export_failed` on failure, and **rethrow** — caller error UI unchanged.
- Contract entry + test sample (57 `TelemetryServiceTests` pass, incl. the contract-parity test); catalog row in `docs/telemetry.md`.

Pairs with `export_used` for a per-format export **success rate**.

## ⚠️ Cross-repo dependency
Needs `export_failed` added to the website Worker `ALLOWED_EVENTS` allowlist (companion PR `macparakeet-website`) **before** any build emitting it ships — an unknown event name drops the whole batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)