### PR TITLE
Allow custom meeting audio retention days

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -91,8 +91,8 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 - `config get|set|list` now includes `auto-meeting-titles`, the shared
   on/off preference for LLM-generated meeting recording titles.
 - `config get|set|list` now includes `meeting-audio-retention`:
-  `keep-forever`, `delete-after-7-days`, `delete-after-14-days`,
-  `delete-after-30-days`, `delete-after-90-days`, or `delete-immediately`.
+  `keep-forever`, `delete-after-<1-365>-days`, `<1-365>d`, or
+  `delete-immediately`.
   The older `save-meeting-audio` key remains supported as a legacy alias:
   `on` maps to `keep-forever`, and `off` maps to `delete-immediately`.
 

--- a/Sources/CLI/Commands/ConfigCommand.swift
+++ b/Sources/CLI/Commands/ConfigCommand.swift
@@ -36,10 +36,8 @@ struct ConfigCommand: ParsableCommand {
           auto-meeting-titles       on|off                          default: on
           save-transcription-audio  on|off                          default: on
           meeting-audio-retention   keep-forever|                   default: keep-forever
-                                    delete-after-7-days|
-                                    delete-after-14-days|
-                                    delete-after-30-days|
-                                    delete-after-90-days|
+                                    delete-after-<1-365>-days|
+                                    <1-365>d|
                                     delete-immediately
           save-meeting-audio        on|off                          legacy alias
           youtube-audio-quality     m4a|best-available              default: m4a
@@ -453,7 +451,7 @@ struct ConfigCommand: ParsableCommand {
 
     static func parseMeetingAudioRetention(_ value: String) throws -> MeetingAudioRetention {
         guard let retention = MeetingAudioRetention.parseConfigurationValue(value) else {
-            throw ValidationError("Invalid value for meeting-audio-retention: '\(value)'. Use keep-forever, delete-immediately, or delete-after-7-days/delete-after-14-days/delete-after-30-days/delete-after-90-days.")
+            throw ValidationError("Invalid value for meeting-audio-retention: '\(value)'. Use keep-forever, delete-immediately, delete-after-<1-365>-days, or <1-365>d.")
         }
         return retention
     }

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -1903,17 +1903,22 @@ struct SettingsView: View {
                     Text("Delete after")
                         .font(DesignSystem.Typography.caption)
                         .foregroundStyle(.secondary)
-                    Picker("Meeting audio retention days", selection: meetingAudioRetentionDaysBinding) {
-                        ForEach(MeetingAudioRetention.allowedDeleteAfterDays, id: \.self) { days in
-                            Text("\(days)").tag(days)
-                        }
-                    }
+                    TextField("30", value: meetingAudioRetentionDaysBinding, format: .number)
+                        .textFieldStyle(.roundedBorder)
+                        .multilineTextAlignment(.trailing)
+                        .frame(width: 64)
+                    Stepper(
+                        "Meeting audio retention days",
+                        value: meetingAudioRetentionDaysBinding,
+                        in: MeetingAudioRetention.deleteAfterDaysRange
+                    )
                     .labelsHidden()
-                    .pickerStyle(.menu)
-                    .frame(width: 76)
-                    Text("days")
+                    Text(viewModel.meetingAudioRetention.deleteAfterDays == 1 ? "day" : "days")
                         .font(DesignSystem.Typography.caption)
                         .foregroundStyle(.secondary)
+                    Text("1-365")
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(.tertiary)
                 }
             }
 
@@ -1941,8 +1946,15 @@ struct SettingsView: View {
         Binding(
             get: { viewModel.meetingAudioRetention.deleteAfterDays },
             set: { days in
-                requestMeetingAudioRetentionChange(.deleteAfterDays(days))
+                requestMeetingAudioRetentionChange(.deleteAfterDays(clampedMeetingAudioRetentionDays(days)))
             }
+        )
+    }
+
+    private func clampedMeetingAudioRetentionDays(_ days: Int) -> Int {
+        min(
+            max(days, MeetingAudioRetention.minDeleteAfterDays),
+            MeetingAudioRetention.maxDeleteAfterDays
         )
     }
 

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -53,8 +53,10 @@ public enum MeetingAudioRetentionMode: String, CaseIterable, Identifiable, Hasha
 }
 
 public enum MeetingAudioRetention: Hashable, Sendable, Equatable {
-    public static let allowedDeleteAfterDays = [7, 14, 30, 90]
+    public static let minDeleteAfterDays = 1
+    public static let maxDeleteAfterDays = 365
     public static let defaultDeleteAfterDays = 30
+    public static let deleteAfterDaysRange = minDeleteAfterDays...maxDeleteAfterDays
 
     case keepForever
     case deleteAfterDays(Int)
@@ -104,7 +106,8 @@ public enum MeetingAudioRetention: Hashable, Sendable, Equatable {
         case .keepForever:
             return "keep-forever"
         case .deleteAfterDays(let days):
-            return "delete-after-\(Self.normalizedDeleteAfterDays(days))-days"
+            let normalizedDays = Self.normalizedDeleteAfterDays(days)
+            return "delete-after-\(normalizedDays)-\(Self.dayUnit(for: normalizedDays))"
         case .deleteImmediately:
             return "delete-immediately"
         }
@@ -122,7 +125,14 @@ public enum MeetingAudioRetention: Hashable, Sendable, Equatable {
     }
 
     public static func normalizedDeleteAfterDays(_ days: Int) -> Int {
-        allowedDeleteAfterDays.contains(days) ? days : defaultDeleteAfterDays
+        guard deleteAfterDaysRange.contains(days) else {
+            return defaultDeleteAfterDays
+        }
+        return days
+    }
+
+    public static func isValidDeleteAfterDays(_ days: Int) -> Bool {
+        deleteAfterDaysRange.contains(days)
     }
 
     public static func parseConfigurationValue(_ value: String) -> MeetingAudioRetention? {
@@ -141,17 +151,29 @@ public enum MeetingAudioRetention: Hashable, Sendable, Equatable {
             break
         }
 
-        for days in allowedDeleteAfterDays {
-            let day = "\(days)"
-            if raw == day
-                || raw == "\(day)d"
-                || raw == "\(day)-days"
-                || raw == "after-\(day)-days"
-                || raw == "delete-after-\(day)-days" {
-                return .deleteAfterDays(days)
-            }
+        var dayValue = raw
+        if dayValue.hasSuffix("-days") {
+            dayValue = String(dayValue.dropLast("-days".count))
+        } else if dayValue.hasSuffix("-day") {
+            dayValue = String(dayValue.dropLast("-day".count))
+        } else if dayValue.hasSuffix("d") {
+            dayValue = String(dayValue.dropLast())
+        }
+        if dayValue.hasPrefix("delete-after-") {
+            dayValue = String(dayValue.dropFirst("delete-after-".count))
+        } else if dayValue.hasPrefix("after-") {
+            dayValue = String(dayValue.dropFirst("after-".count))
+        }
+
+        if let days = Int(dayValue),
+           isValidDeleteAfterDays(days) {
+            return .deleteAfterDays(days)
         }
         return nil
+    }
+
+    private static func dayUnit(for days: Int) -> String {
+        days == 1 ? "day" : "days"
     }
 }
 

--- a/Tests/CLITests/ConfigCommandTests.swift
+++ b/Tests/CLITests/ConfigCommandTests.swift
@@ -182,9 +182,44 @@ final class ConfigCommandTests: XCTestCase {
         )
     }
 
-    func testMeetingAudioRetentionRejectsUnsupportedDayCount() {
+    func testMeetingAudioRetentionAcceptsAnyDayCountInRange() throws {
+        XCTAssertEqual(
+            try ConfigCommand.write(key: "meeting-audio-retention", value: "delete-after-13-days", defaults: defaults),
+            "delete-after-13-days"
+        )
+        XCTAssertEqual(
+            UserDefaultsAppRuntimePreferences.meetingAudioRetention(defaults: defaults),
+            .deleteAfterDays(13)
+        )
+
+        XCTAssertEqual(
+            try ConfigCommand.write(key: "meeting-audio-retention", value: "1d", defaults: defaults),
+            "delete-after-1-day"
+        )
+        XCTAssertEqual(
+            UserDefaultsAppRuntimePreferences.meetingAudioRetention(defaults: defaults),
+            .deleteAfterDays(1)
+        )
+
+        XCTAssertEqual(
+            try ConfigCommand.write(key: "meeting-audio-retention", value: "365", defaults: defaults),
+            "delete-after-365-days"
+        )
+        XCTAssertEqual(
+            UserDefaultsAppRuntimePreferences.meetingAudioRetention(defaults: defaults),
+            .deleteAfterDays(365)
+        )
+    }
+
+    func testMeetingAudioRetentionRejectsOutOfRangeDayCount() {
         XCTAssertThrowsError(
-            try ConfigCommand.write(key: "meeting-audio-retention", value: "delete-after-13-days", defaults: defaults)
+            try ConfigCommand.write(key: "meeting-audio-retention", value: "delete-after-0-days", defaults: defaults)
+        ) { error in
+            XCTAssertTrue(error is ValidationError)
+        }
+
+        XCTAssertThrowsError(
+            try ConfigCommand.write(key: "meeting-audio-retention", value: "delete-after-366-days", defaults: defaults)
         ) { error in
             XCTAssertTrue(error is ValidationError)
         }

--- a/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
+++ b/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
@@ -98,6 +98,38 @@ final class AppRuntimePreferencesTests: XCTestCase {
         XCTAssertEqual(defaults.object(forKey: UserDefaultsAppRuntimePreferences.saveMeetingAudioKey) as? Bool, true)
     }
 
+    func testMeetingAudioRetentionPersistsCustomDayCountInRange() {
+        let suite = "app-runtime-prefs-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        UserDefaultsAppRuntimePreferences.saveMeetingAudioRetention(.deleteAfterDays(13), defaults: defaults)
+
+        let preferences = UserDefaultsAppRuntimePreferences(defaults: defaults)
+        XCTAssertEqual(preferences.meetingAudioRetention, .deleteAfterDays(13))
+        XCTAssertEqual(
+            defaults.object(forKey: UserDefaultsAppRuntimePreferences.meetingAudioRetentionDeleteAfterDaysKey) as? Int,
+            13
+        )
+    }
+
+    func testMeetingAudioRetentionDefaultsInvalidStoredDayCount() {
+        let suite = "app-runtime-prefs-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        defaults.set(
+            MeetingAudioRetentionMode.deleteAfterDays.rawValue,
+            forKey: UserDefaultsAppRuntimePreferences.meetingAudioRetentionKey
+        )
+        defaults.set(366, forKey: UserDefaultsAppRuntimePreferences.meetingAudioRetentionDeleteAfterDaysKey)
+
+        XCTAssertEqual(
+            UserDefaultsAppRuntimePreferences(defaults: defaults).meetingAudioRetention,
+            .deleteAfterDays(MeetingAudioRetention.defaultDeleteAfterDays)
+        )
+    }
+
     func testDictationInsertionStyleDefaultsToSentenceAndReadsPersistedValue() {
         let suite = "app-runtime-prefs-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!


### PR DESCRIPTION
## Summary
- allow meeting audio retention to store any day count from 1 to 365 instead of only fixed presets
- replace the Settings day picker with a bounded numeric field and stepper
- extend CLI parsing/help so values like `13`, `13d`, and `delete-after-13-days` work while out-of-range values are rejected

## Verification
- `git diff --check`
- `swift test --filter 'ConfigCommandTests|AppRuntimePreferencesTests|SettingsViewModelTests'`\n- `swift test`\n