### PR TITLE
Meeting pill: tear down floating pill on app quit so it can't linger

### DIFF
--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -256,7 +256,7 @@ final class MeetingRecordingFlowCoordinator {
     /// `restoreFloatingPillIfRecording()` if the user cancels the quit. Safe
     /// (no-op) when no pill is showing.
     func dismissFloatingPillForQuit() {
-        pillController?.hide()
+        pillController?.hide(preserveFrameForNextShow: true)
     }
 
     /// Re-show the floating pill after a quit was cancelled, but only while a

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -245,6 +245,31 @@ final class MeetingRecordingFlowCoordinator {
         }
     }
 
+    /// Detach the floating recording pill's window without disturbing the
+    /// recording/transcription flow. Called when the app begins a quit
+    /// decision or is terminating: the pill is a `.canJoinAllSpaces`,
+    /// background-draggable `NSPanel`, so while the app's main loop is busy
+    /// with the active-meeting quit alert or the final-transcription wait it
+    /// would otherwise linger on every Space as a window you can drag but
+    /// whose click/right-click handlers no longer respond — a "frozen ghost
+    /// pill." The recording itself keeps running; restore the pill with
+    /// `restoreFloatingPillIfRecording()` if the user cancels the quit. Safe
+    /// (no-op) when no pill is showing.
+    func dismissFloatingPillForQuit() {
+        pillController?.hide()
+    }
+
+    /// Re-show the floating pill after a quit was cancelled, but only while a
+    /// recording is still active — otherwise there is nothing to show and the
+    /// normal `.hidePill` teardown owns the lifecycle. The long-lived pill
+    /// view model still holds live state, so the rebuilt window renders the
+    /// current recording face immediately.
+    func restoreFloatingPillIfRecording() {
+        guard isMeetingRecordingActive else { return }
+        pillController?.show()
+        pillController?.refreshState()
+    }
+
     /// Calendar-driven entry point. Marks the next start as auto-start so
     /// telemetry distinguishes it and pre-names the recording with the
     /// event title, then enters the normal start flow. No-op if a recording

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -366,6 +366,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // would send duplicate appQuit events and double the termination delay.
         dictationFlowCoordinator?.releaseMediaPauseForTermination()
         dictationFlowCoordinator?.hideIdlePill()
+        // Tear down the floating meeting pill so it can't outlive the app as a
+        // draggable-but-dead window during the final moments of termination.
+        meetingRecordingFlowCoordinator?.dismissFloatingPillForQuit()
         hotkeyCoordinator?.stopAll()
         meetingAutoStartCoordinator?.stop()
         meetingAutoStopCoordinator?.stop()
@@ -810,6 +813,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         NSApp.activate(ignoringOtherApps: true)
 
+        // Hide the floating pill while the quit alert is up. It joins all
+        // Spaces, so during this app-modal alert it would otherwise linger as a
+        // draggable, non-interactive window — and if the alert lands on another
+        // Space the pill is all the user sees, reading as a frozen ghost.
+        // Restored below if the user keeps the app open.
+        meetingRecordingFlowCoordinator?.dismissFloatingPillForQuit()
+        var committedToQuit = false
+
         let alert = NSAlert()
         alert.alertStyle = .warning
 
@@ -823,6 +834,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 alert.buttons[0].hasDestructiveAction = true
             }
             if alert.runModal() == .alertFirstButtonReturn {
+                committedToQuit = true
                 finishMeetingThenQuit(discard: true)
             }
 
@@ -837,8 +849,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
             switch alert.runModal() {
             case .alertFirstButtonReturn:
+                committedToQuit = true
                 finishMeetingThenQuit(discard: false)
             case .alertSecondButtonReturn:
+                committedToQuit = true
                 finishMeetingThenQuit(discard: true)
             default:
                 break
@@ -850,8 +864,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             alert.addButton(withTitle: "Finish & Quit")
             alert.addButton(withTitle: "Cancel Quit")
             if alert.runModal() == .alertFirstButtonReturn {
+                committedToQuit = true
                 finishMeetingThenQuit(discard: false)
             }
+        }
+
+        if !committedToQuit {
+            meetingRecordingFlowCoordinator?.restoreFloatingPillIfRecording()
         }
 
         return .terminateCancel
@@ -859,6 +878,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func finishMeetingThenQuit(discard: Bool) {
         guard let coordinator = meetingRecordingFlowCoordinator else { return }
+
+        // The user committed to quitting — tear the floating pill down now so it
+        // doesn't sit on screen as a non-interactive window while the final
+        // transcription finishes in the background ahead of `NSApp.terminate`.
+        coordinator.dismissFloatingPillForQuit()
 
         meetingQuitTask?.cancel()
         meetingQuitTask = Task { @MainActor [weak self, coordinator] in

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPillController.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPillController.swift
@@ -73,6 +73,7 @@ private class PillMenuDelegate: NSObject {
 @MainActor
 final class MeetingRecordingPillController {
     private var panel: NSPanel?
+    private var preservedFrameForNextShow: NSRect?
     private weak var pillView: MeetingRecordingAppKitPillView?
     private let pillViewModel: MeetingRecordingPillViewModel
     var onClick: (() -> Void)?
@@ -132,7 +133,10 @@ final class MeetingRecordingPillController {
         panel.isMovableByWindowBackground = true
         panel.contentView = contentView
 
-        if let screen = NSScreen.main {
+        if let preservedFrame = preservedFrameForNextShow {
+            panel.setFrame(preservedFrame, display: false)
+            preservedFrameForNextShow = nil
+        } else if let screen = NSScreen.main {
             let frame = screen.visibleFrame
             let x = frame.maxX - panelWidth
             let y = frame.midY - panelHeight / 2
@@ -143,7 +147,14 @@ final class MeetingRecordingPillController {
         self.panel = panel
     }
 
-    func hide() {
+    func hide(preserveFrameForNextShow: Bool = false) {
+        if preserveFrameForNextShow {
+            if let frame = panel?.frame {
+                preservedFrameForNextShow = frame
+            }
+        } else {
+            preservedFrameForNextShow = nil
+        }
         panel?.orderOut(nil)
         panel = nil
         pillView = nil

--- a/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowCoordinatorTests.swift
@@ -71,6 +71,59 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
         XCTAssertEqual(operation.systemTrackPresent, true)
     }
 
+    // MARK: - Quit-time pill teardown (fix/meeting-pill-lingers-on-quit)
+
+    /// Hiding the floating pill for a quit decision must be flow-neutral: it
+    /// only detaches the window, never stops or advances the recording. The
+    /// AppKit window visibility itself isn't exercised here (the pill controller
+    /// is only built when the `.showRecordingPill` effect runs, which the test
+    /// hook deliberately skips), so this guards the invariant that matters —
+    /// dismiss/restore can't accidentally tear down the recording.
+    func testDismissAndRestoreFloatingPillDoNotDisturbRecordingFlow() {
+        let coordinator = makeQuitTeardownCoordinator()
+        coordinator.testHook_enterRecording()
+        XCTAssertEqual(coordinator.testHook_state, .recording)
+        XCTAssertTrue(coordinator.isMeetingRecordingActive)
+
+        coordinator.dismissFloatingPillForQuit()
+        XCTAssertEqual(coordinator.testHook_state, .recording)
+        XCTAssertTrue(coordinator.isMeetingRecordingActive)
+
+        coordinator.restoreFloatingPillIfRecording()
+        XCTAssertEqual(coordinator.testHook_state, .recording)
+        XCTAssertTrue(coordinator.isMeetingRecordingActive)
+    }
+
+    /// Both calls are safe (no-ops) when idle, so the `applicationWillTerminate`
+    /// safety-net path can call them unconditionally without crashing.
+    func testDismissAndRestoreFloatingPillAreSafeWhenIdle() {
+        let coordinator = makeQuitTeardownCoordinator()
+        XCTAssertEqual(coordinator.testHook_state, .idle)
+        XCTAssertFalse(coordinator.isMeetingRecordingActive)
+
+        coordinator.dismissFloatingPillForQuit()
+        coordinator.restoreFloatingPillIfRecording()
+
+        XCTAssertEqual(coordinator.testHook_state, .idle)
+        XCTAssertFalse(coordinator.isMeetingRecordingActive)
+    }
+
+    private func makeQuitTeardownCoordinator() -> MeetingRecordingFlowCoordinator {
+        MeetingRecordingFlowCoordinator(
+            meetingRecordingService: MeetingRecordingServiceSpy(output: makeRecordingOutput()),
+            transcriptionService: MockTranscriptionService(),
+            permissionService: MockPermissionService(),
+            transcriptionRepo: MockTranscriptionRepository(),
+            conversationRepo: MockChatConversationRepository(),
+            quickPromptRepo: NoOpQuickPromptRepository(),
+            configStore: NoOpLLMConfigStore(),
+            llmService: nil,
+            pillViewModel: MeetingRecordingPillViewModel(),
+            onMenuBarIconUpdate: { _ in },
+            onTranscriptionReady: { _ in }
+        )
+    }
+
     private func makeRecordingOutput() -> MeetingRecordingOutput {
         let folder = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)


### PR DESCRIPTION
## Summary

Hardens app-quit teardown so the floating meeting-recording pill can't sit on screen as a window you can drag but not click. This is **defense-in-depth for a real gap** — see the honest confidence note below before treating it as a confirmed root-cause fix.

## Confidence / scope (read this)

A user reported a pill they could drag but not click/right-click, frozen in the **recording** face, which then vanished. Investigation **confirmed two things and could not confirm a third**:

- ✅ **Confirmed real gap:** when a meeting is active, `applicationShouldTerminate` defers the quit (modal alert → `finishMeetingThenQuit` awaits full transcription → `NSApp.terminate`), and **nothing hid the pill** during that window. `AppDelegate` never referenced `pillController`; the only hide is the state-machine `.hidePill` effect.
- ✅ **Confirmed not the activity sensor / not a dead process:** ADR-024 detection is flag-off + unwired (can't auto-start); and a dead process can't drag its own window, so it was a live, mid-quit app.
- ⚠️ **Could NOT confirm this is the exact cause the user saw.** Two cracks: (1) `pkill`/SIGTERM (the dev `run_app.sh` restart path) is **not** handled — no SIGTERM handler exists — so it bypasses `applicationShouldTerminate` entirely; the modal path only runs on Cmd-Q / menu Quit / logout. (2) The "draggable-but-not-clickable" symptom fits the *modal-alert phase* only if a `.nonactivatingPanel` stays background-draggable during an app-modal alert (believed, not verified), and a competing explanation — an **orphaned/duplicate pill from two running instances** (`com.macparakeet.dev` + installed `com.macparakeet`) — fits the user's original "duplicate" report and is **not** addressed by this PR. No repro was obtained.

**Net:** this change is correct and low-risk regardless (the pill *should* be torn down on quit), but it is hardening, not a proven fix for the specific report.

## Changes

- **`MeetingRecordingFlowCoordinator`** — `dismissFloatingPillForQuit()` (detach the pill window, leave the recording flow untouched) + `restoreFloatingPillIfRecording()` (re-show if still recording).
- **`presentActiveMeetingQuitAlert()`** — hide before the modal alert, restore on every "keep app open" branch.
- **`finishMeetingThenQuit()`** — hide immediately on commit, so it doesn't sit there during the transcription wait.
- **`applicationWillTerminate()`** — hide as a catch-all safety net.

The recording itself is never interrupted — only the window is hidden/restored.

## Tests

- `MeetingRecordingFlowCoordinatorTests`: dismiss/restore are flow-neutral (never stop or advance the recording) and safe when idle.
- Full suite green: **3810 tests, 0 failures**.
- AppKit window visibility isn't unit-tested headlessly (the pill controller is only built when `.showRecordingPill` runs, which the test hook skips), so the tests guard the load-bearing invariant: dismiss/restore can't tear down the recording.

## Follow-ups worth considering separately

- **Diagnostic logging** around pill show/hide + quit decision + instance PID, so the next occurrence is captured with evidence (the disciplined move given there's no repro).
- **Single-instance guard** for the duplicate-pill hypothesis (dev + installed bundles can run side by side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)