### PR TITLE
Polish meeting audio lifecycle UX

### DIFF
--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingAudioStateChip.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingAudioStateChip.swift
@@ -1,0 +1,86 @@
+import MacParakeetCore
+import SwiftUI
+
+struct MeetingAudioStateChip: View {
+    let state: MeetingAudioFile.State
+
+    var body: some View {
+        Label(title, systemImage: systemImage)
+            .font(.system(size: 11, weight: .medium))
+            .foregroundStyle(foreground)
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(
+                Capsule()
+                    .fill(background)
+            )
+            .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var title: String {
+        switch state {
+        case .saved:
+            return "Audio saved"
+        case .removed:
+            return "Audio removed"
+        case .missing:
+            return "Audio missing"
+        case .notMeeting:
+            return ""
+        }
+    }
+
+    private var systemImage: String {
+        switch state {
+        case .saved:
+            return "waveform"
+        case .removed:
+            return "waveform.slash"
+        case .missing:
+            return "exclamationmark.triangle"
+        case .notMeeting:
+            return "waveform"
+        }
+    }
+
+    private var foreground: Color {
+        switch state {
+        case .saved:
+            return DesignSystem.Colors.textTertiary
+        case .removed:
+            return DesignSystem.Colors.textSecondary
+        case .missing:
+            return DesignSystem.Colors.warningAmber
+        case .notMeeting:
+            return DesignSystem.Colors.textTertiary
+        }
+    }
+
+    private var background: Color {
+        switch state {
+        case .saved:
+            return DesignSystem.Colors.surfaceElevated.opacity(0.65)
+        case .removed:
+            return DesignSystem.Colors.surfaceElevated.opacity(0.9)
+        case .missing:
+            return DesignSystem.Colors.warningAmber.opacity(0.12)
+        case .notMeeting:
+            return .clear
+        }
+    }
+
+    private var accessibilityLabel: String {
+        switch state {
+        case .saved:
+            return "Meeting audio is saved"
+        case .removed:
+            return "Meeting audio has been removed"
+        case .missing:
+            return "Meeting audio file is missing"
+        case .notMeeting:
+            return ""
+        }
+    }
+}

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingAudioStateChip.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingAudioStateChip.swift
@@ -4,19 +4,22 @@ import SwiftUI
 struct MeetingAudioStateChip: View {
     let state: MeetingAudioFile.State
 
+    @ViewBuilder
     var body: some View {
-        Label(title, systemImage: systemImage)
-            .font(.system(size: 11, weight: .medium))
-            .foregroundStyle(foreground)
-            .lineLimit(1)
-            .fixedSize(horizontal: true, vertical: false)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background(
-                Capsule()
-                    .fill(background)
-            )
-            .accessibilityLabel(accessibilityLabel)
+        if state != .notMeeting {
+            Label(title, systemImage: systemImage)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(foreground)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(
+                    Capsule()
+                        .fill(background)
+                )
+                .accessibilityLabel(accessibilityLabel)
+        }
     }
 
     private var title: String {
@@ -41,7 +44,7 @@ struct MeetingAudioStateChip: View {
         case .missing:
             return "exclamationmark.triangle"
         case .notMeeting:
-            return "waveform"
+            return ""
         }
     }
 

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingDeletionCopy.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingDeletionCopy.swift
@@ -72,6 +72,7 @@ enum MeetingDeletionCopy {
     static func audioUnavailableHelp(for state: MeetingAudioFile.State) -> String {
         switch state {
         case .saved:
+            assertionFailure("audioUnavailableHelp called for .saved state; callers should show positive help text instead.")
             return "Meeting audio is available"
         case .removed:
             return "Saved meeting audio has been removed"

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingDeletionCopy.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingDeletionCopy.swift
@@ -1,0 +1,84 @@
+import Foundation
+import MacParakeetCore
+
+enum MeetingDeletionCopy {
+    enum Surface {
+        case library
+        case meetings
+
+        var name: String {
+            switch self {
+            case .library:
+                return "Library"
+            case .meetings:
+                return "Meetings"
+            }
+        }
+    }
+
+    static let audioOnlyAlertTitle = "Remove Meeting Audio?"
+    static let audioOnlyConfirmTitle = "Remove Audio Only"
+    static let audioOnlyMenuTitle = "Remove Audio Only"
+
+    static let fullDeleteAlertTitle = "Delete Meeting?"
+    static let fullDeleteConfirmTitle = "Delete Meeting"
+    static let fullDeleteMenuTitle = "Delete Meeting"
+
+    static func singleAudioOnlyMessage(surface: Surface) -> String {
+        "This removes the saved audio for this meeting. The meeting stays in \(surface.name) with its transcript. Notes, AI results, and chats stay too if they exist. Playback and retranscription will no longer be available unless you saved a copy of the audio."
+    }
+
+    static func bulkAudioOnlyMessage(
+        count: Int,
+        skippedCount: Int,
+        surface: Surface
+    ) -> String {
+        let meetingWord = count == 1 ? "meeting" : "meetings"
+        let meetingSubject = count == 1 ? "The meeting stays" : "The meetings stay"
+        let transcriptObject = count == 1 ? "its transcript" : "their transcripts"
+        let savedCopy = count == 1 ? "a copy" : "copies"
+        var message =
+            "This removes saved audio from \(count) \(meetingWord). \(meetingSubject) in \(surface.name) with \(transcriptObject). Notes, AI results, and chats stay too if they exist. Playback and retranscription will no longer be available unless you saved \(savedCopy) of the audio."
+        if skippedCount > 0 {
+            let skippedWord = skippedCount == 1 ? "item" : "items"
+            message +=
+                " \(skippedCount) selected \(skippedWord) will be skipped because no saved meeting audio is available."
+        }
+        return message
+    }
+
+    static func singleFullDeleteMessage(title: String) -> String {
+        "This permanently deletes \"\(title)\", including its transcript and saved audio. Notes, AI results, and chats for this meeting are also deleted if they exist."
+    }
+
+    static func bulkFullDeleteMessage(count: Int) -> String {
+        let meetingWord = count == 1 ? "meeting" : "meetings"
+        let transcriptObject = count == 1 ? "its transcript and saved audio" : "transcripts and saved audio"
+        let artifactSubject = count == 1 ? "this meeting" : "those meetings"
+        return
+            "This permanently deletes \(count) \(meetingWord), including \(transcriptObject). Notes, AI results, and chats for \(artifactSubject) are also deleted if they exist."
+    }
+
+    static func mixedBulkFullDeleteMessage(
+        totalCount: Int,
+        meetingCount: Int
+    ) -> String {
+        let itemWord = totalCount == 1 ? "item" : "items"
+        let meetingWord = meetingCount == 1 ? "meeting" : "meetings"
+        return
+            "This permanently deletes \(totalCount) \(itemWord), including \(meetingCount) \(meetingWord). Meeting transcripts, saved audio, notes, AI results, and chats are removed if they exist. Original local source files are not removed."
+    }
+
+    static func audioUnavailableHelp(for state: MeetingAudioFile.State) -> String {
+        switch state {
+        case .saved:
+            return "Meeting audio is available"
+        case .removed:
+            return "Saved meeting audio has been removed"
+        case .missing:
+            return "Meeting audio file is missing"
+        case .notMeeting:
+            return "Meeting audio is not available"
+        }
+    }
+}

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
@@ -103,13 +103,16 @@ struct MeetingRowCard<MenuContent: View>: View {
 
             highlightedTitle
                 .font(.system(size: 15, weight: .semibold))
-                .tracking(-0.15)
                 .foregroundStyle(DesignSystem.Colors.textPrimary)
                 .lineLimit(1)
                 .truncationMode(.tail)
                 .contentTransition(.opacity)
+                .layoutPriority(1)
 
             speakerInline
+                .layoutPriority(0)
+
+            audioInline
                 .layoutPriority(0)
 
             Spacer(minLength: 0)
@@ -128,6 +131,13 @@ struct MeetingRowCard<MenuContent: View>: View {
     }
 
     @ViewBuilder
+    private var audioInline: some View {
+        if audioState != .notMeeting {
+            MeetingAudioStateChip(state: audioState)
+        }
+    }
+
+    @ViewBuilder
     private var snippetRow: some View {
         if let snippet = displayedSnippet {
             highlightedText(snippet)
@@ -141,14 +151,14 @@ struct MeetingRowCard<MenuContent: View>: View {
                 .foregroundStyle(DesignSystem.Colors.textTertiary)
                 .lineLimit(1)
         } else if transcription.status == .error {
-            Text("Transcription failed")
+            Text(statusLine("Transcription failed"))
                 .font(DesignSystem.Typography.bodySmall)
                 .foregroundStyle(DesignSystem.Colors.errorRed.opacity(0.85))
                 .lineLimit(1)
         } else if transcription.status == .cancelled {
             // Keep-Audio outcome of the stop-transcription flow (issue #487):
             // the audio is intact and retranscribable from the detail view.
-            Text("Transcription stopped — audio saved")
+            Text(statusLine("Transcription stopped"))
                 .font(DesignSystem.Typography.bodySmall)
                 .foregroundStyle(DesignSystem.Colors.textTertiary)
                 .lineLimit(1)
@@ -214,16 +224,42 @@ struct MeetingRowCard<MenuContent: View>: View {
         return count >= 2 ? count : nil
     }
 
+    private var audioState: MeetingAudioFile.State {
+        MeetingAudioFile.state(for: transcription)
+    }
+
+    private func statusLine(_ prefix: String) -> String {
+        guard let suffix = audioStateSuffix else { return prefix }
+        return "\(prefix) · \(suffix)"
+    }
+
+    private var audioStateSuffix: String? {
+        switch audioState {
+        case .saved:
+            return "audio saved"
+        case .removed:
+            return "audio removed"
+        case .missing:
+            return "audio missing"
+        case .notMeeting:
+            return nil
+        }
+    }
+
     private var timeOfDayString: String {
         transcription.createdAt.formatted(date: .omitted, time: .shortened)
     }
 
     private var hoverTooltip: String {
         let absolute = transcription.createdAt.formatted(date: .abbreviated, time: .shortened)
-        if let engineLabel = engineLabel {
-            return "\(absolute) · \(engineLabel)"
+        var parts = [absolute]
+        if let engineLabel {
+            parts.append(engineLabel)
         }
-        return absolute
+        if let audioStateSuffix {
+            parts.append(audioStateSuffix)
+        }
+        return parts.joined(separator: " · ")
     }
 
     private var engineLabel: String? {

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
@@ -132,7 +132,7 @@ struct MeetingRowCard<MenuContent: View>: View {
 
     @ViewBuilder
     private var audioInline: some View {
-        if audioState != .notMeeting {
+        if showsAudioInline {
             MeetingAudioStateChip(state: audioState)
         }
     }
@@ -226,6 +226,11 @@ struct MeetingRowCard<MenuContent: View>: View {
 
     private var audioState: MeetingAudioFile.State {
         MeetingAudioFile.state(for: transcription)
+    }
+
+    private var showsAudioInline: Bool {
+        guard audioState != .notMeeting else { return false }
+        return transcription.status != .error && transcription.status != .cancelled
     }
 
     private func statusLine(_ prefix: String) -> String {

--- a/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
+++ b/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
@@ -84,23 +84,26 @@ struct MeetingsView: View {
             Text(audioSaveErrorMessage ?? "Unable to save meeting audio.")
         }
         .alert(
-            "Delete Meeting Audio?",
+            MeetingDeletionCopy.audioOnlyAlertTitle,
             isPresented: Binding(
                 get: { pendingDeleteAudio != nil },
                 set: { if !$0 { pendingDeleteAudio = nil } }
             )
         ) {
-            Button("Cancel", role: .cancel) {}
-            Button("Delete Audio Only", role: .destructive) {
+            Button("Cancel", role: .cancel) {
+                pendingDeleteAudio = nil
+            }
+            Button(MeetingDeletionCopy.audioOnlyConfirmTitle, role: .destructive) {
                 if let transcription = pendingDeleteAudio {
                     viewModel.recentMeetingsViewModel.deleteMeetingAudio(transcription)
+                    pendingDeleteAudio = nil
                 }
             }
         } message: {
-            Text("The transcript, notes, AI results, and chats stay in Meetings if they exist. Playback and retranscription will be unavailable unless you saved a copy.")
+            Text(MeetingDeletionCopy.singleAudioOnlyMessage(surface: .meetings))
         }
         .alert(
-            "Delete Meeting?",
+            MeetingDeletionCopy.fullDeleteAlertTitle,
             isPresented: Binding(
                 get: { pendingDeleteMeeting != nil },
                 set: { if !$0 { pendingDeleteMeeting = nil } }
@@ -109,7 +112,7 @@ struct MeetingsView: View {
             Button("Cancel", role: .cancel) {
                 pendingDeleteMeeting = nil
             }
-            Button("Delete Meeting", role: .destructive) {
+            Button(MeetingDeletionCopy.fullDeleteConfirmTitle, role: .destructive) {
                 if let transcription = pendingDeleteMeeting {
                     viewModel.recentMeetingsViewModel.deleteTranscription(transcription)
                     pendingDeleteMeeting = nil
@@ -117,7 +120,7 @@ struct MeetingsView: View {
             }
         } message: {
             if let pendingDeleteMeeting {
-                Text("This permanently removes \"\(pendingDeleteMeeting.fileName)\", its transcript, stored audio, and any notes, AI results, or chats for this meeting.")
+                Text(MeetingDeletionCopy.singleFullDeleteMessage(title: pendingDeleteMeeting.fileName))
             }
         }
         .alert(
@@ -554,7 +557,8 @@ struct MeetingsView: View {
             }
         }
 
-        let audioAvailable = MeetingAudioFile.isAvailable(for: transcription)
+        let audioState = MeetingAudioFile.state(for: transcription)
+        let audioAvailable = audioState == .saved
         let artifactAvailable = MeetingArtifactActions.folderURL(for: transcription) != nil
 
         Divider()
@@ -581,6 +585,9 @@ struct MeetingsView: View {
             Label("Show Audio in Finder", systemImage: "waveform")
         }
         .disabled(!audioAvailable)
+        .help(audioAvailable
+              ? "Reveal the meeting audio file in Finder"
+              : MeetingDeletionCopy.audioUnavailableHelp(for: audioState))
 
         Button {
             saveMeetingAudio(transcription)
@@ -588,20 +595,26 @@ struct MeetingsView: View {
             Label("Save Audio As…", systemImage: "square.and.arrow.down")
         }
         .disabled(!audioAvailable)
+        .help(audioAvailable
+              ? "Save a copy of the meeting audio to a chosen location"
+              : MeetingDeletionCopy.audioUnavailableHelp(for: audioState))
 
         Button(role: .destructive) {
             pendingDeleteAudio = transcription
         } label: {
-            Label("Delete Audio Only", systemImage: "waveform.slash")
+            Label(MeetingDeletionCopy.audioOnlyMenuTitle, systemImage: "waveform.slash")
         }
         .disabled(!audioAvailable)
+        .help(audioAvailable
+              ? "Remove the saved meeting audio while keeping the meeting"
+              : MeetingDeletionCopy.audioUnavailableHelp(for: audioState))
 
         Divider()
 
         Button(role: .destructive) {
             pendingDeleteMeeting = transcription
         } label: {
-            Label("Delete Meeting", systemImage: "trash")
+            Label(MeetingDeletionCopy.fullDeleteMenuTitle, systemImage: "trash")
         }
     }
 
@@ -734,26 +747,26 @@ struct MeetingsView: View {
         guard let operation = viewModel.recentMeetingsViewModel.pendingBulkOperation else {
             return "Delete Meetings?"
         }
-        return operation.isDeleteAudioOnly ? "Delete Meeting Audio?" : "Delete Meetings?"
+        return operation.isDeleteAudioOnly ? MeetingDeletionCopy.audioOnlyAlertTitle : "Delete Meetings?"
     }
 
     private var recentMeetingsBulkOperationConfirmTitle: String {
         guard let operation = viewModel.recentMeetingsViewModel.pendingBulkOperation else {
             return "Delete"
         }
-        return operation.isDeleteAudioOnly ? "Delete Audio Only" : "Delete Meetings"
+        return operation.isDeleteAudioOnly ? MeetingDeletionCopy.audioOnlyConfirmTitle : "Delete Meetings"
     }
 
     private func recentMeetingsBulkOperationMessage(for operation: BulkTranscriptionOperation) -> String {
         if operation.isDeleteAudioOnly {
-            var message = "Delete audio for \(operation.targetCount) \(operation.targetCount == 1 ? "meeting" : "meetings")? Transcripts, notes, AI results, and chats stay in Meetings if they exist. Playback and retranscription will be unavailable unless you saved a copy."
-            if operation.skippedCount > 0 {
-                message += " \(operation.skippedCount) selected \(operation.skippedCount == 1 ? "meeting does" : "meetings do") not have stored audio and will be skipped."
-            }
-            return message
+            return MeetingDeletionCopy.bulkAudioOnlyMessage(
+                count: operation.targetCount,
+                skippedCount: operation.skippedCount,
+                surface: .meetings
+            )
         }
 
-        return "Delete \(operation.targetCount) \(operation.targetCount == 1 ? "meeting" : "meetings")? This permanently removes the selected rows, transcripts, stored audio, and any notes, AI results, or chats for those meetings."
+        return MeetingDeletionCopy.bulkFullDeleteMessage(count: operation.targetCount)
     }
 
     private func handleRecentMeetingsSelectionKeyPress(_ press: KeyPress) -> KeyPress.Result {

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -600,7 +600,7 @@ struct SettingsView: View {
             resetCleanupCard.id("system.reset")
         }
         .alert(
-            "Delete meeting audio automatically?",
+            "Remove meeting audio automatically?",
             isPresented: Binding(
                 get: { pendingMeetingAudioRetention != nil },
                 set: { if !$0 { pendingMeetingAudioRetention = nil } }
@@ -608,7 +608,7 @@ struct SettingsView: View {
             presenting: pendingMeetingAudioRetention
         ) { pending in
             Button("Cancel", role: .cancel) { pendingMeetingAudioRetention = nil }
-            Button("Enable Auto-Delete", role: .destructive) {
+            Button("Enable Auto-Removal", role: .destructive) {
                 viewModel.confirmMeetingAudioRetentionChange(pending.retention)
                 pendingMeetingAudioRetention = nil
             }
@@ -1885,7 +1885,7 @@ struct SettingsView: View {
             HStack(alignment: .center, spacing: DesignSystem.Spacing.md) {
                 rowText(
                     title: "Meeting audio retention",
-                    detail: "Choose how long MacParakeet keeps meeting recordings after transcription."
+                    detail: "Choose how long MacParakeet keeps meeting audio after the transcript is saved."
                 )
                 Spacer(minLength: DesignSystem.Spacing.md)
                 Picker("Meeting audio retention", selection: meetingAudioRetentionModeBinding) {
@@ -1895,7 +1895,7 @@ struct SettingsView: View {
                 }
                 .labelsHidden()
                 .pickerStyle(.menu)
-                .frame(width: 210)
+                .frame(width: 250)
             }
 
             if viewModel.meetingAudioRetention.mode == .deleteAfterDays {
@@ -1922,7 +1922,7 @@ struct SettingsView: View {
                 }
             }
 
-            Text("Transcripts are always kept. Only the audio recording is removed.")
+            Text("Transcripts stay. Removing audio disables playback and retranscription unless you saved a copy.")
                 .font(DesignSystem.Typography.caption)
                 .foregroundStyle(.secondary)
         }
@@ -1971,9 +1971,9 @@ struct SettingsView: View {
         case .keepForever:
             return ""
         case .deleteAfterDays(let days):
-            return "Transcripts, summaries, and notes are always kept. Meeting audio older than \(MeetingAudioRetention.normalizedDeleteAfterDays(days)) days will be removed automatically."
+            return "MacParakeet will remove saved meeting audio older than \(MeetingAudioRetention.normalizedDeleteAfterDays(days)) days. Transcripts stay, and notes, AI results, and chats stay if they exist. Playback and retranscription will no longer be available for meetings whose audio has been removed."
         case .deleteImmediately:
-            return "Transcripts, summaries, and notes are always kept. Meeting audio will be removed automatically after each final transcript is saved."
+            return "MacParakeet will remove saved audio after each final transcript is saved. The meeting stays with its transcript, and notes, AI results, and chats stay if they exist. Playback and retranscription will no longer be available unless you saved a copy of the audio."
         }
     }
 

--- a/Sources/MacParakeet/Views/Transcription/BulkTranscriptionSelectionBar.swift
+++ b/Sources/MacParakeet/Views/Transcription/BulkTranscriptionSelectionBar.swift
@@ -18,9 +18,9 @@ struct BulkTranscriptionSelectionBar: View {
 
     private var deleteAudioTitle: String {
         if isMeetingContext {
-            return "Delete Audio Only..."
+            return "Remove Audio Only..."
         }
-        return "Delete Audio for \(selectedMeetingAudioCount) \(selectedMeetingAudioCount == 1 ? "Meeting" : "Meetings")..."
+        return "Remove Audio for \(selectedMeetingAudioCount) \(selectedMeetingAudioCount == 1 ? "Meeting" : "Meetings")..."
     }
 
     private var deleteItemsTitle: String {

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -458,7 +458,8 @@ struct TranscriptResultView: View {
             }
 
             if activeTranscription.sourceType == .meeting {
-                let audioAvailable = MeetingAudioFile.isAvailable(for: activeTranscription)
+                let audioState = MeetingAudioFile.state(for: activeTranscription)
+                let audioAvailable = audioState == .saved
                 Menu {
                     Button {
                         MeetingAudioActions.revealInFinder(activeTranscription)
@@ -476,7 +477,7 @@ struct TranscriptResultView: View {
                     Button(role: .destructive) {
                         pendingDeleteMeetingAudio = true
                     } label: {
-                        Label("Delete Audio", systemImage: "waveform.slash")
+                        Label(MeetingDeletionCopy.audioOnlyMenuTitle, systemImage: "waveform.slash")
                     }
                 } label: {
                     Label("Audio", systemImage: "waveform")
@@ -485,7 +486,7 @@ struct TranscriptResultView: View {
                 .disabled(!audioAvailable)
                 .help(audioAvailable
                       ? "Reveal or save the meeting audio file"
-                      : "Audio file is not available yet")
+                      : MeetingDeletionCopy.audioUnavailableHelp(for: audioState))
 
                 let artifactAvailable = MeetingArtifactActions.folderURL(for: activeTranscription) != nil
                 Menu {
@@ -588,13 +589,13 @@ struct TranscriptResultView: View {
         } message: { confirmation in
             Text(confirmation.message)
         }
-        .alert("Delete Meeting Audio?", isPresented: $pendingDeleteMeetingAudio) {
+        .alert(MeetingDeletionCopy.audioOnlyAlertTitle, isPresented: $pendingDeleteMeetingAudio) {
             Button("Cancel", role: .cancel) {}
-            Button("Delete Audio", role: .destructive) {
+            Button(MeetingDeletionCopy.audioOnlyConfirmTitle, role: .destructive) {
                 deleteMeetingAudioFromActionBar()
             }
         } message: {
-            Text("The transcript stays in Library. Playback and retranscription will be unavailable unless you saved a copy.")
+            Text(MeetingDeletionCopy.singleAudioOnlyMessage(surface: .library))
         }
         .popover(item: $exportConfirmation, arrowEdge: .top) { confirmation in
             exportConfirmationPopover(confirmation)

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -127,20 +127,23 @@ struct TranscriptionLibraryView: View {
             }
         }
         .alert(
-            "Delete Meeting Audio?",
+            MeetingDeletionCopy.audioOnlyAlertTitle,
             isPresented: Binding(
                 get: { pendingDeleteAudio != nil },
                 set: { if !$0 { pendingDeleteAudio = nil } }
             )
         ) {
-            Button("Cancel", role: .cancel) {}
-            Button("Delete Audio Only", role: .destructive) {
+            Button("Cancel", role: .cancel) {
+                pendingDeleteAudio = nil
+            }
+            Button(MeetingDeletionCopy.audioOnlyConfirmTitle, role: .destructive) {
                 if let transcription = pendingDeleteAudio {
                     viewModel.deleteMeetingAudio(transcription)
+                    pendingDeleteAudio = nil
                 }
             }
         } message: {
-            Text("The transcript, notes, AI results, and chats stay in Library if they exist. Playback and retranscription will be unavailable unless you saved a copy.")
+            Text(MeetingDeletionCopy.singleAudioOnlyMessage(surface: .library))
         }
         .alert(
             bulkOperationTitle,
@@ -267,7 +270,8 @@ struct TranscriptionLibraryView: View {
         }
 
         if transcription.sourceType == .meeting {
-            let audioAvailable = MeetingAudioFile.isAvailable(for: transcription)
+            let audioState = MeetingAudioFile.state(for: transcription)
+            let audioAvailable = audioState == .saved
             let artifactAvailable = MeetingArtifactActions.folderURL(for: transcription) != nil
 
             Divider()
@@ -302,7 +306,7 @@ struct TranscriptionLibraryView: View {
             .disabled(!audioAvailable)
             .help(audioAvailable
                   ? "Reveal the meeting audio file in Finder"
-                  : "Audio file is not available yet")
+                  : MeetingDeletionCopy.audioUnavailableHelp(for: audioState))
 
             Button {
                 saveMeetingAudio(transcription)
@@ -312,17 +316,17 @@ struct TranscriptionLibraryView: View {
             .disabled(!audioAvailable)
             .help(audioAvailable
                   ? "Save a copy of the meeting audio to a chosen location"
-                  : "Audio file is not available yet")
+                  : MeetingDeletionCopy.audioUnavailableHelp(for: audioState))
 
             Button(role: .destructive) {
                 pendingDeleteAudio = transcription
             } label: {
-                Label("Delete Audio Only", systemImage: "waveform.slash")
+                Label(MeetingDeletionCopy.audioOnlyMenuTitle, systemImage: "waveform.slash")
             }
             .disabled(!audioAvailable)
             .help(audioAvailable
-                  ? "Delete the stored meeting audio while keeping the transcript and notes"
-                  : "Audio file is not available yet")
+                  ? "Remove the saved meeting audio while keeping the meeting"
+                  : MeetingDeletionCopy.audioUnavailableHelp(for: audioState))
         }
 
         Divider()
@@ -341,7 +345,7 @@ struct TranscriptionLibraryView: View {
         Button(role: .destructive) {
             pendingDelete = transcription
         } label: {
-            Label(transcription.sourceType == .meeting ? "Delete Meeting" : "Delete", systemImage: "trash")
+            Label(transcription.sourceType == .meeting ? MeetingDeletionCopy.fullDeleteMenuTitle : "Delete", systemImage: "trash")
         }
     }
 
@@ -446,10 +450,10 @@ struct TranscriptionLibraryView: View {
     private var bulkOperationTitle: String {
         guard let operation = viewModel.pendingBulkOperation else { return "Delete Items?" }
         if operation.isDeleteAudioOnly {
-            return "Delete Meeting Audio?"
+            return MeetingDeletionCopy.audioOnlyAlertTitle
         }
         if operation.meetingCount == operation.targetCount, operation.targetCount == 1 {
-            return "Delete Meeting?"
+            return MeetingDeletionCopy.fullDeleteAlertTitle
         }
         if operation.meetingCount == operation.targetCount {
             return "Delete Meetings?"
@@ -460,25 +464,31 @@ struct TranscriptionLibraryView: View {
     private var bulkOperationConfirmTitle: String {
         guard let operation = viewModel.pendingBulkOperation else { return "Delete" }
         if operation.isDeleteAudioOnly {
-            return "Delete Audio Only"
+            return MeetingDeletionCopy.audioOnlyConfirmTitle
         }
         if operation.meetingCount == operation.targetCount {
-            return operation.targetCount == 1 ? "Delete Meeting" : "Delete Meetings"
+            return operation.targetCount == 1 ? MeetingDeletionCopy.fullDeleteConfirmTitle : "Delete Meetings"
         }
         return "Delete Items"
     }
 
     private func bulkOperationMessage(for operation: BulkTranscriptionOperation) -> String {
         if operation.isDeleteAudioOnly {
-            var message = "Delete audio for \(operation.targetCount) \(operation.targetCount == 1 ? "meeting" : "meetings")? Transcripts, notes, AI results, and chats stay in Library if they exist. Playback and retranscription will be unavailable unless you saved a copy."
-            if operation.skippedCount > 0 {
-                message += " \(operation.skippedCount) selected \(operation.skippedCount == 1 ? "item will be skipped" : "items will be skipped")."
-            }
-            return message
+            return MeetingDeletionCopy.bulkAudioOnlyMessage(
+                count: operation.targetCount,
+                skippedCount: operation.skippedCount,
+                surface: .library
+            )
         }
 
         if operation.meetingCount > 0 {
-            return "Delete \(operation.targetCount) \(operation.targetCount == 1 ? "item" : "items"), including \(operation.meetingCount) \(operation.meetingCount == 1 ? "meeting" : "meetings")? This permanently removes the selected rows, transcripts, stored audio, and any notes, AI results, or chats for those meetings. Original local source files are not removed."
+            if operation.meetingCount == operation.targetCount {
+                return MeetingDeletionCopy.bulkFullDeleteMessage(count: operation.targetCount)
+            }
+            return MeetingDeletionCopy.mixedBulkFullDeleteMessage(
+                totalCount: operation.targetCount,
+                meetingCount: operation.meetingCount
+            )
         }
 
         return "Delete \(operation.targetCount) \(operation.targetCount == 1 ? "item" : "items")? This permanently deletes the Library rows and app-owned files. Original local source files are not removed."
@@ -494,7 +504,7 @@ struct TranscriptionLibraryView: View {
 
     private func singleDeleteMessage(for transcription: Transcription) -> String {
         if transcription.sourceType == .meeting {
-            return "This permanently removes \"\(transcription.fileName)\", its transcript, stored audio, and any notes, AI results, or chats for this meeting."
+            return MeetingDeletionCopy.singleFullDeleteMessage(title: transcription.fileName)
         }
         return "\"\(transcription.fileName)\" will be permanently deleted. Original local source files are not removed."
     }

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionThumbnailCard.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionThumbnailCard.swift
@@ -141,6 +141,12 @@ struct TranscriptionThumbnailCard<MenuContent: View>: View {
                         .padding(8)
                 }
             }
+            .overlay(alignment: .bottomLeading) {
+                if transcription.sourceType == .meeting {
+                    MeetingAudioStateChip(state: MeetingAudioFile.state(for: transcription))
+                        .padding(8)
+                }
+            }
             .clipShape(Rectangle())
     }
 

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionThumbnailCard.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionThumbnailCard.swift
@@ -143,8 +143,11 @@ struct TranscriptionThumbnailCard<MenuContent: View>: View {
             }
             .overlay(alignment: .bottomLeading) {
                 if transcription.sourceType == .meeting {
-                    MeetingAudioStateChip(state: MeetingAudioFile.state(for: transcription))
-                        .padding(8)
+                    let state = MeetingAudioFile.state(for: transcription)
+                    if state != .notMeeting {
+                        MeetingAudioStateChip(state: state)
+                            .padding(8)
+                    }
                 }
             }
             .clipShape(Rectangle())

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -45,9 +45,9 @@ public enum MeetingAudioRetentionMode: String, CaseIterable, Identifiable, Hasha
         case .keepForever:
             return "Keep forever"
         case .deleteAfterDays:
-            return "Delete after..."
+            return "Remove after..."
         case .deleteImmediately:
-            return "Delete after transcription"
+            return "Transcript only after processing"
         }
     }
 }

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -47,7 +47,7 @@ public enum MeetingAudioRetentionMode: String, CaseIterable, Identifiable, Hasha
         case .deleteAfterDays:
             return "Remove after..."
         case .deleteImmediately:
-            return "Transcript only after processing"
+            return "Remove audio after transcription"
         }
     }
 }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingAudioFile.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingAudioFile.swift
@@ -12,6 +12,12 @@ import Foundation
 /// "Save Audio As…") and that on-disk layout, so future changes to the
 /// folder structure only ripple through one file.
 public enum MeetingAudioFile {
+    public enum State: Equatable, Sendable {
+        case notMeeting
+        case saved
+        case removed
+        case missing
+    }
 
     // MARK: - URL resolution
 
@@ -42,10 +48,27 @@ public enum MeetingAudioFile {
         for transcription: Transcription,
         fileManager: FileManager = .default
     ) -> Bool {
-        guard let url = mixedAudioURL(for: transcription) else { return false }
+        state(for: transcription, fileManager: fileManager) == .saved
+    }
+
+    /// User-facing availability state for a meeting's stored audio.
+    ///
+    /// `removed` means the DB no longer points at meeting audio, usually
+    /// because the user chose audio-only cleanup or a retention policy removed
+    /// it after final transcription. `missing` means the DB still points at a
+    /// path, but that path is no longer a file on disk.
+    public static func state(
+        for transcription: Transcription,
+        fileManager: FileManager = .default
+    ) -> State {
+        guard transcription.sourceType == .meeting else { return .notMeeting }
+        guard let url = mixedAudioURL(for: transcription) else { return .removed }
         var isDirectory: ObjCBool = false
         let exists = fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory)
-        return exists && !isDirectory.boolValue
+        if exists && !isDirectory.boolValue {
+            return .saved
+        }
+        return .missing
     }
 
     // MARK: - Safe copy

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingAudioFile.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingAudioFile.swift
@@ -34,16 +34,8 @@ public enum MeetingAudioFile {
         return URL(fileURLWithPath: path)
     }
 
-    /// Whether the mixed-track audio file is reachable on disk. Returns
-    /// false for non-meeting transcriptions or when the recorded file is
-    /// missing (deleted, moved, or recovery still in progress).
-    ///
-    /// **Status-agnostic by design.** Returns true for `.processing`,
-    /// `.error`, or `.cancelled` meetings as long as the file is on
-    /// disk. The audio is written incrementally as fragmented MP4 (see
-    /// ADR-019), so a user looking at a failed-transcription row can
-    /// still grab the captured audio. Don't add a status gate here
-    /// without an explicit product reason.
+    /// Whether finalized meeting audio is reachable on disk. Returns false for
+    /// non-meeting rows, actively processing rows, and missing audio files.
     public static func isAvailable(
         for transcription: Transcription,
         fileManager: FileManager = .default
@@ -61,7 +53,10 @@ public enum MeetingAudioFile {
         for transcription: Transcription,
         fileManager: FileManager = .default
     ) -> State {
-        guard transcription.sourceType == .meeting else { return .notMeeting }
+        guard transcription.sourceType == .meeting,
+              transcription.status != .processing else {
+            return .notMeeting
+        }
         guard let url = mixedAudioURL(for: transcription) else { return .removed }
         var isDirectory: ObjCBool = false
         let exists = fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory)

--- a/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
+++ b/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
@@ -418,7 +418,8 @@ public enum SettingsSearchIndex {
             keywords: [
                 "storage", "retention", "disk", "history",
                 "save dictation", "save audio", "keep youtube audio", "youtube",
-                "keep meeting audio", "meeting audio", "meeting recordings", "clear audio"
+                "keep meeting audio", "meeting audio", "meeting recordings",
+                "remove audio", "clear audio", "transcript only", "audio lifecycle"
             ],
             cardAnchor: "system.storage"
         ),

--- a/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
+++ b/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
@@ -133,7 +133,7 @@ final class AppRuntimePreferencesTests: XCTestCase {
     func testMeetingAudioRetentionModeDisplayTitlesUseLifecycleCopy() {
         XCTAssertEqual(MeetingAudioRetentionMode.keepForever.displayTitle, "Keep forever")
         XCTAssertEqual(MeetingAudioRetentionMode.deleteAfterDays.displayTitle, "Remove after...")
-        XCTAssertEqual(MeetingAudioRetentionMode.deleteImmediately.displayTitle, "Transcript only after processing")
+        XCTAssertEqual(MeetingAudioRetentionMode.deleteImmediately.displayTitle, "Remove audio after transcription")
     }
 
     func testMeetingAudioSourceModeDefaultsToMicrophoneAndSystemAndReadsPersistedValue() {

--- a/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
+++ b/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
@@ -130,6 +130,12 @@ final class AppRuntimePreferencesTests: XCTestCase {
         )
     }
 
+    func testMeetingAudioRetentionModeDisplayTitlesUseLifecycleCopy() {
+        XCTAssertEqual(MeetingAudioRetentionMode.keepForever.displayTitle, "Keep forever")
+        XCTAssertEqual(MeetingAudioRetentionMode.deleteAfterDays.displayTitle, "Remove after...")
+        XCTAssertEqual(MeetingAudioRetentionMode.deleteImmediately.displayTitle, "Transcript only after processing")
+    }
+
     func testMeetingAudioSourceModeDefaultsToMicrophoneAndSystemAndReadsPersistedValue() {
         let suite = "app-runtime-prefs-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!

--- a/Tests/MacParakeetTests/Audio/MeetingAudioFileTests.swift
+++ b/Tests/MacParakeetTests/Audio/MeetingAudioFileTests.swift
@@ -96,6 +96,23 @@ final class MeetingAudioFileTests: XCTestCase {
 
     // MARK: - state
 
+    func testStateReturnsNotMeetingWhenStatusIsProcessing() throws {
+        let directory = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let audioURL = directory.appendingPathComponent("meeting.m4a")
+        try Data("audio".utf8).write(to: audioURL)
+
+        let transcription = makeTranscription(
+            fileName: "Meeting",
+            filePath: audioURL.path,
+            sourceType: .meeting,
+            status: .processing
+        )
+
+        XCTAssertEqual(MeetingAudioFile.state(for: transcription), .notMeeting)
+        XCTAssertFalse(MeetingAudioFile.isAvailable(for: transcription))
+    }
+
     func testStateReturnsNotMeetingForNonMeetingSource() {
         let transcription = makeTranscription(
             fileName: "lecture.mp3",
@@ -304,6 +321,7 @@ final class MeetingAudioFileTests: XCTestCase {
         fileName: String,
         filePath: String? = nil,
         sourceType: Transcription.SourceType,
+        status: Transcription.TranscriptionStatus = .completed,
         derivedTitle: String? = nil,
         createdAt: Date = Date()
     ) -> Transcription {
@@ -311,7 +329,7 @@ final class MeetingAudioFileTests: XCTestCase {
             createdAt: createdAt,
             fileName: fileName,
             filePath: filePath,
-            status: .completed,
+            status: status,
             sourceType: sourceType,
             derivedTitle: derivedTitle
         )

--- a/Tests/MacParakeetTests/Audio/MeetingAudioFileTests.swift
+++ b/Tests/MacParakeetTests/Audio/MeetingAudioFileTests.swift
@@ -94,6 +94,53 @@ final class MeetingAudioFileTests: XCTestCase {
         XCTAssertFalse(MeetingAudioFile.isAvailable(for: transcription))
     }
 
+    // MARK: - state
+
+    func testStateReturnsNotMeetingForNonMeetingSource() {
+        let transcription = makeTranscription(
+            fileName: "lecture.mp3",
+            filePath: "/tmp/lecture.mp3",
+            sourceType: .file
+        )
+
+        XCTAssertEqual(MeetingAudioFile.state(for: transcription), .notMeeting)
+    }
+
+    func testStateReturnsRemovedForMeetingWithoutFilePath() {
+        let transcription = makeTranscription(
+            fileName: "Meeting",
+            filePath: nil,
+            sourceType: .meeting
+        )
+
+        XCTAssertEqual(MeetingAudioFile.state(for: transcription), .removed)
+    }
+
+    func testStateReturnsMissingWhenMeetingPathDoesNotExist() {
+        let transcription = makeTranscription(
+            fileName: "Meeting",
+            filePath: "/tmp/macparakeet-tests-missing-\(UUID().uuidString).m4a",
+            sourceType: .meeting
+        )
+
+        XCTAssertEqual(MeetingAudioFile.state(for: transcription), .missing)
+    }
+
+    func testStateReturnsSavedWhenMeetingAudioExists() throws {
+        let directory = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let audioURL = directory.appendingPathComponent("meeting.m4a")
+        try Data("audio".utf8).write(to: audioURL)
+
+        let transcription = makeTranscription(
+            fileName: "Meeting",
+            filePath: audioURL.path,
+            sourceType: .meeting
+        )
+
+        XCTAssertEqual(MeetingAudioFile.state(for: transcription), .saved)
+    }
+
     // MARK: - suggestedExportStem
 
     func testSuggestedExportStemPrefersDerivedTitleWithDate() {

--- a/Tests/MacParakeetTests/ViewModels/SettingsSearchIndexTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsSearchIndexTests.swift
@@ -74,6 +74,15 @@ final class SettingsSearchIndexTests: XCTestCase {
         XCTAssertTrue(results.contains(where: { $0.id == "system.storage" }))
     }
 
+    func testTranscriptOnlyQueryFindsStorageRetention() {
+        let results = SettingsSearchIndex.matches("transcript only")
+
+        XCTAssertTrue(
+            results.contains(where: { $0.id == "system.storage" }),
+            "Transcript-only meeting audio retention should land on Storage"
+        )
+    }
+
     func testCalendarQueriesHonorCalendarFeatureFlag() {
         for query in ["calendar", "auto-start", "auto start", "reminders"] {
             let results = SettingsSearchIndex.matches(query)

--- a/Tests/MacParakeetTests/Views/MeetingDeletionCopyTests.swift
+++ b/Tests/MacParakeetTests/Views/MeetingDeletionCopyTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+
+@testable import MacParakeet
+
+final class MeetingDeletionCopyTests: XCTestCase {
+    func testAudioOnlyCopyKeepsMeetingAndNamesOptionalArtifacts() {
+        let message = MeetingDeletionCopy.singleAudioOnlyMessage(surface: .library)
+
+        XCTAssertTrue(message.contains("removes the saved audio"))
+        XCTAssertTrue(message.contains("meeting stays in Library"))
+        XCTAssertTrue(message.contains("Notes, AI results, and chats stay too if they exist"))
+        XCTAssertTrue(message.contains("Playback and retranscription will no longer be available"))
+    }
+
+    func testFullDeleteCopyDeletesOptionalArtifactsOnlyIfTheyExist() {
+        let message = MeetingDeletionCopy.singleFullDeleteMessage(title: "Roadmap sync")
+
+        XCTAssertTrue(message.contains("permanently deletes \"Roadmap sync\""))
+        XCTAssertTrue(message.contains("including its transcript and saved audio"))
+        XCTAssertTrue(message.contains("Notes, AI results, and chats for this meeting are also deleted if they exist"))
+    }
+
+    func testBulkFullDeleteCopyUsesSingularMeetingCopy() {
+        let message = MeetingDeletionCopy.bulkFullDeleteMessage(count: 1)
+
+        XCTAssertTrue(message.contains("permanently deletes 1 meeting"))
+        XCTAssertTrue(message.contains("including its transcript and saved audio"))
+        XCTAssertTrue(message.contains("Notes, AI results, and chats for this meeting are also deleted if they exist"))
+    }
+
+    func testBulkAudioOnlyCopyMentionsSkippedUnavailableAudio() {
+        let message = MeetingDeletionCopy.bulkAudioOnlyMessage(
+            count: 3,
+            skippedCount: 2,
+            surface: .meetings
+        )
+
+        XCTAssertTrue(message.contains("removes saved audio from 3 meetings"))
+        XCTAssertTrue(message.contains("meetings stay in Meetings"))
+        XCTAssertTrue(message.contains("2 selected items will be skipped"))
+    }
+}

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -725,7 +725,7 @@ Audio path is computed from ID by default. Files stored as WAV (16kHz mono). Use
 | Silence delay | 1s, 1.5s, 2s, 3s, 5s | 2s |
 | Save audio recordings | On / Off | On |
 | Keep downloaded YouTube audio | On / Off | On |
-| Meeting audio retention | Keep forever / Delete after 7, 14, 30, or 90 days / Delete after transcription | Keep forever |
+| Meeting audio retention | Keep forever / Remove after N days / Transcript only after processing | Keep forever |
 | Speech recognition engine | Parakeet / Nemotron Beta / Whisper | Parakeet |
 | Nemotron model | Multilingual Beta (~1.5 GB) / English Beta (~600 MB, English-only) | Multilingual Beta |
 | Whisper language | Auto-detect or language code | Auto-detect |
@@ -1558,7 +1558,7 @@ Embedded video/audio playback, split-pane detail view, synced transcript highlig
 - [x] Search across transcription titles and content
 - [x] Sort by date (newest/oldest)
 - [x] Multi-select cleanup with `Select Many...`, `Select Loaded`, clear/cancel, and contextual destructive confirmations
-- [x] Meeting cleanup supports both full deletion and `Delete Audio Only...`; optional notes, AI results, and chats are removed only by full meeting deletion
+- [x] Meeting cleanup supports both full deletion and `Remove Audio Only...`; optional notes, AI results, and chats are removed only by full meeting deletion
 
 ### F27: Home Page Redesign
 

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -725,7 +725,7 @@ Audio path is computed from ID by default. Files stored as WAV (16kHz mono). Use
 | Silence delay | 1s, 1.5s, 2s, 3s, 5s | 2s |
 | Save audio recordings | On / Off | On |
 | Keep downloaded YouTube audio | On / Off | On |
-| Meeting audio retention | Keep forever / Remove after N days / Transcript only after processing | Keep forever |
+| Meeting audio retention | Keep forever / Remove after N days / Remove audio after transcription | Keep forever |
 | Speech recognition engine | Parakeet / Nemotron Beta / Whisper | Parakeet |
 | Nemotron model | Multilingual Beta (~1.5 GB) / English Beta (~600 MB, English-only) | Multilingual Beta |
 | Whisper language | Auto-detect or language code | Auto-detect |

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -121,13 +121,13 @@ The tile body is informational. Only the visible Start and Stop capsules are rea
 
 ### Library Meetings Filter
 
-When `Library.filter == .meeting`, the view renders a date-grouped list (`Today` / `Yesterday` / `Previous 7 Days` / `Previous 30 Days` / `{Month Year}`) using `MeetingDateGroupHeader` + `MeetingRowCard` instead of the thumbnail grid the other filters use.
+When `Library.filter == .meeting`, the view renders a date-grouped list (`Today` / `Yesterday` / `Previous 7 Days` / `Previous 30 Days` / `{Month Year}`) using `MeetingDateGroupHeader` + `MeetingRowCard` instead of the thumbnail grid the other filters use. Meeting rows surface saved-audio state directly (`Audio saved`, `Audio removed`, or `Audio missing`) so playback/retranscription expectations are visible before the user opens a menu.
 
 ### Library Multi-Select Cleanup
 
-Library offers a `Select Many...` secondary action when there are visible rows. Selection mode keeps actions in a contextual bar above the content: `Cancel`, `Select Loaded`, `Clear`, `Delete Audio Only...` for selected meetings with stored audio, and `Delete Items...` / `Delete Meetings...` for full deletion.
+Library offers a `Select Many...` secondary action when there are visible rows. Selection mode keeps actions in a contextual bar above the content: `Cancel`, `Select Loaded`, `Clear`, `Remove Audio Only...` for selected meetings with stored audio, and `Delete Items...` / `Delete Meetings...` for full deletion.
 
-Selected cards and meeting rows use the app accent/coral selected state. Destructive red is reserved for confirmation actions and destructive menu items, not for the selected state itself. Meeting full deletion removes the meeting row, transcript, stored audio, notes, AI results, and chats when those optional artifacts exist. `Delete Audio Only...` removes only stored meeting audio and leaves the transcript plus optional notes, AI results, and chats.
+Selected cards and meeting rows use the app accent/coral selected state. Destructive red is reserved for confirmation actions and destructive menu items, not for the selected state itself. Meeting full deletion removes the meeting row, transcript, stored audio, notes, AI results, and chats when those optional artifacts exist. `Remove Audio Only...` removes only stored meeting audio and leaves the transcript plus optional notes, AI results, and chats. Confirmation copy must state that playback and retranscription become unavailable unless the user saved a copy of the audio.
 
 The dedicated Meetings workspace mirrors the Library meeting cleanup model for Recent Meetings, using the same top contextual action bar, keyboard handling, and confirmation copy.
 

--- a/spec/contracts/meeting-artifacts-v1.md
+++ b/spec/contracts/meeting-artifacts-v1.md
@@ -110,7 +110,7 @@ The database row stays canonical. Do not teach features to treat the folder as
 the source of truth for mutable meeting metadata unless the contract is updated
 with a migration and conflict-resolution rule.
 
-Audio retention and "Delete Audio Only" clear `transcriptions.filePath` but
+Audio retention and "Remove Audio Only" clear `transcriptions.filePath` but
 must preserve `transcriptions.meetingArtifactFolderPath` and leave the folder's
 non-audio artifact files in place. Full meeting deletion removes the artifact
 folder even when retained audio was already deleted.


### PR DESCRIPTION
## Summary
- Rename meeting audio cleanup copy from delete-oriented language to explicit remove/lifecycle language.
- Surface meeting audio state in Library and Meetings rows/cards, including saved, removed, and missing states.
- Share confirmation copy for Remove Audio Only vs Delete Meeting, including optional notes, AI results, and chats.

## Verification
- swift test --filter MeetingDeletionCopyTests
- swift test --filter 'MeetingAudioFileTests|MeetingDeletionCopyTests|SettingsSearchIndexTests|AppRuntimePreferencesTests'\n- swift test\n- git diff --check\n- stale destructive-copy rg check across Sources, Tests, and spec