### PR TITLE
Plans: Tier-1 meeting feature plans (retention, bulk delete, back-to-back, auto-title)

### DIFF
--- a/plans/active/2026-06-18-library-bulk-delete.md
+++ b/plans/active/2026-06-18-library-bulk-delete.md
@@ -1,0 +1,172 @@
+# Library Multi-Select Bulk Delete
+
+**Status:** ACTIVE PLAN — not started
+**Date:** 2026-06-18
+**ADRs:** none new (UI/data-flow change within existing Library architecture)
+**Requirement:** REQ-LIB-002 (proposed — extends REQ-LIB-001 "Transcription library with thumbnail grid, filters, search")
+**Issues:** #498
+**Decision (owner, 2026-06-18):** Reuse the existing Dictation History
+"Select Multiple" pattern **plus keyboard support** (Delete key, ⌘A). Not
+Finder-style modifier-click selection (keeps the app internally consistent).
+
+## What this plan closes out
+
+The Library has no way to remove more than one item at a time — every delete is a
+context-menu → alert → confirm, one row at a time. #498 ("selecting multiple
+items in Library to bulk delete") is the literal ask, and it compounds with the
+#462 storage-management theme: users accumulating meetings/files need to prune in
+bulk.
+
+The good news: **Dictation History already implements a complete, shipped
+bulk-select pattern** (selection state, mode toggle, an action bar with
+count / Select All / Clear / Delete, batched deletion). This plan ports that
+proven pattern into the Library (both the thumbnail grid and the meetings list)
+rather than inventing a new interaction — and layers on keyboard affordances and
+a brief undo, which Dictation does not yet have.
+
+This plan also creates the selection substrate that the **auto-title backlog**
+follow-up (`2026-06-18-meeting-auto-title-followups.md`) rides on: once rows are
+multi-selectable, "Generate titles" becomes a natural bulk action.
+
+## Scope boundaries
+
+### In scope
+- Multi-select + bulk delete in **both** Library surfaces:
+  the thumbnail grid (`TranscriptionLibraryView` grid mode) and the date-grouped
+  meetings list (`TranscriptionLibraryView` meetings-list mode + `MeetingsView`
+  "Recent Meetings").
+- Selection state + batch-delete operations on `TranscriptionLibraryViewModel`,
+  mirroring `DictationHistoryViewModel`'s API shape.
+- An action bar (count, Select All, Clear, Cancel, Delete) consistent with the
+  Dictation History bar.
+- Keyboard: `⌫`/`Delete` triggers the bulk-delete confirmation when items are
+  selected; `⌘A` selects all currently-filtered items; `Esc` exits select mode.
+- A single confirmation alert stating the count and permanence; copy adapts when
+  the selection includes meetings (audio is unrecoverable).
+- A brief **undo toast** after a bulk delete (industry-best given there is no
+  trash today). Undo restores DB rows; audio files removed from disk are gone —
+  so undo restores transcripts/metadata and is honest that detached audio
+  stays gone.
+
+### Out of scope
+- Bulk delete in Dictation History (already exists) and a true trash/recycle bin
+  (a larger, separate feature).
+- Bulk **audio-only detach** (the single-item "Delete Audio" stays single-item;
+  bulk = full delete). Revisit if requested.
+- Bulk operations other than delete (move, export, favorite) — selection
+  substrate enables them later, but only delete (+ the auto-title follow-up's
+  "Generate titles") ships here.
+- Repository-level batch SQL — loop the existing single deletes in the ViewModel
+  (volumes are small; correctness + asset cleanup parity matter more than a new
+  batch query). Revisit only if perf demands it.
+
+### Invariants
+- **Asset cleanup parity.** Each delete in the batch runs the *same*
+  `TranscriptionDeletionCleanup.removeOwnedAssets()` + repo `delete(id:)` as the
+  single-item path — no shortcut that skips on-disk cleanup.
+- **No partial-silent failure.** If one item in the batch fails to delete, the
+  batch continues and the result surfaces (count succeeded / failed), never a
+  silent drop.
+- **Meeting audio permanence is explicit.** When the selection contains
+  meetings, the confirmation says audio cannot be recovered.
+- **Filter-aware Select All.** `⌘A` / "Select All" selects only the currently
+  filtered + searched set, never hidden rows.
+- Idle hygiene: selection state is torn down on mode exit and on filter change.
+
+## Verified current state (file:line)
+
+- Reusable pattern (source of truth to mirror):
+  `Sources/MacParakeetViewModels/DictationHistoryViewModel.swift`
+  — `selectedDictationIDs: Set<UUID>` + `isBulkSelectionModeEnabled` (~104-111),
+  `beginBulkSelection`/`exitBulkSelection` (~237-246),
+  `requestDeleteSelectedDictations`/`confirmDeleteSelectedDictations` (~248-268),
+  shared `deleteDictations(_:using:)` (~280-301), count-aware alert copy (~303-312).
+- Action bar UI to mirror: `Sources/MacParakeet/Views/History/DictationHistoryView.swift`
+  — `selectedActionsBar` (~173-220), Delete button (~208-214), bar shown when mode on (~83-89).
+- Library views to modify:
+  `Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift`
+  — grid vs meetings-list routing (~75-79), filter chips (~44-57),
+  `thumbnailGrid` (~137-160), `meetingsList` (~162-185),
+  single-delete (context menu → `pendingDelete`, alert ~85-105 → `deleteTranscription`),
+  meeting audio-only detach (~106-121 → `deleteMeetingAudio`).
+- `Sources/MacParakeet/Views/Meetings/MeetingsView.swift` — "Recent Meetings"
+  list reuses `MeetingRowCard` (~406-449).
+- Library ViewModel to extend:
+  `Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift`
+  — `transcriptions` / `filteredTranscriptions` / `groupedTranscriptions`,
+  `deleteTranscription(_:)` (~152-165) calling
+  `TranscriptionDeletionCleanup.removeOwnedAssets()` + repo `delete(id:)`;
+  `deleteMeetingAudio(_:)` (~167-188). No selection state today.
+- `MeetingsWorkspaceViewModel` delegates recents to a `TranscriptionLibraryViewModel`
+  (`recentMeetingsViewModel`) — selection lives in that VM so both surfaces share it.
+- No undo anywhere today (deletes are permanent) — the toast is net new.
+
+## Design
+
+### ViewModel (mirror Dictation, adapt to Transcription)
+On `TranscriptionLibraryViewModel`:
+```swift
+public private(set) var isBulkSelectionModeEnabled: Bool
+public private(set) var selectedTranscriptionIDs: Set<UUID>
+public var pendingBulkDelete: [Transcription]      // drives the alert
+func beginBulkSelection(startingWith: Transcription?)
+func toggleSelection(_ id: UUID)
+func selectAllVisible()                              // filtered + searched only
+func clearSelection()
+func exitBulkSelection()
+func requestDeleteSelected()
+func confirmDeleteSelected() async -> BulkDeleteResult   // {succeeded, failed}
+func undoLastBulkDelete() async                      // restores DB rows
+```
+- `confirmDeleteSelected` loops the existing per-item cleanup+delete, accumulates
+  a result, exits mode, and stages an undo snapshot (the deleted `Transcription`
+  rows; note which had audio detached so undo copy is honest).
+
+### Interaction
+- **Entry:** a row context-menu item "Select Multiple…" (matches Dictation),
+  plus a toolbar "Select" affordance on the Library header.
+- **Selection:** tapping a row toggles its checkmark while in mode; grid cards
+  show a selection overlay, list rows a leading checkbox.
+- **Action bar:** appears at the bottom while in mode — `N selected ·
+  Select All · Clear · Cancel · Delete`.
+- **Keyboard:** `⌘A` select-all-visible, `⌫`/`Delete` → confirmation,
+  `Esc` → exit. (Use SwiftUI `.onKeyPress` / commands on the focused Library
+  view; verify focus behavior in the dev app.)
+- **Confirmation copy:**
+  - files only: *"Delete N items? This permanently deletes them and their files."*
+  - includes meetings: *"Delete N items? Meeting audio cannot be recovered."*
+- **Undo toast:** *"Deleted N items. [Undo]"* — visible ~6s; Undo restores
+  transcript rows (and notes that already-removed audio files are not restored).
+
+## Phases
+1. **ViewModel selection + batch delete + tests** — port the Dictation API onto
+   `TranscriptionLibraryViewModel`; unit tests for select-all-visible (respects
+   filter/search), batch success/partial-failure result, mode teardown.
+2. **Grid + list UI** — selection overlays/checkboxes, action bar; both surfaces.
+3. **Keyboard** — ⌘A / Delete / Esc; dev-app verification of focus + that Delete
+   doesn't fire when not in select mode.
+4. **Undo toast** — snapshot + restore; honest copy about detached audio.
+5. **Docs** — `spec/04-ui-patterns.md` (Library multi-select), `spec/02-features.md`,
+   register REQ-LIB-002.
+
+## Testing
+- ViewModel unit tests: selection toggling, `selectAllVisible` excludes
+  filtered-out/searched-out rows, batch delete returns correct succeeded/failed,
+  undo restores rows, mode teardown clears state.
+- Asset-cleanup parity test: a batch delete invokes the same cleanup as the
+  single-item path (no orphaned files; meeting folders removed).
+- `swift test` before merge. (SwiftUI views themselves untested per repo policy —
+  logic lives in the ViewModel.)
+
+## Open questions (resolve in Phase 1)
+1. **Undo depth:** single-level "undo last bulk delete" (proposed) vs. none.
+   Single-level is cheap and a big safety win; confirm it's worth the snapshot
+   bookkeeping or defer to a future trash feature.
+2. **Favorites in Select All:** include favorited rows in `⌘A` (simplest) vs.
+   warn/exclude. Lean: include, but the confirmation count makes scale visible.
+3. **Toolbar "Select" vs. context-menu-only entry:** ship both for discoverability,
+   or context-menu-only to match Dictation exactly? Lean: both.
+
+## Docs to update on completion
+`spec/04-ui-patterns.md`, `spec/02-features.md`, `spec/README.md`,
+`spec/kernel/requirements.yaml` (REQ-LIB-002), and an issue reply on #498.

--- a/plans/active/2026-06-18-library-bulk-delete.md
+++ b/plans/active/2026-06-18-library-bulk-delete.md
@@ -21,8 +21,9 @@ The good news: **Dictation History already implements a complete, shipped
 bulk-select pattern** (selection state, mode toggle, an action bar with
 count / Select All / Clear / Delete, batched deletion). This plan ports that
 proven pattern into the Library (both the thumbnail grid and the meetings list)
-rather than inventing a new interaction — and layers on keyboard affordances and
-a brief undo, which Dictation does not yet have.
+rather than inventing a new interaction — and layers on keyboard affordances
+Dictation does not yet have. (No undo in v1 — see Out of scope for why a row-only
+undo would be a data-loss trap here.)
 
 This plan also creates the selection substrate that the **auto-title backlog**
 follow-up (`2026-06-18-meeting-auto-title-followups.md`) rides on: once rows are
@@ -42,15 +43,21 @@ multi-selectable, "Generate titles" becomes a natural bulk action.
 - Keyboard: `⌫`/`Delete` triggers the bulk-delete confirmation when items are
   selected; `⌘A` selects all currently-filtered items; `Esc` exits select mode.
 - A single confirmation alert stating the count and permanence; copy adapts when
-  the selection includes meetings (audio is unrecoverable).
-- A brief **undo toast** after a bulk delete (industry-best given there is no
-  trash today). Undo restores DB rows; audio files removed from disk are gone —
-  so undo restores transcripts/metadata and is honest that detached audio
-  stays gone.
+  the selection includes meetings (audio **and** AI summaries/chats are
+  unrecoverable — see Invariants).
+- The batch delete runs off the main thread (`Task.detached`), mirroring
+  `DictationHistoryViewModel.deleteTargets`, so deleting many items never
+  beachballs the UI. [Gemini]
 
 ### Out of scope
-- Bulk delete in Dictation History (already exists) and a true trash/recycle bin
-  (a larger, separate feature).
+- Bulk delete in Dictation History (already exists).
+- **Undo / trash for bulk delete.** Deferred for v1 by design: `delete(id:)`
+  cascade-deletes a transcription's `prompt_results`, `chat_conversations`, and
+  LLM-run rows (`foreignKeysEnabled` + `onDelete: .cascade`,
+  `DatabaseManager.swift:227-229, 404-406, 807-810`), so a row-only undo would
+  silently lose every AI summary and Ask-tab chat — strictly worse than no undo.
+  A real undo needs a full-object-graph snapshot/restore or a soft-delete trash;
+  both are a separate future feature. v1 relies on a precise confirmation instead.
 - Bulk **audio-only detach** (the single-item "Delete Audio" stays single-item;
   bulk = full delete). Revisit if requested.
 - Bulk operations other than delete (move, export, favorite) — selection
@@ -67,10 +74,15 @@ multi-selectable, "Generate titles" becomes a natural bulk action.
 - **No partial-silent failure.** If one item in the batch fails to delete, the
   batch continues and the result surfaces (count succeeded / failed), never a
   silent drop.
-- **Meeting audio permanence is explicit.** When the selection contains
-  meetings, the confirmation says audio cannot be recovered.
+- **Deletion is permanent and total.** A delete removes the transcript, its
+  on-disk audio, **and** its cascaded `prompt_results` / `chat_conversations` /
+  LLM-run rows. There is no undo (see Out of scope), so the confirmation must
+  state this plainly — especially that meeting audio and AI summaries can't be
+  recovered.
 - **Filter-aware Select All.** `⌘A` / "Select All" selects only the currently
   filtered + searched set, never hidden rows.
+- **Accessibility parity.** The action bar and selection controls carry VoiceOver
+  labels (count, selected state, actions), consistent with the active a11y sprint.
 - Idle hygiene: selection state is torn down on mode exit and on filter change.
 
 ## Verified current state (file:line)
@@ -99,7 +111,13 @@ multi-selectable, "Generate titles" becomes a natural bulk action.
   `deleteMeetingAudio(_:)` (~167-188). No selection state today.
 - `MeetingsWorkspaceViewModel` delegates recents to a `TranscriptionLibraryViewModel`
   (`recentMeetingsViewModel`) — selection lives in that VM so both surfaces share it.
-- No undo anywhere today (deletes are permanent) — the toast is net new.
+- Delete cascade: `TranscriptionRepository.delete(id:)` (~357) is a bare
+  `Transcription.deleteOne` and the DB has `foreignKeysEnabled = true` with
+  `prompt_results`, `chat_conversations`, and the LLM-run table all
+  `references("transcriptions", onDelete: .cascade)`
+  (`DatabaseManager.swift:31, 227-229, 404-406, 807-810`) — so a delete takes the
+  AI content with it. This is why undo is out of scope.
+- No undo anywhere today (deletes are permanent).
 
 ## Design
 
@@ -116,11 +134,10 @@ func clearSelection()
 func exitBulkSelection()
 func requestDeleteSelected()
 func confirmDeleteSelected() async -> BulkDeleteResult   // {succeeded, failed}
-func undoLastBulkDelete() async                      // restores DB rows
 ```
-- `confirmDeleteSelected` loops the existing per-item cleanup+delete, accumulates
-  a result, exits mode, and stages an undo snapshot (the deleted `Transcription`
-  rows; note which had audio detached so undo copy is honest).
+- `confirmDeleteSelected` runs the per-item cleanup+delete in a `Task.detached`
+  loop (off the main actor), accumulates a `{succeeded, failed}` result, and exits
+  mode. No snapshot (no undo in v1).
 
 ### Interaction
 - **Entry:** a row context-menu item "Select Multiple…" (matches Dictation),
@@ -132,40 +149,41 @@ func undoLastBulkDelete() async                      // restores DB rows
 - **Keyboard:** `⌘A` select-all-visible, `⌫`/`Delete` → confirmation,
   `Esc` → exit. (Use SwiftUI `.onKeyPress` / commands on the focused Library
   view; verify focus behavior in the dev app.)
-- **Confirmation copy:**
+- **Confirmation copy (no undo, so it must be precise):**
   - files only: *"Delete N items? This permanently deletes them and their files."*
-  - includes meetings: *"Delete N items? Meeting audio cannot be recovered."*
-- **Undo toast:** *"Deleted N items. [Undo]"* — visible ~6s; Undo restores
-  transcript rows (and notes that already-removed audio files are not restored).
+  - includes meetings: *"Delete N items, including M meetings? Audio and AI
+    summaries can't be recovered."*
 
 ## Phases
 1. **ViewModel selection + batch delete + tests** — port the Dictation API onto
-   `TranscriptionLibraryViewModel`; unit tests for select-all-visible (respects
-   filter/search), batch success/partial-failure result, mode teardown.
-2. **Grid + list UI** — selection overlays/checkboxes, action bar; both surfaces.
+   `TranscriptionLibraryViewModel`; off-main-thread (`Task.detached`) batch
+   delete; unit tests for select-all-visible (respects filter/search), batch
+   success/partial-failure result, mode teardown.
+2. **Grid + list UI** — selection overlays/checkboxes, action bar (with VoiceOver
+   labels); both surfaces.
 3. **Keyboard** — ⌘A / Delete / Esc; dev-app verification of focus + that Delete
    doesn't fire when not in select mode.
-4. **Undo toast** — snapshot + restore; honest copy about detached audio.
-5. **Docs** — `spec/04-ui-patterns.md` (Library multi-select), `spec/02-features.md`,
+4. **Docs** — `spec/04-ui-patterns.md` (Library multi-select), `spec/02-features.md`,
    register REQ-LIB-002.
 
 ## Testing
 - ViewModel unit tests: selection toggling, `selectAllVisible` excludes
   filtered-out/searched-out rows, batch delete returns correct succeeded/failed,
-  undo restores rows, mode teardown clears state.
+  off-main-thread execution, mode teardown clears state.
 - Asset-cleanup parity test: a batch delete invokes the same cleanup as the
   single-item path (no orphaned files; meeting folders removed).
 - `swift test` before merge. (SwiftUI views themselves untested per repo policy —
   logic lives in the ViewModel.)
 
 ## Open questions (resolve in Phase 1)
-1. **Undo depth:** single-level "undo last bulk delete" (proposed) vs. none.
-   Single-level is cheap and a big safety win; confirm it's worth the snapshot
-   bookkeeping or defer to a future trash feature.
-2. **Favorites in Select All:** include favorited rows in `⌘A` (simplest) vs.
+1. **Favorites in Select All:** include favorited rows in `⌘A` (simplest) vs.
    warn/exclude. Lean: include, but the confirmation count makes scale visible.
-3. **Toolbar "Select" vs. context-menu-only entry:** ship both for discoverability,
+2. **Toolbar "Select" vs. context-menu-only entry:** ship both for discoverability,
    or context-menu-only to match Dictation exactly? Lean: both.
+
+(Resolved during PR #556 review: no undo/trash in v1 — a row-only undo would lose
+cascade-deleted AI summaries/chats; rely on a precise confirmation. The batch
+delete runs off the main thread.)
 
 ## Docs to update on completion
 `spec/04-ui-patterns.md`, `spec/02-features.md`, `spec/README.md`,

--- a/plans/active/2026-06-18-meeting-audio-retention-ndays.md
+++ b/plans/active/2026-06-18-meeting-audio-retention-ndays.md
@@ -46,10 +46,11 @@ which *only ever touch the audio file and always keep the transcript*.
   stats; a one-time confirmation when the user first enables an auto-delete
   policy (because it deletes user data on a schedule).
 - CLI `config` key (`meeting-audio-retention`) for headless parity.
-- Telemetry: a `settingChanged` case + a privacy-safe sweep-result count
-  (**both new `TelemetryEventName` cases must be mirrored in the website
-  `ALLOWED_EVENTS` allowlist in the same change, or the Worker drops the whole
-  batch** — two-repo gotcha).
+- Telemetry: reuse the existing `settingChanged` event for the preference
+  change, adding only a new `TelemetrySettingName` value if needed. If the sweep
+  emits a new privacy-safe result event (for example `{swept: Int}`), that new
+  `TelemetryEventName` must be mirrored in the website `ALLOWED_EVENTS`
+  allowlist in the same change, or the Worker drops the batch.
 
 ### Out of scope (deferred, by owner decision)
 - **True transcript-only / stream-and-discard mode** (never assemble a full
@@ -70,12 +71,16 @@ which *only ever touch the audio file and always keep the transcript*.
 - **Never delete outside managed roots.** Reuse
   `TranscriptionAssetCleanup.isKnownMeetingFolder` guard — refuse any path not
   under the managed meeting-recordings roots.
-- **Recovered meetings are exempt** from automatic retention (same exemption the
-  immediate-delete path already honors via `applyMeetingRetention: false`); the
-  user made an explicit recover/discard choice for those.
+- **Recovery input is protected; recovered meetings are not permanent
+  exceptions.** Any folder with a `recording.lock` is excluded from automatic
+  retention, and the recovery flow may opt out of immediate deletion while it is
+  turning crash audio into a transcript. Once recovery has completed, the lock is
+  gone, and the row is `.completed`, the normal retention policy applies. A user
+  choosing "Recover" should not silently mean "keep this audio forever."
 - **Never delete untranscribed or in-flight audio.** The sweep only detaches audio
-  for completed meeting transcripts. Skip any meeting whose row is still
-  non-completed / transcript-empty, and skip any session folder that still has a
+  for rows whose status is `.completed`. Empty completed transcripts are still
+  completed; do not keep their audio forever just because the meeting was silent
+  or STT produced no text. Skip any session folder that still has a
   `recording.lock` in *any* state (`recording` or `awaitingTranscription`),
   regardless of whether the PID is still alive. A dead-PID `awaitingTranscription`
   lock is crash-recovery input, not sweepable storage.
@@ -91,32 +96,56 @@ which *only ever touch the audio file and always keep the transcript*.
   `applyMeetingAudioRetentionIfNeeded(_:)` runs right after transcription
   (called ~766/772); when `!shouldSaveMeetingAudio` it deletes audio now.
   The `applyMeetingRetention: Bool = true` param (~841/853) is how recovered
-  meetings opt out (`AppDelegate.swift:181` passes `false`).
+  meetings opt out of deletion *during recovery* (`Sources/MacParakeet/AppDelegate.swift:181`
+  passes `false`). This new plan should keep that immediate recovery opt-out but
+  let later scheduled sweeps apply once the recovered row is completed and
+  unlocked.
 - Detach (keeps transcript): `Sources/MacParakeetCore/Utilities/TranscriptionAssetCleanup.swift`
   — `detachOwnedMeetingAudio()` (~66-81) removes the folder + `updateFilePath(id, nil)`;
   `isKnownMeetingFolder()` managed-path guard (~113-126).
 - Preference plumbing: `Sources/MacParakeetCore/AppRuntimePreferences.swift`
   — `saveMeetingAudioKey` (~221) + protocol (~3-32) + `UserDefaults` impl (~210-363).
   New `meetingAudioRetention` (enum + days) follows this exact pattern.
-- Settings binding: `Sources/MacParakeetViewModels/SettingsViewModel.swift:324`
-  `Telemetry.send(.settingChanged(setting: .audioRetention))`; load in `loadSettings()`.
+- Settings binding: `Sources/MacParakeetViewModels/SettingsViewModel.swift:325`
+  currently stores the binary `saveMeetingAudio` toggle and emits
+  `.settingChanged(setting: .saveMeetingAudio)`; the tri-state setting should
+  follow this path with an exact telemetry setting name (likely
+  `.meetingAudioRetention`) and load in `loadSettings()`.
 - Storage card UI: `Sources/MacParakeet/Views/Settings/SettingsView.swift:1799`
   `storageCard` — "Keep meeting audio" toggle (~1833) is where the new control replaces/augments the toggle; stats tiles (~1841-1862); clear-all (~1943-1960).
-- Storage stats: `Sources/MacParakeetViewModels/SettingsViewModel.swift` `meetingAudioStats()` (~2444-2465) — counts + sizes per meeting folder.
-- Launch sweep hook: `Sources/MacParakeet/App/AppStartupBootstrapper.swift`
-  `bootstrapEnvironment()` (~1-34) already runs detached launch cleanup
-  (`dictationRepo.deleteEmpty()`, `clearMissingAudioPaths()`); add the meeting
-  retention sweep right after.
+- Storage stats: `Sources/MacParakeetViewModels/SettingsViewModel.swift`
+  `meetingAudioStats()` (~1430-1450) counts meeting folders and sizes the
+  meeting-recordings directory.
+- Launch ordering: `Sources/MacParakeet/App/AppStartupBootstrapper.swift`
+  `bootstrapEnvironment()` (~1-34) only has the database manager and dictation
+  launch cleanup; do **not** add the meeting retention sweep directly there.
+  `Sources/MacParakeet/AppDelegate.swift:538` schedules launch recovery later via
+  `MeetingRecoveryCoordinator.scheduleLaunchRecoveryScanIfReady(...)`, and that
+  scan is asynchronous. The retention sweep needs an app-layer coordinator after
+  `AppEnvironment` setup, sequenced after the launch recovery scan task when one
+  is scheduled.
 - Age anchor: `Sources/MacParakeetCore/Models/Transcription.swift` `createdAt`
   (~19, indexed `idx_transcriptions_created_at` in `DatabaseManager.swift:132`).
   **No `audioSavedAt` column** — see Open Questions for the anchor decision.
-- Active-recording guard precedent: `clear-meeting-audio` already refuses while a
+- Active-recording guard precedent: manual `clear-meeting-audio` refuses while a
   live `recording.lock` exists (`MeetingRecordingLockFileStore`, #508 message).
+  Scheduled retention is stricter than the manual destructive command: it must
+  skip *any* lock, live or dead, because dead `awaitingTranscription` locks feed
+  recovery.
 - Cross-plan recovery guard: `MeetingRecordingLockFileStore` models both
   `.recording` and `.awaitingTranscription` states. The back-to-back plan creates
   pre-transcription Library rows and `awaitingTranscription` locks, so retention
   cannot use PID liveness alone as the in-flight signal.
-- CLI config: `Sources/CLI/Commands/ConfigCommand.swift` (`save-meeting-audio` ~66; add `meeting-audio-retention`).
+- Lock API: `MeetingRecordingLockFileStoring.read(folderURL:)` already answers
+  "is there a lock in this exact folder?" Use that (or a tiny wrapper over it)
+  for retention; do not use `discoverActiveSessions(...)`, which filters by PID
+  liveness.
+- Repository API: `TranscriptionRepositoryProtocol` has no purpose-built
+  retention-candidate query today. Add one rather than full-scanning the Library:
+  filter `sourceType == .meeting`, `filePath != nil`, `status == .completed`,
+  and `createdAt <= cutoff` in SQL, then let the sweep runner check lock/managed
+  path state.
+- CLI config: `Sources/CLI/Commands/ConfigCommand.swift` (`save-meeting-audio` ~66; add `meeting-audio-retention` while keeping `save-meeting-audio` as a documented legacy alias).
 
 ## Design
 
@@ -128,14 +157,18 @@ public enum MeetingAudioRetention: Equatable, Sendable {
     case deleteImmediately           // == existing saveMeetingAudio == false behavior
 }
 ```
-- Backward-compat: derive the initial value from the existing
-  `saveMeetingAudio` bool (true -> `.keepForever`, false -> `.deleteImmediately`)
-  once on first read, then persist the richer key. **Migrate #508's legacy
-  readers (Settings + CLI `save-meeting-audio`) to the tri-state in the same PR**
-  rather than faking the bool — `deleteAfterDays(N)` has no honest boolean
-  (`true` would read as "keep forever" to a legacy consumer), so a sync shim
-  would silently mislead. Keep a one-way read shim only if an external consumer
-  is found that cannot be migrated. [Greptile P2]
+- Backward-compat:
+  - Derive the initial value from the existing `saveMeetingAudio` bool
+    (`true -> .keepForever`, `false -> .deleteImmediately`) once on first read,
+    then persist the richer key.
+  - Migrate Settings and app runtime callers to the tri-state in the same PR.
+    Keep `shouldSaveMeetingAudio` only as a compatibility computed view:
+    `deleteImmediately -> false`; `keepForever` and `deleteAfterDays` -> true.
+  - Keep CLI `config get/set save-meeting-audio` as a documented legacy alias for
+    at least one CLI release. Setting it to `off` maps to `.deleteImmediately`;
+    setting it to `on` maps to `.keepForever`; exact N-day state is exposed only
+    through `meeting-audio-retention`. Add this to `Sources/CLI/CHANGELOG.md`.
+    [Greptile P2]
 - N choices: a small, opinionated stepper/menu — **7 / 14 / 30 / 90 days**
   (matches the mental model in #478; avoids a free-form field). Default N when
   switching into the mode: **30**.
@@ -146,11 +179,10 @@ public enum MeetingAudioRetention: Equatable, Sendable {
 public enum MeetingAudioRetentionPolicy {
     public struct Candidate: Sendable, Equatable {
         public var id: UUID
-        public var hasAudioOnDisk: Bool        // filePath != nil
-        public var hasCompletedTranscript: Bool // status == .completed + transcript text present
-        public var ageReferenceDate: Date      // createdAt (see Open Questions)
-        public var isRecovered: Bool
-        public var hasRecoveryLock: Bool       // any recording.lock, live or dead PID
+        public var hasAudioOnDisk: Bool   // filePath != nil
+        public var isCompleted: Bool      // status == .completed; text may be empty
+        public var ageReferenceDate: Date // createdAt (see Open Questions)
+        public var hasRecoveryLock: Bool  // any recording.lock, live or dead PID
     }
     /// Returns the ids whose AUDIO should be detached now. Pure; no I/O.
     public static func sweep(_ candidates: [Candidate],
@@ -158,8 +190,8 @@ public enum MeetingAudioRetentionPolicy {
                              now: Date) -> [UUID]
 }
 ```
-Rules: skip `!hasAudioOnDisk`, `!hasCompletedTranscript`, `isRecovered`,
-`hasRecoveryLock`; `.keepForever` -> []; `.deleteAfterDays(n)` include where
+Rules: skip `!hasAudioOnDisk`, `!isCompleted`, or `hasRecoveryLock`;
+`.keepForever` -> []; `.deleteAfterDays(n)` include where
 `now - ageReferenceDate > n days`;
 **`.deleteImmediately` is treated as `.deleteAfterDays(0)` by the sweep** so that
 switching *into* delete-immediately also reclaims already-transcribed audio. The
@@ -168,16 +200,23 @@ this the sweep would return `[]` for that mode and a privacy-motivated user woul
 be left with a library of audio they believe is gone. [Greptile P1]
 
 ### Sweep runner (app layer)
-A small `@MainActor`/service shim invoked from `AppStartupBootstrapper`:
-1. Run only after launch crash-recovery has scanned/re-enqueued recoverable
-   sessions. If ordering changes later, the policy is still conservative because
-   any remaining `recording.lock` excludes the candidate.
-2. Load meeting transcriptions + transcript completion + lock/recovery status.
+A small app-layer `MeetingAudioRetentionSweepCoordinator`, owned after
+`AppEnvironment` is available:
+1. At launch, schedule the recovery scan first. Run the retention sweep after
+   that scan task completes, or immediately if no launch recovery scan is
+   scheduled. If the user chooses "Later" in the recovery dialog, the lock
+   remains and still excludes the candidate.
+2. On daily foreground/wake checks, run directly if the cadence gate allows it;
+   lock and completion guards remain the safety boundary.
+3. Load meeting transcriptions + completion + lock status.
    Lock status is "any lock exists", not "PID is alive": dead-PID
-   `awaitingTranscription` sessions belong to recovery.
-3. Call the pure policy.
-4. For each id, `TranscriptionAssetCleanup.detachOwnedMeetingAudio()` (guarded).
-5. Emit one privacy-safe telemetry count (`{swept: Int}`), log a single line.
+   `awaitingTranscription` sessions belong to recovery. Use `read(folderURL:)`
+   against the meeting folder or an equivalent helper, not
+   `discoverActiveSessions(...)`.
+4. Call the pure policy.
+5. For each id, `TranscriptionAssetCleanup.detachOwnedMeetingAudio()` (guarded).
+6. Emit one privacy-safe telemetry count (`{swept: Int}`) if adding the paired
+   website allowlist entry in the same change; otherwise log locally only.
 
 **Cadence (not launch-only):** MacParakeet is a persistent menu-bar app that can
 run for weeks, so a once-per-launch sweep could effectively never fire. Run it at
@@ -199,48 +238,72 @@ Replace the bare "Keep meeting audio" toggle with a labeled control:
 
 ## Phases
 1. **Preference + migration** — add `MeetingAudioRetention` to
-   `AppRuntimePreferences` (+ derive from `saveMeetingAudio`, keep in sync),
-   `SettingsViewModel` binding + telemetry case, `AppRuntimePreferencesTests`.
+   `AppRuntimePreferences` (+ derive from `saveMeetingAudio`, keep a legacy
+   computed bool view), `SettingsViewModel` binding + telemetry setting name,
+   `AppRuntimePreferencesTests`.
 2. **Pure policy + tests** — `MeetingAudioRetentionPolicy` with exhaustive
    table tests (boundaries at exactly N days, `deleteImmediately` ==
-   `deleteAfterDays(0)`, non-completed/no-transcript skip, recovered skip,
-   any-recovery-lock skip, no-audio skip).
-3. **Sweep runner + launch hook** — wire into `AppStartupBootstrapper`; integration
+   `deleteAfterDays(0)`, non-completed skip, empty-completed eligible,
+   recovered-completed-without-lock eligible, any-recovery-lock skip,
+   no-audio skip).
+3. **Repository + lock plumbing** — add the retention-candidate query, use
+   folder-local lock existence (`read(folderURL:)` or a wrapper), and cover both
+   live and dead `recording` / `awaitingTranscription` locks.
+4. **Sweep runner + app hook** — wire a coordinator after `AppEnvironment` setup;
    test against an in-memory repo + temp folders proving transcript survives and
-   only eligible audio is detached. Launch wiring must run after crash-recovery
-   scanning/re-enqueue, and tests must plant a dead-PID `awaitingTranscription`
-   lock to prove untranscribed audio is not swept.
-4. **Settings UI + first-enable confirmation** — Storage card control; verify in dev app.
-5. **CLI parity** — `config get/set meeting-audio-retention`; `ConfigCommandTests`; `Sources/CLI/CHANGELOG.md`.
-6. **Docs** — `spec/05-audio-pipeline.md` retention section, `spec/README.md`/`02-features.md` progress, register REQ-MEET-019.
+   only eligible audio is detached. Launch wiring must run after the launch
+   recovery scan task when one is scheduled, and tests must plant a dead-PID
+   `awaitingTranscription` lock to prove untranscribed audio is not swept.
+5. **Settings UI + first-enable confirmation** — Storage card control; verify in dev app.
+6. **CLI parity** — `config get/set meeting-audio-retention`, legacy
+   `save-meeting-audio` alias behavior, `ConfigCommandTests`,
+   `Sources/CLI/CHANGELOG.md`.
+7. **Telemetry/docs** — if a new sweep event is emitted, update the website
+   allowlist in the same change; update `spec/05-audio-pipeline.md`,
+   `spec/README.md`/`02-features.md`, and register REQ-MEET-019.
 
 ## Testing
 - Policy unit tests (pure, deterministic): N-day boundary, keep-forever,
-  immediate behaves as `deleteAfterDays(0)`, non-completed/no-transcript skip,
-  recovered exemption, any `recording.lock` skip (`recording` and
+  immediate behaves as `deleteAfterDays(0)`, non-completed skip, empty completed
+  transcript eligible, recovered completed row eligible after lock removal, any
+  `recording.lock` skip (`recording` and
   `awaitingTranscription`, live and dead PID), no-audio skip.
 - Repo/integration: detach keeps the transcription row and nulls `filePath`;
-  managed-path guard refuses a planted out-of-root path.
+  managed-path guard refuses a planted out-of-root path; retention candidate
+  query does not return file/YouTube rows, nil `filePath` rows, non-completed
+  rows, or rows newer than the cutoff.
 - Recovery ordering: a launch scenario with a dead-PID `awaitingTranscription`
-  lock and a pre-transcription Library row must re-enqueue/recover before the
-  retention sweep, or be skipped by the lock/transcript guards if recovery has
-  not run yet.
+  lock and a pre-transcription Library row must run recovery discovery before
+  the retention sweep, or be skipped by the lock/status guards if the user defers
+  recovery.
 - ViewModel: enabling a mode persists + emits telemetry; first-enable confirmation gating.
-- CLI: round-trip `config set/get meeting-audio-retention`.
+- CLI: round-trip `config set/get meeting-audio-retention`; legacy
+  `save-meeting-audio` maps `off -> deleteImmediately`, `on -> keepForever`,
+  and is documented as an alias.
+- Telemetry: if adding a new sweep event, assert it is present in the app event
+  catalog and website allowlist.
 - `swift test` before merge.
 
 ## Open questions (resolve in Phase 1)
 1. **Age anchor:** `createdAt` (record creation, already indexed) vs. true
    audio-finalized time vs. on-disk mtime. `createdAt` is within minutes of the
-   recording and needs no migration — **recommended**; only add an `audioSavedAt`
-   column if drift proves to matter. Decide before Phase 2.
+   recording in the current lifecycle and needs no migration — **recommended**.
+   Because policy only considers `.completed` rows, queued/back-to-back rows are
+   protected while processing. Only add `audioSavedAt` or switch to `updatedAt`
+   if long queued transcription delays make the user-visible retention window
+   materially wrong. Decide before Phase 2.
 
 (Resolved during PR #556 review: `deleteImmediately` is swept as
 `deleteAfterDays(0)` so a mode switch reclaims existing audio; legacy
-`saveMeetingAudio` readers are migrated to the tri-state in-PR; the sweep runs at
-launch + a gated daily/foreground check rather than launch-only; retention skips
-non-completed/untranscribed meetings and any session with a recovery lock so it
-cannot delete queued back-to-back audio before crash recovery re-enqueues it.)
+`saveMeetingAudio` readers are migrated to the tri-state in-PR with a legacy CLI
+alias; the sweep runs at launch + a gated daily/foreground check rather than
+launch-only; retention skips non-completed/untranscribed meetings and any session
+with a recovery lock so it cannot delete queued back-to-back audio before crash
+recovery re-enqueues it. Follow-up review clarified that empty completed
+transcripts are eligible, recovered meetings are not permanent exemptions after
+lock removal, startup wiring belongs after `AppEnvironment`/recovery scan rather
+than inside `AppStartupBootstrapper`, and only genuinely new telemetry events
+need website allowlist updates.)
 
 ## Docs to update on completion
 `spec/05-audio-pipeline.md`, `spec/02-features.md`, `spec/README.md`,

--- a/plans/active/2026-06-18-meeting-audio-retention-ndays.md
+++ b/plans/active/2026-06-18-meeting-audio-retention-ndays.md
@@ -1,0 +1,206 @@
+# Meeting Audio Auto-Delete After N Days
+
+**Status:** ACTIVE PLAN — not started
+**Date:** 2026-06-18
+**ADRs:** ADR-014/015/016 (meeting recording, concurrency, scheduler), ADR-019 (crash-resilient recording — recovered-meeting handling)
+**Requirement:** REQ-MEET-019 (proposed — register in `spec/kernel/requirements.yaml` at implementation kickoff; extends the #508 retention controls)
+**Issues:** #547, #462, #478
+**Decision (owner, 2026-06-18):** N-day + immediate-delete only. **No** true transcript-only / stream-and-discard mode in this plan (deferred). **No** size-based "max disk, delete oldest" eviction (unpredictable; out of scope).
+
+## What this plan closes out
+
+PR #508 (`Add meeting audio retention controls`, shipped) added the binary
+`saveMeetingAudio` toggle (default on), per-meeting transcript-safe audio
+delete/detach, Settings storage stats + clear-all, and the CLI
+`history delete-meeting-audio` / `clear-meeting-audio` commands. What it did
+*not* add is the most-requested piece: **time-based cleanup** — "keep the audio
+for a while, then delete it automatically so my disk doesn't fill up."
+
+Three issues converge on this:
+- **#462** (andreagrandi): "possibility to automatically delete the audio once
+  transcribed" + "see how much space they take."
+- **#478** (andreagrandi): "with 2-3 meetings/day the audio size could grow very
+  fast: an option to automatically remove the audio files after x days. Once I
+  have the full transcription, I don't need the original audio anymore."
+- **#547**: privacy-driven — does not want a persistent audio file. The
+  *immediate-delete* path (already in #508 via `saveMeetingAudio = false`) is
+  the in-scope answer for this user; the stricter never-write-to-disk mode is
+  explicitly deferred (see Out of scope).
+
+Net new surface: a **retention policy** with three user-facing choices —
+**Keep forever** / **Delete after N days** / **Delete immediately after
+transcription** — plus a once-per-launch background sweep, all of which *only
+ever touch the audio file and always keep the transcript*.
+
+## Scope boundaries
+
+### In scope
+- A `meetingAudioRetention` preference modeling: keep-forever (default),
+  delete-after-N-days (N configurable), delete-immediately.
+- A pure, testable retention policy (given a list of meetings + clock + config,
+  return the set whose audio is eligible for deletion).
+- A once-per-app-launch background sweep that detaches audio (keeps transcript)
+  for eligible meetings, reusing the existing `TranscriptionAssetCleanup`
+  managed-path-guarded detach.
+- Settings Storage card UI: the three-way retention control + the existing
+  stats; a one-time confirmation when the user first enables an auto-delete
+  policy (because it deletes user data on a schedule).
+- CLI `config` key (`meeting-audio-retention`) for headless parity.
+- Telemetry: a `settingChanged` case + a privacy-safe sweep-result count.
+
+### Out of scope (deferred, by owner decision)
+- **True transcript-only / stream-and-discard mode** (never assemble a full
+  audio file on disk). This is a real lift in the capture pipeline and is the
+  only thing that fully satisfies a "contractually may not record" user beyond
+  what immediate-delete gives. Tracked as a follow-up, not built here.
+- **Size-cap eviction** ("max N GB, delete oldest"). Predictable time-based
+  deletion is safer than size-based eviction; explicitly dropped.
+- **Configurable transcript export location / Obsidian** (#462/#478/#460) —
+  belongs to the separate Obsidian-integration scope, not retention.
+- Any change to dictation-audio or downloaded-media retention (separate toggles
+  already exist in the Storage card).
+
+### Invariants
+- **Transcript is sacrosanct.** The sweep deletes *audio only*, via the existing
+  detach path that nulls `filePath` and keeps the Library row, summary, and
+  transcript. Never deletes a transcription row.
+- **Never delete outside managed roots.** Reuse
+  `TranscriptionAssetCleanup.isKnownMeetingFolder` guard — refuse any path not
+  under the managed meeting-recordings roots.
+- **Recovered meetings are exempt** from automatic retention (same exemption the
+  immediate-delete path already honors via `applyMeetingRetention: false`); the
+  user made an explicit recover/discard choice for those.
+- **Never delete the audio of an active or in-flight recording.** Skip any
+  meeting whose session still holds a live `recording.lock` (PID alive).
+- **No surprise.** First time an auto-delete policy is enabled, confirm with copy
+  that states transcripts are kept and audio older than N days will be removed.
+- Idle-CPU hygiene: the sweep is a one-shot detached task at launch, not a
+  resident timer.
+
+## Verified current state (file:line)
+
+- Immediate-delete path: `Sources/MacParakeetViewModels/TranscriptionViewModel.swift:789`
+  `applyMeetingAudioRetentionIfNeeded(_:)` runs right after transcription
+  (called ~766/772); when `!shouldSaveMeetingAudio` it deletes audio now.
+  The `applyMeetingRetention: Bool = true` param (~841/853) is how recovered
+  meetings opt out (`AppDelegate.swift:181` passes `false`).
+- Detach (keeps transcript): `Sources/MacParakeetCore/Utilities/TranscriptionAssetCleanup.swift`
+  — `detachOwnedMeetingAudio()` (~66-81) removes the folder + `updateFilePath(id, nil)`;
+  `isKnownMeetingFolder()` managed-path guard (~113-126).
+- Preference plumbing: `Sources/MacParakeetCore/AppRuntimePreferences.swift`
+  — `saveMeetingAudioKey` (~221) + protocol (~3-32) + `UserDefaults` impl (~210-363).
+  New `meetingAudioRetention` (enum + days) follows this exact pattern.
+- Settings binding: `Sources/MacParakeetViewModels/SettingsViewModel.swift:324`
+  `Telemetry.send(.settingChanged(setting: .audioRetention))`; load in `loadSettings()`.
+- Storage card UI: `Sources/MacParakeet/Views/Settings/SettingsView.swift:1799`
+  `storageCard` — "Keep meeting audio" toggle (~1833) is where the new control replaces/augments the toggle; stats tiles (~1841-1862); clear-all (~1943-1960).
+- Storage stats: `Sources/MacParakeetViewModels/SettingsViewModel.swift` `meetingAudioStats()` (~2444-2465) — counts + sizes per meeting folder.
+- Launch sweep hook: `Sources/MacParakeet/App/AppStartupBootstrapper.swift`
+  `bootstrapEnvironment()` (~1-34) already runs detached launch cleanup
+  (`dictationRepo.deleteEmpty()`, `clearMissingAudioPaths()`); add the meeting
+  retention sweep right after.
+- Age anchor: `Sources/MacParakeetCore/Models/Transcription.swift` `createdAt`
+  (~19, indexed `idx_transcriptions_created_at` in `DatabaseManager.swift:132`).
+  **No `audioSavedAt` column** — see Open Questions for the anchor decision.
+- Active-recording guard precedent: `clear-meeting-audio` already refuses while a
+  live `recording.lock` exists (`MeetingRecordingLockFileStore`, #508 message).
+- CLI config: `Sources/CLI/Commands/ConfigCommand.swift` (`save-meeting-audio` ~66; add `meeting-audio-retention`).
+
+## Design
+
+### Preference model (`AppRuntimePreferences`)
+```swift
+public enum MeetingAudioRetention: Equatable, Sendable {
+    case keepForever                 // default — current behavior when saveMeetingAudio == true
+    case deleteAfterDays(Int)        // N in a bounded set, see below
+    case deleteImmediately           // == existing saveMeetingAudio == false behavior
+}
+```
+- Backward-compat: derive the initial value from the existing
+  `saveMeetingAudio` bool (true -> `.keepForever`, false -> `.deleteImmediately`)
+  on first read, then persist the richer key. Keep `saveMeetingAudio` writing in
+  sync so #508's CLI/Settings reads don't regress (or migrate readers — decide
+  in Phase 1).
+- N choices: a small, opinionated stepper/menu — **7 / 14 / 30 / 90 days**
+  (matches the mental model in #478; avoids a free-form field). Default N when
+  switching into the mode: **30**.
+
+### Pure policy (Core, fully unit-tested)
+`Sources/MacParakeetCore/Services/MeetingRecording/MeetingAudioRetentionPolicy.swift`
+```swift
+public enum MeetingAudioRetentionPolicy {
+    public struct Candidate: Sendable, Equatable {
+        public var id: UUID
+        public var hasAudioOnDisk: Bool        // filePath != nil
+        public var ageReferenceDate: Date      // createdAt (see Open Questions)
+        public var isRecovered: Bool
+        public var hasLiveLock: Bool
+    }
+    /// Returns the ids whose AUDIO should be detached now. Pure; no I/O.
+    public static func sweep(_ candidates: [Candidate],
+                             config: MeetingAudioRetention,
+                             now: Date) -> [UUID]
+}
+```
+Rules: skip `!hasAudioOnDisk`, `isRecovered`, `hasLiveLock`; for
+`.deleteAfterDays(n)` include where `now - ageReferenceDate > n days`;
+`.keepForever` -> []; `.deleteImmediately` is handled by the existing
+post-transcription path, not the sweep.
+
+### Sweep runner (app layer)
+A small `@MainActor`/service shim invoked from `AppStartupBootstrapper`:
+1. Load meeting transcriptions + their lock/recovery status.
+2. Call the pure policy.
+3. For each id, `TranscriptionAssetCleanup.detachOwnedMeetingAudio()` (guarded).
+4. Emit one privacy-safe telemetry count (`{swept: Int}`), log a single line.
+
+### UI (Storage card)
+Replace the bare "Keep meeting audio" toggle with a labeled control:
+- A segmented/menu picker: **Keep forever · Delete after [30 ▾] days · Delete
+  after transcription**.
+- The days stepper only enabled in the middle mode.
+- Helper caption: *"Transcripts are always kept. Only the audio recording is
+  removed."*
+- On first transition into an auto-delete mode, a confirmation sheet/alert:
+  *"Delete meeting audio older than 30 days? Transcripts, summaries, and notes
+  are always kept — only the audio files are removed. This runs automatically."*
+- Keep the existing stats tiles + manual "Clear meeting audio" as-is.
+
+## Phases
+1. **Preference + migration** — add `MeetingAudioRetention` to
+   `AppRuntimePreferences` (+ derive from `saveMeetingAudio`, keep in sync),
+   `SettingsViewModel` binding + telemetry case, `AppRuntimePreferencesTests`.
+2. **Pure policy + tests** — `MeetingAudioRetentionPolicy` with exhaustive
+   table tests (boundaries at exactly N days, recovered/locked/no-audio skips).
+3. **Sweep runner + launch hook** — wire into `AppStartupBootstrapper`; integration
+   test against an in-memory repo + temp folders proving transcript survives and
+   only eligible audio is detached.
+4. **Settings UI + first-enable confirmation** — Storage card control; verify in dev app.
+5. **CLI parity** — `config get/set meeting-audio-retention`; `ConfigCommandTests`; `Sources/CLI/CHANGELOG.md`.
+6. **Docs** — `spec/05-audio-pipeline.md` retention section, `spec/README.md`/`02-features.md` progress, register REQ-MEET-019.
+
+## Testing
+- Policy unit tests (pure, deterministic): N-day boundary, keep-forever,
+  immediate (no-op for sweep), recovered exemption, live-lock skip, no-audio skip.
+- Repo/integration: detach keeps the transcription row and nulls `filePath`;
+  managed-path guard refuses a planted out-of-root path.
+- ViewModel: enabling a mode persists + emits telemetry; first-enable confirmation gating.
+- CLI: round-trip `config set/get meeting-audio-retention`.
+- `swift test` before merge.
+
+## Open questions (resolve in Phase 1)
+1. **Age anchor:** `createdAt` (record creation, already indexed) vs. true
+   audio-finalized time vs. on-disk mtime. `createdAt` is within minutes of the
+   recording and needs no migration — **recommended**; only add an `audioSavedAt`
+   column if drift proves to matter. Decide before Phase 2.
+2. **`saveMeetingAudio` coexistence:** keep the old bool in sync for one release
+   (safer for #508's CLI/readers) vs. migrate all readers to the new enum now.
+   Lean: keep in sync this release, migrate later.
+3. **Sweep cadence:** once-per-launch is simplest and proposed. A long-running
+   app could go many days without a sweep — acceptable for v1? (Add a
+   foreground-return check only if field data shows it matters.)
+
+## Docs to update on completion
+`spec/05-audio-pipeline.md`, `spec/02-features.md`, `spec/README.md`,
+`Sources/CLI/CHANGELOG.md`, `spec/kernel/requirements.yaml` (REQ-MEET-019),
+plus issue replies on #547/#462/#478.

--- a/plans/active/2026-06-18-meeting-audio-retention-ndays.md
+++ b/plans/active/2026-06-18-meeting-audio-retention-ndays.md
@@ -73,8 +73,12 @@ which *only ever touch the audio file and always keep the transcript*.
 - **Recovered meetings are exempt** from automatic retention (same exemption the
   immediate-delete path already honors via `applyMeetingRetention: false`); the
   user made an explicit recover/discard choice for those.
-- **Never delete the audio of an active or in-flight recording.** Skip any
-  meeting whose session still holds a live `recording.lock` (PID alive).
+- **Never delete untranscribed or in-flight audio.** The sweep only detaches audio
+  for completed meeting transcripts. Skip any meeting whose row is still
+  non-completed / transcript-empty, and skip any session folder that still has a
+  `recording.lock` in *any* state (`recording` or `awaitingTranscription`),
+  regardless of whether the PID is still alive. A dead-PID `awaitingTranscription`
+  lock is crash-recovery input, not sweepable storage.
 - **No surprise.** First time an auto-delete policy is enabled, confirm with copy
   that states transcripts are kept and audio older than N days will be removed.
 - Idle-CPU hygiene: the sweep runs at launch + a gated daily/foreground check
@@ -108,6 +112,10 @@ which *only ever touch the audio file and always keep the transcript*.
   **No `audioSavedAt` column** — see Open Questions for the anchor decision.
 - Active-recording guard precedent: `clear-meeting-audio` already refuses while a
   live `recording.lock` exists (`MeetingRecordingLockFileStore`, #508 message).
+- Cross-plan recovery guard: `MeetingRecordingLockFileStore` models both
+  `.recording` and `.awaitingTranscription` states. The back-to-back plan creates
+  pre-transcription Library rows and `awaitingTranscription` locks, so retention
+  cannot use PID liveness alone as the in-flight signal.
 - CLI config: `Sources/CLI/Commands/ConfigCommand.swift` (`save-meeting-audio` ~66; add `meeting-audio-retention`).
 
 ## Design
@@ -139,9 +147,10 @@ public enum MeetingAudioRetentionPolicy {
     public struct Candidate: Sendable, Equatable {
         public var id: UUID
         public var hasAudioOnDisk: Bool        // filePath != nil
+        public var hasCompletedTranscript: Bool // status == .completed + transcript text present
         public var ageReferenceDate: Date      // createdAt (see Open Questions)
         public var isRecovered: Bool
-        public var hasLiveLock: Bool
+        public var hasRecoveryLock: Bool       // any recording.lock, live or dead PID
     }
     /// Returns the ids whose AUDIO should be detached now. Pure; no I/O.
     public static func sweep(_ candidates: [Candidate],
@@ -149,8 +158,9 @@ public enum MeetingAudioRetentionPolicy {
                              now: Date) -> [UUID]
 }
 ```
-Rules: skip `!hasAudioOnDisk`, `isRecovered`, `hasLiveLock`; `.keepForever` -> [];
-`.deleteAfterDays(n)` include where `now - ageReferenceDate > n days`;
+Rules: skip `!hasAudioOnDisk`, `!hasCompletedTranscript`, `isRecovered`,
+`hasRecoveryLock`; `.keepForever` -> []; `.deleteAfterDays(n)` include where
+`now - ageReferenceDate > n days`;
 **`.deleteImmediately` is treated as `.deleteAfterDays(0)` by the sweep** so that
 switching *into* delete-immediately also reclaims already-transcribed audio. The
 post-transcription hook only fires for freshly-finished recordings, so without
@@ -159,10 +169,15 @@ be left with a library of audio they believe is gone. [Greptile P1]
 
 ### Sweep runner (app layer)
 A small `@MainActor`/service shim invoked from `AppStartupBootstrapper`:
-1. Load meeting transcriptions + their lock/recovery status.
-2. Call the pure policy.
-3. For each id, `TranscriptionAssetCleanup.detachOwnedMeetingAudio()` (guarded).
-4. Emit one privacy-safe telemetry count (`{swept: Int}`), log a single line.
+1. Run only after launch crash-recovery has scanned/re-enqueued recoverable
+   sessions. If ordering changes later, the policy is still conservative because
+   any remaining `recording.lock` excludes the candidate.
+2. Load meeting transcriptions + transcript completion + lock/recovery status.
+   Lock status is "any lock exists", not "PID is alive": dead-PID
+   `awaitingTranscription` sessions belong to recovery.
+3. Call the pure policy.
+4. For each id, `TranscriptionAssetCleanup.detachOwnedMeetingAudio()` (guarded).
+5. Emit one privacy-safe telemetry count (`{swept: Int}`), log a single line.
 
 **Cadence (not launch-only):** MacParakeet is a persistent menu-bar app that can
 run for weeks, so a once-per-launch sweep could effectively never fire. Run it at
@@ -187,19 +202,29 @@ Replace the bare "Keep meeting audio" toggle with a labeled control:
    `AppRuntimePreferences` (+ derive from `saveMeetingAudio`, keep in sync),
    `SettingsViewModel` binding + telemetry case, `AppRuntimePreferencesTests`.
 2. **Pure policy + tests** — `MeetingAudioRetentionPolicy` with exhaustive
-   table tests (boundaries at exactly N days, recovered/locked/no-audio skips).
+   table tests (boundaries at exactly N days, `deleteImmediately` ==
+   `deleteAfterDays(0)`, non-completed/no-transcript skip, recovered skip,
+   any-recovery-lock skip, no-audio skip).
 3. **Sweep runner + launch hook** — wire into `AppStartupBootstrapper`; integration
    test against an in-memory repo + temp folders proving transcript survives and
-   only eligible audio is detached.
+   only eligible audio is detached. Launch wiring must run after crash-recovery
+   scanning/re-enqueue, and tests must plant a dead-PID `awaitingTranscription`
+   lock to prove untranscribed audio is not swept.
 4. **Settings UI + first-enable confirmation** — Storage card control; verify in dev app.
 5. **CLI parity** — `config get/set meeting-audio-retention`; `ConfigCommandTests`; `Sources/CLI/CHANGELOG.md`.
 6. **Docs** — `spec/05-audio-pipeline.md` retention section, `spec/README.md`/`02-features.md` progress, register REQ-MEET-019.
 
 ## Testing
 - Policy unit tests (pure, deterministic): N-day boundary, keep-forever,
-  immediate (no-op for sweep), recovered exemption, live-lock skip, no-audio skip.
+  immediate behaves as `deleteAfterDays(0)`, non-completed/no-transcript skip,
+  recovered exemption, any `recording.lock` skip (`recording` and
+  `awaitingTranscription`, live and dead PID), no-audio skip.
 - Repo/integration: detach keeps the transcription row and nulls `filePath`;
   managed-path guard refuses a planted out-of-root path.
+- Recovery ordering: a launch scenario with a dead-PID `awaitingTranscription`
+  lock and a pre-transcription Library row must re-enqueue/recover before the
+  retention sweep, or be skipped by the lock/transcript guards if recovery has
+  not run yet.
 - ViewModel: enabling a mode persists + emits telemetry; first-enable confirmation gating.
 - CLI: round-trip `config set/get meeting-audio-retention`.
 - `swift test` before merge.
@@ -213,7 +238,9 @@ Replace the bare "Keep meeting audio" toggle with a labeled control:
 (Resolved during PR #556 review: `deleteImmediately` is swept as
 `deleteAfterDays(0)` so a mode switch reclaims existing audio; legacy
 `saveMeetingAudio` readers are migrated to the tri-state in-PR; the sweep runs at
-launch + a gated daily/foreground check rather than launch-only.)
+launch + a gated daily/foreground check rather than launch-only; retention skips
+non-completed/untranscribed meetings and any session with a recovery lock so it
+cannot delete queued back-to-back audio before crash recovery re-enqueues it.)
 
 ## Docs to update on completion
 `spec/05-audio-pipeline.md`, `spec/02-features.md`, `spec/README.md`,

--- a/plans/active/2026-06-18-meeting-audio-retention-ndays.md
+++ b/plans/active/2026-06-18-meeting-audio-retention-ndays.md
@@ -29,8 +29,8 @@ Three issues converge on this:
 
 Net new surface: a **retention policy** with three user-facing choices —
 **Keep forever** / **Delete after N days** / **Delete immediately after
-transcription** — plus a once-per-launch background sweep, all of which *only
-ever touch the audio file and always keep the transcript*.
+transcription** — plus a launch + gated-daily/foreground background sweep, all of
+which *only ever touch the audio file and always keep the transcript*.
 
 ## Scope boundaries
 
@@ -39,14 +39,17 @@ ever touch the audio file and always keep the transcript*.
   delete-after-N-days (N configurable), delete-immediately.
 - A pure, testable retention policy (given a list of meetings + clock + config,
   return the set whose audio is eligible for deletion).
-- A once-per-app-launch background sweep that detaches audio (keeps transcript)
-  for eligible meetings, reusing the existing `TranscriptionAssetCleanup`
+- A background sweep (launch + gated daily/foreground) that detaches audio (keeps
+  transcript) for eligible meetings, reusing the existing `TranscriptionAssetCleanup`
   managed-path-guarded detach.
 - Settings Storage card UI: the three-way retention control + the existing
   stats; a one-time confirmation when the user first enables an auto-delete
   policy (because it deletes user data on a schedule).
 - CLI `config` key (`meeting-audio-retention`) for headless parity.
-- Telemetry: a `settingChanged` case + a privacy-safe sweep-result count.
+- Telemetry: a `settingChanged` case + a privacy-safe sweep-result count
+  (**both new `TelemetryEventName` cases must be mirrored in the website
+  `ALLOWED_EVENTS` allowlist in the same change, or the Worker drops the whole
+  batch** — two-repo gotcha).
 
 ### Out of scope (deferred, by owner decision)
 - **True transcript-only / stream-and-discard mode** (never assemble a full
@@ -74,8 +77,9 @@ ever touch the audio file and always keep the transcript*.
   meeting whose session still holds a live `recording.lock` (PID alive).
 - **No surprise.** First time an auto-delete policy is enabled, confirm with copy
   that states transcripts are kept and audio older than N days will be removed.
-- Idle-CPU hygiene: the sweep is a one-shot detached task at launch, not a
-  resident timer.
+- Idle-CPU hygiene: the sweep runs at launch + a gated daily/foreground check
+  (a `lastSweptAt` timestamp prevents redundant runs); no resident
+  high-frequency timer.
 
 ## Verified current state (file:line)
 
@@ -118,9 +122,12 @@ public enum MeetingAudioRetention: Equatable, Sendable {
 ```
 - Backward-compat: derive the initial value from the existing
   `saveMeetingAudio` bool (true -> `.keepForever`, false -> `.deleteImmediately`)
-  on first read, then persist the richer key. Keep `saveMeetingAudio` writing in
-  sync so #508's CLI/Settings reads don't regress (or migrate readers — decide
-  in Phase 1).
+  once on first read, then persist the richer key. **Migrate #508's legacy
+  readers (Settings + CLI `save-meeting-audio`) to the tri-state in the same PR**
+  rather than faking the bool — `deleteAfterDays(N)` has no honest boolean
+  (`true` would read as "keep forever" to a legacy consumer), so a sync shim
+  would silently mislead. Keep a one-way read shim only if an external consumer
+  is found that cannot be migrated. [Greptile P2]
 - N choices: a small, opinionated stepper/menu — **7 / 14 / 30 / 90 days**
   (matches the mental model in #478; avoids a free-form field). Default N when
   switching into the mode: **30**.
@@ -142,10 +149,13 @@ public enum MeetingAudioRetentionPolicy {
                              now: Date) -> [UUID]
 }
 ```
-Rules: skip `!hasAudioOnDisk`, `isRecovered`, `hasLiveLock`; for
+Rules: skip `!hasAudioOnDisk`, `isRecovered`, `hasLiveLock`; `.keepForever` -> [];
 `.deleteAfterDays(n)` include where `now - ageReferenceDate > n days`;
-`.keepForever` -> []; `.deleteImmediately` is handled by the existing
-post-transcription path, not the sweep.
+**`.deleteImmediately` is treated as `.deleteAfterDays(0)` by the sweep** so that
+switching *into* delete-immediately also reclaims already-transcribed audio. The
+post-transcription hook only fires for freshly-finished recordings, so without
+this the sweep would return `[]` for that mode and a privacy-motivated user would
+be left with a library of audio they believe is gone. [Greptile P1]
 
 ### Sweep runner (app layer)
 A small `@MainActor`/service shim invoked from `AppStartupBootstrapper`:
@@ -153,6 +163,12 @@ A small `@MainActor`/service shim invoked from `AppStartupBootstrapper`:
 2. Call the pure policy.
 3. For each id, `TranscriptionAssetCleanup.detachOwnedMeetingAudio()` (guarded).
 4. Emit one privacy-safe telemetry count (`{swept: Int}`), log a single line.
+
+**Cadence (not launch-only):** MacParakeet is a persistent menu-bar app that can
+run for weeks, so a once-per-launch sweep could effectively never fire. Run it at
+launch **and** on a lightweight daily cadence — a `lastMeetingRetentionSweepAt`
+timestamp gates re-runs, checked at launch and on foreground/wake
+(`NSApplication.didBecomeActiveNotification`). No resident high-frequency timer. [Gemini]
 
 ### UI (Storage card)
 Replace the bare "Keep meeting audio" toggle with a labeled control:
@@ -193,12 +209,11 @@ Replace the bare "Keep meeting audio" toggle with a labeled control:
    audio-finalized time vs. on-disk mtime. `createdAt` is within minutes of the
    recording and needs no migration — **recommended**; only add an `audioSavedAt`
    column if drift proves to matter. Decide before Phase 2.
-2. **`saveMeetingAudio` coexistence:** keep the old bool in sync for one release
-   (safer for #508's CLI/readers) vs. migrate all readers to the new enum now.
-   Lean: keep in sync this release, migrate later.
-3. **Sweep cadence:** once-per-launch is simplest and proposed. A long-running
-   app could go many days without a sweep — acceptable for v1? (Add a
-   foreground-return check only if field data shows it matters.)
+
+(Resolved during PR #556 review: `deleteImmediately` is swept as
+`deleteAfterDays(0)` so a mode switch reclaims existing audio; legacy
+`saveMeetingAudio` readers are migrated to the tri-state in-PR; the sweep runs at
+launch + a gated daily/foreground check rather than launch-only.)
 
 ## Docs to update on completion
 `spec/05-audio-pipeline.md`, `spec/02-features.md`, `spec/README.md`,

--- a/plans/active/2026-06-18-meeting-auto-title-followups.md
+++ b/plans/active/2026-06-18-meeting-auto-title-followups.md
@@ -42,10 +42,16 @@ generator and #498's selection.
 - A **single-row "Generate title"** context-menu action on meeting rows (Library
   meetings list + meeting detail) that runs the same generator on demand.
 - A **bulk "Generate titles"** action in the Library multi-select action bar
-  (depends on `2026-06-18-library-bulk-delete.md`).
-- Behavioral rule: **automatic** path only overwrites fallback timestamp names;
-  **manual** path is an explicit user action so it regenerates whatever the
-  current title is (this is also how a user re-rolls a title they dislike).
+  (depends on `2026-06-18-library-bulk-delete.md`) that **only targets
+  fallback timestamp-named meetings in the selection** (skips calendar/custom
+  names) and runs with a **bounded concurrency cap of 3–5 in-flight LLM calls**;
+  a large cloud-key batch shows a one-line spend heads-up before starting.
+  [Gemini, Greptile P2]
+- Behavioral rule on overwrite: **automatic** and **bulk** paths only replace
+  fallback timestamp names (never clobber a calendar/custom name); the
+  **single-row** "Generate title" is an explicit per-item action, so it
+  regenerates whatever the current title is (this is also how a user re-rolls a
+  title they dislike).
 
 ### Out of scope
 - **Automatic backlog sweep** (silently titling all old meetings) — rejected;
@@ -57,9 +63,11 @@ generator and #498's selection.
 ### Invariants
 - **No silent spend.** Manual/bulk generation is explicit; automatic is gated by
   the (default-on) preference + a configured provider; no provider → no-op.
-- **Never clobber a deliberate name automatically.** Calendar event titles and
-  user renames survive the automatic path (#553 already guarantees this);
-  only the *manual* action overwrites them, by intent.
+- **Never clobber a deliberate name except by explicit single-item intent.**
+  Calendar event titles and user renames survive both the automatic path (#553
+  guarantees this) and the **bulk** path (which targets fallback names only);
+  only the **single-row** action overwrites a deliberate name, because the user
+  asked for that specific one. [Gemini]
 - **Graceful degradation.** Generation failure leaves the existing title intact;
   surfaces a quiet error on the manual path, silent on the automatic path.
 - Bulk generation reports succeeded/failed counts; one failure never aborts the batch.
@@ -108,11 +116,13 @@ generator and #498's selection.
   list + meeting detail action bar). Shows a brief in-row progress state; on
   success the row title updates in place with a gentle transition.
 - **Bulk:** a "Generate titles" button in the multi-select action bar; iterates
-  the selection (meetings only), runs generation with bounded concurrency,
-  reports `{titled, skipped, failed}`. Skips rows with no LLM configured with a
-  single explanatory note rather than N errors.
-- Manual path overwrites the current title (explicit intent); automatic path
-  retains #553's fallback-only rule.
+  the **fallback-named meetings in the selection** (skips calendar/custom names
+  and non-meetings), runs generation with a **3–5 in-flight concurrency cap**,
+  and reports `{titled, skipped, failed}`. No LLM configured → a single
+  explanatory note rather than N errors; a large cloud batch → a one-line spend
+  heads-up first.
+- **Single-row** path overwrites the current title (explicit intent); **automatic**
+  and **bulk** paths retain #553's fallback-only rule.
 
 ## Phases
 1. **Merge PR #553** — rebase/de-conflict, review, confirm defaults, merge.
@@ -145,6 +155,11 @@ generator and #498's selection.
 3. **Default-on with a cloud key = silent (tiny) spend.** #553 defaults the pref
    on. Confirm comfort, or gate default-on to local providers and prompt for cloud.
    Lean: keep default-on (spend is negligible, matches category norms like Granola).
+
+(Resolved during PR #556 review: bulk "Generate titles" targets fallback-named
+meetings only — never clobbers calendar/custom names — and caps in-flight LLM
+calls at 3–5 with a spend heads-up for large cloud batches. Single-row stays
+overwrite-anything.)
 
 ## Docs to update on completion
 `spec/02-features.md`, `spec/README.md`, `spec/kernel/requirements.yaml`

--- a/plans/active/2026-06-18-meeting-auto-title-followups.md
+++ b/plans/active/2026-06-18-meeting-auto-title-followups.md
@@ -1,0 +1,151 @@
+# Auto Meeting Titles — Merge PR #553 + Manual/Bulk "Generate Title"
+
+**Status:** ACTIVE PLAN — not started
+**Date:** 2026-06-18
+**ADRs:** ADR-011 (LLM providers), ADR-013 (Prompt Library / multi-summary), ADR-020 (memo-steered summaries — shares the post-meeting LLM path)
+**Requirement:** REQ-MEET-021 (proposed)
+**Issues:** #546
+**Decision (owner, 2026-06-18):** **Option 1.** Get the existing automatic
+title generation in (PR #553), **and** add a manual "Generate title" action so
+the *existing backlog* of timestamp-named meetings can be cleaned up — single-row
+via context menu, and as a **bulk** action riding on the Library multi-select
+substrate (`2026-06-18-library-bulk-delete.md`). No silent mass auto-rewrite of
+the backlog.
+
+## What this plan closes out
+
+#546: meetings are named "Meeting Jun 17, 2026 at 09:59", which is unsearchable —
+*"especially when there are multiple recordings in a day."* The reporter's pain is
+two-part: (a) new meetings should get a real title automatically, and (b) their
+*existing* library of timestamp names is hard to navigate.
+
+Part (a) is **already built** in **PR #553** (`feat/auto-meeting-titles`,
+`MeetingTitleGenerator`, 510 insertions, `swift test` green) — but the PR is
+**merge-conflicting with `main`** and **unreviewed**. Part (b) is the small
+follow-on this plan adds: a user-initiated "Generate title" that reuses #553's
+generator and #498's selection.
+
+## Why this is two workstreams, sequenced
+1. **Merge PR #553** (automatic titles for new meetings) — review + de-conflict +
+   confirm a few product choices. No fresh implementation.
+2. **Manual + bulk "Generate title"** (backlog cleanup) — small, depends on the
+   #498 Library multi-select substrate for the bulk path.
+
+## Scope boundaries
+
+### In scope
+- Review, conflict-resolve, and merge **PR #553**: conservative automatic title
+  generation after a meeting finishes transcribing — only replaces timestamp-style
+  fallback names, preserves calendar/custom names, gated on a configured LLM +
+  the default-on `auto-meeting-titles` preference, rejects generic/date-like
+  output, falls back silently.
+- A **single-row "Generate title"** context-menu action on meeting rows (Library
+  meetings list + meeting detail) that runs the same generator on demand.
+- A **bulk "Generate titles"** action in the Library multi-select action bar
+  (depends on `2026-06-18-library-bulk-delete.md`).
+- Behavioral rule: **automatic** path only overwrites fallback timestamp names;
+  **manual** path is an explicit user action so it regenerates whatever the
+  current title is (this is also how a user re-rolls a title they dislike).
+
+### Out of scope
+- **Automatic backlog sweep** (silently titling all old meetings) — rejected;
+  cloud cost + surprise. Backlog is cleaned only by user-initiated manual/bulk.
+- New title-generation logic — reuse `MeetingTitleGenerator` from #553 verbatim.
+- Titling non-meeting items (files/YouTube already derive titles from content via
+  a different path).
+
+### Invariants
+- **No silent spend.** Manual/bulk generation is explicit; automatic is gated by
+  the (default-on) preference + a configured provider; no provider → no-op.
+- **Never clobber a deliberate name automatically.** Calendar event titles and
+  user renames survive the automatic path (#553 already guarantees this);
+  only the *manual* action overwrites them, by intent.
+- **Graceful degradation.** Generation failure leaves the existing title intact;
+  surfaces a quiet error on the manual path, silent on the automatic path.
+- Bulk generation reports succeeded/failed counts; one failure never aborts the batch.
+
+## Verified current state (file:line)
+
+- PR #553 (`feat/auto-meeting-titles`): open, **`mergeable: CONFLICTING`**,
+  not draft, `swift-test` SUCCESS, no review yet. Adds
+  `Sources/MacParakeetCore/Services/MeetingRecording/MeetingTitleGenerator.swift`
+  (~148 lines), an `auto-meeting-titles` pref (AI Settings + settings search +
+  `UserDefaultsAppRuntimePreferences` + `macparakeet-cli config`), and a
+  finalize-time integration call. Title gate: replaces only "Meeting" / "Meeting
+  <date>" fallback patterns; ≥12-word context gate; 2–8 word output; rejects
+  generic/multiline/>70-char/date-like/`NO_TITLE`.
+- Default title source (on `main`):
+  `Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift`
+  — `makeDisplayName(for:)` (~1517-1523) → "Meeting <date> at <time>"; stored in
+  `Transcription.fileName`.
+- Rename path: `Sources/MacParakeetViewModels/TranscriptionViewModel.swift`
+  — `renameCurrentTranscription(to:)` (~1153-1170) updates `fileName`
+  (+ `derivedTitle`) and persists `updateFileName(id:fileName:)`.
+- LLM call path: `Sources/MacParakeetCore/Services/LLM/LLMService.swift`
+  — `generatePromptResult(transcript:systemPrompt:)` (~6); provider presence is
+  the "configured" check (service is nil when unconfigured).
+- Post-meeting auto-prompt pipeline (where automatic title-gen runs alongside):
+  `PromptResultsViewModel.autoGeneratePromptResults()` (~347-377) +
+  `TranscriptionService.finalize()` (~1559-1575).
+- Bulk substrate dependency: `2026-06-18-library-bulk-delete.md` adds the Library
+  multi-select on `TranscriptionLibraryViewModel`.
+
+## Design
+
+### Workstream 1 — merge PR #553
+- Rebase `feat/auto-meeting-titles` on latest `origin/main`, resolve conflicts
+  (likely in `AppRuntimePreferences`, settings views, settings search, CLI config —
+  all surfaces other recent PRs also touch).
+- Review against the open questions below; adjust if owner changes a default.
+- Greptile LGTM + `swift test` green → merge.
+
+### Workstream 2 — manual + bulk "Generate title"
+- Extract the generator trigger into a ViewModel method usable outside the
+  finalize path, e.g. `generateTitle(for: Transcription) async -> Result`, calling
+  the same `MeetingTitleGenerator` + `LLMService` and persisting via the existing
+  `updateFileName` path.
+- **Single-row:** context-menu "Generate title" on meeting rows (Library meetings
+  list + meeting detail action bar). Shows a brief in-row progress state; on
+  success the row title updates in place with a gentle transition.
+- **Bulk:** a "Generate titles" button in the multi-select action bar; iterates
+  the selection (meetings only), runs generation with bounded concurrency,
+  reports `{titled, skipped, failed}`. Skips rows with no LLM configured with a
+  single explanatory note rather than N errors.
+- Manual path overwrites the current title (explicit intent); automatic path
+  retains #553's fallback-only rule.
+
+## Phases
+1. **Merge PR #553** — rebase/de-conflict, review, confirm defaults, merge.
+   (Unblocks everything; ships automatic titles for new meetings.)
+2. **Extract reusable `generateTitle(for:)`** + unit tests (gating, overwrite
+   rule, failure leaves title intact).
+3. **Single-row context-menu action** + in-row progress; dev-app verify the
+   row updates in place.
+4. **Bulk "Generate titles"** (after `2026-06-18-library-bulk-delete.md` lands)
+   — action-bar button, bounded concurrency, result summary.
+5. **Docs** — `spec/02-features.md`, register REQ-MEET-021, issue reply on #546.
+
+## Testing
+- Reuse/extend #553's `MeetingTitleGenerator` tests.
+- ViewModel tests for `generateTitle(for:)`: no-provider no-op, success persists,
+  failure leaves the old title, manual overwrite vs. automatic fallback-only.
+- Bulk: result counts correct; one failure doesn't abort; no-provider yields a
+  single skip note.
+- `swift test` before merge.
+
+## Open questions (confirm during Workstream 1 review)
+1. **Combine title into the summary call?** #553 makes a *separate* LLM call for
+   the title; the summary auto-prompt already sends the same transcript. Piggybacking
+   the title onto that call halves cloud round-trips at the cost of coupling.
+   Lean: keep separate for now (simpler, more robust); note as a future optimization.
+2. **Zero-LLM fallback to the calendar event title?** For the local-first majority
+   with no LLM, automatic titling is a no-op. When a meeting was calendar-started,
+   using the event title is a strong zero-LLM title. In scope here, or a separate
+   small follow-up? Lean: separate follow-up (keeps this plan focused on #553 + manual).
+3. **Default-on with a cloud key = silent (tiny) spend.** #553 defaults the pref
+   on. Confirm comfort, or gate default-on to local providers and prompt for cloud.
+   Lean: keep default-on (spend is negligible, matches category norms like Granola).
+
+## Docs to update on completion
+`spec/02-features.md`, `spec/README.md`, `spec/kernel/requirements.yaml`
+(REQ-MEET-021), and an issue reply on #546.

--- a/plans/active/2026-06-18-meeting-back-to-back-recording.md
+++ b/plans/active/2026-06-18-meeting-back-to-back-recording.md
@@ -1,0 +1,197 @@
+# Back-to-Back Meeting Recording (Decoupled Post-Stop Transcription)
+
+**Status:** ACTIVE PLAN — not started
+**Date:** 2026-06-18
+**ADRs:** ADR-014 (meeting recording), ADR-015 (concurrent dictation+meeting), ADR-016 (STT scheduler / two-slot), ADR-019 (crash-resilient recording)
+**Requirement:** REQ-MEET-020 (proposed)
+**Issues:** #535
+**Decision (owner, 2026-06-18):** **Sequential** scope. Stop meeting A → its
+transcription is handed to a background queue → the recorder returns to idle
+immediately so meeting B can start. **Not** fully-concurrent simultaneous
+recordings (that is a much larger, separate effort).
+
+## What this plan closes out
+
+Today, after you stop a meeting, the app is "busy transcribing" and you **cannot
+start the next recording** until it finishes. #535: *"When it's transcribing, I
+can't start the next session… being able to transcribe and start a new recording
+session would be awesome (transcribe may be postponed in that situation)."* The
+parenthetical is the design: the user is fine with transcription happening later —
+they just need the **recorder free again immediately**.
+
+The investigation is decisive: **this is not a resource conflict.** Recording
+(audio capture) and transcription (STT) are different subsystems:
+- `SharedMicrophoneStream` already supports multiple subscribers.
+- The STT scheduler already serializes background transcription jobs.
+- The lock-file model already represents multiple sessions by PID.
+
+The block is purely a **single-instance state machine**: a meeting that has
+stopped sits in `.transcribing` until finalize completes, and
+`startRecording` is guarded by `state == .idle`. So the fix is to **decouple
+post-stop transcription from the recorder's lifecycle**: when a recording stops
+and its audio is finalized to disk, hand the file to a background transcription
+queue and return the recorder state machine to `.idle` — the transcription
+finishes on its own and lands in the Library when ready.
+
+## Scope boundaries
+
+### In scope
+- Detach post-stop **transcription** from the recorder state machine so the
+  recorder reaches `.idle` once audio is **finalized to disk** (not once
+  transcription completes).
+- A small **background meeting-transcription queue** that owns in-flight
+  finalize jobs (one or more queued), driving each through the existing
+  `transcribeMeeting` path on the ADR-016 background slot.
+- The stopped meeting appears in the Library/Meetings **immediately** as a row in
+  a "Transcribing…" state, transitioning to done in place (Granola-style trust:
+  the meeting is visibly safe the moment you stop).
+- A lightweight indicator that a *previous* meeting is still transcribing while a
+  *new* recording is active (so the now-recording pill isn't the only signal).
+- Correct interaction with crash recovery when one session is mid-transcribe and
+  another is recording.
+
+### Out of scope
+- **Fully concurrent recordings** (two live captures at once: multiple pills,
+  multiple capture sessions, VPIO arbitration for two meeting mics). Starting a
+  new recording still requires the *active* one to be stopped first.
+- Concurrent **dictation** during a meeting — already supported (ADR-015),
+  untouched.
+- Changing the transcription algorithm, engine routing, or live-preview chunking
+  logic — only *when* finalize runs relative to recorder idle changes.
+- Reworking the STT scheduler's slot topology (we use the existing background slot
+  and its existing priority ranking).
+
+### Invariants
+- **Never lose a recording.** The recorder only returns to `.idle` *after* audio
+  is durably finalized on disk and enqueued for transcription (and a recovery
+  lock reflects `awaitingTranscription`). A crash between stop and finalize is
+  already covered by ADR-019 recovery; this plan must not widen that window.
+- **One live capture at a time** (sequential scope) — the new "start" still
+  refuses while a recording is actively capturing.
+- **Finalize ordering is deterministic.** Queued transcriptions run in stop order
+  on the background slot; a new recording's live-preview chunks
+  (`.meetingLiveChunk`, p1) yield to a prior meeting's `.meetingFinalize` (p0)
+  per ADR-016 — accepted, since live preview is display-only.
+- **Engine lease integrity** (ADR-021). The engine/language captured at *record
+  start* drives that meeting's finalize regardless of what the next meeting
+  selects; engine switching stays guarded while any meeting work is in flight.
+- **Crash recovery handles N sessions.** Recovering must enumerate every session
+  folder (one recording-in-progress at crash time + any awaiting-transcription),
+  not assume a single active session.
+
+## Verified current state (file:line)
+
+- State machine: `Sources/MacParakeetCore/MeetingRecordingFlow/MeetingRecordingFlowStateMachine.swift`
+  — states `idle → checkingPermissions → starting → recording → stopping →
+  transcribing → finishing → idle`; `.recording + .stopRequested → .transcribing`
+  (~130). The recorder is pinned in `.transcribing` for the whole finalize.
+- The block: `Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift`
+  — `startRecording` `guard stateMachine.state == .idle else { return nil }` (~191);
+  `toggleRecording` treats `.transcribing`/`.finishing` as a silent no-op (~199-208).
+  Single long-lived `pillViewModel` (~64) + single `stateMachine` (~59) per app.
+- Single-session service: `Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift`
+  — `Session` represents one active recording (~120); the service holds a single
+  `currentSession?`, not a session map.
+- UI gate: `Sources/MacParakeet/Views/Transcription/MeetingRecordingTile.swift`
+  — start button only in `.idle`; `.completing/.transcribing` show a spinner,
+  no start affordance (~122-134).
+- Pill VM: `Sources/MacParakeetViewModels/MeetingRecordingPillViewModel.swift`
+  — single `PillState` enum (not an array of sessions).
+- Scheduler (not the blocker): `Sources/MacParakeetCore/STT/STTScheduler.swift`
+  — `SchedulerSlot { interactive, background }` (~790-801); `.meetingFinalize`
+  (p0) and `.meetingLiveChunk` (p1) share `background`. Sequential/queued finalize
+  is exactly what it's built for.
+- Capture (not the blocker): `Sources/MacParakeetCore/Audio/SharedMicrophoneStream.swift`
+  — multi-subscriber engine (~187 subscribe; ~54-92 arbitration). Finalize reads a
+  saved file, not the live mic.
+- Crash resilience: `Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingLockFileStore.swift`
+  — `MeetingRecordingLockFile { sessionId, state(.recording/.awaitingTranscription),
+  pid }`; `discoverActiveSessions` already returns **multiple** live sessions by PID
+  (~232). The model supports N sessions; the recovery *flow* must consume that.
+
+## Design
+
+### The decoupling
+1. On stop, the recorder finalizes audio to its session folder and writes the
+   lock as `awaitingTranscription` (already a modeled state). **This is the point
+   the recorder returns to `.idle`** — capture resources released, start button
+   live again.
+2. Finalize (the STT pass) is handed to a new
+   **`MeetingTranscriptionQueue`** (app-layer, `@MainActor` shell over the
+   background-slot scheduler) that owns `[QueuedFinalize]` and drives each via the
+   existing `transcribeMeeting` path. Completion materializes the Library row /
+   summary exactly as today, and clears the lock.
+3. The Library row is created in a **`.transcribing` presentation state at stop
+   time** (not at completion), so the meeting is visibly safe immediately.
+
+### State-machine change (minimal)
+Split the current monolithic `.transcribing` recorder phase: the **recorder**
+flow becomes `recording → stopping → idle` (it no longer waits on STT). The STT
+work moves to the queue. The pill's `.transcribing` presentation is driven by the
+*queue*, not by the recorder state machine — so the pill can show "idle, ready to
+record" while a queue badge shows "1 transcribing". (Exact enum surgery decided in
+Phase 1; goal is the smallest change that frees `startRecording`.)
+
+### UI
+- Stopping a meeting immediately resets the tile/pill to idle (start enabled).
+- A small, non-blocking indicator — a badge on the Meeting tile and/or a Library
+  row spinner — shows "Transcribing previous meeting…". Reuse existing
+  transcribing visuals; do not introduce a second floating pill (that drifts
+  toward the out-of-scope concurrent-recording UI).
+- If the user starts B while A transcribes, B records normally; A's row flips to
+  done in place when its queued finalize finishes.
+
+### Crash recovery
+Audit `MeetingRecordingRecoveryService` to enumerate **all** discovered sessions:
+re-enqueue any `awaitingTranscription` sessions and offer recovery for a
+`recording` session interrupted at crash — without assuming a single session.
+
+## Phases
+1. **Spec the state split** — design doc + the minimal state-machine change that
+   lets `startRecording` succeed once audio is finalized; enumerate every call
+   site that assumes `.transcribing` blocks start. Resolve the enum surgery.
+2. **`MeetingTranscriptionQueue`** — app-layer queue over the background slot;
+   ordered, supports ≥1 pending; unit-tested with a mock scheduler (ordering,
+   completion materialization, failure isolation).
+3. **Wire stop → finalize-to-disk → idle + enqueue** — recorder returns to idle
+   on durable finalize; lock = `awaitingTranscription`; Library row appears as
+   transcribing at stop time.
+4. **UI** — idle-on-stop tile/pill + the "previous meeting transcribing" badge +
+   Library row transcribing→done in place.
+5. **Crash-recovery multi-session audit** — recovery enumerates all sessions;
+   integration test with two planted session folders (one recording-interrupted,
+   one awaiting-transcription).
+6. **Docs** — ADR-016 note (finalize decoupled from recorder lifecycle),
+   `spec/05-audio-pipeline.md`, register REQ-MEET-020.
+
+## Testing
+- Queue unit tests: FIFO by stop order, ≥2 pending, one failing finalize doesn't
+  block the next, completion materializes the row.
+- State-machine tests: stop → idle transition happens at finalize-to-disk, not at
+  STT completion; `startRecording` succeeds while a finalize is queued; start
+  still refused while actively capturing.
+- Recovery integration: two session folders recovered correctly.
+- Manual dev-app: record → stop → immediately record again; confirm first
+  transcript still lands; confirm a real call (live preview of B vs finalize of A
+  ordering looks sane).
+- `swift test` before merge.
+
+## Open questions (resolve in Phase 1)
+1. **Pill vs. queue ownership of `.transcribing`:** cleanest is the pill showing
+   recorder-idle while a separate queue badge owns the transcribing indicator.
+   Confirm we don't want the pill itself to keep showing transcribing (which
+   would re-block the mental model of "free to record").
+2. **Durability boundary for "idle":** return to idle on `finalize-to-disk`
+   (audio written + lock=awaitingTranscription) — confirm this is the safe point
+   and doesn't widen the ADR-019 crash window vs. today.
+3. **Queue depth cap:** unbounded queue (serialized by the slot) vs. a soft cap
+   with UI feedback if a user stops many meetings rapidly. Lean: unbounded; the
+   slot serializes and each row shows its own state.
+4. **Live-preview-of-B vs finalize-of-A:** accept p0-finalize preempting
+   p1-live-chunks (B's preview pauses briefly) — confirm acceptable, or special-
+   case ordering. Lean: accept (preview is display-only).
+
+## Docs to update on completion
+`spec/adr/016-centralized-stt-runtime-scheduler.md` (decoupling note),
+`spec/05-audio-pipeline.md`, `spec/02-features.md`, `spec/README.md`,
+`spec/kernel/requirements.yaml` (REQ-MEET-020), and an issue reply on #535.

--- a/plans/active/2026-06-18-meeting-back-to-back-recording.md
+++ b/plans/active/2026-06-18-meeting-back-to-back-recording.md
@@ -62,19 +62,25 @@ finishes on its own and lands in the Library when ready.
   and its existing priority ranking).
 
 ### Invariants
-- **Never lose a recording.** The recorder only returns to `.idle` *after* audio
-  is durably finalized on disk and enqueued for transcription (and a recovery
-  lock reflects `awaitingTranscription`). A crash between stop and finalize is
-  already covered by ADR-019 recovery; this plan must not widen that window.
+- **Never lose a recording — strict ordering.** The recorder returns to `.idle`
+  only after, and in this exact order: (1) audio is flushed/durably finalized on
+  disk, (2) the recovery lock is written as `awaitingTranscription`, (3) the
+  state machine transitions to `.idle`. If (3) preceded (2), a crash in the gap
+  would leave a stale `.recording` lock over finished audio and recovery could
+  misdiagnose or lose the session. Today's single-session path has the same
+  window; rapid back-to-back stops make it likelier to bite, so this ordering is
+  a hard invariant — not an open question. [Greptile P2]
 - **One live capture at a time** (sequential scope) — the new "start" still
   refuses while a recording is actively capturing.
 - **Finalize ordering is deterministic.** Queued transcriptions run in stop order
   on the background slot; a new recording's live-preview chunks
   (`.meetingLiveChunk`, p1) yield to a prior meeting's `.meetingFinalize` (p0)
   per ADR-016 — accepted, since live preview is display-only.
-- **Engine lease integrity** (ADR-021). The engine/language captured at *record
-  start* drives that meeting's finalize regardless of what the next meeting
-  selects; engine switching stays guarded while any meeting work is in flight.
+- **Engine lease integrity, without over-locking** (ADR-021). The engine/language
+  captured at *record start* drives that meeting's finalize regardless of what the
+  next meeting selects. The lease is **per in-flight job** — a queued finalize must
+  *not* globally block the user from selecting a different engine for the *next*
+  recording; only a switch that would disrupt an active job is guarded. [Gemini]
 - **Crash recovery handles N sessions.** Recovering must enumerate every session
   folder (one recording-in-progress at crash time + any awaiting-transcription),
   not assume a single active session.
@@ -181,9 +187,12 @@ re-enqueue any `awaitingTranscription` sessions and offer recovery for a
    recorder-idle while a separate queue badge owns the transcribing indicator.
    Confirm we don't want the pill itself to keep showing transcribing (which
    would re-block the mental model of "free to record").
-2. **Durability boundary for "idle":** return to idle on `finalize-to-disk`
-   (audio written + lock=awaitingTranscription) — confirm this is the safe point
-   and doesn't widen the ADR-019 crash window vs. today.
+2. **Cross-engine model thrash:** if B records with live preview on a *different*
+   engine than A's in-flight finalize, the `STTRuntime` may load/unload models on
+   the ANE repeatedly. Confirm the runtime serializes/holds model leases sanely,
+   or add a guard (e.g. let A's finalize finish its model lease before B's
+   live-preview model loads — preview can degrade gracefully). Newly raised by
+   this review; not flagged by the bots.
 3. **Queue depth cap:** unbounded queue (serialized by the slot) vs. a soft cap
    with UI feedback if a user stops many meetings rapidly. Lean: unbounded; the
    slot serializes and each row shows its own state.
@@ -191,7 +200,15 @@ re-enqueue any `awaitingTranscription` sessions and offer recovery for a
    p1-live-chunks (B's preview pauses briefly) — confirm acceptable, or special-
    case ordering. Lean: accept (preview is display-only).
 
+(Resolved during PR #556 review: the durability boundary is now a hard invariant —
+audio flush → lock=`awaitingTranscription` → state→idle, in that order; and the
+engine lease is per-job and must not globally block selecting a different engine
+for the next recording.)
+
 ## Docs to update on completion
 `spec/adr/016-centralized-stt-runtime-scheduler.md` (decoupling note),
 `spec/05-audio-pipeline.md`, `spec/02-features.md`, `spec/README.md`,
 `spec/kernel/requirements.yaml` (REQ-MEET-020), and an issue reply on #535.
+Any new `TelemetryEventName` case added here must be mirrored in the website
+`ALLOWED_EVENTS` allowlist in the same change, or the Worker drops the whole
+batch (two-repo gotcha).

--- a/plans/active/2026-06-18-meeting-back-to-back-recording.md
+++ b/plans/active/2026-06-18-meeting-back-to-back-recording.md
@@ -84,6 +84,10 @@ finishes on its own and lands in the Library when ready.
 - **Crash recovery handles N sessions.** Recovering must enumerate every session
   folder (one recording-in-progress at crash time + any awaiting-transcription),
   not assume a single active session.
+- **One Library row per stopped meeting.** The stop path creates the visible
+  `.processing` / "Transcribing..." row once, and the queued finalize updates
+  that same row to completed/error. It must not call a path that creates a second
+  `Transcription` row for the same audio.
 
 ## Verified current state (file:line)
 
@@ -125,10 +129,14 @@ finishes on its own and lands in the Library when ready.
 2. Finalize (the STT pass) is handed to a new
    **`MeetingTranscriptionQueue`** (app-layer, `@MainActor` shell over the
    background-slot scheduler) that owns `[QueuedFinalize]` and drives each via the
-   existing `transcribeMeeting` path. Completion materializes the Library row /
-   summary exactly as today, and clears the lock.
+   existing meeting transcription pipeline. Completion updates the pre-created
+   Library row / summary exactly as today, and clears the lock.
 3. The Library row is created in a **`.transcribing` presentation state at stop
-   time** (not at completion), so the meeting is visibly safe immediately.
+   time** (not at completion), so the meeting is visibly safe immediately. The
+   queue item carries that row id; current `TranscriptionService.transcribeMeeting`
+   creates and saves its own processing row, so implementation must either
+   refactor it to accept an existing row id or add a sibling finalize method that
+   fills the existing stub instead of inserting a duplicate.
 
 ### State-machine change (minimal)
 Split the current monolithic `.transcribing` recorder phase: the **recorder**
@@ -158,10 +166,10 @@ re-enqueue any `awaitingTranscription` sessions and offer recovery for a
    site that assumes `.transcribing` blocks start. Resolve the enum surgery.
 2. **`MeetingTranscriptionQueue`** — app-layer queue over the background slot;
    ordered, supports ≥1 pending; unit-tested with a mock scheduler (ordering,
-   completion materialization, failure isolation).
+   completion materialization onto the original stub row, failure isolation).
 3. **Wire stop → finalize-to-disk → idle + enqueue** — recorder returns to idle
    on durable finalize; lock = `awaitingTranscription`; Library row appears as
-   transcribing at stop time.
+   transcribing at stop time; queued finalize updates that same row by id.
 4. **UI** — idle-on-stop tile/pill + the "previous meeting transcribing" badge +
    Library row transcribing→done in place.
 5. **Crash-recovery multi-session audit** — recovery enumerates all sessions;
@@ -172,7 +180,8 @@ re-enqueue any `awaitingTranscription` sessions and offer recovery for a
 
 ## Testing
 - Queue unit tests: FIFO by stop order, ≥2 pending, one failing finalize doesn't
-  block the next, completion materializes the row.
+  block the next, completion updates the original stub row without inserting a
+  duplicate.
 - State-machine tests: stop → idle transition happens at finalize-to-disk, not at
   STT completion; `startRecording` succeeds while a finalize is queued; start
   still refused while actively capturing.


### PR DESCRIPTION
## Summary

Four implementation plans (docs only, no source changes) for the Tier-1 meeting /
Granola-style feature requests, after an issue review + scoping discussion. Opening
this PR primarily to get a **Greptile review pass on the plans** before any code is
written.

Each plan is grounded in verified `file:line` anchors, has locked scope, invariants
centered on "never lose user data," phased steps, a testing section, and the
remaining open questions to resolve at implementation kickoff.

| Plan | Issues | Scope locked |
|---|---|---|
| `meeting-audio-retention-ndays` | #547 / #462 / #478 | N-day auto-delete sweep + delete-immediately on top of #508's shipped retention controls. Transcripts always kept. True stream-and-discard and size-cap eviction deferred. |
| `library-bulk-delete` | #498 | Port Dictation History's shipped multi-select pattern into the Library grid + meetings list; add Delete/⌘A keyboard + a brief undo toast. |
| `meeting-back-to-back-recording` | #535 | Sequential: decouple post-stop transcription into a background queue so the recorder returns to idle immediately (not fully-concurrent recordings). Investigation confirmed the blocker is a single-instance state machine, not a resource conflict. |
| `meeting-auto-title-followups` | #546 | Merge already-built PR #553 (auto-title for new meetings) + add manual/bulk "Generate title" for the existing backlog, riding on the #498 multi-select substrate. |

## Owner decisions captured

- Retention: N-day + immediate-delete only (no transcript-only mode, no size cap).
- Bulk delete: reuse Dictation "Select Multiple" + keyboard (not Finder-style).
- Back-to-back: sequential (decouple transcription), not concurrent recordings.
- Auto-title: merge PR #553 + manual/bulk "Generate title" for the backlog.

## Sequencing notes

- The auto-title **bulk** action depends on the #498 multi-select substrate (do bulk-delete first).
- PR #553 is currently merge-conflicting + unreviewed; it just needs a rebase + review and ships new-meeting auto-title on its own.

## What this is not

No source changes. New requirement IDs (REQ-MEET-019/020/021, REQ-LIB-002) are
proposed in the plans and get registered in `spec/kernel/requirements.yaml` at
implementation kickoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
