### PR TITLE
Disable transcript Edit in Timed view instead of silently opening raw text

### DIFF
--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -1168,12 +1168,20 @@ struct TranscriptResultView: View {
                 .parakeetAction(.primaryProminent)
                 .disabled(transcriptDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             } else {
+                // Editing operates on the plain text transcript only; the Timed
+                // view is derived from word timestamps and has no editable text.
+                // Disable Edit in Timed mode rather than silently dropping the
+                // user into the raw text view when they click it.
                 Button {
                     beginTranscriptEdit()
                 } label: {
                     Label("Edit", systemImage: "pencil")
                 }
                 .parakeetAction(.secondary)
+                .disabled(transcriptDisplayMode != .text)
+                .help(transcriptDisplayMode == .text
+                    ? "Edit the transcript text"
+                    : "Switch to Text to edit. Edits apply to the text transcript; timestamps are preserved.")
             }
         }
     }


### PR DESCRIPTION
## What

Fixes #570. With the **Timed** transcript view selected, clicking **Edit** used to silently drop you into the raw-text editor — the timed view you were looking at just vanished, with no explanation.

Now Edit is **disabled while Timed is selected**, with a tooltip pointing you to switch to Text first. No more surprise mode-switch.

```
  Transcript view        Edit button
  ─────────────────────────────────────────────────────
  Text             →     enabled    "Edit the transcript text"
  Timed            →     disabled   "Switch to Text to edit…"
  (no timestamps)  →     enabled    (view is always Text)
```

## Why disable, rather than "fix" the switch

Editing is plain-text-only *by design*. The Timed view is derived on the fly from word timestamps (`TranscriptSegmenter.groupIntoSegments`) and has no editable backing text — only the plain transcript (`cleanTranscript`) is persistable. So the honest move is to gate Edit to the Text view, not quietly swap modes underneath the user.

- `.parakeetAction(.secondary)` is `.bordered`, which dims correctly when disabled — the affordance stays visible and discoverable.
- Editing is reachable from any state: the Text view always falls back to the raw transcript, so no transcript is ever un-editable.
- No save-path change: edits still update `cleanTranscript` and leave word timestamps intact.

## Verification

- `swift build` — clean
- `swift test` — 3922 XCTest (0 failures, 10 skipped) + 16 swift-testing
- This `.disabled(…) + .help(…)` shape is the same one already shipped elsewhere in this view (the Audio menu, disabled with an explanatory tooltip when audio is unavailable), so the macOS tooltip behavior is a known quantity on our macOS 14 target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
