### PR TITLE
Polish QA copy for meeting cleanup

### DIFF
--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingDeletionCopy.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingDeletionCopy.swift
@@ -39,8 +39,9 @@ enum MeetingDeletionCopy {
         let meetingSubject = count == 1 ? "The meeting stays" : "The meetings stay"
         let transcriptObject = count == 1 ? "its transcript" : "their transcripts"
         let savedCopy = count == 1 ? "a copy" : "copies"
+        let prefix = skippedCount > 0 ? "\(selectedCount) selected \(selectedWord). " : ""
         var message =
-            "\(selectedCount) selected \(selectedWord). This removes saved audio from \(count) \(meetingWord). \(meetingSubject) in \(surface.name) with \(transcriptObject). Notes, AI results, and chats stay too if they exist. Playback and retranscription will no longer be available unless you saved \(savedCopy) of the audio."
+            "\(prefix)This removes saved audio from \(count) \(meetingWord). \(meetingSubject) in \(surface.name) with \(transcriptObject). Notes, AI results, and chats stay too if they exist. Playback and retranscription will no longer be available unless you saved \(savedCopy) of the audio."
         if skippedCount > 0 {
             let skippedWord = skippedCount == 1 ? "meeting" : "meetings"
             message +=

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingDeletionCopy.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingDeletionCopy.swift
@@ -33,16 +33,18 @@ enum MeetingDeletionCopy {
         skippedCount: Int,
         surface: Surface
     ) -> String {
+        let selectedCount = count + skippedCount
+        let selectedWord = selectedCount == 1 ? "meeting" : "meetings"
         let meetingWord = count == 1 ? "meeting" : "meetings"
         let meetingSubject = count == 1 ? "The meeting stays" : "The meetings stay"
         let transcriptObject = count == 1 ? "its transcript" : "their transcripts"
         let savedCopy = count == 1 ? "a copy" : "copies"
         var message =
-            "This removes saved audio from \(count) \(meetingWord). \(meetingSubject) in \(surface.name) with \(transcriptObject). Notes, AI results, and chats stay too if they exist. Playback and retranscription will no longer be available unless you saved \(savedCopy) of the audio."
+            "\(selectedCount) selected \(selectedWord). This removes saved audio from \(count) \(meetingWord). \(meetingSubject) in \(surface.name) with \(transcriptObject). Notes, AI results, and chats stay too if they exist. Playback and retranscription will no longer be available unless you saved \(savedCopy) of the audio."
         if skippedCount > 0 {
-            let skippedWord = skippedCount == 1 ? "item" : "items"
+            let skippedWord = skippedCount == 1 ? "meeting" : "meetings"
             message +=
-                " \(skippedCount) selected \(skippedWord) will be skipped because no saved meeting audio is available."
+                " \(skippedCount) selected \(skippedWord) already have no saved audio, so they will be skipped."
         }
         return message
     }

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingDeletionCopy.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingDeletionCopy.swift
@@ -43,9 +43,12 @@ enum MeetingDeletionCopy {
         var message =
             "\(prefix)This removes saved audio from \(count) \(meetingWord). \(meetingSubject) in \(surface.name) with \(transcriptObject). Notes, AI results, and chats stay too if they exist. Playback and retranscription will no longer be available unless you saved \(savedCopy) of the audio."
         if skippedCount > 0 {
-            let skippedWord = skippedCount == 1 ? "meeting" : "meetings"
-            message +=
-                " \(skippedCount) selected \(skippedWord) already have no saved audio, so they will be skipped."
+            if skippedCount == 1 {
+                message += " 1 selected meeting already has no saved audio, so it will be skipped."
+            } else {
+                message +=
+                    " \(skippedCount) selected meetings already have no saved audio, so they will be skipped."
+            }
         }
         return message
     }

--- a/Sources/MacParakeet/Views/Transcription/BulkTranscriptionSelectionBar.swift
+++ b/Sources/MacParakeet/Views/Transcription/BulkTranscriptionSelectionBar.swift
@@ -89,7 +89,7 @@ struct BulkTranscriptionSelectionBar: View {
             Button {
                 onSelectLoaded()
             } label: {
-                Label("Select Loaded", systemImage: "checkmark.circle")
+                Label("Select All", systemImage: "checkmark.circle")
             }
             .disabled(areAllLoadedSelected || isPerformingOperation)
             .parakeetAction(.secondary)

--- a/Sources/MacParakeetCore/SpeechEnginePreference.swift
+++ b/Sources/MacParakeetCore/SpeechEnginePreference.swift
@@ -338,7 +338,7 @@ public enum ParakeetModelVariant: String, CaseIterable, Codable, Sendable {
         case .v2:
             "English only. A touch faster, and never mis-hears English as another language."
         case .unified:
-            "English only. Strong offline accuracy with punctuation and capitalization."
+            "English only. Excellent accuracy and speed."
         }
     }
 

--- a/Tests/MacParakeetTests/STT/SpeechEnginePreferenceTests.swift
+++ b/Tests/MacParakeetTests/STT/SpeechEnginePreferenceTests.swift
@@ -204,6 +204,10 @@ final class SpeechEnginePreferenceTests: XCTestCase {
         // picker (Settings, `models list`).
         XCTAssertTrue(ParakeetModelVariant.allCases.contains(.unified))
         XCTAssertEqual(ParakeetModelVariant.unified.modelName, "Parakeet Unified 0.6B")
+        XCTAssertEqual(
+            ParakeetModelVariant.unified.coverageSummary,
+            "English only. Excellent accuracy and speed."
+        )
     }
 
     // MARK: - Nemotron model variant

--- a/Tests/MacParakeetTests/Views/MeetingDeletionCopyTests.swift
+++ b/Tests/MacParakeetTests/Views/MeetingDeletionCopyTests.swift
@@ -40,4 +40,15 @@ final class MeetingDeletionCopyTests: XCTestCase {
         XCTAssertTrue(message.contains("meeting stays in Meetings"))
         XCTAssertTrue(message.contains("2 selected meetings already have no saved audio"))
     }
+
+    func testBulkAudioOnlyCopyOmitsSelectionPrefixWhenNothingIsSkipped() {
+        let message = MeetingDeletionCopy.bulkAudioOnlyMessage(
+            count: 3,
+            skippedCount: 0,
+            surface: .meetings
+        )
+
+        XCTAssertFalse(message.contains("3 selected meetings"))
+        XCTAssertTrue(message.contains("removes saved audio from 3 meetings"))
+    }
 }

--- a/Tests/MacParakeetTests/Views/MeetingDeletionCopyTests.swift
+++ b/Tests/MacParakeetTests/Views/MeetingDeletionCopyTests.swift
@@ -30,13 +30,14 @@ final class MeetingDeletionCopyTests: XCTestCase {
 
     func testBulkAudioOnlyCopyMentionsSkippedUnavailableAudio() {
         let message = MeetingDeletionCopy.bulkAudioOnlyMessage(
-            count: 3,
+            count: 1,
             skippedCount: 2,
             surface: .meetings
         )
 
-        XCTAssertTrue(message.contains("removes saved audio from 3 meetings"))
-        XCTAssertTrue(message.contains("meetings stay in Meetings"))
-        XCTAssertTrue(message.contains("2 selected items will be skipped"))
+        XCTAssertTrue(message.contains("3 selected meetings"))
+        XCTAssertTrue(message.contains("removes saved audio from 1 meeting"))
+        XCTAssertTrue(message.contains("meeting stays in Meetings"))
+        XCTAssertTrue(message.contains("2 selected meetings already have no saved audio"))
     }
 }

--- a/Tests/MacParakeetTests/Views/MeetingDeletionCopyTests.swift
+++ b/Tests/MacParakeetTests/Views/MeetingDeletionCopyTests.swift
@@ -51,4 +51,16 @@ final class MeetingDeletionCopyTests: XCTestCase {
         XCTAssertFalse(message.contains("3 selected meetings"))
         XCTAssertTrue(message.contains("removes saved audio from 3 meetings"))
     }
+
+    func testBulkAudioOnlyCopyUsesSingularSkippedGrammar() {
+        let message = MeetingDeletionCopy.bulkAudioOnlyMessage(
+            count: 1,
+            skippedCount: 1,
+            surface: .meetings
+        )
+
+        XCTAssertTrue(message.contains("2 selected meetings"))
+        XCTAssertTrue(message.contains("1 selected meeting already has no saved audio"))
+        XCTAssertTrue(message.contains("it will be skipped"))
+    }
 }


### PR DESCRIPTION
## Summary
- Rename the bulk selection action from "Select Loaded" to "Select All"
- Make bulk remove-audio confirmation copy show total selected separately from eligible/skipped meetings
- Clarify Parakeet Unified copy as English-only first

## Verification
- swift test --filter SpeechEnginePreferenceTests
- swift test --filter MeetingDeletionCopyTests
- git diff --check origin/main...HEAD