### PR TITLE
Docs: record Cohere as recommended opt-in STT engine (FluidAudio CoreML, no MLX)

### DIFF
--- a/plans/active/asr-benchmark-and-model-expansion.md
+++ b/plans/active/asr-benchmark-and-model-expansion.md
@@ -31,6 +31,17 @@
 > Remaining: SenseVoice/Paraformer reproduced locally (os_log capture gap; cited
 > from FluidAudio's published numbers for now), Qwen3-ASR & Moonshine (MLX, deferred).
 
+> **Outcome & decision 2026-06-19 (benchmark complete).** The harness is hardened
+> and independently verified in **PR #568** (bootstrap + paired-delta CIs, scorer
+> tests, speed/memory micro-benchmark, pinned-version reproducibility, committed
+> evidence). Decision recorded in **ADR-001 (2026-06-19 amendment + Cohere
+> addendum)**: **Cohere is the recommended next engine — an opt-in Beta gated to
+> ≥16 GB RAM — and it is FluidAudio CoreML, NOT MLX** (public `CoherePipeline` in
+> FluidAudio ≥ 0.15.4; no new runtime). The MLX runtime path (Phase 3) is
+> therefore needed only for Qwen3-ASR / Moonshine, which stay deferred. The
+> stale Tier-3 / Phase-3 text below that filed Cohere under the MLX path is
+> corrected inline.
+
 ## North Star tie-in
 
 MacParakeet is "a fast, local-first voice app for Mac." Every model decision
@@ -154,9 +165,12 @@ multilingual + EN (Beta), WhisperKit large-v3-turbo. All reachable via
 **Tier 3 — accuracy leaders, integration unproven on-device:**
 - **Cohere Transcribe (cohere-transcribe-03-2026)** — Apache-2.0, 2B, **#1 on
   the Open ASR Leaderboard at 5.42% avg** (LibriSpeech-clean 1.25%), 14 langs
-  incl. KO/JA/ZH/AR, Conformer enc + Transformer dec. **MLX path exists**
-  (mlx-audio); no production CoreML/Swift yet. Benchmark for quality now;
-  integrate only if the accuracy edge justifies the work.
+  incl. KO/JA/ZH/AR, Conformer enc + Transformer dec. **Runs on-device via
+  FluidAudio CoreML** (q8 repo `FluidInference/cohere-transcribe-03-2026-coreml`,
+  public `CoherePipeline` in FluidAudio ≥ 0.15.4) — **no MLX needed** (the earlier
+  "MLX path exists; no CoreML yet" note was wrong). Benchmarked this session;
+  recommended as an opt-in ≥16 GB add — see the 2026-06-19 outcome above and
+  ADR-001.
 - **Canary-1B-flash** — CC-BY-4.0, multilingual + translation; FluidInference
   (mobius) has CoreML conversion in progress. Watch the FluidAudio roadmap.
 
@@ -190,13 +204,15 @@ Small 24B (too large), all cloud APIs (Deepgram/AssemblyAI/ElevenLabs/Speechmati
    license | size | RTFx | peak RSS | on-device runtime | verdict.
 
 ### Phase 3 — Integration decisions (needs owner steer + ADRs)
-- **Near-term, low-cost:** add SenseVoice-Small as an optional FluidAudio engine
-  (multilingual/ZH/JP/KO + emotion) — mirrors how Nemotron was added. Likely a
-  clear win if Phase 2 confirms.
+- **Near-term, low-cost (FluidAudio CoreML, no new runtime):** **Cohere
+  Transcribe** is the benchmark's recommended add — an opt-in Beta gated to
+  ≥16 GB RAM (ADR-001, 2026-06-19). SenseVoice-Small is a second candidate
+  (multilingual/ZH/JP/KO + emotion). Both mirror how Nemotron/Unified were added.
 - **Strategic, ADR-scale:** an **MLX runtime path** (new ADR, mirrors ADR-021
-  WhisperKit) to unlock Qwen3-ASR (multilingual flagship), Moonshine (low-latency
-  dictation), and eventually Cohere. This is the big fork — it adds a third
-  on-device runtime family alongside FluidAudio/CoreML and WhisperKit.
+  WhisperKit) to unlock Qwen3-ASR (multilingual flagship) and Moonshine
+  (low-latency dictation) — the candidates that genuinely need MLX. This is the
+  big fork — it adds a third on-device runtime family alongside FluidAudio/CoreML
+  and WhisperKit. (Cohere does **not** require this fork.)
 - Decide per winner: default vs opt-in, language routing, model download UX,
   Settings/CLI surfacing, telemetry.
 

--- a/plans/active/asr-benchmark-and-model-expansion.md
+++ b/plans/active/asr-benchmark-and-model-expansion.md
@@ -162,7 +162,7 @@ multilingual + EN (Beta), WhisperKit large-v3-turbo. All reachable via
 - **Kyutai STT 2.6B** — CC-BY-4.0, English, streaming (2.5s delay), MLX weights
   + moshi-swift. Larger; watch FluidAudio for a CoreML conversion.
 
-**Tier 3 — accuracy leaders, integration unproven on-device:**
+**Tier 3 — accuracy leaders (integration cost varies per model):**
 - **Cohere Transcribe (cohere-transcribe-03-2026)** — Apache-2.0, 2B, **#1 on
   the Open ASR Leaderboard at 5.42% avg** (LibriSpeech-clean 1.25%), 14 langs
   incl. KO/JA/ZH/AR, Conformer enc + Transformer dec. **Runs on-device via
@@ -198,8 +198,10 @@ Small 24B (too large), all cloud APIs (Deepgram/AssemblyAI/ElevenLabs/Speechmati
 1. Tier 1: run SenseVoice/Paraformer via the FluidAudio CLI (already built at
    `~/asr-bench/FluidAudio-0154`). Near-free.
 2. Tier 2/3: standalone MLX/Python runners (not integrated) for Qwen3-ASR,
-   Moonshine, Kyutai, Cohere Transcribe — accuracy on the suite + on-device
-   speed/RSS on this machine. Score through the same normalizer.
+   Moonshine, Kyutai — accuracy on the suite + on-device speed/RSS on this
+   machine. (Cohere Transcribe is **done** — it ran via the FluidAudio CLI, not a
+   standalone MLX runner; see the 2026-06-19 outcome.) Score through the same
+   normalizer.
 3. Publish the full matrix: model | langs | WER (per dataset + macro) | streaming |
    license | size | RTFx | peak RSS | on-device runtime | verdict.
 

--- a/spec/06-stt-engine.md
+++ b/spec/06-stt-engine.md
@@ -70,6 +70,19 @@ Because Nemotron is a streaming engine, dictation on **both** Nemotron builds (m
 
 Parakeet remains the default because it is faster, lower-latency, and lower-memory for supported languages. Nemotron is the faster experimental path (multilingual default build, English-only opt-in build); WhisperKit solves mature broad coverage while preserving the local-first speech boundary.
 
+### Cohere Transcribe (Evaluated Candidate — Not Yet Integrated)
+
+Cohere Transcribe (`cohere-transcribe-03-2026`, 2B, Apache-2.0) was evaluated by the gold-standard benchmark (`benchmarks/asr/`, PR #568) and is **recommended as a future opt-in engine, not yet shipped** (ADR-001 amendment 2026-06-19). It runs on-device through the **same FluidAudio CoreML SDK** as Parakeet/Nemotron — FluidAudio ≥ 0.15.4 exposes a public `CoherePipeline`; q8 model repo `FluidInference/cohere-transcribe-03-2026-coreml` — so **no MLX or new runtime is required**, unlike the deferred MLX-only candidates (Qwen3-ASR, Moonshine).
+
+| Property | Value |
+|----------|-------|
+| Status | Evaluated + recommended; **not integrated** |
+| Accuracy | Most accurate on-device: English macro WER 2.07% (full LibriSpeech); best Japanese (FLEURS CER 5.56). Significant lead only on noisy English + Japanese; clean EN/KO/ZH are statistical ties (paired-bootstrap CIs) |
+| Cost | **~11 GB peak RSS**, ~73 s one-time ANE compile, ~11× realtime, ~2.3 GB model |
+| If integrated | Opt-in Beta engine gated to ≥16 GB RAM, via a `CohereEngine` wrapping FluidAudio's `CoherePipeline` routed in `STTRuntime` (the Nemotron/Unified pattern) |
+
+Recommendation: Parakeet v3 stays the default and WhisperKit the light multilingual option; Cohere would be surfaced for accuracy-critical / noisy / Japanese transcription on 16 GB+ Macs. Full methodology, CIs, and speed/memory tables: `benchmarks/asr/README.md`.
+
 ### Three-Chip Architecture
 
 Each ML workload runs on the chip it was designed for:

--- a/spec/adr/001-parakeet-stt.md
+++ b/spec/adr/001-parakeet-stt.md
@@ -10,6 +10,7 @@
 > Amendment (2026-06-11): Nemotron Speech Streaming EN 0.6B (`english-1120ms`) is added as a second opt-in Beta build under the Nemotron engine, a peer of the multilingual build the way Parakeet v2 is a peer of v3. Parakeet v3 remains the primary/default STT engine; promotion of either Nemotron build still requires real MacParakeet corpus benchmarks.
 > Amendment (2026-06-17): NVIDIA Parakeet Unified EN 0.6B (`unified`) is added as a third opt-in Parakeet build (English-only). Unlike the v2/v3 TDT builds it is a separate FluidAudio runtime (`UnifiedAsrManager`, no `AsrModelVersion`) served by a dedicated `ParakeetUnifiedEngine`, but it is presented to users as a Parakeet model. Parakeet v3 remains the primary/default; Unified provides strong English offline accuracy with punctuation/capitalization (FluidAudio v0.15.4 CoreML benchmark: 2.15% average / 1.68% aggregate WER on LibriSpeech test-clean; NVIDIA upstream card: 1.63% offline WER). Phase 1 ships offline-only; FluidAudio's native low-latency streaming build (`parakeet-unified-2080ms`) is the planned follow-up. Issue #520.
 > Amendment (2026-06-18): Parakeet Unified Phase 2 wires FluidAudio's native `StreamingUnifiedAsrManager` (`parakeet-unified-2080ms`) into live dictation preview while keeping file transcription, meeting finalization, and the final dictation paste on the higher-quality offline batch path. Unified remains English-only, opt-in, and non-default; it still exposes no word-level timings through MacParakeet.
+> Amendment (2026-06-19): Cohere Transcribe (`cohere-transcribe-03-2026`, 2B, Apache-2.0) is **evaluated and recommended as a future opt-in engine — not yet integrated**. It runs fully on-device through the **FluidAudio CoreML** SDK already vendored here (FluidAudio ≥ 0.15.4 exposes a public `CoherePipeline`/`CohereAsrConfig` and a q8 CoreML repo); **no MLX runtime or other new dependency is required** — unlike the MLX-only candidates (Qwen3-ASR, Moonshine), which stay deferred. The gold-standard benchmark (`benchmarks/asr/`, hardened + independently verified in PR #568) found Cohere the most accurate on-device engine (full-LibriSpeech macro WER 2.07% vs 2.38% Parakeet-unified; best Japanese), but with a decisive cost — **~11 GB peak RSS**, ~73 s one-time ANE compile, ~11× realtime, ~2.3 GB model — and, under paired-bootstrap CIs, a *significant* accuracy lead only on noisy English and Japanese (clean English, Korean, Chinese are ties). Decision: Parakeet v3 remains the primary/default; **if integrated, Cohere ships as an opt-in Beta engine gated to ≥16 GB RAM**, via a `CohereEngine` wrapping FluidAudio's `CoherePipeline` routed in `STTRuntime` (the Nemotron/Unified pattern). Integration is a separate, ADR-gated change. See the Cohere addendum below.
 
 ## Context
 
@@ -209,6 +210,49 @@ upstream model is under the NVIDIA Open Model License Agreement, so — like eve
 other model — it stays a user-triggered download, never bundled. Fresh installs
 still default to Parakeet v3.
 
+## Addendum: Cohere Transcribe — Evaluated Candidate, Not Yet Integrated (June 2026)
+
+> Date: 2026-06-19
+> Status: **Recommendation** (benchmark outcome; not implemented)
+
+A gold-standard cross-engine benchmark (`benchmarks/asr/`, hardened and
+independently verified in PR #568) evaluated Cohere Transcribe
+(`cohere-transcribe-03-2026`, 2B params, Apache-2.0, #1 on the HF Open ASR
+Leaderboard) as a candidate on-device engine.
+
+**It is FluidAudio CoreML, not MLX.** FluidAudio ≥ 0.15.4 — the exact SDK
+MacParakeet already depends on — ships a public `CoherePipeline` actor and a q8
+CoreML model repo (`FluidInference/cohere-transcribe-03-2026-coreml`). So Cohere
+needs **no new runtime**: it would be integrated exactly like the Nemotron and
+Parakeet-Unified engines — a `CohereEngine` wrapping the FluidAudio pipeline,
+routed inside `STTRuntime`, with a user-triggered model download. This is what
+distinguishes it from the deferred MLX-only candidates (Qwen3-ASR, Moonshine).
+
+**Findings** (Apple M4 Pro; full LibriSpeech + FLEURS; one canonical normalizer;
+paired-bootstrap significance):
+- Most accurate on-device engine — English macro WER **2.07%** (vs 2.38%
+  Parakeet-unified, 3.00% Whisper); best Japanese (FLEURS CER 5.56 vs Whisper 13.42).
+- The accuracy lead is *statistically significant* only on **noisy English**
+  (`test-other`) and **Japanese**; clean English, Korean, and Chinese are ties
+  with the best alternative.
+- Cost is the decisive factor: **~11 GB peak resident memory** (constant across
+  file counts → model-resident, measured via the FluidAudio reference harness),
+  **~73 s one-time ANE compile**, **~11× realtime** (vs ~70× / ~120 MB for
+  Parakeet), ~2.3 GB download.
+
+**Recommendation (not a locked decision yet):** keep Parakeet v3 the default and
+WhisperKit the light multilingual option. **If** integrated, ship Cohere as an
+**opt-in Beta engine gated to ≥16 GB RAM** with a clear download-size /
+cold-start warning, surfaced for accuracy-critical, noisy, or Japanese
+transcription. Both Nemotron builds are dominated by this benchmark (settling
+#520). Actual integration — engine wrapper, model-download UX, Settings/CLI
+surfacing, the RAM gate, telemetry — is a separate, ADR-gated change, and like
+every model the weights stay a user-triggered download, never bundled.
+
+See `benchmarks/asr/README.md` (PR #568) for the full methodology, CIs, and
+speed/memory tables; `plans/active/asr-benchmark-and-model-expansion.md` for the
+candidate landscape.
+
 ## References
 
 - [NVIDIA Parakeet TDT 0.6B-v3](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3)
@@ -218,4 +262,5 @@ still default to Parakeet v3.
 - [parakeet-mlx](https://github.com/senstella/parakeet-mlx) -- MLX port (original runtime, superseded)
 - [ADR-021: WhisperKit as Optional Multilingual STT Engine](021-whisperkit-multilingual-stt.md)
 - [Nemotron 3.5 ASR Streaming 0.6B](https://huggingface.co/nvidia/nemotron-3.5-asr-streaming-0.6b)
+- [FluidInference/cohere-transcribe-03-2026-coreml](https://huggingface.co/FluidInference/cohere-transcribe-03-2026-coreml) -- q8 CoreML conversion of Cohere Transcribe (the on-device path; evaluated in PR #568, not yet integrated)
 - Oatmeal project ADR-011 (prior art for Parakeet selection)

--- a/spec/adr/001-parakeet-stt.md
+++ b/spec/adr/001-parakeet-stt.md
@@ -244,7 +244,7 @@ paired-bootstrap significance):
 WhisperKit the light multilingual option. **If** integrated, ship Cohere as an
 **opt-in Beta engine gated to ≥16 GB RAM** with a clear download-size /
 cold-start warning, surfaced for accuracy-critical, noisy, or Japanese
-transcription. Both Nemotron builds are dominated by this benchmark (settling
+transcription. Both Nemotron builds are dominated by Parakeet in this benchmark (settling
 #520). Actual integration — engine wrapper, model-download UX, Settings/CLI
 surfacing, the RAM gate, telemetry — is a separate, ADR-gated change, and like
 every model the weights stay a user-triggered download, never bundled.


### PR DESCRIPTION
## Summary

Records the ASR benchmark's engine-selection outcome in the canonical docs. **Doc-only** — #568 stays the evidence/tooling PR; this is the decision record.

Decision captured: **Cohere Transcribe is the recommended next on-device STT engine — an opt-in Beta gated to ≥16 GB RAM, not a default — and it runs via FluidAudio CoreML, not MLX** (no new runtime; FluidAudio ≥ 0.15.4 ships a public `CoherePipeline`). It is **evaluated + recommended, not yet integrated.**

## What changed

- **ADR-001** (`spec/adr/001-parakeet-stt.md`) — a 2026-06-19 amendment line + a "Cohere Transcribe — Evaluated Candidate, Not Yet Integrated" addendum, following the same pattern as the Nemotron/Unified amendments.
- **spec/06-stt-engine.md** — a matching "Cohere (Evaluated Candidate)" subsection.
- **plans/active/asr-benchmark-and-model-expansion.md** — an outcome/decision note, and corrected the stale Tier-3/Phase-3 text that had filed Cohere under the (deferred) MLX runtime path.

## Why framed as a recommendation

Cohere is not built in code, and ADRs record *locked* decisions — so it's explicitly marked "Recommendation / not implemented." If integrated, it's a `CohereEngine` wrapping FluidAudio's `CoherePipeline` routed in `STTRuntime` (the Nemotron/Unified pattern), with model-download UX + the RAM gate — a separate, ADR-gated change.

## Evidence

Full methodology, CIs, and speed/memory tables: `benchmarks/asr/` (**PR #568**). Cohere: full-LibriSpeech macro WER **2.07%** (best on-device), best Japanese; **~11 GB peak RSS** / ~73 s compile / ~11× realtime; accuracy lead statistically significant only on noisy English + Japanese (paired-bootstrap CIs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
