### PR TITLE
Settings: group meeting auto-start + auto-stop as "Automatic recording"

### DIFF
--- a/Sources/MacParakeet/Views/Settings/CalendarSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/CalendarSettingsView.swift
@@ -2,9 +2,12 @@ import MacParakeetCore
 import MacParakeetViewModels
 import SwiftUI
 
-/// Calendar auto-start section. Slotted into Settings between Meeting
-/// Recording and Transcription. Exposes all three modes — `.off`, `.notify`,
-/// and `.autoStart` per ADR-017 Phases 1+2.
+/// Calendar auto-start — the "Start recording automatically" half of the
+/// Meeting Recording card's Automatic recording group. A single adaptive row
+/// requests Calendar access in context (so the user opts into auto-start and
+/// *that* prompts for access), then exposes all three modes — `.off`,
+/// `.notify`, `.autoStart` per ADR-017 Phases 1+2 — with disclosed reminder,
+/// event-filter, and per-calendar controls.
 struct CalendarSettingsView: View {
     @Bindable var viewModel: SettingsViewModel
     @State private var availableCalendars: [CalendarInfo] = []
@@ -13,26 +16,21 @@ struct CalendarSettingsView: View {
 
     var body: some View {
         VStack(spacing: DesignSystem.Spacing.md) {
-            permissionRow
+            startRow
 
-            if viewModel.calendarPermissionGranted {
+            if viewModel.calendarPermissionGranted && viewModel.calendarAutoStartMode != .off {
+                if !viewModel.calendarNotificationsAuthorized {
+                    Divider()
+                    notificationWarningRow
+                }
                 Divider()
-                modeRow
+                reminderLeadRow
+                Divider()
+                triggerFilterRow
 
-                if viewModel.calendarAutoStartMode != .off {
-                    if !viewModel.calendarNotificationsAuthorized {
-                        Divider()
-                        notificationWarningRow
-                    }
+                if !availableCalendars.isEmpty {
                     Divider()
-                    reminderLeadRow
-                    Divider()
-                    triggerFilterRow
-
-                    if !availableCalendars.isEmpty {
-                        Divider()
-                        includedCalendarsRow
-                    }
+                    includedCalendarsRow
                 }
             }
         }
@@ -78,42 +76,58 @@ struct CalendarSettingsView: View {
         Task { await viewModel.refreshCalendarNotificationAuthorization() }
     }
 
-    // MARK: - Permission
+    // MARK: - Start (adaptive permission + mode)
 
+    /// Single adaptive row that frames calendar auto-start as the "start" half
+    /// of the Automatic recording group. The trailing control follows Calendar
+    /// permission: a one-tap enable button before access is granted (so the
+    /// user opts into auto-start and *that* triggers the access prompt), the
+    /// mode picker once granted, and a System Settings deep-link if denied.
     @ViewBuilder
-    private var permissionRow: some View {
+    private var startRow: some View {
         HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
             VStack(alignment: .leading, spacing: 2) {
-                Text("Calendar access")
+                Text("Start recording automatically")
                     .font(DesignSystem.Typography.body)
-                Text(permissionDetail)
+                Text(startDetail)
                     .font(DesignSystem.Typography.caption)
                     .foregroundStyle(.secondary)
             }
             Spacer(minLength: DesignSystem.Spacing.md)
-            permissionAction
+            startControl
         }
     }
 
-    private var permissionDetail: String {
+    private var startDetail: String {
         switch viewModel.calendarPermissionStatus {
         case .granted:
-            return "Granted. Events stay on your Mac — MacParakeet never uploads them."
+            return modeDetail
         case .denied:
             // macOS only shows the EventKit prompt once. Once denied, the
-            // only path back is System Settings — telling the user to
-            // "grant access" via a button that can't actually re-prompt
-            // would mystify them.
-            return "Calendar access is blocked. Re-enable it in System Settings → Privacy & Security → Calendars to use reminders."
+            // only path back is System Settings — a button that can't actually
+            // re-prompt would mystify the user, so point them there explicitly.
+            return "Calendar access is blocked. Re-enable it in System Settings → Privacy & Security → Calendars to start meetings automatically."
         case .notDetermined:
-            return "Reads your macOS calendar so MacParakeet can remind you before a meeting starts. Events stay on your Mac."
+            return "Start a recording when a scheduled meeting begins. Needs Calendar access — your events stay on your Mac and are never uploaded."
         }
     }
 
     @ViewBuilder
-    private var permissionAction: some View {
+    private var startControl: some View {
         switch viewModel.calendarPermissionStatus {
-        case .granted, .denied:
+        case .granted:
+            Picker("", selection: $viewModel.calendarAutoStartMode) {
+                Text("Off").tag(CalendarAutoStartMode.off)
+                Text("Notify me").tag(CalendarAutoStartMode.notify)
+                Text("Start automatically").tag(CalendarAutoStartMode.autoStart)
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+            .frame(minWidth: 200)
+            // No explicit accessibilityLabel: the adjacent "Start recording
+            // automatically" title is read first, matching the reminder/event
+            // pickers below. A label here would make VoiceOver speak it twice.
+        case .denied:
             Button("Open System Settings") {
                 viewModel.openCalendarSystemSettings()
             }
@@ -125,35 +139,11 @@ struct CalendarSettingsView: View {
                 if isRequestingPermission {
                     ProgressView().controlSize(.small)
                 } else {
-                    Text("Grant Calendar Access")
+                    Text("Turn On…")
                 }
             }
             .controlSize(.small)
             .disabled(isRequestingPermission)
-        }
-    }
-
-    // MARK: - Mode
-
-    @ViewBuilder
-    private var modeRow: some View {
-        HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Calendar behavior")
-                    .font(DesignSystem.Typography.body)
-                Text(modeDetail)
-                    .font(DesignSystem.Typography.caption)
-                    .foregroundStyle(.secondary)
-            }
-            Spacer(minLength: DesignSystem.Spacing.md)
-            Picker("", selection: $viewModel.calendarAutoStartMode) {
-                Text("Off").tag(CalendarAutoStartMode.off)
-                Text("Notify before meetings").tag(CalendarAutoStartMode.notify)
-                Text("Start recording automatically").tag(CalendarAutoStartMode.autoStart)
-            }
-            .labelsHidden()
-            .pickerStyle(.menu)
-            .frame(minWidth: 240)
         }
     }
 

--- a/Sources/MacParakeet/Views/Settings/CalendarSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/CalendarSettingsView.swift
@@ -124,9 +124,11 @@ struct CalendarSettingsView: View {
             .labelsHidden()
             .pickerStyle(.menu)
             .frame(minWidth: 200)
-            // No explicit accessibilityLabel: the adjacent "Start recording
-            // automatically" title is read first, matching the reminder/event
-            // pickers below. A label here would make VoiceOver speak it twice.
+            // macOS VoiceOver focuses each control independently and does NOT
+            // auto-associate the adjacent title with the picker — without this
+            // the control announces only its value ("Off, pop up button"). The
+            // visible title is mirrored so the accessible name matches it.
+            .accessibilityLabel("Start recording automatically")
         case .denied:
             Button("Open System Settings") {
                 viewModel.openCalendarSystemSettings()
@@ -180,6 +182,7 @@ struct CalendarSettingsView: View {
             .labelsHidden()
             .pickerStyle(.menu)
             .frame(minWidth: 200)
+            .accessibilityLabel("Remind me")
         }
     }
 
@@ -204,6 +207,7 @@ struct CalendarSettingsView: View {
             .labelsHidden()
             .pickerStyle(.menu)
             .frame(minWidth: 200)
+            .accessibilityLabel("Which events count")
         }
     }
 

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -1141,14 +1141,25 @@ struct SettingsView: View {
                     .frame(minWidth: 220, idealWidth: 260, maxWidth: 320)
                 }
 
-                if AppFeatures.meetingAutoStopEnabled {
+                Divider()
+
+                settingsToggleRow(
+                    title: "Auto-save meetings to disk",
+                    detail: "Automatically write a file to the chosen folder after every meeting recording completes.",
+                    isOn: $viewModel.meetingAutoSave
+                )
+
+                if viewModel.meetingAutoSave {
+                    meetingAutoSaveOptionsView
+                }
+
+                // Start (calendar) and stop (activity) automation are grouped
+                // under one subsection so they read as the two ends of the
+                // recording lifecycle. Either flag alone still shows the group.
+                if AppFeatures.calendarEnabled || AppFeatures.meetingAutoStopEnabled {
                     Divider()
 
-                    settingsToggleRow(
-                        title: "Auto-stop ended meetings",
-                        detail: "Offer to stop after a meeting app closes or both channels stay quiet. You can keep recording before anything stops.",
-                        isOn: $viewModel.meetingAutoStopEnabled
-                    )
+                    meetingAutomationSection
                 }
 
                 if viewModel.pendingMeetingRecoveryCount > 0 {
@@ -1168,27 +1179,6 @@ struct SettingsView: View {
                         .parakeetAction(.secondary)
                     }
                 }
-
-                Divider()
-
-                settingsToggleRow(
-                    title: "Auto-save meetings to disk",
-                    detail: "Automatically write a file to the chosen folder after every meeting recording completes.",
-                    isOn: $viewModel.meetingAutoSave
-                )
-
-                if viewModel.meetingAutoSave {
-                    meetingAutoSaveOptionsView
-                }
-
-                if AppFeatures.calendarEnabled {
-                    Divider()
-
-                    // Calendar section folded in from the legacy standalone
-                    // `calendarCard`. Calendar is meeting-only — folding it
-                    // here removes a card without losing any controls.
-                    meetingCalendarSection
-                }
             }
         }
     }
@@ -1203,22 +1193,40 @@ struct SettingsView: View {
         )
     }
 
-    /// Calendar auto-start controls, rendered inline within the Meeting
-    /// Recording card after the auto-save section. Visually demoted to a
-    /// section heading so it reads as part of meeting setup.
-    private var meetingCalendarSection: some View {
-        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+    /// Automatic-recording controls grouped under one subsection: the
+    /// calendar-driven "Start recording automatically" half (ADR-017) and the
+    /// activity-driven "Stop recording automatically" half (ADR-023). They read
+    /// as the two ends of the recording lifecycle but use different signals on
+    /// purpose — calendar *start* times are reliable, *end* times are not, so
+    /// stop keys off meeting-end activity (app quit + dual-channel silence)
+    /// instead. Each flag is independent; either alone still renders the group.
+    private var meetingAutomationSection: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
             HStack(spacing: 6) {
-                Image(systemName: "calendar")
+                Image(systemName: "clock.arrow.circlepath")
                     .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(.secondary)
-                Text("Calendar auto-start")
+                Text("Automatic recording")
                     .font(DesignSystem.Typography.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
                 Spacer()
             }
 
-            CalendarSettingsView(viewModel: viewModel)
+            if AppFeatures.calendarEnabled {
+                CalendarSettingsView(viewModel: viewModel)
+            }
+
+            if AppFeatures.meetingAutoStopEnabled {
+                if AppFeatures.calendarEnabled {
+                    Divider()
+                }
+
+                settingsToggleRow(
+                    title: "Stop recording automatically",
+                    detail: "Stop after a meeting app quits, or both channels stay quiet for a few minutes. A countdown lets you keep recording first.",
+                    isOn: $viewModel.meetingAutoStopEnabled
+                )
+            }
         }
     }
 

--- a/plans/completed/2026-06-14-meeting-automatic-recording-settings.md
+++ b/plans/completed/2026-06-14-meeting-automatic-recording-settings.md
@@ -1,0 +1,120 @@
+# Meeting Recording settings — "Automatic recording" grouping
+
+> Status: **IMPLEMENTED** (2026-06-14)
+> Scope: Settings → Meeting Recording card IA reframe. No engine/behavior change.
+> Shipped on branch `settings/meeting-automatic-recording`; build + full
+> `swift test` green; dual SwiftUI review (no blockers).
+
+## Problem
+
+The Meeting Recording settings card presents the two halves of the recording
+lifecycle inconsistently, which reads as lopsided:
+
+- **Auto-stop** is a single inline toggle ("Auto-stop ended meetings") near the
+  top of the card.
+- **Auto-start already exists** but is buried at the bottom as a visually
+  unrelated "Calendar auto-start" subsection, gated behind a cold "Grant
+  Calendar Access" button, with a 3-way "Calendar behavior" menu picker
+  (Off / Notify before meetings / Start recording automatically).
+
+A user scanning the card sees a stop toggle and asks "where's the matching
+start?" — the answer is there, but it doesn't read as the peer of stop.
+
+## Why they aren't naively symmetric (design constraint)
+
+Start and stop deliberately use **different signals**, because different signals
+are reliable in each direction:
+
+- **Start = calendar** (ADR-017). Meeting *start* times are reliable.
+- **Stop = activity** (ADR-023) — meeting-app quit + prolonged dual-channel
+  silence + a veto countdown. Meeting *end* times are unreliable, so
+  calendar-driven auto-stop was removed (ADR-017 amendment).
+- Activity-*detected* auto-start (ADR-024) is foundation-only (flag off, no UI)
+  — the future symmetric peer, not shippable today.
+
+So the fix is **information architecture, not a new feature or a bare twin
+toggle** (a bare "Auto-start" toggle would falsely imply activity-based start
+like auto-stop).
+
+## Design
+
+Introduce one **"Automatic recording"** subsection inside the Meeting Recording
+card that frames start and stop as a matched pair, each keeping the control
+depth its real mechanism needs. Reuse the existing inline subsection-header
+treatment (SF symbol + semibold secondary caption) already used for the old
+"Calendar auto-start" heading.
+
+New Meeting Recording card order (top → bottom):
+
+1. Meeting hotkey (manual start/stop) — unchanged
+2. Audio sources — unchanged
+3. Auto-save meetings to disk (+ format/folder) — unchanged
+4. **Automatic recording** (new group)
+   - **Start recording automatically** — calendar-driven (adaptive row)
+   - **Stop recording automatically** — activity-driven (toggle)
+5. Pending recovery (conditional) — moved to end (transient, exceptional state)
+
+### Start row (CalendarSettingsView reframe)
+
+Collapse the separate "Calendar access" permission row + "Calendar behavior"
+mode row into ONE adaptive "Start recording automatically" row whose trailing
+control depends on permission state — this gives **in-context permission
+prompting** (you opt into auto-start, and *that* asks for Calendar access)
+and makes the feature discoverable before access is granted:
+
+- `.notDetermined`: detail "Start a recording when a scheduled meeting begins.
+  Needs Calendar access — your events stay on your Mac." → trailing **Turn On…**
+  button (requests permission; existing flow auto-selects `.notify` on grant).
+- `.denied`: detail "Calendar access is blocked. Re-enable it in System
+  Settings → Privacy & Security → Calendars." → trailing **Open System
+  Settings** button.
+- `.granted`: detail = existing mode description → trailing **menu Picker**
+  (Off / Notify me / Start automatically).
+
+When granted and mode ≠ `.off`, keep the existing disclosed sub-rows unchanged:
+notification-off warning, "Remind me" lead time, "Which events count" filter,
+per-calendar include list. Picker gains an explicit `accessibilityLabel`.
+
+### Stop row
+
+Reword the auto-stop toggle for parallelism with start, preserving the veto
+information:
+
+- Title: "Stop recording automatically"
+- Detail: "Stop after a meeting app quits, or both channels stay quiet for a few
+  minutes. A countdown lets you keep recording first."
+
+## Out of scope
+
+- `MeetingsView` `CalendarInlineControlsRow` (Library surface; its own segmented
+  picker, already divergent). Untouched.
+- Auto-stop configurability (countdown/silence knobs) — stays a single toggle.
+- Speaker detection relocation — noted as a possible follow-up, not done here.
+- Any ViewModel/persistence/telemetry/coordinator change. Pure view layer +
+  copy. Bindings (`calendarAutoStartMode`, `meetingAutoStopEnabled`, sub-row
+  settings) and their `didSet` side effects are unchanged.
+
+## Files
+
+- `Sources/MacParakeet/Views/Settings/SettingsView.swift` — reorder meeting card
+  body; replace `meetingCalendarSection` + standalone auto-stop row with
+  `meetingAutomationSection`; reword stop toggle.
+- `Sources/MacParakeet/Views/Settings/CalendarSettingsView.swift` — adaptive
+  start row replacing separate permission + mode rows; concise picker labels;
+  a11y label; doc-comment refresh.
+- Docs: refresh `spec/04-ui-patterns.md` meeting-settings description if stale.
+
+## Invariants (must not change)
+
+- All calendar sub-settings remain reachable and bound to the same UserDefaults.
+- `.denied` vs `.notDetermined` paths stay distinct (macOS prompts once).
+- Notification-authorization pairing on grant/mode-change is preserved.
+- Auto-stop toggle still gated by `AppFeatures.meetingAutoStopEnabled`; calendar
+  still gated by `AppFeatures.calendarEnabled`.
+
+## Test / verification plan
+
+- `swift build` + `swift test` green (view-layer change; logic untested by
+  design, so this confirms no regressions).
+- Fresh code review (Swift/SwiftUI reviewer + second-opinion pass).
+- Visual QA of the live dev app Settings card if headless capture is feasible.

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -723,7 +723,7 @@ Row anatomy:
 
 Settings open in the content area when "Settings" is selected in the sidebar. The current information architecture is a four-tab shell with a persistent header, search field, and status-aware tab badges:
 
-- **Modes** — Audio Input, Dictation, Transcription, and Meeting Recording cards. Calendar controls are folded into Meeting Recording and appear once Calendar access is granted (`AppFeatures.calendarEnabled = true`).
+- **Modes** — Audio Input, Dictation, Transcription, and Meeting Recording cards. The Meeting Recording card groups start/stop automation under an "Automatic recording" subsection: a calendar-driven "Start recording automatically" adaptive row (requests Calendar access in context, then exposes the off/notify/auto-start mode plus disclosed reminder, event-filter, and per-calendar controls; `AppFeatures.calendarEnabled = true`) paired with an activity-driven "Stop recording automatically" toggle (`AppFeatures.meetingAutoStopEnabled = true`).
 - **Engine** — Speech engine selector, Whisper language picker, and local model status/management.
 - **AI** — Optional provider setup for summaries, transcript chat, prompt actions, and live Ask.
 - **System** — Appearance, startup, permissions, storage, updates, privacy/telemetry, onboarding reset, about, and fenced Reset & Cleanup actions.


### PR DESCRIPTION
## Why

The Settings → Meeting Recording card presented the two halves of the recording
lifecycle inconsistently. **Auto-stop** was a clean inline toggle near the top,
while **auto-start already existed** but was buried at the bottom as a visually
unrelated "Calendar auto-start" section behind a cold "Grant Calendar Access"
button. A user scanning the card saw a stop toggle and asked "where's the
matching start?" — the answer was there, but it didn't read as the peer of stop.

Start and stop aren't naively symmetric, **on purpose**: calendar meeting
*start* times are reliable, but *end* times are not. So start keys off the
calendar (ADR-017) and stop keys off meeting-end **activity** — app quit +
prolonged dual-channel silence + veto countdown (ADR-023). Calendar-driven
auto-stop was removed by the ADR-017 amendment for exactly this reason. The fix
here is therefore **information architecture, not a new feature or a bare
symmetric toggle** (which would falsely imply activity-based start).

## What changed

A single **"Automatic recording"** subsection now frames start and stop as a
matched pair, each keeping the control depth its real mechanism needs:

```
✦ Automatic recording
  Start recording automatically            [ Notify me ▾ ]   ← calendar (ADR-017)
    When a scheduled meeting begins …            (Off · Notify me · Start automatically)
    └ Remind me · Which events count · Calendars   (disclosed when on)
  Stop recording automatically                       ( • )   ← activity (ADR-023)
    Stop after a meeting app quits, or both
    channels stay quiet for a few minutes …
```

- **In-context permission.** `CalendarSettingsView` collapses its separate
  "Calendar access" row + "Calendar behavior" picker into one adaptive
  "Start recording automatically" row. The trailing control follows permission
  state — **Turn On…** (not-determined: requests access *when you opt in*),
  **Open System Settings** (denied), or the off/notify/auto-start menu picker
  (granted). The feature is now discoverable *before* access is granted.
- **Latent bug fixed.** The old `permissionAction` coalesced `.granted` and
  `.denied`, so a user who had *already granted* Calendar access saw an
  "Open System Settings" deep-link instead of the mode picker. The new
  exhaustive switch fixes that.
- **Card reordered** into a clean lifecycle story: hotkey → audio sources →
  auto-save → Automatic recording → pending recovery.
- Auto-stop toggle reworded **"Auto-stop ended meetings" → "Stop recording
  automatically"** for parallelism, preserving the veto-countdown explanation.

No engine/behavior/persistence/telemetry change — pure view-layer IA + copy.
All bindings and `didSet` side effects are unchanged; every calendar
sub-setting remains reachable in the same conditions as before.

## Scope / out of scope

- **Out:** `MeetingsView`'s `CalendarInlineControlsRow` (the Library surface —
  its own segmented picker with terser labels, already divergent before this
  PR; verbose labels would truncate at its width). Left untouched.
- **Out:** auto-stop configurability (stays one toggle), speaker-detection
  relocation. Noted as possible follow-ups.

## Verification

- `swift build` ✅ · full `swift test` ✅
- Dual independent review (Swift/SwiftUI specialist + Codex second opinion) —
  **no blockers**; both confirmed view-identity safety of the Button↔Picker
  swap, sub-setting reachability, denied/not-determined distinction, the
  notification-auth pairing on grant, and zero dead code.
- **Recommended manual pass:** eyeball the live card across permission states
  (`scripts/dev/run_app.sh`) — view-layer change, untested by project policy.

## Follow-ups (not blocking)

- Reconcile `CalendarAutoStartMode` labels across the Settings menu picker and
  the `MeetingsView` segmented picker (three label sets for one enum, predates
  this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
