### PR TITLE
Add Library multi-select cleanup

### DIFF
--- a/Sources/MacParakeet/Views/History/DictationHistoryView.swift
+++ b/Sources/MacParakeet/Views/History/DictationHistoryView.swift
@@ -675,7 +675,7 @@ private struct CardMenuButton: View {
         // already in bulk mode (it would be redundant). Named to read as a
         // non-destructive selection gesture, not a delete.
         if showsBulkSelectionEntry {
-            menu.addItem(CallbackMenuItem(title: "Select Multiple…", icon: "checklist", action: onBeginBulkSelection))
+            menu.addItem(CallbackMenuItem(title: "Select Many...", icon: "checklist", action: onBeginBulkSelection))
         }
 
         if !menu.items.isEmpty {

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
@@ -7,6 +7,8 @@ import SwiftUI
 struct MeetingRowCard<MenuContent: View>: View {
     let transcription: Transcription
     var searchText: String = ""
+    var isSelected: Bool = false
+    var showsSelectionControls: Bool = false
     var onTap: () -> Void
     @ViewBuilder var menuContent: () -> MenuContent
 
@@ -15,6 +17,10 @@ struct MeetingRowCard<MenuContent: View>: View {
     var body: some View {
         Button(action: onTap) {
             HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+                if showsSelectionControls {
+                    selectionBadge
+                        .padding(.top, 1)
+                }
                 contentColumn
                 trailingColumn
             }
@@ -30,19 +36,49 @@ struct MeetingRowCard<MenuContent: View>: View {
         .animation(DesignSystem.Animation.hoverTransition, value: hovered)
         .contextMenu { menuContent() }
         .accessibilityElement(children: .combine)
-        .accessibilityHint(hoverTooltip)
+        .accessibilityValue(showsSelectionControls ? (isSelected ? "Selected" : "Not selected") : "")
+        .accessibilityHint(showsSelectionControls ? "Toggles selection" : hoverTooltip)
     }
 
     // MARK: - Backgrounds
 
     @ViewBuilder
     private var rowBackground: some View {
-        if hovered {
+        if isSelected {
+            RoundedRectangle(cornerRadius: 6)
+                .fill(DesignSystem.Colors.accentLight)
+                .overlay {
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(DesignSystem.Colors.accent.opacity(0.38), lineWidth: 0.8)
+                }
+        } else if hovered {
             RoundedRectangle(cornerRadius: 6)
                 .fill(DesignSystem.Colors.rowHoverBackground)
         } else {
             Color.clear
         }
+    }
+
+    private var selectionBadge: some View {
+        ZStack {
+            Circle()
+                .fill(isSelected ? DesignSystem.Colors.accent : Color.clear)
+                .frame(width: 18, height: 18)
+                .overlay {
+                    Circle()
+                        .strokeBorder(
+                            isSelected ? DesignSystem.Colors.accent : DesignSystem.Colors.textTertiary.opacity(0.7),
+                            lineWidth: 1.2
+                        )
+                }
+
+            if isSelected {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(DesignSystem.Colors.onAccent)
+            }
+        }
+        .accessibilityHidden(true)
     }
 
     // MARK: - Content

--- a/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
+++ b/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
@@ -15,8 +15,10 @@ struct MeetingsView: View {
 
     @State private var audioSaveErrorMessage: String?
     @State private var pendingDeleteAudio: Transcription?
+    @State private var pendingDeleteMeeting: Transcription?
     @State private var showingAskPromptsSheet = false
     @State private var showingPromptLibrary = false
+    @FocusState private var recentMeetingsSelectionFocused: Bool
 
     private static let rightRailWidth: CGFloat = 280
     private static let twoColumnMinimumWidth: CGFloat = 1_100
@@ -41,6 +43,16 @@ struct MeetingsView: View {
         }
         .onAppear {
             viewModel.refreshIfNeeded()
+        }
+        .focusable(viewModel.recentMeetingsViewModel.isBulkSelectionModeEnabled)
+        .focused($recentMeetingsSelectionFocused)
+        .onChange(of: viewModel.recentMeetingsViewModel.isBulkSelectionModeEnabled) { _, enabled in
+            if enabled {
+                recentMeetingsSelectionFocused = true
+            }
+        }
+        .onKeyPress(keys: ["a", .delete, .deleteForward, .escape]) { press in
+            handleRecentMeetingsSelectionKeyPress(press)
         }
         .onChange(of: viewModel.settingsViewModel.calendarAutoStartMode) { _, _ in
             viewModel.refreshUpcomingEvents()
@@ -78,13 +90,54 @@ struct MeetingsView: View {
             )
         ) {
             Button("Cancel", role: .cancel) {}
-            Button("Delete Audio", role: .destructive) {
+            Button("Delete Audio Only", role: .destructive) {
                 if let transcription = pendingDeleteAudio {
                     viewModel.recentMeetingsViewModel.deleteMeetingAudio(transcription)
                 }
             }
         } message: {
-            Text("The transcript stays in Meetings. Playback and retranscription will be unavailable unless you saved a copy.")
+            Text("The transcript, notes, AI results, and chats stay in Meetings if they exist. Playback and retranscription will be unavailable unless you saved a copy.")
+        }
+        .alert(
+            "Delete Meeting?",
+            isPresented: Binding(
+                get: { pendingDeleteMeeting != nil },
+                set: { if !$0 { pendingDeleteMeeting = nil } }
+            )
+        ) {
+            Button("Cancel", role: .cancel) {
+                pendingDeleteMeeting = nil
+            }
+            Button("Delete Meeting", role: .destructive) {
+                if let transcription = pendingDeleteMeeting {
+                    viewModel.recentMeetingsViewModel.deleteTranscription(transcription)
+                    pendingDeleteMeeting = nil
+                }
+            }
+        } message: {
+            if let pendingDeleteMeeting {
+                Text("This permanently removes \"\(pendingDeleteMeeting.fileName)\", its transcript, stored audio, and any notes, AI results, or chats for this meeting.")
+            }
+        }
+        .alert(
+            recentMeetingsBulkOperationTitle,
+            isPresented: Binding(
+                get: { viewModel.recentMeetingsViewModel.pendingBulkOperation != nil },
+                set: { if !$0 { viewModel.recentMeetingsViewModel.cancelPendingBulkOperation() } }
+            )
+        ) {
+            Button("Cancel", role: .cancel) {
+                viewModel.recentMeetingsViewModel.cancelPendingBulkOperation()
+            }
+            Button(recentMeetingsBulkOperationConfirmTitle, role: .destructive) {
+                Task {
+                    await viewModel.recentMeetingsViewModel.confirmPendingBulkOperation()
+                }
+            }
+        } message: {
+            if let operation = viewModel.recentMeetingsViewModel.pendingBulkOperation {
+                Text(recentMeetingsBulkOperationMessage(for: operation))
+            }
         }
         .sheet(isPresented: $showingAskPromptsSheet, onDismiss: {
             viewModel.quickPromptsViewModel.cancelCreating()
@@ -410,6 +463,12 @@ struct MeetingsView: View {
                     recentMeetingSearchField
                 }
 
+                if viewModel.recentMeetingsViewModel.isBulkSelectionModeEnabled {
+                    recentMeetingsSelectionBar
+                } else if showsRecentMeetingsSelectManyButton {
+                    recentMeetingsSelectManyRow
+                }
+
                 if viewModel.recentMeetingsViewModel.isLoading
                     && viewModel.recentMeetingsViewModel.filteredTranscriptions.isEmpty {
                     MeetingsLoadingRow(title: "Loading meetings")
@@ -456,7 +515,15 @@ struct MeetingsView: View {
                     MeetingRowCard(
                         transcription: transcription,
                         searchText: viewModel.recentMeetingsViewModel.searchText,
-                        onTap: { onSelectMeeting(transcription) },
+                        isSelected: viewModel.recentMeetingsViewModel.isTranscriptionSelected(transcription),
+                        showsSelectionControls: viewModel.recentMeetingsViewModel.isBulkSelectionModeEnabled,
+                        onTap: {
+                            if viewModel.recentMeetingsViewModel.isBulkSelectionModeEnabled {
+                                viewModel.recentMeetingsViewModel.toggleSelection(for: transcription)
+                            } else {
+                                onSelectMeeting(transcription)
+                            }
+                        },
                         menuContent: { recentMeetingMenu(for: transcription) }
                     )
                     if idx < section.items.count - 1 {
@@ -473,6 +540,14 @@ struct MeetingsView: View {
             onSelectMeeting(transcription)
         } label: {
             Label("Open", systemImage: "doc.text")
+        }
+
+        if !viewModel.recentMeetingsViewModel.isBulkSelectionModeEnabled {
+            Button {
+                viewModel.recentMeetingsViewModel.beginBulkSelection(startingWith: transcription)
+            } label: {
+                Label("Select Many...", systemImage: "checklist")
+            }
         }
 
         let audioAvailable = MeetingAudioFile.isAvailable(for: transcription)
@@ -496,9 +571,48 @@ struct MeetingsView: View {
         Button(role: .destructive) {
             pendingDeleteAudio = transcription
         } label: {
-            Label("Delete Audio", systemImage: "waveform.slash")
+            Label("Delete Audio Only", systemImage: "waveform.slash")
         }
         .disabled(!audioAvailable)
+
+        Divider()
+
+        Button(role: .destructive) {
+            pendingDeleteMeeting = transcription
+        } label: {
+            Label("Delete Meeting", systemImage: "trash")
+        }
+    }
+
+    private var recentMeetingsSelectionBar: some View {
+        BulkTranscriptionSelectionBar(
+            selectedCount: viewModel.recentMeetingsViewModel.selectedTranscriptionCount,
+            selectedMeetingAudioCount: viewModel.recentMeetingsViewModel.selectedMeetingAudioCount,
+            isMeetingContext: true,
+            areAllLoadedSelected: viewModel.recentMeetingsViewModel.areAllLoadedVisibleTranscriptionsSelected,
+            onSelectLoaded: { viewModel.recentMeetingsViewModel.selectLoadedVisibleTranscriptions() },
+            onClear: { viewModel.recentMeetingsViewModel.clearSelection() },
+            onCancel: { viewModel.recentMeetingsViewModel.exitBulkSelection() },
+            onDeleteAudioOnly: { viewModel.recentMeetingsViewModel.requestDeleteSelectedMeetingAudio() },
+            onDeleteItems: { viewModel.recentMeetingsViewModel.requestDeleteSelectedItems() }
+        )
+    }
+
+    private var recentMeetingsSelectManyRow: some View {
+        HStack {
+            Spacer()
+            Button {
+                viewModel.recentMeetingsViewModel.beginBulkSelection()
+            } label: {
+                Label("Select Many", systemImage: "checklist")
+            }
+            .parakeetAction(.secondary)
+            .help("Select multiple recent meetings")
+            .accessibilityHint("Shows selection controls for bulk cleanup")
+        }
+        .padding(.horizontal, DesignSystem.Spacing.lg)
+        .padding(.vertical, DesignSystem.Spacing.sm)
+        .overlay(alignment: .bottom) { Divider() }
     }
 
     private var recentMeetingSearchField: some View {
@@ -588,6 +702,55 @@ struct MeetingsView: View {
         return {
             viewModel.recentMeetingsViewModel.searchText = ""
         }
+    }
+
+    private var showsRecentMeetingsSelectManyButton: Bool {
+        !viewModel.recentMeetingsViewModel.filteredTranscriptions.isEmpty
+    }
+
+    private var recentMeetingsBulkOperationTitle: String {
+        guard let operation = viewModel.recentMeetingsViewModel.pendingBulkOperation else {
+            return "Delete Meetings?"
+        }
+        return operation.isDeleteAudioOnly ? "Delete Meeting Audio?" : "Delete Meetings?"
+    }
+
+    private var recentMeetingsBulkOperationConfirmTitle: String {
+        guard let operation = viewModel.recentMeetingsViewModel.pendingBulkOperation else {
+            return "Delete"
+        }
+        return operation.isDeleteAudioOnly ? "Delete Audio Only" : "Delete Meetings"
+    }
+
+    private func recentMeetingsBulkOperationMessage(for operation: BulkTranscriptionOperation) -> String {
+        if operation.isDeleteAudioOnly {
+            var message = "Delete audio for \(operation.targetCount) \(operation.targetCount == 1 ? "meeting" : "meetings")? Transcripts, notes, AI results, and chats stay in Meetings if they exist. Playback and retranscription will be unavailable unless you saved a copy."
+            if operation.skippedCount > 0 {
+                message += " \(operation.skippedCount) selected \(operation.skippedCount == 1 ? "meeting does" : "meetings do") not have stored audio and will be skipped."
+            }
+            return message
+        }
+
+        return "Delete \(operation.targetCount) \(operation.targetCount == 1 ? "meeting" : "meetings")? This permanently removes the selected rows, transcripts, stored audio, and any notes, AI results, or chats for those meetings."
+    }
+
+    private func handleRecentMeetingsSelectionKeyPress(_ press: KeyPress) -> KeyPress.Result {
+        let recentVM = viewModel.recentMeetingsViewModel
+        guard recentVM.isBulkSelectionModeEnabled else { return .ignored }
+        if press.key == .escape {
+            recentVM.exitBulkSelection()
+            return .handled
+        }
+        if press.key == .delete || press.key == .deleteForward {
+            guard recentVM.hasSelectedTranscriptions else { return .ignored }
+            recentVM.requestDeleteSelectedItems()
+            return .handled
+        }
+        if press.key == "a", press.modifiers.contains(.command) {
+            recentVM.selectLoadedVisibleTranscriptions()
+            return .handled
+        }
+        return .ignored
     }
 
     private func calendarEmptyDetail(for mode: CalendarAutoStartMode) -> String {

--- a/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
+++ b/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
@@ -51,7 +51,8 @@ struct MeetingsView: View {
                 recentMeetingsSelectionFocused = true
             }
         }
-        .onKeyPress(keys: ["a", .delete, .deleteForward, .escape]) { press in
+        .animation(.easeInOut(duration: 0.16), value: viewModel.recentMeetingsViewModel.isBulkSelectionModeEnabled)
+        .onKeyPress(keys: ["a", "A", .delete, .deleteForward]) { press in
             handleRecentMeetingsSelectionKeyPress(press)
         }
         .onChange(of: viewModel.settingsViewModel.calendarAutoStartMode) { _, _ in
@@ -518,6 +519,9 @@ struct MeetingsView: View {
                         isSelected: viewModel.recentMeetingsViewModel.isTranscriptionSelected(transcription),
                         showsSelectionControls: viewModel.recentMeetingsViewModel.isBulkSelectionModeEnabled,
                         onTap: {
+                            if viewModel.recentMeetingsViewModel.isBulkOperationInProgress {
+                                return
+                            }
                             if viewModel.recentMeetingsViewModel.isBulkSelectionModeEnabled {
                                 viewModel.recentMeetingsViewModel.toggleSelection(for: transcription)
                             } else {
@@ -590,6 +594,7 @@ struct MeetingsView: View {
             selectedMeetingAudioCount: viewModel.recentMeetingsViewModel.selectedMeetingAudioCount,
             isMeetingContext: true,
             areAllLoadedSelected: viewModel.recentMeetingsViewModel.areAllLoadedVisibleTranscriptionsSelected,
+            isPerformingOperation: viewModel.recentMeetingsViewModel.isBulkOperationInProgress,
             onSelectLoaded: { viewModel.recentMeetingsViewModel.selectLoadedVisibleTranscriptions() },
             onClear: { viewModel.recentMeetingsViewModel.clearSelection() },
             onCancel: { viewModel.recentMeetingsViewModel.exitBulkSelection() },
@@ -736,17 +741,13 @@ struct MeetingsView: View {
 
     private func handleRecentMeetingsSelectionKeyPress(_ press: KeyPress) -> KeyPress.Result {
         let recentVM = viewModel.recentMeetingsViewModel
-        guard recentVM.isBulkSelectionModeEnabled else { return .ignored }
-        if press.key == .escape {
-            recentVM.exitBulkSelection()
-            return .handled
-        }
+        guard recentVM.isBulkSelectionModeEnabled, !recentVM.isBulkOperationInProgress else { return .ignored }
         if press.key == .delete || press.key == .deleteForward {
             guard recentVM.hasSelectedTranscriptions else { return .ignored }
             recentVM.requestDeleteSelectedItems()
             return .handled
         }
-        if press.key == "a", press.modifiers.contains(.command) {
+        if (press.key == "a" || press.key == "A"), press.modifiers.contains(.command) {
             recentVM.selectLoadedVisibleTranscriptions()
             return .handled
         }

--- a/Sources/MacParakeet/Views/Transcription/BulkTranscriptionSelectionBar.swift
+++ b/Sources/MacParakeet/Views/Transcription/BulkTranscriptionSelectionBar.swift
@@ -1,0 +1,121 @@
+import SwiftUI
+
+struct BulkTranscriptionSelectionBar: View {
+    let selectedCount: Int
+    let selectedMeetingAudioCount: Int
+    let isMeetingContext: Bool
+    let areAllLoadedSelected: Bool
+    let onSelectLoaded: () -> Void
+    let onClear: () -> Void
+    let onCancel: () -> Void
+    let onDeleteAudioOnly: () -> Void
+    let onDeleteItems: () -> Void
+
+    private var showsAudioAction: Bool {
+        isMeetingContext || selectedMeetingAudioCount > 0
+    }
+
+    private var deleteAudioTitle: String {
+        if isMeetingContext {
+            return "Delete Audio Only..."
+        }
+        return "Delete Audio for \(selectedMeetingAudioCount) \(selectedMeetingAudioCount == 1 ? "Meeting" : "Meetings")..."
+    }
+
+    private var deleteItemsTitle: String {
+        isMeetingContext ? "Delete Meetings..." : "Delete Items..."
+    }
+
+    var body: some View {
+        ViewThatFits(in: .horizontal) {
+            horizontalBar
+            wrappedBar
+        }
+        .padding(.horizontal, DesignSystem.Spacing.lg)
+        .padding(.vertical, DesignSystem.Spacing.sm)
+        .background(DesignSystem.Colors.surfaceElevated)
+        .overlay(alignment: .bottom) { Divider() }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("\(selectedCount) selected")
+    }
+
+    private var horizontalBar: some View {
+        HStack(spacing: DesignSystem.Spacing.sm) {
+            selectionSummary
+
+            Spacer(minLength: DesignSystem.Spacing.md)
+
+            utilityActions
+            destructiveActions
+        }
+    }
+
+    private var wrappedBar: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            selectionSummary
+            HStack(spacing: DesignSystem.Spacing.sm) {
+                utilityActions
+                destructiveActions
+            }
+        }
+    }
+
+    private var selectionSummary: some View {
+        HStack(spacing: 7) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(DesignSystem.Colors.accent)
+
+            Text("\(selectedCount) selected")
+                .font(DesignSystem.Typography.bodySmall.weight(.medium))
+                .foregroundStyle(DesignSystem.Colors.textPrimary)
+        }
+        .accessibilityHidden(true)
+    }
+
+    private var utilityActions: some View {
+        HStack(spacing: DesignSystem.Spacing.sm) {
+            Button("Cancel", action: onCancel)
+                .parakeetAction(.subtle)
+                .keyboardShortcut(.escape, modifiers: [])
+
+            Button {
+                onSelectLoaded()
+            } label: {
+                Label("Select Loaded", systemImage: "checkmark.circle")
+            }
+            .disabled(areAllLoadedSelected)
+            .parakeetAction(.secondary)
+
+            Button {
+                onClear()
+            } label: {
+                Label("Clear", systemImage: "xmark.circle")
+            }
+            .disabled(selectedCount == 0)
+            .parakeetAction(.secondary)
+        }
+    }
+
+    private var destructiveActions: some View {
+        HStack(spacing: DesignSystem.Spacing.sm) {
+            if showsAudioAction {
+                Button(role: .destructive) {
+                    onDeleteAudioOnly()
+                } label: {
+                    Label(deleteAudioTitle, systemImage: "waveform.slash")
+                }
+                .disabled(selectedMeetingAudioCount == 0)
+                .parakeetAction(.destructive)
+            }
+
+            Button(role: .destructive) {
+                onDeleteItems()
+            } label: {
+                Label(deleteItemsTitle, systemImage: "trash")
+            }
+            .disabled(selectedCount == 0)
+            .parakeetAction(.destructive)
+        }
+    }
+}

--- a/Sources/MacParakeet/Views/Transcription/BulkTranscriptionSelectionBar.swift
+++ b/Sources/MacParakeet/Views/Transcription/BulkTranscriptionSelectionBar.swift
@@ -5,6 +5,7 @@ struct BulkTranscriptionSelectionBar: View {
     let selectedMeetingAudioCount: Int
     let isMeetingContext: Bool
     let areAllLoadedSelected: Bool
+    let isPerformingOperation: Bool
     let onSelectLoaded: () -> Void
     let onClear: () -> Void
     let onCancel: () -> Void
@@ -36,7 +37,7 @@ struct BulkTranscriptionSelectionBar: View {
         .background(DesignSystem.Colors.surfaceElevated)
         .overlay(alignment: .bottom) { Divider() }
         .accessibilityElement(children: .contain)
-        .accessibilityLabel("\(selectedCount) selected")
+        .accessibilityLabel(isPerformingOperation ? "Deleting selected items" : "\(selectedCount) selected")
     }
 
     private var horizontalBar: some View {
@@ -62,11 +63,16 @@ struct BulkTranscriptionSelectionBar: View {
 
     private var selectionSummary: some View {
         HStack(spacing: 7) {
-            Image(systemName: "checkmark.circle.fill")
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(DesignSystem.Colors.accent)
+            if isPerformingOperation {
+                ProgressView()
+                    .controlSize(.small)
+            } else {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(DesignSystem.Colors.accent)
+            }
 
-            Text("\(selectedCount) selected")
+            Text(isPerformingOperation ? "Deleting..." : "\(selectedCount) selected")
                 .font(DesignSystem.Typography.bodySmall.weight(.medium))
                 .foregroundStyle(DesignSystem.Colors.textPrimary)
         }
@@ -78,13 +84,14 @@ struct BulkTranscriptionSelectionBar: View {
             Button("Cancel", action: onCancel)
                 .parakeetAction(.subtle)
                 .keyboardShortcut(.escape, modifiers: [])
+                .disabled(isPerformingOperation)
 
             Button {
                 onSelectLoaded()
             } label: {
                 Label("Select Loaded", systemImage: "checkmark.circle")
             }
-            .disabled(areAllLoadedSelected)
+            .disabled(areAllLoadedSelected || isPerformingOperation)
             .parakeetAction(.secondary)
 
             Button {
@@ -92,7 +99,7 @@ struct BulkTranscriptionSelectionBar: View {
             } label: {
                 Label("Clear", systemImage: "xmark.circle")
             }
-            .disabled(selectedCount == 0)
+            .disabled(selectedCount == 0 || isPerformingOperation)
             .parakeetAction(.secondary)
         }
     }
@@ -105,7 +112,7 @@ struct BulkTranscriptionSelectionBar: View {
                 } label: {
                     Label(deleteAudioTitle, systemImage: "waveform.slash")
                 }
-                .disabled(selectedMeetingAudioCount == 0)
+                .disabled(selectedMeetingAudioCount == 0 || isPerformingOperation)
                 .parakeetAction(.destructive)
             }
 
@@ -114,7 +121,7 @@ struct BulkTranscriptionSelectionBar: View {
             } label: {
                 Label(deleteItemsTitle, systemImage: "trash")
             }
-            .disabled(selectedCount == 0)
+            .disabled(selectedCount == 0 || isPerformingOperation)
             .parakeetAction(.destructive)
         }
     }

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -15,6 +15,7 @@ struct TranscriptionLibraryView: View {
     @State private var pendingDelete: Transcription?
     @State private var pendingDeleteAudio: Transcription?
     @State private var audioSaveErrorMessage: String?
+    @FocusState private var selectionKeyboardFocused: Bool
 
     private var visibleLibraryFilters: [LibraryFilter] {
         LibraryFilter.allCases.filter { filter in
@@ -31,6 +32,12 @@ struct TranscriptionLibraryView: View {
                     .foregroundStyle(DesignSystem.Colors.textPrimary)
 
                 Spacer()
+
+                if showsSelectManyButton {
+                    LibrarySelectManyButton {
+                        viewModel.beginBulkSelection()
+                    }
+                }
 
                 if let primaryActionTitle, let onPrimaryAction {
                     LibraryPrimaryActionButton(title: primaryActionTitle, action: onPrimaryAction)
@@ -64,6 +71,11 @@ struct TranscriptionLibraryView: View {
                     .padding(.bottom, DesignSystem.Spacing.sm)
             }
 
+            if viewModel.isBulkSelectionModeEnabled {
+                selectionActionsBar
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+
             // Content — date-grouped list for meetings, thumbnail grid otherwise.
             // Reason: meetings have no thumbnail-worthy visual asset, so a list with
             // preview text + speaker count is denser and more useful than a wall of
@@ -79,11 +91,21 @@ struct TranscriptionLibraryView: View {
             }
         }
         .searchable(text: $viewModel.searchText, prompt: "Search transcriptions")
+        .focusable(viewModel.isBulkSelectionModeEnabled)
+        .focused($selectionKeyboardFocused)
+        .onChange(of: viewModel.isBulkSelectionModeEnabled) { _, enabled in
+            if enabled {
+                selectionKeyboardFocused = true
+            }
+        }
+        .onKeyPress(keys: ["a", .delete, .deleteForward, .escape]) { press in
+            handleSelectionKeyPress(press)
+        }
         .onAppear {
             viewModel.loadTranscriptions()
         }
         .alert(
-            "Delete Transcription?",
+            pendingDelete.map(singleDeleteTitle) ?? "Delete Transcription?",
             isPresented: Binding(
                 get: { pendingDelete != nil },
                 set: { if !$0 { pendingDelete = nil } }
@@ -92,7 +114,7 @@ struct TranscriptionLibraryView: View {
             Button("Cancel", role: .cancel) {
                 pendingDelete = nil
             }
-            Button("Delete", role: .destructive) {
+            Button(pendingDelete.map(singleDeleteConfirmTitle) ?? "Delete", role: .destructive) {
                 if let transcription = pendingDelete {
                     viewModel.deleteTranscription(transcription)
                     pendingDelete = nil
@@ -100,7 +122,7 @@ struct TranscriptionLibraryView: View {
             }
         } message: {
             if let pending = pendingDelete {
-                Text("\"\(pending.fileName)\" will be permanently deleted.")
+                Text(singleDeleteMessage(for: pending))
             }
         }
         .alert(
@@ -111,13 +133,33 @@ struct TranscriptionLibraryView: View {
             )
         ) {
             Button("Cancel", role: .cancel) {}
-            Button("Delete Audio", role: .destructive) {
+            Button("Delete Audio Only", role: .destructive) {
                 if let transcription = pendingDeleteAudio {
                     viewModel.deleteMeetingAudio(transcription)
                 }
             }
         } message: {
-            Text("The transcript stays in Library. Playback and retranscription will be unavailable unless you saved a copy.")
+            Text("The transcript, notes, AI results, and chats stay in Library if they exist. Playback and retranscription will be unavailable unless you saved a copy.")
+        }
+        .alert(
+            bulkOperationTitle,
+            isPresented: Binding(
+                get: { viewModel.pendingBulkOperation != nil },
+                set: { if !$0 { viewModel.cancelPendingBulkOperation() } }
+            )
+        ) {
+            Button("Cancel", role: .cancel) {
+                viewModel.cancelPendingBulkOperation()
+            }
+            Button(bulkOperationConfirmTitle, role: .destructive) {
+                Task {
+                    await viewModel.confirmPendingBulkOperation()
+                }
+            }
+        } message: {
+            if let operation = viewModel.pendingBulkOperation {
+                Text(bulkOperationMessage(for: operation))
+            }
         }
         .alert(
             "Save Failed",
@@ -142,8 +184,17 @@ struct TranscriptionLibraryView: View {
                     spacing: DesignSystem.Spacing.md
                 ) {
                     ForEach(viewModel.filteredTranscriptions) { transcription in
-                        TranscriptionThumbnailCard(transcription: transcription, searchText: viewModel.searchText) {
-                            onSelect(transcription)
+                        TranscriptionThumbnailCard(
+                            transcription: transcription,
+                            searchText: viewModel.searchText,
+                            isSelected: viewModel.isTranscriptionSelected(transcription),
+                            showsSelectionControls: viewModel.isBulkSelectionModeEnabled
+                        ) {
+                            if viewModel.isBulkSelectionModeEnabled {
+                                viewModel.toggleSelection(for: transcription)
+                            } else {
+                                onSelect(transcription)
+                            }
                         } menuContent: {
                             libraryMenuItems(for: transcription)
                         }
@@ -168,7 +219,15 @@ struct TranscriptionLibraryView: View {
                         MeetingRowCard(
                             transcription: transcription,
                             searchText: viewModel.searchText,
-                            onTap: { onSelect(transcription) },
+                            isSelected: viewModel.isTranscriptionSelected(transcription),
+                            showsSelectionControls: viewModel.isBulkSelectionModeEnabled,
+                            onTap: {
+                                if viewModel.isBulkSelectionModeEnabled {
+                                    viewModel.toggleSelection(for: transcription)
+                                } else {
+                                    onSelect(transcription)
+                                }
+                            },
                             menuContent: { libraryMenuItems(for: transcription) }
                         )
                         if idx < section.items.count - 1 {
@@ -190,6 +249,14 @@ struct TranscriptionLibraryView: View {
             onSelect(transcription)
         } label: {
             Label("Open", systemImage: "doc.text")
+        }
+
+        if !viewModel.isBulkSelectionModeEnabled {
+            Button {
+                viewModel.beginBulkSelection(startingWith: transcription)
+            } label: {
+                Label("Select Many...", systemImage: "checklist")
+            }
         }
 
         if transcription.sourceType == .meeting {
@@ -220,11 +287,11 @@ struct TranscriptionLibraryView: View {
             Button(role: .destructive) {
                 pendingDeleteAudio = transcription
             } label: {
-                Label("Delete Audio", systemImage: "waveform.slash")
+                Label("Delete Audio Only", systemImage: "waveform.slash")
             }
             .disabled(!audioAvailable)
             .help(audioAvailable
-                  ? "Delete the stored meeting audio while keeping the transcript"
+                  ? "Delete the stored meeting audio while keeping the transcript and notes"
                   : "Audio file is not available yet")
         }
 
@@ -244,8 +311,26 @@ struct TranscriptionLibraryView: View {
         Button(role: .destructive) {
             pendingDelete = transcription
         } label: {
-            Label("Delete", systemImage: "trash")
+            Label(transcription.sourceType == .meeting ? "Delete Meeting" : "Delete", systemImage: "trash")
         }
+    }
+
+    private var selectionActionsBar: some View {
+        BulkTranscriptionSelectionBar(
+            selectedCount: viewModel.selectedTranscriptionCount,
+            selectedMeetingAudioCount: viewModel.selectedMeetingAudioCount,
+            isMeetingContext: isMeetingListMode,
+            areAllLoadedSelected: viewModel.areAllLoadedVisibleTranscriptionsSelected,
+            onSelectLoaded: { viewModel.selectLoadedVisibleTranscriptions() },
+            onClear: { viewModel.clearSelection() },
+            onCancel: { viewModel.exitBulkSelection() },
+            onDeleteAudioOnly: { viewModel.requestDeleteSelectedMeetingAudio() },
+            onDeleteItems: { viewModel.requestDeleteSelectedItems() }
+        )
+    }
+
+    private var showsSelectManyButton: Bool {
+        !viewModel.isBulkSelectionModeEnabled && !viewModel.filteredTranscriptions.isEmpty
     }
 
     private func saveMeetingAudio(_ transcription: Transcription) {
@@ -325,6 +410,80 @@ struct TranscriptionLibraryView: View {
 
     private var isMeetingListMode: Bool {
         viewModel.scope == .meetings || viewModel.filter == .meeting
+    }
+
+    private var bulkOperationTitle: String {
+        guard let operation = viewModel.pendingBulkOperation else { return "Delete Items?" }
+        if operation.isDeleteAudioOnly {
+            return "Delete Meeting Audio?"
+        }
+        if operation.meetingCount == operation.targetCount, operation.targetCount == 1 {
+            return "Delete Meeting?"
+        }
+        if operation.meetingCount == operation.targetCount {
+            return "Delete Meetings?"
+        }
+        return "Delete Items?"
+    }
+
+    private var bulkOperationConfirmTitle: String {
+        guard let operation = viewModel.pendingBulkOperation else { return "Delete" }
+        if operation.isDeleteAudioOnly {
+            return "Delete Audio Only"
+        }
+        if operation.meetingCount == operation.targetCount {
+            return operation.targetCount == 1 ? "Delete Meeting" : "Delete Meetings"
+        }
+        return "Delete Items"
+    }
+
+    private func bulkOperationMessage(for operation: BulkTranscriptionOperation) -> String {
+        if operation.isDeleteAudioOnly {
+            var message = "Delete audio for \(operation.targetCount) \(operation.targetCount == 1 ? "meeting" : "meetings")? Transcripts, notes, AI results, and chats stay in Library if they exist. Playback and retranscription will be unavailable unless you saved a copy."
+            if operation.skippedCount > 0 {
+                message += " \(operation.skippedCount) selected \(operation.skippedCount == 1 ? "item will be skipped" : "items will be skipped")."
+            }
+            return message
+        }
+
+        if operation.meetingCount > 0 {
+            return "Delete \(operation.targetCount) \(operation.targetCount == 1 ? "item" : "items"), including \(operation.meetingCount) \(operation.meetingCount == 1 ? "meeting" : "meetings")? This permanently removes the selected rows, transcripts, stored audio, and any notes, AI results, or chats for those meetings. Original local source files are not removed."
+        }
+
+        return "Delete \(operation.targetCount) \(operation.targetCount == 1 ? "item" : "items")? This permanently deletes the Library rows and app-owned files. Original local source files are not removed."
+    }
+
+    private func singleDeleteTitle(for transcription: Transcription) -> String {
+        transcription.sourceType == .meeting ? "Delete Meeting?" : "Delete Transcription?"
+    }
+
+    private func singleDeleteConfirmTitle(for transcription: Transcription) -> String {
+        transcription.sourceType == .meeting ? "Delete Meeting" : "Delete"
+    }
+
+    private func singleDeleteMessage(for transcription: Transcription) -> String {
+        if transcription.sourceType == .meeting {
+            return "This permanently removes \"\(transcription.fileName)\", its transcript, stored audio, and any notes, AI results, or chats for this meeting."
+        }
+        return "\"\(transcription.fileName)\" will be permanently deleted. Original local source files are not removed."
+    }
+
+    private func handleSelectionKeyPress(_ press: KeyPress) -> KeyPress.Result {
+        guard viewModel.isBulkSelectionModeEnabled else { return .ignored }
+        if press.key == .escape {
+            viewModel.exitBulkSelection()
+            return .handled
+        }
+        if press.key == .delete || press.key == .deleteForward {
+            guard viewModel.hasSelectedTranscriptions else { return .ignored }
+            viewModel.requestDeleteSelectedItems()
+            return .handled
+        }
+        if press.key == "a", press.modifiers.contains(.command) {
+            viewModel.selectLoadedVisibleTranscriptions()
+            return .handled
+        }
+        return .ignored
     }
 
     private var emptyStateIcon: String {
@@ -430,5 +589,19 @@ private struct LibraryPrimaryActionButton: View {
         }
         .accessibilityLabel(title)
         .accessibilityHint("Starts a new transcription")
+    }
+}
+
+private struct LibrarySelectManyButton: View {
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Label("Select Many", systemImage: "checklist")
+                .font(DesignSystem.Typography.bodySmall.weight(.semibold))
+        }
+        .parakeetAction(.secondary)
+        .help("Select multiple visible Library items")
+        .accessibilityHint("Shows selection controls for bulk cleanup")
     }
 }

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -98,7 +98,8 @@ struct TranscriptionLibraryView: View {
                 selectionKeyboardFocused = true
             }
         }
-        .onKeyPress(keys: ["a", .delete, .deleteForward, .escape]) { press in
+        .animation(.easeInOut(duration: 0.16), value: viewModel.isBulkSelectionModeEnabled)
+        .onKeyPress(keys: ["a", "A", .delete, .deleteForward]) { press in
             handleSelectionKeyPress(press)
         }
         .onAppear {
@@ -190,6 +191,9 @@ struct TranscriptionLibraryView: View {
                             isSelected: viewModel.isTranscriptionSelected(transcription),
                             showsSelectionControls: viewModel.isBulkSelectionModeEnabled
                         ) {
+                            if viewModel.isBulkOperationInProgress {
+                                return
+                            }
                             if viewModel.isBulkSelectionModeEnabled {
                                 viewModel.toggleSelection(for: transcription)
                             } else {
@@ -222,6 +226,9 @@ struct TranscriptionLibraryView: View {
                             isSelected: viewModel.isTranscriptionSelected(transcription),
                             showsSelectionControls: viewModel.isBulkSelectionModeEnabled,
                             onTap: {
+                                if viewModel.isBulkOperationInProgress {
+                                    return
+                                }
                                 if viewModel.isBulkSelectionModeEnabled {
                                     viewModel.toggleSelection(for: transcription)
                                 } else {
@@ -321,6 +328,7 @@ struct TranscriptionLibraryView: View {
             selectedMeetingAudioCount: viewModel.selectedMeetingAudioCount,
             isMeetingContext: isMeetingListMode,
             areAllLoadedSelected: viewModel.areAllLoadedVisibleTranscriptionsSelected,
+            isPerformingOperation: viewModel.isBulkOperationInProgress,
             onSelectLoaded: { viewModel.selectLoadedVisibleTranscriptions() },
             onClear: { viewModel.clearSelection() },
             onCancel: { viewModel.exitBulkSelection() },
@@ -469,17 +477,13 @@ struct TranscriptionLibraryView: View {
     }
 
     private func handleSelectionKeyPress(_ press: KeyPress) -> KeyPress.Result {
-        guard viewModel.isBulkSelectionModeEnabled else { return .ignored }
-        if press.key == .escape {
-            viewModel.exitBulkSelection()
-            return .handled
-        }
+        guard viewModel.isBulkSelectionModeEnabled, !viewModel.isBulkOperationInProgress else { return .ignored }
         if press.key == .delete || press.key == .deleteForward {
             guard viewModel.hasSelectedTranscriptions else { return .ignored }
             viewModel.requestDeleteSelectedItems()
             return .handled
         }
-        if press.key == "a", press.modifiers.contains(.command) {
+        if (press.key == "a" || press.key == "A"), press.modifiers.contains(.command) {
             viewModel.selectLoadedVisibleTranscriptions()
             return .handled
         }

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionThumbnailCard.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionThumbnailCard.swift
@@ -7,6 +7,8 @@ private let sharedThumbnailCache = ThumbnailCacheService.shared
 struct TranscriptionThumbnailCard<MenuContent: View>: View {
     let transcription: Transcription
     var searchText: String = ""
+    var isSelected: Bool = false
+    var showsSelectionControls: Bool = false
     var onTap: () -> Void
     @ViewBuilder var menuContent: () -> MenuContent
 
@@ -20,18 +22,28 @@ struct TranscriptionThumbnailCard<MenuContent: View>: View {
             }
             .background(
                 RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
-                    .fill(DesignSystem.Colors.cardBackground)
+                    .fill(isSelected ? DesignSystem.Colors.accentLight : DesignSystem.Colors.cardBackground)
                     .cardShadow(hovered ? DesignSystem.Shadows.cardHover : DesignSystem.Shadows.cardRest)
             )
             .overlay(
                 RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
-                    .strokeBorder(DesignSystem.Colors.border.opacity(0.75), lineWidth: 0.5)
+                    .strokeBorder(
+                        isSelected ? DesignSystem.Colors.accent.opacity(0.72) : DesignSystem.Colors.border.opacity(0.75),
+                        lineWidth: isSelected ? 1.25 : 0.5
+                    )
             )
             .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius))
             .scaleEffect(hovered ? 1.02 : 1.0)
             .animation(DesignSystem.Animation.hoverTransition, value: hovered)
+            .animation(DesignSystem.Animation.hoverTransition, value: isSelected)
         }
         .buttonStyle(.plain)
+        .overlay(alignment: .topLeading) {
+            if showsSelectionControls {
+                selectionBadge
+                    .padding(8)
+            }
+        }
         .overlay(alignment: .topTrailing) {
             moreButton
                 .opacity(hovered ? 1 : 0)
@@ -49,6 +61,8 @@ struct TranscriptionThumbnailCard<MenuContent: View>: View {
                 }
             }
         }
+        .accessibilityValue(showsSelectionControls ? (isSelected ? "Selected" : "Not selected") : "")
+        .accessibilityHint(showsSelectionControls ? "Toggles selection" : "Opens transcription")
     }
 
     @State private var moreHovered = false
@@ -80,6 +94,26 @@ struct TranscriptionThumbnailCard<MenuContent: View>: View {
                 .contentShape(Rectangle())
                 .onHover { moreHovered = $0 }
         )
+    }
+
+    private var selectionBadge: some View {
+        ZStack {
+            Circle()
+                .fill(isSelected ? DesignSystem.Colors.accent : DesignSystem.Colors.surface.opacity(0.92))
+                .frame(width: 22, height: 22)
+                .overlay {
+                    Circle()
+                        .strokeBorder(
+                            isSelected ? DesignSystem.Colors.accent : DesignSystem.Colors.accent.opacity(0.7),
+                            lineWidth: 1.2
+                        )
+                }
+
+            Image(systemName: isSelected ? "checkmark" : "circle")
+                .font(.system(size: isSelected ? 10 : 8, weight: .bold))
+                .foregroundStyle(isSelected ? DesignSystem.Colors.onAccent : DesignSystem.Colors.accent.opacity(0.75))
+        }
+        .accessibilityHidden(true)
     }
 
     // MARK: - Thumbnail

--- a/Sources/MacParakeetCore/Utilities/TranscriptionAssetCleanup.swift
+++ b/Sources/MacParakeetCore/Utilities/TranscriptionAssetCleanup.swift
@@ -91,8 +91,8 @@ public enum TranscriptionAssetCleanup {
             return MeetingAudioDetachResult(removedOwnedAudio: false, hadAudioPath: true)
         }
 
-        try repository.updateFilePath(id: transcription.id, filePath: nil)
         try removeMeetingAudioFiles(removalPlan, fileManager: fileManager)
+        try repository.updateFilePath(id: transcription.id, filePath: nil)
         return MeetingAudioDetachResult(removedOwnedAudio: true, hadAudioPath: true)
     }
 

--- a/Sources/MacParakeetCore/Utilities/TranscriptionAssetCleanup.swift
+++ b/Sources/MacParakeetCore/Utilities/TranscriptionAssetCleanup.swift
@@ -29,6 +29,19 @@ public enum TranscriptionAssetCleanup {
         subsystem: "com.macparakeet.core",
         category: "TranscriptionAssetCleanup"
     )
+    private static let standardMeetingAudioFileNames: Set<String> = [
+        "meeting.m4a",
+        "microphone.m4a",
+        "system.m4a",
+    ]
+    private static let managedMeetingAudioExtensions: Set<String> = [
+        "aac",
+        "caf",
+        "flac",
+        "m4a",
+        "mp3",
+        "wav",
+    ]
 
     public static func removeOwnedAssets(
         for transcription: Transcription,
@@ -69,15 +82,73 @@ public enum TranscriptionAssetCleanup {
         fileManager: FileManager = .default
     ) throws -> MeetingAudioDetachResult {
         let hasAudioPath = !(transcription.filePath?.isEmpty ?? true)
-        let removedOwnedAudio = try removeOwnedMeetingAudio(for: transcription, fileManager: fileManager)
-        let result = MeetingAudioDetachResult(
-            removedOwnedAudio: removedOwnedAudio,
-            hadAudioPath: hasAudioPath
-        )
-        guard result.detached else { return result }
+        guard hasAudioPath else {
+            let result = MeetingAudioDetachResult(removedOwnedAudio: false, hadAudioPath: false)
+            try repository.updateFilePath(id: transcription.id, filePath: nil)
+            return result
+        }
+        guard let removalPlan = try meetingAudioRemovalPlan(for: transcription, fileManager: fileManager) else {
+            return MeetingAudioDetachResult(removedOwnedAudio: false, hadAudioPath: true)
+        }
 
         try repository.updateFilePath(id: transcription.id, filePath: nil)
-        return result
+        try removeMeetingAudioFiles(removalPlan, fileManager: fileManager)
+        return MeetingAudioDetachResult(removedOwnedAudio: true, hadAudioPath: true)
+    }
+
+    private static func meetingAudioRemovalPlan(
+        for transcription: Transcription,
+        fileManager: FileManager
+    ) throws -> MeetingAudioRemovalPlan? {
+        guard transcription.sourceType == .meeting,
+              let filePath = transcription.filePath,
+              !filePath.isEmpty else {
+            return nil
+        }
+
+        let mixedAudioURL = URL(fileURLWithPath: filePath).standardizedFileURL
+        let folderURL = mixedAudioURL.deletingLastPathComponent().standardizedFileURL
+
+        guard isKnownMeetingFolder(folderURL, fileManager: fileManager) else {
+            logger.warning(
+                "Refusing to remove meeting audio outside app support: \(folderURL.path, privacy: .private)"
+            )
+            return nil
+        }
+        let lockURL = MeetingRecordingLockFileStore.lockFileURL(for: folderURL)
+        guard !fileManager.fileExists(atPath: lockURL.path) else {
+            logger.warning(
+                "Refusing to remove audio from locked meeting folder: \(folderURL.path, privacy: .private)"
+            )
+            throw TranscriptionAssetCleanupError.removalFailed(
+                path: folderURL.path,
+                reason: "meeting audio is still awaiting transcription or recovery"
+            )
+        }
+
+        return MeetingAudioRemovalPlan(
+            candidates: meetingAudioFileCandidates(mixedAudioURL: mixedAudioURL, folderURL: folderURL)
+        )
+    }
+
+    private static func removeMeetingAudioFiles(
+        _ plan: MeetingAudioRemovalPlan,
+        fileManager: FileManager
+    ) throws {
+        for candidate in plan.candidates where fileManager.fileExists(atPath: candidate.path) {
+            try removeItem(at: candidate, fileManager: fileManager)
+        }
+    }
+
+    private static func meetingAudioFileCandidates(mixedAudioURL: URL, folderURL: URL) -> Set<URL> {
+        var candidates = Set(
+            standardMeetingAudioFileNames.map { folderURL.appendingPathComponent($0).standardizedFileURL }
+        )
+        if mixedAudioURL.deletingLastPathComponent().standardizedFileURL == folderURL,
+           managedMeetingAudioExtensions.contains(mixedAudioURL.pathExtension.lowercased()) {
+            candidates.insert(mixedAudioURL)
+        }
+        return candidates
     }
 
     private static func removeDownloadedMediaFile(at fileURL: URL, fileManager: FileManager) throws {
@@ -159,4 +230,8 @@ public enum TranscriptionAssetCleanup {
 
 private struct MeetingArtifactManifestProbe: Decodable {
     let schema: String
+}
+
+private struct MeetingAudioRemovalPlan {
+    let candidates: Set<URL>
 }

--- a/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
@@ -121,6 +121,7 @@ public final class TranscriptionLibraryViewModel {
     public var searchDebounceInterval: Duration = .milliseconds(300)
     public private(set) var selectedTranscriptionIDs: Set<UUID> = []
     public private(set) var isBulkSelectionModeEnabled = false
+    public private(set) var isBulkOperationInProgress = false
     public private(set) var pendingBulkOperation: BulkTranscriptionOperation?
 
     /// Override for tests; production code uses `Date()`.
@@ -222,6 +223,7 @@ public final class TranscriptionLibraryViewModel {
     }
 
     public func toggleSelection(for transcription: Transcription) {
+        guard !isBulkOperationInProgress else { return }
         bulkSelectionGeneration += 1
         if selectedTranscriptionIDs.contains(transcription.id) {
             selectedTranscriptionIDs.remove(transcription.id)
@@ -231,16 +233,19 @@ public final class TranscriptionLibraryViewModel {
     }
 
     public func selectLoadedVisibleTranscriptions() {
+        guard !isBulkOperationInProgress else { return }
         bulkSelectionGeneration += 1
         selectedTranscriptionIDs = loadedVisibleTranscriptionIDs
     }
 
     public func clearSelection() {
+        guard !isBulkOperationInProgress else { return }
         bulkSelectionGeneration += 1
         selectedTranscriptionIDs = []
     }
 
     public func beginBulkSelection(startingWith transcription: Transcription? = nil) {
+        guard !isBulkOperationInProgress else { return }
         bulkSelectionGeneration += 1
         isBulkSelectionModeEnabled = true
         if let transcription {
@@ -249,6 +254,11 @@ public final class TranscriptionLibraryViewModel {
     }
 
     public func exitBulkSelection() {
+        guard !isBulkOperationInProgress else { return }
+        finishBulkSelection()
+    }
+
+    private func finishBulkSelection() {
         bulkSelectionGeneration += 1
         isBulkSelectionModeEnabled = false
         selectedTranscriptionIDs = []
@@ -256,10 +266,12 @@ public final class TranscriptionLibraryViewModel {
     }
 
     public func cancelPendingBulkOperation() {
+        guard !isBulkOperationInProgress else { return }
         pendingBulkOperation = nil
     }
 
     public func requestDeleteSelectedItems() {
+        guard !isBulkOperationInProgress else { return }
         let targets = selectedLoadedTranscriptions
         guard !targets.isEmpty else {
             clearSelection()
@@ -269,6 +281,7 @@ public final class TranscriptionLibraryViewModel {
     }
 
     public func requestDeleteSelectedMeetingAudio() {
+        guard !isBulkOperationInProgress else { return }
         let selected = selectedLoadedTranscriptions
         let targets = selected.filter(Self.hasAvailableMeetingAudio)
         guard !targets.isEmpty else {
@@ -293,8 +306,8 @@ public final class TranscriptionLibraryViewModel {
 
         bulkSelectionGeneration += 1
         let operationGeneration = bulkSelectionGeneration
-        isBulkSelectionModeEnabled = false
-        selectedTranscriptionIDs = []
+        isBulkSelectionModeEnabled = true
+        isBulkOperationInProgress = true
         errorMessage = nil
 
         switch operation {
@@ -309,8 +322,12 @@ public final class TranscriptionLibraryViewModel {
                 removeLoadedTranscriptions(withIDs: Set(result.succeededIDs))
             }
             if !result.failedIDs.isEmpty {
+                isBulkOperationInProgress = false
                 restoreFailedSelectionIfCurrent(result.failedIDs, operationGeneration: operationGeneration)
                 errorMessage = Self.bulkDeleteFailureMessage(succeeded: result.succeededIDs.count, failed: result.failedIDs.count)
+            } else {
+                isBulkOperationInProgress = false
+                finishBulkSelection()
             }
             return BulkOperationResult(
                 succeeded: result.succeededIDs.count,
@@ -325,12 +342,16 @@ public final class TranscriptionLibraryViewModel {
                 clearLoadedMeetingAudio(forIDs: Set(result.succeededIDs))
             }
             if !result.failedIDs.isEmpty {
+                isBulkOperationInProgress = false
                 restoreFailedSelectionIfCurrent(result.failedIDs, operationGeneration: operationGeneration)
                 errorMessage = Self.bulkAudioDeleteFailureMessage(
                     succeeded: result.succeededIDs.count,
                     failed: result.failedIDs.count,
                     skipped: skipped
                 )
+            } else {
+                isBulkOperationInProgress = false
+                finishBulkSelection()
             }
             return BulkOperationResult(
                 succeeded: result.succeededIDs.count,

--- a/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
@@ -119,9 +119,9 @@ public final class TranscriptionLibraryViewModel {
     public var errorMessage: String?
     public var pageSize = 100
     public var searchDebounceInterval: Duration = .milliseconds(300)
-    public var selectedTranscriptionIDs: Set<UUID> = []
-    public var isBulkSelectionModeEnabled = false
-    public var pendingBulkOperation: BulkTranscriptionOperation?
+    public private(set) var selectedTranscriptionIDs: Set<UUID> = []
+    public private(set) var isBulkSelectionModeEnabled = false
+    public private(set) var pendingBulkOperation: BulkTranscriptionOperation?
 
     /// Override for tests; production code uses `Date()`.
     public var nowProvider: @Sendable () -> Date = { Date() }
@@ -131,6 +131,7 @@ public final class TranscriptionLibraryViewModel {
     private var loadTask: Task<Void, Never>?
     private var searchDebounceTask: Task<Void, Never>?
     private var loadGeneration = 0
+    private var bulkSelectionGeneration = 0
     public let scope: TranscriptionLibraryScope
 
     public init(scope: TranscriptionLibraryScope = .all) {
@@ -221,6 +222,7 @@ public final class TranscriptionLibraryViewModel {
     }
 
     public func toggleSelection(for transcription: Transcription) {
+        bulkSelectionGeneration += 1
         if selectedTranscriptionIDs.contains(transcription.id) {
             selectedTranscriptionIDs.remove(transcription.id)
         } else {
@@ -229,14 +231,17 @@ public final class TranscriptionLibraryViewModel {
     }
 
     public func selectLoadedVisibleTranscriptions() {
+        bulkSelectionGeneration += 1
         selectedTranscriptionIDs = loadedVisibleTranscriptionIDs
     }
 
     public func clearSelection() {
+        bulkSelectionGeneration += 1
         selectedTranscriptionIDs = []
     }
 
     public func beginBulkSelection(startingWith transcription: Transcription? = nil) {
+        bulkSelectionGeneration += 1
         isBulkSelectionModeEnabled = true
         if let transcription {
             selectedTranscriptionIDs.insert(transcription.id)
@@ -244,6 +249,7 @@ public final class TranscriptionLibraryViewModel {
     }
 
     public func exitBulkSelection() {
+        bulkSelectionGeneration += 1
         isBulkSelectionModeEnabled = false
         selectedTranscriptionIDs = []
         pendingBulkOperation = nil
@@ -285,6 +291,8 @@ public final class TranscriptionLibraryViewModel {
             return BulkOperationResult(succeeded: 0, failed: operation.targetCount, skipped: operation.skippedCount)
         }
 
+        bulkSelectionGeneration += 1
+        let operationGeneration = bulkSelectionGeneration
         isBulkSelectionModeEnabled = false
         selectedTranscriptionIDs = []
         errorMessage = nil
@@ -301,8 +309,7 @@ public final class TranscriptionLibraryViewModel {
                 removeLoadedTranscriptions(withIDs: Set(result.succeededIDs))
             }
             if !result.failedIDs.isEmpty {
-                isBulkSelectionModeEnabled = true
-                selectedTranscriptionIDs = Set(result.failedIDs)
+                restoreFailedSelectionIfCurrent(result.failedIDs, operationGeneration: operationGeneration)
                 errorMessage = Self.bulkDeleteFailureMessage(succeeded: result.succeededIDs.count, failed: result.failedIDs.count)
             }
             return BulkOperationResult(
@@ -318,8 +325,7 @@ public final class TranscriptionLibraryViewModel {
                 clearLoadedMeetingAudio(forIDs: Set(result.succeededIDs))
             }
             if !result.failedIDs.isEmpty {
-                isBulkSelectionModeEnabled = true
-                selectedTranscriptionIDs = Set(result.failedIDs)
+                restoreFailedSelectionIfCurrent(result.failedIDs, operationGeneration: operationGeneration)
                 errorMessage = Self.bulkAudioDeleteFailureMessage(
                     succeeded: result.succeededIDs.count,
                     failed: result.failedIDs.count,
@@ -515,6 +521,14 @@ public final class TranscriptionLibraryViewModel {
             transcriptions[index].filePath = nil
         }
         publishLoadedItems(transcriptions, hasMore: hasMore)
+    }
+
+    private func restoreFailedSelectionIfCurrent(_ failedIDs: [UUID], operationGeneration: Int) {
+        guard bulkSelectionGeneration == operationGeneration else { return }
+        let visibleFailedIDs = Set(failedIDs).intersection(loadedVisibleTranscriptionIDs)
+        guard !visibleFailedIDs.isEmpty else { return }
+        isBulkSelectionModeEnabled = true
+        selectedTranscriptionIDs = visibleFailedIDs
     }
 
     nonisolated private static func deleteTargets(

--- a/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
@@ -58,6 +58,53 @@ public enum TranscriptionDateGroup: Hashable, Sendable {
     }
 }
 
+public enum BulkTranscriptionOperation: Sendable {
+    case deleteItems([Transcription])
+    case deleteAudioOnly(targets: [Transcription], skipped: Int)
+
+    public var targetCount: Int {
+        switch self {
+        case .deleteItems(let targets), .deleteAudioOnly(let targets, _):
+            return targets.count
+        }
+    }
+
+    public var skippedCount: Int {
+        switch self {
+        case .deleteItems:
+            return 0
+        case .deleteAudioOnly(_, let skipped):
+            return skipped
+        }
+    }
+
+    public var meetingCount: Int {
+        switch self {
+        case .deleteItems(let targets):
+            return targets.filter { $0.sourceType == .meeting }.count
+        case .deleteAudioOnly(let targets, _):
+            return targets.count
+        }
+    }
+
+    public var isDeleteAudioOnly: Bool {
+        if case .deleteAudioOnly = self { return true }
+        return false
+    }
+}
+
+public struct BulkOperationResult: Sendable, Equatable {
+    public let succeeded: Int
+    public let failed: Int
+    public let skipped: Int
+
+    public init(succeeded: Int, failed: Int, skipped: Int = 0) {
+        self.succeeded = succeeded
+        self.failed = failed
+        self.skipped = skipped
+    }
+}
+
 @MainActor @Observable
 public final class TranscriptionLibraryViewModel {
     private let logger = Logger(subsystem: "com.macparakeet.viewmodels", category: "TranscriptionLibrary")
@@ -72,6 +119,9 @@ public final class TranscriptionLibraryViewModel {
     public var errorMessage: String?
     public var pageSize = 100
     public var searchDebounceInterval: Duration = .milliseconds(300)
+    public var selectedTranscriptionIDs: Set<UUID> = []
+    public var isBulkSelectionModeEnabled = false
+    public var pendingBulkOperation: BulkTranscriptionOperation?
 
     /// Override for tests; production code uses `Date()`.
     public var nowProvider: @Sendable () -> Date = { Date() }
@@ -89,6 +139,23 @@ public final class TranscriptionLibraryViewModel {
 
     public func configure(transcriptionRepo: TranscriptionRepositoryProtocol) {
         self.transcriptionRepo = transcriptionRepo
+    }
+
+    public var selectedTranscriptionCount: Int {
+        selectedTranscriptionIDs.count
+    }
+
+    public var hasSelectedTranscriptions: Bool {
+        !selectedTranscriptionIDs.isEmpty
+    }
+
+    public var areAllLoadedVisibleTranscriptionsSelected: Bool {
+        let ids = loadedVisibleTranscriptionIDs
+        return !ids.isEmpty && ids.isSubset(of: selectedTranscriptionIDs)
+    }
+
+    public var selectedMeetingAudioCount: Int {
+        selectedLoadedTranscriptions.filter(Self.hasAvailableMeetingAudio).count
     }
 
     private func groupByDate(_ items: [Transcription]) -> [(group: TranscriptionDateGroup, items: [Transcription])] {
@@ -149,6 +216,124 @@ public final class TranscriptionLibraryViewModel {
         }
     }
 
+    public func isTranscriptionSelected(_ transcription: Transcription) -> Bool {
+        selectedTranscriptionIDs.contains(transcription.id)
+    }
+
+    public func toggleSelection(for transcription: Transcription) {
+        if selectedTranscriptionIDs.contains(transcription.id) {
+            selectedTranscriptionIDs.remove(transcription.id)
+        } else {
+            selectedTranscriptionIDs.insert(transcription.id)
+        }
+    }
+
+    public func selectLoadedVisibleTranscriptions() {
+        selectedTranscriptionIDs = loadedVisibleTranscriptionIDs
+    }
+
+    public func clearSelection() {
+        selectedTranscriptionIDs = []
+    }
+
+    public func beginBulkSelection(startingWith transcription: Transcription? = nil) {
+        isBulkSelectionModeEnabled = true
+        if let transcription {
+            selectedTranscriptionIDs.insert(transcription.id)
+        }
+    }
+
+    public func exitBulkSelection() {
+        isBulkSelectionModeEnabled = false
+        selectedTranscriptionIDs = []
+        pendingBulkOperation = nil
+    }
+
+    public func cancelPendingBulkOperation() {
+        pendingBulkOperation = nil
+    }
+
+    public func requestDeleteSelectedItems() {
+        let targets = selectedLoadedTranscriptions
+        guard !targets.isEmpty else {
+            clearSelection()
+            return
+        }
+        pendingBulkOperation = .deleteItems(targets)
+    }
+
+    public func requestDeleteSelectedMeetingAudio() {
+        let selected = selectedLoadedTranscriptions
+        let targets = selected.filter(Self.hasAvailableMeetingAudio)
+        guard !targets.isEmpty else {
+            return
+        }
+        pendingBulkOperation = .deleteAudioOnly(
+            targets: targets,
+            skipped: selected.count - targets.count
+        )
+    }
+
+    @discardableResult
+    public func confirmPendingBulkOperation() async -> BulkOperationResult {
+        guard let operation = pendingBulkOperation else {
+            return BulkOperationResult(succeeded: 0, failed: 0)
+        }
+        pendingBulkOperation = nil
+        guard let repo = transcriptionRepo else {
+            errorMessage = "Unable to update Library: database is not available."
+            return BulkOperationResult(succeeded: 0, failed: operation.targetCount, skipped: operation.skippedCount)
+        }
+
+        isBulkSelectionModeEnabled = false
+        selectedTranscriptionIDs = []
+        errorMessage = nil
+
+        switch operation {
+        case .deleteItems(let targets):
+            let result = await Task.detached(priority: .userInitiated) {
+                Self.deleteTargets(targets, using: repo)
+            }.value
+            for _ in 0..<result.succeededIDs.count {
+                Telemetry.send(.transcriptionDeleted)
+            }
+            if !result.succeededIDs.isEmpty {
+                removeLoadedTranscriptions(withIDs: Set(result.succeededIDs))
+            }
+            if !result.failedIDs.isEmpty {
+                isBulkSelectionModeEnabled = true
+                selectedTranscriptionIDs = Set(result.failedIDs)
+                errorMessage = Self.bulkDeleteFailureMessage(succeeded: result.succeededIDs.count, failed: result.failedIDs.count)
+            }
+            return BulkOperationResult(
+                succeeded: result.succeededIDs.count,
+                failed: result.failedIDs.count
+            )
+
+        case .deleteAudioOnly(let targets, let skipped):
+            let result = await Task.detached(priority: .userInitiated) {
+                Self.detachMeetingAudioTargets(targets, using: repo)
+            }.value
+            if !result.succeededIDs.isEmpty {
+                clearLoadedMeetingAudio(forIDs: Set(result.succeededIDs))
+            }
+            if !result.failedIDs.isEmpty {
+                isBulkSelectionModeEnabled = true
+                selectedTranscriptionIDs = Set(result.failedIDs)
+                errorMessage = Self.bulkAudioDeleteFailureMessage(
+                    succeeded: result.succeededIDs.count,
+                    failed: result.failedIDs.count,
+                    skipped: skipped
+                )
+            }
+            return BulkOperationResult(
+                succeeded: result.succeededIDs.count,
+                failed: result.failedIDs.count,
+                skipped: skipped
+            )
+        }
+    }
+
     public func deleteTranscription(_ transcription: Transcription) {
         do {
             errorMessage = nil
@@ -156,6 +341,7 @@ public final class TranscriptionLibraryViewModel {
             let deleted = try transcriptionRepo?.delete(id: transcription.id) ?? false
             guard deleted else { return }
             transcriptions.removeAll { $0.id == transcription.id }
+            selectedTranscriptionIDs.remove(transcription.id)
             publishLoadedItems(transcriptions, hasMore: hasMore)
             Telemetry.send(.transcriptionDeleted)
         } catch {
@@ -188,12 +374,14 @@ public final class TranscriptionLibraryViewModel {
     }
 
     private func reloadAfterStateChange() {
+        exitBulkSelection()
         searchDebounceTask?.cancel()
         searchDebounceTask = nil
         loadTranscriptions()
     }
 
     private func debounceSearchReload() {
+        exitBulkSelection()
         searchDebounceTask?.cancel()
         searchDebounceTask = Task { @MainActor [weak self] in
             guard let self else { return }
@@ -297,5 +485,110 @@ public final class TranscriptionLibraryViewModel {
         filteredTranscriptions = items
         groupedTranscriptions = groupByDate(items)
         self.hasMore = hasMore
+        pruneSelectionToLoadedItems()
     }
+
+    private var loadedVisibleTranscriptionIDs: Set<UUID> {
+        Set(filteredTranscriptions.map(\.id))
+    }
+
+    private var selectedLoadedTranscriptions: [Transcription] {
+        filteredTranscriptions.filter { selectedTranscriptionIDs.contains($0.id) }
+    }
+
+    nonisolated private static func hasAvailableMeetingAudio(_ transcription: Transcription) -> Bool {
+        MeetingAudioFile.isAvailable(for: transcription)
+    }
+
+    private func pruneSelectionToLoadedItems() {
+        selectedTranscriptionIDs = selectedTranscriptionIDs.intersection(loadedVisibleTranscriptionIDs)
+    }
+
+    private func removeLoadedTranscriptions(withIDs ids: Set<UUID>) {
+        transcriptions.removeAll { ids.contains($0.id) }
+        selectedTranscriptionIDs.subtract(ids)
+        publishLoadedItems(transcriptions, hasMore: hasMore)
+    }
+
+    private func clearLoadedMeetingAudio(forIDs ids: Set<UUID>) {
+        for index in transcriptions.indices where ids.contains(transcriptions[index].id) {
+            transcriptions[index].filePath = nil
+        }
+        publishLoadedItems(transcriptions, hasMore: hasMore)
+    }
+
+    nonisolated private static func deleteTargets(
+        _ targets: [Transcription],
+        using repo: TranscriptionRepositoryProtocol
+    ) -> BatchTargetResult {
+        var succeededIDs: [UUID] = []
+        var failedIDs: [UUID] = []
+
+        for target in targets {
+            do {
+                try TranscriptionDeletionCleanup.removeOwnedAssets(for: target)
+                if try repo.delete(id: target.id) {
+                    succeededIDs.append(target.id)
+                } else {
+                    failedIDs.append(target.id)
+                }
+            } catch {
+                failedIDs.append(target.id)
+            }
+        }
+
+        return BatchTargetResult(succeededIDs: succeededIDs, failedIDs: failedIDs)
+    }
+
+    nonisolated private static func detachMeetingAudioTargets(
+        _ targets: [Transcription],
+        using repo: TranscriptionRepositoryProtocol
+    ) -> BatchTargetResult {
+        var succeededIDs: [UUID] = []
+        var failedIDs: [UUID] = []
+
+        for target in targets {
+            do {
+                let result = try TranscriptionAssetCleanup.detachOwnedMeetingAudio(
+                    for: target,
+                    repository: repo
+                )
+                if result.detached {
+                    succeededIDs.append(target.id)
+                } else {
+                    failedIDs.append(target.id)
+                }
+            } catch {
+                failedIDs.append(target.id)
+            }
+        }
+
+        return BatchTargetResult(succeededIDs: succeededIDs, failedIDs: failedIDs)
+    }
+
+    nonisolated private static func bulkDeleteFailureMessage(succeeded: Int, failed: Int) -> String {
+        if succeeded > 0 {
+            return "Deleted \(succeeded) items. \(failed) could not be deleted."
+        }
+        return failed == 1 ? "1 item could not be deleted." : "\(failed) items could not be deleted."
+    }
+
+    nonisolated private static func bulkAudioDeleteFailureMessage(succeeded: Int, failed: Int, skipped: Int) -> String {
+        var parts: [String] = []
+        if succeeded > 0 {
+            parts.append("Deleted audio for \(succeeded) \(succeeded == 1 ? "meeting" : "meetings").")
+        }
+        if failed > 0 {
+            parts.append(failed == 1 ? "1 meeting audio file could not be deleted." : "\(failed) meeting audio files could not be deleted.")
+        }
+        if skipped > 0 {
+            parts.append(skipped == 1 ? "1 selected item was skipped." : "\(skipped) selected items were skipped.")
+        }
+        return parts.joined(separator: " ")
+    }
+}
+
+private struct BatchTargetResult: Sendable {
+    let succeededIDs: [UUID]
+    let failedIDs: [UUID]
 }

--- a/Tests/CLITests/HistoryCommandTests.swift
+++ b/Tests/CLITests/HistoryCommandTests.swift
@@ -166,7 +166,11 @@ final class HistoryCommandTests: XCTestCase {
             .appendingPathComponent("macparakeet-cli-meeting-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
         let audioURL = folder.appendingPathComponent("meeting.m4a")
+        let systemAudioURL = folder.appendingPathComponent("system.m4a")
+        let notesURL = folder.appendingPathComponent("notes.md")
         XCTAssertTrue(FileManager.default.createFile(atPath: audioURL.path, contents: Data("audio".utf8)))
+        XCTAssertTrue(FileManager.default.createFile(atPath: systemAudioURL.path, contents: Data("system".utf8)))
+        try "notes".write(to: notesURL, atomically: true, encoding: .utf8)
         defer { try? FileManager.default.removeItem(at: folder) }
 
         let transcription = Transcription(
@@ -188,7 +192,10 @@ final class HistoryCommandTests: XCTestCase {
 
         let fetched = try XCTUnwrap(repo.fetch(id: transcription.id))
         XCTAssertNil(fetched.filePath)
-        XCTAssertFalse(FileManager.default.fileExists(atPath: folder.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: folder.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: audioURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: systemAudioURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: notesURL.path))
         XCTAssertTrue(output.contains("Detached managed meeting audio"))
     }
 

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingAudioRetentionSweeperTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingAudioRetentionSweeperTests.swift
@@ -39,7 +39,11 @@ final class MeetingAudioRetentionSweeperTests: XCTestCase {
         XCTAssertEqual(result.eligibleCount, 1)
         XCTAssertEqual(result.detachedCount, 1)
         XCTAssertEqual(result.skippedLockedCount, 2)
-        XCTAssertFalse(FileManager.default.fileExists(atPath: eligible.folderURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: eligible.folderURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: eligible.audioURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: MeetingRecordingMetadataStore.metadataURL(for: eligible.folderURL).path
+        ))
         XCTAssertNil(try repo.fetch(id: eligible.transcription.id)?.filePath)
         XCTAssertNotNil(try repo.fetch(id: eligible.transcription.id))
         XCTAssertTrue(FileManager.default.fileExists(atPath: lockedRecording.folderURL.path))

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingAudioRetentionSweeperTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingAudioRetentionSweeperTests.swift
@@ -102,9 +102,11 @@ final class MeetingAudioRetentionSweeperTests: XCTestCase {
         XCTAssertEqual(result.detachedCount, 1)
         for locked in [zeroByte, corrupt, futureSchema] {
             XCTAssertTrue(FileManager.default.fileExists(atPath: locked.folderURL.path))
+            XCTAssertTrue(FileManager.default.fileExists(atPath: locked.audioURL.path))
             XCTAssertEqual(try repo.fetch(id: locked.transcription.id)?.filePath, locked.audioURL.path)
         }
-        XCTAssertFalse(FileManager.default.fileExists(atPath: eligible.folderURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: eligible.folderURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: eligible.audioURL.path))
         XCTAssertNil(try repo.fetch(id: eligible.transcription.id)?.filePath)
     }
 

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionDeletionCleanupTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionDeletionCleanupTests.swift
@@ -77,7 +77,7 @@ final class TranscriptionDeletionCleanupTests: XCTestCase {
         XCTAssertTrue(removed)
     }
 
-    func testDetachMeetingAudioPreservesAudioWhenRepositoryUpdateFails() throws {
+    func testDetachMeetingAudioRemovesAudioBeforeRepositoryUpdate() throws {
         let folderURL = URL(fileURLWithPath: AppPaths.meetingRecordingsDir, isDirectory: true)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
@@ -99,6 +99,33 @@ final class TranscriptionDeletionCleanupTests: XCTestCase {
         XCTAssertThrowsError(try TranscriptionAssetCleanup.detachOwnedMeetingAudio(
             for: transcription,
             repository: repo
+        ))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: mixedURL.path))
+        XCTAssertEqual(repo.transcriptions.first?.filePath, mixedURL.path)
+    }
+
+    func testDetachMeetingAudioKeepsFilePathWhenFileRemovalFails() throws {
+        let folderURL = URL(fileURLWithPath: AppPaths.meetingRecordingsDir, isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: folderURL) }
+
+        let mixedURL = folderURL.appendingPathComponent("meeting.m4a")
+        XCTAssertTrue(FileManager.default.createFile(atPath: mixedURL.path, contents: Data("mix".utf8)))
+
+        let transcription = Transcription(
+            fileName: "Meeting",
+            filePath: mixedURL.path,
+            status: .completed,
+            sourceType: .meeting
+        )
+        let repo = MockTranscriptionRepository()
+        repo.transcriptions = [transcription]
+
+        XCTAssertThrowsError(try TranscriptionAssetCleanup.detachOwnedMeetingAudio(
+            for: transcription,
+            repository: repo,
+            fileManager: ThrowingRemoveFileManager(failingURLs: [mixedURL])
         ))
         XCTAssertTrue(FileManager.default.fileExists(atPath: mixedURL.path))
         XCTAssertEqual(repo.transcriptions.first?.filePath, mixedURL.path)
@@ -225,4 +252,20 @@ final class TranscriptionDeletionCleanupTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: currentDirectory.path))
     }
 
+}
+
+private final class ThrowingRemoveFileManager: FileManager {
+    private let failingPaths: Set<String>
+
+    init(failingURLs: [URL]) {
+        failingPaths = Set(failingURLs.map { $0.standardizedFileURL.path })
+        super.init()
+    }
+
+    override func removeItem(at url: URL) throws {
+        if failingPaths.contains(url.standardizedFileURL.path) {
+            throw CocoaError(.fileWriteNoPermission)
+        }
+        try super.removeItem(at: url)
+    }
 }

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionDeletionCleanupTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionDeletionCleanupTests.swift
@@ -77,6 +77,33 @@ final class TranscriptionDeletionCleanupTests: XCTestCase {
         XCTAssertTrue(removed)
     }
 
+    func testDetachMeetingAudioPreservesAudioWhenRepositoryUpdateFails() throws {
+        let folderURL = URL(fileURLWithPath: AppPaths.meetingRecordingsDir, isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: folderURL) }
+
+        let mixedURL = folderURL.appendingPathComponent("meeting.m4a")
+        XCTAssertTrue(FileManager.default.createFile(atPath: mixedURL.path, contents: Data("mix".utf8)))
+
+        let transcription = Transcription(
+            fileName: "Meeting",
+            filePath: mixedURL.path,
+            status: .completed,
+            sourceType: .meeting
+        )
+        let repo = MockTranscriptionRepository()
+        repo.transcriptions = [transcription]
+        repo.updateFilePathError = NSError(domain: "test", code: 1)
+
+        XCTAssertThrowsError(try TranscriptionAssetCleanup.detachOwnedMeetingAudio(
+            for: transcription,
+            repository: repo
+        ))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: mixedURL.path))
+        XCTAssertEqual(repo.transcriptions.first?.filePath, mixedURL.path)
+    }
+
     func testMeetingDeletionOutsideAppSupportIsIgnored() throws {
         let folderURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
@@ -251,6 +251,70 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
         XCTAssertFalse(try repo.fetch(id: favorite.id)?.isFavorite ?? true)
     }
 
+    // MARK: - Bulk Selection
+
+    func testBeginBulkSelectionToggleClearAndExit() async throws {
+        let first = Transcription(fileName: "first.mp3", status: .completed)
+        let second = Transcription(fileName: "second.mp3", status: .completed)
+        try repo.save(first)
+        try repo.save(second)
+        await load()
+
+        vm.beginBulkSelection(startingWith: first)
+
+        XCTAssertTrue(vm.isBulkSelectionModeEnabled)
+        XCTAssertTrue(vm.isTranscriptionSelected(first))
+        XCTAssertEqual(vm.selectedTranscriptionCount, 1)
+
+        vm.toggleSelection(for: second)
+        XCTAssertEqual(vm.selectedTranscriptionIDs, [first.id, second.id])
+
+        vm.toggleSelection(for: first)
+        XCTAssertEqual(vm.selectedTranscriptionIDs, [second.id])
+
+        vm.clearSelection()
+        XCTAssertTrue(vm.isBulkSelectionModeEnabled)
+        XCTAssertTrue(vm.selectedTranscriptionIDs.isEmpty)
+
+        vm.exitBulkSelection()
+        XCTAssertFalse(vm.isBulkSelectionModeEnabled)
+        XCTAssertTrue(vm.selectedTranscriptionIDs.isEmpty)
+    }
+
+    func testSelectLoadedVisibleTranscriptionsExcludesUnloadedRows() async throws {
+        vm.pageSize = 2
+        try repo.save(Transcription(createdAt: Date(timeIntervalSince1970: 3), fileName: "third.mp3", status: .completed))
+        try repo.save(Transcription(createdAt: Date(timeIntervalSince1970: 2), fileName: "second.mp3", status: .completed))
+        try repo.save(Transcription(createdAt: Date(timeIntervalSince1970: 1), fileName: "first.mp3", status: .completed))
+
+        await load()
+
+        XCTAssertEqual(vm.filteredTranscriptions.count, 2)
+        XCTAssertTrue(vm.hasMore)
+
+        vm.beginBulkSelection()
+        vm.selectLoadedVisibleTranscriptions()
+
+        XCTAssertEqual(vm.selectedTranscriptionIDs, Set(vm.filteredTranscriptions.map(\.id)))
+        XCTAssertEqual(vm.selectedTranscriptionCount, 2)
+        XCTAssertTrue(vm.areAllLoadedVisibleTranscriptionsSelected)
+    }
+
+    func testSelectLoadedVisibleTranscriptionsRespectsSearch() async throws {
+        let matching = Transcription(fileName: "Swift Tutorial", status: .completed)
+        let other = Transcription(fileName: "Python Basics", status: .completed)
+        try repo.save(matching)
+        try repo.save(other)
+
+        vm.searchText = "swift"
+        await load()
+
+        vm.beginBulkSelection()
+        vm.selectLoadedVisibleTranscriptions()
+
+        XCTAssertEqual(vm.selectedTranscriptionIDs, [matching.id])
+    }
+
     // MARK: - Delete
 
     func testDeleteTranscription() async throws {
@@ -320,6 +384,109 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
         XCTAssertNil(fetched.filePath)
         XCTAssertEqual(vm.transcriptions.first?.id, t.id)
         XCTAssertNil(vm.transcriptions.first?.filePath)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: folder.path))
+    }
+
+    func testBulkDeleteSelectedItemsRemovesRowsAndExitsMode() async throws {
+        let first = Transcription(fileName: "first.mp3", status: .completed)
+        let second = Transcription(fileName: "second.mp3", status: .completed)
+        try repo.save(first)
+        try repo.save(second)
+        await load()
+
+        vm.beginBulkSelection(startingWith: first)
+        vm.toggleSelection(for: second)
+        vm.requestDeleteSelectedItems()
+
+        let result = await vm.confirmPendingBulkOperation()
+
+        XCTAssertEqual(result, BulkOperationResult(succeeded: 2, failed: 0))
+        XCTAssertNil(try repo.fetch(id: first.id))
+        XCTAssertNil(try repo.fetch(id: second.id))
+        XCTAssertTrue(vm.transcriptions.isEmpty)
+        XCTAssertFalse(vm.isBulkSelectionModeEnabled)
+        XCTAssertTrue(vm.selectedTranscriptionIDs.isEmpty)
+    }
+
+    func testBulkDeletePartialFailureKeepsFailedRowSelected() async throws {
+        try AppPaths.ensureDirectories()
+        let protectedDir = URL(fileURLWithPath: AppPaths.youtubeDownloadsDir, isDirectory: true)
+            .appendingPathComponent("library-bulk-protected-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: protectedDir, withIntermediateDirectories: true)
+        let audioURL = protectedDir.appendingPathComponent("asset.m4a")
+        _ = FileManager.default.createFile(atPath: audioURL.path, contents: Data("audio".utf8))
+        try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: protectedDir.path)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: protectedDir.path)
+            try? FileManager.default.removeItem(at: protectedDir)
+        }
+
+        let good = Transcription(fileName: "good.mp3", status: .completed, sourceType: .file)
+        let failing = Transcription(
+            fileName: "yt",
+            filePath: audioURL.path,
+            status: .completed,
+            sourceType: .youtube
+        )
+        try repo.save(good)
+        try repo.save(failing)
+        await load()
+
+        vm.beginBulkSelection(startingWith: good)
+        vm.toggleSelection(for: failing)
+        vm.requestDeleteSelectedItems()
+
+        let result = await vm.confirmPendingBulkOperation()
+
+        XCTAssertEqual(result, BulkOperationResult(succeeded: 1, failed: 1))
+        XCTAssertNil(try repo.fetch(id: good.id))
+        XCTAssertNotNil(try repo.fetch(id: failing.id))
+        XCTAssertEqual(vm.transcriptions.map(\.id), [failing.id])
+        XCTAssertTrue(vm.isBulkSelectionModeEnabled)
+        XCTAssertEqual(vm.selectedTranscriptionIDs, [failing.id])
+        XCTAssertNotNil(vm.errorMessage)
+    }
+
+    func testBulkDeleteAudioOnlyClearsMeetingAudioAndSkipsIneligibleSelection() async throws {
+        try AppPaths.ensureDirectories()
+        let folder = URL(fileURLWithPath: AppPaths.meetingRecordingsDir, isDirectory: true)
+            .appendingPathComponent("library-bulk-meeting-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        let audioURL = folder.appendingPathComponent("meeting.m4a")
+        XCTAssertTrue(FileManager.default.createFile(atPath: audioURL.path, contents: Data("audio".utf8)))
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        let meeting = Transcription(
+            fileName: "Meeting",
+            filePath: audioURL.path,
+            status: .completed,
+            sourceType: .meeting
+        )
+        let meetingWithoutAudio = Transcription(
+            fileName: "No Audio",
+            status: .completed,
+            sourceType: .meeting
+        )
+        let local = Transcription(fileName: "local.mp3", status: .completed, sourceType: .file)
+        try repo.save(meeting)
+        try repo.save(meetingWithoutAudio)
+        try repo.save(local)
+        await load()
+
+        vm.beginBulkSelection(startingWith: meeting)
+        vm.toggleSelection(for: meetingWithoutAudio)
+        vm.toggleSelection(for: local)
+
+        XCTAssertEqual(vm.selectedMeetingAudioCount, 1)
+        vm.requestDeleteSelectedMeetingAudio()
+        let result = await vm.confirmPendingBulkOperation()
+
+        XCTAssertEqual(result, BulkOperationResult(succeeded: 1, failed: 0, skipped: 2))
+        XCTAssertNil(try repo.fetch(id: meeting.id)?.filePath)
+        XCTAssertNotNil(try repo.fetch(id: meetingWithoutAudio.id))
+        XCTAssertNotNil(try repo.fetch(id: local.id))
+        XCTAssertEqual(vm.transcriptions.count, 3)
+        XCTAssertNil(vm.transcriptions.first(where: { $0.id == meeting.id })?.filePath)
         XCTAssertFalse(FileManager.default.fileExists(atPath: folder.path))
     }
 }

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
@@ -411,6 +411,7 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
         XCTAssertNil(try repo.fetch(id: first.id))
         XCTAssertNil(try repo.fetch(id: second.id))
         XCTAssertTrue(vm.transcriptions.isEmpty)
+        XCTAssertFalse(vm.isBulkOperationInProgress)
         XCTAssertFalse(vm.isBulkSelectionModeEnabled)
         XCTAssertTrue(vm.selectedTranscriptionIDs.isEmpty)
     }
@@ -449,12 +450,13 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
         XCTAssertNil(try repo.fetch(id: good.id))
         XCTAssertNotNil(try repo.fetch(id: failing.id))
         XCTAssertEqual(vm.transcriptions.map(\.id), [failing.id])
+        XCTAssertFalse(vm.isBulkOperationInProgress)
         XCTAssertTrue(vm.isBulkSelectionModeEnabled)
         XCTAssertEqual(vm.selectedTranscriptionIDs, [failing.id])
         XCTAssertNotNil(vm.errorMessage)
     }
 
-    func testBulkDeleteFailureDoesNotOverwriteNewSelectionAfterSuspension() async throws {
+    func testBulkDeleteKeepsSelectionModeAndIgnoresSelectionChangesWhileInProgress() async throws {
         let failing = Transcription(fileName: "failing.mp3", status: .completed, sourceType: .file)
         let newSelection = Transcription(fileName: "new.mp3", status: .completed, sourceType: .file)
         let deleteGate = DeleteGate()
@@ -478,13 +480,21 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
             deleteGate.waitForDeleteStarted()
         }.value
 
+        XCTAssertTrue(blockingVM.isBulkOperationInProgress)
+        XCTAssertTrue(blockingVM.isBulkSelectionModeEnabled)
+        XCTAssertEqual(blockingVM.selectedTranscriptionIDs, [failing.id])
+
         blockingVM.beginBulkSelection(startingWith: newSelection)
+        blockingVM.toggleSelection(for: newSelection)
+        XCTAssertEqual(blockingVM.selectedTranscriptionIDs, [failing.id])
+
         deleteGate.allowFinish()
         let result = await operation.value
 
         XCTAssertEqual(result, BulkOperationResult(succeeded: 0, failed: 1))
+        XCTAssertFalse(blockingVM.isBulkOperationInProgress)
         XCTAssertTrue(blockingVM.isBulkSelectionModeEnabled)
-        XCTAssertEqual(blockingVM.selectedTranscriptionIDs, [newSelection.id])
+        XCTAssertEqual(blockingVM.selectedTranscriptionIDs, [failing.id])
         XCTAssertNotNil(blockingVM.errorMessage)
     }
 
@@ -527,6 +537,9 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
         let result = await vm.confirmPendingBulkOperation()
 
         XCTAssertEqual(result, BulkOperationResult(succeeded: 1, failed: 0, skipped: 2))
+        XCTAssertFalse(vm.isBulkOperationInProgress)
+        XCTAssertFalse(vm.isBulkSelectionModeEnabled)
+        XCTAssertTrue(vm.selectedTranscriptionIDs.isEmpty)
         XCTAssertNil(try repo.fetch(id: meeting.id)?.filePath)
         XCTAssertNotNil(try repo.fetch(id: meetingWithoutAudio.id))
         XCTAssertNotNil(try repo.fetch(id: local.id))

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
@@ -366,7 +366,11 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
             .appendingPathComponent("library-meeting-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
         let audioURL = folder.appendingPathComponent("meeting.m4a")
+        let microphoneURL = folder.appendingPathComponent("microphone.m4a")
+        let notesURL = folder.appendingPathComponent("notes.md")
         XCTAssertTrue(FileManager.default.createFile(atPath: audioURL.path, contents: Data("audio".utf8)))
+        XCTAssertTrue(FileManager.default.createFile(atPath: microphoneURL.path, contents: Data("mic".utf8)))
+        try "meeting notes".write(to: notesURL, atomically: true, encoding: .utf8)
         defer { try? FileManager.default.removeItem(at: folder) }
 
         let t = Transcription(
@@ -384,7 +388,10 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
         XCTAssertNil(fetched.filePath)
         XCTAssertEqual(vm.transcriptions.first?.id, t.id)
         XCTAssertNil(vm.transcriptions.first?.filePath)
-        XCTAssertFalse(FileManager.default.fileExists(atPath: folder.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: folder.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: audioURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: microphoneURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: notesURL.path))
     }
 
     func testBulkDeleteSelectedItemsRemovesRowsAndExitsMode() async throws {
@@ -447,13 +454,51 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
         XCTAssertNotNil(vm.errorMessage)
     }
 
+    func testBulkDeleteFailureDoesNotOverwriteNewSelectionAfterSuspension() async throws {
+        let failing = Transcription(fileName: "failing.mp3", status: .completed, sourceType: .file)
+        let newSelection = Transcription(fileName: "new.mp3", status: .completed, sourceType: .file)
+        let deleteGate = DeleteGate()
+        let blockingRepo = MockTranscriptionRepository()
+        blockingRepo.transcriptions = [failing, newSelection]
+        blockingRepo.deleteResult = false
+        blockingRepo.onDelete = { _ in
+            deleteGate.blockUntilAllowed()
+        }
+        let blockingVM = TranscriptionLibraryViewModel()
+        blockingVM.configure(transcriptionRepo: blockingRepo)
+        await load(blockingVM)
+
+        blockingVM.beginBulkSelection(startingWith: failing)
+        blockingVM.requestDeleteSelectedItems()
+
+        let operation = Task {
+            await blockingVM.confirmPendingBulkOperation()
+        }
+        await Task.detached {
+            deleteGate.waitForDeleteStarted()
+        }.value
+
+        blockingVM.beginBulkSelection(startingWith: newSelection)
+        deleteGate.allowFinish()
+        let result = await operation.value
+
+        XCTAssertEqual(result, BulkOperationResult(succeeded: 0, failed: 1))
+        XCTAssertTrue(blockingVM.isBulkSelectionModeEnabled)
+        XCTAssertEqual(blockingVM.selectedTranscriptionIDs, [newSelection.id])
+        XCTAssertNotNil(blockingVM.errorMessage)
+    }
+
     func testBulkDeleteAudioOnlyClearsMeetingAudioAndSkipsIneligibleSelection() async throws {
         try AppPaths.ensureDirectories()
         let folder = URL(fileURLWithPath: AppPaths.meetingRecordingsDir, isDirectory: true)
             .appendingPathComponent("library-bulk-meeting-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
         let audioURL = folder.appendingPathComponent("meeting.m4a")
+        let systemURL = folder.appendingPathComponent("system.m4a")
+        let manifestURL = folder.appendingPathComponent(MeetingArtifactStore.manifestFileName)
         XCTAssertTrue(FileManager.default.createFile(atPath: audioURL.path, contents: Data("audio".utf8)))
+        XCTAssertTrue(FileManager.default.createFile(atPath: systemURL.path, contents: Data("system".utf8)))
+        try Data(#"{"schema":"com.macparakeet.meeting-session"}"#.utf8).write(to: manifestURL)
         defer { try? FileManager.default.removeItem(at: folder) }
 
         let meeting = Transcription(
@@ -487,6 +532,27 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
         XCTAssertNotNil(try repo.fetch(id: local.id))
         XCTAssertEqual(vm.transcriptions.count, 3)
         XCTAssertNil(vm.transcriptions.first(where: { $0.id == meeting.id })?.filePath)
-        XCTAssertFalse(FileManager.default.fileExists(atPath: folder.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: folder.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: audioURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: systemURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: manifestURL.path))
+    }
+}
+
+private final class DeleteGate: @unchecked Sendable {
+    private let deleteStarted = DispatchSemaphore(value: 0)
+    private let allowDelete = DispatchSemaphore(value: 0)
+
+    func blockUntilAllowed() {
+        deleteStarted.signal()
+        allowDelete.wait()
+    }
+
+    func waitForDeleteStarted() {
+        deleteStarted.wait()
+    }
+
+    func allowFinish() {
+        allowDelete.signal()
     }
 }

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -751,7 +751,9 @@ final class TranscriptionViewModelTests: XCTestCase {
             .appendingPathComponent("vm-meeting-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
         let audioURL = folder.appendingPathComponent("meeting.m4a")
+        let notesURL = folder.appendingPathComponent("notes.md")
         XCTAssertTrue(FileManager.default.createFile(atPath: audioURL.path, contents: Data("audio".utf8)))
+        try "notes".write(to: notesURL, atomically: true, encoding: .utf8)
         defer { try? FileManager.default.removeItem(at: folder) }
 
         let t = Transcription(
@@ -767,7 +769,9 @@ final class TranscriptionViewModelTests: XCTestCase {
 
         viewModel.presentCompletedTranscription(t, autoSave: true)
 
-        XCTAssertFalse(FileManager.default.fileExists(atPath: folder.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: folder.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: audioURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: notesURL.path))
         XCTAssertNil(viewModel.currentTranscription?.filePath)
         XCTAssertNil(mockRepo.transcriptions.first?.filePath)
         XCTAssertEqual(viewModel.errorMessage, "Prior load warning")

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -132,6 +132,7 @@ final class MockTranscriptionRepository: TranscriptionRepositoryProtocol, @unche
     var deleteAllCalled = false
     var deleteResult = true
     var deleteError: Error?
+    var onDelete: (@Sendable (UUID) -> Void)?
     var updateFileNameCalls: [(id: UUID, fileName: String)] = []
     var updateChatMessagesCalls: [(id: UUID, chatMessages: [ChatMessage]?)] = []
     var updateSpeakersCalls: [(id: UUID, speakers: [SpeakerInfo]?)] = []
@@ -170,6 +171,7 @@ final class MockTranscriptionRepository: TranscriptionRepositoryProtocol, @unche
 
     func delete(id: UUID) throws -> Bool {
         deleteCalledWith.append(id)
+        onDelete?(id)
         if let deleteError {
             throw deleteError
         }

--- a/plans/active/2026-06-18-library-bulk-delete.md
+++ b/plans/active/2026-06-18-library-bulk-delete.md
@@ -1,6 +1,6 @@
 # Library Multi-Select Bulk Cleanup
 
-**Status:** ACTIVE PLAN — not started
+**Status:** IMPLEMENTED IN PR #572 — pending review/merge
 **Date:** 2026-06-18
 **ADRs:** none new (UI/data-flow change within existing Library architecture)
 **Issues:** #498

--- a/plans/active/2026-06-18-library-bulk-delete.md
+++ b/plans/active/2026-06-18-library-bulk-delete.md
@@ -1,13 +1,13 @@
-# Library Multi-Select Bulk Delete
+# Library Multi-Select Bulk Cleanup
 
 **Status:** ACTIVE PLAN — not started
 **Date:** 2026-06-18
 **ADRs:** none new (UI/data-flow change within existing Library architecture)
-**Requirement:** REQ-LIB-002 (proposed — extends REQ-LIB-001 "Transcription library with thumbnail grid, filters, search")
 **Issues:** #498
 **Decision (owner, 2026-06-18):** Reuse the existing Dictation History
-"Select Multiple" pattern **plus keyboard support** (Delete key, ⌘A). Not
-Finder-style modifier-click selection (keeps the app internally consistent).
+explicit-selection pattern, with the Library/Meetings entry label **"Select
+Many..."**, plus keyboard support (Delete key, ⌘A). Not Finder-style
+modifier-click selection (keeps the app internally consistent).
 
 ## What this plan closes out
 
@@ -19,7 +19,7 @@ bulk.
 
 The good news: **Dictation History already implements a complete, shipped
 bulk-select pattern** (selection state, mode toggle, an action bar with
-count / Select All / Clear / Delete, batched deletion). This plan ports that
+count / Select Loaded / Clear / Delete, batched deletion). This plan ports that
 proven pattern into the Library (both the thumbnail grid and the meetings list)
 rather than inventing a new interaction — and layers on keyboard affordances
 Dictation does not yet have. (No undo in v1 — see Out of scope for why a row-only
@@ -38,14 +38,19 @@ multi-selectable, "Generate titles" becomes a natural bulk action.
   "Recent Meetings").
 - Selection state + batch-delete operations on `TranscriptionLibraryViewModel`,
   mirroring `DictationHistoryViewModel`'s API shape.
-- An action bar (count, Select All, Clear, Cancel, Delete) consistent with the
-  Dictation History bar.
+- An action bar (count, Select Loaded, Clear, Cancel, Delete Audio Only, Delete
+  Items/Delete Meetings) consistent with the Dictation History bar.
 - Keyboard: `⌫`/`Delete` triggers the bulk-delete confirmation when items are
-  selected; `⌘A` selects all currently-filtered items; `Esc` exits select mode.
-- A single confirmation alert stating the count and permanence; copy adapts when
-  the selection includes meetings (audio **and** AI summaries/chats are
-  unrecoverable — see Invariants).
-- The batch delete runs off the main thread (`Task.detached`), mirroring
+  selected; `⌘A` selects all currently loaded filtered items; `Esc` exits select mode.
+- Two bulk cleanup operations:
+  - **Delete Items/Delete Meetings**: permanently removes the selected rows and
+    app-owned assets.
+  - **Delete Audio Only**: removes stored meeting audio only, keeping the
+    meeting row and any transcript, notes, AI results, and chats.
+- Confirmation alerts state the operation, eligible count, and permanence; copy
+  adapts when the selection includes meetings (audio **and** AI summaries/chats
+  are unrecoverable for full deletion — see Invariants).
+- The batch operations run off the main thread (`Task.detached`), mirroring
   `DictationHistoryViewModel.deleteTargets`, so deleting many items never
   beachballs the UI. [Gemini]
 
@@ -58,8 +63,6 @@ multi-selectable, "Generate titles" becomes a natural bulk action.
   silently lose every AI summary and Ask-tab chat — strictly worse than no undo.
   A real undo needs a full-object-graph snapshot/restore or a soft-delete trash;
   both are a separate future feature. v1 relies on a precise confirmation instead.
-- Bulk **audio-only detach** (the single-item "Delete Audio" stays single-item;
-  bulk = full delete). Revisit if requested.
 - Bulk operations other than delete (move, export, favorite) — selection
   substrate enables them later, but only delete (+ the auto-title follow-up's
   "Generate titles") ships here.
@@ -71,16 +74,23 @@ multi-selectable, "Generate titles" becomes a natural bulk action.
 - **Asset cleanup parity.** Each delete in the batch runs the *same*
   `TranscriptionDeletionCleanup.removeOwnedAssets()` + repo `delete(id:)` as the
   single-item path — no shortcut that skips on-disk cleanup.
+- **Audio detach parity.** Bulk "Delete Audio Only" runs the same
+  `TranscriptionAssetCleanup.detachOwnedMeetingAudio()` path as single-row
+  "Delete Audio"; it never deletes the Library/Meetings row, transcript, or any
+  notes, AI results, or chats that exist for that meeting.
 - **No partial-silent failure.** If one item in the batch fails to delete, the
   batch continues and the result surfaces (count succeeded / failed), never a
   silent drop.
-- **Deletion is permanent and total.** A delete removes the transcript, its
-  on-disk audio, **and** its cascaded `prompt_results` / `chat_conversations` /
+- **Deletion is permanent and total.** A full delete removes the row, transcript,
+  on-disk audio, and any associated `prompt_results` / `chat_conversations` /
   LLM-run rows. There is no undo (see Out of scope), so the confirmation must
-  state this plainly — especially that meeting audio and AI summaries can't be
-  recovered.
-- **Filter-aware Select All.** `⌘A` / "Select All" selects only the currently
-  filtered + searched set, never hidden rows.
+  state this plainly without implying optional meeting data always exists.
+- **Audio-only is eligibility-counted.** When a mixed Library selection contains
+  non-meetings or meetings without stored audio, "Delete Audio Only" affects
+  only the selected meetings with available stored audio. The action label and
+  confirmation state the eligible count and skipped count.
+- **Filter-aware Select Loaded.** `⌘A` / "Select Loaded" selects only the
+  currently loaded filtered + searched set, never hidden or unloaded rows.
 - **Accessibility parity.** The action bar and selection controls carry VoiceOver
   labels (count, selected state, actions), consistent with the active a11y sprint.
 - Idle hygiene: selection state is torn down on mode exit and on filter change.
@@ -121,64 +131,105 @@ multi-selectable, "Generate titles" becomes a natural bulk action.
 
 ## Design
 
+### Visual treatment and color
+- **Selection color:** use `DesignSystem.Colors.accent` / `accentLight` for
+  selected rows/cards and checkmarks. This matches the app's coral-orange action
+  language and the Library filter chips.
+- **Destructive color:** reserve `DesignSystem.Colors.errorRed` and
+  `.parakeetAction(.destructive)` for the actual destructive actions:
+  `Delete Audio Only...`, `Delete Items...`, `Delete Meetings...`, and
+  confirmation buttons.
+- **Do not use red for selection state.** Selection is a reversible staging mode;
+  making selected rows red would make the whole surface feel like data is already
+  being destroyed.
+- **Do not introduce a new selection hue.** The sidebar's blue is system/sidebar
+  selection; Library content selection should stay in the product's coral system.
+- Grid cards: selected state gets a subtle `accentLight` wash, a 1-1.5pt accent
+  stroke, and a filled checkmark circle. Avoid heavy fills that compete with
+  thumbnails.
+- Meeting/list rows: selected state gets a leading checkmark circle plus a low
+  opacity accent row background. Keep hover visually subordinate to selected.
+
 ### ViewModel (mirror Dictation, adapt to Transcription)
 On `TranscriptionLibraryViewModel`:
 ```swift
 public private(set) var isBulkSelectionModeEnabled: Bool
 public private(set) var selectedTranscriptionIDs: Set<UUID>
-public var pendingBulkDelete: [Transcription]      // drives the alert
+public var pendingBulkOperation: BulkTranscriptionOperation?
 func beginBulkSelection(startingWith: Transcription?)
 func toggleSelection(_ id: UUID)
 func selectAllVisible()                              // filtered + searched only
 func clearSelection()
 func exitBulkSelection()
-func requestDeleteSelected()
-func confirmDeleteSelected() async -> BulkDeleteResult   // {succeeded, failed}
+func requestDeleteSelectedItems()
+func requestDeleteSelectedMeetingAudio()
+func confirmPendingBulkOperation() async -> BulkOperationResult   // {succeeded, failed, skipped}
 ```
-- `confirmDeleteSelected` runs the per-item cleanup+delete in a `Task.detached`
-  loop (off the main actor), accumulates a `{succeeded, failed}` result, and exits
-  mode. No snapshot (no undo in v1).
+- `BulkTranscriptionOperation` snapshots the selected rows at confirmation time:
+  `.deleteItems([Transcription])` or
+  `.deleteAudioOnly(targets: [Transcription], skipped: Int)`.
+- `confirmPendingBulkOperation` runs the per-item cleanup in a `Task.detached`
+  loop (off the main actor), accumulates `{succeeded, failed, skipped}`, and exits
+  mode after a confirmed operation. No undo in v1.
 
 ### Interaction
-- **Entry:** a row context-menu item "Select Multiple…" (matches Dictation),
-  plus a toolbar "Select" affordance on the Library header.
+- **Entry:** a row context-menu item "Select Many…", plus a toolbar "Select
+  Many" affordance on the Library header.
 - **Selection:** tapping a row toggles its checkmark while in mode; grid cards
   show a selection overlay, list rows a leading checkbox.
 - **Action bar:** appears at the bottom while in mode — `N selected ·
-  Select All · Clear · Cancel · Delete`.
-- **Keyboard:** `⌘A` select-all-visible, `⌫`/`Delete` → confirmation,
+  Select Loaded · Clear · Cancel · Delete Audio Only… · Delete Items…`.
+- **Meetings action bar:** in meeting-only contexts (`Library` Meetings filter
+  and `MeetingsView` Recent Meetings), show the destructive choices plainly:
+  `Delete Audio Only…` and `Delete Meetings…`.
+- **Mixed Library action bar:** always show `Delete Items…`. Show
+  `Delete Audio Only…` only when at least one selected meeting has stored
+  audio; label it with the eligible count where space allows, e.g.
+  `Delete Audio for 3 Meetings…`.
+- **Keyboard:** `⌘A` select loaded visible rows, `⌫`/`Delete` → confirmation,
   `Esc` → exit. (Use SwiftUI `.onKeyPress` / commands on the focused Library
   view; verify focus behavior in the dev app.)
 - **Confirmation copy (no undo, so it must be precise):**
-  - files only: *"Delete N items? This permanently deletes them and their files."*
-  - includes meetings: *"Delete N items, including M meetings? Audio and AI
-    summaries can't be recovered."*
+  - full delete, files only: *"Delete N items? This permanently deletes the
+    Library rows and app-owned files. Original local source files are not
+    removed."*
+  - full delete, includes meetings: *"Delete N items, including M meetings? This
+    permanently removes the selected rows, transcripts, stored audio, and any
+    notes, AI results, or chats for those meetings."*
+  - audio-only: *"Delete audio for M meetings? Transcripts, notes, AI results,
+    and chats stay in Library if they exist. Playback and retranscription will be
+    unavailable unless you saved a copy."*
 
 ## Phases
-1. **ViewModel selection + batch delete + tests** — port the Dictation API onto
-   `TranscriptionLibraryViewModel`; off-main-thread (`Task.detached`) batch
-   delete; unit tests for select-all-visible (respects filter/search), batch
-   success/partial-failure result, mode teardown.
+1. **ViewModel selection + bulk operation model + tests** — port the Dictation
+   API onto `TranscriptionLibraryViewModel`; off-main-thread (`Task.detached`)
+   full delete and audio-only detach; unit tests for select-loaded-visible
+   (respects filter/search and pagination), success/partial-failure/skipped
+   result, mode teardown.
 2. **Grid + list UI** — selection overlays/checkboxes, action bar (with VoiceOver
-   labels); both surfaces.
+   labels); both surfaces; full-delete row menu parity in `MeetingsView`.
 3. **Keyboard** — ⌘A / Delete / Esc; dev-app verification of focus + that Delete
    doesn't fire when not in select mode.
-4. **Docs** — `spec/04-ui-patterns.md` (Library multi-select), `spec/02-features.md`,
-   register REQ-LIB-002.
+4. **Docs** — `spec/04-ui-patterns.md` (Library multi-select) and
+   `spec/02-features.md`.
 
 ## Testing
 - ViewModel unit tests: selection toggling, `selectAllVisible` excludes
-  filtered-out/searched-out rows, batch delete returns correct succeeded/failed,
+  filtered-out/searched-out/unloaded rows, full delete returns correct
+  succeeded/failed, audio-only detach returns correct succeeded/failed/skipped,
   off-main-thread execution, mode teardown clears state.
 - Asset-cleanup parity test: a batch delete invokes the same cleanup as the
   single-item path (no orphaned files; meeting folders removed).
+- Audio-only parity test: selected meeting audio detach keeps the transcription
+  row and clears `filePath`, while selected non-meetings or meetings without
+  audio are skipped and reported.
 - `swift test` before merge. (SwiftUI views themselves untested per repo policy —
   logic lives in the ViewModel.)
 
 ## Open questions (resolve in Phase 1)
-1. **Favorites in Select All:** include favorited rows in `⌘A` (simplest) vs.
+1. **Favorites in Select Loaded:** include favorited rows in `⌘A` (simplest) vs.
    warn/exclude. Lean: include, but the confirmation count makes scale visible.
-2. **Toolbar "Select" vs. context-menu-only entry:** ship both for discoverability,
+2. **Toolbar "Select Many" vs. context-menu-only entry:** ship both for discoverability,
    or context-menu-only to match Dictation exactly? Lean: both.
 
 (Resolved during PR #556 review: no undo/trash in v1 — a row-only undo would lose
@@ -186,5 +237,5 @@ cascade-deleted AI summaries/chats; rely on a precise confirmation. The batch
 delete runs off the main thread.)
 
 ## Docs to update on completion
-`spec/04-ui-patterns.md`, `spec/02-features.md`, `spec/README.md`,
-`spec/kernel/requirements.yaml` (REQ-LIB-002), and an issue reply on #498.
+`spec/04-ui-patterns.md`, `spec/02-features.md`, `spec/README.md`, and an issue
+reply on #498.

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -594,14 +594,14 @@ The app lives primarily in the menu bar. Click the icon for quick actions, or op
 - Full-width flat chronological list (no split pane, no detail view)
 - Grouped by date (Today, Yesterday, specific dates)
 - Each entry shows: time, duration, full transcript text (no line limit)
-- Hover actions: Play/Pause, Copy (with checkmark confirmation), three-dot menu (Download Audio, Select Multiple…, Delete)
+- Hover actions: Play/Pause, Copy (with checkmark confirmation), three-dot menu (Download Audio, Select Many..., Delete)
 - Currently-playing row has subtle accent tint background
 - Bottom bar audio player (Spotify-style): play/pause, transcript snippet, progress bar, time, close
 - Search bar filters by transcript content (substring match, case-insensitive)
 - Context menu: Play/Pause, Copy, Download Audio, Delete
 - Keyboard shortcut: Cmd+Backspace to delete
 - Text selection enabled on transcript text
-- Multi-select cleanup is an explicit bulk-selection mode: hidden during ordinary browsing, entered via the row three-dot menu's `Select Multiple…` (which preselects that row), surfacing per-row selection circles and a bulk action bar (Cancel, Select All, Clear, Delete). The mode exits on confirmed bulk delete, Cancel, switching to the Stats sub-tab, or leaving the Dictations section.
+- Multi-select cleanup is an explicit bulk-selection mode: hidden during ordinary browsing, entered via the row three-dot menu's `Select Many...` (which preselects that row), surfacing per-row selection circles and a bulk action bar (Cancel, Select All, Clear, Delete). The mode exits on confirmed bulk delete, Cancel, switching to the Stats sub-tab, or leaving the Dictations section.
 - Delete confirmation dialog before permanent removal
 
 **Database schema:**
@@ -1557,6 +1557,8 @@ Embedded video/audio playback, split-pane detail view, synced transcript highlig
 - [x] Filter bar: All / YouTube / Local / Favorites
 - [x] Search across transcription titles and content
 - [x] Sort by date (newest/oldest)
+- [x] Multi-select cleanup with `Select Many...`, `Select Loaded`, clear/cancel, and contextual destructive confirmations
+- [x] Meeting cleanup supports both full deletion and `Delete Audio Only...`; optional notes, AI results, and chats are removed only by full meeting deletion
 
 ### F27: Home Page Redesign
 

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -123,6 +123,14 @@ The tile body is informational. Only the visible Start and Stop capsules are rea
 
 When `Library.filter == .meeting`, the view renders a date-grouped list (`Today` / `Yesterday` / `Previous 7 Days` / `Previous 30 Days` / `{Month Year}`) using `MeetingDateGroupHeader` + `MeetingRowCard` instead of the thumbnail grid the other filters use.
 
+### Library Multi-Select Cleanup
+
+Library offers a `Select Many...` secondary action when there are visible rows. Selection mode keeps actions in a contextual bar above the content: `Cancel`, `Select Loaded`, `Clear`, `Delete Audio Only...` for selected meetings with stored audio, and `Delete Items...` / `Delete Meetings...` for full deletion.
+
+Selected cards and meeting rows use the app accent/coral selected state. Destructive red is reserved for confirmation actions and destructive menu items, not for the selected state itself. Meeting full deletion removes the meeting row, transcript, stored audio, notes, AI results, and chats when those optional artifacts exist. `Delete Audio Only...` removes only stored meeting audio and leaves the transcript plus optional notes, AI results, and chats.
+
+The dedicated Meetings workspace mirrors the Library meeting cleanup model for Recent Meetings, using the same top contextual action bar, keyboard handling, and confirmation copy.
+
 ---
 
 ## Dictation History (v0.1)

--- a/spec/README.md
+++ b/spec/README.md
@@ -199,6 +199,7 @@ Dictation + transcription + history + settings. Get audio in, text out, pasted i
 - [x] Transcription library view with thumbnail grid
 - [x] Library filter bar (All/YouTube/Local/Favorites)
 - [x] Library search and sort
+- [x] Library multi-select cleanup with loaded-row selection and contextual delete confirmations
 
 #### Prompt Library & Multi-Summary
 
@@ -229,6 +230,7 @@ Dictation + transcription + history + settings. Get audio in, text out, pasted i
 - [x] Screen Recording permission handling (required, no mic-only fallback)
 - [x] Batch transcription after recording stops (local STT using the pinned engine)
 - [x] Meeting recordings get prompt library, multi-summary, chat, and export automatically
+- [x] Meeting cleanup supports full deletion or stored-audio-only removal from Library and Meetings
 - [x] Live transcript preview (chunked transcription during recording)
 - [x] VAD-guided speech-boundary live-preview chunking with fixed 5s / 1s fallback (flag-on release candidate on `main`; final post-stop transcript unchanged)
 - [x] Joined mic/system frame pairing with raw meeting mic capture by default


### PR DESCRIPTION
## Summary
- Adds `Select Many` mode to Library grid/list and Meetings Recent Meetings, with a contextual top action bar for loaded-row selection, clear/cancel, full delete, and meeting audio-only cleanup.
- Adds ViewModel-level bulk operation snapshots for full deletion and `Delete Audio Only`, including skipped ineligible rows and partial-failure reselection.
- Updates single-row meeting delete/audio labels, shared selected states for cards/meeting rows, the active plan, and feature/UI specs.

Closes #498.

## Test Plan
- `git diff --check origin/main...HEAD`
- `swift test --filter TranscriptionLibraryViewModelTests`
- `swift test`

---
[![Built with Compound Engineering](https://img.shields.io/badge/Built%20with-Compound%20Engineering-6366f1)](https://compound.engineering)