### PR TITLE
Simplify agent instruction docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,171 +1,125 @@
 # AGENTS.md -- MacParakeet
 
-> Read by coding agents (Claude Code, Codex CLI, Hermes, OpenClaw, etc.) working
-> *in this repo*. Deeper project context lives in [`CLAUDE.md`](./CLAUDE.md).
-> If your agent runs *outside* this repo and wants to *call* `macparakeet-cli`,
-> see [`integrations/README.md`](./integrations/README.md) instead.
+> Canonical startup guide for coding agents working in this repo. Claude Code
+> also reads [`CLAUDE.md`](./CLAUDE.md), which is a small Claude-specific
+> overlay. Agents outside this repo that want to call `macparakeet-cli` should
+> start with [`integrations/README.md`](./integrations/README.md).
 
-## What this project is
+## Project Shape
 
-MacParakeet is a fast, private, local-first voice app for macOS. The v0.6
-release has three co-equal capture modes: system-wide dictation, file
-transcription, and meeting recording, plus productized Transforms
-for selected-text rewrites. Parakeet TDT 0.6B via FluidAudio CoreML on the
-Apple Neural Engine is the default STT family: multilingual v3 is the default,
-and English-only v2 is an opt-in Parakeet model for users who want the fastest
-English path without v3 auto-detect. Two optional local engines extend
-coverage: Nemotron 3.5 (Beta), a fast multilingual FluidAudio streaming
-engine, and WhisperKit for languages Parakeet does not cover.
+MacParakeet is a fast, private, local-first voice app for Apple Silicon Macs.
+It ships three primary capture modes -- system-wide dictation, file/media URL
+transcription, and meeting recording -- plus Transforms for selected-text
+rewrites. Speech recognition runs locally by default through Parakeet via
+FluidAudio CoreML/ANE, with optional Nemotron and WhisperKit engines.
 
-**Release status:** The notarized Stable DMG is the user-facing release
-channel; `main` is development. The canonical channel framing — including
-which `AppFeatures` flags differ between `main` and the latest release tag —
-lives in one place: [`CLAUDE.md`](./CLAUDE.md) → "Release Channels". Check
-there before describing release status anywhere; don't restate it in other
-docs.
+The repo contains two products:
 
-Free and open-source (GPL-3.0). Apple Silicon only. Requires macOS 14.2+.
+- `MacParakeet.app`: SwiftUI macOS app.
+- `macparakeet-cli`: public automation surface in `Sources/CLI/`; compatibility
+  notes live in `Sources/CLI/CHANGELOG.md`.
 
-The repo ships two products:
+`main` is development. The notarized DMG is the user-facing stable channel.
+For current release/flag state, read
+[`spec/README.md`](./spec/README.md#release-channels-and-feature-flags) and the
+relevant ADR/spec instead of copying release facts into new docs.
 
-- **`macparakeet-cli`** -- versioned public surface
-  ([`Sources/CLI/`](./Sources/CLI/), semver tracked in
-  [`Sources/CLI/CHANGELOG.md`](./Sources/CLI/CHANGELOG.md)).
-- **`MacParakeet.app`** -- SwiftUI macOS app, one consumer of the CLI's
-  underlying core library.
-
-## Build & Test
+## Commands
 
 ```bash
-# Build everything (app + CLI + core + viewmodels + tests)
 swift build
-
-# Run the test suite (Swift 6 language mode)
 swift test
-
-# Focused run of one test class while iterating (full suite before merge)
 swift test --filter TextProcessingPipelineTests
-
-# Build, codesign, and launch the dev app
+scripts/dev/check.sh [TestFilter]
+scripts/dev/format.sh
+scripts/dev/ci_local.sh
 scripts/dev/run_app.sh
-
-# Run the CLI against your local DB
 swift run macparakeet-cli --help
 swift run macparakeet-cli health
 ```
 
-**Inner loop:** `scripts/dev/check.sh [TestFilter]` runs a debug build +
-optional filtered tests + report-only `swift-format` lint. Use it for fast
-iteration; `scripts/dev/ci_local.sh` remains the full pre-merge check. Run
-`scripts/dev/format.sh` to auto-format before committing.
+Use focused tests while iterating; run `swift test` before declaring code-change
+work complete unless the user explicitly scopes verification differently.
 
-The full test suite is deterministic and normally finishes in roughly one to
-two minutes depending on SwiftPM cache state. Run `swift test` before declaring
-code-change work complete.
+## Worktrees
 
-## Git & Worktrees
+This repo often has many parallel worktrees.
 
-This repo runs many parallel worktrees. Two rules that save real time:
+- Base new branches/worktrees on `origin/main`, not local `main`.
+- Fetch first: `git fetch origin`.
+- Build and test from the worktree that owns the branch. SwiftPM/Xcode state can
+  otherwise point at the wrong checkout.
+- Treat `.build*`, `.claude/worktrees`, `dist`, and
+  `journal/x-agent/node_modules` as generated or archival unless the task
+  specifically asks about them.
 
-- **Base new branches/worktrees on `origin/main`, not local `main`** — the
-  local `main` ref is often stale here. `git fetch origin` first, then
-  `git worktree add -b my-branch ../macparakeet-worktrees/my-branch origin/main`.
-- **Build from the worktree the branch is checked out in.** Xcode/SwiftPM
-  state under `.swiftpm/` pins source paths to the worktree that created it,
-  so `xcodebuild` invoked from another checkout can silently compile the
-  wrong tree. `swift build` / `swift test` from inside the worktree are
-  always safe.
+## Code Boundaries
 
-More git/CI gotchas (flaky-test policy, line-ending rules): [`CLAUDE.md`](./CLAUDE.md) → "Known Pitfalls".
+- Swift package tools-version is 5.9; first-party code is kept Swift 6
+  language-mode/concurrency clean.
+- `MacParakeetCore` owns shared logic and has no SwiftUI view ownership. Small
+  AppKit-backed adapter services are allowed when Foundation has no equivalent.
+- `MacParakeetViewModels` contains `@Observable` view models that can be tested
+  without the GUI.
+- New I/O should use async/await. Avoid new completion-handler or Combine
+  patterns.
+- Database access uses GRDB repositories, roughly one repository per table.
+- UI buttons use `.parakeetAction(...)`; do not tint whole hosting roots coral.
 
-## Code Style
+When editing a load-bearing Core subsystem, read its local README before code:
+`Audio/`, `STT/`, `TextProcessing/`, `Database/`, and `Licensing/` currently
+have subsystem rules.
 
-- Swift package tools-version 5.9; first-party Swift is kept Swift 6
-  language-mode / concurrency clean. SwiftUI for UI and GRDB for SQLite.
-- One repository per database table (see
-  [`Sources/MacParakeetCore/Database/`](./Sources/MacParakeetCore/Database/)).
-- Comments explain *why*, not *what* -- well-named identifiers carry the what.
-  Default to writing none.
-- `MacParakeetCore` has no SwiftUI/view dependencies. It is primarily
-  Foundation + GRDB + FluidAudio + optional WhisperKit, with small
-  AppKit-backed macOS adapter services where no Foundation-only API exists
-  (`ClipboardService`, `PermissionService`, `TelemetryService` termination
-  notification, `ExportService`). New AppKit use in Core should stay
-  adapter-shaped and must not introduce UI ownership.
-- ViewModels live in their own SPM target (`Sources/MacParakeetViewModels/`)
-  so they can be tested without the GUI.
-- Async/await for all I/O. No completion handlers, no Combine in new code.
-- Buttons use `.parakeetAction(.primary / .primaryProminent / .secondary / .destructive / .destructiveProminent / .subtle)` for semantic role + styling. Never apply `.tint(coral)` at NSHostingView roots or sheet wrappers — coral cascades only from `parakeetAction`. See `spec/04-ui-patterns.md` → Buttons.
+## Product Rules
 
-## Architecture Orientation
+- Preserve the local-first posture. Audio/transcripts stay on-device for core
+  dictation, transcription, and meeting recording. Cloud LLMs, media downloads,
+  model/update flows, and telemetry are explicit product surfaces.
+- Treat the user database and meeting artifacts as user data. Do not delete them
+  outside explicit product recovery/discard flows.
+- Keep the product focused. Prefer reliable capture, recovery, durable local
+  artifacts, polished daily workflows, and simple UX over feature sprawl.
+- ADRs in `spec/adr/` record accepted decisions. If reality has changed, update
+  the relevant ADR/spec deliberately instead of silently coding around it.
 
-```
-Sources/
-  MacParakeetCore/        -- Pure Swift library: STT, DB, prompts, LLM, audio
-  MacParakeetViewModels/  -- @Observable view models, no UI
-  MacParakeet/            -- SwiftUI app target
-  CLI/                    -- macparakeet-cli; ArgumentParser commands
-Tests/
-  MacParakeetTests/       -- Unit, database, integration tests
-  CLITests/               -- CLI argument-parsing + helper tests
-```
+## Working Method
 
-Full spec is in [`spec/`](./spec/). Architectural decisions (locked) are in
-[`spec/adr/`](./spec/adr/). Don't second-guess ADRs.
+- Start by finding the governing code, ADRs/specs, and tests for the task.
+- For behavior changes, define the intended scope and must-not-change
+  invariants before editing.
+- Plans are useful working memory for substantial or long-running tasks, but
+  they are optional. Create or update one when it will keep the work coherent.
+- Add tests proportional to risk. Shared flows, persistence, CLI contracts,
+  privacy/telemetry, and concurrency need stronger coverage than copy edits.
+- Update docs when user-visible behavior, public CLI behavior, persistence,
+  privacy, or release framing changes.
 
-**Subsystem READMEs.** Load-bearing folders inside
-[`Sources/MacParakeetCore/`](./Sources/MacParakeetCore/) carry their own
-`README.md` capturing non-obvious rules (threading, ordering,
-retention) that aren't visible from grep. **When you're about to edit
-inside one of these folders, read its README first.** Folders with
-READMEs today: `Audio/`, `STT/`, `TextProcessing/`, `Database/`,
-`Licensing/`.
+The old manual requirements/traceability workflow is retired. The legacy
+requirements index is archived at
+[`docs/historical/requirements-legacy.yaml`](./docs/historical/requirements-legacy.yaml)
+for old references only; do not add new REQ IDs as part of normal work.
 
-## Security & Privacy
+## Review And Commit
 
-- **Local-first speech.** STT runs on the Apple Neural Engine. Audio and
-  transcripts stay on-device for core dictation, transcription, and meeting
-  recording. Network surfaces are limited to user-triggered LLM providers,
-  media downloads, model/update flows, retained purchase activation endpoints
-  if explicitly invoked, and opt-out self-hosted telemetry/crash reporting.
-  Telemetry never includes audio or transcript content.
-- **Retained purchase activation is intentional.** The old
-  LemonSqueezy/trial entitlement code is dormant in current free/GPL builds,
-  but it is deliberate future-option plumbing. Do not delete or "clean up"
-  `EntitlementsService`, `LemonSqueezyLicenseAPI`, entitlement state, or
-  trial/license telemetry as dead code unless explicitly requested by the
-  project owner and reflected in an ADR/spec update.
-- **No accounts, no logins.** No identifying data is sent anywhere.
-- **The user database lives at**
-  `~/Library/Application Support/MacParakeet/macparakeet.db`. Treat it as user
-  data: never delete without explicit user confirmation; write migrations
-  rather than dropping tables.
+Use [`docs/pr-review-workflow.md`](./docs/pr-review-workflow.md) for substantial
+changes. Scale review to risk: trivial edits can go straight in; small contained
+fixes need focused verification; substantial changes benefit from branch-first
+PRs, CI, and independent review until findings converge.
 
-## Important Runtime Locations
+Commit messages should help a future reader understand the change. The rich
+format in [`docs/commit-guidelines.md`](./docs/commit-guidelines.md) is a tool
+for significant work, not ceremony for every typo.
 
-| Item | Path |
-|------|------|
-| App bundle | `/Applications/MacParakeet.app` |
-| Database | `~/Library/Application Support/MacParakeet/macparakeet.db` |
-| Parakeet / Nemotron CoreML STT models (~465 MB per Parakeet build, ~1.5 GB Nemotron multilingual / ~600 MB Nemotron English) | FluidAudio default cache, `~/Library/Application Support/FluidAudio/Models/` (Parakeet: `parakeet-*/`; Nemotron multilingual: `nemotron-multilingual/`; Nemotron English: `nemotron-streaming/<tier>ms`) |
-| WhisperKit STT models | `~/Library/Application Support/MacParakeet/models/stt/whisper/` |
-| yt-dlp / FFmpeg helper binaries | `~/Library/Application Support/MacParakeet/bin/` |
-| Settings | `~/Library/Preferences/com.macparakeet.MacParakeet.plist` (dev build: `com.macparakeet.dev`) |
-| Logs | `~/Library/Logs/MacParakeet/` |
+## Where To Look
 
-## Where to Look Next
-
-- **Coding-agent context for this repo:** [`CLAUDE.md`](./CLAUDE.md) for deep
-  project context; [`spec/10-ai-coding-method.md`](./spec/10-ai-coding-method.md)
-  for spec precedence and lightweight kernel usage; ADRs in
-  [`spec/adr/`](./spec/adr/) for locked decisions.
-- **Calling macparakeet-cli from another agent (OpenClaw / Hermes / etc.):**
-  [`integrations/README.md`](./integrations/README.md) and the CLI changelog
-  at [`Sources/CLI/CHANGELOG.md`](./Sources/CLI/CHANGELOG.md).
-- **Commit format:** rich-format messages per
-  [`docs/commit-guidelines.md`](./docs/commit-guidelines.md) for significant
-  changes.
-- **PR & review workflow:** branch-first PR loop, reviewing to LGTM with
-  judgment, agent fresh-eye review, convergence, and the merge-ready checklist
-  in [`docs/pr-review-workflow.md`](./docs/pr-review-workflow.md). Scale the
-  ceremony to the change — trivial fixes go straight to `main`.
+- Spec index and roadmap: [`spec/README.md`](./spec/README.md)
+- Architecture and product decisions: [`spec/adr/`](./spec/adr/)
+- Feature behavior: [`spec/02-features.md`](./spec/02-features.md)
+- System architecture: [`spec/03-architecture.md`](./spec/03-architecture.md)
+- UI patterns: [`spec/04-ui-patterns.md`](./spec/04-ui-patterns.md)
+- Testing strategy: [`spec/09-testing.md`](./spec/09-testing.md)
+- Agent working method: [`spec/10-ai-coding-method.md`](./spec/10-ai-coding-method.md)
+- Agent instruction research: [`docs/research/coding-agent-instructions-2026-06.md`](./docs/research/coding-agent-instructions-2026-06.md)
+- Active/completed plans: [`plans/README.md`](./plans/README.md)
+- Distribution/release steps: [`docs/distribution.md`](./docs/distribution.md)
+- CLI automation contract: [`integrations/README.md`](./integrations/README.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,649 +1,133 @@
 # CLAUDE.md
 
-> Context for AI coding assistants working on MacParakeet.
-
-## What is MacParakeet?
-
-A **fast, private, local-first voice app** for macOS. The v0.6 release ships system-wide dictation, file and multi-platform video/podcast URL transcription, meeting recording, Parakeet v3/v2 model selection, an optional Nemotron 3.5 Beta engine, optional local WhisperKit multilingual STT for Korean, Japanese, Chinese, and other languages outside Parakeet's coverage, opt-in instant dictation (warm-mic pre-roll), and productized Transforms.
-
-**North Star:** Fast, local-first voice app for Mac.
-
-**Domain:** [macparakeet.com](https://macparakeet.com)
-
-**Pricing:** Current public build is free and open-source (GPL-3.0); official paid distribution/support remains possible.
-
-## Release Channels
-
-> **Canonical release-status block.** This section is the single source of
-> truth for channel framing and the `main`-vs-release `AppFeatures` flag
-> delta. AGENTS.md, README.md, and other docs point here rather than
-> restating it — when a release ships or a flag flips, update this section
-> and leave the pointers alone.
-
-| Channel | Agent Assumption | Features |
-|---------|------------------|----------|
-| Stable DMG | User-facing release, recommended for normal use | Dictation, file and multi-platform video/podcast URL transcription, meeting recording, calendar auto-start (opt-in, default `.off`), productized Transforms, VAD-guided meeting live-preview chunking, opt-in instant dictation, optional Nemotron Beta and WhisperKit engines, exports, vocabulary, AI features |
-| `main` | Development | Latest stable release plus untagged in-progress fixes, plus the flag delta below |
-
-**Flag delta — `main` vs the latest release tag:**
-`AppFeatures.meetingAutoStopEnabled = true`
-(ADR-023 activity-based meeting auto-stop; flag enabled on `main` 2026-06-14 so
-the Settings toggle is dogfoodable — the per-user opt-in setting still defaults
-off, so nothing auto-stops until a user turns it on; not yet in a tagged
-release). Staged default-off flag on `main` that is not user-visible until
-validation flips it: `AppFeatures.meetingActivityDetectionEnabled = false`
-(ADR-024 Phases A+B process-audio attribution + camera activity + pure detector
-foundation; no runtime coordinator/UI yet). Reliability kill-switch on `main`:
-`AppFeatures.meetingCaptureReliabilityEnabled = true` (ADR-025 Phase A
-mic-health telemetry watchdog; default-on, no UI/recording behavior change).
-`AppFeatures.liveDictationStreamingEnabled = true` (display-only live dictation
-transcript preview above the pill — Parakeet v2/v3 use a single-flight
-tail-window batch preview, Parakeet Unified and both Nemotron builds use their
-native live-partial paths, and Whisper stays default-off pending a per-pass
-latency probe; the paste still
-comes from the stop-time transcription path; #517, enabled on `main`
-2026-06-14, not yet in a tagged release).
-Deliberately gated off for now: `AppFeatures.aiFormatterProfilesEnabled = false`
-(app-aware AI Formatter profiles with readable/toggleable smart defaults,
-REQ-LLM-004; code-complete and QA'd but held out of the v0.6.23 release on
-2026-06-14 — flip back to `true` to ship in a later tag; no-data operation).
-All other `AppFeatures` flags match the shipping build.
-
-Ship history for flagged features: Transforms reached stable in v0.6.7;
-calendar auto-start in v0.6.10 (defaults to mode `.off`, strictly opt-in;
-calendar-driven auto-stop was removed per the ADR-017 amendment, 2026-05 —
-scheduled end times are unreliable, so recordings stop manually); VAD-guided
-meeting live-preview chunking in v0.6.14 (launch-time background prep fetches
-the Silero model, Parakeet meetings cut live chunks at speech boundaries when
-it is cached, and all missing/error paths fall back to the fixed 5s / 1s
-chunker — final meeting transcription is unchanged).
-
-## Quick Navigation
-
-| Need | Go To |
-|------|-------|
-| What are we building? | `spec/README.md` -> spec index and roadmap |
-| Product vision | `spec/00-vision.md` |
-| Data model | `spec/01-data-model.md` |
-| Feature details | `spec/02-features.md` |
-| Architecture | `spec/03-architecture.md` |
-| UI patterns | `spec/04-ui-patterns.md` |
-| Audio pipeline | `spec/05-audio-pipeline.md` |
-| STT engine | `spec/06-stt-engine.md` |
-| Text processing | `spec/07-text-processing.md` |
-| Error handling | `spec/08-error-handling.md` |
-| Testing strategy | `spec/09-testing.md` |
-| AI coding methodology | `spec/10-ai-coding-method.md` |
-| LLM integration | `spec/11-llm-integration.md` |
-| Processing layer (prompts, actions, workflows) | `spec/12-processing-layer.md` |
-| Agent workflows | `spec/13-agent-workflows.md` |
-| ADRs (locked decisions) | `spec/adr/` -> individual decision records |
-| CLI testing guide | `docs/cli-testing.md` |
-| Brand identity | `docs/brand-identity.md` |
-| Brand asset library (vectors, palette, posters) | `brand-assets/README.md` |
-| UI/UX design overhaul | `docs/design-overhaul.md` |
-| Distribution, signing & auto-updates | `docs/distribution.md` |
-| Telemetry system | `docs/telemetry.md` |
-| Commit message format | `docs/commit-guidelines.md` |
-| PR & review workflow | `docs/pr-review-workflow.md` -> branch-first PR loop, review judgment, convergence, merge-ready checklist |
-| Implementation plans | `plans/` -> active and completed plans |
-| Codebase audits | `docs/audits/` -> two-pass independent audits with status, refutations, deferred items |
-| Cross-agent coding-agent guide | `AGENTS.md` -> slim, convention-following |
-| Downstream agent integration (calling the CLI) | `integrations/README.md` |
-| CLI semver + compatibility policy | `Sources/CLI/CHANGELOG.md` |
-| Subsystem rules (Audio, STT, Database, etc.) | `Sources/MacParakeetCore/<subsystem>/README.md` -> non-obvious threading, ordering, retention rules colocated with the code |
-
-**When working in `Sources/MacParakeetCore/<subsystem>/`, read the
-`README.md` in that folder before reading code.** The READMEs capture
-non-obvious rules — threading invariants, "do not delete this,"
-ordering constraints, ADR cross-references — that aren't visible
-from grep. Folders with READMEs today: `Audio/`, `STT/`,
-`TextProcessing/`, `Database/`, `Licensing/`.
-
-## Tech Stack (Locked Decisions)
-
-| Layer | Choice | Notes |
-|-------|--------|-------|
-| Platform | macOS 14.2+ | Apple Silicon only |
-| Language | Swift 5.9 (tools-version) | `Package.swift` declares `swift-tools-version: 5.9`; first-party code is kept Swift 6 language-mode / concurrency clean (separate CI compile check). SwiftUI for UI |
-| Database | SQLite | GRDB (single file, dictation history + transcriptions + meeting recordings) |
-| STT | Parakeet TDT 0.6B (v3 default, v2 opt-in) + optional Nemotron 3.5 Beta + optional WhisperKit | Parakeet via FluidAudio CoreML/ANE is default (v3 multilingual: ~2.5% WER, 155x realtime, 25 European languages; v2 English-only: ~2.1% WER and no language auto-detect); Nemotron (Beta) is an opt-in fast FluidAudio engine with two builds — the multilingual 3.5 default and an English-only Nemotron Speech Streaming EN 0.6B — labeled Beta while quality is benchmarked; WhisperKit adds broader local multilingual coverage |
-| Audio | AVAudioEngine + ScreenCaptureKit | Mic capture for dictation; ScreenCaptureKit system audio + AVAudioEngine mic for meeting recording; FFmpeg (bundled) for video file conversion |
-| YouTube | yt-dlp | Standalone macOS binary, weekly non-blocking auto-update via `--update` |
-| Auto-Update | Sparkle 2 | In-app updates via EdDSA-signed appcast (non-App Store) |
-
-## Product Context
-
-MacParakeet is extracted from the OatFlow feature in Oatmeal but is maintained independently -- no shared packages, no monorepo dependencies.
-
-| | MacParakeet | Oatmeal |
-|---|-------------|---------|
-| **Focus** | Voice dictation + file transcription + meeting recording | Meeting memory + calendar |
-| **Complexity** | Simple, focused | Complex, powerful |
-| **Pricing** | Current public build free/GPL; official paid distribution/support possible | Freemium + Pro |
-| **Value prop** | "Fast local transcription" | "Remembers everything" |
-
-## Product Decisions (Settled)
-
-These decisions were made during spec review and are locked:
-
-| Decision | Choice | Rationale |
-|----------|--------|-----------|
-| Empty transcript UX | Silently dismiss | Short hold-to-talk with no speech = user changed their mind. No error card. |
-| Audio retention | On/off toggle | Simpler than 3-tier (all/7d/never). Users who care about storage can manually delete. |
-| Processing mode scope | Global default only | Set once in Vocabulary, applies to all dictations. No per-dictation picker on overlay. |
-| Context awareness | Aspirational future | No version commitment. Don't promise what doesn't exist. Build post-launch. |
-
-## Architecture Decisions (ADRs)
-
-All ADRs are in `spec/adr/`. These are locked decisions -- don't second-guess them.
-
-| ADR | Decision | File |
-|-----|----------|------|
-| ADR-001 | Parakeet TDT 0.6B-v3 as primary/default STT; v2 English-only opt-in and Nemotron 3.5 Beta added by amendment | `spec/adr/001-parakeet-stt.md` |
-| ADR-002 | Local-first processing (amended: opt-in LLM providers, opt-out telemetry) | `spec/adr/002-local-only.md` |
-| ADR-004 | Deterministic text processing pipeline | `spec/adr/004-deterministic-pipeline.md` |
-| ADR-005 | First-run onboarding flow | `spec/adr/005-onboarding-first-run.md` |
-| ADR-007 | FluidAudio CoreML migration (Python elimination) | `spec/adr/007-fluidaudio-coreml-migration.md` |
-| ADR-009 | Custom hotkey support (any single key + chord combos) | `spec/adr/009-custom-hotkey.md` |
-| ADR-010 | Speaker diarization via FluidAudio offline pipeline | `spec/adr/010-speaker-diarization.md` |
-| ADR-011 | LLM via cloud API keys + optional local providers | `spec/adr/011-llm-cloud-and-local-providers.md` |
-| ADR-012 | Self-hosted telemetry via Cloudflare (Worker + D1) | `spec/adr/012-telemetry-system.md` |
-| ADR-013 | Prompt Library + multi-summary architecture | `spec/adr/013-prompt-library-multi-summary.md` |
-| ADR-014 | Meeting recording via ScreenCaptureKit system audio | `spec/adr/014-meeting-recording.md` |
-| ADR-015 | Concurrent dictation and meeting recording | `spec/adr/015-concurrent-dictation-meeting.md` |
-| ADR-016 | Centralized STT runtime and two-slot scheduler | `spec/adr/016-centralized-stt-runtime-scheduler.md` |
-| ADR-017 | Calendar-driven meeting auto-start (Phases 1 + 2 implemented and enabled; auto-start defaults to opt-in `.off`; Phase 3 proposed) | `spec/adr/017-calendar-meeting-auto-start.md` |
-| ADR-018 | Live meeting Ask tab (Insights dropped per amendment; Ask shipped) | `spec/adr/018-live-meeting-insights-and-ask.md` |
-| ADR-019 | Crash-resilient meeting recording (implemented) | `spec/adr/019-crash-resilient-meeting-recording.md` |
-| ADR-020 | Live meeting notepad + memo-steered summaries (implemented) | `spec/adr/020-live-meeting-notepad-and-memo-summaries.md` |
-| ADR-021 | WhisperKit as optional multilingual STT engine (implemented) | `spec/adr/021-whisperkit-multilingual-stt.md` |
-| ADR-022 | Transforms — system-wide LLM rewrites on selected text (Phase 2 productized; enabled, shipping since v0.6.7) | `spec/adr/022-transforms-system-wide-rewrite.md` |
-| ADR-023 | Activity-based meeting auto-stop (silence + app-quit signals + veto countdown; Phases A+B implemented behind default-off flag, Phase C deferred to ADR-024 attribution) | `spec/adr/023-activity-based-meeting-auto-stop.md` |
-| ADR-024 | Activity-based meeting detection (Phases A+B per-process audio attribution + camera activity with pure detector implemented behind default-off flag; coordinator/prompt phases proposed) | `spec/adr/024-activity-based-meeting-detection.md` |
-| ADR-025 | Meeting capture reliability — mic-health watchdog + post-stop coverage repair (Phase A mic-health telemetry watchdog implemented behind default-on kill-switch; warning UI + repair proposed) | `spec/adr/025-meeting-capture-reliability.md` |
-
-> Historical/dormant ADRs (still in `spec/adr/`, kept for context): ADR-003 (one-time purchase pricing), ADR-006 (trial + license activation), ADR-008 (local LLM runtime). Current public builds are free/GPL-3.0 and unlocked. The old LemonSqueezy/trial entitlement plumbing is intentionally retained as future-option code for GPL-compatible official paid distribution/support; do not remove it as dead code without explicit owner direction and an ADR/spec update.
-
-## Current Phase
-
-**v0.6 series** — meeting recording (ADR-014/015/016/019/020), multi-platform
-video/podcast URL transcription (any `yt-dlp` site plus Apple Podcasts and
-freetext podcast search), Parakeet v3/v2 model selection, optional Nemotron
-3.5 Beta (ADR-001 amendment) and WhisperKit (ADR-021) engines, opt-in instant dictation (warm-mic
-pre-roll), app-aware AI Formatter profiles (REQ-LLM-004, code-complete but
-gated off — deferred past v0.6.23),
-default-off activity-based meeting auto-stop (ADR-023, `main` validation flag),
-default-off activity-based meeting detection foundation (ADR-024 Phases A+B,
-no runtime coordinator/UI yet),
-meeting mic-health telemetry watchdog (ADR-025 Phase A, default-on kill-switch),
-display-only live dictation transcript preview (`main`-only flag, #517),
-and productized Transforms with `Polish`/`Distill`/`Decide` built-ins on
-Control-Option hotkeys (ADR-022). Calendar auto-start is ADR-017 Phases 1 + 2
-(enabled, default `.off`); Phase 3 (late-join/retro-link) remains proposed.
-
-Live flag state and the `main`-vs-release delta: see "Release Channels" above.
-Per-version feature history: the `spec/README.md` roadmap and git tags.
-
-## Key Patterns
-
-### Three Primary Modes + Transforms
-
-MacParakeet has three primary capture modes plus a system-wide text-rewrite surface (ADR-022):
-
-1. **System-wide dictation** -- Press hotkey anywhere on macOS, speak, text is pasted (WisprFlow-style)
-2. **File transcription** -- Drag-drop audio/video files (multi-file and folder drops, plus a multi-select/folder Browse picker, fan out into a sequential local batch — `AudioFileEnumerator` expands + caps at 200, `TranscriptionViewModel` drains one at a time, results stream into Library, "Cancel all" stops it) or paste any video/podcast link — YouTube, X, Vimeo, TikTok, Instagram, Facebook, Apple Podcasts, and any other `yt-dlp`-supported site (single-URL; MacWhisper-style). There is no platform allowlist: the gate (`MediaPlatform.isTranscribable`) accepts any plausible media URL and `yt-dlp` tries it; host recognition (`MediaPlatform.recognize`) only picks the brand glyph/label for the orbiting platform hero. A finished file/URL/batch plays a chime + (backgrounded) banner behind one opt-out Settings toggle (`notifyOnTranscriptionComplete`, default on).
-3. **Meeting recording** -- Capture system audio + mic simultaneously, transcribe locally (simple Granola-style)
-4. **Transforms** -- Select text anywhere on macOS, press a bound hotkey (⌃⌥1 / ⌃⌥2 / ⌃⌥3 by default), and the selection is rewritten in place through the user's LLM provider. ADR-022. Productized Transforms are enabled via `AppFeatures.transformsEnabled = true` (shipping since v0.6.7). Ships with three built-in Transforms: *Polish*, *Distill*, *Decide* — synthesized by a paired creative-director + staff-PM review on 2026-05-12 (Improve → Re-shape → Re-direct pedagogy). Reuses the spike's brand-finished floating pill (ADR-022 §4); user-bound shortcuts dispatch through a single process-wide `TransformsHotkeyRegistry`.
-
-The three capture modes share the same STT scheduler/runtime path but have different UI flows, audio sources, and data models. Parakeet is the default engine; Whisper can be selected globally or per CLI call for languages Parakeet does not cover. **Dictation and meeting recording run concurrently** (ADR-015) -- a user can dictate freely during a meeting recording. Dictation and meeting microphone capture fan out from one process-wide `SharedMicrophoneStream`/AVAudioEngine; meeting system audio remains a separate ScreenCaptureKit stream. Transforms is unrelated to STT — it operates on whatever text is currently selected and sends it through the configured LLM provider.
-
-The Transcribe tab is the unified capture surface — one place for all three modes (dictation can also start there via hotkey/menu bar, since dictation is global):
-
-```
-+--------------------------------------------------+
-|  Transcribe YouTube & more  |  Drop a file       |
-|  [link field] [Transcribe]  |  [Browse Files]    |
-|                             |                    |
-+--------------------------------------------------+
-|  ✿ Record Meeting       Capture system + mic ●   |
-+--------------------------------------------------+
-```
-
-The Meeting Recording tile (third row, ~96pt strip) reflects live recording state via a long-lived `MeetingRecordingPillViewModel` shared with the floating pill -- both surfaces stay in sync. Meeting browse lives under `Library`'s Meetings filter chip as a date-grouped list rather than the thumbnail grid the other filters use.
-
-ADR-016 defines the STT architecture as one process-wide scheduler path with a reserved dictation slot and a shared background slot where meeting work outranks file transcription. ADR-021 extends that path with speech-engine routing, engine-switch guards, and meeting-session engine leases.
-
-### STT Integration (Parakeet default, Nemotron/Whisper optional)
-
-- Native Swift SDK via FluidAudio (CoreML on the Neural Engine)
-- Parakeet TDT 0.6B-v3 is the multilingual default; v2 is an English-only opt-in selected through Settings, `config set parakeet-model`, `models select parakeet-v2`, or `transcribe --parakeet-model v2`
-- Parakeet Unified EN 0.6B (`unified`) is a third opt-in Parakeet build (English-only, ~565 MB int8 per encoder export, FluidAudio ≥ 0.15.4) with strong offline English accuracy and built-in punctuation/capitalization. FluidAudio's v0.15.4 CoreML benchmark reports 2.15% average / 1.68% aggregate WER on LibriSpeech test-clean; NVIDIA's upstream model card reports 1.63% offline WER. It is a *separate* FluidAudio runtime served by `ParakeetUnifiedEngine` and routed when `ParakeetModelVariant == .unified`: file/meeting/final dictation use offline `UnifiedAsrManager` (`parakeet-unified-offline-15s`), while live dictation preview uses native `StreamingUnifiedAsrManager` (`parakeet-unified-2080ms`). No word timings; selected via Settings, `config set parakeet-model unified`, `models select parakeet-unified`, or `transcribe --parakeet-model unified`. Issue #520, ADR-001 amendment
-- The TDT builds (v2/v3) return word-level timestamps + confidence scores; the Unified build's offline path returns text only (no word timings)
-- ~155x realtime on Apple Silicon (60 min audio in ~23 seconds)
-- ~2.5% Word Error Rate
-- ~66 MB working memory per active Parakeet inference slot (vs ~2 GB+ on GPU/MLX)
-- ~465 MB CoreML speech model bundle per Parakeet build; v2 and v3 cache independently
-- ~130 MB diarization asset bundle, fetched only when the user enables speaker detection (the toggle defaults off; ADR-010 amendment 2026-06-14) — default onboarding does not prepare it
-- Nemotron 3.5 ASR (Beta) is an opt-in FluidAudio CoreML multilingual streaming engine (default build `nemotron-multilingual-1120ms`, ~1.5 GB) selected via Settings, `config set nemotron-language`, `models select nemotron-multilingual-1120ms`, or `transcribe --engine nemotron`; labeled Beta while real-world quality is benchmarked (no word-level timestamps surfaced yet from either build)
-- A second Nemotron build, Nemotron Speech Streaming EN 0.6B (`nemotron-english-1120ms`, ~600 MB), is English-only (ignores the Nemotron language hint); file/meeting jobs transcribe batch-at-stop, while dictation streams live partials (live transcript preview) like the multilingual build; selected via Settings, `config set nemotron-model`, `models select nemotron-english-1120ms`, or `transcribe --nemotron-model`
-- WhisperKit is available as a local secondary engine for broader language coverage; default model variant is `large-v3-v20240930_turbo_632MB`
-- Display-only live dictation transcript preview (`AppFeatures.liveDictationStreamingEnabled`, `main`-only, #517): an ephemeral tail of in-progress text renders above the dictation pill while you speak. It is decoupled from the paste — the final inserted text always comes from the stop-time transcription path. Parakeet v2/v3 use a single-flight tail-window batch preview, Parakeet Unified and both Nemotron builds use their native live-partial paths, and Whisper stays default-off pending a per-pass latency probe. Users toggle it in Settings → Capture → Dictation (`showLiveDictationPreview`, default on) and can pick a preview text size
-- Whisper and Nemotron language hints are optional (`auto` means detect); persisted defaults are stored in `UserDefaults` and exposed in Settings
-- One process-wide `STTRuntime` owner manages model lifecycle for the app
-- The default STT topology uses 2 execution slots: reserved dictation + shared meeting/batch
-- One `STTScheduler` owns slot assignment, priority, backpressure, cancellation, and job-scoped progress
-- Active meeting recordings capture the selected engine/language at start; engine switching is blocked while speech work or a meeting engine lease is active
-
-**Project STT entry point:**
-```swift
-// App code uses the shared scheduler from AppEnvironment.
-let result = try await sttScheduler.transcribe(
-    audioPath: audioPath,
-    job: .fileTranscription,
-    onProgress: nil
-)
-// result.text contains the transcription
-// result.words contains word-level timestamps + confidence
-```
-
-Use `STTRuntime`/`STTScheduler` for app flows. Direct `AsrModels`/`AsrManager`
-usage belongs inside the runtime wrapper; creating standalone STT clients in app
-code bypasses ADR-016's process-wide scheduler.
-
-**Two-chip architecture:**
-```
-CPU:  MacParakeet app (UI, hotkeys, clipboard, history)
-ANE:  Parakeet / Nemotron STT (via FluidAudio/CoreML) -- dedicated ML chip
-CPU/GPU/CoreML as selected by WhisperKit: optional multilingual STT
-```
-
-### Database
-
-- `macparakeet.db` (GRDB): Dictation history + transcription records in a single file
-- No vector search or embeddings needed (unlike Oatmeal)
-- One repository per table (GRDB pattern)
-- `lifetime_dictation_stats` (DB migration `v0.7.4-lifetime-dictation-stats` — migration markers are internal schema versions, *not* the public app version, which is v0.6): singleton counter row keeping headline voice stats (total words, total time, total count, longest dictation) alive through history deletion. Incremented in the same transaction as each completed dictation save. See `spec/01-data-model.md` and issue #124.
-
-### Audio Capture
-
-- **Dictation**: AVAudioEngine tap on input node (microphone)
-- **File transcription**: FluidAudio's `AudioConverter` resamples audio; FFmpeg (bundled) demuxes video files
-- **Meeting recording**: ScreenCaptureKit for system audio + AVAudioEngine for mic (dual-stream)
-
-### GUI Structure
-
-MacParakeet is a **menu bar app** (NSStatusItem, always visible). UI
-surfaces: the main window (Transcribe capture hub, Library, Dictations,
-Vocabulary, Feedback, Settings, Discover), a persistent idle pill (hidden
-during active dictation), the dictation overlay (compact dark pill with
-waveform + cancel/stop), the floating meeting-recording pill
-(sacred-geometry rosette; shares live state with the Transcribe tile via one
-long-lived `MeetingRecordingPillViewModel`), the Transforms floating
-result/progress pill, and the Settings window. Library's Meetings filter is
-a date-grouped list; the other filters (All/Video/Local/Favorites) use a
-thumbnail grid. Full surface-by-surface breakdown: `spec/04-ui-patterns.md`.
-
-View files organized by feature in `Sources/MacParakeet/Views/`:
-- `Transcription/` -- Transcribe tab, drop zone, video URL card, **Meeting Recording tile**, transcript display, export, library grid + meetings list
-- `Dictation/` -- Overlay, waveform, recording state
-- `MeetingRecording/` -- Floating pill, dual audio levels, live notes/transcript/Ask panel, row card + date headers (consumed by Library Meetings filter)
-- `Meetings/` -- Library Meetings browse list (`MeetingsView`)
-- `Transforms/` -- Transforms management + editor sheet + floating result/progress pill (ADR-022)
-- `Discover/` -- Discover sidebar, curated content cards
-- `Vocabulary/` -- Processing mode, custom words, text snippets
-- `Feedback/` -- Feedback form, category selection, community link
-- `Onboarding/` -- First-run onboarding flow
-- `Settings/` -- Hotkey, LLM providers, storage, permissions
-- `History/` -- Dictation history, search, playback
-- `Components/` -- Reusable components (status badge, waveform view)
-
-## Folder Structure
-
-```
-macparakeet/
-├── CLAUDE.md           # This file (AI assistant context)
-├── AGENTS.md           # Cross-agent guide for coding agents working in this repo
-├── README.md           # Public-facing readme
-├── Package.swift       # Swift package manifest
-├── spec/               # THE SPEC (authoritative, prescriptive)
-│   ├── README.md       # Spec index + roadmap
-│   ├── 00-vision.md through 13-agent-workflows.md
-│   └── adr/            # Architecture Decision Records (locked)
-├── docs/               # Research, explorations (informative)
-│   ├── brand-identity.md   # Logo, colors, typography, brand voice
-│   ├── cli-testing.md      # CLI testing guide
-│   ├── commit-guidelines.md # Rich commit message format
-│   ├── pr-review-workflow.md # PR loop: review to LGTM, converge, merge-ready
-│   ├── design-overhaul.md  # UI/UX redesign spec (warm magical direction)
-│   ├── distribution.md     # Signing, notarization, auto-updates (Sparkle)
-│   ├── telemetry.md        # Telemetry system
-│   └── research/           # Deep dives on competitors, user sentiment
-├── plans/              # Implementation plans (version controlled)
-│   ├── active/         # Currently being implemented
-│   └── completed/      # Done plans (archived, not deleted)
-├── integrations/       # Downstream agent integration docs (OpenClaw, Hermes, ...)
-│   ├── README.md       # Canonical CLI vocabulary + install for agents calling the CLI
-│   ├── openclaw/README.md
-│   └── hermes/README.md
-├── brand-assets/       # Vector marks, Pop palette, poster compositions, raster exports
-│   ├── README.md       # Library guide and philosophy
-│   ├── marks/          # parakeet-line.svg (canonical recolorable line mark)
-│   ├── palette/        # palette.json/css/svg/png
-│   ├── compositions/   # Reusable SVG layouts (Warhol grid, OG, social, lockup)
-│   ├── exports/        # Ready-to-grab PNG renders
-│   └── scripts/render.sh
-├── Sources/
-│   ├── MacParakeet/            # GUI app (SwiftUI, imports MacParakeetCore + ViewModels)
-│   ├── CLI/                    # macparakeet-cli (ArgumentParser, imports MacParakeetCore)
-│   │   └── CHANGELOG.md        # CLI semver + compatibility policy (public contract)
-│   ├── MacParakeetCore/        # Shared library (no SwiftUI views)
-│   ├── MacParakeetViewModels/  # ViewModels (testable, depends on Core)
-│   └── MacParakeetObjCShims/   # ObjC @try/@catch trampoline for NSException (issue #91)
-├── Tests/
-│   ├── MacParakeetTests/   # Unit, database, integration, ViewModel tests
-│   └── CLITests/           # CLI parsing, output, and helper tests
-├── Assets/             # App icon (.icns + source PNG) and SVG logos
-└── scripts/            # Build, test, and release scripts
-```
-
-### Related Repos
-
-- [macparakeet-website](https://github.com/moona3k/macparakeet-website) -- Marketing website (Astro + Tailwind), macparakeet.com
-- [macparakeet-community](https://github.com/moona3k/macparakeet-community) -- Archived; all issues now on moona3k/macparakeet
-- [oatmeal](https://github.com/moona3k/oatmeal) -- Sibling product (meeting memory app); some meeting audio capture code was ported and adapted into MacParakeet
-
-### Feedback & Community
-
-In-app feedback creates GitHub Issues via a Cloudflare Pages Function. User emails are **never** posted in public issues.
-
-**Responding to issues:**
-- Be concise, genuine, no fluff
-- If a feature request is already shipped, say so and close the issue
-- If partially addressed, explain what's done and what's still open
-- Cross-reference related issues
-
-## Implementation Guidelines
-
-1. **Specs are the source of truth** -- Follow `spec/10-ai-coding-method.md` precedence: ADRs first, then narrative specs, then active plans, with `spec/kernel/requirements.yaml` as an optional supporting feature/status index. If code and spec disagree, update code to match the highest-precedence spec (or update the spec if it is wrong).
-2. **ADRs are locked** -- Don't second-guess architectural decisions in `spec/adr/`.
-3. **Never lose user data** -- Graceful degradation for dictation history and transcriptions.
-4. **UI philosophy** -- Minimal during dictation, rich for transcription results.
-5. **Local-first** -- Speech recognition stays on-device by default. Optional provider and media-download flows are user-triggered; model/update flows and self-hosted telemetry/crash reporting are product-managed surfaces. Retained purchase activation endpoints remain in code but current public builds are free/GPL-3.0 and always unlocked. That licensing plumbing is intentionally retained as future-option code for GPL-compatible official paid distribution/support, not cleanup fodder. Telemetry is opt-out in Settings and never includes audio or transcript content.
-6. **Simplicity is the product** -- Resist feature creep. MacParakeet does three things well.
-7. **Fast feedback loops for agents** -- Design everything so the agent can verify its own work: tests for logic, CLI for headless smoke-testing, build errors that surface immediately.
-8. **Bounded agent discretion** -- Agents should choose the simplest process that preserves correctness, test coverage, and ADR constraints. Kernel updates should be proportional to risk and user visibility.
-9. **Protect the context zone** -- For behavior changes, explicitly define in-scope requirements, out-of-scope behavior, and invariants before coding.
-
-## Documentation Hygiene
-
-**Keep docs aligned with code.** Stale documentation is worse than no documentation.
-
-After completing work: update spec progress in `spec/README.md` and `spec/02-features.md`, update README/agent docs when user-visible behavior or release status changes, archive completed plans to `plans/completed/`, and mark outdated docs with `> Status: **HISTORICAL**` headers.
-
-Document status headers: `**ACTIVE**` (authoritative), `**IMPLEMENTED**` (done, still accurate), `**HISTORICAL**` (superseded), `**PROPOSAL**` (under discussion).
-
-Source-of-truth precedence: ADR > narrative spec > active plan > kernel feature/status index > code/comments.
-
-## Working with Plans
-
-Plans live in `plans/` and are version-controlled. Create a plan for multi-file changes, new features, architectural changes, or complex refactoring. Skip plans for bug fixes, typos, single-file changes. See existing plans in `plans/completed/` for format examples.
-
-## Common Tasks
-
-### Add a new feature
-
-1. Read relevant spec (e.g., `spec/02-features.md`) and `spec/10-ai-coding-method.md`
-2. Identify existing requirement IDs, or add one in `spec/kernel/requirements.yaml` for notable user-visible/public behavior
-3. Create a plan in `plans/active/` if multi-file
-4. Implement in `Sources/MacParakeetCore/` (logic) and `Sources/MacParakeet/` (UI)
-5. Add/update tests in `Tests/MacParakeetTests/`
-6. Run focused tests, then `swift test` before merge
-7. Update spec progress markers
-
-### Add a new database table
-
-1. Update `spec/01-data-model.md` with schema
-2. Add migration in `Sources/MacParakeetCore/Database/DatabaseManager.swift` (inline migrations)
-3. Add model in `Sources/MacParakeetCore/Models/`
-4. Add repository in `Sources/MacParakeetCore/Database/{Name}Repository.swift`
-5. Run `swift test` to verify migrations
-
-### Fix a bug
-
-1. Write a test that reproduces the bug
-2. Run focused tests (should fail)
-3. Fix the bug
-4. Run focused tests (should pass), then run `swift test` before merge
-5. Commit with test + fix together
-
-### Release a new build
-
-Follow `docs/distribution.md` — it is the authoritative step-by-step guide
-(pre-flight tests, version bump, build, sign + notarize, R2 upload, Sparkle
-`sign_update`, appcast prepend, website deploy, verify).
-
-Critical invariants (full context and commands in the guide):
-
-- The DMG uploaded to R2 must be the **exact same file** you ran
-  `sign_update` on. Verify the served `content-length` equals the local
-  `stat -f%z dist/MacParakeet.dmg`; if they differ, Sparkle rejects the update.
-- Appcast enclosure URLs must include `?v={BUILD_NUMBER}` cache-busting —
-  Cloudflare CDN caches R2 objects (~4h), and a stale cached DMG fails
-  Sparkle as "improperly signed".
-- Bundled `yt-dlp_macos` (PyInstaller) signed with hardened runtime needs
-  `com.apple.security.cs.disable-library-validation=true`, or fresh installs
-  fail on first YouTube use with a `[PYI:ERROR]` Team ID mismatch. Smoke-test
-  after signing: `dist/MacParakeet.app/Contents/Resources/yt-dlp --version`.
-
-## Testing
-
-**Philosophy:** "Write tests. Not too many. Mostly integration."
-
-See `spec/09-testing.md` for full strategy. Key points:
-
-| Category | What | How |
-|----------|------|-----|
-| Unit | Pure logic, models, text processing | XCTest, fast |
-| Database | CRUD, queries, migrations | In-memory SQLite |
-| Integration | Service boundaries, STT pipeline | Protocol mocks |
-
-### Running Tests
+@AGENTS.md
+
+> Claude Code overlay for MacParakeet. Read [`AGENTS.md`](./AGENTS.md) first;
+> it is the canonical cross-agent startup guide. This file keeps the
+> Claude-specific reminders and high-risk repo lessons that are worth loading
+> every session.
+
+## Operating Style
+
+Use judgment. MacParakeet benefits from agents that can plan, verify, and push
+back when a proposed path is too heavy or too loose.
+
+- For substantial work, make a short plan, define the scope/invariants, then
+  execute. For tiny edits, skip the ceremony and keep momentum.
+- Prefer current code, tests, ADRs, and live command output over stale plans or
+  old notes.
+- If the checkout is dirty or unrelated, preserve it. Use a fresh worktree for
+  branch/PR work rather than cleaning up changes you did not make.
+- When a task touches user data, privacy, audio capture, persistence,
+  telemetry, CLI contracts, or concurrency, slow down and verify with tests or
+  runtime evidence.
+- Keep product decisions grounded in the trust-first direction: reliable
+  capture, recovery, durable local artifacts, polished daily workflows, and
+  simple intuitive UX before broader feature sprawl.
+
+## Current Context
+
+MacParakeet is a local-first voice app for Apple Silicon Macs with dictation,
+file/media URL transcription, meeting recording, and selected-text Transforms.
+The app and CLI share `MacParakeetCore`; the CLI is also a public automation
+surface for agents and scripts.
+
+For current feature/release state, use:
+
+- Release channels and feature flags: [`spec/README.md`](./spec/README.md#release-channels-and-feature-flags)
+- Spec index and roadmap: [`spec/README.md`](./spec/README.md)
+- Accepted decisions: [`spec/adr/`](./spec/adr/)
+- Feature behavior: [`spec/02-features.md`](./spec/02-features.md)
+- Architecture: [`spec/03-architecture.md`](./spec/03-architecture.md)
+- CLI compatibility: [`Sources/CLI/CHANGELOG.md`](./Sources/CLI/CHANGELOG.md)
+
+Do not restate volatile release flags in new docs unless the task is explicitly
+about release notes or feature gating. Link to the source instead.
+
+## Source Of Truth
+
+When artifacts conflict:
+
+1. Accepted ADRs in `spec/adr/`
+2. Narrative specs listed in `spec/README.md`
+3. Active plans, when the task is executing that plan
+4. Current code and tests
+
+If a higher-precedence doc is wrong, update it deliberately and explain why.
+The old manual requirements/traceability workflow is retired; legacy REQ IDs
+are archived at
+[`docs/historical/requirements-legacy.yaml`](./docs/historical/requirements-legacy.yaml)
+only to make old references understandable.
+
+## Workflows
+
+### Normal Code Work
+
+1. Inspect `git status --short`.
+2. Find the governing code, ADR/spec, and tests.
+3. Name the scope and must-not-change invariants for behavior changes.
+4. Edit narrowly, following existing patterns.
+5. Run focused tests, then broader tests proportional to risk.
+6. Update docs only when behavior, public contracts, release framing, privacy,
+   persistence, or user workflows changed.
+
+Plans are working memory for agents, not a process tax. Create/update a plan
+for multi-step or long-running work when it will prevent drift; skip plans for
+small fixes.
+
+### PR Review
+
+Use [`docs/pr-review-workflow.md`](./docs/pr-review-workflow.md). Scale the loop
+to risk:
+
+- Trivial: direct commit is fine.
+- Small: focused tests and one fresh-eye pass are usually enough.
+- Substantial: branch from `origin/main`, open a PR, run CI, use independent
+  review, and converge on findings rather than obeying every model suggestion.
+
+### Commit Messages
+
+Use [`docs/commit-guidelines.md`](./docs/commit-guidelines.md). Rich commit
+messages are for meaningful changes; concise messages are fine when they carry
+the future-reader context.
+
+## Hard-Won Pitfalls
+
+- Base new worktrees on `origin/main`, not local `main`.
+- Build/test from the worktree that owns the branch.
+- Ignore `.build*`, `.claude/worktrees`, `dist`, and
+  `journal/x-agent/node_modules` unless intentionally inspecting generated or
+  archival output.
+- Do not delete the user database, meeting session folders, lock files, or
+  source audio outside explicit recovery/discard flows.
+- Read subsystem READMEs before editing load-bearing Core areas:
+  `Audio/`, `STT/`, `TextProcessing/`, `Database/`, `Licensing/`.
+- GRDB UUID storage may not match `uuidString`; prefer repository/fetch-update
+  patterns over raw SQL `WHERE id = ?` with string UUIDs.
+- `PermissionService` is instantiated; it is not `.shared`.
+- Avoid fire-and-forget `Task` when the caller needs the result. Make the
+  function async and await it.
+- Avoid blocking `@MainActor` with long-running work.
+- `UTType(filenameExtension:)` can be nil.
+- Tooltips/hover behavior on non-activating panels often needs AppKit-level
+  tracking, not only SwiftUI `.help()` or `.onHover`.
+- `DictationFlowCoordinatorLoadCaptionTests` has historically had a short
+  timing race in CI. Rerun once before treating a single failure as a product
+  regression; investigate if it is reproducible or frequent.
+- CLI behavior is a public contract for external-facing commands. Update
+  `Sources/CLI/CHANGELOG.md` for compatibility-relevant changes.
+
+## Verification Defaults
 
 ```bash
-swift test                                       # Full deterministic suite, usually ~1-2 minutes
-swift test --filter TextProcessingPipelineTests  # Focused run of one test class while iterating
-swift test --parallel                            # Optional parallel run when chasing wall-clock time
-```
-
-### AI Agent Testing Loop
-
-1. **Before coding:** `swift test` to establish baseline
-2. **After changes:** `swift test` to verify no regressions
-3. **Bug fix:** Write test that reproduces bug, then fix
-4. Tests must be: **deterministic**, reasonably fast, and have **clear errors**. Use focused tests for quick iteration; the full suite usually takes ~1-2 minutes.
-
-### What We Skip
-
-- SwiftUI view tests (test ViewModels instead)
-- Audio capture tests (test processing logic with fixtures)
-- Third-party library internals (trust GRDB, FluidAudio)
-
-## Building
-
-```bash
-# Build, code-sign, and launch the dev app
-scripts/dev/run_app.sh
-
-# Optional: force a specific signing identity for the dev .app bundle
-MACPARAKEET_CODESIGN_IDENTITY="Apple Development: Your Name (TEAMID)" scripts/dev/run_app.sh
-
-# Build and run CLI -- dual-purpose surface (see note below).
-swift build --target CLI
-swift run macparakeet-cli --help
-swift run macparakeet-cli --version
-swift run macparakeet-cli transcribe /path/to/audio.mp3
-swift run macparakeet-cli health
-
-# Run tests
+swift build
+swift test --filter TextProcessingPipelineTests
 swift test
-
-# Open in Xcode
-open Package.swift  # Select MacParakeet scheme
+scripts/dev/check.sh [TestFilter]
+scripts/dev/run_app.sh
+swift run macparakeet-cli health
 ```
 
-## File Locations (Runtime)
-
-| Item | Path |
-|------|------|
-| App bundle | `/Applications/MacParakeet.app` |
-| Database | `~/Library/Application Support/MacParakeet/macparakeet.db` |
-| Parakeet / Nemotron STT models | FluidAudio default cache, `~/Library/Application Support/FluidAudio/Models/` (Parakeet: `parakeet-*/`; Nemotron multilingual: `nemotron-multilingual/`; Nemotron English: `nemotron-streaming/<tier>ms`, e.g. `nemotron-streaming/1120ms`; CoreML; ~465 MB per Parakeet build, ~1.5 GB Nemotron multilingual / ~600 MB Nemotron English) |
-| Whisper STT models | `~/Library/Application Support/MacParakeet/models/stt/whisper/` |
-| yt-dlp binary | `~/Library/Application Support/MacParakeet/bin/yt-dlp` |
-| FFmpeg binary | `~/Library/Application Support/MacParakeet/bin/ffmpeg` |
-| Settings | `~/Library/Preferences/com.macparakeet.MacParakeet.plist` (dev build: `com.macparakeet.dev`) |
-| Temp audio | `$TMPDIR/macparakeet/` |
-| Logs | `~/Library/Logs/MacParakeet/` |
-
-## Security and Privacy
-
-| Permission | Reason | When Requested |
-|------------|--------|----------------|
-| Microphone | Dictation + meeting recording | Onboarding or first dictation/meeting use |
-| Accessibility | Global hotkey, paste simulation | Onboarding or first dictation use |
-| Screen & System Audio Recording | System audio capture for meeting recording (ScreenCaptureKit) | Optional onboarding step or first meeting recording use |
-
-1. **Offline-first** -- Dictation and file transcription work fully offline. Network is limited to user-triggered downloads/providers, update checks, retained purchase activation endpoints if explicitly invoked, and opt-out non-identifying telemetry.
-2. **Temp files deleted** -- Audio removed after transcription (unless user saves)
-3. **Non-identifying telemetry** -- Session-scoped, opt-out in Settings. No persistent IDs, no IP storage, no content. See `docs/telemetry.md` and ADR-012.
-4. **No accounts** -- No login, no email, no tracking
-
----
-
-## Good Patterns to Follow
-
-### Code Patterns
-
-| Pattern | Why | Example |
-|---------|-----|---------|
-| In-memory SQLite for tests | Fast, isolated, no cleanup needed | Use GRDB's `DatabaseQueue(configuration:)` with in-memory config |
-| Protocol-based services | Makes mocking easy for tests | Define `TranscriptionServiceProtocol`, implement concrete + mock |
-| GRDB repositories (one per table) | Clean separation, consistent CRUD | `DictationRepository`, `TranscriptionRepository` |
-| KeylessPanel for non-activating overlays | NSPanel that never steals focus | Subclass with `canBecomeKey -> false` for dictation overlay |
-| Timer in .common run-loop mode | `.default` mode pauses during UI tracking (slider drag) | `RunLoop.main.add(timer, forMode: .common)` |
-| DesignSystem tokens | Consistent styling, easy to change globally | Centralize spacing, typography, colors in `DesignSystem.swift` |
-| `parakeetAction(_:)` button roles | Semantic intent at the callsite — abstracts `.buttonStyle + .tint` composition; one coral CTA per surface | `.parakeetAction(.primary / .primaryProminent / .secondary / .destructive / .destructiveProminent / .subtle)`. Never re-tint the SwiftUI environment with `.tint(coral)` at NSHostingView roots — coral cascades only from `parakeetAction`. |
-| TextProcessingPipeline as pure function | No side effects, easy to test | Input text -> output text, no state mutation |
-| Cache computed values with signature check | Avoid O(n) work every frame | Check record ID + word count + timestamps before rebuilding |
-
-### Architecture Patterns
-
-| Pattern | Description |
-|---------|-------------|
-| Manual NSApplication.run() | No SwiftUI `App` protocol -- manual `NSApplication.shared.run()` for reliable CLI execution without .app bundle. Same pattern as Oatmeal. |
-| NSStatusItem for menu bar | Menu bar via `NSStatusBar.system.statusItem()`, not SwiftUI `MenuBarExtra` |
-| NSWindow + NSHostingView | Main window created programmatically, SwiftUI content hosted via `NSHostingView` |
-| Core library has no SwiftUI views | `MacParakeetCore` is primarily Foundation + GRDB + FluidAudio plus optional WhisperKit. AppKit is limited to small macOS adapter services (`ClipboardService`, `PermissionService`, `TelemetryService` termination notification, `ExportService`) and must not introduce UI ownership. |
-| ViewModels in separate target | `MacParakeetViewModels/` -- testable without GUI, depends only on Core |
-| Views organized by feature | `Views/Dictation/`, `Views/Transcription/`, not flat |
-| Observable ViewModels | `@MainActor @Observable` on all ViewModels |
-| Async/await for all I/O | No completion handlers, no Combine for new code |
-
-### CLI Dual Purpose
-
-`macparakeet-cli` serves two audiences from one codebase:
-
-1. **Dev/testing tool** -- Agents working on MacParakeet use the CLI to verify features headlessly (database CRUD, pipeline runs, health checks, config). Not GUI parity -- just fast feedback loops where agents can't drive the GUI. Be flexible about what to include.
-2. **Real CLI surface** -- Agent operators and power users running headless STT on Apple Silicon. ~17 top-level subcommands; the externally-supported core is `transcribe`, `export`, `llm`, `transforms`, `vocab`, `prompts`, `quick-prompts`, `meetings`, `history`, `stats`, `models`, `health`, `config`. `transcribe` accepts multiple inputs (files, folders, YouTube URLs) and `--output-dir` for walk-away batch jobs (continue-on-error, one transcript file per input); a single input with no `--output-dir` is unchanged (stdout). Semver tracked in `Sources/CLI/CHANGELOG.md`.
-
-Both audiences share the same command tree. Dev/auxiliary commands (e.g. `calendar`, `meeting-vad-sim`, `spec`, `feedback`) don't hurt external users by being visible. Audio-input diagnostics are surfaced via `macparakeet-cli health`, not a standalone command. When adding CLI commands, decide which audience it primarily serves -- that determines how much polish and JSON contract work it needs.
-
----
-
-## Known Pitfalls (Hard-Won Lessons)
-
-These come from OatFlow experience and from working in this repo. Don't
-repeat them.
-
-### Git / Worktree Gotchas
-
-- **Base new branches/worktrees on `origin/main`, not local `main`** -- this
-  repo runs many parallel worktrees, so the local `main` ref is often stale.
-  `git fetch origin` first, then
-  `git worktree add -b my-branch ../macparakeet-worktrees/my-branch origin/main`.
-- **Build from the worktree the branch is checked out in** -- Xcode/SwiftPM
-  state under `.swiftpm/` pins source paths to the worktree that created it,
-  so `xcodebuild` invoked from another checkout can silently compile the
-  wrong tree. `swift build` / `swift test` run from inside the worktree are
-  always safe.
-- **`DictationFlowCoordinatorLoadCaptionTests` is known-flaky on CI** -- a
-  `waitUntil` races a ~60 ms transient state, so the same commit can pass and
-  fail seconds apart. Re-run the failed job; don't "fix" the test unless the
-  flake rate justifies a harness refactor.
-- **Mixed line endings flip whole files on edit** -- keep text files LF;
-  never commit CRLF. If the repo has `.git-blame-ignore-revs` (added with
-  the repo-wide LF renormalization), run
-  `git config blame.ignoreRevsFile .git-blame-ignore-revs` once locally so
-  mechanical commits don't bury real history.
-
-### Swift Language Gotchas
-
-- **`??` with `try await` does not work** -- Swift's `??` uses an autoclosure for the RHS, which doesn't support async/throwing. Use `if let ... else` instead of `title ?? (try await getTitle())`.
-- **Fire-and-forget `Task` for async side-effects loses results** -- Don't use `Task { try await ... }` inside a sync function if the caller needs the result. Make the function `async` and `await` directly.
-- **Force-unwrap `UTType(filenameExtension:)` can be nil** -- Unregistered extensions return nil. Always use `if let`.
-- **`nonisolated` + existential protocol types conflict** -- Changing an actor's stored property from a concrete type to `any Protocol` breaks `nonisolated` access. Either drop `nonisolated` or keep the concrete type.
-
-### UI/AppKit Gotchas
-
-- **Don't block @MainActor with long-running work** -- Use `Task.detached` for heavy work, hop back to MainActor for UI updates.
-- **Tooltips on non-activating NSPanel need AppKit-level NSTrackingArea** -- `.help()`, `.onHover`, and `NSViewRepresentable` with `.activeInActiveApp` all fail on `.nonactivatingPanel`. Only `NSTrackingArea` with `.activeAlways` works.
-- **Segmented Picker `.labelsHidden()`** -- SwiftUI `Picker` with `.segmented` style shows its label string unless `.labelsHidden()` is applied.
-- **Segmented Picker label truncation** -- 5+ segments in a sidebar-width picker will truncate. Use shorter labels.
-
-### Database Gotchas
-
-- **Raw SQL UPDATE with UUID -- use GRDB's `fetchOne(key:)` + `update()` pattern** -- GRDB stores UUID values via Codable encoding, which may differ from `id.uuidString`. Never use raw SQL `WHERE id = ?` with `uuidString`.
-- **`PermissionService` is not a singleton** -- Instantiate it (`PermissionService()`), don't use `.shared`.
-
-### General
-
-- **Dead code from iterating on approaches** -- When switching approaches, delete old code entirely. Don't leave `_ = unusedVar` artifacts.
-- **Retained purchase activation is intentional** -- Do not delete `EntitlementsService`, `LemonSqueezyLicenseAPI`, entitlement state, or trial/license telemetry as dead code unless the project owner explicitly requests it and the decision is reflected in an ADR/spec update.
-- **Meeting recovery artifacts are user data** -- Do not delete meeting session folders, lock files, or source audio outside the recovery/discard flows without explicit user intent.
-- **CLI is a public contract** -- Preserve `macparakeet-cli` behavior for external-facing commands and update `Sources/CLI/CHANGELOG.md` for compatibility-relevant changes. See "CLI Dual Purpose" above for which commands need full contract treatment.
-- **PyInstaller helpers need library-validation care** -- Bundled `yt-dlp_macos` unpacks and `dlopen`s an embedded Python framework. Developer ID + hardened runtime signing without `com.apple.security.cs.disable-library-validation=true` breaks fresh installs at first YouTube transcription/playback with a Team ID mismatch.
-- **Review agents catch real bugs** -- Running a review agent on critical flows catches P0 issues. Worth the 60 seconds.
-- **CI duplicates without workflow concurrency** -- Add `concurrency` with `cancel-in-progress: true` and a stable group key to avoid duplicate pipelines.
-
----
-
-## Commit Message Guidelines
-
-This project uses **rich commit messages** with `## What Changed`, `## Root Intent`, `## Prompt That Would Produce This Diff`, `## ADRs Applied`, and `## Files Changed` sections. See `docs/commit-guidelines.md` for full format and examples. Use for significant changes; optional for trivial fixes.
-
----
-
-## Quick Checklist for AI Agents
-
-### Before Starting Work
-
-- [ ] Read this file (CLAUDE.md)
-- [ ] Read `spec/10-ai-coding-method.md` for spec precedence and lightweight kernel usage
-- [ ] Check `spec/README.md` for current version progress
-- [ ] Identify requirement IDs for notable feature/public behavior changes (`spec/kernel/requirements.yaml`)
-- [ ] Define the context zone: in-scope behavior, must-not-change invariants, and out-of-scope behavior
-- [ ] Check `plans/active/` for any in-progress plans
-- [ ] Run `swift test` to establish baseline
-
-### After Completing Work
-
-- [ ] Run required focused tests and `swift test` -- all tests should pass
-- [ ] Update docs if behavior changed (specs, README, this file)
-- [ ] Archive completed plans to `plans/completed/`
-- [ ] Commit with rich message (see `docs/commit-guidelines.md`)
-- [ ] Keep it simple -- resist feature creep
-
----
-
-*This file helps AI assistants understand the project quickly. Update it as the project evolves.*
+Use the smallest command that proves the change while iterating. Before calling
+code work complete, run `swift test` unless the user explicitly narrows the
+verification scope or the environment blocks it.

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ All speech recognition runs locally. Parakeet uses the Neural Engine; optional N
 - **Discuss new work first** — For features or behavior changes, open an issue before starting a PR so we can agree on scope and product fit.
 - **Submit scoped PRs** — Once the issue direction is clear, fork, make the scoped changes, run `swift test`, and link the issue in the PR.
 - **Read the specs** — Architecture decisions and feature specs live in `spec/`
-- **Using a coding agent?** Point it at [`AGENTS.md`](AGENTS.md) — build/test commands, code style, and repo conventions for Claude Code, Codex, and friends. Deeper project context is in [`CLAUDE.md`](CLAUDE.md).
+- **Using a coding agent?** Point it at [`AGENTS.md`](AGENTS.md) — the canonical build/test commands, code style, repo conventions, and links to deeper context for Claude Code, Codex, and friends.
 
 ## Support
 

--- a/docs/historical/README.md
+++ b/docs/historical/README.md
@@ -1,0 +1,13 @@
+# Historical Documents
+
+> Status: **HISTORICAL** - Reference only; not active process guidance.
+
+These files are retained so old plans, ADRs, audits, and commits remain
+understandable. They are not active process requirements.
+
+## Files
+
+- [`requirements-legacy.yaml`](requirements-legacy.yaml) -- retired `REQ-*`
+  feature/status index from the old spec kernel workflow. Do not add new REQ
+  IDs for normal work; use current specs, tests, code search, and `git` history
+  for implementation discovery.

--- a/docs/historical/requirements-legacy.yaml
+++ b/docs/historical/requirements-legacy.yaml
@@ -1,8 +1,7 @@
-# MacParakeet Requirements
-# Optional, compact feature/status index. Stable requirement IDs for
-# cross-referencing specs, commits, and ADRs. Not exhaustive and not required
-# on every change. (Tests and git are the authoritative coverage/history record;
-# the former manual source/test traceability map was retired.)
+# MacParakeet Legacy Requirements (Historical)
+# Retired feature/status index retained only so old plans, ADRs, audits, and
+# commits remain understandable. Do not add or update REQ IDs for normal work;
+# use specs, tests, code search, and git history instead.
 # Format: REQ-{area}-{number}: {description}
 #
 # Areas:

--- a/docs/plans/2026-06-14-001-feat-rich-meeting-detection-plan.md
+++ b/docs/plans/2026-06-14-001-feat-rich-meeting-detection-plan.md
@@ -455,11 +455,10 @@ stateDiagram-v2
 - **Files:**
   - `Tests/MacParakeetTests/MeetingActivity/MeetingActivityIntegrationTests.swift`
   - `spec/adr/024-activity-based-meeting-detection.md`
-  - `spec/kernel/requirements.yaml`
   - `docs/qa/meeting-activity-detection.md`
 - **Approach:** Add a small integration-style test layer over fake collectors
   and document a manual QA matrix for real OS behavior. Update ADR-024 and
-  REQ-MEET-016 status only after implementation lands.
+  the narrative specs only after implementation lands.
 - **Patterns to follow:** Existing coordinator integration tests under
   `Tests/MacParakeetTests/Calendar` and
   `Tests/MacParakeetTests/MeetingRecordingFlow`.
@@ -512,8 +511,7 @@ QA matrix is clean.
 ## Documentation and Rollout Notes
 
 - Update ADR-024 only after the implementation lands, not before.
-- Update `spec/kernel/requirements.yaml` status text once Phase C is actually
-  implemented.
+- Update the narrative specs once Phase C is actually implemented.
 - Add `docs/qa/meeting-activity-detection.md` with the real-device test matrix.
 - Keep `AppFeatures.meetingActivityDetectionEnabled = false` until targeted
   tests, full `swift test`, and manual QA pass.
@@ -526,8 +524,8 @@ QA matrix is clean.
 
 - `spec/adr/024-activity-based-meeting-detection.md` defines the intended
   activity-detection architecture and staged rollout.
-- `spec/kernel/requirements.yaml` tracks REQ-MEET-016 as active and describes
-  Phases A+B as foundation only.
+- The legacy `REQ-MEET-016` entry is historical; current status belongs in
+  ADR-024 and the narrative specs.
 - `Sources/MacParakeetCore/MeetingDetection/MeetingActivityDetector.swift`
   shows the current coarse detector contract that this plan replaces.
 - `Sources/MacParakeetCore/MeetingDetection/CameraActivityCollector.swift`

--- a/docs/pr-review-workflow.md
+++ b/docs/pr-review-workflow.md
@@ -32,17 +32,18 @@ Match the ceremony to the risk. Most changes are not "substantial."
 | Tier | Examples | Treatment |
 |------|----------|-----------|
 | **Trivial** | Typos, doc edits, copy tweaks, a single obvious line | Commit direct to `main`. No PR, no agents. |
-| **Small** | A contained bug fix with a test, a self-evident refactor | Branch + PR optional; at least one fresh-eye agent pass on the diff. Self-merge once green. |
+| **Small** | A contained bug fix with a test, a self-evident refactor | Branch + PR optional; focused verification. A fresh-eye pass is useful when the failure mode is subtle. |
 | **Substantial** | New feature, new abstraction, auth/payments/data/migrations, public surface (CLI, telemetry, API), >~50 changed lines, anything user-visible | Full loop below. |
 
-When unsure, ask the owner which tier — don't default to elaborate.
+When unsure, choose the lightest tier that still protects correctness and user
+trust.
 
 ## The full loop (substantial changes)
 
 1. **Branch first.** Create the branch *before* writing code, base it on
-   `origin/main` (not local `main`, which lags — see
-   `memory/feedback_worktree_base_origin_main`). Open a real PR so "merge"
-   actually merges. **Do not** push to `main` and then retrofit a review gate
+   `origin/main` (not local `main`, which often lags; see `AGENTS.md`
+   Worktrees). Open a real PR so "merge" actually merges. **Do not** push to
+   `main` and then retrofit a review gate
    — that forces force-pushes, throwaway base branches, and close-instead-of-
    merge. (We learned this the awkward way.)
 2. **Define the context zone** before coding: in-scope behavior, must-not-
@@ -98,8 +99,7 @@ in parallel, each with a distinct lens. Choose by what the diff touches:
 Give each agent the diff, the intent, and the *specific* invariants to attack
 (e.g. "prove the raw URL cannot reach telemetry"). Their job is to *break* the
 change, not bless it. Convergence between independent agents + the PR bots is
-the strongest readiness signal we have. (See
-`memory/feedback_multi_llm_review`.)
+the strongest readiness signal we have.
 
 ## What makes a good PR description
 
@@ -124,7 +124,9 @@ Write it for a smart reader who wasn't in the room.
       resolved or explicitly declined with reasoning
 - [ ] Fresh-eye agent pass(es) done; findings converged to trivial
 - [ ] No overengineering — simplest design that holds; dead code deleted
-- [ ] Docs updated if behavior changed (spec, README, CLAUDE.md, CHANGELOG)
+- [ ] Docs updated if behavior changed: governing spec/ADR, README or CLI
+      changelog when public-facing, and AGENTS.md/CLAUDE.md only when agent
+      workflow guidance changes
 - [ ] PR description is audience-friendly and complete
 - [ ] Merged into `main`; branch deleted
 

--- a/docs/research/coding-agent-instructions-2026-06.md
+++ b/docs/research/coding-agent-instructions-2026-06.md
@@ -1,0 +1,120 @@
+# Coding Agent Instruction Strategy - 2026-06
+
+> Status: **ACTIVE REFERENCE** - Rationale for the June 2026 agent-doc cleanup.
+
+## Summary
+
+MacParakeet should keep always-loaded agent instructions short, concrete, and
+verification-oriented. Durable startup context should explain how to build,
+test, navigate, and avoid known project hazards. Volatile feature catalogs,
+release deltas, long plans, and historical requirement indexes should live in
+linked docs that agents load only when relevant.
+
+This supports the current split:
+
+- `AGENTS.md` is the canonical cross-agent startup guide.
+- `CLAUDE.md` is a small Claude-specific overlay.
+- `spec/10-ai-coding-method.md` describes the working method.
+- Historical `REQ-*` IDs are archived, not part of normal workflow.
+
+## Official Tool Guidance
+
+### Anthropic Claude Code
+
+Anthropic describes `CLAUDE.md` as persistent context loaded into sessions, not
+enforced configuration. Their guidance says concise, specific instructions are
+followed more consistently, and recommends adding material when it represents
+something Claude would otherwise need re-explained: repeated mistakes, review
+feedback, recurring clarifications, or context a new teammate needs. It also
+suggests moving multi-step or narrow-context procedures out of the always-loaded
+file into more specific mechanisms.
+
+Source: https://code.claude.com/docs/en/memory
+
+### OpenAI Codex
+
+OpenAI's Codex best-practices guidance recommends using `AGENTS.md` for durable
+repo guidance: layout, commands, conventions, PR expectations, constraints, and
+definition of done. It explicitly favors a short, accurate `AGENTS.md` over a
+long file of vague rules, and recommends linking task-specific docs when the
+main file grows too large. It also recommends planning first for complex tasks
+and validating changes with tests/review rather than stopping at code
+generation.
+
+Source: https://developers.openai.com/codex/learn/best-practices
+
+### AGENTS.md Format
+
+The public AGENTS.md format frames the file as a README for agents: a predictable
+place for setup commands, test commands, and project conventions that would
+clutter a human README.
+
+Source: https://agents.md/
+
+## Research Evidence
+
+### Long Context Is Not Free
+
+`Lost in the Middle` shows that long-context models can fail to use information
+robustly depending on where it appears in the prompt. For agent instruction
+files, the practical implication is not "never use long context"; it is "do not
+make every session pay for information that only matters occasionally." Keep
+high-priority rules short and near startup, and link to deeper docs by task.
+
+Source: https://arxiv.org/abs/2307.03172
+
+### Agent Interfaces Matter
+
+`SWE-agent` argues that language-model agents are end users of software tools
+and benefit from purpose-built agent-computer interfaces. The MacParakeet
+translation is that instructions should emphasize actionable interfaces:
+commands, file locations, test loops, worktree rules, and verification paths.
+A giant prose encyclopedia is a weaker interface than a concise guide plus
+discoverable docs.
+
+Source: https://arxiv.org/abs/2405.15793
+
+### Reasoning Plus Action Beats Static Reasoning
+
+`ReAct` supports interleaving reasoning with actions against external tools and
+environments. For coding agents, that favors instructions that tell the agent
+how to inspect, run, test, and verify, rather than instructions that try to
+preload every possible fact.
+
+Source: https://arxiv.org/abs/2210.03629
+
+### Reflection Helps When It Captures Real Feedback
+
+`Reflexion` shows value in agents learning from feedback through persistent
+natural-language reflections. For repo docs, the useful version is not a large
+up-front rulebook; it is updating agent guidance after repeated mistakes,
+review findings, or recurring clarifications.
+
+Source: https://arxiv.org/abs/2303.11366
+
+### Benchmarks Do Not Replace Local Verification
+
+Work on SWE-bench contamination/memorization argues that benchmark gains can
+overstate generalizable coding ability. For MacParakeet, this reinforces the
+need for local verification: current code, focused tests, full tests when
+appropriate, CI, and review. Do not assume a frontier model will infer every
+repo-specific invariant from broad coding ability.
+
+Source: https://arxiv.org/html/2506.12286v1
+
+## MacParakeet Decisions
+
+1. Keep root startup docs under roughly one screen of essential guidance per
+   file when possible.
+2. Put commands, worktree rules, product constraints, and verification defaults
+   in `AGENTS.md`.
+3. Keep `CLAUDE.md` real but narrow: Claude-specific operating style,
+   high-risk pitfalls, and links to current sources.
+4. Link to specs and ADRs for feature state instead of duplicating release
+   flags in startup context.
+5. Treat plans as useful agent working memory for substantial tasks, not a
+   mandatory ceremony.
+6. Retire the manual `REQ-*`/traceability workflow. Use specs, tests, code
+   search, and `git` history for current implementation discovery.
+7. Use independent review and convergence for substantial changes, but keep the
+   review loop proportional to risk.

--- a/plans/active/2026-05-dictation-first-onboarding.md
+++ b/plans/active/2026-05-dictation-first-onboarding.md
@@ -139,8 +139,9 @@ Convention to match: `@MainActor @Observable` ViewModels; telemetry via
 - `Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift`
 - `Sources/MacParakeetCore/AppFeatures.swift` (doc-comments only)
 - `Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift`
-- Docs on completion: `spec/adr/005-onboarding-first-run.md`, `spec/02-features.md`,
-  `spec/README.md`, optional `spec/kernel/requirements.yaml` (`REQ-ONB-001`).
+- Docs on completion: `spec/adr/005-onboarding-first-run.md`,
+  `spec/02-features.md`, and `spec/README.md`. Old `REQ-*` references are
+  historical only; do not update the retired requirements index.
 
 **In scope (Part B, separate commit):** the four bounded warm-up guards in Design §5,
 in the same two source files + the test file.
@@ -406,5 +407,5 @@ firm new-user floor (sessions ≠ users; multi-release days inflate launches).
 - Part B interacts with the warm-up state machine covered by
   `2026-06-onboarding-stall-watchdog-test.md` — run/extend those tests if you
   touch the watchdog arming.
-- On completion: ADR-005 amendment, spec progress, `REQ-ONB-001` (+ traceability),
-  then archive this plan to `plans/completed/`.
+- On completion: ADR-005 amendment and spec progress, then archive this plan to
+  `plans/completed/`.

--- a/plans/active/2026-06-13-live-dictation-streaming-parakeet-and-preview-ui.md
+++ b/plans/active/2026-06-13-live-dictation-streaming-parakeet-and-preview-ui.md
@@ -114,7 +114,7 @@ Confirmed/volatile two-tone + a smoother source (e.g. `SlidingWindowAsrManager`)
 - Part A: screenshots + overlay VM tests.
 
 ## Docs to update (after shipping)
-REQ-STT-002 (above); `CLAUDE.md` Release Channels (feature + `liveDictationStreamingEnabled` in the main-vs-release delta); `Sources/MacParakeetCore/STT/README.md` (display-only ephemeral preview + sample-preview API + single-flight + "never the paste"); `docs/research/live-dictation-streaming.md` (record Whisper probe; flip status); `spec/02-features.md`/`spec/README.md`. Move plan → `completed/`; update board + advisor index. Note: ADR-016 cites FluidAudio 0.13.6 but `Package.resolved` is 0.15.2 — reconcile.
+ADR/spec live-preview wording; `spec/README.md` Release Channels And Feature Flags (feature + `liveDictationStreamingEnabled` in the main-vs-release delta); `Sources/MacParakeetCore/STT/README.md` (display-only ephemeral preview + sample-preview API + single-flight + "never the paste"); `docs/research/live-dictation-streaming.md` (record Whisper probe; flip status); `spec/02-features.md`/`spec/README.md`. Move plan → `completed/`; update board + advisor index. Note: ADR-016 cites FluidAudio 0.13.6 but `Package.resolved` is 0.15.2 — reconcile.
 
 ## STOP conditions
 - Drift on any anchor since `2473828f5`.

--- a/plans/active/2026-06-14-meeting-activity-detection.md
+++ b/plans/active/2026-06-14-meeting-activity-detection.md
@@ -179,8 +179,9 @@ after a false-positive + idle-CPU pass.
 - Mark ADR-024 status from PROPOSAL → IMPLEMENTED as phases ship; record any
   amendments inline (ADR-017 style).
 - `spec/README.md` + `spec/02-features.md`: add the activity-detection entry to
-  the meeting section; update REQ-MEET-016 status when the coordinator wires.
-- `CLAUDE.md` Release Channels: note the new `AppFeatures` flag in the
-  `main`-vs-release delta until it ships in a tagged build.
+  the meeting section and update status when the coordinator wires.
+- `spec/README.md` Release Channels And Feature Flags: note the new
+  `AppFeatures` flag in the `main`-vs-release delta until it ships in a tagged
+  build.
 - Archive this plan to `plans/completed/` once Phase C/D land and the flag is
   on in a release.

--- a/plans/active/2026-06-14-meeting-mic-reliability.md
+++ b/plans/active/2026-06-14-meeting-mic-reliability.md
@@ -46,7 +46,7 @@ This plan implements ADR-025's two halves — a mic-health watchdog (REQ-MEET-01
 
 ## REQ-MEET-013 reconciliation (read before Phase C)
 
-REQ-MEET-013 says VAD-guided live chunking leaves "final post-stop transcription … unchanged." That refers to **how an individual chunk is transcribed** — unchanged whether VAD live chunking is on or off. This plan does **not** touch per-chunk STT, the chunker, or the assembler. It **adds a completeness-repair stage** that re-runs STT **only for speech the live path missed**. For a healthy meeting (coverage high → Accept) the repair stage is a no-op and the final transcript is byte-identical to today's. When Phase C lands, the coordinator narrows REQ-MEET-013's wording in `spec/kernel/requirements.yaml` accordingly (this plan does not edit `requirements.yaml`).
+REQ-MEET-013 says VAD-guided live chunking leaves "final post-stop transcription … unchanged." That refers to **how an individual chunk is transcribed** — unchanged whether VAD live chunking is on or off. This plan does **not** touch per-chunk STT, the chunker, or the assembler. It **adds a completeness-repair stage** that re-runs STT **only for speech the live path missed**. For a healthy meeting (coverage high → Accept) the repair stage is a no-op and the final transcript is byte-identical to today's. When Phase C lands, narrow that old REQ framing in ADR-025 and the narrative specs; the legacy requirements index is archived and no longer updated.
 
 ## Phased rollout
 
@@ -144,7 +144,8 @@ The completeness-repair stage. Pure planner + offline VAD + selective re-transcr
 - [ ] Full-fallback tier handles systemic failure; crash-recovered sessions get coverage repair
 - [ ] Original live transcript + retained `.m4a` never destroyed by repair
 - [ ] Both telemetry events mirrored in `macparakeet-website/functions/api/telemetry.ts` and deployed before flag-on
-- [x] REQ-MEET-017 Phase A status updated by the coordinator; REQ-MEET-013 narrowing and REQ-MEET-018 status remain for Phase C
+- [x] ADR/spec status updated for Phase A; coverage-repair wording remains for
+  Phase C
 - [x] `swift test` exits 0; docs/spec progress updated (`spec/README.md`, `spec/02-features.md`)
 - [ ] Plan archived to `plans/completed/` on completion
 

--- a/plans/active/nemotron-english-streaming-variant.md
+++ b/plans/active/nemotron-english-streaming-variant.md
@@ -241,9 +241,9 @@ main local engine.
 - DONE: `spec/adr/001-parakeet-stt.md` (header amendment line 2026-06-11 +
   full "Addendum: Nemotron English Beta Build (June 2026)" section).
 - DONE: `spec/adr/016-centralized-stt-runtime-scheduler.md` (amendment line).
-- DONE: `spec/kernel/requirements.yaml` → REQ-STT-004 (version: v0.7 — flag
-  to owner in PR; v0.6 is the last closed batch).
-- DONE: `spec/kernel/traceability.md` → REQ-STT-004 row.
+- DONE: legacy `REQ-STT-004` entry was added during the now-retired
+  requirements workflow. Do not update the archived requirements index for
+  follow-up work; use ADR/spec updates instead.
 
 ## REMAINING WORK (in order)
 

--- a/spec/10-ai-coding-method.md
+++ b/spec/10-ai-coding-method.md
@@ -1,290 +1,165 @@
-# 10 - AI Coding Method
+# 10 - Agent Working Method
 
 > Status: **ACTIVE** - Authoritative, current
 
 ## Purpose
 
-This document defines how MacParakeet uses specs to drive implementation with coding agents.
+This document explains how agents and humans should use MacParakeet's specs,
+plans, tests, and review loops without turning process into the product.
 
-Goal: reduce ambiguity, prevent drift, and make generated code maintainable over time.
+The goal is simple: keep changes grounded, verifiable, and easy for the next
+person or agent to continue.
 
-## Philosophy
+Rationale and external references for this approach live in
+[`../docs/research/coding-agent-instructions-2026-06.md`](../docs/research/coding-agent-instructions-2026-06.md).
 
-1. ADRs record locked decisions; do not second-guess them without a new ADR.
+## Principles
+
+1. ADRs record accepted decisions. Do not second-guess them casually.
 2. Narrative specs explain product behavior, architecture, and rationale.
-3. Plans capture active implementation work and should be reconciled back into specs before merge.
-4. The kernel is a lightweight, optional feature/status index, not a parallel contract system or a coverage map.
-5. Determinism beats cleverness for core product flows.
+3. Plans are working memory for substantial or long-running tasks, not a
+   mandatory ceremony for every edit.
+4. Tests, current code, and `git` history are the reliable source for
+   implementation and coverage discovery.
+5. Use the lightest process that still protects correctness, privacy, user
+   data, and product quality.
 
-## Context Zone (Probability Control)
+## Source Of Truth
 
-Coding agents sample actions from context. In practice: weak context spreads probability mass across many plausible edits; strong context concentrates probability mass on valid edits.
-
-The "context zone" is the bounded set of behavior allowed by current ADRs, specs, active plans, and tests.
-
-For every behavior change, define zone boundaries up front:
-
-1. Governing ADRs and spec sections.
-2. Target requirement IDs in `spec/kernel/requirements.yaml` when the change maps to an existing notable feature (adding new IDs is optional).
-3. "Must not change" invariants for public interfaces, persistence formats, privacy boundaries, and stateful/concurrent flows.
-4. Focused tests that verify in-zone behavior and reject out-of-zone drift.
-
-Any out-of-zone behavior change must be explicitly called out and reflected in the highest-precedence artifact it affects.
-
-## External Evidence (Rationale)
-
-The context-zone model is consistent with current research and vendor guidance:
-
-1. Long-context reliability degrades with poor information placement ("lost in the middle").
-   - https://arxiv.org/abs/2307.03172
-2. Prompt structure and query placement materially affect long-context performance.
-   - https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/long-context-tips
-3. Simpler, structured SWE workflows can outperform heavier autonomous setups.
-   - https://arxiv.org/abs/2407.01489
-4. Tool-grounded reasoning loops improve error recovery and reduce hallucination-style failures.
-   - https://arxiv.org/abs/2210.03629
-5. SWE benchmark results can be inflated by memorization/contamination; eval hygiene matters.
-   - https://openai.com/index/introducing-swe-bench-verified/
-   - https://arxiv.org/abs/2506.12286
-
-Inference: strong boundary artifacts improve the probability that agent actions remain in-zone. Use heavier artifacts only where they materially reduce ambiguity.
-
-## Decision
-
-Adopt a pragmatic spec model:
-
-1. **Decision layer:** accepted ADRs in `spec/adr/` for locked architectural and product decisions.
-2. **Narrative layer:** `spec/00-*` docs for product behavior, architecture, data model, UI, testing, and release status.
-3. **Plan layer:** `plans/active/` for in-flight implementation details; completed plans are historical records.
-4. **Kernel support layer:** `spec/kernel/requirements.yaml` as an optional, compact feature/status index. (The former manual feature -> source -> test map, `traceability.md`, was retired: it was a write-only hand-index with no machine consumer, and tests plus `git` are the authoritative coverage and history record.)
-
-Optional contracts and state machines may be added for high-risk seams, but they are not required repo-wide.
-
-## Source-of-Truth Order
-
-When artifacts conflict, precedence is:
+When artifacts conflict, use this order:
 
 1. Accepted ADRs in `spec/adr/`
-2. Narrative specs in `spec/00-*`
-3. Active implementation plans in `plans/active/`
-4. Kernel feature/status index (`spec/kernel/requirements.yaml`)
-5. Existing code/comments
+2. Narrative specs listed in `spec/README.md`
+3. Active plans, when the task is executing that plan
+4. Current code and tests
 
-If conflict is found, update the lower-precedence artifact in the same change. If the higher-precedence artifact is wrong, update it deliberately and explain why.
+If a lower-precedence artifact is stale, update it when it matters to the
+change. If a higher-precedence artifact is wrong, update it deliberately and
+explain why in the PR/commit.
 
-## Kernel Artifacts
+## Retired Kernel Workflow
 
-Maintain the artifacts that currently provide value:
+The old manual requirements and traceability workflow is retired.
+`spec/kernel/traceability.md` was removed, and the legacy requirements index now
+lives at [`../docs/historical/requirements-legacy.yaml`](../docs/historical/requirements-legacy.yaml).
 
-- `spec/kernel/requirements.yaml` (optional feature/status index)
+That file exists only so old plans, ADRs, audits, and commits that mention
+`REQ-*` IDs remain understandable. Do not add new REQ IDs as part of normal
+work. For current implementation discovery, use code search, tests, and git
+history.
 
-### Requirement Index
+## Context Zone
 
-`requirements.yaml` is a compact feature/status index. Each top-level key is the stable requirement ID. Each entry should include:
+For behavior changes, define the context zone before editing:
 
-- `description`
-- `version` or release/train marker
-- `status`
+1. What behavior is in scope.
+2. What must not change.
+3. Which ADRs/specs/code paths govern the work.
+4. Which tests or runtime checks will prove the change.
 
-Allowed `status` values:
+This does not need a long document. A few bullets in a plan, PR, or working
+notes are enough when the scope is clear.
 
-- `status`: `proposed | active | implemented | deprecated | historical`
+## Plans
 
-Requirement ID format:
+Use plans when they help the work stay coherent:
 
-- `REQ-<area>-<nnn>` where `<area>` is stable (`DICT`, `TRANS`, `MEET`, `CLI`, etc.) and `<nnn>` is zero-padded when practical.
+- New features
+- Multi-file refactors
+- Architecture or data-model changes
+- Long-running agent tasks
+- Work likely to be resumed by another agent
 
-Example:
+Skip plans for typos, copy edits, simple bug fixes, small internal refactors,
+and obvious one-file changes.
 
-```yaml
-REQ-YT-001:
-  description: YouTube URL transcription via yt-dlp
-  version: v0.3
-  status: implemented
+Plans should be useful to agents: state the goal, constraints, phases,
+verification, and current status. Archive or mark them historical when they stop
+representing active work.
+
+## Documentation Updates
+
+Update docs when the change affects:
+
+- User-visible behavior
+- Public CLI behavior or JSON/error contracts
+- Persistence, migrations, import/export, or retained local artifacts
+- Privacy, telemetry, network surfaces, or local-first guarantees
+- Release framing, feature flags, onboarding, or support guidance
+- ADR/spec decisions
+
+Do not update docs just to satisfy a checklist. Stale mechanical docs are worse
+than no docs.
+
+## Testing
+
+During development, run focused tests for the touched area. Before merge or
+completion, run broader tests proportional to risk.
+
+Default expectation for code changes:
+
+```bash
+swift test
 ```
 
-Optional fields such as `source`, `priority`, and `acceptance` are allowed when they clarify active or high-risk work, but they are not required for every historical entry.
+Use focused filters for iteration:
 
-### Finding Source and Tests
-
-There is no manual requirement -> source -> test map. To find what implements or tests a feature, use `git grep`, test names, and `git log`/`git blame` — all always-accurate and free. An always-green suite is stronger evidence of coverage than a hand-maintained table that merely claims it.
-
-### Optional Contracts
-
-Create `spec/kernel/contracts/*.yaml` only when a stable interface needs machine-checkable clarity, such as:
-
-- CLI JSON envelopes and exit/error contracts
-- Import/export bundle schemas
-- Database migration compatibility contracts
-- Telemetry/privacy event schemas
-- External-process invocation boundaries
-
-Each contract should include:
-
-- `name`
-- `input`
-- `output`
-- `errors` (stable error codes)
-- `invariants`
-
-Example:
-
-```yaml
-name: transcribe_url
-input:
-  url: string
-  onProgress: optional_callback_string
-output:
-  transcription:
-    id: uuid
-    status: completed
-errors:
-  - invalid_url
-  - video_not_found
-  - download_failed
-  - timed_out
-invariants:
-  - sourceURL must equal request url for URL-based transcriptions
+```bash
+swift test --filter TextProcessingPipelineTests
+scripts/dev/check.sh [TestFilter]
 ```
 
-### Optional State Machines
+Higher-risk areas need stronger proof: audio capture, meeting recovery,
+database migrations, CLI contracts, telemetry/privacy, concurrency, and shared
+runtime scheduling.
 
-Create `spec/kernel/state_machines/*.yaml` only for flows where explicit transitions reduce real risk, such as:
+## Review
 
-- Dictation lifecycle
-- Meeting recording lifecycle and crash recovery
-- STT scheduler/lease behavior
-- Calendar auto-start
-- Destructive import/replace flows
+Review rigor should match the risk:
 
-Each state machine should include:
+- Trivial changes can go straight in after a quick check.
+- Small contained fixes need focused verification and, when useful, one
+  fresh-eye review.
+- Substantial changes should use the full PR loop in
+  [`../docs/pr-review-workflow.md`](../docs/pr-review-workflow.md): branch from
+  `origin/main`, run CI, get independent review, address valid findings, and
+  stop when findings converge to trivial or duplicative.
 
-- `name`
-- `initial`
-- `states`
-- `events`
-- `transitions`
-- `terminal_states`
+Model review is input, not authority. Fix valid issues, decline wrong findings
+with evidence, and avoid worse designs just to satisfy a reviewer.
 
-Example:
+## Agent Discretion
 
-```yaml
-name: dictation_flow
-initial: idle
-states: [idle, recording, processing, success, error]
-events: [start_recording, stop_recording, stt_ok, stt_fail]
-transitions:
-  - { from: idle, event: start_recording, to: recording }
-  - { from: recording, event: stop_recording, to: processing }
-  - { from: processing, event: stt_ok, to: success }
-  - { from: processing, event: stt_fail, to: error }
-terminal_states: [success, error]
-```
+Agents are expected to choose the simplest path that preserves correctness and
+quality. Good discretion looks like:
 
-## Implementation Workflow
-
-For any behavior change:
-
-1. Read the governing ADRs, spec sections, and active plans.
-2. Identify existing requirement IDs to anchor the change; adding a new ID is optional and reserved for naming a genuinely new user-visible capability, persistence format, or CLI surface.
-3. Define must-not-change invariants before editing.
-4. Add/update tests for changed behavior.
-5. Add/update optional contracts or state machines only if the change touches a high-risk seam listed above.
-6. Run tests per test-scope policy.
-
-Small bug fixes, copy changes, internal refactors, and straightforward UI polish may skip new requirement IDs when the existing specs and tests already bound the work.
-
-## Test-Scope Policy
-
-During development:
-
-1. Run focused tests for touched requirements (fast loop).
-2. Run broader local suite when touching shared/core flows.
-
-Before merge:
-
-1. Run `swift test` locally or in CI for full-suite verification.
-
-## Definition of Done
-
-### PR-Ready DoD
-
-A change is PR-ready only when all are true:
-
-1. Governing ADR/spec/plan context was checked.
-2. Requirement entries are updated when the change adds or changes a notable feature/public behavior (optional — see Kernel Artifacts).
-3. Optional contracts/state machines are updated when they exist for the touched seam.
-4. Focused tests pass for affected behavior.
-5. Precedence conflicts are reconciled.
-
-### Merge Gate
-
-A change is merge-complete only when all are true:
-
-1. PR-Ready DoD is satisfied.
-2. Full test suite (`swift test`) passes in CI.
-3. Relevant docs and plan status markers are updated.
-
-## Coding Rules for Agents
-
-1. Do not treat kernel files as higher precedence than ADRs or narrative specs.
-2. Do not introduce major user-visible behavior without updating the relevant spec/plan and, when appropriate, `requirements.yaml`.
-3. Prefer explicit error codes over free-form strings for public CLI, import/export, and core flow errors.
-4. Preserve local-first/privacy ADR constraints unless an ADR changes.
-5. Requirement IDs do not need to appear in Swift source or test names unless that improves clarity.
-
-### Agent Discretion (Bounded)
-
-Agents are expected to use judgment, but within explicit constraints:
-
-1. For behavior changes, documentation updates should be proportional to risk and user visibility.
-2. For non-behavioral changes (formatting, comments, renames, internal refactors with unchanged behavior), agents may use a lighter process.
-3. If a materially better third approach is identified, propose it and update this method before adopting it broadly.
-4. Prefer the simplest process that preserves correctness, test coverage, and ADR constraints.
+- Reading the local subsystem README before touching a load-bearing subsystem.
+- Using the existing architecture instead of inventing a parallel one.
+- Adding tests where failure would matter.
+- Keeping plans and docs proportional to the work.
+- Calling out out-of-scope behavior explicitly.
+- Preserving user worktree changes you did not make.
 
 ## Anti-Patterns
 
 Avoid:
 
-1. Treating optional contracts/state machines as if they already exist.
-2. Claiming CI enforces a process gate (coverage, requirement mapping) unless a CI check actually does.
-3. Requirement IDs that change over time.
-4. Silent behavior changes not reflected in the relevant ADR/spec/plan/kernel docs.
-5. Retrofitting heavy YAML artifacts for low-risk historical features just to satisfy process.
+1. Treating old `REQ-*` IDs as required workflow.
+2. Creating plans that only restate obvious steps.
+3. Updating release or feature status in multiple places instead of linking to
+   the source.
+4. Shipping behavior changes without updating the governing ADR/spec when they
+   conflict.
+5. Running elaborate review loops for trivial edits.
+6. Obeying review comments without deciding whether they are correct.
+7. Leaving dead code from abandoned approaches.
 
-## Rollout Plan
+## Definition Of Done
 
-### Current Operating Mode
+A change is done when:
 
-1. Keep `requirements.yaml` accurate as an optional, compact feature/status index.
-2. Add optional contracts/state machines only when they reduce ambiguity at high-risk seams.
-
-Success metric:
-
-- A new agent can quickly find the source and test surface for a shipped feature via `git grep`, test names, and history.
-- Kernel docs do not contradict ADRs, narrative specs, or current code.
-
-### Targeted Investment
-
-When repeatedly editing a high-risk flow, add the smallest durable artifact that would have prevented the last ambiguity:
-
-- A contract for stable I/O/error schemas.
-- A state machine for tricky lifecycle/concurrency behavior.
-
-Non-goals:
-
-- 100% active-feature kernel coverage.
-- CI failure on unmapped requirements without first building and maintaining that check.
-- Repo-wide retroactive contracts for simple or historical behavior.
-
-## Relationship to Existing Specs
-
-Narrative docs remain the human-facing product and architecture guide. ADRs remain the locked decision record. The kernel supports implementation discovery and review; it is not the primary implementation authority.
-
-Use each artifact for what it is good at:
-
-- ADRs: decisions and constraints.
-- Narrative specs: product behavior and architecture.
-- Plans: active implementation detail.
-- Kernel requirements: compact, optional status/index.
-- Optional contracts/state machines: targeted clarity for high-risk seams.
+1. The implementation matches the governing ADR/spec or deliberately updates it.
+2. The relevant tests or runtime checks pass.
+3. User-visible/public-contract docs are updated when needed.
+4. Plans are updated or archived when they were part of the work.
+5. The final explanation names what changed and what was verified.

--- a/spec/README.md
+++ b/spec/README.md
@@ -19,7 +19,7 @@
 | 07 | [Text Processing](07-text-processing.md) | Clean pipeline, custom words, snippets | Active |
 | 08 | [Error Handling](08-error-handling.md) | Error philosophy, categories, recovery | Active |
 | 09 | [Testing](09-testing.md) | Testing strategy, patterns, guidelines | Active |
-| 10 | [AI Coding Method](10-ai-coding-method.md) | Spec-driven coding philosophy and kernel methodology | Active |
+| 10 | [Agent Working Method](10-ai-coding-method.md) | Pragmatic agent workflow, spec precedence, plans, tests, and review | Active |
 | 11 | [LLM Integration](11-llm-integration.md) | LLM providers, summary, chat, transforms | Implemented (§1 summary superseded by spec/12) |
 | 12 | [Processing Layer](12-processing-layer.md) | Prompt library, multi-summary, v0.5 implementation contract | Active |
 | 13 | [Agent Workflows](13-agent-workflows.md) | Future actions, workflows, agents, voice control, App Intents | Draft |
@@ -47,6 +47,30 @@ These decisions are final. Do not second-guess them.
 | Database | SQLite via GRDB | Single file, embedded, zero config |
 | Platform | macOS 14.2+ (Apple Silicon only) | FluidAudio requires Apple Silicon; Swift 6 language mode (tools-version 5.9) |
 | Business model | Current public build free/GPL/unlocked; official paid distribution/support remains possible | Originally $49 one-time (ADR-003), went free with open-source release in v0.5; retained purchase activation plumbing is future-option code |
+
+## Release Channels And Feature Flags
+
+> Canonical release-status block for agents and docs. Update this section when
+> release channel framing changes or an `AppFeatures` flag flips.
+
+| Channel | Status | Notes |
+|---------|--------|-------|
+| Stable DMG | User-facing release, recommended for normal use | Dictation, file/media URL transcription, meeting recording, calendar auto-start (opt-in, default off), Transforms, VAD-guided meeting live-preview chunking, optional Nemotron Beta and WhisperKit, exports, vocabulary, AI features |
+| `main` | Development | Latest stable release plus untagged fixes and the flag delta below |
+
+Current `main` feature gates in `Sources/MacParakeetCore/AppFeatures.swift`:
+
+| Flag | Value | Release note |
+|------|-------|--------------|
+| `meetingRecordingEnabled` | `true` | Shipping meeting-recording surface |
+| `calendarEnabled` | `true` | Shipping calendar reminders/auto-start; per-user auto-start defaults off |
+| `meetingAutoStopEnabled` | `true` | `main` dogfood flag for ADR-023; per-user setting defaults off and is not yet in a tagged release |
+| `meetingCaptureReliabilityEnabled` | `true` | Default-on kill switch for ADR-025 Phase A mic-health telemetry watchdog |
+| `meetingActivityDetectionEnabled` | `false` | ADR-024 collectors/detector are compiled but runtime coordinator/UI remain gated |
+| `transformsEnabled` | `true` | Productized Transforms shipping surface |
+| `meetingVadLiveChunkingEnabled` | `true` | VAD-guided meeting live-preview chunking; final post-stop transcript path unchanged |
+| `liveDictationStreamingEnabled` | `true` | Display-only live dictation preview enabled on `main`; final paste remains stop-time transcription |
+| `aiFormatterProfilesEnabled` | `false` | App-aware AI Formatter profiles are code-complete but held out of the current tagged release train |
 
 ## Architecture Decision Records (ADRs)
 
@@ -252,21 +276,13 @@ Calendar-related code is implemented and **enabled** (`AppFeatures.calendarEnabl
 - [x] Local Transform history with input/output/source-app/timing stored in `transform_history`
 - [x] CLI `transforms` and `transforms history` command trees for headless provisioning and verification
 
-## For AI Coding Assistants
+## For Coding Agents
 
-### Key Rules
+Start with [`../AGENTS.md`](../AGENTS.md) for build commands, repo conventions,
+and the active agent workflow. This spec index is the map to product behavior,
+architecture, and accepted decisions.
 
-1. **Specs are authoritative.** If code and spec disagree, the spec is correct (then fix the code).
-2. **ADRs are locked.** Do not propose alternatives to locked decisions.
-3. **Version order matters.** Implement v0.1 before v0.2. Do not jump ahead.
-4. **Never lose user data.** Graceful degradation over silent failure.
-5. **Local-first.** Audio stays on-device for STT. Optional AI sends transcript text only to the user-configured provider or CLI tool. Telemetry is opt-out and self-hosted.
-6. **`swift test` is the gate.** All tests must pass before and after changes.
-7. **Kernel is supporting context.** `spec/kernel/requirements.yaml` is an optional, compact feature/status index. ADRs and narrative specs stay higher precedence; tests and `git` are the authoritative coverage and history record.
-
-### Where to Start
-
-1. Read this file (you're here)
-2. Read `CLAUDE.md` in the project root for build instructions and codebase patterns
-3. Check `plans/active/` for in-progress work
-4. Check the version progress above for what needs doing next
+Old `REQ-*` IDs are historical. The manual requirements/traceability workflow
+is retired; the legacy index lives at
+[`../docs/historical/requirements-legacy.yaml`](../docs/historical/requirements-legacy.yaml)
+for old references only.

--- a/spec/adr/022-transforms-system-wide-rewrite.md
+++ b/spec/adr/022-transforms-system-wide-rewrite.md
@@ -115,7 +115,7 @@ Two events:
 
 Custom-Transform names are never transmitted (every non-built-in maps to `custom` in telemetry). This protects users who name a Transform after the company they're using it for, etc.
 
-Both events must be added to `ALLOWED_EVENTS` in `macparakeet-website/functions/api/telemetry.ts` before they fire in production (per `memory/feedback_telemetry_allowlist.md` — the Worker drops the entire batch on any unknown event). This is a two-repo coordination point baked into the rollout plan.
+Both events must be added to `ALLOWED_EVENTS` in `macparakeet-website/functions/api/telemetry.ts` before they fire in production; the Worker drops the entire batch on any unknown event. This is a two-repo coordination point baked into the rollout plan.
 
 ### 9. Feature-flag rollout (`AppFeatures.transformsEnabled`)
 

--- a/spec/adr/025-meeting-capture-reliability.md
+++ b/spec/adr/025-meeting-capture-reliability.md
@@ -159,9 +159,9 @@ reconciliation:
   stage is a no-op and the final transcript is byte-identical to today's.
 - So the precise updated framing: *the per-chunk transcription is
   unchanged; a coverage-repair stage may additionally re-transcribe
-  speech regions the live path failed to cover.* REQ-MEET-013's wording
-  is narrowed accordingly when REQ-MEET-018 lands (the coordinator owns
-  that requirements.yaml edit, not this ADR).
+  speech regions the live path failed to cover.* The old `REQ-MEET-*`
+  references are historical anchors only; current wording belongs in this
+  ADR and the narrative specs.
 
 ### 4. Crash-recovery path benefits from the same repair (ADR-019)
 
@@ -401,7 +401,8 @@ deliver value without later ones.
    `MeetingVADService` wiring in the post-stop path; selective re-
    transcription of uncovered gaps on the `STTScheduler` background slot;
    write-back to the saved row; `meeting_transcript_repair` telemetry.
-   Reconcile REQ-MEET-013 wording in `requirements.yaml` (coordinator).
+   Reconcile the old REQ-MEET-013 framing in this ADR and the narrative
+   specs; the legacy requirements index is archived and no longer updated.
 4. **Phase D — Full-fallback tier + crash-recovery integration.** Add the
    `.fullReTranscribe` tier for systemic-failure coverage, and apply the
    coverage-repair stage to crash-recovered sessions (ADR-019). Optional:


### PR DESCRIPTION
## What Changed

- Rewrites `AGENTS.md` as the canonical cross-agent startup guide.
- Keeps `CLAUDE.md` as a real file, but makes it a small Claude overlay that imports `@AGENTS.md`.
- Reframes `spec/10-ai-coding-method.md` as a pragmatic Agent Working Method: specs/ADRs first, optional plans, tests/git for discovery, and review proportional to risk.
- Adds `spec/README.md` as the canonical release channel / feature-flag location.
- Archives the retired `spec/kernel/requirements.yaml` index under `docs/historical/requirements-legacy.yaml` and updates active/current references that still pointed at the old workflow.
- Adds `docs/research/coding-agent-instructions-2026-06.md` with official Claude/Codex/AGENTS.md guidance plus arXiv grounding.

## Why

The old startup context had grown into a feature encyclopedia and process contract. This keeps the load-bearing rules always available while moving volatile release state, old REQ IDs, and research rationale behind links agents can load when relevant.

## Fresh-Eye Review

Ran two independent document-review passes:

- Coherence review found stale source-of-truth wording, historical file headers, non-repo memory references, and PR checklist drift. Fixed.
- Adversarial review found two merge blockers: Claude needed a real `@AGENTS.md` import, and release/flag state needed a canonical replacement before leaving `CLAUDE.md`. Fixed.

## Verification

- `git diff --cached --check`
- Relative markdown link sanity check across changed staged markdown files
- Confirmed archived requirements index matches the current `origin/main` version before archival

Swift tests not run: docs-only workflow cleanup.
