### PR TITLE
Add microphone-only meeting capture mode

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -98,6 +98,8 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
   `delete-immediately`.
   The older `save-meeting-audio` key remains supported as a legacy alias:
   `on` maps to `keep-forever`, and `off` maps to `delete-immediately`.
+- `config get|set|list` now includes `meeting-audio-source`:
+  `microphone-and-system` (default), `microphone-only`, or `system-only`.
 
 ### Changed
 

--- a/Sources/CLI/Commands/ConfigCommand.swift
+++ b/Sources/CLI/Commands/ConfigCommand.swift
@@ -39,6 +39,9 @@ struct ConfigCommand: ParsableCommand {
                                     delete-after-<1-365>-days|
                                     <1-365>d|
                                     delete-immediately
+          meeting-audio-source      microphone-and-system|          default: microphone-and-system
+                                    microphone-only|
+                                    system-only
           save-meeting-audio        on|off                          legacy alias
           youtube-audio-quality     m4a|best-available              default: m4a
           meeting-artifacts-folder  absolute path|default           default: app support
@@ -71,6 +74,7 @@ struct ConfigCommand: ParsableCommand {
         "auto-meeting-titles",
         "save-transcription-audio",
         "meeting-audio-retention",
+        "meeting-audio-source",
         "save-meeting-audio",
         "youtube-audio-quality",
         "meeting-artifacts-folder",
@@ -204,6 +208,8 @@ struct ConfigCommand: ParsableCommand {
             return on ? "on" : "off"
         case "meeting-audio-retention":
             return UserDefaultsAppRuntimePreferences.meetingAudioRetention(defaults: store).configurationValue
+        case "meeting-audio-source":
+            return MeetingAudioSourceMode.current(defaults: store).configurationValue
         case "save-meeting-audio":
             let on = UserDefaultsAppRuntimePreferences(defaults: store).shouldSaveMeetingAudio
             return on ? "on" : "off"
@@ -283,6 +289,10 @@ struct ConfigCommand: ParsableCommand {
             let retention = try parseMeetingAudioRetention(value)
             UserDefaultsAppRuntimePreferences.saveMeetingAudioRetention(retention, defaults: store)
             return retention.configurationValue
+        case "meeting-audio-source":
+            let mode = try parseMeetingAudioSourceMode(value)
+            store.set(mode.rawValue, forKey: UserDefaultsAppRuntimePreferences.meetingAudioSourceModeKey)
+            return mode.configurationValue
         case "save-meeting-audio":
             let parsed = try parseBool(value, key: key)
             UserDefaultsAppRuntimePreferences.saveMeetingAudioRetention(
@@ -454,6 +464,13 @@ struct ConfigCommand: ParsableCommand {
             throw ValidationError("Invalid value for meeting-audio-retention: '\(value)'. Use keep-forever, delete-immediately, delete-after-<1-365>-days, or <1-365>d.")
         }
         return retention
+    }
+
+    static func parseMeetingAudioSourceMode(_ value: String) throws -> MeetingAudioSourceMode {
+        guard let mode = MeetingAudioSourceMode.parseConfigurationValue(value) else {
+            throw ValidationError("Invalid value for meeting-audio-source: '\(value)'. Use microphone-and-system, microphone-only, or system-only.")
+        }
+        return mode
     }
 
     static func parseMeetingArtifactsFolder(_ value: String) throws -> String? {

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -396,19 +396,21 @@ final class MeetingRecordingFlowCoordinator {
                     Telemetry.send(.permissionGranted(permission: .microphone))
                 }
 
-                let existingScreenGrant = permissionService.checkScreenRecordingPermission()
-                if !existingScreenGrant {
-                    Telemetry.send(.permissionPrompted(permission: .screenRecording))
-                }
-                let screenGranted = existingScreenGrant || permissionService.requestScreenRecordingPermission()
-                if !screenGranted {
-                    Telemetry.send(.permissionDenied(permission: .screenRecording))
-                    self.clearPendingStartContext(failureReason: "permission_denied")
-                    self.sendEvent(.permissionsDenied(generation: gen, reason: .screenRecording))
-                    return
-                }
-                if !existingScreenGrant {
-                    Telemetry.send(.permissionGranted(permission: .screenRecording))
+                if sourceMode.capturesSystemAudio {
+                    let existingScreenGrant = permissionService.checkScreenRecordingPermission()
+                    if !existingScreenGrant {
+                        Telemetry.send(.permissionPrompted(permission: .screenRecording))
+                    }
+                    let screenGranted = existingScreenGrant || permissionService.requestScreenRecordingPermission()
+                    if !screenGranted {
+                        Telemetry.send(.permissionDenied(permission: .screenRecording))
+                        self.clearPendingStartContext(failureReason: "permission_denied")
+                        self.sendEvent(.permissionsDenied(generation: gen, reason: .screenRecording))
+                        return
+                    }
+                    if !existingScreenGrant {
+                        Telemetry.send(.permissionGranted(permission: .screenRecording))
+                    }
                 }
                 self.sendEvent(.permissionsGranted(generation: gen))
             }

--- a/Sources/MacParakeet/Views/Transcription/MeetingRecordingTile.swift
+++ b/Sources/MacParakeet/Views/Transcription/MeetingRecordingTile.swift
@@ -11,7 +11,7 @@ import SwiftUI
 /// Stop symmetric tap targets so users learn one rule.
 struct MeetingRecordingTile: View {
     enum PermissionState: Equatable {
-        case ready(capturesMicrophone: Bool)
+        case ready(sourceMode: MeetingAudioSourceMode)
         case missing(microphone: Bool, screenRecording: Bool)
 
         init(
@@ -20,11 +20,11 @@ struct MeetingRecordingTile: View {
             sourceMode: MeetingAudioSourceMode
         ) {
             let needsMicrophone = sourceMode.capturesMicrophone && !microphoneGranted
-            let needsScreenRecording = !screenRecordingGranted
+            let needsScreenRecording = sourceMode.capturesSystemAudio && !screenRecordingGranted
             if needsMicrophone || needsScreenRecording {
                 self = .missing(microphone: needsMicrophone, screenRecording: needsScreenRecording)
             } else {
-                self = .ready(capturesMicrophone: sourceMode.capturesMicrophone)
+                self = .ready(sourceMode: sourceMode)
             }
         }
 
@@ -46,10 +46,15 @@ struct MeetingRecordingTile: View {
 
         var detail: String {
             switch self {
-            case .ready(let capturesMicrophone):
-                return capturesMicrophone
-                    ? "Transcribes the whole conversation, privately on your Mac."
-                    : "Transcribes the call audio, privately on your Mac."
+            case .ready(let sourceMode):
+                switch sourceMode {
+                case .microphoneAndSystem:
+                    return "Transcribes your voice and call audio, privately on your Mac."
+                case .microphoneOnly:
+                    return "Transcribes microphone audio only, privately on your Mac."
+                case .systemOnly:
+                    return "Transcribes system audio only, privately on your Mac."
+                }
             case .missing(let microphone, let screenRecording):
                 switch (microphone, screenRecording) {
                 case (true, true):
@@ -66,7 +71,7 @@ struct MeetingRecordingTile: View {
     }
 
     @Bindable var viewModel: MeetingRecordingPillViewModel
-    var permissionState: PermissionState = .ready(capturesMicrophone: true)
+    var permissionState: PermissionState = .ready(sourceMode: .microphoneAndSystem)
     var onTap: () -> Void
     /// Optional pause/resume handler. When `nil` the tile renders no pause
     /// control — keeps existing call sites unchanged.

--- a/Sources/MacParakeet/Views/Transcription/TranscribeView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscribeView.swift
@@ -9,7 +9,7 @@ struct TranscribeView: View {
     @Bindable var promptResultsViewModel: PromptResultsViewModel
     @Bindable var promptsViewModel: PromptsViewModel
     @Bindable var meetingPillViewModel: MeetingRecordingPillViewModel
-    var meetingPermissionState: MeetingRecordingTile.PermissionState = .ready(capturesMicrophone: true)
+    var meetingPermissionState: MeetingRecordingTile.PermissionState = .ready(sourceMode: .microphoneAndSystem)
     @Binding var showingProgressDetail: Bool
     var onRecordMeeting: () -> Void
     var onPauseToggleMeeting: (() -> Void)? = nil

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -395,6 +395,7 @@ public enum MeetingAudioSourceMode: String, CaseIterable, Hashable, Sendable, Eq
              "all",
              "default":
             return .microphoneAndSystem
+        // Short source aliases are exclusive; use "both" or "default" for combined capture.
         case "microphone-only", "mic-only", "microphone", "mic":
             return .microphoneOnly
         case "system-only", "system-audio-only", "system", "computer-audio-only", "computer-audio":

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -378,11 +378,22 @@ public enum MeetingAudioSourceMode: String, CaseIterable, Hashable, Sendable, Eq
         let raw = value
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
-            .replacingOccurrences(of: "_", with: "-")
-            .replacingOccurrences(of: " ", with: "-")
+            .components(separatedBy: CharacterSet(charactersIn: "_-+&").union(.whitespacesAndNewlines))
+            .filter { !$0.isEmpty }
+            .joined(separator: "-")
 
         switch raw {
-        case "microphone-and-system", "mic-and-system", "mic-system", "both", "all", "default":
+        case "microphone-and-system",
+             "microphone-and-system-audio",
+             "microphone-system",
+             "microphone-system-audio",
+             "mic-and-system",
+             "mic-and-system-audio",
+             "mic-system",
+             "mic-system-audio",
+             "both",
+             "all",
+             "default":
             return .microphoneAndSystem
         case "microphone-only", "mic-only", "microphone", "mic":
             return .microphoneOnly

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -320,27 +320,76 @@ public enum YouTubeAudioQuality: String, CaseIterable, Hashable, Sendable, Equat
 
 public enum MeetingAudioSourceMode: String, CaseIterable, Hashable, Sendable, Equatable {
     case microphoneAndSystem = "microphone_and_system"
+    case microphoneOnly = "microphone_only"
     case systemOnly = "system_only"
 
     public var capturesMicrophone: Bool {
-        self == .microphoneAndSystem
+        switch self {
+        case .microphoneAndSystem, .microphoneOnly:
+            return true
+        case .systemOnly:
+            return false
+        }
+    }
+
+    public var capturesSystemAudio: Bool {
+        switch self {
+        case .microphoneAndSystem, .systemOnly:
+            return true
+        case .microphoneOnly:
+            return false
+        }
     }
 
     public var displayTitle: String {
         switch self {
         case .microphoneAndSystem:
-            return "Microphone + System Audio"
+            return "Microphone + system audio"
+        case .microphoneOnly:
+            return "Microphone only"
         case .systemOnly:
-            return "System Audio Only"
+            return "System audio only"
         }
     }
 
     public var detail: String {
         switch self {
         case .microphoneAndSystem:
-            return "Capture your microphone and computer audio. Weak mic bleed is suppressed live."
+            return "Capture your voice and call audio. Best when using headphones."
+        case .microphoneOnly:
+            return "Capture only your microphone. Useful when speaker audio bleeds into the mic."
         case .systemOnly:
-            return "Capture computer audio for meetings. Your microphone is still used for dictation."
+            return "Capture only computer audio. Your microphone stays available for dictation."
+        }
+    }
+
+    public var configurationValue: String {
+        switch self {
+        case .microphoneAndSystem:
+            return "microphone-and-system"
+        case .microphoneOnly:
+            return "microphone-only"
+        case .systemOnly:
+            return "system-only"
+        }
+    }
+
+    public static func parseConfigurationValue(_ value: String) -> MeetingAudioSourceMode? {
+        let raw = value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "_", with: "-")
+            .replacingOccurrences(of: " ", with: "-")
+
+        switch raw {
+        case "microphone-and-system", "mic-and-system", "mic-system", "both", "all", "default":
+            return .microphoneAndSystem
+        case "microphone-only", "mic-only", "microphone", "mic":
+            return .microphoneOnly
+        case "system-only", "system-audio-only", "system", "computer-audio-only", "computer-audio":
+            return .systemOnly
+        default:
+            return nil
         }
     }
 

--- a/Sources/MacParakeetCore/Audio/MeetingAudioCaptureService.swift
+++ b/Sources/MacParakeetCore/Audio/MeetingAudioCaptureService.swift
@@ -164,6 +164,7 @@ public actor MeetingAudioCaptureService {
             systemCapture = nil
         }
         eventSink.setHandler(handler)
+        // Mic health compares microphone energy against system audio, so mic-only capture has no reference stream.
         micHealthObserver.start(observing: sourceMode.capturesMicrophone && sourceMode.capturesSystemAudio)
         let systemAudioFailureEvent: @Sendable (MeetingAudioError) -> MeetingAudioCaptureEvent = { error in
             sourceMode.capturesMicrophone

--- a/Sources/MacParakeetCore/Audio/MeetingAudioCaptureService.swift
+++ b/Sources/MacParakeetCore/Audio/MeetingAudioCaptureService.swift
@@ -154,12 +154,17 @@ public actor MeetingAudioCaptureService {
             throw MeetingAudioError.alreadyRunning
         }
 
-        let systemCapture = try systemAudioCaptureFactory()
         let sourceMode = sourceModeOverride ?? sourceModeProvider()
-        eventSink.setHandler(handler)
-        micHealthObserver.start(observing: sourceMode.capturesMicrophone)
         var microphoneStartReport: MeetingMicrophoneCaptureStartReport?
         var attemptedMicrophoneStart = false
+        let systemCapture: (any MeetingSystemAudioCapturing)?
+        if sourceMode.capturesSystemAudio {
+            systemCapture = try systemAudioCaptureFactory()
+        } else {
+            systemCapture = nil
+        }
+        eventSink.setHandler(handler)
+        micHealthObserver.start(observing: sourceMode.capturesMicrophone && sourceMode.capturesSystemAudio)
         let systemAudioFailureEvent: @Sendable (MeetingAudioError) -> MeetingAudioCaptureEvent = { error in
             sourceMode.capturesMicrophone
                 ? .sourceInterrupted(source: .system, error: error)
@@ -193,32 +198,34 @@ public actor MeetingAudioCaptureService {
                 )
             }
 
-            try await systemCapture.start(
-                handler: { [weak self] buffer, time in
-                    guard let copy = Self.deepCopyBuffer(buffer) else {
-                        Logger(subsystem: "com.macparakeet.core", category: "MeetingAudioCaptureService")
-                            .warning("deepCopyBuffer nil for system capture: format=\(buffer.format.commonFormat.rawValue) rate=\(buffer.format.sampleRate) ch=\(buffer.format.channelCount) interleaved=\(buffer.format.isInterleaved) frames=\(buffer.frameLength)")
-                        self?.eventSink.emit(
-                            systemAudioFailureEvent(
-                                .captureRuntimeFailure(
-                                    "system buffer copy failed (format=\(buffer.format.commonFormat.rawValue) rate=\(buffer.format.sampleRate) channels=\(buffer.format.channelCount))"
+            if let systemCapture {
+                try await systemCapture.start(
+                    handler: { [weak self] buffer, time in
+                        guard let copy = Self.deepCopyBuffer(buffer) else {
+                            Logger(subsystem: "com.macparakeet.core", category: "MeetingAudioCaptureService")
+                                .warning("deepCopyBuffer nil for system capture: format=\(buffer.format.commonFormat.rawValue) rate=\(buffer.format.sampleRate) ch=\(buffer.format.channelCount) interleaved=\(buffer.format.isInterleaved) frames=\(buffer.frameLength)")
+                            self?.eventSink.emit(
+                                systemAudioFailureEvent(
+                                    .captureRuntimeFailure(
+                                        "system buffer copy failed (format=\(buffer.format.commonFormat.rawValue) rate=\(buffer.format.sampleRate) channels=\(buffer.format.channelCount))"
+                                    )
                                 )
                             )
-                        )
-                        return
+                            return
+                        }
+                        self?.micHealthObserver.observeSystemBuffer(copy)
+                        self?.eventSink.emit(.systemBuffer(copy, time))
+                    },
+                    onStall: { [weak self] error in
+                        self?.eventSink.emit(systemAudioFailureEvent(error))
                     }
-                    self?.micHealthObserver.observeSystemBuffer(copy)
-                    self?.eventSink.emit(.systemBuffer(copy, time))
-                },
-                onStall: { [weak self] error in
-                    self?.eventSink.emit(systemAudioFailureEvent(error))
-                }
-            )
+                )
+            }
         } catch {
             if attemptedMicrophoneStart {
                 microphoneCapture.stop()
             }
-            await systemCapture.stop()
+            await systemCapture?.stop()
             finishEventStream()
             eventSink.setHandler(nil)
             micHealthObserver.stop()

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -244,9 +244,9 @@ public final class SettingsViewModel {
         if selectedMicrophoneDeviceUID == Self.systemDefaultMicrophoneSelection {
             if meetingAudioSourceMode == .systemOnly {
                 if let currentDefault = microphoneDeviceOptions.first(where: \.isDefault) {
-                    return "Using macOS System Default for dictation: \(currentDefault.name). Meeting recording is set to System Audio Only."
+                    return "Using macOS System Default for dictation: \(currentDefault.name). Meeting recording is set to \(MeetingAudioSourceMode.systemOnly.displayTitle)."
                 }
-                return "Using macOS System Default for dictation. Meeting recording is set to System Audio Only."
+                return "Using macOS System Default for dictation. Meeting recording is set to \(MeetingAudioSourceMode.systemOnly.displayTitle)."
             }
             if let currentDefault = microphoneDeviceOptions.first(where: \.isDefault) {
                 return "Using macOS System Default: \(currentDefault.name)."
@@ -260,7 +260,7 @@ public final class SettingsViewModel {
             return "Selected microphone is unavailable. MacParakeet will use System Default until it returns."
         }
         if meetingAudioSourceMode == .systemOnly {
-            return "Using \(selected.name) for dictation. Meeting recording is set to System Audio Only."
+            return "Using \(selected.name) for dictation. Meeting recording is set to \(MeetingAudioSourceMode.systemOnly.displayTitle)."
         }
         return "Using \(selected.name) for dictation and meeting microphone capture."
     }

--- a/Tests/CLITests/ConfigCommandTests.swift
+++ b/Tests/CLITests/ConfigCommandTests.swift
@@ -38,6 +38,7 @@ final class ConfigCommandTests: XCTestCase {
             "auto-meeting-titles",
             "save-transcription-audio",
             "meeting-audio-retention",
+            "meeting-audio-source",
             "save-meeting-audio",
             "youtube-audio-quality",
             "meeting-artifacts-folder",
@@ -74,6 +75,7 @@ final class ConfigCommandTests: XCTestCase {
         XCTAssertEqual(try ConfigCommand.read(key: "auto-meeting-titles", defaults: defaults), "on")
         XCTAssertEqual(try ConfigCommand.read(key: "save-transcription-audio", defaults: defaults), "on")
         XCTAssertEqual(try ConfigCommand.read(key: "meeting-audio-retention", defaults: defaults), "keep-forever")
+        XCTAssertEqual(try ConfigCommand.read(key: "meeting-audio-source", defaults: defaults), "microphone-and-system")
         XCTAssertEqual(try ConfigCommand.read(key: "save-meeting-audio", defaults: defaults), "on")
         XCTAssertEqual(try ConfigCommand.read(key: "youtube-audio-quality", defaults: defaults), "m4a")
         XCTAssertEqual(try ConfigCommand.read(key: "meeting-artifacts-folder", defaults: defaults), AppPaths.defaultMeetingRecordingsDir)
@@ -85,6 +87,11 @@ final class ConfigCommandTests: XCTestCase {
     func testReadCanonicalizesUnderscoreKeys() throws {
         defaults.set(YouTubeAudioQuality.bestAvailable.rawValue, forKey: UserDefaultsAppRuntimePreferences.youtubeAudioQualityKey)
         XCTAssertEqual(try ConfigCommand.read(key: "youtube_audio_quality", defaults: defaults), "best-available")
+        defaults.set(
+            MeetingAudioSourceMode.microphoneOnly.rawValue,
+            forKey: UserDefaultsAppRuntimePreferences.meetingAudioSourceModeKey
+        )
+        XCTAssertEqual(try ConfigCommand.read(key: "meeting_audio_source", defaults: defaults), "microphone-only")
     }
 
     func testCanonicalKeyNormalizesUnderscoreAliases() throws {
@@ -153,6 +160,15 @@ final class ConfigCommandTests: XCTestCase {
         )
         XCTAssertEqual(try ConfigCommand.read(key: "save-meeting-audio", defaults: defaults), "on")
 
+        XCTAssertEqual(
+            try ConfigCommand.write(key: "meeting-audio-source", value: "microphone-only", defaults: defaults),
+            "microphone-only"
+        )
+        XCTAssertEqual(
+            defaults.string(forKey: UserDefaultsAppRuntimePreferences.meetingAudioSourceModeKey),
+            MeetingAudioSourceMode.microphoneOnly.rawValue
+        )
+
         XCTAssertEqual(try ConfigCommand.write(key: "save-meeting-audio", value: "off", defaults: defaults), "off")
         XCTAssertEqual(defaults.object(forKey: UserDefaultsAppRuntimePreferences.saveMeetingAudioKey) as? Bool, false)
         XCTAssertEqual(
@@ -179,6 +195,10 @@ final class ConfigCommandTests: XCTestCase {
         XCTAssertEqual(
             try ConfigCommand.write(key: "meeting_audio_retention", value: "30d", defaults: defaults),
             "delete-after-30-days"
+        )
+        XCTAssertEqual(
+            try ConfigCommand.write(key: "meeting_audio_source", value: "system-only", defaults: defaults),
+            "system-only"
         )
     }
 
@@ -220,6 +240,41 @@ final class ConfigCommandTests: XCTestCase {
 
         XCTAssertThrowsError(
             try ConfigCommand.write(key: "meeting-audio-retention", value: "delete-after-366-days", defaults: defaults)
+        ) { error in
+            XCTAssertTrue(error is ValidationError)
+        }
+    }
+
+    func testMeetingAudioSourceAcceptsAliasesAndRejectsUnknownValues() throws {
+        XCTAssertEqual(
+            try ConfigCommand.write(key: "meeting-audio-source", value: "both", defaults: defaults),
+            "microphone-and-system"
+        )
+        XCTAssertEqual(
+            defaults.string(forKey: UserDefaultsAppRuntimePreferences.meetingAudioSourceModeKey),
+            MeetingAudioSourceMode.microphoneAndSystem.rawValue
+        )
+
+        XCTAssertEqual(
+            try ConfigCommand.write(key: "meeting-audio-source", value: "mic", defaults: defaults),
+            "microphone-only"
+        )
+        XCTAssertEqual(
+            defaults.string(forKey: UserDefaultsAppRuntimePreferences.meetingAudioSourceModeKey),
+            MeetingAudioSourceMode.microphoneOnly.rawValue
+        )
+
+        XCTAssertEqual(
+            try ConfigCommand.write(key: "meeting-audio-source", value: "computer-audio", defaults: defaults),
+            "system-only"
+        )
+        XCTAssertEqual(
+            defaults.string(forKey: UserDefaultsAppRuntimePreferences.meetingAudioSourceModeKey),
+            MeetingAudioSourceMode.systemOnly.rawValue
+        )
+
+        XCTAssertThrowsError(
+            try ConfigCommand.write(key: "meeting-audio-source", value: "echo-cancelled", defaults: defaults)
         ) { error in
             XCTAssertTrue(error is ValidationError)
         }

--- a/Tests/CLITests/ConfigCommandTests.swift
+++ b/Tests/CLITests/ConfigCommandTests.swift
@@ -251,6 +251,10 @@ final class ConfigCommandTests: XCTestCase {
             "microphone-and-system"
         )
         XCTAssertEqual(
+            try ConfigCommand.write(key: "meeting-audio-source", value: "Microphone + system audio", defaults: defaults),
+            "microphone-and-system"
+        )
+        XCTAssertEqual(
             defaults.string(forKey: UserDefaultsAppRuntimePreferences.meetingAudioSourceModeKey),
             MeetingAudioSourceMode.microphoneAndSystem.rawValue
         )

--- a/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
+++ b/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
@@ -161,6 +161,10 @@ final class AppRuntimePreferencesTests: XCTestCase {
             MeetingAudioSourceMode.parseConfigurationValue("microphone-and-system"),
             .microphoneAndSystem
         )
+        XCTAssertEqual(
+            MeetingAudioSourceMode.parseConfigurationValue("Microphone + system audio"),
+            .microphoneAndSystem
+        )
         XCTAssertEqual(MeetingAudioSourceMode.parseConfigurationValue("mic"), .microphoneOnly)
         XCTAssertEqual(MeetingAudioSourceMode.parseConfigurationValue("computer audio"), .systemOnly)
         XCTAssertNil(MeetingAudioSourceMode.parseConfigurationValue("echo-cancelled"))

--- a/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
+++ b/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
@@ -130,6 +130,42 @@ final class AppRuntimePreferencesTests: XCTestCase {
         )
     }
 
+    func testMeetingAudioSourceModeDefaultsToMicrophoneAndSystemAndReadsPersistedValue() {
+        let suite = "app-runtime-prefs-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        XCTAssertEqual(UserDefaultsAppRuntimePreferences(defaults: defaults).meetingAudioSourceMode, .microphoneAndSystem)
+
+        defaults.set(
+            MeetingAudioSourceMode.microphoneOnly.rawValue,
+            forKey: UserDefaultsAppRuntimePreferences.meetingAudioSourceModeKey
+        )
+
+        XCTAssertEqual(UserDefaultsAppRuntimePreferences(defaults: defaults).meetingAudioSourceMode, .microphoneOnly)
+
+        defaults.set("not-a-source-mode", forKey: UserDefaultsAppRuntimePreferences.meetingAudioSourceModeKey)
+
+        XCTAssertEqual(UserDefaultsAppRuntimePreferences(defaults: defaults).meetingAudioSourceMode, .microphoneAndSystem)
+    }
+
+    func testMeetingAudioSourceModeCaptureBooleansAndConfigurationParsing() {
+        XCTAssertTrue(MeetingAudioSourceMode.microphoneAndSystem.capturesMicrophone)
+        XCTAssertTrue(MeetingAudioSourceMode.microphoneAndSystem.capturesSystemAudio)
+        XCTAssertTrue(MeetingAudioSourceMode.microphoneOnly.capturesMicrophone)
+        XCTAssertFalse(MeetingAudioSourceMode.microphoneOnly.capturesSystemAudio)
+        XCTAssertFalse(MeetingAudioSourceMode.systemOnly.capturesMicrophone)
+        XCTAssertTrue(MeetingAudioSourceMode.systemOnly.capturesSystemAudio)
+
+        XCTAssertEqual(
+            MeetingAudioSourceMode.parseConfigurationValue("microphone-and-system"),
+            .microphoneAndSystem
+        )
+        XCTAssertEqual(MeetingAudioSourceMode.parseConfigurationValue("mic"), .microphoneOnly)
+        XCTAssertEqual(MeetingAudioSourceMode.parseConfigurationValue("computer audio"), .systemOnly)
+        XCTAssertNil(MeetingAudioSourceMode.parseConfigurationValue("echo-cancelled"))
+    }
+
     func testDictationInsertionStyleDefaultsToSentenceAndReadsPersistedValue() {
         let suite = "app-runtime-prefs-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!

--- a/Tests/MacParakeetTests/Audio/MeetingAudioCaptureServiceTests.swift
+++ b/Tests/MacParakeetTests/Audio/MeetingAudioCaptureServiceTests.swift
@@ -215,6 +215,48 @@ final class MeetingAudioCaptureServiceTests: XCTestCase {
         XCTFail("Timed out waiting for system-only capture events")
     }
 
+    func testMicrophoneOnlyModeStartsMicrophoneWithoutSystemCapture() async throws {
+        let microphone = MockMeetingMicrophoneCapture()
+        let systemFactoryCallCount = FactoryInvocationBox()
+        let service = MeetingAudioCaptureService(
+            microphoneCapture: microphone,
+            systemAudioCaptureFactory: {
+                systemFactoryCallCount.increment()
+                throw MeetingAudioError.unsupportedPlatform
+            },
+            sourceModeProvider: { .microphoneOnly }
+        )
+
+        let capturedEvents = CapturedMeetingCaptureEvents()
+        let report = try await service.start { event in
+            Task {
+                await capturedEvents.append(event)
+            }
+        }
+        defer { Task { await service.stop() } }
+
+        XCTAssertEqual(report.sourceMode, .microphoneOnly)
+        XCTAssertTrue(report.microphoneStarted)
+        XCTAssertEqual(microphone.requestedModes, [.raw])
+        XCTAssertEqual(systemFactoryCallCount.get(), 0)
+
+        let buffer = try XCTUnwrap(makeInterleavedFloatStereoBuffer(
+            sampleRate: 48_000,
+            samples: [0.25, 0.25, 0.25, 0.25]
+        ))
+        microphone.emit(buffer: buffer, time: AVAudioTime(hostTime: 1))
+
+        for _ in 0..<20 {
+            let events = await capturedEvents.values()
+            if events.microphoneBufferCount == 1 {
+                XCTAssertEqual(events.systemBufferCount, 0)
+                return
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTFail("Timed out waiting for microphone-only capture events")
+    }
+
     func testMicHealthTelemetryReportsMissingMicOnce() async throws {
         let microphone = MockMeetingMicrophoneCapture()
         let systemCapture = MockMeetingSystemAudioCapture()

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
@@ -1042,6 +1042,41 @@ final class MeetingRecordingServiceTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(counts.system, 1)
     }
 
+    func testMicrophoneOnlyCaptureProducesMicrophoneSourceOnly() async throws {
+        let captureService = MockMeetingAudioCaptureService(
+            startReport: MeetingAudioCaptureStartReport(sourceMode: .microphoneOnly)
+        )
+        let audioConverter = RecordingMeetingAudioFileConverter()
+        let sttClient = CountingMeetingSTTClient()
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: audioConverter,
+            sttTranscriber: sttClient
+        )
+
+        try await service.startRecording(sourceMode: .microphoneOnly)
+
+        let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.5))
+        await captureService.yield(.microphoneBuffer(
+            microphoneBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
+        ))
+        try await waitForMeetingSTTCall(sttClient) { $0.microphone >= 1 }
+
+        let output = try await service.stopRecording()
+        defer { try? FileManager.default.removeItem(at: output.folderURL) }
+
+        XCTAssertNotNil(output.sourceAlignment.microphone)
+        XCTAssertNil(output.sourceAlignment.system)
+        XCTAssertEqual(audioConverter.capturedMixedInputs(), [output.microphoneAudioURL])
+
+        let requestedSourceModes = await captureService.requestedSourceModes
+        XCTAssertEqual(requestedSourceModes, [.microphoneOnly])
+        let counts = await sttClient.callCounts
+        XCTAssertGreaterThanOrEqual(counts.microphone, 1)
+        XCTAssertEqual(counts.system, 0)
+    }
+
     func testStopRecordingMixesDualSourcesInMicrophoneThenSystemOrder() async throws {
         let captureService = MockMeetingAudioCaptureService()
         let audioConverter = RecordingMeetingAudioFileConverter()

--- a/Tests/MacParakeetTests/Views/MeetingRecordingTileTests.swift
+++ b/Tests/MacParakeetTests/Views/MeetingRecordingTileTests.swift
@@ -10,7 +10,7 @@ final class MeetingRecordingTileTests: XCTestCase {
             sourceMode: .microphoneAndSystem
         )
 
-        XCTAssertEqual(state, .ready(capturesMicrophone: true))
+        XCTAssertEqual(state, .ready(sourceMode: .microphoneAndSystem))
     }
 
     func testPermissionStateRequiresMicrophoneOnlyWhenMeetingCapturesMicrophone() {
@@ -24,16 +24,27 @@ final class MeetingRecordingTileTests: XCTestCase {
             screenRecordingGranted: true,
             sourceMode: .systemOnly
         )
+        let microphoneOnly = MeetingRecordingTile.PermissionState(
+            microphoneGranted: false,
+            screenRecordingGranted: true,
+            sourceMode: .microphoneOnly
+        )
 
         XCTAssertEqual(microphoneAndSystem, .missing(microphone: true, screenRecording: false))
-        XCTAssertEqual(systemOnly, .ready(capturesMicrophone: false))
+        XCTAssertEqual(systemOnly, .ready(sourceMode: .systemOnly))
+        XCTAssertEqual(microphoneOnly, .missing(microphone: true, screenRecording: false))
     }
 
-    func testPermissionStateRequiresScreenRecordingForEveryMeetingMode() {
+    func testPermissionStateRequiresScreenRecordingOnlyWhenMeetingCapturesSystemAudio() {
         let microphoneAndSystem = MeetingRecordingTile.PermissionState(
             microphoneGranted: true,
             screenRecordingGranted: false,
             sourceMode: .microphoneAndSystem
+        )
+        let microphoneOnly = MeetingRecordingTile.PermissionState(
+            microphoneGranted: true,
+            screenRecordingGranted: false,
+            sourceMode: .microphoneOnly
         )
         let systemOnly = MeetingRecordingTile.PermissionState(
             microphoneGranted: true,
@@ -42,6 +53,7 @@ final class MeetingRecordingTileTests: XCTestCase {
         )
 
         XCTAssertEqual(microphoneAndSystem, .missing(microphone: false, screenRecording: true))
+        XCTAssertEqual(microphoneOnly, .ready(sourceMode: .microphoneOnly))
         XCTAssertEqual(systemOnly, .missing(microphone: false, screenRecording: true))
     }
 }

--- a/docs/research/vpio-process-tap-conflict.md
+++ b/docs/research/vpio-process-tap-conflict.md
@@ -351,6 +351,8 @@ Current manual verification checklist:
 - Meeting alone with Safari/Zoom/system audio playing -> `system.m4a` contains real system audio and live/final transcript includes the system side.
 - Meeting with built-in speakers -> `microphone.m4a` contains the user's voice; some far-end speaker bleed is acceptable in raw mode, with residual transcript suppression still available.
 - Meeting -> trigger dictation without stopping meeting -> dictation captures and pastes independently; meeting system audio remains continuous.
+- Meeting `microphoneOnly` mode -> microphone audio records without prompting
+  for or starting ScreenCaptureKit system audio.
 - Meeting `systemOnly` mode -> system audio records while the microphone remains free for dictation.
 - Explicit VPIO experiment retry after a failed VPIO start -> the next attempt does not fail with the stale half-VPIO `-10875` state.
 

--- a/spec/05-audio-pipeline.md
+++ b/spec/05-audio-pipeline.md
@@ -231,25 +231,25 @@ Mic Input    → SharedMicrophoneStream (+ Voice Processing I/O when active)┘ 
 
 ```text
 User clicks "Start Meeting Recording"
-    → Check Screen Recording permission (CGPreflightScreenCaptureAccess)
-    → If denied: show error + "Open System Settings" button, block recording
+    → Resolve source mode
+    → Check microphone permission only when the mode includes mic audio
+    → Check Screen & System Audio Recording permission only when the mode includes system audio
+    → If a required permission is denied: show error + "Open System Settings" button, block recording
     → Acquire speech-engine lease from STTScheduler and capture current engine/language
-    → Start MeetingAudioCaptureService (both streams)
+    → Start MeetingAudioCaptureService with the selected source mode
     → Show recording pill (red dot + elapsed timer + stop button)
     → Consume AsyncStream<MeetingAudioCaptureEvent>, write buffers to M4A files
       and keep `recording.lock` current with session state/notes/speech engine
     → User clicks Stop
-    → Stop capture, finalize `microphone.m4a` + `system.m4a`
+    → Stop capture and finalize the captured source file(s)
     → Persist `meeting-recording-metadata.json` with source alignment and speech engine
     → Merge streams into `meeting.m4a` (stereo for dual input; mono for single input)
     → Atomically rewrite `recording.lock` to `awaitingTranscription`
     → Save a processing Transcription row with sourceType = .meeting and filePath = `meeting.m4a`
     → Enqueue background finalization and return recorder to idle
     → User may immediately start the next meeting recording
-    → Background queue converts `microphone.m4a` → 16kHz mono WAV via FFmpeg
-    → Send mic WAV to captured local STT engine
-    → Background queue converts `system.m4a` → 16kHz mono WAV via FFmpeg
-    → Send system WAV to captured local STT engine
+    → Background queue converts each captured source M4A → 16kHz mono WAV via FFmpeg
+    → Send each source WAV to the captured local STT engine
     → Merge fresh per-source STT using persisted source offsets
     → Optionally refine the isolated system side with diarization
     → Update the existing Transcription row and delete `recording.lock`
@@ -271,8 +271,8 @@ the stopped meeting waits for that job to finish; once the slot is free,
 
 ```text
 ~/Library/Application Support/MacParakeet/meeting-recordings/{uuid}/
-    ├── microphone.m4a    # Mic audio (AAC, 48kHz mono)
-    ├── system.m4a        # System audio (AAC, 48kHz mono)
+    ├── microphone.m4a    # Mic audio when captured (AAC, 48kHz mono)
+    ├── system.m4a        # System audio when captured (AAC, 48kHz mono)
     ├── meeting.m4a       # Final playback/export artifact (stereo dual-source when both tracks exist; legacy fallback for downstream tools)
     ├── meeting-recording-metadata.json  # Persisted source timing/alignment + speech engine for post-stop merge
     ├── recording.lock     # Recording/awaiting-transcription recovery state, including notes and speech engine
@@ -358,9 +358,9 @@ alter the pasted text. See `docs/research/live-dictation-streaming.md`.
 
 | Permission | Why | When Requested | Fallback |
 |------------|-----|----------------|----------|
-| Microphone | Dictation recording | Onboarding or first dictation attempt | Show permission dialog with instructions |
+| Microphone | Dictation recording and meeting modes that include mic audio | Onboarding, first dictation attempt, or first mic-capturing meeting attempt | Show permission dialog with instructions |
 | Accessibility | Global shortcut detection + text insertion | Onboarding or first dictation attempt | Show System Settings deep link |
-| Screen & System Audio Recording | Meeting recording (system audio capture via ScreenCaptureKit) | Optional onboarding step or first meeting recording attempt | Show error + "Open System Settings" button, block recording |
+| Screen & System Audio Recording | Meeting modes that include system audio capture via ScreenCaptureKit | Optional onboarding step or first system-audio meeting attempt | Show error + "Open System Settings" button, block recording |
 
 ### Permission Flow
 

--- a/spec/05-audio-pipeline.md
+++ b/spec/05-audio-pipeline.md
@@ -169,15 +169,43 @@ Mic Input    → SharedMicrophoneStream (+ Voice Processing I/O when active)┘ 
                                               → background source-file STT + aligned merge
 ```
 
-- **System audio** is captured via ScreenCaptureKit `SCStream` audio (`SCStreamConfiguration.capturesAudio = true`), which avoids owning or clocking a HAL aggregate output device.
-- **Mic audio** is captured by subscribing to `SharedMicrophoneStream` with a typed policy (`MeetingMicProcessingMode`): `raw` (default), `vpioPreferred`, or `vpioRequired`.
-- MacParakeet ships meeting capture with raw mic capture and ScreenCaptureKit for system audio. VPIO remains available for explicit experiments, but it is not the shipped default because live-call testing showed that engaging it can muffle the user's outgoing mic in Zoom/Meet. The older Core Audio process-tap path also remains out of production because it does not reliably coexist with VPIO in-process. See `docs/research/vpio-process-tap-conflict.md`.
-- Both streams are captured within the same meeting session and aligned by host time. `CaptureOrchestrator` owns join + offset + live-preview chunk boundaries via `MeetingAudioPairJoiner` plus per-source `MeetingLiveAudioChunking` strategies.
+- **Source mode** is user-configurable per recording start: microphone +
+  system audio (default), microphone only, or system audio only. The selected
+  mode controls both permission prompts and which capture streams are started.
+- **System audio** is captured via ScreenCaptureKit `SCStream` audio
+  (`SCStreamConfiguration.capturesAudio = true`) only when the source mode
+  includes system audio, which avoids owning or clocking a HAL aggregate output
+  device.
+- **Mic audio** is captured by subscribing to `SharedMicrophoneStream` only
+  when the source mode includes microphone audio, with a typed policy
+  (`MeetingMicProcessingMode`): `raw` (default), `vpioPreferred`, or
+  `vpioRequired`.
+- MacParakeet ships meeting capture with raw mic capture and ScreenCaptureKit
+  for system audio when both sources are selected. VPIO remains available for
+  explicit experiments, but it is not the shipped default because live-call
+  testing showed that engaging it can muffle the user's outgoing mic in
+  Zoom/Meet. The older Core Audio process-tap path also remains out of
+  production because it does not reliably coexist with VPIO in-process. See
+  `docs/research/vpio-process-tap-conflict.md`.
+- When both streams are selected, they are captured within the same meeting
+  session and aligned by host time. `CaptureOrchestrator` owns join + offset +
+  live-preview chunk boundaries via `MeetingAudioPairJoiner` plus per-source
+  `MeetingLiveAudioChunking` strategies. Single-source sessions skip the
+  unselected stream and produce a mono `meeting.m4a`.
 - Mic conditioning is pass-through. Raw capture applies no capture-time AEC/noise suppression/AGC; transcript-layer system-dominance suppression remains the default guard against obvious speaker bleed. When VPIO is explicitly requested and engages, macOS applies AEC/noise suppression/AGC before buffers reach `MeetingRecordingService`.
 - Audio is stored as separate M4A files (AAC 64kbps, 48kHz mono) per source
 - Source audio is written as fragmented M4A with 1-second movie fragments so kill-9 recovery can keep playable audio through the last committed fragment.
-- After recording stops, microphone + system M4As are finalized and merged into `meeting.m4a`. Dual-input sessions preserve source separation as stereo (`L=mic`, `R=system`), while single-input sessions remain mono. The recovery lock is then rewritten to `awaitingTranscription`, and a processing Library row is saved before the recorder returns to idle.
-- Final meeting STT does **not** transcribe `meeting.m4a`. A background queue transcribes `microphone.m4a` and `system.m4a` separately with the engine captured at recording start, then merges those fresh results by persisted `MeetingSourceAlignment`. `meeting.m4a` is kept as the playback/export artifact. See `docs/research/meeting-dual-stream-transcription-pipeline.md` for the full pipeline and tradeoffs.
+- After recording stops, the captured source M4As are finalized and merged into
+  `meeting.m4a`. Dual-input sessions preserve source separation as stereo
+  (`L=mic`, `R=system`), while single-input sessions remain mono. The recovery
+  lock is then rewritten to `awaitingTranscription`, and a processing Library
+  row is saved before the recorder returns to idle.
+- Final meeting STT does **not** transcribe `meeting.m4a`. A background queue
+  transcribes the captured source files separately with the engine captured at
+  recording start, then merges those fresh results by persisted
+  `MeetingSourceAlignment`. `meeting.m4a` is kept as the playback/export
+  artifact. See `docs/research/meeting-dual-stream-transcription-pipeline.md`
+  for the full pipeline and tradeoffs.
 - Recovery locks and retention safety are a tested boundary contract. See [`spec/contracts/meeting-recovery-retention.md`](contracts/meeting-recovery-retention.md) before changing lock-file predicates or automatic meeting-audio deletion.
 - Live chunk enqueue keeps a conservative guard: when recent system energy strongly dominates processed mic energy for a short freshness window, mic chunks are skipped for live transcription only. Mic audio is still written to disk and included in final mix/output.
 - Joiner queue overflow, long-session sync lag, and runtime capture failures are emitted as diagnostics for observability (`MeetingAudioCaptureEvent.error` where available).


### PR DESCRIPTION
## Summary

Meetings can now be configured for microphone-only capture, so users listening through speakers can avoid feeding the system-audio stream back into the meeting transcript. The existing combined mode stays the default for headphone use, while microphone-only skips ScreenCaptureKit startup and screen-recording permission checks entirely.

This also exposes the new mode through `macparakeet-cli config get|set meeting-audio-source`, keeps the Settings status copy source-aware, and documents how single-source meeting artifacts are finalized.

Closes #540

## Testing

- `git diff --check`
- `swift test --filter 'MeetingAudioCaptureServiceTests|MeetingRecordingServiceTests/testSystemOnlyCaptureProducesSystemSourceOnly|MeetingRecordingServiceTests/testMicrophoneOnlyCaptureProducesMicrophoneSourceOnly|MeetingRecordingTileTests|AppRuntimePreferencesTests|ConfigCommandTests|SettingsViewModelTests/testMeetingAudioSourceModePersists|SettingsViewModelTests/testDefaultValues|SettingsViewModelTests/testInitLoadsFromUserDefaults'`
- `swift test`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5_Codex](https://img.shields.io/badge/GPT_5_Codex-000000)
